### PR TITLE
Disable legacy GitHub Pages deployment workflow automation

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,8 +4,7 @@
 #
 # Triggers:
 #   - Manual dispatch (workflow_dispatch)
-#   - After successful crawler run (workflow_run)
-#   - Push to master (for workflow changes)
+#   - (Legacy) Automatic triggers disabled
 #
 # The static site includes:
 #   - React frontend (if apps/web exists)
@@ -14,7 +13,7 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Manual trigger
+  # Manual trigger only (automatic triggers disabled - legacy workflow)
   workflow_dispatch:
     inputs:
       fresh_build:
@@ -22,23 +21,6 @@ on:
         required: false
         default: 'false'
         type: boolean
-
-  # Deploy after successful crawler run
-  workflow_run:
-    workflows: ["Get Hot News"]
-    types:
-      - completed
-    branches:
-      - master
-
-  # Deploy on push to master (catches workflow file changes)
-  push:
-    branches:
-      - master
-    paths:
-      - '.github/workflows/deploy-pages.yml'
-      - 'scripts/build-static.sh'
-      - 'apps/web/**'
 
 # Only allow one deployment at a time
 concurrency:


### PR DESCRIPTION
## Task

# Disable GitHub Pages Deployment Workflow (Legacy)

## Context

The GitHub Pages deployment workflow failed ([run #21467740394](https://github.com/ptdevhk/trends/actions/runs/21467740394)), but this is **legacy functionality**. The project is moving to Resume Screening development as the main focus.

## Implementation Plan

Disable automatic triggers in `.github/workflows/deploy-pages.yml` while preserving the file for potential future use.

### Change Summary

**File:** `.github/workflows/deploy-pages.yml`

Remove the `workflow_run` and `push` triggers (lines 27-41), keeping only `workflow_dispatch` for manual runs:

```yaml
# Before (lines 16-41):
on:
  workflow_dispatch:
    inputs:
      fresh_build:
        description: 'Run crawler before building (generates fresh reports)'
        required: false
        default: 'false'
        type: boolean

  workflow_run:
    workflows: ["Get Hot News"]
    types:
      - completed
    branches:
      - master

  push:
    branches:
      - master
    paths:
      - '.github/workflows/deploy-pages.yml'
      - 'scripts/build-static.sh'
      - 'apps/web/**'

# After:
on:
  # Manual trigger only (automatic triggers disabled - legacy workflow)
  workflow_dispatch:
    inputs:
      fresh_build:
        description: 'Run crawler before building (generates fresh reports)'
        required: false
        default: 'false'
        type: boolean
```

## Verification

1. Push changes to master
2. Verify no deploy-pages workflow runs are triggered automatically
3. Confirm the workflow can still be triggered manually via GitHub Actions UI if needed

## PR Review Summary
- What Changed:
  - The `.github/workflows/deploy-pages.yml` workflow was modified to disable automatic triggers.
  - The `workflow_run` trigger, which previously deployed GitHub Pages after a successful 'Get Hot News' crawler run, was removed.
  - The `push` trigger, which previously deployed on pushes to the `master` branch (specifically for changes to workflow files, build scripts, or the web app), was removed.
  - The `workflow_dispatch` trigger for manual runs was preserved, making it the sole trigger for this workflow.
  - Comments within the workflow file were updated to reflect that automatic triggers are now disabled for this legacy workflow.
- Review Focus:
  - Confirm that the removal of `workflow_run` and `push` triggers completely prevents any *automatic* deployments of GitHub Pages.
  - Verify that the `workflow_dispatch` trigger remains fully functional for manual deployments, should they be required in the future.
- Test Plan:
  - Push a small, non-code change (e.g., a README update) to the `master` branch and observe that no `Deploy to GitHub Pages` workflow run is automatically initiated.
  - Navigate to the Actions tab in GitHub, select the `Deploy to GitHub Pages` workflow, and confirm you can manually trigger it using the 'Run workflow' button. Verify it successfully starts.