### PR TITLE
Rename TypeScript/JavaScript package scope from @trendradar to @trends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,8 +199,8 @@ check-node:
 		bun run check; \
 	else \
 		npm run --workspaces --if-present typecheck; \
-		npm run --workspace @trendradar/web lint; \
-		npm run --workspace @trendradar/browser-extension lint; \
+			npm run --workspace @trends/web lint; \
+			npm run --workspace @trends/browser-extension lint; \
 	fi
 
 # Build validation (for CI)

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trendradar/api",
+  "name": "@trends/api",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/apps/browser-extension/package.json
+++ b/apps/browser-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trendradar/browser-extension",
+  "name": "@trends/browser-extension",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trendradar/web",
+  "name": "@trends/web",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
       },
     },
     "apps/api": {
-      "name": "@trendradar/api",
+      "name": "@trends/api",
       "version": "0.1.0",
       "dependencies": {
         "@hono/node-server": "^1.13.8",
@@ -30,7 +30,7 @@
       },
     },
     "apps/browser-extension": {
-      "name": "@trendradar/browser-extension",
+      "name": "@trends/browser-extension",
       "version": "0.1.0",
       "devDependencies": {
         "@eslint/js": "^9.13.0",
@@ -41,7 +41,7 @@
       },
     },
     "apps/web": {
-      "name": "@trendradar/web",
+      "name": "@trends/web",
       "version": "0.1.0",
       "dependencies": {
         "class-variance-authority": "^0.7.0",
@@ -72,7 +72,7 @@
       },
     },
     "packages/shared": {
-      "name": "@trendradar/shared",
+      "name": "@trends/shared",
       "version": "0.1.0",
       "devDependencies": {
         "typescript": "^5.7.2",
@@ -276,13 +276,13 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Zv7v6q6aV+VslnpwzqKAmrk5JdVkLUzok2208ZXGipjb+msxBr/fJPZyeEXiFgH7k62Ak0SLIfxQRZQvTuf7rQ=="],
 
-    "@trendradar/api": ["@trendradar/api@workspace:apps/api"],
+    "@trends/api": ["@trends/api@workspace:apps/api"],
 
-    "@trendradar/browser-extension": ["@trendradar/browser-extension@workspace:apps/browser-extension"],
+    "@trends/browser-extension": ["@trends/browser-extension@workspace:apps/browser-extension"],
 
-    "@trendradar/shared": ["@trendradar/shared@workspace:packages/shared"],
+    "@trends/shared": ["@trends/shared@workspace:packages/shared"],
 
-    "@trendradar/web": ["@trendradar/web@workspace:apps/web"],
+    "@trends/web": ["@trends/web@workspace:apps/web"],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -758,11 +758,11 @@
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
-    "@trendradar/api/@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
+    "@trends/api/@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
 
-    "@trendradar/browser-extension/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
+    "@trends/browser-extension/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 
-    "@trendradar/web/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
+    "@trends/web/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -784,7 +784,7 @@
 
     "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": "bin/esbuild" }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
-    "@trendradar/api/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "@trends/api/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "dev:api": "cd apps/api && npm run dev",
     "dev:worker": "cd apps/worker && uv run uvicorn main:app --reload --port 8000",
     "check": "bun run check:typecheck && bun run check:lint",
-    "check:typecheck": "bun run --filter '@trendradar/*' typecheck",
-    "check:lint": "bun run --filter '@trendradar/web' --filter '@trendradar/browser-extension' lint",
-    "check:build": "bun run --filter '@trendradar/*' build"
+    "check:typecheck": "bun run --filter '@trends/*' typecheck",
+    "check:lint": "bun run --filter '@trends/web' --filter '@trends/browser-extension' lint",
+    "check:build": "bun run --filter '@trends/*' build"
   },
   "repository": {
     "type": "git",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trendradar/shared",
+  "name": "@trends/shared",
   "version": "0.1.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Task

# Plan: Rename Package Names from @trendradar/*&#32;to @trends/*

## Summary

Rename all TypeScript/JavaScript package names from `@trendradar/*` to `@trends/*` to reflect that `trendradar` is now just one extension (news aggregation) of the broader `trends` platform, which will include resume screening and other modules.

**Scope:** TypeScript/JavaScript packages and workspace configuration only.
**Excluded:** The upstream Python core (`trendradar/` directory), systemd services, and Docker configurations (per CLAUDE.md backward compatibility note).

## Files to Modify

### 1. Package Names (package.json files)

| File | Current Name | New Name |
|------|--------------|----------|
| `apps/api/package.json:2` | `@trendradar/api` | `@trends/api` |
| `apps/web/package.json:2` | `@trendradar/web` | `@trends/web` |
| `apps/browser-extension/package.json:2` | `@trendradar/browser-extension` | `@trends/browser-extension` |
| `packages/shared/package.json:2` | `@trendradar/shared` | `@trends/shared` |

### 2. Workspace Filter References (root package.json)

| File | Line | Change |
|------|------|--------|
| `package.json:18` | `@trendradar/*` | `@trends/*` |
| `package.json:19` | `@trendradar/web`, `@trendradar/browser-extension` | `@trends/web`, `@trends/browser-extension` |
| `package.json:20` | `@trendradar/*` | `@trends/*` |

### 3. Makefile References

| File | Lines | Change |
|------|-------|--------|
| `Makefile:202` | `@trendradar/web` | `@trends/web` |
| `Makefile:203` | `@trendradar/browser-extension` | `@trends/browser-extension` |

### 4. Lock File (auto-regenerated)

- `bun.lock` - Will be regenerated by running `bun install` after package.json changes

## Implementation Steps

1. **Update&#32;`apps/api/package.json`**

- Change `"name": "@trendradar/api"` to `"name": "@trends/api"`

2. **Update&#32;`apps/web/package.json`**

- Change `"name": "@trendradar/web"` to `"name": "@trends/web"`

3. **Update&#32;`apps/browser-extension/package.json`**

- Change `"name": "@trendradar/browser-extension"` to `"name": "@trends/browser-extension"`

4. **Update&#32;`packages/shared/package.json`**

- Change `"name": "@trendradar/shared"` to `"name": "@trends/shared"`

5. **Update root&#32;`package.json`**

- Line 18: `"check:typecheck": "bun run --filter '@trends/*' typecheck"`
- Line 19: `"check:lint": "bun run --filter '@trends/web' --filter '@trends/browser-extension' lint"`
- Line 20: `"check:build": "bun run --filter '@trends/*' build"`

6. **Update&#32;`Makefile`**

- Line 202: Change `@trendradar/web` to `@trends/web`
- Line 203: Change `@trendradar/browser-extension` to `@trends/browser-extension`

7. **Regenerate lock file**

- Run `bun install` to regenerate `bun.lock` with new package names

## Not Modified (Intentionally Excluded)

| Category | Reason |
|----------|--------|
| `trendradar/` Python module | Upstream core - user requested to skip |
| `python -m trendradar` references | Python module invocation - tied to upstream core |
| Systemd services (`trendradar.service`, etc.) | CLAUDE.md: "Service names use legacy `trendradar` prefix for backward compatibility" |
| Docker images (`wantcat/trendradar`) | Tied to Docker Hub organization |
| `/opt/trendradar`, `/etc/trendradar` paths | Tied to systemd service backward compatibility |

## Verification

1. **Run typecheck:**

```bash
   make check-node
```

   This will test that all `@trends/*` filter patterns work correctly.

2. **Verify workspaces resolve:**

```bash
   bun install
```

   Should complete without errors and update `bun.lock`.

3. **Test individual package builds:**

```bash
   bun run --filter '@trends/*' build
```

4. **Run dev to verify everything works:**

```bash
   make dev
```

## PR Review Summary
- What Changed:
  - Renamed all TypeScript/JavaScript package names from `@trendradar/*` to `@trends/*` across `apps/api`, `apps/web`, `apps/browser-extension`, and `packages/shared` by updating their respective `package.json` files.
  - Updated the root `package.json` to reflect the new `@trends/*` scope in `check:typecheck`, `check:lint`, and `check:build` scripts.
  - Modified `Makefile` references for `npm run --workspace` commands within the `check-node` target to use `@trends/web` and `@trends/browser-extension`.
  - The `bun.lock` file has been regenerated to incorporate all new package names and their references.
- Review Focus:
  - Confirm that all package names in `apps/*/package.json` and `packages/shared/package.json` are correctly changed to `@trends/*`.
  - Verify that the workspace filter patterns in the root `package.json` (lines 18-20) accurately target the new `@trends/*` packages.
  - Check the `Makefile` (lines 202-203) to ensure `npm run --workspace` commands correctly reference `@trends/web` and `@trends/browser-extension`.
  - Examine the `bun.lock` file to ensure consistency with the new package names and their dependencies, as it's auto-generated.
- Test Plan:
  - Run `make check-node` to validate that typechecking and linting function correctly with the updated workspace filters.
  - Execute `bun install` to confirm that all workspaces resolve without errors and the `bun.lock` file is properly updated.
  - Run `bun run --filter '@trends/*' build` to verify that all individual JavaScript/TypeScript packages build successfully.
  - Start the development environment with `make dev` to ensure the entire application stack functions as expected.