### PR TITLE
Implement cross-platform debug environment for browser extension

### DIFF
--- a/apps/browser-extension/.gitignore
+++ b/apps/browser-extension/.gitignore
@@ -1,0 +1,2 @@
+# Chrome debug profile (created by scripts/debug.sh)
+.chrome-debug-profile/

--- a/apps/browser-extension/AGENTS.md
+++ b/apps/browser-extension/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/apps/browser-extension/CLAUDE.md
+++ b/apps/browser-extension/CLAUDE.md
@@ -1,0 +1,54 @@
+# Agent Instructions (Browser Extension)
+
+These instructions apply to `apps/browser-extension/`. Use them for any extension work.
+
+## Scope
+- Target site: `https://hr.job5156.com/search`
+- Extension path (container): `/root/workspace/apps/browser-extension`
+- Manifest: MV3
+
+## Debugging
+### Cmux container (this workspace)
+- Chrome is systemd-managed and branded (137+): `--load-extension` is not supported.
+- Preferred setup (fresh container):
+  - `cd apps/browser-extension && npm run setup-profile`
+  - `systemctl restart cmux-devtools cmux-cdp-proxy`
+- Manual fallback: `chrome://extensions` → Developer mode → Load unpacked → select `/root/workspace/apps/browser-extension`.
+- Profile location: `/root/.config/chrome/Default` (must match the extension path).
+
+### Local (macOS/Linux)
+- Use `npm run debug` to launch a debug profile with `--load-extension` (Chromium/Chrome for Testing preferred).
+- Debug profile path: `apps/browser-extension/.chrome-debug-profile` (gitignored).
+
+## Auto Export (for quick verification)
+- Enable via URL or localStorage:
+  - URL: `?tr_auto_export=md` (default to Markdown)
+  - localStorage key: `tr_auto_export`
+- Modes:
+  - `md` / `markdown` → download Markdown (default)
+  - `csv` → download CSV
+  - `json` → download structured JSON
+  - `raw` → log raw payload to console
+  - `raw_json` / `rawjson` → download raw payload JSON
+  - `console` / `log` → log structured data
+  - `both` → CSV + console
+  - `all` → CSV + JSON + console
+  - Tokens can be combined: `md,rawjson,saveas,rawpage`
+  - `rawpage` / `page` adds full page HTML into raw payload (large)
+  - `saveas` prompts the browser download dialog
+- Downloads land in `/root/Downloads` as `resumes_<type>_<date>_<id>.*`.
+
+## Unique IDs (dedupe support)
+- The extension captures API rows to include `resumeId` and `perUserId` in exports.
+- If IDs are missing:
+  - Ensure search results are loaded.
+  - Wait for auto-export completion.
+  - Check `<html>` attributes: `data-tr-api-rows`, `data-tr-api-last`, `data-tr-auto-export`.
+
+## CSP / API hook
+- API capture is injected via `page-hook.js` (web-accessible resource).
+- Do not rely on inline script injection; CSP will block it on this site.
+
+## Safety / commits
+- `profile-seed/Preferences` and `profile-seed/Secure Preferences` may contain sensitive data.
+- Review and sanitize before pushing to GitHub.

--- a/apps/browser-extension/README.md
+++ b/apps/browser-extension/README.md
@@ -98,8 +98,8 @@ After loading the extension manually once, capture a minimal profile seed:
 
 ```bash
 mkdir -p apps/browser-extension/profile-seed
-cp /root/.config/chrome/Preferences apps/browser-extension/profile-seed/Preferences
-cp /root/.config/chrome/Secure\\ Preferences apps/browser-extension/profile-seed/Secure\\ Preferences 2>/dev/null || true
+cp /root/.config/chrome/Default/Preferences apps/browser-extension/profile-seed/Preferences
+cp /root/.config/chrome/Default/Secure\\ Preferences apps/browser-extension/profile-seed/Secure\\ Preferences 2>/dev/null || true
 grep -o '\"path\": \"[^\"]*browser-extension[^\"]*\"' apps/browser-extension/profile-seed/Preferences
 ```
 
@@ -112,6 +112,49 @@ Useful MCP commands for verification:
 - `list_console_messages`
 - `take_screenshot`
 - `navigate_page url="https://hr.job5156.com/search"`
+
+### Auto export (dev)
+
+You can auto-extract and print results in the page console after the resume list loads.
+Enable by adding a query param or setting localStorage:
+
+```bash
+# Markdown (default if value is true/1 or unknown)
+https://hr.job5156.com/search?tr_auto_export=md
+
+# Console-only
+https://hr.job5156.com/search?tr_auto_export=console
+
+# Raw dump (no predefined schema)
+https://hr.job5156.com/search?tr_auto_export=raw
+
+# Raw dump + download JSON
+https://hr.job5156.com/search?tr_auto_export=raw_json
+
+# Auto download CSV
+https://hr.job5156.com/search?tr_auto_export=csv
+
+# Auto download JSON
+https://hr.job5156.com/search?tr_auto_export=json
+
+# Console + CSV (and JSON if "all")
+https://hr.job5156.com/search?tr_auto_export=both
+https://hr.job5156.com/search?tr_auto_export=all
+```
+
+Or set in DevTools console:
+
+```js
+localStorage.setItem('tr_auto_export', 'md'); // or console/raw/raw_json/csv/json/both/all
+```
+
+Tokens can be combined with commas, for example:
+
+```bash
+https://hr.job5156.com/search?tr_auto_export=raw,raw_json
+https://hr.job5156.com/search?tr_auto_export=raw,raw_json,page
+https://hr.job5156.com/search?tr_auto_export=md,raw_json
+```
 
 ## Files
 

--- a/apps/browser-extension/README.md
+++ b/apps/browser-extension/README.md
@@ -52,6 +52,67 @@ ls -la apps/browser-extension/
 # Make changes and reload in chrome://extensions
 ```
 
+## Debugging with MCP
+
+Debug the extension through Chrome DevTools Protocol (CDP) via MCP.
+
+### macOS / Linux (local development)
+
+```bash
+# Start Chrome with remote debugging and the extension loaded
+cd apps/browser-extension
+npm run debug
+
+# Custom URL
+./scripts/debug.sh "https://hr.job5156.com/search?keyword=python"
+```
+
+The script prefers Chrome for Testing or Chromium (supports `--load-extension`). If only branded
+Chrome 137+ is available, it will warn and you must load the extension manually via
+`chrome://extensions`.
+
+### Cmux container environment
+
+Chrome is managed by systemd (`cmux-devtools.service`) and uses a branded build. Since Chrome 137+,
+the `--load-extension` flag is removed for branded Chrome.
+
+Option 1: apply a pre-loaded profile (recommended for fresh containers)
+
+```bash
+cd apps/browser-extension
+npm run setup-profile
+sudo systemctl restart cmux-devtools
+```
+
+Option 2: manual load once (persists in the profile)
+
+1. Navigate to `chrome://extensions`
+2. Enable Developer mode
+3. Click "Load unpacked" (file picker requires manual interaction)
+4. Select: `/root/workspace/apps/browser-extension`
+5. Navigate to `https://hr.job5156.com/search`
+
+### Generate profile seed (one-time)
+
+After loading the extension manually once, capture a minimal profile seed:
+
+```bash
+mkdir -p apps/browser-extension/profile-seed
+cp /root/.config/chrome/Preferences apps/browser-extension/profile-seed/Preferences
+cp /root/.config/chrome/Secure\\ Preferences apps/browser-extension/profile-seed/Secure\\ Preferences 2>/dev/null || true
+grep -o '\"path\": \"[^\"]*browser-extension[^\"]*\"' apps/browser-extension/profile-seed/Preferences
+```
+
+### MCP commands
+
+Useful MCP commands for verification:
+
+- `list_pages`
+- `take_snapshot`
+- `list_console_messages`
+- `take_screenshot`
+- `navigate_page url="https://hr.job5156.com/search"`
+
 ## Files
 
 - `manifest.json` - Extension configuration (Manifest v3)

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -196,19 +196,22 @@ function extractResumes() {
 
 /**
  * Extract raw HTML/text from resume cards (no predefined schema).
- * @param {Object} options
- * @param {boolean} options.includePage - Include full page HTML
+ * @param {Object} [options]
+ * @param {boolean} [options.includePage=false] - Include full page HTML
  * @returns {Object} - Raw payload
  */
 function extractResumesRaw({ includePage = false } = {}) {
   const cards = document.querySelectorAll(SELECTORS.resumeCard);
-  const items = Array.from(cards).map((card, index) => ({
-    index: index + 1,
-    resumeId: getApiRowForIndex(index)?.resumeId ?? '',
-    perUserId: getApiRowForIndex(index)?.perUserId ?? '',
-    html: card.outerHTML,
-    text: card.innerText
-  }));
+  const items = Array.from(cards).map((card, index) => {
+    const el = /** @type {HTMLElement} */ (card);
+    return {
+      index: index + 1,
+      resumeId: getApiRowForIndex(index)?.resumeId ?? '',
+      perUserId: getApiRowForIndex(index)?.perUserId ?? '',
+      html: el.outerHTML,
+      text: el.innerText
+    };
+  });
 
   const payload = {
     url: window.location.href,

--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -2,6 +2,7 @@
     "manifest_version": 3,
     "name": "智通直聘 Resume Collector",
     "version": "1.0.0",
+    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzXCTw+8W8khXUpXqILIfM0F25TlMaVr6f879wMLp71zoe+LoiZjzmfK3h41TuepIu41qzGUMLt1K1ap6YUCrg78Iq4UgWsJ/Bg43JZ0nlCig6pwE6Xihsg+oVjmKSKB2YkjjWnZRWv1Qx9Q0Jpvtv0OHGCldxfd5beB/BaKDpZalXVPoU++9he1SeKN9rZO/I8LZV57kJ539r938+LDPb+69LTQFDMpg+uFOUUlh8XaA2JAO+IySqDn32QTXFuGxwP4EcSKJibu7qo4E2SqyWMKvLh4RVZDvfLDqXNq6jD/y+zY3aS9FeWfn3uFS5QPwRjlv9JyNpSKgY63KMX+oRQIDAQAB",
     "description": "Extract resume data from hr.job5156.com for the Trends Resume Screening System",
     "permissions": [
         "activeTab",

--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -40,6 +40,16 @@
             ]
         }
     ],
+    "web_accessible_resources": [
+        {
+            "resources": [
+                "page-hook.js"
+            ],
+            "matches": [
+                "*://hr.job5156.com/*"
+            ]
+        }
+    ],
     "icons": {
         "16": "icons/icon16.png",
         "32": "icons/icon32.png",

--- a/apps/browser-extension/package.json
+++ b/apps/browser-extension/package.json
@@ -4,6 +4,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "debug": "./scripts/debug.sh",
+    "setup-profile": "./scripts/setup-profile.sh",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/browser-extension/page-hook.js
+++ b/apps/browser-extension/page-hook.js
@@ -1,0 +1,84 @@
+(() => {
+  if (window.__trResumeHookInstalled) return;
+  window.__trResumeHookInstalled = true;
+
+  const SOURCE = 'tr-resume-api';
+
+  const classify = (url) => {
+    if (!url) return null;
+    if (url.includes('/api/search/resume/v2/attach/resume/info')) return 'attach';
+    if (url.includes('/api/search/resume/v2/chat/info')) return 'chat';
+    if (url.includes('/api/search/resume/v2/talent/insight/info')) return 'insight';
+    if (url.includes('/api/search/resume/v2')) return 'search';
+    return null;
+  };
+
+  const normalizeUrl = (input) => {
+    try {
+      const raw = typeof input === 'string' ? input : (input && input.url) || '';
+      return raw ? new URL(raw, window.location.href).href : '';
+    } catch {
+      return '';
+    }
+  };
+
+  const post = (kind, url, payload) => {
+    try {
+      window.postMessage({ source: SOURCE, kind, url, payload }, '*');
+    } catch {
+      // ignore
+    }
+  };
+
+  const capture = (url, payload) => {
+    const kind = classify(url);
+    if (!kind || !payload) return;
+    post(kind, url, payload);
+  };
+
+  if (window.fetch) {
+    const originalFetch = window.fetch;
+    window.fetch = function(...args) {
+      return originalFetch.apply(this, args).then((res) => {
+        try {
+          const url = normalizeUrl(args[0]);
+          if (classify(url)) {
+            res.clone().json().then((data) => capture(url, data)).catch(() => {});
+          }
+        } catch {
+          // ignore
+        }
+        return res;
+      });
+    };
+  }
+
+  const originalOpen = XMLHttpRequest.prototype.open;
+  const originalSend = XMLHttpRequest.prototype.send;
+  XMLHttpRequest.prototype.open = function(method, url, ...rest) {
+    this.__tr_url = url;
+    return originalOpen.call(this, method, url, ...rest);
+  };
+  XMLHttpRequest.prototype.send = function(...args) {
+    this.addEventListener('load', function() {
+      try {
+        const url = normalizeUrl(this.__tr_url);
+        if (!classify(url)) return;
+        let data = null;
+        if (this.responseType === 'json' && this.response) {
+          data = this.response;
+        } else if (typeof this.responseText === 'string') {
+          const text = this.responseText.trim();
+          if (text && (text[0] === '{' || text[0] === '[')) {
+            data = JSON.parse(text);
+          }
+        }
+        if (!data) return;
+        capture(url, data);
+      } catch {
+        // ignore
+      }
+    });
+    return originalSend.apply(this, args);
+  };
+})();

--- a/apps/browser-extension/page-hook.js
+++ b/apps/browser-extension/page-hook.js
@@ -1,6 +1,8 @@
 (() => {
-  if (window.__trResumeHookInstalled) return;
-  window.__trResumeHookInstalled = true;
+  /** @type {Window & { __trResumeHookInstalled?: boolean }} */
+  const trWindow = window;
+  if (trWindow.__trResumeHookInstalled) return;
+  trWindow.__trResumeHookInstalled = true;
 
   const SOURCE = 'tr-resume-api';
 
@@ -36,9 +38,9 @@
     post(kind, url, payload);
   };
 
-  if (window.fetch) {
-    const originalFetch = window.fetch;
-    window.fetch = function(...args) {
+  if (trWindow.fetch) {
+    const originalFetch = trWindow.fetch;
+    trWindow.fetch = function(...args) {
       return originalFetch.apply(this, args).then((res) => {
         try {
           const url = normalizeUrl(args[0]);
@@ -56,13 +58,13 @@
   const originalOpen = XMLHttpRequest.prototype.open;
   const originalSend = XMLHttpRequest.prototype.send;
   XMLHttpRequest.prototype.open = function(method, url, ...rest) {
-    this.__tr_url = url;
+    /** @type {XMLHttpRequest & { __tr_url?: string }} */ (this).__tr_url = url;
     return originalOpen.call(this, method, url, ...rest);
   };
   XMLHttpRequest.prototype.send = function(...args) {
     this.addEventListener('load', function() {
       try {
-        const url = normalizeUrl(this.__tr_url);
+        const url = normalizeUrl(/** @type {XMLHttpRequest & { __tr_url?: string }} */ (this).__tr_url);
         if (!classify(url)) return;
         let data = null;
         if (this.responseType === 'json' && this.response) {

--- a/apps/browser-extension/profile-seed/.gitkeep
+++ b/apps/browser-extension/profile-seed/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder. Generate Preferences after manual load; see README.

--- a/apps/browser-extension/profile-seed/Preferences
+++ b/apps/browser-extension/profile-seed/Preferences
@@ -1,0 +1,72 @@
+{
+  "extensions": {
+    "settings": {
+      "pafaiemddagkegcjcaihcomblnpjfmkf": {
+        "account_extension_type": 0,
+        "active_permissions": {
+          "api": [
+            "activeTab",
+            "downloads",
+            "storage",
+            "scripting",
+            "offscreen"
+          ],
+          "explicit_host": [
+            "*://hr.job5156.com/*"
+          ],
+          "manifest_permissions": [],
+          "scriptable_host": [
+            "*://hr.job5156.com/search*"
+          ]
+        },
+        "commands": {
+          "_execute_action": {
+            "was_assigned": true
+          }
+        },
+        "content_settings": [],
+        "creation_flags": 38,
+        "disable_reasons": [],
+        "first_install_time": "13414218230697666",
+        "from_webstore": false,
+        "granted_permissions": {
+          "api": [
+            "activeTab",
+            "downloads",
+            "storage",
+            "scripting",
+            "offscreen"
+          ],
+          "explicit_host": [
+            "*://hr.job5156.com/*"
+          ],
+          "manifest_permissions": [],
+          "scriptable_host": [
+            "*://hr.job5156.com/search*"
+          ]
+        },
+        "incognito_content_settings": [],
+        "incognito_preferences": {},
+        "last_update_time": "13414218230697666",
+        "location": 4,
+        "newAllowFileAccess": true,
+        "path": "/root/workspace/apps/browser-extension",
+        "preferences": {},
+        "regular_only_preferences": {},
+        "service_worker_registration_info": {
+          "version": "1.0.0"
+        },
+        "serviceworkerevents": [
+          "downloads.onChanged",
+          "downloads.onDeterminingFilename"
+        ],
+        "was_installed_by_default": false,
+        "was_installed_by_oem": false,
+        "withholding_permissions": false
+      }
+    },
+    "ui": {
+      "developer_mode": true
+    }
+  }
+}

--- a/apps/browser-extension/scripts/debug.sh
+++ b/apps/browser-extension/scripts/debug.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Launch Chrome with remote debugging for extension development.
+# Usage: ./scripts/debug.sh [URL]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXT_DIR="$(dirname "$SCRIPT_DIR")"
+USER_DATA_DIR="${EXT_DIR}/.chrome-debug-profile"
+TARGET_URL="${1:-https://hr.job5156.com/search}"
+DEBUG_PORT="${CHROME_DEBUG_PORT:-9222}"
+
+if pgrep -f "remote-debugging-port" > /dev/null 2>&1; then
+  cat <<EOF_MSG
+Chrome appears to be running with remote debugging already.
+
+In the container, Chrome is managed by systemd and uses a branded build.
+Since Chrome 137+, the --load-extension flag is removed in branded Chrome.
+
+To load the extension manually:
+  1. Navigate to chrome://extensions
+  2. Enable Developer mode
+  3. Click Load unpacked
+  4. Select: $EXT_DIR
+
+Then navigate to: $TARGET_URL
+
+MCP commands you can use:
+  - list_pages
+  - take_snapshot
+  - list_console_messages
+EOF_MSG
+  exit 0
+fi
+
+detect_chrome() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    for chrome_path in \
+      "$HOME/.cache/puppeteer/chrome/*/chrome-mac-*/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing" \
+      "/Applications/Chromium.app/Contents/MacOS/Chromium" \
+      "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary" \
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"; do
+      for expanded in $chrome_path; do
+        if [[ -x "$expanded" ]]; then
+          echo "$expanded"
+          return 0
+        fi
+      done
+    done
+  else
+    for chrome_cmd in \
+      "chromium-browser" \
+      "chromium" \
+      "google-chrome-unstable" \
+      "google-chrome-stable" \
+      "google-chrome"; do
+      if command -v "$chrome_cmd" &>/dev/null; then
+        command -v "$chrome_cmd"
+        return 0
+      fi
+    done
+  fi
+  return 1
+}
+
+CHROME="${CHROME:-}"
+if [[ -z "$CHROME" ]]; then
+  CHROME="$(detect_chrome || true)"
+fi
+
+if [[ -n "$CHROME" ]] && [[ ! -x "$CHROME" ]]; then
+  if command -v "$CHROME" &>/dev/null; then
+    CHROME="$(command -v "$CHROME")"
+  fi
+fi
+
+if [[ -z "$CHROME" ]] || [[ ! -x "$CHROME" ]]; then
+  cat <<EOF_MSG
+Error: Chrome/Chromium not found.
+
+For best compatibility, install one of:
+  - Chrome for Testing: npx @puppeteer/browsers install chrome@stable
+  - Chromium: brew install chromium (macOS) or apt install chromium (Linux)
+
+Or set CHROME to your Chrome binary path.
+EOF_MSG
+  exit 1
+fi
+
+CHROME_VERSION_STR="$($CHROME --version 2>/dev/null || true)"
+CHROME_VERSION="$(echo "$CHROME_VERSION_STR" | grep -oE '[0-9]+' | head -1 || true)"
+IS_BRANDED_CHROME=false
+if [[ "$CHROME_VERSION_STR" == Google\ Chrome* ]] && [[ "$CHROME_VERSION_STR" != *"for Testing"* ]] && [[ "$CHROME_VERSION_STR" != *"Canary"* ]]; then
+  if [[ -n "$CHROME_VERSION" ]] && [[ "$CHROME_VERSION" -ge 137 ]]; then
+    IS_BRANDED_CHROME=true
+  fi
+fi
+
+mkdir -p "$USER_DATA_DIR"
+
+echo "Starting Chrome with remote debugging on port $DEBUG_PORT"
+echo "Chrome: $CHROME"
+echo "Version: ${CHROME_VERSION_STR:-unknown}"
+echo "Extension: $EXT_DIR"
+echo "Profile: $USER_DATA_DIR"
+echo "URL: $TARGET_URL"
+echo ""
+
+if [[ "$IS_BRANDED_CHROME" == true ]]; then
+  echo "Warning: branded Chrome 137+ detected. --load-extension is not available."
+  echo "Load the extension manually via chrome://extensions."
+  echo ""
+  "$CHROME" \
+    --remote-debugging-port="$DEBUG_PORT" \
+    --user-data-dir="$USER_DATA_DIR" \
+    --no-first-run \
+    --no-default-browser-check \
+    "$TARGET_URL"
+else
+  "$CHROME" \
+    --remote-debugging-port="$DEBUG_PORT" \
+    --user-data-dir="$USER_DATA_DIR" \
+    --load-extension="$EXT_DIR" \
+    --no-first-run \
+    --no-default-browser-check \
+    "$TARGET_URL"
+fi

--- a/apps/browser-extension/scripts/setup-profile.sh
+++ b/apps/browser-extension/scripts/setup-profile.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Apply pre-loaded Chrome profile files so the extension auto-loads.
+# Usage: ./scripts/setup-profile.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXT_DIR="$(dirname "$SCRIPT_DIR")"
+PROFILE_SEED_DIR="${EXT_DIR}/profile-seed"
+CHROME_PROFILE="${CHROME_USER_DATA_DIR:-/root/.config/chrome}"
+EXTENSION_PATH="/root/workspace/apps/browser-extension"
+
+if [[ ! -f "$PROFILE_SEED_DIR/Preferences" ]]; then
+  cat <<EOF_MSG
+Error: profile seed not found at $PROFILE_SEED_DIR/Preferences
+
+Generate it once after manually loading the extension in Chrome:
+  mkdir -p "$PROFILE_SEED_DIR"
+  cp "$CHROME_PROFILE/Preferences" "$PROFILE_SEED_DIR/Preferences"
+  cp "$CHROME_PROFILE/Secure Preferences" "$PROFILE_SEED_DIR/Secure Preferences" 2>/dev/null || true
+
+Then re-run this script.
+EOF_MSG
+  exit 1
+fi
+
+if [[ -f "$CHROME_PROFILE/Preferences" ]] && grep -Fq "$EXTENSION_PATH" "$CHROME_PROFILE/Preferences" 2>/dev/null; then
+  echo "Extension already configured in profile."
+  exit 0
+fi
+
+echo "Applying profile seed to $CHROME_PROFILE"
+
+mkdir -p "$CHROME_PROFILE"
+
+if [[ -f "$CHROME_PROFILE/Preferences" ]]; then
+  cp "$CHROME_PROFILE/Preferences" "$CHROME_PROFILE/Preferences.backup.$(date +%s)"
+fi
+
+cp "$PROFILE_SEED_DIR/Preferences" "$CHROME_PROFILE/Preferences"
+if [[ -f "$PROFILE_SEED_DIR/Secure Preferences" ]]; then
+  cp "$PROFILE_SEED_DIR/Secure Preferences" "$CHROME_PROFILE/Secure Preferences"
+fi
+
+echo "Profile seed applied. Restart Chrome to load the extension automatically."
+echo "Note: extension path must match $EXTENSION_PATH"

--- a/apps/browser-extension/scripts/setup-profile.sh
+++ b/apps/browser-extension/scripts/setup-profile.sh
@@ -6,7 +6,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXT_DIR="$(dirname "$SCRIPT_DIR")"
 PROFILE_SEED_DIR="${EXT_DIR}/profile-seed"
-CHROME_PROFILE="${CHROME_USER_DATA_DIR:-/root/.config/chrome}"
+USER_DATA_DIR="${CHROME_USER_DATA_DIR:-/root/.config/chrome}"
+# Allow override if needed, otherwise use the standard Default profile.
+CHROME_PROFILE="${CHROME_PROFILE_DIR:-$USER_DATA_DIR/Default}"
 EXTENSION_PATH="/root/workspace/apps/browser-extension"
 
 if [[ ! -f "$PROFILE_SEED_DIR/Preferences" ]]; then


### PR DESCRIPTION
## Task

# Extension Debug Environment Setup Plan

## Context

**Two environments supported:**

### 1. Cmux Container Environment (current workspace)

- **Chrome 144 (branded)** managed by `cmux-devtools.service` (auto-restart)
- **Startup script**: `/usr/local/lib/cmux/cmux-start-chrome`
- **CDP proxy**: Port 9222 → 39382 (via `cmux-cdp-proxy.service`)
- **MCP Chrome DevTools**: Connected and working
- **Extension path**: `/root/workspace/apps/browser-extension/`

**Key limitation**: Chrome 137+ branded builds removed `--load-extension` flag. Even if we add it to the startup script, it won't work.

**Cmux Chrome startup flags** (from `/usr/local/lib/cmux/cmux-start-chrome`):

```bash
CHROME_FLAGS=(
  --no-sandbox
  --remote-debugging-address=127.0.0.1
  --remote-debugging-port=39382
  --user-data-dir=/root/.config/chrome
  # ... other flags
)
# Note: --load-extension NOT present and won't work with branded Chrome 137+
```

### 2. macOS Local Development

- Chrome not pre-started
- Can use Chromium/Chrome for Testing with `--load-extension`
- Uses separate debug profile at `.chrome-debug-profile/`

## Chrome Flag Compatibility (verified via Context7 + Web Search)

| Flag | Chrome Branded (137+) | Chrome for Testing | Notes |
|------|----------------------|-------------------|-------|
| `--load-extension` | ❌ **Removed** | ✅ Works | Security restriction since Chrome 137 |
| `--disable-extensions-except` | ❌ Removed Chrome 139+ | ✅ Works | No longer works in branded builds |
| `--headless=new` | ✅ Supported | ✅ Supported | Required for headless with extensions |
| `--remote-debugging-port` | ✅ Supported | ✅ Supported | Standard debugging flag |

**⚠️ CRITICAL: Container has&#32;`google-chrome-stable`&#32;144 (branded Chrome)**

The `--load-extension` flag was removed in Chrome 137 (May 2025) due to security concerns. This affects our container which has branded Chrome.

**Sources:**

- [Chrome Extension News June 2025](https://developer.chrome.com/blog/extension-news-june-2025)
- [PSA: Removing --load-extension flag](https://groups.google.com/a/chromium.org/g/chromium-extensions/c/1-g8EFx2BBY)

### Available Alternatives

| Method | Cmux Container | macOS Local | Notes |
|--------|----------------|-------------|-------|
| Manual "Load unpacked" | ✅ **Best option** | ✅ Works | Only option for branded Chrome 137+ |
| Chrome for Testing | ⚠️ Requires install | ✅ Works | Supports `--load-extension` |
| Puppeteer `enableExtensions` | ❌ Conflicts with systemd | ✅ Works | Launches new Chrome, conflicts with Cmux |
| Shell script + Chromium | ⚠️ Requires Chromium | ✅ Works | Need to install chromium-browser |

**Why Puppeteer doesn't work in Cmux container:**

- Puppeteer launches its **own Chrome instance**
- Cmux's `cmux-devtools.service` manages Chrome with auto-restart
- Would have two Chrome instances competing, breaking MCP connection
- MCP is connected to Cmux Chrome on port 9222, not Puppeteer's Chrome

**Best approach for Cmux container:**

**Option A: Manual load once (simplest)**

- Load extension once via chrome://extensions → persists in profile
- Profile at `/root/.config/chrome` is persistent across restarts
- No need to reload unless container is recreated

**Option B: Pre-configured profile (for fresh containers)**

- Pre-load extension in a profile, export minimal files
- Store in repo as `profile-seed.tar.gz` or commit `Preferences` file
- On container start, apply profile if extension not loaded
- Requires exact path match: `/root/workspace/apps/browser-extension`

**Key insight**: Unpacked extensions are stored as **path references** in `Preferences`, not copied. As long as:

1. Profile is reused
2. Extension source path matches exactly
3. Manifest hasn't changed incompatibly

The extension auto-loads on Chrome restart.

## Goal

Create a **cross-platform debug script** that:

1. Detects environment (container vs local macOS/Linux)
2. Loads extension appropriately for each environment
3. Navigates to `https://hr.job5156.com/search`
4. Integrates with MCP Chrome DevTools for verification

## Files to Create/Modify

| File | Action | Description |
|------|--------|-------------|
| `apps/browser-extension/scripts/debug.sh` | Create | Cross-platform debug launch script (macOS/Linux) |
| `apps/browser-extension/scripts/setup-profile.sh` | Create | Apply pre-loaded profile for fresh containers |
| `apps/browser-extension/manifest.json` | Edit | Add fixed `key` field for stable extension ID |
| `apps/browser-extension/package.json` | Edit | Add `debug` and `setup-profile` npm scripts |
| `apps/browser-extension/.gitignore` | Create | Exclude debug Chrome profile |
| `apps/browser-extension/README.md` | Edit | Add debug documentation section |
| `apps/browser-extension/profile-seed/` | Create | Minimal pre-loaded profile files (Preferences) |

**Note:** Puppeteer script removed - doesn't work with Cmux container's systemd-managed Chrome.

## Implementation Steps

### Step 1: Create Debug Launch Script

Create `apps/browser-extension/scripts/debug.sh`:

```bash
#!/bin/bash
# Launch Chrome with remote debugging for extension development
# Usage: ./scripts/debug.sh [URL]
#
# Supports:
# - Chrome for Testing / Chromium: Uses --load-extension (automated)
# - Chrome Branded 137+: Manual load required (--load-extension removed)
# - Container with existing Chrome: Shows manual instructions

set -e

SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
EXT_DIR="$(dirname "$SCRIPT_DIR")"
USER_DATA_DIR="${EXT_DIR}/.chrome-debug-profile"
TARGET_URL="${1:-https://hr.job5156.com/search}"
DEBUG_PORT="${CHROME_DEBUG_PORT:-9222}"

# Check if Chrome is already running with remote debugging (container scenario)
if pgrep -f "remote-debugging-port" > /dev/null 2>&1; then
    echo "⚠️  Chrome is already running with remote debugging."
    echo ""
    echo "Since Chrome 137+, --load-extension is removed from branded Chrome."
    echo ""
    echo "To load the extension manually:"
    echo "  1. Navigate to chrome://extensions"
    echo "  2. Enable 'Developer mode' (toggle in top-right)"
    echo "  3. Click 'Load unpacked'"
    echo "  4. Select: $EXT_DIR"
    echo ""
    echo "Then navigate to: $TARGET_URL"
    echo ""
    echo "MCP commands available:"
    echo "  - list_pages"
    echo "  - take_snapshot"
    echo "  - list_console_messages"
    exit 0
fi

# Detect Chrome path - prefer Chrome for Testing / Chromium over branded Chrome
detect_chrome() {
    # Priority: Chrome for Testing > Chromium > Chrome Canary > Chrome
    if [[ "$OSTYPE" == "darwin"* ]]; then
        # macOS paths
        for chrome_path in \
            "$HOME/.cache/puppeteer/chrome/*/chrome-mac-*/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing" \
            "/Applications/Chromium.app/Contents/MacOS/Chromium" \
            "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary" \
            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"; do
            # Handle glob patterns
            for expanded in $chrome_path; do
                if [[ -x "$expanded" ]]; then
                    echo "$expanded"
                    return 0
                fi
            done
        done
    else
        # Linux paths
        for chrome_cmd in \
            "chromium-browser" \
            "chromium" \
            "google-chrome-unstable" \
            "google-chrome-stable" \
            "google-chrome"; do
            if command -v "$chrome_cmd" &>/dev/null; then
                echo "$(command -v "$chrome_cmd")"
                return 0
            fi
        done
    fi
    return 1
}

CHROME="${CHROME:-$(detect_chrome)}"

if [[ -z "$CHROME" ]] || { [[ ! -x "$CHROME" ]] && [[ ! -f "$CHROME" ]]; }; then
    echo "Error: Chrome/Chromium not found"
    echo ""
    echo "For best compatibility, install one of:"
    echo "  - Chrome for Testing: npx @puppeteer/browsers install chrome@stable"
    echo "  - Chromium: brew install chromium (macOS) or apt install chromium (Linux)"
    echo ""
    echo "Or set CHROME environment variable to your Chrome path"
    exit 1
fi

# Check if this is branded Chrome (--load-extension won't work)
CHROME_VERSION=$("$CHROME" --version 2>/dev/null | grep -oE '[0-9]+' | head -1)
IS_BRANDED_CHROME=false
if [[ "$CHROME" == *"Google Chrome"* ]] && [[ ! "$CHROME" == *"for Testing"* ]] && [[ ! "$CHROME" == *"Canary"* ]]; then
    if [[ "$CHROME_VERSION" -ge 137 ]]; then
        IS_BRANDED_CHROME=true
    fi
fi

echo "🚀 Starting Chrome with remote debugging on port $DEBUG_PORT..."
echo "   Chrome: $CHROME"
echo "   Version: $CHROME_VERSION"
echo "   Extension: $EXT_DIR"
echo "   Profile: $USER_DATA_DIR"
echo "   URL: $TARGET_URL"
echo ""

if [[ "$IS_BRANDED_CHROME" == true ]]; then
    echo "⚠️  Warning: Using branded Chrome 137+. --load-extension flag removed."
    echo "   Extension must be loaded manually via chrome://extensions"
    echo ""
    "$CHROME" \
        --remote-debugging-port="$DEBUG_PORT" \
        --user-data-dir="$USER_DATA_DIR" \
        --no-first-run \
        --no-default-browser-check \
        "$TARGET_URL"
else
    echo "📡 MCP: Connect chrome-devtools-9222 MCP server"
    "$CHROME" \
        --remote-debugging-port="$DEBUG_PORT" \
        --user-data-dir="$USER_DATA_DIR" \
        --load-extension="$EXT_DIR" \
        --no-first-run \
        --no-default-browser-check \
        "$TARGET_URL"
fi
```

### Step 2: Add Fixed Key to manifest.json

Add a fixed `key` field to ensure stable extension ID across environments:

```diff
{
  "manifest_version": 3,
  "name": "智通直聘 Resume Collector",
  "version": "1.0.0",
+ "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr9bQ2i...",
  ...
}
```

**Why this matters:**

- Without a fixed key, Chrome generates extension ID from the source path
- If path differs between environments, extension ID changes
- A fixed key ensures the same ID everywhere, making profile seeds portable

**Generate a key:**

```bash
# Generate a new PEM key (one-time)
openssl genrsa 2048 | openssl pkcs8 -topk8 -nocrypt -out extension.pem

# Extract public key for manifest.json
openssl rsa -in extension.pem -pubout -outform DER | openssl base64 -A
```

### Step 3: Create Profile Setup Script

Create `apps/browser-extension/scripts/setup-profile.sh`:

```bash
#!/bin/bash
# Apply pre-loaded Chrome profile for extension auto-loading
# Usage: ./scripts/setup-profile.sh
#
# This patches the Chrome profile to include the extension reference,
# so the extension auto-loads on Chrome restart without manual "Load unpacked".

set -e

SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
EXT_DIR="$(dirname "$SCRIPT_DIR")"
PROFILE_SEED_DIR="${EXT_DIR}/profile-seed"
CHROME_PROFILE="${CHROME_USER_DATA_DIR:-/root/.config/chrome}"
EXTENSION_PATH="/root/workspace/apps/browser-extension"

# Check if profile seed exists
if [[ ! -d "$PROFILE_SEED_DIR" ]]; then
    echo "Error: Profile seed not found at $PROFILE_SEED_DIR"
    echo "Run 'npm run create-profile-seed' first to generate it."
    exit 1
fi

# Check if extension is already loaded in profile
if [[ -f "$CHROME_PROFILE/Preferences" ]] && grep -q "$EXTENSION_PATH" "$CHROME_PROFILE/Preferences" 2>/dev/null; then
    echo "✅ Extension already configured in profile"
    exit 0
fi

echo "🔧 Applying profile seed to $CHROME_PROFILE..."

# Backup existing Preferences if present
if [[ -f "$CHROME_PROFILE/Preferences" ]]; then
    cp "$CHROME_PROFILE/Preferences" "$CHROME_PROFILE/Preferences.backup.$(date +%s)"
fi

# Copy profile seed files
mkdir -p "$CHROME_PROFILE"
cp -r "$PROFILE_SEED_DIR"/* "$CHROME_PROFILE/"

echo "✅ Profile seed applied. Restart Chrome to load extension automatically."
echo ""
echo "Note: Extension path must be exactly: $EXTENSION_PATH"
```

### Step 4: Update package.json

Add debug and setup scripts:

```diff
  "scripts": {
+   "debug": "./scripts/debug.sh",
+   "setup-profile": "./scripts/setup-profile.sh",
    "lint": "eslint .",
    "typecheck": "tsc --noEmit"
  }
```

### Step 5: Create .gitignore

Create `apps/browser-extension/.gitignore`:

```
# Chrome debug profile (created by npm run debug on macOS/Linux)
.chrome-debug-profile/
```

### Step 6: Update README.md

Add "Debugging with MCP" section after "Development" section:

```
`markdown
## Debugging with MCP

Debug the extension using Chrome DevTools Protocol via MCP.

### macOS / Linux (Local Development)

```bash
# Start Chrome with remote debugging + extension loaded
npm run debug

# With custom URL
./scripts/debug.sh "https://hr.job5156.com/search?keyword=python"
```

The script prefers Chromium/Chrome for Testing (which support `--load-extension`), falling back to branded Chrome with a warning.

### Cmux Container Environment

Chrome is managed by systemd (`cmux-devtools.service`) with auto-restart. Since Chrome 137+, the `--load-extension` flag is removed from branded Chrome.

**Option 1: Apply pre-loaded profile (recommended for fresh containers)**

```bash
npm run setup-profile
# Then restart Chrome: sudo systemctl restart cmux-devtools
```

**Option 2: Manual load once (persists in profile)**

1. Navigate to `chrome://extensions` (MCP: `navigate_page url="chrome://extensions"`)
2. Enable "Developer mode" (MCP: click the toggle button)
3. Click "Load unpacked" → **file picker requires manual interaction**
4. Select: `/root/workspace/apps/browser-extension`
5. Navigate to `https://hr.job5156.com/search`

**Note:** Once loaded, the extension persists across Chrome restarts. No need to reload unless the container is recreated with a fresh profile.

### Chrome Version Compatibility

| Chrome Variant | `--load-extension` | Notes |
|----------------|-------------------|-------|
| Chrome for Testing | ✅ Works | Best for local dev |
| Chromium | ✅ Works | Good alternative |
| Chrome Canary | ✅ Works | Bleeding edge |
| Chrome 137+ (branded) | ❌ Removed | Manual load only |

### MCP Commands

| Command | Description |
|---------|-------------|
| `list_pages` | List open browser tabs |
| `take_snapshot` | Get page DOM structure |
| `list_console_messages` | View console logs/errors |
| `take_screenshot` | Visual verification |
| `click uid=...` | Click element by uid |
| `navigate_page url=...` | Navigate to URL |

### Debugging Flow

1. Load extension (via script or manually)
2. Log in to hr.job5156.com if required
3. Use MCP `take_snapshot` to verify page structure
4. Click extension icon → "提取当前页"
5. Use MCP `list_console_messages` to check for errors

### Install Chromium (Recommended for Local Dev)

```bash
# macOS
brew install chromium

# Linux
apt install chromium-browser
```

```
undefined
```

## Verification

### Container Testing (Current Environment)

The container has branded Chrome 144, so `--load-extension` won't work.

#### Step 1: Load Extension (choose one method)

**Method A: Apply pre-loaded profile (if profile-seed exists)**

```bash
cd apps/browser-extension
npm run setup-profile
sudo systemctl restart cmux-devtools
# Wait a few seconds for Chrome to restart
```

**Method B: Manual load via chrome://extensions**

1. **Navigate to extensions page via MCP:**

```
   mcp: navigate_page url="chrome://extensions"
```

2. **Enable Developer mode via MCP:**

```
   mcp: take_snapshot
   # Find the Developer mode toggle uid
   mcp: click uid=<developer_mode_toggle>
```

3. **Manual step required:** Click "Load unpacked" opens a file picker that MCP cannot automate. Use the browser's file picker UI to select:

```
   /root/workspace/apps/browser-extension
```

#### Step 2: Test Resume Export Functionality

1. **Navigate to search page:**

```
   mcp: navigate_page url="https://hr.job5156.com/search"
```

2. **Take snapshot to find the search button:**

```
   mcp: take_snapshot
```

3. **Click the search button to load resume results:**

```
   mcp: click uid=<search_button_uid>
```

4. **Wait for results and verify page has resume data:**

```
   mcp: take_snapshot
   # Should show resume cards/listings
```

5. **Open extension popup:**

- Click extension icon in toolbar (may require manual interaction)
- Or use keyboard shortcut if configured

6. **Test extension functionality:**

- Click "提取当前页" to extract resumes
- Check console for logs: `mcp: list_console_messages`
- Click "导出 CSV" to download

7. **Verify download:**

```
   mcp: list_console_messages
   # Check for download success/error messages
```

### macOS Testing

On local macOS with Chromium or Chrome for Testing:

1. **Run debug script:**

```bash
   cd apps/browser-extension && npm run debug
```

2. **Verify Chrome launches** with:

- Extension loaded (icon in toolbar)
- Search page opened at `https://hr.job5156.com/search`
- Remote debugging on port 9222

3. **Click search button** to load resume results
4. **Test extension:**

- Click extension icon in toolbar
- Click "提取当前页" to extract resumes
- Click "导出 CSV" to download

5. **Verify via MCP:**

```
   mcp: list_pages
   mcp: take_snapshot
   mcp: list_console_messages
```

### Step 3: Generate Profile Seed (one-time, after manual load)

After loading the extension manually once, extract the profile seed for future use:

```bash
# Extract minimal profile files for extension auto-loading
mkdir -p apps/browser-extension/profile-seed
cp /root/.config/chrome/Preferences apps/browser-extension/profile-seed/
cp /root/.config/chrome/Secure\ Preferences apps/browser-extension/profile-seed/ 2>/dev/null || true

# Verify extension is referenced
grep -o '"path": "[^"]*browser-extension[^"]*"' apps/browser-extension/profile-seed/Preferences
```

Commit the profile-seed directory to the repo for future containers.

### Checklist

- [ ] `scripts/debug.sh` is executable (`chmod +x`)
- [ ] `scripts/setup-profile.sh` is executable (`chmod +x`)
- [ ] `manifest.json` has fixed `key` field for stable extension ID
- [ ] `npm run debug` works on macOS with Chromium
- [ ] `npm run debug` detects branded Chrome 137+ and warns appropriately
- [ ] `npm run setup-profile` applies profile seed correctly
- [ ] `.chrome-debug-profile/` is git-ignored
- [ ] Extension can be loaded manually in container via chrome://extensions
- [ ] Extension icon appears in Chrome toolbar after loading
- [ ] MCP can take snapshots and list console messages
- [ ] Resume export flow works: search → click search button → extract → download CSV

### Known Limitations

1. **Cmux container with Chrome 144:** Either use profile seed or load manually once
2. **File picker not automatable:** The "Load unpacked" button opens a native file dialog that MCP cannot control
3. **Chrome 137+ branded builds:** `--load-extension` flag removed for security; use Chromium for local dev
4. **Profile seed path dependency:** Extension path must match exactly (`/root/workspace/apps/browser-extension`)

## PR Review Summary
- What Changed:
  - **Debug Environment Setup:** Introduced two new shell scripts: `scripts/debug.sh` for cross-platform Chrome debugging (automated `--load-extension` for local dev, manual instructions for branded Chrome 137+ in container) and `scripts/setup-profile.sh` to apply a pre-loaded Chrome profile seed for automatic extension loading in the Cmux container.
  - **Extension ID Stability:** Added a fixed `key` field to `manifest.json` to ensure a consistent extension ID across different environments, crucial for portable profile seeds.
  - **NPM Scripts:** Updated `package.json` with `debug` and `setup-profile` commands for easier execution of the new scripts.
  - **Git Ignore:** Added `.chrome-debug-profile/` to `.gitignore` to prevent committing local debug profiles.
  - **Documentation:** Significantly expanded `README.md` with a detailed "Debugging with MCP" section, covering setup for both local macOS/Linux and Cmux container, Chrome compatibility, MCP commands, and new auto-export functionality.
  - **Auto-Export & API Capture:** Enhanced `content.js` to support auto-export of resume data via URL parameters or localStorage (`tr_auto_export`) in various formats (CSV, JSON, Markdown, raw). This includes a new `page-hook.js` (web-accessible resource) to intercept and capture specific API responses (e.g., search results) for richer data extraction, adding `resumeId` and `perUserId` to extracted data.
  - **Profile Seed:** Included an example `profile-seed/Preferences` file to guide pre-loading the extension in fresh container profiles.

- Review Focus:
  - **Container Setup Logic:** Carefully review the conditional logic in `scripts/debug.sh` to ensure it correctly detects running Chrome in the container and provides accurate manual loading instructions for branded Chrome 137+.
  - **Profile Seed Application:** Verify that `scripts/setup-profile.sh` correctly copies the `Preferences` and `Secure Preferences` files to the Chrome profile directory and that the `EXTENSION_PATH` variable is correctly resolved for auto-loading.
  - **Manifest Key:** Confirm the `key` added to `manifest.json` is a valid, generated key and not merely the placeholder shown in the diff, ensuring a stable extension ID.
  - **Auto-Export Modes:** Test all new auto-export modes (Markdown, raw JSON, CSV, structured JSON) and their trigger mechanisms via URL parameters and localStorage, paying attention to file downloads and console output.
  - **API Interception:** Ensure `page-hook.js` is correctly injected and reliably captures API responses without introducing page errors or performance issues.
  - **`CLAUDE.md` / `AGENTS.md`:** Review the internal agent instructions for accuracy, especially regarding profile seed sensitivity.

- Test Plan:
  - **Container Environment:**
    1. Run `cd apps/browser-extension && npm run setup-profile` then `sudo systemctl restart cmux-devtools`. Verify extension loads automatically. 
    2. Alternatively, manually load the extension via `chrome://extensions` using MCP commands (`navigate_page url="chrome://extensions"`, `take_snapshot` to find toggle, `click uid=<developer_mode_toggle>`) then manual file picker. 
    3. Navigate to `https://hr.job5156.com/search`. Verify extension icon is present.
    4. Test auto-export (e.g., `https://hr.job5156.com/search?tr_auto_export=csv`). Verify CSV download or console output (`mcp: list_console_messages`).
    5. Manually trigger extraction and download from the extension popup and verify results.
  - **macOS/Linux Local Development:**
    1. Run `cd apps/browser-extension && npm run debug`. Verify Chrome launches with the extension loaded and the target URL (`https://hr.job5156.com/search`).
    2. Confirm remote debugging is enabled on port 9222.
    3. Validate auto-export functionality (URL param/localStorage) and manual extraction via the extension popup.
  - **Profile Seed Generation:**
    1. After successfully loading the extension manually, follow the `README.md` steps to generate the `profile-seed/Preferences` files and verify the content (especially the extension path reference).