### PR TITLE
Update browser extension documentation and root CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,7 @@ FastMCP server exposing tools for querying/analysis. Entry point is `mcp_server/
 - **BFF API (`apps/api/`)**: Hono (TypeScript). Routes in `apps/api/src/routes/`, Zod/OpenAPI schemas in `apps/api/src/schemas/`, data access in `apps/api/src/services/` (direct SQLite reads).
 - **Frontend (`apps/web/`)**: React (Vite + shadcn-ui + Tailwind). UI components in `apps/web/src/components/`.
 - **Worker (`apps/worker/`)**: FastAPI scheduler + optional REST endpoints (see `apps/worker/api.py`).
+- **Browser Extension (`apps/browser-extension/`)**: Chrome/Edge extension for resume extraction from hr.job5156.com. Scripts in `apps/browser-extension/scripts/`.
 
 #### Configuration (`config/`)
 - `config/config.yaml`: platforms, modes, AI settings, notifications
@@ -307,6 +308,7 @@ FastMCP server exposing tools for querying/analysis. Entry point is `mcp_server/
 | API schemas (BFF) | `apps/api/src/schemas/` |
 | MCP tools | `mcp_server/tools/` |
 | React components | `apps/web/src/components/` |
+| Browser extension | `apps/browser-extension/` (see `CLAUDE.md` there) |
 
 Tip: when paths drift, use ripgrep: `rg -n "createRoute" apps/api/src/routes` / `rg -n "DataAnalyzer" trendradar`.
 
@@ -520,9 +522,9 @@ Endpoints for the Resume Screening system will be documented here as they are im
 
 ### Package Manager
 
-- **CI (remote)**: Always use `npm` for reproducible builds
-- **Local dev**: Use `bun` for faster installs and execution
-- **Fallback**: If bun is not installed locally, npm is used automatically
+- **CI (remote)**: Always use `npm` / `npx` for reproducible builds
+- **Local dev**: Use `bun` / `bunx` for faster installs and execution
+- **Python**: Use `uv run` for Python scripts
 
 Makefile targets auto-detect bun availability:
 ```bash
@@ -530,4 +532,26 @@ Makefile targets auto-detect bun availability:
 make check-node
 make check-build
 make test-node
+```
+
+### Running Scripts from Project Root
+
+**Preferred: Direct shell script execution** (works with any package manager):
+
+```bash
+./apps/browser-extension/scripts/cmux-setup-profile.sh
+./scripts/dev.sh
+```
+
+**Workspace scripts via package manager:**
+
+```bash
+# bun (local dev)
+bun run --filter @trends/browser-extension cmux:setup-profile
+
+# npm (CI)
+npm run cmux:setup-profile --workspace @trends/browser-extension
+
+# Python (uv)
+uv run python -m mcp_server.server
 ```

--- a/apps/browser-extension/CLAUDE.md
+++ b/apps/browser-extension/CLAUDE.md
@@ -7,12 +7,23 @@ These instructions apply to `apps/browser-extension/`. Use them for any extensio
 - Extension path (container): `/root/workspace/apps/browser-extension`
 - Manifest: MV3
 
+## Running Scripts
+
+Run from **project root** using shell scripts (simplest, works with any package manager):
+
+```bash
+./apps/browser-extension/scripts/cmux-setup-profile.sh   # Setup profile + restart Chrome
+./apps/browser-extension/scripts/open-search.sh          # Open search page
+./apps/browser-extension/scripts/check-profile-seed.sh   # Validate profile seed
+```
+
+**Package managers:** Local dev uses `bun`, CI uses `npm`.
+
 ## Debugging
 ### Cmux container (this workspace)
 - Chrome is systemd-managed and branded (137+): `--load-extension` is not supported.
 - Preferred setup (fresh container):
-  - `cd apps/browser-extension && npm run setup-profile`
-  - `systemctl restart cmux-devtools cmux-cdp-proxy`
+  - `./apps/browser-extension/scripts/cmux-setup-profile.sh`
 - Manual fallback: `chrome://extensions` → Developer mode → Load unpacked → select `/root/workspace/apps/browser-extension`.
 - Profile location: `/root/.config/chrome/Default` (must match the extension path).
 

--- a/apps/browser-extension/README.md
+++ b/apps/browser-extension/README.md
@@ -42,6 +42,8 @@ Chrome/Edge browser extension to extract resume data from hr.job5156.com (智通
 | workHistory | Previous work experience |
 | profileUrl | Link to full resume |
 | extractedAt | Extraction timestamp |
+| resumeId | Resume ID from API (for deduplication) |
+| perUserId | Per-user ID from API (for deduplication) |
 
 ## Development
 
@@ -167,12 +169,18 @@ https://hr.job5156.com/search?tr_auto_export=json
 # Console + CSV (and JSON if "all")
 https://hr.job5156.com/search?tr_auto_export=both
 https://hr.job5156.com/search?tr_auto_export=all
+
+# With save-as dialog
+https://hr.job5156.com/search?tr_auto_export=csv,saveas
+
+# Include full page HTML in raw payload
+https://hr.job5156.com/search?tr_auto_export=raw,page
 ```
 
 Or set in DevTools console:
 
 ```js
-localStorage.setItem('tr_auto_export', 'md'); // or console/raw/raw_json/csv/json/both/all
+localStorage.setItem('tr_auto_export', 'md'); // Modes: md/csv/json/raw/raw_json/console/both/all. Modifiers: saveas, page
 ```
 
 Tokens can be combined with commas, for example:
@@ -187,9 +195,14 @@ https://hr.job5156.com/search?tr_auto_export=md,raw_json
 
 - `manifest.json` - Extension configuration (Manifest v3)
 - `content.js` - Injected script for data extraction
+- `background.js` - Background service worker (handles downloads via Offscreen API)
+- `page-hook.js` - API capture script (intercepts `/api/search/resume/v2` responses)
+- `offscreen.html/js` - Offscreen document for blob URL downloads
 - `popup.html/css/js` - Extension popup UI
 - `content-styles.css` - Minimal page styles
 - `icons/` - Extension icons (16/32/48/128px)
+- `scripts/` - Debug and setup scripts
+- `profile-seed/` - Chrome profile seed for container auto-loading
 
 ## Integration with Trends
 


### PR DESCRIPTION
## Task

# Plan: Update Browser Extension README and CLAUDE.md

## Summary

Update documentation for `apps/browser-extension/` to reflect PRs #28 and #29:

- Fix incorrect setup instructions in CLAUDE.md
- Add missing API-captured fields (`resumeId`, `perUserId`) to README
- Document `saveas` and `page`/`rawpage` modifiers in README
- Update file structure listing in README

---

## Part 0: Add Root-Level Script Convention Note

**File:** `apps/browser-extension/CLAUDE.md`

### Issue

Current CLAUDE.md shows commands like:

```bash
cd apps/browser-extension && npm run setup-profile
```

But the convention should be that all helper scripts (npm/bun, uv, make) are designed to run from **project root**, not requiring manual `cd`.

### Add Section (after line 8 "Manifest: MV3")

Add a new section explaining the script convention:

```markdown
## Running Scripts

Run from **project root** using shell scripts (simplest, works with any package manager):

```bash
./apps/browser-extension/scripts/cmux-setup-profile.sh   # Setup profile + restart Chrome
./apps/browser-extension/scripts/open-search.sh          # Open search page
./apps/browser-extension/scripts/check-profile-seed.sh   # Validate profile seed
```

**Package managers:** Local dev uses `bun`, CI uses `npm`.

```
---

## Part 1: Fix CLAUDE.md (Incorrect Setup Instructions)

**File:** `apps/browser-extension/CLAUDE.md`

### Issue (lines 13-15)

Current:
```markdown
- Preferred setup (fresh container):
  - `cd apps/browser-extension && npm run setup-profile`
  - `systemctl restart cmux-devtools cmux-cdp-proxy`
```

**Problem:** `setup-profile.sh` exits with error if Chrome is running (line 14-27 of the script checks for running Chrome and exits). The 2-step process doesn't work.

### Fix (line 13-15)

Change to use the one-shot shell script (run from project root):

```markdown
- Preferred setup (fresh container):
  - `./apps/browser-extension/scripts/cmux-setup-profile.sh`
```

The script automatically:

1. Stops `cmux-devtools`
2. Applies profile seed
3. Starts `cmux-devtools`

---

## Part 2: Update README.md

**File:** `apps/browser-extension/README.md`

### 2.1 Data Fields Table (after line 44)

Add `resumeId` and `perUserId` fields that are captured from API.

**Add after line 44 (before&#32;`## Development`):**

```markdown
| resumeId | Resume ID from API (for deduplication) |
| perUserId | Per-user ID from API (for deduplication) |
```

**Source:** content.js lines 202-203 show these fields are added from `getApiRowForIndex()`.

**Note:** CSV headers are `['序号', 'resumeId', 'perUserId', ...]` (content.js line 296).

### 2.2 Auto Export Section - Add Missing Modifiers

**Insert after line 169 (after&#32;`all`&#32;example):**

```markdown
# With save-as dialog
https://hr.job5156.com/search?tr_auto_export=csv,saveas

# Include full page HTML in raw payload
https://hr.job5156.com/search?tr_auto_export=raw,page
```

**Update localStorage example (line 175):**

```js
localStorage.setItem('tr_auto_export', 'md'); // or console/raw/raw_json/csv/json/both/all
```

Change to:

```js
localStorage.setItem('tr_auto_export', 'md'); // Modes: md/csv/json/raw/raw_json/console/both/all. Modifiers: saveas, page
```

### 2.3 Files Section (replace lines 186-193)

Current:

```markdown
## Files

- `manifest.json` - Extension configuration (Manifest v3)
- `content.js` - Injected script for data extraction
- `popup.html/css/js` - Extension popup UI
- `content-styles.css` - Minimal page styles
- `icons/` - Extension icons (16/32/48/128px)
```

Replace with:

```markdown
## Files

- `manifest.json` - Extension configuration (Manifest v3)
- `content.js` - Injected script for data extraction
- `background.js` - Background service worker (handles downloads via Offscreen API)
- `page-hook.js` - API capture script (intercepts `/api/search/resume/v2` responses)
- `offscreen.html/js` - Offscreen document for blob URL downloads
- `popup.html/css/js` - Extension popup UI
- `content-styles.css` - Minimal page styles
- `icons/` - Extension icons (16/32/48/128px)
- `scripts/` - Debug and setup scripts
- `profile-seed/` - Chrome profile seed for container auto-loading
```

---

## Part 3: Update Root CLAUDE.md

**File:** `/root/workspace/CLAUDE.md`

### 3.1 Add Browser Extension to Web Stack (after line 241)

Current Web Stack section only lists `apps/api`, `apps/web`, `apps/worker`.

**Add after line 241:**

```markdown
- **Browser Extension (`apps/browser-extension/`)**: Chrome/Edge extension for resume extraction from hr.job5156.com. Scripts in `apps/browser-extension/scripts/`.
```

### 3.2 Add Browser Extension to Finding Code Table (after line 309)

**Add row:**

```markdown
| Browser extension | `apps/browser-extension/` (see `CLAUDE.md` there) |
```

### 3.3 Expand Package Manager Section (line 521-533)

**Update the Package Manager section to include workspace script execution:**

Current:

```markdown
### Package Manager

- **CI (remote)**: Always use `npm` for reproducible builds
- **Local dev**: Use `bun` for faster installs and execution
- **Fallback**: If bun is not installed locally, npm is used automatically

Makefile targets auto-detect bun availability:
```bash
# Uses bun if available, falls back to npm
make check-node
make check-build
make test-node
```

```
Replace with:
```markdown
### Package Manager

- **CI (remote)**: Always use `npm` / `npx` for reproducible builds
- **Local dev**: Use `bun` / `bunx` for faster installs and execution
- **Python**: Use `uv run` for Python scripts

Makefile targets auto-detect bun availability:
```bash
# Uses bun if available, falls back to npm
make check-node
make check-build
make test-node
```

### Running Scripts from Project Root

**Preferred: Direct shell script execution** (works with any package manager):

```bash
./apps/browser-extension/scripts/cmux-setup-profile.sh
./scripts/dev.sh
```

**Workspace scripts via package manager:**

```bash
# bun (local dev)
bun run --filter @trends/browser-extension cmux:setup-profile

# npm (CI)
npm run cmux:setup-profile --workspace @trends/browser-extension

# Python (uv)
uv run python -m mcp_server.server
```

```
---

## Files to Modify

1. `apps/browser-extension/CLAUDE.md`:
   - Add "Running Scripts" section (after line 8)
   - Fix lines 13-15 (setup instructions)
2. `apps/browser-extension/README.md`:
   - Add `resumeId`, `perUserId` to data fields table (after line 44)
   - Add `saveas` and `page` modifier examples (after line 169)
   - Update localStorage comment (line 175)
   - Update files section (lines 186-193)
3. `/root/workspace/CLAUDE.md`:
   - Add browser extension to Web Stack section (after line 241)
   - Add browser extension to Finding Code table (after line 309)
   - Expand Package Manager section with bun/npm/uv and workspace script patterns (lines 521-533)

---

## Verification

1. Test shell scripts work from project root:
   ```bash
   ./apps/browser-extension/scripts/check-profile-seed.sh  # Should validate profile seed
```

2. Verify `apps/browser-extension/CLAUDE.md` documents shell script execution from project root
3. Verify `apps/browser-extension/CLAUDE.md` setup command uses `./apps/browser-extension/scripts/cmux-setup-profile.sh`
4. Verify `apps/browser-extension/README.md` data fields table includes `resumeId` and `perUserId`
5. Verify `apps/browser-extension/README.md` auto-export section documents `saveas` and `page` modifiers
6. Verify `apps/browser-extension/README.md` files section lists all current extension files
7. Verify root `CLAUDE.md` mentions browser extension in Web Stack and Finding Code sections
8. Verify root `CLAUDE.md` Package Manager section documents bun/npm/uv convention
9. Verify root `CLAUDE.md` has "Running Scripts from Project Root" section with workspace examples

## PR Review Summary
- What Changed:
  - `apps/browser-extension/CLAUDE.md`: Added a "Running Scripts" section clarifying shell script execution from the project root and updated the setup instructions to use the `cmux-setup-profile.sh` script for a one-shot setup.
  - `apps/browser-extension/README.md`: Included `resumeId` and `perUserId` in the data fields table. Documented `saveas` and `page` auto-export modifiers with examples, and updated the `localStorage` comment to reflect these. Expanded the file structure listing to include `background.js`, `page-hook.js`, `offscreen.html/js`, `scripts/`, and `profile-seed/`.
  - `CLAUDE.md` (root): Integrated the browser extension into the "Web Stack" and "Finding Code" sections. Enhanced the "Package Manager" section to detail `bun`/`bunx`, `npm`/`npx`, and `uv run` usage, and added a dedicated "Running Scripts from Project Root" section with examples for both direct shell scripts and workspace scripts via package managers.
- Review Focus:
  - Verify the accuracy and clarity of all new documentation, especially the script execution instructions in both `CLAUDE.md` files.
  - Confirm that the `saveas` and `page` auto-export modifiers are correctly explained and exemplified in `apps/browser-extension/README.md`.
  - Ensure the updated file structure in `apps/browser-extension/README.md` is complete and accurate.
- Test Plan:
  - Run `./apps/browser-extension/scripts/check-profile-seed.sh` from the project root to confirm script execution convention.
  - Manually review `apps/browser-extension/CLAUDE.md` and `apps/browser-extension/README.md` for the correct documentation of setup, data fields, and auto-export modifiers.
  - Review the root `CLAUDE.md` to ensure the browser extension is properly referenced and the package manager conventions are clearly documented.
  - (Optional but recommended) Test the browser extension with `tr_auto_export` set to include `saveas` and `page` modifiers to validate their behavior.