### PR TITLE
Fix 'command not found' error in cmux scripts

### DIFF
--- a/apps/browser-extension/scripts/cmux-setup-profile.sh
+++ b/apps/browser-extension/scripts/cmux-setup-profile.sh
@@ -15,8 +15,8 @@ if [[ "$(id -u)" != "0" ]] && command -v sudo >/dev/null 2>&1; then
   SUDO="sudo"
 fi
 
-"$SUDO" systemctl stop "$SERVICE_NAME"
+$SUDO systemctl stop "$SERVICE_NAME"
 "$SCRIPT_DIR/setup-profile.sh"
-"$SUDO" systemctl start "$SERVICE_NAME"
+$SUDO systemctl start "$SERVICE_NAME"
 
 echo "Profile seed applied and $SERVICE_NAME restarted."

--- a/apps/browser-extension/scripts/open-search.sh
+++ b/apps/browser-extension/scripts/open-search.sh
@@ -16,13 +16,13 @@ if [[ "$(id -u)" != "0" ]] && command -v sudo >/dev/null 2>&1; then
   SUDO="sudo"
 fi
 
-if ! "$SUDO" systemctl status "$SERVICE_NAME" >/dev/null 2>&1; then
+if ! $SUDO systemctl status "$SERVICE_NAME" >/dev/null 2>&1; then
   echo "Service $SERVICE_NAME not found. Falling back to ./scripts/debug.sh" >&2
   exec "$SCRIPT_DIR/debug.sh" "$TARGET_URL"
 fi
 
-"$SUDO" systemctl set-environment CHROME_START_URL="$TARGET_URL"
-"$SUDO" systemctl restart "$SERVICE_NAME"
-"$SUDO" systemctl unset-environment CHROME_START_URL
+$SUDO systemctl set-environment CHROME_START_URL="$TARGET_URL"
+$SUDO systemctl restart "$SERVICE_NAME"
+$SUDO systemctl unset-environment CHROME_START_URL
 
 echo "Restarted $SERVICE_NAME with start URL: $TARGET_URL"


### PR DESCRIPTION
## Task

# Fix: cmux-setup-profile.sh "command not found" error

## Problem

Running `./apps/browser-extension/scripts/cmux-setup-profile.sh` produces:

```
./apps/browser-extension/scripts/cmux-setup-profile.sh: line 18: : command not found
```

## Root Cause

When running as root (id -u == 0), the `SUDO` variable is empty. The script then executes:

```bash
"$SUDO" systemctl stop "$SERVICE_NAME"
```

This expands to `"" systemctl stop "cmux-devtools"`, causing bash to try to execute an empty string as a command.

## Solution

Remove quotes around `$SUDO` in all affected scripts. When unquoted and empty, the variable simply expands to nothing:

```bash
$SUDO systemctl stop "$SERVICE_NAME"  # Correct: expands to just "systemctl stop ..."
```

## Files to Modify

1. **`apps/browser-extension/scripts/cmux-setup-profile.sh`** (lines 18, 20)

- Change `"$SUDO"` to `$SUDO`

2. **`apps/browser-extension/scripts/open-search.sh`** (lines 19, 24, 25, 26)

- Change `"$SUDO"` to `$SUDO`

## Verification

After fixes:

```bash
# Test as root (current environment)
./apps/browser-extension/scripts/cmux-setup-profile.sh
```

The script should either succeed or fail gracefully with a meaningful error (e.g., service not found).

## PR Review Summary
- **What Changed:**
  - This PR addresses a "command not found" error occurring when `$SUDO` is empty (e.g., when running scripts as root).
  - The fix involves removing quotes around the `$SUDO` variable in shell commands, changing `"$SUDO"` to `$SUDO`.
  - This ensures that an empty `$SUDO` variable expands to nothing, preventing the shell from attempting to execute an empty string.
  - Specifically, this affects calls to `systemctl` commands in:
    - `apps/browser-extension/scripts/cmux-setup-profile.sh` (lines 18, 20)
    - `apps/browser-extension/scripts/open-search.sh` (lines 19, 24, 25, 26)
- **Review Focus:**
  - Confirm that both `cmux-setup-profile.sh` and `open-search.sh` scripts now execute correctly and without errors when run as root.
  - Verify that the scripts still function as expected when run by a non-root user that requires `sudo` (i.e., `sudo` is correctly prefixed).
  - Ensure all `systemctl` commands (stop, start, set-environment, restart, unset-environment) are correctly invoked.
- **Test Plan:**
  - Execute `./apps/browser-extension/scripts/cmux-setup-profile.sh` as root. Verify it completes successfully without any "command not found" errors.
  - Execute `./apps/browser-extension/scripts/open-search.sh` as root. Verify it completes successfully without any "command not found" errors.
  - If your setup allows, run both scripts as a non-root user who has `sudo` privileges to ensure `sudo` is correctly applied.
  - For `open-search.sh`, confirm that the specified `TARGET_URL` is used to restart the service (if applicable to your test environment).