### PR TITLE
Auto-search resumes by URL keyword

### DIFF
--- a/apps/browser-extension/CLAUDE.md
+++ b/apps/browser-extension/CLAUDE.md
@@ -49,6 +49,15 @@ Run from **project root** using shell scripts (simplest, works with any package 
   - `saveas` prompts the browser download dialog
 - Downloads land in `/root/Downloads` as `resumes_<type>_<date>_<id>.*`.
 
+## Auto Search (URL Keyword)
+- Enable via URL: `?keyword=<search term>`
+- Supports: Simplified Chinese, Traditional Chinese, English, mixed
+- Combined example: `?keyword=python&tr_auto_export=csv`
+- Data attributes set on `<html>`:
+  - `data-tr-auto-search` = "done" or "skipped"
+  - `data-tr-search-keyword` = the keyword used
+- Order: auto-search runs before auto-export.
+
 ## Unique IDs (dedupe support)
 - The extension captures API rows to include `resumeId` and `perUserId` in exports.
 - If IDs are missing:

--- a/apps/browser-extension/README.md
+++ b/apps/browser-extension/README.md
@@ -191,6 +191,31 @@ https://hr.job5156.com/search?tr_auto_export=raw,raw_json,page
 https://hr.job5156.com/search?tr_auto_export=md,raw_json
 ```
 
+### Auto Search (URL Keyword)
+
+The extension can automatically perform a search when you open a URL with a `keyword` parameter.
+
+Usage:
+
+```text
+https://hr.job5156.com/search?keyword=python
+https://hr.job5156.com/search?keyword=车床销售
+https://hr.job5156.com/search?keyword=销售经理
+```
+
+Supported characters:
+- Simplified Chinese (简体中文): `?keyword=软件工程师`
+- Traditional Chinese (繁體中文): `?keyword=軟體工程師`
+- English: `?keyword=python`
+- Mixed: `?keyword=Python开发`
+
+Combine with auto-export for end-to-end workflows:
+
+```text
+https://hr.job5156.com/search?keyword=python&tr_auto_export=csv
+https://hr.job5156.com/search?keyword=车床销售&tr_auto_export=md,rawjson
+```
+
 ## Files
 
 - `manifest.json` - Extension configuration (Manifest v3)


### PR DESCRIPTION
## Summary
- auto-search by URL `keyword` param and trigger search before auto-export
- add debug attributes for auto-search state and keyword used
- document auto-search usage in extension docs

## Testing
- manual (cmux): opened `https://hr.job5156.com/search?keyword=python&tr_auto_export=console`
- manual (cmux): opened `https://hr.job5156.com/search?keyword=车床销售&tr_auto_export=console`
- manual (cmux): opened `https://hr.job5156.com/search?keyword=销售&tr_auto_export=csv`

## Plan Prompt
````text
# Plan: Auto-Search from URL Keyword Parameter

## Summary

Implement a feature that allows the browser extension to automatically perform a search on `hr.job5156.com/search` when a URL contains a `keyword` parameter, without requiring user interaction with the search input field.

**Example URLs:**

- `https://hr.job5156.com/search?keyword=车床销售`
- `https://hr.job5156.com/search?keyword=python`
- `https://hr.job5156.com/search?keyword=销售&tr_auto_export=csv` (combined with auto-export)

## Approach

### How it Works

1. When user navigates to a URL with `?keyword=xxx`, the content script detects the keyword parameter
2. The extension fills the search input with the keyword value
3. The extension triggers the search (clicks the search button)
4. Existing auto-export functionality can then run if enabled

### Technical Details

**Search Form Elements (from page snapshot):**

- Search input: Combobox/textbox with placeholder "请输入关键词，多个词用空格隔开，如：五金 销售"
- Search button: Button with text "搜  索"

**CSS Selectors to add:**

```javascript
const SELECTORS = {
  // ... existing selectors
  searchInput: '.el-autocomplete input.el-input__inner',  // The keyword input field
  searchButton: '.resume-search-item-search-input-block__input-button'  // Search button (div with "搜  索")
};
```

**Note:** The search button is a `<div>` with class `resume-search-item-search-input-block__input-button`, not a `<button>` element.

### Implementation Steps

1. **Add search-related selectors** to the `SELECTORS` constant in `content.js`
2. **Create `autoSearchFromUrl()` function** that:

- Extracts `keyword` parameter from URL
- Finds the search input element
- Fills the input with the keyword value
- Dispatches input/change events to trigger Vue reactivity
- Clicks the search button to trigger the search
- Waits for results to load using existing `waitForResumeCards()`

3. **Call `autoSearchFromUrl()` at initialization** in `content.js`:

- Call it before `runAutoExportIfEnabled()` so the search happens first
- Then auto-export can run on the search results

4. **Add data attributes** for debugging:

- `data-tr-auto-search` = "done" or "skipped"
- `data-tr-search-keyword` = the keyword used

### Code Location

- File: `apps/browser-extension/content.js`
- Insert new function after line ~514 (after `waitForApiRows`)
- Call it at line ~637 before `runAutoExportIfEnabled()`

### Key Considerations

1. **Character encoding**: The `keyword` parameter may contain:

- Simplified Chinese (简体中文)
- Traditional Chinese (繁體中文)
- English
- URL-encoded characters

   Using `URLSearchParams.get()` automatically handles URL decoding.

2. **Vue reactivity**: The page uses Element UI (Vue). We need to:

- Set `input.value` directly
- Dispatch `input` event with `bubbles: true`
- Optionally dispatch `change` event
- Click the search button to trigger the actual search

3. **Timing**: Need to wait for:

- DOM ready before manipulating elements
- Search results to load after triggering search
- API data to be captured (for auto-export)

4. **Skip conditions**: Don't auto-search if:

- No `keyword` parameter in URL
- The input already has the correct keyword (page already loaded with that search)

## Files to Modify

| File | Changes |
|------|---------|
| `apps/browser-extension/content.js` | Add selectors, `autoSearchFromUrl()` function, call at init |
| `apps/browser-extension/README.md` | Document the `keyword` URL parameter feature |
| `apps/browser-extension/CLAUDE.md` | Add auto-search section for developer reference |

## Documentation Updates

### README.md Updates

Add a new section for **Auto Search** feature:

```markdown
## Auto Search (URL Keyword)

The extension can automatically perform a search when you navigate to a URL with a `keyword` parameter.

### Usage

Simply add `?keyword=<search term>` to the URL:
```

https://hr.job5156.com/search?keyword=python
https://hr.job5156.com/search?keyword=车床销售
https://hr.job5156.com/search?keyword=销售经理

```
### Supported Characters

- Simplified Chinese (简体中文): `?keyword=软件工程师`
- Traditional Chinese (繁體中文): `?keyword=軟體工程師`
- English: `?keyword=python`
- Mixed: `?keyword=Python开发`

### Combined with Auto Export

Combine with `tr_auto_export` for automated workflows:
```

https://hr.job5156.com/search?keyword=python&tr_auto_export=csv
https://hr.job5156.com/search?keyword=车床销售&tr_auto_export=md,rawjson

```
This will:
1. Auto-fill the search keyword
2. Trigger the search
3. Wait for results to load
4. Export the results in the specified format
```

### CLAUDE.md Updates

Add a new section after "Auto Export":

```markdown
## Auto Search (URL Keyword)
- Enable via URL: `?keyword=<search term>`
- Supports: Simplified Chinese, Traditional Chinese, English, mixed
- Combined example: `?keyword=python&tr_auto_export=csv`
- Data attributes set:
  - `data-tr-auto-search` = "done" or "skipped"
  - `data-tr-search-keyword` = the keyword used
- Order: Auto-search runs BEFORE auto-export
```

## Verification

1. **Manual testing:**

```bash
   # Navigate to URL with keyword
   ./apps/browser-extension/scripts/open-search.sh "https://hr.job5156.com/search?keyword=python"
```

2. **Check console for:**

- `🎯 [Auto Search] Searching for: python`
- `🎯 [Auto Search] Done, found X results`

3. **Check data attributes:**

```javascript
   // In DevTools console
   document.documentElement.getAttribute('data-tr-auto-search')  // "done"
   document.documentElement.getAttribute('data-tr-search-keyword')  // "python"
```

4. **Test with auto-export:**

```
   https://hr.job5156.com/search?keyword=车床销售&tr_auto_export=csv
```

   Should auto-search first, then auto-export the results.

5. **MCP-based verification:**

```javascript
   mcp__chrome-devtools-9222__navigate_page({"url": "https://hr.job5156.com/search?keyword=测试"})
   mcp__chrome-devtools-9222__wait_for({"text": "个结果"})
   mcp__chrome-devtools-9222__take_snapshot({})
```
````
