### PR TITLE
Hide /trends route and links

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,6 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import { Header } from '@/components/Header'
 import { ResumesPage } from '@/pages/ResumesPage'
-import { TrendsPage } from '@/pages/TrendsPage'
 
 function App() {
   return (
@@ -12,7 +11,6 @@ function App() {
           <Routes>
             <Route path="/" element={<Navigate to="/resumes" replace />} />
             <Route path="/resumes" element={<ResumesPage />} />
-            <Route path="/trends" element={<TrendsPage />} />
             <Route path="*" element={<Navigate to="/resumes" replace />} />
           </Routes>
         </main>

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -30,17 +30,6 @@ export function Header() {
             >
               {t('nav.resumes')}
             </NavLink>
-            <NavLink
-              to="/trends"
-              className={({ isActive }) =>
-                cn(
-                  'transition-colors hover:text-foreground',
-                  isActive ? 'text-foreground' : 'text-muted-foreground'
-                )
-              }
-            >
-              {t('nav.trends')}
-            </NavLink>
           </nav>
         </div>
         <div className="flex items-center gap-3">
@@ -55,17 +44,6 @@ export function Header() {
               }
             >
               {t('nav.resumes')}
-            </NavLink>
-            <NavLink
-              to="/trends"
-              className={({ isActive }) =>
-                cn(
-                  'transition-colors hover:text-foreground',
-                  isActive ? 'text-foreground' : 'text-muted-foreground'
-                )
-              }
-            >
-              {t('nav.trends')}
             </NavLink>
           </nav>
           <LanguageSwitcher />


### PR DESCRIPTION
## Summary
- remove /trends route from the React router
- remove /trends links from desktop and mobile navigation

## Testing
- not run (UI-only change)