### PR TITLE
Automate refresh-sample via CDP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,15 @@ Resume Sources → Gateway → Multi-Agent Pipeline → AI Screening & Matching 
 
 Resume sample files in `output/resumes/samples/` include provenance metadata for reproduction.
 
+**Quick regeneration (automated via CDP):**
+```bash
+make refresh-sample                          # Default: 销售 -> sample-initial.json
+make refresh-sample KEYWORD=python           # Custom keyword
+make refresh-sample KEYWORD=python SAMPLE=sample-python
+```
+Chrome must be running with remote debugging enabled and the extension installed/enabled.
+Manual fallback: `make refresh-sample-manual`.
+
 **Quick regeneration (semi-manual):**
 1. Log into https://hr.job5156.com in Chrome (with the browser extension installed)
 2. Navigate to: `https://hr.job5156.com/search?keyword=销售&tr_auto_export=json&tr_sample_name=sample-initial`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,7 @@ Resume sample files in `output/resumes/samples/` include provenance metadata for
 make refresh-sample                          # Default: 销售 -> sample-initial.json
 make refresh-sample KEYWORD=python           # Custom keyword
 make refresh-sample KEYWORD=python SAMPLE=sample-python
+make refresh-sample ALLOW_EMPTY=1            # Allow saving empty sample
 ```
 Chrome must be running with remote debugging enabled and the extension installed/enabled.
 Manual fallback: `make refresh-sample-manual`.

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ fetch-docs:
 refresh-sample:
 	@KEYWORD="$(or $(KEYWORD),销售)" SAMPLE="$(or $(SAMPLE),sample-initial)" \
 	CDP_PORT="$(or $(CDP_PORT),9222)" \
+	ALLOW_EMPTY="$(ALLOW_EMPTY)" \
 	./scripts/refresh-sample.sh
 
 # Show instructions for refreshing resume sample data
@@ -321,3 +322,5 @@ help:
 	@echo "  WORKER_PORT    FastAPI worker port (default: 8000)"
 	@echo "  API_PORT       BFF API port (default: 3000)"
 	@echo "  WEB_PORT       Web frontend port (default: 5173)"
+	@echo "  CDP_PORT       Chrome DevTools port (default: 9222)"
+	@echo "  ALLOW_EMPTY    Allow empty resume samples (set to 1)"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
         test test-python test-node \
         build-static build-static-fresh serve-static \
         i18n-check i18n-sync i18n-convert i18n-translate i18n-build \
-        refresh-sample
+        refresh-sample refresh-sample-manual
 
 # Default target
 .DEFAULT_GOAL := help
@@ -176,9 +176,15 @@ fetch-docs:
 # Utilities
 # =============================================================================
 
-# Show instructions for refreshing resume sample data
+# Refresh resume sample data automatically via CDP
 refresh-sample:
-	@echo "=== Refresh Resume Sample Data ==="
+	@KEYWORD="$(or $(KEYWORD),销售)" SAMPLE="$(or $(SAMPLE),sample-initial)" \
+	CDP_PORT="$(or $(CDP_PORT),9222)" \
+	./scripts/refresh-sample.sh
+
+# Show instructions for refreshing resume sample data
+refresh-sample-manual:
+	@echo "=== Refresh Resume Sample Data (Manual) ==="
 	@echo "1. Log into https://hr.job5156.com in Chrome (extension installed)"
 	@echo "2. Navigate to this URL:"
 	@echo "   https://hr.job5156.com/search?keyword=销售&tr_auto_export=json&tr_sample_name=sample-initial"
@@ -297,7 +303,8 @@ help:
 	@echo "  fetch-docs     Fetch latest upstream documentation"
 	@echo ""
 	@echo "Utilities:"
-	@echo "  refresh-sample Show instructions for refreshing resume sample data"
+	@echo "  refresh-sample Auto-refresh resume sample data via CDP"
+	@echo "  refresh-sample-manual Show manual instructions for refreshing resume sample data"
 	@echo "  clean          Remove generated/cached files"
 	@echo "  check          Run validation checks (Python + Node)"
 	@echo "  check-python   Run Python checks only"

--- a/apps/browser-extension/CLAUDE.md
+++ b/apps/browser-extension/CLAUDE.md
@@ -59,6 +59,23 @@ https://hr.job5156.com/search?keyword=销售&tr_auto_export=json&tr_sample_name=
 
 The exported JSON includes `metadata.sourceUrl` and `metadata.searchCriteria` for reproduction.
 
+### CDP Automation
+The project uses CDP to automate sample refreshes:
+
+```bash
+make refresh-sample                          # Default: 销售 -> sample-initial.json
+make refresh-sample KEYWORD=python SAMPLE=sample-python
+```
+
+CDP reads from the content script accessor:
+
+```
+window.__TR_RESUME_DATA__.extract()
+window.__TR_RESUME_DATA__.status()
+```
+
+Ensure Chrome is running with remote debugging enabled and the extension is loaded on `hr.job5156.com/search`.
+
 ## Auto Search (URL Keyword)
 - Enable via URL: `?keyword=<search term>`
 - Supports: Simplified Chinese, Traditional Chinese, English, mixed

--- a/apps/browser-extension/CLAUDE.md
+++ b/apps/browser-extension/CLAUDE.md
@@ -65,6 +65,7 @@ The project uses CDP to automate sample refreshes:
 ```bash
 make refresh-sample                          # Default: 销售 -> sample-initial.json
 make refresh-sample KEYWORD=python SAMPLE=sample-python
+make refresh-sample ALLOW_EMPTY=1            # Allow saving empty sample
 ```
 
 CDP reads from the content script accessor:

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -825,12 +825,18 @@ function installExternalAccessor() {
       isLoggedIn: () => isLoggedIn(),
       status: () => {
         const pagination = getPaginationInfo();
+        const cardCount = document.querySelectorAll(SELECTORS.resumeCard).length;
+        const autoSearch = document.documentElement.getAttribute('data-tr-auto-search') || '';
+        const autoExport = document.documentElement.getAttribute('data-tr-auto-export') || '';
         return {
           extensionLoaded: true,
           extensionVersion: version,
           apiSnapshotCount: Array.isArray(apiSnapshot.searchRows) ? apiSnapshot.searchRows.length : 0,
           domReady: document.querySelector(SELECTORS.listContainer) !== null,
           loggedIn: isLoggedIn(),
+          cardCount,
+          autoSearch,
+          autoExport,
           pagination,
           timestamp: new Date().toISOString()
         };

--- a/scripts/refresh-sample.py
+++ b/scripts/refresh-sample.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""
+Refresh resume sample data via Chrome DevTools Protocol (CDP).
+
+Chrome must be running with remote debugging enabled. Example:
+  ./apps/browser-extension/scripts/cmux-setup-profile.sh
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+import time
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+import websockets
+
+CDP_PORT = 9222
+DEFAULT_KEYWORD = "销售"
+DEFAULT_SAMPLE = "sample-initial"
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "output" / "resumes" / "samples"
+
+
+class CDPError(RuntimeError):
+    pass
+
+
+def fetch_json(url: str, timeout: float = 2.0):
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return json.load(response)
+
+
+def create_target(port: int, url: str):
+    encoded = urllib.parse.quote(url, safe="")
+    endpoint = f"http://127.0.0.1:{port}/json/new?{encoded}"
+    try:
+        return fetch_json(endpoint, timeout=3.0)
+    except Exception:
+        return None
+
+
+def sanitize_sample_name(value: str) -> str:
+    if not value:
+        return ""
+    cleaned = value.strip()
+    cleaned = re.sub(r'[\\/:*?"<>|]', "-", cleaned)
+    cleaned = re.sub(r"\s+", "-", cleaned)
+    cleaned = re.sub(r"-+", "-", cleaned)
+    cleaned = cleaned.lstrip(".")
+    return cleaned[:80]
+
+
+def build_search_url(keyword: str) -> str:
+    params = {"keyword": keyword}
+    return "https://hr.job5156.com/search?" + urllib.parse.urlencode(params)
+
+
+def build_metadata(page_url: str, sample_name: str, status: dict | None, resumes: list) -> dict:
+    parsed = urllib.parse.urlparse(page_url)
+    query = urllib.parse.parse_qs(parsed.query, keep_blank_values=True)
+    keyword = (query.get("keyword", [""])[0] or "").strip()
+    location = (query.get("location", [""])[0] or "").strip()
+
+    filters = {}
+    for key, values in query.items():
+        if key in ("keyword", "location", "tr_auto_export", "tr_sample_name"):
+            continue
+        if not values:
+            continue
+        value = values[0]
+        if value:
+            filters[key] = value
+
+    query.pop("tr_auto_export", None)
+    query.pop("tr_sample_name", None)
+    clean_query = urllib.parse.urlencode(
+        [(k, v[0]) for k, v in query.items() if v and v[0] != ""]
+    )
+    source_url = urllib.parse.urlunparse(
+        (parsed.scheme, parsed.netloc, parsed.path, "", clean_query, "")
+    )
+
+    generated_by = "browser-extension"
+    if status:
+        version = status.get("extensionVersion") or ""
+        if version and version != "unknown":
+            generated_by = f"browser-extension@{version}"
+
+    pagination = (status or {}).get("pagination") or {}
+    total_pages = pagination.get("totalPages", 1)
+
+    generated_at = (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+    reproduction_params = urllib.parse.urlencode(
+        {"tr_auto_export": "json", "tr_sample_name": sample_name}
+    )
+
+    return {
+        "sourceUrl": source_url,
+        "searchCriteria": {
+            "keyword": keyword,
+            "location": location,
+            "filters": filters,
+        },
+        "generatedAt": generated_at,
+        "generatedBy": generated_by,
+        "totalPages": total_pages,
+        "totalResumes": len(resumes),
+        "reproduction": f"Navigate to sourceUrl, then add ?{reproduction_params}",
+    }
+
+
+class CDPClient:
+    def __init__(self, ws):
+        self.ws = ws
+        self._next_id = 0
+        self.contexts: dict[int, dict] = {}
+
+    async def _recv(self):
+        raw = await self.ws.recv()
+        msg = json.loads(raw)
+        if "method" in msg:
+            self._handle_event(msg)
+            return ("event", msg)
+        return ("response", msg)
+
+    def _handle_event(self, msg: dict):
+        method = msg.get("method")
+        params = msg.get("params") or {}
+        if method == "Runtime.executionContextCreated":
+            context = params.get("context")
+            if context and "id" in context:
+                self.contexts[context["id"]] = context
+        elif method == "Runtime.executionContextDestroyed":
+            context_id = params.get("executionContextId")
+            if context_id in self.contexts:
+                self.contexts.pop(context_id, None)
+        elif method == "Runtime.executionContextsCleared":
+            self.contexts = {}
+
+    async def call(self, method: str, params: dict | None = None, timeout: float = 20.0):
+        self._next_id += 1
+        request_id = self._next_id
+        message = {"id": request_id, "method": method}
+        if params:
+            message["params"] = params
+        await self.ws.send(json.dumps(message))
+        deadline = time.time() + timeout
+        while True:
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                raise CDPError(f"Timeout waiting for {method}")
+            try:
+                kind, msg = await asyncio.wait_for(self._recv(), timeout=remaining)
+            except asyncio.TimeoutError as exc:
+                raise CDPError(f"Timeout waiting for {method}") from exc
+            if kind == "response" and msg.get("id") == request_id:
+                if "error" in msg:
+                    raise CDPError(f"{method} failed: {msg['error']}")
+                return msg.get("result") or {}
+
+
+async def eval_json(client: CDPClient, expression: str, context_id: int | None = None):
+    params = {
+        "expression": expression,
+        "returnByValue": True,
+        "awaitPromise": True,
+    }
+    if context_id:
+        params["contextId"] = context_id
+    result = await client.call("Runtime.evaluate", params=params)
+    if "exceptionDetails" in result:
+        raise CDPError("Runtime.evaluate threw an exception")
+    return (result.get("result") or {}).get("value")
+
+
+def pick_contexts(contexts: dict[int, dict]) -> list[dict]:
+    isolated = []
+    for ctx in contexts.values():
+        aux = ctx.get("auxData") or {}
+        if aux.get("type") == "isolated":
+            isolated.append(ctx)
+    if not isolated:
+        isolated = list(contexts.values())
+    def rank(ctx: dict) -> tuple[int, str]:
+        name = ctx.get("name") or ""
+        if "Resume" in name or "智通直聘" in name:
+            return (0, name)
+        return (1, name)
+    isolated.sort(key=rank)
+    return isolated
+
+
+async def resolve_accessor_context(client: CDPClient) -> int | None:
+    probe = "(() => !!(window.__TR_RESUME_DATA__ && window.__TR_RESUME_DATA__.status))()"
+    try:
+        if await eval_json(client, probe):
+            return None
+    except CDPError:
+        pass
+
+    for ctx in pick_contexts(client.contexts):
+        ctx_id = ctx.get("id")
+        if not ctx_id:
+            continue
+        try:
+            if await eval_json(client, probe, context_id=ctx_id):
+                return ctx_id
+        except CDPError:
+            continue
+    return None
+
+
+async def wait_for(
+    client: CDPClient,
+    expression: str,
+    timeout: float = 20.0,
+    interval: float = 0.5,
+    context_id: int | None = None,
+):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        try:
+            last = await eval_json(client, expression, context_id=context_id)
+        except CDPError:
+            last = None
+        if last:
+            return last
+        await asyncio.sleep(interval)
+    return last
+
+
+async def run():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--keyword", default=DEFAULT_KEYWORD, help="Search keyword")
+    parser.add_argument("--sample", default=DEFAULT_SAMPLE, help="Sample file name")
+    parser.add_argument("--port", type=int, default=CDP_PORT, help="CDP port")
+    args = parser.parse_args()
+
+    sample_name = sanitize_sample_name(args.sample)
+    if sample_name.lower().endswith(".json"):
+        sample_name = sample_name[:-5]
+    if not sample_name:
+        sample_name = "sample"
+
+    search_url = build_search_url(args.keyword)
+
+    try:
+        targets = fetch_json(f"http://127.0.0.1:{args.port}/json")
+    except Exception as exc:
+        raise CDPError("Chrome is not reachable on the CDP port.") from exc
+
+    pages = [
+        target
+        for target in targets
+        if target.get("type") == "page" and target.get("webSocketDebuggerUrl")
+    ]
+
+    target = None
+    for page in pages:
+        if "hr.job5156.com/search" in (page.get("url") or ""):
+            target = page
+            break
+    if not target:
+        for page in pages:
+            if "hr.job5156.com" in (page.get("url") or ""):
+                target = page
+                break
+    if not target:
+        target = create_target(args.port, search_url)
+    if not target and pages:
+        target = pages[0]
+    if not target:
+        raise CDPError("No debuggable Chrome pages found.")
+
+    ws_url = target.get("webSocketDebuggerUrl")
+    if not ws_url:
+        raise CDPError("Selected target has no webSocketDebuggerUrl.")
+
+    print(f"Using target: {target.get('title') or target.get('url')}")
+
+    async with websockets.connect(ws_url, max_size=64 * 1024 * 1024) as ws:
+        client = CDPClient(ws)
+        await client.call("Page.enable")
+        await client.call("Runtime.enable")
+        await client.call("Page.navigate", {"url": search_url})
+
+        await wait_for(client, "document.readyState === 'complete'", timeout=30.0)
+
+        context_id = await resolve_accessor_context(client)
+        if context_id is None:
+            await wait_for(client, "document.readyState === 'complete'", timeout=5.0)
+            context_id = await resolve_accessor_context(client)
+        if context_id is None:
+            raise CDPError(
+                "Extension accessor not found. Ensure the extension is enabled for hr.job5156.com."
+            )
+
+        status = await wait_for(
+            client,
+            "window.__TR_RESUME_DATA__ ? window.__TR_RESUME_DATA__.status() : null",
+            timeout=15.0,
+            context_id=context_id,
+        )
+        if not status:
+            raise CDPError("Extension did not report status in time.")
+
+        if not status.get("loggedIn", False):
+            print("Not logged in. Please log in manually and re-run.")
+            print(f"Open: {search_url}")
+            return 1
+
+        await wait_for(
+            client,
+            "window.__TR_RESUME_DATA__ && window.__TR_RESUME_DATA__.isReady()",
+            timeout=30.0,
+            context_id=context_id,
+        )
+
+        await asyncio.sleep(1.0)
+
+        resumes = await eval_json(
+            client,
+            "window.__TR_RESUME_DATA__ ? window.__TR_RESUME_DATA__.extract() : null",
+            context_id=context_id,
+        )
+
+        if not isinstance(resumes, list):
+            raise CDPError("Failed to extract resume data from the page.")
+
+        status = await eval_json(
+            client,
+            "window.__TR_RESUME_DATA__ ? window.__TR_RESUME_DATA__.status() : null",
+            context_id=context_id,
+        ) or status
+
+        page_url = await eval_json(client, "window.location.href", context_id=context_id)
+        if not page_url:
+            page_url = search_url
+
+        metadata = build_metadata(page_url, sample_name, status, resumes)
+        payload = {"metadata": metadata, "data": resumes}
+
+        OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+        output_path = OUTPUT_DIR / f"{sample_name}.json"
+        output_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        print(f"Saved {len(resumes)} resumes to {output_path}")
+        return 0
+
+
+def main():
+    try:
+        code = asyncio.run(run())
+    except CDPError as exc:
+        print(f"Error: {exc}")
+        print("Hint: Start Chrome with --remote-debugging-port=9222")
+        return 1
+    except KeyboardInterrupt:
+        print("Aborted.")
+        return 1
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/refresh-sample.sh
+++ b/scripts/refresh-sample.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KEYWORD="${KEYWORD:-销售}"
+SAMPLE="${SAMPLE:-sample-initial}"
+CDP_PORT="${CDP_PORT:-9222}"
+
+if ! curl -fsS "http://127.0.0.1:${CDP_PORT}/json" >/dev/null 2>&1; then
+  echo "Error: Chrome not running with remote debugging on port ${CDP_PORT}."
+  echo "Start Chrome with: --remote-debugging-port=${CDP_PORT}"
+  echo "Or run: ./apps/browser-extension/scripts/cmux-setup-profile.sh"
+  exit 1
+fi
+
+exec uv run python scripts/refresh-sample.py \
+  --keyword "${KEYWORD}" \
+  --sample "${SAMPLE}" \
+  --port "${CDP_PORT}"

--- a/scripts/refresh-sample.sh
+++ b/scripts/refresh-sample.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 KEYWORD="${KEYWORD:-销售}"
 SAMPLE="${SAMPLE:-sample-initial}"
 CDP_PORT="${CDP_PORT:-9222}"
+ALLOW_EMPTY="${ALLOW_EMPTY:-}"
 
 if ! curl -fsS "http://127.0.0.1:${CDP_PORT}/json" >/dev/null 2>&1; then
   echo "Error: Chrome not running with remote debugging on port ${CDP_PORT}."
@@ -15,4 +16,5 @@ fi
 exec uv run python scripts/refresh-sample.py \
   --keyword "${KEYWORD}" \
   --sample "${SAMPLE}" \
-  --port "${CDP_PORT}"
+  --port "${CDP_PORT}" \
+  ${ALLOW_EMPTY:+--allow-empty}


### PR DESCRIPTION
## Summary\n- expose a CDP-friendly accessor in the resume content script\n- add a CDP-based sample refresh script + wrapper\n- wire Makefile/docs for automated and manual sample refresh\n\n## Testing\n- ./apps/browser-extension/scripts/cmux-setup-profile.sh\n- make refresh-sample\n- make test