### PR TITLE
Fix Chinese and Unicode delimiter parsing for text inputs

### DIFF
--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -3,7 +3,7 @@ import { z } from "@hono/zod-openapi";
 const CsvStringArraySchema = z.preprocess((value) => {
   if (typeof value !== "string") return value;
   const parts = value
-    .split(",")
+    .split(/[,，、]/g)
     .map((part) => part.trim())
     .filter(Boolean);
   return parts.length > 0 ? parts : undefined;

--- a/apps/api/src/services/__tests__/unicode-delimiter.test.ts
+++ b/apps/api/src/services/__tests__/unicode-delimiter.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { ResumesQuerySchema } from "../../schemas/resumes";
+
+describe("ResumesQuerySchema Unicode delimiter parsing", () => {
+  const cases = [
+    {
+      label: "ASCII comma",
+      input: "东莞,深圳",
+      expected: ["东莞", "深圳"],
+    },
+    {
+      label: "Full-width comma",
+      input: "东莞，深圳",
+      expected: ["东莞", "深圳"],
+    },
+    {
+      label: "Enumeration comma",
+      input: "东莞、深圳",
+      expected: ["东莞", "深圳"],
+    },
+    {
+      label: "Mixed delimiters",
+      input: "东莞,深圳，广州、佛山",
+      expected: ["东莞", "深圳", "广州", "佛山"],
+    },
+  ];
+
+  it.each(cases)("parses $label", ({ input, expected }) => {
+    const parsed = ResumesQuerySchema.parse({ locations: input });
+    expect(parsed.locations).toEqual(expected);
+  });
+});

--- a/apps/web/src/components/FilterPanel.tsx
+++ b/apps/web/src/components/FilterPanel.tsx
@@ -57,13 +57,13 @@ export function FilterPanel({ filters, onChange, mode }: FilterPanelProps) {
       minMatchScore: mode === 'ai' && minMatchScore ? Number(minMatchScore) : undefined,
       skills: skills
         ? skills
-            .split(',')
+            .split(/[,，、]/g)
             .map((item) => item.trim())
             .filter(Boolean)
         : undefined,
       locations: locations
         ? locations
-            .split(',')
+            .split(/[,，、]/g)
             .map((item) => item.trim())
             .filter(Boolean)
         : undefined,


### PR DESCRIPTION
## Task

# Unicode/Chinese Text Handling Deep Study - Phase 1 Pre-check

## Summary

Before moving to Phase 2 of the Resume Screening System, this plan addresses Unicode/Chinese text (zh-Hans) handling across the codebase to ensure robust parsing of Chinese inputs and outputs.

**Finding: The codebase is generally well-designed for Unicode handling.** Only minor enhancements are needed.

---

## Critical Files to Modify

### Priority 1: Fix Full-Width Comma Handling

**Issue**: CSV parsing uses ASCII comma only, but Chinese input may use full-width comma `，` (U+FF0C).

| File | Line | Current | Fix |
|------|------|---------|-----|
| `apps/api/src/schemas/resumes.ts` | 6 | `.split(",")` | `.split(/[,，、]/g)` |
| `apps/web/src/components/FilterPanel.tsx` | 60, 66 | `.split(',')` | `.split(/[,，、]/g)` |

### Priority 2: Add Unicode Normalization (Optional Enhancement)

**Issue**: Different Unicode representations of same character (NFC vs NFD) could cause matching failures.

| File | Change |
|------|--------|
| `apps/api/src/services/resume-service.ts` | Add `.normalize('NFC')` to search queries |
| `apps/api/src/services/industry-data-service.ts` | Add `.normalize('NFC')` to company/keyword matching |

### Priority 3: Regex Whitespace Patterns

**Issue**: `\s` doesn't match all Unicode whitespace (e.g., `\u3000` ideographic space).

| File | Line | Current | Fix |
|------|------|---------|-----|
| `apps/api/src/services/industry-data-service.ts` | 96, 608 | `/^(#{2,6})\s+(.*)$/` | `/^(#{2,6})[\s\u3000]+(.*)$/` |

---

## Implementation Plan

### Step 1: Create Unicode Utility Module

**File**: `apps/api/src/utils/unicode.ts` (NEW)

```typescript
/**
 * Normalize text for consistent comparison
 * - NFC normalization (precomposed form)
 * - Handles full-width/half-width variants
 */
export function normalizeText(text: string): string {
  return text.normalize('NFC');
}

/**
 * Split by both ASCII and Chinese delimiters
 * Handles: , (comma), ， (full-width comma), 、 (enumeration comma)
 */
export function splitByDelimiter(text: string): string[] {
  return text
    .split(/[,，、]/g)
    .map(s => s.trim())
    .filter(Boolean);
}

/**
 * Unicode-aware whitespace pattern
 * Matches: space, tab, ideographic space (U+3000)
 */
export const UNICODE_WHITESPACE = /[\s\u3000]+/;
```

### Step 2: Update CSV Schema (`apps/api/src/schemas/resumes.ts`)

**Line 3-10**:

```typescript
const CsvStringArraySchema = z.preprocess((value) => {
  if (typeof value !== "string") return value;
  const parts = value
    .split(/[,，、]/g)  // Support Chinese delimiters
    .map((part) => part.trim())
    .filter(Boolean);
  return parts.length > 0 ? parts : undefined;
}, z.array(z.string()).optional());
```

### Step 3: Update FilterPanel (`apps/web/src/components/FilterPanel.tsx`)

**Lines 58-68**:

```typescript
skills: skills
  ? skills
      .split(/[,，、]/g)  // Support Chinese delimiters
      .map((item) => item.trim())
      .filter(Boolean)
  : undefined,
locations: locations
  ? locations
      .split(/[,，、]/g)  // Support Chinese delimiters
      .map((item) => item.trim())
      .filter(Boolean)
  : undefined,
```

### Step 4: Update Industry Data Service (`apps/api/src/services/industry-data-service.ts`)

**Lines 96, 608** - heading regex:

```typescript
const headingMatch = line.match(/^(#{2,6})[\s\u3000]+(.*)$/);
```

### Step 5: Add Tests for Unicode Edge Cases

**File**: `apps/api/src/services/__tests__/unicode.test.ts` (NEW)

Test cases:

- Full-width comma input: `"东莞，深圳，广州"`
- Mixed delimiters: `"东莞,深圳，广州、佛山"`
- Ideographic space in markdown: `## 　公司列表` (with U+3000)
- NFD vs NFC normalized strings
- Chinese company name matching with whitespace variants

---

## Findings Summary

### Already Handled Correctly ✅

| Area | Implementation | Location |
|------|----------------|----------|
| **File I/O (Python)** | All use `encoding="utf-8"` | 15+ locations |
| **JSON Encoding (Python)** | All use `ensure_ascii=False` | 15+ locations |
| **SQLite Storage** | UTF-8 by default, parameterized queries | `database.ts`, `sqlite_mixin.py` |
| **HTTP Requests** | URLSearchParams handles encoding | `apps/web/src/lib/api.ts` |
| **i18n System** | Proper locale loading with fallback | `apps/web/src/i18n/index.ts` |
| **AI Prompts** | Chinese prompts stored correctly | `ai-matching.ts:53-89` |
| **Regex with Chinese** | CJK range `\u4e00-\u9fff` | `data-service.ts:401` |
| **String Comparison** | Uses `.localeCompare()` | Multiple locations |
| **CSS Truncation** | Uses `line-clamp` (not character count) | `ResumeCard.tsx` |
| **Chinese Keyword Parsing** | Regex handles `应届`, `面议`, etc. | `resume-service.ts:229-270` |
| **Education Mapping** | Handles `本科`, `大专`, `硕士`, etc. | `resume-service.ts:241-251` |

### Minor Issues Found ⚠️

| Issue | Severity | Location | Status |
|-------|----------|----------|--------|
| CSV uses ASCII comma only | Medium | `resumes.ts:6`, `FilterPanel.tsx:60,66` | **Fix in this plan** |
| Unicode whitespace in regex | Low | `industry-data-service.ts:96,608` | **Fix in this plan** |
| HTML lang hardcoded | Low | `apps/web/index.html:2` | Optional |
| Inconsistent encoding strings | Low | `"utf-8"` vs `"utf8"` | Optional |

---

## Verification Plan

### Automated Testing

```bash
# Run new Unicode tests
npm run test --workspace @trends/api -- --grep unicode

# Run existing resume tests with Chinese data
npm run test --workspace @trends/api -- --grep resume
```

### Manual Testing

1. **Filter with Chinese delimiters**:

- Enter `东莞，深圳` (full-width comma) in locations filter
- Verify both cities are parsed correctly

2. **Search with Chinese keywords**:

- Search for `销售经理` in resume search
- Verify results match correctly

3. **API with URL-encoded Chinese**:

```bash
   curl "http://localhost:3000/api/resumes?q=%E9%94%80%E5%94%AE&locations=%E4%B8%9C%E8%8E%9E%EF%BC%8C%E6%B7%B1%E5%9C%B3"
```

4. **Industry data with Chinese**:

- Verify company lookup for `东源精密机械`
- Verify keyword matching for `CNC加工中心`

---

## Risk Assessment

| Risk | Likelihood | Impact | Mitigation |
|------|------------|--------|------------|
| Breaking existing tests | Low | Medium | Run full test suite after changes |
| Performance regression | Very Low | Low | Simple regex changes, minimal overhead |
| Backward compatibility | Low | Low | Changes only affect parsing, not storage |

---

## Files Changed

| File | Action | Lines |
|------|--------|-------|
| `apps/api/src/utils/unicode.ts` | CREATE | \~25 |
| `apps/api/src/schemas/resumes.ts` | MODIFY | 1 line |
| `apps/web/src/components/FilterPanel.tsx` | MODIFY | 2 lines |
| `apps/api/src/services/industry-data-service.ts` | MODIFY | 2 lines |
| `apps/api/src/services/__tests__/unicode.test.ts` | CREATE | \~50 |

**Total: 5 files, \~80 lines added/modified**

---

## Decision: Option A Selected

**Approach**: Implement Priority 1 fixes only (full-width comma handling)

- **3 files, 3 line changes**
- Addresses most common Chinese input edge case
- Minimal risk, maximum impact

---

## Final Implementation Steps

### 1. Update `apps/api/src/schemas/resumes.ts` (Line 6)

Change `.split(",")` to `.split(/[,，、]/g)` in CsvStringArraySchema

### 2. Update `apps/web/src/components/FilterPanel.tsx` (Lines 60, 66)

Change `.split(',')` to `.split(/[,，、]/g)` for skills and locations parsing

### 3. Add Unicode Test Cases

**File**: `apps/api/src/services/__tests__/unicode-delimiter.test.ts` (NEW)

Test the delimiter parsing with various Chinese comma variants:

- ASCII comma: `"东莞,深圳"`
- Full-width comma: `"东莞，深圳"`
- Enumeration comma: `"东莞、深圳"`
- Mixed: `"东莞,深圳，广州、佛山"`

### 4. Verify Changes

```bash
# Type check
make check-node

# Run all tests (includes new Unicode tests)
make test

# Manual API test with full-width comma
curl "http://localhost:3000/api/resumes?locations=%E4%B8%9C%E8%8E%9E%EF%BC%8C%E6%B7%B1%E5%9C%B3"
# (东莞，深圳 with full-width comma)
```

## PR Review Summary\n- What Changed: Enhanced Unicode/Chinese text handling by updating `ResumesQuerySchema` (API) and `FilterPanel` (Web) to support Chinese full-width commas (`，`) and enumeration commas (`、`) in addition to standard ASCII commas. A new unit test suite, `unicode-delimiter.test.ts`, was added to verify parsing of mixed delimiters.\n- Review Focus: Ensure the regex `/[ ,，、]/g` correctly handles all intended Chinese delimiters without interfering with other character inputs. Verify that frontend and backend parsing logic remains consistent.\n- Test Plan: 1. Run the new unit tests: `npm run test --workspace @trends/api`. 2. Manually test the FilterPanel by entering locations or skills separated by `，` and `、`. 3. Perform a `curl` request to the API with URL-encoded Chinese delimiters to confirm correct parsing into arrays.