### PR TITLE
[Crown] # Unicode/Chinese Text Handling - Extended Plan (Phase 1.1)

...

### DIFF
--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -74,6 +74,14 @@ export const ResumesQuerySchema = z.object({
   q: z
     .string()
     .optional()
+    .transform((value) => {
+      if (typeof value !== "string") return value;
+      const normalized = value
+        .replace(/[\u3000]/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+      return normalized || undefined;
+    })
     .openapi({
       param: { name: "q", in: "query" },
       example: "sales",

--- a/apps/api/src/services/__tests__/unicode-delimiter.test.ts
+++ b/apps/api/src/services/__tests__/unicode-delimiter.test.ts
@@ -31,3 +31,20 @@ describe("ResumesQuerySchema Unicode delimiter parsing", () => {
     expect(parsed.locations).toEqual(expected);
   });
 });
+
+describe("ResumesQuerySchema Unicode whitespace normalization", () => {
+  it("normalizes full-width space in q", () => {
+    const parsed = ResumesQuerySchema.parse({ q: "车床　销售" });
+    expect(parsed.q).toBe("车床 销售");
+  });
+
+  it("collapses multiple spaces in q", () => {
+    const parsed = ResumesQuerySchema.parse({ q: "车床   销售" });
+    expect(parsed.q).toBe("车床 销售");
+  });
+
+  it("treats whitespace-only q as undefined", () => {
+    const parsed = ResumesQuerySchema.parse({ q: "　　" });
+    expect(parsed.q).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Task

# Unicode/Chinese Text Handling - Extended Plan (Phase 1.1)

## Summary

Extends the previous Unicode handling plan (`snoopy-booping-island.md`) with:

1. **Location selector improvement** - Add specific CSS selector for location element
2. **Keyword space normalization** - Handle full-width space (`\u3000`) in search keywords
3. **Search engine practices** - Document multi-keyword search format

---

## Background

### Platform Search Engine Behavior

From the platform's manual:

> "请输入关键词，多个词用空格隔开，如：五金 销售"

**Input formats users may enter:**

- Half-width space: `车床 销售` (ASCII space U+0020)
- Full-width space: `车床　销售` (Ideographic space U+3000)

**Expected standardized URL format:**

```
?keyword=车床+销售
```

The `+` in URL query strings is standard URL encoding for space character.

---

## Critical Files to Modify

### 1. Location Selector Enhancement

**File:** `apps/browser-extension/content.js`

**Issue:** Current location extraction uses generic `.basic-line__text` selector. User reports specific class: `text-truncate text-center resume-search-item-search-addre__span`

**Current (lines 12-13):**

```javascript
basicInfoRow: '.basic-line',
basicInfoItem: '.basic-line__text',
```

**Proposed addition (line 14):**

```javascript
locationItem: '.resume-search-item-search-addre__span, .text-truncate.text-center',
```

**Update extraction (lines 218-244):**

- Add fallback to specific location selector
- More robust location detection

### 2. Keyword Space Normalization

**File:** `apps/browser-extension/content.js`

**Issue:** No normalization of full-width space to half-width in keyword extraction/search.

**Locations to update:**

| Line | Function | Current | Fix |
|------|----------|---------|-----|
| 693 | `autoSearchFromUrl()` | `.trim()` | `.replace(/[\u3000]/g, ' ').trim()` |
| 70 | `buildExportMetadata()` | `.trim()` | `.replace(/[\u3000]/g, ' ').trim()` |
| 61-63 | `buildExportFilename()` | keyword used directly | normalize spaces |

**Helper function to add:**

```javascript
/**
 * Normalize keyword for consistent handling
 * - Full-width space (U+3000) → half-width space (U+0020)
 * - Multiple spaces → single space
 * - Trim leading/trailing
 */
function normalizeKeyword(keyword) {
  if (!keyword) return '';
  return keyword
    .replace(/[\u3000]/g, ' ')  // Full-width → half-width
    .replace(/\s+/g, ' ')       // Collapse multiple spaces
    .trim();
}
```

### 3. URL Parameter Standardization

**Recommendation:** When building URLs with keywords, use `encodeURIComponent()` which:

- Space → `%20` (or `+` via URLSearchParams)
- Chinese characters → `%XX%XX%XX` UTF-8 encoding

**Standard format:**

```
https://hr.job5156.com/search?keyword=车床+销售
```

Where `+` represents space (standard query string encoding).

---

## Implementation Plan

### Step 1: Add normalizeKeyword Helper

**File:** `apps/browser-extension/content.js` (after line 51)

```javascript
function normalizeKeyword(keyword) {
  if (!keyword) return '';
  return keyword
    .replace(/[\u3000]/g, ' ')
    .replace(/\s+/g, ' ')
    .trim();
}
```

### Step 2: Update Keyword Extraction Points

**Line 61-63 in buildExportFilename():**

```javascript
const rawKeyword = params.get(AUTO_SEARCH_PARAM) || '';
const keyword = sanitizeSampleName(normalizeKeyword(rawKeyword));
```

**Line 70 in buildExportMetadata():**

```javascript
const keyword = normalizeKeyword(url.searchParams.get(AUTO_SEARCH_PARAM) || '');
```

**Line 693 in autoSearchFromUrl():**

```javascript
const keyword = normalizeKeyword(params.get(AUTO_SEARCH_PARAM) || '');
```

### Step 3: Add Location Selector

**Line 14 in SELECTORS:**

```javascript
locationItem: '.resume-search-item-search-addre__span',
```

**Update location extraction (around line 234):**

```javascript
// Try specific location selector first
const locationEl = card.querySelector(SELECTORS.locationItem);
if (locationEl) {
  location = locationEl.textContent.trim();
} else if (basicInfo.length >= 4) {
  [age, experience, education, location] = basicInfo;
} else {
  // Existing fallback logic...
}
```

### Step 4: Update API Schema (if applicable)

**File:** `apps/api/src/schemas/resumes.ts`

Ensure search query handling normalizes spaces:

```typescript
// In search query preprocessing
const normalizedQuery = query?.replace(/[\u3000]/g, ' ').trim();
```

---

## Test Cases

### Manual Testing with Real Data

1. **Full-width space keyword search:**

```
   https://hr.job5156.com/search?keyword=车床　销售&tr_auto_export=json
```

   Expected: Both keywords searched, space normalized in export

2. **Half-width space keyword search:**

```
   https://hr.job5156.com/search?keyword=车床+销售&tr_auto_export=json
```

   Expected: Standard format works correctly

3. **Mixed spaces:**

```
   https://hr.job5156.com/search?keyword=车床　销售 工程师&tr_auto_export=json
```

   Expected: All spaces normalized to single half-width

4. **Location extraction verification:**

- Search for any keyword
- Export JSON
- Verify `location` field is populated from correct DOM element

### Automated Verification

```bash
# Navigate to search and trigger export
./apps/browser-extension/scripts/open-search.sh "https://hr.job5156.com/search?keyword=车床　销售&tr_auto_export=json"

# Check exported JSON for normalized keyword in metadata
cat ~/Downloads/sample-*.json | jq '.metadata.searchCriteria.keyword'
# Expected: "车床 销售" (single half-width space)
```

---

## Platform Search Tips (Reference)

From 智通直聘 manual:

1. **Multi-keyword search:** Use space to separate keywords

- Example: `五金 销售`
- Platform searches for resumes matching ANY keyword

2. **Position + Keyword combined search:**

- Select job position dropdown first
- Then add keywords
- Platform uses both position metadata and keywords for matching

3. **Advanced search filters:**

- 学历要求 (Education)
- 工作经验 (Experience)
- 年龄 (Age)
- 活跃时间 (Activity)
- 期望薪资 (Expected Salary)
- 居住地 (Location)

---

## Confirmed Decisions

1. **Location selector:** Use specific selector with fallback to existing logic for backwards compatibility
2. **URL display:** Normalize internally for export/matching only, keep original URL unchanged

---

## Files Changed Summary

| File | Action | Changes |
|------|--------|---------|
| `apps/browser-extension/content.js` | MODIFY | Add `normalizeKeyword()`, update 3 locations, add location selector with fallback |
| `apps/api/src/schemas/resumes.ts` | MODIFY | Add space normalization to query preprocessing (1 line) |
| `CLAUDE.md` | MODIFY | Add "Chinese Text Handling (zh-Hans)" section (\~65 lines) |

**Total: 3 files, \~80 lines added/modified**

---

## Step 5: Update Project Memory (CLAUDE.md)

Add a new section after "Code Conventions" to document Chinese text handling best practices.

**File:** `CLAUDE.md` (line \~579, after Code Conventions section)

**Add new section:**

```markdown
## Chinese Text Handling (zh-Hans)

The default audience is Chinese HR professionals. Follow these guidelines for robust Simplified Chinese input/output handling.

### Character Encoding

- **Python file I/O**: Always use `encoding="utf-8"` explicitly
- **JSON serialization**: Always use `ensure_ascii=False` to preserve Chinese characters
- **SQLite**: UTF-8 by default, use parameterized queries (never string concat)
- **HTTP URLs**: Use `encodeURIComponent()` / `URLSearchParams` for proper encoding

### Delimiter Handling

Chinese input may use different delimiter characters:

| Type | ASCII | Chinese | Regex Pattern |
|------|-------|---------|---------------|
| Comma | `,` (U+002C) | `，` (U+FF0C) | `/[,，、]/g` |
| Enumeration | N/A | `、` (U+3001) | Include in comma pattern |
| Space | ` ` (U+0020) | `　` (U+3000) | `/[\s\u3000]+/g` |

**Best practice**: When splitting user input by comma, always use `/[,，、]/g` to handle all variants.

### Keyword/Search Input

For multi-keyword search (e.g., `车床 销售`):

1. **Normalize spaces**: Convert full-width space (U+3000) to half-width (U+0020)
2. **Collapse multiple**: Multiple spaces → single space
3. **Trim**: Remove leading/trailing whitespace
4. **URL encoding**: Space becomes `+` or `%20` in query strings

```typescript
function normalizeKeyword(keyword: string): string {
  return keyword
    .replace(/[\u3000]/g, ' ')  // Full-width → half-width
    .replace(/\s+/g, ' ')       // Collapse
    .trim();
}
```

### Text Comparison

- Use `.localeCompare()` for sorting Chinese strings
- Apply `.normalize('NFC')` before comparison if handling user input from multiple sources
- Use case-insensitive matching for mixed Chinese/English text

### Common Chinese Patterns

Resume data often contains these patterns:

| Field | Pattern | Example |
|-------|---------|---------|
| Age | Contains `岁` | `28岁` |
| Experience | Contains `年` (not `元`) | `5年` |
| Salary | Contains `元` | `8000-12000元/月`, `面议` |
| Education | Matches `/(中专\|高中\|大专\|本科\|硕\|博\|研究生\|MBA\|EMBA)/` | `本科` |

### File Naming with Chinese

When using Chinese in filenames:

- Sanitize using: `.replace(/[\\/:*?"<>|]/g, '-')`
- Replace spaces with hyphens: `.replace(/\s+/g, '-')`
- Limit length: `.slice(0, 80)`

```
---

## Verification Checklist

- [ ] Full-width space in URL keyword → normalized in export metadata
- [ ] Half-width space in URL keyword → preserved correctly
- [ ] Location field populated from specific selector when available
- [ ] Fallback location extraction still works when specific selector absent
- [ ] Exported filename uses normalized keyword
- [ ] API search handles both space types identically
- [ ] CLAUDE.md updated with Chinese text handling section
```

## PR Review Summary

### What Changed
- **Unicode Normalization**: Added a `normalizeKeyword` helper to convert full-width spaces (`\u3000`) to standard ASCII spaces, collapse multiple spaces, and trim input. This is applied to search keywords, filenames, and metadata.
- **Enhanced Extraction**: Introduced a specific selector for location data (`.resume-search-item-search-addre__span`) in `content.js`, improving extraction accuracy over the previous positional fallback logic.
- **API Schema Updates**: Added a Zod transform to `ResumesQuerySchema` to ensure search queries are normalized on the server side.
- **Project Documentation**: Updated `CLAUDE.md` with a "Chinese Text Handling (zh-Hans)" section covering encoding, delimiters, and common regex patterns for resume data.
- **Test Coverage**: Added unit tests for whitespace normalization in the API service.

### Review Focus
- **Normalization Logic**: Check the regex implementation in `normalizeKeyword` to ensure it correctly handles mixed ASCII and Chinese characters.
- **Location Extraction Fallback**: Verify that `extractSingleResume` correctly prioritizes the new `locationItem` selector while safely falling back to the generic `basicInfo` array logic if the selector is missing.

### Test Plan
- **Manual URL Testing**: Navigate to a search URL containing ideographic spaces (e.g., `?keyword=车床　销售`) and verify the exported JSON filename and metadata use normalized half-width spaces.
- **Extraction Check**: Use the browser extension on `job5156.com` and verify the `location` field in the exported JSON is correctly populated.
- **API Tests**: Run `npm test` specifically for `unicode-delimiter.test.ts` to validate the schema transformation logic.