### PR TITLE
Add OpenCode Dev-Docs packages and update README with new sources

### DIFF
--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -13,6 +13,9 @@ make fetch-docs
 - `trendradar` → `dev-docs/trendradar/llms.txt` (news crawler, config, report modes, MCP reference)
 - `openclaw` → `dev-docs/openclaw/llms.txt` (Gateway control-plane architecture, Skills system, Plugin SDK)
 - `openclaw_docs` → `dev-docs/openclaw_docs/llms.txt` (official docs site: install/onboarding, gateway ops, config examples)
+- `opencode` → `dev-docs/opencode/llms.txt` (OpenCode core docs: CLI, configuration, SDK, agent architecture)
+- `opencode_ai` → `dev-docs/opencode_ai/llms.txt` (OpenCode AI docs site: config, workflows, integrations)
+- `oh_my_opencode` → `dev-docs/oh_my_opencode/llms.txt` (Oh My OpenCode plugins: community extensions and usage guides)
 
 ## OpenClaw references (why they matter here)
 
@@ -30,6 +33,15 @@ rg -n "## Skills System|## Plugin SDK" dev-docs/openclaw/llms.txt
 
 # Ops/setup snippets (install/onboarding/config examples)
 rg -n "onboard|gateway|\\$include|docker" dev-docs/openclaw_docs/llms.txt
+
+# OpenCode core CLI/config and SDK references
+rg -n "CLI|Configuration|SDK|OpenAPI" dev-docs/opencode/llms.txt
+
+# OpenCode AI docs workflows and setup
+rg -n "workflow|config|integration|provider" dev-docs/opencode_ai/llms.txt
+
+# Oh My OpenCode plugin catalog and usage
+rg -n "plugin|agent|tool|install" dev-docs/oh_my_opencode/llms.txt
 ```
 
 ## Add new packages

--- a/dev-docs/oh_my_opencode/llms.txt
+++ b/dev-docs/oh_my_opencode/llms.txt
@@ -1,0 +1,575 @@
+# Oh My OpenCode
+
+Oh My OpenCode is a batteries-included OpenCode plugin that transforms OpenCode into the best AI agent harness for software development. It provides multi-model orchestration, parallel background agents, crafted LSP/AST tools, and specialized AI agents that work together like a development team. The plugin integrates seamlessly with Claude, OpenAI, Google Gemini, and other providers, automatically configuring optimal models for different task types.
+
+The core philosophy centers around "Sisyphus" - the main orchestrator agent that leverages specialized subagents (Oracle for debugging, Librarian for documentation, Explore for codebase search) to complete complex tasks autonomously. With features like the "ultrawork" keyword, background task execution, and automatic context injection, Oh My OpenCode enables developers to describe tasks naturally and let the AI team handle implementation details, verification, and completion.
+
+---
+
+## Installation
+
+Interactive plugin setup with automatic configuration for available AI providers.
+
+```bash
+# Interactive installation (recommended)
+bunx oh-my-opencode install
+
+# Non-interactive installation with provider flags
+bunx oh-my-opencode install --no-tui \
+  --claude=yes \
+  --openai=yes \
+  --gemini=yes \
+  --copilot=no
+
+# Verify installation
+opencode --version  # Should be 1.0.150 or higher
+cat ~/.config/opencode/opencode.json  # Should contain "oh-my-opencode" in plugin array
+```
+
+---
+
+## Configuration
+
+Plugin configuration with model overrides and feature customization.
+
+```jsonc
+// ~/.config/opencode/oh-my-opencode.json or .opencode/oh-my-opencode.json
+{
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
+
+  // Override specific agent models
+  "agents": {
+    "oracle": { "model": "openai/gpt-5.2" },
+    "librarian": { "model": "zai-coding-plan/glm-4.7" },
+    "explore": { "model": "opencode/gpt-5-nano" },
+    "Sisyphus": {
+      "model": "anthropic/claude-opus-4-5",
+      "temperature": 0.3,
+      "thinking": { "type": "enabled", "budgetTokens": 200000 }
+    }
+  },
+
+  // Category-based model selection for delegate_task
+  "categories": {
+    "quick": { "model": "anthropic/claude-haiku-4-5" },
+    "visual-engineering": { "model": "google/gemini-3-pro" },
+    "ultrabrain": { "model": "openai/gpt-5.2-codex", "variant": "xhigh" }
+  },
+
+  // Background task concurrency limits
+  "background_task": {
+    "defaultConcurrency": 5,
+    "staleTimeoutMs": 180000,
+    "providerConcurrency": { "anthropic": 3, "openai": 5, "google": 10 }
+  },
+
+  // Tmux integration for visual multi-agent
+  "tmux": {
+    "enabled": true,
+    "layout": "main-vertical",
+    "main_pane_size": 60
+  },
+
+  // Disable specific features
+  "disabled_hooks": ["comment-checker", "auto-update-checker"],
+  "disabled_agents": ["multimodal-looker"],
+  "disabled_mcps": ["websearch"]
+}
+```
+
+---
+
+## Ultrawork Mode
+
+Automatic task execution with parallel agents and background exploration.
+
+Include `ultrawork` (or `ulw`) in your prompt to activate full automatic mode. The agent explores the codebase, researches best practices via specialized agents, implements following conventions, verifies with diagnostics, and keeps working until complete.
+
+```
+# Simple ultrawork prompt - agent figures out the rest
+ulw add authentication to my Next.js app
+
+# Ultrawork with specific requirements
+ultrawork refactor the payment module to use the repository pattern
+
+# Start an ultrawork loop for complex multi-step tasks
+/ulw-loop "Build a REST API with authentication and testing"
+```
+
+---
+
+## delegate_task Tool
+
+Spawn specialized agent tasks with category-based or direct agent selection.
+
+The `delegate_task` tool enables multi-agent orchestration by spawning Sisyphus-Junior agents with category-specific configurations or targeting specific agents directly. Supports background execution for parallel exploration.
+
+```typescript
+// Category-based task delegation (uses Sisyphus-Junior with category config)
+delegate_task({
+  category: "visual-engineering",
+  load_skills: ["frontend-ui-ux"],
+  description: "Create dashboard component",
+  prompt: "Build a responsive dashboard with charts using shadcn/ui and Tailwind",
+  run_in_background: false
+})
+// Returns: Full implementation result from visual-engineering agent
+
+// Direct agent targeting for specific expertise
+delegate_task({
+  subagent_type: "oracle",
+  load_skills: [],
+  description: "Architecture review",
+  prompt: "Review this authentication flow design and identify potential issues",
+  run_in_background: false
+})
+// Returns: Detailed analysis from Oracle agent (read-only, high reasoning)
+
+// Parallel background exploration (fire multiple queries)
+delegate_task({
+  category: "quick",
+  load_skills: [],
+  description: "Find auth implementations",
+  prompt: "Search for JWT authentication patterns in the codebase",
+  run_in_background: true  // Returns immediately with task_id
+})
+// Returns: { task_id: "bg_abc123", session_id: "..." }
+
+// Continue existing session (preserves full context)
+delegate_task({
+  session_id: "previous_session_id",
+  load_skills: ["git-master"],
+  description: "Fix commit issue",
+  prompt: "The previous commit failed due to lint errors. Fix and retry.",
+  run_in_background: false
+})
+```
+
+---
+
+## call_omo_agent Tool
+
+Spawn explore or librarian agents for codebase exploration and documentation lookup.
+
+```typescript
+// Fast codebase exploration with Explore agent
+call_omo_agent({
+  subagent_type: "explore",
+  description: "Find auth middleware",
+  prompt: "Search for authentication middleware implementations and how they're applied to routes",
+  run_in_background: false  // Wait for result
+})
+// Returns: Contextual grep results with code snippets and file paths
+
+// Documentation and OSS research with Librarian agent
+call_omo_agent({
+  subagent_type: "librarian",
+  description: "Research React patterns",
+  prompt: "Find official documentation and open source examples for implementing React Server Components with authentication",
+  run_in_background: true  // Returns task_id for later retrieval
+})
+// Returns: { task_id: "bg_xyz789", ... }
+
+// Retrieve background task results
+background_output({
+  task_id: "bg_xyz789",
+  block: false  // Check status immediately
+})
+// Returns: Full research results or status update
+```
+
+---
+
+## LSP Tools
+
+IDE-level code intelligence with Language Server Protocol integration.
+
+```typescript
+// Jump to symbol definition
+lsp_goto_definition({
+  filePath: "/src/auth/middleware.ts",
+  line: 42,      // 1-based line number
+  character: 15  // 0-based character offset
+})
+// Returns: /src/auth/types.ts:15:0 - export interface AuthConfig
+
+// Find all references across workspace
+lsp_find_references({
+  filePath: "/src/auth/middleware.ts",
+  line: 42,
+  character: 15,
+  includeDeclaration: true
+})
+// Returns: List of all locations where symbol is used
+// /src/auth/middleware.ts:42:15
+// /src/api/routes.ts:23:8
+// /src/tests/auth.test.ts:15:22
+
+// Get file outline or workspace symbol search
+lsp_symbols({
+  filePath: "/src/auth/middleware.ts",
+  scope: "document"  // "document" for file, "workspace" for project-wide
+})
+// Returns: Symbol hierarchy with types (function, class, interface, etc.)
+
+// Search symbols across entire workspace
+lsp_symbols({
+  filePath: "/src/index.ts",
+  scope: "workspace",
+  query: "Auth"
+})
+// Returns: All symbols matching "Auth" across the project
+
+// Get diagnostics before running build
+lsp_diagnostics({
+  filePath: "/src/auth/middleware.ts",
+  severity: "error"  // "error", "warning", "information", "hint", "all"
+})
+// Returns: Errors/warnings from language server
+
+// Validate rename operation before executing
+lsp_prepare_rename({
+  filePath: "/src/auth/middleware.ts",
+  line: 42,
+  character: 15
+})
+// Returns: { valid: true, placeholder: "AuthConfig", range: {...} }
+
+// Rename symbol across entire workspace
+lsp_rename({
+  filePath: "/src/auth/middleware.ts",
+  line: 42,
+  character: 15,
+  newName: "AuthenticationConfig"
+})
+// Returns: Applied changes summary with affected files
+```
+
+---
+
+## AST-Grep Tools
+
+AST-aware code pattern search and replacement across 25 languages.
+
+```typescript
+// Search for code patterns with meta-variables
+ast_grep_search({
+  pattern: "console.log($MSG)",  // $MSG matches any single node
+  lang: "typescript",
+  paths: ["./src"],
+  globs: ["!**/node_modules/**"]
+})
+// Returns: All console.log calls with matched content
+// src/utils/debug.ts:15:console.log("User logged in")
+// src/api/handler.ts:42:console.log(error.message)
+
+// Search for function patterns (include params and body)
+ast_grep_search({
+  pattern: "export async function $NAME($$$) { $$$ }",  // $$$ matches multiple nodes
+  lang: "typescript",
+  paths: ["./src/api"]
+})
+// Returns: All exported async functions with their signatures
+
+// Python class pattern search
+ast_grep_search({
+  pattern: "class $NAME($PARENT)",  // Note: no trailing colon for AST patterns
+  lang: "python",
+  paths: ["./src"]
+})
+
+// Replace pattern with AST-aware rewriting (dry-run by default)
+ast_grep_replace({
+  pattern: "console.log($MSG)",
+  rewrite: "logger.info($MSG)",  // Preserves $MSG from match
+  lang: "typescript",
+  paths: ["./src"],
+  dryRun: true  // Preview changes without applying
+})
+// Returns: Preview of all changes that would be made
+
+// Apply replacements (set dryRun: false)
+ast_grep_replace({
+  pattern: "console.log($MSG)",
+  rewrite: "logger.debug($MSG)",
+  lang: "typescript",
+  paths: ["./src"],
+  dryRun: false  // Actually apply changes
+})
+// Returns: Summary of applied changes with file counts
+```
+
+---
+
+## Background Task Management
+
+Manage parallel background agent tasks for complex multi-agent workflows.
+
+```typescript
+// Launch background task (via delegate_task or call_omo_agent)
+const task = delegate_task({
+  category: "quick",
+  load_skills: [],
+  description: "Parallel search",
+  prompt: "Find all API endpoints",
+  run_in_background: true
+})
+// Returns: { task_id: "bg_abc123", session_id: "sess_xyz", status: "running" }
+
+// Check task status (non-blocking)
+background_output({
+  task_id: "bg_abc123",
+  block: false
+})
+// Returns: Current status and any available output
+
+// Wait for task completion (blocking)
+background_output({
+  task_id: "bg_abc123",
+  block: true,
+  timeout: 60000  // Max wait time in ms
+})
+// Returns: Full task result when complete
+
+// Cancel running background task
+background_cancel({
+  task_id: "bg_abc123"
+})
+// Returns: Confirmation of cancellation
+```
+
+---
+
+## Interactive Terminal (Tmux)
+
+Tmux-based terminal for TUI applications and interactive CLI tools.
+
+```typescript
+// Create a new tmux session
+interactive_bash({
+  tmux_command: "new-session -d -s dev-app"
+})
+
+// Send keystrokes to a session
+interactive_bash({
+  tmux_command: "send-keys -t dev-app 'vim main.py' Enter"
+})
+
+// Capture pane output
+interactive_bash({
+  tmux_command: "capture-pane -p -t dev-app"
+})
+// Returns: Current terminal output from the session
+
+// Run interactive debugger
+interactive_bash({
+  tmux_command: "send-keys -t dev-app 'python -m pudb script.py' Enter"
+})
+
+// Kill session when done
+interactive_bash({
+  tmux_command: "kill-session -t dev-app"
+})
+```
+
+---
+
+## Slash Commands
+
+Built-in workflow commands for common development tasks.
+
+```bash
+# Initialize hierarchical AGENTS.md knowledge base
+/init-deep [--create-new] [--max-depth=3]
+
+# Start self-referential development loop
+/ralph-loop "Build a REST API with authentication"
+/ralph-loop "Refactor payment module" --max-iterations=50
+
+# Ultrawork loop (full automatic mode with parallel agents)
+/ulw-loop "Add user dashboard with charts and real-time updates"
+
+# Cancel active Ralph Loop
+/cancel-ralph
+
+# Intelligent refactoring with LSP and AST-grep
+/refactor <target> [--scope=file|module|project] [--strategy=safe|aggressive]
+
+# Start execution from Prometheus-generated plan
+/start-work [plan-name]
+
+# Stop all continuation mechanisms
+/stop-continuation
+```
+
+---
+
+## Skills System
+
+Specialized workflows with embedded MCP servers and detailed instructions.
+
+```bash
+# Browser automation with Playwright
+/playwright Navigate to example.com and take a screenshot
+/playwright Fill the login form and submit
+
+# Git operations with atomic commits
+/git-master commit these changes  # Auto-splits into atomic commits
+/git-master rebase onto main
+/git-master who wrote this authentication code?
+
+# Frontend UI/UX design
+/frontend-ui-ux Create a stunning dashboard with bold typography
+```
+
+```jsonc
+// Custom skill in oh-my-opencode.json
+{
+  "skills": {
+    "data-analyst": {
+      "description": "Specialized for data analysis tasks",
+      "template": "You are a data analyst. Focus on statistical analysis and visualization.",
+      "model": "openai/gpt-5.2",
+      "allowed-tools": ["read", "bash", "lsp_diagnostics"]
+    },
+    "sources": [
+      { "path": "./custom-skills", "recursive": true },
+      "https://example.com/skill.yaml"
+    ]
+  }
+}
+```
+
+---
+
+## CLI Commands
+
+Command-line interface for plugin management and diagnostics.
+
+```bash
+# Interactive setup wizard
+bunx oh-my-opencode install
+
+# Environment diagnostics (17+ health checks)
+bunx oh-my-opencode doctor
+bunx oh-my-opencode doctor --category authentication
+bunx oh-my-opencode doctor --verbose --json
+
+# Run session with completion enforcement
+bunx oh-my-opencode run "Build feature X" --enforce-completion --timeout 300
+
+# MCP OAuth management for remote servers
+bunx oh-my-opencode mcp oauth login my-api --server-url https://api.example.com
+bunx oh-my-opencode mcp oauth logout my-api
+bunx oh-my-opencode mcp oauth status
+
+# Google Antigravity authentication
+bunx oh-my-opencode auth login
+bunx oh-my-opencode auth logout
+bunx oh-my-opencode auth status
+
+# Display version
+bunx oh-my-opencode version
+```
+
+---
+
+## Hooks System
+
+Lifecycle automation hooks for context injection and quality control.
+
+```jsonc
+// Custom Claude Code hooks in ~/.claude/settings.json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [{ "type": "command", "command": "eslint --fix $FILE" }]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": ".*",
+        "hooks": [{ "type": "command", "command": "echo 'Prompt submitted'" }]
+      }
+    ]
+  }
+}
+```
+
+```jsonc
+// Disable specific hooks in oh-my-opencode.json
+{
+  "disabled_hooks": [
+    "comment-checker",      // Don't warn about excessive comments
+    "auto-update-checker",  // Don't check for updates
+    "session-notification", // Don't show OS notifications
+    "directory-agents-injector"  // Don't auto-inject AGENTS.md
+  ]
+}
+```
+
+---
+
+## Built-in MCPs
+
+Model Context Protocol servers for web search, documentation, and code search.
+
+```typescript
+// Web search via Exa AI (websearch MCP)
+// Automatically available to agents for real-time web queries
+
+// Official documentation lookup (context7 MCP)
+// Agents can fetch up-to-date docs for any library/framework
+
+// GitHub code search (grep_app MCP)
+// Ultra-fast search across millions of public repositories
+```
+
+```jsonc
+// Disable specific MCPs in oh-my-opencode.json
+{
+  "disabled_mcps": ["websearch", "context7", "grep_app"]
+}
+```
+
+---
+
+## Session Tools
+
+Session management for history analysis and cross-session continuity.
+
+```typescript
+// List all OpenCode sessions
+session_list()
+// Returns: Array of session metadata with IDs, titles, timestamps
+
+// Read messages from a specific session
+session_read({
+  session_id: "sess_abc123",
+  limit: 50
+})
+// Returns: Messages with roles, content, and metadata
+
+// Search across session messages
+session_search({
+  query: "authentication bug",
+  session_id: "sess_abc123"  // Optional: search specific session
+})
+// Returns: Matching messages with context
+
+// Get session metadata and statistics
+session_info({
+  session_id: "sess_abc123"
+})
+// Returns: Token usage, message counts, duration, agent info
+```
+
+---
+
+## Summary
+
+Oh My OpenCode transforms the OpenCode platform into a comprehensive AI development team by providing specialized agents for different task types (Sisyphus for orchestration, Oracle for debugging, Librarian for documentation, Explore for codebase search), powerful tooling (LSP integration, AST-grep, background tasks), and intelligent automation (ultrawork mode, hooks, context injection). The plugin handles model selection automatically based on available providers, enabling developers to focus on describing tasks rather than managing AI configuration.
+
+Key integration patterns include: using `ultrawork` or `ulw` keywords for fully automatic task completion, leveraging `delegate_task` with categories for domain-specific work (visual-engineering for UI, ultrabrain for complex logic), running parallel background agents for exploration while continuing main work, and using the Prometheus planner with `/start-work` for complex multi-step projects. The tmux integration enables visual multi-agent workflows where developers can watch multiple agents work simultaneously in separate terminal panes, making Oh My OpenCode ideal for complex software development tasks that benefit from multi-model orchestration and autonomous execution.

--- a/dev-docs/opencode/llms.txt
+++ b/dev-docs/opencode/llms.txt
@@ -1,0 +1,1174 @@
+# OpenCode
+
+OpenCode is an open-source AI coding agent that provides a powerful terminal-based interface, desktop application, and IDE extensions for AI-assisted software development. It operates on a client/server architecture where the TUI (Terminal User Interface) acts as a client communicating with a backend server that exposes an OpenAPI endpoint. This enables programmatic control of OpenCode through its SDK, allowing integrations with mobile apps, web interfaces, and custom automation tools.
+
+The core functionality includes two primary agents (Build for full development work, Plan for read-only analysis), comprehensive file operations (read, write, edit, grep, glob), shell command execution, and extensive configurability through JSON/JSONC config files. OpenCode supports multiple LLM providers (Anthropic, OpenAI, Google, local models), MCP (Model Context Protocol) servers for external tool integration, custom plugins for extending functionality, and LSP (Language Server Protocol) integration for code intelligence features.
+
+---
+
+## Installation
+
+Install OpenCode via the install script or package managers.
+
+```bash
+# Install script (recommended)
+curl -fsSL https://opencode.ai/install | bash
+
+# Package managers
+npm i -g opencode-ai@latest
+brew install anomalyco/tap/opencode  # macOS/Linux
+scoop install opencode               # Windows
+paru -S opencode-bin                 # Arch Linux
+
+# Docker
+docker run -it --rm ghcr.io/anomalyco/opencode
+```
+
+---
+
+## CLI Commands
+
+### Run OpenCode TUI
+
+Start the interactive terminal user interface.
+
+```bash
+# Basic usage - starts TUI in current directory
+opencode
+
+# Continue last session
+opencode --continue
+
+# Specify project directory and model
+opencode /path/to/project --model anthropic/claude-sonnet-4-5
+
+# Continue specific session with custom port
+opencode --session abc123 --port 4096
+```
+
+### Run Non-Interactive Commands
+
+Execute prompts without launching the TUI.
+
+```bash
+# Simple prompt execution
+opencode run "Explain how closures work in JavaScript"
+
+# Continue previous session with specific model
+opencode run --continue --model anthropic/claude-sonnet-4-5 "Add error handling to this function"
+
+# Attach files to the prompt
+opencode run --file ./src/index.ts "Review this code for security issues"
+
+# Execute a slash command
+opencode run --command test "Run all unit tests"
+
+# JSON output format for scripting
+opencode run --format json "List all exported functions in src/"
+
+# Attach to running server to avoid cold boot
+opencode run --attach http://localhost:4096 "Generate a README for this project"
+```
+
+### Start Headless Server
+
+Run OpenCode as an HTTP API server without TUI.
+
+```bash
+# Basic server on default port 4096
+opencode serve
+
+# Custom port and hostname with mDNS discovery
+opencode serve --port 8080 --hostname 0.0.0.0 --mdns
+
+# Enable CORS for specific origins
+opencode serve --cors http://localhost:5173 --cors https://app.example.com
+
+# With basic auth protection
+OPENCODE_SERVER_PASSWORD=your-secret opencode serve
+
+# Start with web interface
+opencode web --port 4096
+
+# Attach TUI to remote server
+opencode attach http://10.20.30.40:4096
+```
+
+### Session Management
+
+Manage and export conversation sessions.
+
+```bash
+# List all sessions
+opencode session list
+
+# List with format options
+opencode session list --max-count 10 --format json
+
+# Export session data as JSON
+opencode export abc123
+
+# Import from file or share URL
+opencode import session.json
+opencode import https://opncd.ai/s/abc123
+
+# View usage statistics
+opencode stats --days 30 --models 5
+```
+
+### Authentication and Provider Management
+
+Configure API keys and providers.
+
+```bash
+# Interactive login to add provider credentials
+opencode auth login
+
+# List authenticated providers
+opencode auth list
+
+# Logout from a provider
+opencode auth logout
+
+# List available models from all providers
+opencode models
+
+# List models for specific provider
+opencode models anthropic --verbose
+
+# Refresh models cache
+opencode models --refresh
+```
+
+### MCP Server Management
+
+Configure and manage Model Context Protocol servers.
+
+```bash
+# Add an MCP server interactively
+opencode mcp add
+
+# List configured MCP servers
+opencode mcp list
+
+# Authenticate with OAuth-enabled server
+opencode mcp auth sentry
+
+# List OAuth authentication status
+opencode mcp auth list
+
+# Remove OAuth credentials
+opencode mcp logout my-server
+
+# Debug connection issues
+opencode mcp debug my-server
+```
+
+### Agent Management
+
+Create and list custom agents.
+
+```bash
+# Create new agent interactively
+opencode agent create
+
+# List all available agents
+opencode agent list
+```
+
+---
+
+## SDK Client API
+
+### Create SDK Client
+
+Initialize the OpenCode SDK for programmatic access.
+
+```typescript
+import { createOpencode, createOpencodeClient } from "@opencode-ai/sdk"
+
+// Start both server and client
+const { client, server } = await createOpencode({
+  hostname: "127.0.0.1",
+  port: 4096,
+  timeout: 5000,
+  config: {
+    model: "anthropic/claude-sonnet-4-5",
+  },
+})
+
+console.log(`Server running at ${server.url}`)
+
+// Or connect to existing server
+const clientOnly = createOpencodeClient({
+  baseUrl: "http://localhost:4096",
+  throwOnError: true,
+})
+
+// Clean shutdown
+server.close()
+```
+
+### Session Management API
+
+Create, manage, and interact with conversation sessions.
+
+```typescript
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import type { Session, Message, Part } from "@opencode-ai/sdk"
+
+const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
+
+// Create a new session
+const session = await client.session.create({
+  body: { title: "Feature implementation" },
+})
+console.log(`Created session: ${session.data.id}`)
+
+// List all sessions
+const sessions = await client.session.list()
+sessions.data.forEach((s: Session) => console.log(`- ${s.id}: ${s.title}`))
+
+// Get session details
+const details = await client.session.get({
+  path: { id: session.data.id },
+})
+
+// Send a prompt and get AI response
+const response = await client.session.prompt({
+  path: { id: session.data.id },
+  body: {
+    model: { providerID: "anthropic", modelID: "claude-sonnet-4-5" },
+    parts: [{ type: "text", text: "Explain the architecture of this project" }],
+  },
+})
+console.log("AI Response:", response.data.parts)
+
+// Inject context without triggering AI response (for plugins)
+await client.session.prompt({
+  path: { id: session.data.id },
+  body: {
+    noReply: true,
+    parts: [{ type: "text", text: "Remember: Use TypeScript for all new files." }],
+  },
+})
+
+// Get all messages in session
+const messages = await client.session.messages({ path: { id: session.data.id } })
+
+// Abort running session
+await client.session.abort({ path: { id: session.data.id } })
+
+// Share/unshare session
+await client.session.share({ path: { id: session.data.id } })
+await client.session.unshare({ path: { id: session.data.id } })
+
+// Revert to previous state
+await client.session.revert({
+  path: { id: session.data.id },
+  body: { messageID: "msg_123" },
+})
+
+// Delete session
+await client.session.delete({ path: { id: session.data.id } })
+```
+
+### File Operations API
+
+Search, read, and manage files through the SDK.
+
+```typescript
+const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
+
+// Search file contents with regex
+const textResults = await client.find.text({
+  query: { pattern: "function.*async" },
+})
+textResults.data.forEach((match) => {
+  console.log(`${match.path}:${match.line_number}: ${match.lines}`)
+})
+
+// Find files by name pattern
+const tsFiles = await client.find.files({
+  query: { query: "*.ts", type: "file", limit: 50 },
+})
+console.log("TypeScript files:", tsFiles.data)
+
+// Find directories
+const srcDirs = await client.find.files({
+  query: { query: "src", type: "directory" },
+})
+
+// Find workspace symbols
+const symbols = await client.find.symbols({
+  query: { query: "handleRequest" },
+})
+
+// Read file contents
+const content = await client.file.read({
+  query: { path: "src/index.ts" },
+})
+console.log(content.data.content)
+
+// Get file status (git tracking)
+const status = await client.file.status()
+status.data.forEach((file) => console.log(`${file.status}: ${file.path}`))
+```
+
+### Events API
+
+Subscribe to real-time server events.
+
+```typescript
+const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
+
+// Subscribe to event stream
+const events = await client.event.subscribe()
+
+for await (const event of events.stream) {
+  switch (event.type) {
+    case "session.idle":
+      console.log("Session completed")
+      break
+    case "message.updated":
+      console.log("New message:", event.properties)
+      break
+    case "file.edited":
+      console.log("File changed:", event.properties.path)
+      break
+    case "permission.asked":
+      console.log("Permission requested:", event.properties)
+      break
+    default:
+      console.log("Event:", event.type)
+  }
+}
+```
+
+### TUI Control API
+
+Control the terminal UI programmatically.
+
+```typescript
+const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
+
+// Append text to prompt input
+await client.tui.appendPrompt({
+  body: { text: "Review this code for security issues" },
+})
+
+// Submit the current prompt
+await client.tui.submitPrompt()
+
+// Clear prompt input
+await client.tui.clearPrompt()
+
+// Show toast notification
+await client.tui.showToast({
+  body: {
+    title: "Build Complete",
+    message: "All tests passed successfully",
+    variant: "success", // "success" | "error" | "warning" | "info"
+  },
+})
+
+// Execute slash command
+await client.tui.executeCommand({
+  body: { command: "/share" },
+})
+
+// Open UI dialogs
+await client.tui.openHelp()
+await client.tui.openSessions()
+await client.tui.openThemes()
+await client.tui.openModels()
+```
+
+### Provider and Config API
+
+Manage providers and configuration.
+
+```typescript
+const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
+
+// Get current config
+const config = await client.config.get()
+console.log("Current model:", config.data.model)
+
+// List all providers
+const providers = await client.config.providers()
+providers.data.providers.forEach((p) => {
+  console.log(`${p.id}: ${p.name}`)
+})
+
+// Set provider credentials
+await client.auth.set({
+  path: { id: "anthropic" },
+  body: { type: "api", key: process.env.ANTHROPIC_API_KEY },
+})
+
+// Check server health
+const health = await client.global.health()
+console.log(`Server v${health.data.version}, healthy: ${health.data.healthy}`)
+
+// Get project info
+const project = await client.project.current()
+console.log(`Project: ${project.data.name} at ${project.data.path}`)
+
+// List available agents
+const agents = await client.app.agents()
+agents.data.forEach((agent) => console.log(`- ${agent.name}: ${agent.description}`))
+```
+
+---
+
+## HTTP Server API
+
+### Health and Global Endpoints
+
+Check server status and subscribe to events.
+
+```bash
+# Health check
+curl http://localhost:4096/global/health
+# Response: {"healthy":true,"version":"1.1.53"}
+
+# Server-sent events stream
+curl -N http://localhost:4096/event
+# Streams: {"type":"server.connected"}, {"type":"session.updated",...}
+
+# OpenAPI spec
+curl http://localhost:4096/doc
+```
+
+### Session HTTP Endpoints
+
+Manage sessions via REST API.
+
+```bash
+# List all sessions
+curl http://localhost:4096/session
+
+# Create new session
+curl -X POST http://localhost:4096/session \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Code Review Session"}'
+
+# Get session details
+curl http://localhost:4096/session/abc123
+
+# Update session title
+curl -X PATCH http://localhost:4096/session/abc123 \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Updated Title"}'
+
+# Get session messages
+curl "http://localhost:4096/session/abc123/message?limit=50"
+
+# Send prompt (synchronous - waits for response)
+curl -X POST http://localhost:4096/session/abc123/message \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": {"providerID":"anthropic","modelID":"claude-sonnet-4-5"},
+    "parts": [{"type":"text","text":"Explain this codebase"}]
+  }'
+
+# Send prompt (async - returns immediately)
+curl -X POST http://localhost:4096/session/abc123/prompt_async \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": {"providerID":"anthropic","modelID":"claude-sonnet-4-5"},
+    "parts": [{"type":"text","text":"Refactor auth module"}]
+  }'
+
+# Execute slash command
+curl -X POST http://localhost:4096/session/abc123/command \
+  -H "Content-Type: application/json" \
+  -d '{"command":"init","arguments":""}'
+
+# Fork session at specific message
+curl -X POST http://localhost:4096/session/abc123/fork \
+  -H "Content-Type: application/json" \
+  -d '{"messageID":"msg_456"}'
+
+# Share session
+curl -X POST http://localhost:4096/session/abc123/share
+
+# Abort running session
+curl -X POST http://localhost:4096/session/abc123/abort
+
+# Delete session
+curl -X DELETE http://localhost:4096/session/abc123
+
+# Respond to permission request
+curl -X POST http://localhost:4096/session/abc123/permissions/perm_789 \
+  -H "Content-Type: application/json" \
+  -d '{"response":"allow","remember":true}'
+```
+
+### File Search HTTP Endpoints
+
+Search and read files via REST API.
+
+```bash
+# Search file contents (regex)
+curl "http://localhost:4096/find?pattern=async%20function"
+
+# Find files by name
+curl "http://localhost:4096/find/file?query=*.ts&type=file&limit=100"
+
+# Find directories
+curl "http://localhost:4096/find/file?query=src&type=directory"
+
+# Find workspace symbols
+curl "http://localhost:4096/find/symbol?query=handleRequest"
+
+# Read file contents
+curl "http://localhost:4096/file/content?path=src/index.ts"
+
+# List files in directory
+curl "http://localhost:4096/file?path=src/"
+
+# Get file status
+curl http://localhost:4096/file/status
+```
+
+### TUI Control HTTP Endpoints
+
+Control the TUI remotely.
+
+```bash
+# Append to prompt
+curl -X POST http://localhost:4096/tui/append-prompt \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Review this code"}'
+
+# Submit prompt
+curl -X POST http://localhost:4096/tui/submit-prompt
+
+# Clear prompt
+curl -X POST http://localhost:4096/tui/clear-prompt
+
+# Show toast notification
+curl -X POST http://localhost:4096/tui/show-toast \
+  -H "Content-Type: application/json" \
+  -d '{"message":"Build complete","variant":"success"}'
+
+# Open UI dialogs
+curl -X POST http://localhost:4096/tui/open-help
+curl -X POST http://localhost:4096/tui/open-sessions
+curl -X POST http://localhost:4096/tui/open-models
+```
+
+---
+
+## Configuration
+
+### Basic Configuration File
+
+Configure OpenCode behavior via JSON config.
+
+```jsonc
+// opencode.json or opencode.jsonc (supports comments)
+{
+  "$schema": "https://opencode.ai/config.json",
+
+  // Model configuration
+  "model": "anthropic/claude-sonnet-4-5",
+  "small_model": "anthropic/claude-haiku-4-5",
+
+  // Theme and UI
+  "theme": "opencode",
+  "autoupdate": true,
+
+  // TUI settings
+  "tui": {
+    "scroll_speed": 3,
+    "scroll_acceleration": { "enabled": true },
+    "diff_style": "auto"
+  },
+
+  // Server settings
+  "server": {
+    "port": 4096,
+    "hostname": "127.0.0.1",
+    "mdns": false,
+    "cors": ["http://localhost:5173"]
+  },
+
+  // Tool permissions
+  "permission": {
+    "edit": "allow",
+    "bash": "ask",
+    "webfetch": "allow"
+  },
+
+  // Sharing mode
+  "share": "manual", // "manual" | "auto" | "disabled"
+
+  // Context compaction
+  "compaction": {
+    "auto": true,
+    "prune": true
+  },
+
+  // Instructions files (AGENTS.md, etc.)
+  "instructions": ["AGENTS.md", "docs/guidelines.md", ".cursor/rules/*.md"]
+}
+```
+
+### Provider Configuration
+
+Configure LLM providers with custom options.
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+
+  // Default model
+  "model": "anthropic/claude-sonnet-4-5",
+
+  // Provider-specific settings
+  "provider": {
+    "anthropic": {
+      "options": {
+        "timeout": 600000,
+        "apiKey": "{env:ANTHROPIC_API_KEY}"
+      }
+    },
+    "amazon-bedrock": {
+      "options": {
+        "region": "us-east-1",
+        "profile": "my-aws-profile",
+        "endpoint": "https://bedrock-runtime.us-east-1.vpce.amazonaws.com"
+      }
+    },
+    "openai": {
+      "options": {
+        "apiKey": "{file:~/.secrets/openai-key}"
+      }
+    }
+  },
+
+  // Provider filtering
+  "enabled_providers": ["anthropic", "openai"],
+  "disabled_providers": ["gemini"]
+}
+```
+
+### Agent Configuration
+
+Define custom agents for specialized tasks.
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+
+  // Default agent
+  "default_agent": "build",
+
+  "agent": {
+    // Override built-in agent
+    "build": {
+      "mode": "primary",
+      "model": "anthropic/claude-sonnet-4-5",
+      "prompt": "{file:./prompts/build.txt}",
+      "temperature": 0.3,
+      "tools": {
+        "write": true,
+        "edit": true,
+        "bash": true
+      }
+    },
+
+    // Read-only plan agent
+    "plan": {
+      "mode": "primary",
+      "model": "anthropic/claude-haiku-4-5",
+      "temperature": 0.1,
+      "permission": {
+        "edit": "deny",
+        "bash": "ask"
+      }
+    },
+
+    // Custom code review agent
+    "code-reviewer": {
+      "description": "Reviews code for best practices and security",
+      "mode": "subagent",
+      "model": "anthropic/claude-sonnet-4-5",
+      "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
+      "tools": {
+        "write": false,
+        "edit": false
+      },
+      "permission": {
+        "bash": {
+          "*": "ask",
+          "git diff": "allow",
+          "git log*": "allow"
+        }
+      }
+    },
+
+    // Agent with step limit
+    "quick-thinker": {
+      "description": "Fast reasoning with limited iterations",
+      "mode": "subagent",
+      "steps": 5,
+      "temperature": 0.2
+    }
+  }
+}
+```
+
+### Markdown Agent Definition
+
+Define agents using markdown files in `.opencode/agents/` or `~/.config/opencode/agents/`.
+
+```markdown
+<!-- ~/.config/opencode/agents/security-auditor.md -->
+---
+description: Performs security audits and identifies vulnerabilities
+mode: subagent
+model: anthropic/claude-sonnet-4-5
+temperature: 0.1
+tools:
+  write: false
+  edit: false
+  bash: false
+permission:
+  edit: deny
+  webfetch: deny
+---
+
+You are a security expert. Focus on identifying potential security issues.
+
+Look for:
+- Input validation vulnerabilities
+- Authentication and authorization flaws
+- Data exposure risks
+- Dependency vulnerabilities
+- Configuration security issues
+
+Provide detailed findings with remediation recommendations.
+```
+
+### Custom Commands Configuration
+
+Define reusable slash commands.
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+
+  "command": {
+    "test": {
+      "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
+      "description": "Run tests with coverage",
+      "agent": "build",
+      "model": "anthropic/claude-haiku-4-5"
+    },
+    "component": {
+      "template": "Create a new React component named $ARGUMENTS with TypeScript support.\nInclude proper typing and basic structure.",
+      "description": "Create a new React component"
+    },
+    "review": {
+      "template": "Review the code in $ARGUMENTS for security issues, performance problems, and best practices.",
+      "description": "Code review",
+      "agent": "code-reviewer"
+    }
+  }
+}
+```
+
+### MCP Server Configuration
+
+Configure Model Context Protocol servers for external tools.
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+
+  "mcp": {
+    // Local MCP server
+    "my-local-mcp": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-everything"],
+      "enabled": true,
+      "environment": {
+        "MY_API_KEY": "{env:MY_API_KEY}"
+      },
+      "timeout": 10000
+    },
+
+    // Remote MCP with OAuth
+    "sentry": {
+      "type": "remote",
+      "url": "https://mcp.sentry.dev/mcp",
+      "oauth": {}
+    },
+
+    // Remote MCP with API key
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
+      }
+    },
+
+    // Remote MCP with pre-registered OAuth
+    "custom-oauth": {
+      "type": "remote",
+      "url": "https://mcp.example.com/mcp",
+      "oauth": {
+        "clientId": "{env:MCP_CLIENT_ID}",
+        "clientSecret": "{env:MCP_CLIENT_SECRET}",
+        "scope": "tools:read tools:execute"
+      }
+    },
+
+    // Grep by Vercel
+    "gh_grep": {
+      "type": "remote",
+      "url": "https://mcp.grep.app"
+    }
+  },
+
+  // Disable specific MCP tools globally
+  "tools": {
+    "my-local-mcp_*": false
+  },
+
+  // Enable MCP tools per-agent
+  "agent": {
+    "research": {
+      "tools": {
+        "context7_*": true,
+        "gh_grep_*": true
+      }
+    }
+  }
+}
+```
+
+### Keybinds Configuration
+
+Customize keyboard shortcuts.
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+
+  "keybinds": {
+    "leader": "ctrl+a",
+    "switch_agent": "tab",
+    "session_child_cycle": "leader+right",
+    "session_child_cycle_reverse": "leader+left",
+    "submit": "ctrl+enter",
+    "cancel": "escape",
+    "undo": "ctrl+z",
+    "redo": "ctrl+y"
+  }
+}
+```
+
+### Formatter Configuration
+
+Configure code formatters.
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+
+  "formatter": {
+    // Disable built-in prettier
+    "prettier": {
+      "disabled": true
+    },
+
+    // Custom formatter
+    "custom-prettier": {
+      "command": ["npx", "prettier", "--write", "$FILE"],
+      "environment": {
+        "NODE_ENV": "development"
+      },
+      "extensions": [".js", ".ts", ".jsx", ".tsx"]
+    },
+
+    // Go formatter
+    "gofmt": {
+      "command": ["gofmt", "-w", "$FILE"],
+      "extensions": [".go"]
+    }
+  }
+}
+```
+
+---
+
+## Plugins
+
+### Basic Plugin Structure
+
+Create plugins to extend OpenCode functionality.
+
+```typescript
+// .opencode/plugins/my-plugin.ts
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const MyPlugin: Plugin = async ({ project, client, $, directory, worktree }) => {
+  console.log(`Plugin initialized for project: ${project.name}`)
+  console.log(`Working directory: ${directory}`)
+
+  return {
+    // Event handlers go here
+  }
+}
+```
+
+### Event Subscription Plugin
+
+Subscribe to OpenCode events for notifications and automation.
+
+```typescript
+// .opencode/plugins/notifications.ts
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const NotificationPlugin: Plugin = async ({ client, $ }) => {
+  return {
+    event: async ({ event }) => {
+      switch (event.type) {
+        case "session.idle":
+          // Send macOS notification when session completes
+          await $`osascript -e 'display notification "Session completed!" with title "OpenCode"'`
+          break
+
+        case "session.error":
+          await $`osascript -e 'display notification "Session error occurred" with title "OpenCode" sound name "Basso"'`
+          break
+
+        case "file.edited":
+          console.log(`File edited: ${event.properties.path}`)
+          break
+
+        case "permission.asked":
+          console.log(`Permission requested: ${event.properties.tool}`)
+          break
+      }
+    },
+  }
+}
+```
+
+### Tool Interception Plugin
+
+Intercept and modify tool calls before/after execution.
+
+```typescript
+// .opencode/plugins/security.ts
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const SecurityPlugin: Plugin = async ({ client }) => {
+  return {
+    // Prevent reading sensitive files
+    "tool.execute.before": async (input, output) => {
+      if (input.tool === "read") {
+        const sensitivePatterns = [".env", "credentials", "secrets", ".pem", ".key"]
+        const filePath = output.args.filePath.toLowerCase()
+
+        if (sensitivePatterns.some((p) => filePath.includes(p))) {
+          throw new Error(`Access denied: Cannot read sensitive file ${output.args.filePath}`)
+        }
+      }
+
+      // Log bash commands
+      if (input.tool === "bash") {
+        await client.app.log({
+          body: {
+            service: "security-plugin",
+            level: "info",
+            message: `Executing bash: ${output.args.command}`,
+          },
+        })
+      }
+    },
+
+    // Log tool results
+    "tool.execute.after": async (input, output) => {
+      await client.app.log({
+        body: {
+          service: "security-plugin",
+          level: "debug",
+          message: `Tool ${input.tool} completed`,
+          extra: { duration: output.duration },
+        },
+      })
+    },
+  }
+}
+```
+
+### Environment Injection Plugin
+
+Inject environment variables into shell executions.
+
+```typescript
+// .opencode/plugins/env-inject.ts
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const EnvInjectPlugin: Plugin = async () => {
+  return {
+    "shell.env": async (input, output) => {
+      // Inject custom environment variables
+      output.env.PROJECT_ROOT = input.cwd
+      output.env.NODE_ENV = "development"
+      output.env.CUSTOM_API_URL = process.env.API_URL || "http://localhost:3000"
+
+      // Add PATH modifications
+      output.env.PATH = `${input.cwd}/node_modules/.bin:${output.env.PATH}`
+    },
+  }
+}
+```
+
+### Custom Tool Plugin
+
+Add custom tools that the LLM can use.
+
+```typescript
+// .opencode/plugins/custom-tools.ts
+import { type Plugin, tool } from "@opencode-ai/plugin"
+
+export const CustomToolsPlugin: Plugin = async (ctx) => {
+  return {
+    tool: {
+      // Database query tool
+      database_query: tool({
+        description: "Execute a read-only SQL query against the development database",
+        args: {
+          query: tool.schema.string().describe("SQL query to execute"),
+          database: tool.schema.string().optional().describe("Database name"),
+        },
+        async execute(args, context) {
+          const db = args.database || "development"
+          // Execute query (implementation depends on your setup)
+          const result = await executeQuery(db, args.query)
+          return JSON.stringify(result, null, 2)
+        },
+      }),
+
+      // API health check tool
+      api_health: tool({
+        description: "Check the health status of internal APIs",
+        args: {
+          service: tool.schema.string().describe("Service name to check"),
+        },
+        async execute(args, context) {
+          const response = await fetch(`http://${args.service}.internal/health`)
+          const data = await response.json()
+          return `${args.service}: ${data.status} (latency: ${data.latency}ms)`
+        },
+      }),
+
+      // Git branch info tool
+      branch_info: tool({
+        description: "Get detailed information about git branches",
+        args: {
+          pattern: tool.schema.string().optional().describe("Branch name pattern"),
+        },
+        async execute(args, context) {
+          const { $ } = ctx
+          const pattern = args.pattern || "*"
+          const result = await $`git branch -a --format='%(refname:short) %(upstream:short) %(committerdate:relative)'`.text()
+          return result
+        },
+      }),
+    },
+  }
+}
+```
+
+### Compaction Hook Plugin
+
+Customize context compaction behavior.
+
+```typescript
+// .opencode/plugins/compaction.ts
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const CompactionPlugin: Plugin = async (ctx) => {
+  return {
+    "experimental.session.compacting": async (input, output) => {
+      // Add custom context to preserve during compaction
+      output.context.push(`
+## Project Context
+
+Important state to preserve:
+- Current task: Implementing user authentication
+- Active branch: feature/auth-system
+- Key files: src/auth/*, src/middleware/*
+- Dependencies: jsonwebtoken, bcrypt
+
+## Decisions Made
+- Using JWT for stateless authentication
+- Passwords hashed with bcrypt (12 rounds)
+- Refresh tokens stored in Redis
+`)
+
+      // Or replace the entire compaction prompt
+      // output.prompt = `Custom compaction prompt...`
+    },
+  }
+}
+```
+
+---
+
+## Environment Variables
+
+Configure OpenCode behavior through environment variables.
+
+```bash
+# Configuration
+export OPENCODE_CONFIG=/path/to/custom-config.json
+export OPENCODE_CONFIG_DIR=/path/to/config-directory
+export OPENCODE_CONFIG_CONTENT='{"model":"anthropic/claude-sonnet-4-5"}'
+
+# Server authentication
+export OPENCODE_SERVER_PASSWORD=your-secret-password
+export OPENCODE_SERVER_USERNAME=admin
+
+# Feature flags
+export OPENCODE_AUTO_SHARE=true
+export OPENCODE_DISABLE_AUTOUPDATE=true
+export OPENCODE_DISABLE_AUTOCOMPACT=true
+export OPENCODE_ENABLE_EXA=true  # Enable web search
+
+# Permissions (JSON)
+export OPENCODE_PERMISSION='{"edit":"ask","bash":"ask"}'
+
+# Experimental features
+export OPENCODE_EXPERIMENTAL=true
+export OPENCODE_EXPERIMENTAL_LSP_TOOL=true
+export OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS=120000
+export OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX=8192
+
+# Provider API keys
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
+export GOOGLE_API_KEY=...
+
+# Custom installation
+export OPENCODE_INSTALL_DIR=/usr/local/bin
+export XDG_BIN_DIR=$HOME/.local/bin
+```
+
+---
+
+## Summary
+
+OpenCode serves as a comprehensive AI coding assistant that integrates seamlessly into developer workflows through multiple interfaces. The primary use cases include interactive development sessions via the TUI (switching between Build and Plan agents with Tab), automated scripting through the CLI (`opencode run`), and programmatic integration via the SDK and HTTP API. The tool excels at code exploration, refactoring, test generation, documentation writing, and complex multi-file changes while maintaining full version control awareness.
+
+Integration patterns typically involve running OpenCode as a headless server (`opencode serve`) for remote access from mobile apps or web interfaces, extending functionality through plugins for custom tools and event handling, and configuring MCP servers to integrate external services like Sentry, GitHub, or custom internal APIs. The configuration system supports layered settings (remote, global, project-level) with environment variable substitution, making it suitable for both individual developers and enterprise deployments with organization-wide defaults. Custom agents enable specialized workflows like security auditing, code review, and documentation generation, each with tailored permissions and tool access.

--- a/dev-docs/opencode_ai/llms.txt
+++ b/dev-docs/opencode_ai/llms.txt
@@ -1,0 +1,1894 @@
+### OpenCode JSONC Configuration Example
+
+Source: https://opencode.ai/docs/config
+
+An example of an OpenCode configuration file using the JSONC format, which allows for comments. This snippet demonstrates basic settings like theme, model, and autoupdate.
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  // Theme configuration
+  "theme": "opencode",
+  "model": "anthropic/claude-sonnet-4-5",
+  "autoupdate": true
+}
+```
+
+--------------------------------
+
+### Install OpenCode using curl
+
+Source: https://opencode.ai/docs/index
+
+This command downloads and executes the OpenCode installation script from the official website. It's a quick way to get OpenCode set up on your system.
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+--------------------------------
+
+### Install OpenCode CLI
+
+Source: https://opencode.ai/docs/github
+
+Command to install OpenCode in a GitHub repository. This command initiates an interactive setup process for the GitHub app, workflow, and secrets.
+
+```bash
+opencode github install
+```
+
+--------------------------------
+
+### Configure Formatters (JSON)
+
+Source: https://opencode.ai/docs/config
+
+Sets up code formatters. This example disables 'prettier' and configures a 'custom-prettier' with specific commands, environment variables, and file extensions.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "formatter": {
+    "prettier": {
+      "disabled": true
+    },
+    "custom-prettier": {
+      "command": ["npx", "prettier", "--write", "$FILE"],
+      "environment": {
+        "NODE_ENV": "development"
+      },
+      "extensions": [".js", ".ts", ".jsx", ".tsx"]
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Install Opencode SDK
+
+Source: https://opencode.ai/docs/sdk
+
+Install the opencode SDK using npm. This is the first step to integrate the SDK into your project.
+
+```bash
+npm install @opencode-ai/sdk
+```
+
+--------------------------------
+
+### Install SDK
+
+Source: https://opencode.ai/docs/sdk
+
+Install the opencode AI SDK using npm.
+
+```APIDOC
+## Install
+
+Install the SDK from npm:
+
+```bash
+npm install @opencode-ai/sdk
+```
+```
+
+--------------------------------
+
+### OpenCode Local Override Configuration Example
+
+Source: https://opencode.ai/docs/config
+
+Example of a local OpenCode configuration file (opencode.json) used to override remote settings. This JSON snippet demonstrates enabling a previously disabled MCP Jira service.
+
+```json
+{
+  "mcp": {
+    "jira": {
+      "type": "remote",
+      "url": "https://jira.example.com/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Create Client (Full)
+
+Source: https://opencode.ai/docs/sdk
+
+Create an instance of opencode, starting both a server and a client. This method allows for various configuration options.
+
+```APIDOC
+## Create client
+
+Create an instance of opencode:
+
+```javascript
+import { createOpencode } from "@opencode-ai/sdk"
+
+const { client } = await createOpencode()
+```
+
+This starts both a server and a client
+
+#### Options
+
+| Option     | Type          | Description                    | Default     |
+| ---------- | ------------- | ------------------------------ | ----------- |
+| `hostname` | `string`      | Server hostname                | `127.0.0.1` |
+| `port`     | `number`      | Server port                    | `4096`      |
+| `signal`   | `AbortSignal` | Abort signal for cancellation  | `undefined` |
+| `timeout`  | `number`      | Timeout in ms for server start | `5000`      |
+| `config`   | `Config`      | Configuration object           | `{}`        |
+
+## Config
+
+You can pass a configuration object to customize behavior. The instance still picks up your `opencode.json`, but you can override or add configuration inline:
+
+```javascript
+import { createOpencode } from "@opencode-ai/sdk"
+
+const opencode = await createOpencode({
+  hostname: "127.0.0.1",
+  port: 4096,
+  config: {
+    model: "anthropic/claude-3-5-sonnet-20241022",
+  },
+})
+
+console.log(`Server running at ${opencode.server.url}`)
+
+opencode.server.close()
+```
+```
+
+--------------------------------
+
+### Start OpenCode Web Server
+
+Source: https://opencode.ai/docs/web
+
+Starts the OpenCode web interface by running a local server. It automatically opens the application in your default browser and binds to a random available port on localhost. Ensure OPENCODE_SERVER_PASSWORD is set for secured network access.
+
+```bash
+opencode web
+```
+
+--------------------------------
+
+### Install Clipboard Utilities for Linux (Wayland)
+
+Source: https://opencode.ai/docs/troubleshooting
+
+Installs the necessary clipboard utility for copy/paste functionality on Linux systems using the Wayland display server. 'wl-clipboard' is the preferred tool for Wayland environments. This is required for OpenCode's copy/paste features to work correctly.
+
+```bash
+apt install -y wl-clipboard
+```
+
+--------------------------------
+
+### Install OpenCode using Bun
+
+Source: https://opencode.ai/docs/index
+
+Installs the OpenCode package globally using Bun, a fast JavaScript runtime and package manager. This method requires Bun to be installed.
+
+```javascript
+bun install -g opencode-ai
+```
+
+--------------------------------
+
+### Install OpenCode using Mise
+
+Source: https://opencode.ai/docs/index
+
+Installs OpenCode using Mise, a polyglot version manager. This command uses Mise to install OpenCode from its GitHub repository.
+
+```bash
+mise use -g github:anomalyco/opencode
+```
+
+--------------------------------
+
+### OpenCode Remote Configuration Example
+
+Source: https://opencode.ai/docs/config
+
+Example of a remote configuration for OpenCode, specifying settings for MCP Jira integration. This JSON snippet shows how to define remote service configurations.
+
+```json
+{
+  "mcp": {
+    "jira": {
+      "type": "remote",
+      "url": "https://jira.example.com/mcp",
+      "enabled": false
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Install OpenCode using Scoop
+
+Source: https://opencode.ai/docs/index
+
+Installs OpenCode on Windows using Scoop, a command-line installer for Windows. This command downloads and installs OpenCode via Scoop.
+
+```powershell
+scoop install opencode
+```
+
+--------------------------------
+
+### Start OpenCode Server (Bash)
+
+Source: https://opencode.ai/docs/cli
+
+Starts a headless OpenCode HTTP server for API access. Basic authentication can be enabled by setting the `OPENCODE_SERVER_PASSWORD` environment variable.
+
+```bash
+opencode serve
+```
+
+--------------------------------
+
+### Start Headless OpenCode Web Server
+
+Source: https://opencode.ai/docs/cli
+
+Initiates a headless OpenCode server with a web interface. This command starts an HTTP server and automatically opens a web browser for accessing OpenCode. It supports optional port, hostname, mDNS, and CORS configurations.
+
+```bash
+opencode web
+
+# Example with flags:
+opencode web --port 8080 --hostname localhost --mdns --cors "http://example.com"
+```
+
+--------------------------------
+
+### Install OpenCode using Paru
+
+Source: https://opencode.ai/docs/index
+
+Installs the OpenCode binary package on Arch Linux using Paru, an AUR helper. This command fetches and installs the package from the Arch User Repository.
+
+```bash
+paru -S opencode-bin
+```
+
+--------------------------------
+
+### Install Clipboard Utilities for Linux (X11)
+
+Source: https://opencode.ai/docs/troubleshooting
+
+Installs necessary clipboard utilities for copy/paste functionality on Linux systems using the X11 display server. Users can choose between 'xclip' or 'xsel'. This is required for OpenCode's copy/paste features to work correctly.
+
+```bash
+apt install -y xclip
+# or
+apt install -y xsel
+```
+
+--------------------------------
+
+### Setup Virtual Framebuffer for Headless Linux
+
+Source: https://opencode.ai/docs/troubleshooting
+
+Configures a virtual framebuffer ('xvfb') for running OpenCode in headless Linux environments where a graphical display is not available. This setup allows copy/paste functionality to work by simulating a display server. The DISPLAY environment variable must be set.
+
+```bash
+apt install -y xvfb
+Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+export DISPLAY=:99.0
+```
+
+--------------------------------
+
+### Create Opencode Client Instance
+
+Source: https://opencode.ai/docs/sdk
+
+Create a new instance of the opencode client. This can start both a server and a client, or connect to an existing server using provided options.
+
+```javascript
+import { createOpencode } from "@opencode-ai/sdk"
+
+const { client } = await createOpencode()
+```
+
+--------------------------------
+
+### Run OpenCode Serve Command
+
+Source: https://opencode.ai/docs/server
+
+This snippet shows the basic command to start the OpenCode server. It includes optional flags for specifying the port, hostname, and CORS origins. The `--cors` flag can be used multiple times to allow multiple origins.
+
+```bash
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+```
+
+--------------------------------
+
+### Prompt Example for Local MCP Server
+
+Source: https://opencode.ai/docs/mcp-servers
+
+Demonstrates how to invoke a configured local MCP server, `mcp_everything`, within a prompt. This shows the practical application of adding and enabling MCP tools for LLM interaction.
+
+```txt
+use the mcp_everything tool to add the number 3 and 4
+```
+
+--------------------------------
+
+### Configure Model Instructions (JSON)
+
+Source: https://opencode.ai/docs/config
+
+Defines instruction files for the model, using paths and glob patterns. These files guide the model's behavior and can be located relative to the config file or as absolute paths.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
+}
+```
+
+--------------------------------
+
+### Launching OpenCode with Wayland Support on Linux
+
+Source: https://opencode.ai/docs/troubleshooting
+
+This command launches OpenCode on Linux with Wayland support enabled. It can help resolve blank window or compositor errors that may occur on certain Wayland setups.
+
+```bash
+OC_ALLOW_WAYLAND=1
+```
+
+--------------------------------
+
+### Use Glob Patterns for Bash Permissions (JSON)
+
+Source: https://opencode.ai/docs/agents
+
+Utilize glob patterns to manage permissions for multiple bash commands. This example sets all commands starting with 'git ' to require approval ('ask') for the 'build' agent.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "git *":
+```
+
+--------------------------------
+
+### Install OpenCode using Homebrew
+
+Source: https://opencode.ai/docs/index
+
+Installs OpenCode on macOS and Linux using Homebrew, a package manager for these operating systems. It uses a specific tap for up-to-date releases.
+
+```bash
+brew install anomalyco/tap/opencode
+```
+
+--------------------------------
+
+### Add Custom LSP Server
+
+Source: https://opencode.ai/docs/lsp
+
+This example shows how to add a custom LSP server to opencode.ai. You need to provide the command to execute the server and the file extensions it should handle. This allows integration with language servers not included by default.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "custom-lsp": {
+      "command": ["custom-lsp-server", "--stdio"],
+      "extensions": [".custom"]
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Install OpenCode using npm
+
+Source: https://opencode.ai/docs/index
+
+Installs the OpenCode package globally using npm, the Node Package Manager. This method requires Node.js and npm to be installed on your system.
+
+```javascript
+npm install -g opencode-ai
+```
+
+--------------------------------
+
+### OpenCode Configuration Example (JSON)
+
+Source: https://opencode.ai/docs/enterprise
+
+An example JSON configuration file for OpenCode, specifying schema and sharing settings. The 'share' property is set to 'disabled' by default.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "share": "disabled"
+}
+```
+
+--------------------------------
+
+### Install and Configure OpenCode Helicone Session Plugin
+
+Source: https://opencode.ai/docs/providers
+
+This section provides instructions for installing and configuring the `opencode-helicone-session` plugin. This plugin automates the logging of OpenCode conversations as sessions in Helicone by injecting specific headers into requests. The installation is done via npm, and the configuration is a simple JSON addition to your OpenCode settings.
+
+```bash
+npm install -g opencode-helicone-session
+```
+
+```json
+{
+  "plugin": ["opencode-helicone-session"]
+}
+```
+
+--------------------------------
+
+### Configure Experimental Options (JSON)
+
+Source: https://opencode.ai/docs/config
+
+Includes options that are under active development and may change or be removed without notice. Use with caution.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {}
+}
+```
+
+--------------------------------
+
+### Ask OpenCode a Question
+
+Source: https://opencode.ai/docs/index
+
+An example of how to ask OpenCode a question about a specific file in the codebase. The '@' symbol is used for fuzzy file searching.
+
+```text
+How is authentication handled in @packages/functions/src/api/index.ts
+```
+
+--------------------------------
+
+### Install OpenCode using Chocolatey
+
+Source: https://opencode.ai/docs/index
+
+Installs OpenCode on Windows using Chocolatey, a package manager for Windows. This command downloads and installs OpenCode from the Chocolatey repository.
+
+```powershell
+choco install opencode
+```
+
+--------------------------------
+
+### Install OpenCode using Yarn
+
+Source: https://opencode.ai/docs/index
+
+Installs the OpenCode package globally using Yarn, a popular JavaScript package manager. This method requires Yarn to be installed.
+
+```javascript
+yarn global add opencode-ai
+```
+
+--------------------------------
+
+### Setting Custom OpenCode Configuration Path
+
+Source: https://opencode.ai/docs/config
+
+Demonstrates how to set a custom configuration file path for OpenCode using the OPENCODE_CONFIG environment variable in a bash shell.
+
+```bash
+export OPENCODE_CONFIG=/path/to/my/custom-config.json
+opencode run "Hello world"
+```
+
+--------------------------------
+
+### Add Custom or Override Formatter (Prettier and Markdown)
+
+Source: https://opencode.ai/docs/formatters
+
+This example demonstrates how to add a custom formatter or override an existing one. It shows configurations for Prettier (JavaScript/TypeScript) and a custom markdown formatter using Deno, specifying commands, environment variables, and file extensions.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "formatter": {
+    "prettier": {
+      "command": ["npx", "prettier", "--write", "$FILE"],
+      "environment": {
+        "NODE_ENV": "development"
+      },
+      "extensions": [".js", ".ts", ".jsx", ".tsx"]
+    },
+    "custom-markdown-formatter": {
+      "command": ["deno", "fmt", "$FILE"],
+      "extensions": [".md"]
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Skill File Structure and Frontmatter Example
+
+Source: https://opencode.ai/docs/skills
+
+Demonstrates the required directory structure and the YAML frontmatter for a `SKILL.md` file. The frontmatter includes essential fields like 'name', 'description', and optional fields such as 'license', 'compatibility', and 'metadata'.
+
+```markdown
+---
+name: git-release
+description: Create consistent releases and changelogs
+license: MIT
+compatibility: opencode
+metadata:
+  audience: maintainers
+  workflow: github
+---
+
+## What I do
+
+- Draft release notes from merged PRs
+- Propose a version bump
+- Provide a copy-pasteable `gh release create` command
+
+## When to use me
+
+Use this when you are preparing a tagged release. Ask clarifying questions if the target versioning scheme is unclear.
+
+```
+
+--------------------------------
+
+### Configure Keybinds (JSON)
+
+Source: https://opencode.ai/docs/config
+
+An empty configuration object for customizing keybinds in OpenCode. Further details can be found in the documentation.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "keybinds": {}
+}
+```
+
+--------------------------------
+
+### Install OpenCode using pnpm
+
+Source: https://opencode.ai/docs/index
+
+Installs the OpenCode package globally using pnpm, a performant Node.js package manager. This method requires pnpm to be installed.
+
+```javascript
+pnpm install -g opencode-ai
+```
+
+--------------------------------
+
+### Connect to OpenAI
+
+Source: https://opencode.ai/docs/providers
+
+Guide for connecting OpenCode to OpenAI models, including ChatGPT Plus/Pro. Users can authenticate via browser or by manually entering an API key obtained from OpenAI. The `/connect` command initiates the process.
+
+```txt
+/connect
+```
+
+```txt
+┌ Select auth method
+│
+│ ChatGPT Plus/Pro
+│ Manually enter API Key
+└
+```
+
+```txt
+/models
+```
+
+--------------------------------
+
+### Example AGENTS.md for Monorepo Project
+
+Source: https://opencode.ai/docs/rules
+
+This markdown file provides an example structure and content for an AGENTS.md file, detailing project type, structure, code standards, and monorepo conventions. It serves as a template for customizing OpenCode's behavior for a specific project.
+
+```markdown
+# SST v3 Monorepo Project
+
+This is an SST v3 monorepo with TypeScript. The project uses bun workspaces for package management.
+
+## Project Structure
+
+- `packages/` - Contains all workspace packages (functions, core, web, etc.)
+- `infra/` - Infrastructure definitions split by service (storage.ts, api.ts, web.ts)
+- `sst.config.ts` - Main SST configuration with dynamic imports
+
+## Code Standards
+
+- Use TypeScript with strict mode enabled
+- Shared code goes in `packages/core/` with proper exports configuration
+- Functions go in `packages/functions/`
+- Infrastructure should be split into logical files in `infra/`
+
+## Monorepo Conventions
+
+- Import shared modules using workspace names: `@my-app/core/example`
+```
+
+--------------------------------
+
+### Configure MCP Server Globally (JSON)
+
+Source: https://opencode.ai/docs/mcp-servers
+
+This JSON configuration shows a basic setup for enabling or disabling MCP servers globally. It includes an example of a local MCP server and how to toggle its tool availability.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "my-mcp-foo": {
+      "type": "local",
+      "command": ["bun", "x", "my-mcp-command-foo"]
+    },
+    "my-mcp-bar": {
+      "type": "local",
+      "command": ["bun", "x", "my-mcp-command-bar"]
+    }
+  },
+  "tools": {
+    "my-mcp-foo": false
+  }
+}
+```
+
+--------------------------------
+
+### Start OpenCode TUI
+
+Source: https://opencode.ai/docs/cli
+
+Starts the OpenCode Terminal User Interface (TUI). It can optionally take a project argument and supports flags for continuing sessions, specifying prompts, models, agents, ports, and hostnames.
+
+```bash
+opencode [project]
+opencode -c
+opencode -s <session_id>
+opencode --prompt "<prompt>"
+opencode -m <provider/model>
+opencode --agent <agent_name>
+opencode --port <port_number>
+opencode --hostname <hostname>
+```
+
+--------------------------------
+
+### Setting Custom OpenCode Configuration Directory
+
+Source: https://opencode.ai/docs/config
+
+Shows how to specify a custom directory for OpenCode configuration files (agents, commands, etc.) using the OPENCODE_CONFIG_DIR environment variable in bash.
+
+```bash
+export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
+opencode run "Hello world"
+```
+
+--------------------------------
+
+### Connect to OpenCode Provider
+
+Source: https://opencode.ai/docs/index
+
+This command initiates the process to connect OpenCode to an LLM provider via its TUI. It guides the user through the authentication process on the OpenCode website.
+
+```bash
+/connect
+```
+
+--------------------------------
+
+### Configure Permissions for Tools (JSON)
+
+Source: https://opencode.ai/docs/config
+
+Sets user approval requirements for specific tools. 'edit' and 'bash' tools are configured to 'ask' for user confirmation before execution.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": "ask",
+    "bash": "ask"
+  }
+}
+```
+
+--------------------------------
+
+### Set Authentication for OpenCode Serve
+
+Source: https://opencode.ai/docs/server
+
+This example demonstrates how to secure the OpenCode server using HTTP basic authentication. The `OPENCODE_SERVER_PASSWORD` environment variable sets the password, and `OPENCODE_SERVER_USERNAME` can optionally override the default username 'opencode'.
+
+```bash
+OPENCODE_SERVER_PASSWORD=your-password opencode serve
+```
+
+--------------------------------
+
+### Get Configuration - JavaScript
+
+Source: https://opencode.ai/docs/sdk
+
+Fetches the general configuration settings using the client.config.get() method. This is a simple retrieval operation with no input parameters.
+
+```javascript
+const config = await client.config.get()
+```
+
+--------------------------------
+
+### Configure MCP Servers (JSON)
+
+Source: https://opencode.ai/docs/config
+
+Allows configuration of MCP servers to be used with OpenCode. Currently, this option is an empty object, with further details available in the documentation.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {}
+}
+```
+
+--------------------------------
+
+### Files API
+
+Source: https://opencode.ai/docs/server
+
+Endpoints for searching, retrieving, and getting status of files.
+
+```APIDOC
+## GET /find?pattern=<pat>
+
+### Description
+Search for text in files.
+
+### Method
+GET
+
+### Endpoint
+/find
+
+### Query Parameters
+- **pattern** (string) - Required - The text pattern to search for.
+
+### Response
+#### Success Response (200)
+- Array of match objects with `path`, `lines`, `line_number`, `absolute_offset`, `submatches`.
+
+#### Response Example
+```json
+[
+  {
+    "path": "src/main.js",
+    "lines": [
+      "console.log('Hello, world!');"
+    ],
+    "line_number": 10,
+    "absolute_offset": 250,
+    "submatches": [
+      {
+        "offset": 12,
+        "length": 5
+      }
+    ]
+  }
+]
+```
+```
+
+```APIDOC
+## GET /find/file?query=<q>
+
+### Description
+Find files and directories by name.
+
+### Method
+GET
+
+### Endpoint
+/find/file
+
+### Query Parameters
+- **query** (string) - Required - Search string (fuzzy match).
+- **type** (string) - Optional - Limit results to `"file"` or `"directory"`.
+- **directory** (string) - Optional - Override the project root for the search.
+- **limit** (integer) - Optional - Max results (1–200).
+- **dirs** (string) - Optional - Legacy flag (`"false"` returns only files).
+
+### Response
+#### Success Response (200)
+- **string[]** - An array of file and directory paths.
+
+#### Response Example
+```json
+[
+  "src/components/Button.jsx",
+  "public/index.html"
+]
+```
+```
+
+```APIDOC
+## GET /find/symbol?query=<q>
+
+### Description
+Find workspace symbols.
+
+### Method
+GET
+
+### Endpoint
+/find/symbol
+
+### Query Parameters
+- **query** (string) - Required - The symbol name to search for.
+
+### Response
+#### Success Response (200)
+- **Symbol[]** - An array of symbol objects.
+
+#### Response Example
+```json
+[
+  {
+    "name": "App",
+    "kind": "class",
+    "location": {
+      "uri": "file:///path/to/App.js",
+      "range": {
+        "start": {"line": 0, "character": 0},
+        "end": {"line": 50, "character": 1}
+      }
+    }
+  }
+]
+```
+```
+
+```APIDOC
+## GET /file?path=<path>
+
+### Description
+List files and directories.
+
+### Method
+GET
+
+### Endpoint
+/file
+
+### Query Parameters
+- **path** (string) - Required - The path to list.
+
+### Response
+#### Success Response (200)
+- **FileNode[]** - An array of file and directory nodes.
+
+#### Response Example
+```json
+[
+  {
+    "name": "src",
+    "type": "directory",
+    "children": [
+      {
+        "name": "index.js",
+        "type": "file"
+      }
+    ]
+  }
+]
+```
+```
+
+```APIDOC
+## GET /file/content?path=<p>
+
+### Description
+Read a file.
+
+### Method
+GET
+
+### Endpoint
+/file/content
+
+### Query Parameters
+- **path** (string) - Required - The path to the file.
+
+### Response
+#### Success Response (200)
+- **FileContent** - The content of the file.
+
+#### Response Example
+```json
+{
+  "content": "// This is the content of the file."
+}
+```
+```
+
+```APIDOC
+## GET /file/status
+
+### Description
+Get status for tracked files.
+
+### Method
+GET
+
+### Endpoint
+/file/status
+
+### Response
+#### Success Response (200)
+- **File[]** - An array of file status objects.
+
+#### Response Example
+```json
+[
+  {
+    "path": "src/App.js",
+    "status": "modified"
+  }
+]
+```
+```
+
+--------------------------------
+
+### Use Grep by Vercel MCP Server in Prompt (Text)
+
+Source: https://opencode.ai/docs/mcp-servers
+
+This example prompt shows how to use the Grep by Vercel MCP server, identified as 'gh_grep', to find information on setting custom domains in an SST Astro component. It clearly states the query and the tool to use.
+
+```text
+What's the right way to set a custom domain in an SST Astro component? use the gh_grep tool
+```
+
+--------------------------------
+
+### Run OpenCode using Docker
+
+Source: https://opencode.ai/docs/index
+
+Runs OpenCode in an interactive Docker container. This is useful for trying out OpenCode without installing it directly on your system.
+
+```bash
+docker run -it --rm ghcr.io/anomalyco/opencode
+```
+
+--------------------------------
+
+### Define Local Plugin Dependencies in package.json
+
+Source: https://opencode.ai/docs/plugins
+
+This JSON file defines the npm package dependencies for local plugins. OpenCode runs `bun install` at startup to install these dependencies, making them available for import within your plugins.
+
+```json
+{
+  "dependencies": {
+    "shescape": "^2.1.0"
+  }
+}
+```
+
+--------------------------------
+
+### Example Custom Theme Configuration for OpenCode AI
+
+Source: https://opencode.ai/docs/themes
+
+This JSON file demonstrates a complete custom theme for OpenCode AI, named 'my-theme.json'. It includes a 'defs' section for defining Nord color palette values and a 'theme' section that assigns these defined colors to various UI elements and syntax highlighting categories. The theme supports both dark and light variations.
+
+```json
+{
+  "$schema": "https://opencode.ai/theme.json",
+  "defs": {
+    "nord0": "#2E3440",
+    "nord1": "#3B4252",
+    "nord2": "#434C5E",
+    "nord3": "#4C566A",
+    "nord4": "#D8DEE9",
+    "nord5": "#E5E9F0",
+    "nord6": "#ECEFF4",
+    "nord7": "#8FBCBB",
+    "nord8": "#88C0D0",
+    "nord9": "#81A1C1",
+    "nord10": "#5E81AC",
+    "nord11": "#BF616A",
+    "nord12": "#D08770",
+    "nord13": "#EBCB8B",
+    "nord14": "#A3BE8C",
+    "nord15": "#B48EAD"
+  },
+  "theme": {
+    "primary": {
+      "dark": "nord8",
+      "light": "nord10"
+    },
+    "secondary": {
+      "dark": "nord9",
+      "light": "nord9"
+    },
+    "accent": {
+      "dark": "nord7",
+      "light": "nord7"
+    },
+    "error": {
+      "dark": "nord11",
+      "light": "nord11"
+    },
+    "warning": {
+      "dark": "nord12",
+      "light": "nord12"
+    },
+    "success": {
+      "dark": "nord14",
+      "light": "nord14"
+    },
+    "info": {
+      "dark": "nord8",
+      "light": "nord10"
+    },
+    "text": {
+      "dark": "nord4",
+      "light": "nord0"
+    },
+    "textMuted": {
+      "dark": "nord3",
+      "light": "nord1"
+    },
+    "background": {
+      "dark": "nord0",
+      "light": "nord6"
+    },
+    "backgroundPanel": {
+      "dark": "nord1",
+      "light": "nord5"
+    },
+    "backgroundElement": {
+      "dark": "nord1",
+      "light": "nord4"
+    },
+    "border": {
+      "dark": "nord2",
+      "light": "nord3"
+    },
+    "borderActive": {
+      "dark": "nord3",
+      "light": "nord2"
+    },
+    "borderSubtle": {
+      "dark": "nord2",
+      "light": "nord3"
+    },
+    "diffAdded": {
+      "dark": "nord14",
+      "light": "nord14"
+    },
+    "diffRemoved": {
+      "dark": "nord11",
+      "light": "nord11"
+    },
+    "diffContext": {
+      "dark": "nord3",
+      "light": "nord3"
+    },
+    "diffHunkHeader": {
+      "dark": "nord3",
+      "light": "nord3"
+    },
+    "diffHighlightAdded": {
+      "dark": "nord14",
+      "light": "nord14"
+    },
+    "diffHighlightRemoved": {
+      "dark": "nord11",
+      "light": "nord11"
+    },
+    "diffAddedBg": {
+      "dark": "#3B4252",
+      "light": "#E5E9F0"
+    },
+    "diffRemovedBg": {
+      "dark": "#3B4252",
+      "light": "#E5E9F0"
+    },
+    "diffContextBg": {
+      "dark": "nord1",
+      "light": "nord5"
+    },
+    "diffLineNumber": {
+      "dark": "nord2",
+      "light": "nord4"
+    },
+    "diffAddedLineNumberBg": {
+      "dark": "#3B4252",
+      "light": "#E5E9F0"
+    },
+    "diffRemovedLineNumberBg": {
+      "dark": "#3B4252",
+      "light": "#E5E9F0"
+    },
+    "markdownText": {
+      "dark": "nord4",
+      "light": "nord0"
+    },
+    "markdownHeading": {
+      "dark": "nord8",
+      "light": "nord10"
+    },
+    "markdownLink": {
+      "dark": "nord9",
+      "light": "nord9"
+    },
+    "markdownLinkText": {
+      "dark": "nord7",
+      "light": "nord7"
+    },
+    "markdownCode": {
+      "dark": "nord14",
+      "light": "nord14"
+    },
+    "markdownBlockQuote": {
+      "dark": "nord3",
+      "light": "nord3"
+    },
+    "markdownEmph": {
+      "dark": "nord12",
+      "light": "nord12"
+    },
+    "markdownStrong": {
+      "dark": "nord13",
+      "light": "nord13"
+    },
+    "markdownHorizontalRule": {
+      "dark": "nord3",
+      "light": "nord3"
+    },
+    "markdownListItem": {
+      "dark": "nord8",
+      "light": "nord10"
+    },
+    "markdownListEnumeration": {
+      "dark": "nord7",
+      "light": "nord7"
+    },
+    "markdownImage": {
+      "dark": "nord9",
+      "light": "nord9"
+    },
+    "markdownImageText": {
+      "dark": "nord7",
+      "light": "nord7"
+    },
+    "markdownCodeBlock": {
+      "dark": "nord4",
+      "light": "nord0"
+    },
+    "syntaxComment": {
+      "dark": "nord3",
+      "light": "nord3"
+    },
+    "syntaxKeyword": {
+      "dark": "nord9",
+      "light": "nord9"
+    },
+    "syntaxFunction": {
+      "dark": "nord8",
+      "light": "nord8"
+    },
+    "syntaxVariable": {
+      "dark": "nord7",
+      "light": "nord7"
+    },
+    "syntaxString": {
+      "dark": "nord14",
+      "light": "nord14"
+    },
+    "syntaxNumber": {
+      "dark": "nord15",
+      "light": "nord15"
+    },
+    "syntaxType": {
+      "dark": "nord7",
+      "light": "nord7"
+    },
+    "syntaxOperator": {
+      "dark": "nord9",
+      "light": "nord9"
+    },
+    "syntaxPunctuation": {
+      "dark": "nord4",
+      "light": "nord0"
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Enable Providers (JSON)
+
+Source: https://opencode.ai/docs/config
+
+Specifies an allowlist of providers to be enabled. All other providers will be ignored. This is useful for restricting OpenCode to a specific set of services.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "enabled_providers": ["anthropic", "openai"]
+}
+```
+
+--------------------------------
+
+### Start OpenCode ACP Server
+
+Source: https://opencode.ai/docs/cli
+
+Launches an Agent Client Protocol (ACP) server for OpenCode. This server communicates using nd-JSON over stdin/stdout and can be configured with a working directory, port, and hostname.
+
+```bash
+opencode acp
+
+# Example with flags:
+opencode acp --cwd /path/to/project --port 3000 --hostname 0.0.0.0
+```
+
+--------------------------------
+
+### Manage GitHub Agent
+
+Source: https://opencode.ai/docs/cli
+
+Manages the GitHub agent for repository automation. This includes installing the agent in a repository and running it, typically within GitHub Actions.
+
+```bash
+opencode github [command]
+opencode github install
+opencode github run --event <event_name> --token <github_token>
+```
+
+--------------------------------
+
+### Configure Context Compaction (JSON)
+
+Source: https://opencode.ai/docs/config
+
+Controls how OpenCode manages session context. 'auto' enables automatic compaction when context is full, and 'prune' removes old tool outputs to save tokens.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "compaction": {
+    "auto": true,
+    "prune": true
+  }
+}
+```
+
+--------------------------------
+
+### Substitute File Contents (JSON)
+
+Source: https://opencode.ai/docs/config
+
+Uses `{file:path/to/file}` syntax to substitute the content of a file into configuration values. File paths can be relative or absolute, useful for sensitive data or large instruction sets.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["./custom-instructions.md"],
+  "provider": {
+    "openai": {
+      "options": {
+        "apiKey": "{file:~/.secrets/openai-key}"
+      }
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Configure Custom Commands (JSONC)
+
+Source: https://opencode.ai/docs/config
+
+Defines custom commands for repetitive tasks, specifying a template, description, and associated agent/model. The 'component' command uses $ARGUMENTS for dynamic input.
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "command": {
+    "test": {
+      "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
+      "description": "Run tests with coverage",
+      "agent": "build",
+      "model": "anthropic/claude-haiku-4-5"
+    },
+    "component": {
+      "template": "Create a new React component named $ARGUMENTS with TypeScript support.\nInclude proper typing and basic structure.",
+      "description": "Create a new component"
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Search and Read Files with OpenCode AI SDK (JavaScript)
+
+Source: https://opencode.ai/docs/sdk
+
+Provides examples for searching text within files, finding files and directories by name, and reading file content using the OpenCode AI SDK. Supports pattern matching and filtering by type.
+
+```javascript
+// Search and read files
+const textResults = await client.find.text({
+  query: { pattern: "function.*opencode" },
+})
+
+const files = await client.find.files({
+  query: { query: "*.ts", type: "file" },
+})
+
+const directories = await client.find.files({
+  query: { query: "packages", type: "directory", limit: 20 },
+})
+
+const content = await client.file.read({
+  query: { path: "src/index.ts" },
+})
+```
+
+--------------------------------
+
+### Configure Agent Tools (JSON)
+
+Source: https://opencode.ai/docs/agents
+
+Control which tools are available for an agent by setting their status to true or false in the 'tools' configuration. This example shows how to enable 'write' and 'bash' tools.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "tools": {
+    "write": true,
+    "bash": true
+  },
+  "agent": {
+    "plan": {
+      "tools": {
+        "write": false,
+        "bash": false
+      }
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Describe Feature Request in Plan Mode
+
+Source: https://opencode.ai/docs/index
+
+When in 'Plan mode', describe the desired feature or changes. This example outlines a feature for handling deleted notes, including database flagging and a UI for managing deleted items.
+
+```text
+When a user deletes a note, we'd like to flag it as deleted in the database.
+Then create a screen that shows all the recently deleted notes.
+From this screen, the user can undelete a note or permanently delete it.
+```
+
+--------------------------------
+
+### Clearing Cache on Linux
+
+Source: https://opencode.ai/docs/troubleshooting
+
+This command removes the OpenCode cache directory on Linux systems. Clearing the cache can resolve issues related to corrupted data or stuck plugin installations.
+
+```bash
+rm -rf ~/.cache/opencode
+```
+
+--------------------------------
+
+### Connect to OpenCode Zen
+
+Source: https://opencode.ai/docs/providers
+
+Connect to OpenCode Zen by running the /connect command and entering your OpenCode API key. This allows access to a list of tested and verified models provided by the OpenCode team.
+
+```txt
+/connect
+```
+
+```txt
+┌ API key
+│
+│
+└ enter
+```
+
+--------------------------------
+
+### Add Test Local MCP Server in OpenCode
+
+Source: https://opencode.ai/docs/mcp-servers
+
+Provides an example of adding the `@modelcontextprotocol/server-everything` MCP server locally. This configuration uses `npx` to run the server command, making it available for use in prompts by referencing its name (e.g., `mcp_everything`).
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "mcp_everything": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-everything"]
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Load Plugins via npm (JSON)
+
+Source: https://opencode.ai/docs/config
+
+Specifies plugins to load from npm, extending OpenCode's functionality. Plugins can be custom tools, hooks, or integrations. Alternatively, plugins can be placed in specific directories.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
+}
+```
+
+--------------------------------
+
+### Set Global Tool Permissions (JSON)
+
+Source: https://opencode.ai/docs/agents
+
+Configure global permissions for tools like 'edit', 'bash', and 'webfetch'. Permissions can be set to 'ask' (prompt for approval), 'allow' (always permit), or 'deny' (always block). This example denies the 'edit' tool globally.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": "deny"
+  }
+}
+```
+
+--------------------------------
+
+### Use Sentry MCP Server in Prompt (Text)
+
+Source: https://opencode.ai/docs/mcp-servers
+
+This is an example of a natural language prompt that utilizes the Sentry MCP server to query Sentry issues. The prompt specifies the action and the tool to be used.
+
+```text
+Show me the latest unresolved issues in my project. use sentry
+```
+
+--------------------------------
+
+### Wildcard Bash Command Permissions (JSON)
+
+Source: https://opencode.ai/docs/agents
+
+Use the '*' wildcard for broad permission settings on bash commands, with specific rules taking precedence. This example allows 'git status *' but denies all other bash commands by default for the 'build' agent.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "*":
+```
+
+--------------------------------
+
+### Configure Task Permissions for Subagents (JSON)
+
+Source: https://opencode.ai/docs/agents
+
+Control which subagents a primary agent can invoke using the Task tool. Glob patterns are used for matching. This example denies all tasks by default, allows tasks starting with 'orchestrator-', and prompts for 'code-reviewer'.
+
+```json
+{
+  "agent": {
+    "orchestrator": {
+      "mode": "primary",
+      "permission": {
+        "task": {
+          "*":
+```
+
+--------------------------------
+
+### Reset OpenCode Desktop App Data (Windows)
+
+Source: https://opencode.ai/docs/troubleshooting
+
+This command removes the OpenCode application data directory on Windows, which can resolve issues caused by corrupted configuration files. It's a last resort if the application won't start or behave correctly. This is applicable to Windows systems.
+
+```batch
+del /s /q %USERPROFILE%\.local\share\opencode
+```
+
+--------------------------------
+
+### Create a New Agent using opencode CLI
+
+Source: https://opencode.ai/docs/agents
+
+This bash command initiates an interactive process to create a new agent. The process guides the user through specifying the agent's save location, description, system prompt, identifier, and accessible tools, culminating in the creation of a markdown configuration file.
+
+```bash
+opencode agent create
+```
+
+--------------------------------
+
+### Reset OpenCode Desktop App Data (Linux/macOS)
+
+Source: https://opencode.ai/docs/troubleshooting
+
+This command removes the OpenCode application data directory, which can resolve issues caused by corrupted configuration files. It's a last resort if the application won't start or behave correctly. This is applicable to Linux and macOS systems.
+
+```bash
+rm -rf ~/.local/share/opencode
+```
+
+--------------------------------
+
+### Configure Agent Mode (JSON)
+
+Source: https://opencode.ai/docs/agents
+
+Set the operational mode for an agent using the 'mode' configuration. This example sets the 'review' agent to operate as a 'subagent'.
+
+```json
+{
+  "agent": {
+    "review": {
+      "mode": "subagent"
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Substitute Environment Variables (JSON)
+
+Source: https://opencode.ai/docs/config
+
+Uses `{env:VARIABLE_NAME}` syntax to substitute environment variables into configuration values. If an environment variable is not set, it defaults to an empty string.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "{env:OPENCODE_MODEL}",
+  "provider": {
+    "anthropic": {
+      "models": {},
+      "options": {
+        "apiKey": "{env:ANTHROPIC_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Instance API
+
+Source: https://opencode.ai/docs/server
+
+API to dispose of the current instance.
+
+```APIDOC
+## POST /instance/dispose
+
+### Description
+Dispose of the current instance.
+
+### Method
+POST
+
+### Endpoint
+/instance/dispose
+
+### Response
+#### Success Response (200)
+- **boolean** - Indicates if the instance was successfully disposed.
+
+#### Response Example
+```json
+true
+```
+```
+
+--------------------------------
+
+### Define Agent with Markdown
+
+Source: https://opencode.ai/docs/agents
+
+Defines an agent's behavior and configuration using a markdown file. The filename becomes the agent's name. This example sets up a 'review' agent focused on code quality.
+
+```markdown
+---
+description: Reviews code for quality and best practices
+mode: subagent
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.1
+tools:
+  write: false
+  edit: false
+  bash: false
+---
+
+You are in code review mode. Focus on:
+
+- Code quality and best practices
+- Potential bugs and edge cases
+- Performance implications
+- Security considerations
+
+Provide constructive feedback without making direct changes.
+```
+
+--------------------------------
+
+### Configure Server Settings in opencode.json
+
+Source: https://opencode.ai/docs/config
+
+This JSON snippet configures server settings for OpenCode commands like `opencode serve` and `opencode web`. It specifies the port, hostname, mDNS discovery, and Cross-Origin Resource Sharing (CORS) origins. mDNS allows network discovery of the OpenCode server.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "server": {
+    "port": 4096,
+    "hostname": "0.0.0.0",
+    "mdns": true,
+    "cors": ["http://localhost:5173"]
+  }
+}
+```
+
+--------------------------------
+
+### External Directory Permissions (JSON)
+
+Source: https://opencode.ai/docs/permissions
+
+Manage access to paths outside the working directory using `external_directory`. Home directory expansion (`~` or `$HOME`) can be used in patterns. This example allows all actions under `~/projects/personal/`.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "~/projects/personal/**": "allow"
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Configure Model Providers and Models in opencode.json
+
+Source: https://opencode.ai/docs/config
+
+This JSON snippet configures the LLM providers and specific models to be used by OpenCode. It includes settings for the main model and a 'small_model' for lightweight tasks. Provider-specific options like timeout and cache key settings can also be configured.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {},
+  "model": "anthropic/claude-sonnet-4-5",
+  "small_model": "anthropic/claude-haiku-4-5"
+}
+```
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "anthropic": {
+      "options": {
+        "timeout": 600000,
+        "setCacheKey": true
+      }
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Configure Specialized Agents (JSONC)
+
+Source: https://opencode.ai/docs/config
+
+Defines a 'code-reviewer' agent with specific model, prompt, and tool configurations. It disables file modification tools for review-only purposes. This configuration is typically used in opencode.jsonc files.
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "code-reviewer": {
+      "description": "Reviews code for best practices and potential issues",
+      "model": "anthropic/claude-sonnet-4-5",
+      "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
+      "tools": {
+        "write": false,
+        "edit": false
+      }
+    }
+  }
+}
+```
+
+--------------------------------
+
+### Connect to GitHub Copilot
+
+Source: https://opencode.ai/docs/providers
+
+These commands illustrate the process of connecting OpenCode AI to GitHub Copilot. It involves running a `/connect` command, authorizing through a GitHub device login, and then selecting a model using the `/models` command.
+
+```text
+/connect
+
+https://github.com/login/device
+
+8F43-6FCF
+/models
+```
+
+--------------------------------
+
+### Replace Session Compaction Prompt
+
+Source: https://opencode.ai/docs/plugins
+
+This TypeScript plugin demonstrates how to completely replace the default session compaction prompt using the `experimental.session.compacting` hook by setting the `output.prompt` property. It defines a new prompt structure that guides the LLM to summarize task status, file modifications, blockers, and next steps, ensuring a consistent and structured output for resuming work.
+
+```typescript
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const CustomCompactionPlugin: Plugin = async (ctx) => {
+  return {
+    "experimental.session.compacting": async (input, output) => {
+      // Replace the entire compaction prompt
+      output.prompt = `
+You are generating a continuation prompt for a multi-agent swarm session.
+
+Summarize:
+1. The current task and its status
+2. Which files are being modified and by whom
+3. Any blockers or dependencies between agents
+4. The next steps to complete the work
+
+Format as a structured prompt that a new agent can use to resume work.
+`
+    },
+  }
+}
+```
+
+--------------------------------
+
+### Set Specific Bash Command Permissions (JSON)
+
+Source: https://opencode.ai/docs/agents
+
+Configure permissions for specific bash commands within an agent. This example allows 'grep *' but requires asking for approval before executing 'git push' for the 'build' agent.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "git push": "ask",
+          "grep *":
+```

--- a/dev-docs/packages.yaml
+++ b/dev-docs/packages.yaml
@@ -14,3 +14,18 @@ packages:
     source: https://context7.com/websites/openclaw/llms.txt
     tokens: 10000
     output: dev-docs/openclaw_docs/llms.txt
+  - name: opencode
+    description: OpenCode upstream repository documentation - core usage, configuration, and CLI references
+    source: https://context7.com/anomalyco/opencode/llms.txt
+    tokens: 10000
+    output: dev-docs/opencode/llms.txt
+  - name: opencode_ai
+    description: OpenCode AI docs website - product docs and workflows
+    source: https://context7.com/websites/opencode_ai/llms.txt
+    tokens: 10000
+    output: dev-docs/opencode_ai/llms.txt
+  - name: oh_my_opencode
+    description: Oh My OpenCode plugin collection docs - community plugins and usage guides
+    source: https://context7.com/code-yeongyu/oh-my-opencode/llms.txt
+    tokens: 10000
+    output: dev-docs/oh_my_opencode/llms.txt


### PR DESCRIPTION
## Task

## Add OpenCode Dev-Docs Packages

### Summary

Add 3 new Context7 documentation packages to the dev-docs catalog, fetch and commit their generated [llms.txt](app://-/index.html# "llms.txt") files, and update the dev-docs README so contributors can discover and grep the new sources.

### Public Interfaces / Config Changes

1. Update package catalog in [packages.yaml](app://-/index.html# "/Users/karlchow/Desktop/code/trends/dev-docs/packages.yaml") by adding:
2. name: opencode
[llms.txt](app://-/index.html# "source: https://context7.com/anomalyco/opencode/llms.txt")
tokens: 10000
[llms.txt](app://-/index.html# "output: dev-docs/opencode/llms.txt")
3. name: opencode\_ai
[llms.txt](app://-/index.html# "source: https://context7.com/websites/opencode_ai/llms.txt")
tokens: 10000
[llms.txt](app://-/index.html# "output: dev-docs/opencode_ai/llms.txt")
4. name: oh\_my\_opencode
[llms.txt](app://-/index.html# "source: https://context7.com/code-yeongyu/oh-my-opencode/llms.txt")
tokens: 10000
[llms.txt](app://-/index.html# "output: dev-docs/oh_my_opencode/llms.txt")
5. Keep existing package entries unchanged.

### Implementation Steps

1. Edit [packages.yaml](app://-/index.html# "/Users/karlchow/Desktop/code/trends/dev-docs/packages.yaml") to append the 3 entries above (slug-based naming, as selected).
2. Run make fetch-docs from /Users/karlchow/Desktop/code/trends.
3. Ensure new generated files exist and are committed:
4. [llms.txt](app://-/index.html# "/Users/karlchow/Desktop/code/trends/dev-docs/opencode/llms.txt")
5. [llms.txt](app://-/index.html# "/Users/karlchow/Desktop/code/trends/dev-docs/opencode_ai/llms.txt")
6. [llms.txt](app://-/index.html# "/Users/karlchow/Desktop/code/trends/dev-docs/oh_my_opencode/llms.txt")
7. Update [README.md](app://-/index.html# "/Users/karlchow/Desktop/code/trends/dev-docs/README.md"):
8. Add the 3 new packages under “Included packages”.
9. Add quick grep helper examples for these new docs (OpenCode core/docs/plugin patterns).
10. Do not modify [AGENTS.md](app://-/index.html# "/Users/karlchow/Desktop/code/trends/dev-docs/AGENTS.md") unless wording is explicitly needed (currently generic and sufficient).

### Validation / Test Cases

1. Fetch workflow succeeds:
2. make fetch-docs exits 0.
3. All 3 output files are non-empty (wc -c > 0).
4. Content sanity:
5. Each file starts with package-relevant text (not HTML).
6. None of the 3 new files contains [... not found](app://-/index.html# "Library /... not found").
7. Catalog/readme consistency:
8. Every new package listed in [packages.yaml](app://-/index.html# "packages.yaml") appears in [README.md](app://-/index.html# "README.md") package list with matching output path.
9. Path correctness:
10. Outputs are under [llms.txt](app://-/index.html# "dev-docs/<name>/llms.txt") and match [fetch-docs.sh](app://-/index.html# "fetch-docs.sh") expectations.

### Assumptions and Defaults

1. Scope locked to “Config + Fetch + README”.
2. Naming locked to slug-based (opencode, opencode\_ai, oh\_my\_opencode).
3. Token budget uses project default 10000 per package.
4. Source URLs are stored with explicit [llms.txt](app://-/index.html# "/llms.txt") suffix to match existing convention and avoid ambiguity.

## PR Review Summary
- **What Changed**: Added 3 new documentation packages to the dev-docs catalog: `opencode` (core), `opencode_ai` (workflows), and `oh_my_opencode` (plugins). Updated `packages.yaml` with source URLs, committed the generated `llms.txt` files, and added usage examples to `README.md`.
- **Review Focus**: Verify that the source URLs in `packages.yaml` are accurate and that the committed `llms.txt` files contain valid documentation text (not error messages or HTML 404s).
- **Test Plan**: 
  1. Run `make fetch-docs` and ensure the process exits with code 0.
  2. Validate that `dev-docs/opencode/llms.txt`, `dev-docs/opencode_ai/llms.txt`, and `dev-docs/oh_my_opencode/llms.txt` are non-empty.
  3. Execute the new ripgrep examples from `README.md` to confirm the documentation is searchable.