### PR TITLE
Add new /about page with placeholder text

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import { Header } from '@/components/Header'
 import { ResumesPage } from '@/pages/ResumesPage'
 import { DebugPage } from '@/pages/DebugPage'
+import { AboutPage } from '@/pages/AboutPage'
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
           <Routes>
             <Route path="/" element={<Navigate to="/resumes" replace />} />
             <Route path="/resumes" element={<ResumesPage />} />
+            <Route path="/about" element={<AboutPage />} />
             <Route path="/debug/*" element={<DebugPage />} />
             <Route path="*" element={<Navigate to="/resumes" replace />} />
           </Routes>

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -41,6 +41,17 @@ export function Header() {
             >
               {t('nav.debug')}
             </NavLink>
+            <NavLink
+              to="/about"
+              className={({ isActive }) =>
+                cn(
+                  'transition-colors hover:text-foreground',
+                  isActive ? 'text-foreground' : 'text-muted-foreground'
+                )
+              }
+            >
+              About
+            </NavLink>
           </nav>
         </div>
         <div className="flex items-center gap-3">
@@ -66,6 +77,17 @@ export function Header() {
               }
             >
               {t('nav.debug')}
+            </NavLink>
+            <NavLink
+              to="/about"
+              className={({ isActive }) =>
+                cn(
+                  'transition-colors hover:text-foreground',
+                  isActive ? 'text-foreground' : 'text-muted-foreground'
+                )
+              }
+            >
+              About
             </NavLink>
           </nav>
           <LanguageSwitcher />

--- a/apps/web/src/pages/AboutPage.tsx
+++ b/apps/web/src/pages/AboutPage.tsx
@@ -1,0 +1,8 @@
+export function AboutPage() {
+  return (
+    <div className="rounded-lg border bg-card p-6 text-card-foreground shadow-sm">
+      <h1 className="text-2xl font-semibold">About</h1>
+      <p className="mt-2 text-muted-foreground">Test text</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Task

add /about with test text

## PR Review Summary
- **What Changed:**
  - Added a new `/about` route in `apps/web/src/App.tsx`.
  - Created a new page component `AboutPage.tsx` containing placeholder "Test text".
  - Updated `Header.tsx` to include "About" navigation links in both the desktop and mobile navigation menus.

- **Review Focus:**
  - **Internationalization (i18n):** The "About" label in `Header.tsx` is currently a hardcoded string. Other links use the `t()` function (e.g., `t('nav.debug')`). Consider adding a translation key for consistency.
  - **Layout:** Ensure the padding and card styling in `AboutPage.tsx` align with the visual standards of the existing pages (e.g., `ResumesPage`).

- **Test Plan:**
  - **Routing:** Manually navigate to `/about` to ensure the page renders.
  - **UI Navigation:** Click the "About" link in the header on desktop and verify it navigates correctly and shows the active state.
  - **Mobile:** Toggle the mobile menu and verify the "About" link appears and functions.

- **Follow-ups:**
  - Replace hardcoded "About" and "Test text" with localized strings in the translation files.