### PR TITLE
Add auto-select location from URL param in extension

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -740,17 +740,35 @@ function getAreaItemText(item) {
   return (clone.textContent || '').replace(/\s+/g, ' ').trim();
 }
 
+/**
+ * @param {Element | null | undefined} element
+ * @returns {HTMLElement | null}
+ */
+function asHTMLElement(element) {
+  return element instanceof HTMLElement ? element : null;
+}
+
+/**
+ * @param {ParentNode | null | undefined} container
+ * @param {string} text
+ * @returns {HTMLElement | null}
+ */
 function findAreaItemByText(container, text) {
   if (!container || !text) return null;
   const target = text.replace(/\s+/g, ' ').trim();
   const itemSelector = `${SELECTORS.areaItem}, ${SELECTORS.areaDistrictItem}`;
   const items = container.querySelectorAll(itemSelector);
   for (const item of items) {
-    if (getAreaItemText(item) === target) return item;
+    if (getAreaItemText(item) === target) return asHTMLElement(item);
   }
   return null;
 }
 
+/**
+ * @param {string} blockSelector
+ * @param {{ timeoutMs?: number, itemSelector?: string }} [options]
+ * @returns {Promise<{ block: Element, items: Element[] }>}
+ */
 function waitForAreaItems(blockSelector, { timeoutMs = 5000, itemSelector } = {}) {
   return new Promise((resolve, reject) => {
     let done = false;
@@ -833,7 +851,7 @@ async function autoSelectLocation() {
 
   let modal = document.querySelector(SELECTORS.areaModal);
   if (!isElementVisible(modal)) {
-    const trigger = document.querySelector(SELECTORS.areaTrigger);
+    const trigger = asHTMLElement(document.querySelector(SELECTORS.areaTrigger));
     if (!trigger) {
       setAutoLocationAttributes('failed', location);
       console.warn('🎯 [Auto Location] Trigger not found');
@@ -850,8 +868,8 @@ async function autoSelectLocation() {
   }
 
   const provinceBlock = modal.querySelector(SELECTORS.areaProvinceBlock);
-  const confirmBtn = modal.querySelector(SELECTORS.areaConfirmBtn);
-  const cancelBtn = modal.querySelector(SELECTORS.areaCancelBtn);
+  const confirmBtn = asHTMLElement(modal.querySelector(SELECTORS.areaConfirmBtn));
+  const cancelBtn = asHTMLElement(modal.querySelector(SELECTORS.areaCancelBtn));
   if (!provinceBlock || !confirmBtn || !cancelBtn) {
     setAutoLocationAttributes('failed', location);
     console.warn('🎯 [Auto Location] Missing modal controls');
@@ -913,7 +931,9 @@ async function autoSelectLocation() {
   const provinceItems = Array.from(provinceBlock.querySelectorAll(SELECTORS.areaItem));
   for (const province of provinceItems) {
     if (hotCities && province === hotCities) continue;
-    province.click();
+    const provinceEl = asHTMLElement(province);
+    if (!provinceEl) continue;
+    provinceEl.click();
     await new Promise((resolve) => setTimeout(resolve, 300));
     try {
       if (await tryCityFlow()) return;


### PR DESCRIPTION
## Task

# Phase 1.5 Step 0: Browser Extension — `autoSelectLocation()`

## Goal

Add `autoSelectLocation()` to `content.js` that reads `?location=` from the URL and programmatically clicks through the site's area-selector UI to apply the location filter. The site ignores the URL param for filtering — it only uses it for display — so UI clicks are required.

**File**: `apps/browser-extension/content.js`
**Depends**: none (independent of Steps 1-3)

---

## Site UI Structure (verified via DevTools MCP)

The area selector is a 3-column modal:

```
┌─────────────────────────────────────────────────────────────┐
│  请选择地区 （可多选）  [搜索城市名/区县]                       │
│  已选 0 / 10                                                 │
├──────────────┬──────────────┬───────────────────────────────┤
│ Col 1:       │ Col 2:       │ Col 3:                         │
│ Provinces    │ Cities       │ Districts                      │
│              │              │                                │
│ 热门城市  >  │ (on click)   │ (on city click)               │
│ 直辖市    >  │  广东  ← all │  全东莞 ← all                  │
│ 广东 [1]  >  │  广州        │  莞城区                        │
│ 浙江      >  │  深圳        │  东城区                        │
│ 江苏      >  │  东莞        │  南城区                        │
│ ...          │  ...         │  ...                           │
├──────────────┴──────────────┴───────────────────────────────┤
│                                         [取消]  [确定]       │
└─────────────────────────────────────────────────────────────┘
```

### Key DOM selectors

| Element | Selector |
|---------|----------|
| Trigger (shows "全广东") | `.resume-search-item-search-addre` |
| Modal container | `.area-selector-item-block` |
| Province items (col 1) | `.area-selector-item-block__content__down__blcok:first-child .down__blcok__select` |
| City items (col 2) | `.area-selector-item-block__content__down__blcok:nth-child(2) .down__blcok__select` |
| District items (col 3) | `.area-selector-item-block__content__down__blcok:nth-child(3) .down__block__big-select__block` |
| Confirm button | `.area-selector-item-block__footer .button-block.blue` |
| Cancel button | `.area-selector-item-block__footer .button-block:not(.blue)` |
| Selected count | `.content__up__number__select` |
| Active province | `.down__blcok__select.active` |

### Interaction flow

- Click **province** in col 1 → gets `active hover` class, col 2 populates with cities
- Click **city** in col 2 → col 3 populates with districts (first item = "全X" = select all)
- Click **district/全X** in col 3 → adds to selection, counter increments
- Province name appears as first item in col 2 (= "select all cities in this province")
- "热门城市" in col 1 lists common cities: 东莞, 江门, 佛山, 中山, 深圳, 广州, 惠州...

---

## Implementation

### 1. Add SELECTORS (top of file, in `SELECTORS` object)

```js
// Area selector (location filter modal)
areaTrigger: '.resume-search-item-search-addre',
areaModal: '.area-selector-item-block',
areaProvinceBlock: '.area-selector-item-block__content__down__blcok:first-child',
areaCityBlock: '.area-selector-item-block__content__down__blcok:nth-child(2)',
areaDistrictBlock: '.area-selector-item-block__content__down__blcok:nth-child(3)',
areaItem: '.down__blcok__select',
areaDistrictItem: '.down__block__big-select__block',
areaConfirmBtn: '.area-selector-item-block__footer .button-block.blue',
areaCancelBtn: '.area-selector-item-block__footer .button-block:not(.blue)',
areaSelectedCount: '.content__up__number__select',
```

### 2. Add helper: `waitForAreaModal()`

Wait for `.area-selector-item-block` to become visible (`display !== 'none'`). Follow the same pattern as `waitForSearchElements()` (line 654-684): MutationObserver + interval polling with timeout.

### 3. Add helper: `findAreaItemByText(container, text)`

Search `.down__blcok__select` items within a container, match `<span>` textContent (trimmed, ignoring `.select-num` children) against the target text. Returns the matching DOM element or null.

### 4. Add helper: `waitForAreaItems(blockSelector, { timeoutMs })`

Wait for at least 1 `.down__blcok__select` item to appear in the given block. Needed because column 2/3 populate asynchronously after clicks.

### 5. Add `autoSelectLocation()` — main function

```
async function autoSelectLocation() {
  const params = new URLSearchParams(window.location.search || '');
  const location = (params.get('location') || '').trim();
  if (!location) {
    setAutoLocationAttributes('skipped', '');
    return;
  }

  // 1. Open the area selector modal
  click .resume-search-item-search-addre
  await waitForAreaModal()

  // 2. Try to match as province (column 1)
  const provinceMatch = findAreaItemByText(provinceBlock, location)
  if (provinceMatch) {
    // Province-level: click province in col 1, then click province name
    // (first item) in col 2 = "select all cities"
    provinceMatch.click()
    await waitForAreaItems(cityBlock)
    const selectAllCity = findAreaItemByText(cityBlock, location)
    if (selectAllCity) selectAllCity.click()
    // Wait for district block to show, then click "全{province}"
    await waitForAreaItems(districtBlock)
    const selectAllDistrict = findAreaItemByText(districtBlock, '全' + location)
        || districtBlock.querySelector(areaDistrictItem)  // first item
    if (selectAllDistrict) selectAllDistrict.click()
    // Click confirm
    confirmBtn.click()
    setAutoLocationAttributes('done', location)
    return
  }

  // 3. Not a province — search for city
  //    Try "热门城市" first (most common cities)
  const hotCities = findAreaItemByText(provinceBlock, '热门城市')
  if (hotCities) {
    hotCities.click()
    await waitForAreaItems(cityBlock)
    const cityMatch = findAreaItemByText(cityBlock, location)
    if (cityMatch) {
      cityMatch.click()
      await waitForAreaItems(districtBlock)
      // Click "全{city}" to select all districts
      const selectAll = findAreaItemByText(districtBlock, '全' + location)
          || districtBlock.querySelector(areaDistrictItem)
      if (selectAll) selectAll.click()
      confirmBtn.click()
      setAutoLocationAttributes('done', location)
      return
    }
  }

  // 4. Fallback: scan provinces one by one
  const provinceItems = [...provinceBlock.querySelectorAll(areaItem)]
  for (const province of provinceItems) {
    if (province === hotCities) continue  // already tried
    province.click()
    await sleep(300)
    const cityMatch = findAreaItemByText(cityBlock, location)
    if (cityMatch) {
      cityMatch.click()
      await waitForAreaItems(districtBlock)
      const selectAll = findAreaItemByText(districtBlock, '全' + location)
          || districtBlock.querySelector(areaDistrictItem)
      if (selectAll) selectAll.click()
      confirmBtn.click()
      setAutoLocationAttributes('done', location)
      return
    }
  }

  // 5. Not found — cancel and log warning
  cancelBtn.click()
  setAutoLocationAttributes('failed', location)
  console.warn('[Auto Location] Location not found:', location)
}
```

### 6. Add `setAutoLocationAttributes(status, location)`

Follow the pattern of `setAutoSearchAttributes()` (line 686-697):

```js
function setAutoLocationAttributes(status, location) {
  try {
    document.documentElement.setAttribute('data-tr-auto-location', status);
    if (location) {
      document.documentElement.setAttribute('data-tr-location-value', location);
    } else {
      document.documentElement.removeAttribute('data-tr-location-value');
    }
  } catch { /* ignore */ }
}
```

### 7. Add `autoLocation` to external accessor `status()` (line 891)

Add to the returned status object:

```js
autoLocation: document.documentElement.getAttribute('data-tr-auto-location') || '',
```

### 8. Wire into startup sequence (line 918-922)

Current:

```js
autoSearchFromUrl()
  .catch(...)
  .finally(() => { runAutoExportIfEnabled(); });
```

New — run location selection **before** search, since location affects search results:

```js
autoSelectLocation()
  .catch((error) => console.warn('🎯 [Auto Location] Failed:', error))
  .then(() => autoSearchFromUrl())
  .catch((error) => console.warn('🎯 [Auto Search] Failed:', error))
  .finally(() => { runAutoExportIfEnabled(); });
```

---

## Patterns to Reuse

| Existing function | Reuse for |
|-------------------|-----------|
| `waitForSearchElements()` (line 654) | Pattern for `waitForAreaModal()` — MutationObserver + interval |
| `waitForResumeCards()` (line 592) | Pattern for `waitForAreaItems()` |
| `setAutoSearchAttributes()` (line 686) | Pattern for `setAutoLocationAttributes()` |
| `autoSearchFromUrl()` (line 710) | Overall flow pattern for `autoSelectLocation()` |

---

## Verification

1. **Navigate** to `https://hr.job5156.com/search?location=广东` via Chrome DevTools MCP
2. **Take snapshot** — confirm `data-tr-auto-location="done"` on `<html>` element
3. **Check** that the trigger displays the selected location (e.g., "全广东")
4. **Check** that search results are filtered (resume locations should be in 广东)
5. **Test city-level**: `?location=东莞` — should find 东莞 via 热门城市 or 广东 province scan
6. **Test no location**: `?keyword=销售` only — `data-tr-auto-location="skipped"`, no modal opened
7. **Test invalid**: `?location=INVALID` — `data-tr-auto-location="failed"`, modal cancelled
8. **Test combined**: `?keyword=车床&location=东莞` — both auto-location and auto-search trigger in sequence
9. **Verify CDP access**: `window.__TR_RESUME_DATA__.status().autoLocation` returns `"done"`

## PR Review Summary
- **What Changed**:
  - Added `autoSelectLocation()` to `content.js` to programmatically apply location filters since the site ignores URL parameters for actual filtering.
  - Added a suite of selectors for the 3-column area selector modal (provinces, cities, districts).
  - Implemented async helpers: `waitForAreaModal`, `waitForAreaItems`, and `findAreaItemByText` to handle the modal's multi-step, asynchronous population.
  - Updated the startup sequence to execute `autoSelectLocation` before `autoSearchFromUrl`, ensuring search results are correctly scoped.
  - Exposed operation status via `data-tr-auto-location` attributes and the `status()` helper.

- **Review Focus**:
  - **Timing & Timeouts**: Verify if the 5-second `waitForAreaItems` and 8-second `waitForAreaModal` timeouts are appropriate for standard user latency.
  - **Fallback Efficiency**: The brute-force province scan (Step 4) iterates through provinces if a city isn't in "Hot Cities." Ensure the 300ms sleep between clicks provides enough stability for the DOM to update.
  - **Selection Logic**: The `selectAllDistrictAndConfirm` logic uses a prefix match (`全` + location); ensure this aligns with the site's naming convention for all possible regions.

- **Test Plan**:
  - **Province Level**: Navigate to `?location=广东` and verify selection of all cities in the province.
  - **City Level**: Navigate to `?location=东莞` and verify selection via "Hot Cities" or province scan.
  - **Error Handling**: Test with `?location=NonExistent` to ensure the modal closes and the status is set to `failed` without breaking the `autoSearch` sequence.
  - **Sequential Flow**: Use `?location=深圳&keyword=Python` to verify that location is set before search results are fetched.