### PR TITLE
Add location parameter support to refresh-sample pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ refresh-sample:
 	@KEYWORD="$(or $(KEYWORD),销售)" SAMPLE="$(or $(SAMPLE),sample-initial)" \
 	CDP_PORT="$(or $(CDP_PORT),9222)" \
 	ALLOW_EMPTY="$(ALLOW_EMPTY)" \
+	LOCATION="$(LOCATION)" \
 	./scripts/refresh-sample.sh
 
 # Show instructions for refreshing resume sample data

--- a/scripts/refresh-sample.py
+++ b/scripts/refresh-sample.py
@@ -56,8 +56,10 @@ def sanitize_sample_name(value: str) -> str:
     return cleaned[:80]
 
 
-def build_search_url(keyword: str) -> str:
+def build_search_url(keyword: str, location: str = "") -> str:
     params = {"keyword": keyword}
+    if location:
+        params["location"] = location
     return "https://hr.job5156.com/search?" + urllib.parse.urlencode(params)
 
 
@@ -244,6 +246,7 @@ async def wait_for(
 async def run():
     parser = argparse.ArgumentParser()
     parser.add_argument("--keyword", default=DEFAULT_KEYWORD, help="Search keyword")
+    parser.add_argument("--location", default="", help="Search location filter (e.g. 广东)")
     parser.add_argument("--sample", default=DEFAULT_SAMPLE, help="Sample file name")
     parser.add_argument("--port", type=int, default=CDP_PORT, help="CDP port")
     parser.add_argument(
@@ -259,7 +262,7 @@ async def run():
     if not sample_name:
         sample_name = "sample"
 
-    search_url = build_search_url(args.keyword)
+    search_url = build_search_url(args.keyword, args.location)
 
     try:
         targets = fetch_json(f"http://127.0.0.1:{args.port}/json")

--- a/scripts/refresh-sample.sh
+++ b/scripts/refresh-sample.sh
@@ -5,6 +5,12 @@ KEYWORD="${KEYWORD:-销售}"
 SAMPLE="${SAMPLE:-sample-initial}"
 CDP_PORT="${CDP_PORT:-9222}"
 ALLOW_EMPTY="${ALLOW_EMPTY:-}"
+LOCATION="${LOCATION:-}"
+
+LOCATION_ARGS=()
+if [[ -n "${LOCATION}" ]]; then
+  LOCATION_ARGS=(--location "${LOCATION}")
+fi
 
 if ! curl -fsS "http://127.0.0.1:${CDP_PORT}/json" >/dev/null 2>&1; then
   echo "Error: Chrome not running with remote debugging on port ${CDP_PORT}."
@@ -17,4 +23,5 @@ exec uv run python scripts/refresh-sample.py \
   --keyword "${KEYWORD}" \
   --sample "${SAMPLE}" \
   --port "${CDP_PORT}" \
-  ${ALLOW_EMPTY:+--allow-empty}
+  ${ALLOW_EMPTY:+--allow-empty} \
+  "${LOCATION_ARGS[@]}"


### PR DESCRIPTION
## Task

# Phase 1.5 Step 1: Location-Filtered Resume Collection (Shell + Python + Makefile)

## Goal

Add `LOCATION` parameter support through the full `refresh-sample` pipeline: Makefile -> shell script -> Python script -> search URL. This enables location-filtered resume collection (e.g., `make refresh-sample LOCATION=广东`).

> **Note**: URL `?location=` alone doesn't trigger UI filtering on job5156. Step 0 (Browser Extension `autoSelectLocation()`) handles the actual UI click. This step ensures the parameter flows through the pipeline and into metadata.

---

## Changes

### File 1: `scripts/refresh-sample.sh`

**Current**: Supports `KEYWORD`, `SAMPLE`, `CDP_PORT`, `ALLOW_EMPTY` env vars.
**Change**: Add `LOCATION` env var, pass conditionally to Python.

```diff
 KEYWORD="${KEYWORD:-销售}"
 SAMPLE="${SAMPLE:-sample-initial}"
 CDP_PORT="${CDP_PORT:-9222}"
 ALLOW_EMPTY="${ALLOW_EMPTY:-}"
+LOCATION="${LOCATION:-}"

 ...

 exec uv run python scripts/refresh-sample.py \
   --keyword "${KEYWORD}" \
   --sample "${SAMPLE}" \
   --port "${CDP_PORT}" \
-  ${ALLOW_EMPTY:+--allow-empty}
+  ${ALLOW_EMPTY:+--allow-empty} \
+  ${LOCATION:+--location "${LOCATION}"}
```

### File 2: `scripts/refresh-sample.py`

**Changes**:

1. **CLI arg** (after line 253, in `run()`): Add `--location` argument

```python
parser.add_argument("--location", default="", help="Search location filter (e.g. 广东)")
```

2. **`build_search_url()`&#32;signature** (line 59-61): Accept optional location

```python
def build_search_url(keyword: str, location: str = "") -> str:
    params = {"keyword": keyword}
    if location:
        params["location"] = location
    return "https://hr.job5156.com/search?" + urllib.parse.urlencode(params)
```

3. **Call site** (line 262): Pass location

```python
search_url = build_search_url(args.keyword, args.location)
```

No changes needed to `build_metadata()` - it already extracts `location` from the URL query string at line 68.

### File 3: `Makefile` (lines 180-184)

**Change**: Add `LOCATION` pass-through.

```diff
 refresh-sample:
 	@KEYWORD="$(or $(KEYWORD),销售)" SAMPLE="$(or $(SAMPLE),sample-initial)" \
 	CDP_PORT="$(or $(CDP_PORT),9222)" \
 	ALLOW_EMPTY="$(ALLOW_EMPTY)" \
+	LOCATION="$(LOCATION)" \
 	./scripts/refresh-sample.sh
```

Note: `LOCATION` uses `$(LOCATION)` (not `$(or ...)`) because the default should be empty (no location filter), unlike `KEYWORD` which defaults to `销售`.

---

## Verification

1. **No regression** - `make refresh-sample` works unchanged (no location in URL)
2. **With location** - `make refresh-sample LOCATION=广东` produces URL `https://hr.job5156.com/search?keyword=销售&location=广东`
3. **Direct script** - `LOCATION=东莞 KEYWORD=车床 ./scripts/refresh-sample.sh` passes both params
4. **Python help** - `uv run python scripts/refresh-sample.py --help` shows `--location` argument
5. **Metadata** - Output JSON `searchCriteria.location` field is populated when location is provided

## PR Review Summary
- **What Changed**:
  - **Makefile**: Added `LOCATION` pass-through to the `refresh-sample` command.
  - **scripts/refresh-sample.sh**: Added `LOCATION` environment variable support; implemented conditional argument passing to the Python script using an array (`LOCATION_ARGS`) to ensure clean CLI execution.
  - **scripts/refresh-sample.py**: 
    - Added `--location` to `argparse`.
    - Updated `build_search_url` to conditionally append the `location` parameter to the query string using `urllib.parse.urlencode`.
    - Updated the main `run()` loop to pass the new argument into the URL builder.

- **Review Focus**:
  - **URL Encoding**: Verify that Chinese characters in the `LOCATION` parameter (e.g., '广东') are correctly encoded in the final URL.
  - **Empty Parameters**: Ensure that if `LOCATION` is not provided, the URL remains identical to the previous version without an empty `&location=` parameter.
  - **Shell Robustness**: The shell script uses `"${LOCATION_ARGS[@]}"`, which is the correct way to handle optional arguments in Bash/Zsh.

- **Test Plan**:
  - **No Regression**: Run `make refresh-sample` and check that the URL remains `https://hr.job5156.com/search?keyword=销售`.
  - **Filtering**: Run `make refresh-sample LOCATION=广东` and verify the generated URL includes the encoded location.
  - **Direct Script**: Execute `LOCATION=东莞 scripts/refresh-sample.sh` to ensure environment variable detection works outside of the Makefile.
  - **Help Output**: Run `uv run python scripts/refresh-sample.py --help` to verify the new CLI documentation.