### PR TITLE
Update make dev for debug alignment and bun/npm compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,14 @@
 # Development (Full Experience)
 # =============================================================================
 
-# Start all available services (MCP server + crawler + apps/*)
 # Start all available services (MCP server + crawler + apps/* + Convex)
 dev:
 	@chmod +x scripts/sync-convex-env.sh
-	@./scripts/sync-convex-env.sh
-	@# Run convex dev in background or parallel? dev.sh handles procfile-like behavior?
-	@# Assuming dev.sh runs a procfile or similar. Let's add it there or just run it here if simple.
-	@# Actually, let's just delegate to dev.sh and add convex there if possible, 
-	@# BUT user asked to add steps in dev script 'make dev'.
-	@# Let's verify dev.sh content. For now, just running dev.sh.
+	@if [ -f "packages/convex/.env.local" ] || [ -f ".env.local" ]; then \
+		./scripts/sync-convex-env.sh; \
+	else \
+		echo "Skipping Convex env sync (no Convex .env.local found yet)"; \
+	fi
 	./scripts/dev.sh $(ARGS)
 
 # Stop/clean any stale development services and ports


### PR DESCRIPTION
## Task

# Refresh Plan: make dev Debug Alignment + npm/bun Convention Compliance

  ## Summary

  Update the make dev orchestration plan so it remains focused on your original issue
  (aligned debug output and clean shutdown) while conforming to the refreshed project
  convention:

1. Local dev should prefer bun/bunx with fallback to npm/npx.
2. Service status output should reflect only actually started services.
3. Ctrl+C shutdown should avoid expected watcher-noise in terminal output.
4. No CI workflow changes are included in this task scope.

  ## Current Findings Driving This Plan

1. Services running is currently directory-driven, so scoped runs (for example --mcp-
     only) still print Worker/API/Web lines.
2. Shutdown order/labels are not guaranteed to match startup display because
     associative-array iteration is unordered.
3. API watcher shutdown emits expected signal-noise (tsx force-kill + script exit 130)
     that looks like a real error.
4. Local dev command usage in /Users/karlchow/Desktop/code/trends/scripts/dev.sh is
     currently npm-first for API/Web and not aligned with the new bun-first local
     convention in /Users/karlchow/Desktop/code/trends/AGENTS.md.

  ## Public Interface / Output Contract Changes

1. Console status block for ./scripts/dev.sh and make dev will be standardized to
     show:

    - service label
    - URL (- for non-HTTP services)
    - PID
    - log path

2. Services running will list only started services.
3. Startup and shutdown logs will use the same fixed service order and labels.
4. No API endpoint/schema/type changes.

  ## Implementation Tasks

  ### Task 1: Add Service Metadata Model for Deterministic Output

  Files: /Users/karlchow/Desktop/code/trends/scripts/dev.sh
  Depends: none
  Conflict Risk: /Users/karlchow/Desktop/code/trends/scripts/dev.sh
  Verification: ./scripts/dev.sh --mcp-only, ./scripts/dev.sh
  Implementation:

1. Introduce a single service metadata mapping and order array: convex, mcp, worker,
     scraper, api, web.
2. Add helper functions for service display name, URL, and log file path.
3. Use this shared metadata in both startup status and cleanup logging so output
     cannot drift.

  ### Task 2: Make Status Block Started-Only and Debug-Useful

  Files: /Users/karlchow/Desktop/code/trends/scripts/dev.sh
  Depends: Task 1
  Conflict Risk: /Users/karlchow/Desktop/code/trends/scripts/dev.sh
  Verification: ./scripts/dev.sh --mcp-only, make dev
  Implementation:

1. Rewrite print\_status() to iterate ordered services and include only services with a
     live PID in SERVICE\_PIDS.
2. Format each line as Name | URL | PID | log.
3. Include scraper with URL - rather than hiding it.

  ### Task 3: Apply bun-first Local Runner with npm Fallback

  Files: /Users/karlchow/Desktop/code/trends/scripts/dev.sh
  Depends: none
  Conflict Risk: /Users/karlchow/Desktop/code/trends/scripts/dev.sh
  Verification: make dev, inspect startup lines and logs/api.log/logs/web.log
  Implementation:

1. Add shell helpers to choose local JS runner:

    - bun available -> use bun run (or bunx where relevant).
    - otherwise -> use npm run --silent (or npx as needed).

2. Update start\_api() and start\_web() launch commands to follow this bun-first/
     fallback pattern.
3. Keep existing behavior of Convex startup (already bunx-first) and preserve current
     ports/env handling.

  ### Task 4: Normalize Expected Ctrl+C Watcher Noise

  Files: /Users/karlchow/Desktop/code/trends/scripts/dev.sh
  Depends: Task 1
  Conflict Risk: /Users/karlchow/Desktop/code/trends/scripts/dev.sh
  Verification: make dev then Ctrl+C; inspect terminal and /Users/karlchow/Desktop/code/
  trends/logs/api.log
  Implementation:

1. Keep raw API process output in log files.
2. Filter known expected shutdown-only noise from terminal stream (for example tsx
     “Previous process hasn’t exited…” and script exit 130 lines) so Ctrl+C reads as
     graceful.
3. Do not suppress unexpected errors; only match explicit known benign shutdown
     patterns.

  ## Test Cases and Scenarios

1. Default full run:

    - make dev
    - Confirm status includes only actually started services.
    - Confirm each line shows URL/PID/log.

2. Scoped run:

    - ./scripts/dev.sh --mcp-only
    - Confirm only MCP appears in status.

3. Graceful shutdown:

    - Ctrl+C during full run.
    - Confirm ordered stop messages and clean terminal output without false API
        failure block.

4. Log integrity:

    - Verify expected shutdown details are still present in /Users/karlchow/Desktop/
        code/trends/logs/api.log.

5. bun fallback behavior:

    - With bun installed, API/Web launched via bun.
    - Without bun, npm fallback path remains functional.

  ## Assumptions and Defaults

1. Scope is make dev orchestration only (no workflow/CI edits in this task).
2. CI is already aligned with Node 22 and npm-only behavior; this plan does not
     revisit CI.
3. Exit code 130 from dev watchers on Ctrl+C is treated as expected behavior, not a
     runtime failure.
4. Debug output should prioritize operational clarity over full raw subprocess
     verbosity in terminal.