### PR TITLE
# Fix: Convex Dev Server Startup on Remote Linux (cmux workspace)

##...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Start all available services (MCP server + crawler + apps/* + Convex)
 dev:
 	@chmod +x scripts/sync-convex-env.sh
-	@if [ -f "packages/convex/.env.local" ] || [ -f ".env.local" ]; then \
+	@if [ -f "packages/convex/.env.local" ] || [ -f ".env.local" ] || [ -n "$${CONVEX_URL:-}" ]; then \
 		./scripts/sync-convex-env.sh; \
 	else \
 		echo "Skipping Convex env sync (no Convex .env.local found yet)"; \

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -585,6 +585,15 @@ start_scraper() {
 # Start Convex backend
 start_convex() {
     local port="${CONVEX_PORT:-3210}" 
+
+    # If CONVEX_DEPLOYMENT is set in env but .env.local doesn't exist,
+    # generate it so convex dev can start non-interactively.
+    local convex_env_local="$PROJECT_ROOT/packages/convex/.env.local"
+    if [ -n "${CONVEX_DEPLOYMENT:-}" ] && [ ! -f "$convex_env_local" ]; then
+        log "CONVEX" "$CYAN" "Generating $convex_env_local from system environment"
+        mkdir -p "$(dirname "$convex_env_local")"
+        echo "CONVEX_DEPLOYMENT=$CONVEX_DEPLOYMENT" > "$convex_env_local"
+    fi
     
     if [ -d "$PROJECT_ROOT/packages/convex" ]; then
         if ! check_port "$port"; then

--- a/scripts/sync-convex-env.sh
+++ b/scripts/sync-convex-env.sh
@@ -15,19 +15,23 @@ CONVEX_ENV=""
 if [ -f "$CONVEX_ENV_PACKAGE" ]; then
     CONVEX_ENV="$CONVEX_ENV_PACKAGE"
 elif [ -f "$CONVEX_ENV_ROOT" ]; then
-    # Fallback for users who ran `convex dev` from repo root.
     CONVEX_ENV="$CONVEX_ENV_ROOT"
+fi
+
+# Extract CONVEX_URL: prefer .env.local file, fall back to system environment
+if [ -n "$CONVEX_ENV" ]; then
+    CONVEX_URL="$(grep "^CONVEX_URL=" "$CONVEX_ENV" | cut -d= -f2- || true)"
+elif [ -n "${CONVEX_URL:-}" ]; then
+    echo "Using CONVEX_URL from system environment"
 else
-    echo "Error: Convex .env.local not found."
+    echo "Error: Convex .env.local not found and CONVEX_URL not set in environment."
     echo "Checked: $CONVEX_ENV_PACKAGE and $CONVEX_ENV_ROOT"
-    echo "Run 'bunx convex dev' in '$PROJECT_ROOT/packages/convex' first."
+    echo "Set CONVEX_URL or run 'bunx convex dev' in '$PROJECT_ROOT/packages/convex' first."
     exit 1
 fi
 
-# Extract CONVEX_URL
-CONVEX_URL="$(grep "^CONVEX_URL=" "$CONVEX_ENV" | cut -d= -f2- || true)"
 if [ -z "$CONVEX_URL" ] || [ "$CONVEX_URL" = "null" ]; then
-    echo "Error: valid CONVEX_URL not found in $CONVEX_ENV"
+    echo "Error: valid CONVEX_URL not found"
     exit 1
 fi
 
@@ -41,4 +45,8 @@ else
     echo "VITE_CONVEX_URL=$CONVEX_URL" >> "$WEB_ENV"
 fi
 
-echo "Synced VITE_CONVEX_URL to $WEB_ENV (from $CONVEX_ENV)"
+if [ -n "$CONVEX_ENV" ]; then
+    echo "Synced VITE_CONVEX_URL to $WEB_ENV (from $CONVEX_ENV)"
+else
+    echo "Synced VITE_CONVEX_URL to $WEB_ENV (from system environment)"
+fi


### PR DESCRIPTION
## Task

# Fix: Convex Dev Server Startup on Remote Linux (cmux workspace)

## Problem

On a remote cmux workspace with no `.env.local` files (env vars are system-level), `make dev` fails because:

1. `convex dev` prompts for interactive login → fails with "Cannot prompt for input in non-interactive terminals"
2. `sync-convex-env.sh` only reads from `.env.local` files → fails with "Convex .env.local not found"
3. Downstream services (scraper, web frontend) can't get `CONVEX_URL`

## Required System Env Vars on Remote

The user currently only sets `.env` vars (AI/Telegram). They also need:

| Env Var | Value | Purpose |
|---------|-------|---------|
| `CONVEX_DEPLOYMENT` | `anonymous:anonymous-trends` | Tells `convex dev` which deployment to use (skips login/project setup prompt) |

`CONVEX_URL` and `CONVEX_SITE_URL` are NOT needed as system env vars — `convex dev` generates them when it starts.

## Implementation (3 files)

### Task 1: `scripts/dev.sh` — Generate `.env.local` from system env before starting `convex dev`

**File:** `scripts/dev.sh` (lines 586-617, `start_convex()`)
**Depends:** none

Insert after `local port="${CONVEX_PORT:-3210}"` (line 587), before the `if [ -d ... ]` check:

```bash
    # If CONVEX_DEPLOYMENT is set in env but .env.local doesn't exist,
    # generate it so convex dev can start non-interactively.
    local convex_env_local="$PROJECT_ROOT/packages/convex/.env.local"
    if [ -n "${CONVEX_DEPLOYMENT:-}" ] && [ ! -f "$convex_env_local" ]; then
        log "CONVEX" "$CYAN" "Generating $convex_env_local from system environment"
        mkdir -p "$(dirname "$convex_env_local")"
        echo "CONVEX_DEPLOYMENT=$CONVEX_DEPLOYMENT" > "$convex_env_local"
    fi
```

This creates the minimum `.env.local` needed for `convex dev` to skip the interactive setup wizard. After `convex dev` starts, it will append `CONVEX_URL` and `CONVEX_SITE_URL` to the file itself.

### Task 2: `scripts/sync-convex-env.sh` — Fall back to system `CONVEX_URL` env var

**File:** `scripts/sync-convex-env.sh` (lines 14-32, 44)
**Depends:** none

Replace lines 14-32 (the `.env.local` detection + CONVEX\_URL extraction) with:

```bash
CONVEX_ENV=""
if [ -f "$CONVEX_ENV_PACKAGE" ]; then
    CONVEX_ENV="$CONVEX_ENV_PACKAGE"
elif [ -f "$CONVEX_ENV_ROOT" ]; then
    CONVEX_ENV="$CONVEX_ENV_ROOT"
fi

# Extract CONVEX_URL: prefer .env.local file, fall back to system environment
if [ -n "$CONVEX_ENV" ]; then
    CONVEX_URL="$(grep "^CONVEX_URL=" "$CONVEX_ENV" | cut -d= -f2- || true)"
elif [ -n "${CONVEX_URL:-}" ]; then
    echo "Using CONVEX_URL from system environment"
else
    echo "Error: Convex .env.local not found and CONVEX_URL not set in environment."
    echo "Checked: $CONVEX_ENV_PACKAGE and $CONVEX_ENV_ROOT"
    echo "Set CONVEX_URL or run 'bunx convex dev' in '$PROJECT_ROOT/packages/convex' first."
    exit 1
fi

if [ -z "$CONVEX_URL" ] || [ "$CONVEX_URL" = "null" ]; then
    echo "Error: valid CONVEX_URL not found"
    exit 1
fi
```

Update the final echo (line 44) to show the source:

```bash
if [ -n "$CONVEX_ENV" ]; then
    echo "Synced VITE_CONVEX_URL to $WEB_ENV (from $CONVEX_ENV)"
else
    echo "Synced VITE_CONVEX_URL to $WEB_ENV (from system environment)"
fi
```

### Task 3: `Makefile` — Trigger env sync when `CONVEX_URL` is in system env

**File:** `Makefile` (lines 21-25)
**Depends:** Task 2

Change the condition to also trigger when `CONVEX_URL` is set:

```makefile
	@if [ -f "packages/convex/.env.local" ] || [ -f ".env.local" ] || [ -n "$${CONVEX_URL:-}" ]; then \
```

## Expected Flow on Remote (after fix)

```
1. User sets: CONVEX_DEPLOYMENT=anonymous:anonymous-trends (system env)
2. make dev →
   a. Makefile: no .env.local, no CONVEX_URL yet → skips sync (correct)
   b. dev.sh start_convex():
      - Sees CONVEX_DEPLOYMENT in env, no .env.local → generates packages/convex/.env.local
      - Runs `convex dev` which reads .env.local → starts without prompting
      - convex dev writes CONVEX_URL to .env.local
      - sync-convex-env.sh runs → reads CONVEX_URL from .env.local → writes apps/web/.env.local
   c. Scraper, web, worker all get CONVEX_URL from their respective sources
```

## Backward Compatibility

- **Local dev with existing&#32;`.env.local`**: No behavior change. `CONVEX_DEPLOYMENT` not in system env, `.env.local` already exists → existing flow unchanged.
- **Remote with system env**: New path generates `.env.local` and enables non-interactive `convex dev` startup.

## Verification

1. Remove `packages/convex/.env.local` and `apps/web/.env.local`
2. Set `CONVEX_DEPLOYMENT=anonymous:anonymous-trends` as env var
3. Run `make dev`
4. Verify: no interactive prompt, Convex starts, `packages/convex/.env.local` is generated, `apps/web/.env.local` gets `VITE_CONVEX_URL`
5. Test on actual cmux workspace

## PR Review Summary
- What Changed:
  - **scripts/dev.sh**: Modified the `start_convex()` function to automatically generate `packages/convex/.env.local` with `CONVEX_DEPLOYMENT` from the system environment if the file does not exist. This enables `convex dev` to start non-interactively on remote environments.
  - **scripts/sync-convex-env.sh**: Updated the script to extract `CONVEX_URL` by first checking `.env.local` files and then falling back to the system environment's `CONVEX_URL` variable. Improved error messages and the final sync message now indicates the source of `CONVEX_URL`.
  - **Makefile**: The `dev` target's condition for triggering `sync-convex-env.sh` was expanded to also check if `CONVEX_URL` is set in the system environment, in addition to existing `.env.local` files.
  - These changes address the issue where `make dev` failed on remote Linux cmux workspaces due to `convex dev` prompting for login and downstream services not finding `CONVEX_URL` when environment variables are set system-wide rather than in `.env.local` files.
- Review Focus:
  - Verify that the automatic generation of `packages/convex/.env.local` in `scripts/dev.sh` correctly handles different `CONVEX_DEPLOYMENT` values and directory creation.
  - Confirm the fallback logic in `scripts/sync-convex-env.sh` for `CONVEX_URL` extraction works reliably, especially if `CONVEX_URL` might be partially set or empty in the system environment.
  - Ensure the `Makefile` condition change does not introduce unintended side effects when `CONVEX_URL` is present in the system environment but `convex dev` has not yet started to populate `.env.local`.
- Test Plan:
  - Remove `packages/convex/.env.local` and `apps/web/.env.local` from your project.
  - Set `CONVEX_DEPLOYMENT=anonymous:anonymous-trends` as a system environment variable.
  - Run `make dev`.
  - Verify the following:
    - No interactive prompt appears from `convex dev`.
    - The Convex service starts successfully.
    - `packages/convex/.env.local` is generated and contains both `CONVEX_DEPLOYMENT` and `CONVEX_URL`.
    - `apps/web/.env.local` is created or updated with `VITE_CONVEX_URL`.