### PR TITLE
Use namespaced worker port to avoid cmux conflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ dev-api:
 # Start FastAPI worker REST API only (port 8000)
 dev-api-worker:
 	@if [ -d "apps/worker" ]; then \
-		uv run uvicorn apps.worker.api:app --reload --port 8000; \
+		uv run uvicorn apps.worker.api:app --reload --port $${TRENDS_WORKER_PORT:-8000}; \
 	else \
 		echo "apps/worker not found. Create it with Milestone 1 (FastAPI Wrapper)"; \
 		exit 1; \
@@ -353,7 +353,7 @@ help:
 	@echo "Environment Variables:"
 	@echo "  ENV_FILE       Path to .env file (default: .env)"
 	@echo "  MCP_PORT       MCP server port (default: 3333)"
-	@echo "  WORKER_PORT    FastAPI worker port (default: 8000)"
+	@echo "  TRENDS_WORKER_PORT FastAPI worker port (default: 8000)"
 	@echo "  API_PORT       BFF API port (default: 3000)"
 	@echo "  WEB_PORT       Web frontend port (default: 5173)"
 	@echo "  CDP_PORT       Chrome DevTools port (default: 9222)"

--- a/scripts/clean-dev.sh
+++ b/scripts/clean-dev.sh
@@ -7,7 +7,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 PORTS=(
   "${CONVEX_PORT:-3210}"
   "${MCP_PORT:-3333}"
-  "${WORKER_PORT:-8000}"
+  "${TRENDS_WORKER_PORT:-8000}"
   "${API_PORT:-3000}"
   "${WEB_PORT:-5173}"
 )
@@ -134,4 +134,4 @@ if [ ${#REMAINING_PIDS[@]} -gt 0 ]; then
 fi
 
 echo "Done. Current listeners on dev ports:"
-lsof -nP -iTCP:"${CONVEX_PORT:-3210}" -iTCP:"${MCP_PORT:-3333}" -iTCP:"${WORKER_PORT:-8000}" -iTCP:"${API_PORT:-3000}" -iTCP:"${WEB_PORT:-5173}" -sTCP:LISTEN 2>/dev/null || true
+lsof -nP -iTCP:"${CONVEX_PORT:-3210}" -iTCP:"${MCP_PORT:-3333}" -iTCP:"${TRENDS_WORKER_PORT:-8000}" -iTCP:"${API_PORT:-3000}" -iTCP:"${WEB_PORT:-5173}" -sTCP:LISTEN 2>/dev/null || true

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -183,7 +183,7 @@ service_port() {
     case "$service" in
         convex) echo "${CONVEX_PORT:-3210}" ;;
         mcp) echo "${MCP_PORT:-3333}" ;;
-        worker) echo "${WORKER_PORT:-8000}" ;;
+        worker) echo "${TRENDS_WORKER_PORT:-8000}" ;;
         api) echo "${API_PORT:-3000}" ;;
         web) echo "${WEB_PORT:-5173}" ;;
         *) echo "" ;;
@@ -516,7 +516,7 @@ start_api() {
 
 # Start FastAPI worker (future: apps/worker)
 start_worker() {
-    local port="${WORKER_PORT:-8000}"
+    local port="${TRENDS_WORKER_PORT:-8000}"
 
     if [ -d "$PROJECT_ROOT/apps/worker" ]; then
         if ! check_port "$port"; then
@@ -715,7 +715,7 @@ main() {
                 echo "  ENV_FILE      Path to .env file (default: .env)"
                 echo "  SKIP_CRAWL    Skip crawl on startup (default: true; set to false to crawl)"
                 echo "  MCP_PORT      MCP server port (default: 3333)"
-                echo "  WORKER_PORT   FastAPI worker port (default: 8000)"
+                echo "  TRENDS_WORKER_PORT FastAPI worker port (default: 8000)"
                 echo "  API_PORT      BFF API port (default: 3000)"
                 echo "  WEB_PORT      Web frontend port (default: 5173)"
                 exit 0


### PR DESCRIPTION
## Task

# Follow-up Fix Plan: Namespaced Worker Port to Avoid cmux WORKER\_PORT Conflict

  ## Summary

  Implement a targeted follow-up so dev startup no longer reads generic WORKER\_PORT (which cmux sets in this workspace and causes false port conflicts).
  Per your decisions:

- Use TRENDS\_WORKER\_PORT as the new env var.
- Use new var only (no fallback to WORKER\_PORT).
- Scope: dev scripts + help text.

  This keeps behavior deterministic in cmux and prevents accidental collisions from unrelated environment variables.

  ## Current State (Observed)

- make dev currently reads worker port from WORKER\_PORT in:
    - scripts/dev.sh
    - scripts/clean-dev.sh
    - help output (scripts/dev.sh, Makefile)
- In this cmux workspace, WORKER\_PORT=39377 is already set and occupied, causing make dev to fail before Convex startup.

  ## Public Interface / Env Contract Changes

1. WORKER\_PORT is no longer used by dev orchestration scripts.
2. New supported variable: TRENDS\_WORKER\_PORT (default 8000).
3. Help/usage text is updated to advertise only TRENDS\_WORKER\_PORT.

  Implication: anyone relying on WORKER\_PORT for make dev/clean-dev must switch to TRENDS\_WORKER\_PORT.

  ## Implementation Tasks

  ### Task 1: Update dev runtime port resolution

  Files:

- scripts/dev.sh

  Depends: none
  Conflict Risk: low (scripts/dev.sh)

  Changes:

1. Replace worker port resolution:

    - service\_port(worker) from ${WORKER\_PORT:-8000} → ${TRENDS\_WORKER\_PORT:-8000}

2. Replace start\_worker() local port similarly.
3. Update --help environment variable section:

    - WORKER\_PORT → TRENDS\_WORKER\_PORT

4. Keep all other ports unchanged (CONVEX\_PORT, MCP\_PORT, API\_PORT, WEB\_PORT).

  Verification:

- rg -n "\\bWORKER\_PORT\\b" scripts/dev.sh returns no active references (except possibly unrelated comments removed/updated).
- rg -n "\\bTRENDS\_WORKER\_PORT\\b" scripts/dev.sh shows worker port resolution and help text.

  ———

  ### Task 2: Update cleanup script to same worker port source

  Files:

- scripts/clean-dev.sh

  Depends: none
  Conflict Risk: low (scripts/clean-dev.sh)

  Changes:

1. In PORTS array, replace ${WORKER\_PORT:-8000} with ${TRENDS\_WORKER\_PORT:-8000}.
2. In final lsof line, replace worker port env source likewise.
3. Do not alter cleanup behavior for other services.

  Verification:

- rg -n "\\bWORKER\_PORT\\b" scripts/clean-dev.sh returns no active references.
- rg -n "\\bTRENDS\_WORKER\_PORT\\b" scripts/clean-dev.sh confirms both lookup points.

  ———

  ### Task 3: Update user-visible help text in Makefile

  Files:

- Makefile

  Depends: none
  Conflict Risk: low (Makefile)

  Changes:

1. In help target env vars section, replace:

    - WORKER\_PORT → TRENDS\_WORKER\_PORT

2. Keep wording/default same: “FastAPI worker port (default: 8000)”.
3. Optional consistency tweak in dev-api-worker target:

    - --port 8000 → --port $${TRENDS\_WORKER\_PORT:-8000}
    - This keeps single-worker-launch behavior aligned with the new contract.

  Verification:

- make help displays TRENDS\_WORKER\_PORT and no WORKER\_PORT entry.
- If optional tweak included: make dev-api-worker binds to overridden TRENDS\_WORKER\_PORT.

  ## Test Cases and Scenarios

  ### Scenario A: cmux conflict no longer blocks dev

1. Ensure ambient env still has WORKER\_PORT=39377 (occupied).
2. Remove:

    - packages/convex/.env.local
    - apps/web/.env.local

3. Run:

    - CONVEX\_DEPLOYMENT=anonymous:anonymous-trends make dev

4. Expected:

    - No startup failure due to worker port 39377.
    - Worker uses default 8000 unless TRENDS\_WORKER\_PORT is set.

  ### Scenario B: explicit new var override works

1. Run:

    - TRENDS\_WORKER\_PORT=18000 make dev

2. Expected:

    - Worker startup and conflict checks use 18000.
    - Cleanup script also targets 18000.

  ### Scenario C: regression guard for old var

1. Run with only old var:

    - WORKER\_PORT=39377 make dev

2. Expected:

    - Dev scripts ignore WORKER\_PORT.
    - Worker still resolves to 8000 (or TRENDS\_WORKER\_PORT if set).

  ### Scenario D: help/UX consistency

1. make help
2. ./scripts/dev.sh --help
3. Expected:

    - Both advertise TRENDS\_WORKER\_PORT only.

  ## Acceptance Criteria

- make dev in cmux workspace is no longer blocked by ambient WORKER\_PORT.
- Worker port in dev orchestration is controlled solely by TRENDS\_WORKER\_PORT (or default 8000).
- scripts/clean-dev.sh uses the same source.
- Help text reflects the new env var consistently.
- No unrelated behavior changes to other service ports.

  ## Assumptions and Defaults

- Default worker port remains 8000.
- Backward compatibility with WORKER\_PORT is intentionally dropped (per your choice: new var only).
- Scope is limited to dev scripts and help text; no broad repo-wide renaming beyond this fix.

## PR Review Summary
- What Changed:
  - The environment variable for the FastAPI worker port in dev orchestration scripts has been renamed from `WORKER_PORT` to `TRENDS_WORKER_PORT`.
  - `scripts/dev.sh`: Updated `service_port()` and `start_worker()` functions to use `TRENDS_WORKER_PORT` for resolution, and modified the help output.
  - `scripts/clean-dev.sh`: The `PORTS` array and the `lsof` command were updated to use `TRENDS_WORKER_PORT`.
  - `Makefile`: The `help` target's environment variable section was updated to list `TRENDS_WORKER_PORT`. Additionally, the `dev-api-worker` target was updated to use `${TRENDS_WORKER_PORT:-8000}` for its port.
  - The default worker port remains 8000. The old `WORKER_PORT` is no longer recognized by these scripts.
- Review Focus:
  - Verify that the `TRENDS_WORKER_PORT` is correctly referenced across all affected scripts (`scripts/dev.sh`, `scripts/clean-dev.sh`, `Makefile`).
  - Ensure that `WORKER_PORT` is completely removed from active use in these scripts and only appears in comments or unrelated contexts.
  - Confirm that help and usage messages accurately reflect the new `TRENDS_WORKER_PORT` variable.
  - Check for any unintended side effects on other service ports or script behaviors.
- Test Plan:
  - **Scenario A (cmux conflict fix):** Set `WORKER_PORT=39377` (or an occupied port) in the ambient environment. Run `make dev`. Verify that `make dev` starts successfully without port conflicts, and the worker uses default 8000.
  - **Scenario B (explicit new var override):** Run `TRENDS_WORKER_PORT=18000 make dev`. Verify that the worker starts on port 18000 and `clean-dev.sh` targets this port for cleanup.
  - **Scenario C (old var regression guard):** Run `WORKER_PORT=39377 make dev` (without `TRENDS_WORKER_PORT` set). Verify that `WORKER_PORT` is ignored and the worker still defaults to port 8000.
  - **Scenario D (help/UX consistency):** Execute `make help` and `./scripts/dev.sh --help`. Confirm that both outputs consistently advertise `TRENDS_WORKER_PORT` and do not mention `WORKER_PORT`.