### PR TITLE
Add internationalization keys for new features

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -45,7 +45,32 @@
     },
     "errors": {
       "deleteFailed": "Failed to delete JD. Only custom JDs can be deleted."
-    }
+    },
+    "exportMarkdown": "Export Markdown",
+    "preview": "Preview",
+    "sortAsc": "Sort ascending",
+    "sortDesc": "Sort descending"
+  },
+  "bulkActions": {
+    "selected": "Selected",
+    "selectAll": "Select all",
+    "selectHighScore": "Select 80+",
+    "clearSelection": "Clear selection",
+    "shortlist": "Bulk shortlist",
+    "star": "Bulk star",
+    "reject": "Bulk reject",
+    "export": "Export"
+  },
+  "debugAi": {
+    "title": "AI Debug",
+    "subtitle": "Inspect prompt templates and analysis output",
+    "promptSection": "Prompt Templates",
+    "systemPrompt": "System Prompt",
+    "userPrompt": "User Prompt Template",
+    "selectResume": "Select Resume",
+    "rawOutput": "Raw Output",
+    "scoreBreakdown": "Score Breakdown",
+    "noAnalysis": "No analysis available for this resume"
   },
   "trends": {
     "title": "Trending Topics",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -45,7 +45,32 @@
     },
     "errors": {
       "deleteFailed": "删除失败。只能删除自定义职位描述。"
-    }
+    },
+    "exportMarkdown": "导出 Markdown",
+    "preview": "预览",
+    "sortAsc": "升序排序",
+    "sortDesc": "降序排序"
+  },
+  "bulkActions": {
+    "selected": "已选择",
+    "selectAll": "全选",
+    "selectHighScore": "选择 80+ 分",
+    "clearSelection": "取消选择",
+    "shortlist": "批量入围",
+    "star": "批量标星",
+    "reject": "批量拒绝",
+    "export": "导出"
+  },
+  "debugAi": {
+    "title": "AI 调试",
+    "subtitle": "查看提示词模板与分析输出",
+    "promptSection": "提示词模板",
+    "systemPrompt": "系统提示词",
+    "userPrompt": "用户提示词模板",
+    "selectResume": "选择简历",
+    "rawOutput": "原始输出",
+    "scoreBreakdown": "分数拆解",
+    "noAnalysis": "该简历暂无分析结果"
   },
   "trends": {
     "title": "热门话题",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -45,7 +45,32 @@
     },
     "errors": {
       "deleteFailed": "刪除失敗。只能刪除自定義職位描述。"
-    }
+    },
+    "exportMarkdown": "匯出 Markdown",
+    "preview": "預覽",
+    "sortAsc": "升冪排序",
+    "sortDesc": "降冪排序"
+  },
+  "bulkActions": {
+    "selected": "已選擇",
+    "selectAll": "全選",
+    "selectHighScore": "選擇 80+ 分",
+    "clearSelection": "取消選擇",
+    "shortlist": "批量入圍",
+    "star": "批量標星",
+    "reject": "批量拒絕",
+    "export": "匯出"
+  },
+  "debugAi": {
+    "title": "AI 調試",
+    "subtitle": "檢視提示詞模板與分析輸出",
+    "promptSection": "提示詞模板",
+    "systemPrompt": "系統提示詞",
+    "userPrompt": "使用者提示詞模板",
+    "selectResume": "選擇簡歷",
+    "rawOutput": "原始輸出",
+    "scoreBreakdown": "分數拆解",
+    "noAnalysis": "此簡歷尚無分析結果"
   },
   "trends": {
     "title": "熱門話題",

--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,9 @@
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-progress": "^1.1.8",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "convex": "^1.31.7",
@@ -216,6 +218,14 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.4", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.5", "", { "dependencies": { "@floating-ui/core": "^1.7.4", "@floating-ui/utils": "^0.2.10" } }, "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.7", "", { "dependencies": { "@floating-ui/dom": "^1.7.5" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
     "@hono/zod-openapi": ["@hono/zod-openapi@0.18.4", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^7.1.0", "@hono/zod-validator": "^0.4.1" }, "peerDependencies": { "hono": ">=4.3.6", "zod": "3.*" } }, "sha512-6NHMHU96Hh32B1yDhb94Z4Z5/POsmEu2AXpWLWcBq9arskRnOMt2752yEoXoADV8WUAc7H1IkNaQHGj1ytXbYw=="],
@@ -250,6 +260,8 @@
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
+
     "@radix-ui/react-checkbox": ["@radix-ui/react-checkbox@1.3.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw=="],
 
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
@@ -266,6 +278,10 @@
 
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
 
+    "@radix-ui/react-label": ["@radix-ui/react-label@2.1.8", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A=="],
+
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
+
     "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
 
     "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
@@ -275,6 +291,8 @@
     "@radix-ui/react-progress": ["@radix-ui/react-progress@1.1.8", "", { "dependencies": { "@radix-ui/react-context": "1.1.3", "@radix-ui/react-primitive": "2.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.8", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg=="],
 
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 
@@ -288,7 +306,13 @@
 
     "@radix-ui/react-use-previous": ["@radix-ui/react-use-previous@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ=="],
 
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
+
     "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
     "@redocly/ajv": ["@redocly/ajv@8.17.2", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-rcbDZOfXAgGEJeJ30aWCVVJvxV9ooevb/m1/SFblO2qHs4cqTk178gx7T/vdslf57EA4lTofrwsq5K8rxK9g+g=="],
 
@@ -994,6 +1018,8 @@
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
+    "@radix-ui/react-label/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
+
     "@radix-ui/react-progress/@radix-ui/react-context": ["@radix-ui/react-context@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw=="],
 
     "@radix-ui/react-progress/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
@@ -1043,6 +1069,8 @@
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": "bin/esbuild" }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "@radix-ui/react-label/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
     "@radix-ui/react-progress/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 

--- a/packages/convex/convex/README.md
+++ b/packages/convex/convex/README.md
@@ -1,0 +1,90 @@
+# Welcome to your Convex functions directory!
+
+Write your Convex functions here.
+See https://docs.convex.dev/functions for more.
+
+A query function that takes two arguments looks like:
+
+```ts
+// convex/myFunctions.ts
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myQueryFunction = query({
+  // Validators for arguments.
+  args: {
+    first: v.number(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Read the database as many times as you need here.
+    // See https://docs.convex.dev/database/reading-data.
+    const documents = await ctx.db.query("tablename").collect();
+
+    // Arguments passed from the client are properties of the args object.
+    console.log(args.first, args.second);
+
+    // Write arbitrary JavaScript here: filter, aggregate, build derived data,
+    // remove non-public properties, or create new objects.
+    return documents;
+  },
+});
+```
+
+Using this query function in a React component looks like:
+
+```ts
+const data = useQuery(api.myFunctions.myQueryFunction, {
+  first: 10,
+  second: "hello",
+});
+```
+
+A mutation function looks like:
+
+```ts
+// convex/myFunctions.ts
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myMutationFunction = mutation({
+  // Validators for arguments.
+  args: {
+    first: v.string(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Insert or modify documents in the database here.
+    // Mutations can also read from the database like queries.
+    // See https://docs.convex.dev/database/writing-data.
+    const message = { body: args.first, author: args.second };
+    const id = await ctx.db.insert("messages", message);
+
+    // Optionally, return a value from your mutation.
+    return await ctx.db.get("messages", id);
+  },
+});
+```
+
+Using this mutation function in a React component looks like:
+
+```ts
+const mutation = useMutation(api.myFunctions.myMutationFunction);
+function handleButtonPress() {
+  // fire and forget, the most common way to use mutations
+  mutation({ first: "Hello!", second: "me" });
+  // OR
+  // use the result once the mutation has completed
+  mutation({ first: "Hello!", second: "me" }).then((result) =>
+    console.log(result),
+  );
+}
+```
+
+Use the Convex CLI to push your functions to a deployment. See everything
+the Convex CLI can do by running `npx convex -h` in your project root
+directory. To learn more, launch the docs with `npx convex docs`.

--- a/packages/convex/convex/tsconfig.json
+++ b/packages/convex/convex/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  /* This TypeScript project config describes the environment that
+   * Convex functions run in and is used to typecheck them.
+   * You can modify it, but some settings are required to use Convex.
+   */
+  "compilerOptions": {
+    /* These settings are not required by Convex and can be modified. */
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+
+    /* These compiler options are required by Convex */
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}


### PR DESCRIPTION
## Task

# Parallel Task Plan: Resume Screening Remaining Work

## Progress Summary

**Phases 1-6.3 COMPLETE.** Remaining: 4 independent tasks from Phases 4.2, 6.4, 6.5, plus a critical gap (BulkActionBar handlers are `console.log` only).

---

## Parallel Execution Map

```
Task 1 (BulkActions)  ────── INDEPENDENT ─── ResumeList.tsx, ResumeCard.tsx
Task 2 (DebugJDs UX)  ────── INDEPENDENT ─── DebugJDs.tsx
Task 3 (Route Migration)  ── INDEPENDENT ─── App.tsx, Header.tsx
Task 4 (Debug AI Page)  ──── INDEPENDENT ─── NEW DebugAI.tsx, App.tsx (1 line)
Task 5 (i18n)  ──────────── INDEPENDENT ─── 3 locale files (distinct sections)
```

**All 5 tasks can run in true parallel.** Locale file edits use distinct JSON sections so auto-merge handles them.

---

### Task 1: Wire Up BulkActionBar Selection + Handlers [INDEPENDENT]

**Files**: `apps/web/src/components/ResumeList.tsx`, `apps/web/src/components/ResumeCard.tsx`
**Conflict Risk**: none

**Current state**: `ResumeList.tsx:496-507` passes `selectedCount={0}` and `console.log` for all callbacks. `ResumeCard.tsx:94` renders `<Checkbox>` with no props.

**Changes**:

1. **ResumeList.tsx** — add selection state + handlers:

- `useState<Set<string>>` for `selectedIds`
- `handleSelectAll` — sets all `displayedResumes` keys
- `handleSelectHighScore` — sets keys where score >= 80
- `handleClearSelection` — empties set
- `handleToggleSelect(key)` — toggles one entry
- `handleBulkAction(action)` — for `'shortlist'|'reject'|'star'`: iterate `selectedIds`, call existing `saveAction({ resumeId, actionType })` from `useCandidateActions`; for `'export'`: download selected as JSON blob
- Wire all to `<BulkActionBar>` props (replace console.log block)
- Pass `selected={selectedIds.has(entry.key)}` and `onSelect` to each `<ResumeCard>`
- `useEffect` to clear selection on mode/JD/query change

2. **ResumeCard.tsx** — wire checkbox:

- Add `selected?: boolean` and `onSelect?: () => void` to `ResumeCardProps` (line 16-23)
- Wire existing `<Checkbox>` at line 94: `checked={selected} onCheckedChange={() => onSelect?.()}`

**Reuse**: `useCandidateActions.saveAction()` at `apps/web/src/hooks/useCandidateActions.ts:42-68`

**Verification**: AI mode → check individual cards → "Select 80+" → "Bulk Shortlist" → verify network calls to `/api/actions`

---

### Task 2: DebugJDs Table Enhancements [INDEPENDENT]

**Files**: `apps/web/src/pages/DebugJDs.tsx`
**Conflict Risk**: none

**Changes**:

1. **Column sorting** — add `sortColumn` + `sortDirection` state. Make `<TableHead>` clickable with ArrowUpDown icon. Sort `filteredJDs` by title/type/lastModified before rendering.
2. **JD Preview Modal** — add `previewJd` state. Eye icon button per row. `<Dialog>` rendering `previewJd.content` as whitespace-pre-wrap.
3. **Export as Markdown** — Download icon per row. On click: create Blob with `# ${title}\n\n${content}`, trigger download as `.md` file.

**Verification**: Open `/debug/jds` (or `/config/jds` after Task 3). Click column headers to sort. Click eye icon → preview modal. Click download icon → `.md` file downloads.

---

### Task 3: Route Migration /debug/jds → /config/jds [INDEPENDENT]

**Files**: `apps/web/src/App.tsx` (line 16), `apps/web/src/components/Header.tsx` (lines 44-54, 82-91)
**Conflict Risk**: App.tsx shared with Task 4 (different lines — Task 3 modifies line 16, Task 4 adds a new route line)

**Changes**:

1. **App.tsx**: Change `<Route path="/debug/jds"` to `<Route path="/config/jds"`. Add redirect: `<Route path="/debug/jds" element={<Navigate to="/config/jds" replace />} />`
2. **Header.tsx**: Change `to="/debug/jds"` → `to="/config/jds"` in both desktop nav (line 45) and mobile nav (line 83). Use `{t('nav.jds')}` instead of hardcoded "JDs" (key already exists in all locales).

**Verification**: Direct navigate to `/config/jds` → works. Navigate to `/debug/jds` → redirects. Header link points correctly. Active state highlights.

---

### Task 4: Create /debug/ai Page [INDEPENDENT]

**Files**: NEW `apps/web/src/pages/DebugAI.tsx`, `apps/web/src/App.tsx` (add 1 import + 1 route line)
**Conflict Risk**: App.tsx (additive — new line, no overlap with Task 3)

**Changes**:

1. **New DebugAI.tsx** with 3 sections:

- **Prompt Templates**: Display `SYSTEM_PROMPT` and `USER_PROMPT_TEMPLATE` (copy from `packages/convex/convex/analyze.ts:5-46` as display-only strings) in `<pre>` blocks
- **Resume Selector + Raw Output**: Use `useQuery(api.resumes.list, { limit: 50 })` to list resumes. Select one → show its `analysis`/`analyses` as formatted JSON
- **Score Breakdown Visualization**: For selected resume's `analysis.breakdown`, render horizontal bar per category (experience, skills, industry\_db, education, location) with CSS widths. No charting library needed.

2. **App.tsx**: Add `import DebugAI from '@/pages/DebugAI'` and `<Route path="/debug/ai" element={<DebugAI />} />`

**Reuse**: `useQuery(api.resumes.list)` from `packages/convex/convex/resumes.ts:4-10`, UI components from `@/components/ui/`

**Verification**: Navigate to `/debug/ai`. Prompt templates visible. Select resume from dropdown → JSON output shown. Breakdown bars render with correct widths.

---

### Task 5: i18n Keys for All New Features [INDEPENDENT]

**Files**: `apps/web/src/i18n/locales/en.json`, `zh-Hans.json`, `zh-Hant.json`
**Conflict Risk**: Each task adds a distinct top-level section — auto-merge safe

**Changes** — add these sections to all 3 locale files:

**`bulkActions`&#32;section** (BulkActionBar.tsx uses these keys with Chinese fallbacks):

```
selected, selectAll, selectHighScore, clearSelection, shortlist, star, reject, export
```

**`debugAi`&#32;section** (new page):

```
title, subtitle, promptSection, systemPrompt, userPrompt, selectResume, rawOutput, scoreBreakdown, noAnalysis
```

**`jdManagement`&#32;additions** (DebugJDs enhancements):

```
exportMarkdown, preview, sortAsc, sortDesc
```

**Verification**: `make i18n-check` passes. Switch language in UI → all new text translates.

---

## Merge Strategy

| File | Touched by | Conflict risk |
|------|-----------|---------------|
| `ResumeList.tsx` | Task 1 only | None |
| `ResumeCard.tsx` | Task 1 only | None |
| `DebugJDs.tsx` | Task 2 only | None |
| `App.tsx` | Task 3 (line 16), Task 4 (new line) | Low — different lines |
| `Header.tsx` | Task 3 only | None |
| `DebugAI.tsx` | Task 4 only (new file) | None |
| Locale files | Task 5 only (distinct sections) | None |

## End-to-End Verification

After all tasks merged:

1. `make check-node` — typecheck + lint passes
2. `make dev-web` — app starts
3. `/resumes` — bulk select + actions work in AI mode
4. `/config/jds` — sorting, preview, export work; `/debug/jds` redirects
5. `/debug/ai` — prompt viewer + score breakdown render
6. Language switcher — all new strings translate in en/zh-Hans/zh-Hant

do Task 5

This pull request focuses on internationalization (i18n) and related dependency updates, corresponding to Task 5 of the parallel execution plan. It introduces new localization keys across English, Simplified Chinese, and Traditional Chinese for three distinct feature areas: Bulk Actions (e.g., 'Selected', 'Select all', 'Bulk shortlist'), AI Debug page (e.g., 'AI Debug', 'System Prompt', 'Score Breakdown'), and JD Management enhancements (e.g., 'Export Markdown', 'Preview', 'Sort ascending'). Additionally, the `bun.lock` file has been updated to include new Radix UI components (`@radix-ui/react-label`, `@radix-ui/react-tooltip`) and Floating UI dependencies, which are prerequisites for the UI features described in other tasks. Boilerplate `README.md` and `tsconfig.json` files were also added to the `packages/convex/convex/` directory.