### PR TITLE
Implement Debug Config Editor and UI Refinements

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -16,6 +16,7 @@ import {
   actionsRoutes,
   searchProfilesRoutes,
   filterPresetsRoutes,
+  configRoutes,
 } from "./routes/index.js";
 import { config } from "./services/config.js";
 
@@ -39,6 +40,7 @@ export const openApiConfig = {
     { name: "actions", description: "Candidate actions" },
     { name: "Search Profiles", description: "Search profile management" },
     { name: "Filter Presets", description: "Filter preset management" },
+    { name: "Config", description: "Runtime configuration management" },
   ],
 };
 
@@ -63,6 +65,7 @@ export function createApp() {
   app.route("/", actionsRoutes);
   app.route("/api/search-profiles", searchProfilesRoutes);
   app.route("/api/filter-presets", filterPresetsRoutes);
+  app.route("/api/config", configRoutes);
 
   // OpenAPI documentation endpoint
   app.doc("/doc", openApiConfig);
@@ -95,6 +98,7 @@ export function createApp() {
         industry_verify: "/api/industry/verify",
         job_descriptions: "/api/job-descriptions",
         search_profiles: "/api/search-profiles",
+        config: "/api/config",
       },
     });
   });

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -1,0 +1,199 @@
+import fs from "node:fs";
+import path from "node:path";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
+import JSON5 from "json5";
+import { findProjectRoot } from "../services/db.js";
+import { filterPresetService } from "../services/filter-preset-service.js";
+import { getMaskedApiKey, loadAIConfig, validateAIConfig } from "../services/ai-config.js";
+
+const app = new OpenAPIHono();
+
+const AgentsConfigSchema = z.record(z.unknown());
+const SalaryRangeSchema = z.object({
+  min: z.number().optional(),
+  max: z.number().optional(),
+});
+const PresetFiltersSchema = z.object({
+  minExperience: z.number().optional(),
+  maxExperience: z.number().nullable().optional(),
+  education: z.array(z.string()).optional(),
+  salaryRange: SalaryRangeSchema.optional(),
+});
+const FilterPresetSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  category: z.string(),
+  filters: PresetFiltersSchema,
+});
+const PresetCategorySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  icon: z.string().optional(),
+});
+const FilterPresetsConfigSchema = z.object({
+  presets: z.array(FilterPresetSchema),
+  categories: z.array(PresetCategorySchema),
+});
+const FilterPresetUpdateSchema = z.object({
+  name: z.string().optional(),
+  category: z.string().optional(),
+  filters: PresetFiltersSchema.optional(),
+});
+
+function getAgentsConfigPath(): string {
+  return path.join(findProjectRoot(), "config", "resume", "agents.json5");
+}
+
+app.get("/agents", (c) => {
+  try {
+    const configPath = getAgentsConfigPath();
+    const content = fs.readFileSync(configPath, "utf8");
+    const parsedContent: unknown = JSON5.parse(content);
+    const parsedResult = AgentsConfigSchema.safeParse(parsedContent);
+
+    if (!parsedResult.success) {
+      return c.json({ success: false as const, error: "Invalid agents configuration format" }, 500);
+    }
+
+    return c.json({ success: true as const, config: parsedResult.data }, 200);
+  } catch (error) {
+    console.error("Failed to load agents config", error);
+    return c.json({ success: false as const, error: "Failed to load agents configuration" }, 500);
+  }
+});
+
+app.put("/agents", async (c) => {
+  try {
+    const body: unknown = await c.req.json();
+    const parsedBody = AgentsConfigSchema.safeParse(body);
+
+    if (!parsedBody.success) {
+      return c.json({ success: false as const, error: "Invalid agents configuration payload" }, 400);
+    }
+
+    const configPath = getAgentsConfigPath();
+    fs.writeFileSync(configPath, JSON.stringify(parsedBody.data, null, 2), "utf8");
+
+    return c.json({ success: true as const, config: parsedBody.data }, 200);
+  } catch (error) {
+    console.error("Failed to save agents config", error);
+    return c.json({ success: false as const, error: "Failed to save agents configuration" }, 500);
+  }
+});
+
+app.get("/ai-status", (c) => {
+  try {
+    const aiConfig = loadAIConfig();
+    const validation = validateAIConfig();
+
+    return c.json(
+      {
+        success: true as const,
+        enabled: aiConfig.enabled,
+        model: aiConfig.model,
+        apiBase: aiConfig.apiBase,
+        temperature: aiConfig.temperature,
+        maxTokens: aiConfig.maxTokens,
+        timeout: aiConfig.timeout,
+        apiKeyMasked: getMaskedApiKey(),
+        valid: validation.valid,
+        validationError: validation.error,
+      },
+      200,
+    );
+  } catch (error) {
+    console.error("Failed to load AI status", error);
+    return c.json({ success: false as const, error: "Failed to load AI status" }, 500);
+  }
+});
+
+app.get("/filter-presets", (c) => {
+  try {
+    const presets = filterPresetService.listPresets();
+    const categories = filterPresetService.listCategories();
+    return c.json({ success: true as const, presets, categories }, 200);
+  } catch (error) {
+    console.error("Failed to load filter presets", error);
+    return c.json({ success: false as const, error: "Failed to load filter presets" }, 500);
+  }
+});
+
+app.put("/filter-presets", async (c) => {
+  try {
+    const body: unknown = await c.req.json();
+    const parsedBody = FilterPresetsConfigSchema.safeParse(body);
+
+    if (!parsedBody.success) {
+      return c.json({ success: false as const, error: "Invalid filter presets payload" }, 400);
+    }
+
+    filterPresetService.saveConfig(parsedBody.data);
+    return c.json({ success: true as const, config: parsedBody.data }, 200);
+  } catch (error) {
+    console.error("Failed to save filter presets", error);
+    return c.json({ success: false as const, error: "Failed to save filter presets" }, 500);
+  }
+});
+
+app.put("/filter-presets/:id", async (c) => {
+  try {
+    const id = c.req.param("id");
+    const body: unknown = await c.req.json();
+    const parsedBody = FilterPresetUpdateSchema.safeParse(body);
+
+    if (!parsedBody.success) {
+      return c.json({ success: false as const, error: "Invalid filter preset update payload" }, 400);
+    }
+
+    const updatedPreset = filterPresetService.updatePreset(id, parsedBody.data);
+
+    if (!updatedPreset) {
+      return c.json({ success: false as const, error: `Preset not found: ${id}` }, 404);
+    }
+
+    return c.json({ success: true as const, preset: updatedPreset }, 200);
+  } catch (error) {
+    console.error("Failed to update filter preset", error);
+    return c.json({ success: false as const, error: "Failed to update filter preset" }, 500);
+  }
+});
+
+app.post("/filter-presets", async (c) => {
+  try {
+    const body: unknown = await c.req.json();
+    const parsedBody = FilterPresetSchema.safeParse(body);
+
+    if (!parsedBody.success) {
+      return c.json({ success: false as const, error: "Invalid filter preset payload" }, 400);
+    }
+
+    const existingPreset = filterPresetService.getPreset(parsedBody.data.id);
+    if (existingPreset) {
+      return c.json({ success: false as const, error: `Preset already exists: ${parsedBody.data.id}` }, 409);
+    }
+
+    filterPresetService.addPreset(parsedBody.data);
+    return c.json({ success: true as const, preset: parsedBody.data }, 201);
+  } catch (error) {
+    console.error("Failed to add filter preset", error);
+    return c.json({ success: false as const, error: "Failed to add filter preset" }, 500);
+  }
+});
+
+app.delete("/filter-presets/:id", (c) => {
+  try {
+    const id = c.req.param("id");
+    const deleted = filterPresetService.deletePreset(id);
+
+    if (!deleted) {
+      return c.json({ success: false as const, error: `Preset not found: ${id}` }, 404);
+    }
+
+    return c.json({ success: true as const }, 200);
+  } catch (error) {
+    console.error("Failed to delete filter preset", error);
+    return c.json({ success: false as const, error: "Failed to delete filter preset" }, 500);
+  }
+});
+
+export default app;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -10,4 +10,4 @@ export { default as sessionsRoutes } from "./sessions.js";
 export { default as actionsRoutes } from "./actions.js";
 export { default as searchProfilesRoutes } from "./search-profiles.js";
 export { default as filterPresetsRoutes } from "./filter-presets.js";
-
+export { default as configRoutes } from "./config.js";

--- a/apps/api/src/services/filter-preset-service.ts
+++ b/apps/api/src/services/filter-preset-service.ts
@@ -100,6 +100,45 @@ export class FilterPresetService {
         return { total: config.presets.length, byCategory };
     }
 
+    saveConfig(config: FilterPresetsConfig): void {
+        const configPath = this.getConfigPath();
+        fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
+        this.cache = config;
+    }
+
+    addPreset(preset: FilterPreset): void {
+        const config = this.loadConfig();
+        config.presets.push(preset);
+        this.saveConfig(config);
+    }
+
+    updatePreset(id: string, updates: Partial<FilterPreset>): FilterPreset | undefined {
+        const config = this.loadConfig();
+        const index = config.presets.findIndex((preset) => preset.id === id);
+        if (index === -1) {
+            return undefined;
+        }
+
+        const updatedPreset: FilterPreset = {
+            ...config.presets[index],
+            ...updates,
+        };
+        config.presets[index] = updatedPreset;
+        this.saveConfig(config);
+        return updatedPreset;
+    }
+
+    deletePreset(id: string): boolean {
+        const config = this.loadConfig();
+        const before = config.presets.length;
+        config.presets = config.presets.filter((preset) => preset.id !== id);
+        if (config.presets.length === before) {
+            return false;
+        }
+        this.saveConfig(config);
+        return true;
+    }
+
     /**
      * Clear cache
      */

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,7 @@ import { ResumesPage } from '@/pages/ResumesPage'
 import { DebugPage } from '@/pages/DebugPage'
 import DebugJDs from '@/pages/DebugJDs'
 import DebugAI from '@/pages/DebugAI'
+import DebugConfig from '@/pages/DebugConfig'
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
             <Route path="/config/jds" element={<DebugJDs />} />
             <Route path="/debug/jds" element={<Navigate to="/config/jds" replace />} />
             <Route path="/debug/ai" element={<DebugAI />} />
+            <Route path="/debug/config" element={<DebugConfig />} />
             <Route path="/debug/*" element={<DebugPage />} />
             <Route path="*" element={<Navigate to="/resumes" replace />} />
           </Routes>

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -52,6 +52,17 @@ export function Header() {
             >
               {t('nav.jds')}
             </NavLink>
+            <NavLink
+              to="/debug/ai"
+              className={({ isActive }) =>
+                cn(
+                  'transition-colors hover:text-foreground',
+                  isActive ? 'text-foreground' : 'text-muted-foreground'
+                )
+              }
+            >
+              {t('nav.debugAi')}
+            </NavLink>
           </nav>
         </div>
         <div className="flex items-center gap-3">
@@ -88,6 +99,17 @@ export function Header() {
               }
             >
               {t('nav.jds')}
+            </NavLink>
+            <NavLink
+              to="/debug/ai"
+              className={({ isActive }) =>
+                cn(
+                  'transition-colors hover:text-foreground',
+                  isActive ? 'text-foreground' : 'text-muted-foreground'
+                )
+              }
+            >
+              {t('nav.debugAi')}
             </NavLink>
           </nav>
           <LanguageSwitcher />

--- a/apps/web/src/components/JobDescriptionSelect.tsx
+++ b/apps/web/src/components/JobDescriptionSelect.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { ExternalLink } from 'lucide-react'
+import { Link } from 'react-router-dom'
 import { rawApiClient } from '@/lib/api-helpers'
 import { Select } from '@/components/ui/select'
 
@@ -27,7 +29,7 @@ export function JobDescriptionSelect({ value, onChange, disabled }: JobDescripti
   const [systemOptions, setSystemOptions] = useState<JobDescriptionOption[]>([])
 
   // Fetch Custom JDs
-  const customJDs = useQuery(api.job_descriptions.list, {}) || [];
+  const customJDs = useQuery(api.job_descriptions.list, {})
 
   useEffect(() => {
     let mounted = true
@@ -49,7 +51,7 @@ export function JobDescriptionSelect({ value, onChange, disabled }: JobDescripti
   }, [])
 
   const selectOptions = useMemo(() => {
-    const customOptions = customJDs.map(jd => ({
+    const customOptions = (customJDs ?? []).map(jd => ({
       value: jd._id,
       label: `✨ ${jd.title} (Custom)`
     }));
@@ -62,11 +64,24 @@ export function JobDescriptionSelect({ value, onChange, disabled }: JobDescripti
   }, [systemOptions, customJDs, t])
 
   return (
-    <Select
-      options={selectOptions}
-      value={value}
-      onChange={(event) => onChange(event.target.value)}
-      disabled={disabled}
-    />
+    <div className="flex items-center gap-1.5">
+      <Select
+        className="flex-1"
+        options={selectOptions}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        disabled={disabled}
+      />
+      {value && (
+        <Link
+          to="/config/jds"
+          className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+          title={t('resumes.jobDescription.manage')}
+          aria-label={t('resumes.jobDescription.manage')}
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+        </Link>
+      )}
+    </div>
   )
 }

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -8,6 +8,7 @@
 import { useState, useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Search, Sparkles, Settings2, FilePlus } from 'lucide-react'
+import { Link } from 'react-router-dom'
 import { useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Id } from '../../../../packages/convex/convex/_generated/dataModel'
@@ -358,6 +359,12 @@ export function QuickStartPanel({
                                             {t('quickStart.createCustom', '创建自定义配置')}
                                         </Button>
                                     )}
+                                    <Link
+                                        to="/config/jds"
+                                        className="inline-flex items-center h-7 text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+                                    >
+                                        {t('quickStart.manageJds')}
+                                    </Link>
                                 </div>
                             </div>
                         )}
@@ -368,19 +375,19 @@ export function QuickStartPanel({
                 {matchResult && (
                     <div className="mt-3 p-3 rounded-md border border-dashed border-border text-sm">
                         <p className="text-muted-foreground mb-2">
-                            Current Match Details
+                            {t('quickStart.matchDetails')}
                         </p>
                         <div className="grid grid-cols-2 gap-2 text-xs">
                             <div>
-                                <span className="text-muted-foreground">JD: </span>
+                                <span className="text-muted-foreground">{t('quickStart.labelJd')}: </span>
                                 <span>{matchResult.matched}</span>
                             </div>
                             <div>
-                                <span className="text-muted-foreground">预设: </span>
+                                <span className="text-muted-foreground">{t('quickStart.labelPreset')}: </span>
                                 <span>{matchResult.filterPreset || '-'}</span>
                             </div>
                             <div>
-                                <span className="text-muted-foreground">匹配词: </span>
+                                <span className="text-muted-foreground">{t('quickStart.labelMatchedKeywords')}: </span>
                                 <span>{matchResult.matchedKeywords.join(', ') || '-'}</span>
                             </div>
                         </div>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -9,6 +9,7 @@
     "trends": "Trends",
     "resumes": "Resumes",
     "debug": "Debug",
+    "debugAi": "Debug AI",
     "search": "Search",
     "settings": "Settings",
     "jds": "JDs"
@@ -122,7 +123,8 @@
       "original": "Original Mode"
     },
     "jobDescription": {
-      "placeholder": "Select job description"
+      "placeholder": "Select job description",
+      "manage": "Manage JDs"
     },
     "matching": {
       "matchAll": "Match All",
@@ -182,6 +184,13 @@
       "close": "Close"
     }
   },
+  "quickStart": {
+    "matchDetails": "Current Match Details",
+    "labelJd": "JD",
+    "labelPreset": "Preset",
+    "labelMatchedKeywords": "Matched Keywords",
+    "manageJds": "Manage all JDs →"
+  },
   "debug": {
     "title": "Debug Console",
     "subtitle": "Raw inputs, findings, and process data",
@@ -194,6 +203,7 @@
     "navIndustry": "Industry Data",
     "navJobs": "Job Descriptions",
     "navAi": "AI Debug",
+    "navConfig": "Config",
     "searchPlaceholder": "Search name or intention...",
     "searchButton": "Search",
     "limitPlaceholder": "Limit",
@@ -259,6 +269,43 @@
     "stepNormalize": "Normalize fields + work history",
     "stepAggregate": "Aggregate summary statistics",
     "none": "None"
+  },
+  "debugConfig": {
+    "title": "System Configuration",
+    "subtitle": "View and edit agent pipeline, filter presets, and AI service settings",
+    "aiStatus": "AI Service Status",
+    "aiEnabled": "Enabled",
+    "aiDisabled": "Disabled",
+    "aiModel": "Model",
+    "aiApiBase": "API Base",
+    "aiTemperature": "Temperature",
+    "aiMaxTokens": "Max Tokens",
+    "aiTimeout": "Timeout",
+    "aiValid": "Configuration Valid",
+    "aiInvalid": "Configuration Invalid",
+    "agents": "Agent Pipeline",
+    "agentsDescription": "Multi-stage AI screening pipeline configuration",
+    "agentModel": "Model",
+    "agentBatchSize": "Batch Size",
+    "agentParallelism": "Parallelism",
+    "agentTimeout": "Timeout (ms)",
+    "agentThreshold": "Pass Threshold",
+    "save": "Save",
+    "saved": "Saved",
+    "saveError": "Save failed",
+    "presets": "Filter Presets",
+    "presetsDescription": "Quick filter configurations for common search patterns",
+    "addPreset": "Add Preset",
+    "editPreset": "Edit",
+    "deletePreset": "Delete",
+    "confirmDelete": "Are you sure you want to delete this preset?",
+    "presetId": "ID",
+    "presetName": "Name",
+    "presetCategory": "Category",
+    "presetMinExp": "Min Experience",
+    "presetMaxExp": "Max Experience",
+    "presetEducation": "Education",
+    "presetSalary": "Salary Range"
   },
   "platforms": {
     "zhihu": "Zhihu",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -9,6 +9,7 @@
     "trends": "热点",
     "resumes": "简历",
     "debug": "调试",
+    "debugAi": "AI 调试",
     "search": "搜索",
     "settings": "设置",
     "jds": "职位"
@@ -122,7 +123,8 @@
       "original": "原始模式"
     },
     "jobDescription": {
-      "placeholder": "选择职位"
+      "placeholder": "选择职位",
+      "manage": "管理职位"
     },
     "matching": {
       "matchAll": "AI 匹配全部",
@@ -182,6 +184,13 @@
       "close": "关闭"
     }
   },
+  "quickStart": {
+    "matchDetails": "当前匹配详情",
+    "labelJd": "职位",
+    "labelPreset": "预设",
+    "labelMatchedKeywords": "匹配词",
+    "manageJds": "管理所有职位 →"
+  },
   "debug": {
     "title": "调试控制台",
     "subtitle": "原始输入、分析发现与处理数据",
@@ -194,6 +203,7 @@
     "navIndustry": "行业数据",
     "navJobs": "职位描述",
     "navAi": "AI 调试",
+    "navConfig": "配置",
     "searchPlaceholder": "搜索姓名或意向...",
     "searchButton": "搜索",
     "limitPlaceholder": "数量",
@@ -259,6 +269,43 @@
     "stepNormalize": "字段规范化与工作经历处理",
     "stepAggregate": "汇总统计",
     "none": "无"
+  },
+  "debugConfig": {
+    "title": "系统配置",
+    "subtitle": "查看和编辑 Agent 流程、筛选预设和 AI 服务设置",
+    "aiStatus": "AI 服务状态",
+    "aiEnabled": "已启用",
+    "aiDisabled": "未启用",
+    "aiModel": "模型",
+    "aiApiBase": "API 地址",
+    "aiTemperature": "温度",
+    "aiMaxTokens": "最大 Token",
+    "aiTimeout": "超时",
+    "aiValid": "配置有效",
+    "aiInvalid": "配置无效",
+    "agents": "Agent 流程",
+    "agentsDescription": "多阶段 AI 筛选流程配置",
+    "agentModel": "模型",
+    "agentBatchSize": "批量大小",
+    "agentParallelism": "并发数",
+    "agentTimeout": "超时 (ms)",
+    "agentThreshold": "通过阈值",
+    "save": "保存",
+    "saved": "已保存",
+    "saveError": "保存失败",
+    "presets": "筛选预设",
+    "presetsDescription": "常用搜索模式的快速筛选配置",
+    "addPreset": "添加预设",
+    "editPreset": "编辑",
+    "deletePreset": "删除",
+    "confirmDelete": "确定要删除这个预设吗？",
+    "presetId": "ID",
+    "presetName": "名称",
+    "presetCategory": "类别",
+    "presetMinExp": "最低经验",
+    "presetMaxExp": "最高经验",
+    "presetEducation": "学历",
+    "presetSalary": "薪资范围"
   },
   "platforms": {
     "zhihu": "知乎",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -9,6 +9,7 @@
     "trends": "熱點",
     "resumes": "簡歷",
     "debug": "調試",
+    "debugAi": "AI 偵錯",
     "search": "搜尋",
     "settings": "設定",
     "jds": "職位"
@@ -122,7 +123,8 @@
       "original": "原始模式"
     },
     "jobDescription": {
-      "placeholder": "選擇職位"
+      "placeholder": "選擇職位",
+      "manage": "管理職位"
     },
     "matching": {
       "matchAll": "AI 匹配全部",
@@ -182,6 +184,13 @@
       "close": "關閉"
     }
   },
+  "quickStart": {
+    "matchDetails": "當前匹配詳情",
+    "labelJd": "職位",
+    "labelPreset": "預設",
+    "labelMatchedKeywords": "匹配詞",
+    "manageJds": "管理所有職位 →"
+  },
   "debug": {
     "title": "調試控制台",
     "subtitle": "原始輸入、分析發現與處理數據",
@@ -194,6 +203,7 @@
     "navIndustry": "產業資料",
     "navJobs": "職位描述",
     "navAi": "AI 調試",
+    "navConfig": "配置",
     "searchPlaceholder": "搜尋姓名或意向...",
     "searchButton": "搜尋",
     "limitPlaceholder": "數量",
@@ -259,6 +269,43 @@
     "stepNormalize": "欄位規範化與工作經歷處理",
     "stepAggregate": "彙總統計",
     "none": "無"
+  },
+  "debugConfig": {
+    "title": "系統配置",
+    "subtitle": "查看和編輯 Agent 流程、篩選預設和 AI 服務設定",
+    "aiStatus": "AI 服務狀態",
+    "aiEnabled": "已啟用",
+    "aiDisabled": "未啟用",
+    "aiModel": "模型",
+    "aiApiBase": "API 地址",
+    "aiTemperature": "溫度",
+    "aiMaxTokens": "最大 Token",
+    "aiTimeout": "逾時",
+    "aiValid": "配置有效",
+    "aiInvalid": "配置無效",
+    "agents": "Agent 流程",
+    "agentsDescription": "多階段 AI 篩選流程配置",
+    "agentModel": "模型",
+    "agentBatchSize": "批量大小",
+    "agentParallelism": "並發數",
+    "agentTimeout": "逾時 (ms)",
+    "agentThreshold": "通過閾值",
+    "save": "儲存",
+    "saved": "已儲存",
+    "saveError": "儲存失敗",
+    "presets": "篩選預設",
+    "presetsDescription": "常用搜尋模式的快速篩選配置",
+    "addPreset": "新增預設",
+    "editPreset": "編輯",
+    "deletePreset": "刪除",
+    "confirmDelete": "確定要刪除這個預設嗎？",
+    "presetId": "ID",
+    "presetName": "名稱",
+    "presetCategory": "類別",
+    "presetMinExp": "最低經驗",
+    "presetMaxExp": "最高經驗",
+    "presetEducation": "學歷",
+    "presetSalary": "薪資範圍"
   },
   "platforms": {
     "zhihu": "知乎",

--- a/apps/web/src/pages/DebugConfig.tsx
+++ b/apps/web/src/pages/DebugConfig.tsx
@@ -1,0 +1,1175 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+
+interface AIStatus {
+  enabled: boolean
+  model: string
+  apiBase?: string
+  temperature: number
+  maxTokens: number
+  timeout: number
+  apiKeyMasked: string
+  valid: boolean
+  validationError?: string
+}
+
+interface AgentConfig {
+  batchSize?: number
+  parallelism?: number
+  timeout?: number
+  temperature?: number
+  maxTokens?: number
+  [key: string]: unknown
+}
+
+interface AgentItem {
+  id: string
+  name: string
+  model: string
+  config: AgentConfig
+  [key: string]: unknown
+}
+
+interface AgentDefaults {
+  passThreshold?: number
+  [key: string]: unknown
+}
+
+interface AgentsConfig {
+  agents: {
+    list: AgentItem[]
+    defaults: Record<string, AgentDefaults>
+    [key: string]: unknown
+  }
+  [key: string]: unknown
+}
+
+interface FilterPreset {
+  id: string
+  name: string
+  category: string
+  filters: {
+    minExperience?: number
+    maxExperience?: number | null
+    education?: string[]
+    salaryRange?: {
+      min?: number
+      max?: number
+    }
+  }
+}
+
+interface PresetCategory {
+  id: string
+  name: string
+  icon?: string
+}
+
+interface PresetFormState {
+  id: string
+  name: string
+  category: string
+  minExperience: string
+  maxExperience: string
+  education: string
+  salaryMin: string
+  salaryMax: string
+}
+
+type ToastState = {
+  type: 'success' | 'error'
+  message: string
+}
+
+type AgentNumericField = 'batchSize' | 'parallelism' | 'timeout' | 'temperature'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    return value
+  }
+  return null
+}
+
+function readNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  return null
+}
+
+function readOptionalNumber(value: unknown): number | undefined {
+  const parsed = readNumber(value)
+  if (parsed === null) {
+    return undefined
+  }
+  return parsed
+}
+
+function parseOptionalNumberInput(value: string): { valid: boolean; value?: number } {
+  const normalized = value.trim()
+  if (!normalized) {
+    return { valid: true }
+  }
+
+  const parsed = Number(normalized)
+  if (!Number.isFinite(parsed)) {
+    return { valid: false }
+  }
+
+  return { valid: true, value: parsed }
+}
+
+function parseAgentItem(value: unknown): AgentItem | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = readString(value.id)
+  const name = readString(value.name)
+  const model = readString(value.model)
+  if (!id || !name || !model) {
+    return null
+  }
+
+  const rawConfig = isRecord(value.config) ? value.config : {}
+  const config: AgentConfig = {
+    ...rawConfig,
+    batchSize: readOptionalNumber(rawConfig.batchSize),
+    parallelism: readOptionalNumber(rawConfig.parallelism),
+    timeout: readOptionalNumber(rawConfig.timeout),
+    temperature: readOptionalNumber(rawConfig.temperature),
+    maxTokens: readOptionalNumber(rawConfig.maxTokens),
+  }
+
+  return {
+    ...value,
+    id,
+    name,
+    model,
+    config,
+  }
+}
+
+function parseAgentDefaults(value: unknown): Record<string, AgentDefaults> | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const parsed: Record<string, AgentDefaults> = {}
+  for (const [key, rawValue] of Object.entries(value)) {
+    if (!isRecord(rawValue)) {
+      continue
+    }
+
+    parsed[key] = {
+      ...rawValue,
+      passThreshold: readOptionalNumber(rawValue.passThreshold),
+    }
+  }
+
+  return parsed
+}
+
+function parseAgentsConfigPayload(payload: unknown): AgentsConfig | null {
+  if (!isRecord(payload) || payload.success !== true) {
+    return null
+  }
+
+  const rawConfig = payload.config
+  if (!isRecord(rawConfig)) {
+    return null
+  }
+
+  const rawAgents = rawConfig.agents
+  if (!isRecord(rawAgents)) {
+    return null
+  }
+
+  const rawList = rawAgents.list
+  if (!Array.isArray(rawList)) {
+    return null
+  }
+
+  const list: AgentItem[] = []
+  for (const item of rawList) {
+    const parsedItem = parseAgentItem(item)
+    if (!parsedItem) {
+      continue
+    }
+    list.push(parsedItem)
+  }
+
+  const defaults = parseAgentDefaults(rawAgents.defaults)
+  if (!defaults) {
+    return null
+  }
+
+  return {
+    ...rawConfig,
+    agents: {
+      ...rawAgents,
+      list,
+      defaults,
+    },
+  }
+}
+
+function parseAIStatusPayload(payload: unknown): AIStatus | null {
+  if (!isRecord(payload) || payload.success !== true) {
+    return null
+  }
+
+  const enabled = typeof payload.enabled === 'boolean' ? payload.enabled : null
+  const model = readString(payload.model)
+  const temperature = readNumber(payload.temperature)
+  const maxTokens = readNumber(payload.maxTokens)
+  const timeout = readNumber(payload.timeout)
+  const apiKeyMasked = readString(payload.apiKeyMasked)
+  const valid = typeof payload.valid === 'boolean' ? payload.valid : null
+
+  if (
+    enabled === null ||
+    model === null ||
+    temperature === null ||
+    maxTokens === null ||
+    timeout === null ||
+    apiKeyMasked === null ||
+    valid === null
+  ) {
+    return null
+  }
+
+  const apiBase = readString(payload.apiBase) ?? undefined
+  const validationError = readString(payload.validationError) ?? undefined
+
+  return {
+    enabled,
+    model,
+    apiBase,
+    temperature,
+    maxTokens,
+    timeout,
+    apiKeyMasked,
+    valid,
+    validationError,
+  }
+}
+
+function parseFilterPreset(value: unknown): FilterPreset | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = readString(value.id)
+  const name = readString(value.name)
+  const category = readString(value.category)
+  if (!id || !name || !category) {
+    return null
+  }
+
+  const rawFilters = isRecord(value.filters) ? value.filters : {}
+  const rawSalary = isRecord(rawFilters.salaryRange) ? rawFilters.salaryRange : null
+
+  const filters: FilterPreset['filters'] = {
+    minExperience: readOptionalNumber(rawFilters.minExperience),
+    maxExperience:
+      rawFilters.maxExperience === null
+        ? null
+        : readOptionalNumber(rawFilters.maxExperience),
+  }
+
+  if (Array.isArray(rawFilters.education)) {
+    const education = rawFilters.education.filter((item): item is string => typeof item === 'string')
+    if (education.length > 0) {
+      filters.education = education
+    }
+  }
+
+  if (rawSalary) {
+    const salaryMin = readOptionalNumber(rawSalary.min)
+    const salaryMax = readOptionalNumber(rawSalary.max)
+    if (salaryMin !== undefined || salaryMax !== undefined) {
+      filters.salaryRange = {
+        ...(salaryMin !== undefined ? { min: salaryMin } : {}),
+        ...(salaryMax !== undefined ? { max: salaryMax } : {}),
+      }
+    }
+  }
+
+  return {
+    id,
+    name,
+    category,
+    filters,
+  }
+}
+
+function parsePresetCategory(value: unknown): PresetCategory | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = readString(value.id)
+  const name = readString(value.name)
+  if (!id || !name) {
+    return null
+  }
+
+  const icon = readString(value.icon) ?? undefined
+
+  return {
+    id,
+    name,
+    icon,
+  }
+}
+
+function parseFilterPresetsPayload(payload: unknown): { presets: FilterPreset[]; categories: PresetCategory[] } | null {
+  if (!isRecord(payload) || payload.success !== true) {
+    return null
+  }
+
+  if (!Array.isArray(payload.presets) || !Array.isArray(payload.categories)) {
+    return null
+  }
+
+  const presets = payload.presets
+    .map((item) => parseFilterPreset(item))
+    .filter((item): item is FilterPreset => item !== null)
+
+  const categories = payload.categories
+    .map((item) => parsePresetCategory(item))
+    .filter((item): item is PresetCategory => item !== null)
+
+  return { presets, categories }
+}
+
+function createEmptyPresetForm(): PresetFormState {
+  return {
+    id: '',
+    name: '',
+    category: '',
+    minExperience: '',
+    maxExperience: '',
+    education: '',
+    salaryMin: '',
+    salaryMax: '',
+  }
+}
+
+function presetToForm(preset: FilterPreset): PresetFormState {
+  return {
+    id: preset.id,
+    name: preset.name,
+    category: preset.category,
+    minExperience: preset.filters.minExperience !== undefined ? String(preset.filters.minExperience) : '',
+    maxExperience:
+      preset.filters.maxExperience === null
+        ? ''
+        : preset.filters.maxExperience !== undefined
+          ? String(preset.filters.maxExperience)
+          : '',
+    education: preset.filters.education?.join(', ') ?? '',
+    salaryMin: preset.filters.salaryRange?.min !== undefined ? String(preset.filters.salaryRange.min) : '',
+    salaryMax: preset.filters.salaryRange?.max !== undefined ? String(preset.filters.salaryRange.max) : '',
+  }
+}
+
+function formatSalaryRange(preset: FilterPreset): string {
+  const min = preset.filters.salaryRange?.min
+  const max = preset.filters.salaryRange?.max
+  if (min === undefined && max === undefined) {
+    return '-'
+  }
+  return `${min ?? '-'} - ${max ?? '-'}`
+}
+
+function formatEducation(preset: FilterPreset): string {
+  const education = preset.filters.education
+  if (!education || education.length === 0) {
+    return '-'
+  }
+  return education.join(', ')
+}
+
+function formatMaxExperience(value: number | null | undefined): string {
+  if (value === null) {
+    return '∞'
+  }
+  if (value === undefined) {
+    return '-'
+  }
+  return String(value)
+}
+
+function parseFormNumberField(value: string, fieldLabel: string): number | undefined {
+  const normalized = value.trim()
+  if (!normalized) {
+    return undefined
+  }
+
+  const parsed = Number(normalized)
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${fieldLabel}: invalid number`)
+  }
+
+  return parsed
+}
+
+function parseFormNullableNumberField(value: string, fieldLabel: string): number | null {
+  const normalized = value.trim()
+  if (!normalized) {
+    return null
+  }
+
+  const parsed = Number(normalized)
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${fieldLabel}: invalid number`)
+  }
+
+  return parsed
+}
+
+export default function DebugConfig() {
+  const { t } = useTranslation()
+
+  const apiBaseUrl = useMemo(() => {
+    const rawBaseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000/api'
+    return rawBaseUrl.replace(/\/api\/?$/, '')
+  }, [])
+
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const [aiStatus, setAiStatus] = useState<AIStatus | null>(null)
+  const [agentsConfig, setAgentsConfig] = useState<AgentsConfig | null>(null)
+  const [filterPresets, setFilterPresets] = useState<FilterPreset[]>([])
+  const [presetCategories, setPresetCategories] = useState<PresetCategory[]>([])
+
+  const [savingAgentId, setSavingAgentId] = useState<string | null>(null)
+  const [savingPreset, setSavingPreset] = useState(false)
+
+  const [presetDialogOpen, setPresetDialogOpen] = useState(false)
+  const [editingPresetId, setEditingPresetId] = useState<string | null>(null)
+  const [presetForm, setPresetForm] = useState<PresetFormState>(createEmptyPresetForm)
+
+  const [toast, setToast] = useState<ToastState | null>(null)
+
+  useEffect(() => {
+    if (!toast) {
+      return undefined
+    }
+
+    const timer = window.setTimeout(() => {
+      setToast(null)
+    }, 2500)
+
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [toast])
+
+  const showToast = useCallback((nextToast: ToastState) => {
+    setToast(nextToast)
+  }, [])
+
+  const requestJson = useCallback(
+    async (path: string, init?: RequestInit): Promise<unknown> => {
+      const response = await fetch(`${apiBaseUrl}${path}`, {
+        ...init,
+        headers: {
+          ...(init?.headers ?? {}),
+          'Content-Type': 'application/json',
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`)
+      }
+
+      const payload: unknown = await response.json()
+      return payload
+    },
+    [apiBaseUrl],
+  )
+
+  const loadAIStatus = useCallback(async () => {
+    const payload = await requestJson('/api/config/ai-status')
+    const parsed = parseAIStatusPayload(payload)
+    if (!parsed) {
+      throw new Error('Invalid AI status response')
+    }
+    setAiStatus(parsed)
+  }, [requestJson])
+
+  const loadAgentsConfig = useCallback(async () => {
+    const payload = await requestJson('/api/config/agents')
+    const parsed = parseAgentsConfigPayload(payload)
+    if (!parsed) {
+      throw new Error('Invalid agents config response')
+    }
+    setAgentsConfig(parsed)
+  }, [requestJson])
+
+  const loadFilterPresets = useCallback(async () => {
+    const payload = await requestJson('/api/config/filter-presets')
+    const parsed = parseFilterPresetsPayload(payload)
+    if (!parsed) {
+      throw new Error('Invalid filter presets response')
+    }
+    setFilterPresets(parsed.presets)
+    setPresetCategories(parsed.categories)
+  }, [requestJson])
+
+  const loadData = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+
+    try {
+      await Promise.all([loadAIStatus(), loadAgentsConfig(), loadFilterPresets()])
+    } catch (error) {
+      console.error('Failed to load configuration data', error)
+      setLoadError(t('resumes.error'))
+    } finally {
+      setLoading(false)
+    }
+  }, [loadAIStatus, loadAgentsConfig, loadFilterPresets, t])
+
+  useEffect(() => {
+    loadData().catch((error) => {
+      console.error('Unexpected loadData failure', error)
+    })
+  }, [loadData])
+
+  const updateAgentTextField = useCallback((agentId: string, field: 'name' | 'model', value: string) => {
+    setAgentsConfig((current) => {
+      if (!current) {
+        return current
+      }
+
+      return {
+        ...current,
+        agents: {
+          ...current.agents,
+          list: current.agents.list.map((agent) => {
+            if (agent.id !== agentId) {
+              return agent
+            }
+
+            return {
+              ...agent,
+              [field]: value,
+            }
+          }),
+        },
+      }
+    })
+  }, [])
+
+  const updateAgentNumericField = useCallback((agentId: string, field: AgentNumericField, rawValue: string) => {
+    const parsedInput = parseOptionalNumberInput(rawValue)
+    if (!parsedInput.valid) {
+      return
+    }
+
+    setAgentsConfig((current) => {
+      if (!current) {
+        return current
+      }
+
+      return {
+        ...current,
+        agents: {
+          ...current.agents,
+          list: current.agents.list.map((agent) => {
+            if (agent.id !== agentId) {
+              return agent
+            }
+
+            return {
+              ...agent,
+              config: {
+                ...agent.config,
+                [field]: parsedInput.value,
+              },
+            }
+          }),
+        },
+      }
+    })
+  }, [])
+
+  const updateAgentThreshold = useCallback((agentId: string, rawValue: string) => {
+    const parsedInput = parseOptionalNumberInput(rawValue)
+    if (!parsedInput.valid) {
+      return
+    }
+
+    setAgentsConfig((current) => {
+      if (!current) {
+        return current
+      }
+
+      const currentDefaults = current.agents.defaults[agentId] ?? {}
+
+      return {
+        ...current,
+        agents: {
+          ...current.agents,
+          defaults: {
+            ...current.agents.defaults,
+            [agentId]: {
+              ...currentDefaults,
+              passThreshold: parsedInput.value,
+            },
+          },
+        },
+      }
+    })
+  }, [])
+
+  const handleSaveAgents = useCallback(
+    async (agentId: string) => {
+      if (!agentsConfig) {
+        return
+      }
+
+      setSavingAgentId(agentId)
+
+      try {
+        const payload = await requestJson('/api/config/agents', {
+          method: 'PUT',
+          body: JSON.stringify(agentsConfig),
+        })
+        const parsed = parseAgentsConfigPayload(payload)
+        if (!parsed) {
+          throw new Error('Invalid agents save response')
+        }
+
+        setAgentsConfig(parsed)
+        showToast({ type: 'success', message: t('debugConfig.saved') })
+      } catch (error) {
+        console.error('Failed to save agent config', error)
+        showToast({ type: 'error', message: t('debugConfig.saveError') })
+      } finally {
+        setSavingAgentId(null)
+      }
+    },
+    [agentsConfig, requestJson, showToast, t],
+  )
+
+  const openAddPresetDialog = useCallback(() => {
+    setEditingPresetId(null)
+    setPresetForm(createEmptyPresetForm())
+    setPresetDialogOpen(true)
+  }, [])
+
+  const openEditPresetDialog = useCallback((preset: FilterPreset) => {
+    setEditingPresetId(preset.id)
+    setPresetForm(presetToForm(preset))
+    setPresetDialogOpen(true)
+  }, [])
+
+  const buildPresetFromForm = useCallback((): FilterPreset => {
+    const id = presetForm.id.trim()
+    const name = presetForm.name.trim()
+    const category = presetForm.category.trim()
+
+    if (!id || !name || !category) {
+      throw new Error('Missing required fields')
+    }
+
+    const minExperience = parseFormNumberField(presetForm.minExperience, t('debugConfig.presetMinExp'))
+    const maxExperience = parseFormNullableNumberField(presetForm.maxExperience, t('debugConfig.presetMaxExp'))
+
+    const salaryMin = parseFormNumberField(presetForm.salaryMin, t('debugConfig.presetSalary'))
+    const salaryMax = parseFormNumberField(presetForm.salaryMax, t('debugConfig.presetSalary'))
+
+    const education = presetForm.education
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0)
+
+    const filters: FilterPreset['filters'] = {
+      maxExperience,
+    }
+
+    if (minExperience !== undefined) {
+      filters.minExperience = minExperience
+    }
+
+    if (education.length > 0) {
+      filters.education = education
+    }
+
+    if (salaryMin !== undefined || salaryMax !== undefined) {
+      filters.salaryRange = {
+        ...(salaryMin !== undefined ? { min: salaryMin } : {}),
+        ...(salaryMax !== undefined ? { max: salaryMax } : {}),
+      }
+    }
+
+    return {
+      id,
+      name,
+      category,
+      filters,
+    }
+  }, [presetForm, t])
+
+  const handleSavePreset = useCallback(async () => {
+    setSavingPreset(true)
+
+    try {
+      const preset = buildPresetFromForm()
+
+      if (editingPresetId) {
+        await requestJson(`/api/config/filter-presets/${encodeURIComponent(editingPresetId)}`, {
+          method: 'PUT',
+          body: JSON.stringify({
+            name: preset.name,
+            category: preset.category,
+            filters: preset.filters,
+          }),
+        })
+      } else {
+        await requestJson('/api/config/filter-presets', {
+          method: 'POST',
+          body: JSON.stringify(preset),
+        })
+      }
+
+      await loadFilterPresets()
+      setPresetDialogOpen(false)
+      showToast({ type: 'success', message: t('debugConfig.saved') })
+    } catch (error) {
+      console.error('Failed to save filter preset', error)
+      showToast({ type: 'error', message: t('debugConfig.saveError') })
+    } finally {
+      setSavingPreset(false)
+    }
+  }, [buildPresetFromForm, editingPresetId, loadFilterPresets, requestJson, showToast, t])
+
+  const handleDeletePreset = useCallback(
+    async (presetId: string) => {
+      const confirmed = window.confirm(t('debugConfig.confirmDelete'))
+      if (!confirmed) {
+        return
+      }
+
+      try {
+        await requestJson(`/api/config/filter-presets/${encodeURIComponent(presetId)}`, {
+          method: 'DELETE',
+        })
+        await loadFilterPresets()
+        showToast({ type: 'success', message: t('debugConfig.saved') })
+      } catch (error) {
+        console.error('Failed to delete filter preset', error)
+        showToast({ type: 'error', message: t('debugConfig.saveError') })
+      }
+    },
+    [loadFilterPresets, requestJson, showToast, t],
+  )
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold">{t('debugConfig.title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('debugConfig.subtitle')}</p>
+      </div>
+
+      {loadError && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+          {loadError}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('debugConfig.aiStatus')}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!aiStatus ? (
+            <p className="text-sm text-muted-foreground">{loading ? t('trends.loading') : '-'}</p>
+          ) : (
+            <>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant={aiStatus.enabled ? 'default' : 'secondary'}>
+                  {aiStatus.enabled ? t('debugConfig.aiEnabled') : t('debugConfig.aiDisabled')}
+                </Badge>
+                <Badge variant={aiStatus.valid ? 'default' : 'destructive'}>
+                  {aiStatus.valid ? t('debugConfig.aiValid') : t('debugConfig.aiInvalid')}
+                </Badge>
+              </div>
+
+              <div className="grid gap-3 text-sm sm:grid-cols-2">
+                <div>
+                  <p className="text-muted-foreground">{t('debugConfig.aiModel')}</p>
+                  <p className="font-medium">{aiStatus.model}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">{t('debugConfig.aiApiBase')}</p>
+                  <p className="font-medium">{aiStatus.apiBase ?? '-'}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">{t('debugConfig.aiTemperature')}</p>
+                  <p className="font-medium">{aiStatus.temperature}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">{t('debugConfig.aiMaxTokens')}</p>
+                  <p className="font-medium">{aiStatus.maxTokens}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">{t('debugConfig.aiTimeout')}</p>
+                  <p className="font-medium">{aiStatus.timeout}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">API Key</p>
+                  <p className="font-medium">{aiStatus.apiKeyMasked}</p>
+                </div>
+              </div>
+
+              {aiStatus.validationError && (
+                <p className="rounded border border-destructive/30 bg-destructive/10 p-2 text-sm text-destructive">
+                  {aiStatus.validationError}
+                </p>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('debugConfig.agents')}</CardTitle>
+          <CardDescription>{t('debugConfig.agentsDescription')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!agentsConfig ? (
+            <p className="text-sm text-muted-foreground">{loading ? t('trends.loading') : '-'}</p>
+          ) : agentsConfig.agents.list.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t('debug.none')}</p>
+          ) : (
+            agentsConfig.agents.list.map((agent) => {
+              const defaults = agentsConfig.agents.defaults[agent.id] ?? {}
+              const isSaving = savingAgentId === agent.id
+
+              return (
+                <div key={agent.id} className="space-y-3 rounded-md border p-4">
+                  <div className="flex items-center justify-between gap-2">
+                    <h3 className="text-sm font-semibold">{agent.id}</h3>
+                    <Button
+                      size="sm"
+                      onClick={() => {
+                        handleSaveAgents(agent.id).catch((error) => {
+                          console.error('Unexpected handleSaveAgents failure', error)
+                        })
+                      }}
+                      disabled={isSaving}
+                    >
+                      {isSaving ? `${t('debugConfig.save')}...` : t('debugConfig.save')}
+                    </Button>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <div className="space-y-1">
+                      <p className="text-xs text-muted-foreground">Name</p>
+                      <Input
+                        value={agent.name}
+                        onChange={(event) => {
+                          updateAgentTextField(agent.id, 'name', event.target.value)
+                        }}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs text-muted-foreground">{t('debugConfig.agentModel')}</p>
+                      <Input
+                        value={agent.model}
+                        onChange={(event) => {
+                          updateAgentTextField(agent.id, 'model', event.target.value)
+                        }}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs text-muted-foreground">{t('debugConfig.agentBatchSize')}</p>
+                      <Input
+                        type="number"
+                        value={agent.config.batchSize ?? ''}
+                        onChange={(event) => {
+                          updateAgentNumericField(agent.id, 'batchSize', event.target.value)
+                        }}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs text-muted-foreground">{t('debugConfig.agentParallelism')}</p>
+                      <Input
+                        type="number"
+                        value={agent.config.parallelism ?? ''}
+                        onChange={(event) => {
+                          updateAgentNumericField(agent.id, 'parallelism', event.target.value)
+                        }}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs text-muted-foreground">{t('debugConfig.agentTimeout')}</p>
+                      <Input
+                        type="number"
+                        value={agent.config.timeout ?? ''}
+                        onChange={(event) => {
+                          updateAgentNumericField(agent.id, 'timeout', event.target.value)
+                        }}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs text-muted-foreground">{t('debugConfig.aiTemperature')}</p>
+                      <Input
+                        type="number"
+                        step="0.1"
+                        value={agent.config.temperature ?? ''}
+                        onChange={(event) => {
+                          updateAgentNumericField(agent.id, 'temperature', event.target.value)
+                        }}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs text-muted-foreground">{t('debugConfig.agentThreshold')}</p>
+                      <Input
+                        type="number"
+                        value={defaults.passThreshold ?? ''}
+                        onChange={(event) => {
+                          updateAgentThreshold(agent.id, event.target.value)
+                        }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )
+            })
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <CardTitle>{t('debugConfig.presets')}</CardTitle>
+              <CardDescription>{t('debugConfig.presetsDescription')}</CardDescription>
+            </div>
+            <Button size="sm" onClick={openAddPresetDialog}>
+              {t('debugConfig.addPreset')}
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t('debugConfig.presetId')}</TableHead>
+                  <TableHead>{t('debugConfig.presetName')}</TableHead>
+                  <TableHead>{t('debugConfig.presetCategory')}</TableHead>
+                  <TableHead>{t('debugConfig.presetMinExp')}</TableHead>
+                  <TableHead>{t('debugConfig.presetMaxExp')}</TableHead>
+                  <TableHead>{t('debugConfig.presetEducation')}</TableHead>
+                  <TableHead>{t('debugConfig.presetSalary')}</TableHead>
+                  <TableHead className="text-right">{t('resumes.actions.view')}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filterPresets.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={8} className="py-6 text-center text-muted-foreground">
+                      {loading ? t('trends.loading') : t('debug.none')}
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  filterPresets.map((preset) => (
+                    <TableRow key={preset.id}>
+                      <TableCell className="font-mono text-xs">{preset.id}</TableCell>
+                      <TableCell>{preset.name}</TableCell>
+                      <TableCell>{preset.category}</TableCell>
+                      <TableCell>{preset.filters.minExperience ?? '-'}</TableCell>
+                      <TableCell>{formatMaxExperience(preset.filters.maxExperience)}</TableCell>
+                      <TableCell>{formatEducation(preset)}</TableCell>
+                      <TableCell>{formatSalaryRange(preset)}</TableCell>
+                      <TableCell>
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              openEditPresetDialog(preset)
+                            }}
+                          >
+                            {t('debugConfig.editPreset')}
+                          </Button>
+                          <Button
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => {
+                              handleDeletePreset(preset.id).catch((error) => {
+                                console.error('Unexpected handleDeletePreset failure', error)
+                              })
+                            }}
+                          >
+                            {t('debugConfig.deletePreset')}
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog open={presetDialogOpen} onOpenChange={setPresetDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{editingPresetId ? t('debugConfig.editPreset') : t('debugConfig.addPreset')}</DialogTitle>
+          </DialogHeader>
+
+          <div className="grid gap-3 py-2">
+            <div className="space-y-1">
+              <p className="text-xs text-muted-foreground">{t('debugConfig.presetId')}</p>
+              <Input
+                value={presetForm.id}
+                onChange={(event) => {
+                  setPresetForm((current) => ({ ...current, id: event.target.value }))
+                }}
+                disabled={Boolean(editingPresetId)}
+              />
+            </div>
+            <div className="space-y-1">
+              <p className="text-xs text-muted-foreground">{t('debugConfig.presetName')}</p>
+              <Input
+                value={presetForm.name}
+                onChange={(event) => {
+                  setPresetForm((current) => ({ ...current, name: event.target.value }))
+                }}
+              />
+            </div>
+            <div className="space-y-1">
+              <p className="text-xs text-muted-foreground">{t('debugConfig.presetCategory')}</p>
+              <Input
+                value={presetForm.category}
+                list="preset-category-options"
+                onChange={(event) => {
+                  setPresetForm((current) => ({ ...current, category: event.target.value }))
+                }}
+              />
+              <datalist id="preset-category-options">
+                {presetCategories.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.name}
+                  </option>
+                ))}
+              </datalist>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{t('debugConfig.presetMinExp')}</p>
+                <Input
+                  type="number"
+                  value={presetForm.minExperience}
+                  onChange={(event) => {
+                    setPresetForm((current) => ({ ...current, minExperience: event.target.value }))
+                  }}
+                />
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{t('debugConfig.presetMaxExp')}</p>
+                <Input
+                  type="number"
+                  value={presetForm.maxExperience}
+                  onChange={(event) => {
+                    setPresetForm((current) => ({ ...current, maxExperience: event.target.value }))
+                  }}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <p className="text-xs text-muted-foreground">{t('debugConfig.presetEducation')}</p>
+              <Input
+                value={presetForm.education}
+                onChange={(event) => {
+                  setPresetForm((current) => ({ ...current, education: event.target.value }))
+                }}
+              />
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{t('debugConfig.presetSalary')} (min)</p>
+                <Input
+                  type="number"
+                  value={presetForm.salaryMin}
+                  onChange={(event) => {
+                    setPresetForm((current) => ({ ...current, salaryMin: event.target.value }))
+                  }}
+                />
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{t('debugConfig.presetSalary')} (max)</p>
+                <Input
+                  type="number"
+                  value={presetForm.salaryMax}
+                  onChange={(event) => {
+                    setPresetForm((current) => ({ ...current, salaryMax: event.target.value }))
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setPresetDialogOpen(false)
+              }}
+              disabled={savingPreset}
+            >
+              {t('jdManagement.cancel')}
+            </Button>
+            <Button
+              onClick={() => {
+                handleSavePreset().catch((error) => {
+                  console.error('Unexpected handleSavePreset failure', error)
+                })
+              }}
+              disabled={savingPreset}
+            >
+              {savingPreset ? `${t('debugConfig.save')}...` : t('debugConfig.save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {toast && (
+        <div
+          className={`fixed bottom-4 right-4 rounded-md px-3 py-2 text-sm text-white shadow-lg ${
+            toast.type === 'success' ? 'bg-emerald-600' : 'bg-destructive'
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/DebugPage.tsx
+++ b/apps/web/src/pages/DebugPage.tsx
@@ -378,7 +378,7 @@ export function DebugPage() {
     const parts = location.pathname.split('/').filter(Boolean)
     const index = parts.indexOf('debug')
     const next = index >= 0 ? parts[index + 1] : undefined
-    const allowed = new Set(['all', 'inputs', 'findings', 'process', 'raw', 'industry', 'jobs'])
+    const allowed = new Set(['all', 'inputs', 'findings', 'process', 'raw', 'industry', 'jobs', 'config'])
     if (next && allowed.has(next)) return next
     return 'all'
   }, [location.pathname])
@@ -400,6 +400,7 @@ export function DebugPage() {
       { key: 'raw', label: t('debug.navRaw'), href: '/debug/raw' },
       { key: 'industry', label: t('debug.navIndustry'), href: '/debug/industry' },
       { key: 'jobs', label: t('debug.navJobs'), href: '/debug/jobs' },
+      { key: 'config', label: t('debug.navConfig'), href: '/debug/config' },
       { key: 'ai', label: t('debug.navAi'), href: '/debug/ai' },
     ],
     [t]


### PR DESCRIPTION
## Task

# UI Refinement, Debug Config Editor & Phase 7.1 Follow-up

## Overview

5 parallel tasks across 3 areas:

1. **UI Quick Links** - Add edit/navigate links for JDs from resume screening UI (Tasks 1-2)
2. **Debug Config Editor** - Editable config UI for agents, filter presets, AI status (Tasks 3-4)
3. **Phase 7.1 Cleanup** - DebugAI nav link, QuickStartPanel i18n (Task 5)

---

## Task 1: QuickStartPanel i18n Fix + "Manage JDs" Link [INDEPENDENT]

**Files:**

- `apps/web/src/components/QuickStartPanel.tsx` (lines 321-388)
- `apps/web/src/i18n/locales/en.json`
- `apps/web/src/i18n/locales/zh-Hans.json`
- `apps/web/src/i18n/locales/zh-Hant.json`

**Depends:** None
**Conflict Risk:** i18n locale files (different key sections from other tasks)

**Changes:**

### 1a. Replace hardcoded strings with `t()` calls

- Line 371: `"Current Match Details"` → `t('quickStart.matchDetails')`
- Line 375: `"JD: "` → `t('quickStart.labelJd')`
- Line 379: `"预设: "` → `t('quickStart.labelPreset')`
- Line 383: `"匹配词: "` → `t('quickStart.labelMatchedKeywords')`

### 1b. Add "Manage JDs →" link in match result buttons area

- Import `Link` from `react-router-dom`
- After the "创建自定义配置" button (line 359), add:

```tsx
  <Link to="/config/jds" className="inline-flex items-center h-7 text-xs text-muted-foreground hover:text-foreground underline underline-offset-2">
    {t('quickStart.manageJds')}
  </Link>
```

### 1c. i18n keys (add to all 3 locales under `"quickStart"`)

| Key | en | zh-Hans | zh-Hant |
|-----|----|---------|---------|
| `matchDetails` | Current Match Details | 当前匹配详情 | 當前匹配詳情 |
| `labelJd` | JD | 职位 | 職位 |
| `labelPreset` | Preset | 预设 | 預設 |
| `labelMatchedKeywords` | Matched Keywords | 匹配词 | 匹配詞 |
| `manageJds` | Manage all JDs → | 管理所有职位 → | 管理所有職位 → |

**Verification:** Switch language, confirm match details area shows translated text. Click "Manage all JDs →" navigates to `/config/jds`.

---

## Task 2: Add JD Edit Icon to JobDescriptionSelect [INDEPENDENT]

**Files:**

- `apps/web/src/components/JobDescriptionSelect.tsx`
- `apps/web/src/i18n/locales/en.json`
- `apps/web/src/i18n/locales/zh-Hans.json`
- `apps/web/src/i18n/locales/zh-Hant.json`

**Depends:** None
**Conflict Risk:** None (unique file)

**Changes:**

- Import `ExternalLink` from `lucide-react`, `Link` from `react-router-dom`
- Wrap current `<Select>` in a flex container
- Add a small icon link to `/config/jds` that only shows when a JD is selected:

```tsx
<div className="flex items-center gap-1.5">
  <Select ... className="flex-1" />
  {value && (
    <Link
      to="/config/jds"
      className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
      title={t('resumes.jobDescription.manage')}
    >
      <ExternalLink className="h-3.5 w-3.5" />
    </Link>
  )}
</div>
```

### i18n key

| Key | en | zh-Hans | zh-Hant |
|-----|----|---------|---------|
| `resumes.jobDescription.manage` | Manage JDs | 管理职位 | 管理職位 |

**Verification:** Select a JD in the dropdown on ResumesPage, confirm small icon appears. Click navigates to `/config/jds`.

---

## Task 3: Config API Endpoints (Backend) [INDEPENDENT]

**Files:**

- `apps/api/src/routes/config.ts` (NEW)
- `apps/api/src/routes/index.ts` (add export)
- `apps/api/src/app.ts` (mount route)
- `apps/api/src/services/filter-preset-service.ts` (add save methods)

**Depends:** None
**Conflict Risk:** `app.ts`, `routes/index.ts` (add one line each)

**Changes:**

### 3a. New route file: `apps/api/src/routes/config.ts`

Using Hono (following existing patterns from other route files like `health.ts`, `filter-presets.ts`):

```typescript
// GET /api/config/agents - returns agents.json5 content
// PUT /api/config/agents - writes updated agents config to agents.json5
// GET /api/config/ai-status - returns AI config (read-only, from env vars)
// GET /api/config/filter-presets - list presets (delegates to existing service)
// PUT /api/config/filter-presets - writes updated presets to filter-presets.json5
// PUT /api/config/filter-presets/:id - update single preset
// POST /api/config/filter-presets - add new preset
// DELETE /api/config/filter-presets/:id - delete preset
```

Implementation details:

- **GET /api/config/agents**: Read `config/resume/agents.json5` using `JSON5.parse()`, return as JSON
- **PUT /api/config/agents**: Accept JSON body, write back using `JSON.stringify(data, null, 2)` to `agents.json5` (note: writing as JSON is valid JSON5)
- **GET /api/config/ai-status**: Use existing `loadAIConfig()`, `validateAIConfig()`, `getMaskedApiKey()` from `ai-config.ts`. Return: `{ enabled, model, apiBase, temperature, maxTokens, timeout, apiKeyMasked, valid, validationError }`
- **Filter preset endpoints**: Add `savePresets()` and `updatePreset()` to `FilterPresetService`

### 3b. Extend `FilterPresetService` with write methods

Add to `apps/api/src/services/filter-preset-service.ts`:

```typescript
saveConfig(config: FilterPresetsConfig): void {
  const configPath = this.getConfigPath();
  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
  this.cache = config;
}

addPreset(preset: FilterPreset): void {
  const config = this.loadConfig();
  config.presets.push(preset);
  this.saveConfig(config);
}

updatePreset(id: string, updates: Partial<FilterPreset>): FilterPreset | undefined {
  const config = this.loadConfig();
  const index = config.presets.findIndex(p => p.id === id);
  if (index === -1) return undefined;
  config.presets[index] = { ...config.presets[index], ...updates };
  this.saveConfig(config);
  return config.presets[index];
}

deletePreset(id: string): boolean {
  const config = this.loadConfig();
  const before = config.presets.length;
  config.presets = config.presets.filter(p => p.id !== id);
  if (config.presets.length === before) return false;
  this.saveConfig(config);
  return true;
}
```

### 3c. Register route

- `routes/index.ts`: Add `export { default as configRoutes } from "./config.js";`
- `app.ts`: Import `configRoutes`, mount at `app.route("/api/config", configRoutes);`

**Verification:** `curl http://localhost:3000/api/config/agents` returns agent config JSON. `curl http://localhost:3000/api/config/ai-status` returns AI status. PUT to `/api/config/agents` modifies the file.

---

## Task 4: Debug Config Editor Page (Frontend) [DEPENDS: Task 3]

**Files:**

- `apps/web/src/pages/DebugConfig.tsx` (NEW)
- `apps/web/src/App.tsx` (add route)
- `apps/web/src/pages/DebugPage.tsx` (add sub-nav link)
- `apps/web/src/i18n/locales/en.json`
- `apps/web/src/i18n/locales/zh-Hans.json`
- `apps/web/src/i18n/locales/zh-Hant.json`

**Depends:** Task 3 (API endpoints)
**Conflict Risk:** `App.tsx` (add one route), `DebugPage.tsx` (add one nav link), i18n files

**Changes:**

### 4a. New page: `DebugConfig.tsx`

A dedicated config page at `/debug/config` with 3 sections:

**Section 1: AI Service Status** (read-only)

- Fetch from `GET /api/config/ai-status`
- Display: Enabled/Disabled badge, Model name, API Base URL, Temperature, Max Tokens, Timeout
- Validation status (valid/invalid with error message)
- Use Card + table layout

**Section 2: Agent Pipeline** (editable)

- Fetch from `GET /api/config/agents`
- Display 3-stage pipeline as cards: Screener → Evaluator → Final
- Each card shows: agent name, model, batchSize, parallelism, timeout, temperature, passThreshold
- Each field is an input that can be edited inline
- "Save" button per agent card → `PUT /api/config/agents` with full updated config
- Show toast on save success/failure

**Section 3: Filter Presets** (editable)

- Fetch from `GET /api/config/filter-presets`
- Display as a table with columns: ID, Name, Category, Min Exp, Max Exp, Education, Salary Range
- Each row has Edit/Delete buttons
- Edit opens inline form or modal
- "Add Preset" button at bottom
- Save → `PUT /api/config/filter-presets/:id` or `POST /api/config/filter-presets`
- Delete → `DELETE /api/config/filter-presets/:id`
- Use existing shadcn/ui table patterns from DebugJDs.tsx

### 4b. Route registration

In `App.tsx`, add before the `debug/*` catch-all:

```tsx
<Route path="/debug/config" element={<DebugConfig />} />
```

### 4c. Add to Debug sub-nav

In `DebugPage.tsx` line 394 `navLinks` array, add:

```tsx
{ key: 'config', label: t('debug.navConfig'), href: '/debug/config' }
```

Also in the `allowed` set on line 381, add `'config'`.

### 4d. i18n keys

Add under `"debugConfig"` (new section):

| Key | en | zh-Hans | zh-Hant |
|-----|----|---------|---------|
| `title` | System Configuration | 系统配置 | 系統配置 |
| `subtitle` | View and edit agent pipeline, filter presets, and AI service settings | 查看和编辑 Agent 流程、筛选预设和 AI 服务设置 | 查看和編輯 Agent 流程、篩選預設和 AI 服務設定 |
| `aiStatus` | AI Service Status | AI 服务状态 | AI 服務狀態 |
| `aiEnabled` | Enabled | 已启用 | 已啟用 |
| `aiDisabled` | Disabled | 未启用 | 未啟用 |
| `aiModel` | Model | 模型 | 模型 |
| `aiApiBase` | API Base | API 地址 | API 地址 |
| `aiTemperature` | Temperature | 温度 | 溫度 |
| `aiMaxTokens` | Max Tokens | 最大 Token | 最大 Token |
| `aiTimeout` | Timeout | 超时 | 逾時 |
| `aiValid` | Configuration Valid | 配置有效 | 配置有效 |
| `aiInvalid` | Configuration Invalid | 配置无效 | 配置無效 |
| `agents` | Agent Pipeline | Agent 流程 | Agent 流程 |
| `agentsDescription` | Multi-stage AI screening pipeline configuration | 多阶段 AI 筛选流程配置 | 多階段 AI 篩選流程配置 |
| `agentModel` | Model | 模型 | 模型 |
| `agentBatchSize` | Batch Size | 批量大小 | 批量大小 |
| `agentParallelism` | Parallelism | 并发数 | 並發數 |
| `agentTimeout` | Timeout (ms) | 超时 (ms) | 逾時 (ms) |
| `agentThreshold` | Pass Threshold | 通过阈值 | 通過閾值 |
| `save` | Save | 保存 | 儲存 |
| `saved` | Saved | 已保存 | 已儲存 |
| `saveError` | Save failed | 保存失败 | 儲存失敗 |
| `presets` | Filter Presets | 筛选预设 | 篩選預設 |
| `presetsDescription` | Quick filter configurations for common search patterns | 常用搜索模式的快速筛选配置 | 常用搜尋模式的快速篩選配置 |
| `addPreset` | Add Preset | 添加预设 | 新增預設 |
| `editPreset` | Edit | 编辑 | 編輯 |
| `deletePreset` | Delete | 删除 | 刪除 |
| `confirmDelete` | Are you sure you want to delete this preset? | 确定要删除这个预设吗？ | 確定要刪除這個預設嗎？ |
| `presetId` | ID | ID | ID |
| `presetName` | Name | 名称 | 名稱 |
| `presetCategory` | Category | 类别 | 類別 |
| `presetMinExp` | Min Experience | 最低经验 | 最低經驗 |
| `presetMaxExp` | Max Experience | 最高经验 | 最高經驗 |
| `presetEducation` | Education | 学历 | 學歷 |
| `presetSalary` | Salary Range | 薪资范围 | 薪資範圍 |

Also add to `"debug"` section:
| Key | en | zh-Hans | zh-Hant |
|-----|----|---------|---------|
| `navConfig` | Config | 配置 | 配置 |

**Verification:** Navigate to `/debug/config`. Confirm 3 sections load. Edit an agent threshold, click Save, refresh to confirm persistence. Add/edit/delete a filter preset.

---

## Task 5: Add DebugAI Link to Header [INDEPENDENT]

**Files:**

- `apps/web/src/components/Header.tsx`
- `apps/web/src/i18n/locales/en.json`
- `apps/web/src/i18n/locales/zh-Hans.json`
- `apps/web/src/i18n/locales/zh-Hant.json`

**Depends:** None
**Conflict Risk:** i18n locale files (different key section)

**Changes:**
Add a 4th NavLink for `/debug/ai` in both desktop and mobile nav sections of `Header.tsx`.

After the JDs NavLink (line 54 for desktop, line 91 for mobile), add:

```tsx
<NavLink
  to="/debug/ai"
  className={({ isActive }) =>
    cn(
      'transition-colors hover:text-foreground',
      isActive ? 'text-foreground' : 'text-muted-foreground'
    )
  }
>
  {t('nav.debugAi')}
</NavLink>
```

### i18n key (add to `"nav"` section)

| Key | en | zh-Hans | zh-Hant |
|-----|----|---------|---------|
| `debugAi` | Debug AI | AI 调试 | AI 偵錯 |

**Verification:** Confirm "Debug AI" link appears in header. Click navigates to `/debug/ai`. Works on both desktop and mobile nav.

---

## Task Dependency & Parallelism

```
Task 1 (QuickStartPanel i18n + link)  ──┐
Task 2 (JD edit icon)                  ──┤── All independent, run in parallel
Task 3 (Config API endpoints)          ──┤
Task 5 (Header DebugAI link)           ──┘
                                          │
Task 4 (Debug Config Editor page)      ───┘ depends on Task 3
```

Tasks 1, 2, 3, 5 can all execute in parallel. Task 4 runs after Task 3 completes.

### File Conflict Summary

| File | Tasks | Risk |
|------|-------|------|
| i18n locale files (en/zh-Hans/zh-Hant) | 1, 2, 4, 5 | Low - different key sections |
| `QuickStartPanel.tsx` | 1 | None - only Task 1 |
| `JobDescriptionSelect.tsx` | 2 | None - only Task 2 |
| `Header.tsx` | 5 | None - only Task 5 |
| `DebugPage.tsx` | 4 | None - only Task 4 (add one nav link) |
| `App.tsx` | 4 | None - only Task 4 (add one route) |
| `app.ts` (API) | 3 | None - only Task 3 |
| `routes/index.ts` (API) | 3 | None - only Task 3 |

---

## End-to-End Verification

1. `make dev-api` + `make dev-web`
2. **ResumesPage:**

- Enter keywords in QuickStartPanel → confirm translated match details (switch language)
- Confirm "Manage all JDs →" link in match result area
- Select a JD → confirm edit icon appears → click navigates to `/config/jds`

3. **Header:** Confirm 4 links: Resumes | Debug | JDs | Debug AI
4. **Debug AI:** Click "Debug AI" in header → page loads at `/debug/ai`
5. **Debug Config:**

- Navigate to `/debug/config` (also accessible from Debug page sub-nav pills)
- AI Status section shows current config (read-only)
- Agent Pipeline: Edit a threshold → Save → Refresh → confirm persistence
- Filter Presets: Add a new preset, edit an existing one, delete one → verify file changes

6. `make i18n-check` — all locale keys consistent
7. `make check-node` — TypeScript + lint pass

Implement plan

## PR Review Summary
- What Changed:
    - **UI Enhancements for Job Descriptions & Navigation**:
        - Added a "Manage all JDs →" link within the QuickStartPanel on the Resumes page, and internationalized several existing match detail strings.
        - Introduced an inline "Edit JD" icon next to the Job Description selector, providing a quick navigation link to `/config/jds` when a JD is selected.
        - Integrated a "Debug AI" link into the main application header (desktop and mobile) for direct access to AI debugging utilities.
    - **New Debug Configuration Editor**:
        - **Backend API (`apps/api`)**: A new `apps/api/src/routes/config.ts` file was created, exposing endpoints under `/api/config` for: retrieving and updating `agents.json5` configuration; fetching read-only AI service status (derived from environment variables); and comprehensive CRUD operations (list, add, update, delete) for filter presets, with changes persisting to `filter-presets.json5`.
        - **Frontend Page (`apps/web`)**: A new `DebugConfig.tsx` page (`/debug/config`) was implemented. It provides a read-only display of AI service status, an editable UI for agent pipeline configuration (allowing inline edits for parameters like `batchSize`, `parallelism`, `timeout`, `temperature`, `passThreshold`), and a table-based editor for filter presets with add, edit (via dialog), and delete functionalities.
    - **Internationalization (i18n)**: All new UI elements and features (e.g., quick links, debug config page labels, success/error toasts) have been fully internationalized across English, Simplified Chinese, and Traditional Chinese locales.
- Review Focus:
    - **Backend API Validation & Persistence**: Carefully review the Zod schemas and data writing logic in `apps/api/src/routes/config.ts` and `apps/api/src/services/filter-preset-service.ts` to ensure robust input validation and correct, safe persistence of configuration files (`agents.json5`, `filter-presets.json5`).
    - **Frontend Data Parsing**: Examine the `parse*` helper functions in `DebugConfig.tsx` for their resilience against unexpected or malformed API responses.
    - **Agent Configuration Saving Strategy**: Note that saving changes for a single agent currently sends and overwrites the entire `agents.json5` configuration. While acceptable for a debug tool, consider if this could lead to unintended overwrites in different contexts.
    - **Localization Accuracy**: Verify that all new strings across the UI (especially in the Debug Config editor and QuickStartPanel) are correctly translated and displayed in all supported languages.
- Test Plan:
    - **Setup**: Run `make dev-api` and `make dev-web` locally.
    - **Quick Links**: On the Resumes page, confirm the "Manage all JDs →" link in the QuickStartPanel navigates to `/config/jds`. Select a JD in the dropdown and verify the small "Edit JD" icon appears and also navigates to `/config/jds`. Switch languages to confirm QuickStartPanel translations.
    - **Header Navigation**: Confirm the "Debug AI" link is present in the main header and navigates correctly to `/debug/ai`.
    - **Debug Config Page**: Navigate to `/debug/config`.
        - **AI Status**: Verify the displayed AI service status (enabled, model, validation, errors) is accurate.
        - **Agent Pipeline**: Edit a numeric parameter for an agent (e.g., `passThreshold`), click "Save", and then refresh the page to confirm the change persists.
        - **Filter Presets**: Add a new preset, edit an existing one (testing various filter fields like experience, education, salary), and delete a preset. Verify that changes are saved correctly and reflected upon page refresh.
    - **Overall Code Health**: Run `make i18n-check` to validate locale consistency and `make check-node` for TypeScript and linting checks.