### PR TITLE
Implement AI analysis task system with real-time progress

### DIFF
--- a/apps/web/src/components/AnalysisTaskMonitor.tsx
+++ b/apps/web/src/components/AnalysisTaskMonitor.tsx
@@ -1,0 +1,202 @@
+import { useMutation, useQuery } from 'convex/react'
+import { useTranslation } from 'react-i18next'
+import { Loader2, CheckCircle2, XCircle, Clock, ChevronDown, ChevronUp } from 'lucide-react'
+import { useState } from 'react'
+import { api } from '../../../../packages/convex/convex/_generated/api'
+import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
+import { Progress } from './ui/progress'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from './ui/button'
+
+type AnalysisTaskDoc = Doc<'analysis_tasks'>
+
+function getStatusLabel(status: AnalysisTaskDoc['status']): string {
+  switch (status) {
+    case 'processing':
+      return 'Processing'
+    case 'completed':
+      return 'Completed'
+    case 'failed':
+      return 'Failed'
+    case 'cancelled':
+      return 'Cancelled'
+    default:
+      return 'Pending'
+  }
+}
+
+function getStatusBadgeClass(status: AnalysisTaskDoc['status']): string {
+  if (status === 'completed') {
+    return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+  }
+  if (status === 'failed') {
+    return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+  }
+  if (status === 'cancelled') {
+    return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
+  }
+  if (status === 'processing') {
+    return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+  }
+  return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400'
+}
+
+function StatusIcon({ status }: { status: AnalysisTaskDoc['status'] }) {
+  if (status === 'completed') {
+    return <CheckCircle2 className="h-4 w-4 text-green-500" />
+  }
+  if (status === 'failed') {
+    return <XCircle className="h-4 w-4 text-destructive" />
+  }
+  if (status === 'cancelled') {
+    return <XCircle className="h-4 w-4 text-orange-500" />
+  }
+  if (status === 'processing') {
+    return <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
+  }
+  return <Clock className="h-4 w-4 text-muted-foreground" />
+}
+
+function TaskItem({
+  task,
+  onCancel,
+}: {
+  task: AnalysisTaskDoc
+  onCancel: (args: { taskId: AnalysisTaskDoc['_id'] }) => Promise<unknown>
+}) {
+  const { t } = useTranslation()
+  const [cancelling, setCancelling] = useState(false)
+  const isActive = task.status === 'pending' || task.status === 'processing'
+  const total = task.progress.total || task.config.resumeCount || 1
+  const progress = Math.min(100, Math.max(0, Math.round((task.progress.current / total) * 100)))
+  const taskTitle = task.config.jobDescriptionTitle || task.config.jobDescriptionId
+
+  return (
+    <div className="space-y-2 border-b last:border-0 last:pb-0 pb-4">
+      <div className="flex items-center justify-between text-sm">
+        <div className="flex items-center gap-2">
+          <StatusIcon status={task.status} />
+          <span className="font-medium">{taskTitle}</span>
+          <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full ${getStatusBadgeClass(task.status)}`}>
+            {getStatusLabel(task.status)}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="text-xs text-muted-foreground">
+            {new Date(task._creationTime).toLocaleTimeString()}
+          </div>
+          {isActive ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 text-xs text-destructive hover:text-destructive hover:bg-destructive/10 px-2"
+              disabled={cancelling}
+              onClick={async () => {
+                setCancelling(true)
+                await onCancel({ taskId: task._id })
+              }}
+            >
+              {cancelling ? t('aiTasks.monitor.cancelling') : t('aiTasks.monitor.cancel')}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>
+            {t('aiTasks.monitor.progress')}: {task.progress.current} / {total} ({t('aiTasks.monitor.skipped')}: {task.progress.skipped})
+          </span>
+          <span>{progress}%</span>
+        </div>
+        <Progress value={progress} className="h-2" />
+        {task.lastStatus ? (
+          <p className="text-[10px] text-primary font-medium mt-1">{task.lastStatus}</p>
+        ) : null}
+      </div>
+
+      {task.status === 'completed' && task.results ? (
+        <div className="text-xs text-muted-foreground">
+          {t('aiTasks.monitor.analyzed')}: {task.results.analyzed} | {t('aiTasks.monitor.avgScore')}: {task.results.avgScore} | {t('aiTasks.monitor.highScore')}: {task.results.highScoreCount}
+        </div>
+      ) : null}
+
+      {task.status === 'failed' ? (
+        <div className="text-xs text-destructive">
+          {t('aiTasks.monitor.failed')}
+          {task.error ? `: ${task.error}` : ''}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export function AnalysisTaskMonitor() {
+  const { t } = useTranslation()
+  const tasks = useQuery(api.analysis_tasks.list)
+  const cancelTask = useMutation(api.analysis_tasks.cancel)
+  const [showHistory, setShowHistory] = useState(false)
+
+  if (!tasks || tasks.length === 0) {
+    return null
+  }
+
+  const activeTasks = tasks.filter((task) => task.status === 'pending' || task.status === 'processing')
+  const finishedTasks = tasks.filter((task) => task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled')
+  const hasActive = activeTasks.length > 0
+
+  if (!hasActive && !showHistory && finishedTasks.length > 0) {
+    return (
+      <Card className="mb-6 bg-muted/20">
+        <CardContent className="py-3 flex items-center justify-between">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <CheckCircle2 className="h-4 w-4 text-green-500" />
+            <span>{t('aiTasks.monitor.allCompleted')}</span>
+          </div>
+          <Button variant="ghost" size="sm" onClick={() => setShowHistory(true)} className="h-8 text-xs">
+            {t('aiTasks.monitor.showHistory')}
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="mb-6">
+      <CardHeader className="pb-3 border-b">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            {hasActive ? (
+              <Loader2 className="h-5 w-5 animate-spin text-primary" />
+            ) : (
+              <Clock className="h-5 w-5 text-muted-foreground" />
+            )}
+            {hasActive ? t('aiTasks.monitor.activeTitle') : t('aiTasks.monitor.historyTitle')}
+          </CardTitle>
+          {finishedTasks.length > 0 ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowHistory((prev) => !prev)}
+              className="text-xs h-8"
+            >
+              {showHistory ? <ChevronUp className="h-4 w-4 mr-1" /> : <ChevronDown className="h-4 w-4 mr-1" />}
+              {showHistory ? t('aiTasks.monitor.hideHistory') : t('aiTasks.monitor.showHistory')}
+            </Button>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="pt-4 space-y-4">
+        {activeTasks.map((task) => (
+          <TaskItem key={task._id} task={task} onCancel={cancelTask} />
+        ))}
+
+        {showHistory ? (
+          finishedTasks.map((task) => (
+            <TaskItem key={task._id} task={task} onCancel={cancelTask} />
+          ))
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -184,6 +184,25 @@
       "close": "Close"
     }
   },
+  "aiTasks": {
+    "dispatched": "Analysis task dispatched",
+    "dispatchFailed": "Failed to start analysis",
+    "monitor": {
+      "activeTitle": "Active Analysis",
+      "historyTitle": "Analysis History",
+      "allCompleted": "All analysis tasks completed",
+      "showHistory": "Show History",
+      "hideHistory": "Hide History",
+      "cancel": "Cancel",
+      "cancelling": "Cancelling...",
+      "progress": "Progress",
+      "skipped": "Skipped",
+      "analyzed": "Analyzed",
+      "avgScore": "Avg Score",
+      "highScore": "High Score (80+)",
+      "failed": "Failed"
+    }
+  },
   "quickStart": {
     "matchDetails": "Current Match Details",
     "labelJd": "JD",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -184,6 +184,25 @@
       "close": "关闭"
     }
   },
+  "aiTasks": {
+    "dispatched": "分析任务已创建",
+    "dispatchFailed": "启动分析失败",
+    "monitor": {
+      "activeTitle": "进行中的分析",
+      "historyTitle": "分析历史",
+      "allCompleted": "所有分析任务已完成",
+      "showHistory": "显示历史",
+      "hideHistory": "隐藏历史",
+      "cancel": "取消",
+      "cancelling": "取消中...",
+      "progress": "进度",
+      "skipped": "已跳过",
+      "analyzed": "已分析",
+      "avgScore": "平均分",
+      "highScore": "高分 (80+)",
+      "failed": "失败"
+    }
+  },
   "quickStart": {
     "matchDetails": "当前匹配详情",
     "labelJd": "职位",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -184,6 +184,25 @@
       "close": "關閉"
     }
   },
+  "aiTasks": {
+    "dispatched": "分析任務已建立",
+    "dispatchFailed": "啟動分析失敗",
+    "monitor": {
+      "activeTitle": "進行中的分析",
+      "historyTitle": "分析歷史",
+      "allCompleted": "所有分析任務已完成",
+      "showHistory": "顯示歷史",
+      "hideHistory": "隱藏歷史",
+      "cancel": "取消",
+      "cancelling": "取消中...",
+      "progress": "進度",
+      "skipped": "已跳過",
+      "analyzed": "已分析",
+      "avgScore": "平均分",
+      "highScore": "高分 (80+)",
+      "failed": "失敗"
+    }
+  },
   "quickStart": {
     "matchDetails": "當前匹配詳情",
     "labelJd": "職位",

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as analysis_tasks from "../analysis_tasks.js";
 import type * as analyze from "../analyze.js";
 import type * as job_descriptions from "../job_descriptions.js";
 import type * as resume_tasks from "../resume_tasks.js";
@@ -20,6 +21,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  analysis_tasks: typeof analysis_tasks;
   analyze: typeof analyze;
   job_descriptions: typeof job_descriptions;
   resume_tasks: typeof resume_tasks;

--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -1,0 +1,508 @@
+import { internal } from "./_generated/api";
+import type { Doc } from "./_generated/dataModel";
+import { internalAction, internalMutation, internalQuery, mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { SYSTEM_PROMPT, USER_PROMPT_TEMPLATE, callLLM, normalizeResume } from "./analyze";
+
+type AnalysisTaskStatus = "pending" | "processing" | "completed" | "failed" | "cancelled";
+
+type AnalysisResult = {
+    score: number;
+    summary: string;
+    highlights: string[];
+    recommendation: string;
+    breakdown?: Record<string, number>;
+};
+
+type Message = {
+    role: "system" | "user";
+    content: string;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+function toNumber(value: unknown): number | null {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+    }
+    if (typeof value === "string") {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+    return null;
+}
+
+function toStringArray(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return value.filter((item): item is string => typeof item === "string");
+}
+
+function parseBreakdown(value: unknown): Record<string, number> | undefined {
+    if (!isObject(value)) {
+        return undefined;
+    }
+
+    const parsed: Record<string, number> = {};
+    for (const [key, rawValue] of Object.entries(value)) {
+        const numericValue = toNumber(rawValue);
+        if (numericValue !== null) {
+            parsed[key] = numericValue;
+        }
+    }
+
+    return Object.keys(parsed).length > 0 ? parsed : undefined;
+}
+
+function parseLlmResult(value: unknown): AnalysisResult {
+    if (!isObject(value)) {
+        throw new Error("Invalid analysis result: expected object.");
+    }
+
+    const score = toNumber(value.score);
+    if (score === null) {
+        throw new Error("Invalid analysis result: score is missing.");
+    }
+
+    const summary = typeof value.summary === "string" ? value.summary : "";
+    const recommendation = typeof value.recommendation === "string" ? value.recommendation : "potential";
+
+    return {
+        score,
+        summary: summary || "No summary provided.",
+        highlights: toStringArray(value.highlights),
+        recommendation,
+        breakdown: parseBreakdown(value.breakdown),
+    };
+}
+
+function extractKeywords(input: string): string[] {
+    const matched = input.toLowerCase().match(/[\u4e00-\u9fa5a-z0-9]{2,}/g) ?? [];
+    return [...new Set(matched)];
+}
+
+function classifyResumes(
+    resumes: Doc<"resumes">[],
+    keywords: string[]
+): { toAnalyze: Doc<"resumes">[]; toSkip: Doc<"resumes">[] } {
+    if (keywords.length === 0) {
+        return { toAnalyze: resumes, toSkip: [] };
+    }
+
+    const toAnalyze: Doc<"resumes">[] = [];
+    const toSkip: Doc<"resumes">[] = [];
+    const threshold = 10;
+
+    for (const resume of resumes) {
+        const serialized = JSON.stringify(resume).toLowerCase();
+        let matches = 0;
+        for (const keyword of keywords) {
+            if (serialized.includes(keyword)) {
+                matches += 1;
+            }
+        }
+
+        const score = Math.min(100, Math.round((matches / Math.max(keywords.length, 1)) * 100));
+        if (score < threshold) {
+            toSkip.push(resume);
+            continue;
+        }
+        toAnalyze.push(resume);
+    }
+
+    return { toAnalyze, toSkip };
+}
+
+async function analyzeOneResume(
+    resume: Doc<"resumes">,
+    config: {
+        jobDescriptionId: string;
+        jobDescriptionTitle?: string;
+        jobDescriptionContent?: string;
+    },
+    apiKey: string
+): Promise<AnalysisResult> {
+    const jobTitle = config.jobDescriptionTitle || config.jobDescriptionId || "销售经理 (通用)";
+    const requirements = config.jobDescriptionContent || "具备销售经验，沟通能力强，熟悉机床行业优先。";
+    const matchingRules = "使用默认评分标准";
+    const normalizedResume = normalizeResume(resume.content);
+
+    const prompt = USER_PROMPT_TEMPLATE
+        .replace("{jobTitle}", jobTitle)
+        .replace("{requirements}", requirements)
+        .replace("{matchingRules}", matchingRules)
+        .replace("{candidateName}", normalizedResume.name)
+        .replace("{jobIntention}", normalizedResume.jobIntention)
+        .replace("{workExperience}", String(normalizedResume.workExperience))
+        .replace("{education}", normalizedResume.education)
+        .replace("{skills}", normalizedResume.skills)
+        .replace("{companies}", normalizedResume.companies)
+        .replace("{summary}", normalizedResume.summary);
+
+    const messages: Message[] = [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: prompt },
+    ];
+
+    const rawResult = await callLLM(messages, apiKey);
+    return parseLlmResult(rawResult);
+}
+
+export const list = query({
+    args: {},
+    handler: async (ctx) => {
+        return await ctx.db
+            .query("analysis_tasks")
+            .order("desc")
+            .take(20);
+    },
+});
+
+export const getSummary = query({
+    args: {},
+    handler: async (ctx) => {
+        const tasks = await ctx.db.query("analysis_tasks").collect();
+        return {
+            total: tasks.length,
+            pending: tasks.filter((task) => task.status === "pending").length,
+            processing: tasks.filter((task) => task.status === "processing").length,
+            completed: tasks.filter((task) => task.status === "completed").length,
+            failed: tasks.filter((task) => task.status === "failed").length,
+            cancelled: tasks.filter((task) => task.status === "cancelled").length,
+        };
+    },
+});
+
+export const dispatch = mutation({
+    args: {
+        jobDescriptionId: v.string(),
+        jobDescriptionTitle: v.optional(v.string()),
+        jobDescriptionContent: v.optional(v.string()),
+        sample: v.optional(v.string()),
+        resumeIds: v.array(v.id("resumes")),
+    },
+    handler: async (ctx, args) => {
+        const taskId = await ctx.db.insert("analysis_tasks", {
+            config: {
+                jobDescriptionId: args.jobDescriptionId,
+                jobDescriptionTitle: args.jobDescriptionTitle,
+                jobDescriptionContent: args.jobDescriptionContent,
+                sample: args.sample,
+                resumeCount: args.resumeIds.length,
+            },
+            status: "pending",
+            progress: {
+                current: 0,
+                total: args.resumeIds.length,
+                skipped: 0,
+            },
+        });
+
+        await ctx.scheduler.runAfter(0, internal.analysis_tasks.processAnalysisTask, {
+            taskId,
+            resumeIds: args.resumeIds,
+        });
+
+        return taskId;
+    },
+});
+
+export const cancel = mutation({
+    args: {
+        taskId: v.id("analysis_tasks"),
+    },
+    handler: async (ctx, args) => {
+        const task = await ctx.db.get(args.taskId);
+        if (!task || (task.status !== "pending" && task.status !== "processing")) {
+            return;
+        }
+
+        await ctx.db.patch(args.taskId, {
+            status: "cancelled",
+            completedAt: Date.now(),
+        });
+    },
+});
+
+export const getTask = internalQuery({
+    args: {
+        taskId: v.id("analysis_tasks"),
+    },
+    handler: async (ctx, args) => {
+        return await ctx.db.get(args.taskId);
+    },
+});
+
+export const markProcessing = internalMutation({
+    args: {
+        taskId: v.id("analysis_tasks"),
+    },
+    handler: async (ctx, args) => {
+        const task = await ctx.db.get(args.taskId);
+        if (!task) {
+            return null;
+        }
+
+        if (task.status === "cancelled") {
+            return { status: "cancelled" as const };
+        }
+
+        await ctx.db.patch(args.taskId, {
+            status: "processing",
+            startedAt: Date.now(),
+            completedAt: undefined,
+            error: undefined,
+        });
+
+        return { status: "processing" as const };
+    },
+});
+
+export const updateProgress = internalMutation({
+    args: {
+        taskId: v.id("analysis_tasks"),
+        current: v.number(),
+        skipped: v.number(),
+        lastStatus: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const task = await ctx.db.get(args.taskId);
+        if (!task) {
+            return null;
+        }
+
+        if (task.status === "cancelled") {
+            return { status: "cancelled" as const };
+        }
+
+        await ctx.db.patch(args.taskId, {
+            progress: {
+                current: args.current,
+                total: task.progress.total,
+                skipped: args.skipped,
+            },
+            lastStatus: args.lastStatus,
+        });
+
+        return { status: task.status };
+    },
+});
+
+export const complete = internalMutation({
+    args: {
+        taskId: v.id("analysis_tasks"),
+        status: v.union(v.literal("completed"), v.literal("failed"), v.literal("cancelled")),
+        error: v.optional(v.string()),
+        results: v.optional(v.object({
+            analyzed: v.number(),
+            skipped: v.number(),
+            failed: v.number(),
+            avgScore: v.number(),
+            highScoreCount: v.number(),
+        })),
+    },
+    handler: async (ctx, args) => {
+        const task = await ctx.db.get(args.taskId);
+        if (!task) {
+            return;
+        }
+
+        const nextStatus: AnalysisTaskStatus =
+            task.status === "cancelled" && args.status !== "cancelled"
+                ? "cancelled"
+                : args.status;
+
+        await ctx.db.patch(args.taskId, {
+            status: nextStatus,
+            error: args.error,
+            results: args.results,
+            completedAt: Date.now(),
+            lastStatus: nextStatus === "completed" ? "Completed" : task.lastStatus,
+        });
+    },
+});
+
+export const processAnalysisTask = internalAction({
+    args: {
+        taskId: v.id("analysis_tasks"),
+        resumeIds: v.array(v.id("resumes")),
+    },
+    handler: async (ctx, args) => {
+        let analyzedCount = 0;
+        let failedCount = 0;
+        let highScoreCount = 0;
+        let skippedCount = 0;
+        let scoreSum = 0;
+        let cancelled = false;
+
+        try {
+            const apiKey = process.env.OPENAI_API_KEY;
+            if (!apiKey) {
+                throw new Error("OPENAI_API_KEY is not set in Convex environment variables.");
+            }
+
+            const markResult = await ctx.runMutation(internal.analysis_tasks.markProcessing, {
+                taskId: args.taskId,
+            });
+
+            if (!markResult) {
+                throw new Error(`Analysis task not found: ${String(args.taskId)}`);
+            }
+
+            if (markResult.status === "cancelled") {
+                await ctx.runMutation(internal.analysis_tasks.complete, {
+                    taskId: args.taskId,
+                    status: "cancelled",
+                    results: {
+                        analyzed: 0,
+                        skipped: 0,
+                        failed: 0,
+                        avgScore: 0,
+                        highScoreCount: 0,
+                    },
+                });
+                return { status: "cancelled" as const };
+            }
+
+            const task = await ctx.runQuery(internal.analysis_tasks.getTask, {
+                taskId: args.taskId,
+            });
+            if (!task) {
+                throw new Error(`Analysis task not found: ${String(args.taskId)}`);
+            }
+
+            const resumes = await ctx.runQuery(internal.resumes.getResumesByIds, {
+                resumeIds: args.resumeIds,
+            });
+            const keywordSource = `${task.config.jobDescriptionContent ?? ""} ${task.config.jobDescriptionTitle ?? ""}`;
+            const keywords = extractKeywords(keywordSource);
+            const { toAnalyze, toSkip } = classifyResumes(resumes, keywords);
+
+            skippedCount = toSkip.length;
+
+            if (toSkip.length > 0) {
+                await ctx.runMutation(internal.resumes.updateAnalysisBatch, {
+                    updates: toSkip.map((resume) => ({
+                        resumeId: resume._id,
+                        analysis: {
+                            score: 10,
+                            summary: "Auto-filtered: Low keyword match with JD.",
+                            highlights: [],
+                            recommendation: "no_match",
+                            breakdown: {
+                                keyword_match: 10,
+                            },
+                            jobDescriptionId: task.config.jobDescriptionId,
+                        },
+                    })),
+                });
+            }
+
+            let current = skippedCount;
+            const afterSkip = await ctx.runMutation(internal.analysis_tasks.updateProgress, {
+                taskId: args.taskId,
+                current,
+                skipped: skippedCount,
+                lastStatus: toAnalyze.length > 0
+                    ? `Analyzing resumes ${current}/${task.progress.total}`
+                    : `Processed ${current}/${task.progress.total}`,
+            });
+
+            if (afterSkip?.status === "cancelled") {
+                cancelled = true;
+            }
+
+            if (!cancelled) {
+                for (const resume of toAnalyze) {
+                    try {
+                        const result = await analyzeOneResume(
+                            resume,
+                            {
+                                jobDescriptionId: task.config.jobDescriptionId,
+                                jobDescriptionTitle: task.config.jobDescriptionTitle,
+                                jobDescriptionContent: task.config.jobDescriptionContent,
+                            },
+                            apiKey
+                        );
+
+                        await ctx.runMutation(internal.resumes.updateAnalysis, {
+                            resumeId: resume._id,
+                            analysis: {
+                                score: result.score,
+                                summary: result.summary,
+                                highlights: result.highlights,
+                                recommendation: result.recommendation,
+                                breakdown: result.breakdown,
+                                jobDescriptionId: task.config.jobDescriptionId,
+                            },
+                        });
+
+                        analyzedCount += 1;
+                        scoreSum += result.score;
+                        if (result.score >= 80) {
+                            highScoreCount += 1;
+                        }
+                    } catch (error) {
+                        failedCount += 1;
+                        console.error(`Failed to analyze resume ${String(resume._id)}:`, error);
+                    }
+
+                    current += 1;
+                    const progressResult = await ctx.runMutation(internal.analysis_tasks.updateProgress, {
+                        taskId: args.taskId,
+                        current,
+                        skipped: skippedCount,
+                        lastStatus: `Analyzing resumes ${current}/${task.progress.total}`,
+                    });
+
+                    if (progressResult?.status === "cancelled") {
+                        cancelled = true;
+                        break;
+                    }
+                }
+            }
+
+            const avgScore = analyzedCount > 0
+                ? Number((scoreSum / analyzedCount).toFixed(2))
+                : 0;
+
+            await ctx.runMutation(internal.analysis_tasks.complete, {
+                taskId: args.taskId,
+                status: cancelled ? "cancelled" : "completed",
+                results: {
+                    analyzed: analyzedCount,
+                    skipped: skippedCount,
+                    failed: failedCount,
+                    avgScore,
+                    highScoreCount,
+                },
+            });
+
+            return { status: cancelled ? "cancelled" as const : "completed" as const };
+        } catch (error) {
+            console.error(`Analysis task failed ${String(args.taskId)}:`, error);
+            const message = error instanceof Error ? error.message : "Unknown error";
+            const avgScore = analyzedCount > 0 ? Number((scoreSum / analyzedCount).toFixed(2)) : 0;
+
+            await ctx.runMutation(internal.analysis_tasks.complete, {
+                taskId: args.taskId,
+                status: cancelled ? "cancelled" : "failed",
+                error: message,
+                results: {
+                    analyzed: analyzedCount,
+                    skipped: skippedCount,
+                    failed: failedCount,
+                    avgScore,
+                    highScoreCount,
+                },
+            });
+
+            return { status: "failed" as const, error: message };
+        }
+    },
+});

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -2,7 +2,7 @@ import { action } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
 
-const SYSTEM_PROMPT = `你是一个专业的HR助手，专门帮助筛选精密机械和机床行业的简历。
+export const SYSTEM_PROMPT = `你是一个专业的HR助手，专门帮助筛选精密机械和机床行业的简历。
 你必须严格按照【纯数字 JSON】格式返回结果。
 1. 绝对不要包含 markdown 标记 (如 \`\`\`json ... \`\`\`)。
 2. 所有评分字段（score, breakdown.*）必须是【JSON Number 类型】，绝对禁止使用字符串或中文数字（如 "30", "三十", thirty）。
@@ -10,7 +10,7 @@ const SYSTEM_PROMPT = `你是一个专业的HR助手，专门帮助筛选精密�
 4. 错误示例: "score": "85", "score": "eighty-five"
 5. 如果无法确切评分，请基于现有信息估算一个数字。`;
 
-const USER_PROMPT_TEMPLATE = `请分析以下候选人与职位的匹配度：
+export const USER_PROMPT_TEMPLATE = `请分析以下候选人与职位的匹配度：
 
 ## 职位信息
 **职位名称**: {jobTitle}
@@ -46,7 +46,7 @@ const USER_PROMPT_TEMPLATE = `请分析以下候选人与职位的匹配度：
 }`;
 
 // Helper to normalize resume data
-function normalizeResume(data: any) {
+export function normalizeResume(data: any) {
     return {
         name: data.name || "未填写",
         jobIntention: data.jobIntention || data.desiredPosition || "未填写",
@@ -59,7 +59,7 @@ function normalizeResume(data: any) {
 }
 
 // Helper to call OpenAI/Compatible API
-async function callLLM(messages: any[], apiKey: string) {
+export async function callLLM(messages: any[], apiKey: string) {
     const apiBase = process.env.OPENAI_API_BASE || "https://api.openai.com/v1";
     const url = `${apiBase}/chat/completions`;
 

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -1,4 +1,4 @@
-import { internalMutation, internalQuery, mutation, query } from "./_generated/server";
+import { internalMutation, internalQuery, query } from "./_generated/server";
 import { v } from "convex/values";
 
 export const list = query({
@@ -13,6 +13,16 @@ export const getResume = internalQuery({
     args: { resumeId: v.id("resumes") },
     handler: async (ctx, args) => {
         return await ctx.db.get(args.resumeId);
+    },
+});
+
+export const getResumesByIds = internalQuery({
+    args: {
+        resumeIds: v.array(v.id("resumes")),
+    },
+    handler: async (ctx, args) => {
+        const docs = await Promise.all(args.resumeIds.map((resumeId) => ctx.db.get(resumeId)));
+        return docs.filter((doc): doc is NonNullable<typeof doc> => doc !== null);
     },
 });
 
@@ -45,7 +55,7 @@ export const updateAnalysis = internalMutation({
     },
 });
 
-export const updateAnalysisBatch = mutation({
+export const updateAnalysisBatch = internalMutation({
     args: {
         updates: v.array(v.object({
             resumeId: v.id("resumes"),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -77,4 +77,37 @@ export default defineSchema({
         enabled: v.boolean(),
         lastModified: v.number(),
     }),
+
+    analysis_tasks: defineTable({
+        config: v.object({
+            jobDescriptionId: v.string(),
+            jobDescriptionTitle: v.optional(v.string()),
+            jobDescriptionContent: v.optional(v.string()),
+            sample: v.optional(v.string()),
+            resumeCount: v.number(),
+        }),
+        status: v.union(
+            v.literal("pending"),
+            v.literal("processing"),
+            v.literal("completed"),
+            v.literal("failed"),
+            v.literal("cancelled")
+        ),
+        progress: v.object({
+            current: v.number(),
+            total: v.number(),
+            skipped: v.number(),
+        }),
+        results: v.optional(v.object({
+            analyzed: v.number(),
+            skipped: v.number(),
+            failed: v.number(),
+            avgScore: v.number(),
+            highScoreCount: v.number(),
+        })),
+        lastStatus: v.optional(v.string()),
+        error: v.optional(v.string()),
+        startedAt: v.optional(v.number()),
+        completedAt: v.optional(v.number()),
+    }).index("by_status", ["status"]),
 });


### PR DESCRIPTION
## Task

# Phase 10: AI Analysis Task System

> **Goal**: Convert the inline "Analyze All (AI)" button into a proper Convex-backed task system with progress tracking, cancellation, and inline progress display on the Resumes page — so users can see scores refreshing in real-time.

---

## Architecture

The "worker" is the **Convex action runtime** (not a Python worker). Flow:

```
User clicks "Analyze All (AI)" on Resumes page
  → Dispatches task (Convex mutation creates analysis_task: pending)
  → Scheduler triggers internal action (processing)
  → Action iterates resumes, calls LLM, updates progress per resume
  → Each resume.analysis update triggers Convex reactivity → scores appear in real-time
  → AnalysisTaskMonitor on Resumes page shows progress bar
  → Action checks cancellation via updateProgress return value
  → Calls complete with results summary
```

---

## Task 0: Add `analysis_tasks` Table to Schema [INDEPENDENT]

**Files**: `packages/convex/convex/schema.ts`

Append new table after `job_descriptions` (line \~79):

```typescript
analysis_tasks: defineTable({
    config: v.object({
        jobDescriptionId: v.string(),
        jobDescriptionTitle: v.optional(v.string()),
        jobDescriptionContent: v.optional(v.string()),
        sample: v.optional(v.string()),
        resumeCount: v.number(),
    }),
    status: v.union(
        v.literal("pending"),
        v.literal("processing"),
        v.literal("completed"),
        v.literal("failed"),
        v.literal("cancelled")
    ),
    progress: v.object({
        current: v.number(),
        total: v.number(),
        skipped: v.number(),
    }),
    results: v.optional(v.object({
        analyzed: v.number(),
        skipped: v.number(),
        failed: v.number(),
        avgScore: v.number(),
        highScoreCount: v.number(),
    })),
    lastStatus: v.optional(v.string()),
    error: v.optional(v.string()),
    startedAt: v.optional(v.number()),
    completedAt: v.optional(v.number()),
}).index("by_status", ["status"]),
```

**Verification**: `npx convex dev` succeeds, new table visible in dashboard.

---

## Task 1: Create `analysis_tasks.ts` Convex Module [DEPENDS: Task 0]

**Files**: `packages/convex/convex/analysis_tasks.ts` (NEW)

### Public Queries (for UI)

- **`list`** — 20 most recent tasks, desc order (pattern: `resume_tasks.ts:5-13`)
- **`getSummary`** — aggregate stats: total/pending/processing/completed/failed/cancelled (pattern: `resume_tasks.ts:180-195`)

### Public Mutations (for UI)

- **`dispatch`** `({ jobDescriptionId, jobDescriptionTitle?, jobDescriptionContent?, sample?, resumeIds: Id<"resumes">[] })` — creates task with status=pending, progress={0, total, 0}, then schedules `processAnalysisTask` action. Returns taskId.
- **`cancel`** `({ taskId })` — sets status=cancelled if pending/processing (pattern: `resume_tasks.ts:118-132`)

### Internal Mutations (for the action)

- **`markProcessing`** — sets status=processing, startedAt
- **`updateProgress`** `({ taskId, current, skipped, lastStatus? })` — patches progress, returns `{ status }` for cancellation detection (pattern: `resume_tasks.ts:68-95`)
- **`complete`** `({ taskId, status, error?, results? })` — sets completedAt + results summary

### Internal Action: `processAnalysisTask`

1. Call `markProcessing`
2. Fetch all resume docs via `ctx.runQuery`
3. Hybrid filter: classify into `toSkip` (keyword match < 10) vs `toAnalyze` — reuse logic from `ResumeList.tsx:243-272`
4. Batch-update skipped resumes via `ctx.runMutation(internal.resumes.updateAnalysisBatch)` with score=10, no\_match
5. Update progress with skipped count
6. For each `toAnalyze` resume (sequentially, or small batches of 3-5):

- Call shared `analyzeOneResume()` helper (Task 2) — LLM call + parse
- Store result via `ctx.runMutation(internal.resumes.updateAnalysis)` — **this triggers real-time score updates on Resumes page via Convex reactivity**
- Call `updateProgress` — if returned status is "cancelled", break
- Track scores for avgScore/highScoreCount computation

7. Call `complete` with final results

**JD content**: Passed from UI at dispatch time (stored in `config.jobDescriptionContent`).

**Verification**: Dispatch from Convex dashboard, verify processing completes with results.

---

## Task 2: Extract Shared LLM Helper from `analyze.ts` [INDEPENDENT]

**Files**: `packages/convex/convex/analyze.ts` (MODIFY)

Add `export` to these existing functions/constants so `analysis_tasks.ts` can import them:

- `normalizeResume(data)` (line 49)
- `callLLM(messages, apiKey)` (line 62)
- `SYSTEM_PROMPT` (line 5)
- `USER_PROMPT_TEMPLATE` (line 13)

The existing `analyzeResume` and `analyzeBatch` actions remain unchanged.

**Verification**: Existing `analyzeResume` action still works.

---

## Task 3: Create `AnalysisTaskMonitor` Component [DEPENDS: Tasks 0, 1]

**Files**: `apps/web/src/components/AnalysisTaskMonitor.tsx` (NEW)

Follow `TaskMonitor.tsx` (174 lines) pattern. Key differences:

- `useQuery(api.analysis_tasks.list)` / `useMutation(api.analysis_tasks.cancel)`
- Progress display: `{current} / {total}` with `(skipped: {skipped})`
- Task item title: `task.config.jobDescriptionTitle` (not keyword)
- Completed tasks show results: `Analyzed: {results.analyzed} | Avg: {results.avgScore} | 80+: {results.highScoreCount}`
- Header: "Active Analysis" / "Analysis History"
- Same active/history split with collapsed history by default

**Verification**: Renders correctly with mock/real task data.

**DevTools MCP test (Task 3)**:

```
1. navigate_page → http://localhost:5173/resumes
2. take_snapshot → confirm AnalysisTaskMonitor component renders (or is hidden when no tasks)
3. If tasks exist: verify progress bar element, status badge, cancel button in snapshot
```

---

## Task 4: Integrate AnalysisTaskMonitor into ResumesPage [DEPENDS: Task 3]

**Files**: `apps/web/src/components/ResumeList.tsx` (MODIFY)

Place `<AnalysisTaskMonitor />` on the Resumes page, between the toolbar (Analyze All button) and the resume cards list. This way:

- User clicks "Analyze All (AI)"
- Progress bar appears inline showing "Analyzing resume 15/176... (skipped: 42)"
- Resume cards below update with scores in real-time as each analysis completes (Convex reactivity handles this automatically)
- User can cancel from the inline monitor

Position it after the filter/sort controls and before the resume card grid (around line 528 in ResumeList.tsx).

**DevTools MCP test (Task 4)**:

```
1. navigate_page → http://localhost:5173/resumes
2. take_snapshot → confirm AnalysisTaskMonitor appears between toolbar and resume cards
3. Verify layout: toolbar → monitor → card grid (no overlap, correct ordering)
```

---

## Task 5: Rewire "Analyze All (AI)" Button to Dispatch Task [DEPENDS: Tasks 0, 1]

**Files**: `apps/web/src/components/ResumeList.tsx` (MODIFY)

Replace `handleAnalyzeAll` (lines 215-306) with task dispatch:

```typescript
const dispatchAnalysis = useMutation(api.analysis_tasks.dispatch)

const handleAnalyzeAll = async () => {
  if (!convexResumes.length) return
  setAnalyzing(true)
  try {
    // Fetch JD content (keep existing lines 222-238 for rawApiClient.GET)
    let jdContent = '', jdTitle = ''
    if (jobDescriptionId) { /* existing JD fetch logic */ }

    await dispatchAnalysis({
      jobDescriptionId: jobDescriptionId || 'default',
      jobDescriptionTitle: jdTitle,
      jobDescriptionContent: jdContent,
      sample: selectedSample || undefined,
      resumeIds: convexResumes.map(r => r.resumeId),
    })
    // Toast: "Analysis task dispatched — watch progress below"
  } catch (e) {
    console.error('Failed to dispatch', e)
  } finally {
    setAnalyzing(false)
  }
}
```

Remove from handleAnalyzeAll: inline hybrid filtering, `updateAnalysisBatch` call, `analyzeBatch` call. That logic moves to the Convex action (Task 1).

Keep `updateAnalysisBatch` and `analyzeBatch` imports only if used elsewhere; otherwise remove.

**DevTools MCP test (Task 5)**:

```
1. navigate_page → http://localhost:5173/resumes
2. take_snapshot → find "Analyze All (AI)" button uid
3. click → button uid (click the Analyze All button)
4. wait_for → "Analysis task dispatched" (toast text)
5. take_snapshot → confirm AnalysisTaskMonitor now shows active task with progress bar
6. Wait ~10s, take_snapshot again → verify progress.current has incremented
7. Verify resume cards show new scores (look for score badge elements in snapshot)
```

---

## Task 6: i18n Strings [INDEPENDENT]

**Files**: `apps/web/src/i18n/locales/en.json`, `zh-Hans.json`, `zh-Hant.json`

Add `aiTasks` section:

```json
"aiTasks": {
  "dispatched": "Analysis task dispatched",
  "dispatchFailed": "Failed to start analysis",
  "monitor": {
    "activeTitle": "Active Analysis",
    "historyTitle": "Analysis History",
    "allCompleted": "All analysis tasks completed",
    "showHistory": "Show History",
    "hideHistory": "Hide History",
    "cancel": "Cancel",
    "cancelling": "Cancelling...",
    "progress": "Progress",
    "skipped": "Skipped",
    "analyzed": "Analyzed",
    "avgScore": "Avg Score",
    "highScore": "High Score (80+)",
    "failed": "Failed"
  }
}
```

Plus zh-Hans/zh-Hant equivalents.

**DevTools MCP test (Task 6)**:

```
1. navigate_page → http://localhost:5173/resumes
2. take_snapshot → find language switcher uid
3. click → language switcher, select zh-Hant or en
4. take_snapshot → verify AnalysisTaskMonitor labels changed to selected language
```

---

## Task Dependencies

```
Task 0 (schema) ──┬── Task 1 (mutations/actions) ──┬── Task 4 (integrate into ResumesPage)
                   │                                 ├── Task 3 (AnalysisTaskMonitor)
Task 2 (helpers) ──┘                                 └── Task 5 (rewire button)

Task 6 (i18n) ──── independent, needed by Tasks 3, 4, 5
```

**Parallel sets:**

- Start immediately: Task 0, Task 2, Task 6
- After Task 0+2: Task 1
- After Task 1: Tasks 3, 5 (parallel — different files)
- After Task 3: Task 4

---

## Summary of Changes

| File | Action | What |
|------|--------|------|
| `packages/convex/convex/schema.ts` | MODIFY | Add `analysis_tasks` table |
| `packages/convex/convex/analysis_tasks.ts` | NEW | Task lifecycle: dispatch, process, cancel, list, getSummary |
| `packages/convex/convex/analyze.ts` | MODIFY | Export shared helpers (normalizeResume, callLLM, prompts) |
| `apps/web/src/components/AnalysisTaskMonitor.tsx` | NEW | Progress/history UI for analysis tasks |
| `apps/web/src/components/ResumeList.tsx` | MODIFY | Rewire "Analyze All" to dispatch task + embed AnalysisTaskMonitor |
| `apps/web/src/i18n/locales/*.json` | MODIFY | Add aiTasks i18n strings |

---

## Verification Plan

### Backend

1. **Schema**: `npx convex dev` starts without errors
2. **Backend**: From Convex dashboard, call `dispatch` → verify task processes through pending → processing → completed
3. **Cancellation**: Dispatch task, call `cancel` while processing — verify it stops

### UI — Full E2E via DevTools MCP (chrome-devtools-9222)

**Pre-requisite**: `make dev` running (Vite on :5173, Convex synced)

```
Step 1: Navigate & verify page loads
  → navigate_page url=http://localhost:5173/resumes
  → take_snapshot → confirm page loaded with resume cards and "Analyze All (AI)" button

Step 2: Verify AnalysisTaskMonitor renders (empty/hidden state)
  → take_snapshot → if no active tasks, monitor should be hidden or show "All completed"

Step 3: Select JD (if not already selected)
  → take_snapshot → find JobDescriptionSelect uid
  → click JD dropdown → select a JD option

Step 4: Click "Analyze All (AI)"
  → find button uid from snapshot
  → click button uid
  → wait_for "Analysis task dispatched" (toast)

Step 5: Verify progress bar appears
  → take_snapshot → confirm AnalysisTaskMonitor shows:
    - Active task with JD title
    - Progress bar (e.g. "3 / 176")
    - "Processing" badge
    - Cancel button

Step 6: Verify real-time score updates
  → wait 10-15s
  → take_snapshot → compare resume cards — some should now show score badges
  → verify progress.current has incremented

Step 7: Test cancellation
  → find Cancel button uid in snapshot
  → click Cancel
  → wait_for "Cancelled" badge
  → take_snapshot → confirm task shows "Cancelled" status

Step 8: Test i18n
  → navigate to language switcher (in header or system sidebar)
  → switch language
  → take_snapshot → verify monitor labels changed
```

Implement plan

## PR Review Summary
- What Changed:
  - **Schema Update**: A new `analysis_tasks` table was added to `packages/convex/convex/schema.ts` to track the state and progress of AI resume analysis tasks.
  - **New Convex Module**: `packages/convex/convex/analysis_tasks.ts` was introduced, providing public queries (`list`, `getSummary`), public mutations (`dispatch`, `cancel`), and internal mutations (`markProcessing`, `updateProgress`, `complete`, `getTask`) to manage the task lifecycle.
  - **Internal Action**: The `processAnalysisTask` internal action was implemented to orchestrate the AI analysis workflow. It fetches resumes, performs hybrid filtering to skip low-match resumes, updates skipped resumes, calls the LLM for analysis one-by-one, and updates individual resume analysis, all while tracking progress and handling cancellation.
  - **Shared LLM Helpers**: `packages/convex/convex/analyze.ts` was modified to export `normalizeResume`, `callLLM`, `SYSTEM_PROMPT`, and `USER_PROMPT_TEMPLATE`, making them accessible to the new `analysis_tasks` module.
  - **Resume Operations**: `packages/convex/convex/resumes.ts` gained a new internal query `getResumesByIds` and its `updateAnalysisBatch` mutation was changed to an `internalMutation`.
  - **New UI Component**: `apps/web/src/components/AnalysisTaskMonitor.tsx` was created to display a progress bar, status, and results for active and historical analysis tasks on the Resumes page, including a cancel button.
  - **"Analyze All (AI)" Rewire**: The `handleAnalyzeAll` function in `apps/web/src/components/ResumeList.tsx` was updated to dispatch an `analysis_tasks.dispatch` mutation. The prior inline hybrid filtering and direct `analyzeBatch` calls were removed, as this logic is now handled within the Convex action. The `AnalysisTaskMonitor` component was embedded into this page, and toast notifications for dispatch status were added.
  - **i18n Strings**: New internationalization strings for AI analysis tasks and the task monitor were added across `en.json`, `zh-Hans.json`, and `zh-Hant.json`.

- Review Focus:
  - **Cancellation Logic**: Verify that the `processAnalysisTask` action robustly checks for and respects cancellation requests at multiple points (before starting analysis, after skipping, and between individual resume analyses).
  - **Error Handling**: Ensure that all potential errors within `processAnalysisTask` (e.g., LLM failures, missing API key, DB issues) are caught and correctly update the task status to "failed" with a clear error message.
  - **LLM Output Parsing**: Review `parseLlmResult` in `analysis_tasks.ts` for its resilience against unexpected or malformed LLM responses, especially given the strict JSON requirements.
  - **Performance for Large Datasets**: While the current sequential processing for analysis is acceptable for a first pass, consider the impact on Convex action limits and user experience for a very large number of resumes. The original request mentioned small batches, but the current implementation iterates sequentially.
  - **UI Responsiveness**: Confirm that the `AnalysisTaskMonitor` provides immediate and real-time feedback as tasks progress and that the overall UI remains responsive during analysis.

- Test Plan:
  - **Backend Verification**:
    - Run `npx convex dev` and confirm no schema errors.
    - From the Convex dashboard, manually call `api.analysis_tasks.dispatch` with valid `resumeIds` and `jobDescriptionId`. Verify the task status transitions from `pending` to `processing` and finally to `completed` in the Convex dashboard.
    - Dispatch another task, then call `api.analysis_tasks.cancel` while it's `processing`. Confirm the task status changes to `cancelled` and processing stops.
  - **UI End-to-End Verification (via DevTools MCP or manual)**:
    - Navigate to `http://localhost:5173/resumes`.
    - Verify the `AnalysisTaskMonitor` component renders correctly (or is hidden if no tasks exist).
    - If no tasks are present, verify the "All analysis tasks completed" message and "Show History" button appear correctly after previous tasks.
    - Select a Job Description from the dropdown.
    - Click the "Analyze All (AI)" button.
    - Confirm the "Analysis task dispatched" toast appears.
    - Verify the `AnalysisTaskMonitor` immediately shows an active task with a progress bar, JD title, "Processing" badge, and a "Cancel" button.
    - Wait 10-15 seconds and verify that the progress bar updates (`current` value increases) and that resume cards below start showing new score badges in real-time.
    - Click the "Cancel" button on an active task. Confirm the task's status changes to "Cancelled" in the monitor.
    - Switch the UI language (e.g., to Simplified or Traditional Chinese) and verify that all labels within the `AnalysisTaskMonitor` update to the selected language.