### PR TITLE
[Crown] # Fast Dev Cycle & AI Scoring Optimization Plan

## Problem S...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,7 +401,7 @@ help:
 	@echo "  help           Show this help message"
 	@echo ""
 	@echo "Environment Variables:"
-	@echo "  ENV_FILE       Path to .env file (default: .env)"
+	@echo "  ENV_FILE       Optional env file path (unset by default)"
 	@echo "  MCP_PORT       MCP server port (default: 3333)"
 	@echo "  TRENDS_WORKER_PORT FastAPI worker port (default: 8000)"
 	@echo "  API_PORT       BFF API port (default: 3000)"

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,13 @@
 		build-static build-static-fresh serve-static \
 		i18n-check i18n-sync i18n-convert i18n-translate i18n-build \
 		refresh-sample refresh-sample-manual prefetch-convex chrome-debug \
-		seed seed-full seed-force seed-matches clear-matches
+		seed seed-full seed-force \
+		sync-agent-policy check-agent-policy install-agent-skill check-agent-skill sync-agent-governance
 
 # Default target
 .DEFAULT_GOAL := help
+
+.PHONY: seed-matches clear-matches
 
 # =============================================================================
 # Development (Full Experience)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 		build-static build-static-fresh serve-static \
 		i18n-check i18n-sync i18n-convert i18n-translate i18n-build \
 		refresh-sample refresh-sample-manual prefetch-convex chrome-debug \
-		seed seed-full seed-force
+		seed seed-full seed-force seed-matches clear-matches
 
 # Default target
 .DEFAULT_GOAL := help
@@ -24,6 +24,7 @@ dev:
 	else \
 		echo "Skipping Convex env sync (no Convex .env.local found yet)"; \
 	fi
+	@npx tsx scripts/seed-matches.ts
 	./scripts/dev.sh $(ARGS)
 
 # Stop/clean any stale development services and ports
@@ -216,6 +217,14 @@ seed-force:
 		npx tsx scripts/seed-convex.ts --force; \
 	fi
 
+# Seed deterministic resume matches into output/resume_screening.db
+seed-matches:
+	@npx tsx scripts/seed-matches.ts
+
+# Clear cached resume matches from output/resume_screening.db
+clear-matches:
+	@npx tsx scripts/clear-matches.ts
+
 # Refresh resume sample data automatically via CDP
 refresh-sample:
 	@KEYWORD="$(or $(KEYWORD),销售)" SAMPLE="$(or $(SAMPLE),sample-initial)" \
@@ -375,6 +384,8 @@ help:
 	@echo "  seed           Seed Convex with system job descriptions"
 	@echo "  seed-full      Seed Convex with system job descriptions + sample resumes"
 	@echo "  seed-force     Force seed Convex even if DB is not empty"
+	@echo "  seed-matches   Seed deterministic resume matches for dev mode"
+	@echo "  clear-matches  Clear cached resume matches from SQLite"
 	@echo "  refresh-sample Auto-refresh resume sample data via CDP"
 	@echo "  refresh-sample-manual Show manual instructions for refreshing resume sample data"
 	@echo "  chrome-debug   Start Google Chrome with remote debugging (port 9222)"

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -92,6 +92,7 @@ export function createApp() {
         resume_matches: "/api/resumes/matches",
         resume_match: "/api/resumes/match",
         resume_match_stream: "/api/resumes/match-stream",
+        resume_match_runs: "/api/resumes/match-runs",
         resume_matches_rescore: "/api/resumes/matches/rescore",
         sessions: "/api/sessions",
         actions: "/api/actions",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -91,6 +91,8 @@ export function createApp() {
         resume_samples: "/api/resumes/samples",
         resume_matches: "/api/resumes/matches",
         resume_match: "/api/resumes/match",
+        resume_match_stream: "/api/resumes/match-stream",
+        resume_matches_rescore: "/api/resumes/matches/rescore",
         sessions: "/api/sessions",
         actions: "/api/actions",
         industry_stats: "/api/industry/stats",

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -242,6 +242,18 @@ export const RecommendationSchema = z.enum([
   "no_match",
 ]);
 
+export const ScoreSourceSchema = z.enum(["rule", "ai"]);
+
+export const MatchBreakdownSchema = z
+  .object({
+    skillMatch: z.number().int().openapi({ example: 20 }),
+    experienceMatch: z.number().int().openapi({ example: 18 }),
+    educationMatch: z.number().int().openapi({ example: 12 }),
+    locationMatch: z.number().int().openapi({ example: 15 }),
+    industryMatch: z.number().int().openapi({ example: 10 }),
+  })
+  .openapi("MatchBreakdown");
+
 export const ResumeMatchSchema = z
   .object({
     resumeId: z.string().openapi({ example: "R123456" }),
@@ -251,6 +263,8 @@ export const ResumeMatchSchema = z
     highlights: z.array(z.string()).openapi({ example: ["客户开发经验丰富"] }),
     concerns: z.array(z.string()).openapi({ example: ["缺少机床销售经验"] }),
     summary: z.string().openapi({ example: "候选人与岗位匹配良好，可安排面试。" }),
+    breakdown: MatchBreakdownSchema.optional(),
+    scoreSource: ScoreSourceSchema.optional().openapi({ example: "rule" }),
     matchedAt: z.string().openapi({ example: "2026-02-05T08:00:00.000Z" }),
     sessionId: z.string().optional().openapi({ example: "session-123" }),
     userId: z.string().optional().openapi({ example: "user-abc" }),
@@ -264,6 +278,8 @@ export const MatchRequestSchema = z
     jobDescriptionId: z.string().openapi({ example: "lathe-sales" }),
     resumeIds: z.array(z.string()).optional().openapi({ example: ["R123456"] }),
     limit: z.number().int().min(1).max(1000).optional().openapi({ example: 50 }),
+    topN: z.number().int().min(1).max(500).optional().openapi({ example: 20 }),
+    mode: z.enum(["rules_only", "hybrid", "ai_only"]).optional().openapi({ example: "hybrid" }),
   })
   .openapi("MatchRequest");
 
@@ -273,12 +289,16 @@ export const MatchStatsSchema = z
     matched: z.number().int(),
     avgScore: z.number(),
     processingTimeMs: z.number().int().optional(),
+    pendingAi: z.number().int().optional(),
   })
   .openapi("MatchStats");
 
 export const MatchResponseSchema = z
   .object({
     success: z.literal(true),
+    mode: z.enum(["rules_only", "hybrid", "ai_only"]).optional(),
+    streamPath: z.string().optional(),
+    pendingAiCount: z.number().int().optional(),
     results: z.array(ResumeMatchSchema),
     stats: MatchStatsSchema,
   })

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -327,3 +327,60 @@ export const ResumeMatchesQuerySchema = z.object({
       example: "lathe-sales",
     }),
 });
+
+export const MatchRunStatusSchema = z.enum(["processing", "completed", "failed"]);
+export const MatchRunModeSchema = z.enum(["rules_only", "hybrid", "ai_only"]);
+
+export const MatchRunSchema = z
+  .object({
+    id: z.string().openapi({ example: "run-123" }),
+    sessionId: z.string().optional().openapi({ example: "session-123" }),
+    jobDescriptionId: z.string().openapi({ example: "lathe-sales" }),
+    sampleName: z.string().optional().openapi({ example: "sample-initial" }),
+    mode: MatchRunModeSchema.openapi({ example: "hybrid" }),
+    status: MatchRunStatusSchema.openapi({ example: "completed" }),
+    totalCount: z.number().int().openapi({ example: 100 }),
+    processedCount: z.number().int().openapi({ example: 20 }),
+    failedCount: z.number().int().openapi({ example: 0 }),
+    matchedCount: z.number().int().optional().openapi({ example: 14 }),
+    avgScore: z.number().optional().openapi({ example: 72.3 }),
+    startedAt: z.string().openapi({ example: "2026-02-11T08:00:00.000Z" }),
+    completedAt: z.string().optional().openapi({ example: "2026-02-11T08:00:09.000Z" }),
+    error: z.string().optional().openapi({ example: "AI provider timeout" }),
+  })
+  .openapi("MatchRun");
+
+export const MatchRunsQuerySchema = z.object({
+  sessionId: z
+    .string()
+    .optional()
+    .openapi({
+      param: { name: "sessionId", in: "query" },
+      example: "session-123",
+    }),
+  jobDescriptionId: z
+    .string()
+    .optional()
+    .openapi({
+      param: { name: "jobDescriptionId", in: "query" },
+      example: "lathe-sales",
+    }),
+  limit: z
+    .coerce
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .openapi({
+      param: { name: "limit", in: "query" },
+      example: 20,
+    }),
+});
+
+export const MatchRunsResponseSchema = z
+  .object({
+    success: z.literal(true),
+    runs: z.array(MatchRunSchema),
+  })
+  .openapi("MatchRunsResponse");

--- a/apps/api/src/services/ai-config.ts
+++ b/apps/api/src/services/ai-config.ts
@@ -1,7 +1,9 @@
 /**
  * AI Configuration
  *
- * Reads from shared .env file (same as trendradar Python AI module)
+ * Reads from process environment variables.
+ * Values may come from the system environment or an explicitly provided env file
+ * by the process runner (for example, bun --env-file in development).
  *
  * Environment variables:
  * - AI_ANALYSIS_ENABLED: Enable AI features (default: false)
@@ -21,7 +23,7 @@ export interface AIConfig {
     temperature: number;
     maxTokens: number;
     timeout: number;
-    bonded: string[]; // List of variables explicitly set in .env
+    bonded: string[]; // List of variables explicitly set in process environment
 }
 
 export function loadAIConfig(): AIConfig {

--- a/apps/api/src/services/database.ts
+++ b/apps/api/src/services/database.ts
@@ -90,6 +90,28 @@ function initSchema(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_matches_session ON resume_matches(session_id);
     CREATE INDEX IF NOT EXISTS idx_matches_user ON resume_matches(user_id);
 
+    CREATE TABLE IF NOT EXISTS match_runs (
+      id TEXT PRIMARY KEY,
+      session_id TEXT,
+      job_description_id TEXT NOT NULL,
+      sample_name TEXT,
+      mode TEXT NOT NULL,
+      status TEXT NOT NULL,
+      total_count INTEGER NOT NULL DEFAULT 0,
+      processed_count INTEGER NOT NULL DEFAULT 0,
+      failed_count INTEGER NOT NULL DEFAULT 0,
+      matched_count INTEGER,
+      avg_score REAL,
+      started_at TEXT NOT NULL,
+      completed_at TEXT,
+      error TEXT,
+      FOREIGN KEY (session_id) REFERENCES search_sessions(id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_match_runs_session ON match_runs(session_id);
+    CREATE INDEX IF NOT EXISTS idx_match_runs_job ON match_runs(job_description_id);
+    CREATE INDEX IF NOT EXISTS idx_match_runs_started ON match_runs(started_at DESC);
+
     CREATE TABLE IF NOT EXISTS candidate_actions (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       user_id TEXT,

--- a/apps/api/src/services/match-storage.ts
+++ b/apps/api/src/services/match-storage.ts
@@ -1,6 +1,9 @@
 import { getResumeScreeningDb } from "./database.js";
 import type { MatchingResult } from "./ai-matching.js";
 
+export type MatchRunMode = "rules_only" | "hybrid" | "ai_only";
+export type MatchRunStatus = "processing" | "completed" | "failed";
+
 export type StoredMatch = {
   id: number;
   sessionId?: string;
@@ -18,6 +21,23 @@ export type StoredMatch = {
   aiModel?: string;
   processingTimeMs?: number;
   matchedAt: string;
+};
+
+export type StoredMatchRun = {
+  id: string;
+  sessionId?: string;
+  jobDescriptionId: string;
+  sampleName?: string;
+  mode: MatchRunMode;
+  status: MatchRunStatus;
+  totalCount: number;
+  processedCount: number;
+  failedCount: number;
+  matchedCount?: number;
+  avgScore?: number;
+  startedAt: string;
+  completedAt?: string;
+  error?: string;
 };
 
 function parseJsonArray(value: unknown): string[] {
@@ -81,6 +101,41 @@ function normalizeMatch(row: Record<string, unknown>): StoredMatch {
     aiModel: row.ai_model ? String(row.ai_model) : undefined,
     processingTimeMs: row.processing_time_ms ? Number(row.processing_time_ms) : undefined,
     matchedAt: String(row.matched_at),
+  };
+}
+
+function normalizeMatchRun(row: Record<string, unknown>): StoredMatchRun {
+  const rawMode = String(row.mode ?? "hybrid");
+  const rawStatus = String(row.status ?? "processing");
+
+  const mode: MatchRunMode =
+    rawMode === "rules_only" || rawMode === "ai_only" || rawMode === "hybrid"
+      ? rawMode
+      : "hybrid";
+  const status: MatchRunStatus =
+    rawStatus === "completed" || rawStatus === "failed" || rawStatus === "processing"
+      ? rawStatus
+      : "processing";
+
+  return {
+    id: String(row.id),
+    sessionId: row.session_id ? String(row.session_id) : undefined,
+    jobDescriptionId: String(row.job_description_id),
+    sampleName: row.sample_name ? String(row.sample_name) : undefined,
+    mode,
+    status,
+    totalCount: Number(row.total_count ?? 0),
+    processedCount: Number(row.processed_count ?? 0),
+    failedCount: Number(row.failed_count ?? 0),
+    matchedCount: row.matched_count !== null && row.matched_count !== undefined
+      ? Number(row.matched_count)
+      : undefined,
+    avgScore: row.avg_score !== null && row.avg_score !== undefined
+      ? Number(row.avg_score)
+      : undefined,
+    startedAt: String(row.started_at),
+    completedAt: row.completed_at ? String(row.completed_at) : undefined,
+    error: row.error ? String(row.error) : undefined,
   };
 }
 
@@ -222,5 +277,134 @@ export class MatchStorage {
       ? this.db.prepare("DELETE FROM resume_matches WHERE job_description_id = ?").run(jobDescriptionId)
       : this.db.prepare("DELETE FROM resume_matches").run();
     return result.changes ?? 0;
+  }
+
+  createMatchRun(params: {
+    id: string;
+    sessionId?: string;
+    jobDescriptionId: string;
+    sampleName?: string;
+    mode: MatchRunMode;
+    status?: MatchRunStatus;
+    totalCount: number;
+    startedAt?: string;
+  }): void {
+    const startedAt = params.startedAt ?? new Date().toISOString();
+    this.db
+      .prepare(
+        `
+        INSERT INTO match_runs (
+          id,
+          session_id,
+          job_description_id,
+          sample_name,
+          mode,
+          status,
+          total_count,
+          processed_count,
+          failed_count,
+          matched_count,
+          avg_score,
+          started_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, NULL, NULL, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          session_id = excluded.session_id,
+          job_description_id = excluded.job_description_id,
+          sample_name = excluded.sample_name,
+          mode = excluded.mode,
+          status = excluded.status,
+          total_count = excluded.total_count,
+          processed_count = 0,
+          failed_count = 0,
+          matched_count = NULL,
+          avg_score = NULL,
+          started_at = excluded.started_at,
+          completed_at = NULL,
+          error = NULL
+        `
+      )
+      .run(
+        params.id,
+        params.sessionId ?? null,
+        params.jobDescriptionId,
+        params.sampleName ?? null,
+        params.mode,
+        params.status ?? "processing",
+        params.totalCount,
+        startedAt
+      );
+  }
+
+  finalizeMatchRun(params: {
+    id: string;
+    status: Extract<MatchRunStatus, "completed" | "failed">;
+    processedCount: number;
+    failedCount: number;
+    matchedCount?: number;
+    avgScore?: number;
+    completedAt?: string;
+    error?: string;
+  }): void {
+    const completedAt = params.completedAt ?? new Date().toISOString();
+    this.db
+      .prepare(
+        `
+        UPDATE match_runs
+        SET
+          status = ?,
+          processed_count = ?,
+          failed_count = ?,
+          matched_count = ?,
+          avg_score = ?,
+          completed_at = ?,
+          error = ?
+        WHERE id = ?
+        `
+      )
+      .run(
+        params.status,
+        params.processedCount,
+        params.failedCount,
+        params.matchedCount ?? null,
+        params.avgScore ?? null,
+        completedAt,
+        params.error ?? null,
+        params.id
+      );
+  }
+
+  listMatchRuns(params?: {
+    sessionId?: string;
+    jobDescriptionId?: string;
+    limit?: number;
+  }): StoredMatchRun[] {
+    const limit = Math.max(1, Math.min(params?.limit ?? 20, 100));
+
+    const clauses: string[] = [];
+    const values: Array<string | number> = [];
+
+    if (params?.sessionId) {
+      clauses.push("session_id = ?");
+      values.push(params.sessionId);
+    }
+    if (params?.jobDescriptionId) {
+      clauses.push("job_description_id = ?");
+      values.push(params.jobDescriptionId);
+    }
+
+    const whereClause = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    const rows = this.db
+      .prepare(
+        `
+        SELECT *
+        FROM match_runs
+        ${whereClause}
+        ORDER BY started_at DESC
+        LIMIT ?
+        `
+      )
+      .all(...values, limit) as Record<string, unknown>[];
+
+    return rows.map((row) => normalizeMatchRun(row));
   }
 }

--- a/apps/api/src/services/resume-id.ts
+++ b/apps/api/src/services/resume-id.ts
@@ -1,0 +1,9 @@
+import type { ResumeItem } from "../types/resume.js";
+
+export function resolveResumeId(resume: ResumeItem, index: number): string {
+  if (resume.resumeId) return String(resume.resumeId);
+  if (resume.perUserId) return String(resume.perUserId);
+  if (resume.profileUrl && resume.profileUrl !== "javascript:;") return resume.profileUrl;
+  if (resume.extractedAt) return `${resume.name || "resume"}-${resume.extractedAt}`;
+  return `${resume.name || "resume"}-${index}`;
+}

--- a/apps/api/src/services/resume-index.test.ts
+++ b/apps/api/src/services/resume-index.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ResumeIndexService } from "./resume-index";
+
+import type { ResumeItem } from "../types/resume";
+
+function createFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "resume-index-"));
+  fs.mkdirSync(path.join(root, "config", "resume"), { recursive: true });
+  fs.mkdirSync(path.join(root, "config", "job-descriptions"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(root, "config", "resume", "skills_words.txt"),
+    "CNC lathe sales 机床 车床\n"
+  );
+
+  fs.writeFileSync(
+    path.join(root, "config", "job-descriptions", "lathe-sales.md"),
+    `---
+id: jd-lathe-sales
+title: 车床销售工程师
+status: active
+auto_match:
+  keywords: [车床, CNC, 销售]
+  locations: [东莞, 广州]
+  priority: 90
+---
+# 职位要求\n- 2年以上经验\n`,
+    "utf8"
+  );
+
+  return root;
+}
+
+function cleanupFixtureRoot(root: string): void {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+describe("ResumeIndexService", () => {
+  it("builds structured index fields from resume data", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new ResumeIndexService(root);
+
+      const resumes: ResumeItem[] = [
+        {
+          name: "张三",
+          profileUrl: "javascript:;",
+          activityStatus: "活跃",
+          age: "31",
+          experience: "5年",
+          education: "本科",
+          location: "东莞长安镇",
+          selfIntro: "熟悉CNC车床和设备销售",
+          jobIntention: "东莞 车床 销售 CNC",
+          expectedSalary: "12000-18000元/月",
+          workHistory: [
+            { raw: "2022-01~2025-01 东莞富佳机械设备有限公司 销售经理" },
+          ],
+          extractedAt: "2026-02-11T00:00:00.000Z",
+          resumeId: "R1001",
+          perUserId: "U1001",
+        },
+      ];
+
+      const index = service.buildIndex("sample:test", resumes);
+      const entry = index.get("R1001");
+
+      expect(entry).toBeDefined();
+      expect(entry?.experienceYears).toBe(5);
+      expect(entry?.educationLevel).toBe("bachelor");
+      expect(entry?.locationCity).toBe("东莞");
+      expect(entry?.skills.some((skill) => skill.includes("cnc") || skill.includes("车床"))).toBe(true);
+      expect(entry?.companies.some((company) => company.includes("机械设备"))).toBe(true);
+      expect(entry?.industryTags).toContain("machinery");
+      expect(entry?.industryTags).toContain("sales");
+      expect(entry?.salaryRange?.min).toBe(12000);
+      expect(entry?.salaryRange?.max).toBe(18000);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+});

--- a/apps/api/src/services/resume-index.ts
+++ b/apps/api/src/services/resume-index.ts
@@ -1,0 +1,324 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { findProjectRoot } from "./db.js";
+import { JobDescriptionService } from "./job-description-service.js";
+import { resolveResumeId } from "./resume-id.js";
+
+import type { ResumeItem, ResumeWorkHistoryItem } from "../types/resume.js";
+
+export interface ResumeIndex {
+  resumeId: string;
+  experienceYears: number | null;
+  educationLevel: string | null;
+  locationCity: string | null;
+  skills: string[];
+  companies: string[];
+  industryTags: string[];
+  salaryRange: { min?: number; max?: number } | null;
+  searchText: string;
+}
+
+type IndustryTag = "machinery" | "cnc" | "sales" | "automation" | "metrology" | "software";
+
+const INDUSTRY_KEYWORDS: Record<IndustryTag, string[]> = {
+  machinery: [
+    "机床",
+    "车床",
+    "加工中心",
+    "机械",
+    "设备",
+    "五轴",
+    "夹具",
+    "治具",
+    "lathe",
+    "machining",
+    "milling",
+  ],
+  cnc: ["cnc", "数控", "fanuc", "siemens", "star", "brother", "mitsubishi"],
+  sales: ["销售", "业务", "客户", "大客户", "渠道", "sales", "account", "bd", "market"],
+  automation: ["自动化", "机器人", "plc", "伺服", "automation"],
+  metrology: ["测量", "三维扫描", "3d", "cmm", "metrology", "scan"],
+  software: ["c++", "c#", "mfc", "qt", "软件", "开发", "algorithm", "python"],
+};
+
+function normalizeText(value: string | undefined): string {
+  return (value || "")
+    .replace(/[\u3000\s]+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function normalizeEducationLevel(value: string): string | null {
+  const normalized = value.trim();
+  if (!normalized) return null;
+  if (/博士|phd/i.test(normalized)) return "phd";
+  if (/硕士|研究生|master/i.test(normalized)) return "master";
+  if (/本科|bachelor/i.test(normalized)) return "bachelor";
+  if (/大专|专科|associate/i.test(normalized)) return "associate";
+  if (/高中|中专|中技|high school/i.test(normalized)) return "high_school";
+  return null;
+}
+
+function parseExperienceYears(value: string): number | null {
+  if (!value) return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  if (/应届|无经验/.test(normalized)) return 0;
+  const match = normalized.match(/(\d+)(?:\s*[-~到至]\s*(\d+))?/);
+  if (!match) return null;
+  const min = Number(match[1]);
+  const max = match[2] ? Number(match[2]) : min;
+  if (Number.isNaN(max)) return null;
+  return max;
+}
+
+function parseSalaryRange(value: string): { min?: number; max?: number } | null {
+  if (!value) return null;
+  const normalized = value.replace(/\s+/g, "").toLowerCase();
+  if (!normalized || /面议/.test(normalized)) return null;
+
+  const match = normalized.match(/(\d+(?:\.\d+)?)(?:[-~到至](\d+(?:\.\d+)?))?/);
+  if (!match) return null;
+
+  let min = Number(match[1]);
+  let max = match[2] ? Number(match[2]) : undefined;
+  if (Number.isNaN(min)) return null;
+
+  if (/[k千]/.test(normalized)) {
+    min *= 1000;
+    if (max !== undefined) max *= 1000;
+  }
+  if (/万/.test(normalized)) {
+    min *= 10000;
+    if (max !== undefined) max *= 10000;
+  }
+
+  return { min, max };
+}
+
+function extractTokenCandidates(text: string): string[] {
+  if (!text.trim()) return [];
+  const segments = text.match(/[\u4e00-\u9fa5]{2,}|[a-z0-9+#.-]{2,}/gi) ?? [];
+  return segments
+    .map((item) => item.toLowerCase())
+    .filter((item) => item.length >= 2)
+    .filter((item) => item.length <= 24);
+}
+
+function normalizeCompanyName(raw: string): string {
+  return raw
+    .replace(/^[\d\-~至今年月日()（）.\s]+/, "")
+    .replace(/[\s,，。;；]+/g, " ")
+    .trim();
+}
+
+function extractCompanies(workHistory: ResumeWorkHistoryItem[]): string[] {
+  if (!workHistory.length) return [];
+
+  const companies: string[] = [];
+  for (const item of workHistory) {
+    const cleaned = normalizeCompanyName(item.raw);
+    if (!cleaned) continue;
+
+    const companyMatch = cleaned.match(/([\u4e00-\u9fa5A-Za-z0-9()（）·.&\-]{2,40}(?:公司|集团|科技|机械|设备|自动化|股份|有限|厂))/);
+    if (companyMatch) {
+      companies.push(companyMatch[1]);
+      continue;
+    }
+
+    const firstToken = cleaned.split(/\s+/g).find((token) => token.length >= 2);
+    if (firstToken) {
+      companies.push(firstToken);
+    }
+  }
+
+  return Array.from(new Set(companies)).slice(0, 20);
+}
+
+function createSearchText(item: ResumeItem): string {
+  const parts = [
+    item.name,
+    item.jobIntention,
+    item.selfIntro,
+    item.education,
+    item.location,
+    item.expectedSalary,
+    ...(item.workHistory?.map((entry) => entry.raw) ?? []),
+  ];
+
+  return normalizeText(parts.join(" "));
+}
+
+function scoreIndustryTags(haystack: string): string[] {
+  const tags: string[] = [];
+
+  for (const [tag, keywords] of Object.entries(INDUSTRY_KEYWORDS)) {
+    if (keywords.some((keyword) => haystack.includes(keyword.toLowerCase()))) {
+      tags.push(tag);
+    }
+  }
+
+  return tags;
+}
+
+export class ResumeIndexService {
+  readonly projectRoot: string;
+
+  private readonly indexCache = new Map<string, Map<string, ResumeIndex>>();
+  private readonly jobService: JobDescriptionService;
+
+  private vocabularyLoaded = false;
+  private readonly skillVocabulary = new Set<string>();
+  private readonly jdKeywordVocabulary = new Set<string>();
+  private locationVocabulary: string[] = [];
+
+  constructor(projectRoot?: string) {
+    this.projectRoot = projectRoot ? path.resolve(projectRoot) : findProjectRoot();
+    this.jobService = new JobDescriptionService(this.projectRoot);
+  }
+
+  private loadSkillVocabulary(): void {
+    const filePath = path.join(this.projectRoot, "config", "resume", "skills_words.txt");
+    if (!fs.existsSync(filePath)) return;
+
+    const lines = fs.readFileSync(filePath, "utf8").split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+
+      for (const token of trimmed.split(/\s+/g)) {
+        if (!token) continue;
+        if (token.startsWith("!")) continue;
+        if (token.startsWith("+")) continue;
+        if (token.startsWith("@")) continue;
+        if (token.includes("=>")) continue;
+        if (token.startsWith("[")) continue;
+        if (token.startsWith("/")) continue;
+        if (token.includes("|")) continue;
+
+        const normalized = token.toLowerCase();
+        if (normalized.length >= 2) {
+          this.skillVocabulary.add(normalized);
+        }
+      }
+    }
+  }
+
+  private loadJobDescriptionVocabulary(): void {
+    const jds = this.jobService.listFiles();
+    const locations = new Set<string>();
+
+    for (const jd of jds) {
+      const autoMatch = jd.autoMatch;
+      if (!autoMatch) continue;
+
+      for (const keyword of autoMatch.keywords ?? []) {
+        const normalized = keyword.toLowerCase().trim();
+        if (normalized.length >= 2) {
+          this.jdKeywordVocabulary.add(normalized);
+        }
+      }
+
+      for (const location of autoMatch.locations ?? []) {
+        const normalized = location.trim();
+        if (normalized) {
+          locations.add(normalized);
+        }
+      }
+    }
+
+    this.locationVocabulary = Array.from(locations).sort((a, b) => b.length - a.length);
+  }
+
+  private ensureVocabularyLoaded(): void {
+    if (this.vocabularyLoaded) return;
+
+    this.loadSkillVocabulary();
+    this.loadJobDescriptionVocabulary();
+    this.vocabularyLoaded = true;
+  }
+
+  private extractLocationCity(location: string): string | null {
+    if (!location.trim()) return null;
+
+    for (const knownLocation of this.locationVocabulary) {
+      if (location.includes(knownLocation)) return knownLocation;
+    }
+
+    const normalized = location.trim();
+    const direct = normalized.match(/^([\u4e00-\u9fa5]{2,6}?)(?:市|县|区|镇)/);
+    if (direct?.[1]) return direct[1];
+
+    const fallback = normalized.match(/[\u4e00-\u9fa5]{2,4}/);
+    return fallback?.[0] ?? null;
+  }
+
+  private extractSkills(item: ResumeItem, searchText: string): string[] {
+    const skills = new Set<string>();
+
+    const intentionTokens = extractTokenCandidates(item.jobIntention || "");
+    const summaryTokens = extractTokenCandidates(item.selfIntro || "");
+    for (const token of intentionTokens.slice(0, 30)) {
+      skills.add(token);
+    }
+    for (const token of summaryTokens.slice(0, 30)) {
+      skills.add(token);
+    }
+
+    for (const keyword of this.skillVocabulary) {
+      if (searchText.includes(keyword)) {
+        skills.add(keyword);
+      }
+    }
+    for (const keyword of this.jdKeywordVocabulary) {
+      if (searchText.includes(keyword)) {
+        skills.add(keyword);
+      }
+    }
+
+    return Array.from(skills).slice(0, 40);
+  }
+
+  buildIndex(sampleKey: string, items: ResumeItem[]): Map<string, ResumeIndex> {
+    const cached = this.indexCache.get(sampleKey);
+    if (cached) return cached;
+
+    this.ensureVocabularyLoaded();
+
+    const nextMap = new Map<string, ResumeIndex>();
+    for (let i = 0; i < items.length; i += 1) {
+      const item = items[i];
+      const resumeId = resolveResumeId(item, i);
+      const searchText = createSearchText(item);
+      const companies = extractCompanies(item.workHistory ?? []);
+      const skills = this.extractSkills(item, searchText);
+      const tagHaystack = [searchText, ...skills, ...companies].join(" ").toLowerCase();
+
+      nextMap.set(resumeId, {
+        resumeId,
+        experienceYears: parseExperienceYears(item.experience),
+        educationLevel: normalizeEducationLevel(item.education),
+        locationCity: this.extractLocationCity(item.location || ""),
+        skills,
+        companies,
+        industryTags: scoreIndustryTags(tagHaystack),
+        salaryRange: parseSalaryRange(item.expectedSalary),
+        searchText,
+      });
+    }
+
+    this.indexCache.set(sampleKey, nextMap);
+    return nextMap;
+  }
+
+  getIndex(sampleKey: string): Map<string, ResumeIndex> | undefined {
+    return this.indexCache.get(sampleKey);
+  }
+
+  clearCache(): void {
+    this.indexCache.clear();
+  }
+}
+
+export const resumeIndexService = new ResumeIndexService();

--- a/apps/api/src/services/rule-scoring.test.ts
+++ b/apps/api/src/services/rule-scoring.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { RuleScoringService } from "./rule-scoring";
+
+import type { ResumeIndex } from "./resume-index";
+
+function createFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "rule-scoring-"));
+  fs.mkdirSync(path.join(root, "config", "resume"), { recursive: true });
+  fs.mkdirSync(path.join(root, "config", "job-descriptions"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(root, "config", "resume", "filter-presets.json5"),
+    JSON.stringify({ presets: [], categories: [] }, null, 2),
+    "utf8"
+  );
+
+  fs.writeFileSync(
+    path.join(root, "config", "job-descriptions", "lathe-sales.md"),
+    `---
+id: jd-lathe-sales
+title: 车床销售工程师
+status: active
+auto_match:
+  keywords: [车床, CNC, 销售]
+  locations: [东莞, 广州]
+  priority: 90
+  suggested_filters:
+    minExperience: 2
+    education: [大专, 本科]
+---
+# 职位要求\n- 2年以上车床销售经验\n`,
+    "utf8"
+  );
+
+  return root;
+}
+
+function cleanupFixtureRoot(root: string): void {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+describe("RuleScoringService", () => {
+  it("scores strong candidate higher than weak candidate", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new RuleScoringService(root);
+      const context = service.buildContext("lathe-sales");
+
+      const strongCandidate: ResumeIndex = {
+        resumeId: "R-strong",
+        experienceYears: 5,
+        educationLevel: "bachelor",
+        locationCity: "东莞",
+        skills: ["车床", "cnc", "销售"],
+        companies: ["东莞富佳机械设备有限公司"],
+        industryTags: ["machinery", "cnc", "sales"],
+        salaryRange: { min: 10000, max: 20000 },
+        searchText: "东莞 车床 cnc 销售 机械设备 大客户",
+      };
+
+      const weakCandidate: ResumeIndex = {
+        resumeId: "R-weak",
+        experienceYears: 0,
+        educationLevel: "high_school",
+        locationCity: "北京",
+        skills: ["文员"],
+        companies: ["零售公司"],
+        industryTags: ["sales"],
+        salaryRange: { min: 4000, max: 6000 },
+        searchText: "北京 文员 客服",
+      };
+
+      const strongScore = service.scoreResume(strongCandidate, context);
+      const weakScore = service.scoreResume(weakCandidate, context);
+
+      expect(strongScore.score).toBeGreaterThan(weakScore.score);
+      expect(strongScore.recommendation === "match" || strongScore.recommendation === "strong_match").toBe(true);
+      expect(weakScore.recommendation === "potential" || weakScore.recommendation === "no_match").toBe(true);
+      expect(strongScore.breakdown.skillMatch).toBeGreaterThan(0);
+      expect(strongScore.breakdown.locationMatch).toBe(15);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+});

--- a/apps/api/src/services/rule-scoring.ts
+++ b/apps/api/src/services/rule-scoring.ts
@@ -1,0 +1,277 @@
+import { FilterPresetService } from "./filter-preset-service.js";
+import { JobDescriptionService } from "./job-description-service.js";
+import type { MatchingResult } from "./ai-matching.js";
+import type { ResumeIndex } from "./resume-index.js";
+
+export interface RuleScoringResult {
+  score: number;
+  recommendation: MatchingResult["recommendation"];
+  breakdown: {
+    skillMatch: number;
+    experienceMatch: number;
+    educationMatch: number;
+    locationMatch: number;
+    industryMatch: number;
+  };
+  matchedSkills: string[];
+  matchedCompanies: string[];
+}
+
+export interface RuleScoringContext {
+  jobDescriptionId: string;
+  title: string;
+  keywords: string[];
+  targetLocations: string[];
+  minExperience?: number;
+  educationRequirements: string[];
+  industryKeywords: string[];
+  industryTags: string[];
+}
+
+const EDUCATION_RANK: Record<string, number> = {
+  high_school: 1,
+  associate: 2,
+  bachelor: 3,
+  master: 4,
+  phd: 5,
+};
+
+const INDUSTRY_MAP: Array<{ tag: string; keywords: string[] }> = [
+  { tag: "machinery", keywords: ["机床", "车床", "机械", "设备", "夹具", "五轴", "加工中心", "lathe", "machining"] },
+  { tag: "cnc", keywords: ["cnc", "数控", "fanuc", "siemens", "star"] },
+  { tag: "sales", keywords: ["销售", "客户", "大客户", "业务", "sales", "account"] },
+  { tag: "automation", keywords: ["自动化", "机器人", "plc", "automation"] },
+  { tag: "metrology", keywords: ["测量", "三维", "扫描", "cmm", "metrology"] },
+  { tag: "software", keywords: ["软件", "c++", "c#", "qt", "mfc", "开发"] },
+];
+
+function normalizeEducationLevel(value: string | null | undefined): string | null {
+  const normalized = (value || "").trim().toLowerCase();
+  if (!normalized) return null;
+
+  if (["phd", "doctor"].includes(normalized) || /博士/.test(normalized)) return "phd";
+  if (["master", "masters"].includes(normalized) || /硕士|研究生/.test(normalized)) return "master";
+  if (["bachelor", "bachelors"].includes(normalized) || /本科/.test(normalized)) return "bachelor";
+  if (["associate"].includes(normalized) || /大专|专科/.test(normalized)) return "associate";
+  if (["high_school", "high school"].includes(normalized) || /中专|高中|中技/.test(normalized)) return "high_school";
+
+  return null;
+}
+
+function recommendationFromScore(score: number): MatchingResult["recommendation"] {
+  if (score >= 85) return "strong_match";
+  if (score >= 70) return "match";
+  if (score >= 50) return "potential";
+  return "no_match";
+}
+
+function ensureKeywords(value: string[]): string[] {
+  return Array.from(
+    new Set(
+      value
+        .map((item) => item.trim().toLowerCase())
+        .filter((item) => item.length >= 2)
+    )
+  );
+}
+
+function inferIndustryTags(tokens: string[]): string[] {
+  const haystack = tokens.join(" ").toLowerCase();
+  const tags = new Set<string>();
+
+  for (const item of INDUSTRY_MAP) {
+    if (item.keywords.some((keyword) => haystack.includes(keyword.toLowerCase()))) {
+      tags.add(item.tag);
+    }
+  }
+
+  return Array.from(tags);
+}
+
+function getMinEducationRank(requirements: string[]): number | null {
+  const ranks = requirements
+    .map((item) => normalizeEducationLevel(item))
+    .filter((item): item is string => Boolean(item))
+    .map((item) => EDUCATION_RANK[item] ?? 0)
+    .filter((rank) => rank > 0);
+
+  if (ranks.length === 0) return null;
+  return Math.min(...ranks);
+}
+
+function compactText(value: string): string {
+  return value.toLowerCase().replace(/[\u3000\s]+/g, " ");
+}
+
+export class RuleScoringService {
+  private readonly jobService: JobDescriptionService;
+  private readonly filterPresetService: FilterPresetService;
+
+  constructor(projectRoot?: string) {
+    this.jobService = new JobDescriptionService(projectRoot);
+    this.filterPresetService = new FilterPresetService(projectRoot);
+  }
+
+  buildContext(jobDescriptionId: string): RuleScoringContext {
+    const jd = this.jobService.loadFile(jobDescriptionId);
+    const autoMatch = jd.autoMatch;
+
+    const keywords = ensureKeywords(autoMatch?.keywords ?? []);
+    const targetLocations = Array.from(
+      new Set([
+        ...(autoMatch?.locations ?? []),
+        ...(jd.location ? [jd.location] : []),
+      ]
+        .map((item) => item.trim())
+        .filter(Boolean))
+    );
+
+    const presetId = autoMatch?.filter_preset;
+    const preset = presetId ? this.filterPresetService.getPreset(presetId) : undefined;
+
+    const minExperience = autoMatch?.suggested_filters?.minExperience ?? preset?.filters.minExperience;
+    const educationRequirements = [
+      ...(autoMatch?.suggested_filters?.education ?? []),
+      ...(preset?.filters.education ?? []),
+    ];
+
+    const industryKeywords = ensureKeywords([
+      ...keywords,
+      compactText(jd.title || ""),
+      compactText(jd.content || ""),
+    ]);
+
+    const industryTags = inferIndustryTags(industryKeywords);
+
+    return {
+      jobDescriptionId,
+      title: jd.title || jd.name,
+      keywords,
+      targetLocations,
+      minExperience,
+      educationRequirements,
+      industryKeywords,
+      industryTags,
+    };
+  }
+
+  scoreResume(index: ResumeIndex, context: RuleScoringContext): RuleScoringResult {
+    const matchedSkills = context.keywords.filter((keyword) =>
+      index.searchText.includes(keyword) || index.skills.some((skill) => skill.includes(keyword))
+    );
+
+    const skillMatch = context.keywords.length > 0
+      ? Math.round((matchedSkills.length / context.keywords.length) * 30)
+      : 0;
+
+    let experienceMatch = 0;
+    if (context.minExperience === undefined) {
+      experienceMatch = index.experienceYears === null ? 8 : 25;
+    } else if (index.experienceYears !== null) {
+      if (index.experienceYears >= context.minExperience) {
+        experienceMatch = 25;
+      } else {
+        const gap = context.minExperience - index.experienceYears;
+        experienceMatch = Math.max(0, 25 - Math.round(gap * 8));
+      }
+    }
+
+    let educationMatch = 0;
+    const resumeEducation = normalizeEducationLevel(index.educationLevel);
+    const minEducationRank = getMinEducationRank(context.educationRequirements);
+    if (!minEducationRank) {
+      educationMatch = resumeEducation ? 10 : 0;
+    } else if (resumeEducation) {
+      const rank = EDUCATION_RANK[resumeEducation] ?? 0;
+      if (rank >= minEducationRank) {
+        educationMatch = 15;
+      } else {
+        educationMatch = Math.max(0, 15 - (minEducationRank - rank) * 6);
+      }
+    }
+
+    let locationMatch = 0;
+    if (context.targetLocations.length > 0) {
+      const location = index.locationCity || "";
+      if (location && context.targetLocations.some((target) => location.includes(target) || target.includes(location))) {
+        locationMatch = 15;
+      }
+    }
+
+    const matchedCompanies = index.companies.filter((company) =>
+      context.industryKeywords.some((keyword) => company.toLowerCase().includes(keyword))
+    );
+
+    const matchedIndustryKeywords = context.industryKeywords.filter((keyword) => index.searchText.includes(keyword));
+    const keywordRatioBase = Math.max(1, Math.min(context.industryKeywords.length, 10));
+    const keywordRatio = matchedIndustryKeywords.length / keywordRatioBase;
+    const tagRatio = context.industryTags.length > 0
+      ? index.industryTags.filter((tag) => context.industryTags.includes(tag)).length / context.industryTags.length
+      : 0;
+    const industryRatio = Math.max(keywordRatio, tagRatio);
+    const industryMatch = Math.round(Math.min(1, industryRatio) * 15);
+
+    const rawScore = skillMatch + experienceMatch + educationMatch + locationMatch + industryMatch;
+    const score = Math.max(0, Math.min(100, rawScore));
+
+    return {
+      score,
+      recommendation: recommendationFromScore(score),
+      breakdown: {
+        skillMatch,
+        experienceMatch,
+        educationMatch,
+        locationMatch,
+        industryMatch,
+      },
+      matchedSkills,
+      matchedCompanies,
+    };
+  }
+
+  scoreBatch(indexes: ResumeIndex[], context: RuleScoringContext): Array<{ resumeId: string; result: RuleScoringResult }> {
+    return indexes.map((index) => ({
+      resumeId: index.resumeId,
+      result: this.scoreResume(index, context),
+    }));
+  }
+
+  toMatchingResult(result: RuleScoringResult): MatchingResult {
+    const highlights: string[] = [];
+    const concerns: string[] = [];
+
+    if (result.matchedSkills.length > 0) {
+      highlights.push(`命中关键词: ${result.matchedSkills.slice(0, 6).join("、")}`);
+    }
+    if (result.breakdown.experienceMatch >= 20) {
+      highlights.push("经验与职位要求匹配");
+    } else {
+      concerns.push("经验与职位要求存在差距");
+    }
+    if (result.breakdown.educationMatch >= 12) {
+      highlights.push("学历满足岗位门槛");
+    } else {
+      concerns.push("学历匹配度偏低");
+    }
+    if (result.breakdown.locationMatch === 0) {
+      concerns.push("工作地点可能不匹配");
+    }
+    if (result.matchedCompanies.length > 0) {
+      highlights.push(`相关公司经历: ${result.matchedCompanies.slice(0, 3).join("、")}`);
+    }
+
+    return {
+      score: result.score,
+      recommendation: result.recommendation,
+      highlights,
+      concerns,
+      summary: `规则评分 ${result.score} 分，技能匹配 ${result.breakdown.skillMatch}/30，经验 ${result.breakdown.experienceMatch}/25。`,
+      breakdown: result.breakdown,
+      matchedSkills: result.matchedSkills,
+      matchedCompanies: result.matchedCompanies,
+      scoreSource: "rule",
+    };
+  }
+}
+
+export const ruleScoringService = new RuleScoringService();

--- a/apps/web/src/components/MatchRunHistory.tsx
+++ b/apps/web/src/components/MatchRunHistory.tsx
@@ -1,0 +1,177 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { CheckCircle2, ChevronDown, ChevronUp, Clock, Loader2, XCircle } from 'lucide-react'
+import { useMatchRunHistory, type MatchRunItem } from '@/hooks/useMatchRunHistory'
+import { Progress } from '@/components/ui/progress'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+type MatchRunHistoryProps = {
+  sessionId?: string
+  jobDescriptionId?: string
+}
+
+function runStatusClass(status: MatchRunItem['status']): string {
+  if (status === 'completed') {
+    return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+  }
+  if (status === 'failed') {
+    return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+  }
+  if (status === 'processing') {
+    return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+  }
+  return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400'
+}
+
+function runStatusLabel(status: MatchRunItem['status']): string {
+  if (status === 'completed') return 'Completed'
+  if (status === 'failed') return 'Failed'
+  if (status === 'processing') return 'Processing'
+  return 'Pending'
+}
+
+function runModeLabel(mode: MatchRunItem['mode']): string {
+  if (mode === 'rules_only') return 'Rules'
+  if (mode === 'ai_only') return 'AI'
+  return 'Hybrid'
+}
+
+function RunItem({ run }: { run: MatchRunItem }) {
+  const { t } = useTranslation()
+  const total = Math.max(run.totalCount, 1)
+  const current = Math.min(Math.max(run.processedCount, 0), total)
+  const progress = Math.min(100, Math.max(0, Math.round((current / total) * 100)))
+
+  return (
+    <div className="space-y-2 border-b pb-4 last:border-0 last:pb-0">
+      <div className="flex items-center justify-between text-sm">
+        <div className="flex items-center gap-2">
+          {run.status === 'processing' ? (
+            <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
+          ) : run.status === 'completed' ? (
+            <CheckCircle2 className="h-4 w-4 text-green-500" />
+          ) : (
+            <XCircle className="h-4 w-4 text-destructive" />
+          )}
+          <span className="font-medium">{run.jobDescriptionId}</span>
+          <span
+            className={`rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${runStatusClass(run.status)}`}
+          >
+            {runStatusLabel(run.status)}
+          </span>
+          <span className="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+            {runModeLabel(run.mode)}
+          </span>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {new Date(run.startedAt).toLocaleTimeString()}
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>
+            {t('aiTasks.monitor.progress')}: {current} / {total}
+          </span>
+          <span>{progress}%</span>
+        </div>
+        <Progress value={progress} className="h-2" />
+      </div>
+
+      {run.status === 'completed' ? (
+        <div className="text-xs text-muted-foreground">
+          {t('aiTasks.monitor.analyzed')}: {run.processedCount} | {t('aiTasks.monitor.avgScore')}: {run.avgScore ?? 0}
+          {typeof run.matchedCount === 'number' ? ` | ${t('aiTasks.monitor.highScore')}: ${run.matchedCount}` : ''}
+        </div>
+      ) : null}
+
+      {run.status === 'failed' ? (
+        <div className="text-xs text-destructive">
+          {t('aiTasks.monitor.failed')}
+          {run.error ? `: ${run.error}` : ''}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export function MatchRunHistory({ sessionId, jobDescriptionId }: MatchRunHistoryProps) {
+  const { t } = useTranslation()
+  const { runs, loading, error } = useMatchRunHistory({
+    sessionId,
+    jobDescriptionId,
+    enabled: true,
+    limit: 20,
+  })
+  const [showHistory, setShowHistory] = useState(false)
+
+  const { activeRuns, finishedRuns } = useMemo(() => {
+    return {
+      activeRuns: runs.filter((run) => run.status === 'processing'),
+      finishedRuns: runs.filter((run) => run.status === 'completed' || run.status === 'failed'),
+    }
+  }, [runs])
+
+  if (loading && runs.length === 0) {
+    return null
+  }
+  if (error && runs.length === 0) {
+    return null
+  }
+  if (runs.length === 0) {
+    return null
+  }
+
+  const hasActive = activeRuns.length > 0
+
+  if (!hasActive && !showHistory && finishedRuns.length > 0) {
+    return (
+      <Card className="mb-6 bg-muted/20">
+        <CardContent className="flex items-center justify-between py-3">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <CheckCircle2 className="h-4 w-4 text-green-500" />
+            <span>{t('aiTasks.monitor.allCompleted')}</span>
+          </div>
+          <Button variant="ghost" size="sm" onClick={() => setShowHistory(true)} className="h-8 text-xs">
+            {t('aiTasks.monitor.showHistory')}
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="mb-6">
+      <CardHeader className="border-b pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            {hasActive ? (
+              <Loader2 className="h-5 w-5 animate-spin text-primary" />
+            ) : (
+              <Clock className="h-5 w-5 text-muted-foreground" />
+            )}
+            {hasActive ? t('aiTasks.monitor.activeTitle') : t('aiTasks.monitor.historyTitle')}
+          </CardTitle>
+          {finishedRuns.length > 0 ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowHistory((prev) => !prev)}
+              className="h-8 text-xs"
+            >
+              {showHistory ? <ChevronUp className="mr-1 h-4 w-4" /> : <ChevronDown className="mr-1 h-4 w-4" />}
+              {showHistory ? t('aiTasks.monitor.hideHistory') : t('aiTasks.monitor.showHistory')}
+            </Button>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 pt-4">
+        {activeRuns.map((run) => (
+          <RunItem key={run.id} run={run} />
+        ))}
+        {showHistory ? finishedRuns.map((run) => <RunItem key={run.id} run={run} />) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/components/MatchRunHistory.tsx
+++ b/apps/web/src/components/MatchRunHistory.tsx
@@ -124,8 +124,29 @@ export function MatchRunHistory({ sessionId, jobDescriptionId }: MatchRunHistory
   }
 
   const hasActive = activeRuns.length > 0
+  const latestFinishedRun = finishedRuns[0]
+  const latestFinishedFailed = latestFinishedRun?.status === 'failed'
 
   if (!hasActive && !showHistory && finishedRuns.length > 0) {
+    if (latestFinishedFailed) {
+      return (
+        <Card className="mb-6 bg-muted/20">
+          <CardContent className="flex items-center justify-between py-3">
+            <div className="flex items-center gap-2 text-sm text-destructive">
+              <XCircle className="h-4 w-4" />
+              <span>
+                {t('aiTasks.monitor.failed')}
+                {latestFinishedRun?.error ? `: ${latestFinishedRun.error}` : ''}
+              </span>
+            </div>
+            <Button variant="ghost" size="sm" onClick={() => setShowHistory(true)} className="h-8 text-xs">
+              {t('aiTasks.monitor.showHistory')}
+            </Button>
+          </CardContent>
+        </Card>
+      )
+    }
+
     return (
       <Card className="mb-6 bg-muted/20">
         <CardContent className="flex items-center justify-between py-3">

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -41,6 +41,7 @@ export function ResumeCard({
 
   const score = matchResult?.score
   const recommendation = matchResult?.recommendation
+  const scoreSource = matchResult?.scoreSource
   const scoreLabel = recommendation ? t(`resumes.matching.recommendations.${recommendation}`) : ''
 
   const scoreClassName =
@@ -54,6 +55,13 @@ export function ResumeCard({
             : 'bg-zinc-100 text-zinc-600 border-zinc-200'
       : ''
 
+  const scoreSourceClassName =
+    scoreSource === 'ai'
+      ? 'bg-sky-600 text-white border-sky-700'
+      : scoreSource === 'rule'
+        ? 'bg-amber-500 text-white border-amber-600'
+        : ''
+
   return (
     <div className="mb-3 overflow-hidden rounded-lg border bg-card">
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b bg-muted/50 px-4 py-2 text-sm">
@@ -63,33 +71,40 @@ export function ResumeCard({
           <span className="text-muted-foreground">{resume.expectedSalary}</span>
         ) : null}
         {showAiScore && typeof score === 'number' ? (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="cursor-help">
-                  <Badge className={cn('border', scoreClassName)}>
-                    {t('resumes.matching.scoreLabel', { score })}
-                    {scoreLabel ? ` · ${scoreLabel}` : ''}
-                  </Badge>
-                </div>
-              </TooltipTrigger>
-              <TooltipContent className="p-3 text-xs w-64 bg-slate-900 text-white">
-                <p className="font-semibold mb-2 text-sm border-b pb-1 border-white/20">Analysis Breakdown</p>
-                {matchResult?.breakdown ? (
-                  <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-                    {Object.entries(matchResult.breakdown).map(([key, value]) => (
-                      <div key={key} className="flex justify-between">
-                        <span className="capitalize opacity-80">{key.replace('_', ' ')}:</span>
-                        <span className="font-mono font-bold">{value}</span>
-                      </div>
-                    ))}
+          <div className="flex items-center gap-2">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="cursor-help">
+                    <Badge className={cn('border', scoreClassName)}>
+                      {t('resumes.matching.scoreLabel', { score })}
+                      {scoreLabel ? ` · ${scoreLabel}` : ''}
+                    </Badge>
                   </div>
-                ) : (
-                  <p className="opacity-70 italic">No detailed breakdown available</p>
-                )}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+                </TooltipTrigger>
+                <TooltipContent className="p-3 text-xs w-64 bg-slate-900 text-white">
+                  <p className="font-semibold mb-2 text-sm border-b pb-1 border-white/20">Analysis Breakdown</p>
+                  {matchResult?.breakdown ? (
+                    <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+                      {Object.entries(matchResult.breakdown).map(([key, value]) => (
+                        <div key={key} className="flex justify-between">
+                          <span className="capitalize opacity-80">{key.replace('_', ' ')}:</span>
+                          <span className="font-mono font-bold">{value}</span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="opacity-70 italic">No detailed breakdown available</p>
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            {scoreSource ? (
+              <Badge className={cn('border text-[10px] uppercase tracking-wide', scoreSourceClassName)}>
+                {scoreSource === 'ai' ? 'AI' : 'Rule'}
+              </Badge>
+            ) : null}
+          </div>
         ) : null}
       </div>
 

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -19,6 +19,7 @@ import { FilterPanel } from '@/components/FilterPanel'
 import { QuickStartPanel } from '@/components/QuickStartPanel'
 import { BulkActionBar } from '@/components/BulkActionBar'
 import { AnalysisTaskMonitor } from '@/components/AnalysisTaskMonitor'
+import { MatchRunHistory } from '@/components/MatchRunHistory'
 import type { MatchBreakdown, MatchingResult, Recommendation } from '@/types/resume'
 
 import { useMutation } from 'convex/react'
@@ -95,7 +96,7 @@ function buildResumeKey(resume: ResumeItem, index: number): string {
 export function ResumeList() {
   const { t } = useTranslation()
   const { session, updateSession } = useSession()
-  const [mode, setMode] = useState<'ai' | 'original'>('ai')
+  const [mode, setMode] = useState<'ai' | 'original'>('original')
   const [jobDescriptionId, setJobDescriptionId] = useState('')
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
 
@@ -585,7 +586,11 @@ export function ResumeList() {
         ) : null}
       </div>
 
-      <AnalysisTaskMonitor />
+      {mode === 'ai' ? (
+        <AnalysisTaskMonitor />
+      ) : (
+        <MatchRunHistory sessionId={session?.id} jobDescriptionId={jobDescriptionId || undefined} />
+      )}
 
       <Card>
         <CardHeader>

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -636,7 +636,7 @@ export function ResumeList() {
                   key={entry.key || `${index}-${entry.resume.name}`}
                   resume={entry.resume}
                   matchResult={entry.match}
-                  showAiScore={mode === 'ai'}
+                  showAiScore={Boolean(entry.match)}
                   actionType={entry.action}
                   onAction={(actionType) => saveAction({ resumeId: entry.key, actionType })}
                   onViewDetails={() => setDetailResume(entry.resume)}

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, useEffect, useRef } from 'react'
+import { useCallback, useMemo, useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { RefreshCw } from 'lucide-react'
 import { useResumes, type ResumeItem } from '@/hooks/useResumes'
@@ -96,7 +96,7 @@ function buildResumeKey(resume: ResumeItem, index: number): string {
 export function ResumeList() {
   const { t } = useTranslation()
   const { session, updateSession } = useSession()
-  const [mode, setMode] = useState<'ai' | 'original'>('original')
+  const [mode, setMode] = useState<'ai' | 'original'>('ai')
   const [jobDescriptionId, setJobDescriptionId] = useState('')
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
 
@@ -127,7 +127,6 @@ export function ResumeList() {
     matchAll,
     fetchMatches,
   } = useAiMatching()
-  const autoRunKeyRef = useRef<string>('')
   const { actions, saveAction } = useCandidateActions(session?.id)
 
   // Convex Integration
@@ -197,27 +196,6 @@ export function ResumeList() {
       fetchMatches(session.id, jobDescriptionId)
     }
   }, [fetchMatches, jobDescriptionId, session?.id])
-
-  useEffect(() => {
-    if (mode !== 'original') {
-      autoRunKeyRef.current = ''
-      return
-    }
-    if (!jobDescriptionId) return
-
-    const triggerKey = `${session?.id || 'no-session'}:${selectedSample || ''}:${jobDescriptionId}`
-    if (autoRunKeyRef.current === triggerKey) return
-
-    autoRunKeyRef.current = triggerKey
-    void matchAll({
-      sessionId: session?.id,
-      jobDescriptionId,
-      sample: selectedSample || undefined,
-      limit: 200,
-      topN: 20,
-      mode: 'hybrid',
-    })
-  }, [jobDescriptionId, matchAll, mode, selectedSample, session?.id])
 
   useEffect(() => {
     setSelectedIds(new Set())

--- a/apps/web/src/hooks/useAiMatching.ts
+++ b/apps/web/src/hooks/useAiMatching.ts
@@ -2,12 +2,90 @@ import { useCallback, useState } from 'react'
 import { rawApiClient } from '@/lib/api-helpers'
 import type { MatchStats, MatchingResult } from '@/types/resume'
 
+export type MatchMode = 'rules_only' | 'hybrid' | 'ai_only'
+
 export type MatchRequest = {
   sessionId?: string
   sample?: string
   jobDescriptionId: string
   resumeIds?: string[]
   limit?: number
+  topN?: number
+  mode?: MatchMode
+}
+
+type StreamProgress = {
+  done: number
+  total: number
+}
+
+type StreamResultPayload = {
+  resumeId: string
+  result: MatchingResult
+  progress?: StreamProgress
+}
+
+type StreamRulesPayload = {
+  results?: MatchingResult[]
+  progress?: StreamProgress
+}
+
+type StreamDonePayload = {
+  stats?: MatchStats
+}
+
+const rawBaseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000/api'
+const baseUrl = rawBaseUrl.replace(/\/api\/?$/, '')
+
+function mergeResult(results: MatchingResult[], incoming: MatchingResult): MatchingResult[] {
+  const idx = results.findIndex((item) => item.resumeId === incoming.resumeId)
+  if (idx === -1) return [...results, incoming]
+
+  const next = [...results]
+  next[idx] = {
+    ...next[idx],
+    ...incoming,
+  }
+  return next
+}
+
+function parseSseBlock(block: string): { event: string; data: unknown } | null {
+  const lines = block.split('\n')
+  let event = 'message'
+  const dataLines: string[] = []
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd()
+    if (!line) continue
+    if (line.startsWith('event:')) {
+      event = line.slice(6).trim()
+      continue
+    }
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).trim())
+    }
+  }
+
+  if (dataLines.length === 0) return null
+
+  try {
+    return {
+      event,
+      data: JSON.parse(dataLines.join('')),
+    }
+  } catch {
+    return null
+  }
+}
+
+function calcStats(results: MatchingResult[]): MatchStats | null {
+  if (results.length === 0) return null
+
+  const processed = results.length
+  const matched = results.filter((item) => item.score >= 50).length
+  const avgScore = Number((results.reduce((sum, item) => sum + item.score, 0) / processed).toFixed(2))
+
+  return { processed, matched, avgScore }
 }
 
 export function useAiMatching() {
@@ -15,30 +93,127 @@ export function useAiMatching() {
   const [stats, setStats] = useState<MatchStats | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [progress, setProgress] = useState<StreamProgress | null>(null)
+
+  const consumeMatchStream = useCallback(async (payload: MatchRequest) => {
+    const response = await fetch(`${baseUrl}/api/resumes/match-stream`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+
+    if (!response.ok || !response.body) {
+      throw new Error(`Failed to open stream (${response.status})`)
+    }
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+
+      while (true) {
+        const markerIndex = buffer.indexOf('\n\n')
+        if (markerIndex < 0) break
+
+        const block = buffer.slice(0, markerIndex)
+        buffer = buffer.slice(markerIndex + 2)
+
+        const parsed = parseSseBlock(block)
+        if (!parsed) continue
+
+        if (parsed.event === 'rules') {
+          const data = parsed.data as StreamRulesPayload
+          if (Array.isArray(data.results) && data.results.length > 0) {
+            setResults(data.results)
+            setStats(calcStats(data.results))
+          }
+          if (data.progress) {
+            setProgress(data.progress)
+          }
+          continue
+        }
+
+        if (parsed.event === 'result') {
+          const data = parsed.data as StreamResultPayload
+          if (!data.result) continue
+
+          setResults((prev) => {
+            const next = mergeResult(prev, data.result)
+            setStats(calcStats(next))
+            return next
+          })
+
+          if (data.progress) {
+            setProgress(data.progress)
+          }
+          continue
+        }
+
+        if (parsed.event === 'done') {
+          const data = parsed.data as StreamDonePayload
+          setStats(data.stats ?? null)
+          setProgress(null)
+          return
+        }
+
+        if (parsed.event === 'error') {
+          const payload = parsed.data as { message?: string }
+          throw new Error(payload.message || 'Stream failed')
+        }
+      }
+    }
+  }, [])
 
   const matchAll = useCallback(async (payload: MatchRequest) => {
     setLoading(true)
     setError(null)
+    setProgress(null)
+
+    const mode = payload.mode ?? 'hybrid'
 
     const { data, error: apiError } = await rawApiClient.POST<{
       success: boolean
+      mode?: MatchMode
       results?: MatchingResult[]
       stats?: MatchStats
     }>('/api/resumes/match', {
-      body: payload,
+      body: {
+        ...payload,
+        mode,
+      },
     })
 
     if (apiError || !data?.success) {
-      setError('Failed to run AI matching')
+      setError('Failed to run matching')
       setLoading(false)
       return null
     }
 
     setResults(data.results ?? [])
     setStats(data.stats ?? null)
+
+    if (mode === 'hybrid') {
+      try {
+        await consumeMatchStream({
+          ...payload,
+          mode,
+        })
+      } catch (streamError) {
+        console.error('Match stream failed', streamError)
+        setError('AI streaming updates failed')
+      }
+    }
+
     setLoading(false)
     return data
-  }, [])
+  }, [consumeMatchStream])
 
   const fetchMatches = useCallback(async (sessionId: string, jobDescriptionId?: string) => {
     setLoading(true)
@@ -64,14 +239,7 @@ export function useAiMatching() {
 
     const nextResults = data.results ?? []
     setResults(nextResults)
-    if (nextResults.length) {
-      const processed = nextResults.length
-      const matched = nextResults.filter((item: MatchingResult) => item.score >= 50).length
-      const avgScore = Number((nextResults.reduce((sum: number, item: MatchingResult) => sum + item.score, 0) / processed).toFixed(2))
-      setStats({ processed, matched, avgScore })
-    } else {
-      setStats(null)
-    }
+    setStats(calcStats(nextResults))
     setLoading(false)
     return data
   }, [])
@@ -81,6 +249,7 @@ export function useAiMatching() {
     stats,
     loading,
     error,
+    progress,
     matchAll,
     fetchMatches,
   }

--- a/apps/web/src/hooks/useMatchRunHistory.ts
+++ b/apps/web/src/hooks/useMatchRunHistory.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useState } from 'react'
+import { rawApiClient } from '@/lib/api-helpers'
+
+export type MatchRunMode = 'rules_only' | 'hybrid' | 'ai_only'
+export type MatchRunStatus = 'processing' | 'completed' | 'failed'
+
+export type MatchRunItem = {
+  id: string
+  sessionId?: string
+  jobDescriptionId: string
+  sampleName?: string
+  mode: MatchRunMode
+  status: MatchRunStatus
+  totalCount: number
+  processedCount: number
+  failedCount: number
+  matchedCount?: number
+  avgScore?: number
+  startedAt: string
+  completedAt?: string
+  error?: string
+}
+
+type MatchRunsResponse = {
+  success: boolean
+  runs?: MatchRunItem[]
+}
+
+type UseMatchRunHistoryParams = {
+  sessionId?: string
+  jobDescriptionId?: string
+  enabled?: boolean
+  limit?: number
+  pollIntervalMs?: number
+}
+
+export function useMatchRunHistory(params: UseMatchRunHistoryParams) {
+  const {
+    sessionId,
+    jobDescriptionId,
+    enabled = true,
+    limit = 20,
+    pollIntervalMs = 4000,
+  } = params
+
+  const [runs, setRuns] = useState<MatchRunItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchRuns = useCallback(async () => {
+    if (!enabled) return
+    if (!sessionId && !jobDescriptionId) {
+      setRuns([])
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    const { data, error: apiError } = await rawApiClient.GET<MatchRunsResponse>(
+      '/api/resumes/match-runs',
+      {
+        params: {
+          query: {
+            sessionId,
+            jobDescriptionId,
+            limit,
+          },
+        },
+      }
+    )
+
+    if (apiError || !data?.success) {
+      setError('Failed to load analysis history')
+      setLoading(false)
+      return
+    }
+
+    setRuns(Array.isArray(data.runs) ? data.runs : [])
+    setLoading(false)
+  }, [enabled, jobDescriptionId, limit, sessionId])
+
+  useEffect(() => {
+    void fetchRuns()
+  }, [fetchRuns])
+
+  useEffect(() => {
+    if (!enabled) return undefined
+    const timer = window.setInterval(() => {
+      void fetchRuns()
+    }, pollIntervalMs)
+    return () => window.clearInterval(timer)
+  }, [enabled, fetchRuns, pollIntervalMs])
+
+  return {
+    runs,
+    loading,
+    error,
+    refresh: fetchRuns,
+  }
+}

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -494,6 +494,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/resumes/match-runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get resume match run history
+         * @description Returns recent matching runs for backend AI/rule pipeline
+         */
+        get: {
+            parameters: {
+                query?: {
+                    sessionId?: string;
+                    jobDescriptionId?: string;
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Recent run history */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MatchRunsResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/resumes/matches/rescore": {
         parameters: {
             query?: never;
@@ -2208,6 +2251,47 @@ export interface components {
             /** @enum {boolean} */
             success: true;
             results: components["schemas"]["ResumeMatch"][];
+        };
+        MatchRun: {
+            /** @example run-123 */
+            id: string;
+            /** @example session-123 */
+            sessionId?: string;
+            /** @example lathe-sales */
+            jobDescriptionId: string;
+            /** @example sample-initial */
+            sampleName?: string;
+            /**
+             * @example hybrid
+             * @enum {string}
+             */
+            mode: "rules_only" | "hybrid" | "ai_only";
+            /**
+             * @example completed
+             * @enum {string}
+             */
+            status: "processing" | "completed" | "failed";
+            /** @example 100 */
+            totalCount: number;
+            /** @example 20 */
+            processedCount: number;
+            /** @example 0 */
+            failedCount: number;
+            /** @example 14 */
+            matchedCount?: number;
+            /** @example 72.3 */
+            avgScore?: number;
+            /** @example 2026-02-11T08:00:00.000Z */
+            startedAt: string;
+            /** @example 2026-02-11T08:00:09.000Z */
+            completedAt?: string;
+            /** @example AI provider timeout */
+            error?: string;
+        };
+        MatchRunsResponse: {
+            /** @enum {boolean} */
+            success: true;
+            runs: components["schemas"]["MatchRun"][];
         };
         ResumeFilters: {
             minExperience?: number;

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -367,7 +367,7 @@ export interface paths {
         put?: never;
         /**
          * Match resumes with a job description
-         * @description Runs AI matching and stores results for the session
+         * @description Runs rule/AI matching and stores results for the session
          */
         post: {
             parameters: {
@@ -461,6 +461,92 @@ export interface paths {
         };
         put?: never;
         post?: never;
+        /** Clear cached resume matches */
+        delete: {
+            parameters: {
+                query?: {
+                    jobDescriptionId?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Deleted count */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            deleted: number;
+                            jobDescriptionId?: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/resumes/matches/rescore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Re-score resumes with rule engine */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        sessionId?: string;
+                        sample?: string;
+                        jobDescriptionId: string;
+                        resumeIds?: string[];
+                        limit?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Re-scored results */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MatchResponse"];
+                    };
+                };
+                /** @description Session or data not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;
@@ -2027,6 +2113,18 @@ export interface components {
             };
             data: components["schemas"]["ResumeItem"][];
         };
+        MatchBreakdown: {
+            /** @example 20 */
+            skillMatch: number;
+            /** @example 18 */
+            experienceMatch: number;
+            /** @example 12 */
+            educationMatch: number;
+            /** @example 15 */
+            locationMatch: number;
+            /** @example 10 */
+            industryMatch: number;
+        };
         ResumeMatch: {
             /** @example R123456 */
             resumeId: string;
@@ -2053,6 +2151,12 @@ export interface components {
             concerns: string[];
             /** @example 候选人与岗位匹配良好，可安排面试。 */
             summary: string;
+            breakdown?: components["schemas"]["MatchBreakdown"];
+            /**
+             * @example rule
+             * @enum {string}
+             */
+            scoreSource?: "rule" | "ai";
             /** @example 2026-02-05T08:00:00.000Z */
             matchedAt: string;
             /** @example session-123 */
@@ -2065,10 +2169,15 @@ export interface components {
             matched: number;
             avgScore: number;
             processingTimeMs?: number;
+            pendingAi?: number;
         };
         MatchResponse: {
             /** @enum {boolean} */
             success: true;
+            /** @enum {string} */
+            mode?: "rules_only" | "hybrid" | "ai_only";
+            streamPath?: string;
+            pendingAiCount?: number;
             results: components["schemas"]["ResumeMatch"][];
             stats: components["schemas"]["MatchStats"];
         };
@@ -2087,6 +2196,13 @@ export interface components {
             resumeIds?: string[];
             /** @example 50 */
             limit?: number;
+            /** @example 20 */
+            topN?: number;
+            /**
+             * @example hybrid
+             * @enum {string}
+             */
+            mode?: "rules_only" | "hybrid" | "ai_only";
         };
         ResumeMatchesResponse: {
             /** @enum {boolean} */

--- a/apps/web/src/pages/DebugConfig.tsx
+++ b/apps/web/src/pages/DebugConfig.tsx
@@ -976,7 +976,7 @@ export default function DebugConfig() {
                 </Badge>
                 {aiStatus.bonded?.includes('AI_ANALYSIS_ENABLED') && (
                   <Badge variant="outline" className="border-emerald-500/50 bg-emerald-500/5 text-emerald-600 dark:text-emerald-400">
-                    Bonded to .env
+                    Bound to environment
                   </Badge>
                 )}
                 <Badge variant={aiStatus.valid ? 'default' : 'destructive'}>

--- a/apps/web/src/types/resume.ts
+++ b/apps/web/src/types/resume.ts
@@ -13,6 +13,15 @@ export type ResumeFilters = {
 }
 
 export type Recommendation = 'strong_match' | 'match' | 'potential' | 'no_match'
+export type ScoreSource = 'rule' | 'ai'
+
+export type MatchBreakdown = {
+  skillMatch: number
+  experienceMatch: number
+  educationMatch: number
+  locationMatch: number
+  industryMatch: number
+}
 
 export type MatchingResult = {
   resumeId: string
@@ -25,7 +34,8 @@ export type MatchingResult = {
   matchedAt: string
   sessionId?: string
   userId?: string
-  breakdown?: Record<string, number>
+  breakdown?: MatchBreakdown
+  scoreSource?: ScoreSource
 }
 
 export type MatchStats = {

--- a/config/resume/agents.json5
+++ b/config/resume/agents.json5
@@ -12,6 +12,7 @@
         model: "deepseek/deepseek-chat",
         config: {
           batchSize: 50,           // Process 50 resumes per batch
+          concurrency: 5,          // Default concurrent workers for API batch matching
           parallelism: 10,         // 10 parallel requests
           timeout: 30000,          // 30 second timeout
           maxTokens: 500,          // Short responses
@@ -101,6 +102,15 @@
     { agentId: "evaluator", match: { stage: "technical_review" } },
     { agentId: "final", match: { stage: "final_decision" } }
   ],
+
+  // Rule-first hybrid scoring defaults
+  ruleScoring: {
+    enabled: true,
+    defaultMode: "hybrid",   // rules_only | hybrid | ai_only
+    aiTopN: 20,              // Only top N rule-scored resumes go to AI
+    aiConcurrency: 5,        // AI batch concurrency
+    minRuleScoreForAi: 50
+  },
   
   // Global settings
   global: {

--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -2,7 +2,7 @@ import { internal } from "./_generated/api";
 import type { Doc } from "./_generated/dataModel";
 import { internalAction, internalMutation, internalQuery, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { SYSTEM_PROMPT, USER_PROMPT_TEMPLATE, callLLM, normalizeResume } from "./analyze";
+import { SYSTEM_PROMPT, USER_PROMPT_TEMPLATE, callLLM, getAiApiKey, normalizeResume } from "./analyze";
 
 type AnalysisTaskStatus = "pending" | "processing" | "completed" | "failed" | "cancelled";
 
@@ -345,9 +345,9 @@ export const processAnalysisTask = internalAction({
         let cancelled = false;
 
         try {
-            const apiKey = process.env.OPENAI_API_KEY;
+            const apiKey = getAiApiKey();
             if (!apiKey) {
-                throw new Error("OPENAI_API_KEY is not set in Convex environment variables.");
+                throw new Error("AI_API_KEY/OPENAI_API_KEY is not set in Convex environment variables.");
             }
 
             const markResult = await ctx.runMutation(internal.analysis_tasks.markProcessing, {

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -45,6 +45,18 @@ export const USER_PROMPT_TEMPLATE = `请分析以下候选人与职位的匹配�
   "summary": "中文总结"
 }`;
 
+export function getAiApiKey(): string | undefined {
+    return process.env.AI_API_KEY || process.env.OPENAI_API_KEY || undefined;
+}
+
+export function getAiApiBase(): string {
+    return process.env.AI_API_BASE || process.env.OPENAI_API_BASE || "https://api.openai.com/v1";
+}
+
+export function getAiModel(): string {
+    return process.env.AI_MODEL || process.env.OPENAI_MODEL || "gpt-4-turbo-preview";
+}
+
 // Helper to normalize resume data
 export function normalizeResume(data: any) {
     return {
@@ -60,7 +72,7 @@ export function normalizeResume(data: any) {
 
 // Helper to call OpenAI/Compatible API
 export async function callLLM(messages: any[], apiKey: string) {
-    const apiBase = process.env.OPENAI_API_BASE || "https://api.openai.com/v1";
+    const apiBase = getAiApiBase();
     const url = `${apiBase}/chat/completions`;
 
     console.log(`Calling LLM at ${url}...`);
@@ -72,7 +84,7 @@ export async function callLLM(messages: any[], apiKey: string) {
             "Authorization": `Bearer ${apiKey}`,
         },
         body: JSON.stringify({
-            model: process.env.OPENAI_MODEL || "gpt-4-turbo-preview", // Configurable
+            model: getAiModel(), // Configurable
             messages: messages,
             temperature: 0.1,
             // strict json mode is often supported but sometimes model-dependent
@@ -125,9 +137,9 @@ export const analyzeResume = action({
         jobDescriptionId: v.optional(v.string()), // Added ID
     },
     handler: async (ctx, args) => {
-        const apiKey = process.env.OPENAI_API_KEY;
+        const apiKey = getAiApiKey();
         if (!apiKey) {
-            throw new Error("OPENAI_API_KEY is not set in Convex environment variables.");
+            throw new Error("AI_API_KEY/OPENAI_API_KEY is not set in Convex environment variables.");
         }
 
         const resume = await ctx.runQuery(internal.resumes.getResume, { resumeId: args.resumeId });

--- a/scripts/clear-matches.ts
+++ b/scripts/clear-matches.ts
@@ -1,0 +1,23 @@
+import { MatchStorage } from "../apps/api/src/services/match-storage.js";
+
+function readArg(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag);
+  if (index < 0) return undefined;
+  return process.argv[index + 1];
+}
+
+async function main(): Promise<void> {
+  const jobDescriptionId = readArg("--job") || readArg("--jobDescriptionId");
+  const matchStorage = new MatchStorage();
+  const deleted = matchStorage.clearMatches(jobDescriptionId);
+  console.log(
+    jobDescriptionId
+      ? `Cleared ${deleted} matches for ${jobDescriptionId}`
+      : `Cleared ${deleted} matches`
+  );
+}
+
+main().catch((error) => {
+  console.error("clear-matches failed:", error);
+  process.exit(1);
+});

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -4,10 +4,19 @@ set -e
 # TrendRadar Development Environment
 # Starts all available services concurrently with proper process management
 
-ENV_FILE="${ENV_FILE:-.env}"
+ENV_FILE="${ENV_FILE:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 LOGS_DIR="$PROJECT_ROOT/logs"
+ENV_FILE_RESOLVED=""
+
+if [ -n "$ENV_FILE" ]; then
+    if [ -f "$ENV_FILE" ]; then
+        ENV_FILE_RESOLVED="$ENV_FILE"
+    elif [ -f "$PROJECT_ROOT/$ENV_FILE" ]; then
+        ENV_FILE_RESOLVED="$PROJECT_ROOT/$ENV_FILE"
+    fi
+fi
 
 # Colors for output
 RED='\033[0;31m'
@@ -524,8 +533,8 @@ start_mcp_server() {
 
     cd "$PROJECT_ROOT"
     local cmd="uv run python -m mcp_server.server --transport http --port $port"
-    if [ -f "$ENV_FILE" ]; then
-        cmd="uv run --env-file $ENV_FILE python -m mcp_server.server --transport http --port $port"
+    if [ -n "$ENV_FILE_RESOLVED" ]; then
+        cmd="uv run --env-file \"$ENV_FILE_RESOLVED\" python -m mcp_server.server --transport http --port $port"
     fi
 
     # Use process substitution to capture correct PID
@@ -541,8 +550,8 @@ start_crawler() {
     export SKIP_ROOT_INDEX=true
 
     local cmd="uv run python -m trendradar"
-    if [ -f "$ENV_FILE" ]; then
-        cmd="uv run --env-file $ENV_FILE python -m trendradar"
+    if [ -n "$ENV_FILE_RESOLVED" ]; then
+        cmd="uv run --env-file \"$ENV_FILE_RESOLVED\" python -m trendradar"
     fi
 
     eval "$cmd" > >(tee "$LOGS_DIR/crawler.log" | while read line; do log "CRAWLER" "$GREEN" "$line"; done) 2>&1 &
@@ -602,14 +611,17 @@ start_api() {
         log "API" "$CYAN" "Starting BFF API on http://localhost:$port ($runner run dev)"
         cd "$PROJECT_ROOT/apps/api"
 
-        if [ -n "$ENV_FILE" ] && [ -f "$PROJECT_ROOT/$ENV_FILE" ]; then
-            # Source .env into the current subshell to export vars to the runner
-            set -a
-            source "$PROJECT_ROOT/$ENV_FILE"
-            set +a
+        if [ -n "$ENV_FILE_RESOLVED" ] && [ "$runner" = "bun" ]; then
+            PORT="$port" bun --env-file "$ENV_FILE_RESOLVED" run dev > >(tee "$(service_log_path "api")" | stream_service_logs "api" "$CYAN") 2>&1 &
+        else
+            if [ -n "$ENV_FILE_RESOLVED" ]; then
+                # Export optional env-file values into this subshell for npm fallback.
+                set -a
+                source "$ENV_FILE_RESOLVED"
+                set +a
+            fi
+            PORT="$port" run_local_js_script dev > >(tee "$(service_log_path "api")" | stream_service_logs "api" "$CYAN") 2>&1 &
         fi
-
-        PORT="$port" run_local_js_script dev > >(tee "$(service_log_path "api")" | stream_service_logs "api" "$CYAN") 2>&1 &
         SERVICE_PIDS["api"]=$!
     else
         log "API" "$YELLOW" "apps/api not found (planned for Milestone 2)"
@@ -630,8 +642,8 @@ start_worker() {
         cd "$PROJECT_ROOT/apps/worker"
         
         local cmd="uv run uvicorn api:app --reload --port $port"
-        if [ -f "$ENV_FILE" ]; then
-            cmd="uv run --env-file $ENV_FILE uvicorn api:app --reload --port $port"
+        if [ -n "$ENV_FILE_RESOLVED" ]; then
+            cmd="uv run --env-file \"$ENV_FILE_RESOLVED\" uvicorn api:app --reload --port $port"
         fi
 
         eval "$cmd" > >(tee "$(service_log_path "worker")" | stream_service_logs "worker" "$CYAN") 2>&1 &
@@ -669,8 +681,8 @@ start_scraper() {
 
     cd "$PROJECT_ROOT"
     local cmd="uv run python scripts/worker.py"
-    if [ -f "$ENV_FILE" ]; then
-        cmd="uv run --env-file $ENV_FILE python scripts/worker.py"
+    if [ -n "$ENV_FILE_RESOLVED" ]; then
+        cmd="uv run --env-file \"$ENV_FILE_RESOLVED\" python scripts/worker.py"
     fi
 
     eval "$cmd" > >(tee "$(service_log_path "scraper")" | stream_service_logs "scraper" "$CYAN") 2>&1 &
@@ -895,10 +907,10 @@ main() {
     mkdir -p "$LOGS_DIR"
 
     # Load environment
-    if [ -f "$PROJECT_ROOT/$ENV_FILE" ]; then
-        log "DEV" "$GREEN" "Using environment from: $ENV_FILE"
+    if [ -n "$ENV_FILE_RESOLVED" ]; then
+        log "DEV" "$GREEN" "Using environment from: $ENV_FILE_RESOLVED"
     else
-        log "DEV" "$YELLOW" "No $ENV_FILE found, using system environment"
+        log "DEV" "$YELLOW" "Using system environment variables (no ENV_FILE configured)"
     fi
 
     # Parse command line arguments
@@ -952,7 +964,7 @@ main() {
                 echo "  --help        Show this help message"
                 echo ""
                 echo "Environment variables:"
-                echo "  ENV_FILE      Path to .env file (default: .env)"
+                echo "  ENV_FILE      Optional env file path (unset by default)"
                 echo "  SKIP_CRAWL    Skip crawl on startup (default: true; set to false to crawl)"
                 echo "  SEED_MODE     Convex seed mode: auto|skip (default: auto)"
                 echo "  MCP_PORT      MCP server port (default: 3333)"

--- a/scripts/seed-matches.ts
+++ b/scripts/seed-matches.ts
@@ -1,0 +1,99 @@
+import { MatchStorage } from "../apps/api/src/services/match-storage.js";
+import { ResumeService } from "../apps/api/src/services/resume-service.js";
+import { JobDescriptionService } from "../apps/api/src/services/job-description-service.js";
+import { RuleScoringService } from "../apps/api/src/services/rule-scoring.js";
+import { resolveResumeId } from "../apps/api/src/services/resume-id.js";
+
+function readArg(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag);
+  if (index < 0) return undefined;
+  return process.argv[index + 1];
+}
+
+function hasFlag(flag: string): boolean {
+  return process.argv.includes(flag);
+}
+
+async function main(): Promise<void> {
+  const sampleArg = readArg("--sample");
+  const limitArg = readArg("--limit");
+  const onlyJob = readArg("--job");
+  const clearFirst = hasFlag("--clear");
+
+  const resumeService = new ResumeService();
+  const jobService = new JobDescriptionService();
+  const ruleScoringService = new RuleScoringService();
+  const matchStorage = new MatchStorage();
+
+  const samples = resumeService.listSampleFiles();
+  if (samples.length === 0) {
+    console.log("No resume samples found in output/resumes/samples. Skipping seed-matches.");
+    return;
+  }
+
+  const resolvedSample = sampleArg
+    ? samples.find((sample) => sample.name === sampleArg || sample.filename === sampleArg || `${sample.name}.json` === sampleArg)
+    : samples[0];
+
+  if (!resolvedSample) {
+    console.log(`Sample not found: ${sampleArg}. Available samples: ${samples.map((item) => item.name).join(", ")}`);
+    return;
+  }
+
+  const { items, indexes } = resumeService.loadSample(resolvedSample.name);
+  const limit = limitArg ? Math.max(1, Number.parseInt(limitArg, 10)) : items.length;
+  const limitedItems = Number.isFinite(limit) ? items.slice(0, limit) : items;
+
+  const allJds = jobService.listFiles().filter((jd) => jd.status !== "closed");
+  const jds = onlyJob
+    ? allJds.filter((jd) => jd.name === onlyJob || jd.id === onlyJob)
+    : allJds;
+
+  if (jds.length === 0) {
+    console.log("No job descriptions available for seed-matches. Skipping.");
+    return;
+  }
+
+  if (clearFirst) {
+    const deleted = matchStorage.clearMatches();
+    console.log(`Cleared existing matches: ${deleted}`);
+  }
+
+  let inserted = 0;
+
+  for (const jd of jds) {
+    const context = ruleScoringService.buildContext(jd.name);
+    const entries = limitedItems.map((resume, index) => {
+      const resumeId = resolveResumeId(resume, index);
+      const indexData = indexes.get(resumeId);
+      if (!indexData) {
+        return null;
+      }
+
+      const result = ruleScoringService.scoreResume(indexData, context);
+      return {
+        sessionId: undefined,
+        resumeId,
+        jobDescriptionId: jd.name,
+        sampleName: resolvedSample.name,
+        result: ruleScoringService.toMatchingResult(result),
+        aiModel: "rule-scoring",
+        processingTimeMs: 0,
+      };
+    }).filter((entry) => entry !== null);
+
+    if (entries.length > 0) {
+      matchStorage.saveMatches(entries);
+      inserted += entries.length;
+    }
+
+    console.log(`Seeded ${entries.length} matches for JD ${jd.name}`);
+  }
+
+  console.log(`Done. Seeded ${inserted} deterministic matches from sample ${resolvedSample.name}.`);
+}
+
+main().catch((error) => {
+  console.error("seed-matches failed:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Task

# Fast Dev Cycle & AI Scoring Optimization Plan

## Problem Statement

The current AI scoring pipeline is **unusable for both dev cycles and end-user experience**:

1. **Sequential processing**: `matchBatch()` in `ai-matching.ts:186-207` processes resumes one-by-one with `for...of` loop. 100 resumes × 2-3s each = **200-300s blocking wait**.
2. **No pre-computed scores**: Every dev server restart requires re-triggering AI matching manually.
3. **No rule-based fast path**: Simple deterministic rules (keyword match, industry match, experience range) that could instantly filter 60-70% of candidates are not separated from the expensive AI call.
4. **Dev seed data has no pre-scored results**: `make dev` loads sample resumes but the `resume_matches` table starts empty — dev always hits the slow AI path.
5. **Batch wait-for-all UX**: Frontend blocks until entire batch completes (`resumes.ts:370-393`), no progressive display.

## Core Design Principle

> "Lesser human-in-the-loop" applies to dev workflow too — agents and devs should get instant feedback, not wait for AI.

---

## Architecture: 3-Tier Scoring System

Replace the current single-tier "send everything to LLM" with a **3-tier scoring pyramid**:

```
Tier 3: AI Deep Analysis (LLM)     ← 10-15 candidates, async
    ↑ only top candidates from Tier 2
Tier 2: Rule-Based Scoring          ← all candidates, instant (<1ms each)
    ↑ structured data extraction
Tier 1: Index & Pre-filter          ← all candidates, instant
    ↑ resume data
```

- **Tier 1** (Index): Pre-compute searchable indexes from resume text — skills, companies, experience years, education level, location. Done once on sample load.
- **Tier 2** (Rule Engine): Score every resume instantly using deterministic rules from the JD's `auto_match` config + filter presets. Produces a 0-100 "rule score" with breakdown.
- **Tier 3** (AI): Only for top N candidates from Tier 2. Runs async with streaming results.

---

## Implementation Tasks

### Task 0: Seed Pre-scored Match Data for Dev Mode [INDEPENDENT]

**Files**: `scripts/seed-matches.ts` (new), `Makefile`
**Depends**: none
**Conflict Risk**: none

Create a seed script that populates `resume_matches` table with realistic pre-computed scores for dev mode, so the UI is immediately usable after `make dev`.

- Read `output/resumes/samples/sample-initial.json`
- Read each JD from `config/job-descriptions/`
- Generate deterministic mock scores based on keyword overlap + experience + education
- Insert into `resume_matches` table via `MatchStorage.saveMatches()`
- Add `make seed-matches` target and integrate into `make dev` flow
- Scores should be **deterministic** (same input = same output) so devs get consistent results

**Verification**: `make dev` → open web UI → resumes show pre-sorted scores immediately without clicking "Analyze All"

---

### Task 1: Resume Index Service — Pre-compute Structured Fields [INDEPENDENT]

**Files**: `apps/api/src/services/resume-index.ts` (new)
**Depends**: none
**Conflict Risk**: none

Extract structured, searchable data from raw resume text at load time (not at query time):

```typescript
interface ResumeIndex {
  resumeId: string
  experienceYears: number | null
  educationLevel: string | null  // normalized
  locationCity: string | null
  skills: string[]               // extracted from jobIntention + workHistory
  companies: string[]             // extracted from workHistory
  industryTags: string[]          // inferred from companies + skills
  salaryRange: { min?: number; max?: number } | null
  searchText: string              // pre-built lowercase text for full-text search
}
```

- Build index once when sample is loaded (in `ResumeService.loadSample()`)
- Cache in memory (Map by resumeId)
- Add industry inference: map known company names / skill keywords to industry tags (machinery, CNC, sales, etc.)
- Use `config/resume/skills_words.txt` and JD `auto_match.keywords` as industry vocabulary

**Verification**: Unit test — load sample, verify index has correct parsed fields for known resumes

---

### Task 2: Rule-Based Scoring Engine [DEPENDS: Task 1]

**Files**: `apps/api/src/services/rule-scoring.ts` (new)
**Depends**: Task 1 (uses ResumeIndex)
**Conflict Risk**: none

Instant deterministic scoring that runs in <1ms per resume:

```typescript
interface RuleScoringResult {
  score: number            // 0-100
  recommendation: string   // strong_match | match | potential | no_match
  breakdown: {
    skillMatch: number     // 0-30 points: keyword overlap with JD
    experienceMatch: number // 0-25 points: within JD required range
    educationMatch: number  // 0-15 points: meets JD education req
    locationMatch: number   // 0-15 points: in target location
    industryMatch: number   // 0-15 points: company/industry relevance
  }
  matchedSkills: string[]
  matchedCompanies: string[]
}
```

Scoring rules derived from JD `auto_match` config:

- **Skill match (30pts)**: Count JD keywords found in resume skills/jobIntention/workHistory. Score = (matched/total) × 30.
- **Experience match (25pts)**: If within JD's `suggested_filters.minExperience` range, full points. Graduated penalty outside range.
- **Education match (15pts)**: Full points if education level meets or exceeds JD requirement.
- **Location match (15pts)**: Full points if resume location includes any JD target location.
- **Industry match (15pts)**: Company names or skills matching industry vocabulary from JD.

This gives every resume a score instantly. The AI tier can refine later.

**Verification**: Unit test — score known resumes against `lathe-sales` JD, verify sensible results

---

### Task 3: Parallel Batch Processing with Streaming [INDEPENDENT]

**Files**: `apps/api/src/services/ai-matching.ts`, `apps/api/src/routes/resumes.ts`
**Depends**: none
**Conflict Risk**: `ai-matching.ts`, `resumes.ts`

Fix the sequential bottleneck in `matchBatch()`:

1. **Parallel execution**: Replace `for...of` loop with `Promise.all()` + concurrency limiter (p-limit pattern, inline implementation to avoid new dep). Default concurrency: 5 (configurable via `agents.json5`).
2. **Streaming response**: Add `POST /api/resumes/match-stream` endpoint using SSE (Server-Sent Events). Send each result as it completes instead of wait-for-all.
3. **Progress tracking**: Each SSE message includes `{ resumeId, result, progress: { done, total } }`.

Before (100 resumes, sequential): \~250s
After (100 resumes, 5 concurrent): \~50s
After (with rule pre-filter sending only top 20 to AI): \~10s

**Verification**: Call `/api/resumes/match-stream` with curl, see progressive JSON results

---

### Task 4: Hybrid Match Endpoint — Rules First, AI Second [DEPENDS: Task 1, 2, 3]

**Files**: `apps/api/src/routes/resumes.ts`
**Depends**: Task 1, 2, 3
**Conflict Risk**: `resumes.ts`

Modify `POST /api/resumes/match` to use the 3-tier approach:

1. **Instant phase**: Run rule-based scoring on ALL resumes (<100ms for 200 resumes)
2. **Return immediately**: Send rule-based results to frontend right away
3. **Async AI phase**: Kick off AI analysis for top N candidates (configurable, default: top 20 by rule score)
4. **Merge results**: AI scores override rule scores when available, stored in `resume_matches`

New request field: `mode: "rules_only" | "hybrid" | "ai_only"` (default: `"hybrid"`)

- `rules_only`: Instant return, no AI calls (for dev iteration)
- `hybrid`: Rules first (instant), then AI for top candidates (async via SSE)
- `ai_only`: Legacy behavior

**Verification**: POST `/api/resumes/match` with `mode=hybrid` → instant response with rule scores, then SSE updates with AI scores

---

### Task 5: Frontend Progressive Loading [DEPENDS: Task 4]

**Files**: `apps/web/src/hooks/useAiMatching.ts`, `apps/web/src/components/ResumeList.tsx`, `apps/web/src/components/ResumeCard.tsx`
**Depends**: Task 4
**Conflict Risk**: `ResumeList.tsx`, `ResumeCard.tsx`

Update frontend to consume the hybrid scoring:

1. **Instant display**: Show rule-based scores immediately after clicking "Analyze All"
2. **Progressive AI updates**: Connect to SSE stream, update individual cards as AI results arrive
3. **Score source indicator**: Show badge on ResumeCard: "Rule" (orange) vs "AI" (blue) to indicate score source
4. **Auto-trigger**: When JD is selected, automatically run rule-based scoring (no button click needed — less human-in-loop)

**Verification**: Select JD in UI → resumes instantly re-sort by rule score → AI scores progressively replace rule scores for top candidates

---

### Task 6: Database Clear & Re-score Utility [INDEPENDENT]

**Files**: `apps/api/src/routes/resumes.ts`, `apps/api/src/services/match-storage.ts`
**Depends**: none
**Conflict Risk**: `match-storage.ts`

Add utility endpoints for dev workflow:

- `DELETE /api/resumes/matches` — Clear all match results (for testing fresh scoring)
- `POST /api/resumes/matches/rescore` — Re-run rule scoring for all resumes against a JD
- Add `make clear-matches` target in Makefile

**Verification**: `make clear-matches && make seed-matches` → fresh deterministic scores

---

## Task Dependency Graph

```
Task 0 (seed data)     ←── independent, do first for immediate dev UX win
Task 1 (index)         ←── independent
Task 2 (rule engine)   ←── depends on Task 1
Task 3 (parallel+SSE)  ←── independent
Task 4 (hybrid API)    ←── depends on Task 1, 2, 3
Task 5 (frontend)      ←── depends on Task 4
Task 6 (clear utils)   ←── independent
```

**Parallel execution plan**: Tasks 0, 1, 3, 6 can all run in parallel. Then Task 2. Then Task 4. Then Task 5.

---

## Key Files Reference

| File | Current Role | Changes |
|------|-------------|---------|
| `apps/api/src/services/ai-matching.ts` | Sequential LLM calls | Add parallel batch with concurrency limit |
| `apps/api/src/services/resume-service.ts` | Load + filter resumes | Integrate index building on load |
| `apps/api/src/routes/resumes.ts` | Match endpoint | Add hybrid mode, SSE streaming |
| `apps/api/src/services/match-storage.ts` | SQLite CRUD | Add clear/bulk-rescore methods |
| `apps/api/src/services/database.ts` | Schema | Add composite index `(job_description_id, score DESC)` |
| `config/resume/agents.json5` | Agent pipeline config | Add `concurrency` field, `ruleScoring` section |
| `apps/web/src/hooks/useAiMatching.ts` | Frontend AI matching | Add SSE consumer, rule-score display |
| `apps/web/src/components/ResumeCard.tsx` | Resume card UI | Add score-source badge |
| `apps/web/src/components/ResumeList.tsx` | Resume list | Auto-trigger rule scoring on JD select |

---

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| Dev server start → usable UI | Manual "Analyze All" click + 250s wait | Instant (pre-seeded scores) |
| Score 200 resumes | 250-300s (sequential AI) | <100ms (rule engine) |
| AI analysis (top 20) | N/A (all-or-nothing) | \~12s (5 concurrent) |
| Human clicks needed | Select JD → Click Analyze → Wait → Review | Select JD → Review (auto-scored) |
| Re-iteration after JD edit | Full re-score 250s | Instant rule re-score, AI only for top N |

---

## Verification Plan

1. `make dev` → Web UI loads with pre-scored resumes immediately
2. Select different JD → resumes re-sort instantly by rule scores
3. Click "Deep Analyze" → only top 20 candidates sent to AI, results stream in progressively
4. `make clear-matches && make seed-matches` → clean re-seed works
5. `make check` passes (TypeScript + Python validation)

Implement plan

This pull request significantly overhauls the AI scoring pipeline by implementing a 3-tier scoring system (Index, Rule-based, AI Deep Analysis) to optimize developer workflow and end-user experience. It introduces instant rule-based scoring, parallel AI processing with streaming updates, and improved dev seeding.The new `ResumeIndexService` extracts structured data from resumes at load time. A `RuleScoringService` provides deterministic, instant scores with breakdowns, which are stored in the database. The `AIMatchingService` is enhanced with parallel execution and a configurable concurrency limit. The `POST /api/resumes/match` endpoint now supports `rules_only`, `hybrid`, and `ai_only` modes, with `hybrid` mode returning rule scores instantly and streaming AI results for top candidates via a new SSE endpoint `/api/resumes/match-stream`. The frontend `ResumeList` automatically triggers rule-based scoring on JD selection, and `ResumeCard` displays scores with source indicators ('Rule' or 'AI') and progressive updates. Dev mode is improved with `make dev` automatically seeding matches, and new utilities `make clear-matches` and `POST /api/resumes/matches/rescore` are added for managing match data. Database schema is updated to store score breakdowns and sources, and `config/resume/agents.json5` now includes `ruleScoring` settings and `aiConcurrency`.