### PR TITLE
Auto-install governance skill and add Claude Code command

### DIFF
--- a/.claude/commands/trends-agent-governance.md
+++ b/.claude/commands/trends-agent-governance.md
@@ -1,0 +1,50 @@
+# Trends Agent Governance
+
+Apply this governance workflow for non-trivial technical planning and recommendation tasks in this repository.
+
+## Workflow
+
+1. Classify the task.
+   - If the task is technical design/recommendation, source evidence is required.
+   - If the task is a trivial edit or command-only action, evidence is optional unless explicitly requested.
+2. Load local sources first.
+   - Read relevant implementation and configuration files in this repository.
+   - Read relevant cached docs under `./dev-docs/*.txt`.
+3. Query Context7 for library/framework/API behavior and usage details.
+4. Query official web sources only when freshness-sensitive facts are required.
+5. Include a `Sources Used` section in the final response using the template below.
+6. If AGENTS governance files changed, run:
+   - `make sync-agent-policy`
+   - `make check-agent-policy`
+
+## Source Matrix
+
+Use this strict order for non-trivial technical design/recommendation tasks:
+
+1. Local repository files
+   - Prefer implementation files and config in this repository.
+   - Include relevant cached docs under `./dev-docs/*.txt`.
+2. Context7
+   - Query library/framework/API documentation for correctness and usage details.
+3. Official web sources
+   - Use only for freshness-sensitive facts (new releases, policy changes, current status).
+
+If a source tier is not used, set it to `none` in `Sources Used`.
+
+## Evidence Template
+
+Use this template in non-trivial technical design/recommendation responses:
+
+```markdown
+## Sources Used
+- Local files:
+  - /absolute/path/one
+  - /absolute/path/two
+- Context7:
+  - /org/project
+  - /org/project/version
+- Web:
+  - https://example.com/reference
+```
+
+If a category is not used, set it to `none`.

--- a/scripts/agent-governance/validate-skill.ts
+++ b/scripts/agent-governance/validate-skill.ts
@@ -9,6 +9,7 @@ import YAML from 'yaml';
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..', '..');
 const skillRoot = path.join(repoRoot, 'dev-docs', 'skills', 'trends-agent-governance');
+const claudeCommandPath = path.join(repoRoot, '.claude', 'commands', 'trends-agent-governance.md');
 
 const requiredFiles = [
   'SKILL.md',
@@ -108,6 +109,23 @@ async function run(): Promise<void> {
 
   if (missingOptional.length > 0) {
     console.warn(`Optional skill files are missing: ${missingOptional.join(', ')}`);
+  }
+
+  try {
+    await access(claudeCommandPath);
+  } catch {
+    throw new Error(`Missing Claude Code command file: ${claudeCommandPath}`);
+  }
+
+  const claudeCommandContent = await readFile(claudeCommandPath, 'utf8');
+  if (claudeCommandContent.trim().length === 0) {
+    throw new Error(`Claude Code command file is empty: ${claudeCommandPath}`);
+  }
+
+  const requiredSections = ['Source Matrix', 'Evidence Template', 'Workflow'];
+  const missingSections = requiredSections.filter((section) => !claudeCommandContent.includes(section));
+  if (missingSections.length > 0) {
+    throw new Error(`Claude Code command missing sections: ${missingSections.join(', ')}`);
   }
 
   console.log(`Skill validation passed: ${skillRoot}`);

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -32,4 +32,18 @@ if [ -d "packages/convex" ]; then
     "$SCRIPT_DIR/prefetch-convex-backend.sh" || echo "Warning: Convex prefetch failed (non-fatal)"
 fi
 
+# Sync agent governance artifacts (policy mirror + Codex skill install)
+if [ "${CI:-}" != "true" ]; then
+    echo "Syncing agent governance artifacts..."
+    _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if command -v bun > /dev/null 2>&1; then
+        bunx tsx "$_SCRIPT_DIR/agent-governance/sync-policy.ts" || echo "Warning: Agent policy sync failed (non-fatal)"
+    else
+        npx tsx "$_SCRIPT_DIR/agent-governance/sync-policy.ts" || echo "Warning: Agent policy sync failed (non-fatal)"
+    fi
+    "$_SCRIPT_DIR/agent-governance/install-skill.sh" || echo "Warning: Agent skill install failed (non-fatal)"
+else
+    echo "Skipping agent governance sync in CI"
+fi
+
 echo "Done!"


### PR DESCRIPTION
## Task

# Plan: Auto-install governance skill + Add Claude Code command

## Task 1: Wire governance sync into `install-deps`

**File:** `scripts/install-deps.sh`

Add a block at the end of the script (after the Convex prefetch block, before the final "Done!" echo) that runs `sync-policy.ts` and `install-skill.sh`. Key considerations:

- Must run **after** Node deps install (needs `tsx` from `node_modules`)
- Skip in CI (`CI=true`) — Codex skills are irrelevant in CI
- Non-fatal (`|| echo "Warning: ..."`) — same pattern as Convex prefetch
- Re-compute `SCRIPT_DIR` since existing one is scoped inside the Convex `if` block

```bash
# Sync agent governance artifacts (policy mirror + Codex skill install)
if [ "${CI:-}" != "true" ]; then
    echo "Syncing agent governance artifacts..."
    _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
    if command -v bun > /dev/null 2>&1; then
        bunx tsx "$_SCRIPT_DIR/agent-governance/sync-policy.ts" || echo "Warning: Agent policy sync failed (non-fatal)"
    else
        npx tsx "$_SCRIPT_DIR/agent-governance/sync-policy.ts" || echo "Warning: Agent policy sync failed (non-fatal)"
    fi
    "$_SCRIPT_DIR/agent-governance/install-skill.sh" || echo "Warning: Agent skill install failed (non-fatal)"
else
    echo "Skipping agent governance sync in CI"
fi
```

---

## Task 2: Add Claude Code project command

### 2a: Create `.claude/commands/trends-agent-governance.md`

Claude Code discovers project slash commands from `.claude/commands/*.md`. Each file becomes `/project:<filename>`. The content is the prompt used when invoked.

Consolidate the workflow from `SKILL.md`, source matrix from `references/source-matrix.md`, and evidence template from `references/evidence-template.md` into one self-contained markdown file. Use generic repo-relative paths instead of the hardcoded `/Users/karlchow/.codex/worktrees/...` paths in the Codex version.

### 2b: Extend validation in `scripts/agent-governance/validate-skill.ts`

Add validation at the end of the `run()` function (before the final success log) to check:

1. `.claude/commands/trends-agent-governance.md` exists
2. File is non-empty
3. File contains required sections: "Source Matrix", "Evidence Template", "Workflow"

This keeps both Codex and Claude Code skill formats validated under `make check-agent-skill`.

---

## Files Changed

| File | Action |
|------|--------|
| `scripts/install-deps.sh` | Add governance sync block before "Done!" |
| `.claude/commands/trends-agent-governance.md` | Create (new file) |
| `scripts/agent-governance/validate-skill.ts` | Add Claude Code command validation |

## Verification

```bash
make install-deps          # Should show "Syncing agent governance artifacts..."
CI=true make install-deps  # Should show "Skipping agent governance sync in CI"
make check-agent-skill     # Should validate both Codex skill + Claude Code command
make check                 # Full check suite passes
```

Implement plan

## PR Review Summary
- What Changed:
  - `scripts/install-deps.sh`: Added a new block to automatically sync agent governance artifacts (policy mirror and Codex skill install). This block executes after Node dependencies are installed (requiring `tsx`) and Convex prefetch, but before the final "Done!" message. It explicitly skips execution when `CI=true`.
  - `.claude/commands/trends-agent-governance.md`: A new file was created, defining a Claude Code project slash command `/project:trends-agent-governance`. This file consolidates the governance workflow, source matrix, and evidence template, using generic repo-relative paths.
  - `scripts/agent-governance/validate-skill.ts`: Modified to include validation for the new Claude Code command file. It now checks for the existence and non-emptiness of `.claude/commands/trends-agent-governance.md`, and verifies that it contains the "Source Matrix", "Evidence Template", and "Workflow" sections.
- Review Focus:
  - `scripts/install-deps.sh`: Confirm the new governance sync block runs reliably without fatal errors, correctly skips in CI environments, and that the re-computation of `_SCRIPT_DIR` is accurate.
  - `.claude/commands/trends-agent-governance.md`: Ensure the content accurately reflects the intended governance workflow for Claude Code, is clear, complete, and uses correct repo-relative paths.
  - `scripts/agent-governance/validate-skill.ts`: Verify the new validation logic for the Claude Code command file is robust and correctly identifies missing files or sections.
- Test Plan:
  - Run `make install-deps` and confirm the message "Syncing agent governance artifacts..." is displayed.
  - Run `CI=true make install-deps` and confirm the message "Skipping agent governance sync in CI" is displayed.
  - Run `make check-agent-skill` and confirm that validation passes for both the existing Codex skill and the newly added Claude Code command.
  - Run `make check` to ensure the entire suite of checks passes.