### PR TITLE
Fix Convex dev startup retries and prefetch assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ i18n-build:
 install-deps:
 	./scripts/install-deps.sh
 
-# Prefetch Convex local backend binary into local cache
+# Prefetch Convex local backend and dashboard assets into local cache
 prefetch-convex:
 	./scripts/prefetch-convex-backend.sh
 
@@ -414,7 +414,7 @@ help:
 	@echo ""
 	@echo "Dependencies:"
 	@echo "  install-deps   Install Python/Node deps for development"
-	@echo "  prefetch-convex Prefetch Convex local backend binary"
+	@echo "  prefetch-convex Prefetch Convex local backend + dashboard assets"
 	@echo ""
 	@echo "Documentation:"
 	@echo "  fetch-docs     Fetch latest upstream documentation"

--- a/bun.lock
+++ b/bun.lock
@@ -18,10 +18,12 @@
       "dependencies": {
         "@hono/node-server": "^1.13.8",
         "@hono/zod-openapi": "^0.18.4",
+        "@types/nodemailer": "^7.0.9",
         "better-sqlite3": "^11.0.0",
         "hono": "^4.6.16",
         "js-yaml": "^4.1.0",
         "json5": "^2.2.3",
+        "nodemailer": "^8.0.1",
         "yaml": "^2.8.2",
         "zod": "^3.24.1",
       },
@@ -405,6 +407,8 @@
 
     "@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
+    "@types/nodemailer": ["@types/nodemailer@7.0.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-vI8oF1M+8JvQhsId0Pc38BdUP2evenIIys7c7p+9OZXSPOH5c1dyINP1jT8xQ2xPuBUXmIC87s+91IZMDjH8Ow=="],
+
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
     "@types/react": ["@types/react@18.3.27", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w=="],
@@ -766,6 +770,8 @@
     "node-abi": ["node-abi@3.87.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
+
+    "nodemailer": ["nodemailer@8.0.1", "", {}, "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -170,6 +170,8 @@ kill_all_children() {
 
 # Cleanup function (Graceful + Timeout Kill + Full Child Cleanup)
 cleanup() {
+    local exit_code=$?
+
     # Avoid running cleanup twice (SIGINT/SIGTERM + EXIT)
     if [ "$CLEANUP_DONE" -eq 1 ]; then
         return
@@ -219,7 +221,7 @@ cleanup() {
 
     wait 2>/dev/null || true
     echo -e "${GREEN}All services stopped.${NC}"
-    exit 0
+    exit "$exit_code"
 }
 
 # Trap signals for cleanup
@@ -582,6 +584,37 @@ wait_for_port() {
     return 1
 }
 
+declare -a CONVEX_DEV_CMD=()
+
+build_convex_dev_command() {
+    local selected_backend_version="$1"
+    local use_force_upgrade="$2"
+    local force_local_mode="$3"
+
+    CONVEX_DEV_CMD=(npx convex dev)
+    if command -v bun >/dev/null 2>&1; then
+        CONVEX_DEV_CMD=(bunx convex dev)
+    fi
+
+    if [ -n "$selected_backend_version" ]; then
+        CONVEX_DEV_CMD+=(--local --local-backend-version "$selected_backend_version")
+    elif [ "$force_local_mode" = "true" ]; then
+        CONVEX_DEV_CMD+=(--local)
+    fi
+
+    if [ "$use_force_upgrade" = "true" ]; then
+        CONVEX_DEV_CMD+=(--local-force-upgrade)
+    fi
+}
+
+convex_command_to_string() {
+    local token rendered=""
+    for token in "$@"; do
+        rendered+="$(printf '%q ' "$token")"
+    done
+    echo "${rendered% }"
+}
+
 # Get PIDs of what's using a port (space-separated)
 get_port_pids() {
     local port="$1"
@@ -819,7 +852,22 @@ start_convex() {
     local port="${CONVEX_PORT:-3210}"
     local convex_env_local="$PROJECT_ROOT/packages/convex/.env.local"
     local selected_backend_version=""
+    local cached_backend_version=""
+    local force_upgrade_raw="${CONVEX_LOCAL_FORCE_UPGRADE:-true}"
+    local force_upgrade_enabled="false"
     local prefetch_script="$SCRIPT_DIR/prefetch-convex-backend.sh"
+    local startup_retries_raw="${CONVEX_STARTUP_RETRIES:-1}"
+    local startup_retries=1
+    local retry_delay_raw="${CONVEX_RETRY_DELAY_SECS:-2}"
+    local retry_delay_secs=2
+    local total_attempts=2
+    local attempt=1
+    local use_force_upgrade_for_attempt="false"
+    local local_mode_requested="false"
+    local command_str=""
+    local timeout="${CONVEX_STARTUP_TIMEOUT:-60}"
+    local convex_log=""
+    local convex_pid=""
 
     # Case 1: CONVEX_URL already set in system env (e.g., cloud deployment).
     # Skip starting local convex dev, just sync the URL to downstream consumers.
@@ -861,20 +909,15 @@ start_convex() {
     log "CONVEX" "$CYAN" "Starting Convex Dev..."
     cd "$PROJECT_ROOT/packages/convex"
 
-    local cmd="npx convex dev"
-    if command -v bun >/dev/null 2>&1; then
-        cmd="bunx convex dev"
-    fi
-
     selected_backend_version="${CONVEX_LOCAL_BACKEND_VERSION:-}"
     if [ -z "$selected_backend_version" ]; then
-        if selected_backend_version="$(latest_cached_convex_backend_version)"; then
-            log "CONVEX" "$CYAN" "Using cached local backend version: $selected_backend_version"
+        if cached_backend_version="$(latest_cached_convex_backend_version)"; then
+            log "CONVEX" "$CYAN" "Detected cached local backend version: $cached_backend_version"
         elif [ -f "$prefetch_script" ]; then
             log "CONVEX" "$CYAN" "No cached local backend binary found. Trying prefetch before startup..."
             if "$prefetch_script"; then
-                if selected_backend_version="$(latest_cached_convex_backend_version)"; then
-                    log "CONVEX" "$CYAN" "Using prefetched local backend version: $selected_backend_version"
+                if cached_backend_version="$(latest_cached_convex_backend_version)"; then
+                    log "CONVEX" "$CYAN" "Detected prefetched local backend version: $cached_backend_version"
                 fi
             else
                 log "CONVEX" "$YELLOW" "Prefetch before startup failed; continuing with default convex dev behavior."
@@ -884,32 +927,112 @@ start_convex() {
         log "CONVEX" "$CYAN" "Using CONVEX_LOCAL_BACKEND_VERSION override: $selected_backend_version"
     fi
 
-    if [ -n "$selected_backend_version" ]; then
-        cmd="$cmd --local --local-backend-version $selected_backend_version --local-force-upgrade"
+    case "${force_upgrade_raw,,}" in
+        true|1|yes)
+            force_upgrade_enabled="true"
+            ;;
+        false|0|no|"")
+            force_upgrade_enabled="false"
+            ;;
+        *)
+            log "CONVEX" "$YELLOW" "Invalid CONVEX_LOCAL_FORCE_UPGRADE='$force_upgrade_raw'. Expected true or false; defaulting to true."
+            force_upgrade_enabled="true"
+            ;;
+    esac
+
+    case "$startup_retries_raw" in
+        ''|*[!0-9]*)
+            log "CONVEX" "$YELLOW" "Invalid CONVEX_STARTUP_RETRIES='$startup_retries_raw'. Expected a non-negative integer; defaulting to 1."
+            startup_retries=1
+            ;;
+        *)
+            startup_retries="$startup_retries_raw"
+            ;;
+    esac
+
+    case "$retry_delay_raw" in
+        ''|*[!0-9]*)
+            log "CONVEX" "$YELLOW" "Invalid CONVEX_RETRY_DELAY_SECS='$retry_delay_raw'. Expected a non-negative integer; defaulting to 2."
+            retry_delay_secs=2
+            ;;
+        *)
+            retry_delay_secs="$retry_delay_raw"
+            ;;
+    esac
+
+    total_attempts=$((startup_retries + 1))
+    if [ "$total_attempts" -lt 1 ]; then
+        total_attempts=1
+    fi
+    log "CONVEX" "$CYAN" "Startup retry policy: total attempts=$total_attempts, retry delay=${retry_delay_secs}s."
+    if [ -z "$selected_backend_version" ] && [ "$force_upgrade_enabled" = "true" ]; then
+        local_mode_requested="true"
+        log "CONVEX" "$CYAN" "CONVEX_LOCAL_FORCE_UPGRADE enabled without CONVEX_LOCAL_BACKEND_VERSION; using local mode for startup attempts."
     fi
 
-    $cmd > >(tee "$(service_log_path "convex")" | stream_service_logs "convex" "$CYAN") 2>&1 &
-    SERVICE_PIDS["convex"]=$!
+    attempt=1
+    while [ "$attempt" -le "$total_attempts" ]; do
+        use_force_upgrade_for_attempt="$force_upgrade_enabled"
+        if [ "$attempt" -gt 1 ] && [ "$force_upgrade_enabled" = "true" ]; then
+            use_force_upgrade_for_attempt="false"
+            log "CONVEX" "$CYAN" "Retry attempt $attempt/$total_attempts: dropping --local-force-upgrade."
+        fi
 
-    local timeout="${CONVEX_STARTUP_TIMEOUT:-60}"
-    if ! wait_for_port "$port" "${SERVICE_PIDS["convex"]}" "$timeout" "CONVEX"; then
-        local convex_log
+        build_convex_dev_command "$selected_backend_version" "$use_force_upgrade_for_attempt" "$local_mode_requested"
+        if [ "$use_force_upgrade_for_attempt" = "true" ]; then
+            log "CONVEX" "$CYAN" "Using CONVEX_LOCAL_FORCE_UPGRADE on attempt $attempt."
+        fi
+
+        command_str="$(convex_command_to_string "${CONVEX_DEV_CMD[@]}")"
+        log "CONVEX" "$CYAN" "Attempt $attempt/$total_attempts command: $command_str"
+
+        "${CONVEX_DEV_CMD[@]}" > >(tee "$(service_log_path "convex")" | stream_service_logs "convex" "$CYAN") 2>&1 &
+        SERVICE_PIDS["convex"]=$!
+
+        if wait_for_port "$port" "${SERVICE_PIDS["convex"]}" "$timeout" "CONVEX"; then
+            if [ -f "$SCRIPT_DIR/sync-convex-env.sh" ]; then
+                if ! "$SCRIPT_DIR/sync-convex-env.sh"; then
+                    return 1
+                fi
+            fi
+            sync_convex_ai_env
+            return 0
+        fi
+
         convex_log="$(service_log_path "convex")"
-        log "CONVEX" "$RED" "Convex failed to become ready. Showing last 20 log lines:"
+        log "CONVEX" "$RED" "Attempt $attempt/$total_attempts failed."
+        log "CONVEX" "$CYAN" "Failed command: $command_str"
+        log "CONVEX" "$RED" "Showing last 20 log lines:"
         if [ -f "$convex_log" ]; then
             tail -n 20 "$convex_log"
         else
             log "CONVEX" "$YELLOW" "No convex log file found at $convex_log"
         fi
-        return 1
-    fi
 
-    if [ -f "$SCRIPT_DIR/sync-convex-env.sh" ]; then
-        if ! "$SCRIPT_DIR/sync-convex-env.sh"; then
-            return 1
+        convex_pid="${SERVICE_PIDS["convex"]:-}"
+        if [ -n "$convex_pid" ] && kill -0 "$convex_pid" 2>/dev/null; then
+            log "CONVEX" "$YELLOW" "Stopping failed Convex process (PID: $convex_pid) before retry."
+            kill_process_tree "$convex_pid" "-TERM"
+            sleep 1
+            if kill -0 "$convex_pid" 2>/dev/null; then
+                kill_process_tree "$convex_pid" "-KILL"
+            fi
         fi
+
+        if [ "$attempt" -lt "$total_attempts" ] && [ "$retry_delay_secs" -gt 0 ]; then
+            log "CONVEX" "$CYAN" "Retrying Convex startup in ${retry_delay_secs}s..."
+            sleep "$retry_delay_secs"
+        fi
+
+        attempt=$((attempt + 1))
+    done
+
+    log "CONVEX" "$RED" "Convex failed after ${total_attempts} attempt(s)."
+    if [ "$force_upgrade_enabled" = "true" ]; then
+        log "CONVEX" "$YELLOW" "Tried retry strategy: dropped --local-force-upgrade on retry attempt(s)."
     fi
-    sync_convex_ai_env
+    log "CONVEX" "$YELLOW" "If local deployment remains unstable, you can opt out manually: npx convex disable-local-deployments"
+    return 1
 }
 
 run_seed_script() {
@@ -1099,6 +1222,11 @@ main() {
                 echo "  TRENDS_WORKER_PORT FastAPI worker port (default: 8000)"
                 echo "  API_PORT      BFF API port (default: 3000)"
                 echo "  WEB_PORT      Web frontend port (default: 5173)"
+                echo "  CONVEX_STARTUP_TIMEOUT Convex startup timeout in seconds (default: 60)"
+                echo "  CONVEX_STARTUP_RETRIES Additional Convex startup retries after first failure (default: 1)"
+                echo "  CONVEX_RETRY_DELAY_SECS Delay between Convex startup attempts in seconds (default: 2)"
+                echo "  CONVEX_LOCAL_BACKEND_VERSION Explicit Convex local backend version override"
+                echo "  CONVEX_LOCAL_FORCE_UPGRADE Enable --local-force-upgrade on first attempt: true|false (default: true)"
                 exit 0
                 ;;
             *)

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -27,7 +27,7 @@ fi
 
 if [ -d "packages/convex" ]; then
     EFFECTIVE_CONVEX_MIRROR_MODE="$(resolve_convex_mirror_mode)"
-    echo "Prefetching Convex local backend binary (mirror mode: ${EFFECTIVE_CONVEX_MIRROR_MODE})..."
+    echo "Prefetching Convex local backend and dashboard assets (mirror mode: ${EFFECTIVE_CONVEX_MIRROR_MODE})..."
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     "$SCRIPT_DIR/prefetch-convex-backend.sh" || echo "Warning: Convex prefetch failed (non-fatal)"
 fi

--- a/scripts/prefetch-convex-backend.sh
+++ b/scripts/prefetch-convex-backend.sh
@@ -5,6 +5,9 @@ GITHUB_API="https://api.github.com/repos/get-convex/convex-backend/releases?per_
 DEFAULT_MIRROR_BASES="https://ghproxy.net,https://gh.ddlc.top"
 DEFAULT_DOWNLOAD_TIMEOUT_SECS="240"
 DEFAULT_CONNECT_TIMEOUT_SECS="10"
+DASHBOARD_ASSET_NAME="dashboard.zip"
+DEFAULT_DASHBOARD_PORT="6790"
+DEFAULT_DASHBOARD_API_PORT="6791"
 
 log() {
     echo "[convex-prefetch] $*"
@@ -62,7 +65,7 @@ detect_platform() {
 
 require_command() {
     if ! command -v "$1" >/dev/null 2>&1; then
-        log "Required command '$1' not found. Skipping Convex backend prefetch."
+        log "Required command '$1' not found. Skipping Convex prefetch."
         exit 0
     fi
 }
@@ -222,12 +225,92 @@ latest_release_tag() {
 
 release_info_from_latest_redirect() {
     local asset_name="$1"
+    local dashboard_asset_name="$2"
     local version
     version="$(latest_release_tag)" || return 1
-    printf '%s\t%s\t%s\n' \
+    printf '%s\t%s\t%s\t%s\t%s\n' \
         "$version" \
         "https://github.com/get-convex/convex-backend/releases/download/${version}/${asset_name}" \
+        "" \
+        "https://github.com/get-convex/convex-backend/releases/download/${version}/${dashboard_asset_name}" \
         ""
+}
+
+download_asset_zip() {
+    local asset_label="$1"
+    local official_url="$2"
+    local expected_sha="$3"
+    local base_mirror_mode="$4"
+    local connect_timeout="$5"
+    local download_timeout="$6"
+    local hash_cmd="$7"
+    local output_file="$8"
+
+    local mirror_mode source_line source_label source_url actual_sha
+    local selected_source_label selected_source_url
+    local -a source_lines
+
+    if [ -z "$official_url" ]; then
+        log "No download URL found for ${asset_label}."
+        return 2
+    fi
+
+    mirror_mode="$base_mirror_mode"
+    if [ -z "$expected_sha" ] && [ "$mirror_mode" != "off" ]; then
+        log "Release digest is unavailable for ${asset_label}. For safety, forcing mirror mode to 'off' for this asset."
+        mirror_mode="off"
+    fi
+
+    log "${asset_label}: mirror mode ${mirror_mode} (download timeout ${download_timeout}s, connect timeout ${connect_timeout}s)"
+    if [ -n "$expected_sha" ]; then
+        log "${asset_label}: expected SHA-256 ${expected_sha}"
+    else
+        log "${asset_label}: release metadata has no SHA-256 digest; download will proceed from official source only."
+    fi
+
+    source_lines=()
+    while IFS= read -r source_line; do
+        source_lines+=("$source_line")
+    done < <(build_sources "$mirror_mode" "$official_url")
+
+    if [ "${#source_lines[@]}" -eq 0 ]; then
+        log "No download sources are available for ${asset_label}."
+        return 1
+    fi
+
+    selected_source_label=""
+    selected_source_url=""
+    for source_line in "${source_lines[@]}"; do
+        IFS=$'\t' read -r source_label source_url <<< "$source_line"
+        rm -f "$output_file"
+
+        log "${asset_label}: attempting source: ${source_label}"
+        if ! download_with_retry "$source_url" "$output_file" "$connect_timeout" "$download_timeout"; then
+            log "${asset_label}: source failed: ${source_label}"
+            continue
+        fi
+
+        if [ -n "$expected_sha" ]; then
+            actual_sha="$(sha256_of_file "$output_file" "$hash_cmd")"
+            if [ "$actual_sha" != "$expected_sha" ]; then
+                log "${asset_label}: SHA-256 mismatch from ${source_label} (expected ${expected_sha}, got ${actual_sha})."
+                continue
+            fi
+            log "${asset_label}: SHA-256 verified for source: ${source_label}"
+        fi
+
+        selected_source_label="$source_label"
+        selected_source_url="$source_url"
+        break
+    done
+
+    if [ -z "$selected_source_url" ]; then
+        log "Failed to download ${asset_label} from all sources."
+        return 1
+    fi
+
+    log "${asset_label}: download source: ${selected_source_label}"
+    return 0
 }
 
 main() {
@@ -235,11 +318,19 @@ main() {
     require_command jq
     require_command unzip
 
-    local target_info artifact_name binary_name release_info version url digest expected_sha
-    local cache_root dest_dir binary_path tmp_zip
-    local mirror_mode hash_cmd download_timeout connect_timeout source_line source_label source_url
-    local selected_source_label selected_source_url actual_sha
-    local -a source_lines
+    local target_info artifact_name binary_name release_info version
+    local backend_url backend_digest backend_expected_sha
+    local dashboard_url dashboard_digest dashboard_expected_sha
+    local cache_root cache_parent dest_dir binary_path tmp_zip
+    local dashboard_cache_dir dashboard_out_dir dashboard_config_path dashboard_tmp_zip dashboard_extract_dir
+    local dashboard_cached existing_dashboard_version
+    local dashboard_port dashboard_api_port parsed_dashboard_port parsed_dashboard_api_port
+    local mirror_mode hash_cmd download_timeout connect_timeout
+
+    tmp_zip=""
+    dashboard_tmp_zip=""
+    dashboard_extract_dir=""
+    trap 'rm -f "${tmp_zip:-}" "${dashboard_tmp_zip:-}"; if [ -n "${dashboard_extract_dir:-}" ]; then rm -rf "${dashboard_extract_dir}"; fi' EXIT
 
     target_info="$(detect_platform)"
     if [ -z "$target_info" ]; then
@@ -251,13 +342,19 @@ main() {
     binary_name="${target_info##*|}"
     cache_root="$(cache_dir)"
 
-    log "Prefetching Convex backend binary for asset: ${artifact_name}"
+    log "Prefetching Convex backend and dashboard assets for backend artifact: ${artifact_name}"
 
-    if ! release_info="$(curl -fsSL "$GITHUB_API" | jq -r --arg asset "$artifact_name" '
+    if ! release_info="$(curl -fsSL "$GITHUB_API" | jq -r --arg backend "$artifact_name" --arg dashboard "$DASHBOARD_ASSET_NAME" '
         map(select((.prerelease | not) and (.draft | not)))
-        | map(select(any(.assets[]?; .name == $asset)))
+        | map(select(any(.assets[]?; .name == $backend)))
         | .[0] // empty
-        | [.tag_name, (.assets[] | select(.name == $asset) | .browser_download_url), (.assets[] | select(.name == $asset) | (.digest // ""))]
+        | [
+            .tag_name,
+            (first(.assets[]? | select(.name == $backend) | .browser_download_url) // ""),
+            (first(.assets[]? | select(.name == $backend) | (.digest // "")) // ""),
+            (first(.assets[]? | select(.name == $dashboard) | .browser_download_url) // ""),
+            (first(.assets[]? | select(.name == $dashboard) | (.digest // "")) // "")
+        ]
         | @tsv
     ')"; then
         release_info=""
@@ -265,7 +362,7 @@ main() {
 
     if [ -z "$release_info" ]; then
         log "GitHub API metadata unavailable. Trying releases/latest redirect fallback..."
-        if ! release_info="$(release_info_from_latest_redirect "$artifact_name")"; then
+        if ! release_info="$(release_info_from_latest_redirect "$artifact_name" "$DASHBOARD_ASSET_NAME")"; then
             release_info=""
         fi
     fi
@@ -275,8 +372,9 @@ main() {
         exit 0
     fi
 
-    IFS=$'\t' read -r version url digest <<< "$release_info"
-    expected_sha="$(normalize_digest_sha256 "$digest")"
+    IFS=$'\t' read -r version backend_url backend_digest dashboard_url dashboard_digest <<< "$release_info"
+    backend_expected_sha="$(normalize_digest_sha256 "$backend_digest")"
+    dashboard_expected_sha="$(normalize_digest_sha256 "$dashboard_digest")"
 
     mirror_mode="$(effective_mirror_mode)"
     validate_mirror_mode "$mirror_mode"
@@ -286,91 +384,134 @@ main() {
     validate_positive_integer "$download_timeout" "CONVEX_DOWNLOAD_TIMEOUT_SECS"
     validate_positive_integer "$connect_timeout" "CONVEX_CONNECT_TIMEOUT_SECS"
 
-    if [ -z "$expected_sha" ] && [ "$mirror_mode" != "off" ]; then
-        log "Release digest is unavailable for ${artifact_name}. For safety, forcing mirror mode to 'off' for this run."
-        mirror_mode="off"
-    fi
-
     hash_cmd="$(hash_tool)"
-    if [ -n "$expected_sha" ] && [ -z "$hash_cmd" ]; then
+    if { [ -n "$backend_expected_sha" ] || [ -n "$dashboard_expected_sha" ]; } && [ -z "$hash_cmd" ]; then
         log "Neither 'shasum' nor 'sha256sum' is available; cannot verify SHA-256."
         exit 1
     fi
 
-    log "Mirror mode: ${mirror_mode} (download timeout ${download_timeout}s, connect timeout ${connect_timeout}s)"
-    if [ -n "$expected_sha" ]; then
-        log "Expected SHA-256: ${expected_sha}"
-    else
-        log "Release metadata has no SHA-256 digest; download will proceed from official source only."
-    fi
-
     dest_dir="${cache_root}/${version}"
     binary_path="${dest_dir}/${binary_name}"
+    cache_parent="$(dirname "$cache_root")"
+    dashboard_cache_dir="${cache_parent}/dashboard"
+    dashboard_out_dir="${dashboard_cache_dir}/out"
+    dashboard_config_path="${dashboard_cache_dir}/config.json"
 
     if [ -f "$binary_path" ]; then
         log "Already cached: ${binary_path}"
-        exit 0
-    fi
-
-    source_lines=()
-    while IFS= read -r source_line; do
-        source_lines+=("$source_line")
-    done < <(build_sources "$mirror_mode" "$url")
-
-    if [ "${#source_lines[@]}" -eq 0 ]; then
-        log "No download sources are available. Skipping."
-        exit 0
-    fi
-
-    mkdir -p "$dest_dir"
-    tmp_zip="$(mktemp "${TMPDIR:-/tmp}/convex-backend.XXXXXX")"
-    trap 'rm -f "${tmp_zip:-}"' EXIT
-
-    selected_source_label=""
-    selected_source_url=""
-
-    for source_line in "${source_lines[@]}"; do
-        IFS=$'\t' read -r source_label source_url <<< "$source_line"
-        rm -f "$tmp_zip"
-
-        log "Attempting source: ${source_label}"
-        if ! download_with_retry "$source_url" "$tmp_zip" "$connect_timeout" "$download_timeout"; then
-            log "Source failed: ${source_label}"
-            continue
+    else
+        mkdir -p "$dest_dir"
+        tmp_zip="$(mktemp "${TMPDIR:-/tmp}/convex-backend.XXXXXX")"
+        if ! download_asset_zip \
+            "Convex backend binary (${artifact_name})" \
+            "$backend_url" \
+            "$backend_expected_sha" \
+            "$mirror_mode" \
+            "$connect_timeout" \
+            "$download_timeout" \
+            "$hash_cmd" \
+            "$tmp_zip"; then
+            exit 1
         fi
 
-        if [ -n "$expected_sha" ]; then
-            actual_sha="$(sha256_of_file "$tmp_zip" "$hash_cmd")"
-            if [ "$actual_sha" != "$expected_sha" ]; then
-                log "SHA-256 mismatch from ${source_label} (expected ${expected_sha}, got ${actual_sha})."
-                continue
-            fi
-            log "SHA-256 verified for source: ${source_label}"
+        unzip -o -q "$tmp_zip" -d "$dest_dir"
+
+        if [ ! -f "$binary_path" ]; then
+            log "Archive did not contain expected file: ${binary_name}"
+            exit 1
         fi
 
-        selected_source_label="$source_label"
-        selected_source_url="$source_url"
-        break
-    done
+        if ! is_windows; then
+            chmod +x "$binary_path"
+        fi
 
-    if [ -z "$selected_source_url" ]; then
-        log "Failed to download Convex backend binary from all sources."
-        exit 1
+        log "Cached: ${binary_path}"
     fi
 
-    unzip -o -q "$tmp_zip" -d "$dest_dir"
-
-    if [ ! -f "$binary_path" ]; then
-        log "Archive did not contain expected file: ${binary_name}"
-        exit 1
+    dashboard_cached="false"
+    if [ -f "$dashboard_config_path" ] && [ -d "$dashboard_out_dir" ] && [ -f "$dashboard_out_dir/index.html" ]; then
+        existing_dashboard_version="$(jq -r '.version // empty' "$dashboard_config_path" 2>/dev/null || true)"
+        if [ "$existing_dashboard_version" = "$version" ]; then
+            dashboard_cached="true"
+        fi
     fi
 
-    if ! is_windows; then
-        chmod +x "$binary_path"
+    if [ "$dashboard_cached" = "true" ]; then
+        log "Dashboard already cached for version ${version}: ${dashboard_out_dir}"
+        return
     fi
 
-    log "Download source: ${selected_source_label}"
-    log "Cached: ${binary_path}"
+    if [ -z "$dashboard_url" ]; then
+        log "Dashboard asset URL not found for version ${version}. Skipping dashboard prefetch."
+        return
+    fi
+
+    dashboard_tmp_zip="$(mktemp "${TMPDIR:-/tmp}/convex-dashboard.XXXXXX")"
+    if ! download_asset_zip \
+        "Convex dashboard asset (${DASHBOARD_ASSET_NAME})" \
+        "$dashboard_url" \
+        "$dashboard_expected_sha" \
+        "$mirror_mode" \
+        "$connect_timeout" \
+        "$download_timeout" \
+        "$hash_cmd" \
+        "$dashboard_tmp_zip"; then
+        log "Dashboard prefetch failed (non-fatal)."
+        return
+    fi
+
+    dashboard_extract_dir="$(mktemp -d "${TMPDIR:-/tmp}/convex-dashboard.XXXXXX")"
+    if ! unzip -o -q "$dashboard_tmp_zip" -d "$dashboard_extract_dir"; then
+        log "Failed to extract Convex dashboard archive (non-fatal)."
+        return
+    fi
+
+    if ! mkdir -p "$dashboard_cache_dir"; then
+        log "Failed to create dashboard cache directory ${dashboard_cache_dir} (non-fatal)."
+        return
+    fi
+
+    if ! rm -rf "$dashboard_out_dir"; then
+        log "Failed to clean dashboard output directory ${dashboard_out_dir} (non-fatal)."
+        return
+    fi
+    if ! mkdir -p "$dashboard_out_dir"; then
+        log "Failed to create dashboard output directory ${dashboard_out_dir} (non-fatal)."
+        return
+    fi
+    if ! cp -R "$dashboard_extract_dir"/. "$dashboard_out_dir"/; then
+        log "Failed to copy dashboard assets into ${dashboard_out_dir} (non-fatal)."
+        return
+    fi
+
+    if [ ! -f "$dashboard_out_dir/index.html" ]; then
+        log "Dashboard archive did not contain expected file: index.html (non-fatal)."
+        return
+    fi
+
+    dashboard_port="$DEFAULT_DASHBOARD_PORT"
+    dashboard_api_port="$DEFAULT_DASHBOARD_API_PORT"
+    if [ -f "$dashboard_config_path" ]; then
+        parsed_dashboard_port="$(jq -r 'if (.port|type) == "number" then .port else empty end' "$dashboard_config_path" 2>/dev/null || true)"
+        parsed_dashboard_api_port="$(jq -r 'if (.apiPort|type) == "number" then .apiPort else empty end' "$dashboard_config_path" 2>/dev/null || true)"
+        if [ -n "$parsed_dashboard_port" ]; then
+            dashboard_port="$parsed_dashboard_port"
+        fi
+        if [ -n "$parsed_dashboard_api_port" ]; then
+            dashboard_api_port="$parsed_dashboard_api_port"
+        fi
+    fi
+
+    if ! cat > "$dashboard_config_path" <<EOF
+{"port":${dashboard_port},"apiPort":${dashboard_api_port},"version":"${version}"}
+EOF
+    then
+        log "Failed to update dashboard config at ${dashboard_config_path} (non-fatal)."
+        return
+    fi
+
+    log "Dashboard cached: ${dashboard_out_dir}"
+    log "Dashboard config updated: ${dashboard_config_path}"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- extend the Convex prefetch script so it caches both the backend binary and dashboard assets, and update install/help text to describe the broader scope
- rebuild `convex dev` command assembly in `scripts/dev.sh`, honoring explicit `CONVEX_LOCAL_BACKEND_VERSION`, `CONVEX_LOCAL_FORCE_UPGRADE`, and a configurable retry loop with diagnostics and optional delay
- ensure new Convex env helpers describe the retry/fallback settings in the script’s help output

## Testing
- Not run (not requested)