### PR TITLE
Redesign resume search layout with keyword chips

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -544,7 +544,7 @@ app.openapi(matchResumesRoute, async (c) => {
     });
   } else {
     session = sessionManager.updateSession(session.id, {
-      jobDescriptionId: normalizedJobDescriptionId,
+      jobDescriptionId: normalizedJobDescriptionId ?? null,
       sampleName: sample ?? session.sampleName,
     }) ?? session;
   }

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -275,7 +275,9 @@ export const MatchRequestSchema = z
   .object({
     sessionId: z.string().optional().openapi({ example: "session-123" }),
     sample: z.string().optional().openapi({ example: "sample-initial" }),
-    jobDescriptionId: z.string().openapi({ example: "lathe-sales" }),
+    jobDescriptionId: z.string().optional().openapi({ example: "lathe-sales" }),
+    keywords: z.array(z.string()).optional().openapi({ example: ["cnc", "车床"] }),
+    location: z.string().optional().openapi({ example: "广东" }),
     resumeIds: z.array(z.string()).optional().openapi({ example: ["R123456"] }),
     limit: z.number().int().min(1).max(1000).optional().openapi({ example: 50 }),
     topN: z.number().int().min(1).max(500).optional().openapi({ example: 20 }),

--- a/apps/api/src/services/custom-keyword-service.ts
+++ b/apps/api/src/services/custom-keyword-service.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs";
+import path from "node:path";
+import JSON5 from "json5";
+import { findProjectRoot } from "./db.js";
+
+export interface CustomKeywordTag {
+    id: string;
+    keyword: string;
+    english?: string;
+    category: string;
+}
+
+export interface CustomKeywordCategory {
+    id: string;
+    name: string;
+    icon?: string;
+}
+
+export interface CustomKeywordsConfig {
+    tags: CustomKeywordTag[];
+    categories: CustomKeywordCategory[];
+}
+
+const DEFAULT_CATEGORIES: CustomKeywordCategory[] = [
+    { id: "custom", name: "自定义", icon: "⚙️" },
+];
+
+function normalizeConfig(raw: unknown): CustomKeywordsConfig {
+  if (!raw || typeof raw !== "object") {
+    return { tags: [], categories: [...DEFAULT_CATEGORIES] };
+  }
+
+    const data = raw as {
+        tags?: unknown[];
+        categories?: unknown[];
+    };
+
+    const tags: CustomKeywordTag[] = [];
+    if (Array.isArray(data.tags)) {
+        for (const item of data.tags) {
+            if (!item || typeof item !== "object") continue;
+            const record = item as Record<string, unknown>;
+            const id = typeof record.id === "string" ? record.id.trim() : "";
+            const keyword = typeof record.keyword === "string" ? record.keyword.trim() : "";
+            const category = typeof record.category === "string" ? record.category.trim() : "";
+            if (!id || !keyword || !category) {
+                continue;
+            }
+
+            const english = typeof record.english === "string" && record.english.trim()
+                ? record.english.trim()
+                : undefined;
+            const tag: CustomKeywordTag = { id, keyword, category };
+            if (english) {
+                tag.english = english;
+            }
+            tags.push(tag);
+        }
+    }
+
+    const categories: CustomKeywordCategory[] = [];
+    if (Array.isArray(data.categories)) {
+        for (const item of data.categories) {
+            if (!item || typeof item !== "object") continue;
+            const record = item as Record<string, unknown>;
+            const id = typeof record.id === "string" ? record.id.trim() : "";
+            const name = typeof record.name === "string" ? record.name.trim() : "";
+            if (!id || !name) {
+                continue;
+            }
+
+            const icon = typeof record.icon === "string" && record.icon.trim()
+                ? record.icon.trim()
+                : undefined;
+            const category: CustomKeywordCategory = { id, name };
+            if (icon) {
+                category.icon = icon;
+            }
+            categories.push(category);
+        }
+    }
+
+    if (categories.length === 0) {
+        return { tags, categories: [...DEFAULT_CATEGORIES] };
+    }
+
+    return { tags, categories };
+}
+
+export class CustomKeywordService {
+    readonly projectRoot: string;
+    private cache: CustomKeywordsConfig | null = null;
+
+    constructor(projectRoot?: string) {
+        this.projectRoot = projectRoot ? path.resolve(projectRoot) : findProjectRoot();
+    }
+
+    private getConfigPath(): string {
+        return path.join(this.projectRoot, "config", "resume", "custom-keywords.json5");
+    }
+
+    private loadConfig(): CustomKeywordsConfig {
+        if (this.cache) return this.cache;
+
+        const configPath = this.getConfigPath();
+        if (!fs.existsSync(configPath)) {
+            const fallback = { tags: [], categories: [...DEFAULT_CATEGORIES] };
+            this.cache = fallback;
+            return fallback;
+        }
+
+        const content = fs.readFileSync(configPath, "utf8");
+        const parsed = JSON5.parse(content) as unknown;
+        this.cache = normalizeConfig(parsed);
+        return this.cache;
+    }
+
+    saveConfig(config: CustomKeywordsConfig): void {
+        const normalized = normalizeConfig(config);
+        const configPath = this.getConfigPath();
+        fs.writeFileSync(configPath, JSON.stringify(normalized, null, 2), "utf8");
+        this.cache = normalized;
+    }
+
+    listTags(category?: string): CustomKeywordTag[] {
+        const config = this.loadConfig();
+        if (!category) return config.tags;
+        return config.tags.filter((tag) => tag.category === category);
+    }
+
+    getTag(id: string): CustomKeywordTag | undefined {
+        const config = this.loadConfig();
+        return config.tags.find((tag) => tag.id === id);
+    }
+
+    addTag(tag: CustomKeywordTag): void {
+        const config = this.loadConfig();
+        config.tags.push(tag);
+        this.saveConfig(config);
+    }
+
+    updateTag(id: string, updates: Partial<CustomKeywordTag>): CustomKeywordTag | undefined {
+        const config = this.loadConfig();
+        const index = config.tags.findIndex((tag) => tag.id === id);
+        if (index === -1) {
+            return undefined;
+        }
+
+        const nextTag: CustomKeywordTag = {
+            ...config.tags[index],
+            ...updates,
+            id: config.tags[index].id,
+        };
+
+        if (!nextTag.keyword.trim() || !nextTag.category.trim()) {
+            return undefined;
+        }
+
+        config.tags[index] = {
+            ...nextTag,
+            keyword: nextTag.keyword.trim(),
+            english: nextTag.english?.trim() || undefined,
+            category: nextTag.category.trim(),
+        };
+        this.saveConfig(config);
+        return config.tags[index];
+    }
+
+    deleteTag(id: string): boolean {
+        const config = this.loadConfig();
+        const before = config.tags.length;
+        config.tags = config.tags.filter((tag) => tag.id !== id);
+        if (config.tags.length === before) {
+            return false;
+        }
+        this.saveConfig(config);
+        return true;
+    }
+
+    listCategories(): CustomKeywordCategory[] {
+        const config = this.loadConfig();
+        return config.categories;
+    }
+
+    clearCache(): void {
+        this.cache = null;
+    }
+}
+
+export const customKeywordService = new CustomKeywordService();

--- a/apps/api/src/services/rule-scoring.test.ts
+++ b/apps/api/src/services/rule-scoring.test.ts
@@ -45,6 +45,23 @@ function cleanupFixtureRoot(root: string): void {
 }
 
 describe("RuleScoringService", () => {
+  it("builds keyword-only context with inferred industry tags", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new RuleScoringService(root);
+      const context = service.buildContextFromKeywords(["cnc", "车床"], "广东");
+
+      expect(context.jobDescriptionId).toBe("keyword-search");
+      expect(context.title).toBe("cnc, 车床");
+      expect(context.keywords).toEqual(["cnc", "车床"]);
+      expect(context.targetLocations).toEqual(["广东"]);
+      expect(context.industryTags).toEqual(expect.arrayContaining(["cnc", "machinery"]));
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
   it("scores strong candidate higher than weak candidate", () => {
     const root = createFixtureRoot();
 

--- a/apps/api/src/services/rule-scoring.ts
+++ b/apps/api/src/services/rule-scoring.ts
@@ -155,6 +155,27 @@ export class RuleScoringService {
     };
   }
 
+  buildContextFromKeywords(
+    keywords: string[],
+    location?: string,
+  ): RuleScoringContext {
+    const cleanKeywords = ensureKeywords(keywords);
+    const normalizedLocation = location?.trim();
+    const targetLocations = normalizedLocation ? [normalizedLocation] : [];
+    const industryTags = inferIndustryTags(cleanKeywords);
+
+    return {
+      jobDescriptionId: "keyword-search",
+      title: cleanKeywords.join(", "),
+      keywords: cleanKeywords,
+      targetLocations,
+      minExperience: undefined,
+      educationRequirements: [],
+      industryKeywords: cleanKeywords,
+      industryTags,
+    };
+  }
+
   scoreResume(index: ResumeIndex, context: RuleScoringContext): RuleScoringResult {
     const matchedSkills = context.keywords.filter((keyword) =>
       index.searchText.includes(keyword) || index.skills.some((skill) => skill.includes(keyword))

--- a/apps/api/src/services/session-manager.ts
+++ b/apps/api/src/services/session-manager.ts
@@ -35,6 +35,13 @@ export type SearchSession = {
   expiresAt?: string;
 };
 
+type SessionUpdateInput = Partial<Omit<SearchSession, "jobDescriptionId" | "userId" | "sampleName" | "expiresAt">> & {
+  userId?: string | null;
+  jobDescriptionId?: string | null;
+  sampleName?: string | null;
+  expiresAt?: string | null;
+};
+
 function toIsoNow(): string {
   return formatIsoOffsetInTimezone(new Date(), config.timezone);
 }
@@ -139,7 +146,7 @@ export class SessionManager {
     return this.createSession({ userId });
   }
 
-  updateSession(sessionId: string, updates: Partial<SearchSession>): SearchSession | null {
+  updateSession(sessionId: string, updates: SessionUpdateInput): SearchSession | null {
     const existing = this.getSession(sessionId);
     if (!existing) return null;
 

--- a/apps/web/src/components/AnalysisTaskMonitor.tsx
+++ b/apps/web/src/components/AnalysisTaskMonitor.tsx
@@ -70,7 +70,10 @@ function TaskItem({
   const isActive = task.status === 'pending' || task.status === 'processing'
   const total = task.progress.total || task.config.resumeCount || 1
   const progress = Math.min(100, Math.max(0, Math.round((task.progress.current / total) * 100)))
-  const taskTitle = task.config.jobDescriptionTitle || task.config.jobDescriptionId
+  const keywordLabel = task.config.keywords?.length
+    ? `Keywords: ${task.config.keywords.join(', ')}`
+    : undefined
+  const taskTitle = task.config.jobDescriptionTitle || task.config.jobDescriptionId || keywordLabel || 'Unknown'
 
   return (
     <div className="space-y-2 border-b last:border-0 last:pb-0 pb-4">

--- a/apps/web/src/components/FilterPanel.tsx
+++ b/apps/web/src/components/FilterPanel.tsx
@@ -28,6 +28,7 @@ export function FilterPanel({ filters, onChange, mode }: FilterPanelProps) {
   const [skills, setSkills] = useState('')
   const [locations, setLocations] = useState('')
   const [education, setEducation] = useState<string[]>([])
+  const [clearing, setClearing] = useState(false)
 
   useEffect(() => {
     setMinExperience(filters.minExperience?.toString() ?? '')
@@ -50,6 +51,7 @@ export function FilterPanel({ filters, onChange, mode }: FilterPanelProps) {
   }
 
   const handleApply = () => {
+    if (clearing) return
     onChange({
       ...filters,
       minExperience: minExperience ? Number(minExperience) : undefined,
@@ -72,6 +74,7 @@ export function FilterPanel({ filters, onChange, mode }: FilterPanelProps) {
   }
 
   const handleClear = () => {
+    setClearing(true)
     setMinExperience('')
     setMaxExperience('')
     setMinMatchScore('')
@@ -79,6 +82,7 @@ export function FilterPanel({ filters, onChange, mode }: FilterPanelProps) {
     setLocations('')
     setEducation([])
     onChange({})
+    window.setTimeout(() => setClearing(false), 200)
   }
 
   return (
@@ -89,7 +93,7 @@ export function FilterPanel({ filters, onChange, mode }: FilterPanelProps) {
           <Button size="sm" variant="outline" onClick={handleClear}>
             {t('resumes.filters.clear')}
           </Button>
-          <Button size="sm" onClick={handleApply}>
+          <Button size="sm" onClick={handleApply} disabled={clearing}>
             {t('resumes.filters.apply')}
           </Button>
         </div>

--- a/apps/web/src/components/KeywordChips.tsx
+++ b/apps/web/src/components/KeywordChips.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useMemo, useState, type KeyboardEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import {
+  CATEGORY_LABELS,
+  CATEGORY_ORDER,
+  useIndustryKeywords,
+} from '@/hooks/useIndustryKeywords'
+
+interface KeywordChipsProps {
+  value: string[]
+  onChange: (keywords: string[]) => void
+}
+
+function normalizeKeywords(values: string[]): string[] {
+  const next: string[] = []
+  const seen = new Set<string>()
+  for (const value of values) {
+    const normalized = value.trim()
+    if (!normalized || seen.has(normalized)) continue
+    seen.add(normalized)
+    next.push(normalized)
+  }
+  return next
+}
+
+export function KeywordChips({ value, onChange }: KeywordChipsProps) {
+  const { t } = useTranslation()
+  const { keywords, grouped, hotKeywords, loading, error } = useIndustryKeywords()
+  const [expanded, setExpanded] = useState(false)
+  const [customKeyword, setCustomKeyword] = useState('')
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(normalizeKeywords(value)))
+
+  const normalizedValue = useMemo(() => normalizeKeywords(value), [value])
+
+  useEffect(() => {
+    setSelected(new Set(normalizedValue))
+  }, [normalizedValue])
+
+  const selectedValues = useMemo(() => Array.from(selected), [selected])
+  const hotKeywordSet = useMemo(
+    () => new Set(hotKeywords.map((keyword) => keyword.keyword)),
+    [hotKeywords]
+  )
+  const knownKeywordSet = useMemo(
+    () => new Set(keywords.map((keyword) => keyword.keyword)),
+    [keywords]
+  )
+
+  const additionalSelectedKeywords = useMemo(() => {
+    return selectedValues.filter((keyword) => !hotKeywordSet.has(keyword))
+  }, [hotKeywordSet, selectedValues])
+
+  const customSelectedKeywords = useMemo(() => {
+    return selectedValues.filter((keyword) => !knownKeywordSet.has(keyword))
+  }, [knownKeywordSet, selectedValues])
+
+  const updateSelection = useCallback(
+    (updater: (previous: Set<string>) => Set<string>) => {
+      setSelected((previous) => {
+        const next = updater(previous)
+        onChange(Array.from(next))
+        return next
+      })
+    },
+    [onChange]
+  )
+
+  const toggleKeyword = useCallback(
+    (keyword: string) => {
+      const normalized = keyword.trim()
+      if (!normalized) return
+      updateSelection((previous) => {
+        const next = new Set(previous)
+        if (next.has(normalized)) {
+          next.delete(normalized)
+        } else {
+          next.add(normalized)
+        }
+        return next
+      })
+    },
+    [updateSelection]
+  )
+
+  const addCustomKeyword = useCallback(() => {
+    const normalized = customKeyword.trim()
+    if (!normalized) return
+    updateSelection((previous) => {
+      const next = new Set(previous)
+      next.add(normalized)
+      return next
+    })
+    setCustomKeyword('')
+  }, [customKeyword, updateSelection])
+
+  const handleCustomKeywordKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        addCustomKeyword()
+      }
+    },
+    [addCustomKeyword]
+  )
+
+  const renderChip = useCallback(
+    (keyword: string) => {
+      const selectedKeyword = selected.has(keyword)
+      return (
+        <Badge
+          key={keyword}
+          variant={selectedKeyword ? 'default' : 'outline'}
+          onClick={() => toggleKeyword(keyword)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault()
+              toggleKeyword(keyword)
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          className={cn(
+            'cursor-pointer select-none rounded-full px-2.5 py-1 text-xs transition-colors',
+            selectedKeyword ? 'border-transparent' : 'hover:bg-muted'
+          )}
+        >
+          {keyword}
+        </Badge>
+      )
+    },
+    [selected, toggleKeyword]
+  )
+
+  return (
+    <div className="space-y-2.5">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="text-xs text-muted-foreground">
+          {t('quickStart.hotKeywords', '热门关键词')}:
+        </span>
+        {loading ? (
+          <span className="text-xs text-muted-foreground">{t('trends.loading')}</span>
+        ) : (
+          <>
+            {hotKeywords.map((item) => renderChip(item.keyword))}
+            {!expanded && additionalSelectedKeywords.map((keyword) => renderChip(keyword))}
+          </>
+        )}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-6 px-1 text-xs"
+          onClick={() => setExpanded((previous) => !previous)}
+        >
+          {expanded
+            ? t('quickStart.collapseKeywords', '收起')
+            : t('quickStart.expandKeywords', '展开全部')}
+        </Button>
+      </div>
+
+      {expanded
+        ? CATEGORY_ORDER.map((category) => {
+            if (grouped[category].length === 0) return null
+            return (
+              <div key={category} className="flex flex-wrap items-center gap-1.5">
+                <span className="text-xs font-medium text-muted-foreground">
+                  {CATEGORY_LABELS[category]}:
+                </span>
+                {grouped[category].map((item) => renderChip(item.keyword))}
+              </div>
+            )
+          })
+        : null}
+
+      {customSelectedKeywords.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">{t('quickStart.customKeywords', '自定义')}:</span>
+          {customSelectedKeywords.map((keyword) => renderChip(keyword))}
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          value={customKeyword}
+          onChange={(event) => setCustomKeyword(event.target.value)}
+          onKeyDown={handleCustomKeywordKeyDown}
+          placeholder={t('quickStart.customKeywordPlaceholder', '自定义关键词...')}
+          className="h-8 max-w-xs text-xs"
+        />
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8 px-3 text-xs"
+          onClick={addCustomKeyword}
+          disabled={!customKeyword.trim()}
+        >
+          +
+        </Button>
+      </div>
+
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  )
+}

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -1,419 +1,110 @@
-/**
- * QuickStartPanel - Minimal Human-in-the-Loop Input
- * 
- * User provides only: Location + Keywords
- * System auto-matches: JD → Filter Preset → Suggested Filters
- */
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { JobDescriptionSelect } from "./JobDescriptionSelect";
+import { KeywordChips } from "./KeywordChips";
 
-import { useState, useCallback, useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Settings2, FilePlus } from 'lucide-react'
-import { Link } from 'react-router-dom'
-import { useQuery } from 'convex/react'
-import { api } from '../../../../packages/convex/convex/_generated/api'
-import type { Id } from '../../../../packages/convex/convex/_generated/dataModel'
-import { Button } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
-import { JobDescriptionEditor } from './JobDescriptionEditor'
-import { JobDescriptionSelect } from './JobDescriptionSelect'
-import { KeywordChips } from './KeywordChips'
-
-const API_BASE = import.meta.env.VITE_API_URL || ''
-
-// Common locations for precision machinery industry
 const COMMON_LOCATIONS = [
-    '广东',
-    '东莞', '深圳', '广州', '佛山', '惠州',
-    '苏州', '无锡', '常州', '昆山', '上海'
-]
-
-function toJobDescriptionId(value: string): Id<'job_descriptions'> | null {
-    if (value.length <= 20 || value.includes('-')) {
-        return null
-    }
-    return value as Id<'job_descriptions'>
-}
-
-interface AutoMatchResult {
-    matched?: string
-    title?: string
-    confidence: number
-    matchedKeywords: string[]
-    filterPreset?: string
-    suggestedFilters?: {
-        minExperience?: number
-        maxExperience?: number | null
-        education?: string[]
-        salaryRange?: { min?: number; max?: number }
-    }
-}
+  "广东",
+  "东莞",
+  "深圳",
+  "广州",
+  "佛山",
+  "惠州",
+  "苏州",
+  "无锡",
+  "常州",
+  "昆山",
+  "上海",
+];
 
 interface QuickStartPanelProps {
-    onApplyConfig?: (config: {
-        location: string
-        keywords: string[]
-        jobDescriptionId?: string
-        filterPreset?: string
-        filters?: AutoMatchResult['suggestedFilters']
-    }) => void
-    defaultLocation?: string
-    defaultKeywords?: string[]
-    jobDescriptionId?: string
-    onJobChange?: (value: string) => void
+  onApplyConfig?: (config: {
+    location: string;
+    keywords: string[];
+    jobDescriptionId?: string;
+  }) => void;
+  defaultLocation?: string;
+  defaultKeywords?: string[];
+  jobDescriptionId?: string;
+  onJobChange?: (value: string) => void;
 }
 
 export function QuickStartPanel({
-    onApplyConfig,
-    defaultLocation = '广东',
-    defaultKeywords = [],
-    jobDescriptionId = '',
-    onJobChange,
+  onApplyConfig,
+  defaultLocation = "广东",
+  defaultKeywords = [],
+  jobDescriptionId = "",
+  onJobChange,
 }: QuickStartPanelProps) {
-    const { t } = useTranslation()
+  const { t } = useTranslation();
 
-    const [location, setLocation] = useState(defaultLocation)
-    const [selectedKeywords, setSelectedKeywords] = useState<string[]>(defaultKeywords)
-    const [matchResult, setMatchResult] = useState<AutoMatchResult | null>(null)
-    const [loading, setLoading] = useState(false)
-    const [hasSearched, setHasSearched] = useState(false)
+  const [location, setLocation] = useState(defaultLocation);
+  const [selectedKeywords, setSelectedKeywords] = useState<string[]>(defaultKeywords);
 
-    // Editor State
-    const [showEditor, setShowEditor] = useState(false)
-    const [editorData, setEditorData] = useState<{ id?: Id<'job_descriptions'>, title: string, content: string, type: 'system' | 'custom' } | undefined>(undefined)
+  const handleApply = useCallback(() => {
+    onApplyConfig?.({
+      location,
+      keywords: selectedKeywords.map((keyword) => keyword.trim()).filter(Boolean),
+      jobDescriptionId: jobDescriptionId || undefined,
+    });
+  }, [jobDescriptionId, location, onApplyConfig, selectedKeywords]);
 
-    // Use useQuery for custom JDs (if matchResult is a custom/convex ID)
-    // We assume system JDs are simple strings, Convex IDs are ~32 chars
-    const matchedCustomId = matchResult?.matched ? toJobDescriptionId(matchResult.matched) : null
-    const customJDQuery = useQuery(api.job_descriptions.get, matchedCustomId ? { id: matchedCustomId } : 'skip')
+  const hasKeywords = selectedKeywords.some((keyword) => keyword.trim().length > 0);
+  const canApply = hasKeywords || Boolean(jobDescriptionId);
 
-    const handleModify = async () => {
-        if (!matchResult?.matched) {
-            // No match? Open as new custom JD
-            setEditorData({
-                title: 'Custom JD',
-                content: `# Job Requirements
-- Education: [e.g. Bachelor's Degree]
-- Experience: [e.g. 3+ years in Sales]
-- Skills: [e.g. Communication, Negotiation]
-- Location: ${location || '[City]'}
+  return (
+    <div className="rounded-lg bg-muted/30 px-6 py-5">
+      <p className="mb-3 text-xs text-muted-foreground">
+        {t("quickStart.hint", "输入位置和关键词，系统自动配置")}
+      </p>
 
-# Key Responsibilities
-- [Responsibility 1]
-- [Responsibility 2]
-
-# Preferred Qualifications
-- [Nice-to-have skill]`,
-                type: 'custom'
-            });
-            setShowEditor(true);
-            return;
-        }
-
-        setLoading(true);
-        try {
-            if (matchedCustomId && customJDQuery) {
-                // It's a custom JD and we have data from Convex
-                setEditorData({
-                    id: matchedCustomId,
-                    title: customJDQuery.title,
-                    content: customJDQuery.content,
-                    type: 'custom'
-                });
-                setShowEditor(true);
-            } else {
-                // It's a system JD or we need to fetch via API
-                const response = await fetch(`${API_BASE}/api/job-descriptions/${matchResult.matched}`);
-                if (response.ok) {
-                    const data = await response.json();
-                    if (data.success) {
-                        setEditorData({
-                            title: data.item?.title || matchResult.title || '',
-                            content: data.content || '',
-                            type: 'system'
-                        });
-                        setShowEditor(true);
-                    }
-                }
-            }
-        } catch (e) {
-            console.error("Failed to load JD content", e);
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    // Auto-match when location or keywords change (debounced)
-    useEffect(() => {
-        const keywords = selectedKeywords.map((keyword) => keyword.trim()).filter(Boolean)
-        if (keywords.length === 0) {
-            setMatchResult(null)
-            setHasSearched(false)
-            return
-        }
-
-        const timer = setTimeout(async () => {
-            setLoading(true)
-            try {
-                const response = await fetch(`${API_BASE}/api/job-descriptions/match`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ keywords, location: location || undefined }),
-                })
-                if (response.ok) {
-                    const data = await response.json()
-                    if (data.success) {
-                        setMatchResult({
-                            matched: data.matched,
-                            title: data.title,
-                            confidence: data.confidence,
-                            matchedKeywords: data.matchedKeywords,
-                            filterPreset: data.filterPreset,
-                            suggestedFilters: data.suggestedFilters,
-                        })
-                    }
-                }
-            } catch (error) {
-                console.error('Failed to auto-match job description', error)
-            } finally {
-                setLoading(false)
-                setHasSearched(true)
-            }
-        }, 500)
-
-        return () => clearTimeout(timer)
-    }, [selectedKeywords, location])
-
-    const handleApply = useCallback(() => {
-        const keywords = selectedKeywords.map((keyword) => keyword.trim()).filter(Boolean)
-        onApplyConfig?.({
-            location,
-            keywords,
-            jobDescriptionId: jobDescriptionId || matchResult?.matched,
-            filterPreset: matchResult?.filterPreset,
-            filters: matchResult?.suggestedFilters,
-        })
-    }, [jobDescriptionId, location, matchResult, onApplyConfig, selectedKeywords])
-
-    const hasKeywords = selectedKeywords.some((keyword) => keyword.trim().length > 0)
-
-    const confidenceColor = matchResult?.confidence
-        ? matchResult.confidence >= 0.7
-            ? 'text-green-600 dark:text-green-400'
-            : matchResult.confidence >= 0.4
-                ? 'text-yellow-600 dark:text-yellow-400'
-                : 'text-orange-600 dark:text-orange-400'
-        : ''
-
-    return (
-        <div className="rounded-lg bg-muted/30 px-6 py-5">
-            <p className="mb-3 text-xs text-muted-foreground">
-                {t('quickStart.hint', '输入位置和关键词，系统自动配置')}
-            </p>
-
-            <div className="flex flex-col gap-3">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-                    <div className="sm:w-44">
-                        <label className="mb-1 block text-sm font-medium text-muted-foreground">
-                            {t('quickStart.location', '位置')}
-                        </label>
-                        <div className="relative">
-                            <input
-                                type="text"
-                                value={location}
-                                onChange={(e) => setLocation(e.target.value)}
-                                placeholder="广东"
-                                list="location-suggestions"
-                                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                            />
-                            <datalist id="location-suggestions">
-                                {COMMON_LOCATIONS.map((loc) => (
-                                    <option key={loc} value={loc} />
-                                ))}
-                            </datalist>
-                        </div>
-                    </div>
-
-                    <Button
-                        onClick={handleApply}
-                        disabled={!hasKeywords}
-                        className="sm:w-auto"
-                    >
-                        {t('quickStart.apply', '使用此配置')}
-                    </Button>
-                </div>
-
-                <div>
-                    <label className="mb-1 block text-sm font-medium text-muted-foreground">
-                        {t('quickStart.keywords', '关键词')}
-                    </label>
-                    <KeywordChips
-                        value={selectedKeywords}
-                        onChange={setSelectedKeywords}
-                    />
-                </div>
-
-                <div className="max-w-sm">
-                    <label className="mb-1 block text-xs text-muted-foreground">
-                        {t('quickStart.manualJd', '手动职位（可选）')}
-                    </label>
-                    <JobDescriptionSelect
-                        value={jobDescriptionId}
-                        onChange={(value) => onJobChange?.(value)}
-                        disabled={!onJobChange}
-                    />
-                </div>
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="sm:w-44">
+            <label className="mb-1 block text-sm font-medium text-muted-foreground">
+              {t("quickStart.location", "位置")}
+            </label>
+            <div className="relative">
+              <input
+                type="text"
+                value={location}
+                onChange={(event) => setLocation(event.target.value)}
+                placeholder="广东"
+                list="location-suggestions"
+                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+              <datalist id="location-suggestions">
+                {COMMON_LOCATIONS.map((loc) => (
+                  <option key={loc} value={loc} />
+                ))}
+              </datalist>
             </div>
+          </div>
 
-                {/* Match Result */}
-                {hasSearched && (
-                    <div className="mt-4 p-3 rounded-md bg-background/60 border border-border/50">
-                        {loading ? (
-                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                <div className="h-4 w-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                                {t('quickStart.matching', '正在匹配...')}
-                            </div>
-                        ) : (
-                            <div className="flex flex-col gap-2">
-                                {matchResult?.matched ? (
-                                    <>
-                                        <div className="flex items-center gap-2 flex-wrap">
-                                            <span className="text-sm font-medium">
-                                                ⚡ {t('quickStart.matchedJD', '已匹配')}:
-                                            </span>
-                                            <span className="text-sm font-semibold text-primary">
-                                                {matchResult.title || matchResult.matched}
-                                            </span>
-                                            <span className={cn('text-xs', confidenceColor)}>
-                                                ({Math.round(matchResult.confidence * 100)}% {t('quickStart.confidence', '匹配度')})
-                                            </span>
-                                        </div>
-
-                                        {matchResult.suggestedFilters && (
-                                            <div className="flex items-center flex-wrap gap-2 text-xs text-muted-foreground">
-                                                {matchResult.suggestedFilters.minExperience !== undefined && (
-                                                    <span className="px-2 py-0.5 rounded bg-muted">
-                                                        {matchResult.suggestedFilters.minExperience}年+
-                                                    </span>
-                                                )}
-                                                {matchResult.suggestedFilters.education?.length && (
-                                                    <span className="px-2 py-0.5 rounded bg-muted">
-                                                        {matchResult.suggestedFilters.education.join('/')}
-                                                    </span>
-                                                )}
-                                                {matchResult.suggestedFilters.salaryRange && (
-                                                    <span className="px-2 py-0.5 rounded bg-muted">
-                                                        {matchResult.suggestedFilters.salaryRange.min?.toLocaleString()}-
-                                                        {matchResult.suggestedFilters.salaryRange.max?.toLocaleString()}
-                                                    </span>
-                                                )}
-                                                {matchResult.filterPreset && (
-                                                    <span className="px-2 py-0.5 rounded bg-primary/10 text-primary">
-                                                        {matchResult.filterPreset}
-                                                    </span>
-                                                )}
-                                            </div>
-                                        )}
-                                    </>
-                                ) : (
-                                    <div className="text-sm text-muted-foreground">
-                                        {hasKeywords
-                                            ? t('quickStart.noMatch', '未找到匹配的职位描述，将使用默认配置')
-                                            : t('quickStart.enterKeywords', '请输入关键词开始匹配')
-                                        }
-                                    </div>
-                                )}
-
-                                <div className="flex gap-2 mt-2">
-                                    <Button
-                                        variant="outline"
-                                        size="sm"
-                                        className="h-7 text-xs"
-                                        onClick={handleModify}
-                                    >
-                                        <Settings2 className="h-3 w-3 mr-1" />
-                                        {t('quickStart.modify', '修改配置')}
-                                    </Button>
-
-                                    {matchResult?.matched && (
-                                        <Button
-                                            variant="ghost"
-                                            size="sm"
-                                            className="h-7 text-xs"
-                                            onClick={() => {
-                                                setEditorData({
-                                                    title: 'Custom JD',
-                                                    content: `# Job Requirements
-- Education: [e.g. Bachelor's Degree]
-- Experience: [e.g. 3+ years in Sales]
-- Skills: [e.g. Communication, Negotiation]
-- Location: ${location || '[City]'}
-
-# Key Responsibilities
-- [Responsibility 1]
-- [Responsibility 2]
-
-# Preferred Qualifications
-- [Nice-to-have skill]`,
-                                                    type: 'custom'
-                                                });
-                                                setShowEditor(true);
-                                            }}
-                                        >
-                                            <FilePlus className="h-3 w-3 mr-1" />
-                                            {t('quickStart.createCustom', '创建自定义配置')}
-                                        </Button>
-                                    )}
-                                    <Link
-                                        to="/config/jds"
-                                        className="inline-flex items-center h-7 text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
-                                    >
-                                        {t('quickStart.manageJds')}
-                                    </Link>
-                                </div>
-                            </div>
-                        )}
-                    </div>
-                )}
-
-                {/* Advanced Panel (collapsed by default) */}
-                {matchResult && (
-                    <div className="mt-3 p-3 rounded-md border border-dashed border-border text-sm">
-                        <p className="text-muted-foreground mb-2">
-                            {t('quickStart.matchDetails')}
-                        </p>
-                        <div className="grid grid-cols-2 gap-2 text-xs">
-                            <div>
-                                <span className="text-muted-foreground">{t('quickStart.labelJd')}: </span>
-                                <span>{matchResult.matched}</span>
-                            </div>
-                            <div>
-                                <span className="text-muted-foreground">{t('quickStart.labelPreset')}: </span>
-                                <span>{matchResult.filterPreset || '-'}</span>
-                            </div>
-                            <div>
-                                <span className="text-muted-foreground">{t('quickStart.labelMatchedKeywords')}: </span>
-                                <span>{matchResult.matchedKeywords.join(', ') || '-'}</span>
-                            </div>
-                        </div>
-                    </div>
-                )}
-
-            <JobDescriptionEditor
-                open={showEditor}
-                onOpenChange={setShowEditor}
-                initialData={editorData}
-                onSaveSuccess={(newId) => {
-                    if (matchResult) {
-                        setMatchResult({
-                            ...matchResult,
-                            matched: newId,
-                            title: editorData?.title || matchResult.title,
-                        });
-                    }
-                    // Auto-apply or just confirm? User likely wants to apply.
-                    // For now, let them click "Apply" manually, but maybe highlight it.
-                }}
-            />
+          <Button onClick={handleApply} disabled={!canApply} className="sm:w-auto">
+            {t("quickStart.apply", "使用此配置")}
+          </Button>
         </div>
-    )
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-muted-foreground">
+            {t("quickStart.keywords", "关键词")}
+          </label>
+          <KeywordChips value={selectedKeywords} onChange={setSelectedKeywords} />
+        </div>
+
+        <div className="max-w-sm">
+          <label className="mb-1 block text-xs text-muted-foreground">
+            {t("quickStart.manualJd", "手动职位（可选）")}
+          </label>
+          <JobDescriptionSelect
+            value={jobDescriptionId}
+            onChange={(value) => onJobChange?.(value)}
+            disabled={!onJobChange}
+          />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -5,13 +5,9 @@ import { useResumes, type ResumeItem } from '@/hooks/useResumes'
 import type { ConvexResumeAnalysis, ConvexResumeItem } from '@/hooks/useConvexResumes'
 import { ResumeCard } from '@/components/ResumeCard'
 import { ResumeDetail } from '@/components/ResumeDetail'
-import { SearchBar } from '@/components/SearchBar'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Select } from '@/components/ui/select'
 import { cn } from '@/lib/utils'
 import { ModeToggle } from '@/components/ModeToggle'
-import { JobDescriptionSelect } from '@/components/JobDescriptionSelect'
 import { useSession } from '@/hooks/useSession'
 import { useAiMatching } from '@/hooks/useAiMatching'
 import { useCandidateActions } from '@/hooks/useCandidateActions'
@@ -31,6 +27,15 @@ type JobDescriptionApiResponse = {
   success: boolean
   item?: {
     title?: string
+  }
+  content?: string
+}
+
+type JobDescriptionDetailResponse = {
+  success: boolean
+  item?: {
+    _id: string
+    title: string
   }
   content?: string
 }
@@ -103,15 +108,13 @@ export function ResumeList() {
 
   const {
     resumes,
-    samples,
     summary,
     filters,
     loading,
     error,
     selectedSample,
     setSelectedSample,
-    query, // Added query
-    setQuery,
+    query,
     setFilters,
     refresh,
     reloadSamples,
@@ -217,27 +220,15 @@ export function ResumeList() {
         return
       }
       try {
-        const { data } = await rawApiClient.GET<{
-          success: boolean
-          item?: {
-            _id: string
-            title: string
-            content: string
-          }
-          // The API response type might be slightly different based on previous view
-          // API returns content as top level property in handleAnalyzeAll logic?
-          // In handleAnalyzeAll: data.content
-          // Let's verify the type alias JobDescriptionApiResponse usage
-        }>(`/api/job-descriptions/${jobDescriptionId}`)
+        const { data } = await rawApiClient.GET<JobDescriptionDetailResponse>(
+          `/api/job-descriptions/${jobDescriptionId}`
+        )
 
-        // Based on handleAnalyzeAll logic:
-        // jdTitle = data.item?.title || jobDescriptionId
-        // jdContent = data.content
         if (data?.success) {
           setSelectedJob({
             id: jobDescriptionId,
             title: data.item?.title || 'Unknown Position',
-            requirements: (data as any).content || ''
+            requirements: data.content || ''
           })
         }
       } catch (err) {
@@ -247,38 +238,10 @@ export function ResumeList() {
     loadJob()
   }, [jobDescriptionId])
 
-  const sampleOptions = useMemo(
-    () =>
-      samples.map((sample) => ({
-        value: sample.name,
-        label: sample.name,
-      })),
-    [samples]
-  )
-
-  const handleSearch = useCallback(
-    (keyword: string) => {
-      setQuery(keyword)
-    },
-    [setQuery]
-  )
-
-  const handleClearSearch = useCallback(() => {
-    setQuery('')
-  }, [setQuery])
-
   const handleRefresh = useCallback(async () => {
     await reloadSamples()
     await refresh()
   }, [reloadSamples, refresh])
-
-  const handleSampleChange = useCallback(
-    (value: string) => {
-      setSelectedSample(value)
-      updateSession({ sampleName: value })
-    },
-    [setSelectedSample, updateSession]
-  )
 
   const handleJobChange = useCallback(
     (value: string) => {
@@ -503,106 +466,115 @@ export function ResumeList() {
     ? (!convexResumes.length || analyzing || matchLoading || !jobDescriptionId)
     : (matchLoading || !jobDescriptionId)
 
+  const handleQuickStartApply = useCallback(
+    (config: {
+      location: string
+      keywords: string[]
+      jobDescriptionId?: string
+      filters?: {
+        minExperience?: number
+        maxExperience?: number | null
+        education?: string[]
+        salaryRange?: { min?: number; max?: number }
+      }
+    }) => {
+      if (config.jobDescriptionId) {
+        setJobDescriptionId(config.jobDescriptionId)
+        updateSession({ jobDescriptionId: config.jobDescriptionId })
+      }
+
+      const nextFilters = { ...filters }
+      if (config.location.trim()) {
+        nextFilters.locations = [config.location.trim()]
+      }
+      if (config.keywords.length > 0) {
+        nextFilters.skills = config.keywords
+      }
+      if (config.filters) {
+        if (config.filters.minExperience !== undefined) {
+          nextFilters.minExperience = config.filters.minExperience
+        }
+        if (config.filters.maxExperience !== undefined) {
+          nextFilters.maxExperience = config.filters.maxExperience ?? undefined
+        }
+        if (config.filters.education) {
+          nextFilters.education = config.filters.education
+        }
+        if (config.filters.salaryRange?.min !== undefined) {
+          nextFilters.minSalary = config.filters.salaryRange.min
+        }
+        if (config.filters.salaryRange?.max !== undefined) {
+          nextFilters.maxSalary = config.filters.salaryRange.max
+        }
+      }
+      setFilters(nextFilters)
+      updateSession({ filters: nextFilters })
+    },
+    [filters, updateSession, setFilters]
+  )
+
   return (
-    <div className="flex flex-col gap-6">
-      {/* Quick Start Panel - Minimal Input */}
+    <div className="flex flex-col gap-4">
       <QuickStartPanel
-        onApplyConfig={(config) => {
-          if (config.jobDescriptionId) {
-            setJobDescriptionId(config.jobDescriptionId)
-            updateSession({ jobDescriptionId: config.jobDescriptionId })
-          }
-          if (config.filters) {
-            setFilters({ ...filters, ...config.filters } as typeof filters)
-            updateSession({ filters: { ...filters, ...config.filters } as typeof filters })
-          }
-        }}
+        onApplyConfig={handleQuickStartApply}
+        jobDescriptionId={jobDescriptionId}
+        onJobChange={handleJobChange}
       />
 
-      <div className="flex flex-col gap-3">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="text-2xl font-semibold">{t('resumes.title')}</h1>
-            <p className="text-sm text-muted-foreground">{t('resumes.subtitle')}</p>
-          </div>
-          <div className="flex gap-2">
-            <Button variant="outline" onClick={handleRefresh} disabled={loading}>
-              <RefreshCw className={cn('mr-2 h-4 w-4', loading && 'animate-spin')} />
-              {t('resumes.refresh')}
-            </Button>
-            <Button
-              onClick={mode === 'ai' ? handleAnalyzeAll : handleMatchAll}
-              disabled={disableAnalyzeButton}
-              title={mode === 'ai' && !jobDescriptionId ? t('resumes.selectJobDescriptionFirst') : undefined}
-            >
-              <RefreshCw className={cn('mr-2 h-4 w-4', (analyzing || matchLoading) && 'animate-spin')} />
-              {mode === 'ai' ? (analyzing ? 'Analyzing...' : 'Analyze All (AI)') : (matchLoading ? t('resumes.matching.running') : t('resumes.matching.matchAll'))}
-            </Button>
-          </div>
-        </div>
-
-        {analysisDispatchMessage ? (
-          <div
-            className={cn(
-              'w-fit rounded-md px-2.5 py-1.5 text-xs',
-              analysisDispatchMessage.type === 'success'
-                ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300'
-                : 'bg-destructive/10 text-destructive'
-            )}
-            role="status"
-          >
-            {analysisDispatchMessage.text}
-          </div>
-        ) : null}
-
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
-          <div className="flex-1">
-            <SearchBar
-              onSearch={handleSearch}
-              onClear={handleClearSearch}
-              loading={activeLoading}
-              placeholder={t('resumes.searchPlaceholder')}
-              buttonLabel={t('resumes.searchButton')}
-            />
-          </div>
-          <div className="lg:w-60">
-            <Select
-              options={sampleOptions}
-              value={selectedSample}
-              onChange={(event) => handleSampleChange(event.target.value)}
-              disabled={sampleOptions.length === 0}
-            />
-          </div>
-          <div className="lg:w-64">
-            <JobDescriptionSelect value={jobDescriptionId} onChange={handleJobChange} />
-          </div>
-        </div>
-
-
-        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <ModeToggle mode={mode} onModeChange={setMode} aiStats={aiStats ?? undefined} />
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <ModeToggle mode={mode} onModeChange={setMode} aiStats={aiStats ?? undefined} />
+        <div className="flex flex-wrap items-center gap-2">
           {summary && !error ? (
-            <div className="text-sm text-muted-foreground">
+            <span className="text-sm text-muted-foreground">
               {t('resumes.summary', {
                 returned: mode === 'ai' ? displayedResumes.length : (summary.returned ?? resumes.length),
                 total: mode === 'ai' ? convexResumes.length : (summary.total ?? resumes.length),
                 sample: selectedSample || '--',
               })}
-            </div>
+            </span>
           ) : null}
+          <Button size="sm" variant="outline" onClick={handleRefresh} disabled={activeLoading}>
+            <RefreshCw className={cn('mr-2 h-4 w-4', activeLoading && 'animate-spin')} />
+            {t('resumes.refresh')}
+          </Button>
+          <Button
+            size="sm"
+            onClick={mode === 'ai' ? handleAnalyzeAll : handleMatchAll}
+            disabled={disableAnalyzeButton}
+            title={mode === 'ai' && !jobDescriptionId ? t('resumes.selectJobDescriptionFirst') : undefined}
+          >
+            <RefreshCw className={cn('mr-2 h-4 w-4', (analyzing || matchLoading) && 'animate-spin')} />
+            {mode === 'ai'
+              ? (analyzing ? 'Analyzing...' : 'Analyze All (AI)')
+              : (matchLoading ? t('resumes.matching.running') : t('resumes.matching.matchAll'))}
+          </Button>
         </div>
-
-        <FilterPanel filters={filters} onChange={handleFiltersChange} mode={mode} />
-
-        {matchError ? (
-          <div className="text-xs text-destructive">{matchError}</div>
-        ) : null}
-        {mode !== 'ai' && matchProgress ? (
-          <div className="text-xs text-muted-foreground">
-            AI progress: {matchProgress.done}/{matchProgress.total}
-          </div>
-        ) : null}
       </div>
+
+      {analysisDispatchMessage ? (
+        <div
+          className={cn(
+            'w-fit rounded-md px-2.5 py-1.5 text-xs',
+            analysisDispatchMessage.type === 'success'
+              ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300'
+              : 'bg-destructive/10 text-destructive'
+          )}
+          role="status"
+        >
+          {analysisDispatchMessage.text}
+        </div>
+      ) : null}
+
+      <FilterPanel filters={filters} onChange={handleFiltersChange} mode={mode} />
+
+      {matchError ? (
+        <div className="text-xs text-destructive">{matchError}</div>
+      ) : null}
+      {mode !== 'ai' && matchProgress ? (
+        <div className="text-xs text-muted-foreground">
+          AI progress: {matchProgress.done}/{matchProgress.total}
+        </div>
+      ) : null}
 
       {mode === 'ai' ? (
         <AnalysisTaskMonitor />
@@ -610,64 +582,60 @@ export function ResumeList() {
         <MatchRunHistory sessionId={session?.id} jobDescriptionId={jobDescriptionId || undefined} />
       )}
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex flex-wrap items-center gap-2 text-lg font-semibold">
-            {t('resumes.tableTitle')}
-            {mode === 'ai' ? (
-              <span className="text-xs font-normal text-muted-foreground">
-                {t('resumes.matching.sortedByScore')}
-              </span>
+      <div className="space-y-3">
+        <h2 className="flex flex-wrap items-center gap-2 text-lg font-semibold">
+          {t('resumes.tableTitle')}
+          {mode === 'ai' ? (
+            <span className="text-xs font-normal text-muted-foreground">
+              {t('resumes.matching.sortedByScore')}
+            </span>
+          ) : null}
+        </h2>
+
+        {activeLoading ? (
+          <div className="py-10 text-center text-sm text-muted-foreground">
+            {t('resumes.loading')}
+          </div>
+        ) : error ? (
+          <div className="py-10 text-center">
+            <p className="text-sm text-destructive">{t('resumes.error')}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{error}</p>
+          </div>
+        ) : displayedResumes.length === 0 ? (
+          <div className="py-10 text-center text-sm text-muted-foreground">
+            {t('resumes.empty')}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {mode === 'ai' && displayedResumes.length > 0 ? (
+              <BulkActionBar
+                totalCount={displayedResumes.length}
+                selectedCount={selectedIds.size}
+                highScoreCount={highScoreCount}
+                onSelectAll={handleSelectAll}
+                onSelectHighScore={handleSelectHighScore}
+                onClearSelection={handleClearSelection}
+                onBulkAction={handleBulkAction}
+              />
             ) : null}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {activeLoading ? (
-            <div className="py-10 text-center text-sm text-muted-foreground">
-              {t('resumes.loading')}
-            </div>
-          ) : error ? (
-            <div className="py-10 text-center">
-              <p className="text-sm text-destructive">{t('resumes.error')}</p>
-              <p className="text-xs text-muted-foreground mt-1">{error}</p>
-            </div>
-          ) : displayedResumes.length === 0 ? (
-            <div className="py-10 text-center text-sm text-muted-foreground">
-              {t('resumes.empty')}
-            </div>
-          ) : (
-            <div className="space-y-3">
-              {/* Bulk Action Bar - shown in AI mode */}
-              {mode === 'ai' && displayedResumes.length > 0 && (
-                <BulkActionBar
-                  totalCount={displayedResumes.length}
-                  selectedCount={selectedIds.size}
-                  highScoreCount={highScoreCount}
-                  onSelectAll={handleSelectAll}
-                  onSelectHighScore={handleSelectHighScore}
-                  onClearSelection={handleClearSelection}
-                  onBulkAction={handleBulkAction}
-                />
-              )}
-              {displayedResumes.map((entry, index) => (
-                <ResumeCard
-                  key={entry.key || `${index}-${entry.resume.name}`}
-                  resume={entry.resume}
-                  matchResult={entry.match}
-                  showAiScore={Boolean(entry.match)}
-                  actionType={entry.action}
-                  onAction={(actionType) => saveAction({ resumeId: entry.key, actionType })}
-                  onViewDetails={() => setDetailResume(entry.resume)}
-                  selected={selectedIds.has(entry.key)}
-                  onSelect={() => handleToggleSelect(entry.key)}
-                  jobDescriptionId={jobDescriptionId}
-                  jobDescription={selectedJob || undefined}
-                />
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+            {displayedResumes.map((entry, index) => (
+              <ResumeCard
+                key={entry.key || `${index}-${entry.resume.name}`}
+                resume={entry.resume}
+                matchResult={entry.match}
+                showAiScore={Boolean(entry.match)}
+                actionType={entry.action}
+                onAction={(actionType) => saveAction({ resumeId: entry.key, actionType })}
+                onViewDetails={() => setDetailResume(entry.resume)}
+                selected={selectedIds.has(entry.key)}
+                onSelect={() => handleToggleSelect(entry.key)}
+                jobDescriptionId={jobDescriptionId}
+                jobDescription={selectedJob || undefined}
+              />
+            ))}
+          </div>
+        )}
+      </div>
 
       <ResumeDetail
         resume={detailResume}

--- a/apps/web/src/hooks/useAiMatching.ts
+++ b/apps/web/src/hooks/useAiMatching.ts
@@ -7,7 +7,9 @@ export type MatchMode = 'rules_only' | 'hybrid' | 'ai_only'
 export type MatchRequest = {
   sessionId?: string
   sample?: string
-  jobDescriptionId: string
+  jobDescriptionId?: string
+  keywords?: string[]
+  location?: string
   resumeIds?: string[]
   limit?: number
   topN?: number

--- a/apps/web/src/hooks/useIndustryKeywords.ts
+++ b/apps/web/src/hooks/useIndustryKeywords.ts
@@ -1,43 +1,63 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { rawApiClient } from '@/lib/api-helpers'
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { rawApiClient } from "@/lib/api-helpers";
 
 export type KeywordCategory =
-  | 'machining'
-  | 'lathe'
-  | 'edm'
-  | 'measurement'
-  | 'smt'
-  | '3d_printing'
+  | "machining"
+  | "lathe"
+  | "edm"
+  | "measurement"
+  | "smt"
+  | "3d_printing"
+  | "custom";
 
 export type IndustryKeyword = {
-  id: number
-  keyword: string
-  english?: string
-  category: KeywordCategory
-}
+  id: number | string;
+  keyword: string;
+  english?: string;
+  category: KeywordCategory;
+};
 
 type IndustryKeywordsResponse = {
-  success: boolean
-  data?: IndustryKeyword[]
-}
+  success: boolean;
+  data?: Array<{
+    id: number;
+    keyword: string;
+    english?: string;
+    category: "machining" | "lathe" | "edm" | "measurement" | "smt" | "3d_printing";
+  }>;
+};
+
+type CustomKeywordTag = {
+  id: string;
+  keyword: string;
+  english?: string;
+  category: string;
+};
+
+type CustomKeywordsResponse = {
+  success: boolean;
+  tags?: CustomKeywordTag[];
+};
 
 export const CATEGORY_ORDER: KeywordCategory[] = [
-  'machining',
-  'lathe',
-  'edm',
-  'measurement',
-  'smt',
-  '3d_printing',
-]
+  "machining",
+  "lathe",
+  "edm",
+  "measurement",
+  "smt",
+  "3d_printing",
+  "custom",
+];
 
 export const CATEGORY_LABELS: Record<KeywordCategory, string> = {
-  machining: '加工中心',
-  lathe: '车床',
-  edm: '火花机/线切割',
-  measurement: '测量扫描',
-  smt: 'SMT',
-  '3d_printing': '3D打印',
-}
+  machining: "加工中心",
+  lathe: "车床",
+  edm: "火花机/线切割",
+  measurement: "测量扫描",
+  smt: "SMT",
+  "3d_printing": "3D打印",
+  custom: "自定义",
+};
 
 function createGroupedKeywords(): Record<KeywordCategory, IndustryKeyword[]> {
   return {
@@ -46,55 +66,105 @@ function createGroupedKeywords(): Record<KeywordCategory, IndustryKeyword[]> {
     edm: [],
     measurement: [],
     smt: [],
-    '3d_printing': [],
+    "3d_printing": [],
+    custom: [],
+  };
+}
+
+function normalizeCategory(category: string): KeywordCategory {
+  if (
+    category === "machining" ||
+    category === "lathe" ||
+    category === "edm" ||
+    category === "measurement" ||
+    category === "smt" ||
+    category === "3d_printing" ||
+    category === "custom"
+  ) {
+    return category;
   }
+  return "custom";
 }
 
 export function useIndustryKeywords() {
-  const [keywords, setKeywords] = useState<IndustryKeyword[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [keywords, setKeywords] = useState<IndustryKeyword[]>([]);
+  const [customKeywords, setCustomKeywords] = useState<IndustryKeyword[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchKeywords = useCallback(async () => {
-    setLoading(true)
-    setError(null)
-    const { data, error: apiError } = await rawApiClient.GET<IndustryKeywordsResponse>(
-      '/api/industry/keywords'
-    )
+    setLoading(true);
+    setError(null);
 
-    if (apiError || !data?.success) {
-      setKeywords([])
-      setError('Failed to load industry keywords')
-      setLoading(false)
-      return
+    const [industryResponse, customResponse] = await Promise.all([
+      rawApiClient.GET<IndustryKeywordsResponse>("/api/industry/keywords"),
+      rawApiClient.GET<CustomKeywordsResponse>("/api/config/custom-keywords"),
+    ]);
+
+    const { data: industryData, error: industryError } = industryResponse;
+    if (industryError || !industryData?.success) {
+      setKeywords([]);
+      setCustomKeywords([]);
+      setError("Failed to load industry keywords");
+      setLoading(false);
+      return;
     }
 
-    setKeywords(Array.isArray(data.data) ? data.data : [])
-    setLoading(false)
-  }, [])
+    setKeywords(Array.isArray(industryData.data) ? industryData.data : []);
+
+    const { data: customData, error: customError } = customResponse;
+    if (customError || !customData?.success) {
+      console.error("Failed to load custom keywords", customError);
+      setCustomKeywords([]);
+      setLoading(false);
+      return;
+    }
+
+    const mappedCustomKeywords: IndustryKeyword[] = [];
+    if (Array.isArray(customData.tags)) {
+      for (const tag of customData.tags) {
+        const keyword = tag.keyword?.trim();
+        if (!keyword) continue;
+        mappedCustomKeywords.push({
+          id: tag.id,
+          keyword,
+          english: tag.english?.trim() || undefined,
+          category: normalizeCategory(tag.category),
+        });
+      }
+    }
+
+    setCustomKeywords(mappedCustomKeywords);
+    setLoading(false);
+  }, []);
 
   useEffect(() => {
-    void fetchKeywords()
-  }, [fetchKeywords])
+    void fetchKeywords();
+  }, [fetchKeywords]);
+
+  const allKeywords = useMemo(
+    () => [...keywords, ...customKeywords],
+    [keywords, customKeywords]
+  );
 
   const grouped = useMemo(() => {
-    const groups = createGroupedKeywords()
-    for (const item of keywords) {
-      groups[item.category].push(item)
+    const groups = createGroupedKeywords();
+    for (const item of allKeywords) {
+      groups[item.category].push(item);
     }
-    return groups
-  }, [keywords])
+    return groups;
+  }, [allKeywords]);
 
   const hotKeywords = useMemo(() => {
-    return CATEGORY_ORDER.flatMap((category) => grouped[category].slice(0, 3))
-  }, [grouped])
+    return CATEGORY_ORDER.flatMap((category) => grouped[category].slice(0, 3));
+  }, [grouped]);
 
   return {
-    keywords,
+    keywords: allKeywords,
     grouped,
     hotKeywords,
     loading,
     error,
     refresh: fetchKeywords,
-  }
+  };
 }

--- a/apps/web/src/hooks/useIndustryKeywords.ts
+++ b/apps/web/src/hooks/useIndustryKeywords.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { rawApiClient } from '@/lib/api-helpers'
+
+export type KeywordCategory =
+  | 'machining'
+  | 'lathe'
+  | 'edm'
+  | 'measurement'
+  | 'smt'
+  | '3d_printing'
+
+export type IndustryKeyword = {
+  id: number
+  keyword: string
+  english?: string
+  category: KeywordCategory
+}
+
+type IndustryKeywordsResponse = {
+  success: boolean
+  data?: IndustryKeyword[]
+}
+
+export const CATEGORY_ORDER: KeywordCategory[] = [
+  'machining',
+  'lathe',
+  'edm',
+  'measurement',
+  'smt',
+  '3d_printing',
+]
+
+export const CATEGORY_LABELS: Record<KeywordCategory, string> = {
+  machining: '加工中心',
+  lathe: '车床',
+  edm: '火花机/线切割',
+  measurement: '测量扫描',
+  smt: 'SMT',
+  '3d_printing': '3D打印',
+}
+
+function createGroupedKeywords(): Record<KeywordCategory, IndustryKeyword[]> {
+  return {
+    machining: [],
+    lathe: [],
+    edm: [],
+    measurement: [],
+    smt: [],
+    '3d_printing': [],
+  }
+}
+
+export function useIndustryKeywords() {
+  const [keywords, setKeywords] = useState<IndustryKeyword[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchKeywords = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    const { data, error: apiError } = await rawApiClient.GET<IndustryKeywordsResponse>(
+      '/api/industry/keywords'
+    )
+
+    if (apiError || !data?.success) {
+      setKeywords([])
+      setError('Failed to load industry keywords')
+      setLoading(false)
+      return
+    }
+
+    setKeywords(Array.isArray(data.data) ? data.data : [])
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    void fetchKeywords()
+  }, [fetchKeywords])
+
+  const grouped = useMemo(() => {
+    const groups = createGroupedKeywords()
+    for (const item of keywords) {
+      groups[item.category].push(item)
+    }
+    return groups
+  }, [keywords])
+
+  const hotKeywords = useMemo(() => {
+    return CATEGORY_ORDER.flatMap((category) => grouped[category].slice(0, 3))
+  }, [grouped])
+
+  return {
+    keywords,
+    grouped,
+    hotKeywords,
+    loading,
+    error,
+    refresh: fetchKeywords,
+  }
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -209,6 +209,10 @@
     "labelJd": "JD",
     "labelPreset": "Preset",
     "labelMatchedKeywords": "Matched Keywords",
+    "hotKeywords": "Hot Keywords",
+    "expandKeywords": "Show All",
+    "collapseKeywords": "Collapse",
+    "customKeywordPlaceholder": "Custom keyword...",
     "manageJds": "Manage all JDs →"
   },
   "debug": {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -127,6 +127,7 @@
       "manage": "Manage JDs"
     },
     "selectJobDescriptionFirst": "Please select a Job Description first",
+    "selectKeywordsOrJobDescription": "Please select keywords or a job description",
     "matching": {
       "matchAll": "Match All",
       "running": "Matching...",
@@ -296,7 +297,7 @@
   },
   "debugConfig": {
     "title": "System Configuration",
-    "subtitle": "View and edit agent pipeline, filter presets, and AI service settings",
+    "subtitle": "View and edit agent pipeline, custom keywords, and AI service settings",
     "aiStatus": "AI Service Status",
     "aiEnabled": "Enabled",
     "aiDisabled": "Disabled",
@@ -317,6 +318,15 @@
     "save": "Save",
     "saved": "Saved",
     "saveError": "Save failed",
+    "customKeywords": "Custom Keywords",
+    "customKeywordsDescription": "Manage custom tags available in resume keyword chips",
+    "addCustomKeyword": "Add Keyword",
+    "editCustomKeyword": "Edit",
+    "deleteCustomKeyword": "Delete",
+    "customKeywordId": "ID",
+    "customKeywordKeyword": "Keyword",
+    "customKeywordEnglish": "English",
+    "customKeywordCategory": "Category",
     "presets": "Filter Presets",
     "presetsDescription": "Quick filter configurations for common search patterns",
     "addPreset": "Add Preset",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -127,6 +127,7 @@
       "manage": "管理职位"
     },
     "selectJobDescriptionFirst": "请先选择职位描述",
+    "selectKeywordsOrJobDescription": "请选择关键词或职位描述",
     "matching": {
       "matchAll": "AI 匹配全部",
       "running": "匹配中...",
@@ -296,7 +297,7 @@
   },
   "debugConfig": {
     "title": "系统配置",
-    "subtitle": "查看和编辑 Agent 流程、筛选预设和 AI 服务设置",
+    "subtitle": "查看和编辑 Agent 流程、自定义关键词和 AI 服务设置",
     "aiStatus": "AI 服务状态",
     "aiEnabled": "已启用",
     "aiDisabled": "未启用",
@@ -317,6 +318,15 @@
     "save": "保存",
     "saved": "已保存",
     "saveError": "保存失败",
+    "customKeywords": "自定义关键词",
+    "customKeywordsDescription": "管理可在简历页面关键词芯片中使用的自定义标签",
+    "addCustomKeyword": "添加关键词",
+    "editCustomKeyword": "编辑",
+    "deleteCustomKeyword": "删除",
+    "customKeywordId": "ID",
+    "customKeywordKeyword": "关键词",
+    "customKeywordEnglish": "English",
+    "customKeywordCategory": "类别",
     "presets": "筛选预设",
     "presetsDescription": "常用搜索模式的快速筛选配置",
     "addPreset": "添加预设",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -209,6 +209,10 @@
     "labelJd": "职位",
     "labelPreset": "预设",
     "labelMatchedKeywords": "匹配词",
+    "hotKeywords": "热门关键词",
+    "expandKeywords": "展开全部",
+    "collapseKeywords": "收起",
+    "customKeywordPlaceholder": "自定义关键词...",
     "manageJds": "管理所有职位 →"
   },
   "debug": {

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -127,6 +127,7 @@
       "manage": "管理職位"
     },
     "selectJobDescriptionFirst": "請先選擇職位描述",
+    "selectKeywordsOrJobDescription": "請選擇關鍵詞或職位描述",
     "matching": {
       "matchAll": "AI 匹配全部",
       "running": "匹配中...",
@@ -296,7 +297,7 @@
   },
   "debugConfig": {
     "title": "系統配置",
-    "subtitle": "查看和編輯 Agent 流程、篩選預設和 AI 服務設定",
+    "subtitle": "查看和編輯 Agent 流程、自定義關鍵詞和 AI 服務設定",
     "aiStatus": "AI 服務狀態",
     "aiEnabled": "已啟用",
     "aiDisabled": "未啟用",
@@ -317,6 +318,15 @@
     "save": "儲存",
     "saved": "已儲存",
     "saveError": "儲存失敗",
+    "customKeywords": "自定義關鍵詞",
+    "customKeywordsDescription": "管理可在簡歷頁面關鍵詞晶片中使用的自定義標籤",
+    "addCustomKeyword": "新增關鍵詞",
+    "editCustomKeyword": "編輯",
+    "deleteCustomKeyword": "刪除",
+    "customKeywordId": "ID",
+    "customKeywordKeyword": "關鍵詞",
+    "customKeywordEnglish": "English",
+    "customKeywordCategory": "類別",
     "presets": "篩選預設",
     "presetsDescription": "常用搜尋模式的快速篩選配置",
     "addPreset": "新增預設",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -209,6 +209,10 @@
     "labelJd": "職位",
     "labelPreset": "預設",
     "labelMatchedKeywords": "匹配詞",
+    "hotKeywords": "熱門關鍵詞",
+    "expandKeywords": "展開全部",
+    "collapseKeywords": "收起",
+    "customKeywordPlaceholder": "自定義關鍵詞...",
     "manageJds": "管理所有職位 →"
   },
   "debug": {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -391,6 +391,19 @@ export interface paths {
                         "application/json": components["schemas"]["MatchResponse"];
                     };
                 };
+                /** @description Invalid request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Session or job description not found */
                 404: {
                     headers: {
@@ -559,7 +572,9 @@ export interface paths {
                     "application/json": {
                         sessionId?: string;
                         sample?: string;
-                        jobDescriptionId: string;
+                        jobDescriptionId?: string;
+                        keywords?: string[];
+                        location?: string;
                         resumeIds?: string[];
                         limit?: number;
                     };
@@ -573,6 +588,19 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["MatchResponse"];
+                    };
+                };
+                /** @description Invalid request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
                     };
                 };
                 /** @description Session or data not found */
@@ -2230,7 +2258,16 @@ export interface components {
             /** @example sample-initial */
             sample?: string;
             /** @example lathe-sales */
-            jobDescriptionId: string;
+            jobDescriptionId?: string;
+            /**
+             * @example [
+             *       "cnc",
+             *       "车床"
+             *     ]
+             */
+            keywords?: string[];
+            /** @example 广东 */
+            location?: string;
             /**
              * @example [
              *       "R123456"

--- a/apps/web/src/pages/DebugAI.tsx
+++ b/apps/web/src/pages/DebugAI.tsx
@@ -50,6 +50,12 @@ const USER_PROMPT_TEMPLATE = `请分析以下候选人与职位的匹配度：
   "summary": "中文总结"
 }`
 
+const KEYWORD_PROMPT_VARIANT = `buildKeywordRequirements(['cnc', '车床', '4轴']):
+候选人需具备以下关键技能/经验:
+- cnc
+- 车床
+- 4轴`
+
 type ResumeDoc = Doc<'resumes'>
 type BreakdownKey = 'experience' | 'skills' | 'industry_db' | 'education' | 'location'
 
@@ -233,6 +239,10 @@ export default function DebugAI() {
           <div className="space-y-2">
             <h2 className="text-sm font-semibold">{t('debugAi.userPrompt')}</h2>
             <pre className="max-h-80 overflow-auto rounded-md border bg-muted/40 p-4 text-xs leading-relaxed">{USER_PROMPT_TEMPLATE}</pre>
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-sm font-semibold">Keyword-Based Prompt Variant</h2>
+            <pre className="max-h-64 overflow-auto rounded-md border bg-muted/40 p-4 text-xs leading-relaxed">{KEYWORD_PROMPT_VARIANT}</pre>
           </div>
         </CardContent>
       </Card>

--- a/config/resume/agents.json5
+++ b/config/resume/agents.json5
@@ -1,145 +1,170 @@
 {
-  // Multi-Agent Pipeline Configuration
-  // Follows OpenClaw's multi-agent routing pattern with cost-optimized defaults
-  
-  agents: {
-    list: [
-      // Stage 1: Initial Screener (fast, cheap, high throughput)
+  "agents": {
+    "list": [
       {
-        id: "screener",
-        name: "初筛Agent",
-        description: "快速筛选，排除明显不匹配候选人",
-        model: "deepseek/deepseek-chat",
-        config: {
-          batchSize: 50,           // Process 50 resumes per batch
-          concurrency: 5,          // Default concurrent workers for API batch matching
-          parallelism: 10,         // 10 parallel requests
-          timeout: 30000,          // 30 second timeout
-          maxTokens: 500,          // Short responses
-          temperature: 0.1         // Low creativity, consistent scoring
-        }
+        "id": "screener",
+        "name": "初筛Agent",
+        "description": "快速筛选，排除明显不匹配候选人",
+        "model": "openai/gpt-5-mini",
+        "config": {
+          "batchSize": 50,
+          "concurrency": 5,
+          "parallelism": 10,
+          "timeout": 30000,
+          "maxTokens": 500,
+          "temperature": 0.1
+        },
+        "isBonded": true
       },
-      
-      // Stage 2: Technical Evaluator (moderate cost, detailed analysis)
       {
-        id: "evaluator",
-        name: "详评Agent",
-        description: "详细评估技能匹配度和工作经验",
-        model: "deepseek/deepseek-chat",
-        config: {
-          batchSize: 10,           // Smaller batches for detailed work
-          parallelism: 5,
-          timeout: 60000,
-          maxTokens: 1500,
-          temperature: 0.2,
-          // Only process candidates that passed screener
-          onlyTopPercent: 30,
-          minPreviousScore: 50
-        }
+        "id": "evaluator",
+        "name": "详评Agent",
+        "description": "详细评估技能匹配度和工作经验",
+        "model": "openai/gpt-5-mini",
+        "config": {
+          "batchSize": 10,
+          "parallelism": 5,
+          "timeout": 60000,
+          "maxTokens": 1500,
+          "temperature": 0.2,
+          "onlyTopPercent": 30,
+          "minPreviousScore": 50
+        },
+        "isBonded": true
       },
-      
-      // Stage 3: Final Decision (premium model, top candidates only)
       {
-        id: "final",
-        name: "终审Agent",
-        description: "最终推荐决策和面试建议",
-        model: "anthropic/claude-sonnet-4-5",
-        config: {
-          batchSize: 5,
-          parallelism: 2,
-          timeout: 120000,
-          maxTokens: 2000,
-          temperature: 0.3,
-          // Only process top performers
-          onlyTopPercent: 10,
-          minPreviousScore: 70,
-          // Generate interview questions for shortlisted
-          generateInterviewQuestions: true
-        }
+        "id": "final",
+        "name": "终审Agent",
+        "description": "最终推荐决策和面试建议",
+        "model": "openai/gpt-5-mini",
+        "config": {
+          "batchSize": 5,
+          "parallelism": 2,
+          "timeout": 120000,
+          "maxTokens": 2000,
+          "temperature": 0.3,
+          "onlyTopPercent": 10,
+          "minPreviousScore": 70,
+          "generateInterviewQuestions": true
+        },
+        "isBonded": true
       }
     ],
-    
-    // Default thresholds for each stage
-    defaults: {
-      screener: {
-        passThreshold: 50,         // Minimum score to pass to evaluator
-        recommendations: {
-          reject: [0, 30],         // Score 0-30: Reject
-          review: [30, 50],        // Score 30-50: Maybe, needs review
-          pass: [50, 100]          // Score 50+: Pass to next stage
+    "defaults": {
+      "screener": {
+        "passThreshold": 50,
+        "recommendations": {
+          "reject": [
+            0,
+            30
+          ],
+          "review": [
+            30,
+            50
+          ],
+          "pass": [
+            50,
+            100
+          ]
         }
       },
-      evaluator: {
-        passThreshold: 70,
-        recommendations: {
-          reject: [0, 50],
-          review: [50, 70],
-          pass: [70, 100]
+      "evaluator": {
+        "passThreshold": 70,
+        "recommendations": {
+          "reject": [
+            0,
+            50
+          ],
+          "review": [
+            50,
+            70
+          ],
+          "pass": [
+            70,
+            100
+          ]
         }
       },
-      final: {
-        passThreshold: 80,
-        recommendations: {
-          notRecommended: [0, 60],
-          conditional: [60, 80],
-          recommended: [80, 90],
-          highlyRecommended: [90, 100]
+      "final": {
+        "passThreshold": 80,
+        "recommendations": {
+          "notRecommended": [
+            0,
+            60
+          ],
+          "conditional": [
+            60,
+            80
+          ],
+          "recommended": [
+            80,
+            90
+          ],
+          "highlyRecommended": [
+            90,
+            100
+          ]
         }
       }
     }
   },
-  
-  // Routing bindings
-  // "auto" = determine stage based on processing status
-  // Can also specify explicit bindings like OpenClaw pattern
-  bindings: "auto",
-  
-  // Explicit binding examples (used if bindings != "auto"):
-  explicitBindings: [
-    { agentId: "screener", match: { source: "job_board" } },
-    { agentId: "screener", match: { source: "manual_upload" } },
-    { agentId: "screener", match: { source: "email_ingest" } },
-    { agentId: "evaluator", match: { stage: "technical_review" } },
-    { agentId: "final", match: { stage: "final_decision" } }
-  ],
-
-  // Rule-first hybrid scoring defaults
-  ruleScoring: {
-    enabled: true,
-    defaultMode: "hybrid",   // rules_only | hybrid | ai_only
-    aiTopN: 20,              // Only top N rule-scored resumes go to AI
-    aiConcurrency: 5,        // AI batch concurrency
-    minRuleScoreForAi: 50
-  },
-  
-  // Global settings
-  global: {
-    // Maximum total cost per run (USD)
-    maxCostPerRun: 5.0,
-    
-    // Stop processing if error rate exceeds threshold
-    maxErrorRate: 0.1,
-    
-    // Retry configuration
-    retry: {
-      maxAttempts: 3,
-      backoffMs: 1000,
-      backoffMultiplier: 2
+  "bindings": "auto",
+  "explicitBindings": [
+    {
+      "agentId": "screener",
+      "match": {
+        "source": "job_board"
+      }
     },
-    
-    // Caching
-    cache: {
-      enabled: true,
-      ttlMinutes: 60,
-      // Don't re-process same resume + JD combination
-      dedupeByResumeAndJd: true
+    {
+      "agentId": "screener",
+      "match": {
+        "source": "manual_upload"
+      }
+    },
+    {
+      "agentId": "screener",
+      "match": {
+        "source": "email_ingest"
+      }
+    },
+    {
+      "agentId": "evaluator",
+      "match": {
+        "stage": "technical_review"
+      }
+    },
+    {
+      "agentId": "final",
+      "match": {
+        "stage": "final_decision"
+      }
+    }
+  ],
+  "ruleScoring": {
+    "enabled": true,
+    "defaultMode": "hybrid",
+    "aiTopN": 20,
+    "aiConcurrency": 5,
+    "minRuleScoreForAi": 50
+  },
+  "global": {
+    "maxCostPerRun": 5,
+    "maxErrorRate": 0.1,
+    "retry": {
+      "maxAttempts": 3,
+      "backoffMs": 1000,
+      "backoffMultiplier": 2
+    },
+    "cache": {
+      "enabled": true,
+      "ttlMinutes": 60,
+      "dedupeByResumeAndJd": true
     }
   },
-  
-  // Prompt templates (reference files in config/prompts/)
-  prompts: {
-    screener: "config/prompts/resume-screener.txt",
-    evaluator: "config/prompts/resume-evaluator.txt",
-    final: "config/prompts/resume-final.txt"
+  "prompts": {
+    "screener": "config/prompts/resume-screener.txt",
+    "evaluator": "config/prompts/resume-evaluator.txt",
+    "final": "config/prompts/resume-final.txt"
   }
 }

--- a/config/resume/custom-keywords.json5
+++ b/config/resume/custom-keywords.json5
@@ -1,0 +1,9 @@
+{
+  tags: [
+    // Custom keyword tags added by user via settings
+    // { id: "custom-1", keyword: "激光切割", english: "laser cutting", category: "custom" }
+  ],
+  categories: [
+    { id: "custom", name: "自定义", icon: "⚙️" }
+  ]
+}

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -45,6 +45,14 @@ export const USER_PROMPT_TEMPLATE = `请分析以下候选人与职位的匹配�
   "summary": "中文总结"
 }`;
 
+export function buildKeywordRequirements(keywords: string[]): string {
+    return `候选人需具备以下关键技能/经验:\n${keywords.map((keyword) => `- ${keyword}`).join("\n")}`;
+}
+
+export function buildKeywordMatchingRules(keywords: string[]): string {
+    return `根据候选人与以下关键词的匹配程度评分。关键词越相关评分越高。\n关键词: ${keywords.join(", ")}`;
+}
+
 export function getAiApiKey(): string | undefined {
     return process.env.AI_API_KEY || process.env.OPENAI_API_KEY || undefined;
 }

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -80,9 +80,10 @@ export default defineSchema({
 
     analysis_tasks: defineTable({
         config: v.object({
-            jobDescriptionId: v.string(),
+            jobDescriptionId: v.optional(v.string()),
             jobDescriptionTitle: v.optional(v.string()),
             jobDescriptionContent: v.optional(v.string()),
+            keywords: v.optional(v.array(v.string())),
             sample: v.optional(v.string()),
             resumeCount: v.number(),
         }),

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -152,9 +152,12 @@ async def process_task(task, client: httpx.AsyncClient):
                     context_id=context_id,
                 )
                 final_url = await eval_json(cdp_client, "window.location.href", context_id=context_id)
-                raise CDPError(
-                    f"No resumes extracted for keyword='{keyword}' location='{location}'. "
-                    f"url='{final_url}' status={final_status}"
+                logger.warning(
+                    "No resumes extracted for keyword='%s' location='%s'. url='%s' status=%s",
+                    keyword,
+                    location,
+                    final_url,
+                    final_status,
                 )
             
             # Submit results


### PR DESCRIPTION
Summary
- Default the resume search location to 广东 and streamline QuickStart into a flowing input section without boxed cards
- Replace the keyword text input with a toggleable chip experience powered by the new industry keyword hook and component
- Remove the redundant ResumeList cards/search controls and unify the layout with inline controls and the repositioned JD selector
- Update localized strings for the new keyword UI

Testing
- Not run (not requested)