### PR TITLE
Implement system-level locale environment variables for AI and UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,4 +15,6 @@ DEBUG=true
 TIMEZONE=Asia/Hong_Kong
 TZ=Asia/Hong_Kong
 VITE_APP_TIMEZONE=Asia/Hong_Kong
-DEFAULT_LOCALE=zh-Hant
+# Language / Locale (BCP47 format: zh-Hans, zh-Hant, en)
+AI_OUTPUT_LOCALE=zh-Hans      # AI analysis output language (resume system)
+VITE_DEFAULT_LOCALE=zh-Hans   # Frontend UI / static content default language

--- a/apps/api/src/services/ai-matching.ts
+++ b/apps/api/src/services/ai-matching.ts
@@ -12,6 +12,7 @@ import JSON5 from "json5";
 
 import { aiConfig, validateAIConfig, getMaskedApiKey } from "./ai-config.js";
 import { findProjectRoot } from "./db.js";
+import { localeToNaturalLanguage, resolveAIOutputLocale } from "./locale-utils.js";
 
 // Types
 export interface MatchingRequest {
@@ -131,6 +132,11 @@ const SYSTEM_PROMPT = `你是一个专业的HR助手，专门帮助筛选精密�
 - 0-49分：不匹配，基本要求不满足
 
 你必须严格按照JSON格式返回结果，不要包含任何其他文字。`;
+
+function buildSystemPrompt(locale: string): string {
+    const naturalLanguage = localeToNaturalLanguage(locale);
+    return `${SYSTEM_PROMPT}\nPlease respond entirely in ${naturalLanguage}.`;
+}
 
 const USER_PROMPT_TEMPLATE = `请分析以下候选人与职位的匹配度：
 
@@ -267,9 +273,11 @@ export class AIMatchingService {
             };
         }
 
+        const aiOutputLocale = resolveAIOutputLocale();
+        const systemPrompt = buildSystemPrompt(aiOutputLocale);
         const userPrompt = this.buildPrompt(request);
         const messages = [
-            { role: "system", content: SYSTEM_PROMPT },
+            { role: "system", content: systemPrompt },
             { role: "user", content: userPrompt },
         ];
 

--- a/apps/api/src/services/locale-utils.ts
+++ b/apps/api/src/services/locale-utils.ts
@@ -1,0 +1,18 @@
+const DEFAULT_AI_OUTPUT_LOCALE = "zh-Hans";
+
+const LOCALE_TO_NATURAL: Record<string, string> = {
+    "zh-Hans": "Simplified Chinese",
+    "zh-Hant": "Traditional Chinese",
+    en: "English",
+    ja: "Japanese",
+    ko: "Korean",
+};
+
+export function localeToNaturalLanguage(locale: string): string {
+    return LOCALE_TO_NATURAL[locale] ?? locale;
+}
+
+export function resolveAIOutputLocale(): string {
+    const locale = process.env.AI_OUTPUT_LOCALE?.trim();
+    return locale && locale.length > 0 ? locale : DEFAULT_AI_OUTPUT_LOCALE;
+}

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -16,12 +16,22 @@ const resources = {
   en: { translation: en },
 }
 
+const SUPPORTED_LOCALES = ['zh-Hans', 'zh-Hant', 'en']
+type SupportedLocale = (typeof SUPPORTED_LOCALES)[number]
+
+function isSupportedLocale(locale: string | undefined): locale is SupportedLocale {
+  return typeof locale === 'string' && SUPPORTED_LOCALES.includes(locale)
+}
+
+const envLocale = import.meta.env.VITE_DEFAULT_LOCALE
+const defaultLocale: SupportedLocale = isSupportedLocale(envLocale) ? envLocale : 'zh-Hans'
+
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     resources,
-    fallbackLng: 'zh-Hant',
+    fallbackLng: defaultLocale,
     debug: import.meta.env.DEV,
     interpolation: {
       escapeValue: false,

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -10,6 +10,31 @@ export const SYSTEM_PROMPT = `你是一个专业的HR助手，专门帮助筛选
 4. 错误示例: "score": "85", "score": "eighty-five"
 5. 如果无法确切评分，请基于现有信息估算一个数字。`;
 
+const DEFAULT_AI_OUTPUT_LOCALE = "zh-Hans";
+
+const LOCALE_TO_NATURAL: Record<string, string> = {
+    "zh-Hans": "Simplified Chinese",
+    "zh-Hant": "Traditional Chinese",
+    en: "English",
+    ja: "Japanese",
+    ko: "Korean",
+};
+
+// For Convex deployments, set AI_OUTPUT_LOCALE via the dashboard or `convex env set`.
+export function resolveAIOutputLocale(): string {
+    const locale = process.env.AI_OUTPUT_LOCALE?.trim();
+    return locale && locale.length > 0 ? locale : DEFAULT_AI_OUTPUT_LOCALE;
+}
+
+export function localeToNaturalLanguage(locale: string): string {
+    return LOCALE_TO_NATURAL[locale] ?? locale;
+}
+
+export function buildSystemPrompt(locale: string): string {
+    const naturalLanguage = localeToNaturalLanguage(locale);
+    return `${SYSTEM_PROMPT}\nPlease respond entirely in ${naturalLanguage}.`;
+}
+
 export const USER_PROMPT_TEMPLATE = `请分析以下候选人与职位的匹配度：
 
 ## 职位信息
@@ -178,7 +203,7 @@ export const analyzeResume = action({
             .replace("{summary}", norm.summary);
 
         const messages = [
-            { role: "system", content: SYSTEM_PROMPT },
+            { role: "system", content: buildSystemPrompt(resolveAIOutputLocale()) },
             { role: "user", content: prompt },
         ];
 


### PR DESCRIPTION
## Task

# Plan: Two System-Level Locale Environment Variables

## Goal

Introduce two environment variables using BCP47 format (`zh-Hans`, `zh-Hant`, `en`) with default `zh-Hans`:

| Variable | Scope | Default | Purpose |
|----------|-------|---------|---------|
| `AI_OUTPUT_LOCALE` | Resume AI system only | `zh-Hans` | Controls language of AI analysis output (prompts, responses) for resume matching |
| `VITE_DEFAULT_LOCALE` | Frontend UI + static content | `zh-Hans` | Controls i18next fallback language and static site default locale |

**Out of scope:** trendradar module's `config.yaml` `ai_analysis.language` — unchanged.

---

## Task 1: BCP47-to-Natural-Language Mapping Utility [INDEPENDENT]

**Files:**

- `apps/api/src/services/locale-utils.ts` (new)

**What:**
Create a small utility that maps BCP47 codes to natural language names for AI prompts:

- `zh-Hans` → `Simplified Chinese`
- `zh-Hant` → `Traditional Chinese`
- `en` → `English`
- Fallback: return locale code as-is for unknown values

```typescript
const LOCALE_TO_NATURAL: Record<string, string> = {
  'zh-Hans': 'Simplified Chinese',
  'zh-Hant': 'Traditional Chinese',
  'en': 'English',
  'ja': 'Japanese',
  'ko': 'Korean',
}

export function localeToNaturalLanguage(locale: string): string {
  return LOCALE_TO_NATURAL[locale] ?? locale
}

export function resolveAIOutputLocale(): string {
  return process.env.AI_OUTPUT_LOCALE || 'zh-Hans'
}
```

**Conflict Risk:** none
**Verification:** Unit-level — import and call with known values

---

## Task 2: Wire `AI_OUTPUT_LOCALE` into Resume AI Matching [DEPENDS: Task 1]

**Files:**

- `apps/api/src/services/ai-matching.ts` (edit)

**What:**

1. Import `resolveAIOutputLocale` and `localeToNaturalLanguage` from locale-utils
2. Currently `SYSTEM_PROMPT` and `USER_PROMPT_TEMPLATE` are hardcoded Chinese constants (lines \~124-160)
3. Add a language instruction line to the system prompt so the LLM responds in the requested language:

- Append to system prompt: `Please respond entirely in {naturalLanguage}.`

4. Keep the existing Chinese prompt text as-is (it works as the base prompt) — the language instruction overrides output language
5. Read `AI_OUTPUT_LOCALE` at request time (not module load) so it can be changed without restart

**Conflict Risk:** `ai-matching.ts`
**Verification:** Set `AI_OUTPUT_LOCALE=en`, call POST `/api/resumes/match`, verify AI response is in English

---

## Task 3: Wire `AI_OUTPUT_LOCALE` into Convex AI Backend [INDEPENDENT from Task 2, DEPENDS: Task 1 pattern]

**Files:**

- `packages/convex/convex/analyze.ts` (edit)

**What:**

1. The Convex backend has its own `SYSTEM_PROMPT` and `USER_PROMPT_TEMPLATE` (hardcoded Chinese)
2. Add the same language instruction approach: append language directive to system prompt
3. Convex environment variables are set via Convex dashboard or `convex env set` — document that `AI_OUTPUT_LOCALE` needs to be set there if using Convex backend
4. Since Convex uses `process.env` differently, read from Convex environment

**Conflict Risk:** `analyze.ts`
**Verification:** Set env in Convex, run analysis task, verify output language

---

## Task 4: Wire `VITE_DEFAULT_LOCALE` into Frontend i18n [INDEPENDENT]

**Files:**

- `apps/web/src/i18n/index.ts` (edit)

**What:**

1. Currently `fallbackLng: 'zh-Hant'` is hardcoded
2. Change to read from `import.meta.env.VITE_DEFAULT_LOCALE`
3. Validate the value is one of supported locales (`zh-Hans`, `zh-Hant`, `en`), fallback to `zh-Hans`
4. Also use this as the default when browser language detection finds no match

Before:

```typescript
i18n.init({
  fallbackLng: 'zh-Hant',
  ...
})
```

After:

```typescript
const SUPPORTED_LOCALES = ['zh-Hans', 'zh-Hant', 'en'] as const
const envLocale = import.meta.env.VITE_DEFAULT_LOCALE
const defaultLocale = SUPPORTED_LOCALES.includes(envLocale) ? envLocale : 'zh-Hans'

i18n.init({
  fallbackLng: defaultLocale,
  ...
})
```

**Conflict Risk:** `i18n/index.ts`
**Verification:** Set `VITE_DEFAULT_LOCALE=en` in `.env.local`, start dev server, verify UI defaults to English

---

## Task 5: Wire `VITE_DEFAULT_LOCALE` into Static Site Build [INDEPENDENT]

**Files:**

- `scripts/i18n/build_static.py` (edit)

**What:**

1. Currently builds all 3 locales with no default preference
2. Read `VITE_DEFAULT_LOCALE` (or `DEFAULT_LOCALE` as fallback) from environment
3. When building, set this locale's output as the root `index.html` (redirect or copy)
4. This is a minor enhancement — the default locale's build becomes the root static site entry point

**Conflict Risk:** `build_static.py`
**Verification:** `VITE_DEFAULT_LOCALE=zh-Hans make build-static`, verify root index.html uses zh-Hans

---

## Task 6: Update `.env.example` and Documentation [INDEPENDENT]

**Files:**

- `.env.example` (edit)

**What:**

1. Replace `DEFAULT_LOCALE=zh-Hant` with `VITE_DEFAULT_LOCALE=zh-Hans`
2. Add `AI_OUTPUT_LOCALE=zh-Hans`
3. Add comments explaining both variables

```env
# Language / Locale (BCP47 format: zh-Hans, zh-Hant, en)
AI_OUTPUT_LOCALE=zh-Hans          # AI analysis output language (resume system)
VITE_DEFAULT_LOCALE=zh-Hans       # Frontend UI / static content default language
```

**Conflict Risk:** `.env.example`
**Verification:** Visual review

---

## Verification Plan

1. `make check` — ensure no type errors or lint failures
2. Set `AI_OUTPUT_LOCALE=en` + `VITE_DEFAULT_LOCALE=en` in environment
3. `make dev-web` — verify frontend defaults to English UI
4. Call resume match API — verify AI output is in English
5. Unset both variables — verify defaults to `zh-Hans` (Simplified Chinese)
6. `make build-static` — verify static site respects locale setting

Implement all tasks

## PR Review Summary
- What Changed:
  - Introduced `AI_OUTPUT_LOCALE` environment variable to control the output language of AI analysis for the resume matching system (API and Convex backend), defaulting to `zh-Hans`.
  - Created `apps/api/src/services/locale-utils.ts` to map BCP47 locale codes (e.g., `zh-Hans`, `en`) to natural language names and resolve `AI_OUTPUT_LOCALE`.
  - Modified `apps/api/src/services/ai-matching.ts` to import `locale-utils` and append a language instruction (`Please respond entirely in {naturalLanguage}.`) to the AI's system prompt based on `AI_OUTPUT_LOCALE`.
  - Implemented similar logic directly in `packages/convex/convex/analyze.ts` for the Convex backend, including its own `resolveAIOutputLocale`, `localeToNaturalLanguage`, and `buildSystemPrompt`.
  - Introduced `VITE_DEFAULT_LOCALE` environment variable for frontend i18n and static site generation, defaulting to `zh-Hans`.
  - Updated `apps/web/src/i18n/index.ts` to read `VITE_DEFAULT_LOCALE` (with validation and fallback) for `fallbackLng` instead of a hardcoded value.
  - Modified `scripts/i18n/build_static.py` to use `VITE_DEFAULT_LOCALE` (or `DEFAULT_LOCALE` as fallback) when generating the root `index.html` redirect, removing client-side language detection.
  - Updated `.env.example` to include `AI_OUTPUT_LOCALE` and `VITE_DEFAULT_LOCALE` with documentation.
- Review Focus:
  - Verify the language instruction `Please respond entirely in {naturalLanguage}.` correctly influences AI model output for both the `api` and `convex` services.
  - Confirm that `VITE_DEFAULT_LOCALE` is correctly read and applied in `apps/web/src/i18n/index.ts` and `scripts/i18n/build_static.py` (especially the environment variable precedence logic).
  - Ensure the duplication of locale utility functions in `apps/api` and `packages/convex` is acceptable for the current scope.
- Test Plan:
  - Run `make check` to ensure no type errors or lint failures.
  - Set `AI_OUTPUT_LOCALE=en` and `VITE_DEFAULT_LOCALE=en` in your environment.
  - Start the dev server (`make dev-web`) and verify the frontend UI defaults to English.
  - Call the resume match API (`POST /api/resumes/match`) and verify the AI response is in English.
  - For Convex, set `AI_OUTPUT_LOCALE=en` in the Convex dashboard/env, run an analysis task, and verify output language.
  - Unset both `AI_OUTPUT_LOCALE` and `VITE_DEFAULT_LOCALE` and verify the system defaults to `zh-Hans` (Simplified Chinese) for both UI and AI output.
  - Run `make build-static` and verify the static site's root `index.html` redirects to the expected default locale.