### PR TITLE
# Plan: Refactor Repo Docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ make help             # Show all available commands
 
 All other parameters have smart defaults and are auto-configured.
 
-### Automated Workflow (3-Step Flow)
+### Automated Workflow (Two-Path Architecture)
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -208,43 +208,50 @@ All other parameters have smart defaults and are auto-configured.
 └─────────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                    STEP 1: AUTO-CONFIGURE (No User Action)                   │
-│  ┌─────────────────────────────────────────────────────────────────────┐   │
-│  │ 1. Match keywords to Job Description (JD) from library              │   │
-│  │ 2. Create/resume Session with location + keywords                   │   │
-│  │ 3. Set default filters (experience, education, salary ranges)       │   │
-│  │ 4. Configure AI agents (screener → evaluator → final)               │   │
-│  │ 5. Set notification preferences (WeChat Work, Email)                │   │
-│  └─────────────────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│               STEP 2: AUTO-COLLECT & MATCH (Runs Automatically)              │
-│  ┌─────────────────────────────────────────────────────────────────────┐   │
-│  │ 1. Browser Extension crawls job board with location + keywords      │   │
-│  │ 2. Extract resumes → normalize → deduplicate                        │   │
-│  │ 3. AI Screener: Initial pass (batch, parallel)                      │   │
-│  │ 4. AI Evaluator: Detailed scoring (top candidates only)             │   │
-│  │ 5. Store results with match scores + recommendations                │   │
-│  └─────────────────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                STEP 3: REVIEW & ACT (HR Human-in-the-Loop)                   │
-│  ┌─────────────────────────────────────────────────────────────────────┐   │
-│  │ HR sees: Pre-sorted candidates ranked by AI match score             │   │
-│  │                                                                       │   │
-│  │ Actions: ✅ Shortlist  ❌ Reject  📞 Contact  📝 Add Notes           │   │
-│  │                                                                       │   │
-│  │ Smart Features:                                                       │   │
-│  │ • One-click bulk actions (shortlist all 80+ score)                  │   │
-│  │ • Auto-send notifications for shortlisted candidates                │   │
-│  │ • AI-generated outreach messages (optional)                         │   │
-│  └─────────────────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────────────┘
+INGEST PATH (background, async, on new resume)
+================================================
+New Resume arrives
+       |
+       v
+Background Agent reads:
+  - config/resume/skills.md    (skill taxonomy, synonyms, signals)
+  - config/job-descriptions/*  (all active JDs)
+       |
+       v
+Pre-compute and store:
+  1. buildSearchText()          (CJK-boundary-aware)
+  2. extractIndustryTags()      (from skills.md taxonomy)
+  3. expandSynonymHits()        (from skills.md synonym tables)
+  4. ruleScore(ALL active JDs)  (pre-score against every JD)
+  5. detectExperienceLevel()    (from skills.md signals)
+       |
+       v
+Resume stored in Convex with all pre-computed fields
+  => Ready for instant queries
+
+
+QUERY PATH (user-facing, < 2s, zero LLM)
+================================================
+User: "CNC 东莞"
+       |
+       v
+Convex searchIndex("CNC 东莞")
+  + filter by pre-computed tags/location
+  + sort by pre-computed ruleScores[activeJD]
+       |
+       v
+Ranked results returned instantly
+
+
+LEARNING PATH (append, periodic)
+================================================
+HR feedback (shortlist/reject patterns)
+       |
+       v
+Append to skills.md log section
+       |
+       v
+Next ingest cycle picks up new patterns
 ```
 
 ### Configuration System (Edit When Needed)
@@ -332,6 +339,32 @@ Quick filter presets for common patterns:
 }
 ```
 
+#### 5. Skills Knowledge (`config/resume/skills.md`)
+
+Curated knowledge used by the background ingest agent for deterministic matching:
+
+- Skill taxonomy by domain/function
+- Synonym tables and alias expansion rules
+- Experience-level signals (e.g., junior/mid/senior indicators)
+- Industry context and weighting hints
+- Append-only learning log section for HR feedback patterns
+
+```markdown
+# Skills Knowledge
+
+## Taxonomy
+- cnc-machining: [CNC, 数控, 加工中心, 车铣复合]
+
+## Synonyms
+- 车床销售: [机床销售, 数控销售, CNC销售]
+
+## Experience Signals
+- senior: [团队管理, 大客户, 渠道拓展]
+
+## Learning Log (Append Only)
+- 2026-02-10: shortlist pattern -> STAR + 渠道客户优先
+```
+
 ### UI Design (Minimal Interaction)
 
 #### Quick Start Panel (Default View)
@@ -388,31 +421,22 @@ Quick filter presets for common patterns:
 | `/api/resumes/bulk-action` | POST | Bulk shortlist/reject/contact |
 | `/api/notifications/test` | POST | Test notification channel |
 
-### Implementation Phases
+### Implementation Status
 
-#### Phase 1: Core Automation (Current Focus)
-- [x] Basic resume collection + AI matching
-- [ ] Search Profile system
-- [ ] Auto-match JD from keywords
-- [ ] Filter presets
-- [ ] Simplified Quick Start UI
+#### Completed (Phases 1-22)
+- [x] Foundation through Production Polish (Phases 1-21)
+- [x] E2E Testing, CI Pipeline, Session Memory, JD Enhancements (Phase 22)
 
-#### Phase 2: Bulk Actions & Notifications
-- [ ] Bulk shortlist/reject/contact
-- [ ] Auto-notify shortlisted candidates
-- [ ] AI-generated outreach messages
-- [ ] WeChat Work integration
+#### In Progress
+- [ ] CNC tokenization fix (`addScriptBoundarySpaces` — plan ready)
 
-#### Phase 3: Scheduling & Monitoring
-- [ ] Scheduled crawl jobs
-- [ ] Dashboard with crawl status
-- [ ] Alert on new high-match candidates
-- [ ] Historical analytics
-
-#### Phase 4: Plugin Generalization
-- [ ] Extract common plugin patterns
-- [ ] Plugin configuration UI
-- [ ] Plugin marketplace (internal)
+#### Next: Memory-First Background Agent (Phases M1-M6)
+- [ ] M1: Create `config/resume/skills.md` knowledge file
+- [ ] M2: skills.md parser service (`skills-knowledge.ts`)
+- [ ] M3: Background ingest agent (pre-compute on new resume arrival)
+- [ ] M4: Query path uses pre-computed fields (< 2s, zero LLM)
+- [ ] M5: Backfill existing resumes through ingest agent
+- [ ] M6: Learning feedback loop (append HR patterns to skills.md)
 
 ---
 
@@ -470,7 +494,8 @@ config/
 │   ├── agents.json5           # AI agent configuration
 │   ├── session.json5          # Session settings
 │   ├── filter-presets.json5   # Filter presets
-│   └── skills_words.txt       # Skill keywords
+│   ├── skills_words.txt       # Skill keywords
+│   └── skills.md              # Curated skill taxonomy, synonyms, signals
 ├── job-descriptions/
 │   ├── README.md
 │   ├── lathe-sales.md         # Example with auto_match config
@@ -496,6 +521,8 @@ apps/
 │       ├── job-description-service.ts
 │       ├── search-profile-service.ts  # NEW
 │       ├── auto-match-service.ts      # NEW
+│       ├── skills-knowledge.ts        # skills.md parser
+│       ├── resume-ingest-agent.ts     # Background ingest agent
 │       └── notification-service.ts    # NEW
 ├── web/src/
 │   ├── components/
@@ -584,8 +611,8 @@ Structure each task with:
 1. Match keywords → best Job Description
 2. Apply default filters based on JD
 3. Collect resumes from job boards
-4. Run multi-stage AI screening
-5. Sort by match score
+4. Background agent pre-scores against all JDs using skills.md knowledge
+5. Sort by pre-computed match score (instant, no LLM at query time)
 6. Send notifications on actions
 
 ### When Users Want More Control
@@ -594,5 +621,6 @@ Structure each task with:
 - Customize filter criteria
 - Set up scheduled runs
 - Configure notification channels
+- Edit skills.md to add domain synonyms and experience signals
 
 This design minimizes the "human-in-the-loop" burden while keeping full configurability available when needed.

--- a/config/resume/README.md
+++ b/config/resume/README.md
@@ -1,12 +1,10 @@
-# Resume Screening Config (Phase 1 Prep)
+# Resume Screening Config
 
-This folder contains resume-screening configuration stubs for Phase 1 preparation.
+This folder contains active runtime configuration for resume screening.
 
 Files:
-- session.json5: session scope + reset policy for per-candidate context.
-- agents.json5: multi-agent routing list and bindings.
-- skills_words.txt: keyword groups for skill filtering (TrendRadar-style syntax).
-
-Notes:
-- These files are not yet wired into runtime; they serve as a spec for Phase 1.
-- Keep ASCII only for now; replace placeholder keywords with zh-Hans later.
+- agents.json5: AI agent pipeline config (screener/evaluator/final).
+- session.json5: Session scope and reset policy.
+- filter-presets.json5: Quick filter bundles.
+- skills_words.txt: Legacy keyword groups (used by parser.ts).
+- skills.md: Curated skill taxonomy, synonyms, experience signals (used by background ingest agent).


### PR DESCRIPTION
## Task

# Plan: Refactor Repo Docs to Sync with Memory-First Dev Roadmap

## Context

The Obsidian vault now has the updated trends dev roadmap reflecting the **memory-first background agent** approach (skills.md + pre-computed fields at ingest time, < 2s query path, no RAG/embeddings). Two repo docs still describe the old phase-based roadmap and need to be brought in sync. This is a **docs-only** change — no code files modified.

---

## Files to Modify (2 files only)

| # | File | What's Wrong | What to Do |
|---|------|-------------|------------|
| 1 | `CLAUDE.md` | Lines 198-248: old 3-step batch workflow. Lines 391-415: old Phase 1-4 roadmap. Lines 465-510: file tree missing `skills.md` + new services. Lines 575-598: summary says "Run multi-stage AI screening" at query time. | Update to two-path architecture, replace phases with completed + M1-M6, add new files to tree, fix summary. |
| 2 | `config/resume/README.md` | Says "Phase 1 Prep", files "not yet wired into runtime" | Update to current state: files are live, add `skills.md` reference. |

**No other files need changes.** All other READMEs (AGENTS.md, config/job-descriptions, config/search-profiles, config/notifications, config/industry-data, dev-docs/qa/\*, browser-extension) are already current.

---

## Task 1: Update CLAUDE.md — Resume Screening Section

### 1a. Replace 3-Step Workflow (lines 198-248)

Replace the STEP 1/2/3 batch diagram with the **two-path architecture**:

```
INGEST PATH (background, async, on new resume)
================================================
New Resume arrives
       |
       v
Background Agent reads:
  - config/resume/skills.md    (skill taxonomy, synonyms, signals)
  - config/job-descriptions/*  (all active JDs)
       |
       v
Pre-compute and store:
  1. buildSearchText()          (CJK-boundary-aware)
  2. extractIndustryTags()      (from skills.md taxonomy)
  3. expandSynonymHits()        (from skills.md synonym tables)
  4. ruleScore(ALL active JDs)  (pre-score against every JD)
  5. detectExperienceLevel()    (from skills.md signals)
       |
       v
Resume stored in Convex with all pre-computed fields
  => Ready for instant queries


QUERY PATH (user-facing, < 2s, zero LLM)
================================================
User: "CNC 东莞"
       |
       v
Convex searchIndex("CNC 东莞")
  + filter by pre-computed tags/location
  + sort by pre-computed ruleScores[activeJD]
       |
       v
Ranked results returned instantly


LEARNING PATH (append, periodic)
================================================
HR feedback (shortlist/reject patterns)
       |
       v
Append to skills.md log section
       |
       v
Next ingest cycle picks up new patterns
```

Keep the USER INPUT box unchanged (location + keywords + JD auto-select).

### 1b. Add skills.md Config Section (after line 333)

Add section "5. Skills Knowledge (`config/resume/skills.md`)" showing:

- Curated skill taxonomy, synonym tables, experience signals, industry context
- Append log section for learnings
- Brief example of structure

### 1c. Replace Implementation Phases (lines 391-415)

Replace old Phase 1-4 with:

```markdown
### Implementation Status

#### Completed (Phases 1-22)
- [x] Foundation through Production Polish (Phases 1-21)
- [x] E2E Testing, CI Pipeline, Session Memory, JD Enhancements (Phase 22)

#### In Progress
- [ ] CNC tokenization fix (`addScriptBoundarySpaces` — plan ready)

#### Next: Memory-First Background Agent (Phases M1-M6)
- [ ] M1: Create `config/resume/skills.md` knowledge file
- [ ] M2: skills.md parser service (`skills-knowledge.ts`)
- [ ] M3: Background ingest agent (pre-compute on new resume arrival)
- [ ] M4: Query path uses pre-computed fields (< 2s, zero LLM)
- [ ] M5: Backfill existing resumes through ingest agent
- [ ] M6: Learning feedback loop (append HR patterns to skills.md)
```

### 1d. Update File Structure (lines 465-510)

Add to `config/resume/`:

```
│   ├── skills.md              # Curated skill taxonomy, synonyms, signals
```

Add to `apps/api/src/services/`:

```
│       ├── skills-knowledge.ts       # skills.md parser
│       ├── resume-ingest-agent.ts    # Background ingest agent
```

### 1e. Update Summary (lines 575-598)

Change "What System Does Automatically" item 4 from:

- "Run multi-stage AI screening"

To:

- "Background agent pre-scores against all JDs using skills.md knowledge"
- "Sort by pre-computed match score (instant, no LLM at query time)"

Add under "When Users Want More Control":

- "Edit skills.md to add domain synonyms and experience signals"

---

## Task 2: Update config/resume/README.md

Replace the entire 13-line file with updated content reflecting current state:

- Remove "Phase 1 Prep" framing
- Remove "not yet wired into runtime"
- List all files with current descriptions:
- `agents.json5` — AI agent pipeline config (screener/evaluator/final)
- `session.json5` — Session scope and reset policy
- `filter-presets.json5` — Quick filter bundles
- `skills_words.txt` — Legacy keyword groups (used by parser.ts)
- `skills.md` — **NEW** Curated skill taxonomy, synonyms, experience signals (used by background ingest agent)

---

## Verification

1. Read modified files to confirm consistency with the Obsidian roadmap note
2. `make check-node` — ensure no tooling breaks from docs changes
3. This is docs-only — no runtime behavior changes

## PR Review Summary\n- **What Changed**: This is a **docs-only** update to align the repository with the **memory-first background agent** roadmap. It replaces the legacy 3-step batch workflow with a **Two-Path Architecture** (Async Ingest for pre-computing scores vs. <2s Query Path), updates implementation status (Phases 1-22 completed), and documents the new `skills.md` knowledge configuration.\n- **Review Focus**: Confirm the accuracy of the new architecture diagram in `CLAUDE.md` and ensure the updated file tree correctly anticipates the planned services (`skills-knowledge.ts` and `resume-ingest-agent.ts`).\n- **Test Plan**: Since no code was modified, validation is limited to a documentation audit. Verify Markdown rendering and run `make check-node` to ensure no documentation-related tooling issues arise.\n- **Follow-ups**: The next phase involves the physical creation of `config/resume/skills.md` and the associated ingest services defined in the new roadmap.