### PR TITLE
Implement teh following plan; #

### DIFF
--- a/apps/api/src/services/skills-knowledge.test.ts
+++ b/apps/api/src/services/skills-knowledge.test.ts
@@ -1,0 +1,369 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { SkillsKnowledgeService } from "./skills-knowledge";
+
+const TEST_SKILLS_MD = `---
+version: 1
+updated_at: '2026-02-21'
+description: Test skills knowledge file
+---
+
+# Skills Knowledge
+
+## Domain Taxonomy
+
+### machinery
+- displayName: Machinery
+- keywords: 机床, 车床, lathe, machining
+
+### cnc
+- displayName: CNC
+- keywords: cnc, 数控, fanuc, star
+
+### sales
+- displayName: Sales
+- keywords: 销售, 客户, sales, account
+
+## Synonym Table
+
+- 机床: 机械设备, 加工设备
+- 车床: CNC车床, 数控车床
+- 数控: CNC, Computer Numerical Control
+- 销售: 业务, 商务
+
+## Experience Signals
+
+### senior
+- displayName: Senior Level
+- keywords: 团队管理, 大客户, manager, lead
+
+### mid
+- displayName: Mid Level
+- keywords: 独立, 熟练, specialist
+
+### junior
+- displayName: Junior Level
+- keywords: 应届, 实习, assistant, intern
+
+## Company Patterns
+
+- FANUC (aliases: 发那科, Fanuc)
+- STAR (aliases: 津上, Star Micronics)
+- BROTHER (aliases: 兄弟, Brother Industries)
+
+## Industry Context
+
+### CNC Machining Domain
+CNC machining involves automated control of machine tools. Key brands include FANUC and STAR.
+
+### Sales and Business Development
+B2B sales requires technical knowledge and customer relationship management.
+
+## Exclusion Patterns
+
+- exclude: ad, promo, 广告, spam
+
+## Learning Log (Append Only)
+
+- 2026-02-10: STAR + 渠道客户优先
+- 2026-02-15: 车床经验5年+更匹配
+`;
+
+function createFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "skills-knowledge-"));
+  fs.mkdirSync(path.join(root, "config", "resume"), { recursive: true });
+
+  fs.writeFileSync(path.join(root, "config", "resume", "skills.md"), TEST_SKILLS_MD, "utf8");
+
+  // Add marker files for findProjectRoot
+  fs.writeFileSync(path.join(root, "pyproject.toml"), "", "utf8");
+  fs.mkdirSync(path.join(root, "output"), { recursive: true });
+
+  return root;
+}
+
+function cleanupFixtureRoot(root: string): void {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+describe("SkillsKnowledgeService", () => {
+  it("parses domain taxonomy correctly", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+      const taxonomy = service.getIndustryTaxonomy();
+
+      expect(taxonomy).toHaveLength(3);
+
+      const machinery = taxonomy.find((d) => d.tag === "machinery");
+      expect(machinery).toBeDefined();
+      expect(machinery?.displayName).toBe("Machinery");
+      expect(machinery?.keywords).toContain("机床");
+      expect(machinery?.keywords).toContain("车床");
+      expect(machinery?.keywords).toContain("lathe");
+
+      const cnc = taxonomy.find((d) => d.tag === "cnc");
+      expect(cnc).toBeDefined();
+      expect(cnc?.displayName).toBe("CNC");
+      expect(cnc?.keywords).toContain("cnc");
+      expect(cnc?.keywords).toContain("fanuc");
+
+      const sales = taxonomy.find((d) => d.tag === "sales");
+      expect(sales).toBeDefined();
+      expect(sales?.displayName).toBe("Sales");
+      expect(sales?.keywords).toContain("销售");
+      expect(sales?.keywords).toContain("sales");
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("parses synonym table and returns variant → canonical mapping", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+      const synonymMap = service.getSynonymTable();
+
+      expect(synonymMap.get("机械设备")).toBe("机床");
+      expect(synonymMap.get("加工设备")).toBe("机床");
+      expect(synonymMap.get("cnc车床")).toBe("车床");
+      expect(synonymMap.get("数控车床")).toBe("车床");
+      expect(synonymMap.get("cnc")).toBe("数控");
+      expect(synonymMap.get("业务")).toBe("销售");
+
+      // Canonical terms should map to themselves
+      expect(synonymMap.get("机床")).toBe("机床");
+      expect(synonymMap.get("销售")).toBe("销售");
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("getSkillVocabulary returns union of all keywords and synonyms", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+      const vocab = service.getSkillVocabulary();
+
+      // Domain keywords
+      expect(vocab.has("机床")).toBe(true);
+      expect(vocab.has("车床")).toBe(true);
+      expect(vocab.has("cnc")).toBe(true);
+      expect(vocab.has("销售")).toBe(true);
+
+      // Synonym variants
+      expect(vocab.has("机械设备")).toBe(true);
+      expect(vocab.has("cnc车床")).toBe(true);
+      expect(vocab.has("业务")).toBe(true);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("parses experience signals correctly", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+      const signals = service.getExperienceSignals();
+
+      expect(signals).toHaveLength(3);
+
+      const senior = signals.find((s) => s.level === "senior");
+      expect(senior).toBeDefined();
+      expect(senior?.displayName).toBe("Senior Level");
+      expect(senior?.keywords).toContain("团队管理");
+      expect(senior?.keywords).toContain("manager");
+
+      const mid = signals.find((s) => s.level === "mid");
+      expect(mid).toBeDefined();
+      expect(mid?.displayName).toBe("Mid Level");
+      expect(mid?.keywords).toContain("独立");
+
+      const junior = signals.find((s) => s.level === "junior");
+      expect(junior).toBeDefined();
+      expect(junior?.displayName).toBe("Junior Level");
+      expect(junior?.keywords).toContain("应届");
+      expect(junior?.keywords).toContain("intern");
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("parses company patterns with aliases", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+      const patterns = service.getCompanyPatterns();
+
+      expect(patterns).toHaveLength(3);
+
+      const fanuc = patterns.find((p) => p.name === "fanuc");
+      expect(fanuc).toBeDefined();
+      expect(fanuc?.aliases).toContain("发那科");
+      expect(fanuc?.allNames).toContain("fanuc");
+      expect(fanuc?.allNames).toContain("发那科");
+
+      const star = patterns.find((p) => p.name === "star");
+      expect(star).toBeDefined();
+      expect(star?.aliases).toContain("津上");
+      expect(star?.allNames).toContain("star");
+      expect(star?.allNames).toContain("star micronics");
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("getCompanyLookupSet includes all company names lowercased", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+      const lookup = service.getCompanyLookupSet();
+
+      expect(lookup.has("fanuc")).toBe(true);
+      expect(lookup.has("发那科")).toBe(true);
+      expect(lookup.has("star")).toBe(true);
+      expect(lookup.has("津上")).toBe(true);
+      expect(lookup.has("brother")).toBe(true);
+      expect(lookup.has("兄弟")).toBe(true);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("getIndustryContext returns formatted string", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+      const context = service.getIndustryContext();
+
+      expect(context).toContain("CNC Machining Domain");
+      expect(context).toContain("automated control");
+      expect(context).toContain("Sales and Business Development");
+      expect(context).toContain("customer relationship");
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("parses exclusion tokens", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+      const tokens = service.getExclusionTokens();
+
+      expect(tokens).toContain("ad");
+      expect(tokens).toContain("promo");
+      expect(tokens).toContain("广告");
+      expect(tokens).toContain("spam");
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("parses learning log entries", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+      const log = service.getLearningLog();
+
+      expect(log).toHaveLength(2);
+      expect(log[0].date).toBe("2026-02-10");
+      expect(log[0].observation).toBe("STAR + 渠道客户优先");
+      expect(log[1].date).toBe("2026-02-15");
+      expect(log[1].observation).toBe("车床经验5年+更匹配");
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("caches parsed data and clearCache invalidates it", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+
+      // First call parses and caches
+      const taxonomy1 = service.getIndustryTaxonomy();
+      expect(taxonomy1).toHaveLength(3);
+
+      // Second call uses cache (should be same reference)
+      const taxonomy2 = service.getIndustryTaxonomy();
+      expect(taxonomy2).toBe(taxonomy1);
+
+      // Clear cache
+      service.clearCache();
+
+      // Third call re-parses
+      const taxonomy3 = service.getIndustryTaxonomy();
+      expect(taxonomy3).toHaveLength(3);
+      expect(taxonomy3).not.toBe(taxonomy1);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("throws FileParseError for missing file", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "skills-missing-"));
+    fs.mkdirSync(path.join(root, "config", "resume"), { recursive: true });
+
+    // Add marker files but no skills.md
+    fs.writeFileSync(path.join(root, "pyproject.toml"), "", "utf8");
+    fs.mkdirSync(path.join(root, "output"), { recursive: true });
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+      expect(() => service.getIndustryTaxonomy()).toThrow("skills.md not found");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("handles missing optional sections gracefully", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "skills-minimal-"));
+    fs.mkdirSync(path.join(root, "config", "resume"), { recursive: true });
+
+    const minimalSkills = `---
+version: 1
+updated_at: '2026-02-21'
+---
+
+# Skills Knowledge
+
+## Domain Taxonomy
+
+### machinery
+- displayName: Machinery
+- keywords: lathe
+`;
+
+    fs.writeFileSync(path.join(root, "config", "resume", "skills.md"), minimalSkills, "utf8");
+    fs.writeFileSync(path.join(root, "pyproject.toml"), "", "utf8");
+    fs.mkdirSync(path.join(root, "output"), { recursive: true });
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+
+      expect(service.getIndustryTaxonomy()).toHaveLength(1);
+      expect(service.getSynonymTable().size).toBe(0);
+      expect(service.getExperienceSignals()).toHaveLength(0);
+      expect(service.getCompanyPatterns()).toHaveLength(0);
+      expect(service.getExclusionTokens()).toHaveLength(0);
+      expect(service.getLearningLog()).toHaveLength(0);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/api/src/services/skills-knowledge.ts
+++ b/apps/api/src/services/skills-knowledge.ts
@@ -1,0 +1,470 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { parse as parseYaml } from "yaml";
+
+import { FileParseError } from "./errors";
+import { findProjectRoot } from "./db";
+
+/**
+ * Domain entry from skills taxonomy
+ */
+export interface DomainEntry {
+  tag: string;
+  displayName: string;
+  keywords: string[];
+}
+
+/**
+ * Synonym mapping entry
+ */
+export interface SynonymEntry {
+  canonical: string;
+  variants: string[];
+  allTerms: string[];
+}
+
+/**
+ * Experience level signals
+ */
+export interface ExperienceLevelSignals {
+  level: string;
+  displayName: string;
+  keywords: string[];
+}
+
+/**
+ * Company pattern with aliases
+ */
+export interface CompanyPattern {
+  name: string;
+  aliases: string[];
+  allNames: string[];
+}
+
+/**
+ * Industry context section
+ */
+export interface IndustryContextSection {
+  heading: string;
+  content: string;
+}
+
+/**
+ * Learning log entry
+ */
+export interface LearningLogEntry {
+  date: string;
+  observation: string;
+}
+
+/**
+ * Parsed skills knowledge
+ */
+export interface SkillsKnowledge {
+  version: number;
+  updatedAt: string;
+  domains: DomainEntry[];
+  synonyms: SynonymEntry[];
+  experienceLevels: ExperienceLevelSignals[];
+  companyPatterns: CompanyPattern[];
+  industryContext: IndustryContextSection[];
+  exclusionTokens: string[];
+  learningLog: LearningLogEntry[];
+}
+
+/**
+ * Service for loading and parsing skills.md knowledge file
+ */
+export class SkillsKnowledgeService {
+  readonly projectRoot: string;
+  private cache: SkillsKnowledge | null = null;
+
+  constructor(projectRoot?: string) {
+    this.projectRoot = projectRoot ? path.resolve(projectRoot) : findProjectRoot();
+  }
+
+  private getSkillsPath(): string {
+    return path.join(this.projectRoot, "config", "resume", "skills.md");
+  }
+
+  /**
+   * Parse skills.md file
+   */
+  private parseSkillsFile(): SkillsKnowledge {
+    if (this.cache) return this.cache;
+
+    const skillsPath = this.getSkillsPath();
+
+    if (!fs.existsSync(skillsPath)) {
+      throw new FileParseError(skillsPath, "skills.md not found");
+    }
+
+    const content = fs.readFileSync(skillsPath, "utf8");
+
+    // Parse frontmatter
+    const lines = content.split("\n");
+    let frontmatterEnd = -1;
+
+    if (lines[0]?.trim() === "---") {
+      for (let i = 1; i < lines.length; i += 1) {
+        if (lines[i].trim() === "---") {
+          frontmatterEnd = i;
+          break;
+        }
+      }
+    }
+
+    if (frontmatterEnd === -1) {
+      throw new FileParseError(skillsPath, "Invalid frontmatter: no closing ---");
+    }
+
+    const frontmatterYaml = lines.slice(1, frontmatterEnd).join("\n");
+    const frontmatter = parseYaml(frontmatterYaml) as { version: number; updated_at: string };
+
+    const body = lines.slice(frontmatterEnd + 1).join("\n");
+
+    // Split by top-level sections (## heading)
+    const sections = body.split(/\n## /);
+
+    const knowledge: SkillsKnowledge = {
+      version: frontmatter.version,
+      updatedAt: frontmatter.updated_at,
+      domains: [],
+      synonyms: [],
+      experienceLevels: [],
+      companyPatterns: [],
+      industryContext: [],
+      exclusionTokens: [],
+      learningLog: [],
+    };
+
+    for (const section of sections) {
+      const trimmed = section.trim();
+      if (!trimmed) continue;
+
+      // Identify section by heading
+      if (trimmed.startsWith("Domain Taxonomy")) {
+        knowledge.domains = this.parseDomainTaxonomy(trimmed);
+      } else if (trimmed.startsWith("Synonym Table")) {
+        knowledge.synonyms = this.parseSynonymTable(trimmed);
+      } else if (trimmed.startsWith("Experience Signals")) {
+        knowledge.experienceLevels = this.parseExperienceSignals(trimmed);
+      } else if (trimmed.startsWith("Company Patterns")) {
+        knowledge.companyPatterns = this.parseCompanyPatterns(trimmed);
+      } else if (trimmed.startsWith("Industry Context")) {
+        knowledge.industryContext = this.parseIndustryContext(trimmed);
+      } else if (trimmed.startsWith("Exclusion Patterns")) {
+        knowledge.exclusionTokens = this.parseExclusionPatterns(trimmed);
+      } else if (trimmed.startsWith("Learning Log")) {
+        knowledge.learningLog = this.parseLearningLog(trimmed);
+      }
+    }
+
+    this.cache = knowledge;
+    return knowledge;
+  }
+
+  /**
+   * Parse Domain Taxonomy section
+   */
+  private parseDomainTaxonomy(section: string): DomainEntry[] {
+    const entries: DomainEntry[] = [];
+    const subsections = section.split(/\n### /);
+
+    for (const sub of subsections) {
+      const trimmed = sub.trim();
+      if (!trimmed || trimmed.startsWith("Domain Taxonomy")) continue;
+
+      const lines = trimmed.split("\n");
+      const tag = lines[0].trim();
+
+      let displayName = tag;
+      let keywords: string[] = [];
+
+      for (const line of lines.slice(1)) {
+        const displayMatch = line.match(/^-\s*displayName:\s*(.+)$/);
+        if (displayMatch) {
+          displayName = displayMatch[1].trim();
+        }
+
+        const keywordsMatch = line.match(/^-\s*keywords:\s*(.+)$/);
+        if (keywordsMatch) {
+          keywords = keywordsMatch[1]
+            .split(",")
+            .map((k) => k.trim().toLowerCase())
+            .filter((k) => k.length > 0);
+        }
+      }
+
+      if (keywords.length > 0) {
+        entries.push({ tag, displayName, keywords });
+      }
+    }
+
+    return entries;
+  }
+
+  /**
+   * Parse Synonym Table section
+   */
+  private parseSynonymTable(section: string): SynonymEntry[] {
+    const entries: SynonymEntry[] = [];
+    const lines = section.split("\n");
+
+    for (const line of lines) {
+      const match = line.match(/^-\s*([^:]+):\s*(.+)$/);
+      if (match) {
+        const canonical = match[1].trim().toLowerCase();
+        const variants = match[2]
+          .split(",")
+          .map((v) => v.trim().toLowerCase())
+          .filter((v) => v.length > 0);
+
+        const allTerms = [canonical, ...variants];
+        entries.push({ canonical, variants, allTerms });
+      }
+    }
+
+    return entries;
+  }
+
+  /**
+   * Parse Experience Signals section
+   */
+  private parseExperienceSignals(section: string): ExperienceLevelSignals[] {
+    const signals: ExperienceLevelSignals[] = [];
+    const subsections = section.split(/\n### /);
+
+    for (const sub of subsections) {
+      const trimmed = sub.trim();
+      if (!trimmed || trimmed.startsWith("Experience Signals")) continue;
+
+      const lines = trimmed.split("\n");
+      const level = lines[0].trim();
+
+      let displayName = level;
+      let keywords: string[] = [];
+
+      for (const line of lines.slice(1)) {
+        const displayMatch = line.match(/^-\s*displayName:\s*(.+)$/);
+        if (displayMatch) {
+          displayName = displayMatch[1].trim();
+        }
+
+        const keywordsMatch = line.match(/^-\s*keywords:\s*(.+)$/);
+        if (keywordsMatch) {
+          keywords = keywordsMatch[1]
+            .split(",")
+            .map((k) => k.trim().toLowerCase())
+            .filter((k) => k.length > 0);
+        }
+      }
+
+      if (keywords.length > 0) {
+        signals.push({ level, displayName, keywords });
+      }
+    }
+
+    return signals;
+  }
+
+  /**
+   * Parse Company Patterns section
+   */
+  private parseCompanyPatterns(section: string): CompanyPattern[] {
+    const patterns: CompanyPattern[] = [];
+    const lines = section.split("\n");
+
+    for (const line of lines) {
+      // Match: - NAME (aliases: a1, a2, a3)
+      const match = line.match(/^-\s*([^(]+)\s*\(aliases:\s*([^)]+)\)$/);
+      if (match) {
+        const name = match[1].trim().toLowerCase();
+        const aliases = match[2]
+          .split(",")
+          .map((a) => a.trim().toLowerCase())
+          .filter((a) => a.length > 0);
+
+        const allNames = [name, ...aliases];
+        patterns.push({ name, aliases, allNames });
+      }
+    }
+
+    return patterns;
+  }
+
+  /**
+   * Parse Industry Context section
+   */
+  private parseIndustryContext(section: string): IndustryContextSection[] {
+    const contexts: IndustryContextSection[] = [];
+    const subsections = section.split(/\n### /);
+
+    for (const sub of subsections) {
+      const trimmed = sub.trim();
+      if (!trimmed || trimmed.startsWith("Industry Context")) continue;
+
+      const lines = trimmed.split("\n");
+      const heading = lines[0].trim();
+      const content = lines.slice(1).join("\n").trim();
+
+      if (content) {
+        contexts.push({ heading, content });
+      }
+    }
+
+    return contexts;
+  }
+
+  /**
+   * Parse Exclusion Patterns section
+   */
+  private parseExclusionPatterns(section: string): string[] {
+    const lines = section.split("\n");
+
+    for (const line of lines) {
+      const match = line.match(/^-\s*exclude:\s*(.+)$/);
+      if (match) {
+        return match[1]
+          .split(",")
+          .map((t) => t.trim().toLowerCase())
+          .filter((t) => t.length > 0);
+      }
+    }
+
+    return [];
+  }
+
+  /**
+   * Parse Learning Log section
+   */
+  private parseLearningLog(section: string): LearningLogEntry[] {
+    const entries: LearningLogEntry[] = [];
+    const lines = section.split("\n");
+
+    for (const line of lines) {
+      // Match: - YYYY-MM-DD: observation
+      const match = line.match(/^-\s*(\d{4}-\d{2}-\d{2}):\s*(.+)$/);
+      if (match) {
+        entries.push({
+          date: match[1],
+          observation: match[2].trim(),
+        });
+      }
+    }
+
+    return entries;
+  }
+
+  /**
+   * Get industry taxonomy (replaces INDUSTRY_MAP and INDUSTRY_KEYWORDS)
+   */
+  getIndustryTaxonomy(): DomainEntry[] {
+    return this.parseSkillsFile().domains;
+  }
+
+  /**
+   * Get synonym lookup map (variant → canonical)
+   */
+  getSynonymTable(): Map<string, string> {
+    const map = new Map<string, string>();
+    const synonyms = this.parseSkillsFile().synonyms;
+
+    for (const entry of synonyms) {
+      for (const variant of entry.variants) {
+        map.set(variant, entry.canonical);
+      }
+      // Also map canonical to itself for consistency
+      map.set(entry.canonical, entry.canonical);
+    }
+
+    return map;
+  }
+
+  /**
+   * Get full skill vocabulary (all domain keywords + synonym variants)
+   */
+  getSkillVocabulary(): Set<string> {
+    const vocab = new Set<string>();
+    const knowledge = this.parseSkillsFile();
+
+    // Add domain keywords
+    for (const domain of knowledge.domains) {
+      for (const keyword of domain.keywords) {
+        vocab.add(keyword);
+      }
+    }
+
+    // Add synonym terms
+    for (const entry of knowledge.synonyms) {
+      for (const term of entry.allTerms) {
+        vocab.add(term);
+      }
+    }
+
+    return vocab;
+  }
+
+  /**
+   * Get experience level signals
+   */
+  getExperienceSignals(): ExperienceLevelSignals[] {
+    return this.parseSkillsFile().experienceLevels;
+  }
+
+  /**
+   * Get company patterns
+   */
+  getCompanyPatterns(): CompanyPattern[] {
+    return this.parseSkillsFile().companyPatterns;
+  }
+
+  /**
+   * Get company lookup set (all company names lowercased)
+   */
+  getCompanyLookupSet(): Set<string> {
+    const lookup = new Set<string>();
+    const patterns = this.parseSkillsFile().companyPatterns;
+
+    for (const pattern of patterns) {
+      for (const name of pattern.allNames) {
+        lookup.add(name);
+      }
+    }
+
+    return lookup;
+  }
+
+  /**
+   * Get industry context formatted for AI prompts
+   */
+  getIndustryContext(): string {
+    const sections = this.parseSkillsFile().industryContext;
+    return sections.map((s) => `### ${s.heading}\n${s.content}`).join("\n\n");
+  }
+
+  /**
+   * Get exclusion tokens
+   */
+  getExclusionTokens(): string[] {
+    return this.parseSkillsFile().exclusionTokens;
+  }
+
+  /**
+   * Get learning log entries
+   */
+  getLearningLog(): LearningLogEntry[] {
+    return this.parseSkillsFile().learningLog;
+  }
+
+  /**
+   * Clear cache
+   */
+  clearCache(): void {
+    this.cache = null;
+  }
+}
+
+// Singleton
+export const skillsKnowledgeService = new SkillsKnowledgeService();

--- a/config/resume/skills.md
+++ b/config/resume/skills.md
@@ -1,0 +1,125 @@
+---
+version: 1
+updated_at: '2026-02-21'
+description: >
+  Curated skill taxonomy, synonyms, and domain knowledge for resume screening.
+  Used by the background ingest agent for deterministic matching and pre-scoring.
+  This file consolidates data from rule-scoring.ts, resume-index.ts, and skills_words.txt.
+---
+
+# Skills Knowledge
+
+This file provides structured domain knowledge for automated resume screening. It is parsed by `skills-knowledge.ts` and used by the background ingest agent to pre-compute matching signals on new resume arrival.
+
+## Domain Taxonomy
+
+Skills are organized by domain tags. Each domain has a canonical tag, display name, and associated keywords.
+
+### machinery
+- displayName: Machinery
+- keywords: 机床, 车床, 加工中心, 机械, 设备, 五轴, 夹具, 治具, lathe, machining, milling
+
+### cnc
+- displayName: CNC
+- keywords: cnc, 数控, fanuc, siemens, star, brother, mitsubishi
+
+### sales
+- displayName: Sales
+- keywords: 销售, 业务, 客户, 大客户, 渠道, sales, account, bd, market, engineer
+
+### automation
+- displayName: Automation
+- keywords: 自动化, 机器人, plc, 伺服, automation
+
+### metrology
+- displayName: Metrology
+- keywords: 测量, 三维扫描, 3d, cmm, metrology, scan
+
+### software
+- displayName: Software
+- keywords: c++, c#, mfc, qt, 软件, 开发, algorithm, python
+
+## Synonym Table
+
+Maps variant terms to canonical forms. Used for synonym expansion in search and matching.
+
+- 机床: 机械设备, 加工设备
+- 车床: CNC车床, 数控车床
+- 加工中心: machining center, machining-center, 加工设备
+- 五轴: 5-axis, 五轴联动
+- 夹具: 治具, fixture
+- 数控: CNC, Computer Numerical Control
+- 销售: 业务, 商务, 销售员
+- 大客户: 渠道客户, key account, 关键客户
+- 自动化: automation, 工业自动化
+- 机器人: robot, 工业机器人
+- 测量: 计量, measurement, 质量检测
+- 三维扫描: 3D扫描, 3d-scan, 三维测量
+- CMM: 三坐标, 三坐标测量机
+- 软件: software, 程序, 应用
+
+## Experience Signals
+
+Keywords that indicate experience level. Used by the ingest agent to classify candidates.
+
+### senior
+- displayName: Senior Level
+- keywords: 团队管理, 大客户, 渠道拓展, 主管, 经理, manager, lead, director, 带团队, 培训, 项目管理
+
+### mid
+- displayName: Mid Level
+- keywords: 独立, 熟练, 精通, 负责, 专员, specialist, coordinator, 项目, 方案
+
+### junior
+- displayName: Junior Level
+- keywords: 应届, 实习, 助理, assistant, trainee, intern, 学习, 协助, 初级
+
+## Company Patterns
+
+Known companies in the target industry with name variations. Used for company recognition and industry context.
+
+- FANUC (aliases: 发那科, Fanuc)
+- SIEMENS (aliases: 西门子, Siemens)
+- STAR (aliases: 津上, スター精密, Star Micronics)
+- BROTHER (aliases: 兄弟, Brother Industries)
+- MITSUBISHI (aliases: 三菱, Mitsubishi Electric)
+- HAAS (aliases: 哈斯, Haas Automation)
+- MAZAK (aliases: 马扎克, Yamazaki Mazak)
+- DMG MORI (aliases: 德马吉森精机, DMG森精机)
+- MAKINO (aliases: 牧野, マキノ)
+- OKUMA (aliases: 大隈, オークマ)
+- CITIZEN (aliases: 西铁城, シチズン)
+- DOOSAN (aliases: 斗山, 두산)
+- HYUNDAI WIA (aliases: 现代威亚, 현대위아)
+- TSUGAMI (aliases: 津上, つがみ)
+- JINGDIAO (aliases: 北京精雕, 精雕)
+
+## Industry Context
+
+Background information for AI prompt enrichment and domain understanding.
+
+### CNC Machining Domain
+CNC (Computer Numerical Control) machining involves automated control of machine tools using programmed commands. Key brands include FANUC, SIEMENS, STAR, BROTHER, and MITSUBISHI. Common machine types: lathes (车床), machining centers (加工中心), multi-axis systems (五轴).
+
+### Sales and Business Development
+B2B sales in manufacturing equipment requires technical knowledge of machinery, customer relationship management, and channel development. Keywords: 大客户 (key accounts), 渠道 (channels), 业务拓展 (business development).
+
+### Metrology and Quality
+Precision measurement using CMM (Coordinate Measuring Machine), 3D scanning, and quality inspection. Critical for manufacturing QA/QC processes.
+
+### Automation
+Industrial automation using PLCs (Programmable Logic Controllers), servo systems, and robotics. Common in factory automation and smart manufacturing.
+
+## Exclusion Patterns
+
+Tokens that indicate irrelevant content (ads, promotions). Resumes containing these are flagged for review.
+
+- exclude: ad, promo, 广告, 推广, 招商, 加盟, spam
+
+## Learning Log (Append Only)
+
+HR feedback patterns and observations. New entries are appended by the feedback loop (M6).
+
+<!-- Future feedback entries will be added here in the format:
+- YYYY-MM-DD: observation or pattern
+-->


### PR DESCRIPTION
## Task

Implement teh following plan;

# Plan: Phase M1 + M2 — skills.md Knowledge File + Parser Service

## Context

The resume screening system has skill/keyword matching logic **hardcoded in 3 places**:

1. `apps/api/src/services/rule-scoring.ts:39-46` — `INDUSTRY_MAP` (6 industry tags)
2. `apps/api/src/services/resume-index.ts:24-43` — `INDUSTRY_KEYWORDS` (same 6 tags, slightly different keyword lists)
3. `config/resume/skills_words.txt` — flat text file with space-separated keyword groups

M1 creates a single `config/resume/skills.md` that consolidates all three. M2 creates a parser service that loads it into structured TypeScript types. Both tasks are **independent** and can run in parallel (M2 uses an inline test fixture, not the actual skills.md file).

---

## Task M1: Create `config/resume/skills.md` [INDEPENDENT]

**Files**: `config/resume/skills.md` (new)
**Depends**: none
**Conflict Risk**: none

### Format Design

The markdown uses a consistent, regex-parseable pattern:

- `## Section` headings for top-level sections
- `### Subsection` headings for domain tags / experience levels
- `- keywords: val1, val2` for keyword lists
- `- canonical: variant1, variant2` for synonym entries
- `- name (aliases: a1, a2)` for company patterns
- `- exclude: token1, token2` for exclusion patterns
- `- YYYY-MM-DD: observation` for learning log

YAML frontmatter with `version`, `updated_at`, `description`.

### Data Consolidation (union of all sources)

| Domain | Merged Keywords |
|--------|----------------|
| machinery | 机床, 车床, 加工中心, 机械, 设备, 五轴, 夹具, 治具, lathe, machining, milling |
| cnc | cnc, 数控, fanuc, siemens, star, brother, mitsubishi |
| sales | 销售, 业务, 客户, 大客户, 渠道, sales, account, bd, market |
| automation | 自动化, 机器人, plc, 伺服, automation |
| metrology | 测量, 三维扫描, 3d, cmm, metrology, scan |
| software | c++, c#, mfc, qt, 软件, 开发, algorithm, python |

Plus: synonym table, experience signals (senior/mid/junior), company patterns (15+ CNC industry brands with Chinese aliases), industry context paragraphs, exclusion tokens (`ad, promo, 广告, 推广`), and an append-only learning log.

### Verification

- File renders correctly in Obsidian/GitHub preview
- Contains all keywords from both `INDUSTRY_MAP` and `INDUSTRY_KEYWORDS` (superset)
- `make check` still passes (no existing code touched)

---

## Task M2: Create `apps/api/src/services/skills-knowledge.ts` + tests [INDEPENDENT]

**Files**:

- `apps/api/src/services/skills-knowledge.ts` (new)
- `apps/api/src/services/skills-knowledge.test.ts` (new)

**Depends**: none (test uses inline fixture)
**Conflict Risk**: none

### Service Design

Follows existing codebase patterns exactly:

| Pattern | Reference |
|---------|-----------|
| Class with `constructor(projectRoot?)` | `filter-preset-service.ts:36-42` |
| `findProjectRoot()` for path resolution | `db.ts:29-42` |
| `Map`-based cache with `clearCache()` | `filter-preset-service.ts:38,145-147` |
| YAML frontmatter parsing | `job-description-service.ts:9,70-90` |
| Singleton export | `filter-preset-service.ts:150-151` |
| `FileParseError` for errors | `errors.ts` |

### Type Definitions

```typescript
interface DomainEntry {
  tag: string;           // "machinery", "cnc", etc.
  displayName: string;   // "Machinery", "CNC"
  keywords: string[];    // lowercased keywords
}

interface SynonymEntry {
  canonical: string;
  variants: string[];
  allTerms: string[];    // canonical + variants, lowercased
}

interface ExperienceLevelSignals {
  level: string;         // "senior", "mid", "junior"
  displayName: string;
  keywords: string[];
}

interface CompanyPattern {
  name: string;
  aliases: string[];
  allNames: string[];    // primary + aliases, lowercased
}

interface IndustryContextSection {
  heading: string;
  content: string;
}

interface LearningLogEntry {
  date: string;          // YYYY-MM-DD
  observation: string;
}

interface SkillsKnowledge {
  version: number;
  updatedAt: string;
  domains: DomainEntry[];
  synonyms: SynonymEntry[];
  experienceLevels: ExperienceLevelSignals[];
  companyPatterns: CompanyPattern[];
  industryContext: IndustryContextSection[];
  exclusionTokens: string[];
  learningLog: LearningLogEntry[];
}
```

### Public API

| Method | Returns | Replaces |
|--------|---------|----------|
| `getIndustryTaxonomy()` | `DomainEntry[]` | `INDUSTRY_MAP` in rule-scoring.ts, `INDUSTRY_KEYWORDS` in resume-index.ts |
| `getSynonymTable()` | `Map<string, string>` (variant → canonical) | `skills_words.txt` keyword expansion |
| `getSkillVocabulary()` | `Set<string>` (all domain keywords + synonym variants) | `loadSkillVocabulary()` in resume-index.ts |
| `getExperienceSignals()` | `ExperienceLevelSignals[]` | New for M3 ingest agent |
| `getCompanyPatterns()` | `CompanyPattern[]` | Hardcoded company regex in parser.ts |
| `getCompanyLookupSet()` | `Set<string>` (all names lowercased) | Fast company recognition |
| `getIndustryContext()` | `string` (formatted for AI prompts) | New for AI prompt enrichment |
| `getExclusionTokens()` | `string[]` | `!` prefixed tokens in skills\_words.txt |
| `getLearningLog()` | `LearningLogEntry[]` | New for M6 feedback loop |
| `clearCache()` | `void` | Cache invalidation |

### Parsing Algorithm

1. Split file by \`\\n## \` to get top-level sections
2. Parse YAML frontmatter from first chunk (using `yaml` package, already a dependency)
3. Per section, identify by heading text and apply specific regex:

- Domain Taxonomy: split by `\n### `, parse `- keywords:` lines
- Synonym Table: parse `- canonical: variant1, variant2` lines
- Experience Signals: split by `\n### `, parse `- keywords:` lines
- Company Patterns: parse `- name (aliases: a1, a2)` lines
- Industry Context: split by \`\\n### \`, collect free-form text
- Exclusion Patterns: parse `- exclude:` line
- Learning Log: parse `- YYYY-MM-DD:` lines

### Test Strategy

File: `apps/api/src/services/skills-knowledge.test.ts`
Pattern: follows `resume-index.test.ts` (temp fixture directory)

Key test cases:

- Parses domain taxonomy (correct tags, keywords, display names)
- Parses synonym table (variant → canonical mapping)
- `getSkillVocabulary()` returns union of all tokens
- Parses experience signals (3 levels with correct keywords)
- Parses company patterns with aliases
- `getCompanyLookupSet()` includes all names lowercased
- `getIndustryContext()` returns non-empty formatted string
- Parses exclusion tokens
- Parses learning log entries
- Cache works; `clearCache()` invalidates
- Throws `FileParseError` for missing file
- Handles missing optional sections gracefully

### Verification

```bash
bunx vitest run apps/api/src/services/skills-knowledge.test.ts
make check-node   # TypeScript typecheck + lint
```

---

## What M1+M2 Do NOT Touch (deferred to M3+)

- No changes to `rule-scoring.ts`, `resume-index.ts`, `parser.ts`, or `ai-matching.ts`
- No Convex schema changes
- No new API routes
- The parser service is created and tested but not wired into existing code

## End-to-End Verification

```bash
# M1: skills.md exists and is valid
cat config/resume/skills.md | head -5   # has frontmatter

# M2: tests pass
bunx vitest run apps/api/src/services/skills-knowledge.test.ts

# No regressions
make check
```

## PR Review Summary
- **What Changed**:
  - Created `config/resume/skills.md`: A centralized Markdown knowledge base consolidating industry tags, synonyms, and company patterns previously hardcoded across the API.
  - Created `apps/api/src/services/skills-knowledge.ts`: A new singleton service to parse the Markdown file into structured TypeScript types. It features internal caching, a `clearCache` method, and methods for retrieving industry context, synonym tables, and experience signals.
  - Created `apps/api/src/services/skills-knowledge.test.ts`: A comprehensive test suite validating all parsing logic, cache behavior, and error handling for missing files or invalid frontmatter.
- **Review Focus**:
  - **Regex Reliability**: Review the parser regex in `skills-knowledge.ts` to ensure it handles potential variations in Markdown whitespace or list formatting (e.g., `parseCompanyPatterns`).
  - **Cache Management**: Verify the singleton pattern and caching logic ensure performance without risking stale data if the underlying file changes.
  - **Data Integrity**: Confirm that the keywords migrated to `skills.md` represent a complete superset of the original hardcoded maps.
- **Test Plan**:
  - Run the new test suite: `bunx vitest apps/api/src/services/skills-knowledge.test.ts`.
  - Verify the Markdown structure by opening `config/resume/skills.md` in a viewer to ensure section headers are correctly leveled.
  - Run `make check` to confirm no regressions in existing build or linting processes.
- **Follow-ups**:
  - Future phases (M3+) will involve refactoring `rule-scoring.ts` and `resume-index.ts` to consume this service instead of local constants.