### PR TITLE
# Implement all tasks: Plan:

### DIFF
--- a/apps/api/src/services/skills-knowledge.test.ts
+++ b/apps/api/src/services/skills-knowledge.test.ts
@@ -289,6 +289,26 @@ describe("SkillsKnowledgeService", () => {
     }
   });
 
+  it("appends learning feedback into Learning Log section", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+      const entry = service.appendLearningEntry("shortlist pattern -> cnc + senior");
+
+      expect(entry).toMatch(/^- \d{4}-\d{2}-\d{2}: shortlist pattern -> cnc \+ senior$/);
+
+      const log = service.getLearningLog();
+      expect(log).toHaveLength(3);
+      expect(log[2]?.observation).toBe("shortlist pattern -> cnc + senior");
+
+      const saved = fs.readFileSync(path.join(root, "config", "resume", "skills.md"), "utf8");
+      expect(saved).toContain(entry);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
   it("caches parsed data and clearCache invalidates it", () => {
     const root = createFixtureRoot();
 


### PR DESCRIPTION
## Task

# Implement all tasks:
Plan: Remaining Tasks — CNC Migration + M4 + M5 + M6

## Context

M3 (Background Ingest Agent) is **fully implemented** — schema, mutations, Convex action, BFF service/route, and `submitResumes` trigger all exist. The `addScriptBoundarySpaces()` CJK tokenization fix is also already in code. What remains:

1. **CNC + M5**: Run migrations to backfill existing resumes (searchText reindex + ingestData backfill)
2. **M4**: Make the query path use pre-computed `ingestData` fields (sort by rule scores, expose tags/level)
3. **M6**: Learning feedback loop (append HR patterns to skills.md)

---

## Parallelism Map

```
Group A (INDEPENDENT, run first):
  CNC-1: Run reindexSearchText migration
  M5-1:  Add + run backfillIngestData migration
  M4-1:  Add Convex queries (listWithIngestData, searchWithIngestData)
  M6-1:  Add appendLearningEntry() + API endpoint

Group B (DEPENDS: M4-1):
  M4-2:  Update useConvexResumes hook to expose ingestData + jobDescriptionId
  M4-3:  Update ResumeList to use pre-computed scores + sort controls

Group C (DEPENDS: M6-1):
  M6-2:  Add UI feedback capture on shortlist/reject
  M6-3:  Add cache invalidation in ingest-compute-service
```

---

## Task CNC-1: Run SearchText Reindex [INDEPENDENT]

**Files**: none (existing mutation `migrations.ts:113-127`)
**Action**: `npx convex run migrations:reindexSearchText` (requires `make dev` running)

Rebuilds `searchText` for all \~80 resumes using `buildSearchText()` which now calls `addScriptBoundarySpaces()`. CNC search should go from \~3 → \~19 results.

**Verification**: Search "CNC" in UI → expect \~19 results.

---

## Task M5-1: Add + Run backfillIngestData Migration [INDEPENDENT]

**Files**: `packages/convex/convex/migrations.ts` (append new action)
**Depends**: none (M3 ingest infra already exists)
**Conflict Risk**: none (append-only)

Add `backfillIngestData` action that:

1. Calls `internal.resumes.listUnprocessed` (already exists at `resumes.ts:152-164`)
2. Schedules `internal.ingest_agent.processNewResumes` with those IDs
3. Run via `npx convex run migrations:backfillIngestData`
4. Run multiple times until `listUnprocessed` returns empty

**Verification**: Random resumes in Convex dashboard have `ingestData` with `industryTags`, `synonymHits`, `ruleScores`, `experienceLevel`.

---

## Task M4-1: Add Convex Queries for Pre-Computed Sorting [INDEPENDENT]

**Files**: `packages/convex/convex/resumes.ts` (append new queries)
**Depends**: none
**Conflict Risk**: `resumes.ts` (append-only at bottom)

Add two new queries:

- **`listWithIngestData(limit, jobDescriptionId?)`**: Fetch resumes, sort by `ingestData.ruleScores[jdId]` in-memory
- **`searchWithIngestData(query, limit, jobDescriptionId?)`**: Full-text search + re-sort by pre-computed score

Note: Convex doesn't support indexes on nested fields. In-memory sort after fetch is the standard pattern.

**Verification**: Call from Convex dashboard with `jobDescriptionId: "jd-lathe-sales"` → results sorted by score descending.

---

## Task M4-2: Update useConvexResumes Hook [DEPENDS: M4-1]

**Files**: `apps/web/src/hooks/useConvexResumes.ts`
**Depends**: M4-1

Changes:

1. Add `ConvexIngestData` type and parse `ingestData` from Convex docs
2. Add optional `jobDescriptionId` parameter to hook
3. Switch to `searchWithIngestData` / `listWithIngestData` queries
4. Expose `ingestData` on each `ConvexResumeItem`

Backward compatible — `jobDescriptionId` defaults to `undefined`, preserving existing behavior.

---

## Task M4-3: Update ResumeList to Use Pre-Computed Scores [DEPENDS: M4-2]

**Files**: `apps/web/src/components/ResumeList.tsx`
**Depends**: M4-2

Changes:

1. Pass `jobDescriptionId` to `useConvexResumes()` call
2. In `filteredConvexResumes` useMemo: use `resume.ingestData.ruleScores[jdId]` instead of calling `calculateResumeScore()` on every render
3. Fallback: if no `ingestData`, use existing client-side `calculateResumeScore()`
4. Sort by pre-computed score descending
5. Optional: show `experienceLevel` badge and `industryTags` chips on cards

**Verification**: With JD selected → resumes sorted by pre-computed score. Without JD → fallback to current behavior. No visible delay.

---

## Task M6-1: Add Learning Feedback API [INDEPENDENT]

**Files**: `apps/api/src/services/skills-knowledge.ts`, `apps/api/src/routes/resumes.ts`
**Depends**: none
**Conflict Risk**: `skills-knowledge.ts` (add one method), `resumes.ts` (append route)

1. Add `appendLearningEntry(observation: string)` to `SkillsKnowledgeService`:

- Reads `config/resume/skills.md`
- Finds `## Learning Log` section
- Appends `- YYYY-MM-DD: observation` before next `##` heading
- Writes file, clears cache

2. Add `POST /api/resumes/learning-feedback` route:

- Body: `{ observation: string }`
- Calls `appendLearningEntry()`
- Returns `{ success, entry }`

**Verification**: POST feedback → check `config/resume/skills.md` has new entry in Learning Log section.

---

## Task M6-2: UI Feedback Capture [DEPENDS: M6-1]

**Files**: `apps/web/src/components/ResumeList.tsx`
**Depends**: M6-1

When HR shortlists/rejects a resume with `ingestData`:

- Auto-generate observation: `"shortlist pattern -> {industryTags} + {experienceLevel}"`
- POST to `/api/resumes/learning-feedback` (fire-and-forget, non-blocking)
- Silently catch errors (don't interrupt HR workflow)

---

## Task M6-3: Ingest Agent Cache Invalidation [DEPENDS: M6-1]

**Files**: `apps/api/src/services/ingest-compute-service.ts`
**Depends**: M6-1

Add `skillsKnowledgeService.clearCache()` at start of `computeBatch()` so each ingest cycle picks up any new learning log entries or skills.md edits.

---

## Execution Order

| Priority | Tasks | Can Parallelize |
|----------|-------|-----------------|
| 1 | CNC-1, M5-1, M4-1, M6-1 | Yes (all independent) |
| 2 | M4-2, M6-2, M6-3 | Yes (different files) |
| 3 | M4-3 | After M4-2 |
| 4 | End-to-end verification | After all |

## End-to-End Verification

```bash
# 1. Migrations (requires make dev running)
npx convex run migrations:reindexSearchText
npx convex run migrations:backfillIngestData

# 2. Unit tests
bunx vitest run apps/api/src/services/skills-knowledge.test.ts
bunx vitest run apps/api/src/services/ingest-compute-service.test.ts

# 3. Type check + lint
make check-node

# 4. Manual verification
# - Search "CNC" → ~19 results
# - Select JD → resumes sorted by pre-computed score
# - Shortlist resume → skills.md learning log updated
```

## PR Review Summary

- **What Changed**:
  - **Backend (Convex)**: Added `listWithIngestData` and `searchWithIngestData` queries to utilize pre-computed scores for in-memory sorting. Introduced a `backfillIngestData` migration action to process existing resumes through the ingest agent.
  - **API (Node)**: Implemented `SkillsKnowledgeService.appendLearningEntry` to write recruiter feedback directly to `skills.md`. Added a corresponding `/api/resumes/learning-feedback` endpoint.
  - **Web**: Updated `useConvexResumes` hook and `ResumeList` component to prioritize pre-computed `ingestData` for sorting. Added automated feedback triggers that log observations to the Learning Log when candidates are shortlisted or rejected.
  - **Robustness**: Enhanced `IngestComputeService` to handle varied resume content structures and ensure cache invalidation between batches.

- **Review Focus**:
  - **Performance**: Convex queries now perform in-memory sorting after a fetch. While limited to 200-500 items, monitor this as the resume database scales.
  - **Concurrency**: The `appendLearningEntry` function performs direct file I/O on `skills.md`. Ensure the API environment (e.g., dev vs prod) permits file system persistence for this feature.
  - **Data Integrity**: Verify the `extractResumeItem` logic correctly handles both nested and flat resume data shapes coming from storage.

- **Test Plan**:
  - **Migrations**: Run `npx convex run migrations:reindexSearchText` and `backfillIngestData` to ensure data is prepared.
  - **Automated Tests**: Execute `bunx vitest` on `skills-knowledge.test.ts` and `ingest-compute-service.test.ts` to verify parsing and file appending.
  - **Manual Verification**: Select a Job Description in the UI, verify candidates sort by score, then shortlist a candidate and confirm `config/resume/skills.md` is updated with a new entry.

- **Follow-ups**:
  - Consider adding a file lock or queue for `skills.md` writes if multiple recruiters will be performing bulk actions simultaneously.