### PR TITLE
implement all tasks and fix

### DIFF
--- a/apps/web/src/components/BulkActionBar.test.tsx
+++ b/apps/web/src/components/BulkActionBar.test.tsx
@@ -6,7 +6,7 @@ import { BulkActionBar } from './BulkActionBar'
 // Mock useTranslation
 vi.mock('react-i18next', () => ({
     useTranslation: () => ({
-        t: (key: string, fallback: string) => fallback,
+        t: (_key: string, fallback: string) => fallback,
     }),
 }))
 

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -21,6 +21,8 @@ interface ResumeCardProps {
   onViewDetails: () => void
   matchResult?: MatchingResult
   ruleScore?: number
+  industryTags?: string[]
+  experienceLevel?: string
   showAiScore?: boolean
   actionType?: CandidateActionType
   onAction?: (actionType: CandidateActionType) => void
@@ -54,6 +56,8 @@ export function ResumeCard({
   jobDescriptionId,
   jobDescription,
   isReviewed,
+  industryTags,
+  experienceLevel,
 }: ResumeCardProps) {
   const { t } = useTranslation()
   const [showOutreach, setShowOutreach] = useState(false)
@@ -89,6 +93,18 @@ export function ResumeCard({
       : scoreSource === 'rule'
         ? 'bg-amber-500 text-white border-amber-600'
         : ''
+  const visibleIndustryTags = (industryTags ?? [])
+    .filter((tag) => tag.trim().length > 0)
+    .slice(0, 4)
+  const normalizedExperienceLevel = experienceLevel?.trim().toLowerCase()
+  const experienceBadge =
+    normalizedExperienceLevel === 'senior'
+      ? { label: '资深', className: 'border-orange-200 bg-orange-50 text-orange-700' }
+      : normalizedExperienceLevel === 'mid'
+        ? { label: '中级', className: 'border-teal-200 bg-teal-50 text-teal-700' }
+        : normalizedExperienceLevel === 'junior'
+          ? { label: '初级', className: 'border-zinc-200 bg-zinc-50 text-zinc-600' }
+          : null
 
   return (
     <div className="mb-3 overflow-hidden rounded-lg border bg-card">
@@ -148,6 +164,20 @@ export function ResumeCard({
             </Badge>
           </div>
         ) : null}
+        {experienceBadge ? (
+          <Badge variant="outline" className={cn('text-[10px]', experienceBadge.className)}>
+            {experienceBadge.label}
+          </Badge>
+        ) : null}
+        {visibleIndustryTags.map((tag, index) => (
+          <Badge
+            key={`${tag}-${index}`}
+            variant="outline"
+            className="text-[10px] border-violet-200 bg-violet-50 text-violet-700"
+          >
+            {tag}
+          </Badge>
+        ))}
       </div>
 
       <div className="flex flex-col gap-4 p-4 lg:flex-row">

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -828,24 +828,30 @@ export function ResumeList() {
             description={t('resumes.noResumesDesc', 'Try adjusting your filters or search keywords.')}
           />
         ) : (
-          displayedResumes.map((entry) => (
-            <ResumeCard
-              key={entry.key}
-              resume={entry.resume}
-              matchResult={entry.match}
-              ruleScore={entry.ruleScore}
-              showAiScore={entry.match?.scoreSource === 'ai'}
-              actionType={entry.action}
-              onAction={(action) => handleCardAction(entry.key, action)}
-              onViewDetails={() => {
-                setDetailResume(entry.resume)
-                trackReviewedResume(entry.key)
-              }}
-              selected={selectedIds.has(entry.key)}
-              onSelect={() => handleToggleSelect(entry.key)}
-              isReviewed={reviewedIdsSet.has(entry.key)}
-            />
-          ))
+          displayedResumes.map((entry) => {
+            const ingestData = hasIngestData(entry.resume) ? entry.resume.ingestData : undefined
+
+            return (
+              <ResumeCard
+                key={entry.key}
+                resume={entry.resume}
+                matchResult={entry.match}
+                ruleScore={entry.ruleScore}
+                industryTags={ingestData?.industryTags}
+                experienceLevel={ingestData?.experienceLevel}
+                showAiScore={entry.match?.scoreSource === 'ai'}
+                actionType={entry.action}
+                onAction={(action) => handleCardAction(entry.key, action)}
+                onViewDetails={() => {
+                  setDetailResume(entry.resume)
+                  trackReviewedResume(entry.key)
+                }}
+                selected={selectedIds.has(entry.key)}
+                onSelect={() => handleToggleSelect(entry.key)}
+                isReviewed={reviewedIdsSet.has(entry.key)}
+              />
+            )
+          })
         )}
       </div>
       <ResumeDetail

--- a/apps/web/src/pages/DebugJDs.tsx
+++ b/apps/web/src/pages/DebugJDs.tsx
@@ -19,6 +19,14 @@ import { formatInAppTimezone } from '@/lib/timezone'
 type SortColumn = 'title' | 'type' | 'lastModified' | 'usageCount'
 type SortDirection = 'asc' | 'desc'
 
+function getUsageCount(value: unknown): number {
+    if (typeof value !== 'object' || value === null || !('usageCount' in value)) {
+        return 0
+    }
+    const rawUsageCount = value.usageCount
+    return typeof rawUsageCount === 'number' && Number.isFinite(rawUsageCount) ? rawUsageCount : 0
+}
+
 export default function DebugJDs() {
     const { t } = useTranslation()
     const jds = useQuery(api.job_descriptions.list_with_usage)
@@ -64,7 +72,7 @@ export default function DebugJDs() {
             }
 
             if (sortColumn === 'usageCount') {
-                return ((a as any).usageCount - (b as any).usageCount) * direction
+                return (getUsageCount(a) - getUsageCount(b)) * direction
             }
 
             return a.type.localeCompare(b.type, undefined, { sensitivity: 'base' }) * direction
@@ -385,7 +393,7 @@ export default function DebugJDs() {
                                     </TableCell>
                                     <TableCell>
                                         <Badge variant="outline" className="bg-muted text-xs">
-                                            {(jd as any).usageCount || 0} {t('jdManagement.usageSuffix', { defaultValue: 'Analysis' })}
+                                            {getUsageCount(jd)} {t('jdManagement.usageSuffix', { defaultValue: 'Analysis' })}
                                         </Badge>
                                     </TableCell>
                                     <TableCell>
@@ -502,7 +510,7 @@ export default function DebugJDs() {
                         <div>{t('jdManagement.deleteConfirm')}</div>
                         {deleteId && (() => {
                             const jd = jds?.find(j => j._id === deleteId)
-                            const count = (jd as any)?.usageCount || 0
+                            const count = getUsageCount(jd)
                             if (count > 0) {
                                 return (
                                     <div className="flex items-start gap-2 p-3 bg-warning/10 text-orange-600 rounded-md border border-warning/20 text-sm">
@@ -536,7 +544,7 @@ export default function DebugJDs() {
                         <div>{t('jdManagement.confirmBulkDelete', { count: selectedIds.size })}</div>
                         {(() => {
                             const selectedJDs = jds?.filter(jd => selectedIds.has(jd._id)) || []
-                            const totalUsage = selectedJDs.reduce((acc, jd) => acc + ((jd as any).usageCount || 0), 0)
+                            const totalUsage = selectedJDs.reduce((acc, jd) => acc + getUsageCount(jd), 0)
                             if (totalUsage > 0) {
                                 return (
                                     <div className="flex items-start gap-2 p-3 bg-warning/10 text-orange-600 rounded-md border border-warning/20 text-sm">

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -1,3 +1,4 @@
+/// <reference path="./convex-env.d.ts" />
 import { action } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";

--- a/packages/convex/convex/convex-env.d.ts
+++ b/packages/convex/convex/convex-env.d.ts
@@ -1,0 +1,3 @@
+declare const process: {
+  env: Record<string, string | undefined>;
+};

--- a/packages/convex/convex/ingest_agent.ts
+++ b/packages/convex/convex/ingest_agent.ts
@@ -1,3 +1,4 @@
+/// <reference path="./convex-env.d.ts" />
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { internalAction } from "./_generated/server";
@@ -20,7 +21,10 @@ export const processNewResumes = internalAction({
   args: {
     resumeIds: v.array(v.id("resumes")),
   },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx,
+    args
+  ): Promise<{ processed: number; error: string | null }> => {
     const { resumeIds } = args;
 
     if (resumeIds.length === 0) {
@@ -31,7 +35,7 @@ export const processNewResumes = internalAction({
 
     try {
       // 1. Fetch resume documents
-      const resumes = await ctx.runQuery(internal.resumes.getResumesByIds, {
+      const resumes: Array<{ _id: Id<"resumes">; content: Record<string, unknown> }> = await ctx.runQuery(internal.resumes.getResumesByIds, {
         resumeIds,
       });
 
@@ -42,7 +46,7 @@ export const processNewResumes = internalAction({
 
       // 2. Prepare payload for BFF
       const payload = {
-        resumes: resumes.map((resume) => ({
+        resumes: resumes.map((resume: { _id: Id<"resumes">; content: Record<string, unknown> }) => ({
           resumeId: resume._id,
           content: resume.content,
         })),

--- a/packages/convex/convex/lib/parallelism.ts
+++ b/packages/convex/convex/lib/parallelism.ts
@@ -1,3 +1,4 @@
+/// <reference path="../convex-env.d.ts" />
 type EnvSource = Record<string, string | undefined>;
 
 export const DEFAULT_ANALYSIS_PARALLELISM = 4;

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -1,4 +1,5 @@
 import { mutation, query } from "./_generated/server";
+import { internal } from "./_generated/api";
 import { v } from "convex/values";
 import { buildSearchText } from "./search_text";
 import { resolveSubmitResumeParallelism } from "./lib/parallelism";


### PR DESCRIPTION
## Task

implement all tasks and fix

# Plan: Fix CI TypeScript Errors + Display Ingest Signals in UI

## Context

The memory-first resume screening system (M1-M6) is code-complete and migrations have been run. However, `make check-node` fails with 18+ TypeScript errors across the Convex package and web app. These are pre-existing issues unrelated to the recent JD name-resolution fix. Additionally, the ingest agent computes `industryTags` and `experienceLevel` for each resume but the UI only uses `ruleScores` for sorting — the other signals are invisible to users.

## Parallelism Map

```
Group A (ALL INDEPENDENT — run in parallel):
  Task 1: Add process.env ambient declaration for Convex
  Task 2: Add missing `internal` import to resume_tasks.ts
  Task 3: Add explicit return type to ingest_agent.ts handler
  Task 4: Fix unused parameter in BulkActionBar.test.tsx
  Task 5: Display industryTags + experienceLevel in ResumeCard

Group B (DEPENDS: all of Group A):
  Task 6: Verification — make check-node + visual
```

---

## Task 1: Add `process.env` ambient declaration [INDEPENDENT]

**Files**: `packages/convex/convex/convex-env.d.ts` (NEW)
**Resolves**: 10 errors (`analyze.ts` x4, `ingest_agent.ts` x1, `parallelism.ts` x2, plus web transitive x3)

The Convex tsconfig (`packages/convex/convex/tsconfig.json`) has `"lib": ["ES2021", "dom"]` — no Node types. Adding full `@types/node` is wrong since most Node APIs don't exist in Convex runtime. Instead, declare just `process.env`.

Create `packages/convex/convex/convex-env.d.ts`:

```typescript
declare const process: {
  env: Record<string, string | undefined>;
};
```

Auto-included by existing `"include": ["./**/*"]` in tsconfig.

---

## Task 2: Add missing `internal` import [INDEPENDENT]

**Files**: `packages/convex/convex/resume_tasks.ts` (line 1)
**Resolves**: 2 errors (`resume_tasks.ts:428` in both `@trends/convex` and `@trends/web`)

Current imports (line 1):

```typescript
import { mutation, query } from "./_generated/server";
```

Line 428 uses `internal.ingest_agent.processNewResumes` but `internal` is never imported. Add after line 1:

```typescript
import { internal } from "./_generated/api";
```

---

## Task 3: Add explicit return type to `ingest_agent.ts` [INDEPENDENT]

**Files**: `packages/convex/convex/ingest_agent.ts` (lines 23, 34, 45, 81)
**Resolves**: 7 errors (TS7022/TS7023/TS7006 — circular inference from `internal` API types)

The handler return type can't be inferred because `internal.resumes.getResumesByIds` creates a circular type dependency. Fix by adding explicit types:

1. **Line 23** — add return type to handler:

```typescript
   handler: async (ctx, args): Promise<{ processed: number; error: string | null }> => {
```

2. **Line 34** — type the `resumes` variable:

```typescript
   const resumes: Array<{ _id: Id<"resumes">; content: Record<string, unknown> }> = await ctx.runQuery(...)
```

3. **Line 45** — type the `resume` parameter in `.map()`:

```typescript
   resumes.map((resume: { _id: Id<"resumes">; content: Record<string, unknown> }) => ({
```

4. **Line 81** — already has `(item: any)` which is fine under `strict` since it's explicit

---

## Task 4: Fix unused parameter in test [INDEPENDENT]

**Files**: `apps/web/src/components/BulkActionBar.test.tsx` (line 9)
**Resolves**: 1 error (TS6133 unused parameter)

Change:

```typescript
t: (key: string, fallback: string) => fallback,
```

To:

```typescript
t: (_key: string, fallback: string) => fallback,
```

---

## Task 5: Display ingest signals in ResumeCard [INDEPENDENT]

**Files**:

- `apps/web/src/components/ResumeCard.tsx` — add props + badge UI
- `apps/web/src/components/ResumeList.tsx` — pass ingest data to ResumeCard

Currently `industryTags` and `experienceLevel` are pre-computed and stored but invisible. Add:

- **Industry tags** as small violet outline chips (max 4, after score badges)
- **Experience level** as a colored badge (senior=orange, mid=teal, junior=gray, unknown=hidden)

### ResumeCard changes:

1. Add to `ResumeCardProps`:

```typescript
   industryTags?: string[]
   experienceLevel?: string
```

2. Add badges in the header section near existing score display

### ResumeList changes:

Pass `ingestData` fields through to ResumeCard in the render section (\~line 832-848):

```typescript
industryTags={(resume as ConvexResumeItem).ingestData?.industryTags}
experienceLevel={(resume as ConvexResumeItem).ingestData?.experienceLevel}
```

---

## Task 6: Verification [DEPENDS: Tasks 1-5]

```bash
# 1. Type check + lint (should pass with 0 errors)
make check-node

# 2. Run ingest compute tests
bunx vitest run apps/api/src/services/ingest-compute-service.test.ts

# 3. Visual verification (requires make dev)
# - Open http://localhost:5173
# - Navigate to Resumes page
# - Verify industry tags (violet chips) and experience level badges appear on cards
# - Select a JD → verify resumes sort by pre-computed score
# - Search "CNC" → verify results returned
```

---

## Future Work (not in this plan)

- **Scalability**: `listWithIngestData` uses `.collect()` for JD-sorted queries — O(n) memory. Acceptable for <1000 resumes. Add denormalized `primaryRuleScore` index when needed.
- **Re-ingest on JD changes**: When a new JD is created, existing resumes don't get `ruleScores` for it. Add a trigger endpoint later.

## PR Review Summary

- **What Changed**:
  - **TypeScript Fixes**: Resolved 18+ CI errors by adding an ambient declaration for `process.env` in Convex (`convex-env.d.ts`), fixing circular type inference in `ingest_agent.ts`, and resolving unused parameters in tests.
  - **UI Enhancements**: Updated `ResumeCard` and `ResumeList` to display `industryTags` (violet badges) and `experienceLevel` (color-coded badges: Senior/Orange, Mid/Teal, Junior/Gray).
  - **Logic Fixes**: Added missing `internal` imports in `resume_tasks.ts` and implemented a `getUsageCount` helper in `DebugJDs.tsx` to safely handle usage metrics.

- **Review Focus**:
  - **Type Safety**: Verify the explicit types added to `ingest_agent.ts` accurately reflect the `resumes` table schema.
  - **UI/UX**: Ensure the badge colors and limits (max 4 tags) in `ResumeCard` meet design expectations across different screen sizes.
  - **Data Handling**: Check the `getUsageCount` utility in `DebugJDs.tsx` for robust handling of null/undefined values.

- **Test Plan**:
  - **CI Validation**: Run `make check-node` to ensure all 18+ TypeScript errors are resolved.
  - **Visual Check**: Navigate to the Resumes page and verify that industry tags and experience levels appear correctly on candidate cards.
  - **Logic Test**: Run `bunx vitest run apps/api/src/services/ingest-compute-service.test.ts` to validate the ingest pipeline.