### PR TITLE
Update hot keyword ordering and custom keyword seed data

### DIFF
--- a/apps/web/src/hooks/useIndustryKeywords.ts
+++ b/apps/web/src/hooks/useIndustryKeywords.ts
@@ -156,22 +156,16 @@ export function useIndustryKeywords() {
   }, [allKeywords]);
 
   const hotKeywords = useMemo(() => {
-    const popular = [
-      { id: 'p1', keyword: 'CNC', category: 'machining' },
-      { id: 'p2', keyword: '加工中心', category: 'machining' },
-      { id: 'p3', keyword: '数控车床', category: 'lathe' },
-      { id: 'p4', keyword: '销售', category: 'custom' },
-      { id: 'p5', keyword: '工程师', category: 'custom' },
-    ] as IndustryKeyword[]
+    const customSet = new Set(customKeywords.map((item) => item.keyword));
+    const categoryChips = CATEGORY_ORDER
+      .filter((category) => category !== "custom")
+      .flatMap((category) => grouped[category].slice(0, 3));
+    const filteredCategoryChips = categoryChips.filter(
+      (chip) => !customSet.has(chip.keyword)
+    );
 
-    const categoryChips = CATEGORY_ORDER.flatMap((category) => grouped[category].slice(0, 3));
-
-    // Filter out duplicates from category chips if they are already in popular
-    const popularSet = new Set(popular.map(p => p.keyword));
-    const filteredCategoryChips = categoryChips.filter(c => !popularSet.has(c.keyword));
-
-    return [...popular, ...filteredCategoryChips];
-  }, [grouped]);
+    return [...customKeywords, ...filteredCategoryChips];
+  }, [customKeywords, grouped]);
 
   return {
     keywords: allKeywords,

--- a/config/resume/custom-keywords.json5
+++ b/config/resume/custom-keywords.json5
@@ -1,9 +1,25 @@
 {
   tags: [
-    // Custom keyword tags added by user via settings
-    // { id: "custom-1", keyword: "激光切割", english: "laser cutting", category: "custom" }
+    { id: "seed-equipment-cnc", keyword: "CNC", english: "CNC", category: "equipment" },
+    { id: "seed-equipment-cnc-lathe", keyword: "数控车床", english: "CNC Lathe", category: "equipment" },
+    { id: "seed-equipment-machining-center", keyword: "加工中心", english: "Machining Center", category: "equipment" },
+    { id: "seed-equipment-machine-tool", keyword: "机床", english: "Machine Tool", category: "equipment" },
+    { id: "seed-equipment-lathe", keyword: "车床", english: "Lathe", category: "equipment" },
+    { id: "seed-role-sales", keyword: "销售", english: "Sales", category: "role" },
+    { id: "seed-role-engineer", keyword: "工程师", english: "Engineer", category: "role" },
+    { id: "seed-location-dongguan", keyword: "东莞", english: "Dongguan", category: "location" },
+    { id: "seed-brand-haas-cn", keyword: "哈斯", english: "HAAS", category: "brand" },
+    { id: "seed-brand-haas-en", keyword: "HAAS", english: "HAAS", category: "brand" },
+    { id: "seed-brand-fanuc", keyword: "发那科", english: "FANUC", category: "brand" },
+    { id: "seed-brand-star", keyword: "津上", english: "STAR", category: "brand" },
+    { id: "seed-brand-mazak", keyword: "马扎克", english: "MAZAK", category: "brand" },
+    { id: "seed-brand-dmg-mori", keyword: "德马吉森精机", english: "DMG MORI", category: "brand" }
   ],
   categories: [
+    { id: "equipment", name: "设备", icon: "🔧" },
+    { id: "role", name: "岗位", icon: "👤" },
+    { id: "location", name: "地点", icon: "📍" },
+    { id: "brand", name: "品牌", icon: "🏭" },
     { id: "custom", name: "自定义", icon: "⚙️" }
   ]
 }


### PR DESCRIPTION
Summary
- ensure the hot keyword list now prioritizes stored custom keywords and avoids duplicates when combining category chips in `apps/web/src/hooks/useIndustryKeywords.ts:156`
- expand `config/resume/custom-keywords.json5` with seeded equipment, role, location, and brand entries to support the new ordering logic

Testing
- Not run (not requested)