### PR TITLE
Implement following plan; # Plan:

### DIFF
--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -13,6 +13,7 @@ import { BulkActionBar } from '@/components/BulkActionBar'
 import { AnalysisTaskMonitor } from '@/components/AnalysisTaskMonitor'
 import { CollectResumesButton } from '@/components/CollectResumesButton'
 import { useResumeListState } from '@/hooks/useResumeListState'
+import { useSyncNotifications } from '@/hooks/useSyncNotifications'
 import { buildResumeKey, hasIngestData } from '@/lib/resume-scoring'
 
 export function ResumeList() {
@@ -49,6 +50,7 @@ export function ResumeList() {
     handleBulkAction,
     handleCardAction,
   } = useResumeListState()
+  useSyncNotifications()
 
   const [detailResume, setDetailResume] = useState<ResumeItem | null>(null)
 

--- a/apps/web/src/hooks/useSyncNotifications.ts
+++ b/apps/web/src/hooks/useSyncNotifications.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useQuery } from 'convex/react'
+import { toast } from 'sonner'
+import { api } from '../../../../packages/convex/convex/_generated/api'
+
+const EVENT_STALE_MS = 30_000
+
+export function useSyncNotifications() {
+  const { t } = useTranslation()
+  const latestEvent = useQuery(api.sync_events.getLatest)
+  const initializedRef = useRef(false)
+  const lastSeenTimestampRef = useRef(0)
+
+  useEffect(() => {
+    if (latestEvent === undefined) {
+      return
+    }
+
+    const eventTimestamp = latestEvent?.timestamp ?? 0
+
+    if (!initializedRef.current) {
+      initializedRef.current = true
+      lastSeenTimestampRef.current = eventTimestamp
+      return
+    }
+
+    if (!latestEvent || eventTimestamp <= lastSeenTimestampRef.current) {
+      return
+    }
+
+    lastSeenTimestampRef.current = eventTimestamp
+
+    if (Date.now() - eventTimestamp > EVENT_STALE_MS) {
+      return
+    }
+
+    if (latestEvent.status === 'success') {
+      toast.success(
+        t('syncNotifications.success', {
+          submitted: latestEvent.submitted,
+          inserted: latestEvent.inserted,
+          updated: latestEvent.updated,
+          defaultValue: `Synced ${latestEvent.submitted} resumes (${latestEvent.inserted} new, ${latestEvent.updated} updated)`,
+        })
+      )
+      return
+    }
+
+    toast.error(
+      t('syncNotifications.error', {
+        error: latestEvent.error || 'Unknown error',
+        defaultValue: `Sync failed: ${latestEvent.error || 'Unknown error'}`,
+      })
+    )
+  }, [latestEvent, t])
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -250,6 +250,10 @@
       "failed": "Failed"
     }
   },
+  "syncNotifications": {
+    "success": "Synced {{submitted}} resumes ({{inserted}} new, {{updated}} updated)",
+    "error": "Sync failed: {{error}}"
+  },
   "quickStart": {
     "location": "Location",
     "customKeywords": "Keywords",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -250,6 +250,10 @@
       "failed": "失败"
     }
   },
+  "syncNotifications": {
+    "success": "已同步 {{submitted}} 份简历 ({{inserted}} 新增, {{updated}} 更新)",
+    "error": "同步失败: {{error}}"
+  },
   "quickStart": {
     "location": "位置",
     "customKeywords": "关键词",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -250,6 +250,10 @@
       "failed": "失敗"
     }
   },
+  "syncNotifications": {
+    "success": "已同步 {{submitted}} 份簡歷 ({{inserted}} 新增, {{updated}} 更新)",
+    "error": "同步失敗: {{error}}"
+  },
   "quickStart": {
     "location": "位置",
     "customKeywords": "關鍵詞",

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as resumes from "../resumes.js";
 import type * as search_text from "../search_text.js";
 import type * as seed from "../seed.js";
 import type * as sessions from "../sessions.js";
+import type * as sync_events from "../sync_events.js";
 
 import type {
   ApiFromModules,
@@ -40,6 +41,7 @@ declare const fullApi: ApiFromModules<{
   search_text: typeof search_text;
   seed: typeof seed;
   sessions: typeof sessions;
+  sync_events: typeof sync_events;
 }>;
 
 /**

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -432,6 +432,26 @@ export const submitResumes = mutation({
             }
         }
 
+        const now = Date.now();
+        await ctx.db.insert("sync_events", {
+            source: "browser-extension",
+            status: "success",
+            submitted: resumes.length,
+            inserted,
+            updated,
+            unchanged,
+            timestamp: now,
+        });
+
+        const cutoff = now - 3_600_000;
+        const staleEvents = await ctx.db
+            .query("sync_events")
+            .withIndex("by_timestamp", (q) => q.lt("timestamp", cutoff))
+            .take(20);
+        for (const event of staleEvents) {
+            await ctx.db.delete(event._id);
+        }
+
         return {
             input: totalInput,
             submitted: resumes.length,

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -189,4 +189,15 @@ export default defineSchema({
     })
         .index("by_sessionKey", ["sessionKey"])
         .index("by_status", ["status"]),
+
+    sync_events: defineTable({
+        source: v.string(),
+        status: v.union(v.literal("success"), v.literal("error")),
+        submitted: v.number(),
+        inserted: v.number(),
+        updated: v.number(),
+        unchanged: v.number(),
+        error: v.optional(v.string()),
+        timestamp: v.number(),
+    }).index("by_timestamp", ["timestamp"]),
 });

--- a/packages/convex/convex/sync_events.ts
+++ b/packages/convex/convex/sync_events.ts
@@ -1,0 +1,35 @@
+import { mutation, query } from "./_generated/server";
+
+const STALE_EVENT_MS = 3_600_000;
+const MAX_CLEANUP_BATCH = 20;
+
+export const getLatest = query({
+    args: {},
+    handler: async (ctx) => {
+        return await ctx.db
+            .query("sync_events")
+            .withIndex("by_timestamp")
+            .order("desc")
+            .first();
+    },
+});
+
+export const cleanup = mutation({
+    args: {},
+    handler: async (ctx) => {
+        const cutoff = Date.now() - STALE_EVENT_MS;
+        const staleEvents = await ctx.db
+            .query("sync_events")
+            .withIndex("by_timestamp", (q) => q.lt("timestamp", cutoff))
+            .take(MAX_CLEANUP_BATCH);
+
+        for (const event of staleEvents) {
+            await ctx.db.delete(event._id);
+        }
+
+        return {
+            deleted: staleEvents.length,
+            cutoff,
+        };
+    },
+});


### PR DESCRIPTION
## Task

Implement following plan;

# Plan: Real-Time Sync Notifications in Web App via Convex

## Context

When the browser extension submits resumes, the web app's resume list updates automatically (Convex real-time), but there's no explicit notification. Users don't know a sync happened unless they notice new items. The extension's floating widget handles feedback on the job board page, but the web app at `/resumes` stays silent.

**Goal**: Show a toast in the web app like "已同步 30 份简历 (28 新增, 2 更新)" whenever the backend receives resumes from the extension.

**Approach**: Add a `sync_events` Convex table. The `submitResumes` mutation writes an event after processing. The web app subscribes via `useQuery` and fires a toast when a new event arrives. No new transport needed — uses existing Convex WebSocket.

```
Extension → POST /api/resumes/submit → Convex submitResumes mutation
                                              ↓
                                    insert sync_events record
                                              ↓
                                    Convex WebSocket push to web app
                                              ↓
                                    useSyncNotifications hook → toast.success()
```

---

## Task 0: Add `sync_events` table to Convex schema [INDEPENDENT]

**Files**: `packages/convex/convex/schema.ts`

Insert before the closing `});` at line 192:

```typescript
sync_events: defineTable({
    source: v.string(),
    status: v.union(v.literal("success"), v.literal("error")),
    submitted: v.number(),
    inserted: v.number(),
    updated: v.number(),
    unchanged: v.number(),
    error: v.optional(v.string()),
    timestamp: v.number(),
}).index("by_timestamp", ["timestamp"]),
```

---

## Task 1: Create `sync_events.ts` Convex module [INDEPENDENT]

**Files**: `packages/convex/convex/sync_events.ts` (new)

- `getLatest` query: returns most recent sync\_event (ordered by timestamp desc, `.first()`)
- `cleanup` mutation: deletes events older than 1 hour, bounded to 20 per call

---

## Task 2: Write sync\_event in `submitResumes` mutation [DEPENDS: Task 0]

**Files**: `packages/convex/convex/resume_tasks.ts`

Insert after the ingest scheduling block (line \~433) and before the `return`:

```typescript
await ctx.db.insert("sync_events", {
    source: "browser-extension",
    status: "success" as const,
    submitted: resumes.length,
    inserted,
    updated,
    unchanged,
    timestamp: Date.now(),
});

// Opportunistic cleanup: delete up to 20 stale events (>1hr old)
const cutoff = Date.now() - 3_600_000;
const stale = await ctx.db.query("sync_events")
    .withIndex("by_timestamp", (q) => q.lt("timestamp", cutoff))
    .take(20);
for (const e of stale) { await ctx.db.delete(e._id); }
```

---

## Task 3: Create `useSyncNotifications` React hook [INDEPENDENT]

**Files**: `apps/web/src/hooks/useSyncNotifications.ts` (new)

Key logic:

- `useQuery(api.sync_events.getLatest)` — real-time subscription
- `initializedRef`: on first load, record current timestamp without toasting (prevents stale toasts)
- `lastSeenTimestampRef`: skip already-seen events
- 30-second staleness guard: ignore events older than 30s (handles reconnection artifacts)
- Fire `toast.success()` with i18n-translated message including counts

Follows existing patterns from `useConvexResumes.ts` (API import path) and `useResumeListState.ts` (toast + i18n usage).

---

## Task 4: Integrate hook into ResumeList [DEPENDS: Task 3]

**Files**: `apps/web/src/components/ResumeList.tsx`

- Add import: `import { useSyncNotifications } from '@/hooks/useSyncNotifications'`
- Call `useSyncNotifications()` inside `ResumeList()` after line 51 (`useResumeListState()` destructure)

Scoped to `/resumes` page only — no toasts on trends or system pages.

---

## Task 5: Add i18n keys [INDEPENDENT]

**Files**: `apps/web/src/i18n/locales/{en,zh-Hans,zh-Hant}.json`

Add `syncNotifications` namespace:

| Key | en | zh-Hans | zh-Hant |
|-----|-----|---------|---------|
| `success` | `Synced {{submitted}} resumes ({{inserted}} new, {{updated}} updated)` | `已同步 {{submitted}} 份简历 ({{inserted}} 新增, {{updated}} 更新)` | `已同步 {{submitted}} 份簡歷 ({{inserted}} 新增, {{updated}} 更新)` |
| `error` | `Sync failed: {{error}}` | `同步失败: {{error}}` | `同步失敗: {{error}}` |

---

## File Change Summary

| File | Task | Change |
|------|------|--------|
| `packages/convex/convex/schema.ts` | 0 | Add `sync_events` table (\~10 lines) |
| `packages/convex/convex/sync_events.ts` | 1 | New: `getLatest` query + `cleanup` mutation |
| `packages/convex/convex/resume_tasks.ts` | 2 | Insert sync\_event + cleanup in `submitResumes` (\~12 lines) |
| `apps/web/src/hooks/useSyncNotifications.ts` | 3 | New: React hook (\~55 lines) |
| `apps/web/src/components/ResumeList.tsx` | 4 | Add import + hook call (2 lines) |
| `apps/web/src/i18n/locales/*.json` | 5 | Add `syncNotifications` keys (2 keys x 3 locales) |

---

## Verification

1. `npx convex dev` — schema deploys without errors
2. Click "Collect" in web app → extension syncs on job board → web app shows toast within 1-2s
3. Refresh web app page — no stale toast on load
4. Extension floating widget still works independently on job board page
5. `make check-node` — TypeScript compiles
6. `make i18n-check` — no missing keys

## PR Review Summary - **What Changed**: Added sync_events table to packages/convex/convex/schema.ts and created getLatest/cleanup functions in a new sync_events.ts module. Updated the submitResumes mutation in resume_tasks.ts to insert sync event records and perform opportunistic cleanup of data older than one hour. Created the useSyncNotifications hook in apps/web/src/hooks/useSyncNotifications.ts to handle real-time subscriptions and toast notifications using sonner. Integrated the hook into ResumeList.tsx and added corresponding i18n keys for English, Simplified Chinese, and Traditional Chinese. - **Review Focus**: Examine the staleness logic in useSyncNotifications (specifically initializedRef and the 30-second timestamp guard) to ensure users do not receive legacy notifications upon page refresh or reconnection. Verify that the batch-limited cleanup in submitResumes does not adversely affect mutation latency. - **Test Plan**: 1. Trigger a resume sync from the browser extension and confirm the success toast appears in the web app with correct counts. 2. Refresh the web app page and confirm no stale toasts are displayed. 3. Verify that the translation keys render correctly across all supported languages.