### PR TITLE
Implement following plan;


# Plan: Config Immutability + Disable A...

### DIFF
--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -27,6 +27,14 @@ const CustomKeywordUpdateSchema = z.object({
   english: z.string().optional(),
   category: z.string().optional(),
 });
+const RuleWeightsConfigSchema = z.record(z.unknown());
+const LearningLogEntrySchema = z.object({
+  date: z.string(),
+  observation: z.string(),
+});
+const LearningLogAppendSchema = z.object({
+  observation: z.string().trim().min(1),
+});
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -248,6 +256,63 @@ app.delete("/custom-keywords/:id", requireAdmin, async (c) => {
   } catch (error) {
     console.error("Failed to delete custom keyword", error);
     return c.json({ success: false as const, error: "Failed to delete custom keyword" }, 500);
+  }
+});
+
+app.get("/rule-weights", async (c) => {
+  try {
+    const config = await workspaceConfigService.getRuleWeights(c.var.workspaceSlug);
+    return c.json({ success: true as const, config }, 200);
+  } catch (error) {
+    console.error("Failed to load rule weights", error);
+    return c.json({ success: false as const, error: "Failed to load rule weights" }, 500);
+  }
+});
+
+app.put("/rule-weights", requireAdmin, async (c) => {
+  try {
+    const body: unknown = await c.req.json();
+    const parsed = RuleWeightsConfigSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ success: false as const, error: "Invalid rule weights payload" }, 400);
+    }
+
+    await workspaceConfigService.setWorkspaceRuleWeights(c.var.workspaceSlug, parsed.data);
+    const merged = await workspaceConfigService.getRuleWeights(c.var.workspaceSlug);
+    return c.json({ success: true as const, config: merged }, 200);
+  } catch (error) {
+    console.error("Failed to update rule weights", error);
+    return c.json({ success: false as const, error: "Failed to update rule weights" }, 500);
+  }
+});
+
+app.get("/learning-log", async (c) => {
+  try {
+    const entries = await workspaceConfigService.getLearningLog(c.var.workspaceSlug);
+    const parsed = z.array(LearningLogEntrySchema).safeParse(entries);
+    if (!parsed.success) {
+      return c.json({ success: false as const, error: "Invalid learning log format" }, 500);
+    }
+    return c.json({ success: true as const, entries: parsed.data }, 200);
+  } catch (error) {
+    console.error("Failed to load learning log", error);
+    return c.json({ success: false as const, error: "Failed to load learning log" }, 500);
+  }
+});
+
+app.post("/learning-log", requireAdmin, async (c) => {
+  try {
+    const body: unknown = await c.req.json();
+    const parsed = LearningLogAppendSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ success: false as const, error: "Invalid learning log payload" }, 400);
+    }
+
+    const entry = await workspaceConfigService.appendLearningLogEntry(c.var.workspaceSlug, parsed.data.observation);
+    return c.json({ success: true as const, entry }, 201);
+  } catch (error) {
+    console.error("Failed to append learning log", error);
+    return c.json({ success: false as const, error: "Failed to append learning log" }, 500);
   }
 });
 

--- a/apps/api/src/routes/filter-presets.ts
+++ b/apps/api/src/routes/filter-presets.ts
@@ -29,6 +29,12 @@ const CategorySchema = z.object({
     icon: z.string().optional(),
 });
 
+const PresetUpdateSchema = z.object({
+    name: z.string().optional(),
+    category: z.string().optional(),
+    filters: PresetSchema.shape.filters.optional(),
+});
+
 // ============================================================
 // GET /api/filter-presets
 // ============================================================
@@ -167,13 +173,185 @@ const getRoute = createRoute({
 });
 
 app.openapi(getRoute, async (c) => {
-    const { id } = c.req.valid("param");
-    const merged = await workspaceConfigService.getFilterPresets(c.var.workspaceSlug);
-    const preset = merged.presets.find((item) => item.id === id);
+  const { id } = c.req.valid("param");
+  const merged = await workspaceConfigService.getFilterPresets(c.var.workspaceSlug);
+  const preset = merged.presets.find((item) => item.id === id);
     if (!preset) {
         return c.json({ success: false as const, error: `Preset not found: ${id}` }, 404);
+  }
+  return c.json({ success: true as const, preset }, 200);
+});
+
+// ============================================================
+// POST /api/filter-presets
+// ============================================================
+const createPresetRoute = createRoute({
+    method: "post",
+    path: "/",
+    tags: ["Filter Presets"],
+    summary: "Create workspace filter preset",
+    request: {
+        body: {
+            content: {
+                "application/json": {
+                    schema: PresetSchema,
+                },
+            },
+        },
+    },
+    responses: {
+        201: {
+            content: {
+                "application/json": {
+                    schema: z.object({
+                        success: z.literal(true),
+                        preset: PresetSchema,
+                    }),
+                },
+            },
+            description: "Created",
+        },
+        409: { description: "Already exists" },
+        403: { description: "Forbidden" },
+    },
+});
+
+app.openapi(createPresetRoute, async (c) => {
+    if (c.var.accessLevel !== "admin") {
+        return c.json({ success: false as const, error: "Admin access required" }, 403);
     }
-    return c.json({ success: true as const, preset }, 200);
+    const payload = c.req.valid("json");
+    const workspaceConfig = await workspaceConfigService.getWorkspaceFilterPresets(c.var.workspaceSlug);
+    const exists = workspaceConfig.presets.some((preset) => preset.id === payload.id);
+    if (exists) {
+        return c.json({ success: false as const, error: `Preset already exists: ${payload.id}` }, 409);
+    }
+
+    workspaceConfig.presets.push(payload);
+    const categoryExists = workspaceConfig.categories.some((category) => category.id === payload.category);
+    if (!categoryExists) {
+        workspaceConfig.categories.push({
+            id: payload.category,
+            name: payload.category,
+        });
+    }
+
+    await workspaceConfigService.setWorkspaceFilterPresets(c.var.workspaceSlug, workspaceConfig);
+    return c.json({ success: true as const, preset: payload }, 201);
+});
+
+// ============================================================
+// PUT /api/filter-presets/:id
+// ============================================================
+const updatePresetRoute = createRoute({
+    method: "put",
+    path: "/:id",
+    tags: ["Filter Presets"],
+    summary: "Update workspace filter preset",
+    request: {
+        params: z.object({
+            id: z.string(),
+        }),
+        body: {
+            content: {
+                "application/json": {
+                    schema: PresetUpdateSchema,
+                },
+            },
+        },
+    },
+    responses: {
+        200: {
+            content: {
+                "application/json": {
+                    schema: z.object({
+                        success: z.literal(true),
+                        preset: PresetSchema,
+                    }),
+                },
+            },
+            description: "Updated",
+        },
+        404: { description: "Not found" },
+        403: { description: "Forbidden" },
+    },
+});
+
+app.openapi(updatePresetRoute, async (c) => {
+    if (c.var.accessLevel !== "admin") {
+        return c.json({ success: false as const, error: "Admin access required" }, 403);
+    }
+    const { id } = c.req.valid("param");
+    const updates = c.req.valid("json");
+    const workspaceConfig = await workspaceConfigService.getWorkspaceFilterPresets(c.var.workspaceSlug);
+    const index = workspaceConfig.presets.findIndex((preset) => preset.id === id);
+    if (index === -1) {
+        return c.json({ success: false as const, error: `Preset not found in workspace override: ${id}` }, 404);
+    }
+
+    const existing = workspaceConfig.presets[index];
+    const nextPreset = {
+        ...existing,
+        ...updates,
+        id: existing.id,
+    };
+    workspaceConfig.presets[index] = nextPreset;
+
+    const categoryExists = workspaceConfig.categories.some((category) => category.id === nextPreset.category);
+    if (!categoryExists) {
+        workspaceConfig.categories.push({ id: nextPreset.category, name: nextPreset.category });
+    }
+
+    await workspaceConfigService.setWorkspaceFilterPresets(c.var.workspaceSlug, workspaceConfig);
+    return c.json({ success: true as const, preset: nextPreset }, 200);
+});
+
+// ============================================================
+// DELETE /api/filter-presets/:id
+// ============================================================
+const deletePresetRoute = createRoute({
+    method: "delete",
+    path: "/:id",
+    tags: ["Filter Presets"],
+    summary: "Delete workspace filter preset",
+    request: {
+        params: z.object({
+            id: z.string(),
+        }),
+    },
+    responses: {
+        200: {
+            content: {
+                "application/json": {
+                    schema: z.object({
+                        success: z.literal(true),
+                    }),
+                },
+            },
+            description: "Deleted",
+        },
+        404: { description: "Not found" },
+        403: { description: "Forbidden" },
+    },
+});
+
+app.openapi(deletePresetRoute, async (c) => {
+    if (c.var.accessLevel !== "admin") {
+        return c.json({ success: false as const, error: "Admin access required" }, 403);
+    }
+    const { id } = c.req.valid("param");
+    const workspaceConfig = await workspaceConfigService.getWorkspaceFilterPresets(c.var.workspaceSlug);
+    const nextPresets = workspaceConfig.presets.filter((preset) => preset.id !== id);
+
+    if (nextPresets.length === workspaceConfig.presets.length) {
+        return c.json({ success: false as const, error: `Preset not found in workspace override: ${id}` }, 404);
+    }
+
+    await workspaceConfigService.setWorkspaceFilterPresets(c.var.workspaceSlug, {
+        ...workspaceConfig,
+        presets: nextPresets,
+    });
+    return c.json({ success: true as const }, 200);
 });
 
 export default app;

--- a/apps/api/src/routes/job-descriptions.ts
+++ b/apps/api/src/routes/job-descriptions.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { jobDescriptionService } from "../services/job-description-service.js";
 import { DataNotFoundError } from "../services/errors.js";
@@ -43,6 +45,153 @@ const MatchResponseSchema = z.object({
   filterPreset: z.string().optional(),
   suggestedFilters: z.record(z.unknown()).optional(),
 });
+
+type ConvexJobDescriptionRecord = {
+  _id?: unknown;
+  title?: unknown;
+  slug?: unknown;
+  content?: unknown;
+  type?: unknown;
+  enabled?: unknown;
+  lastModified?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readEnvVarFromFile(filePath: string, key: string): string | null {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match || match[1] !== key) {
+      continue;
+    }
+
+    let value = match[2].trim();
+    const hasDoubleQuotes = value.startsWith("\"") && value.endsWith("\"");
+    const hasSingleQuotes = value.startsWith("'") && value.endsWith("'");
+    if (hasDoubleQuotes || hasSingleQuotes) {
+      value = value.slice(1, -1);
+    }
+
+    return value;
+  }
+
+  return null;
+}
+
+function resolveConvexUrl(): string {
+  if (process.env.CONVEX_URL) {
+    return process.env.CONVEX_URL;
+  }
+  if (process.env.VITE_CONVEX_URL) {
+    return process.env.VITE_CONVEX_URL;
+  }
+
+  const projectRoot = jobDescriptionService.projectRoot;
+  const candidateFiles = [
+    path.join(projectRoot, "packages", "convex", ".env.local"),
+    path.join(projectRoot, "apps", "web", ".env.local"),
+    path.join(projectRoot, ".env.local"),
+    path.join(projectRoot, ".env"),
+  ];
+
+  for (const filePath of candidateFiles) {
+    const direct = readEnvVarFromFile(filePath, "CONVEX_URL");
+    if (direct) {
+      return direct;
+    }
+
+    const vite = readEnvVarFromFile(filePath, "VITE_CONVEX_URL");
+    if (vite) {
+      return vite;
+    }
+  }
+
+  return "http://127.0.0.1:3210";
+}
+
+async function callConvex(
+  type: "query" | "mutation",
+  pathName: string,
+  args: Record<string, unknown>
+): Promise<unknown> {
+  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+  const response = await fetch(`${convexUrl}/api/${type}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ path: pathName, args }),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Convex ${type} failed (${response.status}): ${message}`);
+  }
+
+  const payload = await response.json() as unknown;
+  if (!isRecord(payload) || payload.status !== "success") {
+    const errorMessage = isRecord(payload) ? readString(payload.errorMessage) : undefined;
+    throw new Error(errorMessage ?? `Convex ${type} failed for ${pathName}`);
+  }
+
+  return payload.value;
+}
+
+async function listConvexJobDescriptions(workspaceSlug: string): Promise<ConvexJobDescriptionRecord[]> {
+  const value = await callConvex("query", "job_descriptions:list", { workspaceSlug });
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is ConvexJobDescriptionRecord => isRecord(item));
+}
+
+function toJobDescriptionFile(item: ConvexJobDescriptionRecord): {
+  id: string;
+  name: string;
+  filename: string;
+  updatedAt: string;
+  size: number;
+  title?: string;
+  status?: string;
+} | null {
+  const id = readString(item._id ? String(item._id) : item._id) ?? readString(item.slug);
+  const content = typeof item.content === "string" ? item.content : "";
+  if (!id) {
+    return null;
+  }
+
+  const title = readString(item.title);
+  const name = readString(item.slug) ?? id;
+  const lastModified = typeof item.lastModified === "number" ? item.lastModified : Date.now();
+  const enabled = item.enabled === false ? "inactive" : "active";
+
+  return {
+    id,
+    name,
+    filename: `${name}.md`,
+    updatedAt: new Date(lastModified).toISOString(),
+    size: content.length,
+    title,
+    status: enabled,
+  };
+}
 
 // ============================================================
 // GET /api/job-descriptions
@@ -108,14 +257,35 @@ const createRouteDef = createRoute({
   },
 });
 
-app.openapi(createRouteDef, (c) => {
+app.openapi(createRouteDef, async (c) => {
   if (c.var.accessLevel !== "admin") {
     return c.json({ success: false, error: "Admin access required" }, 403);
   }
   const { name, content, overwrite } = c.req.valid("json");
   try {
-    const jd = jobDescriptionService.createFile({ name, content, overwrite });
-    return c.json({ success: true as const, item: jd, content: jd.content }, 201);
+    if (overwrite) {
+      return c.json({ success: false, error: "Overwrite is not supported for read-only system files" }, 400);
+    }
+
+    const createdId = await callConvex("mutation", "job_descriptions:create", {
+      title: name,
+      content,
+      type: "custom",
+      workspaceSlug: c.var.workspaceSlug,
+    });
+
+    const items = await listConvexJobDescriptions(c.var.workspaceSlug);
+    const created = items.find((item) => String(item._id ?? "") === String(createdId));
+    if (!created) {
+      return c.json({ success: false, error: "Created job description could not be loaded" }, 500);
+    }
+
+    const mapped = toJobDescriptionFile(created);
+    if (!mapped) {
+      return c.json({ success: false, error: "Created job description payload is invalid" }, 500);
+    }
+
+    return c.json({ success: true as const, item: mapped, content }, 201);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (message.includes("already exists")) {
@@ -224,16 +394,40 @@ const getRoute = createRoute({
   },
 });
 
-app.openapi(getRoute, (c) => {
+app.openapi(getRoute, async (c) => {
   const { name } = c.req.valid("param");
   try {
     const jd = jobDescriptionService.loadFile(name);
     return c.json({ success: true as const, item: jd, content: jd.content }, 200);
   } catch (error) {
-    if (error instanceof DataNotFoundError) {
+    if (!(error instanceof DataNotFoundError)) {
+      throw error;
+    }
+
+    const convexItems = await listConvexJobDescriptions(c.var.workspaceSlug);
+    const convexMatch = convexItems.find((item) => {
+      const itemId = String(item._id ?? "");
+      const slug = readString(item.slug);
+      return itemId === name || slug === name;
+    });
+
+    if (!convexMatch || typeof convexMatch.content !== "string") {
       return c.json({ success: false, error: error.message }, 404);
     }
-    throw error;
+
+    const mapped = toJobDescriptionFile(convexMatch);
+    if (!mapped) {
+      return c.json({ success: false, error: `Job description not found: ${name}` }, 404);
+    }
+
+    return c.json(
+      {
+        success: true as const,
+        item: mapped,
+        content: convexMatch.content,
+      },
+      200
+    );
   }
 });
 

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -35,6 +35,7 @@ import {
   type ExportFormat,
   type ResumeExportEntry,
 } from "../services/export-service.js";
+import { workspaceConfigService } from "../services/workspace-config-service.js";
 
 import type { ResumeItem } from "../types/resume.js";
 import type { ResumeIndex } from "../services/resume-index.js";
@@ -1685,7 +1686,11 @@ app.post("/api/resumes/learning-feedback", async (c) => {
   }
 
   try {
-    const entry = skillsKnowledgeService.appendLearningEntry(parsed.data.observation);
+    const learningEntry = await workspaceConfigService.appendLearningLogEntry(
+      c.var.workspaceSlug,
+      parsed.data.observation
+    );
+    const entry = `- ${learningEntry.date}: ${learningEntry.observation}`;
     if (parsed.data.action && parsed.data.resumeId) {
       searchEventLogger.logCandidateAction({
         resumeId: parsed.data.resumeId,
@@ -1705,7 +1710,7 @@ app.post("/api/resumes/learning-feedback", async (c) => {
       | undefined;
 
     if (shouldTriggerSkillsReingest(parsed.data.observation)) {
-      bumpedVersion = skillsKnowledgeService.bumpVersion();
+      bumpedVersion = skillsKnowledgeService.getVersion();
       reingest = await triggerReingestStaleSkillsVersion(parsed.data.autoReingestLimit ?? 200);
     }
 

--- a/apps/api/src/routes/scoring-evaluation.ts
+++ b/apps/api/src/routes/scoring-evaluation.ts
@@ -1,10 +1,10 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
 import { config } from "../services/config.js";
-import { loadRuleWeightsConfig } from "../services/rule-scoring.js";
 import { ScoringAutoTuner } from "../services/scoring-auto-tuner.js";
 import { SearchEventAnalyzer } from "../services/search-event-analyzer.js";
 import { WeightHistoryService } from "../services/weight-history.js";
+import { workspaceConfigService } from "../services/workspace-config-service.js";
 
 const app = new OpenAPIHono();
 const analyzer = new SearchEventAnalyzer(config.projectRoot);
@@ -202,7 +202,10 @@ const runTunerRoute = createRoute({
 app.openapi(runTunerRoute, async (c) => {
   const body = c.req.valid("json");
   try {
-    const result = await autoTuner.run(body);
+    const result = await autoTuner.run({
+      ...body,
+      workspaceSlug: c.var.workspaceSlug,
+    });
     return c.json({ success: true as const, result }, 200);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -282,11 +285,11 @@ const rollbackRoute = createRoute({
   },
 });
 
-app.openapi(rollbackRoute, (c) => {
+app.openapi(rollbackRoute, async (c) => {
   const body = c.req.valid("json");
   try {
-    const rollback = weightHistory.rollback(body.entryTs);
-    const currentCategoryWeights = loadRuleWeightsConfig(config.projectRoot).categoryWeights;
+    const rollback = await weightHistory.rollback(body.entryTs, c.var.workspaceSlug);
+    const currentCategoryWeights = (await workspaceConfigService.getRuleWeights(c.var.workspaceSlug)).categoryWeights;
     return c.json(
       {
         success: true as const,

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
-import { searchProfileService, type SearchProfile } from "../services/search-profile-service.js";
+import { searchProfileService, type AutoMatchResult, type SearchProfile } from "../services/search-profile-service.js";
 
 const app = new OpenAPIHono();
 
@@ -324,14 +324,243 @@ async function getCollectionTaskStatus(taskId: string): Promise<Partial<ProfileR
     const progressCurrent = readNumber(progress?.current);
     const resultCount = submitted ?? extracted ?? progressCurrent;
 
-    return {
-        taskStatus: normalizeTaskStatus(task.status),
-        completedAt: toIsoTimestamp(task.completedAt),
-        resultCount: resultCount !== undefined ? Math.round(resultCount) : undefined,
-        extracted: extracted !== undefined ? Math.round(extracted) : undefined,
-        submitted: submitted !== undefined ? Math.round(submitted) : undefined,
-        error: readString(task.error),
+  return {
+    taskStatus: normalizeTaskStatus(task.status),
+    completedAt: toIsoTimestamp(task.completedAt),
+    resultCount: resultCount !== undefined ? Math.round(resultCount) : undefined,
+    extracted: extracted !== undefined ? Math.round(extracted) : undefined,
+    submitted: submitted !== undefined ? Math.round(submitted) : undefined,
+    error: readString(task.error),
+  };
+}
+
+type ConvexSearchProfileRecord = {
+    _id?: unknown;
+    name?: unknown;
+    profile?: unknown;
+    criteria?: unknown;
+    workspaceSlug?: unknown;
+    updatedAt?: unknown;
+    createdAt?: unknown;
+};
+
+function normalizeKeywordList(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return Array.from(
+        new Set(
+            value
+                .map((item) => readString(item))
+                .filter((item): item is string => Boolean(item))
+        )
+    );
+}
+
+function toSearchProfile(record: ConvexSearchProfileRecord): SearchProfile | null {
+    const profileId = record._id ? String(record._id) : "";
+    if (!profileId) {
+        return null;
+    }
+
+    const profilePayload = isRecord(record.profile) ? record.profile : {};
+    const criteria = isRecord(record.criteria) ? record.criteria : {};
+    const criteriaKeywords = normalizeKeywordList(criteria.keywords);
+    const criteriaLocations = normalizeKeywordList(criteria.locations);
+    const fallbackLocation = criteriaLocations[0] ?? "";
+
+    const fallback: SearchProfile = {
+        id: profileId,
+        name: readString(record.name) ?? profileId,
+        status: "active",
+        location: fallbackLocation,
+        keywords: criteriaKeywords,
     };
+
+    const normalized = searchProfileService.normalizeProfileInput(
+        {
+            ...profilePayload,
+            id: profileId,
+        },
+        fallback
+    );
+
+    normalized.id = profileId;
+    if (!normalized.location && fallbackLocation) {
+        normalized.location = fallbackLocation;
+    }
+    if (normalized.keywords.length === 0 && criteriaKeywords.length > 0) {
+        normalized.keywords = criteriaKeywords;
+    }
+
+    if (!normalized.location || normalized.keywords.length === 0) {
+        return null;
+    }
+
+    return normalized;
+}
+
+async function callConvex(
+    type: "query" | "mutation",
+    pathName: string,
+    args: Record<string, unknown>
+): Promise<unknown> {
+    const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+    const response = await fetch(`${convexUrl}/api/${type}`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
+        body: JSON.stringify({ path: pathName, args }),
+    });
+
+    if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Convex ${type} failed (${response.status}): ${text}`);
+    }
+
+    const payload = await response.json() as unknown;
+    if (!isRecord(payload) || payload.status !== "success") {
+        const errorMessage = isRecord(payload) ? readString(payload.errorMessage) : undefined;
+        throw new Error(errorMessage ?? `Convex ${type} failed for ${pathName}`);
+    }
+
+    return payload.value;
+}
+
+async function listCustomProfiles(workspaceSlug: string): Promise<SearchProfile[]> {
+    const value = await callConvex("query", "search_profiles:list", { workspaceSlug });
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value
+        .filter((item): item is ConvexSearchProfileRecord => isRecord(item))
+        .map((item) => toSearchProfile(item))
+        .filter((item): item is SearchProfile => item !== null);
+}
+
+async function getCustomProfile(id: string, workspaceSlug: string): Promise<SearchProfile | null> {
+    const value = await callConvex("query", "search_profiles:getById", { id, workspaceSlug });
+    if (!isRecord(value)) {
+        return null;
+    }
+    return toSearchProfile(value);
+}
+
+async function createCustomProfile(profile: SearchProfile, workspaceSlug: string): Promise<SearchProfile> {
+    const value = await callConvex("mutation", "search_profiles:create", {
+        profile,
+        workspaceSlug,
+    });
+    if (!isRecord(value)) {
+        throw new Error("Failed to create search profile");
+    }
+
+    const created = toSearchProfile(value);
+    if (!created) {
+        throw new Error("Created search profile payload is invalid");
+    }
+    return created;
+}
+
+async function updateCustomProfile(id: string, profile: SearchProfile, workspaceSlug: string): Promise<SearchProfile> {
+    const value = await callConvex("mutation", "search_profiles:update", {
+        id,
+        profile,
+        workspaceSlug,
+    });
+    if (!isRecord(value)) {
+        throw new Error("Failed to update search profile");
+    }
+
+    const updated = toSearchProfile(value);
+    if (!updated) {
+        throw new Error("Updated search profile payload is invalid");
+    }
+    return updated;
+}
+
+async function deleteCustomProfile(id: string, workspaceSlug: string): Promise<boolean> {
+    const value = await callConvex("mutation", "search_profiles:remove", {
+        id,
+        workspaceSlug,
+    });
+    return value === true;
+}
+
+function matchProfiles(profiles: SearchProfile[], keywords: string[], location?: string): AutoMatchResult {
+    const normalizedInputKeywords = Array.from(
+        new Set(
+            keywords
+                .map((keyword) => keyword.trim().toLowerCase())
+                .filter((keyword) => keyword.length > 0)
+        )
+    );
+    if (normalizedInputKeywords.length === 0) {
+        return {
+            confidence: 0,
+            matchedKeywords: [],
+        };
+    }
+
+    let bestMatch: { profile: SearchProfile; score: number; matchedKeywords: string[] } | null = null;
+    for (const profile of profiles) {
+        if (profile.status !== "active") {
+            continue;
+        }
+
+        const profileKeywords = profile.keywords.map((keyword) => keyword.toLowerCase());
+        const matchedKeywords = normalizedInputKeywords.filter((keyword) =>
+            profileKeywords.some((profileKeyword) => profileKeyword.includes(keyword) || keyword.includes(profileKeyword))
+        );
+        let score = matchedKeywords.length / normalizedInputKeywords.length;
+
+        if (location && profile.location) {
+            const profileLocation = profile.location.toLowerCase();
+            const inputLocation = location.toLowerCase();
+            if (profileLocation.includes(inputLocation) || inputLocation.includes(profileLocation)) {
+                score += 0.2;
+            }
+        }
+
+        if (!bestMatch || score > bestMatch.score) {
+            bestMatch = {
+                profile,
+                score,
+                matchedKeywords,
+            };
+        }
+    }
+
+    if (!bestMatch || bestMatch.score <= 0.3) {
+        return {
+            confidence: 0,
+            matchedKeywords: [],
+        };
+    }
+
+    return {
+        profile: bestMatch.profile,
+        jobDescription: bestMatch.profile.jobDescription,
+        filterPreset: bestMatch.profile.filterPreset,
+        confidence: Math.min(bestMatch.score, 1),
+        matchedKeywords: bestMatch.matchedKeywords,
+    };
+}
+
+async function loadProfileById(id: string, workspaceSlug: string): Promise<SearchProfile | null> {
+    const custom = await getCustomProfile(id, workspaceSlug);
+    if (custom) {
+        return custom;
+    }
+
+    try {
+        return searchProfileService.loadProfile(id);
+    } catch {
+        return null;
+    }
 }
 
 // ============================================================
@@ -357,8 +586,14 @@ const statsRoute = createRoute({
     },
 });
 
-app.openapi(statsRoute, (c) => {
-    const stats = searchProfileService.getStats(c.var.workspaceSlug);
+app.openapi(statsRoute, async (c) => {
+    const profiles = await listCustomProfiles(c.var.workspaceSlug);
+    const stats = {
+        total: profiles.length,
+        active: profiles.filter((profile) => profile.status === "active").length,
+        paused: profiles.filter((profile) => profile.status === "paused").length,
+        archived: profiles.filter((profile) => profile.status === "archived").length,
+    };
     return c.json({ success: true, stats } as const);
 });
 
@@ -385,9 +620,18 @@ const listRoute = createRoute({
     },
 });
 
-app.openapi(listRoute, (c) => {
-    const profiles = searchProfileService.listProfiles(c.var.workspaceSlug);
-    return c.json({ success: true, profiles } as const);
+app.openapi(listRoute, async (c) => {
+    const profiles = await listCustomProfiles(c.var.workspaceSlug);
+    const summaries = profiles.map((profile) => ({
+        id: profile.id,
+        name: profile.name,
+        filename: `${profile.id}.yaml`,
+        updatedAt: profile.updatedAt ?? profile.createdAt ?? new Date().toISOString(),
+        status: profile.status,
+        location: profile.location,
+        keywords: profile.keywords,
+    }));
+    return c.json({ success: true, profiles: summaries } as const);
 });
 
 // ============================================================
@@ -422,7 +666,10 @@ const autoMatchRoute = createRoute({
 
 app.openapi(autoMatchRoute, async (c) => {
     const { keywords, location } = c.req.valid("json");
-    const result = searchProfileService.findByKeywords(keywords, location, c.var.workspaceSlug);
+    const customProfiles = await listCustomProfiles(c.var.workspaceSlug);
+    const customMatch = matchProfiles(customProfiles, keywords, location);
+    const systemMatch = searchProfileService.findByKeywords(keywords, location);
+    const result = customMatch.confidence >= systemMatch.confidence ? customMatch : systemMatch;
 
     return c.json({
         success: true,
@@ -480,7 +727,29 @@ const createProfileRoute = createRoute({
 app.openapi(createProfileRoute, async (c) => {
     try {
         const payload = c.req.valid("json");
-        const profile = searchProfileService.createProfile(payload, c.var.workspaceSlug);
+        const provisional = searchProfileService.normalizeProfileInput(payload);
+        const derivedId = provisional.id !== "profile"
+            ? provisional.id
+            : searchProfileService.normalizeProfileIdentifier(provisional.name);
+        const now = new Date().toISOString();
+        const normalizedProfile = searchProfileService.normalizeProfileInput(
+            {
+                ...provisional,
+                id: derivedId,
+                createdAt: provisional.createdAt ?? now,
+                updatedAt: now,
+            },
+            {
+                id: derivedId,
+                name: provisional.name || derivedId,
+                status: provisional.status || "active",
+                location: provisional.location,
+                keywords: provisional.keywords,
+            }
+        );
+        searchProfileService.validateProfile(normalizedProfile);
+
+        const profile = await createCustomProfile(normalizedProfile, c.var.workspaceSlug);
         return c.json({ success: true as const, profile }, 201);
     } catch (error) {
         const message = error instanceof Error ? error.message : "Failed to create profile";
@@ -542,6 +811,17 @@ const runProfileRoute = createRoute({
                 },
             },
         },
+        403: {
+            description: "Forbidden",
+            content: {
+                "application/json": {
+                    schema: z.object({
+                        success: z.literal(false),
+                        error: z.string(),
+                    }),
+                },
+            },
+        },
     },
 });
 
@@ -549,10 +829,8 @@ app.openapi(runProfileRoute, async (c) => {
     const { id } = c.req.valid("param");
     const workspaceSlug = c.var.workspaceSlug;
 
-    let profile: SearchProfile;
-    try {
-        profile = searchProfileService.loadProfile(id, workspaceSlug);
-    } catch {
+    const profile = await loadProfileById(id, workspaceSlug);
+    if (!profile) {
         return c.json({ success: false as const, error: `Profile not found: ${id}` }, 404);
     }
 
@@ -675,6 +953,14 @@ const getProfileStatusRoute = createRoute({
                 },
             },
         },
+        403: {
+            description: "Forbidden",
+            content: {
+                "application/json": {
+                    schema: z.object({ success: z.literal(false), error: z.string() }),
+                },
+            },
+        },
     },
 });
 
@@ -682,10 +968,8 @@ app.openapi(getProfileStatusRoute, async (c) => {
     const { id } = c.req.valid("param");
     const workspaceSlug = c.var.workspaceSlug;
 
-    let profile: SearchProfile;
-    try {
-        profile = searchProfileService.loadProfile(id, workspaceSlug);
-    } catch {
+    const profile = await loadProfileById(id, workspaceSlug);
+    if (!profile) {
         return c.json({ success: false as const, error: `Profile not found: ${id}` }, 404);
     }
 
@@ -749,17 +1033,27 @@ const getRoute = createRoute({
                 },
             },
         },
+        403: {
+            description: "Forbidden",
+            content: {
+                "application/json": {
+                    schema: z.object({
+                        success: z.literal(false),
+                        error: z.string(),
+                    }),
+                },
+            },
+        },
     },
 });
 
-app.openapi(getRoute, (c) => {
+app.openapi(getRoute, async (c) => {
     const { id } = c.req.valid("param");
-    try {
-        const profile = searchProfileService.loadProfile(id, c.var.workspaceSlug);
-        return c.json({ success: true as const, profile }, 200);
-    } catch {
+    const profile = await loadProfileById(id, c.var.workspaceSlug);
+    if (!profile) {
         return c.json({ success: false as const, error: `Profile not found: ${id}` }, 404);
     }
+    return c.json({ success: true as const, profile }, 200);
 });
 
 // ============================================================
@@ -816,6 +1110,17 @@ const updateProfileRoute = createRoute({
                 },
             },
         },
+        403: {
+            description: "Forbidden",
+            content: {
+                "application/json": {
+                    schema: z.object({
+                        success: z.literal(false),
+                        error: z.string(),
+                    }),
+                },
+            },
+        },
     },
 });
 
@@ -824,7 +1129,30 @@ app.openapi(updateProfileRoute, async (c) => {
     const payload = c.req.valid("json");
 
     try {
-        const profile = searchProfileService.updateProfile(id, payload, c.var.workspaceSlug);
+        const existingCustom = await getCustomProfile(id, c.var.workspaceSlug);
+        if (!existingCustom) {
+            const systemProfile = await loadProfileById(id, c.var.workspaceSlug);
+            if (systemProfile) {
+                return c.json({ success: false as const, error: "System profiles are read-only" }, 403);
+            }
+            return c.json({ success: false as const, error: `Profile not found: ${id}` }, 404);
+        }
+
+        const now = new Date().toISOString();
+        const normalized = searchProfileService.normalizeProfileInput(
+            {
+                ...existingCustom,
+                ...(isRecord(payload) ? payload : {}),
+                id: existingCustom.id,
+                createdAt: existingCustom.createdAt ?? now,
+                updatedAt: now,
+            },
+            existingCustom
+        );
+        normalized.id = existingCustom.id;
+        searchProfileService.validateProfile(normalized);
+
+        const profile = await updateCustomProfile(existingCustom.id, normalized, c.var.workspaceSlug);
         return c.json({ success: true as const, profile }, 200);
     } catch (error) {
         const message = error instanceof Error ? error.message : "Failed to update profile";
@@ -865,18 +1193,31 @@ const deleteProfileRoute = createRoute({
                 },
             },
         },
+        403: {
+            description: "Forbidden",
+            content: {
+                "application/json": {
+                    schema: z.object({ success: z.literal(false), error: z.string() }),
+                },
+            },
+        },
     },
 });
 
-app.openapi(deleteProfileRoute, (c) => {
+app.openapi(deleteProfileRoute, async (c) => {
     const { id } = c.req.valid("param");
-    const deleted = searchProfileService.deleteProfile(id, c.var.workspaceSlug);
+    const deleted = await deleteCustomProfile(id, c.var.workspaceSlug);
 
-    if (!deleted) {
-        return c.json({ success: false as const, error: `Profile not found: ${id}` }, 404);
+    if (deleted) {
+        return c.json({ success: true as const }, 200);
     }
 
-    return c.json({ success: true as const }, 200);
+    const systemProfile = await loadProfileById(id, c.var.workspaceSlug);
+    if (systemProfile) {
+        return c.json({ success: false as const, error: "System profiles are read-only" }, 403);
+    }
+
+    return c.json({ success: false as const, error: `Profile not found: ${id}` }, 404);
 });
 
 export default app;

--- a/apps/api/src/services/custom-keyword-service.ts
+++ b/apps/api/src/services/custom-keyword-service.ts
@@ -129,14 +129,6 @@ export class CustomKeywordService {
         return this.cache;
     }
 
-    saveConfig(config: CustomKeywordsConfig): void {
-        const normalized = normalizeConfig(config);
-        const configPath = this.getConfigPath();
-        fs.writeFileSync(configPath, JSON.stringify(normalized, null, 2), "utf8");
-        this.cache = normalized;
-        this.cacheMtimeMs = this.getConfigMtime(configPath);
-    }
-
     listTags(category?: string): CustomKeywordTag[] {
         const config = this.loadConfig();
         if (!category) return config.tags;
@@ -146,50 +138,6 @@ export class CustomKeywordService {
     getTag(id: string): CustomKeywordTag | undefined {
         const config = this.loadConfig();
         return config.tags.find((tag) => tag.id === id);
-    }
-
-    addTag(tag: CustomKeywordTag): void {
-        const config = this.loadConfig();
-        config.tags.push(tag);
-        this.saveConfig(config);
-    }
-
-    updateTag(id: string, updates: Partial<CustomKeywordTag>): CustomKeywordTag | undefined {
-        const config = this.loadConfig();
-        const index = config.tags.findIndex((tag) => tag.id === id);
-        if (index === -1) {
-            return undefined;
-        }
-
-        const nextTag: CustomKeywordTag = {
-            ...config.tags[index],
-            ...updates,
-            id: config.tags[index].id,
-        };
-
-        if (!nextTag.keyword.trim() || !nextTag.category.trim()) {
-            return undefined;
-        }
-
-        config.tags[index] = {
-            ...nextTag,
-            keyword: nextTag.keyword.trim(),
-            english: nextTag.english?.trim() || undefined,
-            category: nextTag.category.trim(),
-        };
-        this.saveConfig(config);
-        return config.tags[index];
-    }
-
-    deleteTag(id: string): boolean {
-        const config = this.loadConfig();
-        const before = config.tags.length;
-        config.tags = config.tags.filter((tag) => tag.id !== id);
-        if (config.tags.length === before) {
-            return false;
-        }
-        this.saveConfig(config);
-        return true;
     }
 
     listCategories(): CustomKeywordCategory[] {

--- a/apps/api/src/services/filter-preset-service.ts
+++ b/apps/api/src/services/filter-preset-service.ts
@@ -100,45 +100,6 @@ export class FilterPresetService {
         return { total: config.presets.length, byCategory };
     }
 
-    saveConfig(config: FilterPresetsConfig): void {
-        const configPath = this.getConfigPath();
-        fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
-        this.cache = config;
-    }
-
-    addPreset(preset: FilterPreset): void {
-        const config = this.loadConfig();
-        config.presets.push(preset);
-        this.saveConfig(config);
-    }
-
-    updatePreset(id: string, updates: Partial<FilterPreset>): FilterPreset | undefined {
-        const config = this.loadConfig();
-        const index = config.presets.findIndex((preset) => preset.id === id);
-        if (index === -1) {
-            return undefined;
-        }
-
-        const updatedPreset: FilterPreset = {
-            ...config.presets[index],
-            ...updates,
-        };
-        config.presets[index] = updatedPreset;
-        this.saveConfig(config);
-        return updatedPreset;
-    }
-
-    deletePreset(id: string): boolean {
-        const config = this.loadConfig();
-        const before = config.presets.length;
-        config.presets = config.presets.filter((preset) => preset.id !== id);
-        if (config.presets.length === before) {
-            return false;
-        }
-        this.saveConfig(config);
-        return true;
-    }
-
     /**
      * Clear cache
      */

--- a/apps/api/src/services/job-description-service.ts
+++ b/apps/api/src/services/job-description-service.ts
@@ -64,15 +64,6 @@ export class JobDescriptionService {
     return path.join(this.projectRoot, "config", "job-descriptions");
   }
 
-  private normalizeName(name: string): string {
-    return name
-      .trim()
-      .replace(/\.md$/i, "")
-      .toLowerCase()
-      .replace(/[^a-z0-9-_]+/g, "-")
-      .replace(/^-+|-+$/g, "");
-  }
-
   /**
    * Parse YAML frontmatter from markdown content
    */
@@ -193,29 +184,6 @@ export class JobDescriptionService {
 
     this.cache.set(cacheKey, jd);
     return jd;
-  }
-
-  createFile(input: { name: string; content: string; overwrite?: boolean }): JobDescriptionFull {
-    const normalizedName = this.normalizeName(input.name);
-    if (!normalizedName) {
-      throw new Error("Invalid job description name");
-    }
-
-    const dir = this.getDescriptionsDir();
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-
-    const filePath = path.join(dir, `${normalizedName}.md`);
-    if (!input.overwrite && fs.existsSync(filePath)) {
-      throw new Error(`Job description already exists: ${normalizedName}`);
-    }
-
-    const content = input.content.endsWith("\n") ? input.content : `${input.content}\n`;
-    fs.writeFileSync(filePath, content, "utf8");
-    this.cache.delete(normalizedName);
-
-    return this.loadFile(normalizedName);
   }
 
   /**

--- a/apps/api/src/services/rule-scoring.ts
+++ b/apps/api/src/services/rule-scoring.ts
@@ -81,7 +81,7 @@ const ruleWeightsSchema = z.object({
   }).partial().optional(),
 }).partial();
 
-type RuleWeightsConfigOverrides = z.infer<typeof ruleWeightsSchema>;
+export type RuleWeightsConfigOverrides = z.infer<typeof ruleWeightsSchema>;
 
 export function mergeRuleWeights(overrides: RuleWeightsConfigOverrides | undefined): RuleWeightsConfig {
   if (!overrides) {
@@ -112,6 +112,14 @@ export function mergeRuleWeights(overrides: RuleWeightsConfigOverrides | undefin
   };
 }
 
+export function parseRuleWeightsOverrides(raw: unknown): RuleWeightsConfigOverrides | undefined {
+  const parsed = ruleWeightsSchema.safeParse(raw);
+  if (!parsed.success) {
+    return undefined;
+  }
+  return parsed.data;
+}
+
 export function loadRuleWeightsConfig(projectRoot: string): RuleWeightsConfig {
   const configPath = path.join(projectRoot, "config", "resume", "rule-weights.json5");
   if (!fs.existsSync(configPath)) {
@@ -121,23 +129,17 @@ export function loadRuleWeightsConfig(projectRoot: string): RuleWeightsConfig {
   try {
     const content = fs.readFileSync(configPath, "utf8");
     const raw: unknown = JSON5.parse(content);
-    const parsed = ruleWeightsSchema.safeParse(raw);
-    if (!parsed.success) {
-      console.error("[RuleScoring] Failed to parse rule-weights.json5:", parsed.error);
+    const parsed = parseRuleWeightsOverrides(raw);
+    if (!parsed) {
+      console.error("[RuleScoring] Failed to parse rule-weights.json5");
       return DEFAULT_WEIGHTS;
     }
 
-    return mergeRuleWeights(parsed.data);
+    return mergeRuleWeights(parsed);
   } catch (error) {
     console.error("[RuleScoring] Failed to load rule-weights.json5:", error);
     return DEFAULT_WEIGHTS;
   }
-}
-
-export function saveRuleWeightsConfig(projectRoot: string, config: RuleWeightsConfig): void {
-  const configPath = path.join(projectRoot, "config", "resume", "rule-weights.json5");
-  const serialized = `${JSON5.stringify(config, null, 2)}\n`;
-  fs.writeFileSync(configPath, serialized, "utf8");
 }
 
 export interface BrandHit {

--- a/apps/api/src/services/scoring-auto-tuner.test.ts
+++ b/apps/api/src/services/scoring-auto-tuner.test.ts
@@ -2,13 +2,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { resetResumeScreeningDb } from "./database";
 import { MatchStorage } from "./match-storage";
 import { loadRuleWeightsConfig } from "./rule-scoring";
 import { ScoringAutoTuner } from "./scoring-auto-tuner";
 import { WeightHistoryService } from "./weight-history";
+import { workspaceConfigService } from "./workspace-config-service";
 
 function createFixtureRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "scoring-auto-tuner-"));
@@ -188,6 +189,14 @@ describe("ScoringAutoTuner", () => {
 
     try {
       const initialWeights = loadRuleWeightsConfig(root).categoryWeights;
+      const getRuleWeightsMock = vi.spyOn(workspaceConfigService, "getRuleWeights").mockResolvedValue(
+        loadRuleWeightsConfig(root)
+      );
+      const setRuleWeightsMock = vi.spyOn(workspaceConfigService, "setWorkspaceRuleWeights").mockResolvedValue();
+      const appendLearningMock = vi.spyOn(workspaceConfigService, "appendLearningLogEntry").mockResolvedValue({
+        date: "2026-02-25",
+        observation: "mock",
+      });
       const tuner = new ScoringAutoTuner(root, {
         fetchImpl: async () => new Response(JSON.stringify({ success: true }), { status: 200 }),
       });
@@ -202,9 +211,14 @@ describe("ScoringAutoTuner", () => {
 
       expect(result.status).toBe("dry_run");
       expect(result.proposedCategoryWeights).toBeDefined();
+      expect(setRuleWeightsMock).not.toHaveBeenCalled();
 
       const afterWeights = loadRuleWeightsConfig(root).categoryWeights;
       expect(afterWeights).toEqual(initialWeights);
+
+      getRuleWeightsMock.mockRestore();
+      setRuleWeightsMock.mockRestore();
+      appendLearningMock.mockRestore();
     } finally {
       cleanupFixtureRoot(root);
     }
@@ -214,6 +228,22 @@ describe("ScoringAutoTuner", () => {
     const root = createFixtureRoot();
 
     try {
+      let runtimeWeights = loadRuleWeightsConfig(root);
+      const getRuleWeightsMock = vi.spyOn(workspaceConfigService, "getRuleWeights").mockImplementation(async () => runtimeWeights);
+      const setRuleWeightsMock = vi.spyOn(workspaceConfigService, "setWorkspaceRuleWeights").mockImplementation(async (_workspace, config) => {
+        runtimeWeights = {
+          ...runtimeWeights,
+          ...config,
+          categoryWeights: {
+            ...runtimeWeights.categoryWeights,
+            ...config.categoryWeights,
+          },
+        };
+      });
+      const appendLearningMock = vi.spyOn(workspaceConfigService, "appendLearningLogEntry").mockResolvedValue({
+        date: "2026-02-25",
+        observation: "mock",
+      });
       const tuner = new ScoringAutoTuner(root, {
         fetchImpl: async () => new Response(JSON.stringify({ success: true }), { status: 200 }),
       });
@@ -230,7 +260,7 @@ describe("ScoringAutoTuner", () => {
       expect(applied.proposedCategoryWeights).toBeDefined();
       expect(applied.reingestTriggered).toBe(true);
 
-      const currentWeights = loadRuleWeightsConfig(root).categoryWeights;
+      const currentWeights = runtimeWeights.categoryWeights;
       expect(currentWeights).toEqual(applied.proposedCategoryWeights);
 
       const historyService = new WeightHistoryService(root);
@@ -242,6 +272,10 @@ describe("ScoringAutoTuner", () => {
         minLabeledActions: 2,
       });
       expect(cooldown.status).toBe("cooldown");
+
+      getRuleWeightsMock.mockRestore();
+      setRuleWeightsMock.mockRestore();
+      appendLearningMock.mockRestore();
     } finally {
       cleanupFixtureRoot(root);
     }

--- a/apps/api/src/services/scoring-auto-tuner.ts
+++ b/apps/api/src/services/scoring-auto-tuner.ts
@@ -2,19 +2,15 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { findProjectRoot } from "./db.js";
-import {
-  loadRuleWeightsConfig,
-  saveRuleWeightsConfig,
-  type RuleWeightsConfig,
-} from "./rule-scoring.js";
+import { type RuleWeightsConfig } from "./rule-scoring.js";
 import {
   SearchEventAnalyzer,
   type AnalysisReport,
   type WeightValidationReport,
   type WeightAdjustmentSuggestion,
 } from "./search-event-analyzer.js";
-import { SkillsKnowledgeService } from "./skills-knowledge.js";
 import { WeightHistoryService, type WeightHistoryEntry } from "./weight-history.js";
+import { workspaceConfigService } from "./workspace-config-service.js";
 
 type RuleCategoryWeights = RuleWeightsConfig["categoryWeights"];
 type CategoryKey = keyof RuleCategoryWeights;
@@ -27,6 +23,7 @@ interface AutoTuneState {
 type FetchLike = typeof fetch;
 
 export interface ScoringAutoTuneRunOptions {
+  workspaceSlug?: string;
   dryRun?: boolean;
   periodDays?: number;
   k?: number;
@@ -183,7 +180,6 @@ function areCategoryWeightsEqual(left: RuleCategoryWeights, right: RuleCategoryW
 export class ScoringAutoTuner {
   private readonly projectRoot: string;
   private readonly analyzer: SearchEventAnalyzer;
-  private readonly skillsService: SkillsKnowledgeService;
   private readonly weightHistory: WeightHistoryService;
   private readonly fetchImpl: FetchLike;
   private readonly now: () => Date;
@@ -192,7 +188,6 @@ export class ScoringAutoTuner {
     projectRoot?: string,
     deps?: {
       analyzer?: SearchEventAnalyzer;
-      skillsService?: SkillsKnowledgeService;
       weightHistory?: WeightHistoryService;
       fetchImpl?: FetchLike;
       now?: () => Date;
@@ -200,7 +195,6 @@ export class ScoringAutoTuner {
   ) {
     this.projectRoot = projectRoot ? path.resolve(projectRoot) : findProjectRoot();
     this.analyzer = deps?.analyzer ?? new SearchEventAnalyzer(this.projectRoot);
-    this.skillsService = deps?.skillsService ?? new SkillsKnowledgeService(this.projectRoot);
     this.weightHistory = deps?.weightHistory ?? new WeightHistoryService(this.projectRoot);
     this.fetchImpl = deps?.fetchImpl ?? fetch;
     this.now = deps?.now ?? (() => new Date());
@@ -275,6 +269,7 @@ export class ScoringAutoTuner {
   }
 
   async run(options?: ScoringAutoTuneRunOptions): Promise<ScoringAutoTuneRunResult> {
+    const workspaceSlug = options?.workspaceSlug?.trim() || "dev";
     const dryRun = options?.dryRun === true;
     const periodDays = Math.max(1, options?.periodDays ?? 14);
     const k = Math.max(1, options?.k ?? 10);
@@ -309,7 +304,7 @@ export class ScoringAutoTuner {
       };
     }
 
-    const currentConfig = loadRuleWeightsConfig(this.projectRoot);
+    const currentConfig = await workspaceConfigService.getRuleWeights(workspaceSlug);
     const proposedCategoryWeights = this.applySuggestions(
       currentConfig.categoryWeights,
       report.suggestions.weightAdjustments
@@ -378,7 +373,7 @@ export class ScoringAutoTuner {
       ...currentConfig,
       categoryWeights: proposedCategoryWeights,
     };
-    saveRuleWeightsConfig(this.projectRoot, updatedConfig);
+    await workspaceConfigService.setWorkspaceRuleWeights(workspaceSlug, updatedConfig);
 
     const highConfidenceSynonyms = report.suggestions.synonymSuggestions
       .filter((suggestion) => suggestion.confidence >= 0.8)
@@ -386,8 +381,15 @@ export class ScoringAutoTuner {
         variant: suggestion.variant,
         canonical: suggestion.canonical,
       }));
-    const synonymsApplied = this.skillsService.applySynonymSuggestions(highConfidenceSynonyms);
-    this.skillsService.appendLearningEntry(
+    const synonymsApplied = highConfidenceSynonyms.length;
+    for (const suggestion of highConfidenceSynonyms) {
+      await workspaceConfigService.appendLearningLogEntry(
+        workspaceSlug,
+        `synonym_suggestion: ${suggestion.variant} -> ${suggestion.canonical}`
+      );
+    }
+    await workspaceConfigService.appendLearningLogEntry(
+      workspaceSlug,
       `auto_tune_weights: ndcg ${validation.current.ndcgAtK} -> ${validation.projected.ndcgAtK}`
     );
 

--- a/apps/api/src/services/search-profile-service.ts
+++ b/apps/api/src/services/search-profile-service.ts
@@ -8,7 +8,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { parse as parseYaml } from "yaml";
 
 import { findProjectRoot } from "./db.js";
 import { DataNotFoundError } from "./errors.js";
@@ -436,17 +436,6 @@ export class SearchProfileService {
         return path.join(baseDir, normalizedWorkspace);
     }
 
-    private ensureProfilesDir(workspaceSlug?: string): void {
-        const profilesDir = this.getProfilesDir(workspaceSlug);
-        if (!fs.existsSync(profilesDir)) {
-            fs.mkdirSync(profilesDir, { recursive: true });
-        }
-    }
-
-    private getProfilePath(id: string, workspaceSlug?: string): string {
-        return path.join(this.getProfilesDir(workspaceSlug), `${id}.yaml`);
-    }
-
     private findExistingProfilePath(id: string, workspaceSlug?: string): string | null {
         const profilesDir = this.getProfilesDir(workspaceSlug);
         const candidates = [
@@ -551,19 +540,20 @@ export class SearchProfileService {
         }
     }
 
-    private getCacheKey(workspaceSlug: string, profileId: string): string {
-        return `${workspaceSlug}:${profileId}`;
+    normalizeProfileInput(input: unknown, fallback?: SearchProfile): SearchProfile {
+        return this.coerceProfile(input, fallback);
     }
 
-    private writeProfile(profile: SearchProfile, workspaceSlug?: string): void {
-        this.ensureProfilesDir(workspaceSlug);
-        const filePath = this.getProfilePath(profile.id, workspaceSlug);
-        const payload = stringifyYaml(profile, {
-            lineWidth: 120,
-            indent: 2,
-            minContentWidth: 20,
-        });
-        fs.writeFileSync(filePath, payload, "utf8");
+    normalizeProfileIdentifier(id: string): string {
+        return normalizeProfileId(id);
+    }
+
+    validateProfile(profile: SearchProfile): void {
+        this.ensureRequiredCoreFields(profile);
+    }
+
+    private getCacheKey(workspaceSlug: string, profileId: string): string {
+        return `${workspaceSlug}:${profileId}`;
     }
 
     /**
@@ -619,68 +609,6 @@ export class SearchProfileService {
         const profile = this.readProfileFromFile(existingPath, normalizedId);
         this.cache.set(cacheKey, profile);
         return profile;
-    }
-
-    createProfile(input: unknown, workspaceSlug?: string): SearchProfile {
-        const normalizedWorkspace = normalizeWorkspaceSlug(workspaceSlug);
-        const provisional = this.coerceProfile(input);
-        const derivedId = provisional.id !== "profile" ? provisional.id : normalizeProfileId(provisional.name);
-        const profile = this.coerceProfile({ ...provisional, id: derivedId });
-        this.ensureRequiredCoreFields(profile);
-
-        if (this.findExistingProfilePath(profile.id, normalizedWorkspace)) {
-            throw new Error(`Profile already exists: ${profile.id}`);
-        }
-
-        const now = new Date().toISOString();
-        const profileToStore: SearchProfile = {
-            ...profile,
-            createdAt: profile.createdAt ?? now,
-            updatedAt: now,
-        };
-
-        this.writeProfile(profileToStore, normalizedWorkspace);
-        this.cache.set(this.getCacheKey(normalizedWorkspace, profileToStore.id), profileToStore);
-        return profileToStore;
-    }
-
-    updateProfile(id: string, updates: unknown, workspaceSlug?: string): SearchProfile {
-        const normalizedWorkspace = normalizeWorkspaceSlug(workspaceSlug);
-        const normalizedId = normalizeProfileId(id);
-        const existing = this.loadProfile(normalizedId, normalizedWorkspace);
-
-        const mergedInput: Record<string, unknown> = {
-            ...existing,
-            ...(isRecord(updates) ? updates : {}),
-            id: normalizedId,
-        };
-        const profile = this.coerceProfile(mergedInput, existing);
-        this.ensureRequiredCoreFields(profile);
-
-        const now = new Date().toISOString();
-        const profileToStore: SearchProfile = {
-            ...profile,
-            id: normalizedId,
-            createdAt: existing.createdAt ?? profile.createdAt ?? now,
-            updatedAt: now,
-        };
-
-        this.writeProfile(profileToStore, normalizedWorkspace);
-        this.cache.set(this.getCacheKey(normalizedWorkspace, normalizedId), profileToStore);
-        return profileToStore;
-    }
-
-    deleteProfile(id: string, workspaceSlug?: string): boolean {
-        const normalizedWorkspace = normalizeWorkspaceSlug(workspaceSlug);
-        const normalizedId = normalizeProfileId(id);
-        const existingPath = this.findExistingProfilePath(normalizedId, normalizedWorkspace);
-        if (!existingPath) {
-            return false;
-        }
-
-        fs.unlinkSync(existingPath);
-        this.cache.delete(this.getCacheKey(normalizedWorkspace, normalizedId));
-        return true;
     }
 
     /**

--- a/apps/api/src/services/skills-knowledge.test.ts
+++ b/apps/api/src/services/skills-knowledge.test.ts
@@ -343,21 +343,14 @@ describe("SkillsKnowledgeService", () => {
     }
   });
 
-  it("appends learning feedback into Learning Log section", () => {
+  it("rejects appending learning feedback at runtime (skills.md read-only)", () => {
     const root = createFixtureRoot();
 
     try {
       const service = new SkillsKnowledgeService(root);
-      const entry = service.appendLearningEntry("shortlist pattern -> cnc + senior");
-
-      expect(entry).toMatch(/^- \d{4}-\d{2}-\d{2}: shortlist pattern -> cnc \+ senior$/);
-
-      const log = service.getLearningLog();
-      expect(log).toHaveLength(7);
-      expect(log[6]?.observation).toBe("shortlist pattern -> cnc + senior");
-
-      const saved = fs.readFileSync(path.join(root, "config", "resume", "skills.md"), "utf8");
-      expect(saved).toContain(entry);
+      expect(() => service.appendLearningEntry("shortlist pattern -> cnc + senior")).toThrow(
+        "skills.md is read-only at runtime"
+      );
     } finally {
       cleanupFixtureRoot(root);
     }
@@ -421,19 +414,12 @@ describe("SkillsKnowledgeService", () => {
     }
   });
 
-  it("bumps skills version and updates frontmatter timestamp", () => {
+  it("rejects bumping skills version at runtime (skills.md read-only)", () => {
     const root = createFixtureRoot();
 
     try {
       const service = new SkillsKnowledgeService(root);
-      const nextVersion = service.bumpVersion();
-
-      expect(nextVersion).toBe(2);
-      expect(service.getVersion()).toBe(2);
-
-      const saved = fs.readFileSync(path.join(root, "config", "resume", "skills.md"), "utf8");
-      expect(saved).toContain("version: 2");
-      expect(saved).toMatch(/updated_at:\s*'\d{4}-\d{2}-\d{2}'/);
+      expect(() => service.bumpVersion()).toThrow("skills.md is read-only at runtime");
     } finally {
       cleanupFixtureRoot(root);
     }
@@ -465,21 +451,17 @@ describe("SkillsKnowledgeService", () => {
     }
   });
 
-  it("applies synonym suggestions into the Synonym Table section", () => {
+  it("rejects applying synonym suggestions at runtime (skills.md read-only)", () => {
     const root = createFixtureRoot();
 
     try {
       const service = new SkillsKnowledgeService(root);
-      const added = service.applySynonymSuggestions([
-        { variant: "哈斯机台", canonical: "哈斯" },
-        { variant: "车铣复合", canonical: "车床" },
-      ]);
-
-      expect(added).toBe(2);
-
-      const synonyms = service.getSynonymTable();
-      expect(synonyms.get("哈斯机台")).toBe("哈斯");
-      expect(synonyms.get("车铣复合")).toBe("车床");
+      expect(() =>
+        service.applySynonymSuggestions([
+          { variant: "哈斯机台", canonical: "哈斯" },
+          { variant: "车铣复合", canonical: "车床" },
+        ])
+      ).toThrow("skills.md is read-only at runtime");
     } finally {
       cleanupFixtureRoot(root);
     }

--- a/apps/api/src/services/skills-knowledge.ts
+++ b/apps/api/src/services/skills-knowledge.ts
@@ -811,73 +811,7 @@ export class SkillsKnowledgeService {
   }
 
   bumpVersion(): number {
-    const skillsPath = this.getSkillsPath();
-    if (!fs.existsSync(skillsPath)) {
-      throw new FileParseError(skillsPath, "skills.md not found");
-    }
-
-    const content = fs.readFileSync(skillsPath, "utf8");
-    const lines = content.split("\n");
-    if (lines[0]?.trim() !== "---") {
-      throw new FileParseError(skillsPath, "Invalid frontmatter: expected opening ---");
-    }
-
-    let frontmatterEnd = -1;
-    for (let index = 1; index < lines.length; index += 1) {
-      if (lines[index].trim() === "---") {
-        frontmatterEnd = index;
-        break;
-      }
-    }
-
-    if (frontmatterEnd === -1) {
-      throw new FileParseError(skillsPath, "Invalid frontmatter: no closing ---");
-    }
-
-    const frontmatterLines = lines.slice(1, frontmatterEnd);
-    const frontmatter = parseYaml(frontmatterLines.join("\n")) as unknown;
-    const currentVersion = (
-      isRecord(frontmatter)
-      && typeof frontmatter.version === "number"
-      && Number.isFinite(frontmatter.version)
-    )
-      ? Math.floor(frontmatter.version)
-      : 0;
-
-    const nextVersion = currentVersion + 1;
-    const updatedAt = new Date().toISOString().slice(0, 10);
-
-    let hasVersion = false;
-    let hasUpdatedAt = false;
-
-    const updatedFrontmatterLines = frontmatterLines.map((line) => {
-      if (/^version\s*:/.test(line)) {
-        hasVersion = true;
-        return `version: ${nextVersion}`;
-      }
-      if (/^updated_at\s*:/.test(line)) {
-        hasUpdatedAt = true;
-        return `updated_at: '${updatedAt}'`;
-      }
-      return line;
-    });
-
-    if (!hasVersion) {
-      updatedFrontmatterLines.push(`version: ${nextVersion}`);
-    }
-    if (!hasUpdatedAt) {
-      updatedFrontmatterLines.push(`updated_at: '${updatedAt}'`);
-    }
-
-    const nextLines = [
-      lines[0],
-      ...updatedFrontmatterLines,
-      ...lines.slice(frontmatterEnd),
-    ];
-
-    fs.writeFileSync(skillsPath, nextLines.join("\n"), "utf8");
-    this.clearCache();
-    return nextVersion;
+    throw new Error("skills.md is read-only at runtime");
   }
 
   appendLearningEntry(observation: string): string {
@@ -885,53 +819,7 @@ export class SkillsKnowledgeService {
     if (!normalizedObservation) {
       throw new Error("Observation cannot be empty");
     }
-
-    const skillsPath = this.getSkillsPath();
-    if (!fs.existsSync(skillsPath)) {
-      throw new FileParseError(skillsPath, "skills.md not found");
-    }
-
-    const content = fs.readFileSync(skillsPath, "utf8");
-    const lines = content.split("\n");
-    const learningLogIndex = lines.findIndex((line) =>
-      /^##\s+Learning Log(?:\s*\([^)]*\))?\s*$/i.test(line.trim())
-    );
-
-    if (learningLogIndex === -1) {
-      throw new FileParseError(skillsPath, "Learning Log section not found");
-    }
-
-    let sectionEndIndex = lines.length;
-    for (let index = learningLogIndex + 1; index < lines.length; index += 1) {
-      if (/^##\s+/.test(lines[index].trim())) {
-        sectionEndIndex = index;
-        break;
-      }
-    }
-
-    while (sectionEndIndex > learningLogIndex + 1 && lines[sectionEndIndex - 1].trim() === "") {
-      sectionEndIndex -= 1;
-    }
-
-    const date = new Date().toISOString().slice(0, 10);
-    const entry = `- ${date}: ${normalizedObservation}`;
-
-    const insertLines: string[] = [];
-    if (sectionEndIndex === learningLogIndex + 1) {
-      insertLines.push("");
-    }
-    insertLines.push(entry);
-
-    const updatedLines = [
-      ...lines.slice(0, sectionEndIndex),
-      ...insertLines,
-      ...lines.slice(sectionEndIndex),
-    ];
-
-    fs.writeFileSync(skillsPath, updatedLines.join("\n"), "utf8");
-    this.clearCache();
-
-    return entry;
+    throw new Error("skills.md is read-only at runtime");
   }
 
   applySynonymSuggestions(
@@ -940,93 +828,7 @@ export class SkillsKnowledgeService {
     if (suggestions.length === 0) {
       return 0;
     }
-
-    const skillsPath = this.getSkillsPath();
-    if (!fs.existsSync(skillsPath)) {
-      throw new FileParseError(skillsPath, "skills.md not found");
-    }
-
-    const content = fs.readFileSync(skillsPath, "utf8");
-    const lines = content.split("\n");
-    const synonymHeadingIndex = lines.findIndex((line) => /^##\s+Synonym Table\s*$/i.test(line.trim()));
-    if (synonymHeadingIndex === -1) {
-      throw new FileParseError(skillsPath, "Synonym Table section not found");
-    }
-
-    let sectionEndIndex = lines.length;
-    for (let index = synonymHeadingIndex + 1; index < lines.length; index += 1) {
-      if (/^##\s+/.test(lines[index].trim())) {
-        sectionEndIndex = index;
-        break;
-      }
-    }
-
-    const existing = new Map<string, { canonical: string; variants: Set<string> }>();
-    for (const line of lines.slice(synonymHeadingIndex + 1, sectionEndIndex)) {
-      const match = line.match(/^\s*-\s*([^:]+):\s*(.+)$/);
-      if (!match) {
-        continue;
-      }
-
-      const canonicalRaw = match[1].trim();
-      const canonical = normalizeToken(canonicalRaw);
-      if (!canonical) {
-        continue;
-      }
-
-      const variants = match[2]
-        .split(",")
-        .map((value) => normalizeToken(value))
-        .filter((value) => value.length > 0 && value !== canonical);
-      existing.set(canonical, {
-        canonical: canonicalRaw,
-        variants: new Set(variants),
-      });
-    }
-
-    let addedCount = 0;
-    for (const suggestion of suggestions) {
-      const variant = normalizeToken(suggestion.variant);
-      const canonical = normalizeToken(suggestion.canonical);
-      if (!variant || !canonical || variant === canonical) {
-        continue;
-      }
-
-      const entry = existing.get(canonical) ?? {
-        canonical,
-        variants: new Set<string>(),
-      };
-      if (!entry.variants.has(variant)) {
-        entry.variants.add(variant);
-        addedCount += 1;
-      }
-      existing.set(canonical, entry);
-    }
-
-    if (addedCount === 0) {
-      return 0;
-    }
-
-    const synonymLines = Array.from(existing.entries())
-      .map(([canonical, entry]) => ({
-        canonical,
-        variants: Array.from(entry.variants).sort((left, right) => left.localeCompare(right)),
-      }))
-      .filter((entry) => entry.variants.length > 0)
-      .sort((left, right) => left.canonical.localeCompare(right.canonical))
-      .map((entry) => `- ${entry.canonical}: ${entry.variants.join(", ")}`);
-
-    const updatedLines = [
-      ...lines.slice(0, synonymHeadingIndex + 1),
-      "",
-      ...synonymLines,
-      "",
-      ...lines.slice(sectionEndIndex),
-    ];
-
-    fs.writeFileSync(skillsPath, updatedLines.join("\n"), "utf8");
-    this.clearCache();
-    return addedCount;
+    throw new Error("skills.md is read-only at runtime");
   }
 
   /**

--- a/apps/api/src/services/weight-history.test.ts
+++ b/apps/api/src/services/weight-history.test.ts
@@ -2,10 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { loadRuleWeightsConfig } from "./rule-scoring";
 import { WeightHistoryService } from "./weight-history";
+import { workspaceConfigService } from "./workspace-config-service";
 
 function createFixtureRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "weight-history-"));
@@ -81,7 +82,7 @@ describe("WeightHistoryService", () => {
     }
   });
 
-  it("rolls back weights to a previous entry", () => {
+  it("rolls back weights to a previous entry", async () => {
     const root = createFixtureRoot();
 
     try {
@@ -129,15 +130,21 @@ describe("WeightHistoryService", () => {
         "utf8"
       );
 
-      const rollback = service.rollback("2026-02-25T00:00:00.000Z");
-      expect(rollback.restored.reason).toBe("auto_tune");
+      const getRuleWeightsMock = vi.spyOn(workspaceConfigService, "getRuleWeights").mockResolvedValue(
+        loadRuleWeightsConfig(root)
+      );
+      const setRuleWeightsMock = vi.spyOn(workspaceConfigService, "setWorkspaceRuleWeights").mockResolvedValue();
 
-      const weights = loadRuleWeightsConfig(root);
-      expect(weights.categoryWeights.skillMatch).toBe(25);
-      expect(weights.categoryWeights.industryMatch).toBe(10);
+      const rollback = await service.rollback("2026-02-25T00:00:00.000Z", "dev");
+      expect(rollback.restored.reason).toBe("auto_tune");
+      expect(getRuleWeightsMock).toHaveBeenCalledWith("dev");
+      expect(setRuleWeightsMock).toHaveBeenCalledTimes(1);
 
       const history = service.getHistory();
       expect(history.some((entry) => entry.reason.startsWith("rollback:"))).toBe(true);
+
+      getRuleWeightsMock.mockRestore();
+      setRuleWeightsMock.mockRestore();
     } finally {
       cleanupFixtureRoot(root);
     }

--- a/apps/api/src/services/weight-history.ts
+++ b/apps/api/src/services/weight-history.ts
@@ -2,7 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { findProjectRoot } from "./db.js";
-import { loadRuleWeightsConfig, saveRuleWeightsConfig, type RuleWeightsConfig } from "./rule-scoring.js";
+import { type RuleWeightsConfig } from "./rule-scoring.js";
+import { workspaceConfigService } from "./workspace-config-service.js";
 
 type RuleCategoryWeights = RuleWeightsConfig["categoryWeights"];
 
@@ -141,18 +142,21 @@ export class WeightHistoryService {
       .slice(0, Math.max(1, limit));
   }
 
-  rollback(entryTs: string): { restored: WeightHistoryEntry; rollbackEntry: WeightHistoryEntry } {
+  async rollback(
+    entryTs: string,
+    workspaceSlug: string
+  ): Promise<{ restored: WeightHistoryEntry; rollbackEntry: WeightHistoryEntry }> {
     const target = this.getHistory(5000).find((entry) => entry.ts === entryTs);
     if (!target) {
       throw new Error(`Weight history entry not found: ${entryTs}`);
     }
 
-    const current = loadRuleWeightsConfig(this.projectRoot);
+    const current = await workspaceConfigService.getRuleWeights(workspaceSlug);
     const rollbackConfig: RuleWeightsConfig = {
       ...current,
       categoryWeights: target.before,
     };
-    saveRuleWeightsConfig(this.projectRoot, rollbackConfig);
+    await workspaceConfigService.setWorkspaceRuleWeights(workspaceSlug, rollbackConfig);
 
     const rollbackEntry = this.appendEntry({
       reason: `rollback:${entryTs}`,

--- a/apps/api/src/services/workspace-config-service.ts
+++ b/apps/api/src/services/workspace-config-service.ts
@@ -14,6 +14,14 @@ import {
   type FilterPresetsConfig,
   type PresetCategory,
 } from "./filter-preset-service.js";
+import {
+  loadRuleWeightsConfig,
+  mergeRuleWeights,
+  parseRuleWeightsOverrides,
+  type RuleWeightsConfig,
+  type RuleWeightsConfigOverrides,
+} from "./rule-scoring.js";
+import { skillsKnowledgeService, type LearningLogEntry } from "./skills-knowledge.js";
 
 type WorkspaceConfigEntry = {
   workspaceSlug: string;
@@ -220,9 +228,39 @@ function parseFilterPresetsConfig(value: unknown): FilterPresetsConfig {
   return { presets, categories };
 }
 
+function parseLearningLogEntry(value: unknown): LearningLogEntry | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const date = readString(value.date);
+  const observation = readString(value.observation);
+  if (!date || !observation) {
+    return null;
+  }
+
+  return { date, observation };
+}
+
+function parseLearningLogConfig(value: unknown): LearningLogEntry[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => parseLearningLogEntry(item))
+    .filter((item): item is LearningLogEntry => item !== null);
+}
+
+function parseRuleWeightsConfig(value: unknown): RuleWeightsConfigOverrides | undefined {
+  return parseRuleWeightsOverrides(value);
+}
+
 const CUSTOM_KEYWORDS_KEY = "custom-keywords";
 const AGENT_OVERRIDES_KEY = "agent-overrides";
 const FILTER_PRESETS_KEY = "filter-presets";
+const RULE_WEIGHTS_KEY = "rule-weights";
+const LEARNING_LOG_KEY = "learning-log";
 
 export class WorkspaceConfigService {
   readonly projectRoot: string;
@@ -438,6 +476,57 @@ export class WorkspaceConfigService {
       presets: Array.from(presetsById.values()),
       categories: Array.from(categoriesById.values()),
     };
+  }
+
+  async getWorkspaceRuleWeights(workspaceSlug: string): Promise<RuleWeightsConfigOverrides | undefined> {
+    const entry = await this.getWorkspaceConfigEntry(workspaceSlug, RULE_WEIGHTS_KEY);
+    return parseRuleWeightsConfig(entry?.configValue);
+  }
+
+  async setWorkspaceRuleWeights(
+    workspaceSlug: string,
+    config: RuleWeightsConfigOverrides | RuleWeightsConfig
+  ): Promise<void> {
+    await this.upsertWorkspaceConfigEntry(workspaceSlug, RULE_WEIGHTS_KEY, config);
+  }
+
+  async getRuleWeights(workspaceSlug: string): Promise<RuleWeightsConfig> {
+    const systemConfig = loadRuleWeightsConfig(this.projectRoot);
+    const workspaceConfig = await this.getWorkspaceRuleWeights(workspaceSlug);
+    const merged = mergeUnknown(systemConfig, workspaceConfig);
+    const mergedOverrides = parseRuleWeightsConfig(merged);
+    return mergeRuleWeights(mergedOverrides);
+  }
+
+  async getWorkspaceLearningLog(workspaceSlug: string): Promise<LearningLogEntry[]> {
+    const entry = await this.getWorkspaceConfigEntry(workspaceSlug, LEARNING_LOG_KEY);
+    return parseLearningLogConfig(entry?.configValue);
+  }
+
+  async setWorkspaceLearningLog(workspaceSlug: string, entries: LearningLogEntry[]): Promise<void> {
+    await this.upsertWorkspaceConfigEntry(workspaceSlug, LEARNING_LOG_KEY, entries);
+  }
+
+  async appendLearningLogEntry(workspaceSlug: string, observation: string, date?: string): Promise<LearningLogEntry> {
+    const normalizedObservation = observation.trim();
+    if (!normalizedObservation) {
+      throw new Error("Observation cannot be empty");
+    }
+
+    const entry: LearningLogEntry = {
+      date: date?.trim() || new Date().toISOString().slice(0, 10),
+      observation: normalizedObservation,
+    };
+    const currentEntries = await this.getWorkspaceLearningLog(workspaceSlug);
+    currentEntries.push(entry);
+    await this.setWorkspaceLearningLog(workspaceSlug, currentEntries);
+    return entry;
+  }
+
+  async getLearningLog(workspaceSlug: string): Promise<LearningLogEntry[]> {
+    const systemEntries = skillsKnowledgeService.getLearningLog();
+    const workspaceEntries = await this.getWorkspaceLearningLog(workspaceSlug);
+    return [...systemEntries, ...workspaceEntries];
   }
 }
 

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -8,14 +8,12 @@ import { useConvexResumes, type ConvexResumeItem } from '@/hooks/useConvexResume
 import { useSession } from '@/hooks/useSession'
 import { useCandidateActions } from '@/hooks/useCandidateActions'
 import { rawApiClient } from '@/lib/api-helpers'
-import { expandKeyword, DEFAULT_CONFIG, calculateResumeScore } from '@/lib/trendradar/parser'
+import { expandKeyword, DEFAULT_CONFIG } from '@/lib/trendradar/parser'
 import type { CandidateActionType, MatchingResult, ResumeFilters } from '@/types/resume'
 import {
   buildLearningObservation,
   buildResumeKey,
-  buildRuleScoringText,
   getAnalysisForJob,
-  getPrecomputedRuleScore,
   hasIngestData,
   isAutoFilteredAnalysis,
   toMatchBreakdown,
@@ -123,18 +121,10 @@ export function useResumeListState() {
         return !isAutoFilteredAnalysis(analysis)
       })
       .map((resume: ConvexResumeItem) => {
-        const precomputedScore = getPrecomputedRuleScore(resume, jobDescriptionId)
-        if (precomputedScore !== null) {
-          return {
-            ...resume,
-            _ruleScore: precomputedScore,
-          }
-        }
-
-        const fallbackScore = calculateResumeScore(buildRuleScoringText(resume), DEFAULT_CONFIG).score
+        // Pre-computed scores are hidden by default until explicit review.
         return {
           ...resume,
-          _ruleScore: fallbackScore,
+          _ruleScore: 0,
         }
       })
 

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -2029,6 +2029,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Profile not found */
                 404: {
                     headers: {
@@ -2147,6 +2160,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Profile/status not found */
                 404: {
                     headers: {
@@ -2201,6 +2227,19 @@ export interface paths {
                             profile: {
                                 [key: string]: unknown;
                             };
+                        };
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
                         };
                     };
                 };
@@ -2265,6 +2304,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Profile not found */
                 404: {
                     headers: {
@@ -2302,6 +2354,19 @@ export interface paths {
                         "application/json": {
                             /** @enum {boolean} */
                             success: true;
+                        };
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
                         };
                     };
                 };
@@ -2859,7 +2924,75 @@ export interface paths {
             };
         };
         put?: never;
-        post?: never;
+        /** Create workspace filter preset */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        category: string;
+                        filters: {
+                            minExperience?: number;
+                            maxExperience?: number | null;
+                            education?: string[];
+                            salaryRange?: {
+                                min?: number;
+                                max?: number;
+                            };
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            preset: {
+                                id: string;
+                                name: string;
+                                category: string;
+                                filters: {
+                                    minExperience?: number;
+                                    maxExperience?: number | null;
+                                    education?: string[];
+                                    salaryRange?: {
+                                        min?: number;
+                                        max?: number;
+                                    };
+                                };
+                            };
+                        };
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Already exists */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;
@@ -3009,9 +3142,117 @@ export interface paths {
                 };
             };
         };
-        put?: never;
+        /** Update workspace filter preset */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name?: string;
+                        category?: string;
+                        filters?: {
+                            minExperience?: number;
+                            maxExperience?: number | null;
+                            education?: string[];
+                            salaryRange?: {
+                                min?: number;
+                                max?: number;
+                            };
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            preset: {
+                                id: string;
+                                name: string;
+                                category: string;
+                                filters: {
+                                    minExperience?: number;
+                                    maxExperience?: number | null;
+                                    education?: string[];
+                                    salaryRange?: {
+                                        min?: number;
+                                        max?: number;
+                                    };
+                                };
+                            };
+                        };
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         post?: never;
-        delete?: never;
+        /** Delete workspace filter preset */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Deleted */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                        };
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,4 +1,6 @@
 import { expect } from 'vitest'
 import * as matchers from '@testing-library/jest-dom/matchers'
 
+process.env.NODE_ENV = 'test'
+
 expect.extend(matchers)

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as lib_resume_identity from "../lib/resume_identity.js";
 import type * as migrations from "../migrations.js";
 import type * as resume_tasks from "../resume_tasks.js";
 import type * as resumes from "../resumes.js";
+import type * as search_profiles from "../search_profiles.js";
 import type * as search_text from "../search_text.js";
 import type * as seed from "../seed.js";
 import type * as sessions from "../sessions.js";
@@ -39,6 +40,7 @@ declare const fullApi: ApiFromModules<{
   migrations: typeof migrations;
   resume_tasks: typeof resume_tasks;
   resumes: typeof resumes;
+  search_profiles: typeof search_profiles;
   search_text: typeof search_text;
   seed: typeof seed;
   sessions: typeof sessions;

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -119,11 +119,15 @@ export default defineSchema({
     // Optional: Search Profiles (if we want to store user configs)
     search_profiles: defineTable({
         name: v.string(),
+        profileId: v.optional(v.string()),
         criteria: v.object({
             keywords: v.array(v.string()),
             locations: v.array(v.string()),
         }),
+        profile: v.optional(v.any()),
         lastRunAt: v.optional(v.number()),
+        createdAt: v.optional(v.number()),
+        updatedAt: v.optional(v.number()),
         workspaceSlug: v.optional(v.string()),
     }).index("by_workspace", ["workspaceSlug"]),
 

--- a/packages/convex/convex/search_profiles.ts
+++ b/packages/convex/convex/search_profiles.ts
@@ -1,0 +1,190 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+const DEFAULT_WORKSPACE_SLUG = "dev";
+
+function normalizeWorkspaceSlug(input: string | undefined): string {
+  const normalized = input?.trim();
+  return normalized && normalized.length > 0 ? normalized : DEFAULT_WORKSPACE_SLUG;
+}
+
+function belongsToWorkspace(recordWorkspaceSlug: string | undefined, workspaceSlug: string): boolean {
+  if (workspaceSlug === DEFAULT_WORKSPACE_SLUG) {
+    return !recordWorkspaceSlug || recordWorkspaceSlug === DEFAULT_WORKSPACE_SLUG;
+  }
+  return recordWorkspaceSlug === workspaceSlug;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const record: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    record[key] = item;
+  }
+  return record;
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const normalized = value
+    .map((item) => readString(item))
+    .filter((item): item is string => Boolean(item));
+  return Array.from(new Set(normalized));
+}
+
+function normalizeCriteria(profile: unknown): { keywords: string[]; locations: string[] } {
+  const record = asRecord(profile);
+  if (!record) {
+    return {
+      keywords: [],
+      locations: [],
+    };
+  }
+
+  const keywords = readStringArray(record.keywords);
+  const location = readString(record.location);
+  const filters = asRecord(record.filters);
+  const locationsFromFilters = filters ? readStringArray(filters.locations) : [];
+  const locations = Array.from(
+    new Set([
+      ...(location ? [location] : []),
+      ...locationsFromFilters,
+    ])
+  );
+
+  return {
+    keywords,
+    locations,
+  };
+}
+
+export const list = query({
+  args: {
+    workspaceSlug: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+    const records = await ctx.db.query("search_profiles").collect();
+    return records
+      .filter((record) => belongsToWorkspace(record.workspaceSlug, workspaceSlug))
+      .sort((left, right) => {
+        const leftUpdated = left.updatedAt ?? left.lastRunAt ?? left._creationTime;
+        const rightUpdated = right.updatedAt ?? right.lastRunAt ?? right._creationTime;
+        return rightUpdated - leftUpdated;
+      });
+  },
+});
+
+export const getById = query({
+  args: {
+    id: v.string(),
+    workspaceSlug: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+    const records = await ctx.db.query("search_profiles").collect();
+    const found = records.find((record) => String(record._id) === args.id);
+    if (!found) {
+      return null;
+    }
+    if (!belongsToWorkspace(found.workspaceSlug, workspaceSlug)) {
+      return null;
+    }
+    return found;
+  },
+});
+
+export const create = mutation({
+  args: {
+    profile: v.any(),
+    workspaceSlug: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+    const profile = asRecord(args.profile);
+    const criteria = normalizeCriteria(args.profile);
+    const name = readString(profile?.name) ?? "Profile";
+    const profileId = readString(profile?.id);
+    const now = Date.now();
+
+    const id = await ctx.db.insert("search_profiles", {
+      name,
+      profileId,
+      criteria,
+      profile: profile ?? {},
+      workspaceSlug,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return await ctx.db.get(id);
+  },
+});
+
+export const update = mutation({
+  args: {
+    id: v.string(),
+    profile: v.any(),
+    workspaceSlug: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+    const records = await ctx.db.query("search_profiles").collect();
+    const existing = records.find((record) => String(record._id) === args.id);
+    if (!existing) {
+      throw new Error(`Search profile not found: ${args.id}`);
+    }
+    if (!belongsToWorkspace(existing.workspaceSlug, workspaceSlug)) {
+      throw new Error("Cannot update search profile from another workspace");
+    }
+
+    const profile = asRecord(args.profile);
+    const criteria = normalizeCriteria(args.profile);
+    const name = readString(profile?.name) ?? existing.name;
+    const profileId = readString(profile?.id) ?? existing.profileId;
+    const now = Date.now();
+
+    await ctx.db.patch(existing._id, {
+      name,
+      profileId,
+      criteria,
+      profile: profile ?? {},
+      updatedAt: now,
+    });
+
+    return await ctx.db.get(existing._id);
+  },
+});
+
+export const remove = mutation({
+  args: {
+    id: v.string(),
+    workspaceSlug: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+    const records = await ctx.db.query("search_profiles").collect();
+    const existing = records.find((record) => String(record._id) === args.id);
+    if (!existing) {
+      return false;
+    }
+    if (!belongsToWorkspace(existing.workspaceSlug, workspaceSlug)) {
+      return false;
+    }
+
+    await ctx.db.delete(existing._id);
+    return true;
+  },
+});


### PR DESCRIPTION
## Task

Implement following plan;


# Plan: Config Immutability + Disable Auto Score Reveal

## Context



Two problems with the current workspace isolation implementation:



1. **Config pollution**: 6 services write directly to git-tracked `config/` files (custom-keywords.json5, filter-presets.json5, rule-weights.json5, skills.md, job-descriptions/*.md, search-profiles/*.yaml). This pollutes the production-ready git repo with runtime data.

2. **Score reveal without review**: When a JD is selected from the dropdown, pre-computed rule scores are immediately displayed on all resumes. This should require explicit review/approval, not auto-reveal.



### Goal

- `config/` directory = **read-only system defaults** (git-tracked, production-ready, never modified at runtime)
- Runtime workspace config = **Convex&#32;`workspace_config`&#32;table only** (per teamSlug/workspace)
- Pre-computed scores = **hidden by default**, not auto-revealed on JD selection

---



## Part A: Disable Auto Score Reveal

### What happens now

```


User selects JD from dropdown
  → useResumeListState.ts recalculates filteredConvexResumes
  → getPrecomputedRuleScore(resume, jobDescriptionId) returns score
  → ResumeCard shows "Rule Score: 85" + "PRE-SCORE" badge
```

### What should happen
```
User selects JD from dropdown
  → Resumes are filtered but scores stay hidden
  → User clicks "Review Scores" or similar action
  → Only then are pre-computed scores displayed
```

### Task A1: Stop auto-scoring on JD selection [INDEPENDENT]

**Files**: `apps/web/src/hooks/useResumeListState.ts`
**Depends**: none

In the `filteredConvexResumes` memo (~line 126), skip the `getPrecomputedRuleScore()` call. Always use the fallback path so resumes show no meaningful score until explicitly requested.

Change: Remove the `getPrecomputedRuleScore()` branch entirely from the default resume list. The `_ruleScore` stays at 0 (or fallback).

```typescript
// BEFORE (line ~126):
const precomputedScore = getPrecomputedRuleScore(resume, jobDescriptionId)
if (precomputedScore !== null) {
  return { ...resume, _ruleScore: precomputedScore }
}

// AFTER:
// Pre-computed scores disabled — require explicit review action
// Always use fallback (shows no score badge in ResumeCard)
```

**Verify**: Select JD from dropdown → resumes show NO "Rule Score" or "PRE-SCORE" badge.

---

## Part B: Config Immutability — `config/` Read-Only

### Current write paths (ALL must be redirected)

| # | Target File | Service | Write Method |
|---|-------------|---------|-------------|
| 1 | `config/resume/custom-keywords.json5` | `CustomKeywordService` | `saveConfig()` |
| 2 | `config/resume/filter-presets.json5` | `FilterPresetService` | `saveConfig()` |
| 3 | `config/resume/rule-weights.json5` | `RuleScoringService` | `saveRuleWeightsConfig()` |
| 4 | `config/resume/skills.md` | `SkillsKnowledgeService` | `appendLearningLogEntry()`, `addSearchEventLogs()`, `expandDomainTaxonomy()` |
| 5 | `config/job-descriptions/*.md` | `JobDescriptionService` | `createFile()` |
| 6 | `config/search-profiles/*.yaml` | `SearchProfileService` | `writeProfile()`, `deleteProfile()` |

### New architecture

```
┌─────────────────────────────────────────────────────┐
│  config/ (git-tracked, READ-ONLY at runtime)        │
│  = System defaults / seed data                      │
│  ┌─────────────────────────────────────────────┐    │
│  │ resume/agents.json5    (default agent config)│    │
│  │ resume/skills.md       (skill taxonomy)      │    │
│  │ resume/filter-presets.json5  (system presets) │    │
│  │ resume/custom-keywords.json5 (system keywords)│   │
│  │ resume/rule-weights.json5  (system weights)   │   │
│  │ job-descriptions/*.md  (system JDs)           │   │
│  │ search-profiles/*.yaml (example profiles)     │   │
│  └─────────────────────────────────────────────┘    │
│  NEVER WRITTEN TO AT RUNTIME                        │
└─────────────────────────────────────────────────────┘
          │ read on startup / on demand
          ▼
┌─────────────────────────────────────────────────────┐
│  Convex workspace_config (per workspace, runtime)   │
│  = All runtime writes go here                       │
│  ┌─────────────────────────────────────────────┐    │
│  │ configKey: "custom-keywords"  (workspace kw) │    │
│  │ configKey: "filter-presets"   (workspace)     │   │
│  │ configKey: "rule-weights"     (workspace)     │   │
│  │ configKey: "learning-log"     (workspace)     │   │
│  │ configKey: "agent-overrides"  (workspace)     │   │
│  └─────────────────────────────────────────────┘    │
│  + Convex job_descriptions (type=custom, scoped)    │
│  + Convex search_profiles (scoped)                  │
└─────────────────────────────────────────────────────┘
          │ merge: workspace overrides + system defaults
          ▼
┌─────────────────────────────────────────────────────┐
│  API Response (merged config)                       │
│  GET /api/config/custom-keywords                    │
│  → system file defaults + workspace Convex overrides│
└─────────────────────────────────────────────────────┘
```

### Task B1: Make CustomKeywordService read-only [INDEPENDENT]

**Files**:
- `apps/api/src/services/custom-keyword-service.ts`
- `apps/api/src/routes/config.ts`

**Depends**: none
**Conflict Risk**: none

Remove `saveConfig()` write path from `CustomKeywordService`. The service becomes read-only (loads from `config/resume/custom-keywords.json5` as defaults).

POST/PUT/DELETE routes for `/api/config/custom-keywords` → redirect writes to Convex `workspace_config` via `workspaceConfigService` using `c.var.workspaceSlug`.

GET route → merge system file defaults + workspace Convex overrides.

**Verify**: `POST /api/config/custom-keywords` with `X-Workspace-Slug: dev` writes to Convex, not to file. `config/resume/custom-keywords.json5` stays untouched.

---

### Task B2: Make FilterPresetService read-only [INDEPENDENT]

**Files**:
- `apps/api/src/services/filter-preset-service.ts`
- `apps/api/src/routes/filter-presets.ts`

**Depends**: none

Same pattern as B1: remove `saveConfig()`, redirect writes to Convex `workspace_config` configKey=`"filter-presets"`.

**Verify**: System presets read from file, workspace custom presets from Convex.

---

### Task B3: Make RuleWeights read-only [INDEPENDENT]

**Files**:
- `apps/api/src/services/rule-scoring.ts`

**Depends**: none

Remove `saveRuleWeightsConfig()` that writes to `config/resume/rule-weights.json5`. Auto-tuned weights go to Convex `workspace_config` configKey=`"rule-weights"`.

**Verify**: `config/resume/rule-weights.json5` untouched after auto-tuning runs.

---

### Task B4: Make skills.md read-only (learning log to Convex) [INDEPENDENT]

**Files**:
- `apps/api/src/services/skills-knowledge.ts`

**Depends**: none

Remove file-write methods: `appendLearningLogEntry()`, `addSearchEventLogs()`, `expandDomainTaxonomy()`. Redirect learning log appends to Convex `workspace_config` configKey=`"learning-log"`.

The skills.md parser continues to read from the file for taxonomy/synonyms/signals. The learning log section in the file is treated as seed data. Runtime learning goes to Convex.

**Verify**: HR feedback actions don't modify `config/resume/skills.md`. Learning entries appear in Convex.

---

### Task B5: Make JobDescriptionService read-only for files [INDEPENDENT]

**Files**:
- `apps/api/src/services/job-description-service.ts`
- `apps/api/src/routes/job-descriptions.ts`

**Depends**: none

Remove `createFile()` from `JobDescriptionService`. POST `/api/job-descriptions` → create in Convex `job_descriptions` table with `type: "custom"` and `workspaceSlug`. System JDs (from files) remain read-only.

The service still reads `config/job-descriptions/*.md` for system JDs. Custom JDs come from Convex only.

**Verify**: Creating a JD via API creates a Convex record, not a file in `config/job-descriptions/`.

---

### Task B6: Make SearchProfileService read-only for files [INDEPENDENT]

**Files**:
- `apps/api/src/services/search-profile-service.ts`
- `apps/api/src/routes/search-profiles.ts`

**Depends**: none

Remove `writeProfile()` and `deleteProfile()` file operations. All profile CRUD → Convex `search_profiles` table with `workspaceSlug`.

The service can still read `config/search-profiles/*.yaml` as system/example profiles (read-only). All runtime profiles live in Convex.

**Verify**: Creating/updating/deleting profiles via API only touches Convex. `config/search-profiles/` directory stays untouched.

---

### Task B7: WorkspaceConfigService merge logic [DEPENDS: B1-B6]

**Files**:
- `apps/api/src/services/workspace-config-service.ts` (existing, enhance)

**Depends**: B1-B6 (all services redirected)

Ensure the merge service properly combines:
1. System defaults (read from `config/` files)
2. Workspace overrides (read from Convex `workspace_config`)

For each config type (custom-keywords, filter-presets, rule-weights, learning-log):
- System defaults are the base
- Workspace overrides are deep-merged on top
- Result is what the API returns

**Verify**: `GET /api/config/custom-keywords` with `X-Workspace-Slug: hr` returns system defaults + hr-specific overrides merged.

---

## Parallelism Map

```
Phase 1 (all independent):  A1, B1, B2, B3, B4, B5, B6
Phase 2 (after all Phase 1): B7
```

All Phase 1 tasks modify different files and can run in parallel.

## Summary of Changes

| What | Before | After |
|------|--------|-------|
| JD dropdown + scores | Auto-reveals pre-computed scores | Scores hidden, require review |
| custom-keywords writes | → `config/resume/custom-keywords.json5` | → Convex `workspace_config` |
| filter-presets writes | → `config/resume/filter-presets.json5` | → Convex `workspace_config` |
| rule-weights writes | → `config/resume/rule-weights.json5` | → Convex `workspace_config` |
| skills.md learning log | → appended to `config/resume/skills.md` | → Convex `workspace_config` |
| new JD creation | → file in `config/job-descriptions/` | → Convex `job_descriptions` |
| search profile CRUD | → files in `config/search-profiles/` | → Convex `search_profiles` |
| `config/` directory | Read + Write | **Read-only at runtime** |

## Verification

1. Start dev server: `make dev`
2. Create custom keyword via API → check `config/` is untouched, Convex has the data
3. Create JD via UI → check `config/job-descriptions/` is untouched, Convex has the record
4. Select JD from dropdown → no scores displayed
5. `git status` after all operations → `config/` directory clean (no modifications)
```

## PR Review Summary

- **What Changed**:
  - **Score Privacy**: Modified `useResumeListState.ts` to default `_ruleScore` to 0, preventing auto-reveal of pre-computed scores upon JD selection.
  - **Config Immutability**: Transitioned `config/` directory to read-only. Writes to `custom-keywords`, `filter-presets`, and `rule-weights` are redirected to the Convex `workspace_config` table via `WorkspaceConfigService`.
  - **Runtime Data Migration**: 
    - **JDs**: `JobDescriptionService` now creates custom JDs in Convex rather than markdown files.
    - **Profiles**: `SearchProfileService` CRUD operations migrated to Convex `search_profiles` table.
    - **Learning Logs**: `SkillsKnowledgeService` file appends replaced with Convex persistence.
  - **Merge Logic**: Enhanced `WorkspaceConfigService` to perform deep merges of system defaults (local files) and workspace overrides (Convex) before returning API responses.

- **Review Focus**:
  - **Convex URL Resolution**: `routes/job-descriptions.ts` introduces manual `.env` parsing logic to find `CONVEX_URL`. Review if this is redundant with existing environment loaders.
  - **Hierarchy**: Verify that the fallback logic in `routes/job-descriptions.ts` (file first, then Convex) aligns with the goal of JDs living in Convex only for "custom" types.
  - **Validation**: Ensure `zod` schemas in new routes (like `RuleWeightsConfigSchema`) provide sufficient protection against malformed config blobs.

- **Test Plan**:
  - **UI Verification**: Select a JD; confirm no "Rule Score" or "PRE-SCORE" badges appear until explicit action.
  - **Immutability Audit**: Run `POST /api/config/custom-keywords` and check `git status` to ensure `config/` remains untouched while Convex updates.
  - **Merge Testing**: Set a workspace-specific rule weight override in Convex and verify `GET /api/config/rule-weights` returns the merged result.
  - **CRUD Validation**: Create and delete a Search Profile via the UI; verify the `config/search-profiles/` folder is never modified.