### PR TITLE
Fix AI analysis duplicate tasks and monitor output

### DIFF
--- a/apps/web/src/components/AnalysisTaskMonitor.tsx
+++ b/apps/web/src/components/AnalysisTaskMonitor.tsx
@@ -128,7 +128,10 @@ function TaskItem({
 
       {task.status === 'completed' && task.results ? (
         <div className="text-xs text-muted-foreground">
-          {t('aiTasks.monitor.analyzed')}: {task.results.analyzed} | {t('aiTasks.monitor.avgScore')}: {task.results.avgScore} | {t('aiTasks.monitor.highScore')}: {task.results.highScoreCount}
+          {t('aiTasks.monitor.analyzed')}: {task.results.analyzed}
+          {task.results.failed > 0 ? ` | ${t('aiTasks.monitor.failed')}: ${task.results.failed}` : ''}
+          {' '}| {t('aiTasks.monitor.avgScore')}: {task.results.avgScore}
+          {' '}| {t('aiTasks.monitor.highScore')}: {task.results.highScoreCount}
         </div>
       ) : null}
 

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -84,7 +84,7 @@ export function ResumeList() {
                 {analyzing || hasActiveTask ? (
                   <>
                     <RefreshCw className="h-4 w-4 animate-spin" />
-                    {t('aiTasks.analyzing')}
+                    {t('aiTasks.analyzing', 'Analyzing...')}
                   </>
                 ) : (
                   <>

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -32,6 +32,7 @@ export function ResumeList() {
     error,
     activeLoading,
     analyzing,
+    hasActiveTask,
     disableAnalyzeButton,
     selectedIds,
     highScoreCount,
@@ -80,7 +81,7 @@ export function ResumeList() {
                 size="sm"
                 className="gap-2"
               >
-                {analyzing ? (
+                {analyzing || hasActiveTask ? (
                   <>
                     <RefreshCw className="h-4 w-4 animate-spin" />
                     {t('aiTasks.analyzing')}

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useMutation } from 'convex/react'
+import { useMutation, useQuery } from 'convex/react'
 import { toast } from 'sonner'
 import { api } from '../../../../packages/convex/convex/_generated/api'
+import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
 import { useResumes, type ResumeItem } from '@/hooks/useResumes'
 import { useConvexResumes, type ConvexResumeItem } from '@/hooks/useConvexResumes'
 import { useSession } from '@/hooks/useSession'
@@ -40,6 +41,39 @@ type EnrichedResume = {
   match?: MatchingResult
   ruleScore?: number
   action?: CandidateActionType | undefined
+}
+
+type AnalysisTaskDoc = Doc<'analysis_tasks'>
+
+function normalizeKeywordFingerprint(keywords: string[]): string {
+  return [...keywords]
+    .map((keyword) => keyword.trim().toLowerCase())
+    .filter((keyword) => keyword.length > 0)
+    .sort()
+    .join('|')
+}
+
+function taskMatchesCurrentSearch(
+  task: AnalysisTaskDoc,
+  jobDescriptionId: string | undefined,
+  sessionKeywords: string[]
+): boolean {
+  if (task.status !== 'pending' && task.status !== 'processing') {
+    return false
+  }
+
+  const normalizedJobDescriptionId = (jobDescriptionId ?? '').trim()
+  if (normalizedJobDescriptionId && task.config.jobDescriptionId === normalizedJobDescriptionId) {
+    return true
+  }
+
+  if (sessionKeywords.length > 0 && task.config.keywords?.length) {
+    const normalizedSessionKeywords = normalizeKeywordFingerprint(sessionKeywords)
+    const normalizedTaskKeywords = normalizeKeywordFingerprint(task.config.keywords)
+    return normalizedSessionKeywords.length > 0 && normalizedSessionKeywords === normalizedTaskKeywords
+  }
+
+  return false
 }
 
 function getExportErrorMessage(value: unknown): string | undefined {
@@ -103,6 +137,7 @@ export function useResumeListState() {
   }, [jobDescriptionId, sessionKeywords])
 
   const { resumes: convexResumes, loading: convexLoading } = useConvexResumes(200, expandedQuery, jobDescriptionId)
+  const analysisTasks = useQuery(api.analysis_tasks.list)
   const dispatchAnalysis = useMutation(api.analysis_tasks.dispatch)
   const [analyzing, setAnalyzing] = useState(false)
   const [lastDispatchTime, setLastDispatchTime] = useState<number>(0)
@@ -113,6 +148,12 @@ export function useResumeListState() {
   }, [])
 
   const activeLoading = mode === 'ai' ? convexLoading : loading
+  const hasActiveTask = useMemo(() => {
+    if (!analysisTasks || analysisTasks.length === 0) {
+      return false
+    }
+    return analysisTasks.some((task) => taskMatchesCurrentSearch(task, jobDescriptionId, sessionKeywords))
+  }, [analysisTasks, jobDescriptionId, sessionKeywords])
 
   const filteredConvexResumes = useMemo(() => {
     let result: ScoredConvexResume[] = convexResumes
@@ -182,6 +223,10 @@ export function useResumeListState() {
   const handleAnalyzeAll = useCallback(async () => {
     if (!convexResumes.length) return
     if (!jobDescriptionId && sessionKeywords.length === 0) return
+    if (hasActiveTask) {
+      toast.info(t('aiTasks.waitForCompletion', 'Please wait for current analysis to complete.'))
+      return
+    }
 
     const now = Date.now()
     if (now - lastDispatchTime < DISPATCH_COOLDOWN_MS) {
@@ -264,6 +309,7 @@ export function useResumeListState() {
     convexResumes.length,
     dispatchAnalysis,
     filteredConvexResumes,
+    hasActiveTask,
     jobDescriptionId,
     lastDispatchTime,
     selectedSample,
@@ -527,7 +573,7 @@ export function useResumeListState() {
   }, [displayedResumes])
 
   const hasInput = Boolean(jobDescriptionId) || sessionKeywords.length > 0
-  const disableAnalyzeButton = (filteredConvexResumes.length === 0 || analyzing || !hasInput)
+  const disableAnalyzeButton = (filteredConvexResumes.length === 0 || analyzing || !hasInput || hasActiveTask)
 
   const handleQuickStartApply = useCallback(
     (config: {
@@ -578,6 +624,7 @@ export function useResumeListState() {
     error,
     activeLoading,
     analyzing,
+    hasActiveTask,
     disableAnalyzeButton,
     selectedIds,
     highScoreCount,

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -233,6 +233,7 @@
   "aiTasks": {
     "dispatched": "Analysis task dispatched",
     "dispatchFailed": "Failed to start analysis",
+    "error": "Analysis failed",
     "waitForCompletion": "Please wait for current analysis to complete.",
     "analyzing": "Analyzing...",
     "monitor": {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -234,6 +234,7 @@
     "dispatched": "Analysis task dispatched",
     "dispatchFailed": "Failed to start analysis",
     "waitForCompletion": "Please wait for current analysis to complete.",
+    "analyzing": "Analyzing...",
     "monitor": {
       "activeTitle": "Active Analysis",
       "historyTitle": "Analysis History",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -233,6 +233,7 @@
   "aiTasks": {
     "dispatched": "分析任务已创建",
     "dispatchFailed": "启动分析失败",
+    "error": "分析失败",
     "waitForCompletion": "请等待当前分析完成。",
     "analyzing": "分析中...",
     "monitor": {

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -234,6 +234,7 @@
     "dispatched": "分析任务已创建",
     "dispatchFailed": "启动分析失败",
     "waitForCompletion": "请等待当前分析完成。",
+    "analyzing": "分析中...",
     "monitor": {
       "activeTitle": "进行中的分析",
       "historyTitle": "分析历史",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -233,6 +233,7 @@
   "aiTasks": {
     "dispatched": "分析任務已建立",
     "dispatchFailed": "啟動分析失敗",
+    "error": "分析失敗",
     "waitForCompletion": "請等待目前分析完成。",
     "analyzing": "分析中...",
     "monitor": {

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -234,6 +234,7 @@
     "dispatched": "分析任務已建立",
     "dispatchFailed": "啟動分析失敗",
     "waitForCompletion": "請等待目前分析完成。",
+    "analyzing": "分析中...",
     "monitor": {
       "activeTitle": "進行中的分析",
       "historyTitle": "分析歷史",

--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -68,25 +68,53 @@ function parseBreakdown(value: unknown): Record<string, number> | undefined {
     return Object.keys(parsed).length > 0 ? parsed : undefined;
 }
 
-function parseLlmResult(value: unknown): AnalysisResult {
-    if (!isObject(value)) {
-        throw new Error("Invalid analysis result: expected object.");
+/**
+ * Try to locate the analysis payload from potentially nested LLM responses.
+ * Some models wrap results like `{ "result": { "score": 85, ... } }` or
+ * `{ "data": { "score": 85, ... } }`.
+ */
+function unwrapLlmResult(value: unknown): Record<string, unknown> | null {
+    if (!isObject(value)) return null;
+
+    // Top-level score → use as-is
+    if (value.score !== undefined) return value;
+
+    // Try common wrapper keys
+    for (const key of ["result", "data", "analysis", "response", "output"]) {
+        const nested = value[key];
+        if (isObject(nested) && nested.score !== undefined) return nested;
     }
 
-    const score = toNumber(value.score);
-    if (score === null) {
+    // Scan one level for any object with a `score` key
+    for (const nested of Object.values(value)) {
+        if (isObject(nested) && nested.score !== undefined) return nested;
+    }
+
+    return null;
+}
+
+function parseLlmResult(value: unknown): AnalysisResult {
+    const obj = unwrapLlmResult(value);
+    if (!obj) {
+        console.error("parseLlmResult: no score field found in LLM response:", JSON.stringify(value).slice(0, 1000));
         throw new Error("Invalid analysis result: score is missing.");
     }
 
-    const summary = typeof value.summary === "string" ? value.summary : "";
-    const recommendation = typeof value.recommendation === "string" ? value.recommendation : "potential";
+    const score = toNumber(obj.score);
+    if (score === null) {
+        console.error("parseLlmResult: score is not numeric:", JSON.stringify(obj.score), "full:", JSON.stringify(value).slice(0, 500));
+        throw new Error("Invalid analysis result: score is missing.");
+    }
+
+    const summary = typeof obj.summary === "string" ? obj.summary : "";
+    const recommendation = typeof obj.recommendation === "string" ? obj.recommendation : "potential";
 
     return {
         score,
         summary: summary || "No summary provided.",
-        highlights: toStringArray(value.highlights),
+        highlights: toStringArray(obj.highlights),
         recommendation,
-        breakdown: parseBreakdown(value.breakdown),
+        breakdown: parseBreakdown(obj.breakdown),
     };
 }
 
@@ -231,8 +259,20 @@ async function analyzeOneResume(
         { role: "user", content: prompt },
     ];
 
-    const rawResult = await callLLM(messages, apiKey);
-    return parseLlmResult(rawResult);
+    const maxAttempts = 2;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            const rawResult = await callLLM(messages, apiKey);
+            return parseLlmResult(rawResult);
+        } catch (error) {
+            lastError = error;
+            if (attempt < maxAttempts) {
+                console.warn(`analyzeOneResume attempt ${attempt} failed, retrying:`, error instanceof Error ? error.message : error);
+            }
+        }
+    }
+    throw lastError;
 }
 
 export const list = query({

--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -281,6 +281,13 @@ export const dispatch = mutation({
         const uniqueResumeIds = Array.from(uniqueResumeIdMap.values());
         const derivedJobDescriptionId = args.jobDescriptionId
             || (normalizedKeywords.length > 0 ? buildKeywordAnalysisId(normalizedKeywords) : undefined);
+        const jobKey = buildAnalysisDispatchJobKey({
+            derivedJobDescriptionId,
+            jobDescriptionTitle: args.jobDescriptionTitle,
+            jobDescriptionContent: args.jobDescriptionContent,
+            keywords: normalizedKeywords,
+            resumeIds: uniqueResumeIds.map((resumeId) => String(resumeId)),
+        });
         const idempotencyKey = buildAnalysisDispatchIdempotencyKey({
             derivedJobDescriptionId,
             jobDescriptionTitle: args.jobDescriptionTitle,
@@ -309,8 +316,29 @@ export const dispatch = mutation({
             return existingPendingTask._id;
         }
 
+        const existingProcessingTaskByJobKey = await ctx.db
+            .query("analysis_tasks")
+            .withIndex("by_job_key_status", (q) =>
+                q.eq("jobKey", jobKey).eq("status", "processing")
+            )
+            .first();
+        if (existingProcessingTaskByJobKey) {
+            return existingProcessingTaskByJobKey._id;
+        }
+
+        const existingPendingTaskByJobKey = await ctx.db
+            .query("analysis_tasks")
+            .withIndex("by_job_key_status", (q) =>
+                q.eq("jobKey", jobKey).eq("status", "pending")
+            )
+            .first();
+        if (existingPendingTaskByJobKey) {
+            return existingPendingTaskByJobKey._id;
+        }
+
         const taskId = await ctx.db.insert("analysis_tasks", {
             idempotencyKey,
+            jobKey,
             config: {
                 jobDescriptionId: derivedJobDescriptionId,
                 jobDescriptionTitle: args.jobDescriptionTitle,

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -173,8 +173,8 @@ export async function callLLM(messages: any[], apiKey: string) {
         }
         return json;
     } catch (e) {
-        console.error("Failed to parse LLM response:", content);
-        throw new Error("Invalid JSON response from AI");
+        console.error("Failed to parse LLM response (raw content):", content.slice(0, 2000));
+        throw new Error(`Invalid JSON response from AI: ${content.slice(0, 200)}`);
     }
 }
 

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -147,6 +147,7 @@ export default defineSchema({
 
     analysis_tasks: defineTable({
         idempotencyKey: v.optional(v.string()),
+        jobKey: v.optional(v.string()),
         config: v.object({
             jobDescriptionId: v.optional(v.string()),
             jobDescriptionTitle: v.optional(v.string()),
@@ -176,11 +177,12 @@ export default defineSchema({
         })),
         lastStatus: v.optional(v.string()),
         error: v.optional(v.string()),
-            startedAt: v.optional(v.number()),
-            completedAt: v.optional(v.number()),
+        startedAt: v.optional(v.number()),
+        completedAt: v.optional(v.number()),
     })
         .index("by_status", ["status"])
-        .index("by_idempotency_status", ["idempotencyKey", "status"]),
+        .index("by_idempotency_status", ["idempotencyKey", "status"])
+        .index("by_job_key_status", ["jobKey", "status"]),
 
     // Persistent User Sessions
     screening_sessions: defineTable({

--- a/scripts/i18n/sync_keys.py
+++ b/scripts/i18n/sync_keys.py
@@ -19,6 +19,8 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -27,9 +29,15 @@ import yaml
 
 
 # Configuration
-I18N_DIR = Path(__file__).parent.parent.parent / "config" / "i18n"
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+I18N_DIR = PROJECT_ROOT / "config" / "i18n"
 SOURCE_LOCALE = "zh-Hant"
 TARGET_LOCALES = ["zh-Hans", "en"]
+WEB_LOCALES_DIR = PROJECT_ROOT / "apps" / "web" / "src" / "i18n" / "locales"
+WEB_SOURCE_LOCALE = "zh-Hant"
+WEB_TARGET_LOCALES = ["zh-Hans", "en"]
+WEB_SOURCE_DIR = PROJECT_ROOT / "apps" / "web" / "src"
+TRANSLATION_CALL_PATTERN = re.compile(r"\b(?:i18n\.)?t\s*\(\s*(['\"])([^'\"\n]+)\1\s*\)")
 
 
 def flatten_keys(data: dict[str, Any], prefix: str = "") -> set[str]:
@@ -75,6 +83,15 @@ def load_locale(locale: str) -> dict[str, Any]:
         return yaml.safe_load(f) or {}
 
 
+def load_web_locale(locale: str) -> dict[str, Any]:
+    """Load a web locale JSON file."""
+    filepath = WEB_LOCALES_DIR / f"{locale}.json"
+    if not filepath.exists():
+        raise FileNotFoundError(f"Locale file not found: {filepath}")
+    with open(filepath, encoding="utf-8") as f:
+        return json.load(f) or {}
+
+
 def save_locale(locale: str, data: dict[str, Any]) -> None:
     """Save a locale YAML file."""
     filepath = I18N_DIR / f"{locale}.yaml"
@@ -105,6 +122,45 @@ def check_locale_sync(
     extra_keys = target_keys - source_keys
 
     return missing_keys, extra_keys
+
+
+def iter_web_source_files() -> list[Path]:
+    """Return all web source files that can contain translation key usage."""
+    files: list[Path] = []
+    for path in WEB_SOURCE_DIR.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix not in {".ts", ".tsx"}:
+            continue
+        path_str = str(path)
+        if "__tests__" in path_str or path_str.endswith(".test.ts") or path_str.endswith(".test.tsx"):
+            continue
+        files.append(path)
+    return files
+
+
+def find_static_translation_key_usages() -> tuple[set[str], dict[str, str]]:
+    """
+    Find translation keys used via one-arg static calls:
+      - t('some.key')
+      - i18n.t("some.key")
+    """
+    used_keys: set[str] = set()
+    key_locations: dict[str, str] = {}
+
+    for file_path in iter_web_source_files():
+        content = file_path.read_text(encoding="utf-8")
+        for match in TRANSLATION_CALL_PATTERN.finditer(content):
+            key = match.group(2).strip()
+            if not key:
+                continue
+            used_keys.add(key)
+            if key not in key_locations:
+                line_number = content.count("\n", 0, match.start()) + 1
+                relative = file_path.relative_to(PROJECT_ROOT)
+                key_locations[key] = f"{relative}:{line_number}"
+
+    return used_keys, key_locations
 
 
 def format_key_list(keys: set[str], max_display: int = 20) -> str:
@@ -162,9 +218,14 @@ def main() -> int:
         print(f"ERROR: i18n directory not found: {I18N_DIR}")
         return 1
 
+    if not WEB_LOCALES_DIR.exists():
+        print(f"ERROR: web locale directory not found: {WEB_LOCALES_DIR}")
+        return 1
+
     # Load source locale
     try:
         source_data = load_locale(SOURCE_LOCALE)
+        print("YAML locale parity checks")
         print(f"Source locale: {SOURCE_LOCALE}.yaml")
         source_keys = flatten_keys(source_data) - {"meta.locale", "meta.name"}
         print(f"  Total keys: {len(source_keys)}")
@@ -174,7 +235,7 @@ def main() -> int:
         return 1
 
     all_synced = True
-    results = []
+    yaml_results = []
 
     for locale in TARGET_LOCALES:
         print(f"Checking: {locale}.yaml")
@@ -213,21 +274,96 @@ def main() -> int:
         else:
             print(f"  No extra keys")
 
-        results.append({
+        yaml_results.append({
             "locale": locale,
             "missing": len(missing_keys),
             "extra": len(extra_keys),
         })
         print()
 
+    print("Web JSON locale parity checks")
+    print(f"Source locale: {WEB_SOURCE_LOCALE}.json")
+    try:
+        web_source_data = load_web_locale(WEB_SOURCE_LOCALE)
+    except FileNotFoundError as e:
+        print(f"ERROR: {e}")
+        return 1
+
+    web_source_keys = flatten_keys(web_source_data)
+    print(f"  Total keys: {len(web_source_keys)}")
+    print()
+
+    web_results = []
+    for locale in WEB_TARGET_LOCALES:
+        print(f"Checking: {locale}.json")
+        try:
+            target_data = load_web_locale(locale)
+        except FileNotFoundError:
+            print("  ERROR: File not found!")
+            all_synced = False
+            continue
+
+        missing_keys, extra_keys = check_locale_sync(web_source_data, target_data, locale)
+        if missing_keys:
+            all_synced = False
+            print(f"  MISSING keys ({len(missing_keys)}):")
+            if args.verbose:
+                print(format_key_list(missing_keys))
+            else:
+                print("    Run with --verbose to see all keys")
+        else:
+            print("  No missing keys")
+
+        if extra_keys:
+            all_synced = False
+            print(f"  EXTRA keys ({len(extra_keys)}) - consider removing:")
+            if args.verbose:
+                print(format_key_list(extra_keys))
+            else:
+                print("    Run with --verbose to see all keys")
+        else:
+            print("  No extra keys")
+
+        web_results.append({
+            "locale": locale,
+            "missing": len(missing_keys),
+            "extra": len(extra_keys),
+        })
+        print()
+
+    print("Web translation key usage checks")
+    used_keys, key_locations = find_static_translation_key_usages()
+    missing_used_keys = used_keys - web_source_keys
+    print(f"Static one-arg calls found: {len(used_keys)}")
+    if missing_used_keys:
+        all_synced = False
+        print(f"MISSING keys used in code ({len(missing_used_keys)}):")
+        for key in sorted(missing_used_keys)[:20]:
+            location = key_locations.get(key, "unknown")
+            print(f"  - {key} ({location})")
+        if len(missing_used_keys) > 20:
+            print(f"  ... and {len(missing_used_keys) - 20} more")
+    else:
+        print("No missing keys used in one-arg static t()/i18n.t() calls")
+    print()
+
     # Summary
     print("=" * 60)
     print("Summary")
     print("=" * 60)
     print()
+    print("YAML locale parity")
     print(f"{'Locale':<12} {'Missing':<10} {'Extra':<10} {'Status':<10}")
     print("-" * 42)
-    for r in results:
+    for r in yaml_results:
+        status = "OK" if r["missing"] == 0 and r["extra"] == 0 else "ISSUES"
+        print(f"{r['locale']:<12} {r['missing']:<10} {r['extra']:<10} {status:<10}")
+    print()
+
+    print("Web JSON locale parity")
+    print(f"{'Locale':<12} {'Missing':<10} {'Extra':<10} {'Status':<10}")
+    print("-" * 42)
+    for r in web_results:
         status = "OK" if r["missing"] == 0 and r["extra"] == 0 else "ISSUES"
         print(f"{r['locale']:<12} {r['missing']:<10} {r['extra']:<10} {status:<10}")
     print()


### PR DESCRIPTION
Summary
- surface failed count in completed task summaries so users see when resumes error out
- prevent "Analyze All" from re-enabling until the matching backend task finishes and show spinner while it runs
- add a jobKey index to Convex analysis tasks so duplicates are rejected even when resume lists differ

Testing
- Not run (not requested)