### PR TITLE
Update shared exports to JS modules

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./types";
-export * from "./workspace";
+export * from "./types.js";
+export * from "./workspace.js";


### PR DESCRIPTION
Summary
- switch `packages/shared` exports to explicit JS paths so downstream bundles resolve correctly
- this mirrors the source file extensions used in build output and avoids ambiguous resolutions

Testing
- Not run (not requested)