### PR TITLE
Add user settings routes and blacklist management UI

### DIFF
--- a/apps/api/src/routes/blocks.ts
+++ b/apps/api/src/routes/blocks.ts
@@ -124,12 +124,22 @@ const UpsertBlockRequestSchema = z.object({
   blockedBy: z.string().optional(),
 });
 
+const PatchBlockRequestSchema = z.object({
+  identityKey: z.string(),
+  reason: z.string().optional(),
+});
+
 const UpsertBlockResponseSchema = z.object({
   success: z.literal(true),
   inserted: z.number().int().optional(),
   updated: z.number().int().optional(),
   total: z.number().int().optional(),
   id: z.string().optional(),
+});
+
+const PatchBlockResponseSchema = z.object({
+  success: z.literal(true),
+  updated: z.boolean(),
 });
 
 const DeleteBlockQuerySchema = z.object({
@@ -235,6 +245,42 @@ app.openapi(upsertRoute, async (c) => {
     updated,
     total,
   }, 200);
+});
+
+const patchRoute = createRoute({
+  method: "patch",
+  path: "/api/blocks",
+  tags: ["actions"],
+  summary: "Update blocked candidate reason",
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: PatchBlockRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: PatchBlockResponseSchema } },
+      description: "Block reason updated",
+    },
+  },
+});
+
+app.openapi(patchRoute, async (c) => {
+  const body = c.req.valid("json");
+  const identityKey = body.identityKey.trim();
+  if (!identityKey) {
+    return c.json({ success: true as const, updated: false }, 200);
+  }
+
+  const updated = await callConvex("mutation", "candidate_blocks:updateReason", {
+    workspaceSlug: c.var.workspaceSlug,
+    identityKey,
+    reason: body.reason,
+  });
+
+  return c.json({ success: true as const, updated: updated === true }, 200);
 });
 
 const deleteRoute = createRoute({

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,8 +9,10 @@ import DebugJDs from '@/pages/DebugJDs'
 import DebugAI from '@/pages/DebugAI'
 import DebugConfig from '@/pages/DebugConfig'
 import DebugIngest from '@/pages/DebugIngest'
+import { BlacklistPage } from '@/pages/BlacklistPage'
 import { SearchProfilesPage } from '@/pages/SearchProfilesPage'
 import SearchAnalyticsPage from '@/pages/SearchAnalyticsPage'
+import SettingsLayout from '@/layouts/SettingsLayout'
 import SystemLayout from '@/layouts/SystemLayout'
 import { WorkspaceProvider, useWorkspace } from '@/contexts/WorkspaceContext'
 
@@ -86,6 +88,11 @@ function App() {
 
             <Route element={<MainShell />}>
               <Route path="resumes" element={<ResumesPage />} />
+            </Route>
+
+            <Route path="settings" element={<SettingsLayout />}>
+              <Route index element={<Navigate to="blocks" replace />} />
+              <Route path="blocks" element={<BlacklistPage />} />
             </Route>
 
             <Route

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -14,6 +14,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
   const { t } = useTranslation()
   const { slug, name, isAdmin } = useWorkspace()
   const resumesPath = `/${slug}/resumes`
+  const settingsPath = `/${slug}/settings`
   const systemPath = `/${slug}/system`
 
   return (
@@ -39,6 +40,17 @@ export function Header({ leftAction }: HeaderProps = {}) {
               }
             >
               {t('nav.resumes')}
+            </NavLink>
+            <NavLink
+              to={settingsPath}
+              className={({ isActive }) =>
+                cn(
+                  'transition-colors hover:text-foreground',
+                  isActive ? 'text-foreground' : 'text-muted-foreground'
+                )
+              }
+            >
+              {t('nav.settings')}
             </NavLink>
             {isAdmin ? (
               <NavLink
@@ -71,6 +83,17 @@ export function Header({ leftAction }: HeaderProps = {}) {
               }
             >
               {t('nav.resumes')}
+            </NavLink>
+            <NavLink
+              to={settingsPath}
+              className={({ isActive }) =>
+                cn(
+                  'transition-colors hover:text-foreground',
+                  isActive ? 'text-foreground' : 'text-muted-foreground'
+                )
+              }
+            >
+              {t('nav.settings')}
             </NavLink>
             {isAdmin ? (
               <NavLink

--- a/apps/web/src/components/SettingsSidebar.tsx
+++ b/apps/web/src/components/SettingsSidebar.tsx
@@ -1,0 +1,84 @@
+import { Link, useLocation } from 'react-router-dom'
+import { Ban, Home, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { useWorkspace } from '@/contexts/WorkspaceContext'
+import { cn } from '@/lib/utils'
+
+interface NavItem {
+  title: string
+  href: string
+  icon: React.ComponentType<{ className?: string }>
+  matches: string[]
+}
+
+interface SettingsSidebarProps {
+  onClose?: () => void
+}
+
+export function SettingsSidebar({ onClose }: SettingsSidebarProps) {
+  const location = useLocation()
+  const { slug } = useWorkspace()
+  const { t } = useTranslation()
+
+  const navItems: NavItem[] = [
+    {
+      title: t('nav.home', { defaultValue: 'Home' }),
+      href: `/${slug}/resumes`,
+      icon: Home,
+      matches: [`/${slug}/resumes`],
+    },
+    {
+      title: t('settings.blocks.nav', { defaultValue: 'Blacklist' }),
+      href: `/${slug}/settings/blocks`,
+      icon: Ban,
+      matches: [`/${slug}/settings/blocks`],
+    },
+  ]
+
+  return (
+    <div className="flex flex-col h-full bg-muted/30">
+      <div className="flex-1 overflow-y-auto py-4">
+        <div className="px-5 mb-6 flex items-center justify-between">
+          <Link to={`/${slug}/resumes`} className="flex items-center gap-2">
+            <span className="bg-primary text-primary-foreground text-[10px] px-1.5 py-0.5 rounded font-medium">SETTINGS</span>
+            <div className="flex items-baseline gap-1">
+              <span className="font-bold text-base truncate">App Title</span>
+            </div>
+          </Link>
+          {onClose && (
+            <Button variant="ghost" size="icon" className="md:hidden -mr-2" onClick={onClose}>
+              <X className="h-5 w-5" />
+            </Button>
+          )}
+        </div>
+        <div className="px-3 space-y-1">
+          {navItems.map((item) => {
+            const isActive = item.matches.some((match) => location.pathname.startsWith(match))
+            return (
+              <Link
+                key={item.href}
+                to={item.href}
+                onClick={onClose}
+                className={cn(
+                  'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors',
+                  isActive
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                )}
+              >
+                <item.icon className="h-4 w-4 shrink-0" />
+                <span className="truncate">{item.title}</span>
+              </Link>
+            )
+          })}
+        </div>
+      </div>
+      <div className="px-5 mt-auto pt-4">
+        <div className="text-xs text-muted-foreground truncate">
+          v0.9.0 Workspace Settings
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/hooks/useCandidateBlocks.ts
+++ b/apps/web/src/hooks/useCandidateBlocks.ts
@@ -87,6 +87,31 @@ export function useCandidateBlocks() {
     [load]
   )
 
+  const updateBlockReason = useCallback(
+    async (identityKey: string, reason?: string) => {
+      const normalized = identityKey.trim()
+      if (!normalized) {
+        return false
+      }
+
+      const { data, error: apiError } = await rawApiClient.PATCH<{ success: boolean; updated?: boolean }>('/api/blocks', {
+        body: {
+          identityKey: normalized,
+          reason,
+        },
+      })
+
+      if (apiError || !data?.success) {
+        setError('Failed to update block reason')
+        return false
+      }
+
+      await load()
+      return data.updated === true
+    },
+    [load]
+  )
+
   useEffect(() => {
     void load()
   }, [load])
@@ -107,5 +132,6 @@ export function useCandidateBlocks() {
     reload: load,
     blockCandidates,
     unblockCandidate,
+    updateBlockReason,
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -348,6 +348,37 @@
     "suggestionError": "Failed to save suggestion",
     "noSuggestion": "No suggestion available"
   },
+  "settings": {
+    "blocks": {
+      "nav": "Blacklist",
+      "title": "Blacklist Management",
+      "description": "View and manage blocked candidates for this workspace.",
+      "countBadge": "{{count}} blocked",
+      "searchPlaceholder": "Search by candidate key or reason...",
+      "empty": "No blocked candidates yet.",
+      "emptySearch": "No blocked candidates match your search.",
+      "noReason": "-",
+      "bulkUnblock": "Unblock Selected ({{count}})",
+      "columns": {
+        "candidate": "Candidate",
+        "reason": "Reason",
+        "blockedAt": "Blocked Date",
+        "blockedBy": "Blocked By",
+        "actions": "Actions"
+      },
+      "actions": {
+        "unblock": "Unblock"
+      },
+      "toasts": {
+        "reasonUpdated": "Block reason updated",
+        "reasonUpdateFailed": "Failed to update block reason",
+        "unblockSuccess": "Candidate unblocked",
+        "unblockFailed": "Failed to unblock candidate",
+        "bulkUnblockSuccess": "Unblocked {{count}} candidate(s)",
+        "bulkUnblockFailed": "Failed to unblock selected candidates"
+      }
+    }
+  },
   "debug": {
     "title": "Debug Console",
     "subtitle": "Raw inputs, findings, and process data",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -348,6 +348,37 @@
     "suggestionError": "保存同义词建议失败",
     "noSuggestion": "暂无可用建议"
   },
+  "settings": {
+    "blocks": {
+      "nav": "黑名单",
+      "title": "黑名单管理",
+      "description": "查看并管理此工作区已屏蔽候选人。",
+      "countBadge": "已屏蔽 {{count}}",
+      "searchPlaceholder": "按候选人标识键或原因搜索...",
+      "empty": "当前没有已屏蔽候选人。",
+      "emptySearch": "没有符合搜索条件的屏蔽候选人。",
+      "noReason": "-",
+      "bulkUnblock": "批量解除屏蔽 ({{count}})",
+      "columns": {
+        "candidate": "候选人",
+        "reason": "原因",
+        "blockedAt": "屏蔽时间",
+        "blockedBy": "屏蔽人",
+        "actions": "操作"
+      },
+      "actions": {
+        "unblock": "解除屏蔽"
+      },
+      "toasts": {
+        "reasonUpdated": "已更新屏蔽原因",
+        "reasonUpdateFailed": "更新屏蔽原因失败",
+        "unblockSuccess": "已解除屏蔽候选人",
+        "unblockFailed": "解除屏蔽候选人失败",
+        "bulkUnblockSuccess": "已解除屏蔽 {{count}} 位候选人",
+        "bulkUnblockFailed": "批量解除屏蔽失败"
+      }
+    }
+  },
   "debug": {
     "title": "调试控制台",
     "subtitle": "原始输入、分析发现与处理数据",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -348,6 +348,37 @@
     "suggestionError": "儲存同義詞建議失敗",
     "noSuggestion": "暫無可用建議"
   },
+  "settings": {
+    "blocks": {
+      "nav": "黑名單",
+      "title": "黑名單管理",
+      "description": "查看並管理此工作區已封鎖候選人。",
+      "countBadge": "已封鎖 {{count}}",
+      "searchPlaceholder": "依候選人識別鍵或原因搜尋...",
+      "empty": "目前沒有已封鎖候選人。",
+      "emptySearch": "沒有符合搜尋條件的封鎖候選人。",
+      "noReason": "-",
+      "bulkUnblock": "批次解除封鎖 ({{count}})",
+      "columns": {
+        "candidate": "候選人",
+        "reason": "原因",
+        "blockedAt": "封鎖時間",
+        "blockedBy": "封鎖人",
+        "actions": "操作"
+      },
+      "actions": {
+        "unblock": "解除封鎖"
+      },
+      "toasts": {
+        "reasonUpdated": "已更新封鎖原因",
+        "reasonUpdateFailed": "更新封鎖原因失敗",
+        "unblockSuccess": "已解除封鎖候選人",
+        "unblockFailed": "解除封鎖候選人失敗",
+        "bulkUnblockSuccess": "已解除封鎖 {{count}} 位候選人",
+        "bulkUnblockFailed": "批次解除封鎖失敗"
+      }
+    }
+  },
   "debug": {
     "title": "調試控制台",
     "subtitle": "原始輸入、分析發現與處理數據",

--- a/apps/web/src/layouts/SettingsLayout.tsx
+++ b/apps/web/src/layouts/SettingsLayout.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import { Outlet } from 'react-router-dom'
+import { Toaster } from 'sonner'
+import { Menu } from 'lucide-react'
+import { Header } from '@/components/Header'
+import { SettingsSidebar } from '@/components/SettingsSidebar'
+import { Button } from '@/components/ui/button'
+
+export default function SettingsLayout() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="flex flex-col min-h-screen bg-background text-foreground">
+      <Toaster position="top-center" richColors />
+      <Header
+        leftAction={
+          <Button variant="ghost" size="icon" className="xl:hidden shrink-0 -ml-2" onClick={() => setOpen((prev) => !prev)}>
+            <Menu className="h-5 w-5" />
+            <span className="sr-only">Toggle menu</span>
+          </Button>
+        }
+      />
+
+      <div className="flex flex-1">
+        <aside className="hidden xl:flex w-56 flex-col fixed top-14 bottom-0 left-0 z-40 bg-background border-r">
+          <SettingsSidebar />
+        </aside>
+
+        <div className="flex-1 flex flex-col xl:pl-56 transition-all min-w-0">
+          {open && (
+            <div className="fixed inset-0 top-14 z-50 xl:hidden">
+              <div
+                className="absolute inset-0 bg-background/80 backdrop-blur-sm"
+                onClick={() => setOpen(false)}
+              />
+              <div className="absolute top-0 bottom-0 left-0 w-64 bg-background shadow-lg border-r">
+                <SettingsSidebar onClose={() => setOpen(false)} />
+              </div>
+            </div>
+          )}
+
+          <main className="flex-1 p-6 space-y-6">
+            <Outlet />
+          </main>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -1874,7 +1874,38 @@ export interface paths {
         };
         options?: never;
         head?: never;
-        patch?: never;
+        /** Update blocked candidate reason */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        identityKey: string;
+                        reason?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Block reason updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            updated: boolean;
+                        };
+                    };
+                };
+            };
+        };
         trace?: never;
     };
     "/api/candidate-status": {

--- a/apps/web/src/pages/BlacklistPage.tsx
+++ b/apps/web/src/pages/BlacklistPage.tsx
@@ -1,0 +1,299 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { PageHeader } from '@/components/PageHeader'
+import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+
+export function BlacklistPage() {
+  const { t } = useTranslation()
+  const { items, loading, error, unblockCandidate, updateBlockReason } = useCandidateBlocks()
+  const [search, setSearch] = useState('')
+  const [selectedIdentityKeys, setSelectedIdentityKeys] = useState<string[]>([])
+  const [editingIdentityKey, setEditingIdentityKey] = useState<string | null>(null)
+  const [editingReason, setEditingReason] = useState('')
+  const [savingReason, setSavingReason] = useState(false)
+  const [bulkUnblocking, setBulkUnblocking] = useState(false)
+  const [rowUnblockingIdentityKey, setRowUnblockingIdentityKey] = useState<string | null>(null)
+
+  useEffect(() => {
+    const currentKeys = new Set(items.map((item) => item.identityKey))
+    setSelectedIdentityKeys((previous) => previous.filter((identityKey) => currentKeys.has(identityKey)))
+  }, [items])
+
+  const filteredItems = useMemo(() => {
+    const keyword = search.trim().toLowerCase()
+    const sorted = [...items].sort((a, b) => b.blockedAt - a.blockedAt)
+    if (!keyword) {
+      return sorted
+    }
+
+    return sorted.filter((item) => {
+      const reason = item.reason ?? ''
+      return item.identityKey.toLowerCase().includes(keyword) || reason.toLowerCase().includes(keyword)
+    })
+  }, [items, search])
+
+  const filteredIdentityKeys = useMemo(() => filteredItems.map((item) => item.identityKey), [filteredItems])
+  const selectedVisibleCount = useMemo(
+    () => filteredIdentityKeys.filter((identityKey) => selectedIdentityKeys.includes(identityKey)).length,
+    [filteredIdentityKeys, selectedIdentityKeys]
+  )
+  const allVisibleSelected = filteredIdentityKeys.length > 0 && selectedVisibleCount === filteredIdentityKeys.length
+  const someVisibleSelected = selectedVisibleCount > 0 && !allVisibleSelected
+
+  const toggleAllVisible = useCallback(
+    (checked: boolean) => {
+      setSelectedIdentityKeys((previous) => {
+        if (checked) {
+          return Array.from(new Set([...previous, ...filteredIdentityKeys]))
+        }
+        const visible = new Set(filteredIdentityKeys)
+        return previous.filter((identityKey) => !visible.has(identityKey))
+      })
+    },
+    [filteredIdentityKeys]
+  )
+
+  const toggleOne = useCallback((identityKey: string, checked: boolean) => {
+    setSelectedIdentityKeys((previous) => {
+      if (checked) {
+        return Array.from(new Set([...previous, identityKey]))
+      }
+      return previous.filter((item) => item !== identityKey)
+    })
+  }, [])
+
+  const startEditing = useCallback((identityKey: string, reason?: string) => {
+    setEditingIdentityKey(identityKey)
+    setEditingReason(reason ?? '')
+  }, [])
+
+  const cancelEditing = useCallback(() => {
+    setEditingIdentityKey(null)
+    setEditingReason('')
+    setSavingReason(false)
+  }, [])
+
+  const commitReason = useCallback(
+    async (identityKey: string) => {
+      if (savingReason || editingIdentityKey !== identityKey) {
+        return
+      }
+
+      const nextReason = editingReason.trim()
+      const existing = items.find((item) => item.identityKey === identityKey)
+      const currentReason = (existing?.reason ?? '').trim()
+      if (currentReason === nextReason) {
+        cancelEditing()
+        return
+      }
+
+      setSavingReason(true)
+      const updated = await updateBlockReason(identityKey, nextReason.length > 0 ? nextReason : undefined)
+      setSavingReason(false)
+
+      if (!updated) {
+        toast.error(t('settings.blocks.toasts.reasonUpdateFailed', { defaultValue: 'Failed to update block reason' }))
+        return
+      }
+
+      toast.success(t('settings.blocks.toasts.reasonUpdated', { defaultValue: 'Block reason updated' }))
+      cancelEditing()
+    },
+    [cancelEditing, editingIdentityKey, editingReason, items, savingReason, t, updateBlockReason]
+  )
+
+  const handleUnblock = useCallback(
+    async (identityKey: string) => {
+      setRowUnblockingIdentityKey(identityKey)
+      const removed = await unblockCandidate(identityKey)
+      setRowUnblockingIdentityKey(null)
+
+      if (!removed) {
+        toast.error(t('settings.blocks.toasts.unblockFailed', { defaultValue: 'Failed to unblock candidate' }))
+        return
+      }
+
+      setSelectedIdentityKeys((previous) => previous.filter((item) => item !== identityKey))
+      toast.success(t('settings.blocks.toasts.unblockSuccess', { defaultValue: 'Candidate unblocked' }))
+    },
+    [t, unblockCandidate]
+  )
+
+  const handleBulkUnblock = useCallback(async () => {
+    if (selectedIdentityKeys.length === 0 || bulkUnblocking) {
+      return
+    }
+
+    setBulkUnblocking(true)
+    let removedCount = 0
+
+    for (const identityKey of selectedIdentityKeys) {
+      const removed = await unblockCandidate(identityKey)
+      if (removed) {
+        removedCount += 1
+      }
+    }
+
+    setBulkUnblocking(false)
+    setSelectedIdentityKeys([])
+
+    if (removedCount > 0) {
+      toast.success(
+        t('settings.blocks.toasts.bulkUnblockSuccess', {
+          defaultValue: 'Unblocked {{count}} candidate(s)',
+          count: removedCount,
+        })
+      )
+      if (removedCount === selectedIdentityKeys.length) {
+        return
+      }
+    }
+
+    toast.error(t('settings.blocks.toasts.bulkUnblockFailed', { defaultValue: 'Failed to unblock selected candidates' }))
+  }, [bulkUnblocking, selectedIdentityKeys, t, unblockCandidate])
+
+  const isEmpty = items.length === 0
+  const hasNoFilteredResults = !isEmpty && filteredItems.length === 0
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t('settings.blocks.title', { defaultValue: 'Blacklist Management' })}
+        description={t('settings.blocks.description', { defaultValue: 'View and manage blocked candidates for this workspace.' })}
+        actions={<Badge variant="secondary">{t('settings.blocks.countBadge', { defaultValue: '{{count}} blocked', count: items.length })}</Badge>}
+      />
+
+      <Card>
+        <CardHeader className="gap-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <CardTitle>{t('settings.blocks.nav', { defaultValue: 'Blacklist' })}</CardTitle>
+              <CardDescription>
+                {t('settings.blocks.description', { defaultValue: 'View and manage blocked candidates for this workspace.' })}
+              </CardDescription>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder={t('settings.blocks.searchPlaceholder', { defaultValue: 'Search by candidate key or reason...' })}
+                className="w-full sm:w-72"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void handleBulkUnblock()}
+                disabled={selectedIdentityKeys.length === 0 || bulkUnblocking}
+              >
+                {t('settings.blocks.bulkUnblock', { defaultValue: 'Unblock Selected ({{count}})', count: selectedIdentityKeys.length })}
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          {loading ? <div className="text-sm text-muted-foreground">{t('resumes.loading', { defaultValue: 'Loading...' })}</div> : null}
+          {!loading && error ? <div className="text-sm text-destructive">{error}</div> : null}
+          {!loading && !error && isEmpty ? (
+            <div className="text-sm text-muted-foreground">{t('settings.blocks.empty', { defaultValue: 'No blocked candidates yet.' })}</div>
+          ) : null}
+          {!loading && !error && hasNoFilteredResults ? (
+            <div className="text-sm text-muted-foreground">
+              {t('settings.blocks.emptySearch', { defaultValue: 'No blocked candidates match your search.' })}
+            </div>
+          ) : null}
+
+          {!loading && !error && filteredItems.length > 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[42px]">
+                    <Checkbox
+                      checked={allVisibleSelected ? true : someVisibleSelected ? 'indeterminate' : false}
+                      onCheckedChange={(checked) => toggleAllVisible(checked === true)}
+                      aria-label={t('bulkActions.selectAll', { defaultValue: 'Select all' })}
+                    />
+                  </TableHead>
+                  <TableHead>{t('settings.blocks.columns.candidate', { defaultValue: 'Candidate' })}</TableHead>
+                  <TableHead>{t('settings.blocks.columns.reason', { defaultValue: 'Reason' })}</TableHead>
+                  <TableHead>{t('settings.blocks.columns.blockedAt', { defaultValue: 'Blocked Date' })}</TableHead>
+                  <TableHead>{t('settings.blocks.columns.blockedBy', { defaultValue: 'Blocked By' })}</TableHead>
+                  <TableHead className="text-right">{t('settings.blocks.columns.actions', { defaultValue: 'Actions' })}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredItems.map((item) => {
+                  const isEditing = editingIdentityKey === item.identityKey
+                  const isRowUnblocking = rowUnblockingIdentityKey === item.identityKey
+                  const displayedReason = item.reason?.trim()
+
+                  return (
+                    <TableRow key={item._id}>
+                      <TableCell>
+                        <Checkbox
+                          checked={selectedIdentityKeys.includes(item.identityKey)}
+                          onCheckedChange={(checked) => toggleOne(item.identityKey, checked === true)}
+                          aria-label={item.identityKey}
+                        />
+                      </TableCell>
+                      <TableCell className="font-mono text-xs">{item.identityKey}</TableCell>
+                      <TableCell className="max-w-[360px]">
+                        {isEditing ? (
+                          <Input
+                            value={editingReason}
+                            onChange={(event) => setEditingReason(event.target.value)}
+                            onBlur={() => void commitReason(item.identityKey)}
+                            onKeyDown={(event) => {
+                              if (event.key === 'Enter') {
+                                event.preventDefault()
+                                event.currentTarget.blur()
+                              } else if (event.key === 'Escape') {
+                                event.preventDefault()
+                                cancelEditing()
+                              }
+                            }}
+                            disabled={savingReason}
+                            autoFocus
+                            className="h-8"
+                          />
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => startEditing(item.identityKey, item.reason)}
+                            className="w-full text-left text-sm hover:text-foreground text-muted-foreground"
+                          >
+                            {displayedReason || t('settings.blocks.noReason', { defaultValue: '-' })}
+                          </button>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-sm">{new Date(item.blockedAt).toLocaleString()}</TableCell>
+                      <TableCell className="text-sm text-muted-foreground">{item.blockedBy?.trim() || '-'}</TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={isRowUnblocking || bulkUnblocking}
+                          onClick={() => void handleUnblock(item.identityKey)}
+                        >
+                          {t('settings.blocks.actions.unblock', { defaultValue: 'Unblock' })}
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/packages/convex/convex/candidate_blocks.ts
+++ b/packages/convex/convex/candidate_blocks.ts
@@ -87,6 +87,38 @@ export const upsert = mutation({
     },
 });
 
+export const updateReason = mutation({
+    args: {
+        workspaceSlug: v.optional(v.string()),
+        identityKey: v.string(),
+        reason: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+        const identityKey = normalizeIdentityKey(args.identityKey);
+        if (!identityKey) {
+            throw new Error("identityKey is required");
+        }
+
+        const existing = await ctx.db
+            .query("candidate_blocks")
+            .withIndex("by_workspace_identity", (q) =>
+                q.eq("workspaceSlug", workspaceSlug).eq("identityKey", identityKey)
+            )
+            .unique();
+
+        if (!existing) {
+            return false;
+        }
+
+        await ctx.db.patch(existing._id, {
+            reason: args.reason,
+        });
+
+        return true;
+    },
+});
+
 export const bulkUpsert = mutation({
     args: {
         workspaceSlug: v.optional(v.string()),


### PR DESCRIPTION
Summary
- expose a new `/settings` area with a SettingsLayout, sidebar, header link, and router integration so workspaces can access configuration without AdminGate
- add blacklist management UI/hooks that call new PATCH API/Convex mutation for updating block reasons and support selections, inline edits, and bulk actions with localized text
- teach candidate block hook how to PATCH reason and wire translations for the new settings page

Testing
- Not run (not requested)