### PR TITLE
Add resume database reset action to debug ingest

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -127,7 +127,11 @@
     "companyHits": "Company Hits",
     "experienceLevel": "Experience Level",
     "ruleScoreCount": "Rule Scores",
-    "noIngestData": "No ingest data yet for this resume."
+    "noIngestData": "No ingest data yet for this resume.",
+    "resetDatabase": "Clear Resume Database",
+    "resetDatabaseConfirm": "Delete all resume data and task records? This cannot be undone.",
+    "resetDatabaseSuccess": "Deleted {{count}} records from the resume database.",
+    "resetDatabaseFailed": "Failed to clear resume database"
   },
   "trends": {
     "title": "Trending Topics",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -127,7 +127,11 @@
     "companyHits": "公司命中",
     "experienceLevel": "经验等级",
     "ruleScoreCount": "规则分数量",
-    "noIngestData": "该简历尚未生成 ingest 数据。"
+    "noIngestData": "该简历尚未生成 ingest 数据。",
+    "resetDatabase": "清空简历数据库",
+    "resetDatabaseConfirm": "将删除所有简历数据及任务记录，且无法撤销。确定继续吗？",
+    "resetDatabaseSuccess": "已从简历数据库删除 {{count}} 条记录。",
+    "resetDatabaseFailed": "清空简历数据库失败"
   },
   "trends": {
     "title": "热门话题",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -127,7 +127,11 @@
     "companyHits": "公司命中",
     "experienceLevel": "經驗等級",
     "ruleScoreCount": "規則分數數量",
-    "noIngestData": "此簡歷尚未產生 ingest 數據。"
+    "noIngestData": "此簡歷尚未產生 ingest 數據。",
+    "resetDatabase": "清空履歷資料庫",
+    "resetDatabaseConfirm": "將刪除所有履歷資料與任務記錄，且無法復原。確定繼續嗎？",
+    "resetDatabaseSuccess": "已從履歷資料庫刪除 {{count}} 筆記錄。",
+    "resetDatabaseFailed": "清空履歷資料庫失敗"
   },
   "trends": {
     "title": "熱門話題",

--- a/apps/web/src/pages/DebugIngest.tsx
+++ b/apps/web/src/pages/DebugIngest.tsx
@@ -56,6 +56,7 @@ export default function DebugIngest() {
   const backfillIngestData = useAction(api.migrations.backfillIngestData)
   const reIngestStaleSkillsVersion = useAction(api.migrations.reIngestStaleSkillsVersion)
   const clearAnalysesMutation = useMutation(api.resumes.clearAnalyses)
+  const resetDatabaseMutation = useMutation(api.resume_tasks.resetDatabase)
 
   const [search, setSearch] = useState('')
   const [skillsVersion, setSkillsVersion] = useState<number | null>(null)
@@ -63,6 +64,7 @@ export default function DebugIngest() {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [reingesting, setReingesting] = useState(false)
   const [clearingAnalyses, setClearingAnalyses] = useState(false)
+  const [resettingDatabase, setResettingDatabase] = useState(false)
 
   const apiBaseUrl = useMemo(() => {
     const rawBaseUrl = import.meta.env.VITE_API_URL || '/api'
@@ -169,6 +171,40 @@ export default function DebugIngest() {
     }
   }, [clearAnalysesMutation, t])
 
+  const resetDatabase = useCallback(async () => {
+    const confirmed = window.confirm(
+      t('debugIngest.resetDatabaseConfirm', {
+        defaultValue: 'Delete all resume data and task records? This cannot be undone.',
+      })
+    )
+    if (!confirmed) {
+      return
+    }
+
+    setResettingDatabase(true)
+    try {
+      const result = await resetDatabaseMutation({})
+      setSearch('')
+      setExpandedIds(new Set())
+      toast.success(
+        t('debugIngest.resetDatabaseSuccess', {
+          count: result.count,
+          defaultValue: `Deleted ${result.count} records from the resume database.`,
+        })
+      )
+      await loadSkillsVersion()
+    } catch (error) {
+      console.error('Failed to reset resume database', error)
+      toast.error(
+        t('debugIngest.resetDatabaseFailed', {
+          defaultValue: 'Failed to clear resume database',
+        })
+      )
+    } finally {
+      setResettingDatabase(false)
+    }
+  }, [loadSkillsVersion, resetDatabaseMutation, t])
+
   return (
     <div className="space-y-6">
       <PageHeader
@@ -228,6 +264,10 @@ export default function DebugIngest() {
         <Button variant="destructive" onClick={() => void clearAnalyses()} disabled={clearingAnalyses}>
           <Trash2 className={`mr-2 h-4 w-4 ${clearingAnalyses ? 'animate-spin' : ''}`} />
           {t('debugIngest.clearAnalyses', { defaultValue: 'Reset AI Analyses' })}
+        </Button>
+        <Button variant="destructive" onClick={() => void resetDatabase()} disabled={resettingDatabase}>
+          <Trash2 className={`mr-2 h-4 w-4 ${resettingDatabase ? 'animate-spin' : ''}`} />
+          {t('debugIngest.resetDatabase', { defaultValue: 'Clear Resume Database' })}
         </Button>
       </div>
 

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -554,6 +554,44 @@ export const resetDatabase = mutation({
             await ctx.db.delete(status._id);
         }
 
-        return { success: true, count: tasks.length + resumes.length + workers.length + blocks.length + statuses.length };
+        const analysisTasks = await ctx.db.query("analysis_tasks").collect();
+        for (const analysisTask of analysisTasks) {
+            await ctx.db.delete(analysisTask._id);
+        }
+
+        const screeningSessions = await ctx.db.query("screening_sessions").collect();
+        for (const session of screeningSessions) {
+            await ctx.db.delete(session._id);
+        }
+
+        const syncEvents = await ctx.db.query("sync_events").collect();
+        for (const event of syncEvents) {
+            await ctx.db.delete(event._id);
+        }
+
+        const count =
+            tasks.length
+            + resumes.length
+            + workers.length
+            + blocks.length
+            + statuses.length
+            + analysisTasks.length
+            + screeningSessions.length
+            + syncEvents.length;
+
+        return {
+            success: true,
+            count,
+            deleted: {
+                collectionTasks: tasks.length,
+                resumes: resumes.length,
+                collectionWorkers: workers.length,
+                candidateBlocks: blocks.length,
+                candidateStatus: statuses.length,
+                analysisTasks: analysisTasks.length,
+                screeningSessions: screeningSessions.length,
+                syncEvents: syncEvents.length,
+            },
+        };
     },
 });


### PR DESCRIPTION
Summary
- add a destructive "Clear Resume Database" button on the Debug Ingest page with localized copy and toast feedback
- hook the action up to the new `resume_tasks.resetDatabase` mutation so it recreates task, resume, analysis, screening, and sync data counts
- extend the mutation to delete analysis tasks, screening sessions, and sync events while returning detailed deletion counts

Testing
- Not run (not requested)