### PR TITLE
feat(resume): generalize quick role filter by JD required role

### DIFF
--- a/apps/api/src/services/ingest-compute-service.test.ts
+++ b/apps/api/src/services/ingest-compute-service.test.ts
@@ -182,6 +182,28 @@ const SAMPLE_RESUME_HAAS = {
   ],
 };
 
+const SAMPLE_RESUME_ENGINEER = {
+  data: [
+    {
+      name: "赵六",
+      profileUrl: "https://example.com/profile/901",
+      activityStatus: "在线中",
+      age: "30岁",
+      experience: "6年",
+      education: "本科",
+      location: "东莞市",
+      jobIntention: "机械工程师",
+      expectedSalary: "18000-22000元/月",
+      selfIntro: "具备机械设计与研发经验，熟悉设备调试和技术问题排查。",
+      workHistory: [
+        { raw: "2021-01~2025-12(4年11月)东莞自动化设备有限公司机械工程师" },
+        { raw: "2019-06~2020-12(1年6月)深圳科技有限公司研发工程师" },
+      ],
+      extractedAt: "2026-02-21T10:00:00.000Z",
+    },
+  ],
+};
+
 describe("IngestComputeService", () => {
   let tmpDir: string;
   let service: IngestComputeService;
@@ -269,6 +291,15 @@ describe("IngestComputeService", () => {
     expect(salesRole?.signalCount).toBeGreaterThan(0);
     expect(salesRole?.years).toBeGreaterThan(0);
     expect(result.ruleScores["jd-lathe-sales"]).toBeGreaterThan(50);
+  });
+
+  it("should compute engineer role signals from work history", () => {
+    const result = service.computeOne("resume-901", SAMPLE_RESUME_ENGINEER);
+    const engineerRole = result.roleSignals.find((item) => item.type === "engineer");
+
+    expect(engineerRole).toBeDefined();
+    expect(engineerRole?.matchedSignals).toEqual(expect.arrayContaining(["工程师", "研发"]));
+    expect(engineerRole?.years).toBeGreaterThan(0);
   });
 
   it("should classify selfIntro brand mentions as equipment context", () => {

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -221,6 +221,7 @@ const SALES_SIGNALS = ["销售", "代理", "渠道", "推广", "业务", "客户
 const TECHNICAL_SIGNALS = ["维修", "调试", "编程", "安装", "保养", "维护"];
 const DEFAULT_ROLE_SIGNAL_LIBRARY: Record<string, string[]> = {
   sales: ["销售", "业务开发", "客户", "大客户", "渠道", "销售经理", "销售工程师", "sales", "account"],
+  engineer: ["工程师", "设计", "研发", "开发", "编程", "调试", "维修", "技术", "engineer", "developer", "design"],
 };
 
 /**

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -49,6 +49,15 @@ type ProfileApiResponse = {
   profile?: SearchProfileDetails
 }
 
+type JobDescriptionDetailApiResponse = {
+  success: boolean
+  item?: {
+    requiredRoles?: Array<{
+      type?: string
+    }>
+  }
+}
+
 type AutoMatchedProfile = {
   confidence: number
   matchedKeywords: string[]
@@ -67,11 +76,13 @@ interface QuickStartPanelProps {
   jobDescriptionId?: string
   onJobChange?: (value: string) => void
   quickFilters?: {
-    minSalesYears?: number
+    minRoleYears?: number
+    roleFilterType?: string
     maxAge?: number
   }
   onApplyQuickFilters?: (filters: {
-    minSalesYears?: number
+    minRoleYears?: number
+    roleFilterType?: string
     maxAge?: number
   }) => void
   extraActions?: React.ReactNode
@@ -140,6 +151,22 @@ function getFilterSummary(profile: SearchProfileDetails): string {
   return 'default'
 }
 
+const ROLE_LABELS: Record<string, string> = {
+  sales: '销售经验',
+  engineer: '工程经验',
+}
+
+function getRoleLabel(roleType: string | undefined): string {
+  if (!roleType) {
+    return '相关经验'
+  }
+  const normalized = roleType.trim().toLowerCase()
+  if (!normalized) {
+    return '相关经验'
+  }
+  return ROLE_LABELS[normalized] ?? '相关经验'
+}
+
 export function QuickStartPanel({
   onApplyConfig,
   defaultLocation = '广东',
@@ -156,8 +183,9 @@ export function QuickStartPanel({
   const [location, setLocation] = useState(defaultLocation)
   const [selectedKeywords, setSelectedKeywords] = useState<string[]>(defaultKeywords)
   const [customKeyword, setCustomKeyword] = useState(defaultKeywords.join(' '))
-  const [quickMinSalesYears, setQuickMinSalesYears] = useState(quickFilters?.minSalesYears?.toString() ?? '')
+  const [quickMinRoleYears, setQuickMinRoleYears] = useState(quickFilters?.minRoleYears?.toString() ?? '')
   const [quickMaxAge, setQuickMaxAge] = useState(quickFilters?.maxAge?.toString() ?? '')
+  const [activeRoleType, setActiveRoleType] = useState<string | undefined>(quickFilters?.roleFilterType)
   const [autoMatchResult, setAutoMatchResult] = useState<AutoMatchedProfile | null>(null)
   const [matching, setMatching] = useState(false)
 
@@ -171,9 +199,43 @@ export function QuickStartPanel({
   }, [defaultKeywords])
 
   useEffect(() => {
-    setQuickMinSalesYears(quickFilters?.minSalesYears?.toString() ?? '')
+    setQuickMinRoleYears(quickFilters?.minRoleYears?.toString() ?? '')
     setQuickMaxAge(quickFilters?.maxAge?.toString() ?? '')
-  }, [quickFilters?.maxAge, quickFilters?.minSalesYears])
+  }, [quickFilters?.maxAge, quickFilters?.minRoleYears])
+
+  useEffect(() => {
+    const normalizedJobDescriptionId = jobDescriptionId.trim()
+    if (!normalizedJobDescriptionId) {
+      setActiveRoleType(undefined)
+      return
+    }
+
+    let cancelled = false
+
+    const fetchRoleType = async () => {
+      try {
+        const response = await rawApiClient.GET<JobDescriptionDetailApiResponse>(
+          `/api/job-descriptions/${encodeURIComponent(normalizedJobDescriptionId)}`
+        )
+        if (cancelled) {
+          return
+        }
+        const roleType = response.data?.item?.requiredRoles?.[0]?.type?.trim()
+        setActiveRoleType(roleType && roleType.length > 0 ? roleType : undefined)
+      } catch (error) {
+        console.error('Failed to fetch role type from job description', error)
+        if (!cancelled) {
+          setActiveRoleType(undefined)
+        }
+      }
+    }
+
+    void fetchRoleType()
+
+    return () => {
+      cancelled = true
+    }
+  }, [jobDescriptionId])
 
   const normalizedKeywords = useMemo(
     () => selectedKeywords.map((keyword) => keyword.trim()).filter((keyword) => keyword.length > 0),
@@ -288,13 +350,15 @@ export function QuickStartPanel({
   }, [onJobChange])
 
   const handleApplyQuickFilters = useCallback(() => {
-    const minSalesYears = quickMinSalesYears ? Number(quickMinSalesYears) : undefined
+    const minRoleYears = quickMinRoleYears ? Number(quickMinRoleYears) : undefined
     const maxAge = quickMaxAge ? Number(quickMaxAge) : undefined
+    const roleFilterType = activeRoleType?.trim()
     onApplyQuickFilters?.({
-      minSalesYears: typeof minSalesYears === 'number' && Number.isFinite(minSalesYears) ? minSalesYears : undefined,
+      minRoleYears: typeof minRoleYears === 'number' && Number.isFinite(minRoleYears) ? minRoleYears : undefined,
+      roleFilterType: roleFilterType && roleFilterType.length > 0 ? roleFilterType : undefined,
       maxAge: typeof maxAge === 'number' && Number.isFinite(maxAge) ? maxAge : undefined,
     })
-  }, [onApplyQuickFilters, quickMaxAge, quickMinSalesYears])
+  }, [activeRoleType, onApplyQuickFilters, quickMaxAge, quickMinRoleYears])
 
   return (
     <div className="rounded-lg bg-background border px-4 py-4 shadow-sm">
@@ -430,12 +494,12 @@ export function QuickStartPanel({
           <div className="text-sm font-medium">⚡ 快速筛选</div>
           <div className="mt-2 flex flex-wrap items-end gap-3">
             <label className="text-sm text-muted-foreground">
-              要求销售经验 最少
+              要求{getRoleLabel(activeRoleType)} 最少
               <input
                 type="number"
                 min={0}
-                value={quickMinSalesYears}
-                onChange={(event) => setQuickMinSalesYears(event.target.value)}
+                value={quickMinRoleYears}
+                onChange={(event) => setQuickMinRoleYears(event.target.value)}
                 className="mx-2 h-8 w-20 rounded-md border border-input bg-background px-2 text-sm"
               />
               年

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -86,7 +86,9 @@ export function ResumeList() {
         defaultLocation={sessionLocation}
         defaultKeywords={sessionKeywords}
         quickFilters={{
-          minSalesYears: filters.minSalesYears,
+          minRoleYears: filters.minRoleYears ?? filters.minSalesYears,
+          roleFilterType:
+            filters.roleFilterType ?? (typeof filters.minSalesYears === 'number' ? 'sales' : undefined),
           maxAge: filters.maxAge,
         }}
         onApplyQuickFilters={handleQuickConstraintApply}

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -262,8 +262,23 @@ function toStatusFilterList(values: CandidateStatus[] | undefined): CandidateSta
   return Array.from(unique).sort()
 }
 
-function getSalesRoleYears(resume: ConvexResumeItem): number {
-  const roleSignal = resume.ingestData?.roleSignals?.find((signal) => normalizeFilterToken(signal.type) === 'sales')
+function getRoleYears(resume: ConvexResumeItem, roleType: string): number {
+  const roleSignals = resume.ingestData?.roleSignals
+  if (!Array.isArray(roleSignals) || roleSignals.length === 0) {
+    return 0
+  }
+
+  const normalizedRoleType = normalizeFilterToken(roleType)
+  if (!normalizedRoleType) {
+    return roleSignals.reduce((maxYears, signal) => {
+      if (typeof signal.years !== 'number' || !Number.isFinite(signal.years)) {
+        return maxYears
+      }
+      return Math.max(maxYears, signal.years)
+    }, 0)
+  }
+
+  const roleSignal = roleSignals.find((signal) => normalizeFilterToken(signal.type) === normalizedRoleType)
   if (!roleSignal || typeof roleSignal.years !== 'number' || !Number.isFinite(roleSignal.years)) {
     return 0
   }
@@ -660,9 +675,16 @@ export function useResumeListState() {
       result = result.filter((resume: ScoredConvexResume) => parseExperienceYears(resume.experience) <= maxExperience)
     }
 
-    const minSalesYears = filters.minSalesYears
-    if (typeof minSalesYears === 'number') {
-      result = result.filter((resume: ScoredConvexResume) => getSalesRoleYears(resume) >= minSalesYears)
+    const minRoleYears = filters.minRoleYears
+    if (typeof minRoleYears === 'number') {
+      result = result.filter((resume: ScoredConvexResume) =>
+        getRoleYears(resume, filters.roleFilterType ?? '') >= minRoleYears
+      )
+    } else {
+      const minSalesYears = filters.minSalesYears
+      if (typeof minSalesYears === 'number') {
+        result = result.filter((resume: ScoredConvexResume) => getRoleYears(resume, 'sales') >= minSalesYears)
+      }
     }
 
     const minAge = filters.minAge
@@ -1259,12 +1281,15 @@ export function useResumeListState() {
 
   const handleQuickConstraintApply = useCallback(
     (constraints: {
-      minSalesYears?: number
+      minRoleYears?: number
+      roleFilterType?: string
       maxAge?: number
     }) => {
       setFilters((current) => ({
         ...current,
-        minSalesYears: constraints.minSalesYears,
+        minRoleYears: constraints.minRoleYears,
+        roleFilterType: normalizeOptionalString(constraints.roleFilterType),
+        minSalesYears: undefined,
         maxAge: constraints.maxAge,
       }))
     },

--- a/apps/web/src/types/resume.ts
+++ b/apps/web/src/types/resume.ts
@@ -1,6 +1,8 @@
 export type ResumeFilters = {
   minExperience?: number
   maxExperience?: number
+  minRoleYears?: number
+  roleFilterType?: string
   minSalesYears?: number
   minAge?: number
   maxAge?: number

--- a/config/job-descriptions/3d-scanner-sales.md
+++ b/config/job-descriptions/3d-scanner-sales.md
@@ -7,6 +7,11 @@ location: 东莞
 source: hr.job5156.com
 extracted_at: "2026-02-05"
 status: active
+required_roles:
+  - type: sales
+    min_years: 1
+    signals: [销售, 业务开发, 客户, 大客户, 渠道, 销售经理, 销售工程师]
+    verify_in: workHistory
 ---
 
 # 职位描述 (Position Description)
@@ -32,4 +37,3 @@ status: active
 # 关键词 (Keywords)
 
 三维扫描, 3D扫描, ATOS, 测量设备, 精密测量, GOM, 逆向工程, 光学测量
-

--- a/config/job-descriptions/cpp-software-engineer.md
+++ b/config/job-descriptions/cpp-software-engineer.md
@@ -7,6 +7,11 @@ location: 东莞
 source: hr.job5156.com
 extracted_at: "2026-02-05"
 status: active
+required_roles:
+  - type: engineer
+    min_years: 1
+    signals: [工程师, 设计, 研发, 开发, 编程, 调试, 维修, 技术]
+    verify_in: workHistory
 ---
 
 # 职位描述 (Position Description)

--- a/config/job-descriptions/five-axis-application.md
+++ b/config/job-descriptions/five-axis-application.md
@@ -7,6 +7,11 @@ location: 东莞
 source: hr.job5156.com
 extracted_at: "2026-02-05"
 status: active
+required_roles:
+  - type: engineer
+    min_years: 3
+    signals: [工程师, 设计, 研发, 开发, 编程, 调试, 维修, 技术]
+    verify_in: workHistory
 ---
 
 # 职位描述 (Position Description)

--- a/config/job-descriptions/fixture-engineer.md
+++ b/config/job-descriptions/fixture-engineer.md
@@ -7,6 +7,11 @@ location: 东莞
 source: hr.job5156.com
 extracted_at: "2026-02-05"
 status: active
+required_roles:
+  - type: engineer
+    min_years: 2
+    signals: [工程师, 设计, 研发, 开发, 编程, 调试, 维修, 技术]
+    verify_in: workHistory
 ---
 
 # 职位描述 (Position Description)

--- a/config/job-descriptions/machining-center-sales.md
+++ b/config/job-descriptions/machining-center-sales.md
@@ -7,6 +7,11 @@ location: 东莞
 source: hr.job5156.com
 extracted_at: "2026-02-05"
 status: active
+required_roles:
+  - type: sales
+    min_years: 1
+    signals: [销售, 业务开发, 客户, 大客户, 渠道, 销售经理, 销售工程师]
+    verify_in: workHistory
 ---
 
 # 职位描述 (Position Description)

--- a/config/job-descriptions/overseas-sales.md
+++ b/config/job-descriptions/overseas-sales.md
@@ -7,6 +7,11 @@ location: 东莞,海外
 source: hr.job5156.com
 extracted_at: "2026-02-05"
 status: active
+required_roles:
+  - type: sales
+    min_years: 1
+    signals: [销售, 业务开发, 客户, 大客户, 渠道, 销售经理, 销售工程师]
+    verify_in: workHistory
 ---
 
 # 职位描述 (Position Description)

--- a/config/job-descriptions/senior-mechanical-engineer.md
+++ b/config/job-descriptions/senior-mechanical-engineer.md
@@ -7,6 +7,11 @@ location: 东莞
 source: hr.job5156.com
 extracted_at: "2026-02-05"
 status: active
+required_roles:
+  - type: engineer
+    min_years: 5
+    signals: [工程师, 设计, 研发, 开发, 编程, 调试, 维修, 技术]
+    verify_in: workHistory
 ---
 
 # 职位描述 (Position Description)


### PR DESCRIPTION
## Summary
- add `engineer` role signals to ingest compute and cover with tests
- add missing `required_roles` frontmatter for engineer and sales JDs
- generalize quick filter from hardcoded sales to dynamic role type (`minRoleYears` + `roleFilterType`)
- keep backward compatibility via `minSalesYears` fallback path

## Verification
- `npx vitest run apps/api/src/services/ingest-compute-service.test.ts`
- `make check-node`
- `npx convex run migrations:backfillIngestData` (run twice from `packages/convex` until `hasMore: false`)

## Notes
- Quick filter label now resolves by JD `requiredRoles[0].type`:
  - sales -> 销售经验
  - engineer -> 工程经验
  - fallback -> 相关经验
