### PR TITLE
feat(notifications): add feishu template channel support

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -52,7 +52,7 @@ const templateIdSchema = z
 const templateDataSchema = z.record(z.unknown());
 
 const previewSchema = z.object({
-    channel: z.enum(["email", "wechat_work"]),
+    channel: z.enum(["email", "wechat_work", "feishu"]),
     templateId: templateIdSchema,
     data: templateDataSchema,
 });
@@ -67,6 +67,12 @@ const sendTemplateSchema = z.discriminatedUnion("channel", [
     }),
     z.object({
         channel: z.literal("wechat_work"),
+        templateId: templateIdSchema,
+        webhookUrl: z.string().url().optional(),
+        data: templateDataSchema,
+    }),
+    z.object({
+        channel: z.literal("feishu"),
         templateId: templateIdSchema,
         webhookUrl: z.string().url().optional(),
         data: templateDataSchema,
@@ -221,7 +227,15 @@ app.post(
                 return c.json({ success: true, channel: payload.channel, messageId });
             }
 
-            const result = await notificationService.sendWechatWorkMarkdown({
+            if (payload.channel === "wechat_work") {
+                const result = await notificationService.sendWechatWorkMarkdown({
+                    webhookUrl: payload.webhookUrl,
+                    content: rendered.markdown,
+                });
+                return c.json({ success: true, channel: payload.channel, ...result });
+            }
+
+            const result = await notificationService.sendFeishuText({
                 webhookUrl: payload.webhookUrl,
                 content: rendered.markdown,
             });

--- a/apps/api/src/services/notification-service.ts
+++ b/apps/api/src/services/notification-service.ts
@@ -13,6 +13,11 @@ export interface WechatWorkMarkdownOptions {
     webhookUrl?: string;
 }
 
+export interface FeishuTextOptions {
+    content: string;
+    webhookUrl?: string;
+}
+
 export interface NotificationAdapter {
     sendEmail(options: EmailOptions): Promise<unknown>;
 }
@@ -21,6 +26,17 @@ const wechatWorkWebhookResponseSchema = z.object({
     errcode: z.number(),
     errmsg: z.string(),
 });
+
+const feishuWebhookResponseSchema = z.union([
+    z.object({
+        code: z.number(),
+        msg: z.string(),
+    }).passthrough(),
+    z.object({
+        StatusCode: z.number(),
+        StatusMessage: z.string(),
+    }).passthrough(),
+]);
 
 class EtherealAdapter implements NotificationAdapter {
     private transporter: nodemailer.Transporter | null = null;
@@ -131,6 +147,45 @@ export class NotificationService {
         }
 
         return parsed.data;
+    }
+
+    async sendFeishuText(options: FeishuTextOptions) {
+        const webhookUrl = options.webhookUrl ?? process.env.FEISHU_WEBHOOK_URL ?? process.env.FEISHU_WEBHOOK;
+        if (!webhookUrl) {
+            throw new Error("FEISHU_WEBHOOK_URL is not set");
+        }
+
+        const response = await fetch(webhookUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                msg_type: "text",
+                content: { text: options.content },
+            }),
+        });
+
+        const rawText = await response.text();
+        let rawJson: unknown;
+        try {
+            rawJson = JSON.parse(rawText);
+        } catch {
+            throw new Error(`Feishu webhook returned non-JSON (HTTP ${response.status})`);
+        }
+
+        const parsed = feishuWebhookResponseSchema.safeParse(rawJson);
+        if (!parsed.success) {
+            throw new Error(`Feishu webhook returned unexpected response (HTTP ${response.status})`);
+        }
+
+        const data = parsed.data;
+        const code = "code" in data ? data.code : data.StatusCode;
+        const message = "msg" in data ? data.msg : data.StatusMessage;
+
+        if (!response.ok || code !== 0) {
+            throw new Error(`Feishu webhook error: ${message} (code=${code}, HTTP ${response.status})`);
+        }
+
+        return data;
     }
 }
 

--- a/config/notifications/shortlist-feishu.md
+++ b/config/notifications/shortlist-feishu.md
@@ -1,0 +1,33 @@
+# 新候选人推荐｜{{jobTitle}}
+
+候选人：{{candidateName}}
+匹配度：{{matchScore}}分 {{matchStars}}
+工作经验：{{experience}}
+学历：{{education}}
+期望薪资：{{expectedSalary}}
+所在地：{{location}}
+
+AI评估：
+{{aiSummary}}
+
+推荐等级：{{aiRecommendation}}
+
+{{#if matchHighlights}}
+优势亮点：
+{{#each matchHighlights}}
+- {{this}}
+{{/each}}
+{{/if}}
+
+{{#if matchConcerns}}
+需要关注：
+{{#each matchConcerns}}
+- {{this}}
+{{/each}}
+{{/if}}
+
+查看详情：{{detailsUrl}}
+入围：{{actionUrl}}?action=shortlist
+拒绝：{{actionUrl}}?action=reject
+
+时间：{{timestamp}}


### PR DESCRIPTION
## Summary
- add Feishu webhook support in `NotificationService`
- extend `/api/notifications/preview` and `/api/notifications/send-template` to support `channel: feishu`
- add `config/notifications/shortlist-feishu.md` template

## Verification
- `make check-node`
- `npx vitest run apps/api/src/services/notification-template-service.test.ts`

## Notes
- Feishu webhook env fallback order: `FEISHU_WEBHOOK_URL` then `FEISHU_WEBHOOK`
- WeChat Work and Email behavior remains unchanged
