### PR TITLE
test: add keyword mode regression suite and smoke checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: dev dev-fast dev-critical dev-backend dev-clean dev-mcp dev-crawl dev-web dev-api dev-worker dev-api-worker run crawl mcp mcp-http \
 		worker worker-once install install-seed deploy deploy-seed install-deps uninstall fetch-docs clean check help docker docker-build docker-down \
 		check-python check-node check-build \
-		test test-python test-node test-resume \
+		test test-python test-node test-resume test-extension-keyword-mode test-api-search-profiles test-worker-resume-tasks test-collect-url-smoke \
 		build-static build-static-fresh build-extension-zip serve-static \
 		i18n-check i18n-sync i18n-convert i18n-translate i18n-build \
 		refresh-sample refresh-sample-manual prefetch-convex chrome-debug \
@@ -608,6 +608,34 @@ test-node:                                 ## Run TypeScript tests (bun locally,
 		echo "No TypeScript tests found (*.test.ts/*.test.tsx), skipping"; \
 	fi
 
+test-extension-keyword-mode:               ## Run extension keyword mode precedence regression
+	@echo "Running extension keyword mode regression..."
+	@if command -v bun > /dev/null 2>&1; then \
+		bun run test:extension:keyword-mode; \
+	else \
+		npm run test:extension:keyword-mode; \
+	fi
+
+test-api-search-profiles:                  ## Run search-profiles dispatch keyword route test
+	@echo "Running API search-profiles route test..."
+	@if command -v bun > /dev/null 2>&1; then \
+		bun run test:api:search-profiles; \
+	else \
+		npm run test:api:search-profiles; \
+	fi
+
+test-worker-resume-tasks:                  ## Run worker resume task keyword assembly tests
+	@echo "Running worker resume task tests..."
+	@uv run pytest tests/test_resume_tasks.py -q
+
+test-collect-url-smoke:                    ## Run quick smoke for Collect URL keyword concatenation
+	@echo "Running Collect URL smoke check..."
+	@if command -v bun > /dev/null 2>&1; then \
+		bun run test:e2e:collect-url; \
+	else \
+		npm run test:e2e:collect-url; \
+	fi
+
 test-coverage:                             ## Run Node.js tests with coverage
 	@echo "Running Node.js tests with coverage..."
 	@npm run --workspace @trends/shared build
@@ -718,6 +746,10 @@ help:
 	@echo "  test           Run all tests (Python + Node)"
 	@echo "  test-python    Run Python tests only"
 	@echo "  test-node      Run Node.js tests only"
+	@echo "  test-extension-keyword-mode Run extension keyword mode precedence regression"
+	@echo "  test-api-search-profiles Run API route test for profile-run keyword dispatch"
+	@echo "  test-worker-resume-tasks Run worker keyword assembly tests"
+	@echo "  test-collect-url-smoke Run Collect button URL smoke check"
 	@echo "  test-resume    Validate resume fixtures"
 	@echo "  clean-db       Clean local databases and environment (Convex state + SQLite)"
 	@echo "  fresh-env      Wipe everything and reinstall dependencies (nuclear option)"

--- a/apps/api/src/routes/search-profiles.test.ts
+++ b/apps/api/src/routes/search-profiles.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createApp } from '../app'
+
+type ConvexCall = {
+  type: 'query' | 'mutation'
+  pathName: string
+  args: Record<string, unknown>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+  const requestUrl = typeof input === 'string'
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url
+
+  const type: ConvexCall['type'] = requestUrl.includes('/api/query') ? 'query' : 'mutation'
+  const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null
+  if (!isRecord(body)) {
+    throw new Error('Missing convex request body')
+  }
+
+  const pathName = typeof body.path === 'string' ? body.path : ''
+  const args = isRecord(body.args) ? body.args : {}
+
+  if (!pathName) {
+    throw new Error('Missing convex path in request body')
+  }
+
+  return {
+    type,
+    pathName,
+    args,
+  }
+}
+
+function convexSuccess(value: unknown): Response {
+  return new Response(
+    JSON.stringify({
+      status: 'success',
+      value,
+    }),
+    {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  )
+}
+
+function getDispatchCall(calls: ConvexCall[]): ConvexCall {
+  const dispatchCall = calls.find((call) => call.pathName === 'resume_tasks:dispatch')
+  if (!dispatchCall) {
+    throw new Error('Expected resume_tasks:dispatch call')
+  }
+  return dispatchCall
+}
+
+describe('search-profiles run route', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('dispatches concatenated profile keywords when request keyword is omitted', async () => {
+    const calls: ConvexCall[] = []
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+      calls.push(call)
+
+      if (call.pathName === 'search_profiles:getById') {
+        return convexSuccess(null)
+      }
+      if (call.pathName === 'resume_tasks:dispatch') {
+        return convexSuccess('task-concat-default')
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`)
+    })
+
+    const app = createApp()
+    const response = await app.request('/api/search-profiles/dongguan-lathe-sales/run', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Workspace-Slug': 'dev',
+      },
+      body: JSON.stringify({}),
+    })
+
+    expect(response.status).toBe(200)
+
+    const payload = await response.json()
+    expect(payload).toMatchObject({
+      success: true,
+      profileId: 'dongguan-lathe-sales',
+      taskId: 'task-concat-default',
+      dispatch: {
+        keyword: '车床销售CNC数控',
+      },
+    })
+
+    const dispatchCall = getDispatchCall(calls)
+    expect(dispatchCall.args.keyword).toBe('车床销售CNC数控')
+  })
+
+  it('uses explicit request keyword without concatenating profile defaults', async () => {
+    const calls: ConvexCall[] = []
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+      calls.push(call)
+
+      if (call.pathName === 'search_profiles:getById') {
+        return convexSuccess(null)
+      }
+      if (call.pathName === 'resume_tasks:dispatch') {
+        return convexSuccess('task-explicit-keyword')
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`)
+    })
+
+    const app = createApp()
+    const response = await app.request('/api/search-profiles/dongguan-lathe-sales/run', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Workspace-Slug': 'dev',
+      },
+      body: JSON.stringify({
+        keyword: 'CNC 车床 销售 STAR',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+
+    const payload = await response.json()
+    expect(payload).toMatchObject({
+      success: true,
+      profileId: 'dongguan-lathe-sales',
+      taskId: 'task-explicit-keyword',
+      dispatch: {
+        keyword: 'CNC 车床 销售 STAR',
+      },
+    })
+
+    const dispatchCall = getDispatchCall(calls)
+    expect(dispatchCall.args.keyword).toBe('CNC 车床 销售 STAR')
+  })
+})

--- a/dev-docs/releases/2026-03-04-extension-keyword-mode.md
+++ b/dev-docs/releases/2026-03-04-extension-keyword-mode.md
@@ -1,0 +1,38 @@
+# Release Note: Extension Keyword Mode Default Change
+
+Date: 2026-03-04
+Area: Resume Collector Browser Extension (`apps/browser-extension`)
+
+## What Changed
+
+The extension now uses `concat` keyword mode as the default behavior for auto-search.
+
+- Old default behavior: space-joined keyword terms (equivalent to `spaced`)
+- New default behavior: concatenated keyword terms with no separator (`concat`)
+
+Example:
+
+- Input keyword: `CNC 车床 销售 STAR`
+- Default search submit keyword now: `CNC车床销售STAR`
+
+## Backward-Compatible Override
+
+If legacy multi-term spacing is needed, set URL param `tr_kw_mode=spaced`.
+
+Example URL:
+
+- `https://hr.job5156.com/search?keyword=CNC%20车床%20销售%20STAR&tr_kw_mode=spaced`
+
+This keeps submitted keyword as:
+
+- `CNC 车床 销售 STAR`
+
+## User Impact
+
+- Most users do not need to change anything.
+- Users can switch system default in extension Options (`关键词模式`), or force mode per URL with `tr_kw_mode`.
+
+## Operational Notes
+
+- No migration is required.
+- After upgrading extension files, reload the extension in Chrome before testing.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "check:lint": "bun run --filter '@trends/web' --filter '@trends/browser-extension' lint",
     "check:build": "bun run --filter '@trends/*' build",
     "test": "vitest run",
+    "test:extension:keyword-mode": "tsx scripts/test-extension-keyword-mode.ts",
+    "test:api:search-profiles": "vitest run apps/api/src/routes/search-profiles.test.ts",
+    "test:worker:resume-tasks": "uv run pytest tests/test_resume_tasks.py -q",
+    "test:e2e:collect-url": "tsx scripts/e2e-smoke.ts --collect-only",
     "verify:critical-path": "tsx scripts/verify-critical-path.ts",
     "e2e": "tsx scripts/e2e-smoke.ts"
   },

--- a/scripts/e2e-smoke.ts
+++ b/scripts/e2e-smoke.ts
@@ -1,6 +1,42 @@
 import { connectToChrome, waitForToast, DEFAULT_OPTIONS } from './e2e-utils';
 import { Page, expect } from '@playwright/test';
 
+async function runCollectUrlKeywordModeTest(page: Page) {
+    console.log('Testing Quick Start Collect URL keyword concat mode...');
+    await page.goto(
+        `${DEFAULT_OPTIONS.baseUrl}/dev/resumes?location=${encodeURIComponent('东莞')}&keyword=${encodeURIComponent('CNC 车床 销售 STAR')}`
+    );
+
+    await page.evaluate(() => {
+        const scope = window as unknown as { __openedUrls?: string[] };
+        scope.__openedUrls = [];
+        window.open = ((url?: string | URL) => {
+            if (typeof url === 'string') {
+                scope.__openedUrls?.push(url);
+            } else if (url) {
+                scope.__openedUrls?.push(String(url));
+            }
+            return null;
+        }) as typeof window.open;
+    });
+
+    await page.getByRole('button', { name: /采集|Collect/i }).click();
+
+    const openedUrls = await page.evaluate(() => {
+        const scope = window as unknown as { __openedUrls?: string[] };
+        return Array.isArray(scope.__openedUrls) ? scope.__openedUrls : [];
+    });
+
+    expect(openedUrls.length).toBeGreaterThan(0);
+    const openedUrl = new URL(openedUrls[0]);
+    expect(`${openedUrl.origin}${openedUrl.pathname}`).toBe('https://hr.job5156.com/search');
+    expect(openedUrl.searchParams.get('keyword')).toBe('CNC车床销售STAR');
+    expect(openedUrl.searchParams.get('location')).toBe('东莞');
+    expect(openedUrl.searchParams.get('tr_auto_sync')).toBe('true');
+
+    console.log('✅ Collect URL keyword concat test passed.');
+}
+
 async function runCollectionTest(page: Page) {
     console.log('Testing Critical Path 1: Resume Collection...');
     await page.goto(`${DEFAULT_OPTIONS.baseUrl}/system/settings`);
@@ -125,9 +161,15 @@ async function runErrorStateTest(page: Page) {
 }
 
 async function main() {
+    const collectOnly = process.argv.includes('--collect-only');
     const { browser, page } = await connectToChrome();
 
     try {
+        await runCollectUrlKeywordModeTest(page);
+        if (collectOnly) {
+            console.log('\n🌟 Collect URL smoke test passed!');
+            return;
+        }
         await runCollectionTest(page);
         await runSearchTest(page);
         await runAnalysisTest(page);

--- a/scripts/fixtures/extension-keyword-mode-harness.html
+++ b/scripts/fixtures/extension-keyword-mode-harness.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Extension Keyword Mode Harness</title>
+  </head>
+  <body>
+    <div class="el-checkbox-group resume-search-item-list-content-block"></div>
+
+    <div class="el-autocomplete">
+      <input class="el-input__inner" type="text" />
+    </div>
+    <button class="resume-search-item-search-input-block__input-button" type="button">Search</button>
+
+    <script>
+      (() => {
+        const params = new URLSearchParams(window.location.search || '');
+        const storageMode = params.get('mock_storage_mode');
+
+        /** @type {{ keywordMode?: string }} */
+        const store = {};
+        if (storageMode) {
+          store.keywordMode = storageMode;
+        }
+
+        window.__searchClicks = 0;
+        const btn = document.querySelector('.resume-search-item-search-input-block__input-button');
+        if (btn) {
+          btn.addEventListener('click', () => {
+            window.__searchClicks += 1;
+          });
+        }
+
+        window.chrome = {
+          storage: {
+            local: {
+              get(defaults, callback) {
+                callback({ ...defaults, ...store });
+              },
+              set(items, callback) {
+                Object.assign(store, items || {});
+                if (typeof callback === 'function') callback();
+              },
+            },
+          },
+          runtime: {
+            getManifest() {
+              return { version: 'test-harness' };
+            },
+            getURL(path) {
+              return String(path || '');
+            },
+            onMessage: {
+              addListener() {
+                // no-op
+              },
+            },
+            sendMessage(_request, callback) {
+              if (typeof callback === 'function') {
+                callback({ success: true });
+              }
+            },
+            lastError: null,
+          },
+          downloads: {
+            download(_options, callback) {
+              if (typeof callback === 'function') {
+                callback(1);
+              }
+            },
+          },
+        };
+      })();
+    </script>
+  </body>
+</html>

--- a/scripts/test-extension-keyword-mode.ts
+++ b/scripts/test-extension-keyword-mode.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { chromium } from 'playwright'
+
+type Scenario = {
+  name: string
+  query: Record<string, string | undefined>
+  expectedKeyword: string
+}
+
+type ScenarioResult = {
+  inputValue: string
+  status: string | null
+  attrKeyword: string | null
+  clicks: number
+}
+
+const KEYWORD = 'CNC 车床 销售 STAR'
+
+const scenarios: Scenario[] = [
+  {
+    name: 'storage concat strips spaces',
+    query: {
+      keyword: KEYWORD,
+      mock_storage_mode: 'concat',
+    },
+    expectedKeyword: 'CNC车床销售STAR',
+  },
+  {
+    name: 'url spaced overrides storage concat',
+    query: {
+      keyword: KEYWORD,
+      tr_kw_mode: 'spaced',
+      mock_storage_mode: 'concat',
+    },
+    expectedKeyword: 'CNC 车床 销售 STAR',
+  },
+  {
+    name: 'url concat overrides storage spaced',
+    query: {
+      keyword: KEYWORD,
+      tr_kw_mode: 'concat',
+      mock_storage_mode: 'spaced',
+    },
+    expectedKeyword: 'CNC车床销售STAR',
+  },
+  {
+    name: 'storage spaced preserves spaces when url mode is absent',
+    query: {
+      keyword: KEYWORD,
+      mock_storage_mode: 'spaced',
+    },
+    expectedKeyword: 'CNC 车床 销售 STAR',
+  },
+  {
+    name: 'default mode is concat when no url mode and no storage mode',
+    query: {
+      keyword: KEYWORD,
+    },
+    expectedKeyword: 'CNC车床销售STAR',
+  },
+]
+
+function resolveRepoRoot(): string {
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+  return path.resolve(scriptDir, '..')
+}
+
+function buildHarnessUrl(harnessPath: string, query: Record<string, string | undefined>): string {
+  const url = new URL(pathToFileURL(harnessPath).toString())
+  for (const [key, value] of Object.entries(query)) {
+    if (typeof value === 'string' && value.length > 0) {
+      url.searchParams.set(key, value)
+    }
+  }
+  return url.toString()
+}
+
+async function runScenario(contentScriptPath: string, harnessPath: string, scenario: Scenario): Promise<void> {
+  const browser = await chromium.launch({ headless: true })
+  try {
+    const page = await browser.newPage()
+    const harnessUrl = buildHarnessUrl(harnessPath, scenario.query)
+
+    await page.goto(harnessUrl, { waitUntil: 'domcontentloaded' })
+    await page.addScriptTag({ path: contentScriptPath })
+
+    await page.waitForFunction(
+      () => document.documentElement.getAttribute('data-tr-auto-search') === 'done',
+      { timeout: 10_000 },
+    )
+
+    const result = await page.evaluate<ScenarioResult>(() => {
+      const input = document.querySelector('.el-autocomplete input.el-input__inner')
+      const inputValue = input instanceof HTMLInputElement ? input.value : ''
+      const status = document.documentElement.getAttribute('data-tr-auto-search')
+      const attrKeyword = document.documentElement.getAttribute('data-tr-search-keyword')
+      const raw = window as unknown as { __searchClicks?: number }
+      const clicks = typeof raw.__searchClicks === 'number' ? raw.__searchClicks : 0
+
+      return {
+        inputValue,
+        status,
+        attrKeyword,
+        clicks,
+      }
+    })
+
+    assert.equal(result.status, 'done', `${scenario.name}: expected data-tr-auto-search=done`)
+    assert.equal(result.clicks, 1, `${scenario.name}: expected one search click`)
+    assert.equal(result.inputValue, scenario.expectedKeyword, `${scenario.name}: unexpected input value`)
+    assert.equal(result.attrKeyword, scenario.expectedKeyword, `${scenario.name}: unexpected data-tr-search-keyword`)
+
+    console.log(`PASS ${scenario.name}`)
+  } finally {
+    await browser.close()
+  }
+}
+
+async function main(): Promise<void> {
+  const repoRoot = resolveRepoRoot()
+  const contentScriptPath = path.join(repoRoot, 'apps', 'browser-extension', 'content.js')
+  const harnessPath = path.join(repoRoot, 'scripts', 'fixtures', 'extension-keyword-mode-harness.html')
+
+  for (const scenario of scenarios) {
+    await runScenario(contentScriptPath, harnessPath, scenario)
+  }
+
+  console.log('All keyword mode scenarios passed.')
+}
+
+main().catch((error: unknown) => {
+  console.error('Extension keyword mode regression test failed.')
+  console.error(error)
+  process.exit(1)
+})

--- a/tests/test_resume_tasks.py
+++ b/tests/test_resume_tasks.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+from apps.worker import resume_tasks
+
+
+def _make_profile(keywords: Any) -> dict[str, Any]:
+    return {
+        "id": "profile-1",
+        "location": "东莞",
+        "keywords": keywords,
+        "schedule": {"maxCandidates": 120},
+    }
+
+
+def test_run_resume_crawl_task_concatenates_keyword_list(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(resume_tasks, "_resolve_convex_url", lambda: "http://127.0.0.1:3210")
+
+    def fake_mutation(convex_url: str, mutation_path: str, args: dict[str, Any]) -> str:
+        captured["convex_url"] = convex_url
+        captured["mutation_path"] = mutation_path
+        captured["args"] = args
+        return "task-001"
+
+    monkeypatch.setattr(resume_tasks, "_convex_mutation", fake_mutation)
+
+    ok = resume_tasks.run_resume_crawl_task(
+        _make_profile(["CNC", "车床", "销售", "STAR"])
+    )
+
+    assert ok is True
+    assert captured["convex_url"] == "http://127.0.0.1:3210"
+    assert captured["mutation_path"] == "resume_tasks:dispatch"
+    assert captured["args"]["keyword"] == "CNC车床销售STAR"
+    assert captured["args"]["location"] == "东莞"
+    assert captured["args"]["limit"] == 120
+
+
+def test_run_resume_crawl_task_trims_and_skips_empty_keyword_items(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(resume_tasks, "_resolve_convex_url", lambda: "http://127.0.0.1:3210")
+
+    def fake_mutation(_convex_url: str, _mutation_path: str, args: dict[str, Any]) -> str:
+        captured["args"] = args
+        return "task-002"
+
+    monkeypatch.setattr(resume_tasks, "_convex_mutation", fake_mutation)
+
+    ok = resume_tasks.run_resume_crawl_task(
+        _make_profile(["  CNC  ", "", "   ", "车床", "  销售  "])
+    )
+
+    assert ok is True
+    assert captured["args"]["keyword"] == "CNC车床销售"
+
+
+def test_run_resume_crawl_task_keeps_non_list_keyword_string(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(resume_tasks, "_resolve_convex_url", lambda: "http://127.0.0.1:3210")
+
+    def fake_mutation(_convex_url: str, _mutation_path: str, args: dict[str, Any]) -> str:
+        captured["args"] = args
+        return "task-003"
+
+    monkeypatch.setattr(resume_tasks, "_convex_mutation", fake_mutation)
+
+    ok = resume_tasks.run_resume_crawl_task(_make_profile("CNC 车床"))
+
+    assert ok is True
+    assert captured["args"]["keyword"] == "CNC 车床"
+
+
+def test_run_resume_crawl_task_returns_false_for_empty_keyword(monkeypatch) -> None:
+    called = {"mutation": False}
+
+    monkeypatch.setattr(resume_tasks, "_resolve_convex_url", lambda: "http://127.0.0.1:3210")
+
+    def fake_mutation(_convex_url: str, _mutation_path: str, _args: dict[str, Any]) -> str:
+        called["mutation"] = True
+        return "task-unexpected"
+
+    monkeypatch.setattr(resume_tasks, "_convex_mutation", fake_mutation)
+
+    ok = resume_tasks.run_resume_crawl_task(_make_profile(["", "   "]))
+
+    assert ok is False
+    assert called["mutation"] is False


### PR DESCRIPTION
## Summary
- add extension keyword mode regression harness + script to verify precedence ( > storage > default)
- add API route tests for  keyword dispatch (default concat + explicit override)
- add worker tests for  keyword assembly behavior
- add Collect button URL smoke check in  with 
- add extension user release note for concat default and  override
- wire new scripts and Makefile targets for these checks

## Test Evidence
- 
 RUN  v1.6.1 /Users/karlchow/Desktop/code/trends

stdout | apps/api/src/routes/search-profiles.test.ts > search-profiles run route > dispatches concatenated profile keywords when request keyword is omitted
<-- POST /api/search-profiles/dongguan-lathe-sales/run
--> POST /api/search-profiles/dongguan-lathe-sales/run 200 9ms

 ✓ apps/api/src/routes/search-profiles.test.ts  (2 tests) 16ms
stdout | apps/api/src/routes/search-profiles.test.ts > search-profiles run route > uses explicit request keyword without concatenating profile defaults
<-- POST /api/search-profiles/dongguan-lathe-sales/run
--> POST /api/search-profiles/dongguan-lathe-sales/run 200 1ms


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  15:05:16
   Duration  702ms (transform 193ms, setup 0ms, collect 482ms, tests 16ms, environment 0ms, prepare 47ms)
- ....                                                                     [100%]
4 passed in 0.01s
- PASS storage concat strips spaces
PASS url spaced overrides storage concat
PASS url concat overrides storage spaced
PASS storage spaced preserves spaces when url mode is absent
PASS default mode is concat when no url mode and no storage mode
All keyword mode scenarios passed.
- Testing Quick Start Collect URL keyword concat mode...
✅ Collect URL keyword concat test passed.

🌟 Collect URL smoke test passed!
- @trends/shared typecheck: Exited with code 0
@trends/browser-extension typecheck: Exited with code 0
@trends/convex typecheck: Exited with code 0
@trends/web typecheck: Exited with code 0
@trends/api typecheck: Exited with code 0
- Running API search-profiles route test...

 RUN  v1.6.1 /Users/karlchow/Desktop/code/trends

stdout | apps/api/src/routes/search-profiles.test.ts > search-profiles run route > dispatches concatenated profile keywords when request keyword is omitted
<-- POST /api/search-profiles/dongguan-lathe-sales/run
--> POST /api/search-profiles/dongguan-lathe-sales/run 200 8ms

 ✓ apps/api/src/routes/search-profiles.test.ts  (2 tests) 15ms
stdout | apps/api/src/routes/search-profiles.test.ts > search-profiles run route > uses explicit request keyword without concatenating profile defaults
<-- POST /api/search-profiles/dongguan-lathe-sales/run
--> POST /api/search-profiles/dongguan-lathe-sales/run 200 1ms


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  15:05:26
   Duration  646ms (transform 175ms, setup 0ms, collect 441ms, tests 15ms, environment 0ms, prepare 36ms)
- Running worker resume task tests...
....                                                                     [100%]
4 passed in 0.01s
- Running extension keyword mode regression...
PASS storage concat strips spaces
PASS url spaced overrides storage concat
PASS url concat overrides storage spaced
PASS storage spaced preserves spaces when url mode is absent
PASS default mode is concat when no url mode and no storage mode
All keyword mode scenarios passed.
- Running Collect URL smoke check...
Testing Quick Start Collect URL keyword concat mode...
✅ Collect URL keyword concat test passed.

🌟 Collect URL smoke test passed!
