### PR TITLE
feat: add tagging envelope confidence/provenance plumbing

### DIFF
--- a/apps/api/src/services/ingest-compute-service.test.ts
+++ b/apps/api/src/services/ingest-compute-service.test.ts
@@ -308,9 +308,15 @@ describe("IngestComputeService", () => {
     const industryTag = result.tagEnvelope.find((item) => item.tag === "industry:cnc");
     const roleTag = result.tagEnvelope.find((item) => item.tag === "role:sales");
     const companyTag = result.tagEnvelope.find((item) => item.tag === "company:star");
+    const taggingIndustryTag = result.taggingEnvelope.entries.find((item) => item.tag === "industry:cnc");
+    const taggingRoleTag = result.taggingEnvelope.entries.find((item) => item.tag === "role:sales");
+    const taggingCompanyTag = result.taggingEnvelope.entries.find((item) => item.tag === "company:star");
 
     expect(Array.isArray(result.tagEnvelope)).toBe(true);
     expect(result.tagEnvelope.length).toBeGreaterThan(0);
+    expect(result.taggingEnvelope.schemaVersion).toBe(1);
+    expect(result.taggingEnvelope.generatedAt).toBeGreaterThan(0);
+    expect(result.taggingEnvelope.entries.length).toBe(result.tagEnvelope.length);
 
     expect(industryTag).toBeDefined();
     expect(industryTag?.source).toBe("rule");
@@ -323,6 +329,11 @@ describe("IngestComputeService", () => {
 
     expect(companyTag).toBeDefined();
     expect(companyTag?.evidence.some((entry) => entry.startsWith("brandSource:"))).toBe(true);
+
+    expect(taggingIndustryTag?.provenance.stage).toBe("industry_taxonomy");
+    expect(taggingIndustryTag?.provenance.generatedBy).toBe("ingest-compute-service");
+    expect(taggingRoleTag?.provenance.stage).toBe("role_signal_aggregation");
+    expect(taggingCompanyTag?.provenance.stage).toBe("company_pattern_match");
   });
 
   it("should classify selfIntro brand mentions as equipment context", () => {

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -27,6 +27,7 @@ export interface IngestResult {
   companyHits: string[];
   roleSignals: RoleSignalSummary[];
   tagEnvelope: TagEnvelopeEntry[];
+  taggingEnvelope: TaggingEnvelope;
   companyAliasTokens: string;
   ruleScores: Record<string, number>;  // jdId → score (0-100)
   primaryRuleScore: number;
@@ -43,6 +44,32 @@ export interface TagEnvelopeEntry {
   confidence: number;
   evidence: string[];
   version: number;
+}
+
+export type TaggingProvenanceStage =
+  | "industry_taxonomy"
+  | "synonym_expansion"
+  | "company_pattern_match"
+  | "role_signal_aggregation"
+  | "experience_signal_detection"
+  | "derived";
+
+export interface TaggingEnvelopeEntry {
+  tag: string;
+  source: TagEnvelopeSource;
+  confidence: number;
+  version: number;
+  provenance: {
+    stage: TaggingProvenanceStage;
+    generatedBy: "ingest-compute-service";
+    evidence: string[];
+  };
+}
+
+export interface TaggingEnvelope {
+  schemaVersion: number;
+  generatedAt: number;
+  entries: TaggingEnvelopeEntry[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -226,6 +253,25 @@ function createSearchText(item: ResumeItem): string {
   return normalizeText(parts.join(" "));
 }
 
+function inferTaggingStage(tag: string): TaggingProvenanceStage {
+  if (tag.startsWith("industry:")) {
+    return "industry_taxonomy";
+  }
+  if (tag.startsWith("synonym:")) {
+    return "synonym_expansion";
+  }
+  if (tag.startsWith("company:")) {
+    return "company_pattern_match";
+  }
+  if (tag.startsWith("role:")) {
+    return "role_signal_aggregation";
+  }
+  if (tag.startsWith("experience:")) {
+    return "experience_signal_detection";
+  }
+  return "derived";
+}
+
 const BRAND_CONTEXT_WINDOW = 30;
 const EQUIPMENT_SIGNALS = ["操作", "使用", "熟练", "熟悉", "机台", "机型", "设备", "机床"];
 const SALES_SIGNALS = ["销售", "代理", "渠道", "推广", "业务", "客户"];
@@ -280,6 +326,7 @@ export class IngestComputeService {
     const item = extractResumeItem(content);
     const index = buildResumeIndex(item, 0);
     const searchText = index.searchText.toLowerCase();
+    const computedAt = Date.now();
 
     // 1. Compute industryTags
     const industryTags = this.computeIndustryTags(searchText);
@@ -312,6 +359,7 @@ export class IngestComputeService {
       experienceLevel,
       skillsVersion,
     );
+    const taggingEnvelope = this.buildTaggingEnvelope(tagEnvelope, computedAt);
 
     return {
       resumeId,
@@ -321,11 +369,12 @@ export class IngestComputeService {
       companyHits,
       roleSignals,
       tagEnvelope,
+      taggingEnvelope,
       companyAliasTokens,
       ruleScores,
       primaryRuleScore,
       experienceLevel,
-      computedAt: Date.now(),
+      computedAt,
       skillsVersion,
     };
   }
@@ -616,6 +665,32 @@ export class IngestComputeService {
         return left.tag.localeCompare(right.tag);
       })
       .slice(0, 120);
+  }
+
+  private buildTaggingEnvelope(
+    tagEnvelope: TagEnvelopeEntry[],
+    generatedAt: number,
+  ): TaggingEnvelope {
+    const entries = tagEnvelope.map((entry) => {
+      const evidence = Array.from(new Set(entry.evidence.map((item) => item.trim()).filter((item) => item.length > 0)));
+      return {
+        tag: entry.tag,
+        source: entry.source,
+        confidence: entry.confidence,
+        version: entry.version,
+        provenance: {
+          stage: inferTaggingStage(entry.tag),
+          generatedBy: "ingest-compute-service" as const,
+          evidence: evidence.length > 0 ? evidence : [`tag:${entry.tag}`],
+        },
+      };
+    });
+
+    return {
+      schemaVersion: 1,
+      generatedAt,
+      entries,
+    };
   }
 
   /**

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -39,6 +39,21 @@ export type ConvexIngestData = {
     evidence: string[]
     version: number
   }>
+  taggingEnvelope?: {
+    schemaVersion: number
+    generatedAt: number
+    entries: Array<{
+      tag: string
+      source: string
+      confidence: number
+      version: number
+      provenance: {
+        stage: string
+        generatedBy: string
+        evidence: string[]
+      }
+    }>
+  }
   ruleScores: Record<string, number>
   experienceLevel: string
   computedAt: number
@@ -272,6 +287,104 @@ function parseTagEnvelope(value: unknown): ConvexIngestData['tagEnvelope'] {
   return parsed.length > 0 ? parsed : undefined
 }
 
+function inferTaggingStage(tag: string): string {
+  if (tag.startsWith('industry:')) {
+    return 'industry_taxonomy'
+  }
+  if (tag.startsWith('synonym:')) {
+    return 'synonym_expansion'
+  }
+  if (tag.startsWith('company:')) {
+    return 'company_pattern_match'
+  }
+  if (tag.startsWith('role:')) {
+    return 'role_signal_aggregation'
+  }
+  if (tag.startsWith('experience:')) {
+    return 'experience_signal_detection'
+  }
+  return 'derived'
+}
+
+function parseTaggingEnvelope(value: unknown): ConvexIngestData['taggingEnvelope'] {
+  if (!isRecord(value)) {
+    return undefined
+  }
+
+  const schemaVersion = toNumber(value.schemaVersion)
+  const generatedAt = toNumber(value.generatedAt)
+  if (schemaVersion === null || generatedAt === null || !Array.isArray(value.entries)) {
+    return undefined
+  }
+
+  const entries = value.entries
+    .map((item) => {
+      if (!isRecord(item)) {
+        return null
+      }
+
+      const tag = toStringValue(item.tag).trim().toLowerCase()
+      const source = toStringValue(item.source).trim().toLowerCase()
+      const confidence = toNumber(item.confidence)
+      const version = toNumber(item.version)
+      const provenance = isRecord(item.provenance) ? item.provenance : null
+      const stage = provenance ? toStringValue(provenance.stage).trim().toLowerCase() : ''
+      const generatedBy = provenance ? toStringValue(provenance.generatedBy).trim() : ''
+
+      if (!tag || !source || confidence === null || version === null || !stage || !generatedBy) {
+        return null
+      }
+
+      return {
+        tag,
+        source,
+        confidence,
+        version,
+        provenance: {
+          stage,
+          generatedBy,
+          evidence: provenance ? toStringArray(provenance.evidence) : [],
+        },
+      }
+    })
+    .filter((item): item is NonNullable<typeof item> => item !== null)
+
+  if (entries.length === 0) {
+    return undefined
+  }
+
+  return {
+    schemaVersion,
+    generatedAt,
+    entries,
+  }
+}
+
+function parseLegacyTaggingEnvelope(
+  tagEnvelope: ConvexIngestData['tagEnvelope'],
+  generatedAt: number
+): ConvexIngestData['taggingEnvelope'] {
+  if (!tagEnvelope || tagEnvelope.length === 0) {
+    return undefined
+  }
+
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    entries: tagEnvelope.map((entry) => ({
+      tag: entry.tag,
+      source: entry.source,
+      confidence: entry.confidence,
+      version: entry.version,
+      provenance: {
+        stage: inferTaggingStage(entry.tag),
+        generatedBy: 'legacy-tag-envelope-bridge',
+        evidence: entry.evidence,
+      },
+    })),
+  }
+}
+
 function parseAnalysesMap(value: unknown): Record<string, ConvexResumeAnalysis> | undefined {
   if (!isRecord(value)) {
     return undefined
@@ -298,6 +411,10 @@ function parseIngestData(value: unknown): ConvexIngestData | undefined {
   if (computedAt === null || skillsVersion === null) {
     return undefined
   }
+
+  const tagEnvelope = parseTagEnvelope(value.tagEnvelope)
+  const taggingEnvelope = parseTaggingEnvelope(value.taggingEnvelope)
+    ?? parseLegacyTaggingEnvelope(tagEnvelope, computedAt)
 
   return {
     industryTags: toStringArray(value.industryTags),
@@ -326,7 +443,8 @@ function parseIngestData(value: unknown): ConvexIngestData | undefined {
           })
           .filter((item): item is NonNullable<typeof item> => item !== null)
       : undefined,
-    tagEnvelope: parseTagEnvelope(value.tagEnvelope),
+    tagEnvelope,
+    taggingEnvelope,
     ruleScores: parseRuleScores(value.ruleScores),
     experienceLevel: toStringValue(value.experienceLevel) || 'unknown',
     computedAt,

--- a/apps/web/src/pages/DebugIngest.tsx
+++ b/apps/web/src/pages/DebugIngest.tsx
@@ -51,6 +51,20 @@ function toBrandLabel(value: string): string {
   return value.toUpperCase()
 }
 
+function formatTaggingEntry(entry: {
+  tag: string
+  source: string
+  confidence: number
+  provenance: {
+    stage: string
+    evidence: string[]
+  }
+}): string {
+  const evidence = entry.provenance.evidence.slice(0, 2).join(' | ')
+  const evidenceSuffix = evidence ? `; ${evidence}` : ''
+  return `${entry.tag} (${entry.source}, ${entry.confidence}, ${entry.provenance.stage}${evidenceSuffix})`
+}
+
 export default function DebugIngest() {
   const { t } = useTranslation()
   const { resumes, loading } = useConvexResumes(500)
@@ -414,6 +428,15 @@ export default function DebugIngest() {
                               <div>
                                 <span className="font-medium">{t('debugIngest.ruleScoreCount', { defaultValue: 'Rule Scores' })}:</span>{' '}
                                 {Object.keys(ingestData.ruleScores || {}).length}
+                              </div>
+                              <div className="md:col-span-2">
+                                <span className="font-medium">{t('debugIngest.taggingEnvelope', { defaultValue: 'Tagging Envelope' })}:</span>{' '}
+                                {ingestData.taggingEnvelope?.entries?.length
+                                  ? ingestData.taggingEnvelope.entries
+                                    .slice(0, 8)
+                                    .map((entry) => formatTaggingEntry(entry))
+                                    .join('; ')
+                                  : '--'}
                               </div>
                             </div>
                           ) : (

--- a/apps/web/src/types/resume.ts
+++ b/apps/web/src/types/resume.ts
@@ -29,6 +29,32 @@ export type TagEnvelopeEntry = {
   version: number
 }
 
+export type TaggingProvenanceStage =
+  | 'industry_taxonomy'
+  | 'synonym_expansion'
+  | 'company_pattern_match'
+  | 'role_signal_aggregation'
+  | 'experience_signal_detection'
+  | 'derived'
+
+export type TaggingEnvelopeEntry = {
+  tag: string
+  source: TagEnvelopeSource
+  confidence: number
+  version: number
+  provenance: {
+    stage: TaggingProvenanceStage
+    generatedBy: string
+    evidence: string[]
+  }
+}
+
+export type TaggingEnvelope = {
+  schemaVersion: number
+  generatedAt: number
+  entries: TaggingEnvelopeEntry[]
+}
+
 export type Recommendation = 'strong_match' | 'match' | 'potential' | 'no_match'
 export type ScoreSource = 'rule' | 'ai'
 export type CandidateStatus =

--- a/packages/convex/convex/ingest_agent.ts
+++ b/packages/convex/convex/ingest_agent.ts
@@ -95,6 +95,7 @@ export const processNewResumes = internalAction({
           companyHits: item.companyHits || [],
           roleSignals: item.roleSignals || [],
           tagEnvelope: item.tagEnvelope || [],
+          taggingEnvelope: item.taggingEnvelope || undefined,
           ruleScores: item.ruleScores,
           experienceLevel: item.experienceLevel,
           computedAt: item.computedAt,

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -284,6 +284,21 @@ export const updateIngestData = internalMutation({
                 evidence: v.array(v.string()),
                 version: v.number(),
             }))),
+            taggingEnvelope: v.optional(v.object({
+                schemaVersion: v.number(),
+                generatedAt: v.number(),
+                entries: v.array(v.object({
+                    tag: v.string(),
+                    source: v.string(),
+                    confidence: v.number(),
+                    version: v.number(),
+                    provenance: v.object({
+                        stage: v.string(),
+                        generatedBy: v.string(),
+                        evidence: v.array(v.string()),
+                    }),
+                })),
+            })),
             ruleScores: v.any(),
             experienceLevel: v.string(),
             computedAt: v.number(),
@@ -351,6 +366,21 @@ export const updateIngestDataBatch = internalMutation({
                     evidence: v.array(v.string()),
                     version: v.number(),
                 }))),
+                taggingEnvelope: v.optional(v.object({
+                    schemaVersion: v.number(),
+                    generatedAt: v.number(),
+                    entries: v.array(v.object({
+                        tag: v.string(),
+                        source: v.string(),
+                        confidence: v.number(),
+                        version: v.number(),
+                        provenance: v.object({
+                            stage: v.string(),
+                            generatedBy: v.string(),
+                            evidence: v.array(v.string()),
+                        }),
+                    })),
+                })),
                 ruleScores: v.any(),
                 experienceLevel: v.string(),
                 computedAt: v.number(),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -118,6 +118,21 @@ export default defineSchema({
                 evidence: v.array(v.string()),
                 version: v.number(),
             }))),
+            taggingEnvelope: v.optional(v.object({
+                schemaVersion: v.number(),
+                generatedAt: v.number(),
+                entries: v.array(v.object({
+                    tag: v.string(),
+                    source: v.string(),
+                    confidence: v.number(),
+                    version: v.number(),
+                    provenance: v.object({
+                        stage: v.string(),
+                        generatedBy: v.string(),
+                        evidence: v.array(v.string()),
+                    }),
+                })),
+            })),
             ruleScores: v.any(),          // Record<string, number> — JD ID → score
             experienceLevel: v.string(),  // "senior" | "mid" | "junior" | "unknown"
             computedAt: v.number(),


### PR DESCRIPTION
## Summary
- add additive `taggingEnvelope` contract in ingest compute output
- keep existing `tagEnvelope` for backward compatibility
- persist `taggingEnvelope` through Convex ingest validators/schema and ingest agent bridge
- parse `taggingEnvelope` in web resume hook with legacy fallback bridge from `tagEnvelope`
- surface tagging envelope details in System -> Ingest Debug expanded rows
- extend ingest compute tests for provenance stage assertions

## Why
Implements Phase B foundation from #125: tagging envelope with confidence and provenance, while preserving existing filter/ranking behavior.

## Validation
- `make check-node`
- `npm test`
- `npx vitest run apps/api/src/services/ingest-compute-service.test.ts`
- live API check:
  - `POST /api/resumes/ingest-compute` returns both `tagEnvelope` and `taggingEnvelope.entries`

Closes #125
