### PR TITLE
feat: add migration action to re-ingest all resumes

### DIFF
--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -221,6 +221,11 @@ type ReIngestStaleSkillsVersionResult = {
     hasMore: boolean;
 };
 
+type ReIngestAllResumesResult = {
+    scheduled: number;
+    batches: number;
+};
+
 export const backfillSearchText = mutation({
     args: {},
     handler: async (ctx) => {
@@ -424,6 +429,13 @@ export const reIngestStaleSkillsVersion = action({
         return await ctx.runAction(internal.ingest_agent.reIngestStaleResumes, {
             limit: args.limit,
         });
+    },
+});
+
+export const reIngestAllResumes = action({
+    args: {},
+    handler: async (ctx): Promise<ReIngestAllResumesResult> => {
+        return await ctx.runAction(internal.ingest_agent.reIngestAllResumes, {});
     },
 });
 


### PR DESCRIPTION
## Summary
- add `migrations:reIngestAllResumes` action that calls `internal.ingest_agent.reIngestAllResumes`
- provides explicit rollout/backfill path for additive ingest fields (e.g. `taggingEnvelope`) on existing resumes

## Validation
- `make check-node`
- `npm test`

## Usage
```bash
npx convex run migrations:reIngestAllResumes
```
