### PR TITLE
test(web): add role-aware quick filter regressions

### DIFF
--- a/apps/web/e2e/resume-role-filter.spec.ts
+++ b/apps/web/e2e/resume-role-filter.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test'
+
+function countNonEngineerCards(roleTypes: Array<string | null>): number {
+  return roleTypes.filter((value) => {
+    if (!value) {
+      return true
+    }
+
+    const types = value
+      .split(',')
+      .map((item) => item.trim().toLowerCase())
+      .filter((item) => item.length > 0)
+
+    return !types.includes('engineer')
+  }).length
+}
+
+test.describe('Resume quick role filter', () => {
+  test('engineer role filter keeps only engineer-tagged resumes', async ({ page }) => {
+    await page.goto('/dev/resumes?location=%E5%B9%BF%E4%B8%9C&jd=senior-mechanical-engineer')
+
+    await expect(page.getByText('工程经验')).toBeVisible()
+
+    const cards = page.getByTestId('resume-card')
+    const nonEngineerBefore = countNonEngineerCards(await cards.evaluateAll((nodes) =>
+      nodes.map((node) => node.getAttribute('data-role-types'))
+    ))
+
+    await page.getByRole('spinbutton', { name: '要求工程经验 最少 年' }).fill('1')
+    await page.getByRole('button', { name: '应用快速筛选' }).click()
+
+    await expect.poll(async () => {
+      const roleTypes = await cards.evaluateAll((nodes) =>
+        nodes.map((node) => node.getAttribute('data-role-types'))
+      )
+      return countNonEngineerCards(roleTypes)
+    }).toBe(0)
+
+    const nonEngineerAfter = countNonEngineerCards(await cards.evaluateAll((nodes) =>
+      nodes.map((node) => node.getAttribute('data-role-types'))
+    ))
+
+    expect(nonEngineerAfter).toBe(0)
+    expect(nonEngineerAfter).toBeLessThanOrEqual(nonEngineerBefore)
+  })
+})
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e:blacklist": "npm --prefix ../.. --workspace @trends/shared run build && playwright test -c playwright.config.ts e2e/blacklist.spec.ts",
+    "test:e2e:resume-role-filter": "npm --prefix ../.. --workspace @trends/shared run build && playwright test -c playwright.config.ts e2e/resume-role-filter.spec.ts",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { QuickStartPanel } from './QuickStartPanel'
+
+const { getMock, postMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+  postMock: vi.fn(),
+}))
+
+vi.mock('./JobDescriptionSelect', () => ({
+  JobDescriptionSelect: ({
+    value,
+    onChange,
+  }: {
+    value: string
+    onChange?: (value: string) => void
+  }) => (
+    <select
+      data-testid="job-description-select"
+      value={value}
+      onChange={(event) => onChange?.(event.target.value)}
+    >
+      <option value="">Select job description</option>
+      <option value="lathe-sales">车床销售工程师</option>
+      <option value="senior-mechanical-engineer">高级机械工程师</option>
+    </select>
+  ),
+}))
+
+vi.mock('./KeywordChips', () => ({
+  KeywordChips: () => <div data-testid="keyword-chips" />,
+}))
+
+vi.mock('@/contexts/WorkspaceContext', () => ({
+  useWorkspace: () => ({ slug: 'dev' }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: {
+    GET: (...args: unknown[]) => getMock(...args),
+    POST: (...args: unknown[]) => postMock(...args),
+  },
+}))
+
+describe('QuickStartPanel role-aware quick filter label', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    postMock.mockResolvedValue({ data: { success: false } })
+    getMock.mockImplementation(async (path: string) => {
+      if (path.includes('/api/job-descriptions/lathe-sales')) {
+        return {
+          data: {
+            success: true,
+            item: {
+              requiredRoles: [{ type: 'sales' }],
+            },
+          },
+        }
+      }
+
+      if (path.includes('/api/job-descriptions/senior-mechanical-engineer')) {
+        return {
+          data: {
+            success: true,
+            item: {
+              requiredRoles: [{ type: 'engineer' }],
+            },
+          },
+        }
+      }
+
+      return {
+        data: {
+          success: true,
+          item: {
+            requiredRoles: [],
+          },
+        },
+      }
+    })
+  })
+
+  it('switches quick filter label between sales, engineer, and fallback', async () => {
+    const { rerender } = render(
+      <QuickStartPanel
+        defaultLocation="广东"
+        defaultKeywords={[]}
+        jobDescriptionId="lathe-sales"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('spinbutton', { name: '要求销售经验 最少 年' })).toBeInTheDocument()
+    })
+
+    rerender(
+      <QuickStartPanel
+        defaultLocation="广东"
+        defaultKeywords={[]}
+        jobDescriptionId="senior-mechanical-engineer"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('spinbutton', { name: '要求工程经验 最少 年' })).toBeInTheDocument()
+    })
+
+    rerender(
+      <QuickStartPanel
+        defaultLocation="广东"
+        defaultKeywords={[]}
+        jobDescriptionId=""
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('spinbutton', { name: '要求相关经验 最少 年' })).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -26,6 +26,7 @@ interface ResumeCardProps {
   ruleScore?: number
   industryTags?: string[]
   companyHits?: string[]
+  roleTypes?: string[]
   experienceLevel?: string
   onTagClick?: (tag: string) => void
   onCompanyClick?: (company: string) => void
@@ -122,6 +123,7 @@ export function ResumeCard({
   isReviewed,
   industryTags,
   companyHits,
+  roleTypes,
   experienceLevel,
   onTagClick,
   onCompanyClick,
@@ -216,7 +218,11 @@ export function ResumeCard({
           : null
 
   return (
-    <div className="mb-3 overflow-hidden rounded-lg border bg-card">
+    <div
+      className="mb-3 overflow-hidden rounded-lg border bg-card"
+      data-testid="resume-card"
+      data-role-types={(roleTypes ?? []).join(',')}
+    >
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b bg-muted/50 px-4 py-2 text-sm">
         <span className="text-muted-foreground">求职意向</span>
         <span className="font-medium">{jobIntention}</span>

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -205,6 +205,7 @@ export function ResumeList() {
                 ruleScore={entry.ruleScore}
                 industryTags={ingestData?.industryTags}
                 companyHits={ingestData?.companyHits}
+                roleTypes={ingestData?.roleSignals?.map((signal) => signal.type) ?? []}
                 experienceLevel={ingestData?.experienceLevel}
                 onTagClick={handleToggleTag}
                 onCompanyClick={handleToggleCompany}

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1,0 +1,259 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+import { useResumeListState } from './useResumeListState'
+
+const mockState = vi.hoisted(() => ({
+  convexResumes: [] as ConvexResumeItem[],
+  filters: {} as Record<string, unknown>,
+  setFilters: vi.fn(),
+  setLocation: vi.fn(),
+  setKeywords: vi.fn(),
+  setJobDescriptionId: vi.fn(),
+  trackReviewedResume: vi.fn(),
+  applyExternalState: vi.fn(),
+  refresh: vi.fn(async () => {}),
+  reloadSamples: vi.fn(async () => {}),
+  blockCandidates: vi.fn(async () => true),
+  unblockCandidate: vi.fn(async () => true),
+  updateStatus: vi.fn(async () => {}),
+  saveAction: vi.fn(async () => {}),
+  syncToUrl: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: string | { defaultValue?: string }) => {
+      if (typeof options === 'string') {
+        return options
+      }
+      return options?.defaultValue ?? _key
+    },
+  }),
+}))
+
+vi.mock('convex/react', () => ({
+  useQuery: () => [],
+  useMutation: () => vi.fn(async () => ({})),
+}))
+
+vi.mock('@/hooks/useSession', () => ({
+  useSession: () => ({
+    location: '广东',
+    setLocation: mockState.setLocation,
+    keywords: [],
+    setKeywords: mockState.setKeywords,
+    jobDescriptionId: undefined,
+    setJobDescriptionId: mockState.setJobDescriptionId,
+    filters: mockState.filters,
+    setFilters: mockState.setFilters,
+    reviewedIdsSet: new Set<string>(),
+    trackReviewedResume: mockState.trackReviewedResume,
+    applyExternalState: mockState.applyExternalState,
+  }),
+}))
+
+vi.mock('@/hooks/useUrlSearchState', () => ({
+  hasKnownUrlSearchParams: () => false,
+  parseUrlSearchState: () => ({
+    location: undefined,
+    keywords: [],
+    jobDescriptionId: undefined,
+    filters: {},
+    selectedTags: [],
+    selectedCompanies: [],
+    selectedExperienceLevel: undefined,
+  }),
+  useUrlSearchState: () => ({
+    parsedState: {
+      location: undefined,
+      keywords: [],
+      jobDescriptionId: undefined,
+      filters: {},
+      selectedTags: [],
+      selectedCompanies: [],
+      selectedExperienceLevel: undefined,
+    },
+    hasUrlParams: false,
+    hasKeywordParam: false,
+    hasJobDescriptionParam: false,
+    syncToUrl: mockState.syncToUrl,
+  }),
+}))
+
+vi.mock('@/hooks/useResumes', () => ({
+  useResumes: () => ({
+    resumes: [],
+    summary: null,
+    loading: false,
+    error: null,
+    selectedSample: '',
+    refresh: mockState.refresh,
+    reloadSamples: mockState.reloadSamples,
+  }),
+}))
+
+vi.mock('@/hooks/useConvexResumes', () => ({
+  useConvexResumes: () => ({
+    resumes: mockState.convexResumes,
+    loading: false,
+  }),
+}))
+
+vi.mock('@/hooks/useCandidateActions', () => ({
+  useCandidateActions: () => ({
+    actions: {},
+    saveAction: mockState.saveAction,
+  }),
+}))
+
+vi.mock('@/hooks/useCandidateBlocks', () => ({
+  useCandidateBlocks: () => ({
+    blocksByIdentity: {},
+    blockCandidates: mockState.blockCandidates,
+    unblockCandidate: mockState.unblockCandidate,
+  }),
+}))
+
+vi.mock('@/hooks/useCandidateStatus', () => ({
+  useCandidateStatus: () => ({
+    statusByIdentity: {},
+    updateStatus: mockState.updateStatus,
+  }),
+}))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: {
+    POST: vi.fn(async () => ({ data: { success: true } })),
+    GET: vi.fn(async () => ({ data: { success: true } })),
+  },
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+function buildResume(params: {
+  id: string
+  name: string
+  roleSignals: Array<{
+    type: string
+    matchedSignals: string[]
+    signalCount: number
+    occurrences: number
+    years: number
+    verifyIn: string
+  }>
+}): ConvexResumeItem {
+  return {
+    resumeId: params.id as ConvexResumeItem['resumeId'],
+    externalId: `ext-${params.id}`,
+    crawledAt: 1_700_000_000_000,
+    source: 'test',
+    tags: [],
+    identityKey: params.id,
+    name: params.name,
+    profileUrl: `https://example.com/${params.id}`,
+    activityStatus: 'Active',
+    age: '30',
+    ageNumber: 30,
+    experience: '5 years',
+    education: 'Bachelor',
+    location: 'Dongguan',
+    selfIntro: 'Test intro',
+    jobIntention: 'Test role',
+    expectedSalary: '10k-20k',
+    workHistory: [{ raw: 'Test work history' }],
+    extractedAt: '2026-03-01T00:00:00.000Z',
+    ingestData: {
+      industryTags: [],
+      synonymHits: [],
+      brandHits: [],
+      companyHits: [],
+      roleSignals: params.roleSignals,
+      ruleScores: {},
+      experienceLevel: 'mid',
+      computedAt: 1_700_000_000_000,
+      skillsVersion: 1,
+    },
+  }
+}
+
+describe('useResumeListState role filter regression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.history.replaceState({}, '', '/')
+
+    mockState.convexResumes = [
+      buildResume({
+        id: 'resume-engineer-strong',
+        name: 'Engineer Strong',
+        roleSignals: [
+          {
+            type: 'engineer',
+            matchedSignals: ['工程师'],
+            signalCount: 3,
+            occurrences: 3,
+            years: 4,
+            verifyIn: 'workHistory',
+          },
+        ],
+      }),
+      buildResume({
+        id: 'resume-sales-only',
+        name: 'Sales Only',
+        roleSignals: [
+          {
+            type: 'sales',
+            matchedSignals: ['销售'],
+            signalCount: 4,
+            occurrences: 4,
+            years: 6,
+            verifyIn: 'workHistory',
+          },
+        ],
+      }),
+      buildResume({
+        id: 'resume-engineer-junior',
+        name: 'Engineer Junior',
+        roleSignals: [
+          {
+            type: 'engineer',
+            matchedSignals: ['研发'],
+            signalCount: 1,
+            occurrences: 1,
+            years: 1,
+            verifyIn: 'workHistory',
+          },
+        ],
+      }),
+    ]
+  })
+
+  it('filters by minRoleYears + roleFilterType (engineer)', () => {
+    mockState.filters = {
+      minRoleYears: 2,
+      roleFilterType: 'engineer',
+    }
+
+    const { result } = renderHook(() => useResumeListState())
+    const names = result.current.displayedResumes.map((entry) => entry.resume.name)
+
+    expect(names).toEqual(['Engineer Strong'])
+  })
+
+  it('falls back to legacy minSalesYears when minRoleYears is absent', () => {
+    mockState.filters = {
+      minSalesYears: 5,
+    }
+
+    const { result } = renderHook(() => useResumeListState())
+    const names = result.current.displayedResumes.map((entry) => entry.resume.name)
+
+    expect(names).toEqual(['Sales Only'])
+  })
+})

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -161,6 +161,14 @@ export type ResumeWithIngestData = ResumeItem & {
       context: string
     }>
     companyHits: string[]
+    roleSignals?: Array<{
+      type: string
+      matchedSignals: string[]
+      signalCount: number
+      occurrences: number
+      years: number
+      verifyIn: string
+    }>
     ruleScores: Record<string, number>
     experienceLevel: string
     computedAt: number


### PR DESCRIPTION
## Summary
- add `QuickStartPanel` unit regression to verify quick filter label switches across sales/engineer/no-JD states
- add `useResumeListState` hook regression for `minRoleYears + roleFilterType` and legacy `minSalesYears` fallback behavior
- add Playwright regression for engineer quick filter behavior and expose non-visual `data-role-types` on resume cards for deterministic assertion
- add npm script `test:e2e:resume-role-filter`

## Validation
- `cd apps/web && npx vitest run src/components/QuickStartPanel.test.tsx src/hooks/useResumeListState.test.tsx`
- `cd apps/web && npx playwright test -c playwright.config.ts e2e/resume-role-filter.spec.ts`
- `cd apps/web && npm run test:e2e:resume-role-filter`
- `make check-node`
