### PR TITLE
test: harden audit verification coverage

### DIFF
--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -1,0 +1,68 @@
+import ExcelJS from "exceljs";
+import Papa from "papaparse";
+import { describe, expect, it } from "vitest";
+
+import { ExportService } from "./export-service";
+
+import type { ResumeExportEntry } from "./export-service";
+
+function buildEntry(age: string | undefined): ResumeExportEntry {
+  return {
+    key: "resume-1",
+    resume: {
+      name: "Alice",
+      age,
+      experience: "5年",
+      education: "本科",
+      location: "东莞",
+      profileUrl: "https://example.com/resume-1",
+      workHistory: [{ raw: "Test work history" }],
+      selfIntro: "Test intro",
+      ingestData: {
+        industryTags: ["cnc"],
+        companyHits: ["FANUC"],
+      },
+    },
+    match: {
+      score: 88,
+      recommendation: "strong_match",
+      scoreSource: "rule",
+      summary: "Great fit",
+    },
+    action: "follow_up",
+    status: "new",
+    ruleScore: 91,
+  };
+}
+
+describe("ExportService", () => {
+  it("exports normalized age values in CSV output", async () => {
+    const service = new ExportService();
+    const file = await service.exportResumes("csv", [buildEntry(" 29 岁 "), buildEntry("invalid")]);
+    const csv = file.content.toString("utf8");
+    const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
+
+    expect(file.extension).toBe("csv");
+    expect(file.contentType).toBe("text/csv; charset=utf-8");
+    expect(parsed.data[0]?.age).toBe("29");
+    expect(parsed.data[1]?.age).toBe("");
+  });
+
+  it("exports normalized age values in XLSX output", async () => {
+    const service = new ExportService();
+    const file = await service.exportResumes("xlsx", [buildEntry("31"), buildEntry("abc")]);
+    const workbook = new ExcelJS.Workbook();
+
+    await workbook.xlsx.load(file.content);
+    const sheet = workbook.getWorksheet("Resumes");
+
+    expect(file.extension).toBe("xlsx");
+    expect(file.contentType).toBe(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    );
+    expect(sheet).toBeDefined();
+    expect(sheet?.getRow(1).values).toContain("Age");
+    expect(sheet?.getCell("G2").value).toBe(31);
+    expect(sheet?.getCell("G3").value).toBe("");
+  });
+});

--- a/apps/api/src/services/rule-scoring.test.ts
+++ b/apps/api/src/services/rule-scoring.test.ts
@@ -85,6 +85,36 @@ describe("RuleScoringService", () => {
       expect(context.keywords).toEqual(["cnc", "车床"]);
       expect(context.targetLocations).toEqual(["广东"]);
       expect(context.industryTags).toEqual(["cnc"]);
+      expect(context.requiredRoles).toEqual([]);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("does not apply strict role gating for keyword-only searches", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new RuleScoringService(root);
+      const context = service.buildContextFromKeywords(["车床", "销售"], "东莞");
+
+      const operatorCandidate: ResumeIndex = {
+        resumeId: "R-keyword-only-operator",
+        experienceYears: 6,
+        educationLevel: "associate",
+        locationCity: "东莞",
+        evidenceText: "2019-2025 cnc操作员 负责车床编程与设备维护",
+        skills: ["cnc", "车床", "销售"],
+        companies: ["东莞某机床厂"],
+        industryTags: ["machinery", "cnc"],
+        salaryRange: { min: 9000, max: 12000 },
+        searchText: "东莞 cnc 车床 操作 维护",
+      };
+
+      const result = service.scoreResume(operatorCandidate, context);
+
+      expect(context.requiredRoles).toEqual([]);
+      expect(result.breakdown.roleMatch).toBe(10);
     } finally {
       cleanupFixtureRoot(root);
     }

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+import type { CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 import { useResumeListState } from './useResumeListState'
 
 const mockState = vi.hoisted(() => ({
@@ -9,6 +10,8 @@ const mockState = vi.hoisted(() => ({
   sessionLocation: '广东',
   sessionKeywords: [] as string[],
   sessionJobDescriptionId: undefined as string | undefined,
+  blocksByIdentity: {} as Record<string, { identityKey: string }>,
+  statusByIdentity: {} as Record<string, CandidateStatusRecord>,
   setFilters: vi.fn(),
   setLocation: vi.fn(),
   setKeywords: vi.fn(),
@@ -114,7 +117,7 @@ vi.mock('@/hooks/useCandidateActions', () => ({
 
 vi.mock('@/hooks/useCandidateBlocks', () => ({
   useCandidateBlocks: () => ({
-    blocksByIdentity: {},
+    blocksByIdentity: mockState.blocksByIdentity,
     blockCandidates: mockState.blockCandidates,
     unblockCandidate: mockState.unblockCandidate,
   }),
@@ -122,7 +125,7 @@ vi.mock('@/hooks/useCandidateBlocks', () => ({
 
 vi.mock('@/hooks/useCandidateStatus', () => ({
   useCandidateStatus: () => ({
-    statusByIdentity: {},
+    statusByIdentity: mockState.statusByIdentity,
     updateStatus: mockState.updateStatus,
   }),
 }))
@@ -189,13 +192,34 @@ function buildResume(params: {
   }
 }
 
+function buildCandidateStatusRecord(
+  identityKey: string,
+  status: CandidateStatusRecord['status']
+): CandidateStatusRecord {
+  return {
+    _id: `status-${identityKey}`,
+    identityKey,
+    workspaceSlug: 'default',
+    status,
+    updatedAt: 1,
+  }
+}
+
+function getDisplayedResumeNames(): string[] {
+  const { result } = renderHook(() => useResumeListState())
+  return result.current.displayedResumes.map((entry) => entry.resume.name)
+}
+
 describe('useResumeListState role filter regression', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     window.history.replaceState({}, '', '/')
+    mockState.filters = {}
     mockState.sessionLocation = '广东'
     mockState.sessionKeywords = []
     mockState.sessionJobDescriptionId = undefined
+    mockState.blocksByIdentity = {}
+    mockState.statusByIdentity = {}
     mockState.urlParsedState = {
       location: undefined,
       keywords: [],
@@ -261,10 +285,7 @@ describe('useResumeListState role filter regression', () => {
       roleFilterType: 'engineer',
     }
 
-    const { result } = renderHook(() => useResumeListState())
-    const names = result.current.displayedResumes.map((entry) => entry.resume.name)
-
-    expect(names).toEqual(['Engineer Strong'])
+    expect(getDisplayedResumeNames()).toEqual(['Engineer Strong'])
   })
 
   it('falls back to legacy minSalesYears when minRoleYears is absent', () => {
@@ -272,10 +293,52 @@ describe('useResumeListState role filter regression', () => {
       minSalesYears: 5,
     }
 
-    const { result } = renderHook(() => useResumeListState())
-    const names = result.current.displayedResumes.map((entry) => entry.resume.name)
+    expect(getDisplayedResumeNames()).toEqual(['Sales Only'])
+  })
 
-    expect(names).toEqual(['Sales Only'])
+  it('hides blocked candidates by default', () => {
+    mockState.blocksByIdentity = {
+      'resume-sales-only': { identityKey: 'resume-sales-only' },
+    }
+
+    expect(getDisplayedResumeNames()).toEqual(['Engineer Strong', 'Engineer Junior'])
+  })
+
+  it('includes blocked candidates when showBlocked is enabled', () => {
+    mockState.filters = {
+      showBlocked: true,
+    }
+    mockState.blocksByIdentity = {
+      'resume-sales-only': { identityKey: 'resume-sales-only' },
+    }
+
+    expect(getDisplayedResumeNames()).toEqual(['Engineer Strong', 'Sales Only', 'Engineer Junior'])
+  })
+
+  it('filters by interviewed_reject status', () => {
+    mockState.filters = {
+      status: ['interviewed_reject'],
+    }
+    mockState.statusByIdentity = {
+      'resume-sales-only': buildCandidateStatusRecord('resume-sales-only', 'interviewed_reject'),
+    }
+
+    expect(getDisplayedResumeNames()).toEqual(['Sales Only'])
+  })
+
+  it('applies showBlocked together with interviewed_reject status filtering', () => {
+    mockState.filters = {
+      showBlocked: true,
+      status: ['interviewed_reject'],
+    }
+    mockState.blocksByIdentity = {
+      'resume-sales-only': { identityKey: 'resume-sales-only' },
+    }
+    mockState.statusByIdentity = {
+      'resume-sales-only': buildCandidateStatusRecord('resume-sales-only', 'interviewed_reject'),
+    }
+
+    expect(getDisplayedResumeNames()).toEqual(['Sales Only'])
   })
 
   it('reset clears location instead of restoring the Guangdong default', () => {


### PR DESCRIPTION
## Summary
- add a rule-scoring regression that documents keyword-only searches do not apply strict JD role gating
- cover blocked candidate visibility and `interviewed_reject` status filtering in `useResumeListState`
- add CSV/XLSX export tests for normalized age output

## Test plan
- [x] bunx vitest run apps/api/src/services/rule-scoring.test.ts apps/api/src/services/export-service.test.ts packages/convex/convex/__tests__/age.test.ts
- [x] cd apps/web && bunx vitest run src/hooks/useResumeListState.test.tsx
- [x] make -C /root/workspace check