### PR TITLE
fix: use work history only for experience scoring

### DIFF
--- a/apps/api/src/services/rule-scoring.test.ts
+++ b/apps/api/src/services/rule-scoring.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { RuleScoringService } from "./rule-scoring";
+import { RuleScoringService, type RoleSignalSummary } from "./rule-scoring";
 
 import type { ResumeIndex } from "./resume-index";
 
@@ -70,6 +70,17 @@ updated_at: '2026-02-24'
 
 function cleanupFixtureRoot(root: string): void {
   fs.rmSync(root, { recursive: true, force: true });
+}
+
+function createSalesRoleSignal(years: number, matchedSignals: string[] = ["销售经理", "客户", "渠道"]): RoleSignalSummary {
+  return {
+    type: "sales",
+    matchedSignals,
+    signalCount: matchedSignals.length,
+    occurrences: 1,
+    years,
+    verifyIn: "workHistory",
+  };
 }
 
 describe("RuleScoringService", () => {
@@ -152,7 +163,7 @@ describe("RuleScoringService", () => {
         searchText: "北京 文员 客服",
       };
 
-      const strongScore = service.scoreResume(strongCandidate, context);
+      const strongScore = service.scoreResume(strongCandidate, context, [], [createSalesRoleSignal(5)]);
       const weakScore = service.scoreResume(weakCandidate, context);
 
       expect(strongScore.score).toBeGreaterThan(weakScore.score);
@@ -502,10 +513,12 @@ describe("RuleScoringService", () => {
       };
 
       const operatorResult = service.scoreResume(operatorCandidate, context);
-      const salesResult = service.scoreResume(salesCandidate, context);
+      const salesResult = service.scoreResume(salesCandidate, context, [], [createSalesRoleSignal(5)]);
 
       expect(operatorResult.breakdown.roleMatch).toBe(2);
+      expect(operatorResult.breakdown.experienceMatch).toBe(0);
       expect(salesResult.breakdown.roleMatch).toBe(8);
+      expect(salesResult.breakdown.experienceMatch).toBe(25);
       expect(salesResult.score).toBeGreaterThan(operatorResult.score);
     } finally {
       cleanupFixtureRoot(root);
@@ -532,9 +545,12 @@ describe("RuleScoringService", () => {
         searchText: "东莞 cnc 车床 销售 客户 渠道 机床销售工程师 熟悉star fanuc品牌 大客户资源",
       };
 
-      const result = service.scoreResume(retrievalOnlySalesCandidate, context);
+      const result = service.scoreResume(retrievalOnlySalesCandidate, context, [
+        { brand: "fanuc", role: "both", source: "selfIntro", context: "equipment" },
+      ]);
 
       expect(result.breakdown.roleMatch).toBe(2);
+      expect(result.breakdown.brandRelevance).toBe(0);
       expect(result.recommendation).not.toBe("strong_match");
     } finally {
       cleanupFixtureRoot(root);
@@ -563,6 +579,47 @@ describe("RuleScoringService", () => {
       const result = service.scoreResume(legacyOnlyCandidate, context);
 
       expect(result.breakdown.roleMatch).toBe(2);
+      expect(result.breakdown.experienceMatch).toBe(0);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("uses work-history brand hits when required roles exist", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new RuleScoringService(root);
+      const context = service.buildContext("lathe-sales");
+      const candidate: ResumeIndex = {
+        resumeId: "R-brand-work-history-only",
+        experienceYears: 5,
+        educationLevel: "bachelor",
+        locationCity: "东莞",
+        evidenceText: "2020-2025 机床销售工程师 负责客户开发 渠道拓展",
+        skills: ["cnc", "车床", "销售"],
+        companies: ["东莞设备公司"],
+        industryTags: ["machinery", "cnc", "sales"],
+        salaryRange: { min: 12000, max: 18000 },
+        searchText: "东莞 车床 销售 客户 渠道 熟悉fanuc品牌",
+      };
+
+      const selfIntroOnlyResult = service.scoreResume(
+        candidate,
+        context,
+        [{ brand: "fanuc", role: "both", source: "selfIntro", context: "equipment" }],
+        [createSalesRoleSignal(5)]
+      );
+      const workHistoryResult = service.scoreResume(
+        candidate,
+        context,
+        [{ brand: "fanuc", role: "both", source: "workHistory", context: "employer" }],
+        [createSalesRoleSignal(5)]
+      );
+
+      expect(selfIntroOnlyResult.breakdown.brandRelevance).toBe(0);
+      expect(workHistoryResult.breakdown.brandRelevance).toBe(4);
+      expect(workHistoryResult.score).toBeGreaterThan(selfIntroOnlyResult.score);
     } finally {
       cleanupFixtureRoot(root);
     }
@@ -614,7 +671,7 @@ describe("RuleScoringService", () => {
       };
 
       const operatorResult = service.scoreResume(operatorCandidate, context);
-      const salesResult = service.scoreResume(salesCandidate, context);
+      const salesResult = service.scoreResume(salesCandidate, context, [], [createSalesRoleSignal(5)]);
 
       expect(operatorResult.breakdown.roleMatch).toBe(0);
       expect(salesResult.breakdown.roleMatch).toBe(10);

--- a/apps/api/src/services/rule-scoring.ts
+++ b/apps/api/src/services/rule-scoring.ts
@@ -583,7 +583,7 @@ export class RuleScoringService {
     const signalHits = role.signals.filter((signal) => normalizedText.includes(signal.toLowerCase()));
     return {
       signalCount: signalHits.length,
-      years: typeof index.experienceYears === "number" ? index.experienceYears : 0,
+      years: 0,
     };
   }
 
@@ -625,6 +625,23 @@ export class RuleScoringService {
 
     const aggregate = roleScores.reduce((sum, value) => sum + value, 0) / roleScores.length;
     return Math.round(Math.max(0, Math.min(weight, aggregate)));
+  }
+
+  private computeRelevantRoleYears(
+    requiredRoles: RequiredRoleRequirement[],
+    roleSignals: RoleSignalSummary[]
+  ): number {
+    const matchedYears = requiredRoles
+      .map((required) => {
+        const matched = roleSignals.find(
+          (signal) => signal.type.toLowerCase() === required.type.toLowerCase()
+            && signal.verifyIn === required.verifyIn
+        );
+        return matched?.years ?? 0;
+      })
+      .filter((years) => years > 0);
+
+    return matchedYears.length > 0 ? Math.max(...matchedYears) : 0;
   }
 
   private applyRoleContext(
@@ -700,9 +717,22 @@ export class RuleScoringService {
       ? Math.round((matchedSkills.length / context.keywords.length) * categoryWeights.skillMatch)
       : 0;
     const rawRoleMatch = this.scoreRoleMatch(index, context, roleSignals);
+    const hasRequiredRoles = context.requiredRoles.length > 0;
 
     let experienceMatch = 0;
-    if (context.minExperience === undefined) {
+    if (hasRequiredRoles) {
+      const relevantRoleYears = this.computeRelevantRoleYears(context.requiredRoles, roleSignals);
+      const effectiveMinExperience = context.minExperience ?? context.requiredRoles[0]?.minYears ?? 0;
+
+      if (relevantRoleYears >= effectiveMinExperience) {
+        experienceMatch = categoryWeights.experienceMatch;
+      } else if (relevantRoleYears > 0) {
+        const ratio = relevantRoleYears / Math.max(1, effectiveMinExperience);
+        experienceMatch = Math.round(categoryWeights.experienceMatch * Math.min(1, ratio));
+      } else {
+        experienceMatch = 0;
+      }
+    } else if (context.minExperience === undefined) {
       experienceMatch = index.experienceYears === null
         ? Math.round((categoryWeights.experienceMatch * 8) / DEFAULT_WEIGHTS.categoryWeights.experienceMatch)
         : categoryWeights.experienceMatch;
@@ -759,10 +789,13 @@ export class RuleScoringService {
     const normalizedBrandKeywords = (context.brandKeywords ?? [])
       .map((brand) => brand.toLowerCase())
       .filter((brand) => brand.length > 0);
+    const scoringBrandHits = hasRequiredRoles
+      ? brandHits.filter((hit) => hit.source === "workHistory")
+      : brandHits;
     const hasBrandKeywordTargets = normalizedBrandKeywords.length > 0;
     const matchedBrandHits = hasBrandKeywordTargets
-      ? brandHits.filter((hit) => normalizedBrandKeywords.includes(hit.brand.toLowerCase()))
-      : brandHits;
+      ? scoringBrandHits.filter((hit) => normalizedBrandKeywords.includes(hit.brand.toLowerCase()))
+      : scoringBrandHits;
 
     const contextWeights = hasBrandKeywordTargets
       ? this.weights.brandContextWithTarget


### PR DESCRIPTION
## Summary
- use role-specific work-history `roleSignals` for `experienceMatch` when JDs define `requiredRoles`
- stop `resolveRoleSignal()` from falling back to total career years when no strict role signal matches
- filter brand scoring to `workHistory` hits under strict role-gated scoring and add regressions for the new behavior

## Testing
- npm run test -- apps/api/src/services/rule-scoring.test.ts
- make check