### PR TITLE
fix(ai-matching): only evaluate candidates based on work history

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -481,6 +481,14 @@ function createFallbackIndex(resume: ResumeItem, resumeId: string): ResumeIndex 
   };
 }
 
+function formatWorkHistoryForAI(workHistory: Array<{ raw?: string }> | undefined): string {
+  if (!workHistory || workHistory.length === 0) return "";
+  return workHistory
+    .map((entry) => entry.raw?.trim() || "")
+    .filter((raw) => raw.length > 0)
+    .join("\n");
+}
+
 function buildAiResumePayload(item: {
   resume: ResumeItem;
   resumeId: string;
@@ -489,12 +497,11 @@ function buildAiResumePayload(item: {
   return {
     id: item.resumeId,
     name: item.resume.name || "未命名",
-    jobIntention: item.resume.jobIntention || undefined,
     workExperience: item.indexData.experienceYears ?? undefined,
     education: item.resume.education || undefined,
     skills: item.indexData.skills.length > 0 ? item.indexData.skills : extractSkills(item.resume.jobIntention, item.resume.selfIntro),
     companies: item.indexData.companies.length > 0 ? item.indexData.companies : extractCompanies(item.resume.workHistory),
-    summary: item.resume.selfIntro || undefined,
+    workHistory: formatWorkHistoryForAI(item.resume.workHistory) || undefined,
   };
 }
 

--- a/apps/api/src/services/ai-matching.ts
+++ b/apps/api/src/services/ai-matching.ts
@@ -19,12 +19,11 @@ export interface MatchingRequest {
     resume: {
         id: string;
         name: string;
-        jobIntention?: string;
         workExperience?: number;
         education?: string;
         skills?: string[];
         companies?: string[];
-        summary?: string;
+        workHistory?: string;
     };
     jobDescription: {
         title: string;
@@ -149,14 +148,19 @@ const USER_PROMPT_TEMPLATE = `请分析以下候选人与职位的匹配度：
 
 ## 候选人信息
 **姓名**: {candidateName}
-**求职意向**: {jobIntention}
 **工作经验**: {workExperience}年
 **学历**: {education}
 **技能**: {skills}
 **曾任职公司**: {companies}
-**简介**: {summary}
+**工作经历**:
+{workHistory}
 
 {additionalCriteria}
+
+重要评估规则：
+- 只根据"工作经历"中的实际岗位和职责来判断候选人是否有相关经验
+- 不要根据候选人的求职意向或自我介绍来推断其能力
+- 如果工作经历中没有相关岗位经验，即使总工作年限很长也应给予较低评分
 
 请以JSON格式返回分析结果，包含以下字段：
 {
@@ -470,12 +474,11 @@ Return strictly valid JSON:
         return USER_PROMPT_TEMPLATE.replace("{jobTitle}", jobDescription.title)
             .replace("{requirements}", jobDescription.requirements)
             .replace("{candidateName}", resume.name)
-            .replace("{jobIntention}", resume.jobIntention || "未填写")
             .replace("{workExperience}", String(resume.workExperience || 0))
             .replace("{education}", resume.education || "未填写")
             .replace("{skills}", resume.skills?.join(", ") || "未填写")
             .replace("{companies}", resume.companies?.join(", ") || "未填写")
-            .replace("{summary}", resume.summary || "无")
+            .replace("{workHistory}", resume.workHistory || "无工作经历")
             .replace("{additionalCriteria}", additionalCriteria);
     }
 


### PR DESCRIPTION
## Summary

- Remove `jobIntention` and `selfIntro` from AI matching prompt to prevent false positives
- Replace `summary` field (which was `selfIntro`) with actual `workHistory` entries
- Add explicit evaluation rules instructing AI to only consider work history

## Problem

After rule scoring fix, AI analysis still reported things like:
> "求职意向包含CNC学徒与销售岗位，整体匹配度较高"

This caused candidates with no actual sales work history to still receive high AI scores.

## Changes

**`apps/api/src/services/ai-matching.ts`**:
- Remove `jobIntention` from `MatchingRequest.resume` interface
- Replace `summary` with `workHistory` field
- Update prompt template to show work history instead of job intention/self intro
- Add explicit evaluation rules:
  ```
  重要评估规则：
  - 只根据"工作经历"中的实际岗位和职责来判断候选人是否有相关经验
  - 不要根据候选人的求职意向或自我介绍来推断其能力
  - 如果工作经历中没有相关岗位经验，即使总工作年限很长也应给予较低评分
  ```

**`apps/api/src/routes/resumes.ts`**:
- Add `formatWorkHistoryForAI()` helper
- Update `buildAiResumePayload()` to pass work history instead of self intro

## Test plan

- [x] `make check` passes
- [x] Type check passes
- [x] Rule scoring tests pass (16/16)
- [ ] Re-analyze candidates from HR feedback - should no longer mention job intention