### PR TITLE
feat: add scoped AI feedback and export notes

### DIFF
--- a/apps/api/src/routes/actions.ts
+++ b/apps/api/src/routes/actions.ts
@@ -6,7 +6,18 @@ import { ActionStorage } from "../services/action-storage.js";
 const app = new OpenAPIHono();
 const actionStorage = new ActionStorage(config.projectRoot);
 
-const ActionTypeSchema = z.enum(["star", "shortlist", "reject", "archive", "note", "contact"]);
+const ActionTypeSchema = z.enum([
+  "star",
+  "shortlist",
+  "reject",
+  "archive",
+  "note",
+  "contact",
+  "ai_score_like",
+  "ai_score_unlike",
+  "ai_summary_like",
+  "ai_summary_unlike",
+]);
 
 const CandidateActionSchema = z.object({
   id: z.number().int(),
@@ -38,6 +49,10 @@ const CreateActionSchema = z.object({
 
 const ActionsQuerySchema = z.object({
   sessionId: z.string().openapi({ param: { name: "sessionId", in: "query" }, example: "session-123" }),
+  jobDescriptionId: z
+    .string()
+    .optional()
+    .openapi({ param: { name: "jobDescriptionId", in: "query" }, example: "lathe-sales" }),
   latestOnly: z
     .string()
     .optional()
@@ -94,10 +109,11 @@ const listActionsRoute = createRoute({
 });
 
 app.openapi(listActionsRoute, (c) => {
-  const { sessionId, latestOnly } = c.req.valid("query");
+  const { sessionId, jobDescriptionId, latestOnly } = c.req.valid("query");
+  const normalizedJobDescriptionId = jobDescriptionId?.trim() || undefined;
   const actions = latestOnly
-    ? actionStorage.getLatestActionsForSession(sessionId)
-    : actionStorage.getActionsForSession(sessionId);
+    ? actionStorage.getLatestActionsForSession(sessionId, normalizedJobDescriptionId)
+    : actionStorage.getActionsForSession(sessionId, normalizedJobDescriptionId);
   return c.json({ success: true as const, actions }, 200);
 });
 

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -34,6 +34,7 @@ import { SearchEventLogger } from "../services/search-event-logger.js";
 import {
   ExportService,
   type ExportFormat,
+  type ExportBatchMeta,
   type ResumeExportEntry,
 } from "../services/export-service.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
@@ -91,6 +92,8 @@ const TriggerReingestRequestSchema = z.object({
 });
 const ResumeExportRequestSchema = z.object({
   format: z.enum(["csv", "xlsx"]).default("csv"),
+  userComment: z.string().optional(),
+  referenceNote: z.string().optional(),
   entries: z
     .array(
       z.object({
@@ -129,6 +132,8 @@ const ResumeExportRequestSchema = z.object({
             })
             .optional(),
         }),
+        userComment: z.string().optional(),
+        referenceNote: z.string().optional(),
         status: z.string().optional(),
       })
     )
@@ -1660,9 +1665,13 @@ app.post("/api/resumes/export", async (c) => {
 
   const format: ExportFormat = parsed.data.format;
   const entries: ResumeExportEntry[] = parsed.data.entries;
+  const batchMeta: ExportBatchMeta = {
+    userComment: parsed.data.userComment,
+    referenceNote: parsed.data.referenceNote,
+  };
 
   try {
-    const file = await exportService.exportResumes(format, entries);
+    const file = await exportService.exportResumes(format, entries, batchMeta);
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
     const filename = `resumes-export-${timestamp}.${file.extension}`;
 

--- a/apps/api/src/services/action-storage.test.ts
+++ b/apps/api/src/services/action-storage.test.ts
@@ -1,0 +1,160 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ActionStorage, actionTypeGroup } from "./action-storage";
+import { getResumeScreeningDb, resetResumeScreeningDb } from "./database";
+
+function createFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "action-storage-"));
+  fs.mkdirSync(path.join(root, "output"), { recursive: true });
+  fs.writeFileSync(path.join(root, "pyproject.toml"), "", "utf8");
+  return root;
+}
+
+describe("actionTypeGroup", () => {
+  it("classifies primary actions", () => {
+    for (const t of ["star", "shortlist", "reject", "archive", "note", "contact"]) {
+      expect(actionTypeGroup(t)).toBe("primary");
+    }
+  });
+
+  it("classifies ai_score actions", () => {
+    expect(actionTypeGroup("ai_score_like")).toBe("ai_score");
+    expect(actionTypeGroup("ai_score_unlike")).toBe("ai_score");
+  });
+
+  it("classifies ai_summary actions", () => {
+    expect(actionTypeGroup("ai_summary_like")).toBe("ai_summary");
+    expect(actionTypeGroup("ai_summary_unlike")).toBe("ai_summary");
+  });
+
+  it("treats unknown action types as primary", () => {
+    expect(actionTypeGroup("unknown_type")).toBe("primary");
+  });
+});
+
+describe("ActionStorage", () => {
+  let root: string;
+  let storage: ActionStorage;
+
+  afterEach(() => {
+    resetResumeScreeningDb();
+    if (root) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  function setup(): void {
+    root = createFixtureRoot();
+    storage = new ActionStorage(root);
+    // Insert a session row to satisfy FK constraint on candidate_actions.session_id
+    const db = getResumeScreeningDb(root);
+    const now = new Date().toISOString();
+    db.prepare(
+      "INSERT INTO search_sessions (id, status, created_at, updated_at) VALUES (?, ?, ?, ?)"
+    ).run("s1", "active", now, now);
+  }
+
+  it("saves and retrieves new AI feedback action types", () => {
+    setup();
+    const action = storage.saveAction({
+      sessionId: "s1",
+      resumeId: "r1",
+      actionType: "ai_score_like",
+    });
+    expect(action.actionType).toBe("ai_score_like");
+
+    const all = storage.getActionsForSession("s1");
+    expect(all).toHaveLength(1);
+    expect(all[0]?.actionType).toBe("ai_score_like");
+  });
+
+  it("stores synthetic action scopes in action_data when no persisted session exists", () => {
+    setup();
+
+    const action = storage.saveAction({
+      sessionId: "scope:lathe-sales",
+      resumeId: "r1",
+      actionType: "star",
+    });
+
+    expect(action.sessionId).toBe("scope:lathe-sales");
+
+    const scoped = storage.getActionsForSession("scope:lathe-sales");
+    expect(scoped).toHaveLength(1);
+    expect(scoped[0]?.resumeId).toBe("r1");
+    expect(scoped[0]?.actionData).toEqual({ scopeId: "scope:lathe-sales" });
+  });
+
+  describe("getLatestActionsForSession grouped retrieval", () => {
+    it("returns latest primary action and latest AI feedback per resume", () => {
+      setup();
+      // Primary actions: star then shortlist (shortlist is latest)
+      storage.saveAction({ sessionId: "s1", resumeId: "r1", actionType: "star" });
+      storage.saveAction({ sessionId: "s1", resumeId: "r1", actionType: "shortlist" });
+
+      // AI score feedback: like then unlike (unlike is latest)
+      storage.saveAction({ sessionId: "s1", resumeId: "r1", actionType: "ai_score_like" });
+      storage.saveAction({ sessionId: "s1", resumeId: "r1", actionType: "ai_score_unlike" });
+
+      // AI summary feedback: just a like
+      storage.saveAction({ sessionId: "s1", resumeId: "r1", actionType: "ai_summary_like" });
+
+      const latest = storage.getLatestActionsForSession("s1");
+      const types = latest.map((a) => a.actionType).sort();
+
+      // Should have 3 entries: latest primary + latest ai_score + latest ai_summary
+      expect(types).toEqual(["ai_score_unlike", "ai_summary_like", "shortlist"]);
+    });
+
+    it("returns grouped results across multiple resumes", () => {
+      setup();
+      storage.saveAction({ sessionId: "s1", resumeId: "r1", actionType: "star" });
+      storage.saveAction({ sessionId: "s1", resumeId: "r1", actionType: "ai_score_like" });
+      storage.saveAction({ sessionId: "s1", resumeId: "r2", actionType: "reject" });
+      storage.saveAction({ sessionId: "s1", resumeId: "r2", actionType: "ai_summary_unlike" });
+
+      const latest = storage.getLatestActionsForSession("s1");
+      expect(latest).toHaveLength(4);
+
+      const r1Actions = latest.filter((a) => a.resumeId === "r1").map((a) => a.actionType).sort();
+      const r2Actions = latest.filter((a) => a.resumeId === "r2").map((a) => a.actionType).sort();
+
+      expect(r1Actions).toEqual(["ai_score_like", "star"]);
+      expect(r2Actions).toEqual(["ai_summary_unlike", "reject"]);
+    });
+
+    it("returns only primary action when no AI feedback exists", () => {
+      setup();
+      storage.saveAction({ sessionId: "s1", resumeId: "r1", actionType: "star" });
+      storage.saveAction({ sessionId: "s1", resumeId: "r1", actionType: "reject" });
+
+      const latest = storage.getLatestActionsForSession("s1");
+      expect(latest).toHaveLength(1);
+      expect(latest[0]?.actionType).toBe("reject");
+    });
+
+    it("filters AI feedback by job description within synthetic scopes", () => {
+      setup();
+      storage.saveAction({ sessionId: "keywords:cnc", resumeId: "r1", actionType: "star" });
+      storage.saveAction({
+        sessionId: "keywords:cnc",
+        resumeId: "r1",
+        actionType: "ai_score_like",
+        actionData: { jobDescriptionId: "lathe-sales" },
+      });
+      storage.saveAction({
+        sessionId: "keywords:cnc",
+        resumeId: "r1",
+        actionType: "ai_score_unlike",
+        actionData: { jobDescriptionId: "field-service" },
+      });
+
+      const latest = storage.getLatestActionsForSession("keywords:cnc", "lathe-sales");
+      expect(latest.map((action) => action.actionType).sort()).toEqual(["ai_score_like", "star"]);
+    });
+  });
+});

--- a/apps/api/src/services/action-storage.ts
+++ b/apps/api/src/services/action-storage.ts
@@ -2,7 +2,57 @@ import { config } from "./config.js";
 import { getResumeScreeningDb } from "./database.js";
 import { formatIsoOffsetInTimezone } from "./timezone.js";
 
-export type CandidateActionType = "star" | "shortlist" | "reject" | "archive" | "note" | "contact";
+export type CandidateActionType =
+  | "star"
+  | "shortlist"
+  | "reject"
+  | "archive"
+  | "note"
+  | "contact"
+  | "ai_score_like"
+  | "ai_score_unlike"
+  | "ai_summary_like"
+  | "ai_summary_unlike";
+
+/**
+ * Action type group used for "latest per group" retrieval.
+ * Primary candidate actions (star/shortlist/reject/archive/note/contact) form one group,
+ * while each AI feedback dimension forms its own group so they coexist.
+ */
+export type ActionTypeGroup = "primary" | "ai_score" | "ai_summary";
+
+const AI_SCORE_TYPES = ["ai_score_like", "ai_score_unlike"] as const;
+const AI_SUMMARY_TYPES = ["ai_summary_like", "ai_summary_unlike"] as const;
+const AI_FEEDBACK_TYPES = [...AI_SCORE_TYPES, ...AI_SUMMARY_TYPES] as const;
+const AI_SCORE_TYPE_SET: ReadonlySet<string> = new Set(AI_SCORE_TYPES);
+const AI_SUMMARY_TYPE_SET: ReadonlySet<string> = new Set(AI_SUMMARY_TYPES);
+const AI_FEEDBACK_TYPES_SQL = AI_FEEDBACK_TYPES.map((actionType) => `'${actionType}'`).join(", ");
+const ACTION_GROUP_CASE_SQL = `
+  CASE
+    WHEN action_type IN ('ai_score_like', 'ai_score_unlike') THEN 'ai_score'
+    WHEN action_type IN ('ai_summary_like', 'ai_summary_unlike') THEN 'ai_summary'
+    ELSE 'primary'
+  END
+`;
+const SESSION_SCOPE_WHERE_SQL = `
+  (
+    session_id = ?
+    OR json_extract(action_data, '$.scopeId') = ?
+  )
+`;
+const AI_JOB_DESCRIPTION_WHERE_SQL = `
+  (
+    action_type NOT IN (${AI_FEEDBACK_TYPES_SQL})
+    OR json_extract(action_data, '$.jobDescriptionId') IS NULL
+    OR json_extract(action_data, '$.jobDescriptionId') = ?
+  )
+`;
+
+export function actionTypeGroup(actionType: string): ActionTypeGroup {
+  if (AI_SCORE_TYPE_SET.has(actionType)) return "ai_score";
+  if (AI_SUMMARY_TYPE_SET.has(actionType)) return "ai_summary";
+  return "primary";
+}
 
 export type CandidateAction = {
   id: number;
@@ -49,6 +99,16 @@ export class ActionStorage {
     actionType: CandidateActionType;
     actionData?: Record<string, unknown>;
   }): CandidateAction {
+    const normalizedSessionId = params.sessionId?.trim() || undefined;
+    const persistedSessionId = normalizedSessionId && this.hasPersistedSession(normalizedSessionId)
+      ? normalizedSessionId
+      : undefined;
+    const actionData = normalizedSessionId && !persistedSessionId
+      ? {
+          ...(params.actionData ?? {}),
+          scopeId: normalizedSessionId,
+        }
+      : params.actionData;
     const now = formatIsoOffsetInTimezone(new Date(), config.timezone);
     const result = this.db
       .prepare(
@@ -65,50 +125,109 @@ export class ActionStorage {
       )
       .run(
         params.userId ?? null,
-        params.sessionId ?? null,
+        persistedSessionId ?? null,
         params.resumeId,
         params.actionType,
-        params.actionData ? JSON.stringify(params.actionData) : null,
+        actionData ? JSON.stringify(actionData) : null,
         now
       );
 
     return {
       id: Number(result.lastInsertRowid),
       userId: params.userId,
-      sessionId: params.sessionId,
+      sessionId: persistedSessionId ?? normalizedSessionId,
       resumeId: params.resumeId,
       actionType: params.actionType,
-      actionData: params.actionData,
+      actionData,
       createdAt: now,
     };
   }
 
-  getActionsForSession(sessionId: string): CandidateAction[] {
-    const rows = this.db
-      .prepare("SELECT * FROM candidate_actions WHERE session_id = ? ORDER BY created_at DESC")
-      .all(sessionId) as Record<string, unknown>[];
+  getActionsForSession(sessionId: string, jobDescriptionId?: string): CandidateAction[] {
+    const rows = jobDescriptionId
+      ? (
+          this.db
+            .prepare(
+              `
+              SELECT * FROM candidate_actions
+              WHERE ${SESSION_SCOPE_WHERE_SQL}
+                AND ${AI_JOB_DESCRIPTION_WHERE_SQL}
+              ORDER BY created_at DESC
+            `
+            )
+            .all(sessionId, sessionId, jobDescriptionId) as Record<string, unknown>[]
+        )
+      : (this.db
+          .prepare(
+            `
+            SELECT * FROM candidate_actions
+            WHERE ${SESSION_SCOPE_WHERE_SQL}
+            ORDER BY created_at DESC
+          `
+          )
+          .all(sessionId, sessionId) as Record<string, unknown>[]);
 
     return rows.map((row) => normalizeAction(row));
   }
 
-  getLatestActionsForSession(sessionId: string): CandidateAction[] {
-    const rows = this.db
-      .prepare(
-        `
-        SELECT a.* FROM candidate_actions a
-        JOIN (
-          SELECT resume_id, MAX(created_at) AS created_at
-          FROM candidate_actions
-          WHERE session_id = ?
-          GROUP BY resume_id
-        ) latest
-        ON a.resume_id = latest.resume_id AND a.created_at = latest.created_at
-        WHERE a.session_id = ?
-        ORDER BY a.created_at DESC
-      `
-      )
-      .all(sessionId, sessionId) as Record<string, unknown>[];
+  getLatestActionsForSession(sessionId: string, jobDescriptionId?: string): CandidateAction[] {
+    const rows = jobDescriptionId
+      ? (
+          this.db
+            .prepare(
+              `
+              SELECT a.* FROM candidate_actions a
+              JOIN (
+                SELECT resume_id,
+                       ${ACTION_GROUP_CASE_SQL} AS action_group,
+                       MAX(id) AS max_id
+                FROM candidate_actions
+                WHERE ${SESSION_SCOPE_WHERE_SQL}
+                  AND ${AI_JOB_DESCRIPTION_WHERE_SQL}
+                GROUP BY resume_id, action_group
+              ) latest
+              ON a.id = latest.max_id
+              WHERE (
+                  a.session_id = ?
+                  OR json_extract(a.action_data, '$.scopeId') = ?
+                )
+              ORDER BY a.created_at DESC
+            `
+            )
+            .all(sessionId, sessionId, jobDescriptionId, sessionId, sessionId) as Record<string, unknown>[]
+        )
+      : (
+          this.db
+            .prepare(
+              `
+              SELECT a.* FROM candidate_actions a
+              JOIN (
+                SELECT resume_id,
+                       ${ACTION_GROUP_CASE_SQL} AS action_group,
+                       MAX(id) AS max_id
+                FROM candidate_actions
+                WHERE ${SESSION_SCOPE_WHERE_SQL}
+                GROUP BY resume_id, action_group
+              ) latest
+              ON a.id = latest.max_id
+              WHERE (
+                  a.session_id = ?
+                  OR json_extract(a.action_data, '$.scopeId') = ?
+                )
+              ORDER BY a.created_at DESC
+            `
+            )
+            .all(sessionId, sessionId, sessionId, sessionId) as Record<string, unknown>[]
+        );
 
     return rows.map((row) => normalizeAction(row));
+  }
+
+  private hasPersistedSession(sessionId: string): boolean {
+    const row = this.db
+      .prepare("SELECT 1 FROM search_sessions WHERE id = ? LIMIT 1")
+      .get(sessionId) as Record<string, unknown> | undefined;
+
+    return Boolean(row);
   }
 }

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { ExportService } from "./export-service";
 
-import type { ResumeExportEntry } from "./export-service";
+import type { ResumeExportEntry, ExportBatchMeta } from "./export-service";
 
 function buildEntry(age: string | undefined): ResumeExportEntry {
   return {
@@ -64,5 +64,61 @@ describe("ExportService", () => {
     expect(sheet?.getRow(1).values).toContain("Age");
     expect(sheet?.getCell("G2").value).toBe(31);
     expect(sheet?.getCell("G3").value).toBe("");
+  });
+
+  it("includes per-entry userComment and referenceNote in CSV", async () => {
+    const service = new ExportService();
+    const entry: ResumeExportEntry = {
+      ...buildEntry("25"),
+      userComment: "Excellent candidate",
+      referenceNote: "Referred by HR dept",
+    };
+    const file = await service.exportResumes("csv", [entry]);
+    const csv = file.content.toString("utf8");
+    const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
+
+    expect(parsed.data[0]?.userComment).toBe("Excellent candidate");
+    expect(parsed.data[0]?.referenceNote).toBe("Referred by HR dept");
+  });
+
+  it("applies batch-level userComment/referenceNote to every exported row", async () => {
+    const service = new ExportService();
+    const entryWithComment: ResumeExportEntry = {
+      ...buildEntry("28"),
+      userComment: "Per-entry comment",
+      referenceNote: "Per-entry note",
+    };
+    const entryWithout: ResumeExportEntry = buildEntry("30");
+    const batchMeta: ExportBatchMeta = {
+      userComment: "Batch comment",
+      referenceNote: "Batch ref note",
+    };
+
+    const file = await service.exportResumes("csv", [entryWithComment, entryWithout], batchMeta);
+    const csv = file.content.toString("utf8");
+    const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
+
+    expect(parsed.data[0]?.userComment).toBe("Batch comment");
+    expect(parsed.data[0]?.referenceNote).toBe("Batch ref note");
+    expect(parsed.data[1]?.userComment).toBe("Batch comment");
+    expect(parsed.data[1]?.referenceNote).toBe("Batch ref note");
+  });
+
+  it("includes User Comment and Reference Note columns in XLSX header", async () => {
+    const service = new ExportService();
+    const entry: ResumeExportEntry = {
+      ...buildEntry("26"),
+      userComment: "Test comment",
+      referenceNote: "Test note",
+    };
+    const file = await service.exportResumes("xlsx", [entry]);
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(file.content);
+    const sheet = workbook.getWorksheet("Resumes");
+
+    expect(sheet).toBeDefined();
+    const headers = sheet?.getRow(1).values as unknown[];
+    expect(headers).toContain("User Comment");
+    expect(headers).toContain("Reference Note");
   });
 });

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -40,6 +40,8 @@ export type ResumeExportEntry = {
   action?: string;
   status?: string;
   ruleScore?: number;
+  userComment?: string;
+  referenceNote?: string;
 };
 
 type ExportRow = {
@@ -63,6 +65,8 @@ type ExportRow = {
   workHistory: string;
   selfIntro: string;
   aiSummary: string;
+  userComment: string;
+  referenceNote: string;
 };
 
 export type ExportFile = {
@@ -191,6 +195,8 @@ function toRow(entry: ResumeExportEntry): ExportRow {
     workHistory,
     selfIntro: normalizeString(entry.resume.selfIntro),
     aiSummary: normalizeString(entry.match?.summary),
+    userComment: normalizeString(entry.userComment),
+    referenceNote: normalizeString(entry.referenceNote),
   };
 }
 
@@ -215,11 +221,34 @@ const EXCEL_COLUMNS: Array<{ header: string; key: keyof ExportRow; width: number
   { header: "Work History", key: "workHistory", width: 44 },
   { header: "Self Intro", key: "selfIntro", width: 48 },
   { header: "AI Summary", key: "aiSummary", width: 48 },
+  { header: "User Comment", key: "userComment", width: 36 },
+  { header: "Reference Note", key: "referenceNote", width: 36 },
 ];
 
+export type ExportBatchMeta = {
+  userComment?: string;
+  referenceNote?: string;
+};
+
+function applyBatchMeta(row: ExportRow, batchMeta?: ExportBatchMeta): ExportRow {
+  if (!batchMeta) {
+    return row;
+  }
+
+  return {
+    ...row,
+    userComment: batchMeta.userComment ?? row.userComment,
+    referenceNote: batchMeta.referenceNote ?? row.referenceNote,
+  };
+}
+
 export class ExportService {
-  async exportResumes(format: ExportFormat, entries: ResumeExportEntry[]): Promise<ExportFile> {
-    const rows = entries.map((entry) => toRow(entry));
+  async exportResumes(
+    format: ExportFormat,
+    entries: ResumeExportEntry[],
+    batchMeta?: ExportBatchMeta
+  ): Promise<ExportFile> {
+    const rows = entries.map((entry) => applyBatchMeta(toRow(entry), batchMeta));
     if (format === "xlsx") {
       const content = await this.toXlsx(rows);
       return {

--- a/apps/web/src/components/AiFeedbackButtons.tsx
+++ b/apps/web/src/components/AiFeedbackButtons.tsx
@@ -1,0 +1,55 @@
+import { ThumbsDown, ThumbsUp } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { AiFeedbackSentiment } from '@/types/resume'
+
+interface AiFeedbackButtonsProps {
+  feedback?: AiFeedbackSentiment
+  label: string
+  onSelect: (sentiment: AiFeedbackSentiment) => void
+  testId?: string
+  className?: string
+  stopPropagation?: boolean
+}
+
+export function AiFeedbackButtons({
+  feedback,
+  label,
+  onSelect,
+  testId,
+  className,
+  stopPropagation = false,
+}: AiFeedbackButtonsProps) {
+  return (
+    <span className={cn('flex items-center gap-0.5', className)} data-testid={testId}>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn('h-6 w-6', feedback === 'like' && 'text-emerald-600 bg-emerald-50')}
+        onClick={(event) => {
+          if (stopPropagation) {
+            event.stopPropagation()
+          }
+          onSelect('like')
+        }}
+        aria-label={`Like ${label}`}
+      >
+        <ThumbsUp className="h-3 w-3" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn('h-6 w-6', feedback === 'unlike' && 'text-red-600 bg-red-50')}
+        onClick={(event) => {
+          if (stopPropagation) {
+            event.stopPropagation()
+          }
+          onSelect('unlike')
+        }}
+        aria-label={`Unlike ${label}`}
+      >
+        <ThumbsDown className="h-3 w-3" />
+      </Button>
+    </span>
+  )
+}

--- a/apps/web/src/components/BulkActionBar.tsx
+++ b/apps/web/src/components/BulkActionBar.tsx
@@ -9,25 +9,19 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { CheckCircle, XCircle, Download, Users, Star, Ban } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Select } from '@/components/ui/select'
 import { cn } from '@/lib/utils'
-
-type ExportFormat = 'csv' | 'xlsx'
-
-function toExportFormat(value: string): ExportFormat {
-    return value === 'xlsx' ? 'xlsx' : 'csv'
-}
+import { ExportDialog, type ExportBatchMeta, type ExportDialogResult, type ExportFormat } from '@/components/ExportDialog'
 
 interface BulkActionBarProps {
     totalCount: number
     selectedCount: number
-    highScoreCount: number  // 80+ score count
+    highScoreCount: number
     exportFormat?: ExportFormat
     onExportFormatChange?: (format: ExportFormat) => void
     onSelectAll?: () => void
     onSelectHighScore?: () => void
     onClearSelection?: () => void
-    onBulkAction?: (action: 'shortlist' | 'reject' | 'star' | 'block' | 'export', format?: ExportFormat) => void
+    onBulkAction?: (action: 'shortlist' | 'reject' | 'star' | 'block' | 'export', format?: ExportFormat, exportMeta?: ExportBatchMeta) => void
     blockedCount?: number
     blocksSettingsPath?: string
     disabled?: boolean
@@ -49,19 +43,33 @@ export function BulkActionBar({
 }: BulkActionBarProps) {
     const { t } = useTranslation()
     const [loading, setLoading] = useState<string | null>(null)
+    const [exportDialogOpen, setExportDialogOpen] = useState(false)
 
     const handleAction = useCallback(async (action: 'shortlist' | 'reject' | 'star' | 'block' | 'export') => {
+        if (action === 'export') {
+            setExportDialogOpen(true)
+            return
+        }
         setLoading(action)
         try {
-            if (action === 'export') {
-                await onBulkAction?.(action, exportFormat)
-                return
-            }
             await onBulkAction?.(action)
         } finally {
             setLoading(null)
         }
-    }, [exportFormat, onBulkAction])
+    }, [onBulkAction])
+
+    const handleExportConfirm = useCallback(async (result: ExportDialogResult) => {
+        setLoading('export')
+        try {
+            onExportFormatChange?.(result.format)
+            await onBulkAction?.('export', result.format, {
+                userComment: result.userComment,
+                referenceNote: result.referenceNote,
+            })
+        } finally {
+            setLoading(null)
+        }
+    }, [onBulkAction, onExportFormatChange])
 
     return (
         <div className="flex flex-wrap items-center gap-2 p-3 rounded-lg bg-muted/50 border">
@@ -184,17 +192,15 @@ export function BulkActionBar({
                     <Download className={cn('mr-1 h-4 w-4', loading === 'export' && 'animate-spin')} />
                     {t('bulkActions.export', '导出')}
                 </Button>
-                <Select
-                    value={exportFormat}
-                    onChange={(event) => onExportFormatChange?.(toExportFormat(event.target.value))}
-                    options={[
-                        { value: 'csv', label: 'CSV' },
-                        { value: 'xlsx', label: 'XLSX' },
-                    ]}
-                    disabled={disabled || loading !== null}
-                    className="h-9 w-[92px]"
-                />
             </div>
+
+            <ExportDialog
+                open={exportDialogOpen}
+                onOpenChange={setExportDialogOpen}
+                selectedCount={selectedCount}
+                defaultFormat={exportFormat}
+                onConfirm={handleExportConfirm}
+            />
         </div>
     )
 }

--- a/apps/web/src/components/ExportDialog.test.tsx
+++ b/apps/web/src/components/ExportDialog.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { ExportDialog, type ExportDialogResult } from './ExportDialog'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallbackOrOptions?: string | { count?: number; defaultValue?: string }) => {
+      if (typeof fallbackOrOptions === 'string') return fallbackOrOptions
+      return fallbackOrOptions?.defaultValue ?? _key
+    },
+  }),
+}))
+
+describe('ExportDialog', () => {
+  let onConfirm: (result: ExportDialogResult) => void
+  let onOpenChange: (open: boolean) => void
+
+  beforeEach(() => {
+    onConfirm = vi.fn()
+    onOpenChange = vi.fn()
+  })
+
+  it('renders with selected count and default format', () => {
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        selectedCount={5}
+        onConfirm={onConfirm}
+      />
+    )
+
+    expect(screen.getByText('Export Resumes')).toBeInTheDocument()
+    expect(screen.getByText(/5 selected resume/)).toBeInTheDocument()
+    expect(screen.getByTestId('export-comment')).toBeInTheDocument()
+    expect(screen.getByTestId('export-reference')).toBeInTheDocument()
+  })
+
+  it('submits with format, comment, and reference note', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        selectedCount={3}
+        defaultFormat="xlsx"
+        onConfirm={onConfirm}
+      />
+    )
+
+    await user.type(screen.getByTestId('export-comment'), 'Test comment')
+    await user.type(screen.getByTestId('export-reference'), 'Reference note text')
+    await user.click(screen.getByText('Export'))
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      format: 'xlsx',
+      userComment: 'Test comment',
+      referenceNote: 'Reference note text',
+    } satisfies ExportDialogResult)
+  })
+
+  it('submits empty strings when fields are blank', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        selectedCount={1}
+        onConfirm={onConfirm}
+      />
+    )
+
+    await user.click(screen.getByText('Export'))
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      format: 'csv',
+      userComment: '',
+      referenceNote: '',
+    })
+  })
+
+  it('closes on cancel without calling onConfirm', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        selectedCount={2}
+        onConfirm={onConfirm}
+      />
+    )
+
+    await user.click(screen.getByText('Cancel'))
+
+    expect(onConfirm).not.toHaveBeenCalled()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('does not render when closed', () => {
+    render(
+      <ExportDialog
+        open={false}
+        onOpenChange={onOpenChange}
+        selectedCount={2}
+        onConfirm={onConfirm}
+      />
+    )
+
+    expect(screen.queryByText('Export Resumes')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/ExportDialog.tsx
+++ b/apps/web/src/components/ExportDialog.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Download } from 'lucide-react'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Select } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+
+export type ExportFormat = 'csv' | 'xlsx'
+
+export type ExportDialogResult = {
+  format: ExportFormat
+  userComment: string
+  referenceNote: string
+}
+
+export type ExportBatchMeta = Pick<ExportDialogResult, 'userComment' | 'referenceNote'>
+
+interface ExportDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  selectedCount: number
+  defaultFormat?: ExportFormat
+  onConfirm: (result: ExportDialogResult) => void
+}
+
+function toExportFormat(value: string): ExportFormat {
+  return value === 'xlsx' ? 'xlsx' : 'csv'
+}
+
+export function ExportDialog({
+  open,
+  onOpenChange,
+  selectedCount,
+  defaultFormat = 'csv',
+  onConfirm,
+}: ExportDialogProps) {
+  const { t } = useTranslation()
+  const [format, setFormat] = useState<ExportFormat>(defaultFormat)
+  const [userComment, setUserComment] = useState('')
+  const [referenceNote, setReferenceNote] = useState('')
+
+  const resetForm = () => {
+    setFormat(defaultFormat)
+    setUserComment('')
+    setReferenceNote('')
+  }
+
+  useEffect(() => {
+    if (open) {
+      setFormat(defaultFormat)
+    }
+  }, [defaultFormat, open])
+
+  const handleConfirm = () => {
+    onConfirm({
+      format,
+      userComment: userComment.trim(),
+      referenceNote: referenceNote.trim(),
+    })
+    resetForm()
+    onOpenChange(false)
+  }
+
+  const handleCancel = () => {
+    resetForm()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {t('export.dialog.title', 'Export Resumes')}
+          </DialogTitle>
+          <DialogDescription>
+            {t('export.dialog.description', {
+              count: selectedCount,
+              defaultValue: `Export ${selectedCount} selected resume(s). Add optional comments before exporting.`,
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="export-format">
+              {t('export.dialog.formatLabel', 'Format')}
+            </Label>
+            <Select
+              value={format}
+              onChange={(e) => setFormat(toExportFormat(e.target.value))}
+              options={[
+                { value: 'csv', label: 'CSV' },
+                { value: 'xlsx', label: 'XLSX' },
+              ]}
+              className="w-full"
+              data-testid="export-format-select"
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="export-comment">
+              {t('export.dialog.commentLabel', 'Comment')}
+            </Label>
+            <Textarea
+              id="export-comment"
+              value={userComment}
+              onChange={(e) => setUserComment(e.target.value)}
+              placeholder={t('export.dialog.commentPlaceholder', 'Add a comment for this export (optional)')}
+              className="min-h-[60px]"
+              data-testid="export-comment"
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="export-reference">
+              {t('export.dialog.referenceLabel', 'Reference Note')}
+            </Label>
+            <Textarea
+              id="export-reference"
+              value={referenceNote}
+              onChange={(e) => setReferenceNote(e.target.value)}
+              placeholder={t('export.dialog.referencePlaceholder', 'Add a reference note (optional)')}
+              className="min-h-[60px]"
+              data-testid="export-reference"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleCancel}>
+            {t('common.cancel', 'Cancel')}
+          </Button>
+          <Button onClick={handleConfirm} className="gap-2">
+            <Download className="h-4 w-4" />
+            {t('export.dialog.confirm', 'Export')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -4,8 +4,9 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
+import { AiFeedbackButtons } from '@/components/AiFeedbackButtons'
 import type { ResumeItem } from '@/hooks/useResumes'
-import type { CandidateActionType, CandidateStatus, MatchingResult } from '@/types/resume'
+import type { AiFeedbackSentiment, AiFeedbackTarget, CandidateActionType, CandidateStatus, MatchingResult } from '@/types/resume'
 import type { ExperienceLevelFilter } from '@/hooks/useUrlSearchState'
 import { cn } from '@/lib/utils'
 import {
@@ -54,6 +55,8 @@ interface ResumeCardProps {
     requirements?: string
   }
   isReviewed?: boolean
+  aiScoreFeedback?: AiFeedbackSentiment
+  onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
 }
 
 function isSafeProfileUrl(value: string | undefined): value is string {
@@ -121,6 +124,8 @@ export function ResumeCard({
   jobDescriptionId,
   jobDescription,
   isReviewed,
+  aiScoreFeedback,
+  onAiFeedback,
   industryTags,
   companyHits,
   roleTypes,
@@ -274,6 +279,15 @@ export function ResumeCard({
               <Badge className={cn('border text-[10px] uppercase tracking-wide', scoreSourceClassName)}>
                 {scoreSource === 'ai' ? 'AI' : 'Rule'}
               </Badge>
+            ) : null}
+            {onAiFeedback && scoreSource === 'ai' ? (
+              <AiFeedbackButtons
+                feedback={aiScoreFeedback}
+                label="AI score"
+                testId="ai-score-feedback"
+                stopPropagation
+                onSelect={(sentiment) => onAiFeedback('ai_score', sentiment)}
+              />
             ) : null}
           </div>
         ) : isRuleScore && effectiveScore && effectiveScore > 0 ? (

--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -3,15 +3,19 @@ import { useTranslation } from 'react-i18next'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { AiFeedbackButtons } from '@/components/AiFeedbackButtons'
 import type { ResumeItem } from '@/hooks/useResumes'
 
-import type { MatchingResult } from '@/types/resume'
+import type { AiFeedbackSentiment, AiFeedbackTarget, MatchingResult } from '@/types/resume'
 
 interface ResumeDetailProps {
   resume: ResumeItem | null
   matchResult?: MatchingResult
   open: boolean
   onOpenChange: (open: boolean) => void
+  aiScoreFeedback?: AiFeedbackSentiment
+  aiSummaryFeedback?: AiFeedbackSentiment
+  onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
 }
 
 function isSafeProfileUrl(value: string | undefined): value is string {
@@ -19,7 +23,7 @@ function isSafeProfileUrl(value: string | undefined): value is string {
   return value.startsWith('http://') || value.startsWith('https://')
 }
 
-export function ResumeDetail({ resume, matchResult, open, onOpenChange }: ResumeDetailProps) {
+export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreFeedback, aiSummaryFeedback, onAiFeedback }: ResumeDetailProps) {
   const { t } = useTranslation()
 
   const workHistory = useMemo(() => {
@@ -52,13 +56,32 @@ export function ResumeDetail({ resume, matchResult, open, onOpenChange }: Resume
                   <Badge variant={matchResult.score >= 80 ? 'default' : matchResult.score >= 60 ? 'secondary' : 'outline'}>
                     {matchResult.score} 分
                   </Badge>
+                  {onAiFeedback ? (
+                    <AiFeedbackButtons
+                      feedback={aiScoreFeedback}
+                      label="AI score"
+                      testId="detail-ai-score-feedback"
+                      onSelect={(sentiment) => onAiFeedback('ai_score', sentiment)}
+                    />
+                  ) : null}
                 </h3>
                 <span className="text-xs text-muted-foreground uppercase tracking-wider font-bold">
                   {matchResult.recommendation?.replace('_', ' ')}
                 </span>
               </div>
 
-              <p className="text-sm text-foreground mb-3">{matchResult.summary}</p>
+              <div className="flex items-start gap-2 mb-3">
+                <p className="text-sm text-foreground flex-1">{matchResult.summary}</p>
+                {onAiFeedback ? (
+                  <AiFeedbackButtons
+                    feedback={aiSummaryFeedback}
+                    label="AI summary"
+                    testId="detail-ai-summary-feedback"
+                    className="shrink-0"
+                    onSelect={(sentiment) => onAiFeedback('ai_summary', sentiment)}
+                  />
+                ) : null}
+              </div>
 
               <div className="grid grid-cols-2 gap-4 mb-3">
                 {matchResult.highlights && matchResult.highlights.length > 0 && (

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -65,6 +65,8 @@ export function ResumeList() {
     handleToggleBlock,
     handleCandidateStatusChange,
     handleResetAll,
+    handleAiFeedback,
+    getAiFeedback,
   } = useResumeListState(historyRequested)
   useSyncNotifications()
   const { slug: workspaceSlug } = useWorkspace()
@@ -72,13 +74,15 @@ export function ResumeList() {
   const [detailResume, setDetailResume] = useState<ResumeItem | null>(null)
   const [historyOpen, setHistoryOpen] = useState(false)
 
+  const detailKey = useMemo(() => {
+    if (!detailResume) return undefined
+    return buildResumeKey(detailResume, 0)
+  }, [detailResume])
+
   const detailMatch = useMemo(() => {
-    if (!detailResume) {
-      return undefined
-    }
-    const detailKey = buildResumeKey(detailResume, 0)
+    if (!detailKey) return undefined
     return displayedResumes.find((entry) => entry.key === detailKey)?.match
-  }, [detailResume, displayedResumes])
+  }, [detailKey, displayedResumes])
 
   return (
     <div className="flex flex-col gap-4">
@@ -248,6 +252,8 @@ export function ResumeList() {
                 selected={selectedIds.has(entry.key)}
                 onSelect={() => handleToggleSelect(entry.key)}
                 isReviewed={reviewedIdsSet.has(entry.key)}
+                aiScoreFeedback={getAiFeedback(entry.key, 'ai_score')}
+                onAiFeedback={(target, sentiment) => handleAiFeedback(entry.key, target, sentiment)}
               />
             )
           })
@@ -263,6 +269,9 @@ export function ResumeList() {
             setDetailResume(null)
           }
         }}
+        aiScoreFeedback={detailKey ? getAiFeedback(detailKey, 'ai_score') : undefined}
+        aiSummaryFeedback={detailKey ? getAiFeedback(detailKey, 'ai_summary') : undefined}
+        onAiFeedback={detailKey ? (target, sentiment) => handleAiFeedback(detailKey, target, sentiment) : undefined}
       />
 
       <SearchHistoryDialog

--- a/apps/web/src/hooks/useCandidateActions.test.ts
+++ b/apps/web/src/hooks/useCandidateActions.test.ts
@@ -1,0 +1,121 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { CandidateAction } from '@/types/resume'
+import { useCandidateActions } from './useCandidateActions'
+
+type ApiActionResponse = { data: { success: boolean; actions?: CandidateAction[] } }
+type ApiPostResponse = { data: { success: boolean; action?: CandidateAction } }
+
+const mockApiClient = vi.hoisted(() => ({
+  GET: vi.fn(async (): Promise<ApiActionResponse> => ({
+    data: {
+      success: true,
+      actions: [],
+    },
+  })),
+  POST: vi.fn(async (): Promise<ApiPostResponse> => ({
+    data: {
+      success: true,
+      action: { id: 1, resumeId: 'r-1', actionType: 'star' as const, createdAt: '2026-01-01' },
+    },
+  })),
+}))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: mockApiClient,
+}))
+
+describe('useCandidateActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads and separates regular actions from AI feedback actions', async () => {
+    mockApiClient.GET.mockResolvedValueOnce({
+      data: {
+        success: true,
+        actions: [
+          { id: 1, resumeId: 'r-1', actionType: 'star' as const, createdAt: '2026-01-01' },
+          { id: 2, resumeId: 'r-1', actionType: 'ai_score_like' as const, createdAt: '2026-01-01' },
+          { id: 3, resumeId: 'r-2', actionType: 'ai_summary_unlike' as const, createdAt: '2026-01-01' },
+        ],
+      },
+    })
+
+    const { result } = renderHook(() => useCandidateActions('session-1'))
+    await act(async () => {})
+
+    expect(result.current.actions).toEqual({ 'r-1': 'star' })
+    expect(result.current.getAiFeedback('r-1', 'ai_score')).toBe('like')
+    expect(result.current.getAiFeedback('r-2', 'ai_summary')).toBe('unlike')
+    expect(result.current.getAiFeedback('r-1', 'ai_summary')).toBeUndefined()
+  })
+
+  it('saves AI feedback and updates local state', async () => {
+    mockApiClient.POST.mockResolvedValueOnce({
+      data: {
+        success: true,
+        action: { id: 10, resumeId: 'r-1', actionType: 'ai_score_like' as const, createdAt: '2026-01-01' },
+      },
+    })
+
+    const { result } = renderHook(() => useCandidateActions('session-1'))
+
+    await act(async () => {
+      await result.current.saveAction({
+        resumeId: 'r-1',
+        actionType: 'ai_score_like',
+      })
+    })
+
+    expect(result.current.getAiFeedback('r-1', 'ai_score')).toBe('like')
+    expect(result.current.actions['r-1']).toBeUndefined()
+  })
+
+  it('saves regular actions without affecting AI feedback', async () => {
+    mockApiClient.POST.mockResolvedValueOnce({
+      data: {
+        success: true,
+        action: { id: 11, resumeId: 'r-1', actionType: 'shortlist' as const, createdAt: '2026-01-01' },
+      },
+    })
+
+    const { result } = renderHook(() => useCandidateActions('session-1'))
+
+    await act(async () => {
+      await result.current.saveAction({
+        resumeId: 'r-1',
+        actionType: 'shortlist',
+      })
+    })
+
+    expect(result.current.actions['r-1']).toBe('shortlist')
+  })
+
+  it('clears all state when sessionId becomes undefined', async () => {
+    mockApiClient.GET.mockResolvedValueOnce({
+      data: {
+        success: true,
+        actions: [
+          { id: 1, resumeId: 'r-1', actionType: 'star' as const, createdAt: '2026-01-01' },
+          { id: 2, resumeId: 'r-1', actionType: 'ai_score_like' as const, createdAt: '2026-01-01' },
+        ],
+      },
+    })
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string | undefined }) => useCandidateActions(sessionId),
+      { initialProps: { sessionId: 'session-1' as string | undefined } }
+    )
+
+    await act(async () => {})
+
+    expect(result.current.actions['r-1']).toBe('star')
+    expect(result.current.getAiFeedback('r-1', 'ai_score')).toBe('like')
+
+    rerender({ sessionId: undefined })
+
+    expect(result.current.actions).toEqual({})
+    expect(result.current.getAiFeedback('r-1', 'ai_score')).toBeUndefined()
+  })
+})

--- a/apps/web/src/hooks/useCandidateActions.ts
+++ b/apps/web/src/hooks/useCandidateActions.ts
@@ -1,9 +1,32 @@
 import { useCallback, useEffect, useState } from 'react'
 import { rawApiClient } from '@/lib/api-helpers'
-import type { CandidateAction, CandidateActionType } from '@/types/resume'
+import {
+  actionToAiFeedback,
+  type AiFeedbackSentiment,
+  type AiFeedbackState,
+  type AiFeedbackTarget,
+  type CandidateAction,
+  type CandidateActionType,
+} from '@/types/resume'
 
-export function useCandidateActions(sessionId?: string) {
-  const [actions, setActions] = useState<Record<string, CandidateActionType>>({})
+function setFeedbackState(
+  current: Record<string, AiFeedbackState>,
+  resumeId: string,
+  target: AiFeedbackTarget,
+  sentiment: AiFeedbackSentiment
+): Record<string, AiFeedbackState> {
+  return {
+    ...current,
+    [resumeId]: {
+      ...current[resumeId],
+      [target === 'ai_score' ? 'score' : 'summary']: sentiment,
+    },
+  }
+}
+
+export function useCandidateActions(sessionId?: string, jobDescriptionId?: string) {
+  const [actionsByResume, setActionsByResume] = useState<Record<string, CandidateActionType>>({})
+  const [aiFeedbackByResume, setAiFeedbackByResume] = useState<Record<string, AiFeedbackState>>({})
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -19,6 +42,7 @@ export function useCandidateActions(sessionId?: string) {
       params: {
         query: {
           sessionId,
+          jobDescriptionId,
           latestOnly: 'true',
         },
       },
@@ -30,27 +54,42 @@ export function useCandidateActions(sessionId?: string) {
       return
     }
 
-    const map: Record<string, CandidateActionType> = {}
-    ;(data.actions as CandidateAction[]).forEach((action) => {
-      map[action.resumeId] = action.actionType
+    const nextActionsByResume: Record<string, CandidateActionType> = {}
+    let nextAiFeedbackByResume: Record<string, AiFeedbackState> = {}
+
+    ;(data.actions ?? []).forEach((action) => {
+      const feedback = actionToAiFeedback(action.actionType)
+      if (feedback) {
+        nextAiFeedbackByResume = setFeedbackState(
+          nextAiFeedbackByResume,
+          action.resumeId,
+          feedback.target,
+          feedback.sentiment
+        )
+        return
+      }
+
+      nextActionsByResume[action.resumeId] = action.actionType
     })
 
-    setActions(map)
+    setActionsByResume(nextActionsByResume)
+    setAiFeedbackByResume(nextAiFeedbackByResume)
     setLoading(false)
-  }, [sessionId])
+  }, [jobDescriptionId, sessionId])
 
   const saveAction = useCallback(
     async (payload: { resumeId: string; actionType: CandidateActionType; actionData?: Record<string, unknown> }) => {
       if (!sessionId) return null
-    const { data, error: apiError } = await rawApiClient.POST<{
-      success: boolean
-      action?: CandidateAction
-    }>('/api/actions', {
-      body: {
-        sessionId,
-        resumeId: payload.resumeId,
-        actionType: payload.actionType,
-        actionData: payload.actionData,
+
+      const { data, error: apiError } = await rawApiClient.POST<{
+        success: boolean
+        action?: CandidateAction
+      }>('/api/actions', {
+        body: {
+          sessionId,
+          resumeId: payload.resumeId,
+          actionType: payload.actionType,
+          actionData: payload.actionData,
         },
       })
 
@@ -59,31 +98,53 @@ export function useCandidateActions(sessionId?: string) {
         return null
       }
 
-      setActions((prev) => ({
-        ...prev,
-        [payload.resumeId]: payload.actionType,
-      }))
+      const feedback = actionToAiFeedback(payload.actionType)
+      if (feedback) {
+        setAiFeedbackByResume((prev) =>
+          setFeedbackState(prev, payload.resumeId, feedback.target, feedback.sentiment)
+        )
+      } else {
+        setActionsByResume((prev) => ({
+          ...prev,
+          [payload.resumeId]: payload.actionType,
+        }))
+      }
 
       return data.action ?? null
     },
     [sessionId]
   )
 
+  const getAiFeedback = useCallback(
+    (resumeId: string, target: AiFeedbackTarget): AiFeedbackSentiment | undefined => {
+      const feedback = aiFeedbackByResume[resumeId]
+      if (!feedback) {
+        return undefined
+      }
+      return target === 'ai_score' ? feedback.score : feedback.summary
+    },
+    [aiFeedbackByResume]
+  )
+
   useEffect(() => {
-    loadActions()
+    void loadActions()
   }, [loadActions])
 
   useEffect(() => {
     if (!sessionId) {
-      setActions({})
+      setActionsByResume({})
+      setAiFeedbackByResume({})
     }
   }, [sessionId])
 
   return {
-    actions,
+    actions: actionsByResume,
+    actionsByResume,
+    aiFeedbackByResume,
     loading,
     error,
     reload: loadActions,
     saveAction,
+    getAiFeedback,
   }
 }

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -111,7 +111,9 @@ vi.mock('@/hooks/useConvexResumes', () => ({
 vi.mock('@/hooks/useCandidateActions', () => ({
   useCandidateActions: () => ({
     actions: {},
+    aiFeedbackByResume: {},
     saveAction: mockState.saveAction,
+    getAiFeedback: () => undefined,
   }),
 }))
 

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -20,7 +20,15 @@ import {
 import { rawApiClient } from '@/lib/api-helpers'
 import { expandKeyword, DEFAULT_CONFIG } from '@/lib/trendradar/parser'
 import type { SearchHistoryItem } from '@/hooks/useSession'
-import type { CandidateActionType, CandidateStatus, MatchingResult, ResumeFilters } from '@/types/resume'
+import {
+  aiFeedbackToActionType,
+  type AiFeedbackSentiment,
+  type AiFeedbackTarget,
+  type CandidateActionType,
+  type CandidateStatus,
+  type MatchingResult,
+  type ResumeFilters,
+} from '@/types/resume'
 import {
   buildLearningObservation,
   buildResumeKey,
@@ -437,7 +445,16 @@ export function useResumeListState(loadSearchHistory = false) {
     jobDescriptionId,
   })
 
-  const { actions, saveAction } = useCandidateActions(undefined)
+  const sessionActionScope = useMemo(() => {
+    const normalizedJobDescriptionId = jobDescriptionId?.trim()
+    const normalizedKeywords = sessionKeywords
+      .map((keyword) => keyword.trim())
+      .filter((keyword) => keyword.length > 0)
+      .sort()
+    return normalizedJobDescriptionId || normalizedKeywords.join('|') || 'global'
+  }, [jobDescriptionId, sessionKeywords])
+
+  const { actions, saveAction, getAiFeedback } = useCandidateActions(sessionActionScope, jobDescriptionId)
   const { blocksByIdentity, blockCandidates, unblockCandidate } = useCandidateBlocks()
   const { statusByIdentity, updateStatus: updateCandidateStatus } = useCandidateStatus()
 
@@ -1112,7 +1129,7 @@ export function useResumeListState(loadSearchHistory = false) {
   }, [])
 
   const handleBulkAction = useCallback(
-    async (action: 'shortlist' | 'reject' | 'star' | 'block' | 'export', format?: ResumeExportFormat) => {
+    async (action: 'shortlist' | 'reject' | 'star' | 'block' | 'export', format?: ResumeExportFormat, exportMeta?: { userComment: string; referenceNote: string }) => {
       if (selectedIds.size === 0) return
 
       const selectedEntries = displayedResumes.filter((entry) => selectedIds.has(entry.key))
@@ -1149,6 +1166,8 @@ export function useResumeListState(loadSearchHistory = false) {
             body: JSON.stringify({
               format: exportFormat,
               entries: exportEntries,
+              userComment: exportMeta?.userComment ?? '',
+              referenceNote: exportMeta?.referenceNote ?? '',
             }),
           })
 
@@ -1247,6 +1266,32 @@ export function useResumeListState(loadSearchHistory = false) {
         })
     },
     [actionFeedbackLabels, displayedResumeMap, saveAction, sendLearningFeedback]
+  )
+
+  const handleAiFeedback = useCallback(
+    (resumeId: string, target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => {
+      void saveAction({
+        resumeId,
+        actionType: aiFeedbackToActionType(target, sentiment),
+        actionData: {
+          target,
+          sentiment,
+          jobDescriptionId: jobDescriptionId ?? undefined,
+        },
+      })
+        .then((result) => {
+          if (result) {
+            toast.success(t('feedback.saved', { defaultValue: 'Feedback saved' }))
+          } else {
+            toast.error(t('feedback.failed', { defaultValue: 'Failed to save feedback' }))
+          }
+        })
+        .catch((error: unknown) => {
+          console.error('AI feedback save failed', error)
+          toast.error(t('feedback.failed', { defaultValue: 'Failed to save feedback' }))
+        })
+    },
+    [jobDescriptionId, saveAction, t]
   )
 
   const handleToggleBlock = useCallback(
@@ -1434,6 +1479,8 @@ export function useResumeListState(loadSearchHistory = false) {
     handleToggleSelect,
     handleBulkAction,
     handleCardAction,
+    handleAiFeedback,
+    getAiFeedback,
     handleToggleBlock,
     handleCandidateStatusChange,
     handleResetAll,

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -1692,6 +1692,7 @@ export interface paths {
             parameters: {
                 query: {
                     sessionId: string;
+                    jobDescriptionId?: string;
                     latestOnly?: string;
                 };
                 header?: never;
@@ -1715,7 +1716,7 @@ export interface paths {
                                 sessionId?: string;
                                 resumeId: string;
                                 /** @enum {string} */
-                                actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact";
+                                actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
                                 actionData?: {
                                     [key: string]: unknown;
                                 };
@@ -1742,7 +1743,7 @@ export interface paths {
                         sessionId?: string;
                         resumeId: string;
                         /** @enum {string} */
-                        actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact";
+                        actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
                         actionData?: {
                             [key: string]: unknown;
                         };
@@ -1765,7 +1766,7 @@ export interface paths {
                                 sessionId?: string;
                                 resumeId: string;
                                 /** @enum {string} */
-                                actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact";
+                                actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
                                 actionData?: {
                                     [key: string]: unknown;
                                 };

--- a/apps/web/src/types/resume.ts
+++ b/apps/web/src/types/resume.ts
@@ -99,7 +99,60 @@ export type MatchStats = {
   processingTimeMs?: number
 }
 
-export type CandidateActionType = 'star' | 'shortlist' | 'reject' | 'archive' | 'note' | 'contact'
+export type AiFeedbackTarget = 'ai_score' | 'ai_summary'
+export type AiFeedbackSentiment = 'like' | 'unlike'
+
+export type AiFeedbackState = {
+  score?: AiFeedbackSentiment
+  summary?: AiFeedbackSentiment
+}
+
+export type CandidateActionType =
+  | 'star'
+  | 'shortlist'
+  | 'reject'
+  | 'archive'
+  | 'note'
+  | 'contact'
+  | 'ai_score_like'
+  | 'ai_score_unlike'
+  | 'ai_summary_like'
+  | 'ai_summary_unlike'
+
+export const AI_FEEDBACK_ACTION_TYPES = {
+  ai_score: {
+    like: 'ai_score_like',
+    unlike: 'ai_score_unlike',
+  },
+  ai_summary: {
+    like: 'ai_summary_like',
+    unlike: 'ai_summary_unlike',
+  },
+} as const satisfies Record<AiFeedbackTarget, Record<AiFeedbackSentiment, CandidateActionType>>
+
+export function actionToAiFeedback(
+  actionType: CandidateActionType
+): { target: AiFeedbackTarget; sentiment: AiFeedbackSentiment } | null {
+  switch (actionType) {
+    case 'ai_score_like':
+      return { target: 'ai_score', sentiment: 'like' }
+    case 'ai_score_unlike':
+      return { target: 'ai_score', sentiment: 'unlike' }
+    case 'ai_summary_like':
+      return { target: 'ai_summary', sentiment: 'like' }
+    case 'ai_summary_unlike':
+      return { target: 'ai_summary', sentiment: 'unlike' }
+    default:
+      return null
+  }
+}
+
+export function aiFeedbackToActionType(
+  target: AiFeedbackTarget,
+  sentiment: AiFeedbackSentiment
+): CandidateActionType {
+  return AI_FEEDBACK_ACTION_TYPES[target][sentiment]
+}
 
 export type CandidateAction = {
   id: number


### PR DESCRIPTION
## Summary
- add JD/session-scoped AI score and summary feedback actions across the API and web UI
- add export dialog support for batch comment/reference note metadata and include those columns in CSV/XLSX output
- add focused backend/frontend regression coverage and regenerate the web API types

## Validation
- bunx vitest run apps/api/src/services/action-storage.test.ts apps/api/src/services/export-service.test.ts
- cd apps/web && bunx vitest run src/hooks/useCandidateActions.test.ts src/hooks/useResumeListState.test.tsx src/components/ExportDialog.test.tsx
- make check