### PR TITLE
refactor(resumes): rely on work history for strict matching

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -467,8 +467,6 @@ function computeStats(
 function createFallbackIndex(resume: ResumeItem, resumeId: string): ResumeIndex {
   const text = [
     resume.name,
-    resume.jobIntention,
-    resume.selfIntro,
     resume.location,
     resume.education,
     ...(resume.workHistory ?? []).map((item) => item.raw),
@@ -476,14 +474,15 @@ function createFallbackIndex(resume: ResumeItem, resumeId: string): ResumeIndex 
 
   return {
     resumeId,
-    experienceYears: parseExperienceYears(resume.experience),
+    experienceYears: null,
     educationLevel: resume.education || null,
     locationCity: resume.location || null,
-    skills: extractSkills(resume.jobIntention, resume.selfIntro) ?? [],
+    skills: [],
     companies: extractCompanies(resume.workHistory) ?? [],
     industryTags: [],
     salaryRange: null,
     searchText: text,
+    evidenceText: buildWorkHistoryEvidence(resume.workHistory).text,
   };
 }
 
@@ -497,7 +496,7 @@ function buildAiResumePayload(item: {
     name: item.resume.name || "未命名",
     workExperience: item.indexData.experienceYears ?? undefined,
     education: item.resume.education || undefined,
-    skills: item.indexData.skills.length > 0 ? item.indexData.skills : extractSkills(item.resume.jobIntention, item.resume.selfIntro),
+    skills: item.indexData.skills,
     companies: item.indexData.companies.length > 0 ? item.indexData.companies : extractCompanies(item.resume.workHistory),
     workHistory: buildWorkHistoryEvidence(item.resume.workHistory).lines.join("\n") || undefined,
   };

--- a/apps/api/src/services/industry-data-service.ts
+++ b/apps/api/src/services/industry-data-service.ts
@@ -187,7 +187,7 @@ function mapBrandOrigin(sectionName: string): BrandEntry["origin"] {
 // Pre-lowercased CNC industry patterns for fallback matching
 const CNC_INDUSTRY_PATTERNS = [
     "机床", "数控", "cnc", "加工中心", "车床", "铣床", "磨床",
-    "机械", "模具", "精密", "自动化", "五金", "金属加工",
+    "机械", "模具", "自动化", "金属加工",
     "刀具", "夹具", "量具", "测量", "三坐标",
 ].map((p) => p.toLowerCase());
 

--- a/apps/api/src/services/ingest-compute-service.test.ts
+++ b/apps/api/src/services/ingest-compute-service.test.ts
@@ -232,25 +232,25 @@ describe("IngestComputeService", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("should compute industryTags for CNC sales resume", () => {
+  it("should compute industryTags from work history evidence only", () => {
     const result = service.computeOne("resume-123", SAMPLE_RESUME_CNC_SALES);
 
-    expect(result.industryTags).toContain("machinery");
     expect(result.industryTags).toContain("cnc");
     expect(result.industryTags).toContain("sales");
+    expect(result.industryTags).not.toContain("machinery");
   });
 
-  it("should compute synonymHits for CNC sales resume", () => {
+  it("should compute synonymHits from work history evidence only", () => {
     const result = service.computeOne("resume-123", SAMPLE_RESUME_CNC_SALES);
 
     expect(result.synonymHits).toEqual(expect.arrayContaining([
-      "车床",
-      "cnc车床",
-      "数控车床",
       "销售",
       "业务",
       "商务",
     ]));
+    expect(result.synonymHits).not.toContain("车床");
+    expect(result.synonymHits).not.toContain("cnc车床");
+    expect(result.synonymHits).not.toContain("数控车床");
   });
 
   it("should compute ruleScores for all active JDs", () => {
@@ -265,10 +265,10 @@ describe("IngestComputeService", () => {
     expect(result.primaryRuleScore).toBe(maxScore);
   });
 
-  it("should detect senior experience level", () => {
+  it("should not derive senior experience level from selfIntro", () => {
     const result = service.computeOne("resume-123", SAMPLE_RESUME_CNC_SALES);
 
-    expect(result.experienceLevel).toBe("senior");  // has "团队管理", "大客户"
+    expect(result.experienceLevel).toBe("unknown");
   });
 
   it("should detect junior experience level", () => {
@@ -285,13 +285,15 @@ describe("IngestComputeService", () => {
     expect(result.skillsVersion).toBe(42);  // from TEST_SKILLS_MD
   });
 
-  it("should compute role signals from work history", () => {
+  it("should compute role signals and experience years from work history", () => {
     const result = service.computeOne("resume-123", SAMPLE_RESUME_CNC_SALES);
     const salesRole = result.roleSignals.find((item) => item.type === "sales");
+    const index = buildResumeIndex(SAMPLE_RESUME_CNC_SALES.data[0], 0);
 
     expect(salesRole).toBeDefined();
     expect(salesRole?.signalCount).toBeGreaterThan(0);
     expect(salesRole?.years).toBeGreaterThan(0);
+    expect(index.experienceYears).toBeCloseTo(6.5, 1);
     expect(result.ruleScores["jd-lathe-sales"]).toBeGreaterThan(50);
   });
 
@@ -329,16 +331,15 @@ describe("IngestComputeService", () => {
     expect(roleTag?.source).toBe("rule");
     expect(roleTag?.evidence).toEqual(expect.arrayContaining(["roleType:sales"]));
 
-    expect(companyTag).toBeDefined();
-    expect(companyTag?.evidence.some((entry) => entry.startsWith("brandSource:"))).toBe(true);
+    expect(companyTag).toBeUndefined();
 
     expect(taggingIndustryTag?.provenance.stage).toBe("industry_taxonomy");
     expect(taggingIndustryTag?.provenance.generatedBy).toBe("ingest-compute-service");
     expect(taggingRoleTag?.provenance.stage).toBe("role_signal_aggregation");
-    expect(taggingCompanyTag?.provenance.stage).toBe("company_pattern_match");
+    expect(taggingCompanyTag).toBeUndefined();
   });
 
-  it("should classify selfIntro brand mentions as equipment context", () => {
+  it("should ignore selfIntro brand mentions in processing", () => {
     const equipmentResume = {
       data: [
         {
@@ -351,12 +352,7 @@ describe("IngestComputeService", () => {
     };
     const result = service.computeOne("resume-equipment", equipmentResume);
 
-    expect(result.brandHits).toContainEqual({
-      brand: "fanuc",
-      role: "both",
-      source: "selfIntro",
-      context: "equipment",
-    });
+    expect(result.brandHits).toEqual([]);
   });
 
   it("should classify workHistory brand mentions as employer context", () => {
@@ -381,7 +377,7 @@ describe("IngestComputeService", () => {
     });
   });
 
-  it("should classify STAR sales mention as sales context", () => {
+  it("should ignore selfIntro sales brand mentions in processing", () => {
     const salesResume = {
       data: [
         {
@@ -394,15 +390,10 @@ describe("IngestComputeService", () => {
     };
     const result = service.computeOne("resume-sales", salesResume);
 
-    expect(result.brandHits).toContainEqual({
-      brand: "star",
-      role: "both",
-      source: "selfIntro",
-      context: "sales",
-    });
+    expect(result.brandHits).toEqual([]);
   });
 
-  it("should dedupe repeated brand mentions in same source/context", () => {
+  it("should not emit brand hits from selfIntro only content", () => {
     const dedupeResume = {
       data: [
         {
@@ -414,25 +405,22 @@ describe("IngestComputeService", () => {
     };
     const result = service.computeOne("resume-dedupe", dedupeResume);
 
-    const fanucEquipmentHits = result.brandHits.filter((hit) =>
-      hit.brand === "fanuc" && hit.source === "selfIntro" && hit.context === "equipment"
-    );
-    expect(fanucEquipmentHits).toHaveLength(1);
+    expect(result.brandHits).toEqual([]);
   });
 
-  it("should compute companyHits and alias tokens from STAR mention", () => {
+  it("should not compute companyHits from selfIntro-only brand mentions", () => {
     const result = service.computeOne("resume-123", SAMPLE_RESUME_CNC_SALES);
 
-    expect(result.companyHits).toContain("star");
+    expect(result.companyHits).toEqual([]);
     expect(result.companyHits).toEqual(Array.from(new Set(result.brandHits.map((hit) => hit.brand))));
-    expect(result.companyAliasTokens).toContain("スター精密");
+    expect(result.companyAliasTokens).toBe("");
   });
 
-  it("should match HAAS aliases across languages", () => {
+  it("should not match HAAS aliases from excluded fields", () => {
     const result = service.computeOne("resume-789", SAMPLE_RESUME_HAAS);
 
-    expect(result.companyHits).toContain("haas");
-    expect(result.companyAliasTokens).toContain("haas automation");
+    expect(result.companyHits).toEqual([]);
+    expect(result.companyAliasTokens).toBe("");
   });
 
   it("should return empty company matches for unknown brands", () => {
@@ -461,7 +449,7 @@ describe("IngestComputeService", () => {
     expect(results).toHaveLength(2);
     expect(results[0].resumeId).toBe("resume-123");
     expect(results[1].resumeId).toBe("resume-456");
-    expect(results[0].experienceLevel).toBe("senior");
+    expect(results[0].experienceLevel).toBe("unknown");
     expect(results[1].experienceLevel).toBe("junior");
     expect(results.every((item) => Array.isArray(item.brandHits))).toBe(true);
     expect(results.every((item) => Array.isArray(item.companyHits))).toBe(true);
@@ -495,8 +483,10 @@ describe("IngestComputeService", () => {
     };
 
     const result = service.computeOne("resume-789", noHistory);
+    const index = buildResumeIndex(noHistory.data[0], 0);
 
     expect(result.evidenceText).toBe("");
+    expect(index.experienceYears).toBeNull();
     expect(result.industryTags).toBeDefined();
     expect(result.ruleScores).toBeDefined();
   });
@@ -514,6 +504,8 @@ describe("IngestComputeService", () => {
 
     expect(index.evidenceText).toBe(buildWorkHistoryEvidence(item).text);
     expect(index.evidenceText).toBe("2020-2025 sales engineer\ncnc 机床");
+    expect(index.searchText).not.toContain("应届毕业生");
+    expect(index.searchText).not.toContain("机械助理");
   });
 
   it("should throw error for invalid content", () => {

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -5,6 +5,7 @@ import { SkillsKnowledgeService } from "./skills-knowledge.js";
 import { JobDescriptionService } from "./job-description-service.js";
 import { RuleScoringService, type RoleSignalSummary } from "./rule-scoring.js";
 import { resolveResumeId } from "./resume-id.js";
+import { computeWorkHistoryYears, parseRoleYears } from "./work-history.js";
 import type { ResumeItem, ResumeWorkHistoryItem } from "../types/resume.js";
 import type { ResumeIndex } from "./resume-index.js";
 
@@ -176,19 +177,6 @@ function normalizeEducationLevel(value: string): string | null {
   return null;
 }
 
-function parseExperienceYears(value: string): number | null {
-  if (!value) return null;
-  const normalized = value.trim();
-  if (!normalized) return null;
-  if (/应届|无经验/.test(normalized)) return 0;
-  const match = normalized.match(/(\d+)(?:\s*[-~到至]\s*(\d+))?/);
-  if (!match) return null;
-  const min = Number(match[1]);
-  const max = match[2] ? Number(match[2]) : min;
-  if (Number.isNaN(max)) return null;
-  return max;
-}
-
 function parseSalaryRange(value: string): { min?: number; max?: number } | null {
   if (!value) return null;
   const normalized = value.replace(/\s+/g, "").toLowerCase();
@@ -252,8 +240,6 @@ function extractCompanies(workHistory: ResumeWorkHistoryItem[]): string[] {
 function createSearchText(item: ResumeItem): string {
   const parts = [
     item.name,
-    item.jobIntention,
-    item.selfIntro,
     item.education,
     item.expectedSalary,
     ...(item.workHistory?.map((entry) => entry.raw) ?? []),
@@ -304,7 +290,7 @@ export function buildResumeIndex(item: ResumeItem, index: number): ResumeIndex {
   // We just need the basic fields for rule scoring
   return {
     resumeId,
-    experienceYears: parseExperienceYears(item.experience),
+    experienceYears: computeWorkHistoryYears(item.workHistory),
     educationLevel: normalizeEducationLevel(item.education),
     locationCity: item.location || null,
     evidenceText,
@@ -465,38 +451,6 @@ export class IngestComputeService {
     return scores;
   }
 
-  private parseRoleYears(raw: string): number {
-    const text = raw.trim();
-    if (!text) {
-      return 0;
-    }
-
-    const explicitDuration = text.match(/\((\d+)\s*年(?:(\d+)\s*月)?\)/u);
-    if (explicitDuration) {
-      const years = Number(explicitDuration[1] || 0);
-      const months = Number(explicitDuration[2] || 0);
-      if (Number.isFinite(years) && Number.isFinite(months)) {
-        return years + (months / 12);
-      }
-    }
-
-    const range = text.match(/(\d{4})[-./年](\d{1,2})?.*?[~至到-]\s*(\d{4})(?:[-./年](\d{1,2}))?/u);
-    if (range) {
-      const startYear = Number(range[1]);
-      const startMonth = Number(range[2] || 1);
-      const endYear = Number(range[3]);
-      const endMonth = Number(range[4] || 1);
-
-      if ([startYear, startMonth, endYear, endMonth].every((value) => Number.isFinite(value))) {
-        const monthDiff = (endYear - startYear) * 12 + (endMonth - startMonth);
-        if (monthDiff > 0) {
-          return monthDiff / 12;
-        }
-      }
-    }
-
-    return 0;
-  }
 
   private computeRoleSignals(workHistory: ResumeWorkHistoryItem[]): RoleSignalSummary[] {
     if (!Array.isArray(workHistory) || workHistory.length === 0) {
@@ -517,7 +471,7 @@ export class IngestComputeService {
       }
 
       const normalized = raw.toLowerCase();
-      const years = this.parseRoleYears(raw);
+      const years = parseRoleYears(raw);
 
       // Extract company name and verify industry
       const companyName = extractCompanyFromEntry(raw);
@@ -823,23 +777,6 @@ export class IngestComputeService {
       if (!aliases.some((alias) => normalizedSearchText.includes(alias))) {
         continue;
       }
-
-      collectFromSource(
-        "selfIntro",
-        item.selfIntro || "",
-        normalizedCompanies,
-        pattern.name.toLowerCase(),
-        pattern.role,
-        aliases
-      );
-      collectFromSource(
-        "jobIntention",
-        item.jobIntention || "",
-        normalizedCompanies,
-        pattern.name.toLowerCase(),
-        pattern.role,
-        aliases
-      );
 
       for (const entry of item.workHistory || []) {
         const entryCompanies = extractCompanies([entry])

--- a/apps/api/src/services/resume-index.test.ts
+++ b/apps/api/src/services/resume-index.test.ts
@@ -73,14 +73,16 @@ describe("ResumeIndexService", () => {
       const entry = index.get("R1001");
 
       expect(entry).toBeDefined();
-      expect(entry?.experienceYears).toBe(5);
+      expect(entry?.experienceYears).toBeCloseTo(3, 5);
       expect(entry?.educationLevel).toBe("bachelor");
       expect(entry?.locationCity).toBe("东莞");
-      expect(entry?.skills.some((skill) => skill.includes("cnc") || skill.includes("车床"))).toBe(true);
+      expect(entry?.skills.some((skill) => skill.includes("销售") || skill.includes("车床"))).toBe(true);
       expect(entry?.companies.some((company) => company.includes("机械设备"))).toBe(true);
       expect(entry?.industryTags).toContain("machinery");
       expect(entry?.industryTags).toContain("sales");
       expect(entry?.evidenceText).toBe(buildWorkHistoryEvidence(resumes[0]?.workHistory).text);
+      expect(entry?.searchText).not.toContain("熟悉cnc车床和设备销售");
+      expect(entry?.searchText).not.toContain("东莞 车床 销售 cnc");
       expect(entry?.salaryRange?.min).toBe(12000);
       expect(entry?.salaryRange?.max).toBe(18000);
     } finally {

--- a/apps/api/src/services/resume-index.ts
+++ b/apps/api/src/services/resume-index.ts
@@ -7,6 +7,7 @@ import { findProjectRoot } from "./db.js";
 import { JobDescriptionService } from "./job-description-service.js";
 import { SkillsKnowledgeService } from "./skills-knowledge.js";
 import { resolveResumeId } from "./resume-id.js";
+import { computeWorkHistoryYears } from "./work-history.js";
 
 import type { ResumeItem, ResumeWorkHistoryItem } from "../types/resume.js";
 
@@ -64,19 +65,6 @@ function normalizeEducationLevel(value: string): string | null {
   return null;
 }
 
-function parseExperienceYears(value: string): number | null {
-  if (!value) return null;
-  const normalized = value.trim();
-  if (!normalized) return null;
-  if (/应届|无经验/.test(normalized)) return 0;
-  const match = normalized.match(/(\d+)(?:\s*[-~到至]\s*(\d+))?/);
-  if (!match) return null;
-  const min = Number(match[1]);
-  const max = match[2] ? Number(match[2]) : min;
-  if (Number.isNaN(max)) return null;
-  return max;
-}
-
 function parseSalaryRange(value: string): { min?: number; max?: number } | null {
   if (!value) return null;
   const normalized = value.replace(/\s+/g, "").toLowerCase();
@@ -99,15 +87,6 @@ function parseSalaryRange(value: string): { min?: number; max?: number } | null 
   }
 
   return { min, max };
-}
-
-function extractTokenCandidates(text: string): string[] {
-  if (!text.trim()) return [];
-  const segments = text.match(/[\u4e00-\u9fa5]{2,}|[a-z0-9+#.-]{2,}/gi) ?? [];
-  return segments
-    .map((item) => item.toLowerCase())
-    .filter((item) => item.length >= 2)
-    .filter((item) => item.length <= 24);
 }
 
 function normalizeCompanyName(raw: string): string {
@@ -143,8 +122,6 @@ function extractCompanies(workHistory: ResumeWorkHistoryItem[]): string[] {
 function createSearchText(item: ResumeItem): string {
   const parts = [
     item.name,
-    item.jobIntention,
-    item.selfIntro,
     item.education,
     item.location,
     item.expectedSalary,
@@ -273,17 +250,8 @@ export class ResumeIndexService {
     return fallback?.[0] ?? null;
   }
 
-  private extractSkills(item: ResumeItem, searchText: string): string[] {
+  private extractSkills(searchText: string): string[] {
     const skills = new Set<string>();
-
-    const intentionTokens = extractTokenCandidates(item.jobIntention || "");
-    const summaryTokens = extractTokenCandidates(item.selfIntro || "");
-    for (const token of intentionTokens.slice(0, 30)) {
-      skills.add(token);
-    }
-    for (const token of summaryTokens.slice(0, 30)) {
-      skills.add(token);
-    }
 
     for (const keyword of this.skillVocabulary) {
       if (searchText.includes(keyword)) {
@@ -311,14 +279,14 @@ export class ResumeIndexService {
       const resumeId = resolveResumeId(item, i);
       const searchText = createSearchText(item);
       const companies = extractCompanies(item.workHistory ?? []);
-      const skills = this.extractSkills(item, searchText);
+      const skills = this.extractSkills(searchText);
       const tagHaystack = [searchText, ...skills, ...companies].join(" ").toLowerCase();
 
       const evidenceText = buildWorkHistoryEvidence(item.workHistory).text;
 
       nextMap.set(resumeId, {
         resumeId,
-        experienceYears: parseExperienceYears(item.experience),
+        experienceYears: computeWorkHistoryYears(item.workHistory ?? []),
         educationLevel: normalizeEducationLevel(item.education),
         locationCity: this.extractLocationCity(item.location || ""),
         evidenceText,

--- a/apps/api/src/services/rule-scoring.test.ts
+++ b/apps/api/src/services/rule-scoring.test.ts
@@ -337,6 +337,7 @@ describe("RuleScoringService", () => {
         experienceYears: 3,
         educationLevel: "bachelor",
         locationCity: "东莞",
+        evidenceText: "cnc 车床 销售",
         skills: ["cnc"],
         companies: [],
         industryTags: ["cnc"],
@@ -620,6 +621,50 @@ describe("RuleScoringService", () => {
       expect(selfIntroOnlyResult.breakdown.brandRelevance).toBe(0);
       expect(workHistoryResult.breakdown.brandRelevance).toBe(4);
       expect(workHistoryResult.score).toBeGreaterThan(selfIntroOnlyResult.score);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("does not reward cnc mentions that appear only in self intro", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new RuleScoringService(root);
+      const context = service.buildContextFromKeywords(["cnc", "车床", "销售"], "东莞");
+      const misleadingCandidate: ResumeIndex = {
+        resumeId: "R-chen-regression",
+        experienceYears: 1,
+        educationLevel: "associate",
+        locationCity: "东莞",
+        evidenceText: "2024-2025 普通贸易公司 跟单员 客户维护",
+        skills: [],
+        companies: ["普通贸易公司"],
+        industryTags: [],
+        salaryRange: { min: 7000, max: 9000 },
+        searchText: "东莞 cnc 车床 销售 熟悉cnc加工与star fanuc品牌",
+      };
+      const verifiedCandidate: ResumeIndex = {
+        resumeId: "R-verified-cnc",
+        experienceYears: 3,
+        educationLevel: "associate",
+        locationCity: "东莞",
+        evidenceText: "2021-2024 东莞机床公司 销售工程师 负责cnc车床销售与客户开发",
+        skills: ["cnc", "车床", "销售"],
+        companies: ["东莞机床公司"],
+        industryTags: ["cnc", "sales"],
+        salaryRange: { min: 9000, max: 12000 },
+        searchText: "东莞 cnc 车床 销售",
+      };
+
+      const misleadingResult = service.scoreResume(misleadingCandidate, context);
+      const verifiedResult = service.scoreResume(verifiedCandidate, context);
+
+      expect(misleadingResult.breakdown.skillMatch).toBe(0);
+      expect(misleadingResult.breakdown.industryMatch).toBe(0);
+      expect(verifiedResult.breakdown.skillMatch).toBeGreaterThan(misleadingResult.breakdown.skillMatch);
+      expect(verifiedResult.breakdown.industryMatch).toBeGreaterThan(misleadingResult.breakdown.industryMatch);
+      expect(verifiedResult.score).toBeGreaterThan(misleadingResult.score);
     } finally {
       cleanupFixtureRoot(root);
     }

--- a/apps/api/src/services/rule-scoring.ts
+++ b/apps/api/src/services/rule-scoring.ts
@@ -732,10 +732,15 @@ export class RuleScoringService {
       })
     );
 
+    const scoringText = (index.evidenceText || "").toLowerCase();
+    const scoringTokens = compactText(scoringText)
+      .split(/\s+/)
+      .filter((token) => token.length > 0);
+
     const matchedSkills = context.keywords.filter((keyword) => {
       const variants = keywordVariantMap.get(keyword) ?? [keyword];
       return variants.some((variant) =>
-        index.searchText.includes(variant) || index.skills.some((skill) => skill.includes(variant))
+        scoringText.includes(variant) || index.skills.some((skill) => skill.includes(variant))
       );
     });
 
@@ -802,12 +807,13 @@ export class RuleScoringService {
 
     const matchedIndustryKeywords = context.industryKeywords.filter((keyword) => {
       const variants = industryKeywordVariantMap.get(keyword) ?? [keyword];
-      return variants.some((variant) => index.searchText.includes(variant));
+      return variants.some((variant) => scoringText.includes(variant));
     });
     const keywordRatioBase = Math.max(1, Math.min(context.industryKeywords.length, 10));
     const keywordRatio = matchedIndustryKeywords.length / keywordRatioBase;
+    const localIndustryTags = inferIndustryTags(scoringTokens);
     const tagRatio = context.industryTags.length > 0
-      ? index.industryTags.filter((tag) => context.industryTags.includes(tag)).length / context.industryTags.length
+      ? localIndustryTags.filter((tag) => context.industryTags.includes(tag)).length / context.industryTags.length
       : 0;
     const industryRatio = Math.max(keywordRatio, tagRatio);
     const industryMatch = Math.round(Math.min(1, industryRatio) * categoryWeights.industryMatch);

--- a/apps/api/src/services/work-history.ts
+++ b/apps/api/src/services/work-history.ts
@@ -1,0 +1,43 @@
+import type { ResumeWorkHistoryItem } from "../types/resume.js";
+
+export function parseRoleYears(raw: string): number {
+  const text = raw.trim();
+  if (!text) {
+    return 0;
+  }
+
+  const explicitDuration = text.match(/\((\d+)\s*年(?:(\d+)\s*月)?\)/u);
+  if (explicitDuration) {
+    const years = Number(explicitDuration[1] || 0);
+    const months = Number(explicitDuration[2] || 0);
+    if (Number.isFinite(years) && Number.isFinite(months)) {
+      return years + (months / 12);
+    }
+  }
+
+  const range = text.match(/(\d{4})[-./年](\d{1,2})?.*?[~至到-]\s*(\d{4})(?:[-./年](\d{1,2}))?/u);
+  if (range) {
+    const startYear = Number(range[1]);
+    const startMonth = Number(range[2] || 1);
+    const endYear = Number(range[3]);
+    const endMonth = Number(range[4] || 1);
+
+    if ([startYear, startMonth, endYear, endMonth].every((value) => Number.isFinite(value))) {
+      const monthDiff = (endYear - startYear) * 12 + (endMonth - startMonth);
+      if (monthDiff > 0) {
+        return monthDiff / 12;
+      }
+    }
+  }
+
+  return 0;
+}
+
+export function computeWorkHistoryYears(workHistory: ResumeWorkHistoryItem[]): number | null {
+  if (!workHistory.length) return null;
+  let total = 0;
+  for (const entry of workHistory) {
+    total += parseRoleYears(entry.raw || "");
+  }
+  return total > 0 ? Number(total.toFixed(1)) : null;
+}

--- a/config/resume/skills.md
+++ b/config/resume/skills.md
@@ -1,6 +1,6 @@
 ---
-version: 4
-updated_at: '2026-02-27'
+version: 5
+updated_at: '2026-03-10'
 description: >
   Curated skill taxonomy, synonyms, and domain knowledge for resume screening.
   Used by the background ingest agent for deterministic matching and pre-scoring.
@@ -353,3 +353,4 @@ HR feedback patterns and observations. New entries are appended by the feedback 
 - 2026-02-24: shortlist pattern -> cnc + junior
 - 2026-03-02: shortlist_pattern: sales + software + mid -> high_priority
 - 2026-03-02: shortlist_pattern: sales + software + mid -> high_priority
+- 2026-03-10: processing pipeline now excludes selfIntro, jobIntention, and header experience from strict matching; work history is the sole evidence source for experience and scoring.

--- a/packages/convex/convex/search_text.ts
+++ b/packages/convex/convex/search_text.ts
@@ -1,9 +1,6 @@
 const PRIORITY_KEYS = [
     "name",
-    "jobIntention",
     "desiredPosition",
-    "selfIntro",
-    "experience",
     "education",
     "expectedSalary",
     "skills",


### PR DESCRIPTION
## Summary
- remove self intro, job intention, and header experience from strict resume processing inputs
- make indexing and rule scoring rely on work-history evidence for experience and matching
- add regression coverage and extract shared work-history tenure helpers

## Test plan
- [x] npm test -- apps/api/src/services/ingest-compute-service.test.ts
- [x] npm test -- apps/api/src/services/resume-index.test.ts
- [x] npm test -- apps/api/src/services/rule-scoring.test.ts
- [x] make check