### PR TITLE
fix(ingest): tighten jingdiao brand alias to prevent false company matches

### DIFF
--- a/config/resume/skills.md
+++ b/config/resume/skills.md
@@ -92,7 +92,7 @@ Known companies in the target industry with name variations. Used for company re
 - DOOSAN [role: both] (aliases: 斗山, 두산)
 - HYUNDAI WIA [role: both] (aliases: 现代威亚, 현대위아)
 - TSUGAMI [role: both] (aliases: 津上, つがみ)
-- JINGDIAO [role: both] (aliases: 北京精雕, 精雕)
+- JINGDIAO [role: both] (aliases: 北京精雕, 精雕科技, 精雕集团)
 
 Tier 1 - CNC/Machining
 - HARDINGE [role: both] (aliases: 哈挺, Hardinge)


### PR DESCRIPTION
## Summary
- Replace loose alias `精雕` with `精雕科技, 精雕集团` in brand Company Patterns
- Prevents false positive `companyHits: ['jingdiao']` on unrelated companies like "东莞精雕机械科技有限公司"
- The real brand is "北京精雕科技集团有限公司" — the short alias was matching any company with "精雕" in its name

## Test plan
- [x] All 214 tests pass across 35 files
- [x] Verified 朱先生's "东莞精雕机械科技有限公司" would no longer match `jingdiao` brand