### PR TITLE
fix(resume): restore AI score display and sorting priority

### DIFF
--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -163,9 +163,10 @@ export function ResumeCard({
     ? t('resumes.status.updatedAt', { date: new Date(candidateStatusMeta.updatedAt).toLocaleString() })
     : ''
 
-  // Rule score is the primary deterministic score; AI score is secondary
-  const effectiveScore = typeof ruleScore === 'number' && ruleScore > 0 ? ruleScore : score
-  const isRuleScore = typeof ruleScore === 'number' && ruleScore > 0
+  // AI score is primary when available; rule score is deterministic fallback
+  const hasAiScore = typeof score === 'number' && score > 0
+  const effectiveScore = hasAiScore ? score : (typeof ruleScore === 'number' && ruleScore > 0 ? ruleScore : score)
+  const isRuleScore = !hasAiScore && typeof ruleScore === 'number' && ruleScore > 0
 
   const scoreClassName =
     typeof effectiveScore === 'number'

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1047,8 +1047,9 @@ export function useResumeListState(loadSearchHistory = false) {
         return (parseExtractedAt(a.resume.extractedAt) - parseExtractedAt(b.resume.extractedAt)) * direction
       }
 
-      const scoreA = a.ruleScore || (a.match?.score ?? 0)
-      const scoreB = b.ruleScore || (b.match?.score ?? 0)
+      // AI score takes priority; fall back to rule score
+      const scoreA = a.match?.score ?? a.ruleScore ?? 0
+      const scoreB = b.match?.score ?? b.ruleScore ?? 0
       return (scoreA - scoreB) * direction
     })
   }, [enrichedResumes, filters.sortBy, filters.sortOrder])


### PR DESCRIPTION
## Summary
- Commit #152 made rule scores completely override AI scores — when `primaryRuleScore > 0`, AI scores were hidden and not used for sorting
- Restore AI score as primary display and sort key when AI analysis is available
- Rule score remains as deterministic fallback for resumes without AI analysis

## Changes
- `ResumeCard.tsx`: flip priority so AI score badge shows when AI analysis exists; rule badge only when no AI score
- `useResumeListState.ts`: sort by `match.score` (AI) first, fall back to `ruleScore`

## Test plan
- [ ] Verify resumes with AI analysis show AI score badge (not Rule)
- [ ] Verify resumes without AI analysis still show Rule score badge
- [ ] Verify list sorts by AI score descending by default