### PR TITLE
fix(resume): show AI score breakdown in tooltip

### DIFF
--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -61,29 +61,25 @@ describe('resume-scoring', () => {
     expect(toRecommendation('unknown')).toBe('potential')
   })
 
-  it('parses valid match breakdown', () => {
+  it('passes through valid breakdown with AI prompt keys', () => {
     const breakdown = toMatchBreakdown({
-      skillMatch: 80,
-      roleMatch: 10,
-      experienceMatch: 70,
-      educationMatch: 90,
-      locationMatch: 60,
-      industryMatch: 50,
-      brandRelevance: 6,
+      experience: 10,
+      skills: 5,
+      industry_db: 5,
+      education: 5,
+      location: 5,
     })
 
     expect(breakdown).toEqual({
-      skillMatch: 80,
-      roleMatch: 10,
-      experienceMatch: 70,
-      educationMatch: 90,
-      locationMatch: 60,
-      industryMatch: 50,
-      brandRelevance: 6,
+      experience: 10,
+      skills: 5,
+      industry_db: 5,
+      education: 5,
+      location: 5,
     })
   })
 
-  it('fills missing brand relevance with 0 for backward compatibility', () => {
+  it('passes through legacy camelCase breakdown keys', () => {
     expect(
       toMatchBreakdown({
         skillMatch: 80,
@@ -94,25 +90,16 @@ describe('resume-scoring', () => {
       })
     ).toEqual({
       skillMatch: 80,
-      roleMatch: 0,
       experienceMatch: 70,
       educationMatch: 90,
       locationMatch: 60,
       industryMatch: 50,
-      brandRelevance: 0,
     })
   })
 
-  it('returns undefined for incomplete breakdown payload', () => {
-    expect(
-      toMatchBreakdown({
-        skillMatch: 80,
-        roleMatch: 4,
-        experienceMatch: 70,
-        educationMatch: 90,
-        locationMatch: 60,
-      })
-    ).toBeUndefined()
+  it('returns undefined for empty breakdown', () => {
+    expect(toMatchBreakdown({})).toBeUndefined()
+    expect(toMatchBreakdown(undefined)).toBeUndefined()
   })
 
   it('prefers resumeId then perUserId then profileUrl for resume key', () => {

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -14,37 +14,8 @@ export function toRecommendation(value: string): Recommendation {
 }
 
 export function toMatchBreakdown(value: Record<string, number> | undefined): MatchBreakdown | undefined {
-  if (!value) return undefined
-
-  const {
-    skillMatch,
-    roleMatch,
-    experienceMatch,
-    educationMatch,
-    locationMatch,
-    industryMatch,
-    brandRelevance,
-  } = value
-
-  if (
-    typeof skillMatch !== 'number'
-    || typeof experienceMatch !== 'number'
-    || typeof educationMatch !== 'number'
-    || typeof locationMatch !== 'number'
-    || typeof industryMatch !== 'number'
-  ) {
-    return undefined
-  }
-
-  return {
-    skillMatch,
-    roleMatch: typeof roleMatch === 'number' ? roleMatch : 0,
-    experienceMatch,
-    educationMatch,
-    locationMatch,
-    industryMatch,
-    brandRelevance: typeof brandRelevance === 'number' ? brandRelevance : 0,
-  }
+  if (!value || Object.keys(value).length === 0) return undefined
+  return value
 }
 
 export function getAnalysisForJob(

--- a/apps/web/src/types/resume.ts
+++ b/apps/web/src/types/resume.ts
@@ -67,15 +67,7 @@ export type CandidateStatus =
   | 'hired'
   | 'withdrawn'
 
-export type MatchBreakdown = {
-  skillMatch: number
-  roleMatch: number
-  experienceMatch: number
-  educationMatch: number
-  locationMatch: number
-  industryMatch: number
-  brandRelevance: number
-}
+export type MatchBreakdown = Record<string, number>
 
 export type MatchingResult = {
   resumeId: string


### PR DESCRIPTION
## Summary
- `toMatchBreakdown()` expected hardcoded camelCase keys (`skillMatch`, `experienceMatch`, etc.) but the AI prompt returns `experience`, `skills`, `industry_db`, `education`, `location`
- The strict validation always returned `undefined`, causing "No detailed breakdown available" in the tooltip
- Relax `MatchBreakdown` to `Record<string, number>` and pass through any valid breakdown payload

## Test plan
- [ ] Verify AI score tooltip shows breakdown categories (experience, skills, industry_db, etc.)
- [ ] Verify tooltip no longer shows "No detailed breakdown available" for AI-analyzed resumes