### PR TITLE
fix(ingest): raise debug ingest display limit from 500 to 2000

### DIFF
--- a/apps/web/src/pages/DebugIngest.tsx
+++ b/apps/web/src/pages/DebugIngest.tsx
@@ -67,7 +67,7 @@ function formatTaggingEntry(entry: {
 
 export default function DebugIngest() {
   const { t } = useTranslation()
-  const { resumes, loading } = useConvexResumes(500)
+  const { resumes, loading } = useConvexResumes(2000)
   const backfillIngestData = useAction(api.migrations.backfillIngestData)
   const reIngestStaleSkillsVersion = useAction(api.migrations.reIngestStaleSkillsVersion)
   const clearAnalysesMutation = useMutation(api.resumes.clearAnalyses)

--- a/apps/web/src/pages/DebugIngest.tsx
+++ b/apps/web/src/pages/DebugIngest.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
-import { useAction, useMutation } from 'convex/react'
+import { useAction, useMutation, useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import { useConvexResumes } from '@/hooks/useConvexResumes'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
@@ -68,6 +68,7 @@ function formatTaggingEntry(entry: {
 export default function DebugIngest() {
   const { t } = useTranslation()
   const { resumes, loading } = useConvexResumes(2000)
+  const totalCount = useQuery(api.resumes.count)
   const backfillIngestData = useAction(api.migrations.backfillIngestData)
   const reIngestStaleSkillsVersion = useAction(api.migrations.reIngestStaleSkillsVersion)
   const clearAnalysesMutation = useMutation(api.resumes.clearAnalyses)
@@ -230,7 +231,14 @@ export default function DebugIngest() {
           <CardHeader className="pb-2">
             <CardTitle className="text-sm">{t('debugIngest.total', { defaultValue: 'Total Resumes' })}</CardTitle>
           </CardHeader>
-          <CardContent className="text-2xl font-semibold">{resumes.length}</CardContent>
+          <CardContent>
+            <span className="text-2xl font-semibold">{totalCount ?? '...'}</span>
+            {totalCount !== undefined && totalCount > resumes.length && (
+              <span className="ml-2 text-sm text-muted-foreground">
+                ({t('debugIngest.showing', { count: resumes.length, defaultValue: `showing ${resumes.length}` })})
+              </span>
+            )}
+          </CardContent>
         </Card>
         <Card>
           <CardHeader className="pb-2">

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -95,6 +95,14 @@ function appendMissingTokens(existingSearchText: string, tokens: string[]): stri
         : missingTokens.join(" ");
 }
 
+export const count = query({
+    args: {},
+    handler: async (ctx) => {
+        const docs = await ctx.db.query("resumes").collect();
+        return docs.length;
+    },
+});
+
 export const list = query({
     args: { limit: v.optional(v.number()) },
     handler: async (ctx, args) => {


### PR DESCRIPTION
## Summary
- The DebugIngest page (`/dev/system/ingest`) hardcoded `useConvexResumes(500)`, capping display at 500 resumes regardless of how many were actually collected
- When crawl sources return more results (e.g. 762 from job5156), only 500 appeared — causing the discrepancy the user observed
- Raised the limit to 2000 to accommodate larger collections

## Test plan
- [ ] Open `/dev/system/ingest` with a collection that has >500 resumes
- [ ] Verify all collected resumes now appear (up to 2000)