### PR TITLE
Add unified keyword/tag search for resumes

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -5,6 +5,8 @@ import { randomUUID } from "node:crypto";
 import {
   ResumesQuerySchema,
   ResumesResponseSchema,
+  ResumeKeywordExpansionQuerySchema,
+  ResumeKeywordExpansionResponseSchema,
   ResumeSamplesResponseSchema,
   MatchRequestSchema,
   MatchResponseSchema,
@@ -533,6 +535,43 @@ app.openapi(listSamplesRoute, (c) => {
   }, 200);
 });
 
+const getResumeKeywordExpansionRoute = createRoute({
+  method: "get",
+  path: "/api/resumes/keyword-expansion",
+  tags: ["resumes"],
+  summary: "Expand resume keyword query with synonyms",
+  description: "Returns the backend-expanded keyword variants used for unified resume search",
+  request: {
+    query: ResumeKeywordExpansionQuerySchema,
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ResumeKeywordExpansionResponseSchema,
+        },
+      },
+      description: "Successful response",
+    },
+  },
+});
+
+app.openapi(getResumeKeywordExpansionRoute, (c) => {
+  const { q } = c.req.valid("query");
+  const expansion = resumeService.expandSearchQuery(q);
+
+  return c.json({
+    success: true as const,
+    summary: {
+      keyword: q,
+      groups: expansion?.groups ?? [],
+      mode: expansion?.mode ?? "AND",
+      expandedTo: expansion?.flatTerms ?? [],
+      sourceMapping: expansion?.sourceMapping ?? {},
+    },
+  }, 200);
+});
+
 const getResumesRoute = createRoute({
   method: "get",
   path: "/api/resumes",
@@ -576,6 +615,7 @@ app.openapi(getResumesRoute, (c) => {
   } = c.req.valid("query");
   const sampleName = sample?.trim() || undefined;
   const keyword = q?.trim() || undefined;
+  const keywordExpansion = resumeService.expandSearchQuery(keyword);
 
   try {
     const { items, sample: sampleInfo, metadata, indexes } = resumeService.loadSample(sampleName);
@@ -696,6 +736,8 @@ app.openapi(getResumesRoute, (c) => {
         total: working.length,
         returned: limited.length,
         query: keyword,
+        expandedTo: keywordExpansion?.flatTerms,
+        mode: keywordExpansion?.mode,
       },
       data: limited,
     }, 200);

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -206,11 +206,49 @@ export const ResumesResponseSchema = z
         total: z.number().int(),
         returned: z.number().int(),
         query: z.string().optional(),
+        expandedTo: z.array(z.string()).optional(),
+        mode: z.enum(["AND", "OR"]).optional(),
       })
       .optional(),
     data: z.array(ResumeItemSchema),
   })
   .openapi("ResumesResponse");
+
+const KeywordGroupSchema = z.object({
+  original: z.string(),
+  variants: z.array(z.string()),
+});
+
+export const ResumeKeywordExpansionQuerySchema = z.object({
+  q: z
+    .string()
+    .optional()
+    .transform((value) => {
+      if (typeof value !== "string") return value;
+      const normalized = value
+        .replace(/[\u3000]/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+      return normalized || undefined;
+    })
+    .openapi({
+      param: { name: "q", in: "query" },
+      example: "销售",
+    }),
+});
+
+export const ResumeKeywordExpansionResponseSchema = z
+  .object({
+    success: z.literal(true),
+    summary: z.object({
+      keyword: z.string().optional(),
+      groups: z.array(KeywordGroupSchema),
+      mode: z.enum(["AND", "OR"]),
+      expandedTo: z.array(z.string()),
+      sourceMapping: z.record(z.string()),
+    }),
+  })
+  .openapi("ResumeKeywordExpansionResponse");
 
 export const ResumeSamplesResponseSchema = z
   .object({

--- a/apps/api/src/services/ingest-compute-service.test.ts
+++ b/apps/api/src/services/ingest-compute-service.test.ts
@@ -19,7 +19,7 @@ description: Test skills knowledge file
 ## Domain Taxonomy
 
 ### machinery
-- displayName: Machinery
+- displayName: 机械
 - keywords: 机床, 车床, lathe, machining
 
 ### cnc
@@ -27,7 +27,7 @@ description: Test skills knowledge file
 - keywords: cnc, 数控, fanuc, star
 
 ### sales
-- displayName: Sales
+- displayName: 销售
 - keywords: 销售, 客户, sales, account
 
 ## Synonym Table
@@ -263,9 +263,9 @@ describe("IngestComputeService", () => {
   it("should compute industryTags from work history evidence only", () => {
     const result = service.computeOne("resume-123", SAMPLE_RESUME_CNC_SALES);
 
-    expect(result.industryTags).toContain("cnc");
-    expect(result.industryTags).toContain("sales");
-    expect(result.industryTags).not.toContain("machinery");
+    expect(result.industryTags).toContain("CNC");
+    expect(result.industryTags).toContain("销售");
+    expect(result.industryTags).not.toContain("机械");
   });
 
   it("should compute synonymHits from work history evidence only", () => {

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -399,7 +399,7 @@ export class IngestComputeService {
         searchText.includes(keyword.toLowerCase())
       );
       if (hasKeyword) {
-        tags.push(domain.tag);
+        tags.push(domain.displayName);
       }
     }
 

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -9,6 +9,7 @@ import { parseSearchQuery } from "./query-parser.js";
 import { resolveResumeId } from "./resume-id.js";
 import { ResumeIndexService } from "./resume-index.js";
 import { SkillsKnowledgeService } from "./skills-knowledge.js";
+import { UnifiedSearchService, type UnifiedKeywordExpansion } from "./unified-search-service.js";
 
 import type { ResumeItem, ResumeSampleFile, ResumeWorkHistoryItem } from "../types/resume.js";
 import type { ResumeIndex } from "./resume-index.js";
@@ -190,12 +191,14 @@ export class ResumeService {
   private readonly indexService: ResumeIndexService;
   private readonly industryService: IndustryDataService;
   private readonly skillsService: SkillsKnowledgeService;
+  private readonly unifiedSearchService: UnifiedSearchService;
 
   constructor(projectRoot?: string) {
     this.projectRoot = projectRoot ? path.resolve(projectRoot) : findProjectRoot();
     this.indexService = new ResumeIndexService(this.projectRoot);
     this.industryService = new IndustryDataService(this.projectRoot);
     this.skillsService = new SkillsKnowledgeService(this.projectRoot);
+    this.unifiedSearchService = new UnifiedSearchService(this.projectRoot);
   }
 
   private getSamplesDir(): string {
@@ -285,7 +288,7 @@ export class ResumeService {
     }
 
     const keywordSets = parsedQuery.keywords.map((keyword) => {
-      const expanded = this.skillsService.expandQueryWithSynonyms([keyword]);
+      const expanded = this.unifiedSearchService.expandKeyword(keyword).flatTerms;
       const variants = Array.from(
         new Set(
           [keyword, ...expanded]
@@ -401,6 +404,13 @@ export class ResumeService {
     }
 
     return results.sort((a, b) => b.relevanceScore - a.relevanceScore);
+  }
+
+  expandSearchQuery(query?: string): UnifiedKeywordExpansion | undefined {
+    if (!query || !query.trim()) {
+      return undefined;
+    }
+    return this.unifiedSearchService.expandKeyword(query);
   }
 
   filterResumes<T extends ResumeItem>(items: T[], filters?: ResumeFilters): T[] {

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -198,7 +198,7 @@ export class ResumeService {
     this.indexService = new ResumeIndexService(this.projectRoot);
     this.industryService = new IndustryDataService(this.projectRoot);
     this.skillsService = new SkillsKnowledgeService(this.projectRoot);
-    this.unifiedSearchService = new UnifiedSearchService(this.projectRoot);
+    this.unifiedSearchService = new UnifiedSearchService(this.skillsService);
   }
 
   private getSamplesDir(): string {

--- a/apps/api/src/services/skills-knowledge.test.ts
+++ b/apps/api/src/services/skills-knowledge.test.ts
@@ -522,4 +522,86 @@ updated_at: '2026-02-21'
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("parses zh-Hans section headings from canonical skills.md", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "skills-zh-"));
+    fs.mkdirSync(path.join(root, "config", "resume"), { recursive: true });
+
+    const zhSkills = `---
+version: 6
+updated_at: '2026-03-11'
+description: 测试技能知识文件
+---
+
+# 技能知识库
+
+## 领域分类
+
+### machinery
+- displayName: 机械
+- keywords: 机床, lathe
+
+## 同义词表
+
+- 销售: sales, 业务
+
+## 经验等级信号
+
+### senior
+- displayName: 资深
+- keywords: 经理, lead
+
+## 公司数据库
+
+- FANUC [role: both] (aliases: 发那科, Fanuc)
+
+## 行业背景
+
+### 机械销售
+需要行业经验。
+
+## 排除模式
+
+- exclude: 广告, spam
+
+## 学习日志
+
+- 2026-03-11: 测试记录
+`;
+
+    fs.writeFileSync(path.join(root, "config", "resume", "skills.md"), zhSkills, "utf8");
+    fs.writeFileSync(path.join(root, "pyproject.toml"), "", "utf8");
+    fs.mkdirSync(path.join(root, "output"), { recursive: true });
+
+    try {
+      const service = new SkillsKnowledgeService(root);
+
+      expect(service.getIndustryTaxonomy()).toEqual([
+        {
+          tag: "machinery",
+          displayName: "机械",
+          keywords: ["机床", "lathe"],
+        },
+      ]);
+      expect(service.getSynonymTable().get("sales")).toBe("销售");
+      expect(service.getExperienceSignals()).toEqual([
+        {
+          level: "senior",
+          displayName: "资深",
+          keywords: ["经理", "lead"],
+        },
+      ]);
+      expect(service.getCompanyPatterns()).toHaveLength(1);
+      expect(service.getIndustryContext()).toBe("### 机械销售\n需要行业经验。");
+      expect(service.getExclusionTokens()).toEqual(["广告", "spam"]);
+      expect(service.getLearningLog()).toEqual([
+        {
+          date: "2026-03-11",
+          observation: "测试记录",
+        },
+      ]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/apps/api/src/services/skills-knowledge.ts
+++ b/apps/api/src/services/skills-knowledge.ts
@@ -113,9 +113,22 @@ export interface SkillsKnowledge {
 }
 
 const SEARCH_TOKEN_SPLIT_RE = /[\s,，、;；|/]+/;
+const SECTION_HEADING_ALIASES = {
+  domainTaxonomy: ["Domain Taxonomy", "领域分类"],
+  synonymTable: ["Synonym Table", "同义词表"],
+  experienceSignals: ["Experience Signals", "经验等级信号"],
+  companyPatterns: ["Company Patterns", "公司数据库"],
+  industryContext: ["Industry Context", "行业背景"],
+  exclusionPatterns: ["Exclusion Patterns", "排除模式"],
+  learningLog: ["Learning Log", "学习日志"],
+} as const;
 
 function normalizeToken(value: string): string {
   return value.trim().toLowerCase();
+}
+
+function matchesSectionHeading(value: string, aliases: readonly string[]): boolean {
+  return aliases.some((alias) => value.startsWith(alias));
 }
 
 function normalizeQuery(value: string): string {
@@ -234,19 +247,19 @@ export class SkillsKnowledgeService {
       if (!trimmed) continue;
 
       // Identify section by heading
-      if (trimmed.startsWith("Domain Taxonomy")) {
+      if (matchesSectionHeading(trimmed, SECTION_HEADING_ALIASES.domainTaxonomy)) {
         knowledge.domains = this.parseDomainTaxonomy(trimmed);
-      } else if (trimmed.startsWith("Synonym Table")) {
+      } else if (matchesSectionHeading(trimmed, SECTION_HEADING_ALIASES.synonymTable)) {
         knowledge.synonyms = this.parseSynonymTable(trimmed);
-      } else if (trimmed.startsWith("Experience Signals")) {
+      } else if (matchesSectionHeading(trimmed, SECTION_HEADING_ALIASES.experienceSignals)) {
         knowledge.experienceLevels = this.parseExperienceSignals(trimmed);
-      } else if (trimmed.startsWith("Company Patterns")) {
+      } else if (matchesSectionHeading(trimmed, SECTION_HEADING_ALIASES.companyPatterns)) {
         knowledge.companyPatterns = this.parseCompanyPatterns(trimmed);
-      } else if (trimmed.startsWith("Industry Context")) {
+      } else if (matchesSectionHeading(trimmed, SECTION_HEADING_ALIASES.industryContext)) {
         knowledge.industryContext = this.parseIndustryContext(trimmed);
-      } else if (trimmed.startsWith("Exclusion Patterns")) {
+      } else if (matchesSectionHeading(trimmed, SECTION_HEADING_ALIASES.exclusionPatterns)) {
         knowledge.exclusionTokens = this.parseExclusionPatterns(trimmed);
-      } else if (trimmed.startsWith("Learning Log")) {
+      } else if (matchesSectionHeading(trimmed, SECTION_HEADING_ALIASES.learningLog)) {
         knowledge.learningLog = this.parseLearningLog(trimmed);
       }
     }
@@ -264,7 +277,7 @@ export class SkillsKnowledgeService {
 
     for (const sub of subsections) {
       const trimmed = sub.trim();
-      if (!trimmed || trimmed.startsWith("Domain Taxonomy")) continue;
+      if (!trimmed || matchesSectionHeading(trimmed, SECTION_HEADING_ALIASES.domainTaxonomy)) continue;
 
       const lines = trimmed.split("\n");
       const tag = lines[0].trim();
@@ -328,7 +341,7 @@ export class SkillsKnowledgeService {
 
     for (const sub of subsections) {
       const trimmed = sub.trim();
-      if (!trimmed || trimmed.startsWith("Experience Signals")) continue;
+      if (!trimmed || matchesSectionHeading(trimmed, SECTION_HEADING_ALIASES.experienceSignals)) continue;
 
       const lines = trimmed.split("\n");
       const level = lines[0].trim();
@@ -401,7 +414,7 @@ export class SkillsKnowledgeService {
 
     for (const sub of subsections) {
       const trimmed = sub.trim();
-      if (!trimmed || trimmed.startsWith("Industry Context")) continue;
+      if (!trimmed || matchesSectionHeading(trimmed, SECTION_HEADING_ALIASES.industryContext)) continue;
 
       const lines = trimmed.split("\n");
       const heading = lines[0].trim();

--- a/apps/api/src/services/unified-search-service.test.ts
+++ b/apps/api/src/services/unified-search-service.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { SkillsKnowledgeService } from "./skills-knowledge";
 import { UnifiedSearchService } from "./unified-search-service";
 
 import type { ResumeItem } from "../types/resume";
@@ -46,7 +47,8 @@ describe("UnifiedSearchService", () => {
     const root = createFixtureRoot();
 
     try {
-      const service = new UnifiedSearchService(root);
+      const skillsService = new SkillsKnowledgeService(root);
+      const service = new UnifiedSearchService(skillsService);
       const expansion = service.expandKeyword("销售");
 
       expect(expansion.groups).toEqual([
@@ -72,7 +74,8 @@ describe("UnifiedSearchService", () => {
     const root = createFixtureRoot();
 
     try {
-      const service = new UnifiedSearchService(root);
+      const skillsService = new SkillsKnowledgeService(root);
+      const service = new UnifiedSearchService(skillsService);
       const expansion = service.expandKeyword("销售 CNC");
 
       expect(expansion.mode).toBe("AND");
@@ -96,7 +99,8 @@ describe("UnifiedSearchService", () => {
     const root = createFixtureRoot();
 
     try {
-      const service = new UnifiedSearchService(root);
+      const skillsService = new SkillsKnowledgeService(root);
+      const service = new UnifiedSearchService(skillsService);
       const resume: ResumeItem = {
         name: "周祥富",
         profileUrl: "https://example.com/1",
@@ -151,7 +155,8 @@ describe("UnifiedSearchService", () => {
     const root = createFixtureRoot();
 
     try {
-      const service = new UnifiedSearchService(root);
+      const skillsService = new SkillsKnowledgeService(root);
+      const service = new UnifiedSearchService(skillsService);
       const salesResume: ResumeItem = {
         name: "销售候选人",
         profileUrl: "https://example.com/1",

--- a/apps/api/src/services/unified-search-service.test.ts
+++ b/apps/api/src/services/unified-search-service.test.ts
@@ -1,0 +1,193 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { UnifiedSearchService } from "./unified-search-service";
+
+import type { ResumeItem } from "../types/resume";
+import type { ResumeIndex } from "./resume-index";
+
+const TEST_SKILLS_MD = `---
+version: 1
+updated_at: '2026-03-11'
+description: Test skills knowledge file
+---
+
+# Skills Knowledge
+
+## Domain Taxonomy
+
+### sales
+- displayName: Sales
+- keywords: 销售, sales
+
+## Synonym Table
+
+- 销售: 业务, 商务, 销售员, sales
+`;
+
+function createFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "unified-search-service-"));
+  fs.mkdirSync(path.join(root, "config", "resume"), { recursive: true });
+  fs.writeFileSync(path.join(root, "config", "resume", "skills.md"), TEST_SKILLS_MD, "utf8");
+  fs.writeFileSync(path.join(root, "pyproject.toml"), "", "utf8");
+  fs.mkdirSync(path.join(root, "output"), { recursive: true });
+  return root;
+}
+
+function cleanupFixtureRoot(root: string): void {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+describe("UnifiedSearchService", () => {
+  it("expands keywords with source mapping", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new UnifiedSearchService(root);
+      const expansion = service.expandKeyword("销售");
+
+      expect(expansion.groups).toEqual([
+        {
+          original: "销售",
+          variants: ["销售", "业务", "商务", "销售员", "sales"],
+        },
+      ]);
+      expect(expansion.mode).toBe("AND");
+      expect(expansion.flatTerms).toEqual(["销售", "业务", "商务", "销售员", "sales"]);
+      expect(expansion.sourceMapping).toEqual({
+        "业务": "销售",
+        "商务": "销售",
+        "销售员": "销售",
+        "sales": "销售",
+      });
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("preserves AND grouping for multi-keyword queries", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new UnifiedSearchService(root);
+      const expansion = service.expandKeyword("销售 CNC");
+
+      expect(expansion.mode).toBe("AND");
+      expect(expansion.groups).toEqual([
+        {
+          original: "销售",
+          variants: ["销售", "业务", "商务", "销售员", "sales"],
+        },
+        {
+          original: "cnc",
+          variants: ["cnc"],
+        },
+      ]);
+      expect(expansion.flatTerms).toEqual(["销售", "业务", "商务", "销售员", "sales", "cnc"]);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("returns provenance across text, tags, and company fields", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new UnifiedSearchService(root);
+      const resume: ResumeItem = {
+        name: "周祥富",
+        profileUrl: "https://example.com/1",
+        activityStatus: "active",
+        age: "40",
+        experience: "11年",
+        education: "中专",
+        location: "东莞",
+        selfIntro: "",
+        jobIntention: "销售工程师",
+        expectedSalary: "6000-7999",
+        workHistory: [
+          {
+            raw: "2015-12~2020-07(4年7月)东莞市泽钿精密机械有限公司销售工程师",
+          },
+        ],
+        extractedAt: "2026-03-11T00:00:00.000Z",
+        resumeId: "resume-1",
+      };
+      const indexMap = new Map<string, ResumeIndex>([
+        [
+          "resume-1",
+          {
+            resumeId: "resume-1",
+            experienceYears: 11,
+            educationLevel: "high_school",
+            locationCity: "东莞",
+            skills: [],
+            companies: ["泽钿精密"],
+            industryTags: ["sales"],
+            salaryRange: null,
+            searchText: "销售 销售工程师",
+          },
+        ],
+      ]);
+
+      const result = service.searchUnified([resume], "销售", { indexMap });
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]?.provenance).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ term: "销售", source: "searchText" }),
+          expect.objectContaining({ term: "sales", source: "industryTags", expandedFrom: "销售" }),
+        ])
+      );
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("requires all keyword groups in AND mode", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new UnifiedSearchService(root);
+      const salesResume: ResumeItem = {
+        name: "销售候选人",
+        profileUrl: "https://example.com/1",
+        activityStatus: "active",
+        age: "35",
+        experience: "8年",
+        education: "大专",
+        location: "东莞",
+        selfIntro: "",
+        jobIntention: "销售工程师",
+        expectedSalary: "10000-15000",
+        workHistory: [],
+        extractedAt: "2026-03-11T00:00:00.000Z",
+        resumeId: "resume-sales",
+      };
+      const cncResume: ResumeItem = {
+        ...salesResume,
+        name: "CNC候选人",
+        jobIntention: "CNC工程师",
+        resumeId: "resume-cnc",
+      };
+      const bothResume: ResumeItem = {
+        ...salesResume,
+        name: "复合候选人",
+        jobIntention: "CNC销售工程师",
+        resumeId: "resume-both",
+      };
+
+      const results = service.searchUnified(
+        [salesResume, cncResume, bothResume],
+        "销售 CNC"
+      );
+
+      expect(results.results.map((entry) => entry.resume.resumeId)).toEqual(["resume-both"]);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+});

--- a/apps/api/src/services/unified-search-service.ts
+++ b/apps/api/src/services/unified-search-service.ts
@@ -1,0 +1,245 @@
+import path from "node:path";
+
+import { findProjectRoot } from "./db.js";
+import { parseSearchQuery } from "./query-parser.js";
+import { resolveResumeId } from "./resume-id.js";
+import { SkillsKnowledgeService } from "./skills-knowledge.js";
+
+import type { ResumeIndex } from "./resume-index.js";
+import type { ResumeItem } from "../types/resume.js";
+
+export type UnifiedSearchMatchSource =
+  | "searchText"
+  | "industryTags"
+  | "companyHits"
+  | "synonymHits";
+
+export type UnifiedSearchProvenance = {
+  term: string;
+  source: UnifiedSearchMatchSource;
+  expandedFrom?: string;
+};
+
+export interface UnifiedSearchResult {
+  resume: ResumeItem & { relevanceScore: number };
+  provenance: UnifiedSearchProvenance[];
+}
+
+export type KeywordGroup = {
+  original: string;
+  variants: string[];
+};
+
+export interface UnifiedKeywordExpansion {
+  flatTerms: string[];
+  groups: KeywordGroup[];
+  mode: "AND" | "OR";
+  originalKeyword: string;
+  sourceMapping: Record<string, string>;
+}
+
+function normalizeToken(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function buildSearchText(item: ResumeItem): string {
+  const parts = [
+    item.name,
+    item.jobIntention,
+    item.selfIntro,
+    item.education,
+    item.expectedSalary,
+    ...(item.workHistory?.map((entry) => entry.raw) ?? []),
+  ];
+  return parts.join(" ").toLowerCase();
+}
+
+function extractCompanyName(raw: string): string {
+  return raw
+    .replace(/^[\d\-~至今年月日()（）.\s]+/, "")
+    .replace(/[\s,，。;；]+/g, " ")
+    .trim();
+}
+
+function dedupeProvenance(items: UnifiedSearchProvenance[]): UnifiedSearchProvenance[] {
+  const seen = new Set<string>();
+  const deduped: UnifiedSearchProvenance[] = [];
+
+  for (const item of items) {
+    const key = `${item.source}|${item.term}|${item.expandedFrom ?? ""}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(item);
+  }
+
+  return deduped;
+}
+
+export class UnifiedSearchService {
+  readonly projectRoot: string;
+  private readonly skillsService: SkillsKnowledgeService;
+
+  constructor(projectRoot?: string) {
+    this.projectRoot = projectRoot ? path.resolve(projectRoot) : findProjectRoot();
+    this.skillsService = new SkillsKnowledgeService(this.projectRoot);
+  }
+
+  expandKeyword(keyword: string): UnifiedKeywordExpansion {
+    const parsedQuery = parseSearchQuery(keyword.trim());
+    const groups: KeywordGroup[] = [];
+    const flatTerms: string[] = [];
+    const seenFlatTerms = new Set<string>();
+    const sourceMapping: Record<string, string> = {};
+
+    const pushFlatTerm = (term: string, expandedFrom?: string): void => {
+      const normalized = normalizeToken(term);
+      if (normalized.length < 2 || seenFlatTerms.has(normalized)) {
+        return;
+      }
+      seenFlatTerms.add(normalized);
+      flatTerms.push(normalized);
+      if (expandedFrom && normalized !== expandedFrom) {
+        sourceMapping[normalized] = expandedFrom;
+      }
+    };
+
+    for (const rawKeyword of parsedQuery.keywords) {
+      const original = normalizeToken(rawKeyword);
+      if (original.length < 2) {
+        continue;
+      }
+
+      const variants: string[] = [];
+      const seenVariants = new Set<string>();
+      const pushVariant = (term: string): void => {
+        const normalized = normalizeToken(term);
+        if (normalized.length < 2 || seenVariants.has(normalized)) {
+          return;
+        }
+        seenVariants.add(normalized);
+        variants.push(normalized);
+        pushFlatTerm(normalized, original);
+      };
+
+      pushVariant(original);
+      const expanded = this.skillsService.expandQueryWithSynonyms([original]);
+      for (const term of expanded) {
+        pushVariant(term);
+      }
+
+      if (variants.length > 0) {
+        groups.push({
+          original,
+          variants,
+        });
+      }
+    }
+
+    return {
+      flatTerms,
+      groups,
+      mode: parsedQuery.mode,
+      originalKeyword: keyword.trim(),
+      sourceMapping,
+    };
+  }
+
+  searchUnified(
+    items: ResumeItem[],
+    query: string,
+    options?: {
+      indexMap?: Map<string, ResumeIndex>;
+      ruleScoreMap?: Map<string, number>;
+    }
+  ): {
+    expansion: UnifiedKeywordExpansion;
+    results: UnifiedSearchResult[];
+  } {
+    const expansion = this.expandKeyword(query);
+    if (expansion.flatTerms.length === 0) {
+      return { expansion, results: [] };
+    }
+
+    const results: UnifiedSearchResult[] = [];
+
+    for (let i = 0; i < items.length; i += 1) {
+      const item = items[i];
+      const resumeId = resolveResumeId(item, i);
+      const index = options?.indexMap?.get(resumeId);
+      const searchText = index?.searchText || buildSearchText(item);
+      const companies = index?.companies ?? (item.workHistory?.map((entry) => extractCompanyName(entry.raw)) || []);
+      const industryTags = index?.industryTags ?? [];
+      const provenance: UnifiedSearchProvenance[] = [];
+      let matchedGroupCount = 0;
+
+      for (const group of expansion.groups) {
+        const groupMatches: UnifiedSearchProvenance[] = [];
+
+        for (const term of group.variants) {
+          const expandedFrom = expansion.sourceMapping[term];
+
+          if (searchText.includes(term)) {
+            groupMatches.push({ term, source: "searchText", expandedFrom });
+          }
+
+          if (industryTags.some((tag) => normalizeToken(tag) === term)) {
+            groupMatches.push({ term, source: "industryTags", expandedFrom });
+          }
+
+          if (companies.some((company) => normalizeToken(company).includes(term))) {
+            groupMatches.push({ term, source: "companyHits", expandedFrom });
+          }
+        }
+
+        if (groupMatches.length > 0) {
+          matchedGroupCount += 1;
+          provenance.push(...groupMatches);
+        }
+      }
+
+      const matched = expansion.mode === "AND"
+        ? matchedGroupCount === expansion.groups.length
+        : matchedGroupCount > 0;
+      if (!matched) {
+        continue;
+      }
+
+      const dedupedProvenance = dedupeProvenance(provenance);
+      if (dedupedProvenance.length === 0) {
+        continue;
+      }
+
+      const baseScore = dedupedProvenance.reduce((score, match) => {
+        switch (match.source) {
+          case "industryTags":
+          case "companyHits":
+            return score + 30;
+          case "synonymHits":
+            return score + 20;
+          case "searchText":
+          default:
+            return score + 10;
+        }
+      }, 0);
+      const ruleScore = options?.ruleScoreMap?.get(resumeId) ?? 0;
+      const relevanceScore = ruleScore > 0
+        ? Math.round((baseScore * 0.4) + (ruleScore * 0.6))
+        : baseScore;
+
+      results.push({
+        resume: {
+          ...item,
+          relevanceScore,
+        },
+        provenance: dedupedProvenance,
+      });
+    }
+
+    return {
+      expansion,
+      results: results.sort((left, right) => right.resume.relevanceScore - left.resume.relevanceScore),
+    };
+  }
+}

--- a/apps/api/src/services/unified-search-service.ts
+++ b/apps/api/src/services/unified-search-service.ts
@@ -1,10 +1,7 @@
-import path from "node:path";
-
-import { findProjectRoot } from "./db.js";
 import { parseSearchQuery } from "./query-parser.js";
 import { resolveResumeId } from "./resume-id.js";
-import { SkillsKnowledgeService } from "./skills-knowledge.js";
 
+import type { SkillsKnowledgeService } from "./skills-knowledge.js";
 import type { ResumeIndex } from "./resume-index.js";
 import type { ResumeItem } from "../types/resume.js";
 
@@ -78,12 +75,10 @@ function dedupeProvenance(items: UnifiedSearchProvenance[]): UnifiedSearchProven
 }
 
 export class UnifiedSearchService {
-  readonly projectRoot: string;
   private readonly skillsService: SkillsKnowledgeService;
 
-  constructor(projectRoot?: string) {
-    this.projectRoot = projectRoot ? path.resolve(projectRoot) : findProjectRoot();
-    this.skillsService = new SkillsKnowledgeService(this.projectRoot);
+  constructor(skillsService: SkillsKnowledgeService) {
+    this.skillsService = skillsService;
   }
 
   expandKeyword(keyword: string): UnifiedKeywordExpansion {

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -1,6 +1,8 @@
+import { useEffect, useState } from 'react'
 import { useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
+import { rawApiClient } from '@/lib/api-helpers'
 import type { ResumeItem } from './useResumes'
 
 export type ConvexResumeAnalysis = {
@@ -74,6 +76,35 @@ export type ConvexResumeItem = ResumeItem & {
   primaryRuleScore?: number
   source: string
   tags: string[]
+  _provenance?: Array<{
+    term: string
+    source: 'searchText' | 'industryTags' | 'companyHits' | 'synonymHits'
+    expandedFrom?: string
+  }>
+}
+
+type KeywordExpansionSummary = {
+  groups: Array<{
+    original: string
+    variants: string[]
+  }>
+  mode: 'AND' | 'OR'
+  expandedTo: string[]
+  sourceMapping: Record<string, string>
+}
+
+function buildFallbackKeywordExpansion(query: string): KeywordExpansionSummary {
+  const terms = query
+    .split(/\s+/)
+    .map((term) => term.trim().toLowerCase())
+    .filter((term) => term.length > 0)
+
+  return {
+    groups: terms.map((term) => ({ original: term, variants: [term] })),
+    mode: 'AND',
+    expandedTo: terms,
+    sourceMapping: {},
+  }
 }
 
 const JOB5156_HOST = 'hr.job5156.com'
@@ -494,24 +525,109 @@ function mapResumeDoc(doc: Doc<'resumes'>): ConvexResumeItem {
 
 export function useConvexResumes(limit: number = 200, query?: string, jobDescriptionId?: string) {
   const normalizedJobDescriptionId = jobDescriptionId?.trim() || undefined
+  const normalizedQuery = query?.trim() || undefined
+  const [keywordExpansion, setKeywordExpansion] = useState<KeywordExpansionSummary | null>(null)
+  const [expansionLoading, setExpansionLoading] = useState(false)
+
+  useEffect(() => {
+    let active = true
+
+    if (!normalizedQuery) {
+      setKeywordExpansion(null)
+      setExpansionLoading(false)
+      return () => {
+        active = false
+      }
+    }
+
+    setExpansionLoading(true)
+    void rawApiClient
+      .GET<{
+        success: boolean
+        summary?: {
+          groups?: Array<{
+            original: string
+            variants: string[]
+          }>
+          mode?: 'AND' | 'OR'
+          expandedTo?: string[]
+          sourceMapping?: Record<string, string>
+        }
+      }>('/api/resumes/keyword-expansion', {
+        params: {
+          query: {
+            q: normalizedQuery,
+          },
+        },
+      })
+      .then(({ data, error }) => {
+        if (!active) {
+          return
+        }
+
+        if (error || !data?.success) {
+          setKeywordExpansion(buildFallbackKeywordExpansion(normalizedQuery))
+          return
+        }
+
+        setKeywordExpansion({
+          groups: data.summary?.groups ?? [],
+          mode: data.summary?.mode ?? 'AND',
+          expandedTo: data.summary?.expandedTo ?? [],
+          sourceMapping: data.summary?.sourceMapping ?? {},
+        })
+      })
+      .catch((error: unknown) => {
+        console.error('Failed to load keyword expansion', error)
+        if (!active) {
+          return
+        }
+        setKeywordExpansion(buildFallbackKeywordExpansion(normalizedQuery))
+      })
+      .finally(() => {
+        if (active) {
+          setExpansionLoading(false)
+        }
+      })
+
+    return () => {
+      active = false
+    }
+  }, [normalizedQuery])
 
   const searchResults = useQuery(
-    api.resumes.searchWithIngestData,
-    query ? { query, limit, jobDescriptionId: normalizedJobDescriptionId } : 'skip'
+    api.resumes.searchWithTagExpansion,
+    normalizedQuery && keywordExpansion
+      ? {
+          query: normalizedQuery,
+          keywordGroups: keywordExpansion.groups,
+          mode: keywordExpansion.mode,
+          sourceMappings: Object.entries(keywordExpansion.sourceMapping).map(([term, expandedFrom]) => ({
+            term,
+            expandedFrom,
+          })),
+          limit,
+          jobDescriptionId: normalizedJobDescriptionId,
+        }
+      : 'skip'
   )
 
   const listResults = useQuery(
     api.resumes.listWithIngestData,
-    query ? 'skip' : { limit, jobDescriptionId: normalizedJobDescriptionId }
+    normalizedQuery ? 'skip' : { limit, jobDescriptionId: normalizedJobDescriptionId }
   )
 
-  const convexResumes = query ? searchResults : listResults
-
-  const mappedResumes = (convexResumes ?? []).map(mapResumeDoc)
+  const mappedResumes = normalizedQuery
+    ? (searchResults?.results ?? []).map((entry) => ({
+        ...mapResumeDoc(entry.resume),
+        _provenance: entry.provenance,
+      }))
+    : (listResults ?? []).map(mapResumeDoc)
 
   return {
     resumes: mappedResumes,
-    loading: convexResumes === undefined,
+    loading: normalizedQuery ? (expansionLoading || searchResults === undefined) : listResults === undefined,
     jobDescriptionId: normalizedJobDescriptionId,
+    expansion: searchResults?.expansion,
   }
 }

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -603,6 +603,25 @@ describe('useResumeListState role filter regression', () => {
     expect(getDisplayedResumeNames()).toEqual(['Zhou Jingdiao Hit'])
   })
 
+  it('appends clicked tags and companies into session keywords', () => {
+    mockState.sessionKeywords = ['销售']
+
+    const { result } = renderHook(() => useResumeListState())
+
+    act(() => {
+      result.current.handleToggleTag('sales')
+      result.current.handleToggleCompany('FANUC')
+    })
+
+    expect(mockState.setKeywords).toHaveBeenCalledTimes(2)
+
+    const tagUpdater = mockState.setKeywords.mock.calls[0]?.[0] as (current: string[]) => string[]
+    const companyUpdater = mockState.setKeywords.mock.calls[1]?.[0] as (current: string[]) => string[]
+
+    expect(tagUpdater(['销售'])).toEqual(['销售', 'sales'])
+    expect(companyUpdater(['销售', 'sales'])).toEqual(['销售', 'sales', 'FANUC'])
+  })
+
   it('industryVerifiedYears=0 scores low even with total sales years', () => {
     const { result } = renderHook(() => useResumeListState())
     const nonCnc = result.current.displayedResumes.find(

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -18,7 +18,6 @@ import {
   type ExperienceLevelFilter,
 } from '@/hooks/useUrlSearchState'
 import { rawApiClient } from '@/lib/api-helpers'
-import { expandKeyword, DEFAULT_CONFIG } from '@/lib/trendradar/parser'
 import type { SearchHistoryItem } from '@/hooks/useSession'
 import {
   aiFeedbackToActionType,
@@ -77,6 +76,15 @@ function normalizeKeywordFingerprint(keywords: string[]): string {
 
 function areKeywordListsEqual(left: string[], right: string[]): boolean {
   return normalizeKeywordFingerprint(left) === normalizeKeywordFingerprint(right)
+}
+
+function appendKeywordToken(current: string[], token: string): string[] {
+  const normalizedToken = token.trim()
+  if (!normalizedToken) {
+    return current
+  }
+
+  return [...current, normalizedToken]
 }
 
 function normalizeOptionalNumber(value: number | undefined): number | undefined {
@@ -182,20 +190,6 @@ function getExportErrorMessage(value: unknown): string | undefined {
 
 function normalizeFilterToken(value: string): string {
   return value.trim().toLowerCase()
-}
-
-function toggleFilterValue(currentValues: string[], value: string): string[] {
-  const normalizedValue = value.trim()
-  if (normalizedValue.length === 0) {
-    return currentValues
-  }
-
-  const normalizedKey = normalizeFilterToken(normalizedValue)
-  if (currentValues.some((item) => normalizeFilterToken(item) === normalizedKey)) {
-    return currentValues.filter((item) => normalizeFilterToken(item) !== normalizedKey)
-  }
-
-  return [...currentValues, normalizedValue]
 }
 
 function toExperienceLevel(value: string | undefined): ExperienceLevelFilter | undefined {
@@ -461,7 +455,7 @@ export function useResumeListState(loadSearchHistory = false) {
   const expandedQuery = useMemo(() => {
     const kw = sessionKeywords.join(' ').trim()
     if (!kw) return undefined
-    return expandKeyword(kw, DEFAULT_CONFIG)
+    return kw
   }, [sessionKeywords])
 
   const { resumes: convexResumes, loading: convexLoading } = useConvexResumes(200, expandedQuery, jobDescriptionId)
@@ -935,12 +929,12 @@ export function useResumeListState(loadSearchHistory = false) {
   )
 
   const handleToggleTag = useCallback((tag: string) => {
-    setSelectedTags((current) => toggleFilterValue(current, tag))
-  }, [])
+    setSessionKeywords((current) => appendKeywordToken(current, tag))
+  }, [setSessionKeywords])
 
   const handleToggleCompany = useCallback((company: string) => {
-    setSelectedCompanies((current) => toggleFilterValue(current, company))
-  }, [])
+    setSessionKeywords((current) => appendKeywordToken(current, company))
+  }, [setSessionKeywords])
 
   const handleToggleExperienceLevel = useCallback((level: string | undefined) => {
     const normalizedLevel = toExperienceLevel(level)

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -299,6 +299,47 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/resumes/keyword-expansion": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Expand resume keyword query with synonyms
+         * @description Returns the backend-expanded keyword variants used for unified resume search
+         */
+        get: {
+            parameters: {
+                query?: {
+                    q?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ResumeKeywordExpansionResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/resumes": {
         parameters: {
             query?: never;
@@ -3702,6 +3743,23 @@ export interface components {
             success: true;
             samples: components["schemas"]["ResumeSample"][];
         };
+        ResumeKeywordExpansionResponse: {
+            /** @enum {boolean} */
+            success: true;
+            summary: {
+                keyword?: string;
+                groups: {
+                    original: string;
+                    variants: string[];
+                }[];
+                /** @enum {string} */
+                mode: "AND" | "OR";
+                expandedTo: string[];
+                sourceMapping: {
+                    [key: string]: string;
+                };
+            };
+        };
         ResumeSearchCriteria: {
             /** @example 销售 */
             keyword?: string;
@@ -3773,6 +3831,9 @@ export interface components {
                 total: number;
                 returned: number;
                 query?: string;
+                expandedTo?: string[];
+                /** @enum {string} */
+                mode?: "AND" | "OR";
             };
             data: components["schemas"]["ResumeItem"][];
         };

--- a/config/resume/skills.en.md
+++ b/config/resume/skills.en.md
@@ -2,21 +2,20 @@
 version: 6
 updated_at: '2026-03-11'
 description: >
-  简历筛选技能知识库（zh-Hans 主文件）。
-  用于背景计算代理的确定性匹配、同义词扩展与预评分。
-  该文件整合了规则评分、简历索引与行业词库配置。
+  English locale variant for the resume skills knowledge.
+  Maintained alongside the zh-Hans canonical source for localized authoring.
 ---
 
-# 技能知识库
+# Skills Knowledge
 
-本文件提供用于自动化简历筛选的结构化领域知识。`skills-knowledge.ts` 会解析该文件，供背景 ingest 代理在简历入库时预计算匹配信号。
+This file provides structured domain knowledge for automated resume screening. `skills-knowledge.ts` parses the zh-Hans canonical file at runtime, while this English variant is kept in sync for localized authoring and review.
 
-## 领域分类
+## Domain Taxonomy
 
-技能按领域标签组织。每个领域都包含 canonical tag、展示名称与关键词。
+Skills are organized by domain tags. Each domain includes a canonical tag, display name, and keyword set.
 
 ### machinery
-- displayName: 机械
+- displayName: Machinery
 - keywords: 机床, 车床, 加工中心, 机械, 设备, 五轴, 夹具, 治具, lathe, machining, milling
 
 ### cnc
@@ -24,24 +23,24 @@ description: >
 - keywords: cnc, 数控, fanuc, siemens, star, brother, mitsubishi
 
 ### sales
-- displayName: 销售
+- displayName: Sales
 - keywords: 销售, 业务, 客户, 大客户, 渠道, sales, account, bd, market, engineer
 
 ### automation
-- displayName: 自动化
+- displayName: Automation
 - keywords: 自动化, 机器人, plc, 伺服, automation
 
 ### metrology
-- displayName: 测量
+- displayName: Metrology
 - keywords: 测量, 三维扫描, 3d, cmm, metrology, scan
 
 ### software
-- displayName: 软件
+- displayName: Software
 - keywords: c++, c#, mfc, qt, 软件, 开发, algorithm, python
 
-## 同义词表
+## Synonym Table
 
-将变体术语映射到标准形式，用于搜索扩展与匹配归一化。
+Maps variant terms to canonical forms for search expansion and matching normalization.
 
 - 机床: 机械设备, 加工设备
 - 车床: CNC车床, 数控车床
@@ -58,25 +57,25 @@ description: >
 - CMM: 三坐标, 三坐标测量机
 - 软件: software, 程序, 应用
 
-## 经验等级信号
+## Experience Signals
 
-用于识别候选人经验层级的关键词信号，供 ingest 代理做确定性分层。
+Keyword signals used to infer candidate experience level during ingest.
 
 ### senior
-- displayName: 资深
+- displayName: Senior Level
 - keywords: 团队管理, 大客户, 渠道拓展, 主管, 经理, manager, lead, director, 带团队, 培训, 项目管理
 
 ### mid
-- displayName: 中级
+- displayName: Mid Level
 - keywords: 独立, 熟练, 精通, 负责, 专员, specialist, coordinator, 项目, 方案
 
 ### junior
-- displayName: 初级
+- displayName: Junior Level
 - keywords: 应届, 实习, 助理, assistant, trainee, intern, 学习, 协助, 初级
 
-## 公司数据库
+## Company Patterns
 
-目标行业内的重点公司与品牌别名，用于公司识别与行业背景验证。
+Key companies and brand aliases used for company recognition and industry verification.
 
 - FANUC [role: both] (aliases: 发那科, Fanuc)
 - SIEMENS [role: both] (aliases: 西门子, Siemens)
@@ -94,7 +93,7 @@ description: >
 - TSUGAMI [role: both] (aliases: 津上, つがみ)
 - JINGDIAO [role: both] (aliases: 北京精雕, 精雕科技, 精雕集团)
 
-第一梯队 - CNC / 加工
+Tier 1 - CNC / Machining
 - HARDINGE [role: both] (aliases: 哈挺, Hardinge)
 - YASDA [role: both] (aliases: 安田, ヤスダ)
 - HERMLE [role: both] (aliases: 哈默, 赫姆勒)
@@ -115,11 +114,11 @@ description: >
 - NOMURA [role: both] (aliases: 野村)
 - FIDIA [role: equipment] (aliases: 菲迪亚)
 
-第二梯队 - EDM / 线切割
+Tier 2 - EDM / Wire Cutting
 - SODICK [role: equipment] (aliases: 沙迪克, ソディック)
 - CHARMILLES [role: equipment] (aliases: 夏米尔, GF AgieCharmilles)
 
-第三梯队 - 测量 / 计量
+Tier 3 - Measurement / Metrology
 - HEXAGON [role: equipment] (aliases: 海克斯康, ヘキサゴン)
 - ZEISS [role: equipment] (aliases: 蔡司, 卡尔蔡司, Carl Zeiss)
 - KEYENCE [role: equipment] (aliases: 基恩士, キーエンス)
@@ -130,12 +129,12 @@ description: >
 - MAHR [role: equipment] (aliases: 马尔)
 - TESA [role: equipment] (aliases: 天萨)
 
-第四梯队 - 刀具 / 零部件
+Tier 4 - Tooling / Components
 - SANDVIK [role: equipment] (aliases: 山特维克, サンドビック)
 - MARPOSS [role: equipment] (aliases: 马波斯, マーポス)
 - HEIDENHAIN [role: equipment] (aliases: 海德汉, ハイデンハイン)
 
-第五梯队 - 国产 / 珠三角
+Tier 5 - Domestic / Pearl River Delta
 - 创世纪 [role: both] (aliases: 深圳创世纪, CGJ)
 - 台群 [role: both] (aliases: 台群精机, Taiqun)
 - 沈阳机床 [role: both] (aliases: 沈机, SMTCL)
@@ -148,31 +147,31 @@ description: >
 - 程泰 [role: both] (aliases: 程泰机械, Goodway)
 - 乔锋 [role: both] (aliases: 乔锋智能, Qiaofeng)
 
-## 行业背景
+## Industry Context
 
-供 AI 提示增强与领域理解使用的行业背景说明。
+Background notes used for AI prompt enrichment and domain understanding.
 
-### CNC 加工领域
-CNC（Computer Numerical Control，计算机数控）加工是通过程序控制机床执行自动化加工。核心品牌包括 FANUC、SIEMENS、STAR、BROTHER 与 MITSUBISHI。常见设备类型包括车床、加工中心与五轴系统。
+### CNC Machining Domain
+CNC (Computer Numerical Control) machining uses programmed commands to automate machine tools. Core brands include FANUC, SIEMENS, STAR, BROTHER, and MITSUBISHI. Common machine types include lathes, machining centers, and multi-axis systems.
 
-### 销售与业务拓展
-制造业设备 B2B 销售通常需要设备技术理解、客户关系管理与渠道开发能力。典型关键词包括大客户、渠道与业务拓展。
+### Sales and Business Development
+B2B sales for manufacturing equipment usually requires technical product knowledge, customer relationship management, and channel development capability. Typical keywords include key accounts, channels, and business development.
 
-### 测量与质量
-精密测量通常依赖 CMM（三坐标测量机）、3D 扫描与质量检测流程，是制造业 QA/QC 的关键环节。
+### Metrology and Quality
+Precision measurement relies on CMM (Coordinate Measuring Machine), 3D scanning, and quality inspection workflows, which are critical to manufacturing QA/QC.
 
-### 自动化
-工业自动化场景常涉及 PLC、伺服系统与机器人，广泛应用于工厂自动化与智能制造。
+### Automation
+Industrial automation commonly involves PLCs, servo systems, and robotics across factory automation and smart manufacturing scenarios.
 
-## 排除模式
+## Exclusion Patterns
 
-表示无关内容（如广告、推广）的 token。命中后会被标记为需复核。
+Tokens indicating irrelevant content such as ads and promotions. Matching resumes are flagged for review.
 
 - exclude: ad, promo, 广告, 推广, 招商, 加盟, spam
 
-## 学习日志（压缩版）
+## Learning Log (Compacted)
 
-HR 反馈模式与观察记录。已于 2026-03-10 从 174 条原始 shortlist 记录压缩为 50 个唯一模式。带 `(Nx)` 后缀的 `shortlist_pattern` 仍保持机器可读，用于表示信号强度。
+HR feedback patterns and observations. On 2026-03-10, 174 raw shortlist entries were compacted into 50 unique patterns. `shortlist_pattern` entries with `(Nx)` suffixes remain machine-readable as weighted signals.
 
 - 2026-03-10: shortlist_pattern: sales + mid -> high_priority (22x)
 - 2026-03-10: shortlist_pattern: sales + senior -> high_priority (19x)

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -95,6 +95,103 @@ function appendMissingTokens(existingSearchText: string, tokens: string[]): stri
         : missingTokens.join(" ");
 }
 
+type MatchSource = "searchText" | "industryTags" | "companyHits" | "synonymHits";
+
+type SearchProvenance = {
+    term: string;
+    source: MatchSource;
+    expandedFrom?: string;
+};
+
+function dedupeProvenance(items: SearchProvenance[]): SearchProvenance[] {
+    const seen = new Set<string>();
+    const deduped: SearchProvenance[] = [];
+
+    for (const item of items) {
+        const key = `${item.source}|${item.term}|${item.expandedFrom ?? ""}`;
+        if (seen.has(key)) {
+            continue;
+        }
+        seen.add(key);
+        deduped.push(item);
+    }
+
+    return deduped;
+}
+
+function addProvenance(
+    target: Map<string, SearchProvenance[]>,
+    key: string,
+    provenance: SearchProvenance
+): void {
+    const existing = target.get(key);
+    if (existing) {
+        existing.push(provenance);
+        return;
+    }
+    target.set(key, [provenance]);
+}
+
+function compareResumes(
+    left: Doc<"resumes">,
+    right: Doc<"resumes">,
+    jobDescriptionId: string | undefined
+): number {
+    const ruleDiff = getIngestRuleScore(right, jobDescriptionId) - getIngestRuleScore(left, jobDescriptionId);
+    if (ruleDiff !== 0) {
+        return ruleDiff;
+    }
+
+    const primaryRuleDiff = (right.primaryRuleScore || 0) - (left.primaryRuleScore || 0);
+    if (primaryRuleDiff !== 0) {
+        return primaryRuleDiff;
+    }
+
+    return right.crawledAt - left.crawledAt;
+}
+
+function mergeResumeDocs(
+    docs: Doc<"resumes">[],
+    provenanceByResumeId: Map<string, SearchProvenance[]>,
+    jobDescriptionId: string | undefined,
+    limit: number
+): Array<{ resume: Doc<"resumes">; provenance: SearchProvenance[] }> {
+    const merged = new Map<string, { resume: Doc<"resumes">; provenance: SearchProvenance[] }>();
+
+    for (const doc of docs) {
+        const identityKey = typeof doc.identityKey === "string" && doc.identityKey.trim().length > 0
+            ? doc.identityKey
+            : String(doc._id);
+        const incomingProvenance = provenanceByResumeId.get(String(doc._id)) ?? [];
+        const existing = merged.get(identityKey);
+
+        if (!existing) {
+            merged.set(identityKey, {
+                resume: doc,
+                provenance: dedupeProvenance(incomingProvenance),
+            });
+            continue;
+        }
+
+        const preferredResume = compareResumes(existing.resume, doc, jobDescriptionId) <= 0
+            ? existing.resume
+            : doc;
+        merged.set(identityKey, {
+            resume: preferredResume,
+            provenance: dedupeProvenance([...existing.provenance, ...incomingProvenance]),
+        });
+    }
+
+    return Array.from(merged.values())
+        .sort((left, right) => {
+            if (right.provenance.length !== left.provenance.length) {
+                return right.provenance.length - left.provenance.length;
+            }
+            return compareResumes(left.resume, right.resume, jobDescriptionId);
+        })
+        .slice(0, limit);
+}
+
 export const count = query({
     args: {},
     handler: async (ctx) => {
@@ -182,6 +279,152 @@ export const searchWithIngestData = query({
         }
 
         return sortByIngestRuleScore(filtered, jobDescriptionId).slice(0, limit);
+    },
+});
+
+export const searchWithTagExpansion = query({
+    args: {
+        query: v.string(),
+        keywordGroups: v.array(v.object({
+            original: v.string(),
+            variants: v.array(v.string()),
+        })),
+        mode: v.optional(v.union(v.literal("AND"), v.literal("OR"))),
+        sourceMappings: v.optional(v.array(v.object({
+            term: v.string(),
+            expandedFrom: v.string(),
+        }))),
+        limit: v.optional(v.number()),
+        jobDescriptionId: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const limit = args.limit || 50;
+        const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
+        const mode = args.mode ?? "AND";
+        const keywordGroups = args.keywordGroups
+            .map((group) => ({
+                original: group.original.trim().toLowerCase(),
+                variants: Array.from(
+                    new Set(
+                        group.variants
+                            .map((term) => term.trim().toLowerCase())
+                            .filter((term) => term.length >= 2)
+                    )
+                ),
+            }))
+            .filter((group) => group.original.length >= 1 && group.variants.length > 0);
+        const expandedTerms = Array.from(new Set(keywordGroups.flatMap((group) => group.variants)));
+
+        if (expandedTerms.length === 0 || keywordGroups.length === 0) {
+            return {
+                expansion: {
+                    original: args.query,
+                    expanded: [],
+                    groups: [],
+                    mode,
+                },
+                results: [],
+            };
+        }
+
+        const sourceMapping = Object.fromEntries(
+            (args.sourceMappings ?? []).map((entry) => [entry.term, entry.expandedFrom])
+        );
+        const provenanceByResumeId = new Map<string, SearchProvenance[]>();
+        const textMatchesById = new Map<string, Doc<"resumes">>();
+
+        for (const term of expandedTerms) {
+            const matches = await ctx.db
+                .query("resumes")
+                .withSearchIndex("search_body", (q) => q.search("searchText", term))
+                .take(Math.max(limit * 2, 100));
+
+            for (const match of matches) {
+                textMatchesById.set(String(match._id), match);
+                addProvenance(provenanceByResumeId, String(match._id), {
+                    term,
+                    source: "searchText",
+                    expandedFrom: sourceMapping[term],
+                });
+            }
+        }
+
+        const allResumes = await ctx.db.query("resumes").collect();
+        const allMatchedDocs: Doc<"resumes">[] = Array.from(textMatchesById.values());
+        const seenDocIds = new Set(allMatchedDocs.map((doc) => String(doc._id)));
+
+        for (const doc of allResumes) {
+            const industryTags = toNormalizedTokens(doc.ingestData?.industryTags);
+            const companyHits = toNormalizedTokens(doc.ingestData?.companyHits);
+            const synonymHits = toNormalizedTokens(doc.ingestData?.synonymHits);
+            const matchedTerms = expandedTerms.filter((term) =>
+                industryTags.includes(term)
+                || companyHits.includes(term)
+                || synonymHits.includes(term)
+            );
+
+            if (matchedTerms.length === 0) {
+                continue;
+            }
+
+            for (const term of matchedTerms) {
+                if (industryTags.includes(term)) {
+                    addProvenance(provenanceByResumeId, String(doc._id), {
+                        term,
+                        source: "industryTags",
+                        expandedFrom: sourceMapping[term],
+                    });
+                }
+                if (companyHits.includes(term)) {
+                    addProvenance(provenanceByResumeId, String(doc._id), {
+                        term,
+                        source: "companyHits",
+                        expandedFrom: sourceMapping[term],
+                    });
+                }
+                if (synonymHits.includes(term)) {
+                    addProvenance(provenanceByResumeId, String(doc._id), {
+                        term,
+                        source: "synonymHits",
+                        expandedFrom: sourceMapping[term],
+                    });
+                }
+            }
+
+            if (!seenDocIds.has(String(doc._id))) {
+                allMatchedDocs.push(doc);
+                seenDocIds.add(String(doc._id));
+            }
+        }
+
+        const filteredDocs = allMatchedDocs.filter((doc) => {
+            const normalizedSearchText = (doc.searchText || "").toLowerCase();
+            const industryTags = toNormalizedTokens(doc.ingestData?.industryTags);
+            const companyHits = toNormalizedTokens(doc.ingestData?.companyHits);
+            const synonymHits = toNormalizedTokens(doc.ingestData?.synonymHits);
+
+            const groupMatched = (group: { variants: string[] }): boolean =>
+                group.variants.some((variant) =>
+                    normalizedSearchText.includes(variant)
+                    || industryTags.includes(variant)
+                    || companyHits.includes(variant)
+                    || synonymHits.includes(variant)
+                );
+
+            return mode === "AND"
+                ? keywordGroups.every(groupMatched)
+                : keywordGroups.some(groupMatched);
+        });
+
+        return {
+            expansion: {
+                original: args.query,
+                expanded: expandedTerms,
+                groups: keywordGroups,
+                mode,
+            },
+            results: mergeResumeDocs(filteredDocs, provenanceByResumeId, jobDescriptionId, limit),
+        };
     },
 });
 


### PR DESCRIPTION
Summary
- Introduce the new `UnifiedSearchService` so resume keywords expand via skills synonyms and match against resume text, industry tags, and companies with a provenance-aware scoring pipeline.
- Wire the unified search flow into the resume API schema/service, expose the hit provenance in Convex-backed results, and add unit coverage for the expansion logic.
- Update the resume list hook to merge Convex ingest data, rule scores, and provenance/tags so the UI can surface the enriched keyword matches.

Testing
- Not run (not requested)