### PR TITLE
Fix Convex resume search byte limit

### DIFF
--- a/packages/convex/convex/__tests__/search-text.test.ts
+++ b/packages/convex/convex/__tests__/search-text.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { appendMissingSearchTokens, buildIngestSearchTokens, mergeSearchTextWithIngestData } from "../search_text";
+
+describe("buildIngestSearchTokens", () => {
+    it("normalizes and deduplicates ingest metadata tokens", () => {
+        expect(buildIngestSearchTokens({
+            industryTags: [" Machinery ", "cnc"],
+            synonymHits: ["CNC", "sales engineer"],
+            companyHits: ["FANUC", "fanuc"],
+            companyAliasTokens: "  Fanuc 发那科  ",
+        })).toEqual([
+            "machinery",
+            "cnc",
+            "sales engineer",
+            "fanuc",
+            "发那科",
+        ]);
+    });
+});
+
+describe("appendMissingSearchTokens", () => {
+    it("adds only tokens that are not already present", () => {
+        expect(appendMissingSearchTokens("sales cnc", ["cnc", "machinery", "sales engineer"])).toBe(
+            "sales cnc machinery sales engineer"
+        );
+    });
+});
+
+describe("mergeSearchTextWithIngestData", () => {
+    it("augments search text with industry tags, companies, synonyms, and aliases", () => {
+        expect(mergeSearchTextWithIngestData("销售 cnc", {
+            industryTags: ["machinery", "sales"],
+            synonymHits: ["sales engineer", "cnc"],
+            companyHits: ["fanuc"],
+            companyAliasTokens: "fanuc 发那科",
+        })).toBe("销售 cnc machinery sales sales engineer fanuc 发那科");
+    });
+});

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -4,7 +4,7 @@ import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { buildWorkHistoryEvidence } from "@trends/shared";
 
-import { buildSearchText } from "./search_text";
+import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
 import { deriveResumeIdentityKey } from "./lib/resume_identity";
 import { parseAgeFromContent } from "./lib/age";
 import { DEFAULT_WORKSPACE_SLUG } from "./sessions";
@@ -237,7 +237,11 @@ export const backfillSearchText = mutation({
         for (const resume of resumes) {
             if (resume.searchText) continue;
 
-            const searchText = buildSearchText(resume.content);
+            const searchText = mergeSearchTextWithIngestData(buildSearchText(resume.content), {
+                industryTags: resume.ingestData?.industryTags,
+                synonymHits: resume.ingestData?.synonymHits,
+                companyHits: resume.ingestData?.companyHits,
+            });
 
             await ctx.db.patch(resume._id, { searchText });
             count++;
@@ -252,7 +256,11 @@ export const reindexSearchText = mutation({
         const resumes = await ctx.db.query("resumes").collect();
         let count = 0;
         for (const resume of resumes) {
-            const searchText = buildSearchText(resume.content);
+            const searchText = mergeSearchTextWithIngestData(buildSearchText(resume.content), {
+                industryTags: resume.ingestData?.industryTags,
+                synonymHits: resume.ingestData?.synonymHits,
+                companyHits: resume.ingestData?.companyHits,
+            });
             if (searchText !== resume.searchText) {
                 await ctx.db.patch(resume._id, { searchText });
                 count++;

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -2,6 +2,8 @@ import { internalMutation, internalQuery, mutation, query } from "./_generated/s
 import type { Doc } from "./_generated/dataModel";
 import { v } from "convex/values";
 
+import { mergeSearchTextWithIngestData } from "./search_text";
+
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null;
 }
@@ -63,36 +65,6 @@ function matchesAllTokens(searchText: string | undefined, tokens: string[]): boo
     }
     const normalizedText = (searchText || "").toLowerCase();
     return tokens.every((token) => normalizedText.includes(token));
-}
-
-function toNormalizedTokens(values: string[] | undefined): string[] {
-    if (!Array.isArray(values) || values.length === 0) {
-        return [];
-    }
-
-    return Array.from(
-        new Set(
-            values
-                .map((value) => value.trim().toLowerCase())
-                .filter((value) => value.length >= 2)
-        )
-    );
-}
-
-function appendMissingTokens(existingSearchText: string, tokens: string[]): string {
-    if (tokens.length === 0) {
-        return existingSearchText;
-    }
-
-    const normalizedExisting = existingSearchText.toLowerCase();
-    const missingTokens = tokens.filter((token) => !normalizedExisting.includes(token));
-    if (missingTokens.length === 0) {
-        return existingSearchText;
-    }
-
-    return existingSearchText
-        ? `${existingSearchText} ${missingTokens.join(" ")}`
-        : missingTokens.join(" ");
 }
 
 type MatchSource = "searchText" | "industryTags" | "companyHits" | "synonymHits";
@@ -331,17 +303,19 @@ export const searchWithTagExpansion = query({
             (args.sourceMappings ?? []).map((entry) => [entry.term, entry.expandedFrom])
         );
         const provenanceByResumeId = new Map<string, SearchProvenance[]>();
-        const textMatchesById = new Map<string, Doc<"resumes">>();
+        const matchedDocsById = new Map<string, Doc<"resumes">>();
+        const fetchLimit = Math.max(limit * Math.max(keywordGroups.length, 2), 100);
 
         for (const term of expandedTerms) {
             const matches = await ctx.db
                 .query("resumes")
                 .withSearchIndex("search_body", (q) => q.search("searchText", term))
-                .take(Math.max(limit * 2, 100));
+                .take(fetchLimit);
 
             for (const match of matches) {
-                textMatchesById.set(String(match._id), match);
-                addProvenance(provenanceByResumeId, String(match._id), {
+                const matchId = String(match._id);
+                matchedDocsById.set(matchId, match);
+                addProvenance(provenanceByResumeId, matchId, {
                     term,
                     source: "searchText",
                     expandedFrom: sourceMapping[term],
@@ -349,67 +323,11 @@ export const searchWithTagExpansion = query({
             }
         }
 
-        const allResumes = await ctx.db.query("resumes").collect();
-        const allMatchedDocs: Doc<"resumes">[] = Array.from(textMatchesById.values());
-        const seenDocIds = new Set(allMatchedDocs.map((doc) => String(doc._id)));
-
-        for (const doc of allResumes) {
-            const industryTags = toNormalizedTokens(doc.ingestData?.industryTags);
-            const companyHits = toNormalizedTokens(doc.ingestData?.companyHits);
-            const synonymHits = toNormalizedTokens(doc.ingestData?.synonymHits);
-            const matchedTerms = expandedTerms.filter((term) =>
-                industryTags.includes(term)
-                || companyHits.includes(term)
-                || synonymHits.includes(term)
-            );
-
-            if (matchedTerms.length === 0) {
-                continue;
-            }
-
-            for (const term of matchedTerms) {
-                if (industryTags.includes(term)) {
-                    addProvenance(provenanceByResumeId, String(doc._id), {
-                        term,
-                        source: "industryTags",
-                        expandedFrom: sourceMapping[term],
-                    });
-                }
-                if (companyHits.includes(term)) {
-                    addProvenance(provenanceByResumeId, String(doc._id), {
-                        term,
-                        source: "companyHits",
-                        expandedFrom: sourceMapping[term],
-                    });
-                }
-                if (synonymHits.includes(term)) {
-                    addProvenance(provenanceByResumeId, String(doc._id), {
-                        term,
-                        source: "synonymHits",
-                        expandedFrom: sourceMapping[term],
-                    });
-                }
-            }
-
-            if (!seenDocIds.has(String(doc._id))) {
-                allMatchedDocs.push(doc);
-                seenDocIds.add(String(doc._id));
-            }
-        }
-
-        const filteredDocs = allMatchedDocs.filter((doc) => {
+        const filteredDocs = Array.from(matchedDocsById.values()).filter((doc) => {
             const normalizedSearchText = (doc.searchText || "").toLowerCase();
-            const industryTags = toNormalizedTokens(doc.ingestData?.industryTags);
-            const companyHits = toNormalizedTokens(doc.ingestData?.companyHits);
-            const synonymHits = toNormalizedTokens(doc.ingestData?.synonymHits);
 
             const groupMatched = (group: { variants: string[] }): boolean =>
-                group.variants.some((variant) =>
-                    normalizedSearchText.includes(variant)
-                    || industryTags.includes(variant)
-                    || companyHits.includes(variant)
-                    || synonymHits.includes(variant)
-                );
+                group.variants.some((variant) => normalizedSearchText.includes(variant));
 
             return mode === "AND"
                 ? keywordGroups.every(groupMatched)
@@ -571,17 +489,12 @@ export const updateIngestData = internalMutation({
         };
 
         const existingSearchText = resume.searchText || "";
-        let nextSearchText = existingSearchText;
-
-        const aliasTokens = args.companyAliasTokens?.trim().toLowerCase();
-        if (aliasTokens) {
-            nextSearchText = appendMissingTokens(nextSearchText, [aliasTokens]);
-        }
-
-        const synonymTokens = toNormalizedTokens(args.ingestData.synonymHits);
-        if (synonymTokens.length > 0) {
-            nextSearchText = appendMissingTokens(nextSearchText, synonymTokens);
-        }
+        const nextSearchText = mergeSearchTextWithIngestData(existingSearchText, {
+            industryTags: args.ingestData.industryTags,
+            synonymHits: args.ingestData.synonymHits,
+            companyHits: args.ingestData.companyHits,
+            companyAliasTokens: args.companyAliasTokens?.trim().toLowerCase(),
+        });
 
         if (nextSearchText !== existingSearchText) {
             patch.searchText = nextSearchText;
@@ -658,17 +571,12 @@ export const updateIngestDataBatch = internalMutation({
             };
 
             const existingSearchText = resume.searchText || "";
-            let nextSearchText = existingSearchText;
-
-            const aliasTokens = update.companyAliasTokens?.trim().toLowerCase();
-            if (aliasTokens) {
-                nextSearchText = appendMissingTokens(nextSearchText, [aliasTokens]);
-            }
-
-            const synonymTokens = toNormalizedTokens(update.ingestData.synonymHits);
-            if (synonymTokens.length > 0) {
-                nextSearchText = appendMissingTokens(nextSearchText, synonymTokens);
-            }
+            const nextSearchText = mergeSearchTextWithIngestData(existingSearchText, {
+                industryTags: update.ingestData.industryTags,
+                synonymHits: update.ingestData.synonymHits,
+                companyHits: update.ingestData.companyHits,
+                companyAliasTokens: update.companyAliasTokens?.trim().toLowerCase(),
+            });
 
             if (nextSearchText !== existingSearchText) {
                 patch.searchText = nextSearchText;

--- a/packages/convex/convex/search_text.ts
+++ b/packages/convex/convex/search_text.ts
@@ -32,6 +32,66 @@ function addScriptBoundarySpaces(text: string): string {
         .replace(new RegExp(`(${ASCII_WORD})(${CJK_CHAR})`, "g"), "$1 $2");
 }
 
+function toNormalizedSearchTokens(values: readonly string[] | undefined): string[] {
+    if (!Array.isArray(values) || values.length === 0) {
+        return [];
+    }
+
+    return Array.from(
+        new Set(
+            values
+                .map((value) => normalizeWhitespace(value).toLowerCase())
+                .filter((value) => value.length >= 2)
+        )
+    );
+}
+
+export function appendMissingSearchTokens(existingSearchText: string, tokens: readonly string[]): string {
+    const normalizedTokens = toNormalizedSearchTokens(tokens);
+    if (normalizedTokens.length === 0) {
+        return existingSearchText;
+    }
+
+    const normalizedExisting = existingSearchText.toLowerCase();
+    const missingTokens = normalizedTokens.filter((token) => !normalizedExisting.includes(token));
+    if (missingTokens.length === 0) {
+        return existingSearchText;
+    }
+
+    return existingSearchText
+        ? `${existingSearchText} ${missingTokens.join(" ")}`
+        : missingTokens.join(" ");
+}
+
+type IngestSearchTextOptions = {
+    industryTags?: readonly string[];
+    synonymHits?: readonly string[];
+    companyHits?: readonly string[];
+    companyAliasTokens?: string;
+};
+
+export function buildIngestSearchTokens(options: IngestSearchTextOptions): string[] {
+    const aliasTokens = typeof options.companyAliasTokens === "string"
+        ? options.companyAliasTokens.split(/\s+/)
+        : [];
+
+    return Array.from(
+        new Set([
+            ...toNormalizedSearchTokens(options.industryTags),
+            ...toNormalizedSearchTokens(options.synonymHits),
+            ...toNormalizedSearchTokens(options.companyHits),
+            ...toNormalizedSearchTokens(aliasTokens),
+        ])
+    );
+}
+
+export function mergeSearchTextWithIngestData(
+    existingSearchText: string,
+    options: IngestSearchTextOptions
+): string {
+    return appendMissingSearchTokens(existingSearchText, buildIngestSearchTokens(options));
+}
+
 function toTextFragments(value: unknown): string[] {
     if (value === null || value === undefined) {
         return [];


### PR DESCRIPTION
## Summary
- remove the full-table fallback from `searchWithTagExpansion` so expanded resume search stays within Convex read limits
- merge ingest-derived tags, company hits, and synonyms into `searchText` for both live updates and search-text migrations
- add focused tests for ingest search token normalization and merging

## Test plan
- [x] bunx vitest run packages/convex/convex/__tests__/search-text.test.ts
- [x] bun run --filter @trends/convex typecheck
- [x] make check
- [x] reload `http://localhost:5173/dev/resumes?keyword=%E9%94%80%E5%94%AE+CNC&minAge=25&maxAge=40` and confirm the page renders instead of the Convex byte-limit error