### PR TITLE
Add safe first-party resume import path

### DIFF
--- a/apps/api/src/routes/resume-import.test.ts
+++ b/apps/api/src/routes/resume-import.test.ts
@@ -1,0 +1,254 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import resumesRoutes from "./resumes";
+import { workspaceMiddleware } from "../middleware/workspace";
+
+type ConvexCall = {
+  pathName: string;
+  args: Record<string, unknown>;
+};
+
+function createTestApp() {
+  const app = new OpenAPIHono();
+  app.use("*", workspaceMiddleware);
+  app.route("/", resumesRoutes);
+  return app;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+  const requestUrl = typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+
+  if (!requestUrl.includes("/api/mutation")) {
+    throw new Error(`Unexpected request URL: ${requestUrl}`);
+  }
+
+  const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+  if (!isRecord(body)) {
+    throw new Error("Missing convex request body");
+  }
+
+  const pathName = typeof body.path === "string" ? body.path : "";
+  const args = isRecord(body.args) ? body.args : {};
+  if (!pathName) {
+    throw new Error("Missing convex path in request body");
+  }
+
+  return { pathName, args };
+}
+
+function convexSuccess(value: unknown): Response {
+  return new Response(
+    JSON.stringify({
+      status: "success",
+      value,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+}
+
+describe("resume import route", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("blocks hr workspace users from importing resumes", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const app = createTestApp();
+
+    const response = await app.request("/api/resumes/import", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        metadata: {
+          sourceUrl: "https://hr.job5156.com/search?keyword=%E9%94%80%E5%94%AE",
+          generatedBy: "manual-import@1.0.0",
+        },
+        resumes: [
+          {
+            resumeId: "R123456",
+            name: "Alex Chen",
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Admin access required",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows dev admin import for legacy payloads", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+      if (call.pathName === "resume_tasks:submitResumes") {
+        return convexSuccess({
+          submitted: 1,
+          deduped: 0,
+          inserted: 1,
+          updated: 0,
+          unchanged: 0,
+        });
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createTestApp();
+    const response = await app.request("/api/resumes/import", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify({
+        metadata: {
+          sourceUrl: "https://hr.job5156.com/search?keyword=%E9%94%80%E5%94%AE",
+          generatedBy: "manual-import@1.0.0",
+          searchCriteria: {
+            keyword: "销售",
+            location: "东莞",
+            filters: {},
+          },
+        },
+        data: [
+          {
+            resumeId: 1079188,
+            perUserId: 1079188,
+            name: "骆先生",
+            profileUrl: "javascript:;",
+            activityStatus: "在线中",
+            age: "42岁",
+            experience: "20年",
+            education: "高中",
+            location: "东莞石碣镇",
+            jobIntention: "东莞石碣镇机械制图员",
+            expectedSalary: "6000-7999元/月",
+            selfIntro: "...",
+            workHistory: [{ raw: "2018-01 ~ 至今 Example Co." }],
+            extractedAt: "2026-02-11T13:01:41.009Z",
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      submitted: 1,
+      inserted: 1,
+      updated: 0,
+      unchanged: 0,
+      deduped: 0,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toMatchObject({
+      resumes: [
+        {
+          externalId: "hr.job5156.com:resume:1079188",
+          source: "hr.job5156.com",
+          tags: ["销售"],
+        },
+      ],
+    });
+  });
+
+  it("accepts source-aware payloads for admin imports", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+      if (call.pathName === "resume_tasks:submitResumes") {
+        return convexSuccess({
+          submitted: 1,
+          deduped: 0,
+          inserted: 1,
+          updated: 0,
+          unchanged: 0,
+        });
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createTestApp();
+    const response = await app.request("/api/resumes/import", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify({
+        metadata: {
+          sourceKey: "seek",
+          sourceHost: "hk.employer.seek.com",
+          sourceUrl: "https://hk.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=2",
+          keyword: "sales engineer",
+          generatedBy: "manual-import@1.0.0",
+          collectionContext: {
+            captureMode: "json-upload",
+            operation: "manual-import",
+            jobId: 90842915,
+            pageNumber: 2,
+            language: "en",
+            profileType: "seek",
+          },
+        },
+        resumes: [
+          {
+            profileId: 503033454,
+            profileType: "seek",
+            name: "yap kae wen",
+            profileUrl: "https://hk.employer.seek.com/candidates/503033454",
+            activityStatus: "Updated recently",
+            location: "Shah Alam, Selangor, MY",
+            jobIntention: "Senior Sales Engineer",
+            workHistory: [{ raw: "Senior Sales Engineer · Example Co." }],
+            extractedAt: "2026-03-12T01:02:03.000Z",
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      submitted: 1,
+      inserted: 1,
+      updated: 0,
+      unchanged: 0,
+      deduped: 0,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toMatchObject({
+      resumes: [
+        {
+          externalId: "hk.employer.seek.com:profile:503033454",
+          source: "hk.employer.seek.com",
+          tags: ["sales engineer"],
+        },
+      ],
+    });
+  });
+});

--- a/apps/api/src/routes/resume-submit.ts
+++ b/apps/api/src/routes/resume-submit.ts
@@ -1,180 +1,25 @@
-import crypto from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
-
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
-import { config } from "../services/config.js";
+import {
+  ResumeImportItemSchema,
+  ResumeImportMetadataSchema,
+  ResumeSubmitSummarySchema,
+} from "../schemas/resumes.js";
+import { resolveConvexUrl, submitResumeImport } from "../services/resume-import-service.js";
 
 const app = new OpenAPIHono();
 
-const ResumeSubmitMetadataSchema = z.object({
-  sourceUrl: z.string().url(),
-  keyword: z.string().optional(),
-  location: z.string().optional(),
-  searchProfileId: z.string().optional(),
-  generatedBy: z.string(),
-});
-
-const ResumeSubmitWorkHistorySchema = z.object({
-  raw: z.string(),
-});
-
-const ResumeSubmitItemSchema = z.object({
-  resumeId: z.union([z.string(), z.number()]).pipe(z.coerce.string()).optional(),
-  perUserId: z.union([z.string(), z.number()]).pipe(z.coerce.string()).optional(),
-  name: z.string(),
-  age: z.string().optional(),
-  experience: z.string().optional(),
-  education: z.string().optional(),
-  location: z.string().optional(),
-  jobIntention: z.string().optional(),
-  expectedSalary: z.string().optional(),
-  selfIntro: z.string().optional(),
-  workHistory: z.array(ResumeSubmitWorkHistorySchema).optional(),
-  profileUrl: z.string().optional(),
-  activityStatus: z.string().optional(),
-  extractedAt: z.string().optional(),
-});
-
 const ResumeSubmitRequestSchema = z.object({
-  metadata: ResumeSubmitMetadataSchema,
-  resumes: z.array(ResumeSubmitItemSchema),
+  metadata: ResumeImportMetadataSchema,
+  resumes: z.array(ResumeImportItemSchema),
 });
 
-const ResumeSubmitResponseSchema = z.object({
-  success: z.literal(true),
-  submitted: z.number().int(),
-  inserted: z.number().int(),
-  updated: z.number().int(),
-  unchanged: z.number().int(),
-  deduped: z.number().int(),
-});
+const ResumeSubmitResponseSchema = ResumeSubmitSummarySchema;
 
 const ResumeSubmitErrorSchema = z.object({
   success: z.literal(false),
   error: z.string(),
 });
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function stableStringify(value: unknown): string {
-  if (value === null) return "null";
-  if (value === undefined) return "undefined";
-
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(",")}]`;
-  }
-
-  if (typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    const keys = Object.keys(record).sort((a, b) => a.localeCompare(b));
-    return `{${keys.map((key) => `${key}:${stableStringify(record[key])}`).join(",")}}`;
-  }
-
-  return JSON.stringify(value);
-}
-
-function readEnvVarFromFile(filePath: string, key: string): string | null {
-  try {
-    if (!fs.existsSync(filePath)) return null;
-    const content = fs.readFileSync(filePath, "utf8");
-    const lines = content.split(/\r?\n/);
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#")) continue;
-      const idx = trimmed.indexOf("=");
-      if (idx < 0) continue;
-      const k = trimmed.slice(0, idx).trim();
-      if (k !== key) continue;
-      const v = trimmed.slice(idx + 1).trim();
-      return v.replace(/^['"]|['"]$/g, "");
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-function resolveConvexUrl(): string {
-  if (process.env.CONVEX_URL) return process.env.CONVEX_URL;
-  if (process.env.VITE_CONVEX_URL) return process.env.VITE_CONVEX_URL;
-
-  const candidateFiles = [
-    path.join(config.projectRoot, "packages", "convex", ".env.local"),
-    path.join(config.projectRoot, "apps", "web", ".env.local"),
-    path.join(config.projectRoot, ".env.local"),
-    path.join(config.projectRoot, ".env"),
-  ];
-
-  for (const filePath of candidateFiles) {
-    const direct = readEnvVarFromFile(filePath, "CONVEX_URL");
-    if (direct) return direct;
-    const vite = readEnvVarFromFile(filePath, "VITE_CONVEX_URL");
-    if (vite) return vite;
-  }
-
-  return "http://127.0.0.1:3210";
-}
-
-async function submitResumesToConvex(args: {
-  resumes: Array<{
-    externalId: string;
-    content: unknown;
-    hash: string;
-    source: string;
-    tags: string[];
-  }>;
-}): Promise<{
-  submitted: number;
-  deduped: number;
-  inserted: number;
-  updated: number;
-  unchanged: number;
-}> {
-  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
-  const response = await fetch(`${convexUrl}/api/mutation`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({
-      path: "resume_tasks:submitResumes",
-      args,
-    }),
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Convex mutation failed (${response.status}): ${text}`);
-  }
-
-  const payload = (await response.json()) as {
-    status?: string;
-    value?: unknown;
-    errorMessage?: string;
-  };
-
-  if (payload.status !== "success") {
-    throw new Error(payload.errorMessage || "Convex mutation failed");
-  }
-
-  if (!isRecord(payload.value)) {
-    throw new Error("Invalid submitResumes response from Convex");
-  }
-
-  const value = payload.value;
-  return {
-    submitted: typeof value.submitted === "number" ? value.submitted : 0,
-    deduped: typeof value.deduped === "number" ? value.deduped : 0,
-    inserted: typeof value.inserted === "number" ? value.inserted : 0,
-    updated: typeof value.updated === "number" ? value.updated : 0,
-    unchanged: typeof value.unchanged === "number" ? value.unchanged : 0,
-  };
-}
 
 async function recordSyncError(errorMessage: string): Promise<void> {
   try {
@@ -320,41 +165,9 @@ app.openapi(resumeSubmitRoute, async (c) => {
       return c.json({ success: false as const, error: "Invalid resume submit payload" }, 400);
     }
 
-    const { metadata, resumes } = parsedBody.data;
+    const result = await submitResumeImport(parsedBody.data);
 
-    const tag =
-      (metadata.searchProfileId && metadata.searchProfileId.trim()) ||
-      (metadata.keyword && metadata.keyword.trim()) ||
-      null;
-    const tags = tag ? [tag] : [];
-
-    const convexResumes = resumes.map((resume) => {
-      const content: unknown = resume;
-      const hash = crypto.createHash("sha256").update(stableStringify(content), "utf8").digest("hex");
-      const externalId = resume.resumeId?.trim() ? resume.resumeId.trim() : hash;
-
-      return {
-        externalId,
-        content,
-        hash,
-        source: "hr.job5156.com",
-        tags,
-      };
-    });
-
-    const result = await submitResumesToConvex({ resumes: convexResumes });
-
-    return c.json(
-      ResumeSubmitResponseSchema.parse({
-        success: true as const,
-        submitted: result.submitted,
-        inserted: result.inserted,
-        updated: result.updated,
-        unchanged: result.unchanged,
-        deduped: result.deduped,
-      }),
-      200,
-    );
+    return c.json(result, 200);
   } catch (error) {
     console.error("Failed to submit resumes", error);
     const msg = error instanceof Error ? error.message : "Failed to submit resumes";

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -8,6 +8,8 @@ import {
   ResumeKeywordExpansionQuerySchema,
   ResumeKeywordExpansionResponseSchema,
   ResumeSamplesResponseSchema,
+  ResumeImportRequestSchema,
+  ResumeSubmitSummarySchema,
   MatchRequestSchema,
   MatchResponseSchema,
   ResumeMatchesResponseSchema,
@@ -39,6 +41,7 @@ import {
   type ExportBatchMeta,
   type ResumeExportEntry,
 } from "../services/export-service.js";
+import { submitResumeImport } from "../services/resume-import-service.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { BrandDisplayResolver } from "../services/brand-display-resolver.js";
 
@@ -120,6 +123,7 @@ const ResumeExportRequestSchema = z.object({
           education: z.string().optional(),
           expectedSalary: z.string().optional(),
           profileUrl: z.string().optional(),
+          source: z.string().optional(),
           selfIntro: z.string().optional(),
           workHistory: z
             .array(
@@ -142,6 +146,10 @@ const ResumeExportRequestSchema = z.object({
     )
     .min(1)
     .max(2000),
+});
+const ResumeImportErrorSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
 });
 
 function stripFrontMatter(content: string): string {
@@ -1601,6 +1609,56 @@ const rescoreResumeMatchesRoute = createRoute({
       description: "Session or data not found",
     },
   },
+});
+
+const importResumesRoute = createRoute({
+  method: "post",
+  path: "/api/resumes/import",
+  tags: ["resumes"],
+  summary: "Import resumes from a first-party payload",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: ResumeImportRequestSchema,
+        },
+      },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: ResumeSubmitSummarySchema } },
+      description: "Import result",
+    },
+    400: {
+      content: { "application/json": { schema: ResumeImportErrorSchema } },
+      description: "Invalid request payload",
+    },
+    403: {
+      content: { "application/json": { schema: ResumeImportErrorSchema } },
+      description: "Admin access required",
+    },
+    500: {
+      content: { "application/json": { schema: ResumeImportErrorSchema } },
+      description: "Import failed",
+    },
+  },
+});
+
+app.openapi(importResumesRoute, async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  }
+
+  try {
+    const payload = c.req.valid("json");
+    const result = await submitResumeImport(payload);
+    return c.json(result, 200);
+  } catch (error) {
+    console.error("Failed to import resumes", error);
+    return c.json({ success: false as const, error: "Failed to import resumes" }, 500);
+  }
 });
 
 app.openapi(rescoreResumeMatchesRoute, (c) => {

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -31,6 +31,9 @@ export const ResumeItemSchema = z
     extractedAt: z.string().openapi({ example: "2026-02-03T10:00:00.000Z" }),
     resumeId: z.string().optional().openapi({ example: "R123456" }),
     perUserId: z.string().optional().openapi({ example: "U987654" }),
+    profileId: z.string().optional().openapi({ example: "503033454" }),
+    profileType: z.string().optional().openapi({ example: "seek" }),
+    externalId: z.string().optional().openapi({ example: "seek:profile:503033454" }),
   })
   .openapi("ResumeItem");
 
@@ -62,6 +65,86 @@ export const ResumeMetadataSchema = z
     reproduction: z.string().optional().openapi({ example: "Navigate to sourceUrl, then add ?tr_auto_export=json" }),
   })
   .openapi("ResumeMetadata");
+
+export const ResumeImportCollectionContextSchema = z
+  .object({
+    captureMode: z.string().optional(),
+    operation: z.string().optional(),
+    jobId: z.union([z.string(), z.number()]).pipe(z.coerce.string()).optional(),
+    searchId: z.string().optional(),
+    pageNumber: z.coerce.number().int().optional(),
+    language: z.string().optional(),
+    profileType: z.string().optional(),
+  })
+  .openapi("ResumeImportCollectionContext");
+
+export const ResumeImportMetadataSchema = z
+  .object({
+    sourceUrl: z.string().url().openapi({ example: "https://hr.job5156.com/search?keyword=销售" }),
+    generatedBy: z.string().openapi({ example: "browser-extension@1.0.0" }),
+    sourceKey: z.string().optional().openapi({ example: "seek" }),
+    sourceHost: z.string().optional().openapi({ example: "hk.employer.seek.com" }),
+    keyword: z.string().optional().openapi({ example: "销售" }),
+    location: z.string().optional().openapi({ example: "东莞" }),
+    searchProfileId: z.string().optional().openapi({ example: "sales-engineer" }),
+    collectionContext: ResumeImportCollectionContextSchema.optional(),
+    searchCriteria: ResumeSearchCriteriaSchema.optional(),
+    generatedAt: z.string().optional().openapi({ example: "2026-02-03T09:27:52.152Z" }),
+    totalPages: z.number().int().optional().openapi({ example: 1 }),
+    totalResumes: z.number().int().optional().openapi({ example: 20 }),
+    reproduction: z.string().optional().openapi({ example: "Navigate to sourceUrl, then add ?tr_auto_export=json" }),
+  })
+  .openapi("ResumeImportMetadata");
+
+export const ResumeImportItemSchema = z
+  .object({
+    resumeId: z.union([z.string(), z.number()]).pipe(z.coerce.string()).optional(),
+    perUserId: z.union([z.string(), z.number()]).pipe(z.coerce.string()).optional(),
+    profileId: z.union([z.string(), z.number()]).pipe(z.coerce.string()).optional(),
+    profileType: z.string().optional(),
+    externalId: z.string().optional(),
+    name: z.string().openapi({ example: "Alex Chen" }),
+    age: z.string().optional().openapi({ example: "28" }),
+    experience: z.string().optional().openapi({ example: "5 years" }),
+    education: z.string().optional().openapi({ example: "Bachelor" }),
+    location: z.string().optional().openapi({ example: "Shenzhen" }),
+    jobIntention: z.string().optional().openapi({ example: "Sales Manager" }),
+    expectedSalary: z.string().optional().openapi({ example: "10-15K" }),
+    selfIntro: z.string().optional().openapi({ example: "认真敬业，具备团队协作精神" }),
+    workHistory: z.array(ResumeWorkHistorySchema).optional(),
+    profileUrl: z.string().optional().openapi({ example: "https://hr.job5156.com/resume/view/123" }),
+    activityStatus: z.string().optional().openapi({ example: "Active today" }),
+    extractedAt: z.string().optional().openapi({ example: "2026-02-03T10:00:00.000Z" }),
+  })
+  .openapi("ResumeImportItem");
+
+export const ResumeImportRequestSchema = z
+  .object({
+    metadata: ResumeImportMetadataSchema,
+    resumes: z.array(ResumeImportItemSchema).optional(),
+    data: z.array(ResumeImportItemSchema).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.resumes && !value.data) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Expected resumes or data array",
+        path: ["resumes"],
+      });
+    }
+  })
+  .openapi("ResumeImportRequest");
+
+export const ResumeSubmitSummarySchema = z
+  .object({
+    success: z.literal(true),
+    submitted: z.number().int(),
+    inserted: z.number().int(),
+    updated: z.number().int(),
+    unchanged: z.number().int(),
+    deduped: z.number().int(),
+  })
+  .openapi("ResumeSubmitSummary");
 
 export const ResumesQuerySchema = z.object({
   sample: z

--- a/apps/api/src/services/resume-import-service.test.ts
+++ b/apps/api/src/services/resume-import-service.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { normalizeResumeImportPayload, submitResumeImport } from "./resume-import-service";
+
+type ConvexCall = {
+  pathName: string;
+  args: Record<string, unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+  const requestUrl = typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+
+  if (!requestUrl.includes("/api/mutation")) {
+    throw new Error(`Unexpected request URL: ${requestUrl}`);
+  }
+
+  const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+  if (!isRecord(body)) {
+    throw new Error("Missing convex request body");
+  }
+
+  const pathName = typeof body.path === "string" ? body.path : "";
+  const args = isRecord(body.args) ? body.args : {};
+  if (!pathName) {
+    throw new Error("Missing convex path in request body");
+  }
+
+  return { pathName, args };
+}
+
+function convexSuccess(value: unknown): Response {
+  return new Response(
+    JSON.stringify({
+      status: "success",
+      value,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+}
+
+describe("resume-import-service", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("normalizes legacy searchCriteria metadata into top-level fields", () => {
+    const result = normalizeResumeImportPayload({
+      metadata: {
+        sourceUrl: "https://hr.job5156.com/search?keyword=%E9%94%80%E5%94%AE",
+        generatedBy: "browser-extension@1.0.0",
+        searchCriteria: {
+          keyword: " 销售 ",
+          location: " 东莞 ",
+          filters: {},
+        },
+      },
+      data: [
+        {
+          resumeId: 1079188,
+          perUserId: 1079188,
+          name: "骆先生",
+          profileUrl: "javascript:;",
+          activityStatus: "在线中",
+          age: "42岁",
+          experience: "20年",
+          education: "高中",
+          location: "东莞石碣镇",
+          jobIntention: "东莞石碣镇机械制图员",
+          expectedSalary: "6000-7999元/月",
+          selfIntro: "...",
+          workHistory: [{ raw: "2018-01 ~ 至今 Example Co." }],
+          extractedAt: "2026-02-11T13:01:41.009Z",
+        },
+      ],
+    });
+
+    expect(result.metadata.keyword).toBe("销售");
+    expect(result.metadata.location).toBe("东莞");
+    expect(result.source).toBe("hr.job5156.com");
+    expect(result.tags).toEqual(["销售"]);
+    expect(result.resumes).toHaveLength(1);
+    expect(result.convexResumes[0]).toMatchObject({
+      externalId: "hr.job5156.com:resume:1079188",
+      source: "hr.job5156.com",
+      tags: ["销售"],
+      content: expect.objectContaining({
+        resumeId: "1079188",
+        perUserId: "1079188",
+        name: "骆先生",
+      }),
+    });
+  });
+
+  it("submits source-aware payloads through the shared Convex path", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resume_tasks:submitResumes") {
+        return convexSuccess({
+          submitted: 1,
+          deduped: 0,
+          inserted: 1,
+          updated: 0,
+          unchanged: 0,
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const result = await submitResumeImport({
+      metadata: {
+        sourceKey: "seek",
+        sourceHost: "hk.employer.seek.com",
+        sourceUrl: "https://hk.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=2",
+        keyword: "sales engineer",
+        generatedBy: "manual-import@1.0.0",
+        collectionContext: {
+          captureMode: "json-upload",
+          operation: "manual-import",
+          jobId: 90842915,
+          pageNumber: 2,
+          language: "en",
+          profileType: "seek",
+        },
+      },
+      resumes: [
+        {
+          profileId: 503033454,
+          profileType: "seek",
+          name: "yap kae wen",
+          profileUrl: "https://hk.employer.seek.com/candidates/503033454",
+          activityStatus: "Updated recently",
+          location: "Shah Alam, Selangor, MY",
+          jobIntention: "Senior Sales Engineer",
+          workHistory: [{ raw: "Senior Sales Engineer · Example Co." }],
+          extractedAt: "2026-03-12T01:02:03.000Z",
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      success: true,
+      submitted: 1,
+      inserted: 1,
+      updated: 0,
+      unchanged: 0,
+      deduped: 0,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.pathName).toBe("resume_tasks:submitResumes");
+    expect(calls[0]?.args).toMatchObject({
+      resumes: [
+        {
+          externalId: "hk.employer.seek.com:profile:503033454",
+          source: "hk.employer.seek.com",
+          tags: ["sales engineer"],
+          content: expect.objectContaining({
+            profileId: "503033454",
+            profileType: "seek",
+            name: "yap kae wen",
+          }),
+        },
+      ],
+    });
+  });
+});

--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -1,0 +1,279 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { z } from "@hono/zod-openapi";
+
+import {
+  ResumeImportItemSchema,
+  ResumeImportMetadataSchema,
+  ResumeImportRequestSchema,
+  ResumeSubmitSummarySchema,
+} from "../schemas/resumes.js";
+import { config } from "./config.js";
+
+const JOB5156_HOST = "hr.job5156.com";
+
+type ResumeImportMetadata = z.infer<typeof ResumeImportMetadataSchema>;
+export type ResumeImportItem = z.infer<typeof ResumeImportItemSchema>;
+export type ResumeImportRequest = z.infer<typeof ResumeImportRequestSchema>;
+export type ResumeSubmitSummary = z.infer<typeof ResumeSubmitSummarySchema>;
+
+type ConvexResumeSubmitItem = {
+  externalId: string;
+  content: unknown;
+  hash: string;
+  source: string;
+  tags: string[];
+};
+
+export type NormalizedResumeImportPayload = {
+  metadata: ResumeImportMetadata;
+  resumes: ResumeImportItem[];
+  source: string;
+  tags: string[];
+  convexResumes: ConvexResumeSubmitItem[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+
+  if (isRecord(value)) {
+    const keys = Object.keys(value).sort((a, b) => a.localeCompare(b));
+    return `{${keys.map((key) => `${key}:${stableStringify(value[key])}`).join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function readEnvVarFromFile(filePath: string, key: string): string | null {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const content = fs.readFileSync(filePath, "utf8");
+    const lines = content.split(/\r?\n/);
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const idx = trimmed.indexOf("=");
+      if (idx < 0) continue;
+      const currentKey = trimmed.slice(0, idx).trim();
+      if (currentKey !== key) continue;
+      const value = trimmed.slice(idx + 1).trim();
+      return value.replace(/^['"]|['"]$/g, "");
+    }
+    return null;
+  } catch (error) {
+    console.error("Failed to read env var from file", { filePath, key, error });
+    return null;
+  }
+}
+
+export function resolveConvexUrl(): string {
+  if (process.env.CONVEX_URL) return process.env.CONVEX_URL;
+  if (process.env.VITE_CONVEX_URL) return process.env.VITE_CONVEX_URL;
+
+  const candidateFiles = [
+    path.join(config.projectRoot, "packages", "convex", ".env.local"),
+    path.join(config.projectRoot, "apps", "web", ".env.local"),
+    path.join(config.projectRoot, ".env.local"),
+    path.join(config.projectRoot, ".env"),
+  ];
+
+  for (const filePath of candidateFiles) {
+    const direct = readEnvVarFromFile(filePath, "CONVEX_URL");
+    if (direct) return direct;
+    const vite = readEnvVarFromFile(filePath, "VITE_CONVEX_URL");
+    if (vite) return vite;
+  }
+
+  return "http://127.0.0.1:3210";
+}
+
+function normalizeOptionalString(value: string | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function normalizeSourceHost(value: string | undefined): string | null {
+  const normalized = normalizeOptionalString(value);
+  return normalized ? normalized.toLowerCase() : null;
+}
+
+function normalizeImportMetadata(metadata: ResumeImportMetadata): ResumeImportMetadata {
+  const searchKeyword = normalizeOptionalString(metadata.searchCriteria?.keyword);
+  const searchLocation = normalizeOptionalString(metadata.searchCriteria?.location);
+
+  return ResumeImportMetadataSchema.parse({
+    ...metadata,
+    sourceKey: normalizeOptionalString(metadata.sourceKey) ?? undefined,
+    sourceHost: normalizeSourceHost(metadata.sourceHost) ?? undefined,
+    keyword: normalizeOptionalString(metadata.keyword) ?? searchKeyword ?? undefined,
+    location: normalizeOptionalString(metadata.location) ?? searchLocation ?? undefined,
+    searchProfileId: normalizeOptionalString(metadata.searchProfileId) ?? undefined,
+    searchCriteria: metadata.searchCriteria
+      ? {
+          ...metadata.searchCriteria,
+          keyword: searchKeyword ?? undefined,
+          location: searchLocation ?? undefined,
+        }
+      : undefined,
+  });
+}
+
+function resolveResumeSource(metadata: ResumeImportMetadata): string {
+  const sourceHost = normalizeSourceHost(metadata.sourceHost);
+  if (sourceHost) {
+    return sourceHost;
+  }
+
+  const sourceKey = normalizeSourceHost(metadata.sourceKey);
+  if (sourceKey === "job5156") {
+    return JOB5156_HOST;
+  }
+
+  try {
+    return new URL(metadata.sourceUrl).hostname.toLowerCase();
+  } catch (error) {
+    console.error("Failed to parse resume source URL", { sourceUrl: metadata.sourceUrl, error });
+    return sourceKey || JOB5156_HOST;
+  }
+}
+
+function normalizeCandidateId(value: string | undefined): string | null {
+  return normalizeOptionalString(value);
+}
+
+function buildResumeExternalId(resume: ResumeImportItem, source: string, hash: string): string {
+  const explicitExternalId = normalizeCandidateId(resume.externalId);
+  if (explicitExternalId) {
+    return explicitExternalId;
+  }
+
+  const profileId = normalizeCandidateId(resume.profileId);
+  if (profileId) {
+    return `${source}:profile:${profileId}`;
+  }
+
+  const resumeId = normalizeCandidateId(resume.resumeId);
+  if (resumeId) {
+    return `${source}:resume:${resumeId}`;
+  }
+
+  const perUserId = normalizeCandidateId(resume.perUserId);
+  if (perUserId) {
+    return `${source}:user:${perUserId}`;
+  }
+
+  return `${source}:hash:${hash}`;
+}
+
+async function submitResumesToConvex(args: { resumes: ConvexResumeSubmitItem[] }): Promise<{
+  submitted: number;
+  deduped: number;
+  inserted: number;
+  updated: number;
+  unchanged: number;
+}> {
+  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+  const response = await fetch(`${convexUrl}/api/mutation`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      path: "resume_tasks:submitResumes",
+      args,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Convex mutation failed (${response.status}): ${text}`);
+  }
+
+  const payload = (await response.json()) as {
+    status?: string;
+    value?: unknown;
+    errorMessage?: string;
+  };
+
+  if (payload.status !== "success") {
+    throw new Error(payload.errorMessage || "Convex mutation failed");
+  }
+
+  if (!isRecord(payload.value)) {
+    throw new Error("Invalid submitResumes response from Convex");
+  }
+
+  const value = payload.value;
+  return {
+    submitted: typeof value.submitted === "number" ? value.submitted : 0,
+    deduped: typeof value.deduped === "number" ? value.deduped : 0,
+    inserted: typeof value.inserted === "number" ? value.inserted : 0,
+    updated: typeof value.updated === "number" ? value.updated : 0,
+    unchanged: typeof value.unchanged === "number" ? value.unchanged : 0,
+  };
+}
+
+export function normalizeResumeImportPayload(input: ResumeImportRequest): NormalizedResumeImportPayload {
+  const parsedInput = ResumeImportRequestSchema.parse(input);
+  const metadata = normalizeImportMetadata(parsedInput.metadata);
+  const resumes = parsedInput.resumes ?? parsedInput.data ?? [];
+  const tag = normalizeOptionalString(metadata.searchProfileId) ?? normalizeOptionalString(metadata.keyword);
+  const tags = tag ? [tag] : [];
+  const source = resolveResumeSource(metadata);
+
+  const convexResumes = resumes.map((resume) => {
+    const content: unknown = resume;
+    const hash = crypto.createHash("sha256").update(stableStringify(content), "utf8").digest("hex");
+    const externalId = buildResumeExternalId(resume, source, hash);
+
+    return {
+      externalId,
+      content,
+      hash,
+      source,
+      tags,
+    };
+  });
+
+  return {
+    metadata,
+    resumes,
+    source,
+    tags,
+    convexResumes,
+  };
+}
+
+export async function submitNormalizedResumeImport(
+  payload: NormalizedResumeImportPayload,
+): Promise<ResumeSubmitSummary> {
+  const result = await submitResumesToConvex({ resumes: payload.convexResumes });
+
+  return ResumeSubmitSummarySchema.parse({
+    success: true,
+    submitted: result.submitted,
+    inserted: result.inserted,
+    updated: result.updated,
+    unchanged: result.unchanged,
+    deduped: result.deduped,
+  });
+}
+
+export async function submitResumeImport(input: ResumeImportRequest): Promise<ResumeSubmitSummary> {
+  return submitNormalizedResumeImport(normalizeResumeImportPayload(input));
+}

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -591,6 +591,85 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/resumes/import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Import resumes from a first-party payload */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ResumeImportRequest"];
+                };
+            };
+            responses: {
+                /** @description Import result */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ResumeSubmitSummary"];
+                    };
+                };
+                /** @description Invalid request payload */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Admin access required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Import failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/resumes/matches/rescore": {
         parameters: {
             query?: never;
@@ -750,32 +829,8 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        metadata: {
-                            /** Format: uri */
-                            sourceUrl: string;
-                            keyword?: string;
-                            location?: string;
-                            searchProfileId?: string;
-                            generatedBy: string;
-                        };
-                        resumes: {
-                            resumeId?: string | number;
-                            perUserId?: string | number;
-                            name: string;
-                            age?: string;
-                            experience?: string;
-                            education?: string;
-                            location?: string;
-                            jobIntention?: string;
-                            expectedSalary?: string;
-                            selfIntro?: string;
-                            workHistory?: {
-                                raw: string;
-                            }[];
-                            profileUrl?: string;
-                            activityStatus?: string;
-                            extractedAt?: string;
-                        }[];
+                        metadata: components["schemas"]["ResumeImportMetadata"];
+                        resumes: components["schemas"]["ResumeImportItem"][];
                     };
                 };
             };
@@ -786,15 +841,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: true;
-                            submitted: number;
-                            inserted: number;
-                            updated: number;
-                            unchanged: number;
-                            deduped: number;
-                        };
+                        "application/json": components["schemas"]["ResumeSubmitSummary"];
                     };
                 };
                 /** @description Invalid request payload */
@@ -3821,6 +3868,12 @@ export interface components {
             resumeId?: string;
             /** @example U987654 */
             perUserId?: string;
+            /** @example 503033454 */
+            profileId?: string;
+            /** @example seek */
+            profileType?: string;
+            /** @example seek:profile:503033454 */
+            externalId?: string;
         };
         ResumesResponse: {
             /** @enum {boolean} */
@@ -3986,6 +4039,88 @@ export interface components {
             /** @enum {boolean} */
             success: true;
             runs: components["schemas"]["MatchRun"][];
+        };
+        ResumeSubmitSummary: {
+            /** @enum {boolean} */
+            success: true;
+            submitted: number;
+            inserted: number;
+            updated: number;
+            unchanged: number;
+            deduped: number;
+        };
+        ResumeImportCollectionContext: {
+            captureMode?: string;
+            operation?: string;
+            jobId?: string | number;
+            searchId?: string;
+            pageNumber?: number | null;
+            language?: string;
+            profileType?: string;
+        };
+        ResumeImportMetadata: {
+            /**
+             * Format: uri
+             * @example https://hr.job5156.com/search?keyword=销售
+             */
+            sourceUrl: string;
+            /** @example browser-extension@1.0.0 */
+            generatedBy: string;
+            /** @example seek */
+            sourceKey?: string;
+            /** @example hk.employer.seek.com */
+            sourceHost?: string;
+            /** @example 销售 */
+            keyword?: string;
+            /** @example 东莞 */
+            location?: string;
+            /** @example sales-engineer */
+            searchProfileId?: string;
+            collectionContext?: components["schemas"]["ResumeImportCollectionContext"];
+            searchCriteria?: components["schemas"]["ResumeSearchCriteria"];
+            /** @example 2026-02-03T09:27:52.152Z */
+            generatedAt?: string;
+            /** @example 1 */
+            totalPages?: number;
+            /** @example 20 */
+            totalResumes?: number;
+            /** @example Navigate to sourceUrl, then add ?tr_auto_export=json */
+            reproduction?: string;
+        };
+        ResumeImportItem: {
+            resumeId?: string | number;
+            perUserId?: string | number;
+            profileId?: string | number;
+            profileType?: string;
+            externalId?: string;
+            /** @example Alex Chen */
+            name: string;
+            /** @example 28 */
+            age?: string;
+            /** @example 5 years */
+            experience?: string;
+            /** @example Bachelor */
+            education?: string;
+            /** @example Shenzhen */
+            location?: string;
+            /** @example Sales Manager */
+            jobIntention?: string;
+            /** @example 10-15K */
+            expectedSalary?: string;
+            /** @example 认真敬业，具备团队协作精神 */
+            selfIntro?: string;
+            workHistory?: components["schemas"]["ResumeWorkHistory"][];
+            /** @example https://hr.job5156.com/resume/view/123 */
+            profileUrl?: string;
+            /** @example Active today */
+            activityStatus?: string;
+            /** @example 2026-02-03T10:00:00.000Z */
+            extractedAt?: string;
+        };
+        ResumeImportRequest: {
+            metadata: components["schemas"]["ResumeImportMetadata"];
+            resumes?: components["schemas"]["ResumeImportItem"][];
+            data?: components["schemas"]["ResumeImportItem"][];
         };
         ResumeFilters: {
             minExperience?: number;


### PR DESCRIPTION
## Summary
- add shared `ResumeImport*` schemas and a shared resume import service for legacy/sample and source-aware payloads
- refactor `/api/resumes/submit` to delegate to the shared import pipeline and add admin-gated `/api/resumes/import`
- add service/route tests and regenerate web API types for the new import contract

## Test plan
- [x] `bun run vitest run apps/api/src/services/resume-import-service.test.ts apps/api/src/routes/resume-submit.test.ts apps/api/src/routes/resume-import.test.ts`
- [x] `bun run --filter '@trends/api' typecheck && bun run --filter '@trends/web' typecheck`
- [x] `npm --workspace @trends/web run gen:api`
- [x] `make check`