### PR TITLE
feat(screening): normalize industry db scores from frozen cohorts

### DIFF
--- a/apps/api/src/services/ingest-compute-service.test.ts
+++ b/apps/api/src/services/ingest-compute-service.test.ts
@@ -516,8 +516,8 @@ describe("IngestComputeService", () => {
     const result = service.computeOne("resume-123", SAMPLE_RESUME_CNC_SALES);
 
     expect(result.companyHits).toEqual([]);
-    expect(result.companyHits).toEqual(Array.from(new Set(result.brandHits.map((hit) => hit.brand))));
     expect(result.companyAliasTokens).toBe("");
+    expect(result.industryDbV2RawComponents.companyScore).toBe(0);
   });
 
   it("should not match HAAS aliases from excluded fields", () => {
@@ -525,6 +525,53 @@ describe("IngestComputeService", () => {
 
     expect(result.companyHits).toEqual([]);
     expect(result.companyAliasTokens).toBe("");
+  });
+
+  it("should compute deterministic industry_db v2 raw scores from employer and brand evidence", () => {
+    const result = service.computeOne("resume-employer-brand", {
+      data: [
+        {
+          ...SAMPLE_RESUME_JUNIOR.data[0],
+          workHistory: [
+            { raw: "2020-01~2024-12(4年11月)上海发那科机器人有限公司销售工程师，负责STAR车床销售、FANUC系统调试。" },
+            { raw: "2018-01~2019-12(1年11月)北京精雕科技集团有限公司销售工程师，负责STAR设备销售。" },
+          ],
+        },
+      ],
+    });
+
+    expect(result.companyHits).toEqual(expect.arrayContaining(["fanuc", "jingdiao"]));
+    expect(result.industryDbV2RawComponents).toEqual({
+      companyScore: 20,
+      brandScore: 20,
+      weightedBrandUnits: 2,
+      uniqueCompanies: 2,
+      brandUnitCount: 2,
+    });
+    expect(result.industryDbV2Raw).toBe(40);
+  });
+
+  it("should dedupe repeated brand mentions by brand and context for industry_db v2 raw scoring", () => {
+    const result = service.computeOne("resume-brand-dedupe", {
+      data: [
+        {
+          ...SAMPLE_RESUME_JUNIOR.data[0],
+          workHistory: [
+            { raw: "2020-01~2024-12(4年11月)某设备公司销售工程师，负责STAR销售、STAR销售、STAR设备使用、STAR设备使用、STAR编程调试。" },
+          ],
+        },
+      ],
+    });
+
+    expect(result.companyHits).toEqual([]);
+    expect(result.industryDbV2RawComponents).toEqual({
+      companyScore: 0,
+      brandScore: 10,
+      weightedBrandUnits: 1,
+      uniqueCompanies: 0,
+      brandUnitCount: 1,
+    });
+    expect(result.industryDbV2Raw).toBe(10);
   });
 
   it("should return empty company matches for unknown brands", () => {

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -24,6 +24,14 @@ export interface BrandHit {
   companyId?: number;
 }
 
+export interface IndustryDbV2RawComponents {
+  companyScore: number;
+  brandScore: number;
+  weightedBrandUnits: number;
+  uniqueCompanies: number;
+  brandUnitCount: number;
+}
+
 export interface IngestResult {
   resumeId: string;
   evidenceText: string;
@@ -31,6 +39,8 @@ export interface IngestResult {
   synonymHits: string[];
   brandHits: BrandHit[];
   companyHits: string[];
+  industryDbV2Raw: number;
+  industryDbV2RawComponents: IndustryDbV2RawComponents;
   roleSignals: RoleSignalSummary[];
   tagEnvelope: TagEnvelopeEntry[];
   taggingEnvelope: TaggingEnvelope;
@@ -275,10 +285,89 @@ function inferTaggingStage(tag: string): TaggingProvenanceStage {
   return "derived";
 }
 
+function computeIndustryDbV2Raw(
+  companyHits: string[],
+  brandHits: BrandHit[]
+): { raw: number; components: IndustryDbV2RawComponents } {
+  const uniqueCompanies = Array.from(
+    new Set(
+      companyHits
+        .map((company) => company.trim().toLowerCase())
+        .filter((company) => company.length > 0)
+    )
+  );
+
+  const companyScore = Math.min(
+    INDUSTRY_DB_V2_COMPANY_SCORE_CAP,
+    uniqueCompanies.length * INDUSTRY_DB_V2_COMPANY_SCORE_PER_HIT
+  );
+
+  const dedupedBrandKeys = new Set<string>();
+  let weightedBrandUnits = 0;
+  let brandUnitCount = 0;
+
+  for (const hit of brandHits) {
+    if (hit.context === "employer") {
+      continue;
+    }
+
+    const brand = hit.brand.trim().toLowerCase();
+    if (!brand) {
+      continue;
+    }
+
+    const dedupeKey = `${brand}|${hit.context}`;
+    if (dedupedBrandKeys.has(dedupeKey)) {
+      continue;
+    }
+    dedupedBrandKeys.add(dedupeKey);
+
+    const weight = INDUSTRY_DB_V2_CONTEXT_WEIGHTS[hit.context];
+    if (typeof weight !== "number") {
+      continue;
+    }
+
+    weightedBrandUnits += weight;
+    brandUnitCount += 1;
+  }
+
+  const roundedWeightedBrandUnits = Number(weightedBrandUnits.toFixed(2));
+  const brandScore = Math.min(
+    INDUSTRY_DB_V2_BRAND_SCORE_CAP,
+    Number((roundedWeightedBrandUnits * INDUSTRY_DB_V2_BRAND_SCORE_PER_UNIT).toFixed(2))
+  );
+  const raw = Math.min(
+    INDUSTRY_DB_V2_TOTAL_CAP,
+    Number((companyScore + brandScore).toFixed(2))
+  );
+
+  return {
+    raw,
+    components: {
+      companyScore,
+      brandScore,
+      weightedBrandUnits: roundedWeightedBrandUnits,
+      uniqueCompanies: uniqueCompanies.length,
+      brandUnitCount,
+    },
+  };
+}
+
 const BRAND_CONTEXT_WINDOW = 30;
 const EQUIPMENT_SIGNALS = ["操作", "使用", "熟练", "熟悉", "机台", "机型", "设备", "机床"];
 const SALES_SIGNALS = ["销售", "代理", "渠道", "推广", "业务", "客户"];
 const TECHNICAL_SIGNALS = ["维修", "调试", "编程", "安装", "保养", "维护"];
+const INDUSTRY_DB_V2_COMPANY_SCORE_PER_HIT = 10;
+const INDUSTRY_DB_V2_COMPANY_SCORE_CAP = 20;
+const INDUSTRY_DB_V2_BRAND_SCORE_PER_UNIT = 10;
+const INDUSTRY_DB_V2_BRAND_SCORE_CAP = 30;
+const INDUSTRY_DB_V2_TOTAL_CAP = 50;
+const INDUSTRY_DB_V2_CONTEXT_WEIGHTS: Record<Exclude<BrandContext, "employer">, number> = {
+  sales: 1,
+  equipment: 0.8,
+  technical: 0.6,
+  general: 0.3,
+};
 const DEFAULT_ROLE_SIGNAL_LIBRARY: Record<string, string[]> = {
   sales: ["销售", "业务开发", "客户", "大客户", "渠道", "销售经理", "销售工程师", "sales", "account"],
   engineer: ["工程师", "设计", "研发", "开发", "编程", "调试", "维修", "技术", "engineer", "developer", "design"],
@@ -342,7 +431,17 @@ export class IngestComputeService {
 
     // 3. Compute field-aware brandHits, then derive companyHits for backward compatibility
     const brandHits = this.computeBrandHits(item, index.companies, searchText);
-    const companyHits = Array.from(new Set(brandHits.map((hit) => hit.brand)));
+    const companyHits = Array.from(
+      new Set(
+        brandHits
+          .filter((hit) => hit.context === "employer")
+          .map((hit) => hit.brand)
+      )
+    );
+    const { raw: industryDbV2Raw, components: industryDbV2RawComponents } = computeIndustryDbV2Raw(
+      companyHits,
+      brandHits
+    );
     const roleSignals = this.computeRoleSignals(item.workHistory ?? []);
     const companyAliasTokens = this.buildCompanyAliasTokens(companyHits);
 
@@ -374,6 +473,8 @@ export class IngestComputeService {
       synonymHits,
       brandHits,
       companyHits,
+      industryDbV2Raw,
+      industryDbV2RawComponents,
       roleSignals,
       tagEnvelope,
       taggingEnvelope,

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -28,6 +28,14 @@ export type ConvexIngestData = {
     context: string
   }>
   companyHits: string[]
+  industryDbV2Raw?: number
+  industryDbV2RawComponents?: {
+    companyScore: number
+    brandScore: number
+    weightedBrandUnits: number
+    uniqueCompanies: number
+    brandUnitCount: number
+  }
   roleSignals?: Array<{
     type: string
     matchedSignals: string[]
@@ -389,6 +397,16 @@ function parseIngestData(value: unknown): ConvexIngestData | undefined {
     synonymHits: toStringArray(value.synonymHits),
     brandHits: parseBrandHits(value.brandHits),
     companyHits: toStringArray(value.companyHits),
+    industryDbV2Raw: toNumber(value.industryDbV2Raw) ?? undefined,
+    industryDbV2RawComponents: isRecord(value.industryDbV2RawComponents)
+      ? {
+          companyScore: toNumber(value.industryDbV2RawComponents.companyScore) ?? 0,
+          brandScore: toNumber(value.industryDbV2RawComponents.brandScore) ?? 0,
+          weightedBrandUnits: toNumber(value.industryDbV2RawComponents.weightedBrandUnits) ?? 0,
+          uniqueCompanies: toNumber(value.industryDbV2RawComponents.uniqueCompanies) ?? 0,
+          brandUnitCount: toNumber(value.industryDbV2RawComponents.brandUnitCount) ?? 0,
+        }
+      : undefined,
     roleSignals: Array.isArray(value.roleSignals)
       ? value.roleSignals
           .map((item) => {

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -32,6 +32,7 @@ const mockState = vi.hoisted(() => ({
   applyExternalState: vi.fn(),
   saveSearchHistory: vi.fn(async () => 'history-1'),
   markSearchHistoryOpened: vi.fn(async () => {}),
+  searchHistory: [] as Array<Record<string, unknown>>,
   refresh: vi.fn(async () => {}),
   reloadSamples: vi.fn(async () => {}),
   blockCandidates: vi.fn(async () => true),
@@ -82,7 +83,7 @@ vi.mock('@/hooks/useSession', () => ({
     reviewedIdsSet: new Set<string>(),
     trackReviewedResume: mockState.trackReviewedResume,
     applyExternalState: mockState.applyExternalState,
-    searchHistory: [],
+    searchHistory: mockState.searchHistory,
     searchHistoryLoading: false,
     saveSearchHistory: mockState.saveSearchHistory,
     markSearchHistoryOpened: mockState.markSearchHistoryOpened,
@@ -175,6 +176,8 @@ function buildResume(params: {
   primaryRuleScore?: number
   companyHits?: string[]
   industryTags?: string[]
+  industryDbV2Raw?: number
+  analysis?: ConvexResumeItem['analysis']
   roleSignals: Array<{
     type: string
     matchedSignals: string[]
@@ -216,12 +219,14 @@ function buildResume(params: {
     noticePeriodDays: 30,
     extractedAt: '2026-03-01T00:00:00.000Z',
     primaryRuleScore: params.primaryRuleScore,
+    analysis: params.analysis,
     ingestData: {
       evidenceText: 'test work history',
       industryTags: params.industryTags ?? [],
       synonymHits: [],
       brandHits: [],
       companyHits: params.companyHits ?? [],
+      industryDbV2Raw: params.industryDbV2Raw ?? 0,
       roleSignals: params.roleSignals,
       ruleScores: {},
       experienceLevel: 'mid',
@@ -278,6 +283,7 @@ describe('useResumeListState role filter regression', () => {
     mockState.sessionJobDescriptionId = undefined
     mockState.blocksByIdentity = {}
     mockState.statusByIdentity = {}
+    mockState.searchHistory = []
     document.body.innerHTML = ''
     mockState.urlParsedState = {
       location: undefined,
@@ -627,6 +633,27 @@ describe('useResumeListState role filter regression', () => {
   })
 
   it('applies saved search history and updates opened timestamp', async () => {
+    mockState.searchHistory = [
+      {
+        id: 'history-1',
+        sessionKey: 'session-1',
+        title: 'Saved search',
+        location: '苏州',
+        keywords: ['CNC', '销售'],
+        jobDescriptionId: 'lathe-sales',
+        filters: { minAge: 28 },
+        selectedTags: ['STAR'],
+        selectedCompanies: ['Acme'],
+        selectedExperienceLevel: 'mid',
+        industryDbV2Stats: {
+          size: 50,
+          p80: 25,
+          histogram50: Array.from({ length: 51 }, (_, index) => (index === 25 ? 50 : 0)),
+        },
+        createdAt: 1,
+        lastOpenedAt: 2,
+      },
+    ]
     const { result } = renderHook(() => useResumeListState())
 
     await act(async () => {
@@ -653,6 +680,81 @@ describe('useResumeListState role filter regression', () => {
       filters: { minAge: 28 },
     })
     expect(mockState.markSearchHistoryOpened).toHaveBeenCalledWith('history-1')
+    expect(result.current.appliedSearchHistoryId).toBe('history-1')
+  })
+
+  it('passes current convex resume ids when saving search history', async () => {
+    mockState.saveSearchHistory.mockClear()
+    const { result } = renderHook(() => useResumeListState())
+
+    await act(async () => {
+      await result.current.handleSaveCurrentSearch()
+    })
+
+    expect(mockState.saveSearchHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resumeIds: [
+          'resume-ideal-cnc-sales',
+          'resume-zhang-machinery-sales',
+          'resume-li-automation-sales',
+          'resume-zhou-jingdiao',
+          'resume-luo-non-cnc-sales',
+          'resume-engineer-junior',
+        ],
+      })
+    )
+  })
+
+  it('overrides AI industry_db score from applied search history cohort stats', async () => {
+    mockState.convexResumes = [
+      buildResume({
+        id: 'resume-ai-1',
+        name: 'AI Resume',
+        industryDbV2Raw: 20,
+        analysis: {
+          score: 45,
+          summary: 'Good match',
+          highlights: ['summary'],
+          recommendation: 'match',
+          breakdown: {
+            related_exp: 30,
+            industry_db: 15,
+          },
+          jobDescriptionId: 'lathe-sales',
+        },
+        roleSignals: [],
+      }),
+    ]
+    mockState.searchHistory = [
+      {
+        id: 'history-ai',
+        sessionKey: 'session-1',
+        title: 'AI Saved search',
+        location: '苏州',
+        keywords: ['CNC'],
+        jobDescriptionId: 'lathe-sales',
+        filters: {},
+        selectedTags: [],
+        selectedCompanies: [],
+        selectedExperienceLevel: undefined,
+        industryDbV2Stats: {
+          size: 50,
+          p80: 20,
+          histogram50: Array.from({ length: 51 }, (_, index) => (index === 20 ? 50 : 0)),
+        },
+        createdAt: 1,
+        lastOpenedAt: 2,
+      },
+    ]
+
+    const { result } = renderHook(() => useResumeListState())
+
+    await act(async () => {
+      await result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
+    })
+
+    expect(result.current.displayedResumes[0]?.match?.breakdown?.industry_db).toBe(40)
+    expect(result.current.displayedResumes[0]?.match?.score).toBe(70)
   })
 
   it('allows manual profile apply to bypass the URL hydration guard', () => {

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -35,6 +35,7 @@ import {
   getAnalysisForJob,
   hasIngestData,
   isAutoFilteredAnalysis,
+  overrideIndustryDbBreakdown,
   toMatchBreakdown,
   toRecommendation,
 } from '@/lib/resume-scoring'
@@ -369,6 +370,7 @@ export function useResumeListState(loadSearchHistory = false) {
   const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [selectedCompanies, setSelectedCompanies] = useState<string[]>([])
   const [selectedExperienceLevel, setSelectedExperienceLevel] = useState<ExperienceLevelFilter | undefined>(undefined)
+  const [appliedSearchHistoryId, setAppliedSearchHistoryId] = useState<string | undefined>(undefined)
   const [mode] = useState<'ai'>('ai')
   const hydratedSessionIdRef = useRef<string | null>(null)
   const hasInitializedUrlHydrationRef = useRef(false)
@@ -969,6 +971,11 @@ export function useResumeListState(loadSearchHistory = false) {
     [selectedCompanies]
   )
 
+  const appliedSearchHistory = useMemo(
+    () => searchHistory.find((entry) => entry.id === appliedSearchHistoryId),
+    [appliedSearchHistoryId, searchHistory]
+  )
+
   const enrichedResumes = useMemo<EnrichedResume[]>(() => {
     if (mode === 'ai') {
       return filteredConvexResumes.map((resume: ScoredConvexResume, index: number) => {
@@ -976,19 +983,26 @@ export function useResumeListState(loadSearchHistory = false) {
         const identityKey = getResumeIdentityKey(resume, resumeKey)
         const analysis = getAnalysisForJob(resume, jobDescriptionId, sessionKeywords)
         const isAnalysisValid = !jobDescriptionId || analysis?.jobDescriptionId === jobDescriptionId
+        const normalizedAnalysis = analysis && isAnalysisValid
+          ? overrideIndustryDbBreakdown(
+              analysis,
+              resume.ingestData?.industryDbV2Raw,
+              appliedSearchHistory?.industryDbV2Stats
+            )
+          : undefined
 
-        const match: MatchingResult | undefined = analysis && isAnalysisValid
+        const match: MatchingResult | undefined = normalizedAnalysis
           ? {
             resumeId: resumeKey,
-            score: analysis.score,
-            summary: analysis.summary,
-            highlights: analysis.highlights,
-            recommendation: toRecommendation(analysis.recommendation),
-            concerns: analysis.concerns ?? [],
-            breakdown: toMatchBreakdown(analysis.breakdown),
+            score: normalizedAnalysis.score,
+            summary: normalizedAnalysis.summary,
+            highlights: normalizedAnalysis.highlights,
+            recommendation: toRecommendation(normalizedAnalysis.recommendation),
+            concerns: normalizedAnalysis.concerns ?? [],
+            breakdown: toMatchBreakdown(normalizedAnalysis.breakdown),
             scoreSource: 'ai',
             matchedAt: new Date().toISOString(),
-            jobDescriptionId: analysis.jobDescriptionId,
+            jobDescriptionId: normalizedAnalysis.jobDescriptionId,
           }
           : undefined
 
@@ -1020,7 +1034,7 @@ export function useResumeListState(loadSearchHistory = false) {
         action: actions[resumeKey],
       }
     })
-  }, [actions, blocksByIdentity, filteredConvexResumes, jobDescriptionId, mode, resumes, sessionKeywords, statusByIdentity])
+  }, [actions, appliedSearchHistory?.industryDbV2Stats, blocksByIdentity, filteredConvexResumes, jobDescriptionId, mode, resumes, sessionKeywords, statusByIdentity])
 
   const displayedResumes = useMemo(() => {
     const sortBy = filters.sortBy ?? 'score'
@@ -1100,6 +1114,7 @@ export function useResumeListState(loadSearchHistory = false) {
   }, [displayedResumes])
 
   const handleResetAll = useCallback(() => {
+    setAppliedSearchHistoryId(undefined)
     setSessionLocation('')
     setSessionKeywords([])
     setJobDescriptionId('')
@@ -1403,6 +1418,7 @@ export function useResumeListState(loadSearchHistory = false) {
       selectedTags,
       selectedCompanies,
       selectedExperienceLevel,
+      resumeIds: filteredConvexResumes.map((resume) => String(resume.resumeId)),
     })
 
     if (saved) {
@@ -1410,7 +1426,7 @@ export function useResumeListState(loadSearchHistory = false) {
     } else {
       toast.error(t('quickStart.history.saveError', 'Failed to save search history'))
     }
-  }, [filters, jobDescriptionId, saveSearchHistory, selectedCompanies, selectedExperienceLevel, selectedTags, sessionKeywords, sessionLocation, t])
+  }, [filteredConvexResumes, filters, jobDescriptionId, saveSearchHistory, selectedCompanies, selectedExperienceLevel, selectedTags, sessionKeywords, sessionLocation, t])
 
   const handleApplySearchHistory = useCallback(async (entry: SearchHistoryItem) => {
     skipNextUrlSyncRef.current = true
@@ -1420,6 +1436,7 @@ export function useResumeListState(loadSearchHistory = false) {
       jobDescriptionId: entry.jobDescriptionId ?? '',
       filters: entry.filters,
     })
+    setAppliedSearchHistoryId(entry.id)
     setSelectedTags(entry.selectedTags)
     setSelectedCompanies(entry.selectedCompanies)
     setSelectedExperienceLevel(toExperienceLevel(entry.selectedExperienceLevel))
@@ -1431,6 +1448,7 @@ export function useResumeListState(loadSearchHistory = false) {
     sessionLocation,
     sessionKeywords,
     jobDescriptionId,
+    appliedSearchHistoryId,
     filters,
     reviewedIdsSet,
     trackReviewedResume,

--- a/apps/web/src/hooks/useSession.test.tsx
+++ b/apps/web/src/hooks/useSession.test.tsx
@@ -130,6 +130,11 @@ describe('useSession', () => {
             collectionTaskId: '  task-1  ',
             analysisTaskId: '   ',
             notes: '  saved note  ',
+            industryDbV2Stats: {
+              size: 42,
+              p80: 18,
+              histogram50: Array.from({ length: 51 }, (_, index) => (index === 18 ? 42 : 0)),
+            },
             createdAt: 1,
             lastOpenedAt: 2,
           },
@@ -166,6 +171,11 @@ describe('useSession', () => {
         collectionTaskId: 'task-1',
         analysisTaskId: undefined,
         notes: 'saved note',
+        industryDbV2Stats: {
+          size: 42,
+          p80: 18,
+          histogram50: Array.from({ length: 51 }, (_, index) => (index === 18 ? 42 : 0)),
+        },
       }),
     ])
   })
@@ -192,6 +202,7 @@ describe('useSession', () => {
       title: 'HR saved search',
       location: '东莞',
       keywords: ['招聘', '简历'],
+      resumeIds: ['resume-1', 'resume-2'],
     })
     await result.current.markSearchHistoryOpened('history-hr' as never)
 
@@ -209,6 +220,7 @@ describe('useSession', () => {
         title: 'HR saved search',
         location: '东莞',
         keywords: ['招聘', '简历'],
+        resumeIds: ['resume-1', 'resume-2'],
       })
     )
     expect(markSearchHistoryOpenedMutationMock).toHaveBeenCalledWith({

--- a/apps/web/src/hooks/useSession.ts
+++ b/apps/web/src/hooks/useSession.ts
@@ -4,6 +4,7 @@ import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Id } from '../../../../packages/convex/convex/_generated/dataModel'
 import type { ResumeFilters } from '@/types/resume'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
+import { toIndustryDbV2Stats, type IndustryDbV2Stats } from '@/lib/resume-scoring'
 
 export type ExternalSessionState = {
   location?: string
@@ -26,6 +27,7 @@ export type SearchHistoryItem = {
   collectionTaskId?: string
   analysisTaskId?: string
   notes?: string
+  industryDbV2Stats?: IndustryDbV2Stats
   createdAt: number
   lastOpenedAt?: number
 }
@@ -42,6 +44,7 @@ type SaveSearchHistoryInput = {
   selectedExperienceLevel?: string
   collectionTaskId?: string
   analysisTaskId?: string
+  resumeIds?: string[]
 }
 
 const AUTO_RESTORE_SCREENING_SESSION = false
@@ -224,6 +227,7 @@ export function useSession(loadSearchHistory = false) {
       collectionTaskId: normalizeOptionalString(record.collectionTaskId),
       analysisTaskId: normalizeOptionalString(record.analysisTaskId),
       notes: normalizeOptionalString(record.notes),
+      industryDbV2Stats: toIndustryDbV2Stats(record.industryDbV2Stats),
       createdAt: record.createdAt,
       lastOpenedAt: record.lastOpenedAt,
     }))
@@ -248,6 +252,7 @@ export function useSession(loadSearchHistory = false) {
       selectedExperienceLevel: normalizeOptionalString(input.selectedExperienceLevel),
       collectionTaskId: normalizeOptionalString(input.collectionTaskId),
       analysisTaskId: normalizeOptionalString(input.analysisTaskId),
+      resumeIds: normalizeStringList(input.resumeIds),
     })
   }, [filters, jobDescriptionId, keywords, location, saveSearchHistoryMutation, sessionKey, slug])
 

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
   buildLearningObservation,
   buildResumeKey,
+  computeNormalizedIndustryDbScore,
   getPrecomputedRuleScore,
   hasIngestData,
   isAutoFilteredAnalysis,
+  overrideIndustryDbBreakdown,
   toMatchBreakdown,
   toRecommendation,
 } from '@/lib/resume-scoring'
@@ -157,5 +159,44 @@ describe('resume-scoring', () => {
         breakdown: { keyword_match: 10 },
       })
     ).toBe(true)
+  })
+
+  it('normalizes industry_db score from frozen cohort stats', () => {
+    expect(computeNormalizedIndustryDbScore(20, {
+      size: 50,
+      p80: 20,
+      histogram50: Array.from({ length: 51 }, (_, index) => (index === 20 ? 50 : 0)),
+    })).toBe(40)
+  })
+
+  it('falls back to raw industry_db score for weak cohorts', () => {
+    expect(computeNormalizedIndustryDbScore(12, {
+      size: 10,
+      p80: 4,
+      histogram50: Array.from({ length: 51 }, () => 0),
+    })).toBe(12)
+  })
+
+  it('overrides AI breakdown and recomputes total score', () => {
+    expect(overrideIndustryDbBreakdown({
+      score: 45,
+      summary: 'Good match',
+      highlights: [],
+      recommendation: 'match',
+      breakdown: {
+        related_exp: 30,
+        industry_db: 15,
+      },
+    }, 20, {
+      size: 50,
+      p80: 20,
+      histogram50: Array.from({ length: 51 }, (_, index) => (index === 20 ? 50 : 0)),
+    })).toEqual(expect.objectContaining({
+      score: 70,
+      breakdown: {
+        related_exp: 30,
+        industry_db: 40,
+      },
+    }))
   })
 })

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -3,6 +3,12 @@ import type { ConvexResumeAnalysis } from '@/hooks/useConvexResumes'
 import type { MatchBreakdown, Recommendation } from '@/types/resume'
 import { deriveAnalysisLookupKey } from '@/lib/analysis-utils'
 
+export type IndustryDbV2Stats = {
+  size: number
+  p80: number
+  histogram50: number[]
+}
+
 const VALID_RECOMMENDATIONS: Recommendation[] = ['strong_match', 'match', 'potential', 'no_match']
 
 export function isRecommendation(value: string): value is Recommendation {
@@ -154,6 +160,104 @@ function isStringArray(value: unknown): value is string[] {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function normalizeHistogram50(histogram50: number[]): number[] {
+  return Array.from({ length: 51 }, (_, score) => {
+    const count = histogram50[score]
+    return Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0
+  })
+}
+
+function countHistogramSamples(histogram50: number[]): number {
+  return histogram50.reduce((total, count) => total + count, 0)
+}
+
+function percentileRankFromHistogram(histogram50: number[], raw: number): number {
+  const total = countHistogramSamples(histogram50)
+  if (total <= 1) {
+    return 1
+  }
+
+  const roundedRaw = Math.round(clamp(raw, 0, 50))
+  let lowerBound = 0
+  let upperBound = 0
+
+  histogram50.forEach((count, score) => {
+    if (score < roundedRaw) {
+      lowerBound += count
+      upperBound += count
+      return
+    }
+
+    if (score === roundedRaw) {
+      upperBound += count
+    }
+  })
+
+  if (upperBound === 0) {
+    return 0
+  }
+
+  if (lowerBound === total) {
+    return 1
+  }
+
+  const midpoint = (lowerBound + upperBound - 1) / 2
+  return midpoint / (total - 1)
+}
+
+export function toIndustryDbV2Stats(value: unknown): IndustryDbV2Stats | undefined {
+  if (!isRecord(value) || !Array.isArray(value.histogram50)) {
+    return undefined
+  }
+
+  return {
+    size: typeof value.size === 'number' && Number.isFinite(value.size) ? Math.max(0, Math.floor(value.size)) : 0,
+    p80: typeof value.p80 === 'number' && Number.isFinite(value.p80) ? value.p80 : 0,
+    histogram50: normalizeHistogram50(value.histogram50),
+  }
+}
+
+export function computeNormalizedIndustryDbScore(raw: number | undefined, stats: IndustryDbV2Stats | undefined): number {
+  const safeRaw = typeof raw === 'number' && Number.isFinite(raw) ? clamp(raw, 0, 50) : 0
+  if (!stats || stats.size < 30 || stats.p80 <= 5) {
+    return Math.round(safeRaw)
+  }
+
+  const histogram50 = normalizeHistogram50(stats.histogram50)
+  const sampleSize = countHistogramSamples(histogram50)
+  if (sampleSize < 30) {
+    return Math.round(safeRaw)
+  }
+
+  const rank = percentileRankFromHistogram(histogram50, safeRaw)
+  const base = 40 * clamp(safeRaw / Math.max(stats.p80, 1), 0, 1)
+  const bonus = 10 * clamp((rank - 0.8) / 0.2, 0, 1)
+  return Math.round(Math.min(50, base + bonus))
+}
+
+export function overrideIndustryDbBreakdown(
+  analysis: ConvexResumeAnalysis,
+  raw: number | undefined,
+  stats: IndustryDbV2Stats | undefined
+): ConvexResumeAnalysis {
+  const normalizedIndustryDb = computeNormalizedIndustryDbScore(raw, stats)
+  const nextBreakdown: MatchBreakdown = {
+    ...(analysis.breakdown ?? {}),
+    industry_db: normalizedIndustryDb,
+  }
+  const relatedExp = typeof nextBreakdown.related_exp === 'number' ? nextBreakdown.related_exp : 0
+
+  return {
+    ...analysis,
+    score: relatedExp + normalizedIndustryDb,
+    breakdown: nextBreakdown,
+  }
 }
 
 export function hasIngestData(resume: unknown): resume is ResumeWithIngestData {

--- a/packages/convex/convex/ingest_agent.ts
+++ b/packages/convex/convex/ingest_agent.ts
@@ -94,6 +94,8 @@ export const processNewResumes = internalAction({
           synonymHits: item.synonymHits,
           brandHits: item.brandHits || [],
           companyHits: item.companyHits || [],
+          industryDbV2Raw: item.industryDbV2Raw,
+          industryDbV2RawComponents: item.industryDbV2RawComponents || undefined,
           roleSignals: item.roleSignals || [],
           tagEnvelope: item.tagEnvelope || [],
           taggingEnvelope: item.taggingEnvelope || undefined,

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -440,6 +440,14 @@ export const updateIngestData = internalMutation({
                 companyId: v.optional(v.number()),
             }))),
             companyHits: v.optional(v.array(v.string())),
+            industryDbV2Raw: v.optional(v.number()),
+            industryDbV2RawComponents: v.optional(v.object({
+                companyScore: v.number(),
+                brandScore: v.number(),
+                weightedBrandUnits: v.number(),
+                uniqueCompanies: v.number(),
+                brandUnitCount: v.number(),
+            })),
             roleSignals: v.optional(v.array(v.object({
                 type: v.string(),
                 matchedSignals: v.array(v.string()),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -107,6 +107,14 @@ export default defineSchema({
                 companyId: v.optional(v.number()),
             }))),
             companyHits: v.optional(v.array(v.string())),
+            industryDbV2Raw: v.optional(v.number()),
+            industryDbV2RawComponents: v.optional(v.object({
+                companyScore: v.number(),
+                brandScore: v.number(),
+                weightedBrandUnits: v.number(),
+                uniqueCompanies: v.number(),
+                brandUnitCount: v.number(),
+            })),
             roleSignals: v.optional(v.array(v.object({
                 type: v.string(),
                 matchedSignals: v.array(v.string()),
@@ -327,6 +335,17 @@ export default defineSchema({
     })
         .index("by_workspace", ["workspaceSlug"])
         .index("by_sessionKey", ["sessionKey"]),
+
+    industry_db_cohorts: defineTable({
+        searchHistoryId: v.id("search_history"),
+        workspaceSlug: v.string(),
+        computedAt: v.number(),
+        size: v.number(),
+        p80: v.number(),
+        histogram50: v.array(v.number()),
+    })
+        .index("by_searchHistoryId", ["searchHistoryId"])
+        .index("by_workspace", ["workspaceSlug"]),
 
     workspace_config: defineTable({
         workspaceSlug: v.string(),

--- a/packages/convex/convex/sessions.ts
+++ b/packages/convex/convex/sessions.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
+import { mutation, query, type MutationCtx } from "./_generated/server";
 
 export const DEFAULT_WORKSPACE_SLUG = "dev";
 
@@ -48,6 +48,58 @@ function buildHistoryTitle(location: string, keywords: string[]): string {
     const normalizedKeywords = normalizeStringList(keywords);
     const parts = [normalizedLocation, normalizedKeywords.join(" ")].filter((value) => value.length > 0);
     return parts.join(" · ") || "Untitled search";
+}
+
+const INDUSTRY_DB_V2_COHORT_MAX_SIZE = 2000;
+const INDUSTRY_DB_V2_HISTOGRAM_SIZE = 51;
+
+function clampIndustryDbV2RawScore(value: number): number {
+    if (!Number.isFinite(value)) {
+        return 0;
+    }
+    return Math.max(0, Math.min(50, value));
+}
+
+function quantile(sorted: number[], q: number): number {
+    if (sorted.length === 0) {
+        return 0;
+    }
+
+    const clampedQ = Math.max(0, Math.min(1, q));
+    const position = (sorted.length - 1) * clampedQ;
+    const lowerIndex = Math.floor(position);
+    const upperIndex = Math.ceil(position);
+    if (lowerIndex === upperIndex) {
+        return sorted[lowerIndex];
+    }
+
+    const weight = position - lowerIndex;
+    return sorted[lowerIndex] * (1 - weight) + sorted[upperIndex] * weight;
+}
+
+async function buildIndustryDbV2Cohort(
+    ctx: MutationCtx,
+    resumeIds: string[],
+): Promise<{ size: number; p80: number; histogram50: number[] } | null> {
+    const limitedResumeIds = normalizeStringList(resumeIds).slice(0, INDUSTRY_DB_V2_COHORT_MAX_SIZE);
+    if (limitedResumeIds.length === 0) {
+        return null;
+    }
+
+    const resumes = await Promise.all(limitedResumeIds.map((resumeId) => ctx.db.get(resumeId as never)));
+    const sorted = resumes
+        .map((resume) => clampIndustryDbV2RawScore((resume as { ingestData?: { industryDbV2Raw?: number } } | null)?.ingestData?.industryDbV2Raw ?? 0))
+        .sort((left: number, right: number) => left - right);
+    const histogram50 = Array.from({ length: INDUSTRY_DB_V2_HISTOGRAM_SIZE }, () => 0);
+    sorted.forEach((score: number) => {
+        histogram50[Math.round(score)] += 1;
+    });
+
+    return {
+        size: sorted.length,
+        p80: Number(quantile(sorted, 0.8).toFixed(2)),
+        histogram50,
+    };
 }
 
 /**
@@ -192,11 +244,31 @@ export const listSearchHistory = query({
             .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
             .collect();
 
-        return records.sort((left, right) => {
-            const leftTimestamp = left.lastOpenedAt ?? left.createdAt;
-            const rightTimestamp = right.lastOpenedAt ?? right.createdAt;
-            return rightTimestamp - leftTimestamp;
-        });
+        const cohorts = await ctx.db
+            .query("industry_db_cohorts")
+            .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
+            .collect();
+        const cohortBySearchHistoryId = new Map(cohorts.map((cohort) => [String(cohort.searchHistoryId), cohort]));
+
+        return records
+            .map((record) => {
+                const cohort = cohortBySearchHistoryId.get(String(record._id));
+                return {
+                    ...record,
+                    industryDbV2Stats: cohort
+                        ? {
+                            size: cohort.size,
+                            p80: cohort.p80,
+                            histogram50: cohort.histogram50,
+                        }
+                        : undefined,
+                };
+            })
+            .sort((left, right) => {
+                const leftTimestamp = left.lastOpenedAt ?? left.createdAt;
+                const rightTimestamp = right.lastOpenedAt ?? right.createdAt;
+                return rightTimestamp - leftTimestamp;
+            });
     },
 });
 
@@ -215,6 +287,7 @@ export const saveSearchHistory = mutation({
         collectionTaskId: v.optional(v.string()),
         analysisTaskId: v.optional(v.string()),
         notes: v.optional(v.string()),
+        resumeIds: v.optional(v.array(v.string())),
     },
     handler: async (ctx, args) => {
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
@@ -230,7 +303,7 @@ export const saveSearchHistory = mutation({
         const notes = normalizeOptionalString(args.notes);
         const now = Date.now();
 
-        return await ctx.db.insert("search_history", {
+        const searchHistoryId = await ctx.db.insert("search_history", {
             sessionKey: args.sessionKey,
             title,
             location,
@@ -247,6 +320,20 @@ export const saveSearchHistory = mutation({
             createdAt: now,
             lastOpenedAt: undefined,
         });
+
+        const cohort = await buildIndustryDbV2Cohort(ctx, args.resumeIds ?? []);
+        if (cohort) {
+            await ctx.db.insert("industry_db_cohorts", {
+                searchHistoryId,
+                workspaceSlug,
+                computedAt: now,
+                size: cohort.size,
+                p80: cohort.p80,
+                histogram50: cohort.histogram50,
+            });
+        }
+
+        return searchHistoryId;
     },
 });
 


### PR DESCRIPTION
## Summary
- persist deterministic Industry DB v2 raw scores and raw components through API ingest and Convex
- freeze histogram-based cohort stats on saved searches and expose them to the web session flow
- replace displayed AI `industry_db` scores with cohort-normalized deterministic values and cover the flow with targeted tests

## Test plan
- [x] npm run check
- [x] bun test ./apps/web/src/lib/resume-scoring.test.ts ./apps/api/src/services/ingest-compute-service.test.ts