### PR TITLE
fix: normalize legacy industry tags

### DIFF
--- a/apps/api/src/services/resume-index.test.ts
+++ b/apps/api/src/services/resume-index.test.ts
@@ -98,8 +98,7 @@ describe("ResumeIndexService", () => {
       expect(entry?.locationCity).toBe("东莞");
       expect(entry?.skills.some((skill) => skill.includes("销售") || skill.includes("车床"))).toBe(true);
       expect(entry?.companies.some((company) => company.includes("机械设备"))).toBe(true);
-      expect(entry?.industryTags).toContain("machinery");
-      expect(entry?.industryTags).toContain("sales");
+      expect(entry?.industryTags).toEqual(["machinery", "sales"]);
       expect(entry?.evidenceText).toBe(buildWorkHistoryEvidence(resumes[0]?.workHistory).text);
       expect(entry?.searchText).not.toContain("熟悉cnc车床和设备销售");
       expect(entry?.searchText).not.toContain("东莞 车床 销售 cnc");

--- a/apps/api/src/services/resume-index.ts
+++ b/apps/api/src/services/resume-index.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { buildWorkHistoryEvidence } from "@trends/shared";
+import { buildWorkHistoryEvidence, FALLBACK_INDUSTRY_KEYWORDS, normalizeIndustryTags, type CanonicalIndustryTag } from "@trends/shared";
 
 import { findProjectRoot } from "./db.js";
 import { JobDescriptionService } from "./job-description-service.js";
@@ -24,28 +24,7 @@ export interface ResumeIndex {
   searchText: string;
 }
 
-type IndustryTag = "machinery" | "cnc" | "sales" | "automation" | "metrology" | "software";
-
-const INDUSTRY_KEYWORDS: Record<IndustryTag, string[]> = {
-  machinery: [
-    "机床",
-    "车床",
-    "加工中心",
-    "机械",
-    "设备",
-    "五轴",
-    "夹具",
-    "治具",
-    "lathe",
-    "machining",
-    "milling",
-  ],
-  cnc: ["cnc", "数控", "fanuc", "siemens", "star", "brother", "mitsubishi"],
-  sales: ["销售", "业务", "客户", "大客户", "渠道", "sales", "account", "bd", "market"],
-  automation: ["自动化", "机器人", "plc", "伺服", "automation"],
-  metrology: ["测量", "三维扫描", "3d", "cmm", "metrology", "scan"],
-  software: ["c++", "c#", "mfc", "qt", "软件", "开发", "algorithm", "python"],
-};
+const INDUSTRY_KEYWORDS: Record<CanonicalIndustryTag, string[]> = FALLBACK_INDUSTRY_KEYWORDS;
 
 function normalizeText(value: string | undefined): string {
   return (value || "")
@@ -140,7 +119,7 @@ function scoreIndustryTagsLegacy(haystack: string): string[] {
     }
   }
 
-  return tags;
+  return normalizeIndustryTags(tags);
 }
 
 export class ResumeIndexService {
@@ -314,8 +293,9 @@ export class ResumeIndexService {
         }
       }
 
-      if (tags.length > 0) {
-        return tags;
+      const normalizedTags = normalizeIndustryTags(tags);
+      if (normalizedTags.length > 0) {
+        return normalizedTags;
       }
     } catch {
       // Fall through to legacy

--- a/apps/api/src/services/rule-scoring.test.ts
+++ b/apps/api/src/services/rule-scoring.test.ts
@@ -49,9 +49,9 @@ updated_at: '2026-02-24'
 
 ## Domain Taxonomy
 
-### cnc
-- displayName: CNC
-- keywords: cnc, 数控, fanuc
+### machinery
+- displayName: Machinery
+- keywords: 车床, cnc, 数控, fanuc
 
 ## Synonym Table
 
@@ -95,7 +95,7 @@ describe("RuleScoringService", () => {
       expect(context.title).toBe("cnc, 车床");
       expect(context.keywords).toEqual(["cnc", "车床"]);
       expect(context.targetLocations).toEqual(["广东"]);
-      expect(context.industryTags).toEqual(["cnc"]);
+      expect(context.industryTags).toEqual(["machinery"]);
       expect(context.requiredRoles).toEqual([]);
     } finally {
       cleanupFixtureRoot(root);
@@ -117,7 +117,7 @@ describe("RuleScoringService", () => {
         evidenceText: "2019-2025 cnc操作员 负责车床编程与设备维护",
         skills: ["cnc", "车床", "销售"],
         companies: ["东莞某机床厂"],
-        industryTags: ["machinery", "cnc"],
+        industryTags: ["machinery"],
         salaryRange: { min: 9000, max: 12000 },
         searchText: "东莞 cnc 车床 操作 维护",
       };
@@ -147,7 +147,7 @@ describe("RuleScoringService", () => {
         evidenceText: "2021-2025 东莞机床公司 数控车床销售工程师 负责CNC设备客户开发",
         skills: ["cnc", "数控车床", "销售"],
         companies: ["东莞机床公司"],
-        industryTags: ["cnc", "sales"],
+        industryTags: ["machinery", "sales"],
         salaryRange: { min: 12000, max: 18000 },
         searchText: "东莞 cnc 数控车床 销售 客户开发",
       };
@@ -156,6 +156,7 @@ describe("RuleScoringService", () => {
       const jdResult = service.scoreResume(cncSalesCandidate, jdContext);
 
       expect(keywordContext.keywords).toEqual(["cnc", "数控车床", "销售"]);
+      expect(keywordContext.industryTags).toEqual(["machinery"]);
       expect(keywordContext.requiredRoles).toEqual([]);
       expect(keywordResult.breakdown.skillMatch).toBeGreaterThan(0);
       expect(keywordResult.breakdown.roleMatch).toBe(10);
@@ -185,7 +186,7 @@ describe("RuleScoringService", () => {
         evidenceText: "2021-2025 东莞精密机械 销售经理 客户开发 渠道拓展",
         skills: ["车床", "cnc", "销售"],
         companies: ["东莞富佳机械设备有限公司"],
-        industryTags: ["machinery", "cnc", "sales"],
+        industryTags: ["machinery", "sales"],
         salaryRange: { min: 10000, max: 20000 },
         searchText: "东莞 车床 cnc 销售 机械设备 大客户",
       };
@@ -227,7 +228,7 @@ describe("RuleScoringService", () => {
         educationLevel: "bachelor",
         skills: ["cnc"],
         companies: [],
-        industryTags: ["cnc"],
+        industryTags: ["machinery"],
         salaryRange: { min: 8000, max: 15000 },
         searchText: "cnc 销售 北京 东莞",
       };
@@ -281,7 +282,7 @@ describe("RuleScoringService", () => {
         educationLevel: "bachelor",
         skills: ["cnc"],
         companies: [],
-        industryTags: ["cnc"],
+        industryTags: ["machinery"],
         salaryRange: { min: 8000, max: 15000 },
         searchText: "cnc 销售",
       };
@@ -335,7 +336,7 @@ describe("RuleScoringService", () => {
         locationCity: "东莞",
         skills: ["cnc"],
         companies: [],
-        industryTags: ["cnc"],
+        industryTags: ["machinery"],
         salaryRange: { min: 8000, max: 15000 },
         searchText: "cnc 销售",
       };
@@ -370,6 +371,7 @@ describe("RuleScoringService", () => {
     try {
       const service = new RuleScoringService(root);
       const context = service.buildContextFromKeywords(["数控"]);
+      expect(context.industryTags).toEqual(["machinery"]);
 
       const index: ResumeIndex = {
         resumeId: "R-synonym",
@@ -379,7 +381,7 @@ describe("RuleScoringService", () => {
         evidenceText: "cnc 车床 销售",
         skills: ["cnc"],
         companies: [],
-        industryTags: ["cnc"],
+        industryTags: ["machinery"],
         salaryRange: { min: 8000, max: 15000 },
         searchText: "cnc 车床 销售",
       };
@@ -408,7 +410,7 @@ describe("RuleScoringService", () => {
         locationCity: "东莞",
         skills: ["销售", "cnc"],
         companies: ["上海发那科机器人有限公司"],
-        industryTags: ["cnc", "sales"],
+        industryTags: ["machinery", "sales"],
         salaryRange: { min: 10000, max: 18000 },
         searchText: "东莞 发那科 销售 cnc",
       };
@@ -442,7 +444,7 @@ describe("RuleScoringService", () => {
         locationCity: "东莞",
         skills: ["销售", "cnc"],
         companies: [],
-        industryTags: ["cnc"],
+        industryTags: ["machinery"],
         salaryRange: { min: 9000, max: 16000 },
         searchText: "东莞 cnc 销售",
       };
@@ -470,7 +472,7 @@ describe("RuleScoringService", () => {
         locationCity: "东莞",
         skills: ["销售", "cnc"],
         companies: ["上海发那科机器人有限公司"],
-        industryTags: ["cnc", "sales"],
+        industryTags: ["machinery", "sales"],
         salaryRange: { min: 10000, max: 18000 },
         searchText: "东莞 发那科 销售 cnc",
       };
@@ -504,7 +506,7 @@ describe("RuleScoringService", () => {
         locationCity: "东莞",
         skills: ["销售", "cnc"],
         companies: ["上海发那科机器人有限公司"],
-        industryTags: ["cnc", "sales"],
+        industryTags: ["machinery", "sales"],
         salaryRange: { min: 10000, max: 18000 },
         searchText: "东莞 发那科 销售 cnc",
       };
@@ -534,7 +536,7 @@ describe("RuleScoringService", () => {
         evidenceText: "2019-2025 cnc操作员 负责车床编程与设备维护",
         skills: ["cnc", "车床", "销售"],
         companies: ["东莞某机床厂"],
-        industryTags: ["machinery", "cnc"],
+        industryTags: ["machinery"],
         salaryRange: { min: 9000, max: 12000 },
         searchText: "东莞 cnc 车床 操作 维护",
       };
@@ -547,7 +549,7 @@ describe("RuleScoringService", () => {
         evidenceText: "2020-2025 机床销售工程师 负责客户开发 渠道拓展",
         skills: ["cnc", "车床", "销售"],
         companies: ["东莞设备公司"],
-        industryTags: ["machinery", "cnc", "sales"],
+        industryTags: ["machinery", "sales"],
         salaryRange: { min: 12000, max: 18000 },
         searchText: "东莞 车床 销售 客户 渠道",
       };
@@ -580,7 +582,7 @@ describe("RuleScoringService", () => {
         evidenceText: "2020-2025 cnc操作员 负责车床编程与设备维护",
         skills: ["cnc", "车床", "销售"],
         companies: ["东莞设备厂"],
-        industryTags: ["machinery", "cnc"],
+        industryTags: ["machinery"],
         salaryRange: { min: 10000, max: 15000 },
         searchText: "东莞 cnc 车床 销售 客户 渠道 机床销售工程师 熟悉star fanuc品牌 大客户资源",
       };
@@ -611,7 +613,7 @@ describe("RuleScoringService", () => {
         locationCity: "东莞",
         skills: ["cnc", "车床", "销售"],
         companies: ["东莞设备厂"],
-        industryTags: ["machinery", "cnc", "sales"],
+        industryTags: ["machinery", "sales"],
         salaryRange: { min: 10000, max: 15000 },
         searchText: "东莞 cnc 车床 销售 客户 渠道",
       };
@@ -639,7 +641,7 @@ describe("RuleScoringService", () => {
         evidenceText: "2020-2025 机床销售工程师 负责客户开发 渠道拓展",
         skills: ["cnc", "车床", "销售"],
         companies: ["东莞设备公司"],
-        industryTags: ["machinery", "cnc", "sales"],
+        industryTags: ["machinery", "sales"],
         salaryRange: { min: 12000, max: 18000 },
         searchText: "东莞 车床 销售 客户 渠道 熟悉fanuc品牌",
       };
@@ -691,7 +693,7 @@ describe("RuleScoringService", () => {
         evidenceText: "2021-2024 东莞机床公司 销售工程师 负责cnc车床销售与客户开发",
         skills: ["cnc", "车床", "销售"],
         companies: ["东莞机床公司"],
-        industryTags: ["cnc", "sales"],
+        industryTags: ["machinery", "sales"],
         salaryRange: { min: 9000, max: 12000 },
         searchText: "东莞 cnc 车床 销售",
       };
@@ -736,7 +738,7 @@ describe("RuleScoringService", () => {
         evidenceText: "2019-2025 CNC操作员 负责车床编程与设备维护",
         skills: ["cnc", "车床", "销售"],
         companies: ["东莞某机床厂"],
-        industryTags: ["machinery", "cnc"],
+        industryTags: ["machinery"],
         salaryRange: { min: 9000, max: 12000 },
         searchText: "东莞 cnc 车床 操作 维护",
       };
@@ -749,7 +751,7 @@ describe("RuleScoringService", () => {
         evidenceText: "2020-2025 机床销售工程师 负责客户开发 渠道拓展",
         skills: ["cnc", "车床", "销售"],
         companies: ["东莞设备公司"],
-        industryTags: ["machinery", "cnc", "sales"],
+        industryTags: ["machinery", "sales"],
         salaryRange: { min: 12000, max: 18000 },
         searchText: "东莞 车床 销售 客户 渠道",
       };

--- a/apps/api/src/services/rule-scoring.ts
+++ b/apps/api/src/services/rule-scoring.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import JSON5 from "json5";
+import { FALLBACK_INDUSTRY_KEYWORDS, normalizeIndustryTags } from "@trends/shared";
 import { z } from "zod";
 
 import { findProjectRoot } from "./db.js";
@@ -234,14 +235,9 @@ function requiresIndustryVerification(roleType: string): boolean {
   return INDUSTRY_VERIFIED_ROLE_TYPES.has(roleType.toLowerCase());
 }
 
-const INDUSTRY_MAP: Array<{ tag: string; keywords: string[] }> = [
-  { tag: "machinery", keywords: ["机床", "车床", "机械", "设备", "夹具", "五轴", "加工中心", "lathe", "machining"] },
-  { tag: "cnc", keywords: ["cnc", "数控", "fanuc", "siemens", "star"] },
-  { tag: "sales", keywords: ["销售", "客户", "大客户", "业务", "sales", "account"] },
-  { tag: "automation", keywords: ["自动化", "机器人", "plc", "automation"] },
-  { tag: "metrology", keywords: ["测量", "三维", "扫描", "cmm", "metrology"] },
-  { tag: "software", keywords: ["软件", "c++", "c#", "qt", "mfc", "开发"] },
-];
+const INDUSTRY_MAP: Array<{ tag: string; keywords: string[] }> = Object.entries(FALLBACK_INDUSTRY_KEYWORDS).map(
+  ([tag, keywords]) => ({ tag, keywords })
+);
 
 const LOCATION_PROXIMITY_GROUPS: Record<string, string[]> = {
   pearlRiverDelta: ["东莞", "深圳", "广州", "佛山", "惠州", "中山", "珠海", "江门"],
@@ -282,7 +278,7 @@ function inferIndustryTags(tokens: string[]): string[] {
     }
   }
 
-  return Array.from(tags);
+  return normalizeIndustryTags(Array.from(tags));
 }
 
 function getMinEducationRank(requirements: string[]): number | null {
@@ -533,7 +529,7 @@ export class RuleScoringService {
       }
     }
 
-    return Array.from(tags);
+    return normalizeIndustryTags(Array.from(tags));
   }
 
   private inferBrandKeywords(tokens: string[]): string[] {

--- a/apps/api/src/services/skills-knowledge.test.ts
+++ b/apps/api/src/services/skills-knowledge.test.ts
@@ -18,23 +18,20 @@ description: Test skills knowledge file
 
 ### machinery
 - displayName: Machinery
-- keywords: 机床, 车床, lathe, machining
-
-### cnc
-- displayName: CNC
-- keywords: cnc, 数控, fanuc, star
+- keywords: 机床, 车床, lathe, machining, cnc, 数控, fanuc, star
 
 ### sales
 - displayName: Sales
-- keywords: 销售, 客户, sales, account
+- keywords: 销售, 客户, 销售工程师, sales, account, key account
 
 ## Synonym Table
 
 - 机床: 机械设备, 加工设备
-- 车床: CNC车床, 数控车床
+- 车床: CNC车床, 数控车床, cnc lathe
 - 数控: CNC, Computer Numerical Control
 - 销售: 业务, 商务
-- 机床销售: 车床销售
+- 销售工程师: sales engineer, 技术销售
+- 机床销售: 车床销售, cnc销售
 - 销售岗位: 机床销售
 - 哈斯: 哈斯机床
 - 循环A: 循环B
@@ -63,8 +60,8 @@ description: Test skills knowledge file
 
 ## Industry Context
 
-### CNC Machining Domain
-CNC machining involves automated control of machine tools. Key brands include FANUC and STAR.
+### Machinery and Machining Domain
+Machining involves CNC-controlled machine tools. Key brands include FANUC and STAR.
 
 ### Sales and Business Development
 B2B sales requires technical knowledge and customer relationship management.
@@ -108,7 +105,7 @@ describe("SkillsKnowledgeService", () => {
       const service = new SkillsKnowledgeService(root);
       const taxonomy = service.getIndustryTaxonomy();
 
-      expect(taxonomy).toHaveLength(3);
+      expect(taxonomy).toHaveLength(2);
 
       const machinery = taxonomy.find((d) => d.tag === "machinery");
       expect(machinery).toBeDefined();
@@ -117,11 +114,8 @@ describe("SkillsKnowledgeService", () => {
       expect(machinery?.keywords).toContain("车床");
       expect(machinery?.keywords).toContain("lathe");
 
-      const cnc = taxonomy.find((d) => d.tag === "cnc");
-      expect(cnc).toBeDefined();
-      expect(cnc?.displayName).toBe("CNC");
-      expect(cnc?.keywords).toContain("cnc");
-      expect(cnc?.keywords).toContain("fanuc");
+      expect(machinery?.keywords).toContain("cnc");
+      expect(machinery?.keywords).toContain("fanuc");
 
       const sales = taxonomy.find((d) => d.tag === "sales");
       expect(sales).toBeDefined();
@@ -193,6 +187,7 @@ describe("SkillsKnowledgeService", () => {
       expect(vocab.has("机床")).toBe(true);
       expect(vocab.has("车床")).toBe(true);
       expect(vocab.has("cnc")).toBe(true);
+      expect(vocab.has("销售工程师")).toBe(true);
       expect(vocab.has("销售")).toBe(true);
 
       // Synonym variants
@@ -301,8 +296,8 @@ describe("SkillsKnowledgeService", () => {
       const service = new SkillsKnowledgeService(root);
       const context = service.getIndustryContext();
 
-      expect(context).toContain("CNC Machining Domain");
-      expect(context).toContain("automated control");
+      expect(context).toContain("Machinery and Machining Domain");
+      expect(context).toContain("CNC-controlled machine tools");
       expect(context).toContain("Sales and Business Development");
       expect(context).toContain("customer relationship");
     } finally {
@@ -437,7 +432,7 @@ describe("SkillsKnowledgeService", () => {
 
       // First call parses and caches
       const taxonomy1 = service.getIndustryTaxonomy();
-      expect(taxonomy1).toHaveLength(3);
+      expect(taxonomy1).toHaveLength(2);
 
       // Second call uses cache (should be same reference)
       const taxonomy2 = service.getIndustryTaxonomy();
@@ -448,7 +443,7 @@ describe("SkillsKnowledgeService", () => {
 
       // Third call re-parses
       const taxonomy3 = service.getIndustryTaxonomy();
-      expect(taxonomy3).toHaveLength(3);
+      expect(taxonomy3).toHaveLength(2);
       expect(taxonomy3).not.toBe(taxonomy1);
     } finally {
       cleanupFixtureRoot(root);

--- a/apps/web/src/components/JobDescriptionEditor.tsx
+++ b/apps/web/src/components/JobDescriptionEditor.tsx
@@ -12,13 +12,15 @@ import { useTranslation } from "react-i18next"
 import { LocationSelector } from "@/components/LocationSelector"
 import { KeywordInput } from "@/components/KeywordInput"
 import {
+    CANONICAL_INDUSTRY_TAGS,
     DEFAULT_MIN_EXPERIENCE,
     generateStructuredJobDescriptionContent,
+    normalizeIndustryTags,
     normalizeOptionalString,
     type StructuredJobDescriptionSeedFields,
 } from "@trends/shared"
 
-const INDUSTRY_TAG_OPTIONS = ["machinery", "cnc", "sales", "automation", "metrology", "software"] as const
+const INDUSTRY_TAG_OPTIONS = CANONICAL_INDUSTRY_TAGS
 
 type StructuredSeedFields = StructuredJobDescriptionSeedFields
 
@@ -35,19 +37,7 @@ function parseOptionalNumber(value: string): number | undefined {
 }
 
 function sanitizeIndustryTags(values: string[] | undefined): string[] {
-    if (!Array.isArray(values)) {
-        return []
-    }
-
-    const allowed = new Set<string>(INDUSTRY_TAG_OPTIONS)
-    const selected = new Set<string>()
-    values.forEach((value) => {
-        const token = value.trim()
-        if (allowed.has(token)) {
-            selected.add(token)
-        }
-    })
-    return Array.from(selected)
+    return normalizeIndustryTags(values)
 }
 
 function hasStructuredSeedFields(fields: StructuredSeedFields | undefined): boolean {

--- a/config/resume/skills.en.md
+++ b/config/resume/skills.en.md
@@ -16,19 +16,11 @@ Skills are organized by domain tags. Each domain includes a canonical tag, displ
 
 ### machinery
 - displayName: Machinery
-- keywords: 机床, 车床, 加工中心, 机械, 设备, 五轴, 夹具, 治具, lathe, machining, milling
-
-### cnc
-- displayName: CNC
-- keywords: cnc, 数控, fanuc, siemens, star, brother, mitsubishi
+- keywords: 机床, 车床, 加工中心, 机械, 设备, 五轴, 夹具, 治具, lathe, machining, milling, cnc, 数控, fanuc, siemens, star, brother, mitsubishi
 
 ### sales
 - displayName: Sales
-- keywords: 销售, 业务, 客户, 大客户, 渠道, sales, account, bd, market, engineer
-
-### automation
-- displayName: Automation
-- keywords: 自动化, 机器人, plc, 伺服, automation
+- keywords: 销售, 业务, 客户, 大客户, 渠道, 销售工程师, 业务拓展, sales, account, key account, bd, business development
 
 ### metrology
 - displayName: Metrology
@@ -43,14 +35,15 @@ Skills are organized by domain tags. Each domain includes a canonical tag, displ
 Maps variant terms to canonical forms for search expansion and matching normalization.
 
 - 机床: 机械设备, 加工设备
-- 车床: CNC车床, 数控车床
-- 加工中心: machining center, machining-center, 加工设备
+- 车床: CNC车床, 数控车床, cnc lathe
+- 加工中心: machining center, machining-center, 加工设备, machine tool
 - 五轴: 5-axis, 五轴联动
 - 夹具: 治具, fixture
-- 数控: CNC, Computer Numerical Control
+- 数控: CNC, Computer Numerical Control, 数控加工
 - 销售: 业务, 商务, 销售员
+- 销售工程师: sales engineer, 售前销售, 技术销售
 - 大客户: 渠道客户, key account, 关键客户
-- 自动化: automation, 工业自动化
+- 机床销售: 车床销售, cnc销售, 数控机床销售
 - 机器人: robot, 工业机器人
 - 测量: 计量, measurement, 质量检测
 - 三维扫描: 3D扫描, 3d-scan, 三维测量
@@ -151,17 +144,14 @@ Tier 5 - Domestic / Pearl River Delta
 
 Background notes used for AI prompt enrichment and domain understanding.
 
-### CNC Machining Domain
-CNC (Computer Numerical Control) machining uses programmed commands to automate machine tools. Core brands include FANUC, SIEMENS, STAR, BROTHER, and MITSUBISHI. Common machine types include lathes, machining centers, and multi-axis systems.
+### Machinery and Machining Domain
+Machining covers CNC (Computer Numerical Control) machine tools, machining centers, lathes, and multi-axis systems. Core brands include FANUC, SIEMENS, STAR, BROTHER, and MITSUBISHI, and related CNC signals now resolve through the surviving machinery domain.
 
 ### Sales and Business Development
-B2B sales for manufacturing equipment usually requires technical product knowledge, customer relationship management, and channel development capability. Typical keywords include key accounts, channels, and business development.
+B2B sales for manufacturing equipment usually requires technical product knowledge, customer relationship management, and channel development capability. Prefer composite role phrases such as sales engineer, key account, and business development instead of treating bare engineer as a sales signal.
 
 ### Metrology and Quality
 Precision measurement relies on CMM (Coordinate Measuring Machine), 3D scanning, and quality inspection workflows, which are critical to manufacturing QA/QC.
-
-### Automation
-Industrial automation commonly involves PLCs, servo systems, and robotics across factory automation and smart manufacturing scenarios.
 
 ## Exclusion Patterns
 
@@ -177,11 +167,11 @@ HR feedback patterns and observations. On 2026-03-10, 174 raw shortlist entries 
 - 2026-03-10: shortlist_pattern: sales + senior -> high_priority (19x)
 - 2026-03-10: shortlist_pattern: sales/software + senior -> high_priority (16x)
 - 2026-03-10: shortlist_pattern: sales/software + mid -> high_priority (14x)
-- 2026-03-10: shortlist_pattern: machinery/cnc + unknown -> medium_priority (10x)
-- 2026-03-10: shortlist_pattern: machinery/cnc + mid -> medium_priority (7x)
-- 2026-03-10: shortlist_pattern: cnc + mid -> medium_priority (5x)
+- 2026-03-10: shortlist_pattern: machinery + unknown -> medium_priority (10x)
+- 2026-03-10: shortlist_pattern: machinery + mid -> medium_priority (7x)
+- 2026-03-10: shortlist_pattern: machinery + mid -> medium_priority (5x)
 - 2026-03-10: shortlist_pattern: machinery + unknown -> medium_priority (5x)
 - 2026-03-10: shortlist_pattern: machinery/sales/software + senior -> medium_priority (5x)
-- 2026-03-10: shortlist_pattern: cnc + unknown -> medium_priority (5x)
+- 2026-03-10: shortlist_pattern: machinery + unknown -> medium_priority (5x)
 - 2026-03-10: learning_log_compaction: aggregated 174 raw shortlist entries into 50 unique patterns for durable signal storage.
 - 2026-03-10: processing pipeline now excludes selfIntro, jobIntention, and header experience from strict matching; work history is the sole evidence source for experience and scoring.

--- a/config/resume/skills.md
+++ b/config/resume/skills.md
@@ -17,19 +17,11 @@ description: >
 
 ### machinery
 - displayName: 机械
-- keywords: 机床, 车床, 加工中心, 机械, 设备, 五轴, 夹具, 治具, lathe, machining, milling
-
-### cnc
-- displayName: CNC
-- keywords: cnc, 数控, fanuc, siemens, star, brother, mitsubishi
+- keywords: 机床, 车床, 加工中心, 机械, 设备, 五轴, 夹具, 治具, lathe, machining, milling, cnc, 数控, fanuc, siemens, star, brother, mitsubishi
 
 ### sales
 - displayName: 销售
-- keywords: 销售, 业务, 客户, 大客户, 渠道, sales, account, bd, market, engineer
-
-### automation
-- displayName: 自动化
-- keywords: 自动化, 机器人, plc, 伺服, automation
+- keywords: 销售, 业务, 客户, 大客户, 渠道, 销售工程师, 业务拓展, sales, account, key account, bd, business development
 
 ### metrology
 - displayName: 测量
@@ -44,14 +36,15 @@ description: >
 将变体术语映射到标准形式，用于搜索扩展与匹配归一化。
 
 - 机床: 机械设备, 加工设备
-- 车床: CNC车床, 数控车床
-- 加工中心: machining center, machining-center, 加工设备
+- 车床: CNC车床, 数控车床, cnc lathe
+- 加工中心: machining center, machining-center, 加工设备, machine tool
 - 五轴: 5-axis, 五轴联动
 - 夹具: 治具, fixture
-- 数控: CNC, Computer Numerical Control
+- 数控: CNC, Computer Numerical Control, 数控加工
 - 销售: 业务, 商务, 销售员
+- 销售工程师: sales engineer, 售前销售, 技术销售
 - 大客户: 渠道客户, key account, 关键客户
-- 自动化: automation, 工业自动化
+- 机床销售: 车床销售, cnc销售, 数控机床销售
 - 机器人: robot, 工业机器人
 - 测量: 计量, measurement, 质量检测
 - 三维扫描: 3D扫描, 3d-scan, 三维测量
@@ -152,17 +145,14 @@ description: >
 
 供 AI 提示增强与领域理解使用的行业背景说明。
 
-### CNC 加工领域
-CNC（Computer Numerical Control，计算机数控）加工是通过程序控制机床执行自动化加工。核心品牌包括 FANUC、SIEMENS、STAR、BROTHER 与 MITSUBISHI。常见设备类型包括车床、加工中心与五轴系统。
+### 机械加工领域
+机械加工场景包含 CNC（Computer Numerical Control，计算机数控）机床、加工中心、车床与五轴系统。核心品牌包括 FANUC、SIEMENS、STAR、BROTHER 与 MITSUBISHI，相关数控信号统一归入 machinery 领域。
 
 ### 销售与业务拓展
-制造业设备 B2B 销售通常需要设备技术理解、客户关系管理与渠道开发能力。典型关键词包括大客户、渠道与业务拓展。
+制造业设备 B2B 销售通常需要设备技术理解、客户关系管理与渠道开发能力。优先关注销售工程师、大客户与业务拓展等复合角色表达，避免将泛化 engineer 词汇直接视为销售信号。
 
 ### 测量与质量
 精密测量通常依赖 CMM（三坐标测量机）、3D 扫描与质量检测流程，是制造业 QA/QC 的关键环节。
-
-### 自动化
-工业自动化场景常涉及 PLC、伺服系统与机器人，广泛应用于工厂自动化与智能制造。
 
 ## 排除模式
 
@@ -178,11 +168,11 @@ HR 反馈模式与观察记录。已于 2026-03-10 从 174 条原始 shortlist �
 - 2026-03-10: shortlist_pattern: sales + senior -> high_priority (19x)
 - 2026-03-10: shortlist_pattern: sales/software + senior -> high_priority (16x)
 - 2026-03-10: shortlist_pattern: sales/software + mid -> high_priority (14x)
-- 2026-03-10: shortlist_pattern: machinery/cnc + unknown -> medium_priority (10x)
-- 2026-03-10: shortlist_pattern: machinery/cnc + mid -> medium_priority (7x)
-- 2026-03-10: shortlist_pattern: cnc + mid -> medium_priority (5x)
+- 2026-03-10: shortlist_pattern: machinery + unknown -> medium_priority (10x)
+- 2026-03-10: shortlist_pattern: machinery + mid -> medium_priority (7x)
+- 2026-03-10: shortlist_pattern: machinery + mid -> medium_priority (5x)
 - 2026-03-10: shortlist_pattern: machinery + unknown -> medium_priority (5x)
 - 2026-03-10: shortlist_pattern: machinery/sales/software + senior -> medium_priority (5x)
-- 2026-03-10: shortlist_pattern: cnc + unknown -> medium_priority (5x)
+- 2026-03-10: shortlist_pattern: machinery + unknown -> medium_priority (5x)
 - 2026-03-10: learning_log_compaction: aggregated 174 raw shortlist entries into 50 unique patterns for durable signal storage.
 - 2026-03-10: processing pipeline now excludes selfIntro, jobIntention, and header experience from strict matching; work history is the sole evidence source for experience and scoring.

--- a/packages/convex/convex/__tests__/job-descriptions.test.ts
+++ b/packages/convex/convex/__tests__/job-descriptions.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { list_with_usage } from '../job_descriptions'
+
+type ConvexHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+const listWithUsageHandler = (list_with_usage as unknown as ConvexHandler<
+  { workspaceSlug?: string },
+  Array<Record<string, unknown>>
+>)._handler
+
+describe('job description legacy industry tags', () => {
+  it('normalizes legacy industry tags in list_with_usage results', async () => {
+    const jobDescriptions = [
+      {
+        _id: 'custom-jd-1',
+        title: '车床销售',
+        type: 'custom',
+        workspaceSlug: 'dev',
+        enabled: true,
+        lastModified: 1,
+        industryTags: ['machinery', 'cnc', 'automation', 'sales'],
+      },
+    ]
+
+    const ctx = {
+      db: {
+        query(tableName: string) {
+          if (tableName === 'job_descriptions') {
+            return {
+              async collect() {
+                return jobDescriptions
+              },
+            }
+          }
+
+          if (tableName === 'resumes') {
+            return {
+              async collect() {
+                return []
+              },
+            }
+          }
+
+          return {
+            async collect() {
+              return []
+            },
+          }
+        },
+      },
+    }
+
+    const result = await listWithUsageHandler(ctx as never, { workspaceSlug: 'dev' })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(expect.objectContaining({
+      industryTags: ['machinery', 'sales'],
+      usageCount: 0,
+    }))
+  })
+})

--- a/packages/convex/convex/__tests__/search-text.test.ts
+++ b/packages/convex/convex/__tests__/search-text.test.ts
@@ -5,7 +5,7 @@ import { appendMissingSearchTokens, buildIngestSearchTokens, mergeSearchTextWith
 describe("buildIngestSearchTokens", () => {
     it("normalizes and deduplicates ingest metadata tokens", () => {
         expect(buildIngestSearchTokens({
-            industryTags: [" Machinery ", "cnc"],
+            industryTags: [" Machinery ", "machinery"],
             synonymHits: ["CNC", "sales engineer"],
             companyHits: ["FANUC", "fanuc"],
             companyAliasTokens: "  Fanuc 发那科  ",

--- a/packages/convex/convex/job_descriptions.ts
+++ b/packages/convex/convex/job_descriptions.ts
@@ -2,6 +2,8 @@ import { internal } from "./_generated/api";
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 
+import { normalizeIndustryTags } from "@trends/shared";
+
 import { DEFAULT_WORKSPACE_SLUG } from "./sessions";
 
 function normalizeWorkspaceSlug(input: string | undefined): string {
@@ -17,6 +19,19 @@ function belongsToWorkspace(
         return !recordWorkspaceSlug || recordWorkspaceSlug === DEFAULT_WORKSPACE_SLUG;
     }
     return recordWorkspaceSlug === workspaceSlug;
+}
+
+function sanitizeIndustryTags(input: string[] | undefined | null): string[] | undefined {
+    const normalized = normalizeIndustryTags(input);
+    return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeJobDescriptionRecord<T extends { industryTags?: string[] | undefined }>(record: T): T {
+    const industryTags = sanitizeIndustryTags(record.industryTags);
+    return {
+        ...record,
+        industryTags,
+    };
 }
 
 export const list = query({
@@ -44,7 +59,10 @@ export const list = query({
 
         customJDs = customJDs.filter((jd) => belongsToWorkspace(jd.workspaceSlug, workspaceSlug));
 
-        return [...systemJDs, ...customJDs].filter(jd => jd.enabled !== false).sort((a, b) => b.lastModified - a.lastModified);
+        return [...systemJDs, ...customJDs]
+            .filter(jd => jd.enabled !== false)
+            .map(normalizeJobDescriptionRecord)
+            .sort((a, b) => b.lastModified - a.lastModified);
     },
 });
 
@@ -74,7 +92,7 @@ export const create = mutation({
             enabled: true,
             lastModified: Date.now(),
             location: args.location,
-            industryTags: args.industryTags,
+            industryTags: sanitizeIndustryTags(args.industryTags),
             customKeywords: args.customKeywords,
             minExperience: args.minExperience,
             maxExperience: args.maxExperience,
@@ -107,7 +125,7 @@ export const update = mutation({
             ...(updates.content !== undefined ? { content: updates.content } : {}),
             ...(updates.enabled !== undefined ? { enabled: updates.enabled } : {}),
             ...(updates.location !== undefined ? { location: updates.location ?? undefined } : {}),
-            ...(updates.industryTags !== undefined ? { industryTags: updates.industryTags ?? undefined } : {}),
+            ...(updates.industryTags !== undefined ? { industryTags: sanitizeIndustryTags(updates.industryTags) } : {}),
             ...(updates.customKeywords !== undefined ? { customKeywords: updates.customKeywords ?? undefined } : {}),
             ...(updates.minExperience !== undefined ? { minExperience: updates.minExperience ?? undefined } : {}),
             ...(updates.maxExperience !== undefined ? { maxExperience: updates.maxExperience ?? undefined } : {}),
@@ -125,7 +143,8 @@ export const update = mutation({
 export const get = query({
     args: { id: v.id("job_descriptions") },
     handler: async (ctx, args) => {
-        return await ctx.db.get(args.id);
+        const record = await ctx.db.get(args.id);
+        return record ? normalizeJobDescriptionRecord(record) : record;
     },
 });
 
@@ -135,12 +154,14 @@ export const list_all = query({
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
         const jds = await ctx.db.query("job_descriptions").collect();
 
-        return jds.filter((jd) => {
-            if (jd.type === "system") {
-                return true;
-            }
-            return belongsToWorkspace(jd.workspaceSlug, workspaceSlug);
-        });
+        return jds
+            .filter((jd) => {
+                if (jd.type === "system") {
+                    return true;
+                }
+                return belongsToWorkspace(jd.workspaceSlug, workspaceSlug);
+            })
+            .map(normalizeJobDescriptionRecord);
     },
 });
 
@@ -206,19 +227,17 @@ export const list_with_usage = query({
 
             const usageCount = resumes.filter(r => {
                 const analysisJdId = r.analysis?.jobDescriptionId;
-                // Check in legacy analysis field - match by Convex _id or by slug
                 if (analysisJdId === jdIdStr) return true;
                 if (jdSlug && analysisJdId === jdSlug) return true;
-                // Check in multi-JD analyses map - match by Convex _id or by slug
                 if (r.analyses && r.analyses[jdIdStr]) return true;
                 if (jdSlug && r.analyses && r.analyses[jdSlug]) return true;
                 return false;
             }).length;
 
-            return {
+            return normalizeJobDescriptionRecord({
                 ...jd,
-                usageCount
-            };
+                usageCount,
+            });
         });
     }
 });

--- a/packages/convex/convex/seed.ts
+++ b/packages/convex/convex/seed.ts
@@ -2,12 +2,14 @@ import { mutation, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { v } from "convex/values";
+import { generateStructuredJobDescriptionContent } from "@trends/shared";
 import { buildSearchText } from "./search_text";
 import { deriveResumeIdentity } from "./lib/resume_identity";
 
 import { DEFAULT_WORKSPACE_SLUG } from "./sessions";
 
 const jobDescriptionType = v.union(v.literal("system"), v.literal("custom"));
+const WORKSPACE_DEMO_DEV_MACHINERY_SALES_SLUG = "workspace-demo-dev-machinery-sales";
 
 function normalizeWorkspaceSlug(input: string | undefined): string {
   const normalized = input?.trim();
@@ -293,44 +295,21 @@ export const seedWorkspaceDemoData = mutation({
     const customJobDescriptions = [
       {
         title: "车床销售",
-        slug: "workspace-demo-dev-cnc-sales",
+        slug: WORKSPACE_DEMO_DEV_MACHINERY_SALES_SLUG,
         workspaceSlug: "dev",
         location: "广东",
-        industryTags: ["machinery", "cnc", "sales"],
+        industryTags: ["machinery", "sales"],
         customKeywords: ["机床", "销售"],
         minExperience: 1,
         maxAge: 45,
-        content: [
-          "---",
-          'title: "车床销售"',
-          "status: active",
-          'location: "广东"',
-          "min_experience: 1",
-          "max_age: 45",
-          "industry_tags:",
-          '  - "machinery"',
-          '  - "cnc"',
-          '  - "sales"',
-          "auto_match:",
-          "  keywords:",
-          '    - "机床"',
-          '    - "销售"',
-          "---",
-          "",
-          "# 职位描述",
-          "",
-          "请补充「车床销售」的岗位职责。",
-          "",
-          "# 任职要求",
-          "",
-          "- 相关经验：1+ 年",
-          "- 年龄范围：--45",
-          "- 行业方向：machinery / cnc / sales",
-          "",
-          "# 关键词",
-          "",
-          "机床, 销售",
-        ].join("\n"),
+        content: generateStructuredJobDescriptionContent({
+          title: "车床销售",
+          location: "广东",
+          industryTags: ["machinery", "sales"],
+          customKeywords: ["机床", "销售"],
+          minExperience: 1,
+          maxAge: 45,
+        }),
       },
       {
         title: "Workspace Demo · HR Resume Operations Specialist",
@@ -353,16 +332,16 @@ export const seedWorkspaceDemoData = mutation({
 
     const searchProfiles = [
       {
-        name: "CNC销售-Demo",
+        name: "机械销售-Demo",
         criteria: {
-          keywords: ["CNC", "销售"],
+          keywords: ["机床", "销售"],
           locations: [""],
         },
         profile: {
-          name: "CNC销售-Demo",
+          name: "机械销售-Demo",
           status: "active" as const,
           location: "",
-          keywords: ["CNC", "销售"],
+          keywords: ["机床", "销售"],
           filters: {
             minExperience: 1,
             minAge: 25,
@@ -400,8 +379,8 @@ export const seedWorkspaceDemoData = mutation({
         status: "active" as const,
         config: {
           location: "东莞",
-          keywords: ["CNC", "销售"],
-          jobDescriptionId: "workspace-demo-dev-cnc-sales",
+          keywords: ["机床", "销售"],
+          jobDescriptionId: WORKSPACE_DEMO_DEV_MACHINERY_SALES_SLUG,
           filters: {
             minExperience: 3,
             education: ["大专", "本科"],
@@ -432,10 +411,10 @@ export const seedWorkspaceDemoData = mutation({
     const searchHistory = [
       {
         sessionKey: "workspace-demo-session-dev",
-        title: "东莞 · CNC 销售",
+        title: "东莞 · 机械 销售",
         location: "东莞",
-        keywords: ["CNC", "销售"],
-        jobDescriptionId: "workspace-demo-dev-cnc-sales",
+        keywords: ["机床", "销售"],
+        jobDescriptionId: WORKSPACE_DEMO_DEV_MACHINERY_SALES_SLUG,
         filters: {
           minExperience: 3,
           education: ["大专", "本科"],
@@ -482,7 +461,7 @@ export const seedWorkspaceDemoData = mutation({
             {
               id: "workspace-dev-brand-star",
               keyword: "STAR机床",
-              english: "STAR CNC",
+              english: "STAR 机床",
               category: "workspace-dev-brand",
             },
             {

--- a/packages/shared/src/job-description-content.ts
+++ b/packages/shared/src/job-description-content.ts
@@ -1,4 +1,36 @@
 export const DEFAULT_MIN_EXPERIENCE = 1;
+export const CANONICAL_INDUSTRY_TAGS = ["machinery", "sales", "metrology", "software"] as const;
+export type CanonicalIndustryTag = (typeof CANONICAL_INDUSTRY_TAGS)[number];
+export const FALLBACK_INDUSTRY_KEYWORDS: Record<CanonicalIndustryTag, string[]> = {
+  machinery: [
+    "机床",
+    "车床",
+    "加工中心",
+    "机械",
+    "设备",
+    "五轴",
+    "夹具",
+    "治具",
+    "lathe",
+    "machining",
+    "milling",
+    "cnc",
+    "数控",
+    "fanuc",
+    "siemens",
+    "star",
+    "brother",
+    "mitsubishi",
+  ],
+  sales: ["销售", "业务", "客户", "大客户", "渠道", "sales", "account", "bd", "market"],
+  metrology: ["测量", "三维扫描", "3d", "cmm", "metrology", "scan"],
+  software: ["c++", "c#", "mfc", "qt", "软件", "开发", "algorithm", "python"],
+};
+
+const LEGACY_INDUSTRY_TAG_MAP: Record<string, string | null> = {
+  cnc: "machinery",
+  automation: null,
+};
 
 export type StructuredJobDescriptionSeedFields = {
   location?: string;
@@ -46,6 +78,28 @@ function normalizeUniqueStringList(values: string[] | null | undefined): string[
   return normalized;
 }
 
+export function normalizeIndustryTags(values: string[] | null | undefined): string[] {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  const allowed = new Set<string>(CANONICAL_INDUSTRY_TAGS);
+  const selected = new Set<string>();
+
+  values.forEach((value) => {
+    const token = normalizeOptionalString(value)?.toLowerCase();
+    if (!token) {
+      return;
+    }
+    const normalized = token in LEGACY_INDUSTRY_TAG_MAP ? LEGACY_INDUSTRY_TAG_MAP[token] : token;
+    if (normalized && allowed.has(normalized)) {
+      selected.add(normalized);
+    }
+  });
+
+  return Array.from(selected);
+}
+
 function splitLocationTokens(value: string | undefined): string[] {
   if (!value) {
     return [];
@@ -71,7 +125,7 @@ export function generateStructuredJobDescriptionContent(
   const title = fields.title.trim();
   const locationStr = normalizeOptionalString(fields.location);
   const locationsList = splitLocationTokens(locationStr);
-  const industryTags = normalizeUniqueStringList(fields.industryTags);
+  const industryTags = normalizeIndustryTags(fields.industryTags);
   const extraKeywords = normalizeUniqueStringList(fields.customKeywords);
   const minExperience = fields.minExperience ?? DEFAULT_MIN_EXPERIENCE;
   const maxExperience = fields.maxExperience;


### PR DESCRIPTION
## Summary
- simplify the resume/JD industry taxonomy so `machinery`, `sales`, `metrology`, and `software` are the canonical top-level tags
- normalize legacy `cnc` and `automation` tags through shared helpers, Convex JD reads/writes, API scoring, and the JD editor
- update seed data and regression tests so CNC-heavy inputs now resolve through `machinery`

## Test plan
- [x] bun --cwd /root/workspace/packages/shared build
- [x] bun test /root/workspace/apps/api/src/services/skills-knowledge.test.ts
- [x] bun test /root/workspace/apps/api/src/services/resume-index.test.ts
- [x] bun test /root/workspace/apps/api/src/services/rule-scoring.test.ts
- [x] bun test /root/workspace/packages/convex/convex/__tests__/search-text.test.ts
- [x] bun test /root/workspace/packages/convex/convex/__tests__/job-descriptions.test.ts
- [x] make check