### PR TITLE
chore(claude): sync autopilot hook updates

### DIFF
--- a/.claude/commands/autopilot_reset.md
+++ b/.claude/commands/autopilot_reset.md
@@ -77,7 +77,7 @@ if [ -z "$SID" ]; then
   echo "No session ID found. Restart session to enable."
   exit 1
 fi
-rm -f "/tmp/claude-autopilot-turns-${SID}" "/tmp/claude-autopilot-stop-${SID}" "/tmp/claude-autopilot-blocked-${SID}"
+rm -f "/tmp/claude-autopilot-turns-${SID}" "/tmp/claude-autopilot-stop-${SID}" "/tmp/claude-autopilot-blocked-${SID}" "/tmp/claude-autopilot-state-${SID}" "/tmp/claude-autopilot-idle-${SID}"
 echo "Reset current session: ${SID:0:20}..."
 echo "Next cycle will start from turn 1/$MAX_TURNS"
 ```
@@ -90,7 +90,7 @@ shopt -s nullglob 2>/dev/null || true
 for f in /tmp/claude-autopilot-turns-*; do
   [ -f "$f" ] || continue
   SID="${f#/tmp/claude-autopilot-turns-}"
-  rm -f "/tmp/claude-autopilot-turns-${SID}" "/tmp/claude-autopilot-stop-${SID}" "/tmp/claude-autopilot-blocked-${SID}"
+  rm -f "/tmp/claude-autopilot-turns-${SID}" "/tmp/claude-autopilot-stop-${SID}" "/tmp/claude-autopilot-blocked-${SID}" "/tmp/claude-autopilot-state-${SID}" "/tmp/claude-autopilot-idle-${SID}"
   echo "Reset: ${SID:0:20}..."
   COUNT=$((COUNT + 1))
 done

--- a/.claude/hooks/autopilot-keep-running.sh
+++ b/.claude/hooks/autopilot-keep-running.sh
@@ -27,7 +27,18 @@ SESSION_ID="${SESSION_ID:-default}"
 
 # Helper: clean up the blocked flag so downstream hooks know autopilot is done
 cleanup_blocked_flag() {
-  rm -f "/tmp/claude-autopilot-blocked-${SESSION_ID}"
+  local cleanup_session_id="${1:-$SESSION_ID}"
+
+  rm -f "/tmp/claude-autopilot-blocked-${cleanup_session_id}"
+  rm -f "/tmp/claude-autopilot-state-${cleanup_session_id}"
+  rm -f "/tmp/claude-autopilot-idle-${cleanup_session_id}"
+
+  # Record session activity end (if in cmux sandbox with JWT)
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [ -f "$script_dir/session-activity-capture.sh" ]; then
+    "$script_dir/session-activity-capture.sh" end "$cleanup_session_id" 2>/dev/null || true
+  fi
 }
 
 # Clean up any stale completed marker from a previous cycle where codex-review
@@ -53,9 +64,9 @@ if [ -f "$CURRENT_SID_FILE" ]; then
     CURRENT_STOP_FILE="/tmp/claude-autopilot-stop-${CURRENT_SID}"
     if [ -f "$CURRENT_STOP_FILE" ]; then
       rm -f "$CURRENT_STOP_FILE"
-      # Clean up blocked flags for BOTH session IDs to avoid stale flags
+      # Clean up tracked temp files for BOTH session IDs to avoid stale state
       cleanup_blocked_flag
-      rm -f "/tmp/claude-autopilot-blocked-${CURRENT_SID}"
+      cleanup_blocked_flag "$CURRENT_SID"
       echo "Autopilot stop file detected for current-session ${CURRENT_SID}" >&2
       exit 0
     fi
@@ -84,6 +95,44 @@ if [ -f "$TURN_FILE" ]; then
 fi
 TURN_COUNT=$((TURN_COUNT + 1))
 echo "$TURN_COUNT" > "$TURN_FILE"
+
+# Idle detection via git state fingerprinting
+IDLE_THRESHOLD="${CLAUDE_AUTOPILOT_IDLE_THRESHOLD:-3}"
+STATE_FILE="/tmp/claude-autopilot-state-${SESSION_ID}"
+IDLE_COUNT_FILE="/tmp/claude-autopilot-idle-${SESSION_ID}"
+
+# Compute current git state
+CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+HAS_UNCOMMITTED=$(git status --porcelain 2>/dev/null | grep -q . && echo "1" || echo "0")
+if [ "$HAS_UNCOMMITTED" = "1" ]; then
+  DIRTY_HASH=$({ git diff 2>/dev/null; git diff --cached 2>/dev/null; } | shasum -a 256 | cut -c1-8)
+else
+  DIRTY_HASH="clean"
+fi
+CURRENT_STATE="${CURRENT_HEAD}:${DIRTY_HASH}"
+
+# Compare with previous turn
+PREV_STATE=""
+[ -f "$STATE_FILE" ] && PREV_STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "")
+echo "$CURRENT_STATE" > "$STATE_FILE"
+
+# Track consecutive idle turns
+IDLE_COUNT=0
+[ -f "$IDLE_COUNT_FILE" ] && IDLE_COUNT=$(cat "$IDLE_COUNT_FILE" 2>/dev/null || echo "0")
+
+if [ "$CURRENT_STATE" = "$PREV_STATE" ] && [ -n "$PREV_STATE" ]; then
+  IDLE_COUNT=$((IDLE_COUNT + 1))
+  echo "$IDLE_COUNT" > "$IDLE_COUNT_FILE"
+
+  if [ "$IDLE_COUNT" -ge "$IDLE_THRESHOLD" ]; then
+    echo "[Autopilot] No activity for $IDLE_COUNT turns, allowing stop" >&2
+    cleanup_blocked_flag
+    rm -f "$TURN_FILE"
+    exit 0
+  fi
+else
+  rm -f "$IDLE_COUNT_FILE"
+fi
 
 # Check turn limit
 if ! is_infinite_mode && [ "$TURN_COUNT" -ge "$MAX_TURNS" ]; then

--- a/.claude/hooks/session-activity-capture.sh
+++ b/.claude/hooks/session-activity-capture.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Session activity capture script
+# Called by session-start hook (on start) and autopilot-keep-running hook (on end)
+# Captures git commits, PRs, and file changes for the session activity dashboard
+
+set -euo pipefail
+
+ACTION="${1:-}"
+SESSION_ID="${2:-}"
+
+# Check required environment
+if [ -z "${CMUX_TASK_RUN_JWT:-}" ]; then
+  # Not running in a cmux sandbox - skip silently
+  exit 0
+fi
+
+if [ -z "$SESSION_ID" ] || [ "$SESSION_ID" = "default" ]; then
+  # No valid session ID - skip
+  exit 0
+fi
+
+# Resolve API base URL (from CONVEX_SITE_URL or fallback)
+API_BASE="${CONVEX_SITE_URL:-https://api.cmux.sh}"
+
+get_current_commit() {
+  git rev-parse HEAD 2>/dev/null || echo "unknown"
+}
+
+# Record session start
+record_start() {
+  local start_commit
+  start_commit=$(get_current_commit)
+
+  # Store start commit for later diff
+  echo "$start_commit" > "/tmp/claude-session-start-commit-${SESSION_ID}"
+
+  curl -s -X POST "${API_BASE}/api/session-activity/start" \
+    -H "Content-Type: application/json" \
+    -H "X-Task-Run-JWT: ${CMUX_TASK_RUN_JWT}" \
+    -d "{\"sessionId\": \"${SESSION_ID}\", \"startCommit\": \"${start_commit}\"}" \
+    > /dev/null 2>&1 || true
+}
+
+# Record session end with activity data
+record_end() {
+  local start_commit end_commit
+
+  # Get start commit from saved file
+  start_commit=""
+  if [ -f "/tmp/claude-session-start-commit-${SESSION_ID}" ]; then
+    start_commit=$(cat "/tmp/claude-session-start-commit-${SESSION_ID}" 2>/dev/null || echo "")
+    rm -f "/tmp/claude-session-start-commit-${SESSION_ID}"
+  fi
+
+  if [ -z "$start_commit" ]; then
+    # No start commit recorded - skip
+    exit 0
+  fi
+
+  end_commit=$(get_current_commit)
+
+  # Collect commits since start
+  local commits_json="[]"
+  if [ "$start_commit" != "unknown" ] && [ "$end_commit" != "unknown" ] && [ "$start_commit" != "$end_commit" ]; then
+    # Get commits between start and end
+    commits_json=$(git log --format='{"sha":"%H","message":"%s","timestamp":"%aI"}' "${start_commit}..${end_commit}" 2>/dev/null | \
+      jq -s 'map(. + {filesChanged: 0, additions: 0, deletions: 0})' 2>/dev/null || echo "[]")
+
+    # Add file stats to each commit
+    local enriched_commits="[]"
+    while IFS= read -r sha; do
+      if [ -n "$sha" ]; then
+        local stats
+        stats=$(git show --stat --format="" "$sha" 2>/dev/null | tail -1 | \
+          sed -n 's/.* \([0-9]*\) file.* \([0-9]*\) insertion.* \([0-9]*\) deletion.*/{"f":\1,"a":\2,"d":\3}/p' 2>/dev/null || echo '{"f":0,"a":0,"d":0}')
+        if [ -z "$stats" ]; then
+          stats='{"f":0,"a":0,"d":0}'
+        fi
+        enriched_commits=$(echo "$commits_json" | jq --arg sha "$sha" --argjson stats "$stats" \
+          'map(if .sha == $sha then . + {filesChanged: $stats.f, additions: $stats.a, deletions: $stats.d} else . end)' 2>/dev/null || echo "$commits_json")
+        commits_json="$enriched_commits"
+      fi
+    done < <(git log --format="%H" "${start_commit}..${end_commit}" 2>/dev/null)
+  fi
+
+  # Collect file changes
+  local files_json="[]"
+  if [ "$start_commit" != "unknown" ] && [ "$end_commit" != "unknown" ] && [ "$start_commit" != "$end_commit" ]; then
+    files_json=$(git diff --numstat --diff-filter=AMDRT "${start_commit}..${end_commit}" 2>/dev/null | \
+      while IFS=$'\t' read -r add del path; do
+        [ -z "$path" ] && continue
+        # Determine status from first commit that touched this file
+        local status="modified"
+        if git diff --name-status "${start_commit}..${end_commit}" 2>/dev/null | grep -q "^A.*${path}$"; then
+          status="added"
+        elif git diff --name-status "${start_commit}..${end_commit}" 2>/dev/null | grep -q "^D.*${path}$"; then
+          status="deleted"
+        elif git diff --name-status "${start_commit}..${end_commit}" 2>/dev/null | grep -q "^R.*${path}$"; then
+          status="renamed"
+        fi
+        # Handle binary files (- for add/del)
+        [ "$add" = "-" ] && add=0
+        [ "$del" = "-" ] && del=0
+        printf '{"path":"%s","additions":%d,"deletions":%d,"status":"%s"}\n' "$path" "$add" "$del" "$status"
+      done | jq -s '.' 2>/dev/null || echo "[]")
+  fi
+
+  # For now, skip PRs merged detection (would need gh CLI and repo context)
+  local prs_json="[]"
+
+  # Build and send the payload
+  local payload
+  payload=$(jq -n \
+    --arg sessionId "$SESSION_ID" \
+    --arg endCommit "$end_commit" \
+    --argjson commits "$commits_json" \
+    --argjson prsMerged "$prs_json" \
+    --argjson filesChanged "$files_json" \
+    '{sessionId: $sessionId, endCommit: $endCommit, commits: $commits, prsMerged: $prsMerged, filesChanged: $filesChanged}')
+
+  curl -s -X POST "${API_BASE}/api/session-activity/end" \
+    -H "Content-Type: application/json" \
+    -H "X-Task-Run-JWT: ${CMUX_TASK_RUN_JWT}" \
+    -d "$payload" \
+    > /dev/null 2>&1 || true
+}
+
+case "$ACTION" in
+  start)
+    record_start
+    ;;
+  end)
+    record_end
+    ;;
+  *)
+    echo "Usage: $0 <start|end> <session_id>" >&2
+    exit 1
+    ;;
+esac

--- a/.claude/hooks/test-session-activity-capture.sh
+++ b/.claude/hooks/test-session-activity-capture.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Unit tests for session-activity-capture.sh
+# Usage: ./.claude/hooks/test-session-activity-capture.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CAPTURE_SCRIPT="$SCRIPT_DIR/session-activity-capture.sh"
+
+PASSED=0
+FAILED=0
+
+assert() {
+  local name="$1"
+  shift
+  if "$@"; then
+    echo "[PASS] $name"
+    PASSED=$((PASSED + 1))
+  else
+    echo "[FAIL] $name"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_eq() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "[PASS] $name"
+    PASSED=$((PASSED + 1))
+  else
+    echo "[FAIL] $name: expected '$expected', got '$actual'"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# Test 1: Script exists and is executable
+echo ""
+echo "=== Test 1: Script exists and is executable ==="
+assert "script exists" test -f "$CAPTURE_SCRIPT"
+assert "script is executable" test -x "$CAPTURE_SCRIPT"
+
+# Test 2: Script exits cleanly without JWT (no-op mode)
+echo ""
+echo "=== Test 2: Script exits cleanly without JWT ==="
+unset CMUX_TASK_RUN_JWT 2>/dev/null || true
+EXIT_CODE=0
+"$CAPTURE_SCRIPT" start "test-session-1" 2>/dev/null || EXIT_CODE=$?
+assert_eq "start without JWT exits 0" "0" "$EXIT_CODE"
+
+EXIT_CODE=0
+"$CAPTURE_SCRIPT" end "test-session-1" 2>/dev/null || EXIT_CODE=$?
+assert_eq "end without JWT exits 0" "0" "$EXIT_CODE"
+
+# Test 3: Script validates arguments (when JWT is set)
+echo ""
+echo "=== Test 3: Script validates arguments ==="
+export CMUX_TASK_RUN_JWT="fake-jwt-for-test"
+EXIT_CODE=0
+"$CAPTURE_SCRIPT" invalid "test-session-2" 2>/dev/null || EXIT_CODE=$?
+assert_eq "invalid action exits 1" "1" "$EXIT_CODE"
+unset CMUX_TASK_RUN_JWT
+
+# Test 4: Script handles empty session ID gracefully
+echo ""
+echo "=== Test 4: Handles empty/default session ID ==="
+export CMUX_TASK_RUN_JWT="fake-jwt-for-test"
+EXIT_CODE=0
+"$CAPTURE_SCRIPT" start "" 2>/dev/null || EXIT_CODE=$?
+assert_eq "empty session exits 0" "0" "$EXIT_CODE"
+
+EXIT_CODE=0
+"$CAPTURE_SCRIPT" start "default" 2>/dev/null || EXIT_CODE=$?
+assert_eq "default session exits 0" "0" "$EXIT_CODE"
+unset CMUX_TASK_RUN_JWT
+
+# Test 5: Bash syntax is valid
+echo ""
+echo "=== Test 5: Bash syntax validation ==="
+EXIT_CODE=0
+bash -n "$CAPTURE_SCRIPT" 2>/dev/null || EXIT_CODE=$?
+assert_eq "bash syntax valid" "0" "$EXIT_CODE"
+
+# Summary
+echo ""
+echo "=== Summary ==="
+echo "Passed: $PASSED"
+echo "Failed: $FAILED"
+
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- sync repo-local Claude autopilot hook files with the latest cmux hook-side session activity updates
- add the session activity capture hook and its shell test script
- keep autopilot reset in sync with the new temp files used by idle detection

## Test plan
- [x] run `make check`
- [x] run simplify review and apply the resulting cleanup fixes