### PR TITLE
feat(collect): add collect page-limit override input

### DIFF
--- a/apps/web/src/components/CollectResumesButton.tsx
+++ b/apps/web/src/components/CollectResumesButton.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, type ChangeEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Download, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import {
   Tooltip,
   TooltipContent,
@@ -46,13 +47,18 @@ function normalizeAgeBound(value: number | undefined): number | undefined {
 export function CollectResumesButton({ location, keywords, collectLimit, minAge, maxAge }: CollectResumesButtonProps) {
   const { t } = useTranslation()
   const [extensionVersion, setExtensionVersion] = useState<string | null>(null)
+  const [maxPagesInput, setMaxPagesInput] = useState('')
 
-  const normalizedLocation = location.trim()
+  const normalizedLocation = useMemo(() => location.trim(), [location])
   const normalizedKeywords = useMemo(
     () => keywords.map((keyword) => keyword.trim()).filter((keyword) => keyword.length > 0),
     [keywords]
   )
   const normalizedCollectLimit = useMemo(() => normalizeCollectLimit(collectLimit), [collectLimit])
+  const normalizedCollectMaxPages = useMemo(
+    () => normalizeCollectLimit(maxPagesInput.trim().length > 0 ? Number(maxPagesInput) : undefined),
+    [maxPagesInput]
+  )
   const normalizedMinAge = useMemo(() => normalizeAgeBound(minAge), [minAge])
   const normalizedMaxAge = useMemo(() => normalizeAgeBound(maxAge), [maxAge])
 
@@ -76,6 +82,10 @@ export function CollectResumesButton({ location, keywords, collectLimit, minAge,
       query.set('tr_limit', String(normalizedCollectLimit))
     }
 
+    if (normalizedCollectMaxPages > 0) {
+      query.set('tr_max_pages', String(normalizedCollectMaxPages))
+    }
+
     if (typeof normalizedMinAge === 'number') {
       query.set('tr_min_age', String(normalizedMinAge))
     }
@@ -85,7 +95,15 @@ export function CollectResumesButton({ location, keywords, collectLimit, minAge,
     }
 
     return `${JOB_BOARD_BASE_URL}?${query.toString()}`
-  }, [disabled, normalizedCollectLimit, normalizedKeywords, normalizedLocation, normalizedMinAge, normalizedMaxAge])
+  }, [
+    disabled,
+    normalizedCollectLimit,
+    normalizedCollectMaxPages,
+    normalizedKeywords,
+    normalizedLocation,
+    normalizedMinAge,
+    normalizedMaxAge,
+  ])
 
   useEffect(() => {
     let cancelled = false
@@ -115,6 +133,8 @@ export function CollectResumesButton({ location, keywords, collectLimit, minAge,
   const tooltipText = disabled
     ? t('quickStart.collectDisabledHint', 'Enter keywords first')
     : t('quickStart.collectTooltip', 'Opens job board with auto-sync. Requires extension + login.')
+  const maxPagesLabel = t('quickStart.collectMaxPagesLabel', 'Collect page limit')
+  const maxPagesPlaceholder = t('quickStart.collectMaxPagesPlaceholder', 'Pages')
 
   const handleClick = () => {
     if (!collectUrl) {
@@ -124,29 +144,51 @@ export function CollectResumesButton({ location, keywords, collectLimit, minAge,
     window.open(collectUrl, '_blank', 'noopener,noreferrer')
   }
 
+  const handleMaxPagesChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setMaxPagesInput(event.target.value)
+  }
+
   return (
     <div className="flex flex-col items-start gap-1">
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex">
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-2"
-                disabled={disabled}
-                onClick={handleClick}
-              >
-                <ExternalLink className="h-4 w-4" />
-                {t('quickStart.collectResumes', 'Collect')}
-              </Button>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>
-            {tooltipText}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <div className="flex items-center gap-2">
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  disabled={disabled}
+                  onClick={handleClick}
+                >
+                  <ExternalLink className="h-4 w-4" />
+                  {t('quickStart.collectResumes', 'Collect')}
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {tooltipText}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <label htmlFor="collect-max-pages" className="sr-only">
+          {maxPagesLabel}
+        </label>
+        <Input
+          id="collect-max-pages"
+          name="collect-max-pages"
+          type="number"
+          min={1}
+          step={1}
+          inputMode="numeric"
+          value={maxPagesInput}
+          onChange={handleMaxPagesChange}
+          placeholder={maxPagesPlaceholder}
+          aria-label={maxPagesLabel}
+          className="h-9 w-24"
+        />
+      </div>
       {extensionVersion ? (
         <a
           href={EXTENSION_ZIP_URL}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -325,6 +325,8 @@
     "collectResumes": "Collect",
     "collectTooltip": "Opens job board with auto-sync. Requires extension + login.",
     "collectDisabledHint": "Enter location and keywords first",
+    "collectMaxPagesLabel": "Collect page limit",
+    "collectMaxPagesPlaceholder": "Pages",
     "downloadExtension": "Download Extension v{{version}}",
     "matchDetails": "Current Match Details",
     "labelJd": "JD",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -325,6 +325,8 @@
     "collectResumes": "采集",
     "collectTooltip": "打开招聘网站自动同步。需安装扩展并登录。",
     "collectDisabledHint": "请先输入位置和关键词",
+    "collectMaxPagesLabel": "采集页数上限",
+    "collectMaxPagesPlaceholder": "页数",
     "downloadExtension": "下载扩展 v{{version}}",
     "matchDetails": "当前匹配详情",
     "labelJd": "职位",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -325,6 +325,8 @@
     "collectResumes": "採集",
     "collectTooltip": "開啟招聘網站自動同步。需安裝擴展並登入。",
     "collectDisabledHint": "請先輸入位置和關鍵詞",
+    "collectMaxPagesLabel": "採集頁數上限",
+    "collectMaxPagesPlaceholder": "頁數",
     "downloadExtension": "下載擴展 v{{version}}",
     "matchDetails": "當前匹配詳情",
     "labelJd": "職位",

--- a/scripts/e2e-smoke.ts
+++ b/scripts/e2e-smoke.ts
@@ -20,6 +20,7 @@ async function runCollectUrlKeywordModeTest(page: Page) {
         }) as typeof window.open;
     });
 
+    await page.getByLabel(/采集页数上限|採集頁數上限|Collect page limit/i).fill('3');
     await page.getByRole('button', { name: /采集|Collect/i }).click();
 
     const openedUrls = await page.evaluate(() => {
@@ -30,9 +31,10 @@ async function runCollectUrlKeywordModeTest(page: Page) {
     expect(openedUrls.length).toBeGreaterThan(0);
     const openedUrl = new URL(openedUrls[0]);
     expect(`${openedUrl.origin}${openedUrl.pathname}`).toBe('https://hr.job5156.com/search');
-    expect(openedUrl.searchParams.get('keyword')).toBe('CNC车床销售STAR');
+    expect(openedUrl.searchParams.get('keyword')).toBe('CNC 车床 销售 STAR');
     expect(openedUrl.searchParams.get('location')).toBe('东莞');
     expect(openedUrl.searchParams.get('tr_auto_sync')).toBe('true');
+    expect(openedUrl.searchParams.get('tr_max_pages')).toBe('3');
 
     console.log('✅ Collect URL keyword concat test passed.');
 }


### PR DESCRIPTION
## Summary
- add an inline page-limit input next to the Collect button
- append `tr_max_pages` to the Job5156 Collect URL only when users enter a positive integer
- extend locale copy and the collect smoke test to cover the override

## Test plan
- [x] make check
- [x] make test-collect-url-smoke
- [x] Verify the web Collect flow opens a URL containing `tr_max_pages=3`
- [x] Verify the Job5156 extension reads `tr_max_pages=2` and stops after 2 pages