### PR TITLE
feat(job5156): extract resume detail pages and enrich synced resume display

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -65,6 +65,8 @@ const PAGE_BRIDGE_REQUEST_EVENT = 'trResumeBridgeRequest';
 const PAGE_BRIDGE_RESPONSE_EVENT = 'trResumeBridgeResponse';
 const PAGE_BRIDGE_REQUEST_ATTR = 'data-tr-resume-bridge-request';
 const PAGE_BRIDGE_RESPONSE_ATTR = 'data-tr-resume-bridge-response';
+const JOB5156_DETAIL_FETCH_TIMEOUT_MS = 5000;
+const JOB5156_DETAIL_FETCH_CONCURRENCY = 5;
 
 const apiSnapshot = {
   searchRows: null,
@@ -365,8 +367,8 @@ function getJob5156DetailRoot() {
   return document.body;
 }
 
-function getJob5156DetailHeaderText() {
-  const root = getJob5156DetailRoot();
+function getJob5156DetailHeaderText(root = getJob5156DetailRoot()) {
+  if (!(root instanceof Element)) return '';
   const header = root.querySelector('h1, .name, .resume-name, .basic-name, [class*="name"]');
   return normalizeResumeText(
     header?.textContent
@@ -381,7 +383,15 @@ function isJob5156DetailReady() {
   if (!resumeId) return false;
   const root = getJob5156DetailRoot();
   const rootText = normalizeResumeText(root?.textContent || '');
-  return root instanceof Element && rootText.length > 80 && getJob5156DetailHeaderText().length > 0;
+  return root instanceof Element && rootText.length > 80 && getJob5156DetailHeaderText(root).length > 0;
+}
+
+function isJob5156DetailRootReady(root, pathname) {
+  if (!(root instanceof Element)) return false;
+  const resumeId = extractJob5156ResumeId(pathname || '');
+  if (!resumeId) return false;
+  const rootText = normalizeResumeText(root.textContent || '');
+  return rootText.length > 80 && getJob5156DetailHeaderText(root).length > 0;
 }
 
 function isExtractionReady() {
@@ -481,6 +491,16 @@ function buildSeekProfileEducationItem(item) {
 
 function normalizeResumeText(value) {
   return typeof value === 'string' ? value.replace(/[\u3000\s]+/g, ' ').trim() : '';
+}
+
+function normalizeResumeMultilineText(value) {
+  if (typeof value !== 'string') return '';
+  return value
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((line) => line.replace(/[\u3000\t ]+/g, ' ').trim())
+    .filter(Boolean)
+    .join('\n');
 }
 
 function buildWorkHistoryRawParts(parts) {
@@ -760,10 +780,12 @@ function collectSectionItemsByHeading(root, headingPattern) {
   return [];
 }
 
-function extractJob5156DetailResume() {
-  if (!isJob5156DetailPage() || !isJob5156DetailReady()) return [];
+function buildJob5156DetailResumeFromRoot(root, options = {}) {
+  if (!(root instanceof Element)) return [];
 
-  const root = getJob5156DetailRoot();
+  const { pathname, profileUrl: profileUrlInput, extractedAt } = normalizeJob5156ExtractOptions(options);
+  if (!isJob5156DetailRootReady(root, pathname)) return [];
+
   const readText = (selectors, scopedRoot = root) => {
     for (const selector of selectors) {
       const value = normalizeResumeText(scopedRoot.querySelector(selector)?.textContent);
@@ -771,8 +793,8 @@ function extractJob5156DetailResume() {
     }
     return '';
   };
-  const resumeId = extractJob5156ResumeId(window.location.pathname);
-  const profileUrl = normalizeJob5156ProfileUrlForExport(window.location.href);
+  const resumeId = extractJob5156ResumeId(pathname);
+  const profileUrl = normalizeJob5156ProfileUrlForExport(profileUrlInput);
   const basicTextNodes = Array.from(root.querySelectorAll('.basic-line__text, .basic-line span, .resume-basic-info span, [class*="basic"] span, .info-item, .label-value, .tag'))
     .map((node) => node.textContent || '');
   const filteredBasicTextNodes = basicTextNodes.filter((item) => !/求职状态|沟通中|更新时间/.test(item));
@@ -848,9 +870,270 @@ function extractJob5156DetailResume() {
     selfIntro,
     workHistory,
     profileEducation: profileEducation.length > 0 ? profileEducation : undefined,
-    extractedAt: new Date().toISOString(),
+    extractedAt,
     source: JOB5156_HOST,
   }];
+}
+
+function extractJob5156DetailResume() {
+  if (!isJob5156DetailPage() || !isJob5156DetailReady()) return [];
+  return buildJob5156DetailResumeFromRoot(getJob5156DetailRoot(), {
+    pathname: window.location.pathname,
+    profileUrl: window.location.href,
+  });
+}
+
+function buildJob5156DetailWorkHistoryItemFromApi(item) {
+  if (!item || typeof item !== 'object') return null;
+
+  const begin = normalizeResumeText(item.begin);
+  const end = normalizeResumeText(item.end);
+  const dateRange = [begin, end].filter(Boolean).join('~');
+  const durationLabel = normalizeResumeText(item.timeDiff || item.timeDiff2);
+  const companyName = normalizeResumeText(item.comName || item.comNameStr);
+  const jobTitle = normalizeResumeText(item.jobNameStr || item.jobName);
+  const department = normalizeResumeText(item.section);
+  const companyMeta = buildWorkHistoryRawParts([
+    normalizeResumeText(item.comCallingStr),
+    normalizeResumeText(item.comScaleStr),
+    normalizeResumeText(item.comTypeStr),
+  ]);
+  const description = normalizeResumeMultilineText(item.description);
+  const reasonText = normalizeResumeText(item.leftreason);
+  const startDate = begin || undefined;
+  const endDate = end || undefined;
+  const descriptionLines = [
+    companyMeta ? `公司信息：${companyMeta}` : '',
+    department ? `部门：${department}` : '',
+    description,
+    reasonText ? `离职原因：${reasonText}` : '',
+  ].filter(Boolean);
+  const raw = buildWorkHistoryRawParts([
+    dateRange,
+    durationLabel ? `(${durationLabel})` : '',
+    companyName,
+    jobTitle,
+    ...descriptionLines,
+  ]);
+
+  if (!raw && !description && !companyName && !jobTitle) return null;
+
+  return {
+    raw: raw || description || buildWorkHistoryRawParts([companyName, jobTitle, dateRange]),
+    companyName: companyName || undefined,
+    jobTitle: jobTitle || undefined,
+    description: descriptionLines.join('\n') || undefined,
+    startDate,
+    endDate,
+  };
+}
+
+function buildJob5156EducationItemFromApi(item) {
+  if (!item || typeof item !== 'object') return null;
+
+  const institution = normalizeResumeText(item.schoolName);
+  const degree = normalizeResumeText(item.degreeStr);
+  const speciality = normalizeResumeText(item.speciality);
+  const qualification = buildWorkHistoryRawParts([degree, speciality]);
+  const endDate = normalizeResumeText([item.begin, item.end].filter(Boolean).join('~') || item.end);
+  const description = buildWorkHistoryRawParts([degree, speciality, endDate, institution]);
+
+  if (!institution && !qualification && !endDate) return null;
+
+  return {
+    institution: institution || undefined,
+    qualification: qualification || undefined,
+    endDate: endDate || undefined,
+    description: description || undefined,
+  };
+}
+
+function normalizeJob5156ExtractOptions(options = {}) {
+  return {
+    pathname: typeof options.pathname === 'string' ? options.pathname : window.location.pathname,
+    profileUrl: typeof options.profileUrl === 'string' ? options.profileUrl : window.location.href,
+    extractedAt: typeof options.extractedAt === 'string' ? options.extractedAt : new Date().toISOString(),
+  };
+}
+
+function buildJob5156DetailResumeFromApiPayload(payload, options = {}) {
+  if (!payload || typeof payload !== 'object') return [];
+
+  const { pathname, profileUrl, extractedAt } = normalizeJob5156ExtractOptions(options);
+  const resumeId = extractJob5156ResumeId(pathname) || normalizeResumeText(payload.resumeId);
+  const normalizedProfileUrl = normalizeJob5156ProfileUrlForExport(profileUrl);
+  const resumeView = payload.resumeViewVo && typeof payload.resumeViewVo === 'object' ? payload.resumeViewVo : null;
+  const cnVo = resumeView?.cnVo && typeof resumeView.cnVo === 'object' ? resumeView.cnVo : null;
+  const basicInfo = cnVo?.basicInfoVo && typeof cnVo.basicInfoVo === 'object' ? cnVo.basicInfoVo : null;
+  const intentInfo = cnVo?.intentInfoVo && typeof cnVo.intentInfoVo === 'object' ? cnVo.intentInfoVo : null;
+
+  if (!resumeId || !cnVo || !basicInfo) return [];
+
+  const workHistory = Array.isArray(cnVo.workInfoVoList)
+    ? cnVo.workInfoVoList.map((item) => buildJob5156DetailWorkHistoryItemFromApi(item)).filter(Boolean)
+    : [];
+  const profileEducation = Array.isArray(cnVo.educationInfoVoList)
+    ? cnVo.educationInfoVoList.map((item) => buildJob5156EducationItemFromApi(item)).filter(Boolean)
+    : [];
+  const locationParts = [normalizeResumeText(cnVo.liveProvince), normalizeResumeText(cnVo.liveCity), normalizeResumeText(cnVo.liveTown)].filter(Boolean);
+  const intentionParts = Array.isArray(payload.intentInfoVo2List)
+    ? payload.intentInfoVo2List.map((item) => normalizeResumeText(item.jobNameStr || item.jobCodeStr)).filter(Boolean)
+    : [];
+
+  return [{
+    resumeId,
+    perUserId: normalizeResumeText(payload.perUserId || basicInfo.id),
+    name: normalizeResumeText(payload.userName || basicInfo.userName),
+    profileUrl: normalizedProfileUrl,
+    activityStatus: normalizeResumeText(basicInfo.jobStateStr),
+    age: normalizeResumeText(basicInfo.age ? `${basicInfo.age}岁` : ''),
+    experience: normalizeResumeText(basicInfo.firstWorkingTimeStr || basicInfo.jobyearTypeStr),
+    education: normalizeResumeText(basicInfo.degreeStr || cnVo.maxDegree?.degreeStr),
+    location: normalizeResumeText(locationParts.join('') || basicInfo.locationStr),
+    jobIntention: normalizeResumeText(intentionParts.join(',') || intentInfo?.jobLocationStr && `${intentInfo.jobLocationStr}${intentInfo.jobCodeStr ? `${intentInfo.jobCodeStr}` : ''}` || intentInfo?.jobCodeStr),
+    expectedSalary: normalizeResumeText(payload.salaryStr || intentInfo?.salaryStr),
+    selfIntro: normalizeResumeText(intentInfo?.professionSkill),
+    workHistory,
+    profileEducation: profileEducation.length > 0 ? profileEducation : undefined,
+    extractedAt,
+    source: JOB5156_HOST,
+  }];
+}
+
+async function fetchJob5156ResumeDetail(profileUrl, pathname) {
+  const resumePathname = typeof pathname === 'string' && pathname
+    ? pathname
+    : new URL(profileUrl).pathname;
+  const resumeId = extractJob5156ResumeId(resumePathname);
+  if (!resumeId) return null;
+
+  const url = new URL(`/api/com/resume/${encodeURIComponent(resumeId)}`, window.location.origin);
+  url.searchParams.set('t', String(Date.now()));
+  url.searchParams.set('version', '1');
+  url.searchParams.set('dataVersions', '');
+  url.searchParams.set('modType', 'search');
+  url.searchParams.set('keyWord', '');
+  url.searchParams.set('searchNo', '0');
+  url.searchParams.set('searchNumber', '0');
+  url.searchParams.set('searchPageNumber', '0');
+  url.searchParams.set('index_number', '0');
+  url.searchParams.set('isTopResume', 'false');
+  url.searchParams.set('isWindow', 'true');
+  url.searchParams.set('resumeId', resumeId);
+  url.searchParams.set('indexNumber', '0');
+
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), JOB5156_DETAIL_FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url.toString(), {
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        appType: 'pc',
+        pcVersion: '1.0.1',
+        posTypeNewFlag: 'true',
+        version: '2.0',
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) return null;
+    const payload = await response.json();
+    if (!payload || typeof payload !== 'object' || payload.code !== 200 || !payload.data) return null;
+    return payload.data;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') return null;
+    throw error;
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}
+
+async function enrichSingleJob5156SearchResumeWithDetail(resume, extractedAt) {
+  if (!resume || typeof resume !== 'object') return null;
+
+  const profileUrl = normalizeJob5156ProfileUrlForExport(resume.profileUrl || '');
+  const fallbackResume = {
+    ...resume,
+    profileUrl,
+    extractedAt: resume.extractedAt || extractedAt,
+  };
+
+  if (!profileUrl) return fallbackResume;
+
+  try {
+    let detailResume = null;
+    const pathname = new URL(profileUrl).pathname;
+    const detailPayload = await fetchJob5156ResumeDetail(profileUrl, pathname);
+    if (detailPayload) {
+      detailResume = buildJob5156DetailResumeFromApiPayload(detailPayload, {
+        pathname,
+        profileUrl,
+        extractedAt: fallbackResume.extractedAt,
+      })[0] || null;
+    }
+
+    if (!detailResume) {
+      const response = await fetch(profileUrl, {
+        credentials: 'include',
+        headers: { Accept: 'text/html,application/xhtml+xml' },
+      });
+      if (response.ok) {
+        const html = await response.text();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        detailResume = buildJob5156DetailResumeFromRoot(doc.body, {
+          pathname,
+          profileUrl,
+          extractedAt: fallbackResume.extractedAt,
+        })[0] || null;
+      }
+    }
+
+    if (!detailResume) return fallbackResume;
+
+    return {
+      ...fallbackResume,
+      ...detailResume,
+      workHistory: (detailResume.workHistory || fallbackResume.workHistory || []).slice(0, 3),
+      resumeId: detailResume.resumeId || fallbackResume.resumeId,
+      perUserId: detailResume.perUserId || fallbackResume.perUserId,
+      extractedAt: fallbackResume.extractedAt,
+    };
+  } catch (error) {
+    console.warn('🎯 [Auto Sync] Failed to enrich Job5156 detail resume:', profileUrl, error);
+    return fallbackResume;
+  }
+}
+
+function applyJob5156CollectionGuards(resume) {
+  if (!resume || typeof resume !== 'object') return null;
+
+  return {
+    ...resume,
+    experience: '',
+    jobIntention: '',
+    selfIntro: '',
+  };
+}
+
+async function enrichJob5156SearchResumesWithDetail(resumes) {
+  if (!Array.isArray(resumes) || resumes.length === 0) return [];
+
+  const extractedAt = new Date().toISOString();
+  const enriched = [];
+
+  for (let start = 0; start < resumes.length; start += JOB5156_DETAIL_FETCH_CONCURRENCY) {
+    const batch = resumes.slice(start, start + JOB5156_DETAIL_FETCH_CONCURRENCY);
+    const batchResults = await Promise.all(
+      batch.map((resume) => enrichSingleJob5156SearchResumeWithDetail(resume, extractedAt))
+    );
+
+    enriched.push(...batchResults.filter(Boolean).map((resume) => applyJob5156CollectionGuards(resume)));
+  }
+
+  return enriched;
 }
 
 function extractSeekProfileResume() {
@@ -2837,7 +3120,10 @@ async function runAutoExportIfEnabled() {
 }
 
 async function syncCurrentPageToServer(resumesOverride) {
-  const resumes = Array.isArray(resumesOverride) ? resumesOverride : extractResumes();
+  let resumes = Array.isArray(resumesOverride) ? resumesOverride : extractResumes();
+  if (getCurrentSourceKey() === SOURCE_KEYS.JOB5156 && !isJob5156DetailPage() && resumes.length > 0) {
+    resumes = await enrichJob5156SearchResumesWithDetail(resumes);
+  }
   const metadata = buildSubmitMetadata();
   return chrome.runtime.sendMessage({ action: 'syncToServer', metadata, resumes });
 }
@@ -2945,6 +3231,9 @@ async function runAutoSyncIfEnabled() {
       let resumes = extractResumes();
       if (limit > 0 && resumes.length > remainingCapacity) {
         resumes = resumes.slice(0, remainingCapacity);
+      }
+      if (getCurrentSourceKey() === SOURCE_KEYS.JOB5156 && !isJob5156DetailPage() && resumes.length > 0) {
+        resumes = await enrichJob5156SearchResumesWithDetail(resumes);
       }
       if (resumes.length <= 0) {
         const progressHint = limit > 0

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -301,6 +301,11 @@ function getCurrentSourceKey() {
   return SOURCE_KEYS.UNKNOWN;
 }
 
+function isJob5156DetailPage() {
+  return getCurrentSourceKey() === SOURCE_KEYS.JOB5156
+    && /^\/resume\/view\//i.test(window.location.pathname);
+}
+
 function getApiSnapshotCount() {
   if (Array.isArray(apiSnapshot.searchRows)) {
     return apiSnapshot.searchRows.length;
@@ -334,10 +339,59 @@ function isSeekSnapshotReady() {
   return getSeekSnapshotCount() > 0;
 }
 
+function getJob5156DetailRoot() {
+  const candidates = [
+    '.resume-detail',
+    '.resume-detail-content',
+    '.resume-detail-main',
+    '.resume-view-content',
+    '.resume-content',
+    '.detail-content',
+    '.main-content',
+    '[class*="resume-detail"]',
+    '[class*="resumeDetail"]',
+    '[class*="resume-view"]',
+    '[class*="resumeView"]',
+    'main'
+  ];
+
+  for (const selector of candidates) {
+    const el = document.querySelector(selector);
+    if (el instanceof Element && normalizeResumeText(el.textContent || '').length > 40) {
+      return el;
+    }
+  }
+
+  return document.body;
+}
+
+function getJob5156DetailHeaderText() {
+  const root = getJob5156DetailRoot();
+  const header = root.querySelector('h1, .name, .resume-name, .basic-name, [class*="name"]');
+  return normalizeResumeText(
+    header?.textContent
+    || root.querySelector('.basic-line, .resume-basic-info, [class*="basic"], .resume-view-item__block.resume-basic')?.textContent
+    || ''
+  );
+}
+
+function isJob5156DetailReady() {
+  if (!isJob5156DetailPage()) return false;
+  const resumeId = extractJob5156ResumeId(window.location.pathname);
+  if (!resumeId) return false;
+  const root = getJob5156DetailRoot();
+  const rootText = normalizeResumeText(root?.textContent || '');
+  return root instanceof Element && rootText.length > 80 && getJob5156DetailHeaderText().length > 0;
+}
+
 function isExtractionReady() {
-  return getCurrentSourceKey() === SOURCE_KEYS.SEEK
-    ? isSeekSnapshotReady()
-    : document.querySelector(SELECTORS.listContainer) !== null;
+  if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
+    return isSeekSnapshotReady();
+  }
+  if (isJob5156DetailPage()) {
+    return isJob5156DetailReady();
+  }
+  return document.querySelector(SELECTORS.listContainer) !== null;
 }
 
 function getSeekCandidateIdentity(candidate) {
@@ -433,6 +487,33 @@ function buildWorkHistoryRawParts(parts) {
   return parts.filter(Boolean).join(' · ');
 }
 
+function parseJob5156BasicInfoItems(items, locationOverride = '') {
+  const basicInfo = Array.isArray(items)
+    ? items.map((item) => normalizeResumeText(item)).filter(Boolean)
+    : [];
+
+  let age = '';
+  let experience = '';
+  let education = '';
+  let location = '';
+  if (basicInfo.length >= 4) {
+    [age, experience, education, location] = basicInfo;
+  } else {
+    basicInfo.forEach((item) => {
+      if (!age && item.includes('岁')) age = item;
+      else if (!experience && item.includes('年') && !item.includes('元')) experience = item;
+      else if (!education && /(中专|高中|大专|本科|硕|博|研究生|MBA|EMBA)/.test(item)) education = item;
+      else if (!location && !item.includes('元')) location = item;
+    });
+  }
+
+  if (locationOverride) {
+    location = normalizeResumeText(locationOverride);
+  }
+
+  return { age, experience, education, location };
+}
+
 function buildJob5156WorkHistoryItem(item) {
   if (!(item instanceof Element)) return null;
 
@@ -459,6 +540,27 @@ function buildJob5156WorkHistoryItem(item) {
 function buildJob5156EducationItem(item) {
   if (!(item instanceof Element)) return null;
 
+  const liveEducationText = normalizeResumeText(item.textContent);
+  if (item.classList.contains('resume-education__info') || item.closest('.resume-education')) {
+    const institution = normalizeResumeText(item.querySelector('.flex.w-full > div:last-child')?.textContent);
+    const rowText = Array.from(item.querySelectorAll('.flex.w-full > div'))
+      .map((node) => normalizeResumeText(node.textContent))
+      .filter(Boolean);
+    const endDate = rowText.find((value) => /^\d{4}(~|-)/.test(value)) || '';
+    const qualification = rowText
+      .filter((value) => value !== institution && value !== endDate)
+      .join(' · ');
+
+    if (!institution && !qualification && !endDate && !liveEducationText) return null;
+
+    return {
+      institution: institution || undefined,
+      qualification: qualification || undefined,
+      endDate: endDate || undefined,
+      description: liveEducationText || undefined,
+    };
+  }
+
   const institution = normalizeResumeText(item.querySelector('.school-name')?.textContent);
   const qualification = normalizeResumeText(item.querySelector('.school-major')?.textContent);
   const degree = normalizeResumeText(item.querySelector('.school-degree')?.textContent);
@@ -471,6 +573,284 @@ function buildJob5156EducationItem(item) {
     qualification: [qualification, degree].filter(Boolean).join(' · ') || undefined,
     endDate: endDate || undefined,
   };
+}
+
+function buildJob5156DetailWorkHistoryItem(item) {
+  if (!(item instanceof Element)) return null;
+
+  if (item.classList.contains('resume-work__info') || item.closest('.resume-work')) {
+    const row1 = item.querySelector('.resume-work__row-1');
+    const row2 = item.querySelector('.resume-work__row-2');
+    const row3 = item.querySelector('.resume-work__row-3');
+    const row4 = item.querySelector('.resume-work__row-4');
+    const companyName = normalizeResumeText(row1?.querySelector('.flex.flex-1 > span.pointer')?.textContent);
+    const jobTitle = normalizeResumeText(row1?.querySelector('.flex.flex-1 > span:not(.pointer):not(.cut)')?.textContent);
+    const periodText = normalizeResumeText(row1?.querySelector('.time-diff')?.textContent);
+    const periodMatch = periodText.match(/^(.+?)(?:（(.+)）)?$/u);
+    const dateRange = normalizeResumeText(periodMatch?.[1] || periodText);
+    const durationLabel = normalizeResumeText(periodMatch?.[2] || '');
+    const startDate = dateRange.includes('~') ? normalizeResumeText(dateRange.split('~')[0]) : dateRange;
+    const endDate = dateRange.includes('~') ? normalizeResumeText(dateRange.split('~').slice(1).join('~')) : '';
+    const companyMeta = normalizeResumeText(row2?.textContent);
+    const description = normalizeResumeText(row3?.querySelector('pre')?.textContent || row3?.textContent);
+    const reasonText = normalizeResumeText(row4?.textContent).replace(/^离职原因[:：]?\s*/u, '');
+    const raw = buildWorkHistoryRawParts([
+      dateRange,
+      durationLabel ? `(${durationLabel})` : '',
+      companyName,
+      jobTitle,
+      companyMeta ? `公司信息：${companyMeta}` : '',
+      description,
+      reasonText ? `离职原因：${reasonText}` : ''
+    ]);
+
+    if (!raw && !description && !companyName && !jobTitle) return null;
+
+    return {
+      raw: raw || description || buildWorkHistoryRawParts([companyName, jobTitle, dateRange]),
+      companyName: companyName || undefined,
+      jobTitle: jobTitle || undefined,
+      description: [description, reasonText ? `离职原因：${reasonText}` : ''].filter(Boolean).join('\n') || undefined,
+      startDate: startDate || undefined,
+      endDate: endDate || undefined,
+    };
+  }
+
+  const getText = (selectors) => {
+    for (const selector of selectors) {
+      const value = normalizeResumeText(item.querySelector(selector)?.textContent);
+      if (value) return value;
+    }
+    return '';
+  };
+
+  const getOwnText = (selectors) => {
+    for (const selector of selectors) {
+      const node = item.querySelector(selector);
+      if (!(node instanceof Element)) continue;
+      const text = normalizeResumeText(Array.from(node.childNodes)
+        .filter((child) => child.nodeType === Node.TEXT_NODE)
+        .map((child) => child.textContent || '')
+        .join(' '));
+      if (text) return text;
+    }
+    return '';
+  };
+
+  const getLines = (selectors) => {
+    for (const selector of selectors) {
+      const nodes = item.querySelectorAll(selector);
+      const values = Array.from(nodes)
+        .map((node) => normalizeResumeText(node.textContent))
+        .filter(Boolean);
+      if (values.length > 0) return values;
+    }
+    return [];
+  };
+
+  const periodText = getText([
+    '.work-time',
+    '.time',
+    '.date',
+    '.work-date',
+    '.job-time',
+    '[class*="work-time"]',
+    '[class*="job-time"]'
+  ]);
+  const startDate = periodText.includes('~') ? normalizeResumeText(periodText.split('~')[0]) : periodText;
+  const endDate = periodText.includes('~') ? normalizeResumeText(periodText.split('~').slice(1).join('~')) : '';
+  const durationLabel = getText([
+    '.work-time-other',
+    '.time-other',
+    '.duration',
+    '[class*="duration"]'
+  ]);
+  const companyName = getText([
+    '.work-company',
+    '.company-name',
+    '.company',
+    '[class*="company"]'
+  ]);
+  const jobTitle = getText([
+    '.work-position',
+    '.job-title',
+    '.position-name',
+    '.position',
+    '[class*="position"]',
+    '[class*="job-title"]'
+  ]);
+  const department = getText([
+    '.work-department',
+    '.department',
+    '[class*="department"]'
+  ]);
+  const companyMeta = getText([
+    '.company-other',
+    '.company-info',
+    '.company-meta',
+    '[class*="company-other"]',
+    '[class*="company-info"]'
+  ]);
+  const reasonText = getText([
+    '.work-reason',
+    '.leave-reason',
+    '[class*="leave-reason"]',
+    '[class*="reason"]'
+  ]).replace(/^离职原因[:：]?\s*/u, '');
+  const ownDescription = getOwnText([
+    '.work-desc',
+    '.work-detail',
+    '.work-content',
+    '.work-responsibility',
+    '.work-duty',
+    '[class*="work-desc"]',
+    '[class*="responsibility"]',
+    '[class*="duty"]'
+  ]);
+  const descriptionLines = getLines([
+    '.work-desc p, .work-detail p, .work-content p, .work-responsibility p, .work-duty p',
+    '.work-desc li, .work-detail li, .work-content li, .work-responsibility li, .work-duty li',
+    '[class*="work-desc"] p, [class*="responsibility"] p, [class*="duty"] p',
+    '[class*="work-desc"] li, [class*="responsibility"] li, [class*="duty"] li'
+  ]);
+  const description = [
+    ownDescription,
+    descriptionLines.length > 0 ? descriptionLines.join('\n') : '',
+    department ? `部门：${department}` : '',
+    companyMeta ? `公司信息：${companyMeta}` : '',
+    reasonText ? `离职原因：${reasonText}` : ''
+  ].filter(Boolean).join('\n');
+  const raw = buildWorkHistoryRawParts([
+    periodText,
+    durationLabel,
+    companyName,
+    jobTitle,
+    department ? `部门：${department}` : '',
+    companyMeta ? `公司信息：${companyMeta}` : '',
+    ownDescription,
+    descriptionLines.join('；'),
+    reasonText ? `离职原因：${reasonText}` : ''
+  ]);
+
+  if (!raw && !description) return null;
+
+  return {
+    raw: raw || description,
+    companyName: companyName || undefined,
+    jobTitle: jobTitle || undefined,
+    description: description || undefined,
+    startDate: startDate || undefined,
+    endDate: endDate || undefined,
+  };
+}
+
+function collectSectionItemsByHeading(root, headingPattern) {
+  if (!(root instanceof Element)) return [];
+
+  const sections = Array.from(root.querySelectorAll('section, .section, .resume-section, .module, .card, .block, .resume-view-layout, [class*="section"], [class*="module"], [class*="block"]'));
+  for (const section of sections) {
+    const heading = normalizeResumeText(
+      section.querySelector('h1, h2, h3, h4, .title, .section-title, .module-title, .resume-view-layout__title, [class*="title"]')?.textContent
+    );
+    if (heading && headingPattern.test(heading)) {
+      return Array.from(section.querySelectorAll('.resume-work__info, .resume-education__info, .work-item, .school-item, li, .item, [class*="item"]'));
+    }
+  }
+
+  return [];
+}
+
+function extractJob5156DetailResume() {
+  if (!isJob5156DetailPage() || !isJob5156DetailReady()) return [];
+
+  const root = getJob5156DetailRoot();
+  const readText = (selectors, scopedRoot = root) => {
+    for (const selector of selectors) {
+      const value = normalizeResumeText(scopedRoot.querySelector(selector)?.textContent);
+      if (value) return value;
+    }
+    return '';
+  };
+  const resumeId = extractJob5156ResumeId(window.location.pathname);
+  const profileUrl = normalizeJob5156ProfileUrlForExport(window.location.href);
+  const basicTextNodes = Array.from(root.querySelectorAll('.basic-line__text, .basic-line span, .resume-basic-info span, [class*="basic"] span, .info-item, .label-value, .tag'))
+    .map((node) => node.textContent || '');
+  const filteredBasicTextNodes = basicTextNodes.filter((item) => !/求职状态|沟通中|更新时间/.test(item));
+  const {
+    age,
+    experience,
+    education,
+    location
+  } = parseJob5156BasicInfoItems(filteredBasicTextNodes);
+
+  const workItems = collectSectionItemsByHeading(root, /工作经历|工作经验|工作履历/u);
+  const educationItems = collectSectionItemsByHeading(root, /教育经历|教育背景|学习经历/u);
+  const seenWorkHistory = new Set();
+  const workHistory = workItems
+    .map((item) => buildJob5156DetailWorkHistoryItem(item))
+    .filter((item) => item && (item.raw.length > 5 || item.description))
+    .filter((item) => {
+      const signature = [item.companyName || '', item.jobTitle || '', item.startDate || '', item.endDate || '', item.raw || ''].join('|');
+      if (seenWorkHistory.has(signature)) return false;
+      seenWorkHistory.add(signature);
+      return true;
+    });
+
+  const seenEducation = new Set();
+  const profileEducation = educationItems
+    .map((item) => buildJob5156EducationItem(item))
+    .filter((item) => item && [item.institution, item.qualification, item.endDate].some(Boolean))
+    .filter((item) => {
+      const signature = [item.institution || '', item.qualification || '', item.endDate || ''].join('|');
+      if (seenEducation.has(signature)) return false;
+      seenEducation.add(signature);
+      return true;
+    });
+
+  const activityStatus = readText([
+    '.date-type-diff-text-block',
+    '.resume-status',
+    '.active-status',
+    '[class*="status"]'
+  ]);
+  const intentionSection = root.querySelector('.resume-view-layout.resume-interview');
+  const intentionItems = Array.from(intentionSection?.querySelectorAll('.resume-interview-info') || []);
+  const jobIntention = intentionItems
+    .map((item) => normalizeResumeText(item.querySelector('.pos-name')?.textContent))
+    .filter(Boolean)
+    .join(' / ');
+  const expectedSalary = normalizeResumeText(intentionItems[0]?.textContent)
+    .replace(/^.+?\s(\d[^\s]*元\/[月天年]).*$/u, '$1');
+  const selfIntro = normalizeResumeText(
+    root.querySelector('.resume-view-layout.resume-advantages .resume-advantages_skill pre')?.textContent
+    || root.querySelector('.resume-view-layout.resume-advantages .resume-advantages_skill')?.textContent
+    || ''
+  );
+  const name = readText([
+    '.resume-name',
+    '.basic-name',
+    '.name',
+    '.resume-view-item__block.resume-basic',
+    'h1'
+  ]);
+
+  return [{
+    resumeId,
+    name,
+    profileUrl,
+    activityStatus,
+    age,
+    experience,
+    education,
+    location,
+    jobIntention,
+    expectedSalary,
+    selfIntro,
+    workHistory,
+    profileEducation: profileEducation.length > 0 ? profileEducation : undefined,
+    extractedAt: new Date().toISOString(),
+    source: JOB5156_HOST,
+  }];
 }
 
 function extractSeekProfileResume() {
@@ -963,25 +1343,13 @@ function extractSingleResume(card, apiRow = null) {
     )
     : [];
 
-  const basicInfo = Array.from(basicInfoSpans)
-    .map((span) => span.textContent.trim())
-    .filter(Boolean);
-
-  let age = '';
-  let experience = '';
-  let education = '';
-  let location = '';
-  if (basicInfo.length >= 4) {
-    [age, experience, education, location] = basicInfo;
-  } else {
-    basicInfo.forEach((item) => {
-      if (item.includes('岁')) age = item;
-      else if (item.includes('年') && !item.includes('元')) experience = item;
-      else if (/(中专|高中|大专|本科|硕|博|研究生|MBA|EMBA)/.test(item)) education = item;
-      else if (!item.includes('元')) location = item;
-    });
-  }
-  if (locationFromCard) location = locationFromCard;
+  const basicInfo = Array.from(basicInfoSpans).map((span) => span.textContent || '');
+  const {
+    age,
+    experience,
+    education,
+    location
+  } = parseJob5156BasicInfoItems(basicInfo, locationFromCard);
 
   // Extract top row (job intention, salary)
   const topRow = card.querySelector(SELECTORS.topRowText) || card.querySelector(SELECTORS.topRow);
@@ -1127,6 +1495,10 @@ function extractResumes() {
     }
   }
 
+  if (isJob5156DetailPage()) {
+    return filterResumesByAgeRange(extractJob5156DetailResume());
+  }
+
   const cards = document.querySelectorAll(SELECTORS.resumeCard);
   const resumes = [];
 
@@ -1202,17 +1574,27 @@ function extractResumesRaw(options = {}) {
     }
   }
 
-  const cards = document.querySelectorAll(SELECTORS.resumeCard);
-  const items = Array.from(cards).map((card, index) => {
-    const el = /** @type {HTMLElement} */ (card);
-    return {
-      index: index + 1,
-      resumeId: getApiRowForIndex(index)?.resumeId ?? '',
-      perUserId: getApiRowForIndex(index)?.perUserId ?? '',
-      html: el.outerHTML,
-      text: el.innerText
-    };
-  });
+  const detailResumes = isJob5156DetailPage() ? extractJob5156DetailResume() : [];
+  const detailRoot = getJob5156DetailRoot();
+  const detailRootElement = detailRoot instanceof HTMLElement ? detailRoot : null;
+  const items = detailResumes.length > 0
+    ? [{
+        index: 1,
+        resumeId: detailResumes[0]?.resumeId || '',
+        perUserId: '',
+        html: detailRoot?.outerHTML || '',
+        text: detailRootElement?.innerText || detailRoot?.textContent || ''
+      }]
+    : Array.from(document.querySelectorAll(SELECTORS.resumeCard)).map((card, index) => {
+        const el = /** @type {HTMLElement} */ (card);
+        return {
+          index: index + 1,
+          resumeId: getApiRowForIndex(index)?.resumeId ?? '',
+          perUserId: getApiRowForIndex(index)?.perUserId ?? '',
+          html: el.outerHTML,
+          text: el.innerText
+        };
+      });
 
   const payload = {
     url: window.location.href,
@@ -1361,6 +1743,10 @@ function getSeekPaginationInfo() {
 function getPaginationInfo() {
   if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
     return getSeekPaginationInfo();
+  }
+
+  if (isJob5156DetailPage()) {
+    return { currentPage: 1, totalPages: 1, totalItems: isJob5156DetailReady() ? 1 : 0, hasNextPage: false };
   }
 
   const pagination = document.querySelector(SELECTORS.pagination);
@@ -2776,7 +3162,9 @@ function getExternalAccessorStatus() {
   const apiSnapshotCount = getApiSnapshotCount();
   const cardCount = sourceKey === SOURCE_KEYS.SEEK
     ? Math.max(apiSnapshotCount, getSeekCardCount())
-    : document.querySelectorAll(SELECTORS.resumeCard).length;
+    : isJob5156DetailPage()
+      ? (isJob5156DetailReady() ? 1 : 0)
+      : document.querySelectorAll(SELECTORS.resumeCard).length;
   const autoSearch = document.documentElement.getAttribute('data-tr-auto-search') || '';
   const autoLocation = document.documentElement.getAttribute('data-tr-auto-location') || '';
   const autoExport = document.documentElement.getAttribute('data-tr-auto-export') || '';

--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -34,6 +34,7 @@
         {
             "matches": [
                 "*://hr.job5156.com/search*",
+                "*://hr.job5156.com/resume/view/*",
                 "*://hk.employer.seek.com/candidates/recommended*",
                 "*://my.employer.seek.com/candidates/recommended*",
                 "*://hk.employer.seek.com/talentsearch/profile*",

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -1,4 +1,3 @@
-import { buildWorkHistoryEntryText, normalizeWorkHistoryEntry } from '@trends/shared'
 import { useTranslation } from 'react-i18next'
 import { User, CheckCircle, XCircle, Phone, Star, Ban, MessageSquare } from 'lucide-react'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -149,18 +148,6 @@ export function ResumeCard({
   const [blockNoteInput, setBlockNoteInput] = useState('')
   const [commentDialogOpen, setCommentDialogOpen] = useState(false)
   const [commentNoteInput, setCommentNoteInput] = useState('')
-  const workHistory = (resume.workHistory ?? [])
-    .map((item) => {
-      const normalized = normalizeWorkHistoryEntry(item)
-      return {
-        item,
-        normalized,
-        text: normalized ? buildWorkHistoryEntryText(item) : '',
-      }
-    })
-    .filter(({ normalized, text }) => normalized !== null && text.length > 0)
-  const jobIntention = (resume.jobIntention || '').replace(/^[:：]\s*/, '') || '--'
-  const selfIntro = resume.selfIntro || '--'
   const profileUrl = resume.profileUrl?.trim()
   const hasProfileUrl = isSafeProfileUrl(profileUrl)
 
@@ -246,8 +233,6 @@ export function ResumeCard({
       data-role-types={(roleTypes ?? []).join(',')}
     >
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b bg-muted/50 px-4 py-2 text-sm">
-        <span className="text-muted-foreground">求职意向</span>
-        <span className="font-medium">{jobIntention}</span>
         {isReviewed && (
           <Badge variant="outline" className="bg-blue-50 text-blue-600 border-blue-200 text-[10px]">
             {t('resumes.status.reviewed', '已查阅')}
@@ -530,24 +515,10 @@ export function ResumeCard({
             />
           </div>
           <div className="text-sm text-muted-foreground">
-            {resume.age || '--'} | {resume.experience || '--'} | {resume.education || '--'} |{' '}
-            {resume.location || '--'}
+            {resume.age || '--'} | {resume.education || '--'} | {resume.location || '--'}
           </div>
-          <div className="text-sm text-muted-foreground line-clamp-2">{selfIntro}</div>
         </div>
 
-        {workHistory.length > 0 ? (
-          <div className="min-w-0 space-y-1 text-sm lg:w-[420px]">
-            {workHistory.slice(0, 3).map(({ item, text }, index) => (
-              <div key={`${resume.name}-${index}`} className="flex gap-2">
-                <span className="text-muted-foreground">●</span>
-                <span className="truncate" title={item.raw || text}>
-                  {text}
-                </span>
-              </div>
-            ))}
-          </div>
-        ) : null}
       </div>
 
       <Dialog open={promptDialogOpen} onOpenChange={setPromptDialogOpen}>

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -1,3 +1,4 @@
+import { buildWorkHistoryEntryText } from '@trends/shared'
 import { useTranslation } from 'react-i18next'
 import { User, CheckCircle, XCircle, Phone, Star, Ban, MessageSquare } from 'lucide-react'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -9,6 +10,7 @@ import type { ResumeItem } from '@/hooks/useResumes'
 import type { AiFeedbackSentiment, AiFeedbackTarget, CandidateActionType, CandidateStatus, MatchingResult } from '@/types/resume'
 import type { ExperienceLevelFilter } from '@/hooks/useUrlSearchState'
 import { cn } from '@/lib/utils'
+import { isSafeProfileUrl } from '@/lib/resume-scoring'
 import {
   Tooltip,
   TooltipContent,
@@ -58,11 +60,6 @@ interface ResumeCardProps {
   isReviewed?: boolean
   aiScoreFeedback?: AiFeedbackSentiment
   onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
-}
-
-function isSafeProfileUrl(value: string | undefined): value is string {
-  if (!value) return false
-  return value.startsWith('http://') || value.startsWith('https://')
 }
 
 const STATUS_OPTIONS: Array<{ value: CandidateStatus; labelKey: string }> = [
@@ -148,6 +145,15 @@ export function ResumeCard({
   const [blockNoteInput, setBlockNoteInput] = useState('')
   const [commentDialogOpen, setCommentDialogOpen] = useState(false)
   const [commentNoteInput, setCommentNoteInput] = useState('')
+  const workHistory = (resume.workHistory ?? [])
+    .slice(0, 3)
+    .map((item) => ({
+      item,
+      text: buildWorkHistoryEntryText(item),
+    }))
+    .filter(({ text }) => text.length > 0)
+  const jobIntention = (resume.jobIntention || '').replace(/^[:：]\s*/, '') || '--'
+  const selfIntro = resume.selfIntro || '--'
   const profileUrl = resume.profileUrl?.trim()
   const hasProfileUrl = isSafeProfileUrl(profileUrl)
 
@@ -233,6 +239,8 @@ export function ResumeCard({
       data-role-types={(roleTypes ?? []).join(',')}
     >
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b bg-muted/50 px-4 py-2 text-sm">
+        <span className="text-muted-foreground">求职意向</span>
+        <span className="font-medium">{jobIntention}</span>
         {isReviewed && (
           <Badge variant="outline" className="bg-blue-50 text-blue-600 border-blue-200 text-[10px]">
             {t('resumes.status.reviewed', '已查阅')}
@@ -515,10 +523,24 @@ export function ResumeCard({
             />
           </div>
           <div className="text-sm text-muted-foreground">
-            {resume.age || '--'} | {resume.education || '--'} | {resume.location || '--'}
+            {resume.age || '--'} | {resume.experience || '--'} | {resume.education || '--'} |{' '}
+            {resume.location || '--'}
           </div>
+          <div className="text-sm text-muted-foreground line-clamp-2">{selfIntro}</div>
         </div>
 
+        {workHistory.length > 0 ? (
+          <div className="min-w-0 space-y-1 text-sm lg:w-[420px]">
+            {workHistory.map(({ item, text }, index) => (
+              <div key={`${resume.name}-${index}`} className="flex gap-2">
+                <span className="text-muted-foreground">●</span>
+                <span className="truncate" title={item.raw || text}>
+                  {text}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : null}
       </div>
 
       <Dialog open={promptDialogOpen} onOpenChange={setPromptDialogOpen}>

--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -57,7 +57,7 @@ export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreF
 
         <div className="grid gap-4">
           <div className="text-sm relative">
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-2 gap-4 pr-20">
               <div>
                 <p className="text-muted-foreground">{t('resumes.columns.name')}</p>
                 <p className="font-medium">{resume.name || '--'}</p>
@@ -81,10 +81,6 @@ export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreF
           {isInfoExpanded && (
             <div className="grid grid-cols-2 gap-4 text-sm pt-2 border-t">
               <div>
-                <p className="text-muted-foreground">{t('resumes.columns.experience')}</p>
-                <p className="font-medium">{resume.experience || '--'}</p>
-              </div>
-              <div>
                 <p className="text-muted-foreground">{t('resumes.columns.education')}</p>
                 <p className="font-medium">{resume.education || '--'}</p>
               </div>
@@ -96,15 +92,11 @@ export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreF
                 <p className="text-muted-foreground">{t('resumes.columns.salary')}</p>
                 <p className="font-medium">{resume.expectedSalary || '--'}</p>
               </div>
-              <div className="col-span-2">
-                <p className="text-muted-foreground">{t('resumes.columns.intention')}</p>
-                <p className="font-medium">{resume.jobIntention || '--'}</p>
-              </div>
               <div>
                 <p className="text-muted-foreground">{t('resumes.columns.activity')}</p>
                 <p className="font-medium">{resume.activityStatus || '--'}</p>
               </div>
-              <div>
+              <div className="col-span-2">
                 <p className="text-muted-foreground">ID</p>
                 <p className="font-medium">
                   {[resume.resumeId, resume.perUserId].filter(Boolean).join(' / ') || '--'}
@@ -116,14 +108,6 @@ export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreF
                   <p className="font-medium">
                     {new Date(resume.extractedAt).toLocaleString()}
                   </p>
-                </div>
-              )}
-              {resume.selfIntro && (
-                <div className="col-span-2">
-                  <p className="text-muted-foreground">{t('resumes.detail.selfIntro')}</p>
-                  <div className="mt-1 whitespace-pre-wrap">
-                    {resume.selfIntro}
-                  </div>
                 </div>
               )}
             </div>

--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -7,6 +7,7 @@ import { Button, buttonVariants } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { AiFeedbackButtons } from '@/components/AiFeedbackButtons'
 import type { ResumeItem } from '@/hooks/useResumes'
+import { isSafeProfileUrl } from '@/lib/resume-scoring'
 
 import type { AiFeedbackSentiment, AiFeedbackTarget, MatchingResult } from '@/types/resume'
 
@@ -18,11 +19,6 @@ interface ResumeDetailProps {
   aiScoreFeedback?: AiFeedbackSentiment
   aiSummaryFeedback?: AiFeedbackSentiment
   onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
-}
-
-function isSafeProfileUrl(value: string | undefined): value is string {
-  if (!value) return false
-  return value.startsWith('http://') || value.startsWith('https://')
 }
 
 export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreFeedback, aiSummaryFeedback, onAiFeedback }: ResumeDetailProps) {
@@ -57,7 +53,7 @@ export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreF
 
         <div className="grid gap-4">
           <div className="text-sm relative">
-            <div className="grid grid-cols-2 gap-4 pr-20">
+            <div className="grid grid-cols-2 gap-4">
               <div>
                 <p className="text-muted-foreground">{t('resumes.columns.name')}</p>
                 <p className="font-medium">{resume.name || '--'}</p>
@@ -81,6 +77,10 @@ export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreF
           {isInfoExpanded && (
             <div className="grid grid-cols-2 gap-4 text-sm pt-2 border-t">
               <div>
+                <p className="text-muted-foreground">{t('resumes.columns.experience')}</p>
+                <p className="font-medium">{resume.experience || '--'}</p>
+              </div>
+              <div>
                 <p className="text-muted-foreground">{t('resumes.columns.education')}</p>
                 <p className="font-medium">{resume.education || '--'}</p>
               </div>
@@ -92,11 +92,15 @@ export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreF
                 <p className="text-muted-foreground">{t('resumes.columns.salary')}</p>
                 <p className="font-medium">{resume.expectedSalary || '--'}</p>
               </div>
+              <div className="col-span-2">
+                <p className="text-muted-foreground">{t('resumes.columns.intention')}</p>
+                <p className="font-medium">{resume.jobIntention || '--'}</p>
+              </div>
               <div>
                 <p className="text-muted-foreground">{t('resumes.columns.activity')}</p>
                 <p className="font-medium">{resume.activityStatus || '--'}</p>
               </div>
-              <div className="col-span-2">
+              <div>
                 <p className="text-muted-foreground">ID</p>
                 <p className="font-medium">
                   {[resume.resumeId, resume.perUserId].filter(Boolean).join(' / ') || '--'}
@@ -110,6 +114,14 @@ export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreF
                   </p>
                 </div>
               )}
+              {resume.selfIntro && (
+                <div className="col-span-2">
+                  <p className="text-muted-foreground">{t('resumes.detail.selfIntro')}</p>
+                  <div className="mt-1 whitespace-pre-wrap">
+                    {resume.selfIntro}
+                  </div>
+                </div>
+              )}
             </div>
           )}
 
@@ -121,16 +133,15 @@ export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreF
               <ul className="space-y-2 text-sm">
                 {workHistory.map((item, index) => {
                   const dateRange = buildWorkHistoryDateRange(item.startDate, item.endDate)
+                  const durationLabel = item.raw?.match(/[(（]([^)）]+)[)）]/)?.[1] || ''
+                  const dateLine = [dateRange, durationLabel ? `(${durationLabel})` : ''].filter(Boolean).join(' ')
                   const heading = [item.companyName, item.jobTitle].filter(Boolean).join(' · ')
                   return (
                     <li key={`${resume.name}-${index}`} className="rounded-md border border-border p-3 space-y-1">
                       {heading ? <div className="font-medium">{heading}</div> : null}
-                      {dateRange ? <div className="text-xs text-muted-foreground">{dateRange}</div> : null}
+                      {dateLine ? <div className="text-xs text-muted-foreground">{dateLine}</div> : null}
                       {item.description ? <div className="whitespace-pre-wrap">{item.description}</div> : null}
-                      {!heading && !dateRange && !item.description ? <div>{item.raw}</div> : null}
-                      {item.raw && (heading || dateRange || item.description) ? (
-                        <div className="text-xs text-muted-foreground whitespace-pre-wrap">{item.raw}</div>
-                      ) : null}
+                      {!heading && !dateLine && !item.description ? <div>{item.raw}</div> : null}
                     </li>
                   )
                 })}


### PR DESCRIPTION
## Summary
- add browser-extension support for Job5156 resume detail pages
- enrich synced resume data from detail-page extraction
- simplify resume card/detail display to use the richer extracted fields

## Test plan
- [ ] Verify detail-page extraction on Job5156 resume pages
- [ ] Verify synced resume cards show enriched fields
- [ ] Verify resume detail view renders updated extracted data