### PR TITLE
Batch Convex deploy migrations

### DIFF
--- a/packages/convex/convex/__tests__/migrations-batching.test.ts
+++ b/packages/convex/convex/__tests__/migrations-batching.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { backfillIngestData } from "../migrations";
+
+type ConvexHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+type BackfillIngestDataResult = {
+  scheduled: number
+  batches: number
+  hasMore: boolean
+  cursor: string | null
+  scannedResumes: number
+  message: string
+}
+
+const backfillIngestDataHandler = (backfillIngestData as unknown as ConvexHandler<
+  { limit?: number; cursor?: string; batchSize?: number },
+  BackfillIngestDataResult
+>)._handler
+
+describe("backfillIngestData", () => {
+  it("schedules only unprocessed resumes from the current scan batch and returns the next cursor", async () => {
+    const scheduledPayloads: Array<{ resumeIds: string[] }> = []
+
+    const ctx = {
+      async runQuery() {
+        return {
+          continueCursor: "next:cursor",
+          isDone: false,
+          page: [
+            {
+              _id: "resume-1",
+              content: {},
+              ingestData: undefined,
+              primaryRuleScore: undefined,
+              searchText: undefined,
+            },
+            {
+              _id: "resume-2",
+              content: {},
+              ingestData: {
+                evidenceText: "already processed",
+                industryTags: [],
+                synonymHits: [],
+                ruleScores: {},
+                experienceLevel: "unknown",
+                computedAt: 1,
+                skillsVersion: 1,
+              },
+              primaryRuleScore: 0,
+              searchText: "",
+            },
+          ],
+        }
+      },
+      scheduler: {
+        async runAfter(_delay: number, _fn: unknown, payload: { resumeIds: string[] }) {
+          scheduledPayloads.push(payload)
+        },
+      },
+    }
+
+    const result = await backfillIngestDataHandler(ctx as never, { limit: 100 })
+
+    expect(result).toEqual({
+      scheduled: 1,
+      batches: 1,
+      hasMore: true,
+      cursor: "next:cursor",
+      scannedResumes: 2,
+      message: "Scheduled ingest backfill for 1 resumes in 1 batch(es)",
+    })
+    expect(scheduledPayloads).toEqual([{ resumeIds: ["resume-1"] }])
+  })
+})

--- a/packages/convex/convex/__tests__/migrations-evidence-text.test.ts
+++ b/packages/convex/convex/__tests__/migrations-evidence-text.test.ts
@@ -5,6 +5,8 @@ import { backfillEvidenceText, backfillJob5156WorkHistoryEducation } from '../mi
 type BackfillEvidenceTextResult = {
   scannedResumes: number
   patched: number
+  hasMore: boolean
+  cursor: string | null
 }
 
 type ConvexHandler<TArgs, TResult> = {
@@ -18,7 +20,7 @@ const backfillEvidenceTextHandler = (backfillEvidenceText as unknown as ConvexHa
 
 const backfillJob5156WorkHistoryEducationHandler = (backfillJob5156WorkHistoryEducation as unknown as ConvexHandler<
   Record<string, never>,
-  { scannedResumes: number; updatedResumes: number; movedEducationEntries: number }
+  { scannedResumes: number; updatedResumes: number; movedEducationEntries: number; hasMore: boolean; cursor: string | null }
 >)._handler
 
 type ResumeRecord = {
@@ -44,8 +46,17 @@ function createResumesDb(records: ResumeRecord[]) {
       query(tableName: string) {
         expect(tableName).toBe('resumes')
         return {
-          async collect() {
-            return records.map((record) => ({ ...record }))
+          order(direction: 'asc' | 'desc') {
+            expect(direction).toBe('desc')
+            return {
+              async paginate() {
+                return {
+                  page: records.map((record) => ({ ...record })),
+                  isDone: true,
+                  continueCursor: 'cursor:done',
+                }
+              },
+            }
           },
         }
       },
@@ -109,6 +120,8 @@ describe('backfillEvidenceText', () => {
     expect(result).toEqual({
       scannedResumes: 3,
       patched: 1,
+      hasMore: false,
+      cursor: null,
     })
 
     expect(ctx.patches).toContainEqual({
@@ -180,6 +193,8 @@ describe('backfillJob5156WorkHistoryEducation', () => {
       scannedResumes: 2,
       updatedResumes: 1,
       movedEducationEntries: 1,
+      hasMore: false,
+      cursor: null,
     })
 
     expect(ctx.patches).toContainEqual({

--- a/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
+++ b/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { projectIngestDiagnosticsRow, resolveListWithIngestWindow } from "../resumes";
+import { projectIngestDiagnosticsRow, resolveListWithIngestWindow, resolveResumeScanBatchSize } from "../resumes";
 
 describe("resolveListWithIngestWindow", () => {
     it("uses the default list window when no limit is provided", () => {
@@ -15,6 +15,16 @@ describe("resolveListWithIngestWindow", () => {
             limit: 200,
             overfetchLimit: 400,
         });
+    });
+});
+
+describe("resolveResumeScanBatchSize", () => {
+    it("uses the default scan size when no limit is provided", () => {
+        expect(resolveResumeScanBatchSize(undefined)).toBe(25);
+    });
+
+    it("clamps oversized scan batches to the safe maximum", () => {
+        expect(resolveResumeScanBatchSize(5_000)).toBe(50);
     });
 });
 

--- a/packages/convex/convex/ingest_agent.ts
+++ b/packages/convex/convex/ingest_agent.ts
@@ -3,6 +3,7 @@ import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { internalAction } from "./_generated/server";
 import { v } from "convex/values";
+import type { ResumeScanRow } from "./resumes";
 
 /**
  * Background ingest agent (M3)
@@ -19,6 +20,11 @@ function getBffApiUrl(): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function isStaleSkillsVersion(resume: ResumeScanRow, currentVersion: number): boolean {
+  const version = resume.ingestData?.skillsVersion;
+  return typeof version !== "number" || version < currentVersion;
 }
 
 export const processNewResumes = internalAction({
@@ -126,23 +132,39 @@ export const processNewResumes = internalAction({
 export const reIngestAllResumes = internalAction({
   args: {},
   handler: async (ctx): Promise<{ scheduled: number; batches: number }> => {
-    const resumeIds: Id<"resumes">[] = await ctx.runQuery(internal.resumes.listProcessedIds, {});
-
-    if (resumeIds.length === 0) {
-      return { scheduled: 0, batches: 0 };
-    }
-
     const batchSize = 50;
+    let cursor: string | undefined;
+    let scheduled = 0;
     let batches = 0;
 
-    for (let index = 0; index < resumeIds.length; index += batchSize) {
-      await ctx.scheduler.runAfter(0, internal.ingest_agent.processNewResumes, {
-        resumeIds: resumeIds.slice(index, index + batchSize),
-      });
-      batches += 1;
+    while (true) {
+      const batch: {
+        continueCursor: string;
+        isDone: boolean;
+        page: ResumeScanRow[];
+      } = await ctx.runQuery(internal.resumes.listResumeScanBatch, { cursor });
+
+      const resumeIds = batch.page
+        .filter((resume) => resume.ingestData !== undefined)
+        .map((resume) => resume._id);
+
+      for (let index = 0; index < resumeIds.length; index += batchSize) {
+        await ctx.scheduler.runAfter(0, internal.ingest_agent.processNewResumes, {
+          resumeIds: resumeIds.slice(index, index + batchSize),
+        });
+        batches += 1;
+      }
+
+      scheduled += resumeIds.length;
+
+      if (batch.isDone) {
+        break;
+      }
+
+      cursor = batch.continueCursor;
     }
 
-    return { scheduled: resumeIds.length, batches };
+    return { scheduled, batches };
   },
 });
 
@@ -173,23 +195,52 @@ export const reIngestStaleResumes = internalAction({
       throw new Error("Invalid skills version response: version must be a number");
     }
 
-    const staleResumes: Array<{ _id: Id<"resumes"> }> = await ctx.runQuery(internal.resumes.listStaleResumes, {
-      currentVersion,
-      limit,
-    });
+    const batchSize = 50;
+    let cursor: string | undefined;
+    const resumeIds: Id<"resumes">[] = [];
+    let hasMore = false;
+    let batches = 0;
 
-    if (staleResumes.length === 0) {
+    while (resumeIds.length < limit) {
+      const batch: {
+        continueCursor: string;
+        isDone: boolean;
+        page: ResumeScanRow[];
+      } = await ctx.runQuery(internal.resumes.listResumeScanBatch, { cursor });
+
+      const staleIds = batch.page
+        .filter((resume) => resume.ingestData !== undefined && isStaleSkillsVersion(resume, currentVersion))
+        .map((resume) => resume._id);
+      const remaining = limit - resumeIds.length;
+
+      if (staleIds.length > remaining) {
+        resumeIds.push(...staleIds.slice(0, remaining));
+        hasMore = true;
+        break;
+      }
+
+      resumeIds.push(...staleIds);
+
+      if (resumeIds.length === limit) {
+        hasMore = !batch.isDone;
+        break;
+      }
+
+      if (batch.isDone) {
+        break;
+      }
+
+      cursor = batch.continueCursor;
+    }
+
+    if (resumeIds.length === 0) {
       return {
         scheduled: 0,
         batches: 0,
         currentVersion,
-        hasMore: false,
+        hasMore,
       };
     }
-
-    const resumeIds = staleResumes.map((resume) => resume._id);
-    const batchSize = 50;
-    let batches = 0;
 
     for (let index = 0; index < resumeIds.length; index += batchSize) {
       await ctx.scheduler.runAfter(0, internal.ingest_agent.processNewResumes, {
@@ -202,7 +253,7 @@ export const reIngestStaleResumes = internalAction({
       scheduled: resumeIds.length,
       batches,
       currentVersion,
-      hasMore: resumeIds.length === limit,
+      hasMore,
     };
   },
 });

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -8,6 +8,7 @@ import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
 import { deriveResumeIdentityKey } from "./lib/resume_identity";
 import { parseAgeFromContent } from "./lib/age";
 import { DEFAULT_WORKSPACE_SLUG } from "./sessions";
+import { resolveResumeScanBatchSize } from "./resumes";
 
 const JOB5156_HOST = "hr.job5156.com";
 const JOB5156_PROFILE_DISPLAY_PREFIX = `https://${JOB5156_HOST}/resume/view/`;
@@ -215,6 +216,8 @@ type BackfillIngestDataResult = {
     scheduled: number;
     batches: number;
     hasMore: boolean;
+    cursor: string | null;
+    scannedResumes: number;
     message: string;
 };
 
@@ -252,11 +255,20 @@ export const backfillSearchText = mutation({
 });
 
 export const reindexSearchText = mutation({
-    args: {},
-    handler: async (ctx) => {
-        const resumes = await ctx.db.query("resumes").collect();
+    args: {
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const resumes = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.batchSize),
+            });
         let count = 0;
-        for (const resume of resumes) {
+        for (const resume of resumes.page) {
             const searchText = mergeSearchTextWithIngestData(buildSearchText(resume.content), {
                 industryTags: resume.ingestData?.industryTags,
                 synonymHits: resume.ingestData?.synonymHits,
@@ -267,7 +279,12 @@ export const reindexSearchText = mutation({
                 count++;
             }
         }
-        return `Reindexed ${count} resumes`;
+        return {
+            scannedResumes: resumes.page.length,
+            updatedResumes: count,
+            hasMore: !resumes.isDone,
+            cursor: resumes.isDone ? null : resumes.continueCursor,
+        };
     },
 });
 
@@ -356,18 +373,28 @@ export const backfillWorkspaceSlugs = mutation({
 export const backfillIngestData = action({
     args: {
         limit: v.optional(v.number()),
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
     },
     handler: async (ctx, args): Promise<BackfillIngestDataResult> => {
         const limit = Math.max(1, Math.min(args.limit ?? 100, 500));
-        const unprocessed: Array<Pick<Doc<"resumes">, "_id">> = await ctx.runQuery(internal.resumes.listUnprocessed, { limit });
-        const resumeIds: Id<"resumes">[] = unprocessed.map((resume: Pick<Doc<"resumes">, "_id">) => resume._id);
+        const scanBatch = await ctx.runQuery(internal.resumes.listResumeScanBatch, {
+            cursor: args.cursor,
+            limit: Math.min(resolveResumeScanBatchSize(args.batchSize), limit),
+        });
+        const resumeIds: Id<"resumes">[] = scanBatch.page
+            .filter((resume) => resume.ingestData === undefined)
+            .slice(0, limit)
+            .map((resume) => resume._id);
 
         if (resumeIds.length === 0) {
             return {
                 scheduled: 0,
                 batches: 0,
-                hasMore: false,
-                message: "No unprocessed resumes remaining",
+                hasMore: !scanBatch.isDone,
+                cursor: scanBatch.isDone ? null : scanBatch.continueCursor,
+                scannedResumes: scanBatch.page.length,
+                message: scanBatch.isDone ? "No unprocessed resumes remaining" : "No unprocessed resumes found in this batch",
             };
         }
 
@@ -385,19 +412,30 @@ export const backfillIngestData = action({
         return {
             scheduled: resumeIds.length,
             batches,
-            hasMore: resumeIds.length === limit,
+            hasMore: !scanBatch.isDone,
+            cursor: scanBatch.isDone ? null : scanBatch.continueCursor,
+            scannedResumes: scanBatch.page.length,
             message: `Scheduled ingest backfill for ${resumeIds.length} resumes in ${batches} batch(es)`,
         };
     },
 });
 
 export const backfillPrimaryRuleScore = mutation({
-    args: {},
-    handler: async (ctx) => {
-        const resumes = await ctx.db.query("resumes").collect();
+    args: {
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const resumes = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.batchSize),
+            });
         let updated = 0;
 
-        for (const resume of resumes) {
+        for (const resume of resumes.page) {
             if (resume.primaryRuleScore !== undefined) {
                 continue;
             }
@@ -409,17 +447,31 @@ export const backfillPrimaryRuleScore = mutation({
             updated += 1;
         }
 
-        return `Backfilled ${updated} resumes`;
+        return {
+            scannedResumes: resumes.page.length,
+            updatedResumes: updated,
+            hasMore: !resumes.isDone,
+            cursor: resumes.isDone ? null : resumes.continueCursor,
+        };
     },
 });
 
 export const backfillEvidenceText = mutation({
-    args: {},
-    handler: async (ctx) => {
-        const resumes = await ctx.db.query("resumes").collect();
+    args: {
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const resumes = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.batchSize),
+            });
         let patched = 0;
 
-        for (const resume of resumes) {
+        for (const resume of resumes.page) {
             if (!resume.ingestData || typeof resume.ingestData.evidenceText === "string") {
                 continue;
             }
@@ -434,8 +486,10 @@ export const backfillEvidenceText = mutation({
         }
 
         return {
-            scannedResumes: resumes.length,
+            scannedResumes: resumes.page.length,
             patched,
+            hasMore: !resumes.isDone,
+            cursor: resumes.isDone ? null : resumes.continueCursor,
         };
     },
 });
@@ -514,13 +568,22 @@ function rewriteJob5156WorkHistoryContent(content: unknown): {
 }
 
 export const backfillJob5156ProfileUrls = mutation({
-    args: {},
-    handler: async (ctx) => {
-        const resumes = await ctx.db.query("resumes").collect();
+    args: {
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const resumes = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.batchSize),
+            });
         let updatedResumes = 0;
         let updatedProfileFields = 0;
 
-        for (const resume of resumes) {
+        for (const resume of resumes.page) {
             const rewritten = rewriteJob5156ProfileUrlsInContent(resume.content);
             if (!rewritten.content) {
                 continue;
@@ -537,21 +600,32 @@ export const backfillJob5156ProfileUrls = mutation({
         }
 
         return {
-            scannedResumes: resumes.length,
+            scannedResumes: resumes.page.length,
             updatedResumes,
             updatedProfileFields,
+            hasMore: !resumes.isDone,
+            cursor: resumes.isDone ? null : resumes.continueCursor,
         };
     },
 });
 
 export const backfillJob5156WorkHistoryEducation = mutation({
-    args: {},
-    handler: async (ctx) => {
-        const resumes = await ctx.db.query("resumes").collect();
+    args: {
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const resumes = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.batchSize),
+            });
         let updatedResumes = 0;
         let movedEducationEntries = 0;
 
-        for (const resume of resumes) {
+        for (const resume of resumes.page) {
             const rewritten = rewriteJob5156WorkHistoryContent(resume.content);
             if (!rewritten.content) {
                 continue;
@@ -573,9 +647,11 @@ export const backfillJob5156WorkHistoryEducation = mutation({
         }
 
         return {
-            scannedResumes: resumes.length,
+            scannedResumes: resumes.page.length,
             updatedResumes,
             movedEducationEntries,
+            hasMore: !resumes.isDone,
+            cursor: resumes.isDone ? null : resumes.continueCursor,
         };
     },
 });

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -126,11 +126,21 @@ export type IngestDiagnosticsRow = {
     };
 };
 
+export type ResumeScanRow = {
+    _id: Doc<"resumes">["_id"];
+    content: Doc<"resumes">["content"];
+    ingestData: Doc<"resumes">["ingestData"];
+    primaryRuleScore: Doc<"resumes">["primaryRuleScore"];
+    searchText: Doc<"resumes">["searchText"];
+};
+
 const DEFAULT_RESUME_LIMIT = 50;
 export const MAX_SAFE_LIST_WITH_INGEST_LIMIT = 200;
 export const MAX_SAFE_LIST_WITH_INGEST_OVERFETCH = 400;
 const MAX_INGEST_DIAGNOSTICS_PAGE_SIZE = 100;
 const MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES = 8;
+const DEFAULT_RESUME_SCAN_BATCH_SIZE = 25;
+const MAX_RESUME_SCAN_BATCH_SIZE = 50;
 
 function dedupeProvenance(items: SearchProvenance[]): SearchProvenance[] {
     const seen = new Set<string>();
@@ -216,6 +226,13 @@ export function resolveListWithIngestWindow(requestedLimit: number | undefined):
         limit,
         overfetchLimit: Math.min(Math.max(limit * 3, limit), MAX_SAFE_LIST_WITH_INGEST_OVERFETCH),
     };
+}
+
+export function resolveResumeScanBatchSize(requestedLimit: number | undefined): number {
+    const normalizedLimit = typeof requestedLimit === "number" && Number.isFinite(requestedLimit)
+        ? Math.trunc(requestedLimit)
+        : DEFAULT_RESUME_SCAN_BATCH_SIZE;
+    return Math.min(Math.max(normalizedLimit, 1), MAX_RESUME_SCAN_BATCH_SIZE);
 }
 
 function normalizeTagExpansionKeywordGroups(
@@ -831,49 +848,31 @@ export const updateIngestDataBatch = internalMutation({
     },
 });
 
-export const listUnprocessed = internalQuery({
+export const listResumeScanBatch = internalQuery({
     args: {
+        cursor: v.optional(v.string()),
         limit: v.optional(v.number()),
     },
     handler: async (ctx, args) => {
-        const limit = args.limit || 100;
-        const resumes = await ctx.db
+        const page = await ctx.db
             .query("resumes")
-            .filter((q) => q.eq(q.field("ingestData"), undefined))
-            .take(limit);
-        return resumes;
-    },
-});
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.limit),
+            });
 
-export const listProcessedIds = internalQuery({
-    args: {},
-    handler: async (ctx) => {
-        const resumes = await ctx.db.query("resumes").collect();
-        return resumes
-            .filter((resume) => resume.ingestData !== undefined)
-            .map((resume) => resume._id);
-    },
-});
-
-export const listStaleResumes = internalQuery({
-    args: {
-        currentVersion: v.number(),
-        limit: v.optional(v.number()),
-    },
-    handler: async (ctx, args) => {
-        const limit = args.limit || 100;
-        const resumes = await ctx.db
-            .query("resumes")
-            .filter((q) => q.neq(q.field("ingestData"), undefined))
-            .collect();
-
-        return resumes
-            .filter((resume) => {
-                const version = resume.ingestData?.skillsVersion;
-                return typeof version !== "number" || version < args.currentVersion;
-            })
-            .slice(0, limit)
-            .map((resume) => ({ _id: resume._id }));
+        return {
+            continueCursor: page.continueCursor,
+            isDone: page.isDone,
+            page: page.page.map((resume): ResumeScanRow => ({
+                _id: resume._id,
+                content: resume.content,
+                ingestData: resume.ingestData,
+                primaryRuleScore: resume.primaryRuleScore,
+                searchText: resume.searchText,
+            })),
+        };
     },
 });
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -272,17 +272,81 @@ run_convex_migration() {
     local convex_dir="$1"
     local migration_name="$2"
     local migration_args="${3:-}"
-    local migration_suffix=""
-    local command="set -a && [ -f '$CONFIG_DIR/env' ] && source '$CONFIG_DIR/env' && set +a && cd '$convex_dir' && npx convex run migrations:$migration_name"
+    local cursor=""
+    local iteration=1
 
-    if [[ -n "$migration_args" ]]; then
-        migration_suffix=" $migration_args"
-        command="$command '$migration_args'"
-    fi
+    while true; do
+        local call_args=""
+        local command="set -a && [ -f '$CONFIG_DIR/env' ] && source '$CONFIG_DIR/env' && set +a && cd '$convex_dir' && npx convex run migrations:$migration_name"
 
-    log_info "Running Convex migration: $migration_name..."
-    run_as_service_user "$command" \
-        || log_warn "$migration_name failed.$migration_suffix"
+        call_args="$(node - "$migration_args" "$cursor" <<'NODE'
+const baseArgs = process.argv[2] ? JSON.parse(process.argv[2]) : {};
+const cursor = process.argv[3];
+if (cursor) {
+  baseArgs.cursor = cursor;
+}
+process.stdout.write(JSON.stringify(baseArgs));
+NODE
+)"
+
+        if [[ "$call_args" != "{}" ]]; then
+            command="$command '$call_args'"
+        fi
+
+        if [[ "$iteration" -eq 1 ]]; then
+            log_info "Running Convex migration: $migration_name..."
+        else
+            log_info "Running Convex migration: $migration_name (batch $iteration)..."
+        fi
+
+        local output=""
+        if ! output="$(run_as_service_user "$command" 2>&1)"; then
+            printf '%s\n' "$output"
+            log_warn "$migration_name failed.${call_args:+ $call_args}"
+            return 1
+        fi
+        printf '%s\n' "$output"
+
+        local progress=""
+        progress="$(node - "$output" <<'NODE'
+const vm = require('node:vm');
+const source = (process.argv[2] ?? '').trim();
+let hasMore = 0;
+let cursor = '';
+
+try {
+  const value = vm.runInNewContext(`(${source})`);
+  if (value && typeof value === 'object' && !Array.isArray(value) && value.hasMore === true) {
+    hasMore = 1;
+    cursor = typeof value.cursor === 'string' ? value.cursor : '';
+  }
+} catch {
+  hasMore = 0;
+}
+
+process.stdout.write(`${hasMore}\t${Buffer.from(cursor, 'utf8').toString('base64')}`);
+NODE
+)"
+
+        local has_more="${progress%%$'\t'*}"
+        local cursor_b64="${progress#*$'\t'}"
+
+        if [[ "$has_more" != "1" ]]; then
+            break
+        fi
+
+        if [[ -n "$cursor_b64" ]]; then
+            cursor="$(printf '%s' "$cursor_b64" | base64 --decode)"
+        else
+            cursor=""
+        fi
+        iteration=$((iteration + 1))
+
+        if [[ "$iteration" -gt 10000 ]]; then
+            log_warn "$migration_name exceeded the maximum batch iterations."
+            break
+        fi
+    done
 }
 
 create_service_user() {


### PR DESCRIPTION
## Summary
- batch the failing Convex resume migrations so each invocation processes one bounded page and returns cursor progress
- loop Convex migrations in the deploy script until  is false
- replace the remaining unbounded resume re-ingest scans with the same bounded page scan helper

## Testing
- bun run --filter '@trends/convex' build
- bun run --filter '@trends/convex' typecheck
- bunx vitest run packages/convex/convex/__tests__/migrations-batching.test.ts packages/convex/convex/__tests__/migrations-evidence-text.test.ts packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
- bash -n scripts/install.sh
- make check