### PR TITLE
Add canonical resume export flow

### DIFF
--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -1,0 +1,289 @@
+import ExcelJS from "exceljs";
+import Papa from "papaparse";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createApp } from "../app";
+import { ResumeService } from "../services/resume-service";
+
+import type { ResumeItem } from "../types/resume";
+
+type ConvexCall = {
+  pathName: string;
+  args: Record<string, unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+  const requestUrl = typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+
+  if (!requestUrl.includes("/api/query")) {
+    throw new Error(`Unexpected request URL: ${requestUrl}`);
+  }
+
+  const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+  if (!isRecord(body)) {
+    throw new Error("Missing convex request body");
+  }
+
+  const pathName = typeof body.path === "string" ? body.path : "";
+  const args = isRecord(body.args) ? body.args : {};
+  if (!pathName) {
+    throw new Error("Missing convex path in request body");
+  }
+
+  return { pathName, args };
+}
+
+function convexSuccess(value: unknown): Response {
+  return new Response(
+    JSON.stringify({
+      status: "success",
+      value,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+}
+
+function buildSampleResume(overrides: Partial<ResumeItem> & { resumeId: string; name: string }): ResumeItem {
+  return {
+    resumeId: overrides.resumeId,
+    name: overrides.name,
+    profileUrl: overrides.profileUrl ?? `https://example.com/${overrides.resumeId}`,
+    activityStatus: overrides.activityStatus ?? "Active",
+    age: overrides.age ?? "30",
+    experience: overrides.experience ?? "5 years",
+    education: overrides.education ?? "Bachelor",
+    location: overrides.location ?? "Dongguan",
+    selfIntro: overrides.selfIntro ?? "Test intro",
+    jobIntention: overrides.jobIntention ?? "Sales Engineer",
+    expectedSalary: overrides.expectedSalary ?? "10k-20k",
+    workHistory: overrides.workHistory ?? [{ raw: "Test work history" }],
+    extractedAt: overrides.extractedAt ?? "2026-03-01T00:00:00.000Z",
+    perUserId: overrides.perUserId,
+    profileId: overrides.profileId,
+    profileType: overrides.profileType,
+    externalId: overrides.externalId,
+    profileEducation: overrides.profileEducation,
+    skills: overrides.skills,
+    languages: overrides.languages,
+    licences: overrides.licences,
+    resumeSnippet: overrides.resumeSnippet,
+    currentIndustry: overrides.currentIndustry,
+    currentSubindustry: overrides.currentSubindustry,
+    rightToWork: overrides.rightToWork,
+    digitalIdentity: overrides.digitalIdentity,
+    noticePeriodDays: overrides.noticePeriodDays,
+  };
+}
+
+describe("resume export route", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exports sample-backed requests by resumeId and preserves request order", async () => {
+    vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
+      items: [
+        buildSampleResume({ resumeId: "resume-a", name: "Alice" }),
+        buildSampleResume({ resumeId: "resume-b", name: "Bob" }),
+      ],
+      sample: {
+        name: "sample-test",
+        filename: "sample-test.json",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+        size: 1,
+      },
+      metadata: undefined,
+      indexes: new Map(),
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes/export", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        format: "csv",
+        source: "sample",
+        sample: "sample-test",
+        entries: [
+          { resumeId: "resume-b", status: "contacted", userComment: "Call Bob" },
+          { resumeId: "resume-a", status: "new" },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const parsed = Papa.parse<Record<string, string>>(await response.text(), { header: true });
+    expect(parsed.data[0]?.resumeId).toBe("resume-b");
+    expect(parsed.data[0]?.name).toBe("Bob");
+    expect(parsed.data[0]?.userComment).toBe("Call Bob");
+    expect(parsed.data[1]?.resumeId).toBe("resume-a");
+    expect(parsed.data[1]?.name).toBe("Alice");
+  });
+
+  it("exports convex-backed requests via server-side Convex resolution", async () => {
+    const calls: ConvexCall[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+      if (call.pathName === "resumes:getByIdsForExport") {
+        return convexSuccess([
+          {
+            resumeId: "convex-a",
+            resume: {
+              name: "Alice",
+              age: "30",
+              experience: "5 years",
+              education: "Bachelor",
+              location: "Dongguan",
+              jobIntention: "Sales",
+              expectedSalary: "10k-20k",
+              selfIntro: "Intro A",
+              profileUrl: "https://example.com/a",
+              source: "seek",
+              workHistory: [{ raw: "Alice history" }],
+            },
+          },
+          {
+            resumeId: "convex-b",
+            resume: {
+              name: "Bob",
+              age: "32",
+              experience: "6 years",
+              education: "Bachelor",
+              location: "Shenzhen",
+              jobIntention: "Sales",
+              expectedSalary: "12k-24k",
+              selfIntro: "Intro B",
+              profileUrl: "https://example.com/b",
+              source: "seek",
+              workHistory: [{ raw: "Bob history" }],
+            },
+          },
+        ]);
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes/export", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        format: "xlsx",
+        source: "convex",
+        entries: [
+          { resumeId: "convex-b", status: "contacted" },
+          { resumeId: "convex-a", status: "new" },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      pathName: "resumes:getByIdsForExport",
+      args: {
+        resumeIds: ["convex-b", "convex-a"],
+      },
+    });
+
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(Buffer.from(await response.arrayBuffer()));
+    const sheet = workbook.getWorksheet("Resumes");
+    expect(sheet?.getCell("A2").value).toBe("convex-b");
+    expect(sheet?.getCell("B2").value).toBe("Bob");
+    expect(sheet?.getCell("A3").value).toBe("convex-a");
+    expect(sheet?.getCell("B3").value).toBe("Alice");
+  });
+
+  it("returns a clear 404 when any requested resume cannot be resolved", async () => {
+    vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
+      items: [buildSampleResume({ resumeId: "resume-a", name: "Alice" })],
+      sample: {
+        name: "sample-test",
+        filename: "sample-test.json",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+        size: 1,
+      },
+      metadata: undefined,
+      indexes: new Map(),
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes/export", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        format: "csv",
+        source: "sample",
+        sample: "sample-test",
+        entries: [
+          { resumeId: "resume-a" },
+          { resumeId: "missing-resume" },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Unable to resolve resumes for export: missing-resume",
+    });
+  });
+
+  it("keeps legacy embedded-resume payloads working during migration", async () => {
+    const app = createApp();
+    const response = await app.request("/api/resumes/export", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        format: "csv",
+        entries: [
+          {
+            key: "legacy-1",
+            status: "new",
+            resume: {
+              name: "Legacy Alice",
+              age: "29",
+              experience: "4 years",
+              education: "Bachelor",
+              location: "Dongguan",
+              jobIntention: "Sales",
+              expectedSalary: "10k-15k",
+              selfIntro: "Legacy intro",
+              profileUrl: "https://example.com/legacy-1",
+              source: "seek",
+              workHistory: [{ raw: "Legacy history" }],
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const parsed = Papa.parse<Record<string, string>>(await response.text(), { header: true });
+    expect(parsed.data[0]?.resumeId).toBe("legacy-1");
+    expect(parsed.data[0]?.name).toBe("Legacy Alice");
+  });
+});

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-import path from "node:path";
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { randomUUID } from "node:crypto";
 import {
@@ -10,6 +8,11 @@ import {
   ResumeSamplesResponseSchema,
   ResumeImportRequestSchema,
   ResumeSubmitSummarySchema,
+  ResumeExportBinaryResponseSchema,
+  ResumeExportCanonicalRequestSchema,
+  ResumeExportLegacyRequestSchema,
+  ResumeExportLegacyResumeSchema,
+  ResumeExportRequestSchema,
   MatchRequestSchema,
   MatchResponseSchema,
   ResumeMatchesResponseSchema,
@@ -20,6 +23,7 @@ import {
 import { config } from "../services/config.js";
 import { ResumeService, parseExperienceYears } from "../services/resume-service.js";
 import { DataNotFoundError } from "../services/errors.js";
+import { resolveConvexUrl } from "../services/resume-import-service.js";
 import { AIMatchingService, type MatchingRequest, type MatchingResult } from "../services/ai-matching.js";
 import {
   MatchStorage,
@@ -96,88 +100,16 @@ const LearningFeedbackRequestSchema = z.object({
 const TriggerReingestRequestSchema = z.object({
   limit: z.number().int().min(1).max(1000).optional(),
 });
-const ResumeExportRequestSchema = z.object({
-  format: z.enum(["csv", "xlsx"]).default("csv"),
-  userComment: z.string().optional(),
-  referenceNote: z.string().optional(),
-  entries: z
-    .array(
-      z.object({
-        key: z.string().min(1),
-        ruleScore: z.number().optional(),
-        action: z.string().optional(),
-        match: z
-          .object({
-            score: z.number(),
-            recommendation: z.string(),
-            scoreSource: z.enum(["rule", "ai"]).optional(),
-            summary: z.string().optional(),
-          })
-          .optional(),
-        resume: z.object({
-          name: z.string().optional(),
-          jobIntention: z.string().optional(),
-          location: z.string().optional(),
-          age: z.string().optional(),
-          experience: z.string().optional(),
-          education: z.string().optional(),
-          expectedSalary: z.string().optional(),
-          profileUrl: z.string().optional(),
-          source: z.string().optional(),
-          selfIntro: z.string().optional(),
-          workHistory: z
-            .array(
-              z.object({
-                raw: z.string().optional(),
-                companyName: z.string().optional(),
-                jobTitle: z.string().optional(),
-                description: z.string().optional(),
-                startDate: z.string().optional(),
-                endDate: z.string().optional(),
-              })
-            )
-            .optional(),
-          ingestData: z
-            .object({
-              industryTags: z.array(z.string()).optional(),
-              companyHits: z.array(z.string()).optional(),
-              roleSignals: z.array(
-                z.object({
-                  type: z.string(),
-                  matchedSignals: z.array(z.string()),
-                  signalCount: z.number(),
-                  occurrences: z.number(),
-                  years: z.number(),
-                  industryVerifiedYears: z.number().optional(),
-                  roleRelevantYears: z.number().optional(),
-                  industryVerifiedRelevantYears: z.number().optional(),
-                  matchedWorkEntries: z.array(
-                    z.object({
-                      companyName: z.string().optional(),
-                      jobTitle: z.string().optional(),
-                      years: z.number(),
-                      industryVerified: z.boolean(),
-                      matchedSignals: z.array(z.string()),
-                    })
-                  ).optional(),
-                  verifyIn: z.string(),
-                })
-              ).optional(),
-            })
-            .optional(),
-        }),
-        userComment: z.string().optional(),
-        referenceNote: z.string().optional(),
-        status: z.string().optional(),
-      })
-    )
-    .min(1)
-    .max(2000),
-});
 const ResumeImportErrorSchema = z.object({
   success: z.literal(false),
   error: z.string(),
 });
+
+type ResumeExportCanonicalRequest = z.infer<typeof ResumeExportCanonicalRequestSchema>;
+type ResumeExportRequest = z.infer<typeof ResumeExportRequestSchema>;
+type ResumeExportEntryContext = ResumeExportCanonicalRequest["entries"][number];
+type ExportResumePayload = ResumeExportEntry["resume"];
+type ResumeExportEntryFields = Omit<ResumeExportEntry, "key" | "resume">;
 
 function stripFrontMatter(content: string): string {
   const lines = content.split("\n");
@@ -260,63 +192,175 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function readEnvVarFromFile(filePath: string, key: string): string | null {
-  if (!fs.existsSync(filePath)) {
-    return null;
+async function callConvexQuery(pathName: string, args: Record<string, unknown>): Promise<unknown> {
+  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+  const response = await fetch(`${convexUrl}/api/query`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      path: pathName,
+      args,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Convex query failed (${response.status}): ${text}`);
   }
 
-  const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
-    }
+  const payload = await response.json() as {
+    status?: string;
+    value?: unknown;
+    errorMessage?: string;
+  };
 
-    const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
-    if (!match || match[1] !== key) {
-      continue;
-    }
-
-    let value = match[2].trim();
-    const hasDoubleQuotes = value.startsWith("\"") && value.endsWith("\"");
-    const hasSingleQuotes = value.startsWith("'") && value.endsWith("'");
-    if (hasDoubleQuotes || hasSingleQuotes) {
-      value = value.slice(1, -1);
-    }
-
-    return value;
+  if (payload.status !== "success") {
+    throw new Error(payload.errorMessage || `Convex query failed for ${pathName}`);
   }
 
-  return null;
+  return payload.value;
 }
 
-function resolveConvexUrl(): string {
-  if (process.env.CONVEX_URL) {
-    return process.env.CONVEX_URL;
-  }
-  if (process.env.VITE_CONVEX_URL) {
-    return process.env.VITE_CONVEX_URL;
+function toExportResumePayload(resume: ResumeItem): ExportResumePayload {
+  return {
+    name: resume.name,
+    jobIntention: resume.jobIntention,
+    location: resume.location,
+    age: resume.age,
+    experience: resume.experience,
+    education: resume.education,
+    expectedSalary: resume.expectedSalary,
+    profileUrl: resume.profileUrl,
+    source: undefined,
+    selfIntro: resume.selfIntro,
+    workHistory: resume.workHistory,
+  };
+}
+
+function toExportEntryFields(entry: ResumeExportEntryContext): ResumeExportEntryFields {
+  return {
+    match: entry.match,
+    action: entry.action,
+    status: entry.status,
+    ruleScore: entry.ruleScore,
+    userComment: entry.userComment,
+    referenceNote: entry.referenceNote,
+  };
+}
+
+function toExportEntry(key: string, resume: ExportResumePayload, fields: ResumeExportEntryFields): ResumeExportEntry {
+  return {
+    key,
+    resume,
+    ...fields,
+  };
+}
+
+async function resolveConvexExportResumeMap(
+  entries: ResumeExportEntryContext[]
+): Promise<Map<string, ExportResumePayload>> {
+  const resumeIds = Array.from(new Set(entries.map((entry) => entry.resumeId.trim()).filter(Boolean)));
+  if (resumeIds.length === 0) {
+    return new Map();
   }
 
-  const candidateFiles = [
-    path.join(config.projectRoot, "packages", "convex", ".env.local"),
-    path.join(config.projectRoot, "apps", "web", ".env.local"),
-    path.join(config.projectRoot, ".env.local"),
-    path.join(config.projectRoot, ".env"),
-  ];
+  const value = await callConvexQuery("resumes:getByIdsForExport", { resumeIds });
+  if (!Array.isArray(value)) {
+    throw new Error("Invalid export resume response from Convex");
+  }
 
-  for (const filePath of candidateFiles) {
-    const direct = readEnvVarFromFile(filePath, "CONVEX_URL");
-    if (direct) {
-      return direct;
+  const resolved = new Map<string, ExportResumePayload>();
+  value.forEach((item) => {
+    if (!isRecord(item) || typeof item.resumeId !== "string" || item.resumeId.length === 0) {
+      return;
     }
-    const vite = readEnvVarFromFile(filePath, "VITE_CONVEX_URL");
-    if (vite) {
-      return vite;
+    const resumeId = item.resumeId;
+    const parsedResume = ResumeExportLegacyResumeSchema.safeParse(item.resume);
+    if (!parsedResume.success) {
+      return;
     }
+    resolved.set(resumeId, parsedResume.data);
+  });
+
+  return resolved;
+}
+
+function resolveSampleExportResumeMap(
+  sampleName: string,
+  entries: ResumeExportEntryContext[]
+): Map<string, ExportResumePayload> {
+  const { items } = resumeService.loadSample(sampleName);
+  const requestedIds = new Set(entries.map((entry) => entry.resumeId.trim()).filter(Boolean));
+  const resolved = new Map<string, ExportResumePayload>();
+
+  items.forEach((resume, index) => {
+    const resumeId = resolveResumeId(resume, index);
+    if (!requestedIds.has(resumeId)) {
+      return;
+    }
+    resolved.set(resumeId, toExportResumePayload(resume));
+  });
+
+  return resolved;
+}
+
+function buildExportEntriesFromResolvedResumes(
+  entries: ResumeExportEntryContext[],
+  resolvedResumes: Map<string, ExportResumePayload>
+): ResumeExportEntry[] {
+  const missingIds: string[] = [];
+  const resolvedEntries = entries.flatMap((entry) => {
+    const resume = resolvedResumes.get(entry.resumeId);
+    if (!resume) {
+      missingIds.push(entry.resumeId);
+      return [];
+    }
+
+    return [toExportEntry(entry.resumeId, resume, toExportEntryFields(entry))];
+  });
+
+  if (missingIds.length > 0) {
+    throw new DataNotFoundError(`Unable to resolve resumes for export: ${missingIds.join(", ")}`);
   }
 
-  return "http://127.0.0.1:3210";
+  return resolvedEntries;
+}
+
+function isCanonicalExportRequest(
+  value: ResumeExportRequest
+): value is ResumeExportCanonicalRequest {
+  return "source" in value;
+}
+
+async function resolveExportRequest(
+  request: ResumeExportRequest
+): Promise<{ format: ExportFormat; entries: ResumeExportEntry[]; batchMeta: ExportBatchMeta }> {
+  if (!isCanonicalExportRequest(request)) {
+    return {
+      format: request.format,
+      entries: request.entries.map((entry) => toExportEntry(entry.key, entry.resume, toExportEntryFields(entry))),
+      batchMeta: {
+        userComment: request.userComment,
+        referenceNote: request.referenceNote,
+      },
+    };
+  }
+
+  const resolvedResumes = request.source === "sample"
+    ? resolveSampleExportResumeMap(request.sample ?? "", request.entries)
+    : await resolveConvexExportResumeMap(request.entries);
+
+  return {
+    format: request.format,
+    entries: buildExportEntriesFromResolvedResumes(request.entries, resolvedResumes),
+    batchMeta: {
+      userComment: request.userComment,
+      referenceNote: request.referenceNote,
+    },
+  };
 }
 
 async function triggerReingestStaleSkillsVersion(limit: number): Promise<{
@@ -1611,6 +1655,45 @@ app.openapi(clearResumeMatchesRoute, (c) => {
   }, 200);
 });
 
+const exportResumesRoute = createRoute({
+  method: "post",
+  path: "/api/resumes/export",
+  tags: ["resumes"],
+  summary: "Export resumes as CSV or XLSX",
+  description: "Exports selected resumes using a canonical resumeId-based request or the legacy embedded-resume payload.",
+  request: {
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: ResumeExportRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "text/csv": {
+          schema: ResumeExportBinaryResponseSchema,
+        },
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
+          schema: ResumeExportBinaryResponseSchema,
+        },
+      },
+      description: "Exported CSV or XLSX file",
+    },
+    404: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Sample or selected resumes could not be resolved",
+    },
+    500: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Export failed",
+    },
+  },
+});
+
 const rescoreResumeMatchesRoute = createRoute({
   method: "post",
   path: "/api/resumes/matches/rescore",
@@ -1786,21 +1869,11 @@ app.openapi(rescoreResumeMatchesRoute, (c) => {
   );
 });
 
-app.post("/api/resumes/export", async (c) => {
-  const body = await c.req.json().catch(() => ({}));
-  const parsed = ResumeExportRequestSchema.safeParse(body);
-  if (!parsed.success) {
-    return c.json({ success: false, error: "Invalid request body" }, 400);
-  }
-
-  const format: ExportFormat = parsed.data.format;
-  const entries: ResumeExportEntry[] = parsed.data.entries;
-  const batchMeta: ExportBatchMeta = {
-    userComment: parsed.data.userComment,
-    referenceNote: parsed.data.referenceNote,
-  };
+app.openapi(exportResumesRoute, async (c) => {
+  const request = c.req.valid("json");
 
   try {
+    const { format, entries, batchMeta } = await resolveExportRequest(request);
     const file = await exportService.exportResumes(format, entries, batchMeta);
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
     const filename = `resumes-export-${timestamp}.${file.extension}`;
@@ -1815,6 +1888,9 @@ app.post("/api/resumes/export", async (c) => {
       },
     });
   } catch (error) {
+    if (error instanceof DataNotFoundError) {
+      return c.json({ success: false, error: error.message }, 404);
+    }
     console.error("Failed to export resumes:", error);
     const message = error instanceof Error ? error.message : String(error);
     return c.json({ success: false, error: message }, 500);

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -490,6 +490,140 @@ export const ResumeMatchSchema = z
   })
   .openapi("ResumeMatch");
 
+export const ResumeExportSourceSchema = z.enum(["sample", "convex"]).openapi("ResumeExportSource");
+
+export const ResumeExportMatchSchema = z
+  .object({
+    score: z.number().openapi({ example: 88 }),
+    recommendation: RecommendationSchema.openapi({ example: "strong_match" }),
+    scoreSource: ScoreSourceSchema.optional().openapi({ example: "ai" }),
+    summary: z.string().optional().openapi({ example: "Strong CNC sales fit." }),
+  })
+  .openapi("ResumeExportMatch");
+
+export const ResumeExportEntryContextSchema = z
+  .object({
+    resumeId: z.string().min(1).openapi({ example: "resume-1" }),
+    ruleScore: z.number().optional().openapi({ example: 72 }),
+    action: z.string().optional().openapi({ example: "shortlist" }),
+    match: ResumeExportMatchSchema.optional(),
+    userComment: z.string().optional().openapi({ example: "Call back tomorrow" }),
+    referenceNote: z.string().optional().openapi({ example: "Referred by HR" }),
+    status: z.string().optional().openapi({ example: "contacted" }),
+  })
+  .openapi("ResumeExportEntryContext");
+
+export const ResumeExportCanonicalRequestSchema = z
+  .object({
+    format: z.enum(["csv", "xlsx"]).default("csv").openapi({ example: "csv" }),
+    source: ResumeExportSourceSchema,
+    sample: z.string().optional().openapi({ example: "sample-initial" }),
+    userComment: z.string().optional().openapi({ example: "Batch note" }),
+    referenceNote: z.string().optional().openapi({ example: "Internal export" }),
+    entries: z.array(ResumeExportEntryContextSchema).min(1).max(2000),
+  })
+  .superRefine((value, ctx) => {
+    if (value.source === "sample" && !value.sample?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "sample is required when source is sample",
+        path: ["sample"],
+      });
+    }
+    if (value.source === "convex" && value.sample !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "sample is only allowed when source is sample",
+        path: ["sample"],
+      });
+    }
+  })
+  .openapi("ResumeExportCanonicalRequest");
+
+const ResumeExportLegacyWorkHistorySchema = z.object({
+  raw: z.string().optional(),
+  companyName: z.string().optional(),
+  jobTitle: z.string().optional(),
+  description: z.string().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+});
+
+const ResumeExportLegacyRoleSignalSchema = z.object({
+  type: z.string(),
+  matchedSignals: z.array(z.string()),
+  signalCount: z.number().optional(),
+  occurrences: z.number().optional(),
+  years: z.number(),
+  industryVerifiedYears: z.number().optional(),
+  roleRelevantYears: z.number().optional(),
+  industryVerifiedRelevantYears: z.number().optional(),
+  matchedWorkEntries: z
+    .array(
+      z.object({
+        companyName: z.string().optional(),
+        jobTitle: z.string().optional(),
+        years: z.number(),
+        industryVerified: z.boolean(),
+        matchedSignals: z.array(z.string()),
+      })
+    )
+    .optional(),
+  verifyIn: z.string().optional(),
+});
+
+export const ResumeExportLegacyResumeSchema = z.object({
+  name: z.string().optional(),
+  jobIntention: z.string().optional(),
+  location: z.string().optional(),
+  age: z.string().optional(),
+  experience: z.string().optional(),
+  education: z.string().optional(),
+  expectedSalary: z.string().optional(),
+  profileUrl: z.string().optional(),
+  source: z.string().optional(),
+  selfIntro: z.string().optional(),
+  workHistory: z.array(ResumeExportLegacyWorkHistorySchema).optional(),
+  ingestData: z
+    .object({
+      industryTags: z.array(z.string()).optional(),
+      companyHits: z.array(z.string()).optional(),
+      roleSignals: z.array(ResumeExportLegacyRoleSignalSchema).optional(),
+    })
+    .optional(),
+});
+
+export const ResumeExportLegacyRequestSchema = z
+  .object({
+    format: z.enum(["csv", "xlsx"]).default("csv"),
+    userComment: z.string().optional(),
+    referenceNote: z.string().optional(),
+    entries: z
+      .array(
+        z.object({
+          key: z.string().min(1),
+          ruleScore: z.number().optional(),
+          action: z.string().optional(),
+          match: ResumeExportMatchSchema.optional(),
+          resume: ResumeExportLegacyResumeSchema,
+          userComment: z.string().optional(),
+          referenceNote: z.string().optional(),
+          status: z.string().optional(),
+        })
+      )
+      .min(1)
+      .max(2000),
+  })
+  .openapi("ResumeExportLegacyRequest");
+
+export const ResumeExportRequestSchema = z
+  .union([ResumeExportCanonicalRequestSchema, ResumeExportLegacyRequestSchema])
+  .openapi("ResumeExportRequest");
+
+export const ResumeExportBinaryResponseSchema = z
+  .string()
+  .openapi({ format: "binary" });
+
 export const MatchRequestSchema = z
   .object({
     sessionId: z.string().optional().openapi({ example: "session-123" }),

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -196,4 +196,35 @@ describe("ExportService", () => {
     expect(parsed.data[0]?.matchedWorkEntries).toContain("sales · Example Co. · Sales Engineer");
     expect(parsed.data[0]?.matchedWorkEntries).toContain("verified");
   });
+
+  it("keeps CSV and XLSX headers aligned", async () => {
+    const service = new ExportService();
+    const csvFile = await service.exportResumes("csv", [buildEntry("27")]);
+    const xlsxFile = await service.exportResumes("xlsx", [buildEntry("27")]);
+    const csvParsed = Papa.parse<Record<string, string>>(csvFile.content.toString("utf8"), { header: true });
+    const csvHeaders = csvParsed.meta.fields ?? [];
+
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(xlsxFile.content);
+    const sheet = workbook.getWorksheet("Resumes");
+    const xlsxHeaders = ((sheet?.getRow(1).values as unknown[]) ?? [])
+      .filter((value): value is string => typeof value === "string");
+
+    const normalizedCsvHeaders = csvHeaders.map((header) =>
+      header
+        .replace(/([A-Z]+)/g, " $1")
+        .trim()
+        .split(/\s+/)
+        .map((part) => {
+          const lower = part.toLowerCase();
+          if (lower === "id") return "ID";
+          if (lower === "ai") return "AI";
+          if (lower === "url") return "URL";
+          return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+        })
+        .join(" ")
+    );
+
+    expect(xlsxHeaders).toEqual(normalizedCsvHeaders);
+  });
 });

--- a/apps/api/src/services/resume-id.ts
+++ b/apps/api/src/services/resume-id.ts
@@ -1,11 +1,6 @@
+import { resolveResumeId as resolveSharedResumeId } from "@trends/shared";
 import type { ResumeItem } from "../types/resume.js";
 
 export function resolveResumeId(resume: ResumeItem, index: number): string {
-  if (resume.resumeId) return String(resume.resumeId);
-  if (resume.perUserId) return String(resume.perUserId);
-  if (resume.profileId) return String(resume.profileId);
-  if (resume.externalId) return String(resume.externalId);
-  if (resume.profileUrl && resume.profileUrl !== "javascript:;") return resume.profileUrl;
-  if (resume.extractedAt) return `${resume.name || "resume"}-${resume.extractedAt}`;
-  return `${resume.name || "resume"}-${index}`;
+  return resolveSharedResumeId(resume, index);
 }

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -621,12 +621,14 @@ describe('useResumeListState role filter regression', () => {
     const requestInit = requestCall?.[1] as RequestInit | undefined
     expect(requestInit?.body).toBeDefined()
     const parsedBody = JSON.parse(String(requestInit?.body)) as {
-      entries: Array<{ key: string; userComment?: string; status?: string }>
+      source: string
+      entries: Array<{ resumeId: string; userComment?: string; status?: string }>
       format: string
     }
     expect(parsedBody.format).toBe('csv')
+    expect(parsedBody.source).toBe('convex')
     expect(parsedBody.entries).toContainEqual(expect.objectContaining({
-      key: 'resume-ideal-cnc-sales',
+      resumeId: 'resume-ideal-cnc-sales',
       status: 'contacted',
       userComment: 'Call back tomorrow',
     }))

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -18,6 +18,7 @@ import {
   type ExperienceLevelFilter,
 } from '@/hooks/useUrlSearchState'
 import { rawApiClient } from '@/lib/api-helpers'
+import type { components } from '@/lib/api-types'
 import type { SearchHistoryItem } from '@/hooks/useSession'
 import {
   aiFeedbackToActionType,
@@ -47,6 +48,8 @@ type JobDescriptionApiResponse = {
   }
   content?: string
 }
+
+type ResumeExportRequestBody = components['schemas']['ResumeExportCanonicalRequest']
 
 type ScoredConvexResume = ConvexResumeItem & {
   _ruleScore: number
@@ -1167,9 +1170,13 @@ export function useResumeListState(loadSearchHistory = false) {
       }
 
       if (action === 'export') {
-        const exportEntries = selectedEntries.map(({ key, resume, match, action: currentAction, ruleScore, status, statusMeta }) => ({
-          key,
-          resume,
+        if (mode !== 'ai' && !selectedSample) {
+          toast.error(t('bulk.exportFailed', { defaultValue: 'Export failed: sample context is missing. Please refresh and try again.' }))
+          return
+        }
+
+        const exportEntries = selectedEntries.map(({ key, match, action: currentAction, ruleScore, status, statusMeta }) => ({
+          resumeId: key,
           match,
           action: currentAction,
           status,
@@ -1177,6 +1184,12 @@ export function useResumeListState(loadSearchHistory = false) {
           userComment: normalizeOptionalString(statusMeta?.notes),
         }))
         const exportFormat = format ?? bulkExportFormat
+        const exportRequest: ResumeExportRequestBody = {
+          format: exportFormat,
+          source: mode === 'ai' ? 'convex' : 'sample',
+          entries: exportEntries,
+          ...(mode === 'ai' ? {} : { sample: selectedSample }),
+        }
 
         try {
           const response = await fetch(`${apiBaseUrl}/api/resumes/export`, {
@@ -1184,10 +1197,7 @@ export function useResumeListState(loadSearchHistory = false) {
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify({
-              format: exportFormat,
-              entries: exportEntries,
-            }),
+            body: JSON.stringify(exportRequest),
           })
 
           if (!response.ok) {
@@ -1226,7 +1236,10 @@ export function useResumeListState(loadSearchHistory = false) {
           return
         } catch (error) {
           console.error('Export failed', error)
-          toast.error(t('bulk.exportFailed', { defaultValue: 'Export failed. Please try again.' }))
+          const message = error instanceof Error && error.message.trim().length > 0
+            ? error.message
+            : t('bulk.exportFailed', { defaultValue: 'Export failed. Please try again.' })
+          toast.error(message)
           return
         }
       }
@@ -1250,7 +1263,7 @@ export function useResumeListState(loadSearchHistory = false) {
         toast.error(t('bulk.actionFailed', { defaultValue: 'Bulk action failed. Please try again.' }))
       }
     },
-    [apiBaseUrl, blockCandidates, bulkExportFormat, displayedResumes, saveAction, selectedIds, sendLearningFeedback, t]
+    [apiBaseUrl, blockCandidates, bulkExportFormat, displayedResumes, mode, saveAction, selectedIds, selectedSample, sendLearningFeedback, t]
   )
 
   const actionFeedbackLabels = useMemo<Partial<Record<CandidateActionType, string>>>(

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -744,6 +744,76 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/resumes/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Export resumes as CSV or XLSX
+         * @description Exports selected resumes using a canonical resumeId-based request or the legacy embedded-resume payload.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ResumeExportRequest"];
+                };
+            };
+            responses: {
+                /** @description Exported CSV or XLSX file */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/csv": string;
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": string;
+                    };
+                };
+                /** @description Sample or selected resumes could not be resolved */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Export failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/resumes/verify-token": {
         parameters: {
             query?: never;
@@ -4230,6 +4300,116 @@ export interface components {
             resumes?: components["schemas"]["ResumeImportItem"][];
             data?: components["schemas"]["ResumeImportItem"][];
         };
+        /** @enum {string} */
+        ResumeExportSource: "sample" | "convex";
+        ResumeExportMatch: {
+            /** @example 88 */
+            score: number;
+            /**
+             * @example strong_match
+             * @enum {string}
+             */
+            recommendation: "strong_match" | "match" | "potential" | "no_match";
+            /**
+             * @example ai
+             * @enum {string}
+             */
+            scoreSource?: "rule" | "ai";
+            /** @example Strong CNC sales fit. */
+            summary?: string;
+        };
+        ResumeExportEntryContext: {
+            /** @example resume-1 */
+            resumeId: string;
+            /** @example 72 */
+            ruleScore?: number;
+            /** @example shortlist */
+            action?: string;
+            match?: components["schemas"]["ResumeExportMatch"];
+            /** @example Call back tomorrow */
+            userComment?: string;
+            /** @example Referred by HR */
+            referenceNote?: string;
+            /** @example contacted */
+            status?: string;
+        };
+        ResumeExportCanonicalRequest: {
+            /**
+             * @default csv
+             * @example csv
+             * @enum {string}
+             */
+            format: "csv" | "xlsx";
+            source: components["schemas"]["ResumeExportSource"];
+            /** @example sample-initial */
+            sample?: string;
+            /** @example Batch note */
+            userComment?: string;
+            /** @example Internal export */
+            referenceNote?: string;
+            entries: components["schemas"]["ResumeExportEntryContext"][];
+        };
+        ResumeExportLegacyRequest: {
+            /**
+             * @default csv
+             * @enum {string}
+             */
+            format: "csv" | "xlsx";
+            userComment?: string;
+            referenceNote?: string;
+            entries: {
+                key: string;
+                ruleScore?: number;
+                action?: string;
+                match?: components["schemas"]["ResumeExportMatch"];
+                resume: {
+                    name?: string;
+                    jobIntention?: string;
+                    location?: string;
+                    age?: string;
+                    experience?: string;
+                    education?: string;
+                    expectedSalary?: string;
+                    profileUrl?: string;
+                    source?: string;
+                    selfIntro?: string;
+                    workHistory?: {
+                        raw?: string;
+                        companyName?: string;
+                        jobTitle?: string;
+                        description?: string;
+                        startDate?: string;
+                        endDate?: string;
+                    }[];
+                    ingestData?: {
+                        industryTags?: string[];
+                        companyHits?: string[];
+                        roleSignals?: {
+                            type: string;
+                            matchedSignals: string[];
+                            signalCount?: number;
+                            occurrences?: number;
+                            years: number;
+                            industryVerifiedYears?: number;
+                            roleRelevantYears?: number;
+                            industryVerifiedRelevantYears?: number;
+                            matchedWorkEntries?: {
+                                companyName?: string;
+                                jobTitle?: string;
+                                years: number;
+                                industryVerified: boolean;
+                                matchedSignals: string[];
+                            }[];
+                            verifyIn?: string;
+                        }[];
+                    };
+                };
+                userComment?: string;
+                referenceNote?: string;
+                status?: string;
+            }[];
+        };
+        ResumeExportRequest: components["schemas"]["ResumeExportCanonicalRequest"] | components["schemas"]["ResumeExportLegacyRequest"];
         ResumeFilters: {
             minExperience?: number;
             maxExperience?: number;

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -34,6 +34,8 @@ type TestResume = {
   extractedAt: string
   resumeId?: string
   perUserId?: string
+  profileId?: string
+  externalId?: string
   ingestData?: {
     evidenceText?: string
     industryTags: string[]
@@ -112,10 +114,13 @@ describe('resume-scoring', () => {
     expect(toMatchBreakdown(undefined)).toBeUndefined()
   })
 
-  it('prefers resumeId then perUserId then profileUrl for resume key', () => {
+  it('matches the API resume id fallback order for resume keys', () => {
     expect(buildResumeKey(createResume({ resumeId: 'r-1', perUserId: 'u-1', profileUrl: 'https://a.com' }), 0)).toBe('r-1')
     expect(buildResumeKey(createResume({ resumeId: undefined, perUserId: 'u-1', profileUrl: 'https://a.com' }), 0)).toBe('u-1')
+    expect(buildResumeKey(createResume({ resumeId: undefined, perUserId: undefined, profileId: 'p-1', profileUrl: 'https://a.com' }), 0)).toBe('p-1')
+    expect(buildResumeKey(createResume({ resumeId: undefined, perUserId: undefined, profileId: undefined, externalId: 'ext-1', profileUrl: 'https://a.com' }), 0)).toBe('ext-1')
     expect(buildResumeKey(createResume({ resumeId: undefined, perUserId: undefined, profileUrl: 'https://a.com' }), 0)).toBe('https://a.com')
+    expect(buildResumeKey(createResume({ resumeId: undefined, perUserId: undefined, profileUrl: '', extractedAt: '2026-03-01T00:00:00.000Z', name: 'Alice' }), 0)).toBe('Alice-2026-03-01T00:00:00.000Z')
   })
 
   it('reads precomputed rule score from ingest data', () => {

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -1,4 +1,4 @@
-import { buildWorkHistoryEntryText } from '@trends/shared'
+import { buildWorkHistoryEntryText, resolveResumeId } from '@trends/shared'
 import type { ResumeItem } from '@/hooks/useResumes'
 import type { ConvexResumeAnalysis } from '@/hooks/useConvexResumes'
 import type { MatchBreakdown, Recommendation } from '@/types/resume'
@@ -134,16 +134,7 @@ export function isSafeProfileUrl(value: string | undefined): value is string {
 }
 
 export function buildResumeKey(resume: ResumeItem, index: number): string {
-  if (resume.resumeId) {
-    return resume.resumeId
-  }
-  if (resume.perUserId) {
-    return resume.perUserId
-  }
-  if (isSafeProfileUrl(resume.profileUrl)) {
-    return resume.profileUrl
-  }
-  return `${resume.name}-${resume.extractedAt || index}`
+  return resolveResumeId(resume, index)
 }
 
 export function buildRuleScoringText(resume: {

--- a/packages/cli/cmd/resume.go
+++ b/packages/cli/cmd/resume.go
@@ -129,15 +129,20 @@ func newResumeExportCmd() *cobra.Command {
 			entries := make([]client.ResumeExportEntry, 0, len(resumes.Data))
 			for index, item := range resumes.Data {
 				entries = append(entries, client.ResumeExportEntry{
-					Key:    resumeIdentifier(item, index),
-					Resume: item,
+					ResumeID: resumeIdentifier(item, index),
 				})
 			}
 
-			payload, disposition, err := newAPIClient().ExportResumes(context.Background(), client.ResumeExportRequest{
+			request := client.ResumeExportRequest{
 				Format:  format,
+				Source:  "sample",
 				Entries: entries,
-			})
+			}
+			if resumes.Sample != nil && strings.TrimSpace(resumes.Sample.Name) != "" {
+				request.Sample = resumes.Sample.Name
+			}
+
+			payload, disposition, err := newAPIClient().ExportResumes(context.Background(), request)
 			if err != nil {
 				return err
 			}
@@ -182,6 +187,12 @@ func resumeIdentifier(item client.ResumeItem, index int) string {
 	}
 	if strings.TrimSpace(item.PerUserID) != "" {
 		return item.PerUserID
+	}
+	if strings.TrimSpace(item.ProfileID) != "" {
+		return item.ProfileID
+	}
+	if strings.TrimSpace(item.ExternalID) != "" {
+		return item.ExternalID
 	}
 	return fmt.Sprintf("resume-%d", index+1)
 }

--- a/packages/cli/internal/client/api.go
+++ b/packages/cli/internal/client/api.go
@@ -12,12 +12,21 @@ import (
 type ResumeItem struct {
 	ResumeID       string `json:"resumeId"`
 	PerUserID      string `json:"perUserId"`
+	ProfileID      string `json:"profileId"`
+	ExternalID     string `json:"externalId"`
 	Name           string `json:"name"`
 	JobIntention   string `json:"jobIntention"`
 	Location       string `json:"location"`
 	Experience     string `json:"experience"`
 	Education      string `json:"education"`
 	ExpectedSalary string `json:"expectedSalary"`
+}
+
+type ResumeSample struct {
+	Name      string `json:"name"`
+	Filename  string `json:"filename"`
+	UpdatedAt string `json:"updatedAt"`
+	Size      int64  `json:"size"`
 }
 
 type ResumesSummary struct {
@@ -29,6 +38,7 @@ type ResumesSummary struct {
 type ResumesResponse struct {
 	Success bool           `json:"success"`
 	Data    []ResumeItem   `json:"data"`
+	Sample  *ResumeSample  `json:"sample,omitempty"`
 	Summary ResumesSummary `json:"summary"`
 }
 
@@ -58,13 +68,14 @@ type CreateJobDescriptionResponse struct {
 }
 
 type ResumeExportEntry struct {
-	Key       string     `json:"key"`
-	Resume    ResumeItem `json:"resume"`
+	ResumeID  string     `json:"resumeId"`
 	RuleScore *float64   `json:"ruleScore,omitempty"`
 }
 
 type ResumeExportRequest struct {
 	Format  string              `json:"format"`
+	Source  string              `json:"source"`
+	Sample  string              `json:"sample,omitempty"`
 	Entries []ResumeExportEntry `json:"entries"`
 }
 

--- a/packages/cli/internal/client/api_test.go
+++ b/packages/cli/internal/client/api_test.go
@@ -74,6 +74,12 @@ func TestExportResumesUsesBinaryEndpoint(t *testing.T) {
 		if payload.Format != "csv" {
 			t.Fatalf("expected default format csv, got %q", payload.Format)
 		}
+		if payload.Source != "sample" {
+			t.Fatalf("expected source sample, got %q", payload.Source)
+		}
+		if len(payload.Entries) != 1 || payload.Entries[0].ResumeID != "r1" {
+			t.Fatalf("unexpected export entries: %+v", payload.Entries)
+		}
 
 		w.Header().Set("Content-Disposition", `attachment; filename="out.csv"`)
 		_, _ = w.Write([]byte("x,y\n"))
@@ -84,8 +90,9 @@ func TestExportResumesUsesBinaryEndpoint(t *testing.T) {
 	c.HTTP = server.Client()
 
 	content, disposition, err := c.ExportResumes(context.Background(), ResumeExportRequest{
+		Source: "sample",
 		Entries: []ResumeExportEntry{
-			{Key: "r1", Resume: ResumeItem{Name: "Alice"}},
+			{ResumeID: "r1"},
 		},
 	})
 	if err != nil {

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -19,6 +19,11 @@ function toStringValue(value: unknown): string {
     return String(value).trim();
 }
 
+function toOptionalStringValue(value: unknown): string | undefined {
+    const normalized = toStringValue(value);
+    return normalized.length > 0 ? normalized : undefined;
+}
+
 function toRuleScores(value: unknown): Record<string, number> {
     if (!isRecord(value)) {
         return {};
@@ -560,6 +565,44 @@ export const getResume = internalQuery({
     args: { resumeId: v.id("resumes") },
     handler: async (ctx, args) => {
         return await ctx.db.get(args.resumeId);
+    },
+});
+
+export const getByIdsForExport = query({
+    args: {
+        resumeIds: v.array(v.id("resumes")),
+    },
+    handler: async (ctx, args) => {
+        const docs = await Promise.all(args.resumeIds.map((resumeId) => ctx.db.get(resumeId)));
+        return docs
+            .filter((doc): doc is NonNullable<typeof doc> => doc !== null)
+            .map((doc) => {
+                const content = isRecord(doc.content) ? doc.content : {};
+                return {
+                    resumeId: String(doc._id),
+                    resume: {
+                        name: toOptionalStringValue(content.name),
+                        jobIntention: toOptionalStringValue(content.jobIntention),
+                        location: toOptionalStringValue(content.location),
+                        age: toOptionalStringValue(content.age) ?? (typeof doc.age === "number" ? String(doc.age) : undefined),
+                        experience: toOptionalStringValue(content.experience),
+                        education: toOptionalStringValue(content.education),
+                        expectedSalary: toOptionalStringValue(content.expectedSalary),
+                        profileUrl: toOptionalStringValue(content.profileUrl)
+                            ?? toOptionalStringValue(content.profile_url)
+                            ?? toOptionalStringValue(content.profileURL)
+                            ?? toOptionalStringValue(content.url),
+                        source: doc.source,
+                        selfIntro: toOptionalStringValue(content.selfIntro),
+                        workHistory: Array.isArray(content.workHistory) ? content.workHistory : undefined,
+                        ingestData: doc.ingestData ? {
+                            industryTags: doc.ingestData.industryTags,
+                            companyHits: doc.ingestData.companyHits,
+                            roleSignals: doc.ingestData.roleSignals,
+                        } : undefined,
+                    },
+                };
+            });
     },
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,3 +5,4 @@ export * from "./job-description-content.js";
 export * from "./work-history-evidence.js";
 export * from "./generated/resume-ai-prompts.js";
 export * from "./resume-normalization.js";
+export * from "./resume-id.js";

--- a/packages/shared/src/resume-id.ts
+++ b/packages/shared/src/resume-id.ts
@@ -1,0 +1,19 @@
+type ResumeIdentityLike = {
+  resumeId?: string | null
+  perUserId?: string | null
+  profileId?: string | null
+  externalId?: string | null
+  profileUrl?: string | null
+  extractedAt?: string | null
+  name?: string | null
+}
+
+export function resolveResumeId(resume: ResumeIdentityLike, index: number): string {
+  if (resume.resumeId) return String(resume.resumeId)
+  if (resume.perUserId) return String(resume.perUserId)
+  if (resume.profileId) return String(resume.profileId)
+  if (resume.externalId) return String(resume.externalId)
+  if (resume.profileUrl && resume.profileUrl !== 'javascript:;') return resume.profileUrl
+  if (resume.extractedAt) return `${resume.name || 'resume'}-${resume.extractedAt}`
+  return `${resume.name || 'resume'}-${index}`
+}


### PR DESCRIPTION
## Summary
- add a canonical `/api/resumes/export` contract that resolves resume payloads from sample or Convex ids while keeping legacy export requests working
- update web and CLI export callers to send source-aware resume id payloads and share resume id fallback logic via `@trends/shared`
- add backend/export tests and rebase the branch onto the latest `main`, resolving the Convex conflict around string normalization

## Test plan
- [x] `cd /root/workspace/packages/shared && bun run build`
- [x] `cd /root/workspace/packages/cli && go test ./internal/client/...`
- [ ] `bun test apps/web/src/lib/resume-scoring.test.ts apps/web/src/hooks/useResumeListState.test.tsx apps/api/src/services/export-service.test.ts` *(fails in existing test setup: `vi.hoisted is not a function`)*