### PR TITLE
fix(api): widen export entry type to fix deploy build error

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -108,6 +108,7 @@ const ResumeImportErrorSchema = z.object({
 type ResumeExportCanonicalRequest = z.infer<typeof ResumeExportCanonicalRequestSchema>;
 type ResumeExportRequest = z.infer<typeof ResumeExportRequestSchema>;
 type ResumeExportEntryContext = ResumeExportCanonicalRequest["entries"][number];
+type ResumeExportLegacyEntryContext = z.infer<typeof ResumeExportLegacyRequestSchema>["entries"][number];
 type ExportResumePayload = ResumeExportEntry["resume"];
 type ResumeExportEntryFields = Omit<ResumeExportEntry, "key" | "resume">;
 
@@ -240,7 +241,7 @@ function toExportResumePayload(resume: ResumeItem): ExportResumePayload {
   };
 }
 
-function toExportEntryFields(entry: ResumeExportEntryContext): ResumeExportEntryFields {
+function toExportEntryFields(entry: ResumeExportEntryContext | ResumeExportLegacyEntryContext): ResumeExportEntryFields {
   return {
     match: entry.match,
     action: entry.action,


### PR DESCRIPTION
## Summary
- Fixes TS2345 build error in `apps/api/src/routes/resumes.ts:344` blocking `make deploy` on ptcloud
- `toExportEntryFields` was typed to only accept canonical export entries (requiring `resumeId`), but is also called with legacy entries (which have `key`+`resume` instead)
- Adds `ResumeExportLegacyEntryContext` union type to accept both entry shapes

## Test plan
- [x] `make check` passes (all typecheck, lint, tests green)
- [x] `npm run --workspace @trends/api build` succeeds