### PR TITLE
fix(convex): paginate hardResetIngestData to avoid 16MB limit

### DIFF
--- a/apps/web/src/pages/DebugIngest.tsx
+++ b/apps/web/src/pages/DebugIngest.tsx
@@ -232,14 +232,20 @@ export default function DebugIngest() {
   const hardResetAndReIngest = useCallback(async () => {
     setHardResetting(true)
     try {
-      const result = await hardResetIngestDataMutation({})
+      let totalCleared = 0
+      let cursor: string | undefined
+      do {
+        const result = await hardResetIngestDataMutation({ cursor })
+        totalCleared += result.cleared
+        cursor = result.hasMore ? (result.cursor ?? undefined) : undefined
+      } while (cursor)
       const backfillResult = await backfillIngestData({ limit: 500 })
       setHardResetDialogOpen(false)
       toast.success(
         t('debugIngest.hardResetSuccess', {
-          cleared: result.cleared,
+          cleared: totalCleared,
           scheduled: backfillResult.scheduled,
-          defaultValue: `Cleared computed data for ${result.cleared} resumes and scheduled ${backfillResult.scheduled} resumes for re-ingest.`,
+          defaultValue: `Cleared computed data for ${totalCleared} resumes and scheduled ${backfillResult.scheduled} resumes for re-ingest.`,
         })
       )
       await loadSkillsVersion()

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -959,12 +959,21 @@ export const clearAnalyses = mutation({
 });
 
 export const hardResetIngestData = mutation({
-    args: {},
-    handler: async (ctx) => {
-        const resumes = await ctx.db.query("resumes").collect();
+    args: {
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const resumes = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.batchSize),
+            });
         let cleared = 0;
 
-        for (const resume of resumes) {
+        for (const resume of resumes.page) {
             const hasComputedFields = resume.ingestData !== undefined
                 || resume.analysis !== undefined
                 || resume.analyses !== undefined
@@ -985,6 +994,10 @@ export const hardResetIngestData = mutation({
             cleared += 1;
         }
 
-        return { cleared };
+        return {
+            cleared,
+            hasMore: !resumes.isDone,
+            cursor: resumes.isDone ? null : resumes.continueCursor,
+        };
     },
 });


### PR DESCRIPTION
## Summary
- `hardResetIngestData` used `.collect()` which hits Convex 16MB read limit with ~2000 resumes
- Converted to paginated pattern (cursor + batchSize args) matching existing `reindexSearchText`
- Updated DebugIngest UI to loop through all pages before triggering backfill

## Test plan
- [x] `make check` passes
- [ ] Deploy to ptcloud, run `npx convex run resumes:hardResetIngestData` successfully
- [ ] DebugIngest "Hard Reset" button works end-to-end