### PR TITLE
fix resume export downloads in Chrome

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -64,7 +64,7 @@ export function createApp() {
     "*",
     cors({
       origin: "*",
-      exposeHeaders: ["Content-Disposition"],
+      exposeHeaders: ["Content-Disposition", "Content-Length"],
     })
   );
   app.use("*", logger());

--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -88,6 +88,21 @@ function buildSampleResume(overrides: Partial<ResumeItem> & { resumeId: string; 
   };
 }
 
+function expectAttachmentHeaders(response: Response, extension: "csv" | "xlsx") {
+  expect(response.headers.get("content-type")).toBe(
+    extension === "csv"
+      ? "text/csv; charset=utf-8"
+      : "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+  );
+  expect(response.headers.get("content-disposition")).toMatch(
+    extension === "csv"
+      ? /^attachment; filename="resumes-export-.+\.csv"$/
+      : /^attachment; filename="resumes-export-.+\.xlsx"$/
+  );
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  expect(response.headers.get("content-length")).toBeTruthy();
+}
+
 describe("resume export route", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -127,6 +142,7 @@ describe("resume export route", () => {
     });
 
     expect(response.status).toBe(200);
+    expectAttachmentHeaders(response, "csv");
     const parsed = Papa.parse<Record<string, string>>(await response.text(), { header: true });
     expect(parsed.data[0]?.resumeId).toBe("resume-b");
     expect(parsed.data[0]?.name).toBe("Bob");
@@ -196,6 +212,7 @@ describe("resume export route", () => {
     });
 
     expect(response.status).toBe(200);
+    expectAttachmentHeaders(response, "xlsx");
     expect(calls).toHaveLength(1);
     expect(calls[0]).toMatchObject({
       pathName: "resumes:getByIdsForExport",
@@ -282,6 +299,7 @@ describe("resume export route", () => {
     });
 
     expect(response.status).toBe(200);
+    expectAttachmentHeaders(response, "csv");
     const parsed = Papa.parse<Record<string, string>>(await response.text(), { header: true });
     expect(parsed.data[0]?.resumeId).toBe("legacy-1");
     expect(parsed.data[0]?.name).toBe("Legacy Alice");

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -1,4 +1,5 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import type { Context } from "hono";
 import { randomUUID } from "node:crypto";
 import {
   ResumesQuerySchema,
@@ -1656,6 +1657,10 @@ app.openapi(clearResumeMatchesRoute, (c) => {
   }, 200);
 });
 
+const ResumeExportFormSchema = z.object({
+  payload: z.string().min(1),
+});
+
 const exportResumesRoute = createRoute({
   method: "post",
   path: "/api/resumes/export",
@@ -1870,31 +1875,56 @@ app.openapi(rescoreResumeMatchesRoute, (c) => {
   );
 });
 
+async function buildResumeExportResponse(request: z.infer<typeof ResumeExportRequestSchema>) {
+  const { format, entries, batchMeta } = await resolveExportRequest(request);
+  const file = await exportService.exportResumes(format, entries, batchMeta);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `resumes-export-${timestamp}.${file.extension}`;
+
+  return new Response(file.content, {
+    status: 200,
+    headers: {
+      "Content-Type": file.contentType,
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Content-Length": String(file.content.byteLength),
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+async function parseResumeExportDownloadRequest(c: Context) {
+  const formData = await c.req.formData();
+  const parsedForm = ResumeExportFormSchema.parse({
+    payload: formData.get("payload"),
+  });
+  return ResumeExportRequestSchema.parse(JSON.parse(parsedForm.payload));
+}
+
+function buildResumeExportErrorResponse(c: Context, error: unknown) {
+  if (error instanceof DataNotFoundError) {
+    return c.json({ success: false, error: error.message }, 404);
+  }
+
+  console.error("Failed to export resumes:", error);
+  const message = error instanceof Error ? error.message : String(error);
+  return c.json({ success: false, error: message }, 500);
+}
+
 app.openapi(exportResumesRoute, async (c) => {
-  const request = c.req.valid("json");
-
   try {
-    const { format, entries, batchMeta } = await resolveExportRequest(request);
-    const file = await exportService.exportResumes(format, entries, batchMeta);
-    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const filename = `resumes-export-${timestamp}.${file.extension}`;
-
-    return new Response(file.content, {
-      status: 200,
-      headers: {
-        "Content-Type": file.contentType,
-        "Content-Disposition": `attachment; filename="${filename}"`,
-        "Cache-Control": "no-store",
-        "Access-Control-Expose-Headers": "Content-Disposition",
-      },
-    });
+    const request = c.req.valid("json");
+    return await buildResumeExportResponse(request);
   } catch (error) {
-    if (error instanceof DataNotFoundError) {
-      return c.json({ success: false, error: error.message }, 404);
-    }
-    console.error("Failed to export resumes:", error);
-    const message = error instanceof Error ? error.message : String(error);
-    return c.json({ success: false, error: message }, 500);
+    return buildResumeExportErrorResponse(c, error);
+  }
+});
+
+app.post("/api/resumes/export/download", async (c) => {
+  try {
+    const request = await parseResumeExportDownloadRequest(c);
+    return await buildResumeExportResponse(request);
+  } catch (error) {
+    return buildResumeExportErrorResponse(c, error);
   }
 });
 

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -4,17 +4,13 @@ import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 import type { CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 import { useResumeListState } from './useResumeListState'
 
-const fetchMock = vi.fn(async (...args: [RequestInfo | URL, RequestInit?]) => {
-  void args
-  return new Response(new Blob(['resumeId,name\n1,Alice']), {
-    status: 200,
-    headers: {
-      'Content-Disposition': 'attachment; filename="resumes-export-test.csv"',
-    },
-  })
+let submittedFormAction = ''
+let submittedPayloadValue = ''
+const formSubmitMock = vi.fn(function thisFormSubmit(this: HTMLFormElement) {
+  submittedFormAction = this.action
+  const payloadInput = this.querySelector('input[name="payload"]')
+  submittedPayloadValue = payloadInput instanceof HTMLInputElement ? payloadInput.value : ''
 })
-const createObjectURLMock = vi.fn(() => 'blob:test-export')
-const revokeObjectURLMock = vi.fn()
 
 const mockState = vi.hoisted(() => ({
   convexResumes: [] as ConvexResumeItem[],
@@ -152,14 +148,9 @@ vi.mock('@/lib/api-helpers', () => ({
   },
 }))
 
-vi.stubGlobal('fetch', fetchMock)
-Object.defineProperty(globalThis.URL, 'createObjectURL', {
+Object.defineProperty(globalThis.HTMLFormElement.prototype, 'submit', {
   writable: true,
-  value: createObjectURLMock,
-})
-Object.defineProperty(globalThis.URL, 'revokeObjectURL', {
-  writable: true,
-  value: revokeObjectURLMock,
+  value: formSubmitMock,
 })
 
 vi.mock('sonner', () => ({
@@ -276,6 +267,8 @@ describe('useResumeListState role filter regression', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    submittedFormAction = ''
+    submittedPayloadValue = ''
     window.history.replaceState({}, '', '/')
     mockState.filters = {}
     mockState.sessionLocation = '广东'
@@ -606,21 +599,13 @@ describe('useResumeListState role filter regression', () => {
       await result.current.handleBulkAction('export', 'csv')
     })
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/resumes/export',
-      expect.objectContaining({
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      })
-    )
+    expect(formSubmitMock).toHaveBeenCalledTimes(1)
 
-    const requestCall = fetchMock.mock.calls[0]
-    expect(requestCall).toBeDefined()
-    const requestInit = requestCall?.[1] as RequestInit | undefined
-    expect(requestInit?.body).toBeDefined()
-    const parsedBody = JSON.parse(String(requestInit?.body)) as {
+    const submittedForm = document.querySelector('form') as HTMLFormElement | null
+    expect(submittedForm).toBeNull()
+    expect(submittedFormAction).toContain('/api/resumes/export/download')
+
+    const parsedBody = JSON.parse(submittedPayloadValue) as {
       source: string
       entries: Array<{ resumeId: string; userComment?: string; status?: string }>
       format: string

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -177,18 +177,26 @@ function taskMatchesCurrentSearch(
   return false
 }
 
-function getExportErrorMessage(value: unknown): string | undefined {
-  if (typeof value !== 'object' || value === null) {
-    return undefined
+function submitResumeExportDownload(apiBaseUrl: string, payload: ResumeExportRequestBody): void {
+  const form = document.createElement('form')
+  const input = document.createElement('input')
+
+  form.method = 'POST'
+  form.action = new URL(`${apiBaseUrl}/api/resumes/export/download`, window.location.origin).toString()
+  form.style.display = 'none'
+
+  input.type = 'hidden'
+  input.name = 'payload'
+  input.value = JSON.stringify(payload)
+
+  form.appendChild(input)
+  document.body.appendChild(form)
+
+  try {
+    form.submit()
+  } finally {
+    form.remove()
   }
-  if (!('error' in value)) {
-    return undefined
-  }
-  const error = value.error
-  if (typeof error !== 'string' || error.trim().length === 0) {
-    return undefined
-  }
-  return error
 }
 
 function normalizeFilterToken(value: string): string {
@@ -1192,47 +1200,8 @@ export function useResumeListState(loadSearchHistory = false) {
         }
 
         try {
-          const response = await fetch(`${apiBaseUrl}/api/resumes/export`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(exportRequest),
-          })
-
-          if (!response.ok) {
-            let message = `Export failed with status ${response.status}`
-            try {
-              const errorPayload = await response.json()
-              const parsedErrorMessage = getExportErrorMessage(errorPayload)
-              if (parsedErrorMessage) {
-                message = parsedErrorMessage
-              }
-            } catch (error) {
-              console.error('Failed to parse export error payload', error)
-            }
-            throw new Error(message)
-          }
-
-          const contentDisposition = response.headers.get('content-disposition')
-          const filenameMatch = contentDisposition?.match(/filename="?([^";]+)"?/i)
-          const filename = (filenameMatch && filenameMatch[1]) ? filenameMatch[1] : `selected-resumes-${new Date().toISOString().replace(/[:.]/g, '-')}.${exportFormat}`
-
-          const blob = await response.blob()
-          const url = URL.createObjectURL(blob)
-          const anchor = document.createElement('a')
-          anchor.href = url
-          anchor.download = filename
-          anchor.style.display = 'none'
-          document.body.appendChild(anchor)
-          anchor.click()
-
-          window.setTimeout(() => {
-            anchor.remove()
-            URL.revokeObjectURL(url)
-          }, 1000)
-
-          toast.success(t('bulk.exported', { count: exportEntries.length, defaultValue: `Exported ${exportEntries.length} resumes` }))
+          submitResumeExportDownload(apiBaseUrl, exportRequest)
+          toast.info(t('bulk.exportStarted', { count: exportEntries.length, defaultValue: `Started export for ${exportEntries.length} resumes` }))
           return
         } catch (error) {
           console.error('Export failed', error)


### PR DESCRIPTION
## Summary
- switch resume export from fetch/blob URL downloads to a browser-native form submission flow
- add a dedicated POST download endpoint and include Content-Length on attachment responses
- update API and hook tests to cover the new attachment download behavior

## Test plan
- [x] bunx vitest run apps/api/src/routes/resumes-export.test.ts
- [x] cd /root/workspace/apps/web && bunx vitest run src/hooks/useResumeListState.test.tsx
- [x] make check