### PR TITLE
feat: export brand hits in resume downloads

### DIFF
--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -85,6 +85,7 @@ function buildSampleResume(overrides: Partial<ResumeItem> & { resumeId: string; 
     rightToWork: overrides.rightToWork,
     digitalIdentity: overrides.digitalIdentity,
     noticePeriodDays: overrides.noticePeriodDays,
+    ingestData: overrides.ingestData,
   };
 }
 
@@ -103,6 +104,15 @@ function expectAttachmentHeaders(response: Response, extension: "csv" | "xlsx") 
   expect(response.headers.get("content-length")).toBeTruthy();
 }
 
+function findColumnIndex(sheet: ExcelJS.Worksheet | undefined, header: string): number {
+  if (!sheet) {
+    return -1;
+  }
+
+  const headers = (sheet.getRow(1).values as unknown[]) ?? [];
+  return headers.findIndex((value) => value === header);
+}
+
 describe("resume export route", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -111,7 +121,22 @@ describe("resume export route", () => {
   it("exports sample-backed requests by resumeId and preserves request order", async () => {
     vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
       items: [
-        buildSampleResume({ resumeId: "resume-a", name: "Alice" }),
+        buildSampleResume({
+          resumeId: "resume-a",
+          name: "Alice",
+          ingestData: {
+            industryTags: ["sales"],
+            brandHits: [
+              {
+                brand: "fanuc",
+                role: "equipment",
+                source: "workHistory",
+                context: "equipment",
+              },
+            ],
+            companyHits: ["fanuc"],
+          },
+        }),
         buildSampleResume({ resumeId: "resume-b", name: "Bob" }),
       ],
       sample: {
@@ -149,6 +174,7 @@ describe("resume export route", () => {
     expect(parsed.data[0]?.userComment).toBe("Call Bob");
     expect(parsed.data[1]?.resumeId).toBe("resume-a");
     expect(parsed.data[1]?.name).toBe("Alice");
+    expect(parsed.data[1]?.brandHits).toBe("发那科 · source=workHistory · context=equipment");
   });
 
   it("exports convex-backed requests via server-side Convex resolution", async () => {
@@ -172,6 +198,18 @@ describe("resume export route", () => {
               profileUrl: "https://example.com/a",
               source: "seek",
               workHistory: [{ raw: "Alice history" }],
+              ingestData: {
+                industryTags: ["machinery"],
+                brandHits: [
+                  {
+                    brand: "fanuc",
+                    role: "equipment",
+                    source: "workHistory",
+                    context: "equipment",
+                  },
+                ],
+                companyHits: ["fanuc"],
+              },
             },
           },
           {
@@ -224,10 +262,13 @@ describe("resume export route", () => {
     const workbook = new ExcelJS.Workbook();
     await workbook.xlsx.load(Buffer.from(await response.arrayBuffer()));
     const sheet = workbook.getWorksheet("Resumes");
+    const brandHitsColumn = findColumnIndex(sheet, "Brand Hits");
     expect(sheet?.getCell("A2").value).toBe("convex-b");
     expect(sheet?.getCell("B2").value).toBe("Bob");
     expect(sheet?.getCell("A3").value).toBe("convex-a");
     expect(sheet?.getCell("B3").value).toBe("Alice");
+    expect(brandHitsColumn).toBeGreaterThan(0);
+    expect(sheet?.getRow(3).getCell(brandHitsColumn).value).toBe("发那科 · source=workHistory · context=equipment");
   });
 
   it("returns a clear 404 when any requested resume cannot be resolved", async () => {
@@ -292,6 +333,18 @@ describe("resume export route", () => {
               profileUrl: "https://example.com/legacy-1",
               source: "seek",
               workHistory: [{ raw: "Legacy history" }],
+              ingestData: {
+                industryTags: ["sales"],
+                brandHits: [
+                  {
+                    brand: "haas",
+                    role: "equipment",
+                    source: "selfIntro",
+                    context: "sales",
+                  },
+                ],
+                companyHits: ["haas"],
+              },
             },
           },
         ],
@@ -303,5 +356,6 @@ describe("resume export route", () => {
     const parsed = Papa.parse<Record<string, string>>(await response.text(), { header: true });
     expect(parsed.data[0]?.resumeId).toBe("legacy-1");
     expect(parsed.data[0]?.name).toBe("Legacy Alice");
+    expect(parsed.data[0]?.brandHits).toBe("哈斯 · source=selfIntro · context=sales");
   });
 });

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -239,6 +239,7 @@ function toExportResumePayload(resume: ResumeItem): ExportResumePayload {
     source: undefined,
     selfIntro: resume.selfIntro,
     workHistory: resume.workHistory,
+    ingestData: resume.ingestData,
   };
 }
 

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -572,6 +572,14 @@ const ResumeExportLegacyRoleSignalSchema = z.object({
   verifyIn: z.string().optional(),
 });
 
+const ResumeExportLegacyBrandHitSchema = z.object({
+  brand: z.string(),
+  role: z.string(),
+  source: z.string(),
+  context: z.string(),
+  companyId: z.number().optional(),
+});
+
 export const ResumeExportLegacyResumeSchema = z.object({
   name: z.string().optional(),
   jobIntention: z.string().optional(),
@@ -587,6 +595,7 @@ export const ResumeExportLegacyResumeSchema = z.object({
   ingestData: z
     .object({
       industryTags: z.array(z.string()).optional(),
+      brandHits: z.array(ResumeExportLegacyBrandHitSchema).optional(),
       companyHits: z.array(z.string()).optional(),
       roleSignals: z.array(ResumeExportLegacyRoleSignalSchema).optional(),
     })

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -22,6 +22,20 @@ function buildEntry(age: string | undefined): ResumeExportEntry {
       ingestData: {
         industryTags: ["cnc"],
         companyHits: ["FANUC"],
+        brandHits: [
+          {
+            brand: "fanuc",
+            role: "equipment",
+            source: "workHistory",
+            context: "equipment",
+          },
+          {
+            brand: "fanuc",
+            role: "equipment",
+            source: "workHistory",
+            context: "equipment",
+          },
+        ],
         roleSignals: [
           {
             type: "sales",
@@ -195,6 +209,19 @@ describe("ExportService", () => {
     expect(parsed.data[0]?.roleEvidence).toContain("verified 3.5y");
     expect(parsed.data[0]?.matchedWorkEntries).toContain("sales · Example Co. · Sales Engineer");
     expect(parsed.data[0]?.matchedWorkEntries).toContain("verified");
+  });
+
+  it("formats brand hits into a dedicated export column", async () => {
+    const service = new ExportService({
+      resolveZhHans: (brandId: string) => `zh-${brandId.toLowerCase()}`,
+      toJSON: () => ({}),
+    });
+    const file = await service.exportResumes("csv", [buildEntry("27")]);
+    const csv = file.content.toString("utf8");
+    const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
+
+    expect(parsed.meta.fields).toContain("brandHits");
+    expect(parsed.data[0]?.brandHits).toBe("zh-fanuc · source=workHistory · context=equipment");
   });
 
   it("keeps CSV and XLSX headers aligned", async () => {

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -6,31 +6,12 @@ import {
   type ResumeWorkHistoryItem as SharedResumeWorkHistoryItem,
 } from "@trends/shared";
 import type { BrandDisplayResolver } from "./brand-display-resolver.js";
+import type { ResumeIngestBrandHit, ResumeIngestData } from "../types/resume.js";
 
 export type ExportFormat = "csv" | "xlsx";
 
 type ResumeWorkHistoryItem = Partial<SharedResumeWorkHistoryItem> & {
   raw?: string;
-};
-
-type ResumeIngestData = {
-  industryTags?: string[];
-  companyHits?: string[];
-  roleSignals?: Array<{
-    type: string;
-    matchedSignals: string[];
-    years: number;
-    industryVerifiedYears?: number;
-    roleRelevantYears?: number;
-    industryVerifiedRelevantYears?: number;
-    matchedWorkEntries?: Array<{
-      companyName?: string;
-      jobTitle?: string;
-      years: number;
-      industryVerified: boolean;
-      matchedSignals: string[];
-    }>;
-  }>;
 };
 
 type ResumeExportPayload = {
@@ -82,6 +63,7 @@ type ExportRow = {
   scoreSource: string;
   action: string;
   industryTags: string;
+  brandHits: string;
   companyHits: string;
   roleEvidence: string;
   matchedWorkEntries: string;
@@ -185,6 +167,51 @@ function parseAgeNumber(value: unknown): number | null {
   return null;
 }
 
+function resolveBrandDisplayName(
+  brandId: string | undefined,
+  brandDisplayResolver?: BrandDisplayResolver
+): string {
+  const normalizedBrandId = normalizeString(brandId).trim();
+  if (!normalizedBrandId) {
+    return "";
+  }
+
+  return brandDisplayResolver
+    ? brandDisplayResolver.resolveZhHans(normalizedBrandId)
+    : normalizedBrandId.toUpperCase();
+}
+
+function formatBrandHit(hit: ResumeIngestBrandHit, brandDisplayResolver?: BrandDisplayResolver): string {
+  const displayName = resolveBrandDisplayName(hit.brand, brandDisplayResolver);
+  if (!displayName) {
+    return "";
+  }
+
+  const source = normalizeString(hit.source).trim();
+  const context = normalizeString(hit.context).trim();
+  const qualifiers = [
+    source ? `source=${source}` : "",
+    context ? `context=${context}` : "",
+  ].filter(Boolean);
+
+  return [displayName, ...qualifiers].join(" · ");
+}
+
+function formatBrandHits(
+  brandHits: ResumeIngestData["brandHits"],
+  brandDisplayResolver?: BrandDisplayResolver
+): string {
+  if (!Array.isArray(brandHits) || brandHits.length === 0) {
+    return "";
+  }
+
+  const formattedHits = brandHits
+    .map((hit) => formatBrandHit(hit, brandDisplayResolver))
+    .filter((hit) => hit.length > 0);
+
+  return Array.from(new Set(formattedHits)).join(" | ");
+}
+
 function toRow(entry: ResumeExportEntry, brandDisplayResolver?: BrandDisplayResolver): ExportRow {
   const workHistory = Array.isArray(entry.resume.workHistory)
     ? entry.resume.workHistory
@@ -209,8 +236,9 @@ function toRow(entry: ResumeExportEntry, brandDisplayResolver?: BrandDisplayReso
     scoreSource: normalizeString(entry.match?.scoreSource),
     action: normalizeString(entry.action),
     industryTags: normalizeStringArray(entry.resume.ingestData?.industryTags).join(", "),
+    brandHits: formatBrandHits(entry.resume.ingestData?.brandHits, brandDisplayResolver),
     companyHits: normalizeStringArray(entry.resume.ingestData?.companyHits)
-      .map((brandId) => (brandDisplayResolver ? brandDisplayResolver.resolveZhHans(brandId) : brandId.toUpperCase()))
+      .map((brandId) => resolveBrandDisplayName(brandId, brandDisplayResolver))
       .join(", "),
     roleEvidence: formatRoleEvidence(entry.resume.ingestData?.roleSignals),
     matchedWorkEntries: formatMatchedWorkEntries(entry.resume.ingestData?.roleSignals),
@@ -239,6 +267,7 @@ const EXCEL_COLUMNS: Array<{ header: string; key: keyof ExportRow; width: number
   { header: "Score Source", key: "scoreSource", width: 12 },
   { header: "Action", key: "action", width: 12 },
   { header: "Industry Tags", key: "industryTags", width: 22 },
+  { header: "Brand Hits", key: "brandHits", width: 34 },
   { header: "Company Hits", key: "companyHits", width: 22 },
   { header: "Role Evidence", key: "roleEvidence", width: 34 },
   { header: "Matched Work Entries", key: "matchedWorkEntries", width: 44 },

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -18,6 +18,10 @@ import { SkillsKnowledgeService } from "./skills-knowledge.js";
 import { UnifiedSearchService, type UnifiedKeywordExpansion } from "./unified-search-service.js";
 
 import type {
+  ResumeIngestBrandHit,
+  ResumeIngestData,
+  ResumeIngestMatchedWorkEntry,
+  ResumeIngestRoleSignal,
   ResumeDigitalIdentity,
   ResumeIndustry,
   ResumeItem,
@@ -63,6 +67,152 @@ function toStringValue(value: unknown): string {
   if (typeof value === "string") return value.trim();
   if (value === null || value === undefined) return "";
   return String(value);
+}
+
+function toOptionalNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string") return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => toStringValue(item)).filter(Boolean);
+}
+
+function normalizeIngestBrandHits(value: unknown): ResumeIngestBrandHit[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const brandHits = value
+    .map((item) => {
+      if (!isRecord(item)) {
+        return null;
+      }
+
+      const brand = toStringValue(item.brand);
+      const role = toStringValue(item.role);
+      const source = toStringValue(item.source);
+      const context = toStringValue(item.context);
+      const companyId = toOptionalNumber(item.companyId);
+
+      if (!brand || !role || !source || !context) {
+        return null;
+      }
+
+      return {
+        brand,
+        role,
+        source,
+        context,
+        ...(companyId === undefined ? {} : { companyId }),
+      } satisfies ResumeIngestBrandHit;
+    })
+    .filter((item): item is ResumeIngestBrandHit => item !== null);
+
+  return brandHits.length > 0 ? brandHits : undefined;
+}
+
+function normalizeMatchedWorkEntries(value: unknown): ResumeIngestMatchedWorkEntry[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const matchedWorkEntries = value
+    .map((item) => {
+      if (!isRecord(item)) {
+        return null;
+      }
+
+      const years = toOptionalNumber(item.years);
+      if (years === undefined) {
+        return null;
+      }
+
+      const companyName = toStringValue(item.companyName) || undefined;
+      const jobTitle = toStringValue(item.jobTitle) || undefined;
+
+      return {
+        ...(companyName ? { companyName } : {}),
+        ...(jobTitle ? { jobTitle } : {}),
+        years,
+        industryVerified: item.industryVerified === true,
+        matchedSignals: toStringArray(item.matchedSignals),
+      } satisfies ResumeIngestMatchedWorkEntry;
+    })
+    .filter((item): item is ResumeIngestMatchedWorkEntry => item !== null);
+
+  return matchedWorkEntries.length > 0 ? matchedWorkEntries : undefined;
+}
+
+function normalizeRoleSignals(value: unknown): ResumeIngestRoleSignal[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const roleSignals = value
+    .map((item) => {
+      if (!isRecord(item)) {
+        return null;
+      }
+
+      const type = toStringValue(item.type);
+      const years = toOptionalNumber(item.years);
+      if (!type || years === undefined) {
+        return null;
+      }
+
+      const industryVerifiedYears = toOptionalNumber(item.industryVerifiedYears);
+      const roleRelevantYears = toOptionalNumber(item.roleRelevantYears);
+      const industryVerifiedRelevantYears = toOptionalNumber(item.industryVerifiedRelevantYears);
+      const matchedWorkEntries = normalizeMatchedWorkEntries(item.matchedWorkEntries);
+
+      return {
+        type,
+        matchedSignals: toStringArray(item.matchedSignals),
+        years,
+        ...(industryVerifiedYears === undefined ? {} : { industryVerifiedYears }),
+        ...(roleRelevantYears === undefined ? {} : { roleRelevantYears }),
+        ...(industryVerifiedRelevantYears === undefined ? {} : { industryVerifiedRelevantYears }),
+        ...(matchedWorkEntries ? { matchedWorkEntries } : {}),
+      } satisfies ResumeIngestRoleSignal;
+    })
+    .filter((item): item is ResumeIngestRoleSignal => item !== null);
+
+  return roleSignals.length > 0 ? roleSignals : undefined;
+}
+
+function normalizeIngestData(value: unknown): ResumeIngestData | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const industryTags = toStringArray(value.industryTags);
+  const brandHits = normalizeIngestBrandHits(value.brandHits);
+  const companyHits = toStringArray(value.companyHits);
+  const roleSignals = normalizeRoleSignals(value.roleSignals);
+
+  if (
+    industryTags.length === 0
+    && brandHits === undefined
+    && companyHits.length === 0
+    && roleSignals === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(industryTags.length > 0 ? { industryTags } : {}),
+    ...(brandHits ? { brandHits } : {}),
+    ...(companyHits.length > 0 ? { companyHits } : {}),
+    ...(roleSignals ? { roleSignals } : {}),
+  };
 }
 
 function countOccurrences(haystack: string, needle: string): number {
@@ -143,6 +293,7 @@ function normalizeResumeItem(item: unknown, source?: string): ResumeItem {
     selfIntro: toStringValue(record.selfIntro),
     jobIntention: toStringValue(record.jobIntention),
     expectedSalary: toStringValue(record.expectedSalary),
+    ingestData: normalizeIngestData(record.ingestData),
     extractedAt: toStringValue(record.extractedAt),
     ...normalizeSharedResumeFields(record, source),
     resumeId: resumeId || undefined,

--- a/apps/api/src/types/resume.ts
+++ b/apps/api/src/types/resume.ts
@@ -22,6 +22,39 @@ export type {
   ResumeWorkHistoryItem,
 };
 
+export type ResumeIngestBrandHit = {
+  brand: string;
+  role: string;
+  source: string;
+  context: string;
+  companyId?: number;
+};
+
+export type ResumeIngestMatchedWorkEntry = {
+  companyName?: string;
+  jobTitle?: string;
+  years: number;
+  industryVerified: boolean;
+  matchedSignals: string[];
+};
+
+export type ResumeIngestRoleSignal = {
+  type: string;
+  matchedSignals: string[];
+  years: number;
+  industryVerifiedYears?: number;
+  roleRelevantYears?: number;
+  industryVerifiedRelevantYears?: number;
+  matchedWorkEntries?: ResumeIngestMatchedWorkEntry[];
+};
+
+export type ResumeIngestData = {
+  industryTags?: string[];
+  brandHits?: ResumeIngestBrandHit[];
+  companyHits?: string[];
+  roleSignals?: ResumeIngestRoleSignal[];
+};
+
 export type ResumeItem = {
   name: string;
   profileUrl: string;
@@ -44,6 +77,7 @@ export type ResumeItem = {
   rightToWork?: string | boolean | ResumeRightToWork;
   digitalIdentity?: string | ResumeDigitalIdentity;
   noticePeriodDays?: number;
+  ingestData?: ResumeIngestData;
   extractedAt: string;
   resumeId?: string;
   perUserId?: string;

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4383,6 +4383,13 @@ export interface components {
                     }[];
                     ingestData?: {
                         industryTags?: string[];
+                        brandHits?: {
+                            brand: string;
+                            role: string;
+                            source: string;
+                            context: string;
+                            companyId?: number;
+                        }[];
                         companyHits?: string[];
                         roleSignals?: {
                             type: string;

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -614,6 +614,7 @@ export const getByIdsForExport = query({
                         workHistory: Array.isArray(content.workHistory) ? content.workHistory : undefined,
                         ingestData: doc.ingestData ? {
                             industryTags: doc.ingestData.industryTags,
+                            brandHits: doc.ingestData.brandHits,
                             companyHits: doc.ingestData.companyHits,
                             roleSignals: doc.ingestData.roleSignals,
                         } : undefined,


### PR DESCRIPTION
## Summary
- add a dedicated Brand Hits export column with zh-Hans display resolution and source/context formatting
- propagate ingestData.brandHits through Convex, sample, and legacy export paths
- regenerate web API types and add CSV/XLSX export regressions

## Testing
- bunx vitest run apps/api/src/services/export-service.test.ts apps/api/src/routes/resumes-export.test.ts
- bun run --filter @trends/api typecheck
- make check