### PR TITLE
Show brand hits as display names

### DIFF
--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -174,7 +174,7 @@ describe("resume export route", () => {
     expect(parsed.data[0]?.userComment).toBe("Call Bob");
     expect(parsed.data[1]?.resumeId).toBe("resume-a");
     expect(parsed.data[1]?.name).toBe("Alice");
-    expect(parsed.data[1]?.brandHits).toBe("发那科 · source=workHistory · context=equipment");
+    expect(parsed.data[1]?.brandHits).toBe("发那科");
   });
 
   it("exports convex-backed requests via server-side Convex resolution", async () => {
@@ -268,7 +268,7 @@ describe("resume export route", () => {
     expect(sheet?.getCell("A3").value).toBe("convex-a");
     expect(sheet?.getCell("B3").value).toBe("Alice");
     expect(brandHitsColumn).toBeGreaterThan(0);
-    expect(sheet?.getRow(3).getCell(brandHitsColumn).value).toBe("发那科 · source=workHistory · context=equipment");
+    expect(sheet?.getRow(3).getCell(brandHitsColumn).value).toBe("发那科");
   });
 
   it("returns a clear 404 when any requested resume cannot be resolved", async () => {
@@ -356,6 +356,6 @@ describe("resume export route", () => {
     const parsed = Papa.parse<Record<string, string>>(await response.text(), { header: true });
     expect(parsed.data[0]?.resumeId).toBe("legacy-1");
     expect(parsed.data[0]?.name).toBe("Legacy Alice");
-    expect(parsed.data[0]?.brandHits).toBe("哈斯 · source=selfIntro · context=sales");
+    expect(parsed.data[0]?.brandHits).toBe("哈斯");
   });
 });

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -13,6 +13,7 @@ import {
   ResumeExportCanonicalRequestSchema,
   ResumeExportLegacyRequestSchema,
   ResumeExportLegacyResumeSchema,
+  ResumeExportResolvedResumeSchema,
   ResumeExportRequestSchema,
   MatchRequestSchema,
   MatchResponseSchema,
@@ -281,7 +282,7 @@ async function resolveConvexExportResumeMap(
       return;
     }
     const resumeId = item.resumeId;
-    const parsedResume = ResumeExportLegacyResumeSchema.safeParse(item.resume);
+    const parsedResume = ResumeExportResolvedResumeSchema.safeParse(item.resume);
     if (!parsedResume.success) {
       return;
     }

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -580,7 +580,7 @@ const ResumeExportLegacyBrandHitSchema = z.object({
   companyId: z.number().optional(),
 });
 
-export const ResumeExportLegacyResumeSchema = z.object({
+export const ResumeExportResolvedResumeSchema = z.object({
   name: z.string().optional(),
   jobIntention: z.string().optional(),
   location: z.string().optional(),
@@ -601,6 +601,8 @@ export const ResumeExportLegacyResumeSchema = z.object({
     })
     .optional(),
 });
+
+export const ResumeExportLegacyResumeSchema = ResumeExportResolvedResumeSchema;
 
 export const ResumeExportLegacyRequestSchema = z
   .object({

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -221,7 +221,7 @@ describe("ExportService", () => {
     const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
 
     expect(parsed.meta.fields).toContain("brandHits");
-    expect(parsed.data[0]?.brandHits).toBe("zh-fanuc · source=workHistory · context=equipment");
+    expect(parsed.data[0]?.brandHits).toBe("zh-fanuc");
   });
 
   it("keeps CSV and XLSX headers aligned", async () => {

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -181,10 +181,6 @@ function resolveBrandDisplayName(
     : normalizedBrandId.toUpperCase();
 }
 
-function formatBrandHit(hit: ResumeIngestBrandHit, brandDisplayResolver?: BrandDisplayResolver): string {
-  return resolveBrandDisplayName(hit.brand, brandDisplayResolver);
-}
-
 function formatBrandHits(
   brandHits: ResumeIngestData["brandHits"],
   brandDisplayResolver?: BrandDisplayResolver
@@ -194,7 +190,7 @@ function formatBrandHits(
   }
 
   const formattedHits = brandHits
-    .map((hit) => formatBrandHit(hit, brandDisplayResolver))
+    .map((hit) => resolveBrandDisplayName(hit.brand, brandDisplayResolver))
     .filter((hit) => hit.length > 0);
 
   return Array.from(new Set(formattedHits)).join(" | ");

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -182,19 +182,7 @@ function resolveBrandDisplayName(
 }
 
 function formatBrandHit(hit: ResumeIngestBrandHit, brandDisplayResolver?: BrandDisplayResolver): string {
-  const displayName = resolveBrandDisplayName(hit.brand, brandDisplayResolver);
-  if (!displayName) {
-    return "";
-  }
-
-  const source = normalizeString(hit.source).trim();
-  const context = normalizeString(hit.context).trim();
-  const qualifiers = [
-    source ? `source=${source}` : "",
-    context ? `context=${context}` : "",
-  ].filter(Boolean);
-
-  return [displayName, ...qualifiers].join(" · ");
+  return resolveBrandDisplayName(hit.brand, brandDisplayResolver);
 }
 
 function formatBrandHits(

--- a/apps/web/src/components/ResumeCard.test.tsx
+++ b/apps/web/src/components/ResumeCard.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ResumeCard } from './ResumeCard'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+describe('ResumeCard brand-hit badges', () => {
+  it('renders deduped brand names without debug metadata', () => {
+    render(
+      <ResumeCard
+        resume={{
+          name: 'Alice',
+          profileUrl: 'https://example.com/resume-1',
+          activityStatus: 'Active',
+          age: '30',
+          experience: '5 years',
+          education: 'Bachelor',
+          location: 'Dongguan',
+          selfIntro: 'Test intro',
+          jobIntention: 'Sales Engineer',
+          expectedSalary: '10k-20k',
+          workHistory: [{ raw: 'Test work history' }],
+          extractedAt: '2026-03-13T00:00:00.000Z',
+        }}
+        onViewDetails={vi.fn()}
+        brandDisplayResolve={(brandId) => (brandId === 'fanuc' ? '发那科' : brandId.toUpperCase())}
+        brandHits={[
+          { brand: 'fanuc', context: 'equipment', source: 'workHistory' },
+          { brand: 'fanuc', context: 'sales', source: 'selfIntro' },
+          { brand: 'fanuc', context: 'employer', source: 'workHistory' },
+        ]}
+      />
+    )
+
+    expect(screen.getAllByText('发那科')).toHaveLength(1)
+    expect(screen.queryByText('debugIngest.brandContext.equipment')).not.toBeInTheDocument()
+    expect(screen.queryByText('debugIngest.brandContext.sales')).not.toBeInTheDocument()
+    expect(screen.queryByText(/workHistory/i)).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -226,30 +226,21 @@ export function ResumeCard({
     .filter((company) => company.trim().length > 0)
     .slice(0, 3)
   const resolveBrand = brandDisplayResolve ?? ((brandId: string) => brandId.toUpperCase())
-  // Non-employer brand hits grouped by brand name with context labels
+  // Non-employer brand hits grouped by brand name for user-facing badges.
   const brandSummary = useMemo(() => {
     if (!brandHits || brandHits.length === 0) return []
-    const groups = new Map<string, { contexts: Set<string>; count: number }>()
+    const groups = new Map<string, number>()
     for (const hit of brandHits) {
       if (hit.context === 'employer') continue
       const key = hit.brand.trim().toLowerCase()
       if (!key) continue
-      const existing = groups.get(key) ?? { contexts: new Set<string>(), count: 0 }
-      existing.contexts.add(hit.context)
-      existing.count += 1
-      groups.set(key, existing)
+      groups.set(key, (groups.get(key) ?? 0) + 1)
     }
     return Array.from(groups.entries())
-      .sort(([, a], [, b]) => b.count - a.count)
+      .sort(([, a], [, b]) => b - a)
       .slice(0, 4)
-      .map(([brand, { contexts }]) => {
-        const contextValues = Array.from(contexts)
-        return {
-          brand,
-          contextLabels: contextValues.map((context) => t(`debugIngest.brandContext.${context}`, { defaultValue: context })),
-        }
-      })
-  }, [brandHits, t])
+      .map(([brand]) => brand)
+  }, [brandHits])
   const primaryRoleSignal = selectPrimaryRoleSignal(roleSignals)
   const verifiedRoleYears = primaryRoleSignal ? getRoleVerifiedYears(primaryRoleSignal) : 0
   const roleRelevantYears = primaryRoleSignal ? getRoleRelevantYears(primaryRoleSignal) : 0
@@ -464,15 +455,13 @@ export function ResumeCard({
             </Badge>
           )
         })}
-        {brandSummary.map(({ brand, contextLabels }) => (
+        {brandSummary.map((brand) => (
           <Badge
             key={`brand-${brand}`}
             variant="outline"
             className="text-[10px] border-amber-200 bg-amber-50 text-amber-700"
-            title={contextLabels.join(' / ')}
           >
             {resolveBrand(brand)}
-            {contextLabels.length > 0 ? ` · ${contextLabels.join('/')}` : ''}
           </Badge>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- show `brandHits` as readable display names only in resume exports
- show names-only brand-hit badges in `ResumeCard`
- keep detailed `source/context/role` brand-hit metadata in debug-oriented surfaces only

## Test plan
- [x] `bunx vitest run apps/api/src/services/export-service.test.ts apps/api/src/routes/resumes-export.test.ts`
- [x] `make check`