### PR TITLE
fix(export): summarize brand hits with alias-aware display names

### DIFF
--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -177,6 +177,67 @@ describe("resume export route", () => {
     expect(parsed.data[1]?.brandHits).toBe("发那科");
   });
 
+  it("exports sample-backed brand hits as names-only summaries with alias dedupe", async () => {
+    vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
+      items: [
+        buildSampleResume({
+          resumeId: "resume-brand",
+          name: "Brand Candidate",
+          ingestData: {
+            industryTags: ["sales"],
+            brandHits: [
+              {
+                brand: "fanuc",
+                role: "equipment",
+                source: "workHistory",
+                context: "equipment",
+              },
+              {
+                brand: "发那科",
+                role: "equipment",
+                source: "selfIntro",
+                context: "sales",
+              },
+              {
+                brand: "mitsubishi",
+                role: "equipment",
+                source: "workHistory",
+                context: "technical",
+              },
+            ],
+            companyHits: ["fanuc"],
+          },
+        }),
+      ],
+      sample: {
+        name: "sample-test",
+        filename: "sample-test.json",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+        size: 1,
+      },
+      metadata: undefined,
+      indexes: new Map(),
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes/export", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        format: "csv",
+        source: "sample",
+        sample: "sample-test",
+        entries: [{ resumeId: "resume-brand", status: "new" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const parsed = Papa.parse<Record<string, string>>(await response.text(), { header: true });
+    expect(parsed.data[0]?.brandHits).toBe("发那科, 三菱");
+  });
+
   it("exports convex-backed requests via server-side Convex resolution", async () => {
     const calls: ConvexCall[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
@@ -206,6 +267,12 @@ describe("resume export route", () => {
                     role: "equipment",
                     source: "workHistory",
                     context: "equipment",
+                  },
+                  {
+                    brand: "发那科",
+                    role: "equipment",
+                    source: "selfIntro",
+                    context: "sales",
                   },
                 ],
                 companyHits: ["fanuc"],
@@ -341,6 +408,12 @@ describe("resume export route", () => {
                     role: "equipment",
                     source: "selfIntro",
                     context: "sales",
+                  },
+                  {
+                    brand: "哈斯",
+                    role: "equipment",
+                    source: "workHistory",
+                    context: "technical",
                   },
                 ],
                 companyHits: ["haas"],

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -63,8 +63,12 @@ const jobService = new JobDescriptionService(config.projectRoot);
 const ruleScoringService = new RuleScoringService(config.projectRoot);
 const ingestComputeService = new IngestComputeService(config.projectRoot);
 const skillsKnowledgeService = new SkillsKnowledgeService(config.projectRoot);
+const companyPatterns = skillsKnowledgeService.getCompanyPatterns();
 const searchEventLogger = new SearchEventLogger(config.projectRoot);
-const exportService = new ExportService(new BrandDisplayResolver(config.projectRoot));
+const exportService = new ExportService(
+  new BrandDisplayResolver(config.projectRoot, companyPatterns),
+  companyPatterns
+);
 
 const DEFAULT_AI_TOP_N = 20;
 

--- a/apps/api/src/services/brand-display-resolver.ts
+++ b/apps/api/src/services/brand-display-resolver.ts
@@ -1,5 +1,9 @@
 import { IndustryDataService, type BrandEntry } from "./industry-data-service.js";
-import { SkillsKnowledgeService, type CompanyPattern } from "./skills-knowledge.js";
+import {
+  SkillsKnowledgeService,
+  buildCompanyPatternAliasLookup,
+  normalizeCompanyPatternIdentifier,
+} from "./skills-knowledge.js";
 
 export type BrandDisplayEntry = {
   displayName: string;
@@ -12,7 +16,7 @@ function hasChinese(value: string): boolean {
 }
 
 function normalizeBrandId(value: string): string {
-  return value.trim().toLowerCase();
+  return normalizeCompanyPatternIdentifier(value);
 }
 
 function pickPreferredZhHansFromAliases(aliases: string[]): string | null {
@@ -35,15 +39,16 @@ function brandEntryToDisplay(brand: BrandEntry): BrandDisplayEntry {
 export class BrandDisplayResolver {
   private readonly map: Map<string, BrandDisplayEntry>;
 
-  constructor(projectRoot: string) {
+  constructor(projectRoot: string, companyPatterns?: ReturnType<SkillsKnowledgeService["getCompanyPatterns"]>) {
     const skills = new SkillsKnowledgeService(projectRoot);
     const industry = new IndustryDataService(projectRoot);
 
-    const patterns = skills.getCompanyPatterns();
+    const patterns = companyPatterns ?? skills.getCompanyPatterns();
     const brands = industry.loadBrands();
 
     this.map = new Map<string, BrandDisplayEntry>();
 
+    const aliasLookup = buildCompanyPatternAliasLookup(patterns);
     const brandsByEn = new Map<string, BrandDisplayEntry>();
     for (const brand of brands) {
       const nameEn = typeof brand.nameEn === "string" ? brand.nameEn.trim() : "";
@@ -61,7 +66,7 @@ export class BrandDisplayResolver {
 
     // Overlay skills.md company patterns (preferred source for stable IDs + alias selection).
     for (const pattern of patterns) {
-      const brandId = normalizeBrandId(pattern.name);
+      const brandId = aliasLookup.get(normalizeBrandId(pattern.name)) ?? normalizeBrandId(pattern.name);
       if (!brandId) continue;
 
       const displayName = pattern.displayName.trim() || pattern.name.trim();

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -224,6 +224,56 @@ describe("ExportService", () => {
     expect(parsed.data[0]?.brandHits).toBe("zh-fanuc");
   });
 
+  it("summarizes brand hits as deduped names-only evidence with alias expansion", async () => {
+    const service = new ExportService(
+      {
+        resolveZhHans: (brandId: string) => {
+          if (brandId.toLowerCase() === "fanuc") return "发那科";
+          if (brandId.toLowerCase() === "mitsubishi") return "三菱";
+          return brandId.toUpperCase();
+        },
+        toJSON: () => ({}),
+      },
+      [
+        {
+          name: "fanuc",
+          displayName: "FANUC",
+          aliases: ["发那科", "宝力机械有限公司"],
+          displayAliases: ["发那科", "宝力机械有限公司"],
+          allNames: ["fanuc", "发那科", "宝力机械有限公司"],
+          role: "both",
+        },
+        {
+          name: "mitsubishi",
+          displayName: "MITSUBISHI",
+          aliases: ["三菱"],
+          displayAliases: ["三菱"],
+          allNames: ["mitsubishi", "三菱"],
+          role: "both",
+        },
+      ]
+    );
+    const entry = buildEntry("27");
+    entry.resume.ingestData = {
+      ...entry.resume.ingestData,
+      brandHits: [
+        { brand: "fanuc", role: "equipment", source: "workHistory", context: "equipment" },
+        { brand: "宝力机械有限公司", role: "equipment", source: "selfIntro", context: "sales" },
+        { brand: "mitsubishi", role: "equipment", source: "workHistory", context: "technical" },
+        { brand: "fanuc", role: "employer", source: "workHistory", context: "employer" },
+      ],
+    };
+
+    const file = await service.exportResumes("csv", [entry]);
+    const csv = file.content.toString("utf8");
+    const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
+
+    expect(parsed.data[0]?.brandHits).toBe("发那科, 三菱");
+    expect(parsed.data[0]?.brandHits).not.toContain("source");
+    expect(parsed.data[0]?.brandHits).not.toContain("context");
+    expect(parsed.data[0]?.brandHits).not.toContain("role");
+  });
+
   it("keeps CSV and XLSX headers aligned", async () => {
     const service = new ExportService();
     const csvFile = await service.exportResumes("csv", [buildEntry("27")]);

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -6,7 +6,12 @@ import {
   type ResumeWorkHistoryItem as SharedResumeWorkHistoryItem,
 } from "@trends/shared";
 import type { BrandDisplayResolver } from "./brand-display-resolver.js";
-import type { ResumeIngestBrandHit, ResumeIngestData } from "../types/resume.js";
+import {
+  buildCompanyPatternAliasLookup,
+  normalizeCompanyPatternIdentifier,
+  type CompanyPattern,
+} from "./skills-knowledge.js";
+import type { ResumeIngestData } from "../types/resume.js";
 
 export type ExportFormat = "csv" | "xlsx";
 
@@ -181,22 +186,41 @@ function resolveBrandDisplayName(
     : normalizedBrandId.toUpperCase();
 }
 
-function formatBrandHits(
+function summarizeBrandHits(
   brandHits: ResumeIngestData["brandHits"],
-  brandDisplayResolver?: BrandDisplayResolver
+  brandDisplayResolver?: BrandDisplayResolver,
+  companyPatternAliasLookup?: Map<string, string>
 ): string {
   if (!Array.isArray(brandHits) || brandHits.length === 0) {
     return "";
   }
 
-  const formattedHits = brandHits
-    .map((hit) => resolveBrandDisplayName(hit.brand, brandDisplayResolver))
-    .filter((hit) => hit.length > 0);
+  const displayNames = new Set<string>();
+  for (const hit of brandHits) {
+    if (hit.context === "employer") {
+      continue;
+    }
 
-  return Array.from(new Set(formattedHits)).join(" | ");
+    const normalizedBrandId = normalizeCompanyPatternIdentifier(normalizeString(hit.brand));
+    if (!normalizedBrandId) {
+      continue;
+    }
+
+    const canonicalBrandId = companyPatternAliasLookup?.get(normalizedBrandId) ?? normalizedBrandId;
+    const displayName = resolveBrandDisplayName(canonicalBrandId, brandDisplayResolver);
+    if (displayName) {
+      displayNames.add(displayName);
+    }
+  }
+
+  return Array.from(displayNames).join(", ");
 }
 
-function toRow(entry: ResumeExportEntry, brandDisplayResolver?: BrandDisplayResolver): ExportRow {
+function toRow(
+  entry: ResumeExportEntry,
+  brandDisplayResolver?: BrandDisplayResolver,
+  companyPatternAliasLookup?: Map<string, string>
+): ExportRow {
   const workHistory = Array.isArray(entry.resume.workHistory)
     ? entry.resume.workHistory
       .map((item) => buildWorkHistoryEntryText(item))
@@ -220,7 +244,11 @@ function toRow(entry: ResumeExportEntry, brandDisplayResolver?: BrandDisplayReso
     scoreSource: normalizeString(entry.match?.scoreSource),
     action: normalizeString(entry.action),
     industryTags: normalizeStringArray(entry.resume.ingestData?.industryTags).join(", "),
-    brandHits: formatBrandHits(entry.resume.ingestData?.brandHits, brandDisplayResolver),
+    brandHits: summarizeBrandHits(
+      entry.resume.ingestData?.brandHits,
+      brandDisplayResolver,
+      companyPatternAliasLookup
+    ),
     companyHits: normalizeStringArray(entry.resume.ingestData?.companyHits)
       .map((brandId) => resolveBrandDisplayName(brandId, brandDisplayResolver))
       .join(", "),
@@ -281,14 +309,28 @@ function applyBatchMeta(row: ExportRow, batchMeta?: ExportBatchMeta): ExportRow 
 }
 
 export class ExportService {
-  constructor(private readonly brandDisplayResolver?: BrandDisplayResolver) {}
+  private readonly companyPatternAliasLookup: Map<string, string>;
+
+  constructor(
+    private readonly brandDisplayResolver?: BrandDisplayResolver,
+    companyPatternsOrAliasLookup: CompanyPattern[] | Map<string, string> = []
+  ) {
+    this.companyPatternAliasLookup = companyPatternsOrAliasLookup instanceof Map
+      ? companyPatternsOrAliasLookup
+      : buildCompanyPatternAliasLookup(companyPatternsOrAliasLookup);
+  }
 
   async exportResumes(
     format: ExportFormat,
     entries: ResumeExportEntry[],
     batchMeta?: ExportBatchMeta
   ): Promise<ExportFile> {
-    const rows = entries.map((entry) => applyBatchMeta(toRow(entry, this.brandDisplayResolver), batchMeta));
+    const rows = entries.map((entry) =>
+      applyBatchMeta(
+        toRow(entry, this.brandDisplayResolver, this.companyPatternAliasLookup),
+        batchMeta
+      )
+    );
     if (format === "xlsx") {
       const content = await this.toXlsx(rows);
       return {

--- a/apps/api/src/services/skills-knowledge.ts
+++ b/apps/api/src/services/skills-knowledge.ts
@@ -127,6 +127,28 @@ function normalizeToken(value: string): string {
   return value.trim().toLowerCase();
 }
 
+export function normalizeCompanyPatternIdentifier(value: string): string {
+  return normalizeToken(value);
+}
+
+export function buildCompanyPatternAliasLookup(companyPatterns: CompanyPattern[]): Map<string, string> {
+  const lookup = new Map<string, string>();
+  for (const pattern of companyPatterns) {
+    const canonicalId = normalizeCompanyPatternIdentifier(pattern.name);
+    if (!canonicalId) {
+      continue;
+    }
+    lookup.set(canonicalId, canonicalId);
+    for (const alias of pattern.allNames) {
+      const normalizedAlias = normalizeCompanyPatternIdentifier(alias);
+      if (normalizedAlias) {
+        lookup.set(normalizedAlias, canonicalId);
+      }
+    }
+  }
+  return lookup;
+}
+
 function matchesSectionHeading(value: string, aliases: readonly string[]): boolean {
   return aliases.some((alias) => value.startsWith(alias));
 }


### PR DESCRIPTION
## Summary
- summarize exported `brandHits` as readable names-only evidence instead of raw ingest metadata
- dedupe alias variants through shared company-pattern normalization and brand display resolution
- add route and service coverage for sample, Convex, and legacy export paths

## Test plan
- [x] bunx vitest run apps/api/src/services/export-service.test.ts apps/api/src/routes/resumes-export.test.ts
- [x] make check