### PR TITLE
feat(system): centralize metadata for debug and CLI surfaces

### DIFF
--- a/apps/api/src/routes/config.test.ts
+++ b/apps/api/src/routes/config.test.ts
@@ -115,6 +115,8 @@ describe('config route workspace access', () => {
         label: 'Resume AI prompts (active locale)',
         relativePath: 'config/resume/ai-prompts.md',
         type: 'markdown',
+        group: 'prompt',
+        audience: 'developer',
         readOnly: true,
         metadata: {
           version: 3,
@@ -142,6 +144,8 @@ describe('config route workspace access', () => {
           label: 'Resume AI prompts (active locale)',
           relativePath: 'config/resume/ai-prompts.md',
           type: 'markdown',
+          group: 'prompt',
+          audience: 'developer',
           readOnly: true,
           metadata: {
             version: 3,
@@ -154,12 +158,85 @@ describe('config route workspace access', () => {
     })
   })
 
+  it('loads grouped config source summaries', async () => {
+    const listGroupSpy = vi.spyOn(configSourceInspector, 'listSourceGroups').mockReturnValue([
+      {
+        key: 'prompt',
+        label: 'Prompt Sources',
+        description: 'Prompt and AI-inspection sources used by debug and screening flows.',
+        audience: 'developer',
+        sources: [
+          {
+            key: 'resume-ai-prompts-active',
+            label: 'Resume AI prompts (active locale)',
+            relativePath: 'config/resume/ai-prompts.md',
+            type: 'markdown',
+            group: 'prompt',
+            audience: 'developer',
+            readOnly: true,
+          },
+        ],
+      },
+    ])
+
+    const app = createTestApp()
+    const response = await app.request('/api/config/source-groups?locale=en', {
+      headers: {
+        'X-Workspace-Slug': 'hr',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(listGroupSpy).toHaveBeenCalledWith('en')
+    expect(await response.json()).toEqual({
+      success: true,
+      groups: [
+        {
+          key: 'prompt',
+          label: 'Prompt Sources',
+          description: 'Prompt and AI-inspection sources used by debug and screening flows.',
+          audience: 'developer',
+          sources: [
+            {
+              key: 'resume-ai-prompts-active',
+              label: 'Resume AI prompts (active locale)',
+              relativePath: 'config/resume/ai-prompts.md',
+              type: 'markdown',
+              group: 'prompt',
+              audience: 'developer',
+              readOnly: true,
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('loads system metadata payload', async () => {
+    const app = createTestApp()
+    const response = await app.request('/api/config/system-metadata', {
+      headers: {
+        'X-Workspace-Slug': 'hr',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+    expect(payload.success).toBe(true)
+    expect(payload.metadata.identity.appName).toBe('Trends')
+    expect(payload.metadata.navigation.system.length).toBeGreaterThan(0)
+    expect(payload.metadata.labels.aiBreakdown.some((item: { key: string }) => item.key === 'industry_db')).toBe(true)
+    expect(payload.metadata.capabilities.some((item: { id: string }) => item.id === 'cli-system-inspect')).toBe(true)
+  })
+
   it('loads config source detail by key', async () => {
     const getSourceSpy = vi.spyOn(configSourceInspector, 'getSource').mockReturnValue({
       key: 'resume-skills',
       label: 'Resume skills taxonomy',
       relativePath: 'config/resume/skills.md',
       type: 'markdown',
+      group: 'config',
+      audience: 'developer',
       readOnly: true,
       rawSource: '## Skills\n- CNC',
       parsedPreview: {
@@ -183,6 +260,8 @@ describe('config route workspace access', () => {
         label: 'Resume skills taxonomy',
         relativePath: 'config/resume/skills.md',
         type: 'markdown',
+        group: 'config',
+        audience: 'developer',
         readOnly: true,
         rawSource: '## Skills\n- CNC',
         parsedPreview: {

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -1,10 +1,29 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { OpenAPIHono, z } from "@hono/zod-openapi";
+import {
+  APP_SURFACE_IDENTITY,
+  DEBUG_AI_BREAKDOWN_LABELS,
+  DEBUG_AI_KEYWORD_PROMPT_VARIANT,
+  DEBUG_PAGE_SECTION_DEFINITIONS,
+  INGEST_BRAND_CONTEXT_LABELS,
+  INGEST_BRAND_ROLE_LABELS,
+  INGEST_BRAND_SOURCE_LABELS,
+  SETTINGS_NAV_ITEMS,
+  SYSTEM_CAPABILITY_DESCRIPTORS,
+  SYSTEM_NAV_ITEMS,
+} from "@trends/shared";
 import { requireAdmin } from "../middleware/workspace.js";
 import { getMaskedApiKey, loadAIConfig, validateAIConfig } from "../services/ai-config.js";
 import { configSourceInspector, UnknownConfigSourceError } from "../services/config-source-inspector.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 
 const app = new OpenAPIHono();
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const API_ROOT = path.resolve(MODULE_DIR, "../..");
+const REPO_ROOT = path.resolve(API_ROOT, "../..");
 
 const AgentsConfigSchema = z.record(z.unknown());
 const CustomKeywordTagSchema = z.object({
@@ -61,6 +80,8 @@ const ConfigSourceSummarySchema = z.object({
   label: z.string(),
   relativePath: z.string(),
   type: z.enum(["markdown", "json5", "text"]),
+  group: z.enum(["prompt", "config", "project-notes"]),
+  audience: z.enum(["developer", "admin", "app"]),
   readOnly: z.literal(true),
   metadata: ConfigSourceMetadataSchema.optional(),
   parseError: z.string().optional(),
@@ -69,9 +90,120 @@ const ConfigSourceDetailSchema = ConfigSourceSummarySchema.extend({
   rawSource: z.string(),
   parsedPreview: z.unknown(),
 });
+const SourceGroupSummarySchema = z.object({
+  key: z.enum(["prompt", "config", "project-notes"]),
+  label: z.string(),
+  description: z.string(),
+  audience: z.enum(["developer", "admin", "app"]),
+  sources: z.array(ConfigSourceSummarySchema),
+});
+const SurfaceNavItemSchema = z.object({
+  id: z.string(),
+  titleKey: z.string(),
+  defaultTitle: z.string(),
+  hrefSuffix: z.string(),
+  matchesSuffixes: z.array(z.string()).optional(),
+});
+const CapabilityDescriptorSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  category: z.enum(["inspect", "debug", "settings", "navigation", "cli"]),
+  audience: z.enum(["developer", "admin", "app"]),
+  relatedSourceGroups: z.array(z.enum(["prompt", "config", "project-notes"])).optional(),
+});
+const BreakdownLabelSchema = z.object({
+  key: z.string(),
+  aliases: z.array(z.string()),
+  labelKey: z.string(),
+  defaultLabel: z.string(),
+});
+const LabelDescriptorSchema = z.object({
+  value: z.string(),
+  labelKey: z.string(),
+  defaultLabel: z.string(),
+});
+const SystemIdentitySchema = z.object({
+  appName: z.string(),
+  homeTitle: z.string(),
+  systemTitle: z.string(),
+  settingsTitle: z.string(),
+  adminBadgeLabel: z.string(),
+  settingsBadgeLabel: z.string(),
+  appVersion: z.string(),
+  apiVersion: z.string(),
+  webVersion: z.string(),
+});
+const SystemMetadataSchema = z.object({
+  identity: SystemIdentitySchema,
+  navigation: z.object({
+    system: z.array(SurfaceNavItemSchema),
+    settings: z.array(SurfaceNavItemSchema),
+    debugPage: z.array(SurfaceNavItemSchema),
+  }),
+  labels: z.object({
+    aiBreakdown: z.array(BreakdownLabelSchema),
+    ingestBrandSource: z.array(LabelDescriptorSchema),
+    ingestBrandContext: z.array(LabelDescriptorSchema),
+    ingestBrandRole: z.array(LabelDescriptorSchema),
+  }),
+  prompt: z.object({
+    keywordVariantTitle: z.string(),
+    keywordVariantBody: z.string(),
+  }),
+  capabilities: z.array(CapabilityDescriptorSchema),
+});
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readPackageVersion(relativePath: string): string {
+  const packageJsonPath = path.resolve(REPO_ROOT, relativePath);
+  try {
+    const raw = fs.readFileSync(packageJsonPath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (isRecord(parsed) && typeof parsed.version === "string" && parsed.version.trim()) {
+      return parsed.version.trim();
+    }
+  } catch (error) {
+    console.error(`Failed to read package version from ${relativePath}`, error);
+  }
+  return "unknown";
+}
+
+const SYSTEM_METADATA_VERSIONS = {
+  appVersion: readPackageVersion("package.json"),
+  apiVersion: readPackageVersion("apps/api/package.json"),
+  webVersion: readPackageVersion("apps/web/package.json"),
+};
+
+function buildSystemMetadata() {
+  return {
+    identity: {
+      ...APP_SURFACE_IDENTITY,
+      ...SYSTEM_METADATA_VERSIONS,
+    },
+    navigation: {
+      system: SYSTEM_NAV_ITEMS,
+      settings: SETTINGS_NAV_ITEMS,
+      debugPage: DEBUG_PAGE_SECTION_DEFINITIONS.map((section) => ({
+        ...section,
+        matchesSuffixes: section.hrefSuffix ? [section.hrefSuffix] : [""],
+      })),
+    },
+    labels: {
+      aiBreakdown: DEBUG_AI_BREAKDOWN_LABELS,
+      ingestBrandSource: INGEST_BRAND_SOURCE_LABELS,
+      ingestBrandContext: INGEST_BRAND_CONTEXT_LABELS,
+      ingestBrandRole: INGEST_BRAND_ROLE_LABELS,
+    },
+    prompt: {
+      keywordVariantTitle: DEBUG_AI_KEYWORD_PROMPT_VARIANT.title,
+      keywordVariantBody: DEBUG_AI_KEYWORD_PROMPT_VARIANT.body,
+    },
+    capabilities: SYSTEM_CAPABILITY_DESCRIPTORS,
+  };
 }
 
 function applyBondedModel(configValue: Record<string, unknown>, model: string): Record<string, unknown> {
@@ -389,10 +521,27 @@ app.post("/learning-log", requireAdmin, async (c) => {
   }
 });
 
+app.get("/system-metadata", async (c) => {
+  try {
+    const payload = buildSystemMetadata();
+    const parsed = SystemMetadataSchema.safeParse(payload);
+    if (!parsed.success) {
+      return c.json({ success: false as const, error: "Invalid system metadata response" }, 500);
+    }
+    return c.json({ success: true as const, metadata: parsed.data }, 200);
+  } catch (error) {
+    console.error("Failed to load system metadata", error);
+    return c.json({ success: false as const, error: "Failed to load system metadata" }, 500);
+  }
+});
+
 app.get("/sources", async (c) => {
   try {
     const requestedLocale = c.req.query("locale");
-    const summaries = configSourceInspector.listSources(requestedLocale);
+    const group = c.req.query("group");
+    const summaries = group === "prompt" || group === "config" || group === "project-notes"
+      ? configSourceInspector.getSourcesByGroup(group, requestedLocale)
+      : configSourceInspector.listSources(requestedLocale);
     const parsed = z.array(ConfigSourceSummarySchema).safeParse(summaries);
     if (!parsed.success) {
       return c.json({ success: false as const, error: "Invalid config sources response" }, 500);
@@ -401,6 +550,21 @@ app.get("/sources", async (c) => {
   } catch (error) {
     console.error("Failed to list config sources", error);
     return c.json({ success: false as const, error: "Failed to list config sources" }, 500);
+  }
+});
+
+app.get("/source-groups", async (c) => {
+  try {
+    const requestedLocale = c.req.query("locale");
+    const groups = configSourceInspector.listSourceGroups(requestedLocale);
+    const parsed = z.array(SourceGroupSummarySchema).safeParse(groups);
+    if (!parsed.success) {
+      return c.json({ success: false as const, error: "Invalid config source groups response" }, 500);
+    }
+    return c.json({ success: true as const, groups: parsed.data }, 200);
+  } catch (error) {
+    console.error("Failed to list config source groups", error);
+    return c.json({ success: false as const, error: "Failed to list config source groups" }, 500);
   }
 });
 

--- a/apps/api/src/services/config-source-inspector.ts
+++ b/apps/api/src/services/config-source-inspector.ts
@@ -11,40 +11,16 @@ import {
   type ResumeAiPromptDocument,
   type ResumeAiPromptSourceSummary,
 } from "./resume-ai-prompt-service.js";
-
-export type ConfigSourceType = "markdown" | "json5" | "text";
-
-export interface ConfigSourceMetadata {
-  version?: number;
-  updatedAt?: string;
-  description?: string;
-  locale?: string;
-  requestedLocale?: string;
-  resolvedSourceLocale?: string;
-  fallbackToZhHans?: boolean;
-}
-
-export interface ConfigSourceSummary {
-  key: string;
-  label: string;
-  relativePath: string;
-  type: ConfigSourceType;
-  readOnly: true;
-  metadata?: ConfigSourceMetadata;
-  parseError?: string;
-}
-
-export interface ConfigSourceDetail extends ConfigSourceSummary {
-  rawSource: string;
-  parsedPreview: unknown;
-}
-
-type StaticSourceDefinition = {
-  key: string;
-  label: string;
-  relativePath: string;
-  type: ConfigSourceType;
-};
+import {
+  INSPECTABLE_SOURCE_GROUP_DEFINITIONS,
+  STATIC_INSPECTABLE_SOURCE_DEFINITIONS,
+  type ConfigSourceMetadata,
+  type InspectableSourceDetail,
+  type InspectableSourceGroupSummary,
+  type InspectableSourceSummary,
+  type InspectableSourceGroupKey,
+  type StaticInspectableSourceDefinition,
+} from "@trends/shared";
 
 type MarkdownSectionPreview = {
   heading: string;
@@ -67,50 +43,7 @@ export class UnknownConfigSourceError extends Error {
   }
 }
 
-const STATIC_SOURCES: StaticSourceDefinition[] = [
-  {
-    key: "resume-agents",
-    label: "Resume agent pipeline",
-    relativePath: "config/resume/agents.json5",
-    type: "json5",
-  },
-  {
-    key: "resume-skills",
-    label: "Resume skills taxonomy",
-    relativePath: "config/resume/skills.md",
-    type: "markdown",
-  },
-  {
-    key: "resume-skills-words",
-    label: "Resume legacy skill words",
-    relativePath: "config/resume/skills_words.txt",
-    type: "text",
-  },
-  {
-    key: "resume-rule-weights",
-    label: "Resume rule weights",
-    relativePath: "config/resume/rule-weights.json5",
-    type: "json5",
-  },
-  {
-    key: "resume-filter-presets",
-    label: "Resume filter presets",
-    relativePath: "config/resume/filter-presets.json5",
-    type: "json5",
-  },
-  {
-    key: "resume-custom-keywords",
-    label: "Resume custom keywords",
-    relativePath: "config/resume/custom-keywords.json5",
-    type: "json5",
-  },
-  {
-    key: "resume-session",
-    label: "Resume session config",
-    relativePath: "config/resume/session.json5",
-    type: "json5",
-  },
-];
+const STATIC_SOURCES: StaticInspectableSourceDefinition[] = STATIC_INSPECTABLE_SOURCE_DEFINITIONS;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -230,25 +163,28 @@ function toMetadata(frontmatter: Record<string, unknown> | undefined): ConfigSou
   return Object.keys(metadata).length > 0 ? metadata : undefined;
 }
 
-function buildPromptSummary(key: string, label: string, document: ResumeAiPromptDocument): ConfigSourceSummary {
+function buildPromptSummary(key: string, label: string, document: ResumeAiPromptDocument): InspectableSourceSummary {
   return {
     key,
     label,
     relativePath: document.sourceFileRelativePath,
     type: "markdown",
+    group: "prompt",
+    audience: "developer",
     readOnly: true,
     metadata: {
       version: document.metadata.version,
       updatedAt: document.metadata.updatedAt,
       description: document.metadata.description,
       locale: document.resolution.requestedLocale,
+      requestedLocale: document.resolution.requestedLocale,
       resolvedSourceLocale: document.resolution.resolvedSourceLocale,
       fallbackToZhHans: document.resolution.fallbackToZhHans,
     },
   };
 }
 
-function buildPromptDetail(key: string, label: string, document: ResumeAiPromptDocument): ConfigSourceDetail {
+function buildPromptDetail(key: string, label: string, document: ResumeAiPromptDocument): InspectableSourceDetail {
   return {
     ...buildPromptSummary(key, label, document),
     rawSource: document.rawMarkdown,
@@ -270,17 +206,19 @@ export class ConfigSourceInspector {
     this.promptService = new ResumeAiPromptService(this.projectRoot);
   }
 
-  private buildStaticBase(definition: StaticSourceDefinition): ConfigSourceSummary {
+  private buildStaticBase(definition: StaticInspectableSourceDefinition): InspectableSourceSummary {
     return {
       key: definition.key,
       label: definition.label,
       relativePath: definition.relativePath,
       type: definition.type,
+      group: definition.group,
+      audience: definition.audience,
       readOnly: true,
     };
   }
 
-  private readStaticSource(definition: StaticSourceDefinition): ConfigSourceDetail {
+  private readStaticSource(definition: StaticInspectableSourceDefinition): InspectableSourceDetail {
     const absolutePath = path.join(this.projectRoot, definition.relativePath);
     const rawSource = fs.readFileSync(absolutePath, "utf8");
     const base = this.buildStaticBase(definition);
@@ -310,7 +248,7 @@ export class ConfigSourceInspector {
     };
   }
 
-  private buildStaticSummary(definition: StaticSourceDefinition): ConfigSourceSummary | null {
+  private buildStaticSummary(definition: StaticInspectableSourceDefinition): InspectableSourceSummary | null {
     const absolutePath = path.join(this.projectRoot, definition.relativePath);
 
     try {
@@ -333,6 +271,8 @@ export class ConfigSourceInspector {
         label: definition.label,
         relativePath: definition.relativePath,
         type: definition.type,
+        group: definition.group,
+        audience: definition.audience,
         readOnly: true,
         parseError: error instanceof Error ? error.message : "Failed to parse config source",
       };
@@ -343,41 +283,75 @@ export class ConfigSourceInspector {
     return `resume-ai-prompts-${locale}`;
   }
 
-  private buildPromptVariantSummary(source: ResumeAiPromptSourceSummary): ConfigSourceSummary {
+  private buildPromptVariantSummary(source: ResumeAiPromptSourceSummary): InspectableSourceSummary {
     return {
       key: this.buildPromptVariantKey(source.locale),
       label: `Resume AI prompts (${source.locale})`,
       relativePath: source.fileRelativePath,
       type: "markdown",
+      group: "prompt",
+      audience: "developer",
       readOnly: true,
       metadata: {
         version: source.metadata.version,
         updatedAt: source.metadata.updatedAt,
         description: source.metadata.description,
         locale: source.locale,
+        requestedLocale: source.locale,
+        resolvedSourceLocale: source.locale,
+        fallbackToZhHans: false,
       },
     };
   }
 
-  listSources(requestedLocale = process.env.AI_OUTPUT_LOCALE): ConfigSourceSummary[] {
+  private buildPromptSummaries(requestedLocale = process.env.AI_OUTPUT_LOCALE): InspectableSourceSummary[] {
     const promptService = this.promptService;
     const activePrompt = promptService.loadPrompt(requestedLocale);
-    const summaries: ConfigSourceSummary[] = [
+    return [
       buildPromptSummary("resume-ai-prompts-active", "Resume AI prompts (active locale)", activePrompt),
       ...promptService.listAvailablePromptSources().map((source) => this.buildPromptVariantSummary(source)),
     ];
+  }
 
+  private buildStaticSummaries(group?: InspectableSourceGroupKey): InspectableSourceSummary[] {
+    const summaries: InspectableSourceSummary[] = [];
     for (const definition of STATIC_SOURCES) {
+      if (group && definition.group !== group) {
+        continue;
+      }
       const summary = this.buildStaticSummary(definition);
       if (summary) {
         summaries.push(summary);
       }
     }
-
     return summaries;
   }
 
-  getSource(key: string, requestedLocale = process.env.AI_OUTPUT_LOCALE): ConfigSourceDetail {
+  listSources(requestedLocale = process.env.AI_OUTPUT_LOCALE): InspectableSourceSummary[] {
+    return [
+      ...this.buildPromptSummaries(requestedLocale),
+      ...this.buildStaticSummaries(),
+    ];
+  }
+
+  listSourceGroups(requestedLocale = process.env.AI_OUTPUT_LOCALE): InspectableSourceGroupSummary[] {
+    return INSPECTABLE_SOURCE_GROUP_DEFINITIONS.map((groupDefinition) => ({
+      key: groupDefinition.key,
+      label: groupDefinition.label,
+      description: groupDefinition.description,
+      audience: groupDefinition.audience,
+      sources: this.getSourcesByGroup(groupDefinition.key, requestedLocale),
+    })).filter((group) => group.sources.length > 0);
+  }
+
+  getSourcesByGroup(group: InspectableSourceGroupKey, requestedLocale = process.env.AI_OUTPUT_LOCALE): InspectableSourceSummary[] {
+    if (group === "prompt") {
+      return this.buildPromptSummaries(requestedLocale);
+    }
+    return this.buildStaticSummaries(group);
+  }
+
+  getSource(key: string, requestedLocale = process.env.AI_OUTPUT_LOCALE): InspectableSourceDetail {
     const promptService = this.promptService;
 
     if (key === "resume-ai-prompts-active") {

--- a/apps/web/src/components/SettingsSidebar.tsx
+++ b/apps/web/src/components/SettingsSidebar.tsx
@@ -1,15 +1,27 @@
+import { useMemo } from 'react'
+import {
+  APP_SURFACE_IDENTITY,
+  SETTINGS_NAV_ITEMS,
+  type SurfaceNavDefinition,
+} from '@trends/shared'
 import { Link, useLocation } from 'react-router-dom'
 import { Ban, Home, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
+import { useSystemMetadata } from '@/hooks/useSystemMetadata'
 import { cn } from '@/lib/utils'
 
-interface NavItem {
+type NavItem = SurfaceNavDefinition & {
   title: string
   href: string
   icon: React.ComponentType<{ className?: string }>
   matches: string[]
+}
+
+const NAV_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  home: Home,
+  blocks: Ban,
 }
 
 interface SettingsSidebarProps {
@@ -20,30 +32,29 @@ export function SettingsSidebar({ onClose }: SettingsSidebarProps) {
   const location = useLocation()
   const { slug } = useWorkspace()
   const { t } = useTranslation()
+  const identity = useSystemMetadata()
+  const appVersion = identity?.appVersion ?? 'unknown'
 
-  const navItems: NavItem[] = [
-    {
-      title: t('nav.home', { defaultValue: 'Home' }),
-      href: `/${slug}/resumes`,
-      icon: Home,
-      matches: [`/${slug}/resumes`],
-    },
-    {
-      title: t('settings.blocks.nav', { defaultValue: 'Blacklist' }),
-      href: `/${slug}/settings/blocks`,
-      icon: Ban,
-      matches: [`/${slug}/settings/blocks`],
-    },
-  ]
+  const navItems = useMemo<NavItem[]>(() => {
+    return SETTINGS_NAV_ITEMS.map((item) => ({
+      ...item,
+      title: t(item.titleKey, { defaultValue: item.defaultTitle }),
+      href: `/${slug}${item.hrefSuffix}`,
+      matches: item.matchesSuffixes.map((suffix) => `/${slug}${suffix}`),
+      icon: NAV_ICONS[item.id] ?? Home,
+    }))
+  }, [slug, t])
 
   return (
     <div className="flex flex-col h-full bg-muted/30">
       <div className="flex-1 overflow-y-auto py-4">
         <div className="px-5 mb-6 flex items-center justify-between">
           <Link to={`/${slug}/resumes`} className="flex items-center gap-2">
-            <span className="bg-primary text-primary-foreground text-[10px] px-1.5 py-0.5 rounded font-medium">SETTINGS</span>
+            <span className="bg-primary text-primary-foreground text-[10px] px-1.5 py-0.5 rounded font-medium">
+              {APP_SURFACE_IDENTITY.settingsBadgeLabel}
+            </span>
             <div className="flex items-baseline gap-1">
-              <span className="font-bold text-base truncate">App Title</span>
+              <span className="font-bold text-base truncate">{APP_SURFACE_IDENTITY.appName}</span>
             </div>
           </Link>
           {onClose && (
@@ -76,7 +87,7 @@ export function SettingsSidebar({ onClose }: SettingsSidebarProps) {
       </div>
       <div className="px-5 mt-auto pt-4">
         <div className="text-xs text-muted-foreground truncate">
-          v0.9.0 Workspace Settings
+          v{appVersion} {APP_SURFACE_IDENTITY.settingsTitle}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/SystemSidebar.tsx
+++ b/apps/web/src/components/SystemSidebar.tsx
@@ -1,137 +1,111 @@
+import { useMemo } from 'react'
+import {
+  APP_SURFACE_IDENTITY,
+  SYSTEM_NAV_ITEMS,
+  type SurfaceNavDefinition,
+} from '@trends/shared'
 import { Link, useLocation } from 'react-router-dom'
 import {
-    Home,
-    LayoutDashboard,
-    Settings,
-    FileText,
-    Brain,
-    Database,
-    BarChart3,
-    X
+  Home,
+  LayoutDashboard,
+  Settings,
+  FileText,
+  Brain,
+  Database,
+  BarChart3,
+  X,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
+import { useSystemMetadata } from '@/hooks/useSystemMetadata'
 import { cn } from '@/lib/utils'
 import { useTranslation } from 'react-i18next'
 
-interface NavItem {
-    title: string
-    href: string
-    icon: React.ComponentType<{ className?: string }>
-    matches: string[]
+type NavItem = SurfaceNavDefinition & {
+  title: string
+  href: string
+  icon: React.ComponentType<{ className?: string }>
+  matches: string[]
+}
+
+const NAV_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  home: Home,
+  settings: Settings,
+  jds: FileText,
+  profiles: FileText,
+  'ai-debugger': Brain,
+  'ai-tagging': Brain,
+  ingest: Database,
+  'search-analytics': BarChart3,
+  'data-inspector': LayoutDashboard,
 }
 
 interface SystemSidebarProps {
-    onClose?: () => void
+  onClose?: () => void
 }
 
 export function SystemSidebar({ onClose }: SystemSidebarProps) {
-    const location = useLocation()
-    const { slug } = useWorkspace()
+  const location = useLocation()
+  const { slug } = useWorkspace()
+  const { t } = useTranslation()
+  const identity = useSystemMetadata()
+  const appVersion = identity?.appVersion ?? 'unknown'
 
-    const { t } = useTranslation()
+  const navItems = useMemo<NavItem[]>(() => {
+    return SYSTEM_NAV_ITEMS.map((item) => ({
+      ...item,
+      title: t(item.titleKey, { defaultValue: item.defaultTitle }),
+      href: `/${slug}${item.hrefSuffix}`,
+      matches: item.matchesSuffixes.map((suffix) => `/${slug}${suffix}`),
+      icon: NAV_ICONS[item.id] ?? FileText,
+    }))
+  }, [slug, t])
 
-    const navItems: NavItem[] = [
-        {
-            title: t('nav.home', { defaultValue: 'Home' }),
-            href: `/${slug}/resumes`,
-            icon: Home,
-            matches: [`/${slug}/resumes`]
-        },
-        {
-            title: t('nav.settings', { defaultValue: 'System Settings' }),
-            href: `/${slug}/system/settings`,
-            icon: Settings,
-            matches: [`/${slug}/system/settings`]
-        },
-        {
-            title: t('nav.jds', { defaultValue: 'Job Descriptions' }),
-            href: `/${slug}/system/jds`,
-            icon: FileText,
-            matches: [`/${slug}/system/jds`]
-        },
-        {
-            title: t('searchProfiles.nav', { defaultValue: 'Search Profiles' }),
-            href: `/${slug}/system/profiles`,
-            icon: FileText,
-            matches: [`/${slug}/system/profiles`]
-        },
-        {
-            title: t('nav.debugAi', { defaultValue: 'AI Debugger' }),
-            href: `/${slug}/system/ai-debugger`,
-            icon: Brain,
-            matches: [`/${slug}/system/ai-debugger`]
-        },
-        {
-            title: t('nav.aiTaggingCompare', { defaultValue: 'AI Tagging (Compare)' }),
-            href: `/${slug}/system/ai-tagging`,
-            icon: Brain,
-            matches: [`/${slug}/system/ai-tagging`]
-        },
-        {
-            title: t('debugIngest.nav', { defaultValue: 'Ingest Debug' }),
-            href: `/${slug}/system/ingest`,
-            icon: Database,
-            matches: [`/${slug}/system/ingest`]
-        },
-        {
-            title: t('searchAnalytics.nav', { defaultValue: 'Search Analytics' }),
-            href: `/${slug}/system/search-analytics`,
-            icon: BarChart3,
-            matches: [`/${slug}/system/search-analytics`]
-        },
-        {
-            title: t('nav.dataInspector', { defaultValue: 'Data Inspector' }),
-            href: `/${slug}/system/data`,
-            icon: LayoutDashboard,
-            matches: [`/${slug}/system/data`]
-        }
-    ]
-
-    return (
-        <div className="flex flex-col h-full bg-muted/30">
-            {/* Navigation */}
-            <div className="flex-1 overflow-y-auto py-4">
-                <div className="px-5 mb-6 flex items-center justify-between">
-                    <Link to={`/${slug}/resumes`} className="flex items-center gap-2">
-                        <span className="bg-primary text-primary-foreground text-[10px] px-1.5 py-0.5 rounded font-medium">ADMIN</span>
-                        <div className="flex items-baseline gap-1">
-                            <span className="font-bold text-base truncate">App Title</span>
-                        </div>
-                    </Link>
-                    {onClose && (
-                        <Button variant="ghost" size="icon" className="md:hidden -mr-2" onClick={onClose}>
-                            <X className="h-5 w-5" />
-                        </Button>
-                    )}
-                </div>
-                <div className="px-3 space-y-1">
-                    {navItems.map((item) => {
-                        const isActive = item.matches.some(match => location.pathname.startsWith(match))
-                        return (
-                            <Link
-                                key={item.href}
-                                to={item.href}
-                                onClick={onClose}
-                                className={cn(
-                                    "flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors",
-                                    isActive
-                                        ? "bg-primary/10 text-primary"
-                                        : "text-muted-foreground hover:bg-muted hover:text-foreground"
-                                )}
-                            >
-                                <item.icon className="h-4 w-4 shrink-0" />
-                                <span className="truncate">{item.title}</span>
-                            </Link>
-                        )
-                    })}
-                </div>
+  return (
+    <div className="flex flex-col h-full bg-muted/30">
+      <div className="flex-1 overflow-y-auto py-4">
+        <div className="px-5 mb-6 flex items-center justify-between">
+          <Link to={`/${slug}/resumes`} className="flex items-center gap-2">
+            <span className="bg-primary text-primary-foreground text-[10px] px-1.5 py-0.5 rounded font-medium">
+              {APP_SURFACE_IDENTITY.adminBadgeLabel}
+            </span>
+            <div className="flex items-baseline gap-1">
+              <span className="font-bold text-base truncate">{APP_SURFACE_IDENTITY.appName}</span>
             </div>
-            <div className="px-5 mt-auto pt-4">
-                <div className="text-xs text-muted-foreground truncate">
-                    v0.9.0 System Admin
-                </div>
-            </div>
+          </Link>
+          {onClose && (
+            <Button variant="ghost" size="icon" className="md:hidden -mr-2" onClick={onClose}>
+              <X className="h-5 w-5" />
+            </Button>
+          )}
         </div>
-    )
+        <div className="px-3 space-y-1">
+          {navItems.map((item) => {
+            const isActive = item.matches.some((match) => location.pathname.startsWith(match))
+            return (
+              <Link
+                key={item.href}
+                to={item.href}
+                onClick={onClose}
+                className={cn(
+                  'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors',
+                  isActive
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                )}
+              >
+                <item.icon className="h-4 w-4 shrink-0" />
+                <span className="truncate">{item.title}</span>
+              </Link>
+            )
+          })}
+        </div>
+      </div>
+      <div className="px-5 mt-auto pt-4">
+        <div className="text-xs text-muted-foreground truncate">
+          v{appVersion} {APP_SURFACE_IDENTITY.systemTitle}
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/apps/web/src/hooks/useSystemMetadata.ts
+++ b/apps/web/src/hooks/useSystemMetadata.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+import { withWorkspaceHeaders } from '@/lib/workspace-ref'
+
+type SystemMetadataIdentity = {
+  appVersion: string
+}
+
+type SystemMetadataPayload = {
+  success: true
+  metadata: {
+    identity: SystemMetadataIdentity
+  }
+}
+
+export function useSystemMetadata(): SystemMetadataIdentity | null {
+  const [identity, setIdentity] = useState<SystemMetadataIdentity | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    fetch('/api/config/system-metadata', {
+      headers: withWorkspaceHeaders(),
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`)
+        }
+        return response.json() as Promise<SystemMetadataPayload>
+      })
+      .then((payload) => {
+        if (!cancelled && payload.success) {
+          setIdentity(payload.metadata.identity)
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to load system metadata', error)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return identity
+}

--- a/apps/web/src/pages/DebugAI.tsx
+++ b/apps/web/src/pages/DebugAI.tsx
@@ -1,4 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
+import {
+  DEBUG_AI_BREAKDOWN_LABELS,
+  DEBUG_AI_KEYWORD_PROMPT_VARIANT,
+  getResumeAiPromptDefinition,
+} from '@trends/shared'
 import { useQuery } from 'convex/react'
 import { useTranslation } from 'react-i18next'
 import { api } from '../../../../packages/convex/convex/_generated/api'
@@ -8,68 +13,11 @@ import { Select } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
 import { PageHeader } from '@/components/PageHeader'
 
-const SYSTEM_PROMPT = `你是一个专业的HR助手，专门帮助筛选精密机械和机床行业的简历。
-你必须严格按照【纯数字 JSON】格式返回结果。
-1. 绝对不要包含 markdown 标记 (如 \`\`\`json ... \`\`\`)。
-2. 所有评分字段（score, breakdown.*）必须是【JSON Number 类型】，绝对禁止使用字符串或中文数字（如 "30", "三十", thirty）。
-3. 正确示例: "score": 85
-4. 错误示例: "score": "85", "score": "eighty-five"
-5. 如果无法确切评分，请基于现有信息估算一个数字。`
-
-const USER_PROMPT_TEMPLATE = `请分析以下候选人与职位的匹配度：
-
-## 职位信息
-**职位名称**: {jobTitle}
-**职位要求**:
-{requirements}
-
-## 评分规则 (权重与标准)
-{matchingRules}
-
-## 候选人信息
-**姓名**: {candidateName}
-**求职意向**: {jobIntention}
-**工作经验**: {workExperience}年
-**学历**: {education}
-**技能**: {skills}
-**曾任职公司**: {companies}
-**简介**: {summary}
-
-请以JSON格式返回分析结果，确保 score 为数字类型：
-{
-  "score": 30, // 必须是0-100的整数数字 (Number)，不要加引号
-  "breakdown": {
-    "experience": 10, // 数字
-    "skills": 5, // 数字
-    "industry_db": 5, // 数字
-    "education": 5, // 数字
-    "location": 5 // 数字
-  },
-  "recommendation": "strong_match" | "match" | "potential" | "no_match",
-  "highlights": ["匹配亮点1", ...],
-  "concerns": ["不足之处1", ...],
-  "summary": "中文总结"
-}`
-
-const KEYWORD_PROMPT_VARIANT = `buildKeywordRequirements(['cnc', '车床', '4轴']):
-候选人需具备以下关键技能/经验:
-- cnc
-- 车床
-- 4轴`
-
 type ResumeDoc = Doc<'resumes'>
 type BreakdownKey = 'experience' | 'skills' | 'industry_db' | 'education' | 'location'
 
 type ScoreBreakdown = Record<BreakdownKey, number>
-const BREAKDOWN_KEYS: BreakdownKey[] = ['experience', 'skills', 'industry_db', 'education', 'location']
-
-const BREAKDOWN_LABEL_KEYS: Record<BreakdownKey, string> = {
-  experience: 'debugAi.breakdownLabels.experience',
-  skills: 'debugAi.breakdownLabels.skills',
-  industry_db: 'debugAi.breakdownLabels.industryDb',
-  education: 'debugAi.breakdownLabels.education',
-  location: 'debugAi.breakdownLabels.location',
-}
+const BREAKDOWN_KEYS: BreakdownKey[] = DEBUG_AI_BREAKDOWN_LABELS.map((item) => item.key as BreakdownKey)
 
 const EMPTY_BREAKDOWN: ScoreBreakdown = {
   experience: 0,
@@ -78,6 +26,10 @@ const EMPTY_BREAKDOWN: ScoreBreakdown = {
   education: 0,
   location: 0,
 }
+
+const BREAKDOWN_LABELS = new Map(
+  DEBUG_AI_BREAKDOWN_LABELS.map((item) => [item.key as BreakdownKey, item])
+)
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
@@ -175,9 +127,10 @@ function buildResumeLabel(resume: ResumeDoc, unknownCandidateLabel: string): str
 }
 
 export default function DebugAI() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const resumeDocs = useQuery(api.resumes.list, { limit: 50 })
   const resumes = useMemo(() => resumeDocs ?? [], [resumeDocs])
+  const promptDefinition = useMemo(() => getResumeAiPromptDefinition(i18n.resolvedLanguage), [i18n.resolvedLanguage])
 
   const [selectedResumeId, setSelectedResumeId] = useState('')
 
@@ -235,15 +188,15 @@ export default function DebugAI() {
         <CardContent className="space-y-4">
           <div className="space-y-2">
             <h2 className="text-sm font-semibold">{t('debugAi.systemPrompt')}</h2>
-            <pre className="max-h-64 overflow-auto rounded-md border bg-muted/40 p-4 text-xs leading-relaxed">{SYSTEM_PROMPT}</pre>
+            <pre className="max-h-64 overflow-auto rounded-md border bg-muted/40 p-4 text-xs leading-relaxed">{promptDefinition.sections.systemPrompt}</pre>
           </div>
           <div className="space-y-2">
             <h2 className="text-sm font-semibold">{t('debugAi.userPrompt')}</h2>
-            <pre className="max-h-80 overflow-auto rounded-md border bg-muted/40 p-4 text-xs leading-relaxed">{USER_PROMPT_TEMPLATE}</pre>
+            <pre className="max-h-80 overflow-auto rounded-md border bg-muted/40 p-4 text-xs leading-relaxed">{promptDefinition.normalized.userPromptTemplate}</pre>
           </div>
           <div className="space-y-2">
-            <h2 className="text-sm font-semibold">Keyword-Based Prompt Variant</h2>
-            <pre className="max-h-64 overflow-auto rounded-md border bg-muted/40 p-4 text-xs leading-relaxed">{KEYWORD_PROMPT_VARIANT}</pre>
+            <h2 className="text-sm font-semibold">{DEBUG_AI_KEYWORD_PROMPT_VARIANT.title}</h2>
+            <pre className="max-h-64 overflow-auto rounded-md border bg-muted/40 p-4 text-xs leading-relaxed">{DEBUG_AI_KEYWORD_PROMPT_VARIANT.body}</pre>
           </div>
         </CardContent>
       </Card>
@@ -279,10 +232,11 @@ export default function DebugAI() {
           <div className="space-y-4">
             {BREAKDOWN_KEYS.map((key) => {
               const score = scoreBreakdown[key]
+              const label = BREAKDOWN_LABELS.get(key)
               return (
                 <div key={key} className="space-y-1">
                   <div className="flex items-center justify-between text-sm">
-                    <span>{t(BREAKDOWN_LABEL_KEYS[key])}</span>
+                    <span>{t(label?.labelKey ?? key, { defaultValue: label?.defaultLabel ?? key })}</span>
                     <span className="font-mono text-xs text-muted-foreground">{score}</span>
                   </div>
                   <div className="h-2 w-full overflow-hidden rounded-full bg-muted">

--- a/apps/web/src/pages/DebugConfig.test.tsx
+++ b/apps/web/src/pages/DebugConfig.test.tsx
@@ -127,32 +127,52 @@ describe('DebugConfig config sources', () => {
         }
       }
 
-      if (url.endsWith('/api/config/sources')) {
+      if (url.endsWith('/api/config/source-groups')) {
         return {
           ok: true,
           status: 200,
           json: async () => ({
             success: true,
-            sources: [
+            groups: [
               {
-                key: 'resume-ai-prompts-active',
-                label: 'Resume AI prompts (active locale)',
-                relativePath: 'config/resume/ai-prompts.md',
-                type: 'markdown',
-                readOnly: true,
-                metadata: {
-                  version: 4,
-                  requestedLocale: 'en',
-                  resolvedSourceLocale: 'zh-Hans',
-                  fallbackToZhHans: true,
-                },
+                key: 'prompt',
+                label: 'Prompt Sources',
+                description: 'Shared prompt definitions and locale-aware prompt assets.',
+                audience: 'developer',
+                sources: [
+                  {
+                    key: 'resume-ai-prompts-active',
+                    label: 'Resume AI prompts (active locale)',
+                    relativePath: 'config/resume/ai-prompts.md',
+                    type: 'markdown',
+                    group: 'prompt',
+                    audience: 'developer',
+                    readOnly: true,
+                    metadata: {
+                      version: 4,
+                      requestedLocale: 'en',
+                      resolvedSourceLocale: 'zh-Hans',
+                      fallbackToZhHans: true,
+                    },
+                  },
+                ],
               },
               {
-                key: 'resume-rule-weights',
-                label: 'Resume rule weights',
-                relativePath: 'config/resume/rule-weights.json5',
-                type: 'json5',
-                readOnly: true,
+                key: 'config',
+                label: 'Config Sources',
+                description: 'Runtime configuration and rules exposed to debug surfaces.',
+                audience: 'admin',
+                sources: [
+                  {
+                    key: 'resume-rule-weights',
+                    label: 'Resume rule weights',
+                    relativePath: 'config/resume/rule-weights.json5',
+                    type: 'json5',
+                    group: 'config',
+                    audience: 'admin',
+                    readOnly: true,
+                  },
+                ],
               },
             ],
           }),
@@ -170,6 +190,8 @@ describe('DebugConfig config sources', () => {
               label: 'Resume AI prompts (active locale)',
               relativePath: 'config/resume/ai-prompts.md',
               type: 'markdown',
+              group: 'prompt',
+              audience: 'developer',
               readOnly: true,
               metadata: {
                 version: 4,
@@ -206,6 +228,8 @@ describe('DebugConfig config sources', () => {
               label: 'Resume rule weights',
               relativePath: 'config/resume/rule-weights.json5',
               type: 'json5',
+              group: 'config',
+              audience: 'admin',
               readOnly: true,
               rawSource: '{ roleMatch: 50 }',
               parsedPreview: {
@@ -229,6 +253,8 @@ describe('DebugConfig config sources', () => {
       expect(screen.getByText('debugConfig.configSources')).toBeInTheDocument()
     })
 
+    expect(screen.getByText('Prompt Sources')).toBeInTheDocument()
+    expect(screen.getByText('Config Sources')).toBeInTheDocument()
     expect(screen.getAllByText('Resume AI prompts (active locale)').length).toBeGreaterThan(0)
     expect(screen.getAllByText('config/resume/ai-prompts.md').length).toBeGreaterThan(0)
     expect(screen.getAllByText('debugConfig.readOnly').length).toBeGreaterThan(0)

--- a/apps/web/src/pages/DebugConfig.tsx
+++ b/apps/web/src/pages/DebugConfig.tsx
@@ -1,4 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import type {
+  ConfigSourceMetadata,
+  InspectableSourceDetail as ConfigSourceDetail,
+  InspectableSourceGroupSummary as ConfigSourceGroupSummary,
+  InspectableSourceSummary as ConfigSourceSummary,
+} from '@trends/shared'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { useMutation, useQuery } from 'convex/react'
@@ -93,33 +99,6 @@ interface BrandKeywordItem {
   nameEn?: string
   type: string
   origin: string
-}
-
-type ConfigSourceType = 'markdown' | 'json5' | 'text'
-
-interface ConfigSourceMetadata {
-  version?: number
-  updatedAt?: string
-  description?: string
-  locale?: string
-  requestedLocale?: string
-  resolvedSourceLocale?: string
-  fallbackToZhHans?: boolean
-}
-
-interface ConfigSourceSummary {
-  key: string
-  label: string
-  relativePath: string
-  type: ConfigSourceType
-  readOnly: true
-  metadata?: ConfigSourceMetadata
-  parseError?: string
-}
-
-interface ConfigSourceDetail extends ConfigSourceSummary {
-  rawSource: string
-  parsedPreview: unknown
 }
 
 type AgentNumericField = 'batchSize' | 'parallelism' | 'timeout' | 'temperature'
@@ -440,8 +419,10 @@ function parseConfigSourceSummary(value: unknown): ConfigSourceSummary | null {
   const label = readString(value.label)
   const relativePath = readString(value.relativePath)
   const type = value.type === 'markdown' || value.type === 'json5' || value.type === 'text' ? value.type : null
+  const group = value.group === 'prompt' || value.group === 'config' || value.group === 'project-notes' ? value.group : null
+  const audience = value.audience === 'developer' || value.audience === 'admin' || value.audience === 'app' ? value.audience : null
   const readOnly = value.readOnly === true ? true : null
-  if (!key || !label || !relativePath || !type || readOnly === null) {
+  if (!key || !label || !relativePath || !type || !group || !audience || readOnly === null) {
     return null
   }
 
@@ -450,6 +431,8 @@ function parseConfigSourceSummary(value: unknown): ConfigSourceSummary | null {
     label,
     relativePath,
     type,
+    group,
+    audience,
     readOnly,
     metadata: parseConfigSourceMetadata(value.metadata),
     parseError: readString(value.parseError) ?? undefined,
@@ -478,14 +461,38 @@ function parseConfigSourceDetail(value: unknown): ConfigSourceDetail | null {
   }
 }
 
-function parseConfigSourcesPayload(payload: unknown): ConfigSourceSummary[] | null {
-  if (!isRecord(payload) || payload.success !== true || !Array.isArray(payload.sources)) {
+function parseConfigSourceGroupsPayload(payload: unknown): ConfigSourceGroupSummary[] | null {
+  if (!isRecord(payload) || payload.success !== true || !Array.isArray(payload.groups)) {
     return null
   }
 
-  return payload.sources
-    .map((item) => parseConfigSourceSummary(item))
-    .filter((item): item is ConfigSourceSummary => item !== null)
+  return payload.groups
+    .map((group) => {
+      if (!isRecord(group)) {
+        return null
+      }
+
+      const key = group.key === 'prompt' || group.key === 'config' || group.key === 'project-notes' ? group.key : null
+      const label = readString(group.label)
+      const description = readString(group.description)
+      const audience = group.audience === 'developer' || group.audience === 'admin' || group.audience === 'app' ? group.audience : null
+      if (!key || !label || !description || !audience || !Array.isArray(group.sources)) {
+        return null
+      }
+
+      const sources = group.sources
+        .map((item) => parseConfigSourceSummary(item))
+        .filter((item): item is ConfigSourceSummary => item !== null)
+
+      return {
+        key,
+        label,
+        description,
+        audience,
+        sources,
+      }
+    })
+    .filter((group): group is ConfigSourceGroupSummary => group !== null)
 }
 
 function parseConfigSourceDetailPayload(payload: unknown): ConfigSourceDetail | null {
@@ -584,7 +591,7 @@ export default function DebugConfig() {
   const [customKeywordCategories, setCustomKeywordCategories] = useState<CustomKeywordCategory[]>([])
   const [systemLocationItems, setSystemLocationItems] = useState<SystemLocationItem[]>([])
   const [brandKeywords, setBrandKeywords] = useState<BrandKeywordItem[]>([])
-  const [configSources, setConfigSources] = useState<ConfigSourceSummary[]>([])
+  const [configSourceGroups, setConfigSourceGroups] = useState<ConfigSourceGroupSummary[]>([])
   const [selectedConfigSourceKey, setSelectedConfigSourceKey] = useState<string | null>(null)
   const [selectedConfigSourceDetail, setSelectedConfigSourceDetail] = useState<ConfigSourceDetail | null>(null)
 
@@ -688,14 +695,14 @@ export default function DebugConfig() {
     return parsed
   }, [requestJson])
 
-  const loadConfigSources = useCallback(async () => {
-    const payload = await requestJson('/api/config/sources')
-    const parsed = parseConfigSourcesPayload(payload)
+  const loadConfigSourceGroups = useCallback(async () => {
+    const payload = await requestJson('/api/config/source-groups')
+    const parsed = parseConfigSourceGroupsPayload(payload)
     if (!parsed) {
-      throw new Error('Invalid config sources response')
+      throw new Error('Invalid config source groups response')
     }
 
-    setConfigSources(parsed)
+    setConfigSourceGroups(parsed)
     return parsed
   }, [requestJson])
 
@@ -704,20 +711,25 @@ export default function DebugConfig() {
     setLoadError(null)
 
     try {
-      await Promise.all([loadAIStatus(), loadAgentsConfig(), loadCustomKeywords(), loadBrandKeywords(), loadConfigSources()])
+      await Promise.all([loadAIStatus(), loadAgentsConfig(), loadCustomKeywords(), loadBrandKeywords(), loadConfigSourceGroups()])
     } catch (error) {
       console.error('Failed to load configuration data', error)
       setLoadError(t('resumes.error'))
     } finally {
       setLoading(false)
     }
-  }, [loadAIStatus, loadAgentsConfig, loadCustomKeywords, loadBrandKeywords, loadConfigSources, t])
+  }, [loadAIStatus, loadAgentsConfig, loadCustomKeywords, loadBrandKeywords, loadConfigSourceGroups, t])
 
   useEffect(() => {
     loadData().catch((error) => {
       console.error('Unexpected loadData failure', error)
     })
   }, [loadData])
+
+  const configSources = useMemo(
+    () => configSourceGroups.flatMap((group) => group.sources),
+    [configSourceGroups],
+  )
 
   useEffect(() => {
     const nextSelectedKey = configSources.some((source) => source.key === selectedConfigSourceKey)
@@ -1403,60 +1415,74 @@ export default function DebugConfig() {
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
-            <div className="rounded-md border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{t('debugConfig.configSourceLabel')}</TableHead>
-                    <TableHead>{t('debugConfig.configSourceType')}</TableHead>
-                    <TableHead>{t('debugConfig.configSourcePath')}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {configSources.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={3} className="py-6 text-center text-muted-foreground">
-                        {loading ? t('trends.loading') : t('debug.none')}
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    configSources.map((source) => (
-                      <TableRow
-                        key={source.key}
-                        className={selectedConfigSourceKey === source.key ? 'bg-muted/50' : undefined}
-                      >
-                        <TableCell>
-                          <button
-                            type="button"
-                            className="space-y-1 text-left"
-                            onClick={() => {
-                              handleSelectConfigSource(source.key)
-                            }}
+            <div className="space-y-4">
+              {configSourceGroups.length === 0 ? (
+                <div className="rounded-md border p-6 text-center text-muted-foreground">
+                  {loading ? t('trends.loading') : t('debug.none')}
+                </div>
+              ) : (
+                configSourceGroups.map((group) => (
+                  <div key={group.key} className="rounded-md border">
+                    <div className="border-b bg-muted/20 px-4 py-3">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="space-y-1">
+                          <h3 className="text-sm font-semibold">{group.label}</h3>
+                          <p className="text-xs text-muted-foreground">{group.description}</p>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge variant="outline" className="font-normal">{group.audience}</Badge>
+                          <Badge variant="secondary">{group.sources.length}</Badge>
+                        </div>
+                      </div>
+                    </div>
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>{t('debugConfig.configSourceLabel')}</TableHead>
+                          <TableHead>{t('debugConfig.configSourceType')}</TableHead>
+                          <TableHead>{t('debugConfig.configSourcePath')}</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {group.sources.map((source) => (
+                          <TableRow
+                            key={source.key}
+                            className={selectedConfigSourceKey === source.key ? 'bg-muted/50' : undefined}
                           >
-                            <div className="font-medium">{source.label}</div>
-                            <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-                              <Badge variant="outline" className="font-normal">{t('debugConfig.readOnly')}</Badge>
-                              {source.metadata?.locale && (
-                                <Badge variant="secondary" className="font-normal">{source.metadata.locale}</Badge>
-                              )}
-                              {source.metadata?.version !== undefined && (
-                                <span>{t('debugConfig.configSourceVersion', { version: source.metadata.version })}</span>
-                              )}
-                            </div>
-                            {source.parseError && (
-                              <p className="text-xs text-destructive">{source.parseError}</p>
-                            )}
-                          </button>
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant="secondary">{source.type}</Badge>
-                        </TableCell>
-                        <TableCell className="font-mono text-xs text-muted-foreground">{source.relativePath}</TableCell>
-                      </TableRow>
-                    ))
-                  )}
-                </TableBody>
-              </Table>
+                            <TableCell>
+                              <button
+                                type="button"
+                                className="space-y-1 text-left"
+                                onClick={() => {
+                                  handleSelectConfigSource(source.key)
+                                }}
+                              >
+                                <div className="font-medium">{source.label}</div>
+                                <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+                                  <Badge variant="outline" className="font-normal">{t('debugConfig.readOnly')}</Badge>
+                                  {source.metadata?.locale && (
+                                    <Badge variant="secondary" className="font-normal">{source.metadata.locale}</Badge>
+                                  )}
+                                  {source.metadata?.version !== undefined && (
+                                    <span>{t('debugConfig.configSourceVersion', { version: source.metadata.version })}</span>
+                                  )}
+                                </div>
+                                {source.parseError && (
+                                  <p className="text-xs text-destructive">{source.parseError}</p>
+                                )}
+                              </button>
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant="secondary">{source.type}</Badge>
+                            </TableCell>
+                            <TableCell className="font-mono text-xs text-muted-foreground">{source.relativePath}</TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                ))
+              )}
             </div>
 
             <div className="space-y-4">
@@ -1475,6 +1501,8 @@ export default function DebugConfig() {
                       <div className="flex flex-wrap gap-2">
                         <Badge variant="outline">{t('debugConfig.readOnly')}</Badge>
                         <Badge variant="secondary">{selectedConfigSourceDetail.type}</Badge>
+                        <Badge variant="outline">{selectedConfigSourceDetail.group}</Badge>
+                        <Badge variant="outline">{selectedConfigSourceDetail.audience}</Badge>
                         {selectedConfigSourceDetail.metadata?.locale && (
                           <Badge variant="secondary">{selectedConfigSourceDetail.metadata.locale}</Badge>
                         )}
@@ -1489,6 +1517,14 @@ export default function DebugConfig() {
                       <div>
                         <p className="text-muted-foreground">{t('debugConfig.configSourceType')}</p>
                         <p className="font-medium">{selectedConfigSourceDetail.type}</p>
+                      </div>
+                      <div>
+                        <p className="text-muted-foreground">Group</p>
+                        <p className="font-medium">{selectedConfigSourceDetail.group}</p>
+                      </div>
+                      <div>
+                        <p className="text-muted-foreground">Audience</p>
+                        <p className="font-medium">{selectedConfigSourceDetail.audience}</p>
                       </div>
                       <div>
                         <p className="text-muted-foreground">{t('debugConfig.configSourceVersionLabel')}</p>

--- a/apps/web/src/pages/DebugIngest.tsx
+++ b/apps/web/src/pages/DebugIngest.tsx
@@ -1,4 +1,10 @@
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  getLabelDescriptor,
+  INGEST_BRAND_CONTEXT_LABELS,
+  INGEST_BRAND_ROLE_LABELS,
+  INGEST_BRAND_SOURCE_LABELS,
+} from '@trends/shared'
 import { useAction, useMutation, usePaginatedQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import { useTranslation } from 'react-i18next'
@@ -77,8 +83,22 @@ function parseSkillsVersionPayload(value: unknown): number | null {
   return typeof value.version === 'number' ? value.version : null
 }
 
-function toBrandLabel(value: string): string {
-  return value.toUpperCase()
+function formatBrandHitLabel(
+  brand: string,
+  source: string,
+  context: string,
+  role: string,
+  translate: (key: string, options?: { defaultValue?: string }) => string,
+): string {
+  const sourceDescriptor = getLabelDescriptor(source, INGEST_BRAND_SOURCE_LABELS)
+  const contextDescriptor = getLabelDescriptor(context, INGEST_BRAND_CONTEXT_LABELS)
+  const roleDescriptor = getLabelDescriptor(role, INGEST_BRAND_ROLE_LABELS)
+
+  const sourceLabel = translate(sourceDescriptor?.labelKey ?? source, { defaultValue: sourceDescriptor?.defaultLabel ?? source })
+  const contextLabel = translate(contextDescriptor?.labelKey ?? context, { defaultValue: contextDescriptor?.defaultLabel ?? context })
+  const roleLabel = translate(roleDescriptor?.labelKey ?? role, { defaultValue: roleDescriptor?.defaultLabel ?? role })
+
+  return `${brand.toUpperCase()} (${sourceLabel} / ${contextLabel} / ${roleLabel})`
 }
 
 function formatTaggingEntry(entry: {
@@ -545,12 +565,7 @@ export default function DebugIngest() {
                                 <span className="font-medium">{t('debugIngest.brandHits', { defaultValue: 'Brand Hits' })}:</span>{' '}
                                 {ingestData.brandHits.length > 0
                                   ? ingestData.brandHits
-                                    .map((hit) => {
-                                      const sourceLabel = t(`debugIngest.brandSource.${hit.source}`, { defaultValue: hit.source })
-                                      const contextLabel = t(`debugIngest.brandContext.${hit.context}`, { defaultValue: hit.context })
-                                      const roleLabel = t(`debugIngest.brandRole.${hit.role}`, { defaultValue: hit.role })
-                                      return `${toBrandLabel(hit.brand)} (${sourceLabel} / ${contextLabel} / ${roleLabel})`
-                                    })
+                                    .map((hit) => formatBrandHitLabel(hit.brand, hit.source, hit.context, hit.role, t))
                                     .join('; ')
                                   : '--'}
                               </div>

--- a/apps/web/src/pages/DebugPage.tsx
+++ b/apps/web/src/pages/DebugPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { DEBUG_PAGE_SECTION_DEFINITIONS } from '@trends/shared'
 import { useTranslation } from 'react-i18next'
 import { RefreshCw } from 'lucide-react'
 import { NavLink, useLocation } from 'react-router-dom'
@@ -381,15 +382,18 @@ export function DebugPage({ basePath = '/debug' }: { basePath?: string }) {
     // Robust detection: strip trailing slash and check prefix
     const current = location.pathname.endsWith('/') ? location.pathname.slice(0, -1) : location.pathname
     const base = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath
+    const allowed = DEBUG_PAGE_SECTION_DEFINITIONS.map((section) => section.id)
+    type DebugSectionId = (typeof allowed)[number]
 
-    if (current === base) return 'all'
+    if (current === base) return 'all' as DebugSectionId
 
     if (current.startsWith(base + '/')) {
       const next = current.slice(base.length + 1).split('/')[0]
-      const allowed = new Set(['all', 'inputs', 'findings', 'process', 'raw', 'industry', 'jobs', 'config', 'ai'])
-      if (next && allowed.has(next)) return next
+      if (next && allowed.includes(next as DebugSectionId)) {
+        return next as DebugSectionId
+      }
     }
-    return 'all'
+    return 'all' as DebugSectionId
   }, [location.pathname, basePath])
 
   const showAll = activeSection === 'all'
@@ -401,17 +405,11 @@ export function DebugPage({ basePath = '/debug' }: { basePath?: string }) {
   const showJobs = showAll || activeSection === 'jobs'
 
   const navLinks = useMemo(
-    () => [
-      { key: 'all', label: t('debug.navAll'), href: basePath },
-      { key: 'inputs', label: t('debug.navInputs'), href: `${basePath}/inputs` },
-      { key: 'findings', label: t('debug.navFindings'), href: `${basePath}/findings` },
-      { key: 'process', label: t('debug.navProcess'), href: `${basePath}/process` },
-      { key: 'raw', label: t('debug.navRaw'), href: `${basePath}/raw` },
-      { key: 'industry', label: t('debug.navIndustry'), href: `${basePath}/industry` },
-      { key: 'jobs', label: t('debug.navJobs'), href: `${basePath}/jobs` },
-      { key: 'config', label: t('debug.navConfig'), href: `${basePath}/config` },
-      { key: 'ai', label: t('debug.navAi'), href: `${basePath}/ai` },
-    ],
+    () => DEBUG_PAGE_SECTION_DEFINITIONS.map((section) => ({
+      key: section.id,
+      label: t(section.titleKey, { defaultValue: section.defaultTitle }),
+      href: section.hrefSuffix ? `${basePath}${section.hrefSuffix}` : basePath,
+    })),
     [t, basePath]
   )
 

--- a/packages/cli/cmd/root.go
+++ b/packages/cli/cmd/root.go
@@ -61,6 +61,7 @@ func init() {
 		newCrawlCmd(),
 		newResumeCmd(),
 		newJDCmd(),
+		newSystemCmd(),
 		newWorkerCmd(),
 		newMigrateCmd(),
 		newMCPCmd(),
@@ -98,9 +99,13 @@ func currentOptions() RootOptions {
 	}
 }
 
-func newAPIClient() *client.Client {
+var apiClientFactory = func() *client.Client {
 	options := currentOptions()
 	return client.New(options.APIURL, options.WorkerURL)
+}
+
+func newAPIClient() *client.Client {
+	return apiClientFactory()
 }
 
 func normalizeBaseURL(value string) string {

--- a/packages/cli/cmd/system.go
+++ b/packages/cli/cmd/system.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ptdevhk/trends/packages/cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+var getSystemMetadata = func(ctx context.Context, apiClient *client.Client) (*client.SystemMetadataResponse, error) {
+	return apiClient.GetSystemMetadata(ctx)
+}
+
+var listSourceGroups = func(ctx context.Context, apiClient *client.Client) (*client.SourceGroupsResponse, error) {
+	return apiClient.ListSourceGroups(ctx)
+}
+
+var getSourceDetail = func(ctx context.Context, apiClient *client.Client, key string) (*client.SourceDetailResponse, error) {
+	return apiClient.GetSourceDetail(ctx, key)
+}
+
+func newSystemCmd() *cobra.Command {
+	systemCmd := &cobra.Command{
+		Use:   "system",
+		Short: "Inspect system metadata and config sources",
+	}
+
+	systemCmd.AddCommand(
+		newSystemMetadataCmd(),
+		newSystemSourcesCmd(),
+		newSystemSourceCmd(),
+	)
+
+	return systemCmd
+}
+
+func newSystemMetadataCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "metadata",
+		Short: "Show system metadata and capabilities",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := getSystemMetadata(context.Background(), newAPIClient())
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"section", "value", "details"}
+			rows := [][]string{
+				{"app", response.Metadata.Identity.AppName, response.Metadata.Identity.AppVersion},
+				{"api", response.Metadata.Identity.SystemTitle, response.Metadata.Identity.APIVersion},
+				{"web", response.Metadata.Identity.SettingsTitle, response.Metadata.Identity.WebVersion},
+				{"system_nav", fmt.Sprintf("%d", len(response.Metadata.Navigation.System)), joinNavIDs(response.Metadata.Navigation.System)},
+				{"settings_nav", fmt.Sprintf("%d", len(response.Metadata.Navigation.Settings)), joinNavIDs(response.Metadata.Navigation.Settings)},
+				{"debug_nav", fmt.Sprintf("%d", len(response.Metadata.Navigation.DebugPage)), joinNavIDs(response.Metadata.Navigation.DebugPage)},
+				{"capabilities", fmt.Sprintf("%d", len(response.Metadata.Capabilities)), joinCapabilityIDs(response.Metadata.Capabilities)},
+			}
+
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+}
+
+func newSystemSourcesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "sources",
+		Short: "List inspectable source groups",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := listSourceGroups(context.Background(), newAPIClient())
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"group", "audience", "sources", "description"}
+			rows := make([][]string, 0, len(response.Groups))
+			for _, group := range response.Groups {
+				rows = append(rows, []string{
+					group.Label,
+					group.Audience,
+					fmt.Sprintf("%d", len(group.Sources)),
+					group.Description,
+				})
+			}
+
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+}
+
+func newSystemSourceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "source <key>",
+		Short: "Show one inspectable source",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := getSourceDetail(context.Background(), newAPIClient(), args[0])
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"field", "value"}
+			rows := [][]string{
+				{"key", response.Source.Key},
+				{"label", response.Source.Label},
+				{"group", response.Source.Group},
+				{"audience", response.Source.Audience},
+				{"type", response.Source.Type},
+				{"path", response.Source.RelativePath},
+				{"read_only", fmt.Sprintf("%t", response.Source.ReadOnly)},
+				{"raw_source", response.Source.RawSource},
+				{"parse_error", response.Source.ParseError},
+			}
+			if response.Source.Metadata != nil {
+				rows = append(rows,
+					[]string{"version", intPointerString(response.Source.Metadata.Version)},
+					[]string{"updated_at", response.Source.Metadata.UpdatedAt},
+					[]string{"locale", response.Source.Metadata.Locale},
+					[]string{"requested_locale", response.Source.Metadata.RequestedLocale},
+					[]string{"resolved_locale", response.Source.Metadata.ResolvedSourceLocale},
+					[]string{"fallback_to_zh_hans", boolPointerString(response.Source.Metadata.FallbackToZhHans)},
+				)
+			}
+
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+}
+
+func joinNavIDs(items []client.SystemNavItem) string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ID)
+	}
+	return strings.Join(ids, ", ")
+}
+
+func joinCapabilityIDs(items []client.SystemCapabilityDescriptor) string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ID)
+	}
+	return strings.Join(ids, ", ")
+}
+
+func intPointerString(value *int) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d", *value)
+}
+
+func boolPointerString(value *bool) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%t", *value)
+}

--- a/packages/cli/cmd/system_test.go
+++ b/packages/cli/cmd/system_test.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ptdevhk/trends/packages/cli/internal/client"
+	"github.com/spf13/viper"
+)
+
+func TestSystemClientEndpoints(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/config/system-metadata":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"metadata": map[string]any{
+					"identity": map[string]any{
+						"appName":            "Trends",
+						"homeTitle":          "Trends",
+						"systemTitle":        "System Admin",
+						"settingsTitle":      "Workspace Settings",
+						"adminBadgeLabel":    "ADMIN",
+						"settingsBadgeLabel": "SETTINGS",
+						"appVersion":         "1.0.0",
+						"apiVersion":         "1.1.0",
+						"webVersion":         "1.2.0",
+					},
+					"navigation": map[string]any{
+						"system":    []map[string]any{{"id": "home", "titleKey": "home", "defaultTitle": "Home", "hrefSuffix": "/system", "matchesSuffixes": []string{"/system"}}},
+						"settings":  []map[string]any{{"id": "blocks", "titleKey": "blocks", "defaultTitle": "Blocks", "hrefSuffix": "/settings/blocks", "matchesSuffixes": []string{"/settings/blocks"}}},
+						"debugPage": []map[string]any{{"id": "all", "titleKey": "all", "defaultTitle": "All", "hrefSuffix": "", "matchesSuffixes": []string{""}}},
+					},
+					"labels": map[string]any{
+						"aiBreakdown":        []map[string]any{{"key": "skills", "labelKey": "skills", "defaultLabel": "Skills", "aliases": []string{"skills"}}},
+						"ingestBrandSource":  []map[string]any{{"value": "manual", "labelKey": "manual", "defaultLabel": "Manual"}},
+						"ingestBrandContext": []map[string]any{{"value": "resume", "labelKey": "resume", "defaultLabel": "Resume"}},
+						"ingestBrandRole":    []map[string]any{{"value": "operator", "labelKey": "operator", "defaultLabel": "Operator"}},
+					},
+					"prompt": map[string]any{
+						"keywordVariantTitle": "Keyword Variant",
+						"keywordVariantBody":  "Body",
+					},
+					"capabilities": []map[string]any{{"id": "cli-system-inspect", "title": "CLI inspect", "description": "Inspect metadata", "category": "cli", "audience": "developer"}},
+				},
+			})
+		case "/api/config/source-groups":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"groups": []map[string]any{{
+					"key":         "prompt",
+					"label":       "Prompt Sources",
+					"description": "Prompt files",
+					"audience":    "developer",
+					"sources": []map[string]any{{
+						"key":          "resume-ai-prompts-active",
+						"label":        "Resume AI prompts (active locale)",
+						"relativePath": "config/resume/ai-prompts.md",
+						"type":         "markdown",
+						"group":        "prompt",
+						"audience":     "developer",
+						"readOnly":     true,
+					}},
+				}},
+			})
+		case "/api/config/sources/resume-ai-prompts-active":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"source": map[string]any{
+					"key":           "resume-ai-prompts-active",
+					"label":         "Resume AI prompts (active locale)",
+					"relativePath":  "config/resume/ai-prompts.md",
+					"type":          "markdown",
+					"group":         "prompt",
+					"audience":      "developer",
+					"readOnly":      true,
+					"rawSource":     "## Prompt",
+					"parsedPreview": map[string]any{"sections": 1},
+					"metadata":      map[string]any{"requestedLocale": "en"},
+				},
+			})
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	apiClient := client.New(server.URL, server.URL)
+	apiClient.HTTP = server.Client()
+
+	metadata, err := apiClient.GetSystemMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("GetSystemMetadata returned error: %v", err)
+	}
+	if metadata.Metadata.Identity.AppName != "Trends" {
+		t.Fatalf("unexpected app name: %+v", metadata.Metadata.Identity)
+	}
+
+	groups, err := apiClient.ListSourceGroups(context.Background())
+	if err != nil {
+		t.Fatalf("ListSourceGroups returned error: %v", err)
+	}
+	if len(groups.Groups) != 1 || groups.Groups[0].Key != "prompt" {
+		t.Fatalf("unexpected groups: %+v", groups.Groups)
+	}
+
+	detail, err := apiClient.GetSourceDetail(context.Background(), "resume-ai-prompts-active")
+	if err != nil {
+		t.Fatalf("GetSourceDetail returned error: %v", err)
+	}
+	if detail.Source.Group != "prompt" || detail.Source.RawSource == "" {
+		t.Fatalf("unexpected source detail: %+v", detail.Source)
+	}
+}
+
+func TestSystemMetadataCommandWritesTable(t *testing.T) {
+	originalClientFactory := apiClientFactory
+	apiClientFactory = func() *client.Client {
+		return &client.Client{}
+	}
+	defer func() {
+		apiClientFactory = originalClientFactory
+	}()
+
+	originalGetSystemMetadata := getSystemMetadata
+	getSystemMetadata = func(ctx context.Context, apiClient *client.Client) (*client.SystemMetadataResponse, error) {
+		return &client.SystemMetadataResponse{
+			Success: true,
+			Metadata: struct {
+				Identity   client.SystemMetadataIdentity `json:"identity"`
+				Navigation struct {
+					System    []client.SystemNavItem `json:"system"`
+					Settings  []client.SystemNavItem `json:"settings"`
+					DebugPage []client.SystemNavItem `json:"debugPage"`
+				} `json:"navigation"`
+				Labels struct {
+					AIBreakdown        []client.SystemLabelDescriptor `json:"aiBreakdown"`
+					IngestBrandSource  []client.SystemLabelDescriptor `json:"ingestBrandSource"`
+					IngestBrandContext []client.SystemLabelDescriptor `json:"ingestBrandContext"`
+					IngestBrandRole    []client.SystemLabelDescriptor `json:"ingestBrandRole"`
+				} `json:"labels"`
+				Prompt struct {
+					KeywordVariantTitle string `json:"keywordVariantTitle"`
+					KeywordVariantBody  string `json:"keywordVariantBody"`
+				} `json:"prompt"`
+				Capabilities []client.SystemCapabilityDescriptor `json:"capabilities"`
+			}{
+				Identity: client.SystemMetadataIdentity{AppName: "Trends", SystemTitle: "System Admin", SettingsTitle: "Workspace Settings", AppVersion: "1.0.0", APIVersion: "1.1.0", WebVersion: "1.2.0"},
+				Navigation: struct {
+					System    []client.SystemNavItem `json:"system"`
+					Settings  []client.SystemNavItem `json:"settings"`
+					DebugPage []client.SystemNavItem `json:"debugPage"`
+				}{
+					System:    []client.SystemNavItem{{ID: "home"}},
+					Settings:  []client.SystemNavItem{{ID: "blocks"}},
+					DebugPage: []client.SystemNavItem{{ID: "all"}},
+				},
+				Capabilities: []client.SystemCapabilityDescriptor{{ID: "cli-system-inspect"}},
+			},
+		}, nil
+	}
+	defer func() {
+		getSystemMetadata = originalGetSystemMetadata
+	}()
+
+	originalOutput := viper.GetString("output")
+	viper.Set("output", "table")
+	defer viper.Set("output", originalOutput)
+
+	cmd := newSystemMetadataCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("metadata command failed: %v", err)
+	}
+	text := output.String()
+	if !strings.Contains(text, "cli-system-inspect") || !strings.Contains(text, "Trends") {
+		t.Fatalf("unexpected command output: %s", text)
+	}
+}

--- a/packages/cli/internal/client/api.go
+++ b/packages/cli/internal/client/api.go
@@ -67,9 +67,114 @@ type CreateJobDescriptionResponse struct {
 	Content string             `json:"content"`
 }
 
+type InspectableSourceMetadata struct {
+	Version              *int   `json:"version,omitempty"`
+	UpdatedAt            string `json:"updatedAt,omitempty"`
+	Description          string `json:"description,omitempty"`
+	Locale               string `json:"locale,omitempty"`
+	RequestedLocale      string `json:"requestedLocale,omitempty"`
+	ResolvedSourceLocale string `json:"resolvedSourceLocale,omitempty"`
+	FallbackToZhHans     *bool  `json:"fallbackToZhHans,omitempty"`
+}
+
+type InspectableSourceSummary struct {
+	Key          string                     `json:"key"`
+	Label        string                     `json:"label"`
+	RelativePath string                     `json:"relativePath"`
+	Type         string                     `json:"type"`
+	Group        string                     `json:"group"`
+	Audience     string                     `json:"audience"`
+	ReadOnly     bool                       `json:"readOnly"`
+	Metadata     *InspectableSourceMetadata `json:"metadata,omitempty"`
+	ParseError   string                     `json:"parseError,omitempty"`
+}
+
+type InspectableSourceGroup struct {
+	Key         string                     `json:"key"`
+	Label       string                     `json:"label"`
+	Description string                     `json:"description"`
+	Audience    string                     `json:"audience"`
+	Sources     []InspectableSourceSummary `json:"sources"`
+}
+
+type InspectableSourceDetail struct {
+	InspectableSourceSummary
+	RawSource     string `json:"rawSource"`
+	ParsedPreview any    `json:"parsedPreview"`
+}
+
+type SystemNavItem struct {
+	ID              string   `json:"id"`
+	TitleKey        string   `json:"titleKey"`
+	DefaultTitle    string   `json:"defaultTitle"`
+	HrefSuffix      string   `json:"hrefSuffix"`
+	MatchesSuffixes []string `json:"matchesSuffixes,omitempty"`
+}
+
+type SystemLabelDescriptor struct {
+	Value        string `json:"value,omitempty"`
+	Key          string `json:"key,omitempty"`
+	LabelKey     string `json:"labelKey"`
+	DefaultLabel string `json:"defaultLabel"`
+}
+
+type SystemCapabilityDescriptor struct {
+	ID                  string   `json:"id"`
+	Title               string   `json:"title"`
+	Description         string   `json:"description"`
+	Category            string   `json:"category"`
+	Audience            string   `json:"audience"`
+	RelatedSourceGroups []string `json:"relatedSourceGroups,omitempty"`
+}
+
+type SystemMetadataIdentity struct {
+	AppName            string `json:"appName"`
+	HomeTitle          string `json:"homeTitle"`
+	SystemTitle        string `json:"systemTitle"`
+	SettingsTitle      string `json:"settingsTitle"`
+	AdminBadgeLabel    string `json:"adminBadgeLabel"`
+	SettingsBadgeLabel string `json:"settingsBadgeLabel"`
+	AppVersion         string `json:"appVersion"`
+	APIVersion         string `json:"apiVersion"`
+	WebVersion         string `json:"webVersion"`
+}
+
+type SystemMetadataResponse struct {
+	Success  bool `json:"success"`
+	Metadata struct {
+		Identity   SystemMetadataIdentity `json:"identity"`
+		Navigation struct {
+			System    []SystemNavItem `json:"system"`
+			Settings  []SystemNavItem `json:"settings"`
+			DebugPage []SystemNavItem `json:"debugPage"`
+		} `json:"navigation"`
+		Labels struct {
+			AIBreakdown        []SystemLabelDescriptor `json:"aiBreakdown"`
+			IngestBrandSource  []SystemLabelDescriptor `json:"ingestBrandSource"`
+			IngestBrandContext []SystemLabelDescriptor `json:"ingestBrandContext"`
+			IngestBrandRole    []SystemLabelDescriptor `json:"ingestBrandRole"`
+		} `json:"labels"`
+		Prompt struct {
+			KeywordVariantTitle string `json:"keywordVariantTitle"`
+			KeywordVariantBody  string `json:"keywordVariantBody"`
+		} `json:"prompt"`
+		Capabilities []SystemCapabilityDescriptor `json:"capabilities"`
+	} `json:"metadata"`
+}
+
+type SourceGroupsResponse struct {
+	Success bool                     `json:"success"`
+	Groups  []InspectableSourceGroup `json:"groups"`
+}
+
+type SourceDetailResponse struct {
+	Success bool                    `json:"success"`
+	Source  InspectableSourceDetail `json:"source"`
+}
+
 type ResumeExportEntry struct {
-	ResumeID  string     `json:"resumeId"`
-	RuleScore *float64   `json:"ruleScore,omitempty"`
+	ResumeID  string   `json:"resumeId"`
+	RuleScore *float64 `json:"ruleScore,omitempty"`
 }
 
 type ResumeExportRequest struct {
@@ -139,6 +244,42 @@ func (c *Client) CreateJobDescription(ctx context.Context, request CreateJobDesc
 	}
 	if !response.Success {
 		return nil, fmt.Errorf("job description create request was not successful")
+	}
+	return &response, nil
+}
+
+func (c *Client) GetSystemMetadata(ctx context.Context) (*SystemMetadataResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/config/system-metadata", c.APIURL)
+	var response SystemMetadataResponse
+	if err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("system metadata request was not successful")
+	}
+	return &response, nil
+}
+
+func (c *Client) ListSourceGroups(ctx context.Context) (*SourceGroupsResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/config/source-groups", c.APIURL)
+	var response SourceGroupsResponse
+	if err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("source groups request was not successful")
+	}
+	return &response, nil
+}
+
+func (c *Client) GetSourceDetail(ctx context.Context, key string) (*SourceDetailResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/config/sources/%s", c.APIURL, url.PathEscape(strings.TrimSpace(key)))
+	var response SourceDetailResponse
+	if err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("source detail request was not successful")
 	}
 	return &response, nil
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,3 +6,4 @@ export * from "./work-history-evidence.js";
 export * from "./generated/resume-ai-prompts.js";
 export * from "./resume-normalization.js";
 export * from "./resume-id.js";
+export * from "./system-debug-metadata.js";

--- a/packages/shared/src/system-debug-metadata.ts
+++ b/packages/shared/src/system-debug-metadata.ts
@@ -1,0 +1,417 @@
+export type ConfigSourceType = "markdown" | "json5" | "text";
+export type InspectableSourceGroupKey = "prompt" | "config" | "project-notes";
+export type InspectableSourceAudience = "developer" | "admin" | "app";
+
+export interface ConfigSourceMetadata {
+  version?: number;
+  updatedAt?: string;
+  description?: string;
+  locale?: string;
+  requestedLocale?: string;
+  resolvedSourceLocale?: string;
+  fallbackToZhHans?: boolean;
+}
+
+export interface InspectableSourceSummary {
+  key: string;
+  label: string;
+  relativePath: string;
+  type: ConfigSourceType;
+  readOnly: true;
+  group: InspectableSourceGroupKey;
+  audience: InspectableSourceAudience;
+  metadata?: ConfigSourceMetadata;
+  parseError?: string;
+}
+
+export interface InspectableSourceDetail extends InspectableSourceSummary {
+  rawSource: string;
+  parsedPreview: unknown;
+}
+
+export interface InspectableSourceGroupSummary {
+  key: InspectableSourceGroupKey;
+  label: string;
+  description: string;
+  audience: InspectableSourceAudience;
+  sources: InspectableSourceSummary[];
+}
+
+export interface StaticInspectableSourceDefinition {
+  key: string;
+  label: string;
+  relativePath: string;
+  type: ConfigSourceType;
+  group: InspectableSourceGroupKey;
+  audience: InspectableSourceAudience;
+}
+
+export interface SurfaceNavDefinition {
+  id: string;
+  titleKey: string;
+  defaultTitle: string;
+  hrefSuffix: string;
+  matchesSuffixes: string[];
+}
+
+export interface SystemCapabilityDescriptor {
+  id: string;
+  title: string;
+  description: string;
+  category: "inspect" | "debug" | "settings" | "navigation" | "cli";
+  audience: InspectableSourceAudience;
+  relatedSourceGroups?: InspectableSourceGroupKey[];
+}
+
+export interface BreakdownLabelDescriptor {
+  key: string;
+  aliases: string[];
+  labelKey: string;
+  defaultLabel: string;
+}
+
+export interface LabelDescriptor {
+  value: string;
+  labelKey: string;
+  defaultLabel: string;
+}
+
+export interface AppSurfaceIdentityDefinition {
+  appName: string;
+  homeTitle: string;
+  systemTitle: string;
+  settingsTitle: string;
+  adminBadgeLabel: string;
+  settingsBadgeLabel: string;
+}
+
+export const APP_SURFACE_IDENTITY: AppSurfaceIdentityDefinition = {
+  appName: "Trends",
+  homeTitle: "Trends",
+  systemTitle: "System Admin",
+  settingsTitle: "Workspace Settings",
+  adminBadgeLabel: "ADMIN",
+  settingsBadgeLabel: "SETTINGS",
+};
+
+export const INSPECTABLE_SOURCE_GROUP_DEFINITIONS: Array<{
+  key: InspectableSourceGroupKey;
+  label: string;
+  description: string;
+  audience: InspectableSourceAudience;
+}> = [
+  {
+    key: "prompt",
+    label: "Prompt Sources",
+    description: "Prompt and AI-inspection sources used by debug and screening flows.",
+    audience: "developer",
+  },
+  {
+    key: "config",
+    label: "Config Sources",
+    description: "File-backed runtime configuration surfaced to admin and debug tooling.",
+    audience: "admin",
+  },
+  {
+    key: "project-notes",
+    label: "Project Notes",
+    description: "Selected project notes exposed for read-only inspection in system and CLI tooling.",
+    audience: "developer",
+  },
+];
+
+export const STATIC_INSPECTABLE_SOURCE_DEFINITIONS: StaticInspectableSourceDefinition[] = [
+  {
+    key: "resume-agents",
+    label: "Resume agent pipeline",
+    relativePath: "config/resume/agents.json5",
+    type: "json5",
+    group: "config",
+    audience: "admin",
+  },
+  {
+    key: "resume-skills",
+    label: "Resume skills taxonomy",
+    relativePath: "config/resume/skills.md",
+    type: "markdown",
+    group: "config",
+    audience: "developer",
+  },
+  {
+    key: "resume-skills-words",
+    label: "Resume legacy skill words",
+    relativePath: "config/resume/skills_words.txt",
+    type: "text",
+    group: "config",
+    audience: "developer",
+  },
+  {
+    key: "resume-rule-weights",
+    label: "Resume rule weights",
+    relativePath: "config/resume/rule-weights.json5",
+    type: "json5",
+    group: "config",
+    audience: "admin",
+  },
+  {
+    key: "resume-filter-presets",
+    label: "Resume filter presets",
+    relativePath: "config/resume/filter-presets.json5",
+    type: "json5",
+    group: "config",
+    audience: "admin",
+  },
+  {
+    key: "resume-custom-keywords",
+    label: "Resume custom keywords",
+    relativePath: "config/resume/custom-keywords.json5",
+    type: "json5",
+    group: "config",
+    audience: "admin",
+  },
+  {
+    key: "resume-session",
+    label: "Resume session config",
+    relativePath: "config/resume/session.json5",
+    type: "json5",
+    group: "config",
+    audience: "admin",
+  },
+  {
+    key: "release-note-2026-03-12-resume-scoring-rule",
+    label: "Release note: resume scoring rule v0.1.0",
+    relativePath: "dev-docs/releases/2026-03-12-resume-scoring-rule-v0.1.0.md",
+    type: "markdown",
+    group: "project-notes",
+    audience: "developer",
+  },
+  {
+    key: "release-note-2026-03-06-session-history",
+    label: "Release note: screening session history",
+    relativePath: "dev-docs/releases/2026-03-06-screening-session-history-note.md",
+    type: "markdown",
+    group: "project-notes",
+    audience: "developer",
+  },
+  {
+    key: "qa-critical-path-ui-smoke",
+    label: "QA note: critical path UI smoke",
+    relativePath: "dev-docs/qa/critical-path-ui-smoke.md",
+    type: "markdown",
+    group: "project-notes",
+    audience: "developer",
+  },
+];
+
+export const SYSTEM_NAV_ITEMS: SurfaceNavDefinition[] = [
+  {
+    id: "home",
+    titleKey: "nav.home",
+    defaultTitle: "Home",
+    hrefSuffix: "/resumes",
+    matchesSuffixes: ["/resumes"],
+  },
+  {
+    id: "settings",
+    titleKey: "nav.settings",
+    defaultTitle: "System Settings",
+    hrefSuffix: "/system/settings",
+    matchesSuffixes: ["/system/settings"],
+  },
+  {
+    id: "jds",
+    titleKey: "nav.jds",
+    defaultTitle: "Job Descriptions",
+    hrefSuffix: "/system/jds",
+    matchesSuffixes: ["/system/jds"],
+  },
+  {
+    id: "profiles",
+    titleKey: "searchProfiles.nav",
+    defaultTitle: "Search Profiles",
+    hrefSuffix: "/system/profiles",
+    matchesSuffixes: ["/system/profiles"],
+  },
+  {
+    id: "ai-debugger",
+    titleKey: "nav.debugAi",
+    defaultTitle: "AI Debugger",
+    hrefSuffix: "/system/ai-debugger",
+    matchesSuffixes: ["/system/ai-debugger"],
+  },
+  {
+    id: "ai-tagging",
+    titleKey: "nav.aiTaggingCompare",
+    defaultTitle: "AI Tagging (Compare)",
+    hrefSuffix: "/system/ai-tagging",
+    matchesSuffixes: ["/system/ai-tagging"],
+  },
+  {
+    id: "ingest",
+    titleKey: "debugIngest.nav",
+    defaultTitle: "Ingest Debug",
+    hrefSuffix: "/system/ingest",
+    matchesSuffixes: ["/system/ingest"],
+  },
+  {
+    id: "search-analytics",
+    titleKey: "searchAnalytics.nav",
+    defaultTitle: "Search Analytics",
+    hrefSuffix: "/system/search-analytics",
+    matchesSuffixes: ["/system/search-analytics"],
+  },
+  {
+    id: "data-inspector",
+    titleKey: "nav.dataInspector",
+    defaultTitle: "Data Inspector",
+    hrefSuffix: "/system/data",
+    matchesSuffixes: ["/system/data"],
+  },
+];
+
+export const SETTINGS_NAV_ITEMS: SurfaceNavDefinition[] = [
+  {
+    id: "home",
+    titleKey: "nav.home",
+    defaultTitle: "Home",
+    hrefSuffix: "/resumes",
+    matchesSuffixes: ["/resumes"],
+  },
+  {
+    id: "blocks",
+    titleKey: "settings.blocks.nav",
+    defaultTitle: "Blacklist",
+    hrefSuffix: "/settings/blocks",
+    matchesSuffixes: ["/settings/blocks"],
+  },
+];
+
+export const DEBUG_PAGE_SECTION_DEFINITIONS: Array<{
+  id: "all" | "inputs" | "findings" | "process" | "raw" | "industry" | "jobs" | "config" | "ai";
+  titleKey: string;
+  defaultTitle: string;
+  hrefSuffix: string;
+}> = [
+  { id: "all", titleKey: "debug.navAll", defaultTitle: "All", hrefSuffix: "" },
+  { id: "inputs", titleKey: "debug.navInputs", defaultTitle: "Inputs", hrefSuffix: "/inputs" },
+  { id: "findings", titleKey: "debug.navFindings", defaultTitle: "Findings", hrefSuffix: "/findings" },
+  { id: "process", titleKey: "debug.navProcess", defaultTitle: "Process", hrefSuffix: "/process" },
+  { id: "raw", titleKey: "debug.navRaw", defaultTitle: "Raw", hrefSuffix: "/raw" },
+  { id: "industry", titleKey: "debug.navIndustry", defaultTitle: "Industry", hrefSuffix: "/industry" },
+  { id: "jobs", titleKey: "debug.navJobs", defaultTitle: "Jobs", hrefSuffix: "/jobs" },
+  { id: "config", titleKey: "debug.navConfig", defaultTitle: "Config", hrefSuffix: "/config" },
+  { id: "ai", titleKey: "debug.navAi", defaultTitle: "AI", hrefSuffix: "/ai" },
+];
+
+export const DEBUG_AI_BREAKDOWN_LABELS: BreakdownLabelDescriptor[] = [
+  {
+    key: "experience",
+    aliases: ["experience", "related_exp"],
+    labelKey: "debugAi.breakdownLabels.experience",
+    defaultLabel: "Related Experience",
+  },
+  {
+    key: "skills",
+    aliases: ["skills"],
+    labelKey: "debugAi.breakdownLabels.skills",
+    defaultLabel: "Skills",
+  },
+  {
+    key: "industry_db",
+    aliases: ["industry_db"],
+    labelKey: "debugAi.breakdownLabels.industryDb",
+    defaultLabel: "Industry DB",
+  },
+  {
+    key: "education",
+    aliases: ["education"],
+    labelKey: "debugAi.breakdownLabels.education",
+    defaultLabel: "Education",
+  },
+  {
+    key: "location",
+    aliases: ["location"],
+    labelKey: "debugAi.breakdownLabels.location",
+    defaultLabel: "Location",
+  },
+];
+
+export const DEBUG_AI_KEYWORD_PROMPT_VARIANT = {
+  title: "Keyword-Based Prompt Variant",
+  body: `buildKeywordRequirements(['cnc', '车床', '4轴']):\n候选人需具备以下关键技能/经验:\n- cnc\n- 车床\n- 4轴`,
+};
+
+export const INGEST_BRAND_SOURCE_LABELS: LabelDescriptor[] = [
+  { value: "workHistory", labelKey: "debugIngest.brandSource.workHistory", defaultLabel: "Work History" },
+  { value: "selfIntro", labelKey: "debugIngest.brandSource.selfIntro", defaultLabel: "Self Intro" },
+  { value: "jobIntention", labelKey: "debugIngest.brandSource.jobIntention", defaultLabel: "Job Intention" },
+];
+
+export const INGEST_BRAND_CONTEXT_LABELS: LabelDescriptor[] = [
+  { value: "employer", labelKey: "debugIngest.brandContext.employer", defaultLabel: "Employer" },
+  { value: "equipment", labelKey: "debugIngest.brandContext.equipment", defaultLabel: "Equipment" },
+  { value: "sales", labelKey: "debugIngest.brandContext.sales", defaultLabel: "Sales" },
+  { value: "technical", labelKey: "debugIngest.brandContext.technical", defaultLabel: "Technical" },
+  { value: "general", labelKey: "debugIngest.brandContext.general", defaultLabel: "General" },
+];
+
+export const INGEST_BRAND_ROLE_LABELS: LabelDescriptor[] = [
+  { value: "employer", labelKey: "debugIngest.brandRole.employer", defaultLabel: "Employer" },
+  { value: "equipment", labelKey: "debugIngest.brandRole.equipment", defaultLabel: "Equipment" },
+  { value: "both", labelKey: "debugIngest.brandRole.both", defaultLabel: "Both" },
+];
+
+export const SYSTEM_CAPABILITY_DESCRIPTORS: SystemCapabilityDescriptor[] = [
+  {
+    id: "shared-system-navigation",
+    title: "Shared system navigation metadata",
+    description: "System and settings sidebars consume centralized navigation and identity metadata.",
+    category: "navigation",
+    audience: "admin",
+    relatedSourceGroups: ["config"],
+  },
+  {
+    id: "grouped-config-inspection",
+    title: "Grouped config inspection",
+    description: "Config, prompt, and project-note sources are exposed through grouped read-only inspection payloads.",
+    category: "inspect",
+    audience: "developer",
+    relatedSourceGroups: ["prompt", "config", "project-notes"],
+  },
+  {
+    id: "debug-ai-metadata",
+    title: "AI debug metadata",
+    description: "AI prompt and breakdown labels resolve from centralized metadata instead of page-local constants.",
+    category: "debug",
+    audience: "developer",
+    relatedSourceGroups: ["prompt"],
+  },
+  {
+    id: "debug-ingest-label-maps",
+    title: "Ingest debug label maps",
+    description: "Ingest brand source, context, and role labels share a common registry across surfaces.",
+    category: "debug",
+    audience: "developer",
+    relatedSourceGroups: ["config"],
+  },
+  {
+    id: "cli-system-inspect",
+    title: "CLI system inspect parity",
+    description: "The CLI can list sources, show details, and inspect system identity/capability payloads from the API.",
+    category: "cli",
+    audience: "developer",
+    relatedSourceGroups: ["prompt", "config", "project-notes"],
+  },
+];
+
+export function getInspectableSourceGroupDefinition(key: InspectableSourceGroupKey) {
+  return INSPECTABLE_SOURCE_GROUP_DEFINITIONS.find((definition) => definition.key === key) ?? null;
+}
+
+export function getLabelDescriptor(value: string, labels: LabelDescriptor[]): LabelDescriptor | null {
+  return labels.find((label) => label.value === value) ?? null;
+}
+
+export function getBreakdownLabelDescriptor(key: string): BreakdownLabelDescriptor | null {
+  return DEBUG_AI_BREAKDOWN_LABELS.find((item) => item.key === key || item.aliases.includes(key)) ?? null;
+}


### PR DESCRIPTION
## Summary
- centralize system/debug/admin metadata in `packages/shared` and expose API-backed system metadata plus grouped inspectable source endpoints
- refactor web sidebars and debug pages to consume shared/API-backed metadata instead of page-local duplicated DTOs and labels
- add Go CLI `system` commands and typed client support for metadata/source inspection parity

## Test plan
- [x] cd /root/workspace/apps/web && bunx vitest run src/pages/DebugConfig.test.tsx src/pages/DebugIngest.test.tsx
- [x] cd /root/workspace/apps/api && bunx vitest run src/routes/config.test.ts
- [x] cd /root/workspace/packages/cli && go test ./...
- [x] make check
- [x] simplify review cleanup applied after verification