### PR TITLE
fix(search): index brand aliases in resume keyword search

### DIFF
--- a/apps/api/src/services/ingest-compute-service.test.ts
+++ b/apps/api/src/services/ingest-compute-service.test.ts
@@ -55,6 +55,7 @@ description: Test skills knowledge file
 
 - STAR [role: both] (aliases: 星, STAR机床, スター精密)
 - FANUC [role: both] (aliases: 发那科, ファナック)
+- MITSUBISHI [role: both] (aliases: 三菱, 三菱系统)
 - HAAS [role: equipment] (aliases: 哈斯, Haas Automation)
 - MAZAK [role: both] (aliases: 马扎克, Yamazaki Mazak)
 - 润星科技 [role: both] (aliases: 润星, Runxing)
@@ -620,11 +621,22 @@ describe("IngestComputeService", () => {
     expect(result.brandHits).toEqual([]);
   });
 
-  it("should not compute companyHits from selfIntro-only brand mentions", () => {
-    const result = service.computeOne("resume-123", SAMPLE_RESUME_CNC_SALES);
+  it("should compute alias tokens from non-employer brand mentions", () => {
+    const result = service.computeOne("resume-brand-aliases", {
+      data: [
+        {
+          ...SAMPLE_RESUME_JUNIOR.data[0],
+          workHistory: [
+            { raw: "2020-01~2024-12(4年11月)某设备公司销售工程师，负责三菱系统调试、发那科设备维护。" },
+          ],
+        },
+      ],
+    });
 
     expect(result.companyHits).toEqual([]);
-    expect(result.companyAliasTokens).toBe("");
+    expect(result.brandHits.map((hit) => hit.brand)).toEqual(expect.arrayContaining(["mitsubishi", "fanuc"]));
+    expect(result.companyPatternAliasTokens).toContain("mitsubishi");
+    expect(result.companyPatternAliasTokens).toContain("三菱");
     expect(result.industryDbV2RawComponents.companyScore).toBe(0);
   });
 
@@ -632,7 +644,26 @@ describe("IngestComputeService", () => {
     const result = service.computeOne("resume-789", SAMPLE_RESUME_HAAS);
 
     expect(result.companyHits).toEqual([]);
-    expect(result.companyAliasTokens).toBe("");
+    expect(result.companyPatternAliasTokens).toBe("");
+  });
+
+  it("should include aliases for employer and non-employer brand matches without duplication", () => {
+    const result = service.computeOne("resume-brand-aliases", {
+      data: [
+        {
+          ...SAMPLE_RESUME_JUNIOR.data[0],
+          workHistory: [
+            { raw: "2020-01~2024-12(4年11月)上海发那科机器人有限公司销售工程师，负责三菱系统调试、发那科设备维护。" },
+          ],
+        },
+      ],
+    });
+
+    expect(result.companyHits).toEqual(["fanuc"]);
+    expect(result.brandHits.map((hit) => hit.brand)).toEqual(expect.arrayContaining(["fanuc", "mitsubishi"]));
+    const aliasTokens = result.companyPatternAliasTokens.split(/\s+/).filter(Boolean);
+    expect(aliasTokens).toEqual(expect.arrayContaining(["fanuc", "发那科", "mitsubishi", "三菱"]));
+    expect(aliasTokens.filter((token) => token === "三菱")).toHaveLength(1);
   });
 
   it("should compute deterministic industry_db v2 raw scores from employer and brand evidence", () => {
@@ -686,7 +717,7 @@ describe("IngestComputeService", () => {
     const result = service.computeOne("resume-456", SAMPLE_RESUME_JUNIOR);
 
     expect(result.companyHits).toEqual([]);
-    expect(result.companyAliasTokens).toBe("");
+    expect(result.companyPatternAliasTokens).toBe("");
   });
 
   it("should accept direct ResumeItem payloads from Convex storage", () => {
@@ -712,7 +743,7 @@ describe("IngestComputeService", () => {
     expect(results[1].experienceLevel).toBe("junior");
     expect(results.every((item) => Array.isArray(item.brandHits))).toBe(true);
     expect(results.every((item) => Array.isArray(item.companyHits))).toBe(true);
-    expect(results.every((item) => typeof item.companyAliasTokens === "string")).toBe(true);
+    expect(results.every((item) => typeof item.companyPatternAliasTokens === "string")).toBe(true);
   });
 
   it("should clear skills cache before each computeBatch call", () => {

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -1,7 +1,7 @@
 import { buildWorkHistoryEntryText, buildWorkHistoryEvidence, normalizeWorkHistoryEntry } from "@trends/shared";
 
 import { IndustryDataService } from "./industry-data-service.js";
-import { SkillsKnowledgeService } from "./skills-knowledge.js";
+import { normalizeCompanyPatternIdentifier, SkillsKnowledgeService } from "./skills-knowledge.js";
 import { JobDescriptionService } from "./job-description-service.js";
 import { RuleScoringService, type MatchedWorkEntry, type RoleSignalSummary } from "./rule-scoring.js";
 import { resolveResumeId } from "./resume-id.js";
@@ -44,7 +44,7 @@ export interface IngestResult {
   roleSignals: RoleSignalSummary[];
   tagEnvelope: TagEnvelopeEntry[];
   taggingEnvelope: TaggingEnvelope;
-  companyAliasTokens: string;
+  companyPatternAliasTokens: string;
   ruleScores: Record<string, number>;  // jdId → score (0-100)
   primaryRuleScore: number;
   experienceLevel: string;
@@ -432,7 +432,7 @@ export class IngestComputeService {
       brandHits
     );
     const roleSignals = this.computeRoleSignals(item.workHistory ?? []);
-    const companyAliasTokens = this.buildCompanyAliasTokens(companyHits);
+    const companyPatternAliasTokens = this.buildCompanyAliasTokens(companyHits, brandHits);
 
     // 4. Compute ruleScores for all active JDs
     const ruleScores = this.computeRuleScores(index, brandHits, roleSignals);
@@ -467,7 +467,7 @@ export class IngestComputeService {
       roleSignals,
       tagEnvelope,
       taggingEnvelope,
-      companyAliasTokens,
+      companyPatternAliasTokens,
       ruleScores,
       primaryRuleScore,
       experienceLevel,
@@ -1131,27 +1131,31 @@ export class IngestComputeService {
   }
 
   /**
-   * Build alias tokens for matched companies so Convex searchText can match cross-language aliases.
+   * Build alias tokens for matched brands so Convex searchText can match cross-language aliases.
    */
-  private buildCompanyAliasTokens(companyHits: string[]): string {
-    if (companyHits.length === 0) {
+  private buildCompanyAliasTokens(companyHits: string[], brandHits: BrandHit[]): string {
+    const matchedBrands = new Set<string>([
+      ...companyHits,
+      ...brandHits.map((hit) => hit.brand),
+    ]);
+    if (matchedBrands.size === 0) {
       return "";
     }
 
     const patterns = this.skillsKnowledgeService.getCompanyPatterns();
     const patternByName = new Map(
-      patterns.map((pattern) => [pattern.name.toLowerCase(), pattern])
+      patterns.map((pattern) => [normalizeCompanyPatternIdentifier(pattern.name), pattern])
     );
 
     const aliasTokens = new Set<string>();
-    for (const companyHit of companyHits) {
-      const pattern = patternByName.get(companyHit.toLowerCase());
+    for (const matchedBrand of matchedBrands) {
+      const pattern = patternByName.get(normalizeCompanyPatternIdentifier(matchedBrand));
       if (!pattern) {
         continue;
       }
 
       for (const candidate of pattern.allNames) {
-        const normalizedCandidate = candidate.toLowerCase().trim();
+        const normalizedCandidate = normalizeCompanyPatternIdentifier(candidate);
         if (normalizedCandidate) {
           aliasTokens.add(normalizedCandidate);
         }

--- a/apps/api/src/services/unified-search-service.test.ts
+++ b/apps/api/src/services/unified-search-service.test.ts
@@ -27,6 +27,10 @@ description: Test skills knowledge file
 ## Synonym Table
 
 - 销售: 业务, 商务, 销售员, sales
+
+## Company Patterns
+
+- MITSUBISHI [role: both] (aliases: 三菱, 三菱系统)
 `;
 
 function createFixtureRoot(): string {
@@ -90,6 +94,30 @@ describe("UnifiedSearchService", () => {
         },
       ]);
       expect(expansion.flatTerms).toEqual(["销售", "业务", "商务", "销售员", "sales", "cnc"]);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("expands company-pattern aliases to canonical and alternate brand terms", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const skillsService = new SkillsKnowledgeService(root);
+      const service = new UnifiedSearchService(skillsService);
+      const expansion = service.expandKeyword("三菱");
+
+      expect(expansion.groups).toEqual([
+        {
+          original: "三菱",
+          variants: ["三菱", "mitsubishi", "三菱系统"],
+        },
+      ]);
+      expect(expansion.flatTerms).toEqual(["三菱", "mitsubishi", "三菱系统"]);
+      expect(expansion.sourceMapping).toEqual({
+        "mitsubishi": "三菱",
+        "三菱系统": "三菱",
+      });
     } finally {
       cleanupFixtureRoot(root);
     }

--- a/apps/api/src/services/unified-search-service.ts
+++ b/apps/api/src/services/unified-search-service.ts
@@ -4,6 +4,8 @@ import { parseSearchQuery } from "./query-parser.js";
 import { resolveResumeId } from "./resume-id.js";
 import { extractCompanyFromWorkHistory } from "./work-history.js";
 
+import { buildCompanyPatternAliasLookup } from "./skills-knowledge.js";
+
 import type { SkillsKnowledgeService } from "./skills-knowledge.js";
 import type { ResumeIndex } from "./resume-index.js";
 import type { ResumeItem } from "../types/resume.js";
@@ -72,9 +74,16 @@ function dedupeProvenance(items: UnifiedSearchProvenance[]): UnifiedSearchProven
 
 export class UnifiedSearchService {
   private readonly skillsService: SkillsKnowledgeService;
+  private readonly companyPatternAliasLookup: Map<string, string>;
+  private readonly companyPatternsByCanonicalId: Map<string, ReturnType<SkillsKnowledgeService["getCompanyPatterns"]>[number]>;
 
   constructor(skillsService: SkillsKnowledgeService) {
     this.skillsService = skillsService;
+    const companyPatterns = this.skillsService.getCompanyPatterns();
+    this.companyPatternAliasLookup = buildCompanyPatternAliasLookup(companyPatterns);
+    this.companyPatternsByCanonicalId = new Map(
+      companyPatterns.map((pattern) => [pattern.name.toLowerCase(), pattern])
+    );
   }
 
   expandKeyword(keyword: string): UnifiedKeywordExpansion {
@@ -118,6 +127,17 @@ export class UnifiedSearchService {
       const expanded = this.skillsService.expandQueryWithSynonyms([original]);
       for (const term of expanded) {
         pushVariant(term);
+      }
+
+      const canonicalCompanyId = this.companyPatternAliasLookup.get(original);
+      if (canonicalCompanyId) {
+        pushVariant(canonicalCompanyId);
+        const pattern = this.companyPatternsByCanonicalId.get(canonicalCompanyId);
+        if (pattern) {
+          for (const alias of pattern.allNames) {
+            pushVariant(alias);
+          }
+        }
       }
 
       if (variants.length > 0) {

--- a/packages/convex/convex/__tests__/search-text.test.ts
+++ b/packages/convex/convex/__tests__/search-text.test.ts
@@ -7,12 +7,19 @@ describe("buildIngestSearchTokens", () => {
         expect(buildIngestSearchTokens({
             industryTags: [" Machinery ", "machinery"],
             synonymHits: ["CNC", "sales engineer"],
+            brandHits: [
+                { brand: " 三菱 " },
+                { brand: "三菱" },
+                { brand: "MITSUBISHI" },
+            ],
             companyHits: ["FANUC", "fanuc"],
-            companyAliasTokens: "  Fanuc 发那科  ",
+            companyPatternAliasTokens: "  Fanuc 发那科 Mitsubishi 三菱  ",
         })).toEqual([
             "machinery",
             "cnc",
             "sales engineer",
+            "三菱",
+            "mitsubishi",
             "fanuc",
             "发那科",
         ]);
@@ -28,12 +35,16 @@ describe("appendMissingSearchTokens", () => {
 });
 
 describe("mergeSearchTextWithIngestData", () => {
-    it("augments search text with industry tags, companies, synonyms, and aliases", () => {
-        expect(mergeSearchTextWithIngestData("销售 cnc", {
+    it("augments search text with industry tags, brands, companies, synonyms, and aliases", () => {
+        expect(mergeSearchTextWithIngestData("销售 cnc 三菱", {
             industryTags: ["machinery", "sales"],
             synonymHits: ["sales engineer", "cnc"],
+            brandHits: [
+                { brand: "三菱" },
+                { brand: "MITSUBISHI" },
+            ],
             companyHits: ["fanuc"],
-            companyAliasTokens: "fanuc 发那科",
-        })).toBe("销售 cnc machinery sales sales engineer fanuc 发那科");
+            companyPatternAliasTokens: "fanuc 发那科 mitsubishi 三菱",
+        })).toBe("销售 cnc 三菱 machinery sales sales engineer mitsubishi fanuc 发那科");
     });
 });

--- a/packages/convex/convex/ingest_agent.ts
+++ b/packages/convex/convex/ingest_agent.ts
@@ -110,7 +110,7 @@ export const processNewResumes = internalAction({
           computedAt: item.computedAt,
           skillsVersion: item.skillsVersion,
         },
-        companyAliasTokens: item.companyAliasTokens || "",
+        companyPatternAliasTokens: item.companyPatternAliasTokens || "",
         primaryRuleScore: typeof item.primaryRuleScore === "number" ? item.primaryRuleScore : 0,
       }));
 

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -244,6 +244,7 @@ export const backfillSearchText = mutation({
             const searchText = mergeSearchTextWithIngestData(buildSearchText(resume.content), {
                 industryTags: resume.ingestData?.industryTags,
                 synonymHits: resume.ingestData?.synonymHits,
+                brandHits: resume.ingestData?.brandHits,
                 companyHits: resume.ingestData?.companyHits,
             });
 
@@ -272,6 +273,7 @@ export const reindexSearchText = mutation({
             const searchText = mergeSearchTextWithIngestData(buildSearchText(resume.content), {
                 industryTags: resume.ingestData?.industryTags,
                 synonymHits: resume.ingestData?.synonymHits,
+                brandHits: resume.ingestData?.brandHits,
                 companyHits: resume.ingestData?.companyHits,
             });
             if (searchText !== resume.searchText) {

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -764,7 +764,7 @@ export const updateIngestData = internalMutation({
             computedAt: v.number(),
             skillsVersion: v.number(),
         }),
-        companyAliasTokens: v.optional(v.string()),
+        companyPatternAliasTokens: v.optional(v.string()),
         primaryRuleScore: v.optional(v.number()),
     },
     handler: async (ctx, args) => {
@@ -780,8 +780,9 @@ export const updateIngestData = internalMutation({
         const nextSearchText = mergeSearchTextWithIngestData(existingSearchText, {
             industryTags: args.ingestData.industryTags,
             synonymHits: args.ingestData.synonymHits,
+            brandHits: args.ingestData.brandHits,
             companyHits: args.ingestData.companyHits,
-            companyAliasTokens: args.companyAliasTokens?.trim().toLowerCase(),
+            companyPatternAliasTokens: args.companyPatternAliasTokens?.trim().toLowerCase(),
         });
 
         if (nextSearchText !== existingSearchText) {
@@ -861,7 +862,7 @@ export const updateIngestDataBatch = internalMutation({
                 computedAt: v.number(),
                 skillsVersion: v.number(),
             }),
-            companyAliasTokens: v.optional(v.string()),
+            companyPatternAliasTokens: v.optional(v.string()),
             primaryRuleScore: v.optional(v.number()),
         })),
     },
@@ -879,8 +880,9 @@ export const updateIngestDataBatch = internalMutation({
             const nextSearchText = mergeSearchTextWithIngestData(existingSearchText, {
                 industryTags: update.ingestData.industryTags,
                 synonymHits: update.ingestData.synonymHits,
+                brandHits: update.ingestData.brandHits,
                 companyHits: update.ingestData.companyHits,
-                companyAliasTokens: update.companyAliasTokens?.trim().toLowerCase(),
+                companyPatternAliasTokens: update.companyPatternAliasTokens?.trim().toLowerCase(),
             });
 
             if (nextSearchText !== existingSearchText) {

--- a/packages/convex/convex/search_text.ts
+++ b/packages/convex/convex/search_text.ts
@@ -66,19 +66,24 @@ export function appendMissingSearchTokens(existingSearchText: string, tokens: re
 type IngestSearchTextOptions = {
     industryTags?: readonly string[];
     synonymHits?: readonly string[];
+    brandHits?: readonly { brand: string }[];
     companyHits?: readonly string[];
-    companyAliasTokens?: string;
+    companyPatternAliasTokens?: string;
 };
 
 export function buildIngestSearchTokens(options: IngestSearchTextOptions): string[] {
-    const aliasTokens = typeof options.companyAliasTokens === "string"
-        ? options.companyAliasTokens.split(/\s+/)
+    const aliasTokens = typeof options.companyPatternAliasTokens === "string"
+        ? options.companyPatternAliasTokens.split(/\s+/)
+        : [];
+    const brandTokens = Array.isArray(options.brandHits)
+        ? options.brandHits.map((hit) => hit.brand)
         : [];
 
     return Array.from(
         new Set([
             ...toNormalizedSearchTokens(options.industryTags),
             ...toNormalizedSearchTokens(options.synonymHits),
+            ...toNormalizedSearchTokens(brandTokens),
             ...toNormalizedSearchTokens(options.companyHits),
             ...toNormalizedSearchTokens(aliasTokens),
         ])


### PR DESCRIPTION
## Summary
- include `brandHits` and company-pattern alias tokens when enriching Convex `searchText`
- expand company-pattern aliases in unified keyword expansion so queries like `三菱` resolve to canonical and alternate brand terms
- add regression coverage for ingest alias tokens, keyword expansion, and search text dedupe

## Test plan
- [x] `bun test ./apps/api/src/services/ingest-compute-service.test.ts ./apps/api/src/services/unified-search-service.test.ts ./packages/convex/convex/__tests__/search-text.test.ts`
- [x] `make check`