### PR TITLE
feat(export): add industry DB V2 raw/normalized columns with batch normalization

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+regexTarget = "match"
+regexes = [
+  '''industryDbV2(Raw|Normalized)''',
+]

--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -261,6 +261,7 @@ describe("resume export route", () => {
               workHistory: [{ raw: "Alice history" }],
               ingestData: {
                 industryTags: ["machinery"],
+                industryDbV2Raw: 25,
                 brandHits: [
                   {
                     brand: "fanuc",
@@ -293,6 +294,9 @@ describe("resume export route", () => {
               profileUrl: "https://example.com/b",
               source: "seek",
               workHistory: [{ raw: "Bob history" }],
+              ingestData: {
+                industryDbV2Raw: 20,
+              },
             },
           },
         ]);
@@ -309,6 +313,15 @@ describe("resume export route", () => {
       body: JSON.stringify({
         format: "xlsx",
         source: "convex",
+        industryDbV2Stats: {
+          size: 50,
+          p80: 20,
+          histogram50: Array.from({ length: 51 }, (_, index) => {
+            if (index === 20) return 40;
+            if (index === 25) return 10;
+            return 0;
+          }),
+        },
         entries: [
           { resumeId: "convex-b", status: "contacted" },
           { resumeId: "convex-a", status: "new" },
@@ -330,11 +343,19 @@ describe("resume export route", () => {
     await workbook.xlsx.load(Buffer.from(await response.arrayBuffer()));
     const sheet = workbook.getWorksheet("Resumes");
     const brandHitsColumn = findColumnIndex(sheet, "Brand Hits");
+    const industryDbRawColumn = findColumnIndex(sheet, "Industry DB V2 Raw");
+    const industryDbNormalizedColumn = findColumnIndex(sheet, "Industry DB V2 Normalized");
     expect(sheet?.getCell("A2").value).toBe("convex-b");
     expect(sheet?.getCell("B2").value).toBe("Bob");
     expect(sheet?.getCell("A3").value).toBe("convex-a");
     expect(sheet?.getCell("B3").value).toBe("Alice");
     expect(brandHitsColumn).toBeGreaterThan(0);
+    expect(industryDbRawColumn).toBeGreaterThan(0);
+    expect(industryDbNormalizedColumn).toBeGreaterThan(0);
+    expect(sheet?.getRow(2).getCell(industryDbRawColumn).value).toBe(20);
+    expect(sheet?.getRow(2).getCell(industryDbNormalizedColumn).value).toBe(40);
+    expect(sheet?.getRow(3).getCell(industryDbRawColumn).value).toBe(25);
+    expect(sheet?.getRow(3).getCell(industryDbNormalizedColumn).value).toBe(45);
     expect(sheet?.getRow(3).getCell(brandHitsColumn).value).toBe("发那科");
   });
 

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -47,6 +47,10 @@ import {
   type ExportBatchMeta,
   type ResumeExportEntry,
 } from "../services/export-service.js";
+import {
+  computeBatchStats,
+  type IndustryDbV2BatchStats,
+} from "../services/industry-db-batch-stats.js";
 import { submitResumeImport } from "../services/resume-import-service.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { BrandDisplayResolver } from "../services/brand-display-resolver.js";
@@ -345,29 +349,34 @@ function isCanonicalExportRequest(
 
 async function resolveExportRequest(
   request: ResumeExportRequest
-): Promise<{ format: ExportFormat; entries: ResumeExportEntry[]; batchMeta: ExportBatchMeta }> {
+): Promise<{
+  format: ExportFormat;
+  entries: ResumeExportEntry[];
+  batchMeta: ExportBatchMeta;
+  industryDbV2Stats: IndustryDbV2BatchStats;
+}> {
+  let entries: ResumeExportEntry[];
+
   if (!isCanonicalExportRequest(request)) {
-    return {
-      format: request.format,
-      entries: request.entries.map((entry) => toExportEntry(entry.key, entry.resume, toExportEntryFields(entry))),
-      batchMeta: {
-        userComment: request.userComment,
-        referenceNote: request.referenceNote,
-      },
-    };
+    entries = request.entries.map((entry) => toExportEntry(entry.key, entry.resume, toExportEntryFields(entry)));
+  } else {
+    const resolvedResumes = request.source === "sample"
+      ? resolveSampleExportResumeMap(request.sample ?? "", request.entries)
+      : await resolveConvexExportResumeMap(request.entries);
+    entries = buildExportEntriesFromResolvedResumes(request.entries, resolvedResumes);
   }
 
-  const resolvedResumes = request.source === "sample"
-    ? resolveSampleExportResumeMap(request.sample ?? "", request.entries)
-    : await resolveConvexExportResumeMap(request.entries);
+  const industryDbV2Stats = request.industryDbV2Stats
+    ?? computeBatchStats(entries.map((entry) => entry.resume.ingestData?.industryDbV2Raw));
 
   return {
     format: request.format,
-    entries: buildExportEntriesFromResolvedResumes(request.entries, resolvedResumes),
+    entries,
     batchMeta: {
       userComment: request.userComment,
       referenceNote: request.referenceNote,
     },
+    industryDbV2Stats,
   };
 }
 
@@ -1882,8 +1891,8 @@ app.openapi(rescoreResumeMatchesRoute, (c) => {
 });
 
 async function buildResumeExportResponse(request: z.infer<typeof ResumeExportRequestSchema>) {
-  const { format, entries, batchMeta } = await resolveExportRequest(request);
-  const file = await exportService.exportResumes(format, entries, batchMeta);
+  const { format, entries, batchMeta, industryDbV2Stats } = await resolveExportRequest(request);
+  const file = await exportService.exportResumes(format, entries, batchMeta, industryDbV2Stats);
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const filename = `resumes-export-${timestamp}.${file.extension}`;
 

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -513,6 +513,19 @@ export const ResumeExportEntryContextSchema = z
   })
   .openapi("ResumeExportEntryContext");
 
+export const IndustryDbV2StatsSchema = z
+  .object({
+    size: z.number().int().min(0).openapi({ example: 50 }),
+    min: z.number().optional().openapi({ example: 0 }),
+    max: z.number().optional().openapi({ example: 25 }),
+    p50: z.number().optional().openapi({ example: 10 }),
+    p80: z.number().openapi({ example: 20 }),
+    mean: z.number().optional().openapi({ example: 12.4 }),
+    stddev: z.number().optional().openapi({ example: 6.8 }),
+    histogram50: z.array(z.number().int().min(0)).length(51),
+  })
+  .openapi("IndustryDbV2Stats");
+
 export const ResumeExportCanonicalRequestSchema = z
   .object({
     format: z.enum(["csv", "xlsx"]).default("csv").openapi({ example: "csv" }),
@@ -520,6 +533,7 @@ export const ResumeExportCanonicalRequestSchema = z
     sample: z.string().optional().openapi({ example: "sample-initial" }),
     userComment: z.string().optional().openapi({ example: "Batch note" }),
     referenceNote: z.string().optional().openapi({ example: "Internal export" }),
+    industryDbV2Stats: IndustryDbV2StatsSchema.optional(),
     entries: z.array(ResumeExportEntryContextSchema).min(1).max(2000),
   })
   .superRefine((value, ctx) => {
@@ -597,6 +611,7 @@ export const ResumeExportResolvedResumeSchema = z.object({
       industryTags: z.array(z.string()).optional(),
       brandHits: z.array(ResumeExportLegacyBrandHitSchema).optional(),
       companyHits: z.array(z.string()).optional(),
+      industryDbV2Raw: z.number().optional(),
       roleSignals: z.array(ResumeExportLegacyRoleSignalSchema).optional(),
     })
     .optional(),
@@ -609,6 +624,7 @@ export const ResumeExportLegacyRequestSchema = z
     format: z.enum(["csv", "xlsx"]).default("csv"),
     userComment: z.string().optional(),
     referenceNote: z.string().optional(),
+    industryDbV2Stats: IndustryDbV2StatsSchema.optional(),
     entries: z
       .array(
         z.object({

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -22,6 +22,7 @@ function buildEntry(age: string | undefined): ResumeExportEntry {
       ingestData: {
         industryTags: ["cnc"],
         companyHits: ["FANUC"],
+        industryDbV2Raw: 20,
         brandHits: [
           {
             brand: "fanuc",
@@ -113,6 +114,41 @@ describe("ExportService", () => {
 
     expect(parsed.data[0]?.userComment).toBe("Excellent candidate");
     expect(parsed.data[0]?.referenceNote).toBe("Referred by HR dept");
+  });
+
+  it("exports industry DB raw and normalized columns in CSV output", async () => {
+    const service = new ExportService();
+    const firstEntry = buildEntry("25");
+    const secondEntry: ResumeExportEntry = {
+      ...buildEntry("26"),
+      key: "resume-2",
+      resume: {
+        ...buildEntry("26").resume,
+        ingestData: {
+          ...buildEntry("26").resume.ingestData,
+          industryDbV2Raw: 25,
+        },
+      },
+    };
+
+    const file = await service.exportResumes("csv", [firstEntry, secondEntry], undefined, {
+      size: 50,
+      p80: 20,
+      histogram50: Array.from({ length: 51 }, (_, index) => {
+        if (index === 20) return 40;
+        if (index === 25) return 10;
+        return 0;
+      }),
+    });
+    const csv = file.content.toString("utf8");
+    const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
+
+    expect(parsed.meta.fields).toContain("industryDbV2Raw");
+    expect(parsed.meta.fields).toContain("industryDbV2Normalized");
+    expect(parsed.data[0]?.industryDbV2Raw).toBe("20");
+    expect(parsed.data[0]?.industryDbV2Normalized).toBe("40");
+    expect(parsed.data[1]?.industryDbV2Raw).toBe("25");
+    expect(parsed.data[1]?.industryDbV2Normalized).toBe("45");
   });
 
   it("applies batch-level userComment/referenceNote to every exported row", async () => {
@@ -296,6 +332,8 @@ describe("ExportService", () => {
           const lower = part.toLowerCase();
           if (lower === "id") return "ID";
           if (lower === "ai") return "AI";
+          if (lower === "db") return "DB";
+          if (lower === "v2") return "V2";
           if (lower === "url") return "URL";
           return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
         })

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -11,6 +11,10 @@ import {
   normalizeCompanyPatternIdentifier,
   type CompanyPattern,
 } from "./skills-knowledge.js";
+import {
+  createBatchNormalizer,
+  type IndustryDbV2BatchStats,
+} from "./industry-db-batch-stats.js";
 import type { ResumeIngestData } from "../types/resume.js";
 
 export type ExportFormat = "csv" | "xlsx";
@@ -62,6 +66,8 @@ type ExportRow = {
   age: number | "";
   expectedSalary: string;
   aiScore: number | "";
+  industryDbV2Raw: number;
+  industryDbV2Normalized: number;
   ruleScore: number | "";
   recommendation: string;
   status: string;
@@ -218,6 +224,7 @@ function summarizeBrandHits(
 
 function toRow(
   entry: ResumeExportEntry,
+  batchNormalizer: (raw: number | undefined) => { raw: number; normalized: number },
   brandDisplayResolver?: BrandDisplayResolver,
   companyPatternAliasLookup?: Map<string, string>
 ): ExportRow {
@@ -227,6 +234,9 @@ function toRow(
       .filter((item) => item.trim().length > 0)
       .join(" | ")
     : "";
+  const { raw: industryDbV2Raw, normalized: industryDbV2Normalized } = batchNormalizer(
+    entry.resume.ingestData?.industryDbV2Raw
+  );
 
   return {
     resumeId: entry.key,
@@ -238,6 +248,8 @@ function toRow(
     age: parseAgeNumber(entry.resume.age) ?? "",
     expectedSalary: normalizeString(entry.resume.expectedSalary),
     aiScore: typeof entry.match?.score === "number" ? entry.match.score : "",
+    industryDbV2Raw,
+    industryDbV2Normalized,
     ruleScore: typeof entry.ruleScore === "number" ? entry.ruleScore : "",
     recommendation: normalizeString(entry.match?.recommendation),
     status: normalizeString(entry.status),
@@ -273,6 +285,8 @@ const EXCEL_COLUMNS: Array<{ header: string; key: keyof ExportRow; width: number
   { header: "Age", key: "age", width: 10 },
   { header: "Expected Salary", key: "expectedSalary", width: 16 },
   { header: "AI Score", key: "aiScore", width: 10 },
+  { header: "Industry DB V2 Raw", key: "industryDbV2Raw", width: 18 },
+  { header: "Industry DB V2 Normalized", key: "industryDbV2Normalized", width: 24 },
   { header: "Rule Score", key: "ruleScore", width: 10 },
   { header: "Recommendation", key: "recommendation", width: 16 },
   { header: "Status", key: "status", width: 16 },
@@ -323,11 +337,18 @@ export class ExportService {
   async exportResumes(
     format: ExportFormat,
     entries: ResumeExportEntry[],
-    batchMeta?: ExportBatchMeta
+    batchMeta?: ExportBatchMeta,
+    industryDbV2Stats?: IndustryDbV2BatchStats
   ): Promise<ExportFile> {
+    const batchNormalizer = createBatchNormalizer(industryDbV2Stats);
     const rows = entries.map((entry) =>
       applyBatchMeta(
-        toRow(entry, this.brandDisplayResolver, this.companyPatternAliasLookup),
+        toRow(
+          entry,
+          batchNormalizer,
+          this.brandDisplayResolver,
+          this.companyPatternAliasLookup
+        ),
         batchMeta
       )
     );

--- a/apps/api/src/services/industry-db-batch-stats.test.ts
+++ b/apps/api/src/services/industry-db-batch-stats.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clampIndustryDbV2RawScore,
+  computeBatchStats,
+  normalizeIndustryDbScore,
+} from "./industry-db-batch-stats.js";
+
+describe("industry-db-batch-stats", () => {
+  it("computes deterministic batch statistics and histogram buckets", () => {
+    const stats = computeBatchStats([-5, 10, 20, 20, 60]);
+
+    expect(stats).toEqual({
+      size: 5,
+      min: 0,
+      max: 50,
+      p50: 20,
+      p80: 26,
+      mean: 20,
+      stddev: 16.73,
+      histogram50: Array.from({ length: 51 }, (_, index) => {
+        if (index === 0) return 1;
+        if (index === 10) return 1;
+        if (index === 20) return 2;
+        if (index === 50) return 1;
+        return 0;
+      }),
+    });
+  });
+
+  it("mirrors the UI normalization formula for strong cohorts", () => {
+    const normalized = normalizeIndustryDbScore(25, {
+      size: 50,
+      p80: 20,
+      histogram50: Array.from({ length: 51 }, (_, index) => {
+        if (index === 20) return 40;
+        if (index === 25) return 10;
+        return 0;
+      }),
+      min: 0,
+      max: 25,
+      p50: 20,
+      mean: 21,
+      stddev: 2,
+    });
+
+    expect(normalized.normalized).toBe(45);
+    expect(normalized.guardRailApplied).toBe(false);
+    expect(normalized.percentileRank).toBeGreaterThan(0.8);
+  });
+
+  it("falls back to raw score when cohort guard rails are not met", () => {
+    expect(normalizeIndustryDbScore(12, {
+      size: 10,
+      p80: 12,
+      histogram50: Array.from({ length: 51 }, () => 0),
+    })).toEqual({
+      raw: 12,
+      normalized: 12,
+      percentileRank: 0,
+      guardRailApplied: true,
+    });
+  });
+
+  it("coerces invalid raw inputs to the supported score range", () => {
+    expect(clampIndustryDbV2RawScore(undefined)).toBe(0);
+    expect(clampIndustryDbV2RawScore(Number.NaN)).toBe(0);
+    expect(clampIndustryDbV2RawScore(-3)).toBe(0);
+    expect(clampIndustryDbV2RawScore(88)).toBe(50);
+  });
+});

--- a/apps/api/src/services/industry-db-batch-stats.ts
+++ b/apps/api/src/services/industry-db-batch-stats.ts
@@ -1,0 +1,218 @@
+export type IndustryDbV2BatchStats = {
+  size: number;
+  p80: number;
+  histogram50: number[];
+  min?: number;
+  max?: number;
+  p50?: number;
+  mean?: number;
+  stddev?: number;
+};
+
+export type NormalizedIndustryDbScore = {
+  raw: number;
+  normalized: number;
+  percentileRank: number;
+  guardRailApplied: boolean;
+};
+
+const INDUSTRY_DB_V2_SCORE_CAP = 50;
+const INDUSTRY_DB_V2_HISTOGRAM_SIZE = 51;
+const INDUSTRY_DB_V2_MIN_NORMALIZATION_SAMPLE_SIZE = 30;
+
+function roundTo2(value: number): number {
+  return Number(value.toFixed(2));
+}
+
+export function clampIndustryDbV2RawScore(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(INDUSTRY_DB_V2_SCORE_CAP, value));
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function quantile(sorted: number[], q: number): number {
+  if (sorted.length === 0) {
+    return 0;
+  }
+
+  const clampedQ = clamp(q, 0, 1);
+  const position = (sorted.length - 1) * clampedQ;
+  const lowerIndex = Math.floor(position);
+  const upperIndex = Math.ceil(position);
+
+  if (lowerIndex === upperIndex) {
+    return sorted[lowerIndex];
+  }
+
+  const weight = position - lowerIndex;
+  return sorted[lowerIndex] * (1 - weight) + sorted[upperIndex] * weight;
+}
+
+function normalizeHistogram50(histogram50: number[]): number[] {
+  return Array.from({ length: INDUSTRY_DB_V2_HISTOGRAM_SIZE }, (_, score) => {
+    const count = histogram50[score];
+    return Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+  });
+}
+
+function countHistogramSamples(histogram50: number[]): number {
+  return histogram50.reduce((total, count) => total + count, 0);
+}
+
+function percentileRankFromHistogram(histogram50: number[], raw: number): number {
+  const total = countHistogramSamples(histogram50);
+  if (total <= 1) {
+    return 1;
+  }
+
+  const roundedRaw = Math.round(clamp(raw, 0, INDUSTRY_DB_V2_SCORE_CAP));
+  let lowerBound = 0;
+  let upperBound = 0;
+
+  histogram50.forEach((count, score) => {
+    if (score < roundedRaw) {
+      lowerBound += count;
+      upperBound += count;
+      return;
+    }
+
+    if (score === roundedRaw) {
+      upperBound += count;
+    }
+  });
+
+  if (upperBound === 0) {
+    return 0;
+  }
+
+  if (lowerBound === total) {
+    return 1;
+  }
+
+  const midpoint = (lowerBound + upperBound - 1) / 2;
+  return midpoint / (total - 1);
+}
+
+export function computeBatchStats(rawScores: Array<number | undefined>): IndustryDbV2BatchStats {
+  const sorted = rawScores
+    .map((score) => clampIndustryDbV2RawScore(score))
+    .sort((left, right) => left - right);
+  const histogram50 = Array.from({ length: INDUSTRY_DB_V2_HISTOGRAM_SIZE }, () => 0);
+
+  sorted.forEach((score) => {
+    histogram50[Math.round(score)] += 1;
+  });
+
+  if (sorted.length === 0) {
+    return {
+      size: 0,
+      min: 0,
+      max: 0,
+      p50: 0,
+      p80: 0,
+      mean: 0,
+      stddev: 0,
+      histogram50,
+    };
+  }
+
+  const mean = sorted.reduce((total, score) => total + score, 0) / sorted.length;
+  const variance = sorted.reduce((total, score) => total + (score - mean) ** 2, 0) / sorted.length;
+
+  return {
+    size: sorted.length,
+    min: roundTo2(sorted[0]),
+    max: roundTo2(sorted[sorted.length - 1]),
+    p50: roundTo2(quantile(sorted, 0.5)),
+    p80: roundTo2(quantile(sorted, 0.8)),
+    mean: roundTo2(mean),
+    stddev: roundTo2(Math.sqrt(variance)),
+    histogram50,
+  };
+}
+
+function guardRailResult(safeRaw: number): NormalizedIndustryDbScore {
+  return {
+    raw: safeRaw,
+    normalized: Math.round(safeRaw),
+    percentileRank: 0,
+    guardRailApplied: true,
+  };
+}
+
+type PreparedNormalizationContext = {
+  histogram50: number[];
+  sampleSize: number;
+  p80: number;
+};
+
+function prepareNormalizationContext(
+  stats: IndustryDbV2BatchStats
+): PreparedNormalizationContext | null {
+  if (stats.size < INDUSTRY_DB_V2_MIN_NORMALIZATION_SAMPLE_SIZE || stats.p80 <= 5) {
+    return null;
+  }
+
+  const histogram50 = normalizeHistogram50(stats.histogram50);
+  const sampleSize = countHistogramSamples(histogram50);
+  if (sampleSize < INDUSTRY_DB_V2_MIN_NORMALIZATION_SAMPLE_SIZE) {
+    return null;
+  }
+
+  return { histogram50, sampleSize, p80: stats.p80 };
+}
+
+function normalizeWithContext(
+  raw: number | undefined,
+  ctx: PreparedNormalizationContext
+): NormalizedIndustryDbScore {
+  const safeRaw = clampIndustryDbV2RawScore(raw);
+  const percentileRank = percentileRankFromHistogram(ctx.histogram50, safeRaw);
+  const base = 40 * clamp(safeRaw / Math.max(ctx.p80, 1), 0, 1);
+  const bonus = 10 * clamp((percentileRank - 0.8) / 0.2, 0, 1);
+
+  return {
+    raw: safeRaw,
+    normalized: Math.round(Math.min(INDUSTRY_DB_V2_SCORE_CAP, base + bonus)),
+    percentileRank,
+    guardRailApplied: false,
+  };
+}
+
+export function normalizeIndustryDbScore(
+  raw: number | undefined,
+  stats: IndustryDbV2BatchStats | undefined
+): NormalizedIndustryDbScore {
+  const safeRaw = clampIndustryDbV2RawScore(raw);
+  if (!stats) {
+    return guardRailResult(safeRaw);
+  }
+
+  const ctx = prepareNormalizationContext(stats);
+  if (!ctx) {
+    return guardRailResult(safeRaw);
+  }
+
+  return normalizeWithContext(raw, ctx);
+}
+
+export function createBatchNormalizer(
+  stats: IndustryDbV2BatchStats | undefined
+): (raw: number | undefined) => NormalizedIndustryDbScore {
+  if (!stats) {
+    return (raw) => guardRailResult(clampIndustryDbV2RawScore(raw));
+  }
+
+  const ctx = prepareNormalizationContext(stats);
+  if (!ctx) {
+    return (raw) => guardRailResult(clampIndustryDbV2RawScore(raw));
+  }
+
+  return (raw) => normalizeWithContext(raw, ctx);
+}

--- a/apps/api/src/types/resume.ts
+++ b/apps/api/src/types/resume.ts
@@ -52,6 +52,7 @@ export type ResumeIngestData = {
   industryTags?: string[];
   brandHits?: ResumeIngestBrandHit[];
   companyHits?: string[];
+  industryDbV2Raw?: number;
   roleSignals?: ResumeIngestRoleSignal[];
 };
 

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -619,6 +619,68 @@ describe('useResumeListState role filter regression', () => {
     }))
   })
 
+  it('includes applied frozen industry DB cohort stats in export requests', async () => {
+    mockState.searchHistory = [
+      {
+        id: 'history-export',
+        sessionKey: 'session-1',
+        title: 'Saved search',
+        location: '苏州',
+        keywords: ['CNC', '销售'],
+        jobDescriptionId: 'lathe-sales',
+        filters: {},
+        selectedTags: [],
+        selectedCompanies: [],
+        selectedExperienceLevel: undefined,
+        industryDbV2Stats: {
+          size: 50,
+          min: 0,
+          max: 25,
+          p50: 10,
+          p80: 20,
+          mean: 12.4,
+          stddev: 6.8,
+          histogram50: Array.from({ length: 51 }, (_, index) => {
+            if (index === 20) return 40
+            if (index === 25) return 10
+            return 0
+          }),
+        },
+        createdAt: 1,
+        lastOpenedAt: 2,
+      },
+    ]
+
+    const { result } = renderHook(() => useResumeListState())
+
+    await act(async () => {
+      await result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
+    })
+
+    act(() => {
+      result.current.handleToggleSelect('resume-ideal-cnc-sales')
+    })
+
+    await act(async () => {
+      await result.current.handleBulkAction('export', 'csv')
+    })
+
+    const parsedBody = JSON.parse(submittedPayloadValue) as {
+      industryDbV2Stats?: {
+        size: number
+        min?: number
+        max?: number
+        p50?: number
+        p80: number
+        mean?: number
+        stddev?: number
+        histogram50: number[]
+      }
+    }
+
+    expect(parsedBody.industryDbV2Stats).toEqual(mockState.searchHistory[0].industryDbV2Stats)
+  })
+
   it('applies saved search history and updates opened timestamp', async () => {
     mockState.searchHistory = [
       {

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1196,6 +1196,9 @@ export function useResumeListState(loadSearchHistory = false) {
           format: exportFormat,
           source: mode === 'ai' ? 'convex' : 'sample',
           entries: exportEntries,
+          ...(appliedSearchHistory?.industryDbV2Stats
+            ? { industryDbV2Stats: appliedSearchHistory.industryDbV2Stats }
+            : {}),
           ...(mode === 'ai' ? {} : { sample: selectedSample }),
         }
 
@@ -1232,7 +1235,7 @@ export function useResumeListState(loadSearchHistory = false) {
         toast.error(t('bulk.actionFailed', { defaultValue: 'Bulk action failed. Please try again.' }))
       }
     },
-    [apiBaseUrl, blockCandidates, bulkExportFormat, displayedResumes, mode, saveAction, selectedIds, selectedSample, sendLearningFeedback, t]
+    [apiBaseUrl, appliedSearchHistory?.industryDbV2Stats, blockCandidates, bulkExportFormat, displayedResumes, mode, saveAction, selectedIds, selectedSample, sendLearningFeedback, t]
   )
 
   const actionFeedbackLabels = useMemo<Partial<Record<CandidateActionType, string>>>(

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4302,6 +4302,23 @@ export interface components {
         };
         /** @enum {string} */
         ResumeExportSource: "sample" | "convex";
+        IndustryDbV2Stats: {
+            /** @example 50 */
+            size: number;
+            /** @example 0 */
+            min?: number;
+            /** @example 25 */
+            max?: number;
+            /** @example 10 */
+            p50?: number;
+            /** @example 20 */
+            p80: number;
+            /** @example 12.4 */
+            mean?: number;
+            /** @example 6.8 */
+            stddev?: number;
+            histogram50: number[];
+        };
         ResumeExportMatch: {
             /** @example 88 */
             score: number;
@@ -4347,6 +4364,7 @@ export interface components {
             userComment?: string;
             /** @example Internal export */
             referenceNote?: string;
+            industryDbV2Stats?: components["schemas"]["IndustryDbV2Stats"];
             entries: components["schemas"]["ResumeExportEntryContext"][];
         };
         ResumeExportLegacyRequest: {
@@ -4357,6 +4375,7 @@ export interface components {
             format: "csv" | "xlsx";
             userComment?: string;
             referenceNote?: string;
+            industryDbV2Stats?: components["schemas"]["IndustryDbV2Stats"];
             entries: {
                 key: string;
                 ruleScore?: number;
@@ -4391,6 +4410,7 @@ export interface components {
                             companyId?: number;
                         }[];
                         companyHits?: string[];
+                        industryDbV2Raw?: number;
                         roleSignals?: {
                             type: string;
                             matchedSignals: string[];

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -8,6 +8,7 @@ import {
   hasIngestData,
   isAutoFilteredAnalysis,
   overrideIndustryDbBreakdown,
+  toIndustryDbV2Stats,
   toMatchBreakdown,
   toRecommendation,
 } from '@/lib/resume-scoring'
@@ -200,6 +201,28 @@ describe('resume-scoring', () => {
       p80: 20,
       histogram50: Array.from({ length: 51 }, (_, index) => (index === 20 ? 50 : 0)),
     })).toBe(40)
+  })
+
+  it('parses enriched industry_db cohort stats without dropping legacy fields', () => {
+    expect(toIndustryDbV2Stats({
+      size: 50,
+      min: 0,
+      max: 25,
+      p50: 10,
+      p80: 20,
+      mean: 12.4,
+      stddev: 6.8,
+      histogram50: Array.from({ length: 51 }, (_, index) => (index === 20 ? 50 : 0)),
+    })).toEqual({
+      size: 50,
+      min: 0,
+      max: 25,
+      p50: 10,
+      p80: 20,
+      mean: 12.4,
+      stddev: 6.8,
+      histogram50: Array.from({ length: 51 }, (_, index) => (index === 20 ? 50 : 0)),
+    })
   })
 
   it('adds percentile bonus when industry_db raw score exceeds cohort p80', () => {

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -6,7 +6,12 @@ import { deriveAnalysisLookupKey } from '@/lib/analysis-utils'
 
 export type IndustryDbV2Stats = {
   size: number
+  min?: number
+  max?: number
+  p50?: number
   p80: number
+  mean?: number
+  stddev?: number
   histogram50: number[]
 }
 
@@ -257,14 +262,31 @@ function percentileRankFromHistogram(histogram50: number[], raw: number): number
   return midpoint / (total - 1)
 }
 
+function safeFiniteNumber(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined
+}
+
 export function toIndustryDbV2Stats(value: unknown): IndustryDbV2Stats | undefined {
   if (!isRecord(value) || !Array.isArray(value.histogram50)) {
     return undefined
   }
 
+  const size = safeFiniteNumber(value.size)
+  const min = safeFiniteNumber(value.min)
+  const max = safeFiniteNumber(value.max)
+  const p50 = safeFiniteNumber(value.p50)
+  const p80 = safeFiniteNumber(value.p80)
+  const mean = safeFiniteNumber(value.mean)
+  const stddev = safeFiniteNumber(value.stddev)
+
   return {
-    size: typeof value.size === 'number' && Number.isFinite(value.size) ? Math.max(0, Math.floor(value.size)) : 0,
-    p80: typeof value.p80 === 'number' && Number.isFinite(value.p80) ? value.p80 : 0,
+    size: size !== undefined ? Math.max(0, Math.floor(size)) : 0,
+    ...(min !== undefined && { min }),
+    ...(max !== undefined && { max }),
+    ...(p50 !== undefined && { p50 }),
+    p80: p80 ?? 0,
+    ...(mean !== undefined && { mean }),
+    ...(stddev !== undefined && { stddev }),
     histogram50: normalizeHistogram50(value.histogram50),
   }
 }

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -616,6 +616,7 @@ export const getByIdsForExport = query({
                             industryTags: doc.ingestData.industryTags,
                             brandHits: doc.ingestData.brandHits,
                             companyHits: doc.ingestData.companyHits,
+                            industryDbV2Raw: doc.ingestData.industryDbV2Raw,
                             roleSignals: doc.ingestData.roleSignals,
                         } : undefined,
                     },

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -359,7 +359,12 @@ export default defineSchema({
         workspaceSlug: v.string(),
         computedAt: v.number(),
         size: v.number(),
+        min: v.optional(v.number()),
+        max: v.optional(v.number()),
+        p50: v.optional(v.number()),
         p80: v.number(),
+        mean: v.optional(v.number()),
+        stddev: v.optional(v.number()),
         histogram50: v.array(v.number()),
     })
         .index("by_searchHistoryId", ["searchHistoryId"])

--- a/packages/convex/convex/sessions.ts
+++ b/packages/convex/convex/sessions.ts
@@ -53,6 +53,10 @@ function buildHistoryTitle(location: string, keywords: string[]): string {
 const INDUSTRY_DB_V2_COHORT_MAX_SIZE = 2000;
 const INDUSTRY_DB_V2_HISTOGRAM_SIZE = 51;
 
+function roundTo2(value: number): number {
+    return Number(value.toFixed(2));
+}
+
 function clampIndustryDbV2RawScore(value: number): number {
     if (!Number.isFinite(value)) {
         return 0;
@@ -80,7 +84,16 @@ function quantile(sorted: number[], q: number): number {
 async function buildIndustryDbV2Cohort(
     ctx: MutationCtx,
     resumeIds: string[],
-): Promise<{ size: number; p80: number; histogram50: number[] } | null> {
+): Promise<{
+    size: number;
+    min: number;
+    max: number;
+    p50: number;
+    p80: number;
+    mean: number;
+    stddev: number;
+    histogram50: number[];
+} | null> {
     const limitedResumeIds = normalizeStringList(resumeIds).slice(0, INDUSTRY_DB_V2_COHORT_MAX_SIZE);
     if (limitedResumeIds.length === 0) {
         return null;
@@ -94,10 +107,17 @@ async function buildIndustryDbV2Cohort(
     sorted.forEach((score: number) => {
         histogram50[Math.round(score)] += 1;
     });
+    const mean = sorted.reduce((total: number, score: number) => total + score, 0) / sorted.length;
+    const variance = sorted.reduce((total: number, score: number) => total + ((score - mean) ** 2), 0) / sorted.length;
 
     return {
         size: sorted.length,
-        p80: Number(quantile(sorted, 0.8).toFixed(2)),
+        min: roundTo2(sorted[0] ?? 0),
+        max: roundTo2(sorted[sorted.length - 1] ?? 0),
+        p50: roundTo2(quantile(sorted, 0.5)),
+        p80: roundTo2(quantile(sorted, 0.8)),
+        mean: roundTo2(mean),
+        stddev: roundTo2(Math.sqrt(variance)),
         histogram50,
     };
 }
@@ -258,7 +278,12 @@ export const listSearchHistory = query({
                     industryDbV2Stats: cohort
                         ? {
                             size: cohort.size,
+                            min: cohort.min,
+                            max: cohort.max,
+                            p50: cohort.p50,
                             p80: cohort.p80,
+                            mean: cohort.mean,
+                            stddev: cohort.stddev,
                             histogram50: cohort.histogram50,
                         }
                         : undefined,
@@ -328,7 +353,12 @@ export const saveSearchHistory = mutation({
                 workspaceSlug,
                 computedAt: now,
                 size: cohort.size,
+                min: cohort.min,
+                max: cohort.max,
+                p50: cohort.p50,
                 p80: cohort.p80,
+                mean: cohort.mean,
+                stddev: cohort.stddev,
                 histogram50: cohort.histogram50,
             });
         }


### PR DESCRIPTION
## Summary
- Add `industryDbV2Raw` and `industryDbV2Normalized` columns to resume CSV/XLSX exports, powered by cohort statistics (min, max, p50, p80, mean, stddev, histogram) computed at search-save time in Convex.
- Introduce `createBatchNormalizer` to pre-compute histogram normalization once per batch instead of per row, eliminating N redundant array allocations and 3N histogram iterations for N-entry exports.
- Move `computeBatchStats` fallback into `resolveExportRequest` to keep the export response builder clean.
- Extract `safeFiniteNumber` helper in `toIndustryDbV2Stats` to reduce repetitive validation.
- Add `.gitleaks.toml` allowlist for false-positive column key detections.

## Test plan
- [x] `industry-db-batch-stats.test.ts` — 4 tests: batch stats computation, normalization formula, guard rails, input clamping
- [x] `export-service.test.ts` — 12 tests: CSV/XLSX output including new columns
- [x] `resumes-export.test.ts` — 5 tests: end-to-end export route with industry DB stats passthrough
- [x] `resume-scoring.test.ts` — 15 tests: `toIndustryDbV2Stats` parser, normalization
- [x] `useResumeListState.test.tsx` — 23 tests: frozen cohort stats included in export requests