### PR TITLE
fix(scoring): allow normalization when batch p80 is 0

### DIFF
--- a/apps/api/src/services/industry-db-batch-stats.test.ts
+++ b/apps/api/src/services/industry-db-batch-stats.test.ts
@@ -62,6 +62,31 @@ describe("industry-db-batch-stats", () => {
     });
   });
 
+  it("normalizes sparse batches where p80 is 0 due to majority-zero scores", () => {
+    const histogram50 = Array.from({ length: 51 }, (_, i) => {
+      if (i === 0) return 77;
+      if (i === 6) return 1;
+      if (i === 8) return 3;
+      if (i === 10) return 1;
+      if (i === 12) return 1;
+      if (i === 20) return 1;
+      if (i === 30) return 1;
+      return 0;
+    });
+    const stats = { size: 85, p80: 0, histogram50 };
+
+    const zero = normalizeIndustryDbScore(0, stats);
+    expect(zero.normalized).toBe(0);
+    expect(zero.guardRailApplied).toBe(false);
+
+    const six = normalizeIndustryDbScore(6, stats);
+    expect(six.normalized).toBeGreaterThan(0);
+    expect(six.guardRailApplied).toBe(false);
+
+    const thirty = normalizeIndustryDbScore(30, stats);
+    expect(thirty.normalized).toBeGreaterThan(six.normalized);
+  });
+
   it("coerces invalid raw inputs to the supported score range", () => {
     expect(clampIndustryDbV2RawScore(undefined)).toBe(0);
     expect(clampIndustryDbV2RawScore(Number.NaN)).toBe(0);

--- a/apps/api/src/services/industry-db-batch-stats.ts
+++ b/apps/api/src/services/industry-db-batch-stats.ts
@@ -155,7 +155,7 @@ type PreparedNormalizationContext = {
 function prepareNormalizationContext(
   stats: IndustryDbV2BatchStats
 ): PreparedNormalizationContext | null {
-  if (stats.size < INDUSTRY_DB_V2_MIN_NORMALIZATION_SAMPLE_SIZE || stats.p80 <= 5) {
+  if (stats.size < INDUSTRY_DB_V2_MIN_NORMALIZATION_SAMPLE_SIZE) {
     return null;
   }
 

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -293,7 +293,7 @@ export function toIndustryDbV2Stats(value: unknown): IndustryDbV2Stats | undefin
 
 export function computeNormalizedIndustryDbScore(raw: number | undefined, stats: IndustryDbV2Stats | undefined): number {
   const safeRaw = typeof raw === 'number' && Number.isFinite(raw) ? clamp(raw, 0, 50) : 0
-  if (!stats || stats.size < 30 || stats.p80 <= 5) {
+  if (!stats || stats.size < 30) {
     return Math.round(safeRaw)
   }
 


### PR DESCRIPTION
## Problem
When an export batch has mostly zero-scored resumes (no industry DB matches), the batch `p80 = 0`. The previous guard `p80 <= 5` blocked normalization entirely, so `industryDbV2Normalized = industryDbV2Raw` for every row.

## Root Cause
The formula uses `Math.max(p80, 1)` to safely handle `p80 = 0`, so the `p80 <= 5` guard was overly conservative. With p80 = 0, the formula still produces meaningful results:
- `raw = 0` → `normalized = 0`
- `raw ≥ 1` → `base = 40`, plus percentile bonus → `normalized ≈ 40–50`

This correctly signals "has industry signal" vs "no signal" even in sparse batches.

## Fix
Remove `|| stats.p80 <= 5` from the normalization guard in both API (`industry-db-batch-stats.ts`) and web (`resume-scoring.ts`). The `size < 30` guard remains.

## Test plan
- [x] New test: sparse batch (77 zeros + 8 non-zero of 85 total, p80=0) — non-zero scores normalize to 40+, zero stays 0
- [x] Existing guard rail test unchanged (size: 10 still triggers size < 30)
- [x] Full suite: 283 passed, 2 pre-existing Convex mock failures