### PR TITLE
feat(scoring): non-zero p80 normalization and hit-based raw score bump

### DIFF
--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -353,9 +353,9 @@ describe("resume export route", () => {
     expect(industryDbRawColumn).toBeGreaterThan(0);
     expect(industryDbNormalizedColumn).toBeGreaterThan(0);
     expect(sheet?.getRow(2).getCell(industryDbRawColumn).value).toBe(20);
-    expect(sheet?.getRow(2).getCell(industryDbNormalizedColumn).value).toBe(40);
-    expect(sheet?.getRow(3).getCell(industryDbRawColumn).value).toBe(25);
-    expect(sheet?.getRow(3).getCell(industryDbNormalizedColumn).value).toBe(45);
+    expect(sheet?.getRow(2).getCell(industryDbNormalizedColumn).value).toBe(38);
+    expect(sheet?.getRow(3).getCell(industryDbRawColumn).value).toBe(50);
+    expect(sheet?.getRow(3).getCell(industryDbNormalizedColumn).value).toBe(50);
     expect(sheet?.getRow(3).getCell(brandHitsColumn).value).toBe("发那科");
   });
 

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -48,6 +48,7 @@ import {
   type ResumeExportEntry,
 } from "../services/export-service.js";
 import {
+  bumpIndustryDbV2Raw,
   computeBatchStats,
   type IndustryDbV2BatchStats,
 } from "../services/industry-db-batch-stats.js";
@@ -367,7 +368,10 @@ async function resolveExportRequest(
   }
 
   const industryDbV2Stats = request.industryDbV2Stats
-    ?? computeBatchStats(entries.map((entry) => entry.resume.ingestData?.industryDbV2Raw));
+    ?? computeBatchStats(entries.map((entry) => {
+      const d = entry.resume.ingestData;
+      return bumpIndustryDbV2Raw(d?.industryDbV2Raw, (d?.brandHits?.length ?? 0) > 0, (d?.companyHits?.length ?? 0) > 0);
+    }));
 
   return {
     format: request.format,

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -125,7 +125,9 @@ describe("ExportService", () => {
       resume: {
         ...buildEntry("26").resume,
         ingestData: {
-          ...buildEntry("26").resume.ingestData,
+          industryTags: ["cnc"],
+          companyHits: [],
+          brandHits: [],
           industryDbV2Raw: 25,
         },
       },
@@ -145,8 +147,8 @@ describe("ExportService", () => {
 
     expect(parsed.meta.fields).toContain("industryDbV2Raw");
     expect(parsed.meta.fields).toContain("industryDbV2Normalized");
-    expect(parsed.data[0]?.industryDbV2Raw).toBe("20");
-    expect(parsed.data[0]?.industryDbV2Normalized).toBe("40");
+    expect(parsed.data[0]?.industryDbV2Raw).toBe("50");
+    expect(parsed.data[0]?.industryDbV2Normalized).toBe("50");
     expect(parsed.data[1]?.industryDbV2Raw).toBe("25");
     expect(parsed.data[1]?.industryDbV2Normalized).toBe("45");
   });

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -12,6 +12,7 @@ import {
   type CompanyPattern,
 } from "./skills-knowledge.js";
 import {
+  bumpIndustryDbV2Raw,
   createBatchNormalizer,
   type IndustryDbV2BatchStats,
 } from "./industry-db-batch-stats.js";
@@ -234,9 +235,11 @@ function toRow(
       .filter((item) => item.trim().length > 0)
       .join(" | ")
     : "";
-  const { raw: industryDbV2Raw, normalized: industryDbV2Normalized } = batchNormalizer(
-    entry.resume.ingestData?.industryDbV2Raw
-  );
+  const ingestData = entry.resume.ingestData;
+  const hasBrandHits = (ingestData?.brandHits?.length ?? 0) > 0;
+  const hasCompanyHits = (ingestData?.companyHits?.length ?? 0) > 0;
+  const effectiveRaw = bumpIndustryDbV2Raw(ingestData?.industryDbV2Raw, hasBrandHits, hasCompanyHits);
+  const { raw: industryDbV2Raw, normalized: industryDbV2Normalized } = batchNormalizer(effectiveRaw);
 
   return {
     resumeId: entry.key,

--- a/apps/api/src/services/industry-db-batch-stats.test.ts
+++ b/apps/api/src/services/industry-db-batch-stats.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  bumpIndustryDbV2Raw,
   clampIndustryDbV2RawScore,
   computeBatchStats,
   normalizeIndustryDbScore,
@@ -62,7 +63,7 @@ describe("industry-db-batch-stats", () => {
     });
   });
 
-  it("normalizes sparse batches where p80 is 0 due to majority-zero scores", () => {
+  it("normalizes sparse batches using non-zero p80 for meaningful discrimination", () => {
     const histogram50 = Array.from({ length: 51 }, (_, i) => {
       if (i === 0) return 77;
       if (i === 6) return 1;
@@ -80,11 +81,21 @@ describe("industry-db-batch-stats", () => {
     expect(zero.guardRailApplied).toBe(false);
 
     const six = normalizeIndustryDbScore(6, stats);
-    expect(six.normalized).toBeGreaterThan(0);
+    expect(six.normalized).toBe(20);
     expect(six.guardRailApplied).toBe(false);
 
     const thirty = normalizeIndustryDbScore(30, stats);
-    expect(thirty.normalized).toBeGreaterThan(six.normalized);
+    expect(thirty.normalized).toBe(50);
+    expect(thirty.normalized - six.normalized).toBeGreaterThan(20);
+  });
+
+  it("bumps raw score to section max when brand or company hits are present", () => {
+    expect(bumpIndustryDbV2Raw(5, true, false)).toBe(30);
+    expect(bumpIndustryDbV2Raw(5, false, true)).toBe(20);
+    expect(bumpIndustryDbV2Raw(5, true, true)).toBe(50);
+    expect(bumpIndustryDbV2Raw(40, true, false)).toBe(40);
+    expect(bumpIndustryDbV2Raw(undefined, true, true)).toBe(50);
+    expect(bumpIndustryDbV2Raw(0, false, false)).toBe(0);
   });
 
   it("coerces invalid raw inputs to the supported score range", () => {

--- a/apps/api/src/services/industry-db-batch-stats.ts
+++ b/apps/api/src/services/industry-db-batch-stats.ts
@@ -19,6 +19,9 @@ export type NormalizedIndustryDbScore = {
 const INDUSTRY_DB_V2_SCORE_CAP = 50;
 const INDUSTRY_DB_V2_HISTOGRAM_SIZE = 51;
 const INDUSTRY_DB_V2_MIN_NORMALIZATION_SAMPLE_SIZE = 30;
+const INDUSTRY_DB_V2_MIN_NONZERO_SAMPLE_SIZE = 5;
+const INDUSTRY_DB_V2_BRAND_SECTION_SCORE = 30;
+const INDUSTRY_DB_V2_COMPANY_SECTION_SCORE = 20;
 
 function roundTo2(value: number): number {
   return Number(value.toFixed(2));
@@ -63,6 +66,29 @@ function normalizeHistogram50(histogram50: number[]): number[] {
 
 function countHistogramSamples(histogram50: number[]): number {
   return histogram50.reduce((total, count) => total + count, 0);
+}
+
+export function bumpIndustryDbV2Raw(
+  raw: number | undefined,
+  hasBrandHits: boolean,
+  hasCompanyHits: boolean
+): number {
+  const sectionBump =
+    (hasBrandHits ? INDUSTRY_DB_V2_BRAND_SECTION_SCORE : 0) +
+    (hasCompanyHits ? INDUSTRY_DB_V2_COMPANY_SECTION_SCORE : 0);
+  return Math.max(clampIndustryDbV2RawScore(raw), sectionBump);
+}
+
+function nonZeroP80FromHistogram(histogram50: number[]): { p80: number; count: number } {
+  const sorted: number[] = [];
+  histogram50.forEach((count, score) => {
+    if (score > 0) {
+      for (let i = 0; i < count; i++) {
+        sorted.push(score);
+      }
+    }
+  });
+  return { p80: quantile(sorted, 0.8), count: sorted.length };
 }
 
 function percentileRankFromHistogram(histogram50: number[], raw: number): number {
@@ -165,7 +191,12 @@ function prepareNormalizationContext(
     return null;
   }
 
-  return { histogram50, sampleSize, p80: stats.p80 };
+  const { p80: effectiveP80, count: nonZeroCount } = nonZeroP80FromHistogram(histogram50);
+  if (nonZeroCount < INDUSTRY_DB_V2_MIN_NONZERO_SAMPLE_SIZE) {
+    return null;
+  }
+
+  return { histogram50, sampleSize, p80: effectiveP80 };
 }
 
 function normalizeWithContext(

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -245,11 +245,11 @@ describe('resume-scoring', () => {
     })).toBe(12)
   })
 
-  it('falls back to raw industry_db score when p80 guard is too low', () => {
+  it('falls back when non-zero sample count is below minimum threshold', () => {
     expect(computeNormalizedIndustryDbScore(25, {
       size: 50,
-      p80: 5,
-      histogram50: Array.from({ length: 51 }, (_, index) => (index === 25 ? 50 : 0)),
+      p80: 25,
+      histogram50: Array.from({ length: 51 }, (_, index) => (index === 25 ? 3 : 0)),
     })).toBe(25)
   })
 

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -228,6 +228,42 @@ function countHistogramSamples(histogram50: number[]): number {
   return histogram50.reduce((total, count) => total + count, 0)
 }
 
+const INDUSTRY_DB_V2_MIN_NONZERO_SAMPLE_SIZE = 5
+const INDUSTRY_DB_V2_BRAND_SECTION_SCORE = 30
+const INDUSTRY_DB_V2_COMPANY_SECTION_SCORE = 20
+
+export function bumpIndustryDbV2Raw(
+  raw: number | undefined,
+  hasBrandHits: boolean,
+  hasCompanyHits: boolean
+): number {
+  const sectionBump =
+    (hasBrandHits ? INDUSTRY_DB_V2_BRAND_SECTION_SCORE : 0) +
+    (hasCompanyHits ? INDUSTRY_DB_V2_COMPANY_SECTION_SCORE : 0)
+  const safeRaw = typeof raw === 'number' && Number.isFinite(raw) ? clamp(raw, 0, 50) : 0
+  return Math.max(safeRaw, sectionBump)
+}
+
+function nonZeroP80FromHistogram(histogram50: number[]): { p80: number; count: number } {
+  const nonZeroValues: number[] = []
+  histogram50.forEach((count, score) => {
+    if (score > 0) {
+      for (let i = 0; i < count; i++) {
+        nonZeroValues.push(score)
+      }
+    }
+  })
+  if (nonZeroValues.length === 0) {
+    return { p80: 0, count: 0 }
+  }
+  nonZeroValues.sort((a, b) => a - b)
+  const pos = (nonZeroValues.length - 1) * 0.8
+  const lo = Math.floor(pos)
+  const hi = Math.ceil(pos)
+  const p80 = lo === hi ? nonZeroValues[lo] : nonZeroValues[lo] * (1 - (pos - lo)) + nonZeroValues[hi] * (pos - lo)
+  return { p80, count: nonZeroValues.length }
+}
+
 function percentileRankFromHistogram(histogram50: number[], raw: number): number {
   const total = countHistogramSamples(histogram50)
   if (total <= 1) {
@@ -303,8 +339,13 @@ export function computeNormalizedIndustryDbScore(raw: number | undefined, stats:
     return Math.round(safeRaw)
   }
 
+  const { p80: effectiveP80, count: nonZeroCount } = nonZeroP80FromHistogram(histogram50)
+  if (nonZeroCount < INDUSTRY_DB_V2_MIN_NONZERO_SAMPLE_SIZE) {
+    return Math.round(safeRaw)
+  }
+
   const rank = percentileRankFromHistogram(histogram50, safeRaw)
-  const base = 40 * clamp(safeRaw / Math.max(stats.p80, 1), 0, 1)
+  const base = 40 * clamp(safeRaw / Math.max(effectiveP80, 1), 0, 1)
   const bonus = 10 * clamp((rank - 0.8) / 0.2, 0, 1)
   return Math.round(Math.min(50, base + bonus))
 }


### PR DESCRIPTION
## Summary

- **Non-zero p80**: When normalizing industry DB scores, compute p80 from non-zero histogram buckets only (min 5 non-zero samples required). Fixes poor discrimination in sparse batches where p80=0 (majority-zero scores) caused all non-zero resumes to receive the same base score.
- **Hit bump**: If a resume has any `brandHits`, bump its effective raw score to at least 30 (brand section max). If it has any `companyHits`, bump to at least 20 (company section max). Combined max is 50. This ensures any resume verified in the industry DB gets full section credit regardless of hit count.
- Internal batch stats computation in `resolveExportRequest` also applies the bump so histograms reflect the bumped distribution.

## Test plan

- [x] `make check` passes (200 API + 90 web tests)
- [x] `industry-db-batch-stats.test.ts`: new sparse-batch discrimination test with exact values (20 and 50), new bump unit test
- [x] `export-service.test.ts`: first entry (has hits) → raw=50/normalized=50; second entry (no hits) → raw=25/normalized=45
- [x] `resumes-export.test.ts`: Bob (no hits) normalized 40→38; Alice (has hits) raw 25→50/normalized 45→50
- [x] `resume-scoring.test.ts`: stale "p80 guard too low" test replaced with non-zero count guard test