### PR TITLE
refactor(scoring): add computeEffectiveIndustryDbV2Raw helper, guard bump in web

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -48,7 +48,7 @@ import {
   type ResumeExportEntry,
 } from "../services/export-service.js";
 import {
-  bumpIndustryDbV2Raw,
+  computeEffectiveIndustryDbV2Raw,
   computeBatchStats,
   type IndustryDbV2BatchStats,
 } from "../services/industry-db-batch-stats.js";
@@ -369,10 +369,7 @@ async function resolveExportRequest(
 
   const industryDbV2Stats = request.industryDbV2Stats
     ?? computeBatchStats(entries.map((entry) => {
-      const d = entry.resume.ingestData;
-      const hasBrandHits = (d?.brandHits?.length ?? 0) > 0;
-      const hasCompanyHits = (d?.companyHits?.length ?? 0) > 0;
-      return bumpIndustryDbV2Raw(d?.industryDbV2Raw, hasBrandHits, hasCompanyHits);
+      return computeEffectiveIndustryDbV2Raw(entry.resume.ingestData);
     }));
 
   return {

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -12,7 +12,7 @@ import {
   type CompanyPattern,
 } from "./skills-knowledge.js";
 import {
-  bumpIndustryDbV2Raw,
+  computeEffectiveIndustryDbV2Raw,
   createBatchNormalizer,
   type IndustryDbV2BatchStats,
 } from "./industry-db-batch-stats.js";
@@ -236,9 +236,7 @@ function toRow(
       .join(" | ")
     : "";
   const ingestData = entry.resume.ingestData;
-  const hasBrandHits = (ingestData?.brandHits?.length ?? 0) > 0;
-  const hasCompanyHits = (ingestData?.companyHits?.length ?? 0) > 0;
-  const effectiveRaw = bumpIndustryDbV2Raw(ingestData?.industryDbV2Raw, hasBrandHits, hasCompanyHits);
+  const effectiveRaw = computeEffectiveIndustryDbV2Raw(ingestData);
   const { raw: industryDbV2Raw, normalized: industryDbV2Normalized } = batchNormalizer(effectiveRaw);
 
   return {

--- a/apps/api/src/services/industry-db-batch-stats.test.ts
+++ b/apps/api/src/services/industry-db-batch-stats.test.ts
@@ -4,6 +4,7 @@ import {
   bumpIndustryDbV2Raw,
   clampIndustryDbV2RawScore,
   computeBatchStats,
+  computeEffectiveIndustryDbV2Raw,
   normalizeIndustryDbScore,
 } from "./industry-db-batch-stats.js";
 
@@ -96,6 +97,15 @@ describe("industry-db-batch-stats", () => {
     expect(bumpIndustryDbV2Raw(40, true, false)).toBe(40);
     expect(bumpIndustryDbV2Raw(undefined, true, true)).toBe(50);
     expect(bumpIndustryDbV2Raw(0, false, false)).toBe(0);
+  });
+
+  it("derives effective raw from ingest data shape", () => {
+    expect(computeEffectiveIndustryDbV2Raw({ brandHits: [{}], companyHits: [], industryDbV2Raw: 5 })).toBe(30);
+    expect(computeEffectiveIndustryDbV2Raw({ brandHits: [], companyHits: ['star'], industryDbV2Raw: 5 })).toBe(20);
+    expect(computeEffectiveIndustryDbV2Raw({ brandHits: [{}], companyHits: ['star'], industryDbV2Raw: 5 })).toBe(50);
+    expect(computeEffectiveIndustryDbV2Raw({ brandHits: [], companyHits: [], industryDbV2Raw: 25 })).toBe(25);
+    expect(computeEffectiveIndustryDbV2Raw(undefined)).toBe(0);
+    expect(computeEffectiveIndustryDbV2Raw(null)).toBe(0);
   });
 
   it("coerces invalid raw inputs to the supported score range", () => {

--- a/apps/api/src/services/industry-db-batch-stats.ts
+++ b/apps/api/src/services/industry-db-batch-stats.ts
@@ -79,6 +79,18 @@ export function bumpIndustryDbV2Raw(
   return Math.max(clampIndustryDbV2RawScore(raw), sectionBump);
 }
 
+export function computeEffectiveIndustryDbV2Raw(ingestData: {
+  brandHits?: unknown[];
+  companyHits?: unknown[];
+  industryDbV2Raw?: number;
+} | null | undefined): number {
+  return bumpIndustryDbV2Raw(
+    ingestData?.industryDbV2Raw,
+    (ingestData?.brandHits?.length ?? 0) > 0,
+    (ingestData?.companyHits?.length ?? 0) > 0,
+  );
+}
+
 function nonZeroP80FromHistogram(histogram50: number[]): { p80: number; count: number } {
   const sorted: number[] = [];
   histogram50.forEach((count, score) => {

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1005,11 +1005,17 @@ export function useResumeListState(loadSearchHistory = false) {
         const identityKey = getResumeIdentityKey(resume, resumeKey)
         const analysis = getAnalysisForJob(resume, jobDescriptionId, sessionKeywords)
         const isAnalysisValid = !jobDescriptionId || analysis?.jobDescriptionId === jobDescriptionId
-        const hasBrandHits = (resume.ingestData?.brandHits?.length ?? 0) > 0
-        const hasCompanyHits = (resume.ingestData?.companyHits?.length ?? 0) > 0
-        const effectiveRaw = bumpIndustryDbV2Raw(resume.ingestData?.industryDbV2Raw, hasBrandHits, hasCompanyHits)
+        const ingestData = resume.ingestData
         const normalizedAnalysis = analysis && isAnalysisValid
-          ? overrideIndustryDbBreakdown(analysis, effectiveRaw, normalize)
+          ? overrideIndustryDbBreakdown(
+              analysis,
+              bumpIndustryDbV2Raw(
+                ingestData?.industryDbV2Raw,
+                (ingestData?.brandHits?.length ?? 0) > 0,
+                (ingestData?.companyHits?.length ?? 0) > 0,
+              ),
+              normalize,
+            )
           : undefined
 
         const match: MatchingResult | undefined = normalizedAnalysis


### PR DESCRIPTION
## Summary
- Add `computeEffectiveIndustryDbV2Raw(ingestData)` to `industry-db-batch-stats.ts` — encapsulates the repeated 3-line `hasBrandHits/hasCompanyHits/bumpIndustryDbV2Raw` derivation (2 call sites in API)
- `export-service.ts`: 3 lines → 1 call
- `resumes.ts`: 3 lines → 1 call (lambda body collapses to single return)
- `useResumeListState.ts`: extract `ingestData` once, move computation inside the `analysis && isAnalysisValid` guard (avoids work when no analysis)

## Test plan
- [ ] New test: `computeEffectiveIndustryDbV2Raw` with brand/company hits, empty hits, undefined, null
- [ ] All existing tests pass (7 API + 24 web)
- [ ] `make check` passes