### PR TITLE
feat(export): clean column output — industryDb + relatedExp, debug flag for raw detail

### DIFF
--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -313,6 +313,7 @@ describe("resume export route", () => {
       body: JSON.stringify({
         format: "xlsx",
         source: "convex",
+        debug: true,
         industryDbV2Stats: {
           size: 50,
           p80: 20,
@@ -343,6 +344,7 @@ describe("resume export route", () => {
     await workbook.xlsx.load(Buffer.from(await response.arrayBuffer()));
     const sheet = workbook.getWorksheet("Resumes");
     const brandHitsColumn = findColumnIndex(sheet, "Brand Hits");
+    const industryDbColumn = findColumnIndex(sheet, "Industry DB");
     const industryDbRawColumn = findColumnIndex(sheet, "Industry DB V2 Raw");
     const industryDbNormalizedColumn = findColumnIndex(sheet, "Industry DB V2 Normalized");
     expect(sheet?.getCell("A2").value).toBe("convex-b");
@@ -350,10 +352,13 @@ describe("resume export route", () => {
     expect(sheet?.getCell("A3").value).toBe("convex-a");
     expect(sheet?.getCell("B3").value).toBe("Alice");
     expect(brandHitsColumn).toBeGreaterThan(0);
+    expect(industryDbColumn).toBeGreaterThan(0);
     expect(industryDbRawColumn).toBeGreaterThan(0);
     expect(industryDbNormalizedColumn).toBeGreaterThan(0);
+    expect(sheet?.getRow(2).getCell(industryDbColumn).value).toBe(38);
     expect(sheet?.getRow(2).getCell(industryDbRawColumn).value).toBe(20);
     expect(sheet?.getRow(2).getCell(industryDbNormalizedColumn).value).toBe(38);
+    expect(sheet?.getRow(3).getCell(industryDbColumn).value).toBe(50);
     expect(sheet?.getRow(3).getCell(industryDbRawColumn).value).toBe(50);
     expect(sheet?.getRow(3).getCell(industryDbNormalizedColumn).value).toBe(50);
     expect(sheet?.getRow(3).getCell(brandHitsColumn).value).toBe("发那科");

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -355,6 +355,7 @@ async function resolveExportRequest(
   entries: ResumeExportEntry[];
   batchMeta: ExportBatchMeta;
   industryDbV2Stats: IndustryDbV2BatchStats;
+  debug: boolean;
 }> {
   let entries: ResumeExportEntry[];
 
@@ -380,6 +381,7 @@ async function resolveExportRequest(
       referenceNote: request.referenceNote,
     },
     industryDbV2Stats,
+    debug: isCanonicalExportRequest(request) ? (request.debug ?? false) : false,
   };
 }
 
@@ -1894,8 +1896,8 @@ app.openapi(rescoreResumeMatchesRoute, (c) => {
 });
 
 async function buildResumeExportResponse(request: z.infer<typeof ResumeExportRequestSchema>) {
-  const { format, entries, batchMeta, industryDbV2Stats } = await resolveExportRequest(request);
-  const file = await exportService.exportResumes(format, entries, batchMeta, industryDbV2Stats);
+  const { format, entries, batchMeta, industryDbV2Stats, debug } = await resolveExportRequest(request);
+  const file = await exportService.exportResumes(format, entries, batchMeta, industryDbV2Stats, debug);
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const filename = `resumes-export-${timestamp}.${file.extension}`;
 

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -535,7 +535,7 @@ export const ResumeExportCanonicalRequestSchema = z
     userComment: z.string().optional().openapi({ example: "Batch note" }),
     referenceNote: z.string().optional().openapi({ example: "Internal export" }),
     industryDbV2Stats: IndustryDbV2StatsSchema.optional(),
-    debug: z.boolean().optional().default(false).openapi({ example: false }),
+    debug: z.boolean().optional().openapi({ example: false }),
     entries: z.array(ResumeExportEntryContextSchema).min(1).max(2000),
   })
   .superRefine((value, ctx) => {

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -498,7 +498,7 @@ export const ResumeExportMatchSchema = z
     recommendation: RecommendationSchema.openapi({ example: "strong_match" }),
     scoreSource: ScoreSourceSchema.optional().openapi({ example: "ai" }),
     summary: z.string().optional().openapi({ example: "Strong CNC sales fit." }),
-    breakdown: z.record(z.unknown()).optional().openapi({ example: { related_exp: 20, industry_db: 40 } }),
+    breakdown: z.record(z.number()).optional().openapi({ example: { related_exp: 20, industry_db: 40 } }),
   })
   .openapi("ResumeExportMatch");
 

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -498,6 +498,7 @@ export const ResumeExportMatchSchema = z
     recommendation: RecommendationSchema.openapi({ example: "strong_match" }),
     scoreSource: ScoreSourceSchema.optional().openapi({ example: "ai" }),
     summary: z.string().optional().openapi({ example: "Strong CNC sales fit." }),
+    breakdown: z.record(z.unknown()).optional().openapi({ example: { related_exp: 20, industry_db: 40 } }),
   })
   .openapi("ResumeExportMatch");
 
@@ -534,6 +535,7 @@ export const ResumeExportCanonicalRequestSchema = z
     userComment: z.string().optional().openapi({ example: "Batch note" }),
     referenceNote: z.string().optional().openapi({ example: "Internal export" }),
     industryDbV2Stats: IndustryDbV2StatsSchema.optional(),
+    debug: z.boolean().optional().default(false).openapi({ example: false }),
     entries: z.array(ResumeExportEntryContextSchema).min(1).max(2000),
   })
   .superRefine((value, ctx) => {

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -116,7 +116,7 @@ describe("ExportService", () => {
     expect(parsed.data[0]?.referenceNote).toBe("Referred by HR dept");
   });
 
-  it("exports industry DB raw and normalized columns in CSV output", async () => {
+  it("exports industryDb and relatedExp columns in standard CSV output", async () => {
     const service = new ExportService();
     const firstEntry = buildEntry("25");
     const secondEntry: ResumeExportEntry = {
@@ -142,6 +142,43 @@ describe("ExportService", () => {
         return 0;
       }),
     });
+    const csv = file.content.toString("utf8");
+    const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
+
+    expect(parsed.meta.fields).toContain("industryDb");
+    expect(parsed.meta.fields).toContain("relatedExp");
+    expect(parsed.meta.fields).not.toContain("industryDbV2Raw");
+    expect(parsed.meta.fields).not.toContain("industryDbV2Normalized");
+    expect(parsed.data[0]?.industryDb).toBe("50");
+    expect(parsed.data[1]?.industryDb).toBe("45");
+  });
+
+  it("exports industryDbV2Raw and industryDbV2Normalized columns in debug CSV output", async () => {
+    const service = new ExportService();
+    const firstEntry = buildEntry("25");
+    const secondEntry: ResumeExportEntry = {
+      ...buildEntry("26"),
+      key: "resume-2",
+      resume: {
+        ...buildEntry("26").resume,
+        ingestData: {
+          industryTags: ["cnc"],
+          companyHits: [],
+          brandHits: [],
+          industryDbV2Raw: 25,
+        },
+      },
+    };
+
+    const file = await service.exportResumes("csv", [firstEntry, secondEntry], undefined, {
+      size: 50,
+      p80: 20,
+      histogram50: Array.from({ length: 51 }, (_, index) => {
+        if (index === 20) return 40;
+        if (index === 25) return 10;
+        return 0;
+      }),
+    }, true);
     const csv = file.content.toString("utf8");
     const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
 

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -44,7 +44,7 @@ type MatchExportPayload = {
   recommendation: string;
   scoreSource?: "rule" | "ai";
   summary?: string;
-  breakdown?: Record<string, unknown>;
+  breakdown?: Record<string, number>;
 };
 
 export type ResumeExportEntry = {

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -44,6 +44,7 @@ type MatchExportPayload = {
   recommendation: string;
   scoreSource?: "rule" | "ai";
   summary?: string;
+  breakdown?: Record<string, unknown>;
 };
 
 export type ResumeExportEntry = {
@@ -67,6 +68,8 @@ type ExportRow = {
   age: number | "";
   expectedSalary: string;
   aiScore: number | "";
+  industryDb: number;
+  relatedExp: number | "";
   industryDbV2Raw: number;
   industryDbV2Normalized: number;
   ruleScore: number | "";
@@ -249,6 +252,10 @@ function toRow(
     age: parseAgeNumber(entry.resume.age) ?? "",
     expectedSalary: normalizeString(entry.resume.expectedSalary),
     aiScore: typeof entry.match?.score === "number" ? entry.match.score : "",
+    industryDb: industryDbV2Normalized,
+    relatedExp: typeof entry.match?.breakdown?.related_exp === "number"
+      ? entry.match.breakdown.related_exp
+      : "",
     industryDbV2Raw,
     industryDbV2Normalized,
     ruleScore: typeof entry.ruleScore === "number" ? entry.ruleScore : "",
@@ -276,7 +283,9 @@ function toRow(
   };
 }
 
-const EXCEL_COLUMNS: Array<{ header: string; key: keyof ExportRow; width: number }> = [
+type ExcelColumn = { header: string; key: keyof ExportRow; width: number };
+
+const STANDARD_EXCEL_COLUMNS_HEAD: ExcelColumn[] = [
   { header: "Resume ID", key: "resumeId", width: 24 },
   { header: "Name", key: "name", width: 16 },
   { header: "Job Intention", key: "jobIntention", width: 20 },
@@ -286,8 +295,16 @@ const EXCEL_COLUMNS: Array<{ header: string; key: keyof ExportRow; width: number
   { header: "Age", key: "age", width: 10 },
   { header: "Expected Salary", key: "expectedSalary", width: 16 },
   { header: "AI Score", key: "aiScore", width: 10 },
+  { header: "Industry DB", key: "industryDb", width: 14 },
+  { header: "Related Exp", key: "relatedExp", width: 14 },
+];
+
+const DEBUG_EXCEL_COLUMNS: ExcelColumn[] = [
   { header: "Industry DB V2 Raw", key: "industryDbV2Raw", width: 18 },
   { header: "Industry DB V2 Normalized", key: "industryDbV2Normalized", width: 24 },
+];
+
+const STANDARD_EXCEL_COLUMNS_TAIL: ExcelColumn[] = [
   { header: "Rule Score", key: "ruleScore", width: 10 },
   { header: "Recommendation", key: "recommendation", width: 16 },
   { header: "Status", key: "status", width: 16 },
@@ -305,6 +322,18 @@ const EXCEL_COLUMNS: Array<{ header: string; key: keyof ExportRow; width: number
   { header: "User Comment", key: "userComment", width: 36 },
   { header: "Reference Note", key: "referenceNote", width: 36 },
 ];
+
+function getExcelColumns(debug: boolean): ExcelColumn[] {
+  return debug
+    ? [...STANDARD_EXCEL_COLUMNS_HEAD, ...DEBUG_EXCEL_COLUMNS, ...STANDARD_EXCEL_COLUMNS_TAIL]
+    : [...STANDARD_EXCEL_COLUMNS_HEAD, ...STANDARD_EXCEL_COLUMNS_TAIL];
+}
+
+function toOutputRow(row: ExportRow, debug: boolean): Omit<ExportRow, "industryDbV2Raw" | "industryDbV2Normalized"> | ExportRow {
+  if (debug) return row;
+  const { industryDbV2Raw: _r, industryDbV2Normalized: _n, ...standard } = row;
+  return standard;
+}
 
 export type ExportBatchMeta = {
   userComment?: string;
@@ -339,7 +368,8 @@ export class ExportService {
     format: ExportFormat,
     entries: ResumeExportEntry[],
     batchMeta?: ExportBatchMeta,
-    industryDbV2Stats?: IndustryDbV2BatchStats
+    industryDbV2Stats?: IndustryDbV2BatchStats,
+    debug = false
   ): Promise<ExportFile> {
     const batchNormalizer = createBatchNormalizer(industryDbV2Stats);
     const rows = entries.map((entry) =>
@@ -354,7 +384,7 @@ export class ExportService {
       )
     );
     if (format === "xlsx") {
-      const content = await this.toXlsx(rows);
+      const content = await this.toXlsx(rows, debug);
       return {
         extension: "xlsx",
         contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -362,7 +392,8 @@ export class ExportService {
       };
     }
 
-    const csv = Papa.unparse(rows, { header: true, newline: "\n" });
+    const outputRows = rows.map((row) => toOutputRow(row, debug));
+    const csv = Papa.unparse(outputRows, { header: true, newline: "\n" });
     return {
       extension: "csv",
       contentType: "text/csv; charset=utf-8",
@@ -370,11 +401,11 @@ export class ExportService {
     };
   }
 
-  private async toXlsx(rows: ExportRow[]): Promise<Buffer> {
+  private async toXlsx(rows: ExportRow[], debug: boolean): Promise<Buffer> {
     const workbook = new ExcelJS.Workbook();
     const sheet = workbook.addWorksheet("Resumes");
 
-    sheet.columns = EXCEL_COLUMNS;
+    sheet.columns = getExcelColumns(debug);
     rows.forEach((row) => sheet.addRow(row));
     sheet.getRow(1).font = { bold: true };
 

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4374,11 +4374,8 @@ export interface components {
             /** @example Internal export */
             referenceNote?: string;
             industryDbV2Stats?: components["schemas"]["IndustryDbV2Stats"];
-            /**
-             * @default false
-             * @example false
-             */
-            debug: boolean;
+            /** @example false */
+            debug?: boolean;
             entries: components["schemas"]["ResumeExportEntryContext"][];
         };
         ResumeExportLegacyRequest: {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4334,6 +4334,15 @@ export interface components {
             scoreSource?: "rule" | "ai";
             /** @example Strong CNC sales fit. */
             summary?: string;
+            /**
+             * @example {
+             *       "related_exp": 20,
+             *       "industry_db": 40
+             *     }
+             */
+            breakdown?: {
+                [key: string]: unknown;
+            };
         };
         ResumeExportEntryContext: {
             /** @example resume-1 */
@@ -4365,6 +4374,11 @@ export interface components {
             /** @example Internal export */
             referenceNote?: string;
             industryDbV2Stats?: components["schemas"]["IndustryDbV2Stats"];
+            /**
+             * @default false
+             * @example false
+             */
+            debug: boolean;
             entries: components["schemas"]["ResumeExportEntryContext"][];
         };
         ResumeExportLegacyRequest: {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4341,7 +4341,7 @@ export interface components {
              *     }
              */
             breakdown?: {
-                [key: string]: unknown;
+                [key: string]: number;
             };
         };
         ResumeExportEntryContext: {


### PR DESCRIPTION
## Summary

- Default export (`debug` unset or `false`) now outputs **`industryDb`** (final normalized score) and **`relatedExp`** (AI experience component) instead of the two verbose internal columns `industryDbV2Raw` / `industryDbV2Normalized`
- Passing `debug: true` in the export request appends both raw columns after `relatedExp` for diagnostic use
- Column order: `... AI Score | Industry DB | Related Exp | [Industry DB V2 Raw | Industry DB V2 Normalized] | Rule Score ...`
- Web UI sends no `debug` flag, so all existing exports automatically get the clean format

## Changes

- `apps/api/src/schemas/resumes.ts` — add `debug?: boolean` to `ResumeExportCanonicalRequestSchema`; add `breakdown?: Record<string, number>` to `ResumeExportMatchSchema` so `related_exp` passes through from web
- `apps/api/src/services/export-service.ts` — `ExportRow` gains `industryDb` + `relatedExp`; `EXCEL_COLUMNS` split into HEAD/DEBUG/TAIL; `getExcelColumns(debug)` and `toOutputRow(row, debug)` helpers; `exportResumes` and `toXlsx` accept `debug` flag
- `apps/api/src/routes/resumes.ts` — thread `debug` from `resolveExportRequest` through to `exportService.exportResumes`
- Tests updated to assert new standard-mode columns; convex route test adds `debug: true` to cover debug path
- `apps/web/src/lib/api-types.ts` — regenerated (adds `debug?: boolean` and `breakdown?: { [key: string]: number }`)

## Test plan

- [ ] `npx vitest run apps/api/src/services/export-service.test.ts apps/api/src/routes/resumes-export.test.ts` — all 18 tests pass
- [ ] `make check` — typecheck + lint + policy pass
- [ ] Manual: export from UI (no `debug` flag) → CSV has `industryDb`, `relatedExp`, no `industryDbV2Raw` / `industryDbV2Normalized`
- [ ] Manual: export with `debug: true` in request body → CSV has all 4 columns in correct order