### PR TITLE
fix(export): wire DEBUG env var to enable debug columns

### DIFF
--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -457,4 +457,47 @@ describe("resume export route", () => {
     expect(parsed.data[0]?.name).toBe("Legacy Alice");
     expect(parsed.data[0]?.brandHits).toBe("哈斯");
   });
+
+  it("enables debug columns when DEBUG env var is true", async () => {
+    const originalDebug = process.env.DEBUG;
+    process.env.DEBUG = "true";
+    try {
+      vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
+        items: [
+          buildSampleResume({
+            resumeId: "resume-debug",
+            name: "Debug Alice",
+            ingestData: { industryDbV2Raw: 15, companyHits: ["fanuc"], brandHits: [] },
+          }),
+        ],
+        sample: { name: "sample-test", filename: "sample-test.json", updatedAt: "2026-03-01T00:00:00.000Z", size: 1 },
+        metadata: undefined,
+        indexes: new Map(),
+      });
+
+      const app = createApp();
+      const response = await app.request("/api/resumes/export", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          format: "csv",
+          source: "sample",
+          sample: "sample-test",
+          entries: [{ resumeId: "resume-debug" }],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const parsed = Papa.parse<Record<string, string>>(await response.text(), { header: true });
+      expect(parsed.meta.fields).toContain("industryDbV2Raw");
+      expect(parsed.meta.fields).toContain("industryDbV2Normalized");
+      expect(parsed.data[0]?.industryDbV2Raw).toBe("20");
+    } finally {
+      if (originalDebug === undefined) {
+        delete process.env.DEBUG;
+      } else {
+        process.env.DEBUG = originalDebug;
+      }
+    }
+  });
 });

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -381,7 +381,7 @@ async function resolveExportRequest(
       referenceNote: request.referenceNote,
     },
     industryDbV2Stats,
-    debug: isCanonicalExportRequest(request) ? (request.debug ?? false) : false,
+    debug: isCanonicalExportRequest(request) ? (request.debug ?? process.env.DEBUG === "true") : process.env.DEBUG === "true",
   };
 }
 


### PR DESCRIPTION
## Summary

- `DEBUG=true` in `.env` now automatically enables debug columns (`industryDbV2Raw`, `industryDbV2Normalized`) in all exports without needing `debug:true` in the request body
- Request body `debug` field still takes precedence — `debug:false` overrides the env var
- Fixes the company/brand bump visibility: with `DEBUG=true`, exports now show the effective raw score (e.g. `companyHits` only → raw bumped to ≥20, `brandHits` only → ≥30, both → 50)

## Bump logic (already correct, now visible via debug)

| Hits present | Effective raw floor |
|---|---|
| company only | max(rawScore, 20) |
| brand only | max(rawScore, 30) |
| both | max(rawScore, 50) |
| neither | rawScore as-is |

## Test plan

- [ ] `npx vitest run apps/api/src/routes/resumes-export.test.ts` — 6 tests pass
- [ ] `make check` — clean
- [ ] Set `DEBUG=true` in `.env`, export from UI → CSV has `industryDbV2Raw` + `industryDbV2Normalized`
- [ ] Resume with `companyHits` only → `industryDbV2Raw` ≥ 20 in debug output