### PR TITLE
fix(scoring): exclude employer-context brand hits from industryDb bump

### DIFF
--- a/apps/api/src/services/industry-db-batch-stats.test.ts
+++ b/apps/api/src/services/industry-db-batch-stats.test.ts
@@ -108,6 +108,30 @@ describe("industry-db-batch-stats", () => {
     expect(computeEffectiveIndustryDbV2Raw(null)).toBe(0);
   });
 
+  it("ignores employer-context brand hits when computing the bump", () => {
+    // employer-only brandHits → only company bump applies
+    expect(computeEffectiveIndustryDbV2Raw({
+      brandHits: [{ brand: "fanuc", role: "employer", source: "workHistory", context: "employer" }],
+      companyHits: ["fanuc"],
+      industryDbV2Raw: 5,
+    })).toBe(20);
+    // employer brandHit + no companyHits → no bump
+    expect(computeEffectiveIndustryDbV2Raw({
+      brandHits: [{ brand: "fanuc", role: "employer", source: "workHistory", context: "employer" }],
+      companyHits: [],
+      industryDbV2Raw: 5,
+    })).toBe(5);
+    // mixed: employer + non-employer brandHit → brand bump applies
+    expect(computeEffectiveIndustryDbV2Raw({
+      brandHits: [
+        { brand: "fanuc", role: "employer", source: "workHistory", context: "employer" },
+        { brand: "fanuc", role: "equipment", source: "selfIntro", context: "equipment" },
+      ],
+      companyHits: ["fanuc"],
+      industryDbV2Raw: 5,
+    })).toBe(50);
+  });
+
   it("coerces invalid raw inputs to the supported score range", () => {
     expect(clampIndustryDbV2RawScore(undefined)).toBe(0);
     expect(clampIndustryDbV2RawScore(Number.NaN)).toBe(0);

--- a/apps/api/src/services/industry-db-batch-stats.ts
+++ b/apps/api/src/services/industry-db-batch-stats.ts
@@ -84,9 +84,12 @@ export function computeEffectiveIndustryDbV2Raw(ingestData: {
   companyHits?: unknown[];
   industryDbV2Raw?: number;
 } | null | undefined): number {
+  const hasNonEmployerBrandHit = (ingestData?.brandHits ?? []).some(
+    (hit) => typeof hit === "object" && hit !== null && (hit as { context?: string }).context !== "employer"
+  );
   return bumpIndustryDbV2Raw(
     ingestData?.industryDbV2Raw,
-    (ingestData?.brandHits?.length ?? 0) > 0,
+    hasNonEmployerBrandHit,
     (ingestData?.companyHits?.length ?? 0) > 0,
   );
 }

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1011,7 +1011,7 @@ export function useResumeListState(loadSearchHistory = false) {
               analysis,
               bumpIndustryDbV2Raw(
                 ingestData?.industryDbV2Raw,
-                (ingestData?.brandHits?.length ?? 0) > 0,
+                (ingestData?.brandHits?.filter((h) => h.context !== "employer").length ?? 0) > 0,
                 (ingestData?.companyHits?.length ?? 0) > 0,
               ),
               normalize,


### PR DESCRIPTION
## Summary

- Resumes where the candidate **works at** a known CNC brand (e.g. 宝力机械有限公司) were getting the full 50-point bump (brand 30 + company 20) because `computeEffectiveIndustryDbV2Raw` counted all `brandHits` including `context="employer"` entries
- The export display already **filters** employer-context hits from the `brandHits` column, creating a confusing mismatch: empty brandHits shown, but raw score = 50
- Fix: both the API helper (`computeEffectiveIndustryDbV2Raw`) and the web hook (`useResumeListState`) now ignore `context="employer"` brand hits when determining `hasBrandHits`

## Before / After

| Resume type | Before | After |
|---|---|---|
| companyHits only (no brandHits) | raw = 20 ✓ | raw = 20 ✓ |
| employer brandHit + companyHit | raw = **50 ✗** | raw = **20 ✓** |
| equipment brandHit + companyHit | raw = 50 ✓ | raw = 50 ✓ |
| employer + equipment brandHit + companyHit | raw = 50 ✓ | raw = 50 ✓ |

## Test plan

- [x] `industry-db-batch-stats.test.ts` — new `"ignores employer-context brand hits"` test covers all 3 cases above
- [x] `resumes-export.test.ts` — existing `"enables debug columns when DEBUG env var is true"` test (companyHits only, raw 15→20) continues to pass
- [x] `useResumeListState.test.tsx` — 24 existing tests pass
- [x] `make check` passes