### PR TITLE
fix(ingest): restrict employer brandHits to 79 CNC brands only

### DIFF
--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -425,8 +425,9 @@ export class IngestComputeService {
     const synonymHits = this.computeSynonymHits(searchText);
 
     // 3. Compute field-aware brandHits, then derive companyHits for backward compatibility
-    const brandHits = this.computeBrandHits(item, index.companies, searchText);
-    const companyHits = this.computeEmployerCompanyHits(item);
+    const verifiedEmployers = this.collectVerifiedEmployerMatches(item.workHistory ?? []);
+    const brandHits = this.computeBrandHits(item, index.companies, searchText, verifiedEmployers);
+    const companyHits = verifiedEmployers.map((m) => m.key);
     const { raw: industryDbV2Raw, components: industryDbV2RawComponents } = computeIndustryDbV2Raw(
       companyHits,
       brandHits
@@ -947,7 +948,7 @@ export class IngestComputeService {
   /**
    * Compute field-aware brand hits from resume text segments.
    */
-  private computeBrandHits(item: ResumeItem, companies: string[], searchText: string): BrandHit[] {
+  private computeBrandHits(item: ResumeItem, companies: string[], searchText: string, verifiedEmployers: VerifiedEmployerMatch[]): BrandHit[] {
     const patterns = this.skillsKnowledgeService.getCompanyPatterns();
     const normalizedSearchText = searchText.toLowerCase();
     const normalizedCompanies = companies
@@ -1041,7 +1042,7 @@ export class IngestComputeService {
 
     const workHistory = item.workHistory || [];
 
-    // Pre-extract company names per work-history entry so both loops below share the result.
+    // Pre-extract company names per work-history entry for the pattern-scan loop below.
     const extractedByEntry = workHistory.map((entry) => extractCompanies([entry]));
 
     for (const pattern of patterns) {
@@ -1071,7 +1072,7 @@ export class IngestComputeService {
     }
 
     // Strict employer matching against Industry DB companies (Tier 1 only).
-    for (const employerMatch of this.collectVerifiedEmployerMatches(workHistory)) {
+    for (const employerMatch of verifiedEmployers) {
       if (this.industryDataService.matchBrands(employerMatch.companyNameCn).length === 0) {
         continue;
       }
@@ -1091,10 +1092,6 @@ export class IngestComputeService {
     }
 
     return hits;
-  }
-
-  private computeEmployerCompanyHits(item: ResumeItem): string[] {
-    return this.collectVerifiedEmployerMatches(item.workHistory || []).map((match) => match.key);
   }
 
   private collectVerifiedEmployerMatches(workHistory: ResumeWorkHistoryItem[]): VerifiedEmployerMatch[] {


### PR DESCRIPTION
## Summary

- **Root bug**: `computeBrandHits()` Loop 2 created employer `brandHits` for ANY `CompanyEntry` match from `keywords-structured.md` (including `ites_exhibitor` / `agent` categories). Companies like 宝力机械有限公司 (a local CNC distributor, ITES exhibitor) were getting employer brandHits even though they are not in the 79 CNC equipment brands list (`brands.json`).
- **Effect**: Candidates who only worked at a known distributor were getting raw score bumped to 50 (brand 30 + company 20) instead of the correct 20 (company only). Confirmed in real export data: 张先生, 周祥富.
- **Fix**: After verifying the employer via Industry DB, also check `matchBrands(company.nameCn)` — only create the employer brandHit if the company is an actual CNC brand (FANUC, MAZAK, 精雕, etc.). Distributors / exhibitors remain in `companyHits` only.
- **Simplify cleanup**: `collectVerifiedEmployerMatches` was called twice per resume (O(2N)). Refactored to compute once at the call site and pass into `computeBrandHits`.

## Relationship to PR #215

PR #215 (merged) fixed the export-time scoring bump to ignore employer-context brandHits. This PR fixes the upstream ingest so the wrong brandHit is never stored in Convex. Both are complementary.

## Test plan

- [x] New test: `"should keep non-brand ITES employers in companyHits without creating employer brandHits"` — 宝力机械有限公司 produces no employer brandHit
- [x] Existing FANUC employer test still passes (发那科 is in brands.json → employer brandHit kept)
- [x] All 32 ingest tests pass
- [x] `make check` clean
- [ ] After deploy: trigger re-ingest → re-export confirms 张先生/周祥富 show `brandHits=(empty)`, `industryDbV2Raw=20`