### PR TITLE
fix(seek): first-load capture race, terminal-page pagination, Malaysia support, prompt refactor

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -606,6 +606,7 @@ function buildAiResumePayload(item: {
     skills: item.indexData.skills,
     companies: item.indexData.companies.length > 0 ? item.indexData.companies : extractCompanies(item.resume.workHistory),
     workHistory: buildWorkHistoryEvidence(item.resume.workHistory).lines.join("\n") || undefined,
+    sourceKey: item.resume.profileType === "seek" ? "seek" : item.resume.profileType,
   };
 }
 
@@ -1419,7 +1420,6 @@ app.post("/api/resumes/match-stream", async (c) => {
                 requirements,
                 responsibilities,
               },
-              undefined,
               {
                 onResult: ({ resumeId, result, done }) => {
                   const payload = {
@@ -1498,7 +1498,6 @@ app.post("/api/resumes/match-stream", async (c) => {
             requirements,
             responsibilities,
           },
-          undefined,
           {
             onResult: ({ resumeId, result, done, total }) => {
               const payload = {

--- a/apps/api/src/services/ai-matching.ts
+++ b/apps/api/src/services/ai-matching.ts
@@ -13,6 +13,7 @@ import JSON5 from "json5";
 import { aiConfig, validateResumeAIConfig, getMaskedApiKey } from "./ai-config.js";
 import { findProjectRoot } from "./db.js";
 import { localeToNaturalLanguage, resolveAIOutputLocale } from "./locale-utils.js";
+import { resumeAiPromptService, type ResumeAiPromptDocument } from "./resume-ai-prompt-service.js";
 
 // Types
 export interface MatchingRequest {
@@ -24,18 +25,13 @@ export interface MatchingRequest {
         skills?: string[];
         companies?: string[];
         workHistory?: string;
+        sourceKey?: string;
     };
     jobDescription: {
         title: string;
         requirements: string;
         responsibilities?: string;
         company?: string;
-    };
-    criteria?: {
-        requiredSkills?: string[];
-        preferredSkills?: string[];
-        minExperience?: number;
-        educationLevel?: string;
     };
 }
 
@@ -123,59 +119,10 @@ function loadConfiguredConcurrency(): number {
 }
 
 // Prompt templates
-const SYSTEM_PROMPT = `你是一个专业的HR助手，专门帮助筛选精密机械和机床行业的简历。
-你需要根据职位要求对候选人进行评分和分析。
-
-评分标准：
-- 90-100分：完美匹配，技能、经验、教育背景完全符合要求
-- 70-89分：良好匹配，大部分要求符合，有少量可培养的差距
-- 50-69分：潜力候选人，有相关基础但需要培训
-- 0-49分：不匹配，基本要求不满足
-
-你必须严格按照JSON格式返回结果，不要包含任何其他文字。`;
-
-function buildSystemPrompt(locale: string): string {
+function buildSystemPrompt(systemPrompt: string, locale: string): string {
     const naturalLanguage = localeToNaturalLanguage(locale);
-    return `${SYSTEM_PROMPT}\nPlease respond entirely in ${naturalLanguage}.`;
+    return `${systemPrompt}\nPlease respond entirely in ${naturalLanguage}.`;
 }
-
-const USER_PROMPT_TEMPLATE = `请分析以下候选人与职位的匹配度：
-
-## 职位信息
-**职位名称**: {jobTitle}
-**职位要求**:
-{requirements}
-
-## 候选人信息
-**姓名**: {candidateName}
-**工作经验**: {workExperience}年
-**学历**: {education}
-**技能**: {skills}
-**曾任职公司**: {companies}
-**工作经历**:
-{workHistory}
-
-{additionalCriteria}
-
-重要评估规则：
-- 只根据"工作经历"中的实际岗位和职责来判断候选人是否有相关经验
-- 不要根据候选人的求职意向或自我介绍来推断其能力
-- 如果工作经历中没有相关岗位经验，即使总工作年限很长也应给予较低评分
-
-**行业相关性验证规则（重要）：**
-- 对于销售类岗位，销售经验必须来自CNC机床、数控设备、精密机械等相关行业
-- 在非相关行业（如纸业、零售、餐饮、快消品等）的销售经验不计入CNC行业销售经验
-- CNC相关行业关键词：机床、数控、CNC、模具、加工中心、车床、铣床、磨床、机械、自动化、五金、金属加工
-- 如果候选人的销售经历全部来自非CNC相关行业，应给予低分（<50分）并在concerns中说明原因
-
-请以JSON格式返回分析结果，包含以下字段：
-{
-  "score": 0-100的整数评分,
-  "recommendation": "strong_match" 或 "match" 或 "potential" 或 "no_match",
-  "highlights": ["匹配亮点1", "匹配亮点2", ...],
-  "concerns": ["关注点或不足1", "关注点或不足2", ...],
-  "summary": "中文总结，说明匹配原因和建议"
-}`;
 
 const SCORE_WORD_MAP: Record<string, number> = {
     zero: 0,
@@ -274,7 +221,7 @@ export class AIMatchingService {
     /**
      * Match a single resume against a job description
      */
-    async matchResume(request: MatchingRequest): Promise<MatchingResult> {
+    async matchResume(request: MatchingRequest, promptOverride?: ResumeAiPromptDocument): Promise<MatchingResult> {
         const availability = this.isAvailable();
         if (!availability.available) {
             return {
@@ -287,12 +234,10 @@ export class AIMatchingService {
             };
         }
 
-        const aiOutputLocale = resolveAIOutputLocale();
-        const systemPrompt = buildSystemPrompt(aiOutputLocale);
-        const userPrompt = this.buildPrompt(request);
+        const prompt = promptOverride ?? this.loadPromptForResume(request.resume);
         const messages = [
-            { role: "system", content: systemPrompt },
-            { role: "user", content: userPrompt },
+            { role: "system", content: buildSystemPrompt(prompt.normalized.systemPrompt, prompt.normalized.locale) },
+            { role: "user", content: this.buildPrompt(request.resume, request.jobDescription, prompt) },
         ];
 
         try {
@@ -319,7 +264,6 @@ export class AIMatchingService {
     async matchBatch(
         resumes: MatchingRequest["resume"][],
         jobDescription: MatchingRequest["jobDescription"],
-        criteria?: MatchingRequest["criteria"],
         options?: BatchMatchingOptions
     ): Promise<BatchMatchingResult> {
         const startTime = Date.now();
@@ -336,6 +280,7 @@ export class AIMatchingService {
             options?.concurrency ?? this.defaultConcurrency,
             resumes.length
         ));
+        const promptsBySourceKey = new Map<string, ResumeAiPromptDocument>();
 
         const orderedResults: Array<{ resumeId: string; result: MatchingResult } | null> =
             Array.from({ length: resumes.length }, () => null);
@@ -353,11 +298,11 @@ export class AIMatchingService {
 
                 let result: MatchingResult;
                 try {
+                    const prompt = this.loadPromptForResume(resume, promptsBySourceKey);
                     result = await this.matchResume({
                         resume,
                         jobDescription,
-                        criteria,
-                    });
+                    }, prompt);
                 } catch {
                     failedCount += 1;
                     result = {
@@ -454,38 +399,40 @@ Return strictly valid JSON:
     /**
      * Build the prompt from request
      */
-    private buildPrompt(request: MatchingRequest): string {
-        const { resume, jobDescription, criteria } = request;
+    private buildPrompt(
+        resume: MatchingRequest["resume"],
+        jobDescription: MatchingRequest["jobDescription"],
+        prompt: ResumeAiPromptDocument
+    ): string {
+        const matchingRules = jobDescription.responsibilities || jobDescription.requirements || "";
+        const verifiedCompanies = resume.companies?.length ? resume.companies.join(", ") : "无";
+        const evidenceText = resume.workHistory || "无工作经历";
 
-        let additionalCriteria = "";
-        if (criteria) {
-            const parts: string[] = [];
-            if (criteria.requiredSkills?.length) {
-                parts.push(`**必须技能**: ${criteria.requiredSkills.join(", ")}`);
-            }
-            if (criteria.preferredSkills?.length) {
-                parts.push(`**优先技能**: ${criteria.preferredSkills.join(", ")}`);
-            }
-            if (criteria.minExperience) {
-                parts.push(`**最低经验**: ${criteria.minExperience}年`);
-            }
-            if (criteria.educationLevel) {
-                parts.push(`**学历要求**: ${criteria.educationLevel}`);
-            }
-            if (parts.length > 0) {
-                additionalCriteria = "## 额外筛选条件\n" + parts.join("\n");
-            }
-        }
+        return resumeAiPromptService.renderUserPromptTemplate(prompt.normalized.userPromptTemplate, {
+            jobTitle: jobDescription.title,
+            requirements: jobDescription.requirements,
+            matchingRules,
+            candidateName: resume.name,
+            verifiedCompanies,
+            evidenceText,
+            workExperience: String(resume.workExperience || 0),
+            education: resume.education || "未填写",
+            companies: resume.companies?.join(", ") || "未填写",
+        });
+    }
 
-        return USER_PROMPT_TEMPLATE.replace("{jobTitle}", jobDescription.title)
-            .replace("{requirements}", jobDescription.requirements)
-            .replace("{candidateName}", resume.name)
-            .replace("{workExperience}", String(resume.workExperience || 0))
-            .replace("{education}", resume.education || "未填写")
-            .replace("{skills}", resume.skills?.join(", ") || "未填写")
-            .replace("{companies}", resume.companies?.join(", ") || "未填写")
-            .replace("{workHistory}", resume.workHistory || "无工作经历")
-            .replace("{additionalCriteria}", additionalCriteria);
+    private loadPromptForResume(
+        resume: MatchingRequest["resume"],
+        promptCache?: Map<string, ResumeAiPromptDocument>
+    ): ResumeAiPromptDocument {
+        const sourceKey = resume.sourceKey ?? "";
+        const cached = promptCache?.get(sourceKey);
+        if (cached) return cached;
+
+        const aiOutputLocale = resolveAIOutputLocale({ sourceKey: resume.sourceKey });
+        const prompt = resumeAiPromptService.loadPrompt(aiOutputLocale);
+        promptCache?.set(sourceKey, prompt);
+        return prompt;
     }
 
     /**

--- a/apps/api/src/services/locale-utils.ts
+++ b/apps/api/src/services/locale-utils.ts
@@ -1,18 +1,21 @@
-const DEFAULT_AI_OUTPUT_LOCALE = "zh-Hans";
+import {
+    DEFAULT_RESUME_AI_PROMPT_LOCALE,
+    LOCALE_TO_NATURAL_LANGUAGE,
+} from "./resume-ai-prompt-service.js";
 
-const LOCALE_TO_NATURAL: Record<string, string> = {
-    "zh-Hans": "Simplified Chinese",
-    "zh-Hant": "Traditional Chinese",
-    en: "English",
-    ja: "Japanese",
-    ko: "Korean",
-};
+const SEEK_RESUME_AI_OUTPUT_LOCALE = "en";
 
 export function localeToNaturalLanguage(locale: string): string {
-    return LOCALE_TO_NATURAL[locale] ?? locale;
+    return LOCALE_TO_NATURAL_LANGUAGE[locale] ?? locale;
 }
 
-export function resolveAIOutputLocale(): string {
+export function resolveAIOutputLocale(scope?: { sourceKey?: string | null }): string {
     const locale = process.env.AI_OUTPUT_LOCALE?.trim();
-    return locale && locale.length > 0 ? locale : DEFAULT_AI_OUTPUT_LOCALE;
+    if (locale && locale.length > 0) {
+        return locale;
+    }
+    if (scope?.sourceKey === "seek") {
+        return SEEK_RESUME_AI_OUTPUT_LOCALE;
+    }
+    return DEFAULT_RESUME_AI_PROMPT_LOCALE;
 }

--- a/apps/api/src/services/resume-ai-prompt-service.ts
+++ b/apps/api/src/services/resume-ai-prompt-service.ts
@@ -8,7 +8,7 @@ import { FileParseError } from "./errors.js";
 
 export const DEFAULT_RESUME_AI_PROMPT_LOCALE = "zh-Hans";
 
-const LOCALE_TO_NATURAL_LANGUAGE: Record<string, string> = {
+export const LOCALE_TO_NATURAL_LANGUAGE: Record<string, string> = {
   "zh-Hans": "Simplified Chinese",
   "zh-Hant": "Traditional Chinese",
   en: "English",
@@ -77,6 +77,8 @@ export interface ResumeAiPromptNormalized {
   promptVariables: string;
   notes: string;
 }
+
+export type ResumeAiPromptTemplateValues = Record<string, string>;
 
 export interface ResumeAiPromptDocument {
   metadata: ResumeAiPromptMetadata;
@@ -253,6 +255,17 @@ function buildNormalizedPrompt(
     promptVariables: sections.promptVariables.trim(),
     notes: sections.notes.trim(),
   };
+}
+
+function getMissingTemplateVariables(template: string, values: ResumeAiPromptTemplateValues): string[] {
+  return Object.keys(values).filter((key) => !template.includes(`{${key}}`));
+}
+
+function renderPromptTemplate(template: string, values: ResumeAiPromptTemplateValues): string {
+  return Object.entries(values).reduce(
+    (result, [key, value]) => result.replaceAll(`{${key}}`, value),
+    template,
+  );
 }
 
 export class ResumeAiPromptService {
@@ -462,6 +475,14 @@ export class ResumeAiPromptService {
     }
 
     return sources;
+  }
+
+  renderUserPromptTemplate(template: string, values: ResumeAiPromptTemplateValues): string {
+    const missing = getMissingTemplateVariables(template, values);
+    if (missing.length > 0) {
+      throw new FileParseError(template, `Prompt template missing variables: ${missing.join(", ")}`);
+    }
+    return renderPromptTemplate(template, values);
   }
 
   clearCache(): void {

--- a/apps/api/src/services/resume-index.test.ts
+++ b/apps/api/src/services/resume-index.test.ts
@@ -113,4 +113,35 @@ describe("ResumeIndexService", () => {
       cleanupFixtureRoot(root);
     }
   });
+
+  it("extracts seeded English location cities before CJK fallback", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new ResumeIndexService(root);
+      const resumes: ResumeItem[] = [
+        {
+          name: "Alex Tan",
+          profileUrl: "https://my.employer.seek.com/candidates/1",
+          activityStatus: "Active",
+          age: "29",
+          experience: "6 years",
+          education: "Bachelor",
+          location: "Kuala Lumpur, Malaysia",
+          selfIntro: "",
+          jobIntention: "",
+          expectedSalary: "",
+          workHistory: [],
+          extractedAt: "2026-03-16T00:00:00.000Z",
+          resumeId: "R2001",
+          profileType: "seek",
+        },
+      ];
+
+      const index = service.buildIndex("sample:seek", resumes);
+      expect(index.get("R2001")?.locationCity).toBe("Kuala Lumpur");
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
 });

--- a/apps/api/src/services/resume-index.ts
+++ b/apps/api/src/services/resume-index.ts
@@ -5,7 +5,9 @@ import {
   buildWorkHistoryEntryText,
   buildWorkHistoryEvidence,
   FALLBACK_INDUSTRY_KEYWORDS,
+  findLocation,
   normalizeIndustryTags,
+  normalizeLocationName,
   type CanonicalIndustryTag,
 } from "@trends/shared";
 
@@ -207,11 +209,26 @@ export class ResumeIndexService {
       if (location.includes(knownLocation)) return knownLocation;
     }
 
-    const normalized = location.trim();
-    const direct = normalized.match(/^([\u4e00-\u9fa5]{2,6}?)(?:市|县|区|镇)/);
+    const seededLocation = findLocation(location);
+    if (seededLocation) {
+      if (seededLocation.level === "city") {
+        return seededLocation.name;
+      }
+      if (seededLocation.level === "district" && seededLocation.parentName) {
+        return seededLocation.parentName;
+      }
+      return seededLocation.name;
+    }
+
+    const normalized = normalizeLocationName(location.trim());
+    if (/[a-z]/i.test(normalized)) {
+      return normalized || null;
+    }
+
+    const direct = location.trim().match(/^([\u4e00-\u9fa5]{2,6}?)(?:市|县|区|镇)/);
     if (direct?.[1]) return direct[1];
 
-    const fallback = normalized.match(/[\u4e00-\u9fa5]{2,4}/);
+    const fallback = location.trim().match(/[\u4e00-\u9fa5]{2,4}/);
     return fallback?.[0] ?? null;
   }
 

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -20,6 +20,7 @@ const SELECTORS = {
   workItem: '.work-item',
   pagination: '.el-pagination',
   nextPageBtn: '.el-pagination .btn-next',
+  seekPagination: 'nav[aria-label="Pagination of results"]',
   searchInput: '.el-autocomplete input.el-input__inner',
   searchButton: '.resume-search-item-search-input-block__input-button',
   // Area selector (location filter modal)
@@ -255,11 +256,36 @@ function buildExportFilename() {
   return `resumes_${timestamp}_${makeRandomId()}.json`;
 }
 
+function parseAutoLocationValues(locationRaw) {
+  if (!locationRaw) return [];
+  return Array.from(
+    new Set(
+      String(locationRaw)
+        .split(/[，,、]+/)
+        .map((location) => location.trim())
+        .filter(Boolean)
+    )
+  ).slice(0, 10);
+}
+
+function getAutoLocationValues(url) {
+  return parseAutoLocationValues(url.searchParams.get(AUTO_LOCATION_PARAM) || '');
+}
+
+function normalizeSeekLocationLabel(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/\bmalaysia\b/g, '')
+    .replace(/\bmy\b/g, '')
+    .replace(/[，,、]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 function buildExportMetadata(resumes) {
   const url = new URL(window.location.href);
   const keyword = normalizeKeyword(url.searchParams.get(AUTO_SEARCH_PARAM) || '');
-  const location = (url.searchParams.get(AUTO_LOCATION_PARAM) || '').trim();
-  const locationArray = location ? location.split(/[\s,]+/).filter(Boolean) : [];
+  const locationArray = getAutoLocationValues(url);
   const rawSampleName = url.searchParams.get(SAMPLE_NAME_PARAM) || '';
   const sampleName = sanitizeSampleName(rawSampleName).replace(/\.json$/i, '');
 
@@ -1255,8 +1281,7 @@ function buildSubmitMetadata() {
   const url = new URL(window.location.href);
   const sourceKey = getCurrentSourceKey();
   const keyword = normalizeKeyword(url.searchParams.get(AUTO_SEARCH_PARAM) || '');
-  const locationRaw = (url.searchParams.get(AUTO_LOCATION_PARAM) || '').trim();
-  const location = locationRaw ? locationRaw.split(/[\s,]+/).filter(Boolean).join(',') : '';
+  const location = getAutoLocationValues(url).join(',');
 
   url.searchParams.delete(AUTO_EXPORT_PARAM);
   url.searchParams.delete(AUTO_SYNC_PARAM);
@@ -1491,13 +1516,18 @@ function updateApiSnapshot(message) {
 
 function installApiHook() {
   try {
+    if (document.documentElement.hasAttribute('data-tr-page-hook')) {
+      document.documentElement.setAttribute('data-tr-resume-hook', 'true');
+      return;
+    }
     if (document.documentElement.hasAttribute('data-tr-resume-hook')) return;
     const script = document.createElement('script');
     script.src = chrome.runtime.getURL('page-hook.js');
-    script.async = true;
+    script.async = false;
     script.setAttribute('data-tr-resume-hook', 'true');
     script.onload = () => script.remove();
-    (document.head || document.documentElement).appendChild(script);
+    const mountTarget = document.head || document.documentElement;
+    mountTarget.prepend(script);
     document.documentElement.setAttribute('data-tr-resume-hook', 'true');
   } catch (error) {
     console.warn('Failed to install API hook:', error);
@@ -2010,8 +2040,9 @@ function getSeekPaginationInfo() {
       return match ? Number.parseInt(match[1], 10) : 0;
     })
     .filter((value) => Number.isFinite(value) && value > 0);
-  const hasNextPage = links.some((item) => /next/i.test((item.textContent || '').trim()));
   const totalPages = Math.max(pageNumbers.length > 0 ? Math.max(...pageNumbers) : 0, currentPage);
+  const nextLink = getSeekNextPageLink();
+  const hasNextPage = totalPages > currentPage && !isDisabledPaginationControl(nextLink);
 
   return { currentPage, totalPages, totalItems: 0, hasNextPage };
 }
@@ -2050,22 +2081,39 @@ function getPaginationInfo() {
   return { currentPage, totalPages, totalItems, hasNextPage: totalPages > currentPage };
 }
 
+function getSeekNextPageLink() {
+  const pagination = document.querySelector(SELECTORS.seekPagination);
+  if (!pagination) return null;
+  const links = Array.from(pagination.querySelectorAll('a'));
+  const nextLink = links.find((node) => /next/i.test((node.textContent || '').trim()));
+  return asHTMLElement(nextLink || null);
+}
+
+function isDisabledPaginationControl(control) {
+  if (!control) return true;
+  return (
+    control.hasAttribute('disabled')
+    || control.classList.contains('disabled')
+    || control.classList.contains('is-disabled')
+    || control.getAttribute('aria-disabled') === 'true'
+    || control.getAttribute('aria-hidden') === 'true'
+    || control.getAttribute('tabindex') === '-1'
+  );
+}
+
 function goToNextPageInternal() {
-  const nextBtn = /** @type {HTMLElement | null} */ (document.querySelector(SELECTORS.nextPageBtn));
-  if (!nextBtn) return false;
-  if (
-    nextBtn.hasAttribute('disabled')
-    || nextBtn.classList.contains('is-disabled')
-    || nextBtn.getAttribute('aria-disabled') === 'true'
-  ) {
-    return false;
-  }
+  const nextBtn = getCurrentSourceKey() === SOURCE_KEYS.SEEK
+    ? getSeekNextPageLink()
+    : asHTMLElement(document.querySelector(SELECTORS.nextPageBtn));
+  if (!nextBtn || isDisabledPaginationControl(nextBtn)) return false;
   nextBtn.click();
   return true;
 }
 
 function getNextPageButtonState() {
-  const nextBtn = document.querySelector(SELECTORS.nextPageBtn);
+  const nextBtn = getCurrentSourceKey() === SOURCE_KEYS.SEEK
+    ? getSeekNextPageLink()
+    : document.querySelector(SELECTORS.nextPageBtn);
   if (!nextBtn) {
     return {
       exists: false
@@ -2073,6 +2121,8 @@ function getNextPageButtonState() {
   }
   return {
     exists: true,
+    text: nextBtn.textContent || '',
+    href: nextBtn.getAttribute('href') || '',
     className: nextBtn.className || '',
     disabledAttr: nextBtn.getAttribute('disabled') || '',
     ariaDisabled: nextBtn.getAttribute('aria-disabled') || '',
@@ -2372,7 +2422,7 @@ function waitForResumeCards({ timeoutMs = 30000, minCount = 1 } = {}) {
 
     const intervalId = setInterval(check, 500);
     const observer = new MutationObserver(check);
-    observer.observe(document.body, { childList: true, subtree: true });
+    observer.observe(document.body || document.documentElement, { childList: true, subtree: true });
     check();
   });
 }
@@ -2403,7 +2453,7 @@ function waitForApiRows({ timeoutMs = 5000, minCount = 1 } = {}) {
 
     const intervalId = setInterval(check, 300);
     const observer = new MutationObserver(check);
-    observer.observe(document.body, { childList: true, subtree: true });
+    observer.observe(document.body || document.documentElement, { childList: true, subtree: true });
     check();
   });
 }
@@ -2437,8 +2487,9 @@ function waitForPagination({ timeoutMs = 8000 } = {}) {
 
     const check = () => {
       if (done) return;
-      const pagination = document.querySelector(SELECTORS.pagination);
-      const nextBtn = document.querySelector(SELECTORS.nextPageBtn);
+      const isSeek = getCurrentSourceKey() === SOURCE_KEYS.SEEK;
+      const pagination = document.querySelector(isSeek ? SELECTORS.seekPagination : SELECTORS.pagination);
+      const nextBtn = isSeek ? getSeekNextPageLink() : document.querySelector(SELECTORS.nextPageBtn);
       if (pagination && nextBtn) {
         done = true;
         cleanup();
@@ -2457,7 +2508,7 @@ function waitForPagination({ timeoutMs = 8000 } = {}) {
 
     const intervalId = setInterval(check, 300);
     const observer = new MutationObserver(check);
-    observer.observe(document.body, { childList: true, subtree: true });
+    observer.observe(document.body || document.documentElement, { childList: true, subtree: true });
     check();
   });
 }
@@ -2497,7 +2548,7 @@ function waitForPageTransition(options = {}) {
 
     const intervalId = setInterval(check, 300);
     const observer = new MutationObserver(check);
-    observer.observe(document.body, { childList: true, subtree: true, attributes: true });
+    observer.observe(document.body || document.documentElement, { childList: true, subtree: true, attributes: true });
     check();
   });
 }
@@ -2529,7 +2580,7 @@ function waitForSearchElements({ timeoutMs = 8000 } = {}) {
 
     const intervalId = setInterval(check, 300);
     const observer = new MutationObserver(check);
-    observer.observe(document.body, { childList: true, subtree: true });
+    observer.observe(document.body || document.documentElement, { childList: true, subtree: true });
     check();
   });
 }
@@ -2566,7 +2617,7 @@ function waitForAreaModal({ timeoutMs = 8000 } = {}) {
 
     const intervalId = setInterval(check, 300);
     const observer = new MutationObserver(check);
-    observer.observe(document.body, { childList: true, subtree: true, attributes: true });
+    observer.observe(document.body || document.documentElement, { childList: true, subtree: true, attributes: true });
     check();
   });
 }
@@ -2599,12 +2650,27 @@ function asHTMLElement(element) {
 function findAreaItemByText(container, text) {
   if (!container || !text) return null;
   const target = text.replace(/\s+/g, ' ').trim();
+  const normalizedTarget = normalizeSeekLocationLabel(target);
   const itemSelector = `${SELECTORS.areaItem}, ${SELECTORS.areaDistrictItem}`;
   const items = container.querySelectorAll(itemSelector);
+  let normalizedMatch = null;
   for (const item of items) {
-    if (getAreaItemText(item) === target) return asHTMLElement(item);
+    const itemText = getAreaItemText(item);
+    if (itemText === target) return asHTMLElement(item);
+    if (!normalizedMatch) {
+      const normalizedItemText = normalizeSeekLocationLabel(itemText);
+      if (
+        normalizedTarget &&
+        normalizedItemText &&
+        (normalizedItemText === normalizedTarget
+          || normalizedItemText.includes(normalizedTarget)
+          || normalizedTarget.includes(normalizedItemText))
+      ) {
+        normalizedMatch = asHTMLElement(item);
+      }
+    }
   }
-  return null;
+  return normalizedMatch;
 }
 
 /**
@@ -2640,7 +2706,7 @@ function waitForAreaItems(blockSelector, { timeoutMs = 5000, itemSelector } = {}
 
     const intervalId = setInterval(check, 300);
     const observer = new MutationObserver(check);
-    observer.observe(document.body, { childList: true, subtree: true });
+    observer.observe(document.body || document.documentElement, { childList: true, subtree: true });
     check();
   });
 }
@@ -2671,7 +2737,7 @@ function waitForAreaTrigger({ timeoutMs = 8000 } = {}) {
 
     const intervalId = setInterval(check, 300);
     const observer = new MutationObserver(check);
-    observer.observe(document.body, { childList: true, subtree: true, attributes: true });
+    observer.observe(document.body || document.documentElement, { childList: true, subtree: true, attributes: true });
     check();
   });
 }
@@ -2700,6 +2766,11 @@ function setAutoLocationAttributes(status, location) {
   } catch {
     // ignore
   }
+}
+
+function canSkipAutoLocationForSeekPage() {
+  if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return false;
+  return window.location.pathname.includes('/candidates/recommended');
 }
 
 function setAutoAgeAttributes(status, minAge, maxAge) {
@@ -2838,14 +2909,7 @@ async function autoApplyAgeFilterFromUrl() {
 async function autoSelectLocation() {
   const params = new URLSearchParams(window.location.search || '');
   const locationRaw = (params.get(AUTO_LOCATION_PARAM) || '').trim();
-  const parsedLocations = Array.from(
-    new Set(
-      locationRaw
-        .split(/[\s,，、]+/)
-        .map((location) => location.trim())
-        .filter(Boolean)
-    )
-  ).slice(0, 10);
+  const parsedLocations = parseAutoLocationValues(locationRaw);
 
   if (parsedLocations.length === 0) {
     setAutoLocationAttributes('skipped', '');
@@ -2860,16 +2924,26 @@ async function autoSelectLocation() {
     try {
       trigger = await waitForAreaTrigger({});
     } catch {
-      setAutoLocationAttributes('failed', locationRaw);
-      console.warn('🎯 [Auto Location] Trigger not found');
+      if (canSkipAutoLocationForSeekPage()) {
+        setAutoLocationAttributes('skipped', locationRaw);
+        console.warn('🎯 [Auto Location] Trigger not found; skipping on SEEK recommended page');
+      } else {
+        setAutoLocationAttributes('failed', locationRaw);
+        console.warn('🎯 [Auto Location] Trigger not found');
+      }
       return;
     }
     trigger.click();
     try {
       modal = await waitForAreaModal({});
     } catch (error) {
-      setAutoLocationAttributes('failed', locationRaw);
-      console.warn('🎯 [Auto Location] Area selector not ready:', error);
+      if (canSkipAutoLocationForSeekPage()) {
+        setAutoLocationAttributes('skipped', locationRaw);
+        console.warn('🎯 [Auto Location] Area selector not ready; skipping on SEEK recommended page:', error);
+      } else {
+        setAutoLocationAttributes('failed', locationRaw);
+        console.warn('🎯 [Auto Location] Area selector not ready:', error);
+      }
       return;
     }
   }
@@ -2878,8 +2952,13 @@ async function autoSelectLocation() {
   const confirmBtn = asHTMLElement(modal.querySelector(SELECTORS.areaConfirmBtn));
   const cancelBtn = asHTMLElement(modal.querySelector(SELECTORS.areaCancelBtn));
   if (!provinceBlock || !confirmBtn || !cancelBtn) {
-    setAutoLocationAttributes('failed', locationRaw);
-    console.warn('🎯 [Auto Location] Missing modal controls');
+    if (canSkipAutoLocationForSeekPage()) {
+      setAutoLocationAttributes('skipped', locationRaw);
+      console.warn('🎯 [Auto Location] Missing modal controls; skipping on SEEK recommended page');
+    } else {
+      setAutoLocationAttributes('failed', locationRaw);
+      console.warn('🎯 [Auto Location] Missing modal controls');
+    }
     return;
   }
   const locationsToSelect = parsedLocations.filter((location, index) => {
@@ -2998,7 +3077,11 @@ async function autoSelectLocation() {
     setAutoLocationAttributes('done', successLocations.join(','));
   } else {
     cancelBtn.click();
-    setAutoLocationAttributes('failed', locationRaw);
+    if (canSkipAutoLocationForSeekPage()) {
+      setAutoLocationAttributes('skipped', locationRaw);
+    } else {
+      setAutoLocationAttributes('failed', locationRaw);
+    }
   }
 }
 
@@ -3254,6 +3337,10 @@ async function runAutoSyncIfEnabled() {
         }
 
         const paginationAfter = getPaginationInfo();
+        if (!paginationAfter.hasNextPage || paginationAfter.currentPage >= paginationAfter.totalPages) {
+          stopReason = 'no-next-page';
+          break;
+        }
         try {
           await waitForPagination({ timeoutMs: 8000 });
         } catch {
@@ -3312,6 +3399,10 @@ async function runAutoSyncIfEnabled() {
       }
 
       const paginationAfter = getPaginationInfo();
+      if (!paginationAfter.hasNextPage || paginationAfter.currentPage >= paginationAfter.totalPages) {
+        stopReason = 'no-next-page';
+        break;
+      }
       try {
         await waitForPagination({ timeoutMs: 8000 });
       } catch {

--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -41,6 +41,21 @@
                 "*://my.employer.seek.com/talentsearch/profile*"
             ],
             "js": [
+                "page-hook.js"
+            ],
+            "run_at": "document_start",
+            "world": "MAIN"
+        },
+        {
+            "matches": [
+                "*://hr.job5156.com/search*",
+                "*://hr.job5156.com/resume/view/*",
+                "*://hk.employer.seek.com/candidates/recommended*",
+                "*://my.employer.seek.com/candidates/recommended*",
+                "*://hk.employer.seek.com/talentsearch/profile*",
+                "*://my.employer.seek.com/talentsearch/profile*"
+            ],
+            "js": [
                 "content.js"
             ],
             "css": [

--- a/apps/browser-extension/page-hook.js
+++ b/apps/browser-extension/page-hook.js
@@ -3,6 +3,11 @@
   const trWindow = window;
   if (trWindow.__trResumeHookInstalled) return;
   trWindow.__trResumeHookInstalled = true;
+  try {
+    document.documentElement?.setAttribute('data-tr-page-hook', 'true');
+  } catch {
+    // ignore
+  }
 
   const SOURCE = 'tr-resume-api';
   const EXTERNAL_ACCESS_KEY = '__TR_RESUME_DATA__';
@@ -246,7 +251,14 @@
       })
       .filter((value) => Number.isFinite(value) && value > 0);
     const totalPages = Math.max(pageNumbers.length > 0 ? Math.max(...pageNumbers) : 0, currentPage);
-    const hasNextPage = links.some((node) => (node.textContent || '').trim().toLowerCase() === 'next');
+    const nextLink = links.find((node) => (node.textContent || '').trim().toLowerCase() === 'next') || null;
+    const hasNextPage = totalPages > currentPage && !!nextLink
+      && !nextLink.hasAttribute('disabled')
+      && !nextLink.classList.contains('disabled')
+      && !nextLink.classList.contains('is-disabled')
+      && nextLink.getAttribute('aria-disabled') !== 'true'
+      && nextLink.getAttribute('aria-hidden') !== 'true'
+      && nextLink.getAttribute('tabindex') !== '-1';
 
     return {
       currentPage,

--- a/apps/web/src/components/CollectResumesButton.tsx
+++ b/apps/web/src/components/CollectResumesButton.tsx
@@ -10,7 +10,8 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 
-const JOB_BOARD_BASE_URL = 'https://hr.job5156.com/search'
+const SEEK_TALENT_SEARCH_URL = 'https://my.employer.seek.com/candidates/recommended'
+const SEEK_DEFAULT_LOCATION = 'Kuala Lumpur MY'
 const EXTENSION_META_URL = '/extension/extension-meta.json'
 const EXTENSION_ZIP_URL = '/extension/trends-resume-collector-latest.zip'
 
@@ -50,6 +51,10 @@ export function CollectResumesButton({ location, keywords, collectLimit, minAge,
   const [maxPagesInput, setMaxPagesInput] = useState('')
 
   const normalizedLocation = useMemo(() => location.trim(), [location])
+  const collectLocation = useMemo(
+    () => (normalizedLocation.length > 0 ? normalizedLocation : SEEK_DEFAULT_LOCATION),
+    [normalizedLocation]
+  )
   const normalizedKeywords = useMemo(
     () => keywords.map((keyword) => keyword.trim()).filter((keyword) => keyword.length > 0),
     [keywords]
@@ -74,8 +79,8 @@ export function CollectResumesButton({ location, keywords, collectLimit, minAge,
       tr_auto_sync: 'true',
     })
 
-    if (normalizedLocation.length > 0) {
-      query.set('location', normalizedLocation) // will be parsed by extension
+    if (collectLocation.length > 0) {
+      query.set('location', collectLocation)
     }
 
     if (normalizedCollectLimit > 0) {
@@ -94,13 +99,13 @@ export function CollectResumesButton({ location, keywords, collectLimit, minAge,
       query.set('tr_max_age', String(normalizedMaxAge))
     }
 
-    return `${JOB_BOARD_BASE_URL}?${query.toString()}`
+    return `${SEEK_TALENT_SEARCH_URL}?${query.toString()}`
   }, [
     disabled,
     normalizedCollectLimit,
     normalizedCollectMaxPages,
     normalizedKeywords,
-    normalizedLocation,
+    collectLocation,
     normalizedMinAge,
     normalizedMaxAge,
   ])

--- a/packages/shared/src/__tests__/location-tree.test.ts
+++ b/packages/shared/src/__tests__/location-tree.test.ts
@@ -47,4 +47,11 @@ describe("location-tree", () => {
     expect(isLocationMatch("深圳市", "东莞")).toBe(false);
     expect(isLocationMatch("广东", "东莞")).toBe(false);
   });
+
+  it("supports seeded Malaysia and Kuala Lumpur aliases", () => {
+    expect(findLocation("Kuala Lumpur MY")?.name).toBe("Kuala Lumpur");
+    expect(findLocation("Kuala Lumpur, Malaysia")?.name).toBe("Kuala Lumpur");
+    expect(isLocationMatch("Kuala Lumpur, Malaysia", "Kuala Lumpur MY")).toBe(true);
+    expect(isLocationMatch("Kuala Lumpur", "Malaysia")).toBe(true);
+  });
 });

--- a/packages/shared/src/location-tree.ts
+++ b/packages/shared/src/location-tree.ts
@@ -136,6 +136,16 @@ const LOCATION_TREE: LocationSeed[] = [
       { name: "静安", aliases: ["静安区"] },
     ],
   },
+  {
+    name: "Malaysia",
+    aliases: ["MY", "马来西亚"],
+    children: [
+      {
+        name: "Kuala Lumpur",
+        aliases: ["Kuala Lumpur MY", "Kuala Lumpur, Malaysia", "KualaLumpur", "吉隆坡"],
+      },
+    ],
+  },
 ];
 
 const nodesById = new Map<string, InternalLocationNode>();
@@ -328,8 +338,19 @@ export function normalizeLocationName(name: string): string {
     return "";
   }
 
-  let normalized = name
-    .trim()
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  if (/[A-Za-z]/.test(trimmed)) {
+    return trimmed
+      .replace(/[，,、]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  let normalized = trimmed
     .replace(/[，,、]/g, "")
     .replace(/\s+/g, "");
 


### PR DESCRIPTION
## Summary

- **Browser extension**: Fix SEEK first-load GraphQL capture race by loading `page-hook.js` as a main-world `document_start` content script; content.js skips fallback reinjection when the hook marker is already present
- **Browser extension**: Align page-bridge `getSeekPaginationInfo` with content-side `isDisabledPaginationControl` — `hasNextPage` now correctly returns `false` on the terminal page for both helpers
- **API**: Centralize prompt rendering in `resume-ai-prompt-service`; batch path caches prompts per source key instead of re-resolving per resume; template variable validation added
- **Malaysia SEEK**: `my.employer.seek.com` added to manifest, location-tree, resume-index scoring, and CollectResumesButton

## Test plan
- [ ] Fresh load on SEEK recommended page → `data-tr-api-rows` populated immediately (no missed first request)
- [ ] Auto-sync completes all pages and stops with `stopReason: no-next-page`
- [ ] `getPaginationInfo().hasNextPage` returns `false` on terminal page (both content-side and page-bridge)
- [ ] `make check` passes
- [ ] Malaysia SEEK pages (`my.employer.seek.com`) matched by extension and scored correctly