### PR TITLE
fix(export+ingest): align aiScore with components; fix full hard-reset re-ingest

### DIFF
--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -324,8 +324,32 @@ describe("resume export route", () => {
           }),
         },
         entries: [
-          { resumeId: "convex-b", status: "contacted" },
-          { resumeId: "convex-a", status: "new" },
+          {
+            resumeId: "convex-b",
+            status: "contacted",
+            match: {
+              score: 99,
+              recommendation: "match",
+              scoreSource: "ai",
+              breakdown: {
+                related_exp: 12,
+                industry_db: 80,
+              },
+            },
+          },
+          {
+            resumeId: "convex-a",
+            status: "new",
+            match: {
+              score: 68,
+              recommendation: "strong_match",
+              scoreSource: "ai",
+              breakdown: {
+                related_exp: 18,
+                industry_db: 50,
+              },
+            },
+          },
         ],
       }),
     });
@@ -344,7 +368,9 @@ describe("resume export route", () => {
     await workbook.xlsx.load(Buffer.from(await response.arrayBuffer()));
     const sheet = workbook.getWorksheet("Resumes");
     const brandHitsColumn = findColumnIndex(sheet, "Brand Hits");
+    const aiScoreColumn = findColumnIndex(sheet, "AI Score");
     const industryDbColumn = findColumnIndex(sheet, "Industry DB");
+    const relatedExpColumn = findColumnIndex(sheet, "Related Exp");
     const industryDbRawColumn = findColumnIndex(sheet, "Industry DB V2 Raw");
     const industryDbNormalizedColumn = findColumnIndex(sheet, "Industry DB V2 Normalized");
     expect(sheet?.getCell("A2").value).toBe("convex-b");
@@ -352,13 +378,19 @@ describe("resume export route", () => {
     expect(sheet?.getCell("A3").value).toBe("convex-a");
     expect(sheet?.getCell("B3").value).toBe("Alice");
     expect(brandHitsColumn).toBeGreaterThan(0);
+    expect(aiScoreColumn).toBeGreaterThan(0);
     expect(industryDbColumn).toBeGreaterThan(0);
+    expect(relatedExpColumn).toBeGreaterThan(0);
     expect(industryDbRawColumn).toBeGreaterThan(0);
     expect(industryDbNormalizedColumn).toBeGreaterThan(0);
+    expect(sheet?.getRow(2).getCell(aiScoreColumn).value).toBe(50);
     expect(sheet?.getRow(2).getCell(industryDbColumn).value).toBe(38);
+    expect(sheet?.getRow(2).getCell(relatedExpColumn).value).toBe(12);
     expect(sheet?.getRow(2).getCell(industryDbRawColumn).value).toBe(20);
     expect(sheet?.getRow(2).getCell(industryDbNormalizedColumn).value).toBe(38);
+    expect(sheet?.getRow(3).getCell(aiScoreColumn).value).toBe(68);
     expect(sheet?.getRow(3).getCell(industryDbColumn).value).toBe(50);
+    expect(sheet?.getRow(3).getCell(relatedExpColumn).value).toBe(18);
     expect(sheet?.getRow(3).getCell(industryDbRawColumn).value).toBe(50);
     expect(sheet?.getRow(3).getCell(industryDbNormalizedColumn).value).toBe(50);
     expect(sheet?.getRow(3).getCell(brandHitsColumn).value).toBe("发那科");

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -116,9 +116,19 @@ describe("ExportService", () => {
     expect(parsed.data[0]?.referenceNote).toBe("Referred by HR dept");
   });
 
-  it("exports industryDb and relatedExp columns in standard CSV output", async () => {
+  it("exports aiScore aligned with industryDb and relatedExp in standard CSV output", async () => {
     const service = new ExportService();
-    const firstEntry = buildEntry("25");
+    const firstEntry: ResumeExportEntry = {
+      ...buildEntry("25"),
+      match: {
+        ...buildEntry("25").match!,
+        score: 88,
+        breakdown: {
+          related_exp: 18,
+          industry_db: 70,
+        },
+      },
+    };
     const secondEntry: ResumeExportEntry = {
       ...buildEntry("26"),
       key: "resume-2",
@@ -130,6 +140,10 @@ describe("ExportService", () => {
           brandHits: [],
           industryDbV2Raw: 25,
         },
+      },
+      match: {
+        ...buildEntry("26").match!,
+        score: 77,
       },
     };
 
@@ -149,8 +163,12 @@ describe("ExportService", () => {
     expect(parsed.meta.fields).toContain("relatedExp");
     expect(parsed.meta.fields).not.toContain("industryDbV2Raw");
     expect(parsed.meta.fields).not.toContain("industryDbV2Normalized");
+    expect(parsed.data[0]?.aiScore).toBe("68");
     expect(parsed.data[0]?.industryDb).toBe("50");
+    expect(parsed.data[0]?.relatedExp).toBe("18");
+    expect(parsed.data[1]?.aiScore).toBe("45");
     expect(parsed.data[1]?.industryDb).toBe("45");
+    expect(parsed.data[1]?.relatedExp).toBe("");
   });
 
   it("exports industryDbV2Raw and industryDbV2Normalized columns in debug CSV output", async () => {

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -241,6 +241,9 @@ function toRow(
   const ingestData = entry.resume.ingestData;
   const effectiveRaw = computeEffectiveIndustryDbV2Raw(ingestData);
   const { raw: industryDbV2Raw, normalized: industryDbV2Normalized } = batchNormalizer(effectiveRaw);
+  const relatedExp = typeof entry.match?.breakdown?.related_exp === "number"
+    ? entry.match.breakdown.related_exp
+    : undefined;
 
   return {
     resumeId: entry.key,
@@ -251,11 +254,9 @@ function toRow(
     education: normalizeString(entry.resume.education),
     age: parseAgeNumber(entry.resume.age) ?? "",
     expectedSalary: normalizeString(entry.resume.expectedSalary),
-    aiScore: typeof entry.match?.score === "number" ? entry.match.score : "",
+    aiScore: (relatedExp ?? 0) + industryDbV2Normalized,
     industryDb: industryDbV2Normalized,
-    relatedExp: typeof entry.match?.breakdown?.related_exp === "number"
-      ? entry.match.breakdown.related_exp
-      : "",
+    relatedExp: relatedExp ?? "",
     industryDbV2Raw,
     industryDbV2Normalized,
     ruleScore: typeof entry.ruleScore === "number" ? entry.ruleScore : "",

--- a/apps/web/src/pages/DebugIngest.test.tsx
+++ b/apps/web/src/pages/DebugIngest.test.tsx
@@ -8,6 +8,7 @@ const clearAnalysesMutation = vi.fn(async () => ({ cleared: 0 }))
 const hardResetMutation = vi.fn(async () => ({ cleared: 0 }))
 const backfillIngestDataAction = vi.fn(async () => ({ scheduled: 0 }))
 const reIngestStaleSkillsVersionAction = vi.fn(async () => ({ scheduled: 0 }))
+const reIngestAllResumesAction = vi.fn(async () => ({ scheduled: 0 }))
 const loadMore = vi.fn()
 type PaginatedQueryMockResult = {
   results: Array<Record<string, unknown>>
@@ -29,7 +30,7 @@ let mutationHookCallCount = 0
 vi.mock('convex/react', () => ({
   usePaginatedQuery: () => usePaginatedQueryMock(),
   useAction: () => {
-    const action = [backfillIngestDataAction, reIngestStaleSkillsVersionAction][actionHookCallCount % 2]
+    const action = [backfillIngestDataAction, reIngestStaleSkillsVersionAction, reIngestAllResumesAction][actionHookCallCount % 3]
     actionHookCallCount += 1
     return action
   },
@@ -177,7 +178,7 @@ describe('DebugIngest reset database dialog', () => {
 
     expect(
       screen.getByText(
-        'Clear all computed ingest and AI analysis data, then schedule full re-ingest for up to 500 resumes? This cannot be undone.'
+        'Clear all computed ingest and AI analysis data, then schedule a full background re-ingest for all resumes. This cannot be undone.'
       )
     ).toBeInTheDocument()
     expect(confirmSpy).not.toHaveBeenCalled()
@@ -186,7 +187,7 @@ describe('DebugIngest reset database dialog', () => {
   it('hard resets computed data and schedules re-ingest after confirmation', async () => {
     const user = userEvent.setup()
     hardResetMutation.mockResolvedValueOnce({ cleared: 12 })
-    backfillIngestDataAction.mockResolvedValueOnce({ scheduled: 12 })
+    reIngestAllResumesAction.mockResolvedValueOnce({ scheduled: 12 })
 
     render(<DebugIngest />)
 
@@ -203,12 +204,12 @@ describe('DebugIngest reset database dialog', () => {
       expect(hardResetMutation).toHaveBeenCalledWith({})
     })
     await waitFor(() => {
-      expect(backfillIngestDataAction).toHaveBeenCalledWith({ limit: 500 })
+      expect(reIngestAllResumesAction).toHaveBeenCalledWith({})
     })
     await waitFor(() => {
       expect(
         screen.queryByText(
-          'Clear all computed ingest and AI analysis data, then schedule full re-ingest for up to 500 resumes? This cannot be undone.'
+          'Clear all computed ingest and AI analysis data, then schedule a full background re-ingest for all resumes. This cannot be undone.'
         )
       ).not.toBeInTheDocument()
     })

--- a/apps/web/src/pages/DebugIngest.tsx
+++ b/apps/web/src/pages/DebugIngest.tsx
@@ -124,6 +124,7 @@ export default function DebugIngest() {
   } = usePaginatedQuery(api.resumes.listIngestDiagnostics, {}, { initialNumItems: INGEST_DIAGNOSTICS_PAGE_SIZE })
   const backfillIngestData = useAction(api.migrations.backfillIngestData)
   const reIngestStaleSkillsVersion = useAction(api.migrations.reIngestStaleSkillsVersion)
+  const reIngestAllResumes = useAction(api.migrations.reIngestAllResumes)
   const clearAnalysesMutation = useMutation(api.resumes.clearAnalyses)
   const hardResetIngestDataMutation = useMutation(api.resumes.hardResetIngestData)
   const resetDatabaseMutation = useMutation(api.resume_tasks.resetDatabase)
@@ -259,13 +260,13 @@ export default function DebugIngest() {
         totalCleared += result.cleared
         cursor = result.hasMore ? (result.cursor ?? undefined) : undefined
       } while (cursor)
-      const backfillResult = await backfillIngestData({ limit: 500 })
+      const reingestResult = await reIngestAllResumes({})
       setHardResetDialogOpen(false)
       toast.success(
         t('debugIngest.hardResetSuccess', {
           cleared: totalCleared,
-          scheduled: backfillResult.scheduled,
-          defaultValue: `Cleared computed data for ${totalCleared} resumes and scheduled ${backfillResult.scheduled} resumes for re-ingest.`,
+          scheduled: reingestResult.scheduled,
+          defaultValue: `Cleared computed data for ${totalCleared} resumes and scheduled ${reingestResult.scheduled} resumes for full re-ingest.`,
         })
       )
       await loadSkillsVersion()
@@ -279,7 +280,7 @@ export default function DebugIngest() {
     } finally {
       setHardResetting(false)
     }
-  }, [backfillIngestData, hardResetIngestDataMutation, loadSkillsVersion, t])
+  }, [hardResetIngestDataMutation, loadSkillsVersion, reIngestAllResumes, t])
 
   const resetDatabase = useCallback(async () => {
     setResettingDatabase(true)
@@ -408,7 +409,7 @@ export default function DebugIngest() {
             <DialogTitle>{t('debugIngest.hardReset', { defaultValue: 'Hard Reset & Re-ingest' })}</DialogTitle>
             <DialogDescription>
               {t('debugIngest.hardResetConfirm', {
-                defaultValue: 'Clear all computed ingest and AI analysis data, then schedule full re-ingest for up to 500 resumes? This cannot be undone.',
+                defaultValue: 'Clear all computed ingest and AI analysis data, then schedule a full background re-ingest for all resumes. This cannot be undone.',
               })}
             </DialogDescription>
           </DialogHeader>

--- a/packages/convex/convex/__tests__/ingest-agent.test.ts
+++ b/packages/convex/convex/__tests__/ingest-agent.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { reIngestAllResumes } from "../ingest_agent";
+
+type ConvexHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+const reIngestAllResumesHandler = (reIngestAllResumes as unknown as ConvexHandler<
+  Record<string, never>,
+  { scheduled: number; batches: number }
+>)._handler
+
+describe("reIngestAllResumes", () => {
+  it("schedules every resume, including ones without existing ingest data", async () => {
+    const scheduledPayloads: Array<{ resumeIds: string[] }> = []
+    let queryCount = 0
+
+    const ctx = {
+      async runQuery() {
+        queryCount += 1
+
+        if (queryCount === 1) {
+          return {
+            continueCursor: "cursor:2",
+            isDone: false,
+            page: [
+              {
+                _id: "resume-1",
+                content: {},
+                ingestData: undefined,
+                primaryRuleScore: undefined,
+                searchText: undefined,
+              },
+              {
+                _id: "resume-2",
+                content: {},
+                ingestData: {
+                  evidenceText: "already processed",
+                  industryTags: [],
+                  synonymHits: [],
+                  ruleScores: {},
+                  experienceLevel: "unknown",
+                  computedAt: 1,
+                  skillsVersion: 1,
+                },
+                primaryRuleScore: 0,
+                searchText: "",
+              },
+            ],
+          }
+        }
+
+        return {
+          continueCursor: "cursor:done",
+          isDone: true,
+          page: [
+            {
+              _id: "resume-3",
+              content: {},
+              ingestData: undefined,
+              primaryRuleScore: undefined,
+              searchText: undefined,
+            },
+          ],
+        }
+      },
+      scheduler: {
+        async runAfter(_delay: number, _fn: unknown, payload: { resumeIds: string[] }) {
+          scheduledPayloads.push(payload)
+        },
+      },
+    }
+
+    const result = await reIngestAllResumesHandler(ctx as never, {})
+
+    expect(result).toEqual({
+      scheduled: 3,
+      batches: 2,
+    })
+    expect(scheduledPayloads).toEqual([
+      { resumeIds: ["resume-1", "resume-2"] },
+      { resumeIds: ["resume-3"] },
+    ])
+  })
+})

--- a/packages/convex/convex/__tests__/migrations-batching.test.ts
+++ b/packages/convex/convex/__tests__/migrations-batching.test.ts
@@ -62,7 +62,7 @@ describe("backfillIngestData", () => {
       },
     }
 
-    const result = await backfillIngestDataHandler(ctx as never, { limit: 100 })
+    const result = await backfillIngestDataHandler(ctx as never, { limit: 1 })
 
     expect(result).toEqual({
       scheduled: 1,
@@ -73,5 +73,78 @@ describe("backfillIngestData", () => {
       message: "Scheduled ingest backfill for 1 resumes in 1 batch(es)",
     })
     expect(scheduledPayloads).toEqual([{ resumeIds: ["resume-1"] }])
+  })
+
+  it("continues scanning later pages until it finds enough unprocessed resumes", async () => {
+    const scheduledPayloads: Array<{ resumeIds: string[] }> = []
+    let queryCount = 0
+
+    const ctx = {
+      async runQuery() {
+        queryCount += 1
+
+        if (queryCount === 1) {
+          return {
+            continueCursor: "next:cursor",
+            isDone: false,
+            page: [
+              {
+                _id: "resume-1",
+                content: {},
+                ingestData: {
+                  evidenceText: "already processed",
+                  industryTags: [],
+                  synonymHits: [],
+                  ruleScores: {},
+                  experienceLevel: "unknown",
+                  computedAt: 1,
+                  skillsVersion: 1,
+                },
+                primaryRuleScore: 0,
+                searchText: "",
+              },
+            ],
+          }
+        }
+
+        return {
+          continueCursor: "done:cursor",
+          isDone: true,
+          page: [
+            {
+              _id: "resume-2",
+              content: {},
+              ingestData: undefined,
+              primaryRuleScore: undefined,
+              searchText: undefined,
+            },
+            {
+              _id: "resume-3",
+              content: {},
+              ingestData: undefined,
+              primaryRuleScore: undefined,
+              searchText: undefined,
+            },
+          ],
+        }
+      },
+      scheduler: {
+        async runAfter(_delay: number, _fn: unknown, payload: { resumeIds: string[] }) {
+          scheduledPayloads.push(payload)
+        },
+      },
+    }
+
+    const result = await backfillIngestDataHandler(ctx as never, { limit: 2 })
+
+    expect(result).toEqual({
+      scheduled: 2,
+      batches: 1,
+      hasMore: false,
+      cursor: null,
+      scannedResumes: 3,
+      message: "Scheduled ingest backfill for 2 resumes in 1 batch(es)",
+    })
+    expect(scheduledPayloads).toEqual([{ resumeIds: ["resume-2", "resume-3"] }])
   })
 })

--- a/packages/convex/convex/ingest_agent.ts
+++ b/packages/convex/convex/ingest_agent.ts
@@ -144,9 +144,7 @@ export const reIngestAllResumes = internalAction({
         page: ResumeScanRow[];
       } = await ctx.runQuery(internal.resumes.listResumeScanBatch, { cursor });
 
-      const resumeIds = batch.page
-        .filter((resume) => resume.ingestData !== undefined)
-        .map((resume) => resume._id);
+      const resumeIds = batch.page.map((resume) => resume._id);
 
       for (let index = 0; index < resumeIds.length; index += batchSize) {
         await ctx.scheduler.runAfter(0, internal.ingest_agent.processNewResumes, {

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -380,23 +380,46 @@ export const backfillIngestData = action({
     },
     handler: async (ctx, args): Promise<BackfillIngestDataResult> => {
         const limit = Math.max(1, Math.min(args.limit ?? 100, 500));
-        const scanBatch = await ctx.runQuery(internal.resumes.listResumeScanBatch, {
-            cursor: args.cursor,
-            limit: Math.min(resolveResumeScanBatchSize(args.batchSize), limit),
-        });
-        const resumeIds: Id<"resumes">[] = scanBatch.page
-            .filter((resume) => resume.ingestData === undefined)
-            .slice(0, limit)
-            .map((resume) => resume._id);
+        const scanLimit = Math.min(resolveResumeScanBatchSize(args.batchSize), limit);
+        let cursor = args.cursor;
+        let scannedResumes = 0;
+        let hasMore = false;
+        let nextCursor: string | null = args.cursor ?? null;
+        const resumeIds: Id<"resumes">[] = [];
+
+        while (resumeIds.length < limit) {
+            const scanBatch = await ctx.runQuery(internal.resumes.listResumeScanBatch, {
+                cursor,
+                limit: scanLimit,
+            });
+            const remaining = limit - resumeIds.length;
+
+            scannedResumes += scanBatch.page.length;
+            resumeIds.push(
+                ...scanBatch.page
+                    .filter((resume) => resume.ingestData === undefined)
+                    .slice(0, remaining)
+                    .map((resume) => resume._id)
+            );
+
+            nextCursor = scanBatch.isDone ? null : scanBatch.continueCursor;
+            hasMore = !scanBatch.isDone;
+
+            if (scanBatch.isDone || resumeIds.length >= limit) {
+                break;
+            }
+
+            cursor = scanBatch.continueCursor;
+        }
 
         if (resumeIds.length === 0) {
             return {
                 scheduled: 0,
                 batches: 0,
-                hasMore: !scanBatch.isDone,
-                cursor: scanBatch.isDone ? null : scanBatch.continueCursor,
-                scannedResumes: scanBatch.page.length,
-                message: scanBatch.isDone ? "No unprocessed resumes remaining" : "No unprocessed resumes found in this batch",
+                hasMore,
+                cursor: nextCursor,
+                scannedResumes,
+                message: hasMore ? "No unprocessed resumes found in this scan window" : "No unprocessed resumes remaining",
             };
         }
 
@@ -414,9 +437,9 @@ export const backfillIngestData = action({
         return {
             scheduled: resumeIds.length,
             batches,
-            hasMore: !scanBatch.isDone,
-            cursor: scanBatch.isDone ? null : scanBatch.continueCursor,
-            scannedResumes: scanBatch.page.length,
+            hasMore,
+            cursor: nextCursor,
+            scannedResumes,
             message: `Scheduled ingest backfill for ${resumeIds.length} resumes in ${batches} batch(es)`,
         };
     },


### PR DESCRIPTION
## Summary

- **Export aiScore alignment**: Recompute exported `aiScore` as `relatedExp + normalizedIndustryDb` instead of passing through the stale stored `match.score`. The three visible export columns (`aiScore`, `industryDb`, `relatedExp`) are now internally consistent — matching the formula already used in the UI's `overrideIndustryDbBreakdown()`.

- **Full hard-reset re-ingest**: Fix the DebugIngest hard-reset flow to call `reIngestAllResumes` (schedules all resumes regardless of prior ingest state) instead of `backfillIngestData` (only uningest-only resumes). Also removes the `ingestData !== undefined` filter from the internal batch scanner so resumes with no prior ingest data are included in a full re-ingest.

## Test plan
- [ ] `bunx vitest run apps/api/src/services/export-service.test.ts apps/api/src/routes/resumes-export.test.ts` — all 19 tests pass
- [ ] `make check` — all checks pass
- [ ] Manual: verify exported `aiScore` equals `industryDb + relatedExp` for 张先生 and 周祥富
- [ ] Manual: hard reset from DebugIngest schedules all resumes (not just uningest-only ones)