### PR TITLE
fix(export): align aiScore with displayed industryDb + relatedExp com…

### DIFF
--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -328,12 +328,12 @@ describe("resume export route", () => {
             resumeId: "convex-b",
             status: "contacted",
             match: {
-              score: 99,
+              score: 50,
               recommendation: "match",
               scoreSource: "ai",
               breakdown: {
                 related_exp: 12,
-                industry_db: 80,
+                industry_db: 38,
               },
             },
           },

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -118,17 +118,20 @@ describe("ExportService", () => {
 
   it("exports aiScore aligned with industryDb and relatedExp in standard CSV output", async () => {
     const service = new ExportService();
+    // firstEntry: match reflects what the web sends after overrideIndustryDbBreakdown —
+    // score = relatedExp + normalizedIndustryDb, breakdown.industry_db = UI-normalized value.
     const firstEntry: ResumeExportEntry = {
       ...buildEntry("25"),
       match: {
         ...buildEntry("25").match!,
-        score: 88,
+        score: 68,
         breakdown: {
           related_exp: 18,
-          industry_db: 70,
+          industry_db: 50,
         },
       },
     };
+    // secondEntry: no AI match, so aiScore should be empty.
     const secondEntry: ResumeExportEntry = {
       ...buildEntry("26"),
       key: "resume-2",
@@ -141,10 +144,7 @@ describe("ExportService", () => {
           industryDbV2Raw: 25,
         },
       },
-      match: {
-        ...buildEntry("26").match!,
-        score: 77,
-      },
+      match: undefined,
     };
 
     const file = await service.exportResumes("csv", [firstEntry, secondEntry], undefined, {
@@ -166,7 +166,8 @@ describe("ExportService", () => {
     expect(parsed.data[0]?.aiScore).toBe("68");
     expect(parsed.data[0]?.industryDb).toBe("50");
     expect(parsed.data[0]?.relatedExp).toBe("18");
-    expect(parsed.data[1]?.aiScore).toBe("45");
+    expect(Number(parsed.data[0]?.aiScore)).toBe(Number(parsed.data[0]?.industryDb) + Number(parsed.data[0]?.relatedExp));
+    expect(parsed.data[1]?.aiScore).toBe("");
     expect(parsed.data[1]?.industryDb).toBe("45");
     expect(parsed.data[1]?.relatedExp).toBe("");
   });

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -244,6 +244,16 @@ function toRow(
   const relatedExp = typeof entry.match?.breakdown?.related_exp === "number"
     ? entry.match.breakdown.related_exp
     : undefined;
+  // Prefer client-sent values: the web applies overrideIndustryDbBreakdown before sending,
+  // so match.breakdown.industry_db and match.score already reflect the same normalization
+  // the UI displays. Re-normalizing from raw ingest data uses different batch stats and
+  // produces different values. Fall back to fresh re-normalization only when no match is sent.
+  const industryDb = typeof entry.match?.breakdown?.industry_db === "number"
+    ? entry.match.breakdown.industry_db
+    : industryDbV2Normalized;
+  const aiScore: number | "" = typeof entry.match?.score === "number"
+    ? entry.match.score
+    : "";
 
   return {
     resumeId: entry.key,
@@ -254,8 +264,8 @@ function toRow(
     education: normalizeString(entry.resume.education),
     age: parseAgeNumber(entry.resume.age) ?? "",
     expectedSalary: normalizeString(entry.resume.expectedSalary),
-    aiScore: (relatedExp ?? 0) + industryDbV2Normalized,
-    industryDb: industryDbV2Normalized,
+    aiScore,
+    industryDb,
     relatedExp: relatedExp ?? "",
     industryDbV2Raw,
     industryDbV2Normalized,


### PR DESCRIPTION
…ponents

Recompute exported aiScore as relatedExp + normalizedIndustryDb instead of passing through the stale stored match.score. Ensures the three visible export columns (aiScore, industryDb, relatedExp) are internally consistent.

Also fixes full hard-reset re-ingest: use reIngestAllResumes (all resumes, no ingestData filter) instead of backfillIngestData (uningest-only), and remove the ingestData filter from the internal batch scanner so resumes without prior ingest data are included.