### PR TITLE
fix: cap ai resume scores at 100

### DIFF
--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -276,4 +276,17 @@ describe('resume-scoring', () => {
       },
     }))
   })
+
+  it('caps recomputed score at 100 when components exceed 100', () => {
+    expect(overrideIndustryDbBreakdown({
+      score: 88,
+      summary: '',
+      highlights: [],
+      recommendation: 'match',
+      breakdown: {
+        related_exp: 90,
+        industry_db: 15,
+      },
+    }, 50, (raw) => (typeof raw === 'number' ? Math.min(50, raw) : 0)).score).toBe(100)
+  })
 })

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -376,7 +376,7 @@ export function overrideIndustryDbBreakdown(
 
   return {
     ...analysis,
-    score: relatedExp + normalizedIndustryDb,
+    score: Math.min(100, relatedExp + normalizedIndustryDb),
     breakdown: nextBreakdown,
   }
 }


### PR DESCRIPTION
## Summary
- cap recomputed resume scores at 100 in overrideIndustryDbBreakdown
- add a regression test covering oversized related_exp values from the AI response

## Testing
- npm --workspace @trends/web run test -- src/lib/resume-scoring.test.ts
- make check