### PR TITLE
fix: clamp related exp to scoring cap

### DIFF
--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -276,4 +276,17 @@ describe('resume-scoring', () => {
       },
     }))
   })
+
+  it('caps recomputed score at 100 when components exceed 100', () => {
+    expect(overrideIndustryDbBreakdown({
+      score: 88,
+      summary: '',
+      highlights: [],
+      recommendation: 'match',
+      breakdown: {
+        related_exp: 90,
+        industry_db: 15,
+      },
+    }, 50, (raw) => (typeof raw === 'number' ? Math.min(50, raw) : 0)).score).toBe(100)
+  })
 })

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -277,7 +277,7 @@ describe('resume-scoring', () => {
     }))
   })
 
-  it('caps recomputed score at 100 when components exceed 100', () => {
+  it('clamps related_exp to 50 and caps recomputed score at 100', () => {
     expect(overrideIndustryDbBreakdown({
       score: 88,
       summary: '',
@@ -287,6 +287,12 @@ describe('resume-scoring', () => {
         related_exp: 90,
         industry_db: 15,
       },
-    }, 50, (raw) => (typeof raw === 'number' ? Math.min(50, raw) : 0)).score).toBe(100)
+    }, 50, (raw) => (typeof raw === 'number' ? Math.min(50, raw) : 0))).toEqual(expect.objectContaining({
+      score: 100,
+      breakdown: {
+        related_exp: 50,
+        industry_db: 50,
+      },
+    }))
   })
 })

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -376,7 +376,7 @@ export function overrideIndustryDbBreakdown(
 
   return {
     ...analysis,
-    score: relatedExp + normalizedIndustryDb,
+    score: Math.min(100, relatedExp + normalizedIndustryDb),
     breakdown: nextBreakdown,
   }
 }

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -368,15 +368,17 @@ export function overrideIndustryDbBreakdown(
   normalizer: (raw: number | undefined) => number
 ): ConvexResumeAnalysis {
   const normalizedIndustryDb = normalizer(raw)
+  const normalizedRelatedExp =
+    typeof analysis.breakdown?.related_exp === 'number' ? clamp(analysis.breakdown.related_exp, 0, 50) : 0
   const nextBreakdown: MatchBreakdown = {
     ...(analysis.breakdown ?? {}),
+    related_exp: normalizedRelatedExp,
     industry_db: normalizedIndustryDb,
   }
-  const relatedExp = typeof nextBreakdown.related_exp === 'number' ? nextBreakdown.related_exp : 0
 
   return {
     ...analysis,
-    score: Math.min(100, relatedExp + normalizedIndustryDb),
+    score: Math.min(100, normalizedRelatedExp + normalizedIndustryDb),
     breakdown: nextBreakdown,
   }
 }


### PR DESCRIPTION
## Summary
- clamp AI related_exp into the documented 0-50 range before returning the breakdown
- recompute the total score from the normalized related_exp and normalized industry_db values
- add a regression test covering oversized related_exp input from the AI response

## Testing
- npm --workspace @trends/web run test -- src/lib/resume-scoring.test.ts
- make check