### PR TITLE
fix: weight AI related_exp at runtime (0-100 scale × 0.5)

### DIFF
--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -296,57 +296,21 @@ describe('resume-scoring', () => {
     }))
   })
 
-  it('rounds weighted related_exp to the nearest integer', () => {
+  it.each([
+    { label: 'rounds to nearest integer', input: 35 as number | undefined, expected: 18 },
+    { label: 'keeps at 0 when AI returns 0', input: 0 as number | undefined, expected: 0 },
+    { label: 'defaults to 0 when missing', input: undefined, expected: 0 },
+  ])('$label for related_exp weight', ({ input, expected }) => {
     expect(overrideIndustryDbBreakdown({
       score: 40,
       summary: '',
       highlights: [],
       recommendation: 'match',
-      breakdown: {
-        related_exp: 35,
-        industry_db: 10,
-      },
+      breakdown: input !== undefined ? { related_exp: input, industry_db: 10 } : { industry_db: 10 },
     }, 0, () => 0)).toEqual(expect.objectContaining({
-      score: 18,
+      score: expected,
       breakdown: {
-        related_exp: 18,
-        industry_db: 0,
-      },
-    }))
-  })
-
-  it('keeps weighted related_exp at 0 when the AI returns 0', () => {
-    expect(overrideIndustryDbBreakdown({
-      score: 40,
-      summary: '',
-      highlights: [],
-      recommendation: 'match',
-      breakdown: {
-        related_exp: 0,
-        industry_db: 10,
-      },
-    }, 0, () => 0)).toEqual(expect.objectContaining({
-      score: 0,
-      breakdown: {
-        related_exp: 0,
-        industry_db: 0,
-      },
-    }))
-  })
-
-  it('defaults weighted related_exp to 0 when it is missing', () => {
-    expect(overrideIndustryDbBreakdown({
-      score: 40,
-      summary: '',
-      highlights: [],
-      recommendation: 'match',
-      breakdown: {
-        industry_db: 10,
-      },
-    }, 0, () => 0)).toEqual(expect.objectContaining({
-      score: 0,
-      breakdown: {
-        related_exp: 0,
+        related_exp: expected,
         industry_db: 0,
       },
     }))

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -229,6 +229,7 @@ function countHistogramSamples(histogram50: number[]): number {
 }
 
 const INDUSTRY_DB_V2_SCORE_CAP = 50
+const RELATED_EXP_AI_WEIGHT = INDUSTRY_DB_V2_SCORE_CAP / 100
 const INDUSTRY_DB_V2_MIN_NONZERO_SAMPLE_SIZE = 5
 const INDUSTRY_DB_V2_BRAND_SECTION_SCORE = 30
 const INDUSTRY_DB_V2_COMPANY_SECTION_SCORE = 20
@@ -370,7 +371,7 @@ export function overrideIndustryDbBreakdown(
   const normalizedIndustryDb = normalizer(raw)
   const normalizedRelatedExp =
     typeof analysis.breakdown?.related_exp === 'number'
-      ? Math.round(clamp(analysis.breakdown.related_exp, 0, 100) * 0.5)
+      ? Math.round(clamp(analysis.breakdown.related_exp, 0, 100) * RELATED_EXP_AI_WEIGHT)
       : 0
   const nextBreakdown: MatchBreakdown = {
     ...(analysis.breakdown ?? {}),


### PR DESCRIPTION
## Summary

- Changes AI prompt contract so `related_exp` and `industry_db` are declared on a **0-100 scale** in AI output; runtime applies a hardcoded 0.5 weight to convert `related_exp` into its 0-50 contribution slot.
- Replaces the previous hard clamp to 50 with `Math.round(clamp(value, 0, 100) * RELATED_EXP_AI_WEIGHT)`, preserving full ranking signal for AI scores between 50 and 100 (e.g. AI=90 → displayed 45, not 50).
- `industry_db` AI output is still fully replaced by runtime rule-engine values; the prompt change is contract-consistency only.

## Files changed

- `apps/web/src/lib/resume-scoring.ts` — weighted multiply with named constant `RELATED_EXP_AI_WEIGHT = INDUSTRY_DB_V2_SCORE_CAP / 100`
- `apps/web/src/lib/resume-scoring.test.ts` — updated overflow test (90→45, score 100→95); edge cases via `it.each`
- `apps/web/src/hooks/useResumeListState.test.tsx` — updated expected scores to reflect new weighting
- `config/resume/ai-prompts.md` + `config/resume/ai-prompts.en.md` — both components declared 0-100; runtime weight/override notes added
- `packages/shared/src/generated/resume-ai-prompts.ts` — auto-regenerated

## Test plan

- [x] `npm --workspace @trends/web run test -- src/lib/resume-scoring.test.ts` — 19 tests pass
- [x] `npm --workspace @trends/web run test -- src/hooks/useResumeListState.test.tsx` — 24 tests pass
- [x] `make check` — all checks pass