### PR TITLE
fix: use direct industry db scoring

### DIFF
--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -118,8 +118,7 @@ describe("ExportService", () => {
 
   it("exports aiScore aligned with industryDb and relatedExp in standard CSV output", async () => {
     const service = new ExportService();
-    // firstEntry: match reflects what the web sends after overrideIndustryDbBreakdown —
-    // score = relatedExp + normalizedIndustryDb, breakdown.industry_db = UI-normalized value.
+    // firstEntry: match reflects what the web sends after overrideIndustryDbBreakdown.
     const firstEntry: ResumeExportEntry = {
       ...buildEntry("25"),
       match: {
@@ -131,7 +130,7 @@ describe("ExportService", () => {
         },
       },
     };
-    // secondEntry: no AI match, so aiScore should be empty.
+    // secondEntry: no AI match, so aiScore should be empty and industryDb falls back to raw direct scoring.
     const secondEntry: ResumeExportEntry = {
       ...buildEntry("26"),
       key: "resume-2",
@@ -168,8 +167,54 @@ describe("ExportService", () => {
     expect(parsed.data[0]?.relatedExp).toBe("18");
     expect(Number(parsed.data[0]?.aiScore)).toBe(Number(parsed.data[0]?.industryDb) + Number(parsed.data[0]?.relatedExp));
     expect(parsed.data[1]?.aiScore).toBe("");
-    expect(parsed.data[1]?.industryDb).toBe("45");
+    expect(parsed.data[1]?.industryDb).toBe("25");
     expect(parsed.data[1]?.relatedExp).toBe("");
+  });
+
+  it("uses the direct fallback for hit-driven industryDb when no match payload is sent", async () => {
+    const service = new ExportService();
+    const file = await service.exportResumes("csv", [
+      {
+        ...buildEntry("27"),
+        key: "resume-hit",
+        resume: {
+          ...buildEntry("27").resume,
+          ingestData: {
+            industryTags: ["cnc"],
+            companyHits: ["fanuc"],
+            brandHits: [],
+            industryDbV2Raw: 15,
+          },
+        },
+        match: undefined,
+      },
+      {
+        ...buildEntry("28"),
+        key: "resume-employer-only",
+        resume: {
+          ...buildEntry("28").resume,
+          ingestData: {
+            industryTags: ["cnc"],
+            companyHits: [],
+            brandHits: [
+              {
+                brand: "fanuc",
+                role: "employer",
+                source: "workHistory",
+                context: "employer",
+              },
+            ],
+            industryDbV2Raw: 15,
+          },
+        },
+        match: undefined,
+      },
+    ]);
+    const csv = file.content.toString("utf8");
+    const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
+
+    expect(parsed.data[0]?.industryDb).toBe("50");
+    expect(parsed.data[1]?.industryDb).toBe("15");
   });
 
   it("exports industryDbV2Raw and industryDbV2Normalized columns in debug CSV output", async () => {

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -12,6 +12,7 @@ import {
   type CompanyPattern,
 } from "./skills-knowledge.js";
 import {
+  computeDirectIndustryDbScore,
   computeEffectiveIndustryDbV2Raw,
   createBatchNormalizer,
   type IndustryDbV2BatchStats,
@@ -245,12 +246,12 @@ function toRow(
     ? entry.match.breakdown.related_exp
     : undefined;
   // Prefer client-sent values: the web applies overrideIndustryDbBreakdown before sending,
-  // so match.breakdown.industry_db and match.score already reflect the same normalization
-  // the UI displays. Re-normalizing from raw ingest data uses different batch stats and
-  // produces different values. Fall back to fresh re-normalization only when no match is sent.
+  // so match.breakdown.industry_db and match.score already reflect the UI scoring.
+  // Fall back to the same direct rule when no match is sent. Keep debug-only batch
+  // normalization columns intact for diagnostics.
   const industryDb = typeof entry.match?.breakdown?.industry_db === "number"
     ? entry.match.breakdown.industry_db
-    : industryDbV2Normalized;
+    : computeDirectIndustryDbScore(ingestData);
   const aiScore: number | "" = typeof entry.match?.score === "number"
     ? entry.match.score
     : "";

--- a/apps/api/src/services/industry-db-batch-stats.test.ts
+++ b/apps/api/src/services/industry-db-batch-stats.test.ts
@@ -4,6 +4,7 @@ import {
   bumpIndustryDbV2Raw,
   clampIndustryDbV2RawScore,
   computeBatchStats,
+  computeDirectIndustryDbScore,
   computeEffectiveIndustryDbV2Raw,
   normalizeIndustryDbScore,
 } from "./industry-db-batch-stats.js";
@@ -127,6 +128,28 @@ describe("industry-db-batch-stats", () => {
         { brand: "fanuc", role: "employer", source: "workHistory", context: "employer" },
         { brand: "fanuc", role: "equipment", source: "selfIntro", context: "equipment" },
       ],
+      companyHits: ["fanuc"],
+      industryDbV2Raw: 5,
+    })).toBe(50);
+  });
+
+  it("computes direct industry_db score without cohort normalization", () => {
+    expect(computeDirectIndustryDbScore({ brandHits: [{}], companyHits: [], industryDbV2Raw: 5 })).toBe(50);
+    expect(computeDirectIndustryDbScore({ brandHits: [], companyHits: ["star"], industryDbV2Raw: 5 })).toBe(50);
+    expect(computeDirectIndustryDbScore({ brandHits: [{}], companyHits: ["star"], industryDbV2Raw: 5 })).toBe(50);
+    expect(computeDirectIndustryDbScore({ brandHits: [], companyHits: [], industryDbV2Raw: 25 })).toBe(25);
+    expect(computeDirectIndustryDbScore({ brandHits: [], companyHits: [], industryDbV2Raw: 60 })).toBe(50);
+    expect(computeDirectIndustryDbScore(undefined)).toBe(0);
+  });
+
+  it("ignores employer-context brand hits when computing the direct score", () => {
+    expect(computeDirectIndustryDbScore({
+      brandHits: [{ brand: "fanuc", role: "employer", source: "workHistory", context: "employer" }],
+      companyHits: [],
+      industryDbV2Raw: 5,
+    })).toBe(5);
+    expect(computeDirectIndustryDbScore({
+      brandHits: [{ brand: "fanuc", role: "employer", source: "workHistory", context: "employer" }],
       companyHits: ["fanuc"],
       industryDbV2Raw: 5,
     })).toBe(50);

--- a/apps/api/src/services/industry-db-batch-stats.ts
+++ b/apps/api/src/services/industry-db-batch-stats.ts
@@ -79,19 +79,33 @@ export function bumpIndustryDbV2Raw(
   return Math.max(clampIndustryDbV2RawScore(raw), sectionBump);
 }
 
+function hasNonEmployerBrandHit(brandHits: unknown[] | undefined): boolean {
+  return (brandHits ?? []).some(
+    (hit) => typeof hit === "object" && hit !== null && (hit as { context?: string }).context !== "employer"
+  );
+}
+
 export function computeEffectiveIndustryDbV2Raw(ingestData: {
   brandHits?: unknown[];
   companyHits?: unknown[];
   industryDbV2Raw?: number;
 } | null | undefined): number {
-  const hasNonEmployerBrandHit = (ingestData?.brandHits ?? []).some(
-    (hit) => typeof hit === "object" && hit !== null && (hit as { context?: string }).context !== "employer"
-  );
   return bumpIndustryDbV2Raw(
     ingestData?.industryDbV2Raw,
-    hasNonEmployerBrandHit,
+    hasNonEmployerBrandHit(ingestData?.brandHits),
     (ingestData?.companyHits?.length ?? 0) > 0,
   );
+}
+
+export function computeDirectIndustryDbScore(ingestData: {
+  brandHits?: unknown[];
+  companyHits?: unknown[];
+  industryDbV2Raw?: number;
+} | null | undefined): number {
+  if (hasNonEmployerBrandHit(ingestData?.brandHits) || (ingestData?.companyHits?.length ?? 0) > 0) {
+    return INDUSTRY_DB_V2_SCORE_CAP;
+  }
+  return clampIndustryDbV2RawScore(ingestData?.industryDbV2Raw);
 }
 
 function nonZeroP80FromHistogram(histogram50: number[]): { p80: number; count: number } {

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -755,7 +755,7 @@ describe('useResumeListState role filter regression', () => {
     )
   })
 
-  it('overrides AI industry_db score from applied search history cohort stats', async () => {
+  it('overrides AI industry_db score from raw ingest data when no hits are present', async () => {
     mockState.convexResumes = [
       buildResume({
         id: 'resume-ai-1',
@@ -803,9 +803,9 @@ describe('useResumeListState role filter regression', () => {
       await result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
     })
 
-    expect(result.current.displayedResumes[0]?.match?.breakdown?.industry_db).toBe(40)
+    expect(result.current.displayedResumes[0]?.match?.breakdown?.industry_db).toBe(20)
     expect(result.current.displayedResumes[0]?.match?.breakdown?.related_exp).toBe(15)
-    expect(result.current.displayedResumes[0]?.match?.score).toBe(55)
+    expect(result.current.displayedResumes[0]?.match?.score).toBe(35)
   })
 
   it('bumps industry_db to brand section max when resume has brand hits', async () => {
@@ -857,10 +857,64 @@ describe('useResumeListState role filter regression', () => {
       await result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
     })
 
-    // raw=5 bumped to 30 (brand section max), normalizes to 50 at top of cohort
+    // has brand hits -> full slot (50)
     expect(result.current.displayedResumes[0]?.match?.breakdown?.industry_db).toBe(50)
     expect(result.current.displayedResumes[0]?.match?.breakdown?.related_exp).toBe(15)
     expect(result.current.displayedResumes[0]?.match?.score).toBe(65)
+  })
+
+  it('ignores employer-context brand hits when computing direct industry_db score', async () => {
+    mockState.convexResumes = [
+      buildResume({
+        id: 'resume-employer-brand-1',
+        name: 'Employer Brand Resume',
+        industryDbV2Raw: 5,
+        brandHits: [{ brand: 'fanuc', role: 'employer', source: 'workHistory', context: 'employer' }],
+        analysis: {
+          score: 45,
+          summary: 'Good match',
+          highlights: ['summary'],
+          recommendation: 'match',
+          breakdown: {
+            related_exp: 30,
+            industry_db: 5,
+          },
+          jobDescriptionId: 'lathe-sales',
+        },
+        roleSignals: [],
+      }),
+    ]
+    mockState.searchHistory = [
+      {
+        id: 'history-employer-brand',
+        sessionKey: 'session-1',
+        title: 'Employer brand test',
+        location: '苏州',
+        keywords: ['CNC'],
+        jobDescriptionId: 'lathe-sales',
+        filters: {},
+        selectedTags: [],
+        selectedCompanies: [],
+        selectedExperienceLevel: undefined,
+        industryDbV2Stats: {
+          size: 50,
+          p80: 20,
+          histogram50: Array.from({ length: 51 }, (_, index) => (index === 20 ? 50 : 0)),
+        },
+        createdAt: 1,
+        lastOpenedAt: 2,
+      },
+    ]
+
+    const { result } = renderHook(() => useResumeListState())
+
+    await act(async () => {
+      await result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
+    })
+
+    expect(result.current.displayedResumes[0]?.match?.breakdown?.industry_db).toBe(5)
+    expect(result.current.displayedResumes[0]?.match?.breakdown?.related_exp).toBe(15)
+    expect(result.current.displayedResumes[0]?.match?.score).toBe(20)
   })
 
   it('allows manual profile apply to bypass the URL hydration guard', () => {

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -33,8 +33,7 @@ import {
 import {
   buildLearningObservation,
   buildResumeKey,
-  bumpIndustryDbV2Raw,
-  createBatchNormalizer,
+  computeDirectIndustryDb,
   getAnalysisForJob,
   hasIngestData,
   isAutoFilteredAnalysis,
@@ -999,22 +998,22 @@ export function useResumeListState(loadSearchHistory = false) {
 
   const enrichedResumes = useMemo<EnrichedResume[]>(() => {
     if (mode === 'ai') {
-      const normalize = createBatchNormalizer(appliedSearchHistory?.industryDbV2Stats)
       return filteredConvexResumes.map((resume: ScoredConvexResume, index: number) => {
         const resumeKey = buildResumeKey(resume, index)
         const identityKey = getResumeIdentityKey(resume, resumeKey)
         const analysis = getAnalysisForJob(resume, jobDescriptionId, sessionKeywords)
         const isAnalysisValid = !jobDescriptionId || analysis?.jobDescriptionId === jobDescriptionId
         const ingestData = resume.ingestData
+        const hasBrandHits = (ingestData?.brandHits ?? []).some((hit) => hit.context !== 'employer')
+        const hasCompanyHits = (ingestData?.companyHits?.length ?? 0) > 0
         const normalizedAnalysis = analysis && isAnalysisValid
           ? overrideIndustryDbBreakdown(
               analysis,
-              bumpIndustryDbV2Raw(
+              computeDirectIndustryDb(
                 ingestData?.industryDbV2Raw,
-                (ingestData?.brandHits?.filter((h) => h.context !== "employer").length ?? 0) > 0,
-                (ingestData?.companyHits?.length ?? 0) > 0,
+                hasBrandHits,
+                hasCompanyHits,
               ),
-              normalize,
             )
           : undefined
 
@@ -1061,7 +1060,7 @@ export function useResumeListState(loadSearchHistory = false) {
         action: actions[resumeKey],
       }
     })
-  }, [actions, appliedSearchHistory?.industryDbV2Stats, blocksByIdentity, filteredConvexResumes, jobDescriptionId, mode, resumes, sessionKeywords, statusByIdentity])
+  }, [actions, blocksByIdentity, filteredConvexResumes, jobDescriptionId, mode, resumes, sessionKeywords, statusByIdentity])
 
   const displayedResumes = useMemo(() => {
     const sortBy = filters.sortBy ?? 'score'

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -3,8 +3,8 @@ import {
   buildLearningObservation,
   buildResumeKey,
   buildRuleScoringText,
+  computeDirectIndustryDb,
   computeNormalizedIndustryDbScore,
-  createBatchNormalizer,
   getPrecomputedRuleScore,
   hasIngestData,
   isAutoFilteredAnalysis,
@@ -254,6 +254,17 @@ describe('resume-scoring', () => {
     })).toBe(25)
   })
 
+  it.each([
+    { label: 'returns full slot for brand hits', raw: 10, hasBrandHits: true, hasCompanyHits: false, expected: 50 },
+    { label: 'returns full slot for company hits', raw: 10, hasBrandHits: false, hasCompanyHits: true, expected: 50 },
+    { label: 'returns full slot for brand and company hits', raw: 10, hasBrandHits: true, hasCompanyHits: true, expected: 50 },
+    { label: 'keeps raw score with no hits', raw: 20, hasBrandHits: false, hasCompanyHits: false, expected: 20 },
+    { label: 'clamps raw score above cap with no hits', raw: 60, hasBrandHits: false, hasCompanyHits: false, expected: 50 },
+    { label: 'defaults missing raw to 0 with no hits', raw: undefined, hasBrandHits: false, hasCompanyHits: false, expected: 0 },
+  ])('$label', ({ raw, hasBrandHits, hasCompanyHits, expected }) => {
+    expect(computeDirectIndustryDb(raw, hasBrandHits, hasCompanyHits)).toBe(expected)
+  })
+
   it('overrides AI breakdown and recomputes total score', () => {
     expect(overrideIndustryDbBreakdown({
       score: 45,
@@ -264,11 +275,7 @@ describe('resume-scoring', () => {
         related_exp: 30,
         industry_db: 15,
       },
-    }, 20, createBatchNormalizer({
-      size: 50,
-      p80: 20,
-      histogram50: Array.from({ length: 51 }, (_, index) => (index === 20 ? 50 : 0)),
-    }))).toEqual(expect.objectContaining({
+    }, 40)).toEqual(expect.objectContaining({
       score: 55,
       breakdown: {
         related_exp: 15,
@@ -287,7 +294,7 @@ describe('resume-scoring', () => {
         related_exp: 90,
         industry_db: 15,
       },
-    }, 50, (raw) => (typeof raw === 'number' ? Math.min(50, raw) : 0))).toEqual(expect.objectContaining({
+    }, 50)).toEqual(expect.objectContaining({
       score: 95,
       breakdown: {
         related_exp: 45,
@@ -307,7 +314,7 @@ describe('resume-scoring', () => {
       highlights: [],
       recommendation: 'match',
       breakdown: input !== undefined ? { related_exp: input, industry_db: 10 } : { industry_db: 10 },
-    }, 0, () => 0)).toEqual(expect.objectContaining({
+    }, 0)).toEqual(expect.objectContaining({
       score: expected,
       breakdown: {
         related_exp: expected,

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -246,6 +246,16 @@ export function bumpIndustryDbV2Raw(
   return Math.max(safeRaw, sectionBump)
 }
 
+export function computeDirectIndustryDb(
+  raw: number | undefined,
+  hasBrandHits: boolean,
+  hasCompanyHits: boolean,
+): number {
+  if (hasBrandHits || hasCompanyHits) return INDUSTRY_DB_V2_SCORE_CAP
+  const safeRaw = typeof raw === 'number' && Number.isFinite(raw) ? raw : 0
+  return clamp(safeRaw, 0, INDUSTRY_DB_V2_SCORE_CAP)
+}
+
 function nonZeroP80FromHistogram(histogram50: number[]): { p80: number; count: number } {
   const nonZeroValues: number[] = []
   histogram50.forEach((count, score) => {
@@ -365,10 +375,8 @@ export function computeNormalizedIndustryDbScore(raw: number | undefined, stats:
 
 export function overrideIndustryDbBreakdown(
   analysis: ConvexResumeAnalysis,
-  raw: number | undefined,
-  normalizer: (raw: number | undefined) => number
+  industryDb: number,
 ): ConvexResumeAnalysis {
-  const normalizedIndustryDb = normalizer(raw)
   const normalizedRelatedExp =
     typeof analysis.breakdown?.related_exp === 'number'
       ? Math.round(clamp(analysis.breakdown.related_exp, 0, 100) * RELATED_EXP_AI_WEIGHT)
@@ -376,12 +384,12 @@ export function overrideIndustryDbBreakdown(
   const nextBreakdown: MatchBreakdown = {
     ...(analysis.breakdown ?? {}),
     related_exp: normalizedRelatedExp,
-    industry_db: normalizedIndustryDb,
+    industry_db: industryDb,
   }
 
   return {
     ...analysis,
-    score: Math.min(100, normalizedRelatedExp + normalizedIndustryDb),
+    score: Math.min(100, normalizedRelatedExp + industryDb),
     breakdown: nextBreakdown,
   }
 }


### PR DESCRIPTION
## Summary
- replace web-side industry_db cohort normalization with direct scoring
- align standard export fallback with the same direct industry_db rule
- keep debug normalization diagnostics intact and expand regression coverage

## Testing
- npm --workspace @trends/web run test -- src/lib/resume-scoring.test.ts src/hooks/useResumeListState.test.tsx
- npm test -- apps/api/src/services/industry-db-batch-stats.test.ts apps/api/src/services/export-service.test.ts apps/api/src/routes/resumes-export.test.ts
- make check