### PR TITLE
chore: add codex autopilot hooks

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,29 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd); exec \"$ROOT\"/.codex/hooks/session-start.sh'",
+            "timeout": 5,
+            "statusMessage": "Seeding Codex session context"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd); exec \"$ROOT\"/.codex/hooks/autopilot-stop.sh'",
+            "timeout": 75,
+            "statusMessage": "Checking autopilot continuation"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/autopilot-stop.sh
+++ b/.codex/hooks/autopilot-stop.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+export CMUX_HOOK_PROVIDER="codex"
+export CMUX_PROJECT_DIR="${CMUX_PROJECT_DIR:-$PROJECT_DIR}"
+export CMUX_AUTOPILOT_ENABLED="${CMUX_AUTOPILOT_ENABLED:-0}"
+export CMUX_AUTOPILOT_STATE_PREFIX="${CMUX_AUTOPILOT_STATE_PREFIX:-codex-autopilot}"
+export CMUX_AUTOPILOT_CURRENT_SESSION_FILE="${CMUX_AUTOPILOT_CURRENT_SESSION_FILE:-/tmp/codex-current-session-id}"
+export CMUX_AUTOPILOT_ENABLE_REVIEW_WINDOW="${CMUX_AUTOPILOT_ENABLE_REVIEW_WINDOW:-0}"
+export CMUX_AUTOPILOT_INLINE_WRAPUP="${CMUX_AUTOPILOT_INLINE_WRAPUP:-1}"
+# Codex uses hidden monitoring sleeps, so default to monitoring from the
+# first hook instead of waiting for a later visible polling phase.
+export CMUX_AUTOPILOT_MONITORING_THRESHOLD="${CMUX_AUTOPILOT_MONITORING_THRESHOLD:-0}"
+export CMUX_SESSION_ACTIVITY_SCRIPT="${CMUX_SESSION_ACTIVITY_SCRIPT:-$PROJECT_DIR/.claude/hooks/session-activity-capture.sh}"
+
+# Codex launches hook commands through the user's login shell. If shell startup
+# exports stale AUTOPILOT_* defaults, ordinary interactive sessions can be
+# forced into autopilot unexpectedly. Gate Codex autopilot on the cmux-scoped
+# flag and only allow the generic env var path when the wrapper is explicitly
+# enabled by the autopilot runner.
+if [ "$CMUX_AUTOPILOT_ENABLED" = "1" ]; then
+  export AUTOPILOT_KEEP_RUNNING_DISABLED="${AUTOPILOT_KEEP_RUNNING_DISABLED:-0}"
+else
+  export AUTOPILOT_KEEP_RUNNING_DISABLED="1"
+fi
+
+exec "$PROJECT_DIR/scripts/hooks/cmux-autopilot-stop-core.sh"

--- a/.codex/hooks/session-start.sh
+++ b/.codex/hooks/session-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+export CMUX_HOOK_PROVIDER="codex"
+export CMUX_PROJECT_DIR="${CMUX_PROJECT_DIR:-$PROJECT_DIR}"
+export CMUX_SESSION_START_OUTPUT_MODE="text"
+export CMUX_SESSION_STATE_PREFIX="${CMUX_SESSION_STATE_PREFIX:-codex-autopilot}"
+export CMUX_SESSION_FILE="${CMUX_SESSION_FILE:-/tmp/codex-current-session-id}"
+export CMUX_SESSION_ACTIVITY_SCRIPT="${CMUX_SESSION_ACTIVITY_SCRIPT:-$PROJECT_DIR/.claude/hooks/session-activity-capture.sh}"
+export CMUX_SESSION_START_DEBUG_LOG="${CMUX_SESSION_START_DEBUG_LOG:-/tmp/codex-session-start-debug.log}"
+
+exec "$PROJECT_DIR/scripts/hooks/cmux-session-start-core.sh"

--- a/.codex/hooks/test-autopilot-stop.sh
+++ b/.codex/hooks/test-autopilot-stop.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+set -euo pipefail
+
+unset AUTOPILOT_DELAY AUTOPILOT_IDLE_THRESHOLD AUTOPILOT_MAX_TURNS AUTOPILOT_MONITORING_THRESHOLD
+unset CMUX_AUTOPILOT_DELAY CMUX_AUTOPILOT_IDLE_THRESHOLD CMUX_AUTOPILOT_MAX_TURNS CMUX_AUTOPILOT_MONITORING_THRESHOLD
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$SCRIPT_DIR/autopilot-stop.sh"
+TEST_SESSION="codex-hook-test-$$"
+STOP_FILE="/tmp/codex-test-stop-${TEST_SESSION}"
+FAKE_BIN_DIR="/tmp/codex-hook-bin-${TEST_SESSION}"
+FAKE_SLEEP_LOG="/tmp/codex-hook-sleep-${TEST_SESSION}.log"
+PASS=0
+FAIL=0
+CONDITIONAL_WAIT_TEXT="Only if you are blocked on external work and are about to poll status"
+
+cleanup() {
+  rm -f "$STOP_FILE"
+  rm -f "/tmp/codex-autopilot-blocked-${TEST_SESSION}"
+  rm -f "/tmp/codex-autopilot-completed-${TEST_SESSION}"
+  rm -f "/tmp/codex-autopilot-idle-${TEST_SESSION}"
+  rm -f "/tmp/codex-autopilot-pid-${TEST_SESSION}"
+  rm -f "/tmp/codex-autopilot-state-${TEST_SESSION}"
+  rm -f "/tmp/codex-autopilot-stop-${TEST_SESSION}"
+  rm -f "/tmp/codex-autopilot-turns-${TEST_SESSION}"
+  rm -f "/tmp/codex-autopilot-wrapup-${TEST_SESSION}"
+  rm -f "$FAKE_SLEEP_LOG"
+  rm -rf "$FAKE_BIN_DIR"
+}
+trap cleanup EXIT
+
+assert_eq() {
+  local desc="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected: $expected, got: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert() {
+  local desc="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+setup_fake_sleep() {
+  mkdir -p "$FAKE_BIN_DIR"
+  cat > "$FAKE_BIN_DIR/sleep" <<EOF
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "\$1" >> "$FAKE_SLEEP_LOG"
+exit 0
+EOF
+  chmod +x "$FAKE_BIN_DIR/sleep"
+}
+
+sleep_log_line_count() {
+  if [ -f "$FAKE_SLEEP_LOG" ]; then
+    wc -l < "$FAKE_SLEEP_LOG" | tr -d '[:space:]'
+  else
+    echo "0"
+  fi
+}
+
+sleep_log_match_count() {
+  local seconds="$1"
+  if [ -f "$FAKE_SLEEP_LOG" ]; then
+    grep -c "^${seconds}\$" "$FAKE_SLEEP_LOG" || true
+  else
+    echo "0"
+  fi
+}
+
+reason_text() {
+  jq -r '.reason' <<<"$1"
+}
+
+assert_reason_not_contains() {
+  local desc="$1"
+  local output="$2"
+  local pattern="$3"
+  if grep -Fq "$pattern" <<<"$(reason_text "$output")"; then
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+run_enabled_hook() {
+  local input_json="$1"
+  shift
+
+  echo "$input_json" | env \
+    CMUX_AUTOPILOT_ENABLED=1 \
+    AUTOPILOT_KEEP_RUNNING_DISABLED=0 \
+    AUTOPILOT_ENABLED=1 \
+    AUTOPILOT_DELAY=0 \
+    AUTOPILOT_MONITORING_THRESHOLD=999999 \
+    "$@" \
+    bash "$HOOK"
+}
+
+run_hidden_sleep_monitoring_hook() {
+  local input_json="$1"
+  shift
+
+  run_enabled_hook \
+    "$input_json" \
+    AUTOPILOT_MAX_TURNS=30 \
+    AUTOPILOT_MONITORING_THRESHOLD=1 \
+    AUTOPILOT_MONITORING_PHASE1_OFFSET=1 \
+    AUTOPILOT_MONITORING_PHASE1_WAIT=1 \
+    AUTOPILOT_MONITORING_PHASE2_WAIT=2 \
+    AUTOPILOT_IDLE_THRESHOLD=999 \
+    PATH="$FAKE_BIN_DIR:$PATH" \
+    "$@"
+}
+
+echo "=== Codex autopilot hook smoke test ==="
+
+assert "Codex Stop hook timeout allows hidden monitoring sleeps" jq -e '
+  .hooks.Stop[0].hooks[0].timeout >= 75
+' "$PROJECT_DIR/.codex/hooks.json"
+
+cleanup
+touch "$STOP_FILE"
+
+FIRST_OUTPUT=$(run_enabled_hook \
+  "{\"session_id\":\"${TEST_SESSION}\"}" \
+  AUTOPILOT_MAX_TURNS=20 \
+  AUTOPILOT_STOP_FILE="$STOP_FILE")
+
+assert "First stop request blocks for inline wrapup" jq -e '.decision == "block"' <<<"$FIRST_OUTPUT"
+assert "Wrapup marker created" test -f "/tmp/codex-autopilot-wrapup-${TEST_SESSION}"
+assert "Pid marker created on block" test -f "/tmp/codex-autopilot-pid-${TEST_SESSION}"
+
+SECOND_OUTPUT=$(run_enabled_hook \
+  "{\"session_id\":\"${TEST_SESSION}\"}" \
+  AUTOPILOT_MAX_TURNS=20 \
+  AUTOPILOT_STOP_FILE="$STOP_FILE" || true)
+
+assert "Second stop request allows stop" test -z "$SECOND_OUTPUT"
+assert "Wrapup marker removed after allow" test ! -f "/tmp/codex-autopilot-wrapup-${TEST_SESSION}"
+assert "Pid marker removed after allow" test ! -f "/tmp/codex-autopilot-pid-${TEST_SESSION}"
+
+cleanup
+echo "0" > "/tmp/codex-autopilot-turns-${TEST_SESSION}"
+
+MAX_TURN_OUTPUT=$(run_enabled_hook \
+  "{\"session_id\":\"${TEST_SESSION}\"}" \
+  AUTOPILOT_MAX_TURNS=1)
+
+assert "Max turns triggers final wrapup block" jq -e '.decision == "block"' <<<"$MAX_TURN_OUTPUT"
+assert "Max-turn wrapup marker created" grep -q "max-turns" "/tmp/codex-autopilot-wrapup-${TEST_SESSION}"
+
+MAX_TURN_ALLOW=$(run_enabled_hook \
+  "{\"session_id\":\"${TEST_SESSION}\"}" \
+  AUTOPILOT_MAX_TURNS=1 || true)
+
+assert "Follow-up stop after max-turn wrapup allows stop" test -z "$MAX_TURN_ALLOW"
+
+cleanup
+echo "0" > "/tmp/codex-autopilot-turns-${TEST_SESSION}"
+
+ALIAS_PRECEDENCE_OUTPUT=$(run_enabled_hook \
+  "{\"session_id\":\"${TEST_SESSION}\"}" \
+  AUTOPILOT_MAX_TURNS=1 \
+  CMUX_AUTOPILOT_MAX_TURNS=20)
+
+assert "Generic AUTOPILOT_MAX_TURNS overrides CMUX_AUTOPILOT_MAX_TURNS" jq -e '.decision == "block"' <<<"$ALIAS_PRECEDENCE_OUTPUT"
+assert "Generic alias max-turn wrapup marker created" grep -q "max-turns" "/tmp/codex-autopilot-wrapup-${TEST_SESSION}"
+
+cleanup
+echo "0" > "/tmp/codex-autopilot-turns-${TEST_SESSION}"
+
+LEGACY_CLAUDE_ALIAS_OUTPUT=$(run_enabled_hook \
+  "{\"session_id\":\"${TEST_SESSION}\"}" \
+  CLAUDE_AUTOPILOT_MAX_TURNS=1)
+
+assert "Legacy CLAUDE_AUTOPILOT_MAX_TURNS still works for Codex when enabled" jq -e '.decision == "block"' <<<"$LEGACY_CLAUDE_ALIAS_OUTPUT"
+assert "Legacy CLAUDE alias creates max-turn wrapup marker" grep -q "max-turns" "/tmp/codex-autopilot-wrapup-${TEST_SESSION}"
+
+cleanup
+
+# Pre-seed turn count to 1 to simulate a repeated Stop event on the same session
+echo "1" > "/tmp/codex-autopilot-turns-${TEST_SESSION}"
+
+STOP_ACTIVE_OUTPUT=$(run_enabled_hook \
+  "{\"session_id\":\"${TEST_SESSION}\",\"stop_hook_active\":true}" \
+  AUTOPILOT_MAX_TURNS=99999)
+
+assert "Codex repeated stop with stop_hook_active=true still blocks" jq -e '.decision == "block"' <<<"$STOP_ACTIVE_OUTPUT"
+assert "Repeated codex stop recreates blocked flag" test -f "/tmp/codex-autopilot-blocked-${TEST_SESSION}"
+assert "Repeated codex stop increments turn counter to 2" grep -q '^2$' "/tmp/codex-autopilot-turns-${TEST_SESSION}"
+
+cleanup
+
+# Test stop_hook_active=true on turn 1 should also block
+STOP_ACTIVE_TURN1_OUTPUT=$(run_enabled_hook \
+  "{\"session_id\":\"${TEST_SESSION}\",\"stop_hook_active\":true}" \
+  AUTOPILOT_MAX_TURNS=99999)
+
+assert "Codex stop_hook_active=true on turn 1 still blocks" jq -e '.decision == "block"' <<<"$STOP_ACTIVE_TURN1_OUTPUT"
+
+cleanup
+
+DISABLED_BY_DEFAULT_OUTPUT=$(echo "{\"session_id\":\"${TEST_SESSION}\"}" | \
+  env -u AUTOPILOT_KEEP_RUNNING_DISABLED -u CMUX_AUTOPILOT_ENABLED \
+    AUTOPILOT_ENABLED=1 \
+    AUTOPILOT_DELAY=0 \
+    bash "$HOOK" || true)
+
+assert "Unset AUTOPILOT_KEEP_RUNNING_DISABLED disables Codex autopilot" test -z "$DISABLED_BY_DEFAULT_OUTPUT"
+assert "Disabled-by-default run does not create blocked flag" test ! -f "/tmp/codex-autopilot-blocked-${TEST_SESSION}"
+
+STALE_LOGIN_ENV_OUTPUT=$(echo "{\"session_id\":\"${TEST_SESSION}\"}" | \
+  env -u CMUX_AUTOPILOT_ENABLED \
+    AUTOPILOT_KEEP_RUNNING_DISABLED=0 \
+    AUTOPILOT_ENABLED=1 \
+    AUTOPILOT_DELAY=0 \
+    bash "$HOOK" || true)
+
+assert "Stale generic AUTOPILOT_KEEP_RUNNING_DISABLED=0 does not enable Codex autopilot without CMUX_AUTOPILOT_ENABLED=1" test -z "$STALE_LOGIN_ENV_OUTPUT"
+assert "Stale generic enable does not create blocked flag" test ! -f "/tmp/codex-autopilot-blocked-${TEST_SESSION}"
+
+cleanup
+INPUT_JSON="{\"session_id\":\"${TEST_SESSION}\",\"stop_hook_active\":false}"
+setup_fake_sleep
+
+DEFAULT_THRESHOLD_OUTPUT=$(echo "$INPUT_JSON" | env \
+  CMUX_AUTOPILOT_ENABLED=1 \
+  AUTOPILOT_KEEP_RUNNING_DISABLED=0 \
+  AUTOPILOT_ENABLED=1 \
+  AUTOPILOT_DELAY=0 \
+  AUTOPILOT_MAX_TURNS=30 \
+  AUTOPILOT_IDLE_THRESHOLD=999 \
+  PATH="$FAKE_BIN_DIR:$PATH" \
+  bash "$HOOK")
+
+assert_reason_not_contains "Codex first-hook monitoring omits prompt sleep guidance" "$DEFAULT_THRESHOLD_OUTPUT" "sleep 30"
+assert_reason_not_contains "Codex first-hook monitoring omits conditional wait text" "$DEFAULT_THRESHOLD_OUTPUT" "$CONDITIONAL_WAIT_TEXT"
+assert_eq "Codex default threshold triggers hidden 30s sleep on turn 1" "1" "$(sleep_log_match_count 30)"
+assert_eq "Codex default threshold logs one hidden sleep total" "1" "$(sleep_log_line_count)"
+
+cleanup
+INPUT_JSON="{\"session_id\":\"${TEST_SESSION}\",\"stop_hook_active\":false}"
+setup_fake_sleep
+
+WORK_PHASE_OUTPUT=$(run_hidden_sleep_monitoring_hook "$INPUT_JSON")
+
+assert_reason_not_contains "Codex turn 1 work phase has no wait instruction" "$WORK_PHASE_OUTPUT" "sleep"
+assert_eq "Codex turn 1 work phase does not trigger hidden sleep" "0" "$(sleep_log_line_count)"
+
+PHASE1_OUTPUT=$(run_hidden_sleep_monitoring_hook "$INPUT_JSON")
+
+assert_reason_not_contains "Codex monitoring phase 1 omits prompt sleep guidance" "$PHASE1_OUTPUT" "sleep 1"
+assert_reason_not_contains "Codex monitoring phase 1 omits conditional wait text" "$PHASE1_OUTPUT" "$CONDITIONAL_WAIT_TEXT"
+assert_eq "Codex monitoring phase 1 triggers one hidden sleep" "1" "$(sleep_log_match_count 1)"
+assert_eq "Codex monitoring phase 1 logs one hidden sleep total" "1" "$(sleep_log_line_count)"
+
+PHASE2_OUTPUT=$(run_hidden_sleep_monitoring_hook "$INPUT_JSON")
+
+assert_reason_not_contains "Codex monitoring phase 2 omits prompt sleep guidance" "$PHASE2_OUTPUT" "sleep 2"
+assert_reason_not_contains "Codex monitoring phase 2 omits conditional wait text" "$PHASE2_OUTPUT" "$CONDITIONAL_WAIT_TEXT"
+assert_eq "Codex monitoring phase 2 triggers one hidden 2s sleep" "1" "$(sleep_log_match_count 2)"
+assert_eq "Codex monitoring phases log two hidden sleeps total" "2" "$(sleep_log_line_count)"
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/.codex/skills/autopilot_reset/SKILL.md
+++ b/.codex/skills/autopilot_reset/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: autopilot_reset
+description: Use when the user asks for `$autopilot_reset` to inspect, stop, reset, or debug the current Codex autopilot session from Codex. Uses the shared repo script behind the scenes.
+args: "[status|status-all|stop|reset|all|debug-on|debug-off]"
+---
+
+# Autopilot Reset
+
+Use this skill when the user asks for `$autopilot_reset` or wants autopilot status/control from Codex.
+
+## Defaults
+
+- Target: the current Codex autopilot session
+- Default mode: `reset`
+
+## Supported modes
+
+- `status`
+- `status-all`
+- `stop`
+- `reset`
+- `all`
+- `debug-on`
+- `debug-off`
+
+## Workflow
+
+1. Parse the requested mode.
+2. If no mode is provided, use `reset`.
+3. Run the shared repo script with the Codex target baked in:
+
+```bash
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+AUTOPILOT_PROVIDER=codex bash "$ROOT"/scripts/autopilot-reset.sh <mode>
+```
+
+4. Report the script output directly and concisely.
+
+## Examples
+
+```bash
+$autopilot_reset
+$autopilot_reset status
+$autopilot_reset stop
+$autopilot_reset debug-on
+$autopilot_reset status-all
+```
+
+## Notes
+
+- Do not expose or ask for a `--provider` argument when using this skill. It is Codex-only.
+- Claude slash commands and Codex skills are different surfaces. If you need Claude autopilot control, use the shared script directly or Claude's `/autopilot_reset` command.
+- The implementation lives in `scripts/autopilot-reset.sh`. Do not duplicate the control logic inside the skill.

--- a/scripts/autopilot-reset.sh
+++ b/scripts/autopilot-reset.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+set -euo pipefail
+
+PROVIDER="${AUTOPILOT_PROVIDER:-claude}"
+
+if [ "${1:-}" = "--provider" ]; then
+  PROVIDER="${2:-}"
+  shift 2
+fi
+
+MODE="${1:-reset}"
+
+case "$PROVIDER" in
+  claude)
+    STATE_PREFIX="claude-autopilot"
+    CURRENT_SESSION_FILE="/tmp/claude-current-session-id"
+    ;;
+  codex)
+    STATE_PREFIX="codex-autopilot"
+    CURRENT_SESSION_FILE="/tmp/codex-current-session-id"
+    ;;
+  *)
+    echo "Unsupported provider: $PROVIDER" >&2
+    exit 1
+    ;;
+esac
+
+MAX_TURNS="${AUTOPILOT_MAX_TURNS:-${CMUX_AUTOPILOT_MAX_TURNS:-${CLAUDE_AUTOPILOT_MAX_TURNS:-20}}}"
+DEBUG_FLAG_FILE="/tmp/${STATE_PREFIX}-debug-enabled"
+DEBUG_LOG="/tmp/${STATE_PREFIX}-debug.log"
+
+read_optional_file() {
+  local path="$1"
+  if [ -f "$path" ]; then
+    tr -d '\n' < "$path"
+  fi
+}
+
+current_session_id() {
+  read_optional_file "$CURRENT_SESSION_FILE"
+}
+
+pid_file_for_session() {
+  local sid="$1"
+  printf '/tmp/%s-pid-%s\n' "$STATE_PREFIX" "$sid"
+}
+
+session_pid() {
+  local sid="$1"
+  read_optional_file "$(pid_file_for_session "$sid")"
+}
+
+provider_command_pattern() {
+  printf '(^|[[:space:]/])%s([[:space:]]|$)\n' "$PROVIDER"
+}
+
+session_is_live() {
+  local sid="$1"
+  local pid
+  pid="$(session_pid "$sid")"
+  [ -n "$pid" ] || return 1
+
+  # Use ps -p directly; it fails if process doesn't exist (no need for kill -0)
+  local cmd
+  cmd="$(ps -p "$pid" -o command= 2>/dev/null)" || return 1
+  [ -n "$cmd" ] || return 1
+
+  printf '%s\n' "$cmd" | grep -Eq "$(provider_command_pattern)"
+}
+
+prune_stale_runtime_state() {
+  local sid="$1"
+  local runtime_files=(
+    "/tmp/${STATE_PREFIX}-blocked-${sid}"
+    "/tmp/${STATE_PREFIX}-stop-${sid}"
+    "/tmp/${STATE_PREFIX}-state-${sid}"
+    "/tmp/${STATE_PREFIX}-idle-${sid}"
+    "/tmp/${STATE_PREFIX}-wrapup-${sid}"
+    "$(pid_file_for_session "$sid")"
+  )
+
+  # Skip pruning if session is still live
+  session_is_live "$sid" && return 1
+
+  # rm -f is idempotent; no need to check existence first
+  rm -f "${runtime_files[@]}" 2>/dev/null
+  return 0
+}
+
+debug_status() {
+  if [ "${CMUX_AUTOPILOT_DEBUG:-0}" = "1" ]; then
+    printf 'on (env)\n'
+    return 0
+  fi
+
+  if [ -f "$DEBUG_FLAG_FILE" ]; then
+    printf 'on (flag)\n'
+    return 0
+  fi
+
+  printf 'off\n'
+}
+
+session_status_text() {
+  local sid="$1"
+  local has_run="$2"
+  local stale_runtime="$3"
+
+  if [ -f "/tmp/${STATE_PREFIX}-stop-${sid}" ]; then
+    printf 'stop-pending'
+  elif [ -f "/tmp/${STATE_PREFIX}-blocked-${sid}" ]; then
+    printf 'blocked-live'
+  elif [ "$has_run" = "0" ]; then
+    printf 'idle'
+  elif [ "$stale_runtime" -eq 1 ]; then
+    printf 'ready-exited'
+  else
+    printf 'ready-available'
+  fi
+}
+
+status_current() {
+  local sid
+  local has_run
+  sid="$(current_session_id)"
+
+  if [ -z "$sid" ]; then
+    echo "Recorded session ID: (not set - restart session to enable)"
+    exit 0
+  fi
+
+  local turns_file="/tmp/${STATE_PREFIX}-turns-${sid}"
+  local stale_runtime=0
+  if prune_stale_runtime_state "$sid"; then
+    stale_runtime=1
+  fi
+
+  echo "Provider: $PROVIDER"
+  echo "Recorded session ID: ${sid}"
+  echo "Max turns: $MAX_TURNS"
+  echo "Debug: $(debug_status)"
+  echo "Debug log: $DEBUG_LOG"
+
+  if [ -f "$turns_file" ]; then
+    echo "Hook turn: $(cat "$turns_file")"
+    has_run=1
+  else
+    echo "Hook turn: 0"
+    has_run=0
+  fi
+
+  if [ -f "/tmp/${STATE_PREFIX}-stop-${sid}" ]; then
+    echo "Status: STOP (will stop on next turn)"
+  elif [ -f "/tmp/${STATE_PREFIX}-blocked-${sid}" ]; then
+    echo "Status: BLOCKED (actively running)"
+  elif [ "$has_run" = "0" ]; then
+    echo "Status: idle (not started)"
+  elif [ "$stale_runtime" -eq 1 ]; then
+    echo "Status: ready (last session exited)"
+  else
+    echo "Status: ready (available)"
+  fi
+}
+
+status_all() {
+  local current_sid
+  current_sid="$(current_session_id)"
+
+  echo "Provider: $PROVIDER"
+  echo "Max turns: $MAX_TURNS"
+  echo "Debug: $(debug_status)"
+  echo "Debug log: $DEBUG_LOG"
+  echo "Recorded current session: ${current_sid:-"(not set)"}"
+  echo ""
+  echo "Recorded sessions with hook state:"
+
+  local found=0
+  local f=""
+  shopt -s nullglob 2>/dev/null || true
+  for f in /tmp/${STATE_PREFIX}-turns-*; do
+    [ -f "$f" ] || continue
+    found=1
+    local sid="${f#/tmp/${STATE_PREFIX}-turns-}"
+    local stale_runtime=0
+    if prune_stale_runtime_state "$sid"; then
+      stale_runtime=1
+    fi
+    local turns
+    turns="$(cat "$f")"
+    local status_text
+    status_text="$(session_status_text "$sid" "1" "$stale_runtime")"
+    local current_marker=""
+    if [ "$sid" = "$current_sid" ]; then
+      current_marker=" recorded_current=yes"
+    fi
+    echo "  ${sid:0:20}...: hook_turn $turns status=$status_text$current_marker"
+  done
+
+  if [ "$found" -eq 0 ]; then
+    echo "  (none)"
+  fi
+}
+
+stop_current() {
+  local sid
+  sid="$(current_session_id)"
+
+  if [ -z "$sid" ]; then
+    echo "No session ID found. Restart session to enable."
+    exit 1
+  fi
+
+  touch "/tmp/${STATE_PREFIX}-stop-${sid}"
+  echo "Stop file created for current session: ${sid:0:20}..."
+  echo "Autopilot will stop on next turn."
+}
+
+reset_session() {
+  local sid="$1"
+  rm -f \
+    "/tmp/${STATE_PREFIX}-turns-${sid}" \
+    "/tmp/${STATE_PREFIX}-stop-${sid}" \
+    "/tmp/${STATE_PREFIX}-blocked-${sid}" \
+    "/tmp/${STATE_PREFIX}-completed-${sid}" \
+    "/tmp/${STATE_PREFIX}-wrapup-${sid}" \
+    "/tmp/${STATE_PREFIX}-state-${sid}" \
+    "/tmp/${STATE_PREFIX}-idle-${sid}" \
+    "$(pid_file_for_session "$sid")"
+}
+
+reset_current() {
+  local sid
+  sid="$(current_session_id)"
+
+  if [ -z "$sid" ]; then
+    echo "No session ID found. Restart session to enable."
+    exit 1
+  fi
+
+  reset_session "$sid"
+  echo "Reset current session: ${sid:0:20}..."
+  echo "Next cycle will start from turn 1/$MAX_TURNS"
+}
+
+reset_all() {
+  local count=0
+  local f=""
+  shopt -s nullglob 2>/dev/null || true
+  for f in /tmp/${STATE_PREFIX}-turns-*; do
+    [ -f "$f" ] || continue
+    local sid="${f#/tmp/${STATE_PREFIX}-turns-}"
+    reset_session "$sid"
+    echo "Reset: ${sid:0:20}..."
+    count=$((count + 1))
+  done
+
+  echo "Reset $count session(s). Next cycle will start from turn 1/$MAX_TURNS"
+}
+
+debug_on() {
+  touch "$DEBUG_FLAG_FILE"
+  echo "Autopilot debug enabled for provider: $PROVIDER"
+  echo "Debug log: $DEBUG_LOG"
+}
+
+debug_off() {
+  rm -f "$DEBUG_FLAG_FILE"
+  echo "Autopilot debug disabled for provider: $PROVIDER"
+  echo "Debug log: $DEBUG_LOG"
+}
+
+case "$MODE" in
+  status)
+    status_current
+    ;;
+  status-all)
+    status_all
+    ;;
+  stop)
+    stop_current
+    ;;
+  reset)
+    reset_current
+    ;;
+  all)
+    reset_all
+    ;;
+  debug-on)
+    debug_on
+    ;;
+  debug-off)
+    debug_off
+    ;;
+  *)
+    echo "Unknown mode: $MODE" >&2
+    echo "Usage: $0 [--provider claude|codex] [status|status-all|stop|reset|all|debug-on|debug-off]" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/hooks/cmux-autopilot-stop-core.sh
+++ b/scripts/hooks/cmux-autopilot-stop-core.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+set -euo pipefail
+
+PROVIDER="${CMUX_HOOK_PROVIDER:-generic}"
+PROJECT_DIR="${CMUX_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+STATE_PREFIX="${CMUX_AUTOPILOT_STATE_PREFIX:-${PROVIDER}-autopilot}"
+STATE_DIR="${CMUX_AUTOPILOT_STATE_DIR:-/tmp}"
+CURRENT_SESSION_FILE="${CMUX_AUTOPILOT_CURRENT_SESSION_FILE:-/tmp/${PROVIDER}-current-session-id}"
+SESSION_ACTIVITY_SCRIPT="${CMUX_SESSION_ACTIVITY_SCRIPT:-}"
+INLINE_WRAPUP="${CMUX_AUTOPILOT_INLINE_WRAPUP:-0}"
+ENABLE_REVIEW_WINDOW="${CMUX_AUTOPILOT_ENABLE_REVIEW_WINDOW:-0}"
+
+DEBUG_LOG="${CMUX_AUTOPILOT_DEBUG_LOG:-${STATE_DIR}/${STATE_PREFIX}-debug.log}"
+DEBUG_FLAG_FILE="${CMUX_AUTOPILOT_DEBUG_FLAG_FILE:-${STATE_DIR}/${STATE_PREFIX}-debug-enabled}"
+DEBUG_INPUT_FILE_TEMPLATE="${CMUX_AUTOPILOT_DEBUG_INPUT_FILE_TEMPLATE:-${STATE_DIR}/${STATE_PREFIX}-last-stop-input-%s.json}"
+DEBUG_ENABLED="0"
+if [ "${CMUX_AUTOPILOT_DEBUG:-0}" = "1" ] || [ -f "$DEBUG_FLAG_FILE" ]; then
+  DEBUG_ENABLED="1"
+fi
+
+log_debug() {
+  if [ "$DEBUG_ENABLED" = "1" ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$DEBUG_LOG"
+  fi
+}
+
+first_set() {
+  local value=""
+  for value in "$@"; do
+    if [ -n "$value" ]; then
+      printf '%s' "$value"
+      return 0
+    fi
+  done
+
+  return 0
+}
+
+case "${AUTOPILOT_KEEP_RUNNING_DISABLED:-}" in
+  0)
+    autopilot_enabled="1"
+    ;;
+  1)
+    log_debug "autopilot disabled via AUTOPILOT_KEEP_RUNNING_DISABLED=1"
+    exit 0
+    ;;
+  "")
+    log_debug "autopilot disabled because AUTOPILOT_KEEP_RUNNING_DISABLED is unset"
+    exit 0
+    ;;
+  *)
+    log_debug "autopilot disabled because AUTOPILOT_KEEP_RUNNING_DISABLED has unsupported value: ${AUTOPILOT_KEEP_RUNNING_DISABLED}"
+    exit 0
+    ;;
+esac
+
+INPUT=$(cat)
+# Parse only the session id. Codex may also send stop_hook_active, but the
+# shared autopilot loop intentionally ignores that field.
+SESSION_ID="$(echo "$INPUT" | jq -r '.session_id // "default"' 2>/dev/null || echo "default")"
+SESSION_ID="${SESSION_ID:-default}"
+PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
+
+if [ "$DEBUG_ENABLED" = "1" ]; then
+  DEBUG_INPUT_FILE=$(printf "$DEBUG_INPUT_FILE_TEMPLATE" "$SESSION_ID")
+  printf '%s\n' "$INPUT" > "$DEBUG_INPUT_FILE"
+fi
+
+TURN_FILE="${STATE_DIR}/${STATE_PREFIX}-turns-${SESSION_ID}"
+SESSION_STOP_FILE="${STATE_DIR}/${STATE_PREFIX}-stop-${SESSION_ID}"
+BLOCKED_FILE="${STATE_DIR}/${STATE_PREFIX}-blocked-${SESSION_ID}"
+COMPLETED_FILE="${STATE_DIR}/${STATE_PREFIX}-completed-${SESSION_ID}"
+STATE_FILE="${STATE_DIR}/${STATE_PREFIX}-state-${SESSION_ID}"
+IDLE_COUNT_FILE="${STATE_DIR}/${STATE_PREFIX}-idle-${SESSION_ID}"
+WRAPUP_FILE="${STATE_DIR}/${STATE_PREFIX}-wrapup-${SESSION_ID}"
+PID_FILE="${STATE_DIR}/${STATE_PREFIX}-pid-${SESSION_ID}"
+MAX_TURNS="$(first_set "${AUTOPILOT_MAX_TURNS:-}" "${CMUX_AUTOPILOT_MAX_TURNS:-}" "${CLAUDE_AUTOPILOT_MAX_TURNS:-20}")"
+IDLE_THRESHOLD="$(first_set "${AUTOPILOT_IDLE_THRESHOLD:-}" "${CMUX_AUTOPILOT_IDLE_THRESHOLD:-}" "${CLAUDE_AUTOPILOT_IDLE_THRESHOLD:-3}")"
+MONITORING_THRESHOLD="$(first_set "${AUTOPILOT_MONITORING_THRESHOLD:-}" "${CMUX_AUTOPILOT_MONITORING_THRESHOLD:-}" "${CLAUDE_AUTOPILOT_MONITORING_THRESHOLD:-10}")"
+BASE_DELAY="$(first_set "${AUTOPILOT_DELAY:-}" "${CMUX_AUTOPILOT_DELAY:-}" "${CLAUDE_AUTOPILOT_DELAY:-2}")"
+EXTERNAL_STOP_FILE="$(first_set "${AUTOPILOT_STOP_FILE:-}" "${CMUX_AUTOPILOT_STOP_FILE:-}" "${CLAUDE_AUTOPILOT_STOP_FILE:-}")"
+
+MONITORING_PHASE1_OFFSET="$(first_set "${AUTOPILOT_MONITORING_PHASE1_OFFSET:-}" "${CMUX_AUTOPILOT_MONITORING_PHASE1_OFFSET:-}" "${CLAUDE_AUTOPILOT_MONITORING_PHASE1_OFFSET:-5}")"
+MONITORING_PHASE1_WAIT="$(first_set "${AUTOPILOT_MONITORING_PHASE1_WAIT:-}" "${CMUX_AUTOPILOT_MONITORING_PHASE1_WAIT:-}" "${CLAUDE_AUTOPILOT_MONITORING_PHASE1_WAIT:-30}")"
+MONITORING_PHASE2_WAIT="$(first_set "${AUTOPILOT_MONITORING_PHASE2_WAIT:-}" "${CMUX_AUTOPILOT_MONITORING_PHASE2_WAIT:-}" "${CLAUDE_AUTOPILOT_MONITORING_PHASE2_WAIT:-60}")"
+# BASE_DELAY is always enforced between turns.
+# Claude keeps the longer monitoring waits in the prompt so polling stays
+# visible. Codex performs those monitoring waits inside the hook instead.
+WAIT_PROMPT_PREFIX="Only if you are blocked on external work and are about to poll status, run: sleep"
+
+cleanup_runtime_state() {
+  rm -f "$BLOCKED_FILE" "$STATE_FILE" "$IDLE_COUNT_FILE" "$WRAPUP_FILE" "$PID_FILE"
+
+  if [ -n "$SESSION_ACTIVITY_SCRIPT" ] && [ -f "$SESSION_ACTIVITY_SCRIPT" ]; then
+    "$SESSION_ACTIVITY_SCRIPT" end "$SESSION_ID" 2>/dev/null || true
+  fi
+}
+
+remove_owned_stop_files() {
+  rm -f "$SESSION_STOP_FILE"
+
+  if [ -n "${ALT_SESSION_STOP_FILE:-}" ]; then
+    rm -f "$ALT_SESSION_STOP_FILE"
+  fi
+}
+
+build_wrapup_reason() {
+  cat <<'EOF'
+Final turn (wrap up).
+Stop starting large new work. Stabilize what you have, run quick checks if sensible, and write a final summary.
+
+Output a "Self-Correction Session Summary" with:
+- Completed tasks count
+- PRs created (if any), with status
+- Key findings (security/perf/tests)
+- Remaining tasks (with why)
+EOF
+}
+
+is_infinite_mode() {
+  [ "$MAX_TURNS" -eq -1 ]
+}
+
+cd "$PROJECT_DIR"
+log_debug "provider=$PROVIDER project_dir=$PROJECT_DIR session_id=$SESSION_ID"
+
+printf '%s\n' "${CMUX_SESSION_PID:-$PPID}" > "$PID_FILE"
+
+# Clean up stale completed marker from an earlier finished cycle.
+rm -f "$COMPLETED_FILE"
+
+STOP_REQUESTED=0
+STOP_REASON=""
+ALT_SESSION_STOP_FILE=""
+
+if [ -f "$SESSION_STOP_FILE" ]; then
+  STOP_REQUESTED=1
+  STOP_REASON="session-stop"
+fi
+
+if [ "$STOP_REQUESTED" -eq 0 ] && [ -f "$CURRENT_SESSION_FILE" ]; then
+  CURRENT_SID=$(tr -d '\n' < "$CURRENT_SESSION_FILE" 2>/dev/null || echo "")
+  if [ -n "$CURRENT_SID" ] && [ "$CURRENT_SID" != "$SESSION_ID" ]; then
+    ALT_SESSION_STOP_FILE="${STATE_DIR}/${STATE_PREFIX}-stop-${CURRENT_SID}"
+    if [ -f "$ALT_SESSION_STOP_FILE" ]; then
+      STOP_REQUESTED=1
+      STOP_REASON="current-session-stop"
+    fi
+  fi
+fi
+
+if [ "$STOP_REQUESTED" -eq 0 ] && [ -n "$EXTERNAL_STOP_FILE" ] && [ -f "$EXTERNAL_STOP_FILE" ]; then
+  STOP_REQUESTED=1
+  STOP_REASON="external-stop"
+fi
+
+WRAPUP_SOURCE=""
+if [ -f "$WRAPUP_FILE" ]; then
+  WRAPUP_SOURCE=$(cat "$WRAPUP_FILE" 2>/dev/null || echo "")
+fi
+
+if [ "$STOP_REQUESTED" -eq 1 ]; then
+  if [ "$INLINE_WRAPUP" = "1" ]; then
+    if [ -n "$WRAPUP_SOURCE" ]; then
+      log_debug "allowing stop after inline wrapup source=$WRAPUP_SOURCE"
+      remove_owned_stop_files
+      cleanup_runtime_state
+      exit 0
+    fi
+
+    printf '%s\n' "$STOP_REASON" > "$WRAPUP_FILE"
+    WRAPUP_SOURCE="$STOP_REASON"
+    log_debug "inline wrapup requested source=$WRAPUP_SOURCE"
+  else
+    log_debug "allowing stop immediately source=$STOP_REASON"
+    remove_owned_stop_files
+    cleanup_runtime_state
+    exit 0
+  fi
+elif [ "$INLINE_WRAPUP" = "1" ] && [ "$WRAPUP_SOURCE" = "max-turns" ]; then
+  log_debug "allowing stop after max-turn inline wrapup"
+  rm -f "$TURN_FILE"
+  cleanup_runtime_state
+  exit 0
+fi
+
+TURN_COUNT=0
+if [ -f "$TURN_FILE" ]; then
+  TURN_COUNT=$(cat "$TURN_FILE" 2>/dev/null || echo "0")
+fi
+TURN_COUNT=$((TURN_COUNT + 1))
+printf '%s\n' "$TURN_COUNT" > "$TURN_FILE"
+
+# Codex exposes stop_hook_active on repeated Stop events, but cmux autopilot
+# intentionally ignores it so Codex keeps looping until normal stop conditions
+# apply: explicit stop request, idle detection, or max turns / wrap-up.
+
+if [ -z "$WRAPUP_SOURCE" ]; then
+  CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+  HAS_UNCOMMITTED=$(git status --porcelain 2>/dev/null | grep -q . && echo "1" || echo "0")
+  if [ "$HAS_UNCOMMITTED" = "1" ]; then
+    DIRTY_HASH=$({ git diff 2>/dev/null; git diff --cached 2>/dev/null; } | shasum -a 256 | cut -c1-8)
+  else
+    DIRTY_HASH="clean"
+  fi
+  CURRENT_STATE="${CURRENT_HEAD}:${DIRTY_HASH}"
+
+  PREV_STATE=""
+  [ -f "$STATE_FILE" ] && PREV_STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "")
+  printf '%s\n' "$CURRENT_STATE" > "$STATE_FILE"
+
+  IDLE_COUNT=0
+  [ -f "$IDLE_COUNT_FILE" ] && IDLE_COUNT=$(cat "$IDLE_COUNT_FILE" 2>/dev/null || echo "0")
+
+  if [ "$CURRENT_STATE" = "$PREV_STATE" ] && [ -n "$PREV_STATE" ]; then
+    IDLE_COUNT=$((IDLE_COUNT + 1))
+    printf '%s\n' "$IDLE_COUNT" > "$IDLE_COUNT_FILE"
+
+    if [ "$IDLE_COUNT" -ge "$IDLE_THRESHOLD" ]; then
+      echo "[Autopilot] No activity for $IDLE_COUNT turns, allowing stop" >&2
+      log_debug "allowing stop after idle threshold"
+      rm -f "$TURN_FILE"
+      cleanup_runtime_state
+      exit 0
+    fi
+  else
+    rm -f "$IDLE_COUNT_FILE"
+  fi
+fi
+
+if [ -z "$WRAPUP_SOURCE" ] && ! is_infinite_mode && [ "$TURN_COUNT" -ge "$MAX_TURNS" ]; then
+  printf '%s\n' "$TURN_COUNT" > "$COMPLETED_FILE"
+
+  if [ "$INLINE_WRAPUP" = "1" ] && [ "$MAX_TURNS" -gt 0 ]; then
+    printf '%s\n' "max-turns" > "$WRAPUP_FILE"
+    WRAPUP_SOURCE="max-turns"
+    log_debug "inline wrapup requested after max turns"
+  else
+    rm -f "$TURN_FILE"
+    cleanup_runtime_state
+    echo "Autopilot max turns reached ($MAX_TURNS) for session ${SESSION_ID}" >&2
+    exit 0
+  fi
+fi
+
+WAIT_INSTRUCTION=""
+MONITORING_SLEEP_SECONDS=""
+PHASE="work"
+
+if [ -z "$WRAPUP_SOURCE" ] && ! is_infinite_mode && [ "$TURN_COUNT" -gt "$MONITORING_THRESHOLD" ]; then
+  if [ "$TURN_COUNT" -le $((MONITORING_THRESHOLD + MONITORING_PHASE1_OFFSET)) ]; then
+    MONITORING_SLEEP_SECONDS="$MONITORING_PHASE1_WAIT"
+    PHASE="monitoring-${MONITORING_PHASE1_WAIT}s"
+  else
+    MONITORING_SLEEP_SECONDS="$MONITORING_PHASE2_WAIT"
+    PHASE="monitoring-${MONITORING_PHASE2_WAIT}s"
+  fi
+fi
+
+if [ "$PROVIDER" != "codex" ] && [ -n "$MONITORING_SLEEP_SECONDS" ]; then
+  WAIT_INSTRUCTION="${WAIT_PROMPT_PREFIX} ${MONITORING_SLEEP_SECONDS}"
+fi
+
+REVIEW_ENABLED=0
+if [ "$ENABLE_REVIEW_WINDOW" = "1" ] && [ -z "$WRAPUP_SOURCE" ] && ! is_infinite_mode && [ "$MAX_TURNS" -gt 2 ]; then
+  REVIEW_TURN=$((MAX_TURNS - 2))
+  if [ "$TURN_COUNT" -eq "$REVIEW_TURN" ]; then
+    REVIEW_ENABLED=1
+    rm -f "$BLOCKED_FILE"
+    log_debug "review window opened at turn=$TURN_COUNT"
+  fi
+fi
+
+if [ "$REVIEW_ENABLED" != "1" ]; then
+  printf '%s\n' "$TURN_COUNT" > "$BLOCKED_FILE"
+fi
+
+if ! is_infinite_mode && [ "$BASE_DELAY" -gt 0 ]; then
+  sleep "$BASE_DELAY"
+fi
+
+if [ "$PROVIDER" = "codex" ] && [ -n "$MONITORING_SLEEP_SECONDS" ] && [ "$MONITORING_SLEEP_SECONDS" -gt 0 ]; then
+  log_debug "codex monitoring sleep seconds=$MONITORING_SLEEP_SECONDS turn=$TURN_COUNT"
+  sleep "$MONITORING_SLEEP_SECONDS"
+fi
+
+if is_infinite_mode; then
+  TURN_STATUS="${TURN_COUNT}/∞"
+else
+  TURN_STATUS="${TURN_COUNT}/${MAX_TURNS}"
+fi
+
+echo "[Autopilot] Turn $TURN_STATUS ($PHASE) - continuing..." >&2
+
+if [ -n "$WRAPUP_SOURCE" ]; then
+  REASON="$(build_wrapup_reason)"
+elif [ "$REVIEW_ENABLED" = "1" ]; then
+  REASON="Code review is running. After review feedback, address any issues found. You have 2 turns remaining."
+  if [ -n "$WAIT_INSTRUCTION" ]; then
+    REASON="${REASON}
+${WAIT_INSTRUCTION}"
+  fi
+  REASON="${REASON}
+End with: Progress, Commands run, Files changed, Next."
+else
+  REASON="Continue from where you left off. Do not ask whether to continue."
+  if [ -n "$WAIT_INSTRUCTION" ]; then
+    REASON="${REASON}
+${WAIT_INSTRUCTION}"
+  fi
+  REASON="${REASON}
+End with: Progress, Commands run, Files changed, Next."
+fi
+
+jq -cn --arg reason "$REASON" '{"decision":"block","reason":$reason}'

--- a/scripts/hooks/cmux-session-start-core.sh
+++ b/scripts/hooks/cmux-session-start-core.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+PROVIDER="${CMUX_HOOK_PROVIDER:-generic}"
+PROJECT_DIR="${CMUX_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+OUTPUT_MODE="${CMUX_SESSION_START_OUTPUT_MODE:-text}"
+STATE_PREFIX="${CMUX_SESSION_STATE_PREFIX:-${PROVIDER}-autopilot}"
+SESSION_FILE="${CMUX_SESSION_FILE:-/tmp/${PROVIDER}-current-session-id}"
+SESSION_ENV_NAME="${CMUX_SESSION_ENV_NAME:-}"
+SESSION_ACTIVITY_SCRIPT="${CMUX_SESSION_ACTIVITY_SCRIPT:-}"
+
+DEBUG_ENABLED="${SESSION_START_DEBUG:-0}"
+DEBUG_LOG="${CMUX_SESSION_START_DEBUG_LOG:-/tmp/${PROVIDER}-session-start-debug.log}"
+
+log_debug() {
+  if [ "$DEBUG_ENABLED" = "1" ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$DEBUG_LOG"
+  fi
+}
+
+INPUT=$(cat)
+# Parse session_id and source in a single jq call
+read -r SESSION_ID SOURCE < <(echo "$INPUT" | jq -r '[.session_id // "default", .source // "startup"] | @tsv' 2>/dev/null || echo "default startup")
+SESSION_ID="${SESSION_ID:-default}"
+PID_FILE="${CMUX_SESSION_PID_FILE:-/tmp/${STATE_PREFIX}-pid-${SESSION_ID}}"
+SESSION_PID="${CMUX_SESSION_PID:-$PPID}"
+
+log_debug "provider=$PROVIDER source=$SOURCE session_id=$SESSION_ID"
+
+printf '%s\n' "$SESSION_ID" > "$SESSION_FILE"
+log_debug "wrote session file: $SESSION_FILE"
+
+printf '%s\n' "$SESSION_PID" > "$PID_FILE"
+log_debug "wrote pid file: $PID_FILE pid=$SESSION_PID"
+
+if [ -n "$SESSION_ACTIVITY_SCRIPT" ] && [ -f "$SESSION_ACTIVITY_SCRIPT" ]; then
+  "$SESSION_ACTIVITY_SCRIPT" start "$SESSION_ID" 2>/dev/null || true
+fi
+
+case "$OUTPUT_MODE" in
+  claude-env)
+    if [ -z "$SESSION_ENV_NAME" ]; then
+      echo "CMUX_SESSION_ENV_NAME is required for claude-env mode" >&2
+      exit 1
+    fi
+    jq -cn --arg key "$SESSION_ENV_NAME" --arg value "$SESSION_ID" '{env: {($key): $value}}'
+    ;;
+  codex-context)
+    CONTEXT=$(cat <<EOF
+Session source: ${SOURCE}.
+Review AGENTS.md and follow repository instructions before making changes.
+If this session was launched by cmux autopilot, the Stop hook may continue work automatically and later request a final wrap-up turn.
+EOF
+)
+    jq -cn --arg additionalContext "$CONTEXT" '{additionalContext: $additionalContext}'
+    ;;
+  text)
+    cat <<EOF
+Session source: ${SOURCE}.
+Review AGENTS.md and follow repository instructions before making changes.
+EOF
+    ;;
+  *)
+    echo "Unknown CMUX_SESSION_START_OUTPUT_MODE: $OUTPUT_MODE" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/test-autopilot-reset.sh
+++ b/scripts/test-autopilot-reset.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESET_SCRIPT="$SCRIPT_DIR/autopilot-reset.sh"
+CURRENT_SESSION_FILE="/tmp/codex-current-session-id"
+TEST_SESSION="codex-reset-test-$$"
+LEGACY_SESSION="codex-reset-legacy-$$"
+LIVE_PID=""
+PASS=0
+FAIL=0
+
+ORIGINAL_CURRENT_EXISTS=0
+ORIGINAL_CURRENT_CONTENT=""
+if [ -f "$CURRENT_SESSION_FILE" ]; then
+  ORIGINAL_CURRENT_EXISTS=1
+  ORIGINAL_CURRENT_CONTENT="$(cat "$CURRENT_SESSION_FILE")"
+fi
+
+cleanup_session() {
+  local sid="$1"
+  rm -f \
+    "/tmp/codex-autopilot-blocked-${sid}" \
+    "/tmp/codex-autopilot-completed-${sid}" \
+    "/tmp/codex-autopilot-idle-${sid}" \
+    "/tmp/codex-autopilot-pid-${sid}" \
+    "/tmp/codex-autopilot-state-${sid}" \
+    "/tmp/codex-autopilot-stop-${sid}" \
+    "/tmp/codex-autopilot-turns-${sid}" \
+    "/tmp/codex-autopilot-wrapup-${sid}"
+}
+
+cleanup() {
+  cleanup_session "$TEST_SESSION"
+  cleanup_session "$LEGACY_SESSION"
+
+  if [ -n "$LIVE_PID" ]; then
+    kill "$LIVE_PID" 2>/dev/null || true
+  fi
+
+  if [ "$ORIGINAL_CURRENT_EXISTS" -eq 1 ]; then
+    printf '%s\n' "$ORIGINAL_CURRENT_CONTENT" > "$CURRENT_SESSION_FILE"
+  else
+    rm -f "$CURRENT_SESSION_FILE"
+  fi
+}
+trap cleanup EXIT
+
+assert_contains() {
+  local desc="$1"
+  local haystack="$2"
+  local needle="$3"
+  if printf '%s\n' "$haystack" | grep -Fq "$needle"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "    expected to find: $needle"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_file_exists() {
+  local desc="$1"
+  local path="$2"
+  if [ -f "$path" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_file_not_exists() {
+  local desc="$1"
+  local path="$2"
+  if [ ! -f "$path" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== autopilot-reset status smoke test ==="
+
+echo ""
+echo "Test 1: live codex pid keeps BLOCKED status"
+cleanup_session "$TEST_SESSION"
+printf '%s\n' "$TEST_SESSION" > "$CURRENT_SESSION_FILE"
+printf '3\n' > "/tmp/codex-autopilot-turns-${TEST_SESSION}"
+printf '3\n' > "/tmp/codex-autopilot-blocked-${TEST_SESSION}"
+bash -c 'exec -a codex sleep 30' &
+LIVE_PID=$!
+printf '%s\n' "$LIVE_PID" > "/tmp/codex-autopilot-pid-${TEST_SESSION}"
+
+LIVE_OUTPUT="$(bash "$RESET_SCRIPT" --provider codex status)"
+assert_contains "live status shows blocked" "$LIVE_OUTPUT" "Status: BLOCKED (actively running)"
+assert_file_exists "blocked flag kept for live session" "/tmp/codex-autopilot-blocked-${TEST_SESSION}"
+
+kill "$LIVE_PID" 2>/dev/null || true
+LIVE_PID=""
+
+echo ""
+echo "Test 2: stale codex pid gets pruned from status"
+cleanup_session "$TEST_SESSION"
+printf '%s\n' "$TEST_SESSION" > "$CURRENT_SESSION_FILE"
+printf '2\n' > "/tmp/codex-autopilot-turns-${TEST_SESSION}"
+printf '2\n' > "/tmp/codex-autopilot-blocked-${TEST_SESSION}"
+printf '99999999\n' > "/tmp/codex-autopilot-pid-${TEST_SESSION}"
+
+STALE_OUTPUT="$(bash "$RESET_SCRIPT" --provider codex status)"
+assert_contains "stale status keeps hook turn count" "$STALE_OUTPUT" "Hook turn: 2"
+assert_contains "stale status reports exited session" "$STALE_OUTPUT" "Status: ready (last session exited)"
+assert_file_not_exists "stale blocked flag removed" "/tmp/codex-autopilot-blocked-${TEST_SESSION}"
+assert_file_not_exists "stale pid flag removed" "/tmp/codex-autopilot-pid-${TEST_SESSION}"
+
+echo ""
+echo "Test 3: status-all handles legacy blocked sessions without pid files"
+cleanup_session "$TEST_SESSION"
+cleanup_session "$LEGACY_SESSION"
+printf '%s\n' "$TEST_SESSION" > "$CURRENT_SESSION_FILE"
+printf '4\n' > "/tmp/codex-autopilot-turns-${LEGACY_SESSION}"
+printf '4\n' > "/tmp/codex-autopilot-blocked-${LEGACY_SESSION}"
+
+STATUS_ALL_OUTPUT="$(bash "$RESET_SCRIPT" --provider codex status-all)"
+assert_contains "status-all marks legacy blocked session as exited" "$STATUS_ALL_OUTPUT" "status=ready-exited"
+assert_file_not_exists "legacy blocked flag removed" "/tmp/codex-autopilot-blocked-${LEGACY_SESSION}"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- copy the Codex `.codex` hook/config files from `cmux`
- add the shared autopilot/session-start scripts they depend on under `scripts/`
- include the copied smoke tests for the Codex hook and reset flow

## Testing
- bash .codex/hooks/test-autopilot-stop.sh
- bash scripts/test-autopilot-reset.sh
- make check