### PR TITLE
feat: preserve exact seek collection urls

### DIFF
--- a/apps/api/src/routes/search-profiles.test.ts
+++ b/apps/api/src/routes/search-profiles.test.ts
@@ -672,6 +672,107 @@ describe('search-profiles update route', () => {
     expect('filters' in updateCall.args.profile).toBe(false)
   })
 
+  it('persists Seek source job URLs on profile updates', async () => {
+    const calls: ConvexCall[] = []
+    const existingCreatedAt = Date.now() - 1000
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+      calls.push(call)
+
+      if (call.pathName === 'search_profiles:getById') {
+        return convexSuccess({
+          _id: 'custom-profile-1',
+          name: 'Seek profile',
+          criteria: {
+            keywords: ['Sales', 'Engineer'],
+            locations: ['Kuala Lumpur MY'],
+          },
+          profile: {
+            id: 'custom-profile-1',
+            name: 'Seek profile',
+            status: 'active',
+            location: 'Kuala Lumpur MY',
+            keywords: ['Sales', 'Engineer'],
+            sources: [
+              {
+                type: 'job5156',
+                enabled: true,
+                priority: 1,
+              },
+            ],
+          },
+          workspaceSlug: 'dev',
+          createdAt: existingCreatedAt,
+          updatedAt: existingCreatedAt,
+        })
+      }
+
+      if (call.pathName === 'search_profiles:update') {
+        if (!isRecord(call.args.profile)) {
+          throw new Error('Expected updated profile payload')
+        }
+
+        return convexSuccess({
+          _id: 'custom-profile-1',
+          name: call.args.profile.name,
+          criteria: {
+            keywords: call.args.profile.keywords,
+            locations: [call.args.profile.location],
+          },
+          profile: call.args.profile,
+          workspaceSlug: 'dev',
+          createdAt: existingCreatedAt,
+          updatedAt: Date.now(),
+        })
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`)
+    })
+
+    const app = createApp()
+    const response = await app.request('/api/search-profiles/custom-profile-1', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Workspace-Slug': 'dev',
+      },
+      body: JSON.stringify({
+        name: 'Seek profile',
+        location: 'Kuala Lumpur MY',
+        keywords: ['Sales', 'Engineer'],
+        status: 'active',
+        sources: [
+          {
+            type: 'job5156',
+            enabled: true,
+            priority: 1,
+          },
+          {
+            type: 'seek',
+            enabled: true,
+            priority: 2,
+            jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+          },
+        ],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+
+    const updateCall = getUpdateCall(calls)
+    expect(isRecord(updateCall.args.profile)).toBe(true)
+    if (!isRecord(updateCall.args.profile) || !Array.isArray(updateCall.args.profile.sources)) {
+      throw new Error('Expected sources array in updated profile payload')
+    }
+    expect(updateCall.args.profile.sources).toContainEqual({
+      type: 'seek',
+      enabled: true,
+      priority: 2,
+      jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+    })
+  })
+
   it('allows saving an explicitly empty location without restoring the previous one', async () => {
     const calls: ConvexCall[] = []
     const existingCreatedAt = Date.now() - 1000

--- a/apps/api/src/services/search-profile-service.ts
+++ b/apps/api/src/services/search-profile-service.ts
@@ -60,6 +60,7 @@ export interface SearchProfile {
         type: string;
         enabled: boolean;
         priority?: number;
+        jobUrl?: string;
     }>;
 
     // Notifications
@@ -364,12 +365,14 @@ function parseSources(value: unknown): SearchProfile["sources"] | undefined {
             const type = readString(item.type);
             const enabled = readBoolean(item.enabled);
             const priority = readNumber(item.priority);
+            const jobUrl = readString(item.jobUrl);
             if (!type || enabled === undefined) return null;
 
             return {
                 type,
                 enabled,
                 priority,
+                jobUrl,
             };
         })
         .filter((item): item is NonNullable<typeof item> => item !== null);
@@ -501,6 +504,21 @@ function parseSession(value: unknown): SearchProfile["session"] | undefined {
         resetTriggers,
         retention,
     };
+}
+
+function isSeekRecommendedCandidatesUrl(value: string | undefined): boolean {
+    if (!value) {
+        return false;
+    }
+
+    try {
+        const url = new URL(value);
+        return url.protocol === "https:"
+            && url.hostname.toLowerCase().endsWith(".employer.seek.com")
+            && url.pathname.replace(/\/+$/, "") === "/candidates/recommended";
+    } catch {
+        return false;
+    }
 }
 
 export class SearchProfileService {
@@ -635,6 +653,15 @@ export class SearchProfileService {
 
     validateProfile(profile: SearchProfile): void {
         this.ensureRequiredCoreFields(profile);
+
+        const invalidSeekSource = profile.sources?.find((source) => (
+            source.type === "seek"
+            && source.enabled
+            && !isSeekRecommendedCandidatesUrl(source.jobUrl)
+        ));
+        if (invalidSeekSource) {
+            throw new Error("Enabled Seek source requires an exact Seek recommended candidates URL");
+        }
     }
 
     private getCacheKey(workspaceSlug: string, profileId: string): string {

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -75,8 +75,9 @@ const apiSnapshot = {
   chatInfo: null,
   insightInfo: null,
   seekRecommendedCandidates: null,
+  seekRecommendedRequest: null,
   seekProfile: null,
-  seekRequest: null,
+  seekProfileRequest: null,
   lastUpdatedAt: null,
   lastSearchAt: null,
   lastUrl: null,
@@ -348,6 +349,23 @@ function isSeekProfilePage() {
   return window.location.pathname.includes('/talentsearch/profile/');
 }
 
+function isSeekInlineProfileMode() {
+  if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) {
+    return false;
+  }
+
+  if (!window.location.pathname.includes('/candidates/recommended')) {
+    return false;
+  }
+
+  const openProfileId = normalizeOptionalPositiveInt(new URL(window.location.href).searchParams.get('openProfileId'));
+  return openProfileId !== null && hasSeekProfileSnapshot();
+}
+
+function isSeekProfileMode() {
+  return isSeekProfilePage() || isSeekInlineProfileMode();
+}
+
 function hasSeekProfileSnapshot() {
   return !!(apiSnapshot.seekProfile && typeof apiSnapshot.seekProfile === 'object');
 }
@@ -357,7 +375,7 @@ function hasSeekListSnapshot() {
 }
 
 function getSeekSnapshotCount() {
-  if (isSeekProfilePage()) {
+  if (isSeekProfileMode()) {
     return hasSeekProfileSnapshot() ? 1 : 0;
   }
   return hasSeekListSnapshot() ? apiSnapshot.seekRecommendedCandidates.length : 0;
@@ -440,6 +458,41 @@ function getSeekCandidateIdentity(candidate) {
 
 function buildSeekProfileUrl(profileId) {
   return profileId ? `https://${window.location.hostname.toLowerCase()}/candidates/${encodeURIComponent(profileId)}` : '';
+}
+
+function getSeekRecommendedRequest() {
+  return apiSnapshot.seekRecommendedRequest;
+}
+
+function getSeekProfileRequest() {
+  return apiSnapshot.seekProfileRequest || apiSnapshot.seekRecommendedRequest;
+}
+
+function findSeekProfileTrigger(profileId) {
+  if (!profileId) return null;
+
+  const candidateLinks = Array.from(document.querySelectorAll('a[href]'));
+  return candidateLinks.find((link) => {
+    const href = link.getAttribute('href') || '';
+    return href.includes(`/talentsearch/profile/${encodeURIComponent(profileId)}`)
+      || href.includes(`openProfileId=${encodeURIComponent(profileId)}`);
+  }) || null;
+}
+
+function mergeSeekListResumeWithDetail(baseResume, detailResume) {
+  if (!detailResume || typeof detailResume !== 'object') {
+    return baseResume;
+  }
+
+  return {
+    ...baseResume,
+    ...detailResume,
+    pageIndex: baseResume.pageIndex,
+    pageNumber: baseResume.pageNumber,
+    extractedAt: baseResume.extractedAt,
+    source: baseResume.source,
+    searchProfileId: detailResume.searchProfileId || baseResume.searchProfileId,
+  };
 }
 
 function formatSeekExpectedSalary(expectedSalary) {
@@ -1166,8 +1219,9 @@ function extractSeekProfileResume() {
   const profile = apiSnapshot.seekProfile;
   if (!profile || typeof profile !== 'object') return [];
 
-  const requestInput = apiSnapshot.seekRequest?.variables?.input;
-  const language = apiSnapshot.seekRequest?.variables?.language;
+  const request = getSeekProfileRequest();
+  const requestInput = request?.variables?.input;
+  const language = request?.variables?.language;
   const { profileId, profileType } = getSeekCandidateIdentity(profile);
   const firstName = typeof profile.firstName === 'string' ? profile.firstName.trim() : '';
   const lastName = typeof profile.lastName === 'string' ? profile.lastName.trim() : '';
@@ -1240,13 +1294,20 @@ function extractSeekProfileResume() {
   }];
 }
 
-function buildSeekCollectionContext() {
-  const requestInput = apiSnapshot.seekRequest?.variables?.input;
-  const language = apiSnapshot.seekRequest?.variables?.language;
+function buildSeekCollectionContext(options = {}) {
+  /** @type {{ captureModeOverride?: string }} */
+  const normalizedOptions = typeof options === 'object' && options ? options : {};
+  const captureModeOverride = normalizedOptions.captureModeOverride;
+  const useProfileMode = captureModeOverride
+    ? captureModeOverride === 'graphql-profile'
+    : isSeekProfileMode();
+  const request = useProfileMode ? getSeekProfileRequest() : getSeekRecommendedRequest();
+  const requestInput = request?.variables?.input;
+  const language = request?.variables?.language;
   const url = new URL(window.location.href);
   const pageNumberFromUrl = normalizeOptionalPositiveInt(url.searchParams.get('pageNumber'));
   const jobIdFromUrl = normalizeOptionalPositiveInt(url.searchParams.get('jobId'));
-  const captureMode = isSeekProfilePage() && apiSnapshot.seekProfile ? 'graphql-profile' : 'graphql-list';
+  const captureMode = captureModeOverride || (useProfileMode && apiSnapshot.seekProfile ? 'graphql-profile' : 'graphql-list');
   const defaultOperation = captureMode === 'graphql-profile'
     ? 'GetTalentSearchProfileCompleteV2'
     : 'GetTalentSearchRecommendedCandidates';
@@ -1277,7 +1338,7 @@ function getExtensionGeneratedBy() {
   return generatedBy;
 }
 
-function buildSubmitMetadata() {
+function buildSubmitMetadata(options = {}) {
   const url = new URL(window.location.href);
   const sourceKey = getCurrentSourceKey();
   const keyword = normalizeKeyword(url.searchParams.get(AUTO_SEARCH_PARAM) || '');
@@ -1299,7 +1360,9 @@ function buildSubmitMetadata() {
   if (keyword) metadata.keyword = keyword;
   if (location) metadata.location = location;
   if (sourceKey === SOURCE_KEYS.SEEK) {
-    metadata.collectionContext = buildSeekCollectionContext();
+    metadata.collectionContext = buildSeekCollectionContext({
+      captureModeOverride: options.seekCaptureMode,
+    });
   }
 
   return metadata;
@@ -1485,8 +1548,7 @@ function updateApiSnapshot(message) {
       || data?.getTalentSearchRecommendedCandidates?.candidates;
     if (Array.isArray(candidates)) {
       apiSnapshot.seekRecommendedCandidates = candidates;
-      apiSnapshot.seekProfile = null;
-      apiSnapshot.seekRequest = request || null;
+      apiSnapshot.seekRecommendedRequest = request || null;
       apiSnapshot.lastSearchAt = apiSnapshot.lastUpdatedAt;
       try {
         document.documentElement.setAttribute('data-tr-api-rows', String(getApiSnapshotCount()));
@@ -1503,8 +1565,7 @@ function updateApiSnapshot(message) {
       || data?.getTalentSearchProfileCompleteV2
       || data
       || null;
-    apiSnapshot.seekRecommendedCandidates = null;
-    apiSnapshot.seekRequest = request || apiSnapshot.seekRequest || null;
+    apiSnapshot.seekProfileRequest = request || apiSnapshot.seekProfileRequest || apiSnapshot.seekRecommendedRequest || null;
     try {
       document.documentElement.setAttribute('data-tr-api-rows', String(getApiSnapshotCount()));
     } catch {
@@ -1744,8 +1805,9 @@ function extractSingleResume(card, apiRow = null) {
  */
 function extractSeekResumes() {
   const candidates = Array.isArray(apiSnapshot.seekRecommendedCandidates) ? apiSnapshot.seekRecommendedCandidates : [];
-  const requestInput = apiSnapshot.seekRequest?.variables?.input;
-  const language = apiSnapshot.seekRequest?.variables?.language;
+  const request = getSeekRecommendedRequest();
+  const requestInput = request?.variables?.input;
+  const language = request?.variables?.language;
   const currentPage = typeof requestInput?.page === 'number'
     ? requestInput.page
     : normalizeOptionalPositiveInt(new URL(window.location.href).searchParams.get('pageNumber')) || 1;
@@ -1790,7 +1852,7 @@ function extractSeekResumes() {
 
 function extractResumes() {
   if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
-    if (isSeekProfilePage()) {
+    if (isSeekProfileMode()) {
       if (hasSeekProfileSnapshot()) {
         return extractSeekProfileResume();
       }
@@ -1836,7 +1898,7 @@ function extractResumesRaw(options = {}) {
   const includePage = !!(options && typeof options === 'object' && options.includePage);
 
   if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
-    const seekProfile = isSeekProfilePage() && hasSeekProfileSnapshot() ? apiSnapshot.seekProfile : null;
+    const seekProfile = isSeekProfileMode() && hasSeekProfileSnapshot() ? apiSnapshot.seekProfile : null;
     const seekProfileIdentity = seekProfile ? getSeekCandidateIdentity(seekProfile) : null;
     const candidates = !seekProfile && hasSeekListSnapshot() ? apiSnapshot.seekRecommendedCandidates : [];
     const cards = seekProfile
@@ -1868,7 +1930,7 @@ function extractResumesRaw(options = {}) {
           searchRowCount: cards.length,
           sourceKey: SOURCE_KEYS.SEEK,
           operationName: apiSnapshot.lastOperationName,
-          request: apiSnapshot.seekRequest,
+          request: seekProfile ? getSeekProfileRequest() : getSeekRecommendedRequest(),
         }
       };
 
@@ -2476,8 +2538,81 @@ function clearCapturedResultsForNextPage() {
   apiSnapshot.searchRows = null;
   if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
     apiSnapshot.seekRecommendedCandidates = null;
-    apiSnapshot.seekRequest = null;
+    apiSnapshot.seekRecommendedRequest = null;
+    apiSnapshot.seekProfile = null;
+    apiSnapshot.seekProfileRequest = null;
   }
+}
+
+function waitForSeekProfileSnapshot(profileId, { timeoutMs = 12000 } = {}) {
+  return new Promise((resolve, reject) => {
+    let done = false;
+    const deadline = Date.now() + timeoutMs;
+
+    const check = () => {
+      if (done) return;
+      const snapshot = apiSnapshot.seekProfile;
+      const identity = snapshot ? getSeekCandidateIdentity(snapshot) : null;
+      if (identity?.profileId === String(profileId)) {
+        done = true;
+        cleanup();
+        resolve(snapshot);
+        return;
+      }
+      if (Date.now() > deadline) {
+        done = true;
+        cleanup();
+        reject(new Error(`Timed out waiting for Seek profile ${profileId}`));
+      }
+    };
+
+    const cleanup = () => {
+      clearInterval(intervalId);
+      observer.disconnect();
+    };
+
+    const intervalId = setInterval(check, 200);
+    const observer = new MutationObserver(check);
+    observer.observe(document.body || document.documentElement, { childList: true, subtree: true });
+    check();
+  });
+}
+
+async function enrichSingleSeekResumeWithDetail(resume) {
+  const profileId = typeof resume?.profileId === 'string' ? resume.profileId.trim() : '';
+  if (!profileId) {
+    return resume;
+  }
+
+  const trigger = findSeekProfileTrigger(profileId);
+  if (!(trigger instanceof HTMLElement)) {
+    return resume;
+  }
+
+  try {
+    trigger.click();
+    await waitForSeekProfileSnapshot(profileId, { timeoutMs: 12000 });
+    const [detailResume] = extractSeekProfileResume();
+    if (!detailResume || detailResume.profileId !== profileId) {
+      return resume;
+    }
+    return mergeSeekListResumeWithDetail(resume, detailResume);
+  } catch (error) {
+    console.warn('🎯 [Auto Sync] Failed to enrich Seek detail resume:', profileId, error);
+    return resume;
+  }
+}
+
+async function enrichSeekRecommendedResumesWithDetail(resumes) {
+  if (!Array.isArray(resumes) || resumes.length === 0) return [];
+  if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return resumes;
+  if (isSeekProfileMode()) return resumes;
+
+  const enriched = [];
+  for (const resume of resumes) {
+    enriched.push(await enrichSingleSeekResumeWithDetail(resume));
+  }
+  return enriched;
 }
 
 function waitForPagination({ timeoutMs = 8000 } = {}) {
@@ -3197,10 +3332,18 @@ async function runAutoExportIfEnabled() {
 
 async function syncCurrentPageToServer(resumesOverride) {
   let resumes = Array.isArray(resumesOverride) ? resumesOverride : extractResumes();
-  if (getCurrentSourceKey() === SOURCE_KEYS.JOB5156 && !isJob5156DetailPage() && resumes.length > 0) {
+  const shouldEnrichFromCurrentPage = !Array.isArray(resumesOverride);
+  if (shouldEnrichFromCurrentPage && getCurrentSourceKey() === SOURCE_KEYS.JOB5156 && !isJob5156DetailPage() && resumes.length > 0) {
     resumes = await enrichJob5156SearchResumesWithDetail(resumes);
   }
-  const metadata = buildSubmitMetadata();
+  if (shouldEnrichFromCurrentPage && getCurrentSourceKey() === SOURCE_KEYS.SEEK && !isSeekProfileMode() && resumes.length > 0) {
+    resumes = await enrichSeekRecommendedResumesWithDetail(resumes);
+  }
+  const metadata = buildSubmitMetadata({
+    seekCaptureMode: Array.isArray(resumesOverride) && window.location.pathname.includes('/candidates/recommended')
+      ? 'graphql-list'
+      : undefined,
+  });
   return chrome.runtime.sendMessage({ action: 'syncToServer', metadata, resumes });
 }
 
@@ -3310,6 +3453,9 @@ async function runAutoSyncIfEnabled() {
       }
       if (getCurrentSourceKey() === SOURCE_KEYS.JOB5156 && !isJob5156DetailPage() && resumes.length > 0) {
         resumes = await enrichJob5156SearchResumesWithDetail(resumes);
+      }
+      if (getCurrentSourceKey() === SOURCE_KEYS.SEEK && !isSeekProfileMode() && resumes.length > 0) {
+        resumes = await enrichSeekRecommendedResumesWithDetail(resumes);
       }
       if (resumes.length <= 0) {
         const progressHint = limit > 0

--- a/apps/web/src/components/CollectResumesButton.tsx
+++ b/apps/web/src/components/CollectResumesButton.tsx
@@ -9,8 +9,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { buildSeekCollectUrl, isSeekRecommendedCandidatesUrl } from '@/lib/search-profile-sources'
 
-const SEEK_TALENT_SEARCH_URL = 'https://my.employer.seek.com/candidates/recommended'
 const SEEK_DEFAULT_LOCATION = 'Kuala Lumpur MY'
 const EXTENSION_META_URL = '/extension/extension-meta.json'
 const EXTENSION_ZIP_URL = '/extension/trends-resume-collector-latest.zip'
@@ -22,6 +22,7 @@ type ExtensionMeta = {
 interface CollectResumesButtonProps {
   location: string
   keywords: string[]
+  collectUrl?: string
   collectLimit?: number
   minAge?: number
   maxAge?: number
@@ -45,7 +46,7 @@ function normalizeAgeBound(value: number | undefined): number | undefined {
   return parsed > 0 ? parsed : undefined
 }
 
-export function CollectResumesButton({ location, keywords, collectLimit, minAge, maxAge }: CollectResumesButtonProps) {
+export function CollectResumesButton({ location, keywords, collectUrl, collectLimit, minAge, maxAge }: CollectResumesButtonProps) {
   const { t } = useTranslation()
   const [extensionVersion, setExtensionVersion] = useState<string | null>(null)
   const [maxPagesInput, setMaxPagesInput] = useState('')
@@ -66,42 +67,28 @@ export function CollectResumesButton({ location, keywords, collectLimit, minAge,
   )
   const normalizedMinAge = useMemo(() => normalizeAgeBound(minAge), [minAge])
   const normalizedMaxAge = useMemo(() => normalizeAgeBound(maxAge), [maxAge])
+  const hasExactCollectUrl = useMemo(() => isSeekRecommendedCandidatesUrl(collectUrl), [collectUrl])
 
-  const disabled = normalizedKeywords.length === 0
+  const disabled = !hasExactCollectUrl && normalizedKeywords.length === 0
 
-  const collectUrl = useMemo(() => {
+  const launchUrl = useMemo(() => {
     if (disabled) {
       return null
     }
 
-    const query = new URLSearchParams({
-      keyword: normalizedKeywords.join(' '),
-      tr_auto_sync: 'true',
+    return buildSeekCollectUrl({
+      baseUrl: hasExactCollectUrl ? collectUrl : undefined,
+      location: collectLocation,
+      keywords: normalizedKeywords,
+      collectLimit: normalizedCollectLimit,
+      maxPages: normalizedCollectMaxPages,
+      minAge: normalizedMinAge,
+      maxAge: normalizedMaxAge,
     })
-
-    if (collectLocation.length > 0) {
-      query.set('location', collectLocation)
-    }
-
-    if (normalizedCollectLimit > 0) {
-      query.set('tr_limit', String(normalizedCollectLimit))
-    }
-
-    if (normalizedCollectMaxPages > 0) {
-      query.set('tr_max_pages', String(normalizedCollectMaxPages))
-    }
-
-    if (typeof normalizedMinAge === 'number') {
-      query.set('tr_min_age', String(normalizedMinAge))
-    }
-
-    if (typeof normalizedMaxAge === 'number') {
-      query.set('tr_max_age', String(normalizedMaxAge))
-    }
-
-    return `${SEEK_TALENT_SEARCH_URL}?${query.toString()}`
   }, [
+    collectUrl,
     disabled,
+    hasExactCollectUrl,
     normalizedCollectLimit,
     normalizedCollectMaxPages,
     normalizedKeywords,
@@ -142,11 +129,11 @@ export function CollectResumesButton({ location, keywords, collectLimit, minAge,
   const maxPagesPlaceholder = t('quickStart.collectMaxPagesPlaceholder', 'Pages')
 
   const handleClick = () => {
-    if (!collectUrl) {
+    if (!launchUrl) {
       return
     }
 
-    window.open(collectUrl, '_blank', 'noopener,noreferrer')
+    window.open(launchUrl, '_blank', 'noopener,noreferrer')
   }
 
   const handleMaxPagesChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
 import type { ResumeFilters } from '@/types/resume'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
+import { getSearchProfileCollectUrl } from '@/lib/search-profile-sources'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 
 const AUTO_MATCH_MIN_CONFIDENCE = 0.3
@@ -54,12 +55,14 @@ interface QuickStartPanelProps {
       location: string
       keywords: string[]
       jobDescriptionId?: string
+      collectUrl?: string
       filters?: Partial<ResumeFilters>
     },
     applyDuringUrlHydration?: boolean
   ) => void
   defaultLocation?: string
   defaultKeywords?: string[]
+  defaultCollectUrl?: string
   jobDescriptionId?: string
   onJobChange?: (value: string) => void
   quickFilters?: {
@@ -263,6 +266,7 @@ export function QuickStartPanel({
   onApplyConfig,
   defaultLocation = '广东',
   defaultKeywords = [],
+  defaultCollectUrl,
   jobDescriptionId = '',
   onJobChange,
   quickFilters,
@@ -278,6 +282,7 @@ export function QuickStartPanel({
   const [location, setLocation] = useState(defaultLocation)
   const [selectedKeywords, setSelectedKeywords] = useState<string[]>(defaultKeywords)
   const [customKeyword, setCustomKeyword] = useState(defaultKeywords.join(' '))
+  const [collectUrl, setCollectUrl] = useState(defaultCollectUrl)
   const [quickMinRoleYears, setQuickMinRoleYears] = useState(quickFilters?.minRoleYears?.toString() ?? '')
   const [quickMaxAge, setQuickMaxAge] = useState(quickFilters?.maxAge?.toString() ?? '')
   const [activeRoleType, setActiveRoleType] = useState<string | undefined>(quickFilters?.roleFilterType)
@@ -312,6 +317,10 @@ export function QuickStartPanel({
     setSelectedKeywords(defaultKeywords)
     setCustomKeyword(defaultKeywords.join(' '))
   }, [defaultKeywords])
+
+  useEffect(() => {
+    setCollectUrl(defaultCollectUrl)
+  }, [defaultCollectUrl])
 
   useEffect(() => {
     const normalizedJobDescriptionId = jobDescriptionId.trim()
@@ -520,11 +529,12 @@ export function QuickStartPanel({
         location,
         keywords: normalizedKeywords,
         jobDescriptionId: effectiveJobDescriptionId,
+        collectUrl,
       })
     }, 500)
 
     return () => clearTimeout(timer)
-  }, [location, normalizedKeywords, jobDescriptionId, onApplyConfig])
+  }, [collectUrl, location, normalizedKeywords, jobDescriptionId, onApplyConfig])
 
   useEffect(() => {
     if (normalizedKeywords.length === 0) {
@@ -563,6 +573,7 @@ export function QuickStartPanel({
   const handleKeywordsChange = useCallback((keywords: string[]) => {
     setSelectedKeywords(keywords)
     setCustomKeyword(keywords.join(' '))
+    setCollectUrl(undefined)
   }, [])
 
   const handleLocationToggle = useCallback(
@@ -580,12 +591,14 @@ export function QuickStartPanel({
         nextParts.add(toggleLocation)
       }
 
+      setCollectUrl(undefined)
       setLocation(Array.from(nextParts).join(','))
     },
     [location, setLocation, t]
   )
 
   const handleJobChange = useCallback((value: string) => {
+    setCollectUrl(undefined)
     onJobChange?.(value)
   }, [onJobChange])
 
@@ -593,11 +606,13 @@ export function QuickStartPanel({
     const profileLocation = profile.location.trim()
     const profileKeywords = normalizeProfileKeywords(profile)
     const nextJobDescriptionId = profile.jobDescription?.trim() || ''
+    const nextCollectUrl = getSearchProfileCollectUrl(profile.sources)
     const quickConstraints = getProfileQuickConstraints(profile)
 
     setLocation(profileLocation)
     setSelectedKeywords(profileKeywords)
     setCustomKeyword(profileKeywords.join(' '))
+    setCollectUrl(nextCollectUrl)
     setQuickMinRoleYears(
       typeof quickConstraints.minRoleYears === 'number' ? String(quickConstraints.minRoleYears) : ''
     )
@@ -608,6 +623,7 @@ export function QuickStartPanel({
       location: profileLocation,
       keywords: profileKeywords,
       jobDescriptionId: nextJobDescriptionId || undefined,
+      collectUrl: nextCollectUrl,
       filters: mapProfileFiltersToResumeFilters(profile.filters),
     }, true)
     onApplyQuickFilters?.({
@@ -632,6 +648,7 @@ export function QuickStartPanel({
     minExperience?: number
     maxAge?: number
   }) => {
+    setCollectUrl(undefined)
     if (selectedConvexJobDescriptionProfile?.type === 'system') {
       onJobChange?.(newId)
     }
@@ -736,7 +753,10 @@ export function QuickStartPanel({
                   id="quickstart-location"
                   type="text"
                   value={location}
-                  onChange={(event) => setLocation(event.target.value)}
+                  onChange={(event) => {
+                    setCollectUrl(undefined)
+                    setLocation(event.target.value)
+                  }}
                   placeholder={t('quickStart.locationTooltip', '位置 (逗号分隔)')}
                   title={t('quickStart.locationTooltip', '支持多个位置，用逗号分隔，最多10个')}
                   className="h-9 w-40 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -756,6 +776,7 @@ export function QuickStartPanel({
                     const value = event.target.value
                     setCustomKeyword(value)
                     const parts = value.split(/[\s,]+/).filter(Boolean)
+                    setCollectUrl(undefined)
                     setSelectedKeywords(parts)
                   }}
                   placeholder={t('quickStart.customKeywordPlaceholder', '关键词 (空格分隔)...')}

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -27,6 +27,7 @@ export function ResumeList() {
   const {
     sessionLocation,
     sessionKeywords,
+    sessionCollectUrl,
     jobDescriptionId,
     filters,
     reviewedIdsSet,
@@ -95,6 +96,7 @@ export function ResumeList() {
         onJobChange={handleJobChange}
         defaultLocation={sessionLocation}
         defaultKeywords={sessionKeywords}
+        defaultCollectUrl={sessionCollectUrl}
         quickFilters={{
           minRoleYears: filters.minRoleYears ?? filters.minSalesYears,
           roleFilterType:
@@ -132,6 +134,7 @@ export function ResumeList() {
             <CollectResumesButton
               location={sessionLocation}
               keywords={sessionKeywords}
+              collectUrl={sessionCollectUrl}
               minAge={filters.minAge}
               maxAge={filters.maxAge}
             />

--- a/apps/web/src/components/SearchProfileEditorDialog.test.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SearchProfileEditorDialog } from './SearchProfileEditorDialog'
@@ -11,6 +11,27 @@ const { getMock, postMock, putMock } = vi.hoisted(() => ({
 const { useQueryMock } = vi.hoisted(() => ({
   useQueryMock: vi.fn(),
 }))
+const { tMock } = vi.hoisted(() => ({
+  tMock: vi.fn((_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key),
+}))
+
+const CONVEX_JOB_DESCRIPTIONS = [{
+  _id: 'custom-jd-id',
+  title: '车床销售',
+  type: 'custom',
+  enabled: true,
+}]
+
+const CONVEX_JOB_DESCRIPTION_DETAIL = {
+  _id: 'custom-jd-id',
+  title: '车床销售',
+  location: '广东,江苏',
+  customKeywords: ['车床', '销售'],
+  minExperience: 2,
+  maxExperience: 5,
+  minAge: 25,
+  maxAge: 38,
+}
 
 vi.mock('./JobDescriptionSelect', () => ({
   JobDescriptionSelect: ({
@@ -83,13 +104,32 @@ vi.mock('@/components/ui/dialog', () => ({
   DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 
+vi.mock('@/components/ui/checkbox', () => ({
+  Checkbox: ({
+    id,
+    checked,
+    onCheckedChange,
+  }: {
+    id?: string
+    checked?: boolean
+    onCheckedChange?: (checked: boolean) => void
+  }) => (
+    <input
+      id={id}
+      type="checkbox"
+      checked={checked}
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+    />
+  ),
+}))
+
 vi.mock('@/contexts/WorkspaceContext', () => ({
   useWorkspace: () => ({ slug: 'dev' }),
 }))
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+    t: tMock,
   }),
 }))
 
@@ -121,26 +161,12 @@ describe('SearchProfileEditorDialog JD hydration', () => {
       }
 
       if (typeof args === 'object' && args !== null && 'workspaceSlug' in args) {
-        return [{
-          _id: 'custom-jd-id',
-          title: '车床销售',
-          type: 'custom',
-          enabled: true,
-        }]
+        return CONVEX_JOB_DESCRIPTIONS
       }
 
       if (typeof args === 'object' && args !== null && 'id' in args) {
         if (args.id === 'custom-jd-id') {
-          return {
-            _id: 'custom-jd-id',
-            title: '车床销售',
-            location: '广东,江苏',
-            customKeywords: ['车床', '销售'],
-            minExperience: 2,
-            maxExperience: 5,
-            minAge: 25,
-            maxAge: 38,
-          }
+          return CONVEX_JOB_DESCRIPTION_DETAIL
         }
         return null
       }
@@ -194,8 +220,6 @@ describe('SearchProfileEditorDialog JD hydration', () => {
   })
 
   it('loads custom JD defaults into the fast edit form', async () => {
-    const user = userEvent.setup()
-
     render(
       <SearchProfileEditorDialog
         open
@@ -204,7 +228,7 @@ describe('SearchProfileEditorDialog JD hydration', () => {
       />
     )
 
-    await user.selectOptions(screen.getByTestId('job-description-select'), 'custom-jd-id')
+    fireEvent.change(screen.getByTestId('job-description-select'), { target: { value: 'custom-jd-id' } })
 
     await waitFor(() => {
       expect(screen.getByLabelText('地区:')).toHaveValue('广东,江苏')
@@ -219,6 +243,28 @@ describe('SearchProfileEditorDialog JD hydration', () => {
   })
 
   it('falls back to system JD metadata when the selection is not a custom Convex JD', async () => {
+    render(
+      <SearchProfileEditorDialog
+        open
+        onOpenChange={vi.fn()}
+        profileId={null}
+      />
+    )
+
+    fireEvent.change(screen.getByTestId('job-description-select'), { target: { value: 'lathe-sales' } })
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledWith('/api/job-descriptions/lathe-sales')
+      expect(screen.getByLabelText('地区:')).toHaveValue('东莞')
+      expect(screen.getByLabelText('关键词:')).toHaveValue('车床 销售')
+      expect(screen.getByLabelText('最低相关经验(年)')).toHaveValue(4)
+      expect(screen.getByLabelText('最高相关经验(年)')).toHaveValue(6)
+      expect(screen.getByLabelText('最低年龄')).toHaveValue(24)
+      expect(screen.getByLabelText('最高年龄')).toHaveValue(40)
+    })
+  })
+
+  it('persists Seek source job URLs in the profile payload', async () => {
     const user = userEvent.setup()
 
     render(
@@ -229,16 +275,34 @@ describe('SearchProfileEditorDialog JD hydration', () => {
       />
     )
 
-    await user.selectOptions(screen.getByTestId('job-description-select'), 'lathe-sales')
+    await user.type(screen.getByLabelText('Name'), 'Seek profile')
+    await user.type(screen.getByLabelText('关键词:'), '销售 工程师')
+    await user.click(screen.getByLabelText('Seek'))
+    await user.clear(screen.getByLabelText('Seek job URL'))
+    await user.type(
+      screen.getByLabelText('Seek job URL'),
+      'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1'
+    )
+    await user.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
-      expect(getMock).toHaveBeenCalledWith('/api/job-descriptions/lathe-sales')
-      expect(screen.getByLabelText('地区:')).toHaveValue('东莞')
-      expect(screen.getByLabelText('关键词:')).toHaveValue('车床 销售')
-      expect(screen.getByLabelText('最低相关经验(年)')).toHaveValue(4)
-      expect(screen.getByLabelText('最高相关经验(年)')).toHaveValue(6)
-      expect(screen.getByLabelText('最低年龄')).toHaveValue(24)
-      expect(screen.getByLabelText('最高年龄')).toHaveValue(40)
+      expect(postMock).toHaveBeenCalledWith('/api/search-profiles', {
+        body: expect.objectContaining({
+          sources: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'job5156',
+              enabled: true,
+              priority: 1,
+            }),
+            expect.objectContaining({
+              type: 'seek',
+              enabled: true,
+              priority: 2,
+              jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+            }),
+          ]),
+        }),
+      })
     })
   })
 
@@ -271,7 +335,7 @@ describe('SearchProfileEditorDialog JD hydration', () => {
       />
     )
 
-    await user.selectOptions(screen.getByTestId('job-description-select'), '')
+    fireEvent.change(screen.getByTestId('job-description-select'), { target: { value: '' } })
     await user.clear(screen.getByLabelText('最低相关经验(年)'))
     await user.clear(screen.getByLabelText('最高年龄'))
     await user.click(screen.getByRole('button', { name: 'Save' }))

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -12,6 +12,12 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
+import {
+    SEARCH_PROFILE_SOURCE_TYPES,
+    isSeekRecommendedCandidatesUrl,
+    normalizeSeekJobUrl,
+    type SearchProfileSource,
+} from '@/lib/search-profile-sources'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 
 export type SearchProfileFilters = {
@@ -39,7 +45,9 @@ export type SearchProfileDetails = {
     schedule?: {
         enabled: boolean
         cron?: string
+        maxCandidates?: number
     }
+    sources?: SearchProfileSource[]
 }
 
 type ProfileResponse = {
@@ -80,6 +88,14 @@ type ProfileFormState = {
     enabled: boolean
 }
 
+type SourceFormState = {
+    job5156Enabled: boolean
+    job5156Priority: string
+    seekEnabled: boolean
+    seekPriority: string
+    seekJobUrl: string
+}
+
 const DEFAULT_FORM: ProfileFormState = {
     name: '',
     location: '东莞',
@@ -91,6 +107,14 @@ const DEFAULT_FORM: ProfileFormState = {
     maxAge: '',
     cron: '0 9 * * 1-5',
     enabled: true,
+}
+
+const DEFAULT_SOURCES_FORM: SourceFormState = {
+    job5156Enabled: true,
+    job5156Priority: '1',
+    seekEnabled: false,
+    seekPriority: '2',
+    seekJobUrl: '',
 }
 
 function normalizeStringArray(values: string[] | undefined): string[] {
@@ -149,6 +173,66 @@ function parseKeywords(value: string): string[] {
         .filter((keyword) => keyword.length > 0)
 }
 
+function normalizeSourcePriority(value: number | undefined): string {
+    return typeof value === 'number' && Number.isFinite(value) ? String(Math.trunc(value)) : ''
+}
+
+function toSourcesFormState(sources: SearchProfileSource[] | undefined): SourceFormState {
+    if (!Array.isArray(sources) || sources.length === 0) {
+        return DEFAULT_SOURCES_FORM
+    }
+
+    const job5156Source = sources.find((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.job5156)
+    const seekSource = sources.find((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.seek)
+
+    return {
+        job5156Enabled: job5156Source?.enabled ?? DEFAULT_SOURCES_FORM.job5156Enabled,
+        job5156Priority: normalizeSourcePriority(job5156Source?.priority) || DEFAULT_SOURCES_FORM.job5156Priority,
+        seekEnabled: seekSource?.enabled ?? DEFAULT_SOURCES_FORM.seekEnabled,
+        seekPriority: normalizeSourcePriority(seekSource?.priority) || DEFAULT_SOURCES_FORM.seekPriority,
+        seekJobUrl: seekSource?.jobUrl ?? DEFAULT_SOURCES_FORM.seekJobUrl,
+    }
+}
+
+function splitKnownSources(sources: SearchProfileSource[] | undefined): {
+    known: SourceFormState
+    additional: SearchProfileSource[]
+} {
+    if (!Array.isArray(sources) || sources.length === 0) {
+        return {
+            known: DEFAULT_SOURCES_FORM,
+            additional: [],
+        }
+    }
+
+    return {
+        known: toSourcesFormState(sources),
+        additional: sources.filter((source) => (
+            source.type !== SEARCH_PROFILE_SOURCE_TYPES.job5156
+            && source.type !== SEARCH_PROFILE_SOURCE_TYPES.seek
+        )),
+    }
+}
+
+function buildSourcesPayload(sourceForm: SourceFormState, additionalSources: SearchProfileSource[]): SearchProfileSource[] {
+    const sources: SearchProfileSource[] = [...additionalSources]
+
+    sources.push({
+        type: SEARCH_PROFILE_SOURCE_TYPES.job5156,
+        enabled: sourceForm.job5156Enabled,
+        priority: parseOptionalNumber(sourceForm.job5156Priority),
+    })
+
+    sources.push({
+        type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+        enabled: sourceForm.seekEnabled,
+        priority: parseOptionalNumber(sourceForm.seekPriority),
+        jobUrl: normalizeSeekJobUrl(sourceForm.seekJobUrl),
+    })
+
+    return sources
+}
+
 function toFormState(profile: SearchProfileDetails): ProfileFormState {
     return {
         name: profile.name,
@@ -182,6 +266,8 @@ export function SearchProfileEditorDialog({
     const { t } = useTranslation()
     const { slug } = useWorkspace()
     const [form, setForm] = useState<ProfileFormState>(DEFAULT_FORM)
+    const [sourceForm, setSourceForm] = useState<SourceFormState>(DEFAULT_SOURCES_FORM)
+    const [additionalSources, setAdditionalSources] = useState<SearchProfileSource[]>([])
     const [submitting, setSubmitting] = useState(false)
     const [pendingJobDescriptionHydration, setPendingJobDescriptionHydration] = useState<{
         id: string
@@ -203,6 +289,25 @@ export function SearchProfileEditorDialog({
         selectedConvexJobDescription ? { id: selectedConvexJobDescription._id } : 'skip'
     )
 
+    const loadProfile = useCallback(async (id: string) => {
+        try {
+            const { data } = await rawApiClient.GET<ProfileResponse>(`/api/search-profiles/${id}`)
+            if (!data?.success || !data.profile) {
+                toast.error(t('searchProfiles.loadDetailError', { defaultValue: 'Failed to load profile details' }))
+                onOpenChange(false)
+                return
+            }
+            setForm(toFormState(data.profile))
+            const sourceState = splitKnownSources(data.profile.sources)
+            setSourceForm(sourceState.known)
+            setAdditionalSources(sourceState.additional)
+        } catch (error) {
+            console.error('Failed to load profile', error)
+            toast.error(t('searchProfiles.loadDetailError', { defaultValue: 'Failed to load profile details' }))
+            onOpenChange(false)
+        }
+    }, [onOpenChange, t])
+
     useEffect(() => {
         if (!open) {
             setPendingJobDescriptionHydration(null)
@@ -212,6 +317,9 @@ export function SearchProfileEditorDialog({
         // When opened
         if (initialData) {
             setForm(toFormState(initialData))
+            const sourceState = splitKnownSources(initialData.sources)
+            setSourceForm(sourceState.known)
+            setAdditionalSources(sourceState.additional)
             return
         }
 
@@ -219,8 +327,10 @@ export function SearchProfileEditorDialog({
             void loadProfile(profileId)
         } else {
             setForm(DEFAULT_FORM)
+            setSourceForm(DEFAULT_SOURCES_FORM)
+            setAdditionalSources([])
         }
-    }, [open, profileId, initialData])
+    }, [initialData, loadProfile, open, profileId])
 
     useEffect(() => {
         if (!open || !pendingJobDescriptionHydration) {
@@ -314,22 +424,6 @@ export function SearchProfileEditorDialog({
         }
     }, [open, pendingJobDescriptionHydration, convexJobDescriptions, selectedConvexJobDescription, selectedConvexJobDescriptionDetail])
 
-    const loadProfile = async (id: string) => {
-        try {
-            const { data } = await rawApiClient.GET<ProfileResponse>(`/api/search-profiles/${id}`)
-            if (!data?.success || !data.profile) {
-                toast.error(t('searchProfiles.loadDetailError', { defaultValue: 'Failed to load profile details' }))
-                onOpenChange(false)
-                return
-            }
-            setForm(toFormState(data.profile))
-        } catch (error) {
-            console.error('Failed to load profile', error)
-            toast.error(t('searchProfiles.loadDetailError', { defaultValue: 'Failed to load profile details' }))
-            onOpenChange(false)
-        }
-    }
-
     const handleJobDescriptionChange = useCallback((value: string) => {
         setForm((previous) => ({ ...previous, jobDescription: value }))
 
@@ -353,12 +447,22 @@ export function SearchProfileEditorDialog({
             return
         }
 
+        const normalizedSeekJobUrl = normalizeSeekJobUrl(sourceForm.seekJobUrl)
+        if (sourceForm.seekEnabled && !isSeekRecommendedCandidatesUrl(normalizedSeekJobUrl)) {
+            toast.error(t('searchProfiles.seekJobUrlError', { defaultValue: 'Enabled Seek source requires a Seek recommended candidates URL' }))
+            return
+        }
+
         const parsedMinExp = parseOptionalNumber(form.minExperience)
         const parsedMaxExp = parseOptionalNumber(form.maxExperience)
         const parsedMinAge = parseOptionalNumber(form.minAge)
         const parsedMaxAge = parseOptionalNumber(form.maxAge)
 
         const hasFilters = parsedMinExp !== undefined || parsedMaxExp !== undefined || parsedMinAge !== undefined || parsedMaxAge !== undefined
+        const sources = buildSourcesPayload({
+            ...sourceForm,
+            seekJobUrl: normalizedSeekJobUrl ?? sourceForm.seekJobUrl,
+        }, additionalSources)
 
         const payload = {
             name: form.name.trim(),
@@ -376,6 +480,7 @@ export function SearchProfileEditorDialog({
                 enabled: form.enabled,
                 cron: form.cron.trim() || undefined,
             },
+            sources,
         }
 
         setSubmitting(true)
@@ -406,7 +511,7 @@ export function SearchProfileEditorDialog({
         } finally {
             setSubmitting(false)
         }
-    }, [profileId, form, t, onOpenChange, onSaved])
+    }, [additionalSources, form, onOpenChange, onSaved, profileId, sourceForm, t])
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
@@ -515,6 +620,94 @@ export function SearchProfileEditorDialog({
                             onChange={(event) => setForm((previous) => ({ ...previous, cron: event.target.value }))}
                             placeholder="0 9 * * 1-5"
                         />
+                    </div>
+
+                    <div className="grid gap-3">
+                        <Label>{t('searchProfiles.fields.sources', { defaultValue: 'Sources' })}</Label>
+
+                        <div className="rounded-md border p-3">
+                            <div className="flex items-center justify-between gap-3">
+                                <div className="flex items-center gap-2">
+                                    <Checkbox
+                                        id="profile-source-job5156"
+                                        checked={sourceForm.job5156Enabled}
+                                        onCheckedChange={(checked) => setSourceForm((previous) => ({
+                                            ...previous,
+                                            job5156Enabled: checked === true,
+                                        }))}
+                                    />
+                                    <Label htmlFor="profile-source-job5156">Job5156</Label>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <Label htmlFor="profile-source-job5156-priority" className="text-sm text-muted-foreground">
+                                        {t('searchProfiles.fields.priority', { defaultValue: 'Priority' })}
+                                    </Label>
+                                    <Input
+                                        id="profile-source-job5156-priority"
+                                        type="number"
+                                        min={1}
+                                        value={sourceForm.job5156Priority}
+                                        onChange={(event) => setSourceForm((previous) => ({
+                                            ...previous,
+                                            job5156Priority: event.target.value,
+                                        }))}
+                                        className="h-8 w-24"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="rounded-md border p-3">
+                            <div className="flex items-center justify-between gap-3">
+                                <div className="flex items-center gap-2">
+                                    <Checkbox
+                                        id="profile-source-seek"
+                                        checked={sourceForm.seekEnabled}
+                                        onCheckedChange={(checked) => setSourceForm((previous) => ({
+                                            ...previous,
+                                            seekEnabled: checked === true,
+                                        }))}
+                                    />
+                                    <Label htmlFor="profile-source-seek">Seek</Label>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <Label htmlFor="profile-source-seek-priority" className="text-sm text-muted-foreground">
+                                        {t('searchProfiles.fields.priority', { defaultValue: 'Priority' })}
+                                    </Label>
+                                    <Input
+                                        id="profile-source-seek-priority"
+                                        type="number"
+                                        min={1}
+                                        value={sourceForm.seekPriority}
+                                        onChange={(event) => setSourceForm((previous) => ({
+                                            ...previous,
+                                            seekPriority: event.target.value,
+                                        }))}
+                                        className="h-8 w-24"
+                                    />
+                                </div>
+                            </div>
+
+                            {sourceForm.seekEnabled ? (
+                                <div className="mt-3 grid gap-2">
+                                    <Label htmlFor="profile-source-seek-job-url">
+                                        {t('searchProfiles.fields.seekJobUrl', { defaultValue: 'Seek job URL' })}
+                                    </Label>
+                                    <Input
+                                        id="profile-source-seek-job-url"
+                                        value={sourceForm.seekJobUrl}
+                                        onChange={(event) => setSourceForm((previous) => ({
+                                            ...previous,
+                                            seekJobUrl: event.target.value,
+                                        }))}
+                                        placeholder="https://my.employer.seek.com/candidates/recommended?jobId=123&pageNumber=1"
+                                    />
+                                    <span className="text-xs text-muted-foreground">
+                                        {t('searchProfiles.fields.seekJobUrlHint', { defaultValue: 'Use the exact Seek recommended candidates URL for this job lane.' })}
+                                    </span>
+                                </div>
+                            ) : null}
+                        </div>
                     </div>
 
                     <div className="flex items-center gap-2">

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -367,6 +367,8 @@ export function useResumeListState(loadSearchHistory = false) {
     setKeywords: setSessionKeywords,
     jobDescriptionId,
     setJobDescriptionId,
+    collectUrl: sessionCollectUrl,
+    setCollectUrl: setSessionCollectUrl,
     filters,
     setFilters,
     reviewedIdsSet,
@@ -1360,6 +1362,7 @@ export function useResumeListState(loadSearchHistory = false) {
       location: string
       keywords: string[]
       jobDescriptionId?: string
+      collectUrl?: string
       filters?: Partial<ResumeFilters>
     }, applyDuringUrlHydration?: boolean) => {
       if (shouldBlockQuickStartSync && !applyDuringUrlHydration) {
@@ -1380,13 +1383,17 @@ export function useResumeListState(loadSearchHistory = false) {
 
       setSessionKeywords((current) => (areKeywordListsEqual(current, normalizedKeywords) ? current : normalizedKeywords))
       setJobDescriptionId((current) => (current === normalizedJobDescriptionId ? current : normalizedJobDescriptionId))
+      setSessionCollectUrl((current) => {
+        const nextCollectUrl = normalizeOptionalString(config.collectUrl)
+        return current === nextCollectUrl ? current : nextCollectUrl
+      })
       setFilters((current) => ({
         ...current,
         ...(config.filters ?? {}),
         locations: normalizedLocation ? normalizedLocation.split(/[\s,，、]+/).filter(Boolean) : [],
       }))
     },
-    [setFilters, setJobDescriptionId, setSessionKeywords, setSessionLocation, shouldBlockQuickStartSync]
+    [setFilters, setJobDescriptionId, setSessionCollectUrl, setSessionKeywords, setSessionLocation, shouldBlockQuickStartSync]
   )
 
   const handleQuickConstraintApply = useCallback(
@@ -1414,6 +1421,7 @@ export function useResumeListState(loadSearchHistory = false) {
       location: sessionLocation,
       keywords: sessionKeywords,
       jobDescriptionId,
+      collectUrl: sessionCollectUrl,
       filters,
       selectedTags,
       selectedCompanies,
@@ -1426,7 +1434,7 @@ export function useResumeListState(loadSearchHistory = false) {
     } else {
       toast.error(t('quickStart.history.saveError', 'Failed to save search history'))
     }
-  }, [filteredConvexResumes, filters, jobDescriptionId, saveSearchHistory, selectedCompanies, selectedExperienceLevel, selectedTags, sessionKeywords, sessionLocation, t])
+  }, [filteredConvexResumes, filters, jobDescriptionId, saveSearchHistory, selectedCompanies, selectedExperienceLevel, selectedTags, sessionCollectUrl, sessionKeywords, sessionLocation, t])
 
   const handleApplySearchHistory = useCallback(async (entry: SearchHistoryItem) => {
     skipNextUrlSyncRef.current = true
@@ -1434,6 +1442,7 @@ export function useResumeListState(loadSearchHistory = false) {
       location: entry.location,
       keywords: entry.keywords,
       jobDescriptionId: entry.jobDescriptionId ?? '',
+      collectUrl: entry.collectUrl ?? '',
       filters: entry.filters,
     })
     setAppliedSearchHistoryId(entry.id)
@@ -1447,6 +1456,7 @@ export function useResumeListState(loadSearchHistory = false) {
   return {
     sessionLocation,
     sessionKeywords,
+    sessionCollectUrl,
     jobDescriptionId,
     appliedSearchHistoryId,
     filters,

--- a/apps/web/src/hooks/useSession.test.tsx
+++ b/apps/web/src/hooks/useSession.test.tsx
@@ -71,6 +71,7 @@ describe('useSession', () => {
           location: '广东,江苏',
           keywords: ['CNC', '销售'],
           jobDescriptionId: 'lathe-sales',
+          collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
           filters: {
             minExperience: 1,
             minAge: 25,
@@ -123,6 +124,7 @@ describe('useSession', () => {
             location: '东莞',
             keywords: ['CNC', '销售'],
             jobDescriptionId: 'lathe-sales',
+            collectUrl: ' https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1 ',
             filters: { minAge: 25 },
             selectedTags: ['STAR', 'STAR', ''],
             selectedCompanies: ['Acme', '  Acme  ', ''],
@@ -165,6 +167,7 @@ describe('useSession', () => {
         title: '  东莞 · CNC  ',
         location: '东莞',
         keywords: ['CNC', '销售'],
+        collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
         selectedTags: ['STAR'],
         selectedCompanies: ['Acme'],
         selectedExperienceLevel: 'mid',
@@ -202,6 +205,7 @@ describe('useSession', () => {
       title: 'HR saved search',
       location: '东莞',
       keywords: ['招聘', '简历'],
+      collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
       resumeIds: ['resume-1', 'resume-2'],
     })
     await result.current.markSearchHistoryOpened('history-hr' as never)
@@ -220,6 +224,7 @@ describe('useSession', () => {
         title: 'HR saved search',
         location: '东莞',
         keywords: ['招聘', '简历'],
+        collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
         resumeIds: ['resume-1', 'resume-2'],
       })
     )
@@ -251,5 +256,35 @@ describe('useSession', () => {
 
     expect(result.current.location).toBe('')
     expect(result.current.keywords).toEqual(['CNC', '销售'])
+  })
+
+  it('can clear and replace the persisted collect URL through external state', async () => {
+    const { result } = renderHook(() => useSession())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    act(() => {
+      result.current.setCollectUrl('https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1')
+    })
+
+    expect(result.current.collectUrl).toBe('https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1')
+
+    act(() => {
+      result.current.applyExternalState({
+        collectUrl: '',
+      })
+    })
+
+    expect(result.current.collectUrl).toBeUndefined()
+
+    act(() => {
+      result.current.applyExternalState({
+        collectUrl: ' https://my.employer.seek.com/candidates/recommended?jobId=2&pageNumber=1 ',
+      })
+    })
+
+    expect(result.current.collectUrl).toBe('https://my.employer.seek.com/candidates/recommended?jobId=2&pageNumber=1')
   })
 })

--- a/apps/web/src/hooks/useSession.ts
+++ b/apps/web/src/hooks/useSession.ts
@@ -10,6 +10,7 @@ export type ExternalSessionState = {
   location?: string
   keywords?: string[]
   jobDescriptionId?: string
+  collectUrl?: string
   filters?: Partial<ResumeFilters>
 }
 
@@ -20,6 +21,7 @@ export type SearchHistoryItem = {
   location: string
   keywords: string[]
   jobDescriptionId?: string
+  collectUrl?: string
   filters: Partial<ResumeFilters>
   selectedTags: string[]
   selectedCompanies: string[]
@@ -38,6 +40,7 @@ type SaveSearchHistoryInput = {
   location?: string
   keywords?: string[]
   jobDescriptionId?: string
+  collectUrl?: string
   filters?: Partial<ResumeFilters>
   selectedTags?: string[]
   selectedCompanies?: string[]
@@ -121,6 +124,7 @@ export function useSession(loadSearchHistory = false) {
   const [location, setLocation] = useState(DEFAULT_SESSION_LOCATION)
   const [keywords, setKeywords] = useState<string[]>([])
   const [jobDescriptionId, setJobDescriptionId] = useState<string | undefined>(undefined)
+  const [collectUrl, setCollectUrl] = useState<string | undefined>(undefined)
   const [filters, setFilters] = useState<ResumeFilters>({})
 
   useEffect(() => {
@@ -133,6 +137,7 @@ export function useSession(loadSearchHistory = false) {
     setLocation(DEFAULT_SESSION_LOCATION)
     setKeywords([])
     setJobDescriptionId(undefined)
+    setCollectUrl(undefined)
     setFilters({})
   }, [slug, sessionKey])
 
@@ -148,6 +153,7 @@ export function useSession(loadSearchHistory = false) {
       setLocation(activeSession.config.location)
       setKeywords(activeSession.config.keywords)
       setJobDescriptionId(activeSession.config.jobDescriptionId)
+      setCollectUrl(activeSession.config.collectUrl)
       setFilters(activeSession.config.filters || {})
       setHasHydratedInitialState(true)
     }
@@ -164,12 +170,13 @@ export function useSession(loadSearchHistory = false) {
         location,
         keywords,
         jobDescriptionId,
+        collectUrl,
         filters,
       })
     }, 1000)
 
     return () => clearTimeout(timer)
-  }, [sessionKey, slug, location, keywords, jobDescriptionId, filters, saveSession, hasHydratedInitialState])
+  }, [sessionKey, slug, location, keywords, jobDescriptionId, collectUrl, filters, saveSession, hasHydratedInitialState])
 
   const trackReviewedResume = useCallback(
     async (resumeId: string) => {
@@ -201,6 +208,10 @@ export function useSession(loadSearchHistory = false) {
       setJobDescriptionId(normalizedJobDescriptionId.length > 0 ? normalizedJobDescriptionId : undefined)
     }
 
+    if (state.collectUrl !== undefined) {
+      setCollectUrl(normalizeOptionalString(state.collectUrl))
+    }
+
     if (state.filters !== undefined) {
       setFilters(state.filters)
     }
@@ -220,6 +231,7 @@ export function useSession(loadSearchHistory = false) {
       location: record.location,
       keywords: record.keywords,
       jobDescriptionId: record.jobDescriptionId,
+      collectUrl: normalizeOptionalString(record.collectUrl),
       filters: (record.filters ?? {}) as Partial<ResumeFilters>,
       selectedTags: normalizeStringList(record.selectedTags),
       selectedCompanies: normalizeStringList(record.selectedCompanies),
@@ -246,6 +258,7 @@ export function useSession(loadSearchHistory = false) {
       location: input.location ?? location,
       keywords: input.keywords ?? keywords,
       jobDescriptionId: input.jobDescriptionId ?? jobDescriptionId,
+      collectUrl: input.collectUrl !== undefined ? normalizeOptionalString(input.collectUrl) : collectUrl,
       filters: input.filters ?? filters,
       selectedTags: normalizeStringList(input.selectedTags ?? []),
       selectedCompanies: normalizeStringList(input.selectedCompanies ?? []),
@@ -254,7 +267,7 @@ export function useSession(loadSearchHistory = false) {
       analysisTaskId: normalizeOptionalString(input.analysisTaskId),
       resumeIds: normalizeStringList(input.resumeIds),
     })
-  }, [filters, jobDescriptionId, keywords, location, saveSearchHistoryMutation, sessionKey, slug])
+  }, [collectUrl, filters, jobDescriptionId, keywords, location, saveSearchHistoryMutation, sessionKey, slug])
 
   const markSearchHistoryOpened = useCallback(async (id: Id<'search_history'>) => {
     await markSearchHistoryOpenedMutation({ id, workspaceSlug: slug })
@@ -267,6 +280,8 @@ export function useSession(loadSearchHistory = false) {
     setKeywords,
     jobDescriptionId,
     setJobDescriptionId,
+    collectUrl,
+    setCollectUrl,
     filters,
     setFilters,
     reviewedIdsSet,

--- a/apps/web/src/lib/search-profile-sources.test.ts
+++ b/apps/web/src/lib/search-profile-sources.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  SEARCH_PROFILE_SOURCE_TYPES,
+  buildSeekCollectUrl,
+  getActiveSearchProfileSource,
+  getSearchProfileCollectUrl,
+} from './search-profile-sources'
+
+describe('search-profile-sources', () => {
+  it('preserves exact Seek job URLs while replacing Trends control params', () => {
+    const collectUrl = buildSeekCollectUrl({
+      baseUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1&tr_limit=5&tr_auto_sync=false',
+      location: 'Kuala Lumpur MY',
+      keywords: ['Sales Engineer'],
+      collectLimit: 120,
+      maxPages: 3,
+      minAge: 25,
+      maxAge: 40,
+    })
+
+    expect(collectUrl).not.toBeNull()
+    const url = new URL(collectUrl as string)
+    expect(`${url.origin}${url.pathname}`).toBe('https://my.employer.seek.com/candidates/recommended')
+    expect(url.searchParams.get('jobId')).toBe('90842915')
+    expect(url.searchParams.get('pageNumber')).toBe('1')
+    expect(url.searchParams.get('keyword')).toBeNull()
+    expect(url.searchParams.get('tr_auto_sync')).toBe('true')
+    expect(url.searchParams.get('tr_limit')).toBe('120')
+    expect(url.searchParams.get('tr_max_pages')).toBe('3')
+    expect(url.searchParams.get('tr_min_age')).toBe('25')
+    expect(url.searchParams.get('tr_max_age')).toBe('40')
+  })
+
+  it('returns the preferred enabled Seek collect URL even when another source has higher priority', () => {
+    const collectUrl = getSearchProfileCollectUrl([
+      { type: SEARCH_PROFILE_SOURCE_TYPES.job5156, enabled: true, priority: 1 },
+      {
+        type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+        enabled: true,
+        priority: 2,
+        jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+      },
+    ])
+
+    expect(collectUrl).toBe('https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1')
+  })
+
+  it('uses enabled priority order when selecting the active source', () => {
+    const activeSource = getActiveSearchProfileSource([
+      { type: SEARCH_PROFILE_SOURCE_TYPES.seek, enabled: true, priority: 2 },
+      { type: SEARCH_PROFILE_SOURCE_TYPES.job5156, enabled: true, priority: 1 },
+    ])
+
+    expect(activeSource).toEqual({
+      type: SEARCH_PROFILE_SOURCE_TYPES.job5156,
+      enabled: true,
+      priority: 1,
+    })
+  })
+})

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -1,0 +1,200 @@
+const SEEK_TALENT_SEARCH_URL = 'https://my.employer.seek.com/candidates/recommended'
+const SEEK_HOST_SUFFIX = '.employer.seek.com'
+const SEEK_RECOMMENDED_PATH = '/candidates/recommended'
+
+export const SEARCH_PROFILE_SOURCE_TYPES = {
+  job5156: 'job5156',
+  seek: 'seek',
+} as const
+
+export type SearchProfileSource = {
+  type: string
+  enabled: boolean
+  priority?: number
+  jobUrl?: string
+}
+
+type BuildSeekCollectUrlInput = {
+  baseUrl?: string
+  location: string
+  keywords: string[]
+  collectLimit?: number
+  maxPages?: number
+  minAge?: number
+  maxAge?: number
+}
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function normalizeKeywords(keywords: string[]): string[] {
+  return keywords
+    .map((keyword) => keyword.trim())
+    .filter((keyword) => keyword.length > 0)
+}
+
+function normalizeOptionalPositiveInt(value: number | undefined): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined
+  }
+
+  const normalized = Math.trunc(value)
+  return normalized > 0 ? normalized : undefined
+}
+
+function compareSourcePriority(left: SearchProfileSource, right: SearchProfileSource): number {
+  const leftPriority = typeof left.priority === 'number' && Number.isFinite(left.priority)
+    ? left.priority
+    : Number.MAX_SAFE_INTEGER
+  const rightPriority = typeof right.priority === 'number' && Number.isFinite(right.priority)
+    ? right.priority
+    : Number.MAX_SAFE_INTEGER
+
+  return leftPriority - rightPriority
+}
+
+function removeTrendsParams(url: URL): void {
+  const keys = Array.from(url.searchParams.keys())
+  keys.forEach((key) => {
+    if (key.startsWith('tr_')) {
+      url.searchParams.delete(key)
+    }
+  })
+}
+
+export function normalizeSeekJobUrl(value: string | undefined): string | undefined {
+  const normalizedValue = normalizeOptionalString(value)
+  if (!normalizedValue) {
+    return undefined
+  }
+
+  try {
+    const url = new URL(normalizedValue)
+    return url.toString()
+  } catch {
+    return undefined
+  }
+}
+
+export function isSeekRecommendedCandidatesUrl(value: string | undefined): boolean {
+  const normalizedValue = normalizeSeekJobUrl(value)
+  if (!normalizedValue) {
+    return false
+  }
+
+  try {
+    const url = new URL(normalizedValue)
+    return url.protocol === 'https:'
+      && url.hostname.toLowerCase().endsWith(SEEK_HOST_SUFFIX)
+      && url.pathname.replace(/\/+$/, '') === SEEK_RECOMMENDED_PATH
+  } catch {
+    return false
+  }
+}
+
+export function getActiveSearchProfileSource(
+  sources: SearchProfileSource[] | undefined,
+): SearchProfileSource | undefined {
+  if (!Array.isArray(sources) || sources.length === 0) {
+    return undefined
+  }
+
+  return sources
+    .map((source, index) => ({ source, index }))
+    .filter(({ source }) => source.enabled)
+    .sort((left, right) => compareSourcePriority(left.source, right.source) || left.index - right.index)[0]?.source
+}
+
+export function getPreferredSeekSource(
+  sources: SearchProfileSource[] | undefined,
+): SearchProfileSource | undefined {
+  if (!Array.isArray(sources) || sources.length === 0) {
+    return undefined
+  }
+
+  return sources
+    .map((source, index) => ({ source, index }))
+    .filter(({ source }) => source.enabled && source.type === SEARCH_PROFILE_SOURCE_TYPES.seek)
+    .sort((left, right) => compareSourcePriority(left.source, right.source) || left.index - right.index)[0]?.source
+}
+
+export function getSearchProfileCollectUrl(
+  sources: SearchProfileSource[] | undefined,
+): string | undefined {
+  const seekSource = getPreferredSeekSource(sources)
+  if (!seekSource || !isSeekRecommendedCandidatesUrl(seekSource.jobUrl)) {
+    return undefined
+  }
+
+  return normalizeSeekJobUrl(seekSource.jobUrl)
+}
+
+export function buildSeekCollectUrl({
+  baseUrl,
+  location,
+  keywords,
+  collectLimit,
+  maxPages,
+  minAge,
+  maxAge,
+}: BuildSeekCollectUrlInput): string | null {
+  const normalizedBaseUrl = normalizeSeekJobUrl(baseUrl)
+  const normalizedKeywords = normalizeKeywords(keywords)
+  const normalizedLocation = location.trim()
+
+  if (!normalizedBaseUrl && normalizedKeywords.length === 0) {
+    return null
+  }
+
+  const url = normalizedBaseUrl && isSeekRecommendedCandidatesUrl(normalizedBaseUrl)
+    ? new URL(normalizedBaseUrl)
+    : new URL(SEEK_TALENT_SEARCH_URL)
+
+  if (!normalizedBaseUrl) {
+    url.searchParams.set('keyword', normalizedKeywords.join(' '))
+    if (normalizedLocation.length > 0) {
+      url.searchParams.set('location', normalizedLocation)
+    } else {
+      url.searchParams.delete('location')
+    }
+  }
+
+  removeTrendsParams(url)
+  url.searchParams.set('tr_auto_sync', 'true')
+
+  const normalizedCollectLimit = normalizeOptionalPositiveInt(collectLimit)
+  if (typeof normalizedCollectLimit === 'number') {
+    url.searchParams.set('tr_limit', String(normalizedCollectLimit))
+  } else {
+    url.searchParams.delete('tr_limit')
+  }
+
+  const normalizedMaxPages = normalizeOptionalPositiveInt(maxPages)
+  if (typeof normalizedMaxPages === 'number') {
+    url.searchParams.set('tr_max_pages', String(normalizedMaxPages))
+  } else {
+    url.searchParams.delete('tr_max_pages')
+  }
+
+  const normalizedMinAge = normalizeOptionalPositiveInt(minAge)
+  if (typeof normalizedMinAge === 'number') {
+    url.searchParams.set('tr_min_age', String(normalizedMinAge))
+  } else {
+    url.searchParams.delete('tr_min_age')
+  }
+
+  const normalizedMaxAge = normalizeOptionalPositiveInt(maxAge)
+  if (typeof normalizedMaxAge === 'number') {
+    url.searchParams.set('tr_max_age', String(normalizedMaxAge))
+  } else {
+    url.searchParams.delete('tr_max_age')
+  }
+
+  return url.toString()
+}

--- a/apps/web/src/pages/SearchProfilesPage.test.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.test.tsx
@@ -1,0 +1,335 @@
+import type { ReactNode } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SearchProfilesPage } from './SearchProfilesPage'
+
+const { getMock, postMock, deleteMock, setSearchParamsMock, toastSuccessMock, toastErrorMock, tMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+  postMock: vi.fn(),
+  deleteMock: vi.fn(),
+  setSearchParamsMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  tMock: vi.fn((_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [new URLSearchParams(), setSearchParamsMock],
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: tMock,
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: {
+    GET: (...args: unknown[]) => getMock(...args),
+    POST: (...args: unknown[]) => postMock(...args),
+    DELETE: (...args: unknown[]) => deleteMock(...args),
+  },
+}))
+
+vi.mock('@/components/ProfileCard', () => ({
+  ProfileCard: ({
+    profile,
+    onRunNow,
+  }: {
+    profile: { id: string; name: string }
+    onRunNow: (profileId: string) => void
+  }) => (
+    <button type="button" onClick={() => onRunNow(profile.id)}>
+      Run {profile.name}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode
+    onClick?: () => void
+    disabled?: boolean
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/PageHeader', () => ({
+  PageHeader: ({ title }: { title?: string }) => <div>{title}</div>,
+}))
+
+vi.mock('@/components/SearchProfileEditorDialog', () => ({
+  SearchProfileEditorDialog: () => null,
+}))
+
+describe('SearchProfilesPage run behavior', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+    vi.spyOn(globalThis, 'setInterval').mockImplementation(() => 1 as never)
+    getMock.mockImplementation(async (path: string) => {
+      if (path === '/api/search-profiles') {
+        return {
+          data: {
+            success: true,
+            profiles: [
+              {
+                id: 'profile-1',
+                name: 'Profile 1',
+                filename: 'profile-1.yaml',
+                updatedAt: '2026-03-17T00:00:00.000Z',
+                status: 'active',
+                location: 'Kuala Lumpur MY',
+                keywords: ['Sales Engineer', 'Sales Manager'],
+              },
+            ],
+          },
+        }
+      }
+
+      if (path === '/api/search-profiles/profile-1/status') {
+        return {
+          data: {
+            success: true,
+            status: null,
+          },
+        }
+      }
+
+      return {
+        data: {
+          success: true,
+        },
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('opens Seek profiles in a new tab instead of dispatching a worker run', async () => {
+    const user = userEvent.setup()
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    getMock.mockImplementation(async (path: string) => {
+      if (path === '/api/search-profiles') {
+        return {
+          data: {
+            success: true,
+            profiles: [
+              {
+                id: 'profile-1',
+                name: 'Seek profile',
+                filename: 'seek-profile.yaml',
+                updatedAt: '2026-03-17T00:00:00.000Z',
+                status: 'active',
+                location: 'Kuala Lumpur MY',
+                keywords: ['Sales Engineer', 'Sales Manager'],
+              },
+            ],
+          },
+        }
+      }
+
+      if (path === '/api/search-profiles/profile-1') {
+        return {
+          data: {
+            success: true,
+            profile: {
+              id: 'profile-1',
+              name: 'Seek profile',
+              status: 'active',
+              location: 'Kuala Lumpur MY',
+              keywords: ['Sales Engineer', 'Sales Manager'],
+              filters: {
+                minAge: 25,
+                maxAge: 40,
+              },
+              schedule: {
+                enabled: true,
+                cron: '0 9 * * 1-5',
+                maxCandidates: 200,
+              },
+              sources: [
+                {
+                  type: 'seek',
+                  enabled: true,
+                  priority: 1,
+                  jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+                },
+                {
+                  type: 'job5156',
+                  enabled: true,
+                  priority: 2,
+                },
+              ],
+            },
+          },
+        }
+      }
+
+      if (path === '/api/search-profiles/profile-1/status') {
+        return {
+          data: {
+            success: true,
+            status: null,
+          },
+        }
+      }
+
+      return {
+        data: {
+          success: true,
+        },
+      }
+    })
+
+    render(<SearchProfilesPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Run Seek profile' }))
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledTimes(1)
+    })
+
+    const openedUrl = new URL(String(openSpy.mock.calls[0]?.[0]))
+    expect(`${openedUrl.origin}${openedUrl.pathname}`).toBe('https://my.employer.seek.com/candidates/recommended')
+    expect(openedUrl.searchParams.get('jobId')).toBe('90842915')
+    expect(openedUrl.searchParams.get('tr_limit')).toBe('200')
+    expect(openedUrl.searchParams.get('tr_max_pages')).toBe('10')
+    expect(openedUrl.searchParams.get('tr_min_age')).toBe('25')
+    expect(openedUrl.searchParams.get('tr_max_age')).toBe('40')
+    expect(postMock).not.toHaveBeenCalled()
+    expect(getMock).toHaveBeenCalledTimes(3)
+    expect(toastSuccessMock).toHaveBeenCalledWith('Opened Seek collection in a new tab')
+  })
+
+  it('keeps worker-backed sources on the existing dispatch and status polling flow', async () => {
+    const user = userEvent.setup()
+
+    getMock.mockImplementation(async (path: string) => {
+      if (path === '/api/search-profiles') {
+        return {
+          data: {
+            success: true,
+            profiles: [
+              {
+                id: 'profile-1',
+                name: 'Job5156 profile',
+                filename: 'job5156-profile.yaml',
+                updatedAt: '2026-03-17T00:00:00.000Z',
+                status: 'active',
+                location: '东莞',
+                keywords: ['招聘', '简历'],
+              },
+            ],
+          },
+        }
+      }
+
+      if (path === '/api/search-profiles/profile-1') {
+        return {
+          data: {
+            success: true,
+            profile: {
+              id: 'profile-1',
+              name: 'Job5156 profile',
+              status: 'active',
+              location: '东莞',
+              keywords: ['招聘', '简历'],
+              sources: [
+                {
+                  type: 'job5156',
+                  enabled: true,
+                  priority: 1,
+                },
+                {
+                  type: 'seek',
+                  enabled: true,
+                  priority: 2,
+                  jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+                },
+              ],
+            },
+          },
+        }
+      }
+
+      if (path === '/api/search-profiles/profile-1/status') {
+        return {
+          data: {
+            success: true,
+            status: {
+              profileId: 'profile-1',
+              taskId: 'task-1',
+              taskStatus: 'pending',
+              startedAt: '2026-03-17T00:00:00.000Z',
+              updatedAt: '2026-03-17T00:00:00.000Z',
+            },
+          },
+        }
+      }
+
+      return {
+        data: {
+          success: true,
+        },
+      }
+    })
+
+    postMock.mockResolvedValue({
+      data: {
+        success: true,
+        profileId: 'profile-1',
+        taskId: 'task-1',
+      },
+    })
+
+    render(<SearchProfilesPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Run Job5156 profile' }))
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledWith('/api/search-profiles/profile-1/run', {
+        body: {},
+      })
+    })
+
+    await waitFor(() => {
+      expect(getMock.mock.calls.filter(([path]) => path === '/api/search-profiles/profile-1/status')).toHaveLength(2)
+    })
+    expect(toastSuccessMock).toHaveBeenCalledWith('Profile run started')
+  })
+})

--- a/apps/web/src/pages/SearchProfilesPage.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.tsx
@@ -10,6 +10,12 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { PageHeader } from '@/components/PageHeader'
 import { SearchProfileEditorDialog, type SearchProfileDetails } from '@/components/SearchProfileEditorDialog'
+import {
+  SEARCH_PROFILE_SOURCE_TYPES,
+  buildSeekCollectUrl,
+  getActiveSearchProfileSource,
+  isSeekRecommendedCandidatesUrl,
+} from '@/lib/search-profile-sources'
 
 type ListProfilesResponse = {
   success: boolean
@@ -40,6 +46,8 @@ type ProfileStatusResponse = {
 }
 
 const TERMINAL_STATUSES: Array<SearchProfileRunStatus['taskStatus']> = ['completed', 'failed', 'cancelled', 'unknown']
+const DEFAULT_PROFILE_RUN_LIMIT = 120
+const DEFAULT_PROFILE_RUN_MAX_PAGES = 10
 
 
 
@@ -167,6 +175,26 @@ export function SearchProfilesPage() {
     }, 3000)
   }, [clearPolling, fetchRunStatus])
 
+  const fetchProfileDetail = useCallback(async (profileId: string) => {
+    try {
+      const { data } = await rawApiClient.GET<ProfileResponse>(`/api/search-profiles/${profileId}`)
+      if (!data?.success || !data.profile) {
+        return null
+      }
+
+      const profile = data.profile
+
+      setProfileDetails((previous) => ({
+        ...previous,
+        [profileId]: profile,
+      }))
+      return profile
+    } catch (error) {
+      console.error(`Failed to load profile detail ${profileId}`, error)
+      return null
+    }
+  }, [])
+
   const loadProfiles = useCallback(async () => {
     setLoading(true)
     try {
@@ -180,12 +208,9 @@ export function SearchProfilesPage() {
 
       const detailEntries = await Promise.all(
         nextProfiles.map(async (profile) => {
-          const { data: detailData } = await rawApiClient.GET<ProfileResponse>(`/api/search-profiles/${profile.id}`)
-          if (!detailData?.success || !detailData.profile) {
-            return null
-          }
-          return [profile.id, detailData.profile] as const
-        })
+          const detail = await fetchProfileDetail(profile.id)
+          return detail ? [profile.id, detail] as const : null
+        }),
       )
 
       const nextDetails: Record<string, SearchProfileDetails> = {}
@@ -206,7 +231,7 @@ export function SearchProfilesPage() {
     } finally {
       setLoading(false)
     }
-  }, [fetchRunStatus, t])
+  }, [fetchProfileDetail, fetchRunStatus, t])
 
   useEffect(() => {
     void loadProfiles()
@@ -261,6 +286,39 @@ export function SearchProfilesPage() {
   }, [clearPolling, deletingProfileId, loadProfiles, t])
 
   const handleRunNow = useCallback(async (profileId: string) => {
+    const detail = profileDetails[profileId] ?? await fetchProfileDetail(profileId)
+    if (!detail) {
+      toast.error(t('searchProfiles.loadDetailError', { defaultValue: 'Failed to load profile details' }))
+      return
+    }
+    const activeSource = getActiveSearchProfileSource(detail.sources)
+
+    if (activeSource?.type === SEARCH_PROFILE_SOURCE_TYPES.seek) {
+      if (!isSeekRecommendedCandidatesUrl(activeSource.jobUrl)) {
+        toast.error(t('searchProfiles.seekJobUrlMissing', { defaultValue: 'Seek Run Now requires an exact Seek recommended candidates URL.' }))
+        return
+      }
+
+      const launchUrl = buildSeekCollectUrl({
+        baseUrl: activeSource.jobUrl,
+        location: detail.location,
+        keywords: detail.keywords,
+        collectLimit: detail.schedule?.maxCandidates ?? DEFAULT_PROFILE_RUN_LIMIT,
+        maxPages: DEFAULT_PROFILE_RUN_MAX_PAGES,
+        minAge: detail.filters?.minAge,
+        maxAge: detail.filters?.maxAge,
+      })
+
+      if (!launchUrl) {
+        toast.error(t('searchProfiles.seekRunError', { defaultValue: 'Failed to build Seek launch URL.' }))
+        return
+      }
+
+      window.open(launchUrl, '_blank', 'noopener,noreferrer')
+      toast.success(t('searchProfiles.seekRunSuccess', { defaultValue: 'Opened Seek collection in a new tab' }))
+      return
+    }
+
     setRunningIds((previous) => new Set(previous).add(profileId))
 
     try {
@@ -304,7 +362,7 @@ export function SearchProfilesPage() {
         return next
       })
     }
-  }, [startPolling, t])
+  }, [fetchProfileDetail, profileDetails, startPolling, t])
 
 
 

--- a/packages/convex/convex/__tests__/sessions.test.ts
+++ b/packages/convex/convex/__tests__/sessions.test.ts
@@ -116,6 +116,29 @@ function createSearchHistoryDb(records: SearchHistoryRecord[]) {
           }
         }
 
+        if (tableName === 'industry_db_cohorts') {
+          return {
+            withIndex(indexName, apply) {
+              expect(indexName).toBe('by_workspace')
+              const clause = apply({
+                eq(field, value) {
+                  return { field, value }
+                },
+              }) as { field: string; value: string }
+              expect(clause.field).toBe('workspaceSlug')
+
+              return {
+                async collect() {
+                  return []
+                },
+              }
+            },
+            async collect() {
+              return []
+            },
+          }
+        }
+
         return {
           async collect() {
             return []

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -324,6 +324,7 @@ export default defineSchema({
             location: v.string(),
             keywords: v.array(v.string()),
             jobDescriptionId: v.optional(v.string()),
+            collectUrl: v.optional(v.string()),
             filters: v.optional(v.any()), // Stores ResumeFilters object
         }),
         reviewedResumeIds: v.array(v.string()), // IDs of resumes seen/acted upon
@@ -340,6 +341,7 @@ export default defineSchema({
         location: v.string(),
         keywords: v.array(v.string()),
         jobDescriptionId: v.optional(v.string()),
+        collectUrl: v.optional(v.string()),
         filters: v.optional(v.any()),
         selectedTags: v.optional(v.array(v.string())),
         selectedCompanies: v.optional(v.array(v.string())),

--- a/packages/convex/convex/sessions.ts
+++ b/packages/convex/convex/sessions.ts
@@ -157,6 +157,7 @@ export const saveSession = mutation({
         location: v.string(),
         keywords: v.array(v.string()),
         jobDescriptionId: v.optional(v.string()),
+        collectUrl: v.optional(v.string()),
         filters: v.optional(v.any()),
     },
     handler: async (ctx, args) => {
@@ -175,6 +176,7 @@ export const saveSession = mutation({
                 location: args.location,
                 keywords: args.keywords,
                 jobDescriptionId: args.jobDescriptionId,
+                collectUrl: normalizeOptionalString(args.collectUrl),
                 filters: args.filters,
             },
             workspaceSlug,
@@ -305,6 +307,7 @@ export const saveSearchHistory = mutation({
         location: v.string(),
         keywords: v.array(v.string()),
         jobDescriptionId: v.optional(v.string()),
+        collectUrl: v.optional(v.string()),
         filters: v.optional(v.any()),
         selectedTags: v.optional(v.array(v.string())),
         selectedCompanies: v.optional(v.array(v.string())),
@@ -320,6 +323,7 @@ export const saveSearchHistory = mutation({
         const keywords = normalizeStringList(args.keywords);
         const title = normalizeOptionalString(args.title) ?? buildHistoryTitle(location, keywords);
         const jobDescriptionId = normalizeOptionalString(args.jobDescriptionId);
+        const collectUrl = normalizeOptionalString(args.collectUrl);
         const selectedTags = normalizeStringList(args.selectedTags);
         const selectedCompanies = normalizeStringList(args.selectedCompanies);
         const selectedExperienceLevel = normalizeOptionalString(args.selectedExperienceLevel);
@@ -334,6 +338,7 @@ export const saveSearchHistory = mutation({
             location,
             keywords,
             jobDescriptionId,
+            collectUrl,
             filters: args.filters,
             selectedTags,
             selectedCompanies,

--- a/scripts/e2e-smoke.ts
+++ b/scripts/e2e-smoke.ts
@@ -147,7 +147,7 @@ async function runCollectUrlKeywordModeTest(page: Page) {
 
     expect(openedUrls.length).toBeGreaterThan(0);
     const openedUrl = new URL(openedUrls[0]);
-    expect(`${openedUrl.origin}${openedUrl.pathname}`).toBe('https://hr.job5156.com/search');
+    expect(`${openedUrl.origin}${openedUrl.pathname}`).toBe('https://my.employer.seek.com/candidates/recommended');
     expect(openedUrl.searchParams.get('keyword')).toBe('CNC 车床 销售 STAR');
     expect(openedUrl.searchParams.get('location')).toBe('东莞');
     expect(openedUrl.searchParams.get('tr_auto_sync')).toBe('true');


### PR DESCRIPTION
## Summary
- make Search Profiles source-aware for exact Seek recommended-candidates job URLs and preserve `collectUrl` in session/history
- validate and persist Seek source `jobUrl` through the web/API/Convex flow, and keep worker-backed runs unchanged for non-Seek sources
- fix Seek inline-profile extraction on recommended pages and add targeted regression coverage plus collect-url smoke support

## Validation
- make check
- bun --cwd apps/web test src/hooks/useSession.test.tsx src/components/SearchProfileEditorDialog.test.tsx src/pages/SearchProfilesPage.test.tsx src/lib/search-profile-sources.test.ts
- bunx vitest run apps/api/src/routes/search-profiles.test.ts
- bunx vitest run packages/convex/convex/__tests__/sessions.test.ts
- npm run test:e2e:collect-url
- live DevTools verification on Seek recommended list, inline profile, and direct profile pages after extension reload