### PR TITLE
fix: reset resume search on home navigation

### DIFF
--- a/apps/web/e2e/resume-role-filter.spec.ts
+++ b/apps/web/e2e/resume-role-filter.spec.ts
@@ -116,6 +116,53 @@ async function mockResumePageApis(
     })
   })
 
+  await page.route('**/api/industry/keywords**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        data: [],
+      }),
+    })
+  })
+
+  await page.route('**/api/config/custom-keywords**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        tags: [],
+        systemLocations: [],
+      }),
+    })
+  })
+
+  await page.route('**/api/industry/brands**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        data: [],
+      }),
+    })
+  })
+
+  await page.route('**/api/industry/brand-display-map**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        haas: {
+          displayName: 'Haas',
+          zhHans: '哈斯',
+        },
+      }),
+    })
+  })
+
   await page.route('**/api/search-profiles/auto-match', async (route) => {
     await route.fulfill({
       status: 200,
@@ -323,6 +370,33 @@ const salesResume: MockResume = {
 }
 
 test.describe('Resume quick role filter', () => {
+  test('home navigation clears search state while direct links and legacy redirects still hydrate', async ({ page }) => {
+    await mockResumePageApis(page, {
+      searchResumes: [engineerResume, salesResume],
+    })
+
+    await page.goto('/resumes?location=%E4%B8%9C%E8%8E%9E&keyword=CNC+%E8%BD%A6%E5%BA%8A+%E9%94%80%E5%94%AE+STAR')
+
+    const locationInput = page.getByRole('textbox', { name: '位置' })
+    const keywordInput = page.getByPlaceholder('自定义关键词...')
+
+    await expect(page).toHaveURL(/\/dev\/resumes\?location=.*keyword=/)
+    await expect(locationInput).toHaveValue('东莞')
+    await expect(keywordInput).toHaveValue('CNC 车床 销售 STAR')
+
+    await page.getByRole('link', { name: '趋势 Trends' }).click()
+
+    await expect(page).toHaveURL(/\/dev\/resumes$/)
+    await expect(locationInput).toHaveValue('')
+    await expect(keywordInput).toHaveValue('')
+
+    await page.goBack()
+
+    await expect(page).toHaveURL(/\/dev\/resumes\?location=.*keyword=/)
+    await expect(locationInput).toHaveValue('东莞')
+    await expect(keywordInput).toHaveValue('CNC 车床 销售 STAR')
+  })
+
   test('engineer role filter keeps only engineer-tagged resumes', async ({ page }) => {
     await mockResumePageApis(page, {
       listResumes: [engineerResume, salesResume],
@@ -355,7 +429,7 @@ test.describe('Resume quick role filter', () => {
     await expect(cards.first().getByText('machinery')).toBeVisible()
     await expect(cards.first().getByText('sales')).toBeVisible()
     await expect(page.getByText('工程4年(行业验证)')).toBeVisible()
-    await expect(page.getByText(/哈斯 · project/i)).toBeVisible()
+    await expect(cards.first().getByText('哈斯')).toHaveCount(2)
     await expect(page.getByText(/东莞某设备公司.*销售工程师/)).toBeVisible()
 
     await page.getByRole('button', { name: '查看' }).first().click()
@@ -375,4 +449,3 @@ test.describe('Resume quick role filter', () => {
     await expect(page.getByText('王女士')).toHaveCount(0)
   })
 })
-

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -4,6 +4,7 @@ import { TrendingUp } from 'lucide-react'
 import { LanguageSwitcher } from './LanguageSwitcher'
 import { WorkspaceSwitcher } from './WorkspaceSwitcher'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
+import { RESUME_HOME_RESET_STATE } from '@/lib/resume-home-navigation'
 import { cn } from '@/lib/utils'
 
 interface HeaderProps {
@@ -22,7 +23,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
       <div className="container flex h-14 items-center justify-between gap-4">
         <div className="flex items-center gap-3 sm:gap-6">
           {leftAction}
-          <Link to={resumesPath} className="flex items-center gap-2">
+          <Link to={resumesPath} state={RESUME_HOME_RESET_STATE} className="flex items-center gap-2">
             <TrendingUp className="h-6 w-6 text-primary" />
             <div className="flex items-baseline gap-1">
               <span className="font-bold text-lg">{t('app.title')}</span>
@@ -32,6 +33,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
           <nav className="hidden items-center gap-4 text-sm sm:flex">
             <NavLink
               to={resumesPath}
+              state={RESUME_HOME_RESET_STATE}
               className={({ isActive }) =>
                 cn(
                   'transition-colors hover:text-foreground',
@@ -75,6 +77,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
           <nav className="flex items-center gap-3 text-sm sm:hidden">
             <NavLink
               to={resumesPath}
+              state={RESUME_HOME_RESET_STATE}
               className={({ isActive }) =>
                 cn(
                   'transition-colors hover:text-foreground',

--- a/apps/web/src/components/SettingsSidebar.tsx
+++ b/apps/web/src/components/SettingsSidebar.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { useSystemMetadata } from '@/hooks/useSystemMetadata'
+import { RESUME_HOME_RESET_STATE } from '@/lib/resume-home-navigation'
 import { cn } from '@/lib/utils'
 
 type NavItem = SurfaceNavDefinition & {
@@ -49,7 +50,7 @@ export function SettingsSidebar({ onClose }: SettingsSidebarProps) {
     <div className="flex flex-col h-full bg-muted/30">
       <div className="flex-1 overflow-y-auto py-4">
         <div className="px-5 mb-6 flex items-center justify-between">
-          <Link to={`/${slug}/resumes`} className="flex items-center gap-2">
+          <Link to={`/${slug}/resumes`} state={RESUME_HOME_RESET_STATE} className="flex items-center gap-2">
             <span className="bg-primary text-primary-foreground text-[10px] px-1.5 py-0.5 rounded font-medium">
               {APP_SURFACE_IDENTITY.settingsBadgeLabel}
             </span>
@@ -70,6 +71,7 @@ export function SettingsSidebar({ onClose }: SettingsSidebarProps) {
               <Link
                 key={item.href}
                 to={item.href}
+                state={item.id === 'home' ? RESUME_HOME_RESET_STATE : undefined}
                 onClick={onClose}
                 className={cn(
                   'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors',

--- a/apps/web/src/components/SystemSidebar.tsx
+++ b/apps/web/src/components/SystemSidebar.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { useSystemMetadata } from '@/hooks/useSystemMetadata'
+import { RESUME_HOME_RESET_STATE } from '@/lib/resume-home-navigation'
 import { cn } from '@/lib/utils'
 import { useTranslation } from 'react-i18next'
 
@@ -65,7 +66,7 @@ export function SystemSidebar({ onClose }: SystemSidebarProps) {
     <div className="flex flex-col h-full bg-muted/30">
       <div className="flex-1 overflow-y-auto py-4">
         <div className="px-5 mb-6 flex items-center justify-between">
-          <Link to={`/${slug}/resumes`} className="flex items-center gap-2">
+          <Link to={`/${slug}/resumes`} state={RESUME_HOME_RESET_STATE} className="flex items-center gap-2">
             <span className="bg-primary text-primary-foreground text-[10px] px-1.5 py-0.5 rounded font-medium">
               {APP_SURFACE_IDENTITY.adminBadgeLabel}
             </span>
@@ -86,6 +87,7 @@ export function SystemSidebar({ onClose }: SystemSidebarProps) {
               <Link
                 key={item.href}
                 to={item.href}
+                state={item.id === 'home' ? RESUME_HOME_RESET_STATE : undefined}
                 onClick={onClose}
                 className={cn(
                   'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors',

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMutation, useQuery } from 'convex/react'
 import { isLocationMatch } from '@trends/shared'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
@@ -19,6 +20,7 @@ import {
 } from '@/hooks/useUrlSearchState'
 import { rawApiClient } from '@/lib/api-helpers'
 import type { components } from '@/lib/api-types'
+import { isResumeHomeResetState } from '@/lib/resume-home-navigation'
 import type { SearchHistoryItem } from '@/hooks/useSession'
 import {
   aiFeedbackToActionType,
@@ -360,6 +362,8 @@ function matchesEducationFilter(educationValue: string | undefined, selectedEduc
 
 export function useResumeListState(loadSearchHistory = false) {
   const { t } = useTranslation()
+  const location = useLocation()
+  const navigate = useNavigate()
   const {
     location: sessionLocation,
     setLocation: setSessionLocation,
@@ -1141,16 +1145,45 @@ export function useResumeListState(loadSearchHistory = false) {
     )
   }, [displayedResumes])
 
-  const handleResetAll = useCallback(() => {
+  const resetResumeSearchState = useCallback(() => {
     setAppliedSearchHistoryId(undefined)
-    setSessionLocation('')
-    setSessionKeywords([])
-    setJobDescriptionId('')
-    setFilters({})
+    applyExternalState({
+      location: '',
+      keywords: [],
+      jobDescriptionId: '',
+      filters: {},
+    })
     setSelectedTags([])
     setSelectedCompanies([])
     setSelectedExperienceLevel(undefined)
-  }, [setSessionLocation, setSessionKeywords, setJobDescriptionId, setFilters, setSelectedTags, setSelectedCompanies, setSelectedExperienceLevel])
+  }, [applyExternalState])
+
+  useEffect(() => {
+    if (!isResumeHomeResetState(location.state)) {
+      return
+    }
+
+    skipNextUrlSyncRef.current = true
+    isUrlPushingRef.current = false
+    hasInitializedUrlHydrationRef.current = true
+    lastAppliedUrlStateRef.current = null
+    setHasCompletedUrlHydration(true)
+    resetResumeSearchState()
+
+    navigate(
+      {
+        pathname: location.pathname,
+        search: '',
+        hash: location.hash,
+      },
+      {
+        replace: true,
+        state: null,
+      }
+    )
+  }, [location.hash, location.pathname, location.state, navigate, resetResumeSearchState])
+
+  const handleResetAll = resetResumeSearchState
 
   const handleClearSelection = useCallback(() => {
     setSelectedIds(new Set())

--- a/apps/web/src/lib/resume-home-navigation.ts
+++ b/apps/web/src/lib/resume-home-navigation.ts
@@ -1,0 +1,10 @@
+export const RESUME_HOME_RESET_STATE: { readonly resetResumeSearch: true } = {
+  resetResumeSearch: true,
+}
+
+export function isResumeHomeResetState(value: unknown): value is { resetResumeSearch: true } {
+  return typeof value === 'object'
+    && value !== null
+    && 'resetResumeSearch' in value
+    && value.resetResumeSearch === true
+}


### PR DESCRIPTION
## Summary
- add an explicit resume-home reset navigation state for in-app home/resume links
- consume that reset state in the resumes hook before URL sync can restore stale search params
- add browser regression coverage for home reset, legacy redirect hydration, and current resume evidence mocks

## Testing
- make check
- npm --workspace @trends/web run test:e2e:resume-role-filter