### PR TITLE
Add seeded SEEK Malaysia resume fixture

### DIFF
--- a/apps/api/src/services/resume-service.test.ts
+++ b/apps/api/src/services/resume-service.test.ts
@@ -97,6 +97,41 @@ describe("ResumeService", () => {
     expect(items[0]?.profileUrl).toBe("https://hk.employer.seek.com/candidates/503033454");
   });
 
+  it("loads the checked-in SEEK Malaysia sample with searchable Kuala Lumpur fields", () => {
+    const root = createFixtureRoot();
+    roots.push(root);
+
+    const sourcePath = path.resolve(
+      process.cwd(),
+      "output",
+      "resumes",
+      "samples",
+      "sample-seek-malaysia-sales.json"
+    );
+    const samplePath = path.join(
+      root,
+      "output",
+      "resumes",
+      "samples",
+      "sample-seek-malaysia-sales.json"
+    );
+    fs.copyFileSync(sourcePath, samplePath);
+
+    const service = new ResumeService(root);
+    const { items, metadata, indexes } = service.loadSample("sample-seek-malaysia-sales");
+    const salesMatches = service.searchResumes(items, "Sales Engineer", indexes);
+    const locationMatches = service.filterResumes(items, {
+      locations: ["Kuala Lumpur MY"],
+    });
+
+    expect(metadata?.sourceHost).toBe("my.employer.seek.com");
+    expect(items[0]?.profileUrl).toBe("https://my.employer.seek.com/candidates/503033454");
+    expect(items[0]?.location).toBe("Kuala Lumpur, Malaysia");
+    expect(items[0]?.ingestData?.industryTags).toEqual(["machinery", "sales"]);
+    expect(salesMatches.map((item) => item.name)).toEqual(["Yap Kae Wen"]);
+    expect(locationMatches.map((item) => item.name)).toEqual(["Yap Kae Wen"]);
+  });
+
   it("still normalizes Job5156 sample profile URLs into canonical display URLs", () => {
     const root = createFixtureRoot();
     roots.push(root);

--- a/output/resumes/samples/sample-seek-malaysia-sales.json
+++ b/output/resumes/samples/sample-seek-malaysia-sales.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "sourceHost": "my.employer.seek.com",
+    "sourceKey": "seek",
+    "sourceUrl": "https://my.employer.seek.com/candidates/recommended?keyword=Sales%20Engineer%20Sales%20Manager&location=Kuala%20Lumpur%20MY",
+    "searchCriteria": {
+      "keyword": "Sales Engineer Sales Manager",
+      "location": "Kuala Lumpur MY",
+      "filters": {
+        "maxAge": "45",
+        "minExperience": "2"
+      }
+    },
+    "generatedAt": "2026-03-17T08:00:00.000Z",
+    "generatedBy": "browser-extension@1.1.1",
+    "totalPages": 1,
+    "totalResumes": 1,
+    "reproduction": "Open the SEEK Malaysia recommended candidates page, then export structured JSON from the browser extension."
+  },
+  "data": [
+    {
+      "externalId": "my.employer.seek.com:profile:503033454",
+      "profileId": "503033454",
+      "profileType": "seek",
+      "name": "Yap Kae Wen",
+      "profileUrl": "https://my.employer.seek.com/candidates/503033454",
+      "activityStatus": "Updated recently",
+      "age": "32",
+      "experience": "9 years",
+      "education": "Bachelor of Engineering",
+      "location": "Kuala Lumpur, Malaysia",
+      "selfIntro": "Malaysia-based sales engineer covering CNC machine tools, channel partners, and key accounts.",
+      "jobIntention": "Sales Engineer / Sales Manager",
+      "desiredPosition": "Sales Engineer / Sales Manager",
+      "expectedSalary": "MYR 8,000 - MYR 12,000",
+      "summary": "Sales Engineer / Sales Manager for CNC machine tools with Kuala Lumpur coverage and nationwide Malaysia accounts.",
+      "companies": [
+        "Precision Machines Malaysia Sdn Bhd",
+        "STAR Micronics Asia"
+      ],
+      "workHistory": [
+        {
+          "raw": "2021-04~Present Precision Machines Malaysia Sdn Bhd Senior Sales Engineer\nHandled CNC machine tool sales, distributor development, and Kuala Lumpur key accounts.",
+          "companyName": "Precision Machines Malaysia Sdn Bhd",
+          "jobTitle": "Senior Sales Engineer",
+          "startDate": "2021-04",
+          "endDate": "Present",
+          "description": "Handled CNC machine tool sales, distributor development, and Kuala Lumpur key accounts across Malaysia."
+        },
+        {
+          "raw": "2017-01~2021-03 STAR Micronics Asia Regional Sales Executive\nSold STAR sliding headstock lathes and automation solutions across Malaysia.",
+          "companyName": "STAR Micronics Asia",
+          "jobTitle": "Regional Sales Executive",
+          "startDate": "2017-01",
+          "endDate": "2021-03",
+          "description": "Sold STAR sliding headstock lathes and automation solutions across Malaysia."
+        }
+      ],
+      "profileEducation": [
+        {
+          "institution": "Universiti Malaya",
+          "qualification": "Bachelor of Engineering"
+        }
+      ],
+      "skills": [
+        "Sales Engineer",
+        "Sales Manager",
+        "CNC",
+        "machine tools",
+        "account management",
+        {
+          "name": "Key account management",
+          "yearsOfExperience": 6
+        },
+        {
+          "name": "Dealer channel development",
+          "yearsOfExperience": 4
+        }
+      ],
+      "languages": [
+        "English",
+        {
+          "name": "Mandarin",
+          "proficiency": "professional"
+        },
+        {
+          "name": "Bahasa Melayu",
+          "proficiency": "professional"
+        }
+      ],
+      "licences": [
+        {
+          "name": "Class D"
+        }
+      ],
+      "resumeSnippet": {
+        "text": "Kuala Lumpur based CNC sales engineer covering Malaysia machine tool accounts."
+      },
+      "currentIndustry": {
+        "name": "Industrial machinery"
+      },
+      "currentSubindustry": "Machine tools",
+      "rightToWork": {
+        "status": "citizen",
+        "details": "Eligible to work in Malaysia without sponsorship."
+      },
+      "digitalIdentity": {
+        "linkedinUrl": "https://www.linkedin.com/in/yap-kae-wen"
+      },
+      "noticePeriodDays": 30,
+      "ingestData": {
+        "industryTags": [
+          "machinery",
+          "sales"
+        ],
+        "synonymHits": [
+          "Sales Engineer",
+          "Sales Manager",
+          "machine tools",
+          "account management",
+          "Kuala Lumpur",
+          "Malaysia"
+        ],
+        "brandHits": [
+          {
+            "brand": "STAR",
+            "role": "sales engineer",
+            "source": "workHistory",
+            "context": "Sold STAR sliding headstock lathes and automation solutions across Malaysia."
+          }
+        ],
+        "companyHits": [
+          "Precision Machines Malaysia Sdn Bhd",
+          "STAR Micronics Asia"
+        ],
+        "roleSignals": [
+          {
+            "type": "sales",
+            "matchedSignals": [
+              "sales engineer",
+              "sales manager",
+              "account management",
+              "machine tools",
+              "cnc"
+            ],
+            "years": 6,
+            "industryVerifiedYears": 6,
+            "roleRelevantYears": 6,
+            "industryVerifiedRelevantYears": 6,
+            "matchedWorkEntries": [
+              {
+                "companyName": "Precision Machines Malaysia Sdn Bhd",
+                "jobTitle": "Senior Sales Engineer",
+                "years": 4,
+                "industryVerified": true,
+                "matchedSignals": [
+                  "sales engineer",
+                  "machine tools",
+                  "cnc"
+                ]
+              },
+              {
+                "companyName": "STAR Micronics Asia",
+                "jobTitle": "Regional Sales Executive",
+                "years": 4,
+                "industryVerified": true,
+                "matchedSignals": [
+                  "sales manager",
+                  "account management",
+                  "machine tools"
+                ]
+              }
+            ]
+          }
+        ],
+        "ruleScores": {
+          "seek-malaysia-sales": 86,
+          "jd-seek-malaysia-sales": 86
+        },
+        "experienceLevel": "senior",
+        "computedAt": 1762000000000,
+        "skillsVersion": 2
+      },
+      "extractedAt": "2026-03-17T08:00:00.000Z"
+    }
+  ]
+}

--- a/packages/convex/convex/__tests__/seed-workspace-demo-data.test.ts
+++ b/packages/convex/convex/__tests__/seed-workspace-demo-data.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it } from 'vitest'
+
+import { seedWorkspaceDemoData } from '../seed'
+
+type WorkspaceSeedResult = {
+  customJobDescriptions: {
+    inserted: number
+    updated: number
+  }
+  searchProfiles: {
+    inserted: number
+    updated: number
+  }
+  screeningSessions: {
+    inserted: number
+    updated: number
+  }
+  searchHistory: {
+    inserted: number
+    updated: number
+  }
+  workspaceConfig: {
+    inserted: number
+    updated: number
+  }
+  resumes: {
+    inserted: number
+    updated: number
+  }
+}
+
+type ConvexHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+type RecordWithId = {
+  _id: string
+}
+
+type JobDescriptionRecord = RecordWithId & {
+  title: string
+  slug?: string
+  content: string
+  type: string
+  workspaceSlug?: string
+  location?: string
+  industryTags?: string[]
+  customKeywords?: string[]
+  minExperience?: number
+  maxAge?: number
+  enabled: boolean
+  lastModified: number
+}
+
+type SearchProfileRecord = RecordWithId & {
+  name: string
+  criteria: Record<string, unknown>
+  profile?: Record<string, unknown>
+  workspaceSlug?: string
+  lastRunAt?: number
+}
+
+type ScreeningSessionRecord = RecordWithId & {
+  sessionKey: string
+  status: string
+  config: Record<string, unknown>
+  reviewedResumeIds: string[]
+  workspaceSlug?: string
+  lastActive: number
+}
+
+type SearchHistoryRecord = RecordWithId & {
+  sessionKey: string
+  title: string
+  location: string
+  keywords: string[]
+  jobDescriptionId?: string
+  filters?: Record<string, unknown>
+  selectedTags?: string[]
+  selectedCompanies?: string[]
+  selectedExperienceLevel?: string
+  workspaceSlug?: string
+  createdAt: number
+  lastOpenedAt: number
+}
+
+type WorkspaceConfigRecord = RecordWithId & {
+  workspaceSlug: string
+  configKey: string
+  configValue: Record<string, unknown>
+  updatedAt: number
+}
+
+type ResumeRecord = RecordWithId & {
+  externalId: string
+  identityKey?: string
+  content: Record<string, unknown>
+  hash: string
+  source: string
+  tags: string[]
+  crawledAt: number
+  ingestData?: Record<string, unknown>
+  primaryRuleScore?: number
+  searchText?: string
+}
+
+type SeedTables = {
+  job_descriptions: JobDescriptionRecord[]
+  search_profiles: SearchProfileRecord[]
+  screening_sessions: ScreeningSessionRecord[]
+  search_history: SearchHistoryRecord[]
+  workspace_config: WorkspaceConfigRecord[]
+  resumes: ResumeRecord[]
+}
+
+type SupportedTable = keyof SeedTables
+
+const seedWorkspaceDemoDataHandler = (seedWorkspaceDemoData as unknown as ConvexHandler<
+  Record<string, never>,
+  WorkspaceSeedResult
+>)._handler
+
+function createEqChain(clauses: Array<{ field: string; value: string }>) {
+  return {
+    eq(field: string, value: string) {
+      clauses.push({ field, value })
+      return this
+    },
+  }
+}
+
+function createSeedCtx() {
+  const tables: SeedTables = {
+    job_descriptions: [],
+    search_profiles: [],
+    screening_sessions: [],
+    search_history: [],
+    workspace_config: [],
+    resumes: [],
+  }
+  let nextId = 1
+
+  function allocateId(tableName: SupportedTable): string {
+    const next = `${tableName}-${nextId}`
+    nextId += 1
+    return next
+  }
+
+  function patchRecord<T extends RecordWithId>(records: T[], id: string, patch: Partial<T>): void {
+    const record = records.find((entry) => entry._id === id)
+    if (record) {
+      Object.assign(record, patch)
+    }
+  }
+
+  const ctx = {
+    db: {
+      query(tableName: SupportedTable) {
+        if (tableName === 'job_descriptions') {
+          return {
+            filter(
+              apply: (q: {
+                eq: (left: unknown, right: unknown) => { left: unknown; right: unknown }
+                field: (name: string) => string
+              }) => { left: unknown; right: unknown }
+            ) {
+              const clause = apply({
+                eq(left, right) {
+                  return { left, right }
+                },
+                field(name) {
+                  return name
+                },
+              })
+
+              return {
+                async collect() {
+                  if (clause.left === 'type' && clause.right === 'custom') {
+                    return tables.job_descriptions.filter((item) => item.type === 'custom')
+                  }
+                  return []
+                },
+              }
+            },
+            async collect() {
+              return tables.job_descriptions
+            },
+          }
+        }
+
+        if (tableName === 'search_profiles') {
+          return {
+            async collect() {
+              return tables.search_profiles
+            },
+          }
+        }
+
+        if (tableName === 'screening_sessions') {
+          return {
+            async collect() {
+              return tables.screening_sessions
+            },
+          }
+        }
+
+        if (tableName === 'search_history') {
+          return {
+            async collect() {
+              return tables.search_history
+            },
+          }
+        }
+
+        if (tableName === 'workspace_config') {
+          return {
+            withIndex(
+              indexName: string,
+              apply: (q: { eq: (field: string, value: string) => { eq: (field: string, value: string) => unknown } }) => unknown
+            ) {
+              expect(indexName).toBe('by_workspace_key')
+              const clauses: Array<{ field: string; value: string }> = []
+              apply(createEqChain(clauses))
+
+              return {
+                async unique() {
+                  return tables.workspace_config.find((item) =>
+                    clauses.every((clause) => {
+                      if (clause.field === 'workspaceSlug') {
+                        return item.workspaceSlug === clause.value
+                      }
+                      if (clause.field === 'configKey') {
+                        return item.configKey === clause.value
+                      }
+                      return false
+                    })
+                  ) ?? null
+                },
+              }
+            },
+          }
+        }
+
+        return {
+          withIndex(
+            indexName: string,
+            apply: (q: { eq: (field: string, value: string) => { eq: (field: string, value: string) => unknown } }) => unknown
+          ) {
+            const clauses: Array<{ field: string; value: string }> = []
+            apply(createEqChain(clauses))
+
+            return {
+              async unique() {
+                if (tableName !== 'resumes') {
+                  return null
+                }
+
+                if (indexName === 'by_identityKey') {
+                  const identity = clauses.find((clause) => clause.field === 'identityKey')?.value
+                  return tables.resumes.find((item) => item.identityKey === identity) ?? null
+                }
+
+                if (indexName === 'by_externalId') {
+                  const externalId = clauses.find((clause) => clause.field === 'externalId')?.value
+                  return tables.resumes.find((item) => item.externalId === externalId) ?? null
+                }
+
+                return null
+              },
+            }
+          },
+          async collect() {
+            return tables.resumes
+          },
+        }
+      },
+      async insert<T extends SupportedTable>(
+        tableName: T,
+        value: Omit<SeedTables[T][number], '_id'>
+      ) {
+        const record = {
+          ...value,
+          _id: allocateId(tableName),
+        } as SeedTables[T][number]
+        switch (tableName) {
+          case 'job_descriptions':
+            tables.job_descriptions.push(record as JobDescriptionRecord)
+            break
+          case 'search_profiles':
+            tables.search_profiles.push(record as SearchProfileRecord)
+            break
+          case 'screening_sessions':
+            tables.screening_sessions.push(record as ScreeningSessionRecord)
+            break
+          case 'search_history':
+            tables.search_history.push(record as SearchHistoryRecord)
+            break
+          case 'workspace_config':
+            tables.workspace_config.push(record as WorkspaceConfigRecord)
+            break
+          case 'resumes':
+            tables.resumes.push(record as ResumeRecord)
+            break
+        }
+        return record._id
+      },
+      async patch(id: string, patch: Partial<JobDescriptionRecord | SearchProfileRecord | ScreeningSessionRecord | SearchHistoryRecord | WorkspaceConfigRecord | ResumeRecord>) {
+        patchRecord(tables.job_descriptions, id, patch as Partial<JobDescriptionRecord>)
+        patchRecord(tables.search_profiles, id, patch as Partial<SearchProfileRecord>)
+        patchRecord(tables.screening_sessions, id, patch as Partial<ScreeningSessionRecord>)
+        patchRecord(tables.search_history, id, patch as Partial<SearchHistoryRecord>)
+        patchRecord(tables.workspace_config, id, patch as Partial<WorkspaceConfigRecord>)
+        patchRecord(tables.resumes, id, patch as Partial<ResumeRecord>)
+      },
+    },
+  }
+
+  return { ctx, tables }
+}
+
+describe('seedWorkspaceDemoData', () => {
+  it('seeds one deterministic SEEK Malaysia resume and stays idempotent on rerun', async () => {
+    const { ctx, tables } = createSeedCtx()
+
+    const firstRun = await seedWorkspaceDemoDataHandler(ctx as never, {})
+
+    expect(firstRun.resumes).toEqual({ inserted: 1, updated: 0 })
+    expect(tables.resumes).toHaveLength(1)
+    expect(tables.resumes[0]).toEqual(expect.objectContaining({
+      externalId: 'my.employer.seek.com:profile:503033454',
+      identityKey: 'profileUrl:my.employer.seek.com/candidates/503033454',
+      source: 'my.employer.seek.com',
+      primaryRuleScore: 86,
+    }))
+    expect(tables.resumes[0]?.content).toEqual(expect.objectContaining({
+      name: 'Yap Kae Wen',
+      location: 'Kuala Lumpur, Malaysia',
+      jobIntention: 'Sales Engineer / Sales Manager',
+    }))
+    expect(tables.resumes[0]?.searchText).toContain('sales engineer')
+    expect(tables.resumes[0]?.searchText).toContain('kuala lumpur')
+    expect(tables.resumes[0]?.ingestData).toEqual(expect.objectContaining({
+      industryTags: ['machinery', 'sales'],
+      companyHits: ['Precision Machines Malaysia Sdn Bhd', 'STAR Micronics Asia'],
+      experienceLevel: 'senior',
+      ruleScores: expect.objectContaining({
+        'seek-malaysia-sales': 86,
+      }),
+    }))
+
+    const secondRun = await seedWorkspaceDemoDataHandler(ctx as never, {})
+
+    expect(secondRun.resumes).toEqual({ inserted: 0, updated: 0 })
+    expect(tables.resumes).toHaveLength(1)
+  })
+})

--- a/packages/convex/convex/seed.ts
+++ b/packages/convex/convex/seed.ts
@@ -2,8 +2,11 @@ import { mutation, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { v } from "convex/values";
-import { generateStructuredJobDescriptionContent } from "@trends/shared";
-import { buildSearchText } from "./search_text";
+import {
+  buildWorkHistoryEvidence,
+  generateStructuredJobDescriptionContent,
+} from "@trends/shared";
+import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
 import { deriveResumeIdentity } from "./lib/resume_identity";
 
 import { DEFAULT_WORKSPACE_SLUG } from "./sessions";
@@ -57,6 +60,199 @@ function stableSerialize(value: unknown): string {
   }
 
   return JSON.stringify(value);
+}
+
+function stableHash(seed: string): string {
+  let hash = 2166136261;
+  for (const char of seed) {
+    hash ^= char.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16);
+}
+
+function buildSeekMalaysiaSalesDemoResume(seededAt: number) {
+  const externalId = "my.employer.seek.com:profile:503033454";
+  const source = "my.employer.seek.com";
+  const content = {
+    externalId,
+    profileId: "503033454",
+    profileType: "seek",
+    name: "Yap Kae Wen",
+    profileUrl: "https://my.employer.seek.com/candidates/503033454",
+    activityStatus: "Updated recently",
+    age: "32",
+    experience: "9 years",
+    education: "Bachelor of Engineering",
+    location: "Kuala Lumpur, Malaysia",
+    selfIntro:
+      "Malaysia-based sales engineer covering CNC machine tools, channel partners, and key accounts.",
+    jobIntention: "Sales Engineer / Sales Manager",
+    desiredPosition: "Sales Engineer / Sales Manager",
+    expectedSalary: "MYR 8,000 - MYR 12,000",
+    summary:
+      "Sales Engineer / Sales Manager for CNC machine tools with Kuala Lumpur coverage and nationwide Malaysia accounts.",
+    companies: [
+      "Precision Machines Malaysia Sdn Bhd",
+      "STAR Micronics Asia",
+    ],
+    workHistory: [
+      {
+        raw: "2021-04~Present Precision Machines Malaysia Sdn Bhd Senior Sales Engineer\nHandled CNC machine tool sales, distributor development, and Kuala Lumpur key accounts.",
+        companyName: "Precision Machines Malaysia Sdn Bhd",
+        jobTitle: "Senior Sales Engineer",
+        startDate: "2021-04",
+        endDate: "Present",
+        description:
+          "Handled CNC machine tool sales, distributor development, and Kuala Lumpur key accounts across Malaysia.",
+      },
+      {
+        raw: "2017-01~2021-03 STAR Micronics Asia Regional Sales Executive\nSold STAR sliding headstock lathes and automation solutions across Malaysia.",
+        companyName: "STAR Micronics Asia",
+        jobTitle: "Regional Sales Executive",
+        startDate: "2017-01",
+        endDate: "2021-03",
+        description:
+          "Sold STAR sliding headstock lathes and automation solutions across Malaysia.",
+      },
+    ],
+    profileEducation: [
+      {
+        institution: "Universiti Malaya",
+        qualification: "Bachelor of Engineering",
+      },
+    ],
+    skills: [
+      "Sales Engineer",
+      "Sales Manager",
+      "CNC",
+      "machine tools",
+      "account management",
+      { name: "Key account management", yearsOfExperience: 6 },
+      { name: "Dealer channel development", yearsOfExperience: 4 },
+    ],
+    languages: [
+      "English",
+      { name: "Mandarin", proficiency: "professional" },
+      { name: "Bahasa Melayu", proficiency: "professional" },
+    ],
+    licences: [{ name: "Class D" }],
+    resumeSnippet: {
+      text: "Kuala Lumpur based CNC sales engineer covering Malaysia machine tool accounts.",
+    },
+    currentIndustry: { name: "Industrial machinery" },
+    currentSubindustry: "Machine tools",
+    rightToWork: {
+      status: "citizen",
+      details: "Eligible to work in Malaysia without sponsorship.",
+    },
+    digitalIdentity: {
+      linkedinUrl: "https://www.linkedin.com/in/yap-kae-wen",
+    },
+    noticePeriodDays: 30,
+    extractedAt: "2026-03-17T08:00:00.000Z",
+  };
+  const evidenceText = buildWorkHistoryEvidence(content.workHistory).text;
+  const ingestData = {
+    evidenceText,
+    industryTags: ["machinery", "sales"],
+    synonymHits: [
+      "Sales Engineer",
+      "Sales Manager",
+      "machine tools",
+      "account management",
+      "Kuala Lumpur",
+      "Malaysia",
+    ],
+    brandHits: [
+      {
+        brand: "STAR",
+        role: "sales engineer",
+        source: "workHistory",
+        context: "Sold STAR sliding headstock lathes and automation solutions across Malaysia.",
+      },
+    ],
+    companyHits: [
+      "Precision Machines Malaysia Sdn Bhd",
+      "STAR Micronics Asia",
+    ],
+    roleSignals: [
+      {
+        type: "sales",
+        matchedSignals: [
+          "sales engineer",
+          "sales manager",
+          "account management",
+          "machine tools",
+          "cnc",
+        ],
+        signalCount: 5,
+        occurrences: 5,
+        years: 6,
+        industryVerifiedYears: 6,
+        roleRelevantYears: 6,
+        industryVerifiedRelevantYears: 6,
+        matchedWorkEntries: [
+          {
+            companyName: "Precision Machines Malaysia Sdn Bhd",
+            jobTitle: "Senior Sales Engineer",
+            years: 4,
+            industryVerified: true,
+            matchedSignals: [
+              "sales engineer",
+              "machine tools",
+              "cnc",
+            ],
+          },
+          {
+            companyName: "STAR Micronics Asia",
+            jobTitle: "Regional Sales Executive",
+            years: 4,
+            industryVerified: true,
+            matchedSignals: [
+              "sales manager",
+              "account management",
+              "machine tools",
+            ],
+          },
+        ],
+        verifyIn: "workHistory",
+      },
+    ],
+    ruleScores: {
+      "seek-malaysia-sales": 86,
+      "jd-seek-malaysia-sales": 86,
+    },
+    experienceLevel: "senior",
+    computedAt: seededAt,
+    skillsVersion: 2,
+  };
+  const searchText = mergeSearchTextWithIngestData(buildSearchText(content), {
+    industryTags: ingestData.industryTags,
+    synonymHits: ingestData.synonymHits,
+    brandHits: ingestData.brandHits,
+    companyHits: ingestData.companyHits,
+  });
+
+  return {
+    externalId,
+    source,
+    tags: ["seed", "workspace-demo", "seek-malaysia-sales"],
+    content,
+    hash: stableHash(
+      stableSerialize({
+        externalId,
+        source,
+        content,
+        ingestData,
+        primaryRuleScore: 86,
+      }),
+    ),
+    searchText,
+    ingestData,
+    primaryRuleScore: 86,
+    crawledAt: seededAt - 15_000,
+  };
 }
 
 export const status = query({
@@ -612,6 +808,7 @@ export const seedWorkspaceDemoData = mutation({
       screeningSessions: { inserted: 0, updated: 0 },
       searchHistory: { inserted: 0, updated: 0 },
       workspaceConfig: { inserted: 0, updated: 0 },
+      resumes: { inserted: 0, updated: 0 },
     };
 
     const existingCustomJds = await ctx.db
@@ -866,6 +1063,75 @@ export const seedWorkspaceDemoData = mutation({
         updatedAt: seededAt,
       });
       result.workspaceConfig.inserted += 1;
+    }
+
+    const demoResumes = [buildSeekMalaysiaSalesDemoResume(seededAt)];
+    for (const item of demoResumes) {
+      const identity = deriveResumeIdentity({
+        content: item.content,
+        externalId: item.externalId,
+        source: item.source,
+      });
+      let existing = await ctx.db
+        .query("resumes")
+        .withIndex("by_identityKey", (q) =>
+          q.eq("identityKey", identity.identityKey),
+        )
+        .unique();
+      if (!existing) {
+        existing = await ctx.db
+          .query("resumes")
+          .withIndex("by_externalId", (q) =>
+            q.eq("externalId", item.externalId),
+          )
+          .unique();
+      }
+
+      if (existing) {
+        const nextTags = Array.from(new Set([...existing.tags, ...item.tags]));
+        const needsUpdate =
+          existing.identityKey !== identity.identityKey ||
+          existing.externalId !== item.externalId ||
+          existing.source !== item.source ||
+          existing.hash !== item.hash ||
+          stableSerialize(existing.content) !== stableSerialize(item.content) ||
+          stableSerialize(existing.tags) !== stableSerialize(nextTags) ||
+          stableSerialize(existing.ingestData ?? {}) !==
+            stableSerialize(item.ingestData) ||
+          existing.primaryRuleScore !== item.primaryRuleScore ||
+          existing.searchText !== item.searchText ||
+          existing.crawledAt !== item.crawledAt;
+        if (needsUpdate) {
+          await ctx.db.patch(existing._id, {
+            identityKey: identity.identityKey,
+            externalId: item.externalId,
+            content: item.content,
+            hash: item.hash,
+            source: item.source,
+            tags: nextTags,
+            crawledAt: item.crawledAt,
+            ingestData: item.ingestData,
+            primaryRuleScore: item.primaryRuleScore,
+            searchText: item.searchText,
+          });
+          result.resumes.updated += 1;
+        }
+        continue;
+      }
+
+      await ctx.db.insert("resumes", {
+        externalId: item.externalId,
+        identityKey: identity.identityKey,
+        content: item.content,
+        hash: item.hash,
+        source: item.source,
+        tags: item.tags,
+        crawledAt: item.crawledAt,
+        ingestData: item.ingestData,
+        primaryRuleScore: item.primaryRuleScore,
+        searchText: item.searchText,
+      });
+      result.resumes.inserted += 1;
     }
 
     return result;

--- a/scripts/seed-convex.ts
+++ b/scripts/seed-convex.ts
@@ -64,6 +64,10 @@ type WorkspaceSeedResult = {
     inserted: number;
     updated: number;
   };
+  resumes: {
+    inserted: number;
+    updated: number;
+  };
 };
 
 type CliOptions = {
@@ -546,7 +550,8 @@ async function main(): Promise<void> {
     + ` profiles(inserted=${workspaceSeedResult.searchProfiles.inserted}, updated=${workspaceSeedResult.searchProfiles.updated}),`
     + ` sessions(inserted=${workspaceSeedResult.screeningSessions.inserted}, updated=${workspaceSeedResult.screeningSessions.updated}),`
     + ` history(inserted=${workspaceSeedResult.searchHistory.inserted}, updated=${workspaceSeedResult.searchHistory.updated}),`
-    + ` workspaceConfig(inserted=${workspaceSeedResult.workspaceConfig.inserted}, updated=${workspaceSeedResult.workspaceConfig.updated})`
+    + ` workspaceConfig(inserted=${workspaceSeedResult.workspaceConfig.inserted}, updated=${workspaceSeedResult.workspaceConfig.updated}),`
+    + ` resumes(inserted=${workspaceSeedResult.resumes.inserted}, updated=${workspaceSeedResult.resumes.updated})`
   );
 
   if (options.withResumes) {


### PR DESCRIPTION
## Summary
- seed a deterministic SEEK Malaysia sales resume in Convex workspace demo data so `make seed-force` produces a live candidate
- add an aligned checked-in SEEK Malaysia sample fixture and focused API/Convex coverage
- surface seeded resume counts in `scripts/seed-convex.ts` output for easier local verification

## Testing
- bunx vitest run apps/api/src/services/resume-service.test.ts packages/convex/convex/__tests__/seed-workspace-demo-data.test.ts
- make seed-clear && make seed-force
- bunx playwright test --config apps/web/playwright.config.ts apps/web/e2e/resume-role-filter.spec.ts --grep "SEEK Malaysia workflow"
- make check
