### PR TITLE
Prefer exact SEEK profile collect URLs

### DIFF
--- a/apps/web/e2e/resume-role-filter.spec.ts
+++ b/apps/web/e2e/resume-role-filter.spec.ts
@@ -507,7 +507,7 @@ test.describe('Resume quick role filter', () => {
                 type: 'seek',
                 enabled: true,
                 priority: 1,
-                jobUrl: 'https://my.employer.seek.com/candidates/recommended?keyword=Sales%20Engineer%20Sales%20Manager&location=Kuala%20Lumpur%20MY',
+                jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
               },
             ],
           },
@@ -546,8 +546,83 @@ test.describe('Resume quick role filter', () => {
 
     const openedUrl = await page.evaluate(() => (window as Window & { __trOpenedUrls?: string[] }).__trOpenedUrls?.[0] ?? '')
     const collectUrl = new URL(openedUrl)
-    expect(collectUrl.searchParams.get('location')).toBe('Kuala Lumpur MY')
-    expect(collectUrl.searchParams.get('keyword')).toBe('Sales Engineer Sales Manager')
+    expect(collectUrl.searchParams.get('jobId')).toBe('90842915')
+    expect(collectUrl.searchParams.get('pageNumber')).toBe('1')
     expect(collectUrl.searchParams.get('tr_auto_sync')).toBe('true')
+  })
+
+  test('SEEK auto-match prefers the profile jobUrl for collect on raw query pages', async ({ page }) => {
+    await mockResumePageApis(page, {
+      searchResumes: [],
+    })
+
+    await page.route('**/api/search-profiles/auto-match', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          profileId: 'seek-malaysia-sales',
+          confidence: 0.95,
+          matchedKeywords: ['Sales Engineer', 'Sales Manager'],
+        }),
+      })
+    })
+
+    await page.route('**/api/search-profiles/seek-malaysia-sales', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          profile: {
+            id: 'seek-malaysia-sales',
+            name: 'SEEK Malaysia Sales Engineer / Sales Manager',
+            status: 'active',
+            location: 'Kuala Lumpur MY',
+            keywords: ['Sales Engineer', 'Sales Manager'],
+            jobDescription: 'seek-malaysia-sales',
+            filters: {
+              minExperience: 2,
+              maxAge: 45,
+              locations: ['Kuala Lumpur MY'],
+            },
+            sources: [
+              {
+                type: 'seek',
+                enabled: true,
+                priority: 1,
+                jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+              },
+            ],
+          },
+        }),
+      })
+    })
+
+    await page.goto('/dev/resumes?location=Kuala+Lumpur+MY&keyword=Sales+Engineer+Manager')
+    await expect(page.getByText('SEEK Malaysia Sales Engineer / Sales Manager')).toBeVisible()
+
+    await page.evaluate(() => {
+      const openedUrls: string[] = []
+      ;(window as Window & { __trOpenedUrls?: string[] }).__trOpenedUrls = openedUrls
+      window.open = ((url?: string | URL) => {
+        openedUrls.push(String(url))
+        return null
+      }) as typeof window.open
+    })
+
+    await page.getByRole('button', { name: '采集' }).click()
+
+    await expect.poll(async () => {
+      return await page.evaluate(() => (window as Window & { __trOpenedUrls?: string[] }).__trOpenedUrls?.[0] ?? null)
+    }).toContain('https://my.employer.seek.com/candidates/recommended')
+
+    const openedUrl = await page.evaluate(() => (window as Window & { __trOpenedUrls?: string[] }).__trOpenedUrls?.[0] ?? '')
+    const collectUrl = new URL(openedUrl as string)
+    expect(collectUrl.searchParams.get('jobId')).toBe('90842915')
+    expect(collectUrl.searchParams.get('pageNumber')).toBe('1')
+    expect(collectUrl.searchParams.get('tr_auto_sync')).toBe('true')
+    expect(collectUrl.searchParams.get('keyword')).toBeNull()
   })
 })

--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -345,6 +345,79 @@ describe('QuickStartPanel quick-filter display', () => {
     })
   })
 
+  it('promotes the matched SEEK profile jobUrl into collectUrl before manual apply', async () => {
+    const onApplyConfig = vi.fn()
+
+    postMock.mockResolvedValue({
+      data: {
+        success: true,
+        profileId: 'seek-malaysia-sales',
+        confidence: 0.95,
+        matchedKeywords: ['Sales Engineer', 'Sales Manager'],
+      },
+    })
+    getMock.mockImplementation(async (path: string) => {
+      if (path.includes('/api/search-profiles/seek-malaysia-sales')) {
+        return {
+          data: {
+            success: true,
+            profile: {
+              id: 'seek-malaysia-sales',
+              name: 'SEEK Malaysia Sales Engineer / Sales Manager',
+              status: 'active' as const,
+              location: 'Kuala Lumpur MY',
+              keywords: ['Sales Engineer', 'Sales Manager'],
+              jobDescription: 'seek-malaysia-sales',
+              filters: {
+                minExperience: 2,
+                maxAge: 45,
+              },
+              sources: [
+                {
+                  type: 'seek',
+                  enabled: true,
+                  priority: 1,
+                  jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+                },
+              ],
+            },
+          },
+        }
+      }
+
+      return {
+        data: {
+          success: true,
+          item: {
+            requiredRoles: [],
+          },
+        },
+      }
+    })
+
+    render(
+      <QuickStartPanel
+        defaultLocation="Kuala Lumpur MY"
+        defaultKeywords={['Sales Engineer', 'Sales Manager']}
+        jobDescriptionId=""
+        onApplyConfig={onApplyConfig}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('SEEK Malaysia Sales Engineer / Sales Manager')).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(onApplyConfig).toHaveBeenLastCalledWith({
+        location: 'Kuala Lumpur MY',
+        keywords: ['Sales Engineer', 'Sales Manager'],
+        jobDescriptionId: undefined,
+        collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+      })
+    })
+  })
+
   it('applies the SEEK Malaysia workflow preset without splitting the location', async () => {
     const user = userEvent.setup()
     const onApplyConfig = vi.fn()

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -12,7 +12,10 @@ import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
 import type { ResumeFilters } from '@/types/resume'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
-import { buildSeekCollectUrl, getSearchProfileCollectUrl } from '@/lib/search-profile-sources'
+import {
+  buildSeekCollectUrl,
+  getSearchProfileCollectUrl,
+} from '@/lib/search-profile-sources'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 
 const AUTO_MATCH_MIN_CONFIDENCE = 0.3
@@ -473,6 +476,14 @@ export function QuickStartPanel({
     () => selectedKeywords.map((keyword) => keyword.trim()).filter((keyword) => keyword.length > 0),
     [selectedKeywords]
   )
+  const generatedCollectUrl = useMemo(
+    () => buildSeekCollectUrl({ location, keywords: normalizedKeywords }) ?? undefined,
+    [location, normalizedKeywords]
+  )
+  const matchedProfileCollectUrl = useMemo(
+    () => getSearchProfileCollectUrl(autoMatchResult?.profile.sources),
+    [autoMatchResult]
+  )
   const selectedConvexJobDescriptionProfile = useMemo(() => {
     if (!selectedConvexJobDescription || !selectedConvexJobDescriptionDetail) {
       return undefined
@@ -558,6 +569,26 @@ export function QuickStartPanel({
 
     return () => clearTimeout(timer)
   }, [collectUrl, location, normalizedKeywords, jobDescriptionId, onApplyConfig])
+
+  useEffect(() => {
+    if (!matchedProfileCollectUrl) {
+      return
+    }
+    const normalizedCurrent = collectUrl?.trim()
+    const shouldPromoteMatchedProfileUrl = !normalizedCurrent || normalizedCurrent === generatedCollectUrl
+
+    if (!shouldPromoteMatchedProfileUrl || normalizedCurrent === matchedProfileCollectUrl) {
+      return
+    }
+
+    setCollectUrl(matchedProfileCollectUrl)
+    onApplyConfig?.({
+      location,
+      keywords: normalizedKeywords,
+      jobDescriptionId: jobDescriptionId || undefined,
+      collectUrl: matchedProfileCollectUrl,
+    }, true)
+  }, [collectUrl, generatedCollectUrl, jobDescriptionId, location, matchedProfileCollectUrl, normalizedKeywords, onApplyConfig])
 
   useEffect(() => {
     if (normalizedKeywords.length === 0) {

--- a/config/search-profiles/seek-malaysia-sales.yaml
+++ b/config/search-profiles/seek-malaysia-sales.yaml
@@ -32,7 +32,7 @@ sources:
   - type: seek
     enabled: true
     priority: 1
-    jobUrl: https://my.employer.seek.com/candidates/recommended?keyword=Sales%20Engineer%20Sales%20Manager&location=Kuala%20Lumpur%20MY
+    jobUrl: https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1
   - type: job5156
     enabled: false
     priority: 2


### PR DESCRIPTION
## Summary
- promote an auto-matched SEEK profile's exact `jobUrl` into live collect state instead of rebuilding a generic keyword URL
- align the Malaysia SEEK demo profile with the exact `jobId=90842915&pageNumber=1` source URL
- add component and Playwright regression coverage for raw query pages and the Malaysia workflow collect button

## Testing
- npm --workspace @trends/web test -- src/components/QuickStartPanel.test.tsx
- bunx playwright test --config apps/web/playwright.config.ts apps/web/e2e/resume-role-filter.spec.ts --grep "SEEK Malaysia workflow|SEEK auto-match prefers the profile jobUrl"
- npm run test:api:search-profiles
- make check

## Notes
- The current localhost API process may need a restart to pick up the updated profile YAML if it already cached the old seek-malaysia-sales source URL.
