### PR TITLE
test: cover malaysia resume home reset

### DIFF
--- a/apps/web/e2e/resume-role-filter.spec.ts
+++ b/apps/web/e2e/resume-role-filter.spec.ts
@@ -602,6 +602,8 @@ test.describe('Resume quick role filter', () => {
 
     await page.goto('/dev/resumes?location=Kuala+Lumpur+MY&keyword=Sales+Engineer+Manager')
     await expect(page.getByText('SEEK Malaysia Sales Engineer / Sales Manager')).toBeVisible()
+    await expect(page.getByRole('textbox', { name: '位置' })).toHaveValue('Kuala Lumpur MY')
+    await expect(page.getByPlaceholder('自定义关键词...')).toHaveValue('Sales Engineer Manager')
 
     await page.evaluate(() => {
       const openedUrls: string[] = []
@@ -624,5 +626,11 @@ test.describe('Resume quick role filter', () => {
     expect(collectUrl.searchParams.get('pageNumber')).toBe('1')
     expect(collectUrl.searchParams.get('tr_auto_sync')).toBe('true')
     expect(collectUrl.searchParams.get('keyword')).toBeNull()
+
+    await page.getByRole('link', { name: '趋势 Trends' }).click()
+
+    await expect(page).toHaveURL(/\/dev\/resumes$/)
+    await expect(page.getByRole('textbox', { name: '位置' })).toHaveValue('')
+    await expect(page.getByPlaceholder('自定义关键词...')).toHaveValue('')
   })
 })


### PR DESCRIPTION
## Summary
- extend the Malaysia SEEK raw-query Playwright case to assert the pre-reset query state
- verify clicking the header home link clears the query string and resets both location and keyword inputs
- keep the existing exact SEEK collect URL assertions in the same flow

## Testing
- bunx playwright test --config apps/web/playwright.config.ts apps/web/e2e/resume-role-filter.spec.ts --grep "SEEK auto-match prefers the profile jobUrl for collect on raw query pages"
- make check