### PR TITLE
test: cover app redirect search preservation

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import App from './App'
+
+vi.mock('sonner', () => ({
+  Toaster: () => null,
+}))
+
+vi.mock('@/components/Header', () => ({
+  Header: () => <div>Header</div>,
+}))
+
+vi.mock('@/pages/ResumesPage', () => ({
+  ResumesPage: () => <div>Resumes Page</div>,
+}))
+
+vi.mock('@/pages/DebugPage', () => ({
+  DebugPage: ({ basePath }: { basePath: string }) => <div>Debug Page {basePath}</div>,
+}))
+
+vi.mock('@/pages/DebugJDs', () => ({
+  default: () => <div>Debug JDs</div>,
+}))
+
+vi.mock('@/pages/DebugAI', () => ({
+  default: () => <div>Debug AI</div>,
+}))
+
+vi.mock('@/pages/DebugConfig', () => ({
+  default: () => <div>Debug Config</div>,
+}))
+
+vi.mock('@/pages/DebugIngest', () => ({
+  default: () => <div>Debug Ingest</div>,
+}))
+
+vi.mock('@/pages/DebugAiTaggingResults', () => ({
+  default: () => <div>Debug AI Tagging</div>,
+}))
+
+vi.mock('@/pages/BlacklistPage', () => ({
+  BlacklistPage: () => <div>Blacklist Page</div>,
+}))
+
+vi.mock('@/pages/SearchProfilesPage', () => ({
+  SearchProfilesPage: () => <div>Search Profiles Page</div>,
+}))
+
+vi.mock('@/pages/SearchAnalyticsPage', () => ({
+  default: () => <div>Search Analytics Page</div>,
+}))
+
+vi.mock('@/pages/system-settings/SystemSettingsConfigSourcesPage', () => ({
+  SystemSettingsConfigSourcesPage: () => <div>Config Sources</div>,
+}))
+
+vi.mock('@/pages/system-settings/SystemSettingsKeywordsPage', () => ({
+  SystemSettingsKeywordsPage: () => <div>Keywords Page</div>,
+}))
+
+vi.mock('@/pages/system-settings/SystemSettingsLocationsPage', () => ({
+  SystemSettingsLocationsPage: () => <div>Locations Page</div>,
+}))
+
+vi.mock('@/pages/system-settings/SystemSettingsOperationsPage', () => ({
+  SystemSettingsOperationsPage: () => <div>Operations Page</div>,
+}))
+
+vi.mock('@/pages/system-settings/SystemSettingsRuntimePage', () => ({
+  SystemSettingsRuntimePage: () => <div>Runtime Page</div>,
+}))
+
+vi.mock('@/layouts/SettingsLayout', () => ({
+  default: () => <div>Settings Layout</div>,
+}))
+
+vi.mock('@/layouts/SystemLayout', () => ({
+  default: () => <div>System Layout</div>,
+}))
+
+vi.mock('@/layouts/SystemSettingsLayout', () => ({
+  default: () => <div>System Settings Layout</div>,
+}))
+
+describe('App redirects', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/')
+  })
+
+  it('preserves search params when redirecting /resumes to /dev/resumes', async () => {
+    window.history.replaceState({}, '', '/resumes?location=Kuala+Lumpur+MY&keyword=Sales+Engineer+Manager')
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/dev/resumes')
+      expect(window.location.search).toBe('?location=Kuala+Lumpur+MY&keyword=Sales+Engineer+Manager')
+    })
+
+    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
+  })
+
+  it('preserves search params when redirecting a workspace index route to resumes', async () => {
+    window.history.replaceState({}, '', '/hr?keyword=CNC')
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/hr/resumes')
+      expect(window.location.search).toBe('?keyword=CNC')
+    })
+
+    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add app-level redirect tests for search-preserving navigation
- assert `/resumes` redirects to `/dev/resumes` without dropping search params
- assert workspace index routes redirect to `/:teamSlug/resumes` without dropping search params

## Testing
- npm --workspace @trends/web test -- src/App.test.tsx
- make check