### PR TITLE
test: cover admin gate search preservation

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -112,4 +112,17 @@ describe('App redirects', () => {
 
     expect(screen.getByText('Resumes Page')).toBeInTheDocument()
   })
+
+  it('preserves search params when AdminGate redirects a non-admin workspace away from system routes', async () => {
+    window.history.replaceState({}, '', '/hr/system?keyword=CNC&location=Kuala+Lumpur+MY')
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/hr/resumes')
+      expect(window.location.search).toBe('?keyword=CNC&location=Kuala+Lumpur+MY')
+    })
+
+    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- extend the app redirect tests with the non-admin system guard path
- assert `/hr/system?...` redirects to `/hr/resumes?...` without dropping search params
- keep the preserve-vs-reset routing contract explicit at the app level

## Testing
- npm --workspace @trends/web test -- src/App.test.tsx
- make check