### PR TITLE
test: cover workspace fallback search preservation

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -125,4 +125,17 @@ describe('App redirects', () => {
 
     expect(screen.getByText('Resumes Page')).toBeInTheDocument()
   })
+
+  it('preserves search params when an invalid workspace slug falls back to /dev/resumes', async () => {
+    window.history.replaceState({}, '', '/unknown/resumes?keyword=STAR&location=Dongguan')
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/dev/resumes')
+      expect(window.location.search).toBe('?keyword=STAR&location=Dongguan')
+    })
+
+    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- extend the app redirect tests with invalid workspace fallback coverage
- assert `/unknown/resumes?...` falls back to `/dev/resumes?...` without dropping search params
- keep the app-level search-preservation contract explicit for workspace validation redirects

## Testing
- npm --workspace @trends/web test -- src/App.test.tsx
- make check