### PR TITLE
test: cover team legacy redirect preservation

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -173,4 +173,43 @@ describe('App redirects', () => {
 
     expect(screen.getByText('Resumes Page')).toBeInTheDocument()
   })
+
+  it('preserves search params when workspace legacy config jds routes hit the non-admin guard', async () => {
+    window.history.replaceState({}, '', '/hr/config/jds?keyword=STAR')
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/hr/resumes')
+      expect(window.location.search).toBe('?keyword=STAR')
+    })
+
+    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
+  })
+
+  it('preserves search params when workspace legacy debug config routes hit the non-admin guard', async () => {
+    window.history.replaceState({}, '', '/hr/debug/config?keyword=CNC')
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/hr/resumes')
+      expect(window.location.search).toBe('?keyword=CNC')
+    })
+
+    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
+  })
+
+  it('preserves search params when workspace legacy debug wildcard routes hit the non-admin guard', async () => {
+    window.history.replaceState({}, '', '/hr/debug/raw?keyword=Machine')
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/hr/resumes')
+      expect(window.location.search).toBe('?keyword=Machine')
+    })
+
+    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- extend the app redirect tests with team-scoped legacy debug/config routes
- assert those routes preserve search params even when the non-admin guard ultimately redirects to `/:teamSlug/resumes`
- document the full redirect chain for non-admin workspaces more explicitly

## Testing
- npm --workspace @trends/web test -- src/App.test.tsx
- make check