### PR TITLE
test: cover workspace switcher resume reset

### DIFF
--- a/apps/web/src/components/WorkspaceSwitcher.test.tsx
+++ b/apps/web/src/components/WorkspaceSwitcher.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorkspaceSwitcher } from './WorkspaceSwitcher'
+
+const mockState = vi.hoisted(() => ({
+  slug: 'dev',
+  navigate: vi.fn(),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockState.navigate,
+}))
+
+vi.mock('@/contexts/WorkspaceContext', () => ({
+  useWorkspace: () => ({
+    slug: mockState.slug,
+  }),
+}))
+
+describe('WorkspaceSwitcher', () => {
+  beforeEach(() => {
+    mockState.slug = 'dev'
+    mockState.navigate.mockReset()
+  })
+
+  it('navigates to the selected workspace resume home without preserving query state', () => {
+    render(<WorkspaceSwitcher />)
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Workspace switcher' }), {
+      target: { value: 'hr' },
+    })
+
+    expect(mockState.navigate).toHaveBeenCalledWith('/hr/resumes')
+    expect(mockState.navigate).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add focused coverage for workspace switching as an intentional resume-home reset path
- assert switching workspaces navigates directly to `/:teamSlug/resumes`
- keep that behavior distinct from search-preserving router redirects

## Testing
- npm --workspace @trends/web test -- src/components/WorkspaceSwitcher.test.tsx
- make check