### PR TITLE
fix: derive error boundary home from workspace config

### DIFF
--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, ErrorInfo, ReactNode } from 'react'
+import { isValidWorkspace } from '@trends/shared'
 import { AlertTriangle } from 'lucide-react'
 
 interface Props {
@@ -35,7 +36,7 @@ export class ErrorBoundary extends Component<Props, State> {
                 ? window.location.pathname.match(/^\/([^/]+)/)
                 : null
             const workspaceSlug = workspaceMatch?.[1]
-            const homeHref = workspaceSlug === 'dev' || workspaceSlug === 'hr'
+            const homeHref = workspaceSlug && isValidWorkspace(workspaceSlug)
                 ? `/${workspaceSlug}/resumes`
                 : '/dev/resumes'
 


### PR DESCRIPTION
## Summary
- replace the hard-coded `dev`/`hr` check in `ErrorBoundary` with the shared workspace validator
- keep the existing fallback behavior for unknown paths while avoiding duplicated workspace knowledge
- preserve the existing tested home href behavior on valid workspaces

## Testing
- npm --workspace @trends/web test -- src/components/ErrorBoundary.test.tsx
- make check