### PR TITLE
fix: cap seek auto-sync page window

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -68,6 +68,7 @@ const PAGE_BRIDGE_REQUEST_ATTR = 'data-tr-resume-bridge-request';
 const PAGE_BRIDGE_RESPONSE_ATTR = 'data-tr-resume-bridge-response';
 const JOB5156_DETAIL_FETCH_TIMEOUT_MS = 5000;
 const JOB5156_DETAIL_FETCH_CONCURRENCY = 5;
+const DEFAULT_SEEK_PAGE_SIZE = 20;
 
 const apiSnapshot = {
   searchRows: null,
@@ -466,6 +467,153 @@ function getSeekRecommendedRequest() {
 
 function getSeekProfileRequest() {
   return apiSnapshot.seekProfileRequest || apiSnapshot.seekRecommendedRequest;
+}
+
+function getSeekAutoSyncHelpers() {
+  const helpers = globalThis.__TR_SEEK_AUTO_SYNC__;
+  return helpers && typeof helpers === 'object' ? helpers : null;
+}
+
+/**
+ * @param {{
+ *   requestedPageSize?: number | null;
+ *   currentPageCandidateCount?: number | null;
+ *   fallbackPageSize?: number | null;
+ * }} [options]
+ */
+function resolveSeekAutoSyncPageSize(options = {}) {
+  const {
+    requestedPageSize,
+    currentPageCandidateCount,
+    fallbackPageSize = DEFAULT_SEEK_PAGE_SIZE,
+  } = options;
+  const helpers = getSeekAutoSyncHelpers();
+  if (typeof helpers?.resolveSeekAutoSyncPageSize === 'function') {
+    return helpers.resolveSeekAutoSyncPageSize({
+      requestedPageSize,
+      currentPageCandidateCount,
+      fallbackPageSize,
+    });
+  }
+
+  return normalizeOptionalPositiveInt(requestedPageSize)
+    || normalizeOptionalPositiveInt(currentPageCandidateCount)
+    || normalizeOptionalPositiveInt(fallbackPageSize)
+    || DEFAULT_SEEK_PAGE_SIZE;
+}
+
+/**
+ * @param {{
+ *   startPage?: number | null;
+ *   limit?: number | null;
+ *   maxPages?: number | null;
+ *   requestedPageSize?: number | null;
+ *   currentPageCandidateCount?: number | null;
+ * }} [options]
+ */
+function resolveSeekAutoSyncPageWindow(options = {}) {
+  const {
+    startPage,
+    limit,
+    maxPages,
+    requestedPageSize,
+    currentPageCandidateCount,
+  } = options;
+  const helpers = getSeekAutoSyncHelpers();
+  if (typeof helpers?.resolveSeekAutoSyncPageWindow === 'function') {
+    return helpers.resolveSeekAutoSyncPageWindow({
+      startPage,
+      limit,
+      maxPages,
+      requestedPageSize,
+      currentPageCandidateCount,
+      fallbackPageSize: DEFAULT_SEEK_PAGE_SIZE,
+    });
+  }
+
+  const normalizedStartPage = normalizeOptionalPositiveInt(startPage) || 1;
+  const normalizedLimit = normalizeOptionalPositiveInt(limit);
+  const normalizedMaxPages = normalizeOptionalPositiveInt(maxPages);
+  const effectivePageSize = resolveSeekAutoSyncPageSize({
+    requestedPageSize,
+    currentPageCandidateCount,
+    fallbackPageSize: DEFAULT_SEEK_PAGE_SIZE,
+  });
+  const limitPageCount = normalizedLimit
+    ? Math.max(1, Math.ceil(normalizedLimit / effectivePageSize))
+    : null;
+
+  let allowedPageCount = null;
+  if (limitPageCount && normalizedMaxPages) {
+    allowedPageCount = Math.min(limitPageCount, normalizedMaxPages);
+  } else if (limitPageCount) {
+    allowedPageCount = limitPageCount;
+  } else if (normalizedMaxPages) {
+    allowedPageCount = normalizedMaxPages;
+  }
+
+  return {
+    startPage: normalizedStartPage,
+    targetPageEnd: allowedPageCount ? normalizedStartPage + allowedPageCount - 1 : null,
+    effectivePageSize,
+    limitPageCount,
+    maxPages: normalizedMaxPages,
+    allowedPageCount,
+  };
+}
+
+/**
+ * @param {{ targetPageEnd?: number | null } | null | undefined} pageWindow
+ * @param {number | null | undefined} currentPage
+ */
+function isSeekAutoSyncPageWindowReached(pageWindow, currentPage) {
+  const helpers = getSeekAutoSyncHelpers();
+  if (typeof helpers?.isSeekAutoSyncPageWindowReached === 'function') {
+    return helpers.isSeekAutoSyncPageWindowReached({
+      currentPage,
+      targetPageEnd: pageWindow?.targetPageEnd,
+    });
+  }
+
+  const normalizedCurrentPage = normalizeOptionalPositiveInt(currentPage);
+  const targetPageEnd = normalizeOptionalPositiveInt(pageWindow?.targetPageEnd);
+  return !!(normalizedCurrentPage && targetPageEnd && normalizedCurrentPage >= targetPageEnd);
+}
+
+function getSeekRequestedPageSize() {
+  const requestInput = getSeekRecommendedRequest()?.variables?.input;
+  return normalizeOptionalPositiveInt(requestInput?.size);
+}
+
+function getSeekCurrentCandidateCount() {
+  return Array.isArray(apiSnapshot.seekRecommendedCandidates) ? apiSnapshot.seekRecommendedCandidates.length : 0;
+}
+
+/**
+ * @param {{
+ *   startPage?: number | null;
+ *   targetPageEnd?: number | null;
+ *   effectivePageSize?: number | null;
+ * } | null | undefined} pageWindow
+ */
+function setSeekAutoSyncWindowAttributes(pageWindow) {
+  const attrs = /** @type {Array<[string, number | null | undefined]>} */ ([
+    ['data-tr-auto-sync-target-start', pageWindow?.startPage],
+    ['data-tr-auto-sync-target-end', pageWindow?.targetPageEnd],
+    ['data-tr-auto-sync-effective-page-size', pageWindow?.effectivePageSize],
+  ]);
+
+  try {
+    for (const [name, value] of attrs) {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        document.documentElement.setAttribute(name, String(value));
+      } else {
+        document.documentElement.removeAttribute(name);
+      }
+    }
+  } catch {
+    // ignore
+  }
 }
 
 function findSeekProfileTrigger(profileId) {
@@ -3400,6 +3548,7 @@ async function runAutoSyncIfEnabled() {
   const enabled = getAutoSyncEnabled();
   if (!enabled) {
     setAutoSyncAttributes('skipped');
+    setSeekAutoSyncWindowAttributes(null);
     return;
   }
 
@@ -3408,6 +3557,7 @@ async function runAutoSyncIfEnabled() {
   autoSyncTriggered = true;
   autoSyncCancelled = false;
   setAutoSyncAttributes('running', 0, 0);
+  setSeekAutoSyncWindowAttributes(null);
   try {
     document.documentElement.setAttribute('data-tr-auto-sync-limit', String(limit));
     document.documentElement.setAttribute('data-tr-auto-sync-max-pages', String(maxPages));
@@ -3426,6 +3576,7 @@ async function runAutoSyncIfEnabled() {
     let totalUpdated = 0;
     let pagesVisited = 0;
     let stopReason = 'completed';
+    let seekStartPage = null;
 
     while (true) {
       if (autoSyncCancelled) {
@@ -3436,10 +3587,25 @@ async function runAutoSyncIfEnabled() {
       const paginationBefore = getPaginationInfo();
       const currentPage = paginationBefore.currentPage;
       const totalPages = paginationBefore.totalPages;
+      const isSeekListPage = getCurrentSourceKey() === SOURCE_KEYS.SEEK && !isSeekProfileMode();
+      if (isSeekListPage && seekStartPage === null) {
+        seekStartPage = currentPage;
+      }
 
       await waitForExtractionData({});
 
       pagesVisited += 1;
+
+      const seekPageWindow = isSeekListPage
+        ? resolveSeekAutoSyncPageWindow({
+            startPage: seekStartPage || currentPage,
+            limit,
+            maxPages,
+            requestedPageSize: getSeekRequestedPageSize(),
+            currentPageCandidateCount: getSeekCurrentCandidateCount(),
+          })
+        : null;
+      setSeekAutoSyncWindowAttributes(seekPageWindow);
 
       const remainingCapacity = limit > 0 ? Math.max(limit - totalSubmitted, 0) : 0;
       if (limit > 0 && remainingCapacity <= 0) {
@@ -3448,6 +3614,7 @@ async function runAutoSyncIfEnabled() {
       }
 
       let resumes = extractResumes();
+      const hitLimitWithinPage = limit > 0 && resumes.length > remainingCapacity;
       if (limit > 0 && resumes.length > remainingCapacity) {
         resumes = resumes.slice(0, remainingCapacity);
       }
@@ -3477,7 +3644,11 @@ async function runAutoSyncIfEnabled() {
           stopReason = 'cancelled';
           break;
         }
-        if (maxPages > 0 && pagesVisited >= maxPages) {
+        if (isSeekListPage && isSeekAutoSyncPageWindowReached(seekPageWindow, currentPage)) {
+          stopReason = 'page-window-reached';
+          break;
+        }
+        if (!isSeekListPage && maxPages > 0 && pagesVisited >= maxPages) {
           stopReason = 'max-pages-reached';
           break;
         }
@@ -3535,11 +3706,19 @@ async function runAutoSyncIfEnabled() {
         stopReason = 'cancelled';
         break;
       }
-      if (limit > 0 && totalSubmitted >= limit) {
+      if (isSeekListPage && hitLimitWithinPage) {
         stopReason = 'limit-reached';
         break;
       }
-      if (maxPages > 0 && pagesVisited >= maxPages) {
+      if (isSeekListPage && isSeekAutoSyncPageWindowReached(seekPageWindow, currentPage)) {
+        stopReason = 'page-window-reached';
+        break;
+      }
+      if (!isSeekListPage && limit > 0 && totalSubmitted >= limit) {
+        stopReason = 'limit-reached';
+        break;
+      }
+      if (!isSeekListPage && maxPages > 0 && pagesVisited >= maxPages) {
         stopReason = 'max-pages-reached';
         break;
       }
@@ -3690,8 +3869,14 @@ function getExternalAccessorStatus() {
   const autoSync = document.documentElement.getAttribute('data-tr-auto-sync') || '';
   const autoSyncCountRaw = document.documentElement.getAttribute('data-tr-auto-sync-count') || '';
   const autoSyncPagesRaw = document.documentElement.getAttribute('data-tr-auto-sync-pages') || '';
+  const autoSyncTargetStartRaw = document.documentElement.getAttribute('data-tr-auto-sync-target-start') || '';
+  const autoSyncTargetEndRaw = document.documentElement.getAttribute('data-tr-auto-sync-target-end') || '';
+  const autoSyncEffectivePageSizeRaw = document.documentElement.getAttribute('data-tr-auto-sync-effective-page-size') || '';
   const autoSyncCount = Number.parseInt(autoSyncCountRaw, 10);
   const autoSyncPages = Number.parseInt(autoSyncPagesRaw, 10);
+  const autoSyncTargetStart = Number.parseInt(autoSyncTargetStartRaw, 10);
+  const autoSyncTargetEnd = Number.parseInt(autoSyncTargetEndRaw, 10);
+  const autoSyncEffectivePageSize = Number.parseInt(autoSyncEffectivePageSizeRaw, 10);
 
   return {
     extensionLoaded: true,
@@ -3713,6 +3898,9 @@ function getExternalAccessorStatus() {
     autoSync,
     autoSyncCount: Number.isFinite(autoSyncCount) ? autoSyncCount : 0,
     autoSyncPages: Number.isFinite(autoSyncPages) ? autoSyncPages : 0,
+    autoSyncTargetPageStart: Number.isFinite(autoSyncTargetStart) ? autoSyncTargetStart : null,
+    autoSyncTargetPageEnd: Number.isFinite(autoSyncTargetEnd) ? autoSyncTargetEnd : null,
+    autoSyncEffectivePageSize: Number.isFinite(autoSyncEffectivePageSize) ? autoSyncEffectivePageSize : null,
     pagination,
     lastOperationName: apiSnapshot.lastOperationName,
     timestamp: new Date().toISOString()

--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -56,6 +56,7 @@
                 "*://my.employer.seek.com/talentsearch/profile*"
             ],
             "js": [
+                "seek-auto-sync-window.js",
                 "content.js"
             ],
             "css": [

--- a/apps/browser-extension/seek-auto-sync-window.js
+++ b/apps/browser-extension/seek-auto-sync-window.js
@@ -1,0 +1,100 @@
+(() => {
+  const DEFAULT_PAGE_SIZE = 20;
+
+  /**
+   * @param {unknown} value
+   * @returns {number | null}
+   */
+  function normalizePositiveInt(value) {
+    const parsed = Number.parseInt(String(value ?? '').trim(), 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  /**
+   * @param {{
+   *   requestedPageSize?: number | null;
+   *   currentPageCandidateCount?: number | null;
+   *   fallbackPageSize?: number | null;
+   * }} [options]
+   */
+  function resolveSeekAutoSyncPageSize(options = {}) {
+    const {
+      requestedPageSize,
+      currentPageCandidateCount,
+      fallbackPageSize = DEFAULT_PAGE_SIZE,
+    } = options;
+    return normalizePositiveInt(requestedPageSize)
+      || normalizePositiveInt(currentPageCandidateCount)
+      || normalizePositiveInt(fallbackPageSize)
+      || DEFAULT_PAGE_SIZE;
+  }
+
+  /**
+   * @param {{
+   *   startPage?: number | null;
+   *   limit?: number | null;
+   *   maxPages?: number | null;
+   *   requestedPageSize?: number | null;
+   *   currentPageCandidateCount?: number | null;
+   *   fallbackPageSize?: number | null;
+   * }} [options]
+   */
+  function resolveSeekAutoSyncPageWindow(options = {}) {
+    const {
+      startPage,
+      limit,
+      maxPages,
+      requestedPageSize,
+      currentPageCandidateCount,
+      fallbackPageSize = DEFAULT_PAGE_SIZE,
+    } = options;
+    const normalizedStartPage = normalizePositiveInt(startPage) || 1;
+    const normalizedLimit = normalizePositiveInt(limit);
+    const normalizedMaxPages = normalizePositiveInt(maxPages);
+    const effectivePageSize = resolveSeekAutoSyncPageSize({
+      requestedPageSize,
+      currentPageCandidateCount,
+      fallbackPageSize,
+    });
+    const limitPageCount = normalizedLimit
+      ? Math.max(1, Math.ceil(normalizedLimit / effectivePageSize))
+      : null;
+
+    let allowedPageCount = null;
+    if (limitPageCount && normalizedMaxPages) {
+      allowedPageCount = Math.min(limitPageCount, normalizedMaxPages);
+    } else if (limitPageCount) {
+      allowedPageCount = limitPageCount;
+    } else if (normalizedMaxPages) {
+      allowedPageCount = normalizedMaxPages;
+    }
+
+    return {
+      startPage: normalizedStartPage,
+      targetPageEnd: allowedPageCount
+        ? normalizedStartPage + allowedPageCount - 1
+        : null,
+      effectivePageSize,
+      limitPageCount,
+      maxPages: normalizedMaxPages,
+      allowedPageCount,
+    };
+  }
+
+  /**
+   * @param {{ currentPage?: number | null; targetPageEnd?: number | null }} [options]
+   */
+  function isSeekAutoSyncPageWindowReached(options = {}) {
+    const { currentPage, targetPageEnd } = options;
+    const normalizedCurrentPage = normalizePositiveInt(currentPage);
+    const normalizedTargetPageEnd = normalizePositiveInt(targetPageEnd);
+    return !!(normalizedCurrentPage && normalizedTargetPageEnd && normalizedCurrentPage >= normalizedTargetPageEnd);
+  }
+
+  globalThis.__TR_SEEK_AUTO_SYNC__ = Object.freeze({
+    DEFAULT_PAGE_SIZE,
+    resolveSeekAutoSyncPageSize,
+    resolveSeekAutoSyncPageWindow,
+    isSeekAutoSyncPageWindowReached,
+  });
+})();

--- a/apps/browser-extension/seek-auto-sync-window.test.mjs
+++ b/apps/browser-extension/seek-auto-sync-window.test.mjs
@@ -1,0 +1,99 @@
+/* global console, process */
+
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+
+function loadSeekAutoSyncHelpers() {
+  const filePath = path.join(process.cwd(), 'apps/browser-extension/seek-auto-sync-window.js');
+  const code = readFileSync(filePath, 'utf8');
+  const context = { console };
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(code, context, { filename: filePath });
+  return context.__TR_SEEK_AUTO_SYNC__;
+}
+
+const helpers = loadSeekAutoSyncHelpers();
+
+test('stops at the earlier of limit-derived pages and maxPages', () => {
+  const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
+    startPage: 1,
+    limit: 100,
+    maxPages: 10,
+    requestedPageSize: 20,
+  });
+
+  assert.equal(pageWindow.startPage, 1);
+  assert.equal(pageWindow.targetPageEnd, 5);
+  assert.equal(pageWindow.effectivePageSize, 20);
+  assert.equal(pageWindow.limitPageCount, 5);
+  assert.equal(pageWindow.maxPages, 10);
+  assert.equal(pageWindow.allowedPageCount, 5);
+});
+
+test('uses maxPages when there is no limit', () => {
+  const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
+    startPage: 1,
+    limit: 0,
+    maxPages: 5,
+    requestedPageSize: 20,
+  });
+
+  assert.equal(pageWindow.targetPageEnd, 5);
+  assert.equal(pageWindow.allowedPageCount, 5);
+});
+
+test('respects the current start page for exact seek job urls', () => {
+  const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
+    startPage: 3,
+    limit: 40,
+    maxPages: 10,
+    requestedPageSize: 20,
+  });
+
+  assert.equal(pageWindow.startPage, 3);
+  assert.equal(pageWindow.targetPageEnd, 4);
+  assert.equal(pageWindow.allowedPageCount, 2);
+});
+
+test('falls back to the current candidate count when seek request size is unavailable', () => {
+  const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
+    startPage: 1,
+    limit: 45,
+    maxPages: 10,
+    requestedPageSize: null,
+    currentPageCandidateCount: 15,
+  });
+
+  assert.equal(pageWindow.effectivePageSize, 15);
+  assert.equal(pageWindow.limitPageCount, 3);
+  assert.equal(pageWindow.targetPageEnd, 3);
+});
+
+test('falls back to the default page size when no runtime page size is available', () => {
+  const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
+    startPage: 2,
+    limit: 60,
+    maxPages: 0,
+    requestedPageSize: null,
+    currentPageCandidateCount: 0,
+  });
+
+  assert.equal(pageWindow.effectivePageSize, 20);
+  assert.equal(pageWindow.targetPageEnd, 4);
+});
+
+test('detects when the target page window has been reached', () => {
+  assert.equal(helpers.isSeekAutoSyncPageWindowReached({
+    currentPage: 5,
+    targetPageEnd: 5,
+  }), true);
+
+  assert.equal(helpers.isSeekAutoSyncPageWindowReached({
+    currentPage: 4,
+    targetPageEnd: 5,
+  }), false);
+});


### PR DESCRIPTION
## Summary
- cap SEEK auto-sync list traversal to the earlier of the limit-derived page window and `tr_max_pages`
- keep detail enrichment for only the selected resumes on each allowed SEEK page
- expose SEEK page-window status fields and add focused regression coverage for the page-window math

## Testing
- node --test apps/browser-extension/seek-auto-sync-window.test.mjs
- npm --workspace @trends/browser-extension run lint
- npm --workspace @trends/browser-extension run typecheck
- make check
- live MCP verification on `https://hk.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1&tr_auto_sync=true&tr_limit=100&tr_max_pages=10` confirmed `autoSyncTargetPageEnd=5`, `autoSyncCount=100`, `autoSyncPages=5`, and `data-tr-auto-sync-stop-reason=page-window-reached`