### PR TITLE
test: cover seek mid-page limit selection

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -580,6 +580,37 @@ function isSeekAutoSyncPageWindowReached(pageWindow, currentPage) {
   return !!(normalizedCurrentPage && targetPageEnd && normalizedCurrentPage >= targetPageEnd);
 }
 
+/**
+ * @param {{
+ *   limit?: number | null;
+ *   totalSubmitted?: number | null;
+ *   currentPageResumeCount?: number | null;
+ * }} [options]
+ */
+function resolveSeekAutoSyncCurrentPageSelection(options = {}) {
+  const helpers = getSeekAutoSyncHelpers();
+  if (typeof helpers?.resolveSeekAutoSyncCurrentPageSelection === 'function') {
+    return helpers.resolveSeekAutoSyncCurrentPageSelection(options);
+  }
+
+  const normalizedLimit = normalizeOptionalPositiveInt(options.limit);
+  const normalizedTotalSubmitted = normalizeOptionalPositiveInt(options.totalSubmitted) || 0;
+  const normalizedCurrentPageResumeCount = normalizeOptionalPositiveInt(options.currentPageResumeCount) || 0;
+  const remainingCapacity = normalizedLimit
+    ? Math.max(normalizedLimit - normalizedTotalSubmitted, 0)
+    : null;
+  const selectedCount = remainingCapacity === null
+    ? normalizedCurrentPageResumeCount
+    : Math.min(normalizedCurrentPageResumeCount, remainingCapacity);
+
+  return {
+    remainingCapacity,
+    selectedCount,
+    hitLimitWithinPage: remainingCapacity !== null && normalizedCurrentPageResumeCount > remainingCapacity,
+    limitAlreadyReached: remainingCapacity !== null && remainingCapacity <= 0,
+  };
+}
+
 function getSeekRequestedPageSize() {
   const requestInput = getSeekRecommendedRequest()?.variables?.input;
   return normalizeOptionalPositiveInt(requestInput?.size);
@@ -3607,16 +3638,32 @@ async function runAutoSyncIfEnabled() {
         : null;
       setSeekAutoSyncWindowAttributes(seekPageWindow);
 
-      const remainingCapacity = limit > 0 ? Math.max(limit - totalSubmitted, 0) : 0;
-      if (limit > 0 && remainingCapacity <= 0) {
+      const pageSelection = isSeekListPage
+        ? resolveSeekAutoSyncCurrentPageSelection({
+            limit,
+            totalSubmitted,
+            currentPageResumeCount: getSeekCurrentCandidateCount(),
+          })
+        : {
+            remainingCapacity: limit > 0 ? Math.max(limit - totalSubmitted, 0) : null,
+            selectedCount: null,
+            hitLimitWithinPage: false,
+            limitAlreadyReached: limit > 0 ? Math.max(limit - totalSubmitted, 0) <= 0 : false,
+          };
+
+      if ((isSeekListPage && pageSelection.limitAlreadyReached) || (!isSeekListPage && limit > 0 && pageSelection.limitAlreadyReached)) {
         stopReason = 'limit-reached';
         break;
       }
 
       let resumes = extractResumes();
-      const hitLimitWithinPage = limit > 0 && resumes.length > remainingCapacity;
-      if (limit > 0 && resumes.length > remainingCapacity) {
-        resumes = resumes.slice(0, remainingCapacity);
+      const hitLimitWithinPage = isSeekListPage
+        ? pageSelection.hitLimitWithinPage
+        : limit > 0 && typeof pageSelection.remainingCapacity === 'number' && resumes.length > pageSelection.remainingCapacity;
+      if (isSeekListPage && typeof pageSelection.selectedCount === 'number') {
+        resumes = resumes.slice(0, pageSelection.selectedCount);
+      } else if (limit > 0 && typeof pageSelection.remainingCapacity === 'number' && resumes.length > pageSelection.remainingCapacity) {
+        resumes = resumes.slice(0, pageSelection.remainingCapacity);
       }
       if (getCurrentSourceKey() === SOURCE_KEYS.JOB5156 && !isJob5156DetailPage() && resumes.length > 0) {
         resumes = await enrichJob5156SearchResumesWithDetail(resumes);

--- a/apps/browser-extension/seek-auto-sync-window.js
+++ b/apps/browser-extension/seek-auto-sync-window.js
@@ -91,10 +91,42 @@
     return !!(normalizedCurrentPage && normalizedTargetPageEnd && normalizedCurrentPage >= normalizedTargetPageEnd);
   }
 
+  /**
+   * @param {{
+   *   limit?: number | null;
+   *   totalSubmitted?: number | null;
+   *   currentPageResumeCount?: number | null;
+   * }} [options]
+   */
+  function resolveSeekAutoSyncCurrentPageSelection(options = {}) {
+    const {
+      limit,
+      totalSubmitted,
+      currentPageResumeCount,
+    } = options;
+    const normalizedLimit = normalizePositiveInt(limit);
+    const normalizedTotalSubmitted = normalizePositiveInt(totalSubmitted) || 0;
+    const normalizedCurrentPageResumeCount = normalizePositiveInt(currentPageResumeCount) || 0;
+    const remainingCapacity = normalizedLimit
+      ? Math.max(normalizedLimit - normalizedTotalSubmitted, 0)
+      : null;
+    const selectedCount = remainingCapacity === null
+      ? normalizedCurrentPageResumeCount
+      : Math.min(normalizedCurrentPageResumeCount, remainingCapacity);
+
+    return {
+      remainingCapacity,
+      selectedCount,
+      hitLimitWithinPage: remainingCapacity !== null && normalizedCurrentPageResumeCount > remainingCapacity,
+      limitAlreadyReached: remainingCapacity !== null && remainingCapacity <= 0,
+    };
+  }
+
   globalThis.__TR_SEEK_AUTO_SYNC__ = Object.freeze({
     DEFAULT_PAGE_SIZE,
     resolveSeekAutoSyncPageSize,
     resolveSeekAutoSyncPageWindow,
     isSeekAutoSyncPageWindowReached,
+    resolveSeekAutoSyncCurrentPageSelection,
   });
 })();

--- a/apps/browser-extension/seek-auto-sync-window.test.mjs
+++ b/apps/browser-extension/seek-auto-sync-window.test.mjs
@@ -97,3 +97,29 @@ test('detects when the target page window has been reached', () => {
     targetPageEnd: 5,
   }), false);
 });
+
+test('selects only the remaining mid-page subset when the limit is reached on the current page', () => {
+  const selection = helpers.resolveSeekAutoSyncCurrentPageSelection({
+    limit: 5,
+    totalSubmitted: 0,
+    currentPageResumeCount: 20,
+  });
+
+  assert.equal(selection.remainingCapacity, 5);
+  assert.equal(selection.selectedCount, 5);
+  assert.equal(selection.hitLimitWithinPage, true);
+  assert.equal(selection.limitAlreadyReached, false);
+});
+
+test('reports when the limit has already been exhausted before the current page', () => {
+  const selection = helpers.resolveSeekAutoSyncCurrentPageSelection({
+    limit: 5,
+    totalSubmitted: 5,
+    currentPageResumeCount: 20,
+  });
+
+  assert.equal(selection.remainingCapacity, 0);
+  assert.equal(selection.selectedCount, 0);
+  assert.equal(selection.hitLimitWithinPage, true);
+  assert.equal(selection.limitAlreadyReached, true);
+});


### PR DESCRIPTION
## Summary
- add a focused SEEK helper for current-page selection under `tr_limit`
- route the SEEK auto-sync subset slicing through that helper
- add regression coverage for mid-page limit and already-exhausted limit cases

## Testing
- node --test apps/browser-extension/seek-auto-sync-window.test.mjs
- npm --workspace @trends/browser-extension run lint
- npm --workspace @trends/browser-extension run typecheck
- make check
- live MCP verification on `https://hk.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1&tr_auto_sync=true&tr_limit=5&tr_max_pages=10` confirmed `autoSyncCount=5`, `autoSyncPages=1`, `autoSyncTargetPageEnd=1`, and `data-tr-auto-sync-stop-reason=limit-reached`