### PR TITLE
test: cover non-first seek small limit

### DIFF
--- a/apps/browser-extension/seek-auto-sync-window.test.mjs
+++ b/apps/browser-extension/seek-auto-sync-window.test.mjs
@@ -59,6 +59,26 @@ test('respects the current start page for exact seek job urls', () => {
   assert.equal(pageWindow.allowedPageCount, 2);
 });
 
+test('keeps a non-first-page exact seek url on the same page when a small limit fits within one page', () => {
+  const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
+    startPage: 3,
+    limit: 5,
+    maxPages: 10,
+    requestedPageSize: 20,
+  });
+  const selection = helpers.resolveSeekAutoSyncCurrentPageSelection({
+    limit: 5,
+    totalSubmitted: 0,
+    currentPageResumeCount: 20,
+  });
+
+  assert.equal(pageWindow.startPage, 3);
+  assert.equal(pageWindow.targetPageEnd, 3);
+  assert.equal(pageWindow.allowedPageCount, 1);
+  assert.equal(selection.selectedCount, 5);
+  assert.equal(selection.hitLimitWithinPage, true);
+});
+
 test('falls back to the current candidate count when seek request size is unavailable', () => {
   const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
     startPage: 1,


### PR DESCRIPTION
## Summary
- add regression coverage for a non-first-page exact SEEK URL with a one-page small limit
- lock the expectation that `pageNumber=3&tr_limit=5` stays on page 3 and selects only five resumes

## Testing
- node --test apps/browser-extension/seek-auto-sync-window.test.mjs
- make check
- live MCP verification on `https://hk.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=3&tr_auto_sync=true&tr_limit=5&tr_max_pages=10` confirmed `autoSyncTargetPageStart=3`, `autoSyncTargetPageEnd=3`, `autoSyncCount=5`, `autoSyncPages=1`, and `data-tr-auto-sync-stop-reason=limit-reached`