### PR TITLE
test: cover seek page cap from mid stream

### DIFF
--- a/apps/browser-extension/seek-auto-sync-window.test.mjs
+++ b/apps/browser-extension/seek-auto-sync-window.test.mjs
@@ -79,6 +79,26 @@ test('keeps a non-first-page exact seek url on the same page when a small limit 
   assert.equal(selection.hitLimitWithinPage, true);
 });
 
+test('keeps a non-first-page exact seek url on the same page when maxPages is the tighter bound', () => {
+  const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
+    startPage: 3,
+    limit: 100,
+    maxPages: 1,
+    requestedPageSize: 20,
+  });
+  const selection = helpers.resolveSeekAutoSyncCurrentPageSelection({
+    limit: 100,
+    totalSubmitted: 0,
+    currentPageResumeCount: 20,
+  });
+
+  assert.equal(pageWindow.startPage, 3);
+  assert.equal(pageWindow.targetPageEnd, 3);
+  assert.equal(pageWindow.allowedPageCount, 1);
+  assert.equal(selection.selectedCount, 20);
+  assert.equal(selection.hitLimitWithinPage, false);
+});
+
 test('falls back to the current candidate count when seek request size is unavailable', () => {
   const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
     startPage: 1,


### PR DESCRIPTION
## Summary
- add regression coverage for a non-first-page exact SEEK URL where `tr_max_pages` is tighter than `tr_limit`
- lock the expectation that `pageNumber=3&tr_limit=100&tr_max_pages=1` stays on page 3 and stops by page-window after one page

## Testing
- node --test apps/browser-extension/seek-auto-sync-window.test.mjs
- make check
- live MCP verification on `https://hk.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=3&tr_auto_sync=true&tr_limit=100&tr_max_pages=1` confirmed `autoSyncTargetPageStart=3`, `autoSyncTargetPageEnd=3`, `autoSyncCount=20`, `autoSyncPages=1`, and `data-tr-auto-sync-stop-reason=page-window-reached`