### PR TITLE
feat: show auto sync summary in popup

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -3972,6 +3972,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   else if (request.action === 'getPaginationInfo') {
     sendResponse(getPaginationInfo());
   }
+  else if (request.action === 'getRuntimeStatus') {
+    sendResponse({
+      success: true,
+      status: getExternalAccessorStatus()
+    });
+  }
   else if (request.action === 'ping') {
     sendResponse({ success: true, message: 'Content script loaded' });
   }
@@ -4013,6 +4019,7 @@ function getExternalAccessorStatus() {
   const autoSyncEffectivePageSizeRaw = document.documentElement.getAttribute('data-tr-auto-sync-effective-page-size') || '';
   const autoSyncSelectedCountRaw = document.documentElement.getAttribute('data-tr-auto-sync-selected-count') || '';
   const autoSyncRemainingCapacityRaw = document.documentElement.getAttribute('data-tr-auto-sync-remaining-capacity') || '';
+  const autoSyncStopReason = document.documentElement.getAttribute('data-tr-auto-sync-stop-reason') || '';
   const autoSyncCount = Number.parseInt(autoSyncCountRaw, 10);
   const autoSyncPages = Number.parseInt(autoSyncPagesRaw, 10);
   const autoSyncTargetStart = Number.parseInt(autoSyncTargetStartRaw, 10);
@@ -4046,6 +4053,7 @@ function getExternalAccessorStatus() {
     autoSyncEffectivePageSize: Number.isFinite(autoSyncEffectivePageSize) ? autoSyncEffectivePageSize : null,
     autoSyncSelectedCount: Number.isFinite(autoSyncSelectedCount) ? autoSyncSelectedCount : null,
     autoSyncRemainingCapacity: Number.isFinite(autoSyncRemainingCapacity) ? autoSyncRemainingCapacity : null,
+    autoSyncStopReason: autoSyncStopReason || null,
     pagination,
     lastOperationName: apiSnapshot.lastOperationName,
     timestamp: new Date().toISOString()

--- a/apps/browser-extension/popup-auto-sync-summary.js
+++ b/apps/browser-extension/popup-auto-sync-summary.js
@@ -1,0 +1,111 @@
+(() => {
+  /**
+   * @param {string} autoSync
+   * @returns {string}
+   */
+  function formatAutoSyncState(autoSync) {
+    switch (autoSync) {
+      case 'running':
+        return '进行中';
+      case 'done':
+        return '已完成';
+      case 'cancelled':
+        return '已取消';
+      case 'failed':
+        return '失败';
+      default:
+        return '';
+    }
+  }
+
+  /**
+   * @param {string | null | undefined} stopReason
+   * @returns {string}
+   */
+  function formatAutoSyncStopReason(stopReason) {
+    switch (stopReason) {
+      case 'limit-reached':
+        return '命中数量上限';
+      case 'page-window-reached':
+        return '命中页窗上限';
+      case 'max-pages-reached':
+        return '命中页数上限';
+      case 'no-next-page':
+        return '已到最后一页';
+      case 'cancelled':
+        return '用户取消';
+      case 'failed':
+        return '同步失败';
+      default:
+        return '';
+    }
+  }
+
+  /**
+   * @param {{
+   *   autoSync?: string;
+   *   autoSyncCount?: number | null;
+   *   autoSyncPages?: number | null;
+   *   autoSyncSelectedCount?: number | null;
+   *   autoSyncTargetPageStart?: number | null;
+   *   autoSyncTargetPageEnd?: number | null;
+   *   autoSyncEffectivePageSize?: number | null;
+   *   autoSyncRemainingCapacity?: number | null;
+   *   autoSyncStopReason?: string | null;
+   * }} [status]
+   * @returns {{ autoSync: string; stateLabel: string; mainText: string; detailText: string } | null}
+   */
+  function buildAutoSyncSummary(status = {}) {
+    const autoSync = typeof status?.autoSync === 'string' ? status.autoSync : '';
+    if (!autoSync || autoSync === 'skipped') {
+      return null;
+    }
+
+    const stateLabel = formatAutoSyncState(autoSync) || autoSync;
+    const mainParts = [];
+    const detailParts = [];
+
+    if (typeof status.autoSyncCount === 'number') {
+      mainParts.push(`已采集 ${status.autoSyncCount} 份`);
+    }
+    if (typeof status.autoSyncPages === 'number' && status.autoSyncPages > 0) {
+      mainParts.push(`共 ${status.autoSyncPages} 页`);
+    }
+    if (typeof status.autoSyncSelectedCount === 'number' && status.autoSyncSelectedCount > 0) {
+      mainParts.push(`本页选中 ${status.autoSyncSelectedCount} 份`);
+    }
+
+    if (
+      typeof status.autoSyncTargetPageStart === 'number'
+      && typeof status.autoSyncTargetPageEnd === 'number'
+      && status.autoSyncTargetPageStart > 0
+      && status.autoSyncTargetPageEnd > 0
+    ) {
+      detailParts.push(`页窗 ${status.autoSyncTargetPageStart}-${status.autoSyncTargetPageEnd}`);
+    }
+    if (typeof status.autoSyncEffectivePageSize === 'number' && status.autoSyncEffectivePageSize > 0) {
+      detailParts.push(`页容量 ${status.autoSyncEffectivePageSize}`);
+    }
+    if (autoSync === 'running' && typeof status.autoSyncRemainingCapacity === 'number' && status.autoSyncRemainingCapacity > 0) {
+      detailParts.push(`剩余容量 ${status.autoSyncRemainingCapacity}`);
+    }
+
+    const stopReasonLabel = formatAutoSyncStopReason(status.autoSyncStopReason);
+    if (stopReasonLabel) {
+      detailParts.push(stopReasonLabel);
+    }
+
+    return {
+      autoSync,
+      stateLabel,
+      mainText: mainParts.join(' · ') || `自动同步 ${stateLabel}`,
+      detailText: detailParts.join(' · ')
+    };
+  }
+
+  globalThis.__TR_POPUP_AUTO_SYNC_SUMMARY__ = Object.freeze({
+    formatAutoSyncState,
+    formatAutoSyncStopReason,
+    buildAutoSyncSummary,
+  });
+})();

--- a/apps/browser-extension/popup-auto-sync-summary.test.mjs
+++ b/apps/browser-extension/popup-auto-sync-summary.test.mjs
@@ -1,0 +1,79 @@
+/* global console */
+
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import process from 'node:process';
+import test from 'node:test';
+import vm from 'node:vm';
+
+function loadPopupAutoSyncSummaryHelpers() {
+  const filePath = path.join(process.cwd(), 'apps/browser-extension/popup-auto-sync-summary.js');
+  const code = readFileSync(filePath, 'utf8');
+  const context = { console };
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(code, context, { filename: filePath });
+  return context.__TR_POPUP_AUTO_SYNC_SUMMARY__;
+}
+
+const helpers = loadPopupAutoSyncSummaryHelpers();
+
+test('builds a running seek summary with selected count and remaining capacity', () => {
+  const summary = helpers.buildAutoSyncSummary({
+    autoSync: 'running',
+    autoSyncCount: 40,
+    autoSyncPages: 2,
+    autoSyncSelectedCount: 20,
+    autoSyncTargetPageStart: 3,
+    autoSyncTargetPageEnd: 5,
+    autoSyncEffectivePageSize: 20,
+    autoSyncRemainingCapacity: 60,
+  });
+
+  assert.deepEqual(JSON.parse(JSON.stringify(summary)), {
+    autoSync: 'running',
+    stateLabel: '进行中',
+    mainText: '已采集 40 份 · 共 2 页 · 本页选中 20 份',
+    detailText: '页窗 3-5 · 页容量 20 · 剩余容量 60',
+  });
+});
+
+test('builds a completed seek summary with page-window stop reason', () => {
+  const summary = helpers.buildAutoSyncSummary({
+    autoSync: 'done',
+    autoSyncCount: 100,
+    autoSyncPages: 5,
+    autoSyncSelectedCount: 20,
+    autoSyncTargetPageStart: 1,
+    autoSyncTargetPageEnd: 5,
+    autoSyncEffectivePageSize: 20,
+    autoSyncStopReason: 'page-window-reached',
+  });
+
+  assert.deepEqual(JSON.parse(JSON.stringify(summary)), {
+    autoSync: 'done',
+    stateLabel: '已完成',
+    mainText: '已采集 100 份 · 共 5 页 · 本页选中 20 份',
+    detailText: '页窗 1-5 · 页容量 20 · 命中页窗上限',
+  });
+});
+
+test('returns a minimal fallback summary when only the state is available', () => {
+  const summary = helpers.buildAutoSyncSummary({
+    autoSync: 'failed',
+    autoSyncStopReason: 'failed',
+  });
+
+  assert.deepEqual(JSON.parse(JSON.stringify(summary)), {
+    autoSync: 'failed',
+    stateLabel: '失败',
+    mainText: '自动同步 失败',
+    detailText: '同步失败',
+  });
+});
+
+test('skips rendering when auto sync is absent or skipped', () => {
+  assert.equal(helpers.buildAutoSyncSummary({ autoSync: '' }), null);
+  assert.equal(helpers.buildAutoSyncSummary({ autoSync: 'skipped' }), null);
+});

--- a/apps/browser-extension/popup.css
+++ b/apps/browser-extension/popup.css
@@ -79,6 +79,70 @@ h1 {
   color: #555;
 }
 
+.auto-sync-summary {
+  margin-bottom: 16px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+}
+
+.auto-sync-summary__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.auto-sync-summary__title {
+  font-size: 12px;
+  color: #b8c0d6;
+  letter-spacing: 0.2px;
+}
+
+.auto-sync-summary__badge {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.08);
+  color: #d6dcf0;
+}
+
+.auto-sync-summary__badge.state-running {
+  background: rgba(33, 150, 243, 0.2);
+  color: #8cc8ff;
+}
+
+.auto-sync-summary__badge.state-done {
+  background: rgba(76, 175, 80, 0.18);
+  color: #9be7a2;
+}
+
+.auto-sync-summary__badge.state-cancelled {
+  background: rgba(255, 193, 7, 0.18);
+  color: #ffd666;
+}
+
+.auto-sync-summary__badge.state-failed {
+  background: rgba(244, 67, 54, 0.18);
+  color: #ff9d96;
+}
+
+.auto-sync-summary__main {
+  font-size: 13px;
+  line-height: 1.4;
+  color: #f3f5fb;
+}
+
+.auto-sync-summary__detail {
+  margin-top: 6px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: #9ca7c4;
+}
+
 .actions {
   display: flex;
   flex-direction: column;

--- a/apps/browser-extension/popup.html
+++ b/apps/browser-extension/popup.html
@@ -23,6 +23,15 @@
       共 <span id="total-items">-</span> 条简历
     </div>
 
+    <div id="auto-sync-summary" class="auto-sync-summary hidden">
+      <div class="auto-sync-summary__header">
+        <span class="auto-sync-summary__title">自动同步</span>
+        <span id="auto-sync-state" class="auto-sync-summary__badge">-</span>
+      </div>
+      <div id="auto-sync-main" class="auto-sync-summary__main"></div>
+      <div id="auto-sync-detail" class="auto-sync-summary__detail"></div>
+    </div>
+
     <div class="actions">
       <button id="btn-extract" class="btn btn-primary">
         <span class="icon">📥</span>
@@ -95,6 +104,7 @@
     </footer>
   </div>
 
+  <script src="popup-auto-sync-summary.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/apps/browser-extension/popup.js
+++ b/apps/browser-extension/popup.js
@@ -10,6 +10,10 @@ const statusText = /** @type {HTMLElement} */ (document.getElementById('status-t
 const pageCurrent = /** @type {HTMLElement} */ (document.getElementById('page-current'));
 const pageTotal = /** @type {HTMLElement} */ (document.getElementById('page-total'));
 const totalItems = /** @type {HTMLElement} */ (document.getElementById('total-items'));
+const autoSyncSummary = /** @type {HTMLElement} */ (document.getElementById('auto-sync-summary'));
+const autoSyncState = /** @type {HTMLElement} */ (document.getElementById('auto-sync-state'));
+const autoSyncMain = /** @type {HTMLElement} */ (document.getElementById('auto-sync-main'));
+const autoSyncDetail = /** @type {HTMLElement} */ (document.getElementById('auto-sync-detail'));
 const btnExtract = /** @type {HTMLButtonElement} */ (document.getElementById('btn-extract'));
 const btnCSV = /** @type {HTMLButtonElement} */ (document.getElementById('btn-csv'));
 const btnJSON = /** @type {HTMLButtonElement} */ (document.getElementById('btn-json'));
@@ -32,6 +36,23 @@ const DEFAULT_SERVER_URL = 'https://trends.pt-mes.com';
 let lastDiagnosticDownloadId = null;
 let serverConfigured = false;
 let configuredServerUrl = '';
+let runtimeStatusIntervalId = null;
+
+function getPopupAutoSyncSummaryHelpers() {
+    const helpers = globalThis.__TR_POPUP_AUTO_SYNC_SUMMARY__;
+    return helpers && typeof helpers === 'object' ? helpers : null;
+}
+
+function getTargetTabIdOverride() {
+    try {
+        const params = new URLSearchParams(window.location.search || '');
+        const rawTabId = params.get('tabId') || '';
+        const parsedTabId = Number.parseInt(rawTabId, 10);
+        return Number.isFinite(parsedTabId) && parsedTabId >= 0 ? parsedTabId : null;
+    } catch {
+        return null;
+    }
+}
 
 /**
  * Show status message
@@ -59,8 +80,11 @@ async function sendToBackground(action, data = {}) {
  * Send message to content script
  */
 async function sendToContent(action, data = {}) {
-    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-    const tab = tabs[0];
+    const targetTabId = getTargetTabIdOverride();
+    const tab = targetTabId !== null
+        ? await chrome.tabs.get(targetTabId)
+        : (await chrome.tabs.query({ active: true, currentWindow: true }))[0];
+
     if (!tab || typeof tab.id !== 'number') {
         throw new Error('No active tab');
     }
@@ -95,12 +119,73 @@ function showDiagnostics(payload) {
 async function updatePaginationInfo() {
     try {
         const info = await sendToContent('getPaginationInfo');
-        pageCurrent.textContent = info.currentPage || '-';
-        pageTotal.textContent = info.totalPages || '-';
-        totalItems.textContent = info.totalItems || '-';
+        renderPagination(info);
     } catch (error) {
         console.error('Pagination error:', error);
     }
+}
+
+function renderPagination(pagination = {}) {
+    pageCurrent.textContent = pagination.currentPage || '-';
+    pageTotal.textContent = pagination.totalPages || '-';
+    totalItems.textContent = pagination.totalItems || '-';
+}
+
+function hideAutoSyncSummary() {
+    if (!autoSyncSummary || !autoSyncState || !autoSyncMain || !autoSyncDetail) return;
+    autoSyncSummary.classList.add('hidden');
+    autoSyncState.textContent = '-';
+    autoSyncState.className = 'auto-sync-summary__badge';
+    autoSyncMain.textContent = '';
+    autoSyncDetail.textContent = '';
+}
+
+function renderAutoSyncSummary(status) {
+    if (!autoSyncSummary || !autoSyncState || !autoSyncMain || !autoSyncDetail) return;
+    const helpers = getPopupAutoSyncSummaryHelpers();
+    const summary = typeof helpers?.buildAutoSyncSummary === 'function'
+        ? helpers.buildAutoSyncSummary(status)
+        : null;
+    if (!summary) {
+        hideAutoSyncSummary();
+        return;
+    }
+
+    autoSyncSummary.classList.remove('hidden');
+    autoSyncState.textContent = summary.stateLabel;
+    autoSyncState.className = `auto-sync-summary__badge state-${summary.autoSync}`;
+    autoSyncMain.textContent = summary.mainText;
+    autoSyncDetail.textContent = summary.detailText;
+    autoSyncDetail.classList.toggle('hidden', !summary.detailText);
+}
+
+async function refreshRuntimeStatus() {
+    try {
+        const response = await sendToContent('getRuntimeStatus');
+        if (!response?.success || !response.status) {
+            hideAutoSyncSummary();
+            await updatePaginationInfo();
+            return;
+        }
+
+        const status = response.status;
+        if (status.pagination) {
+            renderPagination(status.pagination);
+        } else {
+            await updatePaginationInfo();
+        }
+        renderAutoSyncSummary(status);
+    } catch (error) {
+        hideAutoSyncSummary();
+        console.error('Runtime status error:', error);
+    }
+}
+
+function startRuntimeStatusPolling() {
+    if (runtimeStatusIntervalId !== null) return;
+    runtimeStatusIntervalId = window.setInterval(() => {
+        refreshRuntimeStatus();
+    }, 1500);
 }
 
 async function refreshServerConfig() {
@@ -277,9 +362,7 @@ async function handleExtract() {
             showPreview(resumes);
 
             if (response.pagination) {
-                pageCurrent.textContent = response.pagination.currentPage || '-';
-                pageTotal.textContent = response.pagination.totalPages || '-';
-                totalItems.textContent = response.pagination.totalItems || '-';
+                renderPagination(response.pagination);
             }
         } else {
             showStatus('提取失败', 'error');
@@ -358,7 +441,6 @@ if (lnkConfigureServer) {
 
 // Initialize
 document.addEventListener('DOMContentLoaded', () => {
-    updatePaginationInfo();
     refreshServerConfig();
 
     if (optSaveAs) {
@@ -370,8 +452,22 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    sendToContent('ping').catch(() => {
-        showStatus('请刷新 Job5156 或 Seek 页面', 'error');
-    });
+    sendToContent('ping')
+        .then(() => {
+            refreshRuntimeStatus();
+            startRuntimeStatusPolling();
+        })
+        .catch(() => {
+            hideAutoSyncSummary();
+            updatePaginationInfo();
+            showStatus('请刷新 Job5156 或 Seek 页面', 'error');
+        });
+});
+
+window.addEventListener('unload', () => {
+    if (runtimeStatusIntervalId !== null) {
+        window.clearInterval(runtimeStatusIntervalId);
+        runtimeStatusIntervalId = null;
+    }
 });
 })();


### PR DESCRIPTION
## Summary
- expose content-script runtime auto-sync status to the extension popup
- render a popup summary card for running and completed auto-sync state, including SEEK selected count and page-window detail
- add a focused popup summary helper test for the rendered summary strings

## Verification
- node --test apps/browser-extension/popup-auto-sync-summary.test.mjs
- npm --workspace @trends/browser-extension run lint
- npm --workspace @trends/browser-extension run typecheck
- make check
- live SEEK page verification of content status and completion state on jobId=90842915 pageNumber=3 tr_limit=5