### PR TITLE
feat: persist popup auto sync summary

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -69,6 +69,7 @@ const PAGE_BRIDGE_RESPONSE_ATTR = 'data-tr-resume-bridge-response';
 const JOB5156_DETAIL_FETCH_TIMEOUT_MS = 5000;
 const JOB5156_DETAIL_FETCH_CONCURRENCY = 5;
 const DEFAULT_SEEK_PAGE_SIZE = 20;
+const LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY = 'latestAutoSyncSummary';
 
 const apiSnapshot = {
   searchRows: null,
@@ -85,6 +86,8 @@ const apiSnapshot = {
   lastSourceKey: null,
   lastOperationName: null
 };
+
+let lastPersistedAutoSyncSummaryFingerprint = '';
 
 function sanitizeSampleName(value) {
   if (!value) return '';
@@ -645,6 +648,8 @@ function setSeekAutoSyncWindowAttributes(pageWindow) {
   } catch {
     // ignore
   }
+
+  persistLatestAutoSyncSummary();
 }
 
 /**
@@ -670,6 +675,8 @@ function setSeekAutoSyncSelectionAttributes(selection) {
   } catch {
     // ignore
   }
+
+  persistLatestAutoSyncSummary();
 }
 
 function findSeekProfileTrigger(profileId) {
@@ -2521,6 +2528,10 @@ function setAutoSyncAttributes(status, count, pagesProcessed) {
   } catch {
     // ignore
   }
+
+  if (status && status !== 'skipped') {
+    persistLatestAutoSyncSummary();
+  }
 }
 
 /**
@@ -3884,6 +3895,7 @@ async function runAutoSyncIfEnabled() {
     } catch {
       // ignore
     }
+    persistLatestAutoSyncSummary();
 
     if (autoSyncCancelled) {
       SyncStatusWidget.show({
@@ -3925,6 +3937,7 @@ async function runAutoSyncIfEnabled() {
     } catch {
       // ignore
     }
+    persistLatestAutoSyncSummary();
   }
 }
 
@@ -3995,6 +4008,63 @@ function getExtensionVersion() {
 
 function isLoggedIn() {
   return !document.querySelector('.login-btn, [href*="login"]');
+}
+
+function buildPersistedAutoSyncSummary(status = getExternalAccessorStatus()) {
+  const autoSync = typeof status?.autoSync === 'string' ? status.autoSync : '';
+  if (!autoSync || autoSync === 'skipped') {
+    return null;
+  }
+
+  return {
+    autoSync,
+    autoSyncCount: typeof status?.autoSyncCount === 'number' ? status.autoSyncCount : 0,
+    autoSyncPages: typeof status?.autoSyncPages === 'number' ? status.autoSyncPages : 0,
+    autoSyncTargetPageStart: status?.autoSyncTargetPageStart ?? null,
+    autoSyncTargetPageEnd: status?.autoSyncTargetPageEnd ?? null,
+    autoSyncEffectivePageSize: status?.autoSyncEffectivePageSize ?? null,
+    autoSyncSelectedCount: status?.autoSyncSelectedCount ?? null,
+    autoSyncRemainingCapacity: status?.autoSyncRemainingCapacity ?? null,
+    autoSyncStopReason: status?.autoSyncStopReason ?? null,
+    sourceKey: typeof status?.sourceKey === 'string' ? status.sourceKey : getCurrentSourceKey(),
+    sourceUrl: window.location.href,
+    summarySource: 'stored',
+    persistedAt: new Date().toISOString(),
+  };
+}
+
+function persistLatestAutoSyncSummary() {
+  try {
+    if (!chrome?.storage?.local?.set) return;
+    const summary = buildPersistedAutoSyncSummary();
+    if (!summary) return;
+
+    const fingerprint = JSON.stringify({
+      autoSync: summary.autoSync,
+      autoSyncCount: summary.autoSyncCount,
+      autoSyncPages: summary.autoSyncPages,
+      autoSyncTargetPageStart: summary.autoSyncTargetPageStart,
+      autoSyncTargetPageEnd: summary.autoSyncTargetPageEnd,
+      autoSyncEffectivePageSize: summary.autoSyncEffectivePageSize,
+      autoSyncSelectedCount: summary.autoSyncSelectedCount,
+      autoSyncRemainingCapacity: summary.autoSyncRemainingCapacity,
+      autoSyncStopReason: summary.autoSyncStopReason,
+      sourceKey: summary.sourceKey,
+      sourceUrl: summary.sourceUrl,
+      summarySource: summary.summarySource,
+    });
+
+    if (summary.autoSync === 'running' && fingerprint === lastPersistedAutoSyncSummaryFingerprint) {
+      return;
+    }
+
+    lastPersistedAutoSyncSummaryFingerprint = fingerprint;
+    chrome.storage.local.set({
+      [LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY]: summary
+    });
+  } catch (error) {
+    console.warn('🎯 [Auto Sync] Failed to persist latest auto sync summary:', error);
+  }
 }
 
 function getExternalAccessorStatus() {

--- a/apps/browser-extension/popup-auto-sync-summary.js
+++ b/apps/browser-extension/popup-auto-sync-summary.js
@@ -42,6 +42,31 @@
   }
 
   /**
+   * @param {string | null | undefined} sourceKey
+   * @returns {string}
+   */
+  function formatAutoSyncSourceKey(sourceKey) {
+    if (sourceKey === 'seek') return 'SEEK';
+    if (sourceKey === 'job5156') return 'Job5156';
+    return '';
+  }
+
+  /**
+   * @param {string | null | undefined} persistedAt
+   * @returns {string}
+   */
+  function formatAutoSyncPersistedAt(persistedAt) {
+    if (typeof persistedAt !== 'string') return '';
+    const trimmed = persistedAt.trim();
+    if (!trimmed) return '';
+    return trimmed
+      .replace('T', ' ')
+      .replace(/\.\d+Z?$/u, '')
+      .replace(/Z$/u, '')
+      .slice(0, 16);
+  }
+
+  /**
    * @param {{
    *   autoSync?: string;
    *   autoSyncCount?: number | null;
@@ -52,6 +77,9 @@
    *   autoSyncEffectivePageSize?: number | null;
    *   autoSyncRemainingCapacity?: number | null;
    *   autoSyncStopReason?: string | null;
+   *   summarySource?: string | null;
+   *   sourceKey?: string | null;
+   *   persistedAt?: string | null;
    * }} [status]
    * @returns {{ autoSync: string; stateLabel: string; mainText: string; detailText: string } | null}
    */
@@ -94,6 +122,17 @@
     if (stopReasonLabel) {
       detailParts.push(stopReasonLabel);
     }
+    if (status.summarySource === 'stored') {
+      detailParts.push('最近一次记录');
+      const sourceKeyLabel = formatAutoSyncSourceKey(status.sourceKey);
+      if (sourceKeyLabel) {
+        detailParts.push(`来源 ${sourceKeyLabel}`);
+      }
+      const persistedAtLabel = formatAutoSyncPersistedAt(status.persistedAt);
+      if (persistedAtLabel) {
+        detailParts.push(`记录于 ${persistedAtLabel}`);
+      }
+    }
 
     return {
       autoSync,
@@ -106,6 +145,8 @@
   globalThis.__TR_POPUP_AUTO_SYNC_SUMMARY__ = Object.freeze({
     formatAutoSyncState,
     formatAutoSyncStopReason,
+    formatAutoSyncSourceKey,
+    formatAutoSyncPersistedAt,
     buildAutoSyncSummary,
   });
 })();

--- a/apps/browser-extension/popup-auto-sync-summary.test.mjs
+++ b/apps/browser-extension/popup-auto-sync-summary.test.mjs
@@ -73,6 +73,26 @@ test('returns a minimal fallback summary when only the state is available', () =
   });
 });
 
+test('adds stored-summary metadata when rendering the last persisted result', () => {
+  const summary = helpers.buildAutoSyncSummary({
+    autoSync: 'done',
+    autoSyncCount: 5,
+    autoSyncPages: 1,
+    autoSyncSelectedCount: 5,
+    autoSyncStopReason: 'limit-reached',
+    summarySource: 'stored',
+    sourceKey: 'seek',
+    persistedAt: '2026-03-17T08:21:35.000Z',
+  });
+
+  assert.deepEqual(JSON.parse(JSON.stringify(summary)), {
+    autoSync: 'done',
+    stateLabel: '已完成',
+    mainText: '已采集 5 份 · 共 1 页 · 本页选中 5 份',
+    detailText: '命中数量上限 · 最近一次记录 · 来源 SEEK · 记录于 2026-03-17 08:21',
+  });
+});
+
 test('skips rendering when auto sync is absent or skipped', () => {
   assert.equal(helpers.buildAutoSyncSummary({ autoSync: '' }), null);
   assert.equal(helpers.buildAutoSyncSummary({ autoSync: 'skipped' }), null);

--- a/apps/browser-extension/popup.js
+++ b/apps/browser-extension/popup.js
@@ -31,6 +31,7 @@ const lnkConfigureServer = /** @type {HTMLAnchorElement} */ (document.getElement
 const btnSync = /** @type {HTMLButtonElement} */ (document.getElementById('btn-sync'));
 const syncResult = /** @type {HTMLElement} */ (document.getElementById('sync-result'));
 const DEFAULT_SERVER_URL = 'https://trends.pt-mes.com';
+const LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY = 'latestAutoSyncSummary';
 
 // State
 let lastDiagnosticDownloadId = null;
@@ -74,6 +75,12 @@ function showStatus(message, type = 'info') {
  */
 async function sendToBackground(action, data = {}) {
     return chrome.runtime.sendMessage({ action, ...data });
+}
+
+function storageLocalGet(defaults) {
+    return new Promise((resolve) => {
+        chrome.storage.local.get(defaults, (items) => resolve(items || {}));
+    });
 }
 
 /**
@@ -140,6 +147,19 @@ function hideAutoSyncSummary() {
     autoSyncDetail.textContent = '';
 }
 
+async function getStoredAutoSyncSummary() {
+    try {
+        const items = await storageLocalGet({ [LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY]: null });
+        const summary = items?.[LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY];
+        return summary && typeof summary === 'object' && !Array.isArray(summary)
+            ? summary
+            : null;
+    } catch (error) {
+        console.error('Stored auto sync summary error:', error);
+        return null;
+    }
+}
+
 function renderAutoSyncSummary(status) {
     if (!autoSyncSummary || !autoSyncState || !autoSyncMain || !autoSyncDetail) return;
     const helpers = getPopupAutoSyncSummaryHelpers();
@@ -163,7 +183,12 @@ async function refreshRuntimeStatus() {
     try {
         const response = await sendToContent('getRuntimeStatus');
         if (!response?.success || !response.status) {
-            hideAutoSyncSummary();
+            const storedSummary = await getStoredAutoSyncSummary();
+            if (storedSummary) {
+                renderAutoSyncSummary(storedSummary);
+            } else {
+                hideAutoSyncSummary();
+            }
             await updatePaginationInfo();
             return;
         }
@@ -174,9 +199,24 @@ async function refreshRuntimeStatus() {
         } else {
             await updatePaginationInfo();
         }
-        renderAutoSyncSummary(status);
+        if (status.autoSync && status.autoSync !== 'skipped') {
+            renderAutoSyncSummary(status);
+            return;
+        }
+
+        const storedSummary = await getStoredAutoSyncSummary();
+        if (storedSummary) {
+            renderAutoSyncSummary(storedSummary);
+        } else {
+            hideAutoSyncSummary();
+        }
     } catch (error) {
-        hideAutoSyncSummary();
+        const storedSummary = await getStoredAutoSyncSummary();
+        if (storedSummary) {
+            renderAutoSyncSummary(storedSummary);
+        } else {
+            hideAutoSyncSummary();
+        }
         console.error('Runtime status error:', error);
     }
 }
@@ -457,8 +497,13 @@ document.addEventListener('DOMContentLoaded', () => {
             refreshRuntimeStatus();
             startRuntimeStatusPolling();
         })
-        .catch(() => {
-            hideAutoSyncSummary();
+        .catch(async () => {
+            const storedSummary = await getStoredAutoSyncSummary();
+            if (storedSummary) {
+                renderAutoSyncSummary(storedSummary);
+            } else {
+                hideAutoSyncSummary();
+            }
             updatePaginationInfo();
             showStatus('请刷新 Job5156 或 Seek 页面', 'error');
         });


### PR DESCRIPTION
## Summary
- persist the latest auto-sync summary in extension storage from the content script
- make the popup fall back to that stored summary when current runtime status is missing or the tab is unsupported
- extend popup summary formatting/tests to label stored summaries with source and recorded time

## Verification
- node --test apps/browser-extension/popup-auto-sync-summary.test.mjs
- npm --workspace @trends/browser-extension run lint
- npm --workspace @trends/browser-extension run typecheck
- make check
- live popup fallback verification via chrome-extension://.../popup.html?tabId=999999 showing the stored SEEK summary