### PR TITLE
feat: expire stored popup sync summaries

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -69,7 +69,7 @@ const PAGE_BRIDGE_RESPONSE_ATTR = 'data-tr-resume-bridge-response';
 const JOB5156_DETAIL_FETCH_TIMEOUT_MS = 5000;
 const JOB5156_DETAIL_FETCH_CONCURRENCY = 5;
 const DEFAULT_SEEK_PAGE_SIZE = 20;
-const LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY = 'latestAutoSyncSummary';
+const LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY = 'latestAutoSyncSummaries';
 
 const apiSnapshot = {
   searchRows: null,
@@ -87,7 +87,7 @@ const apiSnapshot = {
   lastOperationName: null
 };
 
-let lastPersistedAutoSyncSummaryFingerprint = '';
+const lastPersistedAutoSyncSummaryFingerprintBySource = {};
 
 function sanitizeSampleName(value) {
   if (!value) return '';
@@ -4035,9 +4035,12 @@ function buildPersistedAutoSyncSummary(status = getExternalAccessorStatus()) {
 
 function persistLatestAutoSyncSummary() {
   try {
-    if (!chrome?.storage?.local?.set) return;
+    if (!chrome?.storage?.local?.get || !chrome?.storage?.local?.set) return;
     const summary = buildPersistedAutoSyncSummary();
     if (!summary) return;
+    const sourceKey = typeof summary.sourceKey === 'string' && summary.sourceKey
+      ? summary.sourceKey
+      : SOURCE_KEYS.UNKNOWN;
 
     const fingerprint = JSON.stringify({
       autoSync: summary.autoSync,
@@ -4054,13 +4057,23 @@ function persistLatestAutoSyncSummary() {
       summarySource: summary.summarySource,
     });
 
-    if (summary.autoSync === 'running' && fingerprint === lastPersistedAutoSyncSummaryFingerprint) {
+    if (
+      summary.autoSync === 'running'
+      && lastPersistedAutoSyncSummaryFingerprintBySource[sourceKey] === fingerprint
+    ) {
       return;
     }
 
-    lastPersistedAutoSyncSummaryFingerprint = fingerprint;
-    chrome.storage.local.set({
-      [LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY]: summary
+    lastPersistedAutoSyncSummaryFingerprintBySource[sourceKey] = fingerprint;
+    chrome.storage.local.get({ [LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY]: {} }, (items) => {
+      const existingSummaries = items?.[LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY];
+      const nextSummaries = existingSummaries && typeof existingSummaries === 'object' && !Array.isArray(existingSummaries)
+        ? { ...existingSummaries }
+        : {};
+      nextSummaries[sourceKey] = summary;
+      chrome.storage.local.set({
+        [LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY]: nextSummaries
+      });
     });
   } catch (error) {
     console.warn('🎯 [Auto Sync] Failed to persist latest auto sync summary:', error);

--- a/apps/browser-extension/popup-auto-sync-summary.js
+++ b/apps/browser-extension/popup-auto-sync-summary.js
@@ -1,4 +1,6 @@
 (() => {
+  const DEFAULT_STORED_AUTO_SYNC_SUMMARY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
   /**
    * @param {string} autoSync
    * @returns {string}
@@ -64,6 +66,88 @@
       .replace(/\.\d+Z?$/u, '')
       .replace(/Z$/u, '')
       .slice(0, 16);
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {Record<string, unknown> | null}
+   */
+  function normalizeStoredAutoSyncSummary(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return null;
+    }
+    return /** @type {Record<string, unknown>} */ (value);
+  }
+
+  /**
+   * @param {Record<string, unknown> | null | undefined} summariesBySource
+   * @returns {Array<Record<string, unknown>>}
+   */
+  function listStoredAutoSyncSummaries(summariesBySource) {
+    if (!summariesBySource || typeof summariesBySource !== 'object' || Array.isArray(summariesBySource)) {
+      return [];
+    }
+
+    const summaries = /** @type {Array<Record<string, unknown>>} */ ([]);
+    for (const value of Object.values(summariesBySource)) {
+      const summary = normalizeStoredAutoSyncSummary(value);
+      if (summary) {
+        summaries.push(summary);
+      }
+    }
+    return summaries;
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {number | null}
+   */
+  function parsePersistedAtMs(value) {
+    if (typeof value !== 'string') return null;
+    const timestamp = Date.parse(value);
+    return Number.isFinite(timestamp) ? timestamp : null;
+  }
+
+  /**
+   * @param {{
+   *   summariesBySource?: Record<string, unknown> | null;
+   *   preferredSourceKey?: string | null;
+   *   nowMs?: number;
+   *   maxAgeMs?: number;
+   * }} [options]
+   * @returns {Record<string, unknown> | null}
+   */
+  function pickStoredAutoSyncSummary(options = {}) {
+    const {
+      summariesBySource = null,
+      preferredSourceKey = '',
+      nowMs = Date.now(),
+      maxAgeMs = DEFAULT_STORED_AUTO_SYNC_SUMMARY_MAX_AGE_MS,
+    } = options;
+    const candidates = listStoredAutoSyncSummaries(summariesBySource)
+      .map((summary) => ({
+        summary,
+        persistedAtMs: parsePersistedAtMs(summary.persistedAt),
+      }))
+      .filter(({ summary, persistedAtMs }) => {
+        const autoSync = typeof summary.autoSync === 'string' ? summary.autoSync : '';
+        if (!autoSync || autoSync === 'skipped') return false;
+        if (!Number.isFinite(persistedAtMs)) return false;
+        return nowMs - persistedAtMs <= maxAgeMs;
+      })
+      .sort((left, right) => /** @type {number} */ (right.persistedAtMs) - /** @type {number} */ (left.persistedAtMs));
+
+    if (!candidates.length) {
+      return null;
+    }
+
+    const normalizedPreferredSourceKey = typeof preferredSourceKey === 'string' ? preferredSourceKey.trim() : '';
+    if (normalizedPreferredSourceKey) {
+      const matched = candidates.find(({ summary }) => summary.sourceKey === normalizedPreferredSourceKey);
+      return matched ? matched.summary : null;
+    }
+
+    return candidates[0]?.summary || null;
   }
 
   /**
@@ -143,10 +227,15 @@
   }
 
   globalThis.__TR_POPUP_AUTO_SYNC_SUMMARY__ = Object.freeze({
+    DEFAULT_STORED_AUTO_SYNC_SUMMARY_MAX_AGE_MS,
     formatAutoSyncState,
     formatAutoSyncStopReason,
     formatAutoSyncSourceKey,
     formatAutoSyncPersistedAt,
+    normalizeStoredAutoSyncSummary,
+    listStoredAutoSyncSummaries,
+    parsePersistedAtMs,
+    pickStoredAutoSyncSummary,
     buildAutoSyncSummary,
   });
 })();

--- a/apps/browser-extension/popup-auto-sync-summary.test.mjs
+++ b/apps/browser-extension/popup-auto-sync-summary.test.mjs
@@ -93,6 +93,76 @@ test('adds stored-summary metadata when rendering the last persisted result', ()
   });
 });
 
+test('picks the preferred source summary when it is recent', () => {
+  const summary = helpers.pickStoredAutoSyncSummary({
+    summariesBySource: {
+      seek: {
+        autoSync: 'done',
+        sourceKey: 'seek',
+        persistedAt: '2026-03-17T08:31:00.000Z',
+      },
+      job5156: {
+        autoSync: 'done',
+        sourceKey: 'job5156',
+        persistedAt: '2026-03-17T08:32:00.000Z',
+      },
+    },
+    preferredSourceKey: 'seek',
+    nowMs: Date.parse('2026-03-17T08:35:00.000Z'),
+  });
+
+  assert.deepEqual(JSON.parse(JSON.stringify(summary)), {
+    autoSync: 'done',
+    sourceKey: 'seek',
+    persistedAt: '2026-03-17T08:31:00.000Z',
+  });
+});
+
+test('returns the newest recent summary when no preferred source is available', () => {
+  const summary = helpers.pickStoredAutoSyncSummary({
+    summariesBySource: {
+      seek: {
+        autoSync: 'done',
+        sourceKey: 'seek',
+        persistedAt: '2026-03-17T08:31:00.000Z',
+      },
+      job5156: {
+        autoSync: 'done',
+        sourceKey: 'job5156',
+        persistedAt: '2026-03-17T08:32:00.000Z',
+      },
+    },
+    nowMs: Date.parse('2026-03-17T08:35:00.000Z'),
+  });
+
+  assert.deepEqual(JSON.parse(JSON.stringify(summary)), {
+    autoSync: 'done',
+    sourceKey: 'job5156',
+    persistedAt: '2026-03-17T08:32:00.000Z',
+  });
+});
+
+test('expires stale stored summaries and returns null when no recent preferred summary exists', () => {
+  const summary = helpers.pickStoredAutoSyncSummary({
+    summariesBySource: {
+      seek: {
+        autoSync: 'done',
+        sourceKey: 'seek',
+        persistedAt: '2026-03-15T08:31:00.000Z',
+      },
+      job5156: {
+        autoSync: 'done',
+        sourceKey: 'job5156',
+        persistedAt: '2026-03-17T08:32:00.000Z',
+      },
+    },
+    preferredSourceKey: 'seek',
+    nowMs: Date.parse('2026-03-17T08:35:00.000Z'),
+  });
+
+  assert.equal(summary, null);
+});
+
 test('skips rendering when auto sync is absent or skipped', () => {
   assert.equal(helpers.buildAutoSyncSummary({ autoSync: '' }), null);
   assert.equal(helpers.buildAutoSyncSummary({ autoSync: 'skipped' }), null);

--- a/apps/browser-extension/popup.js
+++ b/apps/browser-extension/popup.js
@@ -31,7 +31,8 @@ const lnkConfigureServer = /** @type {HTMLAnchorElement} */ (document.getElement
 const btnSync = /** @type {HTMLButtonElement} */ (document.getElementById('btn-sync'));
 const syncResult = /** @type {HTMLElement} */ (document.getElementById('sync-result'));
 const DEFAULT_SERVER_URL = 'https://trends.pt-mes.com';
-const LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY = 'latestAutoSyncSummary';
+const LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY = 'latestAutoSyncSummaries';
+const LEGACY_LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY = 'latestAutoSyncSummary';
 
 // State
 let lastDiagnosticDownloadId = null;
@@ -52,6 +53,30 @@ function getTargetTabIdOverride() {
         return Number.isFinite(parsedTabId) && parsedTabId >= 0 ? parsedTabId : null;
     } catch {
         return null;
+    }
+}
+
+async function getTargetTab() {
+    const targetTabId = getTargetTabIdOverride();
+    return targetTabId !== null
+        ? chrome.tabs.get(targetTabId)
+        : (await chrome.tabs.query({ active: true, currentWindow: true }))[0];
+}
+
+function getSourceKeyFromTabUrl(url) {
+    const value = typeof url === 'string' ? url : '';
+    if (!value) return '';
+    if (value.includes('hr.job5156.com')) return 'job5156';
+    if (value.includes('.employer.seek.com')) return 'seek';
+    return '';
+}
+
+async function getPreferredStoredSummarySourceKey() {
+    try {
+        const tab = await getTargetTab();
+        return getSourceKeyFromTabUrl(tab?.url);
+    } catch {
+        return '';
     }
 }
 
@@ -87,10 +112,7 @@ function storageLocalGet(defaults) {
  * Send message to content script
  */
 async function sendToContent(action, data = {}) {
-    const targetTabId = getTargetTabIdOverride();
-    const tab = targetTabId !== null
-        ? await chrome.tabs.get(targetTabId)
-        : (await chrome.tabs.query({ active: true, currentWindow: true }))[0];
+    const tab = await getTargetTab();
 
     if (!tab || typeof tab.id !== 'number') {
         throw new Error('No active tab');
@@ -149,11 +171,35 @@ function hideAutoSyncSummary() {
 
 async function getStoredAutoSyncSummary() {
     try {
-        const items = await storageLocalGet({ [LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY]: null });
-        const summary = items?.[LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY];
-        return summary && typeof summary === 'object' && !Array.isArray(summary)
-            ? summary
-            : null;
+        const helpers = getPopupAutoSyncSummaryHelpers();
+        if (typeof helpers?.pickStoredAutoSyncSummary !== 'function') {
+            return null;
+        }
+
+        const preferredSourceKey = await getPreferredStoredSummarySourceKey();
+        const items = await storageLocalGet({
+            [LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY]: {},
+            [LEGACY_LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY]: null
+        });
+        const storedSummaries = items?.[LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY];
+        const legacySummary = items?.[LEGACY_LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY];
+        const normalizedStoredSummaries = storedSummaries && typeof storedSummaries === 'object' && !Array.isArray(storedSummaries)
+            ? { ...storedSummaries }
+            : {};
+
+        if (legacySummary && typeof legacySummary === 'object' && !Array.isArray(legacySummary)) {
+            const legacySourceKey = typeof legacySummary.sourceKey === 'string' && legacySummary.sourceKey
+                ? legacySummary.sourceKey
+                : 'unknown';
+            if (!normalizedStoredSummaries[legacySourceKey]) {
+                normalizedStoredSummaries[legacySourceKey] = legacySummary;
+            }
+        }
+
+        return helpers.pickStoredAutoSyncSummary({
+            summariesBySource: normalizedStoredSummaries,
+            preferredSourceKey,
+        });
     } catch (error) {
         console.error('Stored auto sync summary error:', error);
         return null;


### PR DESCRIPTION
## Summary
- keep only the latest stored auto-sync summary per source instead of a single global record
- add a 24-hour expiry window when selecting stored popup summaries
- restrict source-aware popup fallback to the matching source and only fall back across sources when there is no supported source context

## Verification
- node --test apps/browser-extension/popup-auto-sync-summary.test.mjs
- npm --workspace @trends/browser-extension run lint
- npm --workspace @trends/browser-extension run typecheck
- make check
- live fallback verification via chrome-extension://.../popup.html?tabId=999999 showing the refreshed stored SEEK summary