### PR TITLE
feat: clear stored popup sync summaries

### DIFF
--- a/apps/browser-extension/popup.css
+++ b/apps/browser-extension/popup.css
@@ -95,10 +95,35 @@ h1 {
   margin-bottom: 8px;
 }
 
+.auto-sync-summary__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .auto-sync-summary__title {
   font-size: 12px;
   color: #b8c0d6;
   letter-spacing: 0.2px;
+}
+
+.auto-sync-summary__clear {
+  border: none;
+  background: transparent;
+  color: #64b5f6;
+  font-size: 11px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.auto-sync-summary__clear:hover {
+  text-decoration: underline;
+}
+
+.auto-sync-summary__clear:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  text-decoration: none;
 }
 
 .auto-sync-summary__badge {

--- a/apps/browser-extension/popup.html
+++ b/apps/browser-extension/popup.html
@@ -26,7 +26,10 @@
     <div id="auto-sync-summary" class="auto-sync-summary hidden">
       <div class="auto-sync-summary__header">
         <span class="auto-sync-summary__title">自动同步</span>
-        <span id="auto-sync-state" class="auto-sync-summary__badge">-</span>
+        <div class="auto-sync-summary__actions">
+          <button id="btn-clear-auto-sync-summary" class="auto-sync-summary__clear hidden" type="button">清除记录</button>
+          <span id="auto-sync-state" class="auto-sync-summary__badge">-</span>
+        </div>
       </div>
       <div id="auto-sync-main" class="auto-sync-summary__main"></div>
       <div id="auto-sync-detail" class="auto-sync-summary__detail"></div>

--- a/apps/browser-extension/popup.js
+++ b/apps/browser-extension/popup.js
@@ -14,6 +14,7 @@ const autoSyncSummary = /** @type {HTMLElement} */ (document.getElementById('aut
 const autoSyncState = /** @type {HTMLElement} */ (document.getElementById('auto-sync-state'));
 const autoSyncMain = /** @type {HTMLElement} */ (document.getElementById('auto-sync-main'));
 const autoSyncDetail = /** @type {HTMLElement} */ (document.getElementById('auto-sync-detail'));
+const btnClearAutoSyncSummary = /** @type {HTMLButtonElement} */ (document.getElementById('btn-clear-auto-sync-summary'));
 const btnExtract = /** @type {HTMLButtonElement} */ (document.getElementById('btn-extract'));
 const btnCSV = /** @type {HTMLButtonElement} */ (document.getElementById('btn-csv'));
 const btnJSON = /** @type {HTMLButtonElement} */ (document.getElementById('btn-json'));
@@ -108,6 +109,12 @@ function storageLocalGet(defaults) {
     });
 }
 
+function storageLocalRemove(keys) {
+    return new Promise((resolve) => {
+        chrome.storage.local.remove(keys, () => resolve());
+    });
+}
+
 /**
  * Send message to content script
  */
@@ -167,6 +174,10 @@ function hideAutoSyncSummary() {
     autoSyncState.className = 'auto-sync-summary__badge';
     autoSyncMain.textContent = '';
     autoSyncDetail.textContent = '';
+    if (btnClearAutoSyncSummary) {
+        btnClearAutoSyncSummary.classList.add('hidden');
+        btnClearAutoSyncSummary.disabled = false;
+    }
 }
 
 async function getStoredAutoSyncSummary() {
@@ -223,6 +234,30 @@ function renderAutoSyncSummary(status) {
     autoSyncMain.textContent = summary.mainText;
     autoSyncDetail.textContent = summary.detailText;
     autoSyncDetail.classList.toggle('hidden', !summary.detailText);
+    if (btnClearAutoSyncSummary) {
+        btnClearAutoSyncSummary.classList.toggle('hidden', status?.summarySource !== 'stored');
+        btnClearAutoSyncSummary.disabled = false;
+    }
+}
+
+async function handleClearStoredAutoSyncSummary() {
+    if (btnClearAutoSyncSummary) {
+        btnClearAutoSyncSummary.disabled = true;
+    }
+
+    try {
+        await storageLocalRemove([
+            LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY,
+            LEGACY_LATEST_AUTO_SYNC_SUMMARY_STORAGE_KEY,
+        ]);
+        hideAutoSyncSummary();
+        showStatus('已清除自动同步记录', 'success');
+    } catch (error) {
+        showStatus(error?.message || '清除记录失败', 'error');
+        if (btnClearAutoSyncSummary) {
+            btnClearAutoSyncSummary.disabled = false;
+        }
+    }
 }
 
 async function refreshRuntimeStatus() {
@@ -514,6 +549,7 @@ if (btnDiagnose) btnDiagnose.addEventListener('click', handleDiagnose);
 if (btnOpenDownloadSettings) btnOpenDownloadSettings.addEventListener('click', handleOpenDownloadSettings);
 if (btnShowLastDownload) btnShowLastDownload.addEventListener('click', handleShowLastDownload);
 if (btnSync) btnSync.addEventListener('click', handleSyncToServer);
+if (btnClearAutoSyncSummary) btnClearAutoSyncSummary.addEventListener('click', handleClearStoredAutoSyncSummary);
 if (lnkConfigureServer) {
     lnkConfigureServer.addEventListener('click', (event) => {
         event.preventDefault();


### PR DESCRIPTION
## Summary
- add a clear action for stored popup auto-sync summaries
- show the clear control only when the popup is rendering a stored fallback summary
- remove both the per-source storage map and the legacy single-summary key when clearing

## Verification
- npm --workspace @trends/browser-extension run lint
- npm --workspace @trends/browser-extension run typecheck
- make check
- live popup verification on chrome-extension://.../popup.html?tabId=999999 showing 清除记录, then hiding the stored summary after click