### PR TITLE
feat: make HR collection source-aware

### DIFF
--- a/apps/api/src/routes/config.test.ts
+++ b/apps/api/src/routes/config.test.ts
@@ -225,6 +225,7 @@ describe('config route workspace access', () => {
     expect(payload.success).toBe(true)
     expect(payload.metadata.identity.appName).toBe('Trends')
     expect(payload.metadata.navigation.system.length).toBeGreaterThan(0)
+    expect(payload.metadata.navigation.systemSettings.length).toBeGreaterThan(0)
     expect(payload.metadata.labels.aiBreakdown.some((item: { key: string }) => item.key === 'industry_db')).toBe(true)
     expect(payload.metadata.capabilities.some((item: { id: string }) => item.id === 'cli-system-inspect')).toBe(true)
   })

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -12,6 +12,7 @@ import {
   INGEST_BRAND_ROLE_LABELS,
   INGEST_BRAND_SOURCE_LABELS,
   SETTINGS_NAV_ITEMS,
+  SYSTEM_SETTINGS_NAV_ITEMS,
   SYSTEM_CAPABILITY_DESCRIPTORS,
   SYSTEM_NAV_ITEMS,
 } from "@trends/shared";
@@ -139,6 +140,7 @@ const SystemMetadataSchema = z.object({
   navigation: z.object({
     system: z.array(SurfaceNavItemSchema),
     settings: z.array(SurfaceNavItemSchema),
+    systemSettings: z.array(SurfaceNavItemSchema),
     debugPage: z.array(SurfaceNavItemSchema),
   }),
   labels: z.object({
@@ -187,6 +189,7 @@ function buildSystemMetadata() {
     navigation: {
       system: SYSTEM_NAV_ITEMS,
       settings: SETTINGS_NAV_ITEMS,
+      systemSettings: SYSTEM_SETTINGS_NAV_ITEMS,
       debugPage: DEBUG_PAGE_SECTION_DEFINITIONS.map((section) => ({
         ...section,
         matchesSuffixes: section.hrefSuffix ? [section.hrefSuffix] : [""],

--- a/apps/web/src/components/CollectResumesButton.test.tsx
+++ b/apps/web/src/components/CollectResumesButton.test.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CollectResumesButton } from './CollectResumesButton'
+import type { CollectionSource } from '@/lib/search-profile-sources'
+
+const { openMock } = vi.hoisted(() => ({
+  openMock: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+function Harness({
+  initialCollectionSource,
+}: {
+  initialCollectionSource: CollectionSource
+}) {
+  const [collectionSource, setCollectionSource] = useState<CollectionSource | undefined>(initialCollectionSource)
+
+  return (
+    <CollectResumesButton
+      location="Kuala Lumpur MY"
+      keywords={['Sales Engineer', 'Sales Manager']}
+      collectionSource={collectionSource}
+      onCollectionSourceChange={setCollectionSource}
+      collectUrl="https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1"
+      minAge={28}
+      maxAge={40}
+    />
+  )
+}
+
+describe('CollectResumesButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    })))
+    vi.stubGlobal('open', openMock)
+  })
+
+  it('switches between SEEK and Job5156 collection lanes without losing the exact SEEK URL', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Harness
+        initialCollectionSource={{
+          type: 'seek',
+          exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: 'Source' })).toHaveValue('seek')
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Collect' }))
+
+    expect(openMock).toHaveBeenLastCalledWith(
+      'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1&tr_auto_sync=true&tr_min_age=28&tr_max_age=40',
+      '_blank',
+      'noopener,noreferrer'
+    )
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Source' }), 'job5156')
+    await user.click(screen.getByRole('button', { name: 'Collect' }))
+
+    const job5156Url = new URL(openMock.mock.calls[1]?.[0] as string)
+    expect(`${job5156Url.origin}${job5156Url.pathname}`).toBe('https://hr.job5156.com/search')
+    expect(job5156Url.searchParams.get('keyword')).toBe('Sales Engineer Sales Manager')
+    expect(job5156Url.searchParams.get('location')).toBe('Kuala Lumpur MY')
+    expect(job5156Url.searchParams.get('tr_auto_sync')).toBe('true')
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Source' }), 'seek')
+    await user.click(screen.getByRole('button', { name: 'Collect' }))
+
+    expect(openMock).toHaveBeenLastCalledWith(
+      'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1&tr_auto_sync=true&tr_min_age=28&tr_max_age=40',
+      '_blank',
+      'noopener,noreferrer'
+    )
+  })
+})

--- a/apps/web/src/components/CollectResumesButton.tsx
+++ b/apps/web/src/components/CollectResumesButton.tsx
@@ -3,15 +3,20 @@ import { useTranslation } from 'react-i18next'
 import { Download, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { buildSeekCollectUrl, isSeekRecommendedCandidatesUrl } from '@/lib/search-profile-sources'
-
-const SEEK_DEFAULT_LOCATION = 'Kuala Lumpur MY'
+import {
+  buildCollectionLaunchUrl,
+  normalizeCollectionSource,
+  resolveCollectionSource,
+  SEARCH_PROFILE_SOURCE_TYPES,
+  type CollectionSource,
+} from '@/lib/search-profile-sources'
 const EXTENSION_META_URL = '/extension/extension-meta.json'
 const EXTENSION_ZIP_URL = '/extension/trends-resume-collector-latest.zip'
 
@@ -22,6 +27,8 @@ type ExtensionMeta = {
 interface CollectResumesButtonProps {
   location: string
   keywords: string[]
+  collectionSource?: CollectionSource
+  onCollectionSourceChange?: (source: CollectionSource) => void
   collectUrl?: string
   collectLimit?: number
   minAge?: number
@@ -46,16 +53,21 @@ function normalizeAgeBound(value: number | undefined): number | undefined {
   return parsed > 0 ? parsed : undefined
 }
 
-export function CollectResumesButton({ location, keywords, collectUrl, collectLimit, minAge, maxAge }: CollectResumesButtonProps) {
+export function CollectResumesButton({
+  location,
+  keywords,
+  collectionSource,
+  onCollectionSourceChange,
+  collectUrl,
+  collectLimit,
+  minAge,
+  maxAge,
+}: CollectResumesButtonProps) {
   const { t } = useTranslation()
   const [extensionVersion, setExtensionVersion] = useState<string | null>(null)
   const [maxPagesInput, setMaxPagesInput] = useState('')
 
   const normalizedLocation = useMemo(() => location.trim(), [location])
-  const collectLocation = useMemo(
-    () => (normalizedLocation.length > 0 ? normalizedLocation : SEEK_DEFAULT_LOCATION),
-    [normalizedLocation]
-  )
   const normalizedKeywords = useMemo(
     () => keywords.map((keyword) => keyword.trim()).filter((keyword) => keyword.length > 0),
     [keywords]
@@ -67,18 +79,46 @@ export function CollectResumesButton({ location, keywords, collectUrl, collectLi
   )
   const normalizedMinAge = useMemo(() => normalizeAgeBound(minAge), [minAge])
   const normalizedMaxAge = useMemo(() => normalizeAgeBound(maxAge), [maxAge])
-  const hasExactCollectUrl = useMemo(() => isSeekRecommendedCandidatesUrl(collectUrl), [collectUrl])
+  const normalizedCollectionSource = useMemo(
+    () => normalizeCollectionSource(collectionSource),
+    [collectionSource]
+  )
+  const normalizedSelection = useMemo(
+    () => resolveCollectionSource(normalizedCollectionSource, collectUrl) ?? { type: SEARCH_PROFILE_SOURCE_TYPES.job5156 },
+    [collectUrl, normalizedCollectionSource]
+  )
+  const selectedSourceType = normalizedSelection.type
+  const seekSource = useMemo(() => {
+    return resolveCollectionSource(
+      {
+        type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+        exactUrl: normalizedCollectionSource?.type === SEARCH_PROFILE_SOURCE_TYPES.seek
+          ? normalizedCollectionSource.exactUrl
+          : undefined,
+      },
+      collectUrl
+    )
+  }, [collectUrl, normalizedCollectionSource])
 
-  const disabled = !hasExactCollectUrl && normalizedKeywords.length === 0
+  const disabled = selectedSourceType === SEARCH_PROFILE_SOURCE_TYPES.seek
+    ? !seekSource?.exactUrl && normalizedKeywords.length === 0
+    : normalizedKeywords.length === 0
 
   const launchUrl = useMemo(() => {
     if (disabled) {
       return null
     }
 
-    return buildSeekCollectUrl({
-      baseUrl: hasExactCollectUrl ? collectUrl : undefined,
-      location: collectLocation,
+    return buildCollectionLaunchUrl({
+      source: selectedSourceType === SEARCH_PROFILE_SOURCE_TYPES.seek
+        ? {
+            type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+            exactUrl: seekSource?.exactUrl,
+          }
+        : {
+            type: SEARCH_PROFILE_SOURCE_TYPES.job5156,
+          },
+      location: normalizedLocation,
       keywords: normalizedKeywords,
       collectLimit: normalizedCollectLimit,
       maxPages: normalizedCollectMaxPages,
@@ -86,15 +126,15 @@ export function CollectResumesButton({ location, keywords, collectUrl, collectLi
       maxAge: normalizedMaxAge,
     })
   }, [
-    collectUrl,
     disabled,
-    hasExactCollectUrl,
     normalizedCollectLimit,
     normalizedCollectMaxPages,
     normalizedKeywords,
-    collectLocation,
+    normalizedLocation,
     normalizedMinAge,
     normalizedMaxAge,
+    seekSource?.exactUrl,
+    selectedSourceType,
   ])
 
   useEffect(() => {
@@ -125,6 +165,17 @@ export function CollectResumesButton({ location, keywords, collectUrl, collectLi
   const tooltipText = disabled
     ? t('quickStart.collectDisabledHint', 'Enter keywords first')
     : t('quickStart.collectTooltip', 'Opens job board with auto-sync. Requires extension + login.')
+  const sourceLabel = t('quickStart.collectSourceLabel', 'Source')
+  const sourceOptions = useMemo(() => ([
+    {
+      value: SEARCH_PROFILE_SOURCE_TYPES.job5156,
+      label: t('quickStart.collectSourceJob5156', 'China · Job5156'),
+    },
+    {
+      value: SEARCH_PROFILE_SOURCE_TYPES.seek,
+      label: t('quickStart.collectSourceSeek', 'Malaysia · SEEK'),
+    },
+  ]), [t])
   const maxPagesLabel = t('quickStart.collectMaxPagesLabel', 'Collect page limit')
   const maxPagesPlaceholder = t('quickStart.collectMaxPagesPlaceholder', 'Pages')
 
@@ -140,9 +191,39 @@ export function CollectResumesButton({ location, keywords, collectUrl, collectLi
     setMaxPagesInput(event.target.value)
   }
 
+  const handleSourceChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextType = event.target.value === SEARCH_PROFILE_SOURCE_TYPES.seek
+      ? SEARCH_PROFILE_SOURCE_TYPES.seek
+      : SEARCH_PROFILE_SOURCE_TYPES.job5156
+
+    if (nextType === SEARCH_PROFILE_SOURCE_TYPES.seek) {
+      onCollectionSourceChange?.({
+        type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+        ...(seekSource?.exactUrl ? { exactUrl: seekSource.exactUrl } : {}),
+      })
+      return
+    }
+
+    onCollectionSourceChange?.({
+      type: SEARCH_PROFILE_SOURCE_TYPES.job5156,
+    })
+  }
+
   return (
     <div className="flex flex-col items-start gap-1">
       <div className="flex items-center gap-2">
+        <label htmlFor="collect-source" className="sr-only">
+          {sourceLabel}
+        </label>
+        <Select
+          id="collect-source"
+          name="collect-source"
+          value={selectedSourceType}
+          onChange={handleSourceChange}
+          options={sourceOptions}
+          aria-label={sourceLabel}
+          className="h-9 w-40"
+        />
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -413,6 +413,10 @@ describe('QuickStartPanel quick-filter display', () => {
         location: 'Kuala Lumpur MY',
         keywords: ['Sales Engineer', 'Sales Manager'],
         jobDescriptionId: undefined,
+        collectionSource: {
+          type: 'seek',
+          exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+        },
         collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
       })
     })
@@ -442,6 +446,9 @@ describe('QuickStartPanel quick-filter display', () => {
         location: 'Kuala Lumpur MY',
         keywords: ['Sales Engineer', 'Sales Manager'],
         jobDescriptionId: undefined,
+        collectionSource: {
+          type: 'seek',
+        },
         collectUrl: 'https://my.employer.seek.com/candidates/recommended?keyword=Sales+Engineer+Sales+Manager&location=Kuala+Lumpur+MY&tr_auto_sync=true',
       })
     })

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -14,7 +14,10 @@ import type { ResumeFilters } from '@/types/resume'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import {
   buildSeekCollectUrl,
+  getSearchProfileCollectionSource,
   getSearchProfileCollectUrl,
+  stripCollectionSourceExactUrl,
+  type CollectionSource,
 } from '@/lib/search-profile-sources'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 
@@ -59,6 +62,7 @@ type QuickStartWorkflow = {
   label: string
   location: string
   keywords: string[]
+  collectionSource?: CollectionSource
   collectUrl?: string
 }
 
@@ -68,6 +72,7 @@ interface QuickStartPanelProps {
       location: string
       keywords: string[]
       jobDescriptionId?: string
+      collectionSource?: CollectionSource | null
       collectUrl?: string
       filters?: Partial<ResumeFilters>
     },
@@ -75,6 +80,7 @@ interface QuickStartPanelProps {
   ) => void
   defaultLocation?: string
   defaultKeywords?: string[]
+  defaultCollectionSource?: CollectionSource
   defaultCollectUrl?: string
   jobDescriptionId?: string
   onJobChange?: (value: string) => void
@@ -235,6 +241,9 @@ const QUICK_START_WORKFLOWS: QuickStartWorkflow[] = [
     label: 'SEEK · Sales Engineer / Sales Manager · Kuala Lumpur MY',
     location: MALAYSIA_SEEK_WORKFLOW_LOCATION,
     keywords: MALAYSIA_SEEK_WORKFLOW_KEYWORDS,
+    collectionSource: {
+      type: 'seek',
+    },
     collectUrl: buildSeekCollectUrl({
       location: MALAYSIA_SEEK_WORKFLOW_LOCATION,
       keywords: MALAYSIA_SEEK_WORKFLOW_KEYWORDS,
@@ -292,6 +301,7 @@ export function QuickStartPanel({
   onApplyConfig,
   defaultLocation = '广东',
   defaultKeywords = [],
+  defaultCollectionSource,
   defaultCollectUrl,
   jobDescriptionId = '',
   onJobChange,
@@ -308,6 +318,7 @@ export function QuickStartPanel({
   const [location, setLocation] = useState(defaultLocation)
   const [selectedKeywords, setSelectedKeywords] = useState<string[]>(defaultKeywords)
   const [customKeyword, setCustomKeyword] = useState(defaultKeywords.join(' '))
+  const [collectionSource, setCollectionSource] = useState<CollectionSource | undefined>(defaultCollectionSource)
   const [collectUrl, setCollectUrl] = useState(defaultCollectUrl)
   const [quickMinRoleYears, setQuickMinRoleYears] = useState(quickFilters?.minRoleYears?.toString() ?? '')
   const [quickMaxAge, setQuickMaxAge] = useState(quickFilters?.maxAge?.toString() ?? '')
@@ -347,6 +358,10 @@ export function QuickStartPanel({
   useEffect(() => {
     setCollectUrl(defaultCollectUrl)
   }, [defaultCollectUrl])
+
+  useEffect(() => {
+    setCollectionSource(defaultCollectionSource)
+  }, [defaultCollectionSource])
 
   useEffect(() => {
     const normalizedJobDescriptionId = jobDescriptionId.trim()
@@ -563,12 +578,13 @@ export function QuickStartPanel({
         location,
         keywords: normalizedKeywords,
         jobDescriptionId: effectiveJobDescriptionId,
+        collectionSource,
         collectUrl,
       })
     }, 500)
 
     return () => clearTimeout(timer)
-  }, [collectUrl, location, normalizedKeywords, jobDescriptionId, onApplyConfig])
+  }, [collectUrl, collectionSource, location, normalizedKeywords, jobDescriptionId, onApplyConfig])
 
   useEffect(() => {
     if (!matchedProfileCollectUrl) {
@@ -581,11 +597,18 @@ export function QuickStartPanel({
       return
     }
 
+    const nextCollectionSource: CollectionSource = {
+      type: 'seek',
+      exactUrl: matchedProfileCollectUrl,
+    }
+
+    setCollectionSource(nextCollectionSource)
     setCollectUrl(matchedProfileCollectUrl)
     onApplyConfig?.({
       location,
       keywords: normalizedKeywords,
       jobDescriptionId: jobDescriptionId || undefined,
+      collectionSource: nextCollectionSource,
       collectUrl: matchedProfileCollectUrl,
     }, true)
   }, [collectUrl, generatedCollectUrl, jobDescriptionId, location, matchedProfileCollectUrl, normalizedKeywords, onApplyConfig])
@@ -627,6 +650,7 @@ export function QuickStartPanel({
   const handleKeywordsChange = useCallback((keywords: string[]) => {
     setSelectedKeywords(keywords)
     setCustomKeyword(keywords.join(' '))
+    setCollectionSource((current) => stripCollectionSourceExactUrl(current))
     setCollectUrl(undefined)
   }, [])
 
@@ -645,6 +669,7 @@ export function QuickStartPanel({
         nextParts.add(toggleLocation)
       }
 
+      setCollectionSource((current) => stripCollectionSourceExactUrl(current))
       setCollectUrl(undefined)
       setLocation(Array.from(nextParts).join(','))
     },
@@ -652,6 +677,7 @@ export function QuickStartPanel({
   )
 
   const handleJobChange = useCallback((value: string) => {
+    setCollectionSource((current) => stripCollectionSourceExactUrl(current))
     setCollectUrl(undefined)
     onJobChange?.(value)
   }, [onJobChange])
@@ -660,6 +686,7 @@ export function QuickStartPanel({
     setLocation(workflow.location)
     setSelectedKeywords(workflow.keywords)
     setCustomKeyword(workflow.keywords.join(' '))
+    setCollectionSource(workflow.collectionSource)
     setCollectUrl(workflow.collectUrl)
     onJobChange?.('')
   }, [onJobChange])
@@ -668,12 +695,14 @@ export function QuickStartPanel({
     const profileLocation = profile.location.trim()
     const profileKeywords = normalizeProfileKeywords(profile)
     const nextJobDescriptionId = profile.jobDescription?.trim() || ''
+    const nextCollectionSource = getSearchProfileCollectionSource(profile.sources)
     const nextCollectUrl = getSearchProfileCollectUrl(profile.sources)
     const quickConstraints = getProfileQuickConstraints(profile)
 
     setLocation(profileLocation)
     setSelectedKeywords(profileKeywords)
     setCustomKeyword(profileKeywords.join(' '))
+    setCollectionSource(nextCollectionSource)
     setCollectUrl(nextCollectUrl)
     setQuickMinRoleYears(
       typeof quickConstraints.minRoleYears === 'number' ? String(quickConstraints.minRoleYears) : ''
@@ -685,6 +714,7 @@ export function QuickStartPanel({
       location: profileLocation,
       keywords: profileKeywords,
       jobDescriptionId: nextJobDescriptionId || undefined,
+      collectionSource: nextCollectionSource,
       collectUrl: nextCollectUrl,
       filters: mapProfileFiltersToResumeFilters(profile.filters),
     }, true)
@@ -710,6 +740,7 @@ export function QuickStartPanel({
     minExperience?: number
     maxAge?: number
   }) => {
+    setCollectionSource((current) => stripCollectionSourceExactUrl(current))
     setCollectUrl(undefined)
     if (selectedConvexJobDescriptionProfile?.type === 'system') {
       onJobChange?.(newId)

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -27,6 +27,7 @@ export function ResumeList() {
   const {
     sessionLocation,
     sessionKeywords,
+    sessionCollectionSource,
     sessionCollectUrl,
     jobDescriptionId,
     filters,
@@ -52,6 +53,7 @@ export function ResumeList() {
     handleRefresh,
     handleQuickStartApply,
     handleQuickConstraintApply,
+    handleCollectionSourceChange,
     handleSaveCurrentSearch,
     handleApplySearchHistory,
     handleJobChange,
@@ -96,6 +98,7 @@ export function ResumeList() {
         onJobChange={handleJobChange}
         defaultLocation={sessionLocation}
         defaultKeywords={sessionKeywords}
+        defaultCollectionSource={sessionCollectionSource}
         defaultCollectUrl={sessionCollectUrl}
         quickFilters={{
           minRoleYears: filters.minRoleYears ?? filters.minSalesYears,
@@ -134,6 +137,8 @@ export function ResumeList() {
             <CollectResumesButton
               location={sessionLocation}
               keywords={sessionKeywords}
+              collectionSource={sessionCollectionSource}
+              onCollectionSourceChange={handleCollectionSourceChange}
               collectUrl={sessionCollectUrl}
               minAge={filters.minAge}
               maxAge={filters.maxAge}

--- a/apps/web/src/components/SettingsSidebar.tsx
+++ b/apps/web/src/components/SettingsSidebar.tsx
@@ -33,8 +33,8 @@ export function SettingsSidebar({ onClose }: SettingsSidebarProps) {
   const location = useLocation()
   const { slug } = useWorkspace()
   const { t } = useTranslation()
-  const identity = useSystemMetadata()
-  const appVersion = identity?.appVersion ?? 'unknown'
+  const metadata = useSystemMetadata()
+  const appVersion = metadata?.identity.appVersion ?? 'unknown'
 
   const navItems = useMemo<NavItem[]>(() => {
     return SETTINGS_NAV_ITEMS.map((item) => ({

--- a/apps/web/src/components/SystemSidebar.tsx
+++ b/apps/web/src/components/SystemSidebar.tsx
@@ -49,8 +49,8 @@ export function SystemSidebar({ onClose }: SystemSidebarProps) {
   const location = useLocation()
   const { slug } = useWorkspace()
   const { t } = useTranslation()
-  const identity = useSystemMetadata()
-  const appVersion = identity?.appVersion ?? 'unknown'
+  const metadata = useSystemMetadata()
+  const appVersion = metadata?.identity.appVersion ?? 'unknown'
 
   const navItems = useMemo<NavItem[]>(() => {
     return SYSTEM_NAV_ITEMS.map((item) => ({

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -19,6 +19,7 @@ const mockState = vi.hoisted(() => ({
   sessionLocation: '广东',
   sessionKeywords: [] as string[],
   sessionJobDescriptionId: undefined as string | undefined,
+  sessionCollectionSource: undefined as { type: 'job5156' | 'seek'; exactUrl?: string } | undefined,
   sessionCollectUrl: '' as string,
   blocksByIdentity: {} as Record<string, { identityKey: string }>,
   statusByIdentity: {} as Record<string, CandidateStatusRecord>,
@@ -26,6 +27,7 @@ const mockState = vi.hoisted(() => ({
   setLocation: vi.fn(),
   setKeywords: vi.fn(),
   setJobDescriptionId: vi.fn(),
+  setCollectionSource: vi.fn(),
   setCollectUrl: vi.fn(),
   trackReviewedResume: vi.fn(),
   applyExternalState: vi.fn(),
@@ -93,6 +95,8 @@ vi.mock('@/hooks/useSession', () => ({
     setKeywords: mockState.setKeywords,
     jobDescriptionId: mockState.sessionJobDescriptionId,
     setJobDescriptionId: mockState.setJobDescriptionId,
+    collectionSource: mockState.sessionCollectionSource,
+    setCollectionSource: mockState.setCollectionSource,
     collectUrl: mockState.sessionCollectUrl,
     setCollectUrl: mockState.setCollectUrl,
     filters: mockState.filters,
@@ -296,6 +300,8 @@ describe('useResumeListState role filter regression', () => {
     mockState.sessionLocation = '广东'
     mockState.sessionKeywords = []
     mockState.sessionJobDescriptionId = undefined
+    mockState.sessionCollectionSource = undefined
+    mockState.sessionCollectUrl = ''
     mockState.blocksByIdentity = {}
     mockState.statusByIdentity = {}
     mockState.searchHistory = []
@@ -584,6 +590,8 @@ describe('useResumeListState role filter regression', () => {
       location: '',
       keywords: [],
       jobDescriptionId: '',
+      collectionSource: null,
+      collectUrl: '',
       filters: {},
     })
   })
@@ -755,6 +763,7 @@ describe('useResumeListState role filter regression', () => {
       location: '苏州',
       keywords: ['CNC', '销售'],
       jobDescriptionId: 'lathe-sales',
+      collectionSource: null,
       collectUrl: '',
       filters: { minAge: 28 },
     })
@@ -987,6 +996,7 @@ describe('useResumeListState role filter regression', () => {
       result.current.handleQuickStartApply({
         location: 'Kuala Lumpur MY',
         keywords: ['Sales Engineer', 'Sales Manager'],
+        collectionSource: { type: 'seek' },
         collectUrl: 'https://my.employer.seek.com/candidates/recommended?keyword=Sales+Engineer+Sales+Manager&location=Kuala+Lumpur+MY',
       }, true)
     })
@@ -999,6 +1009,7 @@ describe('useResumeListState role filter regression', () => {
     expect(filterUpdater({})).toMatchObject({
       locations: ['Kuala Lumpur MY'],
     })
+    expect(mockState.setCollectionSource).toHaveBeenCalledWith(expect.any(Function))
   })
 
   it('clears query state when navigation requests a resume home reset', async () => {
@@ -1012,6 +1023,8 @@ describe('useResumeListState role filter regression', () => {
         location: '',
         keywords: [],
         jobDescriptionId: '',
+        collectionSource: null,
+        collectUrl: '',
         filters: {},
       })
     })

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -43,6 +43,7 @@ import {
   toMatchBreakdown,
   toRecommendation,
 } from '@/lib/resume-scoring'
+import type { CollectionSource } from '@/lib/search-profile-sources'
 
 type JobDescriptionApiResponse = {
   success: boolean
@@ -371,6 +372,8 @@ export function useResumeListState(loadSearchHistory = false) {
     setKeywords: setSessionKeywords,
     jobDescriptionId,
     setJobDescriptionId,
+    collectionSource: sessionCollectionSource,
+    setCollectionSource: setSessionCollectionSource,
     collectUrl: sessionCollectUrl,
     setCollectUrl: setSessionCollectUrl,
     filters,
@@ -535,6 +538,8 @@ export function useResumeListState(loadSearchHistory = false) {
       location: activeParsedUrlState.location,
       keywords: activeParsedUrlState.keywords,
       jobDescriptionId: jobDescriptionIdForExternalState,
+      collectionSource: null,
+      collectUrl: '',
       filters: activeParsedUrlState.filters,
     })
     setSelectedTags(activeParsedUrlState.selectedTags)
@@ -613,6 +618,8 @@ export function useResumeListState(loadSearchHistory = false) {
       location: activeParsedUrlState.location,
       keywords: activeParsedUrlState.keywords,
       jobDescriptionId: jobDescriptionIdForExternalState,
+      collectionSource: null,
+      collectUrl: '',
       filters: activeParsedUrlState.filters,
     })
     setSelectedTags((current) =>
@@ -1151,6 +1158,8 @@ export function useResumeListState(loadSearchHistory = false) {
       location: '',
       keywords: [],
       jobDescriptionId: '',
+      collectionSource: null,
+      collectUrl: '',
       filters: {},
     })
     setSelectedTags([])
@@ -1395,6 +1404,7 @@ export function useResumeListState(loadSearchHistory = false) {
       location: string
       keywords: string[]
       jobDescriptionId?: string
+      collectionSource?: CollectionSource | null
       collectUrl?: string
       filters?: Partial<ResumeFilters>
     }, applyDuringUrlHydration?: boolean) => {
@@ -1416,6 +1426,15 @@ export function useResumeListState(loadSearchHistory = false) {
 
       setSessionKeywords((current) => (areKeywordListsEqual(current, normalizedKeywords) ? current : normalizedKeywords))
       setJobDescriptionId((current) => (current === normalizedJobDescriptionId ? current : normalizedJobDescriptionId))
+      setSessionCollectionSource((current) => {
+        if (config.collectionSource === undefined) {
+          return current
+        }
+
+        return JSON.stringify(current ?? null) === JSON.stringify(config.collectionSource ?? null)
+          ? current
+          : (config.collectionSource ?? undefined)
+      })
       setSessionCollectUrl((current) => {
         const nextCollectUrl = normalizeOptionalString(config.collectUrl)
         return current === nextCollectUrl ? current : nextCollectUrl
@@ -1431,7 +1450,7 @@ export function useResumeListState(loadSearchHistory = false) {
           : [],
       }))
     },
-    [setFilters, setJobDescriptionId, setSessionCollectUrl, setSessionKeywords, setSessionLocation, shouldBlockQuickStartSync]
+    [setFilters, setJobDescriptionId, setSessionCollectionSource, setSessionCollectUrl, setSessionKeywords, setSessionLocation, shouldBlockQuickStartSync]
   )
 
   const handleQuickConstraintApply = useCallback(
@@ -1452,6 +1471,14 @@ export function useResumeListState(loadSearchHistory = false) {
     [setFilters]
   )
 
+  const handleCollectionSourceChange = useCallback((nextSource: CollectionSource) => {
+    setSessionCollectionSource((current) => (
+      JSON.stringify(current ?? null) === JSON.stringify(nextSource)
+        ? current
+        : nextSource
+    ))
+  }, [setSessionCollectionSource])
+
   const handleSaveCurrentSearch = useCallback(async () => {
     const title = buildSearchHistoryTitle(sessionLocation, sessionKeywords)
     const saved = await saveSearchHistory({
@@ -1459,6 +1486,7 @@ export function useResumeListState(loadSearchHistory = false) {
       location: sessionLocation,
       keywords: sessionKeywords,
       jobDescriptionId,
+      collectionSource: sessionCollectionSource,
       collectUrl: sessionCollectUrl,
       filters,
       selectedTags,
@@ -1472,7 +1500,7 @@ export function useResumeListState(loadSearchHistory = false) {
     } else {
       toast.error(t('quickStart.history.saveError', 'Failed to save search history'))
     }
-  }, [filteredConvexResumes, filters, jobDescriptionId, saveSearchHistory, selectedCompanies, selectedExperienceLevel, selectedTags, sessionCollectUrl, sessionKeywords, sessionLocation, t])
+  }, [filteredConvexResumes, filters, jobDescriptionId, saveSearchHistory, selectedCompanies, selectedExperienceLevel, selectedTags, sessionCollectUrl, sessionCollectionSource, sessionKeywords, sessionLocation, t])
 
   const handleApplySearchHistory = useCallback(async (entry: SearchHistoryItem) => {
     skipNextUrlSyncRef.current = true
@@ -1480,6 +1508,7 @@ export function useResumeListState(loadSearchHistory = false) {
       location: entry.location,
       keywords: entry.keywords,
       jobDescriptionId: entry.jobDescriptionId ?? '',
+      collectionSource: entry.collectionSource ?? null,
       collectUrl: entry.collectUrl ?? '',
       filters: entry.filters,
     })
@@ -1494,6 +1523,7 @@ export function useResumeListState(loadSearchHistory = false) {
   return {
     sessionLocation,
     sessionKeywords,
+    sessionCollectionSource,
     sessionCollectUrl,
     jobDescriptionId,
     appliedSearchHistoryId,
@@ -1526,6 +1556,7 @@ export function useResumeListState(loadSearchHistory = false) {
     handleRefresh,
     handleQuickStartApply,
     handleQuickConstraintApply,
+    handleCollectionSourceChange,
     handleSaveCurrentSearch,
     handleApplySearchHistory,
     handleJobChange,

--- a/apps/web/src/hooks/useSession.test.tsx
+++ b/apps/web/src/hooks/useSession.test.tsx
@@ -71,6 +71,9 @@ describe('useSession', () => {
           location: '广东,江苏',
           keywords: ['CNC', '销售'],
           jobDescriptionId: 'lathe-sales',
+          collectionSource: {
+            type: 'job5156',
+          },
           collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
           filters: {
             minExperience: 1,
@@ -124,6 +127,9 @@ describe('useSession', () => {
             location: '东莞',
             keywords: ['CNC', '销售'],
             jobDescriptionId: 'lathe-sales',
+            collectionSource: {
+              type: 'job5156',
+            },
             collectUrl: ' https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1 ',
             filters: { minAge: 25 },
             selectedTags: ['STAR', 'STAR', ''],
@@ -168,6 +174,7 @@ describe('useSession', () => {
         location: '东莞',
         keywords: ['CNC', '销售'],
         collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+        collectionSource: { type: 'job5156' },
         selectedTags: ['STAR'],
         selectedCompanies: ['Acme'],
         selectedExperienceLevel: 'mid',
@@ -205,6 +212,7 @@ describe('useSession', () => {
       title: 'HR saved search',
       location: '东莞',
       keywords: ['招聘', '简历'],
+      collectionSource: { type: 'job5156' },
       collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
       resumeIds: ['resume-1', 'resume-2'],
     })
@@ -224,6 +232,7 @@ describe('useSession', () => {
         title: 'HR saved search',
         location: '东莞',
         keywords: ['招聘', '简历'],
+        collectionSource: { type: 'job5156' },
         collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
         resumeIds: ['resume-1', 'resume-2'],
       })
@@ -258,7 +267,7 @@ describe('useSession', () => {
     expect(result.current.keywords).toEqual(['CNC', '销售'])
   })
 
-  it('can clear and replace the persisted collect URL through external state', async () => {
+  it('can clear and replace the persisted collection source and collect URL through external state', async () => {
     const { result } = renderHook(() => useSession())
 
     await waitFor(() => {
@@ -266,25 +275,79 @@ describe('useSession', () => {
     })
 
     act(() => {
+      result.current.setCollectionSource({ type: 'seek', exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1' })
       result.current.setCollectUrl('https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1')
     })
 
+    expect(result.current.collectionSource).toEqual({
+      type: 'seek',
+      exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+    })
     expect(result.current.collectUrl).toBe('https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1')
 
     act(() => {
       result.current.applyExternalState({
+        collectionSource: null,
         collectUrl: '',
       })
     })
 
+    expect(result.current.collectionSource).toBeUndefined()
     expect(result.current.collectUrl).toBeUndefined()
 
     act(() => {
       result.current.applyExternalState({
+        collectionSource: {
+          type: 'job5156',
+        },
         collectUrl: ' https://my.employer.seek.com/candidates/recommended?jobId=2&pageNumber=1 ',
       })
     })
 
+    expect(result.current.collectionSource).toEqual({
+      type: 'job5156',
+    })
     expect(result.current.collectUrl).toBe('https://my.employer.seek.com/candidates/recommended?jobId=2&pageNumber=1')
+  })
+
+  it('falls back to legacy seek collectUrl when history records are missing collectionSource', async () => {
+    useQueryMock.mockImplementation((query) => {
+      if (query === 'list-history-query') {
+        return [
+          {
+            _id: 'history-seek',
+            sessionKey: 'session-seek',
+            title: 'Seek history',
+            location: 'Kuala Lumpur MY',
+            keywords: ['Sales Engineer'],
+            collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+            filters: {},
+            selectedTags: [],
+            selectedCompanies: [],
+            createdAt: 1,
+          },
+        ]
+      }
+
+      return {
+        config: {
+          location: '',
+          keywords: [],
+          filters: {},
+        },
+        reviewedResumeIds: [],
+      }
+    })
+
+    const { result } = renderHook(() => useSession(true))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.searchHistory[0]?.collectionSource).toEqual({
+      type: 'seek',
+      exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+    })
   })
 })

--- a/apps/web/src/hooks/useSession.ts
+++ b/apps/web/src/hooks/useSession.ts
@@ -2,6 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Id } from '../../../../packages/convex/convex/_generated/dataModel'
+import {
+  normalizeCollectionSource,
+  resolveCollectionSource,
+  type CollectionSource,
+} from '@/lib/search-profile-sources'
 import type { ResumeFilters } from '@/types/resume'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { toIndustryDbV2Stats, type IndustryDbV2Stats } from '@/lib/resume-scoring'
@@ -10,6 +15,7 @@ export type ExternalSessionState = {
   location?: string
   keywords?: string[]
   jobDescriptionId?: string
+  collectionSource?: CollectionSource | null
   collectUrl?: string
   filters?: Partial<ResumeFilters>
 }
@@ -21,6 +27,7 @@ export type SearchHistoryItem = {
   location: string
   keywords: string[]
   jobDescriptionId?: string
+  collectionSource?: CollectionSource
   collectUrl?: string
   filters: Partial<ResumeFilters>
   selectedTags: string[]
@@ -40,6 +47,7 @@ type SaveSearchHistoryInput = {
   location?: string
   keywords?: string[]
   jobDescriptionId?: string
+  collectionSource?: CollectionSource | null
   collectUrl?: string
   filters?: Partial<ResumeFilters>
   selectedTags?: string[]
@@ -124,6 +132,7 @@ export function useSession(loadSearchHistory = false) {
   const [location, setLocation] = useState(DEFAULT_SESSION_LOCATION)
   const [keywords, setKeywords] = useState<string[]>([])
   const [jobDescriptionId, setJobDescriptionId] = useState<string | undefined>(undefined)
+  const [collectionSource, setCollectionSource] = useState<CollectionSource | undefined>(undefined)
   const [collectUrl, setCollectUrl] = useState<string | undefined>(undefined)
   const [filters, setFilters] = useState<ResumeFilters>({})
 
@@ -137,6 +146,7 @@ export function useSession(loadSearchHistory = false) {
     setLocation(DEFAULT_SESSION_LOCATION)
     setKeywords([])
     setJobDescriptionId(undefined)
+    setCollectionSource(undefined)
     setCollectUrl(undefined)
     setFilters({})
   }, [slug, sessionKey])
@@ -153,6 +163,7 @@ export function useSession(loadSearchHistory = false) {
       setLocation(activeSession.config.location)
       setKeywords(activeSession.config.keywords)
       setJobDescriptionId(activeSession.config.jobDescriptionId)
+      setCollectionSource(resolveCollectionSource(activeSession.config.collectionSource, activeSession.config.collectUrl))
       setCollectUrl(activeSession.config.collectUrl)
       setFilters(activeSession.config.filters || {})
       setHasHydratedInitialState(true)
@@ -170,13 +181,14 @@ export function useSession(loadSearchHistory = false) {
         location,
         keywords,
         jobDescriptionId,
+        collectionSource,
         collectUrl,
         filters,
       })
     }, 1000)
 
     return () => clearTimeout(timer)
-  }, [sessionKey, slug, location, keywords, jobDescriptionId, collectUrl, filters, saveSession, hasHydratedInitialState])
+  }, [sessionKey, slug, location, keywords, jobDescriptionId, collectionSource, collectUrl, filters, saveSession, hasHydratedInitialState])
 
   const trackReviewedResume = useCallback(
     async (resumeId: string) => {
@@ -208,6 +220,10 @@ export function useSession(loadSearchHistory = false) {
       setJobDescriptionId(normalizedJobDescriptionId.length > 0 ? normalizedJobDescriptionId : undefined)
     }
 
+    if (state.collectionSource !== undefined) {
+      setCollectionSource(normalizeCollectionSource(state.collectionSource))
+    }
+
     if (state.collectUrl !== undefined) {
       setCollectUrl(normalizeOptionalString(state.collectUrl))
     }
@@ -217,7 +233,7 @@ export function useSession(loadSearchHistory = false) {
     }
 
     setHasHydratedInitialState(true)
-  }, [setFilters, setJobDescriptionId, setKeywords, setLocation])
+  }, [setCollectionSource, setFilters, setJobDescriptionId, setKeywords, setLocation])
 
   const searchHistory = useMemo<SearchHistoryItem[]>(() => {
     if (!historyRecords) {
@@ -231,6 +247,7 @@ export function useSession(loadSearchHistory = false) {
       location: record.location,
       keywords: record.keywords,
       jobDescriptionId: record.jobDescriptionId,
+      collectionSource: resolveCollectionSource(record.collectionSource, record.collectUrl),
       collectUrl: normalizeOptionalString(record.collectUrl),
       filters: (record.filters ?? {}) as Partial<ResumeFilters>,
       selectedTags: normalizeStringList(record.selectedTags),
@@ -258,6 +275,10 @@ export function useSession(loadSearchHistory = false) {
       location: input.location ?? location,
       keywords: input.keywords ?? keywords,
       jobDescriptionId: input.jobDescriptionId ?? jobDescriptionId,
+      collectionSource:
+        input.collectionSource !== undefined
+          ? normalizeCollectionSource(input.collectionSource)
+          : collectionSource,
       collectUrl: input.collectUrl !== undefined ? normalizeOptionalString(input.collectUrl) : collectUrl,
       filters: input.filters ?? filters,
       selectedTags: normalizeStringList(input.selectedTags ?? []),
@@ -267,7 +288,7 @@ export function useSession(loadSearchHistory = false) {
       analysisTaskId: normalizeOptionalString(input.analysisTaskId),
       resumeIds: normalizeStringList(input.resumeIds),
     })
-  }, [collectUrl, filters, jobDescriptionId, keywords, location, saveSearchHistoryMutation, sessionKey, slug])
+  }, [collectionSource, collectUrl, filters, jobDescriptionId, keywords, location, saveSearchHistoryMutation, sessionKey, slug])
 
   const markSearchHistoryOpened = useCallback(async (id: Id<'search_history'>) => {
     await markSearchHistoryOpenedMutation({ id, workspaceSlug: slug })
@@ -280,6 +301,8 @@ export function useSession(loadSearchHistory = false) {
     setKeywords,
     jobDescriptionId,
     setJobDescriptionId,
+    collectionSource,
+    setCollectionSource,
     collectUrl,
     setCollectUrl,
     filters,

--- a/apps/web/src/hooks/useSystemMetadata.ts
+++ b/apps/web/src/hooks/useSystemMetadata.ts
@@ -1,19 +1,30 @@
 import { useEffect, useState } from 'react'
+import type { SurfaceNavDefinition } from '@trends/shared'
 import { withWorkspaceHeaders } from '@/lib/workspace-ref'
 
 type SystemMetadataIdentity = {
   appVersion: string
 }
 
-type SystemMetadataPayload = {
-  success: true
-  metadata: {
-    identity: SystemMetadataIdentity
-  }
+type SystemMetadataNavigation = {
+  system: SurfaceNavDefinition[]
+  settings: SurfaceNavDefinition[]
+  systemSettings: SurfaceNavDefinition[]
+  debugPage: SurfaceNavDefinition[]
 }
 
-export function useSystemMetadata(): SystemMetadataIdentity | null {
-  const [identity, setIdentity] = useState<SystemMetadataIdentity | null>(null)
+export type SystemMetadata = {
+  identity: SystemMetadataIdentity
+  navigation: SystemMetadataNavigation
+}
+
+type SystemMetadataPayload = {
+  success: true
+  metadata: SystemMetadata
+}
+
+export function useSystemMetadata(): SystemMetadata | null {
+  const [metadata, setMetadata] = useState<SystemMetadata | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -29,7 +40,7 @@ export function useSystemMetadata(): SystemMetadataIdentity | null {
       })
       .then((payload) => {
         if (!cancelled && payload.success) {
-          setIdentity(payload.metadata.identity)
+          setMetadata(payload.metadata)
         }
       })
       .catch((error) => {
@@ -41,5 +52,5 @@ export function useSystemMetadata(): SystemMetadataIdentity | null {
     }
   }, [])
 
-  return identity
+  return metadata
 }

--- a/apps/web/src/layouts/SystemSettingsLayout.tsx
+++ b/apps/web/src/layouts/SystemSettingsLayout.tsx
@@ -2,18 +2,20 @@ import { useMemo } from 'react'
 import { NavLink, Outlet } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { PageHeader } from '@/components/PageHeader'
+import { useSystemMetadata } from '@/hooks/useSystemMetadata'
 import { cn } from '@/lib/utils'
-import { SYSTEM_SETTINGS_SUBPAGES } from '@/pages/system-settings/lib'
+import { resolveSystemSettingsSubpages } from '@/pages/system-settings/lib'
 
 export default function SystemSettingsLayout() {
   const { t } = useTranslation()
+  const metadata = useSystemMetadata()
 
   const navItems = useMemo(() => {
-    return SYSTEM_SETTINGS_SUBPAGES.map((item) => ({
+    return resolveSystemSettingsSubpages(metadata?.navigation.systemSettings).map((item) => ({
       ...item,
       title: t(item.titleKey, { defaultValue: item.defaultTitle }),
     }))
-  }, [t])
+  }, [metadata?.navigation.systemSettings, t])
 
   return (
     <div className="flex flex-col gap-6">

--- a/apps/web/src/lib/search-profile-sources.test.ts
+++ b/apps/web/src/lib/search-profile-sources.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it } from 'vitest'
 
 import {
   SEARCH_PROFILE_SOURCE_TYPES,
+  buildCollectionLaunchUrl,
+  buildJob5156CollectUrl,
   buildSeekCollectUrl,
   getActiveSearchProfileSource,
+  getLegacyCollectionSource,
+  getSearchProfileCollectionSource,
   getSearchProfileCollectUrl,
+  resolveCollectionSource,
 } from './search-profile-sources'
 
 describe('search-profile-sources', () => {
@@ -46,6 +51,17 @@ describe('search-profile-sources', () => {
     expect(collectUrl).toBe('https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1')
   })
 
+  it('returns the active launchable collection source for Job5156 profiles', () => {
+    const collectionSource = getSearchProfileCollectionSource([
+      { type: 'manual_upload', enabled: true, priority: 1 },
+      { type: SEARCH_PROFILE_SOURCE_TYPES.job5156, enabled: true, priority: 2 },
+    ])
+
+    expect(collectionSource).toEqual({
+      type: SEARCH_PROFILE_SOURCE_TYPES.job5156,
+    })
+  })
+
   it('uses enabled priority order when selecting the active source', () => {
     const activeSource = getActiveSearchProfileSource([
       { type: SEARCH_PROFILE_SOURCE_TYPES.seek, enabled: true, priority: 2 },
@@ -71,5 +87,62 @@ describe('search-profile-sources', () => {
     expect(url.searchParams.get('location')).toBe('Kuala Lumpur MY')
     expect(url.searchParams.get('keyword')).toBe('Sales Engineer Sales Manager')
     expect(url.searchParams.get('tr_auto_sync')).toBe('true')
+  })
+
+  it('builds a Job5156 collect URL with Trends control params', () => {
+    const collectUrl = buildJob5156CollectUrl({
+      location: '东莞,深圳',
+      keywords: ['CNC', '销售'],
+      collectLimit: 50,
+      maxPages: 4,
+      minAge: 28,
+      maxAge: 40,
+    })
+
+    expect(collectUrl).not.toBeNull()
+    const url = new URL(collectUrl as string)
+    expect(`${url.origin}${url.pathname}`).toBe('https://hr.job5156.com/search')
+    expect(url.searchParams.get('keyword')).toBe('CNC 销售')
+    expect(url.searchParams.get('location')).toBe('东莞,深圳')
+    expect(url.searchParams.get('tr_auto_sync')).toBe('true')
+    expect(url.searchParams.get('tr_limit')).toBe('50')
+    expect(url.searchParams.get('tr_max_pages')).toBe('4')
+    expect(url.searchParams.get('tr_min_age')).toBe('28')
+    expect(url.searchParams.get('tr_max_age')).toBe('40')
+  })
+
+  it('preserves legacy seek exact URLs as a collection source fallback', () => {
+    const legacySource = getLegacyCollectionSource('https://my.employer.seek.com/candidates/recommended?jobId=9&pageNumber=1')
+
+    expect(legacySource).toEqual({
+      type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+      exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=9&pageNumber=1',
+    })
+    expect(resolveCollectionSource(undefined, legacySource?.exactUrl)).toEqual(legacySource)
+  })
+
+  it('builds launch URLs from an explicit collection source', () => {
+    const seekUrl = buildCollectionLaunchUrl({
+      source: {
+        type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+        exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+      },
+      location: 'Kuala Lumpur MY',
+      keywords: ['Sales Engineer'],
+      maxPages: 2,
+    })
+    const job5156Url = buildCollectionLaunchUrl({
+      source: {
+        type: SEARCH_PROFILE_SOURCE_TYPES.job5156,
+      },
+      location: '东莞',
+      keywords: ['CNC'],
+      maxPages: 2,
+    })
+
+    expect(seekUrl).toContain('jobId=90842915')
+    expect(seekUrl).toContain('tr_max_pages=2')
+    expect(job5156Url).toContain('hr.job5156.com/search')
+    expect(job5156Url).toContain('tr_max_pages=2')
   })
 })

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -1,3 +1,4 @@
+const JOB5156_SEARCH_URL = 'https://hr.job5156.com/search'
 const SEEK_TALENT_SEARCH_URL = 'https://my.employer.seek.com/candidates/recommended'
 const SEEK_HOST_SUFFIX = '.employer.seek.com'
 const SEEK_RECOMMENDED_PATH = '/candidates/recommended'
@@ -6,6 +7,15 @@ export const SEARCH_PROFILE_SOURCE_TYPES = {
   job5156: 'job5156',
   seek: 'seek',
 } as const
+
+export type CollectionSourceType =
+  | typeof SEARCH_PROFILE_SOURCE_TYPES.job5156
+  | typeof SEARCH_PROFILE_SOURCE_TYPES.seek
+
+export type CollectionSource = {
+  type: CollectionSourceType
+  exactUrl?: string
+}
 
 export type SearchProfileSource = {
   type: string
@@ -22,6 +32,12 @@ type BuildSeekCollectUrlInput = {
   maxPages?: number
   minAge?: number
   maxAge?: number
+}
+
+type BuildJob5156CollectUrlInput = Omit<BuildSeekCollectUrlInput, 'baseUrl'>
+
+type BuildCollectionLaunchUrlInput = BuildJob5156CollectUrlInput & {
+  source: CollectionSource
 }
 
 function normalizeOptionalString(value: string | undefined): string | undefined {
@@ -48,6 +64,10 @@ function normalizeOptionalPositiveInt(value: number | undefined): number | undef
   return normalized > 0 ? normalized : undefined
 }
 
+function isCollectionSourceType(value: string | undefined): value is CollectionSourceType {
+  return value === SEARCH_PROFILE_SOURCE_TYPES.job5156 || value === SEARCH_PROFILE_SOURCE_TYPES.seek
+}
+
 function compareSourcePriority(left: SearchProfileSource, right: SearchProfileSource): number {
   const leftPriority = typeof left.priority === 'number' && Number.isFinite(left.priority)
     ? left.priority
@@ -66,6 +86,62 @@ function removeTrendsParams(url: URL): void {
       url.searchParams.delete(key)
     }
   })
+}
+
+export function normalizeCollectionSource(
+  value: CollectionSource | null | undefined,
+): CollectionSource | undefined {
+  if (!value || !isCollectionSourceType(value.type)) {
+    return undefined
+  }
+
+  const exactUrl = value.type === SEARCH_PROFILE_SOURCE_TYPES.seek
+    ? normalizeSeekJobUrl(value.exactUrl)
+    : undefined
+
+  return exactUrl
+    ? { type: value.type, exactUrl }
+    : { type: value.type }
+}
+
+export function getLegacyCollectionSource(collectUrl: string | undefined): CollectionSource | undefined {
+  const exactUrl = normalizeSeekJobUrl(collectUrl)
+  if (!exactUrl || !isSeekRecommendedCandidatesUrl(exactUrl)) {
+    return undefined
+  }
+
+  return {
+    type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+    exactUrl,
+  }
+}
+
+export function resolveCollectionSource(
+  collectionSource: CollectionSource | null | undefined,
+  collectUrl?: string,
+): CollectionSource | undefined {
+  const normalizedSource = normalizeCollectionSource(collectionSource)
+  const legacySource = getLegacyCollectionSource(collectUrl)
+
+  if (normalizedSource?.type === SEARCH_PROFILE_SOURCE_TYPES.seek && !normalizedSource.exactUrl && legacySource?.exactUrl) {
+    return {
+      type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+      exactUrl: legacySource.exactUrl,
+    }
+  }
+
+  return normalizedSource ?? legacySource
+}
+
+export function stripCollectionSourceExactUrl(
+  collectionSource: CollectionSource | null | undefined,
+): CollectionSource | undefined {
+  const normalized = normalizeCollectionSource(collectionSource)
+  if (!normalized) {
+    return undefined
+  }
+
+  return { type: normalized.type }
 }
 
 export function normalizeSeekJobUrl(value: string | undefined): string | undefined {
@@ -122,6 +198,37 @@ export function getPreferredSeekSource(
     .map((source, index) => ({ source, index }))
     .filter(({ source }) => source.enabled && source.type === SEARCH_PROFILE_SOURCE_TYPES.seek)
     .sort((left, right) => compareSourcePriority(left.source, right.source) || left.index - right.index)[0]?.source
+}
+
+export function getPreferredLaunchableSearchProfileSource(
+  sources: SearchProfileSource[] | undefined,
+): SearchProfileSource | undefined {
+  if (!Array.isArray(sources) || sources.length === 0) {
+    return undefined
+  }
+
+  return sources
+    .map((source, index) => ({ source, index }))
+    .filter(({ source }) => source.enabled && isCollectionSourceType(source.type))
+    .sort((left, right) => compareSourcePriority(left.source, right.source) || left.index - right.index)[0]?.source
+}
+
+export function getSearchProfileCollectionSource(
+  sources: SearchProfileSource[] | undefined,
+): CollectionSource | undefined {
+  const source = getPreferredLaunchableSearchProfileSource(sources)
+  if (!source || !isCollectionSourceType(source.type)) {
+    return undefined
+  }
+
+  if (source.type === SEARCH_PROFILE_SOURCE_TYPES.seek) {
+    return normalizeCollectionSource({
+      type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+      exactUrl: source.jobUrl,
+    }) ?? { type: SEARCH_PROFILE_SOURCE_TYPES.seek }
+  }
+
+  return { type: SEARCH_PROFILE_SOURCE_TYPES.job5156 }
 }
 
 export function getSearchProfileCollectUrl(
@@ -197,4 +304,81 @@ export function buildSeekCollectUrl({
   }
 
   return url.toString()
+}
+
+export function buildJob5156CollectUrl({
+  location,
+  keywords,
+  collectLimit,
+  maxPages,
+  minAge,
+  maxAge,
+}: BuildJob5156CollectUrlInput): string | null {
+  const normalizedKeywords = normalizeKeywords(keywords)
+  if (normalizedKeywords.length === 0) {
+    return null
+  }
+
+  const url = new URL(JOB5156_SEARCH_URL)
+  const normalizedLocation = location.trim()
+
+  url.searchParams.set('keyword', normalizedKeywords.join(' '))
+  if (normalizedLocation.length > 0) {
+    url.searchParams.set('location', normalizedLocation)
+  }
+
+  url.searchParams.set('tr_auto_sync', 'true')
+
+  const normalizedCollectLimit = normalizeOptionalPositiveInt(collectLimit)
+  if (typeof normalizedCollectLimit === 'number') {
+    url.searchParams.set('tr_limit', String(normalizedCollectLimit))
+  }
+
+  const normalizedMaxPages = normalizeOptionalPositiveInt(maxPages)
+  if (typeof normalizedMaxPages === 'number') {
+    url.searchParams.set('tr_max_pages', String(normalizedMaxPages))
+  }
+
+  const normalizedMinAge = normalizeOptionalPositiveInt(minAge)
+  if (typeof normalizedMinAge === 'number') {
+    url.searchParams.set('tr_min_age', String(normalizedMinAge))
+  }
+
+  const normalizedMaxAge = normalizeOptionalPositiveInt(maxAge)
+  if (typeof normalizedMaxAge === 'number') {
+    url.searchParams.set('tr_max_age', String(normalizedMaxAge))
+  }
+
+  return url.toString()
+}
+
+export function buildCollectionLaunchUrl({
+  source,
+  location,
+  keywords,
+  collectLimit,
+  maxPages,
+  minAge,
+  maxAge,
+}: BuildCollectionLaunchUrlInput): string | null {
+  if (source.type === SEARCH_PROFILE_SOURCE_TYPES.seek) {
+    return buildSeekCollectUrl({
+      baseUrl: source.exactUrl,
+      location,
+      keywords,
+      collectLimit,
+      maxPages,
+      minAge,
+      maxAge,
+    })
+  }
+
+  return buildJob5156CollectUrl({
+    location,
+    keywords,
+    collectLimit,
+    maxPages,
+    minAge,
+    maxAge,
+  })
 }

--- a/apps/web/src/pages/DebugConfig.test.tsx
+++ b/apps/web/src/pages/DebugConfig.test.tsx
@@ -147,6 +147,66 @@ describe('System settings routes', () => {
         })
       }
 
+      if (url.endsWith('/api/config/system-metadata')) {
+        return jsonResponse({
+          success: true,
+          metadata: {
+            identity: {
+              appVersion: '1.0.0',
+            },
+            navigation: {
+              system: [],
+              settings: [],
+              systemSettings: [
+                {
+                  id: 'overview',
+                  titleKey: 'debugConfig.settingsNavOverview',
+                  defaultTitle: 'Overview',
+                  hrefSuffix: '/system/settings',
+                  matchesSuffixes: ['/system/settings'],
+                },
+                {
+                  id: 'operations',
+                  titleKey: 'debugConfig.settingsNavOperations',
+                  defaultTitle: 'Operations',
+                  hrefSuffix: '/system/settings/operations',
+                  matchesSuffixes: ['/system/settings/operations'],
+                },
+                {
+                  id: 'runtime',
+                  titleKey: 'debugConfig.settingsNavRuntime',
+                  defaultTitle: 'AI and agents',
+                  hrefSuffix: '/system/settings/runtime',
+                  matchesSuffixes: ['/system/settings/runtime'],
+                },
+                {
+                  id: 'config-sources',
+                  titleKey: 'debugConfig.settingsNavConfigSources',
+                  defaultTitle: 'Config sources',
+                  hrefSuffix: '/system/settings/config-sources',
+                  matchesSuffixes: ['/system/settings/config-sources'],
+                },
+                {
+                  id: 'keywords',
+                  titleKey: 'debugConfig.settingsNavKeywords',
+                  defaultTitle: 'Keywords',
+                  hrefSuffix: '/system/settings/keywords',
+                  matchesSuffixes: ['/system/settings/keywords'],
+                },
+                {
+                  id: 'locations',
+                  titleKey: 'debugConfig.settingsNavLocations',
+                  defaultTitle: 'Locations',
+                  hrefSuffix: '/system/settings/locations',
+                  matchesSuffixes: ['/system/settings/locations'],
+                },
+              ],
+              debugPage: [],
+            },
+          },
+        })
+      }
+
       if (url.endsWith('/api/config/sources/resume-ai-prompts-active')) {
         return jsonResponse({
           success: true,

--- a/apps/web/src/pages/DebugConfig.tsx
+++ b/apps/web/src/pages/DebugConfig.tsx
@@ -15,7 +15,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { SYSTEM_SETTINGS_SUBPAGES, type SystemSettingsSubpageDefinition } from '@/pages/system-settings/lib'
+import { useSystemMetadata } from '@/hooks/useSystemMetadata'
+import { resolveSystemSettingsSubpages, type SystemSettingsSubpageDefinition } from '@/pages/system-settings/lib'
 
 function getSectionIcon(id: SystemSettingsSubpageDefinition['id']) {
   switch (id) {
@@ -36,12 +37,13 @@ function getSectionIcon(id: SystemSettingsSubpageDefinition['id']) {
 
 export default function DebugConfig() {
   const { t } = useTranslation()
+  const metadata = useSystemMetadata()
   const resetDatabase = useMutation(api.resume_tasks.resetDatabase)
   const [resetDatabaseDialogOpen, setResetDatabaseDialogOpen] = useState(false)
   const [resettingDatabase, setResettingDatabase] = useState(false)
 
   const sectionCards = useMemo(() => {
-    return SYSTEM_SETTINGS_SUBPAGES
+    return resolveSystemSettingsSubpages(metadata?.navigation.systemSettings)
       .filter((item) => item.id !== 'overview')
       .map((item) => ({
         ...item,
@@ -49,7 +51,7 @@ export default function DebugConfig() {
         description: t(item.descriptionKey, { defaultValue: item.defaultDescription }),
         icon: getSectionIcon(item.id),
       }))
-  }, [t])
+  }, [metadata?.navigation.systemSettings, t])
 
   async function handleResetDatabase() {
     setResettingDatabase(true)

--- a/apps/web/src/pages/system-settings/lib.ts
+++ b/apps/web/src/pages/system-settings/lib.ts
@@ -4,7 +4,9 @@ import type {
   InspectableSourceDetail as ConfigSourceDetail,
   InspectableSourceGroupSummary as ConfigSourceGroupSummary,
   InspectableSourceSummary as ConfigSourceSummary,
+  SurfaceNavDefinition,
 } from '@trends/shared'
+import { SYSTEM_SETTINGS_NAV_ITEMS } from '@trends/shared'
 import { withWorkspaceHeaders } from '@/lib/workspace-ref'
 
 export type {
@@ -107,56 +109,71 @@ export interface SystemSettingsSubpageDefinition {
   defaultDescription: string
 }
 
-export const SYSTEM_SETTINGS_SUBPAGES: SystemSettingsSubpageDefinition[] = [
-  {
-    id: 'overview',
-    href: '.',
-    titleKey: 'debugConfig.settingsNavOverview',
-    defaultTitle: 'Overview',
+const SYSTEM_SETTINGS_SUBPAGE_COPY: Record<SystemSettingsSubpageId, Pick<SystemSettingsSubpageDefinition, 'descriptionKey' | 'defaultDescription'>> = {
+  overview: {
     descriptionKey: 'debugConfig.settingsOverviewPageDescription',
     defaultDescription: 'Open each settings area in a dedicated page instead of scrolling through one long screen.',
   },
-  {
-    id: 'operations',
-    href: 'operations',
-    titleKey: 'debugConfig.settingsNavOperations',
-    defaultTitle: 'Operations',
+  operations: {
     descriptionKey: 'debugConfig.operationsPageDescription',
     defaultDescription: 'Live diagnostics and manual collection controls.',
   },
-  {
-    id: 'runtime',
-    href: 'runtime',
-    titleKey: 'debugConfig.settingsNavRuntime',
-    defaultTitle: 'AI and agents',
+  runtime: {
     descriptionKey: 'debugConfig.runtimePageDescription',
     defaultDescription: 'Inspect AI connectivity and the screening pipeline.',
   },
-  {
-    id: 'config-sources',
-    href: 'config-sources',
-    titleKey: 'debugConfig.settingsNavConfigSources',
-    defaultTitle: 'Config sources',
+  'config-sources': {
     descriptionKey: 'debugConfig.configSourcesPageDescription',
     defaultDescription: 'Inspect read-only prompt and configuration sources.',
   },
-  {
-    id: 'keywords',
-    href: 'keywords',
-    titleKey: 'debugConfig.settingsNavKeywords',
-    defaultTitle: 'Keywords',
+  keywords: {
     descriptionKey: 'debugConfig.keywordsPageDescription',
     defaultDescription: 'Manage editable keywords and review derived brand data.',
   },
-  {
-    id: 'locations',
-    href: 'locations',
-    titleKey: 'debugConfig.settingsNavLocations',
-    defaultTitle: 'Locations',
+  locations: {
     descriptionKey: 'debugConfig.locationsPageDescription',
     defaultDescription: 'Control which system location chips are visible in the UI.',
   },
-]
+}
+
+function isSystemSettingsSubpageId(value: string): value is SystemSettingsSubpageId {
+  return value in SYSTEM_SETTINGS_SUBPAGE_COPY
+}
+
+function toSystemSettingsHref(hrefSuffix: string): string {
+  const relativeSuffix = hrefSuffix.replace(/^\/system\/settings/, '')
+  return relativeSuffix ? relativeSuffix.replace(/^\//, '') : '.'
+}
+
+function toSystemSettingsSubpage(item: SurfaceNavDefinition): SystemSettingsSubpageDefinition | null {
+  if (!isSystemSettingsSubpageId(item.id)) {
+    return null
+  }
+
+  const copy = SYSTEM_SETTINGS_SUBPAGE_COPY[item.id]
+  return {
+    id: item.id,
+    href: toSystemSettingsHref(item.hrefSuffix),
+    titleKey: item.titleKey,
+    defaultTitle: item.defaultTitle,
+    descriptionKey: copy.descriptionKey,
+    defaultDescription: copy.defaultDescription,
+  }
+}
+
+export function resolveSystemSettingsSubpages(
+  navItems: SurfaceNavDefinition[] | undefined,
+): SystemSettingsSubpageDefinition[] {
+  const items = Array.isArray(navItems) && navItems.length > 0
+    ? navItems
+    : SYSTEM_SETTINGS_NAV_ITEMS
+
+  return items
+    .map((item) => toSystemSettingsSubpage(item))
+    .filter((item): item is SystemSettingsSubpageDefinition => item !== null)
+}
+
+export const SYSTEM_SETTINGS_SUBPAGES = resolveSystemSettingsSubpages(undefined)
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null

--- a/packages/cli/cmd/root.go
+++ b/packages/cli/cmd/root.go
@@ -19,6 +19,7 @@ const (
 type RootOptions struct {
 	APIURL    string
 	WorkerURL string
+	Workspace string
 	Output    string
 }
 
@@ -44,6 +45,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	viper.SetDefault("api_url", defaultAPIURL)
 	viper.SetDefault("worker_url", defaultWorkerURL)
+	viper.SetDefault("workspace", "dev")
 	viper.SetDefault("output", defaultOutput)
 
 	viper.SetEnvPrefix("TRENDS")
@@ -51,10 +53,12 @@ func init() {
 
 	rootCmd.PersistentFlags().String("api-url", defaultAPIURL, "BFF API base URL")
 	rootCmd.PersistentFlags().String("worker-url", defaultWorkerURL, "Worker API base URL")
+	rootCmd.PersistentFlags().String("workspace", "dev", "Workspace slug")
 	rootCmd.PersistentFlags().StringP("output", "o", defaultOutput, "Output format: table|json|csv")
 
 	_ = viper.BindPFlag("api_url", rootCmd.PersistentFlags().Lookup("api-url"))
 	_ = viper.BindPFlag("worker_url", rootCmd.PersistentFlags().Lookup("worker-url"))
+	_ = viper.BindPFlag("workspace", rootCmd.PersistentFlags().Lookup("workspace"))
 	_ = viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output"))
 
 	rootCmd.AddCommand(
@@ -95,13 +99,14 @@ func currentOptions() RootOptions {
 	return RootOptions{
 		APIURL:    normalizeBaseURL(viper.GetString("api_url")),
 		WorkerURL: normalizeBaseURL(viper.GetString("worker_url")),
+		Workspace: normalizeWorkspace(viper.GetString("workspace")),
 		Output:    strings.ToLower(strings.TrimSpace(viper.GetString("output"))),
 	}
 }
 
 var apiClientFactory = func() *client.Client {
 	options := currentOptions()
-	return client.New(options.APIURL, options.WorkerURL)
+	return client.New(options.APIURL, options.WorkerURL, options.Workspace)
 }
 
 func newAPIClient() *client.Client {
@@ -114,4 +119,12 @@ func normalizeBaseURL(value string) string {
 		return ""
 	}
 	return strings.TrimRight(trimmed, "/")
+}
+
+func normalizeWorkspace(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "dev"
+	}
+	return trimmed
 }

--- a/packages/cli/cmd/system.go
+++ b/packages/cli/cmd/system.go
@@ -47,12 +47,15 @@ func newSystemMetadataCmd() *cobra.Command {
 			}
 
 			headers := []string{"section", "value", "details"}
+			options := currentOptions()
 			rows := [][]string{
+				{"workspace", options.Workspace, "X-Workspace-Slug"},
 				{"app", response.Metadata.Identity.AppName, response.Metadata.Identity.AppVersion},
 				{"api", response.Metadata.Identity.SystemTitle, response.Metadata.Identity.APIVersion},
 				{"web", response.Metadata.Identity.SettingsTitle, response.Metadata.Identity.WebVersion},
 				{"system_nav", fmt.Sprintf("%d", len(response.Metadata.Navigation.System)), joinNavIDs(response.Metadata.Navigation.System)},
 				{"settings_nav", fmt.Sprintf("%d", len(response.Metadata.Navigation.Settings)), joinNavIDs(response.Metadata.Navigation.Settings)},
+				{"system_settings_nav", fmt.Sprintf("%d", len(response.Metadata.Navigation.SystemSettings)), joinNavIDs(response.Metadata.Navigation.SystemSettings)},
 				{"debug_nav", fmt.Sprintf("%d", len(response.Metadata.Navigation.DebugPage)), joinNavIDs(response.Metadata.Navigation.DebugPage)},
 				{"capabilities", fmt.Sprintf("%d", len(response.Metadata.Capabilities)), joinCapabilityIDs(response.Metadata.Capabilities)},
 			}

--- a/packages/cli/cmd/system_test.go
+++ b/packages/cli/cmd/system_test.go
@@ -32,9 +32,10 @@ func TestSystemClientEndpoints(t *testing.T) {
 						"webVersion":         "1.2.0",
 					},
 					"navigation": map[string]any{
-						"system":    []map[string]any{{"id": "home", "titleKey": "home", "defaultTitle": "Home", "hrefSuffix": "/system", "matchesSuffixes": []string{"/system"}}},
-						"settings":  []map[string]any{{"id": "blocks", "titleKey": "blocks", "defaultTitle": "Blocks", "hrefSuffix": "/settings/blocks", "matchesSuffixes": []string{"/settings/blocks"}}},
-						"debugPage": []map[string]any{{"id": "all", "titleKey": "all", "defaultTitle": "All", "hrefSuffix": "", "matchesSuffixes": []string{""}}},
+						"system":         []map[string]any{{"id": "home", "titleKey": "home", "defaultTitle": "Home", "hrefSuffix": "/system", "matchesSuffixes": []string{"/system"}}},
+						"settings":       []map[string]any{{"id": "blocks", "titleKey": "blocks", "defaultTitle": "Blocks", "hrefSuffix": "/settings/blocks", "matchesSuffixes": []string{"/settings/blocks"}}},
+						"systemSettings": []map[string]any{{"id": "overview", "titleKey": "overview", "defaultTitle": "Overview", "hrefSuffix": "/system/settings", "matchesSuffixes": []string{"/system/settings"}}},
+						"debugPage":      []map[string]any{{"id": "all", "titleKey": "all", "defaultTitle": "All", "hrefSuffix": "", "matchesSuffixes": []string{""}}},
 					},
 					"labels": map[string]any{
 						"aiBreakdown":        []map[string]any{{"key": "skills", "labelKey": "skills", "defaultLabel": "Skills", "aliases": []string{"skills"}}},
@@ -90,7 +91,7 @@ func TestSystemClientEndpoints(t *testing.T) {
 	}))
 	defer server.Close()
 
-	apiClient := client.New(server.URL, server.URL)
+	apiClient := client.New(server.URL, server.URL, "hr")
 	apiClient.HTTP = server.Client()
 
 	metadata, err := apiClient.GetSystemMetadata(context.Background())
@@ -131,13 +132,14 @@ func TestSystemMetadataCommandWritesTable(t *testing.T) {
 	getSystemMetadata = func(ctx context.Context, apiClient *client.Client) (*client.SystemMetadataResponse, error) {
 		return &client.SystemMetadataResponse{
 			Success: true,
-			Metadata: struct {
-				Identity   client.SystemMetadataIdentity `json:"identity"`
-				Navigation struct {
-					System    []client.SystemNavItem `json:"system"`
-					Settings  []client.SystemNavItem `json:"settings"`
-					DebugPage []client.SystemNavItem `json:"debugPage"`
-				} `json:"navigation"`
+		Metadata: struct {
+			Identity   client.SystemMetadataIdentity `json:"identity"`
+			Navigation struct {
+				System         []client.SystemNavItem `json:"system"`
+				Settings       []client.SystemNavItem `json:"settings"`
+				SystemSettings []client.SystemNavItem `json:"systemSettings"`
+				DebugPage      []client.SystemNavItem `json:"debugPage"`
+			} `json:"navigation"`
 				Labels struct {
 					AIBreakdown        []client.SystemLabelDescriptor `json:"aiBreakdown"`
 					IngestBrandSource  []client.SystemLabelDescriptor `json:"ingestBrandSource"`
@@ -152,13 +154,15 @@ func TestSystemMetadataCommandWritesTable(t *testing.T) {
 			}{
 				Identity: client.SystemMetadataIdentity{AppName: "Trends", SystemTitle: "System Admin", SettingsTitle: "Workspace Settings", AppVersion: "1.0.0", APIVersion: "1.1.0", WebVersion: "1.2.0"},
 				Navigation: struct {
-					System    []client.SystemNavItem `json:"system"`
-					Settings  []client.SystemNavItem `json:"settings"`
-					DebugPage []client.SystemNavItem `json:"debugPage"`
+					System         []client.SystemNavItem `json:"system"`
+					Settings       []client.SystemNavItem `json:"settings"`
+					SystemSettings []client.SystemNavItem `json:"systemSettings"`
+					DebugPage      []client.SystemNavItem `json:"debugPage"`
 				}{
-					System:    []client.SystemNavItem{{ID: "home"}},
-					Settings:  []client.SystemNavItem{{ID: "blocks"}},
-					DebugPage: []client.SystemNavItem{{ID: "all"}},
+					System:         []client.SystemNavItem{{ID: "home"}},
+					Settings:       []client.SystemNavItem{{ID: "blocks"}},
+					SystemSettings: []client.SystemNavItem{{ID: "overview"}},
+					DebugPage:      []client.SystemNavItem{{ID: "all"}},
 				},
 				Capabilities: []client.SystemCapabilityDescriptor{{ID: "cli-system-inspect"}},
 			},
@@ -181,7 +185,7 @@ func TestSystemMetadataCommandWritesTable(t *testing.T) {
 		t.Fatalf("metadata command failed: %v", err)
 	}
 	text := output.String()
-	if !strings.Contains(text, "cli-system-inspect") || !strings.Contains(text, "Trends") {
+	if !strings.Contains(text, "cli-system-inspect") || !strings.Contains(text, "Trends") || !strings.Contains(text, "system_settings_nav") || !strings.Contains(text, "dev") {
 		t.Fatalf("unexpected command output: %s", text)
 	}
 }

--- a/packages/cli/internal/client/api.go
+++ b/packages/cli/internal/client/api.go
@@ -144,9 +144,10 @@ type SystemMetadataResponse struct {
 	Metadata struct {
 		Identity   SystemMetadataIdentity `json:"identity"`
 		Navigation struct {
-			System    []SystemNavItem `json:"system"`
-			Settings  []SystemNavItem `json:"settings"`
-			DebugPage []SystemNavItem `json:"debugPage"`
+			System         []SystemNavItem `json:"system"`
+			Settings       []SystemNavItem `json:"settings"`
+			SystemSettings []SystemNavItem `json:"systemSettings"`
+			DebugPage      []SystemNavItem `json:"debugPage"`
 		} `json:"navigation"`
 		Labels struct {
 			AIBreakdown        []SystemLabelDescriptor `json:"aiBreakdown"`

--- a/packages/cli/internal/client/api_test.go
+++ b/packages/cli/internal/client/api_test.go
@@ -31,7 +31,7 @@ func TestListResumesBuildsQueryParams(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := New(server.URL, server.URL)
+	c := New(server.URL, server.URL, "dev")
 	c.HTTP = server.Client()
 
 	response, err := c.ListResumes(context.Background(), 25, "cnc 东莞")
@@ -49,7 +49,7 @@ func TestListResumesFailsWhenSuccessFalse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := New(server.URL, server.URL)
+	c := New(server.URL, server.URL, "dev")
 	c.HTTP = server.Client()
 
 	_, err := c.ListResumes(context.Background(), 0, "")
@@ -86,7 +86,7 @@ func TestExportResumesUsesBinaryEndpoint(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := New(server.URL, server.URL)
+	c := New(server.URL, server.URL, "dev")
 	c.HTTP = server.Client()
 
 	content, disposition, err := c.ExportResumes(context.Background(), ResumeExportRequest{
@@ -138,7 +138,7 @@ func TestListAndCreateJobDescriptions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := New(server.URL, server.URL)
+	c := New(server.URL, server.URL, "dev")
 	c.HTTP = server.Client()
 
 	list, err := c.ListJobDescriptions(context.Background())

--- a/packages/cli/internal/client/client.go
+++ b/packages/cli/internal/client/client.go
@@ -14,17 +14,27 @@ import (
 type Client struct {
 	APIURL    string
 	WorkerURL string
+	Workspace string
 	HTTP      *http.Client
 }
 
-func New(apiURL, workerURL string) *Client {
+func New(apiURL, workerURL, workspace string) *Client {
 	return &Client{
 		APIURL:    strings.TrimRight(apiURL, "/"),
 		WorkerURL: strings.TrimRight(workerURL, "/"),
+		Workspace: normalizeWorkspace(workspace),
 		HTTP: &http.Client{
 			Timeout: 90 * time.Second,
 		},
 	}
+}
+
+func normalizeWorkspace(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "dev"
+	}
+	return trimmed
 }
 
 func (c *Client) doJSON(ctx context.Context, method string, url string, body any, target any) error {
@@ -41,6 +51,7 @@ func (c *Client) doJSON(ctx context.Context, method string, url string, body any
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
+	req.Header.Set("X-Workspace-Slug", c.Workspace)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -85,6 +96,7 @@ func (c *Client) doBinary(ctx context.Context, method string, url string, body a
 	if err != nil {
 		return nil, nil, fmt.Errorf("create request: %w", err)
 	}
+	req.Header.Set("X-Workspace-Slug", c.Workspace)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/packages/cli/internal/client/client_test.go
+++ b/packages/cli/internal/client/client_test.go
@@ -11,12 +11,15 @@ import (
 )
 
 func TestNewNormalizesURLs(t *testing.T) {
-	c := New("http://api.local/", "http://worker.local///")
+	c := New("http://api.local/", "http://worker.local///", " hr ")
 	if c.APIURL != "http://api.local" {
 		t.Fatalf("expected normalized APIURL, got %q", c.APIURL)
 	}
 	if c.WorkerURL != "http://worker.local" {
 		t.Fatalf("expected normalized WorkerURL, got %q", c.WorkerURL)
+	}
+	if c.Workspace != "hr" {
+		t.Fatalf("expected normalized workspace, got %q", c.Workspace)
 	}
 }
 
@@ -28,11 +31,14 @@ func TestDoJSONSuccess(t *testing.T) {
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
 			t.Fatalf("expected Content-Type application/json, got %q", got)
 		}
+		if got := r.Header.Get("X-Workspace-Slug"); got != "hr" {
+			t.Fatalf("expected workspace header hr, got %q", got)
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "value": 42})
 	}))
 	defer server.Close()
 
-	c := New(server.URL, server.URL)
+	c := New(server.URL, server.URL, "hr")
 	c.HTTP = server.Client()
 
 	var target struct {
@@ -54,7 +60,7 @@ func TestDoJSONHTTPError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := New(server.URL, server.URL)
+	c := New(server.URL, server.URL, "dev")
 	c.HTTP = server.Client()
 
 	err := c.doJSON(context.Background(), http.MethodGet, server.URL, nil, nil)
@@ -72,7 +78,7 @@ func TestDoJSONInvalidJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := New(server.URL, server.URL)
+	c := New(server.URL, server.URL, "dev")
 	c.HTTP = server.Client()
 
 	var target map[string]any
@@ -92,7 +98,7 @@ func TestDoJSONTimeout(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := New(server.URL, server.URL)
+	c := New(server.URL, server.URL, "dev")
 	c.HTTP = server.Client()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
@@ -110,12 +116,15 @@ func TestDoJSONTimeout(t *testing.T) {
 
 func TestDoBinarySuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Workspace-Slug"); got != "hr" {
+			t.Fatalf("expected workspace header hr, got %q", got)
+		}
 		w.Header().Set("Content-Disposition", `attachment; filename="x.csv"`)
 		_, _ = w.Write([]byte("a,b\n1,2\n"))
 	}))
 	defer server.Close()
 
-	c := New(server.URL, server.URL)
+	c := New(server.URL, server.URL, "hr")
 	c.HTTP = server.Client()
 
 	payload, headers, err := c.doBinary(context.Background(), http.MethodPost, server.URL, map[string]string{"format": "csv"})

--- a/packages/convex/convex/__tests__/seed-workspace-demo-data.test.ts
+++ b/packages/convex/convex/__tests__/seed-workspace-demo-data.test.ts
@@ -75,6 +75,11 @@ type SearchHistoryRecord = RecordWithId & {
   location: string
   keywords: string[]
   jobDescriptionId?: string
+  collectionSource?: {
+    type: 'job5156' | 'seek'
+    exactUrl?: string
+  }
+  collectUrl?: string
   filters?: Record<string, unknown>
   selectedTags?: string[]
   selectedCompanies?: string[]

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -324,6 +324,10 @@ export default defineSchema({
             location: v.string(),
             keywords: v.array(v.string()),
             jobDescriptionId: v.optional(v.string()),
+            collectionSource: v.optional(v.object({
+                type: v.union(v.literal("job5156"), v.literal("seek")),
+                exactUrl: v.optional(v.string()),
+            })),
             collectUrl: v.optional(v.string()),
             filters: v.optional(v.any()), // Stores ResumeFilters object
         }),
@@ -341,6 +345,10 @@ export default defineSchema({
         location: v.string(),
         keywords: v.array(v.string()),
         jobDescriptionId: v.optional(v.string()),
+        collectionSource: v.optional(v.object({
+            type: v.union(v.literal("job5156"), v.literal("seek")),
+            exactUrl: v.optional(v.string()),
+        })),
         collectUrl: v.optional(v.string()),
         filters: v.optional(v.any()),
         selectedTags: v.optional(v.array(v.string())),

--- a/packages/convex/convex/seed.ts
+++ b/packages/convex/convex/seed.ts
@@ -649,7 +649,25 @@ export const seedWorkspaceDemoData = mutation({
       },
     ];
 
-    const searchHistory = [
+    const searchHistory: Array<{
+      sessionKey: string;
+      title: string;
+      location: string;
+      keywords: string[];
+      jobDescriptionId?: string;
+      collectionSource?: {
+        type: "job5156" | "seek";
+        exactUrl?: string;
+      };
+      collectUrl?: string;
+      filters?: Record<string, unknown>;
+      selectedTags?: string[];
+      selectedCompanies?: string[];
+      selectedExperienceLevel?: string;
+      workspaceSlug?: string;
+      createdAt: number;
+      lastOpenedAt: number;
+    }> = [
       {
         sessionKey: "workspace-demo-session-dev",
         title: "东莞 · 机械 销售",
@@ -991,6 +1009,8 @@ export const seedWorkspaceDemoData = mutation({
           existing.location !== item.location ||
           stableSerialize(existing.keywords) !== stableSerialize(item.keywords) ||
           existing.jobDescriptionId !== item.jobDescriptionId ||
+          stableSerialize(existing.collectionSource ?? null) !== stableSerialize(item.collectionSource ?? null) ||
+          existing.collectUrl !== item.collectUrl ||
           stableSerialize(existing.filters ?? {}) !== stableSerialize(item.filters ?? {}) ||
           stableSerialize(existing.selectedTags ?? []) !== stableSerialize(item.selectedTags ?? []) ||
           stableSerialize(existing.selectedCompanies ?? []) !== stableSerialize(item.selectedCompanies ?? []) ||
@@ -1003,6 +1023,8 @@ export const seedWorkspaceDemoData = mutation({
             location: item.location,
             keywords: item.keywords,
             jobDescriptionId: item.jobDescriptionId,
+            collectionSource: item.collectionSource,
+            collectUrl: item.collectUrl,
             filters: item.filters,
             selectedTags: item.selectedTags,
             selectedCompanies: item.selectedCompanies,
@@ -1022,6 +1044,8 @@ export const seedWorkspaceDemoData = mutation({
         location: item.location,
         keywords: item.keywords,
         jobDescriptionId: item.jobDescriptionId,
+        collectionSource: item.collectionSource,
+        collectUrl: item.collectUrl,
         filters: item.filters,
         selectedTags: item.selectedTags,
         selectedCompanies: item.selectedCompanies,

--- a/packages/convex/convex/sessions.ts
+++ b/packages/convex/convex/sessions.ts
@@ -3,6 +3,11 @@ import { mutation, query, type MutationCtx } from "./_generated/server";
 
 export const DEFAULT_WORKSPACE_SLUG = "dev";
 
+type CollectionSource = {
+    type: "job5156" | "seek";
+    exactUrl?: string;
+};
+
 function normalizeWorkspaceSlug(input: string | undefined): string {
     const normalized = input?.trim();
     return normalized && normalized.length > 0 ? normalized : DEFAULT_WORKSPACE_SLUG;
@@ -31,6 +36,25 @@ function normalizeStringList(values: string[] | undefined): string[] {
     });
 
     return normalized;
+}
+
+function normalizeCollectionSource(
+    input: CollectionSource | undefined,
+    legacyCollectUrl?: string,
+): CollectionSource | undefined {
+    const type = input?.type;
+    if (type === "job5156") {
+        return { type };
+    }
+
+    const exactUrl = normalizeOptionalString(
+        (type === "seek" ? input?.exactUrl : undefined) ?? legacyCollectUrl,
+    );
+    if (type === "seek") {
+        return exactUrl ? { type, exactUrl } : { type };
+    }
+
+    return exactUrl ? { type: "seek", exactUrl } : undefined;
 }
 
 function belongsToWorkspace(
@@ -157,6 +181,10 @@ export const saveSession = mutation({
         location: v.string(),
         keywords: v.array(v.string()),
         jobDescriptionId: v.optional(v.string()),
+        collectionSource: v.optional(v.object({
+            type: v.union(v.literal("job5156"), v.literal("seek")),
+            exactUrl: v.optional(v.string()),
+        })),
         collectUrl: v.optional(v.string()),
         filters: v.optional(v.any()),
     },
@@ -176,6 +204,7 @@ export const saveSession = mutation({
                 location: args.location,
                 keywords: args.keywords,
                 jobDescriptionId: args.jobDescriptionId,
+                collectionSource: normalizeCollectionSource(args.collectionSource, args.collectUrl),
                 collectUrl: normalizeOptionalString(args.collectUrl),
                 filters: args.filters,
             },
@@ -307,6 +336,10 @@ export const saveSearchHistory = mutation({
         location: v.string(),
         keywords: v.array(v.string()),
         jobDescriptionId: v.optional(v.string()),
+        collectionSource: v.optional(v.object({
+            type: v.union(v.literal("job5156"), v.literal("seek")),
+            exactUrl: v.optional(v.string()),
+        })),
         collectUrl: v.optional(v.string()),
         filters: v.optional(v.any()),
         selectedTags: v.optional(v.array(v.string())),
@@ -323,6 +356,7 @@ export const saveSearchHistory = mutation({
         const keywords = normalizeStringList(args.keywords);
         const title = normalizeOptionalString(args.title) ?? buildHistoryTitle(location, keywords);
         const jobDescriptionId = normalizeOptionalString(args.jobDescriptionId);
+        const collectionSource = normalizeCollectionSource(args.collectionSource, args.collectUrl);
         const collectUrl = normalizeOptionalString(args.collectUrl);
         const selectedTags = normalizeStringList(args.selectedTags);
         const selectedCompanies = normalizeStringList(args.selectedCompanies);
@@ -338,6 +372,7 @@ export const saveSearchHistory = mutation({
             location,
             keywords,
             jobDescriptionId,
+            collectionSource,
             collectUrl,
             filters: args.filters,
             selectedTags,

--- a/packages/shared/src/system-debug-metadata.ts
+++ b/packages/shared/src/system-debug-metadata.ts
@@ -286,6 +286,51 @@ export const SETTINGS_NAV_ITEMS: SurfaceNavDefinition[] = [
   },
 ];
 
+export const SYSTEM_SETTINGS_NAV_ITEMS: SurfaceNavDefinition[] = [
+  {
+    id: "overview",
+    titleKey: "debugConfig.settingsNavOverview",
+    defaultTitle: "Overview",
+    hrefSuffix: "/system/settings",
+    matchesSuffixes: ["/system/settings"],
+  },
+  {
+    id: "operations",
+    titleKey: "debugConfig.settingsNavOperations",
+    defaultTitle: "Operations",
+    hrefSuffix: "/system/settings/operations",
+    matchesSuffixes: ["/system/settings/operations"],
+  },
+  {
+    id: "runtime",
+    titleKey: "debugConfig.settingsNavRuntime",
+    defaultTitle: "AI and agents",
+    hrefSuffix: "/system/settings/runtime",
+    matchesSuffixes: ["/system/settings/runtime"],
+  },
+  {
+    id: "config-sources",
+    titleKey: "debugConfig.settingsNavConfigSources",
+    defaultTitle: "Config sources",
+    hrefSuffix: "/system/settings/config-sources",
+    matchesSuffixes: ["/system/settings/config-sources"],
+  },
+  {
+    id: "keywords",
+    titleKey: "debugConfig.settingsNavKeywords",
+    defaultTitle: "Keywords",
+    hrefSuffix: "/system/settings/keywords",
+    matchesSuffixes: ["/system/settings/keywords"],
+  },
+  {
+    id: "locations",
+    titleKey: "debugConfig.settingsNavLocations",
+    defaultTitle: "Locations",
+    hrefSuffix: "/system/settings/locations",
+    matchesSuffixes: ["/system/settings/locations"],
+  },
+];
+
 export const DEBUG_PAGE_SECTION_DEFINITIONS: Array<{
   id: "all" | "inputs" | "findings" | "process" | "raw" | "industry" | "jobs" | "config" | "ai";
   titleKey: string;


### PR DESCRIPTION
## Summary
- make the resume-page Collect action source-aware for Job5156 and SEEK with explicit lane selection
- persist collection source state through Convex sessions/search history while keeping legacy Seek collectUrl compatibility
- align system settings metadata across shared/API/web/CLI and add CLI workspace header propagation

## Testing
- make check
- cd apps/web && bunx vitest run src/lib/search-profile-sources.test.ts src/components/CollectResumesButton.test.tsx src/hooks/useSession.test.tsx src/hooks/useResumeListState.test.tsx src/components/QuickStartPanel.test.tsx src/pages/DebugConfig.test.tsx
- bunx vitest run apps/api/src/routes/config.test.ts packages/convex/convex/__tests__/sessions.test.ts packages/convex/convex/__tests__/seed-workspace-demo-data.test.ts
- cd packages/cli && go test ./internal/client ./cmd