### PR TITLE
fix: guard sidebar system metadata access

### DIFF
--- a/apps/web/src/components/SettingsSidebar.tsx
+++ b/apps/web/src/components/SettingsSidebar.tsx
@@ -34,7 +34,7 @@ export function SettingsSidebar({ onClose }: SettingsSidebarProps) {
   const { slug } = useWorkspace()
   const { t } = useTranslation()
   const metadata = useSystemMetadata()
-  const appVersion = metadata?.identity.appVersion ?? 'unknown'
+  const appVersion = metadata?.identity?.appVersion ?? 'unknown'
 
   const navItems = useMemo<NavItem[]>(() => {
     return SETTINGS_NAV_ITEMS.map((item) => ({

--- a/apps/web/src/components/SidebarResetNavigation.test.tsx
+++ b/apps/web/src/components/SidebarResetNavigation.test.tsx
@@ -63,7 +63,9 @@ vi.mock('@/contexts/WorkspaceContext', () => ({
 
 vi.mock('@/hooks/useSystemMetadata', () => ({
   useSystemMetadata: () => ({
-    appVersion: mockState.appVersion,
+    identity: {
+      appVersion: mockState.appVersion,
+    },
   }),
 }))
 

--- a/apps/web/src/components/SystemSidebar.tsx
+++ b/apps/web/src/components/SystemSidebar.tsx
@@ -50,7 +50,7 @@ export function SystemSidebar({ onClose }: SystemSidebarProps) {
   const { slug } = useWorkspace()
   const { t } = useTranslation()
   const metadata = useSystemMetadata()
-  const appVersion = metadata?.identity.appVersion ?? 'unknown'
+  const appVersion = metadata?.identity?.appVersion ?? 'unknown'
 
   const navItems = useMemo<NavItem[]>(() => {
     return SYSTEM_NAV_ITEMS.map((item) => ({


### PR DESCRIPTION
## Summary
- guard sidebar version labels when system metadata has not loaded yet
- align the sidebar reset-navigation test mock with the real `useSystemMetadata` payload shape
- cover the exact `make test-coverage` regression that failed after #259 merged

## Validation
- `cd apps/web && bunx vitest run src/components/SidebarResetNavigation.test.tsx`
- `make test-coverage`
- `make check`
