### PR TITLE
fix: emit lcov coverage artifacts

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     css: false,
     coverage: {
       provider: 'v8',
+      reporter: ['text', 'html', 'clover', 'json', 'lcov'],
       include: ['src/**/*.{ts,tsx}'],
       exclude: ['src/test/**', 'src/**/*.d.ts', 'src/vite-env.d.ts'],
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,9 @@ export default defineConfig({
         environment: "node",
         include: ["apps/**/*.test.ts", "packages/**/*.test.ts"],
         exclude: ["apps/web/**/*.test.ts", "apps/web/**/*.test.tsx"],
+        coverage: {
+            provider: "v8",
+            reporter: ["text", "html", "clover", "json", "lcov"],
+        },
     },
 });


### PR DESCRIPTION
## Summary
- configure both Vitest coverage runs to emit `lcov.info` alongside the existing reports
- align `make test-coverage` outputs with `.github/workflows/tests.yml`, which already uploads `./apps/web/coverage/lcov.info` and `./coverage/lcov.info`
- remove the local artifact mismatch that currently forces Codecov into fallback autodiscovery

## Validation
- `make test-coverage`
- `make check`

## Note
This does not guarantee Codecov ingest stops returning 500 responses, but it does remove the repo-side missing-file mismatch.
