### PR TITLE
feat: add live resume query debug parity

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createApp } from "../app";
+import { MatchStorage } from "../services/match-storage";
+import { SessionManager } from "../services/session-manager";
+
+type ConvexCall = {
+  pathName: string;
+  args: Record<string, unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+  const requestURL = typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+
+  if (!requestURL.includes("/api/query")) {
+    throw new Error(`Unexpected request URL: ${requestURL}`);
+  }
+
+  const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+  if (!isRecord(body)) {
+    throw new Error("Missing convex request body");
+  }
+
+  const pathName = typeof body.path === "string" ? body.path : "";
+  const args = isRecord(body.args) ? body.args : {};
+  if (!pathName) {
+    throw new Error("Missing convex path");
+  }
+
+  return { pathName, args };
+}
+
+function convexSuccess(value: unknown): Response {
+  return new Response(
+    JSON.stringify({
+      status: "success",
+      value,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+}
+
+describe("resume routes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns convex-backed live query results and expansion metadata", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:searchWithTagExpansion") {
+        return convexSuccess({
+          expansion: {
+            original: "cnc 销售",
+            expanded: ["cnc", "销售"],
+            groups: [
+              { original: "cnc", variants: ["cnc"] },
+              { original: "销售", variants: ["销售", "业务"] },
+            ],
+            mode: "AND",
+          },
+          results: [
+            {
+              resume: {
+                _id: "resume-live-1",
+                source: "seek",
+                primaryRuleScore: 44,
+                content: {
+                  name: "Alice",
+                  location: "东莞",
+                  experience: "5 years",
+                  education: "Bachelor",
+                  jobIntention: "Sales",
+                  profileUrl: "https://example.com/alice",
+                  workHistory: [{ raw: "2020-2025 CNC 销售工程师" }],
+                },
+                ingestData: {
+                  companyHits: ["fanuc"],
+                  brandHits: [],
+                  roleSignals: [],
+                },
+              },
+              provenance: [{ term: "销售", source: "searchText" }],
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&q=CNC%20%E9%94%80%E5%94%AE&limit=5");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.summary.source).toBe("convex");
+    expect(payload.summary.keywordGroups).toEqual(
+      expect.arrayContaining([expect.objectContaining({ original: "cnc" })])
+    );
+    expect(payload.data[0]).toEqual(
+      expect.objectContaining({
+        resumeId: "resume-live-1",
+        name: "Alice",
+        location: "东莞",
+      })
+    );
+    expect(calls[0]?.pathName).toBe("resumes:searchWithTagExpansion");
+  });
+
+  it("returns read-only convex query scores with debug metadata", async () => {
+    const createSessionSpy = vi.spyOn(SessionManager.prototype, "createSession");
+    const saveMatchesSpy = vi.spyOn(MatchStorage.prototype, "saveMatches");
+    const createRunSpy = vi.spyOn(MatchStorage.prototype, "createMatchRun");
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      if (call.pathName === "resumes:getByIdsForExport") {
+        return convexSuccess([
+          {
+            resumeId: "resume-convex-1",
+            resume: {
+              name: "Zhang Sales",
+              location: "东莞",
+              experience: "8 years",
+              education: "Bachelor",
+              jobIntention: "Sales Engineer",
+              profileUrl: "https://example.com/zhang",
+              workHistory: [{ raw: "2018-2026 CNC 销售工程师" }],
+              ingestData: {
+                companyHits: ["fanuc"],
+                brandHits: [
+                  {
+                    brand: "fanuc",
+                    role: "both",
+                    source: "workHistory",
+                    context: "employer",
+                  },
+                ],
+                roleSignals: [
+                  {
+                    type: "sales",
+                    matchedSignals: ["销售工程师", "销售"],
+                    signalCount: 2,
+                    occurrences: 2,
+                    years: 8,
+                    industryVerifiedYears: 8,
+                    verifyIn: "workHistory",
+                  },
+                ],
+              },
+            },
+          },
+        ]);
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes/match", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        source: "convex",
+        persist: false,
+        mode: "rules_only",
+        keywords: ["CNC", "销售"],
+        location: "东莞",
+        resumeIds: ["resume-convex-1"],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.query).toEqual(
+      expect.objectContaining({
+        source: "convex",
+        persisted: false,
+      })
+    );
+    expect(payload.query.inferredRequiredRoles).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "sales", verifyIn: "workHistory" })])
+    );
+    expect(payload.results[0]).toEqual(
+      expect.objectContaining({
+        resumeId: "resume-convex-1",
+        debug: expect.objectContaining({
+          companyHits: ["fanuc"],
+          roleSignals: expect.arrayContaining([expect.objectContaining({ type: "sales" })]),
+          brandHits: expect.arrayContaining([expect.objectContaining({ brand: "fanuc" })]),
+        }),
+      })
+    );
+    expect(createSessionSpy).not.toHaveBeenCalled();
+    expect(saveMatchesSpy).not.toHaveBeenCalled();
+    expect(createRunSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects convex or read-only match-stream requests", async () => {
+    const app = createApp();
+
+    const convexResponse = await app.request("/api/resumes/match-stream", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        source: "convex",
+        keywords: ["CNC"],
+      }),
+    });
+    expect(convexResponse.status).toBe(400);
+
+    const readOnlyResponse = await app.request("/api/resumes/match-stream", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        persist: false,
+        keywords: ["CNC"],
+      }),
+    });
+    expect(readOnlyResponse.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -35,7 +35,15 @@ import {
 } from "../services/match-storage.js";
 import { SessionManager } from "../services/session-manager.js";
 import { JobDescriptionService } from "../services/job-description-service.js";
-import { RuleScoringService } from "../services/rule-scoring.js";
+import {
+  RuleScoringService,
+  type BrandContext,
+  type BrandHit,
+  type BrandRole,
+  type RoleSignalSummary,
+  type RuleScoringContext,
+  type RuleScoringResult,
+} from "../services/rule-scoring.js";
 import { resolveResumeId } from "../services/resume-id.js";
 import { IngestComputeService } from "../services/ingest-compute-service.js";
 import { buildWorkHistoryEntryText, buildWorkHistoryEvidence, normalizeWorkHistoryEntry } from "@trends/shared";
@@ -93,6 +101,8 @@ const ClearMatchesResponseSchema = z.object({
 const RescoreRequestSchema = z.object({
   sessionId: z.string().optional(),
   sample: z.string().optional(),
+  source: z.enum(["sample", "convex"]).default("sample"),
+  persist: z.boolean().default(true),
   jobDescriptionId: z.string().optional(),
   keywords: z.array(z.string()).optional(),
   location: z.string().optional(),
@@ -122,6 +132,23 @@ type ResumeExportEntryContext = ResumeExportCanonicalRequest["entries"][number];
 type ResumeExportLegacyEntryContext = z.infer<typeof ResumeExportLegacyRequestSchema>["entries"][number];
 type ExportResumePayload = ResumeExportEntry["resume"];
 type ResumeExportEntryFields = Omit<ResumeExportEntry, "key" | "resume">;
+type ResumeSource = "sample" | "convex";
+type ResumeKeywordExpansion = ReturnType<ResumeService["expandSearchQuery"]>;
+type ResumeSearchProvenance = {
+  term: string;
+  source: "searchText" | "industryTags" | "companyHits" | "synonymHits";
+  expandedFrom?: string;
+};
+type PreparedResumeCandidate = {
+  resume: ResumeItem;
+  resumeId: string;
+  indexData: ResumeIndex;
+  primaryRuleScore?: number;
+  provenance?: ResumeSearchProvenance[];
+  brandHits: BrandHit[];
+  companyHits: string[];
+  roleSignals: RoleSignalSummary[];
+};
 
 function stripFrontMatter(content: string): string {
   const lines = content.split("\n");
@@ -204,6 +231,262 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function toStringValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value).trim();
+}
+
+function toOptionalNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item) => toStringValue(item))
+    .filter(Boolean);
+}
+
+function toBrandRole(value: unknown): BrandRole | null {
+  if (value === "employer" || value === "equipment" || value === "both") {
+    return value;
+  }
+  return null;
+}
+
+function toBrandContext(value: unknown): BrandContext | null {
+  if (
+    value === "employer"
+    || value === "equipment"
+    || value === "sales"
+    || value === "technical"
+    || value === "general"
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function parseBrandHits(value: unknown): BrandHit[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((item) => {
+    if (!isRecord(item)) {
+      return [];
+    }
+
+    const brand = toStringValue(item.brand);
+    const role = toBrandRole(item.role);
+    const source = item.source === "workHistory" || item.source === "selfIntro" || item.source === "jobIntention"
+      ? item.source
+      : null;
+    const context = toBrandContext(item.context);
+
+    if (!brand || !role || !source || !context) {
+      return [];
+    }
+
+    return [{
+      brand,
+      role,
+      source,
+      context,
+    }];
+  });
+}
+
+function parseRoleSignals(value: unknown): RoleSignalSummary[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((item) => {
+    if (!isRecord(item)) {
+      return [];
+    }
+
+    const type = toStringValue(item.type);
+    const years = toOptionalNumber(item.years);
+    if (!type || years === undefined) {
+      return [];
+    }
+
+    const matchedSignals = toStringArray(item.matchedSignals);
+    const verifyIn = item.verifyIn === "searchText" ? "searchText" : "workHistory";
+    const signalCount = toOptionalNumber(item.signalCount) ?? matchedSignals.length;
+    const occurrences = toOptionalNumber(item.occurrences) ?? matchedSignals.length;
+    const industryVerifiedYears = toOptionalNumber(item.industryVerifiedYears) ?? 0;
+    const roleRelevantYears = toOptionalNumber(item.roleRelevantYears);
+    const industryVerifiedRelevantYears = toOptionalNumber(item.industryVerifiedRelevantYears);
+    const matchedWorkEntries = Array.isArray(item.matchedWorkEntries)
+      ? item.matchedWorkEntries.flatMap((entry) => {
+          if (!isRecord(entry)) {
+            return [];
+          }
+          const entryYears = toOptionalNumber(entry.years);
+          if (entryYears === undefined) {
+            return [];
+          }
+          return [{
+            companyName: toStringValue(entry.companyName) || undefined,
+            jobTitle: toStringValue(entry.jobTitle) || undefined,
+            years: entryYears,
+            industryVerified: entry.industryVerified === true,
+            matchedSignals: toStringArray(entry.matchedSignals),
+          }];
+        })
+      : undefined;
+
+    return [{
+      type,
+      matchedSignals,
+      signalCount,
+      occurrences,
+      years,
+      industryVerifiedYears,
+      ...(roleRelevantYears === undefined ? {} : { roleRelevantYears }),
+      ...(industryVerifiedRelevantYears === undefined ? {} : { industryVerifiedRelevantYears }),
+      ...(matchedWorkEntries && matchedWorkEntries.length > 0 ? { matchedWorkEntries } : {}),
+      verifyIn,
+    }];
+  });
+}
+
+function buildResumeIngestData(value: unknown): ResumeItem["ingestData"] | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const industryTags = toStringArray(value.industryTags);
+  const companyHits = toStringArray(value.companyHits);
+  const brandHits = parseBrandHits(value.brandHits);
+  const roleSignals = parseRoleSignals(value.roleSignals);
+  const industryDbV2Raw = toOptionalNumber(value.industryDbV2Raw);
+
+  if (
+    industryTags.length === 0
+    && companyHits.length === 0
+    && brandHits.length === 0
+    && roleSignals.length === 0
+    && industryDbV2Raw === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(industryTags.length > 0 ? { industryTags } : {}),
+    ...(companyHits.length > 0 ? { companyHits } : {}),
+    ...(brandHits.length > 0 ? { brandHits } : {}),
+    ...(roleSignals.length > 0 ? { roleSignals } : {}),
+    ...(industryDbV2Raw === undefined ? {} : { industryDbV2Raw }),
+  };
+}
+
+function parseConvexProvenance(value: unknown): ResumeSearchProvenance[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const provenance = value.flatMap((item) => {
+    if (!isRecord(item)) {
+      return [];
+    }
+    const term = toStringValue(item.term);
+    const source: ResumeSearchProvenance["source"] | null = item.source === "searchText"
+      || item.source === "industryTags"
+      || item.source === "companyHits"
+      || item.source === "synonymHits"
+      ? item.source
+      : null;
+    const expandedFrom = toStringValue(item.expandedFrom) || undefined;
+    if (!term || !source) {
+      return [];
+    }
+    return [{ term, source, ...(expandedFrom ? { expandedFrom } : {}) }];
+  });
+
+  return provenance.length > 0 ? provenance : undefined;
+}
+
+function toResumeItemFromRecord(record: Record<string, unknown>, source?: string): ResumeItem {
+  const profileUrl = toStringValue(
+    record.profileUrl ?? record.profile_url ?? record.profileURL ?? record.url
+  );
+  const workHistory = Array.isArray(record.workHistory)
+    ? record.workHistory
+      .map((entry) => normalizeWorkHistoryEntry(entry))
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    : [];
+
+  return {
+    name: toStringValue(record.name),
+    profileUrl,
+    activityStatus: toStringValue(record.activityStatus),
+    age: toStringValue(record.age),
+    experience: toStringValue(record.experience),
+    education: toStringValue(record.education),
+    location: toStringValue(record.location),
+    selfIntro: toStringValue(record.selfIntro),
+    jobIntention: toStringValue(record.jobIntention),
+    expectedSalary: toStringValue(record.expectedSalary),
+    workHistory,
+    extractedAt: toStringValue(record.extractedAt),
+    ingestData: buildResumeIngestData(record.ingestData),
+    resumeId: toStringValue(record.resumeId) || undefined,
+    perUserId: toStringValue(record.perUserId) || undefined,
+    profileId: toStringValue(record.profileId) || undefined,
+    profileType: toStringValue(record.profileType) || (source ? source : undefined),
+    externalId: toStringValue(record.externalId) || undefined,
+  };
+}
+
+function prepareResumeCandidate(params: {
+  resume: ResumeItem;
+  resumeId: string;
+  indexData?: ResumeIndex;
+  primaryRuleScore?: number;
+  provenance?: ResumeSearchProvenance[];
+  ingestData?: unknown;
+}): PreparedResumeCandidate {
+  const ingestData = params.ingestData ?? params.resume.ingestData;
+  const resume = params.resume.resumeId
+    ? params.resume
+    : {
+        ...params.resume,
+        resumeId: params.resumeId,
+      };
+  return {
+    resume,
+    resumeId: params.resumeId,
+    indexData: params.indexData ?? createFallbackIndex(resume, params.resumeId),
+    primaryRuleScore: params.primaryRuleScore,
+    provenance: params.provenance,
+    brandHits: parseBrandHits(isRecord(ingestData) ? ingestData.brandHits : undefined),
+    companyHits: toStringArray(isRecord(ingestData) ? ingestData.companyHits : undefined),
+    roleSignals: parseRoleSignals(isRecord(ingestData) ? ingestData.roleSignals : undefined),
+  };
+}
+
 async function callConvexQuery(pathName: string, args: Record<string, unknown>): Promise<unknown> {
   const convexUrl = resolveConvexUrl().replace(/\/$/, "");
   const response = await fetch(`${convexUrl}/api/query`, {
@@ -234,6 +517,221 @@ async function callConvexQuery(pathName: string, args: Record<string, unknown>):
   }
 
   return payload.value;
+}
+
+function buildKeywordExpansionSummary(expansion: ResumeKeywordExpansion): {
+  expandedTo?: string[];
+  mode?: "AND" | "OR";
+  keywordGroups?: Array<{ original: string; variants: string[] }>;
+  sourceMapping?: Record<string, string>;
+} {
+  return {
+    expandedTo: expansion?.flatTerms,
+    mode: expansion?.mode,
+    keywordGroups: expansion?.groups,
+    sourceMapping: expansion?.sourceMapping,
+  };
+}
+
+function buildMatchQueryMetadata(params: {
+  source: ResumeSource;
+  persisted: boolean;
+  keywordExpansion?: ResumeKeywordExpansion;
+  context: RuleScoringContext;
+}) {
+  const requiredRoles = params.context.requiredRoles.map((role) => ({
+    type: role.type,
+    signals: role.signals,
+    verifyIn: role.verifyIn,
+    ...(typeof role.minYears === "number" ? { minYears: role.minYears } : {}),
+  }));
+
+  return {
+    source: params.source,
+    persisted: params.persisted,
+    keywordGroups: params.keywordExpansion?.groups,
+    expandedTo: params.keywordExpansion?.flatTerms,
+    sourceMapping: params.keywordExpansion?.sourceMapping,
+    inferredRequiredRoles: requiredRoles,
+  };
+}
+
+function scorePreparedCandidates(
+  prepared: PreparedResumeCandidate[],
+  context: RuleScoringContext
+): Array<{ resumeId: string; result: RuleScoringResult; candidate: PreparedResumeCandidate }> {
+  return prepared.map((candidate) => ({
+    resumeId: candidate.resumeId,
+    result: ruleScoringService.scoreResume(
+      candidate.indexData,
+      context,
+      candidate.brandHits,
+      candidate.roleSignals
+    ),
+    candidate,
+  }));
+}
+
+function buildRuleMatchResponseEntry(params: {
+  candidate: PreparedResumeCandidate;
+  result: RuleScoringResult;
+  jobDescriptionId: string;
+  sessionId?: string;
+}): z.infer<typeof MatchResponseSchema>["results"][number] {
+  const matchingResult = ruleScoringService.toMatchingResult(params.result);
+  return {
+    resumeId: params.candidate.resumeId,
+    jobDescriptionId: params.jobDescriptionId,
+    score: matchingResult.score,
+    recommendation: matchingResult.recommendation,
+    highlights: matchingResult.highlights,
+    concerns: matchingResult.concerns,
+    summary: matchingResult.summary,
+    breakdown: matchingResult.breakdown,
+    scoreSource: matchingResult.scoreSource,
+    matchedAt: new Date().toISOString(),
+    sessionId: params.sessionId,
+    debug: {
+      primaryRuleScore: params.candidate.primaryRuleScore,
+      provenance: params.candidate.provenance,
+      roleSignals: params.candidate.roleSignals,
+      companyHits: params.candidate.companyHits,
+      brandHits: params.candidate.brandHits,
+    },
+  };
+}
+
+function prepareSampleCandidates(params: {
+  items: ResumeItem[];
+  indexMap: Map<string, ResumeIndex>;
+  resumeIds?: string[];
+  limit?: number;
+}): PreparedResumeCandidate[] {
+  const resumeIdFilter = params.resumeIds?.length
+    ? new Set(params.resumeIds)
+    : null;
+  const selected = resumeIdFilter
+    ? params.items
+      .map((resume, index) => ({ resume, resumeId: resolveResumeId(resume, index) }))
+      .filter((item) => resumeIdFilter.has(item.resumeId))
+    : params.items.map((resume, index) => ({ resume, resumeId: resolveResumeId(resume, index) }));
+  const limited = typeof params.limit === "number" ? selected.slice(0, params.limit) : selected;
+
+  return limited.map((item) => prepareResumeCandidate({
+    resume: item.resume,
+    resumeId: item.resumeId,
+    indexData: params.indexMap.get(item.resumeId) ?? createFallbackIndex(item.resume, item.resumeId),
+  }));
+}
+
+async function prepareConvexCandidates(params: {
+  resumeIds?: string[];
+  keywords?: string[];
+  location?: string;
+  limit?: number;
+  jobDescriptionId?: string;
+}): Promise<{
+  prepared: PreparedResumeCandidate[];
+  keywordExpansion?: ResumeKeywordExpansion;
+}> {
+  const resumeIds = Array.from(new Set((params.resumeIds ?? []).map((resumeId) => resumeId.trim()).filter(Boolean)));
+  if (resumeIds.length > 0) {
+    const value = await callConvexQuery("resumes:getByIdsForExport", { resumeIds });
+    if (!Array.isArray(value)) {
+      throw new Error("Invalid resume response from Convex");
+    }
+
+    const byId = new Map<string, PreparedResumeCandidate>();
+    value.forEach((item) => {
+      if (!isRecord(item)) {
+        return;
+      }
+      const resumeId = toStringValue(item.resumeId);
+      const resumeRecord = isRecord(item.resume) ? item.resume : null;
+      if (!resumeId || !resumeRecord) {
+        return;
+      }
+      const resume = toResumeItemFromRecord(resumeRecord);
+      byId.set(resumeId, prepareResumeCandidate({
+        resume,
+        resumeId,
+        ingestData: resumeRecord.ingestData,
+      }));
+    });
+
+    const prepared = resumeIds
+      .map((resumeId) => byId.get(resumeId))
+      .filter((item): item is PreparedResumeCandidate => Boolean(item));
+    const limited = typeof params.limit === "number" ? prepared.slice(0, params.limit) : prepared;
+    return { prepared: limited };
+  }
+
+  const normalizedKeywords = normalizeKeywords(params.keywords);
+  if (normalizedKeywords.length > 0) {
+    const keywordExpansion = resumeService.expandSearchQuery(normalizedKeywords.join(" "));
+    const value = await callConvexQuery("resumes:searchWithTagExpansion", {
+      query: normalizedKeywords.join(" "),
+      keywordGroups: keywordExpansion?.groups ?? [],
+      mode: keywordExpansion?.mode ?? "AND",
+      sourceMappings: Object.entries(keywordExpansion?.sourceMapping ?? {}).map(([term, expandedFrom]) => ({
+        term,
+        expandedFrom,
+      })),
+      limit: params.limit,
+      jobDescriptionId: params.jobDescriptionId,
+    });
+
+    if (!isRecord(value) || !Array.isArray(value.results)) {
+      throw new Error("Invalid resume search response from Convex");
+    }
+
+    const prepared = value.results.flatMap((entry) => {
+      if (!isRecord(entry) || !isRecord(entry.resume)) {
+        return [];
+      }
+      const resumeRecord = entry.resume;
+      const resumeId = toStringValue(resumeRecord._id);
+      if (!resumeId) {
+        return [];
+      }
+
+      return [prepareResumeCandidate({
+        resume: toResumeItemFromRecord(isRecord(resumeRecord.content) ? resumeRecord.content : {}, toStringValue(resumeRecord.source)),
+        resumeId,
+        primaryRuleScore: toOptionalNumber(resumeRecord.primaryRuleScore),
+        provenance: parseConvexProvenance(entry.provenance),
+        ingestData: resumeRecord.ingestData,
+      })];
+    });
+
+    return { prepared, keywordExpansion };
+  }
+
+  const value = await callConvexQuery("resumes:listWithIngestData", {
+    limit: params.limit,
+    jobDescriptionId: params.jobDescriptionId,
+  });
+  if (!Array.isArray(value)) {
+    throw new Error("Invalid resume list response from Convex");
+  }
+
+  return {
+    prepared: value.flatMap((item) => {
+      if (!isRecord(item)) {
+        return [];
+      }
+      const resumeId = toStringValue(item._id);
+      if (!resumeId) {
+        return [];
+      }
+      return [prepareResumeCandidate({
+        resume: toResumeItemFromRecord(isRecord(item.content) ? item.content : {}, toStringValue(item.source)),
+        resumeId,
+        primaryRuleScore: toOptionalNumber(item.primaryRuleScore),
+        ingestData: item.ingestData,
+      })];
+    }),
+  };
 }
 
 function toExportResumePayload(resume: ResumeItem): ExportResumePayload {
@@ -701,6 +1199,7 @@ const getResumesRoute = createRoute({
 app.openapi(getResumesRoute, (c) => {
   const {
     sample,
+    source,
     q,
     limit,
     offset,
@@ -723,6 +1222,107 @@ app.openapi(getResumesRoute, (c) => {
   const keywordExpansion = resumeService.expandSearchQuery(keyword);
 
   try {
+    if (source === "convex") {
+      return (async () => {
+        const { prepared, keywordExpansion: liveExpansion } = await prepareConvexCandidates({
+          keywords: keyword ? normalizeKeywords(keyword.split(/\s+/)) : [],
+          limit,
+          jobDescriptionId: jobDescriptionId?.trim() || undefined,
+        });
+
+        let filtered = prepared.map((item) => item.resume);
+        filtered = resumeService.filterResumes(filtered, {
+          minExperience,
+          maxExperience,
+          education,
+          skills,
+          locations,
+          minSalary,
+          maxSalary,
+        });
+
+        const enriched = filtered.map((item, index) => ({
+          resume: item,
+          id: resolveResumeId(item, index),
+        }));
+
+        let matchMap: Map<string, { score: number; recommendation: string }> | null = null;
+        const resolvedJobId = jobDescriptionId?.trim() || undefined;
+        const needsMatchContext = Boolean(
+          resolvedJobId
+          && (minMatchScore !== undefined || (recommendation?.length ?? 0) > 0 || sortBy === "score")
+        );
+
+        if (needsMatchContext && resolvedJobId) {
+          const matches = matchStorage.getMatchesByResumeIds(
+            prepared.map((item) => item.resumeId),
+            resolvedJobId
+          );
+          matchMap = new Map(matches.map((match) => [match.resumeId, match]));
+        }
+
+        let working = enriched;
+        if (matchMap) {
+          if (minMatchScore !== undefined) {
+            working = working.filter((item) => {
+              const match = matchMap?.get(item.id);
+              return match && match.score >= minMatchScore;
+            });
+          }
+          if (recommendation?.length) {
+            const allowed = new Set(recommendation);
+            working = working.filter((item) => {
+              const match = matchMap?.get(item.id);
+              return match && allowed.has(match.recommendation);
+            });
+          }
+        }
+
+        if (sortBy) {
+          const order = sortOrder || (sortBy === "score" ? "desc" : "asc");
+          const direction = order === "desc" ? -1 : 1;
+
+          working = [...working].sort((a, b) => {
+            if (sortBy === "score") {
+              const scoreA = matchMap?.get(a.id)?.score ?? -1;
+              const scoreB = matchMap?.get(b.id)?.score ?? -1;
+              return (scoreA - scoreB) * direction;
+            }
+            if (sortBy === "experience") {
+              const expA = parseExperienceYears(a.resume.experience) ?? -1;
+              const expB = parseExperienceYears(b.resume.experience) ?? -1;
+              return (expA - expB) * direction;
+            }
+            if (sortBy === "extractedAt") {
+              const timeA = Date.parse(a.resume.extractedAt || "") || 0;
+              const timeB = Date.parse(b.resume.extractedAt || "") || 0;
+              return (timeA - timeB) * direction;
+            }
+            const nameA = a.resume.name?.toLowerCase() ?? "";
+            const nameB = b.resume.name?.toLowerCase() ?? "";
+            return nameA.localeCompare(nameB) * direction;
+          });
+        }
+
+        const start = offset ?? 0;
+        const end = typeof limit === "number" ? start + limit : undefined;
+        const paged = end ? working.slice(start, end) : working.slice(start);
+        const limited = paged.map((item) => item.resume);
+
+        return c.json({
+          success: true as const,
+          summary: {
+            total: working.length,
+            returned: limited.length,
+            query: keyword,
+            source,
+            ...buildKeywordExpansionSummary(liveExpansion ?? keywordExpansion),
+          },
+          data: limited,
+        }, 200);
+      })();
+    }
+
     const { items, sample: sampleInfo, metadata, indexes } = resumeService.loadSample(sampleName);
     const session = sessionId ? sessionManager.getSession(sessionId) : null;
     const resolvedJobId = jobDescriptionId?.trim() || session?.jobDescriptionId;
@@ -731,11 +1331,11 @@ app.openapi(getResumesRoute, (c) => {
     if (resolvedJobId) {
       try {
         const context = ruleScoringService.buildContext(resolvedJobId);
-        const indexList = items.map((item, index) => {
-          const resumeId = resolveResumeId(item, index);
-          return indexes.get(resumeId) ?? createFallbackIndex(item, resumeId);
+        const preparedForScores = prepareSampleCandidates({
+          items,
+          indexMap: indexes,
         });
-        const scored = ruleScoringService.scoreBatch(indexList, context);
+        const scored = scorePreparedCandidates(preparedForScores, context);
         ruleScoreMap = new Map(scored.map((entry) => [entry.resumeId, entry.result.score]));
       } catch (error) {
         console.error(`[Resumes] Failed to compute rule score map for ${resolvedJobId}:`, error);
@@ -841,8 +1441,11 @@ app.openapi(getResumesRoute, (c) => {
         total: working.length,
         returned: limited.length,
         query: keyword,
+        source,
         expandedTo: keywordExpansion?.flatTerms,
         mode: keywordExpansion?.mode,
+        keywordGroups: keywordExpansion?.groups,
+        sourceMapping: keywordExpansion?.sourceMapping,
       },
       data: limited,
     }, 200);
@@ -901,6 +1504,8 @@ app.openapi(matchResumesRoute, async (c) => {
     keywords,
     location,
     sample,
+    source,
+    persist,
     resumeIds,
     limit,
     topN,
@@ -912,6 +1517,15 @@ app.openapi(matchResumesRoute, async (c) => {
   if (!normalizedJobDescriptionId && normalizedKeywords.length === 0) {
     return c.json({ success: false, error: "jobDescriptionId or keywords is required" }, 400);
   }
+
+  const mode = toMatchMode(modeInput);
+  if (!persist && mode !== "rules_only") {
+    return c.json({ success: false, error: "persist=false only supports rules_only mode" }, 400);
+  }
+  if (source === "convex" && persist !== false) {
+    return c.json({ success: false, error: "source=convex only supports persist=false" }, 400);
+  }
+
   const matchJobDescriptionId = normalizedJobDescriptionId
     ? normalizedJobDescriptionId
     : toKeywordJobDescriptionId(normalizedKeywords, location);
@@ -920,37 +1534,50 @@ app.openapi(matchResumesRoute, async (c) => {
     location,
     jobDescriptionId: normalizedJobDescriptionId,
   });
+  const keywordExpansion = normalizedKeywords.length > 0
+    ? resumeService.expandSearchQuery(normalizedKeywords.join(" "))
+    : undefined;
 
-  const mode = toMatchMode(modeInput);
-
-  let session = sessionId ? sessionManager.getSession(sessionId) : null;
-  if (sessionId && !session) {
+  let session = persist && sessionId ? sessionManager.getSession(sessionId) : null;
+  if (persist && sessionId && !session) {
     return c.json({ success: false, error: "Session not found" }, 404);
   }
-
-  if (!session) {
+  if (persist && !session) {
     session = sessionManager.createSession({
       jobDescriptionId: normalizedJobDescriptionId,
       sampleName: sample,
     });
-  } else {
+  } else if (persist && session) {
     session = sessionManager.updateSession(session.id, {
       jobDescriptionId: normalizedJobDescriptionId ?? null,
       sampleName: sample ?? session.sampleName,
     }) ?? session;
   }
 
-  const sampleName = sample ?? session.sampleName;
-
-  let items: ResumeItem[] = [];
-  let indexMap = new Map<string, ResumeIndex>();
+  let sampleName = sample ?? session?.sampleName;
+  let prepared: PreparedResumeCandidate[] = [];
   let jdMeta: { title?: string } = {};
   let content = "";
 
   try {
-    const sampleData = resumeService.loadSample(sampleName);
-    items = sampleData.items;
-    indexMap = sampleData.indexes;
+    if (source === "convex") {
+      prepared = (await prepareConvexCandidates({
+        resumeIds,
+        keywords: normalizedKeywords,
+        location,
+        limit,
+        jobDescriptionId: normalizedJobDescriptionId,
+      })).prepared;
+    } else {
+      const sampleData = resumeService.loadSample(sampleName);
+      sampleName = sampleData.sample.name;
+      prepared = prepareSampleCandidates({
+        items: sampleData.items,
+        indexMap: sampleData.indexes,
+        resumeIds,
+        limit,
+      });
+    }
 
     if (normalizedJobDescriptionId) {
       const jdData = jobService.loadFile(normalizedJobDescriptionId);
@@ -966,14 +1593,6 @@ app.openapi(matchResumesRoute, async (c) => {
     throw error;
   }
 
-  const selected = resumeIds?.length
-    ? items
-      .map((resume, index) => ({ resume, resumeId: resolveResumeId(resume, index) }))
-      .filter((item) => resumeIds.includes(item.resumeId))
-    : items.map((resume, index) => ({ resume, resumeId: resolveResumeId(resume, index) }));
-
-  const limited = typeof limit === "number" ? selected.slice(0, limit) : selected;
-
   const requirements = normalizedJobDescriptionId
     ? (extractSection(content, ["Requirements", "任职要求", "要求"]) || stripFrontMatter(content))
     : buildKeywordRequirements(normalizedKeywords);
@@ -981,12 +1600,7 @@ app.openapi(matchResumesRoute, async (c) => {
     ? extractSection(content, ["Responsibilities", "岗位职责", "职责"])
     : buildKeywordResponsibilities(normalizedKeywords, location);
 
-  const prepared = limited.map((item) => ({
-    ...item,
-    indexData: indexMap.get(item.resumeId) ?? createFallbackIndex(item.resume, item.resumeId),
-  }));
-
-  const shouldTrackRun = mode !== "hybrid";
+  const shouldTrackRun = persist && mode !== "hybrid";
   const runId = randomUUID();
   if (shouldTrackRun) {
     matchStorage.createMatchRun({
@@ -1006,8 +1620,8 @@ app.openapi(matchResumesRoute, async (c) => {
       const context = normalizedJobDescriptionId
         ? ruleScoringService.buildContext(normalizedJobDescriptionId)
         : ruleScoringService.buildContextFromKeywords(normalizedKeywords, location);
-      const scored = ruleScoringService.scoreBatch(prepared.map((item) => item.indexData), context);
-
+      const scored = scorePreparedCandidates(prepared, context)
+        .sort((a, b) => b.result.score - a.result.score);
       const entries = scored.map((entry) => ({
         sessionId: session?.id,
         resumeId: entry.resumeId,
@@ -1018,19 +1632,16 @@ app.openapi(matchResumesRoute, async (c) => {
         processingTimeMs: Date.now() - startTime,
       }));
 
-      if (entries.length > 0) {
+      if (persist && entries.length > 0) {
         matchStorage.saveMatches(entries);
       }
 
-      const storedMatches = matchStorage.getMatchesByResumeIds(
-        prepared.map((item) => item.resumeId),
-        matchJobDescriptionId
-      );
-
-      const results = storedMatches
-        .map((match) => mapStoredMatch(match))
-        .sort((a, b) => b.score - a.score);
-
+      const results = scored.map((entry) => buildRuleMatchResponseEntry({
+        candidate: entry.candidate,
+        result: entry.result,
+        jobDescriptionId: matchJobDescriptionId,
+        sessionId: session?.id,
+      }));
       const pendingAiCount = mode === "hybrid"
         ? Math.min(toTopN(topN), results.length)
         : 0;
@@ -1051,7 +1662,7 @@ app.openapi(matchResumesRoute, async (c) => {
         });
       }
 
-      if (searchEventQuery) {
+      if (persist && searchEventQuery) {
         searchEventLogger.logSearchQuery({
           query: searchEventQuery,
           resultCount: results.length,
@@ -1065,6 +1676,12 @@ app.openapi(matchResumesRoute, async (c) => {
           mode,
           streamPath: mode === "hybrid" ? "/api/resumes/match-stream" : undefined,
           pendingAiCount: mode === "hybrid" ? pendingAiCount : undefined,
+          query: buildMatchQueryMetadata({
+            source,
+            persisted: persist,
+            keywordExpansion,
+            context,
+          }),
           results,
           stats,
         },
@@ -1072,12 +1689,14 @@ app.openapi(matchResumesRoute, async (c) => {
       );
     }
 
+    const context = normalizedJobDescriptionId
+      ? ruleScoringService.buildContext(normalizedJobDescriptionId)
+      : ruleScoringService.buildContextFromKeywords(normalizedKeywords, location);
     const cachedMatches = matchStorage.getMatchesByResumeIds(
       prepared.map((item) => item.resumeId),
       matchJobDescriptionId
     );
     const cachedMap = new Map(cachedMatches.map((match) => [match.resumeId, match]));
-
     const toProcess = prepared.filter((item) => {
       const cached = cachedMap.get(item.resumeId);
       if (!cached) return true;
@@ -1116,7 +1735,6 @@ app.openapi(matchResumesRoute, async (c) => {
       prepared.map((item) => item.resumeId),
       matchJobDescriptionId
     );
-
     const finalResults = finalMatches
       .map((match) => mapStoredMatch(match))
       .sort((a, b) => b.score - a.score);
@@ -1145,6 +1763,12 @@ app.openapi(matchResumesRoute, async (c) => {
       {
         success: true as const,
         mode: "ai_only",
+        query: buildMatchQueryMetadata({
+          source,
+          persisted: persist,
+          keywordExpansion,
+          context,
+        }),
         results: finalResults,
         stats,
       },
@@ -1177,6 +1801,8 @@ app.post("/api/resumes/match-stream", async (c) => {
     keywords,
     location,
     sample,
+    source,
+    persist,
     resumeIds,
     limit,
     topN,
@@ -1191,6 +1817,12 @@ app.post("/api/resumes/match-stream", async (c) => {
   const matchJobDescriptionId = normalizedJobDescriptionId
     ? normalizedJobDescriptionId
     : toKeywordJobDescriptionId(normalizedKeywords, location);
+  if (source === "convex") {
+    return c.json({ success: false, error: "match-stream does not support source=convex" }, 400);
+  }
+  if (persist === false) {
+    return c.json({ success: false, error: "match-stream does not support persist=false" }, 400);
+  }
 
   const mode = toMatchMode(modeInput);
   const requestedTopN = toTopN(topN);
@@ -1209,15 +1841,18 @@ app.post("/api/resumes/match-stream", async (c) => {
 
   const sampleName = sample ?? session.sampleName;
 
-  let items: ResumeItem[] = [];
-  let indexMap = new Map<string, ResumeIndex>();
+  let prepared: PreparedResumeCandidate[] = [];
   let jdMeta: { title?: string } = {};
   let content = "";
 
   try {
     const sampleData = resumeService.loadSample(sampleName);
-    items = sampleData.items;
-    indexMap = sampleData.indexes;
+    prepared = prepareSampleCandidates({
+      items: sampleData.items,
+      indexMap: sampleData.indexes,
+      resumeIds,
+      limit,
+    });
     if (normalizedJobDescriptionId) {
       const jdData = jobService.loadFile(normalizedJobDescriptionId);
       jdMeta = { title: jdData.title };
@@ -1232,25 +1867,12 @@ app.post("/api/resumes/match-stream", async (c) => {
     throw error;
   }
 
-  const selected = resumeIds?.length
-    ? items
-      .map((resume, index) => ({ resume, resumeId: resolveResumeId(resume, index) }))
-      .filter((item) => resumeIds.includes(item.resumeId))
-    : items.map((resume, index) => ({ resume, resumeId: resolveResumeId(resume, index) }));
-
-  const limited = typeof limit === "number" ? selected.slice(0, limit) : selected;
-
   const requirements = normalizedJobDescriptionId
     ? (extractSection(content, ["Requirements", "任职要求", "要求"]) || stripFrontMatter(content))
     : buildKeywordRequirements(normalizedKeywords);
   const responsibilities = normalizedJobDescriptionId
     ? extractSection(content, ["Responsibilities", "岗位职责", "职责"])
     : buildKeywordResponsibilities(normalizedKeywords, location);
-
-  const prepared = limited.map((item) => ({
-    ...item,
-    indexData: indexMap.get(item.resumeId) ?? createFallbackIndex(item.resume, item.resumeId),
-  }));
   const preparedMap = new Map(prepared.map((item) => [item.resumeId, item]));
 
   const runId = randomUUID();
@@ -1311,11 +1933,16 @@ app.post("/api/resumes/match-stream", async (c) => {
           const context = normalizedJobDescriptionId
             ? ruleScoringService.buildContext(normalizedJobDescriptionId)
             : ruleScoringService.buildContextFromKeywords(normalizedKeywords, location);
-          const scored = ruleScoringService.scoreBatch(prepared.map((item) => item.indexData), context);
+          const scored = scorePreparedCandidates(prepared, context);
           const orderedRuleResults = scored
             .map((entry) => ({
               resumeId: entry.resumeId,
-              result: ruleScoringService.toMatchingResult(entry.result),
+              result: buildRuleMatchResponseEntry({
+                candidate: entry.candidate,
+                result: entry.result,
+                jobDescriptionId: matchJobDescriptionId,
+                sessionId: session?.id,
+              }),
             }))
             .sort((a, b) => b.result.score - a.result.score);
           const existingRuleScopeMatches = matchStorage.getMatchesByResumeIds(
@@ -1336,7 +1963,15 @@ app.post("/api/resumes/match-stream", async (c) => {
               resumeId,
               jobDescriptionId: matchJobDescriptionId,
               sampleName: sampleName ?? undefined,
-              result,
+              result: {
+                score: result.score,
+                recommendation: result.recommendation,
+                highlights: result.highlights,
+                concerns: result.concerns,
+                summary: result.summary,
+                breakdown: result.breakdown,
+                scoreSource: result.scoreSource,
+              },
               aiModel: "rule-scoring",
               processingTimeMs: Date.now() - startTime,
             }));
@@ -1353,11 +1988,9 @@ app.post("/api/resumes/match-stream", async (c) => {
           safeSend("rules", {
             mode,
             results: orderedRuleResults.map(({ resumeId, result }) => ({
-              resumeId,
-              jobDescriptionId: matchJobDescriptionId,
               ...result,
+              resumeId,
               matchedAt: ruleMatchedAt,
-              sessionId: session?.id,
             })),
             progress: { done: orderedRuleResults.length, total: prepared.length },
           });
@@ -1799,12 +2432,18 @@ app.openapi(importResumesRoute, async (c) => {
   }
 });
 
-app.openapi(rescoreResumeMatchesRoute, (c) => {
-  const { sessionId, sample, jobDescriptionId, keywords, location, resumeIds, limit } = c.req.valid("json");
+app.openapi(rescoreResumeMatchesRoute, async (c) => {
+  const { sessionId, sample, source, persist, jobDescriptionId, keywords, location, resumeIds, limit } = c.req.valid("json");
   const normalizedJobDescriptionId = jobDescriptionId?.trim();
   const normalizedKeywords = normalizeKeywords(keywords);
   if (!normalizedJobDescriptionId && normalizedKeywords.length === 0) {
     return c.json({ success: false, error: "jobDescriptionId or keywords is required" }, 400);
+  }
+  if (!persist) {
+    return c.json({ success: false, error: "persist=false is not supported for rescore" }, 400);
+  }
+  if (source === "convex") {
+    return c.json({ success: false, error: "source=convex is not supported for rescore" }, 400);
   }
   const matchJobDescriptionId = normalizedJobDescriptionId
     ? normalizedJobDescriptionId
@@ -1822,13 +2461,16 @@ app.openapi(rescoreResumeMatchesRoute, (c) => {
 
   const sampleName = sample ?? session?.sampleName;
 
-  let items: ResumeItem[] = [];
-  let indexMap = new Map<string, ResumeIndex>();
+  let prepared: PreparedResumeCandidate[] = [];
 
   try {
     const sampleData = resumeService.loadSample(sampleName);
-    items = sampleData.items;
-    indexMap = sampleData.indexes;
+    prepared = prepareSampleCandidates({
+      items: sampleData.items,
+      indexMap: sampleData.indexes,
+      resumeIds,
+      limit,
+    });
     if (normalizedJobDescriptionId) {
       jobService.loadFile(normalizedJobDescriptionId);
     }
@@ -1839,21 +2481,11 @@ app.openapi(rescoreResumeMatchesRoute, (c) => {
     throw error;
   }
 
-  const selected = resumeIds?.length
-    ? items
-      .map((resume, index) => ({ resume, resumeId: resolveResumeId(resume, index) }))
-      .filter((item) => resumeIds.includes(item.resumeId))
-    : items.map((resume, index) => ({ resume, resumeId: resolveResumeId(resume, index) }));
-
-  const limited = typeof limit === "number" ? selected.slice(0, limit) : selected;
-
   const context = normalizedJobDescriptionId
     ? ruleScoringService.buildContext(normalizedJobDescriptionId)
     : ruleScoringService.buildContextFromKeywords(normalizedKeywords, location);
-  const scored = ruleScoringService.scoreBatch(
-    limited.map((item) => indexMap.get(item.resumeId) ?? createFallbackIndex(item.resume, item.resumeId)),
-    context
-  );
+  const scored = scorePreparedCandidates(prepared, context)
+    .sort((a, b) => b.result.score - a.result.score);
 
   const startTime = Date.now();
   const entries = scored.map((entry) => ({
@@ -1870,11 +2502,12 @@ app.openapi(rescoreResumeMatchesRoute, (c) => {
     matchStorage.saveMatches(entries);
   }
 
-  const finalMatches = matchStorage
-    .getMatchesByResumeIds(limited.map((item) => item.resumeId), matchJobDescriptionId)
-    .sort((a, b) => b.score - a.score);
-
-  const results = finalMatches.map((match) => mapStoredMatch(match));
+  const results = scored.map((entry) => buildRuleMatchResponseEntry({
+    candidate: entry.candidate,
+    result: entry.result,
+    jobDescriptionId: matchJobDescriptionId,
+    sessionId: session?.id,
+  }));
   if (searchEventQuery) {
     searchEventLogger.logSearchQuery({
       query: searchEventQuery,
@@ -1887,6 +2520,14 @@ app.openapi(rescoreResumeMatchesRoute, (c) => {
     {
       success: true as const,
       mode: "rules_only",
+      query: buildMatchQueryMetadata({
+        source,
+        persisted: persist,
+        keywordExpansion: normalizedKeywords.length > 0
+          ? resumeService.expandSearchQuery(normalizedKeywords.join(" "))
+          : undefined,
+        context,
+      }),
       results,
       stats: computeStats(results, Date.now() - startTime, 0),
     },

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -265,6 +265,13 @@ export const ResumesQuerySchema = z.object({
       param: { name: "q", in: "query" },
       example: "sales",
     }),
+  source: z
+    .enum(["sample", "convex"])
+    .default("sample")
+    .openapi({
+      param: { name: "source", in: "query" },
+      example: "sample",
+    }),
   limit: z
     .coerce
     .number()
@@ -375,6 +382,11 @@ export const ResumesQuerySchema = z.object({
   }),
 });
 
+const KeywordGroupSchema = z.object({
+  original: z.string(),
+  variants: z.array(z.string()),
+});
+
 export const ResumesResponseSchema = z
   .object({
     success: z.literal(true),
@@ -385,18 +397,16 @@ export const ResumesResponseSchema = z
         total: z.number().int(),
         returned: z.number().int(),
         query: z.string().optional(),
+        source: z.enum(["sample", "convex"]).optional(),
         expandedTo: z.array(z.string()).optional(),
         mode: z.enum(["AND", "OR"]).optional(),
+        keywordGroups: z.array(KeywordGroupSchema).optional(),
+        sourceMapping: z.record(z.string()).optional(),
       })
       .optional(),
     data: z.array(ResumeItemSchema),
   })
   .openapi("ResumesResponse");
-
-const KeywordGroupSchema = z.object({
-  original: z.string(),
-  variants: z.array(z.string()),
-});
 
 export const ResumeKeywordExpansionQuerySchema = z.object({
   q: z
@@ -461,6 +471,10 @@ export const RecommendationSchema = z.enum([
 
 export const ScoreSourceSchema = z.enum(["rule", "ai"]);
 
+export const ResumeResultSourceSchema = z
+  .enum(["sample", "convex"])
+  .openapi("ResumeResultSource");
+
 export const MatchBreakdownSchema = z
   .object({
     skillMatch: z.number().int().openapi({ example: 20 }),
@@ -487,6 +501,46 @@ export const ResumeMatchSchema = z
     matchedAt: z.string().openapi({ example: "2026-02-05T08:00:00.000Z" }),
     sessionId: z.string().optional().openapi({ example: "session-123" }),
     userId: z.string().optional().openapi({ example: "user-abc" }),
+    debug: z
+      .object({
+        primaryRuleScore: z.number().optional().openapi({ example: 85 }),
+        provenance: z
+          .array(
+            z.object({
+              term: z.string().openapi({ example: "销售" }),
+              source: z.enum(["searchText", "industryTags", "companyHits", "synonymHits"]).openapi({ example: "searchText" }),
+              expandedFrom: z.string().optional().openapi({ example: "sales" }),
+            })
+          )
+          .optional(),
+        roleSignals: z
+          .array(
+            z.object({
+              type: z.string().openapi({ example: "sales" }),
+              matchedSignals: z.array(z.string()).openapi({ example: ["销售经理", "渠道"] }),
+              signalCount: z.number().openapi({ example: 2 }),
+              occurrences: z.number().openapi({ example: 2 }),
+              years: z.number().openapi({ example: 5 }),
+              industryVerifiedYears: z.number().openapi({ example: 5 }),
+              roleRelevantYears: z.number().optional().openapi({ example: 5 }),
+              industryVerifiedRelevantYears: z.number().optional().openapi({ example: 5 }),
+              verifyIn: z.enum(["workHistory", "searchText"]).openapi({ example: "workHistory" }),
+            })
+          )
+          .optional(),
+        companyHits: z.array(z.string()).optional().openapi({ example: ["fanuc"] }),
+        brandHits: z
+          .array(
+            z.object({
+              brand: z.string().openapi({ example: "fanuc" }),
+              role: z.enum(["employer", "equipment", "both"]).openapi({ example: "both" }),
+              source: z.enum(["workHistory", "selfIntro", "jobIntention"]).openapi({ example: "workHistory" }),
+              context: z.enum(["employer", "equipment", "sales", "technical", "general"]).openapi({ example: "employer" }),
+            })
+          )
+          .optional(),
+      })
+      .optional(),
   })
   .openapi("ResumeMatch");
 
@@ -657,6 +711,8 @@ export const MatchRequestSchema = z
   .object({
     sessionId: z.string().optional().openapi({ example: "session-123" }),
     sample: z.string().optional().openapi({ example: "sample-initial" }),
+    source: ResumeResultSourceSchema.default("sample").openapi({ example: "sample" }),
+    persist: z.boolean().default(true).openapi({ example: true }),
     jobDescriptionId: z.string().optional().openapi({ example: "lathe-sales" }),
     keywords: z.array(z.string()).optional().openapi({ example: ["cnc", "车床"] }),
     location: z.string().optional().openapi({ example: "广东" }),
@@ -683,6 +739,25 @@ export const MatchResponseSchema = z
     mode: z.enum(["rules_only", "hybrid", "ai_only"]).optional(),
     streamPath: z.string().optional(),
     pendingAiCount: z.number().int().optional(),
+    query: z
+      .object({
+        source: ResumeResultSourceSchema.optional(),
+        persisted: z.boolean().optional(),
+        keywordGroups: z.array(KeywordGroupSchema).optional(),
+        expandedTo: z.array(z.string()).optional(),
+        sourceMapping: z.record(z.string()).optional(),
+        inferredRequiredRoles: z
+          .array(
+            z.object({
+              type: z.string().openapi({ example: "sales" }),
+              signals: z.array(z.string()).openapi({ example: ["销售", "业务"] }),
+              verifyIn: z.enum(["workHistory", "searchText"]).openapi({ example: "workHistory" }),
+              minYears: z.number().optional().openapi({ example: 2 }),
+            })
+          )
+          .optional(),
+      })
+      .optional(),
     results: z.array(ResumeMatchSchema),
     stats: MatchStatsSchema,
   })

--- a/apps/api/src/services/rule-scoring.test.ts
+++ b/apps/api/src/services/rule-scoring.test.ts
@@ -102,7 +102,7 @@ describe("RuleScoringService", () => {
     }
   });
 
-  it("does not apply strict role gating for keyword-only searches", () => {
+  it("infers sales role gating for unambiguous keyword-only searches", () => {
     const root = createFixtureRoot();
 
     try {
@@ -124,14 +124,20 @@ describe("RuleScoringService", () => {
 
       const result = service.scoreResume(operatorCandidate, context);
 
-      expect(context.requiredRoles).toEqual([]);
-      expect(result.breakdown.roleMatch).toBe(10);
+      expect(context.requiredRoles).toEqual([
+        expect.objectContaining({
+          type: "sales",
+          verifyIn: "workHistory",
+        }),
+      ]);
+      expect(result.breakdown.roleMatch).toBe(2);
+      expect(result.breakdown.experienceMatch).toBe(0);
     } finally {
       cleanupFixtureRoot(root);
     }
   });
 
-  it("keeps CNC 数控车床 销售 keyword searches free of JD role gating", () => {
+  it("infers keyword-only sales gating without forcing JD minYears", () => {
     const root = createFixtureRoot();
 
     try {
@@ -153,19 +159,50 @@ describe("RuleScoringService", () => {
       };
 
       const keywordResult = service.scoreResume(cncSalesCandidate, keywordContext);
-      const jdResult = service.scoreResume(cncSalesCandidate, jdContext);
+      const keywordWithSignalsResult = service.scoreResume(
+        cncSalesCandidate,
+        keywordContext,
+        [],
+        [createSalesRoleSignal(0.5)]
+      );
+      const jdResult = service.scoreResume(
+        cncSalesCandidate,
+        jdContext,
+        [],
+        [createSalesRoleSignal(0.5)]
+      );
 
       expect(keywordContext.keywords).toEqual(["cnc", "数控车床", "销售"]);
       expect(keywordContext.industryTags).toEqual(["machinery"]);
-      expect(keywordContext.requiredRoles).toEqual([]);
+      expect(keywordContext.requiredRoles).toEqual([
+        expect.objectContaining({
+          type: "sales",
+          verifyIn: "workHistory",
+        }),
+      ]);
       expect(keywordResult.breakdown.skillMatch).toBeGreaterThan(0);
-      expect(keywordResult.breakdown.roleMatch).toBe(10);
-      expect(keywordResult.recommendation).toBe("strong_match");
-
+      expect(keywordResult.breakdown.roleMatch).toBe(2);
+      expect(keywordResult.breakdown.experienceMatch).toBe(0);
+      expect(keywordWithSignalsResult.breakdown.roleMatch).toBe(8);
+      expect(keywordWithSignalsResult.breakdown.experienceMatch).toBe(25);
       expect(jdContext.requiredRoles).toHaveLength(1);
-      expect(jdResult.breakdown.roleMatch).toBe(2);
-      expect(jdResult.breakdown.experienceMatch).toBe(0);
-      expect(keywordResult.score).toBeGreaterThan(jdResult.score);
+      expect(jdContext.requiredRoles[0]?.minYears).toBe(1);
+      expect(jdResult.breakdown.roleMatch).toBe(5);
+      expect(jdResult.breakdown.experienceMatch).toBe(13);
+      expect(keywordWithSignalsResult.score).toBeGreaterThan(jdResult.score);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("keeps ambiguous multi-role keyword searches recall-first", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new RuleScoringService(root);
+      const context = service.buildContextFromKeywords(["销售", "工程师"], "东莞");
+
+      expect(context.requiredRoles).toEqual([]);
     } finally {
       cleanupFixtureRoot(root);
     }
@@ -422,7 +459,7 @@ describe("RuleScoringService", () => {
         { brand: "fanuc", role: "both", source: "workHistory", context: "employer" },
       ]);
 
-      expect(equipmentResult.breakdown.brandRelevance).toBe(7);
+      expect(equipmentResult.breakdown.brandRelevance).toBe(0);
       expect(employerResult.breakdown.brandRelevance).toBe(10);
       expect(employerResult.score).toBeGreaterThan(equipmentResult.score);
     } finally {

--- a/apps/api/src/services/rule-scoring.ts
+++ b/apps/api/src/services/rule-scoring.ts
@@ -250,6 +250,64 @@ const INDUSTRY_MAP: Array<{ tag: string; keywords: string[] }> = Object.entries(
   ([tag, keywords]) => ({ tag, keywords })
 );
 
+const KEYWORD_ROLE_SIGNAL_LIBRARY: Record<string, string[]> = {
+  sales: [
+    "销售",
+    "业务",
+    "商务",
+    "销售员",
+    "销售经理",
+    "销售工程师",
+    "大客户",
+    "渠道",
+    "客户开发",
+    "sales",
+    "account",
+    "key account",
+    "bd",
+    "business development",
+  ],
+  engineer: [
+    "工程师",
+    "研发",
+    "设计",
+    "开发",
+    "编程",
+    "engineer",
+    "developer",
+    "design",
+  ],
+  operator: [
+    "操作员",
+    "操作",
+    "操机",
+    "开机",
+    "机台",
+    "operator",
+  ],
+  technician: [
+    "技术员",
+    "维修",
+    "维护",
+    "安装",
+    "保养",
+    "售后",
+    "technician",
+    "service",
+    "after-sales",
+  ],
+  manager: [
+    "经理",
+    "主管",
+    "总监",
+    "负责人",
+    "manager",
+    "lead",
+    "leader",
+    "director",
+  ],
+};
+
 const LOCATION_PROXIMITY_GROUPS: Record<string, string[]> = {
   pearlRiverDelta: ["东莞", "深圳", "广州", "佛山", "惠州", "中山", "珠海", "江门"],
   yangtzeRiverDelta: ["上海", "苏州", "杭州", "南京", "无锡", "宁波", "常州", "嘉兴"],
@@ -530,8 +588,58 @@ export class RuleScoringService {
       industryKeywords: cleanKeywords,
       industryTags,
       brandKeywords,
-      requiredRoles: [],
+      requiredRoles: this.inferRequiredRolesFromKeywords(cleanKeywords),
     };
+  }
+
+  inferRequiredRolesFromKeywords(keywords: string[]): RequiredRoleRequirement[] {
+    const cleanKeywords = ensureKeywords(keywords);
+    if (cleanKeywords.length === 0) {
+      return [];
+    }
+
+    const normalizedTokens = new Set<string>();
+    for (const keyword of cleanKeywords) {
+      const variants = this.skillsService.expandQueryWithSynonyms([keyword]);
+      const candidates = variants.length > 0 ? variants : [keyword];
+      for (const candidate of candidates) {
+        const normalized = compactText(candidate);
+        if (!normalized) {
+          continue;
+        }
+        normalizedTokens.add(normalized);
+        normalizedTokens.add(normalized.replace(/\s+/g, ""));
+      }
+    }
+    const normalizedTokenValues = Array.from(normalizedTokens);
+
+    const matchedFamilies = Object.entries(KEYWORD_ROLE_SIGNAL_LIBRARY)
+      .filter(([, signals]) => {
+        return signals.some((signal) => {
+          const normalizedSignal = compactText(signal);
+          if (!normalizedSignal) {
+            return false;
+          }
+          const compactSignal = normalizedSignal.replace(/\s+/g, "");
+          return normalizedTokenValues.some((token) =>
+            token.includes(normalizedSignal)
+            || normalizedSignal.includes(token)
+            || token.includes(compactSignal)
+            || compactSignal.includes(token)
+          );
+        });
+      });
+
+    if (matchedFamilies.length !== 1) {
+      return [];
+    }
+
+    const [type, signals] = matchedFamilies[0];
+    return [{
+      type,
+      signals: ensureKeywords(signals),
+      verifyIn: "workHistory",
+    }];
   }
 
   private inferIndustryTags(tokens: string[], industryMap: Array<{ tag: string; keywords: string[] }>): string[] {
@@ -763,9 +871,11 @@ export class RuleScoringService {
     let experienceMatch = 0;
     if (hasRequiredRoles) {
       const relevantRoleYears = this.computeRelevantRoleYears(context.requiredRoles, roleSignals);
-      const effectiveMinExperience = context.minExperience ?? context.requiredRoles[0]?.minYears ?? 0;
+      const effectiveMinExperience = context.minExperience ?? context.requiredRoles[0]?.minYears;
 
-      if (relevantRoleYears >= effectiveMinExperience) {
+      if (effectiveMinExperience === undefined || effectiveMinExperience <= 0) {
+        experienceMatch = relevantRoleYears > 0 ? categoryWeights.experienceMatch : 0;
+      } else if (relevantRoleYears >= effectiveMinExperience) {
         experienceMatch = categoryWeights.experienceMatch;
       } else if (relevantRoleYears > 0) {
         const ratio = relevantRoleYears / Math.max(1, effectiveMinExperience);

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ConvexIngestData, ConvexResumeItem } from '@/hooks/useConvexResumes'
 import type { CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 import { RESUME_HOME_RESET_STATE } from '@/lib/resume-home-navigation'
+import { rawApiClient } from '@/lib/api-helpers'
 import { useResumeListState } from './useResumeListState'
 
 let submittedFormAction = ''
@@ -34,6 +35,7 @@ const mockState = vi.hoisted(() => ({
   saveSearchHistory: vi.fn(async () => 'history-1'),
   markSearchHistoryOpened: vi.fn(async () => {}),
   searchHistory: [] as Array<Record<string, unknown>>,
+  matchApiResponse: { success: true, results: [] as Array<{ resumeId: string; score: number }> },
   refresh: vi.fn(async () => {}),
   reloadSamples: vi.fn(async () => {}),
   blockCandidates: vi.fn(async () => true),
@@ -168,7 +170,7 @@ vi.mock('@/hooks/useCandidateStatus', () => ({
 
 vi.mock('@/lib/api-helpers', () => ({
   rawApiClient: {
-    POST: vi.fn(async () => ({ data: { success: true } })),
+    POST: vi.fn(async () => ({ data: mockState.matchApiResponse })),
     GET: vi.fn(async () => ({ data: { success: true } })),
   },
 }))
@@ -305,6 +307,7 @@ describe('useResumeListState role filter regression', () => {
     mockState.blocksByIdentity = {}
     mockState.statusByIdentity = {}
     mockState.searchHistory = []
+    mockState.matchApiResponse = { success: true, results: [] }
     document.body.innerHTML = ''
     mockState.urlParsedState = {
       location: undefined,
@@ -477,6 +480,45 @@ describe('useResumeListState role filter regression', () => {
       'Luo Non-CNC Sales',      // primaryRuleScore: 20
       'Engineer Junior',        // primaryRuleScore: 0 (undefined)
     ])
+  })
+
+  it('uses query-specific scores for keyword-only ranking instead of primaryRuleScore', async () => {
+    mockState.sessionKeywords = ['CNC', '销售']
+    mockState.sessionLocation = '东莞'
+    mockState.matchApiResponse = {
+      success: true,
+      results: [
+        { resumeId: 'resume-zhang-machinery-sales', score: 92 },
+        { resumeId: 'resume-li-automation-sales', score: 88 },
+        { resumeId: 'resume-ideal-cnc-sales', score: 84 },
+        { resumeId: 'resume-zhou-jingdiao', score: 40 },
+        { resumeId: 'resume-luo-non-cnc-sales', score: 12 },
+        { resumeId: 'resume-engineer-junior', score: 0 },
+      ],
+    }
+
+    const { result } = renderHook(() => useResumeListState())
+
+    await waitFor(() => {
+      expect(result.current.displayedResumes.map((entry) => entry.resume.name)).toEqual([
+        'Zhang Machinery Sales',
+        'Li Automation Sales',
+        'Ideal CNC Sales',
+        'Zhou Jingdiao Hit',
+        'Luo Non-CNC Sales',
+        'Engineer Junior',
+      ])
+    })
+
+    expect(rawApiClient.POST).toHaveBeenCalledWith('/api/resumes/match', {
+      body: expect.objectContaining({
+        source: 'convex',
+        persist: false,
+        mode: 'rules_only',
+        keywords: ['CNC', '销售'],
+        location: '东莞',
+      }),
+    })
   })
 
   it('minMatchScore >=60 keeps only industry-verified high-score resumes', () => {

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -400,6 +400,7 @@ export function useResumeListState(loadSearchHistory = false) {
   const [selectedCompanies, setSelectedCompanies] = useState<string[]>([])
   const [selectedExperienceLevel, setSelectedExperienceLevel] = useState<ExperienceLevelFilter | undefined>(undefined)
   const [appliedSearchHistoryId, setAppliedSearchHistoryId] = useState<string | undefined>(undefined)
+  const [queryRuleScoreMap, setQueryRuleScoreMap] = useState<Record<string, number>>({})
   const [mode] = useState<'ai'>('ai')
   const hydratedSessionIdRef = useRef<string | null>(null)
   const hasInitializedUrlHydrationRef = useRef(false)
@@ -498,6 +499,7 @@ export function useResumeListState(loadSearchHistory = false) {
     const rawBaseUrl = import.meta.env.VITE_API_URL || '/api'
     return rawBaseUrl.replace(/\/api\/?$/, '')
   }, [])
+  const keywordOnlyQueryScoring = sessionKeywords.length > 0 && !jobDescriptionId?.trim()
 
   const activeLoading = mode === 'ai' ? convexLoading : loading
   const hasActiveTask = useMemo(() => {
@@ -506,6 +508,59 @@ export function useResumeListState(loadSearchHistory = false) {
     }
     return analysisTasks.some((task) => taskMatchesCurrentSearch(task, jobDescriptionId, sessionKeywords))
   }, [analysisTasks, jobDescriptionId, sessionKeywords])
+
+  useEffect(() => {
+    let active = true
+
+    if (!keywordOnlyQueryScoring || convexResumes.length === 0) {
+      setQueryRuleScoreMap({})
+      return () => {
+        active = false
+      }
+    }
+
+    const resumeIds = convexResumes.map((resume) => String(resume.resumeId))
+    void rawApiClient
+      .POST<{
+        success: boolean
+        results?: Array<{
+          resumeId: string
+          score: number
+        }>
+      }>('/api/resumes/match', {
+        body: {
+          source: 'convex',
+          persist: false,
+          mode: 'rules_only',
+          keywords: sessionKeywords,
+          location: sessionLocation,
+          resumeIds,
+        },
+      })
+      .then(({ data, error }) => {
+        if (!active || error || !data?.success) {
+          if (active) {
+            setQueryRuleScoreMap({})
+          }
+          return
+        }
+
+        const nextMap = Object.fromEntries(
+          (data.results ?? []).map((item) => [item.resumeId, item.score])
+        )
+        setQueryRuleScoreMap(nextMap)
+      })
+      .catch((error: unknown) => {
+        console.error('Failed to load query-specific resume scores', error)
+        if (active) {
+          setQueryRuleScoreMap({})
+        }
+      })
+
+    return () => {
+      active = false
+    }
+  }, [convexResumes, jobDescriptionId, keywordOnlyQueryScoring, sessionKeywords, sessionLocation])
 
   useEffect(() => {
     if (!activeHasUrlParams) {
@@ -712,9 +767,15 @@ export function useResumeListState(loadSearchHistory = false) {
         return !isAutoFilteredAnalysis(analysis)
       })
       .map((resume: ConvexResumeItem) => {
+        const querySpecificRuleScore = keywordOnlyQueryScoring
+          ? queryRuleScoreMap[String(resume.resumeId)]
+          : undefined
         return {
           ...resume,
-          _ruleScore: resume.primaryRuleScore ?? 0,
+          _ruleScore:
+            typeof querySpecificRuleScore === 'number'
+              ? querySpecificRuleScore
+              : (resume.primaryRuleScore ?? 0),
         }
       })
 
@@ -826,6 +887,8 @@ export function useResumeListState(loadSearchHistory = false) {
     convexResumes,
     filters,
     jobDescriptionId,
+    keywordOnlyQueryScoring,
+    queryRuleScoreMap,
     selectedCompanies,
     selectedExperienceLevel,
     selectedTags,

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -356,6 +356,7 @@ export interface paths {
                 query?: {
                     sample?: string;
                     q?: string;
+                    source?: "sample" | "convex";
                     limit?: number;
                     offset?: string;
                     sessionId?: string;
@@ -692,6 +693,13 @@ export interface paths {
                     "application/json": {
                         sessionId?: string;
                         sample?: string;
+                        /**
+                         * @default sample
+                         * @enum {string}
+                         */
+                        source?: "sample" | "convex";
+                        /** @default true */
+                        persist?: boolean;
                         jobDescriptionId?: string;
                         keywords?: string[];
                         location?: string;
@@ -4038,12 +4046,23 @@ export interface components {
                 total: number;
                 returned: number;
                 query?: string;
+                /** @enum {string} */
+                source?: "sample" | "convex";
                 expandedTo?: string[];
                 /** @enum {string} */
                 mode?: "AND" | "OR";
+                keywordGroups?: {
+                    original: string;
+                    variants: string[];
+                }[];
+                sourceMapping?: {
+                    [key: string]: string;
+                };
             };
             data: components["schemas"]["ResumeItem"][];
         };
+        /** @enum {string} */
+        ResumeResultSource: "sample" | "convex";
         MatchBreakdown: {
             /** @example 20 */
             skillMatch: number;
@@ -4098,6 +4117,74 @@ export interface components {
             sessionId?: string;
             /** @example user-abc */
             userId?: string;
+            debug?: {
+                /** @example 85 */
+                primaryRuleScore?: number;
+                provenance?: {
+                    /** @example 销售 */
+                    term: string;
+                    /**
+                     * @example searchText
+                     * @enum {string}
+                     */
+                    source: "searchText" | "industryTags" | "companyHits" | "synonymHits";
+                    /** @example sales */
+                    expandedFrom?: string;
+                }[];
+                roleSignals?: {
+                    /** @example sales */
+                    type: string;
+                    /**
+                     * @example [
+                     *       "销售经理",
+                     *       "渠道"
+                     *     ]
+                     */
+                    matchedSignals: string[];
+                    /** @example 2 */
+                    signalCount: number;
+                    /** @example 2 */
+                    occurrences: number;
+                    /** @example 5 */
+                    years: number;
+                    /** @example 5 */
+                    industryVerifiedYears: number;
+                    /** @example 5 */
+                    roleRelevantYears?: number;
+                    /** @example 5 */
+                    industryVerifiedRelevantYears?: number;
+                    /**
+                     * @example workHistory
+                     * @enum {string}
+                     */
+                    verifyIn: "workHistory" | "searchText";
+                }[];
+                /**
+                 * @example [
+                 *       "fanuc"
+                 *     ]
+                 */
+                companyHits?: string[];
+                brandHits?: {
+                    /** @example fanuc */
+                    brand: string;
+                    /**
+                     * @example both
+                     * @enum {string}
+                     */
+                    role: "employer" | "equipment" | "both";
+                    /**
+                     * @example workHistory
+                     * @enum {string}
+                     */
+                    source: "workHistory" | "selfIntro" | "jobIntention";
+                    /**
+                     * @example employer
+                     * @enum {string}
+                     */
+                    context: "employer" | "equipment" | "sales" | "technical" | "general";
+                }[];
+            };
         };
         MatchStats: {
             processed: number;
@@ -4113,6 +4200,36 @@ export interface components {
             mode?: "rules_only" | "hybrid" | "ai_only";
             streamPath?: string;
             pendingAiCount?: number;
+            query?: {
+                source?: components["schemas"]["ResumeResultSource"];
+                persisted?: boolean;
+                keywordGroups?: {
+                    original: string;
+                    variants: string[];
+                }[];
+                expandedTo?: string[];
+                sourceMapping?: {
+                    [key: string]: string;
+                };
+                inferredRequiredRoles?: {
+                    /** @example sales */
+                    type: string;
+                    /**
+                     * @example [
+                     *       "销售",
+                     *       "业务"
+                     *     ]
+                     */
+                    signals: string[];
+                    /**
+                     * @example workHistory
+                     * @enum {string}
+                     */
+                    verifyIn: "workHistory" | "searchText";
+                    /** @example 2 */
+                    minYears?: number;
+                }[];
+            };
             results: components["schemas"]["ResumeMatch"][];
             stats: components["schemas"]["MatchStats"];
         };
@@ -4121,6 +4238,12 @@ export interface components {
             sessionId?: string;
             /** @example sample-initial */
             sample?: string;
+            source?: components["schemas"]["ResumeResultSource"] & unknown;
+            /**
+             * @default true
+             * @example true
+             */
+            persist: boolean;
             /** @example lathe-sales */
             jobDescriptionId?: string;
             /**

--- a/packages/cli/cmd/mcp.go
+++ b/packages/cli/cmd/mcp.go
@@ -211,7 +211,7 @@ func runMCPTool(ctx context.Context, name string, args map[string]interface{}) (
 	switch name {
 	case "resume_list":
 		limit := intArg(args, "limit", 50)
-		result, err := apiClient.ListResumes(ctx, limit, "")
+		result, err := apiClient.ListResumes(ctx, limit, "", "sample")
 		if err != nil {
 			return "", err
 		}
@@ -222,7 +222,7 @@ func runMCPTool(ctx context.Context, name string, args map[string]interface{}) (
 			return "", fmt.Errorf("query is required")
 		}
 		limit := intArg(args, "limit", 50)
-		result, err := apiClient.SearchResumes(ctx, query, limit)
+		result, err := apiClient.SearchResumes(ctx, query, limit, "sample")
 		if err != nil {
 			return "", err
 		}

--- a/packages/cli/cmd/resume.go
+++ b/packages/cli/cmd/resume.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,6 +25,7 @@ func newResumeCmd() *cobra.Command {
 	resumeCmd.AddCommand(
 		newResumeListCmd(),
 		newResumeSearchCmd(),
+		newResumeMatchCmd(),
 		newResumeExportCmd(),
 	)
 
@@ -37,7 +39,7 @@ func newResumeListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List resumes",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			response, err := newAPIClient().ListResumes(context.Background(), limit, "")
+			response, err := newAPIClient().ListResumes(context.Background(), limit, "", "sample")
 			if err != nil {
 				return err
 			}
@@ -65,21 +67,28 @@ func newResumeListCmd() *cobra.Command {
 
 func newResumeSearchCmd() *cobra.Command {
 	var limit int
+	var source string
 
 	cmd := &cobra.Command{
 		Use:   "search <query>",
-		Short: "Search resumes (AND mode: all keywords must match)",
+		Short: "Search resumes (sample or live Convex-backed retrieval)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			response, err := newAPIClient().SearchResumes(context.Background(), args[0], limit)
+			response, err := newAPIClient().SearchResumes(context.Background(), args[0], limit, source)
 			if err != nil {
 				return err
 			}
 
 			options := currentOptions()
 			if options.Output != "json" {
-				fmt.Fprintf(cmd.OutOrStdout(), "Query: %s | Total: %d | Returned: %d\n\n",
-					response.Summary.Query, response.Summary.Total, response.Summary.Returned)
+				fmt.Fprintf(
+					cmd.OutOrStdout(),
+					"Query: %s | Source: %s | Total: %d | Returned: %d\n\n",
+					response.Summary.Query,
+					coalesceString(response.Summary.Source, normalizeResumeSourceFlag(source)),
+					response.Summary.Total,
+					response.Summary.Returned,
+				)
 			}
 
 			headers := []string{"id", "name", "intention", "location", "experience", "education"}
@@ -100,6 +109,90 @@ func newResumeSearchCmd() *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum resumes to fetch")
+	cmd.Flags().StringVar(&source, "source", "sample", "Resume source: sample|convex")
+	return cmd
+}
+
+func newResumeMatchCmd() *cobra.Command {
+	var (
+		query            string
+		location         string
+		jobDescriptionID string
+		sample           string
+		source           string
+		persist          bool
+		limit            int
+		topN             int
+		mode             string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "match",
+		Short: "Run resume matching through the API",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			keywords := splitQueryKeywords(query)
+			if strings.TrimSpace(jobDescriptionID) == "" && len(keywords) == 0 {
+				return fmt.Errorf("query or job-description is required")
+			}
+
+			request := client.ResumeMatchRequest{
+				Sample:           strings.TrimSpace(sample),
+				Source:           source,
+				JobDescriptionID: strings.TrimSpace(jobDescriptionID),
+				Keywords:         keywords,
+				Location:         strings.TrimSpace(location),
+				Limit:            limit,
+				TopN:             topN,
+				Mode:             strings.TrimSpace(mode),
+			}
+			request.Persist = &persist
+
+			response, err := newAPIClient().MatchResumes(context.Background(), request)
+			if err != nil {
+				return err
+			}
+
+			options := currentOptions()
+			if options.Output == "json" {
+				return writeOutput(cmd, nil, nil, response)
+			}
+
+			displayMap, err := loadResumeDisplayMap(context.Background(), newAPIClient(), strings.Join(keywords, " "), limit, source)
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"resume_id", "score", "recommendation", "primary_rule", "sales_years", "company_hits", "name", "location"}
+			rows := make([][]string, 0, len(response.Results))
+			for _, result := range response.Results {
+				display := displayMap[result.ResumeID]
+				rows = append(rows, []string{
+					result.ResumeID,
+					strconv.Itoa(result.Score),
+					result.Recommendation,
+					formatOptionalFloat(debugPrimaryRuleScore(result.Debug)),
+					formatSalesYears(result.Debug),
+					strings.Join(debugCompanyHits(result.Debug), ", "),
+					display.Name,
+					display.Location,
+				})
+			}
+
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	cmd.Flags().StringVar(&query, "query", "", "Keyword query to match against resumes")
+	cmd.Flags().StringVar(&location, "location", "", "Optional location constraint")
+	cmd.Flags().StringVar(&jobDescriptionID, "job-description", "", "Optional job description ID")
+	cmd.Flags().StringVar(&sample, "sample", "", "Optional sample name for sample-backed matching")
+	cmd.Flags().StringVar(&source, "source", "convex", "Resume source: sample|convex")
+	cmd.Flags().BoolVar(&persist, "persist", false, "Persist matches and session state")
+	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum resumes to score")
+	cmd.Flags().IntVar(&topN, "top-n", 20, "Hybrid/AI candidate cutoff")
+	cmd.Flags().StringVar(&mode, "mode", "rules_only", "Match mode: rules_only|hybrid|ai_only")
+
 	return cmd
 }
 
@@ -118,7 +211,7 @@ func newResumeExportCmd() *cobra.Command {
 				return fmt.Errorf("invalid format %q (expected csv|xlsx)", format)
 			}
 
-			resumes, err := newAPIClient().ListResumes(context.Background(), limit, query)
+			resumes, err := newAPIClient().ListResumes(context.Background(), limit, query, "sample")
 			if err != nil {
 				return err
 			}
@@ -179,6 +272,99 @@ func newResumeExportCmd() *cobra.Command {
 	cmd.Flags().StringVar(&outPath, "out", "", "Output file path")
 
 	return cmd
+}
+
+type resumeDisplayRow struct {
+	Name     string
+	Location string
+}
+
+func loadResumeDisplayMap(ctx context.Context, apiClient *client.Client, query string, limit int, source string) (map[string]resumeDisplayRow, error) {
+	var (
+		response *client.ResumesResponse
+		err      error
+	)
+	if strings.TrimSpace(query) != "" {
+		response, err = apiClient.SearchResumes(ctx, query, limit, source)
+	} else {
+		response, err = apiClient.ListResumes(ctx, limit, "", source)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	displayMap := make(map[string]resumeDisplayRow, len(response.Data))
+	for index, item := range response.Data {
+		displayMap[resumeIdentifier(item, index)] = resumeDisplayRow{
+			Name:     item.Name,
+			Location: item.Location,
+		}
+	}
+	return displayMap, nil
+}
+
+func splitQueryKeywords(query string) []string {
+	return strings.Fields(strings.TrimSpace(query))
+}
+
+func coalesceString(values ...string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func normalizeResumeSourceFlag(source string) string {
+	if strings.EqualFold(strings.TrimSpace(source), "convex") {
+		return "convex"
+	}
+	return "sample"
+}
+
+func formatOptionalFloat(value *float64) string {
+	if value == nil {
+		return ""
+	}
+	if *value == float64(int(*value)) {
+		return strconv.Itoa(int(*value))
+	}
+	return strconv.FormatFloat(*value, 'f', 2, 64)
+}
+
+func formatSalesYears(debug *client.ResumeMatchDebug) string {
+	if debug == nil {
+		return ""
+	}
+	for _, signal := range debug.RoleSignals {
+		if strings.EqualFold(signal.Type, "sales") {
+			if signal.IndustryVerifiedRelevantYears != nil {
+				return formatOptionalFloat(signal.IndustryVerifiedRelevantYears)
+			}
+			if signal.RoleRelevantYears != nil {
+				return formatOptionalFloat(signal.RoleRelevantYears)
+			}
+			value := signal.IndustryVerifiedYears
+			return formatOptionalFloat(&value)
+		}
+	}
+	return ""
+}
+
+func debugPrimaryRuleScore(debug *client.ResumeMatchDebug) *float64 {
+	if debug == nil {
+		return nil
+	}
+	return debug.PrimaryRuleScore
+}
+
+func debugCompanyHits(debug *client.ResumeMatchDebug) []string {
+	if debug == nil {
+		return nil
+	}
+	return debug.CompanyHits
 }
 
 func resumeIdentifier(item client.ResumeItem, index int) string {

--- a/packages/cli/cmd/resume_test.go
+++ b/packages/cli/cmd/resume_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ptdevhk/trends/packages/cli/internal/client"
+	"github.com/spf13/viper"
+)
+
+func TestResumeSearchCommandSupportsConvexSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("source"); got != "convex" {
+			t.Fatalf("expected source=convex, got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(client.ResumesResponse{
+			Success: true,
+			Data: []client.ResumeItem{
+				{ResumeID: "resume-1", Name: "Alice", Location: "Dongguan", JobIntention: "Sales"},
+			},
+			Summary: client.ResumesSummary{
+				Total:    1,
+				Returned: 1,
+				Query:    "CNC 销售",
+				Source:   "convex",
+			},
+		})
+	}))
+	defer server.Close()
+
+	originalAPIURL := viper.GetString("api_url")
+	originalWorkerURL := viper.GetString("worker_url")
+	originalWorkspace := viper.GetString("workspace")
+	originalOutput := viper.GetString("output")
+	t.Cleanup(func() {
+		viper.Set("api_url", originalAPIURL)
+		viper.Set("worker_url", originalWorkerURL)
+		viper.Set("workspace", originalWorkspace)
+		viper.Set("output", originalOutput)
+	})
+	viper.Set("api_url", server.URL)
+	viper.Set("worker_url", server.URL)
+	viper.Set("workspace", "hr")
+	viper.Set("output", "table")
+
+	cmd := newResumeSearchCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"CNC 销售", "--limit", "5", "--source", "convex"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume search command failed: %v", err)
+	}
+	text := output.String()
+	if !strings.Contains(text, "Source: convex") || !strings.Contains(text, "Alice") {
+		t.Fatalf("unexpected command output: %s", text)
+	}
+}
+
+func TestResumeMatchCommandWritesJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/match" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var payload client.ResumeMatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode error: %v", err)
+		}
+		if payload.Source != "convex" {
+			t.Fatalf("expected convex source, got %q", payload.Source)
+		}
+		if payload.Persist == nil || *payload.Persist != false {
+			t.Fatalf("expected persist=false, got %+v", payload.Persist)
+		}
+
+		_ = json.NewEncoder(w).Encode(client.ResumeMatchResponse{
+			Success: true,
+			Mode:    "rules_only",
+			Results: []client.ResumeMatchResult{
+				{ResumeID: "resume-1", Score: 90, Recommendation: "match", MatchedAt: "2026-03-17T00:00:00.000Z"},
+			},
+			Stats: client.MatchStats{Processed: 1, Matched: 1, AvgScore: 90},
+		})
+	}))
+	defer server.Close()
+
+	originalAPIURL := viper.GetString("api_url")
+	originalWorkerURL := viper.GetString("worker_url")
+	originalWorkspace := viper.GetString("workspace")
+	originalOutput := viper.GetString("output")
+	t.Cleanup(func() {
+		viper.Set("api_url", originalAPIURL)
+		viper.Set("worker_url", originalWorkerURL)
+		viper.Set("workspace", originalWorkspace)
+		viper.Set("output", originalOutput)
+	})
+	viper.Set("api_url", server.URL)
+	viper.Set("worker_url", server.URL)
+	viper.Set("workspace", "dev")
+	viper.Set("output", "json")
+
+	cmd := newResumeMatchCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--query", "CNC 销售"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume match command failed: %v", err)
+	}
+	if !strings.Contains(output.String(), `"resumeId": "resume-1"`) {
+		t.Fatalf("unexpected command output: %s", output.String())
+	}
+}

--- a/packages/cli/internal/client/api.go
+++ b/packages/cli/internal/client/api.go
@@ -30,9 +30,11 @@ type ResumeSample struct {
 }
 
 type ResumesSummary struct {
-	Total    int    `json:"total"`
-	Returned int    `json:"returned"`
-	Query    string `json:"query"`
+	Total    int      `json:"total"`
+	Returned int      `json:"returned"`
+	Query    string   `json:"query"`
+	Source   string   `json:"source,omitempty"`
+	Expanded []string `json:"expandedTo,omitempty"`
 }
 
 type ResumesResponse struct {
@@ -185,7 +187,117 @@ type ResumeExportRequest struct {
 	Entries []ResumeExportEntry `json:"entries"`
 }
 
-func (c *Client) ListResumes(ctx context.Context, limit int, query string) (*ResumesResponse, error) {
+type MatchQueryRequiredRole struct {
+	Type     string   `json:"type"`
+	Signals  []string `json:"signals"`
+	VerifyIn string   `json:"verifyIn"`
+	MinYears *int     `json:"minYears,omitempty"`
+}
+
+type MatchQueryKeywordGroup struct {
+	Original string   `json:"original"`
+	Variants []string `json:"variants"`
+}
+
+type MatchQueryMetadata struct {
+	Source                string                   `json:"source,omitempty"`
+	Persisted             bool                     `json:"persisted"`
+	KeywordGroups         []MatchQueryKeywordGroup `json:"keywordGroups,omitempty"`
+	ExpandedTo            []string                 `json:"expandedTo,omitempty"`
+	SourceMapping         map[string]string        `json:"sourceMapping,omitempty"`
+	InferredRequiredRoles []MatchQueryRequiredRole `json:"inferredRequiredRoles,omitempty"`
+}
+
+type ResumeMatchDebugProvenance struct {
+	Term         string `json:"term"`
+	Source       string `json:"source"`
+	ExpandedFrom string `json:"expandedFrom,omitempty"`
+}
+
+type ResumeMatchDebugRoleSignal struct {
+	Type                         string   `json:"type"`
+	MatchedSignals               []string `json:"matchedSignals"`
+	SignalCount                  int      `json:"signalCount"`
+	Occurrences                  int      `json:"occurrences"`
+	Years                        float64  `json:"years"`
+	IndustryVerifiedYears        float64  `json:"industryVerifiedYears"`
+	RoleRelevantYears            *float64 `json:"roleRelevantYears,omitempty"`
+	IndustryVerifiedRelevantYears *float64 `json:"industryVerifiedRelevantYears,omitempty"`
+	VerifyIn                     string   `json:"verifyIn"`
+}
+
+type ResumeMatchDebugBrandHit struct {
+	Brand   string `json:"brand"`
+	Role    string `json:"role"`
+	Source  string `json:"source"`
+	Context string `json:"context"`
+}
+
+type ResumeMatchDebug struct {
+	PrimaryRuleScore *float64                     `json:"primaryRuleScore,omitempty"`
+	Provenance       []ResumeMatchDebugProvenance `json:"provenance,omitempty"`
+	RoleSignals      []ResumeMatchDebugRoleSignal `json:"roleSignals,omitempty"`
+	CompanyHits      []string                     `json:"companyHits,omitempty"`
+	BrandHits        []ResumeMatchDebugBrandHit   `json:"brandHits,omitempty"`
+}
+
+type MatchStats struct {
+	Processed        int     `json:"processed"`
+	Matched          int     `json:"matched"`
+	AvgScore         float64 `json:"avgScore"`
+	ProcessingTimeMS int     `json:"processingTimeMs,omitempty"`
+	PendingAI        int     `json:"pendingAi,omitempty"`
+}
+
+type ResumeMatchResult struct {
+	ResumeID         string             `json:"resumeId"`
+	JobDescriptionID string             `json:"jobDescriptionId"`
+	Score            int                `json:"score"`
+	Recommendation   string             `json:"recommendation"`
+	Highlights       []string           `json:"highlights"`
+	Concerns         []string           `json:"concerns"`
+	Summary          string             `json:"summary"`
+	Breakdown        map[string]int     `json:"breakdown,omitempty"`
+	ScoreSource      string             `json:"scoreSource,omitempty"`
+	MatchedAt        string             `json:"matchedAt"`
+	SessionID        string             `json:"sessionId,omitempty"`
+	UserID           string             `json:"userId,omitempty"`
+	Debug            *ResumeMatchDebug  `json:"debug,omitempty"`
+}
+
+type ResumeMatchRequest struct {
+	SessionID        string   `json:"sessionId,omitempty"`
+	Sample           string   `json:"sample,omitempty"`
+	Source           string   `json:"source,omitempty"`
+	Persist          *bool    `json:"persist,omitempty"`
+	JobDescriptionID string   `json:"jobDescriptionId,omitempty"`
+	Keywords         []string `json:"keywords,omitempty"`
+	Location         string   `json:"location,omitempty"`
+	ResumeIDs        []string `json:"resumeIds,omitempty"`
+	Limit            int      `json:"limit,omitempty"`
+	TopN             int      `json:"topN,omitempty"`
+	Mode             string   `json:"mode,omitempty"`
+}
+
+type ResumeMatchResponse struct {
+	Success        bool                `json:"success"`
+	Mode           string              `json:"mode,omitempty"`
+	StreamPath     string              `json:"streamPath,omitempty"`
+	PendingAICount int                 `json:"pendingAiCount,omitempty"`
+	Query          *MatchQueryMetadata `json:"query,omitempty"`
+	Results        []ResumeMatchResult `json:"results"`
+	Stats          MatchStats          `json:"stats"`
+}
+
+func normalizeResumeSource(source string) string {
+	normalized := strings.ToLower(strings.TrimSpace(source))
+	if normalized == "convex" {
+		return "convex"
+	}
+	return "sample"
+}
+
+func (c *Client) ListResumes(ctx context.Context, limit int, query string, source string) (*ResumesResponse, error) {
 	values := url.Values{}
 	if limit > 0 {
 		values.Set("limit", strconv.Itoa(limit))
@@ -193,6 +305,7 @@ func (c *Client) ListResumes(ctx context.Context, limit int, query string) (*Res
 	if strings.TrimSpace(query) != "" {
 		values.Set("q", query)
 	}
+	values.Set("source", normalizeResumeSource(source))
 
 	endpoint := fmt.Sprintf("%s/api/resumes", c.APIURL)
 	if encoded := values.Encode(); encoded != "" {
@@ -209,8 +322,28 @@ func (c *Client) ListResumes(ctx context.Context, limit int, query string) (*Res
 	return &response, nil
 }
 
-func (c *Client) SearchResumes(ctx context.Context, query string, limit int) (*ResumesResponse, error) {
-	return c.ListResumes(ctx, limit, query)
+func (c *Client) SearchResumes(ctx context.Context, query string, limit int, source string) (*ResumesResponse, error) {
+	return c.ListResumes(ctx, limit, query, source)
+}
+
+func (c *Client) MatchResumes(ctx context.Context, request ResumeMatchRequest) (*ResumeMatchResponse, error) {
+	if strings.TrimSpace(request.Source) == "" {
+		request.Source = "sample"
+	}
+	request.Source = normalizeResumeSource(request.Source)
+	if request.Persist == nil {
+		persist := true
+		request.Persist = &persist
+	}
+	endpoint := fmt.Sprintf("%s/api/resumes/match", c.APIURL)
+	var response ResumeMatchResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, request, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("resume match request was not successful")
+	}
+	return &response, nil
 }
 
 func (c *Client) ExportResumes(ctx context.Context, request ResumeExportRequest) ([]byte, string, error) {

--- a/packages/cli/internal/client/api_test.go
+++ b/packages/cli/internal/client/api_test.go
@@ -20,6 +20,9 @@ func TestListResumesBuildsQueryParams(t *testing.T) {
 		if got := r.URL.Query().Get("q"); got != "cnc 东莞" {
 			t.Fatalf("expected q query parameter, got %q", got)
 		}
+		if got := r.URL.Query().Get("source"); got != "convex" {
+			t.Fatalf("expected source=convex, got %q", got)
+		}
 
 		_ = json.NewEncoder(w).Encode(ResumesResponse{
 			Success: true,
@@ -34,7 +37,7 @@ func TestListResumesBuildsQueryParams(t *testing.T) {
 	c := New(server.URL, server.URL, "dev")
 	c.HTTP = server.Client()
 
-	response, err := c.ListResumes(context.Background(), 25, "cnc 东莞")
+	response, err := c.ListResumes(context.Background(), 25, "cnc 东莞", "convex")
 	if err != nil {
 		t.Fatalf("ListResumes returned error: %v", err)
 	}
@@ -52,7 +55,7 @@ func TestListResumesFailsWhenSuccessFalse(t *testing.T) {
 	c := New(server.URL, server.URL, "dev")
 	c.HTTP = server.Client()
 
-	_, err := c.ListResumes(context.Background(), 0, "")
+	_, err := c.ListResumes(context.Background(), 0, "", "sample")
 	if err == nil {
 		t.Fatal("expected error for unsuccessful response")
 	}
@@ -103,6 +106,57 @@ func TestExportResumesUsesBinaryEndpoint(t *testing.T) {
 	}
 	if !strings.Contains(disposition, "out.csv") {
 		t.Fatalf("unexpected disposition: %q", disposition)
+	}
+}
+
+func TestMatchResumesBuildsRequestBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/resumes/match" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+
+		var payload ResumeMatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if payload.Source != "convex" {
+			t.Fatalf("expected source convex, got %q", payload.Source)
+		}
+		if payload.Persist == nil || *payload.Persist != false {
+			t.Fatalf("expected persist=false, got %+v", payload.Persist)
+		}
+		if payload.Mode != "rules_only" {
+			t.Fatalf("expected rules_only mode, got %q", payload.Mode)
+		}
+		if len(payload.Keywords) != 2 || payload.Keywords[0] != "CNC" {
+			t.Fatalf("unexpected keywords: %+v", payload.Keywords)
+		}
+
+		_ = json.NewEncoder(w).Encode(ResumeMatchResponse{
+			Success: true,
+			Mode:    "rules_only",
+			Results: []ResumeMatchResult{{ResumeID: "resume-1", Score: 88, Recommendation: "match"}},
+			Stats:   MatchStats{Processed: 1, Matched: 1, AvgScore: 88},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL, server.URL, "dev")
+	c.HTTP = server.Client()
+	persist := false
+
+	response, err := c.MatchResumes(context.Background(), ResumeMatchRequest{
+		Source:   "convex",
+		Persist:  &persist,
+		Keywords: []string{"CNC", "销售"},
+		Location: "东莞",
+		Mode:     "rules_only",
+	})
+	if err != nil {
+		t.Fatalf("MatchResumes returned error: %v", err)
+	}
+	if len(response.Results) != 1 || response.Results[0].ResumeID != "resume-1" {
+		t.Fatalf("unexpected match response: %+v", response)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add source-aware live resume retrieval and read-only convex query scoring to the resumes API
- switch keyword-only /dev/resumes ranking to query-specific scores and infer strict roles for unambiguous keyword searches
- add CLI support for live source replay and resume match debugging, plus tests and generated API types

## Validation
- bunx vitest run apps/api/src/routes/resumes.test.ts apps/api/src/services/rule-scoring.test.ts
- cd apps/web && bunx vitest run src/hooks/useResumeListState.test.tsx
- cd packages/cli && go test ./internal/client ./cmd
- npm --workspace @trends/web run gen:api
- make check
- go run . resume search 'CNC 销售' --source convex --limit 5 --output json
- go run . resume match --query 'CNC 销售' --source convex --persist=false --mode rules_only --limit 5 --output json