### PR TITLE
fix: stop repeated resume match scoring requests

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -643,22 +643,21 @@ export function useConvexResumes(limit: number = 200, query?: string, jobDescrip
       : normalizedQuery ? 'skip' : { limit, jobDescriptionId: normalizedJobDescriptionId }
   )
 
-  const mockSearchResults = normalizedQuery ? (mockPayload?.search?.results ?? []) : []
-  const mockListResults = !normalizedQuery ? (mockPayload?.list ?? []) : []
-
-  const mappedResumes = mockPayload
-    ? normalizedQuery
-      ? mockSearchResults.map((entry) => ({
-          ...mapResumeDoc(entry.resume),
-          _provenance: entry.provenance,
-        }))
-      : mockListResults.map(mapResumeDoc)
-    : normalizedQuery
-      ? (searchResults?.results ?? []).map((entry) => ({
-          ...mapResumeDoc(entry.resume),
-          _provenance: entry.provenance,
-        }))
-      : (listResults ?? []).map(mapResumeDoc)
+  const mappedResumes = useMemo(() => (
+    mockPayload
+      ? normalizedQuery
+        ? (mockPayload.search?.results ?? []).map((entry) => ({
+            ...mapResumeDoc(entry.resume),
+            _provenance: entry.provenance,
+          }))
+        : (mockPayload.list ?? []).map(mapResumeDoc)
+      : normalizedQuery
+        ? (searchResults?.results ?? []).map((entry) => ({
+            ...mapResumeDoc(entry.resume),
+            _provenance: entry.provenance,
+          }))
+        : (listResults ?? []).map(mapResumeDoc)
+  ), [listResults, mockPayload, normalizedQuery, searchResults])
 
   return {
     resumes: mappedResumes,

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -16,6 +16,7 @@ const formSubmitMock = vi.fn(function thisFormSubmit(this: HTMLFormElement) {
 
 const mockState = vi.hoisted(() => ({
   convexResumes: [] as ConvexResumeItem[],
+  cloneConvexResumesOnRead: false,
   filters: {} as Record<string, unknown>,
   sessionLocation: '广东',
   sessionKeywords: [] as string[],
@@ -139,7 +140,9 @@ vi.mock('@/hooks/useResumes', () => ({
 
 vi.mock('@/hooks/useConvexResumes', () => ({
   useConvexResumes: () => ({
-    resumes: mockState.convexResumes,
+    resumes: mockState.cloneConvexResumesOnRead
+      ? [...mockState.convexResumes]
+      : mockState.convexResumes,
     loading: false,
   }),
 }))
@@ -299,6 +302,7 @@ describe('useResumeListState role filter regression', () => {
     submittedPayloadValue = ''
     window.history.replaceState({}, '', '/')
     mockState.filters = {}
+    mockState.cloneConvexResumesOnRead = false
     mockState.sessionLocation = '广东'
     mockState.sessionKeywords = []
     mockState.sessionJobDescriptionId = undefined
@@ -519,6 +523,32 @@ describe('useResumeListState role filter regression', () => {
         location: '东莞',
       }),
     })
+  })
+
+  it('does not refetch query-specific scores when convex resume arrays are remapped on rerender', async () => {
+    mockState.cloneConvexResumesOnRead = true
+    mockState.sessionKeywords = ['CNC', '销售']
+    mockState.sessionLocation = '东莞'
+    mockState.matchApiResponse = {
+      success: true,
+      results: [
+        { resumeId: 'resume-zhang-machinery-sales', score: 92 },
+        { resumeId: 'resume-li-automation-sales', score: 88 },
+        { resumeId: 'resume-ideal-cnc-sales', score: 84 },
+      ],
+    }
+
+    const { rerender } = renderHook(() => useResumeListState())
+
+    await waitFor(() => {
+      expect(rawApiClient.POST).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      rerender()
+    })
+
+    expect(rawApiClient.POST).toHaveBeenCalledTimes(1)
   })
 
   it('minMatchScore >=60 keeps only industry-verified high-score resumes', () => {

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -85,6 +85,17 @@ function areKeywordListsEqual(left: string[], right: string[]): boolean {
   return normalizeKeywordFingerprint(left) === normalizeKeywordFingerprint(right)
 }
 
+function areScoreMapsEqual(left: Record<string, number>, right: Record<string, number>): boolean {
+  const leftEntries = Object.entries(left)
+  const rightEntries = Object.entries(right)
+
+  if (leftEntries.length !== rightEntries.length) {
+    return false
+  }
+
+  return leftEntries.every(([key, value]) => right[key] === value)
+}
+
 function appendKeywordToken(current: string[], token: string): string[] {
   const normalizedToken = token.trim()
   if (!normalizedToken) {
@@ -205,6 +216,15 @@ function submitResumeExportDownload(apiBaseUrl: string, payload: ResumeExportReq
 
 function normalizeFilterToken(value: string): string {
   return value.trim().toLowerCase()
+}
+
+function parseSerializedStringArray(value: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : []
+  } catch {
+    return []
+  }
 }
 
 function toExperienceLevel(value: string | undefined): ExperienceLevelFilter | undefined {
@@ -500,6 +520,34 @@ export function useResumeListState(loadSearchHistory = false) {
     return rawBaseUrl.replace(/\/api\/?$/, '')
   }, [])
   const keywordOnlyQueryScoring = sessionKeywords.length > 0 && !jobDescriptionId?.trim()
+  const querySpecificKeywordsKey = useMemo(
+    () => JSON.stringify(sessionKeywords.map((keyword) => keyword.trim()).filter((keyword) => keyword.length > 0)),
+    [sessionKeywords]
+  )
+  const querySpecificResumeIdsKey = useMemo(
+    () =>
+      JSON.stringify(
+        Array.from(new Set(convexResumes.map((resume) => String(resume.resumeId)))).sort()
+      ),
+    [convexResumes]
+  )
+  const querySpecificScoreRequest = useMemo(() => {
+    if (!keywordOnlyQueryScoring) {
+      return null
+    }
+
+    const keywords = parseSerializedStringArray(querySpecificKeywordsKey)
+    const resumeIds = parseSerializedStringArray(querySpecificResumeIdsKey)
+    if (keywords.length === 0 || resumeIds.length === 0) {
+      return null
+    }
+
+    return {
+      keywords,
+      location: sessionLocation.trim(),
+      resumeIds,
+    }
+  }, [keywordOnlyQueryScoring, querySpecificKeywordsKey, querySpecificResumeIdsKey, sessionLocation])
 
   const activeLoading = mode === 'ai' ? convexLoading : loading
   const hasActiveTask = useMemo(() => {
@@ -512,14 +560,13 @@ export function useResumeListState(loadSearchHistory = false) {
   useEffect(() => {
     let active = true
 
-    if (!keywordOnlyQueryScoring || convexResumes.length === 0) {
-      setQueryRuleScoreMap({})
+    if (!querySpecificScoreRequest) {
+      setQueryRuleScoreMap((current) => (Object.keys(current).length === 0 ? current : {}))
       return () => {
         active = false
       }
     }
 
-    const resumeIds = convexResumes.map((resume) => String(resume.resumeId))
     void rawApiClient
       .POST<{
         success: boolean
@@ -532,15 +579,15 @@ export function useResumeListState(loadSearchHistory = false) {
           source: 'convex',
           persist: false,
           mode: 'rules_only',
-          keywords: sessionKeywords,
-          location: sessionLocation,
-          resumeIds,
+          keywords: querySpecificScoreRequest.keywords,
+          location: querySpecificScoreRequest.location,
+          resumeIds: querySpecificScoreRequest.resumeIds,
         },
       })
       .then(({ data, error }) => {
         if (!active || error || !data?.success) {
           if (active) {
-            setQueryRuleScoreMap({})
+            setQueryRuleScoreMap((current) => (Object.keys(current).length === 0 ? current : {}))
           }
           return
         }
@@ -548,19 +595,19 @@ export function useResumeListState(loadSearchHistory = false) {
         const nextMap = Object.fromEntries(
           (data.results ?? []).map((item) => [item.resumeId, item.score])
         )
-        setQueryRuleScoreMap(nextMap)
+        setQueryRuleScoreMap((current) => (areScoreMapsEqual(current, nextMap) ? current : nextMap))
       })
       .catch((error: unknown) => {
         console.error('Failed to load query-specific resume scores', error)
         if (active) {
-          setQueryRuleScoreMap({})
+          setQueryRuleScoreMap((current) => (Object.keys(current).length === 0 ? current : {}))
         }
       })
 
     return () => {
       active = false
     }
-  }, [convexResumes, jobDescriptionId, keywordOnlyQueryScoring, sessionKeywords, sessionLocation])
+  }, [querySpecificScoreRequest])
 
   useEffect(() => {
     if (!activeHasUrlParams) {


### PR DESCRIPTION
## Summary
- stabilize keyword-only query scoring requests in the resumes list hook
- memoize mapped Convex resume output so unchanged resume sets do not retrigger the scoring effect
- add a regression test covering rerenders with a remapped resume array

## Validation
- cd apps/web && bunx vitest run src/hooks/useResumeListState.test.tsx
- make check
- headless Playwright repro against /dev/resumes?location=东莞&keyword=CNC 销售 showed exactly one POST /api/resumes/match over ~6.1s