### PR TITLE
feat(cli): add resume debug and local ai scoring

### DIFF
--- a/apps/api/src/services/resume-ai-prompt-service.test.ts
+++ b/apps/api/src/services/resume-ai-prompt-service.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { resumeAiPromptService } from "./resume-ai-prompt-service";
+
+describe("resumeAiPromptService.renderUserPromptTemplate", () => {
+  it("allows extra values and only requires placeholders used by the template", () => {
+    const rendered = resumeAiPromptService.renderUserPromptTemplate(
+      "Hello {candidateName}, role {jobTitle}",
+      {
+        candidateName: "Alice",
+        jobTitle: "Sales Engineer",
+        workExperience: "5",
+        education: "本科",
+        companies: "Foo Corp",
+      },
+    );
+
+    expect(rendered).toBe("Hello Alice, role Sales Engineer");
+  });
+
+  it("throws when a placeholder is missing from the provided values", () => {
+    expect(() =>
+      resumeAiPromptService.renderUserPromptTemplate("Hello {candidateName}, role {jobTitle}", {
+        candidateName: "Alice",
+      }),
+    ).toThrow(/jobTitle/);
+  });
+});

--- a/apps/api/src/services/resume-ai-prompt-service.ts
+++ b/apps/api/src/services/resume-ai-prompt-service.ts
@@ -258,7 +258,16 @@ function buildNormalizedPrompt(
 }
 
 function getMissingTemplateVariables(template: string, values: ResumeAiPromptTemplateValues): string[] {
-  return Object.keys(values).filter((key) => !template.includes(`{${key}}`));
+  const required = new Set<string>();
+  const variablePattern = /\{([A-Za-z][A-Za-z0-9_]*)\}/g;
+  for (const match of template.matchAll(variablePattern)) {
+    const variable = match[1]?.trim();
+    if (variable) {
+      required.add(variable);
+    }
+  }
+
+  return Array.from(required).filter((key) => !(key in values));
 }
 
 function renderPromptTemplate(template: string, values: ResumeAiPromptTemplateValues): string {

--- a/dev-docs/skills/trends-cli/SKILL.md
+++ b/dev-docs/skills/trends-cli/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: trends-cli
-description: Use the Trends Go CLI for backend operations including resume/jd listing, worker triggers, exports, migrations, and MCP server mode.
+description: Use the Trends Go CLI for backend operations including resume/jd listing, resume debug and AI dev-cycle workflows, worker triggers, exports, migrations, and MCP server mode.
 validation:
-  descriptionTerms: [CLI, resume, worker, migration]
+  descriptionTerms: [CLI, resume, debug, worker, migration]
 ---
 
 # Trends CLI
@@ -12,14 +12,23 @@ Use this skill when the user asks to operate backend services from terminal comm
 ## Workflow
 
 1. Build the CLI when binaries are missing or stale: `make cli-build`.
-2. Prefer CLI commands over ad-hoc curl scripts for supported operations.
-3. Use `--output json` when command output needs to be consumed by other tools.
-4. Use `trends mcp serve` when integration requires MCP tool exposure.
+2. Install or refresh the skill when you want the packaged workflow available in Codex: `make install-skill SKILL=trends-cli`.
+3. Prefer CLI commands over ad-hoc curl scripts for supported operations.
+4. Use `--output json` when command output needs to be consumed by other tools.
+5. Use `trends mcp serve` when integration requires MCP tool exposure.
+6. For live Convex AI debug work, prefer `trends resume debug ai-score` over forcing unsupported API match modes.
 
 ## Commands
 
 - `./bin/trends resume list --limit 50`
 - `./bin/trends resume search "CNC 东莞" --limit 50`
+- `./bin/trends resume debug ai-score --query "CNC 销售" --limit 5 --top-n 3`
+- `./bin/trends resume debug matches --job-description lathe-sales`
+- `./bin/trends resume debug match-runs --job-description lathe-sales --limit 20`
+- `./bin/trends resume debug clear-matches --job-description lathe-sales`
+- `./bin/trends resume debug skills-version`
+- `./bin/trends resume debug trigger-reingest --limit 200`
+- `./bin/trends resume debug rescore --source sample --query "CNC 销售"`
 - `./bin/trends resume export --format xlsx --limit 200`
 - `./bin/trends jd list`
 - `./bin/trends jd create ./config/job-descriptions/lathe-sales.md --name lathe-sales-copy`
@@ -35,4 +44,7 @@ Use this skill when the user asks to operate backend services from terminal comm
 
 - Run commands from repository root.
 - Keep `--api-url` and `--worker-url` aligned with running services.
+- `trends resume match` remains the API-backed path; when `source=convex` and AI scoring is needed for debug, use `trends resume debug ai-score`.
+- `trends resume debug rescore` currently mirrors the backend restriction and is sample-only.
+- `trends resume debug trigger-reingest` is the stale-skills-version reingest path, not a generic arbitrary reingest.
 - For migration commands, report the exact `convex run` output back to the user.

--- a/dev-docs/skills/trends-cli/agents/openai.yaml
+++ b/dev-docs/skills/trends-cli/agents/openai.yaml
@@ -1,3 +1,3 @@
 display_name: Trends CLI
-short_description: Operate Trends backend services through the Go CLI and MCP mode.
-default_prompt: Use the trends-cli workflow. Build the CLI if needed, execute the smallest command set for the requested operation, and report concise command output with follow-up actions.
+short_description: Operate Trends backend services and resume debug flows through the Go CLI and MCP mode.
+default_prompt: Use the trends-cli workflow. Build the CLI if needed, prefer CLI commands over ad-hoc API calls, use `resume debug` for cache/reingest/AI dev-cycle tasks, and report concise command output with follow-up actions.

--- a/packages/cli/cmd/mcp.go
+++ b/packages/cli/cmd/mcp.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ptdevhk/trends/packages/cli/internal/client"
 	"github.com/spf13/cobra"
 )
 
@@ -158,6 +159,34 @@ func mcpTools() []map[string]any {
 			},
 		},
 		{
+			"name":        "resume_matches",
+			"description": "Show cached resume matches",
+			"inputSchema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"sessionId":        map[string]any{"type": "string"},
+					"jobDescriptionId": map[string]any{"type": "string"},
+				},
+			},
+		},
+		{
+			"name":        "resume_match_runs",
+			"description": "Show recent resume match runs",
+			"inputSchema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"sessionId":        map[string]any{"type": "string"},
+					"jobDescriptionId": map[string]any{"type": "string"},
+					"limit":            map[string]any{"type": "integer", "minimum": 1},
+				},
+			},
+		},
+		{
+			"name":        "resume_skills_version",
+			"description": "Show the current resume skills/config version",
+			"inputSchema": map[string]any{"type": "object"},
+		},
+		{
 			"name":        "jd_list",
 			"description": "List job descriptions",
 			"inputSchema": map[string]any{"type": "object"},
@@ -223,6 +252,32 @@ func runMCPTool(ctx context.Context, name string, args map[string]interface{}) (
 		}
 		limit := intArg(args, "limit", 50)
 		result, err := apiClient.SearchResumes(ctx, query, limit, "sample")
+		if err != nil {
+			return "", err
+		}
+		return prettyJSON(result)
+	case "resume_matches":
+		result, err := apiClient.ListResumeMatches(
+			ctx,
+			stringArg(args, "sessionId", ""),
+			stringArg(args, "jobDescriptionId", ""),
+		)
+		if err != nil {
+			return "", err
+		}
+		return prettyJSON(result)
+	case "resume_match_runs":
+		result, err := apiClient.ListResumeMatchRuns(ctx, client.MatchRunsQuery{
+			SessionID:        stringArg(args, "sessionId", ""),
+			JobDescriptionID: stringArg(args, "jobDescriptionId", ""),
+			Limit:            intArg(args, "limit", 20),
+		})
+		if err != nil {
+			return "", err
+		}
+		return prettyJSON(result)
+	case "resume_skills_version":
+		result, err := apiClient.GetResumeSkillsVersion(ctx)
 		if err != nil {
 			return "", err
 		}

--- a/packages/cli/cmd/mcp_test.go
+++ b/packages/cli/cmd/mcp_test.go
@@ -144,3 +144,18 @@ func TestArgumentHelpers(t *testing.T) {
 		t.Fatalf("boolArg default expected true, got %v", got)
 	}
 }
+
+func TestMCPToolsIncludeResumeDebugReadOnlyTools(t *testing.T) {
+	tools := mcpTools()
+	names := make(map[string]bool, len(tools))
+	for _, tool := range tools {
+		name, _ := tool["name"].(string)
+		names[name] = true
+	}
+
+	for _, required := range []string{"resume_matches", "resume_match_runs", "resume_skills_version"} {
+		if !names[required] {
+			t.Fatalf("missing MCP tool %q", required)
+		}
+	}
+}

--- a/packages/cli/cmd/resume.go
+++ b/packages/cli/cmd/resume.go
@@ -27,6 +27,7 @@ func newResumeCmd() *cobra.Command {
 		newResumeSearchCmd(),
 		newResumeMatchCmd(),
 		newResumeExportCmd(),
+		newResumeDebugCmd(),
 	)
 
 	return resumeCmd
@@ -147,14 +148,15 @@ func newResumeMatchCmd() *cobra.Command {
 				Mode:             strings.TrimSpace(mode),
 			}
 			request.Persist = &persist
+			if err := validateResumeMatchRequest(request); err != nil {
+				return err
+			}
 
 			response, err := newAPIClient().MatchResumes(context.Background(), request)
 			if err != nil {
 				return err
 			}
-
-			options := currentOptions()
-			if options.Output == "json" {
+			if currentOptions().Output == "json" {
 				return writeOutput(cmd, nil, nil, response)
 			}
 
@@ -162,24 +164,7 @@ func newResumeMatchCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			headers := []string{"resume_id", "score", "recommendation", "primary_rule", "sales_years", "company_hits", "name", "location"}
-			rows := make([][]string, 0, len(response.Results))
-			for _, result := range response.Results {
-				display := displayMap[result.ResumeID]
-				rows = append(rows, []string{
-					result.ResumeID,
-					strconv.Itoa(result.Score),
-					result.Recommendation,
-					formatOptionalFloat(debugPrimaryRuleScore(result.Debug)),
-					formatSalesYears(result.Debug),
-					strings.Join(debugCompanyHits(result.Debug), ", "),
-					display.Name,
-					display.Location,
-				})
-			}
-
-			return writeOutput(cmd, headers, rows, response)
+			return writeResumeMatchTable(cmd, response, displayMap)
 		},
 	}
 

--- a/packages/cli/cmd/resume_debug.go
+++ b/packages/cli/cmd/resume_debug.go
@@ -1,0 +1,491 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/ptdevhk/trends/packages/cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+type localResumeAIScoreRequest struct {
+	APIURL           string   `json:"apiUrl"`
+	Workspace        string   `json:"workspace"`
+	Source           string   `json:"source"`
+	Query            string   `json:"query,omitempty"`
+	Location         string   `json:"location,omitempty"`
+	JobDescriptionID string   `json:"jobDescriptionId,omitempty"`
+	ResumeIDs        []string `json:"resumeIds,omitempty"`
+	Limit            int      `json:"limit"`
+	TopN             int      `json:"topN"`
+}
+
+type localResumeAIScoreStats struct {
+	Processed  int     `json:"processed"`
+	RuleAvg    float64 `json:"ruleAvg"`
+	AIScoreAvg float64 `json:"aiScoreAvg"`
+}
+
+type localResumeAIScoreResult struct {
+	ResumeID       string   `json:"resumeId"`
+	Name           string   `json:"name"`
+	Location       string   `json:"location"`
+	ProfileURL     string   `json:"profileUrl,omitempty"`
+	RuleScore      int      `json:"ruleScore"`
+	AIScore        int      `json:"aiScore"`
+	Recommendation string   `json:"recommendation"`
+	Summary        string   `json:"summary"`
+	Highlights     []string `json:"highlights,omitempty"`
+	Concerns       []string `json:"concerns,omitempty"`
+	RawResponse    string   `json:"rawResponse,omitempty"`
+}
+
+type localResumeAIScoreResponse struct {
+	Success          bool                       `json:"success"`
+	Source           string                     `json:"source"`
+	JobDescriptionID string                     `json:"jobDescriptionId"`
+	Results          []localResumeAIScoreResult `json:"results"`
+	Stats            localResumeAIScoreStats    `json:"stats"`
+}
+
+var runLocalResumeAIScorer = func(ctx context.Context, request localResumeAIScoreRequest) (*localResumeAIScoreResponse, error) {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	input, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshal local AI scorer request: %w", err)
+	}
+
+	scriptPath := filepath.Join(projectRoot, "scripts", "resume", "debug-ai-score.ts")
+	args := []string{scriptPath}
+	envFilePath := filepath.Join(projectRoot, ".env")
+	if _, statErr := os.Stat(envFilePath); statErr == nil {
+		args = append([]string{"--env-file", envFilePath}, args...)
+	}
+
+	command := exec.CommandContext(ctx, "bun", args...)
+	command.Dir = projectRoot
+	command.Stdin = bytes.NewReader(input)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	if err := command.Run(); err != nil {
+		errorOutput := strings.TrimSpace(stderr.String())
+		if errorOutput == "" {
+			errorOutput = strings.TrimSpace(stdout.String())
+		}
+		if errorOutput == "" {
+			errorOutput = "no output"
+		}
+		return nil, fmt.Errorf("run local AI scorer: %w\n%s", err, errorOutput)
+	}
+
+	var response localResumeAIScoreResponse
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		return nil, fmt.Errorf("decode local AI scorer response: %w", err)
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("local AI scorer did not succeed")
+	}
+	return &response, nil
+}
+
+func newResumeDebugCmd() *cobra.Command {
+	debugCmd := &cobra.Command{
+		Use:   "debug",
+		Short: "Resume debug and dev-cycle operations",
+	}
+
+	debugCmd.AddCommand(
+		newResumeDebugMatchesCmd(),
+		newResumeDebugMatchRunsCmd(),
+		newResumeDebugClearMatchesCmd(),
+		newResumeDebugRescoreCmd(),
+		newResumeDebugSkillsVersionCmd(),
+		newResumeDebugTriggerReingestCmd(),
+		newResumeDebugAIScoreCmd(),
+	)
+
+	return debugCmd
+}
+
+func newResumeDebugMatchesCmd() *cobra.Command {
+	var (
+		sessionID        string
+		jobDescriptionID string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "matches",
+		Short: "Show cached resume matches",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(sessionID) == "" && strings.TrimSpace(jobDescriptionID) == "" {
+				return fmt.Errorf("session-id or job-description is required")
+			}
+
+			response, err := newAPIClient().ListResumeMatches(context.Background(), sessionID, jobDescriptionID)
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"resume_id", "score", "source", "recommendation", "matched_at", "session_id"}
+			rows := make([][]string, 0, len(response.Results))
+			for _, result := range response.Results {
+				rows = append(rows, []string{
+					result.ResumeID,
+					strconv.Itoa(result.Score),
+					result.ScoreSource,
+					result.Recommendation,
+					result.MatchedAt,
+					result.SessionID,
+				})
+			}
+
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	cmd.Flags().StringVar(&sessionID, "session-id", "", "Optional session ID")
+	cmd.Flags().StringVar(&jobDescriptionID, "job-description", "", "Optional job description ID")
+	return cmd
+}
+
+func newResumeDebugMatchRunsCmd() *cobra.Command {
+	var (
+		sessionID        string
+		jobDescriptionID string
+		limit            int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "match-runs",
+		Short: "Show recent resume match runs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := newAPIClient().ListResumeMatchRuns(context.Background(), client.MatchRunsQuery{
+				SessionID:        sessionID,
+				JobDescriptionID: jobDescriptionID,
+				Limit:            limit,
+			})
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"id", "mode", "status", "processed", "total", "failed", "matched", "avg_score"}
+			rows := make([][]string, 0, len(response.Runs))
+			for _, run := range response.Runs {
+				rows = append(rows, []string{
+					run.ID,
+					run.Mode,
+					run.Status,
+					strconv.Itoa(run.ProcessedCount),
+					strconv.Itoa(run.TotalCount),
+					strconv.Itoa(run.FailedCount),
+					intPointerString(run.MatchedCount),
+					formatOptionalFloat(run.AvgScore),
+				})
+			}
+
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	cmd.Flags().StringVar(&sessionID, "session-id", "", "Optional session ID")
+	cmd.Flags().StringVar(&jobDescriptionID, "job-description", "", "Optional job description ID")
+	cmd.Flags().IntVar(&limit, "limit", 20, "Maximum runs to fetch")
+	return cmd
+}
+
+func newResumeDebugClearMatchesCmd() *cobra.Command {
+	var jobDescriptionID string
+
+	cmd := &cobra.Command{
+		Use:   "clear-matches",
+		Short: "Clear cached resume matches",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := newAPIClient().ClearResumeMatches(context.Background(), jobDescriptionID)
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"deleted", "job_description"}
+			rows := [][]string{{
+				strconv.Itoa(response.Deleted),
+				response.JobDescriptionID,
+			}}
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	cmd.Flags().StringVar(&jobDescriptionID, "job-description", "", "Optional job description ID to clear only one cache scope")
+	return cmd
+}
+
+func newResumeDebugRescoreCmd() *cobra.Command {
+	var (
+		query            string
+		location         string
+		jobDescriptionID string
+		sample           string
+		source           string
+		limit            int
+		resumeIDs        []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "rescore",
+		Short: "Re-score cached/sample matches with the rule engine",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			keywords := splitQueryKeywords(query)
+			if strings.TrimSpace(jobDescriptionID) == "" && len(keywords) == 0 {
+				return fmt.Errorf("query or job-description is required")
+			}
+			if normalizeResumeSourceFlag(source) == "convex" {
+				return fmt.Errorf("resume debug rescore only supports --source sample")
+			}
+
+			persist := true
+			response, err := newAPIClient().RescoreResumeMatches(context.Background(), client.ResumeRescoreRequest{
+				Sample:           strings.TrimSpace(sample),
+				Source:           source,
+				Persist:          &persist,
+				JobDescriptionID: strings.TrimSpace(jobDescriptionID),
+				Keywords:         keywords,
+				Location:         strings.TrimSpace(location),
+				ResumeIDs:        resumeIDs,
+				Limit:            limit,
+			})
+			if err != nil {
+				return err
+			}
+			if currentOptions().Output == "json" {
+				return writeOutput(cmd, nil, nil, response)
+			}
+
+			displayMap, err := loadResumeDisplayMap(context.Background(), newAPIClient(), strings.Join(keywords, " "), limit, source)
+			if err != nil {
+				return err
+			}
+			return writeResumeMatchTable(cmd, response, displayMap)
+		},
+	}
+
+	cmd.Flags().StringVar(&query, "query", "", "Keyword query to match against resumes")
+	cmd.Flags().StringVar(&location, "location", "", "Optional location constraint")
+	cmd.Flags().StringVar(&jobDescriptionID, "job-description", "", "Optional job description ID")
+	cmd.Flags().StringVar(&sample, "sample", "", "Optional sample name")
+	cmd.Flags().StringVar(&source, "source", "sample", "Resume source: sample")
+	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum resumes to score")
+	cmd.Flags().StringSliceVar(&resumeIDs, "resume-id", nil, "Optional specific resume IDs to rescore")
+	return cmd
+}
+
+func newResumeDebugSkillsVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "skills-version",
+		Short: "Show the current resume skills/config version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := newAPIClient().GetResumeSkillsVersion(context.Background())
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"version"}
+			rows := [][]string{{strconv.Itoa(response.Version)}}
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+}
+
+func newResumeDebugTriggerReingestCmd() *cobra.Command {
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "trigger-reingest",
+		Short: "Trigger stale-skills-version resume reingest",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := newAPIClient().TriggerResumeReingest(context.Background(), limit)
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"scheduled", "batches", "current_version", "has_more"}
+			rows := [][]string{{
+				strconv.Itoa(response.Scheduled),
+				strconv.Itoa(response.Batches),
+				strconv.Itoa(response.CurrentVersion),
+				fmt.Sprintf("%t", response.HasMore),
+			}}
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 200, "Maximum stale resumes to schedule")
+	return cmd
+}
+
+func newResumeDebugAIScoreCmd() *cobra.Command {
+	var (
+		query            string
+		location         string
+		jobDescriptionID string
+		source           string
+		limit            int
+		topN             int
+		resumeIDs        []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "ai-score",
+		Short: "Locally AI-score live Convex candidates for debug work",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if normalizeResumeSourceFlag(source) != "convex" {
+				return fmt.Errorf("resume debug ai-score only supports --source convex")
+			}
+			if strings.TrimSpace(jobDescriptionID) == "" && len(splitQueryKeywords(query)) == 0 {
+				return fmt.Errorf("query or job-description is required")
+			}
+			if topN <= 0 {
+				topN = limit
+			}
+
+			options := currentOptions()
+			response, err := runLocalResumeAIScorer(context.Background(), localResumeAIScoreRequest{
+				APIURL:           options.APIURL,
+				Workspace:        options.Workspace,
+				Source:           source,
+				Query:            strings.TrimSpace(query),
+				Location:         strings.TrimSpace(location),
+				JobDescriptionID: strings.TrimSpace(jobDescriptionID),
+				ResumeIDs:        resumeIDs,
+				Limit:            limit,
+				TopN:             topN,
+			})
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"resume_id", "ai_score", "rule_score", "recommendation", "name", "location"}
+			rows := make([][]string, 0, len(response.Results))
+			for _, result := range response.Results {
+				rows = append(rows, []string{
+					result.ResumeID,
+					strconv.Itoa(result.AIScore),
+					strconv.Itoa(result.RuleScore),
+					result.Recommendation,
+					result.Name,
+					result.Location,
+				})
+			}
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	cmd.Flags().StringVar(&query, "query", "", "Keyword query used to build the AI scoring prompt")
+	cmd.Flags().StringVar(&location, "location", "", "Optional location constraint")
+	cmd.Flags().StringVar(&jobDescriptionID, "job-description", "", "Optional job description ID")
+	cmd.Flags().StringVar(&source, "source", "convex", "Resume source: convex")
+	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum candidates to consider before local AI scoring")
+	cmd.Flags().IntVar(&topN, "top-n", 10, "Number of top rule-ranked candidates to AI-score locally")
+	cmd.Flags().StringSliceVar(&resumeIDs, "resume-id", nil, "Optional specific Convex resume IDs to AI-score")
+	return cmd
+}
+
+func writeResumeMatchTable(cmd *cobra.Command, response *client.ResumeMatchResponse, displayMap map[string]resumeDisplayRow) error {
+	if currentOptions().Output == "json" {
+		return writeOutput(cmd, nil, nil, response)
+	}
+
+	headers := []string{"resume_id", "score", "recommendation", "primary_rule", "sales_years", "company_hits", "name", "location"}
+	rows := make([][]string, 0, len(response.Results))
+	for _, result := range response.Results {
+		display := displayMap[result.ResumeID]
+		rows = append(rows, []string{
+			result.ResumeID,
+			strconv.Itoa(result.Score),
+			result.Recommendation,
+			formatOptionalFloat(debugPrimaryRuleScore(result.Debug)),
+			formatSalesYears(result.Debug),
+			strings.Join(debugCompanyHits(result.Debug), ", "),
+			display.Name,
+			display.Location,
+		})
+	}
+
+	return writeOutput(cmd, headers, rows, response)
+}
+
+func validateResumeMatchRequest(request client.ResumeMatchRequest) error {
+	mode := strings.TrimSpace(request.Mode)
+	if mode == "" {
+		mode = "rules_only"
+	}
+
+	if normalizeResumeSourceFlag(request.Source) == "convex" && mode != "rules_only" {
+		return fmt.Errorf(
+			"source=convex with --mode %s is blocked by /api/resumes/match; use `trends resume debug ai-score ...` for local AI scoring or keep --mode rules_only",
+			mode,
+		)
+	}
+
+	persist := true
+	if request.Persist != nil {
+		persist = *request.Persist
+	}
+
+	if !persist && mode != "rules_only" {
+		return fmt.Errorf("mode=%s requires --persist; the API only allows --persist=false with --mode rules_only", mode)
+	}
+	if normalizeResumeSourceFlag(request.Source) == "convex" && persist {
+		return fmt.Errorf("source=convex only supports --persist=false")
+	}
+
+	return nil
+}
+
+func findProjectRoot() (string, error) {
+	current, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("read working directory: %w", err)
+	}
+
+	for {
+		if looksLikeProjectRoot(current) {
+			return current, nil
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+
+	return "", fmt.Errorf("could not locate project root from %s", current)
+}
+
+func looksLikeProjectRoot(dir string) bool {
+	required := []string{
+		filepath.Join(dir, "CLAUDE.md"),
+		filepath.Join(dir, "packages", "cli", "go.mod"),
+		filepath.Join(dir, "scripts", "resume"),
+	}
+	for _, candidate := range required {
+		if _, err := os.Stat(candidate); err != nil {
+			return false
+		}
+	}
+	return true
+}

--- a/packages/cli/cmd/resume_debug_test.go
+++ b/packages/cli/cmd/resume_debug_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ptdevhk/trends/packages/cli/internal/client"
+	"github.com/spf13/viper"
+)
+
+func TestValidateResumeMatchRequestRejectsConvexHybrid(t *testing.T) {
+	persist := false
+	err := validateResumeMatchRequest(client.ResumeMatchRequest{
+		Source:  "convex",
+		Persist: &persist,
+		Mode:    "hybrid",
+	})
+	if err == nil {
+		t.Fatal("expected convex hybrid validation error")
+	}
+	if !strings.Contains(err.Error(), "resume debug ai-score") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResumeDebugMatchesCommandWritesTable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/matches" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("jobDescriptionId"); got != "lathe-sales" {
+			t.Fatalf("expected jobDescriptionId=lathe-sales, got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(client.ResumeMatchesResponse{
+			Success: true,
+			Results: []client.ResumeMatchResult{
+				{ResumeID: "resume-1", Score: 91, ScoreSource: "ai", Recommendation: "strong_match", MatchedAt: "2026-03-17T00:00:00.000Z"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	originalAPIURL := viper.GetString("api_url")
+	originalWorkerURL := viper.GetString("worker_url")
+	originalWorkspace := viper.GetString("workspace")
+	originalOutput := viper.GetString("output")
+	t.Cleanup(func() {
+		viper.Set("api_url", originalAPIURL)
+		viper.Set("worker_url", originalWorkerURL)
+		viper.Set("workspace", originalWorkspace)
+		viper.Set("output", originalOutput)
+	})
+	viper.Set("api_url", server.URL)
+	viper.Set("worker_url", server.URL)
+	viper.Set("workspace", "dev")
+	viper.Set("output", "table")
+
+	cmd := newResumeDebugMatchesCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--job-description", "lathe-sales"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug matches command failed: %v", err)
+	}
+	text := output.String()
+	if !strings.Contains(text, "resume-1") || !strings.Contains(text, "strong_match") {
+		t.Fatalf("unexpected command output: %s", text)
+	}
+}
+
+func TestResumeDebugAIScoreCommandWritesTable(t *testing.T) {
+	originalOutput := viper.GetString("output")
+	originalAPIURL := viper.GetString("api_url")
+	originalWorkspace := viper.GetString("workspace")
+	originalRunner := runLocalResumeAIScorer
+	t.Cleanup(func() {
+		viper.Set("output", originalOutput)
+		viper.Set("api_url", originalAPIURL)
+		viper.Set("workspace", originalWorkspace)
+		runLocalResumeAIScorer = originalRunner
+	})
+
+	viper.Set("output", "table")
+	viper.Set("api_url", "http://localhost:3000")
+	viper.Set("workspace", "dev")
+	runLocalResumeAIScorer = func(ctx context.Context, request localResumeAIScoreRequest) (*localResumeAIScoreResponse, error) {
+		if request.Source != "convex" {
+			t.Fatalf("expected convex source, got %q", request.Source)
+		}
+		return &localResumeAIScoreResponse{
+			Success: true,
+			Source:  "convex",
+			Results: []localResumeAIScoreResult{
+				{
+					ResumeID:       "resume-1",
+					Name:           "Alice",
+					Location:       "Dongguan",
+					RuleScore:      78,
+					AIScore:        92,
+					Recommendation: "strong_match",
+				},
+			},
+		}, nil
+	}
+
+	cmd := newResumeDebugAIScoreCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--query", "CNC 销售", "--top-n", "1"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug ai-score command failed: %v", err)
+	}
+	text := output.String()
+	if !strings.Contains(text, "Alice") || !strings.Contains(text, "92") {
+		t.Fatalf("unexpected command output: %s", text)
+	}
+}
+
+func TestResumeDebugRescoreRejectsConvex(t *testing.T) {
+	cmd := newResumeDebugRescoreCmd()
+	cmd.SetArgs([]string{"--query", "CNC 销售", "--source", "convex"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected convex rescore error")
+	}
+	if !strings.Contains(err.Error(), "only supports --source sample") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/packages/cli/internal/client/resume_debug.go
+++ b/packages/cli/internal/client/resume_debug.go
@@ -1,0 +1,191 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type ResumeMatchesResponse struct {
+	Success bool                `json:"success"`
+	Results []ResumeMatchResult `json:"results"`
+}
+
+type MatchRun struct {
+	ID               string   `json:"id"`
+	SessionID        string   `json:"sessionId,omitempty"`
+	JobDescriptionID string   `json:"jobDescriptionId"`
+	SampleName       string   `json:"sampleName,omitempty"`
+	Mode             string   `json:"mode"`
+	Status           string   `json:"status"`
+	TotalCount       int      `json:"totalCount"`
+	ProcessedCount   int      `json:"processedCount"`
+	FailedCount      int      `json:"failedCount"`
+	MatchedCount     *int     `json:"matchedCount,omitempty"`
+	AvgScore         *float64 `json:"avgScore,omitempty"`
+	StartedAt        string   `json:"startedAt"`
+	CompletedAt      string   `json:"completedAt,omitempty"`
+	Error            string   `json:"error,omitempty"`
+}
+
+type MatchRunsQuery struct {
+	SessionID        string
+	JobDescriptionID string
+	Limit            int
+}
+
+type MatchRunsResponse struct {
+	Success bool       `json:"success"`
+	Runs    []MatchRun `json:"runs"`
+}
+
+type ClearResumeMatchesResponse struct {
+	Success          bool   `json:"success"`
+	Deleted          int    `json:"deleted"`
+	JobDescriptionID string `json:"jobDescriptionId,omitempty"`
+}
+
+type ResumeRescoreRequest struct {
+	SessionID        string   `json:"sessionId,omitempty"`
+	Sample           string   `json:"sample,omitempty"`
+	Source           string   `json:"source,omitempty"`
+	Persist          *bool    `json:"persist,omitempty"`
+	JobDescriptionID string   `json:"jobDescriptionId,omitempty"`
+	Keywords         []string `json:"keywords,omitempty"`
+	Location         string   `json:"location,omitempty"`
+	ResumeIDs        []string `json:"resumeIds,omitempty"`
+	Limit            int      `json:"limit,omitempty"`
+}
+
+type ResumeSkillsVersionResponse struct {
+	Success bool `json:"success"`
+	Version int  `json:"version"`
+}
+
+type ResumeTriggerReingestResponse struct {
+	Success        bool `json:"success"`
+	Scheduled      int  `json:"scheduled"`
+	Batches        int  `json:"batches"`
+	CurrentVersion int  `json:"currentVersion"`
+	HasMore        bool `json:"hasMore"`
+}
+
+func (c *Client) ListResumeMatches(ctx context.Context, sessionID, jobDescriptionID string) (*ResumeMatchesResponse, error) {
+	values := url.Values{}
+	if strings.TrimSpace(sessionID) != "" {
+		values.Set("sessionId", strings.TrimSpace(sessionID))
+	}
+	if strings.TrimSpace(jobDescriptionID) != "" {
+		values.Set("jobDescriptionId", strings.TrimSpace(jobDescriptionID))
+	}
+
+	endpoint := fmt.Sprintf("%s/api/resumes/matches", c.APIURL)
+	if encoded := values.Encode(); encoded != "" {
+		endpoint = fmt.Sprintf("%s?%s", endpoint, encoded)
+	}
+
+	var response ResumeMatchesResponse
+	if err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("resume matches request was not successful")
+	}
+	return &response, nil
+}
+
+func (c *Client) ListResumeMatchRuns(ctx context.Context, query MatchRunsQuery) (*MatchRunsResponse, error) {
+	values := url.Values{}
+	if strings.TrimSpace(query.SessionID) != "" {
+		values.Set("sessionId", strings.TrimSpace(query.SessionID))
+	}
+	if strings.TrimSpace(query.JobDescriptionID) != "" {
+		values.Set("jobDescriptionId", strings.TrimSpace(query.JobDescriptionID))
+	}
+	if query.Limit > 0 {
+		values.Set("limit", strconv.Itoa(query.Limit))
+	}
+
+	endpoint := fmt.Sprintf("%s/api/resumes/match-runs", c.APIURL)
+	if encoded := values.Encode(); encoded != "" {
+		endpoint = fmt.Sprintf("%s?%s", endpoint, encoded)
+	}
+
+	var response MatchRunsResponse
+	if err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("resume match runs request was not successful")
+	}
+	return &response, nil
+}
+
+func (c *Client) ClearResumeMatches(ctx context.Context, jobDescriptionID string) (*ClearResumeMatchesResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/matches", c.APIURL)
+	if trimmed := strings.TrimSpace(jobDescriptionID); trimmed != "" {
+		endpoint = fmt.Sprintf("%s?jobDescriptionId=%s", endpoint, url.QueryEscape(trimmed))
+	}
+
+	var response ClearResumeMatchesResponse
+	if err := c.doJSON(ctx, http.MethodDelete, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("clear resume matches request was not successful")
+	}
+	return &response, nil
+}
+
+func (c *Client) RescoreResumeMatches(ctx context.Context, request ResumeRescoreRequest) (*ResumeMatchResponse, error) {
+	if strings.TrimSpace(request.Source) == "" {
+		request.Source = "sample"
+	}
+	request.Source = normalizeResumeSource(request.Source)
+	if request.Persist == nil {
+		persist := true
+		request.Persist = &persist
+	}
+
+	endpoint := fmt.Sprintf("%s/api/resumes/matches/rescore", c.APIURL)
+	var response ResumeMatchResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, request, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("resume match rescore request was not successful")
+	}
+	return &response, nil
+}
+
+func (c *Client) GetResumeSkillsVersion(ctx context.Context) (*ResumeSkillsVersionResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/skills-version", c.APIURL)
+	var response ResumeSkillsVersionResponse
+	if err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("resume skills version request was not successful")
+	}
+	return &response, nil
+}
+
+func (c *Client) TriggerResumeReingest(ctx context.Context, limit int) (*ResumeTriggerReingestResponse, error) {
+	payload := map[string]int{}
+	if limit > 0 {
+		payload["limit"] = limit
+	}
+
+	endpoint := fmt.Sprintf("%s/api/resumes/trigger-reingest", c.APIURL)
+	var response ResumeTriggerReingestResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, payload, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("resume trigger reingest request was not successful")
+	}
+	return &response, nil
+}

--- a/packages/cli/internal/client/resume_debug_test.go
+++ b/packages/cli/internal/client/resume_debug_test.go
@@ -1,0 +1,144 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResumeDebugClientEndpoints(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/resumes/matches":
+			if got := r.URL.Query().Get("jobDescriptionId"); got != "lathe-sales" {
+				t.Fatalf("expected jobDescriptionId=lathe-sales, got %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(ResumeMatchesResponse{
+				Success: true,
+				Results: []ResumeMatchResult{
+					{ResumeID: "resume-1", Score: 88, ScoreSource: "ai", Recommendation: "match", MatchedAt: "2026-03-17T00:00:00.000Z"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/resumes/match-runs":
+			if got := r.URL.Query().Get("limit"); got != "5" {
+				t.Fatalf("expected limit=5, got %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(MatchRunsResponse{
+				Success: true,
+				Runs: []MatchRun{
+					{ID: "run-1", Mode: "hybrid", Status: "completed", TotalCount: 10, ProcessedCount: 10, FailedCount: 0},
+				},
+			})
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/resumes/matches":
+			if got := r.URL.Query().Get("jobDescriptionId"); got != "lathe-sales" {
+				t.Fatalf("expected jobDescriptionId=lathe-sales, got %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(ClearResumeMatchesResponse{
+				Success:          true,
+				Deleted:          3,
+				JobDescriptionID: "lathe-sales",
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/resumes/matches/rescore":
+			var payload ResumeRescoreRequest
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+			if payload.Source != "sample" {
+				t.Fatalf("expected sample source, got %q", payload.Source)
+			}
+			if payload.Persist == nil || !*payload.Persist {
+				t.Fatalf("expected persist=true, got %+v", payload.Persist)
+			}
+			_ = json.NewEncoder(w).Encode(ResumeMatchResponse{
+				Success: true,
+				Mode:    "rules_only",
+				Results: []ResumeMatchResult{{ResumeID: "resume-1", Score: 75, Recommendation: "potential"}},
+				Stats:   MatchStats{Processed: 1, Matched: 1, AvgScore: 75},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/resumes/skills-version":
+			_ = json.NewEncoder(w).Encode(ResumeSkillsVersionResponse{
+				Success: true,
+				Version: 42,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/resumes/trigger-reingest":
+			var payload map[string]int
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode trigger-reingest body: %v", err)
+			}
+			if got := payload["limit"]; got != 150 {
+				t.Fatalf("expected limit=150, got %d", got)
+			}
+			_ = json.NewEncoder(w).Encode(ResumeTriggerReingestResponse{
+				Success:        true,
+				Scheduled:      150,
+				Batches:        3,
+				CurrentVersion: 9,
+				HasMore:        true,
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	c := New(server.URL, server.URL, "dev")
+	c.HTTP = server.Client()
+
+	matches, err := c.ListResumeMatches(context.Background(), "", "lathe-sales")
+	if err != nil {
+		t.Fatalf("ListResumeMatches returned error: %v", err)
+	}
+	if len(matches.Results) != 1 || matches.Results[0].ResumeID != "resume-1" {
+		t.Fatalf("unexpected matches response: %+v", matches)
+	}
+
+	runs, err := c.ListResumeMatchRuns(context.Background(), MatchRunsQuery{Limit: 5})
+	if err != nil {
+		t.Fatalf("ListResumeMatchRuns returned error: %v", err)
+	}
+	if len(runs.Runs) != 1 || runs.Runs[0].ID != "run-1" {
+		t.Fatalf("unexpected match-runs response: %+v", runs)
+	}
+
+	cleared, err := c.ClearResumeMatches(context.Background(), "lathe-sales")
+	if err != nil {
+		t.Fatalf("ClearResumeMatches returned error: %v", err)
+	}
+	if cleared.Deleted != 3 {
+		t.Fatalf("unexpected clear response: %+v", cleared)
+	}
+
+	persist := true
+	rescored, err := c.RescoreResumeMatches(context.Background(), ResumeRescoreRequest{
+		Source:  "sample",
+		Persist: &persist,
+		Keywords: []string{
+			"CNC",
+			"销售",
+		},
+	})
+	if err != nil {
+		t.Fatalf("RescoreResumeMatches returned error: %v", err)
+	}
+	if len(rescored.Results) != 1 || rescored.Results[0].Score != 75 {
+		t.Fatalf("unexpected rescore response: %+v", rescored)
+	}
+
+	version, err := c.GetResumeSkillsVersion(context.Background())
+	if err != nil {
+		t.Fatalf("GetResumeSkillsVersion returned error: %v", err)
+	}
+	if version.Version != 42 {
+		t.Fatalf("unexpected version response: %+v", version)
+	}
+
+	reingest, err := c.TriggerResumeReingest(context.Background(), 150)
+	if err != nil {
+		t.Fatalf("TriggerResumeReingest returned error: %v", err)
+	}
+	if reingest.Scheduled != 150 || !reingest.HasMore {
+		t.Fatalf("unexpected reingest response: %+v", reingest)
+	}
+}

--- a/scripts/resume/debug-ai-score.ts
+++ b/scripts/resume/debug-ai-score.ts
@@ -1,0 +1,317 @@
+import { buildWorkHistoryEvidence, buildWorkHistoryEntryText, normalizeWorkHistoryEntry } from "../../packages/shared/src/index.ts";
+import { AIMatchingService, type MatchingRequest } from "../../apps/api/src/services/ai-matching.ts";
+import { JobDescriptionService } from "../../apps/api/src/services/job-description-service.ts";
+import { resolveConvexUrl } from "../../apps/api/src/services/resume-import-service.ts";
+import { parseExperienceYears } from "../../apps/api/src/services/resume-service.ts";
+
+type LocalResumeAIScoreRequest = {
+  apiUrl: string;
+  workspace: string;
+  source: string;
+  query?: string;
+  location?: string;
+  jobDescriptionId?: string;
+  resumeIds?: string[];
+  limit?: number;
+  topN?: number;
+};
+
+type RuleMatchResult = {
+  resumeId: string;
+  score: number;
+};
+
+type RuleMatchResponse = {
+  success: boolean;
+  results: Array<RuleMatchResult>;
+};
+
+type HydratedConvexResume = {
+  resumeId: string;
+  resume: {
+    name?: string;
+    location?: string;
+    education?: string;
+    experience?: string;
+    profileUrl?: string;
+    source?: string;
+    workHistory?: Array<Record<string, unknown>>;
+  };
+};
+
+function splitQueryKeywords(query: string | undefined): string[] {
+  if (!query) return [];
+  return query.trim().split(/\s+/).map((part) => part.trim()).filter(Boolean);
+}
+
+function stripFrontMatter(content: string): string {
+  const lines = content.split("\n");
+  if (lines[0]?.trim() !== "---") return content;
+  const endIndex = lines.slice(1).findIndex((line) => line.trim() === "---");
+  if (endIndex === -1) return content;
+  return lines.slice(endIndex + 2).join("\n");
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractSection(content: string, headings: string[]): string | undefined {
+  const lines = stripFrontMatter(content).split("\n");
+  let startIndex = -1;
+  let endIndex = lines.length;
+  const headingRegex = new RegExp(
+    `^##\\s+(${headings.map((heading) => escapeRegex(heading)).join("|")})\\s*$`,
+    "i",
+  );
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!headingRegex.test(lines[index].trim())) {
+      continue;
+    }
+    startIndex = index + 1;
+    for (let cursor = startIndex; cursor < lines.length; cursor += 1) {
+      if (/^##\s+/.test(lines[cursor].trim())) {
+        endIndex = cursor;
+        break;
+      }
+    }
+    break;
+  }
+
+  if (startIndex === -1) return undefined;
+  return lines.slice(startIndex, endIndex).join("\n").trim();
+}
+
+function buildKeywordRequirements(keywords: string[]): string {
+  return `候选人需具备以下关键技能/经验:\n${keywords.map((keyword) => `- ${keyword}`).join("\n")}`;
+}
+
+function buildKeywordResponsibilities(keywords: string[], location?: string): string | undefined {
+  const parts = [
+    `核心关键词: ${keywords.join(", ")}`,
+    location?.trim() ? `目标地点: ${location.trim()}` : undefined,
+  ].filter((value): value is string => Boolean(value));
+
+  if (parts.length === 0) return undefined;
+  return parts.join("\n");
+}
+
+function extractCompanies(workHistory: Array<Record<string, unknown>> | undefined): string[] | undefined {
+  if (!workHistory || workHistory.length === 0) return undefined;
+
+  const companies = workHistory
+    .map((entry) => {
+      const normalized = normalizeWorkHistoryEntry(entry);
+      return normalized?.companyName || buildWorkHistoryEntryText(entry);
+    })
+    .filter(Boolean)
+    .map((raw) => raw.replace(/^\d[\d\-~至今()年月日\s]*?/g, "").trim())
+    .filter(Boolean);
+
+  if (companies.length === 0) return undefined;
+  return Array.from(new Set(companies)).slice(0, 8);
+}
+
+async function callAPI<T>(input: LocalResumeAIScoreRequest, path: string, method: string, body?: unknown): Promise<T> {
+  const response = await fetch(`${input.apiUrl.replace(/\/$/, "")}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Workspace-Slug": input.workspace,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`API ${method} ${path} failed (${response.status}): ${await response.text()}`);
+  }
+
+  return await response.json() as T;
+}
+
+async function hydrateConvexResumes(resumeIds: string[]): Promise<Map<string, HydratedConvexResume["resume"]>> {
+  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+  const response = await fetch(`${convexUrl}/api/query`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      path: "resumes:getByIdsForExport",
+      args: { resumeIds },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Convex query failed (${response.status}): ${await response.text()}`);
+  }
+
+  const payload = await response.json() as {
+    status?: string;
+    value?: unknown;
+    errorMessage?: string;
+  };
+  if (payload.status !== "success" || !Array.isArray(payload.value)) {
+    throw new Error(payload.errorMessage || "Invalid Convex response for resumes:getByIdsForExport");
+  }
+
+  const result = new Map<string, HydratedConvexResume["resume"]>();
+  for (const entry of payload.value as HydratedConvexResume[]) {
+    result.set(entry.resumeId, entry.resume);
+  }
+  return result;
+}
+
+function buildJobDescription(input: LocalResumeAIScoreRequest, keywords: string[]) {
+  if (input.jobDescriptionId?.trim()) {
+    const service = new JobDescriptionService();
+    const jd = service.loadFile(input.jobDescriptionId.trim());
+    return {
+      title: jd.title || jd.id,
+      requirements: extractSection(jd.content, ["Requirements", "任职要求", "要求"]) || stripFrontMatter(jd.content),
+      responsibilities: extractSection(jd.content, ["Responsibilities", "岗位职责", "职责"]),
+      jobDescriptionId: jd.id,
+    };
+  }
+
+  return {
+    title: keywords.join(" "),
+    requirements: buildKeywordRequirements(keywords),
+    responsibilities: buildKeywordResponsibilities(keywords, input.location),
+    jobDescriptionId: `keyword-search:${keywords.join("|")}${input.location?.trim() ? `@${input.location.trim()}` : ""}`,
+  };
+}
+
+function buildMatchingResumePayload(resumeId: string, resume: HydratedConvexResume["resume"]): MatchingRequest["resume"] {
+  return {
+    id: resumeId,
+    name: resume.name?.trim() || "未命名",
+    workExperience: typeof resume.experience === "string" ? parseExperienceYears(resume.experience) ?? undefined : undefined,
+    education: resume.education || undefined,
+    companies: extractCompanies(resume.workHistory),
+    workHistory: buildWorkHistoryEvidence(resume.workHistory ?? []).lines.join("\n") || undefined,
+    sourceKey: resume.source || undefined,
+  };
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  return Number((values.reduce((sum, value) => sum + value, 0) / values.length).toFixed(2));
+}
+
+async function main(): Promise<void> {
+  const rawInput = await Bun.stdin.text();
+  const input = JSON.parse(rawInput) as LocalResumeAIScoreRequest;
+  const source = (input.source || "convex").trim().toLowerCase();
+  if (source !== "convex") {
+    throw new Error("Local AI scorer currently supports source=convex only");
+  }
+
+  const keywords = splitQueryKeywords(input.query);
+  if (!input.jobDescriptionId?.trim() && keywords.length === 0) {
+    throw new Error("query or jobDescriptionId is required");
+  }
+
+  const aiService = new AIMatchingService();
+  const availability = aiService.isAvailable();
+  if (!availability.available) {
+    throw new Error(availability.reason || "AI service unavailable");
+  }
+
+  const topN = Math.max(1, input.topN || input.limit || 10);
+  const limit = Math.max(topN, input.limit || topN);
+
+  const rulesResponse = await callAPI<RuleMatchResponse>(input, "/api/resumes/match", "POST", {
+    source,
+    persist: false,
+    jobDescriptionId: input.jobDescriptionId?.trim() || undefined,
+    keywords: keywords.length > 0 ? keywords : undefined,
+    location: input.location?.trim() || undefined,
+    resumeIds: input.resumeIds?.length ? input.resumeIds : undefined,
+    limit,
+    topN: limit,
+    mode: "rules_only",
+  });
+  if (!rulesResponse.success) {
+    throw new Error("rules_only matching did not succeed");
+  }
+
+  const topRuleResults = rulesResponse.results.slice(0, topN);
+  const topResumeIDs = topRuleResults.map((result) => result.resumeId);
+  if (topResumeIDs.length === 0) {
+    console.log(JSON.stringify({
+      success: true,
+      source,
+      jobDescriptionId: input.jobDescriptionId?.trim() || `keyword-search:${keywords.join("|")}`,
+      results: [],
+      stats: {
+        processed: 0,
+        ruleAvg: 0,
+        aiScoreAvg: 0,
+      },
+    }));
+    return;
+  }
+
+  const hydratedResumes = await hydrateConvexResumes(topResumeIDs);
+  const jobDescription = buildJobDescription(input, keywords);
+  const aiPayloads = topResumeIDs
+    .map((resumeId) => {
+      const resume = hydratedResumes.get(resumeId);
+      if (!resume) return null;
+      return buildMatchingResumePayload(resumeId, resume);
+    })
+    .filter((entry): entry is MatchingRequest["resume"] => entry !== null);
+
+  const aiBatch = await aiService.matchBatch(aiPayloads, {
+    title: jobDescription.title,
+    requirements: jobDescription.requirements,
+    responsibilities: jobDescription.responsibilities,
+  });
+
+  const aiByResumeID = new Map(aiBatch.results.map((entry) => [entry.resumeId, entry.result]));
+  const results = topRuleResults
+    .map((ruleEntry) => {
+      const aiResult = aiByResumeID.get(ruleEntry.resumeId);
+      const hydrated = hydratedResumes.get(ruleEntry.resumeId);
+      if (!aiResult || !hydrated) {
+        return null;
+      }
+
+      return {
+        resumeId: ruleEntry.resumeId,
+        name: hydrated.name || "",
+        location: hydrated.location || "",
+        profileUrl: hydrated.profileUrl || "",
+        ruleScore: ruleEntry.score,
+        aiScore: aiResult.score,
+        recommendation: aiResult.recommendation,
+        summary: aiResult.summary,
+        highlights: aiResult.highlights,
+        concerns: aiResult.concerns,
+        rawResponse: aiResult.rawResponse || "",
+      };
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    .sort((left, right) => right.aiScore - left.aiScore || right.ruleScore - left.ruleScore);
+
+  console.log(JSON.stringify({
+    success: true,
+    source,
+    jobDescriptionId: jobDescription.jobDescriptionId,
+    results,
+    stats: {
+      processed: results.length,
+      ruleAvg: average(results.map((result) => result.ruleScore)),
+      aiScoreAvg: average(results.map((result) => result.aiScore)),
+    },
+  }));
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `trends resume debug` commands for cached matches, match runs, rescore, skills version, reingest, and explicit local AI scoring
- add typed CLI client bindings plus read-only MCP tools for the new resume debug inspection surfaces
- fix resume AI prompt placeholder validation and update the existing `trends-cli` skill package for the new debug/dev-cycle workflow

## Verification
- `go test ./...` in `packages/cli`
- `bunx vitest run apps/api/src/services/resume-ai-prompt-service.test.ts`
- `go run . --api-url http://localhost:3000 --workspace dev -o json resume debug ai-score --query 'CNC 销售' --limit 5 --top-n 1`
- `make check`
