### PR TITLE
feat(skills): support codex and agents install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,9 +301,9 @@ check-resume-ai-prompts:
 		npx tsx scripts/resume/sync-ai-prompts.ts --check; \
 	fi
 
-# Install repo governance skill into ${CODEX_HOME:-$HOME/.codex}/skills
+# Install repo governance skill into the requested skills target (default: ${CODEX_HOME:-$HOME/.codex}/skills)
 install-agent-skill:
-	@./scripts/skills/install-skill.sh --skill trends-agent-governance
+	@./scripts/skills/install-skill.sh --skill trends-agent-governance --target "$(or $(TARGET),codex)"
 
 # Validate repo governance skill structure + installed skill sync (local only)
 check-agent-skill:
@@ -315,16 +315,16 @@ check-agent-skill:
 	@if [ "$$CI" = "true" ]; then \
 		echo "Skipping installed skill drift check in CI"; \
 	else \
-		./scripts/skills/install-skill.sh --skill trends-agent-governance --check; \
+		./scripts/skills/install-skill.sh --skill trends-agent-governance --target "$(or $(TARGET),codex)" --check; \
 	fi
 
-# Install any repo skill into ${CODEX_HOME:-$HOME/.codex}/skills
+# Install any repo skill into the requested skills target (default: ${CODEX_HOME:-$HOME/.codex}/skills)
 install-skill:
 	@if [ -z "$(SKILL)" ]; then \
-		echo "SKILL is required. Usage: make install-skill SKILL=<skill-name>"; \
+		echo "SKILL is required. Usage: make install-skill SKILL=<skill-name> [TARGET=codex|agents|all]"; \
 		exit 1; \
 	fi
-	@./scripts/skills/install-skill.sh --skill "$(SKILL)"
+	@./scripts/skills/install-skill.sh --skill "$(SKILL)" --target "$(or $(TARGET),codex)"
 
 # Validate skill structure for any repo skill
 validate-skill:
@@ -341,10 +341,10 @@ validate-skill:
 # Check installed skill drift for any repo skill
 check-skill-install:
 	@if [ -z "$(SKILL)" ]; then \
-		echo "SKILL is required. Usage: make check-skill-install SKILL=<skill-name>"; \
+		echo "SKILL is required. Usage: make check-skill-install SKILL=<skill-name> [TARGET=codex|agents|all]"; \
 		exit 1; \
 	fi
-	@./scripts/skills/install-skill.sh --skill "$(SKILL)" --check
+	@./scripts/skills/install-skill.sh --skill "$(SKILL)" --target "$(or $(TARGET),codex)" --check
 
 # Install resume-qa-hybrid-mcp skill into ${CODEX_HOME:-$HOME/.codex}/skills
 install-test-plan-skill:
@@ -771,11 +771,11 @@ help:
 	@echo "  fetch-docs     Fetch latest upstream documentation"
 	@echo "  sync-agent-policy Sync generated dev-docs/AGENTS.md from canonical AGENTS policy"
 	@echo "  check-agent-policy Validate generated dev-docs/AGENTS.md is up to date"
-	@echo "  install-agent-skill Install governance skill into ~/.codex/skills"
+	@echo "  install-agent-skill [TARGET=codex|agents|all] Install governance skill into the selected skills dir"
 	@echo "  check-agent-skill Validate governance skill, command, rules file, and installed copy drift"
-	@echo "  install-skill SKILL=<name> Install any repo skill into ~/.codex/skills"
+	@echo "  install-skill SKILL=<name> [TARGET=codex|agents|all] Install any repo skill into the selected skills dir"
 	@echo "  validate-skill SKILL=<name> Validate skill structure from SKILL.md frontmatter"
-	@echo "  check-skill-install SKILL=<name> Validate installed skill sync with repo source"
+	@echo "  check-skill-install SKILL=<name> [TARGET=codex|agents|all] Validate installed skill sync with repo source"
 	@echo "  install-test-plan-skill Install resume-qa-hybrid-mcp skill into ~/.codex/skills"
 	@echo "  check-test-plan-skill Validate resume-qa-hybrid-mcp skill + installed drift"
 	@echo "  install-browser-ext-skill Install browser-extension-dev skill into ~/.codex/skills"

--- a/dev-docs/skills/trends-cli/SKILL.md
+++ b/dev-docs/skills/trends-cli/SKILL.md
@@ -12,7 +12,10 @@ Use this skill when the user asks to operate backend services from terminal comm
 ## Workflow
 
 1. Build the CLI when binaries are missing or stale: `make cli-build`.
-2. Install or refresh the skill when you want the packaged workflow available in Codex: `make install-skill SKILL=trends-cli`.
+2. Install or refresh the skill from this canonical repo copy when you want the packaged workflow available in Codex or other agent managers:
+   - `make install-skill SKILL=trends-cli`
+   - `make install-skill SKILL=trends-cli TARGET=agents`
+   - `make install-skill SKILL=trends-cli TARGET=all`
 3. Prefer CLI commands over ad-hoc curl scripts for supported operations.
 4. Use `--output json` when command output needs to be consumed by other tools.
 5. Use `trends mcp serve` when integration requires MCP tool exposure.
@@ -43,6 +46,7 @@ Use this skill when the user asks to operate backend services from terminal comm
 ## Rules
 
 - Run commands from repository root.
+- Keep `dev-docs/skills/trends-cli` as the only editable source; install into `~/.codex/skills` and/or `~/.agents/skills` from that source instead of maintaining duplicate copies.
 - Keep `--api-url` and `--worker-url` aligned with running services.
 - `trends resume match` remains the API-backed path; when `source=convex` and AI scoring is needed for debug, use `trends resume debug ai-score`.
 - `trends resume debug rescore` currently mirrors the backend restriction and is sample-only.

--- a/scripts/skills/install-skill.sh
+++ b/scripts/skills/install-skill.sh
@@ -3,10 +3,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-DEST_ROOT="${CODEX_HOME:-$HOME/.codex}/skills"
+CODEX_DEST_ROOT="${CODEX_HOME:-$HOME/.codex}/skills"
+AGENTS_DEST_ROOT="${AGENTS_HOME:-$HOME/.agents}/skills"
 
 usage() {
-  echo "Usage: $0 --skill <skill-name> [--check]"
+  echo "Usage: $0 --skill <skill-name> [--target codex|agents|all] [--check]"
+  echo "Default target: codex"
 }
 
 require_tool() {
@@ -19,6 +21,7 @@ require_tool() {
 
 SKILL_NAME=""
 CHECK_ONLY=false
+TARGET="codex"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -34,6 +37,15 @@ while [[ $# -gt 0 ]]; do
     --check)
       CHECK_ONLY=true
       shift
+      ;;
+    --target)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --target" >&2
+        usage
+        exit 1
+      fi
+      TARGET="$2"
+      shift 2
       ;;
     --help|-h)
       usage
@@ -59,8 +71,13 @@ if [[ ! "$SKILL_NAME" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
   exit 1
 fi
 
+if [[ ! "$TARGET" =~ ^(codex|agents|all)$ ]]; then
+  echo "Invalid target: $TARGET" >&2
+  echo "Expected one of: codex, agents, all" >&2
+  exit 1
+fi
+
 SOURCE_DIR="$REPO_ROOT/dev-docs/skills/$SKILL_NAME"
-DEST_DIR="$DEST_ROOT/$SKILL_NAME"
 
 if [[ ! -d "$SOURCE_DIR" ]]; then
   echo "Missing source skill directory: $SOURCE_DIR" >&2
@@ -69,25 +86,44 @@ fi
 
 require_tool rsync
 
+target_roots=()
+case "$TARGET" in
+  codex)
+    target_roots=("$CODEX_DEST_ROOT")
+    ;;
+  agents)
+    target_roots=("$AGENTS_DEST_ROOT")
+    ;;
+  all)
+    target_roots=("$CODEX_DEST_ROOT" "$AGENTS_DEST_ROOT")
+    ;;
+esac
+
 if [[ "$CHECK_ONLY" == "true" ]]; then
-  if [[ ! -d "$DEST_DIR" ]]; then
-    echo "Installed skill not found: $DEST_DIR" >&2
-    echo "Run: make install-skill SKILL=$SKILL_NAME" >&2
-    exit 1
-  fi
+  for dest_root in "${target_roots[@]}"; do
+    dest_dir="$dest_root/$SKILL_NAME"
+    if [[ ! -d "$dest_dir" ]]; then
+      echo "Installed skill not found: $dest_dir" >&2
+      echo "Run: make install-skill SKILL=$SKILL_NAME TARGET=$TARGET" >&2
+      exit 1
+    fi
 
-  DRIFT_OUTPUT="$(rsync -ani --delete "$SOURCE_DIR"/ "$DEST_DIR"/)"
-  if [[ -n "$DRIFT_OUTPUT" ]]; then
-    echo "Installed skill drift detected at $DEST_DIR" >&2
-    echo "$DRIFT_OUTPUT" >&2
-    echo "Run: make install-skill SKILL=$SKILL_NAME" >&2
-    exit 1
-  fi
+    DRIFT_OUTPUT="$(rsync -ani --delete "$SOURCE_DIR"/ "$dest_dir"/)"
+    if [[ -n "$DRIFT_OUTPUT" ]]; then
+      echo "Installed skill drift detected at $dest_dir" >&2
+      echo "$DRIFT_OUTPUT" >&2
+      echo "Run: make install-skill SKILL=$SKILL_NAME TARGET=$TARGET" >&2
+      exit 1
+    fi
 
-  echo "Installed skill is up to date: $DEST_DIR"
+    echo "Installed skill is up to date: $dest_dir"
+  done
   exit 0
 fi
 
-mkdir -p "$DEST_ROOT"
-rsync -a --delete "$SOURCE_DIR"/ "$DEST_DIR"/
-echo "Installed skill to $DEST_DIR"
+for dest_root in "${target_roots[@]}"; do
+  dest_dir="$dest_root/$SKILL_NAME"
+  mkdir -p "$dest_dir"
+  rsync -a --delete "$SOURCE_DIR"/ "$dest_dir"/
+  echo "Installed skill to $dest_dir"
+done


### PR DESCRIPTION
## Summary
- add explicit codex/agents/all skill install targets to the shared installer
- thread TARGET through Makefile skill install and drift-check commands
- document the canonical single-source trends-cli packaging flow for ~/.codex/skills and ~/.agents/skills

## Testing
- make validate-skill SKILL=trends-cli
- make install-skill SKILL=trends-cli TARGET=all
- ./scripts/skills/install-skill.sh --skill trends-cli --target all --check
- make check