### PR TITLE
fix(skills): avoid mtime-only drift failures

### DIFF
--- a/scripts/skills/install-skill.sh
+++ b/scripts/skills/install-skill.sh
@@ -108,7 +108,7 @@ if [[ "$CHECK_ONLY" == "true" ]]; then
       exit 1
     fi
 
-    DRIFT_OUTPUT="$(rsync -ani --delete "$SOURCE_DIR"/ "$dest_dir"/)"
+    DRIFT_OUTPUT="$(rsync --dry-run --itemize-changes --recursive --links --perms --checksum --delete "$SOURCE_DIR"/ "$dest_dir"/)"
     if [[ -n "$DRIFT_OUTPUT" ]]; then
       echo "Installed skill drift detected at $dest_dir" >&2
       echo "$DRIFT_OUTPUT" >&2


### PR DESCRIPTION
## Summary
- switch skill drift checks away from rsync archive mode so mtime-only differences do not fail installs
- keep drift detection content-based for both ~/.codex/skills and ~/.agents/skills targets
- verify the original failing command now passes from main-installed trends-cli copies

## Testing
- make check-skill-install SKILL=trends-cli TARGET=all
- ./scripts/skills/install-skill.sh --skill trends-cli --target all --check
- make check