### PR TITLE
chore(make): document install-deps skill target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -759,7 +759,7 @@ help:
 	@echo "  i18n-build     Build static sites for all locales"
 	@echo ""
 	@echo "Dependencies:"
-	@echo "  install-deps   Install Python/Node deps for development"
+	@echo "  install-deps [SKILL_INSTALL_TARGET=codex|agents|all] Install deps and bootstrap governance skill targets"
 	@echo "  prefetch-convex Prefetch Convex local backend + dashboard assets"
 	@echo ""
 	@echo "CLI:"


### PR DESCRIPTION
## Summary
- update `make help` so `install-deps` advertises the shipped `SKILL_INSTALL_TARGET` bootstrap option
- keep the help text aligned with the target-aware governance skill bootstrap added in `scripts/install-deps.sh`
- verify help output and rerun the full repo check

## Testing
- make help | rg -n "install-deps|install-agent-skill|install-skill SKILL="
- make check