### PR TITLE
chore(docs): document install-deps skill target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,8 @@ Required flow:
 
 ### Start Development
 ```bash
-make install-deps
+make install-deps                           # Default: bootstrap governance skill into ~/.codex/skills
+SKILL_INSTALL_TARGET=all make install-deps  # Optional: also bootstrap ~/.agents/skills
 make dev                # Full local stack
 make dev-fast           # UI-focused fast profile
 make dev-critical       # Critical path profile


### PR DESCRIPTION
## Summary
- update the canonical CLAUDE/AGENTS start-development runbook to show the new `SKILL_INSTALL_TARGET` install-deps option
- keep the docs aligned with the already-shipped target-aware governance skill bootstrap
- verify the policy mirror stays in sync after the documentation change

## Testing
- make sync-agent-policy
- make check-agent-policy