### PR TITLE
chore(skill): document trends-cli bootstrap flow

### DIFF
--- a/dev-docs/skills/trends-cli/SKILL.md
+++ b/dev-docs/skills/trends-cli/SKILL.md
@@ -11,15 +11,18 @@ Use this skill when the user asks to operate backend services from terminal comm
 
 ## Workflow
 
-1. Build the CLI when binaries are missing or stale: `make cli-build`.
-2. Install or refresh the skill from this canonical repo copy when you want the packaged workflow available in Codex or other agent managers:
+1. Bootstrap local dependencies and default governance skill setup when the environment may be stale:
+   - `make install-deps`
+   - `SKILL_INSTALL_TARGET=all make install-deps`
+2. Build the CLI when binaries are missing or stale: `make cli-build`.
+3. Install or refresh the skill from this canonical repo copy when you want the packaged workflow available in Codex or other agent managers:
    - `make install-skill SKILL=trends-cli`
    - `make install-skill SKILL=trends-cli TARGET=agents`
    - `make install-skill SKILL=trends-cli TARGET=all`
-3. Prefer CLI commands over ad-hoc curl scripts for supported operations.
-4. Use `--output json` when command output needs to be consumed by other tools.
-5. Use `trends mcp serve` when integration requires MCP tool exposure.
-6. For live Convex AI debug work, prefer `trends resume debug ai-score` over forcing unsupported API match modes.
+4. Prefer CLI commands over ad-hoc curl scripts for supported operations.
+5. Use `--output json` when command output needs to be consumed by other tools.
+6. Use `trends mcp serve` when integration requires MCP tool exposure.
+7. For live Convex AI debug work, prefer `trends resume debug ai-score` over forcing unsupported API match modes.
 
 ## Commands
 
@@ -46,6 +49,7 @@ Use this skill when the user asks to operate backend services from terminal comm
 ## Rules
 
 - Run commands from repository root.
+- `make install-deps` bootstraps the governance skill by default into `~/.codex/skills`; use `SKILL_INSTALL_TARGET=all make install-deps` when local setup should also refresh `~/.agents/skills`.
 - Keep `dev-docs/skills/trends-cli` as the only editable source; install into `~/.codex/skills` and/or `~/.agents/skills` from that source instead of maintaining duplicate copies.
 - Keep `--api-url` and `--worker-url` aligned with running services.
 - `trends resume match` remains the API-backed path; when `source=convex` and AI scoring is needed for debug, use `trends resume debug ai-score`.

--- a/dev-docs/skills/trends-cli/agents/openai.yaml
+++ b/dev-docs/skills/trends-cli/agents/openai.yaml
@@ -1,3 +1,3 @@
 display_name: Trends CLI
 short_description: Operate Trends backend services and resume debug flows through the Go CLI and MCP mode.
-default_prompt: Use the trends-cli workflow. Build the CLI if needed, prefer CLI commands over ad-hoc API calls, use `resume debug` for cache/reingest/AI dev-cycle tasks, and report concise command output with follow-up actions.
+default_prompt: Use the trends-cli workflow. Run `make install-deps` when the local environment may be stale, build the CLI if needed, prefer CLI commands over ad-hoc API calls, use `resume debug` for cache/reingest/AI dev-cycle tasks, and report concise command output with follow-up actions.


### PR DESCRIPTION
## Summary
- update the packaged `trends-cli` skill to mention the canonical `make install-deps` bootstrap flow
- include the dual-manager `SKILL_INSTALL_TARGET=all make install-deps` setup path alongside direct skill installs
- refresh the skill UI metadata prompt so it stays aligned with the skill body

## Testing
- make validate-skill SKILL=trends-cli
- make install-skill SKILL=trends-cli TARGET=all
- make check-skill-install SKILL=trends-cli TARGET=all