### PR TITLE
chore(make): document sync-agent-governance target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -780,7 +780,7 @@ help:
 	@echo "  check-test-plan-skill [TARGET=codex|agents|all] Validate resume-qa-hybrid-mcp skill + installed drift"
 	@echo "  install-browser-ext-skill [TARGET=codex|agents|all] Install browser-extension-dev into the selected skills dir"
 	@echo "  check-browser-ext-skill [TARGET=codex|agents|all] Validate browser-extension-dev skill + installed drift"
-	@echo "  sync-agent-governance Run policy sync + skill install"
+	@echo "  sync-agent-governance [TARGET=codex|agents|all] Run policy sync + governance skill install"
 	@echo ""
 	@echo "Utilities:"
 	@echo "  seed           Seed Convex with system job descriptions"


### PR DESCRIPTION
## Summary
- update `make help` so `sync-agent-governance` advertises the supported `TARGET=codex|agents|all` option
- keep the help line aligned with the existing target-aware sync behavior
- verify the target-specific sync path and rerun the full repo check

## Testing
- make sync-agent-governance TARGET=agents
- make help | rg -n "sync-agent-governance|install-agent-skill|check-agent-skill"
- make check