### PR TITLE
chore(docs): document sync-agent-governance usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ make sync-agent-policy
 make check-agent-policy
 make check-agent-skill              # Default: validate ~/.codex/skills copy
 make check-agent-skill TARGET=all   # Optional: validate ~/.codex/skills and ~/.agents/skills
+TARGET=all make sync-agent-governance  # Optional: run policy sync + governance skill install in both roots
 ```
 
 ## Code Style & Safety


### PR DESCRIPTION
## Summary
- update the canonical CLAUDE Governance Sync section to include the target-aware `sync-agent-governance` convenience command
- keep the runbook aligned with the already-documented make help surface
- verify the real convenience command and rerun the full repo check

## Testing
- TARGET=all make sync-agent-governance
- make check-agent-policy
- make check-agent-skill TARGET=all
- make check