### PR TITLE
chore(docs): document target-aware make check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,8 @@ make dev-crawl
 
 ### Verification
 ```bash
-make check
+make check                  # Default: validate ~/.codex/skills governance install
+make check TARGET=all       # Optional: validate governance installs in both skill roots
 make check-node
 make check-python
 npm test

--- a/Makefile
+++ b/Makefile
@@ -603,7 +603,7 @@ fresh-env: clean clean-db
 	$(MAKE) install-deps
 	@echo "Fresh environment ready."
 
-# Run all validation checks (Python + Node.js)
+# Run all validation checks (Python + Node.js + governance skill validation; honors TARGET=all)
 check: check-python check-node check-agent-policy check-agent-skill
 	@echo "All checks passed"
 
@@ -800,7 +800,7 @@ help:
 	@echo "  refresh-sample-manual Show manual instructions for refreshing resume sample data"
 	@echo "  chrome-debug   Start Google Chrome with remote debugging (port 9222)"
 	@echo "  clean          Remove generated/cached files"
-	@echo "  check          Run validation checks (Python + Node)"
+	@echo "  check [TARGET=codex|agents|all] Run validation checks (Python + Node + governance skill validation)"
 	@echo "  check-python   Run Python checks only"
 	@echo "  check-node     Run Node.js checks only"
 	@echo "  check-build    Run checks + build validation"


### PR DESCRIPTION
## Summary
- update `make help` so `check` advertises the supported `TARGET=codex|agents|all` option
- update the canonical Verification runbook in `CLAUDE.md` to show the optional `make check TARGET=all` path
- clarify the Makefile comment so the `check` target behavior matches the docs

## Testing
- make help | rg -n "check [TARGET=codex|agents|all]|check-agent-skill [TARGET=codex|agents|all]"
- make check TARGET=all