### PR TITLE
chore(docs): document target-aware check-build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ make dev-crawl
 ```bash
 make check                  # Default: validate ~/.codex/skills governance install
 make check TARGET=all       # Optional: validate governance installs in both skill roots
+make check-build TARGET=all # Optional: include build validation after dual-root governance checks
 make check-node
 make check-python
 npm test

--- a/Makefile
+++ b/Makefile
@@ -803,7 +803,7 @@ help:
 	@echo "  check [TARGET=codex|agents|all] Run validation checks (Python + Node + governance skill validation)"
 	@echo "  check-python   Run Python checks only"
 	@echo "  check-node     Run Node.js checks only"
-	@echo "  check-build    Run checks + build validation"
+	@echo "  check-build [TARGET=codex|agents|all] Run checks + build validation"
 	@echo "  test           Run all tests (Python + Node)"
 	@echo "  test-python    Run Python tests only"
 	@echo "  test-node      Run Node.js tests only"


### PR DESCRIPTION
## Summary
- update `make help` so `check-build` advertises the supported `TARGET=codex|agents|all` option
- update the canonical Verification runbook in `CLAUDE.md` to show the optional `make check-build TARGET=all` path
- verify the actual build-validation behavior with the dual-root governance validation path enabled

## Testing
- make help | rg -n "check-build [TARGET=codex|agents|all]|check [TARGET=codex|agents|all]"
- make check-build TARGET=all