### PR TITLE
chore(make): align governance comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ check-resume-ai-prompts:
 install-agent-skill:
 	@./scripts/skills/install-skill.sh --skill trends-agent-governance --target "$(or $(TARGET),codex)"
 
-# Validate repo governance skill structure + installed skill sync (local only)
+# Validate repo governance skill structure + installed skill sync for the selected local target
 check-agent-skill:
 	@if command -v bun > /dev/null 2>&1; then \
 		bunx tsx scripts/skills/validate-skill.ts --skill trends-agent-governance; \


### PR DESCRIPTION
## Summary
- update the stale comment above `check-agent-skill` so it matches the current target-aware local validation behavior
- keep the Makefile source comments aligned with the already-shipped operator surface
- rerun the full repo check after the one-line cleanup

## Testing
- make check