### PR TITLE
chore(skills): clarify installer help

### DIFF
--- a/scripts/skills/install-skill.sh
+++ b/scripts/skills/install-skill.sh
@@ -9,6 +9,11 @@ AGENTS_DEST_ROOT="${AGENTS_HOME:-$HOME/.agents}/skills"
 usage() {
   echo "Usage: $0 --skill <skill-name> [--target codex|agents|all] [--check]"
   echo "Default target: codex"
+  echo "Targets:"
+  echo "  codex  -> $CODEX_DEST_ROOT"
+  echo "  agents -> $AGENTS_DEST_ROOT"
+  echo "  all    -> both roots"
+  echo "Env overrides: CODEX_HOME, AGENTS_HOME"
 }
 
 require_tool() {


### PR DESCRIPTION
## Summary
- expand `scripts/skills/install-skill.sh --help` so it documents the codex/agents/all destination mapping
- expose `CODEX_HOME` and `AGENTS_HOME` as the supported env overrides in the help output
- verify the help text and rerun the full repo check

## Testing
- ./scripts/skills/install-skill.sh --help
- make check