### PR TITLE
chore(make): mention skill env overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -781,6 +781,7 @@ help:
 	@echo "  install-browser-ext-skill [TARGET=codex|agents|all] Install browser-extension-dev into the selected skills dir"
 	@echo "  check-browser-ext-skill [TARGET=codex|agents|all] Validate browser-extension-dev skill + installed drift"
 	@echo "  sync-agent-governance [TARGET=codex|agents|all] Run policy sync + governance skill install"
+	@echo "                     Skill roots honor CODEX_HOME and AGENTS_HOME when set"
 	@echo ""
 	@echo "Utilities:"
 	@echo "  seed           Seed Convex with system job descriptions"


### PR DESCRIPTION
## Summary
- add a short `make help` note that the skill-install surfaces honor `CODEX_HOME` and `AGENTS_HOME`
- keep the repo-level help output aligned with the low-level installer `--help` output
- verify the updated help text and rerun the full repo check

## Testing
- make help | rg -n "install-agent-skill|install-skill SKILL=|sync-agent-governance|CODEX_HOME|AGENTS_HOME"
- make check