### PR TITLE
chore(skill): mention skill root env overrides

### DIFF
--- a/dev-docs/skills/trends-cli/SKILL.md
+++ b/dev-docs/skills/trends-cli/SKILL.md
@@ -50,7 +50,7 @@ Use this skill when the user asks to operate backend services from terminal comm
 
 - Run commands from repository root.
 - `make install-deps` bootstraps the governance skill by default into `~/.codex/skills`; use `SKILL_INSTALL_TARGET=all make install-deps` when local setup should also refresh `~/.agents/skills`.
-- Keep `dev-docs/skills/trends-cli` as the only editable source; install into `~/.codex/skills` and/or `~/.agents/skills` from that source instead of maintaining duplicate copies.
+- Keep `dev-docs/skills/trends-cli` as the only editable source; install into `~/.codex/skills` and/or `~/.agents/skills` from that source instead of maintaining duplicate copies. `CODEX_HOME` and `AGENTS_HOME` can override those roots when needed.
 - Keep `--api-url` and `--worker-url` aligned with running services.
 - `trends resume match` remains the API-backed path; when `source=convex` and AI scoring is needed for debug, use `trends resume debug ai-score`.
 - `trends resume debug rescore` currently mirrors the backend restriction and is sample-only.


### PR DESCRIPTION
## Summary
- update the packaged `trends-cli` skill so it mentions `CODEX_HOME` and `AGENTS_HOME` as overrides for the default skill roots
- keep the skill guidance aligned with the repo help surface and the low-level installer `--help`
- validate and resync both installed `trends-cli` copies after the doc update

## Testing
- make validate-skill SKILL=trends-cli
- make install-skill SKILL=trends-cli TARGET=all
- make check-skill-install SKILL=trends-cli TARGET=all