### PR TITLE
chore(scripts): add install-deps help

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,6 +1,30 @@
 #!/bin/bash
 set -e
 
+usage() {
+    echo "Usage: $0 [--help]"
+    echo "Installs local Python/Node dependencies and bootstraps governance artifacts."
+    echo ""
+    echo "Environment:"
+    echo "  SKILL_INSTALL_TARGET   Governance skill install target: codex|agents|all (default: codex)"
+    echo "  CONVEX_MIRROR_MODE     Convex prefetch mode override: off|fallback|mirror"
+    echo "  CI                     When true, uses npm and skips governance sync"
+}
+
+if [ "$#" -gt 0 ]; then
+    case "$1" in
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+fi
+
 resolve_convex_mirror_mode() {
     if [ -n "${CONVEX_MIRROR_MODE:-}" ]; then
         echo "${CONVEX_MIRROR_MODE}"


### PR DESCRIPTION
## Summary
- add a small `--help` / `-h` usage surface to `scripts/install-deps.sh`
- document the supported env knobs (`SKILL_INSTALL_TARGET`, `CONVEX_MIRROR_MODE`, `CI`) directly in the script help output
- make unknown positional arguments fail fast with the same usage text

## Testing
- ./scripts/install-deps.sh --help
- ./scripts/install-deps.sh --bogus
- make check