### PR TITLE
chore(docs): document prefetch-convex env knobs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,8 @@ Required flow:
 ```bash
 make install-deps                           # Default: bootstrap governance skill into ~/.codex/skills
 SKILL_INSTALL_TARGET=all make install-deps  # Optional: also bootstrap ~/.agents/skills
+make prefetch-convex                        # Prefetch local Convex backend + dashboard cache
+CONVEX_MIRROR_MODE=mirror-first make prefetch-convex  # Optional: try configured mirrors before GitHub
 make dev                # Full local stack
 make dev-fast           # UI-focused fast profile
 make dev-critical       # Critical path profile

--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,7 @@ install-deps:
 	./scripts/install-deps.sh
 
 # Prefetch Convex local backend and dashboard assets into local cache
+# Honors CONVEX_MIRROR_MODE / CONVEX_MIRROR_BASES / timeout env knobs; see the script --help surface for details.
 prefetch-convex:
 	./scripts/prefetch-convex-backend.sh
 
@@ -760,7 +761,8 @@ help:
 	@echo ""
 	@echo "Dependencies:"
 	@echo "  install-deps [SKILL_INSTALL_TARGET=codex|agents|all] Install deps and bootstrap governance skill targets"
-	@echo "  prefetch-convex Prefetch Convex local backend + dashboard assets"
+	@echo "  prefetch-convex [CONVEX_MIRROR_MODE=off|fallback|mirror-first] Prefetch Convex local backend + dashboard assets"
+	@echo "                 See ./scripts/prefetch-convex-backend.sh --help for mirror bases, timeout, and curl env knobs"
 	@echo ""
 	@echo "CLI:"
 	@echo "  cli-build      Build Go CLI to bin/trends"


### PR DESCRIPTION
## Summary
- make `prefetch-convex` discoverable from `make help`
- point the repo help surface at the low-level script `--help` for the full env contract
- add the prefetch command examples to the canonical runbook in `CLAUDE.md`

## Validation
- `make help | rg -n "prefetch-convex|install-deps"`
- `sed -n '88,98p' CLAUDE.md`
- `make check`