### PR TITLE
chore(scripts): expand install-deps prefetch help

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -8,7 +8,13 @@ usage() {
     echo "Environment:"
     echo "  SKILL_INSTALL_TARGET   Governance skill install target: codex|agents|all (default: codex)"
     echo "  CONVEX_MIRROR_MODE     Convex prefetch mode override: off|fallback|mirror-first"
+    echo "  CONVEX_MIRROR_BASES    Convex prefetch mirror base URLs (comma-separated)"
+    echo "  CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
+    echo "                         Convex prefetch timeout overrides"
+    echo "  CONVEX_CURL_NO_SILENT  When true/1, keep Convex prefetch curl progress output enabled"
     echo "  CI                     When true, uses npm and skips governance sync"
+    echo ""
+    echo "See ./scripts/prefetch-convex-backend.sh --help for the full Convex prefetch env contract."
 }
 
 if [ "$#" -gt 0 ]; then


### PR DESCRIPTION
## Summary
- expand `scripts/install-deps.sh --help` so it reflects the broader Convex prefetch env contract it passes through
- mention mirror bases, timeout overrides, and curl verbosity alongside `CONVEX_MIRROR_MODE`
- point operators at `./scripts/prefetch-convex-backend.sh --help` for the full low-level contract

## Validation
- `./scripts/install-deps.sh --help`
- `./scripts/install-deps.sh --bogus`
- `make check`