### PR TITLE
chore(docs): document install-deps prefetch env knobs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Required flow:
 ```bash
 make install-deps                           # Default: bootstrap governance skill into ~/.codex/skills
 SKILL_INSTALL_TARGET=all make install-deps  # Optional: also bootstrap ~/.agents/skills
+CONVEX_MIRROR_MODE=mirror-first make install-deps  # Optional: mirror-first Convex prefetch during bootstrap
 make prefetch-convex                        # Prefetch local Convex backend + dashboard cache
 CONVEX_MIRROR_MODE=mirror-first make prefetch-convex  # Optional: try configured mirrors before GitHub
 make dev                # Full local stack

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ i18n-build:
 # Dependencies
 # =============================================================================
 
-# Install Python/Node dependencies for development
+# Install Python/Node dependencies for development, Convex prefetch, and governance bootstrap
 install-deps:
 	./scripts/install-deps.sh
 
@@ -760,7 +760,9 @@ help:
 	@echo "  i18n-build     Build static sites for all locales"
 	@echo ""
 	@echo "Dependencies:"
-	@echo "  install-deps [SKILL_INSTALL_TARGET=codex|agents|all] Install deps and bootstrap governance skill targets"
+	@echo "  install-deps [SKILL_INSTALL_TARGET=codex|agents|all] [CONVEX_MIRROR_MODE=off|fallback|mirror-first]"
+	@echo "               Install deps, prefetch Convex assets, and bootstrap governance skill targets"
+	@echo "               See ./scripts/install-deps.sh --help for mirror bases, timeout, and curl env knobs"
 	@echo "  prefetch-convex [CONVEX_MIRROR_MODE=off|fallback|mirror-first] Prefetch Convex local backend + dashboard assets"
 	@echo "                 See ./scripts/prefetch-convex-backend.sh --help for mirror bases, timeout, and curl env knobs"
 	@echo ""


### PR DESCRIPTION
## Summary
- make `install-deps` discoverable as both a bootstrap and Convex prefetch entrypoint
- point the repo help surface at `./scripts/install-deps.sh --help` for the broader prefetch env contract
- add the `CONVEX_MIRROR_MODE=mirror-first make install-deps` example to the canonical runbook

## Validation
- `make help | rg -n "install-deps|prefetch-convex|CONVEX_MIRROR_MODE|SKILL_INSTALL_TARGET"`
- `sed -n '88,101p' CLAUDE.md`
- `make check`