### PR TITLE
chore(skill): document trends-cli prefetch knobs

### DIFF
--- a/dev-docs/skills/trends-cli/SKILL.md
+++ b/dev-docs/skills/trends-cli/SKILL.md
@@ -14,6 +14,8 @@ Use this skill when the user asks to operate backend services from terminal comm
 1. Bootstrap local dependencies and default governance skill setup when the environment may be stale:
    - `make install-deps`
    - `SKILL_INSTALL_TARGET=all make install-deps`
+   - `CONVEX_MIRROR_MODE=mirror-first make install-deps`
+   - `make prefetch-convex`
 2. Build the CLI when binaries are missing or stale: `make cli-build`.
 3. Install or refresh the skill from this canonical repo copy when you want the packaged workflow available in Codex or other agent managers:
    - `make install-skill SKILL=trends-cli`
@@ -50,6 +52,7 @@ Use this skill when the user asks to operate backend services from terminal comm
 
 - Run commands from repository root.
 - `make install-deps` bootstraps the governance skill by default into `~/.codex/skills`; use `SKILL_INSTALL_TARGET=all make install-deps` when local setup should also refresh `~/.agents/skills`.
+- `CONVEX_MIRROR_MODE=mirror-first make install-deps` is the repo-level bootstrap path when Convex asset prefetch should try configured mirrors before GitHub, and `make prefetch-convex` is the focused prefetch-only escape hatch. Use `./scripts/install-deps.sh --help` or `./scripts/prefetch-convex-backend.sh --help` when mirror-base, timeout, or curl verbosity knobs matter.
 - Keep `dev-docs/skills/trends-cli` as the only editable source; install into `~/.codex/skills` and/or `~/.agents/skills` from that source instead of maintaining duplicate copies. `CODEX_HOME` and `AGENTS_HOME` can override those roots when needed.
 - Keep `--api-url` and `--worker-url` aligned with running services.
 - `trends resume match` remains the API-backed path; when `source=convex` and AI scoring is needed for debug, use `trends resume debug ai-score`.

--- a/dev-docs/skills/trends-cli/agents/openai.yaml
+++ b/dev-docs/skills/trends-cli/agents/openai.yaml
@@ -1,3 +1,3 @@
 display_name: Trends CLI
 short_description: Operate Trends backend services and resume debug flows through the Go CLI and MCP mode.
-default_prompt: Use the trends-cli workflow. Run `make install-deps` when the local environment may be stale, build the CLI if needed, prefer CLI commands over ad-hoc API calls, use `resume debug` for cache/reingest/AI dev-cycle tasks, and report concise command output with follow-up actions.
+default_prompt: Use the trends-cli workflow. Run `make install-deps` when the local environment may be stale, use `CONVEX_MIRROR_MODE=mirror-first make install-deps` or `make prefetch-convex` when Convex asset prefetch behavior matters, build the CLI if needed, prefer CLI commands over ad-hoc API calls, use `resume debug` for cache/reingest/AI dev-cycle tasks, and report concise command output with follow-up actions.


### PR DESCRIPTION
## Summary
- update the packaged `trends-cli` skill so it reflects the current install-deps and prefetch-convex operator surface
- add the mirror-first bootstrap example and direct prefetch command to the skill workflow/rules
- align the OpenAI skill metadata prompt with the new Convex prefetch guidance

## Validation
- `make validate-skill SKILL=trends-cli`
- `make install-skill SKILL=trends-cli TARGET=all`
- `make check-skill-install SKILL=trends-cli TARGET=all`
- `make check`