### PR TITLE
chore(docs): add deployment runbook section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,14 @@ make dev-mcp
 make dev-crawl
 ```
 
+### Deployment
+```bash
+make install                                # Install the production stack from the current checkout
+ENV_FILE=.env.production make deploy-check  # Dry run the deploy precheck against the target env
+CONVEX_MIRROR_MODE=mirror-first make deploy # Optional: mirror-first Convex prefetch during upgrade
+./scripts/install.sh --help                 # Full install/upgrade modes plus production prefetch env knobs
+```
+
 ### Verification
 ```bash
 make check                  # Default: validate ~/.codex/skills governance install


### PR DESCRIPTION
## Summary
- add a Deployment subsection to the canonical CLAUDE runbook
- show the production install/deploy-check flow plus the mirror-first deploy override path
- point operators at `./scripts/install.sh --help` for the full production installer contract

## Validation
- `sed -n '100,121p' CLAUDE.md`
- `./scripts/install.sh --help | sed -n '1,12p'`
- `make check`