### PR TITLE
chore(docs): document seeded deployment paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,10 @@ make dev-crawl
 ### Deployment
 ```bash
 make install                                # Install the production stack from the current checkout
+make install-seed                           # Install the production stack with seeded demo resumes
 ENV_FILE=.env.production make deploy-check  # Dry run the deploy precheck against the target env
 CONVEX_MIRROR_MODE=mirror-first make deploy # Optional: mirror-first Convex prefetch during upgrade
+make deploy-seed                            # Force a full upgrade with seeded demo resumes
 ./scripts/install.sh --help                 # Full install/upgrade modes plus production prefetch env knobs
 ```
 


### PR DESCRIPTION
## Summary
- extend the canonical CLAUDE Deployment subsection with the seeded production wrappers
- keep the runbook aligned with the Makefile help surface for `install-seed` and `deploy-seed`
- preserve `./scripts/install.sh --help` as the canonical low-level production installer reference

## Validation
- `sed -n '109,120p' CLAUDE.md`
- `make help | sed -n '27,35p'`
- `make check`