### PR TITLE
chore(docs): link dev help surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ make dev                # Full local stack
 make dev-fast           # UI-focused fast profile
 make dev-critical       # Critical path profile
 make dev-backend        # Backend-focused profile
+./scripts/dev.sh --help # Full dev service-profile and Convex startup/prefetch env contract
 ```
 
 ### Start Single Services


### PR DESCRIPTION
## Summary
- add the low-level `./scripts/dev.sh --help` reference to the canonical Start Development runbook
- keep the canonical runbook aligned with the repo-level Makefile help surface for dev entrypoints
- point operators at the full service-profile and Convex startup/prefetch contract behind the `make dev*` wrappers

## Validation
- `sed -n '89,100p' CLAUDE.md`
- `./scripts/dev.sh --help | sed -n '1,18p'`
- `make check`