### PR TITLE
chore(scripts): clarify install-deps prefetch defaults

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -8,11 +8,12 @@ usage() {
     echo "Environment:"
     echo "  SKILL_INSTALL_TARGET   Governance skill install target: codex|agents|all (default: codex)"
     echo "  CONVEX_MIRROR_MODE     Convex prefetch mode override: off|fallback|mirror-first"
+    echo "                         Default is fallback, or off when CI=true"
     echo "  CONVEX_MIRROR_BASES    Convex prefetch mirror base URLs (comma-separated)"
     echo "  CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
     echo "                         Convex prefetch timeout overrides"
     echo "  CONVEX_CURL_NO_SILENT  When true/1, keep Convex prefetch curl progress output enabled"
-    echo "  CI                     When true, uses npm and skips governance sync"
+    echo "  CI                     When true, uses npm, skips governance sync, and defaults prefetch mode to off"
     echo ""
     echo "See ./scripts/prefetch-convex-backend.sh --help for the full Convex prefetch env contract."
 }


### PR DESCRIPTION
## Summary
- clarify the install-deps help surface so it reflects the real Convex prefetch default behavior
- document that CI flips the default prefetch mode to off unless CONVEX_MIRROR_MODE is explicitly set

## Validation
- ./scripts/install-deps.sh --help
- make check