### PR TITLE
chore(docs): align install-deps help references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -766,7 +766,7 @@ help:
 	@echo "Dependencies:"
 	@echo "  install-deps [SKILL_INSTALL_TARGET=codex|agents|all] [CONVEX_MIRROR_MODE=off|fallback|mirror-first]"
 	@echo "               Install deps, prefetch Convex assets, and bootstrap governance skill targets"
-	@echo "               See ./scripts/install-deps.sh --help for mirror bases, timeout, and curl env knobs"
+	@echo "               See ./scripts/install-deps.sh --help for skill target, CI behavior, and additional prefetch env knobs"
 	@echo "  prefetch-convex [CONVEX_MIRROR_MODE=off|fallback|mirror-first] Prefetch Convex local backend + dashboard assets"
 	@echo "                 See ./scripts/prefetch-convex-backend.sh --help for mirror bases, timeout, and curl env knobs"
 	@echo ""

--- a/dev-docs/skills/trends-cli/SKILL.md
+++ b/dev-docs/skills/trends-cli/SKILL.md
@@ -52,7 +52,7 @@ Use this skill when the user asks to operate backend services from terminal comm
 
 - Run commands from repository root.
 - `make install-deps` bootstraps the governance skill by default into `~/.codex/skills`; use `SKILL_INSTALL_TARGET=all make install-deps` when local setup should also refresh `~/.agents/skills`.
-- `CONVEX_MIRROR_MODE=mirror-first make install-deps` is the repo-level bootstrap path when Convex asset prefetch should try configured mirrors before GitHub, and `make prefetch-convex` is the focused prefetch-only escape hatch. Use `./scripts/install-deps.sh --help` or `./scripts/prefetch-convex-backend.sh --help` when mirror-base, timeout, or curl verbosity knobs matter.
+- `CONVEX_MIRROR_MODE=mirror-first make install-deps` is the repo-level bootstrap path when Convex asset prefetch should try configured mirrors before GitHub, and `make prefetch-convex` is the focused prefetch-only escape hatch. Use `./scripts/install-deps.sh --help` when skill-target, CI-default, or broader prefetch env knobs matter, and `./scripts/prefetch-convex-backend.sh --help` for the focused low-level prefetch contract.
 - Keep `dev-docs/skills/trends-cli` as the only editable source; install into `~/.codex/skills` and/or `~/.agents/skills` from that source instead of maintaining duplicate copies. `CODEX_HOME` and `AGENTS_HOME` can override those roots when needed.
 - Keep `--api-url` and `--worker-url` aligned with running services.
 - `trends resume match` remains the API-backed path; when `source=convex` and AI scoring is needed for debug, use `trends resume debug ai-score`.


### PR DESCRIPTION
## Summary
- align repo help and the packaged trends-cli skill so they point to scripts/install-deps.sh --help for the broader bootstrap contract
- reflect that the install-deps help surface now covers skill target selection, CI-sensitive defaults, and extra prefetch env knobs

## Validation
- make help | rg -n "install-deps \[SKILL_INSTALL_TARGET|skill target, CI behavior, and additional prefetch env knobs"
- make validate-skill SKILL=trends-cli
- make install-skill SKILL=trends-cli TARGET=all
- make check-skill-install SKILL=trends-cli TARGET=all
- make check