### PR TITLE
chore(make): align prefetch help contract wording

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ install-deps:
 	./scripts/install-deps.sh
 
 # Prefetch Convex local backend and dashboard assets into local cache
-# Honors CONVEX_MIRROR_MODE / CONVEX_MIRROR_BASES / timeout env knobs; see the script --help surface for details.
+# Honors CI-sensitive mirror defaults plus CONVEX_MIRROR_MODE / CONVEX_MIRROR_BASES / timeout / curl env knobs; see the script --help surface for full details.
 prefetch-convex:
 	./scripts/prefetch-convex-backend.sh
 
@@ -768,7 +768,7 @@ help:
 	@echo "               Install deps, prefetch Convex assets, and bootstrap governance skill targets"
 	@echo "               See ./scripts/install-deps.sh --help for skill target, CI behavior, and additional prefetch env knobs"
 	@echo "  prefetch-convex [CONVEX_MIRROR_MODE=off|fallback|mirror-first] Prefetch Convex local backend + dashboard assets"
-	@echo "                 See ./scripts/prefetch-convex-backend.sh --help for mirror bases, timeout, and curl env knobs"
+	@echo "                 See ./scripts/prefetch-convex-backend.sh --help for CI defaults, mirror bases, timeout, and curl env knobs"
 	@echo ""
 	@echo "CLI:"
 	@echo "  cli-build      Build Go CLI to bin/trends"


### PR DESCRIPTION
## Summary
- align the Makefile prefetch-convex help pointer with the underlying prefetch script contract
- document that the prefetch help surface covers CI-sensitive defaults in addition to mirror-base, timeout, and curl knobs

## Validation
- make help | rg -n "prefetch-convex|CI defaults, mirror bases, timeout, and curl env knobs"
- make check