### PR TITLE
chore(scripts): clarify install prefetch defaults

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1445,6 +1445,7 @@ print_usage() {
     echo "  SEED_RESUMES           Seed demo resumes during install/upgrade when truthy"
     echo "  ALLOW_NODE_DOWNGRADE   Permit downgrading a newer Node.js to the required v22"
     echo "  CONVEX_MIRROR_MODE     Convex prefetch source order: off|fallback|mirror-first"
+    echo "                         Default is fallback, or off when CI=true"
     echo "  CONVEX_MIRROR_BASES    Convex prefetch mirror base URLs (comma-separated)"
     echo "  CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
     echo "                         Convex prefetch timeout overrides"


### PR DESCRIPTION
## Summary
- clarify the install.sh help surface so it reflects the CI-sensitive default inherited from the shared Convex prefetch script
- keep the production installer help aligned with the lower-level prefetch contract it already links to

## Validation
- ./scripts/install.sh --help | sed -n "10,22p"
- make check