### PR TITLE
chore(docs): align install help references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ make install-seed                           # Install the production stack with 
 ENV_FILE=.env.production make deploy-check  # Dry run the deploy precheck against the target env
 CONVEX_MIRROR_MODE=mirror-first make deploy # Optional: mirror-first Convex prefetch during upgrade
 make deploy-seed                            # Force a full upgrade with seeded demo resumes
-./scripts/install.sh --help                 # Full install/upgrade modes plus production prefetch env knobs
+./scripts/install.sh --help                 # Full install/upgrade modes plus CI-sensitive production prefetch defaults and env knobs
 ```
 
 ### Verification

--- a/Makefile
+++ b/Makefile
@@ -745,7 +745,7 @@ help:
 	@echo "  deploy-seed    Force a full upgrade with seeded demo resumes (requires sudo)"
 	@echo "  refresh-env    Refresh env, sync frontend build vars, and rebuild the production web bundle"
 	@echo "  uninstall      Remove systemd services (requires sudo)"
-	@echo "                 See ./scripts/install.sh --help for install/upgrade modes and prefetch env knobs"
+	@echo "                 See ./scripts/install.sh --help for install/upgrade modes, CI-sensitive prefetch defaults, and env knobs"
 	@echo "  docker         Start Docker containers"
 	@echo "  docker-build   Build and start Docker containers"
 	@echo "  docker-down    Stop Docker containers"


### PR DESCRIPTION
## Summary
- align the repo-level production help and canonical deployment runbook with the CI-sensitive prefetch defaults now documented by scripts/install.sh --help
- keep the wrapper surfaces accurate about what the installer help entrypoint covers

## Validation
- make help | rg -n "scripts/install\.sh --help|CI-sensitive prefetch defaults"
- ./scripts/install.sh --help | sed -n "1,24p"
- make check