### PR TITLE
chore(scripts): clarify dev prefetch defaults

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1310,6 +1310,7 @@ print_usage() {
     echo "  CONVEX_LOCAL_BACKEND_VERSION Explicit Convex local backend version override"
     echo "  CONVEX_LOCAL_FORCE_UPGRADE Enable --local-force-upgrade on first attempt: true|false (default: true)"
     echo "  CONVEX_MIRROR_MODE Convex prefetch source order before startup: off|fallback|mirror-first"
+    echo "                    Default is fallback, or off when CI=true"
     echo "  CONVEX_MIRROR_BASES / CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
     echo "                    Convex prefetch mirror-base and timeout overrides"
     echo "  CONVEX_CURL_NO_SILENT When true/1, keep Convex prefetch curl progress output enabled"


### PR DESCRIPTION
## Summary
- clarify the dev.sh help surface so it reflects the CI-sensitive default inherited from the shared Convex prefetch script
- keep the dev entrypoint help aligned with the lower-level prefetch contract it already links to

## Validation
- ./scripts/dev.sh --help | rg -n "CONVEX_MIRROR_MODE|Default is fallback, or off when CI=true|prefetch env contract"
- make check