### PR TITLE
chore(docs): align dev help references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ make dev                # Full local stack
 make dev-fast           # UI-focused fast profile
 make dev-critical       # Critical path profile
 make dev-backend        # Backend-focused profile
-./scripts/dev.sh --help # Full dev service-profile and Convex startup/prefetch env contract
+./scripts/dev.sh --help # Full dev service-profile plus CI-sensitive Convex startup/prefetch defaults and env contract
 ```
 
 ### Start Single Services

--- a/Makefile
+++ b/Makefile
@@ -727,7 +727,7 @@ help:
 	@echo "  dev-api        Start Hono BFF API server (port 3000)"
 	@echo "  dev-api-worker Start FastAPI worker REST API (port 8000)"
 	@echo "  dev-worker     Start worker scheduler (run now + verbose)"
-	@echo "                 See ./scripts/dev.sh --help for service profiles and Convex startup/prefetch env knobs"
+	@echo "                 See ./scripts/dev.sh --help for service profiles, CI-sensitive prefetch defaults, and Convex startup/env knobs"
 	@echo ""
 	@echo "Production:"
 	@echo "  run            Run crawler (production mode, full output)"


### PR DESCRIPTION
## Summary
- align the repo-level development help and canonical dev runbook with the CI-sensitive prefetch defaults now documented by scripts/dev.sh --help
- keep the wrapper surfaces accurate about what the dev entrypoint help covers

## Validation
- make help | rg -n "scripts/dev\.sh --help|CI-sensitive prefetch defaults"
- ./scripts/dev.sh --help | rg -n "CONVEX_MIRROR_MODE|Default is fallback, or off when CI=true|prefetch env contract"
- make check