### PR TITLE
chore(scripts): align prefetch CI wording

### DIFF
--- a/scripts/prefetch-convex-backend.sh
+++ b/scripts/prefetch-convex-backend.sh
@@ -15,7 +15,7 @@ Usage: $0 [--help]
 Prefetches stable Convex backend and dashboard assets into the local Convex cache.
 
 Environment:
-  CONVEX_MIRROR_MODE            Download source order: off|fallback|mirror-first (default: fallback, or off in CI)
+  CONVEX_MIRROR_MODE            Download source order: off|fallback|mirror-first (default: fallback, or off when CI=true)
   CONVEX_MIRROR_BASES           Comma-separated mirror base URLs (default: ${DEFAULT_MIRROR_BASES})
   CONVEX_DOWNLOAD_TIMEOUT_SECS  Download timeout in seconds (default: ${DEFAULT_DOWNLOAD_TIMEOUT_SECS})
   CONVEX_CONNECT_TIMEOUT_SECS   Connect timeout in seconds (default: ${DEFAULT_CONNECT_TIMEOUT_SECS})


### PR DESCRIPTION
## Summary
- align the shared prefetch script help with the CI=true wording already used by the repo-level and entrypoint help surfaces
- keep the base prefetch contract phrasing consistent across all entrypoints that reference it

## Validation
- ./scripts/prefetch-convex-backend.sh --help | sed -n "4,10p"
- make check