### PR TITLE
chore(scripts): document CI prefetch env

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1314,6 +1314,7 @@ print_usage() {
     echo "  CONVEX_MIRROR_BASES / CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
     echo "                    Convex prefetch mirror-base and timeout overrides"
     echo "  CONVEX_CURL_NO_SILENT When true/1, keep Convex prefetch curl progress output enabled"
+    echo "  CI            When true, defaults shared Convex prefetch mode to off"
     echo ""
     echo "See $SCRIPT_DIR/prefetch-convex-backend.sh --help for the full Convex prefetch env contract."
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1450,6 +1450,7 @@ print_usage() {
     echo "  CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
     echo "                         Convex prefetch timeout overrides"
     echo "  CONVEX_CURL_NO_SILENT  When true/1, keep Convex prefetch curl progress output enabled"
+    echo "  CI                     When true, defaults shared Convex prefetch mode to off"
     echo ""
     echo "See $WORKSPACE_DIR/scripts/prefetch-convex-backend.sh --help for the full Convex prefetch env contract."
 }


### PR DESCRIPTION
## Summary
- document CI as an explicit supported env var in scripts/dev.sh and scripts/install.sh help output
- make the inherited shared Convex prefetch default contract explicit at both low-level entrypoints

## Validation
- ./scripts/dev.sh --help | sed -n "31,40p"
- ./scripts/install.sh --help | sed -n "15,24p"
- make check