### PR TITLE
chore(scripts): align shared prefetch CI line

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -13,7 +13,7 @@ usage() {
     echo "  CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
     echo "                         Convex prefetch timeout overrides"
     echo "  CONVEX_CURL_NO_SILENT  When true/1, keep Convex prefetch curl progress output enabled"
-    echo "  CI                     When true, uses npm, skips governance sync, and defaults prefetch mode to off"
+    echo "  CI                     When true, uses npm, skips governance sync, and defaults shared Convex prefetch mode to off"
     echo ""
     echo "See ./scripts/prefetch-convex-backend.sh --help for the full Convex prefetch env contract."
 }

--- a/scripts/prefetch-convex-backend.sh
+++ b/scripts/prefetch-convex-backend.sh
@@ -20,7 +20,7 @@ Environment:
   CONVEX_DOWNLOAD_TIMEOUT_SECS  Download timeout in seconds (default: ${DEFAULT_DOWNLOAD_TIMEOUT_SECS})
   CONVEX_CONNECT_TIMEOUT_SECS   Connect timeout in seconds (default: ${DEFAULT_CONNECT_TIMEOUT_SECS})
   CONVEX_CURL_NO_SILENT         When true/1, keep curl progress output enabled
-  CI                            When true, defaults mirror mode to off
+  CI                            When true, defaults shared Convex prefetch mode to off
 EOF
 }
 


### PR DESCRIPTION
## Summary
- align the CI help line wording in scripts/prefetch-convex-backend.sh and scripts/install-deps.sh with the shared Convex prefetch phrasing already used by the dev and install entrypoints
- keep the shared prefetch contract terminology consistent across all help surfaces

## Validation
- ./scripts/prefetch-convex-backend.sh --help | sed -n "4,10p"
- ./scripts/install-deps.sh --help | sed -n "8,16p"
- make check