### PR TITLE
chore(make): document CI env in help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -834,6 +834,7 @@ help:
 	@echo "  ALLOW_NODE_DOWNGRADE Set 1/true to allow installer to downgrade Node to v22 when a newer Node is already installed"
 	@echo "  CONVEX_MIRROR_MODE Shared Convex prefetch source order for dev/install/deploy: off|fallback|mirror-first"
 	@echo "                     Default is fallback, or off when CI=true in shared prefetch entrypoints"
+	@echo "  CI             Set true/1 when running shared prefetch-backed entrypoints in CI"
 	@echo "  CONVEX_MIRROR_BASES / CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
 	@echo "                 Shared Convex prefetch mirror-base and timeout overrides for dev/install/deploy"
 	@echo "  CONVEX_CURL_NO_SILENT Set true/1 to keep shared Convex prefetch curl progress output enabled"


### PR DESCRIPTION
## Summary
- document CI explicitly in the top-level make help env summary for the shared prefetch-backed entrypoints
- keep the repo-level env summary aligned with the lower-level scripts that now list CI directly

## Validation
- make help | rg -n "CONVEX_MIRROR_MODE|CIs+Set true/1 when running shared prefetch-backed entrypoints in CI"
- make check