### PR TITLE
chore(make): align prefetch comment wording

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ install-deps:
 	./scripts/install-deps.sh
 
 # Prefetch Convex local backend and dashboard assets into local cache
-# Honors CI-sensitive mirror defaults plus CONVEX_MIRROR_MODE / CONVEX_MIRROR_BASES / timeout / curl env knobs; see the script --help surface for full details.
+# Honors shared CI env/defaults plus CONVEX_MIRROR_MODE / CONVEX_MIRROR_BASES / timeout / curl env knobs; see the script --help surface for full details.
 prefetch-convex:
 	./scripts/prefetch-convex-backend.sh
 


### PR DESCRIPTION
## Summary
- align the internal Makefile comment above prefetch-convex with the CI env/defaults terminology now used by the repo-level help and lower-level scripts
- keep internal repo comments consistent with the user-facing help surfaces

## Validation
- sed -n "259,263p" Makefile
- make check