### PR TITLE
fix(scripts): support CI=1 for prefetch flow

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -8,12 +8,12 @@ usage() {
     echo "Environment:"
     echo "  SKILL_INSTALL_TARGET   Governance skill install target: codex|agents|all (default: codex)"
     echo "  CONVEX_MIRROR_MODE     Convex prefetch mode override: off|fallback|mirror-first"
-    echo "                         Default is fallback, or off when CI=true"
+    echo "                         Default is fallback, or off when CI=true/1"
     echo "  CONVEX_MIRROR_BASES    Convex prefetch mirror base URLs (comma-separated)"
     echo "  CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
     echo "                         Convex prefetch timeout overrides"
     echo "  CONVEX_CURL_NO_SILENT  When true/1, keep Convex prefetch curl progress output enabled"
-    echo "  CI                     When true, uses npm, skips governance sync, and defaults shared Convex prefetch mode to off"
+    echo "  CI                     When true/1, uses npm, skips governance sync, and defaults shared Convex prefetch mode to off"
     echo ""
     echo "See ./scripts/prefetch-convex-backend.sh --help for the full Convex prefetch env contract."
 }
@@ -35,7 +35,7 @@ fi
 resolve_convex_mirror_mode() {
     local mode="${CONVEX_MIRROR_MODE:-}"
     if [ -z "${mode}" ]; then
-        if [ "${CI:-}" = "true" ]; then
+        if is_ci_env; then
             echo "off"
             return
         fi
@@ -54,6 +54,10 @@ resolve_convex_mirror_mode() {
     esac
 }
 
+is_ci_env() {
+    [ "${CI:-}" = "true" ] || [ "${CI:-}" = "1" ]
+}
+
 resolve_skill_install_target() {
     local target="${SKILL_INSTALL_TARGET:-codex}"
     case "${target}" in
@@ -70,7 +74,7 @@ resolve_skill_install_target() {
 
 EFFECTIVE_CONVEX_MIRROR_MODE=""
 EFFECTIVE_SKILL_INSTALL_TARGET=""
-if [ "${CI:-}" != "true" ]; then
+if ! is_ci_env; then
     EFFECTIVE_CONVEX_MIRROR_MODE="$(resolve_convex_mirror_mode)"
     EFFECTIVE_SKILL_INSTALL_TARGET="$(resolve_skill_install_target)"
 fi
@@ -79,7 +83,7 @@ echo "Installing Python dependencies..."
 uv sync
 
 echo "Installing Node.js dependencies..."
-if [ "${CI:-}" = "true" ]; then
+if is_ci_env; then
     npm install
 elif command -v bun &> /dev/null; then
     if ! bun install; then
@@ -100,7 +104,7 @@ if [ -d "packages/convex" ]; then
 fi
 
 # Sync agent governance artifacts (policy mirror + target-aware skill install)
-if [ "${CI:-}" != "true" ]; then
+if ! is_ci_env; then
     echo "Syncing agent governance artifacts (skill target: ${EFFECTIVE_SKILL_INSTALL_TARGET})..."
     _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     if command -v bun > /dev/null 2>&1; then

--- a/scripts/prefetch-convex-backend.sh
+++ b/scripts/prefetch-convex-backend.sh
@@ -15,12 +15,12 @@ Usage: $0 [--help]
 Prefetches stable Convex backend and dashboard assets into the local Convex cache.
 
 Environment:
-  CONVEX_MIRROR_MODE            Download source order: off|fallback|mirror-first (default: fallback, or off when CI=true)
+  CONVEX_MIRROR_MODE            Download source order: off|fallback|mirror-first (default: fallback, or off when CI=true/1)
   CONVEX_MIRROR_BASES           Comma-separated mirror base URLs (default: ${DEFAULT_MIRROR_BASES})
   CONVEX_DOWNLOAD_TIMEOUT_SECS  Download timeout in seconds (default: ${DEFAULT_DOWNLOAD_TIMEOUT_SECS})
   CONVEX_CONNECT_TIMEOUT_SECS   Connect timeout in seconds (default: ${DEFAULT_CONNECT_TIMEOUT_SECS})
   CONVEX_CURL_NO_SILENT         When true/1, keep curl progress output enabled
-  CI                            When true, defaults shared Convex prefetch mode to off
+  CI                            When true/1, defaults shared Convex prefetch mode to off
 EOF
 }
 
@@ -89,12 +89,16 @@ trim() {
     echo "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
 }
 
+is_ci_env() {
+    [ "${CI:-}" = "true" ] || [ "${CI:-}" = "1" ]
+}
+
 effective_mirror_mode() {
     if [ -n "${CONVEX_MIRROR_MODE:-}" ]; then
         echo "${CONVEX_MIRROR_MODE}"
         return
     fi
-    if [ "${CI:-}" = "true" ]; then
+    if is_ci_env; then
         echo "off"
         return
     fi


### PR DESCRIPTION
## Summary
- make the shared prefetch flow honor CI=1 as documented, not just CI=true
- align the related help text in install-deps and prefetch-convex-backend with the supported CI=true/1 behavior

## Validation
- bash -lc 'eval "$(sed -n "35,60p" scripts/install-deps.sh)"; CI=1 resolve_convex_mirror_mode'\n- bash -lc 'eval "$(sed -n "92,106p" scripts/prefetch-convex-backend.sh)"; CI=1 effective_mirror_mode'\n- ./scripts/install-deps.sh --help | sed -n "4,16p"\n- ./scripts/prefetch-convex-backend.sh --help | sed -n "4,10p"\n- make check