### PR TITLE
chore(docs): simplify prefetch contract wording

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ install-deps:
 	./scripts/install-deps.sh
 
 # Prefetch Convex local backend and dashboard assets into local cache
-# Honors shared CI=true/1 defaults plus CONVEX_MIRROR_MODE / CONVEX_MIRROR_BASES / timeout / curl env knobs; see the script --help surface for full details.
+# Honors the shared Convex prefetch contract for CI=true/1 plus CONVEX_MIRROR_MODE / CONVEX_MIRROR_BASES / timeout / curl env knobs; see the script --help surface for full details.
 prefetch-convex:
 	./scripts/prefetch-convex-backend.sh
 
@@ -833,7 +833,7 @@ help:
 	@echo "  SEED_RESUMES   Set 1/true to seed demo resumes during install/upgrade (wrappers use this for install-seed/deploy-seed)"
 	@echo "  ALLOW_NODE_DOWNGRADE Set 1/true to allow installer to downgrade Node to v22 when a newer Node is already installed"
 	@echo "  CONVEX_MIRROR_MODE Shared Convex prefetch source order for dev/install/deploy: off|fallback|mirror-first"
-	@echo "                     Default is fallback, or off when CI=true/1 in shared prefetch entrypoints"
+	@echo "                     When CI=true/1, shared Convex prefetch mode defaults to off"
 	@echo "  CI             Set true/1 when running shared prefetch-backed entrypoints in CI"
 	@echo "  CONVEX_MIRROR_BASES / CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
 	@echo "                 Shared Convex prefetch mirror-base and timeout overrides for dev/install/deploy"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1314,7 +1314,7 @@ print_usage() {
     echo "  CONVEX_MIRROR_BASES / CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
     echo "                    Convex prefetch mirror-base and timeout overrides"
     echo "  CONVEX_CURL_NO_SILENT When true/1, keep Convex prefetch curl progress output enabled"
-    echo "  CI            When true/1, defaults shared Convex prefetch mode to off"
+    echo "  CI            When true/1, shared Convex prefetch mode defaults to off"
     echo ""
     echo "See $SCRIPT_DIR/prefetch-convex-backend.sh --help for the full Convex prefetch env contract."
 }

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -13,7 +13,7 @@ usage() {
     echo "  CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
     echo "                         Convex prefetch timeout overrides"
     echo "  CONVEX_CURL_NO_SILENT  When true/1, keep Convex prefetch curl progress output enabled"
-    echo "  CI                     When true/1, uses npm, skips governance sync, and defaults shared Convex prefetch mode to off"
+    echo "  CI                     When true/1, shared Convex prefetch mode defaults to off, uses npm, and skips governance sync"
     echo ""
     echo "See ./scripts/prefetch-convex-backend.sh --help for the full Convex prefetch env contract."
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1450,7 +1450,7 @@ print_usage() {
     echo "  CONVEX_DOWNLOAD_TIMEOUT_SECS / CONVEX_CONNECT_TIMEOUT_SECS"
     echo "                         Convex prefetch timeout overrides"
     echo "  CONVEX_CURL_NO_SILENT  When true/1, keep Convex prefetch curl progress output enabled"
-    echo "  CI                     When true/1, defaults shared Convex prefetch mode to off"
+    echo "  CI                     When true/1, shared Convex prefetch mode defaults to off"
     echo ""
     echo "See $WORKSPACE_DIR/scripts/prefetch-convex-backend.sh --help for the full Convex prefetch env contract."
 }

--- a/scripts/prefetch-convex-backend.sh
+++ b/scripts/prefetch-convex-backend.sh
@@ -20,7 +20,7 @@ Environment:
   CONVEX_DOWNLOAD_TIMEOUT_SECS  Download timeout in seconds (default: ${DEFAULT_DOWNLOAD_TIMEOUT_SECS})
   CONVEX_CONNECT_TIMEOUT_SECS   Connect timeout in seconds (default: ${DEFAULT_CONNECT_TIMEOUT_SECS})
   CONVEX_CURL_NO_SILENT         When true/1, keep curl progress output enabled
-  CI                            When true/1, defaults shared Convex prefetch mode to off
+  CI                            When true/1, shared Convex prefetch mode defaults to off
 EOF
 }
 


### PR DESCRIPTION
Tighten the shared Convex prefetch wording so the repo help and packaged skill docs use the same phrasing across scripts and wrappers.