### PR TITLE
feat: backfill resume location hierarchy

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -46,7 +46,12 @@ import {
 } from "../services/rule-scoring.js";
 import { resolveResumeId } from "../services/resume-id.js";
 import { IngestComputeService } from "../services/ingest-compute-service.js";
-import { buildWorkHistoryEntryText, buildWorkHistoryEvidence, normalizeWorkHistoryEntry } from "@trends/shared";
+import {
+  buildWorkHistoryEntryText,
+  buildWorkHistoryEvidence,
+  formatLocationHierarchySearchText,
+  normalizeWorkHistoryEntry,
+} from "@trends/shared";
 import { SkillsKnowledgeService } from "../services/skills-knowledge.js";
 import { SearchEventLogger } from "../services/search-event-logger.js";
 import {
@@ -1070,9 +1075,10 @@ function computeStats(
 }
 
 function createFallbackIndex(resume: ResumeItem, resumeId: string): ResumeIndex {
+  const locationText = formatLocationHierarchySearchText(resume.locationHierarchy) || resume.location || "";
   const text = [
     resume.name,
-    resume.location,
+    locationText,
     resume.education,
     ...(resume.workHistory ?? []).map((item) => buildWorkHistoryEntryText(item)),
   ].join(" ").toLowerCase();
@@ -1081,7 +1087,11 @@ function createFallbackIndex(resume: ResumeItem, resumeId: string): ResumeIndex 
     resumeId,
     experienceYears: null,
     educationLevel: resume.education || null,
-    locationCity: resume.location || null,
+    locationCity: resume.locationHierarchy?.city
+      || resume.locationHierarchy?.province
+      || resume.locationHierarchy?.country
+      || resume.location
+      || null,
     skills: [],
     companies: extractCompanies(resume.workHistory) ?? [],
     industryTags: [],

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -31,6 +31,16 @@ const ResumeImportWorkHistorySchema = z
   })
   .openapi("ResumeImportWorkHistory");
 
+export const ResumeLocationHierarchySchema = z
+  .object({
+    country: z.string().openapi({ example: "中国" }),
+    province: z.string().optional().openapi({ example: "广东" }),
+    city: z.string().optional().openapi({ example: "东莞" }),
+    matchedFrom: z.enum(["location", "profile", "workHistory", "jobIntention"]).optional(),
+    confidence: z.literal("high").optional(),
+  })
+  .openapi("ResumeLocationHierarchy");
+
 const ResumeImportProfileEducationSchema = z
   .object({
     institution: z.string().optional().openapi({ example: "Universiti Malaya" }),
@@ -116,6 +126,7 @@ export const ResumeItemSchema = z
     experience: z.string().openapi({ example: "5 years" }),
     education: z.string().openapi({ example: "Bachelor" }),
     location: z.string().openapi({ example: "Shenzhen" }),
+    locationHierarchy: ResumeLocationHierarchySchema.optional(),
     selfIntro: z.string().openapi({ example: "认真敬业，具备团队协作精神" }),
     jobIntention: z.string().openapi({ example: "Sales Manager" }),
     expectedSalary: z.string().openapi({ example: "10-15K" }),
@@ -202,6 +213,7 @@ export const ResumeImportItemSchema = z
     experience: z.string().optional().openapi({ example: "5 years" }),
     education: z.string().optional().openapi({ example: "Bachelor" }),
     location: z.string().optional().openapi({ example: "Shenzhen" }),
+    locationHierarchy: ResumeLocationHierarchySchema.optional(),
     jobIntention: z.string().optional().openapi({ example: "Sales Manager" }),
     expectedSalary: z.string().optional().openapi({ example: "10-15K" }),
     selfIntro: z.string().optional().openapi({ example: "认真敬业，具备团队协作精神" }),
@@ -654,6 +666,7 @@ export const ResumeExportResolvedResumeSchema = z.object({
   name: z.string().optional(),
   jobIntention: z.string().optional(),
   location: z.string().optional(),
+  locationHierarchy: ResumeLocationHierarchySchema.optional(),
   age: z.string().optional(),
   experience: z.string().optional(),
   education: z.string().optional(),

--- a/apps/api/src/services/__tests__/search-text-builder.test.ts
+++ b/apps/api/src/services/__tests__/search-text-builder.test.ts
@@ -50,6 +50,20 @@ describe("buildSearchText", () => {
     expect(resultA).toBe(resultB);
   });
 
+  it("indexes structured location hierarchy while ignoring hierarchy metadata fields", () => {
+    const result = buildSearchText({
+      locationHierarchy: {
+        country: "中国",
+        province: "广东",
+        city: "东莞",
+        matchedFrom: "location",
+        confidence: "high",
+      },
+    });
+
+    expect(result).toBe("中国 广东 东莞");
+  });
+
   it("splits cjk and ascii boundaries for mixed-script search tokens", () => {
     const result = buildSearchText({
       summary: "东莞CNC编程 熟悉cnc操作和车床CNC技术员",

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -1,4 +1,10 @@
-import { buildWorkHistoryEntryText, buildWorkHistoryEvidence, normalizeWorkHistoryEntry } from "@trends/shared";
+import {
+  buildWorkHistoryEntryText,
+  buildWorkHistoryEvidence,
+  formatLocationHierarchySearchText,
+  normalizeResumeLocationHierarchy,
+  normalizeWorkHistoryEntry,
+} from "@trends/shared";
 
 import { IndustryDataService } from "./industry-data-service.js";
 import { normalizeCompanyPatternIdentifier, SkillsKnowledgeService } from "./skills-knowledge.js";
@@ -135,6 +141,7 @@ function toResumeItem(value: unknown): ResumeItem | null {
     experience: toStringValue(value.experience),
     education: toStringValue(value.education),
     location: toStringValue(value.location),
+    locationHierarchy: normalizeResumeLocationHierarchy(value),
     selfIntro: toStringValue(value.selfIntro),
     jobIntention: toStringValue(value.jobIntention),
     expectedSalary: toStringValue(value.expectedSalary),
@@ -235,9 +242,11 @@ function extractCompanies(workHistory: ResumeWorkHistoryItem[]): string[] {
 }
 
 function createSearchText(item: ResumeItem): string {
+  const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
   const parts = [
     item.name,
     item.education,
+    locationText,
     item.expectedSalary,
     ...(item.workHistory?.map((entry) => buildWorkHistoryEntryText(entry)) ?? []),
   ];
@@ -384,7 +393,11 @@ export function buildResumeIndex(item: ResumeItem, index: number): ResumeIndex {
     resumeId,
     experienceYears: computeWorkHistoryYears(item.workHistory),
     educationLevel: normalizeEducationLevel(item.education),
-    locationCity: item.location || null,
+    locationCity: item.locationHierarchy?.city
+      || item.locationHierarchy?.province
+      || item.locationHierarchy?.country
+      || item.location
+      || null,
     evidenceText,
     skills: [],  // Not needed for ingest - skills are in searchText
     companies,

--- a/apps/api/src/services/resume-import-service.test.ts
+++ b/apps/api/src/services/resume-import-service.test.ts
@@ -100,6 +100,56 @@ describe("resume-import-service", () => {
         resumeId: "1079188",
         perUserId: "1079188",
         name: "骆先生",
+        locationHierarchy: {
+          country: "中国",
+          province: "广东",
+          city: "东莞",
+          matchedFrom: "location",
+          confidence: "high",
+        },
+      }),
+    });
+  });
+
+  it("fills missing Job5156 locations from the derived hierarchy", () => {
+    const result = normalizeResumeImportPayload({
+      metadata: {
+        sourceKey: "job5156",
+        sourceHost: "hr.job5156.com",
+        sourceUrl: "https://hr.job5156.com/resume/view/555555",
+        keyword: "销售",
+        generatedBy: "browser-extension@1.1.1",
+      },
+      resumes: [
+        {
+          resumeId: 555555,
+          name: "空位置候选人",
+          profileUrl: "https://hr.job5156.com/resume/view/555555",
+          activityStatus: "在线中",
+          location: "",
+          jobIntention: "销售工程师",
+          workHistory: [
+            {
+              raw: "2020-01~2024-01 东莞富佳机械设备有限公司 销售工程师",
+              companyName: "东莞富佳机械设备有限公司",
+              jobTitle: "销售工程师",
+            },
+          ],
+          extractedAt: "2026-03-12T01:02:03.000Z",
+        },
+      ],
+    });
+
+    expect(result.convexResumes[0]).toMatchObject({
+      content: expect.objectContaining({
+        location: "广东东莞",
+        locationHierarchy: {
+          country: "中国",
+          province: "广东",
+          city: "东莞",
+          matchedFrom: "workHistory",
+          confidence: "high",
+        },
       }),
     });
   });

--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -5,6 +5,10 @@ import path from "node:path";
 import { z } from "@hono/zod-openapi";
 
 import {
+  formatLocationHierarchyLabel,
+  normalizeResumeLocationHierarchy,
+} from "@trends/shared";
+import {
   ResumeImportItemSchema,
   ResumeImportMetadataSchema,
   ResumeImportRequestSchema,
@@ -179,6 +183,18 @@ function buildResumeExternalId(resume: ResumeImportItem, source: string, hash: s
   return `${source}:hash:${hash}`;
 }
 
+function buildNormalizedResumeContent(resume: ResumeImportItem): Record<string, unknown> {
+  const locationHierarchy = normalizeResumeLocationHierarchy(resume);
+  const rawLocation = typeof resume.location === "string" ? resume.location.trim() : "";
+  const location = rawLocation || (locationHierarchy ? formatLocationHierarchyLabel(locationHierarchy) : "");
+
+  return {
+    ...resume,
+    location,
+    ...(locationHierarchy ? { locationHierarchy } : {}),
+  };
+}
+
 async function submitResumesToConvex(args: { resumes: ConvexResumeSubmitItem[] }): Promise<{
   submitted: number;
   deduped: number;
@@ -237,7 +253,7 @@ export function normalizeResumeImportPayload(input: ResumeImportRequest): Normal
   const source = resolveResumeSource(metadata);
 
   const convexResumes = resumes.map((resume) => {
-    const content: unknown = resume;
+    const content: unknown = buildNormalizedResumeContent(resume);
     const hash = crypto.createHash("sha256").update(stableStringify(content), "utf8").digest("hex");
     const externalId = buildResumeExternalId(resume, source, hash);
 

--- a/apps/api/src/services/resume-index.test.ts
+++ b/apps/api/src/services/resume-index.test.ts
@@ -114,6 +114,48 @@ describe("ResumeIndexService", () => {
     }
   });
 
+  it("uses structured location hierarchy when raw location is missing", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new ResumeIndexService(root);
+
+      const resumes: ResumeItem[] = [
+        {
+          name: "张三",
+          profileUrl: "javascript:;",
+          activityStatus: "活跃",
+          age: "31",
+          experience: "5年",
+          education: "本科",
+          location: "",
+          locationHierarchy: {
+            country: "中国",
+            province: "广东",
+            city: "东莞",
+          },
+          selfIntro: "",
+          jobIntention: "",
+          expectedSalary: "12000-18000元/月",
+          workHistory: [],
+          extractedAt: "2026-02-11T00:00:00.000Z",
+          resumeId: "R2002",
+          perUserId: "U2002",
+        },
+      ];
+
+      const index = service.buildIndex("sample:hierarchy", resumes);
+      const entry = index.get("R2002");
+
+      expect(entry?.locationCity).toBe("东莞");
+      expect(entry?.searchText).toContain("中国");
+      expect(entry?.searchText).toContain("广东");
+      expect(entry?.searchText).toContain("东莞");
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
   it("extracts seeded English location cities before CJK fallback", () => {
     const root = createFixtureRoot();
 

--- a/apps/api/src/services/resume-index.ts
+++ b/apps/api/src/services/resume-index.ts
@@ -5,6 +5,7 @@ import {
   buildWorkHistoryEntryText,
   buildWorkHistoryEvidence,
   FALLBACK_INDUSTRY_KEYWORDS,
+  formatLocationHierarchySearchText,
   findLocation,
   normalizeIndustryTags,
   normalizeLocationName,
@@ -87,10 +88,11 @@ function extractCompanies(workHistory: ResumeWorkHistoryItem[]): string[] {
 }
 
 function createSearchText(item: ResumeItem): string {
+  const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
   const parts = [
     item.name,
     item.education,
-    item.location,
+    locationText,
     item.expectedSalary,
     ...(item.workHistory?.map((entry) => buildWorkHistoryEntryText(entry)) ?? []),
   ];
@@ -202,7 +204,13 @@ export class ResumeIndexService {
     this.vocabularyLoaded = true;
   }
 
-  private extractLocationCity(location: string): string | null {
+  private extractLocationCity(item: ResumeItem): string | null {
+    const hierarchy = item.locationHierarchy;
+    if (hierarchy) {
+      return hierarchy.city || hierarchy.province || hierarchy.country || null;
+    }
+
+    const location = item.location || "";
     if (!location.trim()) return null;
 
     for (const knownLocation of this.locationVocabulary) {
@@ -270,7 +278,7 @@ export class ResumeIndexService {
         resumeId,
         experienceYears: computeWorkHistoryYears(item.workHistory ?? []),
         educationLevel: normalizeEducationLevel(item.education),
-        locationCity: this.extractLocationCity(item.location || ""),
+        locationCity: this.extractLocationCity(item),
         evidenceText,
         skills,
         companies,

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   buildWorkHistoryEntryText,
+  formatLocationHierarchySearchText,
   isLocationMatch,
   normalizeProfileUrlForDisplay,
   normalizeSharedResumeFields,
@@ -234,11 +235,13 @@ function countOccurrences(haystack: string, needle: string): number {
 }
 
 function buildSearchText(item: ResumeItem): string {
+  const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
   const parts = [
     item.name,
     item.jobIntention,
     item.selfIntro,
     item.education,
+    locationText,
     item.expectedSalary,
     ...(item.workHistory?.map((entry) => buildWorkHistoryEntryText(entry)) ?? []),
   ];
@@ -566,7 +569,7 @@ export class ResumeService {
       }
 
       if (filters.locations?.length) {
-        const location = item.location || "";
+        const location = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
         const hasLocation = filters.locations.some((target) => isLocationMatch(location, target));
         if (!hasLocation) return false;
       }

--- a/apps/api/src/services/unified-search-service.ts
+++ b/apps/api/src/services/unified-search-service.ts
@@ -1,4 +1,4 @@
-import { buildWorkHistoryEntryText } from "@trends/shared";
+import { buildWorkHistoryEntryText, formatLocationHierarchySearchText } from "@trends/shared";
 
 import { parseSearchQuery } from "./query-parser.js";
 import { resolveResumeId } from "./resume-id.js";
@@ -45,11 +45,13 @@ function normalizeToken(value: string): string {
 }
 
 function buildSearchText(item: ResumeItem): string {
+  const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
   const parts = [
     item.name,
     item.jobIntention,
     item.selfIntro,
     item.education,
+    locationText,
     item.expectedSalary,
     ...(item.workHistory?.map((entry) => buildWorkHistoryEntryText(entry)) ?? []),
   ];

--- a/apps/api/src/types/resume.ts
+++ b/apps/api/src/types/resume.ts
@@ -8,6 +8,7 @@ import type {
   ResumeSkillDetail,
   ResumeSnippet,
   ResumeWorkHistoryItem,
+  LocationHierarchy,
 } from "@trends/shared";
 
 export type {
@@ -64,6 +65,7 @@ export type ResumeItem = {
   experience: string;
   education: string;
   location: string;
+  locationHierarchy?: LocationHierarchy;
   selfIntro: string;
   jobIntention: string;
   expectedSalary: string;

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -195,6 +195,8 @@ function buildResume(params: {
   id: string
   name: string
   primaryRuleScore?: number
+  location?: string
+  locationHierarchy?: ConvexResumeItem['locationHierarchy']
   brandHits?: ConvexIngestData['brandHits']
   companyHits?: string[]
   industryTags?: string[]
@@ -224,7 +226,8 @@ function buildResume(params: {
     ageNumber: 30,
     experience: '5 years',
     education: 'Bachelor',
-    location: 'Dongguan',
+    location: params.location ?? 'Dongguan',
+    locationHierarchy: params.locationHierarchy,
     selfIntro: 'Test intro',
     jobIntention: 'Test role',
     expectedSalary: '10k-20k',
@@ -583,6 +586,37 @@ describe('useResumeListState role filter regression', () => {
       'Zhang Machinery Sales',
       'Zhou Jingdiao Hit',
     ])
+  })
+
+  it('filters convex resumes by structured location hierarchy when raw location is blank', () => {
+    mockState.convexResumes = [
+      buildResume({
+        id: 'resume-hierarchy-location',
+        name: 'Hierarchy Location',
+        location: '',
+        locationHierarchy: {
+          country: '中国',
+          province: '广东',
+          city: '东莞',
+        },
+        roleSignals: [
+          {
+            type: 'sales',
+            matchedSignals: ['销售'],
+            signalCount: 1,
+            occurrences: 1,
+            years: 3,
+            industryVerifiedYears: 3,
+            verifyIn: 'workHistory',
+          },
+        ],
+      }),
+    ]
+    mockState.filters = {
+      locations: ['东莞'],
+    }
+
+    expect(getDisplayedResumeNames()).toEqual(['Hierarchy Location'])
   })
 
   it('falls back to legacy minSalesYears when minRoleYears is absent', () => {

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMutation, useQuery } from 'convex/react'
-import { isLocationMatch } from '@trends/shared'
+import { formatLocationHierarchySearchText, isLocationMatch } from '@trends/shared'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { api } from '../../../../packages/convex/convex/_generated/api'
@@ -216,6 +216,10 @@ function submitResumeExportDownload(apiBaseUrl: string, payload: ResumeExportReq
 
 function normalizeFilterToken(value: string): string {
   return value.trim().toLowerCase()
+}
+
+function getResumeLocationText(resume: { location?: string; locationHierarchy?: { country: string; province?: string; city?: string } }): string {
+  return formatLocationHierarchySearchText(resume.locationHierarchy) || resume.location || ''
 }
 
 function parseSerializedStringArray(value: string): string[] {
@@ -848,7 +852,7 @@ export function useResumeListState(loadSearchHistory = false) {
     if (filters.locations?.length) {
       const locations = filters.locations
       result = result.filter((resume: ScoredConvexResume) =>
-        locations.some((location) => isLocationMatch(resume.location ?? '', location))
+        locations.some((location) => isLocationMatch(getResumeLocationText(resume), location))
       )
     }
 

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -3914,6 +3914,18 @@ export interface components {
             /** @example Navigate to sourceUrl, then add ?tr_auto_export=json */
             reproduction?: string;
         };
+        ResumeLocationHierarchy: {
+            /** @example 中国 */
+            country: string;
+            /** @example 广东 */
+            province?: string;
+            /** @example 东莞 */
+            city?: string;
+            /** @enum {string} */
+            matchedFrom?: "location" | "profile" | "workHistory" | "jobIntention";
+            /** @enum {string} */
+            confidence?: "high";
+        };
         ResumeWorkHistory: {
             /** @example 2021-03 ~ 2023-08 Example Co. - Sales Manager */
             raw: string;
@@ -4007,6 +4019,7 @@ export interface components {
             education: string;
             /** @example Shenzhen */
             location: string;
+            locationHierarchy?: components["schemas"]["ResumeLocationHierarchy"];
             /** @example 认真敬业，具备团队协作精神 */
             selfIntro: string;
             /** @example Sales Manager */
@@ -4394,6 +4407,7 @@ export interface components {
             education?: string;
             /** @example Shenzhen */
             location?: string;
+            locationHierarchy?: components["schemas"]["ResumeLocationHierarchy"];
             /** @example Sales Manager */
             jobIntention?: string;
             /** @example 10-15K */
@@ -4519,6 +4533,7 @@ export interface components {
                     name?: string;
                     jobIntention?: string;
                     location?: string;
+                    locationHierarchy?: components["schemas"]["ResumeLocationHierarchy"];
                     age?: string;
                     experience?: string;
                     education?: string;

--- a/packages/convex/convex/__tests__/migrations-evidence-text.test.ts
+++ b/packages/convex/convex/__tests__/migrations-evidence-text.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { backfillEvidenceText, backfillJob5156WorkHistoryEducation } from '../migrations'
+import {
+  backfillEvidenceText,
+  backfillJob5156LocationHierarchy,
+  backfillJob5156WorkHistoryEducation,
+} from '../migrations'
 
 type BackfillEvidenceTextResult = {
   scannedResumes: number
@@ -21,6 +25,19 @@ const backfillEvidenceTextHandler = (backfillEvidenceText as unknown as ConvexHa
 const backfillJob5156WorkHistoryEducationHandler = (backfillJob5156WorkHistoryEducation as unknown as ConvexHandler<
   Record<string, never>,
   { scannedResumes: number; updatedResumes: number; movedEducationEntries: number; hasMore: boolean; cursor: string | null }
+>)._handler
+
+const backfillJob5156LocationHierarchyHandler = (backfillJob5156LocationHierarchy as unknown as ConvexHandler<
+  Record<string, never>,
+  {
+    scannedResumes: number
+    updatedResumes: number
+    updatedLocationHierarchy: number
+    updatedLocation: number
+    updatedSearchText: number
+    hasMore: boolean
+    cursor: string | null
+  }
 >)._handler
 
 type ResumeRecord = {
@@ -228,5 +245,68 @@ describe('backfillJob5156WorkHistoryEducation', () => {
     })
 
     expect(ctx.patches.some((entry) => entry.id === 'seek-legacy')).toBe(false)
+  })
+})
+
+describe('backfillJob5156LocationHierarchy', () => {
+  it('backfills structured location hierarchy and rebuilds search text for Job5156 resumes', async () => {
+    const records: ResumeRecord[] = [
+      {
+        _id: 'job5156-location',
+        content: {
+          source: 'hr.job5156.com',
+          profileUrl: 'https://hr.job5156.com/resume/view/123',
+          location: '',
+          workHistory: [
+            {
+              raw: '2020-01~2024-01 东莞精密机械有限公司 销售工程师',
+              companyName: '东莞精密机械有限公司',
+              jobTitle: '销售工程师',
+            },
+          ],
+        },
+        ingestData: {
+          evidenceText: 'stale evidence',
+          industryTags: ['machinery'],
+          synonymHits: ['销售'],
+          ruleScores: { jd1: 80 },
+          experienceLevel: 'mid',
+          computedAt: 1_700_000_000_000,
+          skillsVersion: 1,
+        },
+      },
+    ]
+
+    const ctx = createResumesDb(records)
+    const result = await backfillJob5156LocationHierarchyHandler(ctx as never, {})
+
+    expect(result).toEqual({
+      scannedResumes: 1,
+      updatedResumes: 1,
+      updatedLocationHierarchy: 1,
+      updatedLocation: 1,
+      updatedSearchText: 1,
+      hasMore: false,
+      cursor: null,
+    })
+
+    expect(ctx.patches).toContainEqual({
+      id: 'job5156-location',
+      patch: expect.objectContaining({
+        content: expect.objectContaining({
+          source: 'hr.job5156.com',
+          profileUrl: 'https://hr.job5156.com/resume/view/123',
+          location: '广东东莞',
+          locationHierarchy: {
+            country: '中国',
+            province: '广东',
+            city: '东莞',
+            matchedFrom: 'workHistory',
+            confidence: 'high',
+          },
+        }),
+        searchText: expect.stringContaining('中国'),
+      }),
+    })
   })
 })

--- a/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
+++ b/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
@@ -114,4 +114,21 @@ describe("projectIngestDiagnosticsRow", () => {
         expect(row).not.toHaveProperty("content");
         expect(row).not.toHaveProperty("analysis");
     });
+
+    it("derives a canonical location from raw resume fields when the explicit field is blank", () => {
+        const row = projectIngestDiagnosticsRow({
+            _id: "resume-2",
+            externalId: "ext-2",
+            content: {
+                name: "赵先生",
+                jobIntention: "销售工程师",
+                location: "",
+                workHistory: [
+                    { raw: "2020-01~2024-01 东莞精密机械有限公司 销售工程师" },
+                ],
+            },
+        });
+
+        expect(row.location).toBe("广东东莞");
+    });
 });

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -2,7 +2,12 @@ import { internal } from "./_generated/api";
 import { action, mutation } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
-import { buildWorkHistoryEvidence, normalizeWorkHistoryEntry } from "@trends/shared";
+import {
+    buildWorkHistoryEvidence,
+    formatLocationHierarchyLabel,
+    normalizeResumeLocationHierarchy,
+    normalizeWorkHistoryEntry,
+} from "@trends/shared";
 
 import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
 import { deriveResumeIdentityKey } from "./lib/resume_identity";
@@ -109,6 +114,57 @@ function rewriteJob5156ProfileUrlsInContent(content: unknown): {
     return {
         content: nextContent,
         updatedFields,
+    };
+}
+
+type RewriteJob5156LocationHierarchyResult = {
+    content: Record<string, unknown> | null;
+    updatedLocationHierarchy: boolean;
+    updatedLocation: boolean;
+};
+
+function rewriteJob5156LocationHierarchyInContent(content: unknown): RewriteJob5156LocationHierarchyResult {
+    if (!isRecord(content)) {
+        return {
+            content: null,
+            updatedLocationHierarchy: false,
+            updatedLocation: false,
+        };
+    }
+
+    const source = typeof content.source === "string" ? content.source.toLowerCase() : "";
+    const profileUrl = typeof content.profileUrl === "string" ? content.profileUrl.toLowerCase() : "";
+    const isJob5156 = source === JOB5156_HOST || profileUrl.includes(JOB5156_HOST);
+    if (!isJob5156) {
+        return {
+            content: null,
+            updatedLocationHierarchy: false,
+            updatedLocation: false,
+        };
+    }
+
+    const locationHierarchy = normalizeResumeLocationHierarchy(content);
+    const rawLocation = typeof content.location === "string" ? content.location.trim() : "";
+    const nextLocation = rawLocation || (locationHierarchy ? formatLocationHierarchyLabel(locationHierarchy) : "");
+
+    let nextContent: Record<string, unknown> | null = null;
+    let updatedLocationHierarchy = false;
+    let updatedLocation = false;
+
+    if (locationHierarchy && !content.locationHierarchy) {
+        nextContent = { ...(nextContent ?? content), locationHierarchy };
+        updatedLocationHierarchy = true;
+    }
+
+    if (nextLocation && nextLocation !== rawLocation) {
+        nextContent = { ...(nextContent ?? content), location: nextLocation };
+        updatedLocation = true;
+    }
+
+    return {
+        content: nextContent,
+        updatedLocationHierarchy,
+        updatedLocation,
     };
 }
 
@@ -675,6 +731,77 @@ export const backfillJob5156WorkHistoryEducation = mutation({
             scannedResumes: resumes.page.length,
             updatedResumes,
             movedEducationEntries,
+            hasMore: !resumes.isDone,
+            cursor: resumes.isDone ? null : resumes.continueCursor,
+        };
+    },
+});
+
+export const backfillJob5156LocationHierarchy = mutation({
+    args: {
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const resumes = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.batchSize),
+            });
+
+        let updatedResumes = 0;
+        let updatedLocationHierarchy = 0;
+        let updatedLocation = 0;
+        let updatedSearchText = 0;
+
+        for (const resume of resumes.page) {
+            const rewritten = rewriteJob5156LocationHierarchyInContent(resume.content);
+            const searchText = mergeSearchTextWithIngestData(
+                buildSearchText(rewritten.content ?? resume.content),
+                {
+                    industryTags: resume.ingestData?.industryTags,
+                    synonymHits: resume.ingestData?.synonymHits,
+                    brandHits: resume.ingestData?.brandHits,
+                    companyHits: resume.ingestData?.companyHits,
+                }
+            );
+
+            const patch: {
+                content?: Record<string, unknown>;
+                searchText?: string;
+            } = {};
+
+            if (rewritten.content) {
+                patch.content = rewritten.content;
+                if (rewritten.updatedLocationHierarchy) {
+                    updatedLocationHierarchy += 1;
+                }
+                if (rewritten.updatedLocation) {
+                    updatedLocation += 1;
+                }
+            }
+
+            if (searchText !== resume.searchText) {
+                patch.searchText = searchText;
+                updatedSearchText += 1;
+            }
+
+            if (Object.keys(patch).length === 0) {
+                continue;
+            }
+
+            await ctx.db.patch(resume._id, patch);
+            updatedResumes += 1;
+        }
+
+        return {
+            scannedResumes: resumes.page.length,
+            updatedResumes,
+            updatedLocationHierarchy,
+            updatedLocation,
+            updatedSearchText,
             hasMore: !resumes.isDone,
             cursor: resumes.isDone ? null : resumes.continueCursor,
         };

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -3,6 +3,10 @@ import type { Doc } from "./_generated/dataModel";
 import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 
+import {
+    formatLocationHierarchyLabel,
+    normalizeResumeLocationHierarchy,
+} from "@trends/shared";
 import { mergeSearchTextWithIngestData } from "./search_text";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -202,13 +206,14 @@ export function projectIngestDiagnosticsRow(
 ): IngestDiagnosticsRow {
     const content = isRecord(resume.content) ? resume.content : {};
     const ingestData = resume.ingestData;
+    const locationHierarchy = normalizeResumeLocationHierarchy(content);
 
     return {
         resumeId: resume._id,
         externalId: resume.externalId,
         name: toStringValue(content.name),
         jobIntention: toStringValue(content.jobIntention),
-        location: toStringValue(content.location),
+        location: toStringValue(content.location) || formatLocationHierarchyLabel(locationHierarchy),
         ingestData: ingestData ? {
             industryTags: ingestData.industryTags,
             companyHits: ingestData.companyHits ?? [],

--- a/packages/convex/convex/search_text.ts
+++ b/packages/convex/convex/search_text.ts
@@ -1,3 +1,5 @@
+import { formatLocationHierarchySearchText, type LocationHierarchy } from "@trends/shared";
+
 const PRIORITY_KEYS = [
     "name",
     "desiredPosition",
@@ -7,6 +9,7 @@ const PRIORITY_KEYS = [
     "workHistory",
     "companies",
     "summary",
+    "locationHierarchy",
 ];
 
 const PRIORITY_KEY_SET = new Set(PRIORITY_KEYS);
@@ -137,6 +140,13 @@ function toTextFragments(value: unknown): string[] {
 function collectPriorityFragments(content: UnknownRecord): string[] {
     const parts: string[] = [];
     for (const key of PRIORITY_KEYS) {
+        if (key === "locationHierarchy") {
+            const locationHierarchy = formatLocationHierarchySearchText(content[key] as LocationHierarchy | null | undefined);
+            if (locationHierarchy) {
+                parts.push(locationHierarchy);
+            }
+            continue;
+        }
         parts.push(...toTextFragments(content[key]));
     }
     return parts;

--- a/packages/shared/src/__tests__/location-tree.test.ts
+++ b/packages/shared/src/__tests__/location-tree.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  formatLocationHierarchyLabel,
+  formatLocationHierarchySearchText,
   findLocation,
   getAllDescendants,
   getChildren,
   isLocationMatch,
+  normalizeLocationHierarchy,
   normalizeLocationName,
+  resolveLocationHierarchy,
 } from "../location-tree";
 
 describe("location-tree", () => {
@@ -13,6 +17,7 @@ describe("location-tree", () => {
     expect(normalizeLocationName("东莞市")).toBe("东莞");
     expect(normalizeLocationName("南城区")).toBe("南城");
     expect(normalizeLocationName("浦东新区")).toBe("浦东");
+    expect(normalizeLocationName("中国")).toBe("中国");
   });
 
   it("finds location by alias and compound text", () => {
@@ -41,6 +46,24 @@ describe("location-tree", () => {
     expect(isLocationMatch("东莞南城区", "广东")).toBe(true);
     expect(isLocationMatch("昆山市", "江苏")).toBe(true);
     expect(isLocationMatch("昆山市", "苏州")).toBe(true);
+  });
+
+  it("resolves China-rooted hierarchies with city-level canonical labels", () => {
+    const hierarchy = resolveLocationHierarchy("东莞长安镇");
+    expect(hierarchy).toEqual(expect.objectContaining({
+      country: "中国",
+      province: "广东",
+      city: "东莞",
+      confidence: "high",
+    }));
+    expect(formatLocationHierarchyLabel(hierarchy)).toBe("广东东莞");
+    expect(formatLocationHierarchySearchText(hierarchy)).toBe("中国 广东 东莞");
+    expect(normalizeLocationHierarchy(hierarchy)).toEqual(hierarchy);
+    expect(resolveLocationHierarchy("石碣镇")?.city).toBe("东莞");
+  });
+
+  it("rejects conflicting sibling locations", () => {
+    expect(resolveLocationHierarchy("东莞深圳")).toBeUndefined();
   });
 
   it("does not match non-descendant branches", () => {

--- a/packages/shared/src/location-tree.ts
+++ b/packages/shared/src/location-tree.ts
@@ -1,4 +1,4 @@
-type LocationLevel = "province" | "city" | "district";
+type LocationLevel = "country" | "province" | "city" | "district";
 
 type LocationSeed = {
   name: string;
@@ -30,6 +30,14 @@ export type LocationNode = {
   children: string[];
 };
 
+export type LocationHierarchy = {
+  country: string;
+  province?: string;
+  city?: string;
+  matchedFrom?: "location" | "profile" | "workHistory" | "jobIntention";
+  confidence?: "high";
+};
+
 const LOCATION_SUFFIXES = [
   "特别行政区",
   "自治州",
@@ -49,91 +57,143 @@ const LOCATION_SUFFIXES = [
 
 const LOCATION_TREE: LocationSeed[] = [
   {
-    name: "广东",
-    aliases: ["广东省"],
+    name: "中国",
+    aliases: ["中华人民共和国", "中国大陆"],
     children: [
-      { name: "广州", aliases: ["广州市"] },
-      { name: "深圳", aliases: ["深圳市"] },
-      { name: "珠海", aliases: ["珠海市"] },
-      { name: "汕头", aliases: ["汕头市"] },
-      { name: "佛山", aliases: ["佛山市"] },
-      { name: "韶关", aliases: ["韶关市"] },
-      { name: "湛江", aliases: ["湛江市"] },
-      { name: "肇庆", aliases: ["肇庆市"] },
-      { name: "江门", aliases: ["江门市"] },
-      { name: "茂名", aliases: ["茂名市"] },
-      { name: "惠州", aliases: ["惠州市"] },
-      { name: "梅州", aliases: ["梅州市"] },
-      { name: "汕尾", aliases: ["汕尾市"] },
-      { name: "河源", aliases: ["河源市"] },
-      { name: "阳江", aliases: ["阳江市"] },
-      { name: "清远", aliases: ["清远市"] },
       {
-        name: "东莞",
-        aliases: ["东莞市"],
+        name: "广东",
+        aliases: ["广东省"],
         children: [
-          { name: "南城", aliases: ["南城区"] },
-          { name: "东城", aliases: ["东城区"] },
-          { name: "万江", aliases: ["万江区"] },
-          { name: "莞城", aliases: ["莞城区"] },
-          { name: "长安", aliases: ["长安镇"] },
-          { name: "虎门", aliases: ["虎门镇"] },
-          { name: "厚街", aliases: ["厚街镇"] },
-          { name: "常平", aliases: ["常平镇"] },
-          { name: "塘厦", aliases: ["塘厦镇"] },
-          { name: "凤岗", aliases: ["凤岗镇"] },
-          { name: "松山湖", aliases: ["松山湖高新区", "松山湖园区"] },
+          { name: "广州", aliases: ["广州市"] },
+          { name: "深圳", aliases: ["深圳市"] },
+          { name: "珠海", aliases: ["珠海市"] },
+          { name: "汕头", aliases: ["汕头市"] },
+          { name: "佛山", aliases: ["佛山市"] },
+          { name: "韶关", aliases: ["韶关市"] },
+          { name: "湛江", aliases: ["湛江市"] },
+          { name: "肇庆", aliases: ["肇庆市"] },
+          { name: "江门", aliases: ["江门市"] },
+          { name: "茂名", aliases: ["茂名市"] },
+          { name: "惠州", aliases: ["惠州市"] },
+          { name: "梅州", aliases: ["梅州市"] },
+          { name: "汕尾", aliases: ["汕尾市"] },
+          { name: "河源", aliases: ["河源市"] },
+          { name: "阳江", aliases: ["阳江市"] },
+          { name: "清远", aliases: ["清远市"] },
+          {
+            name: "东莞",
+            aliases: ["东莞市", "全东莞"],
+            children: [
+              { name: "南城", aliases: ["南城区"] },
+              { name: "东城", aliases: ["东城区"] },
+              { name: "万江", aliases: ["万江区"] },
+              { name: "莞城", aliases: ["莞城区"] },
+              { name: "长安", aliases: ["长安镇"] },
+              { name: "虎门", aliases: ["虎门镇"] },
+              { name: "厚街", aliases: ["厚街镇"] },
+              { name: "常平", aliases: ["常平镇"] },
+              { name: "塘厦", aliases: ["塘厦镇"] },
+              { name: "凤岗", aliases: ["凤岗镇"] },
+              { name: "松山湖", aliases: ["松山湖高新区", "松山湖园区"] },
+              { name: "石龙", aliases: ["石龙镇"] },
+              { name: "寮步", aliases: ["寮步镇"] },
+              { name: "樟木头", aliases: ["樟木头镇"] },
+              { name: "高埗", aliases: ["高埗镇"] },
+              { name: "中堂", aliases: ["中堂镇"] },
+              { name: "麻涌", aliases: ["麻涌镇"] },
+              { name: "望牛墩", aliases: ["望牛墩镇"] },
+              { name: "洪梅", aliases: ["洪梅镇"] },
+              { name: "石碣", aliases: ["石碣镇"] },
+              { name: "茶山", aliases: ["茶山镇"] },
+              { name: "石排", aliases: ["石排镇"] },
+              { name: "企石", aliases: ["企石镇"] },
+              { name: "清溪", aliases: ["清溪镇"] },
+              { name: "沙田", aliases: ["沙田镇"] },
+              { name: "道滘", aliases: ["道滘镇"] },
+              { name: "大朗", aliases: ["大朗镇"] },
+              { name: "黄江", aliases: ["黄江镇"] },
+              { name: "大岭山", aliases: ["大岭山镇"] },
+              { name: "横沥", aliases: ["横沥镇"] },
+              { name: "桥头", aliases: ["桥头镇"] },
+              { name: "谢岗", aliases: ["谢岗镇"] },
+              { name: "东坑", aliases: ["东坑镇"] },
+            ],
+          },
+          { name: "中山", aliases: ["中山市"] },
+          { name: "潮州", aliases: ["潮州市"] },
+          { name: "揭阳", aliases: ["揭阳市"] },
+          { name: "云浮", aliases: ["云浮市"] },
         ],
       },
-      { name: "中山", aliases: ["中山市"] },
-      { name: "潮州", aliases: ["潮州市"] },
-      { name: "揭阳", aliases: ["揭阳市"] },
-      { name: "云浮", aliases: ["云浮市"] },
-    ],
-  },
-  {
-    name: "江苏",
-    aliases: ["江苏省"],
-    children: [
-      { name: "南京", aliases: ["南京市"] },
-      { name: "无锡", aliases: ["无锡市"] },
-      { name: "常州", aliases: ["常州市"] },
       {
-        name: "苏州",
-        aliases: ["苏州市"],
-        children: [{ name: "昆山", aliases: ["昆山市"] }],
+        name: "江苏",
+        aliases: ["江苏省"],
+        children: [
+          { name: "南京", aliases: ["南京市"] },
+          { name: "无锡", aliases: ["无锡市"] },
+          { name: "常州", aliases: ["常州市"] },
+          {
+            name: "苏州",
+            aliases: ["苏州市"],
+            children: [{ name: "昆山", aliases: ["昆山市"] }],
+          },
+          { name: "南通", aliases: ["南通市"] },
+          { name: "镇江", aliases: ["镇江市"] },
+          { name: "扬州", aliases: ["扬州市"] },
+        ],
       },
-      { name: "南通", aliases: ["南通市"] },
-      { name: "镇江", aliases: ["镇江市"] },
-      { name: "扬州", aliases: ["扬州市"] },
-    ],
-  },
-  {
-    name: "浙江",
-    aliases: ["浙江省"],
-    children: [
-      { name: "杭州", aliases: ["杭州市"] },
-      { name: "宁波", aliases: ["宁波市"] },
-      { name: "温州", aliases: ["温州市"] },
-      { name: "嘉兴", aliases: ["嘉兴市"] },
-      { name: "湖州", aliases: ["湖州市"] },
-      { name: "绍兴", aliases: ["绍兴市"] },
-      { name: "金华", aliases: ["金华市"] },
-      { name: "台州", aliases: ["台州市"] },
-    ],
-  },
-  {
-    name: "上海",
-    aliases: ["上海市"],
-    children: [
-      { name: "浦东", aliases: ["浦东新区"] },
-      { name: "闵行", aliases: ["闵行区"] },
-      { name: "松江", aliases: ["松江区"] },
-      { name: "嘉定", aliases: ["嘉定区"] },
-      { name: "宝山", aliases: ["宝山区"] },
-      { name: "青浦", aliases: ["青浦区"] },
-      { name: "徐汇", aliases: ["徐汇区"] },
-      { name: "静安", aliases: ["静安区"] },
+      {
+        name: "浙江",
+        aliases: ["浙江省"],
+        children: [
+          { name: "杭州", aliases: ["杭州市"] },
+          { name: "宁波", aliases: ["宁波市"] },
+          { name: "温州", aliases: ["温州市"] },
+          { name: "嘉兴", aliases: ["嘉兴市"] },
+          { name: "湖州", aliases: ["湖州市"] },
+          { name: "绍兴", aliases: ["绍兴市"] },
+          { name: "金华", aliases: ["金华市"] },
+          { name: "台州", aliases: ["台州市"] },
+        ],
+      },
+      {
+        name: "上海",
+        aliases: ["上海市"],
+        children: [
+          { name: "浦东", aliases: ["浦东新区"] },
+          { name: "闵行", aliases: ["闵行区"] },
+          { name: "松江", aliases: ["松江区"] },
+          { name: "嘉定", aliases: ["嘉定区"] },
+          { name: "宝山", aliases: ["宝山区"] },
+          { name: "青浦", aliases: ["青浦区"] },
+          { name: "徐汇", aliases: ["徐汇区"] },
+          { name: "静安", aliases: ["静安区"] },
+        ],
+      },
+      {
+        name: "北京",
+        aliases: ["北京市"],
+      },
+      {
+        name: "天津",
+        aliases: ["天津市"],
+      },
+      {
+        name: "重庆",
+        aliases: ["重庆市"],
+      },
+      {
+        name: "香港",
+        aliases: ["香港特别行政区"],
+      },
+      {
+        name: "澳门",
+        aliases: ["澳门特别行政区"],
+      },
+      {
+        name: "台湾",
+        aliases: ["台湾省"],
+      },
     ],
   },
   {
@@ -153,8 +213,9 @@ const aliasesToNodeIds = new Map<string, string[]>();
 const aliasEntries: AliasEntry[] = [];
 
 function toLocationLevel(depth: number): LocationLevel {
-  if (depth <= 1) return "province";
-  if (depth === 2) return "city";
+  if (depth <= 1) return "country";
+  if (depth === 2) return "province";
+  if (depth === 3) return "city";
   return "district";
 }
 
@@ -242,6 +303,57 @@ function nodeToPublic(node: InternalLocationNode): LocationNode {
       .map((childId) => getNodeById(childId)?.name)
       .filter((value): value is string => Boolean(value)),
   };
+}
+
+function getNodeLineage(nodeId: string): InternalLocationNode[] {
+  const lineage: InternalLocationNode[] = [];
+  let current = getNodeById(nodeId);
+  while (current) {
+    lineage.push(current);
+    current = current.parentId ? getNodeById(current.parentId) : undefined;
+  }
+  return lineage.reverse();
+}
+
+function isHierarchyCompatible(nodeIds: string[]): boolean {
+  for (let i = 0; i < nodeIds.length; i += 1) {
+    for (let j = i + 1; j < nodeIds.length; j += 1) {
+      const left = nodeIds[i];
+      const right = nodeIds[j];
+      if (!isSameOrDescendant(left, right) && !isSameOrDescendant(right, left)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function buildLocationHierarchyFromNode(node: InternalLocationNode, matchedFrom?: LocationHierarchy["matchedFrom"]): LocationHierarchy {
+  const lineage = getNodeLineage(node.id);
+  const root = lineage[0];
+  const hierarchy: LocationHierarchy = {
+    country: root?.name ?? "中国",
+    confidence: "high",
+  };
+
+  if (matchedFrom) {
+    hierarchy.matchedFrom = matchedFrom;
+  }
+
+  for (const ancestor of lineage) {
+    if (ancestor.level === "province") {
+      hierarchy.province = ancestor.name;
+    }
+    if (ancestor.level === "city") {
+      hierarchy.city = ancestor.name;
+    }
+  }
+
+  if (node.level === "province") {
+    delete hierarchy.city;
+  }
+
+  return hierarchy;
 }
 
 function pickBestNode(nodeIds: string[], normalizedInput: string): InternalLocationNode | undefined {
@@ -354,7 +466,7 @@ export function normalizeLocationName(name: string): string {
     .replace(/[，,、]/g, "")
     .replace(/\s+/g, "");
 
-  if (normalized.startsWith("中国")) {
+  if (normalized.startsWith("中国") && normalized.length > "中国".length) {
     normalized = normalized.slice(2);
   }
 
@@ -375,6 +487,100 @@ export function normalizeLocationName(name: string): string {
   }
 
   return normalized;
+}
+
+export function formatLocationHierarchyLabel(hierarchy: LocationHierarchy | null | undefined): string {
+  if (!hierarchy) {
+    return "";
+  }
+
+  const parts = [hierarchy.province, hierarchy.city].filter((value): value is string => Boolean(value));
+  if (parts.length > 0) {
+    return parts.join("");
+  }
+
+  return hierarchy.country || "";
+}
+
+export function formatLocationHierarchySearchText(hierarchy: LocationHierarchy | null | undefined): string {
+  if (!hierarchy) {
+    return "";
+  }
+
+  return [hierarchy.country, hierarchy.province, hierarchy.city]
+    .filter((value): value is string => Boolean(value))
+    .join(" ");
+}
+
+export function resolveLocationHierarchy(name: string, matchedFrom?: LocationHierarchy["matchedFrom"]): LocationHierarchy | undefined {
+  const normalizedInput = normalizeLocationName(name);
+  if (!normalizedInput) {
+    return undefined;
+  }
+
+  const candidateNodeIds = extractLocationNodeIds(name);
+  if (candidateNodeIds.length === 0 || !isHierarchyCompatible(candidateNodeIds)) {
+    return undefined;
+  }
+
+  const bestNode = pickBestNode(candidateNodeIds, normalizedInput);
+  if (!bestNode) {
+    return undefined;
+  }
+
+  return buildLocationHierarchyFromNode(bestNode, matchedFrom);
+}
+
+export function normalizeLocationHierarchy(value: unknown): LocationHierarchy | undefined {
+  if (typeof value === "string") {
+    return resolveLocationHierarchy(value);
+  }
+
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const country = typeof record.country === "string" ? record.country.trim() : "";
+  const province = typeof record.province === "string" ? record.province.trim() : "";
+  const city = typeof record.city === "string" ? record.city.trim() : "";
+  const matchedFrom = record.matchedFrom === "location"
+    || record.matchedFrom === "profile"
+    || record.matchedFrom === "workHistory"
+    || record.matchedFrom === "jobIntention"
+    ? record.matchedFrom
+    : undefined;
+  const confidence = record.confidence === "high" ? "high" : undefined;
+
+  const resolved = resolveLocationHierarchy([country, province, city].filter(Boolean).join(""));
+  if (resolved) {
+    if (matchedFrom) {
+      resolved.matchedFrom = matchedFrom;
+    }
+    if (confidence) {
+      resolved.confidence = confidence;
+    }
+    return resolved;
+  }
+
+  if (country) {
+    const hierarchy: LocationHierarchy = { country };
+    if (province) {
+      hierarchy.province = province;
+    }
+    if (city) {
+      hierarchy.city = city;
+    }
+    if (matchedFrom) {
+      hierarchy.matchedFrom = matchedFrom;
+    }
+    if (confidence) {
+      hierarchy.confidence = confidence;
+    }
+    return hierarchy;
+  }
+
+  return undefined;
 }
 
 export function findLocation(name: string): LocationNode | undefined {
@@ -425,6 +631,16 @@ export function isLocationMatch(resumeLocation: string, filterName: string): boo
     return true;
   }
 
+  const filterNode = findLocationNode(filterName);
+  if (!filterNode) {
+    const normalizedResume = normalizeLocationName(resumeLocation);
+    return Boolean(normalizedResume && normalizedResume.includes(normalizedFilter));
+  }
+
+  if (typeof resumeLocation !== "string") {
+    return false;
+  }
+
   const normalizedResume = normalizeLocationName(resumeLocation);
   if (!normalizedResume) {
     return false;
@@ -432,11 +648,6 @@ export function isLocationMatch(resumeLocation: string, filterName: string): boo
 
   if (normalizedResume === normalizedFilter || normalizedResume.includes(normalizedFilter)) {
     return true;
-  }
-
-  const filterNode = findLocationNode(filterName);
-  if (!filterNode) {
-    return normalizedResume.includes(normalizedFilter);
   }
 
   const resumeNodeIds = extractLocationNodeIds(resumeLocation);

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -1,3 +1,9 @@
+import {
+  formatLocationHierarchyLabel,
+  normalizeLocationHierarchy as normalizeLocationTreeHierarchy,
+  type LocationHierarchy,
+} from "./location-tree.js";
+
 export type ResumeWorkHistoryItem = {
   raw: string;
   companyName?: string;
@@ -57,6 +63,8 @@ export type ResumeDigitalIdentity = {
 
 export type NormalizedResumeFields = {
   profileUrl: string;
+  location?: string;
+  locationHierarchy?: LocationHierarchy;
   workHistory: ResumeWorkHistoryItem[];
   profileEducation?: ResumeProfileEducationItem[];
   skills?: Array<string | ResumeSkillDetail>;
@@ -225,6 +233,140 @@ function normalizeWorkHistory(value: unknown): ResumeWorkHistoryItem[] {
   return normalized;
 }
 
+type RankedLocationHierarchy = {
+  hierarchy: LocationHierarchy;
+  priority: number;
+};
+
+function hierarchySignature(value: LocationHierarchy): string {
+  return [value.country, value.province ?? "", value.city ?? ""].join("|");
+}
+
+function hierarchySpecificity(value: LocationHierarchy): number {
+  return [value.province, value.city].filter((part) => Boolean(part)).length;
+}
+
+function areHierarchiesCompatible(left: LocationHierarchy, right: LocationHierarchy): boolean {
+  if (left.country !== right.country) {
+    return false;
+  }
+
+  if (left.province && right.province && left.province !== right.province) {
+    return false;
+  }
+
+  if (left.city && right.city && left.city !== right.city) {
+    return false;
+  }
+
+  return true;
+}
+
+function chooseBestLocationHierarchy(candidates: RankedLocationHierarchy[]): LocationHierarchy | undefined {
+  if (candidates.length === 0) {
+    return undefined;
+  }
+
+  const deduped = new Map<string, RankedLocationHierarchy>();
+  for (const candidate of candidates) {
+    const key = hierarchySignature(candidate.hierarchy);
+    const existing = deduped.get(key);
+    if (!existing || candidate.priority > existing.priority) {
+      deduped.set(key, candidate);
+    }
+  }
+
+  const uniqueCandidates = Array.from(deduped.values());
+  for (let leftIndex = 0; leftIndex < uniqueCandidates.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < uniqueCandidates.length; rightIndex += 1) {
+      if (!areHierarchiesCompatible(uniqueCandidates[leftIndex].hierarchy, uniqueCandidates[rightIndex].hierarchy)) {
+        return undefined;
+      }
+    }
+  }
+
+  uniqueCandidates.sort((left, right) => {
+    const specificityDiff = hierarchySpecificity(right.hierarchy) - hierarchySpecificity(left.hierarchy);
+    if (specificityDiff !== 0) {
+      return specificityDiff;
+    }
+
+    if (right.priority !== left.priority) {
+      return right.priority - left.priority;
+    }
+
+    return hierarchySignature(left.hierarchy).localeCompare(hierarchySignature(right.hierarchy));
+  });
+
+  return uniqueCandidates[0]?.hierarchy;
+}
+
+function toLocationHierarchyCandidate(
+  value: unknown,
+  matchedFrom: LocationHierarchy["matchedFrom"],
+  priority: number
+): RankedLocationHierarchy | undefined {
+  const hierarchy = normalizeLocationTreeHierarchy(value);
+  if (!hierarchy) {
+    return undefined;
+  }
+
+  const nextHierarchy: LocationHierarchy = {
+    ...hierarchy,
+    matchedFrom,
+    confidence: "high",
+  };
+
+  return {
+    hierarchy: nextHierarchy,
+    priority,
+  };
+}
+
+function collectLocationHierarchyCandidates(record: Record<string, unknown>): RankedLocationHierarchy[] {
+  const candidates: RankedLocationHierarchy[] = [];
+  const pushCandidate = (
+    value: unknown,
+    matchedFrom: LocationHierarchy["matchedFrom"],
+    priority: number
+  ) => {
+    const candidate = toLocationHierarchyCandidate(value, matchedFrom, priority);
+    if (candidate) {
+      candidates.push(candidate);
+    }
+  };
+
+  pushCandidate(record.location, "location", 100);
+
+  if (Array.isArray(record.workHistory)) {
+    for (const entry of record.workHistory) {
+      if (!isRecord(entry)) {
+        if (typeof entry === "string") {
+          pushCandidate(entry, "workHistory", 80);
+        }
+        continue;
+      }
+
+      pushCandidate(entry.raw, "workHistory", 80);
+      pushCandidate(entry.companyName, "workHistory", 80);
+      pushCandidate(entry.description, "workHistory", 80);
+    }
+  }
+
+  pushCandidate(record.jobIntention, "jobIntention", 60);
+
+  return candidates;
+}
+
+export function normalizeResumeLocationHierarchy(record: Record<string, unknown>): LocationHierarchy | undefined {
+  const explicitHierarchy = normalizeLocationTreeHierarchy(record.locationHierarchy);
+  if (explicitHierarchy) {
+    return explicitHierarchy;
+  }
+
+  return chooseBestLocationHierarchy(collectLocationHierarchyCandidates(record));
+}
+
 function normalizeProfileEducation(value: unknown): ResumeProfileEducationItem[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
@@ -379,8 +521,13 @@ function normalizeOptionalNumber(value: unknown): number | undefined {
 }
 
 export function normalizeSharedResumeFields(record: Record<string, unknown>, source?: string): NormalizedResumeFields {
+  const locationHierarchy = normalizeResumeLocationHierarchy(record);
+  const location = toTrimmedString(record.location) || formatLocationHierarchyLabel(locationHierarchy);
+
   return {
     profileUrl: normalizeProfileUrlForDisplay(record.profileUrl, source),
+    ...(location ? { location } : {}),
+    ...(locationHierarchy ? { locationHierarchy } : {}),
     workHistory: normalizeWorkHistory(record.workHistory),
     profileEducation: normalizeProfileEducation(record.profileEducation),
     skills: normalizeStringOrObjectArray(record.skills, normalizeSkillDetail),


### PR DESCRIPTION
Adds China-rooted location hierarchy derivation for resumes, backfills Job5156 blank locations, and updates search/index/filter paths plus tests.\n\nValidation: make check