### PR TITLE
fix: preserve district in location hierarchy

### DIFF
--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -36,6 +36,7 @@ export const ResumeLocationHierarchySchema = z
     country: z.string().openapi({ example: "中国" }),
     province: z.string().optional().openapi({ example: "广东" }),
     city: z.string().optional().openapi({ example: "东莞" }),
+    district: z.string().optional().openapi({ example: "长安" }),
     matchedFrom: z.enum(["location", "profile", "workHistory", "jobIntention"]).optional(),
     confidence: z.literal("high").optional(),
   })

--- a/apps/api/src/services/__tests__/search-text-builder.test.ts
+++ b/apps/api/src/services/__tests__/search-text-builder.test.ts
@@ -56,12 +56,13 @@ describe("buildSearchText", () => {
         country: "中国",
         province: "广东",
         city: "东莞",
+        district: "长安",
         matchedFrom: "location",
         confidence: "high",
       },
     });
 
-    expect(result).toBe("中国 广东 东莞");
+    expect(result).toBe("中国 广东 东莞 长安");
   });
 
   it("splits cjk and ascii boundaries for mixed-script search tokens", () => {

--- a/apps/api/src/services/resume-import-service.test.ts
+++ b/apps/api/src/services/resume-import-service.test.ts
@@ -104,6 +104,7 @@ describe("resume-import-service", () => {
           country: "中国",
           province: "广东",
           city: "东莞",
+          district: "石碣",
           matchedFrom: "location",
           confidence: "high",
         },

--- a/apps/api/src/services/resume-index.test.ts
+++ b/apps/api/src/services/resume-index.test.ts
@@ -133,6 +133,7 @@ describe("ResumeIndexService", () => {
             country: "中国",
             province: "广东",
             city: "东莞",
+            district: "长安",
           },
           selfIntro: "",
           jobIntention: "",
@@ -151,6 +152,7 @@ describe("ResumeIndexService", () => {
       expect(entry?.searchText).toContain("中国");
       expect(entry?.searchText).toContain("广东");
       expect(entry?.searchText).toContain("东莞");
+      expect(entry?.searchText).toContain("长安");
     } finally {
       cleanupFixtureRoot(root);
     }

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -598,6 +598,7 @@ describe('useResumeListState role filter regression', () => {
           country: '中国',
           province: '广东',
           city: '东莞',
+          district: '长安',
         },
         roleSignals: [
           {
@@ -613,7 +614,7 @@ describe('useResumeListState role filter regression', () => {
       }),
     ]
     mockState.filters = {
-      locations: ['东莞'],
+      locations: ['长安'],
     }
 
     expect(getDisplayedResumeNames()).toEqual(['Hierarchy Location'])

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -218,7 +218,9 @@ function normalizeFilterToken(value: string): string {
   return value.trim().toLowerCase()
 }
 
-function getResumeLocationText(resume: { location?: string; locationHierarchy?: { country: string; province?: string; city?: string } }): string {
+function getResumeLocationText(
+  resume: { location?: string; locationHierarchy?: { country: string; province?: string; city?: string; district?: string } }
+): string {
   return formatLocationHierarchySearchText(resume.locationHierarchy) || resume.location || ''
 }
 

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -3921,6 +3921,8 @@ export interface components {
             province?: string;
             /** @example 东莞 */
             city?: string;
+            /** @example 长安 */
+            district?: string;
             /** @enum {string} */
             matchedFrom?: "location" | "profile" | "workHistory" | "jobIntention";
             /** @enum {string} */

--- a/packages/shared/src/__tests__/location-tree.test.ts
+++ b/packages/shared/src/__tests__/location-tree.test.ts
@@ -48,18 +48,28 @@ describe("location-tree", () => {
     expect(isLocationMatch("昆山市", "苏州")).toBe(true);
   });
 
-  it("resolves China-rooted hierarchies with city-level canonical labels", () => {
+  it("resolves China-rooted hierarchies with district-aware canonical labels", () => {
     const hierarchy = resolveLocationHierarchy("东莞长安镇");
     expect(hierarchy).toEqual(expect.objectContaining({
       country: "中国",
       province: "广东",
       city: "东莞",
+      district: "长安",
       confidence: "high",
     }));
-    expect(formatLocationHierarchyLabel(hierarchy)).toBe("广东东莞");
-    expect(formatLocationHierarchySearchText(hierarchy)).toBe("中国 广东 东莞");
+    expect(formatLocationHierarchyLabel(hierarchy)).toBe("广东东莞长安");
+    expect(formatLocationHierarchySearchText(hierarchy)).toBe("中国 广东 东莞 长安");
     expect(normalizeLocationHierarchy(hierarchy)).toEqual(hierarchy);
-    expect(resolveLocationHierarchy("石碣镇")?.city).toBe("东莞");
+    expect(resolveLocationHierarchy("石碣镇")).toEqual(expect.objectContaining({
+      city: "东莞",
+      district: "石碣",
+    }));
+    expect(resolveLocationHierarchy("广东深圳宝安区")).toEqual(expect.objectContaining({
+      country: "中国",
+      province: "广东",
+      city: "深圳",
+      district: "宝安",
+    }));
   });
 
   it("rejects conflicting sibling locations", () => {

--- a/packages/shared/src/location-tree.ts
+++ b/packages/shared/src/location-tree.ts
@@ -34,6 +34,7 @@ export type LocationHierarchy = {
   country: string;
   province?: string;
   city?: string;
+  district?: string;
   matchedFrom?: "location" | "profile" | "workHistory" | "jobIntention";
   confidence?: "high";
 };
@@ -64,8 +65,21 @@ const LOCATION_TREE: LocationSeed[] = [
         name: "广东",
         aliases: ["广东省"],
         children: [
-          { name: "广州", aliases: ["广州市"] },
-          { name: "深圳", aliases: ["深圳市"] },
+          {
+            name: "广州",
+            aliases: ["广州市"],
+            children: [
+              { name: "番禺", aliases: ["番禺区"] },
+              { name: "越秀", aliases: ["越秀区"] },
+            ],
+          },
+          {
+            name: "深圳",
+            aliases: ["深圳市"],
+            children: [
+              { name: "宝安", aliases: ["宝安区"] },
+            ],
+          },
           { name: "珠海", aliases: ["珠海市"] },
           { name: "汕头", aliases: ["汕头市"] },
           { name: "佛山", aliases: ["佛山市"] },
@@ -347,10 +361,18 @@ function buildLocationHierarchyFromNode(node: InternalLocationNode, matchedFrom?
     if (ancestor.level === "city") {
       hierarchy.city = ancestor.name;
     }
+    if (ancestor.level === "district") {
+      hierarchy.district = ancestor.name;
+    }
   }
 
   if (node.level === "province") {
     delete hierarchy.city;
+    delete hierarchy.district;
+  }
+
+  if (node.level === "city") {
+    delete hierarchy.district;
   }
 
   return hierarchy;
@@ -494,7 +516,7 @@ export function formatLocationHierarchyLabel(hierarchy: LocationHierarchy | null
     return "";
   }
 
-  const parts = [hierarchy.province, hierarchy.city].filter((value): value is string => Boolean(value));
+  const parts = [hierarchy.province, hierarchy.city, hierarchy.district].filter((value): value is string => Boolean(value));
   if (parts.length > 0) {
     return parts.join("");
   }
@@ -507,7 +529,7 @@ export function formatLocationHierarchySearchText(hierarchy: LocationHierarchy |
     return "";
   }
 
-  return [hierarchy.country, hierarchy.province, hierarchy.city]
+  return [hierarchy.country, hierarchy.province, hierarchy.city, hierarchy.district]
     .filter((value): value is string => Boolean(value))
     .join(" ");
 }
@@ -544,6 +566,7 @@ export function normalizeLocationHierarchy(value: unknown): LocationHierarchy | 
   const country = typeof record.country === "string" ? record.country.trim() : "";
   const province = typeof record.province === "string" ? record.province.trim() : "";
   const city = typeof record.city === "string" ? record.city.trim() : "";
+  const district = typeof record.district === "string" ? record.district.trim() : "";
   const matchedFrom = record.matchedFrom === "location"
     || record.matchedFrom === "profile"
     || record.matchedFrom === "workHistory"
@@ -552,7 +575,7 @@ export function normalizeLocationHierarchy(value: unknown): LocationHierarchy | 
     : undefined;
   const confidence = record.confidence === "high" ? "high" : undefined;
 
-  const resolved = resolveLocationHierarchy([country, province, city].filter(Boolean).join(""));
+  const resolved = resolveLocationHierarchy([country, province, city, district].filter(Boolean).join(""));
   if (resolved) {
     if (matchedFrom) {
       resolved.matchedFrom = matchedFrom;
@@ -570,6 +593,9 @@ export function normalizeLocationHierarchy(value: unknown): LocationHierarchy | 
     }
     if (city) {
       hierarchy.city = city;
+    }
+    if (district) {
+      hierarchy.district = district;
     }
     if (matchedFrom) {
       hierarchy.matchedFrom = matchedFrom;

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -239,11 +239,11 @@ type RankedLocationHierarchy = {
 };
 
 function hierarchySignature(value: LocationHierarchy): string {
-  return [value.country, value.province ?? "", value.city ?? ""].join("|");
+  return [value.country, value.province ?? "", value.city ?? "", value.district ?? ""].join("|");
 }
 
 function hierarchySpecificity(value: LocationHierarchy): number {
-  return [value.province, value.city].filter((part) => Boolean(part)).length;
+  return [value.province, value.city, value.district].filter((part) => Boolean(part)).length;
 }
 
 function areHierarchiesCompatible(left: LocationHierarchy, right: LocationHierarchy): boolean {
@@ -256,6 +256,10 @@ function areHierarchiesCompatible(left: LocationHierarchy, right: LocationHierar
   }
 
   if (left.city && right.city && left.city !== right.city) {
+    return false;
+  }
+
+  if (left.district && right.district && left.district !== right.district) {
     return false;
   }
 


### PR DESCRIPTION
Preserves district/town in structured resume location hierarchy while keeping raw Job5156 location strings unchanged.\n\nValidation: targeted vitest coverage plus make check on the equivalent patch before clean cherry-pick onto main.