### PR TITLE
feat: add resume backup and restore flows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 		i18n-check i18n-sync i18n-convert i18n-translate i18n-build \
 		refresh-sample refresh-sample-manual prefetch-convex chrome-debug \
 		seed seed-full seed-force seed-clear seed-clear-workspace seed-clear-dev \
+		backup-resumes restore-resumes \
 		clear-resumes \
 		cli-build cli-install cli-test \
 		sync-agent-policy check-agent-policy install-agent-skill check-agent-skill sync-agent-governance \
@@ -191,6 +192,33 @@ refresh-env:
 	sudo systemctl is-active --quiet trends-worker && echo "  trends-worker: active" || echo "  trends-worker: FAILED"; \
 	sudo systemctl is-active --quiet trends-worker-api && echo "  trends-worker-api: active" || echo "  trends-worker-api: FAILED"; \
 	sudo systemctl is-active --quiet trends-mcp && echo "  trends-mcp: active" || echo "  trends-mcp: FAILED"
+
+# Backup live resume records to a portable JSON file
+backup-resumes:
+	@API_URL="$${API_URL:-$${TRENDS_API_URL:-http://localhost:3000}}" \
+	WORKSPACE="$${WORKSPACE:-dev}" \
+	OUT="$${OUT:-}" \
+	LIMIT="$${LIMIT:-}" \
+	RESUME_IDS="$${RESUME_IDS:-}" \
+	SOURCE_HOSTS="$${SOURCE_HOSTS:-}" \
+	if command -v bun >/dev/null 2>&1; then \
+		bunx tsx scripts/resume/backup-resumes.ts; \
+	else \
+		npx tsx scripts/resume/backup-resumes.ts; \
+	fi
+
+# Restore live resume records from a portable JSON backup
+restore-resumes:
+	@API_URL="$${API_URL:-$${TRENDS_API_URL:-http://localhost:3000}}" \
+	WORKSPACE="$${WORKSPACE:-dev}" \
+	FILE="$${FILE:-}" \
+	MODE="$${MODE:-upsert}" \
+	YES="$${YES:-}" \
+	if command -v bun >/dev/null 2>&1; then \
+		bunx tsx scripts/resume/restore-resumes.ts; \
+	else \
+		npx tsx scripts/resume/restore-resumes.ts; \
+	fi
 
 # Docker: start containers
 docker:
@@ -744,6 +772,9 @@ help:
 	@echo "  deploy-check   Dry run deploy precheck without rebuilding"
 	@echo "  deploy-seed    Force a full upgrade with seeded demo resumes (requires sudo)"
 	@echo "  refresh-env    Refresh env, sync frontend build vars, and rebuild the production web bundle"
+	@echo "  backup-resumes Export live resume records to a portable JSON backup"
+	@echo "  restore-resumes Restore resume records from a portable JSON backup"
+	@echo "                 Uses API_URL/TRENDS_API_URL, WORKSPACE=dev, and OUT/FILE/LIMIT/SOURCE_HOSTS/RESUME_IDS/MODE/YES"
 	@echo "  uninstall      Remove systemd services (requires sudo)"
 	@echo "                 See ./scripts/install.sh --help for install/upgrade modes, CI=true/1, and env knobs"
 	@echo "  docker         Start Docker containers"

--- a/apps/api/src/routes/resumes-backup.test.ts
+++ b/apps/api/src/routes/resumes-backup.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createApp } from "../app";
+
+type ConvexCall = {
+  pathName: string;
+  args: Record<string, unknown>;
+  endpoint: "query" | "mutation";
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+  const requestUrl = typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+
+  const endpoint: "query" | "mutation" | null = requestUrl.includes("/api/query")
+    ? "query"
+    : requestUrl.includes("/api/mutation")
+      ? "mutation"
+      : null;
+
+  if (!endpoint) {
+    throw new Error(`Unexpected request URL: ${requestUrl}`);
+  }
+
+  const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+  if (!isRecord(body)) {
+    throw new Error("Missing convex request body");
+  }
+
+  const pathName = typeof body.path === "string" ? body.path : "";
+  const args = isRecord(body.args) ? body.args : {};
+  if (!pathName) {
+    throw new Error("Missing convex path in request body");
+  }
+
+  return { endpoint, pathName, args };
+}
+
+function convexSuccess(value: unknown): Response {
+  return new Response(
+    JSON.stringify({
+      status: "success",
+      value,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+}
+
+describe("resume backup and reset routes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("backs up portable resume payloads with source-specific tags", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.endpoint === "query" && call.pathName === "resumes:listForBackup") {
+        return convexSuccess([
+          {
+            _id: "resume-1",
+            externalId: "hr.job5156.com:resume:1001",
+            source: "hr.job5156.com",
+            tags: ["sales", "job5156"],
+            crawledAt: 200,
+            content: {
+              resumeId: "1001",
+              name: "Alice",
+              profileUrl: "https://hr.job5156.com/resume/view/1001",
+              activityStatus: "Active",
+              age: "30",
+              experience: "5 years",
+              education: "Bachelor",
+              location: "Dongguan",
+              jobIntention: "Sales",
+              expectedSalary: "10k-20k",
+              selfIntro: "Intro",
+              workHistory: [{ raw: "Test work history" }],
+              extractedAt: "2026-03-17T00:00:00.000Z",
+            },
+          },
+          {
+            _id: "resume-2",
+            externalId: "hk.employer.seek.com:profile:2002",
+            source: "hk.employer.seek.com",
+            tags: ["seek"],
+            crawledAt: 100,
+            content: {
+              profileId: "2002",
+              profileType: "seek",
+              name: "Bob",
+              profileUrl: "https://hk.employer.seek.com/candidates/2002",
+              activityStatus: "Active",
+              age: "31",
+              experience: "6 years",
+              education: "Bachelor",
+              location: "Kuala Lumpur",
+              jobIntention: "Sales Engineer",
+              expectedSalary: "8k-12k",
+              selfIntro: "Intro",
+              workHistory: [{ raw: "Test work history" }],
+              extractedAt: "2026-03-17T00:00:00.000Z",
+            },
+          },
+        ]);
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes/backup", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify({
+        resumeIds: ["1001"],
+        sourceHosts: ["hr.job5156.com"],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-disposition")).toMatch(/^attachment; filename="resume-backup-.+\.json"$/);
+    const payload = await response.json();
+    expect(payload.metadata.generatedBy).toBe("trends-api backup");
+    expect(payload.metadata.totalResumes).toBe(1);
+    expect(payload.resumes).toHaveLength(1);
+    expect(payload.resumes[0]).toEqual(expect.objectContaining({
+      resumeId: "1001",
+      externalId: "hr.job5156.com:resume:1001",
+      sourceHost: "hr.job5156.com",
+      tags: ["sales", "job5156"],
+      profileUrl: "https://hr.job5156.com/resume/view/1001",
+    }));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.pathName).toBe("resumes:listForBackup");
+  });
+
+  it("blocks resume backup for non-admin workspaces", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const app = createApp();
+
+    const response = await app.request("/api/resumes/backup", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Admin access required",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("resets resume records through Convex", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.endpoint === "mutation" && call.pathName === "resume_tasks:resetDatabase") {
+        return convexSuccess({
+          success: true,
+          count: 12,
+          partial: false,
+          deleted: {
+            resumes: 4,
+            analysis_tasks: 3,
+          },
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes/reset", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "dev",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      count: 12,
+      partial: false,
+      deleted: {
+        resumes: 4,
+        analysis_tasks: 3,
+      },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.pathName).toBe("resume_tasks:resetDatabase");
+  });
+});

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -7,6 +7,7 @@ import {
   ResumeKeywordExpansionQuerySchema,
   ResumeKeywordExpansionResponseSchema,
   ResumeSamplesResponseSchema,
+  ResumeBackupRequestSchema,
   ResumeImportRequestSchema,
   ResumeSubmitSummarySchema,
   ResumeExportBinaryResponseSchema,
@@ -130,6 +131,13 @@ const TriggerReingestRequestSchema = z.object({
 const ResumeImportErrorSchema = z.object({
   success: z.literal(false),
   error: z.string(),
+});
+
+const ResumeResetResponseSchema = z.object({
+  success: z.literal(true),
+  count: z.number().int(),
+  partial: z.boolean(),
+  deleted: z.record(z.number().int()),
 });
 
 type ResumeExportCanonicalRequest = z.infer<typeof ResumeExportCanonicalRequestSchema>;
@@ -466,6 +474,20 @@ function toResumeItemFromRecord(record: Record<string, unknown>, source?: string
   };
 }
 
+function buildResumeBackupItem(params: {
+  record: Record<string, unknown>;
+  sourceHost: string;
+  tags: string[];
+}): Record<string, unknown> {
+  const content = isRecord(params.record.content) ? params.record.content : {};
+  return {
+    ...content,
+    externalId: toStringValue(params.record.externalId) || toStringValue(content.externalId),
+    sourceHost: params.sourceHost,
+    tags: params.tags,
+  };
+}
+
 function prepareResumeCandidate(params: {
   resume: ResumeItem;
   resumeId: string;
@@ -520,6 +542,38 @@ async function callConvexQuery(pathName: string, args: Record<string, unknown>):
 
   if (payload.status !== "success") {
     throw new Error(payload.errorMessage || `Convex query failed for ${pathName}`);
+  }
+
+  return payload.value;
+}
+
+async function callConvexMutation(pathName: string, args: Record<string, unknown>): Promise<unknown> {
+  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+  const response = await fetch(`${convexUrl}/api/mutation`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      path: pathName,
+      args,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Convex mutation failed (${response.status}): ${text}`);
+  }
+
+  const payload = await response.json() as {
+    status?: string;
+    value?: unknown;
+    errorMessage?: string;
+  };
+
+  if (payload.status !== "success") {
+    throw new Error(payload.errorMessage || `Convex mutation failed for ${pathName}`);
   }
 
   return payload.value;
@@ -2434,6 +2488,70 @@ const importResumesRoute = createRoute({
   },
 });
 
+const backupResumesRoute = createRoute({
+  method: "post",
+  path: "/api/resumes/backup",
+  tags: ["resumes"],
+  summary: "Backup live resume records",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: ResumeBackupRequestSchema,
+        },
+      },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ResumeImportRequestSchema,
+        },
+      },
+      description: "Portable backup payload",
+    },
+    403: {
+      content: { "application/json": { schema: ResumeImportErrorSchema } },
+      description: "Admin access required",
+    },
+    404: {
+      content: { "application/json": { schema: ResumeImportErrorSchema } },
+      description: "Requested resume records could not be resolved",
+    },
+    500: {
+      content: { "application/json": { schema: ResumeImportErrorSchema } },
+      description: "Backup failed",
+    },
+  },
+});
+
+const resetResumesRoute = createRoute({
+  method: "post",
+  path: "/api/resumes/reset",
+  tags: ["resumes"],
+  summary: "Reset resume-related Convex records",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ResumeResetResponseSchema,
+        },
+      },
+      description: "Reset result",
+    },
+    403: {
+      content: { "application/json": { schema: ResumeImportErrorSchema } },
+      description: "Admin access required",
+    },
+    500: {
+      content: { "application/json": { schema: ResumeImportErrorSchema } },
+      description: "Reset failed",
+    },
+  },
+});
+
 app.openapi(importResumesRoute, async (c) => {
   if (c.var.accessLevel !== "admin") {
     return c.json({ success: false as const, error: "Admin access required" }, 403);
@@ -2446,6 +2564,126 @@ app.openapi(importResumesRoute, async (c) => {
   } catch (error) {
     console.error("Failed to import resumes", error);
     return c.json({ success: false as const, error: "Failed to import resumes" }, 500);
+  }
+});
+
+app.openapi(backupResumesRoute, async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  }
+
+  try {
+    const request = c.req.valid("json");
+    const value = await callConvexQuery("resumes:listForBackup", {});
+    if (!Array.isArray(value)) {
+      throw new Error("Invalid resume backup response from Convex");
+    }
+
+    const requestedResumeIds = request.resumeIds?.length
+      ? new Set(request.resumeIds.map((resumeId) => resumeId.trim()).filter(Boolean))
+      : null;
+    const requestedSourceHosts = request.sourceHosts?.length
+      ? new Set(request.sourceHosts.map((sourceHost) => sourceHost.trim().toLowerCase()).filter(Boolean))
+      : null;
+
+    type BackupResumeEntry = {
+      resumeId: string;
+      sourceHost: string;
+      tags: string[];
+      crawledAt: number;
+      payload: Record<string, unknown>;
+    };
+
+    const entries = value.flatMap((item, index): BackupResumeEntry[] => {
+      if (!isRecord(item)) {
+        return [];
+      }
+
+      const sourceHost = toStringValue(item.source).toLowerCase();
+      if (requestedSourceHosts && !requestedSourceHosts.has(sourceHost)) {
+        return [];
+      }
+
+      const content = isRecord(item.content) ? item.content : {};
+      const resume = toResumeItemFromRecord(content, sourceHost);
+      const resumeId = resolveResumeId(resume, index);
+      const tags = toStringArray(item.tags);
+
+      return [{
+        resumeId,
+        sourceHost,
+        tags,
+        crawledAt: typeof item.crawledAt === "number" && Number.isFinite(item.crawledAt) ? item.crawledAt : 0,
+        payload: buildResumeBackupItem({
+          record: item,
+          sourceHost,
+          tags,
+        }),
+      }];
+    });
+
+    let selectedEntries: BackupResumeEntry[];
+    if (requestedResumeIds) {
+      const byResumeId = new Map(entries.map((entry) => [entry.resumeId, entry]));
+      const missingResumeIds = Array.from(requestedResumeIds).filter((resumeId) => !byResumeId.has(resumeId));
+      if (missingResumeIds.length > 0) {
+        return c.json({
+          success: false as const,
+          error: `Unable to resolve resumes for backup: ${missingResumeIds.join(", ")}`,
+        }, 404);
+      }
+
+      selectedEntries = Array.from(requestedResumeIds)
+        .map((resumeId) => byResumeId.get(resumeId))
+        .filter((entry): entry is BackupResumeEntry => Boolean(entry));
+    } else {
+      selectedEntries = [...entries].sort((left, right) => {
+        const crawledDiff = right.crawledAt - left.crawledAt;
+        if (crawledDiff !== 0) {
+          return crawledDiff;
+        }
+
+        const sourceDiff = left.sourceHost.localeCompare(right.sourceHost);
+        if (sourceDiff !== 0) {
+          return sourceDiff;
+        }
+
+        return left.resumeId.localeCompare(right.resumeId);
+      });
+    }
+
+    const limited = typeof request.limit === "number" ? selectedEntries.slice(0, request.limit) : selectedEntries;
+    const generatedAt = new Date().toISOString();
+    c.header("Content-Disposition", `attachment; filename="resume-backup-${generatedAt.replace(/[:.]/g, "-")}.json"`);
+    c.header("Cache-Control", "no-store");
+    return c.json(ResumeImportRequestSchema.parse({
+      metadata: {
+        sourceUrl: c.req.url,
+        generatedBy: "trends-api backup",
+        generatedAt,
+        totalResumes: limited.length,
+      },
+      resumes: limited.map((entry) => entry.payload),
+    }), 200);
+  } catch (error) {
+    console.error("Failed to backup resumes", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false as const, error: message }, 500);
+  }
+});
+
+app.openapi(resetResumesRoute, async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  }
+
+  try {
+    const value = await callConvexMutation("resume_tasks:resetDatabase", {});
+    return c.json(ResumeResetResponseSchema.parse(value), 200);
+  } catch (error) {
+    console.error("Failed to reset resumes", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false as const, error: message }, 500);
   }
 });
 

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -209,6 +209,8 @@ export const ResumeImportItemSchema = z
     profileId: z.union([z.string(), z.number()]).pipe(z.coerce.string()).optional(),
     profileType: z.string().optional(),
     externalId: z.string().optional(),
+    sourceHost: z.string().optional().openapi({ example: "hr.job5156.com" }),
+    tags: z.array(z.string()).optional().openapi({ example: ["sales", "job5156"] }),
     name: z.string().openapi({ example: "Alex Chen" }),
     age: z.string().optional().openapi({ example: "28" }),
     experience: z.string().optional().openapi({ example: "5 years" }),
@@ -243,6 +245,14 @@ export const ResumeImportRequestSchema = z
     }
   })
   .openapi("ResumeImportRequest");
+
+export const ResumeBackupRequestSchema = z
+  .object({
+    resumeIds: z.array(z.string().trim().min(1)).optional(),
+    sourceHosts: z.array(z.string().trim().min(1)).optional(),
+    limit: z.number().int().min(1).optional(),
+  })
+  .openapi("ResumeBackupRequest");
 
 export const ResumeSubmitSummarySchema = z
   .object({

--- a/apps/api/src/services/resume-import-service.test.ts
+++ b/apps/api/src/services/resume-import-service.test.ts
@@ -155,6 +155,71 @@ describe("resume-import-service", () => {
     });
   });
 
+  it("uses per-item sourceHost and tags for mixed-source backup payloads", () => {
+    const result = normalizeResumeImportPayload({
+      metadata: {
+        sourceUrl: "https://backup.example.com/api/resumes/backup",
+        generatedBy: "trends-api backup",
+        keyword: "backup",
+      },
+      resumes: [
+        {
+          resumeId: "1001",
+          name: "Alice",
+          profileUrl: "https://hr.job5156.com/resume/view/1001",
+          activityStatus: "Active",
+          age: "30",
+          experience: "5 years",
+          education: "Bachelor",
+          location: "东莞",
+          jobIntention: "Sales",
+          expectedSalary: "10k-20k",
+          selfIntro: "Intro",
+          workHistory: [{ raw: "Test work history" }],
+          extractedAt: "2026-03-17T00:00:00.000Z",
+          sourceHost: "hr.job5156.com",
+          tags: ["job5156", "sales"],
+        },
+        {
+          profileId: "2002",
+          profileType: "seek",
+          name: "Bob",
+          profileUrl: "https://hk.employer.seek.com/candidates/2002",
+          activityStatus: "Active",
+          age: "31",
+          experience: "6 years",
+          education: "Bachelor",
+          location: "Kuala Lumpur",
+          jobIntention: "Sales Engineer",
+          expectedSalary: "8k-12k",
+          selfIntro: "Intro",
+          workHistory: [{ raw: "Test work history" }],
+          extractedAt: "2026-03-17T00:00:00.000Z",
+          sourceHost: "hk.employer.seek.com",
+          tags: ["seek"],
+        },
+      ],
+    });
+
+    expect(result.source).toBe("backup.example.com");
+    expect(result.tags).toEqual(["backup"]);
+    expect(result.convexResumes).toHaveLength(2);
+    expect(result.convexResumes[0]).toMatchObject({
+      source: "hr.job5156.com",
+      tags: ["job5156", "sales"],
+      externalId: "hr.job5156.com:resume:1001",
+    });
+    expect(result.convexResumes[1]).toMatchObject({
+      source: "hk.employer.seek.com",
+      tags: ["seek"],
+      externalId: "hk.employer.seek.com:profile:2002",
+    });
+    expect(result.convexResumes[0].content).not.toHaveProperty("sourceHost");
+    expect(result.convexResumes[0].content).not.toHaveProperty("tags");
+    expect(result.convexResumes[1].content).not.toHaveProperty("sourceHost");
+    expect(result.convexResumes[1].content).not.toHaveProperty("tags");
+  });
+
   it("preserves Job5156 detail-page work history fields during normalization", () => {
     const result = normalizeResumeImportPayload({
       metadata: {

--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -115,6 +115,22 @@ function normalizeSourceHost(value: string | undefined): string | null {
   return normalized ? normalized.toLowerCase() : null;
 }
 
+function normalizeTagList(values: string[] | undefined): string[] | undefined {
+  if (!Array.isArray(values)) {
+    return undefined;
+  }
+
+  const tags = Array.from(
+    new Set(
+      values
+        .map((value) => normalizeOptionalString(value))
+        .filter((value): value is string => value !== null),
+    ),
+  );
+
+  return tags.length > 0 ? tags : undefined;
+}
+
 function normalizeImportMetadata(metadata: ResumeImportMetadata): ResumeImportMetadata {
   const searchKeyword = normalizeOptionalString(metadata.searchCriteria?.keyword);
   const searchLocation = normalizeOptionalString(metadata.searchCriteria?.location);
@@ -184,12 +200,13 @@ function buildResumeExternalId(resume: ResumeImportItem, source: string, hash: s
 }
 
 function buildNormalizedResumeContent(resume: ResumeImportItem): Record<string, unknown> {
+  const { sourceHost: _sourceHost, tags: _tags, ...content } = resume;
   const locationHierarchy = normalizeResumeLocationHierarchy(resume);
-  const rawLocation = typeof resume.location === "string" ? resume.location.trim() : "";
+  const rawLocation = typeof content.location === "string" ? content.location.trim() : "";
   const location = rawLocation || (locationHierarchy ? formatLocationHierarchyLabel(locationHierarchy) : "");
 
   return {
-    ...resume,
+    ...content,
     location,
     ...(locationHierarchy ? { locationHierarchy } : {}),
   };
@@ -249,20 +266,22 @@ export function normalizeResumeImportPayload(input: ResumeImportRequest): Normal
   const metadata = normalizeImportMetadata(parsedInput.metadata);
   const resumes = parsedInput.resumes ?? parsedInput.data ?? [];
   const tag = normalizeOptionalString(metadata.searchProfileId) ?? normalizeOptionalString(metadata.keyword);
-  const tags = tag ? [tag] : [];
+  const defaultTags = tag ? [tag] : [];
   const source = resolveResumeSource(metadata);
 
   const convexResumes = resumes.map((resume) => {
+    const itemSource = normalizeSourceHost(resume.sourceHost) ?? source;
+    const itemTags = normalizeTagList(resume.tags) ?? defaultTags;
     const content: unknown = buildNormalizedResumeContent(resume);
     const hash = crypto.createHash("sha256").update(stableStringify(content), "utf8").digest("hex");
-    const externalId = buildResumeExternalId(resume, source, hash);
+    const externalId = buildResumeExternalId(resume, itemSource, hash);
 
     return {
       externalId,
       content,
       hash,
-      source,
-      tags,
+      source: itemSource,
+      tags: itemTags,
     };
   });
 
@@ -270,7 +289,7 @@ export function normalizeResumeImportPayload(input: ResumeImportRequest): Normal
     metadata,
     resumes,
     source,
-    tags,
+    tags: defaultTags,
     convexResumes,
   };
 }

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -671,6 +671,155 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/resumes/backup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Backup live resume records */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ResumeBackupRequest"];
+                };
+            };
+            responses: {
+                /** @description Portable backup payload */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ResumeImportRequest"];
+                    };
+                };
+                /** @description Admin access required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Requested resume records could not be resolved */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Backup failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/resumes/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reset resume-related Convex records */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Reset result */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            count: number;
+                            partial: boolean;
+                            deleted: {
+                                [key: string]: number;
+                            };
+                        };
+                    };
+                };
+                /** @description Admin access required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Reset failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/resumes/matches/rescore": {
         parameters: {
             query?: never;
@@ -4399,6 +4548,15 @@ export interface components {
             profileId?: string | number;
             profileType?: string;
             externalId?: string;
+            /** @example hr.job5156.com */
+            sourceHost?: string;
+            /**
+             * @example [
+             *       "sales",
+             *       "job5156"
+             *     ]
+             */
+            tags?: string[];
             /** @example Alex Chen */
             name: string;
             /** @example 28 */
@@ -4438,6 +4596,11 @@ export interface components {
             metadata: components["schemas"]["ResumeImportMetadata"];
             resumes?: components["schemas"]["ResumeImportItem"][];
             data?: components["schemas"]["ResumeImportItem"][];
+        };
+        ResumeBackupRequest: {
+            resumeIds?: string[];
+            sourceHosts?: string[];
+            limit?: number;
         };
         /** @enum {string} */
         ResumeExportSource: "sample" | "convex";

--- a/packages/cli/cmd/resume.go
+++ b/packages/cli/cmd/resume.go
@@ -26,6 +26,8 @@ func newResumeCmd() *cobra.Command {
 		newResumeListCmd(),
 		newResumeSearchCmd(),
 		newResumeMatchCmd(),
+		newResumeBackupCmd(),
+		newResumeRestoreCmd(),
 		newResumeExportCmd(),
 		newResumeDebugCmd(),
 	)

--- a/packages/cli/cmd/resume_backup.go
+++ b/packages/cli/cmd/resume_backup.go
@@ -1,0 +1,236 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ptdevhk/trends/packages/cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+type resumeBackupEnvelope struct {
+	Metadata json.RawMessage   `json:"metadata"`
+	Resumes  []json.RawMessage `json:"resumes"`
+	Data     []json.RawMessage `json:"data"`
+}
+
+func isJSONObject(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+
+	var value map[string]any
+	return json.Unmarshal(raw, &value) == nil
+}
+
+func newResumeBackupCmd() *cobra.Command {
+	var (
+		outPath     string
+		limit       int
+		resumeIDs   []string
+		sourceHosts []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "backup",
+		Short: "Backup live resume records to a portable JSON file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			request := client.ResumeBackupRequest{
+				ResumeIDs:   normalizeStringSlice(resumeIDs),
+				SourceHosts: normalizeStringSlice(sourceHosts),
+			}
+			if limit > 0 {
+				request.Limit = limit
+			}
+
+			payload, disposition, err := newAPIClient().BackupResumes(context.Background(), request)
+			if err != nil {
+				return err
+			}
+
+			var envelope resumeBackupEnvelope
+			if err := json.Unmarshal(payload, &envelope); err != nil {
+				return fmt.Errorf("decode backup payload: %w", err)
+			}
+			if !isJSONObject(envelope.Metadata) {
+				return fmt.Errorf("backup payload is missing metadata")
+			}
+
+			resolvedPath := strings.TrimSpace(outPath)
+			if resolvedPath == "" {
+				resolvedPath = extractFilename(disposition)
+			}
+			if resolvedPath == "" {
+				resolvedPath = fmt.Sprintf("resume-backup-%s.json", time.Now().Format("20060102-150405"))
+			}
+
+			if err := writeJSONFile(resolvedPath, payload); err != nil {
+				return err
+			}
+
+			total := len(envelope.Resumes)
+			if total == 0 {
+				total = len(envelope.Data)
+			}
+
+			summary := map[string]any{
+				"count": total,
+				"file":  resolvedPath,
+				"bytes": len(payload),
+			}
+			headers := []string{"count", "file", "bytes"}
+			rows := [][]string{{
+				fmt.Sprintf("%d", total),
+				resolvedPath,
+				fmt.Sprintf("%d", len(payload)),
+			}}
+			return writeOutput(cmd, headers, rows, summary)
+		},
+	}
+
+	cmd.Flags().StringVar(&outPath, "out", "", "Output file path")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum resumes to include")
+	cmd.Flags().StringArrayVar(&resumeIDs, "resume-id", nil, "Resume identifier to include (repeatable)")
+	cmd.Flags().StringArrayVar(&sourceHosts, "source-host", nil, "Source host to include (repeatable)")
+
+	return cmd
+}
+
+func newResumeRestoreCmd() *cobra.Command {
+	var (
+		mode string
+		yes  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "restore <file>",
+		Short: "Restore resume records from a portable JSON backup",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			filePath := strings.TrimSpace(args[0])
+			if filePath == "" {
+				return fmt.Errorf("backup file path is required")
+			}
+
+			payload, err := os.ReadFile(filePath)
+			if err != nil {
+				return fmt.Errorf("read backup file: %w", err)
+			}
+
+			var envelope resumeBackupEnvelope
+			if err := json.Unmarshal(payload, &envelope); err != nil {
+				return fmt.Errorf("invalid backup file: %w", err)
+			}
+			if !isJSONObject(envelope.Metadata) {
+				return fmt.Errorf("invalid backup file: missing metadata")
+			}
+			if len(envelope.Resumes) == 0 && len(envelope.Data) == 0 {
+				return fmt.Errorf("invalid backup file: missing resumes or data array")
+			}
+
+			normalizedMode := strings.ToLower(strings.TrimSpace(mode))
+			if normalizedMode == "" {
+				normalizedMode = "upsert"
+			}
+			if normalizedMode != "upsert" && normalizedMode != "replace" {
+				return fmt.Errorf("invalid mode %q (expected upsert|replace)", mode)
+			}
+			if normalizedMode == "replace" && !yes {
+				return fmt.Errorf("restore mode replace requires --yes")
+			}
+
+			resetCount := 0
+			resetPartial := false
+			if normalizedMode == "replace" {
+				resetResponse, err := newAPIClient().ResetResumes(context.Background())
+				if err != nil {
+					return err
+				}
+				resetCount = resetResponse.Count
+				resetPartial = resetResponse.Partial
+			}
+
+			response, err := newAPIClient().ImportResumeBackup(context.Background(), json.RawMessage(payload))
+			if err != nil {
+				return err
+			}
+
+			summary := map[string]any{
+				"mode":         normalizedMode,
+				"file":         filePath,
+				"reset":        normalizedMode == "replace",
+				"resetCount":   resetCount,
+				"resetPartial": resetPartial,
+				"submitted":    response.Submitted,
+				"inserted":     response.Inserted,
+				"updated":      response.Updated,
+				"unchanged":    response.Unchanged,
+				"deduped":      response.Deduped,
+			}
+			headers := []string{"mode", "file", "reset", "reset_count", "reset_partial", "submitted", "inserted", "updated", "unchanged", "deduped"}
+			rows := [][]string{{
+				normalizedMode,
+				filePath,
+				fmt.Sprintf("%t", normalizedMode == "replace"),
+				fmt.Sprintf("%d", resetCount),
+				fmt.Sprintf("%t", resetPartial),
+				fmt.Sprintf("%d", response.Submitted),
+				fmt.Sprintf("%d", response.Inserted),
+				fmt.Sprintf("%d", response.Updated),
+				fmt.Sprintf("%d", response.Unchanged),
+				fmt.Sprintf("%d", response.Deduped),
+			}}
+			return writeOutput(cmd, headers, rows, summary)
+		},
+	}
+
+	cmd.Flags().StringVar(&mode, "mode", "upsert", "Restore mode: upsert|replace")
+	cmd.Flags().BoolVar(&yes, "yes", false, "Confirm destructive replace mode")
+
+	return cmd
+}
+
+func normalizeStringSlice(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	return normalized
+}
+
+func writeJSONFile(filePath string, payload []byte) error {
+	resolvedPath := strings.TrimSpace(filePath)
+	if resolvedPath == "" {
+		return fmt.Errorf("output file path is required")
+	}
+
+	dir := filepath.Dir(resolvedPath)
+	if dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create output directory: %w", err)
+		}
+	}
+
+	var formatted bytes.Buffer
+	if err := json.Indent(&formatted, payload, "", "  "); err == nil {
+		formatted.WriteByte('\n')
+		if err := os.WriteFile(resolvedPath, formatted.Bytes(), 0o644); err != nil {
+			return fmt.Errorf("write backup file: %w", err)
+		}
+		return nil
+	}
+
+	if err := os.WriteFile(resolvedPath, payload, 0o644); err != nil {
+		return fmt.Errorf("write backup file: %w", err)
+	}
+	return nil
+}

--- a/packages/cli/cmd/resume_backup_test.go
+++ b/packages/cli/cmd/resume_backup_test.go
@@ -1,0 +1,230 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestResumeBackupCommandWritesBackupFile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/resumes/backup" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if resumeIDs, ok := payload["resumeIds"].([]any); !ok || len(resumeIDs) != 1 || resumeIDs[0] != "r1" {
+			t.Fatalf("unexpected resumeIds payload: %+v", payload)
+		}
+		if sourceHosts, ok := payload["sourceHosts"].([]any); !ok || len(sourceHosts) != 1 || sourceHosts[0] != "hr.job5156.com" {
+			t.Fatalf("unexpected sourceHosts payload: %+v", payload)
+		}
+		if limit, ok := payload["limit"].(float64); !ok || int(limit) != 2 {
+			t.Fatalf("unexpected limit payload: %+v", payload)
+		}
+
+		w.Header().Set("Content-Disposition", `attachment; filename="resume-backup-server.json"`)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"metadata": map[string]any{
+				"generatedBy": "trends-api backup",
+			},
+			"resumes": []map[string]any{
+				{"resumeId": "r1", "name": "Alice"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	originalAPIURL := viper.GetString("api_url")
+	originalWorkerURL := viper.GetString("worker_url")
+	originalWorkspace := viper.GetString("workspace")
+	originalOutput := viper.GetString("output")
+	t.Cleanup(func() {
+		viper.Set("api_url", originalAPIURL)
+		viper.Set("worker_url", originalWorkerURL)
+		viper.Set("workspace", originalWorkspace)
+		viper.Set("output", originalOutput)
+	})
+	viper.Set("api_url", server.URL)
+	viper.Set("worker_url", server.URL)
+	viper.Set("workspace", "hr")
+	viper.Set("output", "json")
+
+	outPath := filepath.Join(t.TempDir(), "backups", "resume-backup.json")
+	cmd := newResumeBackupCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{
+		"--out", outPath,
+		"--resume-id", "r1",
+		"--source-host", "hr.job5156.com",
+		"--limit", "2",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume backup command failed: %v", err)
+	}
+
+	written, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("failed to read backup file: %v", err)
+	}
+	if !strings.Contains(string(written), `"generatedBy": "trends-api backup"`) {
+		t.Fatalf("unexpected backup file contents: %s", string(written))
+	}
+	if !strings.Contains(output.String(), `"count": 1`) {
+		t.Fatalf("unexpected command output: %s", output.String())
+	}
+}
+
+func TestResumeRestoreCommandReplaceModeCallsResetThenImport(t *testing.T) {
+	backupFile := filepath.Join(t.TempDir(), "resume-backup.json")
+	if err := os.WriteFile(backupFile, []byte(`{
+  "metadata": {
+    "sourceUrl": "https://example.com/api/resumes/backup",
+    "generatedBy": "trends-api backup"
+  },
+  "resumes": [
+    {
+      "resumeId": "r1",
+      "name": "Alice"
+    }
+  ]
+}`), 0o644); err != nil {
+		t.Fatalf("failed to write backup file: %v", err)
+	}
+
+	var callOrder []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callOrder = append(callOrder, r.URL.Path)
+
+		switch r.URL.Path {
+		case "/api/resumes/reset":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"count":   1,
+				"partial": false,
+				"deleted": map[string]int{"resumes": 1},
+			})
+		case "/api/resumes/import":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode import payload: %v", err)
+			}
+			if _, ok := payload["metadata"].(map[string]any); !ok {
+				t.Fatalf("expected metadata object: %+v", payload)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success":   true,
+				"submitted": 1,
+				"inserted":  1,
+				"updated":   0,
+				"unchanged": 0,
+				"deduped":   0,
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	originalAPIURL := viper.GetString("api_url")
+	originalWorkerURL := viper.GetString("worker_url")
+	originalWorkspace := viper.GetString("workspace")
+	originalOutput := viper.GetString("output")
+	t.Cleanup(func() {
+		viper.Set("api_url", originalAPIURL)
+		viper.Set("worker_url", originalWorkerURL)
+		viper.Set("workspace", originalWorkspace)
+		viper.Set("output", originalOutput)
+	})
+	viper.Set("api_url", server.URL)
+	viper.Set("worker_url", server.URL)
+	viper.Set("workspace", "dev")
+	viper.Set("output", "json")
+
+	cmd := newResumeRestoreCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{
+		backupFile,
+		"--mode", "replace",
+		"--yes",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume restore command failed: %v", err)
+	}
+
+	if len(callOrder) != 2 || callOrder[0] != "/api/resumes/reset" || callOrder[1] != "/api/resumes/import" {
+		t.Fatalf("unexpected call order: %+v", callOrder)
+	}
+	if !strings.Contains(output.String(), `"mode": "replace"`) {
+		t.Fatalf("unexpected command output: %s", output.String())
+	}
+}
+
+func TestResumeRestoreCommandRequiresYesForReplace(t *testing.T) {
+	backupFile := filepath.Join(t.TempDir(), "resume-backup.json")
+	if err := os.WriteFile(backupFile, []byte(`{
+  "metadata": {
+    "sourceUrl": "https://example.com/api/resumes/backup",
+    "generatedBy": "trends-api backup"
+  },
+  "resumes": [
+    {
+      "resumeId": "r1",
+      "name": "Alice"
+    }
+  ]
+}`), 0o644); err != nil {
+		t.Fatalf("failed to write backup file: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	originalAPIURL := viper.GetString("api_url")
+	originalWorkerURL := viper.GetString("worker_url")
+	originalWorkspace := viper.GetString("workspace")
+	originalOutput := viper.GetString("output")
+	t.Cleanup(func() {
+		viper.Set("api_url", originalAPIURL)
+		viper.Set("worker_url", originalWorkerURL)
+		viper.Set("workspace", originalWorkspace)
+		viper.Set("output", originalOutput)
+	})
+	viper.Set("api_url", server.URL)
+	viper.Set("worker_url", server.URL)
+	viper.Set("workspace", "dev")
+	viper.Set("output", "json")
+
+	cmd := newResumeRestoreCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{
+		backupFile,
+		"--mode", "replace",
+	})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected replace restore without --yes to fail")
+	} else if !strings.Contains(err.Error(), "requires --yes") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/packages/cli/internal/client/resume_backup.go
+++ b/packages/cli/internal/client/resume_backup.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type ResumeBackupRequest struct {
+	ResumeIDs   []string `json:"resumeIds,omitempty"`
+	SourceHosts []string `json:"sourceHosts,omitempty"`
+	Limit       int      `json:"limit,omitempty"`
+}
+
+type ResumeSubmitSummary struct {
+	Success   bool `json:"success"`
+	Submitted int  `json:"submitted"`
+	Inserted  int  `json:"inserted"`
+	Updated   int  `json:"updated"`
+	Unchanged int  `json:"unchanged"`
+	Deduped   int  `json:"deduped"`
+}
+
+type ResumeResetResponse struct {
+	Success bool           `json:"success"`
+	Count   int            `json:"count"`
+	Partial bool           `json:"partial"`
+	Deleted map[string]int `json:"deleted"`
+}
+
+func (c *Client) BackupResumes(ctx context.Context, request ResumeBackupRequest) ([]byte, string, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/backup", c.APIURL)
+	payload, headers, err := c.doBinary(ctx, http.MethodPost, endpoint, request)
+	if err != nil {
+		return nil, "", err
+	}
+	return payload, headers.Get("Content-Disposition"), nil
+}
+
+func (c *Client) ImportResumeBackup(ctx context.Context, payload json.RawMessage) (*ResumeSubmitSummary, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/import", c.APIURL)
+
+	var response ResumeSubmitSummary
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, payload, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("resume import request was not successful")
+	}
+	return &response, nil
+}
+
+func (c *Client) ResetResumes(ctx context.Context) (*ResumeResetResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/reset", c.APIURL)
+
+	var response ResumeResetResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("resume reset request was not successful")
+	}
+	return &response, nil
+}

--- a/packages/cli/internal/client/resume_backup_test.go
+++ b/packages/cli/internal/client/resume_backup_test.go
@@ -1,0 +1,122 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResumeBackupClientEndpoints(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/resumes/backup":
+			if got := r.Header.Get("X-Workspace-Slug"); got != "hr" {
+				t.Fatalf("expected workspace header hr, got %q", got)
+			}
+
+			var payload ResumeBackupRequest
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+			if len(payload.ResumeIDs) != 2 || payload.ResumeIDs[0] != "r1" || payload.ResumeIDs[1] != "r2" {
+				t.Fatalf("unexpected resume IDs: %+v", payload.ResumeIDs)
+			}
+			if len(payload.SourceHosts) != 1 || payload.SourceHosts[0] != "hr.job5156.com" {
+				t.Fatalf("unexpected source hosts: %+v", payload.SourceHosts)
+			}
+			if payload.Limit != 2 {
+				t.Fatalf("expected limit=2, got %d", payload.Limit)
+			}
+
+			w.Header().Set("Content-Disposition", `attachment; filename="resume-backup-test.json"`)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"metadata": map[string]any{
+					"generatedBy": "trends-api backup",
+				},
+				"resumes": []map[string]any{
+					{"resumeId": "r1"},
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/resumes/import":
+			if got := r.Header.Get("Content-Type"); got != "application/json" {
+				t.Fatalf("expected JSON content type, got %q", got)
+			}
+
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode import body: %v", err)
+			}
+			if _, ok := payload["metadata"].(map[string]any); !ok {
+				t.Fatalf("expected metadata object in import payload: %+v", payload)
+			}
+			if resumes, ok := payload["resumes"].([]any); !ok || len(resumes) != 1 {
+				t.Fatalf("expected resumes array in import payload: %+v", payload)
+			}
+
+			_ = json.NewEncoder(w).Encode(ResumeSubmitSummary{
+				Success:   true,
+				Submitted: 1,
+				Inserted:  1,
+				Updated:   0,
+				Unchanged: 0,
+				Deduped:   0,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/resumes/reset":
+			_ = json.NewEncoder(w).Encode(ResumeResetResponse{
+				Success: true,
+				Count:   2,
+				Partial: false,
+				Deleted: map[string]int{"resumes": 2},
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	c := New(server.URL, server.URL, "hr")
+	c.HTTP = server.Client()
+
+	backupPayload, disposition, err := c.BackupResumes(context.Background(), ResumeBackupRequest{
+		ResumeIDs:   []string{"r1", "r2"},
+		SourceHosts: []string{"hr.job5156.com"},
+		Limit:       2,
+	})
+	if err != nil {
+		t.Fatalf("BackupResumes returned error: %v", err)
+	}
+	if !json.Valid(backupPayload) {
+		t.Fatalf("expected JSON backup payload, got %q", string(backupPayload))
+	}
+	if disposition == "" {
+		t.Fatal("expected content-disposition header")
+	}
+
+	importSummary, err := c.ImportResumeBackup(context.Background(), json.RawMessage(`{
+  "metadata": {
+    "generatedBy": "trends-api backup"
+  },
+  "resumes": [
+    {
+      "resumeId": "r1",
+      "name": "Alice"
+    }
+  ]
+}`))
+	if err != nil {
+		t.Fatalf("ImportResumeBackup returned error: %v", err)
+	}
+	if importSummary.Submitted != 1 || !importSummary.Success {
+		t.Fatalf("unexpected import summary: %+v", importSummary)
+	}
+
+	resetSummary, err := c.ResetResumes(context.Background())
+	if err != nil {
+		t.Fatalf("ResetResumes returned error: %v", err)
+	}
+	if resetSummary.Count != 2 || resetSummary.Partial {
+		t.Fatalf("unexpected reset summary: %+v", resetSummary)
+	}
+}

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -413,6 +413,33 @@ export const list = query({
     },
 });
 
+export const listForBackup = query({
+    args: {},
+    handler: async (ctx) => {
+        const docs = await ctx.db.query("resumes").collect();
+        return [...docs].sort((left, right) => {
+            const crawledDiff = right.crawledAt - left.crawledAt;
+            if (crawledDiff !== 0) {
+                return crawledDiff;
+            }
+
+            const externalDiff = left.externalId.localeCompare(right.externalId);
+            if (externalDiff !== 0) {
+                return externalDiff;
+            }
+
+            return String(left._id).localeCompare(String(right._id));
+        }).map((doc) => ({
+            _id: doc._id,
+            externalId: doc.externalId,
+            source: doc.source,
+            tags: doc.tags,
+            crawledAt: doc.crawledAt,
+            content: doc.content,
+        }));
+    },
+});
+
 export const listWithIngestData = query({
     args: {
         limit: v.optional(v.number()),

--- a/scripts/resume/backup-resumes.ts
+++ b/scripts/resume/backup-resumes.ts
@@ -1,0 +1,81 @@
+import { resolveApiUrl, resolveWorkspace, splitCsv, parsePositiveInteger, extractFilename, writePrettyJsonFile } from "./operator-utils.ts";
+
+type BackupResponse = {
+  metadata?: Record<string, unknown>;
+  resumes?: unknown[];
+  data?: unknown[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function resolveOutputPath(disposition: string | null, explicitPath: string | undefined): string {
+  const trimmed = explicitPath?.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+
+  const fromHeader = extractFilename(disposition);
+  if (fromHeader) {
+    return fromHeader;
+  }
+
+  return `resume-backup-${new Date().toISOString().replace(/[:.]/g, "-")}.json`;
+}
+
+async function main(): Promise<void> {
+  const apiUrl = resolveApiUrl();
+  const workspace = resolveWorkspace();
+  const outPath = process.env.OUT;
+  const resumeIds = splitCsv(process.env.RESUME_IDS);
+  const sourceHosts = splitCsv(process.env.SOURCE_HOSTS);
+  const limit = parsePositiveInteger(process.env.LIMIT);
+
+  const response = await fetch(`${apiUrl.replace(/\/$/, "")}/api/resumes/backup`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Workspace-Slug": workspace,
+    },
+    body: JSON.stringify({
+      ...(resumeIds.length > 0 ? { resumeIds } : {}),
+      ...(sourceHosts.length > 0 ? { sourceHosts } : {}),
+      ...(limit ? { limit } : {}),
+    }),
+  });
+
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new Error(`backup request failed (${response.status}): ${responseText.trim() || "no response body"}`);
+  }
+
+  let parsed: BackupResponse;
+  try {
+    const decoded = JSON.parse(responseText) as unknown;
+    if (!isRecord(decoded)) {
+      throw new Error("backup payload is not an object");
+    }
+    parsed = decoded as BackupResponse;
+  } catch (error) {
+    throw new Error(`decode backup response: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const resumes = Array.isArray(parsed.resumes) ? parsed.resumes : Array.isArray(parsed.data) ? parsed.data : [];
+  const filePath = resolveOutputPath(response.headers.get("content-disposition"), outPath);
+  await writePrettyJsonFile(filePath, parsed);
+
+  console.log(JSON.stringify({
+    success: true,
+    apiUrl,
+    workspace,
+    file: filePath,
+    count: resumes.length,
+    bytes: Buffer.byteLength(responseText, "utf8"),
+  }, null, 2));
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/resume/operator-utils.ts
+++ b/scripts/resume/operator-utils.ts
@@ -1,0 +1,80 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export function resolveApiUrl(): string {
+  return (
+    process.env.API_URL?.trim()
+    || process.env.TRENDS_API_URL?.trim()
+    || "http://localhost:3000"
+  );
+}
+
+export function resolveWorkspace(): string {
+  return process.env.WORKSPACE?.trim() || "dev";
+}
+
+export function splitCsv(value: string | undefined): string[] {
+  if (typeof value !== "string") {
+    return [];
+  }
+
+  return value
+    .split(/[,，、]/g)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+export function parsePositiveInteger(value: string | undefined): number | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+export function parseTruthy(value: string | undefined): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "y";
+}
+
+export function extractFilename(contentDisposition: string | null | undefined): string | undefined {
+  if (!contentDisposition) {
+    return undefined;
+  }
+
+  const match = /filename="?([^";]+)"?/i.exec(contentDisposition);
+  if (!match?.[1]) {
+    return undefined;
+  }
+
+  return match[1].trim() || undefined;
+}
+
+async function ensureParentDirectory(filePath: string): Promise<void> {
+  const dir = dirname(filePath);
+  if (dir === ".") {
+    return;
+  }
+
+  await mkdir(dir, { recursive: true });
+}
+
+export async function writePrettyJsonFile(filePath: string, value: unknown): Promise<void> {
+  const content = `${JSON.stringify(value, null, 2)}\n`;
+  await ensureParentDirectory(filePath);
+  await writeFile(filePath, content, "utf8");
+}

--- a/scripts/resume/restore-resumes.ts
+++ b/scripts/resume/restore-resumes.ts
@@ -1,0 +1,104 @@
+import { readFile } from "node:fs/promises";
+
+import { resolveApiUrl, resolveWorkspace, parseTruthy } from "./operator-utils.ts";
+
+type RestorePayload = {
+  metadata?: Record<string, unknown>;
+  resumes?: unknown[];
+  data?: unknown[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function resolveMode(value: string | undefined): "upsert" | "replace" {
+  const normalized = value?.trim().toLowerCase() || "upsert";
+  if (normalized !== "upsert" && normalized !== "replace") {
+    throw new Error(`invalid restore mode ${JSON.stringify(value)} (expected upsert|replace)`);
+  }
+  return normalized;
+}
+
+async function postJson(apiUrl: string, workspace: string, pathName: string, body: unknown): Promise<Response> {
+  return await fetch(`${apiUrl.replace(/\/$/, "")}${pathName}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Workspace-Slug": workspace,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function main(): Promise<void> {
+  const apiUrl = resolveApiUrl();
+  const workspace = resolveWorkspace();
+  const filePath = process.env.FILE?.trim();
+  if (!filePath) {
+    throw new Error("FILE is required");
+  }
+
+  const mode = resolveMode(process.env.MODE);
+  const confirm = parseTruthy(process.env.YES);
+  if (mode === "replace" && !confirm) {
+    throw new Error("MODE=replace requires YES=1");
+  }
+
+  const raw = await readFile(filePath, "utf8");
+  let parsed: RestorePayload;
+  try {
+    const decoded = JSON.parse(raw) as unknown;
+    if (!isRecord(decoded)) {
+      throw new Error("backup file is not an object");
+    }
+    parsed = decoded as RestorePayload;
+  } catch (error) {
+    throw new Error(`invalid backup file: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (!isRecord(parsed.metadata) || (Array.isArray(parsed.resumes) ? parsed.resumes.length === 0 : Array.isArray(parsed.data) ? parsed.data.length === 0 : true)) {
+    throw new Error("invalid backup file: missing metadata or resume array");
+  }
+
+  let resetResult: Record<string, unknown> | undefined;
+  if (mode === "replace") {
+    const resetResponse = await postJson(apiUrl, workspace, "/api/resumes/reset", {});
+    const resetText = await resetResponse.text();
+    if (!resetResponse.ok) {
+      throw new Error(`reset request failed (${resetResponse.status}): ${resetText.trim() || "no response body"}`);
+    }
+    const decodedReset = JSON.parse(resetText) as unknown;
+    if (!isRecord(decodedReset)) {
+      throw new Error("invalid reset response");
+    }
+    resetResult = decodedReset;
+  }
+
+  const importResponse = await postJson(apiUrl, workspace, "/api/resumes/import", parsed);
+  const importText = await importResponse.text();
+  if (!importResponse.ok) {
+    throw new Error(`import request failed (${importResponse.status}): ${importText.trim() || "no response body"}`);
+  }
+
+  const decodedImport = JSON.parse(importText) as unknown;
+  if (!isRecord(decodedImport)) {
+    throw new Error("invalid import response");
+  }
+  const importResult = decodedImport;
+  console.log(JSON.stringify({
+    success: true,
+    apiUrl,
+    workspace,
+    file: filePath,
+    mode,
+    reset: mode === "replace",
+    resetResult,
+    importResult,
+  }, null, 2));
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Adds portable resume backup/restore support with admin API routes, Go CLI commands, Make targets, TS operator scripts, and coverage for the new flows.\n\nValidation:\n- go test ./... in packages/cli\n- npx vitest run apps/api/src/services/resume-import-service.test.ts apps/api/src/routes/resumes-backup.test.ts\n- make check