### PR TITLE
Add tar.gz support to resume backup scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ refresh-env:
 	sudo systemctl is-active --quiet trends-worker-api && echo "  trends-worker-api: active" || echo "  trends-worker-api: FAILED"; \
 	sudo systemctl is-active --quiet trends-mcp && echo "  trends-mcp: active" || echo "  trends-mcp: FAILED"
 
-# Backup live resume records to a portable JSON file
+# Backup live resume records to a portable JSON or .tar.gz file
 backup-resumes:
 	@API_URL="$${API_URL:-$${TRENDS_API_URL:-http://localhost:3000}}" \
 	WORKSPACE="$${WORKSPACE:-dev}" \
@@ -207,7 +207,7 @@ backup-resumes:
 		npx tsx scripts/resume/backup-resumes.ts; \
 	fi
 
-# Restore live resume records from a portable JSON backup
+# Restore live resume records from a portable JSON or .tar.gz backup
 restore-resumes:
 	@API_URL="$${API_URL:-$${TRENDS_API_URL:-http://localhost:3000}}" \
 	WORKSPACE="$${WORKSPACE:-dev}" \
@@ -772,8 +772,8 @@ help:
 	@echo "  deploy-check   Dry run deploy precheck with workspace git status but without rebuilding"
 	@echo "  deploy-seed    Force a full upgrade with seeded demo resumes (requires sudo)"
 	@echo "  refresh-env    Refresh env, sync frontend build vars, and rebuild the production web bundle"
-	@echo "  backup-resumes Export live resume records to a portable JSON backup"
-	@echo "  restore-resumes Restore resume records from a portable JSON backup"
+	@echo "  backup-resumes Export live resume records to a portable JSON or .tar.gz backup"
+	@echo "  restore-resumes Restore resume records from a portable JSON or .tar.gz backup"
 	@echo "                 Uses API_URL/TRENDS_API_URL, WORKSPACE=dev, and OUT/FILE/LIMIT/SOURCE_HOSTS/RESUME_IDS/MODE/YES"
 	@echo "  uninstall      Remove systemd services (requires sudo)"
 	@echo "                 See ./scripts/install.sh --help for branch preflight, rollback backups, CI=true/1, and env knobs"

--- a/scripts/resume/backup-resumes.ts
+++ b/scripts/resume/backup-resumes.ts
@@ -1,4 +1,11 @@
-import { resolveApiUrl, resolveWorkspace, splitCsv, parsePositiveInteger, extractFilename, writePrettyJsonFile } from "./operator-utils.ts";
+import {
+  resolveApiUrl,
+  resolveWorkspace,
+  splitCsv,
+  parsePositiveInteger,
+  extractFilename,
+  writePortableBackupFile,
+} from "./operator-utils.ts";
 
 type BackupResponse = {
   metadata?: Record<string, unknown>;
@@ -63,7 +70,7 @@ async function main(): Promise<void> {
 
   const resumes = Array.isArray(parsed.resumes) ? parsed.resumes : Array.isArray(parsed.data) ? parsed.data : [];
   const filePath = resolveOutputPath(response.headers.get("content-disposition"), outPath);
-  await writePrettyJsonFile(filePath, parsed);
+  const bytes = await writePortableBackupFile(filePath, parsed);
 
   console.log(JSON.stringify({
     success: true,
@@ -71,7 +78,7 @@ async function main(): Promise<void> {
     workspace,
     file: filePath,
     count: resumes.length,
-    bytes: Buffer.byteLength(responseText, "utf8"),
+    bytes,
   }, null, 2));
 }
 

--- a/scripts/resume/operator-utils.test.ts
+++ b/scripts/resume/operator-utils.test.ts
@@ -1,0 +1,95 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { unlink, writeFile } from "node:fs/promises";
+import { basename, dirname } from "node:path";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+import { readPortableBackupFile, writePortableBackupFile } from "./operator-utils.ts";
+
+const execFileAsync = promisify(execFile);
+
+describe("resume operator utils", () => {
+  it("writes and reads plain JSON backups", async () => {
+    const filePath = `${process.env.TMPDIR ?? "/tmp"}/trends-resume-backup-${randomUUID()}.json`;
+    const payload = {
+      metadata: { generatedBy: "test" },
+      resumes: [{ resumeId: "r1" }],
+    };
+
+    try {
+      const bytes = await writePortableBackupFile(filePath, payload);
+      const restored = await readPortableBackupFile(filePath);
+
+      expect(bytes).toBeGreaterThan(0);
+      expect(JSON.parse(restored)).toEqual(payload);
+    } finally {
+      await unlink(filePath).catch(() => undefined);
+    }
+  });
+
+  it("writes and reads tar.gz backups", async () => {
+    const filePath = `${process.env.TMPDIR ?? "/tmp"}/trends-resume-backup-${randomUUID()}.tar.gz`;
+    const payload = {
+      metadata: { generatedBy: "test" },
+      resumes: [{ resumeId: "r1" }, { resumeId: "r2" }],
+    };
+
+    try {
+      const bytes = await writePortableBackupFile(filePath, payload);
+      const restored = await readPortableBackupFile(filePath);
+
+      expect(bytes).toBeGreaterThan(0);
+      expect(JSON.parse(restored)).toEqual(payload);
+    } finally {
+      await unlink(filePath).catch(() => undefined);
+    }
+  });
+
+  it("reads tar.gz backups created by the system tar command", async () => {
+    const basePath = `${process.env.TMPDIR ?? "/tmp"}/trends-resume-backup-${randomUUID()}`;
+    const jsonPath = `${basePath}.json`;
+    const archivePath = `${basePath}.tar.gz`;
+    const payload = {
+      metadata: { generatedBy: "tar" },
+      resumes: [{ resumeId: "external" }],
+    };
+
+    try {
+      await writeFile(jsonPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+      await execFileAsync("tar", ["-czf", archivePath, "-C", dirname(jsonPath), basename(jsonPath)], {
+        env: { ...process.env, COPYFILE_DISABLE: "1" },
+      });
+
+      const restored = await readPortableBackupFile(archivePath);
+      expect(JSON.parse(restored)).toEqual(payload);
+    } finally {
+      await unlink(jsonPath).catch(() => undefined);
+      await unlink(archivePath).catch(() => undefined);
+    }
+  });
+
+  it("reads gzip-compressed tar backups even without a .tar.gz extension", async () => {
+    const basePath = `${process.env.TMPDIR ?? "/tmp"}/trends-resume-backup-${randomUUID()}`;
+    const jsonPath = `${basePath}.json`;
+    const archivePath = `${basePath}.backup`;
+    const payload = {
+      metadata: { generatedBy: "tar" },
+      resumes: [{ resumeId: "extensionless" }],
+    };
+
+    try {
+      await writeFile(jsonPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+      await execFileAsync("tar", ["-czf", archivePath, "-C", dirname(jsonPath), basename(jsonPath)], {
+        env: { ...process.env, COPYFILE_DISABLE: "1" },
+      });
+
+      const restored = await readPortableBackupFile(archivePath);
+      expect(JSON.parse(restored)).toEqual(payload);
+    } finally {
+      await unlink(jsonPath).catch(() => undefined);
+      await unlink(archivePath).catch(() => undefined);
+    }
+  });
+});

--- a/scripts/resume/operator-utils.ts
+++ b/scripts/resume/operator-utils.ts
@@ -1,5 +1,6 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, dirname } from "node:path";
+import { gzipSync, gunzipSync } from "node:zlib";
 
 export function resolveApiUrl(): string {
   return (
@@ -64,6 +65,10 @@ export function extractFilename(contentDisposition: string | null | undefined): 
   return match[1].trim() || undefined;
 }
 
+export function isTarGzPath(filePath: string): boolean {
+  return filePath.trim().toLowerCase().endsWith(".tar.gz");
+}
+
 async function ensureParentDirectory(filePath: string): Promise<void> {
   const dir = dirname(filePath);
   if (dir === ".") {
@@ -73,8 +78,166 @@ async function ensureParentDirectory(filePath: string): Promise<void> {
   await mkdir(dir, { recursive: true });
 }
 
-export async function writePrettyJsonFile(filePath: string, value: unknown): Promise<void> {
-  const content = `${JSON.stringify(value, null, 2)}\n`;
-  await ensureParentDirectory(filePath);
-  await writeFile(filePath, content, "utf8");
+function stringifyJson(value: unknown): string {
+  if (typeof value === "string") {
+    return value.endsWith("\n") ? value : `${value}\n`;
+  }
+
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function writeTarString(target: Buffer, offset: number, length: number, value: string): void {
+  const encoded = Buffer.from(value, "utf8");
+  encoded.copy(target, offset, 0, Math.min(encoded.length, length));
+}
+
+function writeTarOctal(target: Buffer, offset: number, length: number, value: number): void {
+  const raw = Math.max(0, value).toString(8);
+  const encoded = `${raw.padStart(length - 1, "0")}\0`;
+  writeTarString(target, offset, length, encoded);
+}
+
+function createTarArchive(entryName: string, content: Buffer): Buffer {
+  const header = Buffer.alloc(512, 0);
+  const normalizedEntryName = entryName.trim() || "resume-backup.json";
+  const paddedSize = Math.ceil(content.length / 512) * 512;
+
+  writeTarString(header, 0, 100, normalizedEntryName.slice(0, 100));
+  writeTarOctal(header, 100, 8, 0o644);
+  writeTarOctal(header, 108, 8, 0);
+  writeTarOctal(header, 116, 8, 0);
+  writeTarOctal(header, 124, 12, content.length);
+  writeTarOctal(header, 136, 12, Math.floor(Date.now() / 1000));
+  writeTarString(header, 148, 8, "        ");
+  writeTarString(header, 156, 1, "0");
+  writeTarString(header, 257, 6, "ustar\0");
+  writeTarString(header, 263, 2, "00");
+
+  let checksum = 0;
+  for (const byte of header) {
+    checksum += byte;
+  }
+  writeTarString(header, 148, 8, `${checksum.toString(8).padStart(6, "0")}\0 `);
+
+  const archive = Buffer.alloc(512 + paddedSize + 1024, 0);
+  header.copy(archive, 0);
+  content.copy(archive, 512);
+  return archive;
+}
+
+function parseTarOctal(field: Uint8Array): number {
+  const raw = Buffer.from(field)
+    .toString("ascii")
+    .replace(/\0.*$/u, "")
+    .trim();
+
+  if (!raw) {
+    return 0;
+  }
+
+  return Number.parseInt(raw, 8);
+}
+
+function isGzipContent(content: Uint8Array): boolean {
+  return content.length >= 2 && content[0] === 0x1f && content[1] === 0x8b;
+}
+
+function extractTarEntryContent(archive: Uint8Array): Buffer {
+  const payload = Buffer.from(archive);
+  let offset = 0;
+  let jsonEntry: Buffer | undefined;
+  let fallbackFile: Buffer | undefined;
+  let fileEntryCount = 0;
+
+  while (offset + 512 <= payload.length) {
+    const header = payload.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      break;
+    }
+
+    const name = Buffer.from(header.subarray(0, 100))
+      .toString("utf8")
+      .replace(/\0.*$/u, "")
+      .trim();
+    const fileName = basename(name);
+    const size = parseTarOctal(header.subarray(124, 136));
+    const typeFlag = header[156] === 0 ? "0" : String.fromCharCode(header[156]);
+    const contentStart = offset + 512;
+    const contentEnd = contentStart + size;
+
+    if (!Number.isFinite(size) || size < 0 || contentEnd > payload.length) {
+      throw new Error("invalid backup archive: malformed tar entry");
+    }
+
+    if (typeFlag === "0" && !fileName.startsWith("._")) {
+      const entryContent = Buffer.from(payload.subarray(contentStart, contentEnd));
+      fileEntryCount += 1;
+      if (fileName.toLowerCase().endsWith(".json")) {
+        if (jsonEntry) {
+          throw new Error("invalid backup archive: multiple JSON entries found");
+        }
+        jsonEntry = entryContent;
+      } else if (!fallbackFile) {
+        fallbackFile = entryContent;
+      }
+    }
+
+    offset = contentStart + Math.ceil(size / 512) * 512;
+  }
+
+  if (jsonEntry) {
+    return jsonEntry;
+  }
+
+  if (fileEntryCount === 1 && fallbackFile) {
+    return fallbackFile;
+  }
+
+  if (fileEntryCount > 1) {
+    throw new Error("invalid backup archive: expected exactly one JSON payload");
+  }
+
+  throw new Error("invalid backup archive: no file entries found");
+}
+
+function resolveArchiveEntryName(filePath: string): string {
+  const fileName = basename(filePath.trim()).replace(/\.tar\.gz$/iu, "");
+  const normalized = fileName.endsWith(".json") ? fileName : `${fileName || "resume-backup"}.json`;
+  return normalized.length <= 100 ? normalized : "resume-backup.json";
+}
+
+export async function writePortableBackupFile(filePath: string, value: unknown): Promise<number> {
+  const resolvedPath = filePath.trim();
+  if (!resolvedPath) {
+    throw new Error("output file path is required");
+  }
+
+  await ensureParentDirectory(resolvedPath);
+
+  if (!isTarGzPath(resolvedPath)) {
+    const content = stringifyJson(value);
+    await writeFile(resolvedPath, content, "utf8");
+    return Buffer.byteLength(content, "utf8");
+  }
+
+  const content = Buffer.from(stringifyJson(value), "utf8");
+  const archive = createTarArchive(resolveArchiveEntryName(resolvedPath), content);
+  const compressed = gzipSync(archive);
+  await writeFile(resolvedPath, compressed);
+  return compressed.byteLength;
+}
+
+export async function readPortableBackupFile(filePath: string): Promise<string> {
+  const resolvedPath = filePath.trim();
+  if (!resolvedPath) {
+    throw new Error("backup file path is required");
+  }
+
+  const content = await readFile(resolvedPath);
+  if (!isGzipContent(content)) {
+    return content.toString("utf8");
+  }
+
+  const archive = gunzipSync(content);
+  return extractTarEntryContent(archive).toString("utf8");
 }

--- a/scripts/resume/restore-resumes.ts
+++ b/scripts/resume/restore-resumes.ts
@@ -1,6 +1,4 @@
-import { readFile } from "node:fs/promises";
-
-import { resolveApiUrl, resolveWorkspace, parseTruthy } from "./operator-utils.ts";
+import { resolveApiUrl, resolveWorkspace, parseTruthy, readPortableBackupFile } from "./operator-utils.ts";
 
 type RestorePayload = {
   metadata?: Record<string, unknown>;
@@ -45,7 +43,7 @@ async function main(): Promise<void> {
     throw new Error("MODE=replace requires YES=1");
   }
 
-  const raw = await readFile(filePath, "utf8");
+  const raw = await readPortableBackupFile(filePath);
   let parsed: RestorePayload;
   try {
     const decoded = JSON.parse(raw) as unknown;


### PR DESCRIPTION
## Summary
- add portable resume backup read/write support for `.tar.gz` alongside JSON in the TypeScript operator scripts
- keep the existing `make backup-resumes` and `make restore-resumes` wrapper workflow unchanged
- add tests covering JSON round-trips, system `tar` interoperability, and gzip-compressed tar archives without a `.tar.gz` suffix

## Test plan
- [x] bun test "scripts/resume/operator-utils.test.ts"
- [x] make check
- [x] make cli-test