### PR TITLE
fix: remove real DOCX sample from manual import regression

### DIFF
--- a/apps/api/src/routes/manual-resume-import.test.ts
+++ b/apps/api/src/routes/manual-resume-import.test.ts
@@ -1,0 +1,365 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import JSZip from "jszip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { workspaceMiddleware } from "../middleware/workspace";
+
+type ConvexCall = {
+  pathName: string;
+  args: Record<string, unknown>;
+};
+
+async function createTestApp() {
+  const { default: resumesRoutes } = await import("./resumes");
+  const app = new OpenAPIHono();
+  app.use("*", workspaceMiddleware);
+  app.route("/", resumesRoutes);
+  return app;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+  const requestUrl = typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+
+  if (!requestUrl.includes("/api/mutation")) {
+    throw new Error(`Unexpected request URL: ${requestUrl}`);
+  }
+
+  const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+  if (!isRecord(body)) {
+    throw new Error("Missing convex request body");
+  }
+
+  const pathName = typeof body.path === "string" ? body.path : "";
+  const args = isRecord(body.args) ? body.args : {};
+  if (!pathName) {
+    throw new Error("Missing convex path in request body");
+  }
+
+  return { pathName, args };
+}
+
+function convexSuccess(value: unknown): Response {
+  return new Response(
+    JSON.stringify({
+      status: "success",
+      value,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+}
+
+async function createDocxFile(name: string, text: string): Promise<File> {
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`);
+  zip.folder("_rels")?.file(".rels", `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`);
+  zip.folder("word")?.file("document.xml", `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:r><w:t>${text}</w:t></w:r></w:p>
+  </w:body>
+</w:document>`);
+
+  const buffer = await zip.generateAsync({ type: "uint8array" });
+  return new File([buffer], name, { type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" });
+}
+
+describe("manual resume import route", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock("mammoth");
+    vi.resetModules();
+  });
+
+  it("allows hr workspace users to upload direct DOCX resumes", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+      if (call.pathName === "resume_tasks:submitResumes") {
+        return convexSuccess({
+          submitted: 1,
+          deduped: 0,
+          inserted: 1,
+          updated: 0,
+          unchanged: 0,
+        });
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = await createTestApp();
+    const formData = new FormData();
+    formData.append("files", await createDocxFile("51job_张三(123456).docx", "张三 销售工程师 CNC"));
+    formData.append("keyword", "销售工程师");
+
+    const response = await app.request("/api/resumes/manual-import", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+      body: formData,
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      success: true,
+      source: { key: "51job-manual", label: "51job-manual" },
+      summary: {
+        uploadedFiles: 1,
+        discoveredFiles: 1,
+        parsedResumes: 1,
+        imported: 1,
+        inserted: 1,
+        updated: 0,
+        unchanged: 0,
+        deduped: 0,
+        skipped: 0,
+        failed: 0,
+      },
+      files: [
+        {
+          uploadName: "51job_张三(123456).docx",
+          entryPath: "51job_张三(123456).docx",
+          extension: ".docx",
+          status: "imported",
+          resumeName: "张三",
+          profileId: "123456",
+        },
+      ],
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toMatchObject({
+      resumes: [
+        {
+          source: "51job-manual",
+          externalId: "51job-manual:profile:123456",
+          tags: ["销售工程师"],
+          content: expect.objectContaining({
+            name: "张三",
+            profileType: "51job-manual",
+            selfIntro: "张三 销售工程师 CNC",
+            resumeSnippet: { text: "张三 销售工程师 CNC" },
+          }),
+        },
+      ],
+    });
+  });
+
+  it("imports malformed 51job DOCX files via fallback XML extraction", async () => {
+    const calls: ConvexCall[] = [];
+    const fallbackText = [
+      "王某",
+      "人才ID: 987654321",
+      "对门窗体验箱和气密性仪器进行销售",
+      "熟悉门窗检测与客户跟进",
+    ].join("\n");
+    const fallbackFileName = "51job_王某(987654321).docx";
+
+    vi.doMock("mammoth", () => ({
+      extractRawText: vi.fn(async () => {
+        throw new Error("Not implemented");
+      }),
+    }));
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+      if (call.pathName === "resume_tasks:submitResumes") {
+        return convexSuccess({
+          submitted: 1,
+          deduped: 0,
+          inserted: 1,
+          updated: 0,
+          unchanged: 0,
+        });
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = await createTestApp();
+    const formData = new FormData();
+    formData.append("files", await createDocxFile(fallbackFileName, fallbackText));
+
+    const response = await app.request("/api/resumes/manual-import", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+      body: formData,
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      success: true,
+      summary: {
+        uploadedFiles: 1,
+        discoveredFiles: 1,
+        parsedResumes: 1,
+        imported: 1,
+        skipped: 0,
+        failed: 0,
+      },
+      files: [
+        expect.objectContaining({
+          uploadName: fallbackFileName,
+          entryPath: fallbackFileName,
+          status: "imported",
+          resumeName: "王某",
+          profileId: "987654321",
+          warnings: expect.arrayContaining([expect.stringContaining("Used DOCX XML fallback parser: Not implemented")]),
+        }),
+      ],
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toMatchObject({
+      resumes: [
+        {
+          source: "51job-manual",
+          externalId: "51job-manual:profile:987654321",
+          content: expect.objectContaining({
+            name: "王某",
+            profileType: "51job-manual",
+            selfIntro: fallbackText,
+            resumeSnippet: { text: fallbackText },
+          }),
+        },
+      ],
+    });
+  });
+
+  it("returns partial success for mixed supported and unsupported uploads", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+      if (call.pathName === "resume_tasks:submitResumes") {
+        return convexSuccess({
+          submitted: 1,
+          deduped: 0,
+          inserted: 1,
+          updated: 0,
+          unchanged: 0,
+        });
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = await createTestApp();
+    const formData = new FormData();
+    formData.append("files", await createDocxFile("51job_李四(654321).docx", "李四 销售经理"));
+    formData.append("files", new File(["notes"], "notes.txt", { type: "text/plain" }));
+    formData.append("keyword", "销售经理");
+
+    const response = await app.request("/api/resumes/manual-import", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+      body: formData,
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      success: true,
+      summary: {
+        uploadedFiles: 2,
+        discoveredFiles: 2,
+        parsedResumes: 1,
+        imported: 1,
+        skipped: 1,
+        failed: 0,
+      },
+      files: [
+        expect.objectContaining({
+          entryPath: "51job_李四(654321).docx",
+          status: "imported",
+          profileId: "654321",
+        }),
+        expect.objectContaining({
+          entryPath: "notes.txt",
+          status: "skipped",
+          error: "Unsupported file type",
+        }),
+      ],
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("returns 400 when no files are uploaded", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const app = await createTestApp();
+
+    const formData = new FormData();
+    const response = await app.request("/api/resumes/manual-import", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+      body: formData,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Expected at least one uploaded file",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps the legacy JSON import route admin-only", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const app = await createTestApp();
+
+    const response = await app.request("/api/resumes/import", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        metadata: {
+          sourceUrl: "https://www.51job.com/",
+          generatedBy: "manual-resume-import@1.0.0",
+        },
+        resumes: [
+          {
+            name: "张三",
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Admin access required",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/manual-resume-import-service.ts
+++ b/apps/api/src/services/manual-resume-import-service.ts
@@ -1,0 +1,607 @@
+import path from "node:path";
+
+import { unzipSync } from "fflate";
+import * as unrar from "node-unrar-js";
+import { PDFParse } from "pdf-parse";
+import { z } from "@hono/zod-openapi";
+
+import { normalizeOptionalString } from "@trends/shared";
+
+import {
+  type ResumeImportItem,
+  type ResumeSubmitSummary,
+  normalizeResumeImportPayload,
+  submitNormalizedResumeImport,
+} from "./resume-import-service.js";
+import {
+  ResumeImportMetadataSchema,
+  ResumeManualImportResponseSchema,
+} from "../schemas/resumes.js";
+
+type ResumeImportMetadata = z.infer<typeof ResumeImportMetadataSchema>;
+export type ResumeManualImportResponse = z.infer<typeof ResumeManualImportResponseSchema>;
+
+type ManualResumeImportFileResult = ResumeManualImportResponse["files"][number];
+
+type ManualResumeImportSummary = ResumeManualImportResponse["summary"];
+
+type ManualResumeImportInput = {
+  files: File[];
+  searchProfileId?: string;
+  keyword?: string;
+  location?: string;
+};
+
+type EnumeratedImportFile = {
+  uploadName: string;
+  entryPath: string;
+  extension: string;
+  data: Uint8Array;
+  extractionMethod: "direct" | "zip" | "rar";
+};
+
+type ParsedImportCandidate = {
+  result: ManualResumeImportFileResult;
+  resume: ResumeImportItem | null;
+};
+
+type UploadExpansionResult = {
+  entries: EnumeratedImportFile[];
+  fileResult?: ManualResumeImportFileResult;
+};
+
+const MANUAL_SOURCE_KEY = "51job-manual";
+const MANUAL_SOURCE_URL = "https://www.51job.com/";
+const MANUAL_GENERATED_BY = "manual-resume-import@1.0.0";
+const MAX_UPLOAD_FILE_SIZE = 25 * 1024 * 1024;
+const MAX_ARCHIVE_ENTRY_SIZE = 25 * 1024 * 1024;
+const MAX_TOTAL_EXTRACTED_SIZE = 150 * 1024 * 1024;
+const MAX_UPLOAD_REQUEST_SIZE = MAX_TOTAL_EXTRACTED_SIZE;
+const SUPPORTED_FILE_EXTENSIONS = new Set([".pdf", ".doc", ".docx"]);
+const DOCX_MESSAGE_WARNING_TYPES = new Set(["warning", "error"]);
+const DOCX_TEXT_ENTRY_PATH_PATTERN = /^word\/(?:document|header\d+|footer\d+|footnotes|endnotes)\.xml$/i;
+const DOCX_TEXT_RUN_PATTERN = /<w:t\b[^>]*>((?:(?!<\/w:t>)(?:[^<]|<w:(?:br|cr|tab|noBreakHyphen|softHyphen)\b[^>]*\/>))*)<\/w:t>/gis;
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\r/g, "\n").replace(/\u0000/g, "").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function decodeXmlEntities(value: string): string {
+  return value.replace(/&(?:#x([0-9a-fA-F]+)|#(\d+)|amp|lt|gt|quot|apos);/g, (match, hex, decimal) => {
+    if (typeof hex === "string") {
+      return String.fromCodePoint(Number.parseInt(hex, 16));
+    }
+    if (typeof decimal === "string") {
+      return String.fromCodePoint(Number.parseInt(decimal, 10));
+    }
+    switch (match) {
+      case "&amp;":
+        return "&";
+      case "&lt;":
+        return "<";
+      case "&gt;":
+        return ">";
+      case "&quot;":
+        return '"';
+      case "&apos;":
+        return "'";
+      default:
+        return match;
+    }
+  });
+}
+
+function extractDocxTextFromXml(xml: string): string {
+  const fragments = Array.from(xml.matchAll(DOCX_TEXT_RUN_PATTERN), (match) => {
+    return decodeXmlEntities(match[1])
+      .replace(/<w:tab\b[^>]*\/>/g, "\t")
+      .replace(/<w:(?:br|cr)\b[^>]*\/>/g, "\n")
+      .replace(/<w:noBreakHyphen\b[^>]*\/>/g, "-")
+      .replace(/<w:softHyphen\b[^>]*\/>/g, "");
+  }).filter((fragment) => fragment.trim().length > 0);
+
+  return normalizeWhitespace(fragments.join("\n"));
+}
+
+function extractDocxTextFallback(file: EnumeratedImportFile): string {
+  const archiveEntries = unzipSync(file.data);
+  const decoder = new TextDecoder("utf-8");
+  const text = Object.entries(archiveEntries)
+    .filter(([entryPath]) => DOCX_TEXT_ENTRY_PATH_PATTERN.test(entryPath))
+    .map(([, data]) => extractDocxTextFromXml(decoder.decode(data)))
+    .join("\n\n");
+
+  return normalizeWhitespace(text);
+}
+
+function buildBaseMetadata(input: ManualResumeImportInput): ResumeImportMetadata {
+  const keyword = normalizeOptionalString(input.keyword);
+  const location = normalizeOptionalString(input.location);
+  const searchProfileId = normalizeOptionalString(input.searchProfileId);
+
+  return {
+    sourceUrl: MANUAL_SOURCE_URL,
+    generatedBy: MANUAL_GENERATED_BY,
+    sourceKey: MANUAL_SOURCE_KEY,
+    sourceHost: MANUAL_SOURCE_KEY,
+    ...(keyword ? { keyword } : {}),
+    ...(location ? { location } : {}),
+    ...(searchProfileId ? { searchProfileId } : {}),
+    collectionContext: {
+      captureMode: "manual-upload",
+      operation: "manual-import",
+      profileType: MANUAL_SOURCE_KEY,
+    },
+    generatedAt: new Date().toISOString(),
+    totalPages: 1,
+    totalResumes: 0,
+    reproduction: "Upload resume bundles or documents from 51job manual export",
+  };
+}
+
+function toUint8Array(value: ArrayBuffer): Uint8Array {
+  return new Uint8Array(value);
+}
+
+function toArrayBuffer(value: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(value.byteLength);
+  copy.set(value);
+  return copy.buffer;
+}
+
+function getExtension(name: string): string {
+  return path.extname(name).toLowerCase();
+}
+
+function sanitizeEntryPath(entryPath: string): string {
+  return entryPath.replace(/\\/g, "/").replace(/^\/+/, "").trim();
+}
+
+function isSupportedResumeFile(entryPath: string): boolean {
+  return SUPPORTED_FILE_EXTENSIONS.has(getExtension(entryPath));
+}
+
+function ensureFileSizeWithinLimit(name: string, size: number, limit: number): void {
+  if (!Number.isFinite(size) || size < 0) {
+    throw new Error(`Invalid file size for ${name}`);
+  }
+  if (size > limit) {
+    throw new Error(`${name} exceeds the ${Math.round(limit / (1024 * 1024))}MB limit`);
+  }
+}
+
+async function readUploadFile(file: File): Promise<Uint8Array> {
+  ensureFileSizeWithinLimit(file.name, file.size, MAX_UPLOAD_FILE_SIZE);
+  return toUint8Array(await file.arrayBuffer());
+}
+
+function enumerateZipEntries(uploadName: string, archiveData: Uint8Array): EnumeratedImportFile[] {
+  const unzipped = unzipSync(archiveData);
+  const entries: EnumeratedImportFile[] = [];
+  let totalExtractedSize = 0;
+
+  for (const [entryPath, data] of Object.entries(unzipped)) {
+    const normalizedPath = sanitizeEntryPath(entryPath);
+    if (!normalizedPath || normalizedPath.endsWith("/")) {
+      continue;
+    }
+
+    totalExtractedSize += data.byteLength;
+    ensureFileSizeWithinLimit(normalizedPath, data.byteLength, MAX_ARCHIVE_ENTRY_SIZE);
+    ensureFileSizeWithinLimit(uploadName, totalExtractedSize, MAX_TOTAL_EXTRACTED_SIZE);
+
+    entries.push({
+      uploadName,
+      entryPath: normalizedPath,
+      extension: getExtension(normalizedPath),
+      data,
+      extractionMethod: "zip",
+    });
+  }
+
+  return entries;
+}
+
+async function extractRarEntries(uploadName: string, archiveData: Uint8Array): Promise<EnumeratedImportFile[]> {
+  // node-unrar-js works with the provided RAR v5 sample, but DOCX buffers extracted from RAR
+  // are not yet compatible with Mammoth in this runtime. Keep RAR enumeration/import enabled,
+  // and report DOCX entries as file-level failures until that parser lane is hardened.
+  const extractor = await unrar.createExtractorFromData({
+    data: toArrayBuffer(archiveData),
+  });
+  const list = extractor.getFileList();
+  const fileHeaders = [...list.fileHeaders];
+  const archiveEntries = fileHeaders.filter((entry) => !entry.flags.directory);
+  const paths = archiveEntries.map((entry) => entry.name);
+  const extracted = extractor.extract({ files: paths });
+  const extractedFiles = [...extracted.files];
+
+  const entries: EnumeratedImportFile[] = [];
+  let totalExtractedSize = 0;
+
+  for (const file of extractedFiles) {
+    const normalizedPath = sanitizeEntryPath(file.fileHeader.name);
+    if (!normalizedPath || file.fileHeader.flags.directory) {
+      continue;
+    }
+
+    const extraction = file.extraction;
+    if (!(extraction instanceof Uint8Array)) {
+      throw new Error(`Failed to extract ${normalizedPath} from ${uploadName}`);
+    }
+
+    totalExtractedSize += extraction.byteLength;
+    ensureFileSizeWithinLimit(normalizedPath, extraction.byteLength, MAX_ARCHIVE_ENTRY_SIZE);
+    ensureFileSizeWithinLimit(uploadName, totalExtractedSize, MAX_TOTAL_EXTRACTED_SIZE);
+
+    entries.push({
+      uploadName,
+      entryPath: normalizedPath,
+      extension: getExtension(normalizedPath),
+      data: extraction,
+      extractionMethod: "rar",
+    });
+  }
+
+  return entries;
+}
+
+async function expandUploadedFile(file: File): Promise<UploadExpansionResult> {
+  try {
+    const data = await readUploadFile(file);
+    const extension = getExtension(file.name);
+
+    if (extension === ".zip") {
+      return { entries: enumerateZipEntries(file.name, data) };
+    }
+
+    if (extension === ".rar") {
+      return { entries: await extractRarEntries(file.name, data) };
+    }
+
+    return {
+      entries: [{
+        uploadName: file.name,
+        entryPath: file.name,
+        extension,
+        data,
+        extractionMethod: "direct",
+      }],
+    };
+  } catch (error) {
+    return {
+      entries: [],
+      fileResult: {
+        uploadName: file.name,
+        entryPath: file.name,
+        extension: getExtension(file.name),
+        status: "failed",
+        error: error instanceof Error ? error.message : String(error),
+        warnings: ["Archive expansion failed"],
+      },
+    };
+  }
+}
+
+async function enumerateUploadedFiles(files: File[]): Promise<{
+  entries: EnumeratedImportFile[];
+  fileResults: ManualResumeImportFileResult[];
+}> {
+  const entries: EnumeratedImportFile[] = [];
+  const fileResults: ManualResumeImportFileResult[] = [];
+
+  for (const file of files) {
+    const expanded = await expandUploadedFile(file);
+    entries.push(...expanded.entries);
+    if (expanded.fileResult) {
+      fileResults.push(expanded.fileResult);
+    }
+  }
+
+  return { entries, fileResults };
+}
+
+function fileResultBase(file: EnumeratedImportFile): Omit<ManualResumeImportFileResult, "status"> {
+  return {
+    uploadName: file.uploadName,
+    entryPath: file.entryPath,
+    extension: file.extension,
+    warnings: [],
+  };
+}
+
+function inferFilenameResumeName(entryPath: string): string | undefined {
+  const basename = path.basename(entryPath, path.extname(entryPath));
+  const withoutPrefix = basename.replace(/^51job[_-]?/i, "").trim();
+  const withoutId = withoutPrefix.replace(/\([^)]*\)/g, "").trim();
+  return withoutId || undefined;
+}
+
+function isLikelyResumeNameCandidate(value: string): boolean {
+  if (!value || value.length > 20) {
+    return false;
+  }
+  if (/\d/.test(value) || /[：:｜|丨/]/.test(value) || /[()（）]/.test(value)) {
+    return false;
+  }
+
+  const normalized = value.replace(/\s+/g, "");
+  if ([
+    "活跃时间",
+    "最近工作",
+    "最高学历",
+    "最高学历学位",
+    "求职意向",
+    "个人优势",
+    "工作经历",
+    "教育经历",
+    "专业描述",
+    "工作描述",
+    "证书",
+    "声明",
+    "离职",
+    "在职",
+    "全职",
+  ].includes(normalized)) {
+    return false;
+  }
+
+  return /\p{Script=Han}|[A-Za-z]/u.test(normalized);
+}
+
+function inferResumeName(entryPath: string, text: string): string | undefined {
+  const filenameCandidate = inferFilenameResumeName(entryPath);
+  if (filenameCandidate && /\p{Script=Han}/u.test(filenameCandidate)) {
+    return filenameCandidate;
+  }
+
+  const normalizedText = normalizeWhitespace(text);
+  const lines = normalizedText.split(/\n+/).map((line) => line.trim()).filter(Boolean);
+  for (const line of lines.slice(0, 12)) {
+    const firstToken = line.split(/[\s|｜丨]/).find(Boolean)?.trim();
+    if (firstToken && isLikelyResumeNameCandidate(firstToken)) {
+      return firstToken;
+    }
+  }
+
+  return filenameCandidate;
+}
+
+function inferProfileId(entryPath: string, text: string): string | undefined {
+  const entryMatch = entryPath.match(/\((\d{6,})\)/);
+  if (entryMatch?.[1]) {
+    return entryMatch[1];
+  }
+
+  const textMatch = text.match(/(?:人才ID|简历编号|ID)[:：]?\s*(\d{6,})/i);
+  return textMatch?.[1];
+}
+
+function buildImportedResumeCandidate(
+  file: EnumeratedImportFile,
+  text: string,
+  warnings: string[],
+): ParsedImportCandidate {
+  const resumeName = inferResumeName(file.entryPath, text);
+  const profileId = inferProfileId(file.entryPath, text);
+  const resume: ResumeImportItem = {
+    name: resumeName ?? path.basename(file.entryPath, file.extension),
+    selfIntro: text,
+    resumeSnippet: { text },
+    extractedAt: new Date().toISOString(),
+    profileType: MANUAL_SOURCE_KEY,
+    ...(profileId ? { profileId } : {}),
+  };
+
+  return {
+    result: {
+      ...fileResultBase(file),
+      status: "imported",
+      ...(resumeName ? { resumeName } : {}),
+      ...(profileId ? { profileId } : {}),
+      warnings,
+    },
+    resume,
+  };
+}
+
+async function parseDocxFile(file: EnumeratedImportFile): Promise<ParsedImportCandidate> {
+  let text = "";
+  let warnings: string[] = [];
+  let mammothError: unknown;
+
+  try {
+    const mammoth = await import("mammoth");
+    const result = await mammoth.extractRawText({ buffer: Buffer.from(file.data) });
+    text = normalizeWhitespace(result.value);
+    warnings = result.messages
+      .filter((message) => DOCX_MESSAGE_WARNING_TYPES.has(message.type))
+      .map((message) => message.message);
+  } catch (error) {
+    mammothError = error;
+  }
+
+  if (!text) {
+    try {
+      text = extractDocxTextFallback(file);
+      if (text) {
+        warnings = mammothError
+          ? [`Used DOCX XML fallback parser: ${mammothError instanceof Error ? mammothError.message : String(mammothError)}`]
+          : warnings;
+      }
+    } catch (fallbackError) {
+      if (mammothError) {
+        return {
+          result: {
+            ...fileResultBase(file),
+            status: "failed",
+            error: mammothError instanceof Error ? mammothError.message : String(mammothError),
+            warnings: [
+              `DOCX fallback extraction failed: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`,
+            ],
+          },
+          resume: null,
+        };
+      }
+
+      return {
+        result: {
+          ...fileResultBase(file),
+          status: "failed",
+          error: fallbackError instanceof Error ? fallbackError.message : String(fallbackError),
+          warnings,
+        },
+        resume: null,
+      };
+    }
+  }
+
+  if (!text) {
+    return {
+      result: {
+        ...fileResultBase(file),
+        status: "failed",
+        warnings,
+        error: mammothError instanceof Error ? mammothError.message : "No extractable text found in DOCX file",
+      },
+      resume: null,
+    };
+  }
+
+  return buildImportedResumeCandidate(file, text, warnings);
+}
+
+async function parsePdfFile(file: EnumeratedImportFile): Promise<ParsedImportCandidate> {
+  const parser = new PDFParse({ data: Buffer.from(file.data) });
+
+  try {
+    const result = await parser.getText();
+    const text = normalizeWhitespace(result.text);
+    if (!text) {
+      return {
+        result: {
+          ...fileResultBase(file),
+          status: "failed",
+          error: "No extractable text found in PDF file",
+          warnings: [],
+        },
+        resume: null,
+      };
+    }
+
+    return buildImportedResumeCandidate(file, text, []);
+  } catch (error) {
+    return {
+      result: {
+        ...fileResultBase(file),
+        status: "failed",
+        error: error instanceof Error ? error.message : String(error),
+        warnings: [],
+      },
+      resume: null,
+    };
+  } finally {
+    await parser.destroy().catch((error) => {
+      console.error("Failed to destroy PDF parser", error);
+    });
+  }
+}
+
+async function parseResumeFile(file: EnumeratedImportFile): Promise<ParsedImportCandidate> {
+  if (!isSupportedResumeFile(file.entryPath)) {
+    return {
+      result: {
+        ...fileResultBase(file),
+        status: "skipped",
+        error: "Unsupported file type",
+        warnings: [],
+      },
+      resume: null,
+    };
+  }
+
+  if (file.extension === ".doc") {
+    return {
+      result: {
+        ...fileResultBase(file),
+        status: "failed",
+        error: "Legacy .doc parsing is not supported yet",
+        warnings: [],
+      },
+      resume: null,
+    };
+  }
+
+  if (file.extension === ".docx") {
+    return parseDocxFile(file);
+  }
+
+  return parsePdfFile(file);
+}
+
+function buildSummary(
+  uploadedFiles: number,
+  discoveredFiles: number,
+  parsedResumes: number,
+  submitSummary: ResumeSubmitSummary,
+  fileResults: ManualResumeImportFileResult[],
+): ManualResumeImportSummary {
+  const skipped = fileResults.filter((file) => file.status === "skipped").length;
+  const failed = fileResults.filter((file) => file.status === "failed").length;
+
+  return {
+    uploadedFiles,
+    discoveredFiles,
+    parsedResumes,
+    imported: submitSummary.submitted,
+    inserted: submitSummary.inserted,
+    updated: submitSummary.updated,
+    unchanged: submitSummary.unchanged,
+    deduped: submitSummary.deduped,
+    skipped,
+    failed,
+  };
+}
+
+export async function importManualResumes(input: ManualResumeImportInput): Promise<ResumeManualImportResponse> {
+  const metadata = buildBaseMetadata(input);
+  const { entries: enumeratedFiles, fileResults } = await enumerateUploadedFiles(input.files);
+  const resumes: ResumeImportItem[] = [];
+  const warnings: string[] = [];
+
+  for (const file of enumeratedFiles) {
+    const parsed = await parseResumeFile(file);
+    fileResults.push(parsed.result);
+    if (parsed.result.warnings.length > 0) {
+      warnings.push(...parsed.result.warnings.map((warning) => `${parsed.result.entryPath}: ${warning}`));
+    }
+    if (parsed.resume) {
+      resumes.push(parsed.resume);
+    }
+  }
+
+  const submitSummary: ResumeSubmitSummary = resumes.length > 0
+    ? await submitNormalizedResumeImport(normalizeResumeImportPayload({
+      metadata: {
+        ...metadata,
+        totalResumes: resumes.length,
+      },
+      resumes,
+    }))
+    : { success: true, submitted: 0, inserted: 0, updated: 0, unchanged: 0, deduped: 0 };
+
+  return ResumeManualImportResponseSchema.parse({
+    success: true,
+    source: {
+      key: MANUAL_SOURCE_KEY,
+      label: MANUAL_SOURCE_KEY,
+    },
+    summary: buildSummary(input.files.length, enumeratedFiles.length, resumes.length, submitSummary, fileResults),
+    files: fileResults,
+    warnings: Array.from(new Set(warnings)),
+  });
+}
+
+export function getManualResumeImportMaxUploadBytes(): number {
+  return MAX_UPLOAD_REQUEST_SIZE;
+}

--- a/apps/web/src/components/ManualResumeImportDialog.tsx
+++ b/apps/web/src/components/ManualResumeImportDialog.tsx
@@ -1,0 +1,453 @@
+import { normalizeOptionalString } from '@trends/shared'
+import { useEffect, useMemo, useRef, useState, type DragEvent } from 'react'
+import { FileText, Loader2, Upload, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import type { components } from '@/lib/api-types'
+import { apiBaseUrl } from '@/lib/api-client'
+import { withWorkspaceHeaders } from '@/lib/workspace-ref'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+const MANUAL_IMPORT_URL = new URL(`${apiBaseUrl}/api/resumes/manual-import`, window.location.origin).toString()
+
+const ACCEPTED_FILE_TYPES = '.rar,.zip,.pdf,.doc,.docx'
+
+type ManualResumeImportResponse = components['schemas']['ResumeManualImportResponse']
+type ManualResumeImportError = components['schemas']['ResumeManualImportError']
+type ManualResumeImportResult = ManualResumeImportResponse | ManualResumeImportError
+type ManualResumeImportFileResult = components['schemas']['ResumeManualImportFileResult']
+
+type ManualResumeImportDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  location?: string
+  keywords?: string[]
+  onImported?: () => void | Promise<void>
+}
+
+function formatBytes(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) {
+    return '0 B'
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB']
+  let size = value
+  let unitIndex = 0
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex += 1
+  }
+
+  const precision = size >= 10 || unitIndex === 0 ? 0 : 1
+  return `${size.toFixed(precision)} ${units[unitIndex]}`
+}
+
+function getFileFingerprint(file: File): string {
+  return `${file.name}:${file.size}:${file.lastModified}`
+}
+
+function mergeFiles(currentFiles: File[], nextFiles: Iterable<File>): File[] {
+  const merged = [...currentFiles]
+  const seen = new Set(merged.map(getFileFingerprint))
+
+  for (const file of nextFiles) {
+    const fingerprint = getFileFingerprint(file)
+    if (seen.has(fingerprint)) {
+      continue
+    }
+    seen.add(fingerprint)
+    merged.push(file)
+  }
+
+  return merged
+}
+
+function normalizeKeywords(keywords: string[] | undefined): string | undefined {
+  if (!Array.isArray(keywords) || keywords.length === 0) {
+    return undefined
+  }
+
+  const normalized = keywords
+    .map((keyword) => keyword.trim())
+    .filter((keyword) => keyword.length > 0)
+
+  return normalized.length > 0 ? normalized.join(' ') : undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isSuccessResponse(value: unknown): value is ManualResumeImportResponse {
+  return isRecord(value)
+    && value.success === true
+    && Array.isArray(value.files)
+    && isRecord(value.summary)
+    && isRecord(value.source)
+}
+
+function isErrorResponse(value: unknown): value is ManualResumeImportError {
+  return isRecord(value)
+    && value.success === false
+    && typeof value.error === 'string'
+}
+
+function getStatusBadgeClass(status: ManualResumeImportFileResult['status']): string {
+  if (status === 'imported') {
+    return 'border-emerald-200 bg-emerald-50 text-emerald-700'
+  }
+  if (status === 'skipped') {
+    return 'border-amber-200 bg-amber-50 text-amber-700'
+  }
+  return 'border-red-200 bg-red-50 text-red-700'
+}
+
+export function ManualResumeImportDialog({
+  open,
+  onOpenChange,
+  location,
+  keywords,
+  onImported,
+}: ManualResumeImportDialogProps) {
+  const { t } = useTranslation()
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([])
+  const [isDragging, setIsDragging] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState<ManualResumeImportResult | null>(null)
+
+  const keyword = useMemo(() => normalizeKeywords(keywords), [keywords])
+  const normalizedLocation = useMemo(() => normalizeOptionalString(location), [location])
+
+  useEffect(() => {
+    if (open) {
+      return
+    }
+
+    setSelectedFiles([])
+    setIsDragging(false)
+    setSubmitting(false)
+    setResult(null)
+  }, [open])
+
+  const appendFiles = (files: Iterable<File>) => {
+    setSelectedFiles((current) => mergeFiles(current, files))
+    setResult(null)
+  }
+
+  const removeFile = (fileToRemove: File) => {
+    const fingerprint = getFileFingerprint(fileToRemove)
+    setSelectedFiles((current) => current.filter((file) => getFileFingerprint(file) !== fingerprint))
+    setResult(null)
+  }
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    setIsDragging(false)
+    if (event.dataTransfer.files.length === 0) {
+      return
+    }
+    appendFiles(Array.from(event.dataTransfer.files))
+  }
+
+  const handleSubmit = async () => {
+    if (selectedFiles.length === 0) {
+      toast.error(t('manualResumeImport.selectFilesFirst', 'Select at least one file to import'))
+      return
+    }
+
+    setSubmitting(true)
+    setResult(null)
+
+    try {
+      const formData = new FormData()
+      selectedFiles.forEach((file) => {
+        formData.append('files', file)
+      })
+      if (keyword) {
+        formData.append('keyword', keyword)
+      }
+      if (normalizedLocation) {
+        formData.append('location', normalizedLocation)
+      }
+
+      const response = await fetch(MANUAL_IMPORT_URL, {
+        method: 'POST',
+        headers: withWorkspaceHeaders(),
+        body: formData,
+      })
+      const payload: unknown = await response.json()
+
+      if (!response.ok) {
+        const nextError = isErrorResponse(payload)
+          ? payload
+          : { success: false as const, error: t('manualResumeImport.importFailed', 'Failed to import resumes') }
+        setResult(nextError)
+        toast.error(nextError.error)
+        return
+      }
+
+      if (!isSuccessResponse(payload)) {
+        const message = t('manualResumeImport.invalidResponse', 'Received an invalid import response')
+        setResult({ success: false, error: message })
+        toast.error(message)
+        return
+      }
+
+      setResult(payload)
+      toast.success(t('manualResumeImport.importComplete', 'Resume import completed'))
+      await onImported?.()
+    } catch (error) {
+      console.error('Failed to import manual resumes', error)
+      const message = error instanceof Error
+        ? error.message
+        : t('manualResumeImport.importFailed', 'Failed to import resumes')
+      setResult({ success: false, error: message })
+      toast.error(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{t('manualResumeImport.title', 'Import resumes')}</DialogTitle>
+          <DialogDescription>
+            {t(
+              'manualResumeImport.description',
+              'Upload 51job manual export bundles or files in .rar, .zip, .pdf, .doc, or .docx format.'
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="rounded-lg border bg-muted/20 p-3 text-sm">
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-muted-foreground">
+              <span>
+                {t('manualResumeImport.location', 'Location')}: {normalizedLocation || '--'}
+              </span>
+              <span>
+                {t('manualResumeImport.keywords', 'Keywords')}: {keyword || '--'}
+              </span>
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              'rounded-lg border-2 border-dashed p-6 text-center transition-colors',
+              isDragging ? 'border-primary bg-primary/5' : 'border-muted-foreground/25'
+            )}
+            onDragEnter={(event) => {
+              event.preventDefault()
+              setIsDragging(true)
+            }}
+            onDragOver={(event) => {
+              event.preventDefault()
+              setIsDragging(true)
+            }}
+            onDragLeave={(event) => {
+              event.preventDefault()
+              setIsDragging(false)
+            }}
+            onDrop={handleDrop}
+          >
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <Upload className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <div className="mt-3 space-y-1">
+              <p className="text-sm font-medium">
+                {t('manualResumeImport.dropzoneTitle', 'Drag and drop resume files here')}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {t('manualResumeImport.dropzoneSubtitle', 'You can mix archives and direct document uploads in one batch.')}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              className="mt-4"
+              onClick={() => inputRef.current?.click()}
+            >
+              {t('manualResumeImport.selectFiles', 'Select files')}
+            </Button>
+            <input
+              ref={inputRef}
+              type="file"
+              multiple
+              accept={ACCEPTED_FILE_TYPES}
+              className="hidden"
+              data-testid="manual-resume-import-input"
+              onChange={(event) => {
+                if (event.target.files) {
+                  appendFiles(Array.from(event.target.files))
+                }
+                event.target.value = ''
+              }}
+            />
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-sm font-medium">
+                {t('manualResumeImport.selectedFiles', 'Selected files')} ({selectedFiles.length})
+              </div>
+              {selectedFiles.length > 0 ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setSelectedFiles([])
+                    setResult(null)
+                  }}
+                >
+                  {t('manualResumeImport.clearFiles', 'Clear')}
+                </Button>
+              ) : null}
+            </div>
+
+            {selectedFiles.length === 0 ? (
+              <div className="rounded-lg border border-dashed px-4 py-6 text-center text-sm text-muted-foreground">
+                {t('manualResumeImport.noFiles', 'No files selected yet.')}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {selectedFiles.map((file) => (
+                  <div key={getFileFingerprint(file)} className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium">{file.name}</div>
+                        <div className="text-xs text-muted-foreground">{formatBytes(file.size)}</div>
+                      </div>
+                    </div>
+                    <Button type="button" variant="ghost" size="icon" onClick={() => removeFile(file)}>
+                      <X className="h-4 w-4" />
+                      <span className="sr-only">{t('manualResumeImport.removeFile', 'Remove file')}</span>
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {result && !result.success ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              <div className="font-medium">{result.error}</div>
+              {result.warnings && result.warnings.length > 0 ? (
+                <ul className="mt-2 list-disc space-y-1 pl-5 text-xs">
+                  {result.warnings.map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          ) : null}
+
+          {result && result.success ? (
+            <div className="space-y-4 rounded-lg border bg-muted/10 p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-sm font-semibold">
+                    {t('manualResumeImport.resultTitle', 'Import summary')}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {result.source.label}
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">
+                <div className="rounded-md border px-3 py-2">
+                  <div className="text-xs text-muted-foreground">{t('manualResumeImport.uploadedFiles', 'Uploaded')}</div>
+                  <div className="font-semibold">{result.summary.uploadedFiles}</div>
+                </div>
+                <div className="rounded-md border px-3 py-2">
+                  <div className="text-xs text-muted-foreground">{t('manualResumeImport.discoveredFiles', 'Discovered')}</div>
+                  <div className="font-semibold">{result.summary.discoveredFiles}</div>
+                </div>
+                <div className="rounded-md border px-3 py-2">
+                  <div className="text-xs text-muted-foreground">{t('manualResumeImport.parsedResumes', 'Parsed')}</div>
+                  <div className="font-semibold">{result.summary.parsedResumes}</div>
+                </div>
+                <div className="rounded-md border px-3 py-2">
+                  <div className="text-xs text-muted-foreground">{t('manualResumeImport.imported', 'Imported')}</div>
+                  <div className="font-semibold">{result.summary.imported}</div>
+                </div>
+                <div className="rounded-md border px-3 py-2">
+                  <div className="text-xs text-muted-foreground">{t('manualResumeImport.skipped', 'Skipped')}</div>
+                  <div className="font-semibold">{result.summary.skipped}</div>
+                </div>
+                <div className="rounded-md border px-3 py-2">
+                  <div className="text-xs text-muted-foreground">{t('manualResumeImport.failed', 'Failed')}</div>
+                  <div className="font-semibold">{result.summary.failed}</div>
+                </div>
+              </div>
+
+              {result.warnings.length > 0 ? (
+                <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+                  <div className="font-medium">{t('manualResumeImport.warnings', 'Warnings')}</div>
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-xs">
+                    {result.warnings.map((warning) => (
+                      <li key={warning}>{warning}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              <div className="space-y-2">
+                {result.files.map((file) => (
+                  <div key={`${file.uploadName}:${file.entryPath}`} className="rounded-lg border px-3 py-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="truncate text-sm font-medium">{file.entryPath}</span>
+                      <span className={cn('rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase', getStatusBadgeClass(file.status))}>
+                        {file.status}
+                      </span>
+                    </div>
+                    {(file.resumeName || file.profileId || file.error || file.warnings.length > 0) ? (
+                      <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+                        {file.resumeName ? <div>{t('manualResumeImport.resumeName', 'Resume')}: {file.resumeName}</div> : null}
+                        {file.profileId ? <div>{t('manualResumeImport.profileId', 'Profile ID')}: {file.profileId}</div> : null}
+                        {file.error ? <div className="text-red-600">{file.error}</div> : null}
+                        {file.warnings.map((warning) => (
+                          <div key={`${file.entryPath}:${warning}`} className="text-amber-700">{warning}</div>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+            {t('common.close', 'Close')}
+          </Button>
+          <Button type="button" onClick={() => void handleSubmit()} disabled={submitting || selectedFiles.length === 0}>
+            {submitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {t('manualResumeImport.importing', 'Importing...')}
+              </>
+            ) : (
+              t('manualResumeImport.submit', 'Import resumes')
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -2,6 +2,7 @@ import {
   buildWorkHistoryEntryText,
   getCurrentResumeAiPromptVersion,
   normalizeKeywordSalesAnalysis,
+  normalizeOptionalString,
   resolveResumeId,
 } from '@trends/shared'
 import type { ResumeItem } from '@/hooks/useResumes'
@@ -150,6 +151,14 @@ export function isAutoFilteredAnalysis(analysis: ConvexResumeAnalysis | undefine
 export function isSafeProfileUrl(value: string | undefined): value is string {
   if (!value) return false
   return value.startsWith('http://') || value.startsWith('https://')
+}
+
+export function getResumeSourceLabel(resume: unknown): string | undefined {
+  if (!resume || typeof resume !== 'object' || !('source' in resume) || typeof resume.source !== 'string') {
+    return undefined
+  }
+
+  return normalizeOptionalString(resume.source)
 }
 
 export function buildResumeKey(resume: ResumeItem, index: number): string {


### PR DESCRIPTION
## Summary
- replace the manual-import DOCX regression's checked-in sample dependency with an in-memory JSZip-generated fixture
- force the Mammoth fallback path deterministically while keeping route-level assertions for warning, profile ID, and external ID behavior
- deduplicate imported resume assembly and simplify manual import dialog result-state handling

## Test plan
- [x] bunx vitest run apps/api/src/routes/manual-resume-import.test.ts
- [x] cd apps/web && bunx vitest run src/components/ManualResumeImportDialog.test.tsx
- [x] cd apps/api && bun run typecheck
- [x] cd apps/web && bun run typecheck
- [x] make check