### PR TITLE
Fix Convex seed status read limit

### DIFF
--- a/packages/convex/convex/__tests__/seed-status.test.ts
+++ b/packages/convex/convex/__tests__/seed-status.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { status } from "../seed";
+
+type StatusResult = {
+  jobDescriptions: number;
+  resumes: number;
+  collectionTasks: number;
+  searchProfiles: number;
+  screeningSessions: number;
+  searchHistory: number;
+  workspaceConfig: number;
+  isEmpty: boolean;
+};
+
+type ConvexHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+type StatusTable =
+  | "job_descriptions"
+  | "resumes"
+  | "collection_tasks"
+  | "search_profiles"
+  | "screening_sessions"
+  | "search_history"
+  | "workspace_config";
+
+type StatusRecord = Record<string, unknown>;
+
+const statusHandler = (status as unknown as ConvexHandler<
+  Record<string, never>,
+  StatusResult
+>)._handler;
+
+function createStatusCtx(
+  tables: Partial<Record<StatusTable, StatusRecord[]>> = {},
+) {
+  const records: Record<StatusTable, StatusRecord[]> = {
+    job_descriptions: [],
+    resumes: [],
+    collection_tasks: [],
+    search_profiles: [],
+    screening_sessions: [],
+    search_history: [],
+    workspace_config: [],
+    ...tables,
+  };
+  const queryCalls: StatusTable[] = [];
+  const collectCalls: StatusTable[] = [];
+
+  const ctx = {
+    db: {
+      query(tableName: StatusTable) {
+        queryCalls.push(tableName);
+        return {
+          async first() {
+            return records[tableName][0] ?? null;
+          },
+          async collect() {
+            collectCalls.push(tableName);
+            throw new Error(`collect() should not be called for ${tableName}`);
+          },
+        };
+      },
+    },
+  };
+
+  return { ctx, queryCalls, collectCalls };
+}
+
+describe("seed:status", () => {
+  it("uses constant-size probes and reports presence as 0/1", async () => {
+    const { ctx, queryCalls, collectCalls } = createStatusCtx({
+      job_descriptions: [{ _id: "job_descriptions-1" }],
+      resumes: [{ _id: "resumes-1" }],
+      search_profiles: [{ _id: "search_profiles-1" }],
+    });
+
+    await expect(statusHandler(ctx as never, {})).resolves.toEqual({
+      jobDescriptions: 1,
+      resumes: 1,
+      collectionTasks: 0,
+      searchProfiles: 1,
+      screeningSessions: 0,
+      searchHistory: 0,
+      workspaceConfig: 0,
+      isEmpty: false,
+    });
+
+    expect(queryCalls).toEqual([
+      "job_descriptions",
+      "resumes",
+      "collection_tasks",
+      "search_profiles",
+      "screening_sessions",
+      "search_history",
+      "workspace_config",
+    ]);
+    expect(collectCalls).toEqual([]);
+  });
+
+  it("reports an empty database without collecting full tables", async () => {
+    const { ctx } = createStatusCtx();
+
+    await expect(statusHandler(ctx as never, {})).resolves.toEqual({
+      jobDescriptions: 0,
+      resumes: 0,
+      collectionTasks: 0,
+      searchProfiles: 0,
+      screeningSessions: 0,
+      searchHistory: 0,
+      workspaceConfig: 0,
+      isEmpty: true,
+    });
+  });
+});

--- a/packages/convex/convex/seed.ts
+++ b/packages/convex/convex/seed.ts
@@ -267,23 +267,23 @@ export const status = query({
       searchHistory,
       workspaceConfig,
     ] = await Promise.all([
-      ctx.db.query("job_descriptions").collect(),
-      ctx.db.query("resumes").collect(),
-      ctx.db.query("collection_tasks").collect(),
-      ctx.db.query("search_profiles").collect(),
-      ctx.db.query("screening_sessions").collect(),
-      ctx.db.query("search_history").collect(),
-      ctx.db.query("workspace_config").collect(),
+      ctx.db.query("job_descriptions").first(),
+      ctx.db.query("resumes").first(),
+      ctx.db.query("collection_tasks").first(),
+      ctx.db.query("search_profiles").first(),
+      ctx.db.query("screening_sessions").first(),
+      ctx.db.query("search_history").first(),
+      ctx.db.query("workspace_config").first(),
     ]);
 
     const counts = {
-      jobDescriptions: jobDescriptions.length,
-      resumes: resumes.length,
-      collectionTasks: collectionTasks.length,
-      searchProfiles: searchProfiles.length,
-      screeningSessions: screeningSessions.length,
-      searchHistory: searchHistory.length,
-      workspaceConfig: workspaceConfig.length,
+      jobDescriptions: jobDescriptions === null ? 0 : 1,
+      resumes: resumes === null ? 0 : 1,
+      collectionTasks: collectionTasks === null ? 0 : 1,
+      searchProfiles: searchProfiles === null ? 0 : 1,
+      screeningSessions: screeningSessions === null ? 0 : 1,
+      searchHistory: searchHistory === null ? 0 : 1,
+      workspaceConfig: workspaceConfig === null ? 0 : 1,
     };
 
     return {


### PR DESCRIPTION
## Summary
- Replace the seed status full-table scans with constant-size `first()` probes.
- Add a regression test that verifies the status probe never calls `collect()`.

## Validation
- bunx vitest run packages/convex/convex/__tests__/seed-status.test.ts
- npm --workspace @trends/convex run typecheck
- npm --workspace @trends/convex run build
- make check