### PR TITLE
fix: correct manual import batch feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ bin/
 coverage/
 apps/web/coverage/
 apps/web/test-results/
+tool-results/
 
 # Allow web app lib folder (overrides Python lib/ ignore)
 !apps/web/src/lib/

--- a/apps/web/src/components/ManualResumeImportDialog.test.tsx
+++ b/apps/web/src/components/ManualResumeImportDialog.test.tsx
@@ -146,4 +146,129 @@ describe('ManualResumeImportDialog', () => {
       expect(screen.getByText('Upload exceeds size limit')).toBeInTheDocument()
     })
   })
+
+  it('does not show a success toast or refresh when every uploaded file fails', async () => {
+    const user = userEvent.setup()
+    const onImported = vi.fn()
+    const fetchMock = vi.mocked(fetch)
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        source: { key: '51job-manual', label: '51job-manual' },
+        summary: {
+          uploadedFiles: 1,
+          discoveredFiles: 1,
+          parsedResumes: 0,
+          imported: 0,
+          inserted: 0,
+          updated: 0,
+          unchanged: 0,
+          deduped: 0,
+          skipped: 0,
+          failed: 1,
+        },
+        files: [
+          {
+            uploadName: '51job_张三(123456).doc',
+            entryPath: '51job_张三(123456).doc',
+            extension: '.doc',
+            status: 'failed',
+            error: 'Legacy .doc parsing is not supported yet',
+            warnings: [],
+          },
+        ],
+        warnings: [],
+      }),
+    } as Response)
+
+    render(
+      <ManualResumeImportDialog
+        open
+        onOpenChange={vi.fn()}
+        location="东莞"
+        keywords={['销售工程师']}
+        onImported={onImported}
+      />
+    )
+
+    const input = screen.getByTestId('manual-resume-import-input') as HTMLInputElement
+    await user.upload(input, new File(['legacy-doc'], '51job_张三(123456).doc', { type: 'application/msword' }))
+    await user.click(screen.getByRole('button', { name: 'Import resumes' }))
+
+    await waitFor(() => {
+      expect(errorMock).toHaveBeenCalledWith('Legacy .doc parsing is not supported yet')
+      expect(successMock).not.toHaveBeenCalled()
+      expect(onImported).not.toHaveBeenCalled()
+      expect(screen.getByText('Import summary')).toBeInTheDocument()
+      expect(screen.getByText('Legacy .doc parsing is not supported yet')).toBeInTheDocument()
+    })
+  })
+
+  it('keeps success toast and refresh when imported rows exist alongside skipped files', async () => {
+    const user = userEvent.setup()
+    const onImported = vi.fn()
+    const fetchMock = vi.mocked(fetch)
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        source: { key: '51job-manual', label: '51job-manual' },
+        summary: {
+          uploadedFiles: 1,
+          discoveredFiles: 2,
+          parsedResumes: 1,
+          imported: 1,
+          inserted: 1,
+          updated: 0,
+          unchanged: 0,
+          deduped: 0,
+          skipped: 1,
+          failed: 0,
+        },
+        files: [
+          {
+            uploadName: 'mixed.zip',
+            entryPath: '51job_张三(123456).docx',
+            extension: '.docx',
+            status: 'imported',
+            resumeName: '张三',
+            profileId: '123456',
+            warnings: [],
+          },
+          {
+            uploadName: 'mixed.zip',
+            entryPath: 'notes.txt',
+            extension: '.txt',
+            status: 'skipped',
+            error: 'Unsupported file type',
+            warnings: [],
+          },
+        ],
+        warnings: [],
+      }),
+    } as Response)
+
+    render(
+      <ManualResumeImportDialog
+        open
+        onOpenChange={vi.fn()}
+        location="东莞"
+        keywords={['销售工程师']}
+        onImported={onImported}
+      />
+    )
+
+    const input = screen.getByTestId('manual-resume-import-input') as HTMLInputElement
+    await user.upload(input, new File(['archive'], 'mixed.zip', { type: 'application/zip' }))
+    await user.click(screen.getByRole('button', { name: 'Import resumes' }))
+
+    await waitFor(() => {
+      expect(successMock).toHaveBeenCalledWith('Resume import completed')
+      expect(errorMock).not.toHaveBeenCalled()
+      expect(onImported).toHaveBeenCalledTimes(1)
+      expect(screen.getByText('notes.txt')).toBeInTheDocument()
+      expect(screen.getByText('Unsupported file type')).toBeInTheDocument()
+    })
+  })
 })

--- a/apps/web/src/components/ManualResumeImportDialog.tsx
+++ b/apps/web/src/components/ManualResumeImportDialog.tsx
@@ -111,6 +111,17 @@ function getStatusBadgeClass(status: ManualResumeImportFileResult['status']): st
   return 'border-red-200 bg-red-50 text-red-700'
 }
 
+function hasImportedFiles(result: ManualResumeImportResponse): boolean {
+  return result.files.some((file) => file.status === 'imported')
+}
+
+function getBatchFailureMessage(result: ManualResumeImportResponse, fallbackMessage: string): string {
+  const firstProblemFile = result.files.find(
+    (file) => (file.status === 'failed' || file.status === 'skipped') && typeof file.error === 'string' && file.error.length > 0
+  )
+  return firstProblemFile?.error ?? fallbackMessage
+}
+
 export function ManualResumeImportDialog({
   open,
   onOpenChange,
@@ -204,8 +215,14 @@ export function ManualResumeImportDialog({
       }
 
       setResult(payload)
-      toast.success(t('manualResumeImport.importComplete', 'Resume import completed'))
-      await onImported?.()
+
+      if (hasImportedFiles(payload)) {
+        toast.success(t('manualResumeImport.importComplete', 'Resume import completed'))
+        await onImported?.()
+        return
+      }
+
+      toast.error(getBatchFailureMessage(payload, t('manualResumeImport.importFailed', 'Failed to import resumes')))
     } catch (error) {
       console.error('Failed to import manual resumes', error)
       const message = error instanceof Error


### PR DESCRIPTION
## Summary
- only show the manual import success toast when at least one uploaded file is actually imported
- keep failed-only batches from triggering the resume refresh path while preserving mixed imported-plus-skipped success handling
- ignore local `tool-results/` browser-test artifacts

## Test plan
- [x] cd apps/web && bunx vitest run src/components/ManualResumeImportDialog.test.tsx
- [x] make check
- [x] Verified live dialog zero-file state on the target resumes page