### PR TITLE
feat: compress deploy resume backups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -768,7 +768,7 @@ help:
 	@echo "Deployment:"
 	@echo "  install        Install as systemd services (requires sudo)"
 	@echo "  install-seed   Install as systemd services with seeded demo resumes (requires sudo)"
-	@echo "  deploy         Preflight workspace git, snapshot Convex, and best-effort write resumes-<workspace>.json before skip/env-refresh/full upgrade (requires sudo)"
+	@echo "  deploy         Preflight workspace git, snapshot Convex, and best-effort write resumes-<workspace>.tar.gz before skip/env-refresh/full upgrade (requires sudo)"
 	@echo "  deploy-check   Dry run deploy precheck with workspace git status but without rebuilding"
 	@echo "  deploy-seed    Force a full upgrade with seeded demo resumes (requires sudo)"
 	@echo "  refresh-env    Refresh env, sync frontend build vars, and rebuild the production web bundle"

--- a/packages/cli/cmd/resume_backup.go
+++ b/packages/cli/cmd/resume_backup.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -90,16 +93,201 @@ func normalizeResumeBackupOutputPath(outPath string, disposition string) string 
 	return fmt.Sprintf("resume-backup-%s.json", time.Now().Format("20060102-150405"))
 }
 
-func readResumeBackupFile(filePath string) ([]byte, resumeBackupEnvelope, error) {
-	payload, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, resumeBackupEnvelope{}, fmt.Errorf("read backup file: %w", err)
+func normalizeResumeRestoreMode(mode string) (string, error) {
+	normalizedMode := strings.ToLower(strings.TrimSpace(mode))
+	if normalizedMode == "" {
+		normalizedMode = "upsert"
+	}
+	if normalizedMode != "upsert" && normalizedMode != "replace" {
+		return "", fmt.Errorf("invalid mode %q (expected upsert|replace)", mode)
+	}
+	return normalizedMode, nil
+}
+
+func isTarGzPath(filePath string) bool {
+	return strings.HasSuffix(strings.ToLower(strings.TrimSpace(filePath)), ".tar.gz")
+}
+
+func formatJSONPayload(payload []byte) []byte {
+	var formatted bytes.Buffer
+	if err := json.Indent(&formatted, payload, "", "  "); err == nil {
+		formatted.WriteByte('\n')
+		return formatted.Bytes()
 	}
 
-	envelope, err := unmarshalResumeBackupEnvelope(payload)
-	if err != nil {
-		return nil, resumeBackupEnvelope{}, fmt.Errorf("invalid backup file: %w", err)
+	return append([]byte(nil), payload...)
+}
+
+func resolveArchiveEntryName(filePath string) string {
+	fileName := filepath.Base(strings.TrimSpace(filePath))
+	if fileName == "" {
+		return "resume-backup.json"
 	}
+
+	if strings.HasSuffix(strings.ToLower(fileName), ".tar.gz") {
+		fileName = fileName[:len(fileName)-len(".tar.gz")]
+	}
+	if !strings.HasSuffix(strings.ToLower(fileName), ".json") {
+		fileName += ".json"
+	}
+	if len(fileName) > 100 {
+		return "resume-backup.json"
+	}
+
+	return fileName
+}
+
+func buildPortableBackupArchive(filePath string, content []byte) ([]byte, error) {
+	var archive bytes.Buffer
+	gzipWriter := gzip.NewWriter(&archive)
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	header := &tar.Header{
+		Name:     resolveArchiveEntryName(filePath),
+		Mode:     0o644,
+		Size:     int64(len(content)),
+		ModTime:  time.Now().UTC(),
+		Typeflag: tar.TypeReg,
+		Format:   tar.FormatUSTAR,
+	}
+
+	if err := tarWriter.WriteHeader(header); err != nil {
+		_ = tarWriter.Close()
+		_ = gzipWriter.Close()
+		return nil, fmt.Errorf("create backup archive: %w", err)
+	}
+	if _, err := tarWriter.Write(content); err != nil {
+		_ = tarWriter.Close()
+		_ = gzipWriter.Close()
+		return nil, fmt.Errorf("write backup archive content: %w", err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		_ = gzipWriter.Close()
+		return nil, fmt.Errorf("close backup archive: %w", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return nil, fmt.Errorf("compress backup archive: %w", err)
+	}
+
+	return archive.Bytes(), nil
+}
+
+func writePortableBackupFile(filePath string, payload []byte) (int, error) {
+	resolvedPath := strings.TrimSpace(filePath)
+	if resolvedPath == "" {
+		return 0, fmt.Errorf("output file path is required")
+	}
+
+	dir := filepath.Dir(resolvedPath)
+	if dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return 0, fmt.Errorf("create output directory: %w", err)
+		}
+	}
+
+	content := formatJSONPayload(payload)
+	if !isTarGzPath(resolvedPath) {
+		if err := os.WriteFile(resolvedPath, content, 0o644); err != nil {
+			return 0, fmt.Errorf("write backup file: %w", err)
+		}
+		return len(content), nil
+	}
+
+	archive, err := buildPortableBackupArchive(resolvedPath, content)
+	if err != nil {
+		return 0, err
+	}
+	if err := os.WriteFile(resolvedPath, archive, 0o644); err != nil {
+		return 0, fmt.Errorf("write backup file: %w", err)
+	}
+
+	return len(archive), nil
+}
+
+func extractTarEntryContent(reader io.Reader) ([]byte, error) {
+	tarReader := tar.NewReader(reader)
+	var jsonEntry []byte
+	var fallbackFile []byte
+	fileEntryCount := 0
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read backup archive: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeRegA {
+			continue
+		}
+
+		name := strings.TrimSpace(filepath.Base(header.Name))
+		if name == "" || strings.HasPrefix(name, "._") {
+			continue
+		}
+
+		content, err := io.ReadAll(tarReader)
+		if err != nil {
+			return nil, fmt.Errorf("read backup archive content: %w", err)
+		}
+
+		fileEntryCount++
+		if strings.HasSuffix(strings.ToLower(name), ".json") {
+			if jsonEntry != nil {
+				return nil, fmt.Errorf("invalid backup archive: multiple JSON entries found")
+			}
+			jsonEntry = content
+			continue
+		}
+
+		if fallbackFile == nil {
+			fallbackFile = content
+		}
+	}
+
+	if jsonEntry != nil {
+		return jsonEntry, nil
+	}
+	if fileEntryCount == 1 && fallbackFile != nil {
+		return fallbackFile, nil
+	}
+	if fileEntryCount > 1 {
+		return nil, fmt.Errorf("invalid backup archive: expected exactly one JSON payload")
+	}
+
+	return nil, fmt.Errorf("invalid backup archive: no file entries found")
+}
+
+func readPortableBackupFile(filePath string) ([]byte, error) {
+	resolvedPath := strings.TrimSpace(filePath)
+	if resolvedPath == "" {
+		return nil, fmt.Errorf("backup file path is required")
+	}
+
+	content, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		return nil, fmt.Errorf("read backup file: %w", err)
+	}
+	if len(content) < 2 || content[0] != 0x1f || content[1] != 0x8b {
+		return content, nil
+	}
+
+	gzipReader, err := gzip.NewReader(bytes.NewReader(content))
+	if err != nil {
+		return nil, fmt.Errorf("read backup archive: %w", err)
+	}
+	defer gzipReader.Close()
+
+	archivePayload, err := extractTarEntryContent(gzipReader)
+	if err != nil {
+		return nil, err
+	}
+
+	return archivePayload, nil
+}
+
+func validateResumeBackupEnvelope(payload []byte, envelope resumeBackupEnvelope) ([]byte, resumeBackupEnvelope, error) {
 	if !isJSONObject(envelope.Metadata) {
 		return nil, resumeBackupEnvelope{}, fmt.Errorf("invalid backup file: missing metadata")
 	}
@@ -110,15 +298,18 @@ func readResumeBackupFile(filePath string) ([]byte, resumeBackupEnvelope, error)
 	return payload, envelope, nil
 }
 
-func normalizeResumeRestoreMode(mode string) (string, error) {
-	normalizedMode := strings.ToLower(strings.TrimSpace(mode))
-	if normalizedMode == "" {
-		normalizedMode = "upsert"
+func readResumeBackupFile(filePath string) ([]byte, resumeBackupEnvelope, error) {
+	payload, err := readPortableBackupFile(filePath)
+	if err != nil {
+		return nil, resumeBackupEnvelope{}, err
 	}
-	if normalizedMode != "upsert" && normalizedMode != "replace" {
-		return "", fmt.Errorf("invalid mode %q (expected upsert|replace)", mode)
+
+	envelope, err := unmarshalResumeBackupEnvelope(payload)
+	if err != nil {
+		return nil, resumeBackupEnvelope{}, fmt.Errorf("invalid backup file: %w", err)
 	}
-	return normalizedMode, nil
+
+	return validateResumeBackupEnvelope(payload, envelope)
 }
 
 func backupResumesToFile(ctx context.Context, apiClient *client.Client, request client.ResumeBackupRequest, outPath string) (*resumeBackupResult, error) {
@@ -136,14 +327,15 @@ func backupResumesToFile(ctx context.Context, apiClient *client.Client, request 
 	}
 
 	resolvedPath := normalizeResumeBackupOutputPath(outPath, disposition)
-	if err := writeJSONFile(resolvedPath, payload); err != nil {
+	bytesWritten, err := writePortableBackupFile(resolvedPath, payload)
+	if err != nil {
 		return nil, err
 	}
 
 	return &resumeBackupResult{
 		FilePath: resolvedPath,
 		Count:    resumeBackupCount(envelope),
-		Bytes:    len(payload),
+		Bytes:    bytesWritten,
 	}, nil
 }
 
@@ -272,7 +464,7 @@ func newResumeBackupCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "backup",
-		Short: "Backup live resume records to a portable JSON file",
+		Short: "Backup live resume records to a portable JSON or .tar.gz file",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			request := client.ResumeBackupRequest{
 				ResumeIDs:   normalizeStringSlice(resumeIDs),
@@ -308,7 +500,7 @@ func newResumeRestoreCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "restore <file>",
-		Short: "Restore resume records from a portable JSON backup",
+		Short: "Restore resume records from a portable JSON or .tar.gz backup",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			filePath := strings.TrimSpace(args[0])
@@ -356,7 +548,7 @@ func newResumeDeployBackupWriteCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "write [run-dir]",
-		Short: "Write a resume backup JSON file into a deploy backup run directory",
+		Short: "Write a resume backup into a deploy backup run directory (.tar.gz by default)",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runDir, err := resolveOrCreateDeployBackupRunDir(baseDir, args)
@@ -403,7 +595,7 @@ func newResumeDeployBackupRestoreCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "restore [run-dir]",
-		Short: "Restore resume records from a deploy backup run directory",
+		Short: "Restore resume records from a deploy backup run directory (.tar.gz preferred)",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runDir, err := resolveDeployBackupRunDir(baseDir, args)
@@ -411,7 +603,10 @@ func newResumeDeployBackupRestoreCmd() *cobra.Command {
 				return err
 			}
 
-			filePath := deployResumeBackupFilePath(runDir, currentOptions().Workspace)
+			filePath, err := resolveDeployResumeBackupFilePath(runDir, currentOptions().Workspace)
+			if err != nil {
+				return err
+			}
 			result, err := restoreResumeBackupFile(context.Background(), newAPIClient(), filePath, mode, yes)
 			if err != nil {
 				return err
@@ -501,7 +696,33 @@ func latestDeployBackupRunDir(baseDir string) (string, error) {
 }
 
 func deployResumeBackupFilePath(runDir string, workspace string) string {
-	return filepath.Join(runDir, fmt.Sprintf("resumes-%s.json", normalizeWorkspace(workspace)))
+	return filepath.Join(runDir, fmt.Sprintf("resumes-%s.tar.gz", normalizeWorkspace(workspace)))
+}
+
+func deployResumeBackupFilePaths(runDir string, workspace string) []string {
+	normalizedWorkspace := normalizeWorkspace(workspace)
+	return []string{
+		filepath.Join(runDir, fmt.Sprintf("resumes-%s.tar.gz", normalizedWorkspace)),
+		filepath.Join(runDir, fmt.Sprintf("resumes-%s.json", normalizedWorkspace)),
+	}
+}
+
+func resolveDeployResumeBackupFilePath(runDir string, workspace string) (string, error) {
+	candidates := deployResumeBackupFilePaths(runDir, workspace)
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate)
+		if err == nil {
+			if info.IsDir() {
+				continue
+			}
+			return candidate, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("stat deploy backup file %s: %w", candidate, err)
+		}
+	}
+
+	return "", fmt.Errorf("no deploy resume backup found in %s for workspace %s", runDir, normalizeWorkspace(workspace))
 }
 
 func normalizeStringSlice(values []string) []string {
@@ -513,32 +734,4 @@ func normalizeStringSlice(values []string) []string {
 		}
 	}
 	return normalized
-}
-
-func writeJSONFile(filePath string, payload []byte) error {
-	resolvedPath := strings.TrimSpace(filePath)
-	if resolvedPath == "" {
-		return fmt.Errorf("output file path is required")
-	}
-
-	dir := filepath.Dir(resolvedPath)
-	if dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return fmt.Errorf("create output directory: %w", err)
-		}
-	}
-
-	var formatted bytes.Buffer
-	if err := json.Indent(&formatted, payload, "", "  "); err == nil {
-		formatted.WriteByte('\n')
-		if err := os.WriteFile(resolvedPath, formatted.Bytes(), 0o644); err != nil {
-			return fmt.Errorf("write backup file: %w", err)
-		}
-		return nil
-	}
-
-	if err := os.WriteFile(resolvedPath, payload, 0o644); err != nil {
-		return fmt.Errorf("write backup file: %w", err)
-	}
-	return nil
 }

--- a/packages/cli/cmd/resume_backup_test.go
+++ b/packages/cli/cmd/resume_backup_test.go
@@ -11,6 +11,18 @@ import (
 	"testing"
 )
 
+func writeTestPortableBackupFile(t *testing.T, filePath string, value any) {
+	t.Helper()
+
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("failed to marshal backup payload: %v", err)
+	}
+	if _, err := writePortableBackupFile(filePath, payload); err != nil {
+		t.Fatalf("failed to write backup payload: %v", err)
+	}
+}
+
 func TestResumeBackupCommandWritesBackupFile(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/api/resumes/backup" {
@@ -118,43 +130,56 @@ func TestResumeDeployBackupWriteCreatesRunDirAndWorkspaceFile(t *testing.T) {
 	}
 
 	runDir := filepath.Join(baseDir, entries[0].Name())
-	backupPath := filepath.Join(runDir, "resumes-dev.json")
+	backupPath := filepath.Join(runDir, "resumes-dev.tar.gz")
 	written, err := os.ReadFile(backupPath)
 	if err != nil {
 		t.Fatalf("failed to read deploy backup file: %v", err)
 	}
-	if !strings.Contains(string(written), `"resumeId": "r1"`) {
-		t.Fatalf("unexpected deploy backup file contents: %s", string(written))
+	if len(written) < 2 || written[0] != 0x1f || written[1] != 0x8b {
+		prefix := written
+		if len(prefix) > 2 {
+			prefix = prefix[:2]
+		}
+		t.Fatalf("expected gzip-compressed deploy backup, got prefix %x", prefix)
 	}
 
-	payload := decodeCommandJSON(t, output)
-	if payload["workspace"] != "dev" {
-		t.Fatalf("unexpected workspace in output: %+v", payload)
+	payload, envelope, err := readResumeBackupFile(backupPath)
+	if err != nil {
+		t.Fatalf("failed to read compressed deploy backup: %v", err)
 	}
-	if payload["runDir"] != runDir {
-		t.Fatalf("unexpected runDir in output: %+v", payload)
+	if count := resumeBackupCount(envelope); count != 2 {
+		t.Fatalf("unexpected deploy backup resume count: %d", count)
 	}
-	if payload["file"] != backupPath {
-		t.Fatalf("unexpected file path in output: %+v", payload)
+	if !strings.Contains(string(payload), `"resumeId": "r1"`) {
+		t.Fatalf("unexpected deploy backup file contents: %s", string(payload))
+	}
+
+	outputPayload := decodeCommandJSON(t, output)
+	if outputPayload["workspace"] != "dev" {
+		t.Fatalf("unexpected workspace in output: %+v", outputPayload)
+	}
+	if outputPayload["runDir"] != runDir {
+		t.Fatalf("unexpected runDir in output: %+v", outputPayload)
+	}
+	if outputPayload["file"] != backupPath {
+		t.Fatalf("unexpected file path in output: %+v", outputPayload)
 	}
 }
 
 func TestResumeRestoreCommandReplaceModeCallsResetThenImport(t *testing.T) {
-	backupFile := filepath.Join(t.TempDir(), "resume-backup.json")
-	if err := os.WriteFile(backupFile, []byte(`{
-  "metadata": {
-    "sourceUrl": "https://example.com/api/resumes/backup",
-    "generatedBy": "trends-api backup"
-  },
-  "resumes": [
-    {
-      "resumeId": "r1",
-      "name": "Alice"
-    }
-  ]
-}`), 0o644); err != nil {
-		t.Fatalf("failed to write backup file: %v", err)
-	}
+	backupFile := filepath.Join(t.TempDir(), "resume-backup.tar.gz")
+	writeTestPortableBackupFile(t, backupFile, map[string]any{
+		"metadata": map[string]any{
+			"sourceUrl":   "https://example.com/api/resumes/backup",
+			"generatedBy": "trends-api backup",
+		},
+		"resumes": []map[string]any{
+			{
+				"resumeId": "r1",
+				"name":     "Alice",
+			},
+		},
+	})
 
 	var callOrder []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -215,7 +240,7 @@ func TestResumeRestoreCommandReplaceModeCallsResetThenImport(t *testing.T) {
 	}
 }
 
-func TestResumeDeployBackupRestoreUsesLatestRunDir(t *testing.T) {
+func TestResumeDeployBackupRestorePrefersCompressedArtifactInLatestRunDir(t *testing.T) {
 	baseDir := filepath.Join(t.TempDir(), "deploy")
 	olderDir := filepath.Join(baseDir, "deploy-20260101T000000Z-100")
 	latestDir := filepath.Join(baseDir, "deploy-20260102T000000Z-200")
@@ -224,19 +249,32 @@ func TestResumeDeployBackupRestoreUsesLatestRunDir(t *testing.T) {
 			t.Fatalf("failed to create deploy backup dir %s: %v", dir, err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(latestDir, "resumes-dev.json"), []byte(`{
+	legacyPath := filepath.Join(latestDir, "resumes-dev.json")
+	if err := os.WriteFile(legacyPath, []byte(`{
   "metadata": {
     "generatedBy": "trends-api backup"
   },
   "resumes": [
     {
-      "resumeId": "r-latest",
-      "name": "Latest"
+      "resumeId": "r-legacy",
+      "name": "Legacy"
     }
   ]
 }`), 0o644); err != nil {
 		t.Fatalf("failed to write latest deploy backup file: %v", err)
 	}
+	compressedPath := filepath.Join(latestDir, "resumes-dev.tar.gz")
+	writeTestPortableBackupFile(t, compressedPath, map[string]any{
+		"metadata": map[string]any{
+			"generatedBy": "trends-api backup",
+		},
+		"resumes": []map[string]any{
+			{
+				"resumeId": "r-latest",
+				"name":     "Latest",
+			},
+		},
+	})
 
 	var callOrder []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -302,7 +340,114 @@ func TestResumeDeployBackupRestoreUsesLatestRunDir(t *testing.T) {
 	if payload["runDir"] != latestDir {
 		t.Fatalf("unexpected runDir in output: %+v", payload)
 	}
-	if payload["file"] != filepath.Join(latestDir, "resumes-dev.json") {
+	if payload["file"] != compressedPath {
+		t.Fatalf("unexpected file path in output: %+v", payload)
+	}
+	if payload["mode"] != "replace" {
+		t.Fatalf("unexpected mode in output: %+v", payload)
+	}
+}
+
+func TestResumeDeployBackupRestoreFallsBackToLegacyJSON(t *testing.T) {
+	baseDir := filepath.Join(t.TempDir(), "deploy")
+	olderDir := filepath.Join(baseDir, "deploy-20260101T000000Z-100")
+	latestDir := filepath.Join(baseDir, "deploy-20260102T000000Z-200")
+	for _, dir := range []string{olderDir, latestDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("failed to create deploy backup dir %s: %v", dir, err)
+		}
+	}
+	writeTestPortableBackupFile(t, filepath.Join(olderDir, "resumes-dev.tar.gz"), map[string]any{
+		"metadata": map[string]any{
+			"generatedBy": "trends-api backup",
+		},
+		"resumes": []map[string]any{
+			{
+				"resumeId": "r-older",
+				"name":     "Older",
+			},
+		},
+	})
+	legacyPath := filepath.Join(latestDir, "resumes-dev.json")
+	if err := os.WriteFile(legacyPath, []byte(`{
+  "metadata": {
+    "generatedBy": "trends-api backup"
+  },
+  "resumes": [
+    {
+      "resumeId": "r-legacy",
+      "name": "Legacy"
+    }
+  ]
+}`), 0o644); err != nil {
+		t.Fatalf("failed to write legacy deploy backup file: %v", err)
+	}
+
+	var callOrder []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callOrder = append(callOrder, r.URL.Path)
+
+		switch r.URL.Path {
+		case "/api/resumes/reset":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"count":   1,
+				"partial": false,
+				"deleted": map[string]int{"resumes": 1},
+			})
+		case "/api/resumes/import":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode import payload: %v", err)
+			}
+			resumes, ok := payload["resumes"].([]any)
+			if !ok || len(resumes) != 1 {
+				t.Fatalf("unexpected import payload: %+v", payload)
+			}
+			resume, ok := resumes[0].(map[string]any)
+			if !ok || resume["resumeId"] != "r-legacy" {
+				t.Fatalf("unexpected imported resume payload: %+v", payload)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success":   true,
+				"submitted": 1,
+				"inserted":  1,
+				"updated":   0,
+				"unchanged": 0,
+				"deduped":   0,
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+	setCLIOutput(t, "json")
+
+	cmd := newResumeDeployBackupRestoreCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{
+		"--base-dir", baseDir,
+		"--mode", "replace",
+		"--yes",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume deploy-backup restore command failed: %v", err)
+	}
+
+	if len(callOrder) != 2 || callOrder[0] != "/api/resumes/reset" || callOrder[1] != "/api/resumes/import" {
+		t.Fatalf("unexpected call order: %+v", callOrder)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["runDir"] != latestDir {
+		t.Fatalf("unexpected runDir in output: %+v", payload)
+	}
+	if payload["file"] != legacyPath {
 		t.Fatalf("unexpected file path in output: %+v", payload)
 	}
 	if payload["mode"] != "replace" {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1362,7 +1362,7 @@ prepare_deploy_backup_dir() {
 
     DEPLOY_BACKUP_METADATA_PATH="$DEPLOY_BACKUP_RUN_DIR/metadata.txt"
     DEPLOY_BACKUP_CONVEX_PATH="$DEPLOY_BACKUP_RUN_DIR/convex.zip"
-    DEPLOY_BACKUP_RESUME_PATH="$DEPLOY_BACKUP_RUN_DIR/resumes-${DEPLOY_BACKUP_RESUME_WORKSPACE}.json"
+    DEPLOY_BACKUP_RESUME_PATH="$DEPLOY_BACKUP_RUN_DIR/resumes-${DEPLOY_BACKUP_RESUME_WORKSPACE}.tar.gz"
     DEPLOY_BACKUP_RESUME_EXISTS="false"
     DEPLOY_BACKUP_CONFIG_ENV_PATH="$DEPLOY_BACKUP_RUN_DIR/config.env"
     DEPLOY_BACKUP_INSTALL_ENV_PATH="$DEPLOY_BACKUP_RUN_DIR/install.env"
@@ -1926,7 +1926,7 @@ print_usage() {
     echo "  DEPLOY_BACKUP_INCLUDE_FILE_STORAGE"
     echo "                         Include Convex file storage in the pre-deploy backup when truthy"
     echo "  DEPLOY_BACKUP_RESUME_WORKSPACE"
-    echo "                         Workspace slug for best-effort resumes-<workspace>.json export (default: dev)"
+    echo "                         Workspace slug for best-effort resumes-<workspace>.tar.gz export (default: dev)"
     echo "  CONVEX_MIRROR_MODE     Convex prefetch source order: off|fallback|mirror-first"
     echo "                         Default is fallback, or off when CI=true/1"
     echo "  CONVEX_MIRROR_BASES    Convex prefetch mirror base URLs (comma-separated)"


### PR DESCRIPTION
Summary:\n- Default deploy resume artifacts to .tar.gz\n- Teach the CLI to write/read portable tar.gz resume backups\n- Preserve legacy .json restore compatibility\n\nValidation:\n- make cli-test\n- make check\n- bash -n scripts/install.sh