### PR TITLE
fix: preserve phrase-aware resume keyword queries

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -55,8 +55,11 @@ import { IngestComputeService } from "../services/ingest-compute-service.js";
 import {
   buildWorkHistoryEntryText,
   buildWorkHistoryEvidence,
+  formatKeywordQuery,
   formatLocationHierarchySearchText,
+  normalizeKeywordPhrases,
   normalizeWorkHistoryEntry,
+  parseKeywordQuery,
 } from "@trends/shared";
 import { SkillsKnowledgeService } from "../services/skills-knowledge.js";
 import { SearchEventLogger } from "../services/search-event-logger.js";
@@ -238,13 +241,7 @@ function extractCompanies(workHistory: ResumeItem["workHistory"]): string[] | un
 
 function normalizeKeywords(keywords: string[] | undefined): string[] {
   if (!Array.isArray(keywords)) return [];
-  return Array.from(
-    new Set(
-      keywords
-        .map((item) => item.trim().toLowerCase())
-        .filter((item) => item.length > 0)
-    )
-  );
+  return normalizeKeywordPhrases(keywords).map((item) => item.toLowerCase());
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -761,9 +758,10 @@ async function prepareConvexCandidates(params: {
 
   const normalizedKeywords = normalizeKeywords(params.keywords);
   if (normalizedKeywords.length > 0) {
-    const keywordExpansion = resumeService.expandSearchQuery(normalizedKeywords.join(" "));
+    const canonicalKeywordQuery = formatKeywordQuery(normalizedKeywords);
+    const keywordExpansion = resumeService.expandSearchQuery(canonicalKeywordQuery);
     const value = await callConvexQuery("resumes:searchWithTagExpansion", {
-      query: normalizedKeywords.join(" "),
+      query: canonicalKeywordQuery,
       keywordGroups: keywordExpansion?.groups ?? [],
       mode: keywordExpansion?.mode ?? "AND",
       sourceMappings: Object.entries(keywordExpansion?.sourceMapping ?? {}).map(([term, expandedFrom]) => ({
@@ -1034,10 +1032,10 @@ function buildSearchEventQuery(params: {
   location?: string;
   jobDescriptionId?: string;
 }): string | null {
-  const keywords = params.keywords.map((keyword) => keyword.trim()).filter(Boolean);
-  if (keywords.length > 0) {
+  const keywordQuery = formatKeywordQuery(params.keywords).trim();
+  if (keywordQuery) {
     const location = params.location?.trim();
-    return location ? `${keywords.join(" ")} ${location}` : keywords.join(" ");
+    return location ? `${keywordQuery} ${location}` : keywordQuery;
   }
 
   const jobDescriptionId = params.jobDescriptionId?.trim();
@@ -1329,7 +1327,7 @@ app.openapi(getResumesRoute, (c) => {
     if (source === "convex") {
       return (async () => {
         const { prepared, keywordExpansion: liveExpansion } = await prepareConvexCandidates({
-          keywords: keyword ? normalizeKeywords(keyword.split(/\s+/)) : [],
+          keywords: keyword ? normalizeKeywords(parseKeywordQuery(keyword).keywords) : [],
           limit,
           jobDescriptionId: jobDescriptionId?.trim() || undefined,
         });
@@ -1639,7 +1637,7 @@ app.openapi(matchResumesRoute, async (c) => {
     jobDescriptionId: normalizedJobDescriptionId,
   });
   const keywordExpansion = normalizedKeywords.length > 0
-    ? resumeService.expandSearchQuery(normalizedKeywords.join(" "))
+    ? resumeService.expandSearchQuery(formatKeywordQuery(normalizedKeywords))
     : undefined;
 
   let session = persist && sessionId ? sessionManager.getSession(sessionId) : null;
@@ -2900,7 +2898,7 @@ app.openapi(rescoreResumeMatchesRoute, async (c) => {
         source,
         persisted: persist,
         keywordExpansion: normalizedKeywords.length > 0
-          ? resumeService.expandSearchQuery(normalizedKeywords.join(" "))
+          ? resumeService.expandSearchQuery(formatKeywordQuery(normalizedKeywords))
           : undefined,
         context,
       }),

--- a/apps/api/src/services/query-parser.test.ts
+++ b/apps/api/src/services/query-parser.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { parseSearchQuery } from "./query-parser";
 
 describe("parseSearchQuery", () => {
-  it("parses multi-keyword input as AND by default", () => {
+  it("parses legacy whitespace-delimited input as AND tokens by default", () => {
     expect(parseSearchQuery("哈斯 东莞")).toEqual({
       keywords: ["哈斯", "东莞"],
       mode: "AND",
@@ -20,7 +20,26 @@ describe("parseSearchQuery", () => {
     });
   });
 
-  it("parses explicit OR mode and removes operator tokens", () => {
+  it("parses quoted multi-word phrases with explicit OR semantics", () => {
+    expect(parseSearchQuery('"Sales Engineer" OR "Sales Manager"')).toEqual({
+      keywords: ["sales engineer", "sales manager"],
+      mode: "OR",
+    });
+
+    expect(parseSearchQuery('"哈斯 机床" OR "销售 工程师"')).toEqual({
+      keywords: ["哈斯 机床", "销售 工程师"],
+      mode: "OR",
+    });
+  });
+
+  it("treats comma-delimited phrases as OR input for editor-friendly queries", () => {
+    expect(parseSearchQuery("Sales Engineer, Sales Manager")).toEqual({
+      keywords: ["sales engineer", "sales manager"],
+      mode: "OR",
+    });
+  });
+
+  it("parses explicit OR mode and removes operator tokens for single-word terms", () => {
     expect(parseSearchQuery("哈斯 or 东莞")).toEqual({
       keywords: ["哈斯", "东莞"],
       mode: "OR",
@@ -33,11 +52,10 @@ describe("parseSearchQuery", () => {
   });
 
   it("deduplicates normalized keywords", () => {
-    expect(parseSearchQuery("CNC cnc CNC"))
-      .toEqual({
-        keywords: ["cnc"],
-        mode: "AND",
-      });
+    expect(parseSearchQuery("CNC cnc CNC")).toEqual({
+      keywords: ["cnc"],
+      mode: "AND",
+    });
   });
 
   it("returns empty keywords for blank input", () => {

--- a/apps/api/src/services/query-parser.ts
+++ b/apps/api/src/services/query-parser.ts
@@ -1,33 +1,14 @@
+import { parseKeywordQuery } from "@trends/shared";
+
 export interface ParsedQuery {
   keywords: string[];
   mode: "AND" | "OR";
 }
 
 export function parseSearchQuery(raw: string): ParsedQuery {
-  const tokens = raw
-    .split(/\s+/)
-    .map((token) => token.trim())
-    .filter((token) => token.length > 0);
-
-  let mode: ParsedQuery["mode"] = "AND";
-  const dedupe = new Set<string>();
-
-  for (const token of tokens) {
-    if (token === "or" || token === "OR") {
-      mode = "OR";
-      continue;
-    }
-
-    const normalized = token.toLowerCase();
-    if (normalized.length === 0) {
-      continue;
-    }
-
-    dedupe.add(normalized);
-  }
-
+  const parsed = parseKeywordQuery(raw);
   return {
-    keywords: Array.from(dedupe),
-    mode,
+    keywords: parsed.keywords.map((keyword) => keyword.toLowerCase()),
+    mode: parsed.mode,
   };
 }

--- a/apps/api/src/services/unified-search-service.test.ts
+++ b/apps/api/src/services/unified-search-service.test.ts
@@ -74,7 +74,7 @@ describe("UnifiedSearchService", () => {
     }
   });
 
-  it("preserves AND grouping for multi-keyword queries", () => {
+  it("preserves AND grouping for legacy multi-keyword token queries", () => {
     const root = createFixtureRoot();
 
     try {
@@ -94,6 +94,31 @@ describe("UnifiedSearchService", () => {
         },
       ]);
       expect(expansion.flatTerms).toEqual(["销售", "业务", "商务", "销售员", "sales", "cnc"]);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("preserves quoted phrase groups with OR semantics", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const skillsService = new SkillsKnowledgeService(root);
+      const service = new UnifiedSearchService(skillsService);
+      const expansion = service.expandKeyword('"Sales Engineer" OR "Sales Manager"');
+
+      expect(expansion.mode).toBe("OR");
+      expect(expansion.groups).toEqual([
+        {
+          original: "sales engineer",
+          variants: ["sales engineer"],
+        },
+        {
+          original: "sales manager",
+          variants: ["sales manager"],
+        },
+      ]);
+      expect(expansion.flatTerms).toEqual(["sales engineer", "sales manager"]);
     } finally {
       cleanupFixtureRoot(root);
     }
@@ -223,6 +248,54 @@ describe("UnifiedSearchService", () => {
       );
 
       expect(results.results.map((entry) => entry.resume.resumeId)).toEqual(["resume-both"]);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("matches either quoted phrase group in OR mode", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const skillsService = new SkillsKnowledgeService(root);
+      const service = new UnifiedSearchService(skillsService);
+      const engineerResume: ResumeItem = {
+        name: "Engineer only",
+        profileUrl: "https://example.com/1",
+        activityStatus: "active",
+        age: "35",
+        experience: "8年",
+        education: "本科",
+        location: "Kuala Lumpur MY",
+        selfIntro: "",
+        jobIntention: "Sales Engineer",
+        expectedSalary: "10000-15000",
+        workHistory: [],
+        extractedAt: "2026-03-11T00:00:00.000Z",
+        resumeId: "resume-engineer",
+      };
+      const managerResume: ResumeItem = {
+        ...engineerResume,
+        name: "Manager only",
+        jobIntention: "Sales Manager",
+        resumeId: "resume-manager",
+      };
+      const genericSalesResume: ResumeItem = {
+        ...engineerResume,
+        name: "Generic sales",
+        jobIntention: "Sales Executive",
+        resumeId: "resume-generic-sales",
+      };
+
+      const results = service.searchUnified(
+        [engineerResume, managerResume, genericSalesResume],
+        '"Sales Engineer" OR "Sales Manager"'
+      );
+
+      expect(results.results.map((entry) => entry.resume.resumeId)).toEqual([
+        "resume-engineer",
+        "resume-manager",
+      ]);
     } finally {
       cleanupFixtureRoot(root);
     }

--- a/apps/web/e2e/resume-role-filter.spec.ts
+++ b/apps/web/e2e/resume-role-filter.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test'
+import { parseKeywordQuery } from '@trends/shared'
 import type { Doc } from '../../../packages/convex/convex/_generated/dataModel'
 
 type MockResume = Doc<'resumes'>
@@ -20,6 +21,14 @@ function countNonEngineerCards(roleTypes: Array<string | null>): number {
 
 function parseConvexBody(route: Parameters<Page['route']>[1] extends (route: infer T) => unknown ? T : never) {
   return route.request().postDataJSON() as { path?: string; args?: Record<string, unknown> }
+}
+
+function isSeekMalaysiaRoleQuery(query: string): boolean {
+  const parsed = parseKeywordQuery(query)
+  return parsed.mode === 'OR'
+    && parsed.keywords.length === 2
+    && parsed.keywords[0] === 'Sales Engineer'
+    && parsed.keywords[1] === 'Sales Manager'
 }
 
 async function mockResumePageApis(
@@ -101,17 +110,31 @@ async function mockResumePageApis(
   })
 
   await page.route('**/api/resumes/keyword-expansion**', async (route) => {
+    const requestUrl = new URL(route.request().url())
+    const query = requestUrl.searchParams.get('q') ?? ''
+    const summary = isSeekMalaysiaRoleQuery(query)
+      ? {
+          groups: [
+            { original: 'sales engineer', variants: ['sales engineer'] },
+            { original: 'sales manager', variants: ['sales manager'] },
+          ],
+          mode: 'OR',
+          expandedTo: ['sales engineer', 'sales manager'],
+          sourceMapping: {},
+        }
+      : {
+          groups: [],
+          mode: 'AND',
+          expandedTo: [],
+          sourceMapping: {},
+        }
+
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
         success: true,
-        summary: {
-          groups: [],
-          mode: 'AND',
-          expandedTo: [],
-          sourceMapping: {},
-        },
+        summary,
       }),
     })
   })
@@ -369,6 +392,204 @@ const salesResume: MockResume = {
   },
 }
 
+const seekEngineerResume: MockResume = {
+  _id: 'resume_seek_engineer',
+  identityKey: 'resume_seek_engineer',
+  externalId: 'seek:resume:engineer-1',
+  source: 'my.employer.seek.com',
+  tags: ['sales engineer'],
+  crawledAt: 1710205323000,
+  primaryRuleScore: 82,
+  ingestData: {
+    industryTags: ['sales'],
+    synonymHits: [],
+    brandHits: [],
+    companyHits: [],
+    roleSignals: [
+      {
+        type: 'engineer',
+        matchedSignals: ['sales engineer'],
+        signalCount: 1,
+        occurrences: 1,
+        years: 3,
+        industryVerifiedYears: 3,
+        roleRelevantYears: 3,
+        industryVerifiedRelevantYears: 3,
+        matchedWorkEntries: [
+          {
+            companyName: 'KL Automation',
+            jobTitle: 'Sales Engineer',
+            years: 3,
+            industryVerified: true,
+            matchedSignals: ['sales engineer'],
+          },
+        ],
+        verifyIn: 'workHistory',
+      },
+    ],
+    ruleScores: { industry: 78, role: 82 },
+    experienceLevel: 'mid',
+    computedAt: 1710205323000,
+    skillsVersion: 2,
+  },
+  content: {
+    name: 'Engineer Candidate',
+    profileUrl: 'https://my.employer.seek.com/candidates/engineer-1',
+    activityStatus: 'active',
+    age: '31',
+    experience: '7 years',
+    education: 'Bachelor',
+    location: 'Kuala Lumpur MY',
+    selfIntro: 'Experienced in CNC solution selling and application engineering.',
+    jobIntention: 'Sales Engineer',
+    expectedSalary: 'RM 12,000',
+    workHistory: [
+      {
+        raw: '2021-01~至今 KL Automation Sales Engineer',
+        companyName: 'KL Automation',
+        jobTitle: 'Sales Engineer',
+        startDate: '2021-01',
+        endDate: '至今',
+      },
+    ],
+    extractedAt: '2026-03-12T01:02:03.000Z',
+    resumeId: 'engineer-1',
+    perUserId: 'seek-engineer-1',
+  },
+}
+
+const seekManagerResume: MockResume = {
+  _id: 'resume_seek_manager',
+  identityKey: 'resume_seek_manager',
+  externalId: 'seek:resume:manager-1',
+  source: 'my.employer.seek.com',
+  tags: ['sales manager'],
+  crawledAt: 1710205323000,
+  primaryRuleScore: 80,
+  ingestData: {
+    industryTags: ['sales'],
+    synonymHits: [],
+    brandHits: [],
+    companyHits: [],
+    roleSignals: [
+      {
+        type: 'manager',
+        matchedSignals: ['sales manager'],
+        signalCount: 1,
+        occurrences: 1,
+        years: 4,
+        industryVerifiedYears: 4,
+        roleRelevantYears: 4,
+        industryVerifiedRelevantYears: 4,
+        matchedWorkEntries: [
+          {
+            companyName: 'MY Industrial Systems',
+            jobTitle: 'Sales Manager',
+            years: 4,
+            industryVerified: true,
+            matchedSignals: ['sales manager'],
+          },
+        ],
+        verifyIn: 'workHistory',
+      },
+    ],
+    ruleScores: { industry: 76, role: 80 },
+    experienceLevel: 'senior',
+    computedAt: 1710205323000,
+    skillsVersion: 2,
+  },
+  content: {
+    name: 'Manager Candidate',
+    profileUrl: 'https://my.employer.seek.com/candidates/manager-1',
+    activityStatus: 'active',
+    age: '36',
+    experience: '10 years',
+    education: 'Bachelor',
+    location: 'Kuala Lumpur MY',
+    selfIntro: 'Led regional industrial equipment teams across Malaysia.',
+    jobIntention: 'Sales Manager',
+    expectedSalary: 'RM 15,000',
+    workHistory: [
+      {
+        raw: '2020-01~至今 MY Industrial Systems Sales Manager',
+        companyName: 'MY Industrial Systems',
+        jobTitle: 'Sales Manager',
+        startDate: '2020-01',
+        endDate: '至今',
+      },
+    ],
+    extractedAt: '2026-03-12T01:02:03.000Z',
+    resumeId: 'manager-1',
+    perUserId: 'seek-manager-1',
+  },
+}
+
+const seekGenericSalesResume: MockResume = {
+  _id: 'resume_seek_generic',
+  identityKey: 'resume_seek_generic',
+  externalId: 'seek:resume:generic-1',
+  source: 'my.employer.seek.com',
+  tags: ['sales executive'],
+  crawledAt: 1710205323000,
+  primaryRuleScore: 40,
+  ingestData: {
+    industryTags: ['sales'],
+    synonymHits: [],
+    brandHits: [],
+    companyHits: [],
+    roleSignals: [
+      {
+        type: 'sales',
+        matchedSignals: ['sales'],
+        signalCount: 1,
+        occurrences: 1,
+        years: 2,
+        industryVerifiedYears: 1,
+        roleRelevantYears: 2,
+        industryVerifiedRelevantYears: 1,
+        matchedWorkEntries: [
+          {
+            companyName: 'MY General Trading',
+            jobTitle: 'Sales Executive',
+            years: 2,
+            industryVerified: false,
+            matchedSignals: ['sales'],
+          },
+        ],
+        verifyIn: 'workHistory',
+      },
+    ],
+    ruleScores: { industry: 35, role: 40 },
+    experienceLevel: 'mid',
+    computedAt: 1710205323000,
+    skillsVersion: 2,
+  },
+  content: {
+    name: 'Generic Sales Candidate',
+    profileUrl: 'https://my.employer.seek.com/candidates/generic-1',
+    activityStatus: 'active',
+    age: '30',
+    experience: '6 years',
+    education: 'Diploma',
+    location: 'Kuala Lumpur MY',
+    selfIntro: 'General B2B sales background.',
+    jobIntention: 'Sales Executive',
+    expectedSalary: 'RM 8,000',
+    workHistory: [
+      {
+        raw: '2022-01~至今 MY General Trading Sales Executive',
+        companyName: 'MY General Trading',
+        jobTitle: 'Sales Executive',
+        startDate: '2022-01',
+        endDate: '至今',
+      },
+    ],
+    extractedAt: '2026-03-12T01:02:03.000Z',
+    resumeId: 'generic-1',
+    perUserId: 'seek-generic-1',
+  },
+}
+
 test.describe('Resume quick role filter', () => {
   test('home navigation clears search state while direct links and legacy redirects still hydrate', async ({ page }) => {
     await mockResumePageApis(page, {
@@ -449,9 +670,9 @@ test.describe('Resume quick role filter', () => {
     await expect(page.getByText('王女士')).toHaveCount(0)
   })
 
-  test('SEEK Malaysia workflow keeps Kuala Lumpur as one location token and opens the correct collect URL', async ({ page }) => {
+  test('SEEK Malaysia workflow preserves OR phrase intent end to end', async ({ page }) => {
     await mockResumePageApis(page, {
-      searchResumes: [],
+      searchResumes: [seekEngineerResume, seekManagerResume, seekGenericSalesResume],
     })
 
     await page.route('**/api/config/custom-keywords**', async (route) => {
@@ -515,19 +736,21 @@ test.describe('Resume quick role filter', () => {
       })
     })
 
-    await page.goto('/dev/resumes')
-
-    await expect(page.getByRole('button', { name: 'Sales Engineer', exact: true })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Sales Manager', exact: true })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Kuala Lumpur MY', exact: true })).toBeVisible()
-
-    await page.getByRole('button', { name: 'SEEK · Sales Engineer / Sales Manager · Kuala Lumpur MY' }).click()
+    await page.goto('/dev/resumes?location=Kuala+Lumpur+MY&keyword=%22Sales+Engineer%22+OR+%22Sales+Manager%22')
 
     await expect(page.getByRole('textbox', { name: '位置' })).toHaveValue('Kuala Lumpur MY')
-    await expect(page.getByPlaceholder('自定义关键词...')).toHaveValue('Sales Engineer Sales Manager')
+    await expect(page.getByPlaceholder('自定义关键词...')).toHaveValue('Sales Engineer, Sales Manager')
     await expect(page).toHaveURL(/location=Kuala(\+|%20)Lumpur(\+|%20)MY/)
     await expect(page).not.toHaveURL(/location=Kuala,Lumpur,MY/)
     await expect(page.getByText('SEEK Malaysia Sales Engineer / Sales Manager')).toBeVisible()
+    await expect(page.getByText('Engineer Candidate')).toBeVisible()
+    await expect(page.getByText('Manager Candidate')).toBeVisible()
+
+    const resumeCards = page.getByTestId('resume-card')
+    await expect(resumeCards).toHaveCount(2)
+    await expect(resumeCards.filter({ hasText: 'Engineer Candidate' })).toHaveCount(1)
+    await expect(resumeCards.filter({ hasText: 'Manager Candidate' })).toHaveCount(1)
+    await expect(resumeCards.filter({ hasText: 'Generic Sales Candidate' })).toHaveCount(0)
 
     await page.evaluate(() => {
       const openedUrls: string[] = []
@@ -549,6 +772,7 @@ test.describe('Resume quick role filter', () => {
     expect(collectUrl.searchParams.get('jobId')).toBe('90842915')
     expect(collectUrl.searchParams.get('pageNumber')).toBe('1')
     expect(collectUrl.searchParams.get('tr_auto_sync')).toBe('true')
+    expect(collectUrl.searchParams.get('keyword')).toBeNull()
   })
 
   test('SEEK auto-match prefers the profile jobUrl for collect on raw query pages', async ({ page }) => {

--- a/apps/web/src/components/CollectResumesButton.test.tsx
+++ b/apps/web/src/components/CollectResumesButton.test.tsx
@@ -75,7 +75,7 @@ describe('CollectResumesButton', () => {
 
     const job5156Url = new URL(openMock.mock.calls[1]?.[0] as string)
     expect(`${job5156Url.origin}${job5156Url.pathname}`).toBe('https://hr.job5156.com/search')
-    expect(job5156Url.searchParams.get('keyword')).toBe('Sales Engineer Sales Manager')
+    expect(job5156Url.searchParams.get('keyword')).toBe('"Sales Engineer" OR "Sales Manager"')
     expect(job5156Url.searchParams.get('location')).toBe('Kuala Lumpur MY')
     expect(job5156Url.searchParams.get('tr_auto_sync')).toBe('true')
 

--- a/apps/web/src/components/JobDescriptionEditor.tsx
+++ b/apps/web/src/components/JobDescriptionEditor.tsx
@@ -14,9 +14,11 @@ import { KeywordInput } from "@/components/KeywordInput"
 import {
     CANONICAL_INDUSTRY_TAGS,
     DEFAULT_MIN_EXPERIENCE,
+    formatKeywordInput,
     generateStructuredJobDescriptionContent,
     normalizeIndustryTags,
     normalizeOptionalString,
+    parseKeywordQuery,
     type StructuredJobDescriptionSeedFields,
 } from "@trends/shared"
 
@@ -87,12 +89,7 @@ export function JobDescriptionEditor({ open, onOpenChange, initialData, onSaveSu
     const [location, setLocation] = useState("")
     const [industryTags, setIndustryTags] = useState<string[]>([])
     const [customKeywordsText, setCustomKeywordsText] = useState("")
-    const customKeywords = useMemo(() => {
-        return customKeywordsText
-            .split(/[\s,，、]+/)
-            .map((keyword) => keyword.trim())
-            .filter((keyword) => keyword.length > 0)
-    }, [customKeywordsText])
+    const customKeywords = useMemo(() => parseKeywordQuery(customKeywordsText).keywords, [customKeywordsText])
 
     const [minExperience, setMinExperience] = useState(String(DEFAULT_MIN_EXPERIENCE))
     const [maxExperience, setMaxExperience] = useState("")
@@ -121,7 +118,7 @@ export function JobDescriptionEditor({ open, onOpenChange, initialData, onSaveSu
             setTitle(initialData.title + (initialData.type === "system" ? " (Custom Copy)" : ""))
             setLocation(initialData.location ?? "")
             setIndustryTags(sanitizeIndustryTags(initialData.industryTags))
-            setCustomKeywordsText((initialData.customKeywords ?? []).join(" "))
+            setCustomKeywordsText(formatKeywordInput(initialData.customKeywords ?? []))
             setMinExperience(typeof initialData.minExperience === "number" ? String(initialData.minExperience) : defaultMinExperience)
             setMaxExperience(typeof initialData.maxExperience === "number" ? String(initialData.maxExperience) : "")
             setMinAge(typeof initialData.minAge === "number" ? String(initialData.minAge) : "")

--- a/apps/web/src/components/KeywordInput.tsx
+++ b/apps/web/src/components/KeywordInput.tsx
@@ -1,3 +1,4 @@
+import { formatKeywordInput, normalizeKeywordPhrases, parseKeywordQuery } from "@trends/shared"
 import { useMemo, useState } from "react"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
@@ -16,27 +17,20 @@ export function KeywordInput({ value, onChange, placeholder, id }: KeywordInputP
     const availableCustomKeywords = grouped.custom || []
     const [expanded, setExpanded] = useState(false)
 
-    const activeKeywords = useMemo(() => {
-        return value
-            .split(/[\s,，、]+/)
-            .map((keyword) => keyword.trim())
-            .filter((keyword) => keyword.length > 0)
-    }, [value])
+    const activeKeywords = useMemo(() => parseKeywordQuery(value).keywords, [value])
 
     const toggleKeyword = (keyword: string) => {
-        if (activeKeywords.includes(keyword)) {
-            const newKeywords = activeKeywords.filter((k) => k !== keyword)
-            onChange(newKeywords.join(" "))
-        } else {
-            const suffix = value.trim().length > 0 ? " " : ""
-            let newValue = value.trim()
-            if (newValue.endsWith(',') || newValue.endsWith('，') || newValue.endsWith('、')) {
-                newValue = newValue + " " + keyword
-            } else {
-                newValue = newValue + suffix + keyword
-            }
-            onChange(newValue)
+        const normalizedKeyword = keyword.trim()
+        if (!normalizedKeyword) {
+            return
         }
+
+        if (activeKeywords.includes(normalizedKeyword)) {
+            onChange(formatKeywordInput(activeKeywords.filter((k) => k !== normalizedKeyword)))
+            return
+        }
+
+        onChange(formatKeywordInput(normalizeKeywordPhrases([...activeKeywords, normalizedKeyword])))
     }
 
     return (

--- a/apps/web/src/components/ManualResumeImportDialog.tsx
+++ b/apps/web/src/components/ManualResumeImportDialog.tsx
@@ -1,4 +1,4 @@
-import { normalizeOptionalString } from '@trends/shared'
+import { formatKeywordQuery, normalizeOptionalString } from '@trends/shared'
 import { useEffect, useMemo, useRef, useState, type DragEvent } from 'react'
 import { FileText, Loader2, Upload, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -76,11 +76,8 @@ function normalizeKeywords(keywords: string[] | undefined): string | undefined {
     return undefined
   }
 
-  const normalized = keywords
-    .map((keyword) => keyword.trim())
-    .filter((keyword) => keyword.length > 0)
-
-  return normalized.length > 0 ? normalized.join(' ') : undefined
+  const normalized = formatKeywordQuery(keywords).trim()
+  return normalized.length > 0 ? normalized : undefined
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -514,7 +514,7 @@ describe('QuickStartPanel quick-filter display', () => {
     await user.click(screen.getByRole('button', { name: 'Malaysia · SEEK · Sales Engineer / Sales Manager' }))
 
     expect(screen.getByRole('textbox', { name: '位置' })).toHaveValue('Kuala Lumpur MY')
-    expect(screen.getByDisplayValue('Sales Engineer Sales Manager')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Sales Engineer, Sales Manager')).toBeInTheDocument()
 
     await waitFor(() => {
       expect(onApplyConfig).toHaveBeenLastCalledWith({
@@ -523,9 +523,9 @@ describe('QuickStartPanel quick-filter display', () => {
         jobDescriptionId: undefined,
         collectionSource: {
           type: 'seek',
-          exactUrl: 'https://my.employer.seek.com/candidates/recommended?keyword=Sales+Engineer+Sales+Manager&location=Kuala+Lumpur+MY&tr_auto_sync=true',
+          exactUrl: 'https://my.employer.seek.com/candidates/recommended?keyword=%22Sales+Engineer%22+OR+%22Sales+Manager%22&location=Kuala+Lumpur+MY&tr_auto_sync=true',
         },
-        collectUrl: 'https://my.employer.seek.com/candidates/recommended?keyword=Sales+Engineer+Sales+Manager&location=Kuala+Lumpur+MY&tr_auto_sync=true',
+        collectUrl: 'https://my.employer.seek.com/candidates/recommended?keyword=%22Sales+Engineer%22+OR+%22Sales+Manager%22&location=Kuala+Lumpur+MY&tr_auto_sync=true',
       })
     })
   })

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -1,3 +1,4 @@
+import { formatKeywordInput, normalizeKeywordPhrases, parseKeywordQuery } from '@trends/shared'
 import { useCallback, useEffect, useMemo, useRef, useState, type ComponentProps } from 'react'
 import { Pencil, RotateCcw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -230,7 +231,7 @@ function parseLocationParts(value: string): string[] {
 }
 
 function normalizeProfileKeywords(profile: SearchProfileDetails): string[] {
-  return profile.keywords.map((keyword) => keyword.trim()).filter((keyword) => keyword.length > 0)
+  return normalizeKeywordPhrases(profile.keywords)
 }
 
 function getProfileQuickConstraints(profile: SearchProfileDetails): {
@@ -295,7 +296,7 @@ export function QuickStartPanel({
 
   const [location, setLocation] = useState(defaultLocation)
   const [selectedKeywords, setSelectedKeywords] = useState<string[]>(defaultKeywords)
-  const [customKeyword, setCustomKeyword] = useState(defaultKeywords.join(' '))
+  const [customKeyword, setCustomKeyword] = useState(formatKeywordInput(defaultKeywords))
   const [collectionSource, setCollectionSource] = useState<CollectionSource | undefined>(defaultCollectionSource)
   const [collectUrl, setCollectUrl] = useState(defaultCollectUrl)
   const [quickMinRoleYears, setQuickMinRoleYears] = useState(quickFilters?.minRoleYears?.toString() ?? '')
@@ -331,7 +332,7 @@ export function QuickStartPanel({
 
   useEffect(() => {
     setSelectedKeywords(defaultKeywords)
-    setCustomKeyword(defaultKeywords.join(' '))
+    setCustomKeyword(formatKeywordInput(defaultKeywords))
   }, [defaultKeywords])
 
   useEffect(() => {
@@ -411,7 +412,7 @@ export function QuickStartPanel({
 
       if (selectedConvexJobDescriptionDetail?.customKeywords && selectedConvexJobDescriptionDetail.customKeywords.length > 0) {
         setSelectedKeywords(selectedConvexJobDescriptionDetail.customKeywords.map(k => k.trim()))
-        setCustomKeyword(selectedConvexJobDescriptionDetail.customKeywords.join(' '))
+        setCustomKeyword(formatKeywordInput(selectedConvexJobDescriptionDetail.customKeywords))
       }
 
       return
@@ -443,7 +444,7 @@ export function QuickStartPanel({
 
           if (autoMatchKeywords && autoMatchKeywords.length > 0) {
             setSelectedKeywords(autoMatchKeywords.map(k => k.trim()))
-            setCustomKeyword(autoMatchKeywords.join(' '))
+            setCustomKeyword(formatKeywordInput(autoMatchKeywords))
           } else {
             setSelectedKeywords([])
             setCustomKeyword('')
@@ -498,7 +499,7 @@ export function QuickStartPanel({
   }, [])
 
   const normalizedKeywords = useMemo(
-    () => selectedKeywords.map((keyword) => keyword.trim()).filter((keyword) => keyword.length > 0),
+    () => normalizeKeywordPhrases(selectedKeywords),
     [selectedKeywords]
   )
   const currentCollectionSource = useMemo<CollectionSource>(
@@ -668,7 +669,7 @@ export function QuickStartPanel({
 
   const handleKeywordsChange = useCallback((keywords: string[]) => {
     setSelectedKeywords(keywords)
-    setCustomKeyword(keywords.join(' '))
+    setCustomKeyword(formatKeywordInput(keywords))
     setCollectionSource((current) => stripCollectionSourceExactUrl(current))
     setCollectUrl(undefined)
   }, [])
@@ -702,17 +703,18 @@ export function QuickStartPanel({
   }, [onJobChange])
 
   const handleApplyWorkflow = useCallback((workflow: QuickStartWorkflow) => {
+    const workflowKeywords = normalizeKeywordPhrases(workflow.keywords)
     const nextCollectUrl = workflow.collectUrl
       ?? buildCollectionLaunchUrl({
         source: workflow.collectionSource,
         location: workflow.location,
-        keywords: workflow.keywords,
+        keywords: workflowKeywords,
       })
       ?? undefined
 
     setLocation(workflow.location)
-    setSelectedKeywords(workflow.keywords)
-    setCustomKeyword(workflow.keywords.join(' '))
+    setSelectedKeywords(workflowKeywords)
+    setCustomKeyword(formatKeywordInput(workflowKeywords))
     setCollectionSource(workflow.collectionSource)
     setCollectUrl(nextCollectUrl)
     onJobChange?.('')
@@ -728,7 +730,7 @@ export function QuickStartPanel({
 
     setLocation(profileLocation)
     setSelectedKeywords(profileKeywords)
-    setCustomKeyword(profileKeywords.join(' '))
+    setCustomKeyword(formatKeywordInput(profileKeywords))
     setCollectionSource(nextCollectionSource)
     setCollectUrl(nextCollectUrl)
     setQuickMinRoleYears(
@@ -791,13 +793,14 @@ export function QuickStartPanel({
       }
 
       if (savedFields.customKeywords && savedFields.customKeywords.length > 0) {
-        setSelectedKeywords(savedFields.customKeywords.map(k => k.trim()))
-        setCustomKeyword(savedFields.customKeywords.join(' '))
+        const normalizedSavedKeywords = normalizeKeywordPhrases(savedFields.customKeywords)
+        setSelectedKeywords(normalizedSavedKeywords)
+        setCustomKeyword(formatKeywordInput(normalizedSavedKeywords))
       } else if (savedFields.title) {
-        const titleWords = savedFields.title.split(/[\s-]+/).filter(Boolean)
+        const titleWords = normalizeKeywordPhrases(savedFields.title.split(/[\s-]+/))
         if (titleWords.length > 0) {
           setSelectedKeywords(titleWords)
-          setCustomKeyword(titleWords.join(' '))
+          setCustomKeyword(formatKeywordInput(titleWords))
         }
       }
     }
@@ -895,11 +898,10 @@ export function QuickStartPanel({
                   onChange={(event) => {
                     const value = event.target.value
                     setCustomKeyword(value)
-                    const parts = value.split(/[\s,]+/).filter(Boolean)
                     setCollectUrl(undefined)
-                    setSelectedKeywords(parts)
+                    setSelectedKeywords(parseKeywordQuery(value).keywords)
                   }}
-                  placeholder={t('quickStart.customKeywordPlaceholder', '关键词 (空格分隔)...')}
+                  placeholder={t('quickStart.customKeywordPlaceholder', '关键词（支持引号 OR，或用逗号分隔短语）...')}
                   className="h-9 w-full sm:w-64 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                 />
               </div>

--- a/apps/web/src/components/SearchProfileEditorDialog.test.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.test.tsx
@@ -276,7 +276,7 @@ describe('SearchProfileEditorDialog JD hydration', () => {
     )
 
     await user.type(screen.getByLabelText('Name'), 'Seek profile')
-    await user.type(screen.getByLabelText('关键词:'), '销售 工程师')
+    await user.type(screen.getByLabelText('关键词:'), '"Sales Engineer" OR "Sales Manager"')
     await user.click(screen.getByLabelText('Seek'))
     await user.clear(screen.getByLabelText('Seek job URL'))
     await user.type(
@@ -288,6 +288,7 @@ describe('SearchProfileEditorDialog JD hydration', () => {
     await waitFor(() => {
       expect(postMock).toHaveBeenCalledWith('/api/search-profiles', {
         body: expect.objectContaining({
+          keywords: ['Sales Engineer', 'Sales Manager'],
           sources: expect.arrayContaining([
             expect.objectContaining({
               type: 'job5156',

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -1,3 +1,4 @@
+import { formatKeywordInput, inferKeywordQueryMode, normalizeKeywordPhrases, parseKeywordQuery } from '@trends/shared'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from 'convex/react'
 import { useTranslation } from 'react-i18next'
@@ -138,7 +139,7 @@ function normalizeStringArray(values: string[] | undefined): string[] {
 function toKeywordsText(keywords: string[] | undefined, fallbackText?: string): string {
     const normalized = normalizeStringArray(keywords)
     if (normalized.length > 0) {
-        return normalized.join(' ')
+        return formatKeywordInput(normalized)
     }
 
     const fallback = fallbackText?.trim()
@@ -167,10 +168,11 @@ function parseOptionalNumber(value: string): number | undefined {
 }
 
 function parseKeywords(value: string): string[] {
-    return value
-        .split(/[\s,，、]+/)
-        .map((keyword) => keyword.trim())
-        .filter((keyword) => keyword.length > 0)
+    const parsed = parseKeywordQuery(value)
+    const keywords = normalizeKeywordPhrases(parsed.keywords)
+    return inferKeywordQueryMode(keywords) === 'OR'
+        ? keywords
+        : normalizeStringArray(keywords)
 }
 
 function normalizeSourcePriority(value: number | undefined): string {
@@ -237,7 +239,7 @@ function toFormState(profile: SearchProfileDetails): ProfileFormState {
     return {
         name: profile.name,
         location: profile.location,
-        keywordsText: profile.keywords.join(' '),
+        keywordsText: formatKeywordInput(profile.keywords),
         jobDescription: profile.jobDescription || '',
         minExperience: typeof profile.filters?.minExperience === 'number' ? String(profile.filters.minExperience) : '1',
         maxExperience: typeof profile.filters?.maxExperience === 'number' ? String(profile.filters.maxExperience) : '',

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { normalizeProfileUrlForDisplay, normalizeSharedResumeFields } from '@trends/shared'
+import { normalizeProfileUrlForDisplay, normalizeSharedResumeFields, parseKeywordQuery } from '@trends/shared'
 import { useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
@@ -130,15 +130,24 @@ type MockConvexResumePayload = {
   }
 }
 
+type MockSearchResult = NonNullable<NonNullable<MockConvexResumePayload['search']>['results']>[number]
+
+type SearchProvenance = NonNullable<MockSearchResult['provenance']>[number]
+
+type IndexedMockSearchResult = MockSearchResult & {
+  matchedGroupCount: number
+  provenance: SearchProvenance[]
+}
+
 function buildFallbackKeywordExpansion(query: string): KeywordExpansionSummary {
-  const terms = query
-    .split(/\s+/)
+  const parsed = parseKeywordQuery(query)
+  const terms = parsed.keywords
     .map((term) => term.trim().toLowerCase())
     .filter((term) => term.length > 0)
 
   return {
     groups: terms.map((term) => ({ original: term, variants: [term] })),
-    mode: 'AND',
+    mode: parsed.mode,
     expandedTo: terms,
     sourceMapping: {},
   }
@@ -146,6 +155,111 @@ function buildFallbackKeywordExpansion(query: string): KeywordExpansionSummary {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
+}
+
+function buildMockSearchText(doc: Doc<'resumes'>): string {
+  const content = isRecord(doc.content) ? doc.content : {}
+  const fragments = [
+    toStringValue(content.name),
+    toStringValue(content.jobIntention),
+    toStringValue(content.location),
+    toStringValue(content.selfIntro),
+    toStringValue(content.expectedSalary),
+    ...toStringArray(doc.tags),
+    ...toStringArray(doc.ingestData?.industryTags),
+    ...toStringArray(doc.ingestData?.synonymHits),
+    ...toStringArray(doc.ingestData?.companyHits),
+    ...toStringArray(doc.ingestData?.brandHits?.map((hit) => hit.brand)),
+    ...toStringArray(doc.ingestData?.roleSignals?.flatMap((signal) => signal.matchedSignals ?? [])),
+    ...toStringArray(doc.ingestData?.roleSignals?.flatMap((signal) => signal.matchedWorkEntries?.flatMap((entry) => [entry.companyName, entry.jobTitle] as const) ?? [])),
+    ...toStringArray(Array.isArray(content.workHistory)
+      ? content.workHistory.flatMap((entry) => {
+          if (!isRecord(entry)) {
+            return []
+          }
+          return [entry.raw, entry.companyName, entry.jobTitle, entry.description]
+        })
+      : []),
+  ]
+
+  return fragments
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0)
+    .join(' ')
+}
+
+function matchesKeywordExpansion(searchText: string, expansion: KeywordExpansionSummary): SearchProvenance[] {
+  const seen = new Set<string>()
+  const matches: SearchProvenance[] = []
+
+  for (const group of expansion.groups) {
+    for (const variant of group.variants) {
+      const normalizedVariant = variant.trim().toLowerCase()
+      if (!normalizedVariant || !searchText.includes(normalizedVariant) || seen.has(normalizedVariant)) {
+        continue
+      }
+
+      seen.add(normalizedVariant)
+      matches.push({
+        term: normalizedVariant,
+        source: 'searchText',
+        expandedFrom: expansion.sourceMapping[normalizedVariant],
+      })
+    }
+  }
+
+  return matches
+}
+
+function indexMockSearchResults(
+  results: MockSearchResult[],
+  expansion: KeywordExpansionSummary,
+): IndexedMockSearchResult[] {
+  return results.map((entry) => {
+    const searchText = buildMockSearchText(entry.resume)
+    const matchedGroupCount = expansion.groups.filter((group) =>
+      group.variants.some((variant) => searchText.includes(variant.trim().toLowerCase()))
+    ).length
+
+    return {
+      ...entry,
+      matchedGroupCount,
+      provenance: matchesKeywordExpansion(searchText, expansion),
+    }
+  })
+}
+
+function stripMatchedGroupCount(entry: IndexedMockSearchResult): MockSearchResult {
+  return {
+    resume: entry.resume,
+    provenance: entry.provenance,
+  }
+}
+
+function applyMockExpansionProvenance(
+  results: MockSearchResult[],
+  expansion: KeywordExpansionSummary,
+): MockSearchResult[] {
+  return indexMockSearchResults(results, expansion).map(stripMatchedGroupCount)
+}
+
+function filterMockSearchResults(
+  results: MockSearchResult[],
+  expansion: KeywordExpansionSummary,
+): MockSearchResult[] {
+  if (expansion.groups.length === 0) {
+    return []
+  }
+
+  return indexMockSearchResults(results, expansion)
+    .filter((entry) => {
+      const matched = expansion.mode === 'AND'
+        ? entry.matchedGroupCount === expansion.groups.length
+        : entry.matchedGroupCount > 0
+
+      return matched && entry.provenance.length > 0
+    })
+    .map(stripMatchedGroupCount)
 }
 
 function toStringValue(value: unknown): string {
@@ -544,6 +658,10 @@ export function useConvexResumes(limit: number = 200, query?: string, jobDescrip
   const normalizedJobDescriptionId = jobDescriptionId?.trim() || undefined
   const normalizedQuery = query?.trim() || undefined
   const mockPayload = useMemo(() => readMockConvexResumePayload(), [])
+  const mockKeywordExpansion = useMemo(
+    () => normalizedQuery ? buildFallbackKeywordExpansion(normalizedQuery) : null,
+    [normalizedQuery]
+  )
   const [keywordExpansion, setKeywordExpansion] = useState<KeywordExpansionSummary | null>(null)
   const [expansionLoading, setExpansionLoading] = useState(false)
 
@@ -551,7 +669,7 @@ export function useConvexResumes(limit: number = 200, query?: string, jobDescrip
     let active = true
 
     if (mockPayload) {
-      setKeywordExpansion(normalizedQuery ? buildFallbackKeywordExpansion(normalizedQuery) : null)
+      setKeywordExpansion(mockKeywordExpansion)
       setExpansionLoading(false)
       return () => {
         active = false
@@ -619,7 +737,7 @@ export function useConvexResumes(limit: number = 200, query?: string, jobDescrip
     return () => {
       active = false
     }
-  }, [mockPayload, normalizedQuery])
+  }, [mockKeywordExpansion, mockPayload, normalizedQuery])
 
   const searchResults = useQuery(
     api.resumes.searchWithTagExpansion,
@@ -650,10 +768,13 @@ export function useConvexResumes(limit: number = 200, query?: string, jobDescrip
   const mappedResumes = useMemo(() => (
     mockPayload
       ? normalizedQuery
-        ? (mockPayload.search?.results ?? []).map((entry) => ({
+        ? ((mockKeywordExpansion?.mode === 'OR'
+            ? filterMockSearchResults(mockPayload.search?.results ?? [], mockKeywordExpansion)
+            : applyMockExpansionProvenance(mockPayload.search?.results ?? [], mockKeywordExpansion ?? buildFallbackKeywordExpansion(normalizedQuery)))
+          .map((entry) => ({
             ...mapResumeDoc(entry.resume),
             _provenance: entry.provenance,
-          }))
+          })))
         : (mockPayload.list ?? []).map(mapResumeDoc)
       : normalizedQuery
         ? (searchResults?.results ?? []).map((entry) => ({
@@ -661,12 +782,12 @@ export function useConvexResumes(limit: number = 200, query?: string, jobDescrip
             _provenance: entry.provenance,
           }))
         : (listResults ?? []).map(mapResumeDoc)
-  ), [listResults, mockPayload, normalizedQuery, searchResults])
+  ), [listResults, mockKeywordExpansion, mockPayload, normalizedQuery, searchResults])
 
   return {
     resumes: mappedResumes,
     loading: mockPayload ? false : normalizedQuery ? (expansionLoading || searchResults === undefined) : listResults === undefined,
     jobDescriptionId: normalizedJobDescriptionId,
-    expansion: mockPayload ? mockPayload.search?.expansion : searchResults?.expansion,
+    expansion: mockPayload ? (mockPayload.search?.expansion ?? mockKeywordExpansion) : searchResults?.expansion,
   }
 }

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1110,7 +1110,7 @@ describe('useResumeListState role filter regression', () => {
         location: 'Kuala Lumpur MY',
         keywords: ['Sales Engineer', 'Sales Manager'],
         collectionSource: { type: 'seek' },
-        collectUrl: 'https://my.employer.seek.com/candidates/recommended?keyword=Sales+Engineer+Sales+Manager&location=Kuala+Lumpur+MY',
+        collectUrl: 'https://my.employer.seek.com/candidates/recommended?keyword=%22Sales+Engineer%22+OR+%22Sales+Manager%22&location=Kuala+Lumpur+MY',
       }, true)
     })
 
@@ -1126,7 +1126,7 @@ describe('useResumeListState role filter regression', () => {
   })
 
   it('clears query state when navigation requests a resume home reset', async () => {
-    mockState.locationSearch = '?location=Kuala+Lumpur+MY&keyword=Sales+Engineer+Manager'
+    mockState.locationSearch = '?location=Kuala+Lumpur+MY&keyword=%22Sales+Engineer%22+OR+%22Sales+Manager%22'
     mockState.locationState = RESUME_HOME_RESET_STATE
 
     renderHook(() => useResumeListState())

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMutation, useQuery } from 'convex/react'
-import { formatLocationHierarchySearchText, isLocationMatch } from '@trends/shared'
+import { formatKeywordQuery, formatLocationHierarchySearchText, isLocationMatch } from '@trends/shared'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { api } from '../../../../packages/convex/convex/_generated/api'
@@ -159,11 +159,9 @@ function normalizeUrlFilters(filters: Partial<ResumeFilters>): Partial<ResumeFil
 
 function buildSearchHistoryTitle(location: string, keywords: string[]): string {
   const normalizedLocation = location.trim()
-  const normalizedKeywords = keywords
-    .map((keyword) => keyword.trim())
-    .filter((keyword) => keyword.length > 0)
+  const normalizedKeywords = formatKeywordQuery(keywords).trim()
 
-  const parts = [normalizedLocation, normalizedKeywords.join(' ')].filter((value) => value.length > 0)
+  const parts = [normalizedLocation, normalizedKeywords].filter((value) => value.length > 0)
   return parts.join(' · ') || 'Untitled search'
 }
 
@@ -520,7 +518,7 @@ export function useResumeListState(loadSearchHistory = false) {
   const { statusByIdentity, updateStatus: updateCandidateStatus } = useCandidateStatus()
 
   const expandedQuery = useMemo(() => {
-    const kw = sessionKeywords.join(' ').trim()
+    const kw = formatKeywordQuery(sessionKeywords).trim()
     if (!kw) return undefined
     return kw
   }, [sessionKeywords])
@@ -538,7 +536,7 @@ export function useResumeListState(loadSearchHistory = false) {
   const currentPromptVersion = getCurrentResumeAiPromptVersion()
   const keywordOnlyQueryScoring = sessionKeywords.length > 0 && !jobDescriptionId?.trim()
   const salesRequiredContext = useMemo(
-    () => isSalesRequiredContext(sessionKeywords.join(' '), jobDescriptionId),
+    () => isSalesRequiredContext(formatKeywordQuery(sessionKeywords), jobDescriptionId),
     [jobDescriptionId, sessionKeywords]
   )
   const querySpecificKeywordsKey = useMemo(
@@ -798,7 +796,7 @@ export function useResumeListState(loadSearchHistory = false) {
           ? normalizedLocation
           : undefined
       const locationFilters = locationForUrl
-        ? locationForUrl.split(/[\s,，、]+/).filter(Boolean)
+        ? locationForUrl.split(/[,，、]+/).map((item) => item.trim()).filter(Boolean)
         : undefined
       const filtersForUrl: Partial<ResumeFilters> = {
         ...filters,
@@ -1277,12 +1275,9 @@ export function useResumeListState(loadSearchHistory = false) {
   )
 
   const feedbackQuery = useMemo(() => {
-    const parts = [...sessionKeywords]
+    const keywordQuery = formatKeywordQuery(sessionKeywords).trim()
     const normalizedLocation = sessionLocation.trim()
-    if (normalizedLocation) {
-      parts.push(normalizedLocation)
-    }
-    const query = parts.join(' ').trim()
+    const query = [keywordQuery, normalizedLocation].filter((value) => value.length > 0).join(' ').trim()
     return query.length > 0 ? query : undefined
   }, [sessionKeywords, sessionLocation])
 

--- a/apps/web/src/hooks/useUrlSearchState.test.ts
+++ b/apps/web/src/hooks/useUrlSearchState.test.ts
@@ -1,12 +1,72 @@
-import { describe, expect, it } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { parseUrlSearchState } from './useUrlSearchState'
+import { parseUrlSearchState, useUrlSearchState, type UrlSearchState } from './useUrlSearchState'
+
+const { useSearchParamsMock, setSearchParamsMock } = vi.hoisted(() => ({
+  useSearchParamsMock: vi.fn(),
+  setSearchParamsMock: vi.fn(),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => useSearchParamsMock(),
+}))
 
 describe('useUrlSearchState location parsing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('preserves spaced locations as a single location token', () => {
     const state = parseUrlSearchState(new URLSearchParams('location=Kuala+Lumpur+MY'))
 
     expect(state.location).toBe('Kuala Lumpur MY')
     expect(state.filters.locations).toEqual(['Kuala Lumpur MY'])
+  })
+
+  it('parses canonical quoted OR phrase queries without flattening phrases', () => {
+    const state = parseUrlSearchState(
+      new URLSearchParams('location=Kuala+Lumpur+MY&keyword=%22Sales+Engineer%22+OR+%22Sales+Manager%22')
+    )
+
+    expect(state.location).toBe('Kuala Lumpur MY')
+    expect(state.filters.locations).toEqual(['Kuala Lumpur MY'])
+    expect(state.keywords).toEqual(['Sales Engineer', 'Sales Manager'])
+  })
+
+  it('keeps legacy whitespace keyword queries backward compatible', () => {
+    const state = parseUrlSearchState(new URLSearchParams('keyword=CNC+%E9%94%80%E5%94%AE'))
+
+    expect(state.keywords).toEqual(['CNC', '销售'])
+  })
+
+  it('serializes canonical OR phrase queries when syncing to the URL', () => {
+    const currentParams = new URLSearchParams()
+    useSearchParamsMock.mockReturnValue([currentParams, setSearchParamsMock])
+
+    const { result } = renderHook(() => useUrlSearchState())
+
+    const nextState: UrlSearchState = {
+      location: 'Kuala Lumpur MY',
+      keywords: ['Sales Engineer', 'Sales Manager'],
+      jobDescriptionId: undefined,
+      selectedTags: [],
+      selectedCompanies: [],
+      selectedExperienceLevel: undefined,
+      filters: {
+        locations: ['Kuala Lumpur MY'],
+      },
+    }
+
+    result.current.syncToUrl(nextState)
+
+    expect(setSearchParamsMock).toHaveBeenCalledTimes(1)
+    const [updater, options] = setSearchParamsMock.mock.calls[0] ?? []
+    expect(options).toEqual({ replace: true })
+    expect(typeof updater).toBe('function')
+
+    const updatedParams = updater(new URLSearchParams()) as URLSearchParams
+    expect(updatedParams.get('location')).toBe('Kuala Lumpur MY')
+    expect(updatedParams.get('keyword')).toBe('"Sales Engineer" OR "Sales Manager"')
   })
 })

--- a/apps/web/src/hooks/useUrlSearchState.ts
+++ b/apps/web/src/hooks/useUrlSearchState.ts
@@ -1,3 +1,4 @@
+import { formatKeywordQuery, parseKeywordQuery } from '@trends/shared'
 import { useCallback, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import type { CandidateStatus, ResumeFilters } from '@/types/resume'
@@ -53,10 +54,7 @@ function parseKeywordParam(value: string | null): string[] {
     return []
   }
 
-  return value
-    .split(/[\s,，、]+/g)
-    .map((item) => item.trim())
-    .filter((item) => item.length > 0)
+  return parseKeywordQuery(value).keywords
 }
 
 function parseLocationParam(value: string | undefined): string[] {
@@ -309,7 +307,7 @@ export function useUrlSearchState() {
           ? locationForUrlParts.join(',')
           : normalizedLocation
         setParam(nextParams, 'location', locationForUrl)
-        setParam(nextParams, 'keyword', hasKeywords ? normalizedKeywords.join(' ') : undefined)
+        setParam(nextParams, 'keyword', hasKeywords ? formatKeywordQuery(normalizedKeywords) : undefined)
         setParam(nextParams, 'jd', state.jobDescriptionId?.trim())
         setParam(nextParams, 'tags', normalizedTags.length > 0 ? normalizedTags.join(',') : undefined)
         setParam(nextParams, 'co', normalizedCompanies.length > 0 ? normalizedCompanies.join(',') : undefined)

--- a/apps/web/src/lib/search-profile-sources.test.ts
+++ b/apps/web/src/lib/search-profile-sources.test.ts
@@ -85,7 +85,7 @@ describe('search-profile-sources', () => {
 
     const url = new URL(collectUrl as string)
     expect(url.searchParams.get('location')).toBe('Kuala Lumpur MY')
-    expect(url.searchParams.get('keyword')).toBe('Sales Engineer Sales Manager')
+    expect(url.searchParams.get('keyword')).toBe('"Sales Engineer" OR "Sales Manager"')
     expect(url.searchParams.get('tr_auto_sync')).toBe('true')
   })
 

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -1,3 +1,5 @@
+import { formatKeywordQuery, normalizeKeywordPhrases } from '@trends/shared'
+
 const JOB5156_SEARCH_URL = 'https://hr.job5156.com/search'
 const SEEK_TALENT_SEARCH_URL = 'https://my.employer.seek.com/candidates/recommended'
 const SEEK_HOST_SUFFIX = '.employer.seek.com'
@@ -59,9 +61,7 @@ function normalizeOptionalString(value: string | undefined): string | undefined 
 }
 
 function normalizeKeywords(keywords: string[]): string[] {
-  return keywords
-    .map((keyword) => keyword.trim())
-    .filter((keyword) => keyword.length > 0)
+  return normalizeKeywordPhrases(keywords)
 }
 
 function normalizeOptionalPositiveInt(value: number | undefined): number | undefined {
@@ -277,7 +277,7 @@ export function buildSeekCollectUrl({
     : new URL(SEEK_TALENT_SEARCH_URL)
 
   if (!normalizedBaseUrl) {
-    url.searchParams.set('keyword', normalizedKeywords.join(' '))
+    url.searchParams.set('keyword', formatKeywordQuery(normalizedKeywords))
     if (normalizedLocation.length > 0) {
       url.searchParams.set('location', normalizedLocation)
     } else {
@@ -335,7 +335,7 @@ export function buildJob5156CollectUrl({
   const url = new URL(JOB5156_SEARCH_URL)
   const normalizedLocation = location.trim()
 
-  url.searchParams.set('keyword', normalizedKeywords.join(' '))
+  url.searchParams.set('keyword', formatKeywordQuery(normalizedKeywords))
   if (normalizedLocation.length > 0 && !isChinaRootLocationLabel(normalizedLocation)) {
     url.searchParams.set('location', normalizedLocation)
   }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,3 +8,4 @@ export * from "./generated/resume-ai-prompts.js";
 export * from "./resume-normalization.js";
 export * from "./resume-id.js";
 export * from "./system-debug-metadata.js";
+export * from "./keyword-query.js";

--- a/packages/shared/src/keyword-query.ts
+++ b/packages/shared/src/keyword-query.ts
@@ -1,0 +1,168 @@
+export type KeywordQueryMode = "AND" | "OR";
+
+export type ParsedKeywordQuery = {
+  keywords: string[];
+  mode: KeywordQueryMode;
+};
+
+type KeywordToken = {
+  value: string;
+  quoted: boolean;
+};
+
+function normalizeKeywordWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+export function normalizeKeywordPhrases(keywords: string[]): string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+
+  for (const keyword of keywords) {
+    const trimmed = normalizeKeywordWhitespace(keyword);
+    if (!trimmed) {
+      continue;
+    }
+
+    const fingerprint = trimmed.toLowerCase();
+    if (seen.has(fingerprint)) {
+      continue;
+    }
+
+    seen.add(fingerprint);
+    normalized.push(trimmed);
+  }
+
+  return normalized;
+}
+
+function tokenizeKeywordQuery(raw: string): KeywordToken[] {
+  const tokens: KeywordToken[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  const pushCurrent = (quoted: boolean) => {
+    const value = normalizeKeywordWhitespace(current);
+    current = "";
+    if (!value) {
+      return;
+    }
+    tokens.push({ value, quoted });
+  };
+
+  for (const char of raw) {
+    if (char === '"') {
+      if (inQuotes) {
+        pushCurrent(true);
+        inQuotes = false;
+      } else {
+        pushCurrent(false);
+        inQuotes = true;
+      }
+      continue;
+    }
+
+    if (!inQuotes && (/\s/.test(char) || /[\n\r,，、]/.test(char))) {
+      pushCurrent(false);
+      continue;
+    }
+
+    current += char;
+  }
+
+  pushCurrent(inQuotes);
+  return tokens;
+}
+
+export function inferKeywordQueryMode(keywords: string[]): KeywordQueryMode {
+  const normalized = normalizeKeywordPhrases(keywords);
+  if (normalized.length > 1 && normalized.some((keyword) => /\s/.test(keyword))) {
+    return "OR";
+  }
+  return "AND";
+}
+
+export function parseKeywordQuery(raw: string): ParsedKeywordQuery {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { keywords: [], mode: "AND" };
+  }
+
+  const hasPhraseDelimiter = /[\n\r,，、]/.test(trimmed);
+  const hasQuotedPhrase = trimmed.includes('"');
+  const hasExplicitOr = /\bOR\b/i.test(trimmed);
+
+  if (!hasQuotedPhrase && !hasExplicitOr && hasPhraseDelimiter) {
+    const keywords = normalizeKeywordPhrases(trimmed.split(/[\n\r,，、]+/g));
+    return {
+      keywords,
+      mode: inferKeywordQueryMode(keywords),
+    };
+  }
+
+  const tokens = tokenizeKeywordQuery(trimmed);
+  let mode: KeywordQueryMode = "AND";
+  const keywords: string[] = [];
+
+  for (const token of tokens) {
+    if (!token.quoted && /^OR$/i.test(token.value)) {
+      mode = "OR";
+      continue;
+    }
+
+    if (!token.quoted && !hasQuotedPhrase) {
+      keywords.push(...token.value.split(/\s+/g));
+      continue;
+    }
+
+    keywords.push(token.value);
+  }
+
+  const normalizedKeywords = normalizeKeywordPhrases(keywords);
+
+  return {
+    keywords: normalizedKeywords,
+    mode: !hasExplicitOr && hasPhraseDelimiter
+      ? inferKeywordQueryMode(normalizedKeywords)
+      : mode,
+  };
+}
+
+function quoteKeywordPhrase(keyword: string): string {
+  return `"${keyword.replace(/"/g, '\\"')}"`;
+}
+
+export function formatKeywordQuery(
+  keywords: string[],
+  mode: KeywordQueryMode = inferKeywordQueryMode(keywords),
+): string {
+  const normalized = normalizeKeywordPhrases(keywords);
+  if (normalized.length === 0) {
+    return "";
+  }
+
+  if (mode === "OR") {
+    return normalized.map(quoteKeywordPhrase).join(" OR ");
+  }
+
+  if (normalized.some((keyword) => /\s/.test(keyword))) {
+    return normalized.map(quoteKeywordPhrase).join(" ");
+  }
+
+  return normalized.join(" ");
+}
+
+export function formatKeywordInput(keywords: string[]): string {
+  const normalized = normalizeKeywordPhrases(keywords);
+  if (normalized.length === 0) {
+    return "";
+  }
+
+  if (normalized.length === 1 && /\s/.test(normalized[0] ?? "")) {
+    return quoteKeywordPhrase(normalized[0] ?? "");
+  }
+
+  return inferKeywordQueryMode(normalized) === "OR"
+    ? normalized.join(", ")
+    : normalized.join(" ");
+}


### PR DESCRIPTION
## Summary
- add a shared phrase-aware keyword query parser/formatter and reuse it across web and API keyword flows
- preserve multi-word keyword phrases through URL sync, editors, fallback collect URLs, and resume search expansion
- add regression coverage for canonical quoted OR phrase handling, including the SEEK Malaysia end-to-end flow

## Test plan
- [x] npm --workspace @trends/web exec vitest run src/hooks/useUrlSearchState.test.ts src/hooks/useResumeListState.test.tsx src/components/SearchProfileEditorDialog.test.tsx src/components/QuickStartPanel.test.tsx src/lib/search-profile-sources.test.ts src/components/CollectResumesButton.test.tsx
- [x] npm --workspace @trends/api exec vitest run src/services/query-parser.test.ts src/services/unified-search-service.test.ts
- [x] npm --workspace @trends/web run test:e2e:resume-role-filter
- [x] npm --workspace @trends/api run build
- [x] make check