### PR TITLE
fix 51job manual import completeness

### DIFF
--- a/apps/api/src/routes/manual-resume-import.test.ts
+++ b/apps/api/src/routes/manual-resume-import.test.ts
@@ -599,6 +599,78 @@ describe("manual resume import route", () => {
     });
   });
 
+  it("repairs malformed manual 51job work history fields", async () => {
+    const calls: ConvexCall[] = [];
+    const documentText = [
+      "活跃时间：2023.10.10",
+      "ID：205191062",
+      "王先生",
+      "观望有好机会会考虑（一个月内到岗）",
+      "男 ｜ 26岁 ｜ 东莞 ｜ 6年工作经验 ｜ 共青团员",
+      "求职意向",
+      "销售代表 ｜ 5000-7000/月 ｜ 东莞 ｜ 全职",
+      "工作经历",
+      "2018.05 - 2020.11（2年6个月）",
+      "职位：销售代表",
+      "工作描述：在该公司主要负责以电话开发客户。",
+      "长沙冠聚信息技术有限公司",
+      "2017.06 - 2018.01（7个月）",
+      "职位：电话销售",
+      "工作描述：通过公司提供的客户资源进行电话联系。",
+    ].join("\n");
+    const fileName = "王先生(205191062).docx";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+      if (call.pathName === "resume_tasks:submitResumes") {
+        return convexSuccess({
+          submitted: 1,
+          deduped: 0,
+          inserted: 1,
+          updated: 0,
+          unchanged: 0,
+        });
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = await createTestApp();
+    const formData = new FormData();
+    formData.append("files", await createDocxFile(fileName, documentText));
+
+    const response = await app.request("/api/resumes/manual-import", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+      body: formData,
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toMatchObject({
+      resumes: [
+        {
+          source: "51job-manual",
+          externalId: "51job-manual:profile:205191062",
+          content: expect.objectContaining({
+            name: "王先生",
+            profileType: "51job-manual",
+            workHistory: expect.arrayContaining([
+              expect.objectContaining({
+                companyName: "长沙冠聚信息技术有限公司",
+                jobTitle: "销售代表",
+                startDate: "2018-05",
+                endDate: "2020-11",
+              }),
+            ]),
+          }),
+        },
+      ],
+    });
+  });
+
   it("returns partial success for mixed supported and unsupported uploads", async () => {
     const calls: ConvexCall[] = [];
 

--- a/apps/api/src/routes/manual-resume-import.test.ts
+++ b/apps/api/src/routes/manual-resume-import.test.ts
@@ -314,6 +314,102 @@ describe("manual resume import route", () => {
     });
   });
 
+  it("parses summary-style 51job resumes with split work-history blocks", async () => {
+    const calls: ConvexCall[] = [];
+    const documentText = [
+      "曾先生 积极找工作（一个月内到岗）",
+      "36岁\t14年经验\t高中\t现居·清远-英德市",
+      "求职意向",
+      "求职偏好： 单休\tTo B（企业/机构）\t面销/陌拜",
+      "客户代表\t东莞\t全职\t8千-1万/月\t机械/设备/重工",
+      "工作经历",
+      "东莞市世川机械科技有限公司",
+      "2022.02-至今（4年1个月）",
+      "客户代表",
+      "工作描述：主要负责销售津上设备。",
+    ].join("\n");
+    const fileName = "曾先生(227359817).docx";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+      if (call.pathName === "resume_tasks:submitResumes") {
+        return convexSuccess({
+          submitted: 1,
+          deduped: 0,
+          inserted: 1,
+          updated: 0,
+          unchanged: 0,
+        });
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = await createTestApp();
+    const formData = new FormData();
+    formData.append("files", await createDocxFile(fileName, documentText));
+
+    const response = await app.request("/api/resumes/manual-import", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+      body: formData,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      success: true,
+      summary: {
+        uploadedFiles: 1,
+        discoveredFiles: 1,
+        parsedResumes: 1,
+        imported: 1,
+        skipped: 0,
+        failed: 0,
+      },
+      files: [
+        expect.objectContaining({
+          uploadName: fileName,
+          entryPath: fileName,
+          status: "imported",
+          resumeName: "曾先生",
+          profileId: "227359817",
+        }),
+      ],
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toMatchObject({
+      resumes: [
+        {
+          source: "51job-manual",
+          externalId: "51job-manual:profile:227359817",
+          content: expect.objectContaining({
+            name: "曾先生",
+            profileType: "51job-manual",
+            location: "清远-英德市",
+            jobIntention: "客户代表 东莞 全职 8千-1万/月 机械/设备/重工",
+            expectedSalary: "8千-1万/月",
+            experience: "14年经验",
+            education: "高中",
+            resumeSnippet: expect.objectContaining({
+              text: expect.stringContaining("客户代表\t东莞\t全职\t8千-1万/月\t机械/设备/重工"),
+            }),
+            workHistory: [
+              expect.objectContaining({
+                companyName: "东莞市世川机械科技有限公司",
+                jobTitle: "客户代表",
+                description: "主要负责销售津上设备",
+                startDate: "2022-02",
+                endDate: "至今",
+              }),
+            ],
+          }),
+        },
+      ],
+    });
+  });
+
   it("returns partial success for mixed supported and unsupported uploads", async () => {
     const calls: ConvexCall[] = [];
 

--- a/apps/api/src/routes/manual-resume-import.test.ts
+++ b/apps/api/src/routes/manual-resume-import.test.ts
@@ -94,6 +94,56 @@ ${paragraphs}
   return new File([buffer], name, { type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" });
 }
 
+async function expectUnreadablePdfUploadFailure(options: {
+  fileName: string;
+  extractedText: string;
+}) {
+  const fetchSpy = vi.spyOn(globalThis, "fetch");
+  const destroy = vi.fn(async () => undefined);
+
+  vi.doMock("pdf-parse", () => ({
+    PDFParse: vi.fn().mockImplementation(() => ({
+      getText: vi.fn(async () => ({ text: options.extractedText })),
+      destroy,
+    })),
+  }));
+
+  const app = await createTestApp();
+  const formData = new FormData();
+  formData.append("files", new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], options.fileName, {
+    type: "application/pdf",
+  }));
+
+  const response = await app.request("/api/resumes/manual-import", {
+    method: "POST",
+    headers: {
+      "X-Workspace-Slug": "hr",
+    },
+    body: formData,
+  });
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({
+    success: true,
+    summary: {
+      uploadedFiles: 1,
+      discoveredFiles: 1,
+      parsedResumes: 0,
+      imported: 0,
+      failed: 1,
+    },
+    files: [
+      expect.objectContaining({
+        entryPath: options.fileName,
+        status: "failed",
+        error: "PDF text extraction produced unusable content",
+      }),
+    ],
+  });
+  expect(fetchSpy).not.toHaveBeenCalled();
+  expect(destroy).toHaveBeenCalledTimes(1);
+}
+
 describe("manual resume import route", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -314,6 +364,20 @@ describe("manual resume import route", () => {
     });
   });
 
+  it("fails unreadable PDF resumes instead of importing junk text", async () => {
+    await expectUnreadablePdfUploadFailure({
+      fileName: "东莞（加工中心）-周进佑.pdf",
+      extractedText: "-- 1 of 1 --",
+    });
+  });
+
+  it("fails garbled PDF resumes instead of importing control-character junk", async () => {
+    await expectUnreadablePdfUploadFailure({
+      fileName: "车床-龙雄-.pdf",
+      extractedText: "\u0002\u0003\u0004\u0002\u0005\u0004\u0006\u0007\b \u000e\u000f \u0010\u0011\u0012\u0013",
+    });
+  });
+
   it("parses summary-style 51job resumes with split work-history blocks", async () => {
     const calls: ConvexCall[] = [];
     const documentText = [
@@ -404,6 +468,131 @@ describe("manual resume import route", () => {
                 endDate: "至今",
               }),
             ],
+          }),
+        },
+      ],
+    });
+  });
+
+  it("prefers salary from the job-intention section over sales totals in the body", async () => {
+    const calls: ConvexCall[] = [];
+    const documentText = [
+      "张先生 在职（一个月内到岗）",
+      "38岁\t17年经验\t本科\t现居·东莞-茶山镇\t户口·东莞\t中共预备党员",
+      "累计带领团队完成3000万销售额，超额达成既定目标。",
+      "求职意向",
+      "销售主管\t东莞、广州、深圳\t全职\t1.5-2.8万/月\t船舶/航空/航天、机械/设备/重工",
+      "工作经历",
+      "东莞市腾信精密制造股份有限公司",
+      "2020.09-2025.09（5年）",
+      "销售主管",
+      "工作描述：负责刀具与高端设备销售。",
+    ].join("\n");
+    const fileName = "张先生(213422761).docx";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+      if (call.pathName === "resume_tasks:submitResumes") {
+        return convexSuccess({
+          submitted: 1,
+          deduped: 0,
+          inserted: 1,
+          updated: 0,
+          unchanged: 0,
+        });
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = await createTestApp();
+    const formData = new FormData();
+    formData.append("files", await createDocxFile(fileName, documentText));
+
+    const response = await app.request("/api/resumes/manual-import", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+      body: formData,
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toMatchObject({
+      resumes: [
+        {
+          source: "51job-manual",
+          externalId: "51job-manual:profile:213422761",
+          content: expect.objectContaining({
+            name: "张先生",
+            location: "东莞-茶山镇",
+            jobIntention: "销售主管 东莞、广州、深圳 全职 1.5-2.8万/月 船舶/航空/航天、机械/设备/重工",
+            expectedSalary: "1.5-2.8万/月",
+            experience: "17年经验",
+          }),
+        },
+      ],
+    });
+  });
+
+  it("extracts unlabeled inline locations from summary profile headers", async () => {
+    const calls: ConvexCall[] = [];
+    const documentText = [
+      "应聘职位：车床/加工中心销售工程师（东莞）",
+      "李湘",
+      "积极找工作（一个月内到岗）",
+      "女 ｜ 25岁 ｜ 东莞-虎门镇 ｜ 6年工作经验 ｜ 普通公民",
+      "求职意向",
+      "销售 ｜ 8000-11000/月 ｜ 东莞 ｜ 全职",
+      "工作经历",
+      "东莞汇振精密机械有限公司",
+      "2021.04 - 2023.04（2年）",
+      "职位：销售",
+      "工作描述：在职期间，自主开发成交客户。",
+    ].join("\n");
+    const fileName = "李湘(962477902).docx";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+      if (call.pathName === "resume_tasks:submitResumes") {
+        return convexSuccess({
+          submitted: 1,
+          deduped: 0,
+          inserted: 1,
+          updated: 0,
+          unchanged: 0,
+        });
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = await createTestApp();
+    const formData = new FormData();
+    formData.append("files", await createDocxFile(fileName, documentText));
+
+    const response = await app.request("/api/resumes/manual-import", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+      body: formData,
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toMatchObject({
+      resumes: [
+        {
+          source: "51job-manual",
+          externalId: "51job-manual:profile:962477902",
+          content: expect.objectContaining({
+            name: "李湘",
+            location: "东莞-虎门镇",
+            jobIntention: "销售 ｜ 8000-11000/月 ｜ 东莞 ｜ 全职",
+            expectedSalary: "8000-11000/月",
+            experience: "6年工作经验",
           }),
         },
       ],

--- a/apps/api/src/routes/manual-resume-import.test.ts
+++ b/apps/api/src/routes/manual-resume-import.test.ts
@@ -63,6 +63,16 @@ function convexSuccess(value: unknown): Response {
 
 async function createDocxFile(name: string, text: string): Promise<File> {
   const zip = new JSZip();
+  const paragraphs = text
+    .split("\n")
+    .map((line) => line
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&apos;"))
+    .map((line) => `    <w:p><w:r><w:t>${line}</w:t></w:r></w:p>`)
+    .join("\n");
   zip.file("[Content_Types].xml", `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
   <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
@@ -76,7 +86,7 @@ async function createDocxFile(name: string, text: string): Promise<File> {
   zip.folder("word")?.file("document.xml", `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
   <w:body>
-    <w:p><w:r><w:t>${text}</w:t></w:r></w:p>
+${paragraphs}
   </w:body>
 </w:document>`);
 
@@ -93,6 +103,21 @@ describe("manual resume import route", () => {
 
   it("allows hr workspace users to upload direct DOCX resumes", async () => {
     const calls: ConvexCall[] = [];
+    const documentText = [
+      "姓名：张三",
+      "人才ID：123456",
+      "区域：广东东莞",
+      "应聘方向：销售工程师",
+      "工作经验：5年",
+      "最高学历：本科",
+      "工作经历",
+      "2021-03~至今 东莞精密机械有限公司 销售工程师",
+      "工作描述：负责华南区机床销售与客户维护",
+      "教育经历",
+      "2015-09~2019-06 华南理工大学 机械设计制造及其自动化 本科",
+      "个人优势",
+      "熟悉CNC机床销售、客户跟进与方案沟通",
+    ].join("\n");
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const call = parseConvexCall(input, init);
@@ -111,7 +136,7 @@ describe("manual resume import route", () => {
 
     const app = await createTestApp();
     const formData = new FormData();
-    formData.append("files", await createDocxFile("51job_张三(123456).docx", "张三 销售工程师 CNC"));
+    formData.append("files", await createDocxFile("51job_张三(123456).docx", documentText));
     formData.append("keyword", "销售工程师");
 
     const response = await app.request("/api/resumes/manual-import", {
@@ -151,29 +176,49 @@ describe("manual resume import route", () => {
       ],
     });
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.args).toMatchObject({
-      resumes: [
-        {
-          source: "51job-manual",
-          externalId: "51job-manual:profile:123456",
-          tags: ["销售工程师"],
-          content: expect.objectContaining({
-            name: "张三",
-            profileType: "51job-manual",
-            selfIntro: "张三 销售工程师 CNC",
-            resumeSnippet: { text: "张三 销售工程师 CNC" },
-          }),
-        },
-      ],
+    const submittedResume = (calls[0]?.args.resumes as Array<Record<string, unknown>> | undefined)?.[0];
+    expect(submittedResume).toMatchObject({
+      source: "51job-manual",
+      externalId: "51job-manual:profile:123456",
+      tags: ["销售工程师"],
     });
+    const content = submittedResume?.content;
+    expect(content).toHaveProperty("name", "张三");
+    expect(content).toHaveProperty("profileType", "51job-manual");
+    expect(content).toHaveProperty("experience", "5年");
+    expect(content).toHaveProperty("education", "本科");
+    expect(content).toHaveProperty("location", "广东东莞");
+    expect(content).toHaveProperty("jobIntention", "销售工程师");
+    expect(content).toHaveProperty("selfIntro", "熟悉CNC机床销售、客户跟进与方案沟通");
+    expect(content).toHaveProperty("resumeSnippet.text");
+    expect(String((content as { resumeSnippet?: { text?: string } }).resumeSnippet?.text)).toContain("姓名：张三");
+    expect(String((content as { resumeSnippet?: { text?: string } }).resumeSnippet?.text)).toContain("东莞精密机械有限公司 销售工程师");
+    expect(content).toHaveProperty("locationHierarchy");
+    expect(content).toHaveProperty("profileId", "123456");
+    expect(content).toHaveProperty("workHistory.0.companyName", "东莞精密机械有限公司");
+    expect(content).toHaveProperty("workHistory.0.jobTitle", "销售工程师");
+    expect(content).toHaveProperty("workHistory.0.description", "负责华南区机床销售与客户维护");
+    expect(content).toHaveProperty("workHistory.0.startDate", "2021-03");
+    expect(content).toHaveProperty("workHistory.0.endDate", "至今");
+    expect(String((content as { workHistory?: Array<{ raw?: string }> }).workHistory?.[0]?.raw)).toContain("东莞精密机械有限公司 销售工程师");
+    expect(content).toHaveProperty("profileEducation.0.institution", "华南理工大学");
+    expect(content).toHaveProperty("profileEducation.0.qualification", "本科");
+    expect(content).toHaveProperty("profileEducation.0.fieldOfStudy", "机械设计制造及其自动化");
+    expect(content).toHaveProperty("profileEducation.0.startDate", "2015-09");
+    expect(content).toHaveProperty("profileEducation.0.endDate", "2019-06");
   });
 
   it("imports malformed 51job DOCX files via fallback XML extraction", async () => {
     const calls: ConvexCall[] = [];
     const fallbackText = [
-      "王某",
+      "姓名：王某",
       "人才ID: 987654321",
-      "对门窗体验箱和气密性仪器进行销售",
+      "现居·广州",
+      "应聘方向：销售工程师",
+      "工作经历",
+      "2020-01~2024-12 广州门窗设备有限公司 销售工程师",
+      "工作描述：对门窗体验箱和气密性仪器进行销售",
+      "个人优势",
       "熟悉门窗检测与客户跟进",
     ].join("\n");
     const fallbackFileName = "51job_王某(987654321).docx";
@@ -243,8 +288,26 @@ describe("manual resume import route", () => {
           content: expect.objectContaining({
             name: "王某",
             profileType: "51job-manual",
-            selfIntro: fallbackText,
+            location: "广州",
+            locationHierarchy: {
+              country: "中国",
+              province: "广东",
+              city: "广州",
+              matchedFrom: "location",
+              confidence: "high",
+            },
+            jobIntention: "销售工程师",
+            selfIntro: "熟悉门窗检测与客户跟进",
             resumeSnippet: { text: fallbackText },
+            workHistory: [
+              expect.objectContaining({
+                companyName: "广州门窗设备有限公司",
+                jobTitle: "销售工程师",
+                description: "对门窗体验箱和气密性仪器进行销售",
+                startDate: "2020-01",
+                endDate: "2024-12",
+              }),
+            ],
           }),
         },
       ],

--- a/apps/api/src/services/ingest-compute-service.test.ts
+++ b/apps/api/src/services/ingest-compute-service.test.ts
@@ -832,6 +832,52 @@ describe("IngestComputeService", () => {
     expect(index.searchText).not.toContain("机械助理");
   });
 
+  it("should produce evidence from manual-import-shaped structured work history even with empty selfIntro", () => {
+    const item = {
+      ...SAMPLE_RESUME_JUNIOR.data[0],
+      selfIntro: "",
+      jobIntention: "销售工程师",
+      workHistory: [
+        {
+          raw: "2021-03~2025-03 东莞精密机械有限公司 销售工程师",
+          companyName: "东莞精密机械有限公司",
+          jobTitle: "销售工程师",
+          description: "负责华南区机床销售与客户维护",
+          startDate: "2021-03",
+          endDate: "2025-03",
+        },
+      ],
+      profileEducation: [
+        {
+          institution: "华南理工大学",
+          qualification: "本科",
+          fieldOfStudy: "机械设计制造及其自动化",
+          startDate: "2015-09",
+          endDate: "2019-06",
+        },
+      ],
+      resumeSnippet: {
+        text: "姓名：张三\n工作经历\n2021-03~至今 东莞精密机械有限公司 销售工程师\n工作描述：负责华南区机床销售与客户维护",
+      },
+    };
+
+    const index = buildResumeIndex(item, 0);
+    const result = service.computeOne("resume-manual-51job", { data: [item] });
+    const salesRole = result.roleSignals.find((entry) => entry.type === "sales");
+
+    expect(index.evidenceText).toContain("东莞精密机械有限公司");
+    expect(index.evidenceText).toContain("销售工程师");
+    expect(result.evidenceText).toBe(index.evidenceText);
+    expect(result.ruleScores["jd-lathe-sales"]).toBeGreaterThan(0);
+    expect(salesRole?.years).toBeGreaterThan(0);
+    expect(salesRole?.matchedWorkEntries).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        companyName: "东莞精密机械有限公司",
+        jobTitle: "销售工程师",
+      }),
+    ]));
+  });
+
   it("should use structured work history dates and company names", () => {
     const item = {
       ...SAMPLE_RESUME_JUNIOR.data[0],

--- a/apps/api/src/services/manual-resume-import-service.ts
+++ b/apps/api/src/services/manual-resume-import-service.ts
@@ -5,7 +5,12 @@ import * as unrar from "node-unrar-js";
 import { PDFParse } from "pdf-parse";
 import { z } from "@hono/zod-openapi";
 
-import { normalizeOptionalString, parse51jobManualResume } from "@trends/shared";
+import {
+  hasReadableManual51jobText,
+  normalizeOptionalString,
+  parse51jobManualResume,
+  stripManual51jobUnreadableControlCharacters,
+} from "@trends/shared";
 
 import {
   type ResumeImportItem,
@@ -434,13 +439,26 @@ async function parsePdfFile(file: EnumeratedImportFile): Promise<ParsedImportCan
 
   try {
     const result = await parser.getText();
-    const text = normalizeWhitespace(result.text);
-    if (!text) {
+    const rawText = normalizeWhitespace(result.text);
+    if (!rawText) {
       return {
         result: {
           ...fileResultBase(file),
           status: "failed",
           error: "No extractable text found in PDF file",
+          warnings: [],
+        },
+        resume: null,
+      };
+    }
+
+    const text = normalizeWhitespace(stripManual51jobUnreadableControlCharacters(rawText));
+    if (!text || !hasReadableManual51jobText(text)) {
+      return {
+        result: {
+          ...fileResultBase(file),
+          status: "failed",
+          error: "PDF text extraction produced unusable content",
           warnings: [],
         },
         resume: null,

--- a/apps/api/src/services/manual-resume-import-service.ts
+++ b/apps/api/src/services/manual-resume-import-service.ts
@@ -5,7 +5,7 @@ import * as unrar from "node-unrar-js";
 import { PDFParse } from "pdf-parse";
 import { z } from "@hono/zod-openapi";
 
-import { normalizeOptionalString } from "@trends/shared";
+import { normalizeOptionalString, parse51jobManualResume } from "@trends/shared";
 
 import {
   type ResumeImportItem,
@@ -57,6 +57,7 @@ const MAX_UPLOAD_FILE_SIZE = 25 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRY_SIZE = 25 * 1024 * 1024;
 const MAX_TOTAL_EXTRACTED_SIZE = 150 * 1024 * 1024;
 const MAX_UPLOAD_REQUEST_SIZE = MAX_TOTAL_EXTRACTED_SIZE;
+const MAX_PARALLEL_FILE_OPERATIONS = 4;
 const SUPPORTED_FILE_EXTENSIONS = new Set([".pdf", ".doc", ".docx"]);
 const DOCX_MESSAGE_WARNING_TYPES = new Set(["warning", "error"]);
 const DOCX_TEXT_ENTRY_PATH_PATTERN = /^word\/(?:document|header\d+|footer\d+|footnotes|endnotes)\.xml$/i;
@@ -283,15 +284,29 @@ async function expandUploadedFile(file: File): Promise<UploadExpansionResult> {
   }
 }
 
+async function mapInBatches<TItem, TResult>(
+  items: readonly TItem[],
+  mapper: (item: TItem) => Promise<TResult>,
+): Promise<TResult[]> {
+  const results: TResult[] = [];
+
+  for (let index = 0; index < items.length; index += MAX_PARALLEL_FILE_OPERATIONS) {
+    const batch = items.slice(index, index + MAX_PARALLEL_FILE_OPERATIONS);
+    results.push(...await Promise.all(batch.map((item) => mapper(item))));
+  }
+
+  return results;
+}
+
 async function enumerateUploadedFiles(files: File[]): Promise<{
   entries: EnumeratedImportFile[];
   fileResults: ManualResumeImportFileResult[];
 }> {
+  const expandedFiles = await mapInBatches(files, expandUploadedFile);
   const entries: EnumeratedImportFile[] = [];
   const fileResults: ManualResumeImportFileResult[] = [];
 
-  for (const file of files) {
-    const expanded = await expandUploadedFile(file);
+  for (const expanded of expandedFiles) {
     entries.push(...expanded.entries);
     if (expanded.fileResult) {
       fileResults.push(expanded.fileResult);
@@ -310,95 +325,38 @@ function fileResultBase(file: EnumeratedImportFile): Omit<ManualResumeImportFile
   };
 }
 
-function inferFilenameResumeName(entryPath: string): string | undefined {
-  const basename = path.basename(entryPath, path.extname(entryPath));
-  const withoutPrefix = basename.replace(/^51job[_-]?/i, "").trim();
-  const withoutId = withoutPrefix.replace(/\([^)]*\)/g, "").trim();
-  return withoutId || undefined;
-}
-
-function isLikelyResumeNameCandidate(value: string): boolean {
-  if (!value || value.length > 20) {
-    return false;
-  }
-  if (/\d/.test(value) || /[：:｜|丨/]/.test(value) || /[()（）]/.test(value)) {
-    return false;
-  }
-
-  const normalized = value.replace(/\s+/g, "");
-  if ([
-    "活跃时间",
-    "最近工作",
-    "最高学历",
-    "最高学历学位",
-    "求职意向",
-    "个人优势",
-    "工作经历",
-    "教育经历",
-    "专业描述",
-    "工作描述",
-    "证书",
-    "声明",
-    "离职",
-    "在职",
-    "全职",
-  ].includes(normalized)) {
-    return false;
-  }
-
-  return /\p{Script=Han}|[A-Za-z]/u.test(normalized);
-}
-
-function inferResumeName(entryPath: string, text: string): string | undefined {
-  const filenameCandidate = inferFilenameResumeName(entryPath);
-  if (filenameCandidate && /\p{Script=Han}/u.test(filenameCandidate)) {
-    return filenameCandidate;
-  }
-
-  const normalizedText = normalizeWhitespace(text);
-  const lines = normalizedText.split(/\n+/).map((line) => line.trim()).filter(Boolean);
-  for (const line of lines.slice(0, 12)) {
-    const firstToken = line.split(/[\s|｜丨]/).find(Boolean)?.trim();
-    if (firstToken && isLikelyResumeNameCandidate(firstToken)) {
-      return firstToken;
-    }
-  }
-
-  return filenameCandidate;
-}
-
-function inferProfileId(entryPath: string, text: string): string | undefined {
-  const entryMatch = entryPath.match(/\((\d{6,})\)/);
-  if (entryMatch?.[1]) {
-    return entryMatch[1];
-  }
-
-  const textMatch = text.match(/(?:人才ID|简历编号|ID)[:：]?\s*(\d{6,})/i);
-  return textMatch?.[1];
-}
-
 function buildImportedResumeCandidate(
   file: EnumeratedImportFile,
   text: string,
   warnings: string[],
 ): ParsedImportCandidate {
-  const resumeName = inferResumeName(file.entryPath, text);
-  const profileId = inferProfileId(file.entryPath, text);
+  const parsed = parse51jobManualResume({
+    text,
+    entryPath: file.entryPath,
+  });
+  const resumeName = parsed.name ?? path.basename(file.entryPath, file.extension);
   const resume: ResumeImportItem = {
-    name: resumeName ?? path.basename(file.entryPath, file.extension),
-    selfIntro: text,
-    resumeSnippet: { text },
+    name: resumeName,
     extractedAt: new Date().toISOString(),
     profileType: MANUAL_SOURCE_KEY,
-    ...(profileId ? { profileId } : {}),
+    workHistory: parsed.workHistory,
+    resumeSnippet: parsed.resumeSnippet,
+    ...(parsed.profileId ? { profileId: parsed.profileId } : {}),
+    ...(parsed.location ? { location: parsed.location } : {}),
+    ...(parsed.jobIntention ? { jobIntention: parsed.jobIntention } : {}),
+    ...(parsed.expectedSalary ? { expectedSalary: parsed.expectedSalary } : {}),
+    ...(parsed.experience ? { experience: parsed.experience } : {}),
+    ...(parsed.education ? { education: parsed.education } : {}),
+    ...(parsed.selfIntro ? { selfIntro: parsed.selfIntro } : {}),
+    ...(parsed.profileEducation ? { profileEducation: parsed.profileEducation } : {}),
   };
 
   return {
     result: {
       ...fileResultBase(file),
       status: "imported",
-      ...(resumeName ? { resumeName } : {}),
-      ...(profileId ? { profileId } : {}),
+      resumeName,
+      ...(parsed.profileId ? { profileId: parsed.profileId } : {}),
       warnings,
     },
     resume,
@@ -569,8 +527,9 @@ export async function importManualResumes(input: ManualResumeImportInput): Promi
   const resumes: ResumeImportItem[] = [];
   const warnings: string[] = [];
 
-  for (const file of enumeratedFiles) {
-    const parsed = await parseResumeFile(file);
+  const parsedFiles = await mapInBatches(enumeratedFiles, parseResumeFile);
+
+  for (const parsed of parsedFiles) {
     fileResults.push(parsed.result);
     if (parsed.result.warnings.length > 0) {
       warnings.push(...parsed.result.warnings.map((warning) => `${parsed.result.entryPath}: ${warning}`));

--- a/apps/api/src/services/resume-import-service.test.ts
+++ b/apps/api/src/services/resume-import-service.test.ts
@@ -282,6 +282,96 @@ describe("resume-import-service", () => {
     });
   });
 
+  it("preserves structured manual 51job fields through shared normalization", () => {
+    const result = normalizeResumeImportPayload({
+      metadata: {
+        sourceKey: "51job-manual",
+        sourceHost: "51job-manual",
+        sourceUrl: "https://www.51job.com/",
+        keyword: "销售工程师",
+        generatedBy: "manual-import@1.0.0",
+      },
+      resumes: [
+        {
+          profileId: "123456",
+          profileType: "51job-manual",
+          name: "张三",
+          location: "广东东莞",
+          experience: "5年",
+          education: "本科",
+          jobIntention: "销售工程师",
+          selfIntro: "熟悉CNC机床销售、客户跟进与方案沟通",
+          workHistory: [
+            {
+              raw: "2021-03~至今 东莞精密机械有限公司 销售工程师",
+              companyName: "东莞精密机械有限公司",
+              jobTitle: "销售工程师",
+              description: "负责华南区机床销售与客户维护",
+              startDate: "2021-03",
+              endDate: "至今",
+            },
+          ],
+          profileEducation: [
+            {
+              institution: "华南理工大学",
+              qualification: "本科",
+              fieldOfStudy: "机械设计制造及其自动化",
+              startDate: "2015-09",
+              endDate: "2019-06",
+            },
+          ],
+          resumeSnippet: {
+            text: "姓名：张三\n工作经历\n2021-03~至今 东莞精密机械有限公司 销售工程师",
+          },
+          extractedAt: "2026-03-19T00:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(result.convexResumes[0]).toMatchObject({
+      externalId: "51job-manual:profile:123456",
+      source: "51job-manual",
+      tags: ["销售工程师"],
+      content: expect.objectContaining({
+        profileType: "51job-manual",
+        name: "张三",
+        experience: "5年",
+        education: "本科",
+        jobIntention: "销售工程师",
+        selfIntro: "熟悉CNC机床销售、客户跟进与方案沟通",
+        resumeSnippet: {
+          text: "姓名：张三\n工作经历\n2021-03~至今 东莞精密机械有限公司 销售工程师",
+        },
+        locationHierarchy: {
+          country: "中国",
+          province: "广东",
+          city: "东莞",
+          matchedFrom: "location",
+          confidence: "high",
+        },
+        workHistory: [
+          {
+            raw: "2021-03~至今 东莞精密机械有限公司 销售工程师",
+            companyName: "东莞精密机械有限公司",
+            jobTitle: "销售工程师",
+            description: "负责华南区机床销售与客户维护",
+            startDate: "2021-03",
+            endDate: "至今",
+          },
+        ],
+        profileEducation: [
+          {
+            institution: "华南理工大学",
+            qualification: "本科",
+            fieldOfStudy: "机械设计制造及其自动化",
+            startDate: "2015-09",
+            endDate: "2019-06",
+          },
+        ],
+      }),
+    });
+  });
+
   it("submits source-aware payloads through the shared Convex path", async () => {
     const calls: ConvexCall[] = [];
 

--- a/apps/web/src/components/ManualResumeImportDialog.test.tsx
+++ b/apps/web/src/components/ManualResumeImportDialog.test.tsx
@@ -147,6 +147,65 @@ describe('ManualResumeImportDialog', () => {
     })
   })
 
+  it('shows unreadable PDF extraction failures without refreshing', async () => {
+    const user = userEvent.setup()
+    const onImported = vi.fn()
+    const fetchMock = vi.mocked(fetch)
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        source: { key: '51job-manual', label: '51job-manual' },
+        summary: {
+          uploadedFiles: 1,
+          discoveredFiles: 1,
+          parsedResumes: 0,
+          imported: 0,
+          inserted: 0,
+          updated: 0,
+          unchanged: 0,
+          deduped: 0,
+          skipped: 0,
+          failed: 1,
+        },
+        files: [
+          {
+            uploadName: '东莞（加工中心）-周进佑.pdf',
+            entryPath: '东莞（加工中心）-周进佑.pdf',
+            extension: '.pdf',
+            status: 'failed',
+            error: 'PDF text extraction produced unusable content',
+            warnings: [],
+          },
+        ],
+        warnings: [],
+      }),
+    } as Response)
+
+    render(
+      <ManualResumeImportDialog
+        open
+        onOpenChange={vi.fn()}
+        location="东莞"
+        keywords={['销售工程师']}
+        onImported={onImported}
+      />
+    )
+
+    const input = screen.getByTestId('manual-resume-import-input') as HTMLInputElement
+    await user.upload(input, new File(['pdf'], '东莞（加工中心）-周进佑.pdf', { type: 'application/pdf' }))
+    await user.click(screen.getByRole('button', { name: 'Import resumes' }))
+
+    await waitFor(() => {
+      expect(errorMock).toHaveBeenCalledWith('PDF text extraction produced unusable content')
+      expect(successMock).not.toHaveBeenCalled()
+      expect(onImported).not.toHaveBeenCalled()
+      expect(screen.getByText('Import summary')).toBeInTheDocument()
+      expect(screen.getAllByText('东莞（加工中心）-周进佑.pdf')).toHaveLength(2)
+      expect(screen.getByText('PDF text extraction produced unusable content')).toBeInTheDocument()
+    })
+  })
+
   it('does not show a success toast or refresh when every uploaded file fails', async () => {
     const user = userEvent.setup()
     const onImported = vi.fn()

--- a/packages/convex/convex/__tests__/migrations-evidence-text.test.ts
+++ b/packages/convex/convex/__tests__/migrations-evidence-text.test.ts
@@ -449,6 +449,47 @@ describe('backfillManual51jobStructuredContent', () => {
         },
       },
       {
+        _id: 'manual-salary-and-location-refresh',
+        content: {
+          profileType: '51job-manual',
+          name: '李湘',
+          location: '',
+          expectedSalary: '3000万',
+          resumeSnippet: {
+            text: [
+              '应聘职位：车床/加工中心销售工程师（东莞）',
+              '李湘',
+              '积极找工作（一个月内到岗）',
+              '女 ｜ 25岁 ｜ 东莞-虎门镇 ｜ 6年工作经验 ｜ 普通公民',
+              '累计带领团队完成3000万销售额，超额达成既定目标。',
+              '求职意向',
+              '销售 ｜ 8000-11000/月 ｜ 东莞 ｜ 全职',
+              '工作经历',
+              '东莞汇振精密机械有限公司',
+              '2021.04 - 2023.04（2年）',
+              '职位：销售',
+              '工作描述：在职期间，自主开发成交客户。',
+            ].join('\n'),
+          },
+          workHistory: [
+            {
+              raw: '2021.04 - 2023.04（2年）',
+              startDate: '2021-04',
+              endDate: '2023-04',
+            },
+          ],
+        },
+        ingestData: {
+          evidenceText: '',
+          industryTags: ['machinery'],
+          synonymHits: ['销售'],
+          ruleScores: { jd4: 86 },
+          experienceLevel: 'mid',
+          computedAt: 1_700_000_000_350,
+          skillsVersion: 1,
+        },
+      },
+      {
         _id: 'seek-resume',
         content: {
           profileType: 'seek',
@@ -472,10 +513,10 @@ describe('backfillManual51jobStructuredContent', () => {
     const result = await backfillManual51jobStructuredContentHandler(ctx as never, {})
 
     expect(result).toEqual({
-      scannedResumes: 4,
-      updatedResumes: 3,
-      updatedEvidenceText: 3,
-      updatedSearchText: 3,
+      scannedResumes: 5,
+      updatedResumes: 4,
+      updatedEvidenceText: 4,
+      updatedSearchText: 4,
       scheduledReingest: 3,
       batches: 1,
       hasMore: false,
@@ -549,11 +590,27 @@ describe('backfillManual51jobStructuredContent', () => {
         searchText: expect.stringContaining('广州设备有限公司'),
       }),
     })
+
+    expect(ctx.patches).toContainEqual({
+      id: 'manual-salary-and-location-refresh',
+      patch: expect.objectContaining({
+        content: expect.objectContaining({
+          name: '李湘',
+          location: '东莞-虎门镇',
+          expectedSalary: '8000-11000/月',
+          jobIntention: '销售 ｜ 8000-11000/月 ｜ 东莞 ｜ 全职',
+        }),
+        ingestData: expect.objectContaining({
+          evidenceText: expect.stringContaining('东莞汇振精密机械有限公司'),
+        }),
+        searchText: expect.stringContaining('东莞-虎门镇'),
+      }),
+    })
     expect(ctx.patches.some((entry) => entry.id === 'seek-resume')).toBe(false)
     expect(ctx.scheduled).toHaveLength(1)
     expect(ctx.scheduled[0]).toMatchObject({
       delayMs: 0,
-      args: { resumeIds: ['manual-legacy', 'manual-already-structured', 'manual-filename-fallback'] },
+      args: { resumeIds: ['manual-legacy', 'manual-filename-fallback', 'manual-salary-and-location-refresh'] },
     })
   })
 })

--- a/packages/convex/convex/__tests__/migrations-evidence-text.test.ts
+++ b/packages/convex/convex/__tests__/migrations-evidence-text.test.ts
@@ -432,7 +432,11 @@ describe('backfillManual51jobStructuredContent', () => {
               '工作描述：主要销售日本津上数控车床，数控走心机，加工中心。',
             ].join('\n'),
           },
-          workHistory: [],
+          workHistory: [
+            {
+              companyName: '旧占位公司',
+            },
+          ],
         },
         ingestData: {
           evidenceText: '',
@@ -519,9 +523,14 @@ describe('backfillManual51jobStructuredContent', () => {
         content: expect.objectContaining({
           name: '谷仍友',
           location: '广州-番禺区',
+          jobIntention: '车床销售工程师（东莞）',
           workHistory: expect.arrayContaining([
             expect.objectContaining({
               companyName: '广州市振工机电设备有限公司',
+              jobTitle: '销售总监',
+              description: '主要销售日本津上数控车床 数控走心机 加工中心',
+              startDate: '2014-05',
+              endDate: '至今',
             }),
           ]),
         }),

--- a/packages/convex/convex/__tests__/migrations-evidence-text.test.ts
+++ b/packages/convex/convex/__tests__/migrations-evidence-text.test.ts
@@ -434,7 +434,9 @@ describe('backfillManual51jobStructuredContent', () => {
           },
           workHistory: [
             {
-              companyName: '旧占位公司',
+              raw: '2014.05 - 至今（11年1个月）\n职位：销售总监\n工作描述：主要销售日本津上数控车床，数控走心机，加工中心。\n广州市振工机电设备有限公司',
+              companyName: '在该公司',
+              jobTitle: '聊',
             },
           ],
         },

--- a/packages/convex/convex/__tests__/migrations-evidence-text.test.ts
+++ b/packages/convex/convex/__tests__/migrations-evidence-text.test.ts
@@ -4,6 +4,7 @@ import {
   backfillEvidenceText,
   backfillJob5156LocationHierarchy,
   backfillJob5156WorkHistoryEducation,
+  backfillManual51jobStructuredContent,
 } from '../migrations'
 
 type BackfillEvidenceTextResult = {
@@ -40,6 +41,20 @@ const backfillJob5156LocationHierarchyHandler = (backfillJob5156LocationHierarch
   }
 >)._handler
 
+const backfillManual51jobStructuredContentHandler = (backfillManual51jobStructuredContent as unknown as ConvexHandler<
+  Record<string, never>,
+  {
+    scannedResumes: number
+    updatedResumes: number
+    updatedEvidenceText: number
+    updatedSearchText: number
+    scheduledReingest: number
+    batches: number
+    hasMore: boolean
+    cursor: string | null
+  }
+>)._handler
+
 type ResumeRecord = {
   _id: string
   content: Record<string, unknown>
@@ -56,9 +71,11 @@ type ResumeRecord = {
 
 function createResumesDb(records: ResumeRecord[]) {
   const patches: Array<{ id: string; patch: Partial<ResumeRecord> }> = []
+  const scheduled: Array<{ delayMs: number; fn: unknown; args: unknown }> = []
 
   return {
     patches,
+    scheduled,
     db: {
       query(tableName: string) {
         expect(tableName).toBe('resumes')
@@ -83,6 +100,11 @@ function createResumesDb(records: ResumeRecord[]) {
         if (record) {
           Object.assign(record, patch)
         }
+      },
+    },
+    scheduler: {
+      async runAfter(delayMs: number, fn: unknown, args: unknown) {
+        scheduled.push({ delayMs, fn, args })
       },
     },
   }
@@ -307,6 +329,222 @@ describe('backfillJob5156LocationHierarchy', () => {
         }),
         searchText: expect.stringContaining('中国'),
       }),
+    })
+  })
+})
+
+describe('backfillManual51jobStructuredContent', () => {
+  it('repairs broken manual 51job records, rebuilds search text, refreshes evidence, and schedules reingest', async () => {
+    const records: ResumeRecord[] = [
+      {
+        _id: 'manual-legacy',
+        content: {
+          profileType: '51job-manual',
+          name: '张三',
+          selfIntro: [
+            '姓名：张三',
+            '人才ID：123456',
+            '现居·东莞',
+            '应聘方向：销售工程师',
+            '工作经历',
+            '2021-03~至今 东莞精密机械有限公司 销售工程师',
+            '工作描述：负责华南区机床销售与客户维护',
+            '教育经历',
+            '2015-09~2019-06 华南理工大学 机械设计制造及其自动化 本科',
+            '个人优势',
+            '熟悉CNC机床销售、客户跟进与方案沟通',
+          ].join('\n'),
+          resumeSnippet: {
+            text: [
+              '姓名：张三',
+              '人才ID：123456',
+              '现居·东莞',
+              '应聘方向：销售工程师',
+              '工作经历',
+              '2021-03~至今 东莞精密机械有限公司 销售工程师',
+              '工作描述：负责华南区机床销售与客户维护',
+              '教育经历',
+              '2015-09~2019-06 华南理工大学 机械设计制造及其自动化 本科',
+              '个人优势',
+              '熟悉CNC机床销售、客户跟进与方案沟通',
+            ].join('\n'),
+          },
+          workHistory: [],
+        },
+        ingestData: {
+          evidenceText: '',
+          industryTags: ['machinery'],
+          synonymHits: ['销售'],
+          ruleScores: { jd1: 80 },
+          experienceLevel: 'mid',
+          computedAt: 1_700_000_000_000,
+          skillsVersion: 1,
+        },
+      },
+      {
+        _id: 'manual-already-structured',
+        content: {
+          profileType: '51job-manual',
+          name: '李四',
+          resumeSnippet: { text: '姓名：李四' },
+          workHistory: [
+            {
+              raw: '2020-01~至今 广州设备有限公司 销售工程师',
+              companyName: '广州设备有限公司',
+              jobTitle: '销售工程师',
+              startDate: '2020-01',
+              endDate: '至今',
+            },
+          ],
+        },
+        ingestData: {
+          evidenceText: 'stale structured evidence',
+          industryTags: ['machinery'],
+          synonymHits: ['销售'],
+          ruleScores: { jd1: 80 },
+          experienceLevel: 'mid',
+          computedAt: 1_700_000_000_100,
+          skillsVersion: 1,
+        },
+      },
+      {
+        _id: 'manual-filename-fallback',
+        content: {
+          profileType: '51job-manual',
+          name: '车床-谷仍友_销售工程师_广州',
+          location: '广东广州',
+          resumeSnippet: {
+            text: [
+              '应聘职位：车床销售工程师（东莞）',
+              '应聘公司：宝力机械有限公司',
+              '应聘时间：2025.06.03 - 活跃时间：2025.06.03',
+              'ID：265281996',
+              '',
+              '仅供招聘专用，企业应尽保密义务，禁止外传',
+              '',
+              '谷仍友',
+              '积极找工作（一个月内到岗）',
+              '男 ｜ 42岁 ｜ 现居·广州-番禺区 ｜ 18年工作经验',
+              '工作经历',
+              '广州市振工机电设备有限公司',
+              '2014.05 - 至今（11年1个月）',
+              '职位：销售总监',
+              '工作描述：主要销售日本津上数控车床，数控走心机，加工中心。',
+            ].join('\n'),
+          },
+          workHistory: [],
+        },
+        ingestData: {
+          evidenceText: '',
+          industryTags: ['machinery'],
+          synonymHits: ['销售'],
+          ruleScores: { jd3: 88 },
+          experienceLevel: 'senior',
+          computedAt: 1_700_000_000_300,
+          skillsVersion: 1,
+        },
+      },
+      {
+        _id: 'seek-resume',
+        content: {
+          profileType: 'seek',
+          name: 'Bob',
+          selfIntro: 'legacy text',
+          workHistory: [],
+        },
+        ingestData: {
+          evidenceText: '',
+          industryTags: ['sales'],
+          synonymHits: [],
+          ruleScores: { jd2: 70 },
+          experienceLevel: 'mid',
+          computedAt: 1_700_000_000_200,
+          skillsVersion: 1,
+        },
+      },
+    ]
+
+    const ctx = createResumesDb(records)
+    const result = await backfillManual51jobStructuredContentHandler(ctx as never, {})
+
+    expect(result).toEqual({
+      scannedResumes: 4,
+      updatedResumes: 3,
+      updatedEvidenceText: 3,
+      updatedSearchText: 3,
+      scheduledReingest: 3,
+      batches: 1,
+      hasMore: false,
+      cursor: null,
+    })
+
+    expect(ctx.patches).toContainEqual({
+      id: 'manual-legacy',
+      patch: expect.objectContaining({
+        content: expect.objectContaining({
+          profileType: '51job-manual',
+          location: '东莞',
+          jobIntention: '销售工程师',
+          education: '本科',
+          selfIntro: '熟悉CNC机床销售、客户跟进与方案沟通',
+          workHistory: [
+            expect.objectContaining({
+              companyName: '东莞精密机械有限公司',
+              jobTitle: '销售工程师',
+              description: '负责华南区机床销售与客户维护',
+              startDate: '2021-03',
+              endDate: '至今',
+            }),
+          ],
+          profileEducation: [
+            expect.objectContaining({
+              institution: '华南理工大学',
+              qualification: '本科',
+              fieldOfStudy: '机械设计制造及其自动化',
+              startDate: '2015-09',
+              endDate: '2019-06',
+            }),
+          ],
+        }),
+        searchText: expect.stringContaining('东莞精密机械有限公司'),
+        ingestData: expect.objectContaining({
+          evidenceText: expect.stringContaining('东莞精密机械有限公司'),
+        }),
+      }),
+    })
+
+    expect(ctx.patches).toContainEqual({
+      id: 'manual-filename-fallback',
+      patch: expect.objectContaining({
+        content: expect.objectContaining({
+          name: '谷仍友',
+          location: '广州-番禺区',
+          workHistory: expect.arrayContaining([
+            expect.objectContaining({
+              companyName: '广州市振工机电设备有限公司',
+            }),
+          ]),
+        }),
+        ingestData: expect.objectContaining({
+          evidenceText: expect.stringContaining('广州市振工机电设备有限公司'),
+        }),
+      }),
+    })
+
+    expect(ctx.patches).toContainEqual({
+      id: 'manual-already-structured',
+      patch: expect.objectContaining({
+        ingestData: expect.objectContaining({
+          evidenceText: '2020-01 ~ 至今 广州设备有限公司 销售工程师',
+        }),
+        searchText: expect.stringContaining('广州设备有限公司'),
+      }),
+    })
+    expect(ctx.patches.some((entry) => entry.id === 'seek-resume')).toBe(false)
+    expect(ctx.scheduled).toHaveLength(1)
+    expect(ctx.scheduled[0]).toMatchObject({
+      delayMs: 0,
+      args: { resumeIds: ['manual-legacy', 'manual-already-structured', 'manual-filename-fallback'] },
     })
   })
 })

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -8,6 +8,8 @@ import {
     normalizeJob5156ProfileUrlForDisplay,
     normalizeResumeLocationHierarchy,
     normalizeWorkHistoryEntry,
+    isLikelyManual51jobCompanyName,
+    isLikelyManual51jobJobTitle,
     parse51jobManualResume,
     shouldPreferManual51jobOptionalField,
 } from "@trends/shared";
@@ -143,6 +145,42 @@ function isManual51jobResumeContent(content: unknown, source: unknown): content 
     return profileType === MANUAL_51JOB_SOURCE;
 }
 
+function isImplausibleManual51jobCompanyName(value: string): boolean {
+    return !isLikelyManual51jobCompanyName(value);
+}
+
+function isImplausibleManual51jobJobTitle(value: string): boolean {
+    return !isLikelyManual51jobJobTitle(value);
+}
+
+function isManual51jobWorkHistoryEntryMalformed(entry: unknown): boolean {
+    const normalized = normalizeWorkHistoryEntry(entry);
+    if (!normalized) {
+        return true;
+    }
+
+    const hasCompany = Boolean(normalized.companyName);
+    const hasOtherFields = Boolean(normalized.jobTitle || normalized.description || normalized.startDate || normalized.endDate);
+
+    if (!hasCompany && !hasOtherFields) {
+        return true;
+    }
+
+    if (!normalized.companyName) {
+        return false;
+    }
+
+    if (isImplausibleManual51jobCompanyName(normalized.companyName)) {
+        return true;
+    }
+
+    if (normalized.jobTitle && isImplausibleManual51jobJobTitle(normalized.jobTitle)) {
+        return true;
+    }
+
+    return false;
+}
+
 function hasStructuredWorkHistory(content: Record<string, unknown>): boolean {
     if (!Array.isArray(content.workHistory)) {
         return false;
@@ -247,7 +285,11 @@ function rewrite51jobManualContent(content: unknown, source: string): {
     const nextContent: Record<string, unknown> = { ...content };
     let changed = false;
 
-    if (!hasStructuredWorkHistory(nextContent) && parsed.workHistory.length > 0) {
+    const existingWorkHistory = Array.isArray(nextContent.workHistory) ? nextContent.workHistory : [];
+    const shouldRepairWorkHistory = !hasStructuredWorkHistory(nextContent)
+        || existingWorkHistory.some((entry) => isManual51jobWorkHistoryEntryMalformed(entry));
+
+    if (shouldRepairWorkHistory && parsed.workHistory.length > 0) {
         nextContent.workHistory = parsed.workHistory;
         changed = true;
     }

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -9,6 +9,7 @@ import {
     normalizeResumeLocationHierarchy,
     normalizeWorkHistoryEntry,
     parse51jobManualResume,
+    shouldPreferManual51jobOptionalField,
 } from "@trends/shared";
 
 import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
@@ -266,11 +267,11 @@ function rewrite51jobManualContent(content: unknown, source: string): {
         changed = true;
     }
 
-    const optionalFields: Array<keyof typeof parsed> = ["jobIntention", "expectedSalary", "experience", "education"];
+    const optionalFields: Array<"jobIntention" | "expectedSalary" | "experience" | "education"> = ["jobIntention", "expectedSalary", "experience", "education"];
     for (const field of optionalFields) {
         const existing = nextContent[field];
         const parsedValue = parsed[field];
-        if ((typeof existing !== "string" || !existing.trim()) && typeof parsedValue === "string" && parsedValue.trim()) {
+        if (shouldPreferManual51jobOptionalField(field, existing, parsedValue)) {
             nextContent[field] = parsedValue;
             changed = true;
         }
@@ -997,7 +998,9 @@ export const backfillManual51jobStructuredContent = mutation({
             }
 
             await ctx.db.patch(resume._id, patch);
-            repairedResumeIds.push(resume._id);
+            if (rewritten.contentChanged) {
+                repairedResumeIds.push(resume._id);
+            }
             updatedResumes += 1;
         }
 

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -5,8 +5,10 @@ import { v } from "convex/values";
 import {
     buildWorkHistoryEvidence,
     formatLocationHierarchyLabel,
+    normalizeJob5156ProfileUrlForDisplay,
     normalizeResumeLocationHierarchy,
     normalizeWorkHistoryEntry,
+    parse51jobManualResume,
 } from "@trends/shared";
 
 import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
@@ -16,67 +18,11 @@ import { DEFAULT_WORKSPACE_SLUG } from "./sessions";
 import { resolveResumeScanBatchSize } from "./resumes";
 
 const JOB5156_HOST = "hr.job5156.com";
-const JOB5156_PROFILE_DISPLAY_PREFIX = `https://${JOB5156_HOST}/resume/view/`;
 const PROFILE_URL_CONTENT_KEYS = ["profileUrl", "profile_url", "profileURL", "url"];
+const MANUAL_51JOB_SOURCE = "51job-manual";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null;
-}
-
-function decodeURIComponentSafe(value: string): string {
-    try {
-        return decodeURIComponent(value);
-    } catch {
-        return value;
-    }
-}
-
-function extractJob5156ResumeId(pathname: string): string | null {
-    const oldRouteMatch = pathname.match(/^\/api\/com\/resume\/([^/?#]+)/i);
-    if (oldRouteMatch && oldRouteMatch[1]) {
-        return decodeURIComponentSafe(oldRouteMatch[1]);
-    }
-
-    const viewRouteMatch = pathname.match(/^\/resume\/view\/([^/?#]+)/i);
-    if (viewRouteMatch && viewRouteMatch[1]) {
-        return decodeURIComponentSafe(viewRouteMatch[1]);
-    }
-
-    return null;
-}
-
-function normalizeJob5156ProfileUrlForDisplay(value: string): string | null {
-    const trimmed = value.trim();
-    if (!trimmed) {
-        return null;
-    }
-
-    const directResumeId = extractJob5156ResumeId(trimmed);
-    if (directResumeId) {
-        return `${JOB5156_PROFILE_DISPLAY_PREFIX}${encodeURIComponent(directResumeId)}`;
-    }
-
-    let parsed: URL | null = null;
-    try {
-        parsed = new URL(trimmed);
-    } catch {
-        try {
-            parsed = new URL(`https://${trimmed}`);
-        } catch {
-            parsed = null;
-        }
-    }
-
-    if (!parsed || parsed.hostname.toLowerCase() !== JOB5156_HOST) {
-        return null;
-    }
-
-    const resumeId = extractJob5156ResumeId(parsed.pathname);
-    if (!resumeId) {
-        return null;
-    }
-
-    return `${JOB5156_PROFILE_DISPLAY_PREFIX}${encodeURIComponent(resumeId)}`;
 }
 
 function rewriteJob5156ProfileUrlsInContent(content: unknown): {
@@ -180,6 +126,186 @@ function toRuleScores(value: unknown): Record<string, number> {
         }
     }
     return scores;
+}
+
+function isManual51jobResumeContent(content: unknown, source: unknown): content is Record<string, unknown> {
+    if (!isRecord(content)) {
+        return false;
+    }
+
+    const normalizedSource = typeof source === "string" ? source.trim().toLowerCase() : "";
+    if (normalizedSource === MANUAL_51JOB_SOURCE) {
+        return true;
+    }
+
+    const profileType = typeof content.profileType === "string" ? content.profileType.trim().toLowerCase() : "";
+    return profileType === MANUAL_51JOB_SOURCE;
+}
+
+function hasStructuredWorkHistory(content: Record<string, unknown>): boolean {
+    if (!Array.isArray(content.workHistory)) {
+        return false;
+    }
+
+    return content.workHistory.some((entry) => {
+        const normalized = normalizeWorkHistoryEntry(entry);
+        return Boolean(normalized && (normalized.companyName || normalized.jobTitle || normalized.description || normalized.startDate || normalized.endDate));
+    });
+}
+
+function locationHierarchySpecificity(value: {
+    province?: string;
+    city?: string;
+    district?: string;
+} | undefined): number {
+    return [value?.province, value?.city, value?.district].filter(Boolean).length;
+}
+
+function shouldReplaceManual51jobName(existing: unknown, parsedName: string | undefined): boolean {
+    const nextName = typeof parsedName === "string" ? parsedName.trim() : "";
+    if (!nextName) {
+        return false;
+    }
+
+    const currentName = typeof existing === "string" ? existing.trim() : "";
+    if (!currentName) {
+        return true;
+    }
+    if (currentName === nextName) {
+        return false;
+    }
+    if (/[_(（）)]/.test(currentName)) {
+        return true;
+    }
+    if (currentName.includes(nextName) && currentName.length > nextName.length) {
+        return true;
+    }
+
+    return false;
+}
+
+function shouldPreferManual51jobLocation(existing: unknown, parsedLocation: string | undefined): boolean {
+    const nextLocation = typeof parsedLocation === "string" ? parsedLocation.trim() : "";
+    if (!nextLocation) {
+        return false;
+    }
+
+    const currentLocation = typeof existing === "string" ? existing.trim() : "";
+    if (!currentLocation) {
+        return true;
+    }
+    if (currentLocation === nextLocation) {
+        return false;
+    }
+
+    const currentHierarchy = normalizeResumeLocationHierarchy({ location: currentLocation });
+    const nextHierarchy = normalizeResumeLocationHierarchy({ location: nextLocation });
+    if (!nextHierarchy) {
+        return false;
+    }
+    if (!currentHierarchy) {
+        return true;
+    }
+
+    return locationHierarchySpecificity(nextHierarchy) > locationHierarchySpecificity(currentHierarchy);
+}
+
+function rewrite51jobManualContent(content: unknown, source: string): {
+    content: Record<string, unknown> | null;
+    contentChanged: boolean;
+    evidenceText: string;
+} {
+    if (!isManual51jobResumeContent(content, source)) {
+        return {
+            content: null,
+            contentChanged: false,
+            evidenceText: "",
+        };
+    }
+
+    const rawText = typeof content.resumeSnippet === "string"
+        ? content.resumeSnippet.trim()
+        : isRecord(content.resumeSnippet) && typeof content.resumeSnippet.text === "string"
+            ? content.resumeSnippet.text.trim()
+            : typeof content.selfIntro === "string"
+                ? content.selfIntro.trim()
+                : "";
+    if (!rawText) {
+        return {
+            content: null,
+            contentChanged: false,
+            evidenceText: "",
+        };
+    }
+
+    const parsed = parse51jobManualResume({
+        text: rawText,
+        fallbackName: typeof content.name === "string" ? content.name.trim() : undefined,
+        fallbackProfileId: typeof content.profileId === "string" ? content.profileId.trim() : undefined,
+    });
+    const nextContent: Record<string, unknown> = { ...content };
+    let changed = false;
+
+    if (!hasStructuredWorkHistory(nextContent) && parsed.workHistory.length > 0) {
+        nextContent.workHistory = parsed.workHistory;
+        changed = true;
+    }
+
+    if (!Array.isArray(nextContent.profileEducation) && parsed.profileEducation && parsed.profileEducation.length > 0) {
+        nextContent.profileEducation = parsed.profileEducation;
+        changed = true;
+    }
+
+    if (shouldReplaceManual51jobName(nextContent.name, parsed.name)) {
+        nextContent.name = parsed.name;
+        changed = true;
+    }
+
+    if (shouldPreferManual51jobLocation(nextContent.location, parsed.location)) {
+        nextContent.location = parsed.location;
+        changed = true;
+    }
+
+    const optionalFields: Array<keyof typeof parsed> = ["jobIntention", "expectedSalary", "experience", "education"];
+    for (const field of optionalFields) {
+        const existing = nextContent[field];
+        const parsedValue = parsed[field];
+        if ((typeof existing !== "string" || !existing.trim()) && typeof parsedValue === "string" && parsedValue.trim()) {
+            nextContent[field] = parsedValue;
+            changed = true;
+        }
+    }
+
+    const existingSelfIntro = typeof nextContent.selfIntro === "string" ? nextContent.selfIntro.trim() : "";
+    if (!existingSelfIntro) {
+        if (parsed.selfIntro) {
+            nextContent.selfIntro = parsed.selfIntro;
+            changed = true;
+        }
+    } else if (existingSelfIntro === rawText) {
+        if (parsed.selfIntro) {
+            nextContent.selfIntro = parsed.selfIntro;
+        } else {
+            delete nextContent.selfIntro;
+        }
+        changed = true;
+    }
+
+    if (
+        (!isRecord(nextContent.resumeSnippet) || typeof nextContent.resumeSnippet.text !== "string" || !nextContent.resumeSnippet.text.trim())
+        && parsed.resumeSnippet.text
+    ) {
+        nextContent.resumeSnippet = parsed.resumeSnippet;
+        changed = true;
+    }
+
+    const rewrittenContent = changed ? nextContent : content;
+
+    return {
+        content: rewrittenContent,
+        contentChanged: changed,
+        evidenceText: buildWorkHistoryEvidence(rewrittenContent).text,
+    };
 }
 
 function analysisRichness(resume: Doc<"resumes">): number {
@@ -802,6 +928,97 @@ export const backfillJob5156LocationHierarchy = mutation({
             updatedLocationHierarchy,
             updatedLocation,
             updatedSearchText,
+            hasMore: !resumes.isDone,
+            cursor: resumes.isDone ? null : resumes.continueCursor,
+        };
+    },
+});
+
+export const backfillManual51jobStructuredContent = mutation({
+    args: {
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const resumes = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.batchSize),
+            });
+
+        let updatedResumes = 0;
+        let updatedEvidenceText = 0;
+        let updatedSearchText = 0;
+        const repairedResumeIds: Id<"resumes">[] = [];
+
+        for (const resume of resumes.page) {
+            const rewritten = rewrite51jobManualContent(resume.content, resume.source);
+            if (!rewritten.content) {
+                continue;
+            }
+
+            const searchText = mergeSearchTextWithIngestData(
+                buildSearchText(rewritten.content),
+                {
+                    industryTags: resume.ingestData?.industryTags,
+                    synonymHits: resume.ingestData?.synonymHits,
+                    brandHits: resume.ingestData?.brandHits,
+                    companyHits: resume.ingestData?.companyHits,
+                }
+            );
+
+            const patch: {
+                content?: Record<string, unknown>;
+                searchText?: string;
+                ingestData?: Doc<"resumes">["ingestData"];
+            } = {};
+
+            if (rewritten.contentChanged) {
+                patch.content = rewritten.content;
+            }
+
+            if (searchText !== resume.searchText) {
+                patch.searchText = searchText;
+                updatedSearchText += 1;
+            }
+
+            if (resume.ingestData && rewritten.evidenceText !== resume.ingestData.evidenceText) {
+                patch.ingestData = {
+                    ...resume.ingestData,
+                    evidenceText: rewritten.evidenceText,
+                };
+                updatedEvidenceText += 1;
+            }
+
+            if (Object.keys(patch).length === 0) {
+                continue;
+            }
+
+            await ctx.db.patch(resume._id, patch);
+            repairedResumeIds.push(resume._id);
+            updatedResumes += 1;
+        }
+
+        let scheduledReingest = 0;
+        let batches = 0;
+        for (let index = 0; index < repairedResumeIds.length; index += 50) {
+            const chunk = repairedResumeIds.slice(index, index + 50);
+            await ctx.scheduler.runAfter(0, internal.ingest_agent.processNewResumes, {
+                resumeIds: chunk,
+            });
+            scheduledReingest += chunk.length;
+            batches += 1;
+        }
+
+        return {
+            scannedResumes: resumes.page.length,
+            updatedResumes,
+            updatedEvidenceText,
+            updatedSearchText,
+            scheduledReingest,
+            batches,
             hasMore: !resumes.isDone,
             cursor: resumes.isDone ? null : resumes.continueCursor,
         };

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -149,7 +149,7 @@ function hasStructuredWorkHistory(content: Record<string, unknown>): boolean {
 
     return content.workHistory.some((entry) => {
         const normalized = normalizeWorkHistoryEntry(entry);
-        return Boolean(normalized && (normalized.companyName || normalized.jobTitle || normalized.description || normalized.startDate || normalized.endDate));
+        return Boolean(normalized && normalized.companyName && (normalized.jobTitle || normalized.description || normalized.startDate || normalized.endDate));
     });
 }
 

--- a/packages/shared/src/__tests__/resume-normalization.manual51job.test.ts
+++ b/packages/shared/src/__tests__/resume-normalization.manual51job.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { parse51jobManualResume } from "../resume-normalization";
+
+describe("resume-normalization manual 51job", () => {
+  it("does not promote narrative fragments into companyName", () => {
+    const text = [
+      "王先生",
+      "工作经历",
+      "2018.05 - 2020.11（2年6个月）",
+      "职位：销售代表",
+      "工作描述：",
+      "在该公司主要负责以电话开发客户，然后通过线上交流沟通，线下上门拜访客户的方式来完成与客户的合作。",
+      "长沙冠聚信息技术有限公司",
+      "2017.06 - 2018.01（7个月）",
+      "职位：电话销售",
+      "工作描述：通过公司提供的客户资源进行电话联系，开发意向客户。",
+    ].join("\n");
+
+    const parsed = parse51jobManualResume({ text });
+
+    expect(parsed.workHistory).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        companyName: "长沙冠聚信息技术有限公司",
+        jobTitle: "销售代表",
+        startDate: "2018-05",
+        endDate: "2020-11",
+      }),
+      expect.objectContaining({
+        jobTitle: "电话销售",
+        startDate: "2017-06",
+        endDate: "2018-01",
+      }),
+    ]));
+
+    expect(parsed.workHistory.some((entry) => entry.companyName === "在该公司")).toBe(false);
+    expect(parsed.workHistory.some((entry) => entry.companyName === "通过公司")).toBe(false);
+  });
+
+  it("does not treat duration lines as job titles or generic nouns as companies", () => {
+    const text = [
+      "工作经历",
+      "加工中心 2025.05-2025.07（2个月）",
+      "2022.01-2025.04（3年3个月）",
+    ].join("\n");
+
+    const parsed = parse51jobManualResume({ text });
+
+    expect(parsed.workHistory.some((entry) => entry.companyName === "加工中心")).toBe(false);
+    expect(parsed.workHistory.some((entry) => entry.jobTitle === "2025.05-2025.07 2个月")).toBe(false);
+    expect(parsed.workHistory.some((entry) => typeof entry.jobTitle === "string" && /\d{4}/u.test(entry.jobTitle))).toBe(false);
+  });
+});

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -562,10 +562,13 @@ export type Parsed51jobManualResume = {
   resumeSnippet: ResumeSnippet;
 };
 
+export type Manual51jobOptionalField = "jobIntention" | "expectedSalary" | "experience" | "education";
+
 const MANUAL_51JOB_NAME_LABELS = ["姓名", "名称"] as const;
 const MANUAL_51JOB_PROFILE_ID_LABELS = ["人才ID", "简历编号", "ID"] as const;
 const MANUAL_51JOB_LOCATION_LABELS = ["区域", "现居住地", "现居住", "所在地", "所在地区"] as const;
-const MANUAL_51JOB_JOB_INTENTION_LABELS = ["应聘方向", "应聘职位", "求职意向", "期望职位", "意向职位"] as const;
+const MANUAL_51JOB_JOB_INTENTION_LABELS = ["应聘方向", "应聘职位", "期望职位", "意向职位"] as const;
+const MANUAL_51JOB_PREFERRED_JOB_INTENTION_LABELS = ["求职意向"] as const;
 const MANUAL_51JOB_SALARY_LABELS = ["期望薪资", "薪资要求", "期望工资", "期望月薪", "期望年薪"] as const;
 const MANUAL_51JOB_EXPERIENCE_LABELS = ["工作经验", "工作年限", "从业年限", "经验"] as const;
 const MANUAL_51JOB_EDUCATION_LABELS = ["最高学历学位", "最高学历", "学历"] as const;
@@ -631,10 +634,33 @@ const MANUAL_51JOB_TERMINAL_SECTION_HEADER_PATTERNS = [
   /^证书$/u,
   /^声明$/u,
 ] as const;
+const MANUAL_51JOB_UNREADABLE_CONTROL_CHARACTER_PATTERN = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/gu;
+const MANUAL_51JOB_PAGE_MARKER_ONLY_PATTERN = /^--\s*\d+\s+of\s+\d+\s*--$/iu;
+const MANUAL_51JOB_TEXT_SIGNAL_PATTERNS = [
+  /人才ID/u,
+  /求职意向/u,
+  /工作经历/u,
+  /教育经历/u,
+  /现居/u,
+  /应聘(?:方向|职位)/u,
+  /\d{4}[.-]\d{1,2}\s*[-~至]/u,
+] as const;
 const MANUAL_51JOB_INLINE_EXPERIENCE_PATTERN = /(\d+(?:\.\d+)?年(?:\d+个月)?(?:工作经验|经验))/u;
 const MANUAL_51JOB_INLINE_SALARY_PATTERNS = [
   /(面议|\d+(?:\.\d+)?(?:千|万)(?:[-~到至]\d+(?:\.\d+)?(?:千|万))?(?:\/(?:月|年))?)/u,
   /(面议|\d+(?:\.\d+)?(?:[-~到至]\d+(?:\.\d+)?)(?:千|万)(?:\/(?:月|年))?)/u,
+  /(面议|\d{3,5}(?:[-~到至]\d{3,5})?(?:元)?\/(?:月|年))/u,
+] as const;
+const MANUAL_51JOB_INLINE_LOCATION_EXCLUSION_PATTERN = /^(?:男|女|已婚|未婚|离异|普通公民|群众|中共.*|共青团员|党员|本科|大专|专科|高中|硕士|博士|在职.*|离职.*|随时到岗|一个月内到岗)$/u;
+const MANUAL_51JOB_SUMMARY_PRIMARY_LINE_EXCLUDED_LABELS = [
+  ...MANUAL_51JOB_NAME_LABELS,
+  ...MANUAL_51JOB_PROFILE_ID_LABELS,
+  ...MANUAL_51JOB_LOCATION_LABELS,
+  ...MANUAL_51JOB_PREFERRED_JOB_INTENTION_LABELS,
+  ...MANUAL_51JOB_JOB_INTENTION_LABELS,
+  ...MANUAL_51JOB_SALARY_LABELS,
+  ...MANUAL_51JOB_EXPERIENCE_LABELS,
+  ...MANUAL_51JOB_EDUCATION_LABELS,
 ] as const;
 const MANUAL_51JOB_LABEL_PATTERN_CACHE = new Map<string, RegExp>();
 
@@ -661,6 +687,74 @@ function normalizeManual51jobText(value: string): string {
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
+}
+
+export function stripManual51jobUnreadableControlCharacters(value: string): string {
+  return value.replace(MANUAL_51JOB_UNREADABLE_CONTROL_CHARACTER_PATTERN, "");
+}
+
+export function hasReadableManual51jobText(value: string): boolean {
+  const normalized = normalizeManual51jobText(stripManual51jobUnreadableControlCharacters(value));
+  if (!normalized) {
+    return false;
+  }
+  if (MANUAL_51JOB_PAGE_MARKER_ONLY_PATTERN.test(normalized)) {
+    return false;
+  }
+
+  return MANUAL_51JOB_TEXT_SIGNAL_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function shouldPreferManual51jobOptionalField(
+  field: Manual51jobOptionalField,
+  existing: unknown,
+  parsedValue: unknown,
+): boolean {
+  const nextValue = typeof parsedValue === "string" ? parsedValue.trim() : "";
+  if (!nextValue) {
+    return false;
+  }
+
+  const currentValue = typeof existing === "string" ? existing.trim() : "";
+  if (!currentValue) {
+    return true;
+  }
+  if (currentValue === nextValue) {
+    return false;
+  }
+
+  if (field === "expectedSalary") {
+    const currentLooksSuspicious = /(销售额|业绩)/u.test(currentValue)
+      || (!/(?:\/(?:月|年)|面议)/u.test(currentValue) && /万/u.test(currentValue));
+    const nextLooksStructured = /(?:\/(?:月|年)|面议)/u.test(nextValue);
+    if (currentLooksSuspicious && nextLooksStructured) {
+      return true;
+    }
+  }
+
+  if (field === "jobIntention") {
+    const currentParts = currentValue.split(/\s+/u).filter(Boolean);
+    const nextParts = nextValue.split(/\s+/u).filter(Boolean);
+    if (currentParts.length < nextParts.length) {
+      return true;
+    }
+  }
+
+  if (field === "experience") {
+    if (!/工作经验|经验/u.test(currentValue) && /工作经验|经验/u.test(nextValue)) {
+      return true;
+    }
+  }
+
+  if (field === "education") {
+    const currentLooksLikeQualification = /博士|硕士|本科|大专|专科|中专|中技|高中/u.test(currentValue);
+    const nextLooksLikeQualification = /博士|硕士|本科|大专|专科|中专|中技|高中/u.test(nextValue);
+    if (!currentLooksLikeQualification && nextLooksLikeQualification) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function normalizeManual51jobLine(value: string): string {
@@ -769,6 +863,9 @@ function pickManual51jobPrimaryLine(lines: readonly string[]): string | undefine
       if (resolveManual51jobSectionHeader(line) || isManual51jobTerminalSectionHeader(line)) {
         return false;
       }
+      if (getManual51jobLabeledLineValue(line, MANUAL_51JOB_SUMMARY_PRIMARY_LINE_EXCLUDED_LABELS) !== undefined) {
+        return false;
+      }
       if (/^\//.test(line) || /^--\s*\d+\s+of\s+\d+\s*--$/i.test(line)) {
         return false;
       }
@@ -798,14 +895,36 @@ function inferManual51jobSummaryExperience(lines: readonly string[]): string | u
   return undefined;
 }
 
+function inferManual51jobSalary(value: string | undefined): string | undefined {
+  const normalized = normalizeManual51jobLine(value || "");
+  if (!normalized) {
+    return undefined;
+  }
+
+  const matches = MANUAL_51JOB_INLINE_SALARY_PATTERNS
+    .map((pattern) => normalized.match(pattern)?.[1]?.trim())
+    .filter((match): match is string => Boolean(match));
+  if (matches.length === 0) {
+    return undefined;
+  }
+
+  matches.sort((left, right) => {
+    const rangeDiff = Number(right.includes("-") || right.includes("~") || right.includes("到") || right.includes("至"))
+      - Number(left.includes("-") || left.includes("~") || left.includes("到") || left.includes("至"));
+    if (rangeDiff !== 0) {
+      return rangeDiff;
+    }
+    return right.length - left.length;
+  });
+
+  return matches[0];
+}
+
 function inferManual51jobSummarySalary(lines: readonly string[]): string | undefined {
   for (const line of lines) {
-    const normalized = normalizeManual51jobLine(line);
-    for (const pattern of MANUAL_51JOB_INLINE_SALARY_PATTERNS) {
-      const match = normalized.match(pattern);
-      if (match?.[1]) {
-        return match[1];
-      }
+    const salary = inferManual51jobSalary(line);
+    if (salary) {
+      return salary;
     }
   }
   return undefined;
@@ -822,32 +941,69 @@ function splitManual51jobSummarySegments(value: string | undefined): string[] {
 }
 
 function resolveManual51jobJobIntentionLine(lines: readonly string[]): string | undefined {
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] || "";
-    const value = getManual51jobLabeledLineValue(line, MANUAL_51JOB_JOB_INTENTION_LABELS);
-    if (value === undefined) {
-      continue;
-    }
-    if (value) {
-      return value;
-    }
+  const labelGroups = [MANUAL_51JOB_PREFERRED_JOB_INTENTION_LABELS, MANUAL_51JOB_JOB_INTENTION_LABELS] as const;
 
-    return getManual51jobFollowingLine(lines, index, {
-      skip: (nextLine) => /^求职偏好/.test(nextLine),
-    });
+  for (const labels of labelGroups) {
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index] || "";
+      const value = getManual51jobLabeledLineValue(line, labels);
+      if (value === undefined) {
+        continue;
+      }
+      if (value) {
+        return value;
+      }
+
+      return getManual51jobFollowingLine(lines, index, {
+        skip: (nextLine) => /^求职偏好/.test(nextLine),
+      });
+    }
   }
 
   return undefined;
 }
 
 function inferManual51jobInlineLocation(text: string): string | undefined {
-  const match = text.match(/现居(?:住地|住)?[·:：]?\s*([^\n｜|]{1,40})/u);
-  if (!match?.[1]) {
-    return undefined;
+  const explicitMatch = text.match(/现居(?:住地|住)?[·:：]?\s*([^\n\t｜|]{1,40})/u);
+  if (explicitMatch?.[1]) {
+    const location = normalizeManual51jobLine(explicitMatch[1]);
+    if (location) {
+      return location;
+    }
   }
 
-  const location = normalizeManual51jobLine(match[1]);
-  return location || undefined;
+  const lines = splitManual51jobLines(text);
+  const preferredHeaderIndex = lines.findIndex((line) => /(?:^|\s)(?:男|女)\s*[｜|丨]/u.test(line) && MANUAL_51JOB_INLINE_EXPERIENCE_PATTERN.test(line));
+  const candidateLines = preferredHeaderIndex >= 0
+    ? [lines[preferredHeaderIndex] || ""]
+    : lines.slice(0, 12);
+
+  for (const line of candidateLines) {
+    const segments = splitManual51jobSummarySegments(line);
+    for (const segment of segments) {
+      if (!segment || MANUAL_51JOB_INLINE_LOCATION_EXCLUSION_PATTERN.test(segment)) {
+        continue;
+      }
+      if (MANUAL_51JOB_INLINE_EXPERIENCE_PATTERN.test(segment)) {
+        continue;
+      }
+      if (MANUAL_51JOB_INLINE_SALARY_PATTERNS.some((pattern) => pattern.test(segment))) {
+        continue;
+      }
+      if (/\d{11}|@|活跃时间|人才ID|求职意向|工作经历|教育经历/u.test(segment)) {
+        continue;
+      }
+      if (/[（(].*[）)]/.test(segment)) {
+        continue;
+      }
+      const hierarchy = normalizeLocationTreeHierarchy(segment);
+      if (hierarchy) {
+        return normalizeManual51jobLine(segment);
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function resolveManual51jobSectionHeader(line: string): { key: Manual51jobSectionKey; remainder?: string } | null {
@@ -1419,19 +1575,23 @@ export function parse51jobManualResume(args: {
     || inferManual51jobResumeName(lines, args.entryPath)
     || args.fallbackName;
   const profileId = inferManual51jobProfileId(lines, args.entryPath) || args.fallbackProfileId;
+  const inlineLocation = inferManual51jobInlineLocation(text);
   const location = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_LOCATION_LABELS)
-    || inferManual51jobInlineLocation(text);
+    || inlineLocation;
   const primaryJobIntention = resolveManual51jobJobIntentionLine(lines);
   const primaryExpectedSalary = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_SALARY_LABELS);
   const primaryExperience = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_EXPERIENCE_LABELS);
+  const primaryJobIntentionSalary = inferManual51jobSalary(primaryJobIntention);
   const summaryPrimaryLine = pickManual51jobPrimaryLine(summaryLines);
   const summarySegments = splitManual51jobSummarySegments(summaryPrimaryLine);
+  const summarySalary = inferManual51jobSummarySalary(summaryLines);
+  const summarySegmentSalary = summarySegments.find((segment) => MANUAL_51JOB_INLINE_SALARY_PATTERNS.some((pattern) => pattern.test(segment)));
   const jobIntention = primaryJobIntention
     || summarySegments.find((segment) => !MANUAL_51JOB_INLINE_SALARY_PATTERNS.some((pattern) => pattern.test(segment)));
   const expectedSalary = primaryExpectedSalary
-    || inferManual51jobSummarySalary(summaryLines)
-    || splitManual51jobSummarySegments(primaryJobIntention).find((segment) => MANUAL_51JOB_INLINE_SALARY_PATTERNS.some((pattern) => pattern.test(segment)))
-    || summarySegments.find((segment) => MANUAL_51JOB_INLINE_SALARY_PATTERNS.some((pattern) => pattern.test(segment)));
+    || primaryJobIntentionSalary
+    || summarySegmentSalary
+    || summarySalary;
   const experience = primaryExperience || inferManual51jobSummaryExperience(summaryLines);
   const education = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_EDUCATION_LABELS)
     || pickManual51jobEducation(profileEducation)

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -565,7 +565,7 @@ export type Parsed51jobManualResume = {
 const MANUAL_51JOB_NAME_LABELS = ["姓名", "名称"] as const;
 const MANUAL_51JOB_PROFILE_ID_LABELS = ["人才ID", "简历编号", "ID"] as const;
 const MANUAL_51JOB_LOCATION_LABELS = ["区域", "现居住地", "现居住", "所在地", "所在地区"] as const;
-const MANUAL_51JOB_JOB_INTENTION_LABELS = ["应聘方向", "求职意向", "期望职位", "意向职位"] as const;
+const MANUAL_51JOB_JOB_INTENTION_LABELS = ["应聘方向", "应聘职位", "求职意向", "期望职位", "意向职位"] as const;
 const MANUAL_51JOB_SALARY_LABELS = ["期望薪资", "薪资要求", "期望工资", "期望月薪", "期望年薪"] as const;
 const MANUAL_51JOB_EXPERIENCE_LABELS = ["工作经验", "工作年限", "从业年限", "经验"] as const;
 const MANUAL_51JOB_EDUCATION_LABELS = ["最高学历学位", "最高学历", "学历"] as const;
@@ -624,6 +624,18 @@ const MANUAL_51JOB_EDUCATION_RANK: Record<string, number> = {
   博士: 5,
   博士研究生: 5,
 };
+const MANUAL_51JOB_TERMINAL_SECTION_HEADER_PATTERNS = [
+  /^技能\s*\/\s*语言$/u,
+  /^技能(?:特长)?$/u,
+  /^语言(?:能力)?$/u,
+  /^证书$/u,
+  /^声明$/u,
+] as const;
+const MANUAL_51JOB_INLINE_EXPERIENCE_PATTERN = /(\d+(?:\.\d+)?年(?:\d+个月)?(?:工作经验|经验))/u;
+const MANUAL_51JOB_INLINE_SALARY_PATTERNS = [
+  /(面议|\d+(?:\.\d+)?(?:千|万)(?:[-~到至]\d+(?:\.\d+)?(?:千|万))?(?:\/(?:月|年))?)/u,
+  /(面议|\d+(?:\.\d+)?(?:[-~到至]\d+(?:\.\d+)?)(?:千|万)(?:\/(?:月|年))?)/u,
+] as const;
 const MANUAL_51JOB_LABEL_PATTERN_CACHE = new Map<string, RegExp>();
 
 function escapeManual51jobRegExp(value: string): string {
@@ -683,6 +695,28 @@ function splitManual51jobLines(text: string): string[] {
   return text.split("\n").map((line) => normalizeManual51jobLine(line));
 }
 
+function getManual51jobFollowingLine(
+  lines: readonly string[],
+  startIndex: number,
+  options?: { skip?: (line: string) => boolean },
+): string | undefined {
+  for (let nextIndex = startIndex + 1; nextIndex < lines.length; nextIndex += 1) {
+    const nextLine = lines[nextIndex] || "";
+    if (!nextLine) {
+      continue;
+    }
+    if (resolveManual51jobSectionHeader(nextLine)) {
+      break;
+    }
+    if (options?.skip?.(nextLine)) {
+      continue;
+    }
+    return nextLine;
+  }
+
+  return undefined;
+}
+
 function getManual51jobFieldValueFromLines(lines: readonly string[], labels: readonly string[]): string | undefined {
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] || "";
@@ -694,16 +728,113 @@ function getManual51jobFieldValueFromLines(lines: readonly string[], labels: rea
       return value;
     }
 
-    for (let nextIndex = index + 1; nextIndex < lines.length; nextIndex += 1) {
-      const nextLine = lines[nextIndex] || "";
-      if (!nextLine) {
-        continue;
-      }
-      if (resolveManual51jobSectionHeader(nextLine)) {
-        break;
-      }
-      return nextLine;
+    return getManual51jobFollowingLine(lines, index);
+  }
+
+  return undefined;
+}
+
+function getManual51jobSectionStartIndex(lines: readonly string[], key: Manual51jobSectionKey): number {
+  for (let index = 0; index < lines.length; index += 1) {
+    const sectionHeader = resolveManual51jobSectionHeader(lines[index] || "");
+    if (sectionHeader?.key === key) {
+      return index;
     }
+  }
+  return -1;
+}
+
+function getManual51jobSummaryLines(lines: readonly string[]): string[] {
+  const workHistoryIndex = getManual51jobSectionStartIndex(lines, "workHistory");
+  const cutoff = workHistoryIndex >= 0 ? workHistoryIndex : Math.min(lines.length, 40);
+  return lines.slice(0, cutoff).filter(Boolean);
+}
+
+function isManual51jobTerminalSectionHeader(line: string): boolean {
+  const normalized = normalizeManual51jobLine(line).replace(/[：:]$/u, "");
+  if (!normalized) {
+    return false;
+  }
+
+  return MANUAL_51JOB_TERMINAL_SECTION_HEADER_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function pickManual51jobPrimaryLine(lines: readonly string[]): string | undefined {
+  const candidates = lines
+    .map((line) => normalizeManual51jobLine(line))
+    .filter((line) => {
+      if (!line) {
+        return false;
+      }
+      if (resolveManual51jobSectionHeader(line) || isManual51jobTerminalSectionHeader(line)) {
+        return false;
+      }
+      if (/^\//.test(line) || /^--\s*\d+\s+of\s+\d+\s*--$/i.test(line)) {
+        return false;
+      }
+      if (/^(声明|聊|天|该人才偏好电话)/.test(line)) {
+        return false;
+      }
+      if (/找工作|到岗/u.test(line)) {
+        return false;
+      }
+      if (isLikelyManual51jobResumeName(line)) {
+        return false;
+      }
+      return true;
+    });
+
+  return candidates.find((line) => MANUAL_51JOB_INLINE_SALARY_PATTERNS.some((pattern) => pattern.test(line)))
+    || candidates[0];
+}
+
+function inferManual51jobSummaryExperience(lines: readonly string[]): string | undefined {
+  for (const line of lines) {
+    const match = normalizeManual51jobLine(line).match(MANUAL_51JOB_INLINE_EXPERIENCE_PATTERN);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return undefined;
+}
+
+function inferManual51jobSummarySalary(lines: readonly string[]): string | undefined {
+  for (const line of lines) {
+    const normalized = normalizeManual51jobLine(line);
+    for (const pattern of MANUAL_51JOB_INLINE_SALARY_PATTERNS) {
+      const match = normalized.match(pattern);
+      if (match?.[1]) {
+        return match[1];
+      }
+    }
+  }
+  return undefined;
+}
+
+function splitManual51jobSummarySegments(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(/[\t｜|丨]+/)
+    .map((segment) => normalizeManual51jobLine(segment))
+    .filter(Boolean);
+}
+
+function resolveManual51jobJobIntentionLine(lines: readonly string[]): string | undefined {
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] || "";
+    const value = getManual51jobLabeledLineValue(line, MANUAL_51JOB_JOB_INTENTION_LABELS);
+    if (value === undefined) {
+      continue;
+    }
+    if (value) {
+      return value;
+    }
+
+    return getManual51jobFollowingLine(lines, index, {
+      skip: (nextLine) => /^求职偏好/.test(nextLine),
+    });
   }
 
   return undefined;
@@ -775,7 +906,11 @@ function getManual51jobSectionText(
   if (!lines || lines.length === 0) {
     return undefined;
   }
-  const normalized = normalizeManual51jobText(lines.join("\n"));
+  const filteredLines = lines.filter((line) => !isManual51jobTerminalSectionHeader(line));
+  if (filteredLines.length === 0) {
+    return undefined;
+  }
+  const normalized = normalizeManual51jobText(filteredLines.join("\n"));
   return normalized || undefined;
 }
 
@@ -796,6 +931,11 @@ function normalizeManual51jobDate(value: string): string {
     .replace(/\s+/g, "")
     .replace(/-{2,}/g, "-")
     .replace(/^-|-$/g, "");
+}
+
+function resolveManual51jobPrimaryDateLine(lines: readonly string[], fallback: string): string {
+  const dateLineIndex = lines.findIndex((line) => MANUAL_51JOB_TIMELINE_START_PATTERN.test(line));
+  return dateLineIndex >= 0 ? (lines[dateLineIndex] || "") : fallback;
 }
 
 function extractManual51jobDateRange(text: string): {
@@ -832,11 +972,17 @@ function splitManual51jobBlocks(text: string): string[] {
     if (!line) {
       continue;
     }
+    if (isManual51jobTerminalSectionHeader(line)) {
+      break;
+    }
 
     if (MANUAL_51JOB_TIMELINE_START_PATTERN.test(line) && current.length > 0) {
-      blocks.push(current.join("\n"));
-      current = [line];
-      continue;
+      const currentHasTimeline = current.some((entry) => MANUAL_51JOB_TIMELINE_START_PATTERN.test(entry));
+      if (currentHasTimeline) {
+        blocks.push(current.join("\n"));
+        current = [line];
+        continue;
+      }
     }
 
     current.push(line);
@@ -849,7 +995,43 @@ function splitManual51jobBlocks(text: string): string[] {
   return blocks;
 }
 
-function getManual51jobDescriptionLines(lines: string[]): string[] {
+function hasManual51jobTimelineLine(block: string): boolean {
+  return block.split("\n").some((line) => MANUAL_51JOB_TIMELINE_START_PATTERN.test(normalizeManual51jobLine(line)));
+}
+
+function mergeManual51jobLeadingIdentityBlocks(
+  blocks: string[],
+  resolveIdentity: (line: string) => string | undefined,
+): string[] {
+  const merged: string[] = [];
+
+  for (let index = 0; index < blocks.length; index += 1) {
+    const currentBlock = blocks[index] || "";
+    const currentLines = currentBlock.split("\n").map((line) => normalizeManual51jobLine(line)).filter(Boolean);
+    const nextBlock = blocks[index + 1] || "";
+    if (
+      currentLines.length === 1
+      && !hasManual51jobTimelineLine(currentBlock)
+      && resolveIdentity(currentLines[0] || "")
+      && nextBlock
+      && hasManual51jobTimelineLine(nextBlock)
+    ) {
+      merged.push(`${currentLines[0]}\n${nextBlock}`);
+      index += 1;
+      continue;
+    }
+
+    merged.push(currentBlock);
+  }
+
+  return merged;
+}
+
+function getManual51jobDescriptionLines(
+  lines: string[],
+  companyName?: string,
+  jobTitle?: string,
+): string[] {
   const descriptionLines: string[] = [];
 
   for (let index = 1; index < lines.length; index += 1) {
@@ -869,11 +1051,20 @@ function getManual51jobDescriptionLines(lines: string[]): string[] {
     if (
       getManual51jobLabeledLineValue(line, MANUAL_51JOB_WORK_COMPANY_LABELS) !== undefined
       || getManual51jobLabeledLineValue(line, MANUAL_51JOB_WORK_JOB_TITLE_LABELS) !== undefined
+      || MANUAL_51JOB_TIMELINE_START_PATTERN.test(line)
     ) {
       continue;
     }
 
     if (MANUAL_51JOB_SECTION_HEADER_SET.has(line)) {
+      continue;
+    }
+
+    if (companyName && extractManual51jobCompany(line) === companyName) {
+      continue;
+    }
+
+    if (jobTitle && cleanManual51jobRemainder(line) === jobTitle) {
       continue;
     }
 
@@ -920,13 +1111,51 @@ function parseManual51jobWorkHistoryBlock(block: string): ResumeWorkHistoryItem 
 
   const raw = lines.join("\n");
   const headerLine = lines[0] || "";
-  const dateRange = extractManual51jobDateRange(headerLine || raw);
+  const dateLineIndex = lines.findIndex((line) => MANUAL_51JOB_TIMELINE_START_PATTERN.test(line));
+  const dateRange = extractManual51jobDateRange(resolveManual51jobPrimaryDateLine(lines, headerLine) || raw);
   const companyFromLabel = lines
     .map((line) => getManual51jobLabeledLineValue(line, MANUAL_51JOB_WORK_COMPANY_LABELS))
     .find((value): value is string => Boolean(value));
   const jobTitleFromLabel = lines
     .map((line) => getManual51jobLabeledLineValue(line, MANUAL_51JOB_WORK_JOB_TITLE_LABELS))
     .find((value): value is string => Boolean(value));
+
+  const companyCandidateLines: string[] = [];
+  let companyCandidate: string | undefined;
+  let companyLineForCandidate: string | undefined;
+  let roleLineCandidate: string | undefined;
+
+  for (const [index, line] of lines.entries()) {
+    if (index === dateLineIndex) {
+      continue;
+    }
+    if (getManual51jobLabeledLineValue(line, MANUAL_51JOB_WORK_COMPANY_LABELS) !== undefined) {
+      continue;
+    }
+    if (getManual51jobLabeledLineValue(line, MANUAL_51JOB_WORK_JOB_TITLE_LABELS) !== undefined) {
+      continue;
+    }
+    if (getManual51jobLabeledLineValue(line, MANUAL_51JOB_WORK_DESCRIPTION_LABELS) !== undefined) {
+      continue;
+    }
+    if (MANUAL_51JOB_SECTION_HEADER_SET.has(line) || isManual51jobTerminalSectionHeader(line)) {
+      continue;
+    }
+
+    companyCandidateLines.push(line);
+
+    if (!companyCandidate) {
+      const extractedCompany = extractManual51jobCompany(line);
+      if (extractedCompany && !/[中心]$/.test(extractedCompany)) {
+        companyCandidate = extractedCompany;
+        companyLineForCandidate = line;
+      }
+    }
+
+    if (!roleLineCandidate && line !== headerLine && !extractManual51jobCompany(line) && !MANUAL_51JOB_TIMELINE_START_PATTERN.test(line) && !/[｜|丨]/.test(line)) {
+      roleLineCandidate = line;
+    }
+  }
 
   let titleLine = headerLine;
   if (dateRange.matchedText) {
@@ -936,8 +1165,19 @@ function parseManual51jobWorkHistoryBlock(block: string): ResumeWorkHistoryItem 
     titleLine = lines[1] || "";
   }
 
-  const companyName = companyFromLabel || extractManual51jobCompany(titleLine);
+  const companyName = companyFromLabel || companyCandidate || extractManual51jobCompany(titleLine);
   const jobTitle = jobTitleFromLabel || (() => {
+    if (companyName && companyLineForCandidate?.includes(companyName)) {
+      const remainder = cleanManual51jobRemainder(companyLineForCandidate.replace(companyName, " "));
+      if (remainder && remainder.length <= 40) {
+        return remainder;
+      }
+    }
+
+    if (roleLineCandidate && roleLineCandidate.length <= 40) {
+      return roleLineCandidate;
+    }
+
     if (!companyName) {
       return undefined;
     }
@@ -947,7 +1187,7 @@ function parseManual51jobWorkHistoryBlock(block: string): ResumeWorkHistoryItem 
     }
     return remainder;
   })();
-  const description = cleanManual51jobRemainder(getManual51jobDescriptionLines(lines).join("\n"));
+  const description = cleanManual51jobRemainder(getManual51jobDescriptionLines(lines, companyName, jobTitle).join("\n"));
 
   if (!raw && !companyName && !jobTitle && !description && !dateRange.startDate && !dateRange.endDate) {
     return null;
@@ -968,7 +1208,7 @@ function getManual51jobWorkHistory(text: string | undefined): ResumeWorkHistoryI
     return [];
   }
 
-  return splitManual51jobBlocks(text)
+  return mergeManual51jobLeadingIdentityBlocks(splitManual51jobBlocks(text), extractManual51jobCompany)
     .map((block) => parseManual51jobWorkHistoryBlock(block))
     .filter((entry): entry is ResumeWorkHistoryItem => entry !== null);
 }
@@ -983,7 +1223,8 @@ function parseManual51jobEducationBlock(block: string): ResumeProfileEducationIt
   }
 
   const headerLine = lines[0] || "";
-  const dateRange = extractManual51jobDateRange(headerLine || block);
+  const dateLineIndex = lines.findIndex((line) => MANUAL_51JOB_TIMELINE_START_PATTERN.test(line));
+  const dateRange = extractManual51jobDateRange(resolveManual51jobPrimaryDateLine(lines, headerLine) || block);
   const institutionFromLabel = lines
     .map((line) => getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_INSTITUTION_LABELS))
     .find((value): value is string => Boolean(value));
@@ -997,6 +1238,28 @@ function parseManual51jobEducationBlock(block: string): ResumeProfileEducationIt
     .map((line) => getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_DESCRIPTION_LABELS))
     .find((value): value is string => Boolean(value));
 
+  const candidateLines = lines.filter((line, index) => {
+    if (index === dateLineIndex) {
+      return false;
+    }
+    if (getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_INSTITUTION_LABELS) !== undefined) {
+      return false;
+    }
+    if (getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_FIELD_LABELS) !== undefined) {
+      return false;
+    }
+    if (getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_QUALIFICATION_LABELS) !== undefined) {
+      return false;
+    }
+    if (getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_DESCRIPTION_LABELS) !== undefined) {
+      return false;
+    }
+    if (isManual51jobTerminalSectionHeader(line)) {
+      return false;
+    }
+    return true;
+  });
+
   let titleLine = headerLine;
   if (dateRange.matchedText) {
     titleLine = normalizeManual51jobLine(titleLine.replace(dateRange.matchedText, " "));
@@ -1005,9 +1268,17 @@ function parseManual51jobEducationBlock(block: string): ResumeProfileEducationIt
     titleLine = lines[1] || "";
   }
 
-  const institution = institutionFromLabel || extractManual51jobInstitution(titleLine);
-  const qualification = qualificationFromLabel || extractManual51jobQualification(titleLine);
+  const institution = institutionFromLabel
+    || candidateLines.map((line) => extractManual51jobInstitution(line)).find((value): value is string => Boolean(value))
+    || extractManual51jobInstitution(titleLine);
+  const qualification = qualificationFromLabel
+    || candidateLines.map((line) => extractManual51jobQualification(line)).find((value): value is string => Boolean(value))
+    || extractManual51jobQualification(titleLine);
   const fieldOfStudy = fieldFromLabel || (() => {
+    const fieldLine = candidateLines.find((line) => line !== institution && line !== qualification);
+    if (fieldLine && !extractManual51jobInstitution(fieldLine) && !extractManual51jobQualification(fieldLine)) {
+      return cleanManual51jobRemainder(fieldLine);
+    }
     if (!titleLine) {
       return undefined;
     }
@@ -1026,7 +1297,8 @@ function parseManual51jobEducationBlock(block: string): ResumeProfileEducationIt
       ...lines.slice(1).filter((line) => {
         return getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_INSTITUTION_LABELS) === undefined
           && getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_FIELD_LABELS) === undefined
-          && getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_QUALIFICATION_LABELS) === undefined;
+          && getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_QUALIFICATION_LABELS) === undefined
+          && !isManual51jobTerminalSectionHeader(line);
       }),
     ].filter(Boolean).join("\n")
   );
@@ -1050,7 +1322,7 @@ function getManual51jobProfileEducation(text: string | undefined): ResumeProfile
     return undefined;
   }
 
-  const normalized = splitManual51jobBlocks(text)
+  const normalized = mergeManual51jobLeadingIdentityBlocks(splitManual51jobBlocks(text), extractManual51jobInstitution)
     .map((block) => parseManual51jobEducationBlock(block))
     .filter((entry): entry is ResumeProfileEducationItem => entry !== null);
 
@@ -1139,6 +1411,7 @@ export function parse51jobManualResume(args: {
 }): Parsed51jobManualResume {
   const text = normalizeManual51jobText(args.text);
   const lines = splitManual51jobLines(text);
+  const summaryLines = getManual51jobSummaryLines(lines);
   const sections = collectManual51jobSections(text);
   const workHistory = getManual51jobWorkHistory(getManual51jobSectionText(sections, "workHistory"));
   const profileEducation = getManual51jobProfileEducation(getManual51jobSectionText(sections, "education"));
@@ -1148,11 +1421,21 @@ export function parse51jobManualResume(args: {
   const profileId = inferManual51jobProfileId(lines, args.entryPath) || args.fallbackProfileId;
   const location = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_LOCATION_LABELS)
     || inferManual51jobInlineLocation(text);
-  const jobIntention = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_JOB_INTENTION_LABELS);
-  const expectedSalary = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_SALARY_LABELS);
-  const experience = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_EXPERIENCE_LABELS);
+  const primaryJobIntention = resolveManual51jobJobIntentionLine(lines);
+  const primaryExpectedSalary = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_SALARY_LABELS);
+  const primaryExperience = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_EXPERIENCE_LABELS);
+  const summaryPrimaryLine = pickManual51jobPrimaryLine(summaryLines);
+  const summarySegments = splitManual51jobSummarySegments(summaryPrimaryLine);
+  const jobIntention = primaryJobIntention
+    || summarySegments.find((segment) => !MANUAL_51JOB_INLINE_SALARY_PATTERNS.some((pattern) => pattern.test(segment)));
+  const expectedSalary = primaryExpectedSalary
+    || inferManual51jobSummarySalary(summaryLines)
+    || splitManual51jobSummarySegments(primaryJobIntention).find((segment) => MANUAL_51JOB_INLINE_SALARY_PATTERNS.some((pattern) => pattern.test(segment)))
+    || summarySegments.find((segment) => MANUAL_51JOB_INLINE_SALARY_PATTERNS.some((pattern) => pattern.test(segment)));
+  const experience = primaryExperience || inferManual51jobSummaryExperience(summaryLines);
   const education = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_EDUCATION_LABELS)
-    || pickManual51jobEducation(profileEducation);
+    || pickManual51jobEducation(profileEducation)
+    || extractManual51jobQualification(summaryLines.join(" "));
   const selfIntro = cleanManual51jobRemainder(getManual51jobSectionText(sections, "selfIntro") || "");
 
   return {

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -587,11 +587,13 @@ const MANUAL_51JOB_SECTION_LABELS: Array<{ key: Manual51jobSectionKey; labels: r
 const MANUAL_51JOB_SECTION_HEADER_SET = new Set(
   MANUAL_51JOB_SECTION_LABELS.flatMap((entry) => entry.labels)
 );
-const MANUAL_51JOB_COMPANY_PATTERN = /([\u4e00-\u9fa5A-Za-z0-9()（）·.&\-]{2,80}(?:公司|集团|科技|机械|设备|自动化|股份|有限|中心|厂|银行|医院|研究院))/u;
+const MANUAL_51JOB_COMPANY_PATTERN = /^([\u4e00-\u9fa5A-Za-z0-9()（）·.&\-]{2,80}(?:公司|集团|科技|机械|设备|自动化|股份|有限|中心|厂|银行|医院|研究院))/u;
 const MANUAL_51JOB_INSTITUTION_PATTERN = /([\u4e00-\u9fa5A-Za-z0-9()（）·.&\-]{2,80}(?:大学|学院|学校|中学|技校|职业技术学院|技术学院|中专))/u;
 const MANUAL_51JOB_QUALIFICATION_PATTERN = /(博士研究生|博士|硕士研究生|硕士|研究生|本科|大专|专科|中专|中技|高中)/u;
 const MANUAL_51JOB_DATE_RANGE_PATTERN = /(\d{4}(?:[-./年]\d{1,2})?)(?:\s*(?:[~～\-–—]|至|到)+\s*)(至今|目前|今|\d{4}(?:[-./年]\d{1,2})?)/u;
 const MANUAL_51JOB_TIMELINE_START_PATTERN = /^\s*\d{4}(?:[-./年]\d{1,2})?(?:\s*(?:[~～\-–—]|至|到)+\s*)(?:至今|目前|今|\d{4}(?:[-./年]\d{1,2})?)/u;
+const MANUAL_51JOB_INLINE_DATE_RANGE_PATTERN = /\d{4}(?:[-./年]\d{1,2})?(?:\s*(?:[~～\-–—]|至|到)+\s*)(?:至今|目前|今|\d{4}(?:[-./年]\d{1,2})?)/u;
+const MANUAL_51JOB_WORK_HISTORY_PAGE_MARKER_PATTERN = /^--\s*\d+\s+of\s+\d+\s*--$/iu;
 const MANUAL_51JOB_NAME_EXCLUSIONS = new Set([
   "活跃时间",
   "最近工作",
@@ -1212,7 +1214,11 @@ function getManual51jobDescriptionLines(
       continue;
     }
 
-    if (MANUAL_51JOB_SECTION_HEADER_SET.has(line)) {
+    if (MANUAL_51JOB_SECTION_HEADER_SET.has(line) || isManual51jobTerminalSectionHeader(line)) {
+      continue;
+    }
+
+    if (MANUAL_51JOB_WORK_HISTORY_PAGE_MARKER_PATTERN.test(line) || line === "/") {
       continue;
     }
 
@@ -1253,7 +1259,81 @@ function cleanManual51jobRemainder(value: string): string | undefined {
       .replace(/[()（）]/g, " ")
       .replace(/[，,。；;]/g, " ")
   );
-  return normalized || undefined;
+  if (!normalized) {
+    return undefined;
+  }
+
+  const trimmed = normalized.replace(/[：:]+$/u, "").trim();
+  return trimmed || undefined;
+}
+
+export function looksLikeManual51jobWorkHistoryNoise(value: string): boolean {
+  const normalized = normalizeManual51jobLine(value);
+  if (!normalized) {
+    return true;
+  }
+  if (MANUAL_51JOB_WORK_HISTORY_PAGE_MARKER_PATTERN.test(normalized) || normalized === "/") {
+    return true;
+  }
+  if (/^(?:聊|聊\s*天)$/u.test(normalized)) {
+    return true;
+  }
+  if (/^(?:声明|技能\s*\/\s*语言|技能|语言|证书|作品集|项目经验)$/u.test(normalized)) {
+    return true;
+  }
+  return false;
+}
+
+export function isLikelyManual51jobCompanyName(value: string): boolean {
+  const normalized = normalizeManual51jobLine(value);
+  if (!normalized || normalized.length > 80) {
+    return false;
+  }
+  if (looksLikeManual51jobWorkHistoryNoise(normalized)) {
+    return false;
+  }
+  if (MANUAL_51JOB_INLINE_DATE_RANGE_PATTERN.test(normalized)) {
+    return false;
+  }
+  if (/\d{2,}/u.test(normalized)) {
+    return false;
+  }
+  if (normalized.endsWith("中心") && !/(?:公司|集团|有限|股份|银行|医院|研究院|厂)/u.test(normalized)) {
+    return false;
+  }
+  if (/^(?:在该公司|通过公司|参与公司|主要涉及公司)$/u.test(normalized)) {
+    return false;
+  }
+  if (/^(?:熟悉|了解|掌握|负责|参与|主要|通过|在该|具备)/u.test(normalized)) {
+    return false;
+  }
+  return true;
+}
+
+export function isLikelyManual51jobJobTitle(value: string): boolean {
+  const normalized = normalizeManual51jobLine(value);
+  if (!normalized || normalized.length > 60) {
+    return false;
+  }
+  if (looksLikeManual51jobWorkHistoryNoise(normalized)) {
+    return false;
+  }
+  if (MANUAL_51JOB_INLINE_DATE_RANGE_PATTERN.test(normalized)) {
+    return false;
+  }
+  if (/\d{2,}/u.test(normalized)) {
+    return false;
+  }
+  if (/^(?:在该公司|通过公司)$/u.test(normalized)) {
+    return false;
+  }
+  if (/^(?:熟悉|了解|掌握|负责|参与|主要|通过|在该|具备)/u.test(normalized)) {
+    return false;
+  }
+  if (/^[\u4e00-\u9fa5A-Za-z]{1,2}$/u.test(normalized)) {
+    return false;
+  }
+  return true;
 }
 
 function parseManual51jobWorkHistoryBlock(block: string): ResumeWorkHistoryItem | null {
@@ -1297,12 +1377,15 @@ function parseManual51jobWorkHistoryBlock(block: string): ResumeWorkHistoryItem 
     if (MANUAL_51JOB_SECTION_HEADER_SET.has(line) || isManual51jobTerminalSectionHeader(line)) {
       continue;
     }
+    if (looksLikeManual51jobWorkHistoryNoise(line)) {
+      continue;
+    }
 
     companyCandidateLines.push(line);
 
     if (!companyCandidate) {
       const extractedCompany = extractManual51jobCompany(line);
-      if (extractedCompany && !/[中心]$/.test(extractedCompany)) {
+      if (extractedCompany && !/[中心]$/.test(extractedCompany) && isLikelyManual51jobCompanyName(extractedCompany)) {
         companyCandidate = extractedCompany;
         companyLineForCandidate = line;
       }
@@ -1321,16 +1404,43 @@ function parseManual51jobWorkHistoryBlock(block: string): ResumeWorkHistoryItem 
     titleLine = lines[1] || "";
   }
 
-  const companyName = companyFromLabel || companyCandidate || extractManual51jobCompany(titleLine);
-  const jobTitle = jobTitleFromLabel || (() => {
-    if (companyName && companyLineForCandidate?.includes(companyName)) {
-      const remainder = cleanManual51jobRemainder(companyLineForCandidate.replace(companyName, " "));
-      if (remainder && remainder.length <= 40) {
-        return remainder;
+  const companyName = (() => {
+    if (companyFromLabel && isLikelyManual51jobCompanyName(companyFromLabel)) {
+      return companyFromLabel;
+    }
+    if (companyCandidate && isLikelyManual51jobCompanyName(companyCandidate)) {
+      return companyCandidate;
+    }
+
+    if (dateRange.startDate || dateRange.endDate) {
+      const extracted = extractManual51jobCompany(titleLine);
+      if (extracted && isLikelyManual51jobCompanyName(extracted)) {
+        return extracted;
       }
     }
 
-    if (roleLineCandidate && roleLineCandidate.length <= 40) {
+    return undefined;
+  })();
+  const jobTitle = (() => {
+    if (jobTitleFromLabel && isLikelyManual51jobJobTitle(jobTitleFromLabel)) {
+      return jobTitleFromLabel;
+    }
+
+    const remainderFromCompanyLine = (() => {
+      if (!companyName || !companyLineForCandidate?.includes(companyName)) {
+        return undefined;
+      }
+      const remainder = cleanManual51jobRemainder(companyLineForCandidate.replace(companyName, " "));
+      if (!remainder || remainder.length > 40) {
+        return undefined;
+      }
+      return isLikelyManual51jobJobTitle(remainder) ? remainder : undefined;
+    })();
+    if (remainderFromCompanyLine) {
+      return remainderFromCompanyLine;
+    }
+
+    if (roleLineCandidate && roleLineCandidate.length <= 40 && isLikelyManual51jobJobTitle(roleLineCandidate)) {
       return roleLineCandidate;
     }
 
@@ -1341,11 +1451,16 @@ function parseManual51jobWorkHistoryBlock(block: string): ResumeWorkHistoryItem 
     if (!remainder || remainder.length > 40) {
       return undefined;
     }
-    return remainder;
+    return isLikelyManual51jobJobTitle(remainder) ? remainder : undefined;
   })();
   const description = cleanManual51jobRemainder(getManual51jobDescriptionLines(lines, companyName, jobTitle).join("\n"));
 
-  if (!raw && !companyName && !jobTitle && !description && !dateRange.startDate && !dateRange.endDate) {
+  if (
+    !companyName
+    && !jobTitle
+    && !description
+    && (!dateRange.startDate || !dateRange.endDate)
+  ) {
     return null;
   }
 

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -545,3 +545,627 @@ export function normalizeSharedResumeFields(record: Record<string, unknown>, sou
     noticePeriodDays: normalizeOptionalNumber(record.noticePeriodDays),
   };
 }
+
+type Manual51jobSectionKey = "workHistory" | "education" | "selfIntro";
+
+export type Parsed51jobManualResume = {
+  name?: string;
+  profileId?: string;
+  location?: string;
+  jobIntention?: string;
+  expectedSalary?: string;
+  experience?: string;
+  education?: string;
+  selfIntro?: string;
+  workHistory: ResumeWorkHistoryItem[];
+  profileEducation?: ResumeProfileEducationItem[];
+  resumeSnippet: ResumeSnippet;
+};
+
+const MANUAL_51JOB_NAME_LABELS = ["姓名", "名称"] as const;
+const MANUAL_51JOB_PROFILE_ID_LABELS = ["人才ID", "简历编号", "ID"] as const;
+const MANUAL_51JOB_LOCATION_LABELS = ["区域", "现居住地", "现居住", "所在地", "所在地区"] as const;
+const MANUAL_51JOB_JOB_INTENTION_LABELS = ["应聘方向", "求职意向", "期望职位", "意向职位"] as const;
+const MANUAL_51JOB_SALARY_LABELS = ["期望薪资", "薪资要求", "期望工资", "期望月薪", "期望年薪"] as const;
+const MANUAL_51JOB_EXPERIENCE_LABELS = ["工作经验", "工作年限", "从业年限", "经验"] as const;
+const MANUAL_51JOB_EDUCATION_LABELS = ["最高学历学位", "最高学历", "学历"] as const;
+const MANUAL_51JOB_WORK_DESCRIPTION_LABELS = ["工作描述", "职责描述", "工作职责", "主要职责", "工作内容"] as const;
+const MANUAL_51JOB_WORK_COMPANY_LABELS = ["公司", "单位", "企业"] as const;
+const MANUAL_51JOB_WORK_JOB_TITLE_LABELS = ["职位", "岗位", "职务"] as const;
+const MANUAL_51JOB_EDUCATION_INSTITUTION_LABELS = ["学校", "院校"] as const;
+const MANUAL_51JOB_EDUCATION_FIELD_LABELS = ["专业", "主修", "专业名称"] as const;
+const MANUAL_51JOB_EDUCATION_DESCRIPTION_LABELS = ["专业描述", "在校经历", "学习描述"] as const;
+const MANUAL_51JOB_EDUCATION_QUALIFICATION_LABELS = ["学历", "学位"] as const;
+const MANUAL_51JOB_SECTION_LABELS: Array<{ key: Manual51jobSectionKey; labels: readonly string[] }> = [
+  { key: "workHistory", labels: ["工作经历", "工作经验"] },
+  { key: "education", labels: ["教育经历", "教育背景"] },
+  { key: "selfIntro", labels: ["个人优势", "自我介绍", "自我评价", "个人简介"] },
+];
+const MANUAL_51JOB_SECTION_HEADER_SET = new Set(
+  MANUAL_51JOB_SECTION_LABELS.flatMap((entry) => entry.labels)
+);
+const MANUAL_51JOB_COMPANY_PATTERN = /([\u4e00-\u9fa5A-Za-z0-9()（）·.&\-]{2,80}(?:公司|集团|科技|机械|设备|自动化|股份|有限|中心|厂|银行|医院|研究院))/u;
+const MANUAL_51JOB_INSTITUTION_PATTERN = /([\u4e00-\u9fa5A-Za-z0-9()（）·.&\-]{2,80}(?:大学|学院|学校|中学|技校|职业技术学院|技术学院|中专))/u;
+const MANUAL_51JOB_QUALIFICATION_PATTERN = /(博士研究生|博士|硕士研究生|硕士|研究生|本科|大专|专科|中专|中技|高中)/u;
+const MANUAL_51JOB_DATE_RANGE_PATTERN = /(\d{4}(?:[-./年]\d{1,2})?)(?:\s*(?:[~～\-–—]|至|到)+\s*)(至今|目前|今|\d{4}(?:[-./年]\d{1,2})?)/u;
+const MANUAL_51JOB_TIMELINE_START_PATTERN = /^\s*\d{4}(?:[-./年]\d{1,2})?(?:\s*(?:[~～\-–—]|至|到)+\s*)(?:至今|目前|今|\d{4}(?:[-./年]\d{1,2})?)/u;
+const MANUAL_51JOB_NAME_EXCLUSIONS = new Set([
+  "活跃时间",
+  "最近工作",
+  "最高学历",
+  "最高学历学位",
+  "求职意向",
+  "个人优势",
+  "工作经历",
+  "工作经验",
+  "教育经历",
+  "专业描述",
+  "工作描述",
+  "证书",
+  "声明",
+  "离职",
+  "在职",
+  "全职",
+  "男",
+  "女",
+  "仅供招聘专用",
+  "仅供招聘专用，企业应尽保密义务，禁止外传",
+]);
+const MANUAL_51JOB_EDUCATION_RANK: Record<string, number> = {
+  高中: 1,
+  中技: 1,
+  中专: 1,
+  专科: 2,
+  大专: 2,
+  本科: 3,
+  研究生: 4,
+  硕士: 4,
+  硕士研究生: 4,
+  博士: 5,
+  博士研究生: 5,
+};
+const MANUAL_51JOB_LABEL_PATTERN_CACHE = new Map<string, RegExp>();
+
+function escapeManual51jobRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getManual51jobLabelPattern(label: string): RegExp {
+  const cachedPattern = MANUAL_51JOB_LABEL_PATTERN_CACHE.get(label);
+  if (cachedPattern) {
+    return cachedPattern;
+  }
+
+  const pattern = new RegExp(`^${escapeManual51jobRegExp(label)}\\s*[：:]\\s*(.*)$`, "u");
+  MANUAL_51JOB_LABEL_PATTERN_CACHE.set(label, pattern);
+  return pattern;
+}
+
+function normalizeManual51jobText(value: string): string {
+  return value
+    .replace(/\r/g, "\n")
+    .replace(/\u0000/g, "")
+    .replace(/\u00a0/g, " ")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function normalizeManual51jobLine(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function getManual51jobLabeledLineValue(line: string, labels: readonly string[]): string | undefined {
+  const normalizedLine = normalizeManual51jobLine(line);
+  if (!normalizedLine) {
+    return undefined;
+  }
+
+  for (const label of labels) {
+    if (normalizedLine === label) {
+      return "";
+    }
+
+    const match = normalizedLine.match(getManual51jobLabelPattern(label));
+    if (match) {
+      return match[1]?.trim() ?? "";
+    }
+  }
+
+  return undefined;
+}
+
+function splitManual51jobLines(text: string): string[] {
+  if (!text) {
+    return [];
+  }
+
+  return text.split("\n").map((line) => normalizeManual51jobLine(line));
+}
+
+function getManual51jobFieldValueFromLines(lines: readonly string[], labels: readonly string[]): string | undefined {
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] || "";
+    const value = getManual51jobLabeledLineValue(line, labels);
+    if (value === undefined) {
+      continue;
+    }
+    if (value) {
+      return value;
+    }
+
+    for (let nextIndex = index + 1; nextIndex < lines.length; nextIndex += 1) {
+      const nextLine = lines[nextIndex] || "";
+      if (!nextLine) {
+        continue;
+      }
+      if (resolveManual51jobSectionHeader(nextLine)) {
+        break;
+      }
+      return nextLine;
+    }
+  }
+
+  return undefined;
+}
+
+function inferManual51jobInlineLocation(text: string): string | undefined {
+  const match = text.match(/现居(?:住地|住)?[·:：]?\s*([^\n｜|]{1,40})/u);
+  if (!match?.[1]) {
+    return undefined;
+  }
+
+  const location = normalizeManual51jobLine(match[1]);
+  return location || undefined;
+}
+
+function resolveManual51jobSectionHeader(line: string): { key: Manual51jobSectionKey; remainder?: string } | null {
+  const normalizedLine = normalizeManual51jobLine(line);
+  if (!normalizedLine) {
+    return null;
+  }
+
+  for (const entry of MANUAL_51JOB_SECTION_LABELS) {
+    for (const label of entry.labels) {
+      if (normalizedLine === label) {
+        return { key: entry.key };
+      }
+
+      const match = normalizedLine.match(getManual51jobLabelPattern(label));
+      if (match) {
+        const remainder = match[1]?.trim();
+        return remainder ? { key: entry.key, remainder } : { key: entry.key };
+      }
+    }
+  }
+
+  return null;
+}
+
+function collectManual51jobSections(text: string): Partial<Record<Manual51jobSectionKey, string[]>> {
+  const sections: Partial<Record<Manual51jobSectionKey, string[]>> = {};
+  let currentKey: Manual51jobSectionKey | null = null;
+
+  for (const rawLine of normalizeManual51jobText(text).split("\n")) {
+    const sectionHeader = resolveManual51jobSectionHeader(rawLine);
+    if (sectionHeader) {
+      currentKey = sectionHeader.key;
+      sections[currentKey] = [];
+      if (sectionHeader.remainder) {
+        sections[currentKey]?.push(sectionHeader.remainder);
+      }
+      continue;
+    }
+
+    if (currentKey) {
+      sections[currentKey]?.push(rawLine);
+    }
+  }
+
+  return sections;
+}
+
+function getManual51jobSectionText(
+  sections: Partial<Record<Manual51jobSectionKey, string[]>>,
+  key: Manual51jobSectionKey,
+): string | undefined {
+  const lines = sections[key]
+    ?.map((line) => normalizeManual51jobLine(line))
+    .filter((line) => Boolean(line));
+  if (!lines || lines.length === 0) {
+    return undefined;
+  }
+  const normalized = normalizeManual51jobText(lines.join("\n"));
+  return normalized || undefined;
+}
+
+function normalizeManual51jobDate(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (["至今", "目前", "今"].includes(trimmed)) {
+    return "至今";
+  }
+
+  return trimmed
+    .replace(/[./]/g, "-")
+    .replace(/年/g, "-")
+    .replace(/月/g, "")
+    .replace(/日/g, "")
+    .replace(/\s+/g, "")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function extractManual51jobDateRange(text: string): {
+  matchedText?: string;
+  startDate?: string;
+  endDate?: string;
+} {
+  const match = text.match(MANUAL_51JOB_DATE_RANGE_PATTERN);
+  if (!match) {
+    return {};
+  }
+
+  const startDate = normalizeManual51jobDate(match[1] || "");
+  const endDate = normalizeManual51jobDate(match[2] || "");
+
+  return {
+    matchedText: match[0],
+    ...(startDate ? { startDate } : {}),
+    ...(endDate ? { endDate } : {}),
+  };
+}
+
+function splitManual51jobBlocks(text: string): string[] {
+  const normalized = normalizeManual51jobText(text);
+  if (!normalized) {
+    return [];
+  }
+
+  const blocks: string[] = [];
+  let current: string[] = [];
+
+  for (const rawLine of normalized.split("\n")) {
+    const line = normalizeManual51jobLine(rawLine);
+    if (!line) {
+      continue;
+    }
+
+    if (MANUAL_51JOB_TIMELINE_START_PATTERN.test(line) && current.length > 0) {
+      blocks.push(current.join("\n"));
+      current = [line];
+      continue;
+    }
+
+    current.push(line);
+  }
+
+  if (current.length > 0) {
+    blocks.push(current.join("\n"));
+  }
+
+  return blocks;
+}
+
+function getManual51jobDescriptionLines(lines: string[]): string[] {
+  const descriptionLines: string[] = [];
+
+  for (let index = 1; index < lines.length; index += 1) {
+    const line = normalizeManual51jobLine(lines[index] || "");
+    if (!line) {
+      continue;
+    }
+
+    const labeledDescription = getManual51jobLabeledLineValue(line, MANUAL_51JOB_WORK_DESCRIPTION_LABELS);
+    if (labeledDescription !== undefined) {
+      if (labeledDescription) {
+        descriptionLines.push(labeledDescription);
+      }
+      continue;
+    }
+
+    if (
+      getManual51jobLabeledLineValue(line, MANUAL_51JOB_WORK_COMPANY_LABELS) !== undefined
+      || getManual51jobLabeledLineValue(line, MANUAL_51JOB_WORK_JOB_TITLE_LABELS) !== undefined
+    ) {
+      continue;
+    }
+
+    if (MANUAL_51JOB_SECTION_HEADER_SET.has(line)) {
+      continue;
+    }
+
+    descriptionLines.push(line);
+  }
+
+  return descriptionLines;
+}
+
+function extractManual51jobCompany(value: string): string | undefined {
+  const match = normalizeManual51jobLine(value).match(MANUAL_51JOB_COMPANY_PATTERN);
+  return match?.[1]?.trim() || undefined;
+}
+
+function extractManual51jobInstitution(value: string): string | undefined {
+  const match = normalizeManual51jobLine(value).match(MANUAL_51JOB_INSTITUTION_PATTERN);
+  return match?.[1]?.trim() || undefined;
+}
+
+function extractManual51jobQualification(value: string): string | undefined {
+  const match = normalizeManual51jobLine(value).match(MANUAL_51JOB_QUALIFICATION_PATTERN);
+  return match?.[1]?.trim() || undefined;
+}
+
+function cleanManual51jobRemainder(value: string): string | undefined {
+  const normalized = normalizeManual51jobLine(
+    value
+      .replace(/[|｜丨]/g, " ")
+      .replace(/[：:]/g, " ")
+      .replace(/[()（）]/g, " ")
+      .replace(/[，,。；;]/g, " ")
+  );
+  return normalized || undefined;
+}
+
+function parseManual51jobWorkHistoryBlock(block: string): ResumeWorkHistoryItem | null {
+  const lines = block
+    .split("\n")
+    .map((line) => normalizeManual51jobLine(line))
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return null;
+  }
+
+  const raw = lines.join("\n");
+  const headerLine = lines[0] || "";
+  const dateRange = extractManual51jobDateRange(headerLine || raw);
+  const companyFromLabel = lines
+    .map((line) => getManual51jobLabeledLineValue(line, MANUAL_51JOB_WORK_COMPANY_LABELS))
+    .find((value): value is string => Boolean(value));
+  const jobTitleFromLabel = lines
+    .map((line) => getManual51jobLabeledLineValue(line, MANUAL_51JOB_WORK_JOB_TITLE_LABELS))
+    .find((value): value is string => Boolean(value));
+
+  let titleLine = headerLine;
+  if (dateRange.matchedText) {
+    titleLine = normalizeManual51jobLine(titleLine.replace(dateRange.matchedText, " "));
+  }
+  if (!titleLine && lines.length > 1) {
+    titleLine = lines[1] || "";
+  }
+
+  const companyName = companyFromLabel || extractManual51jobCompany(titleLine);
+  const jobTitle = jobTitleFromLabel || (() => {
+    if (!companyName) {
+      return undefined;
+    }
+    const remainder = cleanManual51jobRemainder(titleLine.replace(companyName, " "));
+    if (!remainder || remainder.length > 40) {
+      return undefined;
+    }
+    return remainder;
+  })();
+  const description = cleanManual51jobRemainder(getManual51jobDescriptionLines(lines).join("\n"));
+
+  if (!raw && !companyName && !jobTitle && !description && !dateRange.startDate && !dateRange.endDate) {
+    return null;
+  }
+
+  return {
+    raw,
+    ...(companyName ? { companyName } : {}),
+    ...(jobTitle ? { jobTitle } : {}),
+    ...(description ? { description } : {}),
+    ...(dateRange.startDate ? { startDate: dateRange.startDate } : {}),
+    ...(dateRange.endDate ? { endDate: dateRange.endDate } : {}),
+  };
+}
+
+function getManual51jobWorkHistory(text: string | undefined): ResumeWorkHistoryItem[] {
+  if (!text) {
+    return [];
+  }
+
+  return splitManual51jobBlocks(text)
+    .map((block) => parseManual51jobWorkHistoryBlock(block))
+    .filter((entry): entry is ResumeWorkHistoryItem => entry !== null);
+}
+
+function parseManual51jobEducationBlock(block: string): ResumeProfileEducationItem | null {
+  const lines = block
+    .split("\n")
+    .map((line) => normalizeManual51jobLine(line))
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return null;
+  }
+
+  const headerLine = lines[0] || "";
+  const dateRange = extractManual51jobDateRange(headerLine || block);
+  const institutionFromLabel = lines
+    .map((line) => getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_INSTITUTION_LABELS))
+    .find((value): value is string => Boolean(value));
+  const qualificationFromLabel = lines
+    .map((line) => getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_QUALIFICATION_LABELS))
+    .find((value): value is string => Boolean(value));
+  const fieldFromLabel = lines
+    .map((line) => getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_FIELD_LABELS))
+    .find((value): value is string => Boolean(value));
+  const descriptionFromLabel = lines
+    .map((line) => getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_DESCRIPTION_LABELS))
+    .find((value): value is string => Boolean(value));
+
+  let titleLine = headerLine;
+  if (dateRange.matchedText) {
+    titleLine = normalizeManual51jobLine(titleLine.replace(dateRange.matchedText, " "));
+  }
+  if (!titleLine && lines.length > 1) {
+    titleLine = lines[1] || "";
+  }
+
+  const institution = institutionFromLabel || extractManual51jobInstitution(titleLine);
+  const qualification = qualificationFromLabel || extractManual51jobQualification(titleLine);
+  const fieldOfStudy = fieldFromLabel || (() => {
+    if (!titleLine) {
+      return undefined;
+    }
+    let remainder = titleLine;
+    if (institution) {
+      remainder = remainder.replace(institution, " ");
+    }
+    if (qualification) {
+      remainder = remainder.replace(qualification, " ");
+    }
+    return cleanManual51jobRemainder(remainder);
+  })();
+  const description = cleanManual51jobRemainder(
+    [
+      descriptionFromLabel,
+      ...lines.slice(1).filter((line) => {
+        return getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_INSTITUTION_LABELS) === undefined
+          && getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_FIELD_LABELS) === undefined
+          && getManual51jobLabeledLineValue(line, MANUAL_51JOB_EDUCATION_QUALIFICATION_LABELS) === undefined;
+      }),
+    ].filter(Boolean).join("\n")
+  );
+
+  if (!institution && !qualification && !fieldOfStudy && !description) {
+    return null;
+  }
+
+  return {
+    ...(institution ? { institution } : {}),
+    ...(qualification ? { qualification } : {}),
+    ...(fieldOfStudy ? { fieldOfStudy } : {}),
+    ...(description ? { description } : {}),
+    ...(dateRange.startDate ? { startDate: dateRange.startDate } : {}),
+    ...(dateRange.endDate ? { endDate: dateRange.endDate } : {}),
+  };
+}
+
+function getManual51jobProfileEducation(text: string | undefined): ResumeProfileEducationItem[] | undefined {
+  if (!text) {
+    return undefined;
+  }
+
+  const normalized = splitManual51jobBlocks(text)
+    .map((block) => parseManual51jobEducationBlock(block))
+    .filter((entry): entry is ResumeProfileEducationItem => entry !== null);
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function pickManual51jobEducation(profileEducation: ResumeProfileEducationItem[] | undefined): string | undefined {
+  if (!profileEducation || profileEducation.length === 0) {
+    return undefined;
+  }
+
+  const qualifications = profileEducation
+    .map((entry) => extractManual51jobQualification(entry.qualification || ""))
+    .filter((value): value is string => Boolean(value));
+  if (qualifications.length === 0) {
+    return undefined;
+  }
+
+  return qualifications.sort((left, right) => {
+    const leftRank = MANUAL_51JOB_EDUCATION_RANK[left] || 0;
+    const rightRank = MANUAL_51JOB_EDUCATION_RANK[right] || 0;
+    return rightRank - leftRank;
+  })[0];
+}
+
+function inferManual51jobFilenameResumeName(entryPath: string | undefined): string | undefined {
+  if (!entryPath) {
+    return undefined;
+  }
+
+  const basename = entryPath
+    .split(/[\\/]/)
+    .pop()
+    ?.replace(/\.[^.]+$/, "")
+    .replace(/^51job[_-]?/i, "")
+    .trim();
+  const normalized = basename?.replace(/\([^)]*\)/g, "").trim();
+  return normalized || undefined;
+}
+
+function isLikelyManual51jobResumeName(value: string): boolean {
+  if (!value || value.length > 20) {
+    return false;
+  }
+  if (/\d/.test(value) || /[：:｜|丨/]/.test(value) || /[()（）]/.test(value)) {
+    return false;
+  }
+
+  const normalized = value.replace(/\s+/g, "");
+  if (MANUAL_51JOB_NAME_EXCLUSIONS.has(normalized)) {
+    return false;
+  }
+
+  return /\p{Script=Han}|[A-Za-z]/u.test(normalized);
+}
+
+function inferManual51jobResumeName(lines: readonly string[], entryPath?: string): string | undefined {
+  const filenameCandidate = inferManual51jobFilenameResumeName(entryPath);
+
+  for (const line of lines.slice(0, 12)) {
+    const firstToken = line.split(/[\s|｜丨]/).find(Boolean)?.trim();
+    if (firstToken && isLikelyManual51jobResumeName(firstToken)) {
+      return firstToken;
+    }
+  }
+
+  return filenameCandidate;
+}
+
+function inferManual51jobProfileId(lines: readonly string[], entryPath?: string): string | undefined {
+  const entryMatch = entryPath?.match(/\((\d{6,})\)/);
+  if (entryMatch?.[1]) {
+    return entryMatch[1];
+  }
+
+  const labeledValue = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_PROFILE_ID_LABELS);
+  const match = labeledValue?.match(/\d{6,}/);
+  return match?.[0] || undefined;
+}
+
+export function parse51jobManualResume(args: {
+  text: string;
+  entryPath?: string;
+  fallbackName?: string;
+  fallbackProfileId?: string;
+}): Parsed51jobManualResume {
+  const text = normalizeManual51jobText(args.text);
+  const lines = splitManual51jobLines(text);
+  const sections = collectManual51jobSections(text);
+  const workHistory = getManual51jobWorkHistory(getManual51jobSectionText(sections, "workHistory"));
+  const profileEducation = getManual51jobProfileEducation(getManual51jobSectionText(sections, "education"));
+  const name = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_NAME_LABELS)
+    || inferManual51jobResumeName(lines, args.entryPath)
+    || args.fallbackName;
+  const profileId = inferManual51jobProfileId(lines, args.entryPath) || args.fallbackProfileId;
+  const location = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_LOCATION_LABELS)
+    || inferManual51jobInlineLocation(text);
+  const jobIntention = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_JOB_INTENTION_LABELS);
+  const expectedSalary = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_SALARY_LABELS);
+  const experience = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_EXPERIENCE_LABELS);
+  const education = getManual51jobFieldValueFromLines(lines, MANUAL_51JOB_EDUCATION_LABELS)
+    || pickManual51jobEducation(profileEducation);
+  const selfIntro = cleanManual51jobRemainder(getManual51jobSectionText(sections, "selfIntro") || "");
+
+  return {
+    ...(name ? { name } : {}),
+    ...(profileId ? { profileId } : {}),
+    ...(location ? { location } : {}),
+    ...(jobIntention ? { jobIntention } : {}),
+    ...(expectedSalary ? { expectedSalary } : {}),
+    ...(experience ? { experience } : {}),
+    ...(education ? { education } : {}),
+    ...(selfIntro ? { selfIntro } : {}),
+    workHistory,
+    ...(profileEducation ? { profileEducation } : {}),
+    resumeSnippet: { text },
+  };
+}


### PR DESCRIPTION
## Summary
- reject unreadable manual 51job PDF extracts before import and surface the file-level failure in the web dialog
- improve 51job manual normalization for salary and inline location extraction from real export shapes
- tighten manual 51job migration repair behavior by reusing shared field-preference logic and only scheduling reingest when content actually changes

## Test plan
- [x] bunx vitest run apps/api/src/routes/manual-resume-import.test.ts
- [x] bunx vitest run apps/web/src/components/ManualResumeImportDialog.test.tsx
- [x] bunx vitest run packages/convex/convex/__tests__/migrations-evidence-text.test.ts
- [x] make check