### PR TITLE
test: expand CLI command and MCP coverage

### DIFF
--- a/packages/cli/cmd/jd_test.go
+++ b/packages/cli/cmd/jd_test.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ptdevhk/trends/packages/cli/internal/client"
+)
+
+func TestJDListCommandWritesJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/job-descriptions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(client.JobDescriptionsResponse{
+			Success: true,
+			Items: []client.JobDescriptionFile{{
+				Name:      "cnc-sales",
+				Title:     "CNC Sales",
+				Status:    "active",
+				UpdatedAt: "2026-03-20T08:00:00Z",
+			}},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "hr")
+	setCLIOutput(t, "json")
+
+	cmd := newJDListCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("jd list command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	items, ok := payload["items"].([]interface{})
+	if !ok || len(items) != 1 {
+		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+}
+
+func TestJDCreateCommandUsesFilenameAndWritesTable(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "field-sales.md")
+	content := "# Field Sales\n\nNeed CNC sales experience.\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/job-descriptions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+
+		var payload client.CreateJobDescriptionRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if payload.Name != "field-sales" {
+			t.Fatalf("expected derived name field-sales, got %q", payload.Name)
+		}
+		if payload.Content != content {
+			t.Fatalf("unexpected content: %q", payload.Content)
+		}
+		if payload.Overwrite {
+			t.Fatal("expected overwrite=false by default")
+		}
+
+		_ = json.NewEncoder(w).Encode(client.CreateJobDescriptionResponse{
+			Success: true,
+			Item: client.JobDescriptionFile{
+				Name:   payload.Name,
+				Title:  "Field Sales",
+				Status: "draft",
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "hr")
+	setCLIOutput(t, "table")
+
+	cmd := newJDCreateCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{filePath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("jd create command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "field-sales") || !strings.Contains(text, "Field Sales") || !strings.Contains(text, "draft") {
+		t.Fatalf("unexpected command output: %s", text)
+	}
+}
+
+func TestJDCreateCommandHonorsExplicitNameAndOverwrite(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "ignored-name.md")
+	content := "# Replacement\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload client.CreateJobDescriptionRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if payload.Name != "custom-jd" {
+			t.Fatalf("expected explicit name custom-jd, got %q", payload.Name)
+		}
+		if !payload.Overwrite {
+			t.Fatal("expected overwrite=true")
+		}
+		_ = json.NewEncoder(w).Encode(client.CreateJobDescriptionResponse{
+			Success: true,
+			Item: client.JobDescriptionFile{
+				Name:   payload.Name,
+				Title:  "Replacement",
+				Status: "active",
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "hr")
+	setCLIOutput(t, "json")
+
+	cmd := newJDCreateCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{filePath, "--name", "custom-jd", "--overwrite"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("jd create command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["name"] != "custom-jd" || payload["status"] != "active" {
+		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+}

--- a/packages/cli/cmd/mcp.go
+++ b/packages/cli/cmd/mcp.go
@@ -213,12 +213,12 @@ func mcpTools() []map[string]any {
 		},
 		{
 			"name":        "migrate_reindex_search",
-			"description": "Run migrations:reindexSearchText",
+			"description": "Run " + migrationReindexSearchText,
 			"inputSchema": map[string]any{"type": "object"},
 		},
 		{
 			"name":        "migrate_backfill_ingest",
-			"description": "Run migrations:backfillIngestData",
+			"description": "Run " + migrationBackfillIngestData,
 			"inputSchema": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -228,7 +228,7 @@ func mcpTools() []map[string]any {
 		},
 		{
 			"name":        "migrate_backfill_score",
-			"description": "Run migrations:backfillPrimaryRuleScore",
+			"description": "Run " + migrationBackfillPrimaryScore,
 			"inputSchema": map[string]any{"type": "object"},
 		},
 	}
@@ -308,20 +308,20 @@ func runMCPTool(ctx context.Context, name string, args map[string]interface{}) (
 		}
 		return prettyJSON(result)
 	case "migrate_reindex_search":
-		result, err := runConvexCommand(ctx, "migrations:reindexSearchText")
+		result, err := runConvexCommand(ctx, migrationReindexSearchText)
 		if err != nil {
 			return "", err
 		}
 		return result, nil
 	case "migrate_backfill_ingest":
 		limit := intArg(args, "limit", 100)
-		result, err := runConvexCommand(ctx, "migrations:backfillIngestData", fmt.Sprintf(`{"limit":%d}`, limit))
+		result, err := runConvexCommand(ctx, migrationBackfillIngestData, backfillIngestPayload(limit))
 		if err != nil {
 			return "", err
 		}
 		return result, nil
 	case "migrate_backfill_score":
-		result, err := runConvexCommand(ctx, "migrations:backfillPrimaryRuleScore")
+		result, err := runConvexCommand(ctx, migrationBackfillPrimaryScore)
 		if err != nil {
 			return "", err
 		}

--- a/packages/cli/cmd/mcp_test.go
+++ b/packages/cli/cmd/mcp_test.go
@@ -5,9 +5,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/ptdevhk/trends/packages/cli/internal/client"
 )
 
 func TestReadMCPMessage(t *testing.T) {
@@ -157,5 +161,177 @@ func TestMCPToolsIncludeResumeDebugReadOnlyTools(t *testing.T) {
 		if !names[required] {
 			t.Fatalf("missing MCP tool %q", required)
 		}
+	}
+}
+
+func TestRunMCPToolJDList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/job-descriptions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(client.JobDescriptionsResponse{
+			Success: true,
+			Items: []client.JobDescriptionFile{{
+				Name:   "cnc-sales",
+				Title:  "CNC Sales",
+				Status: "active",
+			}},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "hr")
+
+	text, err := runMCPTool(context.Background(), "jd_list", nil)
+	if err != nil {
+		t.Fatalf("runMCPTool returned error: %v", err)
+	}
+	if !strings.Contains(text, "cnc-sales") || !strings.Contains(text, "CNC Sales") {
+		t.Fatalf("unexpected MCP tool output: %s", text)
+	}
+}
+
+func TestRunMCPToolWorkerStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/worker/status" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(client.WorkerStatus{
+			Running:      true,
+			JobsExecuted: 4,
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+
+	text, err := runMCPTool(context.Background(), "worker_status", nil)
+	if err != nil {
+		t.Fatalf("runMCPTool returned error: %v", err)
+	}
+	if !strings.Contains(text, `"jobs_executed": 4`) || !strings.Contains(text, `"running": true`) {
+		t.Fatalf("unexpected MCP tool output: %s", text)
+	}
+}
+
+func TestRunMCPToolCrawlTrigger(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/worker/crawl" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(client.WorkerTriggerResponse{
+			Success: true,
+			Mode:    "crawl",
+			Message: "crawl started",
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+
+	text, err := runMCPTool(context.Background(), "crawl_trigger", nil)
+	if err != nil {
+		t.Fatalf("runMCPTool returned error: %v", err)
+	}
+	if !strings.Contains(text, `"mode": "crawl"`) || !strings.Contains(text, `"message": "crawl started"`) {
+		t.Fatalf("unexpected MCP tool output: %s", text)
+	}
+}
+
+func TestRunMCPToolWorkerRunPassesOnceFlag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/worker/run" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("once"); got != "false" {
+			t.Fatalf("expected once=false, got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(client.WorkerTriggerResponse{
+			Success: true,
+			Mode:    "scheduled",
+			Message: "worker queued",
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+
+	text, err := runMCPTool(context.Background(), "worker_run", map[string]interface{}{"once": false})
+	if err != nil {
+		t.Fatalf("runMCPTool returned error: %v", err)
+	}
+	if !strings.Contains(text, `"mode": "scheduled"`) || !strings.Contains(text, `"message": "worker queued"`) {
+		t.Fatalf("unexpected MCP tool output: %s", text)
+	}
+}
+
+func TestRunMCPToolWorkerStatusFallsBackToWorkerURL(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "proxy unavailable", http.StatusBadGateway)
+	}))
+	defer proxy.Close()
+
+	worker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/worker/status" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(client.WorkerStatus{
+			Running:      false,
+			JobsExecuted: 9,
+		})
+	}))
+	defer worker.Close()
+
+	setResumeCLIConfigURLs(t, proxy.URL, worker.URL, "ops")
+
+	text, err := runMCPTool(context.Background(), "worker_status", nil)
+	if err != nil {
+		t.Fatalf("runMCPTool returned error: %v", err)
+	}
+	if !strings.Contains(text, `"jobs_executed": 9`) || !strings.Contains(text, `"running": false`) {
+		t.Fatalf("unexpected MCP tool output: %s", text)
+	}
+}
+
+func TestRunMCPToolCrawlTriggerRejectsUnsuccessfulResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(client.WorkerTriggerResponse{
+			Success: false,
+			Mode:    "crawl",
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+
+	_, err := runMCPTool(context.Background(), "crawl_trigger", nil)
+	if err == nil {
+		t.Fatal("expected unsuccessful crawl trigger error")
+	}
+	if !strings.Contains(err.Error(), "not successful") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunMCPToolWorkerRunRejectsUnsuccessfulResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(client.WorkerTriggerResponse{
+			Success: false,
+			Mode:    "once",
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+
+	_, err := runMCPTool(context.Background(), "worker_run", map[string]interface{}{"once": true})
+	if err == nil {
+		t.Fatal("expected unsuccessful worker run error")
+	}
+	if !strings.Contains(err.Error(), "not successful") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/packages/cli/cmd/migrate.go
+++ b/packages/cli/cmd/migrate.go
@@ -9,6 +9,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	migrationReindexSearchText    = "migrations:reindexSearchText"
+	migrationBackfillIngestData   = "migrations:backfillIngestData"
+	migrationBackfillPrimaryScore = "migrations:backfillPrimaryRuleScore"
+)
+
+func backfillIngestPayload(limit int) string {
+	return fmt.Sprintf(`{"limit":%d}`, limit)
+}
+
+var runConvexCommandExecutor = func(ctx context.Context, args []string) (string, error) {
+	command := exec.CommandContext(ctx, "npx", args...)
+	result, err := command.CombinedOutput()
+	output := strings.TrimSpace(string(result))
+	if err != nil {
+		return output, fmt.Errorf("run npx %s: %w\n%s", strings.Join(args, " "), err, output)
+	}
+	return output, nil
+}
+
 func newMigrateCmd() *cobra.Command {
 	migrateCmd := &cobra.Command{
 		Use:   "migrate",
@@ -29,11 +49,11 @@ func newMigrateReindexCmd() *cobra.Command {
 		Use:   "reindex-search",
 		Short: "Run migrations:reindexSearchText",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			output, err := runConvexCommand(context.Background(), "migrations:reindexSearchText")
+			output, err := runConvexCommand(context.Background(), migrationReindexSearchText)
 			if err != nil {
 				return err
 			}
-			return writeMigrationOutput(cmd, "migrations:reindexSearchText", output)
+			return writeMigrationOutput(cmd, migrationReindexSearchText, output)
 		},
 	}
 }
@@ -45,12 +65,12 @@ func newMigrateBackfillIngestCmd() *cobra.Command {
 		Use:   "backfill-ingest",
 		Short: "Run migrations:backfillIngestData",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			argument := fmt.Sprintf(`{"limit":%d}`, limit)
-			output, err := runConvexCommand(context.Background(), "migrations:backfillIngestData", argument)
+			argument := backfillIngestPayload(limit)
+			output, err := runConvexCommand(context.Background(), migrationBackfillIngestData, argument)
 			if err != nil {
 				return err
 			}
-			return writeMigrationOutput(cmd, "migrations:backfillIngestData", output)
+			return writeMigrationOutput(cmd, migrationBackfillIngestData, output)
 		},
 	}
 
@@ -63,11 +83,11 @@ func newMigrateBackfillScoreCmd() *cobra.Command {
 		Use:   "backfill-score",
 		Short: "Run migrations:backfillPrimaryRuleScore",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			output, err := runConvexCommand(context.Background(), "migrations:backfillPrimaryRuleScore")
+			output, err := runConvexCommand(context.Background(), migrationBackfillPrimaryScore)
 			if err != nil {
 				return err
 			}
-			return writeMigrationOutput(cmd, "migrations:backfillPrimaryRuleScore", output)
+			return writeMigrationOutput(cmd, migrationBackfillPrimaryScore, output)
 		},
 	}
 }
@@ -75,14 +95,7 @@ func newMigrateBackfillScoreCmd() *cobra.Command {
 func runConvexCommand(ctx context.Context, migration string, extraArgs ...string) (string, error) {
 	args := []string{"convex", "run", migration}
 	args = append(args, extraArgs...)
-
-	command := exec.CommandContext(ctx, "npx", args...)
-	result, err := command.CombinedOutput()
-	output := strings.TrimSpace(string(result))
-	if err != nil {
-		return output, fmt.Errorf("run npx %s: %w\n%s", strings.Join(args, " "), err, output)
-	}
-	return output, nil
+	return runConvexCommandExecutor(ctx, args)
 }
 
 func writeMigrationOutput(cmd *cobra.Command, migration string, output string) error {

--- a/packages/cli/cmd/migrate_test.go
+++ b/packages/cli/cmd/migrate_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"testing"
+)
+
+func stubConvexExecutor(t *testing.T, executor func(ctx context.Context, args []string) (string, error)) {
+	t.Helper()
+
+	originalExecutor := runConvexCommandExecutor
+	runConvexCommandExecutor = executor
+	t.Cleanup(func() {
+		runConvexCommandExecutor = originalExecutor
+	})
+}
+
+func TestMigrateReindexCommandWritesJSON(t *testing.T) {
+	setCLIOutput(t, "json")
+
+	var gotArgs []string
+	stubConvexExecutor(t, func(ctx context.Context, args []string) (string, error) {
+		gotArgs = append([]string(nil), args...)
+		return "reindex complete", nil
+	})
+
+	cmd := newMigrateReindexCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("reindex command failed: %v", err)
+	}
+
+	wantArgs := []string{"convex", "run", migrationReindexSearchText}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("unexpected args: got %v want %v", gotArgs, wantArgs)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["migration"] != migrationReindexSearchText {
+		t.Fatalf("unexpected migration payload: %#v", payload)
+	}
+	if payload["output"] != "reindex complete" {
+		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+}
+
+func TestMigrateBackfillIngestCommandPassesLimit(t *testing.T) {
+	setCLIOutput(t, "json")
+
+	var gotArgs []string
+	stubConvexExecutor(t, func(ctx context.Context, args []string) (string, error) {
+		gotArgs = append([]string(nil), args...)
+		return "backfill complete", nil
+	})
+
+	cmd := newMigrateBackfillIngestCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--limit", "42"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("backfill-ingest command failed: %v", err)
+	}
+
+	wantArgs := []string{"convex", "run", migrationBackfillIngestData, backfillIngestPayload(42)}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("unexpected args: got %v want %v", gotArgs, wantArgs)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["migration"] != migrationBackfillIngestData {
+		t.Fatalf("unexpected migration payload: %#v", payload)
+	}
+	if payload["output"] != "backfill complete" {
+		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+}
+
+func TestMigrateBackfillScoreCommandWritesJSON(t *testing.T) {
+	setCLIOutput(t, "json")
+
+	var gotArgs []string
+	stubConvexExecutor(t, func(ctx context.Context, args []string) (string, error) {
+		gotArgs = append([]string(nil), args...)
+		return "score backfill complete", nil
+	})
+
+	cmd := newMigrateBackfillScoreCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("backfill-score command failed: %v", err)
+	}
+
+	wantArgs := []string{"convex", "run", migrationBackfillPrimaryScore}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("unexpected args: got %v want %v", gotArgs, wantArgs)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["migration"] != migrationBackfillPrimaryScore {
+		t.Fatalf("unexpected migration payload: %#v", payload)
+	}
+	if payload["output"] != "score backfill complete" {
+		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+}
+
+func TestRunMCPToolMigrateReindexSearch(t *testing.T) {
+	var gotArgs []string
+	stubConvexExecutor(t, func(ctx context.Context, args []string) (string, error) {
+		gotArgs = append([]string(nil), args...)
+		return "mcp reindex complete", nil
+	})
+
+	text, err := runMCPTool(context.Background(), "migrate_reindex_search", nil)
+	if err != nil {
+		t.Fatalf("runMCPTool returned error: %v", err)
+	}
+	if text != "mcp reindex complete" {
+		t.Fatalf("unexpected tool text: %q", text)
+	}
+
+	wantArgs := []string{"convex", "run", migrationReindexSearchText}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("unexpected args: got %v want %v", gotArgs, wantArgs)
+	}
+}
+
+func TestRunMCPToolMigrateBackfillIngestPassesLimit(t *testing.T) {
+	var gotArgs []string
+	stubConvexExecutor(t, func(ctx context.Context, args []string) (string, error) {
+		gotArgs = append([]string(nil), args...)
+		return "mcp ingest complete", nil
+	})
+
+	text, err := runMCPTool(context.Background(), "migrate_backfill_ingest", map[string]interface{}{"limit": float64(7)})
+	if err != nil {
+		t.Fatalf("runMCPTool returned error: %v", err)
+	}
+	if text != "mcp ingest complete" {
+		t.Fatalf("unexpected tool text: %q", text)
+	}
+
+	wantArgs := []string{"convex", "run", migrationBackfillIngestData, backfillIngestPayload(7)}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("unexpected args: got %v want %v", gotArgs, wantArgs)
+	}
+}
+
+func TestRunMCPToolMigrateBackfillScore(t *testing.T) {
+	var gotArgs []string
+	stubConvexExecutor(t, func(ctx context.Context, args []string) (string, error) {
+		gotArgs = append([]string(nil), args...)
+		return "mcp score complete", nil
+	})
+
+	text, err := runMCPTool(context.Background(), "migrate_backfill_score", nil)
+	if err != nil {
+		t.Fatalf("runMCPTool returned error: %v", err)
+	}
+	if text != "mcp score complete" {
+		t.Fatalf("unexpected tool text: %q", text)
+	}
+
+	wantArgs := []string{"convex", "run", migrationBackfillPrimaryScore}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("unexpected args: got %v want %v", gotArgs, wantArgs)
+	}
+}

--- a/packages/cli/cmd/test_helpers_test.go
+++ b/packages/cli/cmd/test_helpers_test.go
@@ -10,6 +10,11 @@ import (
 
 func setResumeCLIConfig(t *testing.T, apiURL string, workspace string) {
 	t.Helper()
+	setResumeCLIConfigURLs(t, apiURL, apiURL, workspace)
+}
+
+func setResumeCLIConfigURLs(t *testing.T, apiURL string, workerURL string, workspace string) {
+	t.Helper()
 
 	originalAPIURL := viper.GetString("api_url")
 	originalWorkerURL := viper.GetString("worker_url")
@@ -21,7 +26,7 @@ func setResumeCLIConfig(t *testing.T, apiURL string, workspace string) {
 	})
 
 	viper.Set("api_url", apiURL)
-	viper.Set("worker_url", apiURL)
+	viper.Set("worker_url", workerURL)
 	viper.Set("workspace", workspace)
 }
 

--- a/packages/cli/cmd/worker_crawl_test.go
+++ b/packages/cli/cmd/worker_crawl_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ptdevhk/trends/packages/cli/internal/client"
+)
+
+func TestWorkerStatusCommandWritesJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/worker/status" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(client.WorkerStatus{
+			Running:      true,
+			JobsExecuted: 12,
+			JobsFailed:   1,
+			JobsMissed:   0,
+			LastRun:      "2026-03-20T10:00:00Z",
+			LastSuccess:  "2026-03-20T09:59:00Z",
+			LastFailure:  "2026-03-19T20:00:00Z",
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+	setCLIOutput(t, "json")
+
+	cmd := newWorkerStatusCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("worker status command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["jobs_executed"] != float64(12) || payload["running"] != true {
+		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+}
+
+func TestWorkerRunCommandPassesOnceFlag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/worker/run" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if got := r.URL.Query().Get("once"); got != "false" {
+			t.Fatalf("expected once=false, got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(client.WorkerTriggerResponse{
+			Success:    true,
+			Mode:       "scheduled",
+			StartedAt:  "2026-03-20T10:10:00Z",
+			FinishedAt: "2026-03-20T10:10:05Z",
+			Message:    "worker queued",
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+	setCLIOutput(t, "table")
+
+	cmd := newWorkerRunCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--once=false"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("worker run command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "scheduled") || !strings.Contains(text, "worker queued") {
+		t.Fatalf("unexpected command output: %s", text)
+	}
+}
+
+func TestCrawlCommandWritesJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/worker/crawl" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(client.WorkerTriggerResponse{
+			Success:    true,
+			Mode:       "crawl",
+			StartedAt:  "2026-03-20T10:20:00Z",
+			FinishedAt: "2026-03-20T10:20:10Z",
+			Message:    "crawl triggered",
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+	setCLIOutput(t, "json")
+
+	cmd := newCrawlCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("crawl command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["mode"] != "crawl" || payload["message"] != "crawl triggered" {
+		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+}

--- a/packages/cli/internal/client/worker_test.go
+++ b/packages/cli/internal/client/worker_test.go
@@ -1,0 +1,156 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWorkerStatusUsesAPIProxyWhenSuccessful(t *testing.T) {
+	var proxyCalls int
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyCalls++
+		if r.URL.Path != "/worker/status" {
+			t.Fatalf("unexpected proxy path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(WorkerStatus{
+			Running:      true,
+			JobsExecuted: 5,
+		})
+	}))
+	defer proxy.Close()
+
+	workerCalls := 0
+	worker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		workerCalls++
+		t.Fatalf("worker fallback should not be called")
+	}))
+	defer worker.Close()
+
+	c := New(proxy.URL, worker.URL, "dev")
+	c.HTTP = proxy.Client()
+
+	status, err := c.WorkerStatus(context.Background())
+	if err != nil {
+		t.Fatalf("WorkerStatus returned error: %v", err)
+	}
+	if status.JobsExecuted != 5 || !status.Running {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+	if proxyCalls != 1 || workerCalls != 0 {
+		t.Fatalf("unexpected call counts: proxy=%d worker=%d", proxyCalls, workerCalls)
+	}
+}
+
+func TestWorkerStatusFallsBackToWorkerURL(t *testing.T) {
+	var proxyCalls int
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyCalls++
+		http.Error(w, "proxy unavailable", http.StatusBadGateway)
+	}))
+	defer proxy.Close()
+
+	var workerCalls int
+	worker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		workerCalls++
+		if r.URL.Path != "/worker/status" {
+			t.Fatalf("unexpected worker path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(WorkerStatus{
+			Running:      false,
+			JobsExecuted: 9,
+		})
+	}))
+	defer worker.Close()
+
+	c := New(proxy.URL, worker.URL, "dev")
+	c.HTTP = proxy.Client()
+
+	status, err := c.WorkerStatus(context.Background())
+	if err != nil {
+		t.Fatalf("WorkerStatus returned error: %v", err)
+	}
+	if status.JobsExecuted != 9 || status.Running {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+	if proxyCalls != 1 || workerCalls != 1 {
+		t.Fatalf("unexpected call counts: proxy=%d worker=%d", proxyCalls, workerCalls)
+	}
+}
+
+func TestWorkerStatusReturnsWorkerErrorWhenFallbackFails(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "proxy unavailable", http.StatusBadGateway)
+	}))
+	defer proxy.Close()
+
+	worker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "worker unavailable", http.StatusServiceUnavailable)
+	}))
+	defer worker.Close()
+
+	c := New(proxy.URL, worker.URL, "dev")
+	c.HTTP = proxy.Client()
+
+	_, err := c.WorkerStatus(context.Background())
+	if err == nil {
+		t.Fatal("expected worker fallback error")
+	}
+	if !strings.Contains(err.Error(), "503") || !strings.Contains(err.Error(), "worker unavailable") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTriggerCrawlFailsWhenResponseNotSuccessful(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/worker/crawl" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(WorkerTriggerResponse{
+			Success: false,
+			Mode:    "crawl",
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL, server.URL, "dev")
+	c.HTTP = server.Client()
+
+	_, err := c.TriggerCrawl(context.Background())
+	if err == nil {
+		t.Fatal("expected unsuccessful crawl trigger error")
+	}
+	if !strings.Contains(err.Error(), "not successful") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunWorkerFailsWhenResponseNotSuccessful(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/worker/run" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("once"); got != "true" {
+			t.Fatalf("expected once=true, got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(WorkerTriggerResponse{
+			Success: false,
+			Mode:    "once",
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL, server.URL, "dev")
+	c.HTTP = server.Client()
+
+	_, err := c.RunWorker(context.Background(), true)
+	if err == nil {
+		t.Fatal("expected unsuccessful worker run error")
+	}
+	if !strings.Contains(err.Error(), "not successful") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared Convex execution seam so migration commands and MCP migration handlers can be tested without shelling out
- add focused Go coverage for `jd`, `worker`, `crawl`, and `migrate` command paths plus MCP tool routes
- add worker client fallback and unsuccessful-response coverage so CLI behavior is locked across API-proxy and worker-host flows

## Test plan
- [x] cd packages/cli && go test ./cmd ./internal/client
- [x] make check