### PR TITLE
fix(scoring): maintain score=sum(breakdown) invariant after sales guard

### DIFF
--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -310,7 +310,7 @@ describe('resume-scoring', () => {
         },
       ],
     })).toEqual(expect.objectContaining({
-      score: 49,
+      score: 60,
       recommendation: 'potential',
       breakdown: {
         related_exp: 20,

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -414,7 +414,7 @@ export function overrideIndustryDbBreakdown(
     industry_db: industryDb,
   }
 
-  return normalizeKeywordSalesAnalysis(
+  const guarded = normalizeKeywordSalesAnalysis(
     {
       ...analysis,
       score: Math.min(100, normalizedRelatedExp + industryDb),
@@ -425,6 +425,20 @@ export function overrideIndustryDbBreakdown(
       roleSignals: options?.roleSignals,
     }
   )
+
+  // Recompute score from the guarded breakdown to maintain the invariant: score = sum(breakdown).
+  // normalizeKeywordSalesAnalysis caps breakdown.related_exp and score independently, which can
+  // produce score != related_exp + industry_db. Use the breakdown values as the source of truth.
+  const guardedRelatedExp = typeof guarded.breakdown?.related_exp === 'number'
+    ? guarded.breakdown.related_exp
+    : normalizedRelatedExp
+  const guardedIndustryDb = typeof guarded.breakdown?.industry_db === 'number'
+    ? guarded.breakdown.industry_db
+    : industryDb
+  return {
+    ...guarded,
+    score: Math.min(100, guardedRelatedExp + guardedIndustryDb),
+  }
 }
 
 export function hasIngestData(resume: unknown): resume is ResumeWithIngestData {


### PR DESCRIPTION
## Summary
- `normalizeKeywordSalesAnalysis` was capping `breakdown.related_exp` and `score` independently, producing `score (49) ≠ related_exp (20) + industry_db (40) = 60` for sales-required analyses with no sales years detected
- Fix: after calling `normalizeKeywordSalesAnalysis`, read the final `guarded.breakdown` values and recompute `score = min(100, guardedRelatedExp + guardedIndustryDb)` to restore the invariant `score = sum(breakdown)`
- Test expectation updated: `score: 49 → score: 60` for the sales-cap test case with `industryDb=40`

## Test plan
- [x] All 27 `resume-scoring.test.ts` tests pass
- [x] Full typecheck + lint passes (`make check-node`)
- [x] Verify at `/dev/resumes?location=Kuala+Lumpur+MY&keyword="Sales+Engineer"+OR+"Sales+Manager"` — score should now equal `related_exp + industry_db` for capped sales analyses