### PR TITLE
feat(search-profile): add required_keywords AND filter for keyword workflows

### DIFF
--- a/apps/api/src/services/search-profile-service.ts
+++ b/apps/api/src/services/search-profile-service.ts
@@ -25,6 +25,7 @@ export interface SearchProfile {
     // Core inputs
     location: string;
     keywords: string[];
+    required_keywords?: string[];
 
     // Auto-configured
     jobDescription?: string;
@@ -574,6 +575,11 @@ export class SearchProfileService {
         const inputKeywords = readStringArray(record.keywords);
         const keywords = normalizeKeywords(inputKeywords ?? fallback?.keywords ?? []);
 
+        const inputRequiredKeywords = readStringArray(record.required_keywords);
+        const required_keywords = inputRequiredKeywords !== undefined
+            ? normalizeKeywords(inputRequiredKeywords)
+            : fallback?.required_keywords;
+
         const inputStatus = readString(record.status);
         const status: SearchProfile["status"] =
             inputStatus === "paused" || inputStatus === "archived" || inputStatus === "active"
@@ -605,6 +611,7 @@ export class SearchProfileService {
             updatedAt,
             location,
             keywords,
+            ...(required_keywords !== undefined && { required_keywords }),
             jobDescription,
             filterPreset,
             filters,

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -66,6 +66,7 @@ interface QuickStartPanelProps {
     config: {
       location: string
       keywords: string[]
+      requiredKeywords?: string[]
       jobDescriptionId?: string
       collectionSource?: CollectionSource | null
       collectUrl?: string
@@ -742,6 +743,7 @@ export function QuickStartPanel({
     onApplyConfig?.({
       location: profileLocation,
       keywords: profileKeywords,
+      requiredKeywords: profile.required_keywords,
       jobDescriptionId: nextJobDescriptionId || undefined,
       collectionSource: nextCollectionSource,
       collectUrl: nextCollectUrl,

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -40,6 +40,7 @@ export type SearchProfileDetails = {
     status: 'active' | 'paused' | 'archived'
     location: string
     keywords: string[]
+    required_keywords?: string[]
     jobDescription?: string
     filterPreset?: string
     filters?: SearchProfileFilters

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -37,6 +37,7 @@ import {
 import {
   buildLearningObservation,
   buildResumeKey,
+  buildRuleScoringText,
   computeDirectIndustryDb,
   getAnalysisForJob,
   hasIngestData,
@@ -432,6 +433,7 @@ export function useResumeListState(loadSearchHistory = false) {
   const [bulkExportFormat, setBulkExportFormat] = useState<ResumeExportFormat>('csv')
   const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [selectedCompanies, setSelectedCompanies] = useState<string[]>([])
+  const [requiredKeywords, setRequiredKeywords] = useState<string[]>([])
   const [selectedExperienceLevel, setSelectedExperienceLevel] = useState<ExperienceLevelFilter | undefined>(undefined)
   const [appliedSearchHistoryId, setAppliedSearchHistoryId] = useState<string | undefined>(undefined)
   const [queryRuleScoreMap, setQueryRuleScoreMap] = useState<Record<string, number>>({})
@@ -479,6 +481,7 @@ export function useResumeListState(loadSearchHistory = false) {
       hasUrlParams: activeHasUrlParams,
       location: activeParsedUrlState.location ?? '',
       keywords: activeParsedUrlState.keywords,
+      requiredKeywords: activeParsedUrlState.requiredKeywords,
       jobDescriptionId: activeParsedUrlState.jobDescriptionId ?? '',
       selectedTags: activeParsedUrlState.selectedTags,
       selectedCompanies: activeParsedUrlState.selectedCompanies,
@@ -667,6 +670,7 @@ export function useResumeListState(loadSearchHistory = false) {
     })
     setSelectedTags(activeParsedUrlState.selectedTags)
     setSelectedCompanies(activeParsedUrlState.selectedCompanies)
+    setRequiredKeywords(activeParsedUrlState.requiredKeywords)
     setSelectedExperienceLevel(activeParsedUrlState.selectedExperienceLevel)
   }, [
     applyExternalState,
@@ -755,6 +759,11 @@ export function useResumeListState(loadSearchHistory = false) {
         ? current
         : activeParsedUrlState.selectedCompanies
     )
+    setRequiredKeywords((current) =>
+      areKeywordListsEqual(current, activeParsedUrlState.requiredKeywords)
+        ? current
+        : activeParsedUrlState.requiredKeywords
+    )
     setSelectedExperienceLevel((current) =>
       (current ?? '') === (activeParsedUrlState.selectedExperienceLevel ?? '')
         ? current
@@ -807,6 +816,7 @@ export function useResumeListState(loadSearchHistory = false) {
       syncToUrl({
         location: locationForUrl,
         keywords: sessionKeywords,
+        requiredKeywords,
         jobDescriptionId,
         selectedTags,
         selectedCompanies,
@@ -820,6 +830,7 @@ export function useResumeListState(loadSearchHistory = false) {
     filters,
     hasCompletedUrlHydration,
     jobDescriptionId,
+    requiredKeywords,
     selectedCompanies,
     selectedExperienceLevel,
     selectedTags,
@@ -955,6 +966,14 @@ export function useResumeListState(loadSearchHistory = false) {
       )
     }
 
+    if (requiredKeywords.length > 0) {
+      const normalizedRequired = requiredKeywords.map((kw) => kw.trim().toLowerCase()).filter((kw) => kw.length > 0)
+      result = result.filter((resume: ScoredConvexResume) => {
+        const text = buildRuleScoringText(resume).toLowerCase()
+        return normalizedRequired.some((kw) => text.includes(kw))
+      })
+    }
+
     return result
   }, [
     blocksByIdentity,
@@ -963,6 +982,7 @@ export function useResumeListState(loadSearchHistory = false) {
     jobDescriptionId,
     keywordOnlyQueryScoring,
     queryRuleScoreMap,
+    requiredKeywords,
     selectedCompanies,
     selectedExperienceLevel,
     selectedTags,
@@ -1569,6 +1589,7 @@ export function useResumeListState(loadSearchHistory = false) {
     (config: {
       location: string
       keywords: string[]
+      requiredKeywords?: string[]
       jobDescriptionId?: string
       collectionSource?: CollectionSource | null
       collectUrl?: string
@@ -1591,6 +1612,8 @@ export function useResumeListState(loadSearchHistory = false) {
       })
 
       setSessionKeywords((current) => (areKeywordListsEqual(current, normalizedKeywords) ? current : normalizedKeywords))
+      const normalizedRequiredKeywords = (config.requiredKeywords ?? []).map((kw) => kw.trim()).filter((kw) => kw.length > 0)
+      setRequiredKeywords((current) => (areKeywordListsEqual(current, normalizedRequiredKeywords) ? current : normalizedRequiredKeywords))
       setJobDescriptionId((current) => (current === normalizedJobDescriptionId ? current : normalizedJobDescriptionId))
       setSessionCollectionSource((current) => {
         if (config.collectionSource === undefined) {
@@ -1616,7 +1639,7 @@ export function useResumeListState(loadSearchHistory = false) {
           : [],
       }))
     },
-    [setFilters, setJobDescriptionId, setSessionCollectionSource, setSessionCollectUrl, setSessionKeywords, setSessionLocation, shouldBlockQuickStartSync]
+    [setFilters, setJobDescriptionId, setRequiredKeywords, setSessionCollectionSource, setSessionCollectUrl, setSessionKeywords, setSessionLocation, shouldBlockQuickStartSync]
   )
 
   const handleQuickConstraintApply = useCallback(
@@ -1708,6 +1731,8 @@ export function useResumeListState(loadSearchHistory = false) {
     selectedIds,
     selectedTags,
     selectedCompanies,
+    requiredKeywords,
+    setRequiredKeywords,
     selectedExperienceLevel,
     activeTagFilters,
     activeCompanyFilters,

--- a/apps/web/src/hooks/useUrlSearchState.test.ts
+++ b/apps/web/src/hooks/useUrlSearchState.test.ts
@@ -40,6 +40,15 @@ describe('useUrlSearchState location parsing', () => {
     expect(state.keywords).toEqual(['CNC', '销售'])
   })
 
+  it('parses required keywords from rkw param', () => {
+    const state = parseUrlSearchState(
+      new URLSearchParams('keyword=%22Sales+Engineer%22+OR+%22Sales+Manager%22&rkw=CNC%2Cmachine+tools')
+    )
+
+    expect(state.keywords).toEqual(['Sales Engineer', 'Sales Manager'])
+    expect(state.requiredKeywords).toEqual(['CNC', 'machine tools'])
+  })
+
   it('serializes canonical OR phrase queries when syncing to the URL', () => {
     const currentParams = new URLSearchParams()
     useSearchParamsMock.mockReturnValue([currentParams, setSearchParamsMock])
@@ -49,6 +58,7 @@ describe('useUrlSearchState location parsing', () => {
     const nextState: UrlSearchState = {
       location: 'Kuala Lumpur MY',
       keywords: ['Sales Engineer', 'Sales Manager'],
+      requiredKeywords: [],
       jobDescriptionId: undefined,
       selectedTags: [],
       selectedCompanies: [],
@@ -68,5 +78,30 @@ describe('useUrlSearchState location parsing', () => {
     const updatedParams = updater(new URLSearchParams()) as URLSearchParams
     expect(updatedParams.get('location')).toBe('Kuala Lumpur MY')
     expect(updatedParams.get('keyword')).toBe('"Sales Engineer" OR "Sales Manager"')
+    expect(updatedParams.get('rkw')).toBeNull()
+  })
+
+  it('serializes required keywords into rkw param', () => {
+    const currentParams = new URLSearchParams()
+    useSearchParamsMock.mockReturnValue([currentParams, setSearchParamsMock])
+
+    const { result } = renderHook(() => useUrlSearchState())
+
+    const nextState: UrlSearchState = {
+      location: 'Kuala Lumpur MY',
+      keywords: ['Sales Engineer', 'Sales Manager'],
+      requiredKeywords: ['CNC', 'machine tools'],
+      jobDescriptionId: undefined,
+      selectedTags: [],
+      selectedCompanies: [],
+      selectedExperienceLevel: undefined,
+      filters: {},
+    }
+
+    result.current.syncToUrl(nextState)
+
+    const [updater] = setSearchParamsMock.mock.calls[0] ?? []
+    const updatedParams = updater(new URLSearchParams()) as URLSearchParams
+    expect(updatedParams.get('rkw')).toBe('CNC,machine tools')
   })
 })

--- a/apps/web/src/hooks/useUrlSearchState.ts
+++ b/apps/web/src/hooks/useUrlSearchState.ts
@@ -11,6 +11,7 @@ const KNOWN_PARAM_KEYS = [
   'jd',
   'tags',
   'co',
+  'rkw',
   'exp',
   'minExp',
   'maxExp',
@@ -32,6 +33,7 @@ export type ExperienceLevelFilter = 'senior' | 'mid' | 'junior'
 export type UrlSearchState = {
   location?: string
   keywords: string[]
+  requiredKeywords: string[]
   jobDescriptionId?: string
   selectedTags: string[]
   selectedCompanies: string[]
@@ -192,6 +194,7 @@ export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchSta
   const location = normalizedLocation || (effectiveLocations.length > 0 ? effectiveLocations.join(',') : undefined)
   const keywordRaw = getFirstParam(searchParams, ['kw', 'keyword'])
   const keywords = normalizeUniqueValues(parseKeywordParam(keywordRaw))
+  const requiredKeywords = normalizeUniqueValues(parseCsvParam(searchParams.get('rkw')))
   const jobDescriptionRaw = searchParams.get('jd')
   const jobDescriptionId = jobDescriptionRaw?.trim() || undefined
   const selectedTags = normalizeUniqueValues(parseCsvParam(searchParams.get('tags')))
@@ -258,6 +261,7 @@ export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchSta
   return {
     location,
     keywords,
+    requiredKeywords,
     jobDescriptionId,
     selectedTags,
     selectedCompanies,
@@ -308,6 +312,8 @@ export function useUrlSearchState() {
           : normalizedLocation
         setParam(nextParams, 'location', locationForUrl)
         setParam(nextParams, 'keyword', hasKeywords ? formatKeywordQuery(normalizedKeywords) : undefined)
+        const normalizedRequiredKeywords = normalizeUniqueValues(state.requiredKeywords)
+        setParam(nextParams, 'rkw', normalizedRequiredKeywords.length > 0 ? normalizedRequiredKeywords.join(',') : undefined)
         setParam(nextParams, 'jd', state.jobDescriptionId?.trim())
         setParam(nextParams, 'tags', normalizedTags.length > 0 ? normalizedTags.join(',') : undefined)
         setParam(nextParams, 'co', normalizedCompanies.length > 0 ? normalizedCompanies.join(',') : undefined)

--- a/config/search-profiles/seek-malaysia-sales.yaml
+++ b/config/search-profiles/seek-malaysia-sales.yaml
@@ -2,16 +2,17 @@ id: seek-malaysia-sales
 name: SEEK Malaysia Sales Engineer / Sales Manager
 description: Malaysia SEEK workflow for Kuala Lumpur sales hiring
 createdAt: "2026-03-17"
-updatedAt: "2026-03-17"
+updatedAt: "2026-03-20"
 status: active
 
 location: Kuala Lumpur MY
 keywords:
   - Sales Engineer
   - Sales Manager
+
+required_keywords:
   - CNC
   - machine tools
-  - Malaysia
 
 jobDescription: seek-malaysia-sales
 


### PR DESCRIPTION
## Summary
- Search profiles now support a `required_keywords` field: candidates must match at least one required keyword in their resume text (hard filter, not just scoring)
- New `rkw` URL param (comma-separated) persists the required keyword filter in the URL, enabling direct linking and browser-back/forward support
- `seek-malaysia-sales` profile now correctly separates role-title keywords (Sales Engineer, Sales Manager — OR mode for scoring) from required industry keywords (CNC, machine tools — hard filter)
- When a profile is applied via QuickStart, `required_keywords` from the YAML is automatically applied as the `rkw` filter

## Why
The keyword query system only supports all-AND or all-OR mode. Users couldn't express `("Sales Engineer" OR "Sales Manager") AND CNC` — adding CNC to keywords made everything OR. The `required_keywords` field is a clean, independent filter layer that works alongside the existing OR-mode keyword scoring.

## Behavior
- `rkw=CNC,machine tools` → resumes that don't mention CNC or machine tools in their scoring text are hidden
- Semantics: at least one required keyword must be present (OR within the required set)
- Profile YAML: `required_keywords: [CNC, machine tools]`

## Test plan
- [x] New `parseUrlSearchState` tests: `rkw` parsing and `rkw` serialization
- [x] All 354 tests pass (1 pre-existing Convex mock failure unrelated)
- [x] Typecheck + lint clean (`make check-node`)
- [ ] Verify at `/dev/resumes?location=Kuala+Lumpur+MY&keyword=%22Sales+Engineer%22+OR+%22Sales+Manager%22&rkw=CNC%2Cmachine+tools` — only CNC/machine tools candidates shown
- [ ] Load SEEK Malaysia profile from QuickStart — `rkw=CNC%2Cmachine+tools` auto-applied in URL