### PR TITLE
fix(resume): preserve rkw URL param when profile has no requiredKeywords

### DIFF
--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1612,8 +1612,10 @@ export function useResumeListState(loadSearchHistory = false) {
       })
 
       setSessionKeywords((current) => (areKeywordListsEqual(current, normalizedKeywords) ? current : normalizedKeywords))
-      const normalizedRequiredKeywords = (config.requiredKeywords ?? []).map((kw) => kw.trim()).filter((kw) => kw.length > 0)
-      setRequiredKeywords((current) => (areKeywordListsEqual(current, normalizedRequiredKeywords) ? current : normalizedRequiredKeywords))
+      if (config.requiredKeywords !== undefined) {
+        const normalizedRequiredKeywords = config.requiredKeywords.map((kw) => kw.trim()).filter((kw) => kw.length > 0)
+        setRequiredKeywords((current) => (areKeywordListsEqual(current, normalizedRequiredKeywords) ? current : normalizedRequiredKeywords))
+      }
       setJobDescriptionId((current) => (current === normalizedJobDescriptionId ? current : normalizedJobDescriptionId))
       setSessionCollectionSource((current) => {
         if (config.collectionSource === undefined) {


### PR DESCRIPTION
## Summary
- Guard `setRequiredKeywords` in `handleQuickStartApply` to only fire when `config.requiredKeywords !== undefined`
- Previously, `undefined` was coerced to `[]` via `?? []`, clearing URL-parsed required keywords on page load when a profile auto-matched without explicit `requiredKeywords`
- `rkw=CNC%2Cmachine+tools` in URL was being stripped when the SEEK Malaysia profile auto-applied

## Test plan
- [ ] Navigate to `http://localhost:5173/dev/resumes?location=Kuala+Lumpur+MY&keyword=%22Sales+Engineer%22+OR+%22Sales+Manager%22&rkw=CNC%2Cmachine+tools`
- [ ] Verify `rkw` param is preserved in URL after profile auto-matches
- [ ] Verify CNC/machine tools filter is active in the resume list
- [ ] Unit tests: all 6 `useUrlSearchState` tests pass