### PR TITLE
fix: enforce latest-three work history across resume flows

### DIFF
--- a/apps/api/src/routes/resumes.latest-work-history.test.ts
+++ b/apps/api/src/routes/resumes.latest-work-history.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createApp } from '../app'
+import { AIMatchingService } from '../services/ai-matching'
+import { ResumeService } from '../services/resume-service'
+
+describe('resume routes latest work history', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('passes only the latest three work history entries to AI matching payloads', async () => {
+    const matchBatchSpy = vi.spyOn(AIMatchingService.prototype, 'matchBatch').mockResolvedValue({
+      results: [{
+        resumeId: 'resume-latest-3-test',
+        result: {
+          score: 80,
+          recommendation: 'match',
+          highlights: [],
+          concerns: [],
+          summary: 'Good fit',
+          scoreSource: 'ai',
+        },
+      }],
+      processedCount: 1,
+      failedCount: 0,
+      processingTimeMs: 1,
+    })
+    vi.spyOn(AIMatchingService.prototype, 'getServiceInfo').mockReturnValue({
+      enabled: true,
+      resumesEnabled: true,
+      model: 'test-model',
+      apiBase: 'https://example.com',
+      apiKeyMasked: '***',
+      concurrency: 1,
+    })
+
+    const loadSampleSpy = vi.spyOn(ResumeService.prototype, 'loadSample').mockReturnValue({
+      items: [{
+        name: 'Alice',
+        profileUrl: 'https://example.com/resume-1',
+        activityStatus: 'Active',
+        age: '30',
+        experience: '5 years',
+        education: 'Bachelor',
+        location: 'Dongguan',
+        selfIntro: 'Intro',
+        jobIntention: 'Sales Engineer',
+        expectedSalary: '10k-20k',
+        workHistory: [
+          { raw: 'Oldest entry', companyName: 'Oldest Co', jobTitle: 'Old Role', startDate: '2018-01', endDate: '2019-01' },
+          { raw: 'Recent entry', companyName: 'Recent Co', jobTitle: 'Recent Role', startDate: '2023-01', endDate: '2024-01' },
+          { raw: 'Current entry', companyName: 'Current Co', jobTitle: 'Current Role', startDate: '2024-02', endDate: '至今' },
+          { raw: 'Middle entry', companyName: 'Middle Co', jobTitle: 'Middle Role', startDate: '2021-01', endDate: '2022-01' },
+        ],
+        extractedAt: '2026-03-13T00:00:00.000Z',
+        resumeId: 'resume-latest-3-test',
+      }],
+      sample: {
+        name: 'sample',
+        filename: 'sample.json',
+        updatedAt: '2026-03-13T00:00:00.000Z',
+        size: 1,
+      },
+      indexes: new Map(),
+    })
+
+    const app = createApp()
+    const response = await app.request('/api/resumes/match', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        source: 'sample',
+        persist: true,
+        mode: 'ai_only',
+        keywords: ['CNC', '销售'],
+        sample: 'sample',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(loadSampleSpy).toHaveBeenCalled()
+    expect(matchBatchSpy).toHaveBeenCalledTimes(1)
+    const resumesArg = matchBatchSpy.mock.calls[0]?.[0]
+    expect(resumesArg).toHaveLength(1)
+    expect(resumesArg[0]).toEqual(expect.objectContaining({
+      companies: ['Current Co', 'Recent Co', 'Middle Co'],
+      workHistory: [
+        '2024-02 ~ 至今 Current Co Current Role',
+        '2023-01 ~ 2024-01 Recent Co Recent Role',
+        '2021-01 ~ 2022-01 Middle Co Middle Role',
+      ].join('\n'),
+    }))
+    expect(resumesArg[0].workHistory).not.toContain('Oldest Co')
+  })
+})

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -53,13 +53,14 @@ import {
 import { resolveResumeId } from "../services/resume-id.js";
 import { IngestComputeService } from "../services/ingest-compute-service.js";
 import {
+  buildLatestWorkHistoryEvidence,
   buildWorkHistoryEntryText,
-  buildWorkHistoryEvidence,
   formatKeywordQuery,
   formatLocationHierarchySearchText,
   normalizeKeywordPhrases,
   normalizeWorkHistoryEntry,
   parseKeywordQuery,
+  selectLatestWorkHistory,
 } from "@trends/shared";
 import { SkillsKnowledgeService } from "../services/skills-knowledge.js";
 import { SearchEventLogger } from "../services/search-event-logger.js";
@@ -223,6 +224,10 @@ function extractSkills(...texts: (string | undefined)[]): string[] | undefined {
   }
   if (allParts.length === 0) return undefined;
   return Array.from(new Set(allParts)).slice(0, 20);
+}
+
+function getLatestWorkHistory(workHistory: ResumeItem["workHistory"] | undefined): ResumeItem["workHistory"] {
+  return selectLatestWorkHistory(workHistory ?? []);
 }
 
 function extractCompanies(workHistory: ResumeItem["workHistory"]): string[] | undefined {
@@ -1163,12 +1168,13 @@ function computeStats(
 }
 
 function createFallbackIndex(resume: ResumeItem, resumeId: string): ResumeIndex {
+  const latestWorkHistory = getLatestWorkHistory(resume.workHistory);
   const locationText = formatLocationHierarchySearchText(resume.locationHierarchy) || resume.location || "";
   const text = [
     resume.name,
     locationText,
     resume.education,
-    ...(resume.workHistory ?? []).map((item) => buildWorkHistoryEntryText(item)),
+    ...latestWorkHistory.map((item) => buildWorkHistoryEntryText(item)),
   ].join(" ").toLowerCase();
 
   return {
@@ -1181,11 +1187,11 @@ function createFallbackIndex(resume: ResumeItem, resumeId: string): ResumeIndex 
       || resume.location
       || null,
     skills: [],
-    companies: extractCompanies(resume.workHistory) ?? [],
+    companies: extractCompanies(latestWorkHistory) ?? [],
     industryTags: [],
     salaryRange: null,
     searchText: text,
-    evidenceText: buildWorkHistoryEvidence(resume.workHistory).text,
+    evidenceText: buildLatestWorkHistoryEvidence(latestWorkHistory).text,
   };
 }
 
@@ -1196,16 +1202,17 @@ function buildAiResumePayload(item: {
   companyHits: string[];
   roleSignals: PreparedResumeCandidate["roleSignals"];
 }): MatchingRequest["resume"] {
+  const latestWorkHistory = getLatestWorkHistory(item.resume.workHistory);
   return {
     id: item.resumeId,
     name: item.resume.name || "未命名",
     workExperience: item.indexData.experienceYears ?? undefined,
     education: item.resume.education || undefined,
     skills: item.indexData.skills,
-    companies: item.indexData.companies.length > 0 ? item.indexData.companies : extractCompanies(item.resume.workHistory),
+    companies: item.indexData.companies.length > 0 ? item.indexData.companies : extractCompanies(latestWorkHistory),
     companyHits: item.companyHits,
     roleSignals: item.roleSignals,
-    workHistory: buildWorkHistoryEvidence(item.resume.workHistory).lines.join("\n") || undefined,
+    workHistory: buildLatestWorkHistoryEvidence(latestWorkHistory).lines.join("\n") || undefined,
     sourceKey: item.resume.profileType === "seek" ? "seek" : item.resume.profileType,
   };
 }

--- a/apps/api/src/services/ingest-compute-service.test.ts
+++ b/apps/api/src/services/ingest-compute-service.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 
-import { buildWorkHistoryEvidence } from "@trends/shared";
+import { buildLatestWorkHistoryEvidence } from "@trends/shared";
 
 import { IngestComputeService, buildResumeIndex } from "./ingest-compute-service";
 
@@ -826,7 +826,7 @@ describe("IngestComputeService", () => {
 
     const index = buildResumeIndex(item, 0);
 
-    expect(index.evidenceText).toBe(buildWorkHistoryEvidence(item).text);
+    expect(index.evidenceText).toBe(buildLatestWorkHistoryEvidence(item).text);
     expect(index.evidenceText).toBe("2020-2025 sales engineer\ncnc 机床");
     expect(index.searchText).not.toContain("应届毕业生");
     expect(index.searchText).not.toContain("机械助理");

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -1,9 +1,10 @@
 import {
+  buildLatestWorkHistoryEvidence,
   buildWorkHistoryEntryText,
-  buildWorkHistoryEvidence,
   formatLocationHierarchySearchText,
   normalizeResumeLocationHierarchy,
   normalizeWorkHistoryEntry,
+  selectLatestWorkHistory,
 } from "@trends/shared";
 
 import { IndustryDataService } from "./industry-data-service.js";
@@ -241,14 +242,19 @@ function extractCompanies(workHistory: ResumeWorkHistoryItem[]): string[] {
   return Array.from(new Set(companies)).slice(0, 20);
 }
 
+function getLatestWorkHistory(workHistory: ResumeWorkHistoryItem[] | undefined): ResumeWorkHistoryItem[] {
+  return selectLatestWorkHistory(workHistory ?? []);
+}
+
 function createSearchText(item: ResumeItem): string {
   const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
+  const latestWorkHistory = getLatestWorkHistory(item.workHistory);
   const parts = [
     item.name,
     item.education,
     locationText,
     item.expectedSalary,
-    ...(item.workHistory?.map((entry) => buildWorkHistoryEntryText(entry)) ?? []),
+    ...latestWorkHistory.map((entry) => buildWorkHistoryEntryText(entry)),
   ];
 
   return normalizeText(parts.join(" "));
@@ -383,15 +389,16 @@ interface RoleSignalMatch {
  */
 export function buildResumeIndex(item: ResumeItem, index: number): ResumeIndex {
   const resumeId = resolveResumeId(item, index);
+  const latestWorkHistory = getLatestWorkHistory(item.workHistory);
   const searchText = createSearchText(item);
-  const companies = extractCompanies(item.workHistory ?? []);
-  const evidenceText = buildWorkHistoryEvidence(item.workHistory).text;
+  const companies = extractCompanies(latestWorkHistory);
+  const evidenceText = buildLatestWorkHistoryEvidence(latestWorkHistory).text;
 
   // For ingest compute, we don't need full skill extraction
   // We just need the basic fields for rule scoring
   return {
     resumeId,
-    experienceYears: computeWorkHistoryYears(item.workHistory),
+    experienceYears: computeWorkHistoryYears(latestWorkHistory),
     educationLevel: normalizeEducationLevel(item.education),
     locationCity: item.locationHierarchy?.city
       || item.locationHierarchy?.province
@@ -438,14 +445,15 @@ export class IngestComputeService {
     const synonymHits = this.computeSynonymHits(searchText);
 
     // 3. Compute field-aware brandHits, then derive companyHits for backward compatibility
-    const verifiedEmployers = this.collectVerifiedEmployerMatches(item.workHistory ?? []);
-    const brandHits = this.computeBrandHits(item, index.companies, searchText, verifiedEmployers);
+    const latestWorkHistory = getLatestWorkHistory(item.workHistory);
+    const verifiedEmployers = this.collectVerifiedEmployerMatches(latestWorkHistory);
+    const brandHits = this.computeBrandHits(latestWorkHistory, index.companies, searchText, verifiedEmployers);
     const companyHits = verifiedEmployers.map((m) => m.key);
     const { raw: industryDbV2Raw, components: industryDbV2RawComponents } = computeIndustryDbV2Raw(
       companyHits,
       brandHits
     );
-    const roleSignals = this.computeRoleSignals(item.workHistory ?? []);
+    const roleSignals = this.computeRoleSignals(latestWorkHistory);
     const companyPatternAliasTokens = this.buildCompanyAliasTokens(companyHits, brandHits);
 
     // 4. Compute ruleScores for all active JDs
@@ -961,7 +969,7 @@ export class IngestComputeService {
   /**
    * Compute field-aware brand hits from resume text segments.
    */
-  private computeBrandHits(item: ResumeItem, companies: string[], searchText: string, verifiedEmployers: VerifiedEmployerMatch[]): BrandHit[] {
+  private computeBrandHits(workHistory: ResumeWorkHistoryItem[], companies: string[], searchText: string, verifiedEmployers: VerifiedEmployerMatch[]): BrandHit[] {
     const patterns = this.skillsKnowledgeService.getCompanyPatterns();
     const normalizedSearchText = searchText.toLowerCase();
     const normalizedCompanies = companies
@@ -1052,8 +1060,6 @@ export class IngestComputeService {
         }
       }
     };
-
-    const workHistory = item.workHistory || [];
 
     // Pre-extract company names per work-history entry for the pattern-scan loop below.
     const extractedByEntry = workHistory.map((entry) => extractCompanies([entry]));

--- a/apps/api/src/services/resume-index.test.ts
+++ b/apps/api/src/services/resume-index.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { buildWorkHistoryEvidence } from "@trends/shared";
+import { buildLatestWorkHistoryEvidence } from "@trends/shared";
 
 import { ResumeIndexService } from "./resume-index";
 
@@ -101,7 +101,7 @@ describe("ResumeIndexService", () => {
       expect(entry?.skills.some((skill) => skill.includes("销售") || skill.includes("车床"))).toBe(true);
       expect(entry?.companies.some((company) => company.includes("机械设备"))).toBe(true);
       expect(entry?.industryTags).toEqual(["machinery", "sales"]);
-      expect(entry?.evidenceText).toBe(buildWorkHistoryEvidence(resumes[0]?.workHistory).text);
+      expect(entry?.evidenceText).toBe(buildLatestWorkHistoryEvidence(resumes[0]?.workHistory).text);
       expect(entry?.searchText).not.toContain("熟悉cnc车床和设备销售");
       expect(entry?.searchText).not.toContain("东莞 车床 销售 cnc");
       expect(resumes[0]?.profileEducation?.[0]?.institution).toBe("华南理工大学");

--- a/apps/api/src/services/resume-index.ts
+++ b/apps/api/src/services/resume-index.ts
@@ -2,13 +2,14 @@ import fs from "node:fs";
 import path from "node:path";
 
 import {
+  buildLatestWorkHistoryEvidence,
   buildWorkHistoryEntryText,
-  buildWorkHistoryEvidence,
   FALLBACK_INDUSTRY_KEYWORDS,
   formatLocationHierarchySearchText,
   findLocation,
   normalizeIndustryTags,
   normalizeLocationName,
+  selectLatestWorkHistory,
   type CanonicalIndustryTag,
 } from "@trends/shared";
 
@@ -77,6 +78,10 @@ function parseSalaryRange(value: string): { min?: number; max?: number } | null 
   return { min, max };
 }
 
+function getLatestWorkHistory(workHistory: ResumeWorkHistoryItem[] | undefined): ResumeWorkHistoryItem[] {
+  return selectLatestWorkHistory(workHistory ?? []);
+}
+
 function extractCompanies(workHistory: ResumeWorkHistoryItem[]): string[] {
   if (!workHistory.length) return [];
 
@@ -89,12 +94,13 @@ function extractCompanies(workHistory: ResumeWorkHistoryItem[]): string[] {
 
 function createSearchText(item: ResumeItem): string {
   const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
+  const latestWorkHistory = getLatestWorkHistory(item.workHistory);
   const parts = [
     item.name,
     item.education,
     locationText,
     item.expectedSalary,
-    ...(item.workHistory?.map((entry) => buildWorkHistoryEntryText(entry)) ?? []),
+    ...latestWorkHistory.map((entry) => buildWorkHistoryEntryText(entry)),
   ];
 
   return normalizeText(parts.join(" "));
@@ -267,16 +273,17 @@ export class ResumeIndexService {
     for (let i = 0; i < items.length; i += 1) {
       const item = items[i];
       const resumeId = resolveResumeId(item, i);
+      const latestWorkHistory = getLatestWorkHistory(item.workHistory);
       const searchText = createSearchText(item);
-      const companies = extractCompanies(item.workHistory ?? []);
+      const companies = extractCompanies(latestWorkHistory);
       const skills = this.extractSkills(searchText);
       const tagHaystack = [searchText, ...skills, ...companies].join(" ").toLowerCase();
 
-      const evidenceText = buildWorkHistoryEvidence(item.workHistory).text;
+      const evidenceText = buildLatestWorkHistoryEvidence(latestWorkHistory).text;
 
       nextMap.set(resumeId, {
         resumeId,
-        experienceYears: computeWorkHistoryYears(item.workHistory ?? []),
+        experienceYears: computeWorkHistoryYears(latestWorkHistory),
         educationLevel: normalizeEducationLevel(item.education),
         locationCity: this.extractLocationCity(item),
         evidenceText,

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -6,6 +6,7 @@ import {
   isLocationMatch,
   normalizeProfileUrlForDisplay,
   normalizeSharedResumeFields,
+  selectLatestWorkHistory,
 } from "@trends/shared";
 
 import { findProjectRoot } from "./db.js";
@@ -236,6 +237,7 @@ function countOccurrences(haystack: string, needle: string): number {
 
 function buildSearchText(item: ResumeItem): string {
   const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
+  const latestWorkHistory = selectLatestWorkHistory(item.workHistory);
   const parts = [
     item.name,
     item.jobIntention,
@@ -243,7 +245,7 @@ function buildSearchText(item: ResumeItem): string {
     item.education,
     locationText,
     item.expectedSalary,
-    ...(item.workHistory?.map((entry) => buildWorkHistoryEntryText(entry)) ?? []),
+    ...latestWorkHistory.map((entry) => buildWorkHistoryEntryText(entry)),
   ];
   return parts.join(" ").toLowerCase();
 }
@@ -453,7 +455,7 @@ export class ResumeService {
       const name = (item.name || "").toLowerCase();
       const jobIntention = (item.jobIntention || "").toLowerCase();
       const searchText = index?.searchText || buildSearchText(item);
-      const companies = index?.companies ?? (item.workHistory?.map((wh) => extractCompanyFromWorkHistory(wh)) || []);
+      const companies = index?.companies ?? selectLatestWorkHistory(item.workHistory).map((wh) => extractCompanyFromWorkHistory(wh));
 
       const perKeywordScores = keywordSets.map(({ original, variants }) => {
         let score = 0;

--- a/apps/api/src/services/unified-search-service.ts
+++ b/apps/api/src/services/unified-search-service.ts
@@ -1,4 +1,4 @@
-import { buildWorkHistoryEntryText, formatLocationHierarchySearchText } from "@trends/shared";
+import { buildWorkHistoryEntryText, formatLocationHierarchySearchText, selectLatestWorkHistory } from "@trends/shared";
 
 import { parseSearchQuery } from "./query-parser.js";
 import { resolveResumeId } from "./resume-id.js";
@@ -46,6 +46,7 @@ function normalizeToken(value: string): string {
 
 function buildSearchText(item: ResumeItem): string {
   const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
+  const latestWorkHistory = selectLatestWorkHistory(item.workHistory);
   const parts = [
     item.name,
     item.jobIntention,
@@ -53,7 +54,7 @@ function buildSearchText(item: ResumeItem): string {
     item.education,
     locationText,
     item.expectedSalary,
-    ...(item.workHistory?.map((entry) => buildWorkHistoryEntryText(entry)) ?? []),
+    ...latestWorkHistory.map((entry) => buildWorkHistoryEntryText(entry)),
   ];
   return parts.join(" ").toLowerCase();
 }
@@ -182,7 +183,7 @@ export class UnifiedSearchService {
       const resumeId = resolveResumeId(item, i);
       const index = options?.indexMap?.get(resumeId);
       const searchText = index?.searchText || buildSearchText(item);
-      const companies = index?.companies ?? (item.workHistory?.map((entry) => extractCompanyFromWorkHistory(entry)) || []);
+      const companies = index?.companies ?? selectLatestWorkHistory(item.workHistory).map((entry) => extractCompanyFromWorkHistory(entry));
       const industryTags = index?.industryTags ?? [];
       const provenance: UnifiedSearchProvenance[] = [];
       let matchedGroupCount = 0;

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -1391,7 +1391,7 @@ async function enrichSingleJob5156SearchResumeWithDetail(resume, extractedAt) {
     return {
       ...fallbackResume,
       ...detailResume,
-      workHistory: (detailResume.workHistory || fallbackResume.workHistory || []).slice(0, 3),
+      workHistory: detailResume.workHistory || fallbackResume.workHistory || [],
       resumeId: detailResume.resumeId || fallbackResume.resumeId,
       perUserId: detailResume.perUserId || fallbackResume.perUserId,
       extractedAt: fallbackResume.extractedAt,

--- a/apps/web/src/components/OutreachModal.test.tsx
+++ b/apps/web/src/components/OutreachModal.test.tsx
@@ -1,0 +1,95 @@
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { OutreachModal } from './OutreachModal'
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ children, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) => <label {...props}>{children}</label>,
+}))
+
+describe('OutreachModal latest work history', () => {
+  it('sends only the latest three work history entries to draft generation', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ subject: 'Hello', body: 'World' }),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <OutreachModal
+        isOpen
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+        analysis={{
+          resumeId: 'resume-1',
+          score: 80,
+          recommendation: 'match',
+          highlights: [],
+          concerns: [],
+          summary: 'Good fit',
+          matchedAt: '2026-03-13T00:00:00.000Z',
+        }}
+        jobDescription={{
+          id: 'jd-1',
+          title: 'Sales Engineer',
+          requirements: 'CNC sales',
+        }}
+        resume={{
+          resumeId: 'resume-1',
+          name: 'Alice',
+          profileUrl: 'https://example.com/resume-1',
+          activityStatus: 'Active',
+          age: '30',
+          experience: '5',
+          education: 'Bachelor',
+          location: 'Dongguan',
+          selfIntro: 'alice@example.com',
+          jobIntention: 'Sales Engineer',
+          expectedSalary: '10k-20k',
+          workHistory: [
+            { raw: 'Oldest entry', companyName: 'Oldest Co', jobTitle: 'Old Role', startDate: '2018-01', endDate: '2019-01' },
+            { raw: 'Recent entry', companyName: 'Recent Co', jobTitle: 'Recent Role', startDate: '2023-01', endDate: '2024-01' },
+            { raw: 'Current entry', companyName: 'Current Co', jobTitle: 'Current Role', startDate: '2024-02', endDate: '至今' },
+            { raw: 'Middle entry', companyName: 'Middle Co', jobTitle: 'Middle Role', startDate: '2021-01', endDate: '2022-01' },
+          ],
+          extractedAt: '2026-03-13T00:00:00.000Z',
+        }}
+      />
+    )
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(String(init?.body ?? '{}'))
+
+    expect(body.resume.companies).toEqual([
+      'Current Co',
+      'Recent Co',
+      'Middle Co',
+    ])
+    expect(body.resume.companies).not.toContain('Oldest Co')
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/apps/web/src/components/OutreachModal.tsx
+++ b/apps/web/src/components/OutreachModal.tsx
@@ -1,5 +1,5 @@
 
-import { buildWorkHistoryEntryText } from "@trends/shared";
+import { selectLatestWorkHistory } from "@trends/shared";
 import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -63,7 +63,9 @@ export function OutreachModal({
                         workExperience: parseInt(resume.experience) || 0,
                         education: resume.education,
                         jobIntention: resume.jobIntention,
-                        companies: resume.workHistory?.map((work) => buildWorkHistoryEntryText(work)).filter((item) => item.length > 0) ?? [],
+                        companies: selectLatestWorkHistory(resume.workHistory)
+                            .map((work) => work.companyName)
+                            .filter((company): company is string => typeof company === "string" && company.length > 0),
                     },
                     jobDescription,
                     analysis,

--- a/apps/web/src/components/ResumeCard.test.tsx
+++ b/apps/web/src/components/ResumeCard.test.tsx
@@ -42,4 +42,36 @@ describe('ResumeCard brand-hit badges', () => {
     expect(screen.queryByText('debugIngest.brandContext.sales')).not.toBeInTheDocument()
     expect(screen.queryByText(/workHistory/i)).not.toBeInTheDocument()
   })
+
+  it('renders only the latest three work history entries', () => {
+    render(
+      <ResumeCard
+        resume={{
+          name: 'Alice',
+          profileUrl: 'https://example.com/resume-1',
+          activityStatus: 'Active',
+          age: '30',
+          experience: '5 years',
+          education: 'Bachelor',
+          location: 'Dongguan',
+          selfIntro: 'Test intro',
+          jobIntention: 'Sales Engineer',
+          expectedSalary: '10k-20k',
+          workHistory: [
+            { raw: 'Oldest entry', companyName: 'Oldest Co', jobTitle: 'Old Role', startDate: '2018-01', endDate: '2019-01' },
+            { raw: 'Recent entry', companyName: 'Recent Co', jobTitle: 'Recent Role', startDate: '2023-01', endDate: '2024-01' },
+            { raw: 'Current entry', companyName: 'Current Co', jobTitle: 'Current Role', startDate: '2024-02', endDate: '至今' },
+            { raw: 'Middle entry', companyName: 'Middle Co', jobTitle: 'Middle Role', startDate: '2021-01', endDate: '2022-01' },
+          ],
+          extractedAt: '2026-03-13T00:00:00.000Z',
+        }}
+        onViewDetails={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('2024-02 ~ 至今 Current Co Current Role')).toBeInTheDocument()
+    expect(screen.getByText('2023-01 ~ 2024-01 Recent Co Recent Role')).toBeInTheDocument()
+    expect(screen.getByText('2021-01 ~ 2022-01 Middle Co Middle Role')).toBeInTheDocument()
+    expect(screen.queryByText('2018-01 ~ 2019-01 Oldest Co Old Role')).not.toBeInTheDocument()
+  })
 })

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -1,4 +1,4 @@
-import { buildWorkHistoryEntryText } from '@trends/shared'
+import { buildWorkHistoryEntryText, selectLatestWorkHistory } from '@trends/shared'
 import { useTranslation } from 'react-i18next'
 import { User, CheckCircle, XCircle, Phone, Star, Ban, MessageSquare } from 'lucide-react'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -182,8 +182,7 @@ export function ResumeCard({
   const [blockNoteInput, setBlockNoteInput] = useState('')
   const [commentDialogOpen, setCommentDialogOpen] = useState(false)
   const [commentNoteInput, setCommentNoteInput] = useState('')
-  const workHistory = (resume.workHistory ?? [])
-    .slice(0, 3)
+  const workHistory = selectLatestWorkHistory(resume.workHistory)
     .map((item) => ({
       item,
       text: buildWorkHistoryEntryText(item),

--- a/apps/web/src/components/ResumeDetail.test.tsx
+++ b/apps/web/src/components/ResumeDetail.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ResumeDetail } from './ResumeDetail'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  buttonVariants: () => '',
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock('@/components/AiFeedbackButtons', () => ({
+  AiFeedbackButtons: () => null,
+}))
+
+describe('ResumeDetail latest work history', () => {
+  it('renders only the latest three work history entries', () => {
+    render(
+      <ResumeDetail
+        open
+        onOpenChange={vi.fn()}
+        resume={{
+          name: 'Alice',
+          profileUrl: 'https://example.com/resume-1',
+          activityStatus: 'Active',
+          age: '30',
+          experience: '5 years',
+          education: 'Bachelor',
+          location: 'Dongguan',
+          selfIntro: 'Test intro',
+          jobIntention: 'Sales Engineer',
+          expectedSalary: '10k-20k',
+          workHistory: [
+            { raw: 'Oldest entry', companyName: 'Oldest Co', jobTitle: 'Old Role', startDate: '2018-01', endDate: '2019-01' },
+            { raw: 'Recent entry', companyName: 'Recent Co', jobTitle: 'Recent Role', startDate: '2023-01', endDate: '2024-01' },
+            { raw: 'Current entry', companyName: 'Current Co', jobTitle: 'Current Role', startDate: '2024-02', endDate: '至今' },
+            { raw: 'Middle entry', companyName: 'Middle Co', jobTitle: 'Middle Role', startDate: '2021-01', endDate: '2022-01' },
+          ],
+          extractedAt: '2026-03-13T00:00:00.000Z',
+        }}
+      />
+    )
+
+    expect(screen.getByText('Current Co · Current Role')).toBeInTheDocument()
+    expect(screen.getByText('Recent Co · Recent Role')).toBeInTheDocument()
+    expect(screen.getByText('Middle Co · Middle Role')).toBeInTheDocument()
+    expect(screen.queryByText('Oldest Co · Old Role')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ChevronDown, ChevronUp } from 'lucide-react'
-import { buildWorkHistoryDateRange, normalizeWorkHistoryEntry, RESUME_AI_PROMPT_LOCALE_TO_NATURAL_LANGUAGE } from '@trends/shared'
+import { buildWorkHistoryDateRange, normalizeWorkHistoryEntry, RESUME_AI_PROMPT_LOCALE_TO_NATURAL_LANGUAGE, selectLatestWorkHistory } from '@trends/shared'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -47,7 +47,7 @@ export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreF
 
   const workHistory = useMemo(() => {
     if (!resume?.workHistory?.length) return []
-    return resume.workHistory.filter((item) => normalizeWorkHistoryEntry(item) !== null)
+    return selectLatestWorkHistory(resume.workHistory)
   }, [resume])
   const workHistoryAnnotations = useMemo(() => {
     if (!resume || !hasIngestData(resume)) {

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -165,24 +165,45 @@ describe('resume-scoring', () => {
     }
   })
 
-  it('builds rule scoring text from structured work history entries', () => {
+  it('builds rule scoring text from the latest three structured work history entries', () => {
     const resume = createResume({
       workHistory: [
         {
-          raw: '2021-03 ~ 2023-08 Example Co. Sales Engineer',
+          raw: 'legacy fallback line',
+          companyName: 'Legacy Works',
+          jobTitle: 'Old Role',
+          startDate: '2016-01',
+          endDate: '2017-02',
         },
         {
-          raw: 'legacy fallback line',
+          raw: '2021-03 ~ 2023-08 Example Co. Sales Engineer',
+          companyName: 'Example Co.',
+          jobTitle: 'Sales Engineer',
+          startDate: '2021-03',
+          endDate: '2023-08',
+        },
+        {
+          raw: 'recent structured line',
           companyName: 'Precision Works',
           jobTitle: 'CNC Sales',
-          startDate: '2019-01',
-          endDate: '2021-02',
+          startDate: '2024-01',
+          endDate: '2025-02',
+        },
+        {
+          raw: 'current structured line',
+          companyName: 'Current Automation',
+          jobTitle: 'Regional Manager',
+          startDate: '2025-03',
+          endDate: '至今',
         },
       ],
     })
 
-    expect(buildRuleScoringText(resume)).toContain('Precision Works CNC Sales')
-    expect(buildRuleScoringText(resume)).toContain('2019-01 ~ 2021-02')
+    const text = buildRuleScoringText(resume)
+    expect(text).toContain('Current Automation Regional Manager')
+    expect(text).toContain('2024-01 ~ 2025-02')
+    expect(text).toContain('Example Co. Sales Engineer')
+    expect(text).not.toContain('Legacy Works Old Role')
   })
 
   it('flags auto-filtered analyses', () => {

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -1,5 +1,5 @@
 import {
-  buildWorkHistoryEntryText,
+  buildLatestWorkHistoryEvidence,
   getCurrentResumeAiPromptVersion,
   normalizeKeywordSalesAnalysis,
   normalizeOptionalString,
@@ -182,7 +182,7 @@ export function buildRuleScoringText(resume: {
     resume.experience,
     resume.location,
     resume.selfIntro,
-    ...(resume.workHistory || []).map((work) => buildWorkHistoryEntryText(work)),
+    ...buildLatestWorkHistoryEvidence(resume.workHistory).lines,
     resume.tags?.join(' '),
   ]
     .filter((item): item is string => Boolean(item))

--- a/packages/convex/convex/__tests__/ai-tagging-results.test.ts
+++ b/packages/convex/convex/__tests__/ai-tagging-results.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildWorkHistoryEvidence } from "@trends/shared";
+import { buildLatestWorkHistoryEvidence } from "@trends/shared";
 
 import { buildAiTaggingIdentity, buildEvidenceTextFromWorkHistory, resolveAiTaggingEvidence, stableHash } from "../ai_tagging_results";
 
@@ -41,7 +41,7 @@ describe("buildEvidenceTextFromWorkHistory", () => {
             workHistory: ["  Sales   Engineer ", { raw: " CNC 机床 " }],
         };
 
-        expect(buildEvidenceTextFromWorkHistory(input)).toEqual(buildWorkHistoryEvidence(input));
+        expect(buildEvidenceTextFromWorkHistory(input)).toEqual(buildLatestWorkHistoryEvidence(input));
     });
 });
 
@@ -76,7 +76,7 @@ describe("resolveAiTaggingEvidence", () => {
     });
 
     it("matches legacy backfill output for stable queue identity", () => {
-        const evidenceText = buildWorkHistoryEvidence({
+        const evidenceText = buildLatestWorkHistoryEvidence({
             workHistory: [
                 { raw: " 2020-2025 Sales Engineer " },
                 { raw: " CNC 机床 " },

--- a/packages/convex/convex/__tests__/analysis-strict-evidence.test.ts
+++ b/packages/convex/convex/__tests__/analysis-strict-evidence.test.ts
@@ -44,6 +44,19 @@ describe("normalizeResume strict evidence", () => {
     expect(normalized.verifiedCompanies).toEqual([]);
   });
 
+  it("limits derived companies to the latest three work history entries", () => {
+    const normalized = normalizeResume({
+      workHistory: [
+        { raw: "2018-01 ~ 2019-01 Oldest Co Old Role", startDate: "2018-01", endDate: "2019-01", companyName: "Oldest Co", jobTitle: "Old Role" },
+        { raw: "2023-01 ~ 2024-01 Recent Co Recent Role", startDate: "2023-01", endDate: "2024-01", companyName: "Recent Co", jobTitle: "Recent Role" },
+        { raw: "2024-02 ~ 至今 Current Co Current Role", startDate: "2024-02", endDate: "至今", companyName: "Current Co", jobTitle: "Current Role" },
+        { raw: "2021-01 ~ 2022-01 Middle Co Middle Role", startDate: "2021-01", endDate: "2022-01", companyName: "Middle Co", jobTitle: "Middle Role" },
+      ],
+    } as unknown, { locale: "en" });
+
+    expect(normalized.companies).toBe("Current Co, Recent Co, Middle Co");
+  });
+
   it("formats structured work-entry evidence in English when locale is en", () => {
     const normalized = normalizeResume({
       ingestData: {

--- a/packages/convex/convex/__tests__/search-text.test.ts
+++ b/packages/convex/convex/__tests__/search-text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { appendMissingSearchTokens, buildIngestSearchTokens, mergeSearchTextWithIngestData } from "../search_text";
+import { appendMissingSearchTokens, buildIngestSearchTokens, buildSearchText, mergeSearchTextWithIngestData } from "../search_text";
 
 describe("buildIngestSearchTokens", () => {
     it("normalizes and deduplicates ingest metadata tokens", () => {
@@ -46,5 +46,19 @@ describe("mergeSearchTextWithIngestData", () => {
             companyHits: ["fanuc"],
             companyPatternAliasTokens: "fanuc 发那科 mitsubishi 三菱",
         })).toBe("销售 cnc 三菱 machinery sales sales engineer mitsubishi fanuc 发那科");
+    });
+});
+
+describe("buildSearchText", () => {
+    it("uses only the latest three work history entries", () => {
+        expect(buildSearchText({
+            name: "Alice",
+            workHistory: [
+                { raw: "2018-01 ~ 2019-01 Oldest Co Old Role", startDate: "2018-01", endDate: "2019-01", companyName: "Oldest Co", jobTitle: "Old Role" },
+                { raw: "2023-01 ~ 2024-01 Recent Co Recent Role", startDate: "2023-01", endDate: "2024-01", companyName: "Recent Co", jobTitle: "Recent Role" },
+                { raw: "2024-02 ~ 至今 Current Co Current Role", startDate: "2024-02", endDate: "至今", companyName: "Current Co", jobTitle: "Current Role" },
+                { raw: "2021-01 ~ 2022-01 Middle Co Middle Role", startDate: "2021-01", endDate: "2022-01", companyName: "Middle Co", jobTitle: "Middle Role" },
+            ],
+        })).toBe("alice 2024-02 ~ 至今 current co current role 2023-01 ~ 2024-01 recent co recent role 2021-01 ~ 2022-01 middle co middle role");
     });
 });

--- a/packages/convex/convex/ai_tagging_results.ts
+++ b/packages/convex/convex/ai_tagging_results.ts
@@ -1,5 +1,5 @@
 /// <reference path="./convex-env.d.ts" />
-import { buildWorkHistoryEvidence } from "@trends/shared";
+import { buildLatestWorkHistoryEvidence } from "@trends/shared";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { internalAction, internalMutation, internalQuery, mutation, query } from "./_generated/server";
@@ -80,7 +80,7 @@ export function resolveAiTaggingEvidence(resume: Pick<Doc<"resumes">, "content" 
 }
 
 export function buildEvidenceTextFromWorkHistory(content: unknown): { lines: string[]; text: string } {
-  return buildWorkHistoryEvidence(content);
+  return buildLatestWorkHistoryEvidence(content);
 }
 
 export function buildAiTaggingIdentity(input: {

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -8,6 +8,7 @@ import {
     isSalesRequiredContext,
     normalizeKeywordSalesAnalysis,
     resolveResumeAiPromptLocale,
+    selectLatestWorkHistory,
 } from "@trends/shared";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
@@ -279,20 +280,12 @@ export function normalizeResume(
         ? root.ingestData
         : (isRecord(content.ingestData) ? content.ingestData : undefined);
 
+    const latestWorkHistory = selectLatestWorkHistory(content.workHistory);
+
     // Extract companies from workHistory since resume content has no "companies" field
-    const historyCompanies = Array.isArray(content.workHistory)
-        ? content.workHistory
-            .map((item) => {
-                if (typeof item === "string") {
-                    return item;
-                }
-                if (isRecord(item) && typeof item.raw === "string") {
-                    return item.raw;
-                }
-                return "";
-            })
-            .filter((item): item is string => item.length > 0)
-        : [];
+    const historyCompanies = latestWorkHistory
+        .map((item) => item.companyName)
+        .filter((item): item is string => typeof item === "string" && item.length > 0);
     const existingCompanies = Array.isArray(content.companies)
         ? content.companies.filter((item): item is string => typeof item === "string" && item.length > 0)
         : [];

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -3,7 +3,7 @@ import { action, mutation } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import {
-    buildWorkHistoryEvidence,
+    buildLatestWorkHistoryEvidence,
     formatLocationHierarchyLabel,
     normalizeJob5156ProfileUrlForDisplay,
     normalizeResumeLocationHierarchy,
@@ -413,7 +413,7 @@ function rewrite51jobManualContent(content: unknown, source: string): {
     return {
         content: rewrittenContent,
         contentChanged: changed,
-        evidenceText: buildWorkHistoryEvidence(rewrittenContent).text,
+        evidenceText: buildLatestWorkHistoryEvidence(rewrittenContent).text,
     };
 }
 
@@ -795,7 +795,7 @@ export const backfillEvidenceText = mutation({
             await ctx.db.patch(resume._id, {
                 ingestData: {
                     ...resume.ingestData,
-                    evidenceText: buildWorkHistoryEvidence(resume.content).text,
+                    evidenceText: buildLatestWorkHistoryEvidence(resume.content).text,
                 },
             });
             patched += 1;
@@ -954,7 +954,7 @@ export const backfillJob5156WorkHistoryEducation = mutation({
                 ingestData: resume.ingestData
                     ? {
                         ...resume.ingestData,
-                        evidenceText: buildWorkHistoryEvidence(rewritten.content).text,
+                        evidenceText: buildLatestWorkHistoryEvidence(rewritten.content).text,
                     }
                     : resume.ingestData,
             });

--- a/packages/convex/convex/search_text.ts
+++ b/packages/convex/convex/search_text.ts
@@ -1,4 +1,4 @@
-import { formatLocationHierarchySearchText, type LocationHierarchy } from "@trends/shared";
+import { buildLatestWorkHistoryEvidence, formatLocationHierarchySearchText, type LocationHierarchy } from "@trends/shared";
 
 const PRIORITY_KEYS = [
     "name",
@@ -145,6 +145,10 @@ function collectPriorityFragments(content: UnknownRecord): string[] {
             if (locationHierarchy) {
                 parts.push(locationHierarchy);
             }
+            continue;
+        }
+        if (key === "workHistory") {
+            parts.push(...buildLatestWorkHistoryEvidence(content[key]).lines);
             continue;
         }
         parts.push(...toTextFragments(content[key]));

--- a/packages/convex/convex/seed.ts
+++ b/packages/convex/convex/seed.ts
@@ -3,7 +3,7 @@ import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import {
-  buildWorkHistoryEvidence,
+  buildLatestWorkHistoryEvidence,
   generateStructuredJobDescriptionContent,
 } from "@trends/shared";
 import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
@@ -152,7 +152,7 @@ function buildSeekMalaysiaSalesDemoResume(seededAt: number) {
     noticePeriodDays: 30,
     extractedAt: "2026-03-17T08:00:00.000Z",
   };
-  const evidenceText = buildWorkHistoryEvidence(content.workHistory).text;
+  const evidenceText = buildLatestWorkHistoryEvidence(content.workHistory).text;
   const ingestData = {
     evidenceText,
     industryTags: ["machinery", "sales"],

--- a/packages/shared/src/__tests__/work-history-evidence.test.ts
+++ b/packages/shared/src/__tests__/work-history-evidence.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLatestWorkHistoryEvidence,
+  buildWorkHistoryEvidence,
+  selectLatestWorkHistory,
+} from "../work-history-evidence";
+
+describe("work-history evidence helpers", () => {
+  it("selects the latest three entries by recency", () => {
+    const selected = selectLatestWorkHistory([
+      { raw: "2018-01 Legacy Co.", startDate: "2018-01", endDate: "2019-01", companyName: "Legacy Co." },
+      { raw: "2024-05 Current Co.", startDate: "2024-05", endDate: "至今", companyName: "Current Co." },
+      { raw: "2021-03 Mid Co.", startDate: "2021-03", endDate: "2023-12", companyName: "Mid Co." },
+      { raw: "2024-01 Recent Co.", startDate: "2024-01", endDate: "2024-04", companyName: "Recent Co." },
+      { raw: "2020-02 Older Co.", startDate: "2020-02", endDate: "2021-02", companyName: "Older Co." },
+    ]);
+
+    expect(selected.map((entry) => entry.companyName)).toEqual([
+      "Current Co.",
+      "Recent Co.",
+      "Mid Co.",
+    ]);
+  });
+
+  it("keeps input order as a stable fallback when dates are missing", () => {
+    const selected = selectLatestWorkHistory([
+      { raw: "First Co.", companyName: "First Co." },
+      { raw: "Second Co.", companyName: "Second Co." },
+      { raw: "Third Co.", companyName: "Third Co." },
+      { raw: "Fourth Co.", companyName: "Fourth Co." },
+    ]);
+
+    expect(selected.map((entry) => entry.companyName)).toEqual([
+      "First Co.",
+      "Second Co.",
+      "Third Co.",
+    ]);
+  });
+
+  it("builds latest-work-history evidence without mutating full evidence behavior", () => {
+    const workHistory = [
+      { raw: "2018-01 Legacy Co.", startDate: "2018-01", endDate: "2019-01", companyName: "Legacy Co.", jobTitle: "Operator" },
+      { raw: "2024-05 Current Co.", startDate: "2024-05", endDate: "至今", companyName: "Current Co.", jobTitle: "Manager" },
+      { raw: "2021-03 Mid Co.", startDate: "2021-03", endDate: "2023-12", companyName: "Mid Co.", jobTitle: "Engineer" },
+      { raw: "2024-01 Recent Co.", startDate: "2024-01", endDate: "2024-04", companyName: "Recent Co.", jobTitle: "Sales" },
+    ];
+
+    expect(buildWorkHistoryEvidence(workHistory).lines).toHaveLength(4);
+    expect(buildLatestWorkHistoryEvidence(workHistory).lines).toEqual([
+      "2024-05 ~ 至今 Current Co. Manager",
+      "2024-01 ~ 2024-04 Recent Co. Sales",
+      "2021-03 ~ 2023-12 Mid Co. Engineer",
+    ]);
+  });
+});

--- a/packages/shared/src/work-history-evidence.ts
+++ b/packages/shared/src/work-history-evidence.ts
@@ -28,6 +28,12 @@ export type WorkHistoryEvidence = {
   text: string;
 };
 
+export type WorkHistorySelectionOptions = {
+  limit?: number;
+};
+
+export const LATEST_WORK_HISTORY_LIMIT = 3;
+
 function toRawEntries(input: unknown): unknown[] {
   if (Array.isArray(input)) {
     return input;
@@ -71,6 +77,107 @@ export function normalizeWorkHistoryEntry(entry: unknown): NormalizedWorkHistory
   };
 }
 
+export function getNormalizedWorkHistoryEntries(input: unknown): NormalizedWorkHistoryEntry[] {
+  return toRawEntries(input)
+    .map((entry) => normalizeWorkHistoryEntry(entry))
+    .filter((entry): entry is NormalizedWorkHistoryEntry => entry !== null);
+}
+
+type WorkHistoryRecency = {
+  primaryDateValue: number | null;
+  startDateValue: number | null;
+};
+
+const CURRENT_WORK_HISTORY_MARKER = /^(?:至今|目前|今|present|current|now|ongoing)$/iu;
+
+function parseWorkHistoryDateValue(value: string | undefined): number | null {
+  const normalized = toOptionalString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  if (CURRENT_WORK_HISTORY_MARKER.test(normalized)) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  const match = normalized.match(/^((?:19|20)\d{2})(?:[-./年](\d{1,2}))?/u);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2] || 12);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || month < 1 || month > 12) {
+    return null;
+  }
+
+  return year * 12 + month;
+}
+
+function getWorkHistoryRecency(entry: NormalizedWorkHistoryEntry): WorkHistoryRecency {
+  const endDateValue = parseWorkHistoryDateValue(entry.endDate);
+  const startDateValue = parseWorkHistoryDateValue(entry.startDate);
+
+  return {
+    primaryDateValue: endDateValue ?? startDateValue,
+    startDateValue,
+  };
+}
+
+function compareWorkHistoryRecency(left: WorkHistoryRecency, right: WorkHistoryRecency): number {
+  if (
+    left.primaryDateValue !== null
+    && right.primaryDateValue !== null
+    && left.primaryDateValue !== right.primaryDateValue
+  ) {
+    return right.primaryDateValue - left.primaryDateValue;
+  }
+
+  if (
+    left.startDateValue !== null
+    && right.startDateValue !== null
+    && left.startDateValue !== right.startDateValue
+  ) {
+    return right.startDateValue - left.startDateValue;
+  }
+
+  if (left.primaryDateValue !== null && right.primaryDateValue === null) {
+    return -1;
+  }
+
+  if (left.primaryDateValue === null && right.primaryDateValue !== null) {
+    return 1;
+  }
+
+  return 0;
+}
+
+export function selectLatestWorkHistory(
+  input: unknown,
+  options?: WorkHistorySelectionOptions,
+): NormalizedWorkHistoryEntry[] {
+  const limit = Math.max(0, Math.floor(options?.limit ?? LATEST_WORK_HISTORY_LIMIT));
+  if (limit === 0) {
+    return [];
+  }
+
+  return getNormalizedWorkHistoryEntries(input)
+    .map((entry, index) => ({
+      entry,
+      index,
+      recency: getWorkHistoryRecency(entry),
+    }))
+    .sort((left, right) => {
+      const recencyComparison = compareWorkHistoryRecency(left.recency, right.recency);
+      if (recencyComparison !== 0) {
+        return recencyComparison;
+      }
+      return left.index - right.index;
+    })
+    .slice(0, limit)
+    .map(({ entry }) => entry);
+}
+
 export function buildWorkHistoryDateRange(startDate: unknown, endDate: unknown): string {
   const normalizedStartDate = toOptionalString(startDate);
   const normalizedEndDate = toOptionalString(endDate);
@@ -102,7 +209,21 @@ export function buildWorkHistoryEntryText(entry: unknown): string {
 }
 
 export function buildWorkHistoryEvidence(input: unknown): WorkHistoryEvidence {
-  const lines = toRawEntries(input)
+  const lines = getNormalizedWorkHistoryEntries(input)
+    .map((entry) => buildWorkHistoryEntryText(entry))
+    .filter((line) => line.length > 0);
+
+  return {
+    lines,
+    text: lines.join("\n").toLowerCase(),
+  };
+}
+
+export function buildLatestWorkHistoryEvidence(
+  input: unknown,
+  options?: WorkHistorySelectionOptions,
+): WorkHistoryEvidence {
+  const lines = selectLatestWorkHistory(input, options)
     .map((entry) => buildWorkHistoryEntryText(entry))
     .filter((line) => line.length > 0);
 

--- a/scripts/fetch-score-cases.ts
+++ b/scripts/fetch-score-cases.ts
@@ -2,6 +2,7 @@
  * Fetch real resume data to find matching (>80) and non-matching cases.
  * Usage: npx tsx scripts/fetch-score-cases.ts
  */
+import { selectLatestWorkHistory } from "@trends/shared";
 import { ConvexHttpClient } from "convex/browser";
 import { api } from "../packages/convex/convex/_generated/api.js";
 
@@ -43,7 +44,7 @@ async function main() {
     roleSignals: r.ingestData?.roleSignals ?? [],
     ruleScores: r.ingestData?.ruleScores ?? {},
     primaryRuleScore: r.primaryRuleScore ?? 0,
-    workHistory: (r.content?.workHistory ?? []).slice(0, 3).map((w) => w.raw),
+    workHistory: selectLatestWorkHistory(r.content?.workHistory).map((w) => w.raw),
   }));
 
   rows.sort((a, b) => b.primaryRuleScore - a.primaryRuleScore);


### PR DESCRIPTION
## Summary
- centralize latest-three work history selection in shared utilities and reuse it across resume analysis flows
- align ingest, search, AI payloads, Convex normalization, and web presentation to use the same latest-three subset while keeping raw work history stored in full
- add backend, Convex, shared, and web tests covering latest-three ordering and payload behavior

## Test plan
- [x] npx vitest run -c vitest.config.ts packages/convex/convex/__tests__/analysis-strict-evidence.test.ts
- [x] npm --workspace @trends/web run test -- src/components/OutreachModal.test.tsx
- [x] make check