### PR TITLE
feat(cli): add resume snapshot restore and 51job manual import

### DIFF
--- a/.agents/skills/trends-cli/SKILL.md
+++ b/.agents/skills/trends-cli/SKILL.md
@@ -31,6 +31,9 @@ Use this skill when the user asks to operate backend services from terminal comm
 
 - `./bin/trends resume list --limit 50`
 - `./bin/trends resume search "CNC 东莞" --limit 50`
+- `./bin/trends resume snapshot --source job5156 --count 20`
+- `./bin/trends resume restore output/resume-backups/<run-stamp> --mode replace --yes`
+- `./bin/trends resume match --query "CNC 销售" --source convex --mode rules_only`
 - `./bin/trends resume debug ai-score --query "CNC 销售" --limit 5 --top-n 3`
 - `./bin/trends resume debug matches --job-description lathe-sales`
 - `./bin/trends resume debug match-runs --job-description lathe-sales --limit 20`
@@ -57,6 +60,9 @@ Use this skill when the user asks to operate backend services from terminal comm
 - `CONVEX_MIRROR_MODE=mirror-first make install-deps` is the repo-level bootstrap path when Convex asset prefetch should try configured mirrors before GitHub, and `make prefetch-convex` is the focused prefetch-only escape hatch. Use `./scripts/install-deps.sh --help` when CI=true/1 or broader prefetch env knobs matter, and `./scripts/prefetch-convex-backend.sh --help` for the focused low-level prefetch contract.
 - Keep `dev-docs/skills/trends-cli` as the only editable source. Refresh `.agents/skills/trends-cli` and `.claude/skills/trends-cli` with `make sync-project-skills`; use `make install-skill SKILL=trends-cli [TARGET=codex|agents|all]` only for manual user-global installs.
 - Keep `--api-url` and `--worker-url` aligned with running services.
+- Prefer `trends resume snapshot` over calling `scripts/resume/snapshot-source-backups.ts` directly when you want a repeatable operator/dev-cycle entrypoint.
+- `trends resume restore` accepts either a single portable backup file or a snapshot run directory; directory restores import files in deterministic source order (`job5156`, `seek`, `51job-manual`) and only reset once in `--mode replace`.
+- The preferred snapshot verification flow is: `resume snapshot` -> `resume restore` -> `resume search` / `resume match --mode rules_only` -> `resume debug ai-score`; use `resume debug matches` or `match-runs` only for persisted review-lane validation.
 - `trends resume match` remains the API-backed path; when `source=convex` and AI scoring is needed for debug, use `trends resume debug ai-score`.
 - `trends resume debug rescore` currently mirrors the backend restriction and is sample-only.
 - `trends resume debug trigger-reingest` is the stale-skills-version reingest path, not a generic arbitrary reingest.

--- a/.agents/skills/trends-cli/SKILL.md
+++ b/.agents/skills/trends-cli/SKILL.md
@@ -32,6 +32,7 @@ Use this skill when the user asks to operate backend services from terminal comm
 - `./bin/trends resume list --limit 50`
 - `./bin/trends resume search "CNC 东莞" --limit 50`
 - `./bin/trends resume snapshot --source job5156 --count 20`
+- `./bin/trends resume import-51job ~/Downloads/51job.rar --keyword "CNC 销售"`
 - `./bin/trends resume restore output/resume-backups/<run-stamp> --mode replace --yes`
 - `./bin/trends resume match --query "CNC 销售" --source convex --mode rules_only`
 - `./bin/trends resume debug ai-score --query "CNC 销售" --limit 5 --top-n 3`
@@ -61,6 +62,7 @@ Use this skill when the user asks to operate backend services from terminal comm
 - Keep `dev-docs/skills/trends-cli` as the only editable source. Refresh `.agents/skills/trends-cli` and `.claude/skills/trends-cli` with `make sync-project-skills`; use `make install-skill SKILL=trends-cli [TARGET=codex|agents|all]` only for manual user-global installs.
 - Keep `--api-url` and `--worker-url` aligned with running services.
 - Prefer `trends resume snapshot` over calling `scripts/resume/snapshot-source-backups.ts` directly when you want a repeatable operator/dev-cycle entrypoint.
+- Use `trends resume import-51job` when you want to validate the live `/api/resumes/manual-import` lane for local `.rar`, `.zip`, `.docx`, or `.pdf` files and inspect file-level warnings/failures before or after snapshot restore.
 - `trends resume restore` accepts either a single portable backup file or a snapshot run directory; directory restores import files in deterministic source order (`job5156`, `seek`, `51job-manual`) and only reset once in `--mode replace`.
 - The preferred snapshot verification flow is: `resume snapshot` -> `resume restore` -> `resume search` / `resume match --mode rules_only` -> `resume debug ai-score`; use `resume debug matches` or `match-runs` only for persisted review-lane validation.
 - `trends resume match` remains the API-backed path; when `source=convex` and AI scoring is needed for debug, use `trends resume debug ai-score`.

--- a/apps/api/src/services/manual-resume-import-service.ts
+++ b/apps/api/src/services/manual-resume-import-service.ts
@@ -224,9 +224,8 @@ function enumerateZipEntries(uploadName: string, archiveData: Uint8Array): Enume
 }
 
 async function extractRarEntries(uploadName: string, archiveData: Uint8Array): Promise<EnumeratedImportFile[]> {
-  // node-unrar-js works with the provided RAR v5 sample, but DOCX buffers extracted from RAR
-  // are not yet compatible with Mammoth in this runtime. Keep RAR enumeration/import enabled,
-  // and report DOCX entries as file-level failures until that parser lane is hardened.
+  // RAR uploads stay in the same downstream parse lane as direct/ZIP DOCX files.
+  // If Mammoth cannot extract text from an entry, parseDocxFile() falls back to raw XML extraction.
   const extractor = await unrar.createExtractorFromData({
     data: toArrayBuffer(archiveData),
   });

--- a/dev-docs/releases/2026-03-21-resume-raw-cdp-snapshot.md
+++ b/dev-docs/releases/2026-03-21-resume-raw-cdp-snapshot.md
@@ -31,6 +31,21 @@ The shared CDP helper can now create a Chrome page target when `9222` is reachab
 
 ## Usage
 
+Preferred CLI wrapper for one source:
+
+```bash
+bin/trends --workspace dev --api-url http://localhost:3000 resume snapshot \
+  --source job5156 \
+  --count 20
+```
+
+Preferred CLI wrapper for all configured sources:
+
+```bash
+bin/trends --workspace dev --api-url http://localhost:3000 resume snapshot \
+  --count 20
+```
+
 Snapshot one source:
 
 ```bash
@@ -69,6 +84,14 @@ uv run python scripts/resume/collect_browser_source.py --source job5156 --limit 
 
 Snapshot generation writes plain JSON backup files under `output/resume-backups/<run-stamp>/`.
 Those files can be restored later without having mutated the live resume tables during snapshot creation.
+The CLI now accepts either a single backup file or a full snapshot run directory.
+
+Restore a whole snapshot run directory with the Trends CLI:
+
+```bash
+bin/trends --workspace dev --api-url http://localhost:3000 resume restore \
+  output/resume-backups/<run-stamp>
+```
 
 Restore any generated snapshot file with the Trends CLI:
 
@@ -83,7 +106,15 @@ Replace live data instead of upserting:
 bin/trends --workspace dev --api-url http://localhost:3000 resume restore \
   --mode replace \
   --yes \
-  output/resume-backups/<run-stamp>/resume-backup-job5156-top20-<run-stamp>.json
+  output/resume-backups/<run-stamp>
+```
+
+Typical local verification flow after restore:
+
+```bash
+bin/trends --workspace dev --api-url http://localhost:3000 resume search "CNC 销售" --source convex --limit 20
+bin/trends --workspace dev --api-url http://localhost:3000 resume match --query "CNC 销售" --source convex --mode rules_only
+bin/trends --workspace dev --api-url http://localhost:3000 resume debug ai-score --query "CNC 销售" --source convex --limit 20 --top-n 5
 ```
 
 ## Defaults
@@ -98,5 +129,7 @@ bin/trends --workspace dev --api-url http://localhost:3000 resume restore \
 ## Operational Notes
 
 - The snapshot job does not reset or import into the live resume tables.
+- `trends resume snapshot` is the preferred operator entrypoint; the Bun script remains the underlying implementation.
+- `trends resume restore <run-dir>` imports files in deterministic source order: `job5156`, `seek`, `51job-manual`.
 - `seek` may redirect to a non-talent-search page depending on the logged-in account; if that happens, the extension accessor will not be available and the helper will fail fast before writing a snapshot file.
 - Generated files are date-stamped in `output/resume-backups/<run-stamp>/`.

--- a/dev-docs/releases/2026-03-21-resume-raw-cdp-snapshot.md
+++ b/dev-docs/releases/2026-03-21-resume-raw-cdp-snapshot.md
@@ -46,6 +46,14 @@ bin/trends --workspace dev --api-url http://localhost:3000 resume snapshot \
   --count 20
 ```
 
+Direct API-side validation of the manual 51job import lane:
+
+```bash
+bin/trends --workspace dev --api-url http://localhost:3000 resume import-51job \
+  ~/Downloads/51job.rar \
+  --keyword "CNC 销售"
+```
+
 Snapshot one source:
 
 ```bash
@@ -117,6 +125,17 @@ bin/trends --workspace dev --api-url http://localhost:3000 resume match --query 
 bin/trends --workspace dev --api-url http://localhost:3000 resume debug ai-score --query "CNC 销售" --source convex --limit 20 --top-n 5
 ```
 
+Manual 51job API verification before or after snapshot restore:
+
+```bash
+bin/trends --workspace dev --api-url http://localhost:3000 resume import-51job \
+  ~/Downloads/51job.rar \
+  --keyword "CNC 销售" \
+  --location "东莞"
+```
+
+The command surfaces per-entry `warnings` and `error` details from `/api/resumes/manual-import`, so it is the preferred live check when validating malformed archives or mixed-success uploads.
+
 ## Defaults
 
 - `job5156` URL:
@@ -130,6 +149,7 @@ bin/trends --workspace dev --api-url http://localhost:3000 resume debug ai-score
 
 - The snapshot job does not reset or import into the live resume tables.
 - `trends resume snapshot` is the preferred operator entrypoint; the Bun script remains the underlying implementation.
+- `trends resume import-51job <file...>` is the preferred live API check for the `51job-manual` upload lane; it accepts local `.rar`, `.zip`, `.docx`, and `.pdf` inputs and surfaces file-level warnings/failures.
 - `trends resume restore <run-dir>` imports files in deterministic source order: `job5156`, `seek`, `51job-manual`.
 - `seek` may redirect to a non-talent-search page depending on the logged-in account; if that happens, the extension accessor will not be available and the helper will fail fast before writing a snapshot file.
 - Generated files are date-stamped in `output/resume-backups/<run-stamp>/`.

--- a/dev-docs/skills/trends-cli/SKILL.md
+++ b/dev-docs/skills/trends-cli/SKILL.md
@@ -31,6 +31,9 @@ Use this skill when the user asks to operate backend services from terminal comm
 
 - `./bin/trends resume list --limit 50`
 - `./bin/trends resume search "CNC 东莞" --limit 50`
+- `./bin/trends resume snapshot --source job5156 --count 20`
+- `./bin/trends resume restore output/resume-backups/<run-stamp> --mode replace --yes`
+- `./bin/trends resume match --query "CNC 销售" --source convex --mode rules_only`
 - `./bin/trends resume debug ai-score --query "CNC 销售" --limit 5 --top-n 3`
 - `./bin/trends resume debug matches --job-description lathe-sales`
 - `./bin/trends resume debug match-runs --job-description lathe-sales --limit 20`
@@ -57,6 +60,9 @@ Use this skill when the user asks to operate backend services from terminal comm
 - `CONVEX_MIRROR_MODE=mirror-first make install-deps` is the repo-level bootstrap path when Convex asset prefetch should try configured mirrors before GitHub, and `make prefetch-convex` is the focused prefetch-only escape hatch. Use `./scripts/install-deps.sh --help` when CI=true/1 or broader prefetch env knobs matter, and `./scripts/prefetch-convex-backend.sh --help` for the focused low-level prefetch contract.
 - Keep `dev-docs/skills/trends-cli` as the only editable source. Refresh `.agents/skills/trends-cli` and `.claude/skills/trends-cli` with `make sync-project-skills`; use `make install-skill SKILL=trends-cli [TARGET=codex|agents|all]` only for manual user-global installs.
 - Keep `--api-url` and `--worker-url` aligned with running services.
+- Prefer `trends resume snapshot` over calling `scripts/resume/snapshot-source-backups.ts` directly when you want a repeatable operator/dev-cycle entrypoint.
+- `trends resume restore` accepts either a single portable backup file or a snapshot run directory; directory restores import files in deterministic source order (`job5156`, `seek`, `51job-manual`) and only reset once in `--mode replace`.
+- The preferred snapshot verification flow is: `resume snapshot` -> `resume restore` -> `resume search` / `resume match --mode rules_only` -> `resume debug ai-score`; use `resume debug matches` or `match-runs` only for persisted review-lane validation.
 - `trends resume match` remains the API-backed path; when `source=convex` and AI scoring is needed for debug, use `trends resume debug ai-score`.
 - `trends resume debug rescore` currently mirrors the backend restriction and is sample-only.
 - `trends resume debug trigger-reingest` is the stale-skills-version reingest path, not a generic arbitrary reingest.

--- a/dev-docs/skills/trends-cli/SKILL.md
+++ b/dev-docs/skills/trends-cli/SKILL.md
@@ -32,6 +32,7 @@ Use this skill when the user asks to operate backend services from terminal comm
 - `./bin/trends resume list --limit 50`
 - `./bin/trends resume search "CNC 东莞" --limit 50`
 - `./bin/trends resume snapshot --source job5156 --count 20`
+- `./bin/trends resume import-51job ~/Downloads/51job.rar --keyword "CNC 销售"`
 - `./bin/trends resume restore output/resume-backups/<run-stamp> --mode replace --yes`
 - `./bin/trends resume match --query "CNC 销售" --source convex --mode rules_only`
 - `./bin/trends resume debug ai-score --query "CNC 销售" --limit 5 --top-n 3`
@@ -61,6 +62,7 @@ Use this skill when the user asks to operate backend services from terminal comm
 - Keep `dev-docs/skills/trends-cli` as the only editable source. Refresh `.agents/skills/trends-cli` and `.claude/skills/trends-cli` with `make sync-project-skills`; use `make install-skill SKILL=trends-cli [TARGET=codex|agents|all]` only for manual user-global installs.
 - Keep `--api-url` and `--worker-url` aligned with running services.
 - Prefer `trends resume snapshot` over calling `scripts/resume/snapshot-source-backups.ts` directly when you want a repeatable operator/dev-cycle entrypoint.
+- Use `trends resume import-51job` when you want to validate the live `/api/resumes/manual-import` lane for local `.rar`, `.zip`, `.docx`, or `.pdf` files and inspect file-level warnings/failures before or after snapshot restore.
 - `trends resume restore` accepts either a single portable backup file or a snapshot run directory; directory restores import files in deterministic source order (`job5156`, `seek`, `51job-manual`) and only reset once in `--mode replace`.
 - The preferred snapshot verification flow is: `resume snapshot` -> `resume restore` -> `resume search` / `resume match --mode rules_only` -> `resume debug ai-score`; use `resume debug matches` or `match-runs` only for persisted review-lane validation.
 - `trends resume match` remains the API-backed path; when `source=convex` and AI scoring is needed for debug, use `trends resume debug ai-score`.

--- a/packages/cli/cmd/local_bun_script.go
+++ b/packages/cli/cmd/local_bun_script.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildBunScriptArgs(projectRoot string, scriptPath string, scriptArgs []string) ([]string, error) {
+	args := make([]string, 0, len(scriptArgs)+3)
+
+	envFilePath := filepath.Join(projectRoot, ".env")
+	info, err := os.Stat(envFilePath)
+	switch {
+	case err == nil && !info.IsDir():
+		args = append(args, "--env-file", envFilePath)
+	case err == nil && info.IsDir():
+		// Ignore directory-shaped .env entries and let the script use inherited env.
+	case os.IsNotExist(err):
+		// No repo-root .env file is fine; rely on inherited env instead.
+	case err != nil:
+		return nil, fmt.Errorf("stat env file: %w", err)
+	}
+
+	args = append(args, scriptPath)
+	args = append(args, scriptArgs...)
+	return args, nil
+}
+
+func runBunScript(ctx context.Context, projectRoot string, scriptPath string, scriptArgs []string, stdin []byte) (string, string, error) {
+	args, err := buildBunScriptArgs(projectRoot, scriptPath, scriptArgs)
+	if err != nil {
+		return "", "", err
+	}
+
+	command := exec.CommandContext(ctx, "bun", args...)
+	command.Dir = projectRoot
+	if stdin != nil {
+		command.Stdin = bytes.NewReader(stdin)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	err = command.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+func commandErrorOutput(stdout string, stderr string) string {
+	if trimmed := strings.TrimSpace(stderr); trimmed != "" {
+		return trimmed
+	}
+	if trimmed := strings.TrimSpace(stdout); trimmed != "" {
+		return trimmed
+	}
+	return "no output"
+}

--- a/packages/cli/cmd/local_bun_script_test.go
+++ b/packages/cli/cmd/local_bun_script_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildBunScriptArgsIncludesEnvFileWhenPresent(t *testing.T) {
+	projectRoot := t.TempDir()
+	envFilePath := filepath.Join(projectRoot, ".env")
+	if err := os.WriteFile(envFilePath, []byte("OPENAI_API_KEY=test\n"), 0o644); err != nil {
+		t.Fatalf("failed to write env file: %v", err)
+	}
+
+	args, err := buildBunScriptArgs(projectRoot, "scripts/resume/example.ts", []string{"--count", "20"})
+	if err != nil {
+		t.Fatalf("buildBunScriptArgs returned error: %v", err)
+	}
+
+	expected := []string{"--env-file", envFilePath, "scripts/resume/example.ts", "--count", "20"}
+	if len(args) != len(expected) {
+		t.Fatalf("unexpected args length: got %d want %d (%v)", len(args), len(expected), args)
+	}
+	for index, value := range expected {
+		if args[index] != value {
+			t.Fatalf("unexpected arg at %d: got %q want %q (%v)", index, args[index], value, args)
+		}
+	}
+}
+
+func TestBuildBunScriptArgsOmitsEnvFileWhenMissing(t *testing.T) {
+	projectRoot := t.TempDir()
+
+	args, err := buildBunScriptArgs(projectRoot, "scripts/resume/example.ts", []string{"--count", "20"})
+	if err != nil {
+		t.Fatalf("buildBunScriptArgs returned error: %v", err)
+	}
+
+	expected := []string{"scripts/resume/example.ts", "--count", "20"}
+	if len(args) != len(expected) {
+		t.Fatalf("unexpected args length: got %d want %d (%v)", len(args), len(expected), args)
+	}
+	for index, value := range expected {
+		if args[index] != value {
+			t.Fatalf("unexpected arg at %d: got %q want %q (%v)", index, args[index], value, args)
+		}
+	}
+}

--- a/packages/cli/cmd/resume.go
+++ b/packages/cli/cmd/resume.go
@@ -26,6 +26,7 @@ func newResumeCmd() *cobra.Command {
 		newResumeListCmd(),
 		newResumeSearchCmd(),
 		newResumeMatchCmd(),
+		newResumeSnapshotCmd(),
 		newResumeBackupCmd(),
 		newResumeRestoreCmd(),
 		newResumeDeployBackupCmd(),

--- a/packages/cli/cmd/resume.go
+++ b/packages/cli/cmd/resume.go
@@ -27,6 +27,7 @@ func newResumeCmd() *cobra.Command {
 		newResumeSearchCmd(),
 		newResumeMatchCmd(),
 		newResumeSnapshotCmd(),
+		newResumeManualImportCmd(),
 		newResumeBackupCmd(),
 		newResumeRestoreCmd(),
 		newResumeDeployBackupCmd(),
@@ -261,6 +262,92 @@ func newResumeExportCmd() *cobra.Command {
 	cmd.Flags().StringVar(&outPath, "out", "", "Output file path")
 
 	return cmd
+}
+
+func newResumeManualImportCmd() *cobra.Command {
+	var (
+		searchProfileID string
+		keyword         string
+		location        string
+		limit           int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "import-51job <file> [file...]",
+		Short: "Import local 51job manual-export archives or documents through the API",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("limit") && limit < 1 {
+				return fmt.Errorf("--limit must be greater than 0")
+			}
+
+			response, err := newAPIClient().ImportManualResumes(context.Background(), client.ResumeManualImportRequest{
+				FilePaths:       normalizeStringSlice(args),
+				SearchProfileID: strings.TrimSpace(searchProfileID),
+				Keyword:         strings.TrimSpace(keyword),
+				Location:        strings.TrimSpace(location),
+				Limit:           limit,
+			})
+			if err != nil {
+				return err
+			}
+
+			if currentOptions().Output != "json" {
+				fmt.Fprintf(
+					cmd.OutOrStdout(),
+					"Source: %s | Uploaded: %d | Discovered: %d | Parsed: %d | Imported: %d | Failed: %d\n\n",
+					coalesceString(response.Source.Label, response.Source.Key, "51job-manual"),
+					response.Summary.UploadedFiles,
+					response.Summary.DiscoveredFiles,
+					response.Summary.ParsedResumes,
+					response.Summary.Imported,
+					response.Summary.Failed,
+				)
+			}
+
+			output := buildResumeManualImportOutput(response)
+			return writeOutput(cmd, output.Headers, output.Rows, response)
+		},
+	}
+
+	cmd.Flags().StringVar(&searchProfileID, "search-profile", "", "Optional search profile ID to attach to imported resumes")
+	cmd.Flags().StringVar(&keyword, "keyword", "", "Optional keyword tag to attach to imported resumes")
+	cmd.Flags().StringVar(&location, "location", "", "Optional location tag to attach to imported resumes")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Optional maximum number of parsed resumes to import")
+
+	return cmd
+}
+
+func buildResumeManualImportOutput(response *client.ResumeManualImportResponse) resumeSummaryOutput {
+	headers := []string{
+		"upload_name",
+		"entry_path",
+		"extension",
+		"status",
+		"resume_name",
+		"profile_id",
+		"warnings",
+		"error",
+	}
+	rows := make([][]string, 0, len(response.Files))
+
+	for _, file := range response.Files {
+		rows = append(rows, []string{
+			file.UploadName,
+			file.EntryPath,
+			file.Extension,
+			file.Status,
+			file.ResumeName,
+			file.ProfileID,
+			strings.Join(file.Warnings, " | "),
+			file.Error,
+		})
+	}
+
+	return resumeSummaryOutput{
+		Headers: headers,
+		Rows:    rows,
+	}
 }
 
 type resumeDisplayRow struct {

--- a/packages/cli/cmd/resume_backup.go
+++ b/packages/cli/cmd/resume_backup.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -32,16 +33,30 @@ type resumeBackupResult struct {
 }
 
 type resumeRestoreResult struct {
-	FilePath     string
-	Mode         string
-	Reset        bool
-	ResetCount   int
-	ResetPartial bool
-	Submitted    int
-	Inserted     int
-	Updated      int
-	Unchanged    int
-	Deduped      int
+	Workspace    string                    `json:"workspace,omitempty"`
+	RunDir       string                    `json:"runDir,omitempty"`
+	InputPath    string                    `json:"inputPath"`
+	FilePath     string                    `json:"file,omitempty"`
+	Mode         string                    `json:"mode"`
+	Reset        bool                      `json:"reset"`
+	ResetCount   int                       `json:"resetCount"`
+	ResetPartial bool                      `json:"resetPartial"`
+	Submitted    int                       `json:"submitted"`
+	Inserted     int                       `json:"inserted"`
+	Updated      int                       `json:"updated"`
+	Unchanged    int                       `json:"unchanged"`
+	Deduped      int                       `json:"deduped"`
+	Files        []resumeRestoreFileResult `json:"files"`
+}
+
+type resumeRestoreFileResult struct {
+	FilePath  string `json:"file"`
+	Count     int    `json:"count"`
+	Submitted int    `json:"submitted"`
+	Inserted  int    `json:"inserted"`
+	Updated   int    `json:"updated"`
+	Unchanged int    `json:"unchanged"`
+	Deduped   int    `json:"deduped"`
 }
 
 type resumeSummaryOutput struct {
@@ -374,8 +389,8 @@ func buildResumeBackupOutput(result *resumeBackupResult, extras resumeOutputExtr
 
 func buildResumeRestoreOutput(result *resumeRestoreResult, extras resumeOutputExtras) resumeSummaryOutput {
 	summary := map[string]any{
+		"inputPath":    result.InputPath,
 		"mode":         result.Mode,
-		"file":         result.FilePath,
 		"reset":        result.Reset,
 		"resetCount":   result.ResetCount,
 		"resetPartial": result.ResetPartial,
@@ -385,43 +400,114 @@ func buildResumeRestoreOutput(result *resumeRestoreResult, extras resumeOutputEx
 		"unchanged":    result.Unchanged,
 		"deduped":      result.Deduped,
 	}
+	if result.FilePath != "" {
+		summary["file"] = result.FilePath
+	}
 	headers := make([]string, 0, 12)
 	row := make([]string, 0, 12)
 	headers, row = appendResumeOutputExtras(summary, headers, row, extras)
-	headers = append(headers, "mode", "file", "reset", "reset_count", "reset_partial", "submitted", "inserted", "updated", "unchanged", "deduped")
-	row = append(
-		row,
-		result.Mode,
-		result.FilePath,
-		fmt.Sprintf("%t", result.Reset),
-		fmt.Sprintf("%d", result.ResetCount),
-		fmt.Sprintf("%t", result.ResetPartial),
-		fmt.Sprintf("%d", result.Submitted),
-		fmt.Sprintf("%d", result.Inserted),
-		fmt.Sprintf("%d", result.Updated),
-		fmt.Sprintf("%d", result.Unchanged),
-		fmt.Sprintf("%d", result.Deduped),
-	)
+	headers = append(headers, "mode", "input_path", "reset", "reset_count", "reset_partial", "file", "count", "submitted", "inserted", "updated", "unchanged", "deduped")
+
+	rows := make([][]string, 0, len(result.Files))
+	for _, file := range result.Files {
+		fileRow := append([]string{}, row...)
+		fileRow = append(
+			fileRow,
+			result.Mode,
+			result.InputPath,
+			fmt.Sprintf("%t", result.Reset),
+			fmt.Sprintf("%d", result.ResetCount),
+			fmt.Sprintf("%t", result.ResetPartial),
+			file.FilePath,
+			fmt.Sprintf("%d", file.Count),
+			fmt.Sprintf("%d", file.Submitted),
+			fmt.Sprintf("%d", file.Inserted),
+			fmt.Sprintf("%d", file.Updated),
+			fmt.Sprintf("%d", file.Unchanged),
+			fmt.Sprintf("%d", file.Deduped),
+		)
+		rows = append(rows, fileRow)
+	}
 
 	return resumeSummaryOutput{
 		Summary: summary,
 		Headers: headers,
-		Rows:    [][]string{row},
+		Rows:    rows,
 	}
 }
 
-func restoreResumeBackupFile(ctx context.Context, apiClient *client.Client, filePath string, mode string, yes bool) (*resumeRestoreResult, error) {
-	payload, _, err := readResumeBackupFile(filePath)
-	if err != nil {
-		return nil, err
+func isSupportedResumeRestorePath(fileName string) bool {
+	normalized := strings.TrimSpace(strings.ToLower(fileName))
+	return strings.HasSuffix(normalized, ".json") || strings.HasSuffix(normalized, ".tar.gz")
+}
+
+func readResumeRestoreOrder(filePath string) int {
+	fileName := filepath.Base(strings.TrimSpace(filePath))
+	sources := []string{"job5156", "seek", "51job-manual"}
+	for index, source := range sources {
+		if strings.HasPrefix(fileName, fmt.Sprintf("resume-backup-%s-", source)) {
+			return index
+		}
+	}
+	return len(sources)
+}
+
+func compareResumeRestorePaths(left string, right string) int {
+	orderDiff := readResumeRestoreOrder(left) - readResumeRestoreOrder(right)
+	if orderDiff != 0 {
+		return orderDiff
+	}
+	return strings.Compare(filepath.Base(left), filepath.Base(right))
+}
+
+func resolveResumeRestorePaths(inputPath string) ([]string, error) {
+	resolvedInputPath := strings.TrimSpace(inputPath)
+	if resolvedInputPath == "" {
+		return nil, fmt.Errorf("backup file path is required")
 	}
 
+	info, err := os.Stat(resolvedInputPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat restore path: %w", err)
+	}
+	if !info.IsDir() {
+		return []string{resolvedInputPath}, nil
+	}
+
+	entries, err := os.ReadDir(resolvedInputPath)
+	if err != nil {
+		return nil, fmt.Errorf("read restore directory: %w", err)
+	}
+
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !isSupportedResumeRestorePath(entry.Name()) {
+			continue
+		}
+		files = append(files, filepath.Join(resolvedInputPath, entry.Name()))
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no restore backup files found in directory %s", resolvedInputPath)
+	}
+
+	sort.Slice(files, func(i int, j int) bool {
+		return compareResumeRestorePaths(files[i], files[j]) < 0
+	})
+	return files, nil
+}
+
+func restoreResumeBackupPath(ctx context.Context, apiClient *client.Client, inputPath string, mode string, yes bool) (*resumeRestoreResult, error) {
 	normalizedMode, err := normalizeResumeRestoreMode(mode)
 	if err != nil {
 		return nil, err
 	}
 	if normalizedMode == "replace" && !yes {
 		return nil, fmt.Errorf("restore mode replace requires --yes")
+	}
+
+	restorePaths, err := resolveResumeRestorePaths(inputPath)
+	if err != nil {
+		return nil, err
 	}
 
 	resetCount := 0
@@ -435,23 +521,47 @@ func restoreResumeBackupFile(ctx context.Context, apiClient *client.Client, file
 		resetPartial = resetResponse.Partial
 	}
 
-	response, err := apiClient.ImportResumeBackup(ctx, json.RawMessage(payload))
-	if err != nil {
-		return nil, err
-	}
-
-	return &resumeRestoreResult{
-		FilePath:     filePath,
+	result := &resumeRestoreResult{
+		InputPath:    inputPath,
 		Mode:         normalizedMode,
 		Reset:        normalizedMode == "replace",
 		ResetCount:   resetCount,
 		ResetPartial: resetPartial,
-		Submitted:    response.Submitted,
-		Inserted:     response.Inserted,
-		Updated:      response.Updated,
-		Unchanged:    response.Unchanged,
-		Deduped:      response.Deduped,
-	}, nil
+		Files:        make([]resumeRestoreFileResult, 0, len(restorePaths)),
+	}
+	if len(restorePaths) == 1 {
+		result.FilePath = restorePaths[0]
+	}
+
+	for _, restorePath := range restorePaths {
+		payload, envelope, err := readResumeBackupFile(restorePath)
+		if err != nil {
+			return nil, err
+		}
+
+		response, err := apiClient.ImportResumeBackup(ctx, json.RawMessage(payload))
+		if err != nil {
+			return nil, err
+		}
+
+		fileResult := resumeRestoreFileResult{
+			FilePath:  restorePath,
+			Count:     resumeBackupCount(envelope),
+			Submitted: response.Submitted,
+			Inserted:  response.Inserted,
+			Updated:   response.Updated,
+			Unchanged: response.Unchanged,
+			Deduped:   response.Deduped,
+		}
+		result.Files = append(result.Files, fileResult)
+		result.Submitted += fileResult.Submitted
+		result.Inserted += fileResult.Inserted
+		result.Updated += fileResult.Updated
+		result.Unchanged += fileResult.Unchanged
+		result.Deduped += fileResult.Deduped
+	}
+
+	return result, nil
 }
 
 func newResumeBackupCmd() *cobra.Command {
@@ -499,22 +609,22 @@ func newResumeRestoreCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "restore <file>",
-		Short: "Restore resume records from a portable JSON or .tar.gz backup",
+		Use:   "restore <path>",
+		Short: "Restore resume records from a portable backup file or snapshot directory",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			filePath := strings.TrimSpace(args[0])
-			if filePath == "" {
+			inputPath := strings.TrimSpace(args[0])
+			if inputPath == "" {
 				return fmt.Errorf("backup file path is required")
 			}
 
-			result, err := restoreResumeBackupFile(context.Background(), newAPIClient(), filePath, mode, yes)
+			result, err := restoreResumeBackupPath(context.Background(), newAPIClient(), inputPath, mode, yes)
 			if err != nil {
 				return err
 			}
 
 			output := buildResumeRestoreOutput(result, resumeOutputExtras{})
-			return writeOutput(cmd, output.Headers, output.Rows, output.Summary)
+			return writeOutput(cmd, output.Headers, output.Rows, result)
 		},
 	}
 
@@ -607,16 +717,18 @@ func newResumeDeployBackupRestoreCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			result, err := restoreResumeBackupFile(context.Background(), newAPIClient(), filePath, mode, yes)
+			result, err := restoreResumeBackupPath(context.Background(), newAPIClient(), filePath, mode, yes)
 			if err != nil {
 				return err
 			}
+			result.Workspace = currentOptions().Workspace
+			result.RunDir = runDir
 
 			output := buildResumeRestoreOutput(result, resumeOutputExtras{
 				Workspace: currentOptions().Workspace,
 				RunDir:    runDir,
 			})
-			return writeOutput(cmd, output.Headers, output.Rows, output.Summary)
+			return writeOutput(cmd, output.Headers, output.Rows, result)
 		},
 	}
 

--- a/packages/cli/cmd/resume_backup_test.go
+++ b/packages/cli/cmd/resume_backup_test.go
@@ -240,6 +240,111 @@ func TestResumeRestoreCommandReplaceModeCallsResetThenImport(t *testing.T) {
 	}
 }
 
+func TestResumeRestoreCommandAcceptsSnapshotDirectoryInDeterministicOrder(t *testing.T) {
+	backupDir := filepath.Join(t.TempDir(), "resume-backups")
+	if err := os.MkdirAll(backupDir, 0o755); err != nil {
+		t.Fatalf("failed to create backup directory: %v", err)
+	}
+
+	writeTestPortableBackupFile(t, filepath.Join(backupDir, "resume-backup-seek-top20-20260321-015304.tar.gz"), map[string]any{
+		"metadata": map[string]any{
+			"generatedBy": "trends-api backup",
+		},
+		"resumes": []map[string]any{{"resumeId": "seek-1", "name": "Seek"}},
+	})
+	writeTestPortableBackupFile(t, filepath.Join(backupDir, "resume-backup-51job-manual-top20-20260321-015304.json"), map[string]any{
+		"metadata": map[string]any{
+			"generatedBy": "trends-api backup",
+		},
+		"resumes": []map[string]any{{"resumeId": "manual-1", "name": "Manual"}},
+	})
+	writeTestPortableBackupFile(t, filepath.Join(backupDir, "resume-backup-job5156-top20-20260321-015304.json"), map[string]any{
+		"metadata": map[string]any{
+			"generatedBy": "trends-api backup",
+		},
+		"resumes": []map[string]any{{"resumeId": "job-1", "name": "Job5156"}},
+	})
+
+	var callOrder []string
+	var importedResumeIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callOrder = append(callOrder, r.URL.Path)
+
+		switch r.URL.Path {
+		case "/api/resumes/reset":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"count":   3,
+				"partial": false,
+				"deleted": map[string]int{"resumes": 3},
+			})
+		case "/api/resumes/import":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode import payload: %v", err)
+			}
+			resumes, ok := payload["resumes"].([]any)
+			if !ok || len(resumes) != 1 {
+				t.Fatalf("unexpected import payload: %+v", payload)
+			}
+			resume, ok := resumes[0].(map[string]any)
+			if !ok {
+				t.Fatalf("unexpected resume payload: %+v", payload)
+			}
+			resumeID, _ := resume["resumeId"].(string)
+			importedResumeIDs = append(importedResumeIDs, resumeID)
+
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success":   true,
+				"submitted": len(resumes),
+				"inserted":  len(resumes),
+				"updated":   0,
+				"unchanged": 0,
+				"deduped":   0,
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+	setCLIOutput(t, "json")
+
+	cmd := newResumeRestoreCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{
+		backupDir,
+		"--mode", "replace",
+		"--yes",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume restore command failed: %v", err)
+	}
+
+	if len(callOrder) != 4 || callOrder[0] != "/api/resumes/reset" {
+		t.Fatalf("unexpected call order: %+v", callOrder)
+	}
+	if want := []string{"job-1", "seek-1", "manual-1"}; strings.Join(importedResumeIDs, ",") != strings.Join(want, ",") {
+		t.Fatalf("unexpected restore order: got %+v want %+v", importedResumeIDs, want)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["inputPath"] != backupDir {
+		t.Fatalf("unexpected inputPath in output: %+v", payload)
+	}
+	if payload["submitted"] != float64(3) {
+		t.Fatalf("unexpected submitted total in output: %+v", payload)
+	}
+	files, ok := payload["files"].([]any)
+	if !ok || len(files) != 3 {
+		t.Fatalf("unexpected files payload: %+v", payload)
+	}
+}
+
 func TestResumeDeployBackupRestorePrefersCompressedArtifactInLatestRunDir(t *testing.T) {
 	baseDir := filepath.Join(t.TempDir(), "deploy")
 	olderDir := filepath.Join(baseDir, "deploy-20260101T000000Z-100")

--- a/packages/cli/cmd/resume_debug.go
+++ b/packages/cli/cmd/resume_debug.go
@@ -1,12 +1,9 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -67,34 +64,13 @@ var runLocalResumeAIScorer = func(ctx context.Context, request localResumeAIScor
 	}
 
 	scriptPath := filepath.Join(projectRoot, "scripts", "resume", "debug-ai-score.ts")
-	args := []string{scriptPath}
-	envFilePath := filepath.Join(projectRoot, ".env")
-	if _, statErr := os.Stat(envFilePath); statErr == nil {
-		args = append([]string{"--env-file", envFilePath}, args...)
-	}
-
-	command := exec.CommandContext(ctx, "bun", args...)
-	command.Dir = projectRoot
-	command.Stdin = bytes.NewReader(input)
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	command.Stdout = &stdout
-	command.Stderr = &stderr
-
-	if err := command.Run(); err != nil {
-		errorOutput := strings.TrimSpace(stderr.String())
-		if errorOutput == "" {
-			errorOutput = strings.TrimSpace(stdout.String())
-		}
-		if errorOutput == "" {
-			errorOutput = "no output"
-		}
-		return nil, fmt.Errorf("run local AI scorer: %w\n%s", err, errorOutput)
+	stdout, stderr, err := runBunScript(ctx, projectRoot, scriptPath, nil, input)
+	if err != nil {
+		return nil, fmt.Errorf("run local AI scorer: %w\n%s", err, commandErrorOutput(stdout, stderr))
 	}
 
 	var response localResumeAIScoreResponse
-	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
 		return nil, fmt.Errorf("decode local AI scorer response: %w", err)
 	}
 	if !response.Success {
@@ -454,4 +430,3 @@ func validateResumeMatchRequest(request client.ResumeMatchRequest) error {
 
 	return nil
 }
-

--- a/packages/cli/cmd/resume_snapshot.go
+++ b/packages/cli/cmd/resume_snapshot.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type resumeSnapshotRequest struct {
+	APIURL      string
+	Workspace   string
+	Count       int
+	MaxPages    int
+	OutDir      string
+	Sources     []string
+	Job5156URL  string
+	SeekURL     string
+	ManualFile  string
+	CDPEndpoint string
+}
+
+type resumeSnapshotManualImportSummary struct {
+	UploadedFiles   *int `json:"uploadedFiles,omitempty"`
+	DiscoveredFiles *int `json:"discoveredFiles,omitempty"`
+	ParsedResumes   *int `json:"parsedResumes,omitempty"`
+	Imported        *int `json:"imported,omitempty"`
+	Inserted        *int `json:"inserted,omitempty"`
+	Updated         *int `json:"updated,omitempty"`
+	Unchanged       *int `json:"unchanged,omitempty"`
+	Deduped         *int `json:"deduped,omitempty"`
+	Skipped         *int `json:"skipped,omitempty"`
+	Failed          *int `json:"failed,omitempty"`
+}
+
+type resumeSnapshotSourceResult struct {
+	Alias               string                             `json:"alias"`
+	SourceHost          string                             `json:"sourceHost"`
+	File                string                             `json:"file"`
+	Count               int                                `json:"count"`
+	LaunchURL           string                             `json:"launchUrl,omitempty"`
+	ManualFile          string                             `json:"manualFile,omitempty"`
+	ResetCount          int                                `json:"resetCount"`
+	ResetPartial        bool                               `json:"resetPartial"`
+	ObservedCount       int                                `json:"observedCount"`
+	ManualImportSummary *resumeSnapshotManualImportSummary `json:"manualImportSummary,omitempty"`
+}
+
+type resumeSnapshotResult struct {
+	Success        bool                         `json:"success"`
+	APIURL         string                       `json:"apiUrl"`
+	Workspace      string                       `json:"workspace"`
+	RepoRoot       string                       `json:"repoRoot"`
+	RunStamp       string                       `json:"runStamp"`
+	OutputDir      string                       `json:"outputDir"`
+	CountPerSource int                          `json:"countPerSource"`
+	Sources        []resumeSnapshotSourceResult `json:"sources"`
+}
+
+var runResumeSnapshot = func(ctx context.Context, request resumeSnapshotRequest) (*resumeSnapshotResult, error) {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	scriptPath := filepath.Join(projectRoot, "scripts", "resume", "snapshot-source-backups.ts")
+	stdout, stderr, err := runBunScript(
+		ctx,
+		projectRoot,
+		scriptPath,
+		buildResumeSnapshotScriptArgs(request),
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("run resume snapshot: %w\n%s", err, commandErrorOutput(stdout, stderr))
+	}
+
+	var response resumeSnapshotResult
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		return nil, fmt.Errorf("decode resume snapshot response: %w", err)
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("resume snapshot did not succeed")
+	}
+	return &response, nil
+}
+
+func buildResumeSnapshotScriptArgs(request resumeSnapshotRequest) []string {
+	args := []string{
+		"--api-url", normalizeBaseURL(request.APIURL),
+		"--workspace", normalizeWorkspace(request.Workspace),
+	}
+
+	if request.Count > 0 {
+		args = append(args, "--count", strconv.Itoa(request.Count))
+	}
+	if request.MaxPages > 0 {
+		args = append(args, "--max-pages", strconv.Itoa(request.MaxPages))
+	}
+
+	for _, source := range normalizeStringSlice(request.Sources) {
+		args = append(args, "--source", source)
+	}
+
+	if value := strings.TrimSpace(request.OutDir); value != "" {
+		args = append(args, "--out-dir", value)
+	}
+	if value := strings.TrimSpace(request.Job5156URL); value != "" {
+		args = append(args, "--job5156-url", value)
+	}
+	if value := strings.TrimSpace(request.SeekURL); value != "" {
+		args = append(args, "--seek-url", value)
+	}
+	if value := strings.TrimSpace(request.ManualFile); value != "" {
+		args = append(args, "--manual-file", value)
+	}
+	if value := strings.TrimSpace(request.CDPEndpoint); value != "" {
+		args = append(args, "--cdp-endpoint", value)
+	}
+
+	return args
+}
+
+func buildResumeSnapshotOutput(result *resumeSnapshotResult) resumeSummaryOutput {
+	headers := []string{
+		"source",
+		"source_host",
+		"count",
+		"observed",
+		"file",
+		"launch_url",
+		"manual_file",
+		"manual_parsed",
+		"manual_imported",
+		"manual_skipped",
+		"manual_failed",
+	}
+	rows := make([][]string, 0, len(result.Sources))
+
+	for _, source := range result.Sources {
+		manualParsed := ""
+		manualImported := ""
+		manualSkipped := ""
+		manualFailed := ""
+		if source.ManualImportSummary != nil {
+			manualParsed = intPointerString(source.ManualImportSummary.ParsedResumes)
+			manualImported = intPointerString(source.ManualImportSummary.Imported)
+			manualSkipped = intPointerString(source.ManualImportSummary.Skipped)
+			manualFailed = intPointerString(source.ManualImportSummary.Failed)
+		}
+
+		rows = append(rows, []string{
+			source.Alias,
+			source.SourceHost,
+			strconv.Itoa(source.Count),
+			strconv.Itoa(source.ObservedCount),
+			source.File,
+			source.LaunchURL,
+			source.ManualFile,
+			manualParsed,
+			manualImported,
+			manualSkipped,
+			manualFailed,
+		})
+	}
+
+	return resumeSummaryOutput{
+		Headers: headers,
+		Rows:    rows,
+	}
+}
+
+func newResumeSnapshotCmd() *cobra.Command {
+	var (
+		count       int
+		maxPages    int
+		outDir      string
+		sources     []string
+		job5156URL  string
+		seekURL     string
+		manualFile  string
+		cdpEndpoint string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "snapshot",
+		Short: "Capture restore-compatible resume snapshots via the extension/CDP pipeline",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("count") && count < 1 {
+				return fmt.Errorf("--count must be greater than 0")
+			}
+			if cmd.Flags().Changed("max-pages") && maxPages < 1 {
+				return fmt.Errorf("--max-pages must be greater than 0")
+			}
+
+			options := currentOptions()
+			response, err := runResumeSnapshot(context.Background(), resumeSnapshotRequest{
+				APIURL:      options.APIURL,
+				Workspace:   options.Workspace,
+				Count:       count,
+				MaxPages:    maxPages,
+				OutDir:      outDir,
+				Sources:     sources,
+				Job5156URL:  job5156URL,
+				SeekURL:     seekURL,
+				ManualFile:  manualFile,
+				CDPEndpoint: cdpEndpoint,
+			})
+			if err != nil {
+				return err
+			}
+
+			output := buildResumeSnapshotOutput(response)
+			return writeOutput(cmd, output.Headers, output.Rows, response)
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&sources, "source", nil, "Snapshot source alias (repeatable): job5156|seek|51job-manual")
+	cmd.Flags().IntVar(&count, "count", 0, "Resumes per source (default: snapshot script default)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 0, "Browser pages per source collection (default: snapshot script default)")
+	cmd.Flags().StringVar(&outDir, "out-dir", "", "Output directory (default: snapshot script default)")
+	cmd.Flags().StringVar(&job5156URL, "job5156-url", "", "Override the Job5156 source URL")
+	cmd.Flags().StringVar(&seekURL, "seek-url", "", "Override the SEEK source URL")
+	cmd.Flags().StringVar(&manualFile, "manual-file", "", "Override the manual 51job archive path")
+	cmd.Flags().StringVar(&cdpEndpoint, "cdp-endpoint", "", "Override the Chrome DevTools endpoint or port")
+
+	return cmd
+}

--- a/packages/cli/cmd/resume_snapshot_test.go
+++ b/packages/cli/cmd/resume_snapshot_test.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestResumeSnapshotCommandPassesFlagsAndWritesJSON(t *testing.T) {
+	setResumeCLIConfig(t, "http://localhost:3000", "ops")
+	setCLIOutput(t, "json")
+
+	originalRunner := runResumeSnapshot
+	t.Cleanup(func() {
+		runResumeSnapshot = originalRunner
+	})
+
+	runResumeSnapshot = func(ctx context.Context, request resumeSnapshotRequest) (*resumeSnapshotResult, error) {
+		if request.APIURL != "http://localhost:3000" {
+			t.Fatalf("unexpected api url: %q", request.APIURL)
+		}
+		if request.Workspace != "ops" {
+			t.Fatalf("unexpected workspace: %q", request.Workspace)
+		}
+		if request.Count != 25 {
+			t.Fatalf("unexpected count: %d", request.Count)
+		}
+		if request.MaxPages != 8 {
+			t.Fatalf("unexpected max pages: %d", request.MaxPages)
+		}
+		if len(request.Sources) != 2 || request.Sources[0] != "job5156" || request.Sources[1] != "51job-manual" {
+			t.Fatalf("unexpected sources: %+v", request.Sources)
+		}
+		if request.OutDir != "output/resume-backups/custom" {
+			t.Fatalf("unexpected out dir: %q", request.OutDir)
+		}
+		if request.ManualFile != "~/Downloads/51job.rar" {
+			t.Fatalf("unexpected manual file: %q", request.ManualFile)
+		}
+		if request.CDPEndpoint != "http://127.0.0.1:9333" {
+			t.Fatalf("unexpected cdp endpoint: %q", request.CDPEndpoint)
+		}
+
+		return &resumeSnapshotResult{
+			Success:        true,
+			APIURL:         request.APIURL,
+			Workspace:      request.Workspace,
+			RepoRoot:       "/repo",
+			RunStamp:       "20260323-010203",
+			OutputDir:      "output/resume-backups/20260323-010203",
+			CountPerSource: 25,
+			Sources: []resumeSnapshotSourceResult{
+				{
+					Alias:         "job5156",
+					SourceHost:    "hr.job5156.com",
+					File:          "output/resume-backups/20260323-010203/resume-backup-job5156-top25-20260323-010203.json",
+					Count:         25,
+					ObservedCount: 25,
+					LaunchURL:     "https://hr.job5156.com/search",
+				},
+			},
+		}, nil
+	}
+
+	cmd := newResumeSnapshotCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{
+		"--source", "job5156",
+		"--source", "51job-manual",
+		"--count", "25",
+		"--max-pages", "8",
+		"--out-dir", "output/resume-backups/custom",
+		"--manual-file", "~/Downloads/51job.rar",
+		"--cdp-endpoint", "http://127.0.0.1:9333",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume snapshot command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["runStamp"] != "20260323-010203" {
+		t.Fatalf("unexpected runStamp in output: %+v", payload)
+	}
+	if payload["workspace"] != "ops" {
+		t.Fatalf("unexpected workspace in output: %+v", payload)
+	}
+}
+
+func TestResumeSnapshotCommandWritesTable(t *testing.T) {
+	setResumeCLIConfig(t, "http://localhost:3000", "dev")
+	setCLIOutput(t, "table")
+
+	originalRunner := runResumeSnapshot
+	t.Cleanup(func() {
+		runResumeSnapshot = originalRunner
+	})
+
+	runResumeSnapshot = func(ctx context.Context, request resumeSnapshotRequest) (*resumeSnapshotResult, error) {
+		return &resumeSnapshotResult{
+			Success:   true,
+			APIURL:    request.APIURL,
+			Workspace: request.Workspace,
+			Sources: []resumeSnapshotSourceResult{
+				{
+					Alias:         "51job-manual",
+					SourceHost:    "51job-manual",
+					File:          "output/resume-backups/20260323-010203/resume-backup-51job-manual-top20-20260323-010203.json",
+					Count:         20,
+					ObservedCount: 20,
+					ManualFile:    "/tmp/51job.rar",
+					ManualImportSummary: &resumeSnapshotManualImportSummary{
+						ParsedResumes: intPointer(20),
+						Imported:      intPointer(20),
+					},
+				},
+			},
+		}, nil
+	}
+
+	cmd := newResumeSnapshotCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume snapshot command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "51job-manual") || !strings.Contains(text, "/tmp/51job.rar") {
+		t.Fatalf("unexpected command output: %s", text)
+	}
+}
+
+func TestResumeSnapshotCommandRejectsZeroCountWhenExplicitlySet(t *testing.T) {
+	cmd := newResumeSnapshotCmd()
+	cmd.SetArgs([]string{"--count", "0"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected zero count to fail")
+	}
+	if !strings.Contains(err.Error(), "--count must be greater than 0") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func intPointer(value int) *int {
+	return &value
+}

--- a/packages/cli/cmd/resume_test.go
+++ b/packages/cli/cmd/resume_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -93,5 +95,91 @@ func TestResumeMatchCommandWritesJSON(t *testing.T) {
 	}
 	if !strings.Contains(output.String(), `"resumeId": "resume-1"`) {
 		t.Fatalf("unexpected command output: %s", output.String())
+	}
+}
+
+func TestResumeManualImportCommandWritesTableSummary(t *testing.T) {
+	uploadPath := filepath.Join(t.TempDir(), "51job.rar")
+	if err := os.WriteFile(uploadPath, []byte("rar-bytes"), 0o644); err != nil {
+		t.Fatalf("failed to write upload file: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/resumes/manual-import" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(8 << 20); err != nil {
+			t.Fatalf("failed to parse multipart form: %v", err)
+		}
+		if got := r.FormValue("keyword"); got != "销售工程师" {
+			t.Fatalf("unexpected keyword: %q", got)
+		}
+		if got := r.FormValue("location"); got != "东莞" {
+			t.Fatalf("unexpected location: %q", got)
+		}
+		if got := r.FormValue("limit"); got != "10" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		files := r.MultipartForm.File["files"]
+		if len(files) != 1 || files[0].Filename != "51job.rar" {
+			t.Fatalf("unexpected uploaded files: %+v", files)
+		}
+
+		_ = json.NewEncoder(w).Encode(client.ResumeManualImportResponse{
+			Success: true,
+			Source: client.ResumeManualImportSource{
+				Key:   "51job-manual",
+				Label: "51job-manual",
+			},
+			Summary: client.ResumeManualImportSummary{
+				UploadedFiles:   1,
+				DiscoveredFiles: 1,
+				ParsedResumes:   1,
+				Imported:        1,
+				Inserted:        1,
+			},
+			Files: []client.ResumeManualImportFileResult{
+				{
+					UploadName: "51job.rar",
+					EntryPath:  "51job_张三(123456).docx",
+					Extension:  ".docx",
+					Status:     "imported",
+					ResumeName: "张三",
+					ProfileID:  "123456",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "hr")
+	setCLIOutput(t, "table")
+
+	cmd := newResumeManualImportCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{uploadPath, "--keyword", "销售工程师", "--location", "东莞", "--limit", "10"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume manual import command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "Source: 51job-manual") || !strings.Contains(text, "张三") || !strings.Contains(text, "123456") {
+		t.Fatalf("unexpected command output: %s", text)
+	}
+}
+
+func TestResumeManualImportCommandRejectsZeroLimitWhenExplicitlySet(t *testing.T) {
+	cmd := newResumeManualImportCmd()
+	cmd.SetArgs([]string{"sample.rar", "--limit", "0"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected zero limit to fail")
+	}
+	if !strings.Contains(err.Error(), "--limit must be greater than 0") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/packages/cli/internal/client/resume_backup.go
+++ b/packages/cli/internal/client/resume_backup.go
@@ -1,10 +1,17 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 )
 
 type ResumeBackupRequest struct {
@@ -27,6 +34,51 @@ type ResumeResetResponse struct {
 	Count   int            `json:"count"`
 	Partial bool           `json:"partial"`
 	Deleted map[string]int `json:"deleted"`
+}
+
+type ResumeManualImportRequest struct {
+	FilePaths       []string
+	SearchProfileID string
+	Keyword         string
+	Location        string
+	Limit           int
+}
+
+type ResumeManualImportSource struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+}
+
+type ResumeManualImportFileResult struct {
+	UploadName string   `json:"uploadName"`
+	EntryPath  string   `json:"entryPath"`
+	Extension  string   `json:"extension"`
+	Status     string   `json:"status"`
+	ResumeName string   `json:"resumeName,omitempty"`
+	ProfileID  string   `json:"profileId,omitempty"`
+	Warnings   []string `json:"warnings,omitempty"`
+	Error      string   `json:"error,omitempty"`
+}
+
+type ResumeManualImportSummary struct {
+	UploadedFiles   int `json:"uploadedFiles"`
+	DiscoveredFiles int `json:"discoveredFiles"`
+	ParsedResumes   int `json:"parsedResumes"`
+	Imported        int `json:"imported"`
+	Inserted        int `json:"inserted"`
+	Updated         int `json:"updated"`
+	Unchanged       int `json:"unchanged"`
+	Deduped         int `json:"deduped"`
+	Skipped         int `json:"skipped"`
+	Failed          int `json:"failed"`
+}
+
+type ResumeManualImportResponse struct {
+	Success  bool                           `json:"success"`
+	Source   ResumeManualImportSource       `json:"source"`
+	Summary  ResumeManualImportSummary      `json:"summary"`
+	Files    []ResumeManualImportFileResult `json:"files"`
+	Warnings []string                       `json:"warnings,omitempty"`
 }
 
 func (c *Client) BackupResumes(ctx context.Context, request ResumeBackupRequest) ([]byte, string, error) {
@@ -62,4 +114,120 @@ func (c *Client) ResetResumes(ctx context.Context) (*ResumeResetResponse, error)
 		return nil, fmt.Errorf("resume reset request was not successful")
 	}
 	return &response, nil
+}
+
+func (c *Client) ImportManualResumes(ctx context.Context, request ResumeManualImportRequest) (*ResumeManualImportResponse, error) {
+	filePaths := normalizeManualImportFilePaths(request.FilePaths)
+	if len(filePaths) == 0 {
+		return nil, fmt.Errorf("at least one file path is required")
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	for _, filePath := range filePaths {
+		if err := appendManualImportFile(writer, filePath); err != nil {
+			_ = writer.Close()
+			return nil, err
+		}
+	}
+	if err := writeManualImportField(writer, "searchProfileId", request.SearchProfileID); err != nil {
+		_ = writer.Close()
+		return nil, err
+	}
+	if err := writeManualImportField(writer, "keyword", request.Keyword); err != nil {
+		_ = writer.Close()
+		return nil, err
+	}
+	if err := writeManualImportField(writer, "location", request.Location); err != nil {
+		_ = writer.Close()
+		return nil, err
+	}
+	if request.Limit > 0 {
+		if err := writeManualImportField(writer, "limit", strconv.Itoa(request.Limit)); err != nil {
+			_ = writer.Close()
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("finalize multipart request: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/api/resumes/manual-import", c.APIURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("X-Workspace-Slug", c.Workspace)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	res, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("perform request: %w", err)
+	}
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+	if res.StatusCode >= 400 {
+		return nil, fmt.Errorf("request POST %s failed: %d %s", endpoint, res.StatusCode, strings.TrimSpace(string(responseBody)))
+	}
+
+	var response ResumeManualImportResponse
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("manual resume import request was not successful")
+	}
+	return &response, nil
+}
+
+func normalizeManualImportFilePaths(filePaths []string) []string {
+	normalized := make([]string, 0, len(filePaths))
+	for _, filePath := range filePaths {
+		trimmed := strings.TrimSpace(filePath)
+		if trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	return normalized
+}
+
+func appendManualImportFile(writer *multipart.Writer, filePath string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("open upload file %s: %w", filePath, err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat upload file %s: %w", filePath, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("upload path %s is a directory", filePath)
+	}
+
+	part, err := writer.CreateFormFile("files", filepath.Base(filePath))
+	if err != nil {
+		return fmt.Errorf("create multipart file for %s: %w", filePath, err)
+	}
+	if _, err := io.Copy(part, file); err != nil {
+		return fmt.Errorf("copy upload file %s: %w", filePath, err)
+	}
+	return nil
+}
+
+func writeManualImportField(writer *multipart.Writer, key string, value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	if err := writer.WriteField(key, trimmed); err != nil {
+		return fmt.Errorf("write multipart field %s: %w", key, err)
+	}
+	return nil
 }

--- a/packages/cli/internal/client/resume_backup_test.go
+++ b/packages/cli/internal/client/resume_backup_test.go
@@ -3,8 +3,12 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -118,5 +122,102 @@ func TestResumeBackupClientEndpoints(t *testing.T) {
 	}
 	if resetSummary.Count != 2 || resetSummary.Partial {
 		t.Fatalf("unexpected reset summary: %+v", resetSummary)
+	}
+}
+
+func TestImportManualResumesUploadsMultipartForm(t *testing.T) {
+	uploadPath := filepath.Join(t.TempDir(), "51job.rar")
+	if err := os.WriteFile(uploadPath, []byte("rar-bytes"), 0o644); err != nil {
+		t.Fatalf("failed to write upload file: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/resumes/manual-import" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("X-Workspace-Slug"); got != "hr" {
+			t.Fatalf("expected workspace header hr, got %q", got)
+		}
+		if got := r.Header.Get("Content-Type"); !strings.Contains(got, "multipart/form-data") {
+			t.Fatalf("expected multipart content type, got %q", got)
+		}
+		if err := r.ParseMultipartForm(8 << 20); err != nil {
+			t.Fatalf("failed to parse multipart form: %v", err)
+		}
+		if got := r.FormValue("searchProfileId"); got != "sales-engineer" {
+			t.Fatalf("unexpected searchProfileId: %q", got)
+		}
+		if got := r.FormValue("keyword"); got != "销售工程师" {
+			t.Fatalf("unexpected keyword: %q", got)
+		}
+		if got := r.FormValue("location"); got != "东莞" {
+			t.Fatalf("unexpected location: %q", got)
+		}
+		if got := r.FormValue("limit"); got != "5" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		files := r.MultipartForm.File["files"]
+		if len(files) != 1 || files[0].Filename != "51job.rar" {
+			t.Fatalf("unexpected upload files: %+v", files)
+		}
+		file, err := files[0].Open()
+		if err != nil {
+			t.Fatalf("failed to open uploaded file: %v", err)
+		}
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("failed to read uploaded file: %v", err)
+		}
+		if string(content) != "rar-bytes" {
+			t.Fatalf("unexpected uploaded file content: %q", string(content))
+		}
+
+		_ = json.NewEncoder(w).Encode(ResumeManualImportResponse{
+			Success: true,
+			Source: ResumeManualImportSource{
+				Key:   "51job-manual",
+				Label: "51job-manual",
+			},
+			Summary: ResumeManualImportSummary{
+				UploadedFiles:   1,
+				DiscoveredFiles: 1,
+				ParsedResumes:   1,
+				Imported:        1,
+				Inserted:        1,
+			},
+			Files: []ResumeManualImportFileResult{
+				{
+					UploadName: "51job.rar",
+					EntryPath:  "51job_张三(123456).docx",
+					Extension:  ".docx",
+					Status:     "imported",
+					ResumeName: "张三",
+					ProfileID:  "123456",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL, server.URL, "hr")
+	c.HTTP = server.Client()
+
+	response, err := c.ImportManualResumes(context.Background(), ResumeManualImportRequest{
+		FilePaths:       []string{uploadPath},
+		SearchProfileID: "sales-engineer",
+		Keyword:         "销售工程师",
+		Location:        "东莞",
+		Limit:           5,
+	})
+	if err != nil {
+		t.Fatalf("ImportManualResumes returned error: %v", err)
+	}
+	if !response.Success || response.Summary.Imported != 1 {
+		t.Fatalf("unexpected import response: %+v", response)
+	}
+	if len(response.Files) != 1 || response.Files[0].ResumeName != "张三" {
+		t.Fatalf("unexpected file response: %+v", response.Files)
 	}
 }


### PR DESCRIPTION
## Summary
- add CLI support for resume snapshot creation and directory restore flows
- add a 51job manual import command for validating manual resume imports
- cover the new backup and snapshot flows with CLI/client tests

## Validation
- go test ./... (in `packages/cli`)