### PR TITLE
fix: harden demo resume seeding and workflow verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 		i18n-check i18n-sync i18n-convert i18n-translate i18n-build \
 		refresh-sample refresh-sample-manual prefetch-convex chrome-debug \
 		seed seed-full seed-force seed-clear seed-clear-workspace seed-clear-dev \
+		seed-clear-demo-resumes \
 		backup-resumes restore-resumes \
 		clear-resumes \
 		cli-build cli-install cli-test \
@@ -16,12 +17,12 @@
 		install-browser-ext-skill check-browser-ext-skill \
 		sync-resume-ai-prompts check-resume-ai-prompts \
 		sync-resume-field-usage-policy check-resume-field-usage-policy \
-		clean-db fresh-env refresh-env
+		clean-db fresh-env refresh-env verify-workflow-dataset
 
 # Default target
 .DEFAULT_GOAL := help
 
-.PHONY: seed-matches clear-matches verify-critical-path benchmark-critical-path benchmark-critical-path-seeded benchmark-parallelism-matrix
+.PHONY: seed-matches clear-matches verify-critical-path verify-workflow-dataset benchmark-critical-path benchmark-critical-path-seeded benchmark-parallelism-matrix
 
 # =============================================================================
 # Development (Full Experience)
@@ -147,21 +148,21 @@ worker-once:
 # Deployment
 # =============================================================================
 
-# Install as systemd services (production) — seeds JDs + runs migrations
+# Install as systemd services (production) — seeds JDs + runs migrations, no demo resumes
 install:
-	sudo REPO_URL="$${REPO_URL:-}" ENV_FILE="$${ENV_FILE:-.env.production}" WORKSPACE_DIR="$$(pwd)" INSTALL_BRANCH="$${INSTALL_BRANCH:-}" ALLOW_NODE_DOWNGRADE="$${ALLOW_NODE_DOWNGRADE:-}" ./scripts/install.sh install
+	sudo REPO_URL="$${REPO_URL:-}" ENV_FILE="$${ENV_FILE:-.env.production}" WORKSPACE_DIR="$$(pwd)" INSTALL_BRANCH="$${INSTALL_BRANCH:-}" ALLOW_NODE_DOWNGRADE="$${ALLOW_NODE_DOWNGRADE:-}" SEED_RESUMES=0 ./scripts/install.sh install
 
 # Install with full demo data (JDs + sample resumes + migrations)
 install-seed:
 	sudo REPO_URL="$${REPO_URL:-}" ENV_FILE="$${ENV_FILE:-.env.production}" WORKSPACE_DIR="$$(pwd)" INSTALL_BRANCH="$${INSTALL_BRANCH:-}" ALLOW_NODE_DOWNGRADE="$${ALLOW_NODE_DOWNGRADE:-}" SEED_RESUMES=1 ./scripts/install.sh install
 
-# Preflight the workspace branch, snapshot Convex, then pull, rebuild, and restart production services
+# Preflight the workspace branch, snapshot Convex, then pull, rebuild, and restart production services (no demo resume seeding)
 deploy:
-	sudo REPO_URL="$${REPO_URL:-}" ENV_FILE="$${ENV_FILE:-.env.production}" WORKSPACE_DIR="$$(pwd)" INSTALL_BRANCH="$${INSTALL_BRANCH:-}" FORCE="$${FORCE:-}" ALLOW_NODE_DOWNGRADE="$${ALLOW_NODE_DOWNGRADE:-}" ./scripts/install.sh upgrade
+	sudo REPO_URL="$${REPO_URL:-}" ENV_FILE="$${ENV_FILE:-.env.production}" WORKSPACE_DIR="$$(pwd)" INSTALL_BRANCH="$${INSTALL_BRANCH:-}" FORCE="$${FORCE:-}" ALLOW_NODE_DOWNGRADE="$${ALLOW_NODE_DOWNGRADE:-}" SEED_RESUMES=0 ./scripts/install.sh upgrade
 
 # Show whether deploy would skip, refresh env only, or run a full upgrade
 deploy-check:
-	sudo REPO_URL="$${REPO_URL:-}" ENV_FILE="$${ENV_FILE:-.env.production}" WORKSPACE_DIR="$$(pwd)" INSTALL_BRANCH="$${INSTALL_BRANCH:-}" FORCE="$${FORCE:-}" ALLOW_NODE_DOWNGRADE="$${ALLOW_NODE_DOWNGRADE:-}" ./scripts/install.sh upgrade-check
+	sudo REPO_URL="$${REPO_URL:-}" ENV_FILE="$${ENV_FILE:-.env.production}" WORKSPACE_DIR="$$(pwd)" INSTALL_BRANCH="$${INSTALL_BRANCH:-}" FORCE="$${FORCE:-}" ALLOW_NODE_DOWNGRADE="$${ALLOW_NODE_DOWNGRADE:-}" SEED_RESUMES=0 ./scripts/install.sh upgrade-check
 
 # Deploy with full demo data (re-seeds JDs + sample resumes + migrations)
 deploy-seed:
@@ -479,6 +480,14 @@ seed-clear-workspace:
 seed-clear-dev:
 	@$(MAKE) seed-clear-workspace WORKSPACE=dev
 
+# Clear only workspace-demo resume records without wiping real resumes
+seed-clear-demo-resumes:
+	@if command -v bun > /dev/null 2>&1; then \
+		CONVEX_URL="$(CONVEX_URL)" bun scripts/resume/clear-workspace-demo-resumes.ts $(if $(JSON),--json) $(ARGS); \
+	else \
+		CONVEX_URL="$(CONVEX_URL)" npx tsx scripts/resume/clear-workspace-demo-resumes.ts $(if $(JSON),--json) $(ARGS); \
+	fi
+
 # Clear resume-related Convex collections via resetDatabase
 clear-resumes:
 	@npm --workspace @trends/convex exec convex run resume_tasks:resetDatabase
@@ -521,6 +530,21 @@ verify-critical-path:
 		ANALYSIS_TIMEOUT_SEC="$(or $(ANALYSIS_TIMEOUT_SEC),300)" \
 		JSON="$(JSON)" \
 		npx tsx scripts/verify-critical-path.ts $(ARGS); \
+	fi
+
+# Verify a source-aware resume workflow dataset and visible-result mix
+verify-workflow-dataset:
+	@set -- --query "$(or $(QUERY),CNC Sales)" --workspace "$(or $(WORKSPACE),dev)" --limit "$(or $(LIMIT),200)" --top "$(or $(TOP),10)"; \
+	if [ -n "$(LOCATION)" ]; then set -- "$$@" --location "$(LOCATION)"; fi; \
+	if [ -n "$(SOURCE_KEY)" ]; then set -- "$$@" --source-key "$(SOURCE_KEY)"; fi; \
+	if [ -n "$(JOB_DESCRIPTION)" ]; then set -- "$$@" --job-description "$(JOB_DESCRIPTION)"; fi; \
+	if [ -n "$(API_BASE_URL)" ]; then set -- "$$@" --api-base-url "$(API_BASE_URL)"; fi; \
+	if [ -n "$(CONVEX_URL)" ]; then set -- "$$@" --convex-url "$(CONVEX_URL)"; fi; \
+	if [ -n "$(JSON)" ]; then set -- "$$@" --json; fi; \
+	if command -v bun > /dev/null 2>&1; then \
+		bun scripts/resume/verify-workflow-dataset.ts "$$@" $(ARGS); \
+	else \
+		npx tsx scripts/resume/verify-workflow-dataset.ts "$$@" $(ARGS); \
 	fi
 
 # Run E2E smoke tests via DevTools MCP / Playwright CDP
@@ -803,7 +827,7 @@ help:
 	@echo "Deployment:"
 	@echo "  install        Install as systemd services (requires sudo)"
 	@echo "  install-seed   Install as systemd services with seeded demo resumes (requires sudo)"
-	@echo "  deploy         Preflight workspace git, snapshot Convex, and best-effort write resumes-<workspace>.tar.gz before skip/env-refresh/full upgrade (requires sudo)"
+	@echo "  deploy         Preflight workspace git, snapshot Convex, and best-effort write resumes-<workspace>.tar.gz before skip/env-refresh/full upgrade; does not seed demo resumes (requires sudo)"
 	@echo "  deploy-check   Dry run deploy precheck with workspace git status but without rebuilding"
 	@echo "  deploy-seed    Force a full upgrade with seeded demo resumes (requires sudo)"
 	@echo "  refresh-env    Refresh env, sync frontend build vars, and rebuild the production web bundle"
@@ -871,10 +895,12 @@ help:
 	@echo "  seed-clear     Clear all Convex seeded data (seed:clearAll)"
 	@echo "  seed-clear-workspace WORKSPACE=<slug> Clear workspace-scoped Convex data (default: dev)"
 	@echo "  seed-clear-dev Clear workspace-scoped Convex data for dev"
+	@echo "  seed-clear-demo-resumes Clear only demo resumes tagged workspace-demo"
 	@echo "  clear-resumes  Clear resume-related Convex collections"
 	@echo "  seed-matches   Seed deterministic resume matches for dev mode"
 	@echo "  clear-matches  Clear cached resume matches from SQLite"
 	@echo "  verify-critical-path Run critical-path smoke verification (Collection -> Search -> Analysis)"
+	@echo "  verify-workflow-dataset Verify source mix, query matches, and visible results for a resume workflow dataset"
 	@echo "  benchmark-critical-path Run repeated critical-path benchmark (median/p95 + rates)"
 	@echo "  benchmark-critical-path-seeded Run seeded-only benchmark profile"
 	@echo "  benchmark-parallelism-matrix Run AI/submit parallelism benchmark matrix"
@@ -903,7 +929,7 @@ help:
 	@echo "  WORKSPACE_DIR  Workspace root used to resolve relative ENV_FILE paths (auto-set by make)"
 	@echo "  INSTALL_BRANCH Git branch to deploy into /opt/trends (default: repo default branch)"
 	@echo "  FORCE          Set 1/true to bypass deploy precheck and force a full upgrade"
-	@echo "  SEED_RESUMES   Set 1/true to seed demo resumes during install/upgrade (wrappers use this for install-seed/deploy-seed)"
+	@echo "  SEED_RESUMES   Set 1/true/yes to seed demo resumes during install/upgrade; false/0 leaves real data untouched"
 	@echo "  ALLOW_NODE_DOWNGRADE Set 1/true to allow installer to downgrade Node to v22 when a newer Node is already installed"
 	@echo "  CONVEX_MIRROR_MODE Shared Convex prefetch source order for dev/install/deploy: off|fallback|mirror-first"
 	@echo "                     When CI=true/1, shared Convex prefetch mode defaults to off"
@@ -934,6 +960,11 @@ help:
 	@echo "  STRICT         Set 1/true to fail benchmark on >25% slowdown"
 	@echo "  OUT            Benchmark JSON output path (set to 1/true for default path)"
 	@echo "  MODE           Verification mode for verify-critical-path (dual|live|seeded)"
+	@echo "  QUERY          Query for verify-workflow-dataset (default: CNC Sales)"
+	@echo "  SOURCE_KEY     Source key filter for verify-workflow-dataset (e.g. seek, job5156)"
+	@echo "  JOB_DESCRIPTION Optional JD id for verify-workflow-dataset score display"
 	@echo "  COLLECTION_TIMEOUT_SEC Collection stage timeout for verify-critical-path"
 	@echo "  ANALYSIS_TIMEOUT_SEC Analysis stage timeout for verify-critical-path"
+	@echo "  API_BASE_URL   API base URL override for verify-workflow-dataset"
+	@echo "  LIMIT / TOP    Scan limit and top visible rows for verify-workflow-dataset"
 	@echo "  JSON           Set to 1/true for JSON verify/benchmark output"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "test:e2e:live-job5156-detail": "tsx scripts/e2e-smoke.ts --live-job5156-detail https://hr.job5156.com/resume/view/987654",
     "test:e2e:live-seek-my": "tsx scripts/e2e-smoke.ts --live-seek-my-recommended https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1",
     "verify:critical-path": "tsx scripts/verify-critical-path.ts",
+    "verify:workflow-dataset": "tsx scripts/resume/verify-workflow-dataset.ts",
+    "clear:workspace-demo-resumes": "tsx scripts/resume/clear-workspace-demo-resumes.ts",
     "verify:industry-scores": "tsx scripts/verify-industry-scores.ts",
     "verify:industry-scores:round-trip": "tsx scripts/verify-industry-scores.ts --sample sample-job5156-detail-enriched --round-trip",
     "e2e": "tsx scripts/e2e-smoke.ts"

--- a/packages/cli/cmd/resume_debug.go
+++ b/packages/cli/cmd/resume_debug.go
@@ -544,6 +544,10 @@ func newResumeDebugWorkflowDatasetCmd() *cobra.Command {
 				return err
 			}
 
+			if options.Output == "json" {
+				return writeOutput(cmd, nil, nil, report)
+			}
+
 			headers := []string{"resume_id", "source_key", "primary_score", "job_score", "name", "location", "source_host"}
 			rows := make([][]string, 0, len(report.VisibleResumes))
 			for _, resume := range report.VisibleResumes {
@@ -556,10 +560,6 @@ func newResumeDebugWorkflowDatasetCmd() *cobra.Command {
 					resume.Location,
 					resume.SourceHost,
 				})
-			}
-
-			if options.Output == "json" {
-				return writeOutput(cmd, nil, nil, report)
 			}
 
 			if options.Output == "table" {

--- a/packages/cli/cmd/resume_debug.go
+++ b/packages/cli/cmd/resume_debug.go
@@ -52,6 +52,64 @@ type localResumeAIScoreResponse struct {
 	Stats            localResumeAIScoreStats    `json:"stats"`
 }
 
+type workflowDatasetVerificationRequest struct {
+	APIBaseURL       string
+	ConvexURL        string
+	Workspace        string
+	Query            string
+	Location         string
+	SourceKey        string
+	Limit            int
+	Top              int
+	JobDescriptionID string
+}
+
+type workflowDatasetSourceCountRow struct {
+	Key   string `json:"key"`
+	Count int    `json:"count"`
+}
+
+type workflowDatasetVisibleResumeRow struct {
+	ResumeID         string `json:"resumeId"`
+	SourceHost       string `json:"sourceHost"`
+	SourceKey        string `json:"sourceKey,omitempty"`
+	Name             string `json:"name"`
+	Location         string `json:"location"`
+	PrimaryRuleScore *int   `json:"primaryRuleScore"`
+	JobRuleScore     *int   `json:"jobRuleScore"`
+	ProfileURL       string `json:"profileUrl,omitempty"`
+}
+
+type workflowDatasetVerificationReport struct {
+	Query                    string                            `json:"query"`
+	Location                 string                            `json:"location,omitempty"`
+	SourceKey                string                            `json:"sourceKey,omitempty"`
+	Workspace                string                            `json:"workspace"`
+	TotalResumeCount         int                               `json:"totalResumeCount"`
+	ScannedResumeCount       int                               `json:"scannedResumeCount"`
+	DatasetBySourceHost      []workflowDatasetSourceCountRow   `json:"datasetBySourceHost"`
+	DatasetBySourceKey       []workflowDatasetSourceCountRow   `json:"datasetBySourceKey"`
+	KeywordExpansion         map[string]any                    `json:"keywordExpansion"`
+	QueryMatchCount          int                               `json:"queryMatchCount"`
+	QueryMatchesBySourceHost []workflowDatasetSourceCountRow   `json:"queryMatchesBySourceHost"`
+	QueryMatchesBySourceKey  []workflowDatasetSourceCountRow   `json:"queryMatchesBySourceKey"`
+	VisibleCount             int                               `json:"visibleCount"`
+	VisibleBySourceHost      []workflowDatasetSourceCountRow   `json:"visibleBySourceHost"`
+	VisibleBySourceKey       []workflowDatasetSourceCountRow   `json:"visibleBySourceKey"`
+	VisibleResumes           []workflowDatasetVisibleResumeRow `json:"visibleResumes"`
+}
+
+type workspaceDemoResumeCleanupRequest struct {
+	ConvexURL string
+}
+
+type workspaceDemoResumeCleanupResponse struct {
+	Success   bool   `json:"success"`
+	ConvexURL string `json:"convexUrl"`
+	Deleted   int    `json:"deleted"`
+	Tag       string `json:"tag"`
+}
+
 var runLocalResumeAIScorer = func(ctx context.Context, request localResumeAIScoreRequest) (*localResumeAIScoreResponse, error) {
 	projectRoot, err := findProjectRoot()
 	if err != nil {
@@ -79,6 +137,70 @@ var runLocalResumeAIScorer = func(ctx context.Context, request localResumeAIScor
 	return &response, nil
 }
 
+var runWorkspaceDemoResumeCleanup = func(ctx context.Context, request workspaceDemoResumeCleanupRequest) (*workspaceDemoResumeCleanupResponse, error) {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	scriptPath := filepath.Join(projectRoot, "scripts", "resume", "clear-workspace-demo-resumes.ts")
+	args := []string{"--json"}
+	if value := normalizeBaseURL(request.ConvexURL); value != "" {
+		args = append(args, "--convex-url", value)
+	}
+
+	stdout, stderr, err := runBunScript(ctx, projectRoot, scriptPath, args, nil)
+	if err != nil {
+		return nil, fmt.Errorf("run workspace-demo resume cleanup: %w\n%s", err, commandErrorOutput(stdout, stderr))
+	}
+
+	var response workspaceDemoResumeCleanupResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		return nil, fmt.Errorf("decode workspace-demo resume cleanup response: %w", err)
+	}
+	return &response, nil
+}
+
+var runWorkflowDatasetVerifier = func(ctx context.Context, request workflowDatasetVerificationRequest) (*workflowDatasetVerificationReport, error) {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	scriptPath := filepath.Join(projectRoot, "scripts", "resume", "verify-workflow-dataset.ts")
+	args := []string{
+		"--query", strings.TrimSpace(request.Query),
+		"--workspace", normalizeWorkspace(request.Workspace),
+		"--api-base-url", normalizeBaseURL(request.APIBaseURL),
+		"--limit", strconv.Itoa(request.Limit),
+		"--top", strconv.Itoa(request.Top),
+		"--json",
+	}
+	if value := normalizeBaseURL(request.ConvexURL); value != "" {
+		args = append(args, "--convex-url", value)
+	}
+	if value := strings.TrimSpace(request.Location); value != "" {
+		args = append(args, "--location", value)
+	}
+	if value := strings.ToLower(strings.TrimSpace(request.SourceKey)); value != "" {
+		args = append(args, "--source-key", value)
+	}
+	if value := strings.TrimSpace(request.JobDescriptionID); value != "" {
+		args = append(args, "--job-description", value)
+	}
+
+	stdout, stderr, err := runBunScript(ctx, projectRoot, scriptPath, args, nil)
+	if err != nil {
+		return nil, fmt.Errorf("run workflow dataset verifier: %w\n%s", err, commandErrorOutput(stdout, stderr))
+	}
+
+	var response workflowDatasetVerificationReport
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		return nil, fmt.Errorf("decode workflow dataset verifier response: %w", err)
+	}
+	return &response, nil
+}
+
 func newResumeDebugCmd() *cobra.Command {
 	debugCmd := &cobra.Command{
 		Use:   "debug",
@@ -93,6 +215,8 @@ func newResumeDebugCmd() *cobra.Command {
 		newResumeDebugSkillsVersionCmd(),
 		newResumeDebugTriggerReingestCmd(),
 		newResumeDebugAIScoreCmd(),
+		newResumeDebugWorkflowDatasetCmd(),
+		newResumeDebugClearDemoResumesCmd(),
 	)
 
 	return debugCmd
@@ -377,6 +501,143 @@ func newResumeDebugAIScoreCmd() *cobra.Command {
 	cmd.Flags().IntVar(&topN, "top-n", 10, "Number of top rule-ranked candidates to AI-score locally")
 	cmd.Flags().StringSliceVar(&resumeIDs, "resume-id", nil, "Optional specific Convex resume IDs to AI-score")
 	return cmd
+}
+
+func newResumeDebugWorkflowDatasetCmd() *cobra.Command {
+	var (
+		query            string
+		location         string
+		sourceKey        string
+		convexURL        string
+		jobDescriptionID string
+		limit            int
+		top              int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "workflow-dataset",
+		Short: "Verify source mix, query matches, and visible results for a workflow dataset",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(query) == "" {
+				return fmt.Errorf("query is required")
+			}
+			if limit <= 0 {
+				return fmt.Errorf("limit must be greater than 0")
+			}
+			if top <= 0 {
+				return fmt.Errorf("top must be greater than 0")
+			}
+
+			options := currentOptions()
+			report, err := runWorkflowDatasetVerifier(context.Background(), workflowDatasetVerificationRequest{
+				APIBaseURL:       options.APIURL,
+				ConvexURL:        convexURL,
+				Workspace:        options.Workspace,
+				Query:            strings.TrimSpace(query),
+				Location:         strings.TrimSpace(location),
+				SourceKey:        strings.TrimSpace(sourceKey),
+				Limit:            limit,
+				Top:              top,
+				JobDescriptionID: strings.TrimSpace(jobDescriptionID),
+			})
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"resume_id", "source_key", "primary_score", "job_score", "name", "location", "source_host"}
+			rows := make([][]string, 0, len(report.VisibleResumes))
+			for _, resume := range report.VisibleResumes {
+				rows = append(rows, []string{
+					resume.ResumeID,
+					resume.SourceKey,
+					intPointerString(resume.PrimaryRuleScore),
+					intPointerString(resume.JobRuleScore),
+					resume.Name,
+					resume.Location,
+					resume.SourceHost,
+				})
+			}
+
+			if options.Output == "json" {
+				return writeOutput(cmd, nil, nil, report)
+			}
+
+			if options.Output == "table" {
+				fmt.Fprintf(
+					cmd.OutOrStdout(),
+					"Query: %s | Workspace: %s | Query matches: %d | Visible after filters: %d\n",
+					report.Query,
+					report.Workspace,
+					report.QueryMatchCount,
+					report.VisibleCount,
+				)
+				fmt.Fprintf(
+					cmd.OutOrStdout(),
+					"Dataset by source key: %s\n",
+					formatWorkflowDatasetCounts(report.DatasetBySourceKey),
+				)
+				fmt.Fprintf(
+					cmd.OutOrStdout(),
+					"Visible by source key: %s\n\n",
+					formatWorkflowDatasetCounts(report.VisibleBySourceKey),
+				)
+			}
+
+			if len(rows) == 0 && options.Output == "table" {
+				return writeMessage(cmd, "No visible resumes after workflow filters")
+			}
+			return writeOutput(cmd, headers, rows, report)
+		},
+	}
+
+	cmd.Flags().StringVar(&query, "query", "", "Keyword query used by the workflow")
+	cmd.Flags().StringVar(&location, "location", "", "Optional location filter")
+	cmd.Flags().StringVar(&sourceKey, "source-key", "", "Optional source key filter (for example seek or job5156)")
+	cmd.Flags().StringVar(&convexURL, "convex-url", "", "Optional Convex URL override for the verifier")
+	cmd.Flags().StringVar(&jobDescriptionID, "job-description", "", "Optional job description ID for score display")
+	cmd.Flags().IntVar(&limit, "limit", 200, "Maximum resumes to scan")
+	cmd.Flags().IntVar(&top, "top", 10, "Maximum visible resumes to print")
+	return cmd
+}
+
+func newResumeDebugClearDemoResumesCmd() *cobra.Command {
+	var convexURL string
+
+	cmd := &cobra.Command{
+		Use:   "clear-demo-resumes",
+		Short: "Delete resumes tagged workspace-demo from the target Convex deployment",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := runWorkspaceDemoResumeCleanup(context.Background(), workspaceDemoResumeCleanupRequest{
+				ConvexURL: convexURL,
+			})
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"deleted", "tag", "convex_url"}
+			rows := [][]string{{
+				strconv.Itoa(response.Deleted),
+				response.Tag,
+				response.ConvexURL,
+			}}
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	cmd.Flags().StringVar(&convexURL, "convex-url", "", "Optional Convex URL override for workspace-demo resume cleanup")
+	return cmd
+}
+
+func formatWorkflowDatasetCounts(rows []workflowDatasetSourceCountRow) string {
+	if len(rows) == 0 {
+		return "none"
+	}
+
+	parts := make([]string, 0, len(rows))
+	for _, row := range rows {
+		parts = append(parts, fmt.Sprintf("%s:%d", row.Key, row.Count))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func writeResumeMatchTable(cmd *cobra.Command, response *client.ResumeMatchResponse, displayMap map[string]resumeDisplayRow) error {

--- a/packages/cli/cmd/resume_debug_test.go
+++ b/packages/cli/cmd/resume_debug_test.go
@@ -125,6 +125,220 @@ func TestResumeDebugAIScoreCommandWritesTable(t *testing.T) {
 	}
 }
 
+func TestResumeDebugWorkflowDatasetCommandWritesJSON(t *testing.T) {
+	setResumeCLIConfig(t, "http://localhost:3000", "ops")
+	setCLIOutput(t, "json")
+
+	originalRunner := runWorkflowDatasetVerifier
+	t.Cleanup(func() {
+		runWorkflowDatasetVerifier = originalRunner
+	})
+
+	runWorkflowDatasetVerifier = func(ctx context.Context, request workflowDatasetVerificationRequest) (*workflowDatasetVerificationReport, error) {
+		if request.APIBaseURL != "http://localhost:3000" {
+			t.Fatalf("unexpected api base url: %q", request.APIBaseURL)
+		}
+		if request.Workspace != "ops" {
+			t.Fatalf("unexpected workspace: %q", request.Workspace)
+		}
+		if request.Query != "CNC Sales" {
+			t.Fatalf("unexpected query: %q", request.Query)
+		}
+		if request.Location != "Kuala Lumpur MY" {
+			t.Fatalf("unexpected location: %q", request.Location)
+		}
+		if request.SourceKey != "seek" {
+			t.Fatalf("unexpected source key: %q", request.SourceKey)
+		}
+		if request.ConvexURL != "http://127.0.0.1:3210" {
+			t.Fatalf("unexpected convex url: %q", request.ConvexURL)
+		}
+		if request.JobDescriptionID != "seek-malaysia-sales" {
+			t.Fatalf("unexpected job description: %q", request.JobDescriptionID)
+		}
+		if request.Limit != 250 || request.Top != 5 {
+			t.Fatalf("unexpected scan config: limit=%d top=%d", request.Limit, request.Top)
+		}
+
+		return &workflowDatasetVerificationReport{
+			Query:              request.Query,
+			Location:           request.Location,
+			SourceKey:          request.SourceKey,
+			Workspace:          request.Workspace,
+			TotalResumeCount:   192,
+			ScannedResumeCount: 192,
+			DatasetBySourceKey: []workflowDatasetSourceCountRow{
+				{Key: "job5156", Count: 191},
+				{Key: "seek", Count: 1},
+			},
+			QueryMatchCount: 6,
+			VisibleCount:    1,
+			VisibleBySourceKey: []workflowDatasetSourceCountRow{
+				{Key: "seek", Count: 1},
+			},
+			VisibleResumes: []workflowDatasetVisibleResumeRow{
+				{
+					ResumeID:   "resume-1",
+					SourceHost: "my.employer.seek.com",
+					SourceKey:  "seek",
+					Name:       "Yap Kae Wen",
+					Location:   "Kuala Lumpur, Malaysia",
+				},
+			},
+		}, nil
+	}
+
+	cmd := newResumeDebugWorkflowDatasetCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{
+		"--query", "CNC Sales",
+		"--location", "Kuala Lumpur MY",
+		"--source-key", "seek",
+		"--convex-url", "http://127.0.0.1:3210",
+		"--job-description", "seek-malaysia-sales",
+		"--limit", "250",
+		"--top", "5",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug workflow-dataset command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["query"] != "CNC Sales" {
+		t.Fatalf("unexpected query in output: %+v", payload)
+	}
+	if payload["visibleCount"] != float64(1) {
+		t.Fatalf("unexpected visible count in output: %+v", payload)
+	}
+}
+
+func TestResumeDebugWorkflowDatasetCommandWritesTable(t *testing.T) {
+	setResumeCLIConfig(t, "http://localhost:3000", "dev")
+	setCLIOutput(t, "table")
+
+	originalRunner := runWorkflowDatasetVerifier
+	t.Cleanup(func() {
+		runWorkflowDatasetVerifier = originalRunner
+	})
+
+	primaryScore := 86
+	runWorkflowDatasetVerifier = func(ctx context.Context, request workflowDatasetVerificationRequest) (*workflowDatasetVerificationReport, error) {
+		return &workflowDatasetVerificationReport{
+			Query:           request.Query,
+			Workspace:       request.Workspace,
+			QueryMatchCount: 6,
+			VisibleCount:    1,
+			DatasetBySourceKey: []workflowDatasetSourceCountRow{
+				{Key: "job5156", Count: 191},
+				{Key: "seek", Count: 1},
+			},
+			VisibleBySourceKey: []workflowDatasetSourceCountRow{
+				{Key: "seek", Count: 1},
+			},
+			VisibleResumes: []workflowDatasetVisibleResumeRow{
+				{
+					ResumeID:         "resume-1",
+					SourceHost:       "my.employer.seek.com",
+					SourceKey:        "seek",
+					Name:             "Yap Kae Wen",
+					Location:         "Kuala Lumpur, Malaysia",
+					PrimaryRuleScore: &primaryScore,
+				},
+			},
+		}, nil
+	}
+
+	cmd := newResumeDebugWorkflowDatasetCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--query", "CNC Sales"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug workflow-dataset command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "Query: CNC Sales | Workspace: dev | Query matches: 6 | Visible after filters: 1") {
+		t.Fatalf("unexpected summary output: %s", text)
+	}
+	if !strings.Contains(text, "Yap Kae Wen") || !strings.Contains(text, "seek") || !strings.Contains(text, "86") {
+		t.Fatalf("unexpected table output: %s", text)
+	}
+}
+
+func TestResumeDebugClearDemoResumesCommandWritesJSON(t *testing.T) {
+	setCLIOutput(t, "json")
+
+	originalRunner := runWorkspaceDemoResumeCleanup
+	t.Cleanup(func() {
+		runWorkspaceDemoResumeCleanup = originalRunner
+	})
+
+	runWorkspaceDemoResumeCleanup = func(ctx context.Context, request workspaceDemoResumeCleanupRequest) (*workspaceDemoResumeCleanupResponse, error) {
+		if request.ConvexURL != "https://demo.example.convex.cloud" {
+			t.Fatalf("unexpected convex url: %q", request.ConvexURL)
+		}
+
+		return &workspaceDemoResumeCleanupResponse{
+			Success:   true,
+			ConvexURL: request.ConvexURL,
+			Deleted:   1,
+			Tag:       "workspace-demo",
+		}, nil
+	}
+
+	cmd := newResumeDebugClearDemoResumesCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--convex-url", "https://demo.example.convex.cloud"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug clear-demo-resumes command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["deleted"] != float64(1) || payload["tag"] != "workspace-demo" {
+		t.Fatalf("unexpected cleanup output: %+v", payload)
+	}
+}
+
+func TestResumeDebugClearDemoResumesCommandWritesTable(t *testing.T) {
+	setCLIOutput(t, "table")
+
+	originalRunner := runWorkspaceDemoResumeCleanup
+	t.Cleanup(func() {
+		runWorkspaceDemoResumeCleanup = originalRunner
+	})
+
+	runWorkspaceDemoResumeCleanup = func(ctx context.Context, request workspaceDemoResumeCleanupRequest) (*workspaceDemoResumeCleanupResponse, error) {
+		return &workspaceDemoResumeCleanupResponse{
+			Success:   true,
+			ConvexURL: "http://127.0.0.1:3210",
+			Deleted:   2,
+			Tag:       "workspace-demo",
+		}, nil
+	}
+
+	cmd := newResumeDebugClearDemoResumesCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug clear-demo-resumes command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "workspace-demo") || !strings.Contains(text, "2") || !strings.Contains(text, "127.0.0.1:3210") {
+		t.Fatalf("unexpected cleanup table output: %s", text)
+	}
+}
+
 func TestResumeDebugRescoreRejectsConvex(t *testing.T) {
 	cmd := newResumeDebugRescoreCmd()
 	cmd.SetArgs([]string{"--query", "CNC 销售", "--source", "convex"})

--- a/packages/convex/convex/__tests__/seed-workspace-demo-data.test.ts
+++ b/packages/convex/convex/__tests__/seed-workspace-demo-data.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { seedWorkspaceDemoData } from '../seed'
+import { clearWorkspaceDemoResumes, seedWorkspaceDemoData } from '../seed'
 
 type WorkspaceSeedResult = {
   customJobDescriptions: {
@@ -31,6 +31,11 @@ type WorkspaceSeedResult = {
 
 type ConvexHandler<TArgs, TResult> = {
   _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+type ClearWorkspaceDemoResumesResult = {
+  deleted: number
+  tag: string
 }
 
 type RecordWithId = {
@@ -121,8 +126,15 @@ type SeedTables = {
 type SupportedTable = keyof SeedTables
 
 const seedWorkspaceDemoDataHandler = (seedWorkspaceDemoData as unknown as ConvexHandler<
-  Record<string, never>,
+  {
+    includeDemoResumes?: boolean
+  },
   WorkspaceSeedResult
+>)._handler
+
+const clearWorkspaceDemoResumesHandler = (clearWorkspaceDemoResumes as unknown as ConvexHandler<
+  Record<string, never>,
+  ClearWorkspaceDemoResumesResult
 >)._handler
 
 function createEqChain(clauses: Array<{ field: string; value: string }>) {
@@ -317,6 +329,14 @@ function createSeedCtx() {
         patchRecord(tables.workspace_config, id, patch as Partial<WorkspaceConfigRecord>)
         patchRecord(tables.resumes, id, patch as Partial<ResumeRecord>)
       },
+      async delete(id: string) {
+        tables.job_descriptions = tables.job_descriptions.filter((entry) => entry._id !== id)
+        tables.search_profiles = tables.search_profiles.filter((entry) => entry._id !== id)
+        tables.screening_sessions = tables.screening_sessions.filter((entry) => entry._id !== id)
+        tables.search_history = tables.search_history.filter((entry) => entry._id !== id)
+        tables.workspace_config = tables.workspace_config.filter((entry) => entry._id !== id)
+        tables.resumes = tables.resumes.filter((entry) => entry._id !== id)
+      },
     },
   }
 
@@ -324,10 +344,21 @@ function createSeedCtx() {
 }
 
 describe('seedWorkspaceDemoData', () => {
-  it('seeds one deterministic SEEK Malaysia resume and stays idempotent on rerun', async () => {
+  it('does not seed demo resumes unless explicitly requested', async () => {
     const { ctx, tables } = createSeedCtx()
 
     const firstRun = await seedWorkspaceDemoDataHandler(ctx as never, {})
+
+    expect(firstRun.resumes).toEqual({ inserted: 0, updated: 0 })
+    expect(tables.resumes).toHaveLength(0)
+  })
+
+  it('seeds one deterministic SEEK Malaysia resume only for explicit demo-resume runs and stays idempotent on rerun', async () => {
+    const { ctx, tables } = createSeedCtx()
+
+    const firstRun = await seedWorkspaceDemoDataHandler(ctx as never, {
+      includeDemoResumes: true,
+    })
 
     expect(firstRun.resumes).toEqual({ inserted: 1, updated: 0 })
     expect(tables.resumes).toHaveLength(1)
@@ -353,9 +384,39 @@ describe('seedWorkspaceDemoData', () => {
       }),
     }))
 
-    const secondRun = await seedWorkspaceDemoDataHandler(ctx as never, {})
+    const secondRun = await seedWorkspaceDemoDataHandler(ctx as never, {
+      includeDemoResumes: true,
+    })
 
     expect(secondRun.resumes).toEqual({ inserted: 0, updated: 0 })
     expect(tables.resumes).toHaveLength(1)
+  })
+
+  it('clears only workspace-demo resumes', async () => {
+    const { ctx, tables } = createSeedCtx()
+
+    await seedWorkspaceDemoDataHandler(ctx as never, {
+      includeDemoResumes: true,
+    })
+    await ctx.db.insert('resumes', {
+      externalId: 'real-seek-profile',
+      identityKey: 'profileUrl:my.employer.seek.com/candidates/real',
+      content: {
+        name: 'Real Candidate',
+      },
+      hash: 'hash-real',
+      source: 'my.employer.seek.com',
+      tags: ['seek'],
+      crawledAt: 1,
+    })
+
+    const result = await clearWorkspaceDemoResumesHandler(ctx as never, {})
+
+    expect(result).toEqual({
+      deleted: 1,
+      tag: 'workspace-demo',
+    })
+    expect(tables.resumes).toHaveLength(1)
+    expect(tables.resumes[0]?.externalId).toBe('real-seek-profile')
   })
 })

--- a/packages/convex/convex/seed.ts
+++ b/packages/convex/convex/seed.ts
@@ -530,9 +530,12 @@ export const seedResumes = mutation({
 });
 
 export const seedWorkspaceDemoData = mutation({
-  args: {},
-  handler: async (ctx) => {
+  args: {
+    includeDemoResumes: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
     const seededAt = 1_762_000_000_000;
+    const includeDemoResumes = args.includeDemoResumes === true;
     const customJobDescriptions = [
       {
         title: "车床销售",
@@ -1089,7 +1092,9 @@ export const seedWorkspaceDemoData = mutation({
       result.workspaceConfig.inserted += 1;
     }
 
-    const demoResumes = [buildSeekMalaysiaSalesDemoResume(seededAt)];
+    const demoResumes = includeDemoResumes
+      ? [buildSeekMalaysiaSalesDemoResume(seededAt)]
+      : [];
     for (const item of demoResumes) {
       const identity = deriveResumeIdentity({
         content: item.content,
@@ -1229,6 +1234,27 @@ export const clearWorkspaceData = mutation({
       screeningSessions,
       searchHistory,
       workspaceConfig,
+    };
+  },
+});
+
+export const clearWorkspaceDemoResumes = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const resumes = await ctx.db.query("resumes").collect();
+    let deleted = 0;
+
+    for (const resume of resumes) {
+      if (!resume.tags.includes("workspace-demo")) {
+        continue;
+      }
+      await ctx.db.delete(resume._id);
+      deleted += 1;
+    }
+
+    return {
+      deleted,
+      tag: "workspace-demo",
     };
   },
 });

--- a/scripts/install-deploy-safety.test.ts
+++ b/scripts/install-deploy-safety.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const makefile = readFileSync(new URL("../Makefile", import.meta.url), "utf8");
+const installScript = readFileSync(new URL("./install.sh", import.meta.url), "utf8");
+
+function getTargetRecipe(target: string): string {
+  const escapedTarget = target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`^${escapedTarget}:\\n((?:\\t.*\\n)+)`, "m");
+  const match = makefile.match(pattern);
+  if (!match || !match[1]) {
+    throw new Error(`Missing Makefile recipe for target: ${target}`);
+  }
+  return match[1];
+}
+
+describe("install/deploy demo resume safety", () => {
+  it("forces non-seeding wrappers to disable demo resumes explicitly", () => {
+    expect(getTargetRecipe("install")).toContain("SEED_RESUMES=0");
+    expect(getTargetRecipe("deploy")).toContain("SEED_RESUMES=0");
+    expect(getTargetRecipe("deploy-check")).toContain("SEED_RESUMES=0");
+  });
+
+  it("keeps seed wrappers opt-in and explicit", () => {
+    expect(getTargetRecipe("install-seed")).toContain("SEED_RESUMES=1");
+    expect(getTargetRecipe("deploy-seed")).toContain("SEED_RESUMES=1");
+  });
+
+  it("uses strict truthiness checks in the installer instead of non-empty env checks", () => {
+    const truthyChecks = installScript.match(/if is_truthy "\$\{SEED_RESUMES:-\}"; then/g) ?? [];
+
+    expect(truthyChecks).toHaveLength(3);
+    expect(installScript).not.toContain('[[ -n "${SEED_RESUMES:-}" ]]');
+  });
+});

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -809,7 +809,7 @@ plan_upgrade_action() {
     fi
 
     UPGRADE_ACTION="full"
-    if [[ -n "${SEED_RESUMES:-}" ]]; then
+    if is_truthy "${SEED_RESUMES:-}"; then
         UPGRADE_ACTION="full"
     elif is_truthy "${FORCE:-}"; then
         UPGRADE_ACTION="full"
@@ -857,7 +857,7 @@ print_upgrade_plan() {
     else
         echo "  env file: unchanged (ENV_FILE empty)"
     fi
-    if [[ -n "${SEED_RESUMES:-}" ]]; then
+    if is_truthy "${SEED_RESUMES:-}"; then
         echo "  seed resumes: yes"
     fi
     if is_truthy "${FORCE:-}"; then
@@ -1272,7 +1272,7 @@ seed_and_migrate_convex() {
     fi
 
     # Always seed JDs (idempotent). Optionally include sample resumes.
-    if [[ -n "${SEED_RESUMES:-}" ]]; then
+    if is_truthy "${SEED_RESUMES:-}"; then
         seed_args="$seed_args --with-resumes"
         log_info "Seeding Convex: job descriptions + sample resumes..."
     else

--- a/scripts/repo-workflow-entrypoints.test.ts
+++ b/scripts/repo-workflow-entrypoints.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const makefile = readFileSync(new URL("../Makefile", import.meta.url), "utf8");
+const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+  scripts?: Record<string, string>;
+};
+
+function getTargetRecipe(target: string): string {
+  const escapedTarget = target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`^${escapedTarget}:\\n((?:\\t.*\\n)+)`, "m");
+  const match = makefile.match(pattern);
+  if (!match || !match[1]) {
+    throw new Error(`Missing Makefile recipe for target: ${target}`);
+  }
+  return match[1];
+}
+
+describe("workflow verifier repo entrypoints", () => {
+  it("exposes the workflow verifier through package.json", () => {
+    expect(packageJson.scripts?.["verify:workflow-dataset"]).toBe("tsx scripts/resume/verify-workflow-dataset.ts");
+  });
+
+  it("exposes the workspace-demo cleanup script through package.json", () => {
+    expect(packageJson.scripts?.["clear:workspace-demo-resumes"]).toBe("tsx scripts/resume/clear-workspace-demo-resumes.ts");
+  });
+
+  it("exposes a Make target with the expected forwarding flags", () => {
+    const recipe = getTargetRecipe("verify-workflow-dataset");
+
+    expect(recipe).toContain('set -- --query "$(or $(QUERY),CNC Sales)"');
+    expect(recipe).toContain('--workspace "$(or $(WORKSPACE),dev)"');
+    expect(recipe).toContain('--source-key "$(SOURCE_KEY)"');
+    expect(recipe).toContain('--api-base-url "$(API_BASE_URL)"');
+    expect(recipe).toContain('--json');
+    expect(recipe).toContain('scripts/resume/verify-workflow-dataset.ts "$$@" $(ARGS)');
+  });
+
+  it("documents the workflow verifier in Make help output", () => {
+    expect(makefile).toContain('verify-workflow-dataset Verify source mix, query matches, and visible results for a resume workflow dataset');
+    expect(makefile).toContain('QUERY          Query for verify-workflow-dataset (default: CNC Sales)');
+    expect(makefile).toContain('SOURCE_KEY     Source key filter for verify-workflow-dataset (e.g. seek, job5156)');
+    expect(makefile).toContain('API_BASE_URL   API base URL override for verify-workflow-dataset');
+  });
+
+  it("exposes a targeted workspace-demo resume cleanup make target", () => {
+    const recipe = getTargetRecipe("seed-clear-demo-resumes");
+
+    expect(recipe).toContain('bun scripts/resume/clear-workspace-demo-resumes.ts');
+    expect(recipe).toContain('npx tsx scripts/resume/clear-workspace-demo-resumes.ts');
+    expect(makefile).toContain('seed-clear-demo-resumes Clear only demo resumes tagged workspace-demo');
+  });
+});

--- a/scripts/resume/clear-workspace-demo-resumes.test.ts
+++ b/scripts/resume/clear-workspace-demo-resumes.test.ts
@@ -1,0 +1,33 @@
+import { ConvexHttpClient } from "convex/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runWorkspaceDemoResumeCleanup } from "./clear-workspace-demo-resumes.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("clear-workspace-demo-resumes", () => {
+  it("calls the workspace-demo cleanup mutation and returns the result payload", async () => {
+    const mutationSpy = vi
+      .spyOn(ConvexHttpClient.prototype, "mutation")
+      .mockResolvedValue({
+        deleted: 1,
+        tag: "workspace-demo",
+      } as never);
+
+    const result = await runWorkspaceDemoResumeCleanup({
+      convexUrl: "http://127.0.0.1:3210",
+      json: true,
+    });
+
+    expect(mutationSpy).toHaveBeenCalledTimes(1);
+    expect(mutationSpy.mock.calls[0]?.[1]).toEqual({});
+    expect(result).toEqual({
+      success: true,
+      convexUrl: "http://127.0.0.1:3210",
+      deleted: 1,
+      tag: "workspace-demo",
+    });
+  });
+});

--- a/scripts/resume/clear-workspace-demo-resumes.ts
+++ b/scripts/resume/clear-workspace-demo-resumes.ts
@@ -1,0 +1,94 @@
+import { fileURLToPath } from "node:url";
+
+import { ConvexHttpClient } from "convex/browser";
+
+import { api } from "../../packages/convex/convex/_generated/api.js";
+
+const DEFAULT_CONVEX_URL = "http://127.0.0.1:3210";
+
+type CliOptions = {
+  convexUrl: string;
+  json: boolean;
+};
+
+type CleanupResult = {
+  success: true;
+  convexUrl: string;
+  deleted: number;
+  tag: string;
+};
+
+function toOptionalString(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readCliValue(flag: string): string | undefined {
+  const fullFlag = `--${flag}`;
+  for (let index = 0; index < process.argv.length; index += 1) {
+    const arg = process.argv[index];
+    if (arg === fullFlag) {
+      return process.argv[index + 1];
+    }
+    if (arg.startsWith(`${fullFlag}=`)) {
+      return arg.slice(fullFlag.length + 1);
+    }
+  }
+  return undefined;
+}
+
+function hasCliFlag(flag: string): boolean {
+  return process.argv.includes(`--${flag}`);
+}
+
+function parseCliOptions(): CliOptions {
+  return {
+    convexUrl: (toOptionalString(readCliValue("convex-url")) ?? toOptionalString(process.env.CONVEX_URL) ?? DEFAULT_CONVEX_URL).replace(/\/$/, ""),
+    json: hasCliFlag("json"),
+  };
+}
+
+export async function runWorkspaceDemoResumeCleanup(options: CliOptions): Promise<CleanupResult> {
+  const client = new ConvexHttpClient(options.convexUrl);
+  const result = await client.mutation(api.seed.clearWorkspaceDemoResumes, {});
+
+  return {
+    success: true,
+    convexUrl: options.convexUrl,
+    deleted: result.deleted,
+    tag: result.tag,
+  };
+}
+
+function printResult(result: CleanupResult): void {
+  console.log(`Convex URL: ${result.convexUrl}`);
+  console.log(`Deleted resumes: ${result.deleted}`);
+  console.log(`Tag: ${result.tag}`);
+}
+
+async function main(): Promise<void> {
+  const options = parseCliOptions();
+  const result = await runWorkspaceDemoResumeCleanup(options);
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  printResult(result);
+}
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const entryFilePath = process.argv[1];
+
+if (entryFilePath && currentFilePath === entryFilePath) {
+  main().catch((error: unknown) => {
+    console.error("clear-workspace-demo-resumes failed:");
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/resume/verify-workflow-dataset.test.ts
+++ b/scripts/resume/verify-workflow-dataset.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { countByKey, getResumeSourceKey, matchesWorkflowFilters } from "./verify-workflow-dataset.ts";
+
+describe("verify workflow dataset helpers", () => {
+  it("derives source keys from source hosts and profile types", () => {
+    expect(getResumeSourceKey({
+      _id: "seek-1",
+      source: "my.employer.seek.com",
+      content: {},
+    })).toBe("seek");
+
+    expect(getResumeSourceKey({
+      _id: "job5156-1",
+      source: "hr.job5156.com",
+      content: {
+        profileType: "job5156",
+      },
+    })).toBe("job5156");
+  });
+
+  it("matches workflow filters using source key and Malaysia location aliases", () => {
+    const seekResume = {
+      _id: "seek-1",
+      source: "my.employer.seek.com",
+      content: {
+        location: "Kuala Lumpur, Malaysia",
+      },
+    };
+    const job5156Resume = {
+      _id: "job5156-1",
+      source: "hr.job5156.com",
+      content: {
+        location: "广东东莞长安镇",
+      },
+    };
+
+    expect(matchesWorkflowFilters(seekResume, { sourceKey: "seek", location: "Kuala Lumpur MY" })).toBe(true);
+    expect(matchesWorkflowFilters(seekResume, { sourceKey: "job5156", location: "Kuala Lumpur MY" })).toBe(false);
+    expect(matchesWorkflowFilters(job5156Resume, { sourceKey: "seek", location: "Kuala Lumpur MY" })).toBe(false);
+  });
+
+  it("counts unknown keys explicitly", () => {
+    const rows = countByKey(
+      [
+        { source: "my.employer.seek.com" },
+        { source: "my.employer.seek.com" },
+        { source: undefined },
+      ],
+      (item) => item.source,
+    );
+
+    expect(rows).toEqual([
+      { key: "my.employer.seek.com", count: 2 },
+      { key: "unknown", count: 1 },
+    ]);
+  });
+});

--- a/scripts/resume/verify-workflow-dataset.ts
+++ b/scripts/resume/verify-workflow-dataset.ts
@@ -1,0 +1,385 @@
+import { fileURLToPath } from "node:url";
+
+import { ConvexHttpClient } from "convex/browser";
+
+import { api } from "../../packages/convex/convex/_generated/api.js";
+import { isLocationMatch, resolveResumeAnalysisSourceKey } from "../../packages/shared/src/index.ts";
+
+const DEFAULT_API_BASE_URL = "http://localhost:3000";
+const DEFAULT_CONVEX_URL = "http://127.0.0.1:3210";
+const DEFAULT_LIMIT = 200;
+const DEFAULT_TOP = 10;
+const DEFAULT_WORKSPACE = "dev";
+
+type KeywordExpansionSummary = {
+  groups: Array<{
+    original: string;
+    variants: string[];
+  }>;
+  mode: "AND" | "OR";
+  expandedTo: string[];
+  sourceMapping: Record<string, string>;
+};
+
+type ResumeDoc = {
+  _id: string;
+  source: string;
+  primaryRuleScore?: number;
+  ingestData?: {
+    ruleScores?: Record<string, number>;
+  };
+  content?: {
+    name?: string;
+    location?: string;
+    profileType?: string;
+    profileUrl?: string;
+  };
+};
+
+type SearchResult = {
+  resume: ResumeDoc;
+  provenance: Array<{
+    term: string;
+    source: string;
+    expandedFrom?: string;
+  }>;
+};
+
+type CliOptions = {
+  apiBaseUrl: string;
+  convexUrl: string;
+  workspace: string;
+  query: string;
+  location?: string;
+  sourceKey?: string;
+  limit: number;
+  top: number;
+  jobDescriptionId?: string;
+  json: boolean;
+};
+
+type SourceCountRow = {
+  key: string;
+  count: number;
+};
+
+type VisibleResumeRow = {
+  resumeId: string;
+  sourceHost: string;
+  sourceKey?: string;
+  name: string;
+  location: string;
+  primaryRuleScore: number | null;
+  jobRuleScore: number | null;
+  profileUrl?: string;
+};
+
+type WorkflowVerificationReport = {
+  query: string;
+  location?: string;
+  sourceKey?: string;
+  workspace: string;
+  totalResumeCount: number;
+  scannedResumeCount: number;
+  datasetBySourceHost: SourceCountRow[];
+  datasetBySourceKey: SourceCountRow[];
+  keywordExpansion: KeywordExpansionSummary;
+  queryMatchCount: number;
+  queryMatchesBySourceHost: SourceCountRow[];
+  queryMatchesBySourceKey: SourceCountRow[];
+  visibleCount: number;
+  visibleBySourceHost: SourceCountRow[];
+  visibleBySourceKey: SourceCountRow[];
+  visibleResumes: VisibleResumeRow[];
+};
+
+function toOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readCliValue(flag: string): string | undefined {
+  const fullFlag = `--${flag}`;
+  for (let index = 0; index < process.argv.length; index += 1) {
+    const arg = process.argv[index];
+    if (arg === fullFlag) {
+      return process.argv[index + 1];
+    }
+    if (arg.startsWith(`${fullFlag}=`)) {
+      return arg.slice(fullFlag.length + 1);
+    }
+  }
+  return undefined;
+}
+
+function hasCliFlag(flag: string): boolean {
+  return process.argv.includes(`--${flag}`);
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number, label: string): number {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  return parsed;
+}
+
+function parseCliOptions(): CliOptions {
+  const query = toOptionalString(readCliValue("query"));
+  if (!query) {
+    throw new Error("Missing required --query");
+  }
+
+  return {
+    apiBaseUrl: (toOptionalString(readCliValue("api-base-url")) ?? toOptionalString(process.env.TRENDS_API_URL) ?? DEFAULT_API_BASE_URL).replace(/\/$/, ""),
+    convexUrl: toOptionalString(readCliValue("convex-url")) ?? toOptionalString(process.env.CONVEX_URL) ?? DEFAULT_CONVEX_URL,
+    workspace: toOptionalString(readCliValue("workspace")) ?? DEFAULT_WORKSPACE,
+    query,
+    location: toOptionalString(readCliValue("location")),
+    sourceKey: toOptionalString(readCliValue("source-key"))?.toLowerCase(),
+    limit: parsePositiveInteger(readCliValue("limit"), DEFAULT_LIMIT, "limit"),
+    top: parsePositiveInteger(readCliValue("top"), DEFAULT_TOP, "top"),
+    jobDescriptionId: toOptionalString(readCliValue("job-description")),
+    json: hasCliFlag("json"),
+  };
+}
+
+export function getResumeSourceKey(resume: ResumeDoc): string | undefined {
+  return resolveResumeAnalysisSourceKey({
+    sourceKey: resume.content?.profileType,
+    source: resume.source,
+  });
+}
+
+export function matchesWorkflowFilters(
+  resume: ResumeDoc,
+  filters: {
+    sourceKey?: string;
+    location?: string;
+  },
+): boolean {
+  if (filters.sourceKey) {
+    const resumeSourceKey = getResumeSourceKey(resume);
+    if (resumeSourceKey !== filters.sourceKey) {
+      return false;
+    }
+  }
+
+  if (filters.location) {
+    const resumeLocation = resume.content?.location ?? "";
+    if (!isLocationMatch(resumeLocation, filters.location)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function countByKey<T>(items: T[], keyResolver: (item: T) => string | undefined): SourceCountRow[] {
+  const counts = new Map<string, number>();
+
+  for (const item of items) {
+    const key = keyResolver(item) ?? "unknown";
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  return Array.from(counts.entries())
+    .map(([key, count]) => ({ key, count }))
+    .sort((left, right) => right.count - left.count || left.key.localeCompare(right.key));
+}
+
+async function fetchKeywordExpansion(apiBaseUrl: string, workspace: string, query: string): Promise<KeywordExpansionSummary> {
+  const url = new URL("/api/resumes/keyword-expansion", apiBaseUrl);
+  url.searchParams.set("q", query);
+
+  const response = await fetch(url, {
+    headers: {
+      "X-Workspace-Slug": workspace,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Keyword expansion request failed: ${response.status}`);
+  }
+
+  const payload = await response.json() as {
+    success?: boolean;
+    summary?: KeywordExpansionSummary;
+  };
+  if (!payload.success || !payload.summary) {
+    throw new Error("Keyword expansion response missing summary");
+  }
+
+  return payload.summary;
+}
+
+function toVisibleResumeRow(
+  resume: ResumeDoc,
+  jobDescriptionId: string | undefined,
+): VisibleResumeRow {
+  const jobRuleScore = jobDescriptionId
+    ? resume.ingestData?.ruleScores?.[jobDescriptionId] ?? null
+    : null;
+
+  return {
+    resumeId: resume._id,
+    sourceHost: resume.source,
+    sourceKey: getResumeSourceKey(resume),
+    name: resume.content?.name ?? "",
+    location: resume.content?.location ?? "",
+    primaryRuleScore: typeof resume.primaryRuleScore === "number" ? resume.primaryRuleScore : null,
+    jobRuleScore: typeof jobRuleScore === "number" ? jobRuleScore : null,
+    profileUrl: resume.content?.profileUrl,
+  };
+}
+
+function formatCounts(rows: SourceCountRow[]): string {
+  return rows.map((row) => `${row.key}:${row.count}`).join(", ");
+}
+
+function printReport(report: WorkflowVerificationReport): void {
+  console.log(`Query: ${report.query}`);
+  console.log(`Workspace: ${report.workspace}`);
+  if (report.location) {
+    console.log(`Location filter: ${report.location}`);
+  }
+  if (report.sourceKey) {
+    console.log(`Source key filter: ${report.sourceKey}`);
+  }
+  console.log(`Total resumes in Convex: ${report.totalResumeCount}`);
+  console.log(`Scanned resumes: ${report.scannedResumeCount}`);
+  console.log(`Dataset by source host: ${formatCounts(report.datasetBySourceHost)}`);
+  console.log(`Dataset by source key: ${formatCounts(report.datasetBySourceKey)}`);
+  console.log(`Expanded terms: ${report.keywordExpansion.expandedTo.join(", ")}`);
+  console.log(`Query match count: ${report.queryMatchCount}`);
+  console.log(`Query matches by source host: ${formatCounts(report.queryMatchesBySourceHost)}`);
+  console.log(`Query matches by source key: ${formatCounts(report.queryMatchesBySourceKey)}`);
+  console.log(`Visible count after source/location filters: ${report.visibleCount}`);
+  console.log(`Visible by source host: ${formatCounts(report.visibleBySourceHost)}`);
+  console.log(`Visible by source key: ${formatCounts(report.visibleBySourceKey)}`);
+
+  if (report.visibleResumes.length === 0) {
+    console.log("Visible resumes: none");
+    return;
+  }
+
+  console.log("Visible resumes:");
+  report.visibleResumes.forEach((resume) => {
+    console.log(
+      [
+        `- ${resume.name || "(unnamed)"}`,
+        `id=${resume.resumeId}`,
+        `source=${resume.sourceHost}`,
+        `location=${resume.location || "-"}`,
+        `primaryRuleScore=${resume.primaryRuleScore ?? "-"}`,
+        `jobRuleScore=${resume.jobRuleScore ?? "-"}`,
+      ].join(" | "),
+    );
+  });
+}
+
+export async function buildWorkflowVerificationReport(options: CliOptions): Promise<WorkflowVerificationReport> {
+  const client = new ConvexHttpClient(options.convexUrl);
+
+  const [totalResumeCount, allResumes, keywordExpansion] = await Promise.all([
+    client.query(api.resumes.count, {}),
+    client.query(api.resumes.listWithIngestData, { limit: options.limit }),
+    fetchKeywordExpansion(options.apiBaseUrl, options.workspace, options.query),
+  ]);
+
+  const searchResult = await client.query(api.resumes.searchWithTagExpansion, {
+    query: options.query,
+    keywordGroups: keywordExpansion.groups,
+    mode: keywordExpansion.mode,
+    sourceMappings: Object.entries(keywordExpansion.sourceMapping).map(([term, expandedFrom]) => ({
+      term,
+      expandedFrom,
+    })),
+    limit: options.limit,
+    jobDescriptionId: options.jobDescriptionId,
+  });
+
+  const queryMatches = (searchResult.results as SearchResult[]).map((entry) => entry.resume);
+  const visibleResumes = queryMatches
+    .filter((resume) =>
+      matchesWorkflowFilters(resume, {
+        sourceKey: options.sourceKey,
+        location: options.location,
+      }),
+    )
+    .map((resume) => toVisibleResumeRow(resume, options.jobDescriptionId))
+    .sort((left, right) => {
+      const leftScore = left.jobRuleScore ?? left.primaryRuleScore ?? -1;
+      const rightScore = right.jobRuleScore ?? right.primaryRuleScore ?? -1;
+      return rightScore - leftScore;
+    })
+    .slice(0, options.top);
+
+  return {
+    query: options.query,
+    location: options.location,
+    sourceKey: options.sourceKey,
+    workspace: options.workspace,
+    totalResumeCount,
+    scannedResumeCount: allResumes.length,
+    datasetBySourceHost: countByKey(allResumes as ResumeDoc[], (resume) => resume.source),
+    datasetBySourceKey: countByKey(allResumes as ResumeDoc[], getResumeSourceKey),
+    keywordExpansion,
+    queryMatchCount: queryMatches.length,
+    queryMatchesBySourceHost: countByKey(queryMatches, (resume) => resume.source),
+    queryMatchesBySourceKey: countByKey(queryMatches, getResumeSourceKey),
+    visibleCount: queryMatches.filter((resume) =>
+      matchesWorkflowFilters(resume, {
+        sourceKey: options.sourceKey,
+        location: options.location,
+      }),
+    ).length,
+    visibleBySourceHost: countByKey(
+      queryMatches.filter((resume) =>
+        matchesWorkflowFilters(resume, {
+          sourceKey: options.sourceKey,
+          location: options.location,
+        }),
+      ),
+      (resume) => resume.source,
+    ),
+    visibleBySourceKey: countByKey(
+      queryMatches.filter((resume) =>
+        matchesWorkflowFilters(resume, {
+          sourceKey: options.sourceKey,
+          location: options.location,
+        }),
+      ),
+      getResumeSourceKey,
+    ),
+    visibleResumes,
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parseCliOptions();
+  const report = await buildWorkflowVerificationReport(options);
+
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  printReport(report);
+}
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const entryFilePath = process.argv[1];
+
+if (entryFilePath && currentFilePath === entryFilePath) {
+  main().catch((error: unknown) => {
+    console.error("verify-workflow-dataset failed:");
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/resume/verify-workflow-dataset.ts
+++ b/scripts/resume/verify-workflow-dataset.ts
@@ -194,6 +194,16 @@ export function countByKey<T>(items: T[], keyResolver: (item: T) => string | und
     .sort((left, right) => right.count - left.count || left.key.localeCompare(right.key));
 }
 
+function filterWorkflowMatches(
+  resumes: ResumeDoc[],
+  filters: {
+    sourceKey?: string;
+    location?: string;
+  },
+): ResumeDoc[] {
+  return resumes.filter((resume) => matchesWorkflowFilters(resume, filters));
+}
+
 async function fetchKeywordExpansion(apiBaseUrl: string, workspace: string, query: string): Promise<KeywordExpansionSummary> {
   const url = new URL("/api/resumes/keyword-expansion", apiBaseUrl);
   url.searchParams.set("q", query);
@@ -305,13 +315,12 @@ export async function buildWorkflowVerificationReport(options: CliOptions): Prom
   });
 
   const queryMatches = (searchResult.results as SearchResult[]).map((entry) => entry.resume);
-  const visibleResumes = queryMatches
-    .filter((resume) =>
-      matchesWorkflowFilters(resume, {
-        sourceKey: options.sourceKey,
-        location: options.location,
-      }),
-    )
+  const workflowFilters = {
+    sourceKey: options.sourceKey,
+    location: options.location,
+  };
+  const visibleMatches = filterWorkflowMatches(queryMatches, workflowFilters);
+  const visibleResumes = visibleMatches
     .map((resume) => toVisibleResumeRow(resume, options.jobDescriptionId))
     .sort((left, right) => {
       const leftScore = left.jobRuleScore ?? left.primaryRuleScore ?? -1;
@@ -333,30 +342,9 @@ export async function buildWorkflowVerificationReport(options: CliOptions): Prom
     queryMatchCount: queryMatches.length,
     queryMatchesBySourceHost: countByKey(queryMatches, (resume) => resume.source),
     queryMatchesBySourceKey: countByKey(queryMatches, getResumeSourceKey),
-    visibleCount: queryMatches.filter((resume) =>
-      matchesWorkflowFilters(resume, {
-        sourceKey: options.sourceKey,
-        location: options.location,
-      }),
-    ).length,
-    visibleBySourceHost: countByKey(
-      queryMatches.filter((resume) =>
-        matchesWorkflowFilters(resume, {
-          sourceKey: options.sourceKey,
-          location: options.location,
-        }),
-      ),
-      (resume) => resume.source,
-    ),
-    visibleBySourceKey: countByKey(
-      queryMatches.filter((resume) =>
-        matchesWorkflowFilters(resume, {
-          sourceKey: options.sourceKey,
-          location: options.location,
-        }),
-      ),
-      getResumeSourceKey,
-    ),
+    visibleCount: visibleMatches.length,
+    visibleBySourceHost: countByKey(visibleMatches, (resume) => resume.source),
+    visibleBySourceKey: countByKey(visibleMatches, getResumeSourceKey),
     visibleResumes,
   };
 }

--- a/scripts/seed-convex.ts
+++ b/scripts/seed-convex.ts
@@ -43,6 +43,10 @@ type SeedResult = {
   skipped: number;
 };
 
+type WorkspaceSeedArgs = {
+  includeDemoResumes?: boolean;
+};
+
 type WorkspaceSeedResult = {
   customJobDescriptions: {
     inserted: number;
@@ -80,7 +84,7 @@ type CliOptions = {
 const seedStatusFunction = makeFunctionReference<"query", Record<string, never>, SeedStatus>("seed:status");
 const seedJobDescriptionsFunction = makeFunctionReference<"mutation", { items: SeedJobDescription[] }, SeedResult>("seed:seedJobDescriptions");
 const seedResumesFunction = makeFunctionReference<"mutation", { resumes: SeedResume[] }, SeedResult>("seed:seedResumes");
-const seedWorkspaceDemoFunction = makeFunctionReference<"mutation", Record<string, never>, WorkspaceSeedResult>("seed:seedWorkspaceDemoData");
+const seedWorkspaceDemoFunction = makeFunctionReference<"mutation", WorkspaceSeedArgs, WorkspaceSeedResult>("seed:seedWorkspaceDemoData");
 
 function printUsage(): void {
   console.log("Usage: seed-convex.ts [--with-resumes] [--force] [--check-only] [--sample <name>]");
@@ -543,7 +547,9 @@ async function main(): Promise<void> {
   const jdResult = await client.mutation(seedJobDescriptionsFunction, { items: jobDescriptions });
   console.log(`Job descriptions: inserted=${jdResult.inserted}, skipped=${jdResult.skipped}`);
 
-  const workspaceSeedResult = await client.mutation(seedWorkspaceDemoFunction, {});
+  const workspaceSeedResult = await client.mutation(seedWorkspaceDemoFunction, {
+    includeDemoResumes: options.withResumes,
+  });
   console.log(
     "Workspace fixtures:"
     + ` customJDs(inserted=${workspaceSeedResult.customJobDescriptions.inserted}, updated=${workspaceSeedResult.customJobDescriptions.updated}),`


### PR DESCRIPTION
## Summary
- prevent default install and deploy flows from seeding demo resumes through inherited env state
- make the deterministic SEEK Malaysia demo resume opt-in so normal workspace demo seeding does not pollute real workflows
- add workflow dataset verification and workspace demo cleanup utilities for resume debugging
- cover the new deploy safety and workflow verification behavior with tests

## Testing
- make check
- bun test scripts/install-deploy-safety.test.ts scripts/repo-workflow-entrypoints.test.ts scripts/resume/clear-workspace-demo-resumes.test.ts scripts/resume/verify-workflow-dataset.test.ts
- go test ./cmd
