### PR TITLE
fix(web): replace form-based export with fetch+blob download

### DIFF
--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -24,6 +24,7 @@ import { rawApiClient } from '@/lib/api-helpers'
 import type { components } from '@/lib/api-types'
 import { getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey } from '@/lib/analysis-utils'
 import { isResumeHomeResetState } from '@/lib/resume-home-navigation'
+import { withWorkspaceHeaders } from '@/lib/workspace-ref'
 import type { SearchHistoryItem } from '@/hooks/useSession'
 import {
   aiFeedbackToActionType,
@@ -240,26 +241,73 @@ function taskMatchesCurrentSearch(
   return false
 }
 
-function submitResumeExportDownload(apiBaseUrl: string, payload: ResumeExportRequestBody): void {
-  const form = document.createElement('form')
-  const input = document.createElement('input')
+function parseDownloadFilename(contentDisposition: string | null): string | undefined {
+  if (!contentDisposition) {
+    return undefined
+  }
 
-  form.method = 'POST'
-  form.action = new URL(`${apiBaseUrl}/api/resumes/export/download`, window.location.origin).toString()
-  form.style.display = 'none'
+  const encodedMatch = contentDisposition.match(/filename\*\s*=\s*UTF-8''([^;]+)/i)
+  if (encodedMatch?.[1]) {
+    const encodedFilename = encodedMatch[1].trim().replace(/^"(.*)"$/, '$1')
+    try {
+      return decodeURIComponent(encodedFilename)
+    } catch {
+      return encodedFilename
+    }
+  }
 
-  input.type = 'hidden'
-  input.name = 'payload'
-  input.value = JSON.stringify(payload)
+  const filenameMatch = contentDisposition.match(/filename\s*=\s*"([^"]+)"|filename\s*=\s*([^;]+)/i)
+  const filename = filenameMatch?.[1] ?? filenameMatch?.[2]
+  return filename?.trim()
+}
 
-  form.appendChild(input)
-  document.body.appendChild(form)
+function triggerBlobDownload(blob: Blob, filename: string): void {
+  const blobUrl = window.URL.createObjectURL(blob)
+  const link = document.createElement('a')
+
+  link.href = blobUrl
+  link.download = filename
+  link.style.display = 'none'
+  document.body.appendChild(link)
 
   try {
-    form.submit()
+    link.click()
   } finally {
-    form.remove()
+    link.remove()
+    window.URL.revokeObjectURL(blobUrl)
   }
+}
+
+async function submitResumeExportDownload(apiBaseUrl: string, payload: ResumeExportRequestBody): Promise<void> {
+  const response = await fetch(
+    new URL(`${apiBaseUrl}/api/resumes/export`, window.location.origin).toString(),
+    {
+      method: 'POST',
+      headers: withWorkspaceHeaders({
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify(payload),
+    }
+  )
+
+  if (!response.ok) {
+    const contentType = response.headers.get('content-type') ?? ''
+    if (contentType.includes('application/json')) {
+      const body = await response.json().catch(() => null) as { error?: unknown } | null
+      const errorMessage = typeof body?.error === 'string' && body.error.trim().length > 0
+        ? body.error
+        : `Export failed (HTTP ${response.status})`
+      throw new Error(errorMessage)
+    }
+
+    const responseText = await response.text().catch(() => '')
+    throw new Error(responseText.trim() || `Export failed (HTTP ${response.status})`)
+  }
+
+  const blob = await response.blob()
+  const filename = parseDownloadFilename(response.headers.get('content-disposition'))
+    ?? `resumes-export.${payload.format === 'xlsx' ? 'xlsx' : 'csv'}`
+  triggerBlobDownload(blob, filename)
 }
 
 function normalizeFilterToken(value: string): string {
@@ -1518,7 +1566,7 @@ export function useResumeListState(loadSearchHistory = false) {
         }
 
         try {
-          submitResumeExportDownload(apiBaseUrl, exportRequest)
+          await submitResumeExportDownload(apiBaseUrl, exportRequest)
           toast.info(t('bulk.exportStarted', { count: exportEntries.length, defaultValue: `Started export for ${exportEntries.length} resumes` }))
           return
         } catch (error) {


### PR DESCRIPTION
## Summary
- Replace synchronous form POST with async fetch+blob approach for resume export
- Parse `Content-Disposition` header for filename (RFC 5987 UTF-8 encoding support)
- Include workspace headers in export request via `withWorkspaceHeaders`
- Proper error handling: JSON and text response body inspection on failure

## Background
The original form-based POST approach (`document.createElement('form')`) cannot include custom headers (workspace isolation headers) and provides no error feedback to the user. The new fetch+blob approach fixes both issues.

## Test plan
- [ ] Export resumes in CSV format — file downloads with correct filename
- [ ] Export resumes in XLSX format — file downloads with correct filename
- [ ] Export with workspace headers applied
- [ ] Export API error returns user-visible toast error message