### PR TITLE
fix(ci): repair web checks

### DIFF
--- a/apps/web/e2e/blacklist.spec.ts
+++ b/apps/web/e2e/blacklist.spec.ts
@@ -15,6 +15,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 async function mockBlocksApi(page: Page, initialItems: BlockItem[]) {
   let items = [...initialItems]
+  let listRequestCount = 0
   const patchPayloads: Array<{ identityKey: string; reason?: string }> = []
   const deletedIdentityKeys: string[] = []
 
@@ -24,6 +25,7 @@ async function mockBlocksApi(page: Page, initialItems: BlockItem[]) {
     const url = new URL(request.url())
 
     if (method === 'GET') {
+      listRequestCount += 1
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -88,6 +90,7 @@ async function mockBlocksApi(page: Page, initialItems: BlockItem[]) {
 
   return {
     getItems: () => items,
+    getListRequestCount: () => listRequestCount,
     patchPayloads,
     deletedIdentityKeys,
   }
@@ -95,7 +98,7 @@ async function mockBlocksApi(page: Page, initialItems: BlockItem[]) {
 
 test.describe('Blacklist page', () => {
   test('inline reason edit sends PATCH and updates row', async ({ page }) => {
-    const { patchPayloads } = await mockBlocksApi(page, [
+    const { patchPayloads, getListRequestCount } = await mockBlocksApi(page, [
       {
         _id: 'block-1',
         identityKey: 'candidate-1',
@@ -107,6 +110,9 @@ test.describe('Blacklist page', () => {
     ])
 
     await page.goto('/dev/settings/blocks')
+    await page.waitForLoadState('networkidle')
+    await expect.poll(() => getListRequestCount()).toBeGreaterThan(0)
+    await expect(page.getByTestId('blacklist-page')).toBeVisible()
     const row = page.locator('[data-testid="blacklist-row"][data-identity-key="candidate-1"]')
     await expect(row).toBeVisible()
 
@@ -124,7 +130,7 @@ test.describe('Blacklist page', () => {
   })
 
   test('bulk unblock sends DELETE per selected row and removes rows', async ({ page }) => {
-    const { deletedIdentityKeys, getItems } = await mockBlocksApi(page, [
+    const { deletedIdentityKeys, getItems, getListRequestCount } = await mockBlocksApi(page, [
       {
         _id: 'block-1',
         identityKey: 'candidate-1',
@@ -144,6 +150,9 @@ test.describe('Blacklist page', () => {
     ])
 
     await page.goto('/dev/settings/blocks')
+    await page.waitForLoadState('networkidle')
+    await expect.poll(() => getListRequestCount()).toBeGreaterThan(0)
+    await expect(page.getByTestId('blacklist-page')).toBeVisible()
     await expect(page.locator('[data-testid="blacklist-row"]')).toHaveCount(2)
 
     await page

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ConvexIngestData, ConvexResumeItem } from '@/hooks/useConvexResumes'
 import type { CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 import { RESUME_HOME_RESET_STATE } from '@/lib/resume-home-navigation'
@@ -7,13 +7,10 @@ import { rawApiClient } from '@/lib/api-helpers'
 import { getCurrentResumeAiPromptVersion } from '@/lib/analysis-utils'
 import { useResumeListState } from './useResumeListState'
 
-let submittedFormAction = ''
-let submittedPayloadValue = ''
-const formSubmitMock = vi.fn(function thisFormSubmit(this: HTMLFormElement) {
-  submittedFormAction = this.action
-  const payloadInput = this.querySelector('input[name="payload"]')
-  submittedPayloadValue = payloadInput instanceof HTMLInputElement ? payloadInput.value : ''
-})
+let capturedExportPayload: unknown = null
+const createObjectUrlMock = vi.fn(() => 'blob:mock')
+const revokeObjectUrlMock = vi.fn()
+const anchorClickMock = vi.fn()
 
 const mockState = vi.hoisted(() => ({
   convexResumes: [] as ConvexResumeItem[],
@@ -180,11 +177,6 @@ vi.mock('@/lib/api-helpers', () => ({
   },
 }))
 
-Object.defineProperty(globalThis.HTMLFormElement.prototype, 'submit', {
-  writable: true,
-  value: formSubmitMock,
-})
-
 vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),
@@ -192,6 +184,21 @@ vi.mock('sonner', () => ({
     info: vi.fn(),
   },
 }))
+
+beforeAll(() => {
+  Object.defineProperty(window.URL, 'createObjectURL', {
+    writable: true,
+    value: createObjectUrlMock,
+  })
+  Object.defineProperty(window.URL, 'revokeObjectURL', {
+    writable: true,
+    value: revokeObjectUrlMock,
+  })
+  Object.defineProperty(globalThis.HTMLAnchorElement.prototype, 'click', {
+    writable: true,
+    value: anchorClickMock,
+  })
+})
 
 function buildResume(params: {
   id: string
@@ -355,8 +362,21 @@ describe('useResumeListState role filter regression', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    submittedFormAction = ''
-    submittedPayloadValue = ''
+    capturedExportPayload = null
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.includes('/api/resumes/export')) {
+        const requestBody = typeof init?.body === 'string' ? init.body : '{}'
+        capturedExportPayload = JSON.parse(requestBody) as unknown
+        return new Response(new Blob(['']), {
+          status: 200,
+          headers: { 'content-disposition': 'attachment; filename="export.csv"' },
+        })
+      }
+
+      return new Response(null, { status: 404 })
+    }))
     window.history.replaceState({}, '', '/')
     mockState.filters = {}
     mockState.cloneConvexResumesOnRead = false
@@ -836,13 +856,13 @@ describe('useResumeListState role filter regression', () => {
       await result.current.handleBulkAction('export', 'csv')
     })
 
-    expect(formSubmitMock).toHaveBeenCalledTimes(1)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/resumes/export'),
+      expect.objectContaining({ method: 'POST' }),
+    )
 
-    const submittedForm = document.querySelector('form') as HTMLFormElement | null
-    expect(submittedForm).toBeNull()
-    expect(submittedFormAction).toContain('/api/resumes/export/download')
-
-    const parsedBody = JSON.parse(submittedPayloadValue) as {
+    const parsedBody = capturedExportPayload as {
       source: string
       entries: Array<{ resumeId: string; userComment?: string; status?: string }>
       format: string
@@ -902,7 +922,7 @@ describe('useResumeListState role filter regression', () => {
       await result.current.handleBulkAction('export', 'csv')
     })
 
-    const parsedBody = JSON.parse(submittedPayloadValue) as {
+    const parsedBody = capturedExportPayload as {
       industryDbV2Stats?: {
         size: number
         min?: number

--- a/apps/web/src/pages/DebugConfig.test.tsx
+++ b/apps/web/src/pages/DebugConfig.test.tsx
@@ -43,10 +43,7 @@ vi.mock('sonner', () => ({
 
 function renderSettingsRoute(initialEntry: string) {
   return render(
-    <MemoryRouter
-      initialEntries={[initialEntry]}
-      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-    >
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route path="/:teamSlug/system/settings" element={<SystemSettingsLayout />}>
           <Route index element={<DebugConfig />} />

--- a/apps/web/src/pages/DebugPage.test.tsx
+++ b/apps/web/src/pages/DebugPage.test.tsx
@@ -59,10 +59,7 @@ function makeResume(
 
 function renderPage() {
   return render(
-    <MemoryRouter
-      initialEntries={['/debug/findings']}
-      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-    >
+    <MemoryRouter initialEntries={['/debug/findings']}>
       <Routes>
         <Route path="/debug/*" element={<DebugPage />} />
       </Routes>


### PR DESCRIPTION
## Summary
- replay the export hook test update onto a fresh branch from current `main`
- harden the blacklist Playwright spec to wait for the mocked list load before row assertions
- remove obsolete `MemoryRouter.future` props from web tests after the React Router 7 dependency bump

## Validation
- `bun run --filter '@trends/web' test -- useResumeListState`
- `bun run --filter '@trends/web' test -- DebugConfig DebugPage`
- `npm --workspace @trends/web run test:e2e:blacklist`
- `make check`