### PR TITLE
fix(web): restore tailwindcss v3

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -56,7 +56,7 @@
     "jsdom": "^28.0.0",
     "openapi-typescript": "^7.6.1",
     "postcss": "^8.4.35",
-    "tailwindcss": "^4.2.1",
+    "tailwindcss": "^3.4.19",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.54.0",


### PR DESCRIPTION
## Summary
- revert the web workspace Tailwind dependency from v4 back to the last working v3 line
- keep the existing PostCSS and global stylesheet setup unchanged so the Playwright web server boots again in `verify`

## Validation
- `npm --workspace @trends/web run test:e2e:blacklist`
- `bun run --filter '@trends/web' test -- useResumeListState DebugConfig DebugPage`
- `make check`