### PR TITLE
fix(ci): align root vitest tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "@vitest/coverage-v8": "^1.6.1",
+    "@vitest/coverage-v8": "^4.1.1",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.0.10",
     "playwright": "^1.58.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
-    "vitest": "^1.6.0",
+    "vitest": "^4.1.1",
     "yaml": "^2.8.2"
   }
 }


### PR DESCRIPTION
## Summary
- update the root Vitest toolchain to v4.1.1
- align the root @vitest/coverage-v8 package with Vitest 4 to fix npm install resolution
- validate the root API Vitest lane and make check

## Testing
- npm run test:api:search-profiles
- make check