### PR TITLE
test(ci): fix API Vitest 4 harnesses

### DIFF
--- a/apps/api/src/routes/manual-resume-import.test.ts
+++ b/apps/api/src/routes/manual-resume-import.test.ts
@@ -136,10 +136,12 @@ async function expectUnreadablePdfUploadFailure(options: {
   const destroy = vi.fn(async () => undefined);
 
   vi.doMock("pdf-parse", () => ({
-    PDFParse: vi.fn().mockImplementation(() => ({
-      getText: vi.fn(async () => ({ text: options.extractedText })),
-      destroy,
-    })),
+    PDFParse: vi.fn(function MockPdfParse() {
+      return {
+        getText: vi.fn(async () => ({ text: options.extractedText })),
+        destroy,
+      };
+    }),
   }));
 
   const formData = new FormData();

--- a/apps/api/src/services/ai-matching.test.ts
+++ b/apps/api/src/services/ai-matching.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AIMatchingService } from "./ai-matching.js";
 
@@ -22,6 +22,14 @@ class CapturingAIMatchingService extends AIMatchingService {
 }
 
 describe("AIMatchingService", () => {
+    beforeEach(() => {
+        vi.stubEnv("AI_OUTPUT_LOCALE", "");
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
     it("hydrates verified companies from companyHits and caps non-sales profiles", async () => {
         const service = new CapturingAIMatchingService();
         const result = await service.matchResume({

--- a/apps/api/src/services/database.test.ts
+++ b/apps/api/src/services/database.test.ts
@@ -4,12 +4,14 @@ const pragmaMock = vi.fn();
 const execMock = vi.fn();
 const prepareMock = vi.fn();
 const closeMock = vi.fn();
-const constructorMock = vi.fn(() => ({
+const constructorMock = vi.fn(function MockDatabase() {
+  return {
   pragma: pragmaMock,
   exec: execMock,
   prepare: prepareMock,
   close: closeMock,
-}));
+  };
+});
 
 vi.mock("better-sqlite3", () => ({
   default: constructorMock,


### PR DESCRIPTION
## Summary
- update constructor-mocked API tests to use function-based Vitest mock implementations
- make AI matching prompt tests deterministic by stubbing AI_OUTPUT_LOCALE during the suite
- restore green coverage for the API test files that regressed after the root Vitest 4 upgrade

## Validation
- npm exec vitest run apps/api/src/services/ai-matching.test.ts apps/api/src/services/database.test.ts apps/api/src/routes/manual-resume-import.test.ts
- make check
- make test-coverage