### PR TITLE
Improve resume list UI performance

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-virtual": "^3.13.23",
     "@trends/shared": "*",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,28 +1,62 @@
-import { type ReactNode } from 'react'
+import { lazy, Suspense, type ReactNode } from 'react'
 import { BrowserRouter, Navigate, Outlet, Route, Routes, useLocation } from 'react-router-dom'
 import { Toaster } from 'sonner'
 import { Header } from '@/components/Header'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { ResumesPage } from '@/pages/ResumesPage'
-import { DebugPage } from '@/pages/DebugPage'
-import DebugJDs from '@/pages/DebugJDs'
-import DebugAI from '@/pages/DebugAI'
-import DebugConfig from '@/pages/DebugConfig'
-import DebugIngest from '@/pages/DebugIngest'
-import DebugAiTaggingResults from '@/pages/DebugAiTaggingResults'
-import { BlacklistPage } from '@/pages/BlacklistPage'
-import { SearchProfilesPage } from '@/pages/SearchProfilesPage'
-import SearchAnalyticsPage from '@/pages/SearchAnalyticsPage'
 import SettingsLayout from '@/layouts/SettingsLayout'
 import SystemLayout from '@/layouts/SystemLayout'
 import SystemSettingsLayout from '@/layouts/SystemSettingsLayout'
 import { WorkspaceProvider, useWorkspace } from '@/contexts/WorkspaceContext'
 import { ResumeFieldUsagePolicyProvider } from '@/contexts/ResumeFieldUsagePolicyContext'
-import { SystemSettingsConfigSourcesPage } from '@/pages/system-settings/SystemSettingsConfigSourcesPage'
-import { SystemSettingsKeywordsPage } from '@/pages/system-settings/SystemSettingsKeywordsPage'
-import { SystemSettingsLocationsPage } from '@/pages/system-settings/SystemSettingsLocationsPage'
-import { SystemSettingsOperationsPage } from '@/pages/system-settings/SystemSettingsOperationsPage'
-import { SystemSettingsRuntimePage } from '@/pages/system-settings/SystemSettingsRuntimePage'
+
+const LazyDebugPage = lazy(async () => {
+  const module = await import('@/pages/DebugPage')
+  return { default: module.DebugPage }
+})
+
+const LazyDebugJDs = lazy(() => import('@/pages/DebugJDs'))
+const LazyDebugAI = lazy(() => import('@/pages/DebugAI'))
+const LazyDebugConfig = lazy(() => import('@/pages/DebugConfig'))
+const LazyDebugIngest = lazy(() => import('@/pages/DebugIngest'))
+const LazyDebugAiTaggingResults = lazy(() => import('@/pages/DebugAiTaggingResults'))
+
+const LazyBlacklistPage = lazy(async () => {
+  const module = await import('@/pages/BlacklistPage')
+  return { default: module.BlacklistPage }
+})
+
+const LazySearchProfilesPage = lazy(async () => {
+  const module = await import('@/pages/SearchProfilesPage')
+  return { default: module.SearchProfilesPage }
+})
+
+const LazySearchAnalyticsPage = lazy(() => import('@/pages/SearchAnalyticsPage'))
+
+const LazySystemSettingsConfigSourcesPage = lazy(async () => {
+  const module = await import('@/pages/system-settings/SystemSettingsConfigSourcesPage')
+  return { default: module.SystemSettingsConfigSourcesPage }
+})
+
+const LazySystemSettingsKeywordsPage = lazy(async () => {
+  const module = await import('@/pages/system-settings/SystemSettingsKeywordsPage')
+  return { default: module.SystemSettingsKeywordsPage }
+})
+
+const LazySystemSettingsLocationsPage = lazy(async () => {
+  const module = await import('@/pages/system-settings/SystemSettingsLocationsPage')
+  return { default: module.SystemSettingsLocationsPage }
+})
+
+const LazySystemSettingsOperationsPage = lazy(async () => {
+  const module = await import('@/pages/system-settings/SystemSettingsOperationsPage')
+  return { default: module.SystemSettingsOperationsPage }
+})
+
+const LazySystemSettingsRuntimePage = lazy(async () => {
+  const module = await import('@/pages/system-settings/SystemSettingsRuntimePage')
+  return { default: module.SystemSettingsRuntimePage }
+})
 
 function MainShell() {
   return (
@@ -34,6 +68,14 @@ function MainShell() {
       </main>
       <footer className="border-t py-6 mt-8" />
     </div>
+  )
+}
+
+function RouteSuspense({ children }: { children: ReactNode }) {
+  return (
+    <Suspense fallback={<div className="py-6 text-sm text-muted-foreground">Loading...</div>}>
+      {children}
+    </Suspense>
   )
 }
 
@@ -63,7 +105,11 @@ function AdminGate({ children }: { children: ReactNode }) {
 
 function WorkspaceDebugPage() {
   const { slug } = useWorkspace()
-  return <DebugPage basePath={`/${slug}/system/data`} />
+  return (
+    <RouteSuspense>
+      <LazyDebugPage basePath={`/${slug}/system/data`} />
+    </RouteSuspense>
+  )
 }
 
 function ProfilesLegacyRedirect() {
@@ -102,7 +148,14 @@ function App() {
 
             <Route path="settings" element={<SettingsLayout />}>
               <Route index element={<Navigate to="blocks" replace />} />
-              <Route path="blocks" element={<BlacklistPage />} />
+              <Route
+                path="blocks"
+                element={(
+                  <RouteSuspense>
+                    <LazyBlacklistPage />
+                  </RouteSuspense>
+                )}
+              />
             </Route>
 
             <Route
@@ -115,19 +168,103 @@ function App() {
             >
               <Route index element={<Navigate to="settings" replace />} />
               <Route path="settings" element={<SystemSettingsLayout />}>
-                <Route index element={<DebugConfig />} />
-                <Route path="operations" element={<SystemSettingsOperationsPage />} />
-                <Route path="runtime" element={<SystemSettingsRuntimePage />} />
-                <Route path="config-sources" element={<SystemSettingsConfigSourcesPage />} />
-                <Route path="keywords" element={<SystemSettingsKeywordsPage />} />
-                <Route path="locations" element={<SystemSettingsLocationsPage />} />
+                <Route
+                  index
+                  element={(
+                    <RouteSuspense>
+                      <LazyDebugConfig />
+                    </RouteSuspense>
+                  )}
+                />
+                <Route
+                  path="operations"
+                  element={(
+                    <RouteSuspense>
+                      <LazySystemSettingsOperationsPage />
+                    </RouteSuspense>
+                  )}
+                />
+                <Route
+                  path="runtime"
+                  element={(
+                    <RouteSuspense>
+                      <LazySystemSettingsRuntimePage />
+                    </RouteSuspense>
+                  )}
+                />
+                <Route
+                  path="config-sources"
+                  element={(
+                    <RouteSuspense>
+                      <LazySystemSettingsConfigSourcesPage />
+                    </RouteSuspense>
+                  )}
+                />
+                <Route
+                  path="keywords"
+                  element={(
+                    <RouteSuspense>
+                      <LazySystemSettingsKeywordsPage />
+                    </RouteSuspense>
+                  )}
+                />
+                <Route
+                  path="locations"
+                  element={(
+                    <RouteSuspense>
+                      <LazySystemSettingsLocationsPage />
+                    </RouteSuspense>
+                  )}
+                />
               </Route>
-              <Route path="jds" element={<DebugJDs />} />
-              <Route path="profiles" element={<SearchProfilesPage />} />
-              <Route path="ai-debugger" element={<DebugAI />} />
-              <Route path="ai-tagging" element={<DebugAiTaggingResults />} />
-              <Route path="ingest" element={<DebugIngest />} />
-              <Route path="search-analytics" element={<SearchAnalyticsPage />} />
+              <Route
+                path="jds"
+                element={(
+                  <RouteSuspense>
+                    <LazyDebugJDs />
+                  </RouteSuspense>
+                )}
+              />
+              <Route
+                path="profiles"
+                element={(
+                  <RouteSuspense>
+                    <LazySearchProfilesPage />
+                  </RouteSuspense>
+                )}
+              />
+              <Route
+                path="ai-debugger"
+                element={(
+                  <RouteSuspense>
+                    <LazyDebugAI />
+                  </RouteSuspense>
+                )}
+              />
+              <Route
+                path="ai-tagging"
+                element={(
+                  <RouteSuspense>
+                    <LazyDebugAiTaggingResults />
+                  </RouteSuspense>
+                )}
+              />
+              <Route
+                path="ingest"
+                element={(
+                  <RouteSuspense>
+                    <LazyDebugIngest />
+                  </RouteSuspense>
+                )}
+              />
+              <Route
+                path="search-analytics"
+                element={(
+                  <RouteSuspense>
+                    <LazySearchAnalyticsPage />
+                  </RouteSuspense>
+                )}
+              />
               <Route path="data/*" element={<WorkspaceDebugPage />} />
             </Route>
 

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -1,11 +1,11 @@
-import { useMemo, useState } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
+import { useWindowVirtualizer } from '@tanstack/react-virtual'
 import { useTranslation } from 'react-i18next'
 import { RefreshCw, FileText, AlertTriangle, History, Upload } from 'lucide-react'
 import { EmptyState } from '@/components/EmptyState'
 import type { ResumeItem } from '@/hooks/useResumes'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 import { ResumeCard, ResumeCardSkeleton } from '@/components/ResumeCard'
-import { ResumeDetail } from '@/components/ResumeDetail'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { FilterPanel } from '@/components/FilterPanel'
@@ -14,13 +14,30 @@ import { BulkActionBar } from '@/components/BulkActionBar'
 import { AnalysisTaskMonitor } from '@/components/AnalysisTaskMonitor'
 import { CollectResumesButton } from '@/components/CollectResumesButton'
 import { ShareLinkButton } from '@/components/ShareLinkButton'
-import { SearchHistoryDialog } from '@/components/SearchHistoryDialog'
-import { ManualResumeImportDialog } from '@/components/ManualResumeImportDialog'
 import { useResumeListState } from '@/hooks/useResumeListState'
 import { useSyncNotifications } from '@/hooks/useSyncNotifications'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { buildResumeKey, hasIngestData } from '@/lib/resume-scoring'
 import { useBrandDisplayMap } from '@/hooks/useBrandDisplayMap'
+
+const loadResumeDetail = () => import('@/components/ResumeDetail')
+const loadSearchHistoryDialog = () => import('@/components/SearchHistoryDialog')
+const loadManualResumeImportDialog = () => import('@/components/ManualResumeImportDialog')
+
+const ResumeDetail = lazy(async () => {
+  const module = await loadResumeDetail()
+  return { default: module.ResumeDetail }
+})
+
+const SearchHistoryDialog = lazy(async () => {
+  const module = await loadSearchHistoryDialog()
+  return { default: module.SearchHistoryDialog }
+})
+
+const ManualResumeImportDialog = lazy(async () => {
+  const module = await loadManualResumeImportDialog()
+  return { default: module.ManualResumeImportDialog }
+})
 
 export function ResumeList() {
   const { t } = useTranslation()
@@ -47,11 +64,15 @@ export function ResumeList() {
     blockedCount,
     bulkExportFormat,
     displayedResumes,
+    loadedConvexResumeCount,
+    canLoadMoreResumes,
+    convexLoadingMore,
     searchHistory,
     searchHistoryLoading,
     setBulkExportFormat,
     handleAnalyzeAll,
     handleRefresh,
+    handleLoadMoreResumes,
     handleQuickStartApply,
     handleQuickConstraintApply,
     handleCollectionSourceChange,
@@ -81,6 +102,9 @@ export function ResumeList() {
   const [detailResume, setDetailResume] = useState<ResumeItem | ConvexResumeItem | null>(null)
   const [historyOpen, setHistoryOpen] = useState(false)
   const [manualImportOpen, setManualImportOpen] = useState(false)
+  const listRef = useRef<HTMLDivElement | null>(null)
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+  const [listScrollMargin, setListScrollMargin] = useState(0)
 
   const detailKey = useMemo(() => {
     if (!detailResume) return undefined
@@ -91,6 +115,106 @@ export function ResumeList() {
     if (!detailKey) return undefined
     return displayedResumes.find((entry) => entry.key === detailKey)?.match
   }, [detailKey, displayedResumes])
+  const shouldVirtualize = displayedResumes.length > 40
+  const rowVirtualizer = useWindowVirtualizer({
+    count: displayedResumes.length,
+    estimateSize: () => 360,
+    overscan: 6,
+    scrollMargin: listScrollMargin,
+  })
+
+  useEffect(() => {
+    const updateScrollMargin = () => {
+      setListScrollMargin(listRef.current?.offsetTop ?? 0)
+    }
+
+    updateScrollMargin()
+    window.addEventListener('resize', updateScrollMargin)
+    return () => window.removeEventListener('resize', updateScrollMargin)
+  }, [displayedResumes.length, shouldVirtualize])
+
+  useEffect(() => {
+    if (!canLoadMoreResumes || convexLoadingMore) {
+      return
+    }
+
+    const target = loadMoreRef.current
+    if (!target) {
+      return
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) {
+        return
+      }
+
+      handleLoadMoreResumes()
+    }, {
+      rootMargin: '600px 0px',
+    })
+
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [canLoadMoreResumes, convexLoadingMore, displayedResumes.length, handleLoadMoreResumes])
+
+  useEffect(() => {
+    if (activeLoading || displayedResumes.length === 0) {
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      void loadResumeDetail()
+    }, 1200)
+
+    return () => window.clearTimeout(timer)
+  }, [activeLoading, displayedResumes.length])
+
+  const renderResumeCard = (entry: (typeof displayedResumes)[number]) => {
+    const ingestData = hasIngestData(entry.resume) ? entry.resume.ingestData : undefined
+
+    return (
+      <ResumeCard
+        key={entry.key}
+        resume={entry.resume}
+        matchResult={entry.match}
+        ruleScore={entry.ruleScore}
+        industryTags={ingestData?.industryTags}
+        companyHits={ingestData?.companyHits}
+        brandHits={ingestData?.brandHits}
+        roleSignals={ingestData?.roleSignals}
+        brandDisplayResolve={brandDisplayResolve}
+        roleTypes={ingestData?.roleSignals?.map((signal) => signal.type) ?? []}
+        experienceLevel={ingestData?.experienceLevel}
+        onTagClick={handleToggleTag}
+        onCompanyClick={handleToggleCompany}
+        onExperienceLevelClick={handleToggleExperienceLevel}
+        activeTagFilters={activeTagFilters}
+        activeCompanyFilters={activeCompanyFilters}
+        activeExperienceLevelFilter={selectedExperienceLevel}
+        showAiScore={entry.match?.scoreSource === 'ai'}
+        actionType={entry.action}
+        onAction={(action) => handleCardAction(entry.key, action)}
+        blocked={entry.blocked}
+        candidateStatus={entry.status}
+        candidateStatusMeta={entry.statusMeta ? {
+          notes: entry.statusMeta.notes,
+          updatedAt: entry.statusMeta.updatedAt,
+        } : undefined}
+        onToggleBlock={(reason) => handleToggleBlock(entry.identityKey, entry.blocked, reason)}
+        onCandidateStatusChange={(status, notes) => handleCandidateStatusChange(entry.identityKey, status, notes)}
+        onViewDetails={() => {
+          void loadResumeDetail()
+          setDetailResume(entry.resume)
+          trackReviewedResume(entry.key)
+        }}
+        selected={selectedIds.has(entry.key)}
+        onSelect={() => handleToggleSelect(entry.key)}
+        isReviewed={reviewedIdsSet.has(entry.key)}
+        aiScoreFeedback={getAiFeedback(entry.key, 'ai_score')}
+        onAiFeedback={(target, sentiment) => handleAiFeedback(entry.key, target, sentiment)}
+      />
+    )
+  }
 
   return (
     <div className="flex flex-col gap-4">
@@ -116,7 +240,14 @@ export function ResumeList() {
               variant="outline"
               size="sm"
               className="gap-2"
+              onMouseEnter={() => {
+                void loadSearchHistoryDialog()
+              }}
+              onFocus={() => {
+                void loadSearchHistoryDialog()
+              }}
               onClick={() => {
+                void loadSearchHistoryDialog()
                 setHistoryRequested(true)
                 setHistoryOpen(true)
               }}
@@ -150,7 +281,16 @@ export function ResumeList() {
               variant="outline"
               size="sm"
               className="gap-2"
-              onClick={() => setManualImportOpen(true)}
+              onMouseEnter={() => {
+                void loadManualResumeImportDialog()
+              }}
+              onFocus={() => {
+                void loadManualResumeImportDialog()
+              }}
+              onClick={() => {
+                void loadManualResumeImportDialog()
+                setManualImportOpen(true)
+              }}
             >
               <Upload className="h-4 w-4" />
               {t('manualResumeImport.title', 'Import resumes')}
@@ -238,88 +378,112 @@ export function ResumeList() {
             description={t('resumes.noResumesDesc', 'Try adjusting your filters or search keywords.')}
           />
         ) : (
-          displayedResumes.map((entry) => {
-            const ingestData = hasIngestData(entry.resume) ? entry.resume.ingestData : undefined
+          <>
+            {shouldVirtualize ? (
+              <div ref={listRef}>
+                <div
+                  className="relative w-full"
+                  style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+                >
+                  {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                    const entry = displayedResumes[virtualRow.index]
+                    if (!entry) {
+                      return null
+                    }
 
-            return (
-              <ResumeCard
-                key={entry.key}
-                resume={entry.resume}
-                matchResult={entry.match}
-                ruleScore={entry.ruleScore}
-                industryTags={ingestData?.industryTags}
-                companyHits={ingestData?.companyHits}
-                brandHits={ingestData?.brandHits}
-                roleSignals={ingestData?.roleSignals}
-                brandDisplayResolve={brandDisplayResolve}
-                roleTypes={ingestData?.roleSignals?.map((signal) => signal.type) ?? []}
-                experienceLevel={ingestData?.experienceLevel}
-                onTagClick={handleToggleTag}
-                onCompanyClick={handleToggleCompany}
-                onExperienceLevelClick={handleToggleExperienceLevel}
-                activeTagFilters={activeTagFilters}
-                activeCompanyFilters={activeCompanyFilters}
-                activeExperienceLevelFilter={selectedExperienceLevel}
-                showAiScore={entry.match?.scoreSource === 'ai'}
-                actionType={entry.action}
-                onAction={(action) => handleCardAction(entry.key, action)}
-                blocked={entry.blocked}
-                candidateStatus={entry.status}
-                candidateStatusMeta={entry.statusMeta ? {
-                  notes: entry.statusMeta.notes,
-                  updatedAt: entry.statusMeta.updatedAt,
-                } : undefined}
-                onToggleBlock={(reason) => handleToggleBlock(entry.identityKey, entry.blocked, reason)}
-                onCandidateStatusChange={(status, notes) => handleCandidateStatusChange(entry.identityKey, status, notes)}
-                onViewDetails={() => {
-                  setDetailResume(entry.resume)
-                  trackReviewedResume(entry.key)
-                }}
-                selected={selectedIds.has(entry.key)}
-                onSelect={() => handleToggleSelect(entry.key)}
-                isReviewed={reviewedIdsSet.has(entry.key)}
-                aiScoreFeedback={getAiFeedback(entry.key, 'ai_score')}
-                onAiFeedback={(target, sentiment) => handleAiFeedback(entry.key, target, sentiment)}
-              />
-            )
-          })
+                    return (
+                      <div
+                        key={entry.key}
+                        data-index={virtualRow.index}
+                        ref={rowVirtualizer.measureElement}
+                        className="absolute left-0 top-0 w-full pb-4"
+                        style={{ transform: `translateY(${virtualRow.start - listScrollMargin}px)` }}
+                      >
+                        {renderResumeCard(entry)}
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            ) : (
+              <div ref={listRef} className="grid gap-4">
+                {displayedResumes.map((entry) => renderResumeCard(entry))}
+              </div>
+            )}
+
+            {(canLoadMoreResumes || convexLoadingMore) && (
+              <div ref={loadMoreRef} className="flex flex-col items-center gap-2 py-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  onClick={handleLoadMoreResumes}
+                  disabled={convexLoadingMore}
+                >
+                  <RefreshCw className={cn('h-4 w-4', convexLoadingMore && 'animate-spin')} />
+                  {convexLoadingMore
+                    ? t('resumes.loadingMore', 'Loading more...')
+                    : t('debugIngest.loadMore', 'Load More')}
+                </Button>
+                <p className="text-xs text-muted-foreground">
+                  {t('resumes.loadedCount', {
+                    defaultValue: 'Loaded {{loaded}} resumes so far',
+                    loaded: loadedConvexResumeCount,
+                  })}
+                </p>
+              </div>
+            )}
+          </>
         )}
       </div>
 
-      <ResumeDetail
-        resume={detailResume}
-        matchResult={detailMatch}
-        open={Boolean(detailResume)}
-        onOpenChange={(open) => {
-          if (!open) {
-            setDetailResume(null)
-          }
-        }}
-        aiScoreFeedback={detailKey ? getAiFeedback(detailKey, 'ai_score') : undefined}
-        aiSummaryFeedback={detailKey ? getAiFeedback(detailKey, 'ai_summary') : undefined}
-        onAiFeedback={detailKey ? (target, sentiment) => handleAiFeedback(detailKey, target, sentiment) : undefined}
-      />
+      {detailResume ? (
+        <Suspense fallback={null}>
+          <ResumeDetail
+            resume={detailResume}
+            matchResult={detailMatch}
+            open={Boolean(detailResume)}
+            onOpenChange={(open) => {
+              if (!open) {
+                setDetailResume(null)
+              }
+            }}
+            aiScoreFeedback={detailKey ? getAiFeedback(detailKey, 'ai_score') : undefined}
+            aiSummaryFeedback={detailKey ? getAiFeedback(detailKey, 'ai_summary') : undefined}
+            onAiFeedback={detailKey ? (target, sentiment) => handleAiFeedback(detailKey, target, sentiment) : undefined}
+          />
+        </Suspense>
+      ) : null}
 
-      <SearchHistoryDialog
-        open={historyOpen}
-        onOpenChange={(open) => {
-          if (open) {
-            setHistoryRequested(true)
-          }
-          setHistoryOpen(open)
-        }}
-        items={searchHistory}
-        loading={searchHistoryLoading}
-        onApply={handleApplySearchHistory}
-      />
+      {historyOpen ? (
+        <Suspense fallback={null}>
+          <SearchHistoryDialog
+            open={historyOpen}
+            onOpenChange={(open) => {
+              if (open) {
+                setHistoryRequested(true)
+              }
+              setHistoryOpen(open)
+            }}
+            items={searchHistory}
+            loading={searchHistoryLoading}
+            onApply={handleApplySearchHistory}
+          />
+        </Suspense>
+      ) : null}
 
-      <ManualResumeImportDialog
-        open={manualImportOpen}
-        onOpenChange={setManualImportOpen}
-        location={sessionLocation}
-        keywords={sessionKeywords}
-        onImported={handleRefresh}
-      />
+      {manualImportOpen ? (
+        <Suspense fallback={null}>
+          <ManualResumeImportDialog
+            open={manualImportOpen}
+            onOpenChange={setManualImportOpen}
+            location={sessionLocation}
+            keywords={sessionKeywords}
+            onImported={handleRefresh}
+          />
+        </Suspense>
+      ) : null}
     </div>
   )
 }

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -6,6 +6,10 @@ import type { Doc } from '../../../../packages/convex/convex/_generated/dataMode
 import { rawApiClient } from '@/lib/api-helpers'
 import type { ResumeItem } from './useResumes'
 
+export const DEFAULT_CONVEX_RESUME_LIMIT = 200
+export const CONVEX_RESUME_PAGE_SIZE = 200
+export const MAX_CONVEX_RESUME_LIMIT = 2000
+
 export type ConvexResumeAnalysis = {
   score: number
   summary: string
@@ -654,9 +658,10 @@ function mapResumeDoc(doc: Doc<'resumes'>): ConvexResumeItem {
   }
 }
 
-export function useConvexResumes(limit: number = 200, query?: string, jobDescriptionId?: string) {
+export function useConvexResumes(limit: number = DEFAULT_CONVEX_RESUME_LIMIT, query?: string, jobDescriptionId?: string) {
   const normalizedJobDescriptionId = jobDescriptionId?.trim() || undefined
   const normalizedQuery = query?.trim() || undefined
+  const scopeKey = `${normalizedJobDescriptionId ?? ''}::${normalizedQuery ?? ''}`
   const mockPayload = useMemo(() => readMockConvexResumePayload(), [])
   const mockKeywordExpansion = useMemo(
     () => normalizedQuery ? buildFallbackKeywordExpansion(normalizedQuery) : null,
@@ -771,23 +776,89 @@ export function useConvexResumes(limit: number = 200, query?: string, jobDescrip
         ? ((mockKeywordExpansion?.mode === 'OR'
             ? filterMockSearchResults(mockPayload.search?.results ?? [], mockKeywordExpansion)
             : applyMockExpansionProvenance(mockPayload.search?.results ?? [], mockKeywordExpansion ?? buildFallbackKeywordExpansion(normalizedQuery)))
+          .slice(0, limit)
           .map((entry) => ({
             ...mapResumeDoc(entry.resume),
             _provenance: entry.provenance,
           })))
-        : (mockPayload.list ?? []).map(mapResumeDoc)
+        : (mockPayload.list ?? []).slice(0, limit).map(mapResumeDoc)
       : normalizedQuery
         ? (searchResults?.results ?? []).map((entry) => ({
             ...mapResumeDoc(entry.resume),
             _provenance: entry.provenance,
           }))
         : (listResults ?? []).map(mapResumeDoc)
-  ), [listResults, mockKeywordExpansion, mockPayload, normalizedQuery, searchResults])
+  ), [limit, listResults, mockKeywordExpansion, mockPayload, normalizedQuery, searchResults])
+
+  const isLoading = mockPayload
+    ? false
+    : normalizedQuery
+      ? (expansionLoading || searchResults === undefined)
+      : listResults === undefined
+
+  const hasMore = useMemo(() => {
+    if (mockPayload) {
+      return normalizedQuery
+        ? (mockPayload.search?.results?.length ?? 0) > limit
+        : (mockPayload.list?.length ?? 0) > limit
+    }
+
+    return normalizedQuery
+      ? (searchResults?.results?.length ?? 0) >= limit
+      : (listResults?.length ?? 0) >= limit
+  }, [limit, listResults, mockPayload, normalizedQuery, searchResults])
+
+  const resolvedExpansion = mockPayload
+    ? (mockPayload.search?.expansion ?? mockKeywordExpansion)
+    : searchResults?.expansion
+
+  const [cachedState, setCachedState] = useState<{
+    scopeKey: string
+    resumes: ConvexResumeItem[]
+    hasMore: boolean
+    expansion: unknown
+  }>({
+    scopeKey,
+    resumes: [],
+    hasMore: false,
+    expansion: undefined,
+  })
+
+  useEffect(() => {
+    setCachedState((current) => (
+      current.scopeKey === scopeKey
+        ? current
+        : {
+            scopeKey,
+            resumes: [],
+            hasMore: false,
+            expansion: undefined,
+          }
+    ))
+  }, [scopeKey])
+
+  useEffect(() => {
+    if (isLoading) {
+      return
+    }
+
+    setCachedState({
+      scopeKey,
+      resumes: mappedResumes,
+      hasMore,
+      expansion: resolvedExpansion,
+    })
+  }, [hasMore, isLoading, mappedResumes, resolvedExpansion, scopeKey])
+
+  const hasCachedResumes = cachedState.scopeKey === scopeKey && cachedState.resumes.length > 0
+  const loadingMore = isLoading && hasCachedResumes
 
   return {
-    resumes: mappedResumes,
-    loading: mockPayload ? false : normalizedQuery ? (expansionLoading || searchResults === undefined) : listResults === undefined,
+    resumes: loadingMore ? cachedState.resumes : mappedResumes,
+    loading: isLoading && !hasCachedResumes,
+    loadingMore,
+    hasMore: loadingMore ? cachedState.hasMore : hasMore,
     jobDescriptionId: normalizedJobDescriptionId,
-    expansion: mockPayload ? (mockPayload.search?.expansion ?? mockKeywordExpansion) : searchResults?.expansion,
+    expansion: loadingMore ? cachedState.expansion : resolvedExpansion,
   }
 }

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -14,6 +14,13 @@ const anchorClickMock = vi.fn()
 
 const mockState = vi.hoisted(() => ({
   convexResumes: [] as ConvexResumeItem[],
+  convexHasMore: false,
+  convexLoadingMore: false,
+  useConvexResumesArgs: [] as Array<{
+    limit?: number
+    query?: string
+    jobDescriptionId?: string
+  }>,
   cloneConvexResumesOnRead: false,
   filters: {} as Record<string, unknown>,
   sessionLocation: '广东',
@@ -138,12 +145,20 @@ vi.mock('@/hooks/useResumes', () => ({
 }))
 
 vi.mock('@/hooks/useConvexResumes', () => ({
-  useConvexResumes: () => ({
-    resumes: mockState.cloneConvexResumesOnRead
-      ? [...mockState.convexResumes]
-      : mockState.convexResumes,
-    loading: false,
-  }),
+  DEFAULT_CONVEX_RESUME_LIMIT: 200,
+  CONVEX_RESUME_PAGE_SIZE: 200,
+  MAX_CONVEX_RESUME_LIMIT: 2000,
+  useConvexResumes: (limit?: number, query?: string, jobDescriptionId?: string) => {
+    mockState.useConvexResumesArgs.push({ limit, query, jobDescriptionId })
+    return {
+      resumes: mockState.cloneConvexResumesOnRead
+        ? [...mockState.convexResumes]
+        : mockState.convexResumes,
+      loading: false,
+      loadingMore: mockState.convexLoadingMore,
+      hasMore: mockState.convexHasMore,
+    }
+  },
 }))
 
 vi.mock('@/hooks/useCandidateActions', () => ({
@@ -296,6 +311,10 @@ function getDisplayedResumeNames(): string[] {
   return result.current.displayedResumes.map((entry) => entry.resume.name)
 }
 
+function getLastConvexArgs() {
+  return mockState.useConvexResumesArgs[mockState.useConvexResumesArgs.length - 1]
+}
+
 describe('useResumeListState role filter regression', () => {
   it('preserves richer imported resume fields on convex resumes', () => {
     mockState.convexResumes = [
@@ -314,6 +333,75 @@ describe('useResumeListState role filter regression', () => {
     expect(resume?.resumeSnippet).toEqual({ text: 'Experienced sales engineer covering machine tools.' })
     expect(resume?.currentIndustry).toEqual({ name: 'Industrial machinery' })
     expect(resume?.noticePeriodDays).toBe(30)
+  })
+
+  it('requests larger Convex windows incrementally and resets when the query changes', async () => {
+    mockState.convexHasMore = true
+
+    const { result, rerender } = renderHook(() => useResumeListState())
+
+    expect(getLastConvexArgs()?.limit).toBe(200)
+
+    act(() => {
+      result.current.handleLoadMoreResumes()
+    })
+
+    expect(getLastConvexArgs()?.limit).toBe(400)
+
+    mockState.sessionKeywords = ['CNC']
+    rerender()
+
+    await waitFor(() => {
+      expect(getLastConvexArgs()).toMatchObject({
+        limit: 200,
+        query: 'CNC',
+      })
+    })
+  })
+
+  it('only requests query-specific rule scores for newly loaded resume ids', async () => {
+    mockState.sessionKeywords = ['销售']
+    mockState.convexResumes = [
+      buildResume({ id: 'resume-1', name: 'First Candidate', roleSignals: [] }),
+      buildResume({ id: 'resume-2', name: 'Second Candidate', roleSignals: [] }),
+    ]
+    mockState.matchApiResponse = {
+      success: true,
+      results: [
+        { resumeId: 'resume-1', score: 88 },
+        { resumeId: 'resume-2', score: 77 },
+      ],
+    }
+
+    const { rerender } = renderHook(() => useResumeListState())
+
+    await waitFor(() => {
+      expect(rawApiClient.POST).toHaveBeenCalledWith('/api/resumes/match', expect.objectContaining({
+        body: expect.objectContaining({
+          resumeIds: ['resume-1', 'resume-2'],
+        }),
+      }))
+    })
+
+    mockState.convexResumes = [
+      ...mockState.convexResumes,
+      buildResume({ id: 'resume-3', name: 'Third Candidate', roleSignals: [] }),
+    ]
+    mockState.matchApiResponse = {
+      success: true,
+      results: [
+        { resumeId: 'resume-3', score: 66 },
+      ],
+    }
+    rerender()
+
+    await waitFor(() => {
+      expect(rawApiClient.POST).toHaveBeenLastCalledWith('/api/resumes/match', expect.objectContaining({
+        body: expect.objectContaining({
+          resumeIds: ['resume-3'],
+        }),
+      }))
+    })
   })
 
   it('filters the main review lane to the active collection source', () => {
@@ -380,6 +468,9 @@ describe('useResumeListState role filter regression', () => {
     window.history.replaceState({}, '', '/')
     mockState.filters = {}
     mockState.cloneConvexResumesOnRead = false
+    mockState.convexHasMore = false
+    mockState.convexLoadingMore = false
+    mockState.useConvexResumesArgs = []
     mockState.sessionLocation = '广东'
     mockState.sessionKeywords = []
     mockState.sessionJobDescriptionId = undefined

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -8,7 +8,13 @@ import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
 import { isSalesRequiredContext } from '@trends/shared'
 import { useResumes, type ResumeItem } from '@/hooks/useResumes'
-import { useConvexResumes, type ConvexResumeItem } from '@/hooks/useConvexResumes'
+import {
+  CONVEX_RESUME_PAGE_SIZE,
+  DEFAULT_CONVEX_RESUME_LIMIT,
+  MAX_CONVEX_RESUME_LIMIT,
+  useConvexResumes,
+  type ConvexResumeItem,
+} from '@/hooks/useConvexResumes'
 import { useSession } from '@/hooks/useSession'
 import { useCandidateActions } from '@/hooks/useCandidateActions'
 import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
@@ -91,17 +97,6 @@ function normalizeKeywordFingerprint(keywords: readonly string[] | undefined): s
 
 function areKeywordListsEqual(left: readonly string[] | undefined, right: readonly string[] | undefined): boolean {
   return normalizeKeywordFingerprint(left) === normalizeKeywordFingerprint(right)
-}
-
-function areScoreMapsEqual(left: Record<string, number>, right: Record<string, number>): boolean {
-  const leftEntries = Object.entries(left)
-  const rightEntries = Object.entries(right)
-
-  if (leftEntries.length !== rightEntries.length) {
-    return false
-  }
-
-  return leftEntries.every(([key, value]) => right[key] === value)
 }
 
 function appendKeywordToken(current: string[], token: string): string[] {
@@ -535,12 +530,16 @@ export function useResumeListState(loadSearchHistory = false) {
   const [selectedExperienceLevel, setSelectedExperienceLevel] = useState<ExperienceLevelFilter | undefined>(undefined)
   const [appliedSearchHistoryId, setAppliedSearchHistoryId] = useState<string | undefined>(undefined)
   const [queryRuleScoreMap, setQueryRuleScoreMap] = useState<Record<string, number>>({})
+  const [requestedConvexLimit, setRequestedConvexLimit] = useState(DEFAULT_CONVEX_RESUME_LIMIT)
   const [mode] = useState<'ai'>('ai')
   const hydratedSessionIdRef = useRef<string | null>(null)
   const hasInitializedUrlHydrationRef = useRef(false)
   const lastAppliedUrlStateRef = useRef<string | null>(null)
   const skipNextUrlSyncRef = useRef(false)
   const isUrlPushingRef = useRef(false)
+  const queryRuleScoreScopeRef = useRef<string | null>(null)
+  const queryRuleScoreMapScopeRef = useRef<string | null>(null)
+  const completedQueryRuleScoreIdsRef = useRef<Set<string>>(new Set())
   const initialWindowSearchStateRef = useRef<{
     hasUrlParams: boolean
     hasKeywordParam: boolean
@@ -628,7 +627,19 @@ export function useResumeListState(loadSearchHistory = false) {
     return kw
   }, [sessionKeywords])
 
-  const { resumes: convexResumes, loading: convexLoading } = useConvexResumes(200, expandedQuery, jobDescriptionId)
+  const convexQueryScopeKey = useMemo(
+    () => JSON.stringify({
+      jobDescriptionId: jobDescriptionId?.trim() ?? '',
+      query: expandedQuery ?? '',
+    }),
+    [expandedQuery, jobDescriptionId]
+  )
+  const {
+    resumes: convexResumes,
+    loading: convexLoading,
+    loadingMore: convexLoadingMore,
+    hasMore: convexHasMore,
+  } = useConvexResumes(requestedConvexLimit, expandedQuery, jobDescriptionId)
   const analysisTasks = useQuery(api.analysis_tasks.list)
   const dispatchAnalysis = useMutation(api.analysis_tasks.dispatch)
   const [analyzing, setAnalyzing] = useState(false)
@@ -655,6 +666,10 @@ export function useResumeListState(loadSearchHistory = false) {
       ),
     [convexResumes]
   )
+  const querySpecificScoreScopeKey = useMemo(
+    () => `${sessionLocation.trim()}::${querySpecificKeywordsKey}`,
+    [querySpecificKeywordsKey, sessionLocation]
+  )
   const querySpecificScoreRequest = useMemo(() => {
     if (!keywordOnlyQueryScoring) {
       return null
@@ -670,10 +685,15 @@ export function useResumeListState(loadSearchHistory = false) {
       keywords,
       location: sessionLocation.trim(),
       resumeIds,
+      scopeKey: querySpecificScoreScopeKey,
     }
-  }, [keywordOnlyQueryScoring, querySpecificKeywordsKey, querySpecificResumeIdsKey, sessionLocation])
+  }, [keywordOnlyQueryScoring, querySpecificKeywordsKey, querySpecificResumeIdsKey, querySpecificScoreScopeKey, sessionLocation])
 
   const activeLoading = mode === 'ai' ? convexLoading : loading
+  const loadedConvexResumeCount = convexResumes.length
+  const canLoadMoreResumes = mode === 'ai'
+    && convexHasMore
+    && requestedConvexLimit < MAX_CONVEX_RESUME_LIMIT
   const hasActiveTask = useMemo(() => {
     if (!analysisTasks || analysisTasks.length === 0) {
       return false
@@ -684,14 +704,51 @@ export function useResumeListState(loadSearchHistory = false) {
   }, [analysisTasks, currentPromptVersion, jobDescriptionId, sessionKeywords, sessionLocation])
 
   useEffect(() => {
+    if (!querySpecificScoreRequest) {
+      queryRuleScoreScopeRef.current = null
+      queryRuleScoreMapScopeRef.current = null
+      completedQueryRuleScoreIdsRef.current = new Set()
+      setQueryRuleScoreMap((current) => (Object.keys(current).length === 0 ? current : {}))
+      return
+    }
+
+    if (queryRuleScoreScopeRef.current === querySpecificScoreRequest.scopeKey) {
+      return
+    }
+
+    queryRuleScoreScopeRef.current = querySpecificScoreRequest.scopeKey
+    queryRuleScoreMapScopeRef.current = null
+    completedQueryRuleScoreIdsRef.current = new Set()
+    setQueryRuleScoreMap((current) => (Object.keys(current).length === 0 ? current : {}))
+  }, [querySpecificScoreRequest])
+
+  useEffect(() => {
     let active = true
 
     if (!querySpecificScoreRequest) {
-      setQueryRuleScoreMap((current) => (Object.keys(current).length === 0 ? current : {}))
       return () => {
         active = false
       }
     }
+
+    const activeQueryRuleScoreMap = queryRuleScoreMapScopeRef.current === querySpecificScoreRequest.scopeKey
+      ? queryRuleScoreMap
+      : {}
+    const pendingResumeIds = querySpecificScoreRequest.resumeIds.filter((resumeId) =>
+      activeQueryRuleScoreMap[resumeId] === undefined && !completedQueryRuleScoreIdsRef.current.has(resumeId)
+    )
+
+    if (pendingResumeIds.length === 0) {
+      return () => {
+        active = false
+      }
+    }
+
+    for (const resumeId of pendingResumeIds) {
+      completedQueryRuleScoreIdsRef.current.add(resumeId)
+    }
+
+    const scopeKey = querySpecificScoreRequest.scopeKey
 
     void rawApiClient
       .POST<{
@@ -707,33 +764,55 @@ export function useResumeListState(loadSearchHistory = false) {
           mode: 'rules_only',
           keywords: querySpecificScoreRequest.keywords,
           location: querySpecificScoreRequest.location,
-          resumeIds: querySpecificScoreRequest.resumeIds,
+          resumeIds: pendingResumeIds,
         },
       })
       .then(({ data, error }) => {
-        if (!active || error || !data?.success) {
-          if (active) {
-            setQueryRuleScoreMap((current) => (Object.keys(current).length === 0 ? current : {}))
+        if (!active || queryRuleScoreScopeRef.current !== scopeKey) {
+          return
+        }
+
+        if (error || !data?.success) {
+          for (const resumeId of pendingResumeIds) {
+            completedQueryRuleScoreIdsRef.current.delete(resumeId)
           }
           return
         }
 
-        const nextMap = Object.fromEntries(
-          (data.results ?? []).map((item) => [item.resumeId, item.score])
-        )
-        setQueryRuleScoreMap((current) => (areScoreMapsEqual(current, nextMap) ? current : nextMap))
+        queryRuleScoreMapScopeRef.current = scopeKey
+        setQueryRuleScoreMap((current) => {
+          let changed = false
+          const nextMap = { ...current }
+
+          for (const item of data.results ?? []) {
+            if (nextMap[item.resumeId] === item.score) {
+              continue
+            }
+
+            nextMap[item.resumeId] = item.score
+            changed = true
+          }
+
+          return changed ? nextMap : current
+        })
       })
       .catch((error: unknown) => {
         console.error('Failed to load query-specific resume scores', error)
-        if (active) {
-          setQueryRuleScoreMap((current) => (Object.keys(current).length === 0 ? current : {}))
+        if (active && queryRuleScoreScopeRef.current === scopeKey) {
+          for (const resumeId of pendingResumeIds) {
+            completedQueryRuleScoreIdsRef.current.delete(resumeId)
+          }
         }
       })
 
     return () => {
       active = false
     }
-  }, [querySpecificScoreRequest])
+  }, [queryRuleScoreMap, querySpecificScoreRequest])
+
+  useEffect(() => {
+    setRequestedConvexLimit(DEFAULT_CONVEX_RESUME_LIMIT)
+  }, [convexQueryScopeKey])
 
   useEffect(() => {
     if (!activeHasUrlParams) {
@@ -1113,11 +1192,20 @@ export function useResumeListState(loadSearchHistory = false) {
 
   const handleRefresh = useCallback(async () => {
     if (mode === 'ai') {
+      setRequestedConvexLimit(DEFAULT_CONVEX_RESUME_LIMIT)
       return
     }
     await reloadSamples()
     await refresh()
-  }, [mode, reloadSamples, refresh])
+  }, [mode, refresh, reloadSamples])
+
+  const handleLoadMoreResumes = useCallback(() => {
+    setRequestedConvexLimit((current) => (
+      current >= MAX_CONVEX_RESUME_LIMIT
+        ? current
+        : Math.min(current + CONVEX_RESUME_PAGE_SIZE, MAX_CONVEX_RESUME_LIMIT)
+    ))
+  }, [])
 
   const handleJobChange = useCallback(
     (value: string) => {
@@ -1868,11 +1956,15 @@ export function useResumeListState(loadSearchHistory = false) {
     blockedCount,
     bulkExportFormat,
     displayedResumes,
+    loadedConvexResumeCount,
+    canLoadMoreResumes,
+    convexLoadingMore,
     searchHistory,
     searchHistoryLoading,
     setBulkExportFormat,
     handleAnalyzeAll,
     handleRefresh,
+    handleLoadMoreResumes,
     handleQuickStartApply,
     handleQuickConstraintApply,
     handleCollectionSourceChange,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,6 +10,55 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) {
+            return undefined
+          }
+
+          if (
+            id.includes('/react/') ||
+            id.includes('/react-dom/') ||
+            id.includes('/react-router-dom/') ||
+            id.includes('/@remix-run/router/')
+          ) {
+            return 'react-vendor'
+          }
+
+          if (id.includes('/convex/')) {
+            return 'convex-vendor'
+          }
+
+          if (
+            id.includes('/i18next/') ||
+            id.includes('/react-i18next/') ||
+            id.includes('/i18next-browser-languagedetector/')
+          ) {
+            return 'i18n-vendor'
+          }
+
+          if (id.includes('/@radix-ui/')) {
+            return 'radix-vendor'
+          }
+
+          if (
+            id.includes('/date-fns/') ||
+            id.includes('/lucide-react/') ||
+            id.includes('/sonner/') ||
+            id.includes('/clsx/') ||
+            id.includes('/class-variance-authority/') ||
+            id.includes('/tailwind-merge/')
+          ) {
+            return 'ui-vendor'
+          }
+
+          return undefined
+        },
+      },
+    },
+  },
   server: {
     host: true,
     port: 5173,

--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@tanstack/react-virtual": "^3.13.23",
         "@trends/shared": "*",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
@@ -459,6 +460,10 @@
     "@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.23", "", { "dependencies": { "@tanstack/virtual-core": "3.13.23" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.23", "", {}, "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
+++ b/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
@@ -12,8 +12,8 @@ describe("resolveListWithIngestWindow", () => {
 
     it("clamps oversized requests to the safe ingest list window", () => {
         expect(resolveListWithIngestWindow(5_000)).toEqual({
-            limit: 200,
-            overfetchLimit: 400,
+            limit: 2000,
+            overfetchLimit: 4000,
         });
     });
 });

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -194,8 +194,8 @@ type DeleteResumesResult = {
 };
 
 const DEFAULT_RESUME_LIMIT = 50;
-export const MAX_SAFE_LIST_WITH_INGEST_LIMIT = 200;
-export const MAX_SAFE_LIST_WITH_INGEST_OVERFETCH = 400;
+export const MAX_SAFE_LIST_WITH_INGEST_LIMIT = 2000;
+export const MAX_SAFE_LIST_WITH_INGEST_OVERFETCH = 4000;
 const MAX_INGEST_DIAGNOSTICS_PAGE_SIZE = 100;
 const MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES = 8;
 const DEFAULT_RESUME_SCAN_BATCH_SIZE = 25;
@@ -797,7 +797,7 @@ export const searchWithTagExpansion = query({
         jobDescriptionId: v.optional(v.string()),
     },
     handler: async (ctx, args) => {
-        const limit = args.limit || 50;
+        const { limit, overfetchLimit } = resolveListWithIngestWindow(args.limit);
         const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
         const mode = args.mode ?? "AND";
         const keywordGroups = normalizeTagExpansionKeywordGroups(args.keywordGroups);
@@ -819,7 +819,7 @@ export const searchWithTagExpansion = query({
             (args.sourceMappings ?? []).map((entry) => [entry.term, entry.expandedFrom])
         );
         const provenanceByResumeId = new Map<string, SearchProvenance[]>();
-        const fetchLimit = Math.min(Math.max(limit * 2, 100), 400);
+        const fetchLimit = overfetchLimit;
         const searchQuery = buildTagExpansionSearchQuery(keywordGroups, mode);
 
         const matches = searchQuery


### PR DESCRIPTION
## Summary
- add incremental Convex loading and virtualized resume rendering for large resume sets
- lazy-load and prefetch heavy resume dialogs and split admin/debug routes out of the default app bundle
- add explicit web vendor chunking and update resume-list performance coverage

## Validation
- npm --workspace @trends/web test -- src/hooks/useResumeListState.test.tsx
- npm --workspace @trends/web run typecheck
- npm --workspace @trends/web run build
- npm exec vitest run packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
- make check