### PR TITLE
fix(api): paginate convex resume windows

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -53,6 +53,33 @@ function convexSuccess(value: unknown): Response {
   );
 }
 
+function buildConvexResumeRecord(
+  resumeId: string,
+  overrides: {
+    name?: string;
+    source?: string;
+    primaryRuleScore?: number;
+    ingestData?: Record<string, unknown>;
+  } = {}
+) {
+  return {
+    _id: resumeId,
+    source: overrides.source ?? "seek",
+    primaryRuleScore: overrides.primaryRuleScore ?? 0,
+    content: {
+      name: overrides.name ?? resumeId,
+      location: "东莞",
+      experience: "5 years",
+      education: "Bachelor",
+      jobIntention: "Sales Engineer",
+      profileUrl: `https://example.com/${resumeId}`,
+      workHistory: [{ raw: "2020-2025 CNC 销售工程师" }],
+      extractedAt: "2026-03-24T00:00:00.000Z",
+    },
+    ingestData: overrides.ingestData,
+  };
+}
+
 describe("resume routes", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -215,6 +242,113 @@ describe("resume routes", () => {
     expect(createSessionSpy).not.toHaveBeenCalled();
     expect(saveMatchesSpy).not.toHaveBeenCalled();
     expect(createRunSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches a large enough convex list window before applying offset pagination", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:listWithIngestData") {
+        return convexSuccess([
+          buildConvexResumeRecord("resume-live-1", { name: "Alice" }),
+          buildConvexResumeRecord("resume-live-2", { name: "Bob" }),
+          buildConvexResumeRecord("resume-live-3", {
+            name: "Carla",
+            ingestData: {
+              industryTags: ["industrial-machinery"],
+              companyHits: ["fanuc"],
+              roleSignals: [
+                {
+                  type: "sales",
+                  matchedSignals: ["销售工程师"],
+                  years: 4,
+                  industryVerifiedYears: 4,
+                  signalCount: 1,
+                  occurrences: 1,
+                  verifyIn: "workHistory",
+                },
+              ],
+            },
+          }),
+          buildConvexResumeRecord("resume-live-4", { name: "Dylan" }),
+        ]);
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&limit=2&offset=2");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.summary).toEqual(expect.objectContaining({
+      total: 4,
+      returned: 2,
+      source: "convex",
+    }));
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Dylan"]);
+    expect(payload.data[0]?.ingestData).toEqual(expect.objectContaining({
+      industryTags: ["industrial-machinery"],
+      companyHits: ["fanuc"],
+      roleSignals: expect.arrayContaining([expect.objectContaining({ type: "sales" })]),
+    }));
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:listWithIngestData",
+      args: expect.objectContaining({ limit: 4 }),
+    }));
+  });
+
+  it("fetches a large enough convex search window before applying offset pagination", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:searchWithTagExpansion") {
+        return convexSuccess({
+          expansion: {
+            original: "cnc sales",
+            expanded: ["cnc", "sales"],
+            groups: [
+              { original: "cnc", variants: ["cnc"] },
+              { original: "sales", variants: ["sales"] },
+            ],
+            mode: "AND",
+          },
+          results: [
+            { resume: buildConvexResumeRecord("resume-live-1", { name: "Alice" }), provenance: [{ term: "cnc", source: "searchText" }] },
+            { resume: buildConvexResumeRecord("resume-live-2", { name: "Bob" }), provenance: [{ term: "sales", source: "searchText" }] },
+            { resume: buildConvexResumeRecord("resume-live-3", { name: "Carla" }), provenance: [{ term: "sales", source: "searchText" }] },
+            { resume: buildConvexResumeRecord("resume-live-4", { name: "Dylan" }), provenance: [{ term: "cnc", source: "searchText" }] },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&q=cnc%20sales&limit=2&offset=2");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.summary).toEqual(expect.objectContaining({
+      total: 4,
+      returned: 2,
+      source: "convex",
+    }));
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Dylan"]);
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:searchWithTagExpansion",
+      args: expect.objectContaining({ limit: 4 }),
+    }));
   });
 
   it("rejects convex or read-only match-stream requests", async () => {

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -101,6 +101,7 @@ const exportService = new ExportService(
 );
 
 const DEFAULT_AI_TOP_N = 20;
+const DEFAULT_CONVEX_RESUME_PAGE_SIZE = 50;
 
 type MatchMode = "rules_only" | "hybrid" | "ai_only";
 
@@ -550,22 +551,29 @@ function prepareResumeCandidate(params: {
   provenance?: ResumeSearchProvenance[];
   ingestData?: unknown;
 }): PreparedResumeCandidate {
-  const ingestData = params.ingestData ?? params.resume.ingestData;
-  const resume = params.resume.resumeId
+  const rawIngestData = params.ingestData ?? params.resume.ingestData;
+  const parsedIngestData = params.resume.ingestData ?? buildResumeIngestData(params.ingestData);
+  const baseResume = params.resume.resumeId
     ? params.resume
     : {
         ...params.resume,
         resumeId: params.resumeId,
       };
+  const resume = parsedIngestData
+    ? {
+        ...baseResume,
+        ingestData: parsedIngestData,
+      }
+    : baseResume;
   return {
     resume,
     resumeId: params.resumeId,
     indexData: params.indexData ?? createFallbackIndex(resume, params.resumeId),
     primaryRuleScore: params.primaryRuleScore,
     provenance: params.provenance,
-    brandHits: parseBrandHits(isRecord(ingestData) ? ingestData.brandHits : undefined),
-    companyHits: toStringArray(isRecord(ingestData) ? ingestData.companyHits : undefined),
-    roleSignals: parseRoleSignals(isRecord(ingestData) ? ingestData.roleSignals : undefined),
+    brandHits: parseBrandHits(isRecord(rawIngestData) ? rawIngestData.brandHits : undefined),
+    companyHits: toStringArray(isRecord(rawIngestData) ? rawIngestData.companyHits : undefined),
+    roleSignals: parseRoleSignals(isRecord(rawIngestData) ? rawIngestData.roleSignals : undefined),
   };
 }
 
@@ -864,6 +872,15 @@ async function prepareConvexCandidates(params: {
   };
 }
 
+function resolveConvexResumeFetchLimit(limit: number | undefined, offset: number | undefined): number | undefined {
+  if (typeof offset !== "number" || offset <= 0) {
+    return limit;
+  }
+
+  const pageSize = typeof limit === "number" ? limit : DEFAULT_CONVEX_RESUME_PAGE_SIZE;
+  return offset + pageSize;
+}
+
 function toExportResumePayload(resume: ResumeItem): ExportResumePayload {
   return {
     name: resume.name,
@@ -878,6 +895,25 @@ function toExportResumePayload(resume: ResumeItem): ExportResumePayload {
     selfIntro: resume.selfIntro,
     workHistory: resume.workHistory,
     ingestData: resume.ingestData,
+  };
+}
+
+function normalizeExportResumePayload(
+  resume: z.infer<typeof ResumeExportResolvedResumeSchema>
+): ExportResumePayload {
+  return {
+    name: resume.name,
+    jobIntention: resume.jobIntention,
+    location: resume.location,
+    age: resume.age,
+    experience: resume.experience,
+    education: resume.education,
+    expectedSalary: resume.expectedSalary,
+    profileUrl: resume.profileUrl,
+    source: resume.source,
+    selfIntro: resume.selfIntro,
+    workHistory: resume.workHistory,
+    ingestData: buildResumeIngestData(resume.ingestData),
   };
 }
 
@@ -923,7 +959,7 @@ async function resolveConvexExportResumeMap(
     if (!parsedResume.success) {
       return;
     }
-    resolved.set(resumeId, parsedResume.data);
+    resolved.set(resumeId, normalizeExportResumePayload(parsedResume.data));
   });
 
   return resolved;
@@ -988,7 +1024,9 @@ async function resolveExportRequest(
   let entries: ResumeExportEntry[];
 
   if (!isCanonicalExportRequest(request)) {
-    entries = request.entries.map((entry) => toExportEntry(entry.key, entry.resume, toExportEntryFields(entry)));
+    entries = request.entries.map((entry) => (
+      toExportEntry(entry.key, normalizeExportResumePayload(entry.resume), toExportEntryFields(entry))
+    ));
   } else {
     const resolvedResumes = request.source === "sample"
       ? resolveSampleExportResumeMap(request.sample ?? "", request.entries)
@@ -1367,9 +1405,10 @@ app.openapi(getResumesRoute, (c) => {
   try {
     if (source === "convex") {
       return (async () => {
+        const convexFetchLimit = resolveConvexResumeFetchLimit(limit, offset);
         const { prepared, keywordExpansion: liveExpansion } = await prepareConvexCandidates({
           keywords: keyword ? normalizeKeywords(parseKeywordQuery(keyword).keywords) : [],
-          limit,
+          limit: convexFetchLimit,
           jobDescriptionId: jobDescriptionId?.trim() || undefined,
         });
 

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -129,6 +129,50 @@ const ResumeStructuredDetailsShape = {
   digitalIdentity: z.union([z.string(), ResumeImportDigitalIdentitySchema]).optional(),
 };
 
+const ResumeIngestMatchedWorkEntrySchema = z
+  .object({
+    companyName: z.string().optional().openapi({ example: "FANUC" }),
+    jobTitle: z.string().optional().openapi({ example: "Sales Engineer" }),
+    years: z.number().openapi({ example: 3 }),
+    industryVerified: z.boolean().openapi({ example: true }),
+    matchedSignals: z.array(z.string()).openapi({ example: ["sales", "cnc"] }),
+  })
+  .openapi("ResumeIngestMatchedWorkEntry");
+
+const ResumeIngestRoleSignalSchema = z
+  .object({
+    type: z.string().openapi({ example: "sales" }),
+    matchedSignals: z.array(z.string()).openapi({ example: ["销售工程师", "销售"] }),
+    signalCount: z.number().optional().openapi({ example: 2 }),
+    occurrences: z.number().optional().openapi({ example: 2 }),
+    years: z.number().openapi({ example: 5 }),
+    industryVerifiedYears: z.number().optional().openapi({ example: 5 }),
+    roleRelevantYears: z.number().optional().openapi({ example: 5 }),
+    industryVerifiedRelevantYears: z.number().optional().openapi({ example: 5 }),
+    matchedWorkEntries: z.array(ResumeIngestMatchedWorkEntrySchema).optional(),
+    verifyIn: z.string().openapi({ example: "workHistory" }),
+  })
+  .openapi("ResumeIngestRoleSignal");
+
+const ResumeIngestBrandHitSchema = z
+  .object({
+    brand: z.string().openapi({ example: "fanuc" }),
+    role: z.string().openapi({ example: "both" }),
+    source: z.string().openapi({ example: "workHistory" }),
+    context: z.string().openapi({ example: "employer" }),
+  })
+  .openapi("ResumeIngestBrandHit");
+
+const ResumeIngestDataSchema = z
+  .object({
+    industryTags: z.array(z.string()).optional().openapi({ example: ["industrial-machinery"] }),
+    brandHits: z.array(ResumeIngestBrandHitSchema).optional(),
+    companyHits: z.array(z.string()).optional().openapi({ example: ["fanuc"] }),
+    industryDbV2Raw: z.number().optional().openapi({ example: 12 }),
+    roleSignals: z.array(ResumeIngestRoleSignalSchema).optional(),
+  })
+  .openapi("ResumeIngestData");
+
 export const ResumeItemSchema = z
   .object({
     name: z.string().openapi({ example: "Alex Chen" }),
@@ -145,6 +189,7 @@ export const ResumeItemSchema = z
     workHistory: z.array(ResumeWorkHistorySchema),
     ...ResumeStructuredDetailsShape,
     noticePeriodDays: z.number().int().optional(),
+    ingestData: ResumeIngestDataSchema.optional(),
     extractedAt: z.string().openapi({ example: "2026-02-03T10:00:00.000Z" }),
     resumeId: z.string().optional().openapi({ example: "R123456" }),
     perUserId: z.string().optional().openapi({ example: "U987654" }),

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -170,19 +170,26 @@ function normalizeRoleSignals(value: unknown): ResumeIngestRoleSignal[] | undefi
         return null;
       }
 
+      const matchedSignals = toStringArray(item.matchedSignals);
+      const signalCount = toOptionalNumber(item.signalCount) ?? matchedSignals.length;
+      const occurrences = toOptionalNumber(item.occurrences) ?? matchedSignals.length;
       const industryVerifiedYears = toOptionalNumber(item.industryVerifiedYears);
       const roleRelevantYears = toOptionalNumber(item.roleRelevantYears);
       const industryVerifiedRelevantYears = toOptionalNumber(item.industryVerifiedRelevantYears);
       const matchedWorkEntries = normalizeMatchedWorkEntries(item.matchedWorkEntries);
+      const verifyIn = toStringValue(item.verifyIn) || "workHistory";
 
       return {
         type,
-        matchedSignals: toStringArray(item.matchedSignals),
+        matchedSignals,
+        signalCount,
+        occurrences,
         years,
         ...(industryVerifiedYears === undefined ? {} : { industryVerifiedYears }),
         ...(roleRelevantYears === undefined ? {} : { roleRelevantYears }),
         ...(industryVerifiedRelevantYears === undefined ? {} : { industryVerifiedRelevantYears }),
         ...(matchedWorkEntries ? { matchedWorkEntries } : {}),
+        verifyIn,
       } satisfies ResumeIngestRoleSignal;
     })
     .filter((item): item is ResumeIngestRoleSignal => item !== null);

--- a/apps/api/src/types/resume.ts
+++ b/apps/api/src/types/resume.ts
@@ -42,11 +42,14 @@ export type ResumeIngestMatchedWorkEntry = {
 export type ResumeIngestRoleSignal = {
   type: string;
   matchedSignals: string[];
+  signalCount: number;
+  occurrences: number;
   years: number;
   industryVerifiedYears?: number;
   roleRelevantYears?: number;
   industryVerifiedRelevantYears?: number;
   matchedWorkEntries?: ResumeIngestMatchedWorkEntry[];
+  verifyIn: string;
 };
 
 export type ResumeIngestData = {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4222,6 +4222,77 @@ export interface components {
             /** @example https://example.com */
             websiteUrl?: string;
         };
+        ResumeIngestBrandHit: {
+            /** @example fanuc */
+            brand: string;
+            /** @example both */
+            role: string;
+            /** @example workHistory */
+            source: string;
+            /** @example employer */
+            context: string;
+        };
+        ResumeIngestMatchedWorkEntry: {
+            /** @example FANUC */
+            companyName?: string;
+            /** @example Sales Engineer */
+            jobTitle?: string;
+            /** @example 3 */
+            years: number;
+            /** @example true */
+            industryVerified: boolean;
+            /**
+             * @example [
+             *       "sales",
+             *       "cnc"
+             *     ]
+             */
+            matchedSignals: string[];
+        };
+        ResumeIngestRoleSignal: {
+            /** @example sales */
+            type: string;
+            /**
+             * @example [
+             *       "销售工程师",
+             *       "销售"
+             *     ]
+             */
+            matchedSignals: string[];
+            /** @example 2 */
+            signalCount?: number;
+            /** @example 2 */
+            occurrences?: number;
+            /** @example 5 */
+            years: number;
+            /** @example 5 */
+            industryVerifiedYears?: number;
+            /** @example 5 */
+            roleRelevantYears?: number;
+            /** @example 5 */
+            industryVerifiedRelevantYears?: number;
+            matchedWorkEntries?: components["schemas"]["ResumeIngestMatchedWorkEntry"][];
+            /** @example workHistory */
+            verifyIn: string;
+        };
+        ResumeIngestData: {
+            /**
+             * @example [
+             *       "industrial-machinery"
+             *     ]
+             */
+            industryTags?: string[];
+            brandHits?: components["schemas"]["ResumeIngestBrandHit"][];
+            /**
+             * @example [
+             *       "fanuc"
+             *     ]
+             */
+            companyHits?: string[];
+            /** @example 12 */
+            industryDbV2Raw?: number;
+            roleSignals?: components["schemas"]["ResumeIngestRoleSignal"][];
+        };
         ResumeItem: {
             /** @example Alex Chen */
             name: string;
@@ -4255,6 +4326,7 @@ export interface components {
             rightToWork?: string | boolean | components["schemas"]["ResumeImportRightToWork"];
             digitalIdentity?: string | components["schemas"]["ResumeImportDigitalIdentity"];
             noticePeriodDays?: number;
+            ingestData?: components["schemas"]["ResumeIngestData"];
             /** @example 2026-02-03T10:00:00.000Z */
             extractedAt: string;
             /** @example R123456 */


### PR DESCRIPTION
## Summary
- fetch an offset-aware Convex candidate window before local paging in `GET /api/resumes?source=convex`
- expose reduced `ingestData` on public `ResumeItem` responses and regenerate web API types
- add API regressions for Convex list and keyword-search pagination plus ingestData presence

## Testing
- npx vitest run apps/api/src/routes/resumes.test.ts
- npm --workspace @trends/api run typecheck
- make check