### PR TITLE
perf(api): page convex resume queries

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -92,7 +92,7 @@ describe("resume routes", () => {
       const call = parseConvexCall(input, init);
       calls.push(call);
 
-      if (call.pathName === "resumes:searchWithTagExpansion") {
+      if (call.pathName === "resumes:searchWithTagExpansionPage") {
         return convexSuccess({
           expansion: {
             original: "cnc 销售",
@@ -127,6 +127,7 @@ describe("resume routes", () => {
               provenance: [{ term: "销售", source: "searchText" }],
             },
           ],
+          total: 1,
         });
       }
 
@@ -150,7 +151,10 @@ describe("resume routes", () => {
         location: "东莞",
       })
     );
-    expect(calls[0]?.pathName).toBe("resumes:searchWithTagExpansion");
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:searchWithTagExpansionPage",
+      args: expect.objectContaining({ limit: 5 }),
+    }));
   });
 
   it("returns read-only convex query scores with debug metadata", async () => {
@@ -251,30 +255,31 @@ describe("resume routes", () => {
       const call = parseConvexCall(input, init);
       calls.push(call);
 
-      if (call.pathName === "resumes:listWithIngestData") {
-        return convexSuccess([
-          buildConvexResumeRecord("resume-live-1", { name: "Alice" }),
-          buildConvexResumeRecord("resume-live-2", { name: "Bob" }),
-          buildConvexResumeRecord("resume-live-3", {
-            name: "Carla",
-            ingestData: {
-              industryTags: ["industrial-machinery"],
-              companyHits: ["fanuc"],
-              roleSignals: [
-                {
-                  type: "sales",
-                  matchedSignals: ["销售工程师"],
-                  years: 4,
-                  industryVerifiedYears: 4,
-                  signalCount: 1,
-                  occurrences: 1,
-                  verifyIn: "workHistory",
-                },
-              ],
-            },
-          }),
-          buildConvexResumeRecord("resume-live-4", { name: "Dylan" }),
-        ]);
+      if (call.pathName === "resumes:listWithIngestDataPage") {
+        return convexSuccess({
+          results: [
+            buildConvexResumeRecord("resume-live-3", {
+              name: "Carla",
+              ingestData: {
+                industryTags: ["industrial-machinery"],
+                companyHits: ["fanuc"],
+                roleSignals: [
+                  {
+                    type: "sales",
+                    matchedSignals: ["销售工程师"],
+                    years: 4,
+                    industryVerifiedYears: 4,
+                    signalCount: 1,
+                    occurrences: 1,
+                    verifyIn: "workHistory",
+                  },
+                ],
+              },
+            }),
+            buildConvexResumeRecord("resume-live-4", { name: "Dylan" }),
+          ],
+          total: 4,
+        });
       }
 
       throw new Error(`Unexpected convex path: ${call.pathName}`);
@@ -298,8 +303,8 @@ describe("resume routes", () => {
       roleSignals: expect.arrayContaining([expect.objectContaining({ type: "sales" })]),
     }));
     expect(calls[0]).toEqual(expect.objectContaining({
-      pathName: "resumes:listWithIngestData",
-      args: expect.objectContaining({ limit: 4 }),
+      pathName: "resumes:listWithIngestDataPage",
+      args: expect.objectContaining({ limit: 2, offset: 2 }),
     }));
   });
 
@@ -310,7 +315,7 @@ describe("resume routes", () => {
       const call = parseConvexCall(input, init);
       calls.push(call);
 
-      if (call.pathName === "resumes:searchWithTagExpansion") {
+      if (call.pathName === "resumes:searchWithTagExpansionPage") {
         return convexSuccess({
           expansion: {
             original: "cnc sales",
@@ -322,11 +327,10 @@ describe("resume routes", () => {
             mode: "AND",
           },
           results: [
-            { resume: buildConvexResumeRecord("resume-live-1", { name: "Alice" }), provenance: [{ term: "cnc", source: "searchText" }] },
-            { resume: buildConvexResumeRecord("resume-live-2", { name: "Bob" }), provenance: [{ term: "sales", source: "searchText" }] },
             { resume: buildConvexResumeRecord("resume-live-3", { name: "Carla" }), provenance: [{ term: "sales", source: "searchText" }] },
             { resume: buildConvexResumeRecord("resume-live-4", { name: "Dylan" }), provenance: [{ term: "cnc", source: "searchText" }] },
           ],
+          total: 4,
         });
       }
 
@@ -346,7 +350,39 @@ describe("resume routes", () => {
     }));
     expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Dylan"]);
     expect(calls[0]).toEqual(expect.objectContaining({
-      pathName: "resumes:searchWithTagExpansion",
+      pathName: "resumes:searchWithTagExpansionPage",
+      args: expect.objectContaining({ limit: 2, offset: 2 }),
+    }));
+  });
+
+  it("falls back to overfetch when local filters must run before paging", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:listWithIngestData") {
+        return convexSuccess([
+          buildConvexResumeRecord("resume-live-1", { name: "Alice" }),
+          buildConvexResumeRecord("resume-live-2", { name: "Bob" }),
+          buildConvexResumeRecord("resume-live-3", { name: "Carla" }),
+          buildConvexResumeRecord("resume-live-4", { name: "Dylan" }),
+        ]);
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&locations=%E4%B8%9C%E8%8E%9E");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Dylan"]);
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:listWithIngestData",
       args: expect.objectContaining({ limit: 4 }),
     }));
   });

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -766,10 +766,13 @@ async function prepareConvexCandidates(params: {
   keywords?: string[];
   location?: string;
   limit?: number;
+  offset?: number;
   jobDescriptionId?: string;
+  paged?: boolean;
 }): Promise<{
   prepared: PreparedResumeCandidate[];
   keywordExpansion?: ResumeKeywordExpansion;
+  total?: number;
 }> {
   const resumeIds = Array.from(new Set((params.resumeIds ?? []).map((resumeId) => resumeId.trim()).filter(Boolean)));
   if (resumeIds.length > 0) {
@@ -807,7 +810,7 @@ async function prepareConvexCandidates(params: {
   if (normalizedKeywords.length > 0) {
     const canonicalKeywordQuery = formatKeywordQuery(normalizedKeywords);
     const keywordExpansion = resumeService.expandSearchQuery(canonicalKeywordQuery);
-    const value = await callConvexQuery("resumes:searchWithTagExpansion", {
+    const value = await callConvexQuery(params.paged ? "resumes:searchWithTagExpansionPage" : "resumes:searchWithTagExpansion", {
       query: canonicalKeywordQuery,
       keywordGroups: keywordExpansion?.groups ?? [],
       mode: keywordExpansion?.mode ?? "AND",
@@ -816,6 +819,7 @@ async function prepareConvexCandidates(params: {
         expandedFrom,
       })),
       limit: params.limit,
+      ...(params.paged ? { offset: params.offset } : {}),
       jobDescriptionId: params.jobDescriptionId,
     });
 
@@ -842,19 +846,27 @@ async function prepareConvexCandidates(params: {
       })];
     });
 
-    return { prepared, keywordExpansion };
+    return {
+      prepared,
+      keywordExpansion,
+      total: params.paged ? (toOptionalNumber(value.total) ?? prepared.length) : undefined,
+    };
   }
 
-  const value = await callConvexQuery("resumes:listWithIngestData", {
+  const value = await callConvexQuery(params.paged ? "resumes:listWithIngestDataPage" : "resumes:listWithIngestData", {
     limit: params.limit,
+    ...(params.paged ? { offset: params.offset } : {}),
     jobDescriptionId: params.jobDescriptionId,
   });
-  if (!Array.isArray(value)) {
+  const items = params.paged && isRecord(value) && Array.isArray(value.results)
+    ? value.results
+    : value;
+  if (!Array.isArray(items)) {
     throw new Error("Invalid resume list response from Convex");
   }
 
   return {
-    prepared: value.flatMap((item) => {
+    prepared: items.flatMap((item) => {
       if (!isRecord(item)) {
         return [];
       }
@@ -869,6 +881,7 @@ async function prepareConvexCandidates(params: {
         ingestData: item.ingestData,
       })];
     }),
+    total: params.paged && isRecord(value) ? (toOptionalNumber(value.total) ?? undefined) : undefined,
   };
 }
 
@@ -879,6 +892,24 @@ function resolveConvexResumeFetchLimit(limit: number | undefined, offset: number
 
   const pageSize = typeof limit === "number" ? limit : DEFAULT_CONVEX_RESUME_PAGE_SIZE;
   return offset + pageSize;
+}
+
+function hasResumeListFilters(params: {
+  minExperience?: number;
+  maxExperience?: number;
+  education?: string[];
+  skills?: string[];
+  locations?: string[];
+  minSalary?: number;
+  maxSalary?: number;
+}): boolean {
+  return params.minExperience !== undefined
+    || params.maxExperience !== undefined
+    || (params.education?.length ?? 0) > 0
+    || (params.skills?.length ?? 0) > 0
+    || (params.locations?.length ?? 0) > 0
+    || params.minSalary !== undefined
+    || params.maxSalary !== undefined;
 }
 
 function toExportResumePayload(resume: ResumeItem): ExportResumePayload {
@@ -1405,11 +1436,25 @@ app.openapi(getResumesRoute, (c) => {
   try {
     if (source === "convex") {
       return (async () => {
-        const convexFetchLimit = resolveConvexResumeFetchLimit(limit, offset);
-        const { prepared, keywordExpansion: liveExpansion } = await prepareConvexCandidates({
+        const resolvedJobId = jobDescriptionId?.trim() || undefined;
+        const hasLocalResumeFilters = hasResumeListFilters({
+          minExperience,
+          maxExperience,
+          education,
+          skills,
+          locations,
+          minSalary,
+          maxSalary,
+        });
+        const hasLocalMatchFilters = minMatchScore !== undefined || (recommendation?.length ?? 0) > 0;
+        const canUseSourcePagination = !hasLocalResumeFilters && !hasLocalMatchFilters && !sortBy;
+        const convexFetchLimit = canUseSourcePagination ? limit : resolveConvexResumeFetchLimit(limit, offset);
+        const { prepared, keywordExpansion: liveExpansion, total: convexTotal } = await prepareConvexCandidates({
           keywords: keyword ? normalizeKeywords(parseKeywordQuery(keyword).keywords) : [],
           limit: convexFetchLimit,
-          jobDescriptionId: jobDescriptionId?.trim() || undefined,
+          offset: canUseSourcePagination ? offset : undefined,
+          jobDescriptionId: resolvedJobId,
+          paged: canUseSourcePagination,
         });
 
         let filtered = prepared.map((item) => item.resume);
@@ -1429,7 +1474,6 @@ app.openapi(getResumesRoute, (c) => {
         }));
 
         let matchMap: Map<string, { score: number; recommendation: string }> | null = null;
-        const resolvedJobId = jobDescriptionId?.trim() || undefined;
         const needsMatchContext = Boolean(
           resolvedJobId
           && (minMatchScore !== undefined || (recommendation?.length ?? 0) > 0 || sortBy === "score")
@@ -1486,15 +1530,19 @@ app.openapi(getResumesRoute, (c) => {
           });
         }
 
-        const start = offset ?? 0;
-        const end = typeof limit === "number" ? start + limit : undefined;
-        const paged = end ? working.slice(start, end) : working.slice(start);
-        const limited = paged.map((item) => item.resume);
+        const limited = canUseSourcePagination
+          ? working.map((item) => item.resume)
+          : (() => {
+              const start = offset ?? 0;
+              const end = typeof limit === "number" ? start + limit : undefined;
+              const paged = end ? working.slice(start, end) : working.slice(start);
+              return paged.map((item) => item.resume);
+            })();
 
         return c.json({
           success: true as const,
           summary: {
-            total: working.length,
+            total: canUseSourcePagination ? (convexTotal ?? working.length) : working.length,
             returned: limited.length,
             query: keyword,
             source,

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -306,6 +306,23 @@ export function resolveListWithIngestWindow(requestedLimit: number | undefined):
     };
 }
 
+function resolveListWithIngestPageWindow(requestedLimit: number | undefined, requestedOffset: number | undefined): {
+    offset: number;
+    pageLimit: number;
+    scanLimit: number;
+    overfetchLimit: number;
+} {
+    const offset = Math.max(Math.trunc(requestedOffset ?? 0), 0);
+    const pageLimit = Math.min(Math.max(requestedLimit || DEFAULT_RESUME_LIMIT, 1), MAX_SAFE_LIST_WITH_INGEST_LIMIT);
+    const { limit: scanLimit, overfetchLimit } = resolveListWithIngestWindow(offset + pageLimit);
+    return {
+        offset,
+        pageLimit,
+        scanLimit,
+        overfetchLimit,
+    };
+}
+
 export function resolveResumeScanBatchSize(requestedLimit: number | undefined): number {
     const normalizedLimit = typeof requestedLimit === "number" && Number.isFinite(requestedLimit)
         ? Math.trunc(requestedLimit)
@@ -676,6 +693,28 @@ export const listWithIngestData = query({
     },
 });
 
+export const listWithIngestDataPage = query({
+    args: {
+        limit: v.optional(v.number()),
+        offset: v.optional(v.number()),
+        jobDescriptionId: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const { offset, pageLimit, scanLimit, overfetchLimit } = resolveListWithIngestPageWindow(args.limit, args.offset);
+        const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
+        const candidates = await ctx.db
+            .query("resumes")
+            .withIndex("by_primaryRuleScore")
+            .order("desc")
+            .take(overfetchLimit);
+        const sorted = sortByIngestRuleScore(candidates, jobDescriptionId).slice(0, scanLimit);
+        return {
+            total: sorted.length,
+            results: sorted.slice(offset, offset + pageLimit),
+        };
+    },
+});
+
 export const listIngestDiagnostics = query({
     args: {
         paginationOpts: paginationOptsValidator,
@@ -854,6 +893,87 @@ export const searchWithTagExpansion = query({
                 mode,
             },
             results: mergeResumeDocs(filteredDocs, provenanceByResumeId, jobDescriptionId, limit),
+        };
+    },
+});
+
+export const searchWithTagExpansionPage = query({
+    args: {
+        query: v.string(),
+        keywordGroups: v.array(v.object({
+            original: v.string(),
+            variants: v.array(v.string()),
+        })),
+        mode: v.optional(v.union(v.literal("AND"), v.literal("OR"))),
+        sourceMappings: v.optional(v.array(v.object({
+            term: v.string(),
+            expandedFrom: v.string(),
+        }))),
+        limit: v.optional(v.number()),
+        offset: v.optional(v.number()),
+        jobDescriptionId: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const { offset, pageLimit, scanLimit, overfetchLimit } = resolveListWithIngestPageWindow(args.limit, args.offset);
+        const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
+        const mode = args.mode ?? "AND";
+        const keywordGroups = normalizeTagExpansionKeywordGroups(args.keywordGroups);
+        const expandedTerms = collectExpandedTerms(keywordGroups);
+
+        if (expandedTerms.length === 0 || keywordGroups.length === 0) {
+            return {
+                expansion: {
+                    original: args.query,
+                    expanded: [],
+                    groups: [],
+                    mode,
+                },
+                total: 0,
+                results: [],
+            };
+        }
+
+        const sourceMapping = Object.fromEntries(
+            (args.sourceMappings ?? []).map((entry) => [entry.term, entry.expandedFrom])
+        );
+        const provenanceByResumeId = new Map<string, SearchProvenance[]>();
+        const searchQuery = buildTagExpansionSearchQuery(keywordGroups, mode);
+
+        const matches = searchQuery
+            ? await ctx.db
+                .query("resumes")
+                .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery))
+                .take(overfetchLimit)
+            : [];
+
+        const filteredDocs = matches.filter((doc) => {
+            const normalizedSearchText = (doc.searchText || "").toLowerCase();
+            const matched = matchesTagExpansionSearchText(normalizedSearchText, keywordGroups, mode);
+
+            if (!matched) {
+                return false;
+            }
+
+            const provenance = collectSearchTextProvenance(normalizedSearchText, keywordGroups, sourceMapping);
+            if (provenance.length === 0) {
+                return false;
+            }
+
+            provenanceByResumeId.set(String(doc._id), provenance);
+            return true;
+        });
+
+        const merged = mergeResumeDocs(filteredDocs, provenanceByResumeId, jobDescriptionId, scanLimit);
+
+        return {
+            expansion: {
+                original: args.query,
+                expanded: expandedTerms,
+                groups: keywordGroups,
+                mode,
+            },
+            total: merged.length,
+            results: merged.slice(offset, offset + pageLimit),
         };
     },
 });


### PR DESCRIPTION
## Summary
- add Convex-side page queries for resume list and keyword search so the API can request only the needed page for the common unfiltered path
- switch `GET /api/resumes?source=convex` to use query-side paging when no local filter or sort would invalidate pre-pagination
- keep the existing offset-aware overfetch fallback for locally filtered requests and add regressions for both behaviors

## Testing
- npx vitest run apps/api/src/routes/resumes.test.ts
- npm --workspace @trends/api run typecheck
- bun run --filter @trends/convex typecheck\n- make check