### PR TITLE
perf(api): push convex sorts into page queries

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -355,6 +355,47 @@ describe("resume routes", () => {
     }));
   });
 
+  it("keeps source pagination when a keyword search uses a non-score sort", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:searchWithTagExpansionPage") {
+        return convexSuccess({
+          expansion: {
+            original: "cnc sales",
+            expanded: ["cnc", "sales"],
+            groups: [
+              { original: "cnc", variants: ["cnc"] },
+              { original: "sales", variants: ["sales"] },
+            ],
+            mode: "AND",
+          },
+          results: [
+            { resume: buildConvexResumeRecord("resume-live-3", { name: "Carla" }), provenance: [{ term: "sales", source: "searchText" }] },
+            { resume: buildConvexResumeRecord("resume-live-4", { name: "Dylan" }), provenance: [{ term: "cnc", source: "searchText" }] },
+          ],
+          total: 4,
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&q=cnc%20sales&limit=2&offset=2&sortBy=name&sortOrder=desc");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:searchWithTagExpansionPage",
+      args: expect.objectContaining({ limit: 2, offset: 2, sortBy: "name", sortOrder: "desc" }),
+    }));
+  });
+
   it("keeps source pagination when resume filters are pushed into the convex page query", async () => {
     const calls: ConvexCall[] = [];
 
@@ -388,7 +429,39 @@ describe("resume routes", () => {
     }));
   });
 
-  it("falls back to overfetch when local sorting must run before paging", async () => {
+  it("keeps source pagination when a non-score sort is pushed into the convex page query", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:listWithIngestDataPage") {
+        return convexSuccess({
+          results: [
+            buildConvexResumeRecord("resume-live-3", { name: "Carla" }),
+            buildConvexResumeRecord("resume-live-4", { name: "Dylan" }),
+          ],
+          total: 4,
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&sortBy=experience");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:listWithIngestDataPage",
+      args: expect.objectContaining({ limit: 2, offset: 2, sortBy: "experience", sortOrder: "asc" }),
+    }));
+  });
+
+  it("falls back to overfetch when score sorting still depends on local match storage", async () => {
     const calls: ConvexCall[] = [];
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
@@ -408,7 +481,7 @@ describe("resume routes", () => {
     });
 
     const app = createApp();
-    const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&sortBy=experience");
+    const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&sortBy=score");
 
     expect(response.status).toBe(200);
     const payload = await response.json();

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -767,6 +767,8 @@ async function prepareConvexCandidates(params: {
   location?: string;
   limit?: number;
   offset?: number;
+  sortBy?: "name" | "experience" | "extractedAt";
+  sortOrder?: "asc" | "desc";
   filters?: {
     minExperience?: number;
     maxExperience?: number;
@@ -829,6 +831,7 @@ async function prepareConvexCandidates(params: {
       })),
       limit: params.limit,
       ...(params.paged ? { offset: params.offset } : {}),
+      ...(params.paged && params.sortBy ? { sortBy: params.sortBy, sortOrder: params.sortOrder } : {}),
       ...(params.paged && params.filters ? params.filters : {}),
       jobDescriptionId: params.jobDescriptionId,
     });
@@ -866,6 +869,7 @@ async function prepareConvexCandidates(params: {
   const value = await callConvexQuery(params.paged ? "resumes:listWithIngestDataPage" : "resumes:listWithIngestData", {
     limit: params.limit,
     ...(params.paged ? { offset: params.offset } : {}),
+    ...(params.paged && params.sortBy ? { sortBy: params.sortBy, sortOrder: params.sortOrder } : {}),
     ...(params.paged && params.filters ? params.filters : {}),
     jobDescriptionId: params.jobDescriptionId,
   });
@@ -903,6 +907,13 @@ function resolveConvexResumeFetchLimit(limit: number | undefined, offset: number
 
   const pageSize = typeof limit === "number" ? limit : DEFAULT_CONVEX_RESUME_PAGE_SIZE;
   return offset + pageSize;
+}
+
+function resolveResumeSortOrder(sortBy: "score" | "name" | "experience" | "extractedAt" | undefined, sortOrder: "asc" | "desc" | undefined): "asc" | "desc" | undefined {
+  if (!sortBy || sortBy === "score") {
+    return sortOrder;
+  }
+  return sortOrder || "asc";
 }
 
 function toExportResumePayload(resume: ResumeItem): ExportResumePayload {
@@ -1431,12 +1442,14 @@ app.openapi(getResumesRoute, (c) => {
       return (async () => {
         const resolvedJobId = jobDescriptionId?.trim() || undefined;
         const hasLocalMatchFilters = minMatchScore !== undefined || (recommendation?.length ?? 0) > 0;
-        const canUseSourcePagination = !hasLocalMatchFilters && !sortBy;
+        const canUseSourcePagination = !hasLocalMatchFilters && sortBy !== "score";
         const convexFetchLimit = canUseSourcePagination ? limit : resolveConvexResumeFetchLimit(limit, offset);
         const { prepared, keywordExpansion: liveExpansion, total: convexTotal } = await prepareConvexCandidates({
           keywords: keyword ? normalizeKeywords(parseKeywordQuery(keyword).keywords) : [],
           limit: convexFetchLimit,
           offset: canUseSourcePagination ? offset : undefined,
+          sortBy: canUseSourcePagination && sortBy ? sortBy : undefined,
+          sortOrder: canUseSourcePagination ? resolveResumeSortOrder(sortBy, sortOrder) : undefined,
           filters: canUseSourcePagination
             ? {
                 minExperience,

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -199,6 +199,9 @@ type ResumeListFilterArgs = {
     maxSalary?: number;
 };
 
+type ResumeListSortBy = "name" | "experience" | "extractedAt";
+type ResumeListSortOrder = "asc" | "desc";
+
 type DeleteResumesResult = {
     requested: number;
     deleted: number;
@@ -474,6 +477,66 @@ function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFil
     }
 
     return true;
+}
+
+function resolveResumeListSortOrder(sortOrder: ResumeListSortOrder | undefined): ResumeListSortOrder {
+    if (sortOrder === "asc" || sortOrder === "desc") {
+        return sortOrder;
+    }
+    return "asc";
+}
+
+function compareResumeListSort(
+    left: Doc<"resumes">,
+    right: Doc<"resumes">,
+    sortBy: ResumeListSortBy,
+    sortOrder: ResumeListSortOrder
+): number {
+    const direction = sortOrder === "desc" ? -1 : 1;
+    const leftContent = isRecord(left.content) ? left.content : {};
+    const rightContent = isRecord(right.content) ? right.content : {};
+
+    if (sortBy === "experience") {
+        const leftExperience = parseExperienceYears(toStringValue(leftContent.experience)) ?? -1;
+        const rightExperience = parseExperienceYears(toStringValue(rightContent.experience)) ?? -1;
+        const diff = (leftExperience - rightExperience) * direction;
+        if (diff !== 0) {
+            return diff;
+        }
+    } else if (sortBy === "extractedAt") {
+        const leftTime = Date.parse(toStringValue(leftContent.extractedAt)) || 0;
+        const rightTime = Date.parse(toStringValue(rightContent.extractedAt)) || 0;
+        const diff = (leftTime - rightTime) * direction;
+        if (diff !== 0) {
+            return diff;
+        }
+    } else {
+        const leftName = toStringValue(leftContent.name).toLowerCase();
+        const rightName = toStringValue(rightContent.name).toLowerCase();
+        const diff = leftName.localeCompare(rightName) * direction;
+        if (diff !== 0) {
+            return diff;
+        }
+    }
+
+    return 0;
+}
+
+function sortResumeDocs(
+    resumes: Doc<"resumes">[],
+    options: {
+        jobDescriptionId?: string;
+        sortBy?: ResumeListSortBy;
+        sortOrder?: ResumeListSortOrder;
+    }
+): Doc<"resumes">[] {
+    if (options.sortBy) {
+        const { sortBy } = options;
+        const resolvedSortOrder = resolveResumeListSortOrder(options.sortOrder);
+        return [...resumes].sort((left, right) => compareResumeListSort(left, right, sortBy, resolvedSortOrder));
+    }
+
+    return sortByIngestRuleScore(resumes, options.jobDescriptionId);
 }
 
 function resolveListWithIngestPageWindow(requestedLimit: number | undefined, requestedOffset: number | undefined): {
@@ -868,6 +931,8 @@ export const listWithIngestDataPage = query({
         limit: v.optional(v.number()),
         offset: v.optional(v.number()),
         jobDescriptionId: v.optional(v.string()),
+        sortBy: v.optional(v.union(v.literal("name"), v.literal("experience"), v.literal("extractedAt"))),
+        sortOrder: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
         minExperience: v.optional(v.number()),
         maxExperience: v.optional(v.number()),
         education: v.optional(v.array(v.string())),
@@ -885,7 +950,11 @@ export const listWithIngestDataPage = query({
             .withIndex("by_primaryRuleScore")
             .order("desc")
             .take(overfetchLimit);
-        const sorted = sortByIngestRuleScore(candidates, jobDescriptionId)
+        const sorted = sortResumeDocs(candidates, {
+            jobDescriptionId,
+            sortBy: args.sortBy,
+            sortOrder: args.sortOrder,
+        })
             .filter((resume) => matchesResumeListFilters(resume, filters))
             .slice(0, scanLimit);
         return {
@@ -1092,6 +1161,8 @@ export const searchWithTagExpansionPage = query({
         limit: v.optional(v.number()),
         offset: v.optional(v.number()),
         jobDescriptionId: v.optional(v.string()),
+        sortBy: v.optional(v.union(v.literal("name"), v.literal("experience"), v.literal("extractedAt"))),
+        sortOrder: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
         minExperience: v.optional(v.number()),
         maxExperience: v.optional(v.number()),
         education: v.optional(v.array(v.string())),
@@ -1153,6 +1224,16 @@ export const searchWithTagExpansionPage = query({
 
         const merged = mergeResumeDocs(filteredDocs, provenanceByResumeId, jobDescriptionId, overfetchLimit)
             .filter((entry) => matchesResumeListFilters(entry.resume, filters));
+        let sorted = merged;
+        if (args.sortBy) {
+            const sortBy = args.sortBy;
+            sorted = [...merged].sort((left, right) => compareResumeListSort(
+                left.resume,
+                right.resume,
+                sortBy,
+                resolveResumeListSortOrder(args.sortOrder)
+            ));
+        }
 
         return {
             expansion: {
@@ -1161,8 +1242,8 @@ export const searchWithTagExpansionPage = query({
                 groups: keywordGroups,
                 mode,
             },
-            total: merged.length,
-            results: merged.slice(offset, offset + pageLimit),
+            total: sorted.length,
+            results: sorted.slice(offset, offset + pageLimit),
         };
     },
 });


### PR DESCRIPTION
## Summary
- push non-score convex resume sorts (name, experience, extractedAt) into the page queries used by `GET /api/resumes?source=convex`
- keep query-side pagination for sorted convex-source list and keyword-search requests
- keep score sorting on the existing local fallback path because it still depends on local match storage

## Validation
- npx vitest run apps/api/src/routes/resumes.test.ts
- npm --workspace @trends/api run typecheck
- bun run --filter '@trends/convex' typecheck\n- make check