### PR TITLE
perf(web): push convex sort windows

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -10,6 +10,8 @@ export const DEFAULT_CONVEX_RESUME_LIMIT = 200
 export const CONVEX_RESUME_PAGE_SIZE = 200
 export const MAX_CONVEX_RESUME_LIMIT = 2000
 
+export type ConvexResumeSortBy = 'experience' | 'extractedAt'
+
 export type ConvexResumeAnalysis = {
   score: number
   summary: string
@@ -658,10 +660,19 @@ function mapResumeDoc(doc: Doc<'resumes'>): ConvexResumeItem {
   }
 }
 
-export function useConvexResumes(limit: number = DEFAULT_CONVEX_RESUME_LIMIT, query?: string, jobDescriptionId?: string) {
+export function useConvexResumes(
+  limit: number = DEFAULT_CONVEX_RESUME_LIMIT,
+  query?: string,
+  jobDescriptionId?: string,
+  options?: {
+    sortBy?: ConvexResumeSortBy
+    sortOrder?: 'asc' | 'desc'
+  }
+) {
   const normalizedJobDescriptionId = jobDescriptionId?.trim() || undefined
   const normalizedQuery = query?.trim() || undefined
-  const scopeKey = `${normalizedJobDescriptionId ?? ''}::${normalizedQuery ?? ''}`
+  const resolvedSortOrder = options?.sortBy ? (options.sortOrder ?? 'desc') : undefined
+  const scopeKey = `${normalizedJobDescriptionId ?? ''}::${normalizedQuery ?? ''}::${options?.sortBy ?? ''}::${resolvedSortOrder ?? ''}`
   const mockPayload = useMemo(() => readMockConvexResumePayload(), [])
   const mockKeywordExpansion = useMemo(
     () => normalizedQuery ? buildFallbackKeywordExpansion(normalizedQuery) : null,
@@ -744,11 +755,33 @@ export function useConvexResumes(limit: number = DEFAULT_CONVEX_RESUME_LIMIT, qu
     }
   }, [mockKeywordExpansion, mockPayload, normalizedQuery])
 
+  const pagedSearchResults = useQuery(
+    api.resumes.searchWithTagExpansionPage,
+    mockPayload
+      ? 'skip'
+      : normalizedQuery && keywordExpansion && options?.sortBy
+        ? {
+            query: normalizedQuery,
+            keywordGroups: keywordExpansion.groups,
+            mode: keywordExpansion.mode,
+            sourceMappings: Object.entries(keywordExpansion.sourceMapping).map(([term, expandedFrom]) => ({
+              term,
+              expandedFrom,
+            })),
+            limit,
+            offset: 0,
+            jobDescriptionId: normalizedJobDescriptionId,
+            sortBy: options.sortBy,
+            sortOrder: resolvedSortOrder,
+          }
+        : 'skip'
+  )
+
   const searchResults = useQuery(
     api.resumes.searchWithTagExpansion,
     mockPayload
       ? 'skip'
-      : normalizedQuery && keywordExpansion
+      : normalizedQuery && keywordExpansion && !options?.sortBy
         ? {
             query: normalizedQuery,
             keywordGroups: keywordExpansion.groups,
@@ -763,11 +796,26 @@ export function useConvexResumes(limit: number = DEFAULT_CONVEX_RESUME_LIMIT, qu
         : 'skip'
   )
 
+  const pagedListResults = useQuery(
+    api.resumes.listWithIngestDataPage,
+    mockPayload
+      ? 'skip'
+      : normalizedQuery || !options?.sortBy
+        ? 'skip'
+        : {
+            limit,
+            offset: 0,
+            jobDescriptionId: normalizedJobDescriptionId,
+            sortBy: options.sortBy,
+            sortOrder: resolvedSortOrder,
+          }
+  )
+
   const listResults = useQuery(
     api.resumes.listWithIngestData,
     mockPayload
       ? 'skip'
-      : normalizedQuery ? 'skip' : { limit, jobDescriptionId: normalizedJobDescriptionId }
+      : normalizedQuery || options?.sortBy ? 'skip' : { limit, jobDescriptionId: normalizedJobDescriptionId }
   )
 
   const mappedResumes = useMemo(() => (
@@ -783,12 +831,12 @@ export function useConvexResumes(limit: number = DEFAULT_CONVEX_RESUME_LIMIT, qu
           })))
         : (mockPayload.list ?? []).slice(0, limit).map(mapResumeDoc)
       : normalizedQuery
-        ? (searchResults?.results ?? []).map((entry) => ({
+        ? ((options?.sortBy ? pagedSearchResults?.results : searchResults?.results) ?? []).map((entry) => ({
             ...mapResumeDoc(entry.resume),
             _provenance: entry.provenance,
           }))
-        : (listResults ?? []).map(mapResumeDoc)
-  ), [limit, listResults, mockKeywordExpansion, mockPayload, normalizedQuery, searchResults])
+        : ((options?.sortBy ? pagedListResults?.results : listResults) ?? []).map(mapResumeDoc)
+  ), [limit, listResults, mockKeywordExpansion, mockPayload, normalizedQuery, options?.sortBy, pagedListResults?.results, pagedSearchResults?.results, searchResults])
 
   const isLoading = mockPayload
     ? false
@@ -804,13 +852,15 @@ export function useConvexResumes(limit: number = DEFAULT_CONVEX_RESUME_LIMIT, qu
     }
 
     return normalizedQuery
-      ? (searchResults?.results?.length ?? 0) >= limit
-      : (listResults?.length ?? 0) >= limit
-  }, [limit, listResults, mockPayload, normalizedQuery, searchResults])
+      ? (((options?.sortBy ? pagedSearchResults?.results?.length : searchResults?.results?.length) ?? 0) >= limit)
+      : (((options?.sortBy ? pagedListResults?.results?.length : listResults?.length) ?? 0) >= limit)
+  }, [limit, listResults?.length, mockPayload, normalizedQuery, options?.sortBy, pagedListResults?.results?.length, pagedSearchResults?.results?.length, searchResults?.results?.length])
 
   const resolvedExpansion = mockPayload
     ? (mockPayload.search?.expansion ?? mockKeywordExpansion)
-    : searchResults?.expansion
+    : options?.sortBy
+      ? pagedSearchResults?.expansion
+      : searchResults?.expansion
 
   const [cachedState, setCachedState] = useState<{
     scopeKey: string

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -6,6 +6,7 @@ import { RESUME_HOME_RESET_STATE } from '@/lib/resume-home-navigation'
 import { rawApiClient } from '@/lib/api-helpers'
 import { getCurrentResumeAiPromptVersion } from '@/lib/analysis-utils'
 import { useResumeListState } from './useResumeListState'
+import type { ConvexResumeSortBy } from '@/hooks/useConvexResumes'
 
 let capturedExportPayload: unknown = null
 const createObjectUrlMock = vi.fn(() => 'blob:mock')
@@ -20,6 +21,10 @@ const mockState = vi.hoisted(() => ({
     limit?: number
     query?: string
     jobDescriptionId?: string
+    options?: {
+      sortBy?: ConvexResumeSortBy
+      sortOrder?: 'asc' | 'desc'
+    }
   }>,
   cloneConvexResumesOnRead: false,
   filters: {} as Record<string, unknown>,
@@ -148,8 +153,16 @@ vi.mock('@/hooks/useConvexResumes', () => ({
   DEFAULT_CONVEX_RESUME_LIMIT: 200,
   CONVEX_RESUME_PAGE_SIZE: 200,
   MAX_CONVEX_RESUME_LIMIT: 2000,
-  useConvexResumes: (limit?: number, query?: string, jobDescriptionId?: string) => {
-    mockState.useConvexResumesArgs.push({ limit, query, jobDescriptionId })
+  useConvexResumes: (
+    limit?: number,
+    query?: string,
+    jobDescriptionId?: string,
+    options?: {
+      sortBy?: ConvexResumeSortBy
+      sortOrder?: 'asc' | 'desc'
+    }
+  ) => {
+    mockState.useConvexResumesArgs.push({ limit, query, jobDescriptionId, options })
     return {
       resumes: mockState.cloneConvexResumesOnRead
         ? [...mockState.convexResumes]
@@ -356,6 +369,53 @@ describe('useResumeListState role filter regression', () => {
         limit: 200,
         query: 'CNC',
       })
+    })
+
+    mockState.filters = {
+      sortBy: 'experience',
+      sortOrder: 'desc',
+    }
+    rerender()
+
+    await waitFor(() => {
+      expect(getLastConvexArgs()).toMatchObject({
+        limit: 200,
+        options: {
+          sortBy: 'experience',
+          sortOrder: 'desc',
+        },
+      })
+    })
+  })
+
+  it('pushes experience sorting into the Convex hook for AI mode', () => {
+    mockState.filters = {
+      sortBy: 'experience',
+      sortOrder: 'asc',
+    }
+
+    renderHook(() => useResumeListState())
+
+    expect(getLastConvexArgs()).toMatchObject({
+      limit: 200,
+      options: {
+        sortBy: 'experience',
+        sortOrder: 'asc',
+      },
+    })
+  })
+
+  it('keeps name sorting local to preserve the existing UI comparator', () => {
+    mockState.filters = {
+      sortBy: 'name',
+      sortOrder: 'asc',
+    }
+
+    renderHook(() => useResumeListState())
+
+    expect(getLastConvexArgs()).toMatchObject({
+      limit: 200,
+      options: {},
     })
   })
 

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -14,6 +14,7 @@ import {
   MAX_CONVEX_RESUME_LIMIT,
   useConvexResumes,
   type ConvexResumeItem,
+  type ConvexResumeSortBy,
 } from '@/hooks/useConvexResumes'
 import { useSession } from '@/hooks/useSession'
 import { useCandidateActions } from '@/hooks/useCandidateActions'
@@ -627,19 +628,34 @@ export function useResumeListState(loadSearchHistory = false) {
     return kw
   }, [sessionKeywords])
 
+  const convexSourceSortBy = useMemo<ConvexResumeSortBy | undefined>(() => {
+    if (filters.sortBy === 'experience' || filters.sortBy === 'extractedAt') {
+      return filters.sortBy
+    }
+    return undefined
+  }, [filters.sortBy])
+  const convexSourceSortOrder = useMemo(
+    () => (convexSourceSortBy ? (filters.sortOrder ?? 'desc') : undefined),
+    [convexSourceSortBy, filters.sortOrder]
+  )
   const convexQueryScopeKey = useMemo(
     () => JSON.stringify({
       jobDescriptionId: jobDescriptionId?.trim() ?? '',
       query: expandedQuery ?? '',
+      sortBy: convexSourceSortBy ?? '',
+      sortOrder: convexSourceSortOrder ?? '',
     }),
-    [expandedQuery, jobDescriptionId]
+    [convexSourceSortBy, convexSourceSortOrder, expandedQuery, jobDescriptionId]
   )
   const {
     resumes: convexResumes,
     loading: convexLoading,
     loadingMore: convexLoadingMore,
     hasMore: convexHasMore,
-  } = useConvexResumes(requestedConvexLimit, expandedQuery, jobDescriptionId)
+  } = useConvexResumes(requestedConvexLimit, expandedQuery, jobDescriptionId, {
+    sortBy: convexSourceSortBy,
+    sortOrder: convexSourceSortOrder,
+  })
   const analysisTasks = useQuery(api.analysis_tasks.list)
   const dispatchAnalysis = useMutation(api.analysis_tasks.dispatch)
   const [analyzing, setAnalyzing] = useState(false)
@@ -1047,7 +1063,9 @@ export function useResumeListState(loadSearchHistory = false) {
         }
       })
 
-    result = [...result].sort((a: ScoredConvexResume, b: ScoredConvexResume) => b._ruleScore - a._ruleScore)
+    if (!convexSourceSortBy) {
+      result = [...result].sort((a: ScoredConvexResume, b: ScoredConvexResume) => b._ruleScore - a._ruleScore)
+    }
 
     const showBlocked = filters.showBlocked === true
     if (!showBlocked) {
@@ -1174,6 +1192,7 @@ export function useResumeListState(loadSearchHistory = false) {
     selectedExperienceLevel,
     selectedTags,
     currentPromptVersion,
+    convexSourceSortBy,
     sessionKeywords,
     sessionCollectionSource,
     sessionLocation,
@@ -1479,6 +1498,10 @@ export function useResumeListState(loadSearchHistory = false) {
   ])
 
   const displayedResumes = useMemo(() => {
+    if (mode === 'ai' && convexSourceSortBy) {
+      return enrichedResumes
+    }
+
     const sortBy = filters.sortBy ?? 'score'
     const sortOrder = filters.sortOrder ?? 'desc'
     const direction = sortOrder === 'asc' ? 1 : -1
@@ -1501,7 +1524,7 @@ export function useResumeListState(loadSearchHistory = false) {
       const scoreB = b.match?.score ?? b.ruleScore ?? 0
       return (scoreA - scoreB) * direction
     })
-  }, [enrichedResumes, filters.sortBy, filters.sortOrder])
+  }, [convexSourceSortBy, enrichedResumes, filters.sortBy, filters.sortOrder, mode])
 
   const displayedResumeMap = useMemo(
     () => new Map(displayedResumes.map((entry) => [entry.key, entry.resume])),


### PR DESCRIPTION
## Summary
- push safe AI-mode Convex sorts (`experience`, `extractedAt`) into the direct web Convex hook instead of re-sorting the loaded window locally
- reset the incremental Convex window and cache when the sort path changes so stale order does not leak across modes
- keep `name` sorting local for now because the UI currently uses a locale-specific comparator

## Validation
- npm --workspace @trends/web run test -- src/hooks/useResumeListState.test.tsx
- npm --workspace @trends/web run typecheck
- make check