### PR TITLE
perf(web): paginate convex resume hook

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.test.ts
+++ b/apps/web/src/hooks/useConvexResumes.test.ts
@@ -1,0 +1,165 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useConvexResumes } from './useConvexResumes'
+
+const loadMoreMock = vi.fn()
+const rawApiGetMock = vi.fn(async (path?: unknown, options?: unknown) => {
+  void path
+  void options
+  return {
+  data: {
+    success: true,
+    summary: {
+      groups: [{ original: 'cnc', variants: ['cnc'] }],
+      mode: 'AND' as const,
+      expandedTo: ['cnc'],
+      sourceMapping: {},
+    },
+  },
+  }
+})
+
+type PaginatedResult = {
+  results: Array<Record<string, unknown>>
+  status: 'LoadingFirstPage' | 'CanLoadMore' | 'LoadingMore' | 'Exhausted'
+  isLoading: boolean
+  loadMore: typeof loadMoreMock
+}
+
+const usePaginatedQueryMock = vi.fn<(
+  query: unknown,
+  args: unknown,
+  options: { initialNumItems: number }
+) => PaginatedResult>()
+
+vi.mock('convex/react', () => ({
+  usePaginatedQuery: (query: unknown, args: unknown, options: { initialNumItems: number }) =>
+    usePaginatedQueryMock(query, args, options),
+}))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: {
+    GET: (path: unknown, options?: unknown) => rawApiGetMock(path, options),
+  },
+}))
+
+function buildResumeDoc(id: string, name: string): Record<string, unknown> {
+  return {
+    _id: id,
+    externalId: `ext-${id}`,
+    source: 'hr.job5156.com',
+    tags: [],
+    crawledAt: 1_700_000_000_000,
+    content: {
+      name,
+      experience: '5 years',
+      education: 'Bachelor',
+      location: 'Dongguan',
+      selfIntro: 'Intro',
+      jobIntention: 'Sales Engineer',
+      expectedSalary: '10k-20k',
+      extractedAt: '2026-03-01T00:00:00.000Z',
+    },
+    ingestData: {
+      industryTags: [],
+      synonymHits: [],
+      brandHits: [],
+      companyHits: [],
+      ruleScores: {},
+      experienceLevel: 'mid',
+      computedAt: 1_700_000_000_000,
+      skillsVersion: 1,
+    },
+  }
+}
+
+function buildSearchEntry(id: string, name: string): Record<string, unknown> {
+  return {
+    resume: buildResumeDoc(id, name),
+    provenance: [{ term: 'cnc', source: 'searchText' }],
+  }
+}
+
+describe('useConvexResumes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    usePaginatedQueryMock.mockImplementation((_query, args) => ({
+      results: args === 'skip' ? [] : [buildResumeDoc('resume-1', 'Alice')],
+      status: 'Exhausted',
+      isLoading: false,
+      loadMore: loadMoreMock,
+    }))
+  })
+
+  it('loads additional list pages when the requested limit exceeds the loaded page', async () => {
+    usePaginatedQueryMock.mockImplementation((_query, args) => ({
+      results: args === 'skip'
+        ? []
+        : [buildResumeDoc('resume-1', 'Alice'), buildResumeDoc('resume-2', 'Bob')],
+      status: args === 'skip' ? 'Exhausted' : 'CanLoadMore',
+      isLoading: false,
+      loadMore: loadMoreMock,
+    }))
+
+    renderHook(() => useConvexResumes(400))
+
+    await waitFor(() => {
+      expect(loadMoreMock).toHaveBeenCalledWith(200)
+    })
+  })
+
+  it('returns only the visible slice when more paginated results are already loaded', () => {
+    usePaginatedQueryMock.mockImplementation((_query, args) => ({
+      results: args === 'skip'
+        ? []
+        : [
+            buildResumeDoc('resume-1', 'Alice'),
+            buildResumeDoc('resume-2', 'Bob'),
+            buildResumeDoc('resume-3', 'Carla'),
+          ],
+      status: 'Exhausted',
+      isLoading: false,
+      loadMore: loadMoreMock,
+    }))
+
+    const { result } = renderHook(() => useConvexResumes(2))
+
+    expect(result.current.resumes.map((resume) => resume.name)).toEqual(['Alice', 'Bob'])
+    expect(result.current.hasMore).toBe(true)
+  })
+
+  it('forwards safe sort options to the paginated list query', () => {
+    renderHook(() => useConvexResumes(200, undefined, 'jd-1', { sortBy: 'experience', sortOrder: 'asc' }))
+
+    const listCall = usePaginatedQueryMock.mock.calls.find(([, args]) => args !== 'skip' && !('query' in (args as Record<string, unknown>)))
+
+    expect(listCall?.[1]).toMatchObject({
+      jobDescriptionId: 'jd-1',
+      sortBy: 'experience',
+      sortOrder: 'asc',
+    })
+  })
+
+  it('uses the paginated search query after keyword expansion resolves', async () => {
+    usePaginatedQueryMock.mockImplementation((_query, args) => ({
+      results: args === 'skip' ? [] : [buildSearchEntry('resume-1', 'Alice')],
+      status: 'Exhausted',
+      isLoading: false,
+      loadMore: loadMoreMock,
+    }))
+
+    renderHook(() => useConvexResumes(200, 'CNC'))
+
+    await waitFor(() => {
+      expect(rawApiGetMock).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      const searchCall = usePaginatedQueryMock.mock.calls.find(([, args]) => args !== 'skip' && 'query' in (args as Record<string, unknown>))
+      expect(searchCall?.[1]).toMatchObject({
+        query: 'CNC',
+        keywordGroups: [{ original: 'cnc', variants: ['cnc'] }],
+      })
+    })
+  })
+})

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { normalizeProfileUrlForDisplay, normalizeSharedResumeFields, parseKeywordQuery } from '@trends/shared'
-import { useQuery } from 'convex/react'
+import { usePaginatedQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
 import { rawApiClient } from '@/lib/api-helpers'
@@ -672,7 +672,7 @@ export function useConvexResumes(
   const normalizedJobDescriptionId = jobDescriptionId?.trim() || undefined
   const normalizedQuery = query?.trim() || undefined
   const resolvedSortOrder = options?.sortBy ? (options.sortOrder ?? 'desc') : undefined
-  const scopeKey = `${normalizedJobDescriptionId ?? ''}::${normalizedQuery ?? ''}::${options?.sortBy ?? ''}::${resolvedSortOrder ?? ''}`
+  const initialNumItems = Math.min(limit, CONVEX_RESUME_PAGE_SIZE)
   const mockPayload = useMemo(() => readMockConvexResumePayload(), [])
   const mockKeywordExpansion = useMemo(
     () => normalizedQuery ? buildFallbackKeywordExpansion(normalizedQuery) : null,
@@ -755,11 +755,11 @@ export function useConvexResumes(
     }
   }, [mockKeywordExpansion, mockPayload, normalizedQuery])
 
-  const pagedSearchResults = useQuery(
-    api.resumes.searchWithTagExpansionPage,
+  const paginatedSearchResults = usePaginatedQuery(
+    api.resumes.searchWithTagExpansionPaginated,
     mockPayload
       ? 'skip'
-      : normalizedQuery && keywordExpansion && options?.sortBy
+      : normalizedQuery && keywordExpansion
         ? {
             query: normalizedQuery,
             keywordGroups: keywordExpansion.groups,
@@ -768,54 +768,65 @@ export function useConvexResumes(
               term,
               expandedFrom,
             })),
-            limit,
-            offset: 0,
             jobDescriptionId: normalizedJobDescriptionId,
-            sortBy: options.sortBy,
-            sortOrder: resolvedSortOrder,
+            ...(options?.sortBy ? {
+              sortBy: options.sortBy,
+              sortOrder: resolvedSortOrder,
+            } : {}),
           }
-        : 'skip'
+        : 'skip',
+    {
+      initialNumItems,
+    }
   )
 
-  const searchResults = useQuery(
-    api.resumes.searchWithTagExpansion,
+  const paginatedListResults = usePaginatedQuery(
+    api.resumes.listWithIngestDataPaginated,
     mockPayload
       ? 'skip'
-      : normalizedQuery && keywordExpansion && !options?.sortBy
-        ? {
-            query: normalizedQuery,
-            keywordGroups: keywordExpansion.groups,
-            mode: keywordExpansion.mode,
-            sourceMappings: Object.entries(keywordExpansion.sourceMapping).map(([term, expandedFrom]) => ({
-              term,
-              expandedFrom,
-            })),
-            limit,
-            jobDescriptionId: normalizedJobDescriptionId,
-          }
-        : 'skip'
-  )
-
-  const pagedListResults = useQuery(
-    api.resumes.listWithIngestDataPage,
-    mockPayload
-      ? 'skip'
-      : normalizedQuery || !options?.sortBy
+      : normalizedQuery
         ? 'skip'
         : {
-            limit,
-            offset: 0,
             jobDescriptionId: normalizedJobDescriptionId,
-            sortBy: options.sortBy,
-            sortOrder: resolvedSortOrder,
-          }
+            ...(options?.sortBy ? {
+              sortBy: options.sortBy,
+              sortOrder: resolvedSortOrder,
+            } : {}),
+          },
+    {
+      initialNumItems,
+    }
   )
 
-  const listResults = useQuery(
-    api.resumes.listWithIngestData,
-    mockPayload
-      ? 'skip'
-      : normalizedQuery || options?.sortBy ? 'skip' : { limit, jobDescriptionId: normalizedJobDescriptionId }
+  const activePaginatedStatus = normalizedQuery ? paginatedSearchResults.status : paginatedListResults.status
+  const activePaginatedResultsLength = normalizedQuery ? paginatedSearchResults.results.length : paginatedListResults.results.length
+  const activePaginatedLoadMore = normalizedQuery ? paginatedSearchResults.loadMore : paginatedListResults.loadMore
+
+  useEffect(() => {
+    if (mockPayload || limit <= 0) {
+      return
+    }
+
+    if (activePaginatedStatus !== 'CanLoadMore' || activePaginatedResultsLength >= limit) {
+      return
+    }
+
+    activePaginatedLoadMore(Math.min(CONVEX_RESUME_PAGE_SIZE, limit - activePaginatedResultsLength))
+  }, [
+    activePaginatedLoadMore,
+    activePaginatedResultsLength,
+    activePaginatedStatus,
+    limit,
+    mockPayload,
+  ])
+
+  const visibleSearchResults = useMemo(
+    () => paginatedSearchResults.results.slice(0, limit),
+    [limit, paginatedSearchResults.results]
+  )
+  const visibleListResults = useMemo(
+    () => paginatedListResults.results.slice(0, limit),
+    [limit, paginatedListResults.results]
   )
 
   const mappedResumes = useMemo(() => (
@@ -831,18 +842,18 @@ export function useConvexResumes(
           })))
         : (mockPayload.list ?? []).slice(0, limit).map(mapResumeDoc)
       : normalizedQuery
-        ? ((options?.sortBy ? pagedSearchResults?.results : searchResults?.results) ?? []).map((entry) => ({
+        ? visibleSearchResults.map((entry) => ({
             ...mapResumeDoc(entry.resume),
             _provenance: entry.provenance,
           }))
-        : ((options?.sortBy ? pagedListResults?.results : listResults) ?? []).map(mapResumeDoc)
-  ), [limit, listResults, mockKeywordExpansion, mockPayload, normalizedQuery, options?.sortBy, pagedListResults?.results, pagedSearchResults?.results, searchResults])
+        : visibleListResults.map(mapResumeDoc)
+  ), [limit, mockKeywordExpansion, mockPayload, normalizedQuery, visibleListResults, visibleSearchResults])
 
   const isLoading = mockPayload
     ? false
     : normalizedQuery
-      ? (expansionLoading || searchResults === undefined)
-      : listResults === undefined
+      ? (expansionLoading || paginatedSearchResults.status === 'LoadingFirstPage')
+      : paginatedListResults.status === 'LoadingFirstPage'
 
   const hasMore = useMemo(() => {
     if (mockPayload) {
@@ -851,64 +862,22 @@ export function useConvexResumes(
         : (mockPayload.list?.length ?? 0) > limit
     }
 
-    return normalizedQuery
-      ? (((options?.sortBy ? pagedSearchResults?.results?.length : searchResults?.results?.length) ?? 0) >= limit)
-      : (((options?.sortBy ? pagedListResults?.results?.length : listResults?.length) ?? 0) >= limit)
-  }, [limit, listResults?.length, mockPayload, normalizedQuery, options?.sortBy, pagedListResults?.results?.length, pagedSearchResults?.results?.length, searchResults?.results?.length])
+    return activePaginatedResultsLength > limit || activePaginatedStatus === 'CanLoadMore' || activePaginatedStatus === 'LoadingMore'
+  }, [activePaginatedResultsLength, activePaginatedStatus, limit, mockPayload, normalizedQuery])
 
   const resolvedExpansion = mockPayload
     ? (mockPayload.search?.expansion ?? mockKeywordExpansion)
-    : options?.sortBy
-      ? pagedSearchResults?.expansion
-      : searchResults?.expansion
+    : keywordExpansion
 
-  const [cachedState, setCachedState] = useState<{
-    scopeKey: string
-    resumes: ConvexResumeItem[]
-    hasMore: boolean
-    expansion: unknown
-  }>({
-    scopeKey,
-    resumes: [],
-    hasMore: false,
-    expansion: undefined,
-  })
-
-  useEffect(() => {
-    setCachedState((current) => (
-      current.scopeKey === scopeKey
-        ? current
-        : {
-            scopeKey,
-            resumes: [],
-            hasMore: false,
-            expansion: undefined,
-          }
-    ))
-  }, [scopeKey])
-
-  useEffect(() => {
-    if (isLoading) {
-      return
-    }
-
-    setCachedState({
-      scopeKey,
-      resumes: mappedResumes,
-      hasMore,
-      expansion: resolvedExpansion,
-    })
-  }, [hasMore, isLoading, mappedResumes, resolvedExpansion, scopeKey])
-
-  const hasCachedResumes = cachedState.scopeKey === scopeKey && cachedState.resumes.length > 0
-  const loadingMore = isLoading && hasCachedResumes
+  const loadingMore = !mockPayload
+    && activePaginatedStatus === 'LoadingMore'
 
   return {
-    resumes: loadingMore ? cachedState.resumes : mappedResumes,
-    loading: isLoading && !hasCachedResumes,
+    resumes: mappedResumes,
+    loading: isLoading,
     loadingMore,
-    hasMore: loadingMore ? cachedState.hasMore : hasMore,
+    hasMore,
     jobDescriptionId: normalizedJobDescriptionId,
-    expansion: loadingMore ? cachedState.expansion : resolvedExpansion,
+    expansion: resolvedExpansion,
   }
 }

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -1,4 +1,4 @@
-import { action, internalMutation, internalQuery, mutation, query } from "./_generated/server";
+import { action, internalMutation, internalQuery, mutation, query, type QueryCtx } from "./_generated/server";
 import { api } from "./_generated/api";
 import type { Doc } from "./_generated/dataModel";
 import { paginationOptsValidator } from "convex/server";
@@ -201,6 +201,27 @@ type ResumeListFilterArgs = {
 
 type ResumeListSortBy = "name" | "experience" | "extractedAt";
 type ResumeListSortOrder = "asc" | "desc";
+
+type ResumeListPageArgs = ResumeListFilterArgs & {
+    limit?: number;
+    offset?: number;
+    jobDescriptionId?: string;
+    sortBy?: ResumeListSortBy;
+    sortOrder?: ResumeListSortOrder;
+};
+
+type SearchWithTagExpansionPageArgs = ResumeListPageArgs & {
+    query: string;
+    keywordGroups: Array<{
+        original: string;
+        variants: string[];
+    }>;
+    mode?: "AND" | "OR";
+    sourceMappings?: Array<{
+        term: string;
+        expandedFrom: string;
+    }>;
+};
 
 type DeleteResumesResult = {
     requested: number;
@@ -556,6 +577,41 @@ function resolveListWithIngestPageWindow(requestedLimit: number | undefined, req
     };
 }
 
+function resolvePaginatedResumeOffsetCursor(cursor: string | null | undefined): number {
+    if (!cursor) {
+        return 0;
+    }
+
+    const parsed = Number.parseInt(cursor, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return 0;
+    }
+
+    return parsed;
+}
+
+function resolvePaginatedResumePageLimit(numItems: number | undefined): number {
+    if (typeof numItems !== "number" || !Number.isFinite(numItems)) {
+        return DEFAULT_RESUME_LIMIT;
+    }
+
+    return Math.min(Math.max(Math.trunc(numItems), 1), MAX_SAFE_LIST_WITH_INGEST_LIMIT);
+}
+
+function buildPaginatedOffsetResult<T>(page: T[], total: number, offset: number): {
+    page: T[];
+    continueCursor: string;
+    isDone: boolean;
+} {
+    const nextOffset = offset + page.length;
+    const isDone = nextOffset >= total;
+    return {
+        page,
+        continueCursor: isDone ? "" : String(nextOffset),
+        isDone,
+    };
+}
+
 export function resolveResumeScanBatchSize(requestedLimit: number | undefined): number {
     const normalizedLimit = typeof requestedLimit === "number" && Number.isFinite(requestedLimit)
         ? Math.trunc(requestedLimit)
@@ -845,6 +901,123 @@ function mergeResumeDocs(
         .slice(0, limit);
 }
 
+async function runListWithIngestDataPageQuery(
+    ctx: QueryCtx,
+    args: ResumeListPageArgs
+): Promise<{
+    total: number;
+    results: Doc<"resumes">[];
+}> {
+    const { offset, pageLimit, scanLimit, overfetchLimit } = resolveListWithIngestPageWindow(args.limit, args.offset);
+    const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
+    const filters = normalizeResumeListFilters(args);
+    const candidates = await ctx.db
+        .query("resumes")
+        .withIndex("by_primaryRuleScore")
+        .order("desc")
+        .take(overfetchLimit);
+    const sorted = sortResumeDocs(candidates, {
+        jobDescriptionId,
+        sortBy: args.sortBy,
+        sortOrder: args.sortOrder,
+    })
+        .filter((resume) => matchesResumeListFilters(resume, filters))
+        .slice(0, scanLimit);
+
+    return {
+        total: sorted.length,
+        results: sorted.slice(offset, offset + pageLimit),
+    };
+}
+
+async function runSearchWithTagExpansionPageQuery(
+    ctx: QueryCtx,
+    args: SearchWithTagExpansionPageArgs
+): Promise<{
+    expansion: {
+        original: string;
+        expanded: string[];
+        groups: TagExpansionKeywordGroup[];
+        mode: "AND" | "OR";
+    };
+    total: number;
+    results: Array<{ resume: Doc<"resumes">; provenance: SearchProvenance[] }>;
+}> {
+    const { offset, pageLimit, overfetchLimit } = resolveListWithIngestPageWindow(args.limit, args.offset);
+    const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
+    const filters = normalizeResumeListFilters(args);
+    const mode = args.mode ?? "AND";
+    const keywordGroups = normalizeTagExpansionKeywordGroups(args.keywordGroups);
+    const expandedTerms = collectExpandedTerms(keywordGroups);
+
+    if (expandedTerms.length === 0 || keywordGroups.length === 0) {
+        return {
+            expansion: {
+                original: args.query,
+                expanded: [],
+                groups: [],
+                mode,
+            },
+            total: 0,
+            results: [],
+        };
+    }
+
+    const sourceMapping = Object.fromEntries(
+        (args.sourceMappings ?? []).map((entry) => [entry.term, entry.expandedFrom])
+    );
+    const provenanceByResumeId = new Map<string, SearchProvenance[]>();
+    const searchQuery = buildTagExpansionSearchQuery(keywordGroups, mode);
+
+    const matches = searchQuery
+        ? await ctx.db
+            .query("resumes")
+            .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery))
+            .take(overfetchLimit)
+        : [];
+
+    const filteredDocs = matches.filter((doc) => {
+        const normalizedSearchText = (doc.searchText || "").toLowerCase();
+        const matched = matchesTagExpansionSearchText(normalizedSearchText, keywordGroups, mode);
+
+        if (!matched) {
+            return false;
+        }
+
+        const provenance = collectSearchTextProvenance(normalizedSearchText, keywordGroups, sourceMapping);
+        if (provenance.length === 0) {
+            return false;
+        }
+
+        provenanceByResumeId.set(String(doc._id), provenance);
+        return true;
+    });
+
+    const merged = mergeResumeDocs(filteredDocs, provenanceByResumeId, jobDescriptionId, overfetchLimit)
+        .filter((entry) => matchesResumeListFilters(entry.resume, filters));
+    let sorted = merged;
+    if (args.sortBy) {
+        const sortBy = args.sortBy;
+        sorted = [...merged].sort((left, right) => compareResumeListSort(
+            left.resume,
+            right.resume,
+            sortBy,
+            resolveResumeListSortOrder(args.sortOrder)
+        ));
+    }
+
+    return {
+        expansion: {
+            original: args.query,
+            expanded: expandedTerms,
+            groups: keywordGroups,
+            mode,
+        },
+        total: sorted.length,
+        results: sorted.slice(offset, offset + pageLimit),
+    };
+}
+
 export const count = action({
     args: {},
     handler: async (ctx) => {
@@ -941,26 +1114,33 @@ export const listWithIngestDataPage = query({
         minSalary: v.optional(v.number()),
         maxSalary: v.optional(v.number()),
     },
+    handler: async (ctx, args) => runListWithIngestDataPageQuery(ctx, args),
+});
+
+export const listWithIngestDataPaginated = query({
+    args: {
+        paginationOpts: paginationOptsValidator,
+        jobDescriptionId: v.optional(v.string()),
+        sortBy: v.optional(v.union(v.literal("name"), v.literal("experience"), v.literal("extractedAt"))),
+        sortOrder: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
+        minExperience: v.optional(v.number()),
+        maxExperience: v.optional(v.number()),
+        education: v.optional(v.array(v.string())),
+        skills: v.optional(v.array(v.string())),
+        locations: v.optional(v.array(v.string())),
+        minSalary: v.optional(v.number()),
+        maxSalary: v.optional(v.number()),
+    },
     handler: async (ctx, args) => {
-        const { offset, pageLimit, scanLimit, overfetchLimit } = resolveListWithIngestPageWindow(args.limit, args.offset);
-        const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
-        const filters = normalizeResumeListFilters(args);
-        const candidates = await ctx.db
-            .query("resumes")
-            .withIndex("by_primaryRuleScore")
-            .order("desc")
-            .take(overfetchLimit);
-        const sorted = sortResumeDocs(candidates, {
-            jobDescriptionId,
-            sortBy: args.sortBy,
-            sortOrder: args.sortOrder,
-        })
-            .filter((resume) => matchesResumeListFilters(resume, filters))
-            .slice(0, scanLimit);
-        return {
-            total: sorted.length,
-            results: sorted.slice(offset, offset + pageLimit),
-        };
+        const offset = resolvePaginatedResumeOffsetCursor(args.paginationOpts.cursor);
+        const limit = resolvePaginatedResumePageLimit(args.paginationOpts.numItems);
+        const page = await runListWithIngestDataPageQuery(ctx, {
+            ...args,
+            limit,
+            offset,
+        });
+
+        return buildPaginatedOffsetResult(page.results, page.total, offset);
     },
 });
 
@@ -1171,80 +1351,43 @@ export const searchWithTagExpansionPage = query({
         minSalary: v.optional(v.number()),
         maxSalary: v.optional(v.number()),
     },
+    handler: async (ctx, args) => runSearchWithTagExpansionPageQuery(ctx, args),
+});
+
+export const searchWithTagExpansionPaginated = query({
+    args: {
+        paginationOpts: paginationOptsValidator,
+        query: v.string(),
+        keywordGroups: v.array(v.object({
+            original: v.string(),
+            variants: v.array(v.string()),
+        })),
+        mode: v.optional(v.union(v.literal("AND"), v.literal("OR"))),
+        sourceMappings: v.optional(v.array(v.object({
+            term: v.string(),
+            expandedFrom: v.string(),
+        }))),
+        jobDescriptionId: v.optional(v.string()),
+        sortBy: v.optional(v.union(v.literal("name"), v.literal("experience"), v.literal("extractedAt"))),
+        sortOrder: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
+        minExperience: v.optional(v.number()),
+        maxExperience: v.optional(v.number()),
+        education: v.optional(v.array(v.string())),
+        skills: v.optional(v.array(v.string())),
+        locations: v.optional(v.array(v.string())),
+        minSalary: v.optional(v.number()),
+        maxSalary: v.optional(v.number()),
+    },
     handler: async (ctx, args) => {
-        const { offset, pageLimit, overfetchLimit } = resolveListWithIngestPageWindow(args.limit, args.offset);
-        const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
-        const filters = normalizeResumeListFilters(args);
-        const mode = args.mode ?? "AND";
-        const keywordGroups = normalizeTagExpansionKeywordGroups(args.keywordGroups);
-        const expandedTerms = collectExpandedTerms(keywordGroups);
-
-        if (expandedTerms.length === 0 || keywordGroups.length === 0) {
-            return {
-                expansion: {
-                    original: args.query,
-                    expanded: [],
-                    groups: [],
-                    mode,
-                },
-                total: 0,
-                results: [],
-            };
-        }
-
-        const sourceMapping = Object.fromEntries(
-            (args.sourceMappings ?? []).map((entry) => [entry.term, entry.expandedFrom])
-        );
-        const provenanceByResumeId = new Map<string, SearchProvenance[]>();
-        const searchQuery = buildTagExpansionSearchQuery(keywordGroups, mode);
-
-        const matches = searchQuery
-            ? await ctx.db
-                .query("resumes")
-                .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery))
-                .take(overfetchLimit)
-            : [];
-
-        const filteredDocs = matches.filter((doc) => {
-            const normalizedSearchText = (doc.searchText || "").toLowerCase();
-            const matched = matchesTagExpansionSearchText(normalizedSearchText, keywordGroups, mode);
-
-            if (!matched) {
-                return false;
-            }
-
-            const provenance = collectSearchTextProvenance(normalizedSearchText, keywordGroups, sourceMapping);
-            if (provenance.length === 0) {
-                return false;
-            }
-
-            provenanceByResumeId.set(String(doc._id), provenance);
-            return true;
+        const offset = resolvePaginatedResumeOffsetCursor(args.paginationOpts.cursor);
+        const limit = resolvePaginatedResumePageLimit(args.paginationOpts.numItems);
+        const page = await runSearchWithTagExpansionPageQuery(ctx, {
+            ...args,
+            limit,
+            offset,
         });
 
-        const merged = mergeResumeDocs(filteredDocs, provenanceByResumeId, jobDescriptionId, overfetchLimit)
-            .filter((entry) => matchesResumeListFilters(entry.resume, filters));
-        let sorted = merged;
-        if (args.sortBy) {
-            const sortBy = args.sortBy;
-            sorted = [...merged].sort((left, right) => compareResumeListSort(
-                left.resume,
-                right.resume,
-                sortBy,
-                resolveResumeListSortOrder(args.sortOrder)
-            ));
-        }
-
-        return {
-            expansion: {
-                original: args.query,
-                expanded: expandedTerms,
-                groups: keywordGroups,
-                mode,
-            },
-            total: sorted.length,
-            results: sorted.slice(offset, offset + pageLimit),
-        };
+        return buildPaginatedOffsetResult(page.results, page.total, offset);
     },
 });
 


### PR DESCRIPTION
## Summary
- switch the direct web Convex resume hook from increasing-limit re-fetches to paginated page-query loading
- add paginated wrappers around the existing Convex page queries so list/search behavior stays aligned with the current offset/limit logic
- keep the visible resume window sliced to the requested limit so resets still behave like today while load-more stops re-downloading prior pages

## Validation
- bun run --filter '@trends/convex' typecheck\n- npm --workspace @trends/web run test -- src/hooks/useConvexResumes.test.ts src/hooks/useResumeListState.test.tsx\n- npm --workspace @trends/web run typecheck\n- make check