### PR TITLE
perf(web): push convex base filters

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.test.ts
+++ b/apps/web/src/hooks/useConvexResumes.test.ts
@@ -140,6 +140,27 @@ describe('useConvexResumes', () => {
     })
   })
 
+  it('forwards safe base filters to the paginated list query', () => {
+    renderHook(() => useConvexResumes(200, undefined, 'jd-1', {
+      filters: {
+        minExperience: 3,
+        maxExperience: 8,
+        education: ['bachelor'],
+        locations: ['Dongguan'],
+      },
+    }))
+
+    const listCall = usePaginatedQueryMock.mock.calls.find(([, args]) => args !== 'skip' && !('query' in (args as Record<string, unknown>)))
+
+    expect(listCall?.[1]).toMatchObject({
+      jobDescriptionId: 'jd-1',
+      minExperience: 3,
+      maxExperience: 8,
+      education: ['bachelor'],
+      locations: ['Dongguan'],
+    })
+  })
+
   it('uses the paginated search query after keyword expansion resolves', async () => {
     usePaginatedQueryMock.mockImplementation((_query, args) => ({
       results: args === 'skip' ? [] : [buildSearchEntry('resume-1', 'Alice')],

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -12,6 +12,13 @@ export const MAX_CONVEX_RESUME_LIMIT = 2000
 
 export type ConvexResumeSortBy = 'experience' | 'extractedAt'
 
+export type ConvexResumeFilters = {
+  minExperience?: number
+  maxExperience?: number
+  education?: string[]
+  locations?: string[]
+}
+
 export type ConvexResumeAnalysis = {
   score: number
   summary: string
@@ -667,6 +674,7 @@ export function useConvexResumes(
   options?: {
     sortBy?: ConvexResumeSortBy
     sortOrder?: 'asc' | 'desc'
+    filters?: ConvexResumeFilters
   }
 ) {
   const normalizedJobDescriptionId = jobDescriptionId?.trim() || undefined
@@ -769,6 +777,7 @@ export function useConvexResumes(
               expandedFrom,
             })),
             jobDescriptionId: normalizedJobDescriptionId,
+            ...(options?.filters ?? {}),
             ...(options?.sortBy ? {
               sortBy: options.sortBy,
               sortOrder: resolvedSortOrder,
@@ -788,6 +797,7 @@ export function useConvexResumes(
         ? 'skip'
         : {
             jobDescriptionId: normalizedJobDescriptionId,
+            ...(options?.filters ?? {}),
             ...(options?.sortBy ? {
               sortBy: options.sortBy,
               sortOrder: resolvedSortOrder,

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -6,7 +6,7 @@ import { RESUME_HOME_RESET_STATE } from '@/lib/resume-home-navigation'
 import { rawApiClient } from '@/lib/api-helpers'
 import { getCurrentResumeAiPromptVersion } from '@/lib/analysis-utils'
 import { useResumeListState } from './useResumeListState'
-import type { ConvexResumeSortBy } from '@/hooks/useConvexResumes'
+import type { ConvexResumeFilters, ConvexResumeSortBy } from '@/hooks/useConvexResumes'
 
 let capturedExportPayload: unknown = null
 const createObjectUrlMock = vi.fn(() => 'blob:mock')
@@ -24,6 +24,7 @@ const mockState = vi.hoisted(() => ({
     options?: {
       sortBy?: ConvexResumeSortBy
       sortOrder?: 'asc' | 'desc'
+      filters?: ConvexResumeFilters
     }
   }>,
   cloneConvexResumesOnRead: false,
@@ -160,6 +161,7 @@ vi.mock('@/hooks/useConvexResumes', () => ({
     options?: {
       sortBy?: ConvexResumeSortBy
       sortOrder?: 'asc' | 'desc'
+      filters?: ConvexResumeFilters
     }
   ) => {
     mockState.useConvexResumesArgs.push({ limit, query, jobDescriptionId, options })
@@ -401,6 +403,29 @@ describe('useResumeListState role filter regression', () => {
       options: {
         sortBy: 'experience',
         sortOrder: 'asc',
+      },
+    })
+  })
+
+  it('pushes safe base filters into the Convex hook for AI mode', () => {
+    mockState.filters = {
+      minExperience: 3,
+      maxExperience: 8,
+      education: ['bachelor'],
+      locations: ['Dongguan'],
+    }
+
+    renderHook(() => useResumeListState())
+
+    expect(getLastConvexArgs()).toMatchObject({
+      limit: 200,
+      options: {
+        filters: {
+          minExperience: 3,
+          maxExperience: 8,
+          education: ['bachelor'],
+          locations: ['Dongguan'],
+        },
       },
     })
   })

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_CONVEX_RESUME_LIMIT,
   MAX_CONVEX_RESUME_LIMIT,
   useConvexResumes,
+  type ConvexResumeFilters,
   type ConvexResumeItem,
   type ConvexResumeSortBy,
 } from '@/hooks/useConvexResumes'
@@ -638,14 +639,25 @@ export function useResumeListState(loadSearchHistory = false) {
     () => (convexSourceSortBy ? (filters.sortOrder ?? 'desc') : undefined),
     [convexSourceSortBy, filters.sortOrder]
   )
+  const convexSourceFilters = useMemo<ConvexResumeFilters | undefined>(() => {
+    const normalized: ConvexResumeFilters = {
+      ...(typeof filters.minExperience === 'number' ? { minExperience: filters.minExperience } : {}),
+      ...(typeof filters.maxExperience === 'number' ? { maxExperience: filters.maxExperience } : {}),
+      ...(Array.isArray(filters.education) && filters.education.length > 0 ? { education: filters.education } : {}),
+      ...(Array.isArray(filters.locations) && filters.locations.length > 0 ? { locations: filters.locations } : {}),
+    }
+
+    return Object.keys(normalized).length > 0 ? normalized : undefined
+  }, [filters.education, filters.locations, filters.maxExperience, filters.minExperience])
   const convexQueryScopeKey = useMemo(
     () => JSON.stringify({
       jobDescriptionId: jobDescriptionId?.trim() ?? '',
       query: expandedQuery ?? '',
       sortBy: convexSourceSortBy ?? '',
       sortOrder: convexSourceSortOrder ?? '',
+      filters: convexSourceFilters ?? null,
     }),
-    [convexSourceSortBy, convexSourceSortOrder, expandedQuery, jobDescriptionId]
+    [convexSourceFilters, convexSourceSortBy, convexSourceSortOrder, expandedQuery, jobDescriptionId]
   )
   const {
     resumes: convexResumes,
@@ -653,6 +665,7 @@ export function useResumeListState(loadSearchHistory = false) {
     loadingMore: convexLoadingMore,
     hasMore: convexHasMore,
   } = useConvexResumes(requestedConvexLimit, expandedQuery, jobDescriptionId, {
+    filters: convexSourceFilters,
     sortBy: convexSourceSortBy,
     sortOrder: convexSourceSortOrder,
   })


### PR DESCRIPTION
## Summary
- forward the safe AI-mode base filters (`locations`, `minExperience`, `maxExperience`, `education`) into the direct Convex hook queries
- keep the existing local filter logic in place for parity while reducing how many resumes the web path has to load and post-filter
- include the forwarded filter state in the direct Convex hook scope so the paginated query path stays aligned with the active filter set

## Validation
- npm --workspace @trends/web run test -- src/hooks/useConvexResumes.test.ts src/hooks/useResumeListState.test.tsx
- npm --workspace @trends/web run typecheck
- make check