### PR TITLE
fix(web): align ai skills and salary filters

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.test.ts
+++ b/apps/web/src/hooks/useConvexResumes.test.ts
@@ -146,7 +146,10 @@ describe('useConvexResumes', () => {
         minExperience: 3,
         maxExperience: 8,
         education: ['bachelor'],
+        skills: ['fanuc'],
         locations: ['Dongguan'],
+        minSalary: 10,
+        maxSalary: 20,
       },
     }))
 
@@ -157,7 +160,10 @@ describe('useConvexResumes', () => {
       minExperience: 3,
       maxExperience: 8,
       education: ['bachelor'],
+      skills: ['fanuc'],
       locations: ['Dongguan'],
+      minSalary: 10,
+      maxSalary: 20,
     })
   })
 

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -16,7 +16,10 @@ export type ConvexResumeFilters = {
   minExperience?: number
   maxExperience?: number
   education?: string[]
+  skills?: string[]
   locations?: string[]
+  minSalary?: number
+  maxSalary?: number
 }
 
 export type ConvexResumeAnalysis = {

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -236,8 +236,12 @@ function buildResume(params: {
   source?: string
   profileType?: string
   primaryRuleScore?: number
+  experience?: string
+  education?: string
   location?: string
   locationHierarchy?: ConvexResumeItem['locationHierarchy']
+  expectedSalary?: string
+  workHistory?: ConvexResumeItem['workHistory']
   brandHits?: ConvexIngestData['brandHits']
   companyHits?: string[]
   industryTags?: string[]
@@ -265,14 +269,14 @@ function buildResume(params: {
     activityStatus: 'Active',
     age: '30',
     ageNumber: 30,
-    experience: '5 years',
-    education: 'Bachelor',
+    experience: params.experience ?? '5 years',
+    education: params.education ?? 'Bachelor',
     location: params.location ?? 'Dongguan',
     locationHierarchy: params.locationHierarchy,
     selfIntro: 'Test intro',
     jobIntention: 'Test role',
-    expectedSalary: '10k-20k',
-    workHistory: [{ raw: 'Test work history', companyName: 'Example Co.', jobTitle: 'Sales Engineer' }],
+    expectedSalary: params.expectedSalary ?? '10k-20k',
+    workHistory: params.workHistory ?? [{ raw: 'Test work history', companyName: 'Example Co.', jobTitle: 'Sales Engineer' }],
     profileEducation: [{ institution: 'Example University', qualification: 'Bachelor' }],
     skills: ['CNC', { name: 'Account management', yearsOfExperience: 3 }],
     languages: ['English', { name: 'Mandarin', proficiency: 'professional' }],
@@ -412,7 +416,10 @@ describe('useResumeListState role filter regression', () => {
       minExperience: 3,
       maxExperience: 8,
       education: ['bachelor'],
+      skills: ['fanuc'],
       locations: ['Dongguan'],
+      minSalary: 10,
+      maxSalary: 20,
     }
 
     renderHook(() => useResumeListState())
@@ -424,10 +431,45 @@ describe('useResumeListState role filter regression', () => {
           minExperience: 3,
           maxExperience: 8,
           education: ['bachelor'],
+          skills: ['fanuc'],
           locations: ['Dongguan'],
+          minSalary: 10,
+          maxSalary: 20,
         },
       },
     })
+  })
+
+  it('applies skills and salary filters in AI mode', () => {
+    mockState.filters = {
+      skills: ['fanuc'],
+      minSalary: 15,
+    }
+    mockState.convexResumes = [
+      buildResume({
+        id: 'resume-1',
+        name: 'High Salary Match',
+        expectedSalary: '20k-30k',
+        workHistory: [{ raw: 'FANUC CNC service and maintenance', companyName: 'Fanuc', jobTitle: 'Engineer' }],
+        roleSignals: [],
+      }),
+      buildResume({
+        id: 'resume-2',
+        name: 'Low Salary Match',
+        expectedSalary: '8k-12k',
+        workHistory: [{ raw: 'FANUC field service', companyName: 'Fanuc', jobTitle: 'Technician' }],
+        roleSignals: [],
+      }),
+      buildResume({
+        id: 'resume-3',
+        name: 'High Salary No Skill',
+        expectedSalary: '20k-30k',
+        workHistory: [{ raw: 'PLC automation sales', companyName: 'Other Co.', jobTitle: 'Sales' }],
+        roleSignals: [],
+      }),
+    ]
+
+    expect(getDisplayedResumeNames()).toEqual(['High Salary Match'])
   })
 
   it('keeps name sorting local to preserve the existing UI comparator', () => {

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1,7 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMutation, useQuery } from 'convex/react'
-import { formatKeywordQuery, formatLocationHierarchySearchText, isLocationMatch, normalizeKeywordPhrases } from '@trends/shared'
+import {
+  buildWorkHistoryEntryText,
+  formatKeywordQuery,
+  formatLocationHierarchySearchText,
+  isLocationMatch,
+  normalizeKeywordPhrases,
+  selectLatestWorkHistory,
+} from '@trends/shared'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { api } from '../../../../packages/convex/convex/_generated/api'
@@ -491,6 +498,45 @@ function matchesEducationFilter(educationValue: string | undefined, selectedEduc
   })
 }
 
+function parseSalaryRange(value: string | undefined): { min?: number; max?: number } | null {
+  if (!value) {
+    return null
+  }
+
+  const normalized = value.replace(/\s/g, '')
+  if (!normalized || /面议/.test(normalized)) {
+    return null
+  }
+
+  const match = normalized.match(/(\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?/)
+  if (!match) {
+    return null
+  }
+
+  const min = Number(match[1])
+  const max = match[2] ? Number(match[2]) : undefined
+  if (Number.isNaN(min)) {
+    return null
+  }
+
+  return { min, max }
+}
+
+function buildResumeFilterSearchText(resume: ConvexResumeItem): string {
+  const parts = [
+    resume.name,
+    resume.education,
+    getResumeLocationText(resume),
+    resume.expectedSalary,
+    ...selectLatestWorkHistory(resume.workHistory).map((entry) => buildWorkHistoryEntryText(entry)),
+  ]
+
+  return parts
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0)
+    .join(' ')
+}
+
 export function useResumeListState(loadSearchHistory = false) {
   const { t } = useTranslation()
   const location = useLocation()
@@ -644,11 +690,14 @@ export function useResumeListState(loadSearchHistory = false) {
       ...(typeof filters.minExperience === 'number' ? { minExperience: filters.minExperience } : {}),
       ...(typeof filters.maxExperience === 'number' ? { maxExperience: filters.maxExperience } : {}),
       ...(Array.isArray(filters.education) && filters.education.length > 0 ? { education: filters.education } : {}),
+      ...(Array.isArray(filters.skills) && filters.skills.length > 0 ? { skills: filters.skills } : {}),
       ...(Array.isArray(filters.locations) && filters.locations.length > 0 ? { locations: filters.locations } : {}),
+      ...(typeof filters.minSalary === 'number' ? { minSalary: filters.minSalary } : {}),
+      ...(typeof filters.maxSalary === 'number' ? { maxSalary: filters.maxSalary } : {}),
     }
 
     return Object.keys(normalized).length > 0 ? normalized : undefined
-  }, [filters.education, filters.locations, filters.maxExperience, filters.minExperience])
+  }, [filters.education, filters.locations, filters.maxExperience, filters.maxSalary, filters.minExperience, filters.minSalary, filters.skills])
   const convexQueryScopeKey = useMemo(
     () => JSON.stringify({
       jobDescriptionId: jobDescriptionId?.trim() ?? '',
@@ -1146,6 +1195,38 @@ export function useResumeListState(loadSearchHistory = false) {
       result = result.filter((resume: ScoredConvexResume) =>
         matchesEducationFilter(resume.education, filters.education ?? [])
       )
+    }
+
+    if (filters.skills?.length) {
+      result = result.filter((resume: ScoredConvexResume) => {
+        const haystack = buildResumeFilterSearchText(resume)
+        return filters.skills?.some((skill) => haystack.includes(normalizeFilterToken(skill))) ?? false
+      })
+    }
+
+    if (typeof filters.minSalary === 'number' || typeof filters.maxSalary === 'number') {
+      result = result.filter((resume: ScoredConvexResume) => {
+        const salary = parseSalaryRange(resume.expectedSalary)
+        if (!salary) {
+          return false
+        }
+
+        if (typeof filters.minSalary === 'number') {
+          const maxSalary = salary.max ?? salary.min
+          if (typeof maxSalary === 'number' && maxSalary < filters.minSalary) {
+            return false
+          }
+        }
+
+        if (typeof filters.maxSalary === 'number') {
+          const minSalary = salary.min ?? salary.max
+          if (typeof minSalary === 'number' && minSalary > filters.maxSalary) {
+            return false
+          }
+        }
+
+        return true
+      })
     }
 
     const minMatchScore = filters.minMatchScore


### PR DESCRIPTION
## Summary
- make AI-mode `skills`, `minSalary`, and `maxSalary` filters actually participate in the direct Convex resume path
- add matching local filter semantics in `useResumeListState` so the AI list no longer ignores those filters
- keep the server-forwarded filter set and local pass aligned so large AI searches fetch fewer resumes and produce correct filtered results

## Validation
- npm --workspace @trends/web run test -- src/hooks/useConvexResumes.test.ts src/hooks/useResumeListState.test.tsx
- npm --workspace @trends/web run typecheck
- make check