### PR TITLE
perf(api,convex): native Convex pagination and match-storage paging

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../app";
-import { MatchStorage } from "../services/match-storage";
+import { MatchStorage, type StoredMatch } from "../services/match-storage";
 import { SessionManager } from "../services/session-manager";
 
 type ConvexCall = {
@@ -77,6 +77,54 @@ function buildConvexResumeRecord(
       extractedAt: "2026-03-24T00:00:00.000Z",
     },
     ingestData: overrides.ingestData,
+  };
+}
+
+function buildConvexExportResumeRecord(
+  resumeId: string,
+  overrides: {
+    name?: string;
+    source?: string;
+    ingestData?: Record<string, unknown>;
+  } = {}
+) {
+  return {
+    resumeId,
+    resume: {
+      name: overrides.name ?? resumeId,
+      location: "东莞",
+      experience: "5 years",
+      education: "Bachelor",
+      jobIntention: "Sales Engineer",
+      profileUrl: `https://example.com/${resumeId}`,
+      workHistory: [{ raw: "2020-2025 CNC 销售工程师" }],
+      extractedAt: "2026-03-24T00:00:00.000Z",
+      source: overrides.source ?? "seek",
+      ingestData: overrides.ingestData,
+    },
+  };
+}
+
+function buildStoredMatch(
+  resumeId: string,
+  overrides: {
+    id?: number;
+    jobDescriptionId?: string;
+    score?: number;
+    recommendation?: StoredMatch["recommendation"];
+  } = {}
+): StoredMatch {
+  return {
+    id: overrides.id ?? 1,
+    resumeId,
+    jobDescriptionId: overrides.jobDescriptionId ?? "jd-1",
+    score: overrides.score ?? 80,
+    recommendation: overrides.recommendation ?? "match",
+    highlights: [],
+    concerns: [],
+    summary: "",
+    scoreSource: "ai",
+    matchedAt: "2026-03-24T00:00:00.000Z",
   };
 }
 
@@ -461,19 +509,27 @@ describe("resume routes", () => {
     }));
   });
 
-  it("falls back to overfetch when score sorting still depends on local match storage", async () => {
+  it("pages score-sorted convex results through match storage and preserves explicit-id order", async () => {
     const calls: ConvexCall[] = [];
+    const getMatchesPageSpy = vi
+      .spyOn(MatchStorage.prototype, "getMatchesPageForJob")
+      .mockReturnValue({
+        matches: [
+          buildStoredMatch("resume-live-3", { id: 3, score: 96 }),
+          buildStoredMatch("resume-live-1", { id: 1, score: 81 }),
+        ],
+        total: 4,
+      });
+    const getMatchesByResumeIdsSpy = vi.spyOn(MatchStorage.prototype, "getMatchesByResumeIds");
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const call = parseConvexCall(input, init);
       calls.push(call);
 
-      if (call.pathName === "resumes:listWithIngestData") {
+      if (call.pathName === "resumes:getByIdsForExport") {
         return convexSuccess([
-          buildConvexResumeRecord("resume-live-1", { name: "Alice" }),
-          buildConvexResumeRecord("resume-live-2", { name: "Bob" }),
-          buildConvexResumeRecord("resume-live-3", { name: "Carla" }),
-          buildConvexResumeRecord("resume-live-4", { name: "Dylan" }),
+          buildConvexExportResumeRecord("resume-live-1", { name: "Alice" }),
+          buildConvexExportResumeRecord("resume-live-3", { name: "Carla" }),
         ]);
       }
 
@@ -481,14 +537,135 @@ describe("resume routes", () => {
     });
 
     const app = createApp();
-    const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&sortBy=score");
+    const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&sortBy=score&jobDescriptionId=jd-1");
 
     expect(response.status).toBe(200);
     const payload = await response.json();
     expect(payload.success).toBe(true);
+    expect(payload.summary).toEqual(expect.objectContaining({
+      total: 4,
+      returned: 2,
+      source: "convex",
+    }));
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Alice"]);
+    expect(getMatchesPageSpy).toHaveBeenCalledWith(expect.objectContaining({
+      jobDescriptionId: "jd-1",
+      limit: 2,
+      offset: 2,
+      sortOrder: "desc",
+    }));
+    expect(getMatchesByResumeIdsSpy).not.toHaveBeenCalled();
     expect(calls[0]).toEqual(expect.objectContaining({
-      pathName: "resumes:listWithIngestData",
-      args: expect.objectContaining({ limit: 4 }),
+      pathName: "resumes:getByIdsForExport",
+      args: expect.objectContaining({ resumeIds: ["resume-live-3", "resume-live-1"] }),
+    }));
+  });
+
+  it("pages minMatchScore convex filtering through match storage", async () => {
+    const calls: ConvexCall[] = [];
+    const getMatchesPageSpy = vi
+      .spyOn(MatchStorage.prototype, "getMatchesPageForJob")
+      .mockReturnValue({
+        matches: [
+          buildStoredMatch("resume-live-2", { id: 2, score: 88 }),
+          buildStoredMatch("resume-live-4", { id: 4, score: 75 }),
+        ],
+        total: 2,
+      });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:getByIdsForExport") {
+        return convexSuccess([
+          buildConvexExportResumeRecord("resume-live-4", { name: "Dylan" }),
+          buildConvexExportResumeRecord("resume-live-2", { name: "Bob" }),
+        ]);
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&limit=2&jobDescriptionId=jd-1&minMatchScore=70");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.summary).toEqual(expect.objectContaining({
+      total: 2,
+      returned: 2,
+      source: "convex",
+    }));
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Bob", "Dylan"]);
+    expect(getMatchesPageSpy).toHaveBeenCalledWith(expect.objectContaining({
+      jobDescriptionId: "jd-1",
+      minScore: 70,
+      sortOrder: "desc",
+    }));
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:getByIdsForExport",
+      args: expect.objectContaining({ resumeIds: ["resume-live-2", "resume-live-4"] }),
+    }));
+  });
+
+  it("pages recommendation-filtered convex results through match storage", async () => {
+    const calls: ConvexCall[] = [];
+    const getMatchesPageSpy = vi
+      .spyOn(MatchStorage.prototype, "getMatchesPageForJob")
+      .mockReturnValue({
+        matches: [
+          buildStoredMatch("resume-live-5", {
+            id: 5,
+            score: 93,
+            recommendation: "strong_match",
+          }),
+          buildStoredMatch("resume-live-6", {
+            id: 6,
+            score: 84,
+            recommendation: "match",
+          }),
+        ],
+        total: 2,
+      });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:getByIdsForExport") {
+        return convexSuccess([
+          buildConvexExportResumeRecord("resume-live-6", { name: "Fiona" }),
+          buildConvexExportResumeRecord("resume-live-5", { name: "Evelyn" }),
+        ]);
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request(
+      "/api/resumes?source=convex&limit=2&jobDescriptionId=jd-1&recommendation=strong_match,match"
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.summary).toEqual(expect.objectContaining({
+      total: 2,
+      returned: 2,
+      source: "convex",
+    }));
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Evelyn", "Fiona"]);
+    expect(getMatchesPageSpy).toHaveBeenCalledWith(expect.objectContaining({
+      jobDescriptionId: "jd-1",
+      recommendation: ["strong_match", "match"],
+      sortOrder: "desc",
+    }));
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:getByIdsForExport",
+      args: expect.objectContaining({ resumeIds: ["resume-live-5", "resume-live-6"] }),
     }));
   });
 

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -250,6 +250,25 @@ function normalizeKeywords(keywords: string[] | undefined): string[] {
   return normalizeKeywordPhrases(keywords).map((item) => item.toLowerCase());
 }
 
+function normalizeMatchRecommendations(
+  values: string[] | undefined
+): MatchingResult["recommendation"][] | undefined {
+  if (!values?.length) {
+    return undefined;
+  }
+
+  const allowed = new Set<MatchingResult["recommendation"]>([
+    "strong_match",
+    "match",
+    "potential",
+    "no_match",
+  ]);
+  const normalized = Array.from(
+    new Set(values.map((value) => value.trim()).filter((value): value is MatchingResult["recommendation"] => allowed.has(value as MatchingResult["recommendation"])))
+  );
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -909,6 +928,24 @@ function resolveConvexResumeFetchLimit(limit: number | undefined, offset: number
   return offset + pageSize;
 }
 
+function hasResumeListFilters(params: {
+  minExperience?: number;
+  maxExperience?: number;
+  education?: string[];
+  skills?: string[];
+  locations?: string[];
+  minSalary?: number;
+  maxSalary?: number;
+}): boolean {
+  return typeof params.minExperience === "number"
+    || typeof params.maxExperience === "number"
+    || (params.education?.length ?? 0) > 0
+    || (params.skills?.length ?? 0) > 0
+    || (params.locations?.length ?? 0) > 0
+    || typeof params.minSalary === "number"
+    || typeof params.maxSalary === "number";
+}
+
 function resolveResumeSortOrder(sortBy: "score" | "name" | "experience" | "extractedAt" | undefined, sortOrder: "asc" | "desc" | undefined): "asc" | "desc" | undefined {
   if (!sortBy || sortBy === "score") {
     return sortOrder;
@@ -1441,29 +1478,78 @@ app.openapi(getResumesRoute, (c) => {
     if (source === "convex") {
       return (async () => {
         const resolvedJobId = jobDescriptionId?.trim() || undefined;
-        const hasLocalMatchFilters = minMatchScore !== undefined || (recommendation?.length ?? 0) > 0;
-        const canUseSourcePagination = !hasLocalMatchFilters && sortBy !== "score";
-        const convexFetchLimit = canUseSourcePagination ? limit : resolveConvexResumeFetchLimit(limit, offset);
-        const { prepared, keywordExpansion: liveExpansion, total: convexTotal } = await prepareConvexCandidates({
-          keywords: keyword ? normalizeKeywords(parseKeywordQuery(keyword).keywords) : [],
-          limit: convexFetchLimit,
-          offset: canUseSourcePagination ? offset : undefined,
-          sortBy: canUseSourcePagination && sortBy ? sortBy : undefined,
-          sortOrder: canUseSourcePagination ? resolveResumeSortOrder(sortBy, sortOrder) : undefined,
-          filters: canUseSourcePagination
-            ? {
-                minExperience,
-                maxExperience,
-                education,
-                skills,
-                locations,
-                minSalary,
-                maxSalary,
-              }
-            : undefined,
-          jobDescriptionId: resolvedJobId,
-          paged: canUseSourcePagination,
+        const normalizedKeywords = keyword ? normalizeKeywords(parseKeywordQuery(keyword).keywords) : [];
+        const normalizedRecommendations = normalizeMatchRecommendations(recommendation);
+        const hasLocalMatchFilters = minMatchScore !== undefined || (normalizedRecommendations?.length ?? 0) > 0;
+        const hasLocalResumeFilters = hasResumeListFilters({
+          minExperience,
+          maxExperience,
+          education,
+          skills,
+          locations,
+          minSalary,
+          maxSalary,
         });
+        const requiresMatchPagination = sortBy === "score" || hasLocalMatchFilters;
+        const canUseMatchStoragePagination = Boolean(
+          resolvedJobId
+          && requiresMatchPagination
+          && normalizedKeywords.length === 0
+          && !hasLocalResumeFilters
+        );
+        const canUseSourcePagination = !requiresMatchPagination;
+        const matchSortOrder = sortBy === "score"
+          ? resolveResumeSortOrder(sortBy, sortOrder) || "desc"
+          : "desc";
+
+        let prepared: PreparedResumeCandidate[] = [];
+        let liveExpansion: ResumeKeywordExpansion | undefined;
+        let totalCount: number | undefined;
+        let matchMap: Map<string, { score: number; recommendation: MatchingResult["recommendation"] }> | null = null;
+
+        if (canUseMatchStoragePagination && resolvedJobId) {
+          const matchPage = matchStorage.getMatchesPageForJob({
+            jobDescriptionId: resolvedJobId,
+            offset,
+            limit,
+            minScore: minMatchScore,
+            recommendation: normalizedRecommendations,
+            sortOrder: matchSortOrder,
+          });
+          const pagedResumeIds = matchPage.matches.map((match) => match.resumeId);
+          matchMap = new Map(matchPage.matches.map((match) => [match.resumeId, match]));
+          totalCount = matchPage.total;
+          if (pagedResumeIds.length > 0) {
+            prepared = (await prepareConvexCandidates({
+              resumeIds: pagedResumeIds,
+            })).prepared;
+          }
+        } else {
+          const convexFetchLimit = canUseSourcePagination ? limit : resolveConvexResumeFetchLimit(limit, offset);
+          const preparedResult = await prepareConvexCandidates({
+            keywords: normalizedKeywords,
+            limit: convexFetchLimit,
+            offset: canUseSourcePagination ? offset : undefined,
+            sortBy: canUseSourcePagination && sortBy ? sortBy : undefined,
+            sortOrder: canUseSourcePagination ? resolveResumeSortOrder(sortBy, sortOrder) : undefined,
+            filters: canUseSourcePagination
+              ? {
+                  minExperience,
+                  maxExperience,
+                  education,
+                  skills,
+                  locations,
+                  minSalary,
+                  maxSalary,
+                }
+              : undefined,
+            jobDescriptionId: resolvedJobId,
+            paged: canUseSourcePagination,
+          });
+          prepared = preparedResult.prepared;
+          liveExpansion = preparedResult.keywordExpansion;
+          totalCount = preparedResult.total;
+        }
 
         let filtered = prepared.map((item) => item.resume);
         filtered = resumeService.filterResumes(filtered, {
@@ -1481,13 +1567,12 @@ app.openapi(getResumesRoute, (c) => {
           id: resolveResumeId(item, index),
         }));
 
-        let matchMap: Map<string, { score: number; recommendation: string }> | null = null;
         const needsMatchContext = Boolean(
           resolvedJobId
-          && (minMatchScore !== undefined || (recommendation?.length ?? 0) > 0 || sortBy === "score")
+          && (minMatchScore !== undefined || (normalizedRecommendations?.length ?? 0) > 0 || sortBy === "score")
         );
 
-        if (needsMatchContext && resolvedJobId) {
+        if (!matchMap && needsMatchContext && resolvedJobId) {
           const matches = matchStorage.getMatchesByResumeIds(
             prepared.map((item) => item.resumeId),
             resolvedJobId
@@ -1496,15 +1581,15 @@ app.openapi(getResumesRoute, (c) => {
         }
 
         let working = enriched;
-        if (matchMap) {
+        if (!canUseMatchStoragePagination && matchMap) {
           if (minMatchScore !== undefined) {
             working = working.filter((item) => {
               const match = matchMap?.get(item.id);
               return match && match.score >= minMatchScore;
             });
           }
-          if (recommendation?.length) {
-            const allowed = new Set(recommendation);
+          if (normalizedRecommendations?.length) {
+            const allowed = new Set(normalizedRecommendations);
             working = working.filter((item) => {
               const match = matchMap?.get(item.id);
               return match && allowed.has(match.recommendation);
@@ -1512,7 +1597,7 @@ app.openapi(getResumesRoute, (c) => {
           }
         }
 
-        if (sortBy) {
+        if (!canUseMatchStoragePagination && sortBy) {
           const order = sortOrder || (sortBy === "score" ? "desc" : "asc");
           const direction = order === "desc" ? -1 : 1;
 
@@ -1538,7 +1623,8 @@ app.openapi(getResumesRoute, (c) => {
           });
         }
 
-        const limited = canUseSourcePagination
+        const isAlreadyPaged = canUseSourcePagination || canUseMatchStoragePagination;
+        const limited = isAlreadyPaged
           ? working.map((item) => item.resume)
           : (() => {
               const start = offset ?? 0;
@@ -1550,7 +1636,7 @@ app.openapi(getResumesRoute, (c) => {
         return c.json({
           success: true as const,
           summary: {
-            total: canUseSourcePagination ? (convexTotal ?? working.length) : working.length,
+            total: isAlreadyPaged ? (totalCount ?? working.length) : working.length,
             returned: limited.length,
             query: keyword,
             source,
@@ -1597,7 +1683,7 @@ app.openapi(getResumesRoute, (c) => {
       relevanceScore: item.relevanceScore,
     }));
 
-    let matchMap: Map<string, { score: number; recommendation: string }> | null = null;
+    let matchMap: Map<string, { score: number; recommendation: MatchingResult["recommendation"] }> | null = null;
     const needsMatchContext = Boolean(
       resolvedJobId
       && (minMatchScore !== undefined || (recommendation?.length ?? 0) > 0 || sortBy === "score")

--- a/apps/api/src/services/match-storage.ts
+++ b/apps/api/src/services/match-storage.ts
@@ -42,6 +42,11 @@ export type StoredMatchRun = {
   error?: string;
 };
 
+export type StoredMatchPage = {
+  matches: StoredMatch[];
+  total: number;
+};
+
 function parseJsonArray(value: unknown): string[] {
   if (typeof value !== "string" || !value.trim()) return [];
   try {
@@ -269,6 +274,74 @@ export class MatchStorage {
       .all(jobDescriptionId, ...resumeIds) as Record<string, unknown>[];
 
     return rows.map((row) => normalizeMatch(row));
+  }
+
+  getMatchesPageForJob(params: {
+    jobDescriptionId: string;
+    offset?: number;
+    limit?: number;
+    minScore?: number;
+    recommendation?: MatchingResult["recommendation"][];
+    sortOrder?: "asc" | "desc";
+  }): StoredMatchPage {
+    const clauses = ["job_description_id = ?"];
+    const values: Array<string | number> = [params.jobDescriptionId];
+
+    if (typeof params.minScore === "number") {
+      clauses.push("score >= ?");
+      values.push(params.minScore);
+    }
+
+    const normalizedRecommendations = Array.from(
+      new Set(
+        (params.recommendation ?? [])
+          .map((value) => value.trim())
+          .filter(Boolean)
+      )
+    ) as MatchingResult["recommendation"][];
+    if (normalizedRecommendations.length > 0) {
+      clauses.push(
+        `recommendation IN (${normalizedRecommendations.map(() => "?").join(", ")})`
+      );
+      values.push(...normalizedRecommendations);
+    }
+
+    const whereClause = `WHERE ${clauses.join(" AND ")}`;
+    const totalRow = this.db
+      .prepare(`SELECT COUNT(*) AS total FROM resume_matches ${whereClause}`)
+      .get(...values) as Record<string, unknown> | undefined;
+
+    const limit = typeof params.limit === "number" ? Math.max(1, params.limit) : undefined;
+    const offset = typeof params.offset === "number" ? Math.max(0, params.offset) : 0;
+    const order = params.sortOrder === "asc" ? "ASC" : "DESC";
+
+    const paginationClause = typeof limit === "number"
+      ? "LIMIT ? OFFSET ?"
+      : offset > 0
+        ? "LIMIT -1 OFFSET ?"
+        : "";
+    const paginationValues = typeof limit === "number"
+      ? [limit, offset]
+      : offset > 0
+        ? [offset]
+        : [];
+
+    const rows = this.db
+      .prepare(
+        `
+        SELECT *
+        FROM resume_matches
+        ${whereClause}
+        ORDER BY score ${order}, matched_at DESC, id DESC
+        ${paginationClause}
+        `
+      )
+      .all(...values, ...paginationValues) as Record<string, unknown>[];
+
+    return {
+      matches: rows.map((row) => normalizeMatch(row)),
+      total: Number(totalRow?.total ?? 0),
+    };
   }
 
   getLatestMatchesByResumeIds(resumeIds: string[]): StoredMatch[] {

--- a/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
+++ b/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import { listWithIngestDataPaginated } from "../resumes";
+
+type ConvexHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+type PaginatedArgs = {
+  paginationOpts: { cursor: string | null; numItems: number };
+  jobDescriptionId?: string;
+  sortBy?: "name" | "experience" | "extractedAt";
+  sortOrder?: "asc" | "desc";
+  minExperience?: number;
+  maxExperience?: number;
+  education?: string[];
+  skills?: string[];
+  locations?: string[];
+  minSalary?: number;
+  maxSalary?: number;
+};
+
+type PaginatedResult = {
+  page: unknown[];
+  continueCursor: string;
+  isDone: boolean;
+};
+
+const handler = (
+  listWithIngestDataPaginated as unknown as ConvexHandler<PaginatedArgs, PaginatedResult>
+)._handler;
+
+function buildResumeDoc(id: string, primaryRuleScore: number) {
+  return {
+    _id: id,
+    externalId: `test:${id}`,
+    source: "test",
+    tags: [],
+    crawledAt: Date.now(),
+    content: { name: id },
+    primaryRuleScore,
+  };
+}
+
+describe("listWithIngestDataPaginated", () => {
+  it("uses native paginate() for the default unfiltered path", async () => {
+    let paginateCalled = false;
+    let takeCalled = false;
+
+    const resumeA = buildResumeDoc("resume-a", 90);
+    const resumeB = buildResumeDoc("resume-b", 80);
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => ({
+              paginate: async (opts: { cursor: string | null; numItems: number }) => {
+                paginateCalled = true;
+                expect(opts.numItems).toBe(10);
+                return {
+                  page: [resumeA, resumeB],
+                  continueCursor: "cursor-next",
+                  isDone: false,
+                };
+              },
+              take: async () => {
+                takeCalled = true;
+                return [];
+              },
+            }),
+          }),
+        }),
+      },
+    };
+
+    const result = await handler(ctx, {
+      paginationOpts: { cursor: null, numItems: 10 },
+    });
+
+    expect(paginateCalled).toBe(true);
+    expect(takeCalled).toBe(false);
+    expect(result.page).toEqual([resumeA, resumeB]);
+    expect(result.continueCursor).toBe("cursor-next");
+    expect(result.isDone).toBe(false);
+  });
+
+  it("falls back to offset/overfetch path when jobDescriptionId is set", async () => {
+    let paginateCalled = false;
+    let takeCalled = false;
+
+    const resumeA = buildResumeDoc("resume-a", 90);
+    const resumeB = buildResumeDoc("resume-b", 80);
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => ({
+              paginate: async () => {
+                paginateCalled = true;
+                return { page: [], continueCursor: "", isDone: true };
+              },
+              take: async () => {
+                takeCalled = true;
+                return [resumeA, resumeB];
+              },
+            }),
+          }),
+        }),
+      },
+    };
+
+    const result = await handler(ctx, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      jobDescriptionId: "jd-1",
+    });
+
+    expect(paginateCalled).toBe(false);
+    expect(takeCalled).toBe(true);
+    expect(result.page.length).toBeLessThanOrEqual(10);
+  });
+
+  it("falls back to offset/overfetch path when sortBy is set", async () => {
+    let paginateCalled = false;
+    let takeCalled = false;
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => ({
+              paginate: async () => {
+                paginateCalled = true;
+                return { page: [], continueCursor: "", isDone: true };
+              },
+              take: async () => {
+                takeCalled = true;
+                return [buildResumeDoc("resume-a", 90)];
+              },
+            }),
+          }),
+        }),
+      },
+    };
+
+    await handler(ctx, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      sortBy: "name",
+    });
+
+    expect(paginateCalled).toBe(false);
+    expect(takeCalled).toBe(true);
+  });
+
+  it("falls back to offset/overfetch path when resume filters are set", async () => {
+    let paginateCalled = false;
+    let takeCalled = false;
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => ({
+              paginate: async () => {
+                paginateCalled = true;
+                return { page: [], continueCursor: "", isDone: true };
+              },
+              take: async () => {
+                takeCalled = true;
+                return [buildResumeDoc("resume-a", 90)];
+              },
+            }),
+          }),
+        }),
+      },
+    };
+
+    await handler(ctx, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      locations: ["东莞"],
+    });
+
+    expect(paginateCalled).toBe(false);
+    expect(takeCalled).toBe(true);
+  });
+});

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -1132,6 +1132,25 @@ export const listWithIngestDataPaginated = query({
         maxSalary: v.optional(v.number()),
     },
     handler: async (ctx, args) => {
+        const filters = normalizeResumeListFilters(args);
+        const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
+        if (!jobDescriptionId && !args.sortBy && !filters) {
+            const page = await ctx.db
+                .query("resumes")
+                .withIndex("by_primaryRuleScore")
+                .order("desc")
+                .paginate({
+                    ...args.paginationOpts,
+                    numItems: resolvePaginatedResumePageLimit(args.paginationOpts.numItems),
+                });
+
+            return {
+                page: page.page,
+                continueCursor: page.continueCursor,
+                isDone: page.isDone,
+            };
+        }
+
         const offset = resolvePaginatedResumeOffsetCursor(args.paginationOpts.cursor);
         const limit = resolvePaginatedResumePageLimit(args.paginationOpts.numItems);
         const page = await runListWithIngestDataPageQuery(ctx, {


### PR DESCRIPTION
## Summary
- Use native Convex `withIndex().paginate()` for the default unfiltered `listWithIngestDataPaginated` path, avoiding the overfetch/`take()` pattern that can exceed Convex's 16 MB read limit on large datasets.
- Add `MatchStorage.getMatchesPageForJob()` to page score-sorted, minMatchScore-filtered, and recommendation-filtered resume queries through SQLite match storage instead of fetching all matches into memory.
- Fix `matchMap` recommendation type from `string` to `MatchingResult["recommendation"]` to resolve the API typecheck error.
- Skip redundant JS post-filtering and re-sorting when results are already filtered and ordered by the match-storage SQL query.

## Test plan
- [x] `npm --workspace @trends/api run typecheck` passes
- [x] `npx vitest run apps/api/src/routes/resumes.test.ts` — 11/11 pass
- [x] `npx vitest run packages/convex/convex/__tests__/resumes-paginated-default.test.ts` — 4/4 pass
- [x] `make check` passes
- [ ] Manual smoke on `/dev/resumes` to confirm the page renders without Convex byte-limit error