### PR TITLE
fix(convex): native paginate with post-filtering for resume filters

### DIFF
--- a/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
+++ b/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
@@ -153,9 +153,12 @@ describe("listWithIngestDataPaginated", () => {
     expect(takeCalled).toBe(true);
   });
 
-  it("falls back to offset/overfetch path when resume filters are set", async () => {
+  it("uses native paginate() with post-filtering when resume filters are set", async () => {
     let paginateCalled = false;
     let takeCalled = false;
+
+    const resumeA = { ...buildResumeDoc("resume-a", 90), content: { name: "Alice", location: "东莞" } };
+    const resumeB = { ...buildResumeDoc("resume-b", 80), content: { name: "Bob", location: "深圳" } };
 
     const ctx = {
       db: {
@@ -164,11 +167,15 @@ describe("listWithIngestDataPaginated", () => {
             order: () => ({
               paginate: async () => {
                 paginateCalled = true;
-                return { page: [], continueCursor: "", isDone: true };
+                return {
+                  page: [resumeA, resumeB],
+                  continueCursor: "cursor-next",
+                  isDone: false,
+                };
               },
               take: async () => {
                 takeCalled = true;
-                return [buildResumeDoc("resume-a", 90)];
+                return [];
               },
             }),
           }),
@@ -176,12 +183,15 @@ describe("listWithIngestDataPaginated", () => {
       },
     };
 
-    await handler(ctx, {
+    const result = await handler(ctx, {
       paginationOpts: { cursor: null, numItems: 10 },
       locations: ["东莞"],
     });
 
-    expect(paginateCalled).toBe(false);
-    expect(takeCalled).toBe(true);
+    expect(paginateCalled).toBe(true);
+    expect(takeCalled).toBe(false);
+    expect(result.page).toHaveLength(1);
+    expect((result.page[0] as { content: { name: string } }).content.name).toBe("Alice");
+    expect(result.continueCursor).toBe("cursor-next");
   });
 });

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -1134,7 +1134,7 @@ export const listWithIngestDataPaginated = query({
     handler: async (ctx, args) => {
         const filters = normalizeResumeListFilters(args);
         const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
-        if (!jobDescriptionId && !args.sortBy && !filters) {
+        if (!jobDescriptionId && !args.sortBy) {
             const page = await ctx.db
                 .query("resumes")
                 .withIndex("by_primaryRuleScore")
@@ -1145,7 +1145,9 @@ export const listWithIngestDataPaginated = query({
                 });
 
             return {
-                page: page.page,
+                page: filters
+                    ? page.page.filter((resume) => matchesResumeListFilters(resume, filters))
+                    : page.page,
                 continueCursor: page.continueCursor,
                 isDone: page.isDone,
             };


### PR DESCRIPTION
## Summary
- Fixes Convex 16 MB read limit crash when `/dev/resumes` has location/education/skills/salary filters active
- Extends the native `paginate()` fast-path to also handle the filtered case (no jobDescriptionId, no custom sortBy)
- Filters are applied as post-filter on each paginated page instead of overfetching 4000 docs
- `usePaginatedQuery` on the client side auto-loads additional pages when filtering shrinks results

## Test plan
- [x] `npx vitest run packages/convex/convex/__tests__/resumes-paginated-default.test.ts` — 4/4 pass
- [x] `npx vitest run apps/api/src/routes/resumes.test.ts` — 11/11 pass
- [x] `npm --workspace @trends/api run typecheck` — pass
- [ ] Smoke test: `/dev/resumes?location=Kuala+Lumpur+MY` renders without crash