### PR TITLE
chore(convex,web): remove pagination perf instrumentation

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { normalizeProfileUrlForDisplay, normalizeSharedResumeFields, parseKeywordQuery } from '@trends/shared'
 import { usePaginatedQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
@@ -815,42 +815,13 @@ export function useConvexResumes(
   const activePaginatedResultsLength = normalizedQuery ? paginatedSearchResults.results.length : paginatedListResults.results.length
   const activePaginatedLoadMore = normalizedQuery ? paginatedSearchResults.loadMore : paginatedListResults.loadMore
 
-  const paginationStatsRef = useRef({ roundTrips: 0, startTime: 0, logged: false })
-  const filtersKey = JSON.stringify(options?.filters ?? null)
-
-  useEffect(() => {
-    paginationStatsRef.current = { roundTrips: 0, startTime: 0, logged: false }
-  }, [normalizedQuery, normalizedJobDescriptionId, filtersKey, options?.sortBy, resolvedSortOrder])
-
   useEffect(() => {
     if (mockPayload || limit <= 0) {
       return
     }
-
-    const stats = paginationStatsRef.current
-
     if (activePaginatedStatus !== 'CanLoadMore' || activePaginatedResultsLength >= limit) {
-      if (import.meta.env.DEV && stats.roundTrips > 0 && !stats.logged) {
-        stats.logged = true
-        const elapsed = Math.round(performance.now() - stats.startTime)
-        console.log(
-          `[perf:paginate] done trips=${stats.roundTrips} total=${elapsed}ms results=${activePaginatedResultsLength} status=${activePaginatedStatus}`
-        )
-      }
       return
     }
-
-    if (stats.roundTrips === 0) {
-      stats.startTime = performance.now()
-    }
-    stats.roundTrips++
-
-    if (import.meta.env.DEV) {
-      console.log(
-        `[perf:paginate] trip=${stats.roundTrips} results=${activePaginatedResultsLength}/${limit} elapsed=${Math.round(performance.now() - stats.startTime)}ms`
-      )
-    }
-
     activePaginatedLoadMore(Math.min(CONVEX_RESUME_PAGE_SIZE, limit - activePaginatedResultsLength))
   }, [
     activePaginatedLoadMore,

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -1153,12 +1153,6 @@ export const listWithIngestDataPaginated = query({
                 ? page.page.filter((resume) => matchesResumeListFilters(resume, filters))
                 : page.page;
 
-            if (filters && page.page.length > 0) {
-                console.log(
-                    `[perf:paginate] raw=${page.page.length} filtered=${filtered.length} rejection=${(((page.page.length - filtered.length) / page.page.length) * 100).toFixed(1)}%`
-                );
-            }
-
             return {
                 page: filtered,
                 continueCursor: page.continueCursor,


### PR DESCRIPTION
## Summary
- Remove `[perf:paginate]` console.log from Convex `resumes.ts` — had no dev guard, would log in production
- Remove pagination stats `useRef`, reset effect, and trip/done logging from `useConvexResumes.ts` (~35 lines)
- Clean up unused `useRef` import

Instrumentation served its purpose validating the 3x overfetch filtered pagination (PRs #398–#402). All perf improvements are validated and merged.

## Test plan
- [x] `make check` passes (typecheck, lint, policy sync, skills sync)
- [x] API smoke test: `GET /api/resumes?source=convex` returns results
- [x] No remaining `[perf:paginate]` references in codebase