### PR TITLE
feat(api): add review-packet storage foundation (Feedback Loop V1 slice 1)

### DIFF
--- a/apps/api/src/services/database.ts
+++ b/apps/api/src/services/database.ts
@@ -154,6 +154,31 @@ function initSchema(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_actions_resume ON candidate_actions(resume_id);
     CREATE INDEX IF NOT EXISTS idx_actions_user ON candidate_actions(user_id);
     CREATE INDEX IF NOT EXISTS idx_actions_type ON candidate_actions(action_type);
+
+    CREATE TABLE IF NOT EXISTS review_packet_runs (
+      id TEXT PRIMARY KEY,
+      workspace_slug TEXT NOT NULL DEFAULT 'dev',
+      source TEXT NOT NULL,
+      sample_name TEXT,
+      session_id TEXT,
+      job_description_id TEXT,
+      format TEXT NOT NULL,
+      status TEXT NOT NULL,
+      total_count INTEGER NOT NULL DEFAULT 0,
+      packet_filename TEXT,
+      exported_at TEXT NOT NULL,
+      feedback_imported_at TEXT,
+      summary_sent_at TEXT,
+      summary_channel TEXT,
+      items_json TEXT NOT NULL,
+      stats_json TEXT,
+      context_json TEXT,
+      error TEXT,
+      FOREIGN KEY (session_id) REFERENCES search_sessions(id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_review_packet_runs_workspace ON review_packet_runs(workspace_slug);
+    CREATE INDEX IF NOT EXISTS idx_review_packet_runs_exported ON review_packet_runs(exported_at DESC);
   `);
 
   ensureColumn(db, "resume_matches", "breakdown", "TEXT");

--- a/apps/api/src/services/review-packet-storage.test.ts
+++ b/apps/api/src/services/review-packet-storage.test.ts
@@ -1,0 +1,173 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ReviewPacketStorage } from "./review-packet-storage";
+import { resetResumeScreeningDb } from "./database";
+
+function createFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "review-packet-storage-"));
+  fs.mkdirSync(path.join(root, "output"), { recursive: true });
+  fs.writeFileSync(path.join(root, "pyproject.toml"), "", "utf8");
+  return root;
+}
+
+describe("ReviewPacketStorage", () => {
+  let root = "";
+
+  afterEach(() => {
+    resetResumeScreeningDb();
+    if (root) {
+      fs.rmSync(root, { recursive: true, force: true });
+      root = "";
+    }
+  });
+
+  it("creates, retrieves, and lists tracked runs", () => {
+    root = createFixtureRoot();
+    const storage = new ReviewPacketStorage(root);
+
+    const created = storage.createRun({
+      id: "packet-1",
+      workspaceSlug: "hr",
+      source: "convex",
+      jobDescriptionId: "lathe-sales",
+      format: "xlsx",
+      totalCount: 2,
+      packetFilename: "packet-1.xlsx",
+      exportedAt: "2026-03-20T09:00:00+08:00",
+      items: [
+        { resumeId: "resume-1", identityKey: "profileUrl:resume-1", name: "Alice" },
+        { resumeId: "resume-2", identityKey: "profileUrl:resume-2", name: "Bob" },
+      ],
+    });
+
+    expect(created.id).toBe("packet-1");
+    expect(created.workspaceSlug).toBe("hr");
+    expect(created.items).toHaveLength(2);
+
+    const fetched = storage.getRun("packet-1", "hr");
+    expect(fetched?.packetFilename).toBe("packet-1.xlsx");
+
+    const listed = storage.listRuns("hr");
+    expect(listed.map((run) => run.id)).toEqual(["packet-1"]);
+  });
+
+  it("records feedback import and summary updates", () => {
+    root = createFixtureRoot();
+    const storage = new ReviewPacketStorage(root);
+
+    storage.createRun({
+      id: "packet-2",
+      workspaceSlug: "dev",
+      source: "sample",
+      sampleName: "sample-initial",
+      format: "csv",
+      totalCount: 1,
+      packetFilename: "packet-2.csv",
+      exportedAt: "2026-03-20T10:00:00+08:00",
+      items: [{ resumeId: "resume-3", identityKey: "resume-3", name: "Carol" }],
+    });
+
+    const imported = storage.recordFeedbackImport({
+      id: "packet-2",
+      workspaceSlug: "dev",
+      stats: {
+        importedAt: "2026-03-20T10:30:00+08:00",
+        fileName: "reviewed.xlsx",
+        totalRows: 1,
+        matchedRows: 1,
+        importedRows: 1,
+        reviewedCount: 1,
+        statusUpdates: 1,
+        actionUpdates: 1,
+        noteUpdates: 0,
+        invalidRows: 0,
+        duplicateRows: 0,
+        warningCount: 1,
+        matchedByProfileUrlCount: 0,
+        nameMismatchCount: 1,
+        reviewedResumeIds: ["resume-3"],
+        warnings: ["Name edited"],
+      },
+    });
+
+    expect(imported?.status).toBe("feedback_imported");
+    expect(imported?.stats?.import?.fileName).toBe("reviewed.xlsx");
+
+    const summarized = storage.updateSummaryStats({
+      id: "packet-2",
+      workspaceSlug: "dev",
+      sent: true,
+      stats: {
+        previewedAt: "2026-03-20T10:35:00+08:00",
+        sentAt: "2026-03-20T10:40:00+08:00",
+        channel: "wechat_work",
+        reviewedCount: 1,
+        pendingCount: 0,
+        warningCount: 1,
+        statusBreakdown: { interviewed_pass: 1 },
+        actionBreakdown: { shortlist: 1 },
+      },
+    });
+
+    expect(summarized?.status).toBe("summary_sent");
+    expect(summarized?.summaryChannel).toBe("wechat_work");
+    expect(summarized?.stats?.summary?.actionBreakdown.shortlist).toBe(1);
+  });
+
+  it("marks a run as failed", () => {
+    root = createFixtureRoot();
+    const storage = new ReviewPacketStorage(root);
+
+    storage.createRun({
+      id: "packet-3",
+      workspaceSlug: "dev",
+      source: "convex",
+      format: "xlsx",
+      totalCount: 5,
+      exportedAt: "2026-03-20T11:00:00+08:00",
+      items: [],
+    });
+
+    const failed = storage.markFailed({
+      id: "packet-3",
+      workspaceSlug: "dev",
+      error: "Export file missing",
+    });
+
+    expect(failed?.status).toBe("failed");
+    expect(failed?.error).toBe("Export file missing");
+  });
+
+  it("isolates runs by workspace", () => {
+    root = createFixtureRoot();
+    const storage = new ReviewPacketStorage(root);
+
+    storage.createRun({
+      id: "packet-hr",
+      workspaceSlug: "hr",
+      source: "convex",
+      format: "xlsx",
+      totalCount: 1,
+      exportedAt: "2026-03-20T12:00:00+08:00",
+      items: [{ resumeId: "r1", identityKey: "r1" }],
+    });
+
+    storage.createRun({
+      id: "packet-dev",
+      workspaceSlug: "dev",
+      source: "convex",
+      format: "xlsx",
+      totalCount: 1,
+      exportedAt: "2026-03-20T12:01:00+08:00",
+      items: [{ resumeId: "r2", identityKey: "r2" }],
+    });
+
+    expect(storage.listRuns("hr").map((r) => r.id)).toEqual(["packet-hr"]);
+    expect(storage.listRuns("dev").map((r) => r.id)).toEqual(["packet-dev"]);
+    expect(storage.getRun("packet-hr", "dev")).toBeNull();
+  });
+});

--- a/apps/api/src/services/review-packet-storage.ts
+++ b/apps/api/src/services/review-packet-storage.ts
@@ -1,0 +1,316 @@
+import { config } from "./config.js";
+import { getResumeScreeningDb } from "./database.js";
+import { formatIsoOffsetInTimezone } from "./timezone.js";
+
+export type ReviewPacketRunStatus = "exported" | "feedback_imported" | "summary_sent" | "failed";
+
+export type ReviewPacketItemSnapshot = {
+  resumeId: string;
+  identityKey: string;
+  profileUrl?: string;
+  name?: string;
+  source?: string;
+};
+
+export type ReviewPacketImportStats = {
+  importedAt: string;
+  fileName: string;
+  totalRows: number;
+  matchedRows: number;
+  importedRows: number;
+  reviewedCount: number;
+  statusUpdates: number;
+  actionUpdates: number;
+  noteUpdates: number;
+  invalidRows: number;
+  duplicateRows: number;
+  warningCount: number;
+  matchedByProfileUrlCount: number;
+  nameMismatchCount: number;
+  reviewedResumeIds: string[];
+  warnings: string[];
+};
+
+export type ReviewPacketSummaryStats = {
+  previewedAt?: string;
+  sentAt?: string;
+  channel?: string;
+  reviewedCount: number;
+  pendingCount: number;
+  warningCount: number;
+  statusBreakdown: Record<string, number>;
+  actionBreakdown: Record<string, number>;
+};
+
+export type ReviewPacketRunStats = {
+  import?: ReviewPacketImportStats;
+  summary?: ReviewPacketSummaryStats;
+};
+
+export type StoredReviewPacketRun = {
+  id: string;
+  workspaceSlug: string;
+  source: "sample" | "convex";
+  sampleName?: string;
+  sessionId?: string;
+  jobDescriptionId?: string;
+  format: "csv" | "xlsx";
+  status: ReviewPacketRunStatus;
+  totalCount: number;
+  packetFilename?: string;
+  exportedAt: string;
+  feedbackImportedAt?: string;
+  summarySentAt?: string;
+  summaryChannel?: string;
+  items: ReviewPacketItemSnapshot[];
+  stats?: ReviewPacketRunStats;
+  error?: string;
+};
+
+function parseJsonArray<T>(value: unknown): T[] {
+  if (typeof value !== "string" || !value.trim()) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseJsonObject<T>(value: unknown): T | undefined {
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(value) as T;
+    return typeof parsed === "object" && parsed !== null ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeStatus(value: unknown): ReviewPacketRunStatus {
+  const status = String(value ?? "exported");
+  if (status === "feedback_imported" || status === "summary_sent" || status === "failed") {
+    return status;
+  }
+  return "exported";
+}
+
+function normalizeRun(row: Record<string, unknown>): StoredReviewPacketRun {
+  const rawSource = String(row.source ?? "convex");
+  const rawFormat = String(row.format ?? "xlsx");
+
+  return {
+    id: String(row.id),
+    workspaceSlug: row.workspace_slug ? String(row.workspace_slug) : "dev",
+    source: rawSource === "sample" ? "sample" : "convex",
+    sampleName: row.sample_name ? String(row.sample_name) : undefined,
+    sessionId: row.session_id ? String(row.session_id) : undefined,
+    jobDescriptionId: row.job_description_id ? String(row.job_description_id) : undefined,
+    format: rawFormat === "csv" ? "csv" : "xlsx",
+    status: normalizeStatus(row.status),
+    totalCount: Number(row.total_count ?? 0),
+    packetFilename: row.packet_filename ? String(row.packet_filename) : undefined,
+    exportedAt: String(row.exported_at),
+    feedbackImportedAt: row.feedback_imported_at ? String(row.feedback_imported_at) : undefined,
+    summarySentAt: row.summary_sent_at ? String(row.summary_sent_at) : undefined,
+    summaryChannel: row.summary_channel ? String(row.summary_channel) : undefined,
+    items: parseJsonArray<ReviewPacketItemSnapshot>(row.items_json),
+    stats: parseJsonObject<ReviewPacketRunStats>(row.stats_json),
+    error: row.error ? String(row.error) : undefined,
+  };
+}
+
+export class ReviewPacketStorage {
+  private readonly db;
+
+  constructor(projectRoot?: string) {
+    this.db = getResumeScreeningDb(projectRoot);
+  }
+
+  createRun(params: {
+    id: string;
+    workspaceSlug: string;
+    source: "sample" | "convex";
+    sampleName?: string;
+    sessionId?: string;
+    jobDescriptionId?: string;
+    format: "csv" | "xlsx";
+    status?: ReviewPacketRunStatus;
+    totalCount: number;
+    packetFilename?: string;
+    exportedAt?: string;
+    items: ReviewPacketItemSnapshot[];
+    stats?: ReviewPacketRunStats;
+    error?: string;
+  }): StoredReviewPacketRun {
+    const exportedAt = params.exportedAt ?? formatIsoOffsetInTimezone(new Date(), config.timezone);
+    this.db
+      .prepare(
+        `
+        INSERT INTO review_packet_runs (
+          id, workspace_slug, source, sample_name, session_id,
+          job_description_id, format, status, total_count,
+          packet_filename, exported_at, items_json, stats_json, error
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        params.id,
+        params.workspaceSlug,
+        params.source,
+        params.sampleName ?? null,
+        params.sessionId ?? null,
+        params.jobDescriptionId ?? null,
+        params.format,
+        params.status ?? "exported",
+        params.totalCount,
+        params.packetFilename ?? null,
+        exportedAt,
+        JSON.stringify(params.items),
+        params.stats ? JSON.stringify(params.stats) : null,
+        params.error ?? null,
+      );
+
+    const created = this.getRun(params.id, params.workspaceSlug);
+    if (!created) {
+      throw new Error(`Failed to create review packet run: ${params.id}`);
+    }
+    return created;
+  }
+
+  getRun(id: string, workspaceSlug: string): StoredReviewPacketRun | null {
+    const row = this.db
+      .prepare("SELECT * FROM review_packet_runs WHERE id = ? AND workspace_slug = ?")
+      .get(id, workspaceSlug) as Record<string, unknown> | undefined;
+
+    return row ? normalizeRun(row) : null;
+  }
+
+  listRuns(workspaceSlug: string, limit = 20): StoredReviewPacketRun[] {
+    const rows = this.db
+      .prepare(
+        `
+        SELECT * FROM review_packet_runs
+        WHERE workspace_slug = ?
+        ORDER BY exported_at DESC
+        LIMIT ?
+        `
+      )
+      .all(workspaceSlug, limit) as Record<string, unknown>[];
+
+    return rows.map((row) => normalizeRun(row));
+  }
+
+  recordFeedbackImport(params: {
+    id: string;
+    workspaceSlug: string;
+    stats: ReviewPacketImportStats;
+  }): StoredReviewPacketRun | null {
+    const existing = this.getRun(params.id, params.workspaceSlug);
+    if (!existing) {
+      return null;
+    }
+
+    const nextStats: ReviewPacketRunStats = {
+      ...existing.stats,
+      import: params.stats,
+    };
+
+    this.db
+      .prepare(
+        `
+        UPDATE review_packet_runs
+        SET status = ?,
+            feedback_imported_at = ?,
+            stats_json = ?,
+            error = NULL
+        WHERE id = ? AND workspace_slug = ?
+        `
+      )
+      .run(
+        "feedback_imported",
+        params.stats.importedAt,
+        JSON.stringify(nextStats),
+        params.id,
+        params.workspaceSlug,
+      );
+
+    return this.getRun(params.id, params.workspaceSlug);
+  }
+
+  updateSummaryStats(params: {
+    id: string;
+    workspaceSlug: string;
+    stats: ReviewPacketSummaryStats;
+    sent?: boolean;
+  }): StoredReviewPacketRun | null {
+    const existing = this.getRun(params.id, params.workspaceSlug);
+    if (!existing) {
+      return null;
+    }
+
+    const nextStats: ReviewPacketRunStats = {
+      ...existing.stats,
+      summary: params.stats,
+    };
+
+    if (params.sent) {
+      this.db
+        .prepare(
+          `
+          UPDATE review_packet_runs
+          SET status = ?,
+              summary_sent_at = ?,
+              summary_channel = ?,
+              stats_json = ?,
+              error = NULL
+          WHERE id = ? AND workspace_slug = ?
+          `
+        )
+        .run(
+          "summary_sent",
+          params.stats.sentAt ?? formatIsoOffsetInTimezone(new Date(), config.timezone),
+          params.stats.channel ?? "wechat_work",
+          JSON.stringify(nextStats),
+          params.id,
+          params.workspaceSlug,
+        );
+    } else {
+      this.db
+        .prepare(
+          `
+          UPDATE review_packet_runs
+          SET stats_json = ?,
+              error = NULL
+          WHERE id = ? AND workspace_slug = ?
+          `
+        )
+        .run(JSON.stringify(nextStats), params.id, params.workspaceSlug);
+    }
+
+    return this.getRun(params.id, params.workspaceSlug);
+  }
+
+  markFailed(params: {
+    id: string;
+    workspaceSlug: string;
+    error: string;
+  }): StoredReviewPacketRun | null {
+    this.db
+      .prepare(
+        `
+        UPDATE review_packet_runs
+        SET status = ?,
+            error = ?
+        WHERE id = ? AND workspace_slug = ?
+        `
+      )
+      .run("failed", params.error, params.id, params.workspaceSlug);
+
+    return this.getRun(params.id, params.workspaceSlug);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `review_packet_runs` SQLite table to `database.ts` schema with workspace scoping and indexes
- Add `ReviewPacketStorage` service class with full CRUD lifecycle: `createRun` → `recordFeedbackImport` → `updateSummaryStats` / `markFailed`
- 4 tests covering create/retrieve/list, feedback import + summary updates, failure marking, and workspace isolation

This is the first small slice extracted from the deferred Feedback Loop V1 PR (#354, closed). It establishes the storage contract that feedback import, summary preview, and web operations slices will build on.

## Test plan
- [x] `npm test` — 465/465 passed (4 new), 75 test files
- [x] `make check` — all checks pass
- [x] New tests: create/list, feedback import + summary, mark failed, workspace isolation