### PR TITLE
feat(api): add feedback summary service (Feedback Loop V1 slice 3)

### DIFF
--- a/apps/api/src/services/feedback-summary-service.test.ts
+++ b/apps/api/src/services/feedback-summary-service.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { FeedbackSummaryService } from "./feedback-summary-service";
+
+describe("FeedbackSummaryService", () => {
+  it("builds aggregate-first summary data from packet, statuses, and actions", () => {
+    const service = new FeedbackSummaryService();
+    const summary = service.buildSummary({
+      run: {
+        id: "packet-1",
+        workspaceSlug: "hr",
+        source: "convex",
+        format: "xlsx",
+        status: "feedback_imported",
+        totalCount: 3,
+        packetFilename: "packet-1.xlsx",
+        exportedAt: "2026-03-20T09:00:00+08:00",
+        feedbackImportedAt: "2026-03-20T10:00:00+08:00",
+        items: [
+          { resumeId: "resume-1", identityKey: "id-1", name: "Alice" },
+          { resumeId: "resume-2", identityKey: "id-2", name: "Bob" },
+          { resumeId: "resume-3", identityKey: "id-3", name: "Carol" },
+        ],
+        stats: {
+          import: {
+            importedAt: "2026-03-20T10:00:00+08:00",
+            fileName: "reviewed.xlsx",
+            totalRows: 2,
+            matchedRows: 2,
+            importedRows: 2,
+            reviewedCount: 2,
+            statusUpdates: 2,
+            actionUpdates: 2,
+            noteUpdates: 0,
+            invalidRows: 0,
+            duplicateRows: 0,
+            warningCount: 1,
+            matchedByProfileUrlCount: 0,
+            nameMismatchCount: 1,
+            reviewedResumeIds: ["resume-1", "resume-2"],
+            warnings: ["Name edited"],
+          },
+        },
+      },
+      statuses: [
+        { identityKey: "id-1", status: "interviewed_pass" },
+        { identityKey: "id-2", status: "offer" },
+      ],
+      actions: [
+        {
+          id: 1,
+          resumeId: "resume-1",
+          actionType: "shortlist",
+          createdAt: "2026-03-20T10:00:00+08:00",
+        },
+        {
+          id: 2,
+          resumeId: "resume-2",
+          actionType: "contact",
+          createdAt: "2026-03-20T10:05:00+08:00",
+        },
+      ],
+    });
+
+    expect(summary.totalExported).toBe(3);
+    expect(summary.reviewedCount).toBe(2);
+    expect(summary.pendingCount).toBe(1);
+    expect(summary.warningCount).toBe(1);
+    expect(summary.statusBreakdown).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: "interviewed_pass", count: 1 }),
+      expect.objectContaining({ key: "offer", count: 1 }),
+      expect.objectContaining({ key: "new", count: 1 }),
+    ]));
+    expect(summary.actionBreakdown).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: "shortlist", count: 1 }),
+      expect.objectContaining({ key: "contact", count: 1 }),
+    ]));
+    expect(summary.warnings).toEqual(["Name edited"]);
+  });
+});

--- a/apps/api/src/services/feedback-summary-service.ts
+++ b/apps/api/src/services/feedback-summary-service.ts
@@ -1,0 +1,152 @@
+import type { CandidateAction } from "./action-storage.js";
+import type {
+  ReviewPacketSummaryStats,
+  StoredReviewPacketRun,
+} from "./review-packet-storage.js";
+
+type CandidateStatusRecord = {
+  identityKey: string;
+  status: string;
+};
+
+type SummaryCountEntry = {
+  key: string;
+  label: string;
+  count: number;
+};
+
+export type FeedbackSummaryData = {
+  packetId: string;
+  workspaceSlug: string;
+  source: "sample" | "convex";
+  sampleName?: string;
+  sessionId?: string;
+  jobDescriptionId?: string;
+  exportedAt: string;
+  feedbackImportedAt?: string;
+  summarySentAt?: string;
+  totalExported: number;
+  reviewedCount: number;
+  pendingCount: number;
+  warningCount: number;
+  statusBreakdown: SummaryCountEntry[];
+  actionBreakdown: SummaryCountEntry[];
+  warnings: string[];
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  new: "New",
+  contacted: "Contacted",
+  interviewing: "Interviewing",
+  interviewed_pass: "Interview Passed",
+  interviewed_reject: "Interview Rejected",
+  offer: "Offer",
+  hired: "Hired",
+  withdrawn: "Withdrawn",
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  shortlist: "Shortlist",
+  reject: "Reject",
+  star: "Star",
+  archive: "Archive",
+  note: "Note",
+  contact: "Contact",
+  ai_score_like: "AI Score Like",
+  ai_score_unlike: "AI Score Unlike",
+  ai_summary_like: "AI Summary Like",
+  ai_summary_unlike: "AI Summary Unlike",
+};
+
+function toSortedEntries(counts: Map<string, number>, labels: Record<string, string>): SummaryCountEntry[] {
+  return Array.from(counts.entries())
+    .filter(([, count]) => count > 0)
+    .sort((left, right) => {
+      if (right[1] !== left[1]) {
+        return right[1] - left[1];
+      }
+      return left[0].localeCompare(right[0]);
+    })
+    .map(([key, count]) => ({
+      key,
+      label: labels[key] ?? key,
+      count,
+    }));
+}
+
+function buildStatusCounts(
+  run: StoredReviewPacketRun,
+  statuses: CandidateStatusRecord[],
+): Map<string, number> {
+  const byIdentity = new Map(statuses.map((item) => [item.identityKey, item.status]));
+  const counts = new Map<string, number>();
+  for (const item of run.items) {
+    const status = byIdentity.get(item.identityKey) ?? "new";
+    counts.set(status, (counts.get(status) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function buildActionCounts(actions: CandidateAction[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const action of actions) {
+    counts.set(action.actionType, (counts.get(action.actionType) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export class FeedbackSummaryService {
+  buildSummary(params: {
+    run: StoredReviewPacketRun;
+    statuses: CandidateStatusRecord[];
+    actions: CandidateAction[];
+  }): FeedbackSummaryData {
+    const reviewedResumeIds = new Set(params.run.stats?.import?.reviewedResumeIds ?? []);
+    const reviewedCount = reviewedResumeIds.size;
+    const pendingCount = Math.max(params.run.totalCount - reviewedCount, 0);
+    const warningCount = params.run.stats?.import?.warningCount ?? 0;
+    const warnings = (params.run.stats?.import?.warnings ?? []).slice(0, 5);
+
+    const statusBreakdown = toSortedEntries(buildStatusCounts(params.run, params.statuses), STATUS_LABELS);
+    const actionBreakdown = toSortedEntries(buildActionCounts(params.actions), ACTION_LABELS);
+
+    return {
+      packetId: params.run.id,
+      workspaceSlug: params.run.workspaceSlug,
+      source: params.run.source,
+      sampleName: params.run.sampleName,
+      sessionId: params.run.sessionId,
+      jobDescriptionId: params.run.jobDescriptionId,
+      exportedAt: params.run.exportedAt,
+      feedbackImportedAt: params.run.feedbackImportedAt,
+      summarySentAt: params.run.summarySentAt,
+      totalExported: params.run.totalCount,
+      reviewedCount,
+      pendingCount,
+      warningCount,
+      statusBreakdown,
+      actionBreakdown,
+      warnings,
+    };
+  }
+
+  toSummaryStats(
+    summary: FeedbackSummaryData,
+    params: {
+      previewedAt?: string;
+      sentAt?: string;
+      channel?: string;
+    } = {}
+  ): ReviewPacketSummaryStats {
+    return {
+      previewedAt: params.previewedAt,
+      sentAt: params.sentAt,
+      channel: params.channel,
+      reviewedCount: summary.reviewedCount,
+      pendingCount: summary.pendingCount,
+      warningCount: summary.warningCount,
+      statusBreakdown: Object.fromEntries(summary.statusBreakdown.map((item) => [item.key, item.count])),
+      actionBreakdown: Object.fromEntries(summary.actionBreakdown.map((item) => [item.key, item.count])),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add `FeedbackSummaryService` for building review-packet feedback summaries
- Status/action count aggregation from candidate records with labeled breakdown entries
- Conversion to `ReviewPacketSummaryStats` for storage persistence
- 1 test covering summary build with status/action breakdowns

Builds on slices 1-2: review-packet storage (PR #406) + feedback import (PR #407).

## Test plan
- [x] `npm test` — 469/469 passed (1 new), 77 test files
- [x] `make check` — all checks pass