### PR TITLE
feat(api): add review packet wechat template rendering

### DIFF
--- a/apps/api/src/services/notification-template-service.test.ts
+++ b/apps/api/src/services/notification-template-service.test.ts
@@ -43,6 +43,28 @@ const createFixtureRoot = (): string => {
     ].join("\n"),
   );
 
+  fs.writeFileSync(
+    path.join(templatesDir, "review-packet-wechat.md"),
+    [
+      "# Review Packet {{packetId}}",
+      "",
+      "{{#if statusBreakdown}}",
+      "## Status Breakdown",
+      "{{#each statusBreakdown}}",
+      "- {{this.label}}: {{this.count}}",
+      "{{/each}}",
+      "{{/if}}",
+      "",
+      "{{#if warnings}}",
+      "## Attention",
+      "{{#each warnings}}",
+      "- {{this}}",
+      "{{/each}}",
+      "{{/if}}",
+      "",
+    ].join("\n"),
+  );
+
   return root;
 };
 
@@ -92,6 +114,26 @@ describe("NotificationTemplateService", () => {
       const rendered = service.render("shortlist-wechat", { note: "Check ASAP" });
 
       expect(rendered.markdown).toContain("Note: Check ASAP");
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("renders packet warning sections only when present", () => {
+    const root = createFixtureRoot();
+    try {
+      const service = new NotificationTemplateService(root);
+      const rendered = service.render("review-packet-wechat", {
+        packetId: "packet-1",
+        statusBreakdown: [{ label: "Offer", count: 2 }],
+        warnings: ["Name edited"],
+      });
+
+      expect(rendered.markdown).toContain("# Review Packet packet-1");
+      expect(rendered.markdown).toContain("## Status Breakdown");
+      expect(rendered.markdown).toContain("- Offer: 2");
+      expect(rendered.markdown).toContain("## Attention");
+      expect(rendered.markdown).toContain("- Name edited");
     } finally {
       cleanupFixtureRoot(root);
     }

--- a/apps/api/src/services/notification-template-service.ts
+++ b/apps/api/src/services/notification-template-service.ts
@@ -80,6 +80,9 @@ function resolveValue(token: string, ctx: RenderContext): unknown {
   const trimmed = token.trim();
   if (trimmed === "this") return ctx.thisValue;
   if (trimmed === "@index") return ctx.index;
+  if (trimmed.startsWith("this.") && isRecord(ctx.thisValue)) {
+    return getPathValue(ctx.thisValue, trimmed.slice("this.".length));
+  }
   return getPathValue(ctx.root, trimmed);
 }
 
@@ -291,4 +294,3 @@ export class NotificationTemplateService {
 }
 
 export const notificationTemplateService = new NotificationTemplateService();
-

--- a/config/notifications/review-packet-wechat.md
+++ b/config/notifications/review-packet-wechat.md
@@ -1,0 +1,33 @@
+# Review Packet {{packetId}}
+
+- Workspace: {{workspaceSlug}}
+- Source: {{source}}
+- Exported At: {{exportedAt}}
+- Feedback Imported At: {{feedbackImportedAt}}
+- Total Exported: {{totalExported}}
+- Reviewed: {{reviewedCount}}
+- Pending: {{pendingCount}}
+- Warnings: {{warningCount}}
+
+{{#if statusBreakdown}}
+## Status Breakdown
+{{#each statusBreakdown}}
+- {{this.label}}: {{this.count}}
+{{/each}}
+{{/if}}
+
+{{#if actionBreakdown}}
+## Action Breakdown
+{{#each actionBreakdown}}
+- {{this.label}}: {{this.count}}
+{{/each}}
+{{/if}}
+
+{{#if warnings}}
+## Attention
+{{#each warnings}}
+- {{this}}
+{{/each}}
+{{/if}}
+
+_Generated at {{timestamp}}_


### PR DESCRIPTION
## Summary
- add `this.field` support for notification template `{{#each}}` loops
- add the review-packet WeChat markdown template used by feedback summaries
- extend notification template tests to cover structured loop items and packet warnings

## Testing
- npx vitest run apps/api/src/services/notification-template-service.test.ts
- make check