### PR TITLE
feat(api): add review packet routes

### DIFF
--- a/apps/api/src/middleware/workspace.ts
+++ b/apps/api/src/middleware/workspace.ts
@@ -13,7 +13,8 @@ const WORKSPACE_HEADER = "X-Workspace-Slug";
 
 export const workspaceMiddleware: MiddlewareHandler = async (c, next) => {
   const rawSlug = c.req.header(WORKSPACE_HEADER);
-  const candidate = rawSlug?.trim() || DEFAULT_WORKSPACE;
+  const querySlug = c.req.query("workspaceSlug");
+  const candidate = rawSlug?.trim() || querySlug?.trim() || DEFAULT_WORKSPACE;
 
   if (!isValidWorkspace(candidate)) {
     return c.json(

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -2,6 +2,8 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { bodyLimit } from "hono/body-limit";
 import type { Context } from "hono";
 import { randomUUID } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
 import {
   ResumesQuerySchema,
   ResumesResponseSchema,
@@ -21,6 +23,17 @@ import {
   ResumeExportLegacyResumeSchema,
   ResumeExportResolvedResumeSchema,
   ResumeExportRequestSchema,
+  ReviewPacketExportRequestSchema,
+  ReviewPacketFeedbackImportFormSchema,
+  ReviewPacketFeedbackImportRequestSchema,
+  ReviewPacketFeedbackImportResponseSchema,
+  ReviewPacketRunSchema,
+  ReviewPacketRunsResponseSchema,
+  ReviewPacketSummaryPreviewRequestSchema,
+  ReviewPacketSummaryPreviewResponseSchema,
+  ReviewPacketSummarySendRequestSchema,
+  ReviewPacketSummarySendResponseSchema,
+  ReviewPacketTrackedExportResponseSchema,
   MatchRequestSchema,
   MatchResponseSchema,
   ResumeMatchesResponseSchema,
@@ -68,8 +81,12 @@ import {
   ExportService,
   type ExportFormat,
   type ExportBatchMeta,
+  type ReviewPacketExportOptions,
   type ResumeExportEntry,
 } from "../services/export-service.js";
+import { ActionStorage } from "../services/action-storage.js";
+import { FeedbackImportService, normalizeProfileIdentityKey } from "../services/feedback-import-service.js";
+import { FeedbackSummaryService } from "../services/feedback-summary-service.js";
 import {
   computeEffectiveIndustryDbV2Raw,
   computeBatchStats,
@@ -77,6 +94,14 @@ import {
 } from "../services/industry-db-batch-stats.js";
 import { submitResumeImport } from "../services/resume-import-service.js";
 import { getManualResumeImportMaxUploadBytes, importManualResumes } from "../services/manual-resume-import-service.js";
+import { notificationService } from "../services/notification-service.js";
+import { notificationTemplateService } from "../services/notification-template-service.js";
+import {
+  ReviewPacketStorage,
+  type ReviewPacketItemSnapshot,
+  type StoredReviewPacketRun,
+} from "../services/review-packet-storage.js";
+import { formatIsoOffsetInTimezone } from "../services/timezone.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { BrandDisplayResolver } from "../services/brand-display-resolver.js";
 
@@ -95,10 +120,14 @@ const ingestComputeService = new IngestComputeService(config.projectRoot);
 const skillsKnowledgeService = new SkillsKnowledgeService(config.projectRoot);
 const companyPatterns = skillsKnowledgeService.getCompanyPatterns();
 const searchEventLogger = new SearchEventLogger(config.projectRoot);
+const actionStorage = new ActionStorage(config.projectRoot);
 const exportService = new ExportService(
   new BrandDisplayResolver(config.projectRoot, companyPatterns),
   companyPatterns
 );
+const reviewPacketStorage = new ReviewPacketStorage(config.projectRoot);
+const feedbackImportService = new FeedbackImportService();
+const feedbackSummaryService = new FeedbackSummaryService();
 
 const DEFAULT_AI_TOP_N = 20;
 const DEFAULT_CONVEX_RESUME_PAGE_SIZE = 50;
@@ -153,8 +182,10 @@ const ResumeResetResponseSchema = z.object({
 
 type ResumeExportCanonicalRequest = z.infer<typeof ResumeExportCanonicalRequestSchema>;
 type ResumeExportRequest = z.infer<typeof ResumeExportRequestSchema>;
+type ReviewPacketExportRequest = z.infer<typeof ReviewPacketExportRequestSchema>;
 type ResumeExportEntryContext = ResumeExportCanonicalRequest["entries"][number];
 type ResumeExportLegacyEntryContext = z.infer<typeof ResumeExportLegacyRequestSchema>["entries"][number];
+type ReviewPacketSummaryTemplateRequest = z.infer<typeof ReviewPacketSummaryPreviewRequestSchema>;
 type ExportResumePayload = ResumeExportEntry["resume"];
 type ResumeExportEntryFields = Omit<ResumeExportEntry, "key" | "resume">;
 type ResumeSource = "sample" | "convex";
@@ -173,6 +204,14 @@ type PreparedResumeCandidate = {
   brandHits: BrandHit[];
   companyHits: string[];
   roleSignals: RoleSignalSummary[];
+};
+type ReviewPacketResolvedRecord = {
+  resumeId: string;
+  resume: ExportResumePayload;
+  identityKey: string;
+  profileUrl?: string;
+  name?: string;
+  source?: string;
 };
 
 function stripFrontMatter(content: string): string {
@@ -1056,6 +1095,136 @@ function resolveSampleExportResumeMap(
   return resolved;
 }
 
+function buildReviewPacketIdentityKey(params: {
+  resumeId: string;
+  profileUrl?: string;
+  source?: string;
+}): string {
+  const profileIdentityKey = normalizeProfileIdentityKey(params.profileUrl, params.source);
+  if (profileIdentityKey) {
+    return profileIdentityKey;
+  }
+  return `resumeId:${params.resumeId.trim().toLowerCase()}`;
+}
+
+function toReviewPacketItemSnapshot(
+  record: ReviewPacketResolvedRecord
+): ReviewPacketItemSnapshot {
+  return {
+    resumeId: record.resumeId,
+    identityKey: record.identityKey,
+    profileUrl: record.profileUrl,
+    name: record.name,
+    source: record.source,
+  };
+}
+
+function buildReviewPacketEntriesFromResolvedRecords(
+  entries: ResumeExportEntryContext[],
+  resolvedRecords: Map<string, ReviewPacketResolvedRecord>
+): {
+  entries: ResumeExportEntry[];
+  items: ReviewPacketItemSnapshot[];
+} {
+  const missingIds: string[] = [];
+  const exportEntries: ResumeExportEntry[] = [];
+  const items: ReviewPacketItemSnapshot[] = [];
+
+  for (const entry of entries) {
+    const resolved = resolvedRecords.get(entry.resumeId);
+    if (!resolved) {
+      missingIds.push(entry.resumeId);
+      continue;
+    }
+
+    exportEntries.push(toExportEntry(entry.resumeId, resolved.resume, toExportEntryFields(entry)));
+    items.push(toReviewPacketItemSnapshot(resolved));
+  }
+
+  if (missingIds.length > 0) {
+    throw new DataNotFoundError(`Unable to resolve resumes for review packet export: ${missingIds.join(", ")}`);
+  }
+
+  return {
+    entries: exportEntries,
+    items,
+  };
+}
+
+async function resolveConvexReviewPacketRecordMap(
+  entries: ResumeExportEntryContext[]
+): Promise<Map<string, ReviewPacketResolvedRecord>> {
+  const resumeIds = Array.from(new Set(entries.map((entry) => entry.resumeId.trim()).filter(Boolean)));
+  if (resumeIds.length === 0) {
+    return new Map();
+  }
+
+  const value = await callConvexQuery("resumes:getByIdsForExport", { resumeIds });
+  if (!Array.isArray(value)) {
+    throw new Error("Invalid export resume response from Convex");
+  }
+
+  const resolved = new Map<string, ReviewPacketResolvedRecord>();
+  value.forEach((item) => {
+    if (!isRecord(item) || typeof item.resumeId !== "string" || item.resumeId.length === 0) {
+      return;
+    }
+    const parsedResume = ResumeExportResolvedResumeSchema.safeParse(item.resume);
+    if (!parsedResume.success) {
+      return;
+    }
+
+    const resumeId = item.resumeId;
+    const resume = normalizeExportResumePayload(parsedResume.data);
+    resolved.set(resumeId, {
+      resumeId,
+      resume,
+      identityKey: buildReviewPacketIdentityKey({
+        resumeId,
+        profileUrl: resume.profileUrl,
+        source: resume.source,
+      }),
+      profileUrl: resume.profileUrl,
+      name: resume.name,
+      source: resume.source,
+    });
+  });
+
+  return resolved;
+}
+
+function resolveSampleReviewPacketRecordMap(
+  sampleName: string,
+  entries: ResumeExportEntryContext[]
+): Map<string, ReviewPacketResolvedRecord> {
+  const { items } = resumeService.loadSample(sampleName);
+  const requestedIds = new Set(entries.map((entry) => entry.resumeId.trim()).filter(Boolean));
+  const resolved = new Map<string, ReviewPacketResolvedRecord>();
+
+  items.forEach((resume, index) => {
+    const resumeId = resolveResumeId(resume, index);
+    if (!requestedIds.has(resumeId)) {
+      return;
+    }
+
+    const payload = toExportResumePayload(resume);
+    resolved.set(resumeId, {
+      resumeId,
+      resume: payload,
+      identityKey: buildReviewPacketIdentityKey({
+        resumeId,
+        profileUrl: payload.profileUrl,
+        source: payload.source,
+      }),
+      profileUrl: payload.profileUrl,
+      name: payload.name,
+      source: payload.source,
+    });
+  });
+
+  return resolved;
+}
+
 function buildExportEntriesFromResolvedResumes(
   entries: ResumeExportEntryContext[],
   resolvedResumes: Map<string, ExportResumePayload>
@@ -1120,6 +1289,120 @@ async function resolveExportRequest(
     },
     industryDbV2Stats,
     debug: isCanonicalExportRequest(request) ? (request.debug ?? process.env.DEBUG === "true") : process.env.DEBUG === "true",
+  };
+}
+
+async function resolveReviewPacketExportRequest(
+  request: ReviewPacketExportRequest
+): Promise<{
+  format: ExportFormat;
+  source: ResumeSource;
+  sampleName?: string;
+  sessionId?: string;
+  jobDescriptionId?: string;
+  entries: ResumeExportEntry[];
+  items: ReviewPacketItemSnapshot[];
+  batchMeta: ExportBatchMeta;
+  industryDbV2Stats: IndustryDbV2BatchStats;
+  debug: boolean;
+}> {
+  const resolvedRecords = request.source === "sample"
+    ? resolveSampleReviewPacketRecordMap(request.sample ?? "", request.entries)
+    : await resolveConvexReviewPacketRecordMap(request.entries);
+  const resolved = buildReviewPacketEntriesFromResolvedRecords(request.entries, resolvedRecords);
+  const industryDbV2Stats = request.industryDbV2Stats
+    ?? computeBatchStats(resolved.entries.map((entry) => computeEffectiveIndustryDbV2Raw(entry.resume.ingestData)));
+
+  return {
+    format: request.format,
+    source: request.source,
+    sampleName: request.sample?.trim() || undefined,
+    sessionId: request.sessionId?.trim() || undefined,
+    jobDescriptionId: request.jobDescriptionId?.trim() || undefined,
+    entries: resolved.entries,
+    items: resolved.items,
+    batchMeta: {
+      userComment: request.userComment,
+      referenceNote: request.referenceNote,
+    },
+    industryDbV2Stats,
+    debug: request.debug ?? process.env.DEBUG === "true",
+  };
+}
+
+function buildReviewPacketDownloadPath(runId: string): string {
+  return `/api/resumes/review-packets/${encodeURIComponent(runId)}/download`;
+}
+
+function buildReviewPacketSessionId(runId: string): string {
+  return `review-packet:${runId}`;
+}
+
+function buildReviewPacketFilename(runId: string, format: ExportFormat): string {
+  return `review-packet-${runId}.${format}`;
+}
+
+function getReviewPacketOutputDir(): string {
+  return path.join(config.projectRoot, "output", "review-packets");
+}
+
+function getReviewPacketFilePath(runId: string, format: ExportFormat): string {
+  return path.join(getReviewPacketOutputDir(), buildReviewPacketFilename(runId, format));
+}
+
+function toPublicReviewPacketRun(run: StoredReviewPacketRun): z.infer<typeof ReviewPacketRunSchema> {
+  const importStats = run.stats?.import
+    ? {
+        importedAt: run.stats.import.importedAt,
+        fileName: run.stats.import.fileName,
+        totalRows: run.stats.import.totalRows,
+        matchedRows: run.stats.import.matchedRows,
+        importedRows: run.stats.import.importedRows,
+        reviewedCount: run.stats.import.reviewedCount,
+        statusUpdates: run.stats.import.statusUpdates,
+        actionUpdates: run.stats.import.actionUpdates,
+        noteUpdates: run.stats.import.noteUpdates,
+        invalidRows: run.stats.import.invalidRows,
+        duplicateRows: run.stats.import.duplicateRows,
+        warningCount: run.stats.import.warningCount,
+        matchedByProfileUrlCount: run.stats.import.matchedByProfileUrlCount,
+        nameMismatchCount: run.stats.import.nameMismatchCount,
+        warnings: run.stats.import.warnings,
+      }
+    : undefined;
+  const summaryStats = run.stats?.summary
+    ? {
+        previewedAt: run.stats.summary.previewedAt,
+        sentAt: run.stats.summary.sentAt,
+        channel: run.stats.summary.channel,
+        reviewedCount: run.stats.summary.reviewedCount,
+        pendingCount: run.stats.summary.pendingCount,
+        warningCount: run.stats.summary.warningCount,
+        statusBreakdown: run.stats.summary.statusBreakdown,
+        actionBreakdown: run.stats.summary.actionBreakdown,
+      }
+    : undefined;
+
+  return {
+    id: run.id,
+    workspaceSlug: run.workspaceSlug,
+    source: run.source,
+    sampleName: run.sampleName,
+    sessionId: run.sessionId,
+    jobDescriptionId: run.jobDescriptionId,
+    format: run.format,
+    status: run.status,
+    totalCount: run.totalCount,
+    packetFilename: run.packetFilename,
+    exportedAt: run.exportedAt,
+    feedbackImportedAt: run.feedbackImportedAt,
+    summarySentAt: run.summarySentAt,
+    summaryChannel: run.summaryChannel,
+    stats: importStats || summaryStats ? {
+      ...(importStats ? { import: importStats } : {}),
+      ...(summaryStats ? { summary: summaryStats } : {}),
+    } : undefined,
+    error: run.error,
   };
 }
 
@@ -2684,6 +2967,255 @@ const exportResumesRoute = createRoute({
   },
 });
 
+const ReviewPacketPathParamSchema = z.object({
+  runId: z.string().min(1).openapi({
+    param: { name: "runId", in: "path" },
+    example: "review-packet-123",
+  }),
+});
+
+const ReviewPacketRunsQuerySchema = z.object({
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .openapi({
+      param: { name: "limit", in: "query" },
+      example: 20,
+    }),
+});
+
+const trackedReviewPacketExportRoute = createRoute({
+  method: "post",
+  path: "/api/resumes/review-packets/export",
+  tags: ["resumes"],
+  summary: "Create a tracked review packet export run",
+  request: {
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: ReviewPacketExportRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ReviewPacketTrackedExportResponseSchema,
+        },
+      },
+      description: "Tracked review packet export metadata",
+    },
+    404: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Selected resumes could not be resolved",
+    },
+    500: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Tracked export failed",
+    },
+  },
+});
+
+const listReviewPacketRunsRoute = createRoute({
+  method: "get",
+  path: "/api/resumes/review-packets",
+  tags: ["resumes"],
+  summary: "List tracked review packet runs",
+  request: {
+    query: ReviewPacketRunsQuerySchema,
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ReviewPacketRunsResponseSchema,
+        },
+      },
+      description: "Review packet runs",
+    },
+  },
+});
+
+const getReviewPacketRunRoute = createRoute({
+  method: "get",
+  path: "/api/resumes/review-packets/{runId}",
+  tags: ["resumes"],
+  summary: "Get tracked review packet run metadata",
+  request: {
+    params: ReviewPacketPathParamSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            success: z.literal(true),
+            run: ReviewPacketRunSchema,
+          }),
+        },
+      },
+      description: "Review packet run",
+    },
+    404: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Run not found",
+    },
+    500: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Run lookup failed",
+    },
+  },
+});
+
+const downloadReviewPacketRoute = createRoute({
+  method: "get",
+  path: "/api/resumes/review-packets/{runId}/download",
+  tags: ["resumes"],
+  summary: "Download a tracked review packet file",
+  request: {
+    params: ReviewPacketPathParamSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        "text/csv": {
+          schema: ResumeExportBinaryResponseSchema,
+        },
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
+          schema: ResumeExportBinaryResponseSchema,
+        },
+      },
+      description: "Review packet file",
+    },
+    404: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Run not found",
+    },
+    500: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Download failed",
+    },
+  },
+});
+
+const importReviewPacketFeedbackRoute = createRoute({
+  method: "post",
+  path: "/api/resumes/review-packets/{runId}/feedback-import",
+  tags: ["resumes"],
+  summary: "Import reviewed CSV/XLSX feedback for a tracked review packet",
+  request: {
+    params: ReviewPacketPathParamSchema,
+    body: {
+      required: true,
+      content: {
+        "multipart/form-data": {
+          schema: ReviewPacketFeedbackImportRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ReviewPacketFeedbackImportResponseSchema,
+        },
+      },
+      description: "Feedback import result",
+    },
+    404: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Run not found",
+    },
+    400: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Invalid import payload",
+    },
+    500: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Feedback import failed",
+    },
+  },
+});
+
+const previewReviewPacketSummaryRoute = createRoute({
+  method: "post",
+  path: "/api/resumes/review-packets/{runId}/summary-preview",
+  tags: ["resumes"],
+  summary: "Preview the WeChat summary for a tracked review packet",
+  request: {
+    params: ReviewPacketPathParamSchema,
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: ReviewPacketSummaryPreviewRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ReviewPacketSummaryPreviewResponseSchema,
+        },
+      },
+      description: "Summary preview",
+    },
+    404: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Run not found",
+    },
+    500: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Summary preview failed",
+    },
+  },
+});
+
+const sendReviewPacketSummaryRoute = createRoute({
+  method: "post",
+  path: "/api/resumes/review-packets/{runId}/summary-send",
+  tags: ["resumes"],
+  summary: "Send the WeChat summary for a tracked review packet",
+  request: {
+    params: ReviewPacketPathParamSchema,
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: ReviewPacketSummarySendRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ReviewPacketSummarySendResponseSchema,
+        },
+      },
+      description: "Summary send result",
+    },
+    404: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Run not found",
+    },
+    500: {
+      content: { "application/json": { schema: SimpleErrorSchema } },
+      description: "Summary send failed",
+    },
+  },
+});
+
 const rescoreResumeMatchesRoute = createRoute({
   method: "post",
   path: "/api/resumes/matches/rescore",
@@ -3174,12 +3706,352 @@ function buildResumeExportErrorResponse(c: Context, error: unknown) {
   return c.json({ success: false, error: message }, 500);
 }
 
+function buildReviewPacketErrorResponse(c: Context, error: unknown) {
+  if (error instanceof DataNotFoundError) {
+    return c.json({ success: false as const, error: error.message }, 404);
+  }
+
+  console.error("Review packet flow failed:", error);
+  const message = error instanceof Error ? error.message : String(error);
+  return c.json({ success: false as const, error: message }, 500);
+}
+
+function getReviewPacketRunOrThrow(runId: string, workspaceSlug: string): StoredReviewPacketRun {
+  const run = reviewPacketStorage.getRun(runId, workspaceSlug);
+  if (!run) {
+    throw new DataNotFoundError(`Review packet run not found: ${runId}`);
+  }
+  return run;
+}
+
+function markReviewPacketRunFailed(runId: string, workspaceSlug: string, error: unknown): void {
+  reviewPacketStorage.markFailed({
+    id: runId,
+    workspaceSlug,
+    error: error instanceof Error ? error.message : String(error),
+  });
+}
+
+async function saveReviewPacketFile(options: {
+  runId: string;
+  format: ExportFormat;
+  entries: ResumeExportEntry[];
+  exportOptions: ReviewPacketExportOptions;
+}): Promise<void> {
+  const file = await exportService.exportReviewPacket(options.format, options.entries, options.exportOptions);
+  await mkdir(getReviewPacketOutputDir(), { recursive: true });
+  await writeFile(getReviewPacketFilePath(options.runId, options.format), file.content);
+}
+
+async function buildReviewPacketDownloadResponse(run: StoredReviewPacketRun): Promise<Response> {
+  const filePath = getReviewPacketFilePath(run.id, run.format);
+  let content: Buffer;
+
+  try {
+    content = await readFile(filePath);
+  } catch {
+    throw new DataNotFoundError(`Stored review packet file missing for run: ${run.id}`, {
+      suggestion: "Re-export the review packet to recreate the stored file.",
+    });
+  }
+
+  const contentType = run.format === "xlsx"
+    ? "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    : "text/csv; charset=utf-8";
+
+  return new Response(content, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Content-Disposition": `attachment; filename="${run.packetFilename ?? buildReviewPacketFilename(run.id, run.format)}"`,
+      "Content-Length": String(content.byteLength),
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+type ReviewPacketStatusListItem = {
+  identityKey: string;
+  status: string;
+};
+
+function toReviewPacketStatusListItem(value: unknown): ReviewPacketStatusListItem | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const identityKey = toStringValue(value.identityKey);
+  const status = toStringValue(value.status);
+  if (!identityKey || !status) {
+    return null;
+  }
+
+  return { identityKey, status };
+}
+
+async function buildReviewPacketSummaryPreview(
+  run: StoredReviewPacketRun,
+  request: ReviewPacketSummaryTemplateRequest
+): Promise<{
+  run: StoredReviewPacketRun;
+  templateId: string;
+  content: string;
+  data: ReturnType<FeedbackSummaryService["buildSummary"]>;
+}> {
+  const templateId = request.templateId?.trim() || "review-packet-wechat";
+  const statusValues = await callConvexQuery("candidate_status:list", {
+    workspaceSlug: run.workspaceSlug,
+  });
+  const identityKeys = new Set(run.items.map((item) => item.identityKey));
+  const statuses = Array.isArray(statusValues)
+    ? statusValues
+        .map((value) => toReviewPacketStatusListItem(value))
+        .filter((value): value is ReviewPacketStatusListItem => value !== null)
+        .filter((value) => identityKeys.has(value.identityKey))
+    : [];
+  const reviewPacketSessionId = buildReviewPacketSessionId(run.id);
+  const reviewPacketResumeIds = new Set(run.items.map((item) => item.resumeId));
+  const actions = actionStorage
+    .getLatestActionsForSession(reviewPacketSessionId)
+    .filter((action) => reviewPacketResumeIds.has(action.resumeId));
+
+  const data = feedbackSummaryService.buildSummary({
+    run,
+    statuses,
+    actions,
+  });
+  const timestamp = formatIsoOffsetInTimezone(new Date(), config.timezone);
+  const rendered = notificationTemplateService.render(templateId, {
+    ...data,
+    timestamp,
+  });
+  const updatedRun = reviewPacketStorage.updateSummaryStats({
+    id: run.id,
+    workspaceSlug: run.workspaceSlug,
+    stats: feedbackSummaryService.toSummaryStats(data, {
+      previewedAt: timestamp,
+      sentAt: run.summarySentAt,
+      channel: run.summaryChannel,
+    }),
+    sent: false,
+  }) ?? run;
+
+  return {
+    run: updatedRun,
+    templateId,
+    content: rendered.markdown,
+    data,
+  };
+}
+
 app.openapi(exportResumesRoute, async (c) => {
   try {
     const request = c.req.valid("json");
     return await buildResumeExportResponse(request);
   } catch (error) {
     return buildResumeExportErrorResponse(c, error);
+  }
+});
+
+app.openapi(trackedReviewPacketExportRoute, async (c) => {
+  try {
+    const request = c.req.valid("json");
+    const resolved = await resolveReviewPacketExportRequest(request);
+    const runId = randomUUID();
+    const exportedAt = formatIsoOffsetInTimezone(new Date(), config.timezone);
+
+    await saveReviewPacketFile({
+      runId,
+      format: resolved.format,
+      entries: resolved.entries,
+      exportOptions: {
+        packetRunId: runId,
+        exportedAt,
+        batchMeta: resolved.batchMeta,
+        industryDbV2Stats: resolved.industryDbV2Stats,
+        debug: resolved.debug,
+      },
+    });
+
+    const run = reviewPacketStorage.createRun({
+      id: runId,
+      workspaceSlug: c.var.workspaceSlug,
+      source: resolved.source,
+      sampleName: resolved.sampleName,
+      sessionId: resolved.sessionId,
+      jobDescriptionId: resolved.jobDescriptionId,
+      format: resolved.format,
+      totalCount: resolved.entries.length,
+      packetFilename: buildReviewPacketFilename(runId, resolved.format),
+      exportedAt,
+      items: resolved.items,
+    });
+
+    return c.json({
+      success: true as const,
+      run: toPublicReviewPacketRun(run),
+      downloadPath: buildReviewPacketDownloadPath(run.id),
+    }, 200);
+  } catch (error) {
+    return buildReviewPacketErrorResponse(c, error);
+  }
+});
+
+app.openapi(listReviewPacketRunsRoute, (c) => {
+  const { limit } = c.req.valid("query");
+  const runs = reviewPacketStorage
+    .listRuns(c.var.workspaceSlug, limit ?? 20)
+    .map((run) => toPublicReviewPacketRun(run));
+
+  return c.json({
+    success: true as const,
+    items: runs,
+  }, 200);
+});
+
+app.openapi(getReviewPacketRunRoute, (c) => {
+  try {
+    const { runId } = c.req.valid("param");
+    const run = getReviewPacketRunOrThrow(runId, c.var.workspaceSlug);
+    return c.json({
+      success: true as const,
+      run: toPublicReviewPacketRun(run),
+    }, 200);
+  } catch (error) {
+    return buildReviewPacketErrorResponse(c, error);
+  }
+});
+
+app.openapi(downloadReviewPacketRoute, async (c) => {
+  const { runId } = c.req.valid("param");
+  try {
+    const run = getReviewPacketRunOrThrow(runId, c.var.workspaceSlug);
+    return await buildReviewPacketDownloadResponse(run);
+  } catch (error) {
+    markReviewPacketRunFailed(runId, c.var.workspaceSlug, error);
+    return buildReviewPacketErrorResponse(c, error);
+  }
+});
+
+app.openapi(importReviewPacketFeedbackRoute, async (c) => {
+  const { runId } = c.req.valid("param");
+  try {
+    const run = getReviewPacketRunOrThrow(runId, c.var.workspaceSlug);
+    const formData = await c.req.formData();
+    const parsedForm = ReviewPacketFeedbackImportFormSchema.safeParse({
+      file: formData.get("file"),
+      updatedBy: formData.get("updatedBy") ?? undefined,
+    });
+
+    if (!parsedForm.success) {
+      return c.json({ success: false as const, error: "Expected one CSV or XLSX file" }, 400);
+    }
+
+    const file = parsedForm.data.file;
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const imported = await feedbackImportService.importFeedback({
+      run,
+      fileName: file.name,
+      buffer,
+      updatedBy: parsedForm.data.updatedBy,
+      callbacks: {
+        upsertCandidateStatus: async (params) => {
+          await callConvexMutation("candidate_status:upsert", {
+            workspaceSlug: c.var.workspaceSlug,
+            identityKey: params.identityKey,
+            status: params.status,
+            notes: params.notes,
+            updatedBy: params.updatedBy,
+          });
+        },
+        saveAction: async (params) => {
+          actionStorage.saveAction({
+            sessionId: buildReviewPacketSessionId(run.id),
+            resumeId: params.resumeId,
+            actionType: params.actionType,
+            actionData: {
+              ...params.actionData,
+              workspaceSlug: c.var.workspaceSlug,
+            },
+          });
+        },
+      },
+    });
+
+    const updatedRun = reviewPacketStorage.recordFeedbackImport({
+      id: run.id,
+      workspaceSlug: c.var.workspaceSlug,
+      stats: imported.stats,
+    });
+    if (!updatedRun) {
+      throw new DataNotFoundError(`Review packet run not found after import: ${run.id}`);
+    }
+
+    return c.json({
+      success: true as const,
+      run: toPublicReviewPacketRun(updatedRun),
+      summary: imported.summary,
+      warnings: imported.warnings,
+    }, 200);
+  } catch (error) {
+    markReviewPacketRunFailed(runId, c.var.workspaceSlug, error);
+    return buildReviewPacketErrorResponse(c, error);
+  }
+});
+
+app.openapi(previewReviewPacketSummaryRoute, async (c) => {
+  try {
+    const { runId } = c.req.valid("param");
+    const request = c.req.valid("json");
+    const run = getReviewPacketRunOrThrow(runId, c.var.workspaceSlug);
+    const preview = await buildReviewPacketSummaryPreview(run, request);
+
+    return c.json({
+      success: true as const,
+      run: toPublicReviewPacketRun(preview.run),
+      channel: "wechat_work" as const,
+      templateId: preview.templateId,
+      content: preview.content,
+      data: preview.data,
+    }, 200);
+  } catch (error) {
+    return buildReviewPacketErrorResponse(c, error);
+  }
+});
+
+app.openapi(sendReviewPacketSummaryRoute, async (c) => {
+  try {
+    const { runId } = c.req.valid("param");
+    const request = c.req.valid("json");
+    const run = getReviewPacketRunOrThrow(runId, c.var.workspaceSlug);
+    const preview = await buildReviewPacketSummaryPreview(run, {
+      templateId: request.templateId,
+    });
+    const delivery = await notificationService.sendWechatWorkMarkdown({
+      webhookUrl: request.webhookUrl,
+      content: preview.content,
+    });
+    const sentAt = formatIsoOffsetInTimezone(new Date(), config.timezone);
+    const updatedRun = reviewPacketStorage.updateSummaryStats({
+      id: run.id,
+      workspaceSlug: c.var.workspaceSlug,
+      stats: feedbackSummaryService.toSummaryStats(preview.data, {
+        previewedAt: preview.run.stats?.summary?.previewedAt,
+        sentAt,
+        channel: "wechat_work",
+      }),
+      sent: true,
+    }) ?? preview.run;
+
+    return c.json({
+      success: true as const,
+      run: toPublicReviewPacketRun(updatedRun),
+      channel: "wechat_work" as const,
+      templateId: preview.templateId,
+      delivery,
+    }, 200);
+  } catch (error) {
+    return buildReviewPacketErrorResponse(c, error);
   }
 });
 

--- a/apps/api/src/routes/review-packets.test.ts
+++ b/apps/api/src/routes/review-packets.test.ts
@@ -1,0 +1,364 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import Papa from "papaparse";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ResumeItem } from "../types/resume";
+
+function createFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "review-packets-route-"));
+  fs.mkdirSync(path.join(root, "output"), { recursive: true });
+  fs.mkdirSync(path.join(root, "config", "resume"), { recursive: true });
+  fs.writeFileSync(path.join(root, "pyproject.toml"), "", "utf8");
+  fs.writeFileSync(
+    path.join(root, "config", "resume", "skills.md"),
+    [
+      "---",
+      "version: 1",
+      'updated_at: "2026-03-20"',
+      "---",
+      "",
+      "## Company Patterns",
+      "",
+      "### fanuc",
+      "- aliases: FANUC, 发那科",
+      "- tier: 1",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+  return root;
+}
+
+function buildSampleResume(overrides: Partial<ResumeItem> & { resumeId: string; name: string }): ResumeItem {
+  return {
+    resumeId: overrides.resumeId,
+    name: overrides.name,
+    profileUrl: overrides.profileUrl ?? `https://example.com/${overrides.resumeId}`,
+    activityStatus: overrides.activityStatus ?? "Active",
+    age: overrides.age ?? "30",
+    experience: overrides.experience ?? "5 years",
+    education: overrides.education ?? "Bachelor",
+    location: overrides.location ?? "Dongguan",
+    selfIntro: overrides.selfIntro ?? "Test intro",
+    jobIntention: overrides.jobIntention ?? "Sales Engineer",
+    expectedSalary: overrides.expectedSalary ?? "10k-20k",
+    workHistory: overrides.workHistory ?? [{ raw: "Test work history" }],
+    extractedAt: overrides.extractedAt ?? "2026-03-01T00:00:00.000Z",
+    ingestData: overrides.ingestData,
+    perUserId: overrides.perUserId,
+    profileId: overrides.profileId,
+    profileType: overrides.profileType,
+    externalId: overrides.externalId,
+    profileEducation: overrides.profileEducation,
+    skills: overrides.skills,
+    languages: overrides.languages,
+    licences: overrides.licences,
+    resumeSnippet: overrides.resumeSnippet,
+    currentIndustry: overrides.currentIndustry,
+    currentSubindustry: overrides.currentSubindustry,
+    rightToWork: overrides.rightToWork,
+    digitalIdentity: overrides.digitalIdentity,
+    noticePeriodDays: overrides.noticePeriodDays,
+  };
+}
+
+async function loadReviewPacketModules(root: string) {
+  process.env.PROJECT_ROOT = root;
+  vi.resetModules();
+  const { createApp } = await import("../app");
+  const { ResumeService } = await import("../services/resume-service");
+  const { ReviewPacketStorage } = await import("../services/review-packet-storage");
+  const { ActionStorage } = await import("../services/action-storage");
+  const { resetResumeScreeningDb } = await import("../services/database");
+  const { notificationService } = await import("../services/notification-service");
+  return {
+    createApp,
+    ResumeService,
+    ReviewPacketStorage,
+    ActionStorage,
+    resetResumeScreeningDb,
+    notificationService,
+  };
+}
+
+describe("review packet routes", () => {
+  let root = "";
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    delete process.env.PROJECT_ROOT;
+    if (root) {
+      const { resetResumeScreeningDb } = await import("../services/database");
+      resetResumeScreeningDb();
+      fs.rmSync(root, { recursive: true, force: true });
+      root = "";
+    }
+  });
+
+  it("creates a tracked packet run and downloads HR-friendly packet headers", async () => {
+    root = createFixtureRoot();
+    const { createApp, ResumeService, ReviewPacketStorage } = await loadReviewPacketModules(root);
+
+    vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
+      items: [
+        buildSampleResume({ resumeId: "resume-a", name: "Alice" }),
+        buildSampleResume({ resumeId: "resume-b", name: "Bob" }),
+      ],
+      sample: {
+        name: "sample-test",
+        filename: "sample-test.json",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+        size: 1,
+      },
+      metadata: undefined,
+      indexes: new Map(),
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes/review-packets/export", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        format: "csv",
+        source: "sample",
+        sample: "sample-test",
+        jobDescriptionId: "lathe-sales",
+        entries: [
+          { resumeId: "resume-b", status: "contacted", userComment: "Call Bob" },
+          { resumeId: "resume-a", status: "new" },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      success: boolean;
+      run: { id: string; jobDescriptionId?: string };
+      downloadPath: string;
+    };
+
+    expect(payload.success).toBe(true);
+    expect(payload.run.jobDescriptionId).toBe("lathe-sales");
+
+    const storage = new ReviewPacketStorage(root);
+    const stored = storage.getRun(payload.run.id, "hr");
+    expect(stored?.items.map((item) => item.resumeId)).toEqual(["resume-b", "resume-a"]);
+
+    const download = await app.request(`${payload.downloadPath}?workspaceSlug=hr`);
+    expect(download.status).toBe(200);
+    const parsed = Papa.parse<Record<string, string>>(await download.text(), { header: true });
+    expect(parsed.meta.fields).toContain("Resume ID");
+    expect(parsed.meta.fields).toContain("Packet Run ID");
+    expect(parsed.meta.fields?.slice(-4)).toEqual(["Status", "Action", "User Comment", "Reference Note"]);
+    expect(parsed.data[0]?.["Resume ID"]).toBe("resume-b");
+    expect(parsed.data[0]?.["Packet Run ID"]).toBe(payload.run.id);
+    expect(parsed.data[0]?.["User Comment"]).toBe("Call Bob");
+  });
+
+  it("imports feedback into candidate status and actions using stored packet membership", async () => {
+    root = createFixtureRoot();
+    const { createApp, ReviewPacketStorage, ActionStorage } = await loadReviewPacketModules(root);
+
+    const storage = new ReviewPacketStorage(root);
+    storage.createRun({
+      id: "packet-import",
+      workspaceSlug: "hr",
+      source: "convex",
+      format: "xlsx",
+      totalCount: 1,
+      packetFilename: "packet-import.xlsx",
+      exportedAt: "2026-03-20T09:00:00+08:00",
+      items: [
+        {
+          resumeId: "resume-1",
+          identityKey: "profileUrl:my.employer.seek.com/candidates/503033454",
+          profileUrl: "https://my.employer.seek.com/candidates/503033454",
+          source: "my.employer.seek.com",
+          name: "Alice",
+        },
+      ],
+    });
+
+    const calls: Array<{ pathName: string; args: Record<string, unknown> }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) : {};
+      calls.push({
+        pathName: typeof body.path === "string" ? body.path : "",
+        args: typeof body.args === "object" && body.args ? body.args as Record<string, unknown> : {},
+      });
+      return new Response(JSON.stringify({ status: "success", value: "ok" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const formData = new FormData();
+    formData.append("file", new File([
+      [
+        "Resume ID,Name,Status,Action,Notes",
+        "resume-1,Alice Zhang,interviewed_pass,shortlist,Strong manager fit",
+      ].join("\n"),
+    ], "reviewed.csv", { type: "text/csv" }));
+
+    const app = createApp();
+    const response = await app.request("/api/resumes/review-packets/packet-import/feedback-import", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+      body: formData,
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      success: boolean;
+      summary: { statusUpdates: number; actionUpdates: number; nameMismatchCount: number };
+      warnings: string[];
+    };
+    expect(payload.success).toBe(true);
+    expect(payload.summary.statusUpdates).toBe(1);
+    expect(payload.summary.actionUpdates).toBe(1);
+    expect(payload.summary.nameMismatchCount).toBe(1);
+    expect(payload.warnings.some((warning) => warning.includes("edited Name"))).toBe(true);
+
+    expect(calls[0]).toMatchObject({
+      pathName: "candidate_status:upsert",
+      args: {
+        workspaceSlug: "hr",
+        identityKey: "profileUrl:my.employer.seek.com/candidates/503033454",
+        status: "interviewed_pass",
+        notes: "Strong manager fit",
+      },
+    });
+
+    const actionStorage = new ActionStorage(root);
+    const actions = actionStorage.getLatestActionsForSession("review-packet:packet-import");
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.resumeId).toBe("resume-1");
+    expect(actions[0]?.actionType).toBe("shortlist");
+  });
+
+  it("previews and sends WeChat summaries from packet stats plus packet-scoped actions", async () => {
+    root = createFixtureRoot();
+    const {
+      createApp,
+      ReviewPacketStorage,
+      ActionStorage,
+      notificationService,
+    } = await loadReviewPacketModules(root);
+
+    const storage = new ReviewPacketStorage(root);
+    storage.createRun({
+      id: "packet-summary",
+      workspaceSlug: "hr",
+      source: "convex",
+      format: "xlsx",
+      totalCount: 2,
+      packetFilename: "packet-summary.xlsx",
+      exportedAt: "2026-03-20T09:00:00+08:00",
+      feedbackImportedAt: "2026-03-20T10:00:00+08:00",
+      items: [
+        { resumeId: "resume-1", identityKey: "id-1", name: "Alice" },
+        { resumeId: "resume-2", identityKey: "id-2", name: "Bob" },
+      ],
+      stats: {
+        import: {
+          importedAt: "2026-03-20T10:00:00+08:00",
+          fileName: "reviewed.xlsx",
+          totalRows: 2,
+          matchedRows: 2,
+          importedRows: 2,
+          reviewedCount: 2,
+          statusUpdates: 2,
+          actionUpdates: 1,
+          noteUpdates: 1,
+          invalidRows: 0,
+          duplicateRows: 0,
+          warningCount: 1,
+          matchedByProfileUrlCount: 0,
+          nameMismatchCount: 1,
+          reviewedResumeIds: ["resume-1", "resume-2"],
+          warnings: ["Name edited"],
+        },
+      },
+    });
+
+    const actionStorage = new ActionStorage(root);
+    actionStorage.saveAction({
+      sessionId: "review-packet:packet-summary",
+      resumeId: "resume-1",
+      actionType: "shortlist",
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) : {};
+      if (body.path === "candidate_status:list") {
+        return new Response(JSON.stringify({
+          status: "success",
+          value: [
+            { identityKey: "id-1", status: "interviewed_pass" },
+            { identityKey: "id-2", status: "offer" },
+          ],
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      throw new Error(`Unexpected fetch in summary test: ${JSON.stringify(body)}`);
+    });
+
+    const sendSpy = vi.spyOn(notificationService, "sendWechatWorkMarkdown").mockResolvedValue({
+      errcode: 0,
+      errmsg: "ok",
+    });
+
+    const app = createApp();
+    const preview = await app.request("/api/resumes/review-packets/packet-summary/summary-preview", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(preview.status).toBe(200);
+    const previewPayload = await preview.json() as {
+      success: boolean;
+      content: string;
+      data: { reviewedCount: number; pendingCount: number; warningCount: number };
+    };
+    expect(previewPayload.success).toBe(true);
+    expect(previewPayload.data.reviewedCount).toBe(2);
+    expect(previewPayload.data.pendingCount).toBe(0);
+    expect(previewPayload.data.warningCount).toBe(1);
+    expect(previewPayload.content).toContain("# Review Packet packet-summary");
+
+    const send = await app.request("/api/resumes/review-packets/packet-summary/summary-send", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(send.status).toBe(200);
+    const sendPayload = await send.json() as {
+      success: boolean;
+      channel: string;
+      run: { status: string };
+    };
+    expect(sendPayload.success).toBe(true);
+    expect(sendPayload.channel).toBe("wechat_work");
+    expect(sendPayload.run.status).toBe("summary_sent");
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -863,6 +863,215 @@ export const ResumeExportBinaryResponseSchema = z
   .string()
   .openapi({ format: "binary" });
 
+export const ReviewPacketRunStatusSchema = z
+  .enum(["exported", "feedback_imported", "summary_sent", "failed"])
+  .openapi("ReviewPacketRunStatus");
+
+export const ReviewPacketSummaryCountSchema = z
+  .object({
+    key: z.string(),
+    label: z.string(),
+    count: z.number().int(),
+  })
+  .openapi("ReviewPacketSummaryCount");
+
+export const ReviewPacketRunSchema = z
+  .object({
+    id: z.string().openapi({ example: "review-packet-123" }),
+    workspaceSlug: z.string().openapi({ example: "hr" }),
+    source: ResumeExportSourceSchema,
+    sampleName: z.string().optional().openapi({ example: "sample-initial" }),
+    sessionId: z.string().optional().openapi({ example: "session-123" }),
+    jobDescriptionId: z.string().optional().openapi({ example: "lathe-sales" }),
+    format: z.enum(["csv", "xlsx"]).openapi({ example: "xlsx" }),
+    status: ReviewPacketRunStatusSchema,
+    totalCount: z.number().int().openapi({ example: 25 }),
+    packetFilename: z.string().optional().openapi({ example: "review-packet-review-packet-123.xlsx" }),
+    exportedAt: z.string().openapi({ example: "2026-03-20T09:00:00+08:00" }),
+    feedbackImportedAt: z.string().optional().openapi({ example: "2026-03-20T11:30:00+08:00" }),
+    summarySentAt: z.string().optional().openapi({ example: "2026-03-20T11:45:00+08:00" }),
+    summaryChannel: z.string().optional().openapi({ example: "wechat_work" }),
+    stats: z
+      .object({
+        import: z
+          .object({
+            importedAt: z.string(),
+            fileName: z.string(),
+            totalRows: z.number().int(),
+            matchedRows: z.number().int(),
+            importedRows: z.number().int(),
+            reviewedCount: z.number().int(),
+            statusUpdates: z.number().int(),
+            actionUpdates: z.number().int(),
+            noteUpdates: z.number().int(),
+            invalidRows: z.number().int(),
+            duplicateRows: z.number().int(),
+            warningCount: z.number().int(),
+            matchedByProfileUrlCount: z.number().int(),
+            nameMismatchCount: z.number().int(),
+            warnings: z.array(z.string()),
+          })
+          .optional(),
+        summary: z
+          .object({
+            previewedAt: z.string().optional(),
+            sentAt: z.string().optional(),
+            channel: z.string().optional(),
+            reviewedCount: z.number().int(),
+            pendingCount: z.number().int(),
+            warningCount: z.number().int(),
+            statusBreakdown: z.record(z.number().int()),
+            actionBreakdown: z.record(z.number().int()),
+          })
+          .optional(),
+      })
+      .optional(),
+    error: z.string().optional(),
+  })
+  .openapi("ReviewPacketRun");
+
+export const ReviewPacketTrackedExportResponseSchema = z
+  .object({
+    success: z.literal(true),
+    run: ReviewPacketRunSchema,
+    downloadPath: z.string().openapi({ example: "/api/resumes/review-packets/review-packet-123/download" }),
+  })
+  .openapi("ReviewPacketTrackedExportResponse");
+
+export const ReviewPacketExportRequestSchema = z
+  .object({
+    format: z.enum(["csv", "xlsx"]).default("csv").openapi({ example: "csv" }),
+    source: ResumeExportSourceSchema,
+    sample: z.string().optional().openapi({ example: "sample-initial" }),
+    userComment: z.string().optional().openapi({ example: "Batch note" }),
+    referenceNote: z.string().optional().openapi({ example: "Internal export" }),
+    industryDbV2Stats: IndustryDbV2StatsSchema.optional(),
+    debug: z.boolean().optional().openapi({ example: false }),
+    sessionId: z.string().optional().openapi({ example: "session-123" }),
+    jobDescriptionId: z.string().optional().openapi({ example: "lathe-sales" }),
+    entries: z.array(ResumeExportEntryContextSchema).min(1).max(2000),
+  })
+  .superRefine((value, ctx) => {
+    if (value.source === "sample" && !value.sample?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "sample is required when source is sample",
+        path: ["sample"],
+      });
+    }
+    if (value.source === "convex" && value.sample !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "sample is only allowed when source is sample",
+        path: ["sample"],
+      });
+    }
+  })
+  .openapi("ReviewPacketExportRequest");
+
+export const ReviewPacketRunsResponseSchema = z
+  .object({
+    success: z.literal(true),
+    items: z.array(ReviewPacketRunSchema),
+  })
+  .openapi("ReviewPacketRunsResponse");
+
+export const ReviewPacketFeedbackImportRequestSchema = z
+  .object({
+    file: z.any().openapi({
+      type: "string",
+      format: "binary",
+    }),
+    updatedBy: z.string().optional().openapi({ example: "hr.lead" }),
+  })
+  .openapi("ReviewPacketFeedbackImportRequest");
+
+export const ReviewPacketFeedbackImportFormSchema = z.object({
+  file: z.instanceof(File),
+  updatedBy: z.string().optional(),
+});
+
+export const ReviewPacketFeedbackImportResponseSchema = z
+  .object({
+    success: z.literal(true),
+    run: ReviewPacketRunSchema,
+    summary: z.object({
+      fileName: z.string(),
+      totalRows: z.number().int(),
+      matchedRows: z.number().int(),
+      importedRows: z.number().int(),
+      reviewedCount: z.number().int(),
+      statusUpdates: z.number().int(),
+      actionUpdates: z.number().int(),
+      noteUpdates: z.number().int(),
+      invalidRows: z.number().int(),
+      duplicateRows: z.number().int(),
+      warningCount: z.number().int(),
+      matchedByProfileUrlCount: z.number().int(),
+      nameMismatchCount: z.number().int(),
+    }),
+    warnings: z.array(z.string()),
+  })
+  .openapi("ReviewPacketFeedbackImportResponse");
+
+export const ReviewPacketSummaryDataSchema = z
+  .object({
+    packetId: z.string(),
+    workspaceSlug: z.string(),
+    source: ResumeExportSourceSchema,
+    sampleName: z.string().optional(),
+    sessionId: z.string().optional(),
+    jobDescriptionId: z.string().optional(),
+    exportedAt: z.string(),
+    feedbackImportedAt: z.string().optional(),
+    summarySentAt: z.string().optional(),
+    totalExported: z.number().int(),
+    reviewedCount: z.number().int(),
+    pendingCount: z.number().int(),
+    warningCount: z.number().int(),
+    statusBreakdown: z.array(ReviewPacketSummaryCountSchema),
+    actionBreakdown: z.array(ReviewPacketSummaryCountSchema),
+    warnings: z.array(z.string()),
+  })
+  .openapi("ReviewPacketSummaryData");
+
+export const ReviewPacketSummaryPreviewRequestSchema = z
+  .object({
+    templateId: z.string().optional().openapi({ example: "review-packet-wechat" }),
+  })
+  .openapi("ReviewPacketSummaryPreviewRequest");
+
+export const ReviewPacketSummaryPreviewResponseSchema = z
+  .object({
+    success: z.literal(true),
+    run: ReviewPacketRunSchema,
+    channel: z.literal("wechat_work"),
+    templateId: z.string(),
+    content: z.string(),
+    data: ReviewPacketSummaryDataSchema,
+  })
+  .openapi("ReviewPacketSummaryPreviewResponse");
+
+export const ReviewPacketSummarySendRequestSchema = z
+  .object({
+    templateId: z.string().optional().openapi({ example: "review-packet-wechat" }),
+    webhookUrl: z.string().url().optional().openapi({ example: "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=***" }),
+  })
+  .openapi("ReviewPacketSummarySendRequest");
+
+export const ReviewPacketSummarySendResponseSchema = z
+  .object({
+    success: z.literal(true),
+    run: ReviewPacketRunSchema,
+    channel: z.literal("wechat_work"),
+    templateId: z.string(),
+    delivery: z.object({
+      errcode: z.number().optional(),
+      errmsg: z.string().optional(),
+    }).passthrough(),
+  })
+  .openapi("ReviewPacketSummarySendResponse");
+
 export const MatchRequestSchema = z
   .object({
     sessionId: z.string().optional().openapi({ example: "session-123" }),

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -91,6 +91,11 @@ type ExportRow = {
   referenceNote: string;
 };
 
+type ReviewPacketRow = ExportRow & {
+  packetRunId: string;
+  exportedAt: string;
+};
+
 export type ExportFile = {
   extension: ExportFormat;
   contentType: string;
@@ -296,6 +301,7 @@ function toRow(
 }
 
 type ExcelColumn = { header: string; key: keyof ExportRow; width: number };
+type ReviewPacketExcelColumn = { header: string; key: keyof ReviewPacketRow; width: number };
 
 const STANDARD_EXCEL_COLUMNS_HEAD: ExcelColumn[] = [
   { header: "Resume ID", key: "resumeId", width: 24 },
@@ -352,6 +358,14 @@ export type ExportBatchMeta = {
   referenceNote?: string;
 };
 
+export type ReviewPacketExportOptions = {
+  packetRunId: string;
+  exportedAt: string;
+  batchMeta?: ExportBatchMeta;
+  industryDbV2Stats?: IndustryDbV2BatchStats;
+  debug?: boolean;
+};
+
 function applyBatchMeta(row: ExportRow, batchMeta?: ExportBatchMeta): ExportRow {
   if (!batchMeta) {
     return row;
@@ -362,6 +376,83 @@ function applyBatchMeta(row: ExportRow, batchMeta?: ExportBatchMeta): ExportRow 
     userComment: batchMeta.userComment ?? row.userComment,
     referenceNote: batchMeta.referenceNote ?? row.referenceNote,
   };
+}
+
+const REVIEW_PACKET_EXCEL_COLUMNS_HEAD: ReviewPacketExcelColumn[] = [
+  { header: "Resume ID", key: "resumeId", width: 24 },
+  { header: "Packet Run ID", key: "packetRunId", width: 40 },
+  { header: "Exported At", key: "exportedAt", width: 28 },
+  { header: "Name", key: "name", width: 16 },
+  { header: "Job Intention", key: "jobIntention", width: 20 },
+  { header: "Location", key: "location", width: 14 },
+  { header: "Experience", key: "experience", width: 14 },
+  { header: "Education", key: "education", width: 14 },
+  { header: "Age", key: "age", width: 10 },
+  { header: "Expected Salary", key: "expectedSalary", width: 16 },
+  { header: "AI Score", key: "aiScore", width: 10 },
+  { header: "Industry DB", key: "industryDb", width: 14 },
+  { header: "Related Exp", key: "relatedExp", width: 14 },
+];
+
+const REVIEW_PACKET_DEBUG_EXCEL_COLUMNS: ReviewPacketExcelColumn[] = [
+  { header: "Industry DB V2 Raw", key: "industryDbV2Raw", width: 18 },
+  { header: "Industry DB V2 Normalized", key: "industryDbV2Normalized", width: 24 },
+];
+
+const REVIEW_PACKET_EXCEL_COLUMNS_MACHINE_TAIL: ReviewPacketExcelColumn[] = [
+  { header: "Rule Score", key: "ruleScore", width: 10 },
+  { header: "Recommendation", key: "recommendation", width: 16 },
+  { header: "Score Source", key: "scoreSource", width: 12 },
+  { header: "Industry Tags", key: "industryTags", width: 22 },
+  { header: "Brand Hits", key: "brandHits", width: 34 },
+  { header: "Company Hits", key: "companyHits", width: 22 },
+  { header: "Role Evidence", key: "roleEvidence", width: 34 },
+  { header: "Matched Work Entries", key: "matchedWorkEntries", width: 44 },
+  { header: "Profile URL", key: "profileUrl", width: 28 },
+  { header: "Work History", key: "workHistory", width: 44 },
+  { header: "Self Intro", key: "selfIntro", width: 48 },
+  { header: "AI Summary", key: "aiSummary", width: 48 },
+];
+
+const REVIEW_PACKET_EXCEL_COLUMNS_HUMAN: ReviewPacketExcelColumn[] = [
+  { header: "Status", key: "status", width: 16 },
+  { header: "Action", key: "action", width: 12 },
+  { header: "User Comment", key: "userComment", width: 36 },
+  { header: "Reference Note", key: "referenceNote", width: 36 },
+];
+
+function getReviewPacketExcelColumns(debug: boolean): ReviewPacketExcelColumn[] {
+  return debug
+    ? [
+        ...REVIEW_PACKET_EXCEL_COLUMNS_HEAD,
+        ...REVIEW_PACKET_DEBUG_EXCEL_COLUMNS,
+        ...REVIEW_PACKET_EXCEL_COLUMNS_MACHINE_TAIL,
+        ...REVIEW_PACKET_EXCEL_COLUMNS_HUMAN,
+      ]
+    : [
+        ...REVIEW_PACKET_EXCEL_COLUMNS_HEAD,
+        ...REVIEW_PACKET_EXCEL_COLUMNS_MACHINE_TAIL,
+        ...REVIEW_PACKET_EXCEL_COLUMNS_HUMAN,
+      ];
+}
+
+function toReviewPacketRow(row: ExportRow, options: { packetRunId: string; exportedAt: string }): ReviewPacketRow {
+  return {
+    ...row,
+    packetRunId: options.packetRunId,
+    exportedAt: options.exportedAt,
+  };
+}
+
+function toReviewPacketCsvRow(
+  row: ReviewPacketRow,
+  debug: boolean
+): Record<string, string | number | ""> {
+  const record: Record<string, string | number | ""> = {};
+  for (const column of getReviewPacketExcelColumns(debug)) {
+    record[column.header] = row[column.key];
+  }
+  return record;
 }
 
 export class ExportService {
@@ -413,11 +504,71 @@ export class ExportService {
     };
   }
 
+  async exportReviewPacket(
+    format: ExportFormat,
+    entries: ResumeExportEntry[],
+    options: ReviewPacketExportOptions,
+  ): Promise<ExportFile> {
+    const batchNormalizer = createBatchNormalizer(options.industryDbV2Stats);
+    const debug = options.debug ?? false;
+    const rows = entries.map((entry) =>
+      toReviewPacketRow(
+        applyBatchMeta(
+          toRow(
+            entry,
+            batchNormalizer,
+            this.brandDisplayResolver,
+            this.companyPatternAliasLookup
+          ),
+          options.batchMeta
+        ),
+        {
+          packetRunId: options.packetRunId,
+          exportedAt: options.exportedAt,
+        }
+      )
+    );
+
+    if (format === "xlsx") {
+      const content = await this.toReviewPacketXlsx(rows, debug);
+      return {
+        extension: "xlsx",
+        contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        content,
+      };
+    }
+
+    const csv = Papa.unparse(rows.map((row) => toReviewPacketCsvRow(row, debug)), {
+      header: true,
+      newline: "\n",
+    });
+    return {
+      extension: "csv",
+      contentType: "text/csv; charset=utf-8",
+      content: Buffer.from(csv, "utf8"),
+    };
+  }
+
   private async toXlsx(rows: ExportRow[], debug: boolean): Promise<Buffer> {
     const workbook = new ExcelJS.Workbook();
     const sheet = workbook.addWorksheet("Resumes");
 
     sheet.columns = getExcelColumns(debug);
+    rows.forEach((row) => sheet.addRow(row));
+    sheet.getRow(1).font = { bold: true };
+
+    const data = await workbook.xlsx.writeBuffer();
+    if (data instanceof ArrayBuffer) {
+      return Buffer.from(data);
+    }
+    return Buffer.from(data);
+  }
+
+  private async toReviewPacketXlsx(rows: ReviewPacketRow[], debug: boolean): Promise<Buffer> {
+    const workbook = new ExcelJS.Workbook();
+    const sheet = workbook.addWorksheet("Review Packet");
+
+    sheet.columns = getReviewPacketExcelColumns(debug);
     rows.forEach((row) => sheet.addRow(row));
     sheet.getRow(1).font = { bold: true };
 

--- a/apps/api/src/services/feedback-import-service.ts
+++ b/apps/api/src/services/feedback-import-service.ts
@@ -161,7 +161,7 @@ function parseUrlLike(value: string): URL | null {
   }
 }
 
-function normalizeProfileIdentityKey(value: string | undefined, source?: string): string | undefined {
+export function normalizeProfileIdentityKey(value: string | undefined, source?: string): string | undefined {
   if (!value) {
     return undefined;
   }

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -1038,6 +1038,460 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/resumes/review-packets/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a tracked review packet export run */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ReviewPacketExportRequest"];
+                };
+            };
+            responses: {
+                /** @description Tracked review packet export metadata */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReviewPacketTrackedExportResponse"];
+                    };
+                };
+                /** @description Selected resumes could not be resolved */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Tracked export failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/resumes/review-packets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List tracked review packet runs */
+        get: {
+            parameters: {
+                query?: {
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Review packet runs */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReviewPacketRunsResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/resumes/review-packets/{runId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get tracked review packet run metadata */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    runId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Review packet run */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            run: components["schemas"]["ReviewPacketRun"];
+                        };
+                    };
+                };
+                /** @description Run not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Run lookup failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/resumes/review-packets/{runId}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Download a tracked review packet file */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    runId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Review packet file */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/csv": string;
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": string;
+                    };
+                };
+                /** @description Run not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Download failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/resumes/review-packets/{runId}/feedback-import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Import reviewed CSV/XLSX feedback for a tracked review packet */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    runId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "multipart/form-data": components["schemas"]["ReviewPacketFeedbackImportRequest"];
+                };
+            };
+            responses: {
+                /** @description Feedback import result */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReviewPacketFeedbackImportResponse"];
+                    };
+                };
+                /** @description Invalid import payload */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Run not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Feedback import failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/resumes/review-packets/{runId}/summary-preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Preview the WeChat summary for a tracked review packet */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    runId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ReviewPacketSummaryPreviewRequest"];
+                };
+            };
+            responses: {
+                /** @description Summary preview */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReviewPacketSummaryPreviewResponse"];
+                    };
+                };
+                /** @description Run not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Summary preview failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/resumes/review-packets/{runId}/summary-send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send the WeChat summary for a tracked review packet */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    runId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ReviewPacketSummarySendRequest"];
+                };
+            };
+            responses: {
+                /** @description Summary send result */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReviewPacketSummarySendResponse"];
+                    };
+                };
+                /** @description Run not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Summary send failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/resumes/verify-token": {
         parameters: {
             query?: never;
@@ -4966,6 +5420,193 @@ export interface components {
             }[];
         };
         ResumeExportRequest: components["schemas"]["ResumeExportCanonicalRequest"] | components["schemas"]["ResumeExportLegacyRequest"];
+        /** @enum {string} */
+        ReviewPacketRunStatus: "exported" | "feedback_imported" | "summary_sent" | "failed";
+        ReviewPacketRun: {
+            /** @example review-packet-123 */
+            id: string;
+            /** @example hr */
+            workspaceSlug: string;
+            source: components["schemas"]["ResumeExportSource"];
+            /** @example sample-initial */
+            sampleName?: string;
+            /** @example session-123 */
+            sessionId?: string;
+            /** @example lathe-sales */
+            jobDescriptionId?: string;
+            /**
+             * @example xlsx
+             * @enum {string}
+             */
+            format: "csv" | "xlsx";
+            status: components["schemas"]["ReviewPacketRunStatus"];
+            /** @example 25 */
+            totalCount: number;
+            /** @example review-packet-review-packet-123.xlsx */
+            packetFilename?: string;
+            /** @example 2026-03-20T09:00:00+08:00 */
+            exportedAt: string;
+            /** @example 2026-03-20T11:30:00+08:00 */
+            feedbackImportedAt?: string;
+            /** @example 2026-03-20T11:45:00+08:00 */
+            summarySentAt?: string;
+            /** @example wechat_work */
+            summaryChannel?: string;
+            stats?: {
+                import?: {
+                    importedAt: string;
+                    fileName: string;
+                    totalRows: number;
+                    matchedRows: number;
+                    importedRows: number;
+                    reviewedCount: number;
+                    statusUpdates: number;
+                    actionUpdates: number;
+                    noteUpdates: number;
+                    invalidRows: number;
+                    duplicateRows: number;
+                    warningCount: number;
+                    matchedByProfileUrlCount: number;
+                    nameMismatchCount: number;
+                    warnings: string[];
+                };
+                summary?: {
+                    previewedAt?: string;
+                    sentAt?: string;
+                    channel?: string;
+                    reviewedCount: number;
+                    pendingCount: number;
+                    warningCount: number;
+                    statusBreakdown: {
+                        [key: string]: number;
+                    };
+                    actionBreakdown: {
+                        [key: string]: number;
+                    };
+                };
+            };
+            error?: string;
+        };
+        ReviewPacketTrackedExportResponse: {
+            /** @enum {boolean} */
+            success: true;
+            run: components["schemas"]["ReviewPacketRun"];
+            /** @example /api/resumes/review-packets/review-packet-123/download */
+            downloadPath: string;
+        };
+        ReviewPacketExportRequest: {
+            /**
+             * @default csv
+             * @example csv
+             * @enum {string}
+             */
+            format: "csv" | "xlsx";
+            source: components["schemas"]["ResumeExportSource"];
+            /** @example sample-initial */
+            sample?: string;
+            /** @example Batch note */
+            userComment?: string;
+            /** @example Internal export */
+            referenceNote?: string;
+            industryDbV2Stats?: components["schemas"]["IndustryDbV2Stats"];
+            /** @example false */
+            debug?: boolean;
+            /** @example session-123 */
+            sessionId?: string;
+            /** @example lathe-sales */
+            jobDescriptionId?: string;
+            entries: components["schemas"]["ResumeExportEntryContext"][];
+        };
+        ReviewPacketRunsResponse: {
+            /** @enum {boolean} */
+            success: true;
+            items: components["schemas"]["ReviewPacketRun"][];
+        };
+        ReviewPacketFeedbackImportResponse: {
+            /** @enum {boolean} */
+            success: true;
+            run: components["schemas"]["ReviewPacketRun"];
+            summary: {
+                fileName: string;
+                totalRows: number;
+                matchedRows: number;
+                importedRows: number;
+                reviewedCount: number;
+                statusUpdates: number;
+                actionUpdates: number;
+                noteUpdates: number;
+                invalidRows: number;
+                duplicateRows: number;
+                warningCount: number;
+                matchedByProfileUrlCount: number;
+                nameMismatchCount: number;
+            };
+            warnings: string[];
+        };
+        ReviewPacketFeedbackImportRequest: {
+            /** Format: binary */
+            file?: string;
+            /** @example hr.lead */
+            updatedBy?: string;
+        };
+        ReviewPacketSummaryCount: {
+            key: string;
+            label: string;
+            count: number;
+        };
+        ReviewPacketSummaryData: {
+            packetId: string;
+            workspaceSlug: string;
+            source: components["schemas"]["ResumeExportSource"];
+            sampleName?: string;
+            sessionId?: string;
+            jobDescriptionId?: string;
+            exportedAt: string;
+            feedbackImportedAt?: string;
+            summarySentAt?: string;
+            totalExported: number;
+            reviewedCount: number;
+            pendingCount: number;
+            warningCount: number;
+            statusBreakdown: components["schemas"]["ReviewPacketSummaryCount"][];
+            actionBreakdown: components["schemas"]["ReviewPacketSummaryCount"][];
+            warnings: string[];
+        };
+        ReviewPacketSummaryPreviewResponse: {
+            /** @enum {boolean} */
+            success: true;
+            run: components["schemas"]["ReviewPacketRun"];
+            /** @enum {string} */
+            channel: "wechat_work";
+            templateId: string;
+            content: string;
+            data: components["schemas"]["ReviewPacketSummaryData"];
+        };
+        ReviewPacketSummaryPreviewRequest: {
+            /** @example review-packet-wechat */
+            templateId?: string;
+        };
+        ReviewPacketSummarySendResponse: {
+            /** @enum {boolean} */
+            success: true;
+            run: components["schemas"]["ReviewPacketRun"];
+            /** @enum {string} */
+            channel: "wechat_work";
+            templateId: string;
+            delivery: {
+                errcode?: number;
+                errmsg?: string;
+            };
+        };
+        ReviewPacketSummarySendRequest: {
+            /** @example review-packet-wechat */
+            templateId?: string;
+            /**
+             * Format: uri
+             * @example https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=***
+             */
+            webhookUrl?: string;
+        };
         ResumeFilters: {
             minExperience?: number;
             maxExperience?: number;


### PR DESCRIPTION
## Summary
- add tracked review-packet export, listing, detail, download, feedback-import, summary-preview, and summary-send API routes
- extend export and schema layers for review-packet runs and regenerate the web API client types
- add focused route tests and workspace query fallback for download URLs

## Testing
- npx vitest run apps/api/src/routes/review-packets.test.ts apps/api/src/routes/resumes-export.test.ts
- npm --workspace @trends/api run typecheck
- make check