### PR TITLE
fix(cli): fully clear resume data before replace restore

### DIFF
--- a/packages/cli/cmd/resume_backup.go
+++ b/packages/cli/cmd/resume_backup.go
@@ -496,6 +496,22 @@ func resolveResumeRestorePaths(inputPath string) ([]string, error) {
 	return files, nil
 }
 
+func resetResumesFully(ctx context.Context, apiClient *client.Client) (int, error) {
+	totalResetCount := 0
+
+	for {
+		resetResponse, err := apiClient.ResetResumes(ctx)
+		if err != nil {
+			return 0, err
+		}
+
+		totalResetCount += resetResponse.Count
+		if !resetResponse.Partial {
+			return totalResetCount, nil
+		}
+	}
+}
+
 func restoreResumeBackupPath(ctx context.Context, apiClient *client.Client, inputPath string, mode string, yes bool) (*resumeRestoreResult, error) {
 	normalizedMode, err := normalizeResumeRestoreMode(mode)
 	if err != nil {
@@ -513,12 +529,10 @@ func restoreResumeBackupPath(ctx context.Context, apiClient *client.Client, inpu
 	resetCount := 0
 	resetPartial := false
 	if normalizedMode == "replace" {
-		resetResponse, err := apiClient.ResetResumes(ctx)
+		resetCount, err = resetResumesFully(ctx, apiClient)
 		if err != nil {
 			return nil, err
 		}
-		resetCount = resetResponse.Count
-		resetPartial = resetResponse.Partial
 	}
 
 	result := &resumeRestoreResult{

--- a/packages/cli/cmd/resume_backup_test.go
+++ b/packages/cli/cmd/resume_backup_test.go
@@ -166,7 +166,7 @@ func TestResumeDeployBackupWriteCreatesRunDirAndWorkspaceFile(t *testing.T) {
 	}
 }
 
-func TestResumeRestoreCommandReplaceModeCallsResetThenImport(t *testing.T) {
+func TestResumeRestoreCommandReplaceModeResetsUntilCompleteBeforeImport(t *testing.T) {
 	backupFile := filepath.Join(t.TempDir(), "resume-backup.tar.gz")
 	writeTestPortableBackupFile(t, backupFile, map[string]any{
 		"metadata": map[string]any{
@@ -182,11 +182,22 @@ func TestResumeRestoreCommandReplaceModeCallsResetThenImport(t *testing.T) {
 	})
 
 	var callOrder []string
+	resetCalls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callOrder = append(callOrder, r.URL.Path)
 
 		switch r.URL.Path {
 		case "/api/resumes/reset":
+			resetCalls += 1
+			if resetCalls == 1 {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"success": true,
+					"count":   200,
+					"partial": true,
+					"deleted": map[string]int{"resumes": 200},
+				})
+				return
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"success": true,
 				"count":   1,
@@ -232,11 +243,17 @@ func TestResumeRestoreCommandReplaceModeCallsResetThenImport(t *testing.T) {
 		t.Fatalf("resume restore command failed: %v", err)
 	}
 
-	if len(callOrder) != 2 || callOrder[0] != "/api/resumes/reset" || callOrder[1] != "/api/resumes/import" {
+	if len(callOrder) != 3 || callOrder[0] != "/api/resumes/reset" || callOrder[1] != "/api/resumes/reset" || callOrder[2] != "/api/resumes/import" {
 		t.Fatalf("unexpected call order: %+v", callOrder)
 	}
 	if !strings.Contains(output.String(), `"mode": "replace"`) {
 		t.Fatalf("unexpected command output: %s", output.String())
+	}
+	if !strings.Contains(output.String(), `"resetCount": 201`) {
+		t.Fatalf("unexpected reset count in output: %s", output.String())
+	}
+	if !strings.Contains(output.String(), `"resetPartial": false`) {
+		t.Fatalf("unexpected reset partial state in output: %s", output.String())
 	}
 }
 

--- a/scripts/resume/restore-resumes.test.ts
+++ b/scripts/resume/restore-resumes.test.ts
@@ -107,7 +107,7 @@ describe("restore-resumes", () => {
     expect(summary.files.map((entry) => entry.count)).toEqual([20, 20, 20]);
   });
 
-  it("resets once before importing the whole directory in replace mode", async () => {
+  it("resets until the API reports the workspace is fully cleared before importing", async () => {
     const dir = await createTempDir();
     tempDirs.push(dir);
 
@@ -123,6 +123,7 @@ describe("restore-resumes", () => {
     });
 
     const requests: string[] = [];
+    let resetCalls = 0;
     const summary = await runRestoreResumes(
       {
         apiUrl: "http://localhost:3000",
@@ -134,12 +135,34 @@ describe("restore-resumes", () => {
       {
         fetch: vi.fn(async (input) => {
           const url = typeof input === "string" ? input : input.toString();
-          requests.push(new URL(url).pathname);
+          const pathName = new URL(url).pathname;
+          requests.push(pathName);
+          if (pathName === "/api/resumes/reset") {
+            resetCalls += 1;
+          }
           return new Response(
             JSON.stringify({
               success: true,
-              submitted: 20,
-              count: 40,
+              ...(pathName === "/api/resumes/reset"
+                ? resetCalls === 1
+                  ? {
+                      count: 200,
+                      partial: true,
+                      deleted: {
+                        resumes: 200,
+                      },
+                    }
+                  : {
+                      count: 12,
+                      partial: false,
+                      deleted: {
+                        resumes: 12,
+                        analysis_tasks: 5,
+                      },
+                    }
+                : {
+                    submitted: 20,
+                  }),
             }),
             {
               status: 200,
@@ -152,10 +175,20 @@ describe("restore-resumes", () => {
 
     expect(requests).toEqual([
       "/api/resumes/reset",
+      "/api/resumes/reset",
       "/api/resumes/import",
       "/api/resumes/import",
     ]);
     expect(summary.reset).toBe(true);
+    expect(summary.resetResult).toEqual({
+      success: true,
+      count: 212,
+      partial: false,
+      deleted: {
+        resumes: 212,
+        analysis_tasks: 5,
+      },
+    });
     expect(summary.files).toHaveLength(2);
   });
 

--- a/scripts/resume/restore-resumes.ts
+++ b/scripts/resume/restore-resumes.ts
@@ -27,6 +27,13 @@ type RestoreFileSummary = {
   importResult: Record<string, unknown>;
 };
 
+type RestoreResetSummary = {
+  success: true;
+  count: number;
+  partial: boolean;
+  deleted: Record<string, number>;
+};
+
 export type RestoreRunSummary = {
   success: true;
   apiUrl: string;
@@ -185,6 +192,55 @@ async function parseJsonRecord(
   return decoded;
 }
 
+function readResetCount(result: Record<string, unknown>): number {
+  const count = result.count;
+  return typeof count === "number" && Number.isFinite(count) ? count : 0;
+}
+
+function mergeDeletedCounts(target: Record<string, number>, deleted: unknown): void {
+  if (!isRecord(deleted)) {
+    return;
+  }
+
+  for (const [key, value] of Object.entries(deleted)) {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      continue;
+    }
+    target[key] = (target[key] ?? 0) + value;
+  }
+}
+
+async function resetResumesFully(
+  apiUrl: string,
+  workspace: string,
+  runtime: RestoreRuntime,
+): Promise<RestoreResetSummary> {
+  let totalCount = 0;
+  const deleted: Record<string, number> = {};
+
+  while (true) {
+    const resetResponse = await postJson(
+      apiUrl,
+      workspace,
+      "/api/resumes/reset",
+      {},
+      runtime,
+    );
+    const resetResult = await parseJsonRecord(resetResponse, "reset request failed");
+    totalCount += readResetCount(resetResult);
+    mergeDeletedCounts(deleted, resetResult.deleted);
+
+    if (resetResult.partial !== true) {
+      return {
+        success: true,
+        count: totalCount,
+        partial: false,
+        deleted,
+      };
+    }
+  }
+}
+
 export async function runRestoreResumes(
   params: {
     apiUrl: string;
@@ -203,14 +259,11 @@ export async function runRestoreResumes(
 
   let resetResult: Record<string, unknown> | undefined;
   if (params.mode === "replace") {
-    const resetResponse = await postJson(
+    resetResult = await resetResumesFully(
       params.apiUrl,
       params.workspace,
-      "/api/resumes/reset",
-      {},
       runtime,
     );
-    resetResult = await parseJsonRecord(resetResponse, "reset request failed");
   }
 
   const files: RestoreFileSummary[] = [];


### PR DESCRIPTION
## Summary
- loop replace-mode resume resets until the API reports `partial: false` in both restore entrypoints
- add focused Go and Vitest coverage for paginated reset responses before import
- keep deterministic restore ordering and aggregate reset counts for reporting

## Validation
- bunx vitest run scripts/resume/restore-resumes.test.ts
- go test ./cmd ./internal/client
- make cli-build
- make check
- live validation: small snapshot restore, 2276-resume backup restore, malformed backup rejection, malformed zip upload, mixed DOCX+TXT manual import, replace restore marker cleanup