### PR TITLE
perf(web): speed up dev resume first paint

### DIFF
--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -24,6 +24,7 @@ interface ResumeDetailProps {
   matchResult?: MatchingResult
   open: boolean
   onOpenChange: (open: boolean) => void
+  loading?: boolean
   aiScoreFeedback?: AiFeedbackSentiment
   aiSummaryFeedback?: AiFeedbackSentiment
   onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
@@ -48,7 +49,16 @@ function matchesStructuredWorkEntry(
   return Boolean(companyMatches || titleMatches)
 }
 
-export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreFeedback, aiSummaryFeedback, onAiFeedback }: ResumeDetailProps) {
+export function ResumeDetail({
+  resume,
+  matchResult,
+  open,
+  onOpenChange,
+  loading = false,
+  aiScoreFeedback,
+  aiSummaryFeedback,
+  onAiFeedback,
+}: ResumeDetailProps) {
   const { t } = useTranslation()
   const fieldUsagePolicy = useResumeFieldUsagePolicy()
   const [isInfoExpanded, setIsInfoExpanded] = useState(false)
@@ -130,6 +140,11 @@ export function ResumeDetail({ resume, matchResult, open, onOpenChange, aiScoreF
         <div className="grid gap-4">
           <div className="text-sm relative">
             <div className="mb-2 flex flex-wrap items-center gap-2">
+              {loading ? (
+                <Badge variant="outline" className="border-sky-200 bg-sky-50 text-sky-700 text-[10px]">
+                  {t('common.loading', 'Loading')}...
+                </Badge>
+              ) : null}
               {sourceLabel ? (
                 <Badge variant="outline" className="border-slate-200 bg-slate-50 text-slate-700 text-[10px]">
                   {sourceLabel}

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { RefreshCw, FileText, AlertTriangle, History, Upload } from 'lucide-react'
 import { EmptyState } from '@/components/EmptyState'
 import type { ResumeItem } from '@/hooks/useResumes'
-import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+import { useConvexResumeDetail, type ConvexResumeItem } from '@/hooks/useConvexResumes'
 import { ResumeCard, ResumeCardSkeleton } from '@/components/ResumeCard'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -39,9 +39,14 @@ const ManualResumeImportDialog = lazy(async () => {
   return { default: module.ManualResumeImportDialog }
 })
 
+function isConvexResumeEntry(resume: ResumeItem | ConvexResumeItem): resume is ConvexResumeItem {
+  return 'source' in resume && 'crawledAt' in resume
+}
+
 export function ResumeList() {
   const { t } = useTranslation()
   const [historyRequested, setHistoryRequested] = useState(false)
+  const [hasCompletedInitialListLoad, setHasCompletedInitialListLoad] = useState(false)
   const {
     sessionLocation,
     sessionKeywords,
@@ -96,11 +101,19 @@ export function ResumeList() {
     handleAiFeedback,
     getAiFeedback,
   } = useResumeListState(historyRequested)
-  useSyncNotifications()
+  useEffect(() => {
+    if (!activeLoading) {
+      setHasCompletedInitialListLoad(true)
+    }
+  }, [activeLoading])
+
+  const backgroundEnhancementsEnabled = hasCompletedInitialListLoad
+  useSyncNotifications(backgroundEnhancementsEnabled)
   const { slug: workspaceSlug } = useWorkspace()
-  const { resolve: brandDisplayResolve } = useBrandDisplayMap()
+  const { resolve: brandDisplayResolve } = useBrandDisplayMap(backgroundEnhancementsEnabled)
 
   const [detailResume, setDetailResume] = useState<ResumeItem | ConvexResumeItem | null>(null)
+  const [detailResumeId, setDetailResumeId] = useState<ConvexResumeItem['resumeId'] | null>(null)
   const [historyOpen, setHistoryOpen] = useState(false)
   const [manualImportOpen, setManualImportOpen] = useState(false)
   const listRef = useRef<HTMLDivElement | null>(null)
@@ -116,6 +129,8 @@ export function ResumeList() {
     if (!detailKey) return undefined
     return displayedResumes.find((entry) => entry.key === detailKey)?.match
   }, [detailKey, displayedResumes])
+  const { resume: detailResumeFromConvex, loading: detailResumeLoading } = useConvexResumeDetail(detailResumeId)
+  const resolvedDetailResume = detailResumeFromConvex ?? detailResume
   const shouldVirtualize = displayedResumes.length > 40
   const rowVirtualizer = useWindowVirtualizer({
     count: displayedResumes.length,
@@ -206,6 +221,7 @@ export function ResumeList() {
         onViewDetails={() => {
           void loadResumeDetail()
           setDetailResume(entry.resume)
+          setDetailResumeId(isConvexResumeEntry(entry.resume) ? entry.resume.resumeId : null)
           trackReviewedResume(entry.key)
         }}
         selected={selectedIds.has(entry.key)}
@@ -443,14 +459,16 @@ export function ResumeList() {
       {detailResume ? (
         <Suspense fallback={null}>
           <ResumeDetail
-            resume={detailResume}
+            resume={resolvedDetailResume}
             matchResult={detailMatch}
             open={Boolean(detailResume)}
             onOpenChange={(open) => {
               if (!open) {
                 setDetailResume(null)
+                setDetailResumeId(null)
               }
             }}
+            loading={detailResumeLoading}
             aiScoreFeedback={detailKey ? getAiFeedback(detailKey, 'ai_score') : undefined}
             aiSummaryFeedback={detailKey ? getAiFeedback(detailKey, 'ai_summary') : undefined}
             onAiFeedback={detailKey ? (target, sentiment) => handleAiFeedback(detailKey, target, sentiment) : undefined}

--- a/apps/web/src/hooks/useBrandDisplayMap.ts
+++ b/apps/web/src/hooks/useBrandDisplayMap.ts
@@ -8,10 +8,14 @@ type BrandDisplayEntry = {
 
 type BrandDisplayMap = Record<string, BrandDisplayEntry>
 
-export function useBrandDisplayMap() {
+export function useBrandDisplayMap(enabled: boolean = true) {
   const [map, setMap] = useState<BrandDisplayMap | null>(null)
 
   useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
     let mounted = true
 
     rawApiClient
@@ -28,7 +32,7 @@ export function useBrandDisplayMap() {
     return () => {
       mounted = false
     }
-  }, [])
+  }, [enabled])
 
   const resolve = useCallback(
     (brandId: string) => {
@@ -41,4 +45,3 @@ export function useBrandDisplayMap() {
 
   return useMemo(() => ({ resolve }), [resolve])
 }
-

--- a/apps/web/src/hooks/useCandidateActions.ts
+++ b/apps/web/src/hooks/useCandidateActions.ts
@@ -24,14 +24,14 @@ function setFeedbackState(
   }
 }
 
-export function useCandidateActions(sessionId?: string, jobDescriptionId?: string) {
+export function useCandidateActions(sessionId?: string, jobDescriptionId?: string, enabled: boolean = true) {
   const [actionsByResume, setActionsByResume] = useState<Record<string, CandidateActionType>>({})
   const [aiFeedbackByResume, setAiFeedbackByResume] = useState<Record<string, AiFeedbackState>>({})
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const loadActions = useCallback(async () => {
-    if (!sessionId) return
+    if (!enabled || !sessionId) return
     setLoading(true)
     setError(null)
 
@@ -75,7 +75,7 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
     setActionsByResume(nextActionsByResume)
     setAiFeedbackByResume(nextAiFeedbackByResume)
     setLoading(false)
-  }, [jobDescriptionId, sessionId])
+  }, [enabled, jobDescriptionId, sessionId])
 
   const saveAction = useCallback(
     async (payload: { resumeId: string; actionType: CandidateActionType; actionData?: Record<string, unknown> }) => {
@@ -127,15 +127,20 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
   )
 
   useEffect(() => {
+    if (!enabled) {
+      setLoading(false)
+      setError(null)
+      return
+    }
     void loadActions()
-  }, [loadActions])
+  }, [enabled, loadActions])
 
   useEffect(() => {
-    if (!sessionId) {
+    if (!enabled || !sessionId) {
       setActionsByResume({})
       setAiFeedbackByResume({})
     }
-  }, [sessionId])
+  }, [enabled, sessionId])
 
   return {
     actions: actionsByResume,

--- a/apps/web/src/hooks/useCandidateBlocks.ts
+++ b/apps/web/src/hooks/useCandidateBlocks.ts
@@ -15,12 +15,17 @@ type BlocksResponse = {
   items?: CandidateBlock[]
 }
 
-export function useCandidateBlocks() {
+export function useCandidateBlocks(enabled: boolean = true) {
   const [items, setItems] = useState<CandidateBlock[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const load = useCallback(async () => {
+    if (!enabled) {
+      setLoading(false)
+      setError(null)
+      return
+    }
     setLoading(true)
     setError(null)
     const { data, error: apiError } = await rawApiClient.GET<BlocksResponse>('/api/blocks')
@@ -33,7 +38,7 @@ export function useCandidateBlocks() {
 
     setItems(Array.isArray(data.items) ? data.items : [])
     setLoading(false)
-  }, [])
+  }, [enabled])
 
   const blockCandidates = useCallback(
     async (identityKeys: string[], reason?: string, blockedBy?: string) => {
@@ -113,8 +118,12 @@ export function useCandidateBlocks() {
   )
 
   useEffect(() => {
+    if (!enabled) {
+      setItems([])
+      return
+    }
     void load()
-  }, [load])
+  }, [enabled, load])
 
   const blocksByIdentity = useMemo(() => {
     const map: Record<string, CandidateBlock> = {}

--- a/apps/web/src/hooks/useCandidateStatus.ts
+++ b/apps/web/src/hooks/useCandidateStatus.ts
@@ -27,12 +27,17 @@ type StatusUpdateResponse = {
   item?: CandidateStatusRecord
 }
 
-export function useCandidateStatus() {
+export function useCandidateStatus(enabled: boolean = true) {
   const [items, setItems] = useState<CandidateStatusRecord[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const load = useCallback(async () => {
+    if (!enabled) {
+      setLoading(false)
+      setError(null)
+      return
+    }
     setLoading(true)
     setError(null)
     const { data, error: apiError } = await rawApiClient.GET<StatusListResponse>('/api/candidate-status')
@@ -43,7 +48,7 @@ export function useCandidateStatus() {
     }
     setItems(Array.isArray(data.items) ? data.items : [])
     setLoading(false)
-  }, [])
+  }, [enabled])
 
   const updateStatus = useCallback(
     async (identityKey: string, status: CandidateStatus, notes?: string) => {
@@ -72,8 +77,12 @@ export function useCandidateStatus() {
   )
 
   useEffect(() => {
+    if (!enabled) {
+      setItems([])
+      return
+    }
     void load()
-  }, [load])
+  }, [enabled, load])
 
   const statusByIdentity = useMemo(() => {
     const map: Record<string, CandidateStatusRecord> = {}

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { normalizeProfileUrlForDisplay, normalizeSharedResumeFields, parseKeywordQuery } from '@trends/shared'
-import { usePaginatedQuery } from 'convex/react'
+import { usePaginatedQuery, useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
 import { rawApiClient } from '@/lib/api-helpers'
@@ -122,6 +122,54 @@ export type ConvexResumeItem = ResumeItem & {
   }>
 }
 
+type ResumeListDocLike = {
+  _id: Doc<'resumes'>['_id']
+  identityKey?: string
+  age?: number
+  externalId: string
+  crawledAt: number
+  analysis?: unknown
+  analyses?: unknown
+  primaryRuleScore?: number
+  ingestData?: {
+    industryTags: string[]
+    synonymHits?: string[]
+    brandHits?: Array<{
+      brand: string
+      role: string
+      source: string
+      context: string
+    }>
+    companyHits?: string[]
+    industryDbV2Raw?: number
+    roleSignals?: Array<{
+      type: string
+      matchedSignals: string[]
+      signalCount: number
+      occurrences: number
+      years: number
+      industryVerifiedYears?: number
+      roleRelevantYears?: number
+      industryVerifiedRelevantYears?: number
+      matchedWorkEntries?: Array<{
+        companyName?: string
+        jobTitle?: string
+        years: number
+        industryVerified: boolean
+        matchedSignals: string[]
+      }>
+      verifyIn: string
+    }>
+    ruleScores: unknown
+    experienceLevel: string
+    computedAt: number
+    skillsVersion: number
+  }
+  source: string
+  tags: string[]
+  content: Record<string, unknown>
+}
+
 type KeywordExpansionSummary = {
   groups: Array<{
     original: string
@@ -133,10 +181,10 @@ type KeywordExpansionSummary = {
 }
 
 type MockConvexResumePayload = {
-  list?: Doc<'resumes'>[]
+  list?: ResumeListDocLike[]
   search?: {
     results?: Array<{
-      resume: Doc<'resumes'>
+      resume: ResumeListDocLike
       provenance?: Array<{
         term: string
         source: 'searchText' | 'industryTags' | 'companyHits' | 'synonymHits'
@@ -174,7 +222,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }
 
-function buildMockSearchText(doc: Doc<'resumes'>): string {
+function buildMockSearchText(doc: ResumeListDocLike): string {
   const content = isRecord(doc.content) ? doc.content : {}
   const fragments = [
     toStringValue(content.name),
@@ -636,7 +684,7 @@ function readMockConvexResumePayload(): MockConvexResumePayload | null {
   return value as MockConvexResumePayload
 }
 
-function mapResumeDoc(doc: Doc<'resumes'>): ConvexResumeItem {
+function mapResumeDoc(doc: ResumeListDocLike): ConvexResumeItem {
   const content = isRecord(doc.content) ? doc.content : {}
   const profileUrl = normalizeProfileUrlForDisplay(
     content.profileUrl ?? content.profile_url ?? content.profileURL ?? content.url,
@@ -891,4 +939,13 @@ export function useConvexResumes(
     jobDescriptionId: normalizedJobDescriptionId,
     expansion: resolvedExpansion,
   }
+}
+
+export function useConvexResumeDetail(resumeId: Doc<'resumes'>['_id'] | null | undefined) {
+  const detailDoc = useQuery(api.resumes.getResumeDetail, resumeId ? { resumeId } : 'skip')
+
+  return useMemo(() => ({
+    resume: detailDoc ? mapResumeDoc(detailDoc) : null,
+    loading: resumeId !== null && resumeId !== undefined && detailDoc === undefined,
+  }), [detailDoc, resumeId])
 }

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -584,6 +584,7 @@ export function useResumeListState(loadSearchHistory = false) {
   const [appliedSearchHistoryId, setAppliedSearchHistoryId] = useState<string | undefined>(undefined)
   const [queryRuleScoreMap, setQueryRuleScoreMap] = useState<Record<string, number>>({})
   const [requestedConvexLimit, setRequestedConvexLimit] = useState(DEFAULT_CONVEX_RESUME_LIMIT)
+  const [hasCompletedInitialConvexLoad, setHasCompletedInitialConvexLoad] = useState(false)
   const [mode] = useState<'ai'>('ai')
   const hydratedSessionIdRef = useRef<string | null>(null)
   const hasInitializedUrlHydrationRef = useRef(false)
@@ -670,10 +671,6 @@ export function useResumeListState(loadSearchHistory = false) {
     return normalizedJobDescriptionId || normalizedKeywords.join('|') || 'global'
   }, [jobDescriptionId, sessionKeywords])
 
-  const { actions, saveAction, getAiFeedback } = useCandidateActions(sessionActionScope, jobDescriptionId)
-  const { blocksByIdentity, blockCandidates, unblockCandidate } = useCandidateBlocks()
-  const { statusByIdentity, updateStatus: updateCandidateStatus } = useCandidateStatus()
-
   const expandedQuery = useMemo(() => {
     const kw = formatKeywordQuery(sessionKeywords).trim()
     if (!kw) return undefined
@@ -723,6 +720,20 @@ export function useResumeListState(loadSearchHistory = false) {
     sortBy: convexSourceSortBy,
     sortOrder: convexSourceSortOrder,
   })
+  useEffect(() => {
+    if (mode !== 'ai' || !convexLoading) {
+      setHasCompletedInitialConvexLoad(true)
+    }
+  }, [convexLoading, mode])
+
+  const auxiliaryResumeDataEnabled = mode !== 'ai' || hasCompletedInitialConvexLoad
+  const { actions, saveAction, getAiFeedback } = useCandidateActions(
+    sessionActionScope,
+    jobDescriptionId,
+    auxiliaryResumeDataEnabled,
+  )
+  const { blocksByIdentity, blockCandidates, unblockCandidate } = useCandidateBlocks(auxiliaryResumeDataEnabled)
+  const { statusByIdentity, updateStatus: updateCandidateStatus } = useCandidateStatus(auxiliaryResumeDataEnabled)
   const analysisTasks = useQuery(api.analysis_tasks.list)
   const dispatchAnalysis = useMutation(api.analysis_tasks.dispatch)
   const [analyzing, setAnalyzing] = useState(false)

--- a/apps/web/src/hooks/useSyncNotifications.ts
+++ b/apps/web/src/hooks/useSyncNotifications.ts
@@ -6,13 +6,19 @@ import { api } from '../../../../packages/convex/convex/_generated/api'
 
 const EVENT_STALE_MS = 30_000
 
-export function useSyncNotifications() {
+export function useSyncNotifications(enabled: boolean = true) {
   const { t } = useTranslation()
-  const latestEvent = useQuery(api.sync_events.getLatest)
+  const latestEvent = useQuery(api.sync_events.getLatest, enabled ? {} : 'skip')
   const initializedRef = useRef(false)
   const lastSeenTimestampRef = useRef(0)
 
   useEffect(() => {
+    if (!enabled) {
+      initializedRef.current = false
+      lastSeenTimestampRef.current = 0
+      return
+    }
+
     if (latestEvent === undefined) {
       return
     }
@@ -53,5 +59,5 @@ export function useSyncNotifications() {
         defaultValue: `Sync failed: ${latestEvent.error || 'Unknown error'}`,
       })
     )
-  }, [latestEvent, t])
+  }, [enabled, latestEvent, t])
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -8,18 +8,19 @@ import { ConvexProvider, ConvexReactClient } from 'convex/react'
 
 const convexUrl = import.meta.env.VITE_CONVEX_URL
 const convex = convexUrl ? new ConvexReactClient(convexUrl) : null
+const enableStrictMode = import.meta.env.PROD || import.meta.env.VITE_ENABLE_STRICT_MODE === 'true'
+
+const app = convex ? (
+  <ConvexProvider client={convex}>
+    <App />
+  </ConvexProvider>
+) : (
+  <div className="p-4 bg-yellow-100 text-yellow-800">
+    Warning: VITE_CONVEX_URL not set in .env
+    <App />
+  </div>
+)
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    {convex ? (
-      <ConvexProvider client={convex}>
-        <App />
-      </ConvexProvider>
-    ) : (
-      <div className="p-4 bg-yellow-100 text-yellow-800">
-        Warning: VITE_CONVEX_URL not set in .env
-        <App />
-      </div>
-    )}
-  </StrictMode>,
+  enableStrictMode ? <StrictMode>{app}</StrictMode> : app,
 )

--- a/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
+++ b/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
@@ -80,7 +80,11 @@ describe("listWithIngestDataPaginated", () => {
 
     expect(paginateCalled).toBe(true);
     expect(takeCalled).toBe(false);
-    expect(result.page).toEqual([resumeA, resumeB]);
+    expect(result.page).toHaveLength(2);
+    expect((result.page[0] as { _id: string; content: { name: string } })._id).toBe("resume-a");
+    expect((result.page[0] as { content: { name: string } }).content.name).toBe("resume-a");
+    expect((result.page[1] as { _id: string; content: { name: string } })._id).toBe("resume-b");
+    expect((result.page[1] as { content: { name: string } }).content.name).toBe("resume-b");
     expect(result.continueCursor).toBe("cursor-next");
     expect(result.isDone).toBe(false);
   });

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -189,6 +189,53 @@ type ResumeBackupFilterSets = {
     sourceHosts?: Set<string>;
 };
 
+type ResumeListProjectedDoc = {
+    _id: Doc<"resumes">["_id"];
+    externalId: string;
+    identityKey?: string;
+    age?: number;
+    content: Record<string, unknown>;
+    crawledAt: number;
+    source: string;
+    tags: string[];
+    analysis?: Doc<"resumes">["analysis"];
+    analyses?: Doc<"resumes">["analyses"];
+    primaryRuleScore?: number;
+    ingestData?: {
+        industryTags: string[];
+        brandHits?: Array<{
+            brand: string;
+            role: string;
+            source: string;
+            context: string;
+        }>;
+        companyHits?: string[];
+        industryDbV2Raw?: number;
+        roleSignals?: Array<{
+            type: string;
+            matchedSignals: string[];
+            signalCount: number;
+            occurrences: number;
+            years: number;
+            industryVerifiedYears?: number;
+            roleRelevantYears?: number;
+            industryVerifiedRelevantYears?: number;
+            matchedWorkEntries?: Array<{
+                companyName?: string;
+                jobTitle?: string;
+                years: number;
+                industryVerified: boolean;
+                matchedSignals: string[];
+            }>;
+            verifyIn: string;
+        }>;
+        ruleScores: unknown;
+        experienceLevel: string;
+        computedAt: number;
+        skillsVersion: number;
+    };
+};
+
 type ResumeListFilterArgs = {
     minExperience?: number;
     maxExperience?: number;
@@ -342,6 +389,158 @@ export function resolveListWithIngestWindow(requestedLimit: number | undefined):
     return {
         limit,
         overfetchLimit: Math.min(Math.max(limit * 3, limit), MAX_SAFE_LIST_WITH_INGEST_OVERFETCH),
+    };
+}
+
+function projectResumeBaseContent(
+    resume: Doc<"resumes">,
+    workHistory: unknown,
+): Record<string, unknown> {
+    const content = isRecord(resume.content) ? resume.content : {};
+    const locationHierarchy = normalizeResumeLocationHierarchy(content);
+    const name = toOptionalStringValue(content.name);
+    const profileUrl = toOptionalStringValue(content.profileUrl)
+        ?? toOptionalStringValue(content.profile_url)
+        ?? toOptionalStringValue(content.profileURL)
+        ?? toOptionalStringValue(content.url);
+    const activityStatus = toOptionalStringValue(content.activityStatus);
+    const age = toOptionalStringValue(content.age);
+    const experience = toOptionalStringValue(content.experience);
+    const education = toOptionalStringValue(content.education);
+    const location = toOptionalStringValue(content.location);
+    const selfIntro = toOptionalStringValue(content.selfIntro);
+    const jobIntention = toOptionalStringValue(content.jobIntention);
+    const expectedSalary = toOptionalStringValue(content.expectedSalary);
+    const extractedAt = toOptionalStringValue(content.extractedAt);
+    const resumeId = toOptionalStringValue(content.resumeId);
+    const perUserId = toOptionalStringValue(content.perUserId);
+    const profileId = toOptionalStringValue(content.profileId);
+    const profileType = toOptionalStringValue(content.profileType);
+
+    return {
+        ...(name ? { name } : {}),
+        ...(profileUrl ? { profileUrl } : {}),
+        ...(activityStatus ? { activityStatus } : {}),
+        ...(age ? { age } : {}),
+        ...(experience ? { experience } : {}),
+        ...(education ? { education } : {}),
+        ...(location ? { location } : {}),
+        ...(locationHierarchy ? { locationHierarchy } : {}),
+        ...(selfIntro ? { selfIntro } : {}),
+        ...(jobIntention ? { jobIntention } : {}),
+        ...(expectedSalary ? { expectedSalary } : {}),
+        ...(Array.isArray(workHistory) && workHistory.length > 0 ? { workHistory } : {}),
+        ...(extractedAt ? { extractedAt } : {}),
+        ...(resumeId ? { resumeId } : {}),
+        ...(perUserId ? { perUserId } : {}),
+        ...(profileId ? { profileId } : {}),
+        ...(profileType ? { profileType } : {}),
+        externalId: resume.externalId,
+    };
+}
+
+function projectResumeListWorkHistory(workHistory: unknown): Array<Record<string, string>> {
+    return selectLatestWorkHistory(workHistory).map((entry) => {
+        const projected = {
+            ...(entry.companyName ? { companyName: entry.companyName } : {}),
+            ...(entry.jobTitle ? { jobTitle: entry.jobTitle } : {}),
+            ...(entry.startDate ? { startDate: entry.startDate } : {}),
+            ...(entry.endDate ? { endDate: entry.endDate } : {}),
+        };
+
+        if (Object.keys(projected).length > 0) {
+            return projected;
+        }
+
+        return entry.raw ? { raw: entry.raw.slice(0, 160) } : {};
+    });
+}
+
+function projectResumeListContent(resume: Doc<"resumes">): Record<string, unknown> {
+    const content = isRecord(resume.content) ? resume.content : {};
+    return projectResumeBaseContent(resume, projectResumeListWorkHistory(content.workHistory));
+}
+
+function projectResumeDetailContent(resume: Doc<"resumes">): Record<string, unknown> {
+    const content = isRecord(resume.content) ? resume.content : {};
+    const workHistory = Array.isArray(content.workHistory) ? content.workHistory : [];
+    return projectResumeBaseContent(resume, workHistory);
+}
+
+function projectResumeListIngestData(
+    ingestData: Doc<"resumes">["ingestData"],
+): ResumeListProjectedDoc["ingestData"] {
+    if (!ingestData) {
+        return undefined;
+    }
+
+    return {
+        industryTags: ingestData.industryTags,
+        ...(ingestData.brandHits
+            ? {
+                brandHits: ingestData.brandHits.map((hit) => ({
+                    brand: hit.brand,
+                    role: hit.role,
+                    source: hit.source,
+                    context: hit.context,
+                })),
+            }
+            : {}),
+        ...(ingestData.companyHits ? { companyHits: ingestData.companyHits } : {}),
+        ...(ingestData.industryDbV2Raw === undefined ? {} : { industryDbV2Raw: ingestData.industryDbV2Raw }),
+        ...(ingestData.roleSignals
+            ? {
+                roleSignals: ingestData.roleSignals.map((signal) => ({
+                    type: signal.type,
+                    matchedSignals: signal.matchedSignals,
+                    signalCount: signal.signalCount,
+                    occurrences: signal.occurrences,
+                    years: signal.years,
+                    ...(signal.industryVerifiedYears === undefined ? {} : { industryVerifiedYears: signal.industryVerifiedYears }),
+                    ...(signal.roleRelevantYears === undefined ? {} : { roleRelevantYears: signal.roleRelevantYears }),
+                    ...(signal.industryVerifiedRelevantYears === undefined ? {} : { industryVerifiedRelevantYears: signal.industryVerifiedRelevantYears }),
+                    verifyIn: signal.verifyIn,
+                })),
+            }
+            : {}),
+        ruleScores: ingestData.ruleScores,
+        experienceLevel: ingestData.experienceLevel,
+        computedAt: ingestData.computedAt,
+        skillsVersion: ingestData.skillsVersion,
+    };
+}
+
+function projectResumeListDoc(resume: Doc<"resumes">): ResumeListProjectedDoc {
+    return {
+        _id: resume._id,
+        externalId: resume.externalId,
+        ...(resume.identityKey ? { identityKey: resume.identityKey } : {}),
+        ...(resume.age === undefined ? {} : { age: resume.age }),
+        content: projectResumeListContent(resume),
+        crawledAt: resume.crawledAt,
+        source: resume.source,
+        tags: resume.tags,
+        ...(resume.analysis ? { analysis: resume.analysis } : {}),
+        ...(resume.analyses ? { analyses: resume.analyses } : {}),
+        ...(resume.primaryRuleScore === undefined ? {} : { primaryRuleScore: resume.primaryRuleScore }),
+        ...(resume.ingestData ? { ingestData: projectResumeListIngestData(resume.ingestData) } : {}),
+    };
+}
+
+function projectResumeDetailDoc(resume: Doc<"resumes">): ResumeListProjectedDoc {
+    return {
+        _id: resume._id,
+        externalId: resume.externalId,
+        ...(resume.identityKey ? { identityKey: resume.identityKey } : {}),
+        ...(resume.age === undefined ? {} : { age: resume.age }),
+        content: projectResumeDetailContent(resume),
+        crawledAt: resume.crawledAt,
+        source: resume.source,
+        tags: resume.tags,
+        ...(resume.analysis ? { analysis: resume.analysis } : {}),
+        ...(resume.analyses ? { analyses: resume.analyses } : {}),
+        ...(resume.primaryRuleScore === undefined ? {} : { primaryRuleScore: resume.primaryRuleScore }),
+        ...(resume.ingestData ? { ingestData: projectResumeListIngestData(resume.ingestData) } : {}),
     };
 }
 
@@ -1096,7 +1295,9 @@ export const listWithIngestData = query({
             .withIndex("by_primaryRuleScore")
             .order("desc")
             .take(overfetchLimit);
-        return sortByIngestRuleScore(candidates, jobDescriptionId).slice(0, limit);
+        return sortByIngestRuleScore(candidates, jobDescriptionId)
+            .slice(0, limit)
+            .map(projectResumeListDoc);
     },
 });
 
@@ -1115,7 +1316,13 @@ export const listWithIngestDataPage = query({
         minSalary: v.optional(v.number()),
         maxSalary: v.optional(v.number()),
     },
-    handler: async (ctx, args) => runListWithIngestDataPageQuery(ctx, args),
+    handler: async (ctx, args) => {
+        const result = await runListWithIngestDataPageQuery(ctx, args);
+        return {
+            total: result.total,
+            results: result.results.map(projectResumeListDoc),
+        };
+    },
 });
 
 export const listWithIngestDataPaginated = query({
@@ -1154,7 +1361,7 @@ export const listWithIngestDataPaginated = query({
                 : page.page;
 
             return {
-                page: filtered,
+                page: filtered.map(projectResumeListDoc),
                 continueCursor: page.continueCursor,
                 isDone: page.isDone,
             };
@@ -1168,7 +1375,7 @@ export const listWithIngestDataPaginated = query({
             offset,
         });
 
-        return buildPaginatedOffsetResult(page.results, page.total, offset);
+        return buildPaginatedOffsetResult(page.results.map(projectResumeListDoc), page.total, offset);
     },
 });
 
@@ -1349,7 +1556,11 @@ export const searchWithTagExpansion = query({
                 groups: keywordGroups,
                 mode,
             },
-            results: mergeResumeDocs(filteredDocs, provenanceByResumeId, jobDescriptionId, limit),
+            results: mergeResumeDocs(filteredDocs, provenanceByResumeId, jobDescriptionId, limit)
+                .map((entry) => ({
+                    resume: projectResumeListDoc(entry.resume),
+                    provenance: entry.provenance,
+                })),
         };
     },
 });
@@ -1379,7 +1590,17 @@ export const searchWithTagExpansionPage = query({
         minSalary: v.optional(v.number()),
         maxSalary: v.optional(v.number()),
     },
-    handler: async (ctx, args) => runSearchWithTagExpansionPageQuery(ctx, args),
+    handler: async (ctx, args) => {
+        const result = await runSearchWithTagExpansionPageQuery(ctx, args);
+        return {
+            expansion: result.expansion,
+            total: result.total,
+            results: result.results.map((entry) => ({
+                resume: projectResumeListDoc(entry.resume),
+                provenance: entry.provenance,
+            })),
+        };
+    },
 });
 
 export const searchWithTagExpansionPaginated = query({
@@ -1415,7 +1636,10 @@ export const searchWithTagExpansionPaginated = query({
             offset,
         });
 
-        return buildPaginatedOffsetResult(page.results, page.total, offset);
+        return buildPaginatedOffsetResult(page.results.map((entry) => ({
+            resume: projectResumeListDoc(entry.resume),
+            provenance: entry.provenance,
+        })), page.total, offset);
     },
 });
 
@@ -1423,6 +1647,18 @@ export const getResume = internalQuery({
     args: { resumeId: v.id("resumes") },
     handler: async (ctx, args) => {
         return await ctx.db.get(args.resumeId);
+    },
+});
+
+export const getResumeDetail = query({
+    args: { resumeId: v.id("resumes") },
+    handler: async (ctx, args) => {
+        const resume = await ctx.db.get(args.resumeId);
+        if (!resume) {
+            return null;
+        }
+
+        return projectResumeDetailDoc(resume);
     },
 });
 


### PR DESCRIPTION
## Summary\n- cut dev-only first-paint overhead on /dev/resumes by gating StrictMode in dev and deferring non-critical startup hooks\n- project lean Convex resume list/search payloads and fetch full resume detail on demand\n- validate with focused web/convex tests, make check, and repeated timing probes\n\n## Testing\n- make check\n- npm --workspace @trends/web run test -- src/hooks/useResumeListState.test.tsx src/hooks/useSession.test.tsx src/hooks/useCandidateActions.test.ts\n- npx vitest run packages/convex/convex/__tests__/resumes-paginated-default.test.ts