### PR TITLE
fix(dev): harden convex refresh startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,9 +158,7 @@ dev-convex-refresh:
 	if tmux has-session -t "$$tmux_session" 2>/dev/null; then \
 		tmux kill-session -t "$$tmux_session" 2>/dev/null || true; \
 	fi; \
-	runner="npx"; \
-	if command -v bun >/dev/null 2>&1; then runner="bunx"; fi; \
-	tmux new-session -d -s "$$tmux_session" "cd '$$project_root/packages/convex' && env -u TZ $$runner convex dev"; \
+	tmux new-session -d -s "$$tmux_session" "cd '$$project_root/packages/convex' && if command -v bun >/dev/null 2>&1; then bun run dev; else npm run dev; fi"; \
 	for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do \
 		if curl -fsS "http://127.0.0.1:$$convex_port/version" >/dev/null 2>&1; then \
 			echo "Local Convex refreshed and ready at http://127.0.0.1:$$convex_port via tmux session $$tmux_session"; \

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -4,8 +4,8 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "dev": "env -u TZ convex dev",
-        "predev": "env -u TZ convex dev --once",
+        "dev": "env -u TZ convex dev --local --local-force-upgrade",
+        "predev": "env -u TZ convex dev --once --local --local-force-upgrade",
         "build": "convex codegen",
         "typecheck": "tsc --noEmit"
     },


### PR DESCRIPTION
## Summary\n- fix make[1]: Entering directory '/root/workspace'
Stopping local Convex tmux session: trends-convex
Stopping local Convex process groups for PIDs: 743633
743651
Local Convex stopped.
make[1]: Leaving directory '/root/workspace'
Local Convex refreshed and ready at http://127.0.0.1:3210 via tmux session trends-convex so the detached tmux path uses the package dev script instead of raw interactive \n- align  dev and predev scripts with the non-interactive local flags already required by the working dev stack\n- confirm that a clean Convex refresh drops retained RSS and restores swap headroom on the local 2276-resume dataset\n\n## Validation\n- make dev-convex-refresh\n- make dev-convex-status\n- make check\n- host memory recheck before vs after refresh