### PR TITLE
feat: add workspace summary preview core

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -24,6 +24,7 @@ import {
   configRoutes,
   notificationRoutes,
   workerRoutes,
+  summariesRoutes,
 } from "./routes/index.js";
 import { config } from "./services/config.js";
 import { workspaceMiddleware } from "./middleware/workspace.js";
@@ -53,6 +54,7 @@ export const openApiConfig = {
     { name: "Scoring Evaluation", description: "Scoring quality analysis, auto-tuning, and rollback" },
     { name: "Filter Presets", description: "Filter preset management" },
     { name: "Config", description: "Runtime configuration management" },
+    { name: "Summaries", description: "Workspace summary previews and delivery" },
   ],
 };
 
@@ -93,6 +95,7 @@ export function createApp() {
   app.route("/api/filter-presets", filterPresetsRoutes);
   app.route("/api/config", configRoutes);
   app.route("/api/notifications", notificationRoutes);
+  app.route("/api/summaries", summariesRoutes);
 
   // OpenAPI documentation endpoint
   app.doc("/doc", openApiConfig);
@@ -133,6 +136,7 @@ export function createApp() {
         search_analytics: "/api/search-analytics",
         scoring_evaluation: "/api/scoring-evaluation/report",
         config: "/api/config",
+        summaries: "/api/summaries/preview",
       },
     });
   });

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -18,3 +18,4 @@ export { default as filterPresetsRoutes } from "./filter-presets.js";
 export { default as configRoutes } from "./config.js";
 export { default as notificationRoutes } from "./notifications.js";
 export { default as workerRoutes } from "./worker.js";
+export { default as summariesRoutes } from "./summaries.js";

--- a/apps/api/src/routes/summaries.test.ts
+++ b/apps/api/src/routes/summaries.test.ts
@@ -1,0 +1,221 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function createFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "summaries-route-"));
+  fs.mkdirSync(path.join(root, "output"), { recursive: true });
+  fs.mkdirSync(path.join(root, "config", "resume"), { recursive: true });
+  fs.writeFileSync(path.join(root, "pyproject.toml"), "", "utf8");
+  fs.writeFileSync(
+    path.join(root, "config", "resume", "skills.md"),
+    [
+      "---",
+      "version: 1",
+      'updated_at: "2026-03-26"',
+      "---",
+      "",
+      "## Company Patterns",
+      "",
+      "### fanuc",
+      "- aliases: FANUC, 发那科",
+      "- tier: 1",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+  return root;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): {
+  pathName: string;
+  args: Record<string, unknown>;
+} {
+  const requestUrl = typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+  if (!requestUrl.includes("/api/query")) {
+    throw new Error(`Unexpected request URL: ${requestUrl}`);
+  }
+
+  const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+  if (!isRecord(body)) {
+    throw new Error("Missing convex request body");
+  }
+
+  const pathName = typeof body.path === "string" ? body.path : "";
+  const args = isRecord(body.args) ? body.args : {};
+  if (!pathName) {
+    throw new Error("Missing convex path in request body");
+  }
+
+  return { pathName, args };
+}
+
+function convexSuccess(value: unknown): Response {
+  return new Response(
+    JSON.stringify({
+      status: "success",
+      value,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+}
+
+async function loadSummaryModules(root: string) {
+  process.env.PROJECT_ROOT = root;
+  vi.resetModules();
+  const { createApp } = await import("../app");
+  const { SessionManager } = await import("../services/session-manager");
+  const { ActionStorage } = await import("../services/action-storage");
+  const { ReviewPacketStorage } = await import("../services/review-packet-storage");
+  const { resetResumeScreeningDb } = await import("../services/database");
+  return {
+    createApp,
+    SessionManager,
+    ActionStorage,
+    ReviewPacketStorage,
+    resetResumeScreeningDb,
+  };
+}
+
+describe("summary preview route", () => {
+  let root = "";
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    delete process.env.PROJECT_ROOT;
+    if (root) {
+      const { resetResumeScreeningDb } = await import("../services/database");
+      resetResumeScreeningDb();
+      fs.rmSync(root, { recursive: true, force: true });
+      root = "";
+    }
+  });
+
+  it("builds a preview from workspace-scoped actions and Convex summary queries", async () => {
+    root = createFixtureRoot();
+    const {
+      createApp,
+      SessionManager,
+      ActionStorage,
+      ReviewPacketStorage,
+    } = await loadSummaryModules(root);
+
+    const sessionManager = new SessionManager(root);
+    const actionStorage = new ActionStorage(root);
+    const reviewPacketStorage = new ReviewPacketStorage(root);
+    const session = sessionManager.createSession({ workspaceSlug: "hr" });
+    reviewPacketStorage.createRun({
+      id: "packet-1",
+      workspaceSlug: "hr",
+      source: "convex",
+      format: "csv",
+      totalCount: 0,
+      items: [],
+    });
+
+    actionStorage.saveAction({ sessionId: session.id, resumeId: "resume-1", actionType: "shortlist" });
+    actionStorage.saveAction({ sessionId: session.id, resumeId: "resume-2", actionType: "contact" });
+    actionStorage.saveAction({ sessionId: "review-packet:packet-1", resumeId: "resume-3", actionType: "reject" });
+
+    const calls: Array<{ pathName: string; args: Record<string, unknown> }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:getSummaryWindow") {
+        return convexSuccess({
+          total: 4,
+          bySource: [
+            { key: "seek", count: 2 },
+            { key: "job5156", count: 2 },
+          ],
+        });
+      }
+
+      if (call.pathName === "candidate_status:list") {
+        return convexSuccess([
+          { status: "interviewing", updatedAt: Date.now() - 60_000 },
+          { status: "offer", updatedAt: Date.now() - 120_000 },
+          { status: "offer", updatedAt: Date.now() - 3 * 24 * 60 * 60 * 1000 },
+        ]);
+      }
+
+      if (call.pathName === "resume_tasks:getSummaryWindow") {
+        return convexSuccess({
+          total: 2,
+          byStatus: [
+            { key: "completed", count: 1 },
+            { key: "failed", count: 1 },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/summaries/preview", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        period: "daily",
+        endAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      success: boolean;
+      report: {
+        workspaceSlug: string;
+        totals: Record<string, number>;
+        breakdowns: {
+          actionsByType: Array<{ key: string; count: number }>;
+        };
+      };
+      markdown: string;
+    };
+
+    expect(payload.success).toBe(true);
+    expect(payload.report.workspaceSlug).toBe("hr");
+    expect(payload.report.totals).toMatchObject({
+      newResumes: 4,
+      candidateStatusUpdates: 2,
+      shortlistActions: 1,
+      rejectActions: 1,
+      contactActions: 1,
+      collectionTasksCompleted: 1,
+      collectionTasksFailed: 1,
+    });
+    expect(payload.report.breakdowns.actionsByType).toEqual([
+      { key: "contact", label: "Contact", count: 1 },
+      { key: "reject", label: "Reject", count: 1 },
+      { key: "shortlist", label: "Shortlist", count: 1 },
+    ]);
+    expect(payload.markdown).toContain("# Daily Ops Summary");
+    expect(calls.map((call) => call.pathName)).toEqual([
+      "resumes:getSummaryWindow",
+      "candidate_status:list",
+      "resume_tasks:getSummaryWindow",
+    ]);
+    expect(calls[1]?.args.workspaceSlug).toBe("hr");
+  });
+});

--- a/apps/api/src/routes/summaries.ts
+++ b/apps/api/src/routes/summaries.ts
@@ -1,0 +1,118 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+
+import { SummaryDataService } from "../services/summaries/summary-data-service.js";
+import { SummaryRenderer } from "../services/summaries/summary-renderer.js";
+
+const app = new OpenAPIHono();
+const summaryDataService = new SummaryDataService();
+const summaryRenderer = new SummaryRenderer();
+
+const SummaryCountEntrySchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  count: z.number().int(),
+});
+
+const SummaryReportSchema = z.object({
+  workspaceSlug: z.string(),
+  period: z.literal("daily"),
+  generatedAt: z.string(),
+  window: z.object({
+    startAt: z.string(),
+    endAt: z.string(),
+    timezone: z.string(),
+  }),
+  totals: z.object({
+    newResumes: z.number().int(),
+    candidateStatusUpdates: z.number().int(),
+    shortlistActions: z.number().int(),
+    rejectActions: z.number().int(),
+    contactActions: z.number().int(),
+    collectionTasksCompleted: z.number().int(),
+    collectionTasksFailed: z.number().int(),
+  }),
+  breakdowns: z.object({
+    resumesBySource: z.array(SummaryCountEntrySchema),
+    candidateStatusByValue: z.array(SummaryCountEntrySchema),
+    actionsByType: z.array(SummaryCountEntrySchema),
+    collectionTasksByStatus: z.array(SummaryCountEntrySchema),
+  }),
+  notes: z.array(z.string()),
+});
+
+const SummaryPreviewRequestSchema = z.object({
+  workspaceSlug: z.string().min(1).optional(),
+  period: z.literal("daily").default("daily"),
+  endAt: z.string().datetime({ offset: true }).optional(),
+});
+
+const SummaryPreviewResponseSchema = z.object({
+  success: z.literal(true),
+  report: SummaryReportSchema,
+  markdown: z.string(),
+});
+
+const ErrorSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+});
+
+const previewRoute = createRoute({
+  method: "post",
+  path: "/preview",
+  tags: ["Summaries"],
+  summary: "Preview a workspace daily summary",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: SummaryPreviewRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Summary preview",
+      content: {
+        "application/json": {
+          schema: SummaryPreviewResponseSchema,
+        },
+      },
+    },
+    500: {
+      description: "Preview error",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(previewRoute, async (c) => {
+  try {
+    const body = c.req.valid("json");
+    const workspaceSlug = body.workspaceSlug?.trim() || c.var.workspaceSlug;
+    const report = await summaryDataService.buildSummaryReport({
+      workspaceSlug,
+      period: body.period,
+      endAt: body.endAt,
+    });
+
+    return c.json({
+      success: true as const,
+      report,
+      markdown: summaryRenderer.renderMarkdown(report),
+    }, 200);
+  } catch (error) {
+    console.error("Failed to preview summary:", error);
+    return c.json({
+      success: false as const,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }, 500);
+  }
+});
+
+export default app;

--- a/apps/api/src/services/action-storage.test.ts
+++ b/apps/api/src/services/action-storage.test.ts
@@ -157,4 +157,48 @@ describe("ActionStorage", () => {
       expect(latest.map((action) => action.actionType).sort()).toEqual(["ai_score_like", "star"]);
     });
   });
+
+  it("summarizes actions in a workspace window using persisted sessions and review packets", () => {
+    root = createFixtureRoot();
+    storage = new ActionStorage(root);
+    const db = getResumeScreeningDb(root);
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `
+      INSERT INTO search_sessions (id, workspace_slug, status, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      `
+    ).run("session-hr", "hr", "active", now, now);
+    db.prepare(
+      `
+      INSERT INTO search_sessions (id, workspace_slug, status, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      `
+    ).run("session-dev", "dev", "active", now, now);
+    db.prepare(
+      `
+      INSERT INTO review_packet_runs (
+        id, workspace_slug, source, format, status, total_count, exported_at, items_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    ).run("packet-hr", "hr", "convex", "csv", "exported", 0, now, "[]");
+
+    storage.saveAction({ sessionId: "session-hr", resumeId: "r1", actionType: "shortlist" });
+    storage.saveAction({ sessionId: "session-dev", resumeId: "r2", actionType: "reject" });
+    storage.saveAction({ sessionId: "review-packet:packet-hr", resumeId: "r3", actionType: "contact" });
+    storage.saveAction({ sessionId: "scope:untracked", resumeId: "r4", actionType: "star" });
+
+    const summary = storage.summarizeActionsInWindow({
+      workspaceSlug: "hr",
+      startAt: "2000-01-01T00:00:00.000Z",
+      endAt: "2999-01-01T00:00:00.000Z",
+    });
+
+    expect(summary.total).toBe(2);
+    expect(summary.breakdown).toEqual([
+      { actionType: "contact", count: 1 },
+      { actionType: "shortlist", count: 1 },
+    ]);
+  });
 });

--- a/apps/api/src/services/action-storage.ts
+++ b/apps/api/src/services/action-storage.ts
@@ -64,6 +64,14 @@ export type CandidateAction = {
   createdAt: string;
 };
 
+export type CandidateActionWindowSummary = {
+  total: number;
+  breakdown: Array<{
+    actionType: CandidateActionType;
+    count: number;
+  }>;
+};
+
 function parseJson(value: unknown): Record<string, unknown> | undefined {
   if (typeof value !== "string" || !value.trim()) return undefined;
   try {
@@ -221,6 +229,63 @@ export class ActionStorage {
         );
 
     return rows.map((row) => normalizeAction(row));
+  }
+
+  summarizeActionsInWindow(params: {
+    workspaceSlug: string;
+    startAt: string;
+    endAt: string;
+  }): CandidateActionWindowSummary {
+    const rows = this.db
+      .prepare(
+        `
+        SELECT
+          ca.action_type,
+          COUNT(*) AS count
+        FROM candidate_actions ca
+        LEFT JOIN search_sessions persisted_session
+          ON persisted_session.id = ca.session_id
+        LEFT JOIN search_sessions scoped_session
+          ON scoped_session.id = json_extract(ca.action_data, '$.scopeId')
+        LEFT JOIN review_packet_runs persisted_packet
+          ON persisted_packet.id = CASE
+            WHEN ca.session_id LIKE 'review-packet:%' THEN substr(ca.session_id, 15)
+            ELSE NULL
+          END
+        LEFT JOIN review_packet_runs scoped_packet
+          ON scoped_packet.id = CASE
+            WHEN json_extract(ca.action_data, '$.scopeId') LIKE 'review-packet:%'
+              THEN substr(json_extract(ca.action_data, '$.scopeId'), 15)
+            ELSE NULL
+          END
+        WHERE ca.created_at >= ?
+          AND ca.created_at < ?
+          AND COALESCE(
+            persisted_session.workspace_slug,
+            scoped_session.workspace_slug,
+            persisted_packet.workspace_slug,
+            scoped_packet.workspace_slug
+          ) = ?
+        GROUP BY ca.action_type
+        ORDER BY count DESC, ca.action_type ASC
+      `
+      )
+      .all(params.startAt, params.endAt, params.workspaceSlug) as Array<{
+      action_type?: unknown;
+      count?: unknown;
+    }>;
+
+    const breakdown = rows
+      .map((row) => ({
+        actionType: String(row.action_type) as CandidateActionType,
+        count: Number(row.count ?? 0),
+      }))
+      .filter((row) => row.count > 0);
+
+    return {
+      total: breakdown.reduce((sum, item) => sum + item.count, 0),
+      breakdown,
+    };
   }
 
   private hasPersistedSession(sessionId: string): boolean {

--- a/apps/api/src/services/summaries/summary-data-service.test.ts
+++ b/apps/api/src/services/summaries/summary-data-service.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { SummaryDataService } from "./summary-data-service";
+
+describe("SummaryDataService", () => {
+  it("builds a daily report from Convex and action summaries", async () => {
+    const service = new SummaryDataService({
+      now: () => new Date("2026-03-26T04:00:00.000Z"),
+      actionStorage: {
+        summarizeActionsInWindow: () => ({
+          total: 3,
+          breakdown: [
+            { actionType: "shortlist", count: 1 },
+            { actionType: "reject", count: 1 },
+            { actionType: "contact", count: 1 },
+          ],
+        }),
+      },
+      queryConvex: async (pathName) => {
+        if (pathName === "resumes:getSummaryWindow") {
+          return {
+            total: 5,
+            bySource: [
+              { key: "job5156", count: 3 },
+              { key: "seek", count: 2 },
+            ],
+          };
+        }
+
+        if (pathName === "candidate_status:list") {
+          return [
+            { status: "interviewing", updatedAt: Date.parse("2026-03-25T12:00:00.000Z") },
+            { status: "offer", updatedAt: Date.parse("2026-03-25T18:00:00.000Z") },
+            { status: "offer", updatedAt: Date.parse("2026-03-20T18:00:00.000Z") },
+          ];
+        }
+
+        if (pathName === "resume_tasks:getSummaryWindow") {
+          return {
+            total: 2,
+            byStatus: [
+              { key: "completed", count: 1 },
+              { key: "failed", count: 1 },
+            ],
+          };
+        }
+
+        throw new Error(`Unexpected Convex path: ${pathName}`);
+      },
+    });
+
+    const report = await service.buildSummaryReport({
+      workspaceSlug: "hr",
+      period: "daily",
+      endAt: "2026-03-26T04:00:00.000Z",
+    });
+
+    expect(report.workspaceSlug).toBe("hr");
+    expect(report.totals).toEqual({
+      newResumes: 5,
+      candidateStatusUpdates: 2,
+      shortlistActions: 1,
+      rejectActions: 1,
+      contactActions: 1,
+      collectionTasksCompleted: 1,
+      collectionTasksFailed: 1,
+    });
+    expect(report.breakdowns.resumesBySource).toEqual([
+      { key: "job5156", label: "job5156", count: 3 },
+      { key: "seek", label: "seek", count: 2 },
+    ]);
+    expect(report.breakdowns.candidateStatusByValue).toEqual([
+      { key: "interviewing", label: "Interviewing", count: 1 },
+      { key: "offer", label: "Offer", count: 1 },
+    ]);
+    expect(report.notes).toHaveLength(2);
+  });
+});

--- a/apps/api/src/services/summaries/summary-data-service.ts
+++ b/apps/api/src/services/summaries/summary-data-service.ts
@@ -1,0 +1,345 @@
+import type {
+  SummaryCountEntry,
+  SummaryPeriod,
+  SummaryReport,
+  SummaryTotals,
+  SummaryWindow,
+} from "@trends/shared";
+
+import {
+  ActionStorage,
+  type CandidateActionType,
+} from "../action-storage.js";
+import { config } from "../config.js";
+import { resolveConvexUrl } from "../resume-import-service.js";
+import { formatIsoOffsetInTimezone } from "../timezone.js";
+
+type ConvexSummaryEntry = {
+  key: string;
+  count: number;
+};
+
+type ResumeWindowSummary = {
+  total: number;
+  bySource: ConvexSummaryEntry[];
+};
+
+type CollectionTaskWindowSummary = {
+  total: number;
+  byStatus: ConvexSummaryEntry[];
+};
+
+type SummaryDataServiceDependencies = {
+  actionStorage?: Pick<ActionStorage, "summarizeActionsInWindow">;
+  now?: () => Date;
+  queryConvex?: (pathName: string, args: Record<string, unknown>) => Promise<unknown>;
+};
+
+const ACTION_LABELS: Record<CandidateActionType, string> = {
+  star: "Star",
+  shortlist: "Shortlist",
+  reject: "Reject",
+  archive: "Archive",
+  note: "Note",
+  contact: "Contact",
+  ai_score_like: "AI Score Like",
+  ai_score_unlike: "AI Score Unlike",
+  ai_summary_like: "AI Summary Like",
+  ai_summary_unlike: "AI Summary Unlike",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  new: "New",
+  contacted: "Contacted",
+  interviewing: "Interviewing",
+  interviewed_pass: "Interview Passed",
+  interviewed_reject: "Interview Rejected",
+  offer: "Offer",
+  hired: "Hired",
+  withdrawn: "Withdrawn",
+};
+
+const TASK_STATUS_LABELS: Record<string, string> = {
+  completed: "Completed",
+  failed: "Failed",
+  cancelled: "Cancelled",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeConvexEntries(
+  value: unknown,
+  labels: Record<string, string> = {},
+): SummaryCountEntry[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => {
+      if (!isRecord(item)) {
+        return null;
+      }
+      const key = readString(item.key);
+      const count = readNumber(item.count);
+      if (!key || typeof count !== "number" || count <= 0) {
+        return null;
+      }
+      return {
+        key,
+        label: labels[key] ?? key,
+        count,
+      } satisfies SummaryCountEntry;
+    })
+    .filter((item): item is SummaryCountEntry => item !== null)
+    .sort((left, right) => {
+      if (right.count !== left.count) {
+        return right.count - left.count;
+      }
+      return left.key.localeCompare(right.key);
+    });
+}
+
+function countFromEntries(entries: SummaryCountEntry[], key: string): number {
+  return entries.find((entry) => entry.key === key)?.count ?? 0;
+}
+
+function normalizeActionEntries(
+  breakdown: Array<{ actionType: CandidateActionType; count: number }>,
+): SummaryCountEntry[] {
+  return breakdown
+    .map((entry) => ({
+      key: entry.actionType,
+      label: ACTION_LABELS[entry.actionType] ?? entry.actionType,
+      count: entry.count,
+    }))
+    .filter((entry) => entry.count > 0)
+    .sort((left, right) => {
+      if (right.count !== left.count) {
+        return right.count - left.count;
+      }
+      return left.key.localeCompare(right.key);
+    });
+}
+
+function buildWindow(params: {
+  period: SummaryPeriod;
+  endAt?: string;
+  now: () => Date;
+  timezone: string;
+}): { fromTimestamp: number; toTimestamp: number; window: SummaryWindow } {
+  const endDate = params.endAt ? new Date(params.endAt) : params.now();
+  if (Number.isNaN(endDate.getTime())) {
+    throw new Error("Invalid endAt value");
+  }
+
+  const durationMs = params.period === "daily" ? 24 * 60 * 60 * 1000 : 0;
+  const startDate = new Date(endDate.getTime() - durationMs);
+
+  return {
+    fromTimestamp: startDate.getTime(),
+    toTimestamp: endDate.getTime(),
+    window: {
+      startAt: formatIsoOffsetInTimezone(startDate, params.timezone),
+      endAt: formatIsoOffsetInTimezone(endDate, params.timezone),
+      timezone: params.timezone,
+    },
+  };
+}
+
+async function callConvexQuery(pathName: string, args: Record<string, unknown>): Promise<unknown> {
+  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+  const response = await fetch(`${convexUrl}/api/query`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      path: pathName,
+      args,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Convex query failed (${response.status}): ${text}`);
+  }
+
+  const payload = await response.json() as {
+    status?: string;
+    value?: unknown;
+    errorMessage?: string;
+  };
+
+  if (payload.status !== "success") {
+    throw new Error(payload.errorMessage || `Convex query failed for ${pathName}`);
+  }
+
+  return payload.value;
+}
+
+function toSummaryTotals(params: {
+  resumeSummary: ResumeWindowSummary;
+  candidateStatusEntries: SummaryCountEntry[];
+  actionEntries: SummaryCountEntry[];
+  taskEntries: SummaryCountEntry[];
+}): SummaryTotals {
+  return {
+    newResumes: params.resumeSummary.total,
+    candidateStatusUpdates: params.candidateStatusEntries.reduce((sum, entry) => sum + entry.count, 0),
+    shortlistActions: countFromEntries(params.actionEntries, "shortlist"),
+    rejectActions: countFromEntries(params.actionEntries, "reject"),
+    contactActions: countFromEntries(params.actionEntries, "contact"),
+    collectionTasksCompleted: countFromEntries(params.taskEntries, "completed"),
+    collectionTasksFailed: countFromEntries(params.taskEntries, "failed"),
+  };
+}
+
+export class SummaryDataService {
+  private readonly actionStorage: Pick<ActionStorage, "summarizeActionsInWindow">;
+  private readonly now: () => Date;
+  private readonly queryConvex: (pathName: string, args: Record<string, unknown>) => Promise<unknown>;
+
+  constructor(dependencies: SummaryDataServiceDependencies = {}) {
+    this.actionStorage = dependencies.actionStorage ?? new ActionStorage(config.projectRoot);
+    this.now = dependencies.now ?? (() => new Date());
+    this.queryConvex = dependencies.queryConvex ?? callConvexQuery;
+  }
+
+  async buildSummaryReport(params: {
+    workspaceSlug: string;
+    period: SummaryPeriod;
+    endAt?: string;
+  }): Promise<SummaryReport> {
+    const { fromTimestamp, toTimestamp, window } = buildWindow({
+      period: params.period,
+      endAt: params.endAt,
+      now: this.now,
+      timezone: config.timezone,
+    });
+
+    const [resumeSummary, candidateStatusSummary, collectionTaskSummary] = await Promise.all([
+      this.loadResumeSummary(fromTimestamp, toTimestamp),
+      this.loadCandidateStatusSummary(params.workspaceSlug, fromTimestamp, toTimestamp),
+      this.loadCollectionTaskSummary(fromTimestamp, toTimestamp),
+    ]);
+
+    const actionSummary = this.actionStorage.summarizeActionsInWindow({
+      workspaceSlug: params.workspaceSlug,
+      startAt: window.startAt,
+      endAt: window.endAt,
+    });
+
+    const candidateStatusEntries = normalizeConvexEntries(candidateStatusSummary.byStatus, STATUS_LABELS);
+    const actionEntries = normalizeActionEntries(actionSummary.breakdown);
+    const taskEntries = normalizeConvexEntries(collectionTaskSummary.byStatus, TASK_STATUS_LABELS);
+    const totals = toSummaryTotals({
+      resumeSummary,
+      candidateStatusEntries,
+      actionEntries,
+      taskEntries,
+    });
+
+    return {
+      workspaceSlug: params.workspaceSlug,
+      period: params.period,
+      generatedAt: formatIsoOffsetInTimezone(this.now(), config.timezone),
+      window,
+      totals,
+      breakdowns: {
+        resumesBySource: normalizeConvexEntries(resumeSummary.bySource),
+        candidateStatusByValue: candidateStatusEntries,
+        actionsByType: actionEntries,
+        collectionTasksByStatus: taskEntries,
+      },
+      notes: [
+        "Resume and collection-task counts are shared ingest totals because those records are not workspace-scoped today.",
+        "Action counts include only workspace-linked rows resolved through persisted sessions or review-packet runs.",
+      ],
+    };
+  }
+
+  private async loadResumeSummary(fromTimestamp: number, toTimestamp: number): Promise<ResumeWindowSummary> {
+    const value = await this.queryConvex("resumes:getSummaryWindow", {
+      fromTimestamp,
+      toTimestamp,
+    });
+
+    if (!isRecord(value)) {
+      return { total: 0, bySource: [] };
+    }
+
+    return {
+      total: readNumber(value.total) ?? 0,
+      bySource: normalizeConvexEntries(value.bySource).map((entry) => ({
+        key: entry.key,
+        count: entry.count,
+      })),
+    };
+  }
+
+  private async loadCandidateStatusSummary(
+    workspaceSlug: string,
+    fromTimestamp: number,
+    toTimestamp: number,
+  ): Promise<{ byStatus: ConvexSummaryEntry[] }> {
+    const value = await this.queryConvex("candidate_status:list", {
+      workspaceSlug,
+    });
+
+    const counts = new Map<string, number>();
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (!isRecord(item)) {
+          continue;
+        }
+        const updatedAt = readNumber(item.updatedAt);
+        const status = readString(item.status);
+        if (!updatedAt || !status) {
+          continue;
+        }
+        if (updatedAt < fromTimestamp || updatedAt >= toTimestamp) {
+          continue;
+        }
+        counts.set(status, (counts.get(status) ?? 0) + 1);
+      }
+    }
+
+    return {
+      byStatus: Array.from(counts.entries()).map(([key, count]) => ({ key, count })),
+    };
+  }
+
+  private async loadCollectionTaskSummary(
+    fromTimestamp: number,
+    toTimestamp: number,
+  ): Promise<CollectionTaskWindowSummary> {
+    const value = await this.queryConvex("resume_tasks:getSummaryWindow", {
+      fromTimestamp,
+      toTimestamp,
+    });
+
+    if (!isRecord(value)) {
+      return { total: 0, byStatus: [] };
+    }
+
+    return {
+      total: readNumber(value.total) ?? 0,
+      byStatus: normalizeConvexEntries(value.byStatus).map((entry) => ({
+        key: entry.key,
+        count: entry.count,
+      })),
+    };
+  }
+}

--- a/apps/api/src/services/summaries/summary-renderer.ts
+++ b/apps/api/src/services/summaries/summary-renderer.ts
@@ -1,0 +1,47 @@
+import type { SummaryCountEntry, SummaryReport } from "@trends/shared";
+
+function renderCountList(entries: SummaryCountEntry[]): string[] {
+  if (entries.length === 0) {
+    return ["- none"];
+  }
+
+  return entries.map((entry) => `- ${entry.label}: ${entry.count}`);
+}
+
+export class SummaryRenderer {
+  renderMarkdown(report: SummaryReport): string {
+    return [
+      `# Daily Ops Summary`,
+      ``,
+      `- Workspace: ${report.workspaceSlug}`,
+      `- Generated: ${report.generatedAt}`,
+      `- Window: ${report.window.startAt} -> ${report.window.endAt}`,
+      `- Timezone: ${report.window.timezone}`,
+      ``,
+      `## Totals`,
+      `- New resumes: ${report.totals.newResumes}`,
+      `- Candidate status updates: ${report.totals.candidateStatusUpdates}`,
+      `- Shortlist actions: ${report.totals.shortlistActions}`,
+      `- Reject actions: ${report.totals.rejectActions}`,
+      `- Contact actions: ${report.totals.contactActions}`,
+      `- Collection tasks completed: ${report.totals.collectionTasksCompleted}`,
+      `- Collection tasks failed: ${report.totals.collectionTasksFailed}`,
+      ``,
+      `## Resume Sources`,
+      ...renderCountList(report.breakdowns.resumesBySource),
+      ``,
+      `## Candidate Status Updates`,
+      ...renderCountList(report.breakdowns.candidateStatusByValue),
+      ``,
+      `## Candidate Actions`,
+      ...renderCountList(report.breakdowns.actionsByType),
+      ``,
+      `## Collection Tasks`,
+      ...renderCountList(report.breakdowns.collectionTasksByStatus),
+      ``,
+      `## Notes`,
+      ...report.notes.map((note) => `- ${note}`),
+      ``,
+    ].join("\n");
+  }
+}

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4406,6 +4406,115 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/summaries/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Preview a workspace daily summary */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        workspaceSlug?: string;
+                        /**
+                         * @default daily
+                         * @enum {string}
+                         */
+                        period?: "daily";
+                        /** Format: date-time */
+                        endAt?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Summary preview */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            report: {
+                                workspaceSlug: string;
+                                /** @enum {string} */
+                                period: "daily";
+                                generatedAt: string;
+                                window: {
+                                    startAt: string;
+                                    endAt: string;
+                                    timezone: string;
+                                };
+                                totals: {
+                                    newResumes: number;
+                                    candidateStatusUpdates: number;
+                                    shortlistActions: number;
+                                    rejectActions: number;
+                                    contactActions: number;
+                                    collectionTasksCompleted: number;
+                                    collectionTasksFailed: number;
+                                };
+                                breakdowns: {
+                                    resumesBySource: {
+                                        key: string;
+                                        label: string;
+                                        count: number;
+                                    }[];
+                                    candidateStatusByValue: {
+                                        key: string;
+                                        label: string;
+                                        count: number;
+                                    }[];
+                                    actionsByType: {
+                                        key: string;
+                                        label: string;
+                                        count: number;
+                                    }[];
+                                    collectionTasksByStatus: {
+                                        key: string;
+                                        label: string;
+                                        count: number;
+                                    }[];
+                                };
+                                notes: string[];
+                            };
+                            markdown: string;
+                        };
+                    };
+                };
+                /** @description Preview error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -640,6 +640,38 @@ export const getSummary = query({
     },
 });
 
+export const getSummaryWindow = query({
+    args: {
+        fromTimestamp: v.number(),
+        toTimestamp: v.number(),
+    },
+    handler: async (ctx, args) => {
+        const tasks = await ctx.db.query("collection_tasks").collect();
+        const matching = tasks.filter((task) =>
+            typeof task.completedAt === "number"
+            && task.completedAt >= args.fromTimestamp
+            && task.completedAt < args.toTimestamp
+        );
+
+        const byStatus = new Map<string, number>();
+        for (const task of matching) {
+            byStatus.set(task.status, (byStatus.get(task.status) ?? 0) + 1);
+        }
+
+        return {
+            total: matching.length,
+            byStatus: Array.from(byStatus.entries())
+                .map(([key, count]) => ({ key, count }))
+                .sort((left, right) => {
+                    if (right.count !== left.count) {
+                        return right.count - left.count;
+                    }
+                    return left.key.localeCompare(right.key);
+                }),
+        };
+    },
+});
+
 const RESET_TABLES = [
     "collection_tasks",
     "resumes",

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -1301,6 +1301,39 @@ export const listWithIngestData = query({
     },
 });
 
+export const getSummaryWindow = query({
+    args: {
+        fromTimestamp: v.number(),
+        toTimestamp: v.number(),
+    },
+    handler: async (ctx, args) => {
+        const rows = await ctx.db
+            .query("resumes")
+            .withIndex("by_crawledAt", (q) =>
+                q.gte("crawledAt", args.fromTimestamp).lt("crawledAt", args.toTimestamp)
+            )
+            .collect();
+
+        const bySource = new Map<string, number>();
+        for (const row of rows) {
+            const sourceKey = row.source.trim() || "unknown";
+            bySource.set(sourceKey, (bySource.get(sourceKey) ?? 0) + 1);
+        }
+
+        return {
+            total: rows.length,
+            bySource: Array.from(bySource.entries())
+                .map(([key, count]) => ({ key, count }))
+                .sort((left, right) => {
+                    if (right.count !== left.count) {
+                        return right.count - left.count;
+                    }
+                    return left.key.localeCompare(right.key);
+                }),
+        };
+    },
+});
+
 export const listWithIngestDataPage = query({
     args: {
         limit: v.optional(v.number()),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,3 +11,4 @@ export * from "./resume-normalization.js";
 export * from "./resume-id.js";
 export * from "./system-debug-metadata.js";
 export * from "./keyword-query.js";
+export * from "./summaries.js";

--- a/packages/shared/src/summaries.ts
+++ b/packages/shared/src/summaries.ts
@@ -1,0 +1,51 @@
+export type SummaryPeriod = "daily";
+
+export type SummaryChannel = "email" | "wechat_work" | "feishu" | "telegram";
+
+export type SummaryWindow = {
+  startAt: string;
+  endAt: string;
+  timezone: string;
+};
+
+export type SummaryTotals = {
+  newResumes: number;
+  candidateStatusUpdates: number;
+  shortlistActions: number;
+  rejectActions: number;
+  contactActions: number;
+  collectionTasksCompleted: number;
+  collectionTasksFailed: number;
+};
+
+export type SummaryCountEntry = {
+  key: string;
+  label: string;
+  count: number;
+};
+
+export type SummaryReport = {
+  workspaceSlug: string;
+  period: SummaryPeriod;
+  generatedAt: string;
+  window: SummaryWindow;
+  totals: SummaryTotals;
+  breakdowns: {
+    resumesBySource: SummaryCountEntry[];
+    candidateStatusByValue: SummaryCountEntry[];
+    actionsByType: SummaryCountEntry[];
+    collectionTasksByStatus: SummaryCountEntry[];
+  };
+  notes: string[];
+};
+
+export type SummaryPreviewRequest = {
+  workspaceSlug?: string;
+  period: SummaryPeriod;
+  endAt?: string;
+};
+
+export type SummarySendRequest = SummaryPreviewRequest & {
+  channel: SummaryChannel;
+  dryRun?: boolean;
+};


### PR DESCRIPTION
## Summary
- add shared summary types and API summary preview services
- add workspace-aware action window aggregation plus Convex window summary queries
- expose /api/summaries/preview with focused tests and regenerate web API types

## Validation
- npx vitest run apps/api/src/services/summaries/summary-data-service.test.ts apps/api/src/routes/summaries.test.ts apps/api/src/services/action-storage.test.ts
- bun run --filter @trends/api typecheck
- make check