### PR TITLE
feat: add summary dispatch and Telegram bridge

### DIFF
--- a/apps/api/src/routes/summaries.test.ts
+++ b/apps/api/src/routes/summaries.test.ts
@@ -8,6 +8,7 @@ function createFixtureRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "summaries-route-"));
   fs.mkdirSync(path.join(root, "output"), { recursive: true });
   fs.mkdirSync(path.join(root, "config", "resume"), { recursive: true });
+  fs.mkdirSync(path.join(root, "config", "notifications"), { recursive: true });
   fs.writeFileSync(path.join(root, "pyproject.toml"), "", "utf8");
   fs.writeFileSync(
     path.join(root, "config", "resume", "skills.md"),
@@ -23,6 +24,33 @@ function createFixtureRoot(): string {
       "- aliases: FANUC, 发那科",
       "- tier: 1",
       "",
+    ].join("\n"),
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(root, "config", "notifications", "summary-daily.md"),
+    [
+      "---",
+      'subject: "Daily Ops Summary {{workspaceSlug}}"',
+      "---",
+      "",
+      "# Daily Ops Summary",
+      "",
+      "- Workspace: {{workspaceSlug}}",
+      "- Generated: {{generatedAt}}",
+      "",
+      "## Totals",
+      "- New resumes: {{totals.newResumes}}",
+      "- Candidate status updates: {{totals.candidateStatusUpdates}}",
+      "",
+      "{{#if breakdowns.actionsByType}}",
+      "## Candidate Actions",
+      "{{#each breakdowns.actionsByType}}",
+      "- {{this.label}}: {{this.count}}",
+      "{{/each}}",
+      "{{/if}}",
+      "",
+      "_Generated at {{timestamp}}_",
     ].join("\n"),
     "utf8"
   );
@@ -82,12 +110,14 @@ async function loadSummaryModules(root: string) {
   const { SessionManager } = await import("../services/session-manager");
   const { ActionStorage } = await import("../services/action-storage");
   const { ReviewPacketStorage } = await import("../services/review-packet-storage");
+  const { summaryTelegramBridge } = await import("../services/summaries/summary-telegram-bridge");
   const { resetResumeScreeningDb } = await import("../services/database");
   return {
     createApp,
     SessionManager,
     ActionStorage,
     ReviewPacketStorage,
+    summaryTelegramBridge,
     resetResumeScreeningDb,
   };
 }
@@ -217,5 +247,126 @@ describe("summary preview route", () => {
       "resume_tasks:getSummaryWindow",
     ]);
     expect(calls[1]?.args.workspaceSlug).toBe("hr");
+  });
+
+  it("supports summary run dry-runs without sending", async () => {
+    root = createFixtureRoot();
+    const {
+      createApp,
+      SessionManager,
+      ActionStorage,
+    } = await loadSummaryModules(root);
+
+    const sessionManager = new SessionManager(root);
+    const actionStorage = new ActionStorage(root);
+    const session = sessionManager.createSession({ workspaceSlug: "hr" });
+    actionStorage.saveAction({ sessionId: session.id, resumeId: "resume-1", actionType: "shortlist" });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      if (call.pathName === "resumes:getSummaryWindow") {
+        return convexSuccess({ total: 1, bySource: [{ key: "seek", count: 1 }] });
+      }
+      if (call.pathName === "candidate_status:list") {
+        return convexSuccess([]);
+      }
+      if (call.pathName === "resume_tasks:getSummaryWindow") {
+        return convexSuccess({ total: 0, byStatus: [] });
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/summaries/run", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        period: "daily",
+        channel: "wechat_work",
+        dryRun: true,
+        endAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      success: boolean;
+      dryRun: boolean;
+      templateId: string;
+      subject?: string;
+      content: string;
+      delivery?: unknown;
+    };
+    expect(payload.success).toBe(true);
+    expect(payload.dryRun).toBe(true);
+    expect(payload.templateId).toBe("summary-daily");
+    expect(payload.subject).toBe("Daily Ops Summary hr");
+    expect(payload.content).toContain("# Daily Ops Summary");
+    expect(payload.delivery).toBeUndefined();
+  });
+
+  it("routes telegram summary sends through the bridge", async () => {
+    root = createFixtureRoot();
+    const {
+      createApp,
+      SessionManager,
+      ActionStorage,
+      summaryTelegramBridge,
+    } = await loadSummaryModules(root);
+
+    const sessionManager = new SessionManager(root);
+    const actionStorage = new ActionStorage(root);
+    const session = sessionManager.createSession({ workspaceSlug: "hr" });
+    actionStorage.saveAction({ sessionId: session.id, resumeId: "resume-1", actionType: "contact" });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      if (call.pathName === "resumes:getSummaryWindow") {
+        return convexSuccess({ total: 2, bySource: [{ key: "job5156", count: 2 }] });
+      }
+      if (call.pathName === "candidate_status:list") {
+        return convexSuccess([]);
+      }
+      if (call.pathName === "resume_tasks:getSummaryWindow") {
+        return convexSuccess({ total: 1, byStatus: [{ key: "completed", count: 1 }] });
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const sendSpy = vi.spyOn(summaryTelegramBridge, "send").mockResolvedValue({
+      ok: true,
+      accountsSent: 1,
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/summaries/run", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        period: "daily",
+        channel: "telegram",
+        endAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      success: boolean;
+      channel: string;
+      dryRun: boolean;
+      delivery: { ok: boolean; accountsSent: number };
+    };
+    expect(payload.success).toBe(true);
+    expect(payload.channel).toBe("telegram");
+    expect(payload.dryRun).toBe(false);
+    expect(payload.delivery).toEqual({ ok: true, accountsSent: 1 });
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0]?.[0].content).toContain("# Daily Ops Summary");
   });
 });

--- a/apps/api/src/routes/summaries.ts
+++ b/apps/api/src/routes/summaries.ts
@@ -1,6 +1,7 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
 import { SummaryDataService } from "../services/summaries/summary-data-service.js";
+import { summaryDispatcher } from "../services/summaries/summary-dispatcher.js";
 import { SummaryRenderer } from "../services/summaries/summary-renderer.js";
 
 const app = new OpenAPIHono();
@@ -50,6 +51,30 @@ const SummaryPreviewResponseSchema = z.object({
   success: z.literal(true),
   report: SummaryReportSchema,
   markdown: z.string(),
+});
+
+const SummaryChannelSchema = z.enum(["email", "wechat_work", "feishu", "telegram"]);
+
+const SummaryRunRequestSchema = SummaryPreviewRequestSchema.extend({
+  channel: SummaryChannelSchema,
+  dryRun: z.boolean().default(false),
+  templateId: z.string().min(1).optional(),
+  to: z.string().email().optional(),
+  subject: z.string().min(1).optional(),
+  webhookUrl: z.string().url().optional(),
+  botToken: z.string().min(1).optional(),
+  chatId: z.string().min(1).optional(),
+});
+
+const SummaryRunResponseSchema = z.object({
+  success: z.literal(true),
+  channel: SummaryChannelSchema,
+  dryRun: z.boolean(),
+  templateId: z.string(),
+  subject: z.string().optional(),
+  report: SummaryReportSchema,
+  content: z.string(),
+  delivery: z.object({}).catchall(z.unknown()).optional(),
 });
 
 const ErrorSchema = z.object({
@@ -108,6 +133,79 @@ app.openapi(previewRoute, async (c) => {
     }, 200);
   } catch (error) {
     console.error("Failed to preview summary:", error);
+    return c.json({
+      success: false as const,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }, 500);
+  }
+});
+
+const runRoute = createRoute({
+  method: "post",
+  path: "/run",
+  tags: ["Summaries"],
+  summary: "Render and optionally send a workspace daily summary",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: SummaryRunRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Summary run result",
+      content: {
+        "application/json": {
+          schema: SummaryRunResponseSchema,
+        },
+      },
+    },
+    500: {
+      description: "Summary run error",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(runRoute, async (c) => {
+  try {
+    const body = c.req.valid("json");
+    const workspaceSlug = body.workspaceSlug?.trim() || c.var.workspaceSlug;
+    const report = await summaryDataService.buildSummaryReport({
+      workspaceSlug,
+      period: body.period,
+      endAt: body.endAt,
+    });
+    const dispatched = await summaryDispatcher.dispatch(report, {
+      channel: body.channel,
+      dryRun: body.dryRun,
+      templateId: body.templateId,
+      to: body.to,
+      subject: body.subject,
+      webhookUrl: body.webhookUrl,
+      botToken: body.botToken,
+      chatId: body.chatId,
+    });
+
+    return c.json({
+      success: true as const,
+      channel: dispatched.channel,
+      dryRun: dispatched.dryRun,
+      templateId: dispatched.templateId,
+      subject: dispatched.subject,
+      report,
+      content: dispatched.content,
+      delivery: dispatched.delivery,
+    }, 200);
+  } catch (error) {
+    console.error("Failed to run summary:", error);
     return c.json({
       success: false as const,
       error: error instanceof Error ? error.message : "Unknown error",

--- a/apps/api/src/services/summaries/summary-dispatcher.ts
+++ b/apps/api/src/services/summaries/summary-dispatcher.ts
@@ -1,0 +1,163 @@
+import type { SummaryChannel, SummaryReport } from "@trends/shared";
+
+import { notificationService } from "../notification-service.js";
+import { notificationTemplateService } from "../notification-template-service.js";
+import { summaryTelegramBridge } from "./summary-telegram-bridge.js";
+
+type SummaryDispatcherDependencies = {
+  notificationService?: Pick<typeof notificationService, "sendEmail" | "sendWechatWorkMarkdown" | "sendFeishuText">;
+  notificationTemplateService?: Pick<typeof notificationTemplateService, "render">;
+  telegramBridge?: Pick<typeof summaryTelegramBridge, "send">;
+};
+
+export type SummaryDispatchRequest = {
+  channel: SummaryChannel;
+  dryRun?: boolean;
+  templateId?: string;
+  to?: string;
+  subject?: string;
+  webhookUrl?: string;
+  botToken?: string;
+  chatId?: string;
+};
+
+export type SummaryDispatchPreview = {
+  templateId: string;
+  subject?: string;
+  content: string;
+};
+
+export type SummaryDispatchResult = SummaryDispatchPreview & {
+  channel: SummaryChannel;
+  dryRun: boolean;
+  delivery?: Record<string, unknown>;
+};
+
+const DEFAULT_TEMPLATE_ID = "summary-daily";
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function renderMarkdownAsHtml(markdown: string): string {
+  return `<pre style="white-space: pre-wrap; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;">${escapeHtml(markdown)}</pre>`;
+}
+
+function getMessageId(info: unknown): string | undefined {
+  if (typeof info !== "object" || info === null || !("messageId" in info)) {
+    return undefined;
+  }
+  return typeof info.messageId === "string" ? info.messageId : undefined;
+}
+
+function buildTemplateData(report: SummaryReport): Record<string, unknown> {
+  return {
+    ...report,
+    timestamp: report.generatedAt,
+  };
+}
+
+export class SummaryDispatcher {
+  private readonly notifications: Pick<typeof notificationService, "sendEmail" | "sendWechatWorkMarkdown" | "sendFeishuText">;
+  private readonly templates: Pick<typeof notificationTemplateService, "render">;
+  private readonly telegramBridge: Pick<typeof summaryTelegramBridge, "send">;
+
+  constructor(dependencies: SummaryDispatcherDependencies = {}) {
+    this.notifications = dependencies.notificationService ?? notificationService;
+    this.templates = dependencies.notificationTemplateService ?? notificationTemplateService;
+    this.telegramBridge = dependencies.telegramBridge ?? summaryTelegramBridge;
+  }
+
+  buildPreview(report: SummaryReport, request: Pick<SummaryDispatchRequest, "templateId">): SummaryDispatchPreview {
+    const templateId = request.templateId?.trim() || DEFAULT_TEMPLATE_ID;
+    const rendered = this.templates.render(templateId, buildTemplateData(report));
+
+    return {
+      templateId,
+      subject: rendered.subject,
+      content: rendered.markdown,
+    };
+  }
+
+  async dispatch(report: SummaryReport, request: SummaryDispatchRequest): Promise<SummaryDispatchResult> {
+    const preview = this.buildPreview(report, request);
+    const dryRun = request.dryRun === true;
+
+    if (dryRun) {
+      return {
+        ...preview,
+        channel: request.channel,
+        dryRun,
+      };
+    }
+
+    if (request.channel === "email") {
+      if (!request.to) {
+        throw new Error("Email recipient is required");
+      }
+
+      const subject = request.subject?.trim() || preview.subject || `Daily Ops Summary (${report.workspaceSlug})`;
+      const delivery = await this.notifications.sendEmail({
+        to: request.to,
+        subject,
+        text: preview.content,
+        html: renderMarkdownAsHtml(preview.content),
+      });
+
+      return {
+        ...preview,
+        channel: request.channel,
+        dryRun,
+        delivery: {
+          messageId: getMessageId(delivery),
+        },
+      };
+    }
+
+    if (request.channel === "wechat_work") {
+      const delivery = await this.notifications.sendWechatWorkMarkdown({
+        webhookUrl: request.webhookUrl,
+        content: preview.content,
+      });
+      return {
+        ...preview,
+        channel: request.channel,
+        dryRun,
+        delivery: delivery as Record<string, unknown>,
+      };
+    }
+
+    if (request.channel === "feishu") {
+      const delivery = await this.notifications.sendFeishuText({
+        webhookUrl: request.webhookUrl,
+        content: preview.content,
+      });
+      return {
+        ...preview,
+        channel: request.channel,
+        dryRun,
+        delivery: delivery as Record<string, unknown>,
+      };
+    }
+
+    const delivery = await this.telegramBridge.send({
+      content: preview.content,
+      botToken: request.botToken,
+      chatId: request.chatId,
+    });
+
+    return {
+      ...preview,
+      channel: request.channel,
+      dryRun,
+      delivery,
+    };
+  }
+}
+
+export const summaryDispatcher = new SummaryDispatcher();

--- a/apps/api/src/services/summaries/summary-telegram-bridge.ts
+++ b/apps/api/src/services/summaries/summary-telegram-bridge.ts
@@ -1,0 +1,76 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+import { config } from "../config.js";
+
+export type SummaryTelegramBridgeRequest = {
+  content: string;
+  botToken?: string;
+  chatId?: string;
+};
+
+export type SummaryTelegramBridgeResult = {
+  ok: boolean;
+  accountsSent: number;
+};
+
+type SummaryTelegramBridgeDependencies = {
+  runner?: (payload: SummaryTelegramBridgeRequest) => Promise<SummaryTelegramBridgeResult>;
+};
+
+export class SummaryTelegramBridge {
+  private readonly projectRoot: string;
+  private readonly runner?: (payload: SummaryTelegramBridgeRequest) => Promise<SummaryTelegramBridgeResult>;
+
+  constructor(projectRoot = config.projectRoot, dependencies: SummaryTelegramBridgeDependencies = {}) {
+    this.projectRoot = projectRoot;
+    this.runner = dependencies.runner;
+  }
+
+  async send(payload: SummaryTelegramBridgeRequest): Promise<SummaryTelegramBridgeResult> {
+    if (this.runner) {
+      return await this.runner(payload);
+    }
+
+    const scriptPath = path.join(this.projectRoot, "scripts", "summaries", "send_telegram_summary.py");
+
+    return await new Promise<SummaryTelegramBridgeResult>((resolve, reject) => {
+      const child = spawn("uv", ["run", "python", scriptPath], {
+        cwd: this.projectRoot,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+      });
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+      });
+      child.on("error", (error) => {
+        reject(new Error(`Failed to start Telegram summary bridge: ${error.message}`));
+      });
+      child.on("close", (code) => {
+        if (code !== 0) {
+          reject(new Error(stderr.trim() || `Telegram summary bridge failed with exit code ${code}`));
+          return;
+        }
+
+        try {
+          resolve(JSON.parse(stdout) as SummaryTelegramBridgeResult);
+        } catch (error) {
+          reject(new Error(`Invalid Telegram summary bridge output: ${String(error)}`));
+        }
+      });
+
+      child.stdin.write(JSON.stringify(payload));
+      child.stdin.end();
+    });
+  }
+}
+
+export const summaryTelegramBridge = new SummaryTelegramBridge();

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4515,6 +4515,135 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/summaries/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Render and optionally send a workspace daily summary */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        workspaceSlug?: string;
+                        /**
+                         * @default daily
+                         * @enum {string}
+                         */
+                        period?: "daily";
+                        /** Format: date-time */
+                        endAt?: string;
+                        /** @enum {string} */
+                        channel: "email" | "wechat_work" | "feishu" | "telegram";
+                        /** @default false */
+                        dryRun?: boolean;
+                        templateId?: string;
+                        /** Format: email */
+                        to?: string;
+                        subject?: string;
+                        /** Format: uri */
+                        webhookUrl?: string;
+                        botToken?: string;
+                        chatId?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Summary run result */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            /** @enum {string} */
+                            channel: "email" | "wechat_work" | "feishu" | "telegram";
+                            dryRun: boolean;
+                            templateId: string;
+                            subject?: string;
+                            report: {
+                                workspaceSlug: string;
+                                /** @enum {string} */
+                                period: "daily";
+                                generatedAt: string;
+                                window: {
+                                    startAt: string;
+                                    endAt: string;
+                                    timezone: string;
+                                };
+                                totals: {
+                                    newResumes: number;
+                                    candidateStatusUpdates: number;
+                                    shortlistActions: number;
+                                    rejectActions: number;
+                                    contactActions: number;
+                                    collectionTasksCompleted: number;
+                                    collectionTasksFailed: number;
+                                };
+                                breakdowns: {
+                                    resumesBySource: {
+                                        key: string;
+                                        label: string;
+                                        count: number;
+                                    }[];
+                                    candidateStatusByValue: {
+                                        key: string;
+                                        label: string;
+                                        count: number;
+                                    }[];
+                                    actionsByType: {
+                                        key: string;
+                                        label: string;
+                                        count: number;
+                                    }[];
+                                    collectionTasksByStatus: {
+                                        key: string;
+                                        label: string;
+                                        count: number;
+                                    }[];
+                                };
+                                notes: string[];
+                            };
+                            content: string;
+                            delivery?: {
+                                [key: string]: unknown;
+                            };
+                        };
+                    };
+                };
+                /** @description Summary run error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/config/notifications/summary-daily.md
+++ b/config/notifications/summary-daily.md
@@ -1,0 +1,57 @@
+---
+subject: "Daily Ops Summary {{workspaceSlug}}"
+---
+
+# Daily Ops Summary
+
+- Workspace: {{workspaceSlug}}
+- Generated: {{generatedAt}}
+- Window Start: {{window.startAt}}
+- Window End: {{window.endAt}}
+- Timezone: {{window.timezone}}
+
+## Totals
+- New resumes: {{totals.newResumes}}
+- Candidate status updates: {{totals.candidateStatusUpdates}}
+- Shortlist actions: {{totals.shortlistActions}}
+- Reject actions: {{totals.rejectActions}}
+- Contact actions: {{totals.contactActions}}
+- Collection tasks completed: {{totals.collectionTasksCompleted}}
+- Collection tasks failed: {{totals.collectionTasksFailed}}
+
+{{#if breakdowns.resumesBySource}}
+## Resume Sources
+{{#each breakdowns.resumesBySource}}
+- {{this.label}}: {{this.count}}
+{{/each}}
+{{/if}}
+
+{{#if breakdowns.candidateStatusByValue}}
+## Candidate Status Updates
+{{#each breakdowns.candidateStatusByValue}}
+- {{this.label}}: {{this.count}}
+{{/each}}
+{{/if}}
+
+{{#if breakdowns.actionsByType}}
+## Candidate Actions
+{{#each breakdowns.actionsByType}}
+- {{this.label}}: {{this.count}}
+{{/each}}
+{{/if}}
+
+{{#if breakdowns.collectionTasksByStatus}}
+## Collection Tasks
+{{#each breakdowns.collectionTasksByStatus}}
+- {{this.label}}: {{this.count}}
+{{/each}}
+{{/if}}
+
+{{#if notes}}
+## Notes
+{{#each notes}}
+- {{this}}
+{{/each}}
+{{/if}}
+
+_Generated at {{timestamp}}_

--- a/packages/shared/src/summaries.ts
+++ b/packages/shared/src/summaries.ts
@@ -48,4 +48,10 @@ export type SummaryPreviewRequest = {
 export type SummarySendRequest = SummaryPreviewRequest & {
   channel: SummaryChannel;
   dryRun?: boolean;
+  templateId?: string;
+  to?: string;
+  subject?: string;
+  webhookUrl?: string;
+  botToken?: string;
+  chatId?: string;
 };

--- a/scripts/summaries/send_telegram_summary.py
+++ b/scripts/summaries/send_telegram_summary.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# coding=utf-8
+
+import contextlib
+import html
+import json
+import sys
+from typing import List
+
+from trendradar.core import load_config
+from trendradar.core.config import (
+    limit_accounts,
+    parse_multi_account_config,
+    validate_paired_configs,
+)
+from trendradar.notification.batch import truncate_to_bytes
+from trendradar.notification.senders import send_to_telegram
+
+
+def split_rendered_content(content: str, max_bytes: int) -> List[str]:
+    normalized = content.replace("\r\n", "\n").strip()
+    if not normalized:
+      return [""]
+    if len(normalized.encode("utf-8")) <= max_bytes:
+      return [normalized]
+
+    batches: List[str] = []
+    current = ""
+    for line in normalized.split("\n"):
+        candidate = f"{current}\n{line}".strip("\n") if current else line
+        if len(candidate.encode("utf-8")) <= max_bytes:
+            current = candidate
+            continue
+
+        if current:
+            batches.append(current)
+            current = ""
+
+        remaining = line
+        while remaining and len(remaining.encode("utf-8")) > max_bytes:
+            chunk = truncate_to_bytes(remaining, max_bytes)
+            if not chunk:
+                break
+            batches.append(chunk)
+            remaining = remaining[len(chunk):]
+        current = remaining
+
+    if current:
+        batches.append(current)
+
+    return batches or [normalized]
+
+
+def build_splitter(content: str):
+    escaped_content = html.escape(content)
+
+    def split_content_func(_report_data, _format_type, _update_info=None, max_bytes=4000, **_kwargs):
+        return split_rendered_content(escaped_content, max_bytes)
+
+    return split_content_func
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    content = str(payload.get("content") or "").strip()
+    if not content:
+        raise ValueError("content is required")
+
+    config = load_config()
+    if payload.get("botToken"):
+        config["TELEGRAM_BOT_TOKEN"] = str(payload["botToken"])
+    if payload.get("chatId"):
+        config["TELEGRAM_CHAT_ID"] = str(payload["chatId"])
+
+    tokens = parse_multi_account_config(config.get("TELEGRAM_BOT_TOKEN", ""))
+    chat_ids = parse_multi_account_config(config.get("TELEGRAM_CHAT_ID", ""))
+    valid, count = validate_paired_configs(
+        {"bot_token": tokens, "chat_id": chat_ids},
+        "Telegram",
+        required_keys=["bot_token", "chat_id"],
+    )
+    if not valid or count <= 0:
+        raise ValueError("Telegram configuration is missing bot token or chat id")
+
+    max_accounts = config.get("MAX_ACCOUNTS_PER_CHANNEL", 3)
+    tokens = limit_accounts(tokens, max_accounts, "Telegram")
+    chat_ids = chat_ids[: len(tokens)]
+    split_content_func = build_splitter(content)
+
+    sent = 0
+    for index, token in enumerate(tokens):
+        chat_id = chat_ids[index] if index < len(chat_ids) else ""
+        if not token or not chat_id:
+            continue
+        with contextlib.redirect_stdout(sys.stderr):
+            ok = send_to_telegram(
+                bot_token=token,
+                chat_id=chat_id,
+                report_data={},
+                report_type="Resume Ops Summary",
+                split_content_func=split_content_func,
+            )
+        if ok:
+            sent += 1
+
+    if sent <= 0:
+        raise RuntimeError("Telegram summary delivery failed")
+
+    json.dump({"ok": True, "accountsSent": sent}, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        print(str(error), file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- add summary dispatcher service and /api/summaries/run with dry-run support
- add a thin Python Telegram bridge that reuses the legacy TrendRadar sender path
- add the summary-daily notification template, focused send tests, and regenerated web API types

## Validation
- npx vitest run apps/api/src/routes/summaries.test.ts apps/api/src/services/summaries/summary-data-service.test.ts apps/api/src/services/action-storage.test.ts
- bun run --filter @trends/api typecheck
- python3 -m py_compile scripts/summaries/send_telegram_summary.py
- make check