### PR TITLE
feat(worker): add workspace summary trigger

### DIFF
--- a/apps/api/src/routes/worker.test.ts
+++ b/apps/api/src/routes/worker.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createApp } from "../app";
+import { config } from "../services/config";
+
+describe("worker proxy routes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("proxies summary trigger requests to the worker API", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          mode: "summary",
+          started_at: "2026-03-26T18:00:00+00:00",
+          finished_at: "2026-03-26T18:00:01+00:00",
+          message: "Summary task completed for hr",
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      )
+    );
+
+    const app = createApp();
+    const body = JSON.stringify({
+      workspaceSlug: "hr",
+      channel: "telegram",
+      dryRun: true,
+      templateId: "summary-daily",
+    });
+
+    const response = await app.request("/api/worker/summary", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      success: true,
+      mode: "summary",
+      message: "Summary task completed for hr",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(`${config.workerUrl}/worker/summary`);
+    expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body,
+    });
+  });
+});

--- a/apps/api/src/routes/worker.ts
+++ b/apps/api/src/routes/worker.ts
@@ -44,4 +44,21 @@ app.post("/run", async (c) => {
     }
 });
 
+app.post("/summary", async (c) => {
+    const body = await c.req.text();
+    const contentType = c.req.header("Content-Type") || "application/json";
+    try {
+        return await proxyToWorker("/worker/summary", {
+            method: "POST",
+            headers: {
+                "Content-Type": contentType,
+            },
+            body,
+        });
+    } catch (error) {
+        console.error("Failed to proxy summary trigger:", error);
+        return c.json({ error: "Failed to connect to worker API" }, 503);
+    }
+});
+
 export default app;

--- a/apps/worker/api.py
+++ b/apps/worker/api.py
@@ -37,7 +37,7 @@ from mcp_server.services.data_service import DataService
 from mcp_server.utils.errors import DataNotFoundError
 from apps.worker.timezone import bootstrap_worker_timezone
 from apps.worker.status_store import resolve_worker_status_path
-from apps.worker.tasks import run_crawl_analyze
+from apps.worker.tasks import run_crawl_analyze, run_workspace_summary
 from trendradar.utils.time import format_iso_offset_time
 
 WORKER_TIMEZONE = bootstrap_worker_timezone()
@@ -180,6 +180,21 @@ class WorkerTriggerResponse(BaseModel):
     message: str
 
 
+class WorkerSummaryTriggerRequest(BaseModel):
+    """Manual worker summary trigger request."""
+
+    workspaceSlug: str = Field(default="dev", min_length=1)
+    channel: str = Field(default="telegram", min_length=1)
+    dryRun: bool = False
+    templateId: Optional[str] = None
+    endAt: Optional[str] = None
+    to: Optional[str] = None
+    subject: Optional[str] = None
+    webhookUrl: Optional[str] = None
+    botToken: Optional[str] = None
+    chatId: Optional[str] = None
+
+
 # ============================================
 # Endpoints
 # ============================================
@@ -261,6 +276,38 @@ async def trigger_worker_run(
         started_at=started_at,
         finished_at=finished_at,
         message="Worker run completed",
+    )
+
+
+@router.post("/worker/summary", response_model=WorkerTriggerResponse, tags=["System"])
+async def trigger_worker_summary(request: WorkerSummaryTriggerRequest):
+    """
+    Trigger a one-time workspace summary run immediately.
+    """
+    started_at = format_iso_offset_time(timezone=WORKER_TIMEZONE)
+    success = await asyncio.to_thread(
+        run_workspace_summary,
+        workspace_slug=request.workspaceSlug,
+        channel=request.channel,
+        dry_run=request.dryRun,
+        template_id=request.templateId,
+        end_at=request.endAt,
+        to=request.to,
+        subject=request.subject,
+        webhook_url=request.webhookUrl,
+        bot_token=request.botToken,
+        chat_id=request.chatId,
+    )
+    finished_at = format_iso_offset_time(timezone=WORKER_TIMEZONE)
+
+    if not success:
+        raise HTTPException(status_code=500, detail="Summary task failed")
+
+    return WorkerTriggerResponse(
+        mode="summary",
+        started_at=started_at,
+        finished_at=finished_at,
+        message=f"Summary task completed for {request.workspaceSlug}",
     )
 
 

--- a/apps/worker/scheduler.py
+++ b/apps/worker/scheduler.py
@@ -31,6 +31,7 @@ from apps.worker.tasks import (
     health_check,
     run_skills_version_check,
     run_scoring_auto_tune,
+    run_workspace_summary,
 )
 from apps.worker.timezone import bootstrap_worker_timezone, resolve_worker_timezone
 from apps.worker.profile_loader import ProfileLoader
@@ -347,6 +348,38 @@ class WorkerScheduler:
         )
         logger.info("Scheduled scoring auto-tune job with cron: %s (dry_run=%s)", cron_expression, dry_run)
 
+    def add_workspace_summary_job(self) -> None:
+        """Schedule an optional workspace summary trigger."""
+        cron_expression = os.environ.get("WORKER_SUMMARY_CRON", "").strip()
+        if not cron_expression:
+            logger.info("Workspace summary job disabled; set WORKER_SUMMARY_CRON to enable it")
+            return
+
+        workspace_slug = os.environ.get("WORKER_SUMMARY_WORKSPACE", "").strip() or "dev"
+        channel = os.environ.get("WORKER_SUMMARY_CHANNEL", "").strip() or "telegram"
+        dry_run_env = os.environ.get("WORKER_SUMMARY_DRY_RUN", "").strip().lower()
+        dry_run = dry_run_env in {"1", "true", "yes", "on"}
+        template_id = os.environ.get("WORKER_SUMMARY_TEMPLATE_ID", "").strip() or None
+        end_at = os.environ.get("WORKER_SUMMARY_END_AT", "").strip() or None
+
+        self.add_custom_job(
+            func=run_workspace_summary,
+            job_id="workspace_summary",
+            cron_expression=cron_expression,
+            workspace_slug=workspace_slug,
+            channel=channel,
+            dry_run=dry_run,
+            template_id=template_id,
+            end_at=end_at,
+        )
+        logger.info(
+            "Scheduled workspace summary job with cron: %s (workspace=%s, channel=%s, dry_run=%s)",
+            cron_expression,
+            workspace_slug,
+            channel,
+            dry_run,
+        )
+
     def start(self) -> None:
         """Start the scheduler."""
         logger.info("Starting Worker Scheduler")
@@ -359,6 +392,7 @@ class WorkerScheduler:
         self.load_profile_jobs()
         self.add_skills_version_check_job()
         self.add_scoring_auto_tune_job()
+        self.add_workspace_summary_job()
 
         # Run immediately if requested
         if self.run_immediately:

--- a/apps/worker/tasks.py
+++ b/apps/worker/tasks.py
@@ -291,3 +291,72 @@ def run_scoring_auto_tune(
         logger.error("[Task] scoring auto-tune failed: %s", error)
         logger.debug(traceback.format_exc())
         return False
+
+
+def run_workspace_summary(
+    api_base_url: Optional[str] = None,
+    workspace_slug: str = "dev",
+    channel: str = "telegram",
+    dry_run: bool = False,
+    template_id: Optional[str] = None,
+    end_at: Optional[str] = None,
+    to: Optional[str] = None,
+    subject: Optional[str] = None,
+    webhook_url: Optional[str] = None,
+    bot_token: Optional[str] = None,
+    chat_id: Optional[str] = None,
+) -> bool:
+    base_url = _worker_api_base_url(api_base_url)
+    normalized_workspace = workspace_slug.strip() or "dev"
+    normalized_channel = channel.strip() or "telegram"
+    logger.info(
+        "[Task] Starting workspace summary (workspace=%s, channel=%s, dry_run=%s)",
+        normalized_workspace,
+        normalized_channel,
+        dry_run,
+    )
+
+    request_body: Dict[str, Any] = {
+        "workspaceSlug": normalized_workspace,
+        "period": "daily",
+        "channel": normalized_channel,
+        "dryRun": bool(dry_run),
+    }
+
+    if template_id and template_id.strip():
+        request_body["templateId"] = template_id.strip()
+    if end_at and end_at.strip():
+        request_body["endAt"] = end_at.strip()
+    if to and to.strip():
+        request_body["to"] = to.strip()
+    if subject and subject.strip():
+        request_body["subject"] = subject.strip()
+    if webhook_url and webhook_url.strip():
+        request_body["webhookUrl"] = webhook_url.strip()
+    if bot_token and bot_token.strip():
+        request_body["botToken"] = bot_token.strip()
+    if chat_id and chat_id.strip():
+        request_body["chatId"] = chat_id.strip()
+
+    try:
+        response = _request_json(
+            f"{base_url}/api/summaries/run",
+            method="POST",
+            body=request_body,
+        )
+
+        if response.get("success") is not True:
+            logger.error("[Task] workspace summary request failed: %s", response)
+            return False
+
+        logger.info(
+            "[Task] workspace summary completed (channel=%s, dry_run=%s, template=%s)",
+            response.get("channel"),
+            response.get("dryRun"),
+            response.get("templateId"),
+        )
+        return True
+    except Exception as error:
+        logger.error("[Task] workspace summary failed: %s", error)
+        logger.debug(traceback.format_exc())
+        return False

--- a/tests/test_resume_tasks.py
+++ b/tests/test_resume_tasks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from apps.worker import resume_tasks
+from apps.worker import resume_tasks, scheduler as worker_scheduler, tasks
 
 
 def _make_profile(keywords: Any, filters: Any = None) -> dict[str, Any]:
@@ -113,3 +113,96 @@ def test_run_resume_crawl_task_passes_age_range_filters(monkeypatch) -> None:
     assert ok is True
     assert captured["args"]["minAge"] == 25
     assert captured["args"]["maxAge"] == 40
+
+
+def test_run_workspace_summary_posts_summary_request(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_request_json(url: str, method: str = "GET", body: dict[str, Any] | None = None) -> dict[str, Any]:
+        captured["url"] = url
+        captured["method"] = method
+        captured["body"] = body
+        return {
+            "success": True,
+            "channel": "telegram",
+            "dryRun": True,
+            "templateId": "summary-daily",
+        }
+
+    monkeypatch.setattr(tasks, "_request_json", fake_request_json)
+
+    ok = tasks.run_workspace_summary(
+        api_base_url="http://localhost:3000/",
+        workspace_slug="hr",
+        channel="telegram",
+        dry_run=True,
+        template_id="summary-daily",
+        end_at="2026-03-26T12:00:00Z",
+    )
+
+    assert ok is True
+    assert captured["url"] == "http://localhost:3000/api/summaries/run"
+    assert captured["method"] == "POST"
+    assert captured["body"] == {
+        "workspaceSlug": "hr",
+        "period": "daily",
+        "channel": "telegram",
+        "dryRun": True,
+        "templateId": "summary-daily",
+        "endAt": "2026-03-26T12:00:00Z",
+    }
+
+
+def test_run_workspace_summary_returns_false_when_api_fails(monkeypatch) -> None:
+    monkeypatch.setattr(
+        tasks,
+        "_request_json",
+        lambda *_args, **_kwargs: {"success": False, "error": "boom"},
+    )
+
+    ok = tasks.run_workspace_summary(api_base_url="http://localhost:3000", workspace_slug="dev")
+
+    assert ok is False
+
+
+def test_add_workspace_summary_job_requires_cron(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    monkeypatch.delenv("WORKER_SUMMARY_CRON", raising=False)
+    scheduler = worker_scheduler.WorkerScheduler(timezone="UTC")
+
+    def fake_add_custom_job(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(scheduler, "add_custom_job", fake_add_custom_job)
+
+    scheduler.add_workspace_summary_job()
+
+    assert calls == []
+
+
+def test_add_workspace_summary_job_uses_env_config(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    monkeypatch.setenv("WORKER_SUMMARY_CRON", "15 18 * * 1-5")
+    monkeypatch.setenv("WORKER_SUMMARY_WORKSPACE", "hr")
+    monkeypatch.setenv("WORKER_SUMMARY_CHANNEL", "telegram")
+    monkeypatch.setenv("WORKER_SUMMARY_DRY_RUN", "true")
+    monkeypatch.setenv("WORKER_SUMMARY_TEMPLATE_ID", "summary-daily")
+    scheduler = worker_scheduler.WorkerScheduler(timezone="UTC")
+
+    def fake_add_custom_job(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(scheduler, "add_custom_job", fake_add_custom_job)
+
+    scheduler.add_workspace_summary_job()
+
+    assert len(calls) == 1
+    assert calls[0]["func"] is tasks.run_workspace_summary
+    assert calls[0]["job_id"] == "workspace_summary"
+    assert calls[0]["cron_expression"] == "15 18 * * 1-5"
+    assert calls[0]["workspace_slug"] == "hr"
+    assert calls[0]["channel"] == "telegram"
+    assert calls[0]["dry_run"] is True
+    assert calls[0]["template_id"] == "summary-daily"


### PR DESCRIPTION
## Summary
- add a worker task and manual worker endpoint for workspace summary runs
- add an env-gated scheduler job for summary delivery plus an API proxy route
- cover the worker task and proxy path with focused Python and Vitest tests

## Testing
- uv run pytest tests/test_resume_tasks.py
- npx vitest run apps/api/src/routes/worker.test.ts apps/api/src/routes/summaries.test.ts
- bun run --filter @trends/api typecheck
- npm --workspace @trends/web run gen:api
- make check