### PR TITLE
fix(worker): align profile schedule runtime

### DIFF
--- a/apps/worker/profile_loader.py
+++ b/apps/worker/profile_loader.py
@@ -16,8 +16,8 @@ class ProfileLoader:
         Load all enabled search profiles from the config directory.
         Returns a list of profile dictionaries containing:
         - id: Profile ID
-        - schedule: Cron expression
-        - limit: Max resumes to collect
+        - schedule: Active runtime schedule metadata
+        - limit: Max resumes to collect (legacy compatibility alias)
         - location: Target location
         - keywords: Search keywords
         """
@@ -41,12 +41,25 @@ class ProfileLoader:
                 if not cron:
                     logger.warning(f"Profile {filepath} enabled but missing cron expression")
                     continue
+
+                max_candidates = schedule.get("maxCandidates")
+                if max_candidates is None:
+                    max_candidates = schedule.get("limit", 50)
+
+                runtime_schedule = {
+                    "enabled": True,
+                    "cron": cron,
+                    "timezone": schedule.get("timezone"),
+                    "maxCandidates": max_candidates,
+                    "notifyOnlyOnNew": schedule.get("notifyOnlyOnNew"),
+                }
                     
                 profile = {
                     "id": data.get("id"),
                     "name": data.get("name"),
                     "cron": cron,
-                    "limit": schedule.get("limit", 50),
+                    "limit": max_candidates,
+                    "schedule": runtime_schedule,
                     "location": data.get("location"),
                     "keywords": data.get("keywords", []),
                     "filters": data.get("filters"),

--- a/config/search-profiles/README.md
+++ b/config/search-profiles/README.md
@@ -5,8 +5,24 @@ This directory contains pre-configured search profiles that combine:
 - Keywords
 - Job Description reference
 - Filter settings
-- Automation settings (scheduling, notifications)
+- Automation settings (currently crawl scheduling only)
 - Source routing and optional AI review behavior
+
+## Runtime Status
+
+The current worker runtime actively uses these profile fields:
+- `location`
+- `keywords`
+- `requiredKeywords`
+- `filters`
+- `jobDescription`
+- `schedule.enabled`
+- `schedule.cron`
+- `schedule.timezone`
+- `schedule.maxCandidates`
+
+The current worker runtime does **not** yet execute profile-level notification or summary triggers from YAML.
+Keep summary delivery on the dedicated summary pipeline and env-driven worker summary job for now.
 
 ## Usage
 
@@ -51,7 +67,8 @@ schedule:
   cron: "0 9 * * 1-5"  # Mon-Fri 9:00 AM
   timezone: Asia/Shanghai
 
-# Notifications
+# Notifications metadata
+# Note: this block is not executed by the current worker runtime.
 notifications:
   enabled: true
   channels:
@@ -60,9 +77,6 @@ notifications:
     - type: email
       recipients:
         - hr@company.com
-  triggers:
-    - event: new_high_match    # Score >= 80
-    - event: daily_summary
 
 # Optional AI review settings
 # Keep deterministic scoring as the default engine; use AI only on shortlisted resumes.
@@ -97,4 +111,4 @@ curl -X POST http://localhost:3000/api/search-profiles/quick-start \
 
 ## Files
 
-- `dongguan-lathe-sales.yaml`: example routing preset with deterministic filters, notifications, and an optional review lane
+- `dongguan-lathe-sales.yaml`: example routing preset with active crawl scheduling plus optional metadata blocks that are not all executed by the worker today

--- a/config/search-profiles/dongguan-lathe-sales.yaml
+++ b/config/search-profiles/dongguan-lathe-sales.yaml
@@ -72,7 +72,11 @@ sources:
     priority: 2
 
 # ============================================================
-# NOTIFICATION SETTINGS
+# NOTIFICATION METADATA
+# Current runtime note:
+# - apps/worker/profile_loader.py does not execute this block today
+# - apps/worker/scheduler.py only schedules crawl jobs from profile YAML
+# - keep summary delivery on the dedicated summary pipeline for now
 # ============================================================
 
 notifications:
@@ -91,23 +95,6 @@ notifications:
         - hr@company.com
         - manager@company.com
   
-  triggers:
-    # Notify immediately when high-match candidate found (score >= 80)
-    - event: new_high_match
-      threshold: 80
-      channels: [wechat_work]
-      
-    # Daily summary at 6:00 PM
-    - event: daily_summary
-      time: "18:00"
-      channels: [email]
-      
-    # Weekly report on Friday
-    - event: weekly_report
-      day: friday
-      time: "17:00"
-      channels: [email]
-
 # ============================================================
 # OPTIONAL AI REVIEW SETTINGS
 # ============================================================

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from apps.worker.profile_loader import ProfileLoader
+
+
+def test_load_profiles_uses_schedule_max_candidates(tmp_path) -> None:
+    config_dir = tmp_path / "profiles"
+    config_dir.mkdir()
+    (config_dir / "profile.yaml").write_text(
+        """
+id: summary-ready
+name: Summary Ready
+location: 东莞
+keywords:
+  - CNC
+schedule:
+  enabled: true
+  cron: "0 9 * * 1-5"
+  timezone: Asia/Hong_Kong
+  maxCandidates: 120
+  notifyOnlyOnNew: true
+""".strip(),
+        encoding="utf-8",
+    )
+
+    profiles = ProfileLoader(config_dir=str(config_dir)).load_profiles()
+
+    assert len(profiles) == 1
+    assert profiles[0]["limit"] == 120
+    assert profiles[0]["schedule"] == {
+        "enabled": True,
+        "cron": "0 9 * * 1-5",
+        "timezone": "Asia/Hong_Kong",
+        "maxCandidates": 120,
+        "notifyOnlyOnNew": True,
+    }
+
+
+def test_load_profiles_keeps_legacy_schedule_limit_fallback(tmp_path) -> None:
+    config_dir = tmp_path / "profiles"
+    config_dir.mkdir()
+    (config_dir / "legacy.yaml").write_text(
+        """
+id: legacy-limit
+name: Legacy Limit
+location: 东莞
+keywords:
+  - 销售
+schedule:
+  enabled: true
+  cron: "0 8 * * 1-5"
+  limit: 80
+""".strip(),
+        encoding="utf-8",
+    )
+
+    profiles = ProfileLoader(config_dir=str(config_dir)).load_profiles()
+
+    assert len(profiles) == 1
+    assert profiles[0]["limit"] == 80
+    assert profiles[0]["schedule"]["maxCandidates"] == 80


### PR DESCRIPTION
## Summary
- make profile cron loading preserve `schedule.maxCandidates` and keep a legacy `schedule.limit` fallback
- add focused profile loader coverage for current and legacy schedule fields
- clean the search profile docs/example so profile-level summary triggers are no longer presented as active runtime behavior

## Testing
- uv run pytest tests/test_profile_loader.py tests/test_resume_tasks.py
- make check