### PR TITLE
fix(summary): harden telegram bridge output

### DIFF
--- a/apps/api/src/routes/summaries.test.ts
+++ b/apps/api/src/routes/summaries.test.ts
@@ -222,6 +222,11 @@ describe("summary preview route", () => {
         };
       };
       markdown: string;
+      run: {
+        status: string;
+        triggerSource: string;
+        dryRun: boolean;
+      };
     };
 
     expect(payload.success).toBe(true);
@@ -241,6 +246,11 @@ describe("summary preview route", () => {
       { key: "shortlist", label: "Shortlist", count: 1 },
     ]);
     expect(payload.markdown).toContain("# Daily Ops Summary");
+    expect(payload.run).toMatchObject({
+      status: "previewed",
+      triggerSource: "api_preview",
+      dryRun: true,
+    });
     expect(calls.map((call) => call.pathName)).toEqual([
       "resumes:getSummaryWindow",
       "candidate_status:list",
@@ -299,6 +309,11 @@ describe("summary preview route", () => {
       subject?: string;
       content: string;
       delivery?: unknown;
+      run: {
+        status: string;
+        triggerSource: string;
+        dryRun: boolean;
+      };
     };
     expect(payload.success).toBe(true);
     expect(payload.dryRun).toBe(true);
@@ -306,6 +321,11 @@ describe("summary preview route", () => {
     expect(payload.subject).toBe("Daily Ops Summary hr");
     expect(payload.content).toContain("# Daily Ops Summary");
     expect(payload.delivery).toBeUndefined();
+    expect(payload.run).toMatchObject({
+      status: "dry_run",
+      triggerSource: "api_manual",
+      dryRun: true,
+    });
   });
 
   it("routes telegram summary sends through the bridge", async () => {
@@ -361,12 +381,144 @@ describe("summary preview route", () => {
       channel: string;
       dryRun: boolean;
       delivery: { ok: boolean; accountsSent: number };
+      run: {
+        status: string;
+        triggerSource: string;
+        dryRun: boolean;
+      };
     };
     expect(payload.success).toBe(true);
     expect(payload.channel).toBe("telegram");
     expect(payload.dryRun).toBe(false);
     expect(payload.delivery).toEqual({ ok: true, accountsSent: 1 });
+    expect(payload.run).toMatchObject({
+      status: "sent",
+      triggerSource: "api_manual",
+      dryRun: false,
+    });
     expect(sendSpy).toHaveBeenCalledTimes(1);
     expect(sendSpy.mock.calls[0]?.[0].content).toContain("# Daily Ops Summary");
+  });
+
+  it("lists and fetches persisted summary runs for the active workspace", async () => {
+    root = createFixtureRoot();
+    const {
+      createApp,
+      SessionManager,
+      ActionStorage,
+    } = await loadSummaryModules(root);
+
+    const sessionManager = new SessionManager(root);
+    const actionStorage = new ActionStorage(root);
+    const hrSession = sessionManager.createSession({ workspaceSlug: "hr" });
+    const otherSession = sessionManager.createSession({ workspaceSlug: "dev" });
+    actionStorage.saveAction({ sessionId: hrSession.id, resumeId: "resume-1", actionType: "shortlist" });
+    actionStorage.saveAction({ sessionId: otherSession.id, resumeId: "resume-9", actionType: "reject" });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      if (call.pathName === "resumes:getSummaryWindow") {
+        return convexSuccess({ total: 1, bySource: [{ key: "seek", count: 1 }] });
+      }
+      if (call.pathName === "candidate_status:list") {
+        return convexSuccess([]);
+      }
+      if (call.pathName === "resume_tasks:getSummaryWindow") {
+        return convexSuccess({ total: 0, byStatus: [] });
+      }
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const previewResponse = await app.request("/api/summaries/preview", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        period: "daily",
+        endAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    });
+    const previewPayload = await previewResponse.json() as {
+      run: { id: string };
+    };
+
+    const runResponse = await app.request("/api/summaries/run", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        period: "daily",
+        channel: "telegram",
+        dryRun: true,
+        endAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    });
+    const runPayload = await runResponse.json() as {
+      run: { id: string };
+    };
+
+    await app.request("/api/summaries/preview", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify({
+        period: "daily",
+        endAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    });
+
+    const listResponse = await app.request("/api/summaries/runs?limit=10", {
+      method: "GET",
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+    });
+    expect(listResponse.status).toBe(200);
+    const listPayload = await listResponse.json() as {
+      success: boolean;
+      items: Array<{ id: string; workspaceSlug: string; status: string }>;
+    };
+    expect(listPayload.success).toBe(true);
+    expect(listPayload.items).toHaveLength(2);
+    expect(listPayload.items.map((item) => item.id).sort()).toEqual([
+      previewPayload.run.id,
+      runPayload.run.id,
+    ].sort());
+    expect(listPayload.items.every((item) => item.workspaceSlug === "hr")).toBe(true);
+
+    const detailResponse = await app.request(`/api/summaries/runs/${runPayload.run.id}`, {
+      method: "GET",
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+    });
+    expect(detailResponse.status).toBe(200);
+    const detailPayload = await detailResponse.json() as {
+      success: boolean;
+      item: { id: string; status: string; workspaceSlug: string };
+    };
+    expect(detailPayload).toMatchObject({
+      success: true,
+      item: {
+        id: runPayload.run.id,
+        status: "dry_run",
+        workspaceSlug: "hr",
+      },
+    });
+
+    const missingResponse = await app.request(`/api/summaries/runs/${previewPayload.run.id}`, {
+      method: "GET",
+      headers: {
+        "X-Workspace-Slug": "dev",
+      },
+    });
+    expect(missingResponse.status).toBe(404);
   });
 });

--- a/apps/api/src/routes/summaries.ts
+++ b/apps/api/src/routes/summaries.ts
@@ -1,12 +1,20 @@
+import { randomUUID } from "node:crypto";
+
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { isValidWorkspace, type WorkspaceSlug } from "@trends/shared";
 
 import { SummaryDataService } from "../services/summaries/summary-data-service.js";
 import { summaryDispatcher } from "../services/summaries/summary-dispatcher.js";
 import { SummaryRenderer } from "../services/summaries/summary-renderer.js";
+import {
+  WorkspaceSummaryRunStorage,
+  type StoredWorkspaceSummaryRun,
+} from "../services/workspace-summary-run-storage.js";
 
 const app = new OpenAPIHono();
 const summaryDataService = new SummaryDataService();
 const summaryRenderer = new SummaryRenderer();
+const workspaceSummaryRunStorage = new WorkspaceSummaryRunStorage();
 
 const SummaryCountEntrySchema = z.object({
   key: z.string(),
@@ -47,17 +55,45 @@ const SummaryPreviewRequestSchema = z.object({
   endAt: z.string().datetime({ offset: true }).optional(),
 });
 
+const SummaryTriggerSourceSchema = z.enum([
+  "api_preview",
+  "api_manual",
+  "worker_manual",
+  "worker_schedule",
+]);
+
+const SummaryChannelSchema = z.enum(["email", "wechat_work", "feishu", "telegram"]);
+
+const StoredSummaryRunSchema = z.object({
+  id: z.string(),
+  workspaceSlug: z.string(),
+  period: z.literal("daily"),
+  triggerSource: SummaryTriggerSourceSchema,
+  status: z.enum(["previewed", "dry_run", "sent", "failed"]),
+  channel: SummaryChannelSchema.optional(),
+  templateId: z.string().optional(),
+  dryRun: z.boolean(),
+  windowStart: z.string(),
+  windowEnd: z.string(),
+  startedAt: z.string(),
+  finishedAt: z.string().optional(),
+  report: SummaryReportSchema,
+  content: z.string().optional(),
+  delivery: z.object({}).catchall(z.unknown()).optional(),
+  error: z.string().optional(),
+});
+
 const SummaryPreviewResponseSchema = z.object({
   success: z.literal(true),
   report: SummaryReportSchema,
   markdown: z.string(),
+  run: StoredSummaryRunSchema,
 });
-
-const SummaryChannelSchema = z.enum(["email", "wechat_work", "feishu", "telegram"]);
 
 const SummaryRunRequestSchema = SummaryPreviewRequestSchema.extend({
   channel: SummaryChannelSchema,
   dryRun: z.boolean().default(false),
+  triggerSource: SummaryTriggerSourceSchema.optional(),
   templateId: z.string().min(1).optional(),
   to: z.string().email().optional(),
   subject: z.string().min(1).optional(),
@@ -75,12 +111,76 @@ const SummaryRunResponseSchema = z.object({
   report: SummaryReportSchema,
   content: z.string(),
   delivery: z.object({}).catchall(z.unknown()).optional(),
+  run: StoredSummaryRunSchema,
+});
+
+const SummaryRunsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+const SummaryRunListResponseSchema = z.object({
+  success: z.literal(true),
+  items: z.array(StoredSummaryRunSchema),
+});
+
+const SummaryRunDetailResponseSchema = z.object({
+  success: z.literal(true),
+  item: StoredSummaryRunSchema,
 });
 
 const ErrorSchema = z.object({
   success: z.literal(false),
   error: z.string(),
 });
+
+function isSummaryReport(value: unknown): value is z.infer<typeof SummaryReportSchema> {
+  return SummaryReportSchema.safeParse(value).success;
+}
+
+function toPublicSummaryRun(run: StoredWorkspaceSummaryRun): z.infer<typeof StoredSummaryRunSchema> {
+  return {
+    ...run,
+    report: isSummaryReport(run.report)
+      ? run.report
+      : {
+        workspaceSlug: run.workspaceSlug,
+        period: "daily",
+        generatedAt: run.finishedAt ?? run.startedAt,
+        window: {
+          startAt: run.windowStart,
+          endAt: run.windowEnd,
+          timezone: "unknown",
+        },
+        totals: {
+          newResumes: 0,
+          candidateStatusUpdates: 0,
+          shortlistActions: 0,
+          rejectActions: 0,
+          contactActions: 0,
+          collectionTasksCompleted: 0,
+          collectionTasksFailed: 0,
+        },
+        breakdowns: {
+          resumesBySource: [],
+          candidateStatusByValue: [],
+          actionsByType: [],
+          collectionTasksByStatus: [],
+        },
+        notes: [],
+      },
+  };
+}
+
+function resolveWorkspaceSlug(value: string | undefined, fallback: WorkspaceSlug): WorkspaceSlug {
+  const candidate = value?.trim();
+  if (!candidate) {
+    return fallback;
+  }
+  if (!isValidWorkspace(candidate)) {
+    throw new Error(`Invalid workspace slug: ${candidate}. Allowed: dev, hr`);
+  }
+  return candidate;
+}
 
 const previewRoute = createRoute({
   method: "post",
@@ -119,17 +219,30 @@ const previewRoute = createRoute({
 app.openapi(previewRoute, async (c) => {
   try {
     const body = c.req.valid("json");
-    const workspaceSlug = body.workspaceSlug?.trim() || c.var.workspaceSlug;
+    const workspaceSlug = resolveWorkspaceSlug(body.workspaceSlug, c.var.workspaceSlug);
     const report = await summaryDataService.buildSummaryReport({
       workspaceSlug,
       period: body.period,
       endAt: body.endAt,
     });
+    const markdown = summaryRenderer.renderMarkdown(report);
+    const run = workspaceSummaryRunStorage.createRun({
+      id: randomUUID(),
+      workspaceSlug,
+      triggerSource: "api_preview",
+      status: "previewed",
+      dryRun: true,
+      windowStart: report.window.startAt,
+      windowEnd: report.window.endAt,
+      report,
+      content: markdown,
+    });
 
     return c.json({
       success: true as const,
       report,
-      markdown: summaryRenderer.renderMarkdown(report),
+      markdown,
+      run: toPublicSummaryRun(run),
     }, 200);
   } catch (error) {
     console.error("Failed to preview summary:", error);
@@ -175,14 +288,29 @@ const runRoute = createRoute({
 });
 
 app.openapi(runRoute, async (c) => {
+  let workspaceSlug = c.var.workspaceSlug;
+  let triggerSource: z.infer<typeof SummaryTriggerSourceSchema> = "api_manual";
+  let dryRun = false;
+  let channel: z.infer<typeof SummaryChannelSchema> | undefined;
+  let templateId: string | undefined;
+  let report: z.infer<typeof SummaryReportSchema> | undefined;
+  let preview: { content: string; templateId: string; subject?: string } | undefined;
   try {
     const body = c.req.valid("json");
-    const workspaceSlug = body.workspaceSlug?.trim() || c.var.workspaceSlug;
-    const report = await summaryDataService.buildSummaryReport({
+    workspaceSlug = resolveWorkspaceSlug(body.workspaceSlug, c.var.workspaceSlug);
+    dryRun = body.dryRun;
+    channel = body.channel;
+    templateId = body.templateId;
+    report = await summaryDataService.buildSummaryReport({
       workspaceSlug,
       period: body.period,
       endAt: body.endAt,
     });
+    preview = summaryDispatcher.buildPreview(report, {
+      templateId: body.templateId,
+    });
+    triggerSource = body.triggerSource ?? "api_manual";
+    const runId = randomUUID();
     const dispatched = await summaryDispatcher.dispatch(report, {
       channel: body.channel,
       dryRun: body.dryRun,
@@ -192,6 +320,20 @@ app.openapi(runRoute, async (c) => {
       webhookUrl: body.webhookUrl,
       botToken: body.botToken,
       chatId: body.chatId,
+    });
+    const run = workspaceSummaryRunStorage.createRun({
+      id: runId,
+      workspaceSlug,
+      triggerSource,
+      status: dispatched.dryRun ? "dry_run" : "sent",
+      channel: dispatched.channel,
+      templateId: dispatched.templateId,
+      dryRun: dispatched.dryRun,
+      windowStart: report.window.startAt,
+      windowEnd: report.window.endAt,
+      report,
+      content: dispatched.content,
+      delivery: dispatched.delivery,
     });
 
     return c.json({
@@ -203,14 +345,109 @@ app.openapi(runRoute, async (c) => {
       report,
       content: dispatched.content,
       delivery: dispatched.delivery,
+      run: toPublicSummaryRun(run),
     }, 200);
   } catch (error) {
+    if (report) {
+      workspaceSummaryRunStorage.createRun({
+        id: randomUUID(),
+        workspaceSlug,
+        triggerSource,
+        status: "failed",
+        channel,
+        templateId,
+        dryRun,
+        windowStart: report.window.startAt,
+        windowEnd: report.window.endAt,
+        report,
+        content: preview?.content,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
     console.error("Failed to run summary:", error);
     return c.json({
       success: false as const,
       error: error instanceof Error ? error.message : "Unknown error",
     }, 500);
   }
+});
+
+const listRunsRoute = createRoute({
+  method: "get",
+  path: "/runs",
+  tags: ["Summaries"],
+  summary: "List persisted workspace summary runs",
+  request: {
+    query: SummaryRunsQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "Summary run list",
+      content: {
+        "application/json": {
+          schema: SummaryRunListResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(listRunsRoute, async (c) => {
+  const query = c.req.valid("query");
+  const items = workspaceSummaryRunStorage
+    .listRuns(c.var.workspaceSlug, query.limit)
+    .map((item) => toPublicSummaryRun(item));
+
+  return c.json({
+    success: true as const,
+    items,
+  }, 200);
+});
+
+const getRunRoute = createRoute({
+  method: "get",
+  path: "/runs/{runId}",
+  tags: ["Summaries"],
+  summary: "Get one persisted workspace summary run",
+  request: {
+    params: z.object({
+      runId: z.string().min(1),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Summary run detail",
+      content: {
+        "application/json": {
+          schema: SummaryRunDetailResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: "Run not found",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(getRunRoute, async (c) => {
+  const { runId } = c.req.valid("param");
+  const item = workspaceSummaryRunStorage.getRun(runId, c.var.workspaceSlug);
+  if (!item) {
+    return c.json({
+      success: false as const,
+      error: `Summary run not found: ${runId}`,
+    }, 404);
+  }
+
+  return c.json({
+    success: true as const,
+    item: toPublicSummaryRun(item),
+  }, 200);
 });
 
 export default app;

--- a/apps/api/src/services/database.ts
+++ b/apps/api/src/services/database.ts
@@ -169,6 +169,28 @@ function initSchema(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_actions_user ON candidate_actions(user_id);
     CREATE INDEX IF NOT EXISTS idx_actions_type ON candidate_actions(action_type);
 
+    CREATE TABLE IF NOT EXISTS workspace_summary_runs (
+      id TEXT PRIMARY KEY,
+      workspace_slug TEXT NOT NULL DEFAULT 'dev',
+      period TEXT NOT NULL DEFAULT 'daily',
+      trigger_source TEXT NOT NULL,
+      status TEXT NOT NULL,
+      channel TEXT,
+      template_id TEXT,
+      dry_run INTEGER NOT NULL DEFAULT 0,
+      window_start TEXT NOT NULL,
+      window_end TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      finished_at TEXT,
+      report_json TEXT NOT NULL,
+      content_text TEXT,
+      delivery_json TEXT,
+      error TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workspace_summary_runs_workspace ON workspace_summary_runs(workspace_slug);
+    CREATE INDEX IF NOT EXISTS idx_workspace_summary_runs_started ON workspace_summary_runs(started_at DESC);
+
     CREATE TABLE IF NOT EXISTS review_packet_runs (
       id TEXT PRIMARY KEY,
       workspace_slug TEXT NOT NULL DEFAULT 'dev',

--- a/apps/api/src/services/summaries/summary-telegram-bridge.test.ts
+++ b/apps/api/src/services/summaries/summary-telegram-bridge.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSummaryTelegramBridgeOutput } from "./summary-telegram-bridge";
+
+describe("parseSummaryTelegramBridgeOutput", () => {
+  it("parses clean JSON output", () => {
+    expect(
+      parseSummaryTelegramBridgeOutput('{"ok":true,"accountsSent":1}')
+    ).toEqual({ ok: true, accountsSent: 1 });
+  });
+
+  it("parses the last JSON line when stdout includes leading logs", () => {
+    expect(
+      parseSummaryTelegramBridgeOutput(
+        [
+          "配置文件加载成功: config/config.yaml",
+          "通知渠道配置来源: Telegram(环境变量, 1个账号)",
+          '{"ok":true,"accountsSent":1}',
+        ].join("\n")
+      )
+    ).toEqual({ ok: true, accountsSent: 1 });
+  });
+
+  it("throws when stdout contains no JSON payload", () => {
+    expect(() => parseSummaryTelegramBridgeOutput("only logs")).toThrow("no JSON object found in stdout");
+  });
+});

--- a/apps/api/src/services/summaries/summary-telegram-bridge.ts
+++ b/apps/api/src/services/summaries/summary-telegram-bridge.ts
@@ -61,7 +61,7 @@ export class SummaryTelegramBridge {
         }
 
         try {
-          resolve(JSON.parse(stdout) as SummaryTelegramBridgeResult);
+          resolve(parseSummaryTelegramBridgeOutput(stdout));
         } catch (error) {
           reject(new Error(`Invalid Telegram summary bridge output: ${String(error)}`));
         }
@@ -70,6 +70,27 @@ export class SummaryTelegramBridge {
       child.stdin.write(JSON.stringify(payload));
       child.stdin.end();
     });
+  }
+}
+
+export function parseSummaryTelegramBridgeOutput(stdout: string): SummaryTelegramBridgeResult {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    throw new Error("empty stdout");
+  }
+
+  try {
+    return JSON.parse(trimmed) as SummaryTelegramBridgeResult;
+  } catch {
+    const lines = trimmed.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      try {
+        return JSON.parse(lines[index]!) as SummaryTelegramBridgeResult;
+      } catch {
+        continue;
+      }
+    }
+    throw new Error("no JSON object found in stdout");
   }
 }
 

--- a/apps/api/src/services/workspace-summary-run-storage.ts
+++ b/apps/api/src/services/workspace-summary-run-storage.ts
@@ -1,0 +1,181 @@
+import { config } from "./config.js";
+import { getResumeScreeningDb } from "./database.js";
+import { formatIsoOffsetInTimezone } from "./timezone.js";
+
+export type WorkspaceSummaryRunStatus = "previewed" | "dry_run" | "sent" | "failed";
+
+export type WorkspaceSummaryTriggerSource =
+  | "api_preview"
+  | "api_manual"
+  | "worker_manual"
+  | "worker_schedule";
+
+export type StoredWorkspaceSummaryRun = {
+  id: string;
+  workspaceSlug: string;
+  period: "daily";
+  triggerSource: WorkspaceSummaryTriggerSource;
+  status: WorkspaceSummaryRunStatus;
+  channel?: "email" | "wechat_work" | "feishu" | "telegram";
+  templateId?: string;
+  dryRun: boolean;
+  windowStart: string;
+  windowEnd: string;
+  startedAt: string;
+  finishedAt?: string;
+  report: Record<string, unknown>;
+  content?: string;
+  delivery?: Record<string, unknown>;
+  error?: string;
+};
+
+function parseJsonObject(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeTriggerSource(value: unknown): WorkspaceSummaryTriggerSource {
+  const source = String(value ?? "api_manual");
+  if (
+    source === "api_preview"
+    || source === "api_manual"
+    || source === "worker_manual"
+    || source === "worker_schedule"
+  ) {
+    return source;
+  }
+  return "api_manual";
+}
+
+function normalizeStatus(value: unknown): WorkspaceSummaryRunStatus {
+  const status = String(value ?? "sent");
+  if (status === "previewed" || status === "dry_run" || status === "sent" || status === "failed") {
+    return status;
+  }
+  return "sent";
+}
+
+function normalizeChannel(value: unknown): StoredWorkspaceSummaryRun["channel"] {
+  const channel = typeof value === "string" ? value : "";
+  if (channel === "email" || channel === "wechat_work" || channel === "feishu" || channel === "telegram") {
+    return channel;
+  }
+  return undefined;
+}
+
+function normalizeRun(row: Record<string, unknown>): StoredWorkspaceSummaryRun {
+  return {
+    id: String(row.id),
+    workspaceSlug: row.workspace_slug ? String(row.workspace_slug) : "dev",
+    period: "daily",
+    triggerSource: normalizeTriggerSource(row.trigger_source),
+    status: normalizeStatus(row.status),
+    channel: normalizeChannel(row.channel),
+    templateId: row.template_id ? String(row.template_id) : undefined,
+    dryRun: Number(row.dry_run ?? 0) === 1,
+    windowStart: String(row.window_start),
+    windowEnd: String(row.window_end),
+    startedAt: String(row.started_at),
+    finishedAt: row.finished_at ? String(row.finished_at) : undefined,
+    report: parseJsonObject(row.report_json) ?? {},
+    content: row.content_text ? String(row.content_text) : undefined,
+    delivery: parseJsonObject(row.delivery_json),
+    error: row.error ? String(row.error) : undefined,
+  };
+}
+
+export class WorkspaceSummaryRunStorage {
+  private readonly db;
+
+  constructor(projectRoot?: string) {
+    this.db = getResumeScreeningDb(projectRoot);
+  }
+
+  createRun(params: {
+    id: string;
+    workspaceSlug: string;
+    triggerSource: WorkspaceSummaryTriggerSource;
+    status: WorkspaceSummaryRunStatus;
+    channel?: StoredWorkspaceSummaryRun["channel"];
+    templateId?: string;
+    dryRun: boolean;
+    windowStart: string;
+    windowEnd: string;
+    startedAt?: string;
+    finishedAt?: string;
+    report: Record<string, unknown>;
+    content?: string;
+    delivery?: Record<string, unknown>;
+    error?: string;
+  }): StoredWorkspaceSummaryRun {
+    const startedAt = params.startedAt ?? formatIsoOffsetInTimezone(new Date(), config.timezone);
+    this.db
+      .prepare(
+        `
+        INSERT INTO workspace_summary_runs (
+          id, workspace_slug, period, trigger_source, status,
+          channel, template_id, dry_run, window_start, window_end,
+          started_at, finished_at, report_json, content_text,
+          delivery_json, error
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        params.id,
+        params.workspaceSlug,
+        "daily",
+        params.triggerSource,
+        params.status,
+        params.channel ?? null,
+        params.templateId ?? null,
+        params.dryRun ? 1 : 0,
+        params.windowStart,
+        params.windowEnd,
+        startedAt,
+        params.finishedAt ?? startedAt,
+        JSON.stringify(params.report),
+        params.content ?? null,
+        params.delivery ? JSON.stringify(params.delivery) : null,
+        params.error ?? null,
+      );
+
+    const created = this.getRun(params.id, params.workspaceSlug);
+    if (!created) {
+      throw new Error(`Failed to create workspace summary run: ${params.id}`);
+    }
+    return created;
+  }
+
+  getRun(id: string, workspaceSlug: string): StoredWorkspaceSummaryRun | null {
+    const row = this.db
+      .prepare("SELECT * FROM workspace_summary_runs WHERE id = ? AND workspace_slug = ?")
+      .get(id, workspaceSlug) as Record<string, unknown> | undefined;
+
+    return row ? normalizeRun(row) : null;
+  }
+
+  listRuns(workspaceSlug: string, limit = 20): StoredWorkspaceSummaryRun[] {
+    const rows = this.db
+      .prepare(
+        `
+        SELECT * FROM workspace_summary_runs
+        WHERE workspace_slug = ?
+        ORDER BY started_at DESC
+        LIMIT ?
+        `
+      )
+      .all(workspaceSlug, limit) as Record<string, unknown>[];
+
+    return rows.map((row) => normalizeRun(row));
+  }
+}

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4491,6 +4491,72 @@ export interface paths {
                                 notes: string[];
                             };
                             markdown: string;
+                            run: {
+                                id: string;
+                                workspaceSlug: string;
+                                /** @enum {string} */
+                                period: "daily";
+                                /** @enum {string} */
+                                triggerSource: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
+                                /** @enum {string} */
+                                status: "previewed" | "dry_run" | "sent" | "failed";
+                                /** @enum {string} */
+                                channel?: "email" | "wechat_work" | "feishu" | "telegram";
+                                templateId?: string;
+                                dryRun: boolean;
+                                windowStart: string;
+                                windowEnd: string;
+                                startedAt: string;
+                                finishedAt?: string;
+                                report: {
+                                    workspaceSlug: string;
+                                    /** @enum {string} */
+                                    period: "daily";
+                                    generatedAt: string;
+                                    window: {
+                                        startAt: string;
+                                        endAt: string;
+                                        timezone: string;
+                                    };
+                                    totals: {
+                                        newResumes: number;
+                                        candidateStatusUpdates: number;
+                                        shortlistActions: number;
+                                        rejectActions: number;
+                                        contactActions: number;
+                                        collectionTasksCompleted: number;
+                                        collectionTasksFailed: number;
+                                    };
+                                    breakdowns: {
+                                        resumesBySource: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                        candidateStatusByValue: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                        actionsByType: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                        collectionTasksByStatus: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                    };
+                                    notes: string[];
+                                };
+                                content?: string;
+                                delivery?: {
+                                    [key: string]: unknown;
+                                };
+                                error?: string;
+                            };
                         };
                     };
                 };
@@ -4547,6 +4613,8 @@ export interface paths {
                         channel: "email" | "wechat_work" | "feishu" | "telegram";
                         /** @default false */
                         dryRun?: boolean;
+                        /** @enum {string} */
+                        triggerSource?: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
                         templateId?: string;
                         /** Format: email */
                         to?: string;
@@ -4620,6 +4688,72 @@ export interface paths {
                             delivery?: {
                                 [key: string]: unknown;
                             };
+                            run: {
+                                id: string;
+                                workspaceSlug: string;
+                                /** @enum {string} */
+                                period: "daily";
+                                /** @enum {string} */
+                                triggerSource: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
+                                /** @enum {string} */
+                                status: "previewed" | "dry_run" | "sent" | "failed";
+                                /** @enum {string} */
+                                channel?: "email" | "wechat_work" | "feishu" | "telegram";
+                                templateId?: string;
+                                dryRun: boolean;
+                                windowStart: string;
+                                windowEnd: string;
+                                startedAt: string;
+                                finishedAt?: string;
+                                report: {
+                                    workspaceSlug: string;
+                                    /** @enum {string} */
+                                    period: "daily";
+                                    generatedAt: string;
+                                    window: {
+                                        startAt: string;
+                                        endAt: string;
+                                        timezone: string;
+                                    };
+                                    totals: {
+                                        newResumes: number;
+                                        candidateStatusUpdates: number;
+                                        shortlistActions: number;
+                                        rejectActions: number;
+                                        contactActions: number;
+                                        collectionTasksCompleted: number;
+                                        collectionTasksFailed: number;
+                                    };
+                                    breakdowns: {
+                                        resumesBySource: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                        candidateStatusByValue: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                        actionsByType: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                        collectionTasksByStatus: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                    };
+                                    notes: string[];
+                                };
+                                content?: string;
+                                delivery?: {
+                                    [key: string]: unknown;
+                                };
+                                error?: string;
+                            };
                         };
                     };
                 };
@@ -4638,6 +4772,233 @@ export interface paths {
                 };
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/summaries/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List persisted workspace summary runs */
+        get: {
+            parameters: {
+                query?: {
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Summary run list */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            items: {
+                                id: string;
+                                workspaceSlug: string;
+                                /** @enum {string} */
+                                period: "daily";
+                                /** @enum {string} */
+                                triggerSource: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
+                                /** @enum {string} */
+                                status: "previewed" | "dry_run" | "sent" | "failed";
+                                /** @enum {string} */
+                                channel?: "email" | "wechat_work" | "feishu" | "telegram";
+                                templateId?: string;
+                                dryRun: boolean;
+                                windowStart: string;
+                                windowEnd: string;
+                                startedAt: string;
+                                finishedAt?: string;
+                                report: {
+                                    workspaceSlug: string;
+                                    /** @enum {string} */
+                                    period: "daily";
+                                    generatedAt: string;
+                                    window: {
+                                        startAt: string;
+                                        endAt: string;
+                                        timezone: string;
+                                    };
+                                    totals: {
+                                        newResumes: number;
+                                        candidateStatusUpdates: number;
+                                        shortlistActions: number;
+                                        rejectActions: number;
+                                        contactActions: number;
+                                        collectionTasksCompleted: number;
+                                        collectionTasksFailed: number;
+                                    };
+                                    breakdowns: {
+                                        resumesBySource: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                        candidateStatusByValue: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                        actionsByType: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                        collectionTasksByStatus: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                    };
+                                    notes: string[];
+                                };
+                                content?: string;
+                                delivery?: {
+                                    [key: string]: unknown;
+                                };
+                                error?: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/summaries/runs/{runId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get one persisted workspace summary run */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    runId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Summary run detail */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            item: {
+                                id: string;
+                                workspaceSlug: string;
+                                /** @enum {string} */
+                                period: "daily";
+                                /** @enum {string} */
+                                triggerSource: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
+                                /** @enum {string} */
+                                status: "previewed" | "dry_run" | "sent" | "failed";
+                                /** @enum {string} */
+                                channel?: "email" | "wechat_work" | "feishu" | "telegram";
+                                templateId?: string;
+                                dryRun: boolean;
+                                windowStart: string;
+                                windowEnd: string;
+                                startedAt: string;
+                                finishedAt?: string;
+                                report: {
+                                    workspaceSlug: string;
+                                    /** @enum {string} */
+                                    period: "daily";
+                                    generatedAt: string;
+                                    window: {
+                                        startAt: string;
+                                        endAt: string;
+                                        timezone: string;
+                                    };
+                                    totals: {
+                                        newResumes: number;
+                                        candidateStatusUpdates: number;
+                                        shortlistActions: number;
+                                        rejectActions: number;
+                                        contactActions: number;
+                                        collectionTasksCompleted: number;
+                                        collectionTasksFailed: number;
+                                    };
+                                    breakdowns: {
+                                        resumesBySource: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                        candidateStatusByValue: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                        actionsByType: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                        collectionTasksByStatus: {
+                                            key: string;
+                                            label: string;
+                                            count: number;
+                                        }[];
+                                    };
+                                    notes: string[];
+                                };
+                                content?: string;
+                                delivery?: {
+                                    [key: string]: unknown;
+                                };
+                                error?: string;
+                            };
+                        };
+                    };
+                };
+                /** @description Run not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;

--- a/apps/worker/api.py
+++ b/apps/worker/api.py
@@ -290,6 +290,7 @@ async def trigger_worker_summary(request: WorkerSummaryTriggerRequest):
         workspace_slug=request.workspaceSlug,
         channel=request.channel,
         dry_run=request.dryRun,
+        trigger_source="worker_manual",
         template_id=request.templateId,
         end_at=request.endAt,
         to=request.to,

--- a/apps/worker/profile_loader.py
+++ b/apps/worker/profile_loader.py
@@ -16,8 +16,8 @@ class ProfileLoader:
         Load all enabled search profiles from the config directory.
         Returns a list of profile dictionaries containing:
         - id: Profile ID
-        - schedule: Cron expression
-        - limit: Max resumes to collect
+        - schedule: Active runtime schedule metadata
+        - limit: Max resumes to collect (legacy compatibility alias)
         - location: Target location
         - keywords: Search keywords
         """
@@ -41,12 +41,25 @@ class ProfileLoader:
                 if not cron:
                     logger.warning(f"Profile {filepath} enabled but missing cron expression")
                     continue
+
+                max_candidates = schedule.get("maxCandidates")
+                if max_candidates is None:
+                    max_candidates = schedule.get("limit", 50)
+
+                runtime_schedule = {
+                    "enabled": True,
+                    "cron": cron,
+                    "timezone": schedule.get("timezone"),
+                    "maxCandidates": max_candidates,
+                    "notifyOnlyOnNew": schedule.get("notifyOnlyOnNew"),
+                }
                     
                 profile = {
                     "id": data.get("id"),
                     "name": data.get("name"),
                     "cron": cron,
-                    "limit": schedule.get("limit", 50),
+                    "limit": max_candidates,
+                    "schedule": runtime_schedule,
                     "location": data.get("location"),
                     "keywords": data.get("keywords", []),
                     "filters": data.get("filters"),

--- a/apps/worker/scheduler.py
+++ b/apps/worker/scheduler.py
@@ -369,6 +369,7 @@ class WorkerScheduler:
             workspace_slug=workspace_slug,
             channel=channel,
             dry_run=dry_run,
+            trigger_source="worker_schedule",
             template_id=template_id,
             end_at=end_at,
         )

--- a/apps/worker/tasks.py
+++ b/apps/worker/tasks.py
@@ -298,6 +298,7 @@ def run_workspace_summary(
     workspace_slug: str = "dev",
     channel: str = "telegram",
     dry_run: bool = False,
+    trigger_source: str = "worker_manual",
     template_id: Optional[str] = None,
     end_at: Optional[str] = None,
     to: Optional[str] = None,
@@ -321,6 +322,7 @@ def run_workspace_summary(
         "period": "daily",
         "channel": normalized_channel,
         "dryRun": bool(dry_run),
+        "triggerSource": trigger_source.strip() if trigger_source.strip() else "worker_manual",
     }
 
     if template_id and template_id.strip():

--- a/config/search-profiles/README.md
+++ b/config/search-profiles/README.md
@@ -5,8 +5,24 @@ This directory contains pre-configured search profiles that combine:
 - Keywords
 - Job Description reference
 - Filter settings
-- Automation settings (scheduling, notifications)
+- Automation settings (currently crawl scheduling only)
 - Source routing and optional AI review behavior
+
+## Runtime Status
+
+The current worker runtime actively uses these profile fields:
+- `location`
+- `keywords`
+- `requiredKeywords`
+- `filters`
+- `jobDescription`
+- `schedule.enabled`
+- `schedule.cron`
+- `schedule.timezone`
+- `schedule.maxCandidates`
+
+The current worker runtime does **not** yet execute profile-level notification or summary triggers from YAML.
+Keep summary delivery on the dedicated summary pipeline and env-driven worker summary job for now.
 
 ## Usage
 
@@ -51,7 +67,8 @@ schedule:
   cron: "0 9 * * 1-5"  # Mon-Fri 9:00 AM
   timezone: Asia/Shanghai
 
-# Notifications
+# Notifications metadata
+# Note: this block is not executed by the current worker runtime.
 notifications:
   enabled: true
   channels:
@@ -60,9 +77,6 @@ notifications:
     - type: email
       recipients:
         - hr@company.com
-  triggers:
-    - event: new_high_match    # Score >= 80
-    - event: daily_summary
 
 # Optional AI review settings
 # Keep deterministic scoring as the default engine; use AI only on shortlisted resumes.
@@ -97,4 +111,4 @@ curl -X POST http://localhost:3000/api/search-profiles/quick-start \
 
 ## Files
 
-- `dongguan-lathe-sales.yaml`: example routing preset with deterministic filters, notifications, and an optional review lane
+- `dongguan-lathe-sales.yaml`: example routing preset with active crawl scheduling plus optional metadata blocks that are not all executed by the worker today

--- a/config/search-profiles/dongguan-lathe-sales.yaml
+++ b/config/search-profiles/dongguan-lathe-sales.yaml
@@ -72,7 +72,11 @@ sources:
     priority: 2
 
 # ============================================================
-# NOTIFICATION SETTINGS
+# NOTIFICATION METADATA
+# Current runtime note:
+# - apps/worker/profile_loader.py does not execute this block today
+# - apps/worker/scheduler.py only schedules crawl jobs from profile YAML
+# - keep summary delivery on the dedicated summary pipeline for now
 # ============================================================
 
 notifications:
@@ -91,23 +95,6 @@ notifications:
         - hr@company.com
         - manager@company.com
   
-  triggers:
-    # Notify immediately when high-match candidate found (score >= 80)
-    - event: new_high_match
-      threshold: 80
-      channels: [wechat_work]
-      
-    # Daily summary at 6:00 PM
-    - event: daily_summary
-      time: "18:00"
-      channels: [email]
-      
-    # Weekly report on Friday
-    - event: weekly_report
-      day: friday
-      time: "17:00"
-      channels: [email]
-
 # ============================================================
 # OPTIONAL AI REVIEW SETTINGS
 # ============================================================

--- a/packages/cli/cmd/worker.go
+++ b/packages/cli/cmd/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ptdevhk/trends/packages/cli/internal/client"
 	"github.com/spf13/cobra"
 )
 
@@ -16,9 +17,155 @@ func newWorkerCmd() *cobra.Command {
 	workerCmd.AddCommand(
 		newWorkerStatusCmd(),
 		newWorkerRunCmd(),
+		newWorkerSummaryCmd(),
 	)
 
 	return workerCmd
+}
+
+func newWorkerSummaryCmd() *cobra.Command {
+	summaryCmd := &cobra.Command{
+		Use:   "summary",
+		Short: "Workspace summary operations",
+	}
+
+	summaryCmd.AddCommand(
+		newWorkerSummaryRunCmd(),
+		newWorkerSummaryHistoryCmd(),
+		newWorkerSummaryShowCmd(),
+	)
+
+	return summaryCmd
+}
+
+func newWorkerSummaryRunCmd() *cobra.Command {
+	var channel string
+	var dryRun bool
+	var templateID string
+	var endAt string
+	var to string
+	var subject string
+	var webhookURL string
+	var botToken string
+	var chatID string
+	var viaWorker bool
+
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run a workspace summary manually",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			request := client.SummaryRunRequest{
+				Channel:       channel,
+				DryRun:        dryRun,
+				TemplateID:    templateID,
+				EndAt:         endAt,
+				To:            to,
+				Subject:       subject,
+				WebhookURL:    webhookURL,
+				BotToken:      botToken,
+				ChatID:        chatID,
+				TriggerSource: "api_manual",
+			}
+
+			if viaWorker {
+				response, err := newAPIClient().TriggerWorkerSummary(context.Background(), request)
+				if err != nil {
+					return err
+				}
+				headers := []string{"mode", "started_at", "finished_at", "message"}
+				rows := [][]string{{response.Mode, response.StartedAt, response.FinishedAt, response.Message}}
+				return writeOutput(cmd, headers, rows, response)
+			}
+
+			response, err := newAPIClient().RunWorkspaceSummary(context.Background(), request)
+			if err != nil {
+				return err
+			}
+			headers := []string{"run_id", "status", "channel", "dry_run", "trigger_source", "window_end"}
+			rows := [][]string{{
+				response.Run.ID,
+				response.Run.Status,
+				response.Channel,
+				boolToString(response.DryRun),
+				response.Run.TriggerSource,
+				response.Run.WindowEnd,
+			}}
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	cmd.Flags().StringVar(&channel, "channel", "telegram", "Summary delivery channel")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Render without sending externally")
+	cmd.Flags().StringVar(&templateID, "template-id", "", "Optional notification template ID")
+	cmd.Flags().StringVar(&endAt, "end-at", "", "Optional ISO8601 end time")
+	cmd.Flags().StringVar(&to, "to", "", "Optional email recipient for email channel")
+	cmd.Flags().StringVar(&subject, "subject", "", "Optional message subject override")
+	cmd.Flags().StringVar(&webhookURL, "webhook-url", "", "Optional webhook override for WeChat Work or Feishu")
+	cmd.Flags().StringVar(&botToken, "bot-token", "", "Optional Telegram bot token override")
+	cmd.Flags().StringVar(&chatID, "chat-id", "", "Optional Telegram chat ID override")
+	cmd.Flags().BoolVar(&viaWorker, "via-worker", false, "Trigger through the worker summary endpoint instead of the API summary route")
+	return cmd
+}
+
+func newWorkerSummaryHistoryCmd() *cobra.Command {
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "history",
+		Short: "List persisted workspace summary runs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := newAPIClient().ListWorkspaceSummaryRuns(context.Background(), limit)
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"id", "status", "channel", "dry_run", "trigger_source", "started_at", "window_end"}
+			rows := make([][]string, 0, len(response.Items))
+			for _, item := range response.Items {
+				rows = append(rows, []string{
+					item.ID,
+					item.Status,
+					item.Channel,
+					boolToString(item.DryRun),
+					item.TriggerSource,
+					item.StartedAt,
+					item.WindowEnd,
+				})
+			}
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 20, "Maximum summary runs to fetch")
+	return cmd
+}
+
+func newWorkerSummaryShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <run-id>",
+		Short: "Show one persisted workspace summary run",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := newAPIClient().GetWorkspaceSummaryRun(context.Background(), args[0])
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"id", "status", "channel", "dry_run", "trigger_source", "started_at", "finished_at"}
+			rows := [][]string{{
+				response.Item.ID,
+				response.Item.Status,
+				response.Item.Channel,
+				boolToString(response.Item.DryRun),
+				response.Item.TriggerSource,
+				response.Item.StartedAt,
+				response.Item.FinishedAt,
+			}}
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	return cmd
 }
 
 func newWorkerStatusCmd() *cobra.Command {

--- a/packages/cli/cmd/worker_summary_test.go
+++ b/packages/cli/cmd/worker_summary_test.go
@@ -1,0 +1,198 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWorkerSummaryRunCommandWritesJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/summaries/run" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if request["workspaceSlug"] != "ops" || request["period"] != "daily" {
+			t.Fatalf("unexpected request: %#v", request)
+		}
+		if request["triggerSource"] != "api_manual" {
+			t.Fatalf("unexpected request: %#v", request)
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success":    true,
+			"channel":    "telegram",
+			"dryRun":     true,
+			"templateId": "summary-daily",
+			"run": map[string]any{
+				"id":            "run-1",
+				"status":        "dry_run",
+				"triggerSource": "api_manual",
+				"windowEnd":     "2026-03-26T12:00:00Z",
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+	setCLIOutput(t, "json")
+
+	cmd := newWorkerSummaryRunCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("worker summary run command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	run, ok := payload["run"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing run payload: %#v", payload)
+	}
+	if run["id"] != "run-1" || run["status"] != "dry_run" {
+		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+}
+
+func TestWorkerSummaryRunViaWorkerCommandWritesJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/worker/summary" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if request["workspaceSlug"] != "ops" || request["period"] != "daily" {
+			t.Fatalf("unexpected request: %#v", request)
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success":     true,
+			"mode":        "summary",
+			"started_at":  "2026-03-26T12:00:00Z",
+			"finished_at": "2026-03-26T12:00:02Z",
+			"message":     "Summary task completed for ops",
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+	setCLIOutput(t, "json")
+
+	cmd := newWorkerSummaryRunCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--via-worker", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("worker summary via-worker command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["mode"] != "summary" {
+		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+}
+
+func TestWorkerSummaryHistoryCommandWritesJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/summaries/runs" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "5" {
+			t.Fatalf("expected limit=5, got %q", got)
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"items": []map[string]any{{
+				"id":            "run-1",
+				"status":        "sent",
+				"triggerSource": "worker_schedule",
+			}},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+	setCLIOutput(t, "json")
+
+	cmd := newWorkerSummaryHistoryCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--limit", "5"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("worker summary history command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	items, ok := payload["items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+	item, ok := items[0].(map[string]any)
+	if !ok || item["triggerSource"] != "worker_schedule" {
+		t.Fatalf("unexpected item payload: %#v", payload)
+	}
+}
+
+func TestWorkerSummaryShowCommandWritesJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/summaries/runs/run-7" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"item": map[string]any{
+				"id":            "run-7",
+				"status":        "failed",
+				"triggerSource": "api_manual",
+				"error":         "boom",
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+	setCLIOutput(t, "json")
+
+	cmd := newWorkerSummaryShowCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"run-7"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("worker summary show command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	item, ok := payload["item"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+	if item["id"] != "run-7" || item["error"] != "boom" {
+		t.Fatalf("unexpected item payload: %#v", payload)
+	}
+}

--- a/packages/cli/internal/client/worker.go
+++ b/packages/cli/internal/client/worker.go
@@ -24,6 +24,72 @@ type WorkerTriggerResponse struct {
 	Message    string `json:"message"`
 }
 
+type SummaryRun struct {
+	ID            string         `json:"id"`
+	WorkspaceSlug string         `json:"workspaceSlug"`
+	Period        string         `json:"period"`
+	TriggerSource string         `json:"triggerSource"`
+	Status        string         `json:"status"`
+	Channel       string         `json:"channel,omitempty"`
+	TemplateID    string         `json:"templateId,omitempty"`
+	DryRun        bool           `json:"dryRun"`
+	WindowStart   string         `json:"windowStart"`
+	WindowEnd     string         `json:"windowEnd"`
+	StartedAt     string         `json:"startedAt"`
+	FinishedAt    string         `json:"finishedAt,omitempty"`
+	Report        map[string]any `json:"report"`
+	Content       string         `json:"content,omitempty"`
+	Delivery      map[string]any `json:"delivery,omitempty"`
+	Error         string         `json:"error,omitempty"`
+}
+
+type SummaryRunRequest struct {
+	WorkspaceSlug string `json:"workspaceSlug,omitempty"`
+	Period        string `json:"period,omitempty"`
+	Channel       string `json:"channel"`
+	DryRun        bool   `json:"dryRun"`
+	TriggerSource string `json:"triggerSource,omitempty"`
+	TemplateID    string `json:"templateId,omitempty"`
+	EndAt         string `json:"endAt,omitempty"`
+	To            string `json:"to,omitempty"`
+	Subject       string `json:"subject,omitempty"`
+	WebhookURL    string `json:"webhookUrl,omitempty"`
+	BotToken      string `json:"botToken,omitempty"`
+	ChatID        string `json:"chatId,omitempty"`
+}
+
+type SummaryRunInvocationResponse struct {
+	Success    bool           `json:"success"`
+	Channel    string         `json:"channel"`
+	DryRun     bool           `json:"dryRun"`
+	TemplateID string         `json:"templateId"`
+	Subject    string         `json:"subject,omitempty"`
+	Report     map[string]any `json:"report"`
+	Content    string         `json:"content"`
+	Delivery   map[string]any `json:"delivery,omitempty"`
+	Run        SummaryRun     `json:"run"`
+}
+
+type SummaryRunListResponse struct {
+	Success bool         `json:"success"`
+	Items   []SummaryRun `json:"items"`
+}
+
+type SummaryRunDetailResponse struct {
+	Success bool       `json:"success"`
+	Item    SummaryRun `json:"item"`
+}
+
+func (c *Client) normalizeSummaryRunRequest(request SummaryRunRequest) SummaryRunRequest {
+	if request.WorkspaceSlug == "" {
+		request.WorkspaceSlug = c.Workspace
+	}
+	if request.Period == "" {
+		request.Period = "daily"
+	}
+	return request
+}
+
 func (c *Client) WorkerStatus(ctx context.Context) (*WorkerStatus, error) {
 	var response WorkerStatus
 
@@ -59,6 +125,48 @@ func (c *Client) RunWorker(ctx context.Context, once bool) (*WorkerTriggerRespon
 	}
 	if !response.Success {
 		return nil, fmt.Errorf("worker run request was not successful")
+	}
+	return &response, nil
+}
+
+func (c *Client) RunWorkspaceSummary(ctx context.Context, request SummaryRunRequest) (*SummaryRunInvocationResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/summaries/run", c.APIURL)
+	var response SummaryRunInvocationResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, c.normalizeSummaryRunRequest(request), &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("workspace summary request was not successful")
+	}
+	return &response, nil
+}
+
+func (c *Client) ListWorkspaceSummaryRuns(ctx context.Context, limit int) (*SummaryRunListResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/summaries/runs?limit=%d", c.APIURL, limit)
+	var response SummaryRunListResponse
+	if err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) GetWorkspaceSummaryRun(ctx context.Context, runID string) (*SummaryRunDetailResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/summaries/runs/%s", c.APIURL, runID)
+	var response SummaryRunDetailResponse
+	if err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) TriggerWorkerSummary(ctx context.Context, request SummaryRunRequest) (*WorkerTriggerResponse, error) {
+	endpoint := fmt.Sprintf("%s/worker/summary", c.APIURL)
+	var response WorkerTriggerResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, c.normalizeSummaryRunRequest(request), &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("worker summary request was not successful")
 	}
 	return &response, nil
 }

--- a/packages/cli/internal/client/worker_test.go
+++ b/packages/cli/internal/client/worker_test.go
@@ -154,3 +154,162 @@ func TestRunWorkerFailsWhenResponseNotSuccessful(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestRunWorkspaceSummaryPostsRunRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/summaries/run" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if got := r.Header.Get("X-Workspace-Slug"); got != "ops" {
+			t.Fatalf("expected workspace header, got %q", got)
+		}
+
+		var request SummaryRunRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if request.WorkspaceSlug != "ops" || request.Period != "daily" {
+			t.Fatalf("unexpected workspace request: %+v", request)
+		}
+		if request.TriggerSource != "api_manual" || request.Channel != "telegram" {
+			t.Fatalf("unexpected request: %+v", request)
+		}
+
+		_ = json.NewEncoder(w).Encode(SummaryRunInvocationResponse{
+			Success:    true,
+			Channel:    "telegram",
+			DryRun:     true,
+			TemplateID: "summary-daily",
+			Run: SummaryRun{
+				ID:            "run-1",
+				Status:        "dry_run",
+				TriggerSource: "api_manual",
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL, server.URL, "ops")
+	c.HTTP = server.Client()
+
+	response, err := c.RunWorkspaceSummary(context.Background(), SummaryRunRequest{
+		Channel:       "telegram",
+		DryRun:        true,
+		TriggerSource: "api_manual",
+	})
+	if err != nil {
+		t.Fatalf("RunWorkspaceSummary returned error: %v", err)
+	}
+	if response.Run.ID != "run-1" || response.Run.Status != "dry_run" {
+		t.Fatalf("unexpected response: %+v", response)
+	}
+}
+
+func TestListWorkspaceSummaryRunsFetchesHistory(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/summaries/runs" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "5" {
+			t.Fatalf("expected limit=5, got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(SummaryRunListResponse{
+			Success: true,
+			Items: []SummaryRun{{
+				ID:            "run-1",
+				Status:        "sent",
+				TriggerSource: "worker_schedule",
+			}},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL, server.URL, "ops")
+	c.HTTP = server.Client()
+
+	response, err := c.ListWorkspaceSummaryRuns(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListWorkspaceSummaryRuns returned error: %v", err)
+	}
+	if len(response.Items) != 1 || response.Items[0].TriggerSource != "worker_schedule" {
+		t.Fatalf("unexpected response: %+v", response)
+	}
+}
+
+func TestGetWorkspaceSummaryRunFetchesDetail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/summaries/runs/run-42" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(SummaryRunDetailResponse{
+			Success: true,
+			Item: SummaryRun{
+				ID:            "run-42",
+				Status:        "failed",
+				TriggerSource: "api_manual",
+				Error:         "boom",
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL, server.URL, "ops")
+	c.HTTP = server.Client()
+
+	response, err := c.GetWorkspaceSummaryRun(context.Background(), "run-42")
+	if err != nil {
+		t.Fatalf("GetWorkspaceSummaryRun returned error: %v", err)
+	}
+	if response.Item.Error != "boom" || response.Item.ID != "run-42" {
+		t.Fatalf("unexpected response: %+v", response)
+	}
+}
+
+func TestTriggerWorkerSummaryPostsWorkerSummaryRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/worker/summary" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if got := r.Header.Get("X-Workspace-Slug"); got != "ops" {
+			t.Fatalf("expected workspace header, got %q", got)
+		}
+
+		var request SummaryRunRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if request.WorkspaceSlug != "ops" || request.Period != "daily" {
+			t.Fatalf("unexpected workspace request: %+v", request)
+		}
+		if request.Channel != "telegram" || !request.DryRun {
+			t.Fatalf("unexpected request: %+v", request)
+		}
+
+		_ = json.NewEncoder(w).Encode(WorkerTriggerResponse{
+			Success: true,
+			Mode:    "summary",
+			Message: "Summary task completed",
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL, server.URL, "ops")
+	c.HTTP = server.Client()
+
+	response, err := c.TriggerWorkerSummary(context.Background(), SummaryRunRequest{
+		Channel: "telegram",
+		DryRun:  true,
+	})
+	if err != nil {
+		t.Fatalf("TriggerWorkerSummary returned error: %v", err)
+	}
+	if response.Mode != "summary" {
+		t.Fatalf("unexpected response: %+v", response)
+	}
+}

--- a/scripts/summaries/send_telegram_summary.py
+++ b/scripts/summaries/send_telegram_summary.py
@@ -66,33 +66,33 @@ def main() -> int:
     if not content:
         raise ValueError("content is required")
 
-    config = load_config()
-    if payload.get("botToken"):
-        config["TELEGRAM_BOT_TOKEN"] = str(payload["botToken"])
-    if payload.get("chatId"):
-        config["TELEGRAM_CHAT_ID"] = str(payload["chatId"])
+    with contextlib.redirect_stdout(sys.stderr):
+        config = load_config()
+        if payload.get("botToken"):
+            config["TELEGRAM_BOT_TOKEN"] = str(payload["botToken"])
+        if payload.get("chatId"):
+            config["TELEGRAM_CHAT_ID"] = str(payload["chatId"])
 
-    tokens = parse_multi_account_config(config.get("TELEGRAM_BOT_TOKEN", ""))
-    chat_ids = parse_multi_account_config(config.get("TELEGRAM_CHAT_ID", ""))
-    valid, count = validate_paired_configs(
-        {"bot_token": tokens, "chat_id": chat_ids},
-        "Telegram",
-        required_keys=["bot_token", "chat_id"],
-    )
-    if not valid or count <= 0:
-        raise ValueError("Telegram configuration is missing bot token or chat id")
+        tokens = parse_multi_account_config(config.get("TELEGRAM_BOT_TOKEN", ""))
+        chat_ids = parse_multi_account_config(config.get("TELEGRAM_CHAT_ID", ""))
+        valid, count = validate_paired_configs(
+            {"bot_token": tokens, "chat_id": chat_ids},
+            "Telegram",
+            required_keys=["bot_token", "chat_id"],
+        )
+        if not valid or count <= 0:
+            raise ValueError("Telegram configuration is missing bot token or chat id")
 
-    max_accounts = config.get("MAX_ACCOUNTS_PER_CHANNEL", 3)
-    tokens = limit_accounts(tokens, max_accounts, "Telegram")
-    chat_ids = chat_ids[: len(tokens)]
-    split_content_func = build_splitter(content)
+        max_accounts = config.get("MAX_ACCOUNTS_PER_CHANNEL", 3)
+        tokens = limit_accounts(tokens, max_accounts, "Telegram")
+        chat_ids = chat_ids[: len(tokens)]
+        split_content_func = build_splitter(content)
 
-    sent = 0
-    for index, token in enumerate(tokens):
-        chat_id = chat_ids[index] if index < len(chat_ids) else ""
-        if not token or not chat_id:
-            continue
-        with contextlib.redirect_stdout(sys.stderr):
+        sent = 0
+        for index, token in enumerate(tokens):
+            chat_id = chat_ids[index] if index < len(chat_ids) else ""
+            if not token or not chat_id:
+                continue
             ok = send_to_telegram(
                 bot_token=token,
                 chat_id=chat_id,
@@ -100,8 +100,8 @@ def main() -> int:
                 report_type="Resume Ops Summary",
                 split_content_func=split_content_func,
             )
-        if ok:
-            sent += 1
+            if ok:
+                sent += 1
 
     if sent <= 0:
         raise RuntimeError("Telegram summary delivery failed")

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from apps.worker.profile_loader import ProfileLoader
+
+
+def test_load_profiles_uses_schedule_max_candidates(tmp_path) -> None:
+    config_dir = tmp_path / "profiles"
+    config_dir.mkdir()
+    (config_dir / "profile.yaml").write_text(
+        """
+id: summary-ready
+name: Summary Ready
+location: 东莞
+keywords:
+  - CNC
+schedule:
+  enabled: true
+  cron: "0 9 * * 1-5"
+  timezone: Asia/Hong_Kong
+  maxCandidates: 120
+  notifyOnlyOnNew: true
+""".strip(),
+        encoding="utf-8",
+    )
+
+    profiles = ProfileLoader(config_dir=str(config_dir)).load_profiles()
+
+    assert len(profiles) == 1
+    assert profiles[0]["limit"] == 120
+    assert profiles[0]["schedule"] == {
+        "enabled": True,
+        "cron": "0 9 * * 1-5",
+        "timezone": "Asia/Hong_Kong",
+        "maxCandidates": 120,
+        "notifyOnlyOnNew": True,
+    }
+
+
+def test_load_profiles_keeps_legacy_schedule_limit_fallback(tmp_path) -> None:
+    config_dir = tmp_path / "profiles"
+    config_dir.mkdir()
+    (config_dir / "legacy.yaml").write_text(
+        """
+id: legacy-limit
+name: Legacy Limit
+location: 东莞
+keywords:
+  - 销售
+schedule:
+  enabled: true
+  cron: "0 8 * * 1-5"
+  limit: 80
+""".strip(),
+        encoding="utf-8",
+    )
+
+    profiles = ProfileLoader(config_dir=str(config_dir)).load_profiles()
+
+    assert len(profiles) == 1
+    assert profiles[0]["limit"] == 80
+    assert profiles[0]["schedule"]["maxCandidates"] == 80

--- a/tests/test_resume_tasks.py
+++ b/tests/test_resume_tasks.py
@@ -148,6 +148,7 @@ def test_run_workspace_summary_posts_summary_request(monkeypatch) -> None:
         "period": "daily",
         "channel": "telegram",
         "dryRun": True,
+        "triggerSource": "worker_manual",
         "templateId": "summary-daily",
         "endAt": "2026-03-26T12:00:00Z",
     }
@@ -205,4 +206,5 @@ def test_add_workspace_summary_job_uses_env_config(monkeypatch) -> None:
     assert calls[0]["workspace_slug"] == "hr"
     assert calls[0]["channel"] == "telegram"
     assert calls[0]["dry_run"] is True
+    assert calls[0]["trigger_source"] == "worker_schedule"
     assert calls[0]["template_id"] == "summary-daily"


### PR DESCRIPTION
## Summary
- keep the Python Telegram summary bridge from polluting stdout with config logs
- harden the API bridge parser to accept the last JSON line defensively
- add focused bridge parsing coverage and verify a real Telegram send succeeds

## Testing
- bun x vitest run apps/api/src/services/summaries/summary-telegram-bridge.test.ts apps/api/src/routes/summaries.test.ts
- bun run --filter "@trends/api" typecheck
- make check
- go run . --output json --workspace dev worker summary run --channel telegram
- go run . --output json --workspace dev worker summary history --limit 2
- go run . --output json --workspace dev worker summary show 1a879083-1ab7-48ae-a798-3e368a718651