### PR TITLE
feat(summary): enrich telegram delivery audit

### DIFF
--- a/apps/api/src/routes/summaries.test.ts
+++ b/apps/api/src/routes/summaries.test.ts
@@ -398,7 +398,26 @@ describe("summary preview route", () => {
 
     const sendSpy = vi.spyOn(summaryTelegramBridge, "send").mockResolvedValue({
       ok: true,
+      channel: "telegram",
+      accountsConfigured: 1,
+      accountsSelected: 1,
+      accountsAttempted: 1,
       accountsSent: 1,
+      batchCountPerAccount: 2,
+      totalBatches: 2,
+      batchSizes: [3800, 240],
+      maxBytesPerBatch: 4000,
+      usedOverrideBotToken: false,
+      usedOverrideChatId: false,
+      accounts: [
+        {
+          index: 1,
+          chatIdHint: "***1234",
+          attempted: true,
+          sent: true,
+          batchesPlanned: 2,
+        },
+      ],
     });
 
     const app = createApp();
@@ -420,7 +439,41 @@ describe("summary preview route", () => {
       success: boolean;
       channel: string;
       dryRun: boolean;
-      delivery: { ok: boolean; accountsSent: number };
+      delivery: {
+        ok: boolean;
+        channel: string;
+        accountsConfigured: number;
+        accountsSelected: number;
+        accountsAttempted: number;
+        accountsSent: number;
+        batchCountPerAccount: number;
+        totalBatches: number;
+        batchSizes: number[];
+        maxBytesPerBatch: number;
+        usedOverrideBotToken: boolean;
+        usedOverrideChatId: boolean;
+        accounts: Array<{
+          index: number;
+          chatIdHint: string;
+          attempted: boolean;
+          sent: boolean;
+          batchesPlanned: number;
+        }>;
+      };
+      report: {
+        scopes?: {
+          sharedIngest: {
+            totals: {
+              newResumes: number;
+            };
+          };
+          workspaceActivity: {
+            totals: {
+              contactActions: number;
+            };
+          };
+        };
+      };
       run: {
         status: string;
         triggerSource: string;
@@ -430,7 +483,29 @@ describe("summary preview route", () => {
     expect(payload.success).toBe(true);
     expect(payload.channel).toBe("telegram");
     expect(payload.dryRun).toBe(false);
-    expect(payload.delivery).toEqual({ ok: true, accountsSent: 1 });
+    expect(payload.delivery).toEqual({
+      ok: true,
+      channel: "telegram",
+      accountsConfigured: 1,
+      accountsSelected: 1,
+      accountsAttempted: 1,
+      accountsSent: 1,
+      batchCountPerAccount: 2,
+      totalBatches: 2,
+      batchSizes: [3800, 240],
+      maxBytesPerBatch: 4000,
+      usedOverrideBotToken: false,
+      usedOverrideChatId: false,
+      accounts: [
+        {
+          index: 1,
+          chatIdHint: "***1234",
+          attempted: true,
+          sent: true,
+          batchesPlanned: 2,
+        },
+      ],
+    });
     expect(payload.report.scopes?.sharedIngest.totals.newResumes).toBe(2);
     expect(payload.report.scopes?.workspaceActivity.totals.contactActions).toBe(1);
     expect(payload.run).toMatchObject({

--- a/apps/api/src/routes/summaries.ts
+++ b/apps/api/src/routes/summaries.ts
@@ -103,6 +103,32 @@ const SummaryTriggerSourceSchema = z.enum([
 
 const SummaryChannelSchema = z.enum(["email", "wechat_work", "feishu", "telegram"]);
 
+const SummaryDeliveryAccountSchema = z.object({
+  index: z.number().int(),
+  chatIdHint: z.string(),
+  attempted: z.boolean(),
+  sent: z.boolean(),
+  batchesPlanned: z.number().int(),
+  skippedReason: z.string().optional(),
+});
+
+const SummaryDeliverySchema = z.object({
+  channel: SummaryChannelSchema.optional(),
+  ok: z.boolean().optional(),
+  messageId: z.string().optional(),
+  accountsConfigured: z.number().int().optional(),
+  accountsSelected: z.number().int().optional(),
+  accountsAttempted: z.number().int().optional(),
+  accountsSent: z.number().int().optional(),
+  batchCountPerAccount: z.number().int().optional(),
+  totalBatches: z.number().int().optional(),
+  batchSizes: z.array(z.number().int()).optional(),
+  maxBytesPerBatch: z.number().int().optional(),
+  usedOverrideBotToken: z.boolean().optional(),
+  usedOverrideChatId: z.boolean().optional(),
+  accounts: z.array(SummaryDeliveryAccountSchema).optional(),
+}).catchall(z.unknown());
+
 const StoredSummaryRunSchema = z.object({
   id: z.string(),
   workspaceSlug: z.string(),
@@ -118,7 +144,7 @@ const StoredSummaryRunSchema = z.object({
   finishedAt: z.string().optional(),
   report: SummaryReportSchema,
   content: z.string().optional(),
-  delivery: z.object({}).catchall(z.unknown()).optional(),
+  delivery: SummaryDeliverySchema.optional(),
   error: z.string().optional(),
 });
 
@@ -149,7 +175,7 @@ const SummaryRunResponseSchema = z.object({
   subject: z.string().optional(),
   report: SummaryReportSchema,
   content: z.string(),
-  delivery: z.object({}).catchall(z.unknown()).optional(),
+  delivery: SummaryDeliverySchema.optional(),
   run: StoredSummaryRunSchema,
 });
 

--- a/apps/api/src/services/summaries/summary-telegram-bridge.test.ts
+++ b/apps/api/src/services/summaries/summary-telegram-bridge.test.ts
@@ -4,21 +4,67 @@ import { parseSummaryTelegramBridgeOutput } from "./summary-telegram-bridge";
 
 describe("parseSummaryTelegramBridgeOutput", () => {
   it("parses clean JSON output", () => {
+    const payload = {
+      ok: true,
+      channel: "telegram" as const,
+      accountsConfigured: 1,
+      accountsSelected: 1,
+      accountsAttempted: 1,
+      accountsSent: 1,
+      batchCountPerAccount: 1,
+      totalBatches: 1,
+      batchSizes: [128],
+      maxBytesPerBatch: 4000,
+      usedOverrideBotToken: false,
+      usedOverrideChatId: false,
+      accounts: [
+        {
+          index: 1,
+          chatIdHint: "***1234",
+          attempted: true,
+          sent: true,
+          batchesPlanned: 1,
+        },
+      ],
+    };
     expect(
-      parseSummaryTelegramBridgeOutput('{"ok":true,"accountsSent":1}')
-    ).toEqual({ ok: true, accountsSent: 1 });
+      parseSummaryTelegramBridgeOutput(JSON.stringify(payload))
+    ).toEqual(payload);
   });
 
   it("parses the last JSON line when stdout includes leading logs", () => {
+    const payload = {
+      ok: true,
+      channel: "telegram" as const,
+      accountsConfigured: 1,
+      accountsSelected: 1,
+      accountsAttempted: 1,
+      accountsSent: 1,
+      batchCountPerAccount: 2,
+      totalBatches: 2,
+      batchSizes: [3920, 410],
+      maxBytesPerBatch: 4000,
+      usedOverrideBotToken: true,
+      usedOverrideChatId: true,
+      accounts: [
+        {
+          index: 1,
+          chatIdHint: "***5678",
+          attempted: true,
+          sent: true,
+          batchesPlanned: 2,
+        },
+      ],
+    };
     expect(
       parseSummaryTelegramBridgeOutput(
         [
           "配置文件加载成功: config/config.yaml",
           "通知渠道配置来源: Telegram(环境变量, 1个账号)",
-          '{"ok":true,"accountsSent":1}',
+          JSON.stringify(payload),
         ].join("\n")
       )
-    ).toEqual({ ok: true, accountsSent: 1 });
+    ).toEqual(payload);
   });
 
   it("throws when stdout contains no JSON payload", () => {

--- a/apps/api/src/services/summaries/summary-telegram-bridge.ts
+++ b/apps/api/src/services/summaries/summary-telegram-bridge.ts
@@ -9,9 +9,29 @@ export type SummaryTelegramBridgeRequest = {
   chatId?: string;
 };
 
+export type SummaryTelegramDeliveryAccount = {
+  index: number;
+  chatIdHint: string;
+  attempted: boolean;
+  sent: boolean;
+  batchesPlanned: number;
+  skippedReason?: string;
+};
+
 export type SummaryTelegramBridgeResult = {
   ok: boolean;
+  channel: "telegram";
+  accountsConfigured: number;
+  accountsSelected: number;
+  accountsAttempted: number;
   accountsSent: number;
+  batchCountPerAccount: number;
+  totalBatches: number;
+  batchSizes: number[];
+  maxBytesPerBatch: number;
+  usedOverrideBotToken: boolean;
+  usedOverrideChatId: boolean;
+  accounts: SummaryTelegramDeliveryAccount[];
 };
 
 type SummaryTelegramBridgeDependencies = {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4635,6 +4635,29 @@ export interface paths {
                                 };
                                 content?: string;
                                 delivery?: {
+                                    /** @enum {string} */
+                                    channel?: "email" | "wechat_work" | "feishu" | "telegram";
+                                    ok?: boolean;
+                                    messageId?: string;
+                                    accountsConfigured?: number;
+                                    accountsSelected?: number;
+                                    accountsAttempted?: number;
+                                    accountsSent?: number;
+                                    batchCountPerAccount?: number;
+                                    totalBatches?: number;
+                                    batchSizes?: number[];
+                                    maxBytesPerBatch?: number;
+                                    usedOverrideBotToken?: boolean;
+                                    usedOverrideChatId?: boolean;
+                                    accounts?: {
+                                        index: number;
+                                        chatIdHint: string;
+                                        attempted: boolean;
+                                        sent: boolean;
+                                        batchesPlanned: number;
+                                        skippedReason?: string;
+                                    }[];
+                                } & {
                                     [key: string]: unknown;
                                 };
                                 error?: string;
@@ -4809,6 +4832,29 @@ export interface paths {
                             };
                             content: string;
                             delivery?: {
+                                /** @enum {string} */
+                                channel?: "email" | "wechat_work" | "feishu" | "telegram";
+                                ok?: boolean;
+                                messageId?: string;
+                                accountsConfigured?: number;
+                                accountsSelected?: number;
+                                accountsAttempted?: number;
+                                accountsSent?: number;
+                                batchCountPerAccount?: number;
+                                totalBatches?: number;
+                                batchSizes?: number[];
+                                maxBytesPerBatch?: number;
+                                usedOverrideBotToken?: boolean;
+                                usedOverrideChatId?: boolean;
+                                accounts?: {
+                                    index: number;
+                                    chatIdHint: string;
+                                    attempted: boolean;
+                                    sent: boolean;
+                                    batchesPlanned: number;
+                                    skippedReason?: string;
+                                }[];
+                            } & {
                                 [key: string]: unknown;
                             };
                             run: {
@@ -4914,6 +4960,29 @@ export interface paths {
                                 };
                                 content?: string;
                                 delivery?: {
+                                    /** @enum {string} */
+                                    channel?: "email" | "wechat_work" | "feishu" | "telegram";
+                                    ok?: boolean;
+                                    messageId?: string;
+                                    accountsConfigured?: number;
+                                    accountsSelected?: number;
+                                    accountsAttempted?: number;
+                                    accountsSent?: number;
+                                    batchCountPerAccount?: number;
+                                    totalBatches?: number;
+                                    batchSizes?: number[];
+                                    maxBytesPerBatch?: number;
+                                    usedOverrideBotToken?: boolean;
+                                    usedOverrideChatId?: boolean;
+                                    accounts?: {
+                                        index: number;
+                                        chatIdHint: string;
+                                        attempted: boolean;
+                                        sent: boolean;
+                                        batchesPlanned: number;
+                                        skippedReason?: string;
+                                    }[];
+                                } & {
                                     [key: string]: unknown;
                                 };
                                 error?: string;
@@ -5073,6 +5142,29 @@ export interface paths {
                                 };
                                 content?: string;
                                 delivery?: {
+                                    /** @enum {string} */
+                                    channel?: "email" | "wechat_work" | "feishu" | "telegram";
+                                    ok?: boolean;
+                                    messageId?: string;
+                                    accountsConfigured?: number;
+                                    accountsSelected?: number;
+                                    accountsAttempted?: number;
+                                    accountsSent?: number;
+                                    batchCountPerAccount?: number;
+                                    totalBatches?: number;
+                                    batchSizes?: number[];
+                                    maxBytesPerBatch?: number;
+                                    usedOverrideBotToken?: boolean;
+                                    usedOverrideChatId?: boolean;
+                                    accounts?: {
+                                        index: number;
+                                        chatIdHint: string;
+                                        attempted: boolean;
+                                        sent: boolean;
+                                        batchesPlanned: number;
+                                        skippedReason?: string;
+                                    }[];
+                                } & {
                                     [key: string]: unknown;
                                 };
                                 error?: string;
@@ -5221,6 +5313,29 @@ export interface paths {
                                 };
                                 content?: string;
                                 delivery?: {
+                                    /** @enum {string} */
+                                    channel?: "email" | "wechat_work" | "feishu" | "telegram";
+                                    ok?: boolean;
+                                    messageId?: string;
+                                    accountsConfigured?: number;
+                                    accountsSelected?: number;
+                                    accountsAttempted?: number;
+                                    accountsSent?: number;
+                                    batchCountPerAccount?: number;
+                                    totalBatches?: number;
+                                    batchSizes?: number[];
+                                    maxBytesPerBatch?: number;
+                                    usedOverrideBotToken?: boolean;
+                                    usedOverrideChatId?: boolean;
+                                    accounts?: {
+                                        index: number;
+                                        chatIdHint: string;
+                                        attempted: boolean;
+                                        sent: boolean;
+                                        batchesPlanned: number;
+                                        skippedReason?: string;
+                                    }[];
+                                } & {
                                     [key: string]: unknown;
                                 };
                                 error?: string;

--- a/scripts/summaries/send_telegram_summary.py
+++ b/scripts/summaries/send_telegram_summary.py
@@ -13,16 +13,22 @@ from trendradar.core.config import (
     parse_multi_account_config,
     validate_paired_configs,
 )
-from trendradar.notification.batch import truncate_to_bytes
+from trendradar.notification.batch import (
+    add_batch_headers,
+    get_max_batch_header_size,
+    truncate_to_bytes,
+)
 from trendradar.notification.senders import send_to_telegram
+
+TELEGRAM_BATCH_BYTES = 4000
 
 
 def split_rendered_content(content: str, max_bytes: int) -> List[str]:
     normalized = content.replace("\r\n", "\n").strip()
     if not normalized:
-      return [""]
+        return [""]
     if len(normalized.encode("utf-8")) <= max_bytes:
-      return [normalized]
+        return [normalized]
 
     batches: List[str] = []
     current = ""
@@ -51,6 +57,13 @@ def split_rendered_content(content: str, max_bytes: int) -> List[str]:
     return batches or [normalized]
 
 
+def plan_telegram_batches(content: str, max_bytes: int = TELEGRAM_BATCH_BYTES) -> List[str]:
+    escaped_content = html.escape(content)
+    header_reserve = get_max_batch_header_size("telegram")
+    batches = split_rendered_content(escaped_content, max_bytes - header_reserve)
+    return add_batch_headers(batches, "telegram", max_bytes)
+
+
 def build_splitter(content: str):
     escaped_content = html.escape(content)
 
@@ -58,6 +71,14 @@ def build_splitter(content: str):
         return split_rendered_content(escaped_content, max_bytes)
 
     return split_content_func
+
+
+def mask_chat_id(chat_id: str) -> str:
+    normalized = str(chat_id or "").strip()
+    if not normalized:
+        return "(missing)"
+    suffix = normalized[-4:] if len(normalized) > 4 else normalized
+    return f"***{suffix}"
 
 
 def main() -> int:
@@ -87,12 +108,29 @@ def main() -> int:
         tokens = limit_accounts(tokens, max_accounts, "Telegram")
         chat_ids = chat_ids[: len(tokens)]
         split_content_func = build_splitter(content)
+        planned_batches = plan_telegram_batches(content)
+        batch_count_per_account = len(planned_batches)
+        batch_sizes = [len(batch.encode("utf-8")) for batch in planned_batches]
 
         sent = 0
+        attempted = 0
+        account_entries = []
         for index, token in enumerate(tokens):
             chat_id = chat_ids[index] if index < len(chat_ids) else ""
-            if not token or not chat_id:
+            attempted_account = bool(token and chat_id)
+            account_entry = {
+                "index": index + 1,
+                "chatIdHint": mask_chat_id(chat_id),
+                "attempted": attempted_account,
+                "sent": False,
+                "batchesPlanned": batch_count_per_account if attempted_account else 0,
+            }
+            if not attempted_account:
+                account_entry["skippedReason"] = "missing token or chat_id"
+                account_entries.append(account_entry)
                 continue
+
+            attempted += 1
             ok = send_to_telegram(
                 bot_token=token,
                 chat_id=chat_id,
@@ -102,11 +140,30 @@ def main() -> int:
             )
             if ok:
                 sent += 1
+                account_entry["sent"] = True
+            account_entries.append(account_entry)
 
     if sent <= 0:
         raise RuntimeError("Telegram summary delivery failed")
 
-    json.dump({"ok": True, "accountsSent": sent}, sys.stdout)
+    json.dump(
+        {
+            "ok": True,
+            "channel": "telegram",
+            "accountsConfigured": count,
+            "accountsSelected": len(tokens),
+            "accountsAttempted": attempted,
+            "accountsSent": sent,
+            "batchCountPerAccount": batch_count_per_account,
+            "totalBatches": batch_count_per_account * attempted,
+            "batchSizes": batch_sizes,
+            "maxBytesPerBatch": TELEGRAM_BATCH_BYTES,
+            "usedOverrideBotToken": bool(payload.get("botToken")),
+            "usedOverrideChatId": bool(payload.get("chatId")),
+            "accounts": account_entries,
+        },
+        sys.stdout,
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary
- enrich Telegram summary delivery metadata with per-account and per-batch audit details
- expose explicit optional delivery fields in summary route schemas and generated web API types
- keep the existing Telegram bridge transport and split-send behavior intact

## Validation
- uv run python -m py_compile scripts/summaries/send_telegram_summary.py
- bun x vitest run apps/api/src/services/summaries/summary-telegram-bridge.test.ts apps/api/src/routes/summaries.test.ts
- bun run --filter "@trends/api" typecheck
- npm --workspace @trends/web run gen:api
- make check