### PR TITLE
feat(cli): show summary delivery audit

### DIFF
--- a/packages/cli/cmd/worker.go
+++ b/packages/cli/cmd/worker.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/ptdevhk/trends/packages/cli/internal/client"
 	"github.com/spf13/cobra"
@@ -81,7 +82,7 @@ func newWorkerSummaryRunCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			headers := []string{"run_id", "status", "channel", "dry_run", "trigger_source", "window_end"}
+			headers := []string{"run_id", "status", "channel", "dry_run", "trigger_source", "window_end", "delivery"}
 			rows := [][]string{{
 				response.Run.ID,
 				response.Run.Status,
@@ -89,6 +90,7 @@ func newWorkerSummaryRunCmd() *cobra.Command {
 				boolToString(response.DryRun),
 				response.Run.TriggerSource,
 				response.Run.WindowEnd,
+				summaryDeliverySummary(response.Delivery),
 			}}
 			return writeOutput(cmd, headers, rows, response)
 		},
@@ -119,7 +121,7 @@ func newWorkerSummaryHistoryCmd() *cobra.Command {
 				return err
 			}
 
-			headers := []string{"id", "status", "channel", "dry_run", "trigger_source", "started_at", "window_end"}
+			headers := []string{"id", "status", "channel", "dry_run", "trigger_source", "started_at", "window_end", "delivery"}
 			rows := make([][]string, 0, len(response.Items))
 			for _, item := range response.Items {
 				rows = append(rows, []string{
@@ -130,6 +132,7 @@ func newWorkerSummaryHistoryCmd() *cobra.Command {
 					item.TriggerSource,
 					item.StartedAt,
 					item.WindowEnd,
+					summaryDeliverySummary(item.Delivery),
 				})
 			}
 			return writeOutput(cmd, headers, rows, response)
@@ -151,7 +154,7 @@ func newWorkerSummaryShowCmd() *cobra.Command {
 				return err
 			}
 
-			headers := []string{"id", "status", "channel", "dry_run", "trigger_source", "started_at", "finished_at"}
+			headers := []string{"id", "status", "channel", "dry_run", "trigger_source", "started_at", "finished_at", "delivery", "accounts", "error"}
 			rows := [][]string{{
 				response.Item.ID,
 				response.Item.Status,
@@ -160,6 +163,9 @@ func newWorkerSummaryShowCmd() *cobra.Command {
 				response.Item.TriggerSource,
 				response.Item.StartedAt,
 				response.Item.FinishedAt,
+				summaryDeliverySummary(response.Item.Delivery),
+				summaryDeliveryAccounts(response.Item.Delivery),
+				emptyDash(response.Item.Error),
 			}}
 			return writeOutput(cmd, headers, rows, response)
 		},
@@ -213,4 +219,73 @@ func newWorkerRunCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&once, "once", true, "Run once immediately")
 	return cmd
+}
+
+func summaryDeliverySummary(delivery *client.SummaryDelivery) string {
+	if delivery == nil {
+		return "-"
+	}
+
+	if delivery.MessageID != "" {
+		return "message:" + delivery.MessageID
+	}
+
+	if delivery.AccountsSelected > 0 || delivery.AccountsAttempted > 0 || delivery.AccountsSent > 0 {
+		denominator := delivery.AccountsAttempted
+		if denominator == 0 {
+			denominator = delivery.AccountsSelected
+		}
+		if denominator == 0 {
+			denominator = delivery.AccountsConfigured
+		}
+
+		parts := []string{fmt.Sprintf("%d/%d sent", delivery.AccountsSent, denominator)}
+		if delivery.TotalBatches > 0 {
+			parts = append(parts, fmt.Sprintf("%d batches", delivery.TotalBatches))
+		}
+		if delivery.UsedOverrideBotToken || delivery.UsedOverrideChatID {
+			parts = append(parts, "override")
+		}
+		return strings.Join(parts, ", ")
+	}
+
+	if delivery.Channel != "" {
+		return delivery.Channel
+	}
+	if delivery.OK {
+		return "ok"
+	}
+
+	return "available"
+}
+
+func summaryDeliveryAccounts(delivery *client.SummaryDelivery) string {
+	if delivery == nil || len(delivery.Accounts) == 0 {
+		return "-"
+	}
+
+	parts := make([]string, 0, len(delivery.Accounts))
+	for _, account := range delivery.Accounts {
+		status := "skipped"
+		if account.Sent {
+			status = "sent"
+		} else if account.Attempted {
+			status = "failed"
+		}
+
+		part := fmt.Sprintf("%d:%s:%s", account.Index, account.ChatIDHint, status)
+		if account.BatchesPlanned > 0 {
+			part += fmt.Sprintf("(%db)", account.BatchesPlanned)
+		}
+		parts = append(parts, part)
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+func emptyDash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
 }

--- a/packages/cli/cmd/worker_summary_test.go
+++ b/packages/cli/cmd/worker_summary_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -112,6 +113,51 @@ func TestWorkerSummaryRunViaWorkerCommandWritesJSON(t *testing.T) {
 	}
 }
 
+func TestWorkerSummaryRunCommandWritesTableDeliverySummary(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success":    true,
+			"channel":    "telegram",
+			"dryRun":     false,
+			"templateId": "summary-daily",
+			"delivery": map[string]any{
+				"channel":              "telegram",
+				"ok":                   true,
+				"accountsConfigured":   1,
+				"accountsSelected":     1,
+				"accountsAttempted":    1,
+				"accountsSent":         1,
+				"batchCountPerAccount": 2,
+				"totalBatches":         2,
+			},
+			"run": map[string]any{
+				"id":            "run-2",
+				"status":        "sent",
+				"triggerSource": "api_manual",
+				"windowEnd":     "2026-03-26T12:00:00Z",
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+	setCLIOutput(t, "table")
+
+	cmd := newWorkerSummaryRunCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("worker summary run command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "1/1 sent, 2 batches") {
+		t.Fatalf("expected delivery summary in table output, got: %s", text)
+	}
+}
+
 func TestWorkerSummaryHistoryCommandWritesJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/summaries/runs" {
@@ -156,6 +202,43 @@ func TestWorkerSummaryHistoryCommandWritesJSON(t *testing.T) {
 	}
 }
 
+func TestWorkerSummaryHistoryCommandWritesTableDeliverySummary(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"items": []map[string]any{{
+				"id":            "run-3",
+				"status":        "sent",
+				"triggerSource": "worker_schedule",
+				"delivery": map[string]any{
+					"channel":           "telegram",
+					"accountsAttempted": 1,
+					"accountsSent":      1,
+					"totalBatches":      3,
+				},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+	setCLIOutput(t, "table")
+
+	cmd := newWorkerSummaryHistoryCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("worker summary history command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "1/1 sent, 3 batches") {
+		t.Fatalf("expected delivery summary in history table output, got: %s", text)
+	}
+}
+
 func TestWorkerSummaryShowCommandWritesJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/summaries/runs/run-7" {
@@ -194,5 +277,70 @@ func TestWorkerSummaryShowCommandWritesJSON(t *testing.T) {
 	}
 	if item["id"] != "run-7" || item["error"] != "boom" {
 		t.Fatalf("unexpected item payload: %#v", payload)
+	}
+}
+
+func TestWorkerSummaryShowCommandWritesTableDeliveryDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"item": map[string]any{
+				"id":            "run-8",
+				"status":        "sent",
+				"channel":       "telegram",
+				"triggerSource": "api_manual",
+				"error":         "",
+				"delivery": map[string]any{
+					"channel":              "telegram",
+					"ok":                   true,
+					"accountsConfigured":   2,
+					"accountsSelected":     2,
+					"accountsAttempted":    1,
+					"accountsSent":         1,
+					"batchCountPerAccount": 2,
+					"totalBatches":         2,
+					"usedOverrideChatId":   true,
+					"accounts": []map[string]any{
+						{
+							"index":          1,
+							"chatIdHint":     "***1234",
+							"attempted":      true,
+							"sent":           true,
+							"batchesPlanned": 2,
+						},
+						{
+							"index":          2,
+							"chatIdHint":     "***5678",
+							"attempted":      false,
+							"sent":           false,
+							"batchesPlanned": 0,
+							"skippedReason":  "missing token or chat_id",
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+	setCLIOutput(t, "table")
+
+	cmd := newWorkerSummaryShowCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"run-8"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("worker summary show command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "1/1 sent, 2 batches, override") {
+		t.Fatalf("expected delivery summary in show table output, got: %s", text)
+	}
+	if !strings.Contains(text, "1:***1234:sent(2b), 2:***5678:skipped") {
+		t.Fatalf("expected account detail summary in show table output, got: %s", text)
 	}
 }

--- a/packages/cli/internal/client/worker.go
+++ b/packages/cli/internal/client/worker.go
@@ -24,23 +24,49 @@ type WorkerTriggerResponse struct {
 	Message    string `json:"message"`
 }
 
+type SummaryDeliveryAccount struct {
+	Index          int    `json:"index"`
+	ChatIDHint     string `json:"chatIdHint"`
+	Attempted      bool   `json:"attempted"`
+	Sent           bool   `json:"sent"`
+	BatchesPlanned int    `json:"batchesPlanned"`
+	SkippedReason  string `json:"skippedReason,omitempty"`
+}
+
+type SummaryDelivery struct {
+	Channel              string                   `json:"channel,omitempty"`
+	OK                   bool                     `json:"ok,omitempty"`
+	MessageID            string                   `json:"messageId,omitempty"`
+	AccountsConfigured   int                      `json:"accountsConfigured,omitempty"`
+	AccountsSelected     int                      `json:"accountsSelected,omitempty"`
+	AccountsAttempted    int                      `json:"accountsAttempted,omitempty"`
+	AccountsSent         int                      `json:"accountsSent,omitempty"`
+	BatchCountPerAccount int                      `json:"batchCountPerAccount,omitempty"`
+	TotalBatches         int                      `json:"totalBatches,omitempty"`
+	BatchSizes           []int                    `json:"batchSizes,omitempty"`
+	MaxBytesPerBatch     int                      `json:"maxBytesPerBatch,omitempty"`
+	UsedOverrideBotToken bool                     `json:"usedOverrideBotToken,omitempty"`
+	UsedOverrideChatID   bool                     `json:"usedOverrideChatId,omitempty"`
+	Accounts             []SummaryDeliveryAccount `json:"accounts,omitempty"`
+}
+
 type SummaryRun struct {
-	ID            string         `json:"id"`
-	WorkspaceSlug string         `json:"workspaceSlug"`
-	Period        string         `json:"period"`
-	TriggerSource string         `json:"triggerSource"`
-	Status        string         `json:"status"`
-	Channel       string         `json:"channel,omitempty"`
-	TemplateID    string         `json:"templateId,omitempty"`
-	DryRun        bool           `json:"dryRun"`
-	WindowStart   string         `json:"windowStart"`
-	WindowEnd     string         `json:"windowEnd"`
-	StartedAt     string         `json:"startedAt"`
-	FinishedAt    string         `json:"finishedAt,omitempty"`
-	Report        map[string]any `json:"report"`
-	Content       string         `json:"content,omitempty"`
-	Delivery      map[string]any `json:"delivery,omitempty"`
-	Error         string         `json:"error,omitempty"`
+	ID            string           `json:"id"`
+	WorkspaceSlug string           `json:"workspaceSlug"`
+	Period        string           `json:"period"`
+	TriggerSource string           `json:"triggerSource"`
+	Status        string           `json:"status"`
+	Channel       string           `json:"channel,omitempty"`
+	TemplateID    string           `json:"templateId,omitempty"`
+	DryRun        bool             `json:"dryRun"`
+	WindowStart   string           `json:"windowStart"`
+	WindowEnd     string           `json:"windowEnd"`
+	StartedAt     string           `json:"startedAt"`
+	FinishedAt    string           `json:"finishedAt,omitempty"`
+	Report        map[string]any   `json:"report"`
+	Content       string           `json:"content,omitempty"`
+	Delivery      *SummaryDelivery `json:"delivery,omitempty"`
+	Error         string           `json:"error,omitempty"`
 }
 
 type SummaryRunRequest struct {
@@ -59,15 +85,15 @@ type SummaryRunRequest struct {
 }
 
 type SummaryRunInvocationResponse struct {
-	Success    bool           `json:"success"`
-	Channel    string         `json:"channel"`
-	DryRun     bool           `json:"dryRun"`
-	TemplateID string         `json:"templateId"`
-	Subject    string         `json:"subject,omitempty"`
-	Report     map[string]any `json:"report"`
-	Content    string         `json:"content"`
-	Delivery   map[string]any `json:"delivery,omitempty"`
-	Run        SummaryRun     `json:"run"`
+	Success    bool             `json:"success"`
+	Channel    string           `json:"channel"`
+	DryRun     bool             `json:"dryRun"`
+	TemplateID string           `json:"templateId"`
+	Subject    string           `json:"subject,omitempty"`
+	Report     map[string]any   `json:"report"`
+	Content    string           `json:"content"`
+	Delivery   *SummaryDelivery `json:"delivery,omitempty"`
+	Run        SummaryRun       `json:"run"`
 }
 
 type SummaryRunListResponse struct {


### PR DESCRIPTION
## Summary
- surface summary delivery audit details in the default CLI output for worker summary run, history, and show
- type the summary delivery payload in the Go client instead of treating it as an unstructured map
- add table-output coverage so the operator-facing path is tested, not just JSON mode

## Validation
- go test ./internal/client ./cmd
- make check