### PR TITLE
feat(summary): add weekly summary periods

### DIFF
--- a/apps/api/src/routes/summaries.test.ts
+++ b/apps/api/src/routes/summaries.test.ts
@@ -31,12 +31,13 @@ function createFixtureRoot(): string {
     path.join(root, "config", "notifications", "summary-daily.md"),
     [
       "---",
-      'subject: "Daily Ops Summary {{workspaceSlug}}"',
+      'subject: "{{summaryTitle}} {{workspaceSlug}}"',
       "---",
       "",
-      "# Daily Ops Summary",
+      "# {{summaryTitle}}",
       "",
       "- Workspace: {{workspaceSlug}}",
+      "- Period: {{period}}",
       "- Generated: {{generatedAt}}",
       "",
       "{{#if scopes.sharedIngest}}",
@@ -59,6 +60,12 @@ function createFixtureRoot(): string {
       "{{#each scopes.workspaceActivity.breakdowns.actionsByType}}",
       "- {{this.label}}: {{this.count}}",
       "{{/each}}",
+      "{{/if}}",
+      "",
+      "{{#if comparison}}",
+      "## Previous Period Comparison",
+      "- Previous Window Start: {{comparison.previousWindow.startAt}}",
+      "- Previous Window End: {{comparison.previousWindow.endAt}}",
       "{{/if}}",
       "",
       "_Generated at {{timestamp}}_",
@@ -227,6 +234,17 @@ describe("summary preview route", () => {
       success: boolean;
       report: {
         workspaceSlug: string;
+        comparison?: {
+          previousWindow: {
+            startAt: string;
+            endAt: string;
+          };
+          totalsDelta: {
+            sharedIngest: {
+              newResumes: number;
+            };
+          };
+        };
         totals: Record<string, number>;
         scopes?: {
           sharedIngest: {
@@ -245,6 +263,7 @@ describe("summary preview route", () => {
       };
       markdown: string;
       run: {
+        period: string;
         status: string;
         triggerSource: string;
         dryRun: boolean;
@@ -285,17 +304,23 @@ describe("summary preview route", () => {
     ]);
     expect(payload.markdown).toContain("## Shared Ingest Totals");
     expect(payload.markdown).toContain("## Workspace Activity");
+    expect(payload.markdown).toContain("## Previous Period Comparison");
+    expect(payload.report.comparison?.totalsDelta.sharedIngest.newResumes).toBe(0);
     expect(payload.run).toMatchObject({
+      period: "daily",
       status: "previewed",
       triggerSource: "api_preview",
       dryRun: true,
     });
-    expect(calls.map((call) => call.pathName)).toEqual([
-      "resumes:getSummaryWindow",
-      "candidate_status:list",
-      "resume_tasks:getSummaryWindow",
-    ]);
-    expect(calls[1]?.args.workspaceSlug).toBe("hr");
+    expect(calls).toHaveLength(6);
+    expect(calls.filter((call) => call.pathName === "resumes:getSummaryWindow")).toHaveLength(2);
+    expect(calls.filter((call) => call.pathName === "candidate_status:list")).toHaveLength(2);
+    expect(calls.filter((call) => call.pathName === "resume_tasks:getSummaryWindow")).toHaveLength(2);
+    expect(
+      calls
+        .filter((call) => call.pathName === "candidate_status:list")
+        .every((call) => call.args.workspaceSlug === "hr"),
+    ).toBe(true);
   });
 
   it("supports summary run dry-runs without sending", async () => {
@@ -360,6 +385,7 @@ describe("summary preview route", () => {
     expect(payload.subject).toBe("Daily Ops Summary hr");
     expect(payload.content).toContain("## Shared Ingest Totals");
     expect(payload.content).toContain("## Workspace Activity");
+    expect(payload.content).toContain("## Previous Period Comparison");
     expect(payload.delivery).toBeUndefined();
     expect(payload.run).toMatchObject({
       status: "dry_run",
@@ -517,6 +543,116 @@ describe("summary preview route", () => {
     expect(sendSpy.mock.calls[0]?.[0].content).toContain("# Daily Ops Summary");
   });
 
+  it("supports weekly previews and persists the weekly run period", async () => {
+    root = createFixtureRoot();
+    const { createApp } = await loadSummaryModules(root);
+
+    const currentWeekStart = Date.parse("2026-03-22T16:00:00.000Z");
+    const previousWeekStart = Date.parse("2026-03-15T16:00:00.000Z");
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      if (call.pathName === "resumes:getSummaryWindow") {
+        if (call.args.fromTimestamp === currentWeekStart) {
+          return convexSuccess({ total: 7, bySource: [{ key: "seek", count: 7 }] });
+        }
+        if (call.args.fromTimestamp === previousWeekStart) {
+          return convexSuccess({ total: 3, bySource: [{ key: "job5156", count: 3 }] });
+        }
+      }
+
+      if (call.pathName === "candidate_status:list") {
+        return convexSuccess([]);
+      }
+
+      if (call.pathName === "resume_tasks:getSummaryWindow") {
+        if (call.args.fromTimestamp === currentWeekStart) {
+          return convexSuccess({
+            total: 2,
+            byStatus: [
+              { key: "completed", count: 1 },
+              { key: "failed", count: 1 },
+            ],
+          });
+        }
+        if (call.args.fromTimestamp === previousWeekStart) {
+          return convexSuccess({
+            total: 1,
+            byStatus: [{ key: "completed", count: 1 }],
+          });
+        }
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/summaries/preview", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        period: "weekly",
+        endAt: "2026-03-26T04:00:00.000Z",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      report: {
+        period: string;
+        window: {
+          startAt: string;
+          endAt: string;
+          timezone: string;
+        };
+        comparison?: {
+          previousWindow: {
+            startAt: string;
+            endAt: string;
+            timezone: string;
+          };
+          totalsDelta: {
+            sharedIngest: {
+              newResumes: number;
+              collectionTasksCompleted: number;
+              collectionTasksFailed: number;
+            };
+          };
+        };
+      };
+      markdown: string;
+      run: {
+        period: string;
+      };
+    };
+
+    expect(payload.report.period).toBe("weekly");
+    expect(payload.report.window).toEqual({
+      startAt: "2026-03-23T00:00:00+08:00",
+      endAt: "2026-03-30T00:00:00+08:00",
+      timezone: "Asia/Hong_Kong",
+    });
+    expect(payload.report.comparison).toMatchObject({
+      previousWindow: {
+        startAt: "2026-03-16T00:00:00+08:00",
+        endAt: "2026-03-23T00:00:00+08:00",
+        timezone: "Asia/Hong_Kong",
+      },
+      totalsDelta: {
+        sharedIngest: {
+          newResumes: 4,
+          collectionTasksCompleted: 0,
+          collectionTasksFailed: 1,
+        },
+      },
+    });
+    expect(payload.markdown).toContain("# Weekly Ops Summary");
+    expect(payload.run.period).toBe("weekly");
+  });
+
   it("lists and fetches persisted summary runs for the active workspace", async () => {
     root = createFixtureRoot();
     const {
@@ -609,6 +745,7 @@ describe("summary preview route", () => {
       runPayload.run.id,
     ].sort());
     expect(listPayload.items.every((item) => item.workspaceSlug === "hr")).toBe(true);
+    expect(listPayload.items.every((item) => item.period === "daily")).toBe(true);
 
     const detailResponse = await app.request(`/api/summaries/runs/${runPayload.run.id}`, {
       method: "GET",

--- a/apps/api/src/routes/summaries.ts
+++ b/apps/api/src/routes/summaries.ts
@@ -15,6 +15,7 @@ const app = new OpenAPIHono();
 const summaryDataService = new SummaryDataService();
 const summaryRenderer = new SummaryRenderer();
 const workspaceSummaryRunStorage = new WorkspaceSummaryRunStorage();
+const SummaryPeriodSchema = z.enum(["daily", "weekly"]);
 
 const SummaryCountEntrySchema = z.object({
   key: z.string(),
@@ -73,15 +74,26 @@ const SummaryScopesSchema = z.object({
   }),
 });
 
+const SummaryWindowSchema = z.object({
+  startAt: z.string(),
+  endAt: z.string(),
+  timezone: z.string(),
+});
+
+const SummaryComparisonSchema = z.object({
+  previousWindow: SummaryWindowSchema,
+  totalsDelta: z.object({
+    sharedIngest: SummarySharedIngestTotalsSchema,
+    workspaceActivity: SummaryWorkspaceActivityTotalsSchema,
+  }),
+});
+
 const SummaryReportSchema = z.object({
   workspaceSlug: z.string(),
-  period: z.literal("daily"),
+  period: SummaryPeriodSchema,
   generatedAt: z.string(),
-  window: z.object({
-    startAt: z.string(),
-    endAt: z.string(),
-    timezone: z.string(),
-  }),
+  window: SummaryWindowSchema,
+  comparison: SummaryComparisonSchema.optional(),
   totals: SummaryTotalsSchema,
   breakdowns: SummaryBreakdownsSchema,
   scopes: SummaryScopesSchema.optional(),
@@ -90,7 +102,7 @@ const SummaryReportSchema = z.object({
 
 const SummaryPreviewRequestSchema = z.object({
   workspaceSlug: z.string().min(1).optional(),
-  period: z.literal("daily").default("daily"),
+  period: SummaryPeriodSchema.default("daily"),
   endAt: z.string().datetime({ offset: true }).optional(),
 });
 
@@ -132,7 +144,7 @@ const SummaryDeliverySchema = z.object({
 const StoredSummaryRunSchema = z.object({
   id: z.string(),
   workspaceSlug: z.string(),
-  period: z.literal("daily"),
+  period: SummaryPeriodSchema,
   triggerSource: SummaryTriggerSourceSchema,
   status: z.enum(["previewed", "dry_run", "sent", "failed"]),
   channel: SummaryChannelSchema.optional(),
@@ -237,7 +249,7 @@ function toPublicSummaryRun(run: StoredWorkspaceSummaryRun): z.infer<typeof Stor
       ? run.report
       : {
         workspaceSlug: run.workspaceSlug,
-        period: "daily",
+        period: run.period,
         generatedAt: run.finishedAt ?? run.startedAt,
         window: {
           startAt: run.windowStart,
@@ -280,7 +292,7 @@ const previewRoute = createRoute({
   method: "post",
   path: "/preview",
   tags: ["Summaries"],
-  summary: "Preview a workspace daily summary",
+  summary: "Preview a workspace summary",
   request: {
     body: {
       content: {
@@ -323,6 +335,7 @@ app.openapi(previewRoute, async (c) => {
     const run = workspaceSummaryRunStorage.createRun({
       id: randomUUID(),
       workspaceSlug,
+      period: report.period,
       triggerSource: "api_preview",
       status: "previewed",
       dryRun: true,
@@ -351,7 +364,7 @@ const runRoute = createRoute({
   method: "post",
   path: "/run",
   tags: ["Summaries"],
-  summary: "Render and optionally send a workspace daily summary",
+  summary: "Render and optionally send a workspace summary",
   request: {
     body: {
       content: {
@@ -418,6 +431,7 @@ app.openapi(runRoute, async (c) => {
     const run = workspaceSummaryRunStorage.createRun({
       id: runId,
       workspaceSlug,
+      period: report.period,
       triggerSource,
       status: dispatched.dryRun ? "dry_run" : "sent",
       channel: dispatched.channel,
@@ -446,6 +460,7 @@ app.openapi(runRoute, async (c) => {
       workspaceSummaryRunStorage.createRun({
         id: randomUUID(),
         workspaceSlug,
+        period: report.period,
         triggerSource,
         status: "failed",
         channel,

--- a/apps/api/src/routes/worker.test.ts
+++ b/apps/api/src/routes/worker.test.ts
@@ -30,6 +30,7 @@ describe("worker proxy routes", () => {
     const app = createApp();
     const body = JSON.stringify({
       workspaceSlug: "hr",
+      period: "weekly",
       channel: "telegram",
       dryRun: true,
       templateId: "summary-daily",

--- a/apps/api/src/services/__tests__/timezone.test.ts
+++ b/apps/api/src/services/__tests__/timezone.test.ts
@@ -8,6 +8,8 @@ import {
   DEFAULT_TIMEZONE,
   formatDateInTimezone,
   formatIsoOffsetInTimezone,
+  getLocalDatePartsInTimezone,
+  resolveLocalMidnightUtc,
   resolveTimezone,
 } from "../timezone";
 
@@ -83,5 +85,43 @@ describe("timezone formatting helpers", () => {
   it("formats date key in target timezone to avoid UTC day shifts", () => {
     const dateKey = formatDateInTimezone("2026-02-11T23:30:00Z", "Asia/Hong_Kong");
     expect(dateKey).toBe("2026-02-12");
+  });
+
+  it("reads local date parts in the target timezone", () => {
+    expect(getLocalDatePartsInTimezone("2026-02-11T23:30:00Z", "Asia/Hong_Kong")).toEqual({
+      year: 2026,
+      month: 2,
+      day: 12,
+    });
+  });
+
+  it("resolves local midnight in a non-DST timezone", () => {
+    const resolved = resolveLocalMidnightUtc(
+      { year: 2026, month: 3, day: 23 },
+      "Asia/Hong_Kong",
+    );
+
+    expect(resolved.toISOString()).toBe("2026-03-22T16:00:00.000Z");
+    expect(formatIsoOffsetInTimezone(resolved, "Asia/Hong_Kong")).toBe("2026-03-23T00:00:00+08:00");
+  });
+
+  it("resolves local midnight across the spring DST transition", () => {
+    const resolved = resolveLocalMidnightUtc(
+      { year: 2026, month: 3, day: 30 },
+      "Europe/London",
+    );
+
+    expect(resolved.toISOString()).toBe("2026-03-29T23:00:00.000Z");
+    expect(formatIsoOffsetInTimezone(resolved, "Europe/London")).toBe("2026-03-30T00:00:00+01:00");
+  });
+
+  it("resolves local midnight after the fall DST transition", () => {
+    const resolved = resolveLocalMidnightUtc(
+      { year: 2026, month: 10, day: 26 },
+      "Europe/London",
+    );
+
+    expect(resolved.toISOString()).toBe("2026-10-26T00:00:00.000Z");
+    expect(formatIsoOffsetInTimezone(resolved, "Europe/London")).toBe("2026-10-26T00:00:00+00:00");
   });
 });

--- a/apps/api/src/services/summaries/summary-data-service.test.ts
+++ b/apps/api/src/services/summaries/summary-data-service.test.ts
@@ -116,4 +116,127 @@ describe("SummaryDataService", () => {
       "Workspace activity totals cover candidate-status updates and persisted workspace-linked actions only.",
     ]);
   });
+
+  it("builds a weekly report with previous-period comparison totals", async () => {
+    const currentWeekStart = Date.parse("2026-03-22T16:00:00.000Z");
+    const previousWeekStart = Date.parse("2026-03-15T16:00:00.000Z");
+    const service = new SummaryDataService({
+      now: () => new Date("2026-03-26T04:00:00.000Z"),
+      actionStorage: {
+        summarizeActionsInWindow: ({ startAt }) => {
+          if (startAt === "2026-03-23T00:00:00+08:00") {
+            return {
+              total: 4,
+              breakdown: [
+                { actionType: "shortlist", count: 3 },
+                { actionType: "contact", count: 1 },
+              ],
+            };
+          }
+
+          return {
+            total: 3,
+            breakdown: [
+              { actionType: "shortlist", count: 1 },
+              { actionType: "reject", count: 2 },
+            ],
+          };
+        },
+      },
+      queryConvex: async (pathName, args) => {
+        if (pathName === "resumes:getSummaryWindow") {
+          if (args.fromTimestamp === currentWeekStart) {
+            return {
+              total: 8,
+              bySource: [
+                { key: "seek", count: 5 },
+                { key: "job5156", count: 3 },
+              ],
+            };
+          }
+
+          if (args.fromTimestamp === previousWeekStart) {
+            return {
+              total: 5,
+              bySource: [
+                { key: "job5156", count: 3 },
+                { key: "seek", count: 2 },
+              ],
+            };
+          }
+        }
+
+        if (pathName === "candidate_status:list") {
+          return [
+            { status: "interviewing", updatedAt: Date.parse("2026-03-24T00:00:00.000Z") },
+            { status: "offer", updatedAt: Date.parse("2026-03-25T10:00:00.000Z") },
+            { status: "offer", updatedAt: Date.parse("2026-03-18T10:00:00.000Z") },
+          ];
+        }
+
+        if (pathName === "resume_tasks:getSummaryWindow") {
+          if (args.fromTimestamp === currentWeekStart) {
+            return {
+              total: 3,
+              byStatus: [
+                { key: "completed", count: 2 },
+                { key: "failed", count: 1 },
+              ],
+            };
+          }
+
+          if (args.fromTimestamp === previousWeekStart) {
+            return {
+              total: 1,
+              byStatus: [{ key: "completed", count: 1 }],
+            };
+          }
+        }
+
+        throw new Error(`Unexpected Convex path: ${pathName}`);
+      },
+    });
+
+    const report = await service.buildSummaryReport({
+      workspaceSlug: "hr",
+      period: "weekly",
+      endAt: "2026-03-26T04:00:00.000Z",
+    });
+
+    expect(report.period).toBe("weekly");
+    expect(report.window).toEqual({
+      startAt: "2026-03-23T00:00:00+08:00",
+      endAt: "2026-03-30T00:00:00+08:00",
+      timezone: "Asia/Hong_Kong",
+    });
+    expect(report.totals).toEqual({
+      newResumes: 8,
+      candidateStatusUpdates: 2,
+      shortlistActions: 3,
+      rejectActions: 0,
+      contactActions: 1,
+      collectionTasksCompleted: 2,
+      collectionTasksFailed: 1,
+    });
+    expect(report.comparison).toEqual({
+      previousWindow: {
+        startAt: "2026-03-16T00:00:00+08:00",
+        endAt: "2026-03-23T00:00:00+08:00",
+        timezone: "Asia/Hong_Kong",
+      },
+      totalsDelta: {
+        sharedIngest: {
+          newResumes: 3,
+          collectionTasksCompleted: 1,
+          collectionTasksFailed: 1,
+        },
+        workspaceActivity: {
+          candidateStatusUpdates: 1,
+          shortlistActions: 2,
+          rejectActions: -2,
+          contactActions: 1,
+        },
+      },
+    });
+  });
 });

--- a/apps/api/src/services/summaries/summary-data-service.ts
+++ b/apps/api/src/services/summaries/summary-data-service.ts
@@ -1,10 +1,13 @@
 import type {
+  SummaryComparison,
   SummaryCountEntry,
   SummaryPeriod,
   SummaryReport,
   SummaryScopes,
+  SummarySharedIngestTotals,
   SummaryTotals,
   SummaryWindow,
+  SummaryWorkspaceActivityTotals,
 } from "@trends/shared";
 
 import {
@@ -13,7 +16,12 @@ import {
 } from "../action-storage.js";
 import { config } from "../config.js";
 import { resolveConvexUrl } from "../resume-import-service.js";
-import { formatIsoOffsetInTimezone } from "../timezone.js";
+import {
+  formatIsoOffsetInTimezone,
+  getLocalDatePartsInTimezone,
+  resolveLocalMidnightUtc,
+  type LocalDateParts,
+} from "../timezone.js";
 
 type ConvexSummaryEntry = {
   key: string;
@@ -35,6 +43,25 @@ type SummaryDataServiceDependencies = {
   now?: () => Date;
   queryConvex?: (pathName: string, args: Record<string, unknown>) => Promise<unknown>;
 };
+
+type SummaryWindowRange = {
+  fromTimestamp: number;
+  toTimestamp: number;
+  window: SummaryWindow;
+};
+
+type SummaryWindowSet = {
+  current: SummaryWindowRange;
+  previous: SummaryWindowRange;
+};
+
+type SummaryMetrics = {
+  totals: SummaryTotals;
+  breakdowns: SummaryReport["breakdowns"];
+  scopes: SummaryScopes;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const ACTION_LABELS: Record<CandidateActionType, string> = {
   star: "Star",
@@ -138,22 +165,107 @@ function buildWindow(params: {
   endAt?: string;
   now: () => Date;
   timezone: string;
-}): { fromTimestamp: number; toTimestamp: number; window: SummaryWindow } {
-  const endDate = params.endAt ? new Date(params.endAt) : params.now();
-  if (Number.isNaN(endDate.getTime())) {
+}): SummaryWindowSet {
+  const anchorDate = params.endAt ? new Date(params.endAt) : params.now();
+  if (Number.isNaN(anchorDate.getTime())) {
     throw new Error("Invalid endAt value");
   }
 
-  const durationMs = params.period === "daily" ? 24 * 60 * 60 * 1000 : 0;
-  const startDate = new Date(endDate.getTime() - durationMs);
+  if (params.period === "daily") {
+    const currentEnd = anchorDate;
+    const currentStart = new Date(currentEnd.getTime() - DAY_MS);
+    const previousEnd = currentStart;
+    const previousStart = new Date(previousEnd.getTime() - DAY_MS);
+    return {
+      current: buildWindowRange(currentStart, currentEnd, params.timezone),
+      previous: buildWindowRange(previousStart, previousEnd, params.timezone),
+    };
+  }
 
+  const localAnchorDate = getLocalDatePartsInTimezone(anchorDate, params.timezone);
+  const currentWeekStart = getWeekStartLocalDate(localAnchorDate);
+  const currentWeekEnd = shiftLocalDateParts(currentWeekStart, 7);
+  const previousWeekStart = shiftLocalDateParts(currentWeekStart, -7);
+
+  const currentStart = resolveLocalMidnightUtc(currentWeekStart, params.timezone);
+  const currentEnd = resolveLocalMidnightUtc(currentWeekEnd, params.timezone);
+  const previousStart = resolveLocalMidnightUtc(previousWeekStart, params.timezone);
+  return {
+    current: buildWindowRange(currentStart, currentEnd, params.timezone),
+    previous: buildWindowRange(previousStart, currentStart, params.timezone),
+  };
+}
+
+function buildWindowRange(startDate: Date, endDate: Date, timezone: string): SummaryWindowRange {
   return {
     fromTimestamp: startDate.getTime(),
     toTimestamp: endDate.getTime(),
-    window: {
-      startAt: formatIsoOffsetInTimezone(startDate, params.timezone),
-      endAt: formatIsoOffsetInTimezone(endDate, params.timezone),
-      timezone: params.timezone,
+    window: buildSummaryWindow(startDate, endDate, timezone),
+  };
+}
+
+function buildSummaryWindow(startDate: Date, endDate: Date, timezone: string): SummaryWindow {
+  return {
+    startAt: formatIsoOffsetInTimezone(startDate, timezone),
+    endAt: formatIsoOffsetInTimezone(endDate, timezone),
+    timezone,
+  };
+}
+
+function shiftLocalDateParts(parts: LocalDateParts, days: number): LocalDateParts {
+  const shifted = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + days));
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth() + 1,
+    day: shifted.getUTCDate(),
+  };
+}
+
+function getWeekStartLocalDate(parts: LocalDateParts): LocalDateParts {
+  const weekday = new Date(Date.UTC(parts.year, parts.month - 1, parts.day)).getUTCDay();
+  const daysSinceMonday = (weekday + 6) % 7;
+  return shiftLocalDateParts(parts, -daysSinceMonday);
+}
+
+function subtractSharedIngestTotals(
+  current: SummarySharedIngestTotals,
+  previous: SummarySharedIngestTotals,
+): SummarySharedIngestTotals {
+  return {
+    newResumes: current.newResumes - previous.newResumes,
+    collectionTasksCompleted: current.collectionTasksCompleted - previous.collectionTasksCompleted,
+    collectionTasksFailed: current.collectionTasksFailed - previous.collectionTasksFailed,
+  };
+}
+
+function subtractWorkspaceActivityTotals(
+  current: SummaryWorkspaceActivityTotals,
+  previous: SummaryWorkspaceActivityTotals,
+): SummaryWorkspaceActivityTotals {
+  return {
+    candidateStatusUpdates: current.candidateStatusUpdates - previous.candidateStatusUpdates,
+    shortlistActions: current.shortlistActions - previous.shortlistActions,
+    rejectActions: current.rejectActions - previous.rejectActions,
+    contactActions: current.contactActions - previous.contactActions,
+  };
+}
+
+function buildComparison(
+  previousWindow: SummaryWindow,
+  currentScopes: SummaryScopes,
+  previousScopes: SummaryScopes,
+): SummaryComparison {
+  return {
+    previousWindow,
+    totalsDelta: {
+      sharedIngest: subtractSharedIngestTotals(
+        currentScopes.sharedIngest.totals,
+        previousScopes.sharedIngest.totals,
+      ),
+      workspaceActivity: subtractWorkspaceActivityTotals(
+        currentScopes.workspaceActivity.totals,
+        previousScopes.workspaceActivity.totals,
+      ),
     },
   };
 }
@@ -257,23 +369,56 @@ export class SummaryDataService {
     period: SummaryPeriod;
     endAt?: string;
   }): Promise<SummaryReport> {
-    const { fromTimestamp, toTimestamp, window } = buildWindow({
+    const windows = buildWindow({
       period: params.period,
       endAt: params.endAt,
       now: this.now,
       timezone: config.timezone,
     });
 
+    const [currentMetrics, previousMetrics] = await Promise.all([
+      this.buildWindowMetrics(params.workspaceSlug, windows.current),
+      this.buildWindowMetrics(params.workspaceSlug, windows.previous),
+    ]);
+
+    return {
+      workspaceSlug: params.workspaceSlug,
+      period: params.period,
+      generatedAt: formatIsoOffsetInTimezone(this.now(), config.timezone),
+      window: windows.current.window,
+      comparison: buildComparison(
+        windows.previous.window,
+        currentMetrics.scopes,
+        previousMetrics.scopes,
+      ),
+      totals: currentMetrics.totals,
+      breakdowns: currentMetrics.breakdowns,
+      scopes: currentMetrics.scopes,
+      notes: [
+        "Shared ingest totals come from the global resume and collection-task pools in the current workspace model.",
+        "Workspace activity totals cover candidate-status updates and persisted workspace-linked actions only.",
+      ],
+    };
+  }
+
+  private async buildWindowMetrics(
+    workspaceSlug: string,
+    windowRange: SummaryWindowRange,
+  ): Promise<SummaryMetrics> {
     const [resumeSummary, candidateStatusSummary, collectionTaskSummary] = await Promise.all([
-      this.loadResumeSummary(fromTimestamp, toTimestamp),
-      this.loadCandidateStatusSummary(params.workspaceSlug, fromTimestamp, toTimestamp),
-      this.loadCollectionTaskSummary(fromTimestamp, toTimestamp),
+      this.loadResumeSummary(windowRange.fromTimestamp, windowRange.toTimestamp),
+      this.loadCandidateStatusSummary(
+        workspaceSlug,
+        windowRange.fromTimestamp,
+        windowRange.toTimestamp,
+      ),
+      this.loadCollectionTaskSummary(windowRange.fromTimestamp, windowRange.toTimestamp),
     ]);
 
     const actionSummary = this.actionStorage.summarizeActionsInWindow({
-      workspaceSlug: params.workspaceSlug,
-      startAt: window.startAt,
-      endAt: window.endAt,
+      workspaceSlug,
+      startAt: windowRange.window.startAt,
+      endAt: windowRange.window.endAt,
     });
 
     const resumeEntries = normalizeConvexEntries(resumeSummary.bySource);
@@ -286,19 +431,8 @@ export class SummaryDataService {
       actionEntries,
       taskEntries,
     });
-    const scopes = toSummaryScopes({
-      totals,
-      resumeEntries,
-      candidateStatusEntries,
-      actionEntries,
-      taskEntries,
-    });
 
     return {
-      workspaceSlug: params.workspaceSlug,
-      period: params.period,
-      generatedAt: formatIsoOffsetInTimezone(this.now(), config.timezone),
-      window,
       totals,
       breakdowns: {
         resumesBySource: resumeEntries,
@@ -306,11 +440,13 @@ export class SummaryDataService {
         actionsByType: actionEntries,
         collectionTasksByStatus: taskEntries,
       },
-      scopes,
-      notes: [
-        "Shared ingest totals come from the global resume and collection-task pools in the current workspace model.",
-        "Workspace activity totals cover candidate-status updates and persisted workspace-linked actions only.",
-      ],
+      scopes: toSummaryScopes({
+        totals,
+        resumeEntries,
+        candidateStatusEntries,
+        actionEntries,
+        taskEntries,
+      }),
     };
   }
 

--- a/apps/api/src/services/summaries/summary-dispatcher.ts
+++ b/apps/api/src/services/summaries/summary-dispatcher.ts
@@ -35,6 +35,10 @@ export type SummaryDispatchResult = SummaryDispatchPreview & {
 
 const DEFAULT_TEMPLATE_ID = "summary-daily";
 
+function getSummaryTitle(report: Pick<SummaryReport, "period">): string {
+  return report.period === "weekly" ? "Weekly Ops Summary" : "Daily Ops Summary";
+}
+
 function escapeHtml(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -59,6 +63,7 @@ function buildTemplateData(report: SummaryReport): Record<string, unknown> {
   return {
     ...report,
     timestamp: report.generatedAt,
+    summaryTitle: getSummaryTitle(report),
   };
 }
 
@@ -101,7 +106,7 @@ export class SummaryDispatcher {
         throw new Error("Email recipient is required");
       }
 
-      const subject = request.subject?.trim() || preview.subject || `Daily Ops Summary (${report.workspaceSlug})`;
+      const subject = request.subject?.trim() || preview.subject || `${getSummaryTitle(report)} (${report.workspaceSlug})`;
       const delivery = await this.notifications.sendEmail({
         to: request.to,
         subject,

--- a/apps/api/src/services/summaries/summary-renderer.ts
+++ b/apps/api/src/services/summaries/summary-renderer.ts
@@ -1,4 +1,4 @@
-import type { SummaryCountEntry, SummaryReport } from "@trends/shared";
+import type { SummaryCountEntry, SummaryPeriod, SummaryReport } from "@trends/shared";
 
 function renderCountList(entries: SummaryCountEntry[]): string[] {
   if (entries.length === 0) {
@@ -8,15 +8,25 @@ function renderCountList(entries: SummaryCountEntry[]): string[] {
   return entries.map((entry) => `- ${entry.label}: ${entry.count}`);
 }
 
+function getSummaryTitle(period: SummaryPeriod): string {
+  return period === "weekly" ? "Weekly Ops Summary" : "Daily Ops Summary";
+}
+
+function formatDelta(value: number): string {
+  return value > 0 ? `+${value}` : String(value);
+}
+
 export class SummaryRenderer {
   renderMarkdown(report: SummaryReport): string {
     const sharedIngest = report.scopes?.sharedIngest;
     const workspaceActivity = report.scopes?.workspaceActivity;
+    const comparison = report.comparison;
 
     return [
-      `# Daily Ops Summary`,
+      `# ${getSummaryTitle(report.period)}`,
       ``,
       `- Workspace: ${report.workspaceSlug}`,
+      `- Period: ${report.period}`,
       `- Generated: ${report.generatedAt}`,
       `- Window: ${report.window.startAt} -> ${report.window.endAt}`,
       `- Timezone: ${report.window.timezone}`,
@@ -44,6 +54,20 @@ export class SummaryRenderer {
       `## Candidate Actions`,
       ...renderCountList(workspaceActivity?.breakdowns.actionsByType ?? report.breakdowns.actionsByType),
       ``,
+      ...(comparison
+        ? [
+          `## Previous Period Comparison`,
+          `- Previous Window: ${comparison.previousWindow.startAt} -> ${comparison.previousWindow.endAt}`,
+          `- Shared ingest new resumes delta: ${formatDelta(comparison.totalsDelta.sharedIngest.newResumes)}`,
+          `- Shared ingest completed tasks delta: ${formatDelta(comparison.totalsDelta.sharedIngest.collectionTasksCompleted)}`,
+          `- Shared ingest failed tasks delta: ${formatDelta(comparison.totalsDelta.sharedIngest.collectionTasksFailed)}`,
+          `- Workspace activity candidate status delta: ${formatDelta(comparison.totalsDelta.workspaceActivity.candidateStatusUpdates)}`,
+          `- Workspace activity shortlist delta: ${formatDelta(comparison.totalsDelta.workspaceActivity.shortlistActions)}`,
+          `- Workspace activity reject delta: ${formatDelta(comparison.totalsDelta.workspaceActivity.rejectActions)}`,
+          `- Workspace activity contact delta: ${formatDelta(comparison.totalsDelta.workspaceActivity.contactActions)}`,
+          ``,
+        ]
+        : []),
       `## Notes`,
       ...report.notes.map((note) => `- ${note}`),
       ``,

--- a/apps/api/src/services/timezone.ts
+++ b/apps/api/src/services/timezone.ts
@@ -5,6 +5,12 @@ import yaml from "js-yaml";
 
 export const DEFAULT_TIMEZONE = "Asia/Hong_Kong";
 
+export type LocalDateParts = {
+  year: number;
+  month: number;
+  day: number;
+};
+
 type ResolveTimezoneOptions = {
   envTimezone?: string;
   projectRoot?: string;
@@ -117,6 +123,68 @@ function getDateParts(date: Date, timezone: string): {
     second: values.get("second") ?? "00",
     offset: normalizeOffset(values.get("timeZoneName") ?? "GMT+00:00"),
   };
+}
+
+function parseOffsetMinutes(offset: string): number {
+  const match = /^([+-])(\d{2}):(\d{2})$/.exec(offset);
+  if (!match) {
+    return 0;
+  }
+
+  const sign = match[1] === "-" ? -1 : 1;
+  return sign * (Number.parseInt(match[2], 10) * 60 + Number.parseInt(match[3], 10));
+}
+
+function isLocalMidnight(parts: LocalDateParts, rendered: ReturnType<typeof getDateParts>): boolean {
+  return Number.parseInt(rendered.year, 10) === parts.year
+    && Number.parseInt(rendered.month, 10) === parts.month
+    && Number.parseInt(rendered.day, 10) === parts.day
+    && rendered.hour === "00"
+    && rendered.minute === "00"
+    && rendered.second === "00";
+}
+
+export function getLocalDatePartsInTimezone(
+  value: Date | number | string,
+  timezone: string,
+): LocalDateParts {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error("Invalid date value");
+  }
+
+  const parts = getDateParts(date, timezone);
+  return {
+    year: Number.parseInt(parts.year, 10),
+    month: Number.parseInt(parts.month, 10),
+    day: Number.parseInt(parts.day, 10),
+  };
+}
+
+export function resolveLocalMidnightUtc(parts: LocalDateParts, timezone: string): Date {
+  const baseUtcMidnight = Date.UTC(parts.year, parts.month - 1, parts.day, 0, 0, 0);
+  let candidateMs = baseUtcMidnight;
+
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    const candidate = new Date(candidateMs);
+    const rendered = getDateParts(candidate, timezone);
+    if (isLocalMidnight(parts, rendered)) {
+      return candidate;
+    }
+
+    const offsetMinutes = parseOffsetMinutes(rendered.offset);
+    candidateMs = baseUtcMidnight - offsetMinutes * 60 * 1000;
+  }
+
+  const resolved = new Date(candidateMs);
+  const rendered = getDateParts(resolved, timezone);
+  if (!isLocalMidnight(parts, rendered)) {
+    throw new Error(
+      `Unable to resolve local midnight for ${parts.year}-${String(parts.month).padStart(2, "0")}-${String(parts.day).padStart(2, "0")} in ${timezone}`,
+    );
+  }
+
+  return resolved;
 }
 
 export function formatIsoOffsetInTimezone(

--- a/apps/api/src/services/workspace-summary-run-storage.ts
+++ b/apps/api/src/services/workspace-summary-run-storage.ts
@@ -1,3 +1,5 @@
+import type { SummaryPeriod } from "@trends/shared";
+
 import { config } from "./config.js";
 import { getResumeScreeningDb } from "./database.js";
 import { formatIsoOffsetInTimezone } from "./timezone.js";
@@ -13,7 +15,7 @@ export type WorkspaceSummaryTriggerSource =
 export type StoredWorkspaceSummaryRun = {
   id: string;
   workspaceSlug: string;
-  period: "daily";
+  period: SummaryPeriod;
   triggerSource: WorkspaceSummaryTriggerSource;
   status: WorkspaceSummaryRunStatus;
   channel?: "email" | "wechat_work" | "feishu" | "telegram";
@@ -73,11 +75,15 @@ function normalizeChannel(value: unknown): StoredWorkspaceSummaryRun["channel"] 
   return undefined;
 }
 
+function normalizePeriod(value: unknown): SummaryPeriod {
+  return value === "weekly" ? "weekly" : "daily";
+}
+
 function normalizeRun(row: Record<string, unknown>): StoredWorkspaceSummaryRun {
   return {
     id: String(row.id),
     workspaceSlug: row.workspace_slug ? String(row.workspace_slug) : "dev",
-    period: "daily",
+    period: normalizePeriod(row.period),
     triggerSource: normalizeTriggerSource(row.trigger_source),
     status: normalizeStatus(row.status),
     channel: normalizeChannel(row.channel),
@@ -104,6 +110,7 @@ export class WorkspaceSummaryRunStorage {
   createRun(params: {
     id: string;
     workspaceSlug: string;
+    period: SummaryPeriod;
     triggerSource: WorkspaceSummaryTriggerSource;
     status: WorkspaceSummaryRunStatus;
     channel?: StoredWorkspaceSummaryRun["channel"];
@@ -133,7 +140,7 @@ export class WorkspaceSummaryRunStorage {
       .run(
         params.id,
         params.workspaceSlug,
-        "daily",
+        params.period,
         params.triggerSource,
         params.status,
         params.channel ?? null,

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4415,7 +4415,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Preview a workspace daily summary */
+        /** Preview a workspace summary */
         post: {
             parameters: {
                 query?: never;
@@ -4431,7 +4431,7 @@ export interface paths {
                          * @default daily
                          * @enum {string}
                          */
-                        period?: "daily";
+                        period?: "daily" | "weekly";
                         /** Format: date-time */
                         endAt?: string;
                     };
@@ -4450,12 +4450,32 @@ export interface paths {
                             report: {
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                period: "daily";
+                                period: "daily" | "weekly";
                                 generatedAt: string;
                                 window: {
                                     startAt: string;
                                     endAt: string;
                                     timezone: string;
+                                };
+                                comparison?: {
+                                    previousWindow: {
+                                        startAt: string;
+                                        endAt: string;
+                                        timezone: string;
+                                    };
+                                    totalsDelta: {
+                                        sharedIngest: {
+                                            newResumes: number;
+                                            collectionTasksCompleted: number;
+                                            collectionTasksFailed: number;
+                                        };
+                                        workspaceActivity: {
+                                            candidateStatusUpdates: number;
+                                            shortlistActions: number;
+                                            rejectActions: number;
+                                            contactActions: number;
+                                        };
+                                    };
                                 };
                                 totals: {
                                     newResumes: number;
@@ -4536,7 +4556,7 @@ export interface paths {
                                 id: string;
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                period: "daily";
+                                period: "daily" | "weekly";
                                 /** @enum {string} */
                                 triggerSource: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
                                 /** @enum {string} */
@@ -4552,12 +4572,32 @@ export interface paths {
                                 report: {
                                     workspaceSlug: string;
                                     /** @enum {string} */
-                                    period: "daily";
+                                    period: "daily" | "weekly";
                                     generatedAt: string;
                                     window: {
                                         startAt: string;
                                         endAt: string;
                                         timezone: string;
+                                    };
+                                    comparison?: {
+                                        previousWindow: {
+                                            startAt: string;
+                                            endAt: string;
+                                            timezone: string;
+                                        };
+                                        totalsDelta: {
+                                            sharedIngest: {
+                                                newResumes: number;
+                                                collectionTasksCompleted: number;
+                                                collectionTasksFailed: number;
+                                            };
+                                            workspaceActivity: {
+                                                candidateStatusUpdates: number;
+                                                shortlistActions: number;
+                                                rejectActions: number;
+                                                contactActions: number;
+                                            };
+                                        };
                                     };
                                     totals: {
                                         newResumes: number;
@@ -4695,7 +4735,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Render and optionally send a workspace daily summary */
+        /** Render and optionally send a workspace summary */
         post: {
             parameters: {
                 query?: never;
@@ -4711,7 +4751,7 @@ export interface paths {
                          * @default daily
                          * @enum {string}
                          */
-                        period?: "daily";
+                        period?: "daily" | "weekly";
                         /** Format: date-time */
                         endAt?: string;
                         /** @enum {string} */
@@ -4749,12 +4789,32 @@ export interface paths {
                             report: {
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                period: "daily";
+                                period: "daily" | "weekly";
                                 generatedAt: string;
                                 window: {
                                     startAt: string;
                                     endAt: string;
                                     timezone: string;
+                                };
+                                comparison?: {
+                                    previousWindow: {
+                                        startAt: string;
+                                        endAt: string;
+                                        timezone: string;
+                                    };
+                                    totalsDelta: {
+                                        sharedIngest: {
+                                            newResumes: number;
+                                            collectionTasksCompleted: number;
+                                            collectionTasksFailed: number;
+                                        };
+                                        workspaceActivity: {
+                                            candidateStatusUpdates: number;
+                                            shortlistActions: number;
+                                            rejectActions: number;
+                                            contactActions: number;
+                                        };
+                                    };
                                 };
                                 totals: {
                                     newResumes: number;
@@ -4861,7 +4921,7 @@ export interface paths {
                                 id: string;
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                period: "daily";
+                                period: "daily" | "weekly";
                                 /** @enum {string} */
                                 triggerSource: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
                                 /** @enum {string} */
@@ -4877,12 +4937,32 @@ export interface paths {
                                 report: {
                                     workspaceSlug: string;
                                     /** @enum {string} */
-                                    period: "daily";
+                                    period: "daily" | "weekly";
                                     generatedAt: string;
                                     window: {
                                         startAt: string;
                                         endAt: string;
                                         timezone: string;
+                                    };
+                                    comparison?: {
+                                        previousWindow: {
+                                            startAt: string;
+                                            endAt: string;
+                                            timezone: string;
+                                        };
+                                        totalsDelta: {
+                                            sharedIngest: {
+                                                newResumes: number;
+                                                collectionTasksCompleted: number;
+                                                collectionTasksFailed: number;
+                                            };
+                                            workspaceActivity: {
+                                                candidateStatusUpdates: number;
+                                                shortlistActions: number;
+                                                rejectActions: number;
+                                                contactActions: number;
+                                            };
+                                        };
                                     };
                                     totals: {
                                         newResumes: number;
@@ -5043,7 +5123,7 @@ export interface paths {
                                 id: string;
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                period: "daily";
+                                period: "daily" | "weekly";
                                 /** @enum {string} */
                                 triggerSource: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
                                 /** @enum {string} */
@@ -5059,12 +5139,32 @@ export interface paths {
                                 report: {
                                     workspaceSlug: string;
                                     /** @enum {string} */
-                                    period: "daily";
+                                    period: "daily" | "weekly";
                                     generatedAt: string;
                                     window: {
                                         startAt: string;
                                         endAt: string;
                                         timezone: string;
+                                    };
+                                    comparison?: {
+                                        previousWindow: {
+                                            startAt: string;
+                                            endAt: string;
+                                            timezone: string;
+                                        };
+                                        totalsDelta: {
+                                            sharedIngest: {
+                                                newResumes: number;
+                                                collectionTasksCompleted: number;
+                                                collectionTasksFailed: number;
+                                            };
+                                            workspaceActivity: {
+                                                candidateStatusUpdates: number;
+                                                shortlistActions: number;
+                                                rejectActions: number;
+                                                contactActions: number;
+                                            };
+                                        };
                                     };
                                     totals: {
                                         newResumes: number;
@@ -5214,7 +5314,7 @@ export interface paths {
                                 id: string;
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                period: "daily";
+                                period: "daily" | "weekly";
                                 /** @enum {string} */
                                 triggerSource: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
                                 /** @enum {string} */
@@ -5230,12 +5330,32 @@ export interface paths {
                                 report: {
                                     workspaceSlug: string;
                                     /** @enum {string} */
-                                    period: "daily";
+                                    period: "daily" | "weekly";
                                     generatedAt: string;
                                     window: {
                                         startAt: string;
                                         endAt: string;
                                         timezone: string;
+                                    };
+                                    comparison?: {
+                                        previousWindow: {
+                                            startAt: string;
+                                            endAt: string;
+                                            timezone: string;
+                                        };
+                                        totalsDelta: {
+                                            sharedIngest: {
+                                                newResumes: number;
+                                                collectionTasksCompleted: number;
+                                                collectionTasksFailed: number;
+                                            };
+                                            workspaceActivity: {
+                                                candidateStatusUpdates: number;
+                                                shortlistActions: number;
+                                                rejectActions: number;
+                                                contactActions: number;
+                                            };
+                                        };
                                     };
                                     totals: {
                                         newResumes: number;

--- a/apps/web/src/pages/SummaryRunsPage.test.tsx
+++ b/apps/web/src/pages/SummaryRunsPage.test.tsx
@@ -55,7 +55,7 @@ describe('SummaryRunsPage', () => {
               {
                 id: 'run-1',
                 workspaceSlug: 'dev',
-                period: 'daily',
+                period: 'weekly',
                 triggerSource: 'api_manual',
                 status: 'sent',
                 channel: 'telegram',
@@ -66,12 +66,32 @@ describe('SummaryRunsPage', () => {
                 finishedAt: '2026-03-26T00:05:30Z',
                 report: {
                   workspaceSlug: 'dev',
-                  period: 'daily',
+                  period: 'weekly',
                   generatedAt: '2026-03-26T00:05:00Z',
                   window: {
                     startAt: '2026-03-25T00:00:00Z',
                     endAt: '2026-03-26T00:00:00Z',
                     timezone: 'UTC',
+                  },
+                  comparison: {
+                    previousWindow: {
+                      startAt: '2026-03-18T00:00:00Z',
+                      endAt: '2026-03-25T00:00:00Z',
+                      timezone: 'UTC',
+                    },
+                    totalsDelta: {
+                      sharedIngest: {
+                        newResumes: 2,
+                        collectionTasksCompleted: 1,
+                        collectionTasksFailed: 0,
+                      },
+                      workspaceActivity: {
+                        candidateStatusUpdates: 1,
+                        shortlistActions: 1,
+                        rejectActions: 0,
+                        contactActions: 1,
+                      },
+                    },
                   },
                   totals: {
                     newResumes: 2,
@@ -155,7 +175,7 @@ describe('SummaryRunsPage', () => {
             item: {
               id: 'run-1',
               workspaceSlug: 'dev',
-              period: 'daily',
+              period: 'weekly',
               triggerSource: 'api_manual',
               status: 'sent',
               channel: 'telegram',
@@ -166,12 +186,32 @@ describe('SummaryRunsPage', () => {
               finishedAt: '2026-03-26T00:05:30Z',
               report: {
                 workspaceSlug: 'dev',
-                period: 'daily',
+                period: 'weekly',
                 generatedAt: '2026-03-26T00:05:00Z',
                 window: {
                   startAt: '2026-03-25T00:00:00Z',
                   endAt: '2026-03-26T00:00:00Z',
                   timezone: 'UTC',
+                },
+                comparison: {
+                  previousWindow: {
+                    startAt: '2026-03-18T00:00:00Z',
+                    endAt: '2026-03-25T00:00:00Z',
+                    timezone: 'UTC',
+                  },
+                  totalsDelta: {
+                    sharedIngest: {
+                      newResumes: 2,
+                      collectionTasksCompleted: 1,
+                      collectionTasksFailed: 0,
+                    },
+                    workspaceActivity: {
+                      candidateStatusUpdates: 1,
+                      shortlistActions: 1,
+                      rejectActions: 0,
+                      contactActions: 1,
+                    },
+                  },
                 },
                 totals: {
                   newResumes: 2,
@@ -292,7 +332,11 @@ describe('SummaryRunsPage', () => {
     renderSummaryRunsPage()
 
     expect(await screen.findByText('run-1')).toBeInTheDocument()
+    expect(await screen.findAllByText('Weekly')).toHaveLength(2)
     expect(await screen.findAllByText(/1\/1 sent • 2 batches • override/i)).toHaveLength(2)
+    expect(await screen.findByText(/Compared with previous week • shared ingest \+2 resumes • workspace \+1 status/i)).toBeInTheDocument()
+    expect(await screen.findByText(/Previous period window/i)).toBeInTheDocument()
+    expect(await screen.findByText(/2026-03-18T00:00:00Z → 2026-03-25T00:00:00Z/i)).toBeInTheDocument()
     expect(await screen.findByText('***1234')).toBeInTheDocument()
     expect(await screen.findByText('Rendered summary content')).toBeInTheDocument()
     expect(await screen.findByText('First run note')).toBeInTheDocument()

--- a/apps/web/src/pages/SummaryRunsPage.tsx
+++ b/apps/web/src/pages/SummaryRunsPage.tsx
@@ -66,6 +66,24 @@ function formatTimestamp(value: string | undefined): string {
   }).format(parsed)
 }
 
+function formatPeriodLabel(period: SummaryRunItem['period'] | SummaryRunDetailItem['period'] | undefined): string {
+  if (period === 'weekly') {
+    return 'Weekly'
+  }
+  return 'Daily'
+}
+
+function formatDelta(value: number | undefined): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '0'
+  }
+  return value > 0 ? `+${value}` : String(value)
+}
+
+function formatComparisonLabel(period: SummaryRunDetailItem['period'] | undefined): string {
+  return period === 'weekly' ? 'Compared with previous week' : 'Compared with previous day'
+}
+
 function formatDeliverySummary(delivery: SummaryRunItem['delivery']): string {
   if (!delivery) {
     return '—'
@@ -114,6 +132,21 @@ function formatAccountStatus(account: SummaryDeliveryAccount): string {
     return 'failed'
   }
   return 'skipped'
+}
+
+function formatComparisonSummary(item: SummaryRunDetailItem | null): string {
+  const comparison = item?.report.comparison
+  if (!comparison) {
+    return '—'
+  }
+
+  const shared = comparison.totalsDelta.sharedIngest
+  const workspace = comparison.totalsDelta.workspaceActivity
+  return [
+    `${formatComparisonLabel(item?.report.period)}`,
+    `shared ingest ${formatDelta(shared.newResumes)} resumes`,
+    `workspace ${formatDelta(workspace.candidateStatusUpdates)} status`,
+  ].join(' • ')
 }
 
 function getRunStatusVariant(status: SummaryRunItem['status']) {
@@ -200,6 +233,7 @@ export function SummaryRunsPage() {
   }, [loadRuns])
 
   const selectedRunSummary = formatDeliverySummary(selectedRun?.delivery)
+  const selectedRunComparisonSummary = formatComparisonSummary(selectedRun)
 
   async function handleRefresh() {
     setRefreshing(true)
@@ -255,6 +289,7 @@ export function SummaryRunsPage() {
                 <TableHeader>
                   <TableRow>
                     <TableHead>{t('summaries.columnRun', { defaultValue: 'Run' })}</TableHead>
+                    <TableHead>{t('summaries.columnPeriod', { defaultValue: 'Period' })}</TableHead>
                     <TableHead>{t('summaries.columnStatus', { defaultValue: 'Status' })}</TableHead>
                     <TableHead>{t('summaries.columnStarted', { defaultValue: 'Started' })}</TableHead>
                     <TableHead>{t('summaries.columnDelivery', { defaultValue: 'Delivery' })}</TableHead>
@@ -275,6 +310,9 @@ export function SummaryRunsPage() {
                           <div className="text-xs text-muted-foreground">
                             {run.triggerSource} • {run.channel || 'preview'}
                           </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline">{formatPeriodLabel(run.period)}</Badge>
                         </TableCell>
                         <TableCell>
                           <Badge variant={getRunStatusVariant(run.status)}>{run.status}</Badge>
@@ -313,6 +351,10 @@ export function SummaryRunsPage() {
                       <div className="mt-1"><Badge variant={getRunStatusVariant(selectedRun.status)}>{selectedRun.status}</Badge></div>
                     </div>
                     <div>
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">{t('summaries.detailPeriod', { defaultValue: 'Period' })}</div>
+                      <div className="mt-1 text-sm">{formatPeriodLabel(selectedRun.period)}</div>
+                    </div>
+                    <div>
                       <div className="text-xs uppercase tracking-wide text-muted-foreground">{t('summaries.detailWindow', { defaultValue: 'Window' })}</div>
                       <div className="mt-1 text-sm">{selectedRun.windowStart} → {selectedRun.windowEnd}</div>
                     </div>
@@ -332,7 +374,39 @@ export function SummaryRunsPage() {
                       <div className="text-xs uppercase tracking-wide text-muted-foreground">{t('summaries.detailDelivery', { defaultValue: 'Delivery' })}</div>
                       <div className="mt-1 text-sm">{selectedRunSummary}</div>
                     </div>
+                    <div className="sm:col-span-2">
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">{t('summaries.detailComparison', { defaultValue: 'Comparison' })}</div>
+                      <div className="mt-1 text-sm">{selectedRunComparisonSummary}</div>
+                    </div>
                   </div>
+
+                  {selectedRun.report.comparison ? (
+                    <div className="space-y-2">
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">{t('summaries.detailComparisonWindow', { defaultValue: 'Previous period window' })}</div>
+                      <div className="text-sm text-muted-foreground">
+                        {selectedRun.report.comparison.previousWindow.startAt} → {selectedRun.report.comparison.previousWindow.endAt}
+                      </div>
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        <div className="rounded-md border p-3">
+                          <div className="text-xs uppercase tracking-wide text-muted-foreground">{t('summaries.detailComparisonShared', { defaultValue: 'Shared ingest deltas' })}</div>
+                          <div className="mt-2 space-y-1 text-sm">
+                            <div>{t('summaries.detailComparisonResumes', { defaultValue: 'New resumes' })}: {formatDelta(selectedRun.report.comparison.totalsDelta.sharedIngest.newResumes)}</div>
+                            <div>{t('summaries.detailComparisonCompleted', { defaultValue: 'Completed tasks' })}: {formatDelta(selectedRun.report.comparison.totalsDelta.sharedIngest.collectionTasksCompleted)}</div>
+                            <div>{t('summaries.detailComparisonFailed', { defaultValue: 'Failed tasks' })}: {formatDelta(selectedRun.report.comparison.totalsDelta.sharedIngest.collectionTasksFailed)}</div>
+                          </div>
+                        </div>
+                        <div className="rounded-md border p-3">
+                          <div className="text-xs uppercase tracking-wide text-muted-foreground">{t('summaries.detailComparisonWorkspace', { defaultValue: 'Workspace activity deltas' })}</div>
+                          <div className="mt-2 space-y-1 text-sm">
+                            <div>{t('summaries.detailComparisonStatus', { defaultValue: 'Candidate status updates' })}: {formatDelta(selectedRun.report.comparison.totalsDelta.workspaceActivity.candidateStatusUpdates)}</div>
+                            <div>{t('summaries.detailComparisonShortlist', { defaultValue: 'Shortlist actions' })}: {formatDelta(selectedRun.report.comparison.totalsDelta.workspaceActivity.shortlistActions)}</div>
+                            <div>{t('summaries.detailComparisonReject', { defaultValue: 'Reject actions' })}: {formatDelta(selectedRun.report.comparison.totalsDelta.workspaceActivity.rejectActions)}</div>
+                            <div>{t('summaries.detailComparisonContact', { defaultValue: 'Contact actions' })}: {formatDelta(selectedRun.report.comparison.totalsDelta.workspaceActivity.contactActions)}</div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ) : null}
 
                   {selectedRun.delivery?.accounts && selectedRun.delivery.accounts.length > 0 ? (
                     <div className="space-y-2">

--- a/apps/worker/api.py
+++ b/apps/worker/api.py
@@ -22,7 +22,7 @@ import sys
 import asyncio
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from fastapi import APIRouter, FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
@@ -184,6 +184,7 @@ class WorkerSummaryTriggerRequest(BaseModel):
     """Manual worker summary trigger request."""
 
     workspaceSlug: str = Field(default="dev", min_length=1)
+    period: Literal["daily", "weekly"] = "daily"
     channel: str = Field(default="telegram", min_length=1)
     dryRun: bool = False
     templateId: Optional[str] = None
@@ -288,6 +289,7 @@ async def trigger_worker_summary(request: WorkerSummaryTriggerRequest):
     success = await asyncio.to_thread(
         run_workspace_summary,
         workspace_slug=request.workspaceSlug,
+        period=request.period,
         channel=request.channel,
         dry_run=request.dryRun,
         trigger_source="worker_manual",

--- a/apps/worker/scheduler.py
+++ b/apps/worker/scheduler.py
@@ -31,6 +31,7 @@ from apps.worker.tasks import (
     health_check,
     run_skills_version_check,
     run_scoring_auto_tune,
+    normalize_summary_period,
     run_workspace_summary,
 )
 from apps.worker.timezone import bootstrap_worker_timezone, resolve_worker_timezone
@@ -357,6 +358,7 @@ class WorkerScheduler:
 
         workspace_slug = os.environ.get("WORKER_SUMMARY_WORKSPACE", "").strip() or "dev"
         channel = os.environ.get("WORKER_SUMMARY_CHANNEL", "").strip() or "telegram"
+        period = normalize_summary_period(os.environ.get("WORKER_SUMMARY_PERIOD"))
         dry_run_env = os.environ.get("WORKER_SUMMARY_DRY_RUN", "").strip().lower()
         dry_run = dry_run_env in {"1", "true", "yes", "on"}
         template_id = os.environ.get("WORKER_SUMMARY_TEMPLATE_ID", "").strip() or None
@@ -367,6 +369,7 @@ class WorkerScheduler:
             job_id="workspace_summary",
             cron_expression=cron_expression,
             workspace_slug=workspace_slug,
+            period=period,
             channel=channel,
             dry_run=dry_run,
             trigger_source="worker_schedule",
@@ -374,9 +377,10 @@ class WorkerScheduler:
             end_at=end_at,
         )
         logger.info(
-            "Scheduled workspace summary job with cron: %s (workspace=%s, channel=%s, dry_run=%s)",
+            "Scheduled workspace summary job with cron: %s (workspace=%s, period=%s, channel=%s, dry_run=%s)",
             cron_expression,
             workspace_slug,
+            period,
             channel,
             dry_run,
         )

--- a/apps/worker/tasks.py
+++ b/apps/worker/tasks.py
@@ -22,6 +22,8 @@ from trendradar.utils.time import get_configured_time
 
 logger = logging.getLogger(__name__)
 
+VALID_SUMMARY_PERIODS = {"daily", "weekly"}
+
 
 def run_crawl_analyze(config_overrides: Optional[Dict[str, Any]] = None) -> bool:
     """
@@ -128,6 +130,15 @@ def health_check() -> bool:
 def _worker_api_base_url(override: Optional[str] = None) -> str:
     base_url = override or os.environ.get("TRENDS_API_URL", "http://localhost:3000")
     return base_url.rstrip("/")
+
+
+def normalize_summary_period(period: Optional[str]) -> str:
+    normalized = (period or "").strip().lower()
+    if normalized in VALID_SUMMARY_PERIODS:
+        return normalized
+    if normalized:
+        logger.warning("[Task] Invalid summary period %s, falling back to daily", period)
+    return "daily"
 
 
 def _skills_state_path() -> Path:
@@ -296,6 +307,7 @@ def run_scoring_auto_tune(
 def run_workspace_summary(
     api_base_url: Optional[str] = None,
     workspace_slug: str = "dev",
+    period: str = "daily",
     channel: str = "telegram",
     dry_run: bool = False,
     trigger_source: str = "worker_manual",
@@ -309,17 +321,19 @@ def run_workspace_summary(
 ) -> bool:
     base_url = _worker_api_base_url(api_base_url)
     normalized_workspace = workspace_slug.strip() or "dev"
+    normalized_period = normalize_summary_period(period)
     normalized_channel = channel.strip() or "telegram"
     logger.info(
-        "[Task] Starting workspace summary (workspace=%s, channel=%s, dry_run=%s)",
+        "[Task] Starting workspace summary (workspace=%s, period=%s, channel=%s, dry_run=%s)",
         normalized_workspace,
+        normalized_period,
         normalized_channel,
         dry_run,
     )
 
     request_body: Dict[str, Any] = {
         "workspaceSlug": normalized_workspace,
-        "period": "daily",
+        "period": normalized_period,
         "channel": normalized_channel,
         "dryRun": bool(dry_run),
         "triggerSource": trigger_source.strip() if trigger_source.strip() else "worker_manual",
@@ -352,7 +366,8 @@ def run_workspace_summary(
             return False
 
         logger.info(
-            "[Task] workspace summary completed (channel=%s, dry_run=%s, template=%s)",
+            "[Task] workspace summary completed (period=%s, channel=%s, dry_run=%s, template=%s)",
+            normalized_period,
             response.get("channel"),
             response.get("dryRun"),
             response.get("templateId"),

--- a/config/notifications/summary-daily.md
+++ b/config/notifications/summary-daily.md
@@ -1,10 +1,11 @@
 ---
-subject: "Daily Ops Summary {{workspaceSlug}}"
+subject: "{{summaryTitle}} {{workspaceSlug}}"
 ---
 
-# Daily Ops Summary
+# {{summaryTitle}}
 
 - Workspace: {{workspaceSlug}}
+- Period: {{period}}
 - Generated: {{generatedAt}}
 - Window Start: {{window.startAt}}
 - Window End: {{window.endAt}}
@@ -51,6 +52,19 @@ subject: "Daily Ops Summary {{workspaceSlug}}"
 {{#each scopes.workspaceActivity.breakdowns.actionsByType}}
 - {{this.label}}: {{this.count}}
 {{/each}}
+{{/if}}
+
+{{#if comparison}}
+## Previous Period Comparison
+- Previous Window Start: {{comparison.previousWindow.startAt}}
+- Previous Window End: {{comparison.previousWindow.endAt}}
+- Shared ingest new resumes delta: {{comparison.totalsDelta.sharedIngest.newResumes}}
+- Shared ingest completed tasks delta: {{comparison.totalsDelta.sharedIngest.collectionTasksCompleted}}
+- Shared ingest failed tasks delta: {{comparison.totalsDelta.sharedIngest.collectionTasksFailed}}
+- Workspace activity candidate status delta: {{comparison.totalsDelta.workspaceActivity.candidateStatusUpdates}}
+- Workspace activity shortlist delta: {{comparison.totalsDelta.workspaceActivity.shortlistActions}}
+- Workspace activity reject delta: {{comparison.totalsDelta.workspaceActivity.rejectActions}}
+- Workspace activity contact delta: {{comparison.totalsDelta.workspaceActivity.contactActions}}
 {{/if}}
 
 {{#if notes}}

--- a/packages/cli/cmd/worker.go
+++ b/packages/cli/cmd/worker.go
@@ -41,6 +41,7 @@ func newWorkerSummaryCmd() *cobra.Command {
 
 func newWorkerSummaryRunCmd() *cobra.Command {
 	var channel string
+	var period string
 	var dryRun bool
 	var templateID string
 	var endAt string
@@ -55,8 +56,13 @@ func newWorkerSummaryRunCmd() *cobra.Command {
 		Use:   "run",
 		Short: "Run a workspace summary manually",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			normalizedPeriod, err := normalizeSummaryPeriodFlag(period)
+			if err != nil {
+				return err
+			}
 			request := client.SummaryRunRequest{
 				Channel:       channel,
+				Period:        normalizedPeriod,
 				DryRun:        dryRun,
 				TemplateID:    templateID,
 				EndAt:         endAt,
@@ -82,9 +88,10 @@ func newWorkerSummaryRunCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			headers := []string{"run_id", "status", "channel", "dry_run", "trigger_source", "window_end", "delivery"}
+			headers := []string{"run_id", "period", "status", "channel", "dry_run", "trigger_source", "window_end", "delivery"}
 			rows := [][]string{{
 				response.Run.ID,
+				response.Run.Period,
 				response.Run.Status,
 				response.Channel,
 				boolToString(response.DryRun),
@@ -97,6 +104,7 @@ func newWorkerSummaryRunCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&channel, "channel", "telegram", "Summary delivery channel")
+	cmd.Flags().StringVar(&period, "period", "daily", "Summary period (daily or weekly)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Render without sending externally")
 	cmd.Flags().StringVar(&templateID, "template-id", "", "Optional notification template ID")
 	cmd.Flags().StringVar(&endAt, "end-at", "", "Optional ISO8601 end time")
@@ -121,11 +129,12 @@ func newWorkerSummaryHistoryCmd() *cobra.Command {
 				return err
 			}
 
-			headers := []string{"id", "status", "channel", "dry_run", "trigger_source", "started_at", "window_end", "delivery"}
+			headers := []string{"id", "period", "status", "channel", "dry_run", "trigger_source", "started_at", "window_end", "delivery"}
 			rows := make([][]string, 0, len(response.Items))
 			for _, item := range response.Items {
 				rows = append(rows, []string{
 					item.ID,
+					item.Period,
 					item.Status,
 					item.Channel,
 					boolToString(item.DryRun),
@@ -154,9 +163,10 @@ func newWorkerSummaryShowCmd() *cobra.Command {
 				return err
 			}
 
-			headers := []string{"id", "status", "channel", "dry_run", "trigger_source", "started_at", "finished_at", "delivery", "accounts", "error"}
+			headers := []string{"id", "period", "status", "channel", "dry_run", "trigger_source", "started_at", "finished_at", "delivery", "accounts", "error"}
 			rows := [][]string{{
 				response.Item.ID,
+				response.Item.Period,
 				response.Item.Status,
 				response.Item.Channel,
 				boolToString(response.Item.DryRun),
@@ -219,6 +229,18 @@ func newWorkerRunCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&once, "once", true, "Run once immediately")
 	return cmd
+}
+
+func normalizeSummaryPeriodFlag(value string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case "", "daily":
+		return "daily", nil
+	case "weekly":
+		return "weekly", nil
+	default:
+		return "", fmt.Errorf("invalid --period %q: expected daily or weekly", value)
+	}
 }
 
 func summaryDeliverySummary(delivery *client.SummaryDelivery) string {

--- a/packages/cli/cmd/worker_summary_test.go
+++ b/packages/cli/cmd/worker_summary_test.go
@@ -22,7 +22,7 @@ func TestWorkerSummaryRunCommandWritesJSON(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		if request["workspaceSlug"] != "ops" || request["period"] != "daily" {
+		if request["workspaceSlug"] != "ops" || request["period"] != "weekly" {
 			t.Fatalf("unexpected request: %#v", request)
 		}
 		if request["triggerSource"] != "api_manual" {
@@ -36,6 +36,7 @@ func TestWorkerSummaryRunCommandWritesJSON(t *testing.T) {
 			"templateId": "summary-daily",
 			"run": map[string]any{
 				"id":            "run-1",
+				"period":        "weekly",
 				"status":        "dry_run",
 				"triggerSource": "api_manual",
 				"windowEnd":     "2026-03-26T12:00:00Z",
@@ -51,7 +52,7 @@ func TestWorkerSummaryRunCommandWritesJSON(t *testing.T) {
 	var output bytes.Buffer
 	cmd.SetOut(&output)
 	cmd.SetErr(&output)
-	cmd.SetArgs([]string{"--dry-run"})
+	cmd.SetArgs([]string{"--dry-run", "--period", "weekly"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("worker summary run command failed: %v", err)
@@ -62,7 +63,7 @@ func TestWorkerSummaryRunCommandWritesJSON(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing run payload: %#v", payload)
 	}
-	if run["id"] != "run-1" || run["status"] != "dry_run" {
+	if run["id"] != "run-1" || run["status"] != "dry_run" || run["period"] != "weekly" {
 		t.Fatalf("unexpected output payload: %#v", payload)
 	}
 }
@@ -80,7 +81,7 @@ func TestWorkerSummaryRunViaWorkerCommandWritesJSON(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		if request["workspaceSlug"] != "ops" || request["period"] != "daily" {
+		if request["workspaceSlug"] != "ops" || request["period"] != "weekly" {
 			t.Fatalf("unexpected request: %#v", request)
 		}
 
@@ -101,7 +102,7 @@ func TestWorkerSummaryRunViaWorkerCommandWritesJSON(t *testing.T) {
 	var output bytes.Buffer
 	cmd.SetOut(&output)
 	cmd.SetErr(&output)
-	cmd.SetArgs([]string{"--via-worker", "--dry-run"})
+	cmd.SetArgs([]string{"--via-worker", "--dry-run", "--period", "weekly"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("worker summary via-worker command failed: %v", err)
@@ -110,6 +111,25 @@ func TestWorkerSummaryRunViaWorkerCommandWritesJSON(t *testing.T) {
 	payload := decodeCommandJSON(t, output)
 	if payload["mode"] != "summary" {
 		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+}
+
+func TestWorkerSummaryRunCommandRejectsInvalidPeriod(t *testing.T) {
+	setResumeCLIConfig(t, "http://127.0.0.1:1", "ops")
+	setCLIOutput(t, "json")
+
+	cmd := newWorkerSummaryRunCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--period", "monthly"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected invalid period error")
+	}
+	if !strings.Contains(err.Error(), "expected daily or weekly") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -132,6 +152,7 @@ func TestWorkerSummaryRunCommandWritesTableDeliverySummary(t *testing.T) {
 			},
 			"run": map[string]any{
 				"id":            "run-2",
+				"period":        "weekly",
 				"status":        "sent",
 				"triggerSource": "api_manual",
 				"windowEnd":     "2026-03-26T12:00:00Z",
@@ -153,7 +174,7 @@ func TestWorkerSummaryRunCommandWritesTableDeliverySummary(t *testing.T) {
 	}
 
 	text := output.String()
-	if !strings.Contains(text, "1/1 sent, 2 batches") {
+	if !strings.Contains(text, "weekly") || !strings.Contains(text, "1/1 sent, 2 batches") {
 		t.Fatalf("expected delivery summary in table output, got: %s", text)
 	}
 }
@@ -171,6 +192,7 @@ func TestWorkerSummaryHistoryCommandWritesJSON(t *testing.T) {
 			"success": true,
 			"items": []map[string]any{{
 				"id":            "run-1",
+				"period":        "weekly",
 				"status":        "sent",
 				"triggerSource": "worker_schedule",
 			}},
@@ -197,7 +219,7 @@ func TestWorkerSummaryHistoryCommandWritesJSON(t *testing.T) {
 		t.Fatalf("unexpected output payload: %#v", payload)
 	}
 	item, ok := items[0].(map[string]any)
-	if !ok || item["triggerSource"] != "worker_schedule" {
+	if !ok || item["triggerSource"] != "worker_schedule" || item["period"] != "weekly" {
 		t.Fatalf("unexpected item payload: %#v", payload)
 	}
 }
@@ -208,6 +230,7 @@ func TestWorkerSummaryHistoryCommandWritesTableDeliverySummary(t *testing.T) {
 			"success": true,
 			"items": []map[string]any{{
 				"id":            "run-3",
+				"period":        "weekly",
 				"status":        "sent",
 				"triggerSource": "worker_schedule",
 				"delivery": map[string]any{
@@ -234,7 +257,7 @@ func TestWorkerSummaryHistoryCommandWritesTableDeliverySummary(t *testing.T) {
 	}
 
 	text := output.String()
-	if !strings.Contains(text, "1/1 sent, 3 batches") {
+	if !strings.Contains(text, "weekly") || !strings.Contains(text, "1/1 sent, 3 batches") {
 		t.Fatalf("expected delivery summary in history table output, got: %s", text)
 	}
 }
@@ -249,6 +272,7 @@ func TestWorkerSummaryShowCommandWritesJSON(t *testing.T) {
 			"success": true,
 			"item": map[string]any{
 				"id":            "run-7",
+				"period":        "weekly",
 				"status":        "failed",
 				"triggerSource": "api_manual",
 				"error":         "boom",
@@ -275,7 +299,7 @@ func TestWorkerSummaryShowCommandWritesJSON(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected output payload: %#v", payload)
 	}
-	if item["id"] != "run-7" || item["error"] != "boom" {
+	if item["id"] != "run-7" || item["error"] != "boom" || item["period"] != "weekly" {
 		t.Fatalf("unexpected item payload: %#v", payload)
 	}
 }
@@ -286,6 +310,7 @@ func TestWorkerSummaryShowCommandWritesTableDeliveryDetails(t *testing.T) {
 			"success": true,
 			"item": map[string]any{
 				"id":            "run-8",
+				"period":        "weekly",
 				"status":        "sent",
 				"channel":       "telegram",
 				"triggerSource": "api_manual",
@@ -337,7 +362,7 @@ func TestWorkerSummaryShowCommandWritesTableDeliveryDetails(t *testing.T) {
 	}
 
 	text := output.String()
-	if !strings.Contains(text, "1/1 sent, 2 batches, override") {
+	if !strings.Contains(text, "weekly") || !strings.Contains(text, "1/1 sent, 2 batches, override") {
 		t.Fatalf("expected delivery summary in show table output, got: %s", text)
 	}
 	if !strings.Contains(text, "1:***1234:sent(2b), 2:***5678:skipped") {

--- a/packages/cli/internal/client/worker_test.go
+++ b/packages/cli/internal/client/worker_test.go
@@ -171,7 +171,7 @@ func TestRunWorkspaceSummaryPostsRunRequest(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		if request.WorkspaceSlug != "ops" || request.Period != "daily" {
+		if request.WorkspaceSlug != "ops" || request.Period != "weekly" {
 			t.Fatalf("unexpected workspace request: %+v", request)
 		}
 		if request.TriggerSource != "api_manual" || request.Channel != "telegram" {
@@ -197,6 +197,7 @@ func TestRunWorkspaceSummaryPostsRunRequest(t *testing.T) {
 
 	response, err := c.RunWorkspaceSummary(context.Background(), SummaryRunRequest{
 		Channel:       "telegram",
+		Period:        "weekly",
 		DryRun:        true,
 		TriggerSource: "api_manual",
 	})
@@ -284,7 +285,7 @@ func TestTriggerWorkerSummaryPostsWorkerSummaryRequest(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		if request.WorkspaceSlug != "ops" || request.Period != "daily" {
+		if request.WorkspaceSlug != "ops" || request.Period != "weekly" {
 			t.Fatalf("unexpected workspace request: %+v", request)
 		}
 		if request.Channel != "telegram" || !request.DryRun {
@@ -304,6 +305,7 @@ func TestTriggerWorkerSummaryPostsWorkerSummaryRequest(t *testing.T) {
 
 	response, err := c.TriggerWorkerSummary(context.Background(), SummaryRunRequest{
 		Channel: "telegram",
+		Period:  "weekly",
 		DryRun:  true,
 	})
 	if err != nil {

--- a/packages/shared/src/summaries.ts
+++ b/packages/shared/src/summaries.ts
@@ -1,4 +1,4 @@
-export type SummaryPeriod = "daily";
+export type SummaryPeriod = "daily" | "weekly";
 
 export type SummaryChannel = "email" | "wechat_work" | "feishu" | "telegram";
 
@@ -34,6 +34,14 @@ export type SummaryWorkspaceActivityTotals = Pick<
   "candidateStatusUpdates" | "shortlistActions" | "rejectActions" | "contactActions"
 >;
 
+export type SummaryComparison = {
+  previousWindow: SummaryWindow;
+  totalsDelta: {
+    sharedIngest: SummarySharedIngestTotals;
+    workspaceActivity: SummaryWorkspaceActivityTotals;
+  };
+};
+
 export type SummaryScopes = {
   sharedIngest: {
     totals: SummarySharedIngestTotals;
@@ -56,6 +64,7 @@ export type SummaryReport = {
   period: SummaryPeriod;
   generatedAt: string;
   window: SummaryWindow;
+  comparison?: SummaryComparison;
   totals: SummaryTotals;
   breakdowns: {
     resumesBySource: SummaryCountEntry[];

--- a/tests/test_resume_tasks.py
+++ b/tests/test_resume_tasks.py
@@ -134,6 +134,7 @@ def test_run_workspace_summary_posts_summary_request(monkeypatch) -> None:
     ok = tasks.run_workspace_summary(
         api_base_url="http://localhost:3000/",
         workspace_slug="hr",
+        period="weekly",
         channel="telegram",
         dry_run=True,
         template_id="summary-daily",
@@ -145,7 +146,7 @@ def test_run_workspace_summary_posts_summary_request(monkeypatch) -> None:
     assert captured["method"] == "POST"
     assert captured["body"] == {
         "workspaceSlug": "hr",
-        "period": "daily",
+        "period": "weekly",
         "channel": "telegram",
         "dryRun": True,
         "triggerSource": "worker_manual",
@@ -164,6 +165,32 @@ def test_run_workspace_summary_returns_false_when_api_fails(monkeypatch) -> None
     ok = tasks.run_workspace_summary(api_base_url="http://localhost:3000", workspace_slug="dev")
 
     assert ok is False
+
+
+def test_run_workspace_summary_falls_back_to_daily_for_invalid_period(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_request_json(url: str, method: str = "GET", body: dict[str, Any] | None = None) -> dict[str, Any]:
+        captured["url"] = url
+        captured["method"] = method
+        captured["body"] = body
+        return {
+            "success": True,
+            "channel": "telegram",
+            "dryRun": True,
+            "templateId": "summary-daily",
+        }
+
+    monkeypatch.setattr(tasks, "_request_json", fake_request_json)
+
+    ok = tasks.run_workspace_summary(
+        api_base_url="http://localhost:3000",
+        workspace_slug="dev",
+        period="monthly",
+    )
+
+    assert ok is True
+    assert captured["body"]["period"] == "daily"
 
 
 def test_add_workspace_summary_job_requires_cron(monkeypatch) -> None:
@@ -188,6 +215,7 @@ def test_add_workspace_summary_job_uses_env_config(monkeypatch) -> None:
     monkeypatch.setenv("WORKER_SUMMARY_CRON", "15 18 * * 1-5")
     monkeypatch.setenv("WORKER_SUMMARY_WORKSPACE", "hr")
     monkeypatch.setenv("WORKER_SUMMARY_CHANNEL", "telegram")
+    monkeypatch.setenv("WORKER_SUMMARY_PERIOD", "weekly")
     monkeypatch.setenv("WORKER_SUMMARY_DRY_RUN", "true")
     monkeypatch.setenv("WORKER_SUMMARY_TEMPLATE_ID", "summary-daily")
     scheduler = worker_scheduler.WorkerScheduler(timezone="UTC")
@@ -204,6 +232,7 @@ def test_add_workspace_summary_job_uses_env_config(monkeypatch) -> None:
     assert calls[0]["job_id"] == "workspace_summary"
     assert calls[0]["cron_expression"] == "15 18 * * 1-5"
     assert calls[0]["workspace_slug"] == "hr"
+    assert calls[0]["period"] == "weekly"
     assert calls[0]["channel"] == "telegram"
     assert calls[0]["dry_run"] is True
     assert calls[0]["trigger_source"] == "worker_schedule"


### PR DESCRIPTION
## Summary
- add weekly summary period support with timezone-safe Monday window boundaries and previous-period comparison data
- thread summary period through the worker, scheduler, and CLI transport path with `WORKER_SUMMARY_PERIOD`
- surface summary period and comparison context in the web and CLI operator history/detail views

## Validation
- bun x vitest run apps/api/src/services/__tests__/timezone.test.ts
- bun x vitest run apps/api/src/services/summaries/summary-data-service.test.ts
- bun x vitest run apps/api/src/routes/summaries.test.ts
- bun x vitest run apps/api/src/routes/worker.test.ts
- uv run pytest tests/test_resume_tasks.py
- go test ./internal/client ./cmd
- npm --workspace @trends/web test -- --run src/pages/SummaryRunsPage.test.tsx
- bun run --filter '@trends/api' typecheck
- bun run --filter '@trends/web' typecheck
- make check
