### PR TITLE
feat(web): add summary run controls

### DIFF
--- a/apps/web/src/pages/SummaryRunsPage.test.tsx
+++ b/apps/web/src/pages/SummaryRunsPage.test.tsx
@@ -4,9 +4,11 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SummaryRunsPage } from './SummaryRunsPage'
 
-const { getMock, toastErrorMock, tMock } = vi.hoisted(() => ({
+const { getMock, postMock, toastErrorMock, toastSuccessMock, tMock } = vi.hoisted(() => ({
   getMock: vi.fn(),
+  postMock: vi.fn(),
   toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
   tMock: vi.fn((_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key),
 }))
 
@@ -19,14 +21,97 @@ vi.mock('react-i18next', () => ({
 vi.mock('sonner', () => ({
   toast: {
     error: (...args: unknown[]) => toastErrorMock(...args),
+    success: (...args: unknown[]) => toastSuccessMock(...args),
   },
 }))
 
 vi.mock('@/lib/api-helpers', () => ({
   rawApiClient: {
     GET: (...args: unknown[]) => getMock(...args),
+    POST: (...args: unknown[]) => postMock(...args),
   },
 }))
+
+type SummaryRun = {
+  id: string
+  workspaceSlug: string
+  period: 'daily' | 'weekly'
+  triggerSource: 'api_manual' | 'worker_schedule' | 'api_preview' | 'worker_manual'
+  status: 'previewed' | 'dry_run' | 'sent' | 'failed'
+  channel?: 'telegram' | 'wechat_work' | 'feishu' | 'email'
+  templateId?: string
+  dryRun: boolean
+  windowStart: string
+  windowEnd: string
+  startedAt: string
+  finishedAt?: string
+  report: {
+    workspaceSlug: string
+    period: 'daily' | 'weekly'
+    generatedAt: string
+    window: {
+      startAt: string
+      endAt: string
+      timezone: string
+    }
+    comparison?: {
+      previousWindow: {
+        startAt: string
+        endAt: string
+        timezone: string
+      }
+      totalsDelta: {
+        sharedIngest: {
+          newResumes: number
+          collectionTasksCompleted: number
+          collectionTasksFailed: number
+        }
+        workspaceActivity: {
+          candidateStatusUpdates: number
+          shortlistActions: number
+          rejectActions: number
+          contactActions: number
+        }
+      }
+    }
+    totals: {
+      newResumes: number
+      candidateStatusUpdates: number
+      shortlistActions: number
+      rejectActions: number
+      contactActions: number
+      collectionTasksCompleted: number
+      collectionTasksFailed: number
+    }
+    breakdowns: {
+      resumesBySource: unknown[]
+      candidateStatusByValue: unknown[]
+      actionsByType: unknown[]
+      collectionTasksByStatus: unknown[]
+    }
+    notes: string[]
+  }
+  content?: string
+  delivery?: {
+    channel?: string
+    accountsConfigured?: number
+    accountsSelected?: number
+    accountsAttempted?: number
+    accountsSent?: number
+    totalBatches?: number
+    usedOverrideChatId?: boolean
+    usedOverrideBotToken?: boolean
+    accounts?: Array<{
+      index: number
+      chatIdHint: string
+      attempted: boolean
+      sent: boolean
+      batchesPlanned: number
+      skippedReason?: string
+    }>
+  }
+  error?: string
+}
 
 function renderSummaryRunsPage() {
   return render(
@@ -38,6 +123,198 @@ function renderSummaryRunsPage() {
   )
 }
 
+function createWeeklyRun(overrides: Partial<SummaryRun> = {}): SummaryRun {
+  return {
+    id: 'run-1',
+    workspaceSlug: 'dev',
+    period: 'weekly',
+    triggerSource: 'api_manual',
+    status: 'sent',
+    channel: 'telegram',
+    templateId: 'summary-daily',
+    dryRun: false,
+    windowStart: '2026-03-25T00:00:00Z',
+    windowEnd: '2026-03-26T00:00:00Z',
+    startedAt: '2026-03-26T00:05:00Z',
+    finishedAt: '2026-03-26T00:05:30Z',
+    report: {
+      workspaceSlug: 'dev',
+      period: 'weekly',
+      generatedAt: '2026-03-26T00:05:00Z',
+      window: {
+        startAt: '2026-03-25T00:00:00Z',
+        endAt: '2026-03-26T00:00:00Z',
+        timezone: 'UTC',
+      },
+      comparison: {
+        previousWindow: {
+          startAt: '2026-03-18T00:00:00Z',
+          endAt: '2026-03-25T00:00:00Z',
+          timezone: 'UTC',
+        },
+        totalsDelta: {
+          sharedIngest: {
+            newResumes: 2,
+            collectionTasksCompleted: 1,
+            collectionTasksFailed: 0,
+          },
+          workspaceActivity: {
+            candidateStatusUpdates: 1,
+            shortlistActions: 1,
+            rejectActions: 0,
+            contactActions: 1,
+          },
+        },
+      },
+      totals: {
+        newResumes: 2,
+        candidateStatusUpdates: 1,
+        shortlistActions: 1,
+        rejectActions: 0,
+        contactActions: 1,
+        collectionTasksCompleted: 1,
+        collectionTasksFailed: 0,
+      },
+      breakdowns: {
+        resumesBySource: [],
+        candidateStatusByValue: [],
+        actionsByType: [],
+        collectionTasksByStatus: [],
+      },
+      notes: ['First run note'],
+    },
+    content: 'Rendered summary content',
+    delivery: {
+      channel: 'telegram',
+      accountsConfigured: 2,
+      accountsSelected: 2,
+      accountsAttempted: 1,
+      accountsSent: 1,
+      totalBatches: 2,
+      usedOverrideChatId: true,
+      accounts: [
+        {
+          index: 1,
+          chatIdHint: '***1234',
+          attempted: true,
+          sent: true,
+          batchesPlanned: 2,
+        },
+        {
+          index: 2,
+          chatIdHint: '***5678',
+          attempted: false,
+          sent: false,
+          batchesPlanned: 0,
+          skippedReason: 'missing token or chat_id',
+        },
+      ],
+    },
+    ...overrides,
+  }
+}
+
+function createDailyFailedRun(): SummaryRun {
+  return {
+    id: 'run-2',
+    workspaceSlug: 'dev',
+    period: 'daily',
+    triggerSource: 'worker_schedule',
+    status: 'failed',
+    channel: 'telegram',
+    dryRun: false,
+    windowStart: '2026-03-24T00:00:00Z',
+    windowEnd: '2026-03-25T00:00:00Z',
+    startedAt: '2026-03-25T00:05:00Z',
+    finishedAt: '2026-03-25T00:05:45Z',
+    report: {
+      workspaceSlug: 'dev',
+      period: 'daily',
+      generatedAt: '2026-03-25T00:05:00Z',
+      window: {
+        startAt: '2026-03-24T00:00:00Z',
+        endAt: '2026-03-25T00:00:00Z',
+        timezone: 'UTC',
+      },
+      totals: {
+        newResumes: 0,
+        candidateStatusUpdates: 0,
+        shortlistActions: 0,
+        rejectActions: 0,
+        contactActions: 0,
+        collectionTasksCompleted: 0,
+        collectionTasksFailed: 1,
+      },
+      breakdowns: {
+        resumesBySource: [],
+        candidateStatusByValue: [],
+        actionsByType: [],
+        collectionTasksByStatus: [],
+      },
+      notes: [],
+    },
+    content: 'Failed summary content',
+    delivery: {
+      channel: 'telegram',
+      accountsAttempted: 1,
+      accountsSent: 0,
+      totalBatches: 3,
+      accounts: [
+        {
+          index: 1,
+          chatIdHint: '***9999',
+          attempted: true,
+          sent: false,
+          batchesPlanned: 3,
+        },
+      ],
+    },
+    error: 'Telegram summary delivery failed',
+  }
+}
+
+function createListAndDetailMocks(detailRun: SummaryRun, extraRuns: SummaryRun[] = []) {
+  getMock.mockImplementation(async (path: string) => {
+    if (path === '/api/summaries/runs') {
+      return {
+        data: {
+          success: true,
+          items: [detailRun, ...extraRuns],
+        },
+      }
+    }
+
+    if (path === `/api/summaries/runs/${detailRun.id}`) {
+      return {
+        data: {
+          success: true,
+          item: detailRun,
+        },
+      }
+    }
+
+    const matchingExtraRun = extraRuns.find((item) => `/api/summaries/runs/${item.id}` === path)
+    if (matchingExtraRun) {
+      return {
+        data: {
+          success: true,
+          item: matchingExtraRun,
+        },
+      }
+    }
+
+    return { data: { success: false } }
+  })
+}
+
+function getRequestBody(options: unknown): Record<string, unknown> {
+  if (typeof options !== 'object' || options === null || !('body' in options)) {
+    return {}
+  }
+  const body = options.body
+  return typeof body === 'object' && body !== null ? body as Record<string, unknown> : {}
+}
+
 describe('SummaryRunsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -45,294 +322,14 @@ describe('SummaryRunsPage', () => {
 
   it('renders summary run history and detail with delivery audit metadata', async () => {
     const user = userEvent.setup()
-
-    getMock.mockImplementation(async (path: string) => {
-      if (path === '/api/summaries/runs') {
-        return {
-          data: {
-            success: true,
-            items: [
-              {
-                id: 'run-1',
-                workspaceSlug: 'dev',
-                period: 'weekly',
-                triggerSource: 'api_manual',
-                status: 'sent',
-                channel: 'telegram',
-                dryRun: false,
-                windowStart: '2026-03-25T00:00:00Z',
-                windowEnd: '2026-03-26T00:00:00Z',
-                startedAt: '2026-03-26T00:05:00Z',
-                finishedAt: '2026-03-26T00:05:30Z',
-                report: {
-                  workspaceSlug: 'dev',
-                  period: 'weekly',
-                  generatedAt: '2026-03-26T00:05:00Z',
-                  window: {
-                    startAt: '2026-03-25T00:00:00Z',
-                    endAt: '2026-03-26T00:00:00Z',
-                    timezone: 'UTC',
-                  },
-                  comparison: {
-                    previousWindow: {
-                      startAt: '2026-03-18T00:00:00Z',
-                      endAt: '2026-03-25T00:00:00Z',
-                      timezone: 'UTC',
-                    },
-                    totalsDelta: {
-                      sharedIngest: {
-                        newResumes: 2,
-                        collectionTasksCompleted: 1,
-                        collectionTasksFailed: 0,
-                      },
-                      workspaceActivity: {
-                        candidateStatusUpdates: 1,
-                        shortlistActions: 1,
-                        rejectActions: 0,
-                        contactActions: 1,
-                      },
-                    },
-                  },
-                  totals: {
-                    newResumes: 2,
-                    candidateStatusUpdates: 1,
-                    shortlistActions: 1,
-                    rejectActions: 0,
-                    contactActions: 1,
-                    collectionTasksCompleted: 1,
-                    collectionTasksFailed: 0,
-                  },
-                  breakdowns: {
-                    resumesBySource: [],
-                    candidateStatusByValue: [],
-                    actionsByType: [],
-                    collectionTasksByStatus: [],
-                  },
-                  notes: ['First run note'],
-                },
-                delivery: {
-                  channel: 'telegram',
-                  accountsAttempted: 1,
-                  accountsSent: 1,
-                  totalBatches: 2,
-                  usedOverrideChatId: true,
-                },
-              },
-              {
-                id: 'run-2',
-                workspaceSlug: 'dev',
-                period: 'daily',
-                triggerSource: 'worker_schedule',
-                status: 'failed',
-                channel: 'telegram',
-                dryRun: false,
-                windowStart: '2026-03-24T00:00:00Z',
-                windowEnd: '2026-03-25T00:00:00Z',
-                startedAt: '2026-03-25T00:05:00Z',
-                finishedAt: '2026-03-25T00:05:45Z',
-                report: {
-                  workspaceSlug: 'dev',
-                  period: 'daily',
-                  generatedAt: '2026-03-25T00:05:00Z',
-                  window: {
-                    startAt: '2026-03-24T00:00:00Z',
-                    endAt: '2026-03-25T00:00:00Z',
-                    timezone: 'UTC',
-                  },
-                  totals: {
-                    newResumes: 0,
-                    candidateStatusUpdates: 0,
-                    shortlistActions: 0,
-                    rejectActions: 0,
-                    contactActions: 0,
-                    collectionTasksCompleted: 0,
-                    collectionTasksFailed: 1,
-                  },
-                  breakdowns: {
-                    resumesBySource: [],
-                    candidateStatusByValue: [],
-                    actionsByType: [],
-                    collectionTasksByStatus: [],
-                  },
-                  notes: [],
-                },
-                delivery: {
-                  channel: 'telegram',
-                  accountsAttempted: 1,
-                  accountsSent: 0,
-                  totalBatches: 3,
-                },
-              },
-            ],
-          },
-        }
-      }
-
-      if (path === '/api/summaries/runs/run-1') {
-        return {
-          data: {
-            success: true,
-            item: {
-              id: 'run-1',
-              workspaceSlug: 'dev',
-              period: 'weekly',
-              triggerSource: 'api_manual',
-              status: 'sent',
-              channel: 'telegram',
-              dryRun: false,
-              windowStart: '2026-03-25T00:00:00Z',
-              windowEnd: '2026-03-26T00:00:00Z',
-              startedAt: '2026-03-26T00:05:00Z',
-              finishedAt: '2026-03-26T00:05:30Z',
-              report: {
-                workspaceSlug: 'dev',
-                period: 'weekly',
-                generatedAt: '2026-03-26T00:05:00Z',
-                window: {
-                  startAt: '2026-03-25T00:00:00Z',
-                  endAt: '2026-03-26T00:00:00Z',
-                  timezone: 'UTC',
-                },
-                comparison: {
-                  previousWindow: {
-                    startAt: '2026-03-18T00:00:00Z',
-                    endAt: '2026-03-25T00:00:00Z',
-                    timezone: 'UTC',
-                  },
-                  totalsDelta: {
-                    sharedIngest: {
-                      newResumes: 2,
-                      collectionTasksCompleted: 1,
-                      collectionTasksFailed: 0,
-                    },
-                    workspaceActivity: {
-                      candidateStatusUpdates: 1,
-                      shortlistActions: 1,
-                      rejectActions: 0,
-                      contactActions: 1,
-                    },
-                  },
-                },
-                totals: {
-                  newResumes: 2,
-                  candidateStatusUpdates: 1,
-                  shortlistActions: 1,
-                  rejectActions: 0,
-                  contactActions: 1,
-                  collectionTasksCompleted: 1,
-                  collectionTasksFailed: 0,
-                },
-                breakdowns: {
-                  resumesBySource: [],
-                  candidateStatusByValue: [],
-                  actionsByType: [],
-                  collectionTasksByStatus: [],
-                },
-                notes: ['First run note'],
-              },
-              content: 'Rendered summary content',
-              delivery: {
-                channel: 'telegram',
-                accountsConfigured: 2,
-                accountsSelected: 2,
-                accountsAttempted: 1,
-                accountsSent: 1,
-                totalBatches: 2,
-                usedOverrideChatId: true,
-                accounts: [
-                  {
-                    index: 1,
-                    chatIdHint: '***1234',
-                    attempted: true,
-                    sent: true,
-                    batchesPlanned: 2,
-                  },
-                  {
-                    index: 2,
-                    chatIdHint: '***5678',
-                    attempted: false,
-                    sent: false,
-                    batchesPlanned: 0,
-                    skippedReason: 'missing token or chat_id',
-                  },
-                ],
-              },
-            },
-          },
-        }
-      }
-
-      if (path === '/api/summaries/runs/run-2') {
-        return {
-          data: {
-            success: true,
-            item: {
-              id: 'run-2',
-              workspaceSlug: 'dev',
-              period: 'daily',
-              triggerSource: 'worker_schedule',
-              status: 'failed',
-              channel: 'telegram',
-              dryRun: false,
-              windowStart: '2026-03-24T00:00:00Z',
-              windowEnd: '2026-03-25T00:00:00Z',
-              startedAt: '2026-03-25T00:05:00Z',
-              finishedAt: '2026-03-25T00:05:45Z',
-              report: {
-                workspaceSlug: 'dev',
-                period: 'daily',
-                generatedAt: '2026-03-25T00:05:00Z',
-                window: {
-                  startAt: '2026-03-24T00:00:00Z',
-                  endAt: '2026-03-25T00:00:00Z',
-                  timezone: 'UTC',
-                },
-                totals: {
-                  newResumes: 0,
-                  candidateStatusUpdates: 0,
-                  shortlistActions: 0,
-                  rejectActions: 0,
-                  contactActions: 0,
-                  collectionTasksCompleted: 0,
-                  collectionTasksFailed: 1,
-                },
-                breakdowns: {
-                  resumesBySource: [],
-                  candidateStatusByValue: [],
-                  actionsByType: [],
-                  collectionTasksByStatus: [],
-                },
-                notes: [],
-              },
-              content: 'Failed summary content',
-              delivery: {
-                channel: 'telegram',
-                accountsAttempted: 1,
-                accountsSent: 0,
-                totalBatches: 3,
-                accounts: [
-                  {
-                    index: 1,
-                    chatIdHint: '***9999',
-                    attempted: true,
-                    sent: false,
-                    batchesPlanned: 3,
-                  },
-                ],
-              },
-              error: 'Telegram summary delivery failed',
-            },
-          },
-        }
-      }
-
-      return { data: { success: false } }
-    })
+    const weeklyRun = createWeeklyRun()
+    const failedRun = createDailyFailedRun()
+    createListAndDetailMocks(weeklyRun, [failedRun])
 
     renderSummaryRunsPage()
 
     expect(await screen.findByText('run-1')).toBeInTheDocument()
-    expect(await screen.findAllByText('Weekly')).toHaveLength(2)
+    expect(await screen.findAllByText('Weekly')).toHaveLength(3)
     expect(await screen.findAllByText(/1\/1 sent • 2 batches • override/i)).toHaveLength(2)
     expect(await screen.findByText(/Compared with previous week • shared ingest \+2 resumes • workspace \+1 status/i)).toBeInTheDocument()
     expect(await screen.findByText(/Previous period window/i)).toBeInTheDocument()
@@ -349,5 +346,169 @@ describe('SummaryRunsPage', () => {
     expect(screen.getByText('***9999')).toBeInTheDocument()
     expect(screen.getByText('Telegram summary delivery failed')).toBeInTheDocument()
     expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('reuses the selected run and submits preview and send actions', async () => {
+    const user = userEvent.setup()
+    const weeklyRun = createWeeklyRun()
+    createListAndDetailMocks(weeklyRun)
+
+    postMock.mockImplementation(async (path: string, options?: unknown) => {
+      expect(path).toBe('/api/summaries/run')
+      const body = getRequestBody(options)
+
+      if (body.dryRun === true) {
+        return {
+          data: {
+            success: true,
+            channel: body.channel,
+            dryRun: true,
+            templateId: body.templateId ?? 'summary-daily',
+            subject: body.subject ?? 'Preview subject',
+            report: weeklyRun.report,
+            content: 'Preview content from dry run',
+            run: createWeeklyRun({
+              id: 'run-preview',
+              status: 'dry_run',
+              dryRun: true,
+              channel: (typeof body.channel === 'string' ? body.channel : 'email') as SummaryRun['channel'],
+              templateId: typeof body.templateId === 'string' ? body.templateId : 'summary-daily',
+              windowEnd: typeof body.endAt === 'string' ? body.endAt : weeklyRun.windowEnd,
+              content: 'Preview content from dry run',
+              delivery: undefined,
+            }),
+          },
+        }
+      }
+
+      return {
+        data: {
+          success: true,
+          channel: body.channel,
+          dryRun: false,
+          templateId: body.templateId ?? 'summary-daily',
+          subject: body.subject ?? 'Send subject',
+          report: weeklyRun.report,
+          content: 'Sent content from run',
+          delivery: {
+            channel: body.channel,
+            accountsAttempted: 1,
+            accountsSent: 1,
+            totalBatches: 1,
+          },
+          run: createWeeklyRun({
+            id: 'run-send',
+            status: 'sent',
+            dryRun: false,
+            channel: (typeof body.channel === 'string' ? body.channel : 'telegram') as SummaryRun['channel'],
+            templateId: typeof body.templateId === 'string' ? body.templateId : 'summary-daily',
+            windowEnd: typeof body.endAt === 'string' ? body.endAt : weeklyRun.windowEnd,
+            content: 'Sent content from run',
+            delivery: {
+              channel: typeof body.channel === 'string' ? body.channel : 'telegram',
+              accountsAttempted: 1,
+              accountsSent: 1,
+              totalBatches: 1,
+            },
+          }),
+        },
+      }
+    })
+
+    renderSummaryRunsPage()
+
+    expect(await screen.findByText('Rendered summary content')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Use selected run' }))
+
+    expect(screen.getByLabelText('Period')).toHaveValue('weekly')
+    expect(screen.getByLabelText('Channel')).toHaveValue('telegram')
+    expect(screen.getByLabelText('Template ID')).toHaveValue('summary-daily')
+    expect(screen.getByLabelText('Window end (ISO8601)')).toHaveValue('2026-03-26T00:00:00Z')
+
+    await user.selectOptions(screen.getByLabelText('Channel'), 'email')
+    expect(screen.getByLabelText('Email recipient')).toBeInTheDocument()
+    expect(screen.getByLabelText('Subject override')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Telegram bot token override')).not.toBeInTheDocument()
+
+    await user.type(screen.getByLabelText('Email recipient'), 'ops@example.com')
+    await user.type(screen.getByLabelText('Subject override'), 'Weekly digest')
+    await user.click(screen.getByRole('button', { name: 'Preview summary' }))
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledTimes(1)
+    })
+    expect(postMock.mock.calls[0]?.[0]).toBe('/api/summaries/run')
+    expect(postMock.mock.calls[0]?.[1]).toMatchObject({
+      body: {
+        period: 'weekly',
+        channel: 'email',
+        dryRun: true,
+        templateId: 'summary-daily',
+        endAt: '2026-03-26T00:00:00Z',
+        to: 'ops@example.com',
+        subject: 'Weekly digest',
+      },
+    })
+    expect(await screen.findByText('Preview content from dry run')).toBeInTheDocument()
+    expect(await screen.findByText('run-preview')).toBeInTheDocument()
+    expect(toastSuccessMock).toHaveBeenCalledWith('Summary preview generated')
+
+    await user.selectOptions(screen.getByLabelText('Channel'), 'telegram')
+    expect(screen.queryByLabelText('Email recipient')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Telegram bot token override')).toBeInTheDocument()
+    expect(screen.getByLabelText('Telegram chat ID override')).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText('Telegram bot token override'), 'bot-1')
+    await user.type(screen.getByLabelText('Telegram chat ID override'), 'chat-1')
+    await user.click(screen.getByRole('button', { name: 'Send summary' }))
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledTimes(2)
+    })
+    expect(postMock.mock.calls[1]?.[1]).toMatchObject({
+      body: {
+        period: 'weekly',
+        channel: 'telegram',
+        dryRun: false,
+        templateId: 'summary-daily',
+        endAt: '2026-03-26T00:00:00Z',
+        botToken: 'bot-1',
+        chatId: 'chat-1',
+      },
+    })
+    expect(postMock.mock.calls[1]?.[1]).not.toMatchObject({
+      body: {
+        to: 'ops@example.com',
+        subject: 'Weekly digest',
+      },
+    })
+    expect(await screen.findByText('Sent content from run')).toBeInTheDocument()
+    expect(await screen.findByText('run-send')).toBeInTheDocument()
+    expect(toastSuccessMock).toHaveBeenCalledWith('Summary sent')
+  })
+
+  it('shows an error toast for failed run actions and preserves the current detail', async () => {
+    const user = userEvent.setup()
+    const weeklyRun = createWeeklyRun()
+    createListAndDetailMocks(weeklyRun)
+
+    postMock.mockResolvedValue({
+      error: {
+        message: 'Failed to send summary',
+      },
+    })
+
+    renderSummaryRunsPage()
+
+    expect(await screen.findByText('Rendered summary content')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Preview summary' }))
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledTimes(1)
+    })
+    expect(toastErrorMock).toHaveBeenCalledWith('Failed to send summary')
+    expect(screen.getByText('Rendered summary content')).toBeInTheDocument()
   })
 })

--- a/apps/web/src/pages/SummaryRunsPage.tsx
+++ b/apps/web/src/pages/SummaryRunsPage.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useState } from 'react'
-import { RefreshCw } from 'lucide-react'
+import { RefreshCw, RotateCcw, Send, Sparkles } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select } from '@/components/ui/select'
 import { PageHeader } from '@/components/PageHeader'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { rawApiClient } from '@/lib/api-helpers'
@@ -12,12 +15,58 @@ import type { paths } from '@/lib/api-types'
 
 type SummaryRunListResponse = paths['/api/summaries/runs']['get']['responses'][200]['content']['application/json']
 type SummaryRunDetailResponse = paths['/api/summaries/runs/{runId}']['get']['responses'][200]['content']['application/json']
+type SummaryRunRequest = NonNullable<paths['/api/summaries/run']['post']['requestBody']>['content']['application/json']
+type SummaryRunResponse = paths['/api/summaries/run']['post']['responses'][200]['content']['application/json']
 type SummaryRunItem = SummaryRunListResponse['items'][number]
 type SummaryRunDetailItem = SummaryRunDetailResponse['item']
 type SummaryDelivery = NonNullable<SummaryRunDetailItem['delivery']>
 type SummaryDeliveryAccount = NonNullable<SummaryDelivery['accounts']>[number]
+type SummaryPeriod = NonNullable<SummaryRunRequest['period']>
+type SummaryChannel = NonNullable<SummaryRunRequest['channel']>
+type SummaryRunFormState = {
+  period: SummaryPeriod
+  channel: SummaryChannel
+  templateId: string
+  endAt: string
+  to: string
+  subject: string
+  webhookUrl: string
+  botToken: string
+  chatId: string
+}
 
 const SUMMARY_RUN_LIST_LIMIT = 20
+const DEFAULT_SUMMARY_RUN_FORM: SummaryRunFormState = {
+  period: 'daily',
+  channel: 'telegram',
+  templateId: '',
+  endAt: '',
+  to: '',
+  subject: '',
+  webhookUrl: '',
+  botToken: '',
+  chatId: '',
+}
+
+const SUMMARY_PERIOD_OPTIONS: Array<{ value: SummaryPeriod; label: string }> = [
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekly', label: 'Weekly' },
+]
+
+const SUMMARY_CHANNEL_OPTIONS: Array<{ value: SummaryChannel; label: string }> = [
+  { value: 'telegram', label: 'Telegram' },
+  { value: 'wechat_work', label: 'WeChat Work' },
+  { value: 'feishu', label: 'Feishu' },
+  { value: 'email', label: 'Email' },
+]
+
+function isSummaryPeriod(value: string): value is SummaryPeriod {
+  return value === 'daily' || value === 'weekly'
+}
+
+function isSummaryChannel(value: string): value is SummaryChannel {
+  return value === 'telegram' || value === 'wechat_work' || value === 'feishu' || value === 'email'
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
@@ -48,6 +97,11 @@ function extractApiErrorMessage(error: unknown): string | null {
   }
 
   return readString(error.error)
+}
+
+function normalizeOptionalString(value: string): string | undefined {
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
 }
 
 function formatTimestamp(value: string | undefined): string {
@@ -162,14 +216,20 @@ function getRunStatusVariant(status: SummaryRunItem['status']) {
   return 'outline' as const
 }
 
+function mergeRunIntoList(runs: SummaryRunItem[], run: SummaryRunDetailItem): SummaryRunItem[] {
+  return [run, ...runs.filter((item) => item.id !== run.id)].slice(0, SUMMARY_RUN_LIST_LIMIT)
+}
+
 export function SummaryRunsPage() {
   const { t } = useTranslation()
   const [runs, setRuns] = useState<SummaryRunItem[]>([])
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
   const [selectedRun, setSelectedRun] = useState<SummaryRunDetailItem | null>(null)
+  const [runForm, setRunForm] = useState<SummaryRunFormState>(DEFAULT_SUMMARY_RUN_FORM)
   const [loading, setLoading] = useState(true)
   const [detailLoading, setDetailLoading] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
+  const [submittingMode, setSubmittingMode] = useState<'preview' | 'send' | null>(null)
 
   const loadRunDetail = useCallback(async (runId: string) => {
     setDetailLoading(true)
@@ -234,6 +294,117 @@ export function SummaryRunsPage() {
 
   const selectedRunSummary = formatDeliverySummary(selectedRun?.delivery)
   const selectedRunComparisonSummary = formatComparisonSummary(selectedRun)
+  const submittingPreview = submittingMode === 'preview'
+  const submittingSend = submittingMode === 'send'
+  const submitting = submittingMode !== null
+
+  function updateRunForm<Key extends keyof SummaryRunFormState>(key: Key, value: SummaryRunFormState[Key]) {
+    setRunForm((current) => ({
+      ...current,
+      [key]: value,
+    }))
+  }
+
+  function buildRunRequest(dryRun: boolean): SummaryRunRequest {
+    const request: SummaryRunRequest = {
+      period: runForm.period,
+      channel: runForm.channel,
+      dryRun,
+    }
+
+    const templateId = normalizeOptionalString(runForm.templateId)
+    if (templateId) {
+      request.templateId = templateId
+    }
+
+    const endAt = normalizeOptionalString(runForm.endAt)
+    if (endAt) {
+      request.endAt = endAt
+    }
+
+    if (runForm.channel === 'email') {
+      const to = normalizeOptionalString(runForm.to)
+      if (to) {
+        request.to = to
+      }
+
+      const subject = normalizeOptionalString(runForm.subject)
+      if (subject) {
+        request.subject = subject
+      }
+    }
+
+    if (runForm.channel === 'wechat_work' || runForm.channel === 'feishu') {
+      const webhookUrl = normalizeOptionalString(runForm.webhookUrl)
+      if (webhookUrl) {
+        request.webhookUrl = webhookUrl
+      }
+    }
+
+    if (runForm.channel === 'telegram') {
+      const botToken = normalizeOptionalString(runForm.botToken)
+      if (botToken) {
+        request.botToken = botToken
+      }
+
+      const chatId = normalizeOptionalString(runForm.chatId)
+      if (chatId) {
+        request.chatId = chatId
+      }
+    }
+
+    return request
+  }
+
+  async function handleRunAction(mode: 'preview' | 'send') {
+    setSubmittingMode(mode)
+    try {
+      const { data, error } = await rawApiClient.POST<SummaryRunResponse>('/api/summaries/run', {
+        body: buildRunRequest(mode === 'preview'),
+      })
+      if (error || !data?.success) {
+        throw new Error(extractApiErrorMessage(error) ?? `Failed to ${mode} summary`)
+      }
+
+      setRuns((current) => mergeRunIntoList(current, data.run))
+      setSelectedRunId(data.run.id)
+      setSelectedRun(data.run)
+      toast.success(
+        mode === 'preview'
+          ? t('summaries.previewSuccess', { defaultValue: 'Summary preview generated' })
+          : t('summaries.sendSuccess', { defaultValue: 'Summary sent' }),
+      )
+    } catch (error) {
+      console.error(`Failed to ${mode} summary`, error)
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : mode === 'preview'
+            ? t('summaries.previewError', { defaultValue: 'Failed to preview summary' })
+            : t('summaries.sendError', { defaultValue: 'Failed to send summary' }),
+      )
+    } finally {
+      setSubmittingMode(null)
+    }
+  }
+
+  function handleUseSelectedRun() {
+    if (!selectedRun) {
+      return
+    }
+
+    setRunForm({
+      period: selectedRun.period,
+      channel: selectedRun.channel ?? DEFAULT_SUMMARY_RUN_FORM.channel,
+      templateId: selectedRun.templateId ?? '',
+      endAt: selectedRun.windowEnd,
+      to: '',
+      subject: '',
+      webhookUrl: '',
+      botToken: '',
+      chatId: '',
+    })
+  }
 
   async function handleRefresh() {
     setRefreshing(true)
@@ -329,6 +500,191 @@ export function SummaryRunsPage() {
         </Card>
 
         <div className="space-y-6 min-w-0">
+          <Card>
+            <CardHeader>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <CardTitle>{t('summaries.runTitle', { defaultValue: 'Run summary' })}</CardTitle>
+                  <CardDescription>
+                    {t('summaries.runDescription', {
+                      defaultValue: 'Preview the outbound summary content as a dry-run, then send it through the selected channel using the existing summary ledger.',
+                    })}
+                  </CardDescription>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleUseSelectedRun}
+                  disabled={!selectedRun || submitting}
+                >
+                  <RotateCcw className="mr-2 h-4 w-4" />
+                  {t('summaries.useSelectedRun', { defaultValue: 'Use selected run' })}
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="summary-period">
+                    {t('summaries.formPeriod', { defaultValue: 'Period' })}
+                  </Label>
+                  <Select
+                    id="summary-period"
+                    value={runForm.period}
+                    onChange={(event) => {
+                      if (isSummaryPeriod(event.target.value)) {
+                        updateRunForm('period', event.target.value)
+                      }
+                    }}
+                    options={SUMMARY_PERIOD_OPTIONS}
+                    disabled={submitting}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="summary-channel">
+                    {t('summaries.formChannel', { defaultValue: 'Channel' })}
+                  </Label>
+                  <Select
+                    id="summary-channel"
+                    value={runForm.channel}
+                    onChange={(event) => {
+                      if (isSummaryChannel(event.target.value)) {
+                        updateRunForm('channel', event.target.value)
+                      }
+                    }}
+                    options={SUMMARY_CHANNEL_OPTIONS}
+                    disabled={submitting}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="summary-template-id">
+                    {t('summaries.formTemplateId', { defaultValue: 'Template ID' })}
+                  </Label>
+                  <Input
+                    id="summary-template-id"
+                    value={runForm.templateId}
+                    onChange={(event) => updateRunForm('templateId', event.target.value)}
+                    placeholder="summary-daily"
+                    disabled={submitting}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="summary-end-at">
+                    {t('summaries.formEndAt', { defaultValue: 'Window end (ISO8601)' })}
+                  </Label>
+                  <Input
+                    id="summary-end-at"
+                    value={runForm.endAt}
+                    onChange={(event) => updateRunForm('endAt', event.target.value)}
+                    placeholder="2026-03-26T00:00:00Z"
+                    disabled={submitting}
+                  />
+                </div>
+              </div>
+
+              {runForm.channel === 'email' ? (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="summary-to">
+                      {t('summaries.formEmailTo', { defaultValue: 'Email recipient' })}
+                    </Label>
+                    <Input
+                      id="summary-to"
+                      value={runForm.to}
+                      onChange={(event) => updateRunForm('to', event.target.value)}
+                      placeholder="ops@example.com"
+                      disabled={submitting}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="summary-subject">
+                      {t('summaries.formSubject', { defaultValue: 'Subject override' })}
+                    </Label>
+                    <Input
+                      id="summary-subject"
+                      value={runForm.subject}
+                      onChange={(event) => updateRunForm('subject', event.target.value)}
+                      placeholder="Weekly Ops Summary dev"
+                      disabled={submitting}
+                    />
+                  </div>
+                </div>
+              ) : null}
+
+              {(runForm.channel === 'wechat_work' || runForm.channel === 'feishu') ? (
+                <div className="space-y-2">
+                  <Label htmlFor="summary-webhook-url">
+                    {t('summaries.formWebhookUrl', { defaultValue: 'Webhook URL override' })}
+                  </Label>
+                  <Input
+                    id="summary-webhook-url"
+                    value={runForm.webhookUrl}
+                    onChange={(event) => updateRunForm('webhookUrl', event.target.value)}
+                    placeholder="https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=***"
+                    disabled={submitting}
+                  />
+                </div>
+              ) : null}
+
+              {runForm.channel === 'telegram' ? (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="summary-bot-token">
+                      {t('summaries.formBotToken', { defaultValue: 'Telegram bot token override' })}
+                    </Label>
+                    <Input
+                      id="summary-bot-token"
+                      value={runForm.botToken}
+                      onChange={(event) => updateRunForm('botToken', event.target.value)}
+                      placeholder="123456:ABCDEF"
+                      disabled={submitting}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="summary-chat-id">
+                      {t('summaries.formChatId', { defaultValue: 'Telegram chat ID override' })}
+                    </Label>
+                    <Input
+                      id="summary-chat-id"
+                      value={runForm.chatId}
+                      onChange={(event) => updateRunForm('chatId', event.target.value)}
+                      placeholder="-1001234567890"
+                      disabled={submitting}
+                    />
+                  </div>
+                </div>
+              ) : null}
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    void handleRunAction('preview')
+                  }}
+                  disabled={submitting}
+                >
+                  <Sparkles className="mr-2 h-4 w-4" />
+                  {submittingPreview
+                    ? t('summaries.previewSubmitting', { defaultValue: 'Previewing…' })
+                    : t('summaries.previewAction', { defaultValue: 'Preview summary' })}
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => {
+                    void handleRunAction('send')
+                  }}
+                  disabled={submitting}
+                >
+                  <Send className="mr-2 h-4 w-4" />
+                  {submittingSend
+                    ? t('summaries.sendSubmitting', { defaultValue: 'Sending…' })
+                    : t('summaries.sendAction', { defaultValue: 'Send summary' })}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
           <Card>
             <CardHeader>
               <CardTitle>{t('summaries.detailTitle', { defaultValue: 'Run detail' })}</CardTitle>


### PR DESCRIPTION
## Summary
- add preview and send controls to the summary runs page using the existing /api/summaries/run contract
- support reusing the selected historical run to prefill period, channel, template, and window end
- extend SummaryRunsPage tests for preview, send, and failure handling

## Validation
- npm --workspace @trends/web test -- --run src/pages/SummaryRunsPage.test.tsx
- bun run --filter '@trends/web' typecheck
- make check