### PR TITLE
feat(api): add summary profile routes

### DIFF
--- a/apps/api/src/routes/summaries.test.ts
+++ b/apps/api/src/routes/summaries.test.ts
@@ -129,6 +129,7 @@ async function loadSummaryModules(root: string) {
   const { ActionStorage } = await import("../services/action-storage");
   const { ReviewPacketStorage } = await import("../services/review-packet-storage");
   const { summaryTelegramBridge } = await import("../services/summaries/summary-telegram-bridge");
+  const { workspaceConfigService } = await import("../services/workspace-config-service");
   const { resetResumeScreeningDb } = await import("../services/database");
   return {
     createApp,
@@ -136,7 +137,39 @@ async function loadSummaryModules(root: string) {
     ActionStorage,
     ReviewPacketStorage,
     summaryTelegramBridge,
+    workspaceConfigService,
     resetResumeScreeningDb,
+  };
+}
+
+function createSummaryProfile(overrides: {
+  id?: string;
+  name?: string;
+  enabled?: boolean;
+  cron?: string;
+  period?: "daily" | "weekly";
+  channel?: "email" | "wechat_work" | "feishu" | "telegram";
+  dryRun?: boolean;
+  templateId?: string;
+  to?: string;
+  subject?: string;
+} = {}) {
+  const channel = overrides.channel ?? "telegram";
+  return {
+    id: overrides.id ?? "daily-ops",
+    name: overrides.name ?? "Daily Ops",
+    enabled: overrides.enabled ?? true,
+    schedule: {
+      cron: overrides.cron ?? "0 9 * * *",
+    },
+    request: {
+      period: overrides.period ?? "daily",
+      channel,
+      dryRun: overrides.dryRun ?? false,
+      ...(overrides.templateId ? { templateId: overrides.templateId } : {}),
+      ...(channel === "email" && overrides.to ? { to: overrides.to } : {}),
+      ...(channel === "email" && overrides.subject ? { subject: overrides.subject } : {}),
+    },
   };
 }
 
@@ -774,5 +807,294 @@ describe("summary preview route", () => {
       },
     });
     expect(missingResponse.status).toBe(404);
+  });
+
+  it("creates and lists workspace summary profiles for admin workspaces", async () => {
+    root = createFixtureRoot();
+    const {
+      createApp,
+      workspaceConfigService,
+    } = await loadSummaryModules(root);
+
+    const profile = createSummaryProfile();
+    const getProfilesSpy = vi.spyOn(workspaceConfigService, "getWorkspaceSummaryProfiles")
+      .mockResolvedValueOnce({ profiles: [] })
+      .mockResolvedValueOnce({ profiles: [profile] });
+    const setProfilesSpy = vi.spyOn(workspaceConfigService, "setWorkspaceSummaryProfiles").mockResolvedValue();
+
+    const app = createApp();
+    const createResponse = await app.request("/api/summaries/profiles", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify(profile),
+    });
+
+    expect(createResponse.status).toBe(201);
+    expect(setProfilesSpy).toHaveBeenCalledWith("dev", {
+      profiles: [profile],
+    });
+    expect(await createResponse.json()).toEqual({
+      success: true,
+      profile,
+    });
+
+    const listResponse = await app.request("/api/summaries/profiles", {
+      headers: {
+        "X-Workspace-Slug": "dev",
+      },
+    });
+
+    expect(listResponse.status).toBe(200);
+    expect(getProfilesSpy).toHaveBeenCalledTimes(2);
+    expect(await listResponse.json()).toEqual({
+      success: true,
+      profiles: [profile],
+    });
+  });
+
+  it("blocks hr users from reading or mutating workspace summary profiles", async () => {
+    root = createFixtureRoot();
+    const {
+      createApp,
+      workspaceConfigService,
+    } = await loadSummaryModules(root);
+
+    const getProfilesSpy = vi.spyOn(workspaceConfigService, "getWorkspaceSummaryProfiles");
+    const setProfilesSpy = vi.spyOn(workspaceConfigService, "setWorkspaceSummaryProfiles").mockResolvedValue();
+
+    const app = createApp();
+    const listResponse = await app.request("/api/summaries/profiles", {
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+    });
+    expect(listResponse.status).toBe(403);
+    expect(await listResponse.json()).toEqual({
+      success: false,
+      error: "Admin access required",
+    });
+
+    const createResponse = await app.request("/api/summaries/profiles", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify(createSummaryProfile()),
+    });
+    expect(createResponse.status).toBe(403);
+    expect(await createResponse.json()).toEqual({
+      success: false,
+      error: "Admin access required",
+    });
+    expect(getProfilesSpy).not.toHaveBeenCalled();
+    expect(setProfilesSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects duplicate summary profile ids in the same workspace", async () => {
+    root = createFixtureRoot();
+    const {
+      createApp,
+      workspaceConfigService,
+    } = await loadSummaryModules(root);
+
+    const profile = createSummaryProfile();
+    vi.spyOn(workspaceConfigService, "getWorkspaceSummaryProfiles").mockResolvedValue({
+      profiles: [profile],
+    });
+    const setProfilesSpy = vi.spyOn(workspaceConfigService, "setWorkspaceSummaryProfiles").mockResolvedValue();
+
+    const app = createApp();
+    const response = await app.request("/api/summaries/profiles", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify(profile),
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: `Summary profile already exists: ${profile.id}`,
+    });
+    expect(setProfilesSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for missing workspace-local summary profiles", async () => {
+    root = createFixtureRoot();
+    const {
+      createApp,
+      workspaceConfigService,
+    } = await loadSummaryModules(root);
+
+    vi.spyOn(workspaceConfigService, "getWorkspaceSummaryProfiles").mockResolvedValue({
+      profiles: [],
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/summaries/profiles/missing-profile", {
+      headers: {
+        "X-Workspace-Slug": "dev",
+      },
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Summary profile not found: missing-profile",
+    });
+  });
+
+  it("preserves immutable summary profile ids on update", async () => {
+    root = createFixtureRoot();
+    const {
+      createApp,
+      workspaceConfigService,
+    } = await loadSummaryModules(root);
+
+    const existingProfile = createSummaryProfile({ id: "daily-ops", name: "Daily Ops" });
+    vi.spyOn(workspaceConfigService, "getWorkspaceSummaryProfiles").mockResolvedValue({
+      profiles: [existingProfile],
+    });
+    const setProfilesSpy = vi.spyOn(workspaceConfigService, "setWorkspaceSummaryProfiles").mockResolvedValue();
+
+    const app = createApp();
+    const response = await app.request("/api/summaries/profiles/daily-ops", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify(createSummaryProfile({
+        id: "renamed-profile",
+        name: "Updated Daily Ops",
+        cron: "0 10 * * *",
+      })),
+    });
+
+    expect(response.status).toBe(200);
+    expect(setProfilesSpy).toHaveBeenCalledWith("dev", {
+      profiles: [
+        createSummaryProfile({
+          id: "daily-ops",
+          name: "Updated Daily Ops",
+          cron: "0 10 * * *",
+        }),
+      ],
+    });
+    expect(await response.json()).toEqual({
+      success: true,
+      profile: createSummaryProfile({
+        id: "daily-ops",
+        name: "Updated Daily Ops",
+        cron: "0 10 * * *",
+      }),
+    });
+  });
+
+  it("deletes workspace-local summary profiles", async () => {
+    root = createFixtureRoot();
+    const {
+      createApp,
+      workspaceConfigService,
+    } = await loadSummaryModules(root);
+
+    const keptProfile = createSummaryProfile({ id: "weekly-ops", period: "weekly", name: "Weekly Ops" });
+    vi.spyOn(workspaceConfigService, "getWorkspaceSummaryProfiles").mockResolvedValue({
+      profiles: [
+        createSummaryProfile({ id: "daily-ops" }),
+        keptProfile,
+      ],
+    });
+    const setProfilesSpy = vi.spyOn(workspaceConfigService, "setWorkspaceSummaryProfiles").mockResolvedValue();
+
+    const app = createApp();
+    const response = await app.request("/api/summaries/profiles/daily-ops", {
+      method: "DELETE",
+      headers: {
+        "X-Workspace-Slug": "dev",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(setProfilesSpy).toHaveBeenCalledWith("dev", {
+      profiles: [keptProfile],
+    });
+    expect(await response.json()).toEqual({ success: true });
+  });
+
+  it("aggregates only enabled runtime profiles across known workspaces", async () => {
+    root = createFixtureRoot();
+    const {
+      createApp,
+      workspaceConfigService,
+    } = await loadSummaryModules(root);
+
+    vi.spyOn(workspaceConfigService, "getWorkspaceSummaryProfiles").mockImplementation(async (workspaceSlug) => {
+      if (workspaceSlug === "dev") {
+        return {
+          profiles: [
+            createSummaryProfile({ id: "dev-daily", name: "Dev Daily" }),
+            createSummaryProfile({ id: "dev-disabled", enabled: false, name: "Dev Disabled" }),
+          ],
+        };
+      }
+
+      if (workspaceSlug === "hr") {
+        return {
+          profiles: [
+            createSummaryProfile({
+              id: "hr-weekly",
+              name: "HR Weekly",
+              period: "weekly",
+              channel: "email",
+              to: "ops@example.com",
+              subject: "Weekly HR Summary",
+            }),
+          ],
+        };
+      }
+
+      return { profiles: [] };
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/summaries/profiles/runtime", {
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      items: [
+        {
+          workspaceSlug: "dev",
+          profileId: "dev-daily",
+          name: "Dev Daily",
+          cron: "0 9 * * *",
+          period: "daily",
+          channel: "telegram",
+          dryRun: false,
+        },
+        {
+          workspaceSlug: "hr",
+          profileId: "hr-weekly",
+          name: "HR Weekly",
+          cron: "0 9 * * *",
+          period: "weekly",
+          channel: "email",
+          dryRun: false,
+          to: "ops@example.com",
+          subject: "Weekly HR Summary",
+        },
+      ],
+    });
   });
 });

--- a/apps/api/src/routes/summaries.ts
+++ b/apps/api/src/routes/summaries.ts
@@ -1,11 +1,19 @@
 import { randomUUID } from "node:crypto";
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import { isValidWorkspace, type WorkspaceSlug } from "@trends/shared";
+import {
+  WORKSPACE_TEAMS,
+  isValidWorkspace,
+  type SummaryProfileRecord as SummaryProfileRecordType,
+  type SummaryProfileRuntimeItem as SummaryProfileRuntimeItemType,
+  type SummaryProfilesConfig as SummaryProfilesConfigType,
+  type WorkspaceSlug,
+} from "@trends/shared";
 
 import { SummaryDataService } from "../services/summaries/summary-data-service.js";
 import { summaryDispatcher } from "../services/summaries/summary-dispatcher.js";
 import { SummaryRenderer } from "../services/summaries/summary-renderer.js";
+import { workspaceConfigService } from "../services/workspace-config-service.js";
 import {
   WorkspaceSummaryRunStorage,
   type StoredWorkspaceSummaryRun,
@@ -15,7 +23,9 @@ const app = new OpenAPIHono();
 const summaryDataService = new SummaryDataService();
 const summaryRenderer = new SummaryRenderer();
 const workspaceSummaryRunStorage = new WorkspaceSummaryRunStorage();
+const KNOWN_WORKSPACE_SLUGS = Object.keys(WORKSPACE_TEAMS).filter(isValidWorkspace);
 const SummaryPeriodSchema = z.enum(["daily", "weekly"]);
+const WorkspaceSlugSchema = z.string().min(1);
 
 const SummaryCountEntrySchema = z.object({
   key: z.string(),
@@ -205,6 +215,55 @@ const SummaryRunDetailResponseSchema = z.object({
   item: StoredSummaryRunSchema,
 });
 
+const SummaryProfileScheduleSchema = z.object({
+  cron: z.string().trim().min(1),
+});
+
+const SummaryProfileRequestSchema = z.object({
+  period: SummaryPeriodSchema,
+  channel: SummaryChannelSchema,
+  dryRun: z.boolean(),
+  templateId: z.string().trim().min(1).optional(),
+  to: z.string().trim().email().optional(),
+  subject: z.string().trim().min(1).optional(),
+});
+
+const SummaryProfileSchema = z.object({
+  id: z.string().trim().min(1),
+  name: z.string().trim().min(1),
+  enabled: z.boolean(),
+  schedule: SummaryProfileScheduleSchema,
+  request: SummaryProfileRequestSchema,
+});
+
+const SummaryProfilesListResponseSchema = z.object({
+  success: z.literal(true),
+  profiles: z.array(SummaryProfileSchema),
+});
+
+const SummaryProfileDetailResponseSchema = z.object({
+  success: z.literal(true),
+  profile: SummaryProfileSchema,
+});
+
+const SummaryProfileRuntimeItemSchema = z.object({
+  workspaceSlug: WorkspaceSlugSchema,
+  profileId: z.string(),
+  name: z.string(),
+  cron: z.string(),
+  period: SummaryPeriodSchema,
+  channel: SummaryChannelSchema,
+  dryRun: z.boolean(),
+  templateId: z.string().optional(),
+  to: z.string().optional(),
+  subject: z.string().optional(),
+});
+
+const SummaryProfilesRuntimeResponseSchema = z.object({
+  success: z.literal(true),
+  items: z.array(SummaryProfileRuntimeItemSchema),
+});
+
 const ErrorSchema = z.object({
   success: z.literal(false),
   error: z.string(),
@@ -287,6 +346,427 @@ function resolveWorkspaceSlug(value: string | undefined, fallback: WorkspaceSlug
   }
   return candidate;
 }
+
+function cloneSummaryProfile(profile: SummaryProfileRecordType): SummaryProfileRecordType {
+  const isEmailProfile = profile.request.channel === "email";
+  return {
+    id: profile.id,
+    name: profile.name,
+    enabled: profile.enabled,
+    schedule: {
+      cron: profile.schedule.cron,
+    },
+    request: {
+      period: profile.request.period,
+      channel: profile.request.channel,
+      dryRun: profile.request.dryRun,
+      ...(profile.request.templateId ? { templateId: profile.request.templateId } : {}),
+      ...(isEmailProfile && profile.request.to ? { to: profile.request.to } : {}),
+      ...(isEmailProfile && profile.request.subject ? { subject: profile.request.subject } : {}),
+    },
+  };
+}
+
+function getSummaryProfileValidationError(profile: SummaryProfileRecordType): string | null {
+  if (profile.request.channel === "email" && !profile.request.to) {
+    return "Email recipient is required";
+  }
+
+  return null;
+}
+
+function findSummaryProfile(
+  config: SummaryProfilesConfigType,
+  profileId: string,
+): SummaryProfileRecordType | undefined {
+  return config.profiles.find((profile) => profile.id === profileId);
+}
+
+function toSummaryProfileRuntimeItem(
+  workspaceSlug: WorkspaceSlug,
+  profile: SummaryProfileRecordType,
+): SummaryProfileRuntimeItemType {
+  return {
+    workspaceSlug,
+    profileId: profile.id,
+    name: profile.name,
+    cron: profile.schedule.cron,
+    period: profile.request.period,
+    channel: profile.request.channel,
+    dryRun: profile.request.dryRun,
+    ...(profile.request.templateId ? { templateId: profile.request.templateId } : {}),
+    ...(profile.request.to ? { to: profile.request.to } : {}),
+    ...(profile.request.subject ? { subject: profile.request.subject } : {}),
+  };
+}
+
+const listProfilesRoute = createRoute({
+  method: "get",
+  path: "/profiles",
+  tags: ["Summaries"],
+  summary: "List workspace summary profiles",
+  responses: {
+    200: {
+      description: "Workspace summary profiles",
+      content: {
+        "application/json": {
+          schema: SummaryProfilesListResponseSchema,
+        },
+      },
+    },
+    403: {
+      description: "Forbidden",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(listProfilesRoute, async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  }
+
+  const config = await workspaceConfigService.getWorkspaceSummaryProfiles(c.var.workspaceSlug);
+  return c.json({
+    success: true as const,
+    profiles: config.profiles.map((profile) => cloneSummaryProfile(profile)),
+  }, 200);
+});
+
+const createProfileRoute = createRoute({
+  method: "post",
+  path: "/profiles",
+  tags: ["Summaries"],
+  summary: "Create workspace summary profile",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: SummaryProfileSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    400: {
+      description: "Invalid summary profile",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+    201: {
+      description: "Summary profile created",
+      content: {
+        "application/json": {
+          schema: SummaryProfileDetailResponseSchema,
+        },
+      },
+    },
+    403: {
+      description: "Forbidden",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+    409: {
+      description: "Duplicate profile id",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(createProfileRoute, async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  }
+
+  const payload = c.req.valid("json");
+  const profile = cloneSummaryProfile(payload);
+  const validationError = getSummaryProfileValidationError(profile);
+  if (validationError) {
+    return c.json({ success: false as const, error: validationError }, 400);
+  }
+
+  const config = await workspaceConfigService.getWorkspaceSummaryProfiles(c.var.workspaceSlug);
+  if (findSummaryProfile(config, profile.id)) {
+    return c.json({
+      success: false as const,
+      error: `Summary profile already exists: ${profile.id}`,
+    }, 409);
+  }
+
+  await workspaceConfigService.setWorkspaceSummaryProfiles(c.var.workspaceSlug, {
+    profiles: [...config.profiles, profile],
+  });
+
+  return c.json({
+    success: true as const,
+    profile,
+  }, 201);
+});
+
+const runtimeProfilesRoute = createRoute({
+  method: "get",
+  path: "/profiles/runtime",
+  tags: ["Summaries"],
+  summary: "List enabled summary profiles across known workspaces for worker runtime",
+  responses: {
+    200: {
+      description: "Runtime summary profile list",
+      content: {
+        "application/json": {
+          schema: SummaryProfilesRuntimeResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(runtimeProfilesRoute, async (c) => {
+  const configs = await Promise.all(
+    KNOWN_WORKSPACE_SLUGS.map(async (workspaceSlug) => ({
+      workspaceSlug,
+      config: await workspaceConfigService.getWorkspaceSummaryProfiles(workspaceSlug),
+    })),
+  );
+
+  const items = configs.flatMap(({ workspaceSlug, config }) =>
+    config.profiles
+      .filter((profile) => profile.enabled)
+      .map((profile) => toSummaryProfileRuntimeItem(workspaceSlug, profile)),
+  );
+
+  return c.json({
+    success: true as const,
+    items,
+  }, 200);
+});
+
+const getProfileRoute = createRoute({
+  method: "get",
+  path: "/profiles/{profileId}",
+  tags: ["Summaries"],
+  summary: "Get one workspace summary profile",
+  request: {
+    params: z.object({
+      profileId: z.string().trim().min(1),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Summary profile detail",
+      content: {
+        "application/json": {
+          schema: SummaryProfileDetailResponseSchema,
+        },
+      },
+    },
+    403: {
+      description: "Forbidden",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+    404: {
+      description: "Summary profile not found",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(getProfileRoute, async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  }
+
+  const { profileId } = c.req.valid("param");
+  const config = await workspaceConfigService.getWorkspaceSummaryProfiles(c.var.workspaceSlug);
+  const profile = findSummaryProfile(config, profileId);
+  if (!profile) {
+    return c.json({
+      success: false as const,
+      error: `Summary profile not found: ${profileId}`,
+    }, 404);
+  }
+
+  return c.json({
+    success: true as const,
+    profile: cloneSummaryProfile(profile),
+  }, 200);
+});
+
+const updateProfileRoute = createRoute({
+  method: "put",
+  path: "/profiles/{profileId}",
+  tags: ["Summaries"],
+  summary: "Update one workspace summary profile",
+  request: {
+    params: z.object({
+      profileId: z.string().trim().min(1),
+    }),
+    body: {
+      content: {
+        "application/json": {
+          schema: SummaryProfileSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    400: {
+      description: "Invalid summary profile",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+    200: {
+      description: "Summary profile updated",
+      content: {
+        "application/json": {
+          schema: SummaryProfileDetailResponseSchema,
+        },
+      },
+    },
+    403: {
+      description: "Forbidden",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+    404: {
+      description: "Summary profile not found",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(updateProfileRoute, async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  }
+
+  const { profileId } = c.req.valid("param");
+  const payload = c.req.valid("json");
+  const nextProfileBase = cloneSummaryProfile(payload);
+  const validationError = getSummaryProfileValidationError(nextProfileBase);
+  if (validationError) {
+    return c.json({ success: false as const, error: validationError }, 400);
+  }
+
+  const config = await workspaceConfigService.getWorkspaceSummaryProfiles(c.var.workspaceSlug);
+  const profileIndex = config.profiles.findIndex((profile) => profile.id === profileId);
+  if (profileIndex === -1) {
+    return c.json({
+      success: false as const,
+      error: `Summary profile not found: ${profileId}`,
+    }, 404);
+  }
+
+  const existingProfile = config.profiles[profileIndex];
+  const nextProfile: SummaryProfileRecordType = {
+    ...nextProfileBase,
+    id: existingProfile.id,
+  };
+  const nextProfiles = [...config.profiles];
+  nextProfiles[profileIndex] = nextProfile;
+
+  await workspaceConfigService.setWorkspaceSummaryProfiles(c.var.workspaceSlug, {
+    profiles: nextProfiles,
+  });
+
+  return c.json({
+    success: true as const,
+    profile: nextProfile,
+  }, 200);
+});
+
+const deleteProfileRoute = createRoute({
+  method: "delete",
+  path: "/profiles/{profileId}",
+  tags: ["Summaries"],
+  summary: "Delete one workspace summary profile",
+  request: {
+    params: z.object({
+      profileId: z.string().trim().min(1),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Summary profile deleted",
+      content: {
+        "application/json": {
+          schema: z.object({
+            success: z.literal(true),
+          }),
+        },
+      },
+    },
+    403: {
+      description: "Forbidden",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+    404: {
+      description: "Summary profile not found",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(deleteProfileRoute, async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  }
+
+  const { profileId } = c.req.valid("param");
+  const config = await workspaceConfigService.getWorkspaceSummaryProfiles(c.var.workspaceSlug);
+  const nextProfiles = config.profiles.filter((profile) => profile.id !== profileId);
+  if (nextProfiles.length === config.profiles.length) {
+    return c.json({
+      success: false as const,
+      error: `Summary profile not found: ${profileId}`,
+    }, 404);
+  }
+
+  await workspaceConfigService.setWorkspaceSummaryProfiles(c.var.workspaceSlug, {
+    profiles: nextProfiles,
+  });
+
+  return c.json({ success: true as const }, 200);
+});
 
 const previewRoute = createRoute({
   method: "post",

--- a/apps/api/src/services/workspace-config-service.ts
+++ b/apps/api/src/services/workspace-config-service.ts
@@ -6,6 +6,10 @@ import {
   resolveResumeFieldUsagePolicy,
   type ResumeFieldUsagePolicy,
   type ResumeFieldUsagePolicyOverrides,
+  type SummaryChannel,
+  type SummaryPeriod,
+  type SummaryProfileRecord,
+  type SummaryProfilesConfig,
 } from "@trends/shared";
 import { findProjectRoot } from "./db.js";
 import {
@@ -57,6 +61,10 @@ function readNumber(value: unknown): number | null {
   return null;
 }
 
+function readBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
 function parseMarkets(value: unknown): Array<"CN" | "MY"> | undefined {
   if (!Array.isArray(value)) {
     return undefined;
@@ -67,7 +75,7 @@ function parseMarkets(value: unknown): Array<"CN" | "MY"> | undefined {
 }
 
 function parseVisible(value: unknown): boolean | undefined {
-  return typeof value === "boolean" ? value : undefined;
+  return readBoolean(value) ?? undefined;
 }
 
 function parseWorkflowCollectionSource(value: unknown): CustomKeywordWorkflowSeed["collectionSource"] | null {
@@ -128,6 +136,109 @@ function mergeUnknown(baseValue: unknown, overrideValue: unknown): unknown {
   }
 
   return overrideValue;
+}
+
+function parseSummaryPeriod(value: unknown): SummaryPeriod | null {
+  return value === "daily" || value === "weekly" ? value : null;
+}
+
+function parseSummaryChannel(value: unknown): SummaryChannel | null {
+  return value === "email" || value === "wechat_work" || value === "feishu" || value === "telegram"
+    ? value
+    : null;
+}
+
+function parseSummaryProfileSchedule(value: unknown): SummaryProfileRecord["schedule"] | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const cron = readString(value.cron);
+  if (!cron) {
+    return null;
+  }
+
+  return { cron };
+}
+
+function parseSummaryProfileRequest(value: unknown): SummaryProfileRecord["request"] | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const period = parseSummaryPeriod(value.period);
+  const channel = parseSummaryChannel(value.channel);
+  const dryRun = readBoolean(value.dryRun);
+  if (!period || !channel || dryRun === null) {
+    return null;
+  }
+
+  const request: SummaryProfileRecord["request"] = {
+    period,
+    channel,
+    dryRun,
+  };
+
+  const templateId = readString(value.templateId) ?? undefined;
+  if (templateId) {
+    request.templateId = templateId;
+  }
+
+  if (channel === "email") {
+    const to = readString(value.to) ?? undefined;
+    if (!to) {
+      return null;
+    }
+    request.to = to;
+
+    const subject = readString(value.subject) ?? undefined;
+    if (subject) {
+      request.subject = subject;
+    }
+  }
+
+  return request;
+}
+
+function parseSummaryProfileRecord(value: unknown): SummaryProfileRecord | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const id = readString(value.id);
+  const name = readString(value.name);
+  const enabled = readBoolean(value.enabled);
+  const schedule = parseSummaryProfileSchedule(value.schedule);
+  const request = parseSummaryProfileRequest(value.request);
+  if (!id || !name || enabled === null || !schedule || !request) {
+    return null;
+  }
+
+  return {
+    id,
+    name,
+    enabled,
+    schedule,
+    request,
+  };
+}
+
+function parseSummaryProfilesConfig(value: unknown): SummaryProfilesConfig {
+  if (!isRecord(value)) {
+    return { profiles: [] };
+  }
+
+  const profiles = Array.isArray(value.profiles)
+    ? value.profiles
+        .map((item) => parseSummaryProfileRecord(item))
+        .filter((item): item is SummaryProfileRecord => item !== null)
+    : [];
+
+  return { profiles };
+}
+
+function sanitizeSummaryProfilesConfig(config: SummaryProfilesConfig): SummaryProfilesConfig {
+  return parseSummaryProfilesConfig(config);
 }
 
 function parseCustomKeywordTag(value: unknown): CustomKeywordTag | null {
@@ -458,6 +569,7 @@ const FILTER_PRESETS_KEY = "filter-presets";
 const RULE_WEIGHTS_KEY = "rule-weights";
 const LEARNING_LOG_KEY = "learning-log";
 const RESUME_FIELD_USAGE_POLICY_KEY = "resume-field-usage-policy";
+const SUMMARY_PROFILES_KEY = "summary-profiles";
 
 export class WorkspaceConfigService {
   readonly projectRoot: string;
@@ -673,6 +785,15 @@ export class WorkspaceConfigService {
       presets: Array.from(presetsById.values()),
       categories: Array.from(categoriesById.values()),
     };
+  }
+
+  async getWorkspaceSummaryProfiles(workspaceSlug: string): Promise<SummaryProfilesConfig> {
+    const entry = await this.getWorkspaceConfigEntry(workspaceSlug, SUMMARY_PROFILES_KEY);
+    return parseSummaryProfilesConfig(entry?.configValue);
+  }
+
+  async setWorkspaceSummaryProfiles(workspaceSlug: string, config: SummaryProfilesConfig): Promise<void> {
+    await this.upsertWorkspaceConfigEntry(workspaceSlug, SUMMARY_PROFILES_KEY, sanitizeSummaryProfilesConfig(config));
   }
 
   async getWorkspaceRuleWeights(workspaceSlug: string): Promise<RuleWeightsConfigOverrides | undefined> {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4406,6 +4406,475 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/summaries/profiles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List workspace summary profiles */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Workspace summary profiles */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            profiles: {
+                                id: string;
+                                name: string;
+                                enabled: boolean;
+                                schedule: {
+                                    cron: string;
+                                };
+                                request: {
+                                    /** @enum {string} */
+                                    period: "daily" | "weekly";
+                                    /** @enum {string} */
+                                    channel: "email" | "wechat_work" | "feishu" | "telegram";
+                                    dryRun: boolean;
+                                    templateId?: string;
+                                    /** Format: email */
+                                    to?: string;
+                                    subject?: string;
+                                };
+                            }[];
+                        };
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create workspace summary profile */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        enabled: boolean;
+                        schedule: {
+                            cron: string;
+                        };
+                        request: {
+                            /** @enum {string} */
+                            period: "daily" | "weekly";
+                            /** @enum {string} */
+                            channel: "email" | "wechat_work" | "feishu" | "telegram";
+                            dryRun: boolean;
+                            templateId?: string;
+                            /** Format: email */
+                            to?: string;
+                            subject?: string;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Summary profile created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            profile: {
+                                id: string;
+                                name: string;
+                                enabled: boolean;
+                                schedule: {
+                                    cron: string;
+                                };
+                                request: {
+                                    /** @enum {string} */
+                                    period: "daily" | "weekly";
+                                    /** @enum {string} */
+                                    channel: "email" | "wechat_work" | "feishu" | "telegram";
+                                    dryRun: boolean;
+                                    templateId?: string;
+                                    /** Format: email */
+                                    to?: string;
+                                    subject?: string;
+                                };
+                            };
+                        };
+                    };
+                };
+                /** @description Invalid summary profile */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Duplicate profile id */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/summaries/profiles/runtime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List enabled summary profiles across known workspaces for worker runtime */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Runtime summary profile list */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            items: {
+                                workspaceSlug: string;
+                                profileId: string;
+                                name: string;
+                                cron: string;
+                                /** @enum {string} */
+                                period: "daily" | "weekly";
+                                /** @enum {string} */
+                                channel: "email" | "wechat_work" | "feishu" | "telegram";
+                                dryRun: boolean;
+                                templateId?: string;
+                                to?: string;
+                                subject?: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/summaries/profiles/{profileId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get one workspace summary profile */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    profileId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Summary profile detail */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            profile: {
+                                id: string;
+                                name: string;
+                                enabled: boolean;
+                                schedule: {
+                                    cron: string;
+                                };
+                                request: {
+                                    /** @enum {string} */
+                                    period: "daily" | "weekly";
+                                    /** @enum {string} */
+                                    channel: "email" | "wechat_work" | "feishu" | "telegram";
+                                    dryRun: boolean;
+                                    templateId?: string;
+                                    /** Format: email */
+                                    to?: string;
+                                    subject?: string;
+                                };
+                            };
+                        };
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Summary profile not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        /** Update one workspace summary profile */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    profileId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        enabled: boolean;
+                        schedule: {
+                            cron: string;
+                        };
+                        request: {
+                            /** @enum {string} */
+                            period: "daily" | "weekly";
+                            /** @enum {string} */
+                            channel: "email" | "wechat_work" | "feishu" | "telegram";
+                            dryRun: boolean;
+                            templateId?: string;
+                            /** Format: email */
+                            to?: string;
+                            subject?: string;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Summary profile updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            profile: {
+                                id: string;
+                                name: string;
+                                enabled: boolean;
+                                schedule: {
+                                    cron: string;
+                                };
+                                request: {
+                                    /** @enum {string} */
+                                    period: "daily" | "weekly";
+                                    /** @enum {string} */
+                                    channel: "email" | "wechat_work" | "feishu" | "telegram";
+                                    dryRun: boolean;
+                                    templateId?: string;
+                                    /** Format: email */
+                                    to?: string;
+                                    subject?: string;
+                                };
+                            };
+                        };
+                    };
+                };
+                /** @description Invalid summary profile */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Summary profile not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        /** Delete one workspace summary profile */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    profileId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Summary profile deleted */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                        };
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Summary profile not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/summaries/preview": {
         parameters: {
             query?: never;

--- a/packages/shared/src/summaries.ts
+++ b/packages/shared/src/summaries.ts
@@ -92,3 +92,41 @@ export type SummarySendRequest = SummaryPreviewRequest & {
   botToken?: string;
   chatId?: string;
 };
+
+export type SummaryProfileSchedule = {
+  cron: string;
+};
+
+export type SummaryProfileRequest = {
+  period: SummaryPeriod;
+  channel: SummaryChannel;
+  dryRun: boolean;
+  templateId?: string;
+  to?: string;
+  subject?: string;
+};
+
+export type SummaryProfileRecord = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  schedule: SummaryProfileSchedule;
+  request: SummaryProfileRequest;
+};
+
+export type SummaryProfilesConfig = {
+  profiles: SummaryProfileRecord[];
+};
+
+export type SummaryProfileRuntimeItem = {
+  workspaceSlug: string;
+  profileId: string;
+  name: string;
+  cron: string;
+  period: SummaryPeriod;
+  channel: SummaryChannel;
+  dryRun: boolean;
+  templateId?: string;
+  to?: string;
+  subject?: string;
+};


### PR DESCRIPTION
## Summary
- add workspace-config backed summary profile types and storage helpers
- add summaries-domain CRUD and cross-workspace runtime routes for summary profiles
- add focused summaries route coverage and regenerate committed API client types

## Validation
- bun run vitest run apps/api/src/routes/summaries.test.ts
- bun run check:typecheck
- make check