### PR TITLE
feat(worker): schedule summary profiles at startup

### DIFF
--- a/apps/worker/scheduler.py
+++ b/apps/worker/scheduler.py
@@ -29,6 +29,7 @@ from apscheduler.events import (
 from apps.worker.tasks import (
     run_crawl_analyze,
     health_check,
+    list_summary_profiles_runtime,
     run_skills_version_check,
     run_scoring_auto_tune,
     normalize_summary_period,
@@ -235,6 +236,7 @@ class WorkerScheduler:
         job_id: str,
         interval_minutes: Optional[int] = None,
         cron_expression: Optional[str] = None,
+        job_name: Optional[str] = None,
         **kwargs,
     ) -> None:
         """
@@ -254,12 +256,18 @@ class WorkerScheduler:
         else:
             raise ValueError("Either interval_minutes or cron_expression must be specified")
 
+        add_job_kwargs = {
+            "id": job_id,
+            "kwargs": kwargs,
+            "replace_existing": True,
+        }
+        if job_name is not None:
+            add_job_kwargs["name"] = job_name
+
         self.scheduler.add_job(
             func,
             trigger=trigger,
-            id=job_id,
-            kwargs=kwargs,
-            replace_existing=True,
+            **add_job_kwargs,
         )
         logger.info(f"Added custom job: {job_id}")
 
@@ -367,6 +375,7 @@ class WorkerScheduler:
         self.add_custom_job(
             func=run_workspace_summary,
             job_id="workspace_summary",
+            job_name=f"Workspace Summary ({workspace_slug})",
             cron_expression=cron_expression,
             workspace_slug=workspace_slug,
             period=period,
@@ -385,6 +394,39 @@ class WorkerScheduler:
             dry_run,
         )
 
+    def add_summary_profile_jobs(self, api_base_url: Optional[str] = None) -> None:
+        """Load and schedule summary profile jobs from the API runtime view."""
+        try:
+            runtime_items = list_summary_profiles_runtime(api_base_url=api_base_url)
+            for item in runtime_items:
+                workspace_slug = item["workspaceSlug"]
+                profile_id = item["profileId"]
+                cron = item["cron"]
+                job_id = f"workspace_summary:{workspace_slug}:{profile_id}"
+                self.add_custom_job(
+                    func=run_workspace_summary,
+                    job_id=job_id,
+                    job_name=f"Summary Profile: {workspace_slug} / {item['name']}",
+                    cron_expression=cron,
+                    workspace_slug=workspace_slug,
+                    period=item["period"],
+                    channel=item["channel"],
+                    dry_run=bool(item["dryRun"]),
+                    trigger_source="worker_schedule",
+                    template_id=item.get("templateId"),
+                    to=item.get("to"),
+                    subject=item.get("subject"),
+                )
+                logger.info(
+                    "Scheduled summary profile job: %s (%s, channel=%s, period=%s)",
+                    job_id,
+                    cron,
+                    item["channel"],
+                    item["period"],
+                )
+        except Exception as e:
+            logger.error(f"Failed to load summary profile jobs: {e}")
+
     def start(self) -> None:
         """Start the scheduler."""
         logger.info("Starting Worker Scheduler")
@@ -397,6 +439,7 @@ class WorkerScheduler:
         self.load_profile_jobs()
         self.add_skills_version_check_job()
         self.add_scoring_auto_tune_job()
+        self.add_summary_profile_jobs()
         self.add_workspace_summary_job()
 
         # Run immediately if requested

--- a/apps/worker/tasks.py
+++ b/apps/worker/tasks.py
@@ -23,6 +23,7 @@ from trendradar.utils.time import get_configured_time
 logger = logging.getLogger(__name__)
 
 VALID_SUMMARY_PERIODS = {"daily", "weekly"}
+VALID_SUMMARY_CHANNELS = {"email", "wechat_work", "feishu", "telegram"}
 
 
 def run_crawl_analyze(config_overrides: Optional[Dict[str, Any]] = None) -> bool:
@@ -141,6 +142,15 @@ def normalize_summary_period(period: Optional[str]) -> str:
     return "daily"
 
 
+def normalize_summary_channel(channel: Optional[str]) -> str:
+    normalized = (channel or "").strip().lower()
+    if normalized in VALID_SUMMARY_CHANNELS:
+        return normalized
+    if normalized:
+        logger.warning("[Task] Invalid summary channel %s, falling back to telegram", channel)
+    return "telegram"
+
+
 def _skills_state_path() -> Path:
     return Path("apps/worker/skills-version-state.json")
 
@@ -166,6 +176,63 @@ def _request_json(url: str, method: str = "GET", body: Optional[Dict[str, Any]] 
         raise RuntimeError(f"HTTP {error.code} from {url}: {detail}") from error
     except URLError as error:
         raise RuntimeError(f"Network error for {url}: {error}") from error
+
+
+def list_summary_profiles_runtime(api_base_url: Optional[str] = None) -> list[Dict[str, Any]]:
+    base_url = _worker_api_base_url(api_base_url)
+    response = _request_json(f"{base_url}/api/summaries/profiles/runtime")
+    if response.get("success") is not True:
+        raise RuntimeError(f"Summary profile runtime request failed: {response}")
+
+    raw_items = response.get("items")
+    if not isinstance(raw_items, list):
+        raise RuntimeError("Summary profile runtime payload is missing items[]")
+
+    items: list[Dict[str, Any]] = []
+    for raw_item in raw_items:
+        if not isinstance(raw_item, dict):
+            continue
+
+        workspace_slug = str(raw_item.get("workspaceSlug") or "").strip()
+        profile_id = str(raw_item.get("profileId") or "").strip()
+        cron = str(raw_item.get("cron") or "").strip()
+        name = str(raw_item.get("name") or profile_id).strip()
+        if not workspace_slug or not profile_id or not cron:
+            continue
+
+        channel = normalize_summary_channel(raw_item.get("channel"))
+        item: Dict[str, Any] = {
+            "workspaceSlug": workspace_slug,
+            "profileId": profile_id,
+            "name": name or profile_id,
+            "cron": cron,
+            "period": normalize_summary_period(raw_item.get("period")),
+            "channel": channel,
+            "dryRun": bool(raw_item.get("dryRun")),
+        }
+
+        template_id = raw_item.get("templateId")
+        if isinstance(template_id, str) and template_id.strip():
+            item["templateId"] = template_id.strip()
+
+        if channel == "email":
+            recipient = raw_item.get("to")
+            if not isinstance(recipient, str) or not recipient.strip():
+                logger.warning(
+                    "[Task] Skipping summary profile runtime item without email recipient (%s:%s)",
+                    workspace_slug,
+                    profile_id,
+                )
+                continue
+            item["to"] = recipient.strip()
+
+            subject = raw_item.get("subject")
+            if isinstance(subject, str) and subject.strip():
+                item["subject"] = subject.strip()
+
+        items.append(item)
+
+    return items
 
 
 def _load_last_skills_version() -> Optional[int]:
@@ -322,7 +389,7 @@ def run_workspace_summary(
     base_url = _worker_api_base_url(api_base_url)
     normalized_workspace = workspace_slug.strip() or "dev"
     normalized_period = normalize_summary_period(period)
-    normalized_channel = channel.strip() or "telegram"
+    normalized_channel = normalize_summary_channel(channel)
     logger.info(
         "[Task] Starting workspace summary (workspace=%s, period=%s, channel=%s, dry_run=%s)",
         normalized_workspace,

--- a/tests/test_resume_tasks.py
+++ b/tests/test_resume_tasks.py
@@ -191,6 +191,75 @@ def test_run_workspace_summary_falls_back_to_daily_for_invalid_period(monkeypatc
 
     assert ok is True
     assert captured["body"]["period"] == "daily"
+    assert captured["body"]["channel"] == "telegram"
+
+
+def test_list_summary_profiles_runtime_normalizes_payload(monkeypatch) -> None:
+    monkeypatch.setattr(
+        tasks,
+        "_request_json",
+        lambda *_args, **_kwargs: {
+            "success": True,
+            "items": [
+                {
+                    "workspaceSlug": "dev",
+                    "profileId": "daily-ops",
+                    "name": "Daily Ops",
+                    "cron": "0 9 * * *",
+                    "period": "monthly",
+                    "channel": "slack",
+                    "dryRun": 1,
+                    "templateId": "summary-daily",
+                },
+                {
+                    "workspaceSlug": "hr",
+                    "profileId": "hr-weekly",
+                    "name": "HR Weekly",
+                    "cron": "0 10 * * 1",
+                    "period": "weekly",
+                    "channel": "email",
+                    "dryRun": False,
+                    "to": "ops@example.com",
+                    "subject": "Weekly HR Summary",
+                },
+                {
+                    "workspaceSlug": "hr",
+                    "profileId": "missing-email",
+                    "name": "Missing Email",
+                    "cron": "0 8 * * *",
+                    "period": "daily",
+                    "channel": "email",
+                    "dryRun": False,
+                },
+            ],
+        },
+    )
+
+    items = tasks.list_summary_profiles_runtime(api_base_url="http://localhost:3000/")
+
+    assert items == [
+        {
+            "workspaceSlug": "dev",
+            "profileId": "daily-ops",
+            "name": "Daily Ops",
+            "cron": "0 9 * * *",
+            "period": "daily",
+            "channel": "telegram",
+            "dryRun": True,
+            "templateId": "summary-daily",
+        },
+        {
+            "workspaceSlug": "hr",
+            "profileId": "hr-weekly",
+            "name": "HR Weekly",
+            "cron": "0 10 * * 1",
+            "period": "weekly",
+            "channel": "email",
+            "dryRun": False,
+            "to": "ops@example.com",
+            "subject": "Weekly HR Summary",
+        },
+    ]
 
 
 def test_add_workspace_summary_job_requires_cron(monkeypatch) -> None:
@@ -237,3 +306,60 @@ def test_add_workspace_summary_job_uses_env_config(monkeypatch) -> None:
     assert calls[0]["dry_run"] is True
     assert calls[0]["trigger_source"] == "worker_schedule"
     assert calls[0]["template_id"] == "summary-daily"
+    assert calls[0]["job_name"] == "Workspace Summary (hr)"
+
+
+def test_add_summary_profile_jobs_schedules_runtime_profiles(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(
+        worker_scheduler,
+        "list_summary_profiles_runtime",
+        lambda api_base_url=None: [
+            {
+                "workspaceSlug": "dev",
+                "profileId": "daily-ops",
+                "name": "Daily Ops",
+                "cron": "0 9 * * *",
+                "period": "daily",
+                "channel": "telegram",
+                "dryRun": False,
+            },
+            {
+                "workspaceSlug": "hr",
+                "profileId": "weekly-email",
+                "name": "Weekly Email",
+                "cron": "0 10 * * 1",
+                "period": "weekly",
+                "channel": "email",
+                "dryRun": True,
+                "to": "ops@example.com",
+                "subject": "Weekly HR Summary",
+            },
+        ],
+    )
+    scheduler = worker_scheduler.WorkerScheduler(timezone="UTC")
+
+    def fake_add_custom_job(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(scheduler, "add_custom_job", fake_add_custom_job)
+
+    scheduler.add_summary_profile_jobs(api_base_url="http://localhost:3000")
+
+    assert len(calls) == 2
+    assert calls[0]["func"] is tasks.run_workspace_summary
+    assert calls[0]["job_id"] == "workspace_summary:dev:daily-ops"
+    assert calls[0]["job_name"] == "Summary Profile: dev / Daily Ops"
+    assert calls[0]["cron_expression"] == "0 9 * * *"
+    assert calls[0]["workspace_slug"] == "dev"
+    assert calls[0]["period"] == "daily"
+    assert calls[0]["channel"] == "telegram"
+    assert calls[0]["dry_run"] is False
+    assert calls[0]["trigger_source"] == "worker_schedule"
+
+    assert calls[1]["job_id"] == "workspace_summary:hr:weekly-email"
+    assert calls[1]["job_name"] == "Summary Profile: hr / Weekly Email"
+    assert calls[1]["channel"] == "email"
+    assert calls[1]["to"] == "ops@example.com"
+    assert calls[1]["subject"] == "Weekly HR Summary"


### PR DESCRIPTION
## Summary
- fetch summary profile runtime items from `/api/summaries/profiles/runtime` during worker startup
- schedule one APScheduler job per runtime profile with stable ids and user-facing names
- keep the existing env-driven `workspace_summary` job as the fallback lane

## Validation
- uv run pytest tests/test_resume_tasks.py -q
- make check