### PR TITLE
feat(web): add summary profile admin UI

### DIFF
--- a/apps/web/src/pages/SummaryRunsPage.test.tsx
+++ b/apps/web/src/pages/SummaryRunsPage.test.tsx
@@ -4,9 +4,11 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SummaryRunsPage } from './SummaryRunsPage'
 
-const { getMock, postMock, toastErrorMock, toastSuccessMock, tMock } = vi.hoisted(() => ({
+const { getMock, postMock, putMock, deleteMock, toastErrorMock, toastSuccessMock, tMock } = vi.hoisted(() => ({
   getMock: vi.fn(),
   postMock: vi.fn(),
+  putMock: vi.fn(),
+  deleteMock: vi.fn(),
   toastErrorMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   tMock: vi.fn((_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key),
@@ -29,6 +31,8 @@ vi.mock('@/lib/api-helpers', () => ({
   rawApiClient: {
     GET: (...args: unknown[]) => getMock(...args),
     POST: (...args: unknown[]) => postMock(...args),
+    PUT: (...args: unknown[]) => putMock(...args),
+    DELETE: (...args: unknown[]) => deleteMock(...args),
   },
 }))
 
@@ -111,6 +115,23 @@ type SummaryRun = {
     }>
   }
   error?: string
+}
+
+type SummaryProfile = {
+  id: string
+  name: string
+  enabled: boolean
+  schedule: {
+    cron: string
+  }
+  request: {
+    period: 'daily' | 'weekly'
+    channel: 'telegram' | 'wechat_work' | 'feishu' | 'email'
+    dryRun: boolean
+    templateId?: string
+    to?: string
+    subject?: string
+  }
 }
 
 function renderSummaryRunsPage() {
@@ -273,8 +294,35 @@ function createDailyFailedRun(): SummaryRun {
   }
 }
 
-function createListAndDetailMocks(detailRun: SummaryRun, extraRuns: SummaryRun[] = []) {
+function createSummaryProfile(overrides: Partial<SummaryProfile> = {}): SummaryProfile {
+  return {
+    id: 'daily-ops',
+    name: 'Daily Ops',
+    enabled: true,
+    schedule: {
+      cron: '0 9 * * 1-5',
+    },
+    request: {
+      period: 'daily',
+      channel: 'telegram',
+      dryRun: false,
+      templateId: 'summary-daily',
+    },
+    ...overrides,
+  }
+}
+
+function createPageMocks(detailRun: SummaryRun, extraRuns: SummaryRun[] = [], profiles: SummaryProfile[] = []) {
   getMock.mockImplementation(async (path: string) => {
+    if (path === '/api/summaries/profiles') {
+      return {
+        data: {
+          success: true,
+          profiles,
+        },
+      }
+    }
+
     if (path === '/api/summaries/runs') {
       return {
         data: {
@@ -324,12 +372,12 @@ describe('SummaryRunsPage', () => {
     const user = userEvent.setup()
     const weeklyRun = createWeeklyRun()
     const failedRun = createDailyFailedRun()
-    createListAndDetailMocks(weeklyRun, [failedRun])
+    createPageMocks(weeklyRun, [failedRun])
 
     renderSummaryRunsPage()
 
     expect(await screen.findByText('run-1')).toBeInTheDocument()
-    expect(await screen.findAllByText('Weekly')).toHaveLength(3)
+    expect((await screen.findAllByText('Weekly')).length).toBeGreaterThanOrEqual(3)
     expect(await screen.findAllByText(/1\/1 sent • 2 batches • override/i)).toHaveLength(2)
     expect(await screen.findByText(/Compared with previous week • shared ingest \+2 resumes • workspace \+1 status/i)).toBeInTheDocument()
     expect(await screen.findByText(/Previous period window/i)).toBeInTheDocument()
@@ -351,7 +399,7 @@ describe('SummaryRunsPage', () => {
   it('reuses the selected run and submits preview and send actions', async () => {
     const user = userEvent.setup()
     const weeklyRun = createWeeklyRun()
-    createListAndDetailMocks(weeklyRun)
+    createPageMocks(weeklyRun)
 
     postMock.mockImplementation(async (path: string, options?: unknown) => {
       expect(path).toBe('/api/summaries/run')
@@ -491,7 +539,7 @@ describe('SummaryRunsPage', () => {
   it('shows an error toast for failed run actions and preserves the current detail', async () => {
     const user = userEvent.setup()
     const weeklyRun = createWeeklyRun()
-    createListAndDetailMocks(weeklyRun)
+    createPageMocks(weeklyRun)
 
     postMock.mockResolvedValue({
       error: {
@@ -510,5 +558,171 @@ describe('SummaryRunsPage', () => {
     })
     expect(toastErrorMock).toHaveBeenCalledWith('Failed to send summary')
     expect(screen.getByText('Rendered summary content')).toBeInTheDocument()
+  })
+
+  it('loads summary profiles, shows restart guidance, and updates the selected profile', async () => {
+    const user = userEvent.setup()
+    const weeklyRun = createWeeklyRun()
+    const dailyOps = createSummaryProfile()
+    const weeklyEmail = createSummaryProfile({
+      id: 'weekly-email',
+      name: 'Weekly Email',
+      enabled: false,
+      schedule: {
+        cron: '0 10 * * 1',
+      },
+      request: {
+        period: 'weekly',
+        channel: 'email',
+        dryRun: true,
+        to: 'ops@example.com',
+        subject: 'Weekly HR Summary',
+      },
+    })
+
+    createPageMocks(weeklyRun, [], [dailyOps, weeklyEmail])
+    putMock.mockResolvedValue({
+      data: {
+        success: true,
+        profile: {
+          ...weeklyEmail,
+          name: 'Weekly Email v2',
+          enabled: true,
+          request: {
+            ...weeklyEmail.request,
+            dryRun: false,
+            subject: 'Updated HR Summary',
+          },
+        },
+      },
+    })
+
+    renderSummaryRunsPage()
+
+    expect(await screen.findByText('Summary profiles')).toBeInTheDocument()
+    expect(screen.getByText('Changes apply after the next worker restart.')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('daily-ops')).toBeDisabled()
+    expect(screen.getByDisplayValue('Daily Ops')).toBeInTheDocument()
+
+    await user.click(screen.getByText('Weekly Email'))
+
+    expect(await screen.findByDisplayValue('weekly-email')).toBeDisabled()
+    expect(screen.getByDisplayValue('Weekly Email')).toBeInTheDocument()
+    expect(screen.getByLabelText('Profile period')).toHaveValue('weekly')
+    expect(screen.getByLabelText('Profile channel')).toHaveValue('email')
+    expect(screen.getByLabelText('Profile email recipient')).toHaveValue('ops@example.com')
+    expect(screen.getByLabelText('Profile email subject')).toHaveValue('Weekly HR Summary')
+
+    await user.clear(screen.getByLabelText('Profile name'))
+    await user.type(screen.getByLabelText('Profile name'), 'Weekly Email v2')
+    await user.clear(screen.getByLabelText('Profile email subject'))
+    await user.type(screen.getByLabelText('Profile email subject'), 'Updated HR Summary')
+    await user.click(screen.getByRole('checkbox', { name: 'Enabled after restart' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Dry run only' }))
+    await user.click(screen.getByRole('button', { name: 'Save profile' }))
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledTimes(1)
+    })
+    expect(putMock.mock.calls[0]?.[0]).toBe('/api/summaries/profiles/weekly-email')
+    expect(putMock.mock.calls[0]?.[1]).toMatchObject({
+      body: {
+        id: 'weekly-email',
+        name: 'Weekly Email v2',
+        enabled: true,
+        schedule: {
+          cron: '0 10 * * 1',
+        },
+        request: {
+          period: 'weekly',
+          channel: 'email',
+          dryRun: false,
+          to: 'ops@example.com',
+          subject: 'Updated HR Summary',
+        },
+      },
+    })
+    expect(await screen.findByDisplayValue('Weekly Email v2')).toBeInTheDocument()
+    expect(toastSuccessMock).toHaveBeenCalledWith('Summary profile saved')
+  })
+
+  it('creates and deletes summary profiles from the page editor', async () => {
+    const user = userEvent.setup()
+    const weeklyRun = createWeeklyRun()
+    const createdProfile = createSummaryProfile({
+      id: 'nightly-email',
+      name: 'Nightly Email',
+      enabled: true,
+      schedule: {
+        cron: '0 20 * * *',
+      },
+      request: {
+        period: 'daily',
+        channel: 'email',
+        dryRun: true,
+        to: 'night@example.com',
+        subject: 'Nightly digest',
+      },
+    })
+
+    createPageMocks(weeklyRun)
+    postMock.mockResolvedValue({
+      data: {
+        success: true,
+        profile: createdProfile,
+      },
+    })
+    deleteMock.mockResolvedValue({
+      data: {
+        success: true,
+      },
+    })
+
+    renderSummaryRunsPage()
+
+    expect(await screen.findByText(/No summary profiles saved yet/i)).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText('Profile ID'), 'nightly-email')
+    await user.type(screen.getByLabelText('Profile name'), 'Nightly Email')
+    await user.clear(screen.getByLabelText('Cron expression'))
+    await user.type(screen.getByLabelText('Cron expression'), '0 20 * * *')
+    await user.selectOptions(screen.getByLabelText('Profile channel'), 'email')
+    await user.type(screen.getByLabelText('Profile email recipient'), 'night@example.com')
+    await user.type(screen.getByLabelText('Profile email subject'), 'Nightly digest')
+    await user.click(screen.getByRole('button', { name: 'Create profile' }))
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledTimes(1)
+    })
+    expect(postMock.mock.calls[0]?.[0]).toBe('/api/summaries/profiles')
+    expect(postMock.mock.calls[0]?.[1]).toMatchObject({
+      body: {
+        id: 'nightly-email',
+        name: 'Nightly Email',
+        enabled: false,
+        schedule: {
+          cron: '0 20 * * *',
+        },
+        request: {
+          period: 'daily',
+          channel: 'email',
+          dryRun: true,
+          to: 'night@example.com',
+          subject: 'Nightly digest',
+        },
+      },
+    })
+    expect(await screen.findByText('Nightly Email')).toBeInTheDocument()
+    expect(toastSuccessMock).toHaveBeenCalledWith('Summary profile created')
+
+    await user.click(screen.getByRole('button', { name: 'Delete profile' }))
+
+    await waitFor(() => {
+      expect(deleteMock).toHaveBeenCalledTimes(1)
+    })
+    expect(deleteMock.mock.calls[0]?.[0]).toBe('/api/summaries/profiles/nightly-email')
+    expect(await screen.findByText(/No summary profiles saved yet/i)).toBeInTheDocument()
+    expect(screen.getByLabelText('Profile ID')).toHaveValue('')
+    expect(toastSuccessMock).toHaveBeenCalledWith('Summary profile deleted')
   })
 })

--- a/apps/web/src/pages/SummaryRunsPage.tsx
+++ b/apps/web/src/pages/SummaryRunsPage.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState } from 'react'
-import { RefreshCw, RotateCcw, Send, Sparkles } from 'lucide-react'
+import { Plus, RefreshCw, RotateCcw, Send, Sparkles, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select } from '@/components/ui/select'
@@ -17,12 +18,19 @@ type SummaryRunListResponse = paths['/api/summaries/runs']['get']['responses'][2
 type SummaryRunDetailResponse = paths['/api/summaries/runs/{runId}']['get']['responses'][200]['content']['application/json']
 type SummaryRunRequest = NonNullable<paths['/api/summaries/run']['post']['requestBody']>['content']['application/json']
 type SummaryRunResponse = paths['/api/summaries/run']['post']['responses'][200]['content']['application/json']
+type SummaryProfileListResponse = paths['/api/summaries/profiles']['get']['responses'][200]['content']['application/json']
+type SummaryProfileCreateRequest = NonNullable<paths['/api/summaries/profiles']['post']['requestBody']>['content']['application/json']
+type SummaryProfileCreateResponse = paths['/api/summaries/profiles']['post']['responses'][201]['content']['application/json']
+type SummaryProfileUpdateRequest = NonNullable<paths['/api/summaries/profiles/{profileId}']['put']['requestBody']>['content']['application/json']
+type SummaryProfileUpdateResponse = paths['/api/summaries/profiles/{profileId}']['put']['responses'][200]['content']['application/json']
+type SummaryProfileDeleteResponse = paths['/api/summaries/profiles/{profileId}']['delete']['responses'][200]['content']['application/json']
 type SummaryRunItem = SummaryRunListResponse['items'][number]
 type SummaryRunDetailItem = SummaryRunDetailResponse['item']
 type SummaryDelivery = NonNullable<SummaryRunDetailItem['delivery']>
 type SummaryDeliveryAccount = NonNullable<SummaryDelivery['accounts']>[number]
 type SummaryPeriod = NonNullable<SummaryRunRequest['period']>
 type SummaryChannel = NonNullable<SummaryRunRequest['channel']>
+type SummaryProfileItem = SummaryProfileListResponse['profiles'][number]
 type SummaryRunFormState = {
   period: SummaryPeriod
   channel: SummaryChannel
@@ -33,6 +41,18 @@ type SummaryRunFormState = {
   webhookUrl: string
   botToken: string
   chatId: string
+}
+type SummaryProfileFormState = {
+  id: string
+  name: string
+  enabled: boolean
+  cron: string
+  period: SummaryPeriod
+  channel: SummaryChannel
+  dryRun: boolean
+  templateId: string
+  to: string
+  subject: string
 }
 
 const SUMMARY_RUN_LIST_LIMIT = 20
@@ -46,6 +66,18 @@ const DEFAULT_SUMMARY_RUN_FORM: SummaryRunFormState = {
   webhookUrl: '',
   botToken: '',
   chatId: '',
+}
+const DEFAULT_SUMMARY_PROFILE_FORM: SummaryProfileFormState = {
+  id: '',
+  name: '',
+  enabled: false,
+  cron: '0 9 * * 1-5',
+  period: 'daily',
+  channel: 'telegram',
+  dryRun: true,
+  templateId: '',
+  to: '',
+  subject: '',
 }
 
 const SUMMARY_PERIOD_OPTIONS: Array<{ value: SummaryPeriod; label: string }> = [
@@ -220,16 +252,71 @@ function mergeRunIntoList(runs: SummaryRunItem[], run: SummaryRunDetailItem): Su
   return [run, ...runs.filter((item) => item.id !== run.id)].slice(0, SUMMARY_RUN_LIST_LIMIT)
 }
 
+function createEmptyProfileForm(): SummaryProfileFormState {
+  return { ...DEFAULT_SUMMARY_PROFILE_FORM }
+}
+
+function toProfileFormState(profile: SummaryProfileItem): SummaryProfileFormState {
+  return {
+    id: profile.id,
+    name: profile.name,
+    enabled: profile.enabled,
+    cron: profile.schedule.cron,
+    period: profile.request.period,
+    channel: profile.request.channel,
+    dryRun: profile.request.dryRun,
+    templateId: profile.request.templateId ?? '',
+    to: profile.request.to ?? '',
+    subject: profile.request.subject ?? '',
+  }
+}
+
+function formatChannelLabel(channel: SummaryChannel): string {
+  return SUMMARY_CHANNEL_OPTIONS.find((option) => option.value === channel)?.label ?? channel
+}
+
+function formatProfileDelivery(profile: SummaryProfileItem): string {
+  if (profile.request.channel === 'email') {
+    return profile.request.to ?? 'Email recipient required'
+  }
+
+  return `${formatChannelLabel(profile.request.channel)} env defaults`
+}
+
+function getProfileStatusVariant(enabled: boolean) {
+  return enabled ? 'default' as const : 'outline' as const
+}
+
+function getProfileModeVariant(dryRun: boolean) {
+  return dryRun ? 'secondary' as const : 'outline' as const
+}
+
+function upsertProfile(profiles: SummaryProfileItem[], nextProfile: SummaryProfileItem): SummaryProfileItem[] {
+  const existingIndex = profiles.findIndex((profile) => profile.id === nextProfile.id)
+  if (existingIndex === -1) {
+    return [...profiles, nextProfile]
+  }
+
+  return profiles.map((profile) => (
+    profile.id === nextProfile.id ? nextProfile : profile
+  ))
+}
+
 export function SummaryRunsPage() {
   const { t } = useTranslation()
   const [runs, setRuns] = useState<SummaryRunItem[]>([])
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
   const [selectedRun, setSelectedRun] = useState<SummaryRunDetailItem | null>(null)
   const [runForm, setRunForm] = useState<SummaryRunFormState>(DEFAULT_SUMMARY_RUN_FORM)
+  const [profiles, setProfiles] = useState<SummaryProfileItem[]>([])
+  const [profileForm, setProfileForm] = useState<SummaryProfileFormState>(createEmptyProfileForm)
+  const [editingProfileId, setEditingProfileId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [profilesLoading, setProfilesLoading] = useState(true)
   const [detailLoading, setDetailLoading] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const [submittingMode, setSubmittingMode] = useState<'preview' | 'send' | null>(null)
+  const [profileSubmittingMode, setProfileSubmittingMode] = useState<'create' | 'update' | 'delete' | null>(null)
 
   const loadRunDetail = useCallback(async (runId: string) => {
     setDetailLoading(true)
@@ -292,17 +379,100 @@ export function SummaryRunsPage() {
     void loadRuns()
   }, [loadRuns])
 
+  const loadProfiles = useCallback(async (preferredProfileId?: string | null) => {
+    setProfilesLoading(true)
+    try {
+      const { data, error } = await rawApiClient.GET<SummaryProfileListResponse>('/api/summaries/profiles')
+      if (error || !data?.success) {
+        throw new Error(extractApiErrorMessage(error) ?? 'Failed to load summary profiles')
+      }
+
+      const items = data.profiles || []
+      setProfiles(items)
+
+      const nextEditingProfileId = preferredProfileId && items.some((profile) => profile.id === preferredProfileId)
+        ? preferredProfileId
+        : items[0]?.id ?? null
+
+      if (nextEditingProfileId) {
+        const nextProfile = items.find((profile) => profile.id === nextEditingProfileId)
+        if (nextProfile) {
+          setEditingProfileId(nextProfile.id)
+          setProfileForm(toProfileFormState(nextProfile))
+        }
+      } else {
+        setEditingProfileId(null)
+        setProfileForm(createEmptyProfileForm())
+      }
+    } catch (error) {
+      console.error('Failed to load summary profiles', error)
+      toast.error(error instanceof Error ? error.message : 'Failed to load summary profiles')
+      setProfiles([])
+      setEditingProfileId(null)
+      setProfileForm(createEmptyProfileForm())
+    } finally {
+      setProfilesLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadProfiles()
+  }, [loadProfiles])
+
   const selectedRunSummary = formatDeliverySummary(selectedRun?.delivery)
   const selectedRunComparisonSummary = formatComparisonSummary(selectedRun)
   const submittingPreview = submittingMode === 'preview'
   const submittingSend = submittingMode === 'send'
   const submitting = submittingMode !== null
+  const editingExistingProfile = editingProfileId !== null
+  const profileSubmitting = profileSubmittingMode !== null
+  const profileSubmittingCreate = profileSubmittingMode === 'create'
+  const profileSubmittingUpdate = profileSubmittingMode === 'update'
+  const profileSubmittingDelete = profileSubmittingMode === 'delete'
+  const profileSubmitLabel = profileSubmittingCreate
+    ? t('summaries.profileCreating', { defaultValue: 'Creating…' })
+    : profileSubmittingUpdate
+      ? t('summaries.profileSaving', { defaultValue: 'Saving…' })
+      : editingExistingProfile
+        ? t('summaries.profileSave', { defaultValue: 'Save profile' })
+        : t('summaries.profileCreate', { defaultValue: 'Create profile' })
 
   function updateRunForm<Key extends keyof SummaryRunFormState>(key: Key, value: SummaryRunFormState[Key]) {
     setRunForm((current) => ({
       ...current,
       [key]: value,
     }))
+  }
+
+  function updateProfileForm<Key extends keyof SummaryProfileFormState>(key: Key, value: SummaryProfileFormState[Key]) {
+    setProfileForm((current) => ({
+      ...current,
+      [key]: value,
+    }))
+  }
+
+  function resetProfileForm(profile: SummaryProfileItem | null) {
+    if (profile) {
+      setEditingProfileId(profile.id)
+      setProfileForm(toProfileFormState(profile))
+      return
+    }
+
+    setEditingProfileId(null)
+    setProfileForm(createEmptyProfileForm())
+  }
+
+  function handleStartNewProfile() {
+    resetProfileForm(null)
+  }
+
+  function handleSelectProfile(profileId: string) {
+    const nextProfile = profiles.find((profile) => profile.id === profileId)
+    if (!nextProfile) {
+      return
+    }
+
+    resetProfileForm(nextProfile)
   }
 
   function buildRunRequest(dryRun: boolean): SummaryRunRequest {
@@ -356,6 +526,60 @@ export function SummaryRunsPage() {
     return request
   }
 
+  function buildProfileRequest():
+  | { request: SummaryProfileCreateRequest | SummaryProfileUpdateRequest; validationError: null }
+  | { request: null; validationError: string } {
+    const id = normalizeOptionalString(profileForm.id)
+    if (!id) {
+      return { request: null, validationError: 'Profile ID is required' }
+    }
+
+    const name = normalizeOptionalString(profileForm.name)
+    if (!name) {
+      return { request: null, validationError: 'Profile name is required' }
+    }
+
+    const cron = normalizeOptionalString(profileForm.cron)
+    if (!cron) {
+      return { request: null, validationError: 'Cron expression is required' }
+    }
+
+    const request: SummaryProfileCreateRequest = {
+      id,
+      name,
+      enabled: profileForm.enabled,
+      schedule: {
+        cron,
+      },
+      request: {
+        period: profileForm.period,
+        channel: profileForm.channel,
+        dryRun: profileForm.dryRun,
+      },
+    }
+
+    const templateId = normalizeOptionalString(profileForm.templateId)
+    if (templateId) {
+      request.request.templateId = templateId
+    }
+
+    if (profileForm.channel === 'email') {
+      const to = normalizeOptionalString(profileForm.to)
+      if (!to) {
+        return { request: null, validationError: 'Email recipient is required' }
+      }
+
+      request.request.to = to
+
+      const subject = normalizeOptionalString(profileForm.subject)
+      if (subject) {
+        request.request.subject = subject
+      }
+    }
+
+    return { request, validationError: null }
+  }
+
   async function handleRunAction(mode: 'preview' | 'send') {
     setSubmittingMode(mode)
     try {
@@ -388,6 +612,87 @@ export function SummaryRunsPage() {
     }
   }
 
+  async function handleSaveProfile() {
+    const { request, validationError } = buildProfileRequest()
+    if (validationError || !request) {
+      toast.error(validationError ?? 'Invalid summary profile')
+      return
+    }
+
+    const nextMode = editingExistingProfile ? 'update' : 'create'
+    setProfileSubmittingMode(nextMode)
+
+    try {
+      if (editingProfileId) {
+        const { data, error } = await rawApiClient.PUT<SummaryProfileUpdateResponse>(
+          `/api/summaries/profiles/${encodeURIComponent(editingProfileId)}`,
+          {
+            body: request,
+          },
+        )
+
+        if (error || !data?.success) {
+          throw new Error(extractApiErrorMessage(error) ?? 'Failed to save summary profile')
+        }
+
+        setProfiles((current) => upsertProfile(current, data.profile))
+        resetProfileForm(data.profile)
+      } else {
+        const { data, error } = await rawApiClient.POST<SummaryProfileCreateResponse>('/api/summaries/profiles', {
+          body: request,
+        })
+
+        if (error || !data?.success) {
+          throw new Error(extractApiErrorMessage(error) ?? 'Failed to create summary profile')
+        }
+
+        setProfiles((current) => upsertProfile(current, data.profile))
+        resetProfileForm(data.profile)
+      }
+
+      toast.success(editingExistingProfile ? 'Summary profile saved' : 'Summary profile created')
+    } catch (error) {
+      console.error(`Failed to ${nextMode} summary profile`, error)
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : editingExistingProfile
+            ? 'Failed to save summary profile'
+            : 'Failed to create summary profile',
+      )
+    } finally {
+      setProfileSubmittingMode(null)
+    }
+  }
+
+  async function handleDeleteProfile() {
+    if (!editingProfileId) {
+      return
+    }
+
+    setProfileSubmittingMode('delete')
+
+    try {
+      const { data, error } = await rawApiClient.DELETE<SummaryProfileDeleteResponse>(
+        `/api/summaries/profiles/${encodeURIComponent(editingProfileId)}`,
+      )
+
+      if (error || !data?.success) {
+        throw new Error(extractApiErrorMessage(error) ?? 'Failed to delete summary profile')
+      }
+
+      const nextProfiles = profiles.filter((profile) => profile.id !== editingProfileId)
+      setProfiles(nextProfiles)
+      resetProfileForm(nextProfiles[0] ?? null)
+      toast.success('Summary profile deleted')
+    } catch (error) {
+      console.error(`Failed to delete summary profile ${editingProfileId}`, error)
+      toast.error(error instanceof Error ? error.message : 'Failed to delete summary profile')
+    } finally {
+      setProfileSubmittingMode(null)
+    }
+  }
+
   function handleUseSelectedRun() {
     if (!selectedRun) {
       return
@@ -409,7 +714,10 @@ export function SummaryRunsPage() {
   async function handleRefresh() {
     setRefreshing(true)
     try {
-      await loadRuns(selectedRunId ?? undefined)
+      await Promise.all([
+        loadRuns(selectedRunId ?? undefined),
+        loadProfiles(editingProfileId),
+      ])
     } finally {
       setRefreshing(false)
     }
@@ -428,7 +736,7 @@ export function SummaryRunsPage() {
       <PageHeader
         title={t('summaries.pageTitle', { defaultValue: 'Summary Runs' })}
         description={t('summaries.pageDescription', {
-          defaultValue: 'Inspect recent workspace summary runs, delivery outcomes, and the rendered content that was stored for operator history.',
+          defaultValue: 'Create scheduled summary profiles, validate sends manually, and inspect the persisted run history for the active workspace.',
         })}
         actions={(
           <Button variant="outline" onClick={() => void handleRefresh()} disabled={refreshing}>
@@ -500,6 +808,263 @@ export function SummaryRunsPage() {
         </Card>
 
         <div className="space-y-6 min-w-0">
+          <Card>
+            <CardHeader>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <CardTitle>{t('summaries.profilesTitle', { defaultValue: 'Summary profiles' })}</CardTitle>
+                  <CardDescription>
+                    {t('summaries.profilesDescription', {
+                      defaultValue: 'Save reusable scheduled summary profiles here, then validate the output with the manual run tools below before enabling them for worker restarts.',
+                    })}
+                  </CardDescription>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleStartNewProfile}
+                  disabled={profileSubmitting}
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  {t('summaries.profileNew', { defaultValue: 'New profile' })}
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-sm text-muted-foreground">
+                <div className="font-medium text-foreground">
+                  {t('summaries.profileRestartTitle', { defaultValue: 'Changes apply after the next worker restart.' })}
+                </div>
+                <div className="mt-1">
+                  {t('summaries.profileRestartDescription', {
+                    defaultValue: 'The scheduler rebuilds profile jobs on startup. The worker API does not live-reload summary profiles yet, and cron timing still uses the global worker timezone.',
+                  })}
+                </div>
+              </div>
+
+              {profilesLoading ? (
+                <div className="text-sm text-muted-foreground">{t('summaries.profilesLoading', { defaultValue: 'Loading summary profiles…' })}</div>
+              ) : profiles.length === 0 ? (
+                <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+                  {t('summaries.profilesEmpty', {
+                    defaultValue: 'No summary profiles saved yet. Create one here, validate it with the manual preview/send tools below, and restart the worker when you are ready to activate it.',
+                  })}
+                </div>
+              ) : (
+                <div className="rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>{t('summaries.profileColumnProfile', { defaultValue: 'Profile' })}</TableHead>
+                        <TableHead>{t('summaries.profileColumnSchedule', { defaultValue: 'Schedule' })}</TableHead>
+                        <TableHead>{t('summaries.profileColumnDelivery', { defaultValue: 'Delivery' })}</TableHead>
+                        <TableHead>{t('summaries.profileColumnState', { defaultValue: 'State' })}</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {profiles.map((profile) => {
+                        const isSelected = profile.id === editingProfileId
+                        return (
+                          <TableRow
+                            key={profile.id}
+                            className="cursor-pointer"
+                            data-state={isSelected ? 'selected' : undefined}
+                            onClick={() => handleSelectProfile(profile.id)}
+                          >
+                            <TableCell>
+                              <div className="font-medium">{profile.name}</div>
+                              <div className="text-xs font-mono text-muted-foreground">{profile.id}</div>
+                            </TableCell>
+                            <TableCell className="text-sm text-muted-foreground">{profile.schedule.cron}</TableCell>
+                            <TableCell className="text-sm text-muted-foreground">{formatProfileDelivery(profile)}</TableCell>
+                            <TableCell>
+                              <div className="flex flex-wrap gap-2">
+                                <Badge variant={getProfileStatusVariant(profile.enabled)}>
+                                  {profile.enabled ? 'enabled' : 'paused'}
+                                </Badge>
+                                <Badge variant={getProfileModeVariant(profile.request.dryRun)}>
+                                  {profile.request.dryRun ? 'dry run' : 'send'}
+                                </Badge>
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        )
+                      })}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="summary-profile-id">
+                    {t('summaries.profileFormId', { defaultValue: 'Profile ID' })}
+                  </Label>
+                  <Input
+                    id="summary-profile-id"
+                    value={profileForm.id}
+                    onChange={(event) => updateProfileForm('id', event.target.value)}
+                    placeholder="daily-ops"
+                    disabled={profileSubmitting || editingExistingProfile}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="summary-profile-name">
+                    {t('summaries.profileFormName', { defaultValue: 'Profile name' })}
+                  </Label>
+                  <Input
+                    id="summary-profile-name"
+                    value={profileForm.name}
+                    onChange={(event) => updateProfileForm('name', event.target.value)}
+                    placeholder="Daily Ops"
+                    disabled={profileSubmitting}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="summary-profile-cron">
+                    {t('summaries.profileFormCron', { defaultValue: 'Cron expression' })}
+                  </Label>
+                  <Input
+                    id="summary-profile-cron"
+                    value={profileForm.cron}
+                    onChange={(event) => updateProfileForm('cron', event.target.value)}
+                    placeholder="0 9 * * 1-5"
+                    disabled={profileSubmitting}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {t('summaries.profileFormCronHint', { defaultValue: 'Uses the global worker timezone.' })}
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="summary-profile-template-id">
+                    {t('summaries.profileFormTemplateId', { defaultValue: 'Profile template ID' })}
+                  </Label>
+                  <Input
+                    id="summary-profile-template-id"
+                    value={profileForm.templateId}
+                    onChange={(event) => updateProfileForm('templateId', event.target.value)}
+                    placeholder="summary-daily"
+                    disabled={profileSubmitting}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="summary-profile-period">
+                    {t('summaries.profileFormPeriod', { defaultValue: 'Profile period' })}
+                  </Label>
+                  <Select
+                    id="summary-profile-period"
+                    value={profileForm.period}
+                    onChange={(event) => {
+                      if (isSummaryPeriod(event.target.value)) {
+                        updateProfileForm('period', event.target.value)
+                      }
+                    }}
+                    options={SUMMARY_PERIOD_OPTIONS}
+                    disabled={profileSubmitting}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="summary-profile-channel">
+                    {t('summaries.profileFormChannel', { defaultValue: 'Profile channel' })}
+                  </Label>
+                  <Select
+                    id="summary-profile-channel"
+                    value={profileForm.channel}
+                    onChange={(event) => {
+                      if (isSummaryChannel(event.target.value)) {
+                        updateProfileForm('channel', event.target.value)
+                      }
+                    }}
+                    options={SUMMARY_CHANNEL_OPTIONS}
+                    disabled={profileSubmitting}
+                  />
+                </div>
+              </div>
+
+              {profileForm.channel === 'email' ? (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="summary-profile-to">
+                      {t('summaries.profileFormEmailTo', { defaultValue: 'Profile email recipient' })}
+                    </Label>
+                    <Input
+                      id="summary-profile-to"
+                      value={profileForm.to}
+                      onChange={(event) => updateProfileForm('to', event.target.value)}
+                      placeholder="ops@example.com"
+                      disabled={profileSubmitting}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="summary-profile-subject">
+                      {t('summaries.profileFormSubject', { defaultValue: 'Profile email subject' })}
+                    </Label>
+                    <Input
+                      id="summary-profile-subject"
+                      value={profileForm.subject}
+                      onChange={(event) => updateProfileForm('subject', event.target.value)}
+                      placeholder="Weekly Ops Summary"
+                      disabled={profileSubmitting}
+                    />
+                  </div>
+                </div>
+              ) : (
+                <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+                  {t('summaries.profileDeliveryHint', {
+                    defaultValue: 'Telegram, WeChat Work, and Feishu profiles use the existing environment-backed delivery defaults. Manual preview/send remains the fast validation path for one-off override testing.',
+                  })}
+                </div>
+              )}
+
+              <div className="flex flex-wrap gap-4">
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={profileForm.enabled}
+                    onCheckedChange={(checked) => updateProfileForm('enabled', checked === true)}
+                    disabled={profileSubmitting}
+                  />
+                  <span>{t('summaries.profileFormEnabled', { defaultValue: 'Enabled after restart' })}</span>
+                </label>
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={profileForm.dryRun}
+                    onCheckedChange={(checked) => updateProfileForm('dryRun', checked === true)}
+                    disabled={profileSubmitting}
+                  />
+                  <span>{t('summaries.profileFormDryRun', { defaultValue: 'Dry run only' })}</span>
+                </label>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  onClick={() => {
+                    void handleSaveProfile()
+                  }}
+                  disabled={profileSubmitting}
+                >
+                  {profileSubmitLabel}
+                </Button>
+                {editingExistingProfile ? (
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={() => {
+                      void handleDeleteProfile()
+                    }}
+                    disabled={profileSubmitting}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    {profileSubmittingDelete
+                      ? t('summaries.profileDeleting', { defaultValue: 'Deleting…' })
+                      : t('summaries.profileDelete', { defaultValue: 'Delete profile' })}
+                  </Button>
+                ) : null}
+              </div>
+            </CardContent>
+          </Card>
+
           <Card>
             <CardHeader>
               <div className="flex flex-wrap items-start justify-between gap-3">


### PR DESCRIPTION
## Summary
- add admin summary-profile CRUD to the summary runs page
- keep restart-required scheduler guidance explicit and use safe defaults for new profiles
- cover create, update, and delete flows in page tests

## Validation
- bun run --filter @trends/web test -- SummaryRunsPage\n- bun run --filter @trends/web typecheck\n- make check