### PR TITLE
feat(cli): expose worker schedule metadata

### DIFF
--- a/packages/cli/cmd/mcp_test.go
+++ b/packages/cli/cmd/mcp_test.go
@@ -251,8 +251,16 @@ func TestRunMCPToolWorkerStatus(t *testing.T) {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		_ = json.NewEncoder(w).Encode(client.WorkerStatus{
-			Running:      true,
-			JobsExecuted: 4,
+			Running:       true,
+			JobsExecuted:  4,
+			ScheduleType:  "cron",
+			ScheduleValue: "0 9 * * *",
+			Jobs: []client.WorkerJob{{
+				ID:      "workspace_summary:dev:daily-ops",
+				Name:    "Summary Profile: dev / Daily Ops",
+				NextRun: "2026-03-27T09:00:00Z",
+				Trigger: "cron[0 9 * * *]",
+			}},
 		})
 	}))
 	defer server.Close()
@@ -264,6 +272,9 @@ func TestRunMCPToolWorkerStatus(t *testing.T) {
 		t.Fatalf("runMCPTool returned error: %v", err)
 	}
 	if !strings.Contains(text, `"jobs_executed": 4`) || !strings.Contains(text, `"running": true`) {
+		t.Fatalf("unexpected MCP tool output: %s", text)
+	}
+	if !strings.Contains(text, `"schedule_value": "0 9 * * *"`) || !strings.Contains(text, `"id": "workspace_summary:dev:daily-ops"`) {
 		t.Fatalf("unexpected MCP tool output: %s", text)
 	}
 }
@@ -333,8 +344,16 @@ func TestRunMCPToolWorkerStatusFallsBackToWorkerURL(t *testing.T) {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		_ = json.NewEncoder(w).Encode(client.WorkerStatus{
-			Running:      false,
-			JobsExecuted: 9,
+			Running:       false,
+			JobsExecuted:  9,
+			ScheduleType:  "interval",
+			ScheduleValue: "30m",
+			Jobs: []client.WorkerJob{{
+				ID:      "crawl_analyze",
+				Name:    "Crawl & Analyze",
+				NextRun: "2026-03-27T00:30:00Z",
+				Trigger: "interval[0:30:00]",
+			}},
 		})
 	}))
 	defer worker.Close()
@@ -346,6 +365,9 @@ func TestRunMCPToolWorkerStatusFallsBackToWorkerURL(t *testing.T) {
 		t.Fatalf("runMCPTool returned error: %v", err)
 	}
 	if !strings.Contains(text, `"jobs_executed": 9`) || !strings.Contains(text, `"running": false`) {
+		t.Fatalf("unexpected MCP tool output: %s", text)
+	}
+	if !strings.Contains(text, `"schedule_type": "interval"`) || !strings.Contains(text, `"id": "crawl_analyze"`) {
 		t.Fatalf("unexpected MCP tool output: %s", text)
 	}
 }

--- a/packages/cli/cmd/worker.go
+++ b/packages/cli/cmd/worker.go
@@ -194,12 +194,14 @@ func newWorkerStatusCmd() *cobra.Command {
 				return err
 			}
 
-			headers := []string{"running", "jobs_executed", "jobs_failed", "jobs_missed", "last_run", "last_success", "last_failure"}
+			headers := []string{"running", "jobs_executed", "jobs_failed", "jobs_missed", "schedule", "job_count", "last_run", "last_success", "last_failure"}
 			rows := [][]string{{
 				boolToString(status.Running),
 				fmt.Sprintf("%d", status.JobsExecuted),
 				fmt.Sprintf("%d", status.JobsFailed),
 				fmt.Sprintf("%d", status.JobsMissed),
+				formatWorkerSchedule(status),
+				fmt.Sprintf("%d", len(status.Jobs)),
 				status.LastRun,
 				status.LastSuccess,
 				status.LastFailure,
@@ -310,4 +312,24 @@ func emptyDash(value string) string {
 		return "-"
 	}
 	return value
+}
+
+func formatWorkerSchedule(status *client.WorkerStatus) string {
+	if status == nil {
+		return "-"
+	}
+
+	value := strings.TrimSpace(status.ScheduleValue)
+	if value == "" {
+		return "-"
+	}
+
+	switch strings.TrimSpace(status.ScheduleType) {
+	case "cron":
+		return "Cron: " + value
+	case "interval":
+		return "Every " + value
+	default:
+		return value
+	}
 }

--- a/packages/cli/cmd/worker_crawl_test.go
+++ b/packages/cli/cmd/worker_crawl_test.go
@@ -20,13 +20,21 @@ func TestWorkerStatusCommandWritesJSON(t *testing.T) {
 			t.Fatalf("unexpected method: %s", r.Method)
 		}
 		_ = json.NewEncoder(w).Encode(client.WorkerStatus{
-			Running:      true,
-			JobsExecuted: 12,
-			JobsFailed:   1,
-			JobsMissed:   0,
-			LastRun:      "2026-03-20T10:00:00Z",
-			LastSuccess:  "2026-03-20T09:59:00Z",
-			LastFailure:  "2026-03-19T20:00:00Z",
+			Running:       true,
+			JobsExecuted:  12,
+			JobsFailed:    1,
+			JobsMissed:    0,
+			LastRun:       "2026-03-20T10:00:00Z",
+			LastSuccess:   "2026-03-20T09:59:00Z",
+			LastFailure:   "2026-03-19T20:00:00Z",
+			ScheduleType:  "cron",
+			ScheduleValue: "0 9 * * *",
+			Jobs: []client.WorkerJob{{
+				ID:      "workspace_summary:dev:daily-ops",
+				Name:    "Summary Profile: dev / Daily Ops",
+				NextRun: "2026-03-21T09:00:00Z",
+				Trigger: "cron[0 9 * * *]",
+			}},
 		})
 	}))
 	defer server.Close()
@@ -46,6 +54,58 @@ func TestWorkerStatusCommandWritesJSON(t *testing.T) {
 	payload := decodeCommandJSON(t, output)
 	if payload["jobs_executed"] != float64(12) || payload["running"] != true {
 		t.Fatalf("unexpected output payload: %#v", payload)
+	}
+	if payload["schedule_value"] != "0 9 * * *" {
+		t.Fatalf("expected schedule metadata in JSON output, got: %#v", payload)
+	}
+	jobs, ok := payload["jobs"].([]any)
+	if !ok || len(jobs) != 1 {
+		t.Fatalf("expected jobs list in output payload: %#v", payload)
+	}
+	job, ok := jobs[0].(map[string]any)
+	if !ok || job["id"] != "workspace_summary:dev:daily-ops" {
+		t.Fatalf("unexpected job payload: %#v", payload)
+	}
+}
+
+func TestWorkerStatusCommandWritesCompactTable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(client.WorkerStatus{
+			Running:       true,
+			JobsExecuted:  12,
+			JobsFailed:    1,
+			JobsMissed:    0,
+			LastRun:       "2026-03-20T10:00:00Z",
+			LastSuccess:   "2026-03-20T09:59:00Z",
+			LastFailure:   "2026-03-19T20:00:00Z",
+			ScheduleType:  "cron",
+			ScheduleValue: "0 9 * * *",
+			Jobs: []client.WorkerJob{{
+				ID:   "workspace_summary:dev:daily-ops",
+				Name: "Summary Profile: dev / Daily Ops",
+			}},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "ops")
+	setCLIOutput(t, "table")
+
+	cmd := newWorkerStatusCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("worker status command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "Cron: 0 9 * * *") || !strings.Contains(strings.ToUpper(text), "JOB COUNT") {
+		t.Fatalf("expected schedule summary and job count in table output, got: %s", text)
+	}
+	if strings.Contains(text, "workspace_summary:dev:daily-ops") {
+		t.Fatalf("expected table output to stay compact, got: %s", text)
 	}
 }
 

--- a/packages/cli/internal/client/worker.go
+++ b/packages/cli/internal/client/worker.go
@@ -7,13 +7,23 @@ import (
 )
 
 type WorkerStatus struct {
-	JobsExecuted int    `json:"jobs_executed"`
-	JobsFailed   int    `json:"jobs_failed"`
-	JobsMissed   int    `json:"jobs_missed"`
-	LastRun      string `json:"last_run"`
-	LastSuccess  string `json:"last_success"`
-	LastFailure  string `json:"last_failure"`
-	Running      bool   `json:"running"`
+	JobsExecuted  int         `json:"jobs_executed"`
+	JobsFailed    int         `json:"jobs_failed"`
+	JobsMissed    int         `json:"jobs_missed"`
+	LastRun       string      `json:"last_run"`
+	LastSuccess   string      `json:"last_success"`
+	LastFailure   string      `json:"last_failure"`
+	ScheduleType  string      `json:"schedule_type"`
+	ScheduleValue string      `json:"schedule_value"`
+	Running       bool        `json:"running"`
+	Jobs          []WorkerJob `json:"jobs"`
+}
+
+type WorkerJob struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	NextRun string `json:"next_run"`
+	Trigger string `json:"trigger"`
 }
 
 type WorkerTriggerResponse struct {

--- a/packages/cli/internal/client/worker_test.go
+++ b/packages/cli/internal/client/worker_test.go
@@ -17,8 +17,16 @@ func TestWorkerStatusUsesAPIProxyWhenSuccessful(t *testing.T) {
 			t.Fatalf("unexpected proxy path: %s", r.URL.Path)
 		}
 		_ = json.NewEncoder(w).Encode(WorkerStatus{
-			Running:      true,
-			JobsExecuted: 5,
+			Running:       true,
+			JobsExecuted:  5,
+			ScheduleType:  "cron",
+			ScheduleValue: "0 9 * * *",
+			Jobs: []WorkerJob{{
+				ID:      "workspace_summary:dev:daily-ops",
+				Name:    "Summary Profile: dev / Daily Ops",
+				NextRun: "2026-03-27T09:00:00Z",
+				Trigger: "cron[0 9 * * *]",
+			}},
 		})
 	}))
 	defer proxy.Close()
@@ -40,6 +48,9 @@ func TestWorkerStatusUsesAPIProxyWhenSuccessful(t *testing.T) {
 	if status.JobsExecuted != 5 || !status.Running {
 		t.Fatalf("unexpected status: %+v", status)
 	}
+	if status.ScheduleValue != "0 9 * * *" || len(status.Jobs) != 1 || status.Jobs[0].ID != "workspace_summary:dev:daily-ops" {
+		t.Fatalf("expected schedule metadata and jobs to be preserved: %+v", status)
+	}
 	if proxyCalls != 1 || workerCalls != 0 {
 		t.Fatalf("unexpected call counts: proxy=%d worker=%d", proxyCalls, workerCalls)
 	}
@@ -60,8 +71,16 @@ func TestWorkerStatusFallsBackToWorkerURL(t *testing.T) {
 			t.Fatalf("unexpected worker path: %s", r.URL.Path)
 		}
 		_ = json.NewEncoder(w).Encode(WorkerStatus{
-			Running:      false,
-			JobsExecuted: 9,
+			Running:       false,
+			JobsExecuted:  9,
+			ScheduleType:  "interval",
+			ScheduleValue: "30m",
+			Jobs: []WorkerJob{{
+				ID:      "crawl_analyze",
+				Name:    "Crawl & Analyze",
+				NextRun: "2026-03-27T00:30:00Z",
+				Trigger: "interval[0:30:00]",
+			}},
 		})
 	}))
 	defer worker.Close()
@@ -75,6 +94,9 @@ func TestWorkerStatusFallsBackToWorkerURL(t *testing.T) {
 	}
 	if status.JobsExecuted != 9 || status.Running {
 		t.Fatalf("unexpected status: %+v", status)
+	}
+	if status.ScheduleType != "interval" || len(status.Jobs) != 1 || status.Jobs[0].ID != "crawl_analyze" {
+		t.Fatalf("expected fallback status to include jobs metadata: %+v", status)
 	}
 	if proxyCalls != 1 || workerCalls != 1 {
 		t.Fatalf("unexpected call counts: proxy=%d worker=%d", proxyCalls, workerCalls)


### PR DESCRIPTION
## Summary\n- preserve worker schedule metadata and jobs in the CLI worker status client\n- expose richer worker status JSON and MCP output while keeping table output compact\n- add focused CLI and MCP tests plus validate against the live local summary-profile restart flow\n\n## Testing\n- cd packages/cli && go test ./internal/client ./cmd\n- make cli-build\n- make check\n- live local validation of summary-profile restart registration via /api/worker/status and CLI JSON output