### PR TITLE
feat(web): pass search history into review packets

### DIFF
--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1159,7 +1159,28 @@ describe('useResumeListState role filter regression', () => {
 
   it('opens the review packets page with selected resume ids and current context', () => {
     mockState.sessionJobDescriptionId = 'lathe-sales'
+    mockState.searchHistory = [
+      {
+        id: 'history-1',
+        sessionKey: 'session-1',
+        title: 'Saved search',
+        location: '苏州',
+        keywords: ['CNC', '销售'],
+        jobDescriptionId: 'lathe-sales',
+        filters: {},
+        selectedTags: [],
+        selectedCompanies: [],
+        selectedExperienceLevel: undefined,
+        notes: 'Priority shortlist for HR sync',
+        createdAt: 1,
+        lastOpenedAt: 2,
+      },
+    ]
     const { result } = renderHook(() => useResumeListState())
+
+    act(() => {
+      result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
+    })
 
     act(() => {
       result.current.handleToggleSelect('resume-ideal-cnc-sales')
@@ -1178,6 +1199,8 @@ describe('useResumeListState role filter regression', () => {
     expect(params.get('source')).toBe('convex')
     expect(params.get('format')).toBe('csv')
     expect(params.get('jobDescriptionId')).toBe('lathe-sales')
+    expect(params.get('sessionId')).toBe('session-1')
+    expect(params.get('referenceNote')).toBe('Priority shortlist for HR sync')
     expect(params.get('resumeIds')).toBe('resume-ideal-cnc-sales,resume-zhang-machinery-sales')
   })
 

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1852,11 +1852,33 @@ export function useResumeListState(loadSearchHistory = false) {
       params.set('jobDescriptionId', normalizedJobDescriptionId)
     }
 
+    const normalizedSessionId = normalizeOptionalString(appliedSearchHistory?.sessionKey)
+    if (normalizedSessionId) {
+      params.set('sessionId', normalizedSessionId)
+    }
+
+    const normalizedReferenceNote = normalizeOptionalString(appliedSearchHistory?.notes)
+    if (normalizedReferenceNote) {
+      params.set('referenceNote', normalizedReferenceNote)
+    }
+
     navigate({
       pathname: `/${resolveWorkspaceSlugFromPathname(location.pathname)}/review-packets`,
       search: `?${params.toString()}`,
     })
-  }, [bulkExportFormat, displayedResumes, jobDescriptionId, location.pathname, mode, navigate, selectedIds, selectedSample, t])
+  }, [
+    appliedSearchHistory?.notes,
+    appliedSearchHistory?.sessionKey,
+    bulkExportFormat,
+    displayedResumes,
+    jobDescriptionId,
+    location.pathname,
+    mode,
+    navigate,
+    selectedIds,
+    selectedSample,
+    t,
+  ])
 
   const actionFeedbackLabels = useMemo<Partial<Record<CandidateActionType, string>>>(
     () => ({

--- a/apps/web/src/pages/ReviewPacketsPage.test.tsx
+++ b/apps/web/src/pages/ReviewPacketsPage.test.tsx
@@ -252,7 +252,7 @@ describe('ReviewPacketsPage', () => {
 
   it('prefills the export form from route search params', async () => {
     searchParamsState.value = new URLSearchParams(
-      'source=sample&format=csv&sample=sample-initial&jobDescriptionId=lathe-sales&sessionId=session-123&resumeIds=resume-1,resume-2'
+      'source=sample&format=csv&sample=sample-initial&jobDescriptionId=lathe-sales&sessionId=session-123&referenceNote=Internal%20handoff&resumeIds=resume-1,resume-2'
     )
 
     getMock.mockImplementation(async (path: string) => {
@@ -285,6 +285,7 @@ describe('ReviewPacketsPage', () => {
     expect(screen.getByLabelText('Sample name')).toHaveValue('sample-initial')
     expect(screen.getByLabelText('Session ID')).toHaveValue('session-123')
     expect(screen.getByLabelText('Job description ID')).toHaveValue('lathe-sales')
+    expect(screen.getByLabelText('Reference note')).toHaveValue('Internal handoff')
     expect(screen.getByLabelText('Resume IDs')).toHaveValue('resume-1\nresume-2')
   })
 })


### PR DESCRIPTION
## Summary
- pass saved search history session context into the ResumeList -> review-packets handoff
- include saved search notes as the initial review-packet reference note
- extend the web tests for the handoff params and route-prefill behavior

## Testing
- npm --workspace @trends/web run test -- src/hooks/useResumeListState.test.tsx src/pages/ReviewPacketsPage.test.tsx
- make check