### PR TITLE
fix(web): keep review packet session ids manual

### DIFF
--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1157,7 +1157,7 @@ describe('useResumeListState role filter regression', () => {
     expect(parsedBody.industryDbV2Stats).toEqual(mockState.searchHistory[0].industryDbV2Stats)
   })
 
-  it('opens the review packets page with selected resume ids and current context', () => {
+  it('opens the review packets page with selected resume ids, current context, and note prefill', () => {
     mockState.sessionJobDescriptionId = 'lathe-sales'
     mockState.searchHistory = [
       {
@@ -1199,7 +1199,7 @@ describe('useResumeListState role filter regression', () => {
     expect(params.get('source')).toBe('convex')
     expect(params.get('format')).toBe('csv')
     expect(params.get('jobDescriptionId')).toBe('lathe-sales')
-    expect(params.get('sessionId')).toBe('session-1')
+    expect(params.get('sessionId')).toBeNull()
     expect(params.get('referenceNote')).toBe('Priority shortlist for HR sync')
     expect(params.get('resumeIds')).toBe('resume-ideal-cnc-sales,resume-zhang-machinery-sales')
   })

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1852,11 +1852,6 @@ export function useResumeListState(loadSearchHistory = false) {
       params.set('jobDescriptionId', normalizedJobDescriptionId)
     }
 
-    const normalizedSessionId = normalizeOptionalString(appliedSearchHistory?.sessionKey)
-    if (normalizedSessionId) {
-      params.set('sessionId', normalizedSessionId)
-    }
-
     const normalizedReferenceNote = normalizeOptionalString(appliedSearchHistory?.notes)
     if (normalizedReferenceNote) {
       params.set('referenceNote', normalizedReferenceNote)
@@ -1868,7 +1863,6 @@ export function useResumeListState(loadSearchHistory = false) {
     })
   }, [
     appliedSearchHistory?.notes,
-    appliedSearchHistory?.sessionKey,
     bulkExportFormat,
     displayedResumes,
     jobDescriptionId,


### PR DESCRIPTION
## Summary
- remove the ResumeList handoff of front-end search `sessionKey` into review-packet `sessionId`
- keep the saved search note prefill in `referenceNote`
- lock the hook test so `sessionId` stays absent from the generated route params

## Why
The review-packet API stores `session_id` as a foreign key to API `search_sessions.id`, so the front-end `sessionKey` is not a safe value to forward.

## Testing
- npm --workspace @trends/web run test -- src/hooks/useResumeListState.test.tsx src/pages/ReviewPacketsPage.test.tsx
- make check