### PR TITLE
feat(web): bridge review packet session ids

### DIFF
--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -43,6 +43,7 @@ const mockState = vi.hoisted(() => ({
   setJobDescriptionId: vi.fn(),
   setCollectionSource: vi.fn(),
   setCollectUrl: vi.fn(),
+  ensureApiSession: vi.fn(async () => 'api-session-1'),
   trackReviewedResume: vi.fn(),
   applyExternalState: vi.fn(),
   saveSearchHistory: vi.fn(async () => 'history-1'),
@@ -124,6 +125,7 @@ vi.mock('@/hooks/useSession', () => ({
     searchHistoryLoading: false,
     saveSearchHistory: mockState.saveSearchHistory,
     markSearchHistoryOpened: mockState.markSearchHistoryOpened,
+    ensureApiSession: mockState.ensureApiSession,
   }),
 }))
 
@@ -604,6 +606,7 @@ describe('useResumeListState role filter regression', () => {
     mockState.sessionJobDescriptionId = undefined
     mockState.sessionCollectionSource = undefined
     mockState.sessionCollectUrl = ''
+    mockState.ensureApiSession.mockResolvedValue('api-session-1')
     mockState.blocksByIdentity = {}
     mockState.statusByIdentity = {}
     mockState.searchHistory = []
@@ -1157,7 +1160,7 @@ describe('useResumeListState role filter regression', () => {
     expect(parsedBody.industryDbV2Stats).toEqual(mockState.searchHistory[0].industryDbV2Stats)
   })
 
-  it('opens the review packets page with selected resume ids, current context, and note prefill', () => {
+  it('opens the review packets page with selected resume ids, current context, and bridged session id', async () => {
     mockState.sessionJobDescriptionId = 'lathe-sales'
     mockState.searchHistory = [
       {
@@ -1178,7 +1181,7 @@ describe('useResumeListState role filter regression', () => {
     ]
     const { result } = renderHook(() => useResumeListState())
 
-    act(() => {
+    await act(async () => {
       result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
     })
 
@@ -1187,8 +1190,8 @@ describe('useResumeListState role filter regression', () => {
       result.current.handleToggleSelect('resume-zhang-machinery-sales')
     })
 
-    act(() => {
-      result.current.handleOpenReviewPacket()
+    await act(async () => {
+      await result.current.handleOpenReviewPacket()
     })
 
     expect(mockState.navigate).toHaveBeenCalledTimes(1)
@@ -1199,7 +1202,7 @@ describe('useResumeListState role filter regression', () => {
     expect(params.get('source')).toBe('convex')
     expect(params.get('format')).toBe('csv')
     expect(params.get('jobDescriptionId')).toBe('lathe-sales')
-    expect(params.get('sessionId')).toBeNull()
+    expect(params.get('sessionId')).toBe('api-session-1')
     expect(params.get('referenceNote')).toBe('Priority shortlist for HR sync')
     expect(params.get('resumeIds')).toBe('resume-ideal-cnc-sales,resume-zhang-machinery-sales')
   })

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -566,6 +566,7 @@ export function useResumeListState(loadSearchHistory = false) {
     searchHistoryLoading,
     saveSearchHistory,
     markSearchHistoryOpened,
+    ensureApiSession,
   } = useSession(loadSearchHistory)
 
   const {
@@ -1822,7 +1823,7 @@ export function useResumeListState(loadSearchHistory = false) {
     [apiBaseUrl, appliedSearchHistory?.industryDbV2Stats, blockCandidates, bulkExportFormat, displayedResumes, mode, saveAction, selectedIds, selectedSample, sendLearningFeedback, t]
   )
 
-  const handleOpenReviewPacket = useCallback(() => {
+  const handleOpenReviewPacket = useCallback(async () => {
     if (selectedIds.size === 0) {
       return
     }
@@ -1852,6 +1853,11 @@ export function useResumeListState(loadSearchHistory = false) {
       params.set('jobDescriptionId', normalizedJobDescriptionId)
     }
 
+    const bridgedSessionId = await ensureApiSession()
+    if (bridgedSessionId) {
+      params.set('sessionId', bridgedSessionId)
+    }
+
     const normalizedReferenceNote = normalizeOptionalString(appliedSearchHistory?.notes)
     if (normalizedReferenceNote) {
       params.set('referenceNote', normalizedReferenceNote)
@@ -1865,6 +1871,7 @@ export function useResumeListState(loadSearchHistory = false) {
     appliedSearchHistory?.notes,
     bulkExportFormat,
     displayedResumes,
+    ensureApiSession,
     jobDescriptionId,
     location.pathname,
     mode,

--- a/apps/web/src/hooks/useSession.test.tsx
+++ b/apps/web/src/hooks/useSession.test.tsx
@@ -20,6 +20,8 @@ const {
   useQueryMock,
   useMutationMock,
   workspaceMock,
+  rawApiPostMock,
+  rawApiPatchMock,
   saveSessionMutationMock,
   addReviewedItemMutationMock,
   saveSearchHistoryMutationMock,
@@ -30,6 +32,8 @@ const {
   workspaceMock: {
     slug: 'dev',
   },
+  rawApiPostMock: vi.fn(),
+  rawApiPatchMock: vi.fn(),
   saveSessionMutationMock: vi.fn(),
   addReviewedItemMutationMock: vi.fn(),
   saveSearchHistoryMutationMock: vi.fn(async () => 'history-1'),
@@ -49,6 +53,13 @@ vi.mock('@/contexts/WorkspaceContext', () => ({
   useWorkspace: () => ({ slug: workspaceMock.slug }),
 }))
 
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: {
+    POST: (...args: unknown[]) => rawApiPostMock(...args),
+    PATCH: (...args: unknown[]) => rawApiPatchMock(...args),
+  },
+}))
+
 vi.mock('sonner', () => ({
   toast: {
     info: (...args: unknown[]) => toastInfoMock(...args),
@@ -60,6 +71,8 @@ describe('useSession', () => {
     vi.clearAllMocks()
     localStorage.clear()
     workspaceMock.slug = 'dev'
+    rawApiPostMock.mockResolvedValue({ data: { success: true, session: { id: 'api-session-1' } } })
+    rawApiPatchMock.mockResolvedValue({ data: { success: true, session: { id: 'api-session-1' } } })
 
     useQueryMock.mockImplementation((query) => {
       if (query === 'list-history-query') {
@@ -241,6 +254,69 @@ describe('useSession', () => {
       id: 'history-hr',
       workspaceSlug: 'hr',
     })
+  })
+
+  it('creates and persists an API search session id for the current local session', async () => {
+    const { result } = renderHook(() => useSession())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    act(() => {
+      result.current.setJobDescriptionId('lathe-sales')
+      result.current.setFilters({ minExperience: 3 })
+    })
+
+    let ensuredSessionId: string | undefined
+    await act(async () => {
+      ensuredSessionId = await result.current.ensureApiSession()
+    })
+
+    const sessionKey = localStorage.getItem('trends.resume.sessionKey.dev')
+    expect(ensuredSessionId).toBe('api-session-1')
+    expect(rawApiPostMock).toHaveBeenCalledWith('/api/sessions', {
+      body: {
+        jobDescriptionId: 'lathe-sales',
+        filters: { minExperience: 3 },
+      },
+    })
+    expect(localStorage.getItem(`trends.resume.apiSessionId.dev.${sessionKey}`)).toBe('api-session-1')
+  })
+
+  it('updates an existing persisted API session id before reusing it', async () => {
+    localStorage.setItem('trends.resume.sessionKey.dev', 'existing-session-key')
+    localStorage.setItem('trends.resume.apiSessionId.dev.existing-session-key', 'api-session-existing')
+    rawApiPatchMock.mockResolvedValueOnce({
+      data: {
+        success: true,
+        session: { id: 'api-session-existing' },
+      },
+    })
+
+    const { result } = renderHook(() => useSession())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    act(() => {
+      result.current.setFilters({ minExperience: 5 })
+    })
+
+    let ensuredSessionId: string | undefined
+    await act(async () => {
+      ensuredSessionId = await result.current.ensureApiSession()
+    })
+
+    expect(ensuredSessionId).toBe('api-session-existing')
+    expect(rawApiPatchMock).toHaveBeenCalledWith('/api/sessions/api-session-existing', {
+      body: {
+        jobDescriptionId: undefined,
+        filters: { minExperience: 5 },
+      },
+    })
+    expect(rawApiPostMock).not.toHaveBeenCalled()
   })
 
   it('clears location when external state explicitly provides an empty location', async () => {

--- a/apps/web/src/hooks/useSession.ts
+++ b/apps/web/src/hooks/useSession.ts
@@ -7,6 +7,7 @@ import {
   resolveCollectionSource,
   type CollectionSource,
 } from '@/lib/search-profile-sources'
+import { rawApiClient } from '@/lib/api-helpers'
 import type { ResumeFilters } from '@/types/resume'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { toIndustryDbV2Stats, type IndustryDbV2Stats } from '@/lib/resume-scoring'
@@ -58,6 +59,13 @@ type SaveSearchHistoryInput = {
   resumeIds?: string[]
 }
 
+type SearchSessionApiResponse = {
+  success: boolean
+  session?: {
+    id?: string
+  }
+}
+
 const AUTO_RESTORE_SCREENING_SESSION = false
 const DEFAULT_SESSION_LOCATION = ''
 
@@ -100,6 +108,14 @@ export function useSession(loadSearchHistory = false) {
     localStorage.setItem(storageKey, newKey)
     return newKey
   })
+  const apiSessionStorageKey = `trends.resume.apiSessionId.${slug}.${sessionKey}`
+  const [apiSessionId, setApiSessionId] = useState<string | undefined>(() => {
+    const storedSessionKey = localStorage.getItem(storageKey)
+    if (!storedSessionKey) {
+      return undefined
+    }
+    return normalizeOptionalString(localStorage.getItem(`trends.resume.apiSessionId.${slug}.${storedSessionKey}`) ?? undefined)
+  })
 
   useEffect(() => {
     const stored = localStorage.getItem(storageKey)
@@ -112,6 +128,10 @@ export function useSession(loadSearchHistory = false) {
     localStorage.setItem(storageKey, newKey)
     setSessionKey(newKey)
   }, [storageKey])
+
+  useEffect(() => {
+    setApiSessionId(normalizeOptionalString(localStorage.getItem(apiSessionStorageKey) ?? undefined))
+  }, [apiSessionStorageKey])
 
   const activeSession = useQuery(
     api.sessions.getActiveSession,
@@ -202,6 +222,47 @@ export function useSession(loadSearchHistory = false) {
     () => new Set(activeSession?.reviewedResumeIds || []),
     [activeSession?.reviewedResumeIds]
   )
+
+  const persistApiSessionId = useCallback((nextSessionId: string | undefined) => {
+    if (nextSessionId) {
+      localStorage.setItem(apiSessionStorageKey, nextSessionId)
+    } else {
+      localStorage.removeItem(apiSessionStorageKey)
+    }
+    setApiSessionId((current) => (current === nextSessionId ? current : nextSessionId))
+  }, [apiSessionStorageKey])
+
+  const ensureApiSession = useCallback(async () => {
+    const body = {
+      jobDescriptionId: normalizeOptionalString(jobDescriptionId),
+      filters: Object.keys(filters).length > 0 ? filters : undefined,
+    }
+
+    if (apiSessionId) {
+      const { data, error } = await rawApiClient.PATCH<SearchSessionApiResponse>(
+        `/api/sessions/${apiSessionId}`,
+        { body }
+      )
+
+      const updatedSessionId = normalizeOptionalString(data?.session?.id)
+      if (!error && data?.success && updatedSessionId) {
+        persistApiSessionId(updatedSessionId)
+        return updatedSessionId
+      }
+    }
+
+    const { data, error } = await rawApiClient.POST<SearchSessionApiResponse>('/api/sessions', {
+      body,
+    })
+    const createdSessionId = normalizeOptionalString(data?.session?.id)
+    if (error || !data?.success || !createdSessionId) {
+      console.error('Failed to ensure API search session', error ?? data)
+      return undefined
+    }
+
+    persistApiSessionId(createdSessionId)
+    return createdSessionId
+  }, [apiSessionId, filters, jobDescriptionId, persistApiSessionId])
 
   const applyExternalState = useCallback((state: ExternalSessionState) => {
     if (state.location !== undefined) {
@@ -314,6 +375,7 @@ export function useSession(loadSearchHistory = false) {
     searchHistoryLoading: loadSearchHistory && historyRecords === undefined,
     saveSearchHistory,
     markSearchHistoryOpened,
+    ensureApiSession,
     loading: !hasHydratedInitialState,
   }
 }


### PR DESCRIPTION
## Summary\n- bridge local resume session state to persisted API search sessions via /api/sessions\n- forward the bridged API session id during ResumeList review-packet handoff\n- add focused hook coverage for API session bridging and review-packet navigation\n\n## Testing\n- bun run --filter '@trends/web' test -- src/hooks/useSession.test.tsx src/hooks/useResumeListState.test.tsx\n- npm --workspace @trends/web run typecheck\n- make check