### PR TITLE
feat(web): add durable resume share sessions

### DIFF
--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -1,0 +1,230 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function createFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "sessions-route-"));
+  fs.mkdirSync(path.join(root, "output"), { recursive: true });
+  fs.mkdirSync(path.join(root, "config", "resume"), { recursive: true });
+  fs.writeFileSync(path.join(root, "pyproject.toml"), "", "utf8");
+  fs.writeFileSync(
+    path.join(root, "config", "resume", "skills.md"),
+    [
+      "---",
+      "version: 1",
+      'updated_at: "2026-03-26"',
+      "---",
+      "",
+      "## Company Patterns",
+      "",
+      "### fanuc",
+      "- aliases: FANUC, 发那科",
+      "- tier: 1",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+  return root;
+}
+
+async function loadSessionModules(root: string) {
+  process.env.PROJECT_ROOT = root;
+  vi.resetModules();
+  const { createApp } = await import("../app");
+  const { resetResumeScreeningDb } = await import("../services/database");
+  return {
+    createApp,
+    resetResumeScreeningDb,
+  };
+}
+
+describe("session routes", () => {
+  let root = "";
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    delete process.env.PROJECT_ROOT;
+    if (root) {
+      const { resetResumeScreeningDb } = await import("../services/database");
+      resetResumeScreeningDb();
+      fs.rmSync(root, { recursive: true, force: true });
+      root = "";
+    }
+  });
+
+  it("creates and rehydrates persisted share session state", async () => {
+    root = createFixtureRoot();
+    const { createApp } = await loadSessionModules(root);
+    const app = createApp();
+
+    const createResponse = await app.request("/api/sessions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        jobDescriptionId: "lathe-sales",
+        filters: {
+          minExperience: 3,
+          minAge: 28,
+          status: ["offer"],
+        },
+        shareTitle: "Kuala Lumpur · Sales Engineer",
+        searchState: {
+          location: "Kuala Lumpur MY",
+          keywords: ["Sales Engineer", "CNC"],
+          requiredKeywords: ["machine tools"],
+          jobDescriptionId: "lathe-sales",
+          selectedTags: ["STAR"],
+          selectedCompanies: ["fanuc"],
+          selectedExperienceLevel: "mid",
+          collectionSource: {
+            type: "seek",
+            exactUrl: "https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1",
+          },
+          collectUrl: "https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1",
+          filters: {
+            minExperience: 3,
+            minAge: 28,
+            status: ["offer"],
+          },
+        },
+      }),
+    });
+
+    expect(createResponse.status).toBe(200);
+    const createdPayload = await createResponse.json() as {
+      success: boolean;
+      session: {
+        id: string;
+        workspaceSlug: string;
+        shareTitle?: string;
+        searchState?: {
+          location?: string;
+          filters?: {
+            minAge?: number;
+            status?: string[];
+          };
+        };
+      };
+    };
+
+    expect(createdPayload.success).toBe(true);
+    expect(createdPayload.session.workspaceSlug).toBe("hr");
+    expect(createdPayload.session.shareTitle).toBe("Kuala Lumpur · Sales Engineer");
+    expect(createdPayload.session.searchState).toMatchObject({
+      location: "Kuala Lumpur MY",
+      filters: {
+        minAge: 28,
+        status: ["offer"],
+      },
+    });
+
+    const getResponse = await app.request(`/api/sessions/${createdPayload.session.id}`, {
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+    });
+
+    expect(getResponse.status).toBe(200);
+    const getPayload = await getResponse.json() as {
+      success: boolean;
+      session: {
+        shareTitle?: string;
+        filters?: {
+          minAge?: number;
+        };
+        searchState?: {
+          requiredKeywords?: string[];
+          selectedTags?: string[];
+          selectedCompanies?: string[];
+          selectedExperienceLevel?: string;
+        };
+      };
+    };
+
+    expect(getPayload.success).toBe(true);
+    expect(getPayload.session.shareTitle).toBe("Kuala Lumpur · Sales Engineer");
+    expect(getPayload.session.filters).toMatchObject({ minAge: 28 });
+    expect(getPayload.session.searchState).toMatchObject({
+      requiredKeywords: ["machine tools"],
+      selectedTags: ["STAR"],
+      selectedCompanies: ["fanuc"],
+      selectedExperienceLevel: "mid",
+    });
+  });
+
+  it("updates and clears persisted share metadata within the workspace scope", async () => {
+    root = createFixtureRoot();
+    const { createApp } = await loadSessionModules(root);
+    const app = createApp();
+
+    const createResponse = await app.request("/api/sessions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        shareTitle: "Original title",
+        searchState: {
+          location: "Dongguan",
+          keywords: ["CNC"],
+        },
+      }),
+    });
+    const createdPayload = await createResponse.json() as {
+      session: {
+        id: string;
+      };
+    };
+
+    const updateResponse = await app.request(`/api/sessions/${createdPayload.session.id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        shareTitle: null,
+        searchState: null,
+        filters: {
+          minExperience: 5,
+          minAge: 30,
+        },
+      }),
+    });
+
+    expect(updateResponse.status).toBe(200);
+    const updatePayload = await updateResponse.json() as {
+      success: boolean;
+      session: {
+        shareTitle?: string;
+        searchState?: unknown;
+        filters?: {
+          minExperience?: number;
+          minAge?: number;
+        };
+      };
+    };
+
+    expect(updatePayload.success).toBe(true);
+    expect(updatePayload.session.shareTitle).toBeUndefined();
+    expect(updatePayload.session.searchState).toBeUndefined();
+    expect(updatePayload.session.filters).toMatchObject({
+      minExperience: 5,
+      minAge: 30,
+    });
+
+    const missingWorkspaceResponse = await app.request(`/api/sessions/${createdPayload.session.id}`, {
+      headers: {
+        "X-Workspace-Slug": "dev",
+      },
+    });
+
+    expect(missingWorkspaceResponse.status).toBe(404);
+  });
+});

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -8,6 +8,41 @@ const app = new OpenAPIHono();
 const sessionManager = new SessionManager(config.projectRoot);
 
 const SessionStatusSchema = z.enum(["active", "completed", "archived"]);
+const CandidateStatusSchema = z.enum([
+  "new",
+  "contacted",
+  "interviewing",
+  "interviewed_pass",
+  "interviewed_reject",
+  "offer",
+  "hired",
+  "withdrawn",
+]);
+const SessionFiltersSchema = ResumeFiltersSchema.extend({
+  minRoleYears: z.number().min(0).optional(),
+  roleFilterType: z.string().optional(),
+  minSalesYears: z.number().min(0).optional(),
+  minAge: z.number().min(0).optional(),
+  maxAge: z.number().min(0).optional(),
+  status: z.array(CandidateStatusSchema).optional(),
+  showBlocked: z.boolean().optional(),
+});
+const SearchSessionCollectionSourceSchema = z.object({
+  type: z.enum(["job5156", "seek"]),
+  exactUrl: z.string().optional(),
+});
+const SearchSessionStateSchema = z.object({
+  location: z.string().optional().openapi({ example: "Kuala Lumpur MY" }),
+  keywords: z.array(z.string()).optional().openapi({ example: ["Sales Engineer", "CNC"] }),
+  requiredKeywords: z.array(z.string()).optional().openapi({ example: ["machine tools"] }),
+  jobDescriptionId: z.string().optional().openapi({ example: "lathe-sales" }),
+  selectedTags: z.array(z.string()).optional().openapi({ example: ["STAR"] }),
+  selectedCompanies: z.array(z.string()).optional().openapi({ example: ["fanuc"] }),
+  selectedExperienceLevel: z.enum(["senior", "mid", "junior"]).optional().openapi({ example: "mid" }),
+  collectionSource: SearchSessionCollectionSourceSchema.optional(),
+  collectUrl: z.string().optional().openapi({ example: "https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1" }),
+  filters: SessionFiltersSchema.optional(),
+});
 
 const SearchSessionSchema = z.object({
   id: z.string().openapi({ example: "session-123" }),
@@ -15,7 +50,9 @@ const SearchSessionSchema = z.object({
   userId: z.string().optional().openapi({ example: "user-1" }),
   jobDescriptionId: z.string().optional().openapi({ example: "lathe-sales" }),
   sampleName: z.string().optional().openapi({ example: "sample-initial" }),
-  filters: ResumeFiltersSchema.optional(),
+  filters: SessionFiltersSchema.optional(),
+  shareTitle: z.string().optional().openapi({ example: "Kuala Lumpur · Sales Engineer" }),
+  searchState: SearchSessionStateSchema.optional(),
   status: SessionStatusSchema.openapi({ example: "active" }),
   createdAt: z.string().openapi({ example: "2026-02-05T08:00:00.000Z" }),
   updatedAt: z.string().openapi({ example: "2026-02-05T08:00:00.000Z" }),
@@ -31,14 +68,18 @@ const SessionCreateSchema = z.object({
   userId: z.string().optional(),
   jobDescriptionId: z.string().optional(),
   sampleName: z.string().optional(),
-  filters: ResumeFiltersSchema.optional(),
+  filters: SessionFiltersSchema.optional(),
+  shareTitle: z.string().optional(),
+  searchState: SearchSessionStateSchema.optional(),
 });
 
 const SessionUpdateSchema = z.object({
   userId: z.string().optional(),
   jobDescriptionId: z.string().optional(),
   sampleName: z.string().optional(),
-  filters: ResumeFiltersSchema.optional(),
+  filters: SessionFiltersSchema.optional(),
+  shareTitle: z.string().nullable().optional(),
+  searchState: SearchSessionStateSchema.nullable().optional(),
   status: SessionStatusSchema.optional(),
   expiresAt: z.string().optional(),
 });
@@ -46,6 +87,15 @@ const SessionUpdateSchema = z.object({
 const SessionIdParamSchema = z.object({
   id: z.string().openapi({ param: { name: "id", in: "path" }, example: "session-123" }),
 });
+
+function normalizeOptionalString(value: string | null | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
 
 const createSessionRoute = createRoute({
   method: "post",
@@ -76,6 +126,8 @@ app.openapi(createSessionRoute, (c) => {
     jobDescriptionId: body.jobDescriptionId,
     sampleName: body.sampleName,
     filters: body.filters,
+    shareTitle: normalizeOptionalString(body.shareTitle),
+    searchState: body.searchState ?? undefined,
   });
   return c.json({ success: true as const, session }, 200);
 });
@@ -142,6 +194,8 @@ app.openapi(updateSessionRoute, (c) => {
     jobDescriptionId: body.jobDescriptionId,
     sampleName: body.sampleName,
     filters: body.filters,
+    shareTitle: body.shareTitle === null ? null : normalizeOptionalString(body.shareTitle),
+    searchState: body.searchState === null ? null : body.searchState,
     status: body.status,
     expiresAt: body.expiresAt,
   }, workspaceSlug);

--- a/apps/api/src/services/database.ts
+++ b/apps/api/src/services/database.ts
@@ -95,6 +95,8 @@ function initSchema(db: Database.Database): void {
       job_description_id TEXT,
       sample_name TEXT,
       filters TEXT,
+      share_title TEXT,
+      search_state TEXT,
       status TEXT DEFAULT 'active',
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
@@ -224,6 +226,8 @@ function initSchema(db: Database.Database): void {
 
   if (existingTables.has("search_sessions")) {
     ensureColumn(db, "search_sessions", "workspace_slug", "TEXT DEFAULT 'dev'");
+    ensureColumn(db, "search_sessions", "share_title", "TEXT");
+    ensureColumn(db, "search_sessions", "search_state", "TEXT");
   }
 }
 

--- a/apps/api/src/services/session-manager.ts
+++ b/apps/api/src/services/session-manager.ts
@@ -10,9 +10,16 @@ export type ResumeFilters = {
   offset?: number;
   minExperience?: number;
   maxExperience?: number;
+  minRoleYears?: number;
+  roleFilterType?: string;
+  minSalesYears?: number;
+  minAge?: number;
+  maxAge?: number;
   education?: string[];
   skills?: string[];
   locations?: string[];
+  status?: CandidateStatus[];
+  showBlocked?: boolean;
   minSalary?: number;
   maxSalary?: number;
   minMatchScore?: number;
@@ -22,6 +29,33 @@ export type ResumeFilters = {
 };
 
 export type SearchSessionStatus = "active" | "completed" | "archived";
+export type CandidateStatus =
+  | "new"
+  | "contacted"
+  | "interviewing"
+  | "interviewed_pass"
+  | "interviewed_reject"
+  | "offer"
+  | "hired"
+  | "withdrawn";
+
+export type SearchSessionCollectionSource = {
+  type: "job5156" | "seek";
+  exactUrl?: string;
+};
+
+export type SearchSessionState = {
+  location?: string;
+  keywords?: string[];
+  requiredKeywords?: string[];
+  jobDescriptionId?: string;
+  selectedTags?: string[];
+  selectedCompanies?: string[];
+  selectedExperienceLevel?: "senior" | "mid" | "junior";
+  collectionSource?: SearchSessionCollectionSource;
+  collectUrl?: string;
+  filters?: ResumeFilters;
+};
 
 export type SearchSession = {
   id: string;
@@ -30,17 +64,23 @@ export type SearchSession = {
   jobDescriptionId?: string;
   sampleName?: string;
   filters?: ResumeFilters;
+  shareTitle?: string;
+  searchState?: SearchSessionState;
   status: SearchSessionStatus;
   createdAt: string;
   updatedAt: string;
   expiresAt?: string;
 };
 
-type SessionUpdateInput = Partial<Omit<SearchSession, "jobDescriptionId" | "userId" | "sampleName" | "expiresAt">> & {
+type SessionUpdateInput = {
   userId?: string | null;
   jobDescriptionId?: string | null;
   sampleName?: string | null;
+  filters?: ResumeFilters;
+  status?: SearchSessionStatus;
   expiresAt?: string | null;
+  shareTitle?: string | null;
+  searchState?: SearchSessionState | null;
 };
 
 function toIsoNow(): string {
@@ -64,6 +104,8 @@ function normalizeSession(row: Record<string, unknown>): SearchSession {
     jobDescriptionId: row.job_description_id ? String(row.job_description_id) : undefined,
     sampleName: row.sample_name ? String(row.sample_name) : undefined,
     filters: parseJson<ResumeFilters>(row.filters) ?? undefined,
+    shareTitle: row.share_title ? String(row.share_title) : undefined,
+    searchState: parseJson<SearchSessionState>(row.search_state) ?? undefined,
     status: (row.status ? String(row.status) : "active") as SearchSessionStatus,
     createdAt: String(row.created_at),
     updatedAt: String(row.updated_at),
@@ -84,6 +126,8 @@ export class SessionManager {
     jobDescriptionId?: string;
     sampleName?: string;
     filters?: ResumeFilters;
+    shareTitle?: string;
+    searchState?: SearchSessionState;
   } = {}): SearchSession {
     const id = randomUUID();
     const now = toIsoNow();
@@ -98,11 +142,13 @@ export class SessionManager {
           job_description_id,
           sample_name,
           filters,
+          share_title,
+          search_state,
           status,
           created_at,
           updated_at,
           expires_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `)
       .run(
         id,
@@ -111,6 +157,8 @@ export class SessionManager {
         params.jobDescriptionId ?? null,
         params.sampleName ?? null,
         params.filters ? JSON.stringify(params.filters) : null,
+        params.shareTitle ?? null,
+        params.searchState ? JSON.stringify(params.searchState) : null,
         "active",
         now,
         now,
@@ -124,6 +172,8 @@ export class SessionManager {
       jobDescriptionId: params.jobDescriptionId,
       sampleName: params.sampleName,
       filters: params.filters,
+      shareTitle: params.shareTitle,
+      searchState: params.searchState,
       status: "active",
       createdAt: now,
       updatedAt: now,
@@ -178,6 +228,14 @@ export class SessionManager {
     if (updates.filters !== undefined) {
       fields.push("filters = ?");
       values.push(updates.filters ? JSON.stringify(updates.filters) : null);
+    }
+    if (updates.shareTitle !== undefined) {
+      fields.push("share_title = ?");
+      values.push(updates.shareTitle ?? null);
+    }
+    if (updates.searchState !== undefined) {
+      fields.push("search_state = ?");
+      values.push(updates.searchState ? JSON.stringify(updates.searchState) : null);
     }
     if (updates.status !== undefined) {
       fields.push("status = ?");

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -62,6 +62,8 @@ export function ResumeList() {
     hasActiveTask,
     disableAnalyzeButton,
     selectedIds,
+    shareTitle,
+    shareState,
     selectedExperienceLevel,
     activeTagFilters,
     activeCompanyFilters,
@@ -98,6 +100,7 @@ export function ResumeList() {
     handleToggleBlock,
     handleCandidateStatusChange,
     handleResetAll,
+    ensureApiSession,
     handleAiFeedback,
     getAiFeedback,
   } = useResumeListState(historyRequested)
@@ -354,7 +357,11 @@ export function ResumeList() {
         defaultCollapsed={true}
         headerAction={
           <div className="flex items-center gap-2">
-            <ShareLinkButton />
+            <ShareLinkButton
+              shareTitle={shareTitle}
+              state={shareState}
+              ensureApiSession={ensureApiSession}
+            />
             <Button size="sm" variant="ghost" className="h-8 w-8 p-0" onClick={handleRefresh} disabled={activeLoading}>
               <RefreshCw className={cn('h-3.5 w-3.5', activeLoading && 'animate-spin')} />
             </Button>

--- a/apps/web/src/components/ShareLinkButton.test.tsx
+++ b/apps/web/src/components/ShareLinkButton.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ShareLinkButton } from './ShareLinkButton'
+
+const { toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}))
+
+describe('ShareLinkButton', () => {
+  const clipboardWriteTextMock = vi.fn(async () => {})
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.history.replaceState({}, '', '/dev/resumes')
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: clipboardWriteTextMock,
+      },
+    })
+  })
+
+  it('copies the current URL directly for simple shareable search state', async () => {
+    window.history.replaceState({}, '', '/dev/resumes?location=Dongguan&keyword=CNC')
+    const ensureApiSession = vi.fn(async () => 'session-share-1')
+
+    render(
+      <ShareLinkButton
+        shareTitle="Dongguan · CNC"
+        state={{
+          location: 'Dongguan',
+          keywords: ['CNC'],
+          requiredKeywords: [],
+          filters: {},
+          selectedTags: [],
+          selectedCompanies: [],
+        }}
+        ensureApiSession={ensureApiSession}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '分享' }))
+
+    await waitFor(() => {
+      expect(clipboardWriteTextMock).toHaveBeenCalledWith(
+        `${window.location.origin}/dev/resumes?location=Dongguan&keyword=CNC`
+      )
+    })
+
+    expect(ensureApiSession).not.toHaveBeenCalled()
+    expect(toastSuccessMock).toHaveBeenCalledWith('已复制分享链接')
+  })
+
+  it('creates and copies a short sid link for bulky or session-backed state', async () => {
+    window.history.replaceState({}, '', '/dev/resumes?location=Kuala+Lumpur+MY&keyword=%22Sales+Engineer%22')
+    const ensureApiSession = vi.fn(async () => 'session-share-1')
+
+    render(
+      <ShareLinkButton
+        shareTitle="Kuala Lumpur · Sales Engineer"
+        state={{
+          location: 'Kuala Lumpur MY',
+          keywords: ['Sales Engineer'],
+          requiredKeywords: ['CNC'],
+          collectionSource: {
+            type: 'seek',
+            exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+          },
+          collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+          filters: {
+            minAge: 28,
+          },
+          selectedTags: ['STAR'],
+          selectedCompanies: ['Acme'],
+          selectedExperienceLevel: 'mid',
+          jobDescriptionId: 'lathe-sales',
+        }}
+        ensureApiSession={ensureApiSession}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '分享' }))
+
+    await waitFor(() => {
+      expect(ensureApiSession).toHaveBeenCalledWith({
+        shareTitle: 'Kuala Lumpur · Sales Engineer',
+        searchState: expect.objectContaining({
+          location: 'Kuala Lumpur MY',
+          keywords: ['Sales Engineer'],
+          collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+        }),
+      })
+    })
+
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith(
+      `${window.location.origin}/dev/resumes?sid=session-share-1`
+    )
+    expect(toastSuccessMock).toHaveBeenCalledWith('已复制会话链接')
+  })
+})

--- a/apps/web/src/components/ShareLinkButton.tsx
+++ b/apps/web/src/components/ShareLinkButton.tsx
@@ -2,21 +2,112 @@ import { useCallback } from 'react'
 import { Link2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import type { EnsureApiSessionOptions, ResumeSearchShareState } from '@/hooks/useSession'
 
-export function ShareLinkButton() {
+type ShareLinkButtonProps = {
+  shareTitle: string
+  state: ResumeSearchShareState
+  ensureApiSession: (options?: EnsureApiSessionOptions) => Promise<string | undefined>
+}
+
+function countActiveFilters(filters: ResumeSearchShareState['filters']): number {
+  if (!filters) {
+    return 0
+  }
+
+  return Object.values(filters).reduce<number>((count, value) => {
+    if (Array.isArray(value)) {
+      return count + (value.length > 0 ? 1 : 0)
+    }
+    if (typeof value === 'boolean') {
+      return count + (value ? 1 : 0)
+    }
+    return count + (value !== undefined ? 1 : 0)
+  }, 0)
+}
+
+function shouldPersistShareLink(currentUrl: URL, state: ResumeSearchShareState): boolean {
+  if (currentUrl.searchParams.has('sid')) {
+    return false
+  }
+
+  if (state.collectionSource || state.collectUrl) {
+    return true
+  }
+
+  const selectionComplexity =
+    (state.keywords?.length ?? 0)
+    + (state.requiredKeywords?.length ?? 0)
+    + (state.selectedTags?.length ?? 0)
+    + (state.selectedCompanies?.length ?? 0)
+    + countActiveFilters(state.filters)
+    + (state.selectedExperienceLevel ? 1 : 0)
+    + (state.jobDescriptionId ? 1 : 0)
+
+  return currentUrl.toString().length > 700 || selectionComplexity >= 9
+}
+
+function buildSessionShareUrl(sessionId: string): string {
+  const shareUrl = new URL(window.location.href)
+  shareUrl.search = ''
+  shareUrl.hash = ''
+  shareUrl.searchParams.set('sid', sessionId)
+  return shareUrl.toString()
+}
+
+async function copyText(text: string): Promise<void> {
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+    try {
+      await navigator.clipboard.writeText(text)
+      return
+    } catch (error) {
+      console.error('Clipboard API copy failed, falling back to execCommand', error)
+    }
+  }
+
+  const textArea = document.createElement('textarea')
+  textArea.value = text
+  textArea.setAttribute('readonly', 'true')
+  textArea.style.position = 'fixed'
+  textArea.style.top = '0'
+  textArea.style.left = '-9999px'
+  document.body.appendChild(textArea)
+  textArea.select()
+
+  const execCommand = document.execCommand?.bind(document)
+  const copied = execCommand ? execCommand('copy') : false
+  textArea.remove()
+
+  if (!copied) {
+    throw new Error('Clipboard copy unavailable')
+  }
+}
+
+export function ShareLinkButton({ shareTitle, state, ensureApiSession }: ShareLinkButtonProps) {
   const handleCopy = useCallback(async () => {
     try {
-      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
-        await navigator.clipboard.writeText(window.location.href)
-      } else {
-        throw new Error('Clipboard API unavailable')
+      const currentUrl = new URL(window.location.href)
+      let shareUrl = currentUrl.toString()
+      let usedSessionLink = false
+
+      if (shouldPersistShareLink(currentUrl, state)) {
+        const sessionId = await ensureApiSession({
+          shareTitle,
+          searchState: state,
+        })
+        if (sessionId) {
+          shareUrl = buildSessionShareUrl(sessionId)
+          usedSessionLink = true
+        }
       }
-      toast.success('已复制分享链接')
+
+      await copyText(shareUrl)
+      toast.success(usedSessionLink ? '已复制会话链接' : '已复制分享链接')
     } catch (error) {
       console.error('Failed to copy share URL', error)
       toast.error('复制链接失败，请手动复制地址栏 URL')
     }
-  }, [])
+  }, [ensureApiSession, shareTitle, state])
 
   return (
     <Button

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -44,6 +44,7 @@ const mockState = vi.hoisted(() => ({
   setCollectionSource: vi.fn(),
   setCollectUrl: vi.fn(),
   ensureApiSession: vi.fn(async () => 'api-session-1'),
+  rememberApiSessionId: vi.fn(),
   trackReviewedResume: vi.fn(),
   applyExternalState: vi.fn(),
   saveSearchHistory: vi.fn(async () => 'history-1'),
@@ -58,6 +59,7 @@ const mockState = vi.hoisted(() => ({
   saveAction: vi.fn(async () => {}),
   syncToUrl: vi.fn(),
   urlParsedState: {
+    shareSessionId: undefined as string | undefined,
     location: undefined as string | undefined,
     keywords: [] as string[],
     requiredKeywords: [] as string[],
@@ -70,6 +72,7 @@ const mockState = vi.hoisted(() => ({
   urlHasParams: false,
   urlHasKeywordParam: false,
   urlHasJobDescriptionParam: false,
+  sessionGetResponse: { data: { success: true } } as { data: Record<string, unknown> },
   locationPathname: '/dev/resumes',
   locationSearch: '',
   locationHash: '',
@@ -126,6 +129,7 @@ vi.mock('@/hooks/useSession', () => ({
     saveSearchHistory: mockState.saveSearchHistory,
     markSearchHistoryOpened: mockState.markSearchHistoryOpened,
     ensureApiSession: mockState.ensureApiSession,
+    rememberApiSessionId: mockState.rememberApiSessionId,
   }),
 }))
 
@@ -206,7 +210,12 @@ vi.mock('@/hooks/useCandidateStatus', () => ({
 vi.mock('@/lib/api-helpers', () => ({
   rawApiClient: {
     POST: vi.fn(async () => ({ data: mockState.matchApiResponse })),
-    GET: vi.fn(async () => ({ data: { success: true } })),
+    GET: vi.fn(async (path: string) => {
+      if (path.startsWith('/api/sessions/')) {
+        return mockState.sessionGetResponse
+      }
+      return { data: { success: true } }
+    }),
   },
 }))
 
@@ -607,12 +616,14 @@ describe('useResumeListState role filter regression', () => {
     mockState.sessionCollectionSource = undefined
     mockState.sessionCollectUrl = ''
     mockState.ensureApiSession.mockResolvedValue('api-session-1')
+    mockState.sessionGetResponse = { data: { success: true } }
     mockState.blocksByIdentity = {}
     mockState.statusByIdentity = {}
     mockState.searchHistory = []
     mockState.matchApiResponse = { success: true, results: [] }
     document.body.innerHTML = ''
     mockState.urlParsedState = {
+      shareSessionId: undefined,
       location: undefined,
       keywords: [],
       jobDescriptionId: undefined,
@@ -1260,6 +1271,89 @@ describe('useResumeListState role filter regression', () => {
     expect(result.current.appliedSearchHistoryId).toBe('history-1')
   })
 
+  it('hydrates persisted share-session state from sid links when explicit params are absent', async () => {
+    window.history.replaceState({}, '', '/dev/resumes?sid=shared-session-1')
+    mockState.locationSearch = '?sid=shared-session-1'
+    mockState.urlParsedState = {
+      ...mockState.urlParsedState,
+      shareSessionId: 'shared-session-1',
+    }
+    mockState.sessionGetResponse = {
+      data: {
+        success: true,
+        session: {
+          id: 'shared-session-1',
+          searchState: {
+            location: 'Kuala Lumpur MY',
+            keywords: ['Sales Engineer'],
+            requiredKeywords: ['CNC'],
+            jobDescriptionId: 'lathe-sales',
+            collectionSource: {
+              type: 'seek',
+              exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+            },
+            collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+            selectedTags: ['STAR'],
+            selectedCompanies: ['Acme'],
+            selectedExperienceLevel: 'mid',
+            filters: {
+              minAge: 28,
+            },
+          },
+        },
+      },
+    }
+
+    renderHook(() => useResumeListState())
+
+    await waitFor(() => {
+      expect(rawApiClient.GET).toHaveBeenCalledWith('/api/sessions/shared-session-1')
+    })
+
+    expect(mockState.rememberApiSessionId).toHaveBeenCalledWith('shared-session-1')
+    expect(mockState.applyExternalState).toHaveBeenCalledWith({
+      location: 'Kuala Lumpur MY',
+      keywords: ['Sales Engineer'],
+      jobDescriptionId: 'lathe-sales',
+      collectionSource: {
+        type: 'seek',
+        exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+      },
+      collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+      filters: {
+        minAge: 28,
+      },
+    })
+  })
+
+  it('prefers explicit URL params over sid hydration when both are present', async () => {
+    window.history.replaceState({}, '', '/dev/resumes?sid=shared-session-1&location=Dongguan&keyword=CNC')
+    mockState.locationSearch = '?sid=shared-session-1&location=Dongguan&keyword=CNC'
+    mockState.urlHasParams = true
+    mockState.urlHasKeywordParam = true
+    mockState.urlParsedState = {
+      ...mockState.urlParsedState,
+      shareSessionId: 'shared-session-1',
+      location: 'Dongguan',
+      keywords: ['CNC'],
+    }
+
+    renderHook(() => useResumeListState())
+
+    await waitFor(() => {
+      expect(mockState.applyExternalState).toHaveBeenCalledWith({
+        location: 'Dongguan',
+        keywords: ['CNC'],
+        jobDescriptionId: undefined,
+        collectionSource: null,
+        collectUrl: '',
+        filters: {},
+      })
+    })
+
+    expect(rawApiClient.GET).not.toHaveBeenCalled()
+  })
+
   it('passes current convex resume ids when saving search history', async () => {
     mockState.saveSearchHistory.mockClear()
     const { result } = renderHook(() => useResumeListState())
@@ -1447,6 +1541,7 @@ describe('useResumeListState role filter regression', () => {
   it('allows manual profile apply to bypass the URL hydration guard', () => {
     mockState.sessionLocation = ''
     mockState.urlParsedState = {
+      shareSessionId: undefined,
       location: '广东',
       keywords: ['CNC'],
       jobDescriptionId: undefined,

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -40,7 +40,7 @@ import type { components } from '@/lib/api-types'
 import { getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey } from '@/lib/analysis-utils'
 import { isResumeHomeResetState } from '@/lib/resume-home-navigation'
 import { withWorkspaceHeaders } from '@/lib/workspace-ref'
-import type { SearchHistoryItem } from '@/hooks/useSession'
+import type { ResumeSearchShareState, SearchHistoryItem } from '@/hooks/useSession'
 import {
   aiFeedbackToActionType,
   type AiFeedbackSentiment,
@@ -74,6 +74,14 @@ type JobDescriptionApiResponse = {
 }
 
 type ResumeExportRequestBody = components['schemas']['ResumeExportCanonicalRequest']
+type SearchSessionApiResponse = {
+  success: boolean
+  session?: {
+    id?: string
+    shareTitle?: string
+    searchState?: ResumeSearchShareState
+  }
+}
 
 type ScoredConvexResume = ConvexResumeItem & {
   _ruleScore: number
@@ -196,6 +204,7 @@ function normalizeUrlFilters(filters: Partial<ResumeFilters>): Partial<ResumeFil
 
 function normalizeUrlSearchStateValue(state: Partial<UrlSearchState> | undefined): UrlSearchState {
   return {
+    shareSessionId: normalizeOptionalString(state?.shareSessionId),
     location: normalizeOptionalString(state?.location),
     keywords: Array.isArray(state?.keywords) ? state.keywords : [],
     requiredKeywords: Array.isArray(state?.requiredKeywords) ? state.requiredKeywords : [],
@@ -207,11 +216,12 @@ function normalizeUrlSearchStateValue(state: Partial<UrlSearchState> | undefined
   }
 }
 
-function buildSearchHistoryTitle(location: string, keywords: string[]): string {
+function buildSearchHistoryTitle(location: string, keywords: string[], jobDescriptionId?: string): string {
   const normalizedLocation = location.trim()
   const normalizedKeywords = formatKeywordQuery(keywords).trim()
-
-  const parts = [normalizedLocation, normalizedKeywords].filter((value) => value.length > 0)
+  const normalizedJobDescriptionId = normalizeOptionalString(jobDescriptionId)
+  const primarySubject = normalizedKeywords || normalizedJobDescriptionId || ''
+  const parts = [normalizedLocation, primarySubject].filter((value) => value.length > 0)
   return parts.join(' · ') || 'Untitled search'
 }
 
@@ -567,6 +577,7 @@ export function useResumeListState(loadSearchHistory = false) {
     saveSearchHistory,
     markSearchHistoryOpened,
     ensureApiSession,
+    rememberApiSessionId,
   } = useSession(loadSearchHistory)
 
   const {
@@ -602,6 +613,8 @@ export function useResumeListState(loadSearchHistory = false) {
     parsedState: ReturnType<typeof parseUrlSearchState>
   } | null>(null)
   const [hasCompletedUrlHydration, setHasCompletedUrlHydration] = useState(false)
+  const [hasCompletedShareSessionHydration, setHasCompletedShareSessionHydration] = useState(false)
+  const hydratedShareSessionIdRef = useRef<string | null>(null)
 
   if (!initialWindowSearchStateRef.current) {
     const params = new URLSearchParams(window.location.search)
@@ -630,6 +643,10 @@ export function useResumeListState(loadSearchHistory = false) {
   const activeParsedUrlState = hasUrlParams
     ? normalizedParsedUrlState
     : initialWindowSearchState.parsedState
+  const activeShareSessionId = normalizeOptionalString(parsedUrlState.shareSessionId)
+    ?? (!hasInitializedUrlHydrationRef.current
+      ? normalizeOptionalString(initialWindowSearchState.parsedState.shareSessionId)
+      : undefined)
   const activeUrlStateSignature = useMemo(
     () => JSON.stringify({
       hasKeywordParam: activeHasKeywordParam,
@@ -646,6 +663,7 @@ export function useResumeListState(loadSearchHistory = false) {
     }),
     [activeHasJobDescriptionParam, activeHasKeywordParam, activeHasUrlParams, activeParsedUrlState]
   )
+  const hasCompletedSearchHydration = hasCompletedUrlHydration && hasCompletedShareSessionHydration
 
   const {
     resumes,
@@ -1065,7 +1083,79 @@ export function useResumeListState(loadSearchHistory = false) {
   }, [hasCompletedUrlHydration, hasHydratedUrlState])
 
   useEffect(() => {
-    if (!hasCompletedUrlHydration) {
+    if (activeHasUrlParams) {
+      hydratedShareSessionIdRef.current = null
+      setHasCompletedShareSessionHydration(true)
+      return
+    }
+
+    if (!activeShareSessionId) {
+      hydratedShareSessionIdRef.current = null
+      setHasCompletedShareSessionHydration(true)
+      return
+    }
+
+    if (hydratedShareSessionIdRef.current === activeShareSessionId) {
+      setHasCompletedShareSessionHydration(true)
+      return
+    }
+
+    let active = true
+    hydratedShareSessionIdRef.current = activeShareSessionId
+    setHasCompletedShareSessionHydration(false)
+
+    void rawApiClient
+      .GET<SearchSessionApiResponse>(`/api/sessions/${encodeURIComponent(activeShareSessionId)}`)
+      .then(({ data, error }) => {
+        if (!active) {
+          return
+        }
+
+        const sharedSearchState = data?.session?.searchState
+        if (error || !data?.success || !sharedSearchState) {
+          console.error('Failed to hydrate shared search session', error ?? data)
+          setHasCompletedShareSessionHydration(true)
+          return
+        }
+
+        skipNextUrlSyncRef.current = true
+        rememberApiSessionId(activeShareSessionId)
+        applyExternalState({
+          location: sharedSearchState.location,
+          keywords: sharedSearchState.keywords,
+          jobDescriptionId: sharedSearchState.jobDescriptionId ?? '',
+          collectionSource: sharedSearchState.collectionSource ?? null,
+          collectUrl: sharedSearchState.collectUrl ?? '',
+          filters: sharedSearchState.filters ?? {},
+        })
+        setAppliedSearchHistoryId(undefined)
+        setSelectedTags(sharedSearchState.selectedTags ?? [])
+        setSelectedCompanies(sharedSearchState.selectedCompanies ?? [])
+        setRequiredKeywords(sharedSearchState.requiredKeywords ?? [])
+        setSelectedExperienceLevel(sharedSearchState.selectedExperienceLevel)
+        setHasCompletedShareSessionHydration(true)
+      })
+      .catch((error: unknown) => {
+        if (!active) {
+          return
+        }
+
+        console.error('Failed to hydrate shared search session', error)
+        setHasCompletedShareSessionHydration(true)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [
+    activeHasUrlParams,
+    activeShareSessionId,
+    applyExternalState,
+    rememberApiSessionId,
+  ])
+
+  useEffect(() => {
+    if (!hasCompletedSearchHydration) {
       return
     }
 
@@ -1104,7 +1194,7 @@ export function useResumeListState(loadSearchHistory = false) {
     return () => window.clearTimeout(timer)
   }, [
     filters,
-    hasCompletedUrlHydration,
+    hasCompletedSearchHydration,
     jobDescriptionId,
     requiredKeywords,
     selectedCompanies,
@@ -1698,6 +1788,7 @@ export function useResumeListState(loadSearchHistory = false) {
     })
     setSelectedTags([])
     setSelectedCompanies([])
+    setRequiredKeywords([])
     setSelectedExperienceLevel(undefined)
   }, [applyExternalState])
 
@@ -2077,7 +2168,7 @@ export function useResumeListState(loadSearchHistory = false) {
   }, [setSessionCollectionSource])
 
   const handleSaveCurrentSearch = useCallback(async () => {
-    const title = buildSearchHistoryTitle(sessionLocation, sessionKeywords)
+    const title = buildSearchHistoryTitle(sessionLocation, sessionKeywords, jobDescriptionId)
     const saved = await saveSearchHistory({
       title,
       location: sessionLocation,
@@ -2112,10 +2203,49 @@ export function useResumeListState(loadSearchHistory = false) {
     setAppliedSearchHistoryId(entry.id)
     setSelectedTags(entry.selectedTags)
     setSelectedCompanies(entry.selectedCompanies)
+    setRequiredKeywords([])
     setSelectedExperienceLevel(toExperienceLevel(entry.selectedExperienceLevel))
     await markSearchHistoryOpened(entry.id)
     toast.success(t('quickStart.history.applySuccess', 'Applied saved search'))
   }, [applyExternalState, markSearchHistoryOpened, t])
+
+  const shareTitle = useMemo(
+    () => buildSearchHistoryTitle(sessionLocation, sessionKeywords, jobDescriptionId),
+    [jobDescriptionId, sessionKeywords, sessionLocation]
+  )
+  const shareState = useMemo<ResumeSearchShareState>(() => {
+    const normalizedLocation = normalizeOptionalString(sessionLocation)
+    const locationFilters = normalizedLocation
+      ? normalizedLocation.split(/[,，、]+/).map((item) => item.trim()).filter(Boolean)
+      : (Array.isArray(filters.locations) ? filters.locations : [])
+
+    return {
+      location: normalizedLocation,
+      keywords: sessionKeywords,
+      requiredKeywords,
+      jobDescriptionId: normalizeOptionalString(jobDescriptionId),
+      collectionSource: sessionCollectionSource,
+      collectUrl: normalizeOptionalString(sessionCollectUrl),
+      filters: {
+        ...filters,
+        locations: locationFilters,
+      },
+      selectedTags,
+      selectedCompanies,
+      selectedExperienceLevel,
+    }
+  }, [
+    filters,
+    jobDescriptionId,
+    requiredKeywords,
+    selectedCompanies,
+    selectedExperienceLevel,
+    selectedTags,
+    sessionCollectUrl,
+    sessionCollectionSource,
+    sessionKeywords,
+    sessionLocation,
+  ])
 
   return {
     sessionLocation,
@@ -2137,6 +2267,8 @@ export function useResumeListState(loadSearchHistory = false) {
     hasActiveTask,
     disableAnalyzeButton,
     selectedIds,
+    shareTitle,
+    shareState,
     selectedTags,
     selectedCompanies,
     requiredKeywords,
@@ -2181,5 +2313,6 @@ export function useResumeListState(loadSearchHistory = false) {
     handleToggleBlock,
     handleCandidateStatusChange,
     handleResetAll,
+    ensureApiSession,
   }
 }

--- a/apps/web/src/hooks/useSession.test.tsx
+++ b/apps/web/src/hooks/useSession.test.tsx
@@ -279,9 +279,67 @@ describe('useSession', () => {
       body: {
         jobDescriptionId: 'lathe-sales',
         filters: { minExperience: 3 },
+        shareTitle: undefined,
+        searchState: undefined,
       },
     })
     expect(localStorage.getItem(`trends.resume.apiSessionId.dev.${sessionKey}`)).toBe('api-session-1')
+  })
+
+  it('persists share metadata when ensuring an API session for a durable share link', async () => {
+    const { result } = renderHook(() => useSession())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    await act(async () => {
+      await result.current.ensureApiSession({
+        shareTitle: 'Kuala Lumpur · Sales Engineer',
+        searchState: {
+          location: 'Kuala Lumpur MY',
+          keywords: ['Sales Engineer', 'CNC'],
+          requiredKeywords: ['machine tools'],
+          jobDescriptionId: 'lathe-sales',
+          selectedTags: ['STAR'],
+          selectedCompanies: ['Acme'],
+          selectedExperienceLevel: 'mid',
+          collectionSource: {
+            type: 'seek',
+            exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+          },
+          collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+          filters: {
+            minAge: 28,
+          },
+        },
+      })
+    })
+
+    expect(rawApiPostMock).toHaveBeenCalledWith('/api/sessions', {
+      body: {
+        jobDescriptionId: undefined,
+        filters: undefined,
+        shareTitle: 'Kuala Lumpur · Sales Engineer',
+        searchState: {
+          location: 'Kuala Lumpur MY',
+          keywords: ['Sales Engineer', 'CNC'],
+          requiredKeywords: ['machine tools'],
+          jobDescriptionId: 'lathe-sales',
+          selectedTags: ['STAR'],
+          selectedCompanies: ['Acme'],
+          selectedExperienceLevel: 'mid',
+          collectionSource: {
+            type: 'seek',
+            exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+          },
+          collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+          filters: {
+            minAge: 28,
+          },
+        },
+      },
+    })
   })
 
   it('updates an existing persisted API session id before reusing it', async () => {
@@ -314,9 +372,37 @@ describe('useSession', () => {
       body: {
         jobDescriptionId: undefined,
         filters: { minExperience: 5 },
+        shareTitle: undefined,
+        searchState: undefined,
       },
     })
     expect(rawApiPostMock).not.toHaveBeenCalled()
+  })
+
+  it('can adopt a shared API session id and reuse it for later updates', async () => {
+    const { result } = renderHook(() => useSession())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    act(() => {
+      result.current.rememberApiSessionId('shared-session-id')
+      result.current.setFilters({ minExperience: 6 })
+    })
+
+    await act(async () => {
+      await result.current.ensureApiSession()
+    })
+
+    expect(rawApiPatchMock).toHaveBeenCalledWith('/api/sessions/shared-session-id', {
+      body: {
+        jobDescriptionId: undefined,
+        filters: { minExperience: 6 },
+        shareTitle: undefined,
+        searchState: undefined,
+      },
+    })
   })
 
   it('clears location when external state explicitly provides an empty location', async () => {

--- a/apps/web/src/hooks/useSession.ts
+++ b/apps/web/src/hooks/useSession.ts
@@ -21,6 +21,18 @@ export type ExternalSessionState = {
   filters?: Partial<ResumeFilters>
 }
 
+export type ResumeSearchShareState = ExternalSessionState & {
+  requiredKeywords?: string[]
+  selectedTags?: string[]
+  selectedCompanies?: string[]
+  selectedExperienceLevel?: 'senior' | 'mid' | 'junior'
+}
+
+export type EnsureApiSessionOptions = {
+  shareTitle?: string
+  searchState?: ResumeSearchShareState
+}
+
 export type SearchHistoryItem = {
   id: Id<'search_history'>
   sessionKey: string
@@ -94,6 +106,74 @@ function normalizeStringList(values: string[] | undefined): string[] {
     seen.add(token)
     normalized.push(token)
   })
+
+  return normalized
+}
+
+function normalizeShareExperienceLevel(
+  value: string | undefined,
+): ResumeSearchShareState['selectedExperienceLevel'] | undefined {
+  const normalized = normalizeOptionalString(value)?.toLowerCase()
+  if (normalized === 'senior' || normalized === 'mid' || normalized === 'junior') {
+    return normalized
+  }
+  return undefined
+}
+
+function normalizeShareFilters(
+  filters: Partial<ResumeFilters> | undefined,
+): Partial<ResumeFilters> | undefined {
+  if (!filters) {
+    return undefined
+  }
+
+  const hasActiveFilters = Object.values(filters).some((value) => {
+    if (Array.isArray(value)) {
+      return value.length > 0
+    }
+    if (typeof value === 'boolean') {
+      return value
+    }
+    return value !== undefined
+  })
+
+  return hasActiveFilters ? filters : undefined
+}
+
+function normalizeShareState(
+  state: ResumeSearchShareState | undefined,
+): ResumeSearchShareState | undefined {
+  if (!state) {
+    return undefined
+  }
+
+  const normalized: ResumeSearchShareState = {
+    location: normalizeOptionalString(state.location),
+    keywords: normalizeStringList(state.keywords),
+    requiredKeywords: normalizeStringList(state.requiredKeywords),
+    jobDescriptionId: normalizeOptionalString(state.jobDescriptionId),
+    selectedTags: normalizeStringList(state.selectedTags),
+    selectedCompanies: normalizeStringList(state.selectedCompanies),
+    selectedExperienceLevel: normalizeShareExperienceLevel(state.selectedExperienceLevel),
+    collectionSource: normalizeCollectionSource(state.collectionSource),
+    collectUrl: normalizeOptionalString(state.collectUrl),
+    filters: normalizeShareFilters(state.filters),
+  }
+
+  if (
+    !normalized.location
+    && !normalized.jobDescriptionId
+    && !normalized.collectUrl
+    && !normalized.collectionSource
+    && (normalized.keywords?.length ?? 0) === 0
+    && (normalized.requiredKeywords?.length ?? 0) === 0
+    && (normalized.selectedTags?.length ?? 0) === 0
+    && (normalized.selectedCompanies?.length ?? 0) === 0
+    && !normalized.selectedExperienceLevel
+    && !normalized.filters
+  ) {
+    return undefined
+  }
 
   return normalized
 }
@@ -232,10 +312,18 @@ export function useSession(loadSearchHistory = false) {
     setApiSessionId((current) => (current === nextSessionId ? current : nextSessionId))
   }, [apiSessionStorageKey])
 
-  const ensureApiSession = useCallback(async () => {
+  const rememberApiSessionId = useCallback((nextSessionId: string | undefined) => {
+    persistApiSessionId(normalizeOptionalString(nextSessionId))
+  }, [persistApiSessionId])
+
+  const ensureApiSession = useCallback(async (options?: EnsureApiSessionOptions) => {
+    const shareTitle = normalizeOptionalString(options?.shareTitle)
+    const searchState = normalizeShareState(options?.searchState)
     const body = {
       jobDescriptionId: normalizeOptionalString(jobDescriptionId),
       filters: Object.keys(filters).length > 0 ? filters : undefined,
+      shareTitle,
+      searchState,
     }
 
     if (apiSessionId) {
@@ -376,6 +464,7 @@ export function useSession(loadSearchHistory = false) {
     saveSearchHistory,
     markSearchHistoryOpened,
     ensureApiSession,
+    rememberApiSessionId,
     loading: !hasHydratedInitialState,
   }
 }

--- a/apps/web/src/hooks/useUrlSearchState.test.ts
+++ b/apps/web/src/hooks/useUrlSearchState.test.ts
@@ -49,6 +49,12 @@ describe('useUrlSearchState location parsing', () => {
     expect(state.requiredKeywords).toEqual(['CNC', 'machine tools'])
   })
 
+  it('parses sid without treating it as explicit URL search state', () => {
+    const state = parseUrlSearchState(new URLSearchParams('sid=session-share-1'))
+
+    expect(state.shareSessionId).toBe('session-share-1')
+  })
+
   it('serializes canonical OR phrase queries when syncing to the URL', () => {
     const currentParams = new URLSearchParams()
     useSearchParamsMock.mockReturnValue([currentParams, setSearchParamsMock])
@@ -103,5 +109,32 @@ describe('useUrlSearchState location parsing', () => {
     const [updater] = setSearchParamsMock.mock.calls[0] ?? []
     const updatedParams = updater(new URLSearchParams()) as URLSearchParams
     expect(updatedParams.get('rkw')).toBe('CNC,machine tools')
+  })
+
+  it('removes sid when syncing explicit state back into the URL', () => {
+    const currentParams = new URLSearchParams('sid=session-share-1')
+    useSearchParamsMock.mockReturnValue([currentParams, setSearchParamsMock])
+
+    const { result } = renderHook(() => useUrlSearchState())
+
+    const nextState: UrlSearchState = {
+      shareSessionId: 'session-share-1',
+      location: 'Dongguan',
+      keywords: ['CNC'],
+      requiredKeywords: [],
+      jobDescriptionId: undefined,
+      selectedTags: [],
+      selectedCompanies: [],
+      selectedExperienceLevel: undefined,
+      filters: {},
+    }
+
+    result.current.syncToUrl(nextState)
+
+    const [updater] = setSearchParamsMock.mock.calls[0] ?? []
+    const updatedParams = updater(currentParams) as URLSearchParams
+    expect(updatedParams.get('sid')).toBeNull()
+    expect(updatedParams.get('location')).toBe('Dongguan')
+    expect(updatedParams.get('keyword')).toBe('CNC')
   })
 })

--- a/apps/web/src/hooks/useUrlSearchState.ts
+++ b/apps/web/src/hooks/useUrlSearchState.ts
@@ -31,6 +31,7 @@ const KNOWN_PARAM_KEYS = [
 export type ExperienceLevelFilter = 'senior' | 'mid' | 'junior'
 
 export type UrlSearchState = {
+  shareSessionId?: string
   location?: string
   keywords: string[]
   requiredKeywords: string[]
@@ -184,6 +185,8 @@ export function hasKnownUrlSearchParams(searchParams: URLSearchParams): boolean 
 }
 
 export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchState {
+  const shareSessionIdRaw = searchParams.get('sid')
+  const shareSessionId = shareSessionIdRaw?.trim() || undefined
   const locationRaw = getFirstParam(searchParams, ['loc', 'location'])
   const normalizedLocation = locationRaw?.trim() || ''
   const locationFromLocationParam = normalizeUniqueValues(parseLocationParam(normalizedLocation))
@@ -259,6 +262,7 @@ export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchSta
   }
 
   return {
+    shareSessionId,
     location,
     keywords,
     requiredKeywords,
@@ -293,6 +297,7 @@ export function useUrlSearchState() {
         KNOWN_PARAM_KEYS.forEach((key) => {
           nextParams.delete(key)
         })
+        nextParams.delete('sid')
 
         const normalizedKeywords = normalizeUniqueValues(state.keywords)
         const normalizedTags = normalizeUniqueValues(state.selectedTags)

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -2372,7 +2372,68 @@ export interface paths {
                         userId?: string;
                         jobDescriptionId?: string;
                         sampleName?: string;
-                        filters?: components["schemas"]["ResumeFilters"];
+                        filters?: components["schemas"]["ResumeFilters"] & {
+                            minRoleYears?: number;
+                            roleFilterType?: string;
+                            minSalesYears?: number;
+                            minAge?: number;
+                            maxAge?: number;
+                            status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
+                            showBlocked?: boolean;
+                        };
+                        shareTitle?: string;
+                        searchState?: {
+                            /** @example Kuala Lumpur MY */
+                            location?: string;
+                            /**
+                             * @example [
+                             *       "Sales Engineer",
+                             *       "CNC"
+                             *     ]
+                             */
+                            keywords?: string[];
+                            /**
+                             * @example [
+                             *       "machine tools"
+                             *     ]
+                             */
+                            requiredKeywords?: string[];
+                            /** @example lathe-sales */
+                            jobDescriptionId?: string;
+                            /**
+                             * @example [
+                             *       "STAR"
+                             *     ]
+                             */
+                            selectedTags?: string[];
+                            /**
+                             * @example [
+                             *       "fanuc"
+                             *     ]
+                             */
+                            selectedCompanies?: string[];
+                            /**
+                             * @example mid
+                             * @enum {string}
+                             */
+                            selectedExperienceLevel?: "senior" | "mid" | "junior";
+                            collectionSource?: {
+                                /** @enum {string} */
+                                type: "job5156" | "seek";
+                                exactUrl?: string;
+                            };
+                            /** @example https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1 */
+                            collectUrl?: string;
+                            filters?: components["schemas"]["ResumeFilters"] & {
+                                minRoleYears?: number;
+                                roleFilterType?: string;
+                                minSalesYears?: number;
+                                minAge?: number;
+                                maxAge?: number;
+                                status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
+                                showBlocked?: boolean;
+                            };
+                        };
                     };
                 };
             };
@@ -2397,7 +2458,69 @@ export interface paths {
                                 jobDescriptionId?: string;
                                 /** @example sample-initial */
                                 sampleName?: string;
-                                filters?: components["schemas"]["ResumeFilters"];
+                                filters?: components["schemas"]["ResumeFilters"] & {
+                                    minRoleYears?: number;
+                                    roleFilterType?: string;
+                                    minSalesYears?: number;
+                                    minAge?: number;
+                                    maxAge?: number;
+                                    status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
+                                    showBlocked?: boolean;
+                                };
+                                /** @example Kuala Lumpur · Sales Engineer */
+                                shareTitle?: string;
+                                searchState?: {
+                                    /** @example Kuala Lumpur MY */
+                                    location?: string;
+                                    /**
+                                     * @example [
+                                     *       "Sales Engineer",
+                                     *       "CNC"
+                                     *     ]
+                                     */
+                                    keywords?: string[];
+                                    /**
+                                     * @example [
+                                     *       "machine tools"
+                                     *     ]
+                                     */
+                                    requiredKeywords?: string[];
+                                    /** @example lathe-sales */
+                                    jobDescriptionId?: string;
+                                    /**
+                                     * @example [
+                                     *       "STAR"
+                                     *     ]
+                                     */
+                                    selectedTags?: string[];
+                                    /**
+                                     * @example [
+                                     *       "fanuc"
+                                     *     ]
+                                     */
+                                    selectedCompanies?: string[];
+                                    /**
+                                     * @example mid
+                                     * @enum {string}
+                                     */
+                                    selectedExperienceLevel?: "senior" | "mid" | "junior";
+                                    collectionSource?: {
+                                        /** @enum {string} */
+                                        type: "job5156" | "seek";
+                                        exactUrl?: string;
+                                    };
+                                    /** @example https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1 */
+                                    collectUrl?: string;
+                                    filters?: components["schemas"]["ResumeFilters"] & {
+                                        minRoleYears?: number;
+                                        roleFilterType?: string;
+                                        minSalesYears?: number;
+                                        minAge?: number;
+                                        maxAge?: number;
+                                        status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
+                                        showBlocked?: boolean;
+                                    };
+                                };
                                 /**
                                  * @example active
                                  * @enum {string}
@@ -2460,7 +2583,69 @@ export interface paths {
                                 jobDescriptionId?: string;
                                 /** @example sample-initial */
                                 sampleName?: string;
-                                filters?: components["schemas"]["ResumeFilters"];
+                                filters?: components["schemas"]["ResumeFilters"] & {
+                                    minRoleYears?: number;
+                                    roleFilterType?: string;
+                                    minSalesYears?: number;
+                                    minAge?: number;
+                                    maxAge?: number;
+                                    status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
+                                    showBlocked?: boolean;
+                                };
+                                /** @example Kuala Lumpur · Sales Engineer */
+                                shareTitle?: string;
+                                searchState?: {
+                                    /** @example Kuala Lumpur MY */
+                                    location?: string;
+                                    /**
+                                     * @example [
+                                     *       "Sales Engineer",
+                                     *       "CNC"
+                                     *     ]
+                                     */
+                                    keywords?: string[];
+                                    /**
+                                     * @example [
+                                     *       "machine tools"
+                                     *     ]
+                                     */
+                                    requiredKeywords?: string[];
+                                    /** @example lathe-sales */
+                                    jobDescriptionId?: string;
+                                    /**
+                                     * @example [
+                                     *       "STAR"
+                                     *     ]
+                                     */
+                                    selectedTags?: string[];
+                                    /**
+                                     * @example [
+                                     *       "fanuc"
+                                     *     ]
+                                     */
+                                    selectedCompanies?: string[];
+                                    /**
+                                     * @example mid
+                                     * @enum {string}
+                                     */
+                                    selectedExperienceLevel?: "senior" | "mid" | "junior";
+                                    collectionSource?: {
+                                        /** @enum {string} */
+                                        type: "job5156" | "seek";
+                                        exactUrl?: string;
+                                    };
+                                    /** @example https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1 */
+                                    collectUrl?: string;
+                                    filters?: components["schemas"]["ResumeFilters"] & {
+                                        minRoleYears?: number;
+                                        roleFilterType?: string;
+                                        minSalesYears?: number;
+                                        minAge?: number;
+                                        maxAge?: number;
+                                        status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
+                                        showBlocked?: boolean;
+                                    };
+                                };
                                 /**
                                  * @example active
                                  * @enum {string}
@@ -2506,7 +2691,68 @@ export interface paths {
                         userId?: string;
                         jobDescriptionId?: string;
                         sampleName?: string;
-                        filters?: components["schemas"]["ResumeFilters"];
+                        filters?: components["schemas"]["ResumeFilters"] & {
+                            minRoleYears?: number;
+                            roleFilterType?: string;
+                            minSalesYears?: number;
+                            minAge?: number;
+                            maxAge?: number;
+                            status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
+                            showBlocked?: boolean;
+                        };
+                        shareTitle?: string | null;
+                        searchState?: {
+                            /** @example Kuala Lumpur MY */
+                            location?: string;
+                            /**
+                             * @example [
+                             *       "Sales Engineer",
+                             *       "CNC"
+                             *     ]
+                             */
+                            keywords?: string[];
+                            /**
+                             * @example [
+                             *       "machine tools"
+                             *     ]
+                             */
+                            requiredKeywords?: string[];
+                            /** @example lathe-sales */
+                            jobDescriptionId?: string;
+                            /**
+                             * @example [
+                             *       "STAR"
+                             *     ]
+                             */
+                            selectedTags?: string[];
+                            /**
+                             * @example [
+                             *       "fanuc"
+                             *     ]
+                             */
+                            selectedCompanies?: string[];
+                            /**
+                             * @example mid
+                             * @enum {string}
+                             */
+                            selectedExperienceLevel?: "senior" | "mid" | "junior";
+                            collectionSource?: {
+                                /** @enum {string} */
+                                type: "job5156" | "seek";
+                                exactUrl?: string;
+                            };
+                            /** @example https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1 */
+                            collectUrl?: string;
+                            filters?: components["schemas"]["ResumeFilters"] & {
+                                minRoleYears?: number;
+                                roleFilterType?: string;
+                                minSalesYears?: number;
+                                minAge?: number;
+                                maxAge?: number;
+                                status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
+                                showBlocked?: boolean;
+                            };
+                        } | null;
                         /** @enum {string} */
                         status?: "active" | "completed" | "archived";
                         expiresAt?: string;
@@ -2534,7 +2780,69 @@ export interface paths {
                                 jobDescriptionId?: string;
                                 /** @example sample-initial */
                                 sampleName?: string;
-                                filters?: components["schemas"]["ResumeFilters"];
+                                filters?: components["schemas"]["ResumeFilters"] & {
+                                    minRoleYears?: number;
+                                    roleFilterType?: string;
+                                    minSalesYears?: number;
+                                    minAge?: number;
+                                    maxAge?: number;
+                                    status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
+                                    showBlocked?: boolean;
+                                };
+                                /** @example Kuala Lumpur · Sales Engineer */
+                                shareTitle?: string;
+                                searchState?: {
+                                    /** @example Kuala Lumpur MY */
+                                    location?: string;
+                                    /**
+                                     * @example [
+                                     *       "Sales Engineer",
+                                     *       "CNC"
+                                     *     ]
+                                     */
+                                    keywords?: string[];
+                                    /**
+                                     * @example [
+                                     *       "machine tools"
+                                     *     ]
+                                     */
+                                    requiredKeywords?: string[];
+                                    /** @example lathe-sales */
+                                    jobDescriptionId?: string;
+                                    /**
+                                     * @example [
+                                     *       "STAR"
+                                     *     ]
+                                     */
+                                    selectedTags?: string[];
+                                    /**
+                                     * @example [
+                                     *       "fanuc"
+                                     *     ]
+                                     */
+                                    selectedCompanies?: string[];
+                                    /**
+                                     * @example mid
+                                     * @enum {string}
+                                     */
+                                    selectedExperienceLevel?: "senior" | "mid" | "junior";
+                                    collectionSource?: {
+                                        /** @enum {string} */
+                                        type: "job5156" | "seek";
+                                        exactUrl?: string;
+                                    };
+                                    /** @example https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1 */
+                                    collectUrl?: string;
+                                    filters?: components["schemas"]["ResumeFilters"] & {
+                                        minRoleYears?: number;
+                                        roleFilterType?: string;
+                                        minSalesYears?: number;
+                                        minAge?: number;
+                                        maxAge?: number;
+                                        status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
+                                        showBlocked?: boolean;
+                                    };
+                                };
                                 /**
                                  * @example active
                                  * @enum {string}


### PR DESCRIPTION
## Summary
- persist resume search share metadata in API search sessions
- add smart share button behavior that chooses raw URLs or short `sid` links
- hydrate `sid` links back into the resume shell only when explicit URL params are absent

## Validation
- bun run --filter '@trends/web' test -- src/hooks/useUrlSearchState.test.ts src/hooks/useSession.test.tsx src/hooks/useResumeListState.test.tsx src/components/ShareLinkButton.test.tsx
- npx vitest run apps/api/src/routes/sessions.test.ts
- npm --workspace @trends/web run typecheck
- npm --workspace @trends/api run typecheck
- make check
