### PR TITLE
feat(web): improve tablet resume shell

### DIFF
--- a/apps/web/src/components/FilterPanel.test.tsx
+++ b/apps/web/src/components/FilterPanel.test.tsx
@@ -29,14 +29,19 @@ describe('FilterPanel', () => {
     )
 
     const toggle = screen.getByRole('button', { name: /resumes\.filters\.title/i })
+    const clearButton = screen.getByRole('button', { name: 'resumes.filters.clear' })
+    const applyButton = screen.getByRole('button', { name: 'resumes.filters.apply' })
 
     expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(toggle.className).toContain('min-h-10')
     expect(screen.getByText('≥1年')).toBeInTheDocument()
     expect(screen.getByText('25-35岁')).toBeInTheDocument()
     expect(screen.getByText('广东, 江苏')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '分享' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'resumes.filters.clear' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'resumes.filters.apply' })).toBeInTheDocument()
+    expect(clearButton).toBeInTheDocument()
+    expect(clearButton).toHaveClass('h-10')
+    expect(applyButton).toBeInTheDocument()
+    expect(applyButton).toHaveClass('h-10')
 
     await user.click(toggle)
 

--- a/apps/web/src/components/FilterPanel.tsx
+++ b/apps/web/src/components/FilterPanel.tsx
@@ -169,22 +169,22 @@ export function FilterPanel({
     window.setTimeout(() => setClearing(false), 200)
   }
 
-  const toolbarButtonClassName = 'h-8 text-xs'
+  const toolbarButtonClassName = 'h-10 px-3 text-sm'
 
   return (
     <div className={cn("rounded-lg border bg-card shadow-sm transition-all duration-200", className)}>
-      <div className="px-4 py-3">
-        <div className="flex items-center justify-between gap-4">
+      <div className="px-3 py-3 sm:px-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <button
             type="button"
             aria-expanded={!isCollapsed}
             onClick={() => setIsCollapsed(!isCollapsed)}
-            className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden whitespace-nowrap text-left"
+            className="flex min-h-10 min-w-0 flex-1 items-center gap-2 overflow-hidden whitespace-nowrap rounded-lg text-left"
           >
             <h3 className="shrink-0 text-sm font-semibold text-foreground/90">{t('resumes.filters.title')}</h3>
             {isCollapsed ? <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" /> : <ChevronUp className="h-4 w-4 shrink-0 text-muted-foreground" />}
             {activeFilterBadges.length > 0 && (
-              <span className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden whitespace-nowrap text-xs text-muted-foreground">
+              <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 overflow-hidden text-xs text-muted-foreground">
                 {activeFilterBadges.map((badge, i) => (
                   <Badge key={i} variant="secondary" className="font-normal text-[10px] sm:text-xs px-1.5 sm:px-2 py-0 border-transparent bg-muted/60 text-muted-foreground whitespace-nowrap">
                     {badge}
@@ -194,9 +194,9 @@ export function FilterPanel({
             )}
           </button>
 
-          <div className="flex shrink-0 items-center justify-end gap-2">
+          <div className="flex w-full shrink-0 flex-wrap items-center justify-end gap-2 lg:w-auto">
             {headerAction}
-            {headerAction && <div className="hidden h-5 w-px bg-border sm:block" aria-hidden="true" />}
+            {headerAction && <div className="hidden h-5 w-px bg-border lg:block" aria-hidden="true" />}
             <Button
               size="sm"
               variant="ghost"
@@ -214,11 +214,11 @@ export function FilterPanel({
       </div>
 
       {!isCollapsed && (
-        <div className="border-t px-4 pb-4 pt-4">
+        <div className="border-t px-3 pb-4 pt-4 sm:px-4">
           <div className="grid gap-6 pt-2">
 
             {/* Row 1: Numeric Filters */}
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1.5">
                   <label className="text-xs font-medium text-muted-foreground">{t('resumes.filters.minExperience')}</label>
@@ -275,7 +275,7 @@ export function FilterPanel({
             </div>
 
             {/* Row 2: Text Filters */}
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
               <div className="space-y-1.5">
                 <label className="text-xs font-medium text-muted-foreground">{t('resumes.filters.skills')}</label>
                 <Input
@@ -299,9 +299,9 @@ export function FilterPanel({
             {/* Row 3: Education */}
             <div className="space-y-2">
               <label className="text-xs font-medium text-muted-foreground">{t('resumes.filters.education.title')}</label>
-              <div className="flex flex-wrap gap-4">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-5">
                 {EDUCATION_LEVELS.map((level) => (
-                  <label key={level.value} className="flex cursor-pointer items-center gap-2 text-sm text-foreground/80 hover:text-foreground">
+                  <label key={level.value} className="flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border border-border/70 bg-background px-3 py-2.5 text-sm text-foreground/80 hover:text-foreground">
                     <Checkbox
                       checked={educationSet.has(level.value)}
                       onCheckedChange={() => toggleEducation(level.value)}
@@ -315,9 +315,9 @@ export function FilterPanel({
             {/* Row 4: Status and Block Toggle */}
             <div className="space-y-3">
               <label className="text-xs font-medium text-muted-foreground">{t('resumes.filters.status')}</label>
-              <div className="flex flex-wrap gap-4">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-4">
                 {STATUS_OPTIONS.map((item) => (
-                  <label key={item.value} className="flex cursor-pointer items-center gap-2 text-sm text-foreground/80 hover:text-foreground">
+                  <label key={item.value} className="flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border border-border/70 bg-background px-3 py-2.5 text-sm text-foreground/80 hover:text-foreground">
                     <Checkbox
                       checked={statusSet.has(item.value)}
                       onCheckedChange={() => toggleStatus(item.value)}
@@ -327,7 +327,7 @@ export function FilterPanel({
                 ))}
               </div>
 
-              <label className="flex cursor-pointer items-center gap-2 text-sm text-foreground/80 hover:text-foreground">
+              <label className="flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border border-border/70 bg-background px-3 py-2.5 text-sm text-foreground/80 hover:text-foreground">
                 <Checkbox
                   checked={showBlocked}
                   onCheckedChange={(checked) => setShowBlocked(checked === true)}

--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -241,6 +241,24 @@ describe('QuickStartPanel quick-filter display', () => {
     expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument()
   })
 
+  it('keeps the shell compact until large tablet and desktop breakpoints', () => {
+    render(
+      <QuickStartPanel
+        defaultLocation="广东"
+        defaultKeywords={[]}
+        jobDescriptionId=""
+      />
+    )
+
+    const searchGrid = screen.getByTestId('quickstart-search-grid')
+    const jobDescriptionCard = screen.getByTestId('quickstart-jd-card')
+
+    expect(searchGrid.className).toContain('lg:grid-cols-[minmax(0,1.3fr)_minmax(220px,0.85fr)]')
+    expect(searchGrid.className).toContain('xl:grid-cols-[minmax(0,1.45fr)_minmax(180px,0.7fr)_minmax(220px,0.85fr)]')
+    expect(jobDescriptionCard.className).toContain('lg:col-span-2')
+    expect(jobDescriptionCard.className).toContain('xl:col-span-1')
+  })
+
   it('does not auto-apply min years when no JD is selected', async () => {
     const onApplyQuickFilters = vi.fn()
 

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -865,15 +865,15 @@ export function QuickStartPanel({
   }, [quickMinRoleYears, quickMaxAge, activeRoleType, onApplyQuickFilters, quickFilters?.minRoleYears, quickFilters?.maxAge, quickFilters?.roleFilterType])
 
   return (
-    <div className="rounded-lg border bg-background px-4 py-4 shadow-sm">
+    <div className="rounded-lg border bg-background px-3 py-3 shadow-sm sm:px-4 sm:py-4">
       <div className="flex flex-col gap-4">
-        <div className="rounded-2xl border border-border/70 bg-gradient-to-br from-background via-background to-muted/40 p-4">
+        <div className="rounded-2xl border border-border/70 bg-gradient-to-br from-background via-background to-muted/40 p-3 sm:p-4">
           <div className="flex flex-col gap-4">
             <div className="space-y-1">
               <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
                 {t('quickStart.shellEyebrow', 'Search workspace')}
               </p>
-              <div className="flex flex-col gap-1 lg:flex-row lg:items-end lg:justify-between">
+              <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
                 <div className="space-y-1">
                   <h2 className="text-lg font-semibold text-foreground">
                     {t('quickStart.shellTitle', 'Start from a keyword, workflow, or JD')}
@@ -890,7 +890,7 @@ export function QuickStartPanel({
                     type="button"
                     variant="ghost"
                     size="sm"
-                    className="h-9 gap-1 self-start px-3 text-sm font-medium text-foreground/80 hover:bg-background hover:text-foreground lg:self-auto"
+                    className="h-10 gap-1.5 self-start rounded-lg px-3 text-sm font-medium text-foreground/80 hover:bg-background hover:text-foreground lg:self-auto"
                     onClick={onResetAll}
                   >
                     <RotateCcw className="h-4 w-4" />
@@ -900,7 +900,10 @@ export function QuickStartPanel({
               </div>
             </div>
 
-            <div className="grid gap-3 xl:grid-cols-[minmax(0,1.45fr)_minmax(180px,0.7fr)_minmax(220px,0.85fr)]">
+            <div
+              data-testid="quickstart-search-grid"
+              className="grid gap-3 lg:grid-cols-[minmax(0,1.3fr)_minmax(220px,0.85fr)] xl:grid-cols-[minmax(0,1.45fr)_minmax(180px,0.7fr)_minmax(220px,0.85fr)]"
+            >
               <div className={shellFieldCardClassName}>
                 <label className={shellFieldLabelClassName}>
                   {t('quickStart.customKeywords', '关键词')}
@@ -944,7 +947,10 @@ export function QuickStartPanel({
                 </div>
               </div>
 
-              <div className={shellFieldCardClassName}>
+              <div
+                data-testid="quickstart-jd-card"
+                className={`${shellFieldCardClassName} lg:col-span-2 xl:col-span-1`}
+              >
                 <label className={shellFieldLabelClassName}>
                   {t('quickStart.manualJd', '手动职位(可选)')}
                 </label>
@@ -979,7 +985,7 @@ export function QuickStartPanel({
               type="button"
               variant="outline"
               size="sm"
-              className="h-8 rounded-full border-border/70 bg-background px-3 text-xs"
+              className="h-10 rounded-full border-border/70 bg-background px-3.5 text-xs"
               onClick={() => handleApplyWorkflow(workflow)}
             >
               {workflow.label}
@@ -996,7 +1002,7 @@ export function QuickStartPanel({
         />
 
         {extraActions ? (
-          <div className="rounded-xl border border-dashed border-border/80 bg-muted/20 px-3 py-3">
+          <div className="rounded-xl border border-dashed border-border/80 bg-muted/20 px-3 py-3 sm:px-4">
             <div className="mb-2 flex flex-wrap items-center gap-2">
               <span className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                 {t('quickStart.shortcutsTitle', 'Shortcuts')}
@@ -1094,7 +1100,7 @@ export function QuickStartPanel({
               ) : null}
             </div>
             <div className="mt-3 flex items-center gap-3">
-              <Button size="sm" onClick={handleUseMatchedConfig}>
+              <Button size="sm" className="h-10 px-4" onClick={handleUseMatchedConfig}>
                 {t('quickStart.useConfig', 'Use this config')}
               </Button>
               <Button

--- a/apps/web/src/components/ResumeDetail.test.tsx
+++ b/apps/web/src/components/ResumeDetail.test.tsx
@@ -6,17 +6,22 @@ import { ResumeDetail } from './ResumeDetail'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, fallback?: string) => fallback ?? key,
+    t: (key: string, fallback?: string | { defaultValue?: string }) => {
+      if (typeof fallback === 'string') {
+        return fallback
+      }
+      return fallback?.defaultValue ?? key
+    },
   }),
 }))
 
 vi.mock('@/components/ui/dialog', () => ({
   Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children, className, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div className={className} {...props}>{children}</div>,
+  DialogDescription: ({ children, className, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div className={className} {...props}>{children}</div>,
+  DialogFooter: ({ children, className, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div className={className} {...props}>{children}</div>,
+  DialogHeader: ({ children, className, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div className={className} {...props}>{children}</div>,
+  DialogTitle: ({ children, className, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div className={className} {...props}>{children}</div>,
 }))
 
 vi.mock('@/components/ui/button', () => ({
@@ -94,5 +99,59 @@ describe('ResumeDetail latest work history', () => {
 
     expect(screen.queryByText('Sales Engineer')).not.toBeInTheDocument()
     expect(screen.queryByText('Test intro')).not.toBeInTheDocument()
+  })
+
+  it('uses tablet-friendly responsive layout classes for the detail surface', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ResumeDetail
+        open
+        onOpenChange={vi.fn()}
+        resume={{
+          name: 'Alice',
+          profileUrl: 'https://example.com/resume-1',
+          activityStatus: 'Active',
+          age: '30',
+          experience: '5 years',
+          education: 'Bachelor',
+          location: 'Dongguan',
+          selfIntro: 'Test intro',
+          jobIntention: 'Sales Engineer',
+          expectedSalary: '10k-20k',
+          workHistory: [],
+          extractedAt: '2026-03-13T00:00:00.000Z',
+        }}
+        matchResult={{
+          resumeId: 'resume-1',
+          score: 84,
+          recommendation: 'strong_match',
+          highlights: ['Strong CNC background'],
+          concerns: ['Limited region coverage'],
+          summary: 'Strong overall fit.',
+          matchedAt: '2026-03-13T00:00:00.000Z',
+          breakdown: {
+            skills: 90,
+            experience: 88,
+            industry: 85,
+            stability: 70,
+            location: 65,
+          },
+        }}
+      />,
+    )
+
+    const content = screen.getByTestId('resume-detail-content')
+
+    expect(content.className).toContain('md:max-w-3xl')
+    expect(content.className).toContain('lg:max-w-4xl')
+
+    await user.click(screen.getByRole('button', { name: 'Expand' }))
+
+    expect(screen.getByTestId('resume-detail-primary-grid').className).toContain('sm:grid-cols-2')
+    expect(screen.getByTestId('resume-detail-expanded-grid').className).toContain('sm:grid-cols-2')
+    expect(screen.getByTestId('resume-detail-breakdown-grid').className).toContain('grid-cols-2')
+    expect(screen.getByTestId('resume-detail-breakdown-grid').className).toContain('md:grid-cols-3')
+    expect(screen.getByTestId('resume-detail-breakdown-grid').className).toContain('xl:grid-cols-5')
   })
 })

--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -129,7 +129,10 @@ export function ResumeDetail({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogContent
+        data-testid="resume-detail-content"
+        className="max-h-[90vh] w-[calc(100vw-1.5rem)] max-w-2xl overflow-y-auto p-4 sm:w-full sm:p-6 md:max-w-3xl lg:max-w-4xl"
+      >
         <DialogHeader>
           <DialogTitle>{t('resumes.detail.title')}</DialogTitle>
           <DialogDescription className="sr-only">
@@ -138,7 +141,7 @@ export function ResumeDetail({
         </DialogHeader>
 
         <div className="grid gap-4">
-          <div className="text-sm relative">
+          <div className="relative pr-24 text-sm sm:pr-28">
             <div className="mb-2 flex flex-wrap items-center gap-2">
               {loading ? (
                 <Badge variant="outline" className="border-sky-200 bg-sky-50 text-sky-700 text-[10px]">
@@ -151,7 +154,10 @@ export function ResumeDetail({
                 </Badge>
               ) : null}
             </div>
-            <div className="grid grid-cols-2 gap-4">
+            <div
+              data-testid="resume-detail-primary-grid"
+              className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4"
+            >
               <div>
                 <p className="text-muted-foreground">{t('resumes.columns.name')}</p>
                 <p className="font-medium">{displayResume.name || '--'}</p>
@@ -164,7 +170,7 @@ export function ResumeDetail({
             <Button
               variant="ghost"
               size="sm"
-              className="absolute right-0 top-0 text-muted-foreground hover:text-foreground h-8 px-2"
+              className="absolute right-0 top-0 h-9 px-2 text-muted-foreground hover:text-foreground"
               onClick={() => setIsInfoExpanded(!isInfoExpanded)}
             >
               {isInfoExpanded ? t('common.collapse', 'Collapse') : t('common.expand', 'Expand')}
@@ -173,7 +179,10 @@ export function ResumeDetail({
           </div>
 
           {isInfoExpanded && (
-            <div className="grid grid-cols-2 gap-4 text-sm pt-2 border-t">
+            <div
+              data-testid="resume-detail-expanded-grid"
+              className="grid grid-cols-1 gap-3 border-t pt-2 text-sm sm:grid-cols-2 sm:gap-4"
+            >
               <div>
                 <p className="text-muted-foreground">{t('resumes.columns.experience')}</p>
                 <p className="font-medium">{displayResume.experience || '--'}</p>
@@ -310,7 +319,7 @@ export function ResumeDetail({
                 <p className="text-sm text-foreground">{matchResult.summary}</p>
               </div>
 
-              <div className={`grid gap-4 mb-3 ${matchResult.highlights?.length && matchResult.concerns?.length ? 'grid-cols-2' : 'grid-cols-1'}`}>
+              <div className={`mb-3 grid gap-4 ${matchResult.highlights?.length && matchResult.concerns?.length ? 'grid-cols-1 lg:grid-cols-2' : 'grid-cols-1'}`}>
                 {matchResult.highlights && matchResult.highlights.length > 0 && (
                   <div>
                     <h4 className="text-xs font-semibold text-green-600 mb-1">Highlights</h4>
@@ -332,7 +341,10 @@ export function ResumeDetail({
               {matchResult.breakdown && (
                 <div className="bg-background rounded p-2 border">
                   <h4 className="text-xs font-semibold mb-2">Detailed Breakdown</h4>
-                  <div className="grid grid-cols-5 gap-2 text-center">
+                  <div
+                    data-testid="resume-detail-breakdown-grid"
+                    className="grid grid-cols-2 gap-2 text-center md:grid-cols-3 xl:grid-cols-5"
+                  >
                     {Object.entries(matchResult.breakdown).map(([k, v]) => (
                       <div key={k} className="flex flex-col">
                         <span className="text-[10px] text-muted-foreground uppercase truncate" title={k}>{k.replace('_', ' ')}</span>
@@ -343,8 +355,8 @@ export function ResumeDetail({
                 </div>
               )}
               {onAiFeedback ? (
-                <div className="mt-3 flex items-center justify-end border-t border-slate-200 dark:border-slate-800 pt-3">
-                  <span className="text-xs text-muted-foreground mr-3">Summary Feedback</span>
+                <div className="mt-3 flex flex-col gap-2 border-t border-slate-200 pt-3 dark:border-slate-800 sm:flex-row sm:items-center sm:justify-end">
+                  <span className="text-xs text-muted-foreground sm:mr-3">Summary Feedback</span>
                   <AiFeedbackButtons
                     feedback={aiSummaryFeedback}
                     label="AI summary"
@@ -357,10 +369,10 @@ export function ResumeDetail({
           )}
         </div>
 
-        <DialogFooter className="gap-2">
+        <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-end">
           {hasProfileUrl ? (
             <a
-              className={buttonVariants()}
+              className={buttonVariants({ className: 'w-full sm:w-auto' })}
               href={profileUrl}
               target="_blank"
               rel="noreferrer"
@@ -368,7 +380,7 @@ export function ResumeDetail({
               {t('resumes.detail.profileLink')}
             </a>
           ) : null}
-          <Button variant="secondary" onClick={() => onOpenChange(false)}>
+          <Button variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
             {t('resumes.detail.close')}
           </Button>
         </DialogFooter>

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -254,14 +254,14 @@ export function ResumeList() {
         }}
         onApplyQuickFilters={handleQuickConstraintApply}
         extraActions={
-          <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
             <div className="flex flex-wrap items-center gap-2">
               <div className="flex flex-wrap items-center gap-2 rounded-full border border-border/70 bg-background/90 p-1">
                 <Button
                   type="button"
                   variant="ghost"
                   size="sm"
-                  className="gap-2 rounded-full"
+                  className="h-10 gap-2 rounded-full px-3"
                   onMouseEnter={() => {
                     void loadSearchHistoryDialog()
                   }}
@@ -281,7 +281,7 @@ export function ResumeList() {
                   type="button"
                   variant="ghost"
                   size="sm"
-                  className="gap-2 rounded-full"
+                  className="h-10 gap-2 rounded-full px-3"
                   onClick={() => {
                     void handleSaveCurrentSearch()
                   }}
@@ -305,7 +305,7 @@ export function ResumeList() {
                 type="button"
                 variant="outline"
                 size="sm"
-                className="gap-2"
+                className="h-10 gap-2 px-3"
                 onMouseEnter={() => {
                   void loadManualResumeImportDialog()
                 }}
@@ -328,7 +328,7 @@ export function ResumeList() {
                   onClick={handleAnalyzeAll}
                   disabled={disableAnalyzeButton}
                   size="sm"
-                  className="gap-2"
+                  className="h-10 gap-2 px-4"
                 >
                   {analyzing || hasActiveTask ? (
                     <>
@@ -356,13 +356,13 @@ export function ResumeList() {
         className=""
         defaultCollapsed={true}
         headerAction={
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <ShareLinkButton
               shareTitle={shareTitle}
               state={shareState}
               ensureApiSession={ensureApiSession}
             />
-            <Button size="sm" variant="ghost" className="h-8 w-8 p-0" onClick={handleRefresh} disabled={activeLoading}>
+            <Button size="sm" variant="ghost" className="h-10 w-10 p-0" onClick={handleRefresh} disabled={activeLoading}>
               <RefreshCw className={cn('h-3.5 w-3.5', activeLoading && 'animate-spin')} />
             </Button>
           </div>

--- a/apps/web/src/components/ShareLinkButton.tsx
+++ b/apps/web/src/components/ShareLinkButton.tsx
@@ -113,7 +113,7 @@ export function ShareLinkButton({ shareTitle, state, ensureApiSession }: ShareLi
     <Button
       size="sm"
       variant="ghost"
-      className="h-8 gap-1.5 px-2"
+      className="h-10 gap-1.5 px-3"
       onClick={() => {
         void handleCopy()
       }}


### PR DESCRIPTION
## Summary
- make the resume quick-start shell and filter/header actions more touch-friendly on tablet widths
- widen the resume detail dialog and make its grids step up later for portrait and landscape tablet layouts
- extend focused component tests to cover the new responsive hooks and sizing classes

## Testing
- bun run --filter '@trends/web' test -- src/components/FilterPanel.test.tsx src/components/ResumeDetail.test.tsx src/components/QuickStartPanel.test.tsx
- npm --workspace @trends/web run typecheck
- make check