### PR TITLE
feat(web): add resume search assistant drawer

### DIFF
--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { QuickStartPanel } from './QuickStartPanel'
+import type { SearchHistoryItem } from '@/hooks/useSession'
 
 const { getMock, postMock } = vi.hoisted(() => ({
   getMock: vi.fn(),
@@ -257,6 +258,46 @@ describe('QuickStartPanel quick-filter display', () => {
     expect(searchGrid.className).toContain('xl:grid-cols-[minmax(0,1.45fr)_minmax(180px,0.7fr)_minmax(220px,0.85fr)]')
     expect(jobDescriptionCard.className).toContain('lg:col-span-2')
     expect(jobDescriptionCard.className).toContain('xl:col-span-1')
+  })
+
+  it('opens the assistant drawer and surfaces recent saved searches', async () => {
+    const user = userEvent.setup()
+    const onAssistantOpen = vi.fn()
+
+    render(
+      <QuickStartPanel
+        defaultLocation="广东"
+        defaultKeywords={['CNC']}
+        jobDescriptionId=""
+        onAssistantOpen={onAssistantOpen}
+        assistantHistory={[
+          {
+            id: 'history-1' as SearchHistoryItem['id'],
+            sessionKey: 'session-1',
+            title: '广东 · CNC',
+            location: '广东',
+            keywords: ['CNC'],
+            filters: {},
+            selectedTags: ['STAR'],
+            selectedCompanies: [],
+            createdAt: Date.UTC(2026, 2, 26, 10, 0, 0),
+            lastOpenedAt: Date.UTC(2026, 2, 26, 11, 0, 0),
+          },
+        ]}
+        onApplyAssistantHistory={vi.fn(async () => {})}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Assistant' })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Assistant' }))
+
+    expect(onAssistantOpen).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('search-assistant-drawer')).toBeInTheDocument()
+    expect(screen.getByText('广东 · CNC')).toBeInTheDocument()
+    expect(screen.getByText('Workflow starts')).toBeInTheDocument()
   })
 
   it('does not auto-apply min years when no JD is selected', async () => {

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -1,16 +1,18 @@
 import { formatKeywordInput, normalizeKeywordPhrases, parseKeywordQuery } from '@trends/shared'
 import { useCallback, useEffect, useMemo, useRef, useState, type ComponentProps } from 'react'
-import { Pencil, RotateCcw } from 'lucide-react'
+import { MessageSquareMore, Pencil, RotateCcw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from 'convex/react'
 import { JobDescriptionSelect } from './JobDescriptionSelect'
 import { JobDescriptionEditor } from './JobDescriptionEditor'
 import { KeywordChips } from './KeywordChips'
 import { SearchProfileEditorDialog, type SearchProfileDetails, type SearchProfileFilters } from './SearchProfileEditorDialog'
+import { SearchAssistantDrawer } from './SearchAssistantDrawer'
 import { rawApiClient } from '@/lib/api-helpers'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
+import type { SearchHistoryItem } from '@/hooks/useSession'
 import type { ResumeFilters } from '@/types/resume'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import {
@@ -90,6 +92,10 @@ interface QuickStartPanelProps {
     roleFilterType?: string
     maxAge?: number
   }) => void
+  assistantHistory?: SearchHistoryItem[]
+  assistantHistoryLoading?: boolean
+  onApplyAssistantHistory?: (item: SearchHistoryItem) => void | Promise<void>
+  onAssistantOpen?: () => void
   extraActions?: React.ReactNode
   onResetAll?: () => void
 }
@@ -290,6 +296,10 @@ export function QuickStartPanel({
   onJobChange,
   quickFilters,
   onApplyQuickFilters,
+  assistantHistory = [],
+  assistantHistoryLoading = false,
+  onApplyAssistantHistory,
+  onAssistantOpen,
   extraActions,
   onResetAll,
 }: QuickStartPanelProps) {
@@ -312,6 +322,7 @@ export function QuickStartPanel({
   const [matching, setMatching] = useState(false)
   const [showJdEditor, setShowJdEditor] = useState(false)
   const [showProfileEditor, setShowProfileEditor] = useState(false)
+  const [assistantOpen, setAssistantOpen] = useState(false)
   const [workflowSeeds, setWorkflowSeeds] = useState<QuickStartWorkflow[]>([])
   const lastJobDescriptionIdRef = useRef(jobDescriptionId.trim())
 
@@ -885,18 +896,33 @@ export function QuickStartPanel({
                     )}
                   </p>
                 </div>
-                {onResetAll ? (
+                <div className="flex flex-wrap items-center gap-2 self-start lg:self-auto">
                   <Button
                     type="button"
-                    variant="ghost"
+                    variant="outline"
                     size="sm"
-                    className="h-10 gap-1.5 self-start rounded-lg px-3 text-sm font-medium text-foreground/80 hover:bg-background hover:text-foreground lg:self-auto"
-                    onClick={onResetAll}
+                    className="h-10 gap-1.5 rounded-lg px-3 text-sm"
+                    onClick={() => {
+                      onAssistantOpen?.()
+                      setAssistantOpen(true)
+                    }}
                   >
-                    <RotateCcw className="h-4 w-4" />
-                    {t('quickStart.resetKeywords', '重置')}
+                    <MessageSquareMore className="h-4 w-4" />
+                    {t('quickStart.assistant.button', 'Assistant')}
                   </Button>
-                ) : null}
+                  {onResetAll ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-10 gap-1.5 rounded-lg px-3 text-sm font-medium text-foreground/80 hover:bg-background hover:text-foreground"
+                      onClick={onResetAll}
+                    >
+                      <RotateCcw className="h-4 w-4" />
+                      {t('quickStart.resetKeywords', '重置')}
+                    </Button>
+                  ) : null}
+                </div>
               </div>
             </div>
 
@@ -1131,6 +1157,39 @@ export function QuickStartPanel({
           onSaved={handleProfileEditorSaved}
         />
       )}
+
+      <SearchAssistantDrawer
+        open={assistantOpen}
+        onOpenChange={setAssistantOpen}
+        location={location}
+        keywords={normalizedKeywords}
+        jobDescriptionId={jobDescriptionId}
+        workflows={workflowSeeds.map((workflow) => ({
+          id: workflow.id,
+          label: workflow.label,
+          location: workflow.location,
+          keywords: normalizeKeywordPhrases(workflow.keywords),
+        }))}
+        onApplyWorkflow={(workflow) => {
+          const nextWorkflow = workflowSeeds.find((item) => item.id === workflow.id)
+          if (!nextWorkflow) {
+            return
+          }
+          handleApplyWorkflow(nextWorkflow)
+        }}
+        matching={matching}
+        matchedProfile={autoMatchResult ? {
+          name: autoMatchResult.profile.name,
+          confidence: autoMatchResult.confidence,
+          jobDescriptionId: autoMatchResult.profile.jobDescription,
+          matchedKeywords: autoMatchResult.matchedKeywords,
+          filterSummary: getFilterSummary(autoMatchResult.profile, yearsLabel, ageUnit),
+        } : null}
+        onUseMatchedProfile={handleUseMatchedConfig}
+        historyItems={assistantHistory}
+        historyLoading={assistantHistoryLoading}
+        onApplyHistoryItem={onApplyAssistantHistory}
+      />
     </div>
   )
 }

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -253,6 +253,12 @@ export function ResumeList() {
           maxAge: filters.maxAge,
         }}
         onApplyQuickFilters={handleQuickConstraintApply}
+        assistantHistory={searchHistory}
+        assistantHistoryLoading={historyRequested && searchHistoryLoading}
+        onApplyAssistantHistory={handleApplySearchHistory}
+        onAssistantOpen={() => {
+          setHistoryRequested(true)
+        }}
         extraActions={
           <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
             <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/components/SearchAssistantDrawer.test.tsx
+++ b/apps/web/src/components/SearchAssistantDrawer.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { SearchAssistantDrawer } from './SearchAssistantDrawer'
+import type { SearchHistoryItem } from '@/hooks/useSession'
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children, className, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div className={className} {...props}>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children, className }: React.HTMLAttributes<HTMLDivElement>) => <div className={className}>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+function buildItem(overrides: Partial<SearchHistoryItem> = {}): SearchHistoryItem {
+  return {
+    id: 'history-1' as SearchHistoryItem['id'],
+    sessionKey: 'session-1',
+    title: '东莞 · CNC 销售',
+    location: '东莞',
+    keywords: ['CNC', '销售'],
+    jobDescriptionId: 'lathe-sales',
+    filters: {},
+    selectedTags: ['STAR'],
+    selectedCompanies: [],
+    selectedExperienceLevel: 'mid',
+    createdAt: Date.UTC(2026, 2, 26, 10, 0, 0),
+    lastOpenedAt: Date.UTC(2026, 2, 26, 11, 0, 0),
+    ...overrides,
+  }
+}
+
+describe('SearchAssistantDrawer', () => {
+  it('renders the current draft and applies a workflow suggestion', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const onApplyWorkflow = vi.fn()
+
+    render(
+      <SearchAssistantDrawer
+        open
+        onOpenChange={onOpenChange}
+        location="Dongguan"
+        keywords={['CNC', 'Sales']}
+        jobDescriptionId="lathe-sales"
+        workflows={[
+          {
+            id: 'workflow-1',
+            label: 'Dongguan CNC Sales',
+            location: 'Dongguan',
+            keywords: ['CNC', 'Sales'],
+          },
+        ]}
+        onApplyWorkflow={onApplyWorkflow}
+      />
+    )
+
+    expect(screen.getByTestId('search-assistant-drawer').className).toContain('right-0')
+    expect(screen.getAllByText('Dongguan').length).toBeGreaterThan(0)
+    expect(screen.getByText('lathe-sales')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Use workflow' }))
+
+    expect(onApplyWorkflow).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'workflow-1',
+      label: 'Dongguan CNC Sales',
+    }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('applies matched profiles and recent history through explicit actions', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const onUseMatchedProfile = vi.fn()
+    const onApplyHistoryItem = vi.fn(async () => {})
+
+    render(
+      <SearchAssistantDrawer
+        open
+        onOpenChange={onOpenChange}
+        workflows={[]}
+        onApplyWorkflow={vi.fn()}
+        matchedProfile={{
+          name: 'SEEK Malaysia CNC Sales',
+          confidence: 0.91,
+          jobDescriptionId: 'seek-malaysia-sales',
+          matchedKeywords: ['cnc', 'sales'],
+          filterSummary: '2+ yrs | Age <=45',
+        }}
+        onUseMatchedProfile={onUseMatchedProfile}
+        historyItems={[buildItem()]}
+        onApplyHistoryItem={onApplyHistoryItem}
+      />
+    )
+
+    expect(screen.getByText('SEEK Malaysia CNC Sales')).toBeInTheDocument()
+    expect(screen.getByText('2+ yrs | Age <=45')).toBeInTheDocument()
+    expect(screen.getByText('东莞 · CNC 销售')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Use matched profile' }))
+    expect(onUseMatchedProfile).toHaveBeenCalledTimes(1)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+
+    await user.click(screen.getByRole('button', { name: 'Open search' }))
+    expect(onApplyHistoryItem).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'history-1',
+      title: '东莞 · CNC 销售',
+    }))
+  })
+})

--- a/apps/web/src/components/SearchAssistantDrawer.tsx
+++ b/apps/web/src/components/SearchAssistantDrawer.tsx
@@ -1,0 +1,307 @@
+import { History, Loader2, MapPin, MessageSquareMore, Sparkles, Tags, Wand2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { SearchHistoryItem } from '@/hooks/useSession'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { formatInAppTimezone } from '@/lib/timezone'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+export type SearchAssistantWorkflow = {
+  id: string
+  label: string
+  location: string
+  keywords: string[]
+}
+
+export type SearchAssistantMatchedProfile = {
+  name: string
+  confidence: number
+  jobDescriptionId?: string
+  matchedKeywords: string[]
+  filterSummary?: string
+}
+
+type SearchAssistantDrawerProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  location?: string
+  keywords?: string[]
+  jobDescriptionId?: string
+  workflows: SearchAssistantWorkflow[]
+  onApplyWorkflow: (workflow: SearchAssistantWorkflow) => void
+  matching?: boolean
+  matchedProfile?: SearchAssistantMatchedProfile | null
+  onUseMatchedProfile?: () => void
+  historyItems?: SearchHistoryItem[]
+  historyLoading?: boolean
+  onApplyHistoryItem?: (item: SearchHistoryItem) => void | Promise<void>
+}
+
+function formatTimestamp(value: number | undefined): string {
+  if (!value) {
+    return '—'
+  }
+
+  return formatInAppTimezone(value, { includeDate: true })
+}
+
+export function SearchAssistantDrawer({
+  open,
+  onOpenChange,
+  location = '',
+  keywords = [],
+  jobDescriptionId,
+  workflows,
+  onApplyWorkflow,
+  matching = false,
+  matchedProfile,
+  onUseMatchedProfile,
+  historyItems = [],
+  historyLoading = false,
+  onApplyHistoryItem,
+}: SearchAssistantDrawerProps) {
+  const { t } = useTranslation()
+  const hasDraftSummary = Boolean(location.trim() || keywords.length > 0 || jobDescriptionId?.trim())
+  const recentHistory = historyItems.slice(0, 3)
+
+  const handleApplyWorkflow = (workflow: SearchAssistantWorkflow) => {
+    onApplyWorkflow(workflow)
+    onOpenChange(false)
+  }
+
+  const handleApplyHistory = async (item: SearchHistoryItem) => {
+    if (!onApplyHistoryItem) {
+      return
+    }
+
+    await onApplyHistoryItem(item)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        data-testid="search-assistant-drawer"
+        className="left-auto right-0 top-0 h-screen max-h-screen w-full max-w-md translate-x-0 translate-y-0 gap-0 overflow-y-auto rounded-none border-l border-border/70 bg-background p-0 sm:max-w-lg sm:rounded-none"
+      >
+        <DialogHeader className="border-b border-border/70 px-4 py-4 text-left sm:px-5">
+          <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+            <MessageSquareMore className="h-4 w-4" />
+            {t('quickStart.assistant.eyebrow', 'Search assistant')}
+          </div>
+          <DialogTitle className="text-left text-lg">
+            {t('quickStart.assistant.title', 'Use suggestions, keep the search shell canonical')}
+          </DialogTitle>
+          <DialogDescription className="text-left">
+            {t(
+              'quickStart.assistant.description',
+              'This drawer only proposes search state. Every accepted suggestion writes back into the same shareable shell.'
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 p-4 sm:p-5">
+          <section className="rounded-2xl border border-border/70 bg-muted/20 p-4">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <Sparkles className="h-4 w-4 text-amber-600" />
+              {t('quickStart.assistant.currentDraft', 'Current draft')}
+            </div>
+            {hasDraftSummary ? (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {location.trim() ? (
+                  <Badge variant="outline" className="h-6 px-2 text-xs font-normal">
+                    <MapPin className="mr-1 h-3 w-3" />
+                    {location}
+                  </Badge>
+                ) : null}
+                {keywords.map((keyword) => (
+                  <Badge key={`draft-${keyword}`} variant="secondary" className="h-6 px-2 text-xs font-normal">
+                    {keyword}
+                  </Badge>
+                ))}
+                {jobDescriptionId?.trim() ? (
+                  <Badge variant="outline" className="h-6 px-2 text-xs font-normal">
+                    {jobDescriptionId}
+                  </Badge>
+                ) : null}
+              </div>
+            ) : (
+              <p className="mt-3 text-sm text-muted-foreground">
+                {t('quickStart.assistant.currentDraftEmpty', 'Start with a workflow, matched profile, or recent search to reduce typing.')}
+              </p>
+            )}
+          </section>
+
+          <section className="rounded-2xl border border-border/70 bg-background p-4">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <Wand2 className="h-4 w-4 text-sky-600" />
+              {t('quickStart.assistant.bestNextMove', 'Best next move')}
+            </div>
+
+            {matching ? (
+              <div className="mt-3 flex items-center gap-2 rounded-xl border border-dashed border-border/70 px-3 py-3 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t('quickStart.assistant.matching', 'Matching a profile for the current keywords...')}
+              </div>
+            ) : matchedProfile ? (
+              <div className="mt-3 rounded-xl border border-primary/25 bg-primary/5 p-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium text-foreground">{matchedProfile.name}</span>
+                  <Badge variant="outline" className="border-primary/30 text-primary">
+                    {Math.round(matchedProfile.confidence * 100)}%
+                  </Badge>
+                  {matchedProfile.jobDescriptionId ? (
+                    <Badge variant="outline" className="font-normal">
+                      {matchedProfile.jobDescriptionId}
+                    </Badge>
+                  ) : null}
+                </div>
+                {matchedProfile.matchedKeywords.length > 0 ? (
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {matchedProfile.matchedKeywords.map((keyword) => (
+                      <Badge key={`matched-${keyword}`} variant="secondary" className="h-5 px-1.5 text-[10px] font-normal">
+                        {keyword}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
+                {matchedProfile.filterSummary ? (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {matchedProfile.filterSummary}
+                  </p>
+                ) : null}
+                <Button
+                  type="button"
+                  size="sm"
+                  className="mt-3 h-10 px-4"
+                  disabled={!onUseMatchedProfile}
+                  onClick={() => {
+                    onUseMatchedProfile?.()
+                    onOpenChange(false)
+                  }}
+                >
+                  {t('quickStart.assistant.useMatched', 'Use matched profile')}
+                </Button>
+              </div>
+            ) : (
+              <p className="mt-3 text-sm text-muted-foreground">
+                {t('quickStart.assistant.noMatch', 'No matched profile yet. Try a workflow or add keywords in the main shell first.')}
+              </p>
+            )}
+          </section>
+
+          <section className="rounded-2xl border border-border/70 bg-background p-4">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <Sparkles className="h-4 w-4 text-emerald-600" />
+              {t('quickStart.assistant.workflowStarts', 'Workflow starts')}
+            </div>
+            {workflows.length > 0 ? (
+              <div className="mt-3 space-y-3">
+                {workflows.map((workflow) => (
+                  <div key={workflow.id} className="rounded-xl border border-border/70 bg-muted/20 p-3">
+                    <div className="text-sm font-medium text-foreground">{workflow.label}</div>
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {workflow.location ? (
+                        <Badge variant="outline" className="h-5 px-1.5 text-[10px] font-normal">
+                          <MapPin className="mr-1 h-3 w-3" />
+                          {workflow.location}
+                        </Badge>
+                      ) : null}
+                      {workflow.keywords.slice(0, 4).map((keyword) => (
+                        <Badge key={`${workflow.id}-${keyword}`} variant="secondary" className="h-5 px-1.5 text-[10px] font-normal">
+                          {keyword}
+                        </Badge>
+                      ))}
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="mt-3 h-10 px-4"
+                      onClick={() => handleApplyWorkflow(workflow)}
+                    >
+                      {t('quickStart.assistant.useWorkflow', 'Use workflow')}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-3 text-sm text-muted-foreground">
+                {t('quickStart.assistant.noWorkflow', 'No workflow suggestions are available for this workspace yet.')}
+              </p>
+            )}
+          </section>
+
+          <section className="rounded-2xl border border-border/70 bg-background p-4">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <History className="h-4 w-4 text-violet-600" />
+              {t('quickStart.assistant.recentHistory', 'Recent history')}
+            </div>
+
+            {historyLoading ? (
+              <div className="mt-3 flex items-center gap-2 rounded-xl border border-dashed border-border/70 px-3 py-3 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t('quickStart.assistant.historyLoading', 'Loading recent saved searches...')}
+              </div>
+            ) : recentHistory.length > 0 ? (
+              <div className="mt-3 space-y-3">
+                {recentHistory.map((item) => (
+                  <div key={item.id} className="rounded-xl border border-border/70 bg-muted/20 p-3">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="min-w-0 flex-1 space-y-2">
+                        <div className="text-sm font-medium text-foreground">{item.title}</div>
+                        <div className="flex flex-wrap gap-1.5">
+                          {item.location ? (
+                            <Badge variant="outline" className="h-5 px-1.5 text-[10px] font-normal">
+                              <MapPin className="mr-1 h-3 w-3" />
+                              {item.location}
+                            </Badge>
+                          ) : null}
+                          {item.keywords.slice(0, 4).map((keyword) => (
+                            <Badge key={`${item.id}-${keyword}`} variant="secondary" className="h-5 px-1.5 text-[10px] font-normal">
+                              {keyword}
+                            </Badge>
+                          ))}
+                          {item.selectedTags.slice(0, 2).map((tag) => (
+                            <Badge key={`${item.id}-tag-${tag}`} variant="outline" className="h-5 px-1.5 text-[10px] font-normal">
+                              <Tags className="mr-1 h-3 w-3" />
+                              {tag}
+                            </Badge>
+                          ))}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {t('quickStart.assistant.lastOpened', 'Last opened')}: {formatTimestamp(item.lastOpenedAt)}
+                        </div>
+                      </div>
+                      <Button
+                        type="button"
+                        size="sm"
+                        className="h-10 px-4"
+                        disabled={!onApplyHistoryItem}
+                        onClick={() => {
+                          void handleApplyHistory(item)
+                        }}
+                      >
+                        {t('quickStart.assistant.openHistory', 'Open search')}
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-3 text-sm text-muted-foreground">
+                {t('quickStart.assistant.noHistory', 'No saved searches yet. Save one from the shell to make it reusable here.')}
+              </p>
+            )}
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- add a secondary assistant drawer for /resumes that suggests workflow starts, matched profiles, and recent saved searches
- keep the search shell canonical by routing every accepted suggestion back through the existing quick-start and history apply flows
- cover the new drawer with focused component tests and rerun the existing session/list hook suites

## Testing
- bun run --filter '@trends/web' test -- src/components/SearchAssistantDrawer.test.tsx src/components/QuickStartPanel.test.tsx src/hooks/useResumeListState.test.tsx src/hooks/useSession.test.tsx
- npm --workspace @trends/web run typecheck
- make check

## Notes
- Local HTTP smoke was possible via curl against :5173, but browser MCP attachment timed out in this environment, so no interactive browser smoke was completed.
