### PR TITLE
fix(resumes): recover JD-backed searches from empty keyword results

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.test.ts
+++ b/apps/web/src/hooks/useConvexResumes.test.ts
@@ -7,15 +7,15 @@ const rawApiGetMock = vi.fn(async (path?: unknown, options?: unknown) => {
   void path
   void options
   return {
-  data: {
-    success: true,
-    summary: {
-      groups: [{ original: 'cnc', variants: ['cnc'] }],
-      mode: 'AND' as const,
-      expandedTo: ['cnc'],
-      sourceMapping: {},
+    data: {
+      success: true,
+      summary: {
+        groups: [{ original: 'cnc', variants: ['cnc'] }],
+        mode: 'AND' as const,
+        expandedTo: ['cnc'],
+        sourceMapping: {},
+      },
     },
-  },
   }
 })
 
@@ -187,6 +187,45 @@ describe('useConvexResumes', () => {
         query: 'CNC',
         keywordGroups: [{ original: 'cnc', variants: ['cnc'] }],
       })
+    })
+  })
+
+  it('falls back to the JD list query when a JD-backed keyword search returns no matches', async () => {
+    usePaginatedQueryMock.mockImplementation((_query, args) => {
+      if (args === 'skip') {
+        return {
+          results: [],
+          status: 'Exhausted',
+          isLoading: false,
+          loadMore: loadMoreMock,
+        }
+      }
+
+      if ('query' in (args as Record<string, unknown>)) {
+        return {
+          results: [],
+          status: 'Exhausted',
+          isLoading: false,
+          loadMore: loadMoreMock,
+        }
+      }
+
+      return {
+        results: [buildResumeDoc('resume-fallback', 'Fallback Candidate')],
+        status: 'Exhausted',
+        isLoading: false,
+        loadMore: loadMoreMock,
+      }
+    })
+
+    const { result } = renderHook(() => useConvexResumes(200, 'CNC', 'lathe-sales'))
+
+    await waitFor(() => {
+      expect(rawApiGetMock).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(result.current.resumes.map((resume) => resume.name)).toEqual(['Fallback Candidate'])
     })
   })
 })

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -844,7 +844,7 @@ export function useConvexResumes(
     api.resumes.listWithIngestDataPaginated,
     mockPayload
       ? 'skip'
-      : normalizedQuery
+      : normalizedQuery && !normalizedJobDescriptionId
         ? 'skip'
         : {
             jobDescriptionId: normalizedJobDescriptionId,
@@ -859,9 +859,23 @@ export function useConvexResumes(
     }
   )
 
-  const activePaginatedStatus = normalizedQuery ? paginatedSearchResults.status : paginatedListResults.status
-  const activePaginatedResultsLength = normalizedQuery ? paginatedSearchResults.results.length : paginatedListResults.results.length
-  const activePaginatedLoadMore = normalizedQuery ? paginatedSearchResults.loadMore : paginatedListResults.loadMore
+  const useJobDescriptionFallback = Boolean(
+    normalizedQuery
+      && normalizedJobDescriptionId
+      && !expansionLoading
+      && paginatedSearchResults.status === 'Exhausted'
+      && paginatedSearchResults.results.length === 0
+  )
+
+  const activePaginatedStatus = normalizedQuery
+    ? (useJobDescriptionFallback ? paginatedListResults.status : paginatedSearchResults.status)
+    : paginatedListResults.status
+  const activePaginatedResultsLength = normalizedQuery
+    ? (useJobDescriptionFallback ? paginatedListResults.results.length : paginatedSearchResults.results.length)
+    : paginatedListResults.results.length
+  const activePaginatedLoadMore = normalizedQuery
+    ? (useJobDescriptionFallback ? paginatedListResults.loadMore : paginatedSearchResults.loadMore)
+    : paginatedListResults.loadMore
 
   useEffect(() => {
     if (mockPayload || limit <= 0) {
@@ -901,17 +915,19 @@ export function useConvexResumes(
           })))
         : (mockPayload.list ?? []).slice(0, limit).map(mapResumeDoc)
       : normalizedQuery
-        ? visibleSearchResults.map((entry) => ({
-            ...mapResumeDoc(entry.resume),
-            _provenance: entry.provenance,
-          }))
+        ? useJobDescriptionFallback
+          ? visibleListResults.map(mapResumeDoc)
+          : visibleSearchResults.map((entry) => ({
+              ...mapResumeDoc(entry.resume),
+              _provenance: entry.provenance,
+            }))
         : visibleListResults.map(mapResumeDoc)
-  ), [limit, mockKeywordExpansion, mockPayload, normalizedQuery, visibleListResults, visibleSearchResults])
+  ), [limit, mockKeywordExpansion, mockPayload, normalizedQuery, useJobDescriptionFallback, visibleListResults, visibleSearchResults])
 
   const isLoading = mockPayload
     ? false
     : normalizedQuery
-      ? (expansionLoading || paginatedSearchResults.status === 'LoadingFirstPage')
+      ? (expansionLoading || activePaginatedStatus === 'LoadingFirstPage')
       : paginatedListResults.status === 'LoadingFirstPage'
 
   const hasMore = useMemo(() => {

--- a/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
+++ b/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
@@ -30,7 +30,7 @@ const handler = (
   listWithIngestDataPaginated as unknown as ConvexHandler<PaginatedArgs, PaginatedResult>
 )._handler;
 
-function buildResumeDoc(id: string, primaryRuleScore: number) {
+function buildResumeDoc(id: string, primaryRuleScore: number, ruleScores?: Record<string, number>) {
   return {
     _id: id,
     externalId: `test:${id}`,
@@ -38,6 +38,13 @@ function buildResumeDoc(id: string, primaryRuleScore: number) {
     tags: [],
     crawledAt: Date.now(),
     content: { name: id },
+    ingestData: ruleScores ? {
+      ruleScores,
+      industryTags: [],
+      experienceLevel: "mid",
+      computedAt: 1,
+      skillsVersion: 1,
+    } : undefined,
     primaryRuleScore,
   };
 }
@@ -89,7 +96,7 @@ describe("listWithIngestDataPaginated", () => {
     expect(result.isDone).toBe(false);
   });
 
-  it("falls back to offset/overfetch path when jobDescriptionId is set", async () => {
+  it("uses native paginate() for JD-only requests to avoid large overfetch scans", async () => {
     let paginateCalled = false;
     let takeCalled = false;
 
@@ -120,9 +127,39 @@ describe("listWithIngestDataPaginated", () => {
       jobDescriptionId: "jd-1",
     });
 
-    expect(paginateCalled).toBe(false);
-    expect(takeCalled).toBe(true);
+    expect(paginateCalled).toBe(true);
+    expect(takeCalled).toBe(false);
     expect(result.page.length).toBeLessThanOrEqual(10);
+  });
+
+  it("matches canonical rule score keys when the request passes a slug jobDescriptionId", async () => {
+    const lowerPrimaryHigherJd = buildResumeDoc("resume-a", 70, { "jd-lathe-sales": 88 });
+    const higherPrimaryLowerJd = buildResumeDoc("resume-b", 95, { "jd-lathe-sales": 40 });
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => ({
+              paginate: async () => ({
+                page: [higherPrimaryLowerJd, lowerPrimaryHigherJd],
+                continueCursor: "",
+                isDone: true,
+              }),
+              take: async () => [],
+            }),
+          }),
+        }),
+      },
+    };
+
+    const result = await handler(ctx, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      jobDescriptionId: "lathe-sales",
+    });
+
+    expect((result.page[0] as { _id: string })._id).toBe("resume-a");
+    expect((result.page[1] as { _id: string })._id).toBe("resume-b");
   });
 
   it("falls back to offset/overfetch path when sortBy is set", async () => {

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -51,14 +51,32 @@ function toRuleScores(value: unknown): Record<string, number> {
     return scores;
 }
 
-function getIngestRuleScore(resume: Doc<"resumes">, jobDescriptionId: string | undefined): number {
-    if (!jobDescriptionId) {
-        return 0;
+function resolveRuleScoreLookupKeys(jobDescriptionId: string | undefined): string[] {
+    const normalized = toOptionalStringValue(jobDescriptionId);
+    if (!normalized) {
+        return [];
     }
 
-    const score = toRuleScores(resume.ingestData?.ruleScores)[jobDescriptionId];
-    if (typeof score === "number" && Number.isFinite(score)) {
-        return score;
+    const keys = new Set<string>([normalized]);
+    if (normalized.startsWith("jd-")) {
+        const legacySlug = normalized.slice(3).trim();
+        if (legacySlug) {
+            keys.add(legacySlug);
+        }
+    } else {
+        keys.add(`jd-${normalized}`);
+    }
+
+    return Array.from(keys);
+}
+
+function getIngestRuleScore(resume: Doc<"resumes">, jobDescriptionId: string | undefined): number {
+    const ruleScores = toRuleScores(resume.ingestData?.ruleScores);
+    for (const key of resolveRuleScoreLookupKeys(jobDescriptionId)) {
+        const score = ruleScores[key];
+        if (typeof score === "number" && Number.isFinite(score)) {
+            return score;
+        }
     }
     return 0;
 }
@@ -282,6 +300,7 @@ const DEFAULT_RESUME_LIMIT = 50;
 export const MAX_SAFE_LIST_WITH_INGEST_LIMIT = 2000;
 export const MAX_SAFE_LIST_WITH_INGEST_OVERFETCH = 4000;
 const FILTERED_PAGINATE_OVERFETCH_MULTIPLIER = 3;
+const MAX_SAFE_JD_PAGINATE_SCAN = 250;
 const MAX_INGEST_DIAGNOSTICS_PAGE_SIZE = 100;
 const MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES = 8;
 const DEFAULT_RESUME_SCAN_BATCH_SIZE = 25;
@@ -1375,11 +1394,19 @@ export const listWithIngestDataPaginated = query({
     handler: async (ctx, args) => {
         const filters = normalizeResumeListFilters(args);
         const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
-        if (!jobDescriptionId && !args.sortBy) {
+        if (!args.sortBy) {
             const requestedPageSize = resolvePaginatedResumePageLimit(args.paginationOpts.numItems);
-            const numItems = filters
-                ? Math.min(requestedPageSize * FILTERED_PAGINATE_OVERFETCH_MULTIPLIER, MAX_SAFE_LIST_WITH_INGEST_LIMIT)
-                : requestedPageSize;
+            const numItems = jobDescriptionId
+                ? Math.min(
+                    Math.max(
+                        requestedPageSize,
+                        filters ? Math.ceil(requestedPageSize * 1.5) : requestedPageSize
+                    ),
+                    MAX_SAFE_JD_PAGINATE_SCAN
+                )
+                : filters
+                    ? Math.min(requestedPageSize * FILTERED_PAGINATE_OVERFETCH_MULTIPLIER, MAX_SAFE_LIST_WITH_INGEST_LIMIT)
+                    : requestedPageSize;
             const page = await ctx.db
                 .query("resumes")
                 .withIndex("by_primaryRuleScore")
@@ -1392,9 +1419,12 @@ export const listWithIngestDataPaginated = query({
             const filtered = filters
                 ? page.page.filter((resume) => matchesResumeListFilters(resume, filters))
                 : page.page;
+            const ranked = jobDescriptionId
+                ? sortByIngestRuleScore(filtered, jobDescriptionId)
+                : filtered;
 
             return {
-                page: filtered.map(projectResumeListDoc),
+                page: ranked.map(projectResumeListDoc),
                 continueCursor: page.continueCursor,
                 isDone: page.isDone,
             };


### PR DESCRIPTION
## Summary
- fall back from empty JD-backed keyword expansion results to the JD-ranked list query in the web hook
- accept both slug and canonical `jd-` rule-score keys when ranking JD-backed resume lists
- use bounded native pagination for JD-only Convex list requests so the fallback avoids the old wide overfetch byte-limit failure

## Validation
- bun run --filter @trends/web test -- src/hooks/useConvexResumes.test.ts
- npx vitest run packages/convex/convex/__tests__/resumes-paginated-default.test.ts
- make check
- manual `/dev/resumes?jd=lathe-sales` smoke on local dev stack