### PR TITLE
feat(web): add resume search continue cards

### DIFF
--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -296,8 +296,65 @@ describe('QuickStartPanel quick-filter display', () => {
 
     expect(onAssistantOpen).toHaveBeenCalledTimes(1)
     expect(screen.getByTestId('search-assistant-drawer')).toBeInTheDocument()
-    expect(screen.getByText('广东 · CNC')).toBeInTheDocument()
+    expect(screen.getAllByText('广东 · CNC').length).toBeGreaterThan(0)
     expect(screen.getByText('Workflow starts')).toBeInTheDocument()
+  })
+
+  it('requests history on mount so recent searches can become one-tap shortcuts', () => {
+    const onRequestHistory = vi.fn()
+
+    render(
+      <QuickStartPanel
+        defaultLocation="广东"
+        defaultKeywords={['CNC']}
+        jobDescriptionId=""
+        onRequestHistory={onRequestHistory}
+      />
+    )
+
+    expect(onRequestHistory).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes recent searches as one-tap continue cards', async () => {
+    const user = userEvent.setup()
+    const onApplyAssistantHistory = vi.fn(async () => {})
+
+    render(
+      <QuickStartPanel
+        defaultLocation="广东"
+        defaultKeywords={['CNC']}
+        jobDescriptionId=""
+        assistantHistory={[
+          {
+            id: 'history-2' as SearchHistoryItem['id'],
+            sessionKey: 'session-2',
+            title: 'Kuala Lumpur MY · CNC Sales',
+            location: 'Kuala Lumpur MY',
+            keywords: ['CNC', 'Sales'],
+            jobDescriptionId: 'seek-malaysia-sales',
+            filters: {},
+            selectedTags: [],
+            selectedCompanies: [],
+            notes: 'Resume shortlist for Malaysia flow',
+            createdAt: Date.UTC(2026, 2, 26, 12, 0, 0),
+            lastOpenedAt: Date.UTC(2026, 2, 26, 13, 0, 0),
+          },
+        ]}
+        onApplyAssistantHistory={onApplyAssistantHistory}
+      />
+    )
+
+    expect(screen.getByTestId('quickstart-recent-history')).toBeInTheDocument()
+    expect(screen.getByText('Kuala Lumpur MY · CNC Sales')).toBeInTheDocument()
+    expect(screen.getByText('Resume shortlist for Malaysia flow')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Kuala Lumpur MY · CNC Sales/i }))
+
+    expect(onApplyAssistantHistory).toHaveBeenCalledTimes(1)
+    expect(onApplyAssistantHistory).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Kuala Lumpur MY · CNC Sales',
+      jobDescriptionId: 'seek-malaysia-sales',
+    }))
   })
 
   it('does not auto-apply min years when no JD is selected', async () => {

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -96,6 +96,7 @@ interface QuickStartPanelProps {
   assistantHistoryLoading?: boolean
   onApplyAssistantHistory?: (item: SearchHistoryItem) => void | Promise<void>
   onAssistantOpen?: () => void
+  onRequestHistory?: () => void
   extraActions?: React.ReactNode
   onResetAll?: () => void
 }
@@ -300,6 +301,7 @@ export function QuickStartPanel({
   assistantHistoryLoading = false,
   onApplyAssistantHistory,
   onAssistantOpen,
+  onRequestHistory,
   extraActions,
   onResetAll,
 }: QuickStartPanelProps) {
@@ -325,6 +327,7 @@ export function QuickStartPanel({
   const [assistantOpen, setAssistantOpen] = useState(false)
   const [workflowSeeds, setWorkflowSeeds] = useState<QuickStartWorkflow[]>([])
   const lastJobDescriptionIdRef = useRef(jobDescriptionId.trim())
+  const hasRequestedHistoryRef = useRef(false)
 
   const convexJobDescriptions = useQuery(api.job_descriptions.list, { workspaceSlug: slug })
   const selectedConvexJobDescription = useMemo(() => {
@@ -483,6 +486,15 @@ export function QuickStartPanel({
   }, [jobDescriptionId, convexJobDescriptions, selectedConvexJobDescription, selectedConvexJobDescriptionDetail])
 
   useEffect(() => {
+    if (hasRequestedHistoryRef.current || !onRequestHistory || assistantHistoryLoading || assistantHistory.length > 0) {
+      return
+    }
+
+    hasRequestedHistoryRef.current = true
+    onRequestHistory()
+  }, [assistantHistory.length, assistantHistoryLoading, onRequestHistory])
+
+  useEffect(() => {
     let cancelled = false
 
     const loadWorkflowSeeds = async () => {
@@ -516,6 +528,12 @@ export function QuickStartPanel({
   const normalizedKeywords = useMemo(
     () => normalizeKeywordPhrases(selectedKeywords),
     [selectedKeywords]
+  )
+  const recentHistoryItems = useMemo(
+    () => [...assistantHistory]
+      .sort((left, right) => (right.lastOpenedAt ?? right.createdAt) - (left.lastOpenedAt ?? left.createdAt))
+      .slice(0, 2),
+    [assistantHistory]
   )
   const currentCollectionSource = useMemo<CollectionSource>(
     () => resolveCollectionSource(collectionSource, collectUrl) ?? { type: SEARCH_PROFILE_SOURCE_TYPES.job5156 },
@@ -1018,6 +1036,82 @@ export function QuickStartPanel({
             </Button>
           ))}
         </div>
+
+        {assistantHistoryLoading || recentHistoryItems.length > 0 ? (
+          <section
+            data-testid="quickstart-recent-history"
+            className="rounded-xl border border-border/70 bg-background/80 px-3 py-3 shadow-sm sm:px-4"
+          >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div className="space-y-1">
+                <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                  {t('quickStart.continueWork', 'Continue work')}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {t('quickStart.continueWorkDescription', 'Reuse a saved search in one tap instead of rebuilding the same shell state.')}
+                </p>
+              </div>
+              {recentHistoryItems.length > 0 ? (
+                <Badge variant="outline" className="h-6 px-2 text-[10px] font-normal">
+                  {t('quickStart.continueWorkRecentCount', '{{count}} recent', { count: recentHistoryItems.length })}
+                </Badge>
+              ) : null}
+            </div>
+
+            {assistantHistoryLoading ? (
+              <div className="mt-3 rounded-xl border border-dashed border-border/70 px-3 py-3 text-sm text-muted-foreground">
+                {t('quickStart.continueWorkLoading', 'Loading recent saved searches...')}
+              </div>
+            ) : (
+              <div className="mt-3 grid gap-2 lg:grid-cols-2">
+                {recentHistoryItems.map((item) => (
+                  <Button
+                    key={item.id}
+                    type="button"
+                    variant="outline"
+                    className="h-auto justify-start rounded-xl border-border/70 bg-muted/20 px-3 py-3 text-left"
+                    onClick={() => {
+                      void onApplyAssistantHistory?.(item)
+                    }}
+                  >
+                    <div className="flex w-full items-start justify-between gap-3">
+                      <div className="min-w-0 space-y-2">
+                        <div className="truncate text-sm font-medium text-foreground">
+                          {item.title}
+                        </div>
+                        <div className="flex flex-wrap gap-1.5">
+                          {item.location ? (
+                            <Badge variant="outline" className="h-5 px-1.5 text-[10px] font-normal">
+                              {item.location}
+                            </Badge>
+                          ) : null}
+                          {item.keywords.slice(0, 3).map((keyword) => (
+                            <Badge key={`${item.id}-${keyword}`} variant="secondary" className="h-5 px-1.5 text-[10px] font-normal">
+                              {keyword}
+                            </Badge>
+                          ))}
+                          {item.jobDescriptionId ? (
+                            <Badge variant="outline" className="h-5 px-1.5 text-[10px] font-normal">
+                              {item.jobDescriptionId}
+                            </Badge>
+                          ) : null}
+                        </div>
+                        {item.notes ? (
+                          <p className="truncate text-xs text-muted-foreground">
+                            {item.notes}
+                          </p>
+                        ) : null}
+                      </div>
+                      <span className="pt-0.5 text-xs font-medium text-primary">
+                        {t('quickStart.continueWorkAction', 'Continue')}
+                      </span>
+                    </div>
+                  </Button>
+                ))}
+              </div>
+            )}
+          </section>
+        ) : null}
 
         <KeywordChips
           value={selectedKeywords}

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -259,6 +259,9 @@ export function ResumeList() {
         onAssistantOpen={() => {
           setHistoryRequested(true)
         }}
+        onRequestHistory={() => {
+          setHistoryRequested(true)
+        }}
         extraActions={
           <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
             <div className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary
- prefetch saved-search history for the resume shell so recent work can show up without an extra open-assistant step
- add compact one-tap continue cards to `QuickStartPanel` so operators can reopen recent searches directly from the top shell
- keep the existing canonical search/session model intact while improving tablet-friendly layout for the new cards

## Validation
- bun run --filter @trends/web test -- src/components/QuickStartPanel.test.tsx
- npm --workspace @trends/web run typecheck
- make check