### PR TITLE
feat(web): surface resume search session summary

### DIFF
--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -357,6 +357,25 @@ describe('QuickStartPanel quick-filter display', () => {
     }))
   })
 
+  it('shows the current session summary when a shared or reopened search is active', () => {
+    render(
+      <QuickStartPanel
+        defaultLocation="广东"
+        defaultKeywords={['CNC']}
+        jobDescriptionId=""
+        activeSessionTitle="Kuala Lumpur · Sales Engineer"
+        activeSessionLabel="Shared link"
+        activeSessionDescription="Opened from a durable sid link and ready to refine or reshare."
+        activeSessionId="shared-session-1"
+      />
+    )
+
+    expect(screen.getByTestId('quickstart-active-session')).toBeInTheDocument()
+    expect(screen.getByText('Kuala Lumpur · Sales Engineer')).toBeInTheDocument()
+    expect(screen.getByText('Shared link')).toBeInTheDocument()
+    expect(screen.getByText('shared-ses…')).toBeInTheDocument()
+  })
+
   it('does not auto-apply min years when no JD is selected', async () => {
     const onApplyQuickFilters = vi.fn()
 

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -97,6 +97,10 @@ interface QuickStartPanelProps {
   onApplyAssistantHistory?: (item: SearchHistoryItem) => void | Promise<void>
   onAssistantOpen?: () => void
   onRequestHistory?: () => void
+  activeSessionTitle?: string
+  activeSessionLabel?: string
+  activeSessionDescription?: string
+  activeSessionId?: string
   extraActions?: React.ReactNode
   onResetAll?: () => void
 }
@@ -238,6 +242,15 @@ function parseLocationParts(value: string): string[] {
   return parts
 }
 
+function formatSessionIdPreview(value: string | undefined): string | undefined {
+  const normalized = value?.trim()
+  if (!normalized) {
+    return undefined
+  }
+
+  return normalized.length > 10 ? `${normalized.slice(0, 10)}…` : normalized
+}
+
 function normalizeProfileKeywords(profile: SearchProfileDetails): string[] {
   return normalizeKeywordPhrases(profile.keywords)
 }
@@ -302,6 +315,10 @@ export function QuickStartPanel({
   onApplyAssistantHistory,
   onAssistantOpen,
   onRequestHistory,
+  activeSessionTitle,
+  activeSessionLabel,
+  activeSessionDescription,
+  activeSessionId,
   extraActions,
   onResetAll,
 }: QuickStartPanelProps) {
@@ -534,6 +551,10 @@ export function QuickStartPanel({
       .sort((left, right) => (right.lastOpenedAt ?? right.createdAt) - (left.lastOpenedAt ?? left.createdAt))
       .slice(0, 2),
     [assistantHistory]
+  )
+  const activeSessionIdPreview = useMemo(
+    () => formatSessionIdPreview(activeSessionId),
+    [activeSessionId]
   )
   const currentCollectionSource = useMemo<CollectionSource>(
     () => resolveCollectionSource(collectionSource, collectUrl) ?? { type: SEARCH_PROFILE_SOURCE_TYPES.job5156 },
@@ -1036,6 +1057,41 @@ export function QuickStartPanel({
             </Button>
           ))}
         </div>
+
+        {activeSessionTitle ? (
+          <section
+            data-testid="quickstart-active-session"
+            className="rounded-xl border border-border/70 bg-background/80 px-3 py-3 shadow-sm sm:px-4"
+          >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0 space-y-1">
+                <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                  {t('quickStart.activeSession', 'Current session')}
+                </p>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="truncate text-sm font-medium text-foreground">
+                    {activeSessionTitle}
+                  </span>
+                  {activeSessionLabel ? (
+                    <Badge variant="outline" className="h-6 px-2 text-[10px] font-normal">
+                      {activeSessionLabel}
+                    </Badge>
+                  ) : null}
+                  {activeSessionIdPreview ? (
+                    <Badge variant="secondary" className="h-6 px-2 font-mono text-[10px] font-normal">
+                      {activeSessionIdPreview}
+                    </Badge>
+                  ) : null}
+                </div>
+                {activeSessionDescription ? (
+                  <p className="text-sm text-muted-foreground">
+                    {activeSessionDescription}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          </section>
+        ) : null}
 
         {assistantHistoryLoading || recentHistoryItems.length > 0 ? (
           <section

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -62,6 +62,10 @@ export function ResumeList() {
     hasActiveTask,
     disableAnalyzeButton,
     selectedIds,
+    activeSessionTitle,
+    activeSessionLabel,
+    activeSessionDescription,
+    activeSessionId,
     shareTitle,
     shareState,
     selectedExperienceLevel,
@@ -262,6 +266,10 @@ export function ResumeList() {
         onRequestHistory={() => {
           setHistoryRequested(true)
         }}
+        activeSessionTitle={activeSessionTitle}
+        activeSessionLabel={activeSessionLabel}
+        activeSessionDescription={activeSessionDescription}
+        activeSessionId={activeSessionId}
         extraActions={
           <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
             <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -43,6 +43,7 @@ const mockState = vi.hoisted(() => ({
   setJobDescriptionId: vi.fn(),
   setCollectionSource: vi.fn(),
   setCollectUrl: vi.fn(),
+  apiSessionId: undefined as string | undefined,
   ensureApiSession: vi.fn(async () => 'api-session-1'),
   rememberApiSessionId: vi.fn(),
   trackReviewedResume: vi.fn(),
@@ -119,6 +120,7 @@ vi.mock('@/hooks/useSession', () => ({
     setCollectionSource: mockState.setCollectionSource,
     collectUrl: mockState.sessionCollectUrl,
     setCollectUrl: mockState.setCollectUrl,
+    apiSessionId: mockState.apiSessionId,
     filters: mockState.filters,
     setFilters: mockState.setFilters,
     reviewedIdsSet: new Set<string>(),
@@ -615,6 +617,7 @@ describe('useResumeListState role filter regression', () => {
     mockState.sessionJobDescriptionId = undefined
     mockState.sessionCollectionSource = undefined
     mockState.sessionCollectUrl = ''
+    mockState.apiSessionId = undefined
     mockState.ensureApiSession.mockResolvedValue('api-session-1')
     mockState.sessionGetResponse = { data: { success: true } }
     mockState.blocksByIdentity = {}
@@ -1283,6 +1286,7 @@ describe('useResumeListState role filter regression', () => {
         success: true,
         session: {
           id: 'shared-session-1',
+          shareTitle: 'Kuala Lumpur · Sales Engineer',
           searchState: {
             location: 'Kuala Lumpur MY',
             keywords: ['Sales Engineer'],
@@ -1304,7 +1308,7 @@ describe('useResumeListState role filter regression', () => {
       },
     }
 
-    renderHook(() => useResumeListState())
+    const { result } = renderHook(() => useResumeListState())
 
     await waitFor(() => {
       expect(rawApiClient.GET).toHaveBeenCalledWith('/api/sessions/shared-session-1')
@@ -1324,6 +1328,9 @@ describe('useResumeListState role filter regression', () => {
         minAge: 28,
       },
     })
+    expect(result.current.activeSessionTitle).toBe('Kuala Lumpur · Sales Engineer')
+    expect(result.current.activeSessionLabel).toBe('Shared link')
+    expect(result.current.activeSessionId).toBe('shared-session-1')
   })
 
   it('prefers explicit URL params over sid hydration when both are present', async () => {
@@ -1338,7 +1345,7 @@ describe('useResumeListState role filter regression', () => {
       keywords: ['CNC'],
     }
 
-    renderHook(() => useResumeListState())
+    const { result } = renderHook(() => useResumeListState())
 
     await waitFor(() => {
       expect(mockState.applyExternalState).toHaveBeenCalledWith({
@@ -1352,6 +1359,35 @@ describe('useResumeListState role filter regression', () => {
     })
 
     expect(rawApiClient.GET).not.toHaveBeenCalled()
+    expect(result.current.activeSessionLabel).toBeUndefined()
+  })
+
+  it('surfaces a saved-search session summary after reopening history', async () => {
+    mockState.searchHistory = [
+      {
+        id: 'history-1',
+        sessionKey: 'session-1',
+        title: 'Saved search',
+        location: '苏州',
+        keywords: ['CNC', '销售'],
+        jobDescriptionId: 'lathe-sales',
+        filters: { minAge: 28 },
+        selectedTags: ['STAR'],
+        selectedCompanies: ['Acme'],
+        selectedExperienceLevel: 'mid',
+        createdAt: 1,
+        lastOpenedAt: 2,
+      },
+    ]
+    const { result } = renderHook(() => useResumeListState())
+
+    await act(async () => {
+      await result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
+    })
+
+    expect(result.current.activeSessionTitle).toBe('Saved search')
+    expect(result.current.activeSessionLabel).toBe('Saved search')
+    expect(result.current.activeSessionDescription).toContain('Reopened from saved history')
   })
 
   it('passes current convex resume ids when saving search history', async () => {

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -557,6 +557,7 @@ export function useResumeListState(loadSearchHistory = false) {
   const location = useLocation()
   const navigate = useNavigate()
   const {
+    apiSessionId,
     location: sessionLocation,
     setLocation: setSessionLocation,
     keywords: sessionKeywords,
@@ -615,6 +616,7 @@ export function useResumeListState(loadSearchHistory = false) {
   const [hasCompletedUrlHydration, setHasCompletedUrlHydration] = useState(false)
   const [hasCompletedShareSessionHydration, setHasCompletedShareSessionHydration] = useState(false)
   const hydratedShareSessionIdRef = useRef<string | null>(null)
+  const [hydratedShareSessionTitle, setHydratedShareSessionTitle] = useState<string | undefined>(undefined)
 
   if (!initialWindowSearchStateRef.current) {
     const params = new URLSearchParams(window.location.search)
@@ -1085,12 +1087,14 @@ export function useResumeListState(loadSearchHistory = false) {
   useEffect(() => {
     if (activeHasUrlParams) {
       hydratedShareSessionIdRef.current = null
+      setHydratedShareSessionTitle(undefined)
       setHasCompletedShareSessionHydration(true)
       return
     }
 
     if (!activeShareSessionId) {
       hydratedShareSessionIdRef.current = null
+      setHydratedShareSessionTitle(undefined)
       setHasCompletedShareSessionHydration(true)
       return
     }
@@ -1114,12 +1118,21 @@ export function useResumeListState(loadSearchHistory = false) {
         const sharedSearchState = data?.session?.searchState
         if (error || !data?.success || !sharedSearchState) {
           console.error('Failed to hydrate shared search session', error ?? data)
+          setHydratedShareSessionTitle(undefined)
           setHasCompletedShareSessionHydration(true)
           return
         }
 
         skipNextUrlSyncRef.current = true
         rememberApiSessionId(activeShareSessionId)
+        setHydratedShareSessionTitle(
+          normalizeOptionalString(data.session?.shareTitle)
+            ?? buildSearchHistoryTitle(
+              sharedSearchState.location ?? '',
+              sharedSearchState.keywords ?? [],
+              sharedSearchState.jobDescriptionId,
+            )
+        )
         applyExternalState({
           location: sharedSearchState.location,
           keywords: sharedSearchState.keywords,
@@ -1141,6 +1154,7 @@ export function useResumeListState(loadSearchHistory = false) {
         }
 
         console.error('Failed to hydrate shared search session', error)
+        setHydratedShareSessionTitle(undefined)
         setHasCompletedShareSessionHydration(true)
       })
 
@@ -2213,6 +2227,71 @@ export function useResumeListState(loadSearchHistory = false) {
     () => buildSearchHistoryTitle(sessionLocation, sessionKeywords, jobDescriptionId),
     [jobDescriptionId, sessionKeywords, sessionLocation]
   )
+  const linkedShareSessionId = !activeHasUrlParams ? activeShareSessionId : undefined
+  const hasShareableSessionContext = useMemo(
+    () => Boolean(
+      normalizeOptionalString(sessionLocation)
+      || sessionKeywords.length > 0
+      || normalizeOptionalString(jobDescriptionId)
+      || normalizeOptionalString(sessionCollectUrl)
+      || sessionCollectionSource
+    ),
+    [jobDescriptionId, sessionCollectUrl, sessionCollectionSource, sessionKeywords, sessionLocation]
+  )
+  const activeSessionId = linkedShareSessionId
+    ?? (apiSessionId && hasShareableSessionContext ? apiSessionId : undefined)
+  const activeSessionTitle = useMemo(() => {
+    if (linkedShareSessionId) {
+      return hydratedShareSessionTitle ?? shareTitle
+    }
+
+    if (appliedSearchHistory) {
+      return appliedSearchHistory.title
+    }
+
+    if (apiSessionId && hasShareableSessionContext) {
+      return shareTitle
+    }
+
+    return undefined
+  }, [
+    linkedShareSessionId,
+    apiSessionId,
+    appliedSearchHistory,
+    hasShareableSessionContext,
+    hydratedShareSessionTitle,
+    shareTitle,
+  ])
+  const activeSessionLabel = useMemo(() => {
+    if (linkedShareSessionId) {
+      return 'Shared link'
+    }
+
+    if (appliedSearchHistory) {
+      return 'Saved search'
+    }
+
+    if (apiSessionId && hasShareableSessionContext) {
+      return 'Share-ready'
+    }
+
+    return undefined
+  }, [linkedShareSessionId, apiSessionId, appliedSearchHistory, hasShareableSessionContext])
+  const activeSessionDescription = useMemo(() => {
+    if (linkedShareSessionId) {
+      return 'Opened from a durable sid link and ready to refine or reshare.'
+    }
+
+    if (appliedSearchHistory) {
+      return 'Reopened from saved history so you can continue the same search with less re-entry.'
+    }
+
+    if (apiSessionId && hasShareableSessionContext) {
+      return 'This search already has a persisted session record for short durable share links.'
+    }
+
+    return undefined
+  }, [linkedShareSessionId, apiSessionId, appliedSearchHistory, hasShareableSessionContext])
   const shareState = useMemo<ResumeSearchShareState>(() => {
     const normalizedLocation = normalizeOptionalString(sessionLocation)
     const locationFilters = normalizedLocation
@@ -2267,6 +2346,10 @@ export function useResumeListState(loadSearchHistory = false) {
     hasActiveTask,
     disableAnalyzeButton,
     selectedIds,
+    activeSessionTitle,
+    activeSessionLabel,
+    activeSessionDescription,
+    activeSessionId,
     shareTitle,
     shareState,
     selectedTags,

--- a/apps/web/src/hooks/useSession.test.tsx
+++ b/apps/web/src/hooks/useSession.test.tsx
@@ -283,6 +283,7 @@ describe('useSession', () => {
         searchState: undefined,
       },
     })
+    expect(result.current.apiSessionId).toBe('api-session-1')
     expect(localStorage.getItem(`trends.resume.apiSessionId.dev.${sessionKey}`)).toBe('api-session-1')
   })
 
@@ -390,6 +391,8 @@ describe('useSession', () => {
       result.current.rememberApiSessionId('shared-session-id')
       result.current.setFilters({ minExperience: 6 })
     })
+
+    expect(result.current.apiSessionId).toBe('shared-session-id')
 
     await act(async () => {
       await result.current.ensureApiSession()

--- a/apps/web/src/hooks/useSession.ts
+++ b/apps/web/src/hooks/useSession.ts
@@ -444,6 +444,7 @@ export function useSession(loadSearchHistory = false) {
   }, [markSearchHistoryOpenedMutation, slug])
 
   return {
+    apiSessionId,
     location,
     setLocation,
     keywords,


### PR DESCRIPTION
## Summary
- expose the active saved-search or shared-session title in the resume shell so users can see the current named context without reopening history or guessing from URL params
- thread persisted API session metadata through the web hooks so sid hydration, saved-search reopen, and share-ready sessions can all drive the same shell summary card
- keep explicit URL params canonical by suppressing the shared-link label when sid is present but overridden by direct query params

## Validation
- bun run --filter @trends/web test -- src/hooks/useSession.test.tsx src/hooks/useResumeListState.test.tsx src/components/QuickStartPanel.test.tsx
- npm --workspace @trends/web run typecheck
- make check