### PR TITLE
feat(web): promote copied resume share links

### DIFF
--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -105,6 +105,7 @@ export function ResumeList() {
     handleCandidateStatusChange,
     handleResetAll,
     ensureApiSession,
+    handleShareSessionCopied,
     handleAiFeedback,
     getAiFeedback,
   } = useResumeListState(historyRequested)
@@ -378,6 +379,11 @@ export function ResumeList() {
               shareTitle={shareTitle}
               state={shareState}
               ensureApiSession={ensureApiSession}
+              onCopyState={({ sessionId, usedSessionLink }) => {
+                if (usedSessionLink) {
+                  handleShareSessionCopied(sessionId)
+                }
+              }}
             />
             <Button size="sm" variant="ghost" className="h-10 w-10 p-0" onClick={handleRefresh} disabled={activeLoading}>
               <RefreshCw className={cn('h-3.5 w-3.5', activeLoading && 'animate-spin')} />

--- a/apps/web/src/components/ShareLinkButton.test.tsx
+++ b/apps/web/src/components/ShareLinkButton.test.tsx
@@ -63,6 +63,7 @@ describe('ShareLinkButton', () => {
   it('creates and copies a short sid link for bulky or session-backed state', async () => {
     window.history.replaceState({}, '', '/dev/resumes?location=Kuala+Lumpur+MY&keyword=%22Sales+Engineer%22')
     const ensureApiSession = vi.fn(async () => 'session-share-1')
+    const onCopyState = vi.fn()
 
     render(
       <ShareLinkButton
@@ -85,6 +86,7 @@ describe('ShareLinkButton', () => {
           jobDescriptionId: 'lathe-sales',
         }}
         ensureApiSession={ensureApiSession}
+        onCopyState={onCopyState}
       />
     )
 
@@ -104,6 +106,48 @@ describe('ShareLinkButton', () => {
     expect(clipboardWriteTextMock).toHaveBeenCalledWith(
       `${window.location.origin}/dev/resumes?sid=session-share-1`
     )
+    expect(onCopyState).toHaveBeenCalledWith({
+      shareUrl: `${window.location.origin}/dev/resumes?sid=session-share-1`,
+      sessionId: 'session-share-1',
+      usedSessionLink: true,
+    })
     expect(toastSuccessMock).toHaveBeenCalledWith('已复制会话链接')
+  })
+
+  it('reports the existing sid when copying a shared-link URL directly', async () => {
+    window.history.replaceState({}, '', '/dev/resumes?sid=session-share-2')
+    const ensureApiSession = vi.fn(async () => 'session-share-3')
+    const onCopyState = vi.fn()
+
+    render(
+      <ShareLinkButton
+        shareTitle="Shared search"
+        state={{
+          location: undefined,
+          keywords: [],
+          requiredKeywords: [],
+          filters: {},
+          selectedTags: [],
+          selectedCompanies: [],
+        }}
+        ensureApiSession={ensureApiSession}
+        onCopyState={onCopyState}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '分享' }))
+
+    await waitFor(() => {
+      expect(clipboardWriteTextMock).toHaveBeenCalledWith(
+        `${window.location.origin}/dev/resumes?sid=session-share-2`
+      )
+    })
+
+    expect(ensureApiSession).not.toHaveBeenCalled()
+    expect(onCopyState).toHaveBeenCalledWith({
+      shareUrl: `${window.location.origin}/dev/resumes?sid=session-share-2`,
+      sessionId: 'session-share-2',
+      usedSessionLink: true,
+    })
   })
 })

--- a/apps/web/src/components/ShareLinkButton.tsx
+++ b/apps/web/src/components/ShareLinkButton.tsx
@@ -8,6 +8,11 @@ type ShareLinkButtonProps = {
   shareTitle: string
   state: ResumeSearchShareState
   ensureApiSession: (options?: EnsureApiSessionOptions) => Promise<string | undefined>
+  onCopyState?: (payload: {
+    shareUrl: string
+    sessionId?: string
+    usedSessionLink: boolean
+  }) => void
 }
 
 function countActiveFilters(filters: ResumeSearchShareState['filters']): number {
@@ -83,12 +88,13 @@ async function copyText(text: string): Promise<void> {
   }
 }
 
-export function ShareLinkButton({ shareTitle, state, ensureApiSession }: ShareLinkButtonProps) {
+export function ShareLinkButton({ shareTitle, state, ensureApiSession, onCopyState }: ShareLinkButtonProps) {
   const handleCopy = useCallback(async () => {
     try {
       const currentUrl = new URL(window.location.href)
       let shareUrl = currentUrl.toString()
-      let usedSessionLink = false
+      let copiedSessionId = currentUrl.searchParams.get('sid')?.trim() || undefined
+      let usedSessionLink = Boolean(copiedSessionId)
 
       if (shouldPersistShareLink(currentUrl, state)) {
         const sessionId = await ensureApiSession({
@@ -97,17 +103,23 @@ export function ShareLinkButton({ shareTitle, state, ensureApiSession }: ShareLi
         })
         if (sessionId) {
           shareUrl = buildSessionShareUrl(sessionId)
+          copiedSessionId = sessionId
           usedSessionLink = true
         }
       }
 
       await copyText(shareUrl)
+      onCopyState?.({
+        shareUrl,
+        sessionId: copiedSessionId,
+        usedSessionLink,
+      })
       toast.success(usedSessionLink ? '已复制会话链接' : '已复制分享链接')
     } catch (error) {
       console.error('Failed to copy share URL', error)
       toast.error('复制链接失败，请手动复制地址栏 URL')
     }
-  }, [ensureApiSession, shareTitle, state])
+  }, [ensureApiSession, onCopyState, shareTitle, state])
 
   return (
     <Button

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1390,6 +1390,23 @@ describe('useResumeListState role filter regression', () => {
     expect(result.current.activeSessionDescription).toContain('Reopened from saved history')
   })
 
+  it('promotes the active session to a shared-link summary after a durable link is copied', () => {
+    mockState.apiSessionId = 'api-session-1'
+    mockState.sessionLocation = 'Dongguan'
+    mockState.sessionKeywords = ['CNC']
+
+    const { result } = renderHook(() => useResumeListState())
+
+    act(() => {
+      result.current.handleShareSessionCopied('session-share-1')
+    })
+
+    expect(result.current.activeSessionTitle).toBe('Dongguan · CNC')
+    expect(result.current.activeSessionLabel).toBe('Shared link')
+    expect(result.current.activeSessionId).toBe('session-share-1')
+    expect(result.current.activeSessionDescription).toContain('Short durable link copied')
+  })
+
   it('passes current convex resume ids when saving search history', async () => {
     mockState.saveSearchHistory.mockClear()
     const { result } = renderHook(() => useResumeListState())

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -595,6 +595,8 @@ export function useResumeListState(loadSearchHistory = false) {
   const [requiredKeywords, setRequiredKeywords] = useState<string[]>([])
   const [selectedExperienceLevel, setSelectedExperienceLevel] = useState<ExperienceLevelFilter | undefined>(undefined)
   const [appliedSearchHistoryId, setAppliedSearchHistoryId] = useState<string | undefined>(undefined)
+  const [copiedShareSessionId, setCopiedShareSessionId] = useState<string | undefined>(undefined)
+  const [copiedShareScopeSignature, setCopiedShareScopeSignature] = useState<string | undefined>(undefined)
   const [queryRuleScoreMap, setQueryRuleScoreMap] = useState<Record<string, number>>({})
   const [requestedConvexLimit, setRequestedConvexLimit] = useState(DEFAULT_CONVEX_RESUME_LIMIT)
   const [hasCompletedInitialConvexLoad, setHasCompletedInitialConvexLoad] = useState(false)
@@ -2227,6 +2229,34 @@ export function useResumeListState(loadSearchHistory = false) {
     () => buildSearchHistoryTitle(sessionLocation, sessionKeywords, jobDescriptionId),
     [jobDescriptionId, sessionKeywords, sessionLocation]
   )
+  const shareScopeSignature = useMemo(
+    () => JSON.stringify({
+      title: shareTitle,
+      location: normalizeOptionalString(sessionLocation),
+      keywords: sessionKeywords,
+      requiredKeywords,
+      jobDescriptionId: normalizeOptionalString(jobDescriptionId),
+      collectionSource: sessionCollectionSource ?? null,
+      collectUrl: normalizeOptionalString(sessionCollectUrl),
+      filters: normalizeUrlFilters(filters),
+      selectedTags,
+      selectedCompanies,
+      selectedExperienceLevel,
+    }),
+    [
+      filters,
+      jobDescriptionId,
+      requiredKeywords,
+      selectedCompanies,
+      selectedExperienceLevel,
+      selectedTags,
+      sessionCollectUrl,
+      sessionCollectionSource,
+      sessionKeywords,
+      sessionLocation,
+      shareTitle,
+    ]
+  )
   const linkedShareSessionId = !activeHasUrlParams ? activeShareSessionId : undefined
   const hasShareableSessionContext = useMemo(
     () => Boolean(
@@ -2238,11 +2268,27 @@ export function useResumeListState(loadSearchHistory = false) {
     ),
     [jobDescriptionId, sessionCollectUrl, sessionCollectionSource, sessionKeywords, sessionLocation]
   )
+  useEffect(() => {
+    if (!copiedShareSessionId || !copiedShareScopeSignature) {
+      return
+    }
+
+    if (copiedShareScopeSignature !== shareScopeSignature) {
+      setCopiedShareSessionId(undefined)
+      setCopiedShareScopeSignature(undefined)
+    }
+  }, [copiedShareScopeSignature, copiedShareSessionId, shareScopeSignature])
+
   const activeSessionId = linkedShareSessionId
+    ?? copiedShareSessionId
     ?? (apiSessionId && hasShareableSessionContext ? apiSessionId : undefined)
   const activeSessionTitle = useMemo(() => {
     if (linkedShareSessionId) {
       return hydratedShareSessionTitle ?? shareTitle
+    }
+
+    if (copiedShareSessionId) {
+      return shareTitle
     }
 
     if (appliedSearchHistory) {
@@ -2255,6 +2301,7 @@ export function useResumeListState(loadSearchHistory = false) {
 
     return undefined
   }, [
+    copiedShareSessionId,
     linkedShareSessionId,
     apiSessionId,
     appliedSearchHistory,
@@ -2267,6 +2314,10 @@ export function useResumeListState(loadSearchHistory = false) {
       return 'Shared link'
     }
 
+    if (copiedShareSessionId) {
+      return 'Shared link'
+    }
+
     if (appliedSearchHistory) {
       return 'Saved search'
     }
@@ -2276,10 +2327,14 @@ export function useResumeListState(loadSearchHistory = false) {
     }
 
     return undefined
-  }, [linkedShareSessionId, apiSessionId, appliedSearchHistory, hasShareableSessionContext])
+  }, [copiedShareSessionId, linkedShareSessionId, apiSessionId, appliedSearchHistory, hasShareableSessionContext])
   const activeSessionDescription = useMemo(() => {
     if (linkedShareSessionId) {
       return 'Opened from a durable sid link and ready to refine or reshare.'
+    }
+
+    if (copiedShareSessionId) {
+      return 'Short durable link copied for this search and ready to reopen or share.'
     }
 
     if (appliedSearchHistory) {
@@ -2291,7 +2346,16 @@ export function useResumeListState(loadSearchHistory = false) {
     }
 
     return undefined
-  }, [linkedShareSessionId, apiSessionId, appliedSearchHistory, hasShareableSessionContext])
+  }, [copiedShareSessionId, linkedShareSessionId, apiSessionId, appliedSearchHistory, hasShareableSessionContext])
+  const handleShareSessionCopied = useCallback((sessionId: string | undefined) => {
+    const normalizedSessionId = normalizeOptionalString(sessionId)
+    if (!normalizedSessionId) {
+      return
+    }
+
+    setCopiedShareSessionId(normalizedSessionId)
+    setCopiedShareScopeSignature(shareScopeSignature)
+  }, [shareScopeSignature])
   const shareState = useMemo<ResumeSearchShareState>(() => {
     const normalizedLocation = normalizeOptionalString(sessionLocation)
     const locationFilters = normalizedLocation
@@ -2397,5 +2461,6 @@ export function useResumeListState(loadSearchHistory = false) {
     handleCandidateStatusChange,
     handleResetAll,
     ensureApiSession,
+    handleShareSessionCopied,
   }
 }


### PR DESCRIPTION
## Summary
- promote the shell session summary from `Share-ready` to `Shared link` immediately after a durable resume share link is copied
- have `ShareLinkButton` report whether it copied a durable sid link, including when the current URL is already a sid link
- clear the promoted shared-link state automatically when the underlying search state changes so the shell summary stays honest

## Validation
- bun run --filter @trends/web test -- src/components/ShareLinkButton.test.tsx src/hooks/useResumeListState.test.tsx src/components/QuickStartPanel.test.tsx
- npm --workspace @trends/web run typecheck
- make check