### PR TITLE
fix(web): preserve saved state on JD reopen

### DIFF
--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { QuickStartPanel } from './QuickStartPanel'
 import type { SearchHistoryItem } from '@/hooks/useSession'
@@ -357,6 +358,83 @@ describe('QuickStartPanel quick-filter display', () => {
     }))
   })
 
+  it('preserves externally restored location and keywords when a saved search includes a JD', async () => {
+    const onApplyConfig = vi.fn()
+
+    getMock.mockImplementation(async (path: string) => {
+      if (path.includes('/api/config/custom-keywords')) {
+        return {
+          data: {
+            success: true,
+            tags: [],
+            categories: [],
+            systemLocations: [],
+            workflowSeeds: [],
+          },
+        }
+      }
+
+      if (path.includes('/api/job-descriptions/lathe-sales')) {
+        return {
+          data: {
+            success: true,
+            item: {
+              location: '东莞',
+              autoMatch: {
+                keywords: ['车床', 'STAR'],
+              },
+              requiredRoles: [{ type: 'sales', min_years: 1 }],
+            },
+          },
+        }
+      }
+
+      return {
+        data: {
+          success: true,
+          item: {
+            requiredRoles: [],
+          },
+        },
+      }
+    })
+
+    const { rerender } = render(
+      <QuickStartPanel
+        defaultLocation=""
+        defaultKeywords={[]}
+        jobDescriptionId=""
+        onApplyConfig={onApplyConfig}
+      />
+    )
+
+    rerender(
+      <QuickStartPanel
+        defaultLocation="China"
+        defaultKeywords={['CNC', '销售']}
+        jobDescriptionId="lathe-sales"
+        onApplyConfig={onApplyConfig}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: '位置' })).toHaveValue('China')
+      expect(screen.getByDisplayValue('CNC 销售')).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(onApplyConfig).toHaveBeenLastCalledWith({
+        location: 'China',
+        keywords: ['CNC', '销售'],
+        jobDescriptionId: 'lathe-sales',
+        collectionSource: {
+          type: 'job5156',
+        },
+        collectUrl: undefined,
+      })
+    })
+  })
+
   it('shows the current session summary when a shared or reopened search is active', () => {
     render(
       <QuickStartPanel
@@ -397,6 +475,70 @@ describe('QuickStartPanel quick-filter display', () => {
     expect(
       onApplyQuickFilters.mock.calls.some(([value]) => value?.minRoleYears === 1)
     ).toBe(false)
+  })
+
+  it('still auto-fills JD defaults for a manual JD selection', async () => {
+    const user = userEvent.setup()
+
+    getMock.mockImplementation(async (path: string) => {
+      if (path.includes('/api/config/custom-keywords')) {
+        return {
+          data: {
+            success: true,
+            tags: [],
+            categories: [],
+            systemLocations: [],
+            workflowSeeds: [],
+          },
+        }
+      }
+
+      if (path.includes('/api/job-descriptions/lathe-sales')) {
+        return {
+          data: {
+            success: true,
+            item: {
+              location: '东莞',
+              autoMatch: {
+                keywords: ['车床'],
+              },
+              requiredRoles: [{ type: 'sales', min_years: 1 }],
+            },
+          },
+        }
+      }
+
+      return {
+        data: {
+          success: true,
+          item: {
+            requiredRoles: [],
+          },
+        },
+      }
+    })
+
+    function StatefulQuickStartPanel() {
+      const [jobDescriptionId, setJobDescriptionId] = useState('')
+
+      return (
+        <QuickStartPanel
+          defaultLocation="广东"
+          defaultKeywords={[]}
+          jobDescriptionId={jobDescriptionId}
+          onJobChange={setJobDescriptionId}
+        />
+      )
+    }
+
+    render(<StatefulQuickStartPanel />)
+
+    await user.selectOptions(screen.getByTestId('job-description-select'), 'lathe-sales')
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: '位置' })).toHaveValue('东莞')
+      expect(screen.getByDisplayValue('车床')).toBeInTheDocument()
+    })
   })
 
   it('applies workflow seeds from the config payload', async () => {

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -343,8 +343,42 @@ export function QuickStartPanel({
   const [showProfileEditor, setShowProfileEditor] = useState(false)
   const [assistantOpen, setAssistantOpen] = useState(false)
   const [workflowSeeds, setWorkflowSeeds] = useState<QuickStartWorkflow[]>([])
-  const lastJobDescriptionIdRef = useRef(jobDescriptionId.trim())
+  const normalizedJobDescriptionId = jobDescriptionId.trim()
+  const normalizedDefaultLocation = defaultLocation.trim()
+  const normalizedDefaultKeywordsSignature = normalizeKeywordPhrases(defaultKeywords).join('\u0000')
+  const currentExternalShellStateSignature = [
+    normalizedJobDescriptionId,
+    normalizedDefaultLocation,
+    normalizedDefaultKeywordsSignature,
+  ].join('\u0001')
+  const lastJobDescriptionIdRef = useRef(normalizedJobDescriptionId)
+  const previousExternalShellStateRef = useRef({
+    jobDescriptionId: normalizedJobDescriptionId,
+    location: normalizedDefaultLocation,
+    keywordsSignature: normalizedDefaultKeywordsSignature,
+  })
+  const skipNextJobDescriptionAutofillRef = useRef<string | null>(null)
   const hasRequestedHistoryRef = useRef(false)
+
+  const previousExternalShellState = previousExternalShellStateRef.current
+  const jobDescriptionChangedFromExternalState = previousExternalShellState.jobDescriptionId !== normalizedJobDescriptionId
+  const externalLocationChanged = previousExternalShellState.location !== normalizedDefaultLocation
+  const externalKeywordsChanged = previousExternalShellState.keywordsSignature !== normalizedDefaultKeywordsSignature
+
+  if (
+    normalizedJobDescriptionId
+    && jobDescriptionChangedFromExternalState
+    && (externalLocationChanged || externalKeywordsChanged)
+    && (normalizedDefaultLocation.length > 0 || normalizedDefaultKeywordsSignature.length > 0)
+  ) {
+    skipNextJobDescriptionAutofillRef.current = currentExternalShellStateSignature
+  }
+
+  previousExternalShellStateRef.current = {
+    jobDescriptionId: normalizedJobDescriptionId,
+    location: normalizedDefaultLocation,
+    keywordsSignature: normalizedDefaultKeywordsSignature,
+  }
 
   const convexJobDescriptions = useQuery(api.job_descriptions.list, { workspaceSlug: slug })
   const selectedConvexJobDescription = useMemo(() => {
@@ -379,7 +413,6 @@ export function QuickStartPanel({
   }, [defaultCollectionSource])
 
   useEffect(() => {
-    const normalizedJobDescriptionId = jobDescriptionId.trim()
     const hasJobSelectionChanged = lastJobDescriptionIdRef.current !== normalizedJobDescriptionId
 
     if (hasJobSelectionChanged) {
@@ -409,11 +442,11 @@ export function QuickStartPanel({
     } else {
       setQuickMaxAge('')
     }
-  }, [jobDescriptionId, quickFilters?.maxAge, quickFilters?.minRoleYears, effectiveDefaultMinRoleYears, jdMaxAge])
+  }, [normalizedJobDescriptionId, quickFilters?.maxAge, quickFilters?.minRoleYears, effectiveDefaultMinRoleYears, jdMaxAge])
 
   useEffect(() => {
-    const normalizedJobDescriptionId = jobDescriptionId.trim()
     if (!normalizedJobDescriptionId) {
+      skipNextJobDescriptionAutofillRef.current = null
       setActiveRoleType(undefined)
       setJdMinRoleYears(undefined)
       setJdMaxAge(undefined)
@@ -429,6 +462,9 @@ export function QuickStartPanel({
         return
       }
 
+      const shouldPreserveExternalShellState =
+        skipNextJobDescriptionAutofillRef.current === currentExternalShellStateSignature
+
       setActiveRoleType(undefined)
       setJdMinRoleYears(
         typeof selectedConvexJobDescriptionDetail?.minExperience === 'number'
@@ -441,11 +477,15 @@ export function QuickStartPanel({
           : undefined
       )
 
-      if (selectedConvexJobDescriptionDetail?.location) {
+      if (!shouldPreserveExternalShellState && selectedConvexJobDescriptionDetail?.location) {
         setLocation(selectedConvexJobDescriptionDetail.location)
       }
 
-      if (selectedConvexJobDescriptionDetail?.customKeywords && selectedConvexJobDescriptionDetail.customKeywords.length > 0) {
+      if (
+        !shouldPreserveExternalShellState
+        && selectedConvexJobDescriptionDetail?.customKeywords
+        && selectedConvexJobDescriptionDetail.customKeywords.length > 0
+      ) {
         setSelectedKeywords(selectedConvexJobDescriptionDetail.customKeywords.map(k => k.trim()))
         setCustomKeyword(formatKeywordInput(selectedConvexJobDescriptionDetail.customKeywords))
       }
@@ -469,7 +509,10 @@ export function QuickStartPanel({
         setJdMinRoleYears(requiredRole?.min_years)
         setJdMaxAge(undefined)
 
-        if (!selectedConvexJobDescriptionDetail && response.data?.item) {
+        const shouldPreserveExternalShellState =
+          skipNextJobDescriptionAutofillRef.current === currentExternalShellStateSignature
+
+        if (!selectedConvexJobDescriptionDetail && response.data?.item && !shouldPreserveExternalShellState) {
           const itemLocation = response.data.item.location
           const autoMatchKeywords = response.data.item.autoMatch?.keywords
 
@@ -500,7 +543,7 @@ export function QuickStartPanel({
     return () => {
       cancelled = true
     }
-  }, [jobDescriptionId, convexJobDescriptions, selectedConvexJobDescription, selectedConvexJobDescriptionDetail])
+  }, [currentExternalShellStateSignature, normalizedJobDescriptionId, convexJobDescriptions, selectedConvexJobDescription, selectedConvexJobDescriptionDetail])
 
   useEffect(() => {
     if (hasRequestedHistoryRef.current || !onRequestHistory || assistantHistoryLoading || assistantHistory.length > 0) {


### PR DESCRIPTION
## Summary
- preserve saved-search location and keywords when reopening a JD-backed search from history/share state
- keep the manual JD autofill path for direct shell selection
- add QuickStartPanel regression tests for both restore and manual-JD cases

## Testing
- npm --workspace @trends/web exec vitest run src/hooks/useResumeListState.test.tsx src/components/QuickStartPanel.test.tsx
- npm --workspace @trends/web run typecheck
- make check