### PR TITLE
fix: keep reference note in shared resume sessions

### DIFF
--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -91,6 +91,7 @@ describe("session routes", () => {
             minAge: 28,
             status: ["offer"],
           },
+          referenceNote: "Priority shortlist for HR sync",
         },
       }),
     });
@@ -104,6 +105,7 @@ describe("session routes", () => {
         shareTitle?: string;
         searchState?: {
           location?: string;
+          referenceNote?: string;
           filters?: {
             minAge?: number;
             status?: string[];
@@ -117,6 +119,7 @@ describe("session routes", () => {
     expect(createdPayload.session.shareTitle).toBe("Kuala Lumpur · Sales Engineer");
     expect(createdPayload.session.searchState).toMatchObject({
       location: "Kuala Lumpur MY",
+      referenceNote: "Priority shortlist for HR sync",
       filters: {
         minAge: 28,
         status: ["offer"],
@@ -139,6 +142,7 @@ describe("session routes", () => {
         };
         searchState?: {
           requiredKeywords?: string[];
+          referenceNote?: string;
           selectedTags?: string[];
           selectedCompanies?: string[];
           selectedExperienceLevel?: string;
@@ -151,6 +155,7 @@ describe("session routes", () => {
     expect(getPayload.session.filters).toMatchObject({ minAge: 28 });
     expect(getPayload.session.searchState).toMatchObject({
       requiredKeywords: ["machine tools"],
+      referenceNote: "Priority shortlist for HR sync",
       selectedTags: ["STAR"],
       selectedCompanies: ["fanuc"],
       selectedExperienceLevel: "mid",

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -42,6 +42,7 @@ const SearchSessionStateSchema = z.object({
   collectionSource: SearchSessionCollectionSourceSchema.optional(),
   collectUrl: z.string().optional().openapi({ example: "https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1" }),
   filters: SessionFiltersSchema.optional(),
+  referenceNote: z.string().optional().openapi({ example: "Priority shortlist for HR sync" }),
 });
 
 const SearchSessionSchema = z.object({

--- a/apps/api/src/services/session-manager.ts
+++ b/apps/api/src/services/session-manager.ts
@@ -55,6 +55,7 @@ export type SearchSessionState = {
   collectionSource?: SearchSessionCollectionSource;
   collectUrl?: string;
   filters?: ResumeFilters;
+  referenceNote?: string;
 };
 
 export type SearchSession = {

--- a/apps/web/src/components/ShareLinkButton.test.tsx
+++ b/apps/web/src/components/ShareLinkButton.test.tsx
@@ -128,6 +128,45 @@ describe('ShareLinkButton', () => {
     expect(toastSuccessMock).toHaveBeenCalledWith('已复制会话链接')
   })
 
+  it('creates a durable sid link when share state includes a reference note', async () => {
+    window.history.replaceState({}, '', '/dev/resumes?location=China&keyword=CNC')
+    const ensureApiSession = vi.fn(async () => 'session-share-note')
+
+    render(
+      <ShareLinkButton
+        shareTitle="China · CNC"
+        state={{
+          location: 'China',
+          keywords: ['CNC'],
+          requiredKeywords: [],
+          filters: {},
+          selectedTags: [],
+          selectedCompanies: [],
+          referenceNote: 'Priority shortlist for HR sync',
+        }}
+        ensureApiSession={ensureApiSession}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '分享' }))
+
+    await waitFor(() => {
+      expect(ensureApiSession).toHaveBeenCalledWith({
+        shareTitle: 'China · CNC',
+        searchState: expect.objectContaining({
+          location: 'China',
+          keywords: ['CNC'],
+          referenceNote: 'Priority shortlist for HR sync',
+        }),
+      })
+    })
+
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith(
+      `${window.location.origin}/dev/resumes?sid=session-share-note`
+    )
+    expect(toastSuccessMock).toHaveBeenCalledWith('已复制会话链接')
+  })
+
   it('reports the existing sid when copying a shared-link URL directly', async () => {
     window.history.replaceState({}, '', '/dev/resumes?sid=session-share-2')
     const ensureApiSession = vi.fn(async () => 'session-share-3')

--- a/apps/web/src/components/ShareLinkButton.tsx
+++ b/apps/web/src/components/ShareLinkButton.tsx
@@ -51,6 +51,10 @@ function shouldPersistShareLink(currentUrl: URL, state: ResumeSearchShareState):
     return false
   }
 
+  if (state.referenceNote) {
+    return true
+  }
+
   if (state.collectionSource || state.collectUrl) {
     return true
   }

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1303,6 +1303,7 @@ describe('useResumeListState role filter regression', () => {
             filters: {
               minAge: 28,
             },
+            referenceNote: 'Priority shortlist for HR sync',
           },
         },
       },
@@ -1312,6 +1313,10 @@ describe('useResumeListState role filter regression', () => {
 
     await waitFor(() => {
       expect(rawApiClient.GET).toHaveBeenCalledWith('/api/sessions/shared-session-1')
+    })
+
+    await waitFor(() => {
+      expect(result.current.activeSessionTitle).toBe('Kuala Lumpur · Sales Engineer')
     })
 
     expect(mockState.rememberApiSessionId).toHaveBeenCalledWith('shared-session-1')
@@ -1328,9 +1333,60 @@ describe('useResumeListState role filter regression', () => {
         minAge: 28,
       },
     })
-    expect(result.current.activeSessionTitle).toBe('Kuala Lumpur · Sales Engineer')
     expect(result.current.activeSessionLabel).toBe('Shared link')
     expect(result.current.activeSessionId).toBe('shared-session-1')
+  })
+
+  it('keeps the hydrated sid reference note when opening review packets', async () => {
+    window.history.replaceState({}, '', '/dev/resumes?sid=shared-session-1')
+    mockState.locationSearch = '?sid=shared-session-1'
+    mockState.urlParsedState = {
+      ...mockState.urlParsedState,
+      shareSessionId: 'shared-session-1',
+    }
+    mockState.sessionJobDescriptionId = 'lathe-sales'
+    mockState.sessionGetResponse = {
+      data: {
+        success: true,
+        session: {
+          id: 'shared-session-1',
+          shareTitle: 'China · CNC 销售',
+          searchState: {
+            location: 'China',
+            keywords: ['CNC 销售'],
+            jobDescriptionId: 'lathe-sales',
+            filters: {},
+            referenceNote: 'Priority shortlist for HR sync',
+          },
+        },
+      },
+    }
+
+    const { result } = renderHook(() => useResumeListState())
+
+    await waitFor(() => {
+      expect(rawApiClient.GET).toHaveBeenCalledWith('/api/sessions/shared-session-1')
+    })
+
+    await waitFor(() => {
+      expect(result.current.activeSessionId).toBe('shared-session-1')
+    })
+
+    act(() => {
+      result.current.handleToggleSelect('resume-ideal-cnc-sales')
+      result.current.handleToggleSelect('resume-zhang-machinery-sales')
+    })
+
+    await act(async () => {
+      await result.current.handleOpenReviewPacket()
+    })
+
+    const navigateTarget = mockState.navigate.mock.calls[0]?.[0] as { pathname: string; search: string }
+    const params = new URLSearchParams(navigateTarget.search)
+
+    expect(params.get('jobDescriptionId')).toBe('lathe-sales')
+    expect(params.get('sessionId')).toBe('api-session-1')
+    expect(params.get('referenceNote')).toBe('Priority shortlist for HR sync')
   })
 
   it('prefers explicit URL params over sid hydration when both are present', async () => {

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -619,6 +619,7 @@ export function useResumeListState(loadSearchHistory = false) {
   const [hasCompletedShareSessionHydration, setHasCompletedShareSessionHydration] = useState(false)
   const hydratedShareSessionIdRef = useRef<string | null>(null)
   const [hydratedShareSessionTitle, setHydratedShareSessionTitle] = useState<string | undefined>(undefined)
+  const [hydratedShareSessionReferenceNote, setHydratedShareSessionReferenceNote] = useState<string | undefined>(undefined)
 
   if (!initialWindowSearchStateRef.current) {
     const params = new URLSearchParams(window.location.search)
@@ -1109,6 +1110,7 @@ export function useResumeListState(loadSearchHistory = false) {
     let active = true
     hydratedShareSessionIdRef.current = activeShareSessionId
     setHasCompletedShareSessionHydration(false)
+    setHydratedShareSessionReferenceNote(undefined)
 
     void rawApiClient
       .GET<SearchSessionApiResponse>(`/api/sessions/${encodeURIComponent(activeShareSessionId)}`)
@@ -1121,6 +1123,7 @@ export function useResumeListState(loadSearchHistory = false) {
         if (error || !data?.success || !sharedSearchState) {
           console.error('Failed to hydrate shared search session', error ?? data)
           setHydratedShareSessionTitle(undefined)
+          setHydratedShareSessionReferenceNote(undefined)
           setHasCompletedShareSessionHydration(true)
           return
         }
@@ -1135,6 +1138,7 @@ export function useResumeListState(loadSearchHistory = false) {
               sharedSearchState.jobDescriptionId,
             )
         )
+        setHydratedShareSessionReferenceNote(normalizeOptionalString(sharedSearchState.referenceNote))
         applyExternalState({
           location: sharedSearchState.location,
           keywords: sharedSearchState.keywords,
@@ -1157,6 +1161,7 @@ export function useResumeListState(loadSearchHistory = false) {
 
         console.error('Failed to hydrate shared search session', error)
         setHydratedShareSessionTitle(undefined)
+        setHydratedShareSessionReferenceNote(undefined)
         setHasCompletedShareSessionHydration(true)
       })
 
@@ -1624,6 +1629,10 @@ export function useResumeListState(loadSearchHistory = false) {
     () => searchHistory.find((entry) => entry.id === appliedSearchHistoryId),
     [appliedSearchHistoryId, searchHistory]
   )
+  const continuityReferenceNote = useMemo(
+    () => normalizeOptionalString(appliedSearchHistory?.notes) ?? hydratedShareSessionReferenceNote,
+    [appliedSearchHistory?.notes, hydratedShareSessionReferenceNote]
+  )
 
   const enrichedResumes = useMemo<EnrichedResume[]>(() => {
     if (mode === 'ai') {
@@ -1794,6 +1803,7 @@ export function useResumeListState(loadSearchHistory = false) {
 
   const resetResumeSearchState = useCallback(() => {
     setAppliedSearchHistoryId(undefined)
+    setHydratedShareSessionReferenceNote(undefined)
     applyExternalState({
       location: '',
       keywords: [],
@@ -1965,7 +1975,7 @@ export function useResumeListState(loadSearchHistory = false) {
       params.set('sessionId', bridgedSessionId)
     }
 
-    const normalizedReferenceNote = normalizeOptionalString(appliedSearchHistory?.notes)
+    const normalizedReferenceNote = continuityReferenceNote
     if (normalizedReferenceNote) {
       params.set('referenceNote', normalizedReferenceNote)
     }
@@ -1975,8 +1985,8 @@ export function useResumeListState(loadSearchHistory = false) {
       search: `?${params.toString()}`,
     })
   }, [
-    appliedSearchHistory?.notes,
     bulkExportFormat,
+    continuityReferenceNote,
     displayedResumes,
     ensureApiSession,
     jobDescriptionId,
@@ -2208,6 +2218,7 @@ export function useResumeListState(loadSearchHistory = false) {
 
   const handleApplySearchHistory = useCallback(async (entry: SearchHistoryItem) => {
     skipNextUrlSyncRef.current = true
+    setHydratedShareSessionReferenceNote(undefined)
     applyExternalState({
       location: entry.location,
       keywords: entry.keywords,
@@ -2242,8 +2253,10 @@ export function useResumeListState(loadSearchHistory = false) {
       selectedTags,
       selectedCompanies,
       selectedExperienceLevel,
+      referenceNote: continuityReferenceNote,
     }),
     [
+      continuityReferenceNote,
       filters,
       jobDescriptionId,
       requiredKeywords,
@@ -2376,8 +2389,10 @@ export function useResumeListState(loadSearchHistory = false) {
       selectedTags,
       selectedCompanies,
       selectedExperienceLevel,
+      referenceNote: continuityReferenceNote,
     }
   }, [
+    continuityReferenceNote,
     filters,
     jobDescriptionId,
     requiredKeywords,

--- a/apps/web/src/hooks/useSession.test.tsx
+++ b/apps/web/src/hooks/useSession.test.tsx
@@ -313,6 +313,7 @@ describe('useSession', () => {
           filters: {
             minAge: 28,
           },
+          referenceNote: '  Priority shortlist for HR sync  ',
         },
       })
     })
@@ -338,6 +339,7 @@ describe('useSession', () => {
           filters: {
             minAge: 28,
           },
+          referenceNote: 'Priority shortlist for HR sync',
         },
       },
     })

--- a/apps/web/src/hooks/useSession.ts
+++ b/apps/web/src/hooks/useSession.ts
@@ -26,6 +26,7 @@ export type ResumeSearchShareState = ExternalSessionState & {
   selectedTags?: string[]
   selectedCompanies?: string[]
   selectedExperienceLevel?: 'senior' | 'mid' | 'junior'
+  referenceNote?: string
 }
 
 export type EnsureApiSessionOptions = {
@@ -158,6 +159,7 @@ function normalizeShareState(
     collectionSource: normalizeCollectionSource(state.collectionSource),
     collectUrl: normalizeOptionalString(state.collectUrl),
     filters: normalizeShareFilters(state.filters),
+    referenceNote: normalizeOptionalString(state.referenceNote),
   }
 
   if (
@@ -171,6 +173,7 @@ function normalizeShareState(
     && (normalized.selectedCompanies?.length ?? 0) === 0
     && !normalized.selectedExperienceLevel
     && !normalized.filters
+    && !normalized.referenceNote
   ) {
     return undefined
   }

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -2433,6 +2433,8 @@ export interface paths {
                                 status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
                                 showBlocked?: boolean;
                             };
+                            /** @example Priority shortlist for HR sync */
+                            referenceNote?: string;
                         };
                     };
                 };
@@ -2520,6 +2522,8 @@ export interface paths {
                                         status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
                                         showBlocked?: boolean;
                                     };
+                                    /** @example Priority shortlist for HR sync */
+                                    referenceNote?: string;
                                 };
                                 /**
                                  * @example active
@@ -2645,6 +2649,8 @@ export interface paths {
                                         status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
                                         showBlocked?: boolean;
                                     };
+                                    /** @example Priority shortlist for HR sync */
+                                    referenceNote?: string;
                                 };
                                 /**
                                  * @example active
@@ -2752,6 +2758,8 @@ export interface paths {
                                 status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
                                 showBlocked?: boolean;
                             };
+                            /** @example Priority shortlist for HR sync */
+                            referenceNote?: string;
                         } | null;
                         /** @enum {string} */
                         status?: "active" | "completed" | "archived";
@@ -2842,6 +2850,8 @@ export interface paths {
                                         status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn")[];
                                         showBlocked?: boolean;
                                     };
+                                    /** @example Priority shortlist for HR sync */
+                                    referenceNote?: string;
                                 };
                                 /**
                                  * @example active


### PR DESCRIPTION
## Summary
- persist saved-search reference notes in durable sid session state
- hydrate reference notes back from shared sessions and carry them into review-packet handoff
- force durable sid sharing when a search includes reference-note continuity

## Testing
- npm --workspace @trends/web exec vitest run src/components/ShareLinkButton.test.tsx src/hooks/useSession.test.tsx src/hooks/useResumeListState.test.tsx
- bunx vitest run apps/api/src/routes/sessions.test.ts
- npm --workspace @trends/web run gen:api
- npm --workspace @trends/web run typecheck
- bun run --filter @trends/api typecheck
- make check