### PR TITLE
feat: show active session context notes

### DIFF
--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -444,6 +444,7 @@ describe('QuickStartPanel quick-filter display', () => {
         activeSessionTitle="Kuala Lumpur · Sales Engineer"
         activeSessionLabel="Shared link"
         activeSessionDescription="Opened from a durable sid link and ready to refine or reshare."
+        activeSessionNote="Priority shortlist for HR sync"
         activeSessionId="shared-session-1"
       />
     )
@@ -452,6 +453,8 @@ describe('QuickStartPanel quick-filter display', () => {
     expect(screen.getByText('Kuala Lumpur · Sales Engineer')).toBeInTheDocument()
     expect(screen.getByText('Shared link')).toBeInTheDocument()
     expect(screen.getByText('shared-ses…')).toBeInTheDocument()
+    expect(screen.getByText('Context note')).toBeInTheDocument()
+    expect(screen.getByText('Priority shortlist for HR sync')).toBeInTheDocument()
   })
 
   it('does not auto-apply min years when no JD is selected', async () => {

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -100,6 +100,7 @@ interface QuickStartPanelProps {
   activeSessionTitle?: string
   activeSessionLabel?: string
   activeSessionDescription?: string
+  activeSessionNote?: string
   activeSessionId?: string
   extraActions?: React.ReactNode
   onResetAll?: () => void
@@ -318,6 +319,7 @@ export function QuickStartPanel({
   activeSessionTitle,
   activeSessionLabel,
   activeSessionDescription,
+  activeSessionNote,
   activeSessionId,
   extraActions,
   onResetAll,
@@ -1130,6 +1132,14 @@ export function QuickStartPanel({
                   <p className="text-sm text-muted-foreground">
                     {activeSessionDescription}
                   </p>
+                ) : null}
+                {activeSessionNote ? (
+                  <div className="rounded-lg border border-border/70 bg-muted/35 px-2.5 py-2 text-xs text-muted-foreground">
+                    <span className="mr-1 font-medium uppercase tracking-[0.14em] text-foreground/70">
+                      {t('quickStart.activeSessionNote', 'Context note')}
+                    </span>
+                    <span>{activeSessionNote}</span>
+                  </div>
                 ) : null}
               </div>
             </div>

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -65,6 +65,7 @@ export function ResumeList() {
     activeSessionTitle,
     activeSessionLabel,
     activeSessionDescription,
+    activeSessionNote,
     activeSessionId,
     shareTitle,
     shareState,
@@ -270,6 +271,7 @@ export function ResumeList() {
         activeSessionTitle={activeSessionTitle}
         activeSessionLabel={activeSessionLabel}
         activeSessionDescription={activeSessionDescription}
+        activeSessionNote={activeSessionNote}
         activeSessionId={activeSessionId}
         extraActions={
           <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1334,6 +1334,7 @@ describe('useResumeListState role filter regression', () => {
       },
     })
     expect(result.current.activeSessionLabel).toBe('Shared link')
+    expect(result.current.activeSessionNote).toBe('Priority shortlist for HR sync')
     expect(result.current.activeSessionId).toBe('shared-session-1')
   })
 
@@ -1444,6 +1445,35 @@ describe('useResumeListState role filter regression', () => {
     expect(result.current.activeSessionTitle).toBe('Saved search')
     expect(result.current.activeSessionLabel).toBe('Saved search')
     expect(result.current.activeSessionDescription).toContain('Reopened from saved history')
+    expect(result.current.activeSessionNote).toBeUndefined()
+  })
+
+  it('surfaces the saved-search note in the active session summary after reopening history', async () => {
+    mockState.searchHistory = [
+      {
+        id: 'history-1',
+        sessionKey: 'session-1',
+        title: 'Saved search',
+        location: '苏州',
+        keywords: ['CNC', '销售'],
+        jobDescriptionId: 'lathe-sales',
+        filters: { minAge: 28 },
+        selectedTags: ['STAR'],
+        selectedCompanies: ['Acme'],
+        selectedExperienceLevel: 'mid',
+        notes: 'Priority shortlist for HR sync',
+        createdAt: 1,
+        lastOpenedAt: 2,
+      },
+    ]
+    const { result } = renderHook(() => useResumeListState())
+
+    await act(async () => {
+      await result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
+    })
+
+    expect(result.current.activeSessionTitle).toBe('Saved search')
+    expect(result.current.activeSessionNote).toBe('Priority shortlist for HR sync')
   })
 
   it('promotes the active session to a shared-link summary after a durable link is copied', () => {

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -2360,6 +2360,7 @@ export function useResumeListState(loadSearchHistory = false) {
 
     return undefined
   }, [copiedShareSessionId, linkedShareSessionId, apiSessionId, appliedSearchHistory, hasShareableSessionContext])
+  const activeSessionNote = activeSessionTitle ? continuityReferenceNote : undefined
   const handleShareSessionCopied = useCallback((sessionId: string | undefined) => {
     const normalizedSessionId = normalizeOptionalString(sessionId)
     if (!normalizedSessionId) {
@@ -2428,6 +2429,7 @@ export function useResumeListState(loadSearchHistory = false) {
     activeSessionTitle,
     activeSessionLabel,
     activeSessionDescription,
+    activeSessionNote,
     activeSessionId,
     shareTitle,
     shareState,


### PR DESCRIPTION
## Summary
- surface the current session continuity note in the QuickStart active-session card
- carry saved-search and sid-hydrated notes through the active-session summary state
- add focused web tests for the shell note preview

## Testing
- npm --workspace @trends/web exec vitest run src/components/QuickStartPanel.test.tsx src/hooks/useResumeListState.test.tsx
- npm --workspace @trends/web run typecheck
- make check