### PR TITLE
fix: preload resume dialogs on touch

### DIFF
--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -19,6 +19,7 @@ import { useSyncNotifications } from '@/hooks/useSyncNotifications'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { buildResumeKey, hasIngestData } from '@/lib/resume-scoring'
 import { useBrandDisplayMap } from '@/hooks/useBrandDisplayMap'
+import { shouldPreloadOnPointerDown } from '@/lib/pointer-preload'
 
 const loadResumeDetail = () => import('@/components/ResumeDetail')
 const loadSearchHistoryDialog = () => import('@/components/SearchHistoryDialog')
@@ -194,6 +195,13 @@ export function ResumeList() {
     return () => window.clearTimeout(timer)
   }, [activeLoading, displayedResumes.length])
 
+  const preloadHistoryDialog = () => {
+    void loadSearchHistoryDialog()
+  }
+  const preloadManualImportDialog = () => {
+    void loadManualResumeImportDialog()
+  }
+
   const renderResumeCard = (entry: (typeof displayedResumes)[number]) => {
     const ingestData = hasIngestData(entry.resume) ? entry.resume.ingestData : undefined
 
@@ -282,14 +290,19 @@ export function ResumeList() {
                   variant="ghost"
                   size="sm"
                   className="h-10 gap-2 rounded-full px-3"
-                  onMouseEnter={() => {
-                    void loadSearchHistoryDialog()
+                  onPointerEnter={() => {
+                    preloadHistoryDialog()
                   }}
                   onFocus={() => {
-                    void loadSearchHistoryDialog()
+                    preloadHistoryDialog()
+                  }}
+                  onPointerDown={(event) => {
+                    if (shouldPreloadOnPointerDown(event.pointerType)) {
+                      preloadHistoryDialog()
+                    }
                   }}
                   onClick={() => {
-                    void loadSearchHistoryDialog()
+                    preloadHistoryDialog()
                     setHistoryRequested(true)
                     setHistoryOpen(true)
                   }}
@@ -326,14 +339,19 @@ export function ResumeList() {
                 variant="outline"
                 size="sm"
                 className="h-10 gap-2 px-3"
-                onMouseEnter={() => {
-                  void loadManualResumeImportDialog()
+                onPointerEnter={() => {
+                  preloadManualImportDialog()
                 }}
                 onFocus={() => {
-                  void loadManualResumeImportDialog()
+                  preloadManualImportDialog()
+                }}
+                onPointerDown={(event) => {
+                  if (shouldPreloadOnPointerDown(event.pointerType)) {
+                    preloadManualImportDialog()
+                  }
                 }}
                 onClick={() => {
-                  void loadManualResumeImportDialog()
+                  preloadManualImportDialog()
                   setManualImportOpen(true)
                 }}
               >

--- a/apps/web/src/lib/pointer-preload.test.ts
+++ b/apps/web/src/lib/pointer-preload.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldPreloadOnPointerDown } from './pointer-preload'
+
+describe('shouldPreloadOnPointerDown', () => {
+  it('preloads for touch-first pointer types', () => {
+    expect(shouldPreloadOnPointerDown('touch')).toBe(true)
+    expect(shouldPreloadOnPointerDown('pen')).toBe(true)
+    expect(shouldPreloadOnPointerDown(' Touch ')).toBe(true)
+  })
+
+  it('skips desktop hover-first pointer types', () => {
+    expect(shouldPreloadOnPointerDown('mouse')).toBe(false)
+    expect(shouldPreloadOnPointerDown(undefined)).toBe(false)
+    expect(shouldPreloadOnPointerDown('')).toBe(false)
+  })
+})

--- a/apps/web/src/lib/pointer-preload.ts
+++ b/apps/web/src/lib/pointer-preload.ts
@@ -1,0 +1,4 @@
+export function shouldPreloadOnPointerDown(pointerType: string | undefined): boolean {
+  const normalized = pointerType?.trim().toLowerCase()
+  return normalized === 'touch' || normalized === 'pen'
+}


### PR DESCRIPTION
## Summary
- make resume-shell dialog preloading pointer-aware instead of hover-only
- warm history and manual-import dialogs on touch or pen pointer-down as well as desktop pointer enter/focus
- add focused helper coverage for touch-aware preload decisions

## Testing
- npm --workspace @trends/web exec vitest run src/lib/pointer-preload.test.ts
- npm --workspace @trends/web run typecheck
- make check