### PR TITLE
feat: expand seek english vocabulary coverage

### DIFF
--- a/apps/api/src/services/ingest-compute-service.test.ts
+++ b/apps/api/src/services/ingest-compute-service.test.ts
@@ -460,6 +460,39 @@ describe("IngestComputeService", () => {
     ]));
   });
 
+  it("should recognize English business-development sales titles in work history", () => {
+    const result = service.computeOne("resume-bd-manager", {
+      data: [
+        {
+          ...SAMPLE_RESUME_ENGINEER.data[0],
+          jobIntention: "Business Development Manager",
+          selfIntro: "Focused on machine tools channel growth in Malaysia.",
+          workHistory: [
+            {
+              raw: "2021-01~2024-12 Acme Precision Sdn Bhd Business Development Manager",
+              companyName: "Acme Precision Sdn Bhd",
+              jobTitle: "Business Development Manager",
+              description: "Managed channel sales and key account manager coverage for machine tools distributors",
+              startDate: "2021-01",
+              endDate: "2024-12",
+            },
+          ],
+        },
+      ],
+    });
+
+    const salesRole = result.roleSignals.find((item) => item.type === "sales");
+
+    expect(salesRole).toBeDefined();
+    expect(salesRole?.matchedSignals).toEqual(expect.arrayContaining([
+      "business development",
+      "business development manager",
+      "channel sales",
+      "key account manager",
+    ]));
+    expect(salesRole?.years).toBeGreaterThan(3);
+  });
+
   it("should build tag envelope with confidence and provenance", () => {
     const result = service.computeOne("resume-123", SAMPLE_RESUME_CNC_SALES);
 

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -363,7 +363,24 @@ const INDUSTRY_DB_V2_CONTEXT_WEIGHTS: Record<Exclude<BrandContext, "employer">, 
   general: 0.3,
 };
 const DEFAULT_ROLE_SIGNAL_LIBRARY: Record<string, string[]> = {
-  sales: ["销售", "业务开发", "大客户", "渠道", "销售经理", "销售工程师", "sales", "account"],
+  sales: [
+    "销售",
+    "业务开发",
+    "大客户",
+    "渠道",
+    "销售经理",
+    "销售工程师",
+    "sales",
+    "account",
+    "sales engineer",
+    "sales manager",
+    "account manager",
+    "key account manager",
+    "business development",
+    "business development manager",
+    "channel sales",
+    "channel manager",
+  ],
   engineer: ["工程师", "设计", "研发", "开发", "编程", "调试", "维修", "技术", "engineer", "developer", "design"],
 };
 const ROLE_SIGNAL_MATCH_WEIGHTS = {

--- a/apps/api/src/services/resume-index.test.ts
+++ b/apps/api/src/services/resume-index.test.ts
@@ -10,10 +10,71 @@ import { ResumeIndexService } from "./resume-index";
 
 import type { ResumeItem } from "../types/resume";
 
+const TEST_SKILLS_MD = `---
+version: 1
+updated_at: '2026-03-27'
+description: Test skills knowledge file
+---
+
+# Skills Knowledge
+
+## Domain Taxonomy
+
+### machinery
+- displayName: Machinery
+- keywords: 机床, 车床, cnc, 数控, machine tools, machining center, precision machinery
+
+### sales
+- displayName: Sales
+- keywords: 销售, sales, sales engineer, business development manager, account manager
+
+### metrology
+- displayName: Metrology
+- keywords: 测量, metrology, coordinate measuring machine, quality inspection
+
+## Synonym Table
+
+- 机床: machine tools, cnc machines
+- 销售工程师: sales engineer, technical sales engineer
+- 业务拓展: business development, business development manager
+- 大客户: key account, key account manager, account manager
+- 测量: metrology, quality inspection
+- CMM: coordinate measuring machine
+
+## Experience Signals
+
+### mid
+- displayName: Mid
+- keywords: specialist
+
+## Company Patterns
+
+- FANUC [role: both] (aliases: 发那科, Fanuc)
+
+## Industry Context
+
+### Test
+Machine tools and metrology
+
+## Exclusion Patterns
+
+- exclude: ad, promo
+
+## Learning Log
+
+- 2026-03-27: test fixture
+`;
+
 function createFixtureRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "resume-index-"));
   fs.mkdirSync(path.join(root, "config", "resume"), { recursive: true });
   fs.mkdirSync(path.join(root, "config", "job-descriptions"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(root, "config", "resume", "skills.md"),
+    TEST_SKILLS_MD,
+    "utf8"
+  );
 
   fs.writeFileSync(
     path.join(root, "config", "resume", "skills_words.txt"),
@@ -184,6 +245,55 @@ describe("ResumeIndexService", () => {
 
       const index = service.buildIndex("sample:seek", resumes);
       expect(index.get("R2001")?.locationCity).toBe("Kuala Lumpur");
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("derives English manufacturing and recruiter phrases from canonical skills knowledge", () => {
+    const root = createFixtureRoot();
+
+    try {
+      const service = new ResumeIndexService(root);
+      const resumes: ResumeItem[] = [
+        {
+          name: "Alex Tan",
+          profileUrl: "https://my.employer.seek.com/candidates/2",
+          activityStatus: "Active",
+          age: "33",
+          experience: "8 years",
+          education: "Bachelor",
+          location: "Selangor, Malaysia",
+          selfIntro: "",
+          jobIntention: "Business Development Manager",
+          expectedSalary: "",
+          workHistory: [
+            {
+              raw: "2020-01~2024-12 Precision Motion Sdn Bhd Business Development Manager",
+              companyName: "Precision Motion Sdn Bhd",
+              jobTitle: "Business Development Manager",
+              description: "Handled machine tools distributors and coordinate measuring machine accounts",
+              startDate: "2020-01",
+              endDate: "2024-12",
+            },
+          ],
+          extractedAt: "2026-03-27T00:00:00.000Z",
+          resumeId: "R3001",
+          profileType: "seek",
+        },
+      ];
+
+      const index = service.buildIndex("sample:seek-english-vocab", resumes);
+      const entry = index.get("R3001");
+
+      expect(entry?.skills).toEqual(expect.arrayContaining([
+        "business development manager",
+        "machine tools",
+        "coordinate measuring machine",
+      ]));
+      expect(entry?.industryTags).toEqual(expect.arrayContaining(["machinery", "sales", "metrology"]));
+      expect(entry?.searchText).toContain("business development manager");
+      expect(entry?.searchText).toContain("machine tools");
     } finally {
       cleanupFixtureRoot(root);
     }

--- a/apps/api/src/services/skills-knowledge.test.ts
+++ b/apps/api/src/services/skills-knowledge.test.ts
@@ -18,19 +18,22 @@ description: Test skills knowledge file
 
 ### machinery
 - displayName: Machinery
-- keywords: 机床, 车床, lathe, machining, cnc, 数控, fanuc, star
+- keywords: 机床, 车床, lathe, machining, cnc, 数控, fanuc, star, machine tools, precision machinery
 
 ### sales
 - displayName: Sales
-- keywords: 销售, 客户, 销售工程师, sales, account, key account
+- keywords: 销售, 客户, 销售工程师, sales, account, key account, sales engineer, business development manager, account manager
 
 ## Synonym Table
 
-- 机床: 机械设备, 加工设备
+- 机床: 机械设备, 加工设备, machine tools, cnc machines
 - 车床: CNC车床, 数控车床, cnc lathe
 - 数控: CNC, Computer Numerical Control
 - 销售: 业务, 商务
 - 销售工程师: sales engineer, 技术销售
+- 业务拓展: business development, business development manager, bd manager
+- 大客户: 渠道客户, key account, key account manager, account manager
+- 渠道: channel sales, distributor, dealer
 - 机床销售: 车床销售, cnc销售
 - 销售岗位: 机床销售
 - 哈斯: 哈斯机床
@@ -168,6 +171,16 @@ describe("SkillsKnowledgeService", () => {
       expect(expandedFromEnglish).toContain("cnc");
       expect(expandedFromEnglish).toContain("数控");
 
+      const expandedBusinessDevelopment = service.expandQueryWithSynonyms(["Business Development Manager"]);
+      expect(expandedBusinessDevelopment).toContain("business development manager");
+      expect(expandedBusinessDevelopment).toContain("business development");
+      expect(expandedBusinessDevelopment).toContain("业务拓展");
+
+      const expandedManufacturing = service.expandQueryWithSynonyms(["machine tools"]);
+      expect(expandedManufacturing).toContain("machine tools");
+      expect(expandedManufacturing).toContain("机床");
+      expect(expandedManufacturing).toContain("cnc machines");
+
       const expandedWithDeduping = service.expandQueryWithSynonyms(["CNC", "cnc", "a"]);
       expect(expandedWithDeduping[0]).toBe("cnc");
       expect(expandedWithDeduping).not.toContain("a");
@@ -189,6 +202,8 @@ describe("SkillsKnowledgeService", () => {
       expect(vocab.has("cnc")).toBe(true);
       expect(vocab.has("销售工程师")).toBe(true);
       expect(vocab.has("销售")).toBe(true);
+      expect(vocab.has("business development manager")).toBe(true);
+      expect(vocab.has("machine tools")).toBe(true);
 
       // Synonym variants
       expect(vocab.has("机械设备")).toBe(true);

--- a/config/resume/skills.en.md
+++ b/config/resume/skills.en.md
@@ -1,6 +1,6 @@
 ---
-version: 7
-updated_at: '2026-03-13'
+version: 8
+updated_at: '2026-03-27'
 description: >
   English locale variant for the resume skills knowledge.
   Maintained alongside the zh-Hans canonical source for localized authoring.
@@ -16,15 +16,15 @@ Skills are organized by domain tags. Each domain includes a canonical tag, displ
 
 ### machinery
 - displayName: Machinery
-- keywords: 机床, 车床, 加工中心, 机械, 设备, cnc, 数控
+- keywords: 机床, 车床, 加工中心, 机械, 设备, cnc, 数控, machine tools, machining center, precision machinery, precision machining, cnc machine
 
 ### sales
 - displayName: Sales
-- keywords: 销售, 业务, 销售工程师, 业务拓展, sales, account, key account, bd, business development
+- keywords: 销售, 业务, 销售工程师, 销售经理, 业务拓展, 大客户, 渠道, sales, account, key account, bd, business development, sales engineer, sales manager, account manager, business development manager, key account manager, channel sales, channel manager
 
 ### metrology
 - displayName: Metrology
-- keywords: 测量, 三维扫描, 3d, cmm, metrology, scan
+- keywords: 测量, 三维扫描, 3d, cmm, metrology, measurement, 3d scanning, coordinate measuring machine, quality inspection, scan
 
 ### software
 - displayName: Software
@@ -34,20 +34,24 @@ Skills are organized by domain tags. Each domain includes a canonical tag, displ
 
 Maps variant terms to canonical forms for search expansion and matching normalization.
 
-- 机床: 机械设备, 加工设备
+- 机床: 机械设备, 加工设备, machine tools, cnc machine, cnc machines, precision machinery
 - 车床: CNC车床, 数控车床, cnc lathe
-- 加工中心: machining center, machining-center, 加工设备, machine tool
+- 加工中心: machining center, machining-center, vertical machining center, horizontal machining center, 加工设备, machine tool, precision machining
 - 五轴: 5-axis, 五轴联动
 - 夹具: 治具, fixture
 - 数控: CNC, Computer Numerical Control, 数控加工
 - 销售: 业务, 商务, 销售员
-- 销售工程师: sales engineer, 售前销售, 技术销售
-- 大客户: 渠道客户, key account, 关键客户
-- 机床销售: 车床销售, cnc销售, 数控机床销售
+- 销售工程师: sales engineer, technical sales, technical sales engineer, 售前销售, 技术销售
+- 销售经理: sales manager, regional sales manager, territory sales manager
+- 业务拓展: business development, business development manager, bd manager
+- 大客户: 渠道客户, key account, key account manager, account manager, 关键客户
+- 渠道: channel sales, channel manager, channel partner, channel partners, distributor, distributors, dealer, dealers
+- 机床销售: 车床销售, cnc销售, 数控机床销售, machine tool sales, cnc machine sales
+- 应用工程师: application engineer, applications engineer
 - 机器人: robot, 工业机器人
-- 测量: 计量, measurement, 质量检测
-- 三维扫描: 3D扫描, 3d-scan, 三维测量
-- CMM: 三坐标, 三坐标测量机
+- 测量: 计量, measurement, metrology, quality inspection, dimensional inspection, 质量检测
+- 三维扫描: 3D扫描, 3d-scan, 3d scanning, 3d scanner, 三维测量
+- CMM: 三坐标, 三坐标测量机, coordinate measuring machine
 - 软件: software, 程序, 应用
 
 ## Experience Signals
@@ -148,10 +152,10 @@ Background notes used for AI prompt enrichment and domain understanding.
 Machining covers CNC (Computer Numerical Control) machine tools, machining centers, lathes, and multi-axis systems. Core brands include FANUC, SIEMENS, STAR, BROTHER, and MITSUBISHI, and related CNC signals now resolve through the surviving machinery domain.
 
 ### Sales and Business Development
-B2B sales for manufacturing equipment usually requires technical product knowledge, customer relationship management, and channel development capability. Prefer composite role phrases such as sales engineer, key account, and business development instead of treating bare engineer as a sales signal.
+B2B sales for manufacturing equipment usually requires technical product knowledge, customer relationship management, and channel development capability. Prefer composite role phrases such as sales engineer, sales manager, key account, channel sales, and business development, including common English titles like account manager and business development manager, instead of treating bare engineer as a sales signal.
 
 ### Metrology and Quality
-Precision measurement relies on CMM (Coordinate Measuring Machine), 3D scanning, and quality inspection workflows, which are critical to manufacturing QA/QC.
+Precision measurement relies on CMM (Coordinate Measuring Machine), 3D scanning, and quality inspection workflows, which are critical to manufacturing QA/QC. English Seek resumes often use metrology, quality inspection, and coordinate measuring machine terminology for the same domain.
 
 ## Exclusion Patterns
 

--- a/config/resume/skills.md
+++ b/config/resume/skills.md
@@ -1,6 +1,6 @@
 ---
-version: 7
-updated_at: '2026-03-13'
+version: 8
+updated_at: '2026-03-27'
 description: >
   简历筛选技能知识库（zh-Hans 主文件）。
   用于背景计算代理的确定性匹配、同义词扩展与预评分。
@@ -17,15 +17,15 @@ description: >
 
 ### machinery
 - displayName: 机械
-- keywords: 机床, 车床, 加工中心, 机械, 设备, cnc, 数控
+- keywords: 机床, 车床, 加工中心, 机械, 设备, cnc, 数控, machine tools, machining center, precision machinery, precision machining, cnc machine
 
 ### sales
 - displayName: 销售
-- keywords: 销售, 业务, 销售工程师, 业务拓展, sales, account, key account, bd, business development
+- keywords: 销售, 业务, 销售工程师, 销售经理, 业务拓展, 大客户, 渠道, sales, account, key account, bd, business development, sales engineer, sales manager, account manager, business development manager, key account manager, channel sales, channel manager
 
 ### metrology
 - displayName: 测量
-- keywords: 测量, 三维扫描, 3d, cmm, metrology, scan
+- keywords: 测量, 三维扫描, 3d, cmm, metrology, measurement, 3d scanning, coordinate measuring machine, quality inspection, scan
 
 ### software
 - displayName: 软件
@@ -35,20 +35,24 @@ description: >
 
 将变体术语映射到标准形式，用于搜索扩展与匹配归一化。
 
-- 机床: 机械设备, 加工设备
+- 机床: 机械设备, 加工设备, machine tools, cnc machine, cnc machines, precision machinery
 - 车床: CNC车床, 数控车床, cnc lathe
-- 加工中心: machining center, machining-center, 加工设备, machine tool
+- 加工中心: machining center, machining-center, vertical machining center, horizontal machining center, 加工设备, machine tool, precision machining
 - 五轴: 5-axis, 五轴联动
 - 夹具: 治具, fixture
 - 数控: CNC, Computer Numerical Control, 数控加工
 - 销售: 业务, 商务, 销售员
-- 销售工程师: sales engineer, 售前销售, 技术销售
-- 大客户: 渠道客户, key account, 关键客户
-- 机床销售: 车床销售, cnc销售, 数控机床销售
+- 销售工程师: sales engineer, technical sales, technical sales engineer, 售前销售, 技术销售
+- 销售经理: sales manager, regional sales manager, territory sales manager
+- 业务拓展: business development, business development manager, bd manager
+- 大客户: 渠道客户, key account, key account manager, account manager, 关键客户
+- 渠道: channel sales, channel manager, channel partner, channel partners, distributor, distributors, dealer, dealers
+- 机床销售: 车床销售, cnc销售, 数控机床销售, machine tool sales, cnc machine sales
+- 应用工程师: application engineer, applications engineer
 - 机器人: robot, 工业机器人
-- 测量: 计量, measurement, 质量检测
-- 三维扫描: 3D扫描, 3d-scan, 三维测量
-- CMM: 三坐标, 三坐标测量机
+- 测量: 计量, measurement, metrology, quality inspection, dimensional inspection, 质量检测
+- 三维扫描: 3D扫描, 3d-scan, 3d scanning, 3d scanner, 三维测量
+- CMM: 三坐标, 三坐标测量机, coordinate measuring machine
 - 软件: software, 程序, 应用
 
 ## 经验等级信号
@@ -149,10 +153,10 @@ description: >
 机械加工场景包含 CNC（Computer Numerical Control，计算机数控）机床、加工中心、车床与五轴系统。核心品牌包括 FANUC、SIEMENS、STAR、BROTHER 与 MITSUBISHI，相关数控信号统一归入 machinery 领域。
 
 ### 销售与业务拓展
-制造业设备 B2B 销售通常需要设备技术理解、客户关系管理与渠道开发能力。优先关注销售工程师、大客户与业务拓展等复合角色表达，避免将泛化 engineer 词汇直接视为销售信号。
+制造业设备 B2B 销售通常需要设备技术理解、客户关系管理与渠道开发能力。优先关注销售工程师、销售经理、大客户、渠道销售与业务拓展等复合角色表达，覆盖常见英文头衔如 sales engineer、account manager、business development manager，避免将泛化 engineer 词汇直接视为销售信号。
 
 ### 测量与质量
-精密测量通常依赖 CMM（三坐标测量机）、3D 扫描与质量检测流程，是制造业 QA/QC 的关键环节。
+精密测量通常依赖 CMM（三坐标测量机）、3D 扫描与质量检测流程，是制造业 QA/QC 的关键环节；英文 Seek 简历中常见的 metrology、quality inspection 与 coordinate measuring machine 也应归入同一测量语义。
 
 ## 排除模式
 


### PR DESCRIPTION
## Summary
- expand zh-Hans and English resume skills vocab for English manufacturing and recruiter phrases
- broaden English sales role signal detection for work-history scoring
- add focused tests for synonym expansion, resume indexing, and ingest role signals

## Validation
- bun test apps/api/src/services/skills-knowledge.test.ts apps/api/src/services/resume-index.test.ts apps/api/src/services/ingest-compute-service.test.ts
- bun scripts/resume/check-skills-locales.ts
- make check