### PR TITLE
fix: widen convex keyword search window

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -444,6 +444,129 @@ describe("resume routes", () => {
     }));
   });
 
+  it("keeps filtered keyword searches on the paged convex route for sparse seek lanes", async () => {
+    const calls: ConvexCall[] = [];
+    const keeKimLoong = buildConvexResumeRecord("resume-live-5", {
+      name: "Kee Kim Loong",
+      source: "hk.employer.seek.com",
+      ingestData: {
+        industryTags: ["机械", "销售"],
+        companyHits: [],
+        brandHits: [],
+        roleSignals: [
+          { type: "sales", matchedSignals: ["sales", "sales engineer"] },
+          { type: "engineer", matchedSignals: ["engineer"] },
+        ],
+      },
+    });
+    keeKimLoong.content = {
+      ...keeKimLoong.content,
+      location: "Kuala Lumpur, MY",
+    };
+    const johnsonLeeWeiTao = buildConvexResumeRecord("resume-live-6", {
+      name: "Johnson Lee Wei Tao",
+      source: "hk.employer.seek.com",
+      ingestData: {
+        industryTags: ["销售"],
+        companyHits: [],
+        brandHits: [],
+        roleSignals: [
+          { type: "sales", matchedSignals: ["sales", "sales engineer", "account"] },
+          { type: "engineer", matchedSignals: ["engineer", "design"] },
+        ],
+      },
+    });
+    johnsonLeeWeiTao.content = {
+      ...johnsonLeeWeiTao.content,
+      location: "Kuala Lumpur, MY",
+    };
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:searchWithTagExpansionPage") {
+        return convexSuccess({
+          expansion: {
+            original: "\"machine tools\"",
+            expanded: [
+              "machine tools",
+              "机床",
+              "机械设备",
+              "加工设备",
+              "加工中心",
+              "cnc machine",
+              "cnc machines",
+              "precision machinery",
+            ],
+            groups: [
+              {
+                original: "machine tools",
+                variants: [
+                  "machine tools",
+                  "机床",
+                  "机械设备",
+                  "加工设备",
+                  "加工中心",
+                  "cnc machine",
+                  "cnc machines",
+                  "precision machinery",
+                ],
+              },
+            ],
+            mode: "AND",
+          },
+          results: [
+            {
+              resume: keeKimLoong,
+              provenance: [{ term: "machine tools", source: "searchText" }],
+            },
+            {
+              resume: johnsonLeeWeiTao,
+              provenance: [{ term: "precision machinery", source: "searchText", expandedFrom: "machine tools" }],
+            },
+          ],
+          total: 2,
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request(
+      "/api/resumes?source=convex&q=%22machine%20tools%22&locations=Kuala%20Lumpur%20MY&jobDescriptionId=seek-malaysia-sales&limit=5"
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.summary).toEqual(expect.objectContaining({
+      total: 2,
+      returned: 2,
+      source: "convex",
+      query: "\"machine tools\"",
+    }));
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual([
+      "Kee Kim Loong",
+      "Johnson Lee Wei Tao",
+    ]);
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:searchWithTagExpansionPage",
+      args: expect.objectContaining({
+        limit: 5,
+        locations: ["Kuala Lumpur MY"],
+        jobDescriptionId: "seek-malaysia-sales",
+        keywordGroups: expect.arrayContaining([
+          expect.objectContaining({
+            original: "machine tools",
+            variants: expect.arrayContaining(["machine tools", "precision machinery"]),
+          }),
+        ]),
+      }),
+    }));
+  });
+
   it("keeps source pagination when resume filters are pushed into the convex page query", async () => {
     const calls: ConvexCall[] = [];
 

--- a/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
+++ b/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { projectIngestDiagnosticsRow, resolveListWithIngestWindow, resolveResumeScanBatchSize } from "../resumes";
+import {
+    projectIngestDiagnosticsRow,
+    resolveListWithIngestWindow,
+    resolveResumeScanBatchSize,
+    resolveSearchWithTagExpansionTakeLimit,
+} from "../resumes";
 
 describe("resolveListWithIngestWindow", () => {
     it("uses the default list window when no limit is provided", () => {
@@ -25,6 +30,25 @@ describe("resolveResumeScanBatchSize", () => {
 
     it("clamps oversized scan batches to the safe maximum", () => {
         expect(resolveResumeScanBatchSize(5_000)).toBe(50);
+    });
+});
+
+describe("resolveSearchWithTagExpansionTakeLimit", () => {
+    it("keeps the default narrow overfetch for unconstrained keyword pages", () => {
+        expect(resolveSearchWithTagExpansionTakeLimit({
+            limit: 5,
+            offset: 0,
+            hasFilters: false,
+        })).toBe(15);
+    });
+
+    it("widens the search take window for filtered job-scoped keyword pages", () => {
+        expect(resolveSearchWithTagExpansionTakeLimit({
+            limit: 5,
+            offset: 0,
+            hasFilters: true,
+            jobDescriptionId: "jd-seek-malaysia-sales",
+        })).toBe(250);
     });
 });
 

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -411,6 +411,25 @@ export function resolveListWithIngestWindow(requestedLimit: number | undefined):
     };
 }
 
+export function resolveSearchWithTagExpansionTakeLimit(params: {
+    limit: number | undefined;
+    offset: number | undefined;
+    hasFilters: boolean;
+    jobDescriptionId?: string;
+}): number {
+    const { offset, pageLimit, overfetchLimit } = resolveListWithIngestPageWindow(params.limit, params.offset);
+    const requestedWindow = offset + pageLimit;
+
+    if (!params.hasFilters && !params.jobDescriptionId?.trim()) {
+        return overfetchLimit;
+    }
+
+    return Math.min(
+        Math.max(overfetchLimit, requestedWindow, MAX_SAFE_JD_PAGINATE_SCAN),
+        MAX_SAFE_LIST_WITH_INGEST_OVERFETCH,
+    );
+}
+
 function projectResumeBaseContent(
     resume: Doc<"resumes">,
     workHistory: unknown,
@@ -1162,7 +1181,7 @@ async function runSearchWithTagExpansionPageQuery(
     total: number;
     results: Array<{ resume: Doc<"resumes">; provenance: SearchProvenance[] }>;
 }> {
-    const { offset, pageLimit, overfetchLimit } = resolveListWithIngestPageWindow(args.limit, args.offset);
+    const { offset, pageLimit } = resolveListWithIngestPageWindow(args.limit, args.offset);
     const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
     const filters = normalizeResumeListFilters(args);
     const mode = args.mode ?? "AND";
@@ -1187,12 +1206,18 @@ async function runSearchWithTagExpansionPageQuery(
     );
     const provenanceByResumeId = new Map<string, SearchProvenance[]>();
     const searchQuery = buildTagExpansionSearchQuery(keywordGroups, mode);
+    const takeLimit = resolveSearchWithTagExpansionTakeLimit({
+        limit: args.limit,
+        offset: args.offset,
+        hasFilters: filters !== undefined,
+        jobDescriptionId,
+    });
 
     const matches = searchQuery
         ? await ctx.db
             .query("resumes")
             .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery))
-            .take(overfetchLimit)
+            .take(takeLimit)
         : [];
 
     const filteredDocs = matches.filter((doc) => {
@@ -1212,7 +1237,7 @@ async function runSearchWithTagExpansionPageQuery(
         return true;
     });
 
-    const merged = mergeResumeDocs(filteredDocs, provenanceByResumeId, jobDescriptionId, overfetchLimit)
+    const merged = mergeResumeDocs(filteredDocs, provenanceByResumeId, jobDescriptionId, takeLimit)
         .filter((entry) => matchesResumeListFilters(entry.resume, filters));
     let sorted = merged;
     if (args.sortBy) {


### PR DESCRIPTION
## Summary
- widen the Convex tag-expansion take window for filtered or job-scoped keyword pages
- keep the default narrow overfetch for unconstrained keyword pages
- add Convex and API regressions for sparse SEEK filtered keyword searches

## Testing
- npx vitest run /root/workspace/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
- npx vitest run /root/workspace/apps/api/src/routes/resumes.test.ts
- make check