### PR TITLE
fix: push required keyword filters into paging

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -567,6 +567,47 @@ describe("resume routes", () => {
     }));
   });
 
+  it("pushes required keywords into paged convex keyword searches", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:searchWithTagExpansionPage") {
+        return convexSuccess({
+          expansion: {
+            original: "cnc sales",
+            expanded: ["cnc", "sales"],
+            groups: [
+              { original: "cnc", variants: ["cnc"] },
+              { original: "sales", variants: ["sales"] },
+            ],
+            mode: "AND",
+          },
+          results: [
+            { resume: buildConvexResumeRecord("resume-live-3", { name: "Carla" }), provenance: [{ term: "sales", source: "searchText" }] },
+          ],
+          total: 1,
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&q=cnc%20sales&limit=2&requiredKeywords=machine%20tools,CNC");
+
+    expect(response.status).toBe(200);
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:searchWithTagExpansionPage",
+      args: expect.objectContaining({
+        limit: 2,
+        requiredKeywords: ["machine tools", "cnc"],
+      }),
+    }));
+  });
+
   it("keeps source pagination when resume filters are pushed into the convex page query", async () => {
     const calls: ConvexCall[] = [];
 
@@ -588,7 +629,7 @@ describe("resume routes", () => {
     });
 
     const app = createApp();
-    const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&locations=%E4%B8%9C%E8%8E%9E");
+    const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&locations=%E4%B8%9C%E8%8E%9E&requiredKeywords=CNC");
 
     expect(response.status).toBe(200);
     const payload = await response.json();
@@ -596,7 +637,7 @@ describe("resume routes", () => {
     expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Dylan"]);
     expect(calls[0]).toEqual(expect.objectContaining({
       pathName: "resumes:listWithIngestDataPage",
-      args: expect.objectContaining({ limit: 2, offset: 2, locations: ["东莞"] }),
+      args: expect.objectContaining({ limit: 2, offset: 2, locations: ["东莞"], requiredKeywords: ["cnc"] }),
     }));
   });
 

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -832,6 +832,7 @@ async function prepareConvexCandidates(params: {
     maxExperience?: number;
     education?: string[];
     skills?: string[];
+    requiredKeywords?: string[];
     locations?: string[];
     minSalary?: number;
     maxSalary?: number;

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -972,6 +972,7 @@ function hasResumeListFilters(params: {
   maxExperience?: number;
   education?: string[];
   skills?: string[];
+  requiredKeywords?: string[];
   locations?: string[];
   minSalary?: number;
   maxSalary?: number;
@@ -980,6 +981,7 @@ function hasResumeListFilters(params: {
     || typeof params.maxExperience === "number"
     || (params.education?.length ?? 0) > 0
     || (params.skills?.length ?? 0) > 0
+    || (params.requiredKeywords?.length ?? 0) > 0
     || (params.locations?.length ?? 0) > 0
     || typeof params.minSalary === "number"
     || typeof params.maxSalary === "number";
@@ -1743,6 +1745,7 @@ app.openapi(getResumesRoute, (c) => {
     maxExperience,
     education,
     skills,
+    requiredKeywords,
     locations,
     minSalary,
     maxSalary,
@@ -1762,6 +1765,7 @@ app.openapi(getResumesRoute, (c) => {
       return (async () => {
         const resolvedJobId = jobDescriptionId?.trim() || undefined;
         const normalizedKeywords = keyword ? normalizeKeywords(parseKeywordQuery(keyword).keywords) : [];
+        const normalizedRequiredKeywords = normalizeKeywords(requiredKeywords);
         const normalizedRecommendations = normalizeMatchRecommendations(recommendation);
         const hasLocalMatchFilters = minMatchScore !== undefined || (normalizedRecommendations?.length ?? 0) > 0;
         const hasLocalResumeFilters = hasResumeListFilters({
@@ -1769,6 +1773,7 @@ app.openapi(getResumesRoute, (c) => {
           maxExperience,
           education,
           skills,
+          requiredKeywords: normalizedRequiredKeywords,
           locations,
           minSalary,
           maxSalary,
@@ -1821,6 +1826,7 @@ app.openapi(getResumesRoute, (c) => {
                   maxExperience,
                   education,
                   skills,
+                  requiredKeywords: normalizedRequiredKeywords,
                   locations,
                   minSalary,
                   maxSalary,
@@ -1840,6 +1846,7 @@ app.openapi(getResumesRoute, (c) => {
           maxExperience,
           education,
           skills,
+          requiredKeywords: normalizedRequiredKeywords,
           locations,
           minSalary,
           maxSalary,
@@ -1955,6 +1962,7 @@ app.openapi(getResumesRoute, (c) => {
       maxExperience,
       education,
       skills,
+      requiredKeywords: normalizeKeywords(requiredKeywords),
       locations,
       minSalary,
       maxSalary,

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -509,6 +509,10 @@ export const ResumesQuerySchema = z.object({
     param: { name: "skills", in: "query" },
     example: "CNC,FANUC",
   }),
+  requiredKeywords: CsvStringArraySchema.openapi({
+    param: { name: "requiredKeywords", in: "query" },
+    example: "machine tools,CNC",
+  }),
   locations: CsvStringArraySchema.openapi({
     param: { name: "locations", in: "query" },
     example: "东莞,深圳",

--- a/apps/api/src/services/resume-service.test.ts
+++ b/apps/api/src/services/resume-service.test.ts
@@ -132,6 +132,49 @@ describe("ResumeService", () => {
     expect(locationMatches.map((item) => item.name)).toEqual(["Yap Kae Wen"]);
   });
 
+  it("applies required keyword filters with all-keyword semantics", () => {
+    const root = createFixtureRoot();
+    roots.push(root);
+
+    const service = new ResumeService(root);
+    const items = [
+      {
+        name: "Both Terms",
+        profileUrl: "https://example.com/both",
+        activityStatus: "Active",
+        age: "30",
+        experience: "5 years",
+        education: "Bachelor",
+        location: "Dongguan",
+        selfIntro: "",
+        jobIntention: "Sales Engineer",
+        expectedSalary: "10k-20k",
+        workHistory: [{ raw: "2020-2025 machine tools cnc sales engineer" }],
+        extractedAt: "2026-03-27T00:00:00.000Z",
+      },
+      {
+        name: "One Term",
+        profileUrl: "https://example.com/one",
+        activityStatus: "Active",
+        age: "29",
+        experience: "4 years",
+        education: "Bachelor",
+        location: "Dongguan",
+        selfIntro: "",
+        jobIntention: "Sales Engineer",
+        expectedSalary: "10k-20k",
+        workHistory: [{ raw: "2020-2025 machine tools sales engineer" }],
+        extractedAt: "2026-03-27T00:00:00.000Z",
+      },
+    ];
+
+    const filtered = service.filterResumes(items, {
+      requiredKeywords: ["machine tools", "cnc"],
+    });
+
+    expect(filtered.map((item) => item.name)).toEqual(["Both Terms"]);
+  });
+
   it("still normalizes Job5156 sample profile URLs into canonical display URLs", () => {
     const root = createFixtureRoot();
     roots.push(root);

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -4,6 +4,7 @@ import {
   buildWorkHistoryEntryText,
   formatLocationHierarchySearchText,
   isLocationMatch,
+  normalizeKeywordPhrases,
   normalizeProfileUrlForDisplay,
   normalizeSharedResumeFields,
   selectLatestWorkHistory,
@@ -43,6 +44,7 @@ export type ResumeFilters = {
   maxExperience?: number;
   education?: string[];
   skills?: string[];
+  requiredKeywords?: string[];
   locations?: string[];
   minSalary?: number;
   maxSalary?: number;
@@ -253,6 +255,20 @@ function buildSearchText(item: ResumeItem): string {
     ...latestWorkHistory.map((entry) => buildWorkHistoryEntryText(entry)),
   ];
   return parts.join(" ").toLowerCase();
+}
+
+function matchesAllRequiredKeywords(text: string, requiredKeywords: string[] | undefined): boolean {
+  const normalizedKeywords = normalizeKeywordPhrases(requiredKeywords ?? []).map((keyword) => keyword.toLowerCase());
+  if (normalizedKeywords.length === 0) {
+    return true;
+  }
+
+  const haystack = text.trim().toLowerCase();
+  if (!haystack) {
+    return false;
+  }
+
+  return normalizedKeywords.every((keyword) => haystack.includes(keyword));
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -574,6 +590,11 @@ export class ResumeService {
         const haystack = buildSearchText(item);
         const hasSkill = filters.skills.some((skill) => haystack.includes(skill.toLowerCase()));
         if (!hasSkill) return false;
+      }
+
+      if (filters.requiredKeywords?.length) {
+        const haystack = buildSearchText(item);
+        if (!matchesAllRequiredKeywords(haystack, filters.requiredKeywords)) return false;
       }
 
       if (filters.minSalary !== undefined || filters.maxSalary !== undefined) {

--- a/apps/web/src/hooks/useConvexResumes.test.ts
+++ b/apps/web/src/hooks/useConvexResumes.test.ts
@@ -147,6 +147,7 @@ describe('useConvexResumes', () => {
         maxExperience: 8,
         education: ['bachelor'],
         skills: ['fanuc'],
+        requiredKeywords: ['machine tools', 'cnc'],
         locations: ['Dongguan'],
         minSalary: 10,
         maxSalary: 20,
@@ -161,6 +162,7 @@ describe('useConvexResumes', () => {
       maxExperience: 8,
       education: ['bachelor'],
       skills: ['fanuc'],
+      requiredKeywords: ['machine tools', 'cnc'],
       locations: ['Dongguan'],
       minSalary: 10,
       maxSalary: 20,
@@ -186,6 +188,33 @@ describe('useConvexResumes', () => {
       expect(searchCall?.[1]).toMatchObject({
         query: 'CNC',
         keywordGroups: [{ original: 'cnc', variants: ['cnc'] }],
+      })
+    })
+  })
+
+  it('forwards required keywords to the paginated search query', async () => {
+    usePaginatedQueryMock.mockImplementation((_query, args) => ({
+      results: args === 'skip' ? [] : [buildSearchEntry('resume-1', 'Alice')],
+      status: 'Exhausted',
+      isLoading: false,
+      loadMore: loadMoreMock,
+    }))
+
+    renderHook(() => useConvexResumes(200, 'CNC', 'jd-1', {
+      filters: {
+        requiredKeywords: ['machine tools', 'cnc'],
+      },
+    }))
+
+    await waitFor(() => {
+      expect(rawApiGetMock).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      const searchCall = usePaginatedQueryMock.mock.calls.find(([, args]) => args !== 'skip' && 'query' in (args as Record<string, unknown>))
+      expect(searchCall?.[1]).toMatchObject({
+        jobDescriptionId: 'jd-1',
+        requiredKeywords: ['machine tools', 'cnc'],
       })
     })
   })

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -17,6 +17,7 @@ export type ConvexResumeFilters = {
   maxExperience?: number
   education?: string[]
   skills?: string[]
+  requiredKeywords?: string[]
   locations?: string[]
   minSalary?: number
   maxSalary?: number

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -54,7 +54,6 @@ import {
 import {
   buildLearningObservation,
   buildResumeKey,
-  buildRuleScoringText,
   computeDirectIndustryDb,
   getAnalysisForJob,
   hasIngestData,
@@ -552,6 +551,23 @@ function buildResumeFilterSearchText(resume: ConvexResumeItem): string {
     .join(' ')
 }
 
+function matchesAllRequiredKeywords(text: string, requiredKeywords: string[]): boolean {
+  const normalizedKeywords = normalizeKeywordPhrases(requiredKeywords)
+    .map((keyword) => normalizeFilterToken(keyword))
+    .filter((keyword) => keyword.length > 0)
+
+  if (normalizedKeywords.length === 0) {
+    return true
+  }
+
+  const haystack = text.trim().toLowerCase()
+  if (!haystack) {
+    return false
+  }
+
+  return normalizedKeywords.every((keyword) => haystack.includes(keyword))
+}
+
 export function useResumeListState(loadSearchHistory = false) {
   const { t } = useTranslation()
   const location = useLocation()
@@ -717,13 +733,14 @@ export function useResumeListState(loadSearchHistory = false) {
       ...(typeof filters.maxExperience === 'number' ? { maxExperience: filters.maxExperience } : {}),
       ...(Array.isArray(filters.education) && filters.education.length > 0 ? { education: filters.education } : {}),
       ...(Array.isArray(filters.skills) && filters.skills.length > 0 ? { skills: filters.skills } : {}),
+      ...(requiredKeywords.length > 0 ? { requiredKeywords } : {}),
       ...(Array.isArray(filters.locations) && filters.locations.length > 0 ? { locations: filters.locations } : {}),
       ...(typeof filters.minSalary === 'number' ? { minSalary: filters.minSalary } : {}),
       ...(typeof filters.maxSalary === 'number' ? { maxSalary: filters.maxSalary } : {}),
     }
 
     return Object.keys(normalized).length > 0 ? normalized : undefined
-  }, [filters.education, filters.locations, filters.maxExperience, filters.maxSalary, filters.minExperience, filters.minSalary, filters.skills])
+  }, [filters.education, filters.locations, filters.maxExperience, filters.maxSalary, filters.minExperience, filters.minSalary, filters.skills, requiredKeywords])
   const convexQueryScopeKey = useMemo(
     () => JSON.stringify({
       jobDescriptionId: jobDescriptionId?.trim() ?? '',
@@ -1394,10 +1411,9 @@ export function useResumeListState(loadSearchHistory = false) {
     }
 
     if (requiredKeywords.length > 0) {
-      const normalizedRequired = requiredKeywords.map(normalizeFilterToken).filter((kw) => kw.length > 0)
       result = result.filter((resume: ScoredConvexResume) => {
-        const text = buildRuleScoringText(resume).toLowerCase()
-        return normalizedRequired.every((kw) => text.includes(kw))
+        const text = buildResumeFilterSearchText(resume)
+        return matchesAllRequiredKeywords(text, requiredKeywords)
       })
     }
 

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -368,6 +368,7 @@ export interface paths {
                     maxExperience?: string;
                     education?: string[];
                     skills?: string[];
+                    requiredKeywords?: string[];
                     locations?: string[];
                     minSalary?: string;
                     maxSalary?: string;

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -11,6 +11,7 @@ import {
     formatLocationHierarchyLabel,
     isResumeAnalysisKeyForJobDescription,
     isLocationMatch,
+    normalizeKeywordPhrases,
     normalizeResumeLocationHierarchy,
     resolveResumeAnalysisSourceKey,
     selectLatestWorkHistory,
@@ -259,6 +260,7 @@ type ResumeListFilterArgs = {
     maxExperience?: number;
     education?: string[];
     skills?: string[];
+    requiredKeywords?: string[];
     locations?: string[];
     minSalary?: number;
     maxSalary?: number;
@@ -589,6 +591,9 @@ function normalizeResumeListFilters(filters: ResumeListFilterArgs | undefined): 
 
     const education = filters.education?.map((value) => value.trim().toLowerCase()).filter((value) => value.length > 0);
     const skills = filters.skills?.map((value) => value.trim().toLowerCase()).filter((value) => value.length > 0);
+    const requiredKeywords = normalizeKeywordPhrases(filters.requiredKeywords ?? [])
+        .map((value) => value.toLowerCase())
+        .filter((value) => value.length > 0);
     const locations = filters.locations?.map((value) => value.trim()).filter((value) => value.length > 0);
 
     const normalized: ResumeListFilterArgs = {
@@ -596,6 +601,7 @@ function normalizeResumeListFilters(filters: ResumeListFilterArgs | undefined): 
         ...(filters.maxExperience === undefined ? {} : { maxExperience: filters.maxExperience }),
         ...(education && education.length > 0 ? { education } : {}),
         ...(skills && skills.length > 0 ? { skills } : {}),
+        ...(requiredKeywords.length > 0 ? { requiredKeywords } : {}),
         ...(locations && locations.length > 0 ? { locations } : {}),
         ...(filters.minSalary === undefined ? {} : { minSalary: filters.minSalary }),
         ...(filters.maxSalary === undefined ? {} : { maxSalary: filters.maxSalary }),
@@ -673,6 +679,21 @@ function buildResumeFilterSearchText(content: Record<string, unknown>): string {
     return parts.join(" ").toLowerCase();
 }
 
+function matchesAllRequiredKeywords(text: string, requiredKeywords: string[] | undefined): boolean {
+    const normalizedKeywords = normalizeKeywordPhrases(requiredKeywords ?? [])
+        .map((keyword) => keyword.toLowerCase());
+    if (normalizedKeywords.length === 0) {
+        return true;
+    }
+
+    const haystack = text.trim().toLowerCase();
+    if (!haystack) {
+        return false;
+    }
+
+    return normalizedKeywords.every((keyword) => haystack.includes(keyword));
+}
+
 function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFilterArgs | undefined): boolean {
     if (!filters) {
         return true;
@@ -712,6 +733,13 @@ function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFil
         const haystack = buildResumeFilterSearchText(content);
         const hasSkill = filters.skills.some((skill) => haystack.includes(skill));
         if (!hasSkill) {
+            return false;
+        }
+    }
+
+    if (filters.requiredKeywords?.length) {
+        const haystack = buildResumeFilterSearchText(content);
+        if (!matchesAllRequiredKeywords(haystack, filters.requiredKeywords)) {
             return false;
         }
     }
@@ -1389,6 +1417,7 @@ export const listWithIngestDataPage = query({
         maxExperience: v.optional(v.number()),
         education: v.optional(v.array(v.string())),
         skills: v.optional(v.array(v.string())),
+        requiredKeywords: v.optional(v.array(v.string())),
         locations: v.optional(v.array(v.string())),
         minSalary: v.optional(v.number()),
         maxSalary: v.optional(v.number()),
@@ -1412,6 +1441,7 @@ export const listWithIngestDataPaginated = query({
         maxExperience: v.optional(v.number()),
         education: v.optional(v.array(v.string())),
         skills: v.optional(v.array(v.string())),
+        requiredKeywords: v.optional(v.array(v.string())),
         locations: v.optional(v.array(v.string())),
         minSalary: v.optional(v.number()),
         maxSalary: v.optional(v.number()),
@@ -1674,6 +1704,7 @@ export const searchWithTagExpansionPage = query({
         maxExperience: v.optional(v.number()),
         education: v.optional(v.array(v.string())),
         skills: v.optional(v.array(v.string())),
+        requiredKeywords: v.optional(v.array(v.string())),
         locations: v.optional(v.array(v.string())),
         minSalary: v.optional(v.number()),
         maxSalary: v.optional(v.number()),
@@ -1711,6 +1742,7 @@ export const searchWithTagExpansionPaginated = query({
         maxExperience: v.optional(v.number()),
         education: v.optional(v.array(v.string())),
         skills: v.optional(v.array(v.string())),
+        requiredKeywords: v.optional(v.array(v.string())),
         locations: v.optional(v.array(v.string())),
         minSalary: v.optional(v.number()),
         maxSalary: v.optional(v.number()),


### PR DESCRIPTION
## Summary
- push `requiredKeywords` into the paged Convex and `/api/resumes` filter contract instead of leaving it client-only
- keep direct web Convex pagination and BFF paging aligned for required-keyword search profiles
- add focused API, service, and web-hook regressions plus regenerate the web API types

## Testing
- npx vitest run /root/workspace/apps/api/src/services/resume-service.test.ts
- npx vitest run /root/workspace/apps/api/src/routes/resumes.test.ts
- npm --workspace @trends/web exec vitest run src/hooks/useConvexResumes.test.ts src/hooks/useResumeListState.test.tsx
- npx vitest run /root/workspace/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
- npm --workspace @trends/web run gen:api
- make check