### PR TITLE
fix: widen convex post-filter fetch window

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -673,6 +673,95 @@ describe("resume routes", () => {
     }));
   });
 
+  it("widens the convex fetch window when score sorting falls back to local resume filters", async () => {
+    const calls: ConvexCall[] = [];
+    const getMatchesPageSpy = vi.spyOn(MatchStorage.prototype, "getMatchesPageForJob");
+    const getMatchesByResumeIdsSpy = vi
+      .spyOn(MatchStorage.prototype, "getMatchesByResumeIds")
+      .mockReturnValue([
+        buildStoredMatch("resume-live-3", { id: 3, score: 96 }),
+        buildStoredMatch("resume-live-1", { id: 1, score: 81 }),
+      ]);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:listWithIngestData") {
+        return convexSuccess([
+          buildConvexResumeRecord("resume-live-1", { name: "Alice" }),
+          buildConvexResumeRecord("resume-live-3", { name: "Carla" }),
+        ]);
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&limit=2&sortBy=score&jobDescriptionId=jd-1&locations=%E4%B8%9C%E8%8E%9E");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Alice"]);
+    expect(getMatchesPageSpy).not.toHaveBeenCalled();
+    expect(getMatchesByResumeIdsSpy).toHaveBeenCalledWith(["resume-live-1", "resume-live-3"], "jd-1");
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:listWithIngestData",
+      args: expect.objectContaining({ limit: 250, jobDescriptionId: "jd-1" }),
+    }));
+  });
+
+  it("widens the convex fetch window when score-sorted keyword searches cannot use match-storage pagination", async () => {
+    const calls: ConvexCall[] = [];
+    const getMatchesPageSpy = vi.spyOn(MatchStorage.prototype, "getMatchesPageForJob");
+    const getMatchesByResumeIdsSpy = vi
+      .spyOn(MatchStorage.prototype, "getMatchesByResumeIds")
+      .mockReturnValue([
+        buildStoredMatch("resume-live-3", { id: 3, score: 96 }),
+        buildStoredMatch("resume-live-1", { id: 1, score: 81 }),
+      ]);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:searchWithTagExpansion") {
+        return convexSuccess({
+          expansion: {
+            original: "cnc sales",
+            expanded: ["cnc", "sales"],
+            groups: [
+              { original: "cnc", variants: ["cnc"] },
+              { original: "sales", variants: ["sales"] },
+            ],
+            mode: "AND",
+          },
+          results: [
+            { resume: buildConvexResumeRecord("resume-live-1", { name: "Alice" }), provenance: [{ term: "sales", source: "searchText" }] },
+            { resume: buildConvexResumeRecord("resume-live-3", { name: "Carla" }), provenance: [{ term: "cnc", source: "searchText" }] },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&limit=2&sortBy=score&jobDescriptionId=jd-1&q=cnc%20sales");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Alice"]);
+    expect(getMatchesPageSpy).not.toHaveBeenCalled();
+    expect(getMatchesByResumeIdsSpy).toHaveBeenCalledWith(["resume-live-1", "resume-live-3"], "jd-1");
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:searchWithTagExpansion",
+      args: expect.objectContaining({ limit: 250, jobDescriptionId: "jd-1" }),
+    }));
+  });
+
   it("pages score-sorted convex results through match storage and preserves explicit-id order", async () => {
     const calls: ConvexCall[] = [];
     const getMatchesPageSpy = vi

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -131,6 +131,8 @@ const feedbackSummaryService = new FeedbackSummaryService();
 
 const DEFAULT_AI_TOP_N = 20;
 const DEFAULT_CONVEX_RESUME_PAGE_SIZE = 50;
+const MAX_SAFE_CONVEX_POST_FILTER_SCAN = 250;
+const MAX_SAFE_CONVEX_POST_FILTER_LIMIT = 2000;
 
 type MatchMode = "rules_only" | "hybrid" | "ai_only";
 
@@ -959,13 +961,29 @@ async function prepareConvexCandidates(params: {
   };
 }
 
-function resolveConvexResumeFetchLimit(limit: number | undefined, offset: number | undefined): number | undefined {
-  if (typeof offset !== "number" || offset <= 0) {
-    return limit;
+function resolveConvexResumeFetchLimit(params: {
+  limit: number | undefined;
+  offset: number | undefined;
+  requiresMatchPagination: boolean;
+  hasLocalResumeFilters: boolean;
+  hasKeywordQuery: boolean;
+}): number | undefined {
+  const pageSize = typeof params.limit === "number" ? params.limit : DEFAULT_CONVEX_RESUME_PAGE_SIZE;
+  const requestedOffset = typeof params.offset === "number" && params.offset > 0 ? params.offset : 0;
+  const requestedWindow = requestedOffset + pageSize;
+
+  if (!params.requiresMatchPagination) {
+    return params.limit;
   }
 
-  const pageSize = typeof limit === "number" ? limit : DEFAULT_CONVEX_RESUME_PAGE_SIZE;
-  return offset + pageSize;
+  if (!params.hasLocalResumeFilters && !params.hasKeywordQuery) {
+    return requestedWindow;
+  }
+
+  return Math.min(
+    Math.max(requestedWindow, MAX_SAFE_CONVEX_POST_FILTER_SCAN),
+    MAX_SAFE_CONVEX_POST_FILTER_LIMIT,
+  );
 }
 
 function hasResumeListFilters(params: {
@@ -1814,7 +1832,13 @@ app.openapi(getResumesRoute, (c) => {
             })).prepared;
           }
         } else {
-          const convexFetchLimit = canUseSourcePagination ? limit : resolveConvexResumeFetchLimit(limit, offset);
+          const convexFetchLimit = canUseSourcePagination ? limit : resolveConvexResumeFetchLimit({
+            limit,
+            offset,
+            requiresMatchPagination,
+            hasLocalResumeFilters,
+            hasKeywordQuery: normalizedKeywords.length > 0,
+          });
           const preparedResult = await prepareConvexCandidates({
             keywords: normalizedKeywords,
             limit: convexFetchLimit,


### PR DESCRIPTION
## Summary
- widen the fallback Convex candidate fetch when score-sorted or match-filtered requests cannot stay on query-side pagination
- cover both local-filter and keyword-search paths that must sort or filter after fetch
- keep the scoped fix in the BFF route with focused regressions

## Testing
- npx vitest run /root/workspace/apps/api/src/routes/resumes.test.ts
- bun run --filter @trends/api typecheck
- make check