### PR TITLE
fix: page filtered convex score results via match storage

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -57,6 +57,7 @@ function buildConvexResumeRecord(
   resumeId: string,
   overrides: {
     name?: string;
+    location?: string;
     source?: string;
     primaryRuleScore?: number;
     ingestData?: Record<string, unknown>;
@@ -68,7 +69,7 @@ function buildConvexResumeRecord(
     primaryRuleScore: overrides.primaryRuleScore ?? 0,
     content: {
       name: overrides.name ?? resumeId,
-      location: "东莞",
+      location: overrides.location ?? "东莞",
       experience: "5 years",
       education: "Bachelor",
       jobIntention: "Sales Engineer",
@@ -84,6 +85,7 @@ function buildConvexExportResumeRecord(
   resumeId: string,
   overrides: {
     name?: string;
+    location?: string;
     source?: string;
     ingestData?: Record<string, unknown>;
   } = {}
@@ -92,7 +94,7 @@ function buildConvexExportResumeRecord(
     resumeId,
     resume: {
       name: overrides.name ?? resumeId,
-      location: "东莞",
+      location: overrides.location ?? "东莞",
       experience: "5 years",
       education: "Bachelor",
       jobIntention: "Sales Engineer",
@@ -673,24 +675,34 @@ describe("resume routes", () => {
     }));
   });
 
-  it("widens the convex fetch window when score sorting falls back to local resume filters", async () => {
+  it("pages score-sorted convex results through filtered match storage when local resume filters are present", async () => {
     const calls: ConvexCall[] = [];
-    const getMatchesPageSpy = vi.spyOn(MatchStorage.prototype, "getMatchesPageForJob");
+    const getMatchesPageSpy = vi
+      .spyOn(MatchStorage.prototype, "getMatchesPageForJob")
+      .mockReturnValue({
+        matches: [
+          buildStoredMatch("resume-live-1", { id: 1, score: 96 }),
+          buildStoredMatch("resume-live-2", { id: 2, score: 90 }),
+          buildStoredMatch("resume-live-3", { id: 3, score: 81 }),
+        ],
+        total: 3,
+      });
     const getMatchesByResumeIdsSpy = vi
       .spyOn(MatchStorage.prototype, "getMatchesByResumeIds")
-      .mockReturnValue([
-        buildStoredMatch("resume-live-3", { id: 3, score: 96 }),
-        buildStoredMatch("resume-live-1", { id: 1, score: 81 }),
-      ]);
+      .mockReturnValue([]);
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const call = parseConvexCall(input, init);
       calls.push(call);
 
-      if (call.pathName === "resumes:listWithIngestData") {
+      if (call.pathName === "resumes:getByIdsForExport") {
         return convexSuccess([
-          buildConvexResumeRecord("resume-live-1", { name: "Alice" }),
-          buildConvexResumeRecord("resume-live-3", { name: "Carla" }),
+          buildConvexExportResumeRecord("resume-live-3", { name: "Carla" }),
+          buildConvexExportResumeRecord("resume-live-2", {
+            name: "Bob",
+            location: "深圳",
+          }),
+          buildConvexExportResumeRecord("resume-live-1", { name: "Alice" }),
         ]);
       }
 
@@ -698,18 +710,36 @@ describe("resume routes", () => {
     });
 
     const app = createApp();
-    const response = await app.request("/api/resumes?source=convex&limit=2&sortBy=score&jobDescriptionId=jd-1&locations=%E4%B8%9C%E8%8E%9E");
+    const response = await app.request(
+      "/api/resumes?source=convex&limit=1&offset=1&sortBy=score&jobDescriptionId=jd-1&locations=%E4%B8%9C%E8%8E%9E"
+    );
 
     expect(response.status).toBe(200);
     const payload = await response.json();
     expect(payload.success).toBe(true);
-    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Alice"]);
-    expect(getMatchesPageSpy).not.toHaveBeenCalled();
-    expect(getMatchesByResumeIdsSpy).toHaveBeenCalledWith(["resume-live-1", "resume-live-3"], "jd-1");
-    expect(calls[0]).toEqual(expect.objectContaining({
-      pathName: "resumes:listWithIngestData",
-      args: expect.objectContaining({ limit: 250, jobDescriptionId: "jd-1" }),
+    expect(payload.summary).toEqual(expect.objectContaining({
+      total: 2,
+      returned: 1,
+      source: "convex",
     }));
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla"]);
+    expect(getMatchesPageSpy).toHaveBeenCalledWith(expect.objectContaining({
+      jobDescriptionId: "jd-1",
+      limit: 250,
+      offset: 0,
+      sortOrder: "desc",
+    }));
+    expect(getMatchesByResumeIdsSpy).not.toHaveBeenCalled();
+    expect(calls).toEqual([
+      expect.objectContaining({
+        pathName: "resumes:getByIdsForExport",
+        args: expect.objectContaining({
+          resumeIds: ["resume-live-1", "resume-live-2", "resume-live-3"],
+        }),
+      }),
+    ]);
+    expect(calls.some((call) => call.pathName === "resumes:listWithIngestData")).toBe(false);
+    expect(calls.some((call) => call.pathName === "resumes:searchWithTagExpansion")).toBe(false);
   });
 
   it("widens the convex fetch window when score-sorted keyword searches cannot use match-storage pagination", async () => {

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -42,7 +42,7 @@ import {
   MatchRunsQuerySchema,
 } from "../schemas/index.js";
 import { config } from "../services/config.js";
-import { ResumeService, parseExperienceYears } from "../services/resume-service.js";
+import { ResumeService, parseExperienceYears, type ResumeFilters } from "../services/resume-service.js";
 import { DataNotFoundError } from "../services/errors.js";
 import { resolveConvexUrl } from "../services/resume-import-service.js";
 import { AIMatchingService, type MatchingRequest, type MatchingResult } from "../services/ai-matching.js";
@@ -133,6 +133,7 @@ const DEFAULT_AI_TOP_N = 20;
 const DEFAULT_CONVEX_RESUME_PAGE_SIZE = 50;
 const MAX_SAFE_CONVEX_POST_FILTER_SCAN = 250;
 const MAX_SAFE_CONVEX_POST_FILTER_LIMIT = 2000;
+const MATCH_STORAGE_FILTER_SCAN_BATCH_SIZE = 250;
 
 type MatchMode = "rules_only" | "hybrid" | "ai_only";
 
@@ -958,6 +959,93 @@ async function prepareConvexCandidates(params: {
       })];
     }),
     total: params.paged && isRecord(value) ? (toOptionalNumber(value.total) ?? undefined) : undefined,
+  };
+}
+
+function filterPreparedCandidatesByResumeFilters(
+  prepared: PreparedResumeCandidate[],
+  filters: ResumeFilters | undefined,
+): PreparedResumeCandidate[] {
+  if (!filters) {
+    return prepared;
+  }
+
+  const allowed = new Set(resumeService.filterResumes(prepared.map((item) => item.resume), filters));
+  return prepared.filter((item) => allowed.has(item.resume));
+}
+
+async function prepareFilteredMatchStoragePage(params: {
+  jobDescriptionId: string;
+  offset?: number;
+  limit?: number;
+  minScore?: number;
+  recommendation?: MatchingResult["recommendation"][];
+  sortOrder?: "asc" | "desc";
+  resumeFilters: ResumeFilters;
+}): Promise<{
+  prepared: PreparedResumeCandidate[];
+  total: number;
+  matchMap: Map<string, { score: number; recommendation: MatchingResult["recommendation"] }>;
+}> {
+  const pageOffset = typeof params.offset === "number" ? Math.max(0, params.offset) : 0;
+  const pageLimit = typeof params.limit === "number" ? Math.max(1, params.limit) : DEFAULT_CONVEX_RESUME_PAGE_SIZE;
+  const pageEnd = pageOffset + pageLimit;
+  const matchMap = new Map<string, { score: number; recommendation: MatchingResult["recommendation"] }>();
+  const pagedPrepared: PreparedResumeCandidate[] = [];
+  let filteredCount = 0;
+  let scanOffset = 0;
+  let totalMatches = 0;
+
+  while (true) {
+    const matchPage = matchStorage.getMatchesPageForJob({
+      jobDescriptionId: params.jobDescriptionId,
+      offset: scanOffset,
+      limit: MATCH_STORAGE_FILTER_SCAN_BATCH_SIZE,
+      minScore: params.minScore,
+      recommendation: params.recommendation,
+      sortOrder: params.sortOrder,
+    });
+    totalMatches = matchPage.total;
+
+    if (matchPage.matches.length === 0) {
+      break;
+    }
+
+    const preparedBatch = (await prepareConvexCandidates({
+      resumeIds: matchPage.matches.map((match) => match.resumeId),
+    })).prepared;
+    const filteredBatch = filterPreparedCandidatesByResumeFilters(preparedBatch, params.resumeFilters);
+    const batchMatchMap = new Map(
+      matchPage.matches.map((match) => [
+        match.resumeId,
+        {
+          score: match.score,
+          recommendation: match.recommendation,
+        },
+      ]),
+    );
+
+    for (const candidate of filteredBatch) {
+      if (filteredCount >= pageOffset && filteredCount < pageEnd) {
+        pagedPrepared.push(candidate);
+        const match = batchMatchMap.get(candidate.resumeId);
+        if (match) {
+          matchMap.set(candidate.resumeId, match);
+        }
+      }
+      filteredCount += 1;
+    }
+
+    scanOffset += matchPage.matches.length;
+    if (scanOffset >= totalMatches) {
+      break;
+    }
+  }
+
+  return {
+    prepared: pagedPrepared,
+    total: filteredCount,
+    matchMap,
   };
 }
 
@@ -1798,13 +1886,30 @@ app.openapi(getResumesRoute, (c) => {
           maxSalary,
         });
         const requiresMatchPagination = sortBy === "score" || hasLocalMatchFilters;
+        const localResumeFilters: ResumeFilters = {
+          minExperience,
+          maxExperience,
+          education,
+          skills,
+          requiredKeywords: normalizedRequiredKeywords,
+          locations,
+          minSalary,
+          maxSalary,
+        };
         const canUseMatchStoragePagination = Boolean(
           resolvedJobId
           && requiresMatchPagination
           && normalizedKeywords.length === 0
           && !hasLocalResumeFilters
         );
+        const canUseFilteredMatchStoragePagination = Boolean(
+          resolvedJobId
+          && requiresMatchPagination
+          && normalizedKeywords.length === 0
+          && hasLocalResumeFilters
+        );
         const canUseSourcePagination = !requiresMatchPagination;
+        const usesMatchStoragePagination = canUseMatchStoragePagination || canUseFilteredMatchStoragePagination;
         const matchSortOrder = sortBy === "score"
           ? resolveResumeSortOrder(sortBy, sortOrder) || "desc"
           : "desc";
@@ -1831,6 +1936,19 @@ app.openapi(getResumesRoute, (c) => {
               resumeIds: pagedResumeIds,
             })).prepared;
           }
+        } else if (canUseFilteredMatchStoragePagination && resolvedJobId) {
+          const filteredMatchPage = await prepareFilteredMatchStoragePage({
+            jobDescriptionId: resolvedJobId,
+            offset,
+            limit,
+            minScore: minMatchScore,
+            recommendation: normalizedRecommendations,
+            sortOrder: matchSortOrder,
+            resumeFilters: localResumeFilters,
+          });
+          prepared = filteredMatchPage.prepared;
+          matchMap = filteredMatchPage.matchMap;
+          totalCount = filteredMatchPage.total;
         } else {
           const convexFetchLimit = canUseSourcePagination ? limit : resolveConvexResumeFetchLimit({
             limit,
@@ -1845,18 +1963,7 @@ app.openapi(getResumesRoute, (c) => {
             offset: canUseSourcePagination ? offset : undefined,
             sortBy: canUseSourcePagination && sortBy ? sortBy : undefined,
             sortOrder: canUseSourcePagination ? resolveResumeSortOrder(sortBy, sortOrder) : undefined,
-            filters: canUseSourcePagination
-              ? {
-                  minExperience,
-                  maxExperience,
-                  education,
-                  skills,
-                  requiredKeywords: normalizedRequiredKeywords,
-                  locations,
-                  minSalary,
-                  maxSalary,
-                }
-              : undefined,
+            filters: canUseSourcePagination ? localResumeFilters : undefined,
             jobDescriptionId: resolvedJobId,
             paged: canUseSourcePagination,
           });
@@ -1866,16 +1973,9 @@ app.openapi(getResumesRoute, (c) => {
         }
 
         let filtered = prepared.map((item) => item.resume);
-        filtered = resumeService.filterResumes(filtered, {
-          minExperience,
-          maxExperience,
-          education,
-          skills,
-          requiredKeywords: normalizedRequiredKeywords,
-          locations,
-          minSalary,
-          maxSalary,
-        });
+        filtered = usesMatchStoragePagination
+          ? filtered
+          : resumeService.filterResumes(filtered, localResumeFilters);
 
         const enriched = filtered.map((item, index) => ({
           resume: item,
@@ -1896,7 +1996,7 @@ app.openapi(getResumesRoute, (c) => {
         }
 
         let working = enriched;
-        if (!canUseMatchStoragePagination && matchMap) {
+        if (!usesMatchStoragePagination && matchMap) {
           if (minMatchScore !== undefined) {
             working = working.filter((item) => {
               const match = matchMap?.get(item.id);
@@ -1912,7 +2012,7 @@ app.openapi(getResumesRoute, (c) => {
           }
         }
 
-        if (!canUseMatchStoragePagination && sortBy) {
+        if (!usesMatchStoragePagination && sortBy) {
           const order = sortOrder || (sortBy === "score" ? "desc" : "asc");
           const direction = order === "desc" ? -1 : 1;
 
@@ -1938,7 +2038,7 @@ app.openapi(getResumesRoute, (c) => {
           });
         }
 
-        const isAlreadyPaged = canUseSourcePagination || canUseMatchStoragePagination;
+        const isAlreadyPaged = canUseSourcePagination || usesMatchStoragePagination;
         const limited = isAlreadyPaged
           ? working.map((item) => item.resume)
           : (() => {


### PR DESCRIPTION
## Summary\n- page no-keyword convex score/match requests with local resume filters through match-storage scanning\n- skip the second local filter/sort pass when the result page already came from filtered match storage\n- replace the outdated regression with a true filtered pagination test and keep the keyword fallback widening coverage\n\n## Validation\n- npx vitest run /root/workspace/apps/api/src/routes/resumes.test.ts\n- bun run --filter @trends/api typecheck\n- make check