### PR TITLE
fix: generalize bounded keyword score pagination

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -806,7 +806,63 @@ describe("resume routes", () => {
     expect(calls.some((call) => call.pathName === "resumes:searchWithTagExpansion")).toBe(false);
   });
 
-  it("widens the convex fetch window when score-sorted keyword searches without source-side resume filters cannot use match-storage pagination", async () => {
+  it("pages bounded score-sorted keyword convex results through keyword page scans without source-side resume filters", async () => {
+    const calls: ConvexCall[] = [];
+    const getMatchesPageSpy = vi.spyOn(MatchStorage.prototype, "getMatchesPageForJob");
+    const getMatchesByResumeIdsSpy = vi
+      .spyOn(MatchStorage.prototype, "getMatchesByResumeIds")
+      .mockReturnValue([
+        buildStoredMatch("resume-live-1", { id: 1, score: 96 }),
+        buildStoredMatch("resume-live-3", { id: 3, score: 81 }),
+      ]);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:searchWithTagExpansionPage") {
+        return convexSuccess({
+          expansion: {
+            original: "cnc sales",
+            expanded: ["cnc", "sales"],
+            groups: [
+              { original: "cnc", variants: ["cnc"] },
+              { original: "sales", variants: ["sales"] },
+            ],
+            mode: "AND",
+          },
+          results: [
+            { resume: buildConvexResumeRecord("resume-live-1", { name: "Alice" }), provenance: [{ term: "sales", source: "searchText" }] },
+            { resume: buildConvexResumeRecord("resume-live-3", { name: "Carla" }), provenance: [{ term: "cnc", source: "searchText" }] },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&limit=1&offset=1&sortBy=score&jobDescriptionId=jd-1&q=cnc%20sales");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.summary).toEqual(expect.objectContaining({
+      total: 2,
+      returned: 1,
+      source: "convex",
+    }));
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla"]);
+    expect(getMatchesPageSpy).not.toHaveBeenCalled();
+    expect(getMatchesByResumeIdsSpy).toHaveBeenCalledWith(["resume-live-1", "resume-live-3"], "jd-1");
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:searchWithTagExpansionPage",
+      args: expect.objectContaining({ limit: 250, offset: 0, jobDescriptionId: "jd-1" }),
+    }));
+    expect(calls.some((call) => call.pathName === "resumes:searchWithTagExpansion")).toBe(false);
+  });
+
+  it("widens the convex fetch window when score-sorted keyword searches exceed the safe paged scan limit", async () => {
     const calls: ConvexCall[] = [];
     const getMatchesPageSpy = vi.spyOn(MatchStorage.prototype, "getMatchesPageForJob");
     const getMatchesByResumeIdsSpy = vi
@@ -819,6 +875,25 @@ describe("resume routes", () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const call = parseConvexCall(input, init);
       calls.push(call);
+
+      if (call.pathName === "resumes:searchWithTagExpansionPage") {
+        return convexSuccess({
+          expansion: {
+            original: "cnc sales",
+            expanded: ["cnc", "sales"],
+            groups: [
+              { original: "cnc", variants: ["cnc"] },
+              { original: "sales", variants: ["sales"] },
+            ],
+            mode: "AND",
+          },
+          total: 2501,
+          results: [
+            { resume: buildConvexResumeRecord("resume-live-1", { name: "Alice" }), provenance: [{ term: "sales", source: "searchText" }] },
+            { resume: buildConvexResumeRecord("resume-live-3", { name: "Carla" }), provenance: [{ term: "cnc", source: "searchText" }] },
+          ],
+        });
+      }
 
       if (call.pathName === "resumes:searchWithTagExpansion") {
         return convexSuccess({
@@ -851,6 +926,10 @@ describe("resume routes", () => {
     expect(getMatchesPageSpy).not.toHaveBeenCalled();
     expect(getMatchesByResumeIdsSpy).toHaveBeenCalledWith(["resume-live-1", "resume-live-3"], "jd-1");
     expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:searchWithTagExpansionPage",
+      args: expect.objectContaining({ limit: 250, offset: 0, jobDescriptionId: "jd-1" }),
+    }));
+    expect(calls[1]).toEqual(expect.objectContaining({
       pathName: "resumes:searchWithTagExpansion",
       args: expect.objectContaining({ limit: 250, jobDescriptionId: "jd-1" }),
     }));

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -1081,7 +1081,7 @@ async function prepareFilteredMatchStoragePage(params: {
   };
 }
 
-async function prepareFilteredKeywordMatchPage(params: {
+async function prepareKeywordMatchPage(params: {
   jobDescriptionId: string;
   keywords: string[];
   offset?: number;
@@ -1090,7 +1090,7 @@ async function prepareFilteredKeywordMatchPage(params: {
   recommendation?: MatchingResult["recommendation"][];
   sortByScore: boolean;
   sortOrder?: "asc" | "desc";
-  resumeFilters: ResumeFilters;
+  resumeFilters?: ResumeFilters;
 }): Promise<{
   prepared: PreparedResumeCandidate[];
   total: number;
@@ -2038,11 +2038,10 @@ app.openapi(getResumesRoute, (c) => {
           && normalizedKeywords.length === 0
           && hasLocalResumeFilters
         );
-        const canUseFilteredKeywordPagination = Boolean(
+        const canUseKeywordMatchPagination = Boolean(
           resolvedJobId
           && requiresMatchPagination
           && normalizedKeywords.length > 0
-          && hasLocalResumeFilters
         );
         const canUseSourcePagination = !requiresMatchPagination;
         let usesPrePagedMatchResults = canUseMatchStoragePagination || canUseFilteredMatchStoragePagination;
@@ -2085,8 +2084,8 @@ app.openapi(getResumesRoute, (c) => {
           prepared = filteredMatchPage.prepared;
           matchMap = filteredMatchPage.matchMap;
           totalCount = filteredMatchPage.total;
-        } else if (canUseFilteredKeywordPagination && resolvedJobId) {
-          const filteredKeywordPage = await prepareFilteredKeywordMatchPage({
+        } else if (canUseKeywordMatchPagination && resolvedJobId) {
+          const keywordMatchPage = await prepareKeywordMatchPage({
             jobDescriptionId: resolvedJobId,
             keywords: normalizedKeywords,
             offset,
@@ -2097,11 +2096,11 @@ app.openapi(getResumesRoute, (c) => {
             sortOrder: resolveResumeSortOrder(sortBy, sortOrder) || "desc",
             resumeFilters: localResumeFilters,
           });
-          if (filteredKeywordPage) {
-            prepared = filteredKeywordPage.prepared;
-            matchMap = filteredKeywordPage.matchMap;
-            totalCount = filteredKeywordPage.total;
-            liveExpansion = filteredKeywordPage.keywordExpansion;
+          if (keywordMatchPage) {
+            prepared = keywordMatchPage.prepared;
+            matchMap = keywordMatchPage.matchMap;
+            totalCount = keywordMatchPage.total;
+            liveExpansion = keywordMatchPage.keywordExpansion;
             usesPrePagedMatchResults = true;
           } else {
             const convexFetchLimit = resolveConvexResumeFetchLimit({


### PR DESCRIPTION
## Summary\n- use the keyword pre-paging scan for bounded keyword score/match requests even when there are no source-side resume filters\n- keep the widened keyword fallback only for oversized scans above the safe cap\n- update route regressions to cover both the bounded exact path and the oversized fallback path\n\n## Validation\n- npx vitest run /root/workspace/apps/api/src/routes/resumes.test.ts\n- bun run --filter @trends/api typecheck\n- make check