### PR TITLE
fix: exact-scan oversized keyword score pages

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -862,7 +862,7 @@ describe("resume routes", () => {
     expect(calls.some((call) => call.pathName === "resumes:searchWithTagExpansion")).toBe(false);
   });
 
-  it("widens the convex fetch window when score-sorted keyword searches exceed the safe paged scan limit", async () => {
+  it("scans oversized score-sorted keyword searches through cursor pages instead of falling back to widened overfetch", async () => {
     const calls: ConvexCall[] = [];
     const getMatchesPageSpy = vi.spyOn(MatchStorage.prototype, "getMatchesPageForJob");
     const getMatchesByResumeIdsSpy = vi
@@ -895,21 +895,19 @@ describe("resume routes", () => {
         });
       }
 
-      if (call.pathName === "resumes:searchWithTagExpansion") {
+      if (call.pathName === "resumes:searchWithTagExpansionScanPage") {
         return convexSuccess({
-          expansion: {
-            original: "cnc sales",
-            expanded: ["cnc", "sales"],
-            groups: [
-              { original: "cnc", variants: ["cnc"] },
-              { original: "sales", variants: ["sales"] },
-            ],
-            mode: "AND",
-          },
-          results: [
-            { resume: buildConvexResumeRecord("resume-live-1", { name: "Alice" }), provenance: [{ term: "sales", source: "searchText" }] },
-            { resume: buildConvexResumeRecord("resume-live-3", { name: "Carla" }), provenance: [{ term: "cnc", source: "searchText" }] },
-          ],
+          page: call.args.paginationOpts && isRecord(call.args.paginationOpts) && call.args.paginationOpts.cursor === "scan-2"
+            ? [
+                { resume: buildConvexResumeRecord("resume-live-3", { name: "Carla" }), provenance: [{ term: "cnc", source: "searchText" }] },
+              ]
+            : [
+                { resume: buildConvexResumeRecord("resume-live-1", { name: "Alice" }), provenance: [{ term: "sales", source: "searchText" }] },
+              ],
+          continueCursor: call.args.paginationOpts && isRecord(call.args.paginationOpts) && call.args.paginationOpts.cursor === "scan-2"
+            ? ""
+            : "scan-2",
+          isDone: Boolean(call.args.paginationOpts && isRecord(call.args.paginationOpts) && call.args.paginationOpts.cursor === "scan-2"),
         });
       }
 
@@ -930,9 +928,18 @@ describe("resume routes", () => {
       args: expect.objectContaining({ limit: 250, offset: 0, jobDescriptionId: "jd-1" }),
     }));
     expect(calls[1]).toEqual(expect.objectContaining({
-      pathName: "resumes:searchWithTagExpansion",
-      args: expect.objectContaining({ limit: 250, jobDescriptionId: "jd-1" }),
+      pathName: "resumes:searchWithTagExpansionScanPage",
+      args: expect.objectContaining({
+        paginationOpts: expect.objectContaining({ cursor: null, numItems: 250 }),
+      }),
     }));
+    expect(calls[2]).toEqual(expect.objectContaining({
+      pathName: "resumes:searchWithTagExpansionScanPage",
+      args: expect.objectContaining({
+        paginationOpts: expect.objectContaining({ cursor: "scan-2", numItems: 250 }),
+      }),
+    }));
+    expect(calls.some((call) => call.pathName === "resumes:searchWithTagExpansion")).toBe(false);
   });
 
   it("pages score-sorted convex results through match storage and preserves explicit-id order", async () => {

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -215,6 +215,19 @@ type ResumeMatchContext = {
 type ResumeMatchContextEntry = ResumeMatchContext & {
   resumeId: string;
 };
+type ExactKeywordScanCandidate = {
+  candidate: PreparedResumeCandidate;
+  identityKey: string;
+  crawledAt: number;
+  jobRuleScore: number;
+  primaryRuleScore: number;
+  provenance: ResumeSearchProvenance[];
+};
+type SortableKeywordMatchEntry = {
+  candidate: PreparedResumeCandidate;
+  match: ResumeMatchContext | undefined;
+  sortMetadata?: ExactKeywordScanCandidate;
+};
 type ReviewPacketResolvedRecord = {
   resumeId: string;
   resume: ExportResumePayload;
@@ -1014,6 +1027,254 @@ function loadResumeMatchContextMap(
   return matchMap;
 }
 
+function dedupeResumeSearchProvenance(items: ResumeSearchProvenance[] | undefined): ResumeSearchProvenance[] {
+  const deduped: ResumeSearchProvenance[] = [];
+  const seen = new Set<string>();
+
+  for (const item of items ?? []) {
+    const key = `${item.source}|${item.term}|${item.expandedFrom ?? ""}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(item);
+  }
+
+  return deduped;
+}
+
+function resolveProjectedResumeRuleScore(resumeRecord: Record<string, unknown>, jobDescriptionId: string): number {
+  const ingestData = isRecord(resumeRecord.ingestData) ? resumeRecord.ingestData : null;
+  const ruleScores = ingestData && isRecord(ingestData.ruleScores) ? ingestData.ruleScores : null;
+  return ruleScores ? (toOptionalNumber(ruleScores[jobDescriptionId]) ?? 0) : 0;
+}
+
+function compareExactKeywordScanCandidates(left: ExactKeywordScanCandidate, right: ExactKeywordScanCandidate): number {
+  const ruleScoreDiff = right.jobRuleScore - left.jobRuleScore;
+  if (ruleScoreDiff !== 0) {
+    return ruleScoreDiff;
+  }
+
+  const primaryRuleScoreDiff = right.primaryRuleScore - left.primaryRuleScore;
+  if (primaryRuleScoreDiff !== 0) {
+    return primaryRuleScoreDiff;
+  }
+
+  return right.crawledAt - left.crawledAt;
+}
+
+function parseExactKeywordScanCandidate(
+  value: unknown,
+  jobDescriptionId: string,
+): ExactKeywordScanCandidate | null {
+  if (!isRecord(value) || !isRecord(value.resume)) {
+    return null;
+  }
+
+  const resumeRecord = value.resume;
+  const resumeId = toStringValue(resumeRecord._id);
+  if (!resumeId) {
+    return null;
+  }
+
+  const provenance = dedupeResumeSearchProvenance(parseConvexProvenance(value.provenance));
+  const candidate = prepareResumeCandidate({
+    resume: toResumeItemFromRecord(
+      isRecord(resumeRecord.content) ? resumeRecord.content : {},
+      toStringValue(resumeRecord.source),
+    ),
+    resumeId,
+    primaryRuleScore: toOptionalNumber(resumeRecord.primaryRuleScore),
+    provenance,
+    ingestData: resumeRecord.ingestData,
+  });
+
+  return {
+    candidate,
+    identityKey: toStringValue(resumeRecord.identityKey) || resumeId,
+    crawledAt: toOptionalNumber(resumeRecord.crawledAt) ?? 0,
+    jobRuleScore: resolveProjectedResumeRuleScore(resumeRecord, jobDescriptionId),
+    primaryRuleScore: toOptionalNumber(resumeRecord.primaryRuleScore) ?? 0,
+    provenance,
+  };
+}
+
+function mergeExactKeywordScanCandidate(
+  existing: ExactKeywordScanCandidate,
+  incoming: ExactKeywordScanCandidate,
+): ExactKeywordScanCandidate {
+  const mergedProvenance = dedupeResumeSearchProvenance([
+    ...existing.provenance,
+    ...incoming.provenance,
+  ]);
+  const preferred = compareExactKeywordScanCandidates(existing, incoming) <= 0
+    ? existing
+    : incoming;
+
+  return {
+    ...preferred,
+    provenance: mergedProvenance,
+    candidate: {
+      ...preferred.candidate,
+      ...(mergedProvenance.length > 0 ? { provenance: mergedProvenance } : {}),
+    },
+  };
+}
+
+function sortKeywordMatchEntries(
+  entries: SortableKeywordMatchEntry[],
+  sortBy: "score" | "name" | "experience" | "extractedAt" | undefined,
+  sortOrder: "asc" | "desc" | undefined,
+): SortableKeywordMatchEntry[] {
+  if (!sortBy) {
+    return entries;
+  }
+
+  const direction = (sortOrder || (sortBy === "score" ? "desc" : "asc")) === "desc" ? -1 : 1;
+  return [...entries].sort((left, right) => {
+    if (sortBy === "score") {
+      const leftScore = left.match?.score ?? -1;
+      const rightScore = right.match?.score ?? -1;
+      return (leftScore - rightScore) * direction;
+    }
+    if (sortBy === "experience") {
+      const leftExperience = parseExperienceYears(left.candidate.resume.experience) ?? -1;
+      const rightExperience = parseExperienceYears(right.candidate.resume.experience) ?? -1;
+      return (leftExperience - rightExperience) * direction;
+    }
+    if (sortBy === "extractedAt") {
+      const leftTime = Date.parse(left.candidate.resume.extractedAt || "") || 0;
+      const rightTime = Date.parse(right.candidate.resume.extractedAt || "") || 0;
+      return (leftTime - rightTime) * direction;
+    }
+
+    const leftName = left.candidate.resume.name?.toLowerCase() ?? "";
+    const rightName = right.candidate.resume.name?.toLowerCase() ?? "";
+    return leftName.localeCompare(rightName) * direction;
+  });
+}
+
+async function prepareKeywordMatchPageByCursor(params: {
+  jobDescriptionId: string;
+  keywords: string[];
+  offset?: number;
+  limit?: number;
+  minScore?: number;
+  recommendation?: MatchingResult["recommendation"][];
+  sortBy?: "score" | "name" | "experience" | "extractedAt";
+  sortOrder?: "asc" | "desc";
+  resumeFilters?: ResumeFilters;
+}): Promise<{
+  prepared: PreparedResumeCandidate[];
+  total: number;
+  matchMap: Map<string, ResumeMatchContext>;
+  keywordExpansion?: ResumeKeywordExpansion;
+}> {
+  const canonicalKeywordQuery = formatKeywordQuery(params.keywords);
+  const keywordExpansion = resumeService.expandSearchQuery(canonicalKeywordQuery);
+  const merged = new Map<string, ExactKeywordScanCandidate>();
+  let cursor: string | null = null;
+
+  while (true) {
+    const value = await callConvexQuery("resumes:searchWithTagExpansionScanPage", {
+      paginationOpts: {
+        cursor,
+        numItems: MATCH_STORAGE_FILTER_SCAN_BATCH_SIZE,
+      },
+      query: canonicalKeywordQuery,
+      keywordGroups: keywordExpansion?.groups ?? [],
+      mode: keywordExpansion?.mode ?? "AND",
+      sourceMappings: Object.entries(keywordExpansion?.sourceMapping ?? {}).map(([term, expandedFrom]) => ({
+        term,
+        expandedFrom,
+      })),
+      ...(params.resumeFilters ?? {}),
+    });
+
+    if (!isConvexPaginatedQueryPage(value)) {
+      throw new Error("Invalid paginated keyword scan response from Convex");
+    }
+
+    for (const item of value.page) {
+      const parsed = parseExactKeywordScanCandidate(item, params.jobDescriptionId);
+      if (!parsed) {
+        continue;
+      }
+      const existing = merged.get(parsed.identityKey);
+      merged.set(
+        parsed.identityKey,
+        existing ? mergeExactKeywordScanCandidate(existing, parsed) : parsed,
+      );
+    }
+
+    if (value.isDone) {
+      break;
+    }
+
+    if (!value.continueCursor) {
+      throw new Error("Convex keyword scan returned an unfinished page without a continueCursor");
+    }
+    cursor = value.continueCursor;
+  }
+
+  const fullMatchMap = loadResumeMatchContextMap(
+    params.jobDescriptionId,
+    Array.from(merged.values()).map((entry) => entry.candidate.resumeId),
+  );
+  const allowedRecommendations = params.recommendation?.length
+    ? new Set(params.recommendation)
+    : null;
+
+  let working: SortableKeywordMatchEntry[] = Array.from(merged.values()).map((entry) => ({
+    candidate: entry.candidate,
+    match: fullMatchMap.get(entry.candidate.resumeId),
+    sortMetadata: entry,
+  }));
+
+  const minScore = params.minScore;
+  if (typeof minScore === "number") {
+    working = working.filter((entry) => entry.match && entry.match.score >= minScore);
+  }
+
+  if (allowedRecommendations) {
+    working = working.filter((entry) => entry.match && allowedRecommendations.has(entry.match.recommendation));
+  }
+
+  working = params.sortBy
+    ? sortKeywordMatchEntries(working, params.sortBy, params.sortOrder)
+    : [...working].sort((left, right) => {
+        const leftMetadata = left.sortMetadata;
+        const rightMetadata = right.sortMetadata;
+        if (!leftMetadata || !rightMetadata) {
+          return 0;
+        }
+
+        if (rightMetadata.provenance.length !== leftMetadata.provenance.length) {
+          return rightMetadata.provenance.length - leftMetadata.provenance.length;
+        }
+        return compareExactKeywordScanCandidates(leftMetadata, rightMetadata);
+      });
+
+  const pageOffset = typeof params.offset === "number" ? Math.max(0, params.offset) : 0;
+  const pageLimit = typeof params.limit === "number" ? Math.max(1, params.limit) : DEFAULT_CONVEX_RESUME_PAGE_SIZE;
+  const paged = working.slice(pageOffset, pageOffset + pageLimit);
+
+  return {
+    prepared: paged.map((entry) => entry.candidate),
+    total: working.length,
+    matchMap: createResumeMatchContextMap(
+      paged.flatMap((entry) => entry.match
+        ? [{
+            resumeId: entry.candidate.resumeId,
+            score: entry.match.score,
+            recommendation: entry.match.recommendation,
+          }]
+        : []),
+    ),
+    keywordExpansion,
+  };
+}
+
 async function prepareFilteredMatchStoragePage(params: {
   jobDescriptionId: string;
   offset?: number;
@@ -1088,7 +1349,7 @@ async function prepareKeywordMatchPage(params: {
   limit?: number;
   minScore?: number;
   recommendation?: MatchingResult["recommendation"][];
-  sortByScore: boolean;
+  sortBy?: "score" | "name" | "experience" | "extractedAt";
   sortOrder?: "asc" | "desc";
   resumeFilters?: ResumeFilters;
 }): Promise<{
@@ -1096,13 +1357,12 @@ async function prepareKeywordMatchPage(params: {
   total: number;
   matchMap: Map<string, ResumeMatchContext>;
   keywordExpansion?: ResumeKeywordExpansion;
-} | null> {
+}> {
   const pageOffset = typeof params.offset === "number" ? Math.max(0, params.offset) : 0;
   const pageLimit = typeof params.limit === "number" ? Math.max(1, params.limit) : DEFAULT_CONVEX_RESUME_PAGE_SIZE;
   const allowedRecommendations = params.recommendation?.length
     ? new Set(params.recommendation)
     : null;
-  const direction = (params.sortOrder || "desc") === "desc" ? -1 : 1;
   const allPrepared: PreparedResumeCandidate[] = [];
   let keywordExpansion: ResumeKeywordExpansion | undefined;
   let scanOffset = 0;
@@ -1122,7 +1382,7 @@ async function prepareKeywordMatchPage(params: {
     total = preparedResult.total ?? 0;
 
     if (total > MAX_SAFE_CONVEX_POST_FILTER_LIMIT) {
-      return null;
+      return prepareKeywordMatchPageByCursor(params);
     }
 
     if (preparedResult.prepared.length === 0) {
@@ -1140,7 +1400,7 @@ async function prepareKeywordMatchPage(params: {
     params.jobDescriptionId,
     allPrepared.map((item) => item.resumeId),
   );
-  let working = allPrepared.map((candidate) => ({
+  let working: SortableKeywordMatchEntry[] = allPrepared.map((candidate) => ({
     candidate,
     match: fullMatchMap.get(candidate.resumeId),
   }));
@@ -1154,12 +1414,8 @@ async function prepareKeywordMatchPage(params: {
     working = working.filter((entry) => entry.match && allowedRecommendations.has(entry.match.recommendation));
   }
 
-  if (params.sortByScore) {
-    working = [...working].sort((left, right) => {
-      const scoreLeft = left.match?.score ?? -1;
-      const scoreRight = right.match?.score ?? -1;
-      return (scoreLeft - scoreRight) * direction;
-    });
+  if (params.sortBy) {
+    working = sortKeywordMatchEntries(working, params.sortBy, params.sortOrder);
   }
 
   const paged = working.slice(pageOffset, pageOffset + pageLimit);
@@ -2092,33 +2348,15 @@ app.openapi(getResumesRoute, (c) => {
             limit,
             minScore: minMatchScore,
             recommendation: normalizedRecommendations,
-            sortByScore: sortBy === "score",
+            sortBy,
             sortOrder: resolveResumeSortOrder(sortBy, sortOrder) || "desc",
             resumeFilters: localResumeFilters,
           });
-          if (keywordMatchPage) {
-            prepared = keywordMatchPage.prepared;
-            matchMap = keywordMatchPage.matchMap;
-            totalCount = keywordMatchPage.total;
-            liveExpansion = keywordMatchPage.keywordExpansion;
-            usesPrePagedMatchResults = true;
-          } else {
-            const convexFetchLimit = resolveConvexResumeFetchLimit({
-              limit,
-              offset,
-              requiresMatchPagination,
-              hasLocalResumeFilters,
-              hasKeywordQuery: normalizedKeywords.length > 0,
-            });
-            const preparedResult = await prepareConvexCandidates({
-              keywords: normalizedKeywords,
-              limit: convexFetchLimit,
-              jobDescriptionId: resolvedJobId,
-            });
-            prepared = preparedResult.prepared;
-            liveExpansion = preparedResult.keywordExpansion;
-            totalCount = preparedResult.total;
-          }
+          prepared = keywordMatchPage.prepared;
+          matchMap = keywordMatchPage.matchMap;
+          totalCount = keywordMatchPage.total;
+          liveExpansion = keywordMatchPage.keywordExpansion;
+          usesPrePagedMatchResults = true;
         } else {
           const convexFetchLimit = canUseSourcePagination ? limit : resolveConvexResumeFetchLimit({
             limit,

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -290,6 +290,23 @@ type SearchWithTagExpansionPageArgs = ResumeListPageArgs & {
     }>;
 };
 
+type SearchWithTagExpansionScanPageArgs = ResumeListFilterArgs & {
+    paginationOpts: {
+        cursor: string | null;
+        numItems: number;
+    };
+    query: string;
+    keywordGroups: Array<{
+        original: string;
+        variants: string[];
+    }>;
+    mode?: "AND" | "OR";
+    sourceMappings?: Array<{
+        term: string;
+        expandedFrom: string;
+    }>;
+};
+
 type DeleteResumesResult = {
     requested: number;
     deleted: number;
@@ -1290,6 +1307,91 @@ async function runSearchWithTagExpansionPageQuery(
     };
 }
 
+async function runSearchWithTagExpansionScanPageQuery(
+    ctx: QueryCtx,
+    args: SearchWithTagExpansionScanPageArgs
+): Promise<{
+    expansion: {
+        original: string;
+        expanded: string[];
+        groups: TagExpansionKeywordGroup[];
+        mode: "AND" | "OR";
+    };
+    page: Array<{ resume: ResumeListProjectedDoc; provenance: SearchProvenance[] }>;
+    continueCursor: string;
+    isDone: boolean;
+}> {
+    const filters = normalizeResumeListFilters(args);
+    const mode = args.mode ?? "AND";
+    const keywordGroups = normalizeTagExpansionKeywordGroups(args.keywordGroups);
+    const expandedTerms = collectExpandedTerms(keywordGroups);
+
+    if (expandedTerms.length === 0 || keywordGroups.length === 0) {
+        return {
+            expansion: {
+                original: args.query,
+                expanded: [],
+                groups: [],
+                mode,
+            },
+            page: [],
+            continueCursor: "",
+            isDone: true,
+        };
+    }
+
+    const sourceMapping = Object.fromEntries(
+        (args.sourceMappings ?? []).map((entry) => [entry.term, entry.expandedFrom])
+    );
+    const searchQuery = buildTagExpansionSearchQuery(keywordGroups, mode);
+    const pageSize = Math.min(
+        Math.max(Math.trunc(args.paginationOpts.numItems), 1),
+        MAX_SAFE_JD_PAGINATE_SCAN,
+    );
+
+    const searchPage = searchQuery
+        ? await ctx.db
+            .query("resumes")
+            .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery))
+            .paginate({
+                ...args.paginationOpts,
+                numItems: pageSize,
+            })
+        : {
+            page: [] as Doc<"resumes">[],
+            continueCursor: "",
+            isDone: true,
+        };
+
+    return {
+        expansion: {
+            original: args.query,
+            expanded: expandedTerms,
+            groups: keywordGroups,
+            mode,
+        },
+        page: searchPage.page.flatMap((doc) => {
+            const normalizedSearchText = (doc.searchText || "").toLowerCase();
+            const matched = matchesTagExpansionSearchText(normalizedSearchText, keywordGroups, mode);
+            if (!matched || !matchesResumeListFilters(doc, filters)) {
+                return [];
+            }
+
+            const provenance = collectSearchTextProvenance(normalizedSearchText, keywordGroups, sourceMapping);
+            if (provenance.length === 0) {
+                return [];
+            }
+
+            return [{
+                resume: projectResumeListDoc(doc),
+                provenance,
+            }];
+        }),
+        continueCursor: searchPage.continueCursor,
+        isDone: searchPage.isDone,
+    };
+}
+
 export const count = action({
     args: {},
     handler: async (ctx) => {
@@ -1760,6 +1862,39 @@ export const searchWithTagExpansionPaginated = query({
             resume: projectResumeListDoc(entry.resume),
             provenance: entry.provenance,
         })), page.total, offset);
+    },
+});
+
+export const searchWithTagExpansionScanPage = query({
+    args: {
+        paginationOpts: paginationOptsValidator,
+        query: v.string(),
+        keywordGroups: v.array(v.object({
+            original: v.string(),
+            variants: v.array(v.string()),
+        })),
+        mode: v.optional(v.union(v.literal("AND"), v.literal("OR"))),
+        sourceMappings: v.optional(v.array(v.object({
+            term: v.string(),
+            expandedFrom: v.string(),
+        }))),
+        minExperience: v.optional(v.number()),
+        maxExperience: v.optional(v.number()),
+        education: v.optional(v.array(v.string())),
+        skills: v.optional(v.array(v.string())),
+        requiredKeywords: v.optional(v.array(v.string())),
+        locations: v.optional(v.array(v.string())),
+        minSalary: v.optional(v.number()),
+        maxSalary: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const page = await runSearchWithTagExpansionScanPageQuery(ctx, args);
+        return {
+            expansion: page.expansion,
+            page: page.page,
+            continueCursor: page.continueCursor,
+            isDone: page.isDone,
+        };
     },
 });
 


### PR DESCRIPTION
## Summary\n- add a dedicated Convex keyword scan query backed by search-index pagination for oversized keyword candidate sets\n- switch oversized keyword score/match pagination from widened overfetch fallback to exact cursor scans with identity-aware dedupe in the API\n- update route regressions so oversized keyword score searches prove the cursor path instead of the old fallback\n\n## Validation\n- npx vitest run /root/workspace/apps/api/src/routes/resumes.test.ts\n- bun run --filter @trends/api typecheck\n- make check