### PR TITLE
fix: prefer best duplicate keyword match

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -58,6 +58,7 @@ function buildConvexResumeRecord(
   overrides: {
     name?: string;
     location?: string;
+    identityKey?: string;
     source?: string;
     primaryRuleScore?: number;
     ingestData?: Record<string, unknown>;
@@ -65,6 +66,7 @@ function buildConvexResumeRecord(
 ) {
   return {
     _id: resumeId,
+    identityKey: overrides.identityKey,
     source: overrides.source ?? "seek",
     primaryRuleScore: overrides.primaryRuleScore ?? 0,
     content: {
@@ -940,6 +942,184 @@ describe("resume routes", () => {
       }),
     }));
     expect(calls.some((call) => call.pathName === "resumes:searchWithTagExpansion")).toBe(false);
+  });
+
+  it("keeps the best-scoring duplicate identity when oversized keyword scans merge exact cursor pages", async () => {
+    const calls: ConvexCall[] = [];
+    const getMatchesPageSpy = vi.spyOn(MatchStorage.prototype, "getMatchesPageForJob");
+    const getMatchesByResumeIdsSpy = vi
+      .spyOn(MatchStorage.prototype, "getMatchesByResumeIds")
+      .mockImplementation((resumeIds) => {
+        const ordered = Array.isArray(resumeIds) ? resumeIds : [];
+        return ordered.flatMap((resumeId) => {
+          if (resumeId === "resume-live-1") {
+            return [buildStoredMatch("resume-live-1", { id: 1, score: 70 })];
+          }
+          if (resumeId === "resume-live-2") {
+            return [buildStoredMatch("resume-live-2", { id: 2, score: 95 })];
+          }
+          if (resumeId === "resume-live-3") {
+            return [buildStoredMatch("resume-live-3", { id: 3, score: 81 })];
+          }
+          return [];
+        });
+      });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:searchWithTagExpansionPage") {
+        return convexSuccess({
+          expansion: {
+            original: "cnc sales",
+            expanded: ["cnc", "sales"],
+            groups: [
+              { original: "cnc", variants: ["cnc"] },
+              { original: "sales", variants: ["sales"] },
+            ],
+            mode: "AND",
+          },
+          total: 2501,
+          results: [
+            {
+              resume: buildConvexResumeRecord("resume-live-1", {
+                name: "Alice Older",
+                identityKey: "dup-1",
+                primaryRuleScore: 99,
+              }),
+              provenance: [{ term: "sales", source: "searchText" }],
+            },
+          ],
+        });
+      }
+
+      if (call.pathName === "resumes:searchWithTagExpansionScanPage") {
+        return convexSuccess({
+          page: call.args.paginationOpts && isRecord(call.args.paginationOpts) && call.args.paginationOpts.cursor === "scan-2"
+            ? [
+                {
+                  resume: buildConvexResumeRecord("resume-live-2", {
+                    name: "Alice Better",
+                    identityKey: "dup-1",
+                    primaryRuleScore: 10,
+                  }),
+                  provenance: [{ term: "cnc", source: "searchText" }],
+                },
+                {
+                  resume: buildConvexResumeRecord("resume-live-3", {
+                    name: "Carla",
+                    identityKey: "dup-2",
+                    primaryRuleScore: 40,
+                  }),
+                  provenance: [{ term: "cnc", source: "searchText" }],
+                },
+              ]
+            : [
+                {
+                  resume: buildConvexResumeRecord("resume-live-1", {
+                    name: "Alice Older",
+                    identityKey: "dup-1",
+                    primaryRuleScore: 99,
+                  }),
+                  provenance: [{ term: "sales", source: "searchText" }],
+                },
+              ],
+          continueCursor: call.args.paginationOpts && isRecord(call.args.paginationOpts) && call.args.paginationOpts.cursor === "scan-2"
+            ? ""
+            : "scan-2",
+          isDone: Boolean(call.args.paginationOpts && isRecord(call.args.paginationOpts) && call.args.paginationOpts.cursor === "scan-2"),
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&limit=2&sortBy=score&jobDescriptionId=jd-1&q=cnc%20sales");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.summary).toEqual(expect.objectContaining({
+      total: 2,
+      returned: 2,
+      source: "convex",
+    }));
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Alice Better", "Carla"]);
+    expect(getMatchesPageSpy).not.toHaveBeenCalled();
+    expect(getMatchesByResumeIdsSpy).toHaveBeenCalledWith(["resume-live-1", "resume-live-2", "resume-live-3"], "jd-1");
+    expect(calls.some((call) => call.pathName === "resumes:searchWithTagExpansionScanPage")).toBe(true);
+  });
+
+  it("keeps explicit non-score keyword sorts when match filters require keyword scan pagination", async () => {
+    const calls: ConvexCall[] = [];
+    const getMatchesPageSpy = vi.spyOn(MatchStorage.prototype, "getMatchesPageForJob");
+    const getMatchesByResumeIdsSpy = vi
+      .spyOn(MatchStorage.prototype, "getMatchesByResumeIds")
+      .mockImplementation((resumeIds) => {
+        const ordered = Array.isArray(resumeIds) ? resumeIds : [];
+        return ordered.flatMap((resumeId) => {
+          if (resumeId === "resume-live-1") {
+            return [buildStoredMatch("resume-live-1", { id: 1, score: 88 })];
+          }
+          if (resumeId === "resume-live-2") {
+            return [buildStoredMatch("resume-live-2", { id: 2, score: 74 })];
+          }
+          if (resumeId === "resume-live-3") {
+            return [buildStoredMatch("resume-live-3", { id: 3, score: 91 })];
+          }
+          return [];
+        });
+      });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:searchWithTagExpansionPage") {
+        return convexSuccess({
+          expansion: {
+            original: "cnc sales",
+            expanded: ["cnc", "sales"],
+            groups: [
+              { original: "cnc", variants: ["cnc"] },
+              { original: "sales", variants: ["sales"] },
+            ],
+            mode: "AND",
+          },
+          total: 3,
+          results: [
+            { resume: buildConvexResumeRecord("resume-live-1", { name: "Alice", location: "东莞" }), provenance: [{ term: "sales", source: "searchText" }] },
+            { resume: buildConvexResumeRecord("resume-live-2", { name: "Bob", location: "东莞", primaryRuleScore: 10 }), provenance: [{ term: "cnc", source: "searchText" }] },
+            { resume: buildConvexResumeRecord("resume-live-3", { name: "Carla", location: "东莞" }), provenance: [{ term: "cnc", source: "searchText" }] },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request(
+      "/api/resumes?source=convex&limit=2&jobDescriptionId=jd-1&q=cnc%20sales&minMatchScore=70&sortBy=name&sortOrder=desc"
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.success).toBe(true);
+    expect(payload.summary).toEqual(expect.objectContaining({
+      total: 3,
+      returned: 2,
+      source: "convex",
+    }));
+    expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Bob"]);
+    expect(getMatchesPageSpy).not.toHaveBeenCalled();
+    expect(getMatchesByResumeIdsSpy).toHaveBeenCalledWith(["resume-live-1", "resume-live-2", "resume-live-3"], "jd-1");
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:searchWithTagExpansionPage",
+      args: expect.objectContaining({ limit: 250, offset: 0, jobDescriptionId: "jd-1" }),
+    }));
   });
 
   it("pages score-sorted convex results through match storage and preserves explicit-id order", async () => {

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -1099,26 +1099,82 @@ function parseExactKeywordScanCandidate(
   };
 }
 
-function mergeExactKeywordScanCandidate(
-  existing: ExactKeywordScanCandidate,
-  incoming: ExactKeywordScanCandidate,
-): ExactKeywordScanCandidate {
-  const mergedProvenance = dedupeResumeSearchProvenance([
-    ...existing.provenance,
-    ...incoming.provenance,
-  ]);
-  const preferred = compareExactKeywordScanCandidates(existing, incoming) <= 0
-    ? existing
-    : incoming;
+function matchesKeywordIdentityFilters(
+  match: ResumeMatchContext | undefined,
+  minScore: number | undefined,
+  allowedRecommendations: Set<MatchingResult["recommendation"]> | null,
+): boolean {
+  if (typeof minScore === "number" && (!match || match.score < minScore)) {
+    return false;
+  }
+  if (allowedRecommendations && (!match || !allowedRecommendations.has(match.recommendation))) {
+    return false;
+  }
+  return true;
+}
 
-  return {
-    ...preferred,
-    provenance: mergedProvenance,
-    candidate: {
-      ...preferred.candidate,
-      ...(mergedProvenance.length > 0 ? { provenance: mergedProvenance } : {}),
-    },
-  };
+function compareExactKeywordIdentityCandidates(
+  left: ExactKeywordScanCandidate,
+  right: ExactKeywordScanCandidate,
+  matchMap: Map<string, ResumeMatchContext>,
+  params: {
+    minScore?: number;
+    allowedRecommendations: Set<MatchingResult["recommendation"]> | null;
+    sortBy?: "score" | "name" | "experience" | "extractedAt";
+  },
+): number {
+  const leftMatch = matchMap.get(left.candidate.resumeId);
+  const rightMatch = matchMap.get(right.candidate.resumeId);
+  const leftPasses = matchesKeywordIdentityFilters(leftMatch, params.minScore, params.allowedRecommendations);
+  const rightPasses = matchesKeywordIdentityFilters(rightMatch, params.minScore, params.allowedRecommendations);
+
+  if (leftPasses !== rightPasses) {
+    return leftPasses ? -1 : 1;
+  }
+
+  if (params.sortBy === "score" || typeof params.minScore === "number" || params.allowedRecommendations) {
+    const scoreDiff = (rightMatch?.score ?? -1) - (leftMatch?.score ?? -1);
+    if (scoreDiff !== 0) {
+      return scoreDiff;
+    }
+  }
+
+  return compareExactKeywordScanCandidates(left, right);
+}
+
+function resolveExactKeywordIdentityCandidates(
+  candidates: ExactKeywordScanCandidate[],
+  matchMap: Map<string, ResumeMatchContext>,
+  params: {
+    minScore?: number;
+    allowedRecommendations: Set<MatchingResult["recommendation"]> | null;
+    sortBy?: "score" | "name" | "experience" | "extractedAt";
+  },
+): ExactKeywordScanCandidate[] {
+  const groups = new Map<string, ExactKeywordScanCandidate[]>();
+
+  for (const candidate of candidates) {
+    const group = groups.get(candidate.identityKey);
+    if (group) {
+      group.push(candidate);
+    } else {
+      groups.set(candidate.identityKey, [candidate]);
+    }
+  }
+
+  return Array.from(groups.values()).map((group) => {
+    const preferred = [...group].sort((left, right) => compareExactKeywordIdentityCandidates(left, right, matchMap, params))[0];
+    const mergedProvenance = dedupeResumeSearchProvenance(group.flatMap((entry) => entry.provenance));
+
+    return {
+      ...preferred,
+      provenance: mergedProvenance,
+      candidate: {
+        ...preferred.candidate,
+        ...(mergedProvenance.length > 0 ? { provenance: mergedProvenance } : {}),
+      },
+    };
+  });
 }
 
 function sortKeywordMatchEntries(
@@ -1172,7 +1228,7 @@ async function prepareKeywordMatchPageByCursor(params: {
 }> {
   const canonicalKeywordQuery = formatKeywordQuery(params.keywords);
   const keywordExpansion = resumeService.expandSearchQuery(canonicalKeywordQuery);
-  const merged = new Map<string, ExactKeywordScanCandidate>();
+  const scanned: ExactKeywordScanCandidate[] = [];
   let cursor: string | null = null;
 
   while (true) {
@@ -1200,11 +1256,7 @@ async function prepareKeywordMatchPageByCursor(params: {
       if (!parsed) {
         continue;
       }
-      const existing = merged.get(parsed.identityKey);
-      merged.set(
-        parsed.identityKey,
-        existing ? mergeExactKeywordScanCandidate(existing, parsed) : parsed,
-      );
+      scanned.push(parsed);
     }
 
     if (value.isDone) {
@@ -1219,13 +1271,18 @@ async function prepareKeywordMatchPageByCursor(params: {
 
   const fullMatchMap = loadResumeMatchContextMap(
     params.jobDescriptionId,
-    Array.from(merged.values()).map((entry) => entry.candidate.resumeId),
+    scanned.map((entry) => entry.candidate.resumeId),
   );
   const allowedRecommendations = params.recommendation?.length
     ? new Set(params.recommendation)
     : null;
+  const merged = resolveExactKeywordIdentityCandidates(scanned, fullMatchMap, {
+    minScore: params.minScore,
+    allowedRecommendations,
+    sortBy: params.sortBy,
+  });
 
-  let working: SortableKeywordMatchEntry[] = Array.from(merged.values()).map((entry) => ({
+  let working: SortableKeywordMatchEntry[] = merged.map((entry) => ({
     candidate: entry.candidate,
     match: fullMatchMap.get(entry.candidate.resumeId),
     sortMetadata: entry,


### PR DESCRIPTION
## Summary\n- choose duplicate keyword-scan identity representatives after match context is loaded so score/match requests keep the best matching duplicate\n- add regressions for duplicate identity selection in oversized exact scans and for explicit non-score keyword sorts under match filters\n- keep the rest of the keyword pagination path unchanged\n\n## Validation\n- npx vitest run /root/workspace/apps/api/src/routes/resumes.test.ts\n- bun run --filter @trends/api typecheck\n- make check