### PR TITLE
fix: align web JD keyword search with exact scan

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.test.ts
+++ b/apps/web/src/hooks/useConvexResumes.test.ts
@@ -18,6 +18,15 @@ const rawApiGetMock = vi.fn(async (path?: unknown, options?: unknown) => {
     },
   }
 })
+const rawApiPostMock = vi.fn(async (...args: unknown[]) => {
+  void args
+  return {
+    data: {
+      success: true,
+      results: [] as Array<{ resumeId: string; score: number; recommendation: string }>,
+    },
+  }
+})
 
 type PaginatedResult = {
   results: Array<Record<string, unknown>>
@@ -40,25 +49,38 @@ vi.mock('convex/react', () => ({
 vi.mock('@/lib/api-helpers', () => ({
   rawApiClient: {
     GET: (path: unknown, options?: unknown) => rawApiGetMock(path, options),
+    POST: (path: unknown, options?: unknown) => rawApiPostMock(path, options),
   },
 }))
 
-function buildResumeDoc(id: string, name: string): Record<string, unknown> {
+function buildResumeDoc(
+  id: string,
+  name: string,
+  overrides?: {
+    identityKey?: string
+    primaryRuleScore?: number
+    experience?: string
+    extractedAt?: string
+    crawledAt?: number
+  },
+): Record<string, unknown> {
   return {
     _id: id,
     externalId: `ext-${id}`,
     source: 'hr.job5156.com',
     tags: [],
-    crawledAt: 1_700_000_000_000,
+    identityKey: overrides?.identityKey,
+    crawledAt: overrides?.crawledAt ?? 1_700_000_000_000,
+    primaryRuleScore: overrides?.primaryRuleScore,
     content: {
       name,
-      experience: '5 years',
+      experience: overrides?.experience ?? '5 years',
       education: 'Bachelor',
       location: 'Dongguan',
       selfIntro: 'Intro',
       jobIntention: 'Sales Engineer',
       expectedSalary: '10k-20k',
-      extractedAt: '2026-03-01T00:00:00.000Z',
+      extractedAt: overrides?.extractedAt ?? '2026-03-01T00:00:00.000Z',
     },
     ingestData: {
       industryTags: [],
@@ -83,6 +105,15 @@ function buildSearchEntry(id: string, name: string): Record<string, unknown> {
 describe('useConvexResumes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    rawApiPostMock.mockImplementation(async (...args: unknown[]) => {
+      void args
+      return {
+        data: {
+          success: true,
+          results: [] as Array<{ resumeId: string; score: number; recommendation: string }>,
+        },
+      }
+    })
     usePaginatedQueryMock.mockImplementation((_query, args) => ({
       results: args === 'skip' ? [] : [buildResumeDoc('resume-1', 'Alice')],
       status: 'Exhausted',
@@ -211,11 +242,24 @@ describe('useConvexResumes', () => {
     })
 
     await waitFor(() => {
-      const searchCall = usePaginatedQueryMock.mock.calls.find(([, args]) => args !== 'skip' && 'query' in (args as Record<string, unknown>))
+      const searchCall = usePaginatedQueryMock.mock.calls.find(([, args]) =>
+        args !== 'skip'
+        && 'query' in (args as Record<string, unknown>)
+        && !('jobDescriptionId' in (args as Record<string, unknown>))
+      )
       expect(searchCall?.[1]).toMatchObject({
-        jobDescriptionId: 'jd-1',
         requiredKeywords: ['machine tools', 'cnc'],
       })
+    })
+
+    expect(rawApiPostMock).toHaveBeenCalledWith('/api/resumes/match', {
+      body: {
+        source: 'convex',
+        persist: false,
+        mode: 'rules_only',
+        jobDescriptionId: 'jd-1',
+        resumeIds: ['resume-1'],
+      },
     })
   })
 
@@ -255,6 +299,84 @@ describe('useConvexResumes', () => {
 
     await waitFor(() => {
       expect(result.current.resumes.map((resume) => resume.name)).toEqual(['Fallback Candidate'])
+    })
+  })
+
+  it('prefers the best JD match when exact keyword scan returns duplicate identities', async () => {
+    rawApiPostMock.mockResolvedValue({
+      data: {
+        success: true,
+        results: [
+          { resumeId: 'resume-low-match', score: 35, recommendation: 'potential' },
+          { resumeId: 'resume-best-match', score: 91, recommendation: 'match' },
+          { resumeId: 'resume-third', score: 72, recommendation: 'match' },
+        ],
+      },
+    })
+
+    usePaginatedQueryMock.mockImplementation((_query, args) => {
+      if (args === 'skip') {
+        return {
+          results: [],
+          status: 'Exhausted',
+          isLoading: false,
+          loadMore: loadMoreMock,
+        }
+      }
+
+      if ('query' in (args as Record<string, unknown>)) {
+        return {
+          results: [
+            {
+              resume: buildResumeDoc('resume-low-match', 'Lower Match Duplicate', {
+                identityKey: 'identity-1',
+                primaryRuleScore: 90,
+                crawledAt: 1_700_000_000_000,
+              }),
+              provenance: [{ term: 'cnc', source: 'searchText' }],
+            },
+            {
+              resume: buildResumeDoc('resume-best-match', 'Best Match Duplicate', {
+                identityKey: 'identity-1',
+                primaryRuleScore: 60,
+                crawledAt: 1_700_000_000_100,
+              }),
+              provenance: [{ term: 'sales', source: 'searchText' }],
+            },
+            {
+              resume: buildResumeDoc('resume-third', 'Third Candidate', {
+                identityKey: 'identity-2',
+                primaryRuleScore: 70,
+                crawledAt: 1_700_000_000_200,
+              }),
+              provenance: [{ term: 'cnc', source: 'searchText' }],
+            },
+          ],
+          status: 'Exhausted',
+          isLoading: false,
+          loadMore: loadMoreMock,
+        }
+      }
+
+      return {
+        results: [],
+        status: 'Exhausted',
+        isLoading: false,
+        loadMore: loadMoreMock,
+      }
+    })
+
+    const { result } = renderHook(() => useConvexResumes(200, 'CNC sales', 'jd-1'))
+
+    await waitFor(() => {
+      expect(rawApiPostMock).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(result.current.resumes.map((resume) => resume.name)).toEqual([
+        'Best Match Duplicate',
+        'Third Candidate',
+      ])
     })
   })
 })

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -205,6 +205,15 @@ type IndexedMockSearchResult = MockSearchResult & {
   provenance: SearchProvenance[]
 }
 
+type SearchResultEntry = {
+  resume: ResumeListDocLike
+  provenance?: SearchProvenance[]
+}
+
+type ExactKeywordMatchContext = {
+  score: number
+}
+
 function buildFallbackKeywordExpansion(query: string): KeywordExpansionSummary {
   const parsed = parseKeywordQuery(query)
   const terms = parsed.keywords
@@ -719,6 +728,124 @@ function mapResumeDoc(doc: ResumeListDocLike): ConvexResumeItem {
   }
 }
 
+function getResumeIdentityKey(doc: ResumeListDocLike): string {
+  const identityKey = typeof doc.identityKey === 'string' ? doc.identityKey.trim() : ''
+  return identityKey || String(doc._id)
+}
+
+function mergeSearchProvenance(
+  left: SearchProvenance[] | undefined,
+  right: SearchProvenance[] | undefined,
+): SearchProvenance[] {
+  const merged: SearchProvenance[] = []
+  const seen = new Set<string>()
+
+  for (const entry of [...(left ?? []), ...(right ?? [])]) {
+    const key = `${entry.term}::${entry.source}::${entry.expandedFrom ?? ''}`
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    merged.push(entry)
+  }
+
+  return merged
+}
+
+function getKeywordMatchScore(
+  entry: SearchResultEntry,
+  matchMap: Readonly<Record<string, ExactKeywordMatchContext>>,
+): number {
+  return matchMap[String(entry.resume._id)]?.score ?? -1
+}
+
+function getKeywordPrimaryRuleScore(entry: SearchResultEntry): number {
+  return typeof entry.resume.primaryRuleScore === 'number' ? entry.resume.primaryRuleScore : 0
+}
+
+function compareExactKeywordDuplicateSelection(
+  left: SearchResultEntry,
+  right: SearchResultEntry,
+  matchMap: Readonly<Record<string, ExactKeywordMatchContext>>,
+): number {
+  const matchScoreDiff = getKeywordMatchScore(right, matchMap) - getKeywordMatchScore(left, matchMap)
+  if (matchScoreDiff !== 0) {
+    return matchScoreDiff
+  }
+
+  const primaryRuleDiff = getKeywordPrimaryRuleScore(right) - getKeywordPrimaryRuleScore(left)
+  if (primaryRuleDiff !== 0) {
+    return primaryRuleDiff
+  }
+
+  return right.resume.crawledAt - left.resume.crawledAt
+}
+
+function parseKeywordEntryExperience(entry: SearchResultEntry): number {
+  const content = isRecord(entry.resume.content) ? entry.resume.content : {}
+  const matched = toStringValue(content.experience).match(/\d+(?:\.\d+)?/)
+  if (!matched?.[0]) {
+    return -1
+  }
+
+  const parsed = Number(matched[0])
+  return Number.isFinite(parsed) ? parsed : -1
+}
+
+function parseKeywordEntryExtractedAt(entry: SearchResultEntry): number {
+  const content = isRecord(entry.resume.content) ? entry.resume.content : {}
+  const timestamp = Date.parse(toStringValue(content.extractedAt))
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+function sortKeywordEntries(
+  entries: SearchResultEntry[],
+  sortBy: ConvexResumeSortBy | undefined,
+  sortOrder: 'asc' | 'desc' | undefined,
+): SearchResultEntry[] {
+  if (!sortBy) {
+    return entries
+  }
+
+  const direction = (sortOrder ?? 'desc') === 'desc' ? -1 : 1
+  return [...entries].sort((left, right) => {
+    if (sortBy === 'experience') {
+      return (parseKeywordEntryExperience(left) - parseKeywordEntryExperience(right)) * direction
+    }
+
+    return (parseKeywordEntryExtractedAt(left) - parseKeywordEntryExtractedAt(right)) * direction
+  })
+}
+
+function dedupeExactKeywordEntries(
+  entries: SearchResultEntry[],
+  matchMap: Readonly<Record<string, ExactKeywordMatchContext>>,
+): SearchResultEntry[] {
+  const deduped = new Map<string, SearchResultEntry>()
+
+  for (const entry of entries) {
+    const identityKey = getResumeIdentityKey(entry.resume)
+    const existing = deduped.get(identityKey)
+    if (!existing) {
+      deduped.set(identityKey, {
+        ...entry,
+        provenance: mergeSearchProvenance(undefined, entry.provenance),
+      })
+      continue
+    }
+
+    const preferred = compareExactKeywordDuplicateSelection(existing, entry, matchMap) <= 0
+      ? existing
+      : entry
+    deduped.set(identityKey, {
+      ...preferred,
+      provenance: mergeSearchProvenance(existing.provenance, entry.provenance),
+    })
+  }
+
+  return Array.from(deduped.values())
+}
+
 export function useConvexResumes(
   limit: number = DEFAULT_CONVEX_RESUME_LIMIT,
   query?: string,
@@ -731,6 +858,7 @@ export function useConvexResumes(
 ) {
   const normalizedJobDescriptionId = jobDescriptionId?.trim() || undefined
   const normalizedQuery = query?.trim() || undefined
+  const useExactKeywordScan = Boolean(normalizedQuery && normalizedJobDescriptionId)
   const resolvedSortOrder = options?.sortBy ? (options.sortOrder ?? 'desc') : undefined
   const initialNumItems = Math.min(limit, CONVEX_RESUME_PAGE_SIZE)
   const mockPayload = useMemo(() => readMockConvexResumePayload(), [])
@@ -819,7 +947,7 @@ export function useConvexResumes(
     api.resumes.searchWithTagExpansionPaginated,
     mockPayload
       ? 'skip'
-      : normalizedQuery && keywordExpansion
+      : !useExactKeywordScan && normalizedQuery && keywordExpansion
         ? {
             query: normalizedQuery,
             keywordGroups: keywordExpansion.groups,
@@ -834,6 +962,27 @@ export function useConvexResumes(
               sortBy: options.sortBy,
               sortOrder: resolvedSortOrder,
             } : {}),
+          }
+        : 'skip',
+    {
+      initialNumItems,
+    }
+  )
+
+  const paginatedKeywordScanResults = usePaginatedQuery(
+    api.resumes.searchWithTagExpansionScanPage,
+    mockPayload
+      ? 'skip'
+      : normalizedQuery && normalizedJobDescriptionId && keywordExpansion
+        ? {
+            query: normalizedQuery,
+            keywordGroups: keywordExpansion.groups,
+            mode: keywordExpansion.mode,
+            sourceMappings: Object.entries(keywordExpansion.sourceMapping).map(([term, expandedFrom]) => ({
+              term,
+              expandedFrom,
+            })),
+            ...(options?.filters ?? {}),
           }
         : 'skip',
     {
@@ -860,22 +1009,138 @@ export function useConvexResumes(
     }
   )
 
+  const [exactKeywordMatchMap, setExactKeywordMatchMap] = useState<Record<string, ExactKeywordMatchContext>>({})
+  const exactKeywordResumeIds = useMemo(() => {
+    if (!useExactKeywordScan) {
+      return []
+    }
+
+    return Array.from(new Set(
+      paginatedKeywordScanResults.results.map((entry) => String(entry.resume._id))
+    )).sort()
+  }, [paginatedKeywordScanResults.results, useExactKeywordScan])
+  const exactKeywordMatchScopeKey = useMemo(() => {
+    if (!useExactKeywordScan) {
+      return ''
+    }
+
+    return JSON.stringify({
+      jobDescriptionId: normalizedJobDescriptionId,
+      resumeIds: exactKeywordResumeIds,
+    })
+  }, [exactKeywordResumeIds, normalizedJobDescriptionId, useExactKeywordScan])
+
+  useEffect(() => {
+    let active = true
+
+    if (!useExactKeywordScan || !normalizedJobDescriptionId) {
+      setExactKeywordMatchMap((current) => (Object.keys(current).length === 0 ? current : {}))
+      return () => {
+        active = false
+      }
+    }
+
+    if (exactKeywordResumeIds.length === 0) {
+      setExactKeywordMatchMap((current) => (Object.keys(current).length === 0 ? current : {}))
+      return () => {
+        active = false
+      }
+    }
+
+    void rawApiClient
+      .POST<{
+        success: boolean
+        results?: Array<{
+          resumeId: string
+          score: number
+          recommendation: string
+        }>
+      }>('/api/resumes/match', {
+        body: {
+          source: 'convex',
+          persist: false,
+          mode: 'rules_only',
+          jobDescriptionId: normalizedJobDescriptionId,
+          resumeIds: exactKeywordResumeIds,
+        },
+      })
+      .then(({ data, error }) => {
+        if (!active) {
+          return
+        }
+
+        if (error || !data?.success) {
+          setExactKeywordMatchMap({})
+          return
+        }
+
+        const nextMatchMap: Record<string, ExactKeywordMatchContext> = {}
+        for (const item of data.results ?? []) {
+          nextMatchMap[item.resumeId] = {
+            score: item.score,
+          }
+        }
+        setExactKeywordMatchMap(nextMatchMap)
+      })
+      .catch((error: unknown) => {
+        console.error('Failed to load exact keyword match scores', error)
+        if (active) {
+          setExactKeywordMatchMap({})
+        }
+      })
+
+    return () => {
+      active = false
+    }
+  }, [exactKeywordMatchScopeKey, exactKeywordResumeIds, normalizedJobDescriptionId, useExactKeywordScan])
+
+  const dedupedExactKeywordEntries = useMemo(() => {
+    if (mockPayload || !useExactKeywordScan) {
+      return []
+    }
+
+    return sortKeywordEntries(
+      dedupeExactKeywordEntries(paginatedKeywordScanResults.results, exactKeywordMatchMap),
+      options?.sortBy,
+      resolvedSortOrder,
+    )
+  }, [
+    exactKeywordMatchMap,
+    mockPayload,
+    options?.sortBy,
+    paginatedKeywordScanResults.results,
+    resolvedSortOrder,
+    useExactKeywordScan,
+  ])
+
   const useJobDescriptionFallback = Boolean(
     normalizedQuery
       && normalizedJobDescriptionId
       && !expansionLoading
-      && paginatedSearchResults.status === 'Exhausted'
-      && paginatedSearchResults.results.length === 0
+      && (useExactKeywordScan ? paginatedKeywordScanResults.status : paginatedSearchResults.status) === 'Exhausted'
+      && (useExactKeywordScan ? paginatedKeywordScanResults.results.length : paginatedSearchResults.results.length) === 0
   )
 
   const activePaginatedStatus = normalizedQuery
-    ? (useJobDescriptionFallback ? paginatedListResults.status : paginatedSearchResults.status)
+    ? (useJobDescriptionFallback
+        ? paginatedListResults.status
+        : useExactKeywordScan
+          ? paginatedKeywordScanResults.status
+          : paginatedSearchResults.status)
     : paginatedListResults.status
   const activePaginatedResultsLength = normalizedQuery
-    ? (useJobDescriptionFallback ? paginatedListResults.results.length : paginatedSearchResults.results.length)
+    ? (useJobDescriptionFallback
+        ? paginatedListResults.results.length
+        : useExactKeywordScan
+          ? dedupedExactKeywordEntries.length
+          : paginatedSearchResults.results.length)
     : paginatedListResults.results.length
   const activePaginatedLoadMore = normalizedQuery
-    ? (useJobDescriptionFallback ? paginatedListResults.loadMore : paginatedSearchResults.loadMore)
+    ? (useJobDescriptionFallback
+        ? paginatedListResults.loadMore
+        : useExactKeywordScan
+          ? paginatedKeywordScanResults.loadMore
+          : paginatedSearchResults.loadMore)
     : paginatedListResults.loadMore
 
   useEffect(() => {
@@ -898,6 +1163,10 @@ export function useConvexResumes(
     () => paginatedSearchResults.results.slice(0, limit),
     [limit, paginatedSearchResults.results]
   )
+  const visibleExactKeywordEntries = useMemo(
+    () => dedupedExactKeywordEntries.slice(0, limit),
+    [dedupedExactKeywordEntries, limit]
+  )
   const visibleListResults = useMemo(
     () => paginatedListResults.results.slice(0, limit),
     [limit, paginatedListResults.results]
@@ -918,12 +1187,27 @@ export function useConvexResumes(
       : normalizedQuery
         ? useJobDescriptionFallback
           ? visibleListResults.map(mapResumeDoc)
+          : useExactKeywordScan
+            ? visibleExactKeywordEntries.map((entry) => ({
+                ...mapResumeDoc(entry.resume),
+                _provenance: entry.provenance,
+              }))
           : visibleSearchResults.map((entry) => ({
               ...mapResumeDoc(entry.resume),
               _provenance: entry.provenance,
             }))
         : visibleListResults.map(mapResumeDoc)
-  ), [limit, mockKeywordExpansion, mockPayload, normalizedQuery, useJobDescriptionFallback, visibleListResults, visibleSearchResults])
+  ), [
+    limit,
+    mockKeywordExpansion,
+    mockPayload,
+    normalizedQuery,
+    useExactKeywordScan,
+    useJobDescriptionFallback,
+    visibleExactKeywordEntries,
+    visibleListResults,
+    visibleSearchResults,
+  ])
 
   const isLoading = mockPayload
     ? false


### PR DESCRIPTION
## Summary
- switch JD-backed keyword resume hooks onto the exact Convex scan path instead of the older paginated merged search path
- load JD match scores for scanned Convex resumes so duplicate identity selection prefers the best JD match before the web UI filters locally
- add hook regressions for the exact-scan JD path, including duplicate identity selection and required-keyword forwarding

## Validation
- bun run --filter '@trends/web' test -- src/hooks/useConvexResumes.test.ts src/hooks/useResumeListState.test.tsx
- bun run --filter '@trends/web' typecheck
- make check