### PR TITLE
feat: add search-first resume UI

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import { prettyJSON } from "hono/pretty-json";
 import {
   healthRoutes,
   aiSummaryRoutes,
+  taxonomyRoutes,
   trendsRoutes,
   topicsRoutes,
   searchRoutes,
@@ -77,6 +78,7 @@ export function createApp() {
   // Mount routes
   app.route("/", healthRoutes);
   app.route("/", aiSummaryRoutes);
+  app.route("/", taxonomyRoutes);
   app.route("/", trendsRoutes);
   app.route("/", topicsRoutes);
   app.route("/", searchRoutes);

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,6 +5,7 @@ import { prettyJSON } from "hono/pretty-json";
 
 import {
   healthRoutes,
+  aiSummaryRoutes,
   trendsRoutes,
   topicsRoutes,
   searchRoutes,
@@ -75,6 +76,7 @@ export function createApp() {
 
   // Mount routes
   app.route("/", healthRoutes);
+  app.route("/", aiSummaryRoutes);
   app.route("/", trendsRoutes);
   app.route("/", topicsRoutes);
   app.route("/", searchRoutes);

--- a/apps/api/src/routes/ai-summary.test.ts
+++ b/apps/api/src/routes/ai-summary.test.ts
@@ -287,4 +287,37 @@ describe("ai summary routes", () => {
       expect.any(Error),
     )
   })
+
+  it("returns a stable json error when summary generation fails without usable cache", async () => {
+    vi.spyOn(aiSummaryService, "generateSummary").mockRejectedValue(new Error("LLM unavailable"))
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+
+      expect(call.method).toBe("query")
+      expect(call.pathName).toBe("ai_summary_cache:get")
+
+      return convexSuccess(null)
+    })
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const app = createTestApp()
+    const response = await app.request("/api/resumes/search-summary", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify(createSummaryRequestBody()),
+    })
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Failed to generate AI search summary",
+    })
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to generate AI search summary",
+      expect.any(Error),
+    )
+  })
 })

--- a/apps/api/src/routes/ai-summary.test.ts
+++ b/apps/api/src/routes/ai-summary.test.ts
@@ -1,0 +1,290 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import aiSummaryRoutes from "./ai-summary";
+import { workspaceMiddleware } from "../middleware/workspace";
+import { aiSummaryService } from "../services/ai-summary-service";
+
+const {
+  resolveConvexUrlMock,
+} = vi.hoisted(() => ({
+  resolveConvexUrlMock: vi.fn(() => "http://127.0.0.1:3210"),
+}))
+
+vi.mock("../services/resume-import-service.js", () => ({
+  resolveConvexUrl: () => resolveConvexUrlMock(),
+}))
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use("*", workspaceMiddleware)
+  app.route("/", aiSummaryRoutes)
+  return app
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function convexSuccess(value: unknown): Response {
+  return new Response(
+    JSON.stringify({
+      status: "success",
+      value,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  )
+}
+
+function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): {
+  method: "query" | "mutation"
+  pathName: string
+  args: Record<string, unknown>
+} {
+  const requestUrl = typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url
+  const method = requestUrl.includes("/api/mutation") ? "mutation" : "query"
+  const body = typeof init?.body === "string" ? JSON.parse(init.body) : null
+  if (!isRecord(body)) {
+    throw new Error("Missing convex request body")
+  }
+
+  const pathName = typeof body.path === "string" ? body.path : ""
+  const args = isRecord(body.args) ? body.args : {}
+  if (!pathName) {
+    throw new Error("Missing convex path in request body")
+  }
+
+  return {
+    method,
+    pathName,
+    args,
+  }
+}
+
+function createSummaryRequestBody(overrides: Record<string, unknown> = {}) {
+  return {
+    urlHash: "search-url-hash",
+    query: "machine tools sales",
+    location: "Malaysia",
+    jobDescriptionId: "jd-machine-tools",
+    facets: {
+      selectedTags: ["cluster:manufacturing-systems", "Machine Tools"],
+      selectedCompanies: ["FANUC"],
+      selectedExperienceLevel: "senior",
+    },
+    resultCount: 2,
+    resultSetHash: "result-set-hash",
+    results: [
+      {
+        id: "resume-1",
+        name: "Ada Tan",
+        title: "Regional Sales Manager",
+        location: "Kuala Lumpur",
+        score: 96,
+        keywords: ["Machine Tools", "FANUC"],
+        snippet: "Led machine tools sales across Malaysia.",
+      },
+      {
+        id: "resume-2",
+        name: "Ben Lee",
+        title: "Sales Engineer",
+        location: "Johor",
+        score: 90,
+        keywords: ["CNC", "Automation"],
+        snippet: "Built CNC pipeline coverage.",
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe("ai summary routes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns a cached summary for the requested workspace and surfaces stale-refresh metadata", async () => {
+    const now = Date.UTC(2026, 2, 27, 20, 0, 0)
+    vi.spyOn(Date, "now").mockReturnValue(now)
+    const generateSummarySpy = vi.spyOn(aiSummaryService, "generateSummary")
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+
+      expect(call.method).toBe("query")
+      expect(call.pathName).toBe("ai_summary_cache:get")
+      expect(call.args).toEqual({
+        workspaceSlug: "hr",
+        urlHash: "search-url-hash",
+      })
+
+      return convexSuccess({
+        summary: "Cached recruiter summary",
+        model: "anthropic/claude-3-haiku-20240307",
+        generatedAt: now - (55 * 60 * 1000),
+        expiresAt: now + (5 * 60 * 1000),
+        resultSetHash: "result-set-hash",
+      })
+    })
+
+    const app = createTestApp()
+    const response = await app.request("/api/resumes/search-summary", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify(createSummaryRequestBody()),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      success: true,
+      summary: "Cached recruiter summary",
+      model: "anthropic/claude-3-haiku-20240307",
+      generatedAt: now - (55 * 60 * 1000),
+      shouldRefresh: true,
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(generateSummarySpy).not.toHaveBeenCalled()
+  })
+
+  it("generates and upserts a summary when the cache misses", async () => {
+    const now = Date.UTC(2026, 2, 27, 21, 0, 0)
+    const requestBody = createSummaryRequestBody()
+    vi.spyOn(Date, "now").mockReturnValue(now)
+    const generateSummarySpy = vi.spyOn(aiSummaryService, "generateSummary").mockResolvedValue({
+      summary: "Generated recruiter summary",
+      model: "anthropic/claude-3-haiku-20240307",
+    })
+    const calls: Array<{ method: "query" | "mutation"; pathName: string; args: Record<string, unknown> }> = []
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+      calls.push(call)
+
+      if (call.method === "query" && call.pathName === "ai_summary_cache:get") {
+        return convexSuccess(null)
+      }
+
+      if (call.method === "mutation" && call.pathName === "ai_summary_cache:upsert") {
+        return convexSuccess("cache-record-1")
+      }
+
+      throw new Error(`Unexpected convex call: ${call.method} ${call.pathName}`)
+    })
+
+    const app = createTestApp()
+    const response = await app.request("/api/resumes/search-summary", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify(requestBody),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      success: true,
+      summary: "Generated recruiter summary",
+      model: "anthropic/claude-3-haiku-20240307",
+      generatedAt: now,
+    })
+    expect(generateSummarySpy).toHaveBeenCalledWith({
+      workspaceSlug: "hr",
+      query: "machine tools sales",
+      location: "Malaysia",
+      jobDescriptionId: "jd-machine-tools",
+      facets: {
+        selectedTags: ["cluster:manufacturing-systems", "Machine Tools"],
+        selectedCompanies: ["FANUC"],
+        selectedExperienceLevel: "senior",
+      },
+      results: requestBody.results,
+    })
+    expect(calls).toEqual([
+      {
+        method: "query",
+        pathName: "ai_summary_cache:get",
+        args: {
+          workspaceSlug: "hr",
+          urlHash: "search-url-hash",
+        },
+      },
+      {
+        method: "mutation",
+        pathName: "ai_summary_cache:upsert",
+        args: {
+          urlHash: "search-url-hash",
+          workspaceSlug: "hr",
+          query: "machine tools sales",
+          facets: JSON.stringify({
+            selectedTags: ["cluster:manufacturing-systems", "Machine Tools"],
+            selectedCompanies: ["FANUC"],
+            selectedExperienceLevel: "senior",
+          }),
+          resultCount: 2,
+          resultSetHash: "result-set-hash",
+          summary: "Generated recruiter summary",
+          model: "anthropic/claude-3-haiku-20240307",
+          generatedAt: now,
+          expiresAt: now + (60 * 60 * 1000),
+        },
+      },
+    ])
+  })
+
+  it("falls back to cached content when generation fails after a forced refresh", async () => {
+    const now = Date.UTC(2026, 2, 27, 22, 0, 0)
+    vi.spyOn(Date, "now").mockReturnValue(now)
+    vi.spyOn(aiSummaryService, "generateSummary").mockRejectedValue(new Error("LLM unavailable"))
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+
+      expect(call.method).toBe("query")
+      expect(call.pathName).toBe("ai_summary_cache:get")
+
+      return convexSuccess({
+        summary: "Fallback cached recruiter summary",
+        model: "anthropic/claude-3-haiku-20240307",
+        generatedAt: now - (2 * 60 * 60 * 1000),
+        expiresAt: now - 1,
+        resultSetHash: "older-result-set-hash",
+      })
+    })
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const app = createTestApp()
+    const response = await app.request("/api/resumes/search-summary", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify(createSummaryRequestBody({
+        forceRefresh: true,
+      })),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      success: true,
+      summary: "Fallback cached recruiter summary",
+      model: "anthropic/claude-3-haiku-20240307",
+      generatedAt: now - (2 * 60 * 60 * 1000),
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to generate AI search summary",
+      expect.any(Error),
+    )
+  })
+})

--- a/apps/api/src/routes/ai-summary.ts
+++ b/apps/api/src/routes/ai-summary.ts
@@ -1,0 +1,183 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { resolveConvexUrl } from "../services/resume-import-service.js";
+import { aiSummaryService } from "../services/ai-summary-service.js";
+
+const AI_SUMMARY_TTL_MS = 60 * 60 * 1000;
+const AI_SUMMARY_STALE_AFTER_MS = 50 * 60 * 1000;
+
+const app = new OpenAPIHono();
+
+const SummaryCandidateSchema = z.object({
+  id: z.string(),
+  keywords: z.array(z.string()).optional(),
+  location: z.string().optional(),
+  name: z.string(),
+  score: z.number().optional(),
+  snippet: z.string(),
+  title: z.string().optional(),
+});
+
+const SearchSummaryRequestSchema = z.object({
+  urlHash: z.string().min(1),
+  query: z.string().min(1),
+  location: z.string().optional(),
+  jobDescriptionId: z.string().optional(),
+  facets: z.object({
+    selectedTags: z.array(z.string()).optional(),
+    selectedCompanies: z.array(z.string()).optional(),
+    selectedExperienceLevel: z.string().optional(),
+  }).optional(),
+  resultCount: z.number().int().min(0),
+  resultSetHash: z.string().min(1),
+  results: z.array(SummaryCandidateSchema).min(1).max(20),
+  forceRefresh: z.boolean().optional(),
+});
+
+const SearchSummaryResponseSchema = z.object({
+  success: z.literal(true),
+  summary: z.string(),
+  model: z.string(),
+  generatedAt: z.number(),
+  shouldRefresh: z.boolean().optional(),
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function callConvex(
+  type: "query" | "mutation",
+  pathName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+  const response = await fetch(`${convexUrl}/api/${type}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ path: pathName, args }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Convex ${type} failed (${response.status}): ${await response.text()}`);
+  }
+
+  const payload = await response.json() as unknown;
+  if (!isRecord(payload) || payload.status !== "success") {
+    throw new Error(`Convex ${type} failed for ${pathName}`);
+  }
+
+  return payload.value;
+}
+
+const searchSummaryRoute = createRoute({
+  method: "post",
+  path: "/api/resumes/search-summary",
+  tags: ["resumes"],
+  summary: "Generate or return a cached AI summary for the current resume search result set",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: SearchSummaryRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "AI summary response",
+      content: {
+        "application/json": {
+          schema: SearchSummaryResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(searchSummaryRoute, async (c) => {
+  const body = c.req.valid("json");
+  const workspaceSlug = c.var.workspaceSlug;
+  const now = Date.now();
+  const cached = await callConvex("query", "ai_summary_cache:get", {
+    urlHash: body.urlHash,
+  }) as {
+    summary?: string;
+    model?: string;
+    generatedAt?: number;
+    expiresAt?: number;
+    resultSetHash?: string;
+  } | null;
+
+  if (
+    !body.forceRefresh
+    && cached
+    && cached.summary
+    && cached.model
+    && typeof cached.generatedAt === "number"
+    && typeof cached.expiresAt === "number"
+    && cached.expiresAt > now
+    && cached.resultSetHash === body.resultSetHash
+  ) {
+    return c.json({
+      success: true as const,
+      summary: cached.summary,
+      model: cached.model,
+      generatedAt: cached.generatedAt,
+      shouldRefresh: cached.generatedAt <= (now - AI_SUMMARY_STALE_AFTER_MS),
+    }, 200);
+  }
+
+  try {
+    const generated = await aiSummaryService.generateSummary({
+      workspaceSlug,
+      query: body.query,
+      location: body.location,
+      jobDescriptionId: body.jobDescriptionId,
+      facets: body.facets,
+      results: body.results,
+    });
+
+    await callConvex("mutation", "ai_summary_cache:upsert", {
+      urlHash: body.urlHash,
+      workspaceSlug,
+      query: body.query,
+      facets: body.facets ? JSON.stringify(body.facets) : undefined,
+      resultCount: body.resultCount,
+      resultSetHash: body.resultSetHash,
+      summary: generated.summary,
+      model: generated.model,
+      generatedAt: now,
+      expiresAt: now + AI_SUMMARY_TTL_MS,
+    });
+
+    return c.json({
+      success: true as const,
+      summary: generated.summary,
+      model: generated.model,
+      generatedAt: now,
+    }, 200);
+  } catch (error) {
+    console.error("Failed to generate AI search summary", error);
+    if (
+      cached
+      && typeof cached.summary === "string"
+      && typeof cached.model === "string"
+      && typeof cached.generatedAt === "number"
+    ) {
+      return c.json({
+        success: true as const,
+        summary: cached.summary,
+        model: cached.model,
+        generatedAt: cached.generatedAt,
+      }, 200);
+    }
+
+    throw error;
+  }
+});
+
+export default app;

--- a/apps/api/src/routes/ai-summary.ts
+++ b/apps/api/src/routes/ai-summary.ts
@@ -41,6 +41,11 @@ const SearchSummaryResponseSchema = z.object({
   shouldRefresh: z.boolean().optional(),
 });
 
+const SearchSummaryErrorResponseSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+});
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -92,6 +97,14 @@ const searchSummaryRoute = createRoute({
       content: {
         "application/json": {
           schema: SearchSummaryResponseSchema,
+        },
+      },
+    },
+    500: {
+      description: "AI summary generation failed",
+      content: {
+        "application/json": {
+          schema: SearchSummaryErrorResponseSchema,
         },
       },
     },
@@ -177,7 +190,10 @@ app.openapi(searchSummaryRoute, async (c) => {
       }, 200);
     }
 
-    throw error;
+    return c.json({
+      success: false as const,
+      error: "Failed to generate AI search summary",
+    }, 500);
   }
 });
 

--- a/apps/api/src/routes/ai-summary.ts
+++ b/apps/api/src/routes/ai-summary.ts
@@ -103,6 +103,7 @@ app.openapi(searchSummaryRoute, async (c) => {
   const workspaceSlug = c.var.workspaceSlug;
   const now = Date.now();
   const cached = await callConvex("query", "ai_summary_cache:get", {
+    workspaceSlug,
     urlHash: body.urlHash,
   }) as {
     summary?: string;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,5 +1,6 @@
 export { default as healthRoutes } from "./health.js";
 export { default as aiSummaryRoutes } from "./ai-summary.js";
+export { default as taxonomyRoutes } from "./taxonomy.js";
 export { default as trendsRoutes } from "./trends.js";
 export { default as topicsRoutes } from "./topics.js";
 export { default as searchRoutes } from "./search.js";

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,4 +1,5 @@
 export { default as healthRoutes } from "./health.js";
+export { default as aiSummaryRoutes } from "./ai-summary.js";
 export { default as trendsRoutes } from "./trends.js";
 export { default as topicsRoutes } from "./topics.js";
 export { default as searchRoutes } from "./search.js";

--- a/apps/api/src/routes/job-descriptions.test.ts
+++ b/apps/api/src/routes/job-descriptions.test.ts
@@ -74,4 +74,29 @@ describe("job description routes", () => {
     expect(response.status).toBe(400)
     expect(extractKeywordsMock).not.toHaveBeenCalled()
   })
+
+  it("returns a stable json error when keyword extraction fails", async () => {
+    extractKeywordsMock.mockRejectedValue(new Error("AI provider unavailable"))
+
+    const app = createTestApp()
+    const response = await app.request("/api/job-descriptions/extract-keywords", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify({
+        text: "Machine tools sales lead for CNC capital equipment across Malaysia and Singapore with channel and distributor ownership.",
+      }),
+    })
+
+    expect(response.status).toBe(500)
+    expect(extractKeywordsMock).toHaveBeenCalledWith({
+      text: "Machine tools sales lead for CNC capital equipment across Malaysia and Singapore with channel and distributor ownership.",
+    })
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Failed to extract keywords from the job description",
+    })
+  })
 })

--- a/apps/api/src/routes/job-descriptions.test.ts
+++ b/apps/api/src/routes/job-descriptions.test.ts
@@ -1,0 +1,77 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import jobDescriptionsRoutes from "./job-descriptions";
+import { workspaceMiddleware } from "../middleware/workspace";
+
+const {
+  extractKeywordsMock,
+} = vi.hoisted(() => ({
+  extractKeywordsMock: vi.fn(),
+}))
+
+vi.mock("../services/jd-keyword-extraction-service.js", () => ({
+  jdKeywordExtractionService: {
+    extractKeywords: (...args: unknown[]) => extractKeywordsMock(...args),
+  },
+}))
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use("*", workspaceMiddleware)
+  app.route("/", jobDescriptionsRoutes)
+  return app
+}
+
+describe("job description routes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    extractKeywordsMock.mockReset()
+  })
+
+  it("extracts recruiter keywords from pasted job description text", async () => {
+    extractKeywordsMock.mockResolvedValue({
+      keywords: ["Machine Tools", "Business Development", "CNC"],
+      model: "anthropic/claude-3-haiku-20240307",
+    })
+
+    const app = createTestApp()
+    const response = await app.request("/api/job-descriptions/extract-keywords", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify({
+        text: "   Machine tools sales lead for CNC capital equipment across Malaysia and Singapore. Must own business development and distributor channels.   ",
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(extractKeywordsMock).toHaveBeenCalledWith({
+      text: "Machine tools sales lead for CNC capital equipment across Malaysia and Singapore. Must own business development and distributor channels.",
+    })
+    expect(await response.json()).toEqual({
+      success: true,
+      keywords: ["Machine Tools", "Business Development", "CNC"],
+      model: "anthropic/claude-3-haiku-20240307",
+    })
+  })
+
+  it("rejects short pasted text before calling the extraction service", async () => {
+    const app = createTestApp()
+    const response = await app.request("/api/job-descriptions/extract-keywords", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify({
+        text: "Too short JD",
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(extractKeywordsMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/routes/job-descriptions.ts
+++ b/apps/api/src/routes/job-descriptions.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { jobDescriptionService } from "../services/job-description-service.js";
+import { jdKeywordExtractionService } from "../services/jd-keyword-extraction-service.js";
 import { DataNotFoundError } from "../services/errors.js";
 
 const app = new OpenAPIHono();
@@ -40,6 +41,10 @@ const CreateRequestSchema = z.object({
   overwrite: z.boolean().optional(),
 });
 
+const ExtractKeywordsRequestSchema = z.object({
+  text: z.string().trim().min(20).max(20000),
+});
+
 const MatchResponseSchema = z.object({
   success: z.literal(true),
   matched: z.string().optional(),
@@ -48,6 +53,12 @@ const MatchResponseSchema = z.object({
   matchedKeywords: z.array(z.string()),
   filterPreset: z.string().optional(),
   suggestedFilters: z.record(z.unknown()).optional(),
+});
+
+const ExtractKeywordsResponseSchema = z.object({
+  success: z.literal(true),
+  keywords: z.array(z.string()),
+  model: z.string(),
 });
 
 type ConvexJobDescriptionRecord = {
@@ -363,6 +374,38 @@ const statsRoute = createRoute({
 app.openapi(statsRoute, (c) => {
   const stats = jobDescriptionService.getStats();
   return c.json({ success: true as const, stats }, 200);
+});
+
+// ============================================================
+// POST /api/job-descriptions/extract-keywords
+// ============================================================
+const extractKeywordsRoute = createRoute({
+  method: "post",
+  path: "/api/job-descriptions/extract-keywords",
+  tags: ["job-descriptions"],
+  summary: "Extract search keywords from pasted job description text",
+  request: {
+    body: {
+      content: { "application/json": { schema: ExtractKeywordsRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: ExtractKeywordsResponseSchema } },
+      description: "Extracted keywords",
+    },
+  },
+});
+
+app.openapi(extractKeywordsRoute, async (c) => {
+  const { text } = c.req.valid("json");
+  const extracted = await jdKeywordExtractionService.extractKeywords({ text });
+
+  return c.json({
+    success: true as const,
+    keywords: extracted.keywords,
+    model: extracted.model,
+  }, 200);
 });
 
 // ============================================================

--- a/apps/api/src/routes/job-descriptions.ts
+++ b/apps/api/src/routes/job-descriptions.ts
@@ -61,6 +61,11 @@ const ExtractKeywordsResponseSchema = z.object({
   model: z.string(),
 });
 
+const ErrorResponseSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+});
+
 type ConvexJobDescriptionRecord = {
   _id?: unknown;
   title?: unknown;
@@ -394,18 +399,30 @@ const extractKeywordsRoute = createRoute({
       content: { "application/json": { schema: ExtractKeywordsResponseSchema } },
       description: "Extracted keywords",
     },
+    500: {
+      content: { "application/json": { schema: ErrorResponseSchema } },
+      description: "Keyword extraction failed",
+    },
   },
 });
 
 app.openapi(extractKeywordsRoute, async (c) => {
   const { text } = c.req.valid("json");
-  const extracted = await jdKeywordExtractionService.extractKeywords({ text });
+  try {
+    const extracted = await jdKeywordExtractionService.extractKeywords({ text });
 
-  return c.json({
-    success: true as const,
-    keywords: extracted.keywords,
-    model: extracted.model,
-  }, 200);
+    return c.json({
+      success: true as const,
+      keywords: extracted.keywords,
+      model: extracted.model,
+    }, 200);
+  } catch (error) {
+    console.error("Failed to extract job description keywords", error);
+    return c.json({
+      success: false as const,
+      error: "Failed to extract keywords from the job description",
+    }, 500);
+  }
 });
 
 // ============================================================

--- a/apps/api/src/routes/taxonomy.test.ts
+++ b/apps/api/src/routes/taxonomy.test.ts
@@ -315,4 +315,75 @@ describe("taxonomy routes", () => {
       },
     ])
   })
+
+  it("deletes a taxonomy cluster in the current workspace and returns the refreshed registry", async () => {
+    const calls: Array<{ method: "query" | "mutation"; pathName: string; args: Record<string, unknown> }> = []
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+      calls.push(call)
+
+      if (call.method === "mutation" && call.pathName === "taxonomy_clusters:remove") {
+        return convexSuccess(true)
+      }
+
+      if (call.method === "query" && call.pathName === "taxonomy_clusters:list") {
+        return convexSuccess([
+          createTaxonomyRecord({
+            _id: "cluster-2",
+            name: "Automation",
+            slug: "automation",
+            parentSlug: "",
+            source: "merged",
+            status: "active",
+          }),
+        ])
+      }
+
+      throw new Error(`Unexpected convex call: ${call.method} ${call.pathName}`)
+    })
+
+    const app = createTestApp()
+    const response = await app.request("/api/taxonomy/cluster-1", {
+      method: "DELETE",
+      headers: {
+        "X-Workspace-Slug": "dev",
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      success: true,
+      items: [
+        {
+          id: "cluster-2",
+          workspaceSlug: "dev",
+          name: "Automation",
+          slug: "automation",
+          tags: ["Machine Tools", "Automation"],
+          source: "merged",
+          confidence: 0.81,
+          status: "active",
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    })
+    expect(calls).toEqual([
+      {
+        method: "mutation",
+        pathName: "taxonomy_clusters:remove",
+        args: {
+          id: "cluster-1",
+          workspaceSlug: "dev",
+        },
+      },
+      {
+        method: "query",
+        pathName: "taxonomy_clusters:list",
+        args: {
+          workspaceSlug: "dev",
+        },
+      },
+    ])
+  })
 })

--- a/apps/api/src/routes/taxonomy.test.ts
+++ b/apps/api/src/routes/taxonomy.test.ts
@@ -173,6 +173,30 @@ describe("taxonomy routes", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 
+  it("returns a stable json error when taxonomy loading fails", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("convex unavailable", { status: 502 }),
+    )
+
+    const app = createTestApp()
+    const response = await app.request("/api/taxonomy", {
+      headers: {
+        "X-Workspace-Slug": "dev",
+      },
+    })
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Failed to load taxonomy clusters",
+    })
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to load taxonomy clusters",
+      expect.any(Error),
+    )
+  })
+
   it("upserts a taxonomy cluster in the current workspace and returns the refreshed registry", async () => {
     const calls: Array<{ method: "query" | "mutation"; pathName: string; args: Record<string, unknown> }> = []
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {

--- a/apps/api/src/routes/taxonomy.test.ts
+++ b/apps/api/src/routes/taxonomy.test.ts
@@ -1,0 +1,318 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import taxonomyRoutes from "./taxonomy";
+import { workspaceMiddleware } from "../middleware/workspace";
+
+const {
+  resolveConvexUrlMock,
+} = vi.hoisted(() => ({
+  resolveConvexUrlMock: vi.fn(() => "http://127.0.0.1:3210"),
+}))
+
+vi.mock("../services/resume-import-service.js", () => ({
+  resolveConvexUrl: () => resolveConvexUrlMock(),
+}))
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use("*", workspaceMiddleware)
+  app.route("/", taxonomyRoutes)
+  return app
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function convexSuccess(value: unknown): Response {
+  return new Response(
+    JSON.stringify({
+      status: "success",
+      value,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  )
+}
+
+function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): {
+  method: "query" | "mutation"
+  pathName: string
+  args: Record<string, unknown>
+} {
+  const requestUrl = typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url
+  const method = requestUrl.includes("/api/mutation") ? "mutation" : "query"
+  const body = typeof init?.body === "string" ? JSON.parse(init.body) : null
+  if (!isRecord(body)) {
+    throw new Error("Missing convex request body")
+  }
+
+  const pathName = typeof body.path === "string" ? body.path : ""
+  const args = isRecord(body.args) ? body.args : {}
+  if (!pathName) {
+    throw new Error("Missing convex path in request body")
+  }
+
+  return {
+    method,
+    pathName,
+    args,
+  }
+}
+
+function createTaxonomyRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "cluster-1",
+    workspaceSlug: "dev",
+    name: "Manufacturing Systems",
+    slug: "manufacturing-systems",
+    parentSlug: "core-domains",
+    tags: ["Machine Tools", "Automation"],
+    source: "human",
+    confidence: 0.81,
+    status: "active",
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides,
+  }
+}
+
+describe("taxonomy routes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("blocks non-admin workspaces from taxonomy access", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+    const app = createTestApp()
+
+    const response = await app.request("/api/taxonomy", {
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+    })
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Admin access required",
+    })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("lists workspace-scoped taxonomy clusters for admins", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+
+      expect(call.method).toBe("query")
+      expect(call.pathName).toBe("taxonomy_clusters:list")
+      expect(call.args).toEqual({
+        workspaceSlug: "dev",
+      })
+
+      return convexSuccess([
+        createTaxonomyRecord(),
+        createTaxonomyRecord({
+          _id: "cluster-2",
+          slug: "sales",
+          name: "Sales",
+          parentSlug: "",
+          source: "unexpected",
+          status: "mystery",
+          confidence: "bad-input",
+        }),
+      ])
+    })
+
+    const app = createTestApp()
+    const response = await app.request("/api/taxonomy", {
+      headers: {
+        "X-Workspace-Slug": "dev",
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      success: true,
+      items: [
+        {
+          id: "cluster-1",
+          workspaceSlug: "dev",
+          name: "Manufacturing Systems",
+          slug: "manufacturing-systems",
+          parentSlug: "core-domains",
+          tags: ["Machine Tools", "Automation"],
+          source: "human",
+          confidence: 0.81,
+          status: "active",
+          createdAt: 1,
+          updatedAt: 2,
+        },
+        {
+          id: "cluster-2",
+          workspaceSlug: "dev",
+          name: "Sales",
+          slug: "sales",
+          tags: ["Machine Tools", "Automation"],
+          source: "human",
+          status: "active",
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("upserts a taxonomy cluster in the current workspace and returns the refreshed registry", async () => {
+    const calls: Array<{ method: "query" | "mutation"; pathName: string; args: Record<string, unknown> }> = []
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+      calls.push(call)
+
+      if (call.method === "mutation" && call.pathName === "taxonomy_clusters:upsert") {
+        return convexSuccess("cluster-1")
+      }
+
+      if (call.method === "query" && call.pathName === "taxonomy_clusters:list") {
+        return convexSuccess([createTaxonomyRecord()])
+      }
+
+      throw new Error(`Unexpected convex call: ${call.method} ${call.pathName}`)
+    })
+
+    const app = createTestApp()
+    const response = await app.request("/api/taxonomy", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify({
+        name: "Manufacturing Systems",
+        slug: "manufacturing-systems",
+        parentSlug: "core-domains",
+        tags: ["Machine Tools", "Automation"],
+        source: "human",
+        confidence: 0.81,
+        status: "active",
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      success: true,
+      items: [
+        {
+          id: "cluster-1",
+          workspaceSlug: "dev",
+          name: "Manufacturing Systems",
+          slug: "manufacturing-systems",
+          parentSlug: "core-domains",
+          tags: ["Machine Tools", "Automation"],
+          source: "human",
+          confidence: 0.81,
+          status: "active",
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    })
+    expect(calls).toEqual([
+      {
+        method: "mutation",
+        pathName: "taxonomy_clusters:upsert",
+        args: {
+          workspaceSlug: "dev",
+          name: "Manufacturing Systems",
+          slug: "manufacturing-systems",
+          parentSlug: "core-domains",
+          tags: ["Machine Tools", "Automation"],
+          source: "human",
+          confidence: 0.81,
+          status: "active",
+        },
+      },
+      {
+        method: "query",
+        pathName: "taxonomy_clusters:list",
+        args: {
+          workspaceSlug: "dev",
+        },
+      },
+    ])
+  })
+
+  it("suggests taxonomy drafts within the current workspace", async () => {
+    const calls: Array<{ method: "query" | "mutation"; pathName: string; args: Record<string, unknown> }> = []
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+      calls.push(call)
+
+      if (call.method === "mutation" && call.pathName === "taxonomy_clusters:suggest") {
+        return convexSuccess([
+          createTaxonomyRecord({
+            _id: "cluster-draft-1",
+            name: "Automation Stack",
+            slug: "automation-stack",
+            source: "ai",
+            status: "draft",
+          }),
+        ])
+      }
+
+      throw new Error(`Unexpected convex call: ${call.method} ${call.pathName}`)
+    })
+
+    const app = createTestApp()
+    const response = await app.request("/api/taxonomy/suggest", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify({
+        limit: 10,
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      success: true,
+      items: [
+        {
+          id: "cluster-draft-1",
+          workspaceSlug: "dev",
+          name: "Automation Stack",
+          slug: "automation-stack",
+          parentSlug: "core-domains",
+          tags: ["Machine Tools", "Automation"],
+          source: "ai",
+          confidence: 0.81,
+          status: "draft",
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    })
+    expect(calls).toEqual([
+      {
+        method: "mutation",
+        pathName: "taxonomy_clusters:suggest",
+        args: {
+          workspaceSlug: "dev",
+          limit: 10,
+        },
+      },
+    ])
+  })
+})

--- a/apps/api/src/routes/taxonomy.ts
+++ b/apps/api/src/routes/taxonomy.ts
@@ -23,6 +23,11 @@ const TaxonomyResponseSchema = z.object({
   items: z.array(TaxonomyClusterSchema),
 });
 
+const TaxonomyErrorResponseSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+});
+
 const TaxonomyUpsertSchema = z.object({
   id: z.string().optional(),
   name: z.string().trim().min(1),
@@ -102,6 +107,14 @@ function toTaxonomyCluster(value: unknown): TaxonomyClusterResponse | null {
   };
 }
 
+function toTaxonomyItems(value: unknown): TaxonomyClusterResponse[] {
+  return Array.isArray(value)
+    ? value
+        .map((item) => toTaxonomyCluster(item))
+        .filter((item): item is NonNullable<ReturnType<typeof toTaxonomyCluster>> => item !== null)
+    : [];
+}
+
 app.use("/api/taxonomy", requireAdmin);
 app.use("/api/taxonomy/*", requireAdmin);
 
@@ -119,17 +132,27 @@ const listRoute = createRoute({
         },
       },
     },
+    500: {
+      description: "Taxonomy request failed",
+      content: {
+        "application/json": {
+          schema: TaxonomyErrorResponseSchema,
+        },
+      },
+    },
   },
 });
 
 app.openapi(listRoute, async (c) => {
-  const value = await callConvex("query", "taxonomy_clusters:list", {
-    workspaceSlug: c.var.workspaceSlug,
-  });
-  const items = Array.isArray(value)
-    ? value.map((item) => toTaxonomyCluster(item)).filter((item): item is NonNullable<ReturnType<typeof toTaxonomyCluster>> => item !== null)
-    : [];
-  return c.json({ success: true as const, items }, 200);
+  try {
+    const value = await callConvex("query", "taxonomy_clusters:list", {
+      workspaceSlug: c.var.workspaceSlug,
+    });
+    return c.json({ success: true as const, items: toTaxonomyItems(value) }, 200);
+  } catch (error) {
+    console.error("Failed to load taxonomy clusters", error);
+    return c.json({ success: false as const, error: "Failed to load taxonomy clusters" }, 500);
+  }
 });
 
 const upsertRoute = createRoute({
@@ -155,22 +178,32 @@ const upsertRoute = createRoute({
         },
       },
     },
+    500: {
+      description: "Taxonomy request failed",
+      content: {
+        "application/json": {
+          schema: TaxonomyErrorResponseSchema,
+        },
+      },
+    },
   },
 });
 
 app.openapi(upsertRoute, async (c) => {
-  const body = c.req.valid("json");
-  await callConvex("mutation", "taxonomy_clusters:upsert", {
-    ...body,
-    workspaceSlug: c.var.workspaceSlug,
-  });
-  const value = await callConvex("query", "taxonomy_clusters:list", {
-    workspaceSlug: c.var.workspaceSlug,
-  });
-  const items = Array.isArray(value)
-    ? value.map((item) => toTaxonomyCluster(item)).filter((item): item is NonNullable<ReturnType<typeof toTaxonomyCluster>> => item !== null)
-    : [];
-  return c.json({ success: true as const, items }, 200);
+  try {
+    const body = c.req.valid("json");
+    await callConvex("mutation", "taxonomy_clusters:upsert", {
+      ...body,
+      workspaceSlug: c.var.workspaceSlug,
+    });
+    const value = await callConvex("query", "taxonomy_clusters:list", {
+      workspaceSlug: c.var.workspaceSlug,
+    });
+    return c.json({ success: true as const, items: toTaxonomyItems(value) }, 200);
+  } catch (error) {
+    console.error("Failed to save taxonomy cluster", error);
+    return c.json({ success: false as const, error: "Failed to save taxonomy cluster" }, 500);
+  }
 });
 
 const suggestRoute = createRoute({
@@ -196,19 +229,29 @@ const suggestRoute = createRoute({
         },
       },
     },
+    500: {
+      description: "Taxonomy request failed",
+      content: {
+        "application/json": {
+          schema: TaxonomyErrorResponseSchema,
+        },
+      },
+    },
   },
 });
 
 app.openapi(suggestRoute, async (c) => {
-  const body = c.req.valid("json");
-  const value = await callConvex("mutation", "taxonomy_clusters:suggest", {
-    workspaceSlug: c.var.workspaceSlug,
-    limit: body.limit,
-  });
-  const items = Array.isArray(value)
-    ? value.map((item) => toTaxonomyCluster(item)).filter((item): item is NonNullable<ReturnType<typeof toTaxonomyCluster>> => item !== null)
-    : [];
-  return c.json({ success: true as const, items }, 200);
+  try {
+    const body = c.req.valid("json");
+    const value = await callConvex("mutation", "taxonomy_clusters:suggest", {
+      workspaceSlug: c.var.workspaceSlug,
+      limit: body.limit,
+    });
+    return c.json({ success: true as const, items: toTaxonomyItems(value) }, 200);
+  } catch (error) {
+    console.error("Failed to suggest taxonomy clusters", error);
+    return c.json({ success: false as const, error: "Failed to suggest taxonomy clusters" }, 500);
+  }
 });
 
 const deleteRoute = createRoute({
@@ -228,22 +271,32 @@ const deleteRoute = createRoute({
         },
       },
     },
+    500: {
+      description: "Taxonomy request failed",
+      content: {
+        "application/json": {
+          schema: TaxonomyErrorResponseSchema,
+        },
+      },
+    },
   },
 });
 
 app.openapi(deleteRoute, async (c) => {
-  const { id } = c.req.valid("param");
-  await callConvex("mutation", "taxonomy_clusters:remove", {
-    id,
-    workspaceSlug: c.var.workspaceSlug,
-  });
-  const value = await callConvex("query", "taxonomy_clusters:list", {
-    workspaceSlug: c.var.workspaceSlug,
-  });
-  const items = Array.isArray(value)
-    ? value.map((item) => toTaxonomyCluster(item)).filter((item): item is NonNullable<ReturnType<typeof toTaxonomyCluster>> => item !== null)
-    : [];
-  return c.json({ success: true as const, items }, 200);
+  try {
+    const { id } = c.req.valid("param");
+    await callConvex("mutation", "taxonomy_clusters:remove", {
+      id,
+      workspaceSlug: c.var.workspaceSlug,
+    });
+    const value = await callConvex("query", "taxonomy_clusters:list", {
+      workspaceSlug: c.var.workspaceSlug,
+    });
+    return c.json({ success: true as const, items: toTaxonomyItems(value) }, 200);
+  } catch (error) {
+    console.error("Failed to delete taxonomy cluster", error);
+    return c.json({ success: false as const, error: "Failed to delete taxonomy cluster" }, 500);
+  }
 });
 
 export default app;

--- a/apps/api/src/routes/taxonomy.ts
+++ b/apps/api/src/routes/taxonomy.ts
@@ -1,0 +1,249 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { requireAdmin } from "../middleware/workspace.js";
+import { resolveConvexUrl } from "../services/resume-import-service.js";
+
+const app = new OpenAPIHono();
+
+const TaxonomyClusterSchema = z.object({
+  id: z.string(),
+  workspaceSlug: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  parentSlug: z.string().optional(),
+  tags: z.array(z.string()),
+  source: z.enum(["human", "ai", "merged"]),
+  confidence: z.number().optional(),
+  status: z.enum(["active", "draft", "archived"]),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+const TaxonomyResponseSchema = z.object({
+  success: z.literal(true),
+  items: z.array(TaxonomyClusterSchema),
+});
+
+const TaxonomyUpsertSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().trim().min(1),
+  slug: z.string().trim().min(1),
+  parentSlug: z.string().optional(),
+  tags: z.array(z.string()).min(1),
+  source: z.enum(["human", "ai", "merged"]).default("human"),
+  confidence: z.number().min(0).max(1).optional(),
+  status: z.enum(["active", "draft", "archived"]).default("active"),
+});
+
+const SuggestTaxonomySchema = z.object({
+  limit: z.number().int().min(1).max(24).optional(),
+});
+
+const DeleteTaxonomyParamsSchema = z.object({
+  id: z.string().openapi({ param: { name: "id", in: "path" } }),
+});
+
+type TaxonomyClusterResponse = z.infer<typeof TaxonomyClusterSchema>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function callConvex(
+  type: "query" | "mutation",
+  pathName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+  const response = await fetch(`${convexUrl}/api/${type}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ path: pathName, args }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Convex ${type} failed (${response.status}): ${await response.text()}`);
+  }
+
+  const payload = await response.json() as unknown;
+  if (!isRecord(payload) || payload.status !== "success") {
+    throw new Error(`Convex ${type} failed for ${pathName}`);
+  }
+
+  return payload.value;
+}
+
+function toTaxonomyCluster(value: unknown): TaxonomyClusterResponse | null {
+  if (!isRecord(value) || typeof value._id !== "string") {
+    return null;
+  }
+
+  const source = value.source === "human" || value.source === "ai" || value.source === "merged"
+    ? value.source
+    : "human";
+  const status = value.status === "active" || value.status === "draft" || value.status === "archived"
+    ? value.status
+    : "active";
+
+  return {
+    id: value._id,
+    workspaceSlug: typeof value.workspaceSlug === "string" ? value.workspaceSlug : "",
+    name: typeof value.name === "string" ? value.name : "",
+    slug: typeof value.slug === "string" ? value.slug : "",
+    parentSlug: typeof value.parentSlug === "string" && value.parentSlug.trim().length > 0 ? value.parentSlug : undefined,
+    tags: Array.isArray(value.tags) ? value.tags.filter((item): item is string => typeof item === "string") : [],
+    source,
+    confidence: typeof value.confidence === "number" ? value.confidence : undefined,
+    status,
+    createdAt: typeof value.createdAt === "number" ? value.createdAt : 0,
+    updatedAt: typeof value.updatedAt === "number" ? value.updatedAt : 0,
+  };
+}
+
+app.use("/api/taxonomy", requireAdmin);
+app.use("/api/taxonomy/*", requireAdmin);
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/api/taxonomy",
+  tags: ["Config"],
+  summary: "List taxonomy clusters for the current workspace",
+  responses: {
+    200: {
+      description: "Taxonomy clusters",
+      content: {
+        "application/json": {
+          schema: TaxonomyResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(listRoute, async (c) => {
+  const value = await callConvex("query", "taxonomy_clusters:list", {
+    workspaceSlug: c.var.workspaceSlug,
+  });
+  const items = Array.isArray(value)
+    ? value.map((item) => toTaxonomyCluster(item)).filter((item): item is NonNullable<ReturnType<typeof toTaxonomyCluster>> => item !== null)
+    : [];
+  return c.json({ success: true as const, items }, 200);
+});
+
+const upsertRoute = createRoute({
+  method: "post",
+  path: "/api/taxonomy",
+  tags: ["Config"],
+  summary: "Create or update a taxonomy cluster",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: TaxonomyUpsertSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Updated taxonomy clusters",
+      content: {
+        "application/json": {
+          schema: TaxonomyResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(upsertRoute, async (c) => {
+  const body = c.req.valid("json");
+  await callConvex("mutation", "taxonomy_clusters:upsert", {
+    ...body,
+    workspaceSlug: c.var.workspaceSlug,
+  });
+  const value = await callConvex("query", "taxonomy_clusters:list", {
+    workspaceSlug: c.var.workspaceSlug,
+  });
+  const items = Array.isArray(value)
+    ? value.map((item) => toTaxonomyCluster(item)).filter((item): item is NonNullable<ReturnType<typeof toTaxonomyCluster>> => item !== null)
+    : [];
+  return c.json({ success: true as const, items }, 200);
+});
+
+const suggestRoute = createRoute({
+  method: "post",
+  path: "/api/taxonomy/suggest",
+  tags: ["Config"],
+  summary: "Create draft taxonomy suggestions from uncategorized resume tags",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: SuggestTaxonomySchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Suggested taxonomy clusters",
+      content: {
+        "application/json": {
+          schema: TaxonomyResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(suggestRoute, async (c) => {
+  const body = c.req.valid("json");
+  const value = await callConvex("mutation", "taxonomy_clusters:suggest", {
+    workspaceSlug: c.var.workspaceSlug,
+    limit: body.limit,
+  });
+  const items = Array.isArray(value)
+    ? value.map((item) => toTaxonomyCluster(item)).filter((item): item is NonNullable<ReturnType<typeof toTaxonomyCluster>> => item !== null)
+    : [];
+  return c.json({ success: true as const, items }, 200);
+});
+
+const deleteRoute = createRoute({
+  method: "delete",
+  path: "/api/taxonomy/{id}",
+  tags: ["Config"],
+  summary: "Delete a taxonomy cluster",
+  request: {
+    params: DeleteTaxonomyParamsSchema,
+  },
+  responses: {
+    200: {
+      description: "Remaining taxonomy clusters",
+      content: {
+        "application/json": {
+          schema: TaxonomyResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+app.openapi(deleteRoute, async (c) => {
+  const { id } = c.req.valid("param");
+  await callConvex("mutation", "taxonomy_clusters:remove", {
+    id,
+    workspaceSlug: c.var.workspaceSlug,
+  });
+  const value = await callConvex("query", "taxonomy_clusters:list", {
+    workspaceSlug: c.var.workspaceSlug,
+  });
+  const items = Array.isArray(value)
+    ? value.map((item) => toTaxonomyCluster(item)).filter((item): item is NonNullable<ReturnType<typeof toTaxonomyCluster>> => item !== null)
+    : [];
+  return c.json({ success: true as const, items }, 200);
+});
+
+export default app;

--- a/apps/api/src/services/ai-chat-client.ts
+++ b/apps/api/src/services/ai-chat-client.ts
@@ -1,0 +1,63 @@
+import { aiConfig, loadAIConfig } from "./ai-config.js";
+
+export type AIChatMessage = {
+  role: string;
+  content: string;
+};
+
+export function extractModelName(model: string): string {
+  const parts = model.split("/");
+  return parts.length > 1 ? parts.slice(1).join("/") : model;
+}
+
+export async function callChatCompletion(args: {
+  config?: ReturnType<typeof loadAIConfig>;
+  maxTokens: number;
+  messages: AIChatMessage[];
+  model: string;
+  temperature?: number;
+}): Promise<string> {
+  const config = args.config ?? loadAIConfig();
+  const baseUrl = config.apiBase || aiConfig.apiBase || "https://api.openai.com/v1";
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), config.timeout);
+
+  try {
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${config.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: extractModelName(args.model),
+        messages: args.messages,
+        temperature: args.temperature ?? 0,
+        max_tokens: Math.min(config.maxTokens, args.maxTokens),
+      }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      throw new Error(`AI request failed with status ${response.status}: ${await response.text()}`);
+    }
+
+    const payload = await response.json() as {
+      choices?: Array<{ message?: { content?: string }; text?: string }>;
+    };
+    const content = payload.choices?.[0]?.message?.content ?? payload.choices?.[0]?.text;
+    if (!content) {
+      throw new Error("No content returned from AI provider");
+    }
+
+    return content;
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`AI request timed out after ${config.timeout}ms`);
+    }
+    throw error;
+  }
+}

--- a/apps/api/src/services/ai-summary-service.test.ts
+++ b/apps/api/src/services/ai-summary-service.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  callChatCompletionMock,
+  getWorkspaceConfigValueMock,
+  loadAIConfigMock,
+} = vi.hoisted(() => ({
+  callChatCompletionMock: vi.fn(),
+  getWorkspaceConfigValueMock: vi.fn(),
+  loadAIConfigMock: vi.fn(),
+}));
+
+vi.mock("./ai-config.js", () => ({
+  loadAIConfig: () => loadAIConfigMock(),
+}));
+
+vi.mock("./ai-chat-client.js", () => ({
+  callChatCompletion: (args: unknown) => callChatCompletionMock(args),
+}));
+
+vi.mock("./workspace-config-service.js", () => ({
+  workspaceConfigService: {
+    getWorkspaceConfigValue: (workspaceSlug: string, configKey: string) =>
+      getWorkspaceConfigValueMock(workspaceSlug, configKey),
+  },
+}));
+
+import { AiSummaryService } from "./ai-summary-service.js";
+
+function createAIConfig(overrides: Partial<ReturnType<typeof loadAIConfigMock>> = {}) {
+  return {
+    enabled: true,
+    resumesEnabled: true,
+    model: "openai/gpt-4o-mini",
+    apiKey: "test-api-key",
+    apiBase: "https://ai.example.test/v1",
+    temperature: 0,
+    maxTokens: 4000,
+    timeout: 120000,
+    bonded: [],
+    ...overrides,
+  };
+}
+
+describe("AiSummaryService", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    callChatCompletionMock.mockReset();
+    getWorkspaceConfigValueMock.mockReset();
+    loadAIConfigMock.mockReset();
+  });
+
+  it("uses the workspace override model, builds the recruiter summary prompt, and strips fenced output", async () => {
+    loadAIConfigMock.mockReturnValue(createAIConfig());
+    getWorkspaceConfigValueMock.mockResolvedValue("anthropic/claude-3-5-haiku-20241022");
+    callChatCompletionMock.mockResolvedValue(`\`\`\`markdown
+Strong overlap around machine tools and CNC sales backgrounds.
+\`\`\``);
+
+    const service = new AiSummaryService();
+    const result = await service.generateSummary({
+      workspaceSlug: "dev",
+      query: "machine tools",
+      location: "Malaysia",
+      jobDescriptionId: "lathe-sales",
+      facets: {
+        selectedTags: ["Machine Tools", "CNC"],
+        selectedCompanies: ["DMG Mori"],
+        selectedExperienceLevel: "senior",
+      },
+      results: [
+        {
+          id: "resume-1",
+          name: "Jane Tan",
+          title: "Regional Sales Manager",
+          location: "Kuala Lumpur",
+          score: 92.4,
+          keywords: ["Machine Tools", "CNC"],
+          snippet: "  Led   CNC\nsales   across   SEA markets. ",
+        },
+      ],
+    });
+
+    expect(getWorkspaceConfigValueMock).toHaveBeenCalledWith("dev", "ai_summary_model");
+    expect(callChatCompletionMock).toHaveBeenCalledTimes(1);
+
+    const call = callChatCompletionMock.mock.calls[0]?.[0] as {
+      config: ReturnType<typeof loadAIConfigMock>;
+      maxTokens: number;
+      messages: Array<{ role: string; content: string }>;
+      model: string;
+      temperature: number;
+    };
+
+    expect(call.config).toEqual(createAIConfig());
+    expect(call.model).toBe("anthropic/claude-3-5-haiku-20241022");
+    expect(call.temperature).toBe(0.1);
+    expect(call.maxTokens).toBe(900);
+    expect(call.messages[0]?.content).toContain("You summarize resume search results for recruiters");
+    expect(call.messages[1]?.content).toContain("Query: machine tools");
+    expect(call.messages[1]?.content).toContain("Location: Malaysia");
+    expect(call.messages[1]?.content).toContain("Job description: lathe-sales");
+    expect(call.messages[1]?.content).toContain("Selected tags: Machine Tools, CNC");
+    expect(call.messages[1]?.content).toContain("Selected companies: DMG Mori");
+    expect(call.messages[1]?.content).toContain("Selected experience level: senior");
+    expect(call.messages[1]?.content).toContain("Visible result count: 1");
+    expect(call.messages[1]?.content).toContain("score=92");
+    expect(call.messages[1]?.content).toContain("snippet=Led CNC sales across SEA markets.");
+
+    expect(result).toEqual({
+      model: "anthropic/claude-3-5-haiku-20241022",
+      summary: "Strong overlap around machine tools and CNC sales backgrounds.",
+    });
+  });
+
+  it("falls back to the default model when the workspace override is not provider-qualified", async () => {
+    loadAIConfigMock.mockReturnValue(createAIConfig());
+    getWorkspaceConfigValueMock.mockResolvedValue("claude-3-haiku");
+    callChatCompletionMock.mockResolvedValue("Plain summary");
+
+    const service = new AiSummaryService();
+    const result = await service.generateSummary({
+      workspaceSlug: "dev",
+      query: "automation",
+      results: [
+        {
+          id: "resume-1",
+          name: "Alex",
+          snippet: "Automation and robotics background",
+        },
+      ],
+    });
+
+    const call = callChatCompletionMock.mock.calls[0]?.[0] as { model: string };
+    expect(call.model).toContain("/");
+    expect(call.model).not.toBe("claude-3-haiku");
+    expect(result.model).toBe(call.model);
+  });
+
+  it("fails before the AI call when the runtime has no API key", async () => {
+    loadAIConfigMock.mockReturnValue(createAIConfig({ apiKey: "" }));
+    getWorkspaceConfigValueMock.mockResolvedValue(undefined);
+
+    const service = new AiSummaryService();
+
+    await expect(
+      service.generateSummary({
+        workspaceSlug: "dev",
+        query: "cnc",
+        results: [
+          {
+            id: "resume-1",
+            name: "Lee",
+            snippet: "CNC applications engineer",
+          },
+        ],
+      }),
+    ).rejects.toThrow("Missing AI_API_KEY environment variable");
+
+    expect(callChatCompletionMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/ai-summary-service.ts
+++ b/apps/api/src/services/ai-summary-service.ts
@@ -1,4 +1,5 @@
-import { aiConfig, loadAIConfig } from "./ai-config.js";
+import { loadAIConfig } from "./ai-config.js";
+import { callChatCompletion } from "./ai-chat-client.js";
 import { workspaceConfigService } from "./workspace-config-service.js";
 
 const DEFAULT_AI_SUMMARY_MODEL = process.env.AI_SUMMARY_MODEL || "anthropic/claude-3-haiku-20240307";
@@ -29,11 +30,6 @@ type GenerateSummaryRequest = {
 function normalizeOptionalString(value: string | undefined): string | undefined {
   const normalized = value?.trim();
   return normalized && normalized.length > 0 ? normalized : undefined;
-}
-
-function extractModelName(model: string): string {
-  const parts = model.split("/");
-  return parts.length > 1 ? parts.slice(1).join("/") : model;
 }
 
 function compactWhitespace(value: string): string {
@@ -134,48 +130,13 @@ export class AiSummaryService {
     model: string,
     messages: Array<{ role: string; content: string }>,
   ): Promise<string> {
-    const baseUrl = config.apiBase || aiConfig.apiBase || "https://api.openai.com/v1";
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), config.timeout);
-
-    try {
-      const response = await fetch(`${baseUrl}/chat/completions`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${config.apiKey}`,
-        },
-        body: JSON.stringify({
-          model: extractModelName(model),
-          messages,
-          temperature: 0.1,
-          max_tokens: Math.min(config.maxTokens, 900),
-        }),
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        throw new Error(`AI summary request failed with status ${response.status}: ${await response.text()}`);
-      }
-
-      const payload = await response.json() as {
-        choices?: Array<{ message?: { content?: string }; text?: string }>;
-      };
-      const content = payload.choices?.[0]?.message?.content ?? payload.choices?.[0]?.text;
-      if (!content) {
-        throw new Error("No summary content returned from AI provider");
-      }
-
-      return content;
-    } catch (error) {
-      clearTimeout(timeoutId);
-      if (error instanceof Error && error.name === "AbortError") {
-        throw new Error(`AI summary request timed out after ${config.timeout}ms`);
-      }
-      throw error;
-    }
+    return callChatCompletion({
+      config,
+      model,
+      messages,
+      temperature: 0.1,
+      maxTokens: 900,
+    });
   }
 }
 

--- a/apps/api/src/services/ai-summary-service.ts
+++ b/apps/api/src/services/ai-summary-service.ts
@@ -1,0 +1,182 @@
+import { aiConfig, loadAIConfig } from "./ai-config.js";
+import { workspaceConfigService } from "./workspace-config-service.js";
+
+const DEFAULT_AI_SUMMARY_MODEL = process.env.AI_SUMMARY_MODEL || "anthropic/claude-3-haiku-20240307";
+
+type SummaryCandidate = {
+  id: string;
+  keywords?: string[];
+  location?: string;
+  name: string;
+  score?: number;
+  snippet: string;
+  title?: string;
+};
+
+type GenerateSummaryRequest = {
+  workspaceSlug: string;
+  query: string;
+  location?: string;
+  jobDescriptionId?: string;
+  facets?: {
+    selectedTags?: string[];
+    selectedCompanies?: string[];
+    selectedExperienceLevel?: string;
+  };
+  results: SummaryCandidate[];
+};
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized && normalized.length > 0 ? normalized : undefined;
+}
+
+function extractModelName(model: string): string {
+  const parts = model.split("/");
+  return parts.length > 1 ? parts.slice(1).join("/") : model;
+}
+
+function compactWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function stripCodeFence(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed.includes("```")) {
+    return trimmed;
+  }
+
+  return trimmed
+    .replace(/^```[a-zA-Z0-9_-]*\s*/, "")
+    .replace(/```$/m, "")
+    .trim();
+}
+
+export class AiSummaryService {
+  async resolveModel(workspaceSlug: string): Promise<string> {
+    const workspaceOverride = await workspaceConfigService.getWorkspaceConfigValue(workspaceSlug, "ai_summary_model");
+    if (typeof workspaceOverride === "string" && workspaceOverride.trim().includes("/")) {
+      return workspaceOverride.trim();
+    }
+
+    return DEFAULT_AI_SUMMARY_MODEL;
+  }
+
+  async generateSummary(request: GenerateSummaryRequest): Promise<{ model: string; summary: string }> {
+    if (process.env.AI_MOCK_ENABLED === "true") {
+      return {
+        model: DEFAULT_AI_SUMMARY_MODEL,
+        summary: `Found ${request.results.length} candidate snippets for "${request.query}". Common themes include ${request.results[0]?.keywords?.slice(0, 2).join(", ") || "relevant experience"}.`,
+      };
+    }
+
+    const config = loadAIConfig();
+    if (!config.apiKey) {
+      throw new Error("Missing AI_API_KEY environment variable");
+    }
+
+    const model = await this.resolveModel(request.workspaceSlug);
+    if (!model.includes("/")) {
+      throw new Error(`Invalid AI summary model: ${model}`);
+    }
+
+    const message = this.buildUserPrompt(request);
+    const content = await this.callLLM(config, model, [
+      {
+        role: "system",
+        content: "You summarize resume search results for recruiters. Stay factual, compact, and read-only. Do not invent candidate details or recommend contacting anyone directly.",
+      },
+      {
+        role: "user",
+        content: message,
+      },
+    ]);
+
+    return {
+      model,
+      summary: stripCodeFence(content),
+    };
+  }
+
+  private buildUserPrompt(request: GenerateSummaryRequest): string {
+    const candidateLines = request.results
+      .map((candidate, index) => [
+        `${index + 1}. ${candidate.name}`,
+        candidate.title ? `title=${candidate.title}` : undefined,
+        candidate.location ? `location=${candidate.location}` : undefined,
+        typeof candidate.score === "number" ? `score=${Math.round(candidate.score)}` : undefined,
+        candidate.keywords?.length ? `keywords=${candidate.keywords.join(", ")}` : undefined,
+        candidate.snippet ? `snippet=${compactWhitespace(candidate.snippet)}` : undefined,
+      ].filter(Boolean).join(" | "))
+      .join("\n");
+
+    return [
+      `Query: ${request.query}`,
+      request.location ? `Location: ${request.location}` : undefined,
+      request.jobDescriptionId ? `Job description: ${request.jobDescriptionId}` : undefined,
+      request.facets?.selectedTags?.length ? `Selected tags: ${request.facets.selectedTags.join(", ")}` : undefined,
+      request.facets?.selectedCompanies?.length ? `Selected companies: ${request.facets.selectedCompanies.join(", ")}` : undefined,
+      request.facets?.selectedExperienceLevel ? `Selected experience level: ${request.facets.selectedExperienceLevel}` : undefined,
+      `Visible result count: ${request.results.length}`,
+      "",
+      "Write a concise summary in 3 short paragraphs:",
+      "1. Describe the strongest shared patterns in the visible result set.",
+      "2. Call out where the result set is narrow, mixed, or missing clear evidence.",
+      "3. Mention 2-3 useful keywords or filters to refine next if needed.",
+      "",
+      "Candidate snippets:",
+      candidateLines,
+    ].filter(Boolean).join("\n");
+  }
+
+  private async callLLM(
+    config: ReturnType<typeof loadAIConfig>,
+    model: string,
+    messages: Array<{ role: string; content: string }>,
+  ): Promise<string> {
+    const baseUrl = config.apiBase || aiConfig.apiBase || "https://api.openai.com/v1";
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), config.timeout);
+
+    try {
+      const response = await fetch(`${baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${config.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: extractModelName(model),
+          messages,
+          temperature: 0.1,
+          max_tokens: Math.min(config.maxTokens, 900),
+        }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw new Error(`AI summary request failed with status ${response.status}: ${await response.text()}`);
+      }
+
+      const payload = await response.json() as {
+        choices?: Array<{ message?: { content?: string }; text?: string }>;
+      };
+      const content = payload.choices?.[0]?.message?.content ?? payload.choices?.[0]?.text;
+      if (!content) {
+        throw new Error("No summary content returned from AI provider");
+      }
+
+      return content;
+    } catch (error) {
+      clearTimeout(timeoutId);
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(`AI summary request timed out after ${config.timeout}ms`);
+      }
+      throw error;
+    }
+  }
+}
+
+export const aiSummaryService = new AiSummaryService();

--- a/apps/api/src/services/jd-keyword-extraction-service.test.ts
+++ b/apps/api/src/services/jd-keyword-extraction-service.test.ts
@@ -1,11 +1,50 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  callChatCompletionMock,
+  loadAIConfigMock,
+} = vi.hoisted(() => ({
+  callChatCompletionMock: vi.fn(),
+  loadAIConfigMock: vi.fn(),
+}));
+
+vi.mock("./ai-config.js", () => ({
+  loadAIConfig: () => loadAIConfigMock(),
+}));
+
+vi.mock("./ai-chat-client.js", () => ({
+  callChatCompletion: (args: unknown) => callChatCompletionMock(args),
+}));
 
 import {
+  JdKeywordExtractionService,
   normalizeExtractedKeywords,
   parseKeywordExtractionResponse,
 } from "./jd-keyword-extraction-service.js";
 
-describe("jdKeywordExtractionService helpers", () => {
+function createAIConfig(overrides: Partial<ReturnType<typeof loadAIConfigMock>> = {}) {
+  return {
+    enabled: true,
+    resumesEnabled: true,
+    model: "openai/gpt-4o-mini",
+    apiKey: "test-api-key",
+    apiBase: "https://ai.example.test/v1",
+    temperature: 0,
+    maxTokens: 4000,
+    timeout: 120000,
+    bonded: [],
+    ...overrides,
+  };
+}
+
+describe("JdKeywordExtractionService", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    callChatCompletionMock.mockReset();
+    loadAIConfigMock.mockReset();
+  });
+
   it("parses fenced JSON keyword output and deduplicates values", () => {
     const keywords = parseKeywordExtractionResponse(`\`\`\`json
 {"keywords":["Machine Tools","Business Development","machine tools","Team Player"]}
@@ -32,5 +71,65 @@ describe("jdKeywordExtractionService helpers", () => {
       "machine tools",
       "Business Development",
     ]);
+  });
+
+  it("extracts recruiter keywords through the AI client and filters filler terms", async () => {
+    loadAIConfigMock.mockReturnValue(createAIConfig());
+    callChatCompletionMock.mockResolvedValue(`\`\`\`json
+{"keywords":["Machine Tools","team player","CNC","machine tools"]}
+\`\`\``);
+
+    const service = new JdKeywordExtractionService();
+    const result = await service.extractKeywords({
+      text: "Responsibilities: machine tools sales; Requirements: CNC application experience; Team player",
+    });
+
+    expect(callChatCompletionMock).toHaveBeenCalledTimes(1);
+    const call = callChatCompletionMock.mock.calls[0]?.[0] as {
+      maxTokens: number;
+      messages: Array<{ role: string; content: string }>;
+      model: string;
+      temperature: number;
+    };
+
+    expect(call.temperature).toBe(0);
+    expect(call.maxTokens).toBe(400);
+    expect(call.messages[0]?.content).toContain("Return JSON only");
+    expect(call.messages[1]?.content).toContain("Extract the most useful resume-search keywords");
+    expect(call.messages[1]?.content).toContain("Job description:");
+    expect(result).toEqual({
+      keywords: ["Machine Tools", "CNC"],
+      model: call.model,
+    });
+  });
+
+  it("throws when the AI response does not produce any usable keywords", async () => {
+    loadAIConfigMock.mockReturnValue(createAIConfig());
+    callChatCompletionMock.mockResolvedValue(`{"keywords":["team player","none","communication skills"]}`);
+
+    const service = new JdKeywordExtractionService();
+
+    await expect(
+      service.extractKeywords({
+        text: "Responsibilities: team player communication and responsible attitude",
+      }),
+    ).rejects.toThrow("No keywords could be extracted from the job description");
+  });
+
+  it("uses heuristic extraction in mock mode without calling the AI client", async () => {
+    vi.stubEnv("AI_MOCK_ENABLED", "true");
+
+    const service = new JdKeywordExtractionService();
+    const result = await service.extractKeywords({
+      text: "Requirements: CNC, Machine Tools; Responsibilities: business development; Team player",
+    });
+
+    expect(callChatCompletionMock).not.toHaveBeenCalled();
+    expect(result.keywords).toEqual([
+      "CNC",
+      "Machine Tools",
+      "business development",
+    ]);
+    expect(result.model).toContain("/");
   });
 });

--- a/apps/api/src/services/jd-keyword-extraction-service.test.ts
+++ b/apps/api/src/services/jd-keyword-extraction-service.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeExtractedKeywords,
+  parseKeywordExtractionResponse,
+} from "./jd-keyword-extraction-service.js";
+
+describe("jdKeywordExtractionService helpers", () => {
+  it("parses fenced JSON keyword output and deduplicates values", () => {
+    const keywords = parseKeywordExtractionResponse(`\`\`\`json
+{"keywords":["Machine Tools","Business Development","machine tools","Team Player"]}
+\`\`\``);
+
+    expect(keywords).toEqual([
+      "Machine Tools",
+      "Business Development",
+    ]);
+  });
+
+  it("normalizes plain-text keyword lists", () => {
+    const keywords = normalizeExtractedKeywords([
+      "keywords: CNC",
+      " machine tools ",
+      "Business Development",
+      "business development",
+      "communication skills",
+      "N/A",
+    ]);
+
+    expect(keywords).toEqual([
+      "CNC",
+      "machine tools",
+      "Business Development",
+    ]);
+  });
+});

--- a/apps/api/src/services/jd-keyword-extraction-service.ts
+++ b/apps/api/src/services/jd-keyword-extraction-service.ts
@@ -1,0 +1,170 @@
+import { callChatCompletion } from "./ai-chat-client.js";
+import { loadAIConfig } from "./ai-config.js";
+
+const DEFAULT_JD_KEYWORD_EXTRACTION_MODEL = process.env.JD_KEYWORD_EXTRACTION_MODEL
+  || process.env.AI_SUMMARY_MODEL
+  || "anthropic/claude-3-haiku-20240307";
+
+const GENERIC_FILLER_KEYWORDS = new Set([
+  "communication",
+  "communication skills",
+  "detail oriented",
+  "hard working",
+  "responsible",
+  "self motivated",
+  "team player",
+]);
+
+type ExtractKeywordsRequest = {
+  text: string;
+};
+
+function compactWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function stripCodeFence(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed.includes("```")) {
+    return trimmed;
+  }
+
+  return trimmed
+    .replace(/^```[a-zA-Z0-9_-]*\s*/, "")
+    .replace(/```$/m, "")
+    .trim();
+}
+
+function cleanKeyword(value: string): string {
+  return value
+    .trim()
+    .replace(/^[-*•\d.)\s]+/, "")
+    .replace(/^keywords?\s*:\s*/i, "")
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function normalizeExtractedKeywords(values: string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  values.forEach((value) => {
+    const cleaned = cleanKeyword(value);
+    const key = cleaned.toLowerCase();
+    if (
+      cleaned.length < 2
+      || cleaned.length > 80
+      || seen.has(key)
+      || GENERIC_FILLER_KEYWORDS.has(key)
+      || /^n\/a$/i.test(cleaned)
+      || /^none$/i.test(cleaned)
+    ) {
+      return;
+    }
+
+    seen.add(key);
+    normalized.push(cleaned);
+  });
+
+  return normalized.slice(0, 12);
+}
+
+export function parseKeywordExtractionResponse(content: string): string[] {
+  const normalizedContent = stripCodeFence(content);
+
+  try {
+    const parsed = JSON.parse(normalizedContent) as unknown;
+    if (Array.isArray(parsed)) {
+      return normalizeExtractedKeywords(parsed.filter((item): item is string => typeof item === "string"));
+    }
+
+    if (parsed && typeof parsed === "object" && Array.isArray((parsed as { keywords?: unknown }).keywords)) {
+      return normalizeExtractedKeywords(
+        (parsed as { keywords: unknown[] }).keywords.filter((item): item is string => typeof item === "string"),
+      );
+    }
+  } catch {
+    // Fall through to the plain-text parser.
+  }
+
+  return normalizeExtractedKeywords(
+    normalizedContent
+      .split(/[\n,;|，、；]+/g)
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0),
+  );
+}
+
+function heuristicExtractKeywords(text: string): string[] {
+  return normalizeExtractedKeywords(
+    text
+      .split(/[\n,;|，、；]+/g)
+      .map((item) => compactWhitespace(
+        item
+          .replace(/^[A-Za-z][A-Za-z\s/()-]{0,30}:\s*/, "")
+          .replace(/\b(requirements?|responsibilities|job description|about the role)\b/gi, ""),
+      ))
+      .filter((item) => item.length > 1),
+  );
+}
+
+export class JdKeywordExtractionService {
+  async extractKeywords(request: ExtractKeywordsRequest): Promise<{ keywords: string[]; model: string }> {
+    const text = compactWhitespace(request.text);
+    if (!text) {
+      throw new Error("Job description text is required");
+    }
+
+    if (process.env.AI_MOCK_ENABLED === "true") {
+      return {
+        model: DEFAULT_JD_KEYWORD_EXTRACTION_MODEL,
+        keywords: heuristicExtractKeywords(text),
+      };
+    }
+
+    const config = loadAIConfig();
+    if (!config.apiKey) {
+      throw new Error("Missing AI_API_KEY environment variable");
+    }
+
+    const content = await callChatCompletion({
+      config,
+      model: DEFAULT_JD_KEYWORD_EXTRACTION_MODEL,
+      messages: [
+        {
+          role: "system",
+          content: "You extract concise recruiter search keywords from job descriptions. Return JSON only in the shape {\"keywords\":[\"...\"]}. Prefer 5 to 10 high-signal keywords or short phrases. Do not include explanations.",
+        },
+        {
+          role: "user",
+          content: [
+            "Extract the most useful resume-search keywords from this job description.",
+            "Rules:",
+            "- Keep keywords short and practical for recruiter search.",
+            "- Include role titles, product or domain terms, core skills, and market terms when they are explicit.",
+            "- Preserve meaningful multi-word phrases like machine tools or business development.",
+            "- Exclude generic filler such as communication, team player, or responsible.",
+            "- Return valid JSON only.",
+            "",
+            `Job description: ${text.slice(0, 8000)}`,
+          ].join("\n"),
+        },
+      ],
+      temperature: 0,
+      maxTokens: 400,
+    });
+
+    const keywords = parseKeywordExtractionResponse(content);
+    if (keywords.length === 0) {
+      throw new Error("No keywords could be extracted from the job description");
+    }
+
+    return {
+      keywords,
+      model: DEFAULT_JD_KEYWORD_EXTRACTION_MODEL,
+    };
+  }
+}
+
+export const jdKeywordExtractionService = new JdKeywordExtractionService();

--- a/apps/api/src/services/jd-keyword-extraction-service.ts
+++ b/apps/api/src/services/jd-keyword-extraction-service.ts
@@ -102,6 +102,7 @@ function heuristicExtractKeywords(text: string): string[] {
       .split(/[\n,;|，、；]+/g)
       .map((item) => compactWhitespace(
         item
+          .trim()
           .replace(/^[A-Za-z][A-Za-z\s/()-]{0,30}:\s*/, "")
           .replace(/\b(requirements?|responsibilities|job description|about the role)\b/gi, ""),
       ))

--- a/apps/api/src/services/workspace-config-service.ts
+++ b/apps/api/src/services/workspace-config-service.ts
@@ -707,6 +707,11 @@ export class WorkspaceConfigService {
     return mergeUnknown(systemConfig, entry.configValue);
   }
 
+  async getWorkspaceConfigValue(workspaceSlug: string, configKey: string): Promise<unknown> {
+    const entry = await this.getWorkspaceConfigEntry(workspaceSlug, configKey);
+    return entry?.configValue;
+  }
+
   async setAgentOverrides(workspaceSlug: string, configValue: unknown): Promise<void> {
     await this.upsertWorkspaceConfigEntry(workspaceSlug, AGENT_OVERRIDES_KEY, configValue);
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -64,6 +64,11 @@ const LazySystemSettingsRuntimePage = lazy(async () => {
   return { default: module.SystemSettingsRuntimePage }
 })
 
+const LazySystemSettingsTaxonomyPage = lazy(async () => {
+  const module = await import('@/pages/system-settings/SystemSettingsTaxonomyPage')
+  return { default: module.SystemSettingsTaxonomyPage }
+})
+
 function MainShell() {
   return (
     <div className="min-h-screen bg-background">
@@ -213,6 +218,14 @@ function App() {
                   element={(
                     <RouteSuspense>
                       <LazySystemSettingsKeywordsPage />
+                    </RouteSuspense>
+                  )}
+                />
+                <Route
+                  path="taxonomy"
+                  element={(
+                    <RouteSuspense>
+                      <LazySystemSettingsTaxonomyPage />
                     </RouteSuspense>
                   )}
                 />

--- a/apps/web/src/components/search/AiSummaryPanel.test.tsx
+++ b/apps/web/src/components/search/AiSummaryPanel.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AiSummaryPanel } from '@/components/search/AiSummaryPanel'
+
+describe('AiSummaryPanel', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-27T18:10:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows fallback copy when no summary is available', () => {
+    render(<AiSummaryPanel />)
+
+    expect(screen.getByText('No summary is available for the current search yet.')).toBeInTheDocument()
+  })
+
+  it('renders generated timing relative to now', () => {
+    render(
+      <AiSummaryPanel
+        generatedAt={Date.parse('2026-03-27T18:05:00.000Z')}
+        summary="Strong machine-tools coverage with a narrow senior skew."
+      />
+    )
+
+    expect(screen.getByText('Strong machine-tools coverage with a narrow senior skew.')).toBeInTheDocument()
+    expect(screen.getByText('Generated 5 minutes ago')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/search/AiSummaryPanel.tsx
+++ b/apps/web/src/components/search/AiSummaryPanel.tsx
@@ -1,0 +1,55 @@
+import { Sparkles } from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+type AiSummaryPanelProps = {
+  generatedAt?: number
+  loading?: boolean
+  summary?: string
+}
+
+function formatGeneratedAt(value: number | undefined): string | null {
+  if (!value) {
+    return null
+  }
+
+  const elapsedMinutes = Math.max(0, Math.round((Date.now() - value) / 60_000))
+  if (elapsedMinutes < 1) {
+    return 'Generated just now'
+  }
+
+  if (elapsedMinutes === 1) {
+    return 'Generated 1 minute ago'
+  }
+
+  return `Generated ${elapsedMinutes} minutes ago`
+}
+
+export function AiSummaryPanel({ generatedAt, loading = false, summary }: AiSummaryPanelProps) {
+  return (
+    <Card className="hidden rounded-[1.75rem] border-slate-200 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white shadow-[0_28px_70px_-46px_rgba(15,23,42,0.9)] md:block">
+      <CardContent className="space-y-4 p-6">
+        <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-slate-300">
+          <Sparkles className="h-4 w-4" />
+          AI result summary
+        </div>
+
+        {loading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-full bg-white/15" />
+            <Skeleton className="h-4 w-5/6 bg-white/15" />
+            <Skeleton className="h-4 w-4/6 bg-white/15" />
+          </div>
+        ) : (
+          <p className="text-sm leading-7 text-slate-100">
+            {summary || 'No summary is available for the current search yet.'}
+          </p>
+        )}
+
+        {formatGeneratedAt(generatedAt) ? (
+          <div className="text-xs text-slate-400">{formatGeneratedAt(generatedAt)}</div>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/components/search/FacetBadge.test.tsx
+++ b/apps/web/src/components/search/FacetBadge.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FacetBadge } from '@/components/search/FacetBadge'
+
+describe('FacetBadge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders without a count badge when there are no active filters', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+
+    render(<FacetBadge activeCount={0} onClick={onClick} />)
+
+    const button = screen.getByRole('button', { name: 'Filters' })
+    expect(button).toBeInTheDocument()
+    expect(screen.queryByText('0')).not.toBeInTheDocument()
+
+    await user.click(button)
+
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('renders the active-count badge and floating style when requested', () => {
+    render(<FacetBadge activeCount={3} floating onClick={vi.fn()} />)
+
+    const button = screen.getByRole('button', { name: /Filters\s*3/i })
+    expect(button).toHaveClass('shadow-lg')
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/search/FacetBadge.tsx
+++ b/apps/web/src/components/search/FacetBadge.tsx
@@ -1,0 +1,27 @@
+import { SlidersHorizontal } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+type FacetBadgeProps = {
+  activeCount: number
+  floating?: boolean
+  onClick: () => void
+}
+
+export function FacetBadge({ activeCount, floating = false, onClick }: FacetBadgeProps) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      className={floating ? 'rounded-full bg-white shadow-lg' : 'rounded-full bg-white'}
+      onClick={onClick}
+    >
+      <SlidersHorizontal className="mr-2 h-4 w-4" />
+      Filters
+      {activeCount > 0 ? (
+        <span className="ml-2 rounded-full bg-slate-900 px-2 py-0.5 text-xs text-white">
+          {activeCount}
+        </span>
+      ) : null}
+    </Button>
+  )
+}

--- a/apps/web/src/components/search/FacetGroup.test.tsx
+++ b/apps/web/src/components/search/FacetGroup.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FacetGroup } from '@/components/search/FacetGroup'
+
+describe('FacetGroup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the empty state when there are no facet values', () => {
+    render(
+      <FacetGroup
+        title="Tags"
+        items={[]}
+        selectedValues={[]}
+        onToggle={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('No values available')).toBeInTheDocument()
+    expect(screen.queryByText('Show less')).not.toBeInTheDocument()
+  })
+
+  it('uses case-insensitive selection and expands hidden facet values', async () => {
+    const user = userEvent.setup()
+    const onToggle = vi.fn()
+
+    render(
+      <FacetGroup
+        title="Tags"
+        items={[
+          { value: 'Machine Tools', label: 'Machine Tools', count: 12 },
+          { value: 'Automation', count: 7 },
+          { value: 'Robotics', count: 4 },
+        ]}
+        maxVisible={2}
+        selectedValues={['machine tools']}
+        onToggle={onToggle}
+      />
+    )
+
+    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Machine Tools/i })).toHaveClass('bg-slate-900')
+    expect(screen.queryByRole('button', { name: /Robotics/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show 1 more' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Show 1 more' }))
+
+    expect(screen.getByRole('button', { name: /Robotics/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Automation/i }))
+
+    expect(onToggle).toHaveBeenCalledWith('Automation')
+  })
+})

--- a/apps/web/src/components/search/FacetGroup.tsx
+++ b/apps/web/src/components/search/FacetGroup.tsx
@@ -59,7 +59,7 @@ export function FacetGroup({
                 )}
                 onClick={() => onToggle(item.value)}
               >
-                {item.value}
+                {item.label ?? item.value}
                 <span className={cn('ml-2 text-xs', active ? 'text-slate-200' : 'text-muted-foreground')}>
                   {item.count}
                 </span>

--- a/apps/web/src/components/search/FacetGroup.tsx
+++ b/apps/web/src/components/search/FacetGroup.tsx
@@ -1,0 +1,79 @@
+import { useMemo, useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { FacetValueCount } from '@/components/search/search-types'
+
+type FacetGroupProps = {
+  emptyLabel?: string
+  items: FacetValueCount[]
+  maxVisible?: number
+  selectedValues: string[]
+  title: string
+  onToggle: (value: string) => void
+}
+
+export function FacetGroup({
+  emptyLabel = 'No values available',
+  items,
+  maxVisible = 8,
+  selectedValues,
+  title,
+  onToggle,
+}: FacetGroupProps) {
+  const [expanded, setExpanded] = useState(false)
+  const normalizedSelectedValues = useMemo(
+    () => new Set(selectedValues.map((value) => value.toLowerCase())),
+    [selectedValues]
+  )
+  const visibleItems = expanded ? items : items.slice(0, maxVisible)
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+          {title}
+        </div>
+        {selectedValues.length > 0 ? (
+          <Badge variant="outline">{selectedValues.length}</Badge>
+        ) : null}
+      </div>
+
+      {items.length === 0 ? (
+        <div className="rounded-2xl border border-dashed px-3 py-3 text-sm text-muted-foreground">
+          {emptyLabel}
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {visibleItems.map((item) => {
+            const active = normalizedSelectedValues.has(item.value.toLowerCase())
+            return (
+              <button
+                key={`${title}-${item.value}`}
+                type="button"
+                className={cn(
+                  'rounded-full border px-3 py-1.5 text-sm transition-colors',
+                  active
+                    ? 'border-slate-900 bg-slate-900 text-white'
+                    : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300'
+                )}
+                onClick={() => onToggle(item.value)}
+              >
+                {item.value}
+                <span className={cn('ml-2 text-xs', active ? 'text-slate-200' : 'text-muted-foreground')}>
+                  {item.count}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {items.length > maxVisible ? (
+        <Button type="button" variant="ghost" className="h-auto px-0 text-sm" onClick={() => setExpanded((value) => !value)}>
+          {expanded ? 'Show less' : `Show ${items.length - maxVisible} more`}
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/components/search/FacetSidebar.test.tsx
+++ b/apps/web/src/components/search/FacetSidebar.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FacetSidebar } from '@/components/search/FacetSidebar'
+import type { FacetCounts } from '@/components/search/search-types'
+
+function buildFacetCounts(): FacetCounts {
+  return {
+    clusters: [
+      { value: 'manufacturing-systems', label: 'Manufacturing Systems', count: 4 },
+    ],
+    tags: [
+      { value: 'Machine Tools', count: 12 },
+      { value: 'Automation', count: 7 },
+      { value: 'Servo', count: 5 },
+      { value: 'Robotics', count: 4 },
+      { value: 'PLC', count: 4 },
+      { value: 'CNC', count: 3 },
+      { value: 'Servo Drives', count: 2 },
+      { value: 'Siemens', count: 2 },
+      { value: 'Mitsubishi', count: 1 },
+    ],
+    companies: [
+      { value: 'FANUC', count: 3 },
+    ],
+    experienceLevels: [
+      { value: 'senior', count: 5 },
+    ],
+    education: [
+      { value: 'Bachelor', count: 6 },
+    ],
+    statuses: [
+      { value: 'new', count: 8 },
+    ],
+    minScoreOptions: [
+      { value: '60', count: 8 },
+      { value: '70', count: 5 },
+      { value: '80', count: 2 },
+    ],
+  }
+}
+
+describe('FacetSidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forwards reset and filter toggle actions', async () => {
+    const user = userEvent.setup()
+    const onClearAll = vi.fn()
+    const onToggleCluster = vi.fn()
+    const onToggleTag = vi.fn()
+    const onToggleCompany = vi.fn()
+    const onToggleEducation = vi.fn()
+    const onToggleStatus = vi.fn()
+
+    render(
+      <FacetSidebar
+        facetCounts={buildFacetCounts()}
+        selectedClusters={['manufacturing-systems']}
+        selectedCompanies={[]}
+        selectedEducation={['Bachelor']}
+        selectedStatuses={['new']}
+        selectedTags={['machine tools']}
+        onClearAll={onClearAll}
+        onSetExperienceLevel={vi.fn()}
+        onSetMinScore={vi.fn()}
+        onToggleCluster={onToggleCluster}
+        onToggleCompany={onToggleCompany}
+        onToggleEducation={onToggleEducation}
+        onToggleStatus={onToggleStatus}
+        onToggleTag={onToggleTag}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /Machine Tools/i })).toHaveClass('bg-slate-900')
+    expect(screen.getByRole('button', { name: /Show 1 more/i })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Reset' }))
+    await user.click(screen.getByRole('button', { name: /Manufacturing Systems/i }))
+    await user.click(screen.getByRole('button', { name: /Machine Tools/i }))
+    await user.click(screen.getByRole('button', { name: /FANUC/i }))
+    await user.click(screen.getByRole('button', { name: /Bachelor/i }))
+    await user.click(screen.getByRole('button', { name: /new/i }))
+
+    expect(onClearAll).toHaveBeenCalled()
+    expect(onToggleCluster).toHaveBeenCalledWith('manufacturing-systems')
+    expect(onToggleTag).toHaveBeenCalledWith('Machine Tools')
+    expect(onToggleCompany).toHaveBeenCalledWith('FANUC')
+    expect(onToggleEducation).toHaveBeenCalledWith('Bachelor')
+    expect(onToggleStatus).toHaveBeenCalledWith('new')
+  })
+
+  it('toggles experience level and minimum score filters', async () => {
+    const user = userEvent.setup()
+    const onSetExperienceLevel = vi.fn()
+    const onSetMinScore = vi.fn()
+
+    render(
+      <FacetSidebar
+        facetCounts={buildFacetCounts()}
+        minScore={80}
+        selectedClusters={[]}
+        selectedCompanies={[]}
+        selectedEducation={[]}
+        selectedExperienceLevel="senior"
+        selectedStatuses={[]}
+        selectedTags={[]}
+        onClearAll={vi.fn()}
+        onSetExperienceLevel={onSetExperienceLevel}
+        onSetMinScore={onSetMinScore}
+        onToggleCluster={vi.fn()}
+        onToggleCompany={vi.fn()}
+        onToggleEducation={vi.fn()}
+        onToggleStatus={vi.fn()}
+        onToggleTag={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Senior' }))
+    await user.click(screen.getByRole('button', { name: 'Mid' }))
+    await user.click(screen.getByRole('button', { name: /80\+/i }))
+    await user.click(screen.getByRole('button', { name: /70\+/i }))
+
+    expect(onSetExperienceLevel).toHaveBeenNthCalledWith(1, undefined)
+    expect(onSetExperienceLevel).toHaveBeenNthCalledWith(2, 'mid')
+    expect(onSetMinScore).toHaveBeenNthCalledWith(1, undefined)
+    expect(onSetMinScore).toHaveBeenNthCalledWith(2, 70)
+  })
+})

--- a/apps/web/src/components/search/FacetSidebar.tsx
+++ b/apps/web/src/components/search/FacetSidebar.tsx
@@ -1,0 +1,118 @@
+import { FacetGroup } from '@/components/search/FacetGroup'
+import { Card, CardContent } from '@/components/ui/card'
+import type { FacetCounts } from '@/components/search/search-types'
+import type { ExperienceLevelFilter } from '@/hooks/useUrlSearchState'
+import type { CandidateStatus } from '@/types/resume'
+
+export type FacetSidebarProps = {
+  embedded?: boolean
+  facetCounts: FacetCounts
+  minScore?: number
+  selectedCompanies: string[]
+  selectedEducation: string[]
+  selectedExperienceLevel?: ExperienceLevelFilter
+  selectedStatuses: CandidateStatus[]
+  selectedTags: string[]
+  onClearAll: () => void
+  onSetExperienceLevel: (value: ExperienceLevelFilter | undefined) => void
+  onSetMinScore: (value: number | undefined) => void
+  onToggleCompany: (value: string) => void
+  onToggleEducation: (value: string) => void
+  onToggleStatus: (value: CandidateStatus) => void
+  onToggleTag: (value: string) => void
+}
+
+function ExperienceLevelGroup({
+  selectedExperienceLevel,
+  onSetExperienceLevel,
+}: Pick<FacetSidebarProps, 'selectedExperienceLevel' | 'onSetExperienceLevel'>) {
+  const items = [
+    { value: 'senior', label: 'Senior' },
+    { value: 'mid', label: 'Mid' },
+    { value: 'junior', label: 'Junior' },
+  ] as const
+
+  return (
+    <div className="space-y-3">
+      <div className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+        Experience level
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {items.map((item) => {
+          const active = selectedExperienceLevel === item.value
+          return (
+            <button
+              key={item.value}
+              type="button"
+              className={active
+                ? 'rounded-full border border-slate-900 bg-slate-900 px-3 py-1.5 text-sm text-white'
+                : 'rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700'}
+              onClick={() => onSetExperienceLevel(active ? undefined : item.value)}
+            >
+              {item.label}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export function FacetSidebar({
+  embedded = false,
+  facetCounts,
+  minScore,
+  selectedCompanies,
+  selectedEducation,
+  selectedExperienceLevel,
+  selectedStatuses,
+  selectedTags,
+  onClearAll,
+  onSetExperienceLevel,
+  onSetMinScore,
+  onToggleCompany,
+  onToggleEducation,
+  onToggleStatus,
+  onToggleTag,
+}: FacetSidebarProps) {
+  const content = (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-sm font-semibold text-slate-900">Filters</div>
+          <div className="text-xs text-muted-foreground">Refine the current result set without leaving the search flow.</div>
+        </div>
+        <button type="button" className="text-sm text-muted-foreground hover:text-foreground" onClick={onClearAll}>
+          Reset
+        </button>
+      </div>
+
+      <FacetGroup title="Tags" items={facetCounts.tags} selectedValues={selectedTags} onToggle={onToggleTag} />
+      <FacetGroup title="Companies" items={facetCounts.companies} selectedValues={selectedCompanies} onToggle={onToggleCompany} />
+      <ExperienceLevelGroup selectedExperienceLevel={selectedExperienceLevel} onSetExperienceLevel={onSetExperienceLevel} />
+      <FacetGroup title="Education" items={facetCounts.education} selectedValues={selectedEducation} onToggle={onToggleEducation} />
+      <FacetGroup title="Status" items={facetCounts.statuses} selectedValues={selectedStatuses} onToggle={(value) => onToggleStatus(value as CandidateStatus)} />
+      <FacetGroup
+        title="Match score"
+        items={facetCounts.minScoreOptions.map((item) => ({ ...item, value: `${item.value}+` }))}
+        selectedValues={typeof minScore === 'number' ? [`${minScore}+`] : []}
+        onToggle={(value) => {
+          const numericValue = Number(value.replace('+', ''))
+          onSetMinScore(minScore === numericValue ? undefined : numericValue)
+        }}
+      />
+    </div>
+  )
+
+  if (embedded) {
+    return content
+  }
+
+  return (
+    <Card className="rounded-[1.75rem] border-slate-200 bg-white">
+      <CardContent className="p-5">
+        {content}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/components/search/FacetSidebar.tsx
+++ b/apps/web/src/components/search/FacetSidebar.tsx
@@ -8,6 +8,7 @@ export type FacetSidebarProps = {
   embedded?: boolean
   facetCounts: FacetCounts
   minScore?: number
+  selectedClusters: string[]
   selectedCompanies: string[]
   selectedEducation: string[]
   selectedExperienceLevel?: ExperienceLevelFilter
@@ -17,6 +18,7 @@ export type FacetSidebarProps = {
   onSetExperienceLevel: (value: ExperienceLevelFilter | undefined) => void
   onSetMinScore: (value: number | undefined) => void
   onToggleCompany: (value: string) => void
+  onToggleCluster: (value: string) => void
   onToggleEducation: (value: string) => void
   onToggleStatus: (value: CandidateStatus) => void
   onToggleTag: (value: string) => void
@@ -62,6 +64,7 @@ export function FacetSidebar({
   embedded = false,
   facetCounts,
   minScore,
+  selectedClusters,
   selectedCompanies,
   selectedEducation,
   selectedExperienceLevel,
@@ -71,6 +74,7 @@ export function FacetSidebar({
   onSetExperienceLevel,
   onSetMinScore,
   onToggleCompany,
+  onToggleCluster,
   onToggleEducation,
   onToggleStatus,
   onToggleTag,
@@ -87,6 +91,12 @@ export function FacetSidebar({
         </button>
       </div>
 
+      <FacetGroup
+        title="Skill Clusters"
+        items={facetCounts.clusters}
+        selectedValues={selectedClusters}
+        onToggle={onToggleCluster}
+      />
       <FacetGroup title="Tags" items={facetCounts.tags} selectedValues={selectedTags} onToggle={onToggleTag} />
       <FacetGroup title="Companies" items={facetCounts.companies} selectedValues={selectedCompanies} onToggle={onToggleCompany} />
       <ExperienceLevelGroup selectedExperienceLevel={selectedExperienceLevel} onSetExperienceLevel={onSetExperienceLevel} />

--- a/apps/web/src/components/search/GoogleSearchBar.test.tsx
+++ b/apps/web/src/components/search/GoogleSearchBar.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ComponentProps } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GoogleSearchBar } from '@/components/search/GoogleSearchBar'
 import type { ResumeSearchRecentItem } from '@/components/search/search-types'
@@ -25,6 +26,41 @@ function buildRecentSearch(overrides: Partial<ResumeSearchRecentItem> = {}): Res
     filters: {},
     createdAt: Date.now(),
     ...overrides,
+  }
+}
+
+function renderSearchBar({
+  compact,
+  loading,
+  onApplyExtractedKeywords,
+  onApplyRecentSearch = vi.fn(),
+  onChange = vi.fn(),
+  onClear = vi.fn(),
+  onSubmit = vi.fn(),
+  placeholder,
+  recentSearches = [buildRecentSearch()],
+  value = '',
+}: Partial<ComponentProps<typeof GoogleSearchBar>> = {}) {
+  render(
+    <GoogleSearchBar
+      compact={compact}
+      loading={loading}
+      recentSearches={recentSearches}
+      value={value}
+      onApplyRecentSearch={onApplyRecentSearch}
+      onApplyExtractedKeywords={onApplyExtractedKeywords}
+      onChange={onChange}
+      onClear={onClear}
+      onSubmit={onSubmit}
+      placeholder={placeholder}
+    />
+  )
+
+  return {
+    onApplyRecentSearch,
+    onChange,
+    onClear,
+    onSubmit,
   }
 }
 
@@ -58,5 +94,145 @@ describe('GoogleSearchBar', () => {
 
     expect(screen.queryByText('JD Popover')).not.toBeInTheDocument()
     expect(onClear).not.toHaveBeenCalled()
+  })
+
+  it('submits the trimmed query from the search button', async () => {
+    const user = userEvent.setup()
+    const { onSubmit } = renderSearchBar({
+      value: '  machine tools  ',
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Search' }))
+
+    expect(onSubmit).toHaveBeenCalledWith('machine tools')
+  })
+
+  it('shows the first six recent searches for an empty query and filters them by query text', async () => {
+    const user = userEvent.setup()
+    const recentSearches = [
+      buildRecentSearch({
+        id: 'history-1' as ResumeSearchRecentItem['id'],
+        title: 'Machine tools',
+        keywords: ['Machine Tools'],
+        location: 'Kuala Lumpur',
+      }),
+      buildRecentSearch({
+        id: 'history-2' as ResumeSearchRecentItem['id'],
+        title: 'CNC sales',
+        keywords: ['CNC Sales'],
+        location: 'Shenzhen',
+      }),
+      buildRecentSearch({
+        id: 'history-3' as ResumeSearchRecentItem['id'],
+        title: 'Account manager',
+        keywords: ['Account Manager'],
+        location: 'Singapore',
+      }),
+      buildRecentSearch({
+        id: 'history-4' as ResumeSearchRecentItem['id'],
+        title: 'Industrial automation',
+        keywords: ['Industrial Automation'],
+        location: 'Penang',
+      }),
+      buildRecentSearch({
+        id: 'history-5' as ResumeSearchRecentItem['id'],
+        title: 'Factory GM',
+        keywords: ['Factory GM'],
+        location: 'Johor Bahru',
+      }),
+      buildRecentSearch({
+        id: 'history-6' as ResumeSearchRecentItem['id'],
+        title: 'Regional director',
+        keywords: ['Regional Director'],
+        location: 'Bangkok',
+      }),
+      buildRecentSearch({
+        id: 'history-7' as ResumeSearchRecentItem['id'],
+        title: 'Rust backend',
+        keywords: ['Rust Backend'],
+        location: 'Tokyo',
+      }),
+    ]
+
+    const { rerender } = render(
+      <GoogleSearchBar
+        recentSearches={recentSearches}
+        value=""
+        onApplyRecentSearch={vi.fn()}
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    const input = screen.getByPlaceholderText('Search resumes by keywords, brands, roles, or locations')
+    await user.click(input)
+
+    expect(screen.getByText('Recent searches')).toBeInTheDocument()
+    expect(screen.getByText('Machine Tools')).toBeInTheDocument()
+    expect(screen.getByText('Regional Director')).toBeInTheDocument()
+    expect(screen.queryByText('Rust Backend')).not.toBeInTheDocument()
+
+    rerender(
+      <GoogleSearchBar
+        recentSearches={recentSearches}
+        value="sing"
+        onApplyRecentSearch={vi.fn()}
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByDisplayValue('sing'))
+
+    expect(screen.getByText('Account Manager')).toBeInTheDocument()
+    expect(screen.queryByText('Machine Tools')).not.toBeInTheDocument()
+    expect(screen.queryByText('CNC Sales')).not.toBeInTheDocument()
+  })
+
+  it('applies a recent search selection from the dropdown', async () => {
+    const user = userEvent.setup()
+    const recentItem = buildRecentSearch({
+      id: 'history-apply' as ResumeSearchRecentItem['id'],
+      title: 'CNC sales',
+      keywords: ['CNC Sales'],
+      location: 'Shenzhen',
+    })
+    const onApplyRecentSearch = vi.fn()
+
+    renderSearchBar({
+      recentSearches: [recentItem],
+      onApplyRecentSearch,
+    })
+
+    await user.click(screen.getByPlaceholderText('Search resumes by keywords, brands, roles, or locations'))
+    await user.click(screen.getByRole('button', { name: /CNC Sales/i }))
+
+    expect(onApplyRecentSearch).toHaveBeenCalledWith(recentItem)
+  })
+
+  it('clears the query on escape when the JD popover is closed', async () => {
+    const user = userEvent.setup()
+    const { onClear } = renderSearchBar({
+      value: 'machine tools',
+      onApplyExtractedKeywords: vi.fn(),
+    })
+
+    await user.click(screen.getByPlaceholderText('Search resumes by keywords, brands, roles, or locations'))
+    await user.keyboard('{Escape}')
+
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards the clear button click when the query is present', async () => {
+    const user = userEvent.setup()
+    const { onClear } = renderSearchBar({
+      value: 'machine tools',
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Clear search' }))
+
+    expect(onClear).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/components/search/GoogleSearchBar.test.tsx
+++ b/apps/web/src/components/search/GoogleSearchBar.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GoogleSearchBar } from '@/components/search/GoogleSearchBar'
+import type { ResumeSearchRecentItem } from '@/components/search/search-types'
+
+vi.mock('@/components/search/JdPastePopover', () => ({
+  JdPastePopover: ({ onClose }: { onClose: () => void }) => (
+    <div>
+      <div>JD Popover</div>
+      <button type="button" onClick={onClose}>Close JD Popover</button>
+    </div>
+  ),
+}))
+
+function buildRecentSearch(overrides: Partial<ResumeSearchRecentItem> = {}): ResumeSearchRecentItem {
+  return {
+    id: 'history-1' as ResumeSearchRecentItem['id'],
+    sessionKey: 'session-1',
+    title: 'Machine tools',
+    location: 'Kuala Lumpur',
+    keywords: ['Machine Tools'],
+    selectedTags: [],
+    selectedCompanies: [],
+    filters: {},
+    createdAt: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('GoogleSearchBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('closes the JD popover on escape before clearing the query', async () => {
+    const user = userEvent.setup()
+    const onClear = vi.fn()
+
+    render(
+      <GoogleSearchBar
+        value="machine tools"
+        recentSearches={[buildRecentSearch()]}
+        onApplyRecentSearch={vi.fn()}
+        onApplyExtractedKeywords={vi.fn()}
+        onChange={vi.fn()}
+        onClear={onClear}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Paste job description' }))
+    expect(screen.getByText('JD Popover')).toBeInTheDocument()
+
+    const input = screen.getByPlaceholderText('Search resumes by keywords, brands, roles, or locations')
+    await user.click(input)
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByText('JD Popover')).not.toBeInTheDocument()
+    expect(onClear).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/search/GoogleSearchBar.tsx
+++ b/apps/web/src/components/search/GoogleSearchBar.tsx
@@ -98,6 +98,11 @@ export function GoogleSearchBar({
           onKeyDown={(event) => {
             if (event.key === 'Escape') {
               event.preventDefault()
+              if (jdPopoverOpen) {
+                setJdPopoverOpen(false)
+                return
+              }
+
               onClear()
             }
           }}

--- a/apps/web/src/components/search/GoogleSearchBar.tsx
+++ b/apps/web/src/components/search/GoogleSearchBar.tsx
@@ -1,6 +1,7 @@
-import { Clock3, Search, X } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { Clock3, FileText, Search, X } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { JdPastePopover } from '@/components/search/JdPastePopover'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 import type { ResumeSearchRecentItem } from '@/components/search/search-types'
@@ -11,6 +12,7 @@ type GoogleSearchBarProps = {
   recentSearches: ResumeSearchRecentItem[]
   value: string
   onApplyRecentSearch: (item: ResumeSearchRecentItem) => void | Promise<void>
+  onApplyExtractedKeywords?: (keywords: string[]) => void
   onChange: (value: string) => void
   onClear: () => void
   onSubmit: (value?: string) => void
@@ -27,12 +29,15 @@ export function GoogleSearchBar({
   recentSearches,
   value,
   onApplyRecentSearch,
+  onApplyExtractedKeywords,
   onChange,
   onClear,
   onSubmit,
   placeholder = 'Search resumes by keywords, brands, roles, or locations',
 }: GoogleSearchBarProps) {
   const [focused, setFocused] = useState(false)
+  const [jdPopoverOpen, setJdPopoverOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
   const trimmedValue = value.trim()
   const filteredRecentSearches = useMemo(() => {
     if (!trimmedValue) {
@@ -47,8 +52,23 @@ export function GoogleSearchBar({
     ).slice(0, 6)
   }, [recentSearches, trimmedValue])
 
+  useEffect(() => {
+    if (!jdPopoverOpen) {
+      return undefined
+    }
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setJdPopoverOpen(false)
+      }
+    }
+
+    window.addEventListener('mousedown', handlePointerDown)
+    return () => window.removeEventListener('mousedown', handlePointerDown)
+  }, [jdPopoverOpen])
+
   return (
-    <div className="relative">
+    <div ref={containerRef} className="relative">
       <form
         className={cn(
           'relative flex items-center overflow-hidden rounded-full border bg-background/95 shadow-[0_12px_40px_-28px_rgba(15,23,42,0.85)] transition-shadow focus-within:shadow-[0_20px_60px_-30px_rgba(15,23,42,0.55)]',
@@ -56,6 +76,7 @@ export function GoogleSearchBar({
         )}
         onSubmit={(event) => {
           event.preventDefault()
+          setJdPopoverOpen(false)
           onSubmit(trimmedValue)
         }}
       >
@@ -81,6 +102,21 @@ export function GoogleSearchBar({
             }
           }}
         />
+        {onApplyExtractedKeywords ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="mr-1 rounded-full text-muted-foreground"
+            onClick={() => {
+              setFocused(false)
+              setJdPopoverOpen((current) => !current)
+            }}
+          >
+            <FileText className="h-4 w-4" />
+            <span className="sr-only">Paste job description</span>
+          </Button>
+        ) : null}
         {trimmedValue ? (
           <Button
             type="button"
@@ -100,7 +136,15 @@ export function GoogleSearchBar({
         </div>
       </form>
 
-      {focused && filteredRecentSearches.length > 0 ? (
+      {jdPopoverOpen && onApplyExtractedKeywords ? (
+        <JdPastePopover
+          compact={compact}
+          onApplyKeywords={onApplyExtractedKeywords}
+          onClose={() => setJdPopoverOpen(false)}
+        />
+      ) : null}
+
+      {focused && !jdPopoverOpen && filteredRecentSearches.length > 0 ? (
         <div className="absolute inset-x-0 top-[calc(100%+0.75rem)] z-30 overflow-hidden rounded-3xl border bg-background shadow-xl">
           <div className="border-b px-4 py-3 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
             Recent searches

--- a/apps/web/src/components/search/GoogleSearchBar.tsx
+++ b/apps/web/src/components/search/GoogleSearchBar.tsx
@@ -1,0 +1,134 @@
+import { Clock3, Search, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import type { ResumeSearchRecentItem } from '@/components/search/search-types'
+
+type GoogleSearchBarProps = {
+  compact?: boolean
+  loading?: boolean
+  recentSearches: ResumeSearchRecentItem[]
+  value: string
+  onApplyRecentSearch: (item: ResumeSearchRecentItem) => void | Promise<void>
+  onChange: (value: string) => void
+  onClear: () => void
+  onSubmit: (value?: string) => void
+  placeholder?: string
+}
+
+function getRecentSearchLabel(item: ResumeSearchRecentItem): string {
+  return item.keywords.join(' ') || item.title
+}
+
+export function GoogleSearchBar({
+  compact = false,
+  loading = false,
+  recentSearches,
+  value,
+  onApplyRecentSearch,
+  onChange,
+  onClear,
+  onSubmit,
+  placeholder = 'Search resumes by keywords, brands, roles, or locations',
+}: GoogleSearchBarProps) {
+  const [focused, setFocused] = useState(false)
+  const trimmedValue = value.trim()
+  const filteredRecentSearches = useMemo(() => {
+    if (!trimmedValue) {
+      return recentSearches.slice(0, 6)
+    }
+
+    const normalizedQuery = trimmedValue.toLowerCase()
+    return recentSearches.filter((item) =>
+      item.title.toLowerCase().includes(normalizedQuery)
+      || item.keywords.some((keyword) => keyword.toLowerCase().includes(normalizedQuery))
+      || item.location.toLowerCase().includes(normalizedQuery)
+    ).slice(0, 6)
+  }, [recentSearches, trimmedValue])
+
+  return (
+    <div className="relative">
+      <form
+        className={cn(
+          'relative flex items-center overflow-hidden rounded-full border bg-background/95 shadow-[0_12px_40px_-28px_rgba(15,23,42,0.85)] transition-shadow focus-within:shadow-[0_20px_60px_-30px_rgba(15,23,42,0.55)]',
+          compact ? 'min-h-14' : 'min-h-16'
+        )}
+        onSubmit={(event) => {
+          event.preventDefault()
+          onSubmit(trimmedValue)
+        }}
+      >
+        <div className="pl-5 text-muted-foreground">
+          <Search className={cn(compact ? 'h-4 w-4' : 'h-5 w-5')} />
+        </div>
+        <Input
+          value={value}
+          className={cn(
+            'border-0 bg-transparent shadow-none focus-visible:ring-0 focus-visible:ring-offset-0',
+            compact ? 'h-14 text-base' : 'h-16 text-lg'
+          )}
+          placeholder={placeholder}
+          onBlur={() => {
+            window.setTimeout(() => setFocused(false), 120)
+          }}
+          onChange={(event) => onChange(event.target.value)}
+          onFocus={() => setFocused(true)}
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') {
+              event.preventDefault()
+              onClear()
+            }
+          }}
+        />
+        {trimmedValue ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="mr-1 rounded-full text-muted-foreground"
+            onClick={onClear}
+          >
+            <X className="h-4 w-4" />
+            <span className="sr-only">Clear search</span>
+          </Button>
+        ) : null}
+        <div className="pr-2">
+          <Button type="submit" className="rounded-full px-5" disabled={loading}>
+            {loading ? 'Searching...' : 'Search'}
+          </Button>
+        </div>
+      </form>
+
+      {focused && filteredRecentSearches.length > 0 ? (
+        <div className="absolute inset-x-0 top-[calc(100%+0.75rem)] z-30 overflow-hidden rounded-3xl border bg-background shadow-xl">
+          <div className="border-b px-4 py-3 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Recent searches
+          </div>
+          <div className="p-2">
+            {filteredRecentSearches.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className="flex w-full items-start gap-3 rounded-2xl px-3 py-3 text-left transition-colors hover:bg-muted"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => {
+                  setFocused(false)
+                  void onApplyRecentSearch(item)
+                }}
+              >
+                <Clock3 className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium">{getRecentSearchLabel(item)}</div>
+                  <div className="truncate text-xs text-muted-foreground">
+                    {[item.location, item.jobDescriptionId].filter(Boolean).join(' · ') || item.title}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/components/search/JdPastePopover.test.tsx
+++ b/apps/web/src/components/search/JdPastePopover.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { JdPastePopover } from '@/components/search/JdPastePopover'
+
+const postMock = vi.fn()
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: {
+    POST: (...args: unknown[]) => postMock(...args),
+  },
+}))
+
+describe('JdPastePopover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('extracts keywords and applies them to the parent flow', async () => {
+    const user = userEvent.setup()
+    const onApplyKeywords = vi.fn()
+    const onClose = vi.fn()
+
+    postMock.mockResolvedValueOnce({
+      data: {
+        success: true,
+        keywords: ['Business Development', 'Machine Tools'],
+      },
+    })
+
+    render(
+      <JdPastePopover
+        onApplyKeywords={onApplyKeywords}
+        onClose={onClose}
+      />
+    )
+
+    await user.type(
+      screen.getByPlaceholderText('Paste the job description text here to extract role, product, and domain keywords.'),
+      'Business development manager for machine tools in Malaysia.'
+    )
+    await user.click(screen.getByRole('button', { name: 'Extract keywords' }))
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledWith('/api/job-descriptions/extract-keywords', {
+        body: {
+          text: 'Business development manager for machine tools in Malaysia.',
+        },
+      })
+    })
+
+    expect(onApplyKeywords).toHaveBeenCalledWith(['Business Development', 'Machine Tools'])
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows an inline error when extraction fails', async () => {
+    const user = userEvent.setup()
+
+    postMock.mockResolvedValueOnce({
+      error: new Error('network failed'),
+    })
+
+    render(
+      <JdPastePopover
+        onApplyKeywords={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+
+    await user.type(
+      screen.getByPlaceholderText('Paste the job description text here to extract role, product, and domain keywords.'),
+      'Machine tools sales engineer'
+    )
+    await user.keyboard('{Control>}{Enter}{/Control}')
+
+    expect(await screen.findByText('Failed to extract keywords from the job description')).toBeInTheDocument()
+  })
+
+  it('closes on escape without calling extraction', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(
+      <JdPastePopover
+        onApplyKeywords={vi.fn()}
+        onClose={onClose}
+      />
+    )
+
+    await user.type(
+      screen.getByPlaceholderText('Paste the job description text here to extract role, product, and domain keywords.'),
+      'Machine tools sales engineer'
+    )
+    await user.keyboard('{Escape}')
+
+    expect(onClose).toHaveBeenCalled()
+    expect(postMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/search/JdPastePopover.tsx
+++ b/apps/web/src/components/search/JdPastePopover.tsx
@@ -1,0 +1,123 @@
+import { Loader2, WandSparkles } from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { rawApiClient } from '@/lib/api-helpers'
+
+type ExtractKeywordsResponse = {
+  success: boolean
+  keywords?: string[]
+  model?: string
+}
+
+type JdPastePopoverProps = {
+  compact?: boolean
+  onApplyKeywords: (keywords: string[]) => void
+  onClose: () => void
+}
+
+export function JdPastePopover({
+  compact = false,
+  onApplyKeywords,
+  onClose,
+}: JdPastePopoverProps) {
+  const [value, setValue] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | undefined>(undefined)
+
+  const submit = async () => {
+    const trimmedValue = value.trim()
+    if (!trimmedValue) {
+      setError('Paste a job description first')
+      return
+    }
+
+    setLoading(true)
+    setError(undefined)
+
+    const { data, error: requestError } = await rawApiClient.POST<ExtractKeywordsResponse>('/api/job-descriptions/extract-keywords', {
+      body: {
+        text: trimmedValue,
+      },
+    })
+
+    setLoading(false)
+
+    if (requestError || !data?.success) {
+      setError('Failed to extract keywords from the job description')
+      return
+    }
+
+    if (!data.keywords || data.keywords.length === 0) {
+      setError('No useful keywords were extracted')
+      return
+    }
+
+    onApplyKeywords(data.keywords)
+    setValue('')
+    setError(undefined)
+    onClose()
+  }
+
+  return (
+    <div className="absolute right-0 top-[calc(100%+0.75rem)] z-40 w-[calc(100vw-2rem)] max-w-[30rem] overflow-hidden rounded-[1.75rem] border bg-background shadow-[0_30px_80px_-40px_rgba(15,23,42,0.45)]">
+      <div className="border-b px-5 py-4">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-900">
+          <WandSparkles className="h-4 w-4 text-amber-600" />
+          Paste JD to extract keywords
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          We only extract search terms. Nothing is written back to the job description.
+        </p>
+      </div>
+
+      <div className="space-y-4 p-5">
+        <Textarea
+          autoFocus
+          value={value}
+          className={compact ? 'min-h-[180px]' : 'min-h-[220px]'}
+          placeholder="Paste the job description text here to extract role, product, and domain keywords."
+          onChange={(event) => setValue(event.target.value)}
+          onKeyDown={(event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+              event.preventDefault()
+              void submit()
+            }
+
+            if (event.key === 'Escape') {
+              event.preventDefault()
+              onClose()
+            }
+          }}
+        />
+
+        {error ? (
+          <div className="rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-xs text-muted-foreground">
+            Tip: use <span className="font-medium">Ctrl/Cmd + Enter</span> to extract.
+          </div>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={() => void submit()} disabled={loading}>
+              {loading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Extracting...
+                </>
+              ) : (
+                'Extract keywords'
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/search/MigrationBanner.test.tsx
+++ b/apps/web/src/components/search/MigrationBanner.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MigrationBanner } from '@/components/search/MigrationBanner'
+
+vi.mock('@/contexts/WorkspaceContext', () => ({
+  useWorkspace: () => ({
+    slug: 'dev',
+  }),
+}))
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}))
+
+const STORAGE_KEY = 'trends.resume.search-first.migration-banner.dismissed'
+
+describe('MigrationBanner', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('renders the migration copy and search profiles link until dismissed', async () => {
+    render(<MigrationBanner />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Search Profiles still exist, but the primary resume route is now search-first.')).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/system/profiles')
+  })
+
+  it('persists dismissal in local storage', async () => {
+    const user = userEvent.setup()
+
+    render(<MigrationBanner />)
+
+    const dismissButton = await screen.findByRole('button', { name: 'Dismiss migration banner' })
+    await user.click(dismissButton)
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('1')
+    expect(screen.queryByText('Search Profiles still exist, but the primary resume route is now search-first.')).not.toBeInTheDocument()
+  })
+
+  it('stays hidden when already dismissed', () => {
+    localStorage.setItem(STORAGE_KEY, '1')
+
+    render(<MigrationBanner />)
+
+    expect(screen.queryByText('Search Profiles still exist, but the primary resume route is now search-first.')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/search/MigrationBanner.tsx
+++ b/apps/web/src/components/search/MigrationBanner.tsx
@@ -1,0 +1,49 @@
+import { X } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { useWorkspace } from '@/contexts/WorkspaceContext'
+
+const STORAGE_KEY = 'trends.resume.search-first.migration-banner.dismissed'
+
+export function MigrationBanner() {
+  const { slug } = useWorkspace()
+  const [dismissed, setDismissed] = useState(true)
+
+  useEffect(() => {
+    setDismissed(localStorage.getItem(STORAGE_KEY) === '1')
+  }, [])
+
+  if (dismissed) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-[1.5rem] border border-sky-200 bg-sky-50 px-4 py-4 text-sm text-sky-900 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+      <div className="space-y-1">
+        <div className="font-medium">Search Profiles still exist, but the primary resume route is now search-first.</div>
+        <div className="text-sky-800/80">
+          Use this page for fast keyword review. Use Search Profiles when you need managed workflow presets and JD-driven setup.
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Link className="inline-flex h-9 items-center rounded-md border border-sky-200 bg-white px-3 text-sm font-medium" to={`/${slug}/system/profiles`}>
+          Open Search Profiles
+        </Link>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="rounded-full"
+          onClick={() => {
+            localStorage.setItem(STORAGE_KEY, '1')
+            setDismissed(true)
+          }}
+        >
+          <X className="h-4 w-4" />
+          <span className="sr-only">Dismiss migration banner</span>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/search/MobileFilterSheet.test.tsx
+++ b/apps/web/src/components/search/MobileFilterSheet.test.tsx
@@ -1,0 +1,113 @@
+import type { ComponentProps, ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MobileFilterSheet } from '@/components/search/MobileFilterSheet'
+import type { FacetSidebarProps } from '@/components/search/FacetSidebar'
+import type { FacetCounts } from '@/components/search/search-types'
+
+const { facetSidebarMock } = vi.hoisted(() => ({
+  facetSidebarMock: vi.fn(),
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({
+    children,
+    onOpenChange,
+    open,
+  }: {
+    children: ReactNode
+    onOpenChange: (open: boolean) => void
+    open: boolean
+  }) => (
+    <div data-testid="dialog-root" data-open={String(open)}>
+      <button type="button" onClick={() => onOpenChange(false)}>
+        Close dialog
+      </button>
+      {children}
+    </div>
+  ),
+  DialogContent: ({
+    children,
+    className,
+  }: {
+    children: ReactNode
+    className?: string
+  }) => <div className={className}>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogHeader: ({ children, className }: { children: ReactNode; className?: string }) => <div className={className}>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}))
+
+vi.mock('@/components/search/FacetSidebar', () => ({
+  FacetSidebar: (props: FacetSidebarProps) => {
+    facetSidebarMock(props)
+    return <div>FacetSidebar embedded:{String(props.embedded)} tags:{props.selectedTags.join('|')}</div>
+  },
+}))
+
+function buildFacetCounts(): FacetCounts {
+  return {
+    clusters: [],
+    tags: [],
+    companies: [],
+    experienceLevels: [],
+    education: [],
+    statuses: [],
+    minScoreOptions: [],
+  }
+}
+
+function buildProps(overrides: Partial<ComponentProps<typeof MobileFilterSheet>> = {}): ComponentProps<typeof MobileFilterSheet> {
+  return {
+    open: true,
+    onOpenChange: vi.fn(),
+    facetCounts: buildFacetCounts(),
+    selectedClusters: [],
+    selectedCompanies: [],
+    selectedEducation: [],
+    selectedStatuses: [],
+    selectedTags: ['Machine Tools'],
+    onClearAll: vi.fn(),
+    onSetExperienceLevel: vi.fn(),
+    onSetMinScore: vi.fn(),
+    onToggleCluster: vi.fn(),
+    onToggleCompany: vi.fn(),
+    onToggleEducation: vi.fn(),
+    onToggleStatus: vi.fn(),
+    onToggleTag: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('MobileFilterSheet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the mobile filter copy and always embeds the sidebar', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+
+    render(
+      <MobileFilterSheet
+        {...buildProps({
+          embedded: false,
+          onOpenChange,
+        })}
+      />
+    )
+
+    expect(screen.getByText('Filters')).toBeInTheDocument()
+    expect(screen.getByText('Narrow the current search without leaving the result list.')).toBeInTheDocument()
+    expect(screen.getByText('FacetSidebar embedded:true tags:Machine Tools')).toBeInTheDocument()
+    expect(facetSidebarMock).toHaveBeenCalledWith(expect.objectContaining({
+      embedded: true,
+      selectedTags: ['Machine Tools'],
+    }))
+
+    await user.click(screen.getByRole('button', { name: 'Close dialog' }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/apps/web/src/components/search/MobileFilterSheet.tsx
+++ b/apps/web/src/components/search/MobileFilterSheet.tsx
@@ -18,7 +18,7 @@ export function MobileFilterSheet({ open, onOpenChange, ...props }: MobileFilter
           </DialogDescription>
         </DialogHeader>
         <div className="max-h-[75vh] overflow-y-auto px-6 pb-6">
-          <FacetSidebar embedded {...props} />
+          <FacetSidebar {...props} embedded />
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/search/MobileFilterSheet.tsx
+++ b/apps/web/src/components/search/MobileFilterSheet.tsx
@@ -1,0 +1,26 @@
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { FacetSidebar } from '@/components/search/FacetSidebar'
+import type { FacetSidebarProps } from '@/components/search/FacetSidebar'
+
+type MobileFilterSheetProps = FacetSidebarProps & {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function MobileFilterSheet({ open, onOpenChange, ...props }: MobileFilterSheetProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bottom-0 top-auto translate-y-0 rounded-t-[2rem] p-0 sm:max-w-lg">
+        <DialogHeader className="px-6 pt-6">
+          <DialogTitle>Filters</DialogTitle>
+          <DialogDescription>
+            Narrow the current search without leaving the result list.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[75vh] overflow-y-auto px-6 pb-6">
+          <FacetSidebar embedded {...props} />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/search/SearchHeader.test.tsx
+++ b/apps/web/src/components/search/SearchHeader.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SearchHeader } from '@/components/search/SearchHeader'
+import type { ResumeSearchRecentItem } from '@/components/search/search-types'
+
+vi.mock('@/components/search/GoogleSearchBar', () => ({
+  GoogleSearchBar: ({
+    compact,
+    loading,
+    recentSearches,
+    value,
+  }: {
+    compact?: boolean
+    loading?: boolean
+    recentSearches: ResumeSearchRecentItem[]
+    value: string
+  }) => (
+    <div>
+      <div>
+        Search Header Bar {compact ? 'compact' : 'full'} {value} {loading ? 'loading' : 'idle'} {recentSearches.length}
+      </div>
+    </div>
+  ),
+}))
+
+function buildRecentSearch(): ResumeSearchRecentItem {
+  return {
+    id: 'history-1' as ResumeSearchRecentItem['id'],
+    sessionKey: 'session-1',
+    title: 'Machine tools',
+    location: 'Malaysia',
+    keywords: ['Machine Tools'],
+    selectedTags: [],
+    selectedCompanies: [],
+    filters: {},
+    createdAt: Date.now(),
+  }
+}
+
+describe('SearchHeader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders summary badges and forwards sort changes', async () => {
+    const user = userEvent.setup()
+    const onSortChange = vi.fn()
+
+    render(
+      <SearchHeader
+        activeQuery="machine tools"
+        activeResultCount={1250}
+        jobDescriptionId="lathe-sales"
+        location="Malaysia"
+        queryInput="machine tools"
+        recentSearches={[buildRecentSearch()]}
+        sortValue="newest"
+        onApplyRecentSearch={vi.fn()}
+        onApplyExtractedKeywords={vi.fn()}
+        onChangeQuery={vi.fn()}
+        onClearQuery={vi.fn()}
+        onSubmitQuery={vi.fn()}
+        onSortChange={onSortChange}
+      />
+    )
+
+    expect(screen.getByText('Search Header Bar compact machine tools idle 1')).toBeInTheDocument()
+    expect(screen.getByText('1,250 results for "machine tools"')).toBeInTheDocument()
+    expect(screen.getByText('Malaysia')).toBeInTheDocument()
+    expect(screen.getByText('JD lathe-sales')).toBeInTheDocument()
+
+    await user.selectOptions(screen.getByRole('combobox'), 'experience')
+
+    expect(onSortChange).toHaveBeenCalledWith('experience')
+  })
+
+  it('omits the quoted query suffix when no active query is set', () => {
+    render(
+      <SearchHeader
+        activeResultCount={3}
+        queryInput=""
+        recentSearches={[]}
+        sortValue="relevance"
+        onApplyRecentSearch={vi.fn()}
+        onApplyExtractedKeywords={vi.fn()}
+        onChangeQuery={vi.fn()}
+        onClearQuery={vi.fn()}
+        onSubmitQuery={vi.fn()}
+        onSortChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('3 results')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/search/SearchHeader.tsx
+++ b/apps/web/src/components/search/SearchHeader.tsx
@@ -13,6 +13,7 @@ type SearchHeaderProps = {
   recentSearches: ResumeSearchRecentItem[]
   sortValue: SearchSortValue
   onApplyRecentSearch: (item: ResumeSearchRecentItem) => void | Promise<void>
+  onApplyExtractedKeywords: (keywords: string[]) => void
   onChangeQuery: (value: string) => void
   onClearQuery: () => void
   onSubmitQuery: (value?: string) => void
@@ -29,6 +30,7 @@ export function SearchHeader({
   recentSearches,
   sortValue,
   onApplyRecentSearch,
+  onApplyExtractedKeywords,
   onChangeQuery,
   onClearQuery,
   onSubmitQuery,
@@ -43,6 +45,7 @@ export function SearchHeader({
           loading={loading}
           recentSearches={recentSearches}
           onApplyRecentSearch={onApplyRecentSearch}
+          onApplyExtractedKeywords={onApplyExtractedKeywords}
           onChange={onChangeQuery}
           onClear={onClearQuery}
           onSubmit={onSubmitQuery}

--- a/apps/web/src/components/search/SearchHeader.tsx
+++ b/apps/web/src/components/search/SearchHeader.tsx
@@ -1,0 +1,81 @@
+import { Badge } from '@/components/ui/badge'
+import { Select } from '@/components/ui/select'
+import { GoogleSearchBar } from '@/components/search/GoogleSearchBar'
+import type { ResumeSearchRecentItem, SearchSortValue } from '@/components/search/search-types'
+
+type SearchHeaderProps = {
+  activeQuery?: string
+  activeResultCount: number
+  jobDescriptionId?: string
+  loading?: boolean
+  location?: string
+  queryInput: string
+  recentSearches: ResumeSearchRecentItem[]
+  sortValue: SearchSortValue
+  onApplyRecentSearch: (item: ResumeSearchRecentItem) => void | Promise<void>
+  onChangeQuery: (value: string) => void
+  onClearQuery: () => void
+  onSubmitQuery: (value?: string) => void
+  onSortChange: (value: SearchSortValue) => void
+}
+
+export function SearchHeader({
+  activeQuery,
+  activeResultCount,
+  jobDescriptionId,
+  loading = false,
+  location,
+  queryInput,
+  recentSearches,
+  sortValue,
+  onApplyRecentSearch,
+  onChangeQuery,
+  onClearQuery,
+  onSubmitQuery,
+  onSortChange,
+}: SearchHeaderProps) {
+  return (
+    <div className="space-y-4">
+      <div className="mx-auto max-w-5xl">
+        <GoogleSearchBar
+          compact
+          value={queryInput}
+          loading={loading}
+          recentSearches={recentSearches}
+          onApplyRecentSearch={onApplyRecentSearch}
+          onChange={onChangeQuery}
+          onClear={onClearQuery}
+          onSubmit={onSubmitQuery}
+        />
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-[1.5rem] border bg-white/80 px-4 py-3 shadow-sm lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0 space-y-2">
+          <div className="text-sm font-medium text-slate-900">
+            {activeResultCount.toLocaleString()} results{activeQuery ? ` for "${activeQuery}"` : ''}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {location ? <Badge variant="outline">{location}</Badge> : null}
+            {jobDescriptionId ? <Badge variant="outline">JD {jobDescriptionId}</Badge> : null}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <span className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+            Sort
+          </span>
+          <Select
+            className="min-w-40"
+            options={[
+              { value: 'relevance', label: 'Relevance' },
+              { value: 'newest', label: 'Newest' },
+              { value: 'experience', label: 'Experience' },
+            ]}
+            value={sortValue}
+            onChange={(event) => onSortChange(event.target.value as SearchSortValue)}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/search/SearchHero.test.tsx
+++ b/apps/web/src/components/search/SearchHero.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SearchHero } from '@/components/search/SearchHero'
+import type { ResumeSearchRecentItem } from '@/components/search/search-types'
+
+vi.mock('@/components/search/GoogleSearchBar', () => ({
+  GoogleSearchBar: ({
+    loading,
+    onSubmit,
+    recentSearches,
+    value,
+  }: {
+    loading?: boolean
+    onSubmit: (value?: string) => void
+    recentSearches: ResumeSearchRecentItem[]
+    value: string
+  }) => (
+    <div>
+      <div>
+        Search Bar {value} {loading ? 'loading' : 'idle'} {recentSearches.length}
+      </div>
+      <button type="button" onClick={() => onSubmit('submitted')}>
+        Submit from hero bar
+      </button>
+    </div>
+  ),
+}))
+
+function buildRecentSearch(overrides: Partial<ResumeSearchRecentItem> = {}): ResumeSearchRecentItem {
+  return {
+    id: 'history-1' as ResumeSearchRecentItem['id'],
+    sessionKey: 'session-1',
+    title: 'Saved search',
+    location: 'Malaysia',
+    keywords: ['Machine Tools', 'Sales'],
+    selectedTags: [],
+    selectedCompanies: [],
+    filters: {},
+    createdAt: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('SearchHero', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the loading state while recent searches are loading', () => {
+    render(
+      <SearchHero
+        queryInput="machine tools"
+        recentSearches={[]}
+        recentSearchesLoading
+        onApplyRecentSearch={vi.fn()}
+        onApplyExtractedKeywords={vi.fn()}
+        onChangeQuery={vi.fn()}
+        onClearQuery={vi.fn()}
+        onSubmitQuery={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Loading recent searches...')).toBeInTheDocument()
+    expect(screen.getByText('Search Bar machine tools idle 0')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when there are no recent searches', () => {
+    render(
+      <SearchHero
+        queryInput=""
+        recentSearches={[]}
+        onApplyRecentSearch={vi.fn()}
+        onApplyExtractedKeywords={vi.fn()}
+        onChangeQuery={vi.fn()}
+        onClearQuery={vi.fn()}
+        onSubmitQuery={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('No saved searches yet. Recent searches will appear here after you start exploring.')).toBeInTheDocument()
+  })
+
+  it('renders recent-search cards and forwards click selection', async () => {
+    const user = userEvent.setup()
+    const onApplyRecentSearch = vi.fn()
+
+    render(
+      <SearchHero
+        queryInput=""
+        recentSearches={[
+          buildRecentSearch(),
+          buildRecentSearch({
+            id: 'history-2' as ResumeSearchRecentItem['id'],
+            title: 'Lathe follow-up',
+            keywords: [],
+            jobDescriptionId: 'lathe-sales',
+          }),
+        ]}
+        onApplyRecentSearch={onApplyRecentSearch}
+        onApplyExtractedKeywords={vi.fn()}
+        onChangeQuery={vi.fn()}
+        onClearQuery={vi.fn()}
+        onSubmitQuery={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /Machine Tools Sales/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Lathe follow-up/i })).toBeInTheDocument()
+    expect(screen.getByText('Malaysia · lathe-sales')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Lathe follow-up/i }))
+
+    expect(onApplyRecentSearch).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'history-2',
+      title: 'Lathe follow-up',
+      jobDescriptionId: 'lathe-sales',
+    }))
+  })
+})

--- a/apps/web/src/components/search/SearchHero.tsx
+++ b/apps/web/src/components/search/SearchHero.tsx
@@ -9,6 +9,7 @@ type SearchHeroProps = {
   recentSearches: ResumeSearchRecentItem[]
   recentSearchesLoading?: boolean
   onApplyRecentSearch: (item: ResumeSearchRecentItem) => void | Promise<void>
+  onApplyExtractedKeywords: (keywords: string[]) => void
   onChangeQuery: (value: string) => void
   onClearQuery: () => void
   onSubmitQuery: (value?: string) => void
@@ -20,6 +21,7 @@ export function SearchHero({
   recentSearches,
   recentSearchesLoading = false,
   onApplyRecentSearch,
+  onApplyExtractedKeywords,
   onChangeQuery,
   onClearQuery,
   onSubmitQuery,
@@ -51,6 +53,7 @@ export function SearchHero({
             loading={loading}
             recentSearches={recentSearches}
             onApplyRecentSearch={onApplyRecentSearch}
+            onApplyExtractedKeywords={onApplyExtractedKeywords}
             onChange={onChangeQuery}
             onClear={onClearQuery}
             onSubmit={onSubmitQuery}

--- a/apps/web/src/components/search/SearchHero.tsx
+++ b/apps/web/src/components/search/SearchHero.tsx
@@ -1,0 +1,100 @@
+import { Clock3, Sparkles } from 'lucide-react'
+import { GoogleSearchBar } from '@/components/search/GoogleSearchBar'
+import { Card, CardContent } from '@/components/ui/card'
+import type { ResumeSearchRecentItem } from '@/components/search/search-types'
+
+type SearchHeroProps = {
+  loading?: boolean
+  queryInput: string
+  recentSearches: ResumeSearchRecentItem[]
+  recentSearchesLoading?: boolean
+  onApplyRecentSearch: (item: ResumeSearchRecentItem) => void | Promise<void>
+  onChangeQuery: (value: string) => void
+  onClearQuery: () => void
+  onSubmitQuery: (value?: string) => void
+}
+
+export function SearchHero({
+  loading = false,
+  queryInput,
+  recentSearches,
+  recentSearchesLoading = false,
+  onApplyRecentSearch,
+  onChangeQuery,
+  onClearQuery,
+  onSubmitQuery,
+}: SearchHeroProps) {
+  return (
+    <section className="relative overflow-hidden rounded-[2rem] border bg-gradient-to-br from-white via-slate-50 to-amber-50 px-6 py-12 shadow-[0_28px_80px_-52px_rgba(15,23,42,0.55)] sm:px-10 sm:py-16">
+      <div className="absolute right-0 top-0 h-40 w-40 rounded-full bg-amber-200/30 blur-3xl" />
+      <div className="absolute bottom-0 left-0 h-40 w-40 rounded-full bg-sky-200/30 blur-3xl" />
+
+      <div className="relative mx-auto flex max-w-4xl flex-col items-center gap-8 text-center">
+        <div className="space-y-4">
+          <div className="inline-flex items-center gap-2 rounded-full border border-amber-200 bg-white/80 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-amber-700">
+            <Sparkles className="h-3.5 w-3.5" />
+            Search-first resume review
+          </div>
+          <div className="space-y-3">
+            <h1 className="text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl">
+              Search resumes like a conversation, not a control panel.
+            </h1>
+            <p className="mx-auto max-w-2xl text-sm text-slate-600 sm:text-base">
+              Start with keywords. Refine with facets. Review the strongest snippets before you open the full profile.
+            </p>
+          </div>
+        </div>
+
+        <div className="w-full max-w-3xl">
+          <GoogleSearchBar
+            value={queryInput}
+            loading={loading}
+            recentSearches={recentSearches}
+            onApplyRecentSearch={onApplyRecentSearch}
+            onChange={onChangeQuery}
+            onClear={onClearQuery}
+            onSubmit={onSubmitQuery}
+          />
+        </div>
+
+        <div className="w-full max-w-3xl text-left">
+          <div className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+            <Clock3 className="h-3.5 w-3.5" />
+            Recent searches
+          </div>
+          {recentSearchesLoading ? (
+            <Card className="rounded-[1.5rem] border-dashed">
+              <CardContent className="p-6 text-sm text-muted-foreground">
+                Loading recent searches...
+              </CardContent>
+            </Card>
+          ) : recentSearches.length === 0 ? (
+            <Card className="rounded-[1.5rem] border-dashed">
+              <CardContent className="p-6 text-sm text-muted-foreground">
+                No saved searches yet. Recent searches will appear here after you start exploring.
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2">
+              {recentSearches.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  className="rounded-[1.5rem] border bg-white/80 px-4 py-4 text-left transition-transform transition-colors hover:-translate-y-0.5 hover:border-slate-300 hover:bg-white"
+                  onClick={() => void onApplyRecentSearch(item)}
+                >
+                  <div className="truncate text-sm font-medium text-slate-900">
+                    {item.keywords.join(' ') || item.title}
+                  </div>
+                  <div className="mt-1 truncate text-xs text-muted-foreground">
+                    {[item.location, item.jobDescriptionId].filter(Boolean).join(' · ') || item.title}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/components/search/SearchResultsList.test.tsx
+++ b/apps/web/src/components/search/SearchResultsList.test.tsx
@@ -5,6 +5,8 @@ import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 
 let virtualRows: Array<{ index: number; start: number }> = [{ index: 0, start: 0 }]
+const observeMock = vi.fn()
+const disconnectMock = vi.fn()
 const virtualizer = {
   getTotalSize: () => 480,
   getVirtualItems: () => virtualRows,
@@ -15,7 +17,13 @@ vi.mock('@tanstack/react-virtual', () => ({
 }))
 
 vi.mock('@/components/search/SnippetCard', () => ({
-  SnippetCard: ({ item }: { item: ResumeSearchResultItem }) => <div>{item.key}</div>,
+  SnippetCard: ({
+    expanded,
+    item,
+  }: {
+    expanded: boolean
+    item: ResumeSearchResultItem
+  }) => <div>{`${item.key}:${expanded ? 'expanded' : 'collapsed'}`}</div>,
 }))
 
 describe('SearchResultsList', () => {
@@ -23,9 +31,19 @@ describe('SearchResultsList', () => {
     virtualRows = [{ index: 0, start: 0 }]
     vi.clearAllMocks()
 
+    observeMock.mockImplementation(() => {})
+    disconnectMock.mockImplementation(() => {})
     vi.stubGlobal('IntersectionObserver', class {
-      observe() {}
-      disconnect() {}
+      constructor(private readonly callback: (entries: Array<{ isIntersecting: boolean }>) => void) {}
+
+      observe(target: Element) {
+        observeMock(target)
+        this.callback([{ isIntersecting: true }])
+      }
+
+      disconnect() {
+        disconnectMock()
+      }
     })
   })
 
@@ -86,7 +104,7 @@ describe('SearchResultsList', () => {
       />
     )
 
-    expect(screen.getByText('resume-0')).toBeInTheDocument()
+    expect(screen.getByText('resume-0:collapsed')).toBeInTheDocument()
 
     virtualRows = [{ index: 1, start: 120 }]
     rerender(
@@ -100,7 +118,44 @@ describe('SearchResultsList', () => {
       />
     )
 
-    expect(screen.getByText('resume-1')).toBeInTheDocument()
-    expect(screen.queryByText('resume-0')).not.toBeInTheDocument()
+    expect(screen.getByText('resume-1:collapsed')).toBeInTheDocument()
+    expect(screen.queryByText('resume-0:collapsed')).not.toBeInTheDocument()
+  })
+
+  it('triggers load more when the sentinel intersects and more results are available', () => {
+    const onLoadMore = vi.fn()
+
+    render(
+      <SearchResultsList
+        expandedIds={new Set()}
+        hasMore
+        items={Array.from({ length: 2 }, (_, index) => createItem(index))}
+        onLoadMore={onLoadMore}
+        onToggleExpanded={vi.fn()}
+      />,
+    )
+
+    expect(observeMock).toHaveBeenCalledTimes(1)
+    expect(onLoadMore).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Scroll for more')).toBeInTheDocument()
+  })
+
+  it('renders the full non-virtualized list when any result is expanded', () => {
+    const items = Array.from({ length: 45 }, (_, index) => createItem(index))
+
+    render(
+      <SearchResultsList
+        expandedIds={new Set(['resume-1'])}
+        hasMore={false}
+        items={items}
+        onLoadMore={vi.fn()}
+        onToggleExpanded={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('resume-0:collapsed')).toBeInTheDocument()
+    expect(screen.getByText('resume-1:expanded')).toBeInTheDocument()
+    expect(screen.getByText('resume-44:collapsed')).toBeInTheDocument()
+    expect(screen.getByText('End of results')).toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/search/SearchResultsList.test.tsx
+++ b/apps/web/src/components/search/SearchResultsList.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SearchResultsList } from '@/components/search/SearchResultsList'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+
+let virtualRows: Array<{ index: number; start: number }> = [{ index: 0, start: 0 }]
+const virtualizer = {
+  getTotalSize: () => 480,
+  getVirtualItems: () => virtualRows,
+}
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useWindowVirtualizer: () => virtualizer,
+}))
+
+vi.mock('@/components/search/SnippetCard', () => ({
+  SnippetCard: ({ item }: { item: ResumeSearchResultItem }) => <div>{item.key}</div>,
+}))
+
+describe('SearchResultsList', () => {
+  beforeEach(() => {
+    virtualRows = [{ index: 0, start: 0 }]
+    vi.clearAllMocks()
+
+    vi.stubGlobal('IntersectionObserver', class {
+      observe() {}
+      disconnect() {}
+    })
+  })
+
+  function createItem(index: number): ResumeSearchResultItem {
+    return {
+      key: `resume-${index}`,
+      identityKey: `identity-${index}`,
+      blocked: false,
+      status: 'new',
+      resume: {
+        resumeId: `resume-${index}` as ConvexResumeItem['resumeId'],
+        externalId: `resume-${index}`,
+        name: `Candidate ${index}`,
+        profileUrl: '',
+        activityStatus: '',
+        age: '',
+        ageNumber: 30,
+        experience: '5 years',
+        education: 'Bachelor',
+        location: 'Kuala Lumpur',
+        extractedAt: new Date().toISOString(),
+        expectedSalary: '',
+        jobIntention: '',
+        selfIntro: '',
+        skills: [],
+        workHistory: [],
+        source: 'seek',
+        crawledAt: Date.now(),
+        tags: [],
+        ingestData: undefined,
+      },
+    }
+  }
+
+  it('renders the empty state when there are no search results', () => {
+    render(
+      <SearchResultsList
+        expandedIds={new Set()}
+        hasMore={false}
+        items={[]}
+        onLoadMore={vi.fn()}
+        onToggleExpanded={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('No resumes matched this search')).toBeInTheDocument()
+  })
+
+  it('recomputes virtual rows on rerender instead of keeping stale memoized rows', () => {
+    const items = Array.from({ length: 45 }, (_, index) => createItem(index))
+    const { rerender } = render(
+      <SearchResultsList
+        expandedIds={new Set()}
+        hasMore={false}
+        items={items}
+        onLoadMore={vi.fn()}
+        onToggleExpanded={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('resume-0')).toBeInTheDocument()
+
+    virtualRows = [{ index: 1, start: 120 }]
+    rerender(
+      <SearchResultsList
+        expandedIds={new Set()}
+        hasMore={false}
+        items={items}
+        loadingMore
+        onLoadMore={vi.fn()}
+        onToggleExpanded={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('resume-1')).toBeInTheDocument()
+    expect(screen.queryByText('resume-0')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/search/SearchResultsList.tsx
+++ b/apps/web/src/components/search/SearchResultsList.tsx
@@ -1,0 +1,141 @@
+import { useWindowVirtualizer } from '@tanstack/react-virtual'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { EmptyState } from '@/components/EmptyState'
+import { SnippetCard } from '@/components/search/SnippetCard'
+import { Skeleton } from '@/components/ui/skeleton'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+
+type SearchResultsListProps = {
+  expandedIds: Set<string>
+  hasMore: boolean
+  items: ResumeSearchResultItem[]
+  loading?: boolean
+  loadingMore?: boolean
+  onLoadMore: () => void
+  onToggleExpanded: (key: string) => void
+}
+
+function SearchResultsSkeleton() {
+  return (
+    <div className="space-y-4">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div key={index} className="rounded-[1.5rem] border bg-white p-5 shadow-sm">
+          <div className="space-y-3">
+            <Skeleton className="h-6 w-1/3" />
+            <Skeleton className="h-4 w-2/5" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function SearchResultsList({
+  expandedIds,
+  hasMore,
+  items,
+  loading = false,
+  loadingMore = false,
+  onLoadMore,
+  onToggleExpanded,
+}: SearchResultsListProps) {
+  const listRef = useRef<HTMLDivElement | null>(null)
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+  const [scrollMargin, setScrollMargin] = useState(0)
+  const shouldVirtualize = items.length > 40 && expandedIds.size === 0
+
+  const rowVirtualizer = useWindowVirtualizer({
+    count: items.length,
+    estimateSize: () => 182,
+    overscan: 6,
+    scrollMargin,
+  })
+
+  useEffect(() => {
+    const updateScrollMargin = () => {
+      setScrollMargin(listRef.current?.offsetTop ?? 0)
+    }
+
+    updateScrollMargin()
+    window.addEventListener('resize', updateScrollMargin)
+    return () => window.removeEventListener('resize', updateScrollMargin)
+  }, [items.length])
+
+  useEffect(() => {
+    if (!hasMore || loadingMore) {
+      return
+    }
+
+    const target = loadMoreRef.current
+    if (!target) {
+      return
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        onLoadMore()
+      }
+    }, { rootMargin: '500px 0px' })
+
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [hasMore, loadingMore, onLoadMore])
+
+  const virtualItems = useMemo(() => rowVirtualizer.getVirtualItems(), [rowVirtualizer])
+
+  if (loading) {
+    return <SearchResultsSkeleton />
+  }
+
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        title="No resumes matched this search"
+        description="Try broader keywords or remove a few facet filters to widen the result set."
+      />
+    )
+  }
+
+  return (
+    <div ref={listRef} className="space-y-4">
+      {shouldVirtualize ? (
+        <div
+          className="relative"
+          style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+        >
+          {virtualItems.map((virtualRow) => {
+            const item = items[virtualRow.index]
+            return (
+              <div
+                key={item.key}
+                className="absolute left-0 top-0 w-full"
+                style={{ transform: `translateY(${virtualRow.start}px)` }}
+              >
+                <SnippetCard
+                  item={item}
+                  expanded={false}
+                  onToggleExpanded={() => onToggleExpanded(item.key)}
+                />
+              </div>
+            )
+          })}
+        </div>
+      ) : (
+        items.map((item) => (
+          <SnippetCard
+            key={item.key}
+            item={item}
+            expanded={expandedIds.has(item.key)}
+            onToggleExpanded={() => onToggleExpanded(item.key)}
+          />
+        ))
+      )}
+
+      <div ref={loadMoreRef} className="py-2 text-center text-sm text-muted-foreground">
+        {loadingMore ? 'Loading more resumes...' : hasMore ? 'Scroll for more' : 'End of results'}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/search/SearchResultsList.tsx
+++ b/apps/web/src/components/search/SearchResultsList.tsx
@@ -1,5 +1,5 @@
 import { useWindowVirtualizer } from '@tanstack/react-virtual'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { EmptyState } from '@/components/EmptyState'
 import { SnippetCard } from '@/components/search/SnippetCard'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -83,7 +83,7 @@ export function SearchResultsList({
     return () => observer.disconnect()
   }, [hasMore, loadingMore, onLoadMore])
 
-  const virtualItems = useMemo(() => rowVirtualizer.getVirtualItems(), [rowVirtualizer])
+  const virtualItems = rowVirtualizer.getVirtualItems()
 
   if (loading) {
     return <SearchResultsSkeleton />

--- a/apps/web/src/components/search/SnippetCard.test.tsx
+++ b/apps/web/src/components/search/SnippetCard.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SnippetCard } from '@/components/search/SnippetCard'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+
+vi.mock('@/components/search/SnippetCardExpanded', () => ({
+  SnippetCardExpanded: ({ item }: { item: ResumeSearchResultItem }) => (
+    <div>Expanded card for {item.resume.name ?? 'Unnamed resume'}</div>
+  ),
+}))
+
+function createResume(index: number, overrides: Partial<ConvexResumeItem> = {}): ConvexResumeItem {
+  return {
+    resumeId: `resume-${index}` as ConvexResumeItem['resumeId'],
+    externalId: `resume-${index}`,
+    name: `Candidate ${index}`,
+    profileUrl: '',
+    activityStatus: '',
+    age: '',
+    ageNumber: 30,
+    experience: '6 years',
+    education: 'Bachelor',
+    location: 'Kuala Lumpur',
+    extractedAt: new Date('2026-03-27T10:00:00.000Z').toISOString(),
+    expectedSalary: '',
+    jobIntention: 'Regional sales coverage',
+    selfIntro: 'Short intro summary',
+    skills: [],
+    workHistory: [
+      {
+        companyName: `Company ${index}`,
+        jobTitle: 'Regional Sales Manager',
+        raw: 'Led machine tools growth across Malaysia.',
+      },
+    ],
+    source: 'seek',
+    crawledAt: Date.now(),
+    tags: [],
+    ingestData: {
+      industryTags: ['Machine Tools', 'Automation', 'Robotics', 'Servo'],
+      synonymHits: [],
+      brandHits: [],
+      companyHits: ['FANUC'],
+      ruleScores: {},
+      experienceLevel: 'senior',
+      computedAt: Date.now(),
+      skillsVersion: 1,
+    },
+    _provenance: [
+      { term: 'CNC', source: 'searchText' },
+      { term: 'Machine Tools', source: 'industryTags' },
+      { term: 'Malaysia', source: 'searchText' },
+      { term: 'Ignored', source: 'searchText' },
+    ],
+    ...overrides,
+  }
+}
+
+function createResult(index: number, overrides: Partial<ResumeSearchResultItem> = {}): ResumeSearchResultItem {
+  const hasScoreOverride = Object.prototype.hasOwnProperty.call(overrides, 'score')
+
+  return {
+    key: overrides.key ?? `resume-${index}`,
+    identityKey: overrides.identityKey ?? `identity-${index}`,
+    blocked: overrides.blocked ?? false,
+    score: hasScoreOverride ? overrides.score : 87.6,
+    status: overrides.status ?? 'new',
+    statusMeta: overrides.statusMeta,
+    resume: overrides.resume ?? createResume(index),
+  }
+}
+
+describe('SnippetCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders headline, score, provenance keywords, and toggles expansion', async () => {
+    const user = userEvent.setup()
+    const onToggleExpanded = vi.fn()
+
+    render(
+      <SnippetCard
+        expanded
+        item={createResult(1)}
+        onToggleExpanded={onToggleExpanded}
+      />
+    )
+
+    expect(screen.getByText('Candidate 1')).toBeInTheDocument()
+    expect(screen.getByText('Regional Sales Manager')).toBeInTheDocument()
+    expect(screen.getByText('Led machine tools growth across Malaysia.')).toBeInTheDocument()
+    expect(screen.getByText('Kuala Lumpur')).toBeInTheDocument()
+    expect(screen.getByText('6 years')).toBeInTheDocument()
+    expect(screen.getByText('senior')).toBeInTheDocument()
+    expect(screen.getByText('88')).toBeInTheDocument()
+    expect(screen.getByText('CNC')).toBeInTheDocument()
+    expect(screen.getByText('Machine Tools')).toBeInTheDocument()
+    expect(screen.getByText('Malaysia')).toBeInTheDocument()
+    expect(screen.queryByText('Ignored')).not.toBeInTheDocument()
+    expect(screen.getByText('Expanded card for Candidate 1')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Collapse/i }))
+
+    expect(onToggleExpanded).toHaveBeenCalled()
+  })
+
+  it('falls back to generic labels and ingest tags when work history and provenance are missing', async () => {
+    const user = userEvent.setup()
+    const onToggleExpanded = vi.fn()
+
+    render(
+      <SnippetCard
+        expanded={false}
+        item={createResult(2, {
+          score: undefined,
+          resume: createResume(2, {
+            name: '',
+            jobIntention: '',
+            selfIntro: '',
+            workHistory: [],
+            location: '',
+            experience: '',
+            ingestData: {
+              industryTags: ['Automation', 'PLC', 'CNC'],
+              synonymHits: [],
+              brandHits: [],
+              companyHits: [],
+              ruleScores: {},
+              experienceLevel: 'mid',
+              computedAt: Date.now(),
+              skillsVersion: 1,
+            },
+            _provenance: undefined,
+          }),
+        })}
+        onToggleExpanded={onToggleExpanded}
+      />
+    )
+
+    expect(screen.getByText('Unnamed resume')).toBeInTheDocument()
+    expect(screen.getByText('Profile overview')).toBeInTheDocument()
+    expect(screen.getByText('Open the card to inspect recent work history and extracted signals.')).toBeInTheDocument()
+    expect(screen.getByText('Automation')).toBeInTheDocument()
+    expect(screen.getByText('PLC')).toBeInTheDocument()
+    expect(screen.getByText('CNC')).toBeInTheDocument()
+    expect(screen.queryByText('Expanded card for Unnamed resume')).not.toBeInTheDocument()
+    expect(screen.queryByText('mid')).toBeInTheDocument()
+    expect(screen.queryByText('88')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Expand/i }))
+
+    expect(onToggleExpanded).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -1,0 +1,95 @@
+import { ChevronDown, ChevronUp, MapPin, Star } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+import { SnippetCardExpanded } from '@/components/search/SnippetCardExpanded'
+
+type SnippetCardProps = {
+  expanded: boolean
+  item: ResumeSearchResultItem
+  onToggleExpanded: () => void
+}
+
+function getPrimaryHeadline(item: ResumeSearchResultItem): string {
+  const latestWorkEntry = item.resume.workHistory?.[0]
+  if (latestWorkEntry?.jobTitle) {
+    return latestWorkEntry.jobTitle
+  }
+
+  return item.resume.jobIntention || 'Profile overview'
+}
+
+function getSnippetText(item: ResumeSearchResultItem): string {
+  const latestWorkEntry = item.resume.workHistory?.[0]
+  if (latestWorkEntry?.raw) {
+    return latestWorkEntry.raw
+  }
+
+  return item.resume.selfIntro || 'Open the card to inspect recent work history and extracted signals.'
+}
+
+export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardProps) {
+  const visibleKeywords = (
+    item.resume._provenance?.map((entry) => entry.term)
+    ?? item.resume.ingestData?.industryTags
+    ?? []
+  ).slice(0, 3)
+
+  return (
+    <Card className="overflow-hidden rounded-[1.5rem] border-slate-200 bg-white shadow-[0_18px_50px_-40px_rgba(15,23,42,0.7)]">
+      <div className="space-y-4 px-5 py-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0 space-y-3">
+            <div className="space-y-1">
+              <div className="truncate text-lg font-semibold text-slate-900">{item.resume.name || 'Unnamed resume'}</div>
+              <div className="truncate text-sm text-slate-600">{getPrimaryHeadline(item)}</div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              {item.resume.location ? (
+                <span className="inline-flex items-center gap-1">
+                  <MapPin className="h-3.5 w-3.5" />
+                  {item.resume.location}
+                </span>
+              ) : null}
+              {item.resume.experience ? <span>{item.resume.experience}</span> : null}
+              {item.resume.ingestData?.experienceLevel ? (
+                <Badge variant="outline" className="capitalize">{item.resume.ingestData.experienceLevel}</Badge>
+              ) : null}
+            </div>
+
+            <p className="line-clamp-2 text-sm leading-6 text-slate-700">
+              {getSnippetText(item)}
+            </p>
+
+            <div className="flex flex-wrap gap-2">
+              {visibleKeywords.map((keyword) => (
+                <Badge key={`${item.key}-${keyword}`} variant="secondary">
+                  {keyword}
+                </Badge>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-3">
+            {typeof item.score === 'number' ? (
+              <div className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-sm font-semibold text-amber-700">
+                <span className="inline-flex items-center gap-1">
+                  <Star className="h-3.5 w-3.5" />
+                  {Math.round(item.score)}
+                </span>
+              </div>
+            ) : null}
+            <Button type="button" variant="outline" className="rounded-full" onClick={onToggleExpanded}>
+              {expanded ? 'Collapse' : 'Expand'}
+              {expanded ? <ChevronUp className="ml-2 h-4 w-4" /> : <ChevronDown className="ml-2 h-4 w-4" />}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {expanded ? <SnippetCardExpanded item={item} /> : null}
+    </Card>
+  )
+}

--- a/apps/web/src/components/search/SnippetCardExpanded.test.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SnippetCardExpanded } from '@/components/search/SnippetCardExpanded'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+
+const {
+  buildWorkHistoryEntryTextMock,
+  sanitizeResumeRecordForSurfaceMock,
+  selectLatestWorkHistoryMock,
+  useResumeFieldUsagePolicyMock,
+} = vi.hoisted(() => ({
+  buildWorkHistoryEntryTextMock: vi.fn(),
+  sanitizeResumeRecordForSurfaceMock: vi.fn(),
+  selectLatestWorkHistoryMock: vi.fn(),
+  useResumeFieldUsagePolicyMock: vi.fn(),
+}))
+
+vi.mock('@trends/shared', () => ({
+  buildWorkHistoryEntryText: (...args: unknown[]) => buildWorkHistoryEntryTextMock(...args),
+  sanitizeResumeRecordForSurface: (...args: unknown[]) => sanitizeResumeRecordForSurfaceMock(...args),
+  selectLatestWorkHistory: (...args: unknown[]) => selectLatestWorkHistoryMock(...args),
+}))
+
+vi.mock('@/contexts/ResumeFieldUsagePolicyContext', () => ({
+  useResumeFieldUsagePolicy: () => useResumeFieldUsagePolicyMock(),
+}))
+
+function createResume(index: number, overrides: Partial<ConvexResumeItem> = {}): ConvexResumeItem {
+  return {
+    resumeId: `resume-${index}` as ConvexResumeItem['resumeId'],
+    externalId: `resume-${index}`,
+    name: `Candidate ${index}`,
+    profileUrl: 'https://example.com/profile',
+    activityStatus: '',
+    age: '',
+    ageNumber: 30,
+    experience: '8 years',
+    education: 'Bachelor',
+    location: 'Malaysia',
+    extractedAt: new Date('2026-03-27T10:00:00.000Z').toISOString(),
+    expectedSalary: '',
+    jobIntention: 'Regional sales coverage',
+    selfIntro: 'Strong machine-tools operator with channel sales depth.',
+    skills: [],
+    workHistory: [
+      { companyName: 'FANUC', jobTitle: 'Sales Engineer', raw: 'Built CNC pipeline' },
+      { companyName: 'DMG MORI', jobTitle: 'Account Manager', raw: 'Expanded distributor network' },
+    ],
+    source: 'seek',
+    crawledAt: Date.now(),
+    tags: [],
+    ingestData: {
+      industryTags: ['Machine Tools', 'Automation', 'Robotics'],
+      synonymHits: [],
+      brandHits: [],
+      companyHits: ['FANUC', 'DMG MORI'],
+      ruleScores: {},
+      experienceLevel: 'senior',
+      computedAt: Date.now(),
+      skillsVersion: 1,
+    },
+    ...overrides,
+  }
+}
+
+function createResult(index: number, overrides: Partial<ResumeSearchResultItem> = {}): ResumeSearchResultItem {
+  return {
+    key: overrides.key ?? `resume-${index}`,
+    identityKey: overrides.identityKey ?? `identity-${index}`,
+    blocked: overrides.blocked ?? false,
+    score: overrides.score ?? 90,
+    status: overrides.status ?? 'interviewed_reject',
+    statusMeta: overrides.statusMeta,
+    resume: overrides.resume ?? createResume(index),
+  }
+}
+
+describe('SnippetCardExpanded', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useResumeFieldUsagePolicyMock.mockReturnValue({})
+    sanitizeResumeRecordForSurfaceMock.mockImplementation((resume: ConvexResumeItem) => resume)
+    selectLatestWorkHistoryMock.mockImplementation((workHistory: ConvexResumeItem['workHistory']) => workHistory ?? [])
+    buildWorkHistoryEntryTextMock.mockImplementation((entry: { companyName?: string; jobTitle?: string }) =>
+      [entry.jobTitle, entry.companyName].filter(Boolean).join(' @ ')
+    )
+  })
+
+  it('renders snapshot, metadata, signals, and a safe source-profile link', () => {
+    render(<SnippetCardExpanded item={createResult(1)} />)
+
+    expect(screen.getByText('Snapshot')).toBeInTheDocument()
+    expect(screen.getByText('Strong machine-tools operator with channel sales depth.')).toBeInTheDocument()
+    expect(screen.getByText('Recent work')).toBeInTheDocument()
+    expect(screen.getByText('Sales Engineer @ FANUC')).toBeInTheDocument()
+    expect(screen.getByText('Account Manager @ DMG MORI')).toBeInTheDocument()
+    expect(screen.getByText('Malaysia')).toBeInTheDocument()
+    expect(screen.getByText('Bachelor')).toBeInTheDocument()
+    expect(screen.getByText('Status: interviewed reject')).toBeInTheDocument()
+    expect(screen.getByText('Machine Tools')).toBeInTheDocument()
+    expect(screen.getByText('Automation')).toBeInTheDocument()
+    expect(screen.getByText('Robotics')).toBeInTheDocument()
+    expect(screen.getByText('FANUC')).toBeInTheDocument()
+    expect(screen.getByText('DMG MORI')).toBeInTheDocument()
+    expect(screen.getByText('senior')).toBeInTheDocument()
+
+    const link = screen.getByRole('link', { name: /Open source profile/i })
+    expect(link).toHaveAttribute('href', 'https://example.com/profile')
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+
+  it('falls back when summary, work history, metadata, and profile URL are missing', () => {
+    render(
+      <SnippetCardExpanded
+        item={createResult(2, {
+          status: 'new',
+          resume: createResume(2, {
+            profileUrl: 'javascript:alert(1)',
+            location: '',
+            education: '',
+            selfIntro: '',
+            jobIntention: '',
+            workHistory: [],
+            ingestData: {
+              industryTags: [],
+              synonymHits: [],
+              brandHits: [],
+              companyHits: [],
+              ruleScores: {},
+              experienceLevel: '',
+              computedAt: Date.now(),
+              skillsVersion: 1,
+            },
+          }),
+        })}
+      />
+    )
+
+    expect(screen.getByText('No summary available for this resume yet.')).toBeInTheDocument()
+    expect(screen.getByText('No structured work history available.')).toBeInTheDocument()
+    expect(screen.getByText('No location')).toBeInTheDocument()
+    expect(screen.getByText('No education listed')).toBeInTheDocument()
+    expect(screen.getByText('Status: new')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /Open source profile/i })).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/search/SnippetCardExpanded.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.tsx
@@ -1,0 +1,120 @@
+import { buildWorkHistoryEntryText, sanitizeResumeRecordForSurface, selectLatestWorkHistory } from '@trends/shared'
+import { BriefcaseBusiness, ExternalLink, MapPin, School, Sparkles } from 'lucide-react'
+import { useMemo } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { buttonVariants } from '@/components/ui/button'
+import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
+import { cn } from '@/lib/utils'
+import { isSafeProfileUrl } from '@/lib/resume-scoring'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+
+type SnippetCardExpandedProps = {
+  item: ResumeSearchResultItem
+}
+
+function formatStatusLabel(value: string): string {
+  return value.replace(/_/g, ' ')
+}
+
+export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
+  const fieldUsagePolicy = useResumeFieldUsagePolicy()
+  const presentationResume = useMemo(
+    () => sanitizeResumeRecordForSurface(item.resume, 'presentation', fieldUsagePolicy),
+    [fieldUsagePolicy, item.resume]
+  )
+  const workHistory = useMemo(
+    () => selectLatestWorkHistory(presentationResume.workHistory)
+      .map((entry) => buildWorkHistoryEntryText(entry))
+      .filter((entry) => entry.length > 0)
+      .slice(0, 4),
+    [presentationResume.workHistory]
+  )
+  const profileUrl = item.resume.profileUrl?.trim()
+  const hasProfileUrl = isSafeProfileUrl(profileUrl)
+
+  return (
+    <div className="border-t bg-slate-50/70 px-5 py-5">
+      <div className="grid gap-4 lg:grid-cols-[1.3fr,0.9fr]">
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <div className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Snapshot
+            </div>
+            <p className="text-sm leading-6 text-slate-700">
+              {presentationResume.selfIntro?.trim() || presentationResume.jobIntention?.trim() || 'No summary available for this resume yet.'}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              <BriefcaseBusiness className="h-3.5 w-3.5" />
+              Recent work
+            </div>
+            <div className="space-y-2">
+              {workHistory.length > 0 ? workHistory.map((entry) => (
+                <div key={entry} className="rounded-2xl border bg-white px-3 py-2 text-sm text-slate-700">
+                  {entry}
+                </div>
+              )) : (
+                <div className="rounded-2xl border border-dashed bg-white px-3 py-3 text-sm text-muted-foreground">
+                  No structured work history available.
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="rounded-3xl border bg-white p-4">
+            <div className="mb-3 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Resume metadata
+            </div>
+            <div className="space-y-3 text-sm text-slate-700">
+              <div className="flex items-start gap-2">
+                <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                <span>{presentationResume.location || 'No location'}</span>
+              </div>
+              <div className="flex items-start gap-2">
+                <School className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                <span>{presentationResume.education || 'No education listed'}</span>
+              </div>
+              <div className="flex items-start gap-2">
+                <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                <span>Status: {formatStatusLabel(item.status)}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border bg-white p-4">
+            <div className="mb-3 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Signals
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {(item.resume.ingestData?.industryTags ?? []).slice(0, 8).map((tag) => (
+                <Badge key={tag} variant="secondary">{tag}</Badge>
+              ))}
+              {(item.resume.ingestData?.companyHits ?? []).slice(0, 5).map((company) => (
+                <Badge key={company} variant="outline">{company}</Badge>
+              ))}
+              {item.resume.ingestData?.experienceLevel ? (
+                <Badge variant="outline" className="capitalize">{item.resume.ingestData.experienceLevel}</Badge>
+              ) : null}
+            </div>
+          </div>
+
+          {hasProfileUrl ? (
+            <a
+              href={profileUrl}
+              target="_blank"
+              rel="noreferrer"
+              className={cn(buttonVariants({ variant: 'outline' }), 'w-full justify-center rounded-full')}
+            >
+              Open source profile
+              <ExternalLink className="ml-2 h-4 w-4" />
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/search/search-types.ts
+++ b/apps/web/src/components/search/search-types.ts
@@ -8,9 +8,11 @@ export type SearchSortValue = 'relevance' | 'newest' | 'experience'
 export type FacetValueCount = {
   value: string
   count: number
+  label?: string
 }
 
 export type FacetCounts = {
+  clusters: FacetValueCount[]
   tags: FacetValueCount[]
   companies: FacetValueCount[]
   experienceLevels: FacetValueCount[]

--- a/apps/web/src/components/search/search-types.ts
+++ b/apps/web/src/components/search/search-types.ts
@@ -1,0 +1,32 @@
+import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+import type { SearchHistoryItem } from '@/hooks/useSession'
+import type { CandidateStatus } from '@/types/resume'
+import type { CandidateStatusRecord } from '@/hooks/useCandidateStatus'
+
+export type SearchSortValue = 'relevance' | 'newest' | 'experience'
+
+export type FacetValueCount = {
+  value: string
+  count: number
+}
+
+export type FacetCounts = {
+  tags: FacetValueCount[]
+  companies: FacetValueCount[]
+  experienceLevels: FacetValueCount[]
+  education: FacetValueCount[]
+  statuses: FacetValueCount[]
+  minScoreOptions: FacetValueCount[]
+}
+
+export type ResumeSearchResultItem = {
+  key: string
+  identityKey: string
+  resume: ConvexResumeItem
+  blocked: boolean
+  score?: number
+  status: CandidateStatus
+  statusMeta?: CandidateStatusRecord
+}
+
+export type ResumeSearchRecentItem = SearchHistoryItem

--- a/apps/web/src/hooks/useAiSearchSummary.test.tsx
+++ b/apps/web/src/hooks/useAiSearchSummary.test.tsx
@@ -1,0 +1,309 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAiSearchSummary } from '@/hooks/useAiSearchSummary'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+
+const { postMock } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+}))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: {
+    POST: (...args: unknown[]) => postMock(...args),
+  },
+}))
+
+function createResume(index: number, overrides: Partial<ConvexResumeItem> = {}): ConvexResumeItem {
+  return {
+    resumeId: `resume-${index}` as ConvexResumeItem['resumeId'],
+    externalId: `resume-${index}`,
+    name: `Candidate ${index}`,
+    profileUrl: '',
+    activityStatus: '',
+    age: '',
+    ageNumber: 30,
+    experience: '5 years',
+    education: 'Bachelor',
+    location: 'Malaysia',
+    extractedAt: new Date('2026-03-27T10:00:00.000Z').toISOString(),
+    expectedSalary: '',
+    jobIntention: `Job intention ${index}`,
+    selfIntro: `Self intro ${index}`,
+    skills: [],
+    workHistory: [
+      {
+        companyName: `Company ${index}`,
+        jobTitle: `Sales title ${index}`,
+        raw: `Work history raw ${index}`,
+      },
+    ],
+    source: 'seek',
+    crawledAt: Date.now(),
+    tags: [],
+    ingestData: {
+      industryTags: ['Machine Tools', 'CNC', 'Automation'],
+      synonymHits: [],
+      brandHits: [],
+      companyHits: [`Company ${index}`],
+      ruleScores: {},
+      experienceLevel: 'senior',
+      computedAt: Date.now(),
+      skillsVersion: 1,
+    },
+    ...overrides,
+  }
+}
+
+function createResult(index: number, overrides: Partial<ResumeSearchResultItem> = {}): ResumeSearchResultItem {
+  return {
+    key: overrides.key ?? `resume-${index}`,
+    identityKey: overrides.identityKey ?? `identity-${index}`,
+    blocked: overrides.blocked ?? false,
+    score: overrides.score ?? 80 + index,
+    status: overrides.status ?? 'new',
+    statusMeta: overrides.statusMeta,
+    resume: overrides.resume ?? createResume(index),
+  }
+}
+
+async function advanceDebounceWindow(milliseconds = 2000) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(milliseconds)
+  })
+}
+
+describe('useAiSearchSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not request a summary when the query is blank or there are no results', async () => {
+    const { rerender, result } = renderHook(
+      (props: Parameters<typeof useAiSearchSummary>[0]) => useAiSearchSummary(props),
+      {
+        initialProps: {
+          query: '   ',
+          results: [createResult(1)],
+          selectedCompanies: [],
+          selectedTags: [],
+        },
+      }
+    )
+
+    await advanceDebounceWindow(2500)
+
+    expect(postMock).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(false)
+    expect(result.current.summary).toBeUndefined()
+    expect(result.current.generatedAt).toBeUndefined()
+
+    rerender({
+      query: 'machine tools',
+      results: [],
+      selectedCompanies: [],
+      selectedTags: [],
+    })
+
+    await advanceDebounceWindow(2500)
+
+    expect(postMock).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('debounces for 2 seconds and posts the canonical summary payload for the top 20 results', async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        success: true,
+        summary: 'Strong machine-tools sales bench across Malaysia.',
+        generatedAt: 1710000000000,
+      },
+    })
+
+    const results = Array.from({ length: 22 }, (_, index) => createResult(index + 1))
+    results[0] = createResult(1, {
+      score: 96,
+      resume: createResume(1, {
+        name: 'Ada Tan',
+        location: 'Kuala Lumpur',
+        jobIntention: 'Regional sales leader',
+        selfIntro: 'Led CNC and machine tools sales across Malaysia.',
+        workHistory: [
+          {
+            companyName: 'FANUC',
+            jobTitle: 'Regional Sales Manager',
+            raw: 'Closed multimillion machine tools deals.',
+          },
+        ],
+        ingestData: {
+          industryTags: ['Machine Tools', 'CNC', 'FANUC', 'Automation', 'Sales', 'Robotics', 'Service'],
+          synonymHits: [],
+          brandHits: [],
+          companyHits: ['FANUC'],
+          ruleScores: {},
+          experienceLevel: 'senior',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+        },
+      }),
+    })
+    results[1] = createResult(2, {
+      score: 91,
+      resume: createResume(2, {
+        name: 'Ben Lee',
+        selfIntro: '',
+        jobIntention: 'Account management',
+        workHistory: [
+          {
+            companyName: 'DMG MORI',
+            jobTitle: 'Sales Engineer',
+            raw: 'Built CNC sales pipeline across Johor.',
+          },
+        ],
+      }),
+    })
+    results[2] = createResult(3, {
+      score: 88,
+      resume: createResume(3, {
+        name: 'Cara Ong',
+        selfIntro: '',
+        jobIntention: 'Regional sales coverage',
+        workHistory: [],
+      }),
+    })
+
+    const { result } = renderHook(() => useAiSearchSummary({
+      query: '   machine tools sales   ',
+      location: 'Malaysia',
+      jobDescriptionId: 'jd-machine-tools',
+      results,
+      selectedTags: ['cluster:manufacturing-systems', 'Machine Tools'],
+      selectedCompanies: ['FANUC', 'DMG MORI'],
+      selectedExperienceLevel: 'senior',
+    }))
+
+    await advanceDebounceWindow(1999)
+    expect(postMock).not.toHaveBeenCalled()
+
+    await advanceDebounceWindow(1)
+
+    expect(postMock).toHaveBeenCalledTimes(1)
+    expect(postMock).toHaveBeenCalledWith('/api/resumes/search-summary', {
+      body: expect.objectContaining({
+        query: 'machine tools sales',
+        location: 'Malaysia',
+        jobDescriptionId: 'jd-machine-tools',
+        resultCount: 22,
+        facets: {
+          selectedTags: ['cluster:manufacturing-systems', 'Machine Tools'],
+          selectedCompanies: ['FANUC', 'DMG MORI'],
+          selectedExperienceLevel: 'senior',
+        },
+        forceRefresh: false,
+      }),
+    })
+
+    const requestBody = postMock.mock.calls[0]?.[1]?.body as {
+      resultSetHash: string
+      results: Array<{
+        id: string
+        keywords: string[]
+        location?: string
+        name: string
+        score?: number
+        snippet: string
+        title?: string
+      }>
+      urlHash: string
+    }
+
+    expect(requestBody.results).toHaveLength(20)
+    expect(requestBody.results.map((entry) => entry.id)).toEqual(
+      Array.from({ length: 20 }, (_, index) => `resume-${index + 1}`)
+    )
+    expect(requestBody.results[0]).toEqual({
+      id: 'resume-1',
+      name: 'Ada Tan',
+      title: 'Regional Sales Manager',
+      location: 'Kuala Lumpur',
+      score: 96,
+      keywords: ['Machine Tools', 'CNC', 'FANUC', 'Automation', 'Sales', 'Robotics'],
+      snippet: 'Led CNC and machine tools sales across Malaysia.',
+    })
+    expect(requestBody.results[1]?.snippet).toBe('Built CNC sales pipeline across Johor.')
+    expect(requestBody.results[2]?.snippet).toBe('Regional sales coverage')
+    expect(requestBody.urlHash).toMatch(/^[0-9a-f]+$/)
+    expect(requestBody.resultSetHash).toMatch(/^[0-9a-f]+$/)
+    expect(result.current.summary).toBe('Strong machine-tools sales bench across Malaysia.')
+    expect(result.current.generatedAt).toBe(1710000000000)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('fires a background force refresh when the cached summary response is marked stale', async () => {
+    postMock
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          summary: 'Cached summary',
+          generatedAt: 1710000000000,
+          shouldRefresh: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          summary: 'Fresh summary',
+          generatedAt: 1710000300000,
+        },
+      })
+
+    const { result } = renderHook(() => useAiSearchSummary({
+      query: 'machine tools',
+      results: [createResult(1)],
+      selectedCompanies: ['FANUC'],
+      selectedTags: ['Machine Tools'],
+    }))
+
+    await advanceDebounceWindow()
+
+    expect(postMock).toHaveBeenCalledTimes(2)
+    expect(postMock.mock.calls[0]?.[1]).toEqual({
+      body: expect.objectContaining({
+        forceRefresh: false,
+      }),
+    })
+    expect(postMock.mock.calls[1]?.[1]).toEqual({
+      body: expect.objectContaining({
+        forceRefresh: true,
+      }),
+    })
+    expect(result.current.summary).toBe('Fresh summary')
+    expect(result.current.generatedAt).toBe(1710000300000)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('clears loading if the first summary request fails', async () => {
+    postMock.mockResolvedValueOnce({
+      error: new Error('network failed'),
+    })
+
+    const { result } = renderHook(() => useAiSearchSummary({
+      query: 'machine tools',
+      results: [createResult(1)],
+      selectedCompanies: [],
+      selectedTags: [],
+    }))
+
+    await advanceDebounceWindow()
+
+    expect(postMock).toHaveBeenCalledTimes(1)
+    expect(result.current.loading).toBe(false)
+    expect(result.current.summary).toBeUndefined()
+    expect(result.current.generatedAt).toBeUndefined()
+  })
+})

--- a/apps/web/src/hooks/useAiSearchSummary.ts
+++ b/apps/web/src/hooks/useAiSearchSummary.ts
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useState } from 'react'
+import { rawApiClient } from '@/lib/api-helpers'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+
+type UseAiSearchSummaryArgs = {
+  jobDescriptionId?: string
+  location?: string
+  query?: string
+  results: ResumeSearchResultItem[]
+  selectedCompanies: string[]
+  selectedExperienceLevel?: string
+  selectedTags: string[]
+}
+
+type SearchSummaryResponse = {
+  success: boolean
+  generatedAt?: number
+  model?: string
+  shouldRefresh?: boolean
+  summary?: string
+}
+
+type SearchSummaryCandidate = {
+  id: string
+  keywords: string[]
+  location?: string
+  name: string
+  score?: number
+  snippet: string
+  title?: string
+}
+
+function hashString(value: string): string {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return Math.abs(hash >>> 0).toString(16)
+}
+
+function buildSnippet(item: ResumeSearchResultItem): string {
+  return item.resume.selfIntro?.trim()
+    || item.resume.workHistory?.[0]?.raw?.trim()
+    || item.resume.jobIntention?.trim()
+    || ''
+}
+
+export function useAiSearchSummary({
+  jobDescriptionId,
+  location,
+  query,
+  results,
+  selectedCompanies,
+  selectedExperienceLevel,
+  selectedTags,
+}: UseAiSearchSummaryArgs) {
+  const [summary, setSummary] = useState<string | undefined>(undefined)
+  const [generatedAt, setGeneratedAt] = useState<number | undefined>(undefined)
+  const [loading, setLoading] = useState(false)
+
+  const payload = useMemo(() => {
+    const normalizedQuery = query?.trim()
+    if (!normalizedQuery || results.length === 0) {
+      return null
+    }
+
+    const candidates: SearchSummaryCandidate[] = results.slice(0, 20).map((item) => ({
+      id: String(item.resume.resumeId),
+      name: item.resume.name || 'Unnamed resume',
+      title: item.resume.workHistory?.[0]?.jobTitle || item.resume.jobIntention,
+      location: item.resume.location,
+      score: item.score,
+      keywords: item.resume.ingestData?.industryTags?.slice(0, 6) ?? [],
+      snippet: buildSnippet(item),
+    }))
+
+    const payloadValue = {
+      query: normalizedQuery,
+      location,
+      jobDescriptionId,
+      facets: {
+        selectedTags,
+        selectedCompanies,
+        selectedExperienceLevel,
+      },
+      resultCount: results.length,
+      resultSetHash: hashString(candidates.map((item) => item.id).join('|')),
+      urlHash: hashString(JSON.stringify({
+        query: normalizedQuery,
+        location,
+        jobDescriptionId,
+        selectedTags,
+        selectedCompanies,
+        selectedExperienceLevel,
+      })),
+      results: candidates,
+    }
+
+    return payloadValue
+  }, [jobDescriptionId, location, query, results, selectedCompanies, selectedExperienceLevel, selectedTags])
+
+  useEffect(() => {
+    let active = true
+
+    if (!payload) {
+      setLoading(false)
+      setSummary(undefined)
+      setGeneratedAt(undefined)
+      return () => {
+        active = false
+      }
+    }
+
+    const requestSummary = async (forceRefresh: boolean) => {
+      const { data, error } = await rawApiClient.POST<SearchSummaryResponse>('/api/resumes/search-summary', {
+        body: {
+          ...payload,
+          forceRefresh,
+        },
+      })
+
+      if (!active || error || !data?.success) {
+        if (active && forceRefresh === false) {
+          setLoading(false)
+        }
+        return
+      }
+
+      setSummary(data.summary)
+      setGeneratedAt(data.generatedAt)
+      setLoading(false)
+
+      if (data.shouldRefresh && !forceRefresh) {
+        void requestSummary(true)
+      }
+    }
+
+    const timer = window.setTimeout(() => {
+      setLoading(true)
+      void requestSummary(false)
+    }, 2000)
+
+    return () => {
+      active = false
+      window.clearTimeout(timer)
+    }
+  }, [payload])
+
+  return {
+    generatedAt,
+    loading,
+    summary,
+  }
+}

--- a/apps/web/src/hooks/useConvexResumes.test.ts
+++ b/apps/web/src/hooks/useConvexResumes.test.ts
@@ -2,8 +2,21 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useConvexResumes } from './useConvexResumes'
 
+type KeywordExpansionResponse = {
+  data?: {
+    success: boolean
+    summary?: {
+      groups?: Array<{ original: string; variants: string[] }>
+      mode?: 'AND' | 'OR'
+      expandedTo?: string[]
+      sourceMapping?: Record<string, string>
+    }
+  }
+  error?: Error
+}
+
 const loadMoreMock = vi.fn()
-const rawApiGetMock = vi.fn(async (path?: unknown, options?: unknown) => {
+const rawApiGetMock = vi.fn(async (path?: unknown, options?: unknown): Promise<KeywordExpansionResponse> => {
   void path
   void options
   return {
@@ -223,6 +236,43 @@ describe('useConvexResumes', () => {
     })
   })
 
+  it('falls back to local keyword expansion when the expansion request fails', async () => {
+    rawApiGetMock.mockResolvedValueOnce({
+      error: new Error('network failed'),
+    })
+    usePaginatedQueryMock.mockImplementation((_query, args) => ({
+      results: args === 'skip' ? [] : [buildSearchEntry('resume-1', 'Alice')],
+      status: 'Exhausted',
+      isLoading: false,
+      loadMore: loadMoreMock,
+    }))
+
+    const { result } = renderHook(() => useConvexResumes(200, 'CNC Sales'))
+
+    await waitFor(() => {
+      const searchCall = usePaginatedQueryMock.mock.calls.find(([, args]) => args !== 'skip' && 'query' in (args as Record<string, unknown>))
+      expect(searchCall?.[1]).toMatchObject({
+        query: 'CNC Sales',
+        keywordGroups: [
+          { original: 'cnc', variants: ['cnc'] },
+          { original: 'sales', variants: ['sales'] },
+        ],
+        mode: 'AND',
+        sourceMappings: [],
+      })
+    })
+
+    expect(result.current.expansion).toEqual({
+      groups: [
+        { original: 'cnc', variants: ['cnc'] },
+        { original: 'sales', variants: ['sales'] },
+      ],
+      mode: 'AND',
+      expandedTo: ['cnc', 'sales'],
+      sourceMapping: {},
+    })
+  })
+
   it('forwards required keywords to the paginated search query', async () => {
     usePaginatedQueryMock.mockImplementation((_query, args) => ({
       results: args === 'skip' ? [] : [buildSearchEntry('resume-1', 'Alice')],
@@ -378,5 +428,94 @@ describe('useConvexResumes', () => {
         'Third Candidate',
       ])
     })
+  })
+
+  it('merges duplicate provenance while preserving explicit newest sort on exact keyword scans', async () => {
+    rawApiPostMock.mockResolvedValue({
+      data: {
+        success: true,
+        results: [
+          { resumeId: 'resume-best-match', score: 91, recommendation: 'match' },
+          { resumeId: 'resume-lower-match', score: 30, recommendation: 'potential' },
+          { resumeId: 'resume-newest', score: 72, recommendation: 'match' },
+        ],
+      },
+    })
+
+    usePaginatedQueryMock.mockImplementation((_query, args) => {
+      if (args === 'skip') {
+        return {
+          results: [],
+          status: 'Exhausted',
+          isLoading: false,
+          loadMore: loadMoreMock,
+        }
+      }
+
+      if ('query' in (args as Record<string, unknown>)) {
+        return {
+          results: [
+            {
+              resume: buildResumeDoc('resume-best-match', 'Best Match Duplicate', {
+                identityKey: 'identity-1',
+                primaryRuleScore: 60,
+                extractedAt: '2026-03-02T00:00:00.000Z',
+                crawledAt: 1_700_000_000_000,
+              }),
+              provenance: [{ term: 'cnc', source: 'searchText' }],
+            },
+            {
+              resume: buildResumeDoc('resume-lower-match', 'Lower Match Duplicate', {
+                identityKey: 'identity-1',
+                primaryRuleScore: 90,
+                extractedAt: '2026-03-10T00:00:00.000Z',
+                crawledAt: 1_700_000_000_100,
+              }),
+              provenance: [{ term: 'servo', source: 'searchText' }],
+            },
+            {
+              resume: buildResumeDoc('resume-newest', 'Newest Candidate', {
+                identityKey: 'identity-2',
+                primaryRuleScore: 70,
+                extractedAt: '2026-03-15T00:00:00.000Z',
+                crawledAt: 1_700_000_000_200,
+              }),
+              provenance: [{ term: 'automation', source: 'searchText' }],
+            },
+          ],
+          status: 'Exhausted',
+          isLoading: false,
+          loadMore: loadMoreMock,
+        }
+      }
+
+      return {
+        results: [],
+        status: 'Exhausted',
+        isLoading: false,
+        loadMore: loadMoreMock,
+      }
+    })
+
+    const { result } = renderHook(() => useConvexResumes(200, 'CNC servo', 'jd-1', {
+      sortBy: 'extractedAt',
+      sortOrder: 'desc',
+    }))
+
+    await waitFor(() => {
+      expect(rawApiPostMock).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(result.current.resumes.map((resume) => resume.name)).toEqual([
+        'Newest Candidate',
+        'Best Match Duplicate',
+      ])
+    })
+
+    expect(result.current.resumes[1]?._provenance).toEqual([
+      { term: 'cnc', source: 'searchText' },
+      { term: 'servo', source: 'searchText' },
+    ])
   })
 })

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -851,11 +851,13 @@ export function useConvexResumes(
   query?: string,
   jobDescriptionId?: string,
   options?: {
+    enabled?: boolean
     sortBy?: ConvexResumeSortBy
     sortOrder?: 'asc' | 'desc'
     filters?: ConvexResumeFilters
   }
 ) {
+  const enabled = options?.enabled ?? true
   const normalizedJobDescriptionId = jobDescriptionId?.trim() || undefined
   const normalizedQuery = query?.trim() || undefined
   const useExactKeywordScan = Boolean(normalizedQuery && normalizedJobDescriptionId)
@@ -871,6 +873,14 @@ export function useConvexResumes(
 
   useEffect(() => {
     let active = true
+
+    if (!enabled) {
+      setKeywordExpansion(null)
+      setExpansionLoading(false)
+      return () => {
+        active = false
+      }
+    }
 
     if (mockPayload) {
       setKeywordExpansion(mockKeywordExpansion)
@@ -941,13 +951,13 @@ export function useConvexResumes(
     return () => {
       active = false
     }
-  }, [mockKeywordExpansion, mockPayload, normalizedQuery])
+  }, [enabled, mockKeywordExpansion, mockPayload, normalizedQuery])
 
   const paginatedSearchResults = usePaginatedQuery(
     api.resumes.searchWithTagExpansionPaginated,
     mockPayload
       ? 'skip'
-      : !useExactKeywordScan && normalizedQuery && keywordExpansion
+      : enabled && !useExactKeywordScan && normalizedQuery && keywordExpansion
         ? {
             query: normalizedQuery,
             keywordGroups: keywordExpansion.groups,
@@ -973,7 +983,7 @@ export function useConvexResumes(
     api.resumes.searchWithTagExpansionScanPage,
     mockPayload
       ? 'skip'
-      : normalizedQuery && normalizedJobDescriptionId && keywordExpansion
+      : enabled && normalizedQuery && normalizedJobDescriptionId && keywordExpansion
         ? {
             query: normalizedQuery,
             keywordGroups: keywordExpansion.groups,
@@ -994,7 +1004,9 @@ export function useConvexResumes(
     api.resumes.listWithIngestDataPaginated,
     mockPayload
       ? 'skip'
-      : normalizedQuery && !normalizedJobDescriptionId
+      : !enabled
+        ? 'skip'
+        : normalizedQuery && !normalizedJobDescriptionId
         ? 'skip'
         : {
             jobDescriptionId: normalizedJobDescriptionId,
@@ -1033,7 +1045,7 @@ export function useConvexResumes(
   useEffect(() => {
     let active = true
 
-    if (!useExactKeywordScan || !normalizedJobDescriptionId) {
+    if (!enabled || !useExactKeywordScan || !normalizedJobDescriptionId) {
       setExactKeywordMatchMap((current) => (Object.keys(current).length === 0 ? current : {}))
       return () => {
         active = false
@@ -1092,7 +1104,7 @@ export function useConvexResumes(
     return () => {
       active = false
     }
-  }, [exactKeywordMatchScopeKey, exactKeywordResumeIds, normalizedJobDescriptionId, useExactKeywordScan])
+  }, [enabled, exactKeywordMatchScopeKey, exactKeywordResumeIds, normalizedJobDescriptionId, useExactKeywordScan])
 
   const dedupedExactKeywordEntries = useMemo(() => {
     if (mockPayload || !useExactKeywordScan) {
@@ -1209,13 +1221,19 @@ export function useConvexResumes(
     visibleSearchResults,
   ])
 
-  const isLoading = mockPayload
+  const isLoading = !enabled
+    ? false
+    : mockPayload
     ? false
     : normalizedQuery
       ? (expansionLoading || activePaginatedStatus === 'LoadingFirstPage')
       : paginatedListResults.status === 'LoadingFirstPage'
 
   const hasMore = useMemo(() => {
+    if (!enabled) {
+      return false
+    }
+
     if (mockPayload) {
       return normalizedQuery
         ? (mockPayload.search?.results?.length ?? 0) > limit
@@ -1223,17 +1241,18 @@ export function useConvexResumes(
     }
 
     return activePaginatedResultsLength > limit || activePaginatedStatus === 'CanLoadMore' || activePaginatedStatus === 'LoadingMore'
-  }, [activePaginatedResultsLength, activePaginatedStatus, limit, mockPayload, normalizedQuery])
+  }, [activePaginatedResultsLength, activePaginatedStatus, enabled, limit, mockPayload, normalizedQuery])
 
   const resolvedExpansion = mockPayload
     ? (mockPayload.search?.expansion ?? mockKeywordExpansion)
     : keywordExpansion
 
-  const loadingMore = !mockPayload
+  const loadingMore = enabled
+    && !mockPayload
     && activePaginatedStatus === 'LoadingMore'
 
   return {
-    resumes: mappedResumes,
+    resumes: enabled ? mappedResumes : [],
     loading: isLoading,
     loadingMore,
     hasMore,

--- a/apps/web/src/hooks/useFacetCounts.test.ts
+++ b/apps/web/src/hooks/useFacetCounts.test.ts
@@ -182,6 +182,7 @@ describe('useFacetCounts', () => {
   it('limits facet bucket computation to the first 2000 results', () => {
     const manyResults = Array.from({ length: 2001 }, (_, index) => createResult({
       key: `resume-${index + 1}`,
+      score: 95,
       status: 'new',
       resume: createResume({
         resumeId: `resume-${index + 1}` as ConvexResumeItem['resumeId'],
@@ -202,6 +203,7 @@ describe('useFacetCounts', () => {
 
     manyResults[2000] = createResult({
       key: 'resume-over-limit',
+      score: 10,
       status: 'contacted',
       resume: createResume({
         resumeId: 'resume-over-limit' as ConvexResumeItem['resumeId'],
@@ -236,6 +238,12 @@ describe('useFacetCounts', () => {
     ])
     expect(result.current.statuses).toEqual([
       { value: 'new', label: undefined, count: 2000 },
+    ])
+    expect(result.current.minScoreOptions).toEqual([
+      { value: '60', count: 2000 },
+      { value: '70', count: 2000 },
+      { value: '80', count: 2000 },
+      { value: '90', count: 2000 },
     ])
   })
 })

--- a/apps/web/src/hooks/useFacetCounts.test.ts
+++ b/apps/web/src/hooks/useFacetCounts.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { useFacetCounts } from '@/hooks/useFacetCounts'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+import type { TaxonomyClusterInput } from '@/lib/taxonomy'
 
 function createResume(overrides: Partial<ConvexResumeItem>): ConvexResumeItem {
   return {
@@ -53,6 +54,19 @@ function createResult(overrides: Partial<ResumeSearchResultItem>): ResumeSearchR
 
 describe('useFacetCounts', () => {
   it('aggregates facet counts from search results', () => {
+    const taxonomyClusters: TaxonomyClusterInput[] = [
+      {
+        name: 'Manufacturing Systems',
+        slug: 'manufacturing-systems',
+        tags: [],
+      },
+      {
+        name: 'Automation Stack',
+        slug: 'automation-stack',
+        parentSlug: 'manufacturing-systems',
+        tags: ['Machine Tools', 'Automation'],
+      },
+    ]
     const { result } = renderHook(() => useFacetCounts([
       createResult({ key: 'one', score: 85, status: 'new' }),
       createResult({
@@ -77,27 +91,30 @@ describe('useFacetCounts', () => {
           },
         }),
       }),
-    ]))
+    ], taxonomyClusters))
 
+    expect(result.current.clusters).toEqual([
+      { value: 'manufacturing-systems', label: 'Manufacturing Systems', count: 2 },
+    ])
     expect(result.current.tags.slice(0, 2)).toEqual([
-      { value: 'Machine Tools', count: 2 },
-      { value: 'Automation', count: 1 },
+      { value: 'Machine Tools', label: undefined, count: 2 },
+      { value: 'Automation', label: undefined, count: 1 },
     ])
     expect(result.current.companies).toEqual([
-      { value: 'DMG MORI', count: 1 },
-      { value: 'FANUC', count: 1 },
+      { value: 'DMG MORI', label: undefined, count: 1 },
+      { value: 'FANUC', label: undefined, count: 1 },
     ])
     expect(result.current.experienceLevels).toEqual([
-      { value: 'mid', count: 1 },
-      { value: 'senior', count: 1 },
+      { value: 'mid', label: undefined, count: 1 },
+      { value: 'senior', label: undefined, count: 1 },
     ])
     expect(result.current.education).toEqual([
-      { value: 'Bachelor', count: 1 },
-      { value: 'Master', count: 1 },
+      { value: 'Bachelor', label: undefined, count: 1 },
+      { value: 'Master', label: undefined, count: 1 },
     ])
     expect(result.current.statuses).toEqual([
-      { value: 'contacted', count: 1 },
-      { value: 'new', count: 1 },
+      { value: 'contacted', label: undefined, count: 1 },
+      { value: 'new', label: undefined, count: 1 },
     ])
     expect(result.current.minScoreOptions).toEqual([
       { value: '60', count: 2 },

--- a/apps/web/src/hooks/useFacetCounts.test.ts
+++ b/apps/web/src/hooks/useFacetCounts.test.ts
@@ -1,0 +1,109 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useFacetCounts } from '@/hooks/useFacetCounts'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+
+function createResume(overrides: Partial<ConvexResumeItem>): ConvexResumeItem {
+  return {
+    resumeId: 'resume-1' as ConvexResumeItem['resumeId'],
+    externalId: 'resume-1',
+    name: 'Candidate',
+    profileUrl: '',
+    activityStatus: '',
+    age: '',
+    ageNumber: 30,
+    experience: '5 years',
+    education: 'Bachelor',
+    location: 'Kuala Lumpur',
+    extractedAt: new Date().toISOString(),
+    expectedSalary: '',
+    jobIntention: '',
+    selfIntro: '',
+    skills: [],
+    workHistory: [],
+    source: 'seek',
+    crawledAt: Date.now(),
+    tags: [],
+    ingestData: {
+      industryTags: ['CNC', 'Machine Tools'],
+      synonymHits: [],
+      brandHits: [],
+      companyHits: ['FANUC'],
+      ruleScores: {},
+      experienceLevel: 'mid',
+      computedAt: Date.now(),
+      skillsVersion: 1,
+    },
+    ...overrides,
+  }
+}
+
+function createResult(overrides: Partial<ResumeSearchResultItem>): ResumeSearchResultItem {
+  return {
+    key: overrides.key ?? 'resume-1',
+    identityKey: overrides.identityKey ?? overrides.key ?? 'resume-1',
+    blocked: overrides.blocked ?? false,
+    score: overrides.score ?? 78,
+    status: overrides.status ?? 'new',
+    statusMeta: overrides.statusMeta,
+    resume: overrides.resume ?? createResume({}),
+  }
+}
+
+describe('useFacetCounts', () => {
+  it('aggregates facet counts from search results', () => {
+    const { result } = renderHook(() => useFacetCounts([
+      createResult({ key: 'one', score: 85, status: 'new' }),
+      createResult({
+        key: 'two',
+        score: 65,
+        status: 'contacted',
+        resume: createResume({
+          resumeId: 'resume-2' as ConvexResumeItem['resumeId'],
+          externalId: 'resume-2',
+          name: 'Candidate Two',
+          experience: '8 years',
+          education: 'Master',
+          ingestData: {
+            industryTags: ['Machine Tools', 'Automation'],
+            synonymHits: [],
+            brandHits: [],
+            companyHits: ['DMG MORI'],
+            ruleScores: {},
+            experienceLevel: 'senior',
+            computedAt: Date.now(),
+            skillsVersion: 1,
+          },
+        }),
+      }),
+    ]))
+
+    expect(result.current.tags.slice(0, 2)).toEqual([
+      { value: 'Machine Tools', count: 2 },
+      { value: 'Automation', count: 1 },
+    ])
+    expect(result.current.companies).toEqual([
+      { value: 'DMG MORI', count: 1 },
+      { value: 'FANUC', count: 1 },
+    ])
+    expect(result.current.experienceLevels).toEqual([
+      { value: 'mid', count: 1 },
+      { value: 'senior', count: 1 },
+    ])
+    expect(result.current.education).toEqual([
+      { value: 'Bachelor', count: 1 },
+      { value: 'Master', count: 1 },
+    ])
+    expect(result.current.statuses).toEqual([
+      { value: 'contacted', count: 1 },
+      { value: 'new', count: 1 },
+    ])
+    expect(result.current.minScoreOptions).toEqual([
+      { value: '60', count: 2 },
+      { value: '70', count: 1 },
+      { value: '80', count: 1 },
+      { value: '90', count: 0 },
+    ])
+  })
+})

--- a/apps/web/src/hooks/useFacetCounts.test.ts
+++ b/apps/web/src/hooks/useFacetCounts.test.ts
@@ -123,4 +123,119 @@ describe('useFacetCounts', () => {
       { value: '90', count: 0 },
     ])
   })
+
+  it('counts a parent taxonomy cluster at most once per resume even when multiple child tags match it', () => {
+    const taxonomyClusters: TaxonomyClusterInput[] = [
+      {
+        name: 'Manufacturing Systems',
+        slug: 'manufacturing-systems',
+        tags: [],
+      },
+      {
+        name: 'Automation Stack',
+        slug: 'automation-stack',
+        parentSlug: 'manufacturing-systems',
+        tags: ['Machine Tools', 'Automation'],
+      },
+    ]
+
+    const { result } = renderHook(() => useFacetCounts([
+      createResult({
+        key: 'one',
+        resume: createResume({
+          ingestData: {
+            industryTags: ['Machine Tools', 'Automation'],
+            synonymHits: [],
+            brandHits: [],
+            companyHits: ['FANUC'],
+            ruleScores: {},
+            experienceLevel: 'mid',
+            computedAt: Date.now(),
+            skillsVersion: 1,
+          },
+        }),
+      }),
+      createResult({
+        key: 'two',
+        resume: createResume({
+          resumeId: 'resume-2' as ConvexResumeItem['resumeId'],
+          externalId: 'resume-2',
+          ingestData: {
+            industryTags: ['Automation'],
+            synonymHits: [],
+            brandHits: [],
+            companyHits: ['DMG MORI'],
+            ruleScores: {},
+            experienceLevel: 'senior',
+            computedAt: Date.now(),
+            skillsVersion: 1,
+          },
+        }),
+      }),
+    ], taxonomyClusters))
+
+    expect(result.current.clusters).toEqual([
+      { value: 'manufacturing-systems', label: 'Manufacturing Systems', count: 2 },
+    ])
+  })
+
+  it('limits facet bucket computation to the first 2000 results', () => {
+    const manyResults = Array.from({ length: 2001 }, (_, index) => createResult({
+      key: `resume-${index + 1}`,
+      status: 'new',
+      resume: createResume({
+        resumeId: `resume-${index + 1}` as ConvexResumeItem['resumeId'],
+        externalId: `resume-${index + 1}`,
+        education: 'Bachelor',
+        ingestData: {
+          industryTags: ['Machine Tools'],
+          synonymHits: [],
+          brandHits: [],
+          companyHits: ['FANUC'],
+          ruleScores: {},
+          experienceLevel: 'mid',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+        },
+      }),
+    }))
+
+    manyResults[2000] = createResult({
+      key: 'resume-over-limit',
+      status: 'contacted',
+      resume: createResume({
+        resumeId: 'resume-over-limit' as ConvexResumeItem['resumeId'],
+        externalId: 'resume-over-limit',
+        education: 'Doctorate',
+        ingestData: {
+          industryTags: ['Robotics'],
+          synonymHits: [],
+          brandHits: [],
+          companyHits: ['DMG MORI'],
+          ruleScores: {},
+          experienceLevel: 'senior',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+        },
+      }),
+    })
+
+    const { result } = renderHook(() => useFacetCounts(manyResults))
+
+    expect(result.current.tags).toEqual([
+      { value: 'Machine Tools', label: undefined, count: 2000 },
+    ])
+    expect(result.current.companies).toEqual([
+      { value: 'FANUC', label: undefined, count: 2000 },
+    ])
+    expect(result.current.experienceLevels).toEqual([
+      { value: 'mid', label: undefined, count: 2000 },
+    ])
+    expect(result.current.education).toEqual([
+      { value: 'Bachelor', label: undefined, count: 2000 },
+    ])
+    expect(result.current.statuses).toEqual([
+      { value: 'new', label: undefined, count: 2000 },
+    ])
+  })
 })

--- a/apps/web/src/hooks/useFacetCounts.ts
+++ b/apps/web/src/hooks/useFacetCounts.ts
@@ -57,6 +57,7 @@ export function useFacetCounts(
   taxonomyClusters?: TaxonomyClusterInput[],
 ): FacetCounts {
   return useMemo(() => {
+    const limitedResults = results.slice(0, 2000)
     const taxonomyResolver = createTaxonomyClusterResolver(taxonomyClusters)
     const clusterCounts = new Map<string, number>()
     const clusterLabels = new Map(
@@ -68,7 +69,7 @@ export function useFacetCounts(
     const educationCounts = new Map<string, number>()
     const statusCounts = new Map<string, number>()
 
-    results.slice(0, 2000).forEach((item) => {
+    limitedResults.forEach((item) => {
       taxonomyResolver.resolveTagClusters(item.resume.ingestData?.industryTags).forEach((cluster) => {
         incrementCount(clusterCounts, cluster.slug)
       })
@@ -81,7 +82,7 @@ export function useFacetCounts(
 
     const minScoreOptions = MIN_SCORE_OPTIONS.map((threshold) => ({
       value: String(threshold),
-      count: results.filter((item) => (item.score ?? 0) >= threshold).length,
+      count: limitedResults.filter((item) => (item.score ?? 0) >= threshold).length,
     }))
 
     return {

--- a/apps/web/src/hooks/useFacetCounts.ts
+++ b/apps/web/src/hooks/useFacetCounts.ts
@@ -1,0 +1,74 @@
+import { useMemo } from 'react'
+import type { FacetCounts, FacetValueCount, ResumeSearchResultItem } from '@/components/search/search-types'
+
+const MIN_SCORE_OPTIONS = [60, 70, 80, 90] as const
+
+function incrementCount(map: Map<string, number>, value: string | undefined) {
+  const normalized = value?.trim()
+  if (!normalized) {
+    return
+  }
+
+  map.set(normalized, (map.get(normalized) ?? 0) + 1)
+}
+
+function incrementMany(map: Map<string, number>, values: string[] | undefined) {
+  if (!values) {
+    return
+  }
+
+  const seen = new Set<string>()
+  values.forEach((value) => {
+    const normalized = value.trim()
+    if (!normalized || seen.has(normalized)) {
+      return
+    }
+
+    seen.add(normalized)
+    incrementCount(map, normalized)
+  })
+}
+
+function toSortedCounts(map: Map<string, number>): FacetValueCount[] {
+  return Array.from(map.entries())
+    .map(([value, count]) => ({ value, count }))
+    .sort((left, right) => {
+      if (right.count !== left.count) {
+        return right.count - left.count
+      }
+
+      return left.value.localeCompare(right.value)
+    })
+}
+
+export function useFacetCounts(results: ResumeSearchResultItem[]): FacetCounts {
+  return useMemo(() => {
+    const tagCounts = new Map<string, number>()
+    const companyCounts = new Map<string, number>()
+    const experienceCounts = new Map<string, number>()
+    const educationCounts = new Map<string, number>()
+    const statusCounts = new Map<string, number>()
+
+    results.slice(0, 2000).forEach((item) => {
+      incrementMany(tagCounts, item.resume.ingestData?.industryTags)
+      incrementMany(companyCounts, item.resume.ingestData?.companyHits)
+      incrementCount(experienceCounts, item.resume.ingestData?.experienceLevel)
+      incrementCount(educationCounts, item.resume.education)
+      incrementCount(statusCounts, item.status)
+    })
+
+    const minScoreOptions = MIN_SCORE_OPTIONS.map((threshold) => ({
+      value: String(threshold),
+      count: results.filter((item) => (item.score ?? 0) >= threshold).length,
+    }))
+
+    return {
+      tags: toSortedCounts(tagCounts),
+      companies: toSortedCounts(companyCounts),
+      experienceLevels: toSortedCounts(experienceCounts),
+      education: toSortedCounts(educationCounts),
+      statuses: toSortedCounts(statusCounts),
+      minScoreOptions,
+    }
+  }, [results])
+}

--- a/apps/web/src/hooks/useFacetCounts.ts
+++ b/apps/web/src/hooks/useFacetCounts.ts
@@ -1,5 +1,9 @@
 import { useMemo } from 'react'
 import type { FacetCounts, FacetValueCount, ResumeSearchResultItem } from '@/components/search/search-types'
+import {
+  createTaxonomyClusterResolver,
+  type TaxonomyClusterInput,
+} from '@/lib/taxonomy'
 
 const MIN_SCORE_OPTIONS = [60, 70, 80, 90] as const
 
@@ -29,20 +33,35 @@ function incrementMany(map: Map<string, number>, values: string[] | undefined) {
   })
 }
 
-function toSortedCounts(map: Map<string, number>): FacetValueCount[] {
+function toSortedCounts(
+  map: Map<string, number>,
+  labelsByValue?: Map<string, string>,
+): FacetValueCount[] {
   return Array.from(map.entries())
-    .map(([value, count]) => ({ value, count }))
+    .map(([value, count]) => ({
+      value,
+      count,
+      label: labelsByValue?.get(value),
+    }))
     .sort((left, right) => {
       if (right.count !== left.count) {
         return right.count - left.count
       }
 
-      return left.value.localeCompare(right.value)
+      return (left.label ?? left.value).localeCompare(right.label ?? right.value)
     })
 }
 
-export function useFacetCounts(results: ResumeSearchResultItem[]): FacetCounts {
+export function useFacetCounts(
+  results: ResumeSearchResultItem[],
+  taxonomyClusters?: TaxonomyClusterInput[],
+): FacetCounts {
   return useMemo(() => {
+    const taxonomyResolver = createTaxonomyClusterResolver(taxonomyClusters)
+    const clusterCounts = new Map<string, number>()
+    const clusterLabels = new Map(
+      taxonomyResolver.clusters.map((cluster) => [cluster.slug, cluster.name]),
+    )
     const tagCounts = new Map<string, number>()
     const companyCounts = new Map<string, number>()
     const experienceCounts = new Map<string, number>()
@@ -50,6 +69,9 @@ export function useFacetCounts(results: ResumeSearchResultItem[]): FacetCounts {
     const statusCounts = new Map<string, number>()
 
     results.slice(0, 2000).forEach((item) => {
+      taxonomyResolver.resolveTagClusters(item.resume.ingestData?.industryTags).forEach((cluster) => {
+        incrementCount(clusterCounts, cluster.slug)
+      })
       incrementMany(tagCounts, item.resume.ingestData?.industryTags)
       incrementMany(companyCounts, item.resume.ingestData?.companyHits)
       incrementCount(experienceCounts, item.resume.ingestData?.experienceLevel)
@@ -63,6 +85,7 @@ export function useFacetCounts(results: ResumeSearchResultItem[]): FacetCounts {
     }))
 
     return {
+      clusters: toSortedCounts(clusterCounts, clusterLabels),
       tags: toSortedCounts(tagCounts),
       companies: toSortedCounts(companyCounts),
       experienceLevels: toSortedCounts(experienceCounts),
@@ -70,5 +93,5 @@ export function useFacetCounts(results: ResumeSearchResultItem[]): FacetCounts {
       statuses: toSortedCounts(statusCounts),
       minScoreOptions,
     }
-  }, [results])
+  }, [results, taxonomyClusters])
 }

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -204,6 +204,7 @@ function normalizeUrlFilters(filters: Partial<ResumeFilters>): Partial<ResumeFil
 function normalizeUrlSearchStateValue(state: Partial<UrlSearchState> | undefined): UrlSearchState {
   return {
     shareSessionId: normalizeOptionalString(state?.shareSessionId),
+    query: normalizeOptionalString(state?.query),
     location: normalizeOptionalString(state?.location),
     keywords: Array.isArray(state?.keywords) ? state.keywords : [],
     requiredKeywords: Array.isArray(state?.requiredKeywords) ? state.requiredKeywords : [],

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -1,0 +1,398 @@
+import { act, renderHook } from '@testing-library/react'
+import { formatKeywordQuery } from '@trends/shared'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useResumeSearchState } from '@/hooks/useResumeSearchState'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+import type { UrlSearchState } from '@/hooks/useUrlSearchState'
+
+vi.mock('../../../../packages/convex/convex/_generated/api', () => ({
+  api: {
+    sessions: {
+      listSearchHistory: 'list-search-history-query',
+      saveSearchHistory: 'save-search-history-mutation',
+      markSearchHistoryOpened: 'mark-search-history-opened-mutation',
+    },
+    taxonomy_clusters: {
+      list: 'taxonomy-clusters-list-query',
+    },
+  },
+}))
+
+const {
+  blocksByIdentityMock,
+  markSearchHistoryOpenedMutationMock,
+  parsedStateMock,
+  resumesMock,
+  saveSearchHistoryMutationMock,
+  searchHistoryRecordsMock,
+  statusByIdentityMock,
+  syncToUrlMock,
+  taxonomyClusterRecordsMock,
+  useFacetCountsMock,
+  useMutationMock,
+  useQueryMock,
+  workspaceMock,
+} = vi.hoisted(() => ({
+  blocksByIdentityMock: {} as Record<string, boolean>,
+  markSearchHistoryOpenedMutationMock: vi.fn(async () => {}),
+  parsedStateMock: {} as UrlSearchState,
+  resumesMock: [] as ConvexResumeItem[],
+  saveSearchHistoryMutationMock: vi.fn(async () => 'history-1'),
+  searchHistoryRecordsMock: [] as Array<Record<string, unknown>>,
+  statusByIdentityMock: {} as Record<string, { status: ResumeSearchResultItem['status'] }>,
+  syncToUrlMock: vi.fn(),
+  taxonomyClusterRecordsMock: [] as Array<Record<string, unknown>>,
+  useFacetCountsMock: vi.fn(),
+  useMutationMock: vi.fn(),
+  useQueryMock: vi.fn(),
+  workspaceMock: {
+    slug: 'dev',
+  },
+}))
+
+vi.mock('convex/react', () => ({
+  useMutation: (...args: unknown[]) => useMutationMock(...args),
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}))
+
+vi.mock('@/contexts/WorkspaceContext', () => ({
+  useWorkspace: () => workspaceMock,
+}))
+
+vi.mock('@/hooks/useUrlSearchState', () => ({
+  useUrlSearchState: () => ({
+    parsedState: parsedStateMock,
+    syncToUrl: syncToUrlMock,
+  }),
+}))
+
+vi.mock('@/hooks/useCandidateStatus', () => ({
+  useCandidateStatus: () => ({
+    statusByIdentity: statusByIdentityMock,
+  }),
+}))
+
+vi.mock('@/hooks/useCandidateBlocks', () => ({
+  useCandidateBlocks: () => ({
+    blocksByIdentity: blocksByIdentityMock,
+  }),
+}))
+
+vi.mock('@/hooks/useConvexResumes', () => ({
+  useConvexResumes: () => ({
+    resumes: resumesMock,
+    hasMore: false,
+    loading: false,
+    loadingMore: false,
+  }),
+}))
+
+vi.mock('@/hooks/useFacetCounts', () => ({
+  useFacetCounts: (...args: unknown[]) => useFacetCountsMock(...args),
+}))
+
+function createParsedState(overrides: Partial<UrlSearchState> = {}): UrlSearchState {
+  return {
+    shareSessionId: undefined,
+    query: undefined,
+    location: undefined,
+    keywords: [],
+    requiredKeywords: [],
+    jobDescriptionId: undefined,
+    selectedTags: [],
+    selectedCompanies: [],
+    selectedExperienceLevel: undefined,
+    filters: {},
+    ...overrides,
+  }
+}
+
+function createResume(index: number, overrides: Partial<ConvexResumeItem> = {}): ConvexResumeItem {
+  const extractedDay = ((index - 1) % 28) + 1
+
+  return {
+    resumeId: `resume-${index}` as ConvexResumeItem['resumeId'],
+    externalId: `external-${index}`,
+    identityKey: `identity-${index}`,
+    name: `Candidate ${index}`,
+    profileUrl: '',
+    activityStatus: '',
+    age: '',
+    ageNumber: 30,
+    experience: '5 years',
+    education: 'Bachelor',
+    location: 'Malaysia',
+    extractedAt: new Date(`2026-03-${String(extractedDay).padStart(2, '0')}T10:00:00.000Z`).toISOString(),
+    expectedSalary: '',
+    jobIntention: '',
+    selfIntro: '',
+    skills: [],
+    workHistory: [],
+    source: 'seek',
+    crawledAt: Date.now(),
+    tags: [],
+    primaryRuleScore: 85,
+    ingestData: {
+      industryTags: ['Machine Tools', 'Automation'],
+      synonymHits: [],
+      brandHits: [],
+      companyHits: ['FANUC'],
+      ruleScores: {},
+      experienceLevel: 'senior',
+      computedAt: Date.now(),
+      skillsVersion: 1,
+    },
+    ...overrides,
+  }
+}
+
+describe('useResumeSearchState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    localStorage.clear()
+
+    workspaceMock.slug = 'dev'
+    parsedStateMock.shareSessionId = undefined
+    parsedStateMock.query = undefined
+    parsedStateMock.location = undefined
+    parsedStateMock.keywords = []
+    parsedStateMock.requiredKeywords = []
+    parsedStateMock.jobDescriptionId = undefined
+    parsedStateMock.selectedTags = []
+    parsedStateMock.selectedCompanies = []
+    parsedStateMock.selectedExperienceLevel = undefined
+    parsedStateMock.filters = {}
+
+    resumesMock.splice(0, resumesMock.length)
+    searchHistoryRecordsMock.splice?.(0, searchHistoryRecordsMock.length)
+    taxonomyClusterRecordsMock.splice?.(0, taxonomyClusterRecordsMock.length)
+    Object.keys(statusByIdentityMock).forEach((key) => delete statusByIdentityMock[key])
+    Object.keys(blocksByIdentityMock).forEach((key) => delete blocksByIdentityMock[key])
+
+    useFacetCountsMock.mockReturnValue({
+      clusters: [],
+      tags: [],
+      companies: [],
+      experienceLevels: [],
+      education: [],
+      statuses: [],
+      minScoreOptions: [],
+    })
+
+    useQueryMock.mockImplementation((query) => {
+      if (query === 'list-search-history-query') {
+        return searchHistoryRecordsMock
+      }
+      if (query === 'taxonomy-clusters-list-query') {
+        return taxonomyClusterRecordsMock
+      }
+      return undefined
+    })
+
+    useMutationMock.mockImplementation((mutation) => {
+      if (mutation === 'save-search-history-mutation') {
+        return saveSearchHistoryMutationMock
+      }
+      if (mutation === 'mark-search-history-opened-mutation') {
+        return markSearchHistoryOpenedMutationMock
+      }
+      return vi.fn()
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('derives raw and cluster tags, applies local filters, and sorts matching results', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'machine tools',
+      keywords: ['machine tools'],
+      selectedTags: ['cluster:manufacturing-systems', 'Machine Tools'],
+      selectedCompanies: ['FANUC'],
+      selectedExperienceLevel: 'senior',
+      filters: {
+        education: ['Bachelor'],
+        status: ['contacted'],
+        minMatchScore: 80,
+        sortBy: 'experience',
+        sortOrder: 'desc',
+      },
+    }))
+
+    taxonomyClusterRecordsMock.push(
+      {
+        name: 'Manufacturing Systems',
+        slug: 'manufacturing-systems',
+        tags: ['Machine Tools', 'Automation'],
+      },
+    )
+    resumesMock.push(
+      createResume(1, {
+        experience: '10 years',
+        primaryRuleScore: 92,
+      }),
+      createResume(2, {
+        experience: '3 years',
+        primaryRuleScore: 86,
+      }),
+      createResume(3, {
+        experience: '12 years',
+        primaryRuleScore: 95,
+        education: 'Master',
+        ingestData: {
+          industryTags: ['Machine Tools'],
+          synonymHits: [],
+          brandHits: [],
+          companyHits: ['DMG MORI'],
+          ruleScores: {},
+          experienceLevel: 'senior',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+        },
+      }),
+    )
+    statusByIdentityMock['identity-1'] = { status: 'contacted' }
+    statusByIdentityMock['identity-2'] = { status: 'contacted' }
+    statusByIdentityMock['identity-3'] = { status: 'contacted' }
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(result.current.isLanding).toBe(false)
+    expect(result.current.activeSort).toBe('experience')
+    expect(result.current.selectedClusterTags).toEqual(['manufacturing-systems'])
+    expect(result.current.selectedRawTags).toEqual(['Machine Tools'])
+    expect(result.current.filterCount).toBe(7)
+    expect(result.current.taxonomyClusters).toEqual([
+      {
+        name: 'Manufacturing Systems',
+        slug: 'manufacturing-systems',
+        parentSlug: undefined,
+        tags: ['Machine Tools', 'Automation'],
+      },
+    ])
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1', 'resume-2'])
+    expect(result.current.filteredResults[0]?.resume.experience).toBe('10 years')
+    expect(result.current.filteredResults[1]?.resume.experience).toBe('3 years')
+  })
+
+  it('normalizes a recent search and syncs it back to canonical url state when applied', async () => {
+    const historyKeywords = ['Machine Tools', 'Sales']
+    const expectedQuery = formatKeywordQuery(historyKeywords)
+
+    searchHistoryRecordsMock.push(
+      {
+        _id: 'history-1',
+        sessionKey: 'session-1',
+        title: 'Saved search',
+        location: 'Malaysia',
+        keywords: historyKeywords,
+        jobDescriptionId: 'lathe-sales',
+        selectedTags: ['cluster:manufacturing-systems', 'Machine Tools', 'machine tools'],
+        selectedCompanies: ['FANUC', ' fanuc '],
+        selectedExperienceLevel: ' senior ',
+        filters: {
+          education: ['Bachelor'],
+          status: ['new'],
+        },
+        createdAt: 1,
+        lastOpenedAt: 2,
+      },
+    )
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(result.current.recentSearches).toEqual([
+      expect.objectContaining({
+        id: 'history-1',
+        location: 'Malaysia',
+        keywords: historyKeywords,
+        selectedTags: ['cluster:manufacturing-systems', 'Machine Tools'],
+        selectedCompanies: ['FANUC'],
+        selectedExperienceLevel: 'senior',
+      }),
+    ])
+
+    await act(async () => {
+      await result.current.applyRecentSearch(result.current.recentSearches[0]!)
+    })
+
+    expect(markSearchHistoryOpenedMutationMock).toHaveBeenCalledWith({
+      id: 'history-1',
+      workspaceSlug: 'dev',
+    })
+    expect(syncToUrlMock).toHaveBeenCalledWith({
+      query: expectedQuery,
+      shareSessionId: undefined,
+      location: 'Malaysia',
+      keywords: historyKeywords,
+      requiredKeywords: [],
+      jobDescriptionId: 'lathe-sales',
+      selectedTags: ['cluster:manufacturing-systems', 'Machine Tools'],
+      selectedCompanies: ['FANUC'],
+      selectedExperienceLevel: 'senior',
+      filters: {
+        education: ['Bachelor'],
+        status: ['new'],
+      },
+    })
+    expect(result.current.queryInput).toBe(expectedQuery)
+  })
+
+  it('debounces search-history persistence and caps saved resume ids to the first 50', async () => {
+    const query = formatKeywordQuery(['Machine Tools', 'Sales'])
+    Object.assign(parsedStateMock, createParsedState({
+      query,
+      keywords: ['Machine Tools', 'Sales'],
+      location: 'Malaysia',
+      selectedTags: ['cluster:manufacturing-systems'],
+      selectedCompanies: ['FANUC'],
+      selectedExperienceLevel: 'senior',
+      filters: {
+        status: ['contacted'],
+      },
+    }))
+    localStorage.setItem('trends.resume.search.sessionKey.dev', 'session-dev')
+
+    resumesMock.push(
+      ...Array.from({ length: 55 }, (_, index) => createResume(index + 1, {
+        resumeId: `resume-${index + 1}` as ConvexResumeItem['resumeId'],
+        identityKey: `identity-${index + 1}`,
+      })),
+    )
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(result.current.isLanding).toBe(false)
+    expect(saveSearchHistoryMutationMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(799)
+    })
+
+    expect(saveSearchHistoryMutationMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+
+    expect(saveSearchHistoryMutationMock).toHaveBeenCalledTimes(1)
+    expect(saveSearchHistoryMutationMock).toHaveBeenCalledWith({
+      sessionKey: 'session-dev',
+      workspaceSlug: 'dev',
+      title: `Malaysia · ${query}`,
+      location: 'Malaysia',
+      keywords: ['Machine Tools', 'Sales'],
+      jobDescriptionId: undefined,
+      filters: {
+        status: ['contacted'],
+      },
+      selectedTags: ['cluster:manufacturing-systems'],
+      selectedCompanies: ['FANUC'],
+      selectedExperienceLevel: 'senior',
+      resumeIds: Array.from({ length: 50 }, (_, index) => `resume-${index + 1}`),
+    })
+  })
+})

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -9,7 +9,7 @@ import type { UrlSearchState } from '@/hooks/useUrlSearchState'
 vi.mock('../../../../packages/convex/convex/_generated/api', () => ({
   api: {
     sessions: {
-      listSearchHistory: 'list-search-history-query',
+      recentSearches: 'recent-searches-query',
       saveSearchHistory: 'save-search-history-mutation',
       markSearchHistoryOpened: 'mark-search-history-opened-mutation',
     },
@@ -25,7 +25,7 @@ const {
   parsedStateMock,
   resumesMock,
   saveSearchHistoryMutationMock,
-  searchHistoryRecordsMock,
+  recentSearchHistoryRecordsMock,
   statusByIdentityMock,
   syncToUrlMock,
   taxonomyClusterRecordsMock,
@@ -39,7 +39,7 @@ const {
   parsedStateMock: {} as UrlSearchState,
   resumesMock: [] as ConvexResumeItem[],
   saveSearchHistoryMutationMock: vi.fn(async () => 'history-1'),
-  searchHistoryRecordsMock: [] as Array<Record<string, unknown>>,
+  recentSearchHistoryRecordsMock: [] as Array<Record<string, unknown>>,
   statusByIdentityMock: {} as Record<string, { status: ResumeSearchResultItem['status'] }>,
   syncToUrlMock: vi.fn(),
   taxonomyClusterRecordsMock: [] as Array<Record<string, unknown>>,
@@ -166,7 +166,7 @@ describe('useResumeSearchState', () => {
     parsedStateMock.filters = {}
 
     resumesMock.splice(0, resumesMock.length)
-    searchHistoryRecordsMock.splice?.(0, searchHistoryRecordsMock.length)
+    recentSearchHistoryRecordsMock.splice?.(0, recentSearchHistoryRecordsMock.length)
     taxonomyClusterRecordsMock.splice?.(0, taxonomyClusterRecordsMock.length)
     Object.keys(statusByIdentityMock).forEach((key) => delete statusByIdentityMock[key])
     Object.keys(blocksByIdentityMock).forEach((key) => delete blocksByIdentityMock[key])
@@ -182,8 +182,8 @@ describe('useResumeSearchState', () => {
     })
 
     useQueryMock.mockImplementation((query) => {
-      if (query === 'list-search-history-query') {
-        return searchHistoryRecordsMock
+      if (query === 'recent-searches-query') {
+        return recentSearchHistoryRecordsMock
       }
       if (query === 'taxonomy-clusters-list-query') {
         return taxonomyClusterRecordsMock
@@ -282,7 +282,7 @@ describe('useResumeSearchState', () => {
     const historyKeywords = ['Machine Tools', 'Sales']
     const expectedQuery = formatKeywordQuery(historyKeywords)
 
-    searchHistoryRecordsMock.push(
+    recentSearchHistoryRecordsMock.push(
       {
         _id: 'history-1',
         sessionKey: 'session-1',
@@ -339,6 +339,18 @@ describe('useResumeSearchState', () => {
       },
     })
     expect(result.current.queryInput).toBe(expectedQuery)
+  })
+
+  it('loads recent searches from the active session only', () => {
+    localStorage.setItem('trends.resume.search.sessionKey.dev', 'session-dev')
+
+    renderHook(() => useResumeSearchState())
+
+    expect(useQueryMock).toHaveBeenCalledWith('recent-searches-query', {
+      sessionKey: 'session-dev',
+      workspaceSlug: 'dev',
+      limit: 10,
+    })
   })
 
   it('debounces search-history persistence and caps saved resume ids to the first 50', async () => {

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -1,0 +1,624 @@
+import { formatKeywordQuery, parseKeywordQuery } from '@trends/shared'
+import { useMutation, useQuery } from 'convex/react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { api } from '../../../../packages/convex/convex/_generated/api'
+import { useWorkspace } from '@/contexts/WorkspaceContext'
+import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
+import { useCandidateStatus } from '@/hooks/useCandidateStatus'
+import { useConvexResumes, type ConvexResumeFilters, type ConvexResumeItem } from '@/hooks/useConvexResumes'
+import { useFacetCounts } from '@/hooks/useFacetCounts'
+import {
+  useUrlSearchState,
+  type ExperienceLevelFilter,
+  type UrlSearchState,
+} from '@/hooks/useUrlSearchState'
+import { toIndustryDbV2Stats } from '@/lib/resume-scoring'
+import { resolveCollectionSource } from '@/lib/search-profile-sources'
+import type { SearchHistoryItem } from '@/hooks/useSession'
+import type { CandidateStatus, ResumeFilters } from '@/types/resume'
+import type {
+  FacetCounts,
+  ResumeSearchRecentItem,
+  ResumeSearchResultItem,
+  SearchSortValue,
+} from '@/components/search/search-types'
+
+const INITIAL_RESUME_LIMIT = 200
+const RESUME_PAGE_INCREMENT = 200
+const SESSION_KEY_PREFIX = 'trends.resume.search.sessionKey'
+
+type SearchHistoryRecord = {
+  _id: SearchHistoryItem['id']
+  sessionKey: string
+  title: string
+  location: string
+  keywords: string[]
+  jobDescriptionId?: string
+  collectionSource?: SearchHistoryItem['collectionSource']
+  collectUrl?: string
+  filters?: Partial<ResumeFilters>
+  selectedTags?: string[]
+  selectedCompanies?: string[]
+  selectedExperienceLevel?: string
+  collectionTaskId?: string
+  analysisTaskId?: string
+  notes?: string
+  industryDbV2Stats?: unknown
+  createdAt: number
+  lastOpenedAt?: number
+}
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  const normalized = value?.trim()
+  return normalized ? normalized : undefined
+}
+
+function normalizeStringList(values: string[] | undefined): string[] {
+  if (!Array.isArray(values) || values.length === 0) {
+    return []
+  }
+
+  const seen = new Set<string>()
+  const normalized: string[] = []
+
+  values.forEach((value) => {
+    const token = value.trim()
+    const key = token.toLowerCase()
+    if (!token || seen.has(key)) {
+      return
+    }
+
+    seen.add(key)
+    normalized.push(token)
+  })
+
+  return normalized
+}
+
+function parseExperienceYears(value: string | undefined): number {
+  if (!value) {
+    return 0
+  }
+
+  const matched = value.match(/\d+(?:\.\d+)?/)
+  if (!matched) {
+    return 0
+  }
+
+  const parsed = Number(matched[0])
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function resolveScore(resume: ConvexResumeItem, jobDescriptionId: string | undefined): number | undefined {
+  const normalizedJobDescriptionId = normalizeOptionalString(jobDescriptionId)
+  const ruleScores = resume.ingestData?.ruleScores ?? {}
+
+  if (normalizedJobDescriptionId) {
+    const candidateKeys = normalizedJobDescriptionId.startsWith('jd-')
+      ? [normalizedJobDescriptionId, normalizedJobDescriptionId.slice(3)]
+      : [normalizedJobDescriptionId, `jd-${normalizedJobDescriptionId}`]
+
+    for (const key of candidateKeys) {
+      const score = ruleScores[key]
+      if (typeof score === 'number' && Number.isFinite(score)) {
+        return score
+      }
+    }
+  }
+
+  if (typeof resume.primaryRuleScore === 'number' && Number.isFinite(resume.primaryRuleScore)) {
+    return resume.primaryRuleScore
+  }
+
+  if (typeof resume.analysis?.score === 'number' && Number.isFinite(resume.analysis.score)) {
+    return resume.analysis.score
+  }
+
+  return undefined
+}
+
+function hasExplicitSearchContext(state: UrlSearchState): boolean {
+  return Boolean(
+    normalizeOptionalString(state.query)
+    || normalizeOptionalString(state.location)
+    || normalizeOptionalString(state.jobDescriptionId)
+    || state.requiredKeywords.length > 0
+    || state.selectedTags.length > 0
+    || state.selectedCompanies.length > 0
+    || state.selectedExperienceLevel
+    || (state.filters.education?.length ?? 0) > 0
+    || (state.filters.status?.length ?? 0) > 0
+    || typeof state.filters.minMatchScore === 'number'
+    || typeof state.filters.minExperience === 'number'
+    || typeof state.filters.maxExperience === 'number'
+    || (state.filters.locations?.length ?? 0) > 0
+  )
+}
+
+function resolveSortValue(filters: Partial<ResumeFilters>): SearchSortValue {
+  if (filters.sortBy === 'experience') {
+    return 'experience'
+  }
+
+  if (filters.sortBy === 'extractedAt') {
+    return 'newest'
+  }
+
+  return 'relevance'
+}
+
+function buildUrlState(
+  state: UrlSearchState,
+  overrides: Partial<UrlSearchState>,
+): UrlSearchState {
+  return {
+    shareSessionId: overrides.shareSessionId ?? state.shareSessionId,
+    query: overrides.query ?? state.query,
+    location: overrides.location ?? state.location,
+    keywords: overrides.keywords ?? state.keywords,
+    requiredKeywords: overrides.requiredKeywords ?? state.requiredKeywords,
+    jobDescriptionId: overrides.jobDescriptionId ?? state.jobDescriptionId,
+    selectedTags: overrides.selectedTags ?? state.selectedTags,
+    selectedCompanies: overrides.selectedCompanies ?? state.selectedCompanies,
+    selectedExperienceLevel: overrides.selectedExperienceLevel ?? state.selectedExperienceLevel,
+    filters: overrides.filters ?? state.filters,
+  }
+}
+
+function sortResults(results: ResumeSearchResultItem[], sortValue: SearchSortValue): ResumeSearchResultItem[] {
+  if (sortValue === 'relevance') {
+    return results
+  }
+
+  return [...results].sort((left, right) => {
+    if (sortValue === 'newest') {
+      const rightTimestamp = right.resume.extractedAt
+        ? Date.parse(right.resume.extractedAt)
+        : right.resume.crawledAt
+      const leftTimestamp = left.resume.extractedAt
+        ? Date.parse(left.resume.extractedAt)
+        : left.resume.crawledAt
+      return rightTimestamp - leftTimestamp
+    }
+
+    return parseExperienceYears(right.resume.experience) - parseExperienceYears(left.resume.experience)
+  })
+}
+
+function matchesLocalFilters(item: ResumeSearchResultItem, state: UrlSearchState): boolean {
+  const normalizedSelectedTags = state.selectedTags.map((value) => value.toLowerCase())
+  const normalizedSelectedCompanies = state.selectedCompanies.map((value) => value.toLowerCase())
+  const normalizedEducation = (state.filters.education ?? []).map((value) => value.toLowerCase())
+  const normalizedStatuses = state.filters.status ?? []
+  const industryTags = item.resume.ingestData?.industryTags?.map((value) => value.toLowerCase()) ?? []
+  const companyHits = item.resume.ingestData?.companyHits?.map((value) => value.toLowerCase()) ?? []
+  const education = item.resume.education?.trim().toLowerCase() ?? ''
+  const experienceLevel = item.resume.ingestData?.experienceLevel?.trim().toLowerCase()
+  const minScore = state.filters.minMatchScore
+
+  if (normalizedSelectedTags.length > 0 && !normalizedSelectedTags.every((tag) => industryTags.includes(tag))) {
+    return false
+  }
+
+  if (normalizedSelectedCompanies.length > 0 && !normalizedSelectedCompanies.some((company) => companyHits.includes(company))) {
+    return false
+  }
+
+  if (state.selectedExperienceLevel && experienceLevel !== state.selectedExperienceLevel) {
+    return false
+  }
+
+  if (normalizedEducation.length > 0 && !normalizedEducation.includes(education)) {
+    return false
+  }
+
+  if (normalizedStatuses.length > 0 && !normalizedStatuses.includes(item.status)) {
+    return false
+  }
+
+  if (typeof minScore === 'number' && (item.score ?? 0) < minScore) {
+    return false
+  }
+
+  return true
+}
+
+function toRecentSearchItems(records: SearchHistoryRecord[] | undefined): ResumeSearchRecentItem[] {
+  if (!records) {
+    return []
+  }
+
+  return records.map((record) => ({
+    id: record._id,
+    sessionKey: record.sessionKey,
+    title: record.title,
+    location: record.location,
+    keywords: record.keywords,
+    jobDescriptionId: normalizeOptionalString(record.jobDescriptionId),
+    collectionSource: resolveCollectionSource(
+      record.collectionSource,
+      record.collectUrl,
+    ),
+    collectUrl: normalizeOptionalString(record.collectUrl),
+    filters: record.filters ?? {},
+    selectedTags: normalizeStringList(record.selectedTags),
+    selectedCompanies: normalizeStringList(record.selectedCompanies),
+    selectedExperienceLevel: normalizeOptionalString(record.selectedExperienceLevel),
+    collectionTaskId: normalizeOptionalString(record.collectionTaskId),
+    analysisTaskId: normalizeOptionalString(record.analysisTaskId),
+    notes: normalizeOptionalString(record.notes),
+    industryDbV2Stats: toIndustryDbV2Stats(record.industryDbV2Stats),
+    createdAt: record.createdAt,
+    lastOpenedAt: record.lastOpenedAt,
+  }))
+}
+
+function createSessionKey(): string {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36)
+}
+
+function ensureStoredSessionKey(storageKey: string): string {
+  const stored = localStorage.getItem(storageKey)
+  if (stored) {
+    return stored
+  }
+
+  const nextKey = createSessionKey()
+  localStorage.setItem(storageKey, nextKey)
+  return nextKey
+}
+
+export function useResumeSearchState() {
+  const { slug } = useWorkspace()
+  const { parsedState, syncToUrl } = useUrlSearchState()
+  const storageKey = `${SESSION_KEY_PREFIX}.${slug}`
+  const [sessionKey, setSessionKey] = useState(() => ensureStoredSessionKey(storageKey))
+  const [queryInput, setQueryInput] = useState(() => parsedState.query ?? formatKeywordQuery(parsedState.keywords))
+  const [resumeLimit, setResumeLimit] = useState(INITIAL_RESUME_LIMIT)
+  const saveSearchHistory = useMutation(api.sessions.saveSearchHistory)
+  const markSearchHistoryOpened = useMutation(api.sessions.markSearchHistoryOpened)
+  const searchHistoryRecords = useQuery(api.sessions.listSearchHistory, { workspaceSlug: slug })
+  const { statusByIdentity } = useCandidateStatus(true)
+  const { blocksByIdentity } = useCandidateBlocks(true)
+
+  useEffect(() => {
+    setQueryInput(parsedState.query ?? formatKeywordQuery(parsedState.keywords))
+  }, [parsedState.keywords, parsedState.query])
+
+  useEffect(() => {
+    setSessionKey(ensureStoredSessionKey(storageKey))
+  }, [storageKey])
+
+  useEffect(() => {
+    setResumeLimit(INITIAL_RESUME_LIMIT)
+  }, [
+    parsedState.filters.education,
+    parsedState.filters.locations,
+    parsedState.filters.maxExperience,
+    parsedState.filters.minExperience,
+    parsedState.filters.minMatchScore,
+    parsedState.filters.status,
+    parsedState.jobDescriptionId,
+    parsedState.location,
+    parsedState.query,
+    parsedState.requiredKeywords,
+    parsedState.selectedCompanies,
+    parsedState.selectedExperienceLevel,
+    parsedState.selectedTags,
+  ])
+
+  const isLanding = !hasExplicitSearchContext(parsedState)
+  const activeQuery = normalizeOptionalString(parsedState.query)
+  const backendFilters = useMemo<ConvexResumeFilters>(() => ({
+    minExperience: parsedState.filters.minExperience,
+    maxExperience: parsedState.filters.maxExperience,
+    requiredKeywords: parsedState.requiredKeywords,
+    locations: parsedState.filters.locations,
+  }), [
+    parsedState.filters.locations,
+    parsedState.filters.maxExperience,
+    parsedState.filters.minExperience,
+    parsedState.requiredKeywords,
+  ])
+  const activeSort = resolveSortValue(parsedState.filters)
+  const resumeQuery = useConvexResumes(
+    resumeLimit,
+    activeQuery,
+    parsedState.jobDescriptionId,
+    {
+      enabled: !isLanding,
+      filters: backendFilters,
+      ...(activeSort === 'newest' ? { sortBy: 'extractedAt' as const, sortOrder: 'desc' as const } : {}),
+      ...(activeSort === 'experience' ? { sortBy: 'experience' as const, sortOrder: 'desc' as const } : {}),
+    }
+  )
+
+  const recentSearches = useMemo(
+    () => toRecentSearchItems(searchHistoryRecords).slice(0, 10),
+    [searchHistoryRecords]
+  )
+
+  const results = useMemo<ResumeSearchResultItem[]>(() => {
+    return resumeQuery.resumes.map((resume) => {
+      const identityKey = resume.identityKey?.trim() || resume.externalId
+      const statusRecord = statusByIdentity[identityKey]
+      return {
+        key: `${resume.resumeId}`,
+        identityKey,
+        resume,
+        blocked: Boolean(blocksByIdentity[identityKey]),
+        score: resolveScore(resume, parsedState.jobDescriptionId),
+        status: statusRecord?.status ?? 'new',
+        statusMeta: statusRecord,
+      }
+    })
+  }, [blocksByIdentity, parsedState.jobDescriptionId, resumeQuery.resumes, statusByIdentity])
+
+  const filteredResults = useMemo(
+    () => sortResults(results.filter((item) => matchesLocalFilters(item, parsedState)), activeSort),
+    [activeSort, parsedState, results]
+  )
+
+  const facetCounts: FacetCounts = useFacetCounts(results)
+  const hasMore = resumeQuery.hasMore
+  const loading = !isLanding && resumeQuery.loading
+  const loadingMore = resumeQuery.loadingMore
+  const filterCount = parsedState.selectedTags.length
+    + parsedState.selectedCompanies.length
+    + (parsedState.selectedExperienceLevel ? 1 : 0)
+    + (parsedState.filters.education?.length ?? 0)
+    + (parsedState.filters.status?.length ?? 0)
+    + (typeof parsedState.filters.minMatchScore === 'number' ? 1 : 0)
+
+  const lastSavedFingerprintRef = useRef<string>('')
+  useEffect(() => {
+    if (isLanding) {
+      return
+    }
+
+    const normalizedKeywords = parseKeywordQuery(parsedState.query ?? formatKeywordQuery(parsedState.keywords)).keywords
+    if (normalizedKeywords.length === 0 && !parsedState.jobDescriptionId) {
+      return
+    }
+
+    const fingerprint = JSON.stringify({
+      query: parsedState.query,
+      location: parsedState.location,
+      jobDescriptionId: parsedState.jobDescriptionId,
+      requiredKeywords: parsedState.requiredKeywords,
+      selectedTags: parsedState.selectedTags,
+      selectedCompanies: parsedState.selectedCompanies,
+      selectedExperienceLevel: parsedState.selectedExperienceLevel,
+      filters: parsedState.filters,
+    })
+
+    if (lastSavedFingerprintRef.current === fingerprint) {
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      lastSavedFingerprintRef.current = fingerprint
+      void saveSearchHistory({
+        sessionKey,
+        workspaceSlug: slug,
+        title: normalizeOptionalString([
+          normalizeOptionalString(parsedState.location),
+          normalizeOptionalString(parsedState.query) ?? formatKeywordQuery(normalizedKeywords),
+        ].filter(Boolean).join(' · ')),
+        location: parsedState.location ?? '',
+        keywords: normalizedKeywords,
+        jobDescriptionId: parsedState.jobDescriptionId,
+        filters: parsedState.filters,
+        selectedTags: parsedState.selectedTags,
+        selectedCompanies: parsedState.selectedCompanies,
+        selectedExperienceLevel: parsedState.selectedExperienceLevel,
+        resumeIds: results.slice(0, 50).map((item) => String(item.resume.resumeId)),
+      })
+    }, 800)
+
+    return () => window.clearTimeout(timer)
+  }, [isLanding, parsedState, results, saveSearchHistory, sessionKey, slug])
+
+  const submitSearch = useCallback((nextQuery?: string) => {
+    const resolvedQuery = normalizeOptionalString(nextQuery ?? queryInput)
+    const nextKeywords = parseKeywordQuery(resolvedQuery ?? '').keywords
+
+    syncToUrl(buildUrlState(parsedState, {
+      query: resolvedQuery,
+      keywords: nextKeywords,
+    }))
+  }, [parsedState, queryInput, syncToUrl])
+
+  const clearSearch = useCallback(() => {
+    setQueryInput('')
+    syncToUrl(buildUrlState(parsedState, {
+      query: undefined,
+      keywords: [],
+      requiredKeywords: [],
+      jobDescriptionId: undefined,
+      selectedTags: [],
+      selectedCompanies: [],
+      selectedExperienceLevel: undefined,
+      filters: {},
+    }))
+  }, [parsedState, syncToUrl])
+
+  const applyRecentSearch = useCallback(async (item: ResumeSearchRecentItem) => {
+    await markSearchHistoryOpened({ id: item.id, workspaceSlug: slug })
+
+    const query = formatKeywordQuery(item.keywords)
+    setQueryInput(query)
+    syncToUrl({
+      query,
+      shareSessionId: undefined,
+      location: normalizeOptionalString(item.location),
+      keywords: item.keywords,
+      requiredKeywords: [],
+      jobDescriptionId: item.jobDescriptionId,
+      selectedTags: item.selectedTags,
+      selectedCompanies: item.selectedCompanies,
+      selectedExperienceLevel: (item.selectedExperienceLevel as ExperienceLevelFilter | undefined) ?? undefined,
+      filters: item.filters ?? {},
+    })
+  }, [markSearchHistoryOpened, slug, syncToUrl])
+
+  const setSelectedTags = useCallback((selectedTags: string[]) => {
+    syncToUrl(buildUrlState(parsedState, { selectedTags }))
+  }, [parsedState, syncToUrl])
+
+  const toggleTag = useCallback((tag: string) => {
+    const normalized = tag.trim()
+    if (!normalized) {
+      return
+    }
+
+    const nextTags = parsedState.selectedTags.some((value) => value.toLowerCase() === normalized.toLowerCase())
+      ? parsedState.selectedTags.filter((value) => value.toLowerCase() !== normalized.toLowerCase())
+      : [...parsedState.selectedTags, normalized]
+
+    setSelectedTags(nextTags)
+  }, [parsedState.selectedTags, setSelectedTags])
+
+  const setSelectedCompanies = useCallback((selectedCompanies: string[]) => {
+    syncToUrl(buildUrlState(parsedState, { selectedCompanies }))
+  }, [parsedState, syncToUrl])
+
+  const toggleCompany = useCallback((company: string) => {
+    const normalized = company.trim()
+    if (!normalized) {
+      return
+    }
+
+    const nextCompanies = parsedState.selectedCompanies.some((value) => value.toLowerCase() === normalized.toLowerCase())
+      ? parsedState.selectedCompanies.filter((value) => value.toLowerCase() !== normalized.toLowerCase())
+      : [...parsedState.selectedCompanies, normalized]
+
+    setSelectedCompanies(nextCompanies)
+  }, [parsedState.selectedCompanies, setSelectedCompanies])
+
+  const setSelectedExperienceLevel = useCallback((selectedExperienceLevel: ExperienceLevelFilter | undefined) => {
+    syncToUrl(buildUrlState(parsedState, { selectedExperienceLevel }))
+  }, [parsedState, syncToUrl])
+
+  const setEducationFilters = useCallback((education: string[]) => {
+    syncToUrl(buildUrlState(parsedState, {
+      filters: {
+        ...parsedState.filters,
+        education,
+      },
+    }))
+  }, [parsedState, syncToUrl])
+
+  const toggleEducation = useCallback((educationValue: string) => {
+    const normalized = educationValue.trim()
+    if (!normalized) {
+      return
+    }
+
+    const current = parsedState.filters.education ?? []
+    const nextEducation = current.some((value) => value.toLowerCase() === normalized.toLowerCase())
+      ? current.filter((value) => value.toLowerCase() !== normalized.toLowerCase())
+      : [...current, normalized]
+
+    setEducationFilters(nextEducation)
+  }, [parsedState.filters.education, setEducationFilters])
+
+  const setStatusFilters = useCallback((status: CandidateStatus[]) => {
+    syncToUrl(buildUrlState(parsedState, {
+      filters: {
+        ...parsedState.filters,
+        status,
+      },
+    }))
+  }, [parsedState, syncToUrl])
+
+  const toggleStatus = useCallback((status: CandidateStatus) => {
+    const current = parsedState.filters.status ?? []
+    const nextStatus = current.includes(status)
+      ? current.filter((value) => value !== status)
+      : [...current, status]
+
+    setStatusFilters(nextStatus)
+  }, [parsedState.filters.status, setStatusFilters])
+
+  const setMinScoreFilter = useCallback((minMatchScore: number | undefined) => {
+    syncToUrl(buildUrlState(parsedState, {
+      filters: {
+        ...parsedState.filters,
+        minMatchScore,
+      },
+    }))
+  }, [parsedState, syncToUrl])
+
+  const setSort = useCallback((sortValue: SearchSortValue) => {
+    const nextFilters: Partial<ResumeFilters> = {
+      ...parsedState.filters,
+      sortBy:
+        sortValue === 'newest'
+          ? 'extractedAt'
+          : sortValue === 'experience'
+            ? 'experience'
+            : undefined,
+      sortOrder:
+        sortValue === 'relevance'
+          ? undefined
+          : 'desc',
+    }
+
+    syncToUrl(buildUrlState(parsedState, { filters: nextFilters }))
+  }, [parsedState, syncToUrl])
+
+  const clearFacetFilters = useCallback(() => {
+    syncToUrl(buildUrlState(parsedState, {
+      selectedTags: [],
+      selectedCompanies: [],
+      selectedExperienceLevel: undefined,
+      filters: {
+        ...parsedState.filters,
+        education: undefined,
+        status: undefined,
+        minMatchScore: undefined,
+      },
+    }))
+  }, [parsedState, syncToUrl])
+
+  const loadMore = useCallback(() => {
+    if (!hasMore || loadingMore) {
+      return
+    }
+
+    setResumeLimit((current) => current + RESUME_PAGE_INCREMENT)
+  }, [hasMore, loadingMore])
+
+  return {
+    activeQuery,
+    activeSort,
+    applyRecentSearch,
+    clearFacetFilters,
+    clearSearch,
+    facetCounts,
+    filterCount,
+    filteredResults,
+    hasMore,
+    isLanding,
+    loading,
+    loadingMore,
+    parsedState,
+    queryInput,
+    recentSearches,
+    results,
+    searchHistoryLoading: searchHistoryRecords === undefined,
+    setMinScoreFilter,
+    setQueryInput,
+    setSelectedCompanies,
+    setSelectedExperienceLevel,
+    setSelectedTags,
+    setSort,
+    submitSearch,
+    toggleCompany,
+    toggleEducation,
+    toggleStatus,
+    toggleTag,
+    loadMore,
+  }
+}

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -299,7 +299,11 @@ export function useResumeSearchState() {
   const [resumeLimit, setResumeLimit] = useState(INITIAL_RESUME_LIMIT)
   const saveSearchHistory = useMutation(api.sessions.saveSearchHistory)
   const markSearchHistoryOpened = useMutation(api.sessions.markSearchHistoryOpened)
-  const searchHistoryRecords = useQuery(api.sessions.listSearchHistory, { workspaceSlug: slug })
+  const recentSearchHistoryRecords = useQuery(api.sessions.recentSearches, {
+    sessionKey,
+    workspaceSlug: slug,
+    limit: 10,
+  })
   const taxonomyClusterRecords = useQuery(api.taxonomy_clusters.list, {
     workspaceSlug: slug,
     status: 'active',
@@ -360,8 +364,8 @@ export function useResumeSearchState() {
   )
 
   const recentSearches = useMemo(
-    () => toRecentSearchItems(searchHistoryRecords).slice(0, 10),
-    [searchHistoryRecords]
+    () => toRecentSearchItems(recentSearchHistoryRecords),
+    [recentSearchHistoryRecords]
   )
   const taxonomyClusters = useMemo<TaxonomyClusterInput[]>(
     () => (taxonomyClusterRecords ?? []).map((cluster) => ({
@@ -683,7 +687,7 @@ export function useResumeSearchState() {
     results,
     selectedClusterTags,
     selectedRawTags,
-    searchHistoryLoading: searchHistoryRecords === undefined,
+    searchHistoryLoading: recentSearchHistoryRecords === undefined,
     setMinScoreFilter,
     setQueryInput,
     setSelectedCompanies,

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -12,6 +12,14 @@ import {
   type ExperienceLevelFilter,
   type UrlSearchState,
 } from '@/hooks/useUrlSearchState'
+import {
+  createTaxonomyClusterResolver,
+  fromClusterFilterToken,
+  isClusterFilterToken,
+  toClusterFilterToken,
+  type TaxonomyClusterInput,
+  type TaxonomyClusterResolver,
+} from '@/lib/taxonomy'
 import { toIndustryDbV2Stats } from '@/lib/resume-scoring'
 import { resolveCollectionSource } from '@/lib/search-profile-sources'
 import type { SearchHistoryItem } from '@/hooks/useSession'
@@ -185,18 +193,32 @@ function sortResults(results: ResumeSearchResultItem[], sortValue: SearchSortVal
   })
 }
 
-function matchesLocalFilters(item: ResumeSearchResultItem, state: UrlSearchState): boolean {
-  const normalizedSelectedTags = state.selectedTags.map((value) => value.toLowerCase())
+function matchesLocalFilters(
+  item: ResumeSearchResultItem,
+  state: UrlSearchState,
+  selectedRawTags: string[],
+  selectedClusterTags: string[],
+  taxonomyResolver: TaxonomyClusterResolver,
+): boolean {
+  const normalizedSelectedTags = selectedRawTags.map((value) => value.toLowerCase())
+  const normalizedSelectedClusters = selectedClusterTags.map((value) => value.toLowerCase())
   const normalizedSelectedCompanies = state.selectedCompanies.map((value) => value.toLowerCase())
   const normalizedEducation = (state.filters.education ?? []).map((value) => value.toLowerCase())
   const normalizedStatuses = state.filters.status ?? []
   const industryTags = item.resume.ingestData?.industryTags?.map((value) => value.toLowerCase()) ?? []
+  const matchedClusters = new Set(
+    taxonomyResolver.resolveTagClusters(item.resume.ingestData?.industryTags).map((cluster) => cluster.slug.toLowerCase()),
+  )
   const companyHits = item.resume.ingestData?.companyHits?.map((value) => value.toLowerCase()) ?? []
   const education = item.resume.education?.trim().toLowerCase() ?? ''
   const experienceLevel = item.resume.ingestData?.experienceLevel?.trim().toLowerCase()
   const minScore = state.filters.minMatchScore
 
   if (normalizedSelectedTags.length > 0 && !normalizedSelectedTags.every((tag) => industryTags.includes(tag))) {
+    return false
+  }
+
+  if (normalizedSelectedClusters.length > 0 && !normalizedSelectedClusters.every((slug) => matchedClusters.has(slug))) {
     return false
   }
 
@@ -278,6 +300,10 @@ export function useResumeSearchState() {
   const saveSearchHistory = useMutation(api.sessions.saveSearchHistory)
   const markSearchHistoryOpened = useMutation(api.sessions.markSearchHistoryOpened)
   const searchHistoryRecords = useQuery(api.sessions.listSearchHistory, { workspaceSlug: slug })
+  const taxonomyClusterRecords = useQuery(api.taxonomy_clusters.list, {
+    workspaceSlug: slug,
+    status: 'active',
+  })
   const { statusByIdentity } = useCandidateStatus(true)
   const { blocksByIdentity } = useCandidateBlocks(true)
 
@@ -337,6 +363,31 @@ export function useResumeSearchState() {
     () => toRecentSearchItems(searchHistoryRecords).slice(0, 10),
     [searchHistoryRecords]
   )
+  const taxonomyClusters = useMemo<TaxonomyClusterInput[]>(
+    () => (taxonomyClusterRecords ?? []).map((cluster) => ({
+      name: cluster.name,
+      slug: cluster.slug,
+      parentSlug: cluster.parentSlug,
+      tags: cluster.tags,
+    })),
+    [taxonomyClusterRecords]
+  )
+  const taxonomyResolver = useMemo(
+    () => createTaxonomyClusterResolver(taxonomyClusters),
+    [taxonomyClusters]
+  )
+  const selectedClusterTags = useMemo(
+    () => normalizeStringList(
+      parsedState.selectedTags
+        .filter((value) => isClusterFilterToken(value))
+        .map((value) => fromClusterFilterToken(value))
+    ),
+    [parsedState.selectedTags]
+  )
+  const selectedRawTags = useMemo(
+    () => normalizeStringList(parsedState.selectedTags.filter((value) => !isClusterFilterToken(value))),
+    [parsedState.selectedTags]
+  )
 
   const results = useMemo<ResumeSearchResultItem[]>(() => {
     return resumeQuery.resumes.map((resume) => {
@@ -355,11 +406,20 @@ export function useResumeSearchState() {
   }, [blocksByIdentity, parsedState.jobDescriptionId, resumeQuery.resumes, statusByIdentity])
 
   const filteredResults = useMemo(
-    () => sortResults(results.filter((item) => matchesLocalFilters(item, parsedState)), activeSort),
-    [activeSort, parsedState, results]
+    () => sortResults(
+      results.filter((item) => matchesLocalFilters(
+        item,
+        parsedState,
+        selectedRawTags,
+        selectedClusterTags,
+        taxonomyResolver,
+      )),
+      activeSort
+    ),
+    [activeSort, parsedState, results, selectedClusterTags, selectedRawTags, taxonomyResolver]
   )
 
-  const facetCounts: FacetCounts = useFacetCounts(results)
+  const facetCounts: FacetCounts = useFacetCounts(results, taxonomyClusters)
   const hasMore = resumeQuery.hasMore
   const loading = !isLanding && resumeQuery.loading
   const loadingMore = resumeQuery.loadingMore
@@ -475,6 +535,20 @@ export function useResumeSearchState() {
     const nextTags = parsedState.selectedTags.some((value) => value.toLowerCase() === normalized.toLowerCase())
       ? parsedState.selectedTags.filter((value) => value.toLowerCase() !== normalized.toLowerCase())
       : [...parsedState.selectedTags, normalized]
+
+    setSelectedTags(nextTags)
+  }, [parsedState.selectedTags, setSelectedTags])
+
+  const toggleCluster = useCallback((clusterSlug: string) => {
+    const normalized = clusterSlug.trim().toLowerCase()
+    if (!normalized) {
+      return
+    }
+
+    const token = toClusterFilterToken(normalized)
+    const nextTags = parsedState.selectedTags.some((value) => value.trim().toLowerCase() === token)
+      ? parsedState.selectedTags.filter((value) => value.trim().toLowerCase() !== token)
+      : [...parsedState.selectedTags, token]
 
     setSelectedTags(nextTags)
   }, [parsedState.selectedTags, setSelectedTags])
@@ -607,6 +681,8 @@ export function useResumeSearchState() {
     queryInput,
     recentSearches,
     results,
+    selectedClusterTags,
+    selectedRawTags,
     searchHistoryLoading: searchHistoryRecords === undefined,
     setMinScoreFilter,
     setQueryInput,
@@ -615,7 +691,9 @@ export function useResumeSearchState() {
     setSelectedTags,
     setSort,
     submitSearch,
+    taxonomyClusters,
     toggleCompany,
+    toggleCluster,
     toggleEducation,
     toggleStatus,
     toggleTag,

--- a/apps/web/src/hooks/useUrlSearchState.test.ts
+++ b/apps/web/src/hooks/useUrlSearchState.test.ts
@@ -17,6 +17,29 @@ describe('useUrlSearchState location parsing', () => {
     vi.clearAllMocks()
   })
 
+  it('reports url-state presence flags without treating sid alone as explicit search state', () => {
+    useSearchParamsMock.mockReturnValue([new URLSearchParams('sid=session-share-1'), setSearchParamsMock])
+
+    const { result } = renderHook(() => useUrlSearchState())
+
+    expect(result.current.hasUrlParams).toBe(false)
+    expect(result.current.hasKeywordParam).toBe(false)
+    expect(result.current.hasJobDescriptionParam).toBe(false)
+    expect(result.current.parsedState.shareSessionId).toBe('session-share-1')
+  })
+
+  it('detects legacy keyword params and jd params as explicit url search state', () => {
+    useSearchParamsMock.mockReturnValue([new URLSearchParams('kw=CNC+Sales&jd=jd-123'), setSearchParamsMock])
+
+    const { result } = renderHook(() => useUrlSearchState())
+
+    expect(result.current.hasUrlParams).toBe(true)
+    expect(result.current.hasKeywordParam).toBe(true)
+    expect(result.current.hasJobDescriptionParam).toBe(true)
+    expect(result.current.parsedState.query).toBe('CNC Sales')
+    expect(result.current.parsedState.jobDescriptionId).toBe('jd-123')
+  })
+
   it('preserves spaced locations as a single location token', () => {
     const state = parseUrlSearchState(new URLSearchParams('location=Kuala+Lumpur+MY'))
 
@@ -205,5 +228,56 @@ describe('useUrlSearchState location parsing', () => {
 
     expect(state.selectedTags).toEqual(['cluster:manufacturing-systems', 'Machine Tools'])
     expect(state.query).toBe('machine tools')
+  })
+
+  it('clears legacy params and deduplicates canonical values when syncing to the url', () => {
+    const currentParams = new URLSearchParams(
+      'sid=session-share-1&kw=legacy&keyword=legacy&loc=Oldtown&locs=Oldtown%2COldtown&minExp=3&maxExp=9&status=new'
+    )
+    useSearchParamsMock.mockReturnValue([currentParams, setSearchParamsMock])
+
+    const { result } = renderHook(() => useUrlSearchState())
+
+    const nextState: UrlSearchState = {
+      query: undefined,
+      location: 'Dongguan,Shenzhen',
+      keywords: ['CNC', 'Sales', 'cnc'],
+      requiredKeywords: ['Machine Tools', 'machine tools'],
+      jobDescriptionId: 'jd-456',
+      selectedTags: ['cluster:manufacturing-systems', 'Machine Tools', 'machine tools'],
+      selectedCompanies: ['FANUC', ' fanuc ', 'DMG MORI'],
+      selectedExperienceLevel: 'mid',
+      filters: {
+        minExperience: 5,
+        maxExperience: 12,
+        education: ['Bachelor', 'bachelor', 'Master'],
+        status: ['contacted', 'contacted', 'offer'],
+      },
+    }
+
+    result.current.syncToUrl(nextState)
+
+    const [updater] = setSearchParamsMock.mock.calls[0] ?? []
+    const updatedParams = updater(currentParams) as URLSearchParams
+
+    expect(updatedParams.get('sid')).toBeNull()
+    expect(updatedParams.get('kw')).toBeNull()
+    expect(updatedParams.get('keyword')).toBeNull()
+    expect(updatedParams.get('loc')).toBeNull()
+    expect(updatedParams.get('locs')).toBeNull()
+    expect(updatedParams.get('minExp')).toBeNull()
+    expect(updatedParams.get('maxExp')).toBeNull()
+
+    expect(updatedParams.get('location')).toBe('Dongguan,Shenzhen')
+    expect(updatedParams.get('q')).toBe('CNC Sales')
+    expect(updatedParams.get('rkw')).toBe('Machine Tools')
+    expect(updatedParams.get('jd')).toBe('jd-456')
+    expect(updatedParams.get('tags')).toBe('cluster:manufacturing-systems,Machine Tools')
+    expect(updatedParams.get('co')).toBe('FANUC,DMG MORI')
+    expect(updatedParams.get('exp')).toBe('mid')
+    expect(updatedParams.get('minRoleYears')).toBe('5')
+    expect(updatedParams.get('maxRoleYears')).toBe('12')
+    expect(updatedParams.get('edu')).toBe('Bachelor,Master')
+    expect(updatedParams.get('status')).toBe('contacted,offer')
   })
 })

--- a/apps/web/src/hooks/useUrlSearchState.test.ts
+++ b/apps/web/src/hooks/useUrlSearchState.test.ts
@@ -26,9 +26,10 @@ describe('useUrlSearchState location parsing', () => {
 
   it('parses canonical quoted OR phrase queries without flattening phrases', () => {
     const state = parseUrlSearchState(
-      new URLSearchParams('location=Kuala+Lumpur+MY&keyword=%22Sales+Engineer%22+OR+%22Sales+Manager%22')
+      new URLSearchParams('location=Kuala+Lumpur+MY&q=%22Sales+Engineer%22+OR+%22Sales+Manager%22')
     )
 
+    expect(state.query).toBe('"Sales Engineer" OR "Sales Manager"')
     expect(state.location).toBe('Kuala Lumpur MY')
     expect(state.filters.locations).toEqual(['Kuala Lumpur MY'])
     expect(state.keywords).toEqual(['Sales Engineer', 'Sales Manager'])
@@ -37,6 +38,7 @@ describe('useUrlSearchState location parsing', () => {
   it('keeps legacy whitespace keyword queries backward compatible', () => {
     const state = parseUrlSearchState(new URLSearchParams('keyword=CNC+%E9%94%80%E5%94%AE'))
 
+    expect(state.query).toBe('CNC 销售')
     expect(state.keywords).toEqual(['CNC', '销售'])
   })
 
@@ -62,6 +64,7 @@ describe('useUrlSearchState location parsing', () => {
     const { result } = renderHook(() => useUrlSearchState())
 
     const nextState: UrlSearchState = {
+      query: '"Sales Engineer" OR "Sales Manager"',
       location: 'Kuala Lumpur MY',
       keywords: ['Sales Engineer', 'Sales Manager'],
       requiredKeywords: [],
@@ -83,7 +86,7 @@ describe('useUrlSearchState location parsing', () => {
 
     const updatedParams = updater(new URLSearchParams()) as URLSearchParams
     expect(updatedParams.get('location')).toBe('Kuala Lumpur MY')
-    expect(updatedParams.get('keyword')).toBe('"Sales Engineer" OR "Sales Manager"')
+    expect(updatedParams.get('q')).toBe('"Sales Engineer" OR "Sales Manager"')
     expect(updatedParams.get('rkw')).toBeNull()
   })
 
@@ -94,6 +97,7 @@ describe('useUrlSearchState location parsing', () => {
     const { result } = renderHook(() => useUrlSearchState())
 
     const nextState: UrlSearchState = {
+      query: '"Sales Engineer" OR "Sales Manager"',
       location: 'Kuala Lumpur MY',
       keywords: ['Sales Engineer', 'Sales Manager'],
       requiredKeywords: ['CNC', 'machine tools'],
@@ -119,6 +123,7 @@ describe('useUrlSearchState location parsing', () => {
 
     const nextState: UrlSearchState = {
       shareSessionId: 'session-share-1',
+      query: 'CNC',
       location: 'Dongguan',
       keywords: ['CNC'],
       requiredKeywords: [],
@@ -135,6 +140,6 @@ describe('useUrlSearchState location parsing', () => {
     const updatedParams = updater(currentParams) as URLSearchParams
     expect(updatedParams.get('sid')).toBeNull()
     expect(updatedParams.get('location')).toBe('Dongguan')
-    expect(updatedParams.get('keyword')).toBe('CNC')
+    expect(updatedParams.get('q')).toBe('CNC')
   })
 })

--- a/apps/web/src/hooks/useUrlSearchState.test.ts
+++ b/apps/web/src/hooks/useUrlSearchState.test.ts
@@ -115,6 +115,61 @@ describe('useUrlSearchState location parsing', () => {
     expect(updatedParams.get('rkw')).toBe('CNC,machine tools')
   })
 
+  it('round-trips the canonical search-first state including cluster tag tokens', () => {
+    const currentParams = new URLSearchParams()
+    useSearchParamsMock.mockReturnValue([currentParams, setSearchParamsMock])
+
+    const { result } = renderHook(() => useUrlSearchState())
+
+    const nextState: UrlSearchState = {
+      query: '"Business Development" OR "Machine Tools"',
+      location: 'Kuala Lumpur MY',
+      keywords: ['Business Development', 'Machine Tools'],
+      requiredKeywords: ['CNC', 'Automation'],
+      jobDescriptionId: 'jd-123',
+      selectedTags: ['cluster:manufacturing-systems', 'Machine Tools'],
+      selectedCompanies: ['FANUC', 'DMG MORI'],
+      selectedExperienceLevel: 'senior',
+      filters: {
+        minRoleYears: 5,
+        minExperience: 5,
+        maxExperience: 12,
+        minAge: 28,
+        maxAge: 45,
+        education: ['Bachelor', 'Master'],
+        locations: ['Kuala Lumpur MY'],
+        status: ['contacted', 'offer'],
+        minMatchScore: 80,
+        sortBy: 'experience',
+        sortOrder: 'desc',
+      },
+    }
+
+    result.current.syncToUrl(nextState)
+
+    const [updater] = setSearchParamsMock.mock.calls[0] ?? []
+    const updatedParams = updater(new URLSearchParams()) as URLSearchParams
+
+    expect(updatedParams.get('q')).toBe('"Business Development" OR "Machine Tools"')
+    expect(updatedParams.get('location')).toBe('Kuala Lumpur MY')
+    expect(updatedParams.get('rkw')).toBe('CNC,Automation')
+    expect(updatedParams.get('jd')).toBe('jd-123')
+    expect(updatedParams.get('tags')).toBe('cluster:manufacturing-systems,Machine Tools')
+    expect(updatedParams.get('co')).toBe('FANUC,DMG MORI')
+    expect(updatedParams.get('exp')).toBe('senior')
+    expect(updatedParams.get('minRoleYears')).toBe('5')
+    expect(updatedParams.get('maxRoleYears')).toBe('12')
+    expect(updatedParams.get('minAge')).toBe('28')
+    expect(updatedParams.get('maxAge')).toBe('45')
+    expect(updatedParams.get('edu')).toBe('Bachelor,Master')
+    expect(updatedParams.get('status')).toBe('contacted,offer')
+    expect(updatedParams.get('minScore')).toBe('80')
+    expect(updatedParams.get('sort')).toBe('experience')
+    expect(updatedParams.get('order')).toBe('desc')
+
+    expect(parseUrlSearchState(updatedParams)).toEqual(nextState)
+  })
+
   it('removes sid when syncing explicit state back into the URL', () => {
     const currentParams = new URLSearchParams('sid=session-share-1')
     useSearchParamsMock.mockReturnValue([currentParams, setSearchParamsMock])
@@ -141,5 +196,14 @@ describe('useUrlSearchState location parsing', () => {
     expect(updatedParams.get('sid')).toBeNull()
     expect(updatedParams.get('location')).toBe('Dongguan')
     expect(updatedParams.get('q')).toBe('CNC')
+  })
+
+  it('parses raw and cluster tag tokens from legacy tags params together', () => {
+    const state = parseUrlSearchState(
+      new URLSearchParams('q=machine+tools&tags=cluster%3Amanufacturing-systems%2CMachine+Tools')
+    )
+
+    expect(state.selectedTags).toEqual(['cluster:manufacturing-systems', 'Machine Tools'])
+    expect(state.query).toBe('machine tools')
   })
 })

--- a/apps/web/src/hooks/useUrlSearchState.ts
+++ b/apps/web/src/hooks/useUrlSearchState.ts
@@ -4,6 +4,7 @@ import { useSearchParams } from 'react-router-dom'
 import type { CandidateStatus, ResumeFilters } from '@/types/resume'
 
 const KNOWN_PARAM_KEYS = [
+  'q',
   'loc',
   'location',
   'kw',
@@ -32,6 +33,7 @@ export type ExperienceLevelFilter = 'senior' | 'mid' | 'junior'
 
 export type UrlSearchState = {
   shareSessionId?: string
+  query?: string
   location?: string
   keywords: string[]
   requiredKeywords: string[]
@@ -187,6 +189,8 @@ export function hasKnownUrlSearchParams(searchParams: URLSearchParams): boolean 
 export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchState {
   const shareSessionIdRaw = searchParams.get('sid')
   const shareSessionId = shareSessionIdRaw?.trim() || undefined
+  const queryRaw = getFirstParam(searchParams, ['q', 'kw', 'keyword'])
+  const query = queryRaw?.trim() || undefined
   const locationRaw = getFirstParam(searchParams, ['loc', 'location'])
   const normalizedLocation = locationRaw?.trim() || ''
   const locationFromLocationParam = normalizeUniqueValues(parseLocationParam(normalizedLocation))
@@ -195,8 +199,7 @@ export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchSta
     ? locationFromLocsParam
     : locationFromLocationParam
   const location = normalizedLocation || (effectiveLocations.length > 0 ? effectiveLocations.join(',') : undefined)
-  const keywordRaw = getFirstParam(searchParams, ['kw', 'keyword'])
-  const keywords = normalizeUniqueValues(parseKeywordParam(keywordRaw))
+  const keywords = normalizeUniqueValues(parseKeywordParam(query ?? null))
   const requiredKeywords = normalizeUniqueValues(parseCsvParam(searchParams.get('rkw')))
   const jobDescriptionRaw = searchParams.get('jd')
   const jobDescriptionId = jobDescriptionRaw?.trim() || undefined
@@ -263,6 +266,7 @@ export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchSta
 
   return {
     shareSessionId,
+    query,
     location,
     keywords,
     requiredKeywords,
@@ -276,7 +280,8 @@ export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchSta
 
 export function useUrlSearchState() {
   const [searchParams, setSearchParams] = useSearchParams()
-  const hasKeywordParam = searchParams.has('kw')
+  const hasKeywordParam = searchParams.has('q')
+    || searchParams.has('kw')
     || searchParams.has('keyword')
   const hasJobDescriptionParam = searchParams.has('jd')
 
@@ -302,6 +307,7 @@ export function useUrlSearchState() {
         const normalizedKeywords = normalizeUniqueValues(state.keywords)
         const normalizedTags = normalizeUniqueValues(state.selectedTags)
         const normalizedCompanies = normalizeUniqueValues(state.selectedCompanies)
+        const normalizedQuery = state.query?.trim()
         const hasKeywords = normalizedKeywords.length > 0
 
         const normalizedLocation = state.location?.trim()
@@ -316,7 +322,7 @@ export function useUrlSearchState() {
           ? locationForUrlParts.join(',')
           : normalizedLocation
         setParam(nextParams, 'location', locationForUrl)
-        setParam(nextParams, 'keyword', hasKeywords ? formatKeywordQuery(normalizedKeywords) : undefined)
+        setParam(nextParams, 'q', normalizedQuery || (hasKeywords ? formatKeywordQuery(normalizedKeywords) : undefined))
         const normalizedRequiredKeywords = normalizeUniqueValues(state.requiredKeywords)
         setParam(nextParams, 'rkw', normalizedRequiredKeywords.length > 0 ? normalizedRequiredKeywords.join(',') : undefined)
         setParam(nextParams, 'jd', state.jobDescriptionId?.trim())

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -112,6 +112,235 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/taxonomy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List taxonomy clusters for the current workspace */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Taxonomy clusters */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            items: {
+                                id: string;
+                                workspaceSlug: string;
+                                name: string;
+                                slug: string;
+                                parentSlug?: string;
+                                tags: string[];
+                                /** @enum {string} */
+                                source: "human" | "ai" | "merged";
+                                confidence?: number;
+                                /** @enum {string} */
+                                status: "active" | "draft" | "archived";
+                                createdAt: number;
+                                updatedAt: number;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create or update a taxonomy cluster */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        id?: string;
+                        name: string;
+                        slug: string;
+                        parentSlug?: string;
+                        tags: string[];
+                        /**
+                         * @default human
+                         * @enum {string}
+                         */
+                        source?: "human" | "ai" | "merged";
+                        confidence?: number;
+                        /**
+                         * @default active
+                         * @enum {string}
+                         */
+                        status?: "active" | "draft" | "archived";
+                    };
+                };
+            };
+            responses: {
+                /** @description Updated taxonomy clusters */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            items: {
+                                id: string;
+                                workspaceSlug: string;
+                                name: string;
+                                slug: string;
+                                parentSlug?: string;
+                                tags: string[];
+                                /** @enum {string} */
+                                source: "human" | "ai" | "merged";
+                                confidence?: number;
+                                /** @enum {string} */
+                                status: "active" | "draft" | "archived";
+                                createdAt: number;
+                                updatedAt: number;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/taxonomy/suggest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create draft taxonomy suggestions from uncategorized resume tags */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        limit?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Suggested taxonomy clusters */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            items: {
+                                id: string;
+                                workspaceSlug: string;
+                                name: string;
+                                slug: string;
+                                parentSlug?: string;
+                                tags: string[];
+                                /** @enum {string} */
+                                source: "human" | "ai" | "merged";
+                                confidence?: number;
+                                /** @enum {string} */
+                                status: "active" | "draft" | "archived";
+                                createdAt: number;
+                                updatedAt: number;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/taxonomy/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a taxonomy cluster */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Remaining taxonomy clusters */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            items: {
+                                id: string;
+                                workspaceSlug: string;
+                                name: string;
+                                slug: string;
+                                parentSlug?: string;
+                                tags: string[];
+                                /** @enum {string} */
+                                source: "human" | "ai" | "merged";
+                                confidence?: number;
+                                /** @enum {string} */
+                                status: "active" | "draft" | "archived";
+                                createdAt: number;
+                                updatedAt: number;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/trends": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -2560,6 +2560,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Keyword extraction failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
             };
         };
         delete?: never;

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -2521,6 +2521,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/job-descriptions/extract-keywords": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Extract search keywords from pasted job description text */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        text: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Extracted keywords */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            keywords: string[];
+                            model: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/job-descriptions/match": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -43,6 +43,75 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/resumes/search-summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Generate or return a cached AI summary for the current resume search result set */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        urlHash: string;
+                        query: string;
+                        location?: string;
+                        jobDescriptionId?: string;
+                        facets?: {
+                            selectedTags?: string[];
+                            selectedCompanies?: string[];
+                            selectedExperienceLevel?: string;
+                        };
+                        resultCount: number;
+                        resultSetHash: string;
+                        results: {
+                            id: string;
+                            keywords?: string[];
+                            location?: string;
+                            name: string;
+                            score?: number;
+                            snippet: string;
+                            title?: string;
+                        }[];
+                        forceRefresh?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description AI summary response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            summary: string;
+                            model: string;
+                            generatedAt: number;
+                            shouldRefresh?: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/trends": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -104,6 +104,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description AI summary generation failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
             };
         };
         delete?: never;

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -169,6 +169,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Taxonomy request failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
             };
         };
         put?: never;
@@ -227,6 +240,19 @@ export interface paths {
                                 createdAt: number;
                                 updatedAt: number;
                             }[];
+                        };
+                    };
+                };
+                /** @description Taxonomy request failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
                         };
                     };
                 };
@@ -290,6 +316,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Taxonomy request failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
             };
         };
         delete?: never;
@@ -344,6 +383,19 @@ export interface paths {
                                 createdAt: number;
                                 updatedAt: number;
                             }[];
+                        };
+                    };
+                };
+                /** @description Taxonomy request failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
                         };
                     };
                 };

--- a/apps/web/src/lib/taxonomy.test.ts
+++ b/apps/web/src/lib/taxonomy.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createTaxonomyClusterResolver,
+  fromClusterFilterToken,
+  isClusterFilterToken,
+  parseTaxonomyCluster,
+  parseTaxonomyClustersPayload,
+  toClusterFilterToken,
+} from '@/lib/taxonomy'
+
+describe('taxonomy helpers', () => {
+  it('normalizes cluster filter tokens to canonical lowercase slugs', () => {
+    expect(toClusterFilterToken(' Manufacturing Systems ')).toBe('cluster:manufacturing systems')
+    expect(isClusterFilterToken(' Cluster:Manufacturing-Systems ')).toBe(true)
+    expect(fromClusterFilterToken(' Cluster:Manufacturing-Systems ')).toBe('manufacturing-systems')
+  })
+
+  it('parses taxonomy clusters with lowercase slug lineage and normalized tags', () => {
+    expect(parseTaxonomyCluster({
+      _id: 'cluster-1',
+      workspaceSlug: 'dev',
+      name: ' Manufacturing Systems ',
+      slug: ' Manufacturing-Systems ',
+      parentSlug: ' Core-Domains ',
+      tags: [' Machine Tools ', 'machine tools', 'Automation'],
+      source: 'human',
+      confidence: 0.82,
+      status: 'active',
+      createdAt: 1,
+      updatedAt: 2,
+    })).toEqual({
+      id: 'cluster-1',
+      workspaceSlug: 'dev',
+      name: 'Manufacturing Systems',
+      slug: 'manufacturing-systems',
+      parentSlug: 'core-domains',
+      tags: ['Machine Tools', 'Automation'],
+      source: 'human',
+      confidence: 0.82,
+      status: 'active',
+      createdAt: 1,
+      updatedAt: 2,
+    })
+  })
+
+  it('returns only valid clusters from taxonomy payload envelopes', () => {
+    expect(parseTaxonomyClustersPayload({
+      success: true,
+      items: [
+        {
+          id: 'cluster-1',
+          workspaceSlug: 'dev',
+          name: 'Manufacturing Systems',
+          slug: 'manufacturing-systems',
+          tags: ['Machine Tools'],
+          source: 'human',
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 2,
+        },
+        {
+          id: 'cluster-2',
+          workspaceSlug: 'dev',
+          name: '',
+          slug: 'invalid',
+          tags: ['Automation'],
+          source: 'human',
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    })).toEqual([
+      {
+        id: 'cluster-1',
+        workspaceSlug: 'dev',
+        name: 'Manufacturing Systems',
+        slug: 'manufacturing-systems',
+        parentSlug: undefined,
+        tags: ['Machine Tools'],
+        source: 'human',
+        confidence: undefined,
+        status: 'active',
+        createdAt: 1,
+        updatedAt: 2,
+      },
+    ])
+
+    expect(parseTaxonomyClustersPayload({
+      success: false,
+      items: [],
+    })).toBeNull()
+  })
+
+  it('resolves child tags to their parent display cluster and dedupes matches case-insensitively', () => {
+    const resolver = createTaxonomyClusterResolver([
+      {
+        name: 'Manufacturing Systems',
+        slug: 'manufacturing-systems',
+        tags: [],
+      },
+      {
+        name: 'Automation Stack',
+        slug: 'automation-stack',
+        parentSlug: 'manufacturing-systems',
+        tags: ['Machine Tools', 'Automation'],
+      },
+      {
+        name: 'Go To Market',
+        slug: 'go-to-market',
+        tags: ['Sales'],
+      },
+    ])
+
+    expect(resolver.clusters).toEqual([
+      { slug: 'go-to-market', name: 'Go To Market' },
+      { slug: 'manufacturing-systems', name: 'Manufacturing Systems' },
+    ])
+    expect(resolver.clusterBySlug.get('manufacturing-systems')).toEqual({
+      slug: 'manufacturing-systems',
+      name: 'Manufacturing Systems',
+    })
+    expect(resolver.resolveTagClusters([' automation ', 'Machine Tools', 'SALES', 'sales'])).toEqual([
+      { slug: 'go-to-market', name: 'Go To Market' },
+      { slug: 'manufacturing-systems', name: 'Manufacturing Systems' },
+    ])
+  })
+})

--- a/apps/web/src/lib/taxonomy.ts
+++ b/apps/web/src/lib/taxonomy.ts
@@ -1,0 +1,272 @@
+export type TaxonomyClusterSource = 'human' | 'ai' | 'merged'
+export type TaxonomyClusterStatus = 'active' | 'draft' | 'archived'
+
+export type TaxonomyCluster = {
+  id: string
+  workspaceSlug: string
+  name: string
+  slug: string
+  parentSlug?: string
+  tags: string[]
+  source: TaxonomyClusterSource
+  confidence?: number
+  status: TaxonomyClusterStatus
+  createdAt: number
+  updatedAt: number
+}
+
+export type TaxonomyClusterInput = {
+  name: string
+  slug: string
+  parentSlug?: string
+  tags: string[]
+}
+
+export type TaxonomyFacetCluster = {
+  slug: string
+  name: string
+}
+
+export type TaxonomyClusterResolver = {
+  clusters: TaxonomyFacetCluster[]
+  clusterBySlug: Map<string, TaxonomyFacetCluster>
+  resolveTagClusters: (tags: string[] | undefined) => TaxonomyFacetCluster[]
+}
+
+export type TaxonomyClusterFormState = {
+  name: string
+  slug: string
+  parentSlug: string
+  tags: string
+  source: TaxonomyClusterSource
+  confidence: string
+  status: TaxonomyClusterStatus
+}
+
+export const CLUSTER_FILTER_PREFIX = 'cluster:'
+
+export function normalizeOptionalString(value: string | undefined): string | undefined {
+  const normalized = value?.trim()
+  return normalized && normalized.length > 0 ? normalized : undefined
+}
+
+export function normalizeStringList(values: string[] | undefined): string[] {
+  if (!Array.isArray(values) || values.length === 0) {
+    return []
+  }
+
+  const seen = new Set<string>()
+  const normalized: string[] = []
+
+  values.forEach((value) => {
+    const token = value.trim()
+    const key = token.toLowerCase()
+    if (!token || seen.has(key)) {
+      return
+    }
+
+    seen.add(key)
+    normalized.push(token)
+  })
+
+  return normalized
+}
+
+export function slugifyTaxonomyValue(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function toClusterFilterToken(slug: string): string {
+  return `${CLUSTER_FILTER_PREFIX}${slug.trim().toLowerCase()}`
+}
+
+export function isClusterFilterToken(value: string): boolean {
+  return value.trim().toLowerCase().startsWith(CLUSTER_FILTER_PREFIX)
+}
+
+export function fromClusterFilterToken(value: string): string {
+  return value.trim().slice(CLUSTER_FILTER_PREFIX.length)
+}
+
+export function createEmptyTaxonomyClusterForm(): TaxonomyClusterFormState {
+  return {
+    name: '',
+    slug: '',
+    parentSlug: '',
+    tags: '',
+    source: 'human',
+    confidence: '',
+    status: 'active',
+  }
+}
+
+export function taxonomyClusterToForm(cluster: TaxonomyCluster): TaxonomyClusterFormState {
+  return {
+    name: cluster.name,
+    slug: cluster.slug,
+    parentSlug: cluster.parentSlug ?? '',
+    tags: cluster.tags.join(', '),
+    source: cluster.source,
+    confidence: typeof cluster.confidence === 'number' ? String(cluster.confidence) : '',
+    status: cluster.status,
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+export function parseTaxonomyCluster(value: unknown): TaxonomyCluster | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = typeof value._id === 'string'
+    ? value._id
+    : typeof value.id === 'string'
+      ? value.id
+      : null
+  const workspaceSlug = typeof value.workspaceSlug === 'string' ? value.workspaceSlug : null
+  const name = typeof value.name === 'string' ? value.name.trim() : null
+  const slug = typeof value.slug === 'string' ? value.slug.trim() : null
+  const source = value.source === 'human' || value.source === 'ai' || value.source === 'merged'
+    ? value.source
+    : null
+  const status = value.status === 'active' || value.status === 'draft' || value.status === 'archived'
+    ? value.status
+    : null
+  const createdAt = typeof value.createdAt === 'number' ? value.createdAt : null
+  const updatedAt = typeof value.updatedAt === 'number' ? value.updatedAt : null
+
+  if (!id || !workspaceSlug || !name || !slug || !source || !status || createdAt === null || updatedAt === null) {
+    return null
+  }
+
+  return {
+    id,
+    workspaceSlug,
+    name,
+    slug,
+    parentSlug: typeof value.parentSlug === 'string' && value.parentSlug.trim().length > 0 ? value.parentSlug.trim() : undefined,
+    tags: Array.isArray(value.tags) ? normalizeStringList(value.tags.filter((item): item is string => typeof item === 'string')) : [],
+    source,
+    confidence: typeof value.confidence === 'number' ? value.confidence : undefined,
+    status,
+    createdAt,
+    updatedAt,
+  }
+}
+
+export function parseTaxonomyClustersPayload(payload: unknown): TaxonomyCluster[] | null {
+  if (!isRecord(payload) || payload.success !== true || !Array.isArray(payload.items)) {
+    return null
+  }
+
+  return payload.items
+    .map((item) => parseTaxonomyCluster(item))
+    .filter((item): item is TaxonomyCluster => item !== null)
+}
+
+function createFacetCluster(input: TaxonomyClusterInput): TaxonomyFacetCluster {
+  return {
+    slug: input.slug.trim().toLowerCase(),
+    name: input.name.trim(),
+  }
+}
+
+export function createTaxonomyClusterResolver(
+  clusters: TaxonomyClusterInput[] | undefined,
+): TaxonomyClusterResolver {
+  const normalizedClusters = (clusters ?? [])
+    .map((cluster) => ({
+      name: cluster.name.trim(),
+      slug: cluster.slug.trim().toLowerCase(),
+      parentSlug: normalizeOptionalString(cluster.parentSlug)?.toLowerCase(),
+      tags: normalizeStringList(cluster.tags),
+    }))
+    .filter((cluster) => cluster.name.length > 0 && cluster.slug.length > 0)
+  const sourceBySlug = new Map(normalizedClusters.map((cluster) => [cluster.slug, cluster]))
+  const displayBySlug = new Map<string, TaxonomyFacetCluster>()
+  const tagToCluster = new Map<string, TaxonomyFacetCluster>()
+
+  const resolveDisplayCluster = (
+    cluster: TaxonomyClusterInput & { slug: string; parentSlug?: string },
+    lineage = new Set<string>(),
+  ): TaxonomyFacetCluster => {
+    const cached = displayBySlug.get(cluster.slug)
+    if (cached) {
+      return cached
+    }
+
+    if (cluster.parentSlug && !lineage.has(cluster.parentSlug)) {
+      const parent = sourceBySlug.get(cluster.parentSlug)
+      if (parent) {
+        const nextLineage = new Set(lineage)
+        nextLineage.add(cluster.slug)
+        const resolvedParent = resolveDisplayCluster(parent, nextLineage)
+        displayBySlug.set(cluster.slug, resolvedParent)
+        return resolvedParent
+      }
+    }
+
+    const next = createFacetCluster(cluster)
+    displayBySlug.set(cluster.slug, next)
+    return next
+  }
+
+  normalizedClusters.forEach((cluster) => {
+    const displayCluster = resolveDisplayCluster(cluster)
+    cluster.tags.forEach((tag) => {
+      const normalizedTag = tag.trim().toLowerCase()
+      if (!normalizedTag || tagToCluster.has(normalizedTag)) {
+        return
+      }
+
+      tagToCluster.set(normalizedTag, displayCluster)
+    })
+  })
+
+  const clusterBySlug = new Map(
+    Array.from(new Set(normalizedClusters.map((cluster) => resolveDisplayCluster(cluster).slug)))
+      .map((slug) => {
+        const cluster = displayBySlug.get(slug)
+        return cluster ? [slug, cluster] : null
+      })
+      .filter((entry): entry is [string, TaxonomyFacetCluster] => entry !== null)
+      .sort((left, right) => left[1].name.localeCompare(right[1].name))
+  )
+
+  return {
+    clusters: Array.from(clusterBySlug.values()),
+    clusterBySlug,
+    resolveTagClusters: (tags) => {
+      if (!tags || tags.length === 0) {
+        return []
+      }
+
+      const seen = new Set<string>()
+      const matched: TaxonomyFacetCluster[] = []
+
+      tags.forEach((tag) => {
+        const normalizedTag = tag.trim().toLowerCase()
+        if (!normalizedTag) {
+          return
+        }
+
+        const cluster = tagToCluster.get(normalizedTag)
+        if (!cluster || seen.has(cluster.slug)) {
+          return
+        }
+
+        seen.add(cluster.slug)
+        matched.push(cluster)
+      })
+
+      return matched.sort((left, right) => left.name.localeCompare(right.name))
+    },
+  }
+}

--- a/apps/web/src/lib/taxonomy.ts
+++ b/apps/web/src/lib/taxonomy.ts
@@ -89,7 +89,7 @@ export function isClusterFilterToken(value: string): boolean {
 }
 
 export function fromClusterFilterToken(value: string): string {
-  return value.trim().slice(CLUSTER_FILTER_PREFIX.length)
+  return value.trim().slice(CLUSTER_FILTER_PREFIX.length).trim().toLowerCase()
 }
 
 export function createEmptyTaxonomyClusterForm(): TaxonomyClusterFormState {
@@ -150,8 +150,8 @@ export function parseTaxonomyCluster(value: unknown): TaxonomyCluster | null {
     id,
     workspaceSlug,
     name,
-    slug,
-    parentSlug: typeof value.parentSlug === 'string' && value.parentSlug.trim().length > 0 ? value.parentSlug.trim() : undefined,
+    slug: slug.toLowerCase(),
+    parentSlug: typeof value.parentSlug === 'string' && value.parentSlug.trim().length > 0 ? value.parentSlug.trim().toLowerCase() : undefined,
     tags: Array.isArray(value.tags) ? normalizeStringList(value.tags.filter((item): item is string => typeof item === 'string')) : [],
     source,
     confidence: typeof value.confidence === 'number' ? value.confidence : undefined,

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -1,0 +1,335 @@
+import { formatKeywordQuery } from '@trends/shared'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ResumeSearchPage } from './ResumeSearchPage'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+import type { UrlSearchState } from '@/hooks/useUrlSearchState'
+
+const {
+  useAiSearchSummaryMock,
+  useResumeSearchStateMock,
+} = vi.hoisted(() => ({
+  useAiSearchSummaryMock: vi.fn(),
+  useResumeSearchStateMock: vi.fn(),
+}))
+
+vi.mock('@/hooks/useAiSearchSummary', () => ({
+  useAiSearchSummary: (...args: unknown[]) => useAiSearchSummaryMock(...args),
+}))
+
+vi.mock('@/hooks/useResumeSearchState', () => ({
+  useResumeSearchState: () => useResumeSearchStateMock(),
+}))
+
+vi.mock('@/components/search/MigrationBanner', () => ({
+  MigrationBanner: () => <div>Migration Banner</div>,
+}))
+
+vi.mock('@/components/search/SearchHero', () => ({
+  SearchHero: ({
+    queryInput,
+    onApplyExtractedKeywords,
+  }: {
+    queryInput: string
+    onApplyExtractedKeywords: (keywords: string[]) => void
+  }) => (
+    <div>
+      <div>Landing Hero {queryInput}</div>
+      <button type="button" onClick={() => onApplyExtractedKeywords(['Machine Tools', 'Business Development'])}>
+        Apply Hero JD
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('@/components/search/SearchHeader', () => ({
+  SearchHeader: ({
+    activeQuery,
+    activeResultCount,
+    onApplyExtractedKeywords,
+  }: {
+    activeQuery?: string
+    activeResultCount: number
+    onApplyExtractedKeywords: (keywords: string[]) => void
+  }) => (
+    <div>
+      <div>Header {activeQuery} {activeResultCount}</div>
+      <button type="button" onClick={() => onApplyExtractedKeywords(['Machine Tools', 'Business Development'])}>
+        Apply Header JD
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('@/components/search/FacetSidebar', () => ({
+  FacetSidebar: ({
+    selectedClusters,
+    selectedTags,
+  }: {
+    selectedClusters: string[]
+    selectedTags: string[]
+  }) => (
+    <div>
+      Sidebar clusters:{selectedClusters.join('|')} tags:{selectedTags.join('|')}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/search/FacetBadge', () => ({
+  FacetBadge: ({
+    activeCount,
+    floating,
+    onClick,
+  }: {
+    activeCount: number
+    floating?: boolean
+    onClick: () => void
+  }) => (
+    <button type="button" onClick={onClick}>
+      Facet badge {activeCount} {floating ? 'floating' : 'inline'}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/search/MobileFilterSheet', () => ({
+  MobileFilterSheet: ({
+    open,
+    selectedClusters,
+    selectedTags,
+  }: {
+    open: boolean
+    selectedClusters: string[]
+    selectedTags: string[]
+  }) => (
+    <div>
+      Mobile Filter Sheet {open ? 'open' : 'closed'} clusters:{selectedClusters.join('|')} tags:{selectedTags.join('|')}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/search/AiSummaryPanel', () => ({
+  AiSummaryPanel: ({
+    generatedAt,
+    loading,
+    summary,
+  }: {
+    generatedAt?: number
+    loading?: boolean
+    summary?: string
+  }) => (
+    <div>
+      AI Summary {summary ?? 'none'} generated:{generatedAt ?? 'none'} loading:{String(loading)}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/search/SearchResultsList', () => ({
+  SearchResultsList: ({
+    items,
+  }: {
+    items: ResumeSearchResultItem[]
+  }) => <div>Results List {items.length}</div>,
+}))
+
+function createResume(index: number): ConvexResumeItem {
+  return {
+    resumeId: `resume-${index}` as ConvexResumeItem['resumeId'],
+    externalId: `resume-${index}`,
+    name: `Candidate ${index}`,
+    profileUrl: '',
+    activityStatus: '',
+    age: '',
+    ageNumber: 30,
+    experience: '5 years',
+    education: 'Bachelor',
+    location: 'Kuala Lumpur',
+    extractedAt: new Date().toISOString(),
+    expectedSalary: '',
+    jobIntention: '',
+    selfIntro: '',
+    skills: [],
+    workHistory: [],
+    source: 'seek',
+    crawledAt: Date.now(),
+    tags: [],
+    ingestData: {
+      industryTags: ['Machine Tools'],
+      synonymHits: [],
+      brandHits: [],
+      companyHits: ['FANUC'],
+      ruleScores: {},
+      experienceLevel: 'senior',
+      computedAt: Date.now(),
+      skillsVersion: 1,
+    },
+  }
+}
+
+function createResult(index: number): ResumeSearchResultItem {
+  return {
+    key: `resume-${index}`,
+    identityKey: `identity-${index}`,
+    blocked: false,
+    score: 80 + index,
+    status: 'new',
+    resume: createResume(index),
+  }
+}
+
+function createParsedState(overrides: Partial<UrlSearchState> = {}): UrlSearchState {
+  return {
+    query: undefined,
+    location: undefined,
+    keywords: [],
+    requiredKeywords: [],
+    jobDescriptionId: undefined,
+    selectedTags: [],
+    selectedCompanies: [],
+    selectedExperienceLevel: undefined,
+    filters: {},
+    ...overrides,
+  }
+}
+
+function createResumeSearchState(overrides: Record<string, unknown> = {}) {
+  return {
+    activeQuery: undefined,
+    activeSort: 'relevance',
+    applyRecentSearch: vi.fn(),
+    clearFacetFilters: vi.fn(),
+    clearSearch: vi.fn(),
+    facetCounts: {
+      clusters: [],
+      tags: [],
+      companies: [],
+      experienceLevels: [],
+      education: [],
+      statuses: [],
+      minScoreOptions: [],
+    },
+    filterCount: 0,
+    filteredResults: [] as ResumeSearchResultItem[],
+    hasMore: false,
+    isLanding: true,
+    loading: false,
+    loadingMore: false,
+    loadMore: vi.fn(),
+    parsedState: createParsedState(),
+    queryInput: '',
+    recentSearches: [],
+    searchHistoryLoading: false,
+    selectedClusterTags: [] as string[],
+    selectedRawTags: [] as string[],
+    setMinScoreFilter: vi.fn(),
+    setQueryInput: vi.fn(),
+    setSelectedExperienceLevel: vi.fn(),
+    setSort: vi.fn(),
+    submitSearch: vi.fn(),
+    taxonomyClusters: [] as Array<{ name: string; slug: string; tags: string[]; parentSlug?: string }>,
+    toggleCompany: vi.fn(),
+    toggleCluster: vi.fn(),
+    toggleEducation: vi.fn(),
+    toggleStatus: vi.fn(),
+    toggleTag: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('ResumeSearchPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAiSearchSummaryMock.mockReturnValue({
+      generatedAt: undefined,
+      loading: false,
+      summary: undefined,
+    })
+  })
+
+  it('renders the landing hero and routes extracted JD keywords into canonical search state', async () => {
+    const user = userEvent.setup()
+    const state = createResumeSearchState({
+      queryInput: 'machine tools',
+    })
+    useResumeSearchStateMock.mockReturnValue(state)
+
+    render(<ResumeSearchPage />)
+
+    expect(screen.getByText('Migration Banner')).toBeInTheDocument()
+    expect(screen.getByText('Landing Hero machine tools')).toBeInTheDocument()
+    expect(screen.queryByText(/Header /)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Results List/)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Apply Hero JD' }))
+
+    const expectedQuery = formatKeywordQuery(['Machine Tools', 'Business Development'])
+    expect(state.setQueryInput).toHaveBeenCalledWith(expectedQuery)
+    expect(state.submitSearch).toHaveBeenCalledWith(expectedQuery)
+  })
+
+  it('renders the active results shell, maps cluster names for AI summary, and opens the mobile filter sheet from the badge', async () => {
+    const user = userEvent.setup()
+    const state = createResumeSearchState({
+      activeQuery: 'machine tools',
+      filterCount: 3,
+      filteredResults: [createResult(1), createResult(2)],
+      isLanding: false,
+      parsedState: createParsedState({
+        jobDescriptionId: 'jd-1',
+        location: 'Kuala Lumpur',
+        selectedCompanies: ['FANUC'],
+        selectedExperienceLevel: 'senior',
+        selectedTags: ['cluster:manufacturing-systems', 'Machine Tools'],
+        filters: {
+          education: ['Bachelor'],
+          minMatchScore: 80,
+          status: ['contacted'],
+        },
+      }),
+      queryInput: 'machine tools',
+      selectedClusterTags: ['manufacturing-systems'],
+      selectedRawTags: ['Machine Tools'],
+      taxonomyClusters: [
+        {
+          name: 'Manufacturing Systems',
+          slug: 'manufacturing-systems',
+          tags: ['Machine Tools'],
+        },
+      ],
+    })
+    useResumeSearchStateMock.mockReturnValue(state)
+    useAiSearchSummaryMock.mockReturnValue({
+      generatedAt: 123,
+      loading: false,
+      summary: 'Summary text',
+    })
+
+    render(<ResumeSearchPage />)
+
+    expect(screen.queryByText(/Landing Hero/)).not.toBeInTheDocument()
+    expect(screen.getByText('Header machine tools 2')).toBeInTheDocument()
+    expect(screen.getByText('Results List 2')).toBeInTheDocument()
+    expect(screen.getByText('Sidebar clusters:manufacturing-systems tags:Machine Tools')).toBeInTheDocument()
+    expect(screen.getByText('Mobile Filter Sheet closed clusters:manufacturing-systems tags:Machine Tools')).toBeInTheDocument()
+    expect(screen.getByText('AI Summary Summary text generated:123 loading:false')).toBeInTheDocument()
+
+    expect(useAiSearchSummaryMock).toHaveBeenCalledWith(expect.objectContaining({
+      query: 'machine tools',
+      location: 'Kuala Lumpur',
+      jobDescriptionId: 'jd-1',
+      selectedCompanies: ['FANUC'],
+      selectedExperienceLevel: 'senior',
+      selectedTags: ['Machine Tools', 'Manufacturing Systems'],
+      results: state.filteredResults,
+    }))
+
+    await user.click(screen.getByRole('button', { name: 'Apply Header JD' }))
+    const expectedQuery = formatKeywordQuery(['Machine Tools', 'Business Development'])
+    expect(state.setQueryInput).toHaveBeenCalledWith(expectedQuery)
+    expect(state.submitSearch).toHaveBeenCalledWith(expectedQuery)
+
+    await user.click(screen.getByRole('button', { name: 'Facet badge 3 inline' }))
+    expect(screen.getByText('Mobile Filter Sheet open clusters:manufacturing-systems tags:Machine Tools')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -1,0 +1,174 @@
+import { useMemo, useState } from 'react'
+import { AiSummaryPanel } from '@/components/search/AiSummaryPanel'
+import { FacetBadge } from '@/components/search/FacetBadge'
+import { FacetSidebar } from '@/components/search/FacetSidebar'
+import { MigrationBanner } from '@/components/search/MigrationBanner'
+import { MobileFilterSheet } from '@/components/search/MobileFilterSheet'
+import { SearchHeader } from '@/components/search/SearchHeader'
+import { SearchHero } from '@/components/search/SearchHero'
+import { SearchResultsList } from '@/components/search/SearchResultsList'
+import { useAiSearchSummary } from '@/hooks/useAiSearchSummary'
+import { useResumeSearchState } from '@/hooks/useResumeSearchState'
+
+export function ResumeSearchPage() {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+  const [filtersOpen, setFiltersOpen] = useState(false)
+  const {
+    activeQuery,
+    activeSort,
+    applyRecentSearch,
+    clearFacetFilters,
+    clearSearch,
+    facetCounts,
+    filterCount,
+    filteredResults,
+    hasMore,
+    isLanding,
+    loading,
+    loadingMore,
+    loadMore,
+    parsedState,
+    queryInput,
+    recentSearches,
+    searchHistoryLoading,
+    setMinScoreFilter,
+    setQueryInput,
+    setSelectedExperienceLevel,
+    setSort,
+    submitSearch,
+    toggleCompany,
+    toggleEducation,
+    toggleStatus,
+    toggleTag,
+  } = useResumeSearchState()
+  const aiSummary = useAiSearchSummary({
+    query: activeQuery,
+    location: parsedState.location,
+    jobDescriptionId: parsedState.jobDescriptionId,
+    selectedTags: parsedState.selectedTags,
+    selectedCompanies: parsedState.selectedCompanies,
+    selectedExperienceLevel: parsedState.selectedExperienceLevel,
+    results: filteredResults,
+  })
+
+  const mobileFilterProps = useMemo(() => ({
+    facetCounts,
+    minScore: parsedState.filters.minMatchScore,
+    selectedTags: parsedState.selectedTags,
+    selectedCompanies: parsedState.selectedCompanies,
+    selectedExperienceLevel: parsedState.selectedExperienceLevel,
+    selectedEducation: parsedState.filters.education ?? [],
+    selectedStatuses: parsedState.filters.status ?? [],
+    onToggleTag: toggleTag,
+    onToggleCompany: toggleCompany,
+    onSetExperienceLevel: setSelectedExperienceLevel,
+    onToggleEducation: toggleEducation,
+    onToggleStatus: toggleStatus,
+    onSetMinScore: setMinScoreFilter,
+    onClearAll: clearFacetFilters,
+  }), [
+    clearFacetFilters,
+    facetCounts,
+    parsedState.filters.education,
+    parsedState.filters.minMatchScore,
+    parsedState.filters.status,
+    parsedState.selectedCompanies,
+    parsedState.selectedExperienceLevel,
+    parsedState.selectedTags,
+    setMinScoreFilter,
+    setSelectedExperienceLevel,
+    toggleCompany,
+    toggleEducation,
+    toggleStatus,
+    toggleTag,
+  ])
+
+  return (
+    <div className="space-y-6">
+      <MigrationBanner />
+
+      {isLanding ? (
+        <SearchHero
+          loading={loading}
+          queryInput={queryInput}
+          recentSearches={recentSearches}
+          recentSearchesLoading={searchHistoryLoading}
+          onApplyRecentSearch={applyRecentSearch}
+          onChangeQuery={setQueryInput}
+          onClearQuery={clearSearch}
+          onSubmitQuery={submitSearch}
+        />
+      ) : (
+        <>
+          <SearchHeader
+            activeQuery={activeQuery}
+            activeResultCount={filteredResults.length}
+            jobDescriptionId={parsedState.jobDescriptionId}
+            loading={loading}
+            location={parsedState.location}
+            queryInput={queryInput}
+            recentSearches={recentSearches}
+            sortValue={activeSort}
+            onApplyRecentSearch={applyRecentSearch}
+            onChangeQuery={setQueryInput}
+            onClearQuery={clearSearch}
+            onSubmitQuery={submitSearch}
+            onSortChange={setSort}
+          />
+
+          <div className="flex gap-6">
+            <div className="hidden w-72 shrink-0 min-[1440px]:block">
+              <div className="sticky top-24">
+                <FacetSidebar {...mobileFilterProps} />
+              </div>
+            </div>
+
+            <div className="hidden shrink-0 md:block min-[1440px]:hidden">
+              <div className="sticky top-24">
+                <FacetBadge activeCount={filterCount} onClick={() => setFiltersOpen(true)} />
+              </div>
+            </div>
+
+            <div className="min-w-0 flex-1 space-y-4">
+              <AiSummaryPanel
+                generatedAt={aiSummary.generatedAt}
+                loading={aiSummary.loading}
+                summary={aiSummary.summary}
+              />
+
+              <SearchResultsList
+                expandedIds={expandedIds}
+                hasMore={hasMore}
+                items={filteredResults}
+                loading={loading}
+                loadingMore={loadingMore}
+                onLoadMore={loadMore}
+                onToggleExpanded={(key) => {
+                  setExpandedIds((current) => {
+                    const next = new Set(current)
+                    if (next.has(key)) {
+                      next.delete(key)
+                    } else {
+                      next.add(key)
+                    }
+                    return next
+                  })
+                }}
+              />
+            </div>
+          </div>
+
+          <div className="fixed bottom-5 right-5 z-30 md:hidden">
+            <FacetBadge floating activeCount={filterCount} onClick={() => setFiltersOpen(true)} />
+          </div>
+
+          <MobileFilterSheet
+            open={filtersOpen}
+            onOpenChange={setFiltersOpen}
+            {...mobileFilterProps}
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -1,3 +1,4 @@
+import { formatKeywordQuery } from '@trends/shared'
 import { useMemo, useState } from 'react'
 import { AiSummaryPanel } from '@/components/search/AiSummaryPanel'
 import { FacetBadge } from '@/components/search/FacetBadge'
@@ -64,6 +65,11 @@ export function ResumeSearchPage() {
     selectedExperienceLevel: parsedState.selectedExperienceLevel,
     results: filteredResults,
   })
+  const applyExtractedKeywords = (keywords: string[]) => {
+    const query = formatKeywordQuery(keywords)
+    setQueryInput(query)
+    submitSearch(query)
+  }
 
   const mobileFilterProps = useMemo(() => ({
     facetCounts,
@@ -112,6 +118,7 @@ export function ResumeSearchPage() {
           recentSearches={recentSearches}
           recentSearchesLoading={searchHistoryLoading}
           onApplyRecentSearch={applyRecentSearch}
+          onApplyExtractedKeywords={applyExtractedKeywords}
           onChangeQuery={setQueryInput}
           onClearQuery={clearSearch}
           onSubmitQuery={submitSearch}
@@ -128,6 +135,7 @@ export function ResumeSearchPage() {
             recentSearches={recentSearches}
             sortValue={activeSort}
             onApplyRecentSearch={applyRecentSearch}
+            onApplyExtractedKeywords={applyExtractedKeywords}
             onChangeQuery={setQueryInput}
             onClearQuery={clearSearch}
             onSubmitQuery={submitSearch}

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -31,21 +31,35 @@ export function ResumeSearchPage() {
     queryInput,
     recentSearches,
     searchHistoryLoading,
+    selectedClusterTags,
+    selectedRawTags,
     setMinScoreFilter,
     setQueryInput,
     setSelectedExperienceLevel,
     setSort,
     submitSearch,
+    taxonomyClusters,
     toggleCompany,
+    toggleCluster,
     toggleEducation,
     toggleStatus,
     toggleTag,
   } = useResumeSearchState()
+  const selectedSummaryTags = useMemo(() => {
+    const clusterNamesBySlug = new Map(
+      taxonomyClusters.map((cluster) => [cluster.slug.trim().toLowerCase(), cluster.name]),
+    )
+
+    return [
+      ...selectedRawTags,
+      ...selectedClusterTags.map((slug) => clusterNamesBySlug.get(slug.trim().toLowerCase()) ?? slug),
+    ]
+  }, [selectedClusterTags, selectedRawTags, taxonomyClusters])
   const aiSummary = useAiSearchSummary({
     query: activeQuery,
     location: parsedState.location,
     jobDescriptionId: parsedState.jobDescriptionId,
-    selectedTags: parsedState.selectedTags,
+    selectedTags: selectedSummaryTags,
     selectedCompanies: parsedState.selectedCompanies,
     selectedExperienceLevel: parsedState.selectedExperienceLevel,
     results: filteredResults,
@@ -54,11 +68,13 @@ export function ResumeSearchPage() {
   const mobileFilterProps = useMemo(() => ({
     facetCounts,
     minScore: parsedState.filters.minMatchScore,
-    selectedTags: parsedState.selectedTags,
+    selectedClusters: selectedClusterTags,
+    selectedTags: selectedRawTags,
     selectedCompanies: parsedState.selectedCompanies,
     selectedExperienceLevel: parsedState.selectedExperienceLevel,
     selectedEducation: parsedState.filters.education ?? [],
     selectedStatuses: parsedState.filters.status ?? [],
+    onToggleCluster: toggleCluster,
     onToggleTag: toggleTag,
     onToggleCompany: toggleCompany,
     onSetExperienceLevel: setSelectedExperienceLevel,
@@ -74,10 +90,12 @@ export function ResumeSearchPage() {
     parsedState.filters.status,
     parsedState.selectedCompanies,
     parsedState.selectedExperienceLevel,
-    parsedState.selectedTags,
     setMinScoreFilter,
     setSelectedExperienceLevel,
+    selectedClusterTags,
+    selectedRawTags,
     toggleCompany,
+    toggleCluster,
     toggleEducation,
     toggleStatus,
     toggleTag,

--- a/apps/web/src/pages/ResumesPage.tsx
+++ b/apps/web/src/pages/ResumesPage.tsx
@@ -1,5 +1,5 @@
-import { ResumeList } from '@/components/ResumeList'
+import { ResumeSearchPage } from '@/pages/ResumeSearchPage'
 
 export function ResumesPage() {
-  return <ResumeList />
+  return <ResumeSearchPage />
 }

--- a/apps/web/src/pages/system-settings/SystemSettingsTaxonomyPage.test.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsTaxonomyPage.test.tsx
@@ -1,0 +1,221 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SystemSettingsTaxonomyPage } from './SystemSettingsTaxonomyPage'
+import type { TaxonomyCluster } from '@/lib/taxonomy'
+
+const {
+  requestJsonMock,
+  toastSuccessMock,
+  toastErrorMock,
+} = vi.hoisted(() => ({
+  requestJsonMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}))
+
+const tMock = (key: string, options?: string | { defaultValue?: string; [key: string]: unknown }) => {
+  if (typeof options === 'string') {
+    return options
+  }
+
+  return options?.defaultValue ?? key
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: tMock,
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}))
+
+vi.mock('@/pages/system-settings/lib', async () => {
+  const actual = await vi.importActual<typeof import('@/pages/system-settings/lib')>('@/pages/system-settings/lib')
+  return {
+    ...actual,
+    useSettingsRequestJson: () => ({
+      requestJson: requestJsonMock,
+    }),
+  }
+})
+
+function buildCluster(overrides: Partial<TaxonomyCluster> = {}): TaxonomyCluster {
+  const id = overrides.id ?? 'cluster-1'
+  const slug = overrides.slug ?? 'manufacturing-systems'
+  const name = overrides.name ?? 'Manufacturing Systems'
+
+  return {
+    id,
+    workspaceSlug: overrides.workspaceSlug ?? 'dev',
+    name,
+    slug,
+    parentSlug: overrides.parentSlug,
+    tags: overrides.tags ?? ['Machine Tools', 'Automation'],
+    source: overrides.source ?? 'human',
+    confidence: overrides.confidence,
+    status: overrides.status ?? 'active',
+    createdAt: overrides.createdAt ?? 1,
+    updatedAt: overrides.updatedAt ?? 2,
+  }
+}
+
+function buildPayload(items: TaxonomyCluster[]) {
+  return {
+    success: true,
+    items: items.map((item) => ({
+      id: item.id,
+      workspaceSlug: item.workspaceSlug,
+      name: item.name,
+      slug: item.slug,
+      parentSlug: item.parentSlug,
+      tags: item.tags,
+      source: item.source,
+      confidence: item.confidence,
+      status: item.status,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    })),
+  }
+}
+
+describe('SystemSettingsTaxonomyPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads and renders the existing taxonomy registry', async () => {
+    requestJsonMock.mockResolvedValueOnce(buildPayload([
+      buildCluster(),
+      buildCluster({
+        id: 'cluster-2',
+        slug: 'draft-coverage',
+        name: 'Draft Coverage',
+        source: 'ai',
+        status: 'draft',
+        tags: ['Robotics'],
+      }),
+    ]))
+
+    render(<SystemSettingsTaxonomyPage />)
+
+    expect(requestJsonMock).toHaveBeenCalledWith('/api/taxonomy')
+    expect(await screen.findByText('Manufacturing Systems')).toBeInTheDocument()
+    expect(screen.getByText('Draft Coverage')).toBeInTheDocument()
+    expect(screen.getByText('Cluster registry')).toBeInTheDocument()
+  })
+
+  it('creates a new taxonomy cluster with normalized payload fields', async () => {
+    const user = userEvent.setup()
+    const existingCluster = buildCluster()
+    const newCluster = buildCluster({
+      id: 'cluster-2',
+      slug: 'backend-languages',
+      name: 'Backend Languages',
+      tags: ['Go', 'Java', 'Rust'],
+      confidence: 0.75,
+    })
+
+    requestJsonMock
+      .mockResolvedValueOnce(buildPayload([existingCluster]))
+      .mockResolvedValueOnce(buildPayload([existingCluster, newCluster]))
+
+    render(<SystemSettingsTaxonomyPage />)
+
+    expect(await screen.findByText('Manufacturing Systems')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'New Cluster' }))
+    await user.type(screen.getByPlaceholderText('Backend Languages'), 'Backend Languages')
+    expect(screen.getByDisplayValue('backend-languages')).toBeInTheDocument()
+    await user.type(screen.getByPlaceholderText('Go, Java, Rust'), 'Go, Java, Rust')
+    await user.type(screen.getByPlaceholderText('0.75'), '0.75')
+    await user.click(screen.getByRole('button', { name: 'Create Cluster' }))
+
+    await waitFor(() => {
+      expect(requestJsonMock).toHaveBeenCalledWith('/api/taxonomy', expect.objectContaining({
+        method: 'POST',
+      }))
+    })
+
+    const saveCall = requestJsonMock.mock.calls.find((call) => call[0] === '/api/taxonomy' && call[1]?.method === 'POST')
+    const body = JSON.parse(String(saveCall?.[1]?.body))
+
+    expect(body).toEqual({
+      name: 'Backend Languages',
+      slug: 'backend-languages',
+      tags: ['Go', 'Java', 'Rust'],
+      source: 'human',
+      confidence: 0.75,
+      status: 'active',
+    })
+    expect(await screen.findByText('Backend Languages')).toBeInTheDocument()
+    expect(toastSuccessMock).toHaveBeenCalledWith('debugConfig.saved')
+  })
+
+  it('deletes a taxonomy cluster with an encoded route id', async () => {
+    const user = userEvent.setup()
+    const cluster = buildCluster({
+      id: 'cluster/with slash',
+    })
+
+    requestJsonMock
+      .mockResolvedValueOnce(buildPayload([cluster]))
+      .mockResolvedValueOnce(buildPayload([]))
+
+    render(<SystemSettingsTaxonomyPage />)
+
+    expect(await screen.findByText('Manufacturing Systems')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(requestJsonMock).toHaveBeenCalledWith('/api/taxonomy/cluster%2Fwith%20slash', {
+        method: 'DELETE',
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('Manufacturing Systems')).not.toBeInTheDocument()
+    })
+    expect(toastSuccessMock).toHaveBeenCalledWith('debugConfig.saved')
+  })
+
+  it('generates draft suggestions and refreshes the registry', async () => {
+    const user = userEvent.setup()
+    const existingCluster = buildCluster()
+    const suggestedCluster = buildCluster({
+      id: 'cluster-2',
+      slug: 'robotics-platforms',
+      name: 'Robotics Platforms',
+      source: 'ai',
+      status: 'draft',
+      tags: ['Robotics', 'Cobots'],
+    })
+
+    requestJsonMock
+      .mockResolvedValueOnce(buildPayload([existingCluster]))
+      .mockResolvedValueOnce(buildPayload([suggestedCluster]))
+      .mockResolvedValueOnce(buildPayload([existingCluster, suggestedCluster]))
+
+    render(<SystemSettingsTaxonomyPage />)
+
+    expect(await screen.findByText('Manufacturing Systems')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Generate Drafts' }))
+
+    await waitFor(() => {
+      expect(requestJsonMock).toHaveBeenCalledWith('/api/taxonomy/suggest', {
+        method: 'POST',
+        body: JSON.stringify({ limit: 10 }),
+      })
+    })
+
+    expect(await screen.findByText('Robotics Platforms')).toBeInTheDocument()
+    expect(toastSuccessMock).toHaveBeenCalledWith('Generated 1 draft taxonomy suggestions')
+  })
+})

--- a/apps/web/src/pages/system-settings/SystemSettingsTaxonomyPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsTaxonomyPage.tsx
@@ -358,10 +358,13 @@ export function SystemSettingsTaxonomyPage() {
                 value={form.name}
                 onChange={(event) => {
                   const name = event.target.value
+                  const nextAutoSlug = slugifyTaxonomyValue(name)
                   setForm((current) => ({
                     ...current,
                     name,
-                    slug: current.slug ? current.slug : slugifyTaxonomyValue(name),
+                    slug: !current.slug || current.slug === slugifyTaxonomyValue(current.name)
+                      ? nextAutoSlug
+                      : current.slug,
                   }))
                 }}
                 placeholder="Backend Languages"

--- a/apps/web/src/pages/system-settings/SystemSettingsTaxonomyPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsTaxonomyPage.tsx
@@ -1,0 +1,456 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { parseOptionalNumberInput, useSettingsRequestJson } from '@/pages/system-settings/lib'
+import {
+  createEmptyTaxonomyClusterForm,
+  normalizeOptionalString,
+  parseTaxonomyClustersPayload,
+  slugifyTaxonomyValue,
+  taxonomyClusterToForm,
+  type TaxonomyCluster,
+  type TaxonomyClusterFormState,
+  type TaxonomyClusterSource,
+  type TaxonomyClusterStatus,
+} from '@/lib/taxonomy'
+
+const STATUS_OPTIONS: Array<{ value: TaxonomyClusterStatus; label: string }> = [
+  { value: 'active', label: 'Active' },
+  { value: 'draft', label: 'Draft' },
+  { value: 'archived', label: 'Archived' },
+]
+
+const SOURCE_OPTIONS: Array<{ value: TaxonomyClusterSource; label: string }> = [
+  { value: 'human', label: 'Human' },
+  { value: 'ai', label: 'AI' },
+  { value: 'merged', label: 'Merged' },
+]
+
+function buildTaxonomyPayload(form: TaxonomyClusterFormState) {
+  const tags = form.tags
+    .split(/[,，\n]+/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+
+  if (!form.name.trim() || !form.slug.trim() || tags.length === 0) {
+    throw new Error('Missing taxonomy fields')
+  }
+
+  const confidenceInput = parseOptionalNumberInput(form.confidence)
+  if (!confidenceInput.valid) {
+    throw new Error('Invalid confidence value')
+  }
+
+  return {
+    name: form.name.trim(),
+    slug: slugifyTaxonomyValue(form.slug),
+    parentSlug: normalizeOptionalString(form.parentSlug),
+    tags,
+    source: form.source,
+    confidence: confidenceInput.value,
+    status: form.status,
+  }
+}
+
+function formatSourceLabel(value: TaxonomyClusterSource): string {
+  return SOURCE_OPTIONS.find((option) => option.value === value)?.label ?? value
+}
+
+function formatStatusLabel(value: TaxonomyClusterStatus): string {
+  return STATUS_OPTIONS.find((option) => option.value === value)?.label ?? value
+}
+
+export function SystemSettingsTaxonomyPage() {
+  const { t } = useTranslation()
+  const { requestJson } = useSettingsRequestJson()
+  const [items, setItems] = useState<TaxonomyCluster[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingItem, setEditingItem] = useState<TaxonomyCluster | null>(null)
+  const [form, setForm] = useState<TaxonomyClusterFormState>(createEmptyTaxonomyClusterForm)
+  const [saving, setSaving] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [suggesting, setSuggesting] = useState(false)
+
+  const loadData = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+    try {
+      const payload = await requestJson('/api/taxonomy')
+      const parsed = parseTaxonomyClustersPayload(payload)
+      if (!parsed) {
+        throw new Error('Invalid taxonomy payload')
+      }
+      setItems(parsed)
+    } catch (error) {
+      console.error('Failed to load taxonomy clusters', error)
+      setLoadError(t('resumes.error'))
+    } finally {
+      setLoading(false)
+    }
+  }, [requestJson, t])
+
+  useEffect(() => {
+    loadData().catch((error) => {
+      console.error('Unexpected taxonomy load failure', error)
+    })
+  }, [loadData])
+
+  const statusCounts = useMemo(() => ({
+    active: items.filter((item) => item.status === 'active').length,
+    draft: items.filter((item) => item.status === 'draft').length,
+    archived: items.filter((item) => item.status === 'archived').length,
+  }), [items])
+
+  const parentSlugOptions = useMemo(() => {
+    return [
+      { value: '', label: 'None' },
+      ...items
+        .filter((item) => !editingItem || item.id !== editingItem.id)
+        .map((item) => ({ value: item.slug, label: item.name })),
+    ]
+  }, [editingItem, items])
+
+  const openCreateDialog = useCallback(() => {
+    setEditingItem(null)
+    setForm(createEmptyTaxonomyClusterForm())
+    setDialogOpen(true)
+  }, [])
+
+  const openEditDialog = useCallback((item: TaxonomyCluster) => {
+    setEditingItem(item)
+    setForm(taxonomyClusterToForm(item))
+    setDialogOpen(true)
+  }, [])
+
+  const saveCluster = useCallback(async () => {
+    setSaving(true)
+    try {
+      const body = {
+        ...(editingItem ? { id: editingItem.id } : {}),
+        ...buildTaxonomyPayload(form),
+      }
+      const payload = await requestJson('/api/taxonomy', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      })
+      const parsed = parseTaxonomyClustersPayload(payload)
+      if (!parsed) {
+        throw new Error('Invalid taxonomy save payload')
+      }
+      setItems(parsed)
+      setDialogOpen(false)
+      toast.success(t('debugConfig.saved'))
+    } catch (error) {
+      console.error('Failed to save taxonomy cluster', error)
+      toast.error(t('debugConfig.saveError'))
+    } finally {
+      setSaving(false)
+    }
+  }, [editingItem, form, requestJson, t])
+
+  const deleteCluster = useCallback(async (id: string) => {
+    setDeletingId(id)
+    try {
+      const payload = await requestJson(`/api/taxonomy/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+      })
+      const parsed = parseTaxonomyClustersPayload(payload)
+      if (!parsed) {
+        throw new Error('Invalid taxonomy delete payload')
+      }
+      setItems(parsed)
+      toast.success(t('debugConfig.saved'))
+    } catch (error) {
+      console.error('Failed to delete taxonomy cluster', error)
+      toast.error(t('debugConfig.saveError'))
+    } finally {
+      setDeletingId(null)
+    }
+  }, [requestJson, t])
+
+  const suggestClusters = useCallback(async () => {
+    setSuggesting(true)
+    try {
+      const payload = await requestJson('/api/taxonomy/suggest', {
+        method: 'POST',
+        body: JSON.stringify({ limit: 10 }),
+      })
+      const parsed = parseTaxonomyClustersPayload(payload)
+      if (!parsed) {
+        throw new Error('Invalid taxonomy suggest payload')
+      }
+      await loadData()
+      toast.success(`Generated ${parsed.length} draft taxonomy suggestions`)
+    } catch (error) {
+      console.error('Failed to suggest taxonomy clusters', error)
+      toast.error(t('debugConfig.saveError'))
+    } finally {
+      setSuggesting(false)
+    }
+  }, [loadData, requestJson, t])
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold tracking-tight">
+            {t('debugConfig.settingsNavTaxonomy', { defaultValue: 'Taxonomy' })}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {t('debugConfig.taxonomyPageDescription', {
+              defaultValue: 'Manage grouped resume skill clusters used by the search facet sidebar.',
+            })}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" onClick={() => {
+            loadData().catch((error) => {
+              console.error('Unexpected taxonomy load failure', error)
+            })
+          }} disabled={loading}>
+            {loading ? t('trends.loading') : t('common.refresh', { defaultValue: 'Refresh' })}
+          </Button>
+          <Button variant="outline" onClick={() => {
+            void suggestClusters()
+          }} disabled={suggesting}>
+            {suggesting ? 'Generating drafts...' : 'Generate Drafts'}
+          </Button>
+          <Button onClick={openCreateDialog}>New Cluster</Button>
+        </div>
+      </div>
+
+      {loadError ? (
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+          {loadError}
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Active</CardTitle>
+            <CardDescription>Visible in the search facet sidebar.</CardDescription>
+          </CardHeader>
+          <CardContent className="text-3xl font-semibold">{statusCounts.active}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Draft</CardTitle>
+            <CardDescription>Generated or staged before approval.</CardDescription>
+          </CardHeader>
+          <CardContent className="text-3xl font-semibold">{statusCounts.draft}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Archived</CardTitle>
+            <CardDescription>Kept for history but hidden from search.</CardDescription>
+          </CardHeader>
+          <CardContent className="text-3xl font-semibold">{statusCounts.archived}</CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Cluster registry</CardTitle>
+          <CardDescription>
+            Drafts can be reviewed and promoted to active clusters. Active clusters are used by the search-first resume sidebar.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="text-sm text-muted-foreground">{t('trends.loading')}</div>
+          ) : items.length === 0 ? (
+            <div className="rounded-md border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
+              No taxonomy clusters yet.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead>Parent</TableHead>
+                  <TableHead>Tags</TableHead>
+                  <TableHead className="w-[180px] text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((item) => (
+                  <TableRow key={item.id}>
+                    <TableCell className="align-top">
+                      <div className="font-medium">{item.name}</div>
+                      <div className="text-xs text-muted-foreground">{item.slug}</div>
+                    </TableCell>
+                    <TableCell className="align-top">
+                      <Badge variant={item.status === 'active' ? 'default' : 'outline'}>
+                        {formatStatusLabel(item.status)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="align-top">{formatSourceLabel(item.source)}</TableCell>
+                    <TableCell className="align-top">{item.parentSlug ?? '—'}</TableCell>
+                    <TableCell className="align-top">
+                      <div className="flex flex-wrap gap-1.5">
+                        {item.tags.slice(0, 6).map((tag) => (
+                          <Badge key={`${item.id}-${tag}`} variant="secondary">
+                            {tag}
+                          </Badge>
+                        ))}
+                        {item.tags.length > 6 ? (
+                          <Badge variant="outline">+{item.tags.length - 6}</Badge>
+                        ) : null}
+                      </div>
+                    </TableCell>
+                    <TableCell className="align-top text-right">
+                      <div className="flex justify-end gap-2">
+                        <Button variant="outline" size="sm" onClick={() => openEditDialog(item)}>
+                          Edit
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            void deleteCluster(item.id)
+                          }}
+                          disabled={deletingId === item.id}
+                        >
+                          {deletingId === item.id ? 'Deleting...' : 'Delete'}
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{editingItem ? 'Edit taxonomy cluster' : 'Create taxonomy cluster'}</DialogTitle>
+            <DialogDescription>
+              Define a stable cluster name, slug, and the raw tags that should roll up into it.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Name</label>
+              <Input
+                value={form.name}
+                onChange={(event) => {
+                  const name = event.target.value
+                  setForm((current) => ({
+                    ...current,
+                    name,
+                    slug: current.slug ? current.slug : slugifyTaxonomyValue(name),
+                  }))
+                }}
+                placeholder="Backend Languages"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Slug</label>
+              <Input
+                value={form.slug}
+                onChange={(event) => {
+                  const slug = slugifyTaxonomyValue(event.target.value)
+                  setForm((current) => ({ ...current, slug }))
+                }}
+                placeholder="backend-languages"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Status</label>
+              <Select
+                options={STATUS_OPTIONS}
+                value={form.status}
+                onChange={(event) => {
+                  setForm((current) => ({ ...current, status: event.target.value as TaxonomyClusterStatus }))
+                }}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Source</label>
+              <Select
+                options={SOURCE_OPTIONS}
+                value={form.source}
+                onChange={(event) => {
+                  setForm((current) => ({ ...current, source: event.target.value as TaxonomyClusterSource }))
+                }}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Parent Cluster</label>
+              <Select
+                options={parentSlugOptions}
+                value={form.parentSlug}
+                onChange={(event) => {
+                  setForm((current) => ({ ...current, parentSlug: event.target.value }))
+                }}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Confidence</label>
+              <Input
+                value={form.confidence}
+                onChange={(event) => {
+                  setForm((current) => ({ ...current, confidence: event.target.value }))
+                }}
+                placeholder="0.75"
+              />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label className="text-sm font-medium">Tags</label>
+              <Input
+                value={form.tags}
+                onChange={(event) => {
+                  setForm((current) => ({ ...current, tags: event.target.value }))
+                }}
+                placeholder="Go, Java, Rust"
+              />
+              <p className="text-xs text-muted-foreground">
+                Separate tags with commas. Search facets will group any matching resume tag into this cluster.
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={() => {
+              void saveCluster()
+            }} disabled={saving}>
+              {saving ? 'Saving...' : editingItem ? 'Save Changes' : 'Create Cluster'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/web/src/pages/system-settings/lib.ts
+++ b/apps/web/src/pages/system-settings/lib.ts
@@ -134,7 +134,7 @@ export interface BrandKeywordItem {
 }
 
 export type AgentNumericField = 'batchSize' | 'parallelism' | 'timeout' | 'temperature'
-export type SystemSettingsSubpageId = 'overview' | 'operations' | 'runtime' | 'config-sources' | 'keywords' | 'locations'
+export type SystemSettingsSubpageId = 'overview' | 'operations' | 'runtime' | 'config-sources' | 'keywords' | 'taxonomy' | 'locations'
 
 export interface SystemSettingsSubpageDefinition {
   id: SystemSettingsSubpageId
@@ -165,6 +165,10 @@ const SYSTEM_SETTINGS_SUBPAGE_COPY: Record<SystemSettingsSubpageId, Pick<SystemS
   keywords: {
     descriptionKey: 'debugConfig.keywordsPageDescription',
     defaultDescription: 'Manage editable keywords and review derived brand data.',
+  },
+  taxonomy: {
+    descriptionKey: 'debugConfig.taxonomyPageDescription',
+    defaultDescription: 'Manage grouped resume skill clusters used by the search facet sidebar.',
   },
   locations: {
     descriptionKey: 'debugConfig.locationsPageDescription',

--- a/packages/convex/convex/__tests__/ai_summary_cache.test.ts
+++ b/packages/convex/convex/__tests__/ai_summary_cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { cleanupExpired } from "../ai_summary_cache";
+import { cleanupExpired, get, upsert } from "../ai_summary_cache";
 
 type ConvexHandler<TArgs, TResult> = {
   _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
@@ -8,8 +8,33 @@ type ConvexHandler<TArgs, TResult> = {
 
 type CacheRecord = {
   _id: string
+  generatedAt?: number
+  summary?: string
+  workspaceSlug?: string
+  urlHash?: string
   expiresAt: number
 }
+
+const getHandler = (get as unknown as ConvexHandler<
+  { workspaceSlug: string; urlHash: string },
+  CacheRecord | null
+>)._handler
+
+const upsertHandler = (upsert as unknown as ConvexHandler<
+  {
+    urlHash: string
+    workspaceSlug: string
+    query: string
+    facets?: string
+    resultCount: number
+    resultSetHash: string
+    summary: string
+    model: string
+    generatedAt: number
+    expiresAt: number
+  },
+  string
+>)._handler
 
 const cleanupExpiredHandler = (cleanupExpired as unknown as ConvexHandler<
   { now?: number },
@@ -18,18 +43,49 @@ const cleanupExpiredHandler = (cleanupExpired as unknown as ConvexHandler<
 
 function createCacheDb(records: CacheRecord[]) {
   const deletedIds: string[] = []
+  const insertedRecords: Array<Record<string, unknown>> = []
+  const patchedRecords: Array<{ id: string; patch: Record<string, unknown> }> = []
 
   return {
     deletedIds,
+    insertedRecords,
+    patchedRecords,
     db: {
       query(tableName: string) {
         expect(tableName).toBe("ai_summary_cache")
 
         return {
+          withIndex(indexName: string, apply: (q: { eq: (field: string, value: string) => unknown }) => { clauses: Array<{ field: string; value: string }> }) {
+            expect(indexName).toBe("by_workspace_url_hash")
+            const chain = {
+              clauses: [] as Array<{ field: string; value: string }>,
+              eq(field: string, value: string) {
+                this.clauses.push({ field, value })
+                return this
+              },
+            }
+            const clauseChain = apply(chain as never)
+
+            return {
+              async collect() {
+                return records
+                  .filter((record) => clauseChain.clauses.every((clause) => record[clause.field as keyof CacheRecord] === clause.value))
+                  .map((record) => ({ ...record }))
+              },
+            }
+          },
           async collect() {
             return records.map((record) => ({ ...record }))
           },
         }
+      },
+      async insert(tableName: string, value: Record<string, unknown>) {
+        expect(tableName).toBe("ai_summary_cache")
+        insertedRecords.push(value)
+        return "inserted-cache-record"
+      },
+      async patch(id: string, patch: Record<string, unknown>) {
+        patchedRecords.push({ id, patch })
       },
       async delete(id: string) {
         deletedIds.push(id)
@@ -39,6 +95,85 @@ function createCacheDb(records: CacheRecord[]) {
 }
 
 describe("ai summary cache cleanup", () => {
+  it("scopes cache reads to the workspace-specific url hash", async () => {
+    const record = await getHandler(createCacheDb([
+      {
+        _id: "dev-cache",
+        workspaceSlug: "dev",
+        urlHash: "same-url",
+        generatedAt: 20,
+        summary: "Dev summary",
+        expiresAt: Date.UTC(2026, 2, 27, 21, 0, 0),
+      },
+      {
+        _id: "hr-cache",
+        workspaceSlug: "hr",
+        urlHash: "same-url",
+        generatedAt: 30,
+        summary: "HR summary",
+        expiresAt: Date.UTC(2026, 2, 27, 21, 0, 0),
+      },
+    ]) as never, {
+      workspaceSlug: "dev",
+      urlHash: "same-url",
+    })
+
+    expect(record?._id).toBe("dev-cache")
+    expect(record?.summary).toBe("Dev summary")
+  })
+
+  it("updates only matching workspace records during upsert", async () => {
+    const ctx = createCacheDb([
+      {
+        _id: "dev-cache",
+        workspaceSlug: "dev",
+        urlHash: "same-url",
+        generatedAt: 10,
+        summary: "Dev summary",
+        expiresAt: Date.UTC(2026, 2, 27, 20, 0, 0),
+      },
+      {
+        _id: "hr-cache",
+        workspaceSlug: "hr",
+        urlHash: "same-url",
+        generatedAt: 12,
+        summary: "HR summary",
+        expiresAt: Date.UTC(2026, 2, 27, 20, 0, 0),
+      },
+    ])
+
+    const result = await upsertHandler(ctx as never, {
+      workspaceSlug: "dev",
+      urlHash: "same-url",
+      query: "machine tools",
+      resultCount: 5,
+      resultSetHash: "result-set",
+      summary: "Updated dev summary",
+      model: "anthropic/claude-3-haiku-20240307",
+      generatedAt: 99,
+      expiresAt: Date.UTC(2026, 2, 27, 22, 0, 0),
+    })
+
+    expect(result).toBe("dev-cache")
+    expect(ctx.patchedRecords).toEqual([
+      {
+        id: "dev-cache",
+        patch: {
+          workspaceSlug: "dev",
+          urlHash: "same-url",
+          query: "machine tools",
+          resultCount: 5,
+          resultSetHash: "result-set",
+          summary: "Updated dev summary",
+          model: "anthropic/claude-3-haiku-20240307",
+          generatedAt: 99,
+          expiresAt: Date.UTC(2026, 2, 27, 22, 0, 0),
+        },
+      },
+    ])
+    expect(ctx.deletedIds).toEqual([])
+  })
+
   it("deletes only expired cache entries", async () => {
     const now = Date.UTC(2026, 2, 27, 20, 0, 0)
     const ctx = createCacheDb([

--- a/packages/convex/convex/__tests__/ai_summary_cache.test.ts
+++ b/packages/convex/convex/__tests__/ai_summary_cache.test.ts
@@ -55,27 +55,48 @@ function createCacheDb(records: CacheRecord[]) {
         expect(tableName).toBe("ai_summary_cache")
 
         return {
-          withIndex(indexName: string, apply: (q: { eq: (field: string, value: string) => unknown }) => { clauses: Array<{ field: string; value: string }> }) {
-            expect(indexName).toBe("by_workspace_url_hash")
+          withIndex(indexName: string, apply: (q: unknown) => unknown) {
+            expect(indexName === "by_workspace_url_hash" || indexName === "by_expires_at").toBe(true)
+            if (indexName === "by_workspace_url_hash") {
+              const chain = {
+                clauses: [] as Array<{ field: string; value: string }>,
+                eq(field: string, value: string) {
+                  this.clauses.push({ field, value })
+                  return this
+                },
+              }
+              const clauseChain = apply(chain as never) as { clauses: Array<{ field: string; value: string }> }
+
+              return {
+                async collect() {
+                  return records
+                    .filter((record) => clauseChain.clauses.every((clause) => record[clause.field as keyof CacheRecord] === clause.value))
+                    .map((record) => ({ ...record }))
+                },
+              }
+            }
+
             const chain = {
-              clauses: [] as Array<{ field: string; value: string }>,
-              eq(field: string, value: string) {
-                this.clauses.push({ field, value })
+              field: "" as string,
+              value: 0,
+              lte(field: string, value: number) {
+                this.field = field
+                this.value = value
                 return this
               },
             }
-            const clauseChain = apply(chain as never)
+            const clause = apply(chain as never) as { field: string; value: number }
 
             return {
               async collect() {
                 return records
-                  .filter((record) => clauseChain.clauses.every((clause) => record[clause.field as keyof CacheRecord] === clause.value))
+                  .filter((record) => {
+                    const candidate = record[clause.field as keyof CacheRecord]
+                    return typeof candidate === "number" && candidate <= clause.value
+                  })
                   .map((record) => ({ ...record }))
               },
             }
-          },
-          async collect() {
-            return records.map((record) => ({ ...record }))
           },
         }
       },

--- a/packages/convex/convex/__tests__/ai_summary_cache.test.ts
+++ b/packages/convex/convex/__tests__/ai_summary_cache.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { cleanupExpired } from "../ai_summary_cache";
+
+type ConvexHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+type CacheRecord = {
+  _id: string
+  expiresAt: number
+}
+
+const cleanupExpiredHandler = (cleanupExpired as unknown as ConvexHandler<
+  { now?: number },
+  { deleted: number }
+>)._handler
+
+function createCacheDb(records: CacheRecord[]) {
+  const deletedIds: string[] = []
+
+  return {
+    deletedIds,
+    db: {
+      query(tableName: string) {
+        expect(tableName).toBe("ai_summary_cache")
+
+        return {
+          async collect() {
+            return records.map((record) => ({ ...record }))
+          },
+        }
+      },
+      async delete(id: string) {
+        deletedIds.push(id)
+      },
+    },
+  }
+}
+
+describe("ai summary cache cleanup", () => {
+  it("deletes only expired cache entries", async () => {
+    const now = Date.UTC(2026, 2, 27, 20, 0, 0)
+    const ctx = createCacheDb([
+      { _id: "expired-1", expiresAt: now - 5_000 },
+      { _id: "active-1", expiresAt: now + 5_000 },
+      { _id: "expired-2", expiresAt: now },
+    ])
+
+    const result = await cleanupExpiredHandler(ctx as never, { now })
+
+    expect(result).toEqual({ deleted: 2 })
+    expect(ctx.deletedIds).toEqual(["expired-1", "expired-2"])
+  })
+})

--- a/packages/convex/convex/__tests__/sessions.test.ts
+++ b/packages/convex/convex/__tests__/sessions.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { backfillWorkspaceSlugs } from '../migrations'
-import { DEFAULT_WORKSPACE_SLUG, listSearchHistory } from '../sessions'
+import { DEFAULT_WORKSPACE_SLUG, listSearchHistory, recentSearches } from '../sessions'
 
 type BackfillWorkspaceSlugsResult = {
   defaultWorkspace: string
@@ -17,6 +17,11 @@ type ConvexHandler<TArgs, TResult> = {
 
 const listSearchHistoryHandler = (listSearchHistory as unknown as ConvexHandler<
   { workspaceSlug?: string },
+  SearchHistoryRecord[]
+>)._handler
+
+const recentSearchesHandler = (recentSearches as unknown as ConvexHandler<
+  { sessionKey: string; workspaceSlug?: string; limit?: number },
   SearchHistoryRecord[]
 >)._handler
 
@@ -62,26 +67,26 @@ function createSearchHistoryDb(records: SearchHistoryRecord[]) {
     db: {
       query(tableName: string): QueryBuilder {
         if (tableName === 'search_history') {
-          const buildRecords = (workspaceSlug?: string) => {
-            const next = workspaceSlug === undefined
+          const buildRecords = (fieldName?: string, value?: string) => {
+            const next = value === undefined
               ? records
-              : records.filter((record) => record.workspaceSlug === workspaceSlug)
+              : records.filter((record) => record[fieldName as keyof SearchHistoryRecord] === value)
             return next.map((record) => ({ ...record }))
           }
 
           return {
             withIndex(indexName, apply) {
-              expect(indexName).toBe('by_workspace')
+              expect(indexName === 'by_workspace' || indexName === 'by_sessionKey').toBe(true)
               const clause = apply({
                 eq(field, value) {
                   return { field, value }
                 },
               }) as { field: string; value: string }
-              expect(clause.field).toBe('workspaceSlug')
+              expect(clause.field === 'workspaceSlug' || clause.field === 'sessionKey').toBe(true)
 
               return {
                 async collect() {
-                  return buildRecords(clause.value)
+                  return buildRecords(clause.field, clause.value)
                 },
               }
             },
@@ -198,5 +203,57 @@ describe('search history workspace rollout safety', () => {
 
     const hrResults = await listSearchHistoryHandler(ctx as never, { workspaceSlug: 'hr' })
     expect(hrResults.map((record) => record._id)).toEqual(['hr-history'])
+  })
+
+  it('returns the most recent searches for the active session only', async () => {
+    const now = Date.UTC(2026, 2, 27, 11, 0, 0)
+    const records: SearchHistoryRecord[] = [
+      {
+        _id: 'session-older',
+        sessionKey: 'session-a',
+        title: 'Older search',
+        location: 'Malaysia',
+        keywords: ['CNC'],
+        workspaceSlug: DEFAULT_WORKSPACE_SLUG,
+        createdAt: now - 5_000,
+      },
+      {
+        _id: 'session-newer',
+        sessionKey: 'session-a',
+        title: 'Newer search',
+        location: 'Malaysia',
+        keywords: ['Machine Tools'],
+        workspaceSlug: DEFAULT_WORKSPACE_SLUG,
+        createdAt: now - 4_000,
+        lastOpenedAt: now,
+      },
+      {
+        _id: 'other-session',
+        sessionKey: 'session-b',
+        title: 'Other session',
+        location: 'Malaysia',
+        keywords: ['Robotics'],
+        workspaceSlug: DEFAULT_WORKSPACE_SLUG,
+        createdAt: now - 1_000,
+      },
+      {
+        _id: 'other-workspace',
+        sessionKey: 'session-a',
+        title: 'Other workspace',
+        location: 'Shenzhen',
+        keywords: ['Sales'],
+        workspaceSlug: 'hr',
+        createdAt: now - 500,
+      },
+    ]
+    const ctx = createSearchHistoryDb(records)
+
+    const result = await recentSearchesHandler(ctx as never, {
+      sessionKey: 'session-a',
+      workspaceSlug: DEFAULT_WORKSPACE_SLUG,
+      limit: 1,
+    })
+
+    expect(result.map((record) => record._id)).toEqual(['session-newer'])
   })
 })

--- a/packages/convex/convex/__tests__/taxonomy_clusters.test.ts
+++ b/packages/convex/convex/__tests__/taxonomy_clusters.test.ts
@@ -1,0 +1,505 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { list, remove, suggest, upsert } from "../taxonomy_clusters"
+
+type ConvexHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+type TaxonomyRecord = {
+  _id: string
+  workspaceSlug: string
+  name: string
+  slug: string
+  parentSlug?: string
+  tags: string[]
+  source: "human" | "ai" | "merged"
+  confidence?: number
+  status: "active" | "draft" | "archived"
+  createdAt: number
+  updatedAt: number
+}
+
+type ResumeRecord = {
+  _id: string
+  ingestData?: {
+    industryTags?: string[]
+  }
+}
+
+const listHandler = (list as unknown as ConvexHandler<
+  {
+    workspaceSlug?: string
+    status?: "active" | "draft" | "archived"
+  },
+  TaxonomyRecord[]
+>)._handler
+
+const upsertHandler = (upsert as unknown as ConvexHandler<
+  {
+    id?: string
+    workspaceSlug?: string
+    name: string
+    slug: string
+    parentSlug?: string
+    tags: string[]
+    source: "human" | "ai" | "merged"
+    confidence?: number
+    status: "active" | "draft" | "archived"
+  },
+  TaxonomyRecord | null
+>)._handler
+
+const removeHandler = (remove as unknown as ConvexHandler<
+  { id: string; workspaceSlug?: string },
+  boolean
+>)._handler
+
+const suggestHandler = (suggest as unknown as ConvexHandler<
+  { workspaceSlug?: string; limit?: number },
+  TaxonomyRecord[]
+>)._handler
+
+function cloneTaxonomyRecord(record: TaxonomyRecord): TaxonomyRecord {
+  return {
+    ...record,
+    tags: [...record.tags],
+  }
+}
+
+function cloneResumeRecord(record: ResumeRecord): ResumeRecord {
+  return {
+    ...record,
+    ingestData: record.ingestData
+      ? {
+          ...record.ingestData,
+          industryTags: [...(record.ingestData.industryTags ?? [])],
+        }
+      : undefined,
+  }
+}
+
+function createTaxonomyDb(
+  taxonomyRecords: TaxonomyRecord[],
+  resumes: ResumeRecord[] = [],
+) {
+  const records = taxonomyRecords.map(cloneTaxonomyRecord)
+  const resumeRecords = resumes.map(cloneResumeRecord)
+  const insertedRecords: Array<Record<string, unknown>> = []
+  const patchedRecords: Array<{ id: string; patch: Record<string, unknown> }> = []
+  const deletedIds: string[] = []
+  let nextId = 1
+
+  return {
+    insertedRecords,
+    patchedRecords,
+    deletedIds,
+    records,
+    db: {
+      query(tableName: string) {
+        if (tableName === "taxonomy_clusters") {
+          return {
+            withIndex(
+              indexName: string,
+              apply: (
+                q: {
+                  eq: (
+                    field: string,
+                    value: string,
+                  ) => {
+                    eq: (field: string, value: string) => unknown
+                    clauses: Array<{ field: string; value: string }>
+                  }
+                },
+              ) => { clauses: Array<{ field: string; value: string }> },
+            ) {
+              expect(
+                indexName === "by_workspace" ||
+                  indexName === "by_workspace_slug" ||
+                  indexName === "by_workspace_status",
+              ).toBe(true)
+
+              const clauses: Array<{ field: string; value: string }> = []
+              const clauseBuilder: {
+                eq: (
+                  field: string,
+                  value: string,
+                ) => {
+                  eq: (field: string, value: string) => unknown
+                  clauses: Array<{ field: string; value: string }>
+                }
+                clauses: Array<{ field: string; value: string }>
+              } = {
+                clauses,
+                eq(field: string, value: string) {
+                  clauses.push({ field, value })
+                  return this
+                },
+              }
+              apply(clauseBuilder)
+
+              const matches = () =>
+                records
+                  .filter((record) =>
+                    clauses.every(
+                      (clause) => String(record[clause.field as keyof TaxonomyRecord] ?? "") === clause.value,
+                    ),
+                  )
+                  .map(cloneTaxonomyRecord)
+
+              return {
+                async collect() {
+                  return matches()
+                },
+                async unique() {
+                  return matches()[0] ?? null
+                },
+              }
+            },
+          }
+        }
+
+        if (tableName === "resumes") {
+          return {
+            async collect() {
+              return resumeRecords.map(cloneResumeRecord)
+            },
+          }
+        }
+
+        throw new Error(`Unexpected table query: ${tableName}`)
+      },
+      async get(id: string) {
+        const record = records.find((entry) => entry._id === id)
+        return record ? cloneTaxonomyRecord(record) : null
+      },
+      async patch(id: string, patch: Record<string, unknown>) {
+        patchedRecords.push({ id, patch })
+        const record = records.find((entry) => entry._id === id)
+        if (!record) {
+          throw new Error(`Missing taxonomy cluster ${id}`)
+        }
+
+        Object.assign(record, patch, {
+          tags: Array.isArray(patch.tags) ? [...(patch.tags as string[])] : record.tags,
+        })
+      },
+      async insert(tableName: string, value: Record<string, unknown>) {
+        expect(tableName).toBe("taxonomy_clusters")
+        insertedRecords.push(value)
+        const id = `cluster-new-${nextId++}`
+        records.push({
+          _id: id,
+          workspaceSlug: String(value.workspaceSlug),
+          name: String(value.name),
+          slug: String(value.slug),
+          parentSlug: typeof value.parentSlug === "string" ? value.parentSlug : undefined,
+          tags: Array.isArray(value.tags) ? [...(value.tags as string[])] : [],
+          source: value.source as TaxonomyRecord["source"],
+          confidence: typeof value.confidence === "number" ? value.confidence : undefined,
+          status: value.status as TaxonomyRecord["status"],
+          createdAt: Number(value.createdAt),
+          updatedAt: Number(value.updatedAt),
+        })
+        return id
+      },
+      async delete(id: string) {
+        deletedIds.push(id)
+        const index = records.findIndex((entry) => entry._id === id)
+        if (index >= 0) {
+          records.splice(index, 1)
+        }
+      },
+    },
+  }
+}
+
+describe("taxonomy cluster mutations", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("lists only the requested workspace and sorts by status then recency", async () => {
+    const result = await listHandler(
+      createTaxonomyDb([
+        {
+          _id: "dev-older-active",
+          workspaceSlug: "dev",
+          name: "Older Active",
+          slug: "older-active",
+          tags: ["Machine Tools"],
+          source: "human",
+          status: "active",
+          createdAt: 1,
+          updatedAt: 10,
+        },
+        {
+          _id: "dev-newer-active",
+          workspaceSlug: "dev",
+          name: "Newer Active",
+          slug: "newer-active",
+          tags: ["Automation"],
+          source: "human",
+          status: "active",
+          createdAt: 2,
+          updatedAt: 20,
+        },
+        {
+          _id: "dev-draft",
+          workspaceSlug: "dev",
+          name: "Draft",
+          slug: "draft",
+          tags: ["Robotics"],
+          source: "ai",
+          status: "draft",
+          createdAt: 3,
+          updatedAt: 30,
+        },
+        {
+          _id: "dev-archived",
+          workspaceSlug: "dev",
+          name: "Archived",
+          slug: "archived",
+          tags: ["Sales"],
+          source: "merged",
+          status: "archived",
+          createdAt: 4,
+          updatedAt: 40,
+        },
+        {
+          _id: "hr-active",
+          workspaceSlug: "hr",
+          name: "HR Active",
+          slug: "hr-active",
+          tags: ["Recruiting"],
+          source: "human",
+          status: "active",
+          createdAt: 5,
+          updatedAt: 50,
+        },
+      ]) as never,
+      { workspaceSlug: "dev" },
+    )
+
+    expect(result.map((record) => record._id)).toEqual([
+      "dev-newer-active",
+      "dev-older-active",
+      "dev-draft",
+      "dev-archived",
+    ])
+
+    const activeOnly = await listHandler(
+      createTaxonomyDb([
+        {
+          _id: "dev-active",
+          workspaceSlug: "dev",
+          name: "Active",
+          slug: "active",
+          tags: ["Automation"],
+          source: "human",
+          status: "active",
+          createdAt: 1,
+          updatedAt: 20,
+        },
+        {
+          _id: "dev-draft",
+          workspaceSlug: "dev",
+          name: "Draft",
+          slug: "draft",
+          tags: ["Robotics"],
+          source: "ai",
+          status: "draft",
+          createdAt: 2,
+          updatedAt: 10,
+        },
+      ]) as never,
+      { workspaceSlug: "dev", status: "active" },
+    )
+
+    expect(activeOnly.map((record) => record._id)).toEqual(["dev-active"])
+  })
+
+  it("normalizes slug lineage and deduplicated tags during upsert", async () => {
+    const now = Date.UTC(2026, 2, 27, 15, 0, 0)
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    const ctx = createTaxonomyDb([])
+    const result = await upsertHandler(ctx as never, {
+      workspaceSlug: "dev",
+      name: "Backend Languages",
+      slug: " Backend Languages ",
+      parentSlug: " Core Domains ",
+      tags: ["Go", "go", " Rust ", "Rust"],
+      source: "human",
+      confidence: 0.82,
+      status: "active",
+    })
+
+    expect(result?._id).toBe("cluster-new-1")
+    expect(ctx.insertedRecords).toEqual([
+      {
+        workspaceSlug: "dev",
+        name: "Backend Languages",
+        slug: "backend-languages",
+        parentSlug: "core-domains",
+        tags: ["Go", "Rust"],
+        source: "human",
+        confidence: 0.82,
+        status: "active",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ])
+  })
+
+  it("rejects cross-workspace upserts when the requested id belongs to another workspace", async () => {
+    const ctx = createTaxonomyDb([
+      {
+        _id: "hr-cluster",
+        workspaceSlug: "hr",
+        name: "HR Cluster",
+        slug: "hr-cluster",
+        tags: ["Recruiting"],
+        source: "human",
+        status: "active",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+    ])
+
+    await expect(
+      upsertHandler(ctx as never, {
+        id: "hr-cluster",
+        workspaceSlug: "dev",
+        name: "HR Cluster",
+        slug: "hr-cluster",
+        tags: ["Recruiting"],
+        source: "human",
+        status: "active",
+      }),
+    ).rejects.toThrow("Taxonomy cluster not found in workspace")
+
+    expect(ctx.patchedRecords).toEqual([])
+    expect(ctx.insertedRecords).toEqual([])
+  })
+
+  it("removes only records from the requested workspace", async () => {
+    const ctx = createTaxonomyDb([
+      {
+        _id: "dev-cluster",
+        workspaceSlug: "dev",
+        name: "Dev Cluster",
+        slug: "dev-cluster",
+        tags: ["Automation"],
+        source: "human",
+        status: "active",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      {
+        _id: "hr-cluster",
+        workspaceSlug: "hr",
+        name: "HR Cluster",
+        slug: "hr-cluster",
+        tags: ["Recruiting"],
+        source: "human",
+        status: "active",
+        createdAt: 3,
+        updatedAt: 4,
+      },
+    ])
+
+    const blocked = await removeHandler(ctx as never, {
+      id: "hr-cluster",
+      workspaceSlug: "dev",
+    })
+    expect(blocked).toBe(false)
+    expect(ctx.deletedIds).toEqual([])
+
+    const removed = await removeHandler(ctx as never, {
+      id: "dev-cluster",
+      workspaceSlug: "dev",
+    })
+    expect(removed).toBe(true)
+    expect(ctx.deletedIds).toEqual(["dev-cluster"])
+  })
+
+  it("suggests grouped drafts and merges into existing human clusters", async () => {
+    const now = Date.UTC(2026, 2, 27, 16, 0, 0)
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    const ctx = createTaxonomyDb(
+      [
+        {
+          _id: "existing-cnc",
+          workspaceSlug: "dev",
+          name: "CNC",
+          slug: "cnc",
+          tags: ["CNC Milling"],
+          source: "human",
+          confidence: 0.9,
+          status: "active",
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+      [
+        {
+          _id: "resume-1",
+          ingestData: {
+            industryTags: ["CNC Grinding", "Robotics Vision", "CNC Grinding"],
+          },
+        },
+        {
+          _id: "resume-2",
+          ingestData: {
+            industryTags: ["CNC Lathe", "Robotics Programming"],
+          },
+        },
+        {
+          _id: "resume-3",
+          ingestData: {
+            industryTags: ["Robotics Vision"],
+          },
+        },
+      ],
+    )
+
+    const result = await suggestHandler(ctx as never, {
+      workspaceSlug: "dev",
+      limit: 4,
+    })
+
+    expect(ctx.patchedRecords).toEqual([
+      {
+        id: "existing-cnc",
+        patch: {
+          tags: ["CNC Milling", "CNC Grinding", "CNC Lathe"],
+          source: "human",
+          confidence: 0.25,
+          status: "active",
+          updatedAt: now,
+        },
+      },
+    ])
+    expect(ctx.insertedRecords).toEqual([
+      {
+        workspaceSlug: "dev",
+        name: "Robotics",
+        slug: "robotics",
+        tags: ["Robotics Vision", "Robotics Programming"],
+        source: "merged",
+        confidence: 0.25,
+        status: "draft",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ])
+    expect(result.map((record) => record.slug)).toEqual(["robotics", "cnc"])
+    expect(result.find((record) => record.slug === "cnc")?.tags).toEqual([
+      "CNC Milling",
+      "CNC Grinding",
+      "CNC Lathe",
+    ])
+  })
+})

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -28,6 +28,7 @@ import type * as search_text from "../search_text.js";
 import type * as seed from "../seed.js";
 import type * as sessions from "../sessions.js";
 import type * as sync_events from "../sync_events.js";
+import type * as taxonomy_clusters from "../taxonomy_clusters.js";
 import type * as workspace_config from "../workspace_config.js";
 
 import type {
@@ -57,6 +58,7 @@ declare const fullApi: ApiFromModules<{
   seed: typeof seed;
   sessions: typeof sessions;
   sync_events: typeof sync_events;
+  taxonomy_clusters: typeof taxonomy_clusters;
   workspace_config: typeof workspace_config;
 }>;
 

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type * as analysis_tasks from "../analysis_tasks.js";
 import type * as analyze from "../analyze.js";
 import type * as candidate_blocks from "../candidate_blocks.js";
 import type * as candidate_status from "../candidate_status.js";
+import type * as crons from "../crons.js";
 import type * as ingest_agent from "../ingest_agent.js";
 import type * as job_descriptions from "../job_descriptions.js";
 import type * as lib_age from "../lib/age.js";
@@ -44,6 +45,7 @@ declare const fullApi: ApiFromModules<{
   analyze: typeof analyze;
   candidate_blocks: typeof candidate_blocks;
   candidate_status: typeof candidate_status;
+  crons: typeof crons;
   ingest_agent: typeof ingest_agent;
   job_descriptions: typeof job_descriptions;
   "lib/age": typeof lib_age;

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as ai_summary_cache from "../ai_summary_cache.js";
 import type * as ai_tagging_results from "../ai_tagging_results.js";
 import type * as analysis_tasks from "../analysis_tasks.js";
 import type * as analyze from "../analyze.js";
@@ -36,6 +37,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  ai_summary_cache: typeof ai_summary_cache;
   ai_tagging_results: typeof ai_tagging_results;
   analysis_tasks: typeof analysis_tasks;
   analyze: typeof analyze;

--- a/packages/convex/convex/ai_summary_cache.ts
+++ b/packages/convex/convex/ai_summary_cache.ts
@@ -1,4 +1,4 @@
-import { mutation, query } from "./_generated/server";
+import { internalMutation, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 
 export const get = query({
@@ -48,7 +48,7 @@ export const upsert = mutation({
     },
 });
 
-export const cleanupExpired = mutation({
+export const cleanupExpired = internalMutation({
     args: {
         now: v.optional(v.number()),
     },

--- a/packages/convex/convex/ai_summary_cache.ts
+++ b/packages/convex/convex/ai_summary_cache.ts
@@ -1,0 +1,68 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const get = query({
+    args: {
+        urlHash: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const records = await ctx.db
+            .query("ai_summary_cache")
+            .withIndex("by_url_hash", (q) => q.eq("urlHash", args.urlHash))
+            .collect();
+
+        return records.sort((left, right) => right.generatedAt - left.generatedAt)[0] ?? null;
+    },
+});
+
+export const upsert = mutation({
+    args: {
+        urlHash: v.string(),
+        workspaceSlug: v.string(),
+        query: v.string(),
+        facets: v.optional(v.string()),
+        resultCount: v.number(),
+        resultSetHash: v.string(),
+        summary: v.string(),
+        model: v.string(),
+        generatedAt: v.number(),
+        expiresAt: v.number(),
+    },
+    handler: async (ctx, args) => {
+        const existing = await ctx.db
+            .query("ai_summary_cache")
+            .withIndex("by_url_hash", (q) => q.eq("urlHash", args.urlHash))
+            .collect();
+
+        const [primaryRecord, ...duplicateRecords] = existing.sort((left, right) => right.generatedAt - left.generatedAt);
+        for (const record of duplicateRecords) {
+            await ctx.db.delete(record._id);
+        }
+
+        if (primaryRecord) {
+            await ctx.db.patch(primaryRecord._id, args);
+            return primaryRecord._id;
+        }
+
+        return await ctx.db.insert("ai_summary_cache", args);
+    },
+});
+
+export const cleanupExpired = mutation({
+    args: {
+        now: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const now = args.now ?? Date.now();
+        const records = await ctx.db.query("ai_summary_cache").collect();
+        const expiredRecords = records.filter((record) => record.expiresAt <= now);
+
+        for (const record of expiredRecords) {
+            await ctx.db.delete(record._id);
+        }
+
+        return {
+            deleted: expiredRecords.length,
+        };
+    },
+});

--- a/packages/convex/convex/ai_summary_cache.ts
+++ b/packages/convex/convex/ai_summary_cache.ts
@@ -55,8 +55,10 @@ export const cleanupExpired = internalMutation({
     },
     handler: async (ctx, args) => {
         const now = args.now ?? Date.now();
-        const records = await ctx.db.query("ai_summary_cache").collect();
-        const expiredRecords = records.filter((record) => record.expiresAt <= now);
+        const expiredRecords = await ctx.db
+            .query("ai_summary_cache")
+            .withIndex("by_expires_at", (q) => q.lte("expiresAt", now))
+            .collect();
 
         for (const record of expiredRecords) {
             await ctx.db.delete(record._id);

--- a/packages/convex/convex/ai_summary_cache.ts
+++ b/packages/convex/convex/ai_summary_cache.ts
@@ -3,12 +3,13 @@ import { v } from "convex/values";
 
 export const get = query({
     args: {
+        workspaceSlug: v.string(),
         urlHash: v.string(),
     },
     handler: async (ctx, args) => {
         const records = await ctx.db
             .query("ai_summary_cache")
-            .withIndex("by_url_hash", (q) => q.eq("urlHash", args.urlHash))
+            .withIndex("by_workspace_url_hash", (q) => q.eq("workspaceSlug", args.workspaceSlug).eq("urlHash", args.urlHash))
             .collect();
 
         return records.sort((left, right) => right.generatedAt - left.generatedAt)[0] ?? null;
@@ -31,7 +32,7 @@ export const upsert = mutation({
     handler: async (ctx, args) => {
         const existing = await ctx.db
             .query("ai_summary_cache")
-            .withIndex("by_url_hash", (q) => q.eq("urlHash", args.urlHash))
+            .withIndex("by_workspace_url_hash", (q) => q.eq("workspaceSlug", args.workspaceSlug).eq("urlHash", args.urlHash))
             .collect();
 
         const [primaryRecord, ...duplicateRecords] = existing.sort((left, right) => right.generatedAt - left.generatedAt);

--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -1,0 +1,13 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+crons.interval(
+    "cleanup ai summary cache",
+    { hours: 1 },
+    internal.ai_summary_cache.cleanupExpired,
+    {},
+);
+
+export default crons;

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -399,7 +399,7 @@ export default defineSchema({
         generatedAt: v.number(),
         expiresAt: v.number(),
     })
-        .index("by_url_hash", ["urlHash"])
+        .index("by_workspace_url_hash", ["workspaceSlug", "urlHash"])
         .index("by_expires_at", ["expiresAt"]),
 
     taxonomy_clusters: defineTable({

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -402,6 +402,22 @@ export default defineSchema({
         .index("by_url_hash", ["urlHash"])
         .index("by_expires_at", ["expiresAt"]),
 
+    taxonomy_clusters: defineTable({
+        workspaceSlug: v.string(),
+        name: v.string(),
+        slug: v.string(),
+        parentSlug: v.optional(v.string()),
+        tags: v.array(v.string()),
+        source: v.union(v.literal("human"), v.literal("ai"), v.literal("merged")),
+        confidence: v.optional(v.number()),
+        status: v.union(v.literal("active"), v.literal("draft"), v.literal("archived")),
+        createdAt: v.number(),
+        updatedAt: v.number(),
+    })
+        .index("by_workspace", ["workspaceSlug"])
+        .index("by_workspace_slug", ["workspaceSlug", "slug"])
+        .index("by_workspace_status", ["workspaceSlug", "status"]),
+
     workspace_config: defineTable({
         workspaceSlug: v.string(),
         configKey: v.string(),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -387,6 +387,21 @@ export default defineSchema({
         .index("by_searchHistoryId", ["searchHistoryId"])
         .index("by_workspace", ["workspaceSlug"]),
 
+    ai_summary_cache: defineTable({
+        urlHash: v.string(),
+        workspaceSlug: v.string(),
+        query: v.string(),
+        facets: v.optional(v.string()),
+        resultCount: v.number(),
+        resultSetHash: v.string(),
+        summary: v.string(),
+        model: v.string(),
+        generatedAt: v.number(),
+        expiresAt: v.number(),
+    })
+        .index("by_url_hash", ["urlHash"])
+        .index("by_expires_at", ["expiresAt"]),
+
     workspace_config: defineTable({
         workspaceSlug: v.string(),
         configKey: v.string(),

--- a/packages/convex/convex/sessions.ts
+++ b/packages/convex/convex/sessions.ts
@@ -74,6 +74,14 @@ function buildHistoryTitle(location: string, keywords: string[]): string {
     return parts.join(" · ") || "Untitled search";
 }
 
+function sortByHistoryRecency<T extends { createdAt: number; lastOpenedAt?: number }>(records: T[]): T[] {
+    return [...records].sort((left, right) => {
+        const leftTimestamp = left.lastOpenedAt ?? left.createdAt;
+        const rightTimestamp = right.lastOpenedAt ?? right.createdAt;
+        return rightTimestamp - leftTimestamp;
+    });
+}
+
 const INDUSTRY_DB_V2_COHORT_MAX_SIZE = 2000;
 const INDUSTRY_DB_V2_HISTOGRAM_SIZE = 51;
 
@@ -301,7 +309,7 @@ export const listSearchHistory = query({
             .collect();
         const cohortBySearchHistoryId = new Map(cohorts.map((cohort) => [String(cohort.searchHistoryId), cohort]));
 
-        return records
+        return sortByHistoryRecency(records
             .map((record) => {
                 const cohort = cohortBySearchHistoryId.get(String(record._id));
                 return {
@@ -319,12 +327,27 @@ export const listSearchHistory = query({
                         }
                         : undefined,
                 };
-            })
-            .sort((left, right) => {
-                const leftTimestamp = left.lastOpenedAt ?? left.createdAt;
-                const rightTimestamp = right.lastOpenedAt ?? right.createdAt;
-                return rightTimestamp - leftTimestamp;
-            });
+            }));
+    },
+});
+
+export const recentSearches = query({
+    args: {
+        sessionKey: v.string(),
+        workspaceSlug: v.optional(v.string()),
+        limit: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+        const limit = Math.max(1, Math.min(Math.floor(args.limit ?? 10), 10));
+        const records = await ctx.db
+            .query("search_history")
+            .withIndex("by_sessionKey", (q) => q.eq("sessionKey", args.sessionKey))
+            .collect();
+
+        return sortByHistoryRecency(records
+            .filter((record) => belongsToWorkspace(record.workspaceSlug, workspaceSlug)))
+            .slice(0, limit);
     },
 });
 

--- a/packages/convex/convex/taxonomy_clusters.ts
+++ b/packages/convex/convex/taxonomy_clusters.ts
@@ -106,25 +106,31 @@ export const upsert = mutation({
         const slug = slugify(args.slug || args.name);
         const tags = normalizeStringList(args.tags);
         const parentSlug = normalizeOptionalString(args.parentSlug);
+        const normalizedParentSlug = parentSlug ? slugify(parentSlug) : undefined;
         const updatedAt = Date.now();
 
         if (!name || !slug || tags.length === 0) {
             throw new Error("Missing taxonomy cluster fields");
         }
 
-        const existingBySlug = await ctx.db
-            .query("taxonomy_clusters")
-            .withIndex("by_workspace_slug", (q) => q.eq("workspaceSlug", workspaceSlug).eq("slug", slug))
-            .unique();
-        const existing = args.id
-            ? await ctx.db.get(args.id)
-            : existingBySlug;
+        const existingById = args.id ? await ctx.db.get(args.id) : null;
+        if (existingById && existingById.workspaceSlug !== workspaceSlug) {
+            throw new Error("Taxonomy cluster not found in workspace");
+        }
+
+        const existingBySlug = existingById
+            ? null
+            : await ctx.db
+                .query("taxonomy_clusters")
+                .withIndex("by_workspace_slug", (q) => q.eq("workspaceSlug", workspaceSlug).eq("slug", slug))
+                .unique();
+        const existing = existingById ?? existingBySlug;
 
         const patch = {
             workspaceSlug,
             name,
             slug,
-            parentSlug,
+            parentSlug: normalizedParentSlug,
             tags,
             source: args.source,
             confidence: args.confidence,

--- a/packages/convex/convex/taxonomy_clusters.ts
+++ b/packages/convex/convex/taxonomy_clusters.ts
@@ -1,0 +1,272 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { DEFAULT_WORKSPACE_SLUG } from "./sessions";
+
+type TaxonomyStatus = "active" | "draft" | "archived";
+
+function normalizeWorkspaceSlug(input: string | undefined): string {
+    const normalized = input?.trim();
+    return normalized && normalized.length > 0 ? normalized : DEFAULT_WORKSPACE_SLUG;
+}
+
+function normalizeOptionalString(input: string | undefined): string | undefined {
+    const normalized = input?.trim();
+    return normalized && normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeStringList(values: string[]): string[] {
+    const seen = new Set<string>();
+    const normalized: string[] = [];
+
+    values.forEach((value) => {
+        const token = value.trim();
+        const key = token.toLowerCase();
+        if (!token || seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        normalized.push(token);
+    });
+
+    return normalized;
+}
+
+function slugify(value: string): string {
+    return value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+}
+
+function deriveSuggestionKey(tag: string): string {
+    const normalized = tag.trim().toLowerCase();
+    if (!normalized) {
+        return "";
+    }
+
+    const tokens = normalized.split(/[\s/_-]+/g).filter((token) => token.length > 0);
+    return tokens[0] ?? normalized;
+}
+
+function toTitleCase(value: string): string {
+    return value
+        .split(/[\s_-]+/g)
+        .filter((token) => token.length > 0)
+        .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+        .join(" ");
+}
+
+export const list = query({
+    args: {
+        workspaceSlug: v.optional(v.string()),
+        status: v.optional(v.union(v.literal("active"), v.literal("draft"), v.literal("archived"))),
+    },
+    handler: async (ctx, args) => {
+        const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+        const records = args.status
+            ? await ctx.db
+                .query("taxonomy_clusters")
+                .withIndex("by_workspace_status", (q) =>
+                    q.eq("workspaceSlug", workspaceSlug).eq("status", args.status as TaxonomyStatus)
+                )
+                .collect()
+            : await ctx.db
+                .query("taxonomy_clusters")
+                .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
+                .collect();
+
+        return records.sort((left, right) => {
+            if (left.status !== right.status) {
+                const order: Record<TaxonomyStatus, number> = { active: 0, draft: 1, archived: 2 };
+                return order[left.status] - order[right.status];
+            }
+
+            return right.updatedAt - left.updatedAt;
+        });
+    },
+});
+
+export const upsert = mutation({
+    args: {
+        id: v.optional(v.id("taxonomy_clusters")),
+        workspaceSlug: v.optional(v.string()),
+        name: v.string(),
+        slug: v.string(),
+        parentSlug: v.optional(v.string()),
+        tags: v.array(v.string()),
+        source: v.union(v.literal("human"), v.literal("ai"), v.literal("merged")),
+        confidence: v.optional(v.number()),
+        status: v.union(v.literal("active"), v.literal("draft"), v.literal("archived")),
+    },
+    handler: async (ctx, args) => {
+        const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+        const name = args.name.trim();
+        const slug = slugify(args.slug || args.name);
+        const tags = normalizeStringList(args.tags);
+        const parentSlug = normalizeOptionalString(args.parentSlug);
+        const updatedAt = Date.now();
+
+        if (!name || !slug || tags.length === 0) {
+            throw new Error("Missing taxonomy cluster fields");
+        }
+
+        const existingBySlug = await ctx.db
+            .query("taxonomy_clusters")
+            .withIndex("by_workspace_slug", (q) => q.eq("workspaceSlug", workspaceSlug).eq("slug", slug))
+            .unique();
+        const existing = args.id
+            ? await ctx.db.get(args.id)
+            : existingBySlug;
+
+        const patch = {
+            workspaceSlug,
+            name,
+            slug,
+            parentSlug,
+            tags,
+            source: args.source,
+            confidence: args.confidence,
+            status: args.status,
+            updatedAt,
+        };
+
+        if (existing) {
+            await ctx.db.patch(existing._id, patch);
+            return await ctx.db.get(existing._id);
+        }
+
+        const createdAt = updatedAt;
+        const id = await ctx.db.insert("taxonomy_clusters", {
+            ...patch,
+            createdAt,
+        });
+        return await ctx.db.get(id);
+    },
+});
+
+export const remove = mutation({
+    args: {
+        id: v.id("taxonomy_clusters"),
+        workspaceSlug: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+        const existing = await ctx.db.get(args.id);
+        if (!existing || existing.workspaceSlug !== workspaceSlug) {
+            return false;
+        }
+
+        await ctx.db.delete(existing._id);
+        return true;
+    },
+});
+
+export const suggest = mutation({
+    args: {
+        workspaceSlug: v.optional(v.string()),
+        limit: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+        const limit = Math.max(1, Math.min(args.limit ?? 12, 24));
+        const existingClusters = await ctx.db
+            .query("taxonomy_clusters")
+            .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
+            .collect();
+        const clusteredTags = new Set(
+            existingClusters.flatMap((cluster) => cluster.tags.map((tag) => tag.trim().toLowerCase()))
+        );
+
+        const resumes = await ctx.db.query("resumes").collect();
+        const tagCounts = new Map<string, number>();
+        for (const resume of resumes) {
+            const seen = new Set<string>();
+            for (const tag of resume.ingestData?.industryTags ?? []) {
+                const normalized = tag.trim();
+                const key = normalized.toLowerCase();
+                if (!normalized || clusteredTags.has(key) || seen.has(key)) {
+                    continue;
+                }
+                seen.add(key);
+                tagCounts.set(normalized, (tagCounts.get(normalized) ?? 0) + 1);
+            }
+        }
+
+        const grouped = new Map<string, Array<{ tag: string; count: number }>>();
+        for (const [tag, count] of tagCounts.entries()) {
+            const suggestionKey = deriveSuggestionKey(tag);
+            if (!suggestionKey) {
+                continue;
+            }
+
+            const current = grouped.get(suggestionKey) ?? [];
+            current.push({ tag, count });
+            grouped.set(suggestionKey, current);
+        }
+
+        const suggestions = Array.from(grouped.entries())
+            .map(([key, entries]) => {
+                const sortedEntries = [...entries].sort((left, right) => right.count - left.count);
+                const totalCount = sortedEntries.reduce((sum, entry) => sum + entry.count, 0);
+                const name = toTitleCase(key);
+                const slug = slugify(name);
+                return {
+                    key,
+                    name,
+                    slug,
+                    tags: sortedEntries.slice(0, 6).map((entry) => entry.tag),
+                    totalCount,
+                    confidence: Math.min(0.95, Math.max(0.25, totalCount / 20)),
+                };
+            })
+            .filter((entry) => entry.tags.length > 0)
+            .sort((left, right) => right.totalCount - left.totalCount)
+            .slice(0, limit);
+
+        const created = [];
+        for (const suggestion of suggestions) {
+            const existing = await ctx.db
+                .query("taxonomy_clusters")
+                .withIndex("by_workspace_slug", (q) =>
+                    q.eq("workspaceSlug", workspaceSlug).eq("slug", suggestion.slug)
+                )
+                .unique();
+
+            const now = Date.now();
+            if (existing) {
+                await ctx.db.patch(existing._id, {
+                    tags: normalizeStringList([...existing.tags, ...suggestion.tags]),
+                    source: existing.source === "human" ? existing.source : "merged",
+                    confidence: suggestion.confidence,
+                    status: existing.status,
+                    updatedAt: now,
+                });
+                const updated = await ctx.db.get(existing._id);
+                if (updated) {
+                    created.push(updated);
+                }
+                continue;
+            }
+
+            const id = await ctx.db.insert("taxonomy_clusters", {
+                workspaceSlug,
+                name: suggestion.name,
+                slug: suggestion.slug,
+                tags: suggestion.tags,
+                source: "merged" as const,
+                confidence: suggestion.confidence,
+                status: "draft" as const,
+                createdAt: now,
+                updatedAt: now,
+            });
+            const record = await ctx.db.get(id);
+            if (record) {
+                created.push(record);
+            }
+        }
+
+        return created;
+    },
+});

--- a/packages/shared/src/system-debug-metadata.ts
+++ b/packages/shared/src/system-debug-metadata.ts
@@ -338,6 +338,13 @@ export const SYSTEM_SETTINGS_NAV_ITEMS: SurfaceNavDefinition[] = [
     matchesSuffixes: ["/system/settings/keywords"],
   },
   {
+    id: "taxonomy",
+    titleKey: "debugConfig.settingsNavTaxonomy",
+    defaultTitle: "Taxonomy",
+    hrefSuffix: "/system/settings/taxonomy",
+    matchesSuffixes: ["/system/settings/taxonomy"],
+  },
+  {
     id: "locations",
     titleKey: "debugConfig.settingsNavLocations",
     defaultTitle: "Locations",


### PR DESCRIPTION
## Summary
- replace `/:teamSlug/resumes` with the search-first resume shell from the implementation plan
- add taxonomy-backed facets, recent-search recall, JD keyword extraction, and cached AI search summaries
- add focused API, Convex, and web coverage for the new search-first flows and supporting contracts

## Validation
- `npm --workspace @trends/web exec vitest run src/components/search/GoogleSearchBar.test.tsx`
- `npm --workspace @trends/web run typecheck`
- `make check`