### PR TITLE
test: cover ai summary panel states

### DIFF
--- a/apps/web/src/components/search/AiSummaryPanel.test.tsx
+++ b/apps/web/src/components/search/AiSummaryPanel.test.tsx
@@ -29,4 +29,37 @@ describe('AiSummaryPanel', () => {
     expect(screen.getByText('Strong machine-tools coverage with a narrow senior skew.')).toBeInTheDocument()
     expect(screen.getByText('Generated 5 minutes ago')).toBeInTheDocument()
   })
+
+  it('shows loading skeletons instead of summary copy while pending', () => {
+    const { container } = render(
+      <AiSummaryPanel
+        generatedAt={Date.parse('2026-03-27T18:09:30.000Z')}
+        loading
+        summary="This copy should stay hidden while loading."
+      />
+    )
+
+    expect(screen.queryByText('This copy should stay hidden while loading.')).not.toBeInTheDocument()
+    expect(screen.getByText('Generated 1 minute ago')).toBeInTheDocument()
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(3)
+  })
+
+  it('renders the just-now timing branch for freshly generated summaries', () => {
+    render(
+      <AiSummaryPanel
+        generatedAt={Date.parse('2026-03-27T18:09:40.000Z')}
+        summary="Fresh summary."
+      />
+    )
+
+    expect(screen.getByText('Fresh summary.')).toBeInTheDocument()
+    expect(screen.getByText('Generated just now')).toBeInTheDocument()
+  })
+
+  it('omits the timing footer when no generated timestamp is provided', () => {
+    render(<AiSummaryPanel summary="Summary without cache metadata." />)
+
+    expect(screen.getByText('Summary without cache metadata.')).toBeInTheDocument()
+    expect(screen.queryByText(/Generated /)).not.toBeInTheDocument()
+  })
 })

--- a/apps/web/src/components/search/AiSummaryPanel.tsx
+++ b/apps/web/src/components/search/AiSummaryPanel.tsx
@@ -26,6 +26,8 @@ function formatGeneratedAt(value: number | undefined): string | null {
 }
 
 export function AiSummaryPanel({ generatedAt, loading = false, summary }: AiSummaryPanelProps) {
+  const generatedAtLabel = formatGeneratedAt(generatedAt)
+
   return (
     <Card className="hidden rounded-[1.75rem] border-slate-200 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white shadow-[0_28px_70px_-46px_rgba(15,23,42,0.9)] md:block">
       <CardContent className="space-y-4 p-6">
@@ -46,8 +48,8 @@ export function AiSummaryPanel({ generatedAt, loading = false, summary }: AiSumm
           </p>
         )}
 
-        {formatGeneratedAt(generatedAt) ? (
-          <div className="text-xs text-slate-400">{formatGeneratedAt(generatedAt)}</div>
+        {generatedAtLabel ? (
+          <div className="text-xs text-slate-400">{generatedAtLabel}</div>
         ) : null}
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- expand `AiSummaryPanel` coverage for loading, just-now, and no-timestamp render paths
- avoid recomputing the generated-time label twice during render

## Validation
- `npm --workspace @trends/web exec vitest run src/components/search/AiSummaryPanel.test.tsx`
- `npm --workspace @trends/web run typecheck`
- `make check`