### PR TITLE
test: cover search hero forwarding

### DIFF
--- a/apps/web/src/components/search/SearchHero.test.tsx
+++ b/apps/web/src/components/search/SearchHero.test.tsx
@@ -6,11 +6,17 @@ import type { ResumeSearchRecentItem } from '@/components/search/search-types'
 
 vi.mock('@/components/search/GoogleSearchBar', () => ({
   GoogleSearchBar: ({
+    onApplyExtractedKeywords,
+    onChange,
+    onClear,
     loading,
     onSubmit,
     recentSearches,
     value,
   }: {
+    onApplyExtractedKeywords: (keywords: string[]) => void
+    onChange: (value: string) => void
+    onClear: () => void
     loading?: boolean
     onSubmit: (value?: string) => void
     recentSearches: ResumeSearchRecentItem[]
@@ -20,6 +26,15 @@ vi.mock('@/components/search/GoogleSearchBar', () => ({
       <div>
         Search Bar {value} {loading ? 'loading' : 'idle'} {recentSearches.length}
       </div>
+      <button type="button" onClick={() => onChange('changed from hero bar')}>
+        Change from hero bar
+      </button>
+      <button type="button" onClick={onClear}>
+        Clear from hero bar
+      </button>
+      <button type="button" onClick={() => onApplyExtractedKeywords(['lathe', 'cnc'])}>
+        Extract from hero bar
+      </button>
       <button type="button" onClick={() => onSubmit('submitted')}>
         Submit from hero bar
       </button>
@@ -116,5 +131,62 @@ describe('SearchHero', () => {
       title: 'Lathe follow-up',
       jobDescriptionId: 'lathe-sales',
     }))
+  })
+
+  it('forwards hero search-bar callbacks to the parent handlers', async () => {
+    const user = userEvent.setup()
+    const onApplyExtractedKeywords = vi.fn()
+    const onChangeQuery = vi.fn()
+    const onClearQuery = vi.fn()
+    const onSubmitQuery = vi.fn()
+
+    render(
+      <SearchHero
+        loading
+        queryInput="lathe sales"
+        recentSearches={[buildRecentSearch()]}
+        onApplyRecentSearch={vi.fn()}
+        onApplyExtractedKeywords={onApplyExtractedKeywords}
+        onChangeQuery={onChangeQuery}
+        onClearQuery={onClearQuery}
+        onSubmitQuery={onSubmitQuery}
+      />
+    )
+
+    expect(screen.getByText('Search Bar lathe sales loading 1')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Change from hero bar' }))
+    await user.click(screen.getByRole('button', { name: 'Clear from hero bar' }))
+    await user.click(screen.getByRole('button', { name: 'Extract from hero bar' }))
+    await user.click(screen.getByRole('button', { name: 'Submit from hero bar' }))
+
+    expect(onChangeQuery).toHaveBeenCalledWith('changed from hero bar')
+    expect(onClearQuery).toHaveBeenCalledTimes(1)
+    expect(onApplyExtractedKeywords).toHaveBeenCalledWith(['lathe', 'cnc'])
+    expect(onSubmitQuery).toHaveBeenCalledWith('submitted')
+  })
+
+  it('falls back to the title when a recent search has no location or job description id', () => {
+    render(
+      <SearchHero
+        queryInput=""
+        recentSearches={[
+          buildRecentSearch({
+            id: 'history-3' as ResumeSearchRecentItem['id'],
+            title: 'Distributor focus',
+            location: '',
+            keywords: [],
+            jobDescriptionId: undefined,
+          }),
+        ]}
+        onApplyRecentSearch={vi.fn()}
+        onApplyExtractedKeywords={vi.fn()}
+        onChangeQuery={vi.fn()}
+        onClearQuery={vi.fn()}
+        onSubmitQuery={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByText('Distributor focus')).toHaveLength(2)
   })
 })


### PR DESCRIPTION
## Summary
- expand `SearchHero` coverage for forwarded search-bar callbacks
- lock down the recent-search title fallback when secondary metadata is missing

## Validation
- `npm --workspace @trends/web exec vitest run src/components/search/SearchHero.test.tsx`
- `make check`