### PR TITLE
test: cover resume search status toggles

### DIFF
--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -715,6 +715,64 @@ describe('useResumeSearchState', () => {
     })
   })
 
+  it('toggles status filters while preserving the active search context', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'machine tools',
+      location: 'Malaysia',
+      keywords: ['machine tools'],
+      requiredKeywords: ['CNC'],
+      jobDescriptionId: 'jd-123',
+      selectedTags: ['cluster:manufacturing-systems'],
+      selectedCompanies: ['FANUC'],
+      selectedExperienceLevel: 'senior',
+      filters: {
+        minExperience: 5,
+        education: ['Bachelor'],
+        status: ['contacted'],
+        minMatchScore: 80,
+      },
+    }))
+
+    const { result } = renderHook(() => useResumeSearchState())
+    const baseSyncedState = {
+      shareSessionId: undefined,
+      query: 'machine tools',
+      location: 'Malaysia',
+      keywords: ['machine tools'],
+      requiredKeywords: ['CNC'],
+      jobDescriptionId: 'jd-123',
+      selectedTags: ['cluster:manufacturing-systems'],
+      selectedCompanies: ['FANUC'],
+      selectedExperienceLevel: 'senior',
+      filters: {
+        minExperience: 5,
+        education: ['Bachelor'],
+        minMatchScore: 80,
+      },
+    }
+
+    act(() => {
+      result.current.toggleStatus('contacted')
+      result.current.toggleStatus('offer')
+    })
+
+    expect(syncToUrlMock).toHaveBeenNthCalledWith(1, {
+      ...baseSyncedState,
+      filters: {
+        ...baseSyncedState.filters,
+        status: [],
+      },
+    })
+
+    expect(syncToUrlMock).toHaveBeenNthCalledWith(2, {
+      ...baseSyncedState,
+      filters: {
+        ...baseSyncedState.filters,
+        status: ['contacted', 'offer'],
+      },
+    })
+  })
+
   it('only grows the resume window when more results are available and not already loading more', () => {
     Object.assign(parsedStateMock, createParsedState({
       query: 'machine tools',


### PR DESCRIPTION
## Summary
- add focused useResumeSearchState coverage for toggleStatus
- verify existing status removal and new status addition at the hook level
- preserve the active search context while status filters sync back to URL state

## Testing
- npm --workspace @trends/web exec vitest run src/hooks/useResumeSearchState.test.tsx
- make check