### PR TITLE
fix: limit landing hot keywords to system seeds

### DIFF
--- a/apps/web/src/hooks/useIndustryKeywords.test.tsx
+++ b/apps/web/src/hooks/useIndustryKeywords.test.tsx
@@ -1,0 +1,110 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useIndustryKeywords } from '@/hooks/useIndustryKeywords'
+
+const { getMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+}))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: {
+    GET: (...args: unknown[]) => getMock(...args),
+  },
+}))
+
+describe('useIndustryKeywords', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    getMock.mockImplementation((path: string) => {
+      if (path === '/api/industry/keywords') {
+        return Promise.resolve({
+          data: {
+            success: true,
+            data: [],
+          },
+        })
+      }
+
+      if (path === '/api/config/custom-keywords') {
+        return Promise.resolve({
+          data: {
+            success: true,
+            tags: [
+              {
+                id: 'seed-equipment-cnc',
+                keyword: 'CNC',
+                category: 'equipment',
+                visible: true,
+                source: 'system',
+              },
+              {
+                id: 'seed-role-sales',
+                keyword: '销售',
+                category: 'role',
+                visible: true,
+                source: 'system',
+              },
+              {
+                id: 'workspace-dev-brand-haas',
+                keyword: 'HAAS',
+                category: 'workspace-dev-brand',
+                source: 'workspace',
+              },
+              {
+                id: 'workspace-dev-brand-star',
+                keyword: 'STAR机床',
+                category: 'workspace-dev-brand',
+                source: 'workspace',
+              },
+            ],
+            workflowSeeds: [
+              {
+                id: 'seek-my-cnc-sales',
+                label: 'Malaysia · SEEK · CNC Sales',
+                market: 'MY',
+                location: 'Kuala Lumpur MY',
+                keywords: ['CNC', 'Sales'],
+                collectionSource: {
+                  type: 'seek',
+                },
+                visible: true,
+              },
+            ],
+          },
+        })
+      }
+
+      if (path === '/api/industry/brands') {
+        return Promise.resolve({
+          data: {
+            success: true,
+            data: [],
+          },
+        })
+      }
+
+      throw new Error(`Unexpected GET path: ${path}`)
+    })
+  })
+
+  it('keeps workspace custom tags in grouped keywords while limiting hotKeywords to system seed tags', async () => {
+    const { result } = renderHook(() => useIndustryKeywords())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.hotKeywords.map((item) => item.keyword)).toEqual([
+      'CNC',
+      '销售',
+    ])
+    expect(result.current.grouped.custom.map((item) => item.keyword)).toEqual([
+      'CNC',
+      '销售',
+      'HAAS',
+      'STAR机床',
+    ])
+    expect(result.current.workflowSeeds).toHaveLength(1)
+  })
+})

--- a/apps/web/src/hooks/useIndustryKeywords.ts
+++ b/apps/web/src/hooks/useIndustryKeywords.ts
@@ -106,6 +106,14 @@ function getKeywordFingerprint(keyword: string): string {
   return keyword.trim().toLowerCase();
 }
 
+function isHotKeywordSeed(item: IndustryKeyword): boolean {
+  return (
+    item.source === "system" &&
+    typeof item.id === "string" &&
+    item.id.startsWith("seed-")
+  );
+}
+
 function deduplicateKeywords(items: IndustryKeyword[]): IndustryKeyword[] {
   const seen = new Set<string>();
   const deduplicated: IndustryKeyword[] = [];
@@ -322,7 +330,7 @@ export function useIndustryKeywords() {
   }, [allKeywords]);
 
   const hotKeywords = useMemo(() => {
-    return [...customKeywords];
+    return customKeywords.filter(isHotKeywordSeed);
   }, [customKeywords]);
 
   return {


### PR DESCRIPTION
## Summary
- keep landing hot keywords restricted to system seed tags even when workspaces add visible custom tags
- add focused hook coverage for the workspace-tag leakage case
- confirm the live `/dev/resumes` hero shows only the 4 deduplicated seed chips after reload

## Testing
- npm --workspace @trends/web exec vitest run src/hooks/useIndustryKeywords.test.tsx
- npm --workspace @trends/web exec vitest run src/components/search/SearchHero.test.tsx src/pages/ResumeSearchPage.test.tsx src/hooks/useResumeSearchState.test.tsx
- make check