### PR TITLE
fix: restore search result export and score sort

### DIFF
--- a/apps/web/src/components/search/SearchHeader.test.tsx
+++ b/apps/web/src/components/search/SearchHeader.test.tsx
@@ -71,6 +71,7 @@ describe('SearchHeader', () => {
       <SearchHeader
         activeQuery="machine tools"
         activeResultCount={1250}
+        exportFormat="csv"
         jobDescriptionId="lathe-sales"
         location="Malaysia"
         queryInput="machine tools"
@@ -80,6 +81,8 @@ describe('SearchHeader', () => {
         onApplyExtractedKeywords={vi.fn()}
         onChangeQuery={vi.fn()}
         onClearQuery={vi.fn()}
+        onExportFormatChange={vi.fn()}
+        onExportResults={vi.fn()}
         onSubmitQuery={vi.fn()}
         onSortChange={onSortChange}
       />
@@ -87,10 +90,16 @@ describe('SearchHeader', () => {
 
     expect(screen.getByText('Search Header Bar compact machine tools idle 1')).toBeInTheDocument()
     expect(screen.getByText('1,250 results for "machine tools"')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Export 1,250' }),
+    ).toBeInTheDocument()
     expect(screen.getByText('Malaysia')).toBeInTheDocument()
     expect(screen.getByText('JD lathe-sales')).toBeInTheDocument()
 
-    await user.selectOptions(screen.getByRole('combobox'), 'experience')
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: 'Sort results' }),
+      'experience',
+    )
 
     expect(onSortChange).toHaveBeenCalledWith('experience')
   })
@@ -99,13 +108,16 @@ describe('SearchHeader', () => {
     render(
       <SearchHeader
         activeResultCount={3}
+        exportFormat="csv"
         queryInput=""
         recentSearches={[]}
-        sortValue="relevance"
+        sortValue="score"
         onApplyRecentSearch={vi.fn()}
         onApplyExtractedKeywords={vi.fn()}
         onChangeQuery={vi.fn()}
         onClearQuery={vi.fn()}
+        onExportFormatChange={vi.fn()}
+        onExportResults={vi.fn()}
         onSubmitQuery={vi.fn()}
         onSortChange={vi.fn()}
       />
@@ -119,19 +131,25 @@ describe('SearchHeader', () => {
     const onApplyExtractedKeywords = vi.fn()
     const onChangeQuery = vi.fn()
     const onClearQuery = vi.fn()
+    const onExportFormatChange = vi.fn()
+    const onExportResults = vi.fn()
     const onSubmitQuery = vi.fn()
 
     render(
       <SearchHeader
         activeResultCount={42}
+        exportFormat="csv"
+        exportingResults
         loading
         queryInput="servo automation"
         recentSearches={[buildRecentSearch()]}
-        sortValue="relevance"
+        sortValue="score"
         onApplyRecentSearch={vi.fn()}
         onApplyExtractedKeywords={onApplyExtractedKeywords}
         onChangeQuery={onChangeQuery}
         onClearQuery={onClearQuery}
+        onExportFormatChange={onExportFormatChange}
+        onExportResults={onExportResults}
         onSubmitQuery={onSubmitQuery}
         onSortChange={vi.fn()}
       />
@@ -148,6 +166,40 @@ describe('SearchHeader', () => {
     expect(onClearQuery).toHaveBeenCalledTimes(1)
     expect(onApplyExtractedKeywords).toHaveBeenCalledWith(['servo', 'automation'])
     expect(onSubmitQuery).toHaveBeenCalledWith('submitted from header')
+    expect(screen.getByRole('button', { name: 'Exporting...' })).toBeDisabled()
+  })
+
+  it('forwards export format changes and export clicks', async () => {
+    const user = userEvent.setup()
+    const onExportFormatChange = vi.fn()
+    const onExportResults = vi.fn()
+
+    render(
+      <SearchHeader
+        activeResultCount={18}
+        exportFormat="csv"
+        queryInput="machine tools"
+        recentSearches={[]}
+        sortValue="score"
+        onApplyRecentSearch={vi.fn()}
+        onApplyExtractedKeywords={vi.fn()}
+        onChangeQuery={vi.fn()}
+        onClearQuery={vi.fn()}
+        onExportFormatChange={onExportFormatChange}
+        onExportResults={onExportResults}
+        onSubmitQuery={vi.fn()}
+        onSortChange={vi.fn()}
+      />
+    )
+
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: 'Export format' }),
+      'xlsx',
+    )
+    await user.click(screen.getByRole('button', { name: 'Export 18' }))
+
+    expect(onExportFormatChange).toHaveBeenCalledWith('xlsx')
+    expect(onExportResults).toHaveBeenCalledTimes(1)
   })
 
   it('omits the location and job description badges when that metadata is absent', () => {
@@ -155,13 +207,16 @@ describe('SearchHeader', () => {
       <SearchHeader
         activeQuery="machine tools"
         activeResultCount={7}
+        exportFormat="csv"
         queryInput="machine tools"
         recentSearches={[]}
-        sortValue="relevance"
+        sortValue="score"
         onApplyRecentSearch={vi.fn()}
         onApplyExtractedKeywords={vi.fn()}
         onChangeQuery={vi.fn()}
         onClearQuery={vi.fn()}
+        onExportFormatChange={vi.fn()}
+        onExportResults={vi.fn()}
         onSubmitQuery={vi.fn()}
         onSortChange={vi.fn()}
       />

--- a/apps/web/src/components/search/SearchHeader.tsx
+++ b/apps/web/src/components/search/SearchHeader.tsx
@@ -1,11 +1,17 @@
+import { Download } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Select } from '@/components/ui/select'
 import { GoogleSearchBar } from '@/components/search/GoogleSearchBar'
 import type { ResumeSearchRecentItem, SearchSortValue } from '@/components/search/search-types'
+import type { ResumeExportFormat } from '@/types/resume'
+import { cn } from '@/lib/utils'
 
 type SearchHeaderProps = {
   activeQuery?: string
   activeResultCount: number
+  exportFormat: ResumeExportFormat
+  exportingResults?: boolean
   jobDescriptionId?: string
   loading?: boolean
   location?: string
@@ -16,6 +22,8 @@ type SearchHeaderProps = {
   onApplyExtractedKeywords: (keywords: string[]) => void
   onChangeQuery: (value: string) => void
   onClearQuery: () => void
+  onExportFormatChange: (format: ResumeExportFormat) => void
+  onExportResults: () => void | Promise<void>
   onSubmitQuery: (value?: string) => void
   onSortChange: (value: SearchSortValue) => void
 }
@@ -23,6 +31,8 @@ type SearchHeaderProps = {
 export function SearchHeader({
   activeQuery,
   activeResultCount,
+  exportFormat,
+  exportingResults = false,
   jobDescriptionId,
   loading = false,
   location,
@@ -33,6 +43,8 @@ export function SearchHeader({
   onApplyExtractedKeywords,
   onChangeQuery,
   onClearQuery,
+  onExportFormatChange,
+  onExportResults,
   onSubmitQuery,
   onSortChange,
 }: SearchHeaderProps) {
@@ -63,20 +75,59 @@ export function SearchHeader({
           </div>
         </div>
 
-        <div className="flex items-center gap-3">
-          <span className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-            Sort
-          </span>
-          <Select
-            className="min-w-40"
-            options={[
-              { value: 'relevance', label: 'Relevance' },
-              { value: 'newest', label: 'Newest' },
-              { value: 'experience', label: 'Experience' },
-            ]}
-            value={sortValue}
-            onChange={(event) => onSortChange(event.target.value as SearchSortValue)}
-          />
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-3">
+            <span className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Sort
+            </span>
+            <Select
+              aria-label="Sort results"
+              className="min-w-40"
+              options={[
+                { value: 'score', label: 'AI score' },
+                { value: 'newest', label: 'Newest' },
+                { value: 'experience', label: 'Experience' },
+              ]}
+              value={sortValue}
+              onChange={(event) =>
+                onSortChange(event.target.value as SearchSortValue)
+              }
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Select
+              aria-label="Export format"
+              className="h-10 min-w-24 rounded-full border-0 bg-slate-100/90 pr-8 focus-visible:ring-0 focus-visible:ring-offset-0"
+              options={[
+                { value: 'csv', label: 'CSV' },
+                { value: 'xlsx', label: 'XLSX' },
+              ]}
+              value={exportFormat}
+              onChange={(event) =>
+                onExportFormatChange(
+                  event.target.value === 'xlsx' ? 'xlsx' : 'csv',
+                )
+              }
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-10 gap-2 rounded-full px-4"
+              disabled={loading || exportingResults || activeResultCount === 0}
+              onClick={() => {
+                void onExportResults()
+              }}
+            >
+              <Download
+                className={cn('h-4 w-4', exportingResults && 'animate-spin')}
+              />
+              {exportingResults
+                ? 'Exporting...'
+                : `Export ${activeResultCount.toLocaleString()}`}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/search/search-types.ts
+++ b/apps/web/src/components/search/search-types.ts
@@ -3,7 +3,7 @@ import type { SearchHistoryItem } from '@/hooks/useSession'
 import type { CandidateStatus } from '@/types/resume'
 import type { CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 
-export type SearchSortValue = 'relevance' | 'newest' | 'experience'
+export type SearchSortValue = 'score' | 'newest' | 'experience'
 
 export type FacetValueCount = {
   value: string

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -36,10 +36,9 @@ import {
   type UrlSearchState,
 } from '@/hooks/useUrlSearchState'
 import { rawApiClient } from '@/lib/api-helpers'
-import type { components } from '@/lib/api-types'
 import { getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey } from '@/lib/analysis-utils'
+import { submitResumeExportDownload, type ResumeExportRequestBody } from '@/lib/resume-export'
 import { isResumeHomeResetState } from '@/lib/resume-home-navigation'
-import { withWorkspaceHeaders } from '@/lib/workspace-ref'
 import type { ResumeSearchShareState, SearchHistoryItem } from '@/hooks/useSession'
 import {
   aiFeedbackToActionType,
@@ -72,7 +71,6 @@ type JobDescriptionApiResponse = {
   content?: string
 }
 
-type ResumeExportRequestBody = components['schemas']['ResumeExportCanonicalRequest']
 type SearchSessionApiResponse = {
   success: boolean
   session?: {
@@ -258,75 +256,6 @@ function taskMatchesCurrentSearch(
   }
 
   return false
-}
-
-function parseDownloadFilename(contentDisposition: string | null): string | undefined {
-  if (!contentDisposition) {
-    return undefined
-  }
-
-  const encodedMatch = contentDisposition.match(/filename\*\s*=\s*UTF-8''([^;]+)/i)
-  if (encodedMatch?.[1]) {
-    const encodedFilename = encodedMatch[1].trim().replace(/^"(.*)"$/, '$1')
-    try {
-      return decodeURIComponent(encodedFilename)
-    } catch {
-      return encodedFilename
-    }
-  }
-
-  const filenameMatch = contentDisposition.match(/filename\s*=\s*"([^"]+)"|filename\s*=\s*([^;]+)/i)
-  const filename = filenameMatch?.[1] ?? filenameMatch?.[2]
-  return filename?.trim()
-}
-
-function triggerBlobDownload(blob: Blob, filename: string): void {
-  const blobUrl = window.URL.createObjectURL(blob)
-  const link = document.createElement('a')
-
-  link.href = blobUrl
-  link.download = filename
-  link.style.display = 'none'
-  document.body.appendChild(link)
-
-  try {
-    link.click()
-  } finally {
-    link.remove()
-    window.URL.revokeObjectURL(blobUrl)
-  }
-}
-
-async function submitResumeExportDownload(apiBaseUrl: string, payload: ResumeExportRequestBody): Promise<void> {
-  const response = await fetch(
-    new URL(`${apiBaseUrl}/api/resumes/export`, window.location.origin).toString(),
-    {
-      method: 'POST',
-      headers: withWorkspaceHeaders({
-        'Content-Type': 'application/json',
-      }),
-      body: JSON.stringify(payload),
-    }
-  )
-
-  if (!response.ok) {
-    const contentType = response.headers.get('content-type') ?? ''
-    if (contentType.includes('application/json')) {
-      const body = await response.json().catch(() => null) as { error?: unknown } | null
-      const errorMessage = typeof body?.error === 'string' && body.error.trim().length > 0
-        ? body.error
-        : `Export failed (HTTP ${response.status})`
-      throw new Error(errorMessage)
-    }
-
-    const responseText = await response.text().catch(() => '')
-    throw new Error(responseText.trim() || `Export failed (HTTP ${response.status})`)
-  }
-
-  const blob = await response.blob()
-  const filename = parseDownloadFilename(response.headers.get('content-disposition'))
-    ?? `resumes-export.${payload.format === 'xlsx' ? 'xlsx' : 'csv'}`
-  triggerBlobDownload(blob, filename)
 }
 
 function normalizeFilterToken(value: string): string {

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -2,9 +2,22 @@ import { act, renderHook } from '@testing-library/react'
 import { formatKeywordQuery } from '@trends/shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useResumeSearchState } from '@/hooks/useResumeSearchState'
-import type { ResumeSearchResultItem } from '@/components/search/search-types'
+import type { CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 import type { UrlSearchState } from '@/hooks/useUrlSearchState'
+
+const {
+  exportDownloadMock,
+  toastErrorMock,
+  toastInfoMock,
+} = vi.hoisted(() => ({
+  exportDownloadMock: vi.fn(async (apiBaseUrl: string, payload: unknown) => {
+    void apiBaseUrl
+    void payload
+  }),
+  toastErrorMock: vi.fn(),
+  toastInfoMock: vi.fn(),
+}))
 
 vi.mock('../../../../packages/convex/convex/_generated/api', () => ({
   api: {
@@ -16,6 +29,21 @@ vi.mock('../../../../packages/convex/convex/_generated/api', () => ({
     taxonomy_clusters: {
       list: 'taxonomy-clusters-list-query',
     },
+  },
+}))
+
+vi.mock('@/lib/resume-export', () => ({
+  submitResumeExportDownload: (apiBaseUrl: string, payload: unknown) => {
+    void apiBaseUrl
+    void payload
+    return exportDownloadMock(apiBaseUrl, payload)
+  },
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: (message: unknown) => toastErrorMock(message),
+    info: (message: unknown) => toastInfoMock(message),
   },
 }))
 
@@ -47,7 +75,7 @@ const {
   resumesMock: [] as ConvexResumeItem[],
   saveSearchHistoryMutationMock: vi.fn(async () => 'history-1'),
   recentSearchHistoryRecordsMock: [] as Array<Record<string, unknown>>,
-  statusByIdentityMock: {} as Record<string, { status: ResumeSearchResultItem['status'] }>,
+  statusByIdentityMock: {} as Record<string, CandidateStatusRecord>,
   syncToUrlMock: vi.fn(),
   taxonomyClusterRecordsMock: [] as Array<Record<string, unknown>>,
   useFacetCountsMock: vi.fn(),
@@ -107,6 +135,21 @@ function createParsedState(overrides: Partial<UrlSearchState> = {}): UrlSearchSt
     selectedCompanies: [],
     selectedExperienceLevel: undefined,
     filters: {},
+    ...overrides,
+  }
+}
+
+function createStatusRecord(
+  identityKey: string,
+  status: CandidateStatusRecord['status'],
+  overrides: Partial<CandidateStatusRecord> = {},
+): CandidateStatusRecord {
+  return {
+    _id: `${identityKey}-status`,
+    identityKey,
+    workspaceSlug: 'dev',
+    status,
+    updatedAt: Date.now(),
     ...overrides,
   }
 }
@@ -218,10 +261,33 @@ describe('useResumeSearchState', () => {
       loading: convexQueryStateMock.loading,
       loadingMore: convexQueryStateMock.loadingMore,
     }))
+    exportDownloadMock.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('defaults to score-first ordering for loaded search results', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'machine tools',
+      keywords: ['machine tools'],
+    }))
+
+    resumesMock.push(
+      createResume(1, { primaryRuleScore: 72 }),
+      createResume(2, { primaryRuleScore: 91 }),
+      createResume(3, { primaryRuleScore: 84 }),
+    )
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(result.current.activeSort).toBe('score')
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual([
+      'resume-2',
+      'resume-3',
+      'resume-1',
+    ])
   })
 
   it('derives raw and cluster tags, applies local filters, and sorts matching results', () => {
@@ -272,9 +338,9 @@ describe('useResumeSearchState', () => {
         },
       }),
     )
-    statusByIdentityMock['identity-1'] = { status: 'contacted' }
-    statusByIdentityMock['identity-2'] = { status: 'contacted' }
-    statusByIdentityMock['identity-3'] = { status: 'contacted' }
+    statusByIdentityMock['identity-1'] = createStatusRecord('identity-1', 'contacted')
+    statusByIdentityMock['identity-2'] = createStatusRecord('identity-2', 'contacted')
+    statusByIdentityMock['identity-3'] = createStatusRecord('identity-3', 'contacted')
 
     const { result } = renderHook(() => useResumeSearchState())
 
@@ -494,7 +560,7 @@ describe('useResumeSearchState', () => {
     })
 
     act(() => {
-      result.current.setSort('relevance')
+      result.current.setSort('score')
     })
 
     expect(syncToUrlMock).toHaveBeenNthCalledWith(3, {
@@ -531,6 +597,72 @@ describe('useResumeSearchState', () => {
       selectedExperienceLevel: undefined,
       filters: {},
     })
+  })
+
+  it('exports the current filtered results with score-first metadata', async () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'machine tools',
+      keywords: ['machine tools'],
+    }))
+
+    resumesMock.push(
+      createResume(1, {
+        primaryRuleScore: 88,
+        analysis: {
+          score: 91,
+          summary: 'Strong fit',
+          highlights: [],
+          recommendation: 'strong_match',
+          breakdown: {
+            industry_db: 55,
+          },
+        },
+      }),
+      createResume(2, {
+        primaryRuleScore: 79,
+      }),
+    )
+    statusByIdentityMock['identity-1'] = createStatusRecord('identity-1', 'contacted', {
+      notes: 'Call first',
+    })
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    await act(async () => {
+      await result.current.exportResults()
+    })
+
+    expect(exportDownloadMock).toHaveBeenCalledWith(
+      '',
+      {
+        format: 'csv',
+        source: 'convex',
+        entries: [
+          {
+            resumeId: 'resume-1',
+            status: 'contacted',
+            match: {
+              score: 88,
+              recommendation: 'strong_match',
+              scoreSource: 'rule',
+            },
+            ruleScore: 88,
+            userComment: 'Call first',
+          },
+          {
+            resumeId: 'resume-2',
+            status: 'new',
+            match: {
+              score: 79,
+              recommendation: 'match',
+              scoreSource: 'rule',
+            },
+            ruleScore: 79,
+          },
+        ],
+      },
+    )
+    expect(toastInfoMock).toHaveBeenCalledWith('Started export for 2 resumes')
   })
 
   it('clears only facet filters while preserving the active search context', () => {

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -1,6 +1,7 @@
 import { formatKeywordQuery, parseKeywordQuery } from '@trends/shared'
 import { useMutation, useQuery } from 'convex/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
@@ -17,6 +18,10 @@ import {
   type UrlSearchState,
 } from '@/hooks/useUrlSearchState'
 import {
+  submitResumeExportDownload,
+  type ResumeExportRequestBody,
+} from '@/lib/resume-export'
+import {
   createTaxonomyClusterResolver,
   fromClusterFilterToken,
   isClusterFilterToken,
@@ -27,7 +32,11 @@ import {
 import { toIndustryDbV2Stats } from '@/lib/resume-scoring'
 import { resolveCollectionSource } from '@/lib/search-profile-sources'
 import type { SearchHistoryItem } from '@/hooks/useSession'
-import type { CandidateStatus, ResumeFilters } from '@/types/resume'
+import type {
+  CandidateStatus,
+  ResumeExportFormat,
+  ResumeFilters,
+} from '@/types/resume'
 import type {
   FacetCounts,
   ResumeSearchRecentItem,
@@ -59,6 +68,9 @@ type SearchHistoryRecord = {
   createdAt: number
   lastOpenedAt?: number
 }
+
+type ResumeExportEntryMatch =
+  NonNullable<ResumeExportRequestBody['entries'][number]['match']>
 
 function normalizeOptionalString(
   value: string | undefined,
@@ -167,7 +179,7 @@ function resolveSortValue(filters: Partial<ResumeFilters>): SearchSortValue {
     return 'newest'
   }
 
-  return 'relevance'
+  return 'score'
 }
 
 function buildUrlState(
@@ -201,8 +213,10 @@ function sortResults(
   results: ResumeSearchResultItem[],
   sortValue: SearchSortValue,
 ): ResumeSearchResultItem[] {
-  if (sortValue === 'relevance') {
-    return results
+  if (sortValue === 'score') {
+    return [...results].sort(
+      (left, right) => (right.score ?? -1) - (left.score ?? -1),
+    )
   }
 
   return [...results].sort((left, right) => {
@@ -221,6 +235,64 @@ function sortResults(
       parseExperienceYears(left.resume.experience)
     )
   })
+}
+
+function resolveExportRecommendation(
+  score: number,
+): ResumeExportEntryMatch['recommendation'] {
+  if (score >= 85) {
+    return 'strong_match'
+  }
+
+  if (score >= 70) {
+    return 'match'
+  }
+
+  if (score >= 50) {
+    return 'potential'
+  }
+
+  return 'no_match'
+}
+
+function buildSearchExportMatch(
+  item: ResumeSearchResultItem,
+): ResumeExportEntryMatch | undefined {
+  if (typeof item.score !== 'number' || !Number.isFinite(item.score)) {
+    return undefined
+  }
+
+  const analysis = item.resume.analysis
+  const matchesAiScore =
+    typeof analysis?.score === 'number' &&
+    Number.isFinite(analysis.score) &&
+    analysis.score === item.score
+
+  return {
+    score: item.score,
+    recommendation: resolveExportRecommendation(item.score),
+    scoreSource: matchesAiScore ? 'ai' : 'rule',
+    ...(matchesAiScore && analysis?.breakdown
+      ? { breakdown: analysis.breakdown }
+      : {}),
+  }
+}
+
+function buildSearchExportEntry(
+  item: ResumeSearchResultItem,
+): ResumeExportRequestBody['entries'][number] {
+  const match = buildSearchExportMatch(item)
+  const userComment = normalizeOptionalString(item.statusMeta?.notes)
+
+  return {
+    resumeId: item.key,
+    status: item.status,
+    ...(match ? { match } : {}),
+    ...(typeof item.resume.primaryRuleScore === 'number'
+      ? { ruleScore: item.resume.primaryRuleScore }
+      : {}),
+    ...(userComment ? { userComment } : {}),
+  }
 }
 
 function matchesLocalFilters(
@@ -370,6 +442,8 @@ export function useResumeSearchState() {
   const [queryInput, setQueryInput] = useState(
     () => parsedState.query ?? formatKeywordQuery(parsedState.keywords),
   )
+  const [exportFormat, setExportFormat] = useState<ResumeExportFormat>('csv')
+  const [exportingResults, setExportingResults] = useState(false)
   const [resumeLimit, setResumeLimit] = useState(INITIAL_RESUME_LIMIT)
   const saveSearchHistory = useMutation(api.sessions.saveSearchHistory)
   const markSearchHistoryOpened = useMutation(
@@ -386,6 +460,10 @@ export function useResumeSearchState() {
   })
   const { statusByIdentity } = useCandidateStatus(true)
   const { blocksByIdentity } = useCandidateBlocks(true)
+  const apiBaseUrl = useMemo(() => {
+    const rawBaseUrl = import.meta.env.VITE_API_URL || '/api'
+    return rawBaseUrl.replace(/\/api\/?$/, '')
+  }, [])
 
   useEffect(() => {
     setQueryInput(parsedState.query ?? formatKeywordQuery(parsedState.keywords))
@@ -826,7 +904,7 @@ export function useResumeSearchState() {
             : sortValue === 'experience'
               ? 'experience'
               : undefined,
-        sortOrder: sortValue === 'relevance' ? undefined : 'desc',
+        sortOrder: sortValue === 'score' ? undefined : 'desc',
       }
 
       syncToUrl(buildUrlState(parsedState, { filters: nextFilters }))
@@ -858,12 +936,42 @@ export function useResumeSearchState() {
     setResumeLimit((current) => current + RESUME_PAGE_INCREMENT)
   }, [hasMore, loadingMore])
 
+  const exportResults = useCallback(async () => {
+    if (filteredResults.length === 0) {
+      return
+    }
+
+    setExportingResults(true)
+    try {
+      const exportRequest: ResumeExportRequestBody = {
+        format: exportFormat,
+        source: 'convex',
+        entries: filteredResults.map(buildSearchExportEntry),
+      }
+
+      await submitResumeExportDownload(apiBaseUrl, exportRequest)
+      toast.info(`Started export for ${filteredResults.length} resumes`)
+    } catch (error) {
+      console.error('Failed to export search results', error)
+      const message =
+        error instanceof Error && error.message.trim().length > 0
+          ? error.message
+          : 'Export failed. Please try again.'
+      toast.error(message)
+    } finally {
+      setExportingResults(false)
+    }
+  }, [apiBaseUrl, exportFormat, filteredResults])
+
   return {
     activeQuery,
     activeSort,
     applyRecentSearch,
     clearFacetFilters,
     clearSearch,
+    exportFormat,
+    exportingResults,
+    exportResults,
     facetCounts,
     filterCount,
     filteredResults,
@@ -879,6 +987,7 @@ export function useResumeSearchState() {
     selectedRawTags,
     searchHistoryLoading: recentSearchHistoryRecords === undefined,
     setMinScoreFilter,
+    setExportFormat,
     setQueryInput,
     setSelectedCompanies,
     setSelectedExperienceLevel,

--- a/apps/web/src/lib/resume-export.ts
+++ b/apps/web/src/lib/resume-export.ts
@@ -1,0 +1,90 @@
+import type { components } from '@/lib/api-types'
+import { withWorkspaceHeaders } from '@/lib/workspace-ref'
+
+export type ResumeExportRequestBody =
+  components['schemas']['ResumeExportCanonicalRequest']
+
+function parseDownloadFilename(
+  contentDisposition: string | null,
+): string | undefined {
+  if (!contentDisposition) {
+    return undefined
+  }
+
+  const encodedMatch = contentDisposition.match(
+    /filename\*\s*=\s*UTF-8''([^;]+)/i,
+  )
+  if (encodedMatch?.[1]) {
+    const encodedFilename = encodedMatch[1].trim().replace(/^"(.*)"$/, '$1')
+    try {
+      return decodeURIComponent(encodedFilename)
+    } catch {
+      return encodedFilename
+    }
+  }
+
+  const filenameMatch = contentDisposition.match(
+    /filename\s*=\s*"([^"]+)"|filename\s*=\s*([^;]+)/i,
+  )
+  const filename = filenameMatch?.[1] ?? filenameMatch?.[2]
+  return filename?.trim()
+}
+
+function triggerBlobDownload(blob: Blob, filename: string): void {
+  const blobUrl = window.URL.createObjectURL(blob)
+  const link = document.createElement('a')
+
+  link.href = blobUrl
+  link.download = filename
+  link.style.display = 'none'
+  document.body.appendChild(link)
+
+  try {
+    link.click()
+  } finally {
+    link.remove()
+    window.URL.revokeObjectURL(blobUrl)
+  }
+}
+
+export async function submitResumeExportDownload(
+  apiBaseUrl: string,
+  payload: ResumeExportRequestBody,
+): Promise<void> {
+  const response = await fetch(
+    new URL(`${apiBaseUrl}/api/resumes/export`, window.location.origin)
+      .toString(),
+    {
+      method: 'POST',
+      headers: withWorkspaceHeaders({
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify(payload),
+    },
+  )
+
+  if (!response.ok) {
+    const contentType = response.headers.get('content-type') ?? ''
+    if (contentType.includes('application/json')) {
+      const body = (await response.json().catch(() => null)) as
+        | { error?: unknown }
+        | null
+      const errorMessage =
+        typeof body?.error === 'string' && body.error.trim().length > 0
+          ? body.error
+          : `Export failed (HTTP ${response.status})`
+      throw new Error(errorMessage)
+    }
+
+    const responseText = await response.text().catch(() => '')
+    throw new Error(
+      responseText.trim() || `Export failed (HTTP ${response.status})`,
+    )
+  }
+
+  const blob = await response.blob()
+  const filename =
+    parseDownloadFilename(response.headers.get('content-disposition')) ??
+    `resumes-export.${payload.format === 'xlsx' ? 'xlsx' : 'csv'}`
+  triggerBlobDownload(blob, filename)
+}

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -88,15 +88,24 @@ vi.mock('@/components/search/SearchHeader', () => ({
   SearchHeader: ({
     activeQuery,
     activeResultCount,
+    exportFormat,
+    exportingResults,
     onApplyExtractedKeywords,
+    onExportFormatChange,
+    onExportResults,
   }: {
     activeQuery?: string
     activeResultCount: number
+    exportFormat: 'csv' | 'xlsx'
+    exportingResults?: boolean
     onApplyExtractedKeywords: (keywords: string[]) => void
+    onExportFormatChange: (format: 'csv' | 'xlsx') => void
+    onExportResults: () => void
   }) => (
     <div>
       <div>
-        Header {activeQuery} {activeResultCount}
+        Header {activeQuery} {activeResultCount} export:{exportFormat} exporting:
+        {String(exportingResults)}
       </div>
       <button
         type="button"
@@ -105,6 +114,12 @@ vi.mock('@/components/search/SearchHeader', () => ({
         }
       >
         Apply Header JD
+      </button>
+      <button type="button" onClick={() => onExportFormatChange('xlsx')}>
+        Change Header Export Format
+      </button>
+      <button type="button" onClick={onExportResults}>
+        Export Header Results
       </button>
     </div>
   ),
@@ -276,10 +291,13 @@ function createParsedState(
 function createResumeSearchState(overrides: Record<string, unknown> = {}) {
   return {
     activeQuery: undefined,
-    activeSort: 'relevance',
+    activeSort: 'score',
     applyRecentSearch: vi.fn(),
     clearFacetFilters: vi.fn(),
     clearSearch: vi.fn(),
+    exportFormat: 'csv',
+    exportingResults: false,
+    exportResults: vi.fn(),
     facetCounts: {
       clusters: [],
       tags: [],
@@ -302,6 +320,7 @@ function createResumeSearchState(overrides: Record<string, unknown> = {}) {
     searchHistoryLoading: false,
     selectedClusterTags: [] as string[],
     selectedRawTags: [] as string[],
+    setExportFormat: vi.fn(),
     setMinScoreFilter: vi.fn(),
     setQueryInput: vi.fn(),
     setSelectedExperienceLevel: vi.fn(),
@@ -443,7 +462,9 @@ describe('ResumeSearchPage', () => {
     render(<ResumeSearchPage />)
 
     expect(screen.queryByText(/Landing Hero/)).not.toBeInTheDocument()
-    expect(screen.getByText('Header machine tools 2')).toBeInTheDocument()
+    expect(
+      screen.getByText('Header machine tools 2 export:csv exporting:false'),
+    ).toBeInTheDocument()
     expect(
       screen.getByText(
         'Results List 2 hasMore:false loading:false loadingMore:false expanded:none',
@@ -555,5 +576,27 @@ describe('ResumeSearchPage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Load more results' }))
     expect(state.loadMore).toHaveBeenCalledTimes(1)
+  })
+
+  it('wires header export controls into the search-state actions', async () => {
+    const user = userEvent.setup()
+    const state = createResumeSearchState({
+      activeQuery: 'CNC Sales',
+      filteredResults: [createResult(1)],
+      isLanding: false,
+    })
+    useResumeSearchStateMock.mockReturnValue(state)
+
+    render(<ResumeSearchPage />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Change Header Export Format' }),
+    )
+    await user.click(
+      screen.getByRole('button', { name: 'Export Header Results' }),
+    )
+
+    expect(state.setExportFormat).toHaveBeenCalledWith('xlsx')
+    expect(state.exportResults).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -22,6 +22,9 @@ export function ResumeSearchPage() {
     applyRecentSearch,
     clearFacetFilters,
     clearSearch,
+    exportFormat,
+    exportingResults,
+    exportResults,
     facetCounts,
     filterCount,
     filteredResults,
@@ -36,6 +39,7 @@ export function ResumeSearchPage() {
     searchHistoryLoading,
     selectedClusterTags,
     selectedRawTags,
+    setExportFormat,
     setMinScoreFilter,
     setQueryInput,
     setSelectedExperienceLevel,
@@ -168,6 +172,8 @@ export function ResumeSearchPage() {
           <SearchHeader
             activeQuery={activeQuery}
             activeResultCount={filteredResults.length}
+            exportFormat={exportFormat}
+            exportingResults={exportingResults}
             jobDescriptionId={parsedState.jobDescriptionId}
             loading={loading}
             location={parsedState.location}
@@ -178,6 +184,8 @@ export function ResumeSearchPage() {
             onApplyExtractedKeywords={applyExtractedKeywords}
             onChangeQuery={setQueryInput}
             onClearQuery={clearSearch}
+            onExportFormatChange={setExportFormat}
+            onExportResults={exportResults}
             onSubmitQuery={submitSearch}
             onSortChange={setSort}
           />


### PR DESCRIPTION
## Summary
- restore fast export controls on the search-first resume results header
- default the search-first shell back to score-first ordering
- share the export download helper between the search-first and legacy resume flows

## Validation
- bunx vitest run -c vitest.config.ts src/components/search/SearchHeader.test.tsx src/hooks/useResumeSearchState.test.tsx src/pages/ResumeSearchPage.test.tsx
- bun run --filter @trends/web typecheck
- make check