### PR TITLE
fix: restore search-first resume ai analysis ui

### DIFF
--- a/apps/web/src/components/search/SnippetCard.test.tsx
+++ b/apps/web/src/components/search/SnippetCard.test.tsx
@@ -64,8 +64,10 @@ function createResult(index: number, overrides: Partial<ResumeSearchResultItem> 
   return {
     key: overrides.key ?? `resume-${index}`,
     identityKey: overrides.identityKey ?? `identity-${index}`,
+    analysis: overrides.analysis,
     blocked: overrides.blocked ?? false,
     score: hasScoreOverride ? overrides.score : 87.6,
+    scoreSource: overrides.scoreSource ?? 'ai',
     status: overrides.status ?? 'new',
     statusMeta: overrides.statusMeta,
     resume: overrides.resume ?? createResume(index),
@@ -84,7 +86,14 @@ describe('SnippetCard', () => {
     render(
       <SnippetCard
         expanded
-        item={createResult(1)}
+        item={createResult(1, {
+          analysis: {
+            score: 87.6,
+            summary: 'Strong CNC sales coverage across Malaysia.',
+            highlights: [],
+            recommendation: 'strong_match',
+          },
+        })}
         onToggleExpanded={onToggleExpanded}
       />
     )
@@ -96,9 +105,11 @@ describe('SnippetCard', () => {
     expect(screen.getByText('6 years')).toBeInTheDocument()
     expect(screen.getByText('senior')).toBeInTheDocument()
     expect(screen.getByText('88')).toBeInTheDocument()
+    expect(screen.getByText('AI')).toBeInTheDocument()
     expect(screen.getByText('CNC')).toBeInTheDocument()
     expect(screen.getByText('Machine Tools')).toBeInTheDocument()
     expect(screen.getByText('Malaysia')).toBeInTheDocument()
+    expect(screen.getByText(/AI summary: Strong CNC sales coverage across Malaysia\./i)).toBeInTheDocument()
     expect(screen.queryByText('Ignored')).not.toBeInTheDocument()
     expect(screen.getByText('Expanded card for Candidate 1')).toBeInTheDocument()
 
@@ -115,6 +126,7 @@ describe('SnippetCard', () => {
       <SnippetCard
         expanded={false}
         item={createResult(2, {
+          scoreSource: undefined,
           score: undefined,
           resume: createResume(2, {
             name: '',

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -30,6 +30,7 @@ function getSnippetText(item: ResumeSearchResultItem): string {
 }
 
 export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardProps) {
+  const analysis = item.analysis ?? item.resume.analysis
   const visibleKeywords = (
     item.resume._provenance?.map((entry) => entry.term)
     ?? item.resume.ingestData?.industryTags
@@ -63,6 +64,12 @@ export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardPro
               {getSnippetText(item)}
             </p>
 
+            {item.scoreSource === 'ai' && analysis?.summary ? (
+              <p className="line-clamp-2 text-xs leading-5 text-slate-500">
+                AI summary: {analysis.summary}
+              </p>
+            ) : null}
+
             <div className="flex flex-wrap gap-2">
               {visibleKeywords.map((keyword) => (
                 <Badge key={`${item.key}-${keyword}`} variant="secondary">
@@ -74,11 +81,18 @@ export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardPro
 
           <div className="flex shrink-0 items-center gap-3">
             {typeof item.score === 'number' ? (
-              <div className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-sm font-semibold text-amber-700">
-                <span className="inline-flex items-center gap-1">
-                  <Star className="h-3.5 w-3.5" />
-                  {Math.round(item.score)}
-                </span>
+              <div className="flex items-center gap-2">
+                <div className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-sm font-semibold text-amber-700">
+                  <span className="inline-flex items-center gap-1">
+                    <Star className="h-3.5 w-3.5" />
+                    {Math.round(item.score)}
+                  </span>
+                </div>
+                {item.scoreSource ? (
+                  <Badge variant="outline" className="uppercase">
+                    {item.scoreSource === 'ai' ? 'AI' : 'Rule'}
+                  </Badge>
+                ) : null}
               </div>
             ) : null}
             <Button type="button" variant="outline" className="rounded-full" onClick={onToggleExpanded}>

--- a/apps/web/src/components/search/SnippetCardExpanded.test.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.test.tsx
@@ -68,8 +68,10 @@ function createResult(index: number, overrides: Partial<ResumeSearchResultItem> 
   return {
     key: overrides.key ?? `resume-${index}`,
     identityKey: overrides.identityKey ?? `identity-${index}`,
+    analysis: overrides.analysis,
     blocked: overrides.blocked ?? false,
     score: overrides.score ?? 90,
+    scoreSource: overrides.scoreSource ?? 'ai',
     status: overrides.status ?? 'interviewed_reject',
     statusMeta: overrides.statusMeta,
     resume: overrides.resume ?? createResume(index),
@@ -88,10 +90,35 @@ describe('SnippetCardExpanded', () => {
   })
 
   it('renders snapshot, metadata, signals, and a safe source-profile link', () => {
-    render(<SnippetCardExpanded item={createResult(1)} />)
+    render(
+      <SnippetCardExpanded
+        item={createResult(1, {
+          analysis: {
+            score: 90,
+            summary: 'Strong CNC sales fit with current machine-tool coverage.',
+            highlights: ['CNC sales', 'FANUC', 'Channel development'],
+            concerns: ['No Mandarin listed'],
+            recommendation: 'strong_match',
+            breakdown: {
+              industry_db: 48,
+              related_exp: 24,
+            },
+          },
+        })}
+      />
+    )
 
     expect(screen.getByText('Snapshot')).toBeInTheDocument()
     expect(screen.getByText('Strong machine-tools operator with channel sales depth.')).toBeInTheDocument()
+    expect(screen.getByText('AI analysis')).toBeInTheDocument()
+    expect(screen.getByText('Strong CNC sales fit with current machine-tool coverage.')).toBeInTheDocument()
+    expect(screen.getByText('CNC sales')).toBeInTheDocument()
+    expect(screen.getByText('Channel development')).toBeInTheDocument()
+    expect(screen.getByText('No Mandarin listed')).toBeInTheDocument()
+    expect(screen.getByText('industry db')).toBeInTheDocument()
+    expect(screen.getByText('48')).toBeInTheDocument()
+    expect(screen.getByText('related exp')).toBeInTheDocument()
+    expect(screen.getByText('24')).toBeInTheDocument()
     expect(screen.getByText('Recent work')).toBeInTheDocument()
     expect(screen.getByText('Sales Engineer @ FANUC')).toBeInTheDocument()
     expect(screen.getByText('Account Manager @ DMG MORI')).toBeInTheDocument()
@@ -101,7 +128,7 @@ describe('SnippetCardExpanded', () => {
     expect(screen.getByText('Machine Tools')).toBeInTheDocument()
     expect(screen.getByText('Automation')).toBeInTheDocument()
     expect(screen.getByText('Robotics')).toBeInTheDocument()
-    expect(screen.getByText('FANUC')).toBeInTheDocument()
+    expect(screen.getAllByText('FANUC').length).toBeGreaterThan(0)
     expect(screen.getByText('DMG MORI')).toBeInTheDocument()
     expect(screen.getByText('senior')).toBeInTheDocument()
 
@@ -114,6 +141,7 @@ describe('SnippetCardExpanded', () => {
     render(
       <SnippetCardExpanded
         item={createResult(2, {
+          scoreSource: 'rule',
           status: 'new',
           resume: createResume(2, {
             profileUrl: 'javascript:alert(1)',
@@ -137,6 +165,8 @@ describe('SnippetCardExpanded', () => {
       />
     )
 
+    expect(screen.getByText('Score source')).toBeInTheDocument()
+    expect(screen.getByText('AI summary is not available for this resume. The current visible score comes from rule scoring only.')).toBeInTheDocument()
     expect(screen.getByText('No summary available for this resume yet.')).toBeInTheDocument()
     expect(screen.getByText('No structured work history available.')).toBeInTheDocument()
     expect(screen.getByText('No location')).toBeInTheDocument()

--- a/apps/web/src/components/search/SnippetCardExpanded.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.tsx
@@ -16,8 +16,14 @@ function formatStatusLabel(value: string): string {
   return value.replace(/_/g, ' ')
 }
 
+function formatBreakdownLabel(value: string): string {
+  return value.replace(/_/g, ' ')
+}
+
 export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
   const fieldUsagePolicy = useResumeFieldUsagePolicy()
+  const analysis = item.analysis ?? item.resume.analysis
+  const hasAiAnalysis = item.scoreSource === 'ai' && Boolean(analysis)
   const presentationResume = useMemo(
     () => sanitizeResumeRecordForSurface(item.resume, 'presentation', fieldUsagePolicy),
     [fieldUsagePolicy, item.resume]
@@ -65,6 +71,73 @@ export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
         </div>
 
         <div className="space-y-4">
+          <div className="rounded-3xl border bg-white p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                {hasAiAnalysis ? 'AI analysis' : 'Score source'}
+              </div>
+              {typeof item.score === 'number' ? (
+                <Badge variant="outline" className="uppercase">
+                  {item.scoreSource === 'ai' ? `AI ${Math.round(item.score)}` : `Rule ${Math.round(item.score)}`}
+                </Badge>
+              ) : null}
+            </div>
+            {hasAiAnalysis && analysis ? (
+              <div className="space-y-4 text-sm text-slate-700">
+                <p className="leading-6">{analysis.summary || 'No AI summary available for this resume yet.'}</p>
+
+                {analysis.highlights.length > 0 ? (
+                  <div className="space-y-2">
+                    <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                      Highlights
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {analysis.highlights.slice(0, 6).map((highlight) => (
+                        <Badge key={highlight} variant="secondary">{highlight}</Badge>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                {analysis.concerns && analysis.concerns.length > 0 ? (
+                  <div className="space-y-2">
+                    <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                      Concerns
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {analysis.concerns.slice(0, 6).map((concern) => (
+                        <Badge key={concern} variant="outline">{concern}</Badge>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                {analysis.breakdown && Object.keys(analysis.breakdown).length > 0 ? (
+                  <div className="space-y-2">
+                    <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                      Breakdown
+                    </div>
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      {Object.entries(analysis.breakdown).map(([label, value]) => (
+                        <div
+                          key={label}
+                          className="flex items-center justify-between rounded-2xl border bg-slate-50 px-3 py-2"
+                        >
+                          <span className="capitalize text-slate-600">{formatBreakdownLabel(label)}</span>
+                          <span className="font-semibold text-slate-900">{value}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <p className="text-sm leading-6 text-slate-700">
+                AI summary is not available for this resume. The current visible score comes from rule scoring only.
+              </p>
+            )}
+          </div>
+
           <div className="rounded-3xl border bg-white p-4">
             <div className="mb-3 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Resume metadata

--- a/apps/web/src/components/search/search-types.ts
+++ b/apps/web/src/components/search/search-types.ts
@@ -4,6 +4,7 @@ import type { CandidateStatus } from '@/types/resume'
 import type { CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 
 export type SearchSortValue = 'score' | 'newest' | 'experience'
+export type SearchScoreSource = 'ai' | 'rule'
 
 export type FacetValueCount = {
   value: string
@@ -26,7 +27,9 @@ export type ResumeSearchResultItem = {
   identityKey: string
   resume: ConvexResumeItem
   blocked: boolean
+  analysis?: ConvexResumeItem['analysis']
   score?: number
+  scoreSource?: SearchScoreSource
   status: CandidateStatus
   statusMeta?: CandidateStatusRecord
 }

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { formatKeywordQuery } from '@trends/shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useResumeSearchState } from '@/hooks/useResumeSearchState'
+import { getCurrentResumeAiPromptVersion } from '@/lib/analysis-utils'
 import type { CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 import type { UrlSearchState } from '@/hooks/useUrlSearchState'
@@ -18,6 +19,8 @@ const {
   toastErrorMock: vi.fn(),
   toastInfoMock: vi.fn(),
 }))
+
+const CURRENT_PROMPT_VERSION = getCurrentResumeAiPromptVersion()
 
 vi.mock('../../../../packages/convex/convex/_generated/api', () => ({
   api: {
@@ -275,7 +278,16 @@ describe('useResumeSearchState', () => {
     }))
 
     resumesMock.push(
-      createResume(1, { primaryRuleScore: 72 }),
+      createResume(1, {
+        primaryRuleScore: 72,
+        analysis: {
+          score: 93,
+          summary: 'Best AI match',
+          highlights: [],
+          recommendation: 'strong_match',
+          promptVersion: CURRENT_PROMPT_VERSION,
+        },
+      }),
       createResume(2, { primaryRuleScore: 91 }),
       createResume(3, { primaryRuleScore: 84 }),
     )
@@ -284,10 +296,12 @@ describe('useResumeSearchState', () => {
 
     expect(result.current.activeSort).toBe('score')
     expect(result.current.filteredResults.map((item) => item.key)).toEqual([
+      'resume-1',
       'resume-2',
       'resume-3',
-      'resume-1',
     ])
+    expect(result.current.filteredResults[0]?.scoreSource).toBe('ai')
+    expect(result.current.filteredResults[0]?.analysis?.summary).toBe('Best AI match')
   })
 
   it('derives raw and cluster tags, applies local filters, and sorts matching results', () => {
@@ -613,6 +627,7 @@ describe('useResumeSearchState', () => {
           summary: 'Strong fit',
           highlights: [],
           recommendation: 'strong_match',
+          promptVersion: CURRENT_PROMPT_VERSION,
           breakdown: {
             industry_db: 55,
           },
@@ -642,9 +657,13 @@ describe('useResumeSearchState', () => {
             resumeId: 'resume-1',
             status: 'contacted',
             match: {
-              score: 88,
+              score: 91,
               recommendation: 'strong_match',
-              scoreSource: 'rule',
+              scoreSource: 'ai',
+              summary: 'Strong fit',
+              breakdown: {
+                industry_db: 55,
+              },
             },
             ruleScore: 88,
             userComment: 'Call first',

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -29,7 +29,15 @@ import {
   type TaxonomyClusterInput,
   type TaxonomyClusterResolver,
 } from '@/lib/taxonomy'
-import { toIndustryDbV2Stats } from '@/lib/resume-scoring'
+import {
+  getAnalysisForJob,
+  toIndustryDbV2Stats,
+  toRecommendation,
+} from '@/lib/resume-scoring'
+import {
+  getCurrentResumeAiPromptVersion,
+  resolveResumeAnalysisSourceKey,
+} from '@/lib/analysis-utils'
 import { resolveCollectionSource } from '@/lib/search-profile-sources'
 import type { SearchHistoryItem } from '@/hooks/useSession'
 import type {
@@ -118,7 +126,15 @@ function parseExperienceYears(value: string | undefined): number {
 function resolveScore(
   resume: ConvexResumeItem,
   jobDescriptionId: string | undefined,
+  analysis: ConvexResumeItem['analysis'],
 ): number | undefined {
+  if (
+    typeof analysis?.score === 'number' &&
+    Number.isFinite(analysis.score)
+  ) {
+    return analysis.score
+  }
+
   const normalizedJobDescriptionId = normalizeOptionalString(jobDescriptionId)
   const ruleScores = resume.ingestData?.ruleScores ?? {}
 
@@ -142,14 +158,52 @@ function resolveScore(
     return resume.primaryRuleScore
   }
 
-  if (
-    typeof resume.analysis?.score === 'number' &&
-    Number.isFinite(resume.analysis.score)
-  ) {
-    return resume.analysis.score
+  return undefined
+}
+
+function resolveSearchAnalysis(
+  resume: ConvexResumeItem,
+  jobDescriptionId: string | undefined,
+  keywords: string[],
+  location: string | undefined,
+  currentPromptVersion: number,
+): ConvexResumeItem['analysis'] {
+  const matchedAnalysis = getAnalysisForJob(
+    resume,
+    jobDescriptionId,
+    keywords,
+    {
+      location,
+      promptVersion: currentPromptVersion,
+      sourceKey: resolveResumeAnalysisSourceKey({
+        source: resume.source,
+      }),
+    },
+  )
+
+  if (matchedAnalysis) {
+    return matchedAnalysis
   }
 
-  return undefined
+  const fallbackAnalysis = resume.analysis
+  if (!fallbackAnalysis) {
+    return undefined
+  }
+
+  if (fallbackAnalysis.promptVersion !== currentPromptVersion) {
+    return undefined
+  }
+
+  const ingestComputedAt = resume.ingestData?.computedAt
+  if (
+    typeof ingestComputedAt === 'number' &&
+    typeof fallbackAnalysis.analyzedAt === 'number' &&
+    ingestComputedAt > fallbackAnalysis.analyzedAt
+  ) {
+    return undefined
+  }
+
+  return fallbackAnalysis
 }
 
 function hasExplicitSearchContext(state: UrlSearchState): boolean {
@@ -262,17 +316,20 @@ function buildSearchExportMatch(
     return undefined
   }
 
-  const analysis = item.resume.analysis
-  const matchesAiScore =
-    typeof analysis?.score === 'number' &&
-    Number.isFinite(analysis.score) &&
-    analysis.score === item.score
+  const analysis = item.analysis
+  const usesAiScore = item.scoreSource === 'ai' && Boolean(analysis)
 
   return {
     score: item.score,
-    recommendation: resolveExportRecommendation(item.score),
-    scoreSource: matchesAiScore ? 'ai' : 'rule',
-    ...(matchesAiScore && analysis?.breakdown
+    recommendation:
+      usesAiScore && analysis
+        ? toRecommendation(analysis.recommendation)
+        : resolveExportRecommendation(item.score),
+    scoreSource: usesAiScore ? 'ai' : 'rule',
+    ...(usesAiScore && analysis?.summary
+      ? { summary: analysis.summary }
+      : {}),
+    ...(usesAiScore && analysis?.breakdown
       ? { breakdown: analysis.breakdown }
       : {}),
   }
@@ -493,6 +550,15 @@ export function useResumeSearchState() {
 
   const isLanding = !hasExplicitSearchContext(parsedState)
   const activeQuery = normalizeOptionalString(parsedState.query)
+  const currentPromptVersion = useMemo(() => getCurrentResumeAiPromptVersion(), [])
+  const analysisKeywords = useMemo(
+    () =>
+      normalizeStringList([
+        ...parsedState.keywords,
+        ...parseKeywordQuery(activeQuery ?? '').keywords,
+      ]),
+    [activeQuery, parsedState.keywords],
+  )
   const backendFilters = useMemo<ConvexResumeFilters>(
     () => ({
       minExperience: parsedState.filters.minExperience,
@@ -565,19 +631,41 @@ export function useResumeSearchState() {
     return resumeQuery.resumes.map((resume) => {
       const identityKey = resume.identityKey?.trim() || resume.externalId
       const statusRecord = statusByIdentity[identityKey]
+      const analysis = resolveSearchAnalysis(
+        resume,
+        parsedState.jobDescriptionId,
+        analysisKeywords,
+        parsedState.location,
+        currentPromptVersion,
+      )
+      const score = resolveScore(
+        resume,
+        parsedState.jobDescriptionId,
+        analysis,
+      )
       return {
         key: `${resume.resumeId}`,
         identityKey,
         resume,
         blocked: Boolean(blocksByIdentity[identityKey]),
-        score: resolveScore(resume, parsedState.jobDescriptionId),
+        analysis,
+        score,
+        scoreSource:
+          typeof score === 'number'
+            ? analysis && analysis.score === score
+              ? 'ai'
+              : 'rule'
+            : undefined,
         status: statusRecord?.status ?? 'new',
         statusMeta: statusRecord,
       }
     })
   }, [
+    analysisKeywords,
     blocksByIdentity,
+    currentPromptVersion,
     parsedState.jobDescriptionId,
+    parsedState.location,
     resumeQuery.resumes,
     statusByIdentity,
   ])


### PR DESCRIPTION
## Summary
- prefer cached AI analysis over rule score in the search-first resume hook
- surface per-resume AI summary and breakdown in search-first result cards
- preserve AI analysis metadata in export payloads and add focused test coverage

## Testing
- bunx vitest run -c vitest.config.ts src/components/search/SnippetCard.test.tsx src/components/search/SnippetCardExpanded.test.tsx src/hooks/useResumeSearchState.test.tsx
- bun run --filter '@trends/web' typecheck
- make check