### PR TITLE
feat: add search-first resume analysis dispatch

### DIFF
--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -8,16 +8,20 @@ import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 import type { UrlSearchState } from '@/hooks/useUrlSearchState'
 
 const {
+  dispatchAnalysisMutationMock,
   exportDownloadMock,
   toastErrorMock,
   toastInfoMock,
+  toastSuccessMock,
 } = vi.hoisted(() => ({
+  dispatchAnalysisMutationMock: vi.fn(async () => 'analysis-task-1'),
   exportDownloadMock: vi.fn(async (apiBaseUrl: string, payload: unknown) => {
     void apiBaseUrl
     void payload
   }),
   toastErrorMock: vi.fn(),
   toastInfoMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
 }))
 
 const CURRENT_PROMPT_VERSION = getCurrentResumeAiPromptVersion()
@@ -28,6 +32,10 @@ vi.mock('../../../../packages/convex/convex/_generated/api', () => ({
       recentSearches: 'recent-searches-query',
       saveSearchHistory: 'save-search-history-mutation',
       markSearchHistoryOpened: 'mark-search-history-opened-mutation',
+    },
+    analysis_tasks: {
+      dispatch: 'analysis-tasks-dispatch-mutation',
+      list: 'analysis-tasks-list-query',
     },
     taxonomy_clusters: {
       list: 'taxonomy-clusters-list-query',
@@ -47,6 +55,7 @@ vi.mock('sonner', () => ({
   toast: {
     error: (message: unknown) => toastErrorMock(message),
     info: (message: unknown) => toastInfoMock(message),
+    success: (message: unknown) => toastSuccessMock(message),
   },
 }))
 
@@ -58,6 +67,7 @@ const {
   resumesMock,
   saveSearchHistoryMutationMock,
   recentSearchHistoryRecordsMock,
+  analysisTasksMock,
   statusByIdentityMock,
   syncToUrlMock,
   taxonomyClusterRecordsMock,
@@ -78,6 +88,7 @@ const {
   resumesMock: [] as ConvexResumeItem[],
   saveSearchHistoryMutationMock: vi.fn(async () => 'history-1'),
   recentSearchHistoryRecordsMock: [] as Array<Record<string, unknown>>,
+  analysisTasksMock: [] as Array<Record<string, unknown>>,
   statusByIdentityMock: {} as Record<string, CandidateStatusRecord>,
   syncToUrlMock: vi.fn(),
   taxonomyClusterRecordsMock: [] as Array<Record<string, unknown>>,
@@ -221,6 +232,7 @@ describe('useResumeSearchState', () => {
 
     resumesMock.splice(0, resumesMock.length)
     recentSearchHistoryRecordsMock.splice?.(0, recentSearchHistoryRecordsMock.length)
+    analysisTasksMock.splice?.(0, analysisTasksMock.length)
     taxonomyClusterRecordsMock.splice?.(0, taxonomyClusterRecordsMock.length)
     Object.keys(statusByIdentityMock).forEach((key) => delete statusByIdentityMock[key])
     Object.keys(blocksByIdentityMock).forEach((key) => delete blocksByIdentityMock[key])
@@ -242,6 +254,9 @@ describe('useResumeSearchState', () => {
       if (query === 'recent-searches-query') {
         return recentSearchHistoryRecordsMock
       }
+      if (query === 'analysis-tasks-list-query') {
+        return analysisTasksMock
+      }
       if (query === 'taxonomy-clusters-list-query') {
         return taxonomyClusterRecordsMock
       }
@@ -255,6 +270,9 @@ describe('useResumeSearchState', () => {
       if (mutation === 'mark-search-history-opened-mutation') {
         return markSearchHistoryOpenedMutationMock
       }
+      if (mutation === 'analysis-tasks-dispatch-mutation') {
+        return dispatchAnalysisMutationMock
+      }
       return vi.fn()
     })
 
@@ -265,6 +283,7 @@ describe('useResumeSearchState', () => {
       loadingMore: convexQueryStateMock.loadingMore,
     }))
     exportDownloadMock.mockResolvedValue(undefined)
+    dispatchAnalysisMutationMock.mockResolvedValue('analysis-task-1')
   })
 
   afterEach(() => {
@@ -682,6 +701,38 @@ describe('useResumeSearchState', () => {
       },
     )
     expect(toastInfoMock).toHaveBeenCalledWith('Started export for 2 resumes')
+  })
+
+  it('dispatches analysis for top visible results without cached analysis', async () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'machine tools',
+      keywords: ['machine tools'],
+      location: 'China',
+    }))
+
+    resumesMock.push(
+      createResume(1, { primaryRuleScore: 88 }),
+      createResume(2, { primaryRuleScore: 79 }),
+    )
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(result.current.analysisCandidateCount).toBe(2)
+    expect(result.current.disableAnalyzeResults).toBe(false)
+
+    await act(async () => {
+      await result.current.analyzeResults()
+    })
+
+    expect(dispatchAnalysisMutationMock).toHaveBeenCalledWith({
+      keywords: ['machine tools', 'machine', 'tools'],
+      location: 'China',
+      promptVersion: CURRENT_PROMPT_VERSION,
+      resumeIds: ['resume-1', 'resume-2'],
+    })
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      'Analyzing top 2 candidates...',
+    )
   })
 
   it('clears only facet filters while preserving the active search context', () => {

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -21,6 +21,7 @@ import {
   submitResumeExportDownload,
   type ResumeExportRequestBody,
 } from '@/lib/resume-export'
+import { rawApiClient } from '@/lib/api-helpers'
 import {
   createTaxonomyClusterResolver,
   fromClusterFilterToken,
@@ -55,6 +56,15 @@ import type {
 const INITIAL_RESUME_LIMIT = 200
 const RESUME_PAGE_INCREMENT = 200
 const SESSION_KEY_PREFIX = 'trends.resume.search.sessionKey'
+const ANALYSIS_DISPATCH_COOLDOWN_MS = 2000
+
+type JobDescriptionApiResponse = {
+  success: boolean
+  item?: {
+    title?: string
+  }
+  content?: string
+}
 
 type SearchHistoryRecord = {
   _id: SearchHistoryItem['id']
@@ -501,11 +511,15 @@ export function useResumeSearchState() {
   )
   const [exportFormat, setExportFormat] = useState<ResumeExportFormat>('csv')
   const [exportingResults, setExportingResults] = useState(false)
+  const [analyzingResults, setAnalyzingResults] = useState(false)
+  const [lastAnalysisDispatchTime, setLastAnalysisDispatchTime] = useState(0)
   const [resumeLimit, setResumeLimit] = useState(INITIAL_RESUME_LIMIT)
   const saveSearchHistory = useMutation(api.sessions.saveSearchHistory)
   const markSearchHistoryOpened = useMutation(
     api.sessions.markSearchHistoryOpened,
   )
+  const dispatchAnalysis = useMutation(api.analysis_tasks.dispatch)
+  const analysisTasks = useQuery(api.analysis_tasks.list)
   const recentSearchHistoryRecords = useQuery(api.sessions.recentSearches, {
     sessionKey,
     workspaceSlug: slug,
@@ -698,6 +712,32 @@ export function useResumeSearchState() {
   const hasMore = resumeQuery.hasMore
   const loading = !isLanding && resumeQuery.loading
   const loadingMore = resumeQuery.loadingMore
+  const analysisCandidateLimit =
+    Number(import.meta.env.VITE_ANALYSIS_TOP_N) || 10
+  const analysisCandidates = useMemo(
+    () =>
+      filteredResults
+        .filter(
+          (item) =>
+            !item.analysis &&
+            typeof item.resume.resumeId === 'string',
+        )
+        .slice(0, analysisCandidateLimit),
+    [analysisCandidateLimit, filteredResults],
+  )
+  const hasActiveAnalysisTask = useMemo(
+    () =>
+      (analysisTasks ?? []).some(
+        (task) => task.status === 'pending' || task.status === 'processing',
+      ),
+    [analysisTasks],
+  )
+  const disableAnalyzeResults =
+    isLanding ||
+    filteredResults.length === 0 ||
+    analyzingResults ||
+    hasActiveAnalysisTask ||
+    (!parsedState.jobDescriptionId && analysisKeywords.length === 0)
   const filterCount =
     parsedState.selectedTags.length +
     parsedState.selectedCompanies.length +
@@ -1051,12 +1091,92 @@ export function useResumeSearchState() {
     }
   }, [apiBaseUrl, exportFormat, filteredResults])
 
+  const analyzeResults = useCallback(async () => {
+    if (filteredResults.length === 0) {
+      return
+    }
+
+    if (hasActiveAnalysisTask) {
+      toast.info('Please wait for current analysis to complete.')
+      return
+    }
+
+    const now = Date.now()
+    if (now - lastAnalysisDispatchTime < ANALYSIS_DISPATCH_COOLDOWN_MS) {
+      toast.info('Please wait for current analysis to complete.')
+      return
+    }
+
+    if (analysisCandidates.length === 0) {
+      toast.info('No new candidates to analyze among top matches.')
+      return
+    }
+
+    setAnalyzingResults(true)
+    try {
+      const resumeIds = analysisCandidates.map((item) => item.resume.resumeId)
+      const normalizedLocation = normalizeOptionalString(parsedState.location)
+      const keywords =
+        analysisKeywords.length > 0 ? analysisKeywords : undefined
+      let jobDescriptionTitle: string | undefined
+      let jobDescriptionContent: string | undefined
+
+      if (parsedState.jobDescriptionId) {
+        try {
+          const { data } = await rawApiClient.GET<JobDescriptionApiResponse>(
+            `/api/job-descriptions/${parsedState.jobDescriptionId}`,
+          )
+          if (data?.success) {
+            jobDescriptionTitle = normalizeOptionalString(data.item?.title)
+            jobDescriptionContent = normalizeOptionalString(data.content)
+          }
+        } catch (error) {
+          console.error('Failed to fetch JD content for analysis dispatch', error)
+        }
+      }
+
+      await dispatchAnalysis({
+        ...(parsedState.jobDescriptionId
+          ? { jobDescriptionId: parsedState.jobDescriptionId }
+          : {}),
+        ...(jobDescriptionTitle ? { jobDescriptionTitle } : {}),
+        ...(jobDescriptionContent ? { jobDescriptionContent } : {}),
+        ...(keywords ? { keywords } : {}),
+        ...(normalizedLocation ? { location: normalizedLocation } : {}),
+        promptVersion: currentPromptVersion,
+        resumeIds,
+      })
+
+      setLastAnalysisDispatchTime(Date.now())
+      toast.success(`Analyzing top ${resumeIds.length} candidates...`)
+    } catch (error) {
+      console.error('Failed to dispatch search analysis task', error)
+      toast.error('Failed to start AI analysis. Please try again.')
+    } finally {
+      setAnalyzingResults(false)
+    }
+  }, [
+    analysisCandidates,
+    analysisKeywords,
+    currentPromptVersion,
+    dispatchAnalysis,
+    filteredResults.length,
+    hasActiveAnalysisTask,
+    lastAnalysisDispatchTime,
+    parsedState.jobDescriptionId,
+    parsedState.location,
+  ])
+
   return {
     activeQuery,
     activeSort,
+    analysisCandidateCount: analysisCandidates.length,
+    analyzeResults,
     applyRecentSearch,
+    analyzingResults,
     clearFacetFilters,
     clearSearch,
+    disableAnalyzeResults,
     exportFormat,
     exportingResults,
     exportResults,
@@ -1064,6 +1184,7 @@ export function useResumeSearchState() {
     filterCount,
     filteredResults,
     hasMore,
+    hasActiveAnalysisTask,
     isLanding,
     loading,
     loadingMore,

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -226,6 +226,10 @@ vi.mock('@/components/search/SearchResultsList', () => ({
   ),
 }))
 
+vi.mock('@/components/AnalysisTaskMonitor', () => ({
+  AnalysisTaskMonitor: () => <div>Analysis Task Monitor</div>,
+}))
+
 function createResume(index: number): ConvexResumeItem {
   return {
     resumeId: `resume-${index}` as ConvexResumeItem['resumeId'],
@@ -292,9 +296,13 @@ function createResumeSearchState(overrides: Record<string, unknown> = {}) {
   return {
     activeQuery: undefined,
     activeSort: 'score',
+    analysisCandidateCount: 0,
+    analyzeResults: vi.fn(),
+    analyzingResults: false,
     applyRecentSearch: vi.fn(),
     clearFacetFilters: vi.fn(),
     clearSearch: vi.fn(),
+    disableAnalyzeResults: true,
     exportFormat: 'csv',
     exportingResults: false,
     exportResults: vi.fn(),
@@ -310,6 +318,7 @@ function createResumeSearchState(overrides: Record<string, unknown> = {}) {
     filterCount: 0,
     filteredResults: [] as ResumeSearchResultItem[],
     hasMore: false,
+    hasActiveAnalysisTask: false,
     isLanding: true,
     loading: false,
     loadingMore: false,
@@ -483,6 +492,8 @@ describe('ResumeSearchPage', () => {
     expect(
       screen.getByText('AI Summary Summary text generated:123 loading:false'),
     ).toBeInTheDocument()
+    expect(screen.getByText('Resume AI analysis')).toBeInTheDocument()
+    expect(screen.getByText('Analysis Task Monitor')).toBeInTheDocument()
 
     expect(useAiSearchSummaryMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -598,5 +609,25 @@ describe('ResumeSearchPage', () => {
 
     expect(state.setExportFormat).toHaveBeenCalledWith('xlsx')
     expect(state.exportResults).toHaveBeenCalledTimes(1)
+  })
+
+  it('wires the search-first analyze action into the page controls', async () => {
+    const user = userEvent.setup()
+    const state = createResumeSearchState({
+      activeQuery: 'CNC Sales',
+      analysisCandidateCount: 2,
+      analyzeResults: vi.fn(),
+      disableAnalyzeResults: false,
+      filteredResults: [createResult(1)],
+      hasActiveAnalysisTask: false,
+      isLanding: false,
+    })
+    useResumeSearchStateMock.mockReturnValue(state)
+
+    render(<ResumeSearchPage />)
+
+    await user.click(screen.getByRole('button', { name: /Analyze top 2/i }))
+
+    expect(state.analyzeResults).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -1,5 +1,7 @@
 import { formatKeywordQuery, parseKeywordQuery } from '@trends/shared'
+import { RefreshCw } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import { AnalysisTaskMonitor } from '@/components/AnalysisTaskMonitor'
 import { AiSummaryPanel } from '@/components/search/AiSummaryPanel'
 import { FacetBadge } from '@/components/search/FacetBadge'
 import { FacetSidebar } from '@/components/search/FacetSidebar'
@@ -8,6 +10,7 @@ import { MobileFilterSheet } from '@/components/search/MobileFilterSheet'
 import { SearchHeader } from '@/components/search/SearchHeader'
 import { SearchHero } from '@/components/search/SearchHero'
 import { SearchResultsList } from '@/components/search/SearchResultsList'
+import { Button } from '@/components/ui/button'
 import { useAiSearchSummary } from '@/hooks/useAiSearchSummary'
 import { useIndustryKeywords } from '@/hooks/useIndustryKeywords'
 import { useResumeSearchState } from '@/hooks/useResumeSearchState'
@@ -19,9 +22,13 @@ export function ResumeSearchPage() {
   const {
     activeQuery,
     activeSort,
+    analysisCandidateCount,
+    analyzeResults,
+    analyzingResults,
     applyRecentSearch,
     clearFacetFilters,
     clearSearch,
+    disableAnalyzeResults,
     exportFormat,
     exportingResults,
     exportResults,
@@ -29,6 +36,7 @@ export function ResumeSearchPage() {
     filterCount,
     filteredResults,
     hasMore,
+    hasActiveAnalysisTask,
     isLanding,
     loading,
     loadingMore,
@@ -207,6 +215,43 @@ export function ResumeSearchPage() {
             </div>
 
             <div className="min-w-0 flex-1 space-y-4">
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-[1.5rem] border bg-white/80 px-4 py-3 shadow-sm">
+                <div className="min-w-0">
+                  <div className="text-sm font-medium text-slate-900">
+                    Resume AI analysis
+                  </div>
+                  <p className="text-sm text-slate-600">
+                    Generate per-resume AI summaries and breakdowns for the top visible matches.
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="h-10 gap-2 rounded-full px-4"
+                    disabled={disableAnalyzeResults}
+                    onClick={() => {
+                      void analyzeResults()
+                    }}
+                  >
+                    {analyzingResults || hasActiveAnalysisTask ? (
+                      <>
+                        <RefreshCw className="h-4 w-4 animate-spin" />
+                        Analyzing...
+                      </>
+                    ) : (
+                      <>
+                        <RefreshCw className="h-4 w-4" />
+                        {analysisCandidateCount > 0
+                          ? `Analyze top ${analysisCandidateCount}`
+                          : 'Analyze top results'}
+                      </>
+                    )}
+                  </Button>
+                  <AnalysisTaskMonitor />
+                </div>
+              </div>
+
               <AiSummaryPanel
                 generatedAt={aiSummary.generatedAt}
                 loading={aiSummary.loading}


### PR DESCRIPTION
## Summary
- add a search-first `Analyze top results` action that dispatches Convex analysis tasks for the current visible matches
- reuse the existing analysis task monitor in the search-first page so operators can see processing state
- cover the new dispatch path in the search-first hook and page tests

## Testing
- bunx vitest run -c vitest.config.ts src/hooks/useResumeSearchState.test.tsx src/pages/ResumeSearchPage.test.tsx src/components/search/SnippetCard.test.tsx src/components/search/SnippetCardExpanded.test.tsx
- bun run --filter '@trends/web' typecheck
- make check