### PR TITLE
feat: unify landing quick starts with search profiles

### DIFF
--- a/apps/api/src/routes/search-profiles.test.ts
+++ b/apps/api/src/routes/search-profiles.test.ts
@@ -82,6 +82,60 @@ function removeRunStatusFile(): void {
   }
 }
 
+describe('search-profiles list route', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('includes seeded system profiles with landing quick-start metadata', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+
+      if (call.pathName === 'search_profiles:list') {
+        return convexSuccess([])
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`)
+    })
+
+    const app = createApp()
+    const response = await app.request('/api/search-profiles', {
+      headers: {
+        'X-Workspace-Slug': 'dev',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+
+    expect(payload.success).toBe(true)
+    expect(payload.profiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'job5156-cn-cnc-sales',
+          origin: 'system',
+          readOnly: true,
+          quickStart: expect.objectContaining({
+            enabled: true,
+            rank: 1,
+            label: 'China · Job5156 · CNC 销售',
+          }),
+        }),
+        expect.objectContaining({
+          id: 'seek-malaysia-sales',
+          origin: 'system',
+          readOnly: true,
+          quickStart: expect.objectContaining({
+            enabled: true,
+            rank: 2,
+            label: 'Malaysia · SEEK · CNC Sales',
+          }),
+        }),
+      ]),
+    )
+  })
+})
+
 describe('search-profiles run route', () => {
   beforeEach(() => {
     removeRunStatusFile()

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -26,6 +26,14 @@ const ProfileSummarySchema = z.object({
     status: z.enum(["active", "paused", "archived"]),
     location: z.string(),
     keywords: z.array(z.string()),
+    origin: z.enum(["system", "workspace"]),
+    readOnly: z.boolean(),
+    quickStart: z.object({
+        enabled: z.boolean(),
+        rank: z.number().optional(),
+        label: z.string().optional(),
+        description: z.string().optional(),
+    }).optional(),
 });
 
 const StatsSchema = z.object({
@@ -613,10 +621,32 @@ async function loadProfileById(id: string, workspaceSlug: string): Promise<Searc
     }
 
     try {
-        return searchProfileService.loadProfile(id);
+        return searchProfileService.loadProfile(id, workspaceSlug);
     } catch {
         return null;
     }
+}
+
+function compareProfileSummaries(
+    left: z.infer<typeof ProfileSummarySchema>,
+    right: z.infer<typeof ProfileSummarySchema>
+): number {
+    const leftQuickStartRank = left.quickStart?.enabled ? left.quickStart.rank ?? Number.MAX_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
+    const rightQuickStartRank = right.quickStart?.enabled ? right.quickStart.rank ?? Number.MAX_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
+
+    if (leftQuickStartRank !== rightQuickStartRank) {
+        return leftQuickStartRank - rightQuickStartRank;
+    }
+
+    if (left.quickStart?.enabled !== right.quickStart?.enabled) {
+        return left.quickStart?.enabled ? -1 : 1;
+    }
+
+    if (left.origin !== right.origin) {
+        return left.origin === "system" ? -1 : 1;
+    }
+
+    return right.updatedAt.localeCompare(left.updatedAt);
 }
 
 // ============================================================
@@ -677,8 +707,21 @@ const listRoute = createRoute({
 });
 
 app.openapi(listRoute, async (c) => {
-    const profiles = await listCustomProfiles(c.var.workspaceSlug);
-    const summaries = profiles.map((profile) => ({
+    const workspaceProfiles = await listCustomProfiles(c.var.workspaceSlug);
+    const systemProfiles = searchProfileService.listProfiles(c.var.workspaceSlug)
+        .map((profileFile) => ({
+            id: profileFile.id,
+            name: profileFile.name,
+            filename: profileFile.filename,
+            updatedAt: profileFile.updatedAt,
+            status: profileFile.status,
+            location: profileFile.location,
+            keywords: profileFile.keywords,
+            origin: "system" as const,
+            readOnly: true,
+            quickStart: profileFile.quickStart,
+        }));
+    const workspaceSummaries = workspaceProfiles.map((profile) => ({
         id: profile.id,
         name: profile.name,
         filename: `${profile.id}.yaml`,
@@ -686,7 +729,20 @@ app.openapi(listRoute, async (c) => {
         status: profile.status,
         location: profile.location,
         keywords: profile.keywords,
+        origin: "workspace" as const,
+        readOnly: false,
+        quickStart: profile.quickStart,
     }));
+
+    const summariesById = new Map<string, z.infer<typeof ProfileSummarySchema>>();
+    for (const summary of systemProfiles) {
+        summariesById.set(summary.id, summary);
+    }
+    for (const summary of workspaceSummaries) {
+        summariesById.set(summary.id, summary);
+    }
+
+    const summaries = Array.from(summariesById.values()).sort(compareProfileSummaries);
     return c.json({ success: true, profiles: summaries } as const);
 });
 
@@ -724,7 +780,7 @@ app.openapi(autoMatchRoute, async (c) => {
     const { keywords, location } = c.req.valid("json");
     const customProfiles = await listCustomProfiles(c.var.workspaceSlug);
     const customMatch = matchProfiles(customProfiles, keywords, location);
-    const systemMatch = searchProfileService.findByKeywords(keywords, location);
+    const systemMatch = searchProfileService.findByKeywords(keywords, location, c.var.workspaceSlug);
     const result = customMatch.confidence >= systemMatch.confidence ? customMatch : systemMatch;
 
     return c.json({

--- a/apps/api/src/services/search-profile-service.ts
+++ b/apps/api/src/services/search-profile-service.ts
@@ -65,6 +65,14 @@ export interface SearchProfile {
         jobUrl?: string;
     }>;
 
+    // Landing page quick start
+    quickStart?: {
+        enabled: boolean;
+        rank?: number;
+        label?: string;
+        description?: string;
+    };
+
     // Notifications
     notifications?: {
         enabled: boolean;
@@ -110,11 +118,13 @@ export interface SearchProfile {
 export interface SearchProfileFile {
     id: string;
     name: string;
+    description?: string;
     filename: string;
     updatedAt: string;
     status: "active" | "paused" | "archived";
     location: string;
     keywords: string[];
+    quickStart?: SearchProfile["quickStart"];
 }
 
 export interface AutoMatchResult {
@@ -127,6 +137,7 @@ export interface AutoMatchResult {
 
 type ProfileFilters = NonNullable<SearchProfile["filters"]>;
 type ProfileSalaryRange = NonNullable<ProfileFilters["salaryRange"]>;
+type ProfileQuickStart = NonNullable<SearchProfile["quickStart"]>;
 type ProfileSession = NonNullable<SearchProfile["session"]>;
 type ProfileRetention = NonNullable<ProfileSession["retention"]>;
 
@@ -380,6 +391,28 @@ function parseSources(value: unknown): SearchProfile["sources"] | undefined {
     return sources.length > 0 ? sources : undefined;
 }
 
+function parseQuickStart(value: unknown): SearchProfile["quickStart"] | undefined {
+    if (!isRecord(value)) return undefined;
+
+    const enabled = readBoolean(value.enabled) ?? false;
+    const rank = readNumber(value.rank);
+    const label = readString(value.label);
+    const description = readString(value.description);
+
+    if (!enabled && rank === undefined && !label && !description) {
+        return undefined;
+    }
+
+    const quickStart: ProfileQuickStart = {
+        enabled,
+        rank,
+        label,
+        description,
+    };
+
+    return quickStart;
+}
+
 function parseNotifications(value: unknown): SearchProfile["notifications"] | undefined {
     if (!isRecord(value)) return undefined;
 
@@ -533,7 +566,7 @@ export class SearchProfileService {
         return path.join(this.projectRoot, "config", "search-profiles");
     }
 
-    private getProfilesDir(workspaceSlug?: string): string {
+    private getProfilesWorkspaceDir(workspaceSlug?: string): string {
         const normalizedWorkspace = normalizeWorkspaceSlug(workspaceSlug);
         const baseDir = this.getProfilesBaseDir();
         if (normalizedWorkspace === DEFAULT_WORKSPACE_SLUG) {
@@ -542,16 +575,36 @@ export class SearchProfileService {
         return path.join(baseDir, normalizedWorkspace);
     }
 
-    private findExistingProfilePath(id: string, workspaceSlug?: string): string | null {
-        const profilesDir = this.getProfilesDir(workspaceSlug);
-        const candidates = [
-            path.join(profilesDir, `${id}.yaml`),
-            path.join(profilesDir, `${id}.yml`),
-        ];
+    private getProfilesListDirs(workspaceSlug?: string): string[] {
+        const normalizedWorkspace = normalizeWorkspaceSlug(workspaceSlug);
+        const baseDir = this.getProfilesBaseDir();
+        if (normalizedWorkspace === DEFAULT_WORKSPACE_SLUG) {
+            return [baseDir];
+        }
+        return [baseDir, this.getProfilesWorkspaceDir(normalizedWorkspace)];
+    }
 
-        for (const candidate of candidates) {
-            if (fs.existsSync(candidate)) {
-                return candidate;
+    private getProfilesLookupDirs(workspaceSlug?: string): string[] {
+        const normalizedWorkspace = normalizeWorkspaceSlug(workspaceSlug);
+        const baseDir = this.getProfilesBaseDir();
+        if (normalizedWorkspace === DEFAULT_WORKSPACE_SLUG) {
+            return [baseDir];
+        }
+        return [this.getProfilesWorkspaceDir(normalizedWorkspace), baseDir];
+    }
+
+    private findExistingProfilePath(id: string, workspaceSlug?: string): string | null {
+        const profileDirs = this.getProfilesLookupDirs(workspaceSlug);
+        for (const profilesDir of profileDirs) {
+            const candidates = [
+                path.join(profilesDir, `${id}.yaml`),
+                path.join(profilesDir, `${id}.yml`),
+            ];
+
+            for (const candidate of candidates) {
+                if (fs.existsSync(candidate)) {
+                    return candidate;
+                }
             }
         }
 
@@ -596,6 +649,7 @@ export class SearchProfileService {
         const filters = hasOwn(record, "filters") ? parseFilters(record.filters) : fallback?.filters;
         const schedule = hasOwn(record, "schedule") ? parseSchedule(record.schedule) : fallback?.schedule;
         const sources = hasOwn(record, "sources") ? parseSources(record.sources) : fallback?.sources;
+        const quickStart = hasOwn(record, "quickStart") ? parseQuickStart(record.quickStart) : fallback?.quickStart;
         const notifications = hasOwn(record, "notifications")
             ? parseNotifications(record.notifications)
             : fallback?.notifications;
@@ -617,6 +671,7 @@ export class SearchProfileService {
             filters,
             schedule,
             sources,
+            quickStart,
             notifications,
             ai,
             session,
@@ -679,29 +734,34 @@ export class SearchProfileService {
      * List all profile files
      */
     listProfiles(workspaceSlug?: string): SearchProfileFile[] {
-        const dir = this.getProfilesDir(workspaceSlug);
-        if (!fs.existsSync(dir)) return [];
+        const entriesById = new Map<string, SearchProfileFile>();
 
-        const entries = fs.readdirSync(dir)
-            .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
-            .map((filename) => {
+        for (const dir of this.getProfilesListDirs(workspaceSlug)) {
+            if (!fs.existsSync(dir)) {
+                continue;
+            }
+
+            for (const filename of fs.readdirSync(dir).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))) {
                 const filePath = path.join(dir, filename);
                 const stat = fs.statSync(filePath);
                 const fallbackId = filename.replace(/\.(yaml|yml)$/i, "");
                 const profile = this.readProfileFromFile(filePath, fallbackId);
 
-                return {
+                entriesById.set(profile.id, {
                     id: profile.id,
                     name: profile.name,
+                    description: profile.description,
                     filename,
                     updatedAt: stat.mtime.toISOString(),
                     status: profile.status,
                     location: profile.location,
                     keywords: profile.keywords,
-                } satisfies SearchProfileFile;
-            });
+                    quickStart: profile.quickStart,
+                } satisfies SearchProfileFile);
+            }
+        }
 
-        return entries.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+        return Array.from(entriesById.values()).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
     }
 
     /**

--- a/apps/web/src/components/ProfileCard.tsx
+++ b/apps/web/src/components/ProfileCard.tsx
@@ -12,6 +12,14 @@ export type SearchProfileSummary = {
   status: 'active' | 'paused' | 'archived'
   location: string
   keywords: string[]
+  origin: 'system' | 'workspace'
+  readOnly: boolean
+  quickStart?: {
+    enabled: boolean
+    rank?: number
+    label?: string
+    description?: string
+  }
 }
 
 export type SearchProfileRunStatus = {
@@ -47,6 +55,10 @@ function statusBadgeVariant(status: SearchProfileSummary['status']): 'default' |
   return 'outline'
 }
 
+function originBadgeLabel(origin: SearchProfileSummary['origin']): string {
+  return origin === 'system' ? 'seeded' : 'workspace'
+}
+
 function runStatusLabel(status: SearchProfileRunStatus['taskStatus']): string {
   if (status === 'pending') return 'pending'
   if (status === 'processing') return 'running'
@@ -74,13 +86,25 @@ export function ProfileCard({
       <CardHeader className="space-y-2">
         <div className="flex items-center justify-between gap-2">
           <CardTitle className="text-base leading-tight">{profile.name}</CardTitle>
-          <Badge variant={statusBadgeVariant(profile.status)}>{profile.status}</Badge>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            {profile.quickStart?.enabled ? (
+              <Badge variant="secondary">quick start</Badge>
+            ) : null}
+            <Badge variant="outline">{originBadgeLabel(profile.origin)}</Badge>
+            <Badge variant={statusBadgeVariant(profile.status)}>{profile.status}</Badge>
+          </div>
         </div>
         <div className="text-sm text-muted-foreground">
           {profile.location} · {profile.keywords.join(', ') || '--'}
         </div>
       </CardHeader>
       <CardContent className="space-y-2 text-sm">
+        {profile.quickStart?.enabled ? (
+          <div>
+            <span className="font-medium">Landing quick start:</span>{' '}
+            {profile.quickStart.label || profile.name}
+          </div>
+        ) : null}
         <div>
           <span className="font-medium">Schedule:</span> {scheduleLabel}
         </div>
@@ -99,11 +123,21 @@ export function ProfileCard({
           <Play className="h-3.5 w-3.5 mr-1" />
           Run Now
         </Button>
-        <Button size="sm" variant="outline" onClick={() => onEdit(profile.id)}>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => onEdit(profile.id)}
+          disabled={profile.readOnly}
+        >
           <Pencil className="h-3.5 w-3.5 mr-1" />
           Edit
         </Button>
-        <Button size="sm" variant="outline" onClick={() => onDelete(profile.id)}>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => onDelete(profile.id)}
+          disabled={profile.readOnly}
+        >
           <Trash2 className="h-3.5 w-3.5 mr-1" />
           Delete
         </Button>

--- a/apps/web/src/components/search/MigrationBanner.tsx
+++ b/apps/web/src/components/search/MigrationBanner.tsx
@@ -23,7 +23,7 @@ export function MigrationBanner() {
       <div className="space-y-1">
         <div className="font-medium">Search Profiles still exist, but the primary resume route is now search-first.</div>
         <div className="text-sky-800/80">
-          Use this page for fast keyword review. Use Search Profiles when you need managed workflow presets and JD-driven setup.
+          Use this page for fast keyword review. Use Search Profiles when you need landing quick starts, scheduled collectors, and JD-driven setup.
         </div>
       </div>
       <div className="flex items-center gap-2">

--- a/apps/web/src/components/search/SearchHero.test.tsx
+++ b/apps/web/src/components/search/SearchHero.test.tsx
@@ -65,15 +65,14 @@ function buildRecentSearch(
   }
 }
 
-function buildWorkflowSeed(
+function buildQuickStart(
   overrides: Partial<
-    NonNullable<SearchHeroProps['workflowSeeds']>[number]
+    NonNullable<SearchHeroProps['quickStarts']>[number]
   > = {},
 ) {
   return {
-    id: 'workflow-1',
+    id: 'profile-1',
     label: 'China · Job5156 · CNC 销售',
-    market: 'CN',
     location: 'China',
     keywords: ['CNC', '销售'],
     ...overrides,
@@ -97,11 +96,11 @@ function renderSearchHero(overrides: Partial<SearchHeroProps> = {}) {
     queryInput: '',
     recentSearches: [],
     recentSearchesLoading: false,
-    workflowSeeds: undefined,
+    quickStarts: undefined,
     hotKeywords: undefined,
     onApplyRecentSearch: vi.fn(),
     onApplyExtractedKeywords: vi.fn(),
-    onApplyWorkflowSeed: undefined,
+    onApplyQuickStart: undefined,
     onToggleHotKeyword: undefined,
     onChangeQuery: vi.fn(),
     onClearQuery: vi.fn(),
@@ -218,14 +217,13 @@ describe('SearchHero', () => {
     expect(onSubmitQuery).toHaveBeenCalledWith('submitted')
   })
 
-  it('renders quick-start cards from workflowSeeds', () => {
+  it('renders quick-start cards from profile-backed quick starts', () => {
     renderSearchHero({
-      workflowSeeds: [
-        buildWorkflowSeed(),
-        buildWorkflowSeed({
-          id: 'workflow-2',
+      quickStarts: [
+        buildQuickStart(),
+        buildQuickStart({
+          id: 'profile-2',
           label: 'Malaysia · SEEK · CNC Sales',
-          market: 'MY',
           location: 'Kuala Lumpur MY',
           keywords: ['CNC', 'Sales'],
         }),
@@ -259,20 +257,20 @@ describe('SearchHero', () => {
     expect(screen.getByRole('button', { name: 'China' })).toBeInTheDocument()
   })
 
-  it('clicking a quick-start card calls onApplyWorkflowSeed', async () => {
+  it('clicking a quick-start card calls onApplyQuickStart', async () => {
     const user = userEvent.setup()
-    const onApplyWorkflowSeed = vi.fn()
+    const onApplyQuickStart = vi.fn()
 
     renderSearchHero({
-      workflowSeeds: [buildWorkflowSeed()],
-      onApplyWorkflowSeed,
+      quickStarts: [buildQuickStart()],
+      onApplyQuickStart,
     })
 
     await user.click(
       screen.getByRole('button', { name: /China · Job5156 · CNC 销售/i }),
     )
 
-    expect(onApplyWorkflowSeed).toHaveBeenCalledWith({
+    expect(onApplyQuickStart).toHaveBeenCalledWith({
       keywords: ['CNC', '销售'],
       location: 'China',
     })

--- a/apps/web/src/components/search/SearchHero.tsx
+++ b/apps/web/src/components/search/SearchHero.tsx
@@ -3,12 +3,12 @@ import { GoogleSearchBar } from '@/components/search/GoogleSearchBar'
 import { Card, CardContent } from '@/components/ui/card'
 import type { ResumeSearchRecentItem } from '@/components/search/search-types'
 
-type SearchHeroWorkflowSeed = {
+type SearchHeroQuickStart = {
   id: string
   label: string
-  market: string
   location: string
   keywords: string[]
+  description?: string
 }
 
 type SearchHeroHotKeyword = {
@@ -22,11 +22,11 @@ type SearchHeroProps = {
   queryInput: string
   recentSearches: ResumeSearchRecentItem[]
   recentSearchesLoading?: boolean
-  workflowSeeds?: SearchHeroWorkflowSeed[]
+  quickStarts?: SearchHeroQuickStart[]
   hotKeywords?: SearchHeroHotKeyword[]
   onApplyRecentSearch: (item: ResumeSearchRecentItem) => void | Promise<void>
   onApplyExtractedKeywords: (keywords: string[]) => void
-  onApplyWorkflowSeed?: (seed: { keywords: string[]; location: string }) => void
+  onApplyQuickStart?: (seed: { keywords: string[]; location: string }) => void
   onToggleHotKeyword?: (keyword: string) => void
   onChangeQuery: (value: string) => void
   onClearQuery: () => void
@@ -64,11 +64,11 @@ export function SearchHero({
   queryInput,
   recentSearches,
   recentSearchesLoading = false,
-  workflowSeeds = [],
+  quickStarts = [],
   hotKeywords = [],
   onApplyRecentSearch,
   onApplyExtractedKeywords,
-  onApplyWorkflowSeed,
+  onApplyQuickStart,
   onToggleHotKeyword,
   onChangeQuery,
   onClearQuery,
@@ -92,20 +92,20 @@ export function SearchHero({
           />
         </div>
 
-        {workflowSeeds.length > 0 ? (
+        {quickStarts.length > 0 ? (
           <div className="mx-auto w-full max-w-3xl text-left">
             <div className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
               <Zap className="h-3.5 w-3.5" />
               Quick Start
             </div>
             <div className="grid gap-3 sm:grid-cols-2">
-              {workflowSeeds.map((seed) => (
+              {quickStarts.map((seed) => (
                 <button
                   key={seed.id}
                   type="button"
                   className={INTERACTIVE_CARD_CLASS_NAME}
                   onClick={() =>
-                    void onApplyWorkflowSeed?.({
+                    void onApplyQuickStart?.({
                       keywords: seed.keywords,
                       location: seed.location,
                     })

--- a/apps/web/src/hooks/useIndustryKeywords.test.tsx
+++ b/apps/web/src/hooks/useIndustryKeywords.test.tsx
@@ -58,19 +58,6 @@ describe('useIndustryKeywords', () => {
                 source: 'workspace',
               },
             ],
-            workflowSeeds: [
-              {
-                id: 'seek-my-cnc-sales',
-                label: 'Malaysia · SEEK · CNC Sales',
-                market: 'MY',
-                location: 'Kuala Lumpur MY',
-                keywords: ['CNC', 'Sales'],
-                collectionSource: {
-                  type: 'seek',
-                },
-                visible: true,
-              },
-            ],
           },
         })
       }
@@ -84,11 +71,33 @@ describe('useIndustryKeywords', () => {
         })
       }
 
+      if (path === '/api/search-profiles') {
+        return Promise.resolve({
+          data: {
+            success: true,
+            profiles: [
+              {
+                id: 'job5156-cn-cnc-sales',
+                name: 'China Job5156 CNC Sales',
+                status: 'active',
+                location: 'China',
+                keywords: ['CNC', '销售'],
+                quickStart: {
+                  enabled: true,
+                  rank: 1,
+                  label: 'China · Job5156 · CNC 销售',
+                },
+              },
+            ],
+          },
+        })
+      }
+
       throw new Error(`Unexpected GET path: ${path}`)
     })
   })
 
-  it('keeps workspace custom tags in grouped keywords while limiting hotKeywords to system seed tags', async () => {
+  it('keeps workspace custom tags in grouped keywords while sourcing landing quick starts from search profiles', async () => {
     const { result } = renderHook(() => useIndustryKeywords())
 
     await waitFor(() => {
@@ -105,6 +114,12 @@ describe('useIndustryKeywords', () => {
       'HAAS',
       'STAR机床',
     ])
-    expect(result.current.workflowSeeds).toHaveLength(1)
+    expect(result.current.quickStartProfiles).toEqual([
+      expect.objectContaining({
+        id: 'job5156-cn-cnc-sales',
+        label: 'China · Job5156 · CNC 销售',
+        location: 'China',
+      }),
+    ])
   })
 })

--- a/apps/web/src/hooks/useIndustryKeywords.ts
+++ b/apps/web/src/hooks/useIndustryKeywords.ts
@@ -3,7 +3,6 @@ import { rawApiClient } from "@/lib/api-helpers";
 
 export type KeywordMarket = "CN" | "MY";
 export type ConfigSourceOrigin = "system" | "workspace";
-export type WorkflowSeedCollectionSourceType = "job5156" | "seek";
 
 export type KeywordCategory =
   | "machining"
@@ -75,19 +74,18 @@ type SystemLocationItem = {
   markets?: KeywordMarket[];
 };
 
-type CustomKeywordWorkflowSeed = {
+export type SearchProfileQuickStart = {
   id: string;
   label: string;
-  market: KeywordMarket;
   location: string;
   keywords: string[];
-  collectionSource: {
-    type: WorkflowSeedCollectionSourceType;
-    exactUrl?: string;
+  description?: string;
+  quickStart: {
+    enabled: boolean;
+    rank?: number;
+    label?: string;
+    description?: string;
   };
-  collectUrl?: string;
-  visible?: boolean;
-  source?: ConfigSourceOrigin;
 };
 
 type CustomKeywordsResponse = {
@@ -99,7 +97,23 @@ type CustomKeywordsResponse = {
   }>;
   tags?: CustomKeywordTag[];
   systemLocations?: SystemLocationItem[];
-  workflowSeeds?: CustomKeywordWorkflowSeed[];
+};
+
+type SearchProfilesResponse = {
+  success: boolean;
+  profiles?: Array<{
+    id: string;
+    name: string;
+    status: "active" | "paused" | "archived";
+    location: string;
+    keywords: string[];
+    quickStart?: {
+      enabled: boolean;
+      rank?: number;
+      label?: string;
+      description?: string;
+    };
+  }>;
 };
 
 function getKeywordFingerprint(keyword: string): string {
@@ -196,8 +210,8 @@ export function useIndustryKeywords() {
   const [systemLocationKeywords, setSystemLocationKeywords] = useState<
     IndustryKeyword[]
   >([]);
-  const [workflowSeeds, setWorkflowSeeds] = useState<
-    CustomKeywordWorkflowSeed[]
+  const [quickStartProfiles, setQuickStartProfiles] = useState<
+    SearchProfileQuickStart[]
   >([]);
   const [brandKeywords, setBrandKeywords] = useState<IndustryKeyword[]>([]);
   const [loading, setLoading] = useState(true);
@@ -207,11 +221,12 @@ export function useIndustryKeywords() {
     setLoading(true);
     setError(null);
 
-    const [industryResponse, customResponse, brandResponse] = await Promise.all(
+    const [industryResponse, customResponse, brandResponse, profilesResponse] = await Promise.all(
       [
         rawApiClient.GET<IndustryKeywordsResponse>("/api/industry/keywords"),
         rawApiClient.GET<CustomKeywordsResponse>("/api/config/custom-keywords"),
         rawApiClient.GET<BrandsResponse>("/api/industry/brands"),
+        rawApiClient.GET<SearchProfilesResponse>("/api/search-profiles"),
       ],
     );
 
@@ -220,7 +235,7 @@ export function useIndustryKeywords() {
       setKeywords([]);
       setCustomKeywords([]);
       setSystemLocationKeywords([]);
-      setWorkflowSeeds([]);
+      setQuickStartProfiles([]);
       setBrandKeywords([]);
       setError("Failed to load industry keywords");
       setLoading(false);
@@ -234,7 +249,6 @@ export function useIndustryKeywords() {
       console.error("Failed to load custom keywords", customError);
       setCustomKeywords([]);
       setSystemLocationKeywords([]);
-      setWorkflowSeeds([]);
     } else {
       const mappedCustomKeywords: IndustryKeyword[] = [];
       if (Array.isArray(customData.tags)) {
@@ -270,11 +284,6 @@ export function useIndustryKeywords() {
         }
       }
       setSystemLocationKeywords(mappedSystemLocationKeywords);
-
-      const mappedWorkflowSeeds = Array.isArray(customData.workflowSeeds)
-        ? customData.workflowSeeds.filter((item) => item.visible !== false)
-        : [];
-      setWorkflowSeeds(mappedWorkflowSeeds);
     }
 
     const { data: brandData, error: brandError } = brandResponse;
@@ -296,6 +305,38 @@ export function useIndustryKeywords() {
         }
       }
       setBrandKeywords(mappedBrands);
+    }
+
+    const { data: profilesData, error: profilesError } = profilesResponse;
+    if (profilesError || !profilesData?.success) {
+      console.error("Failed to load landing quick-start profiles", profilesError);
+      setQuickStartProfiles([]);
+    } else {
+      const mappedQuickStarts = Array.isArray(profilesData.profiles)
+        ? profilesData.profiles
+          .filter((profile) => (
+            profile.status === "active"
+            && profile.quickStart?.enabled === true
+          ))
+          .sort((left, right) => (
+            (left.quickStart?.rank ?? Number.MAX_SAFE_INTEGER)
+            - (right.quickStart?.rank ?? Number.MAX_SAFE_INTEGER)
+          ))
+          .map((profile) => ({
+            id: profile.id,
+            label: profile.quickStart?.label?.trim() || profile.name,
+            location: profile.location,
+            keywords: profile.keywords,
+            description: profile.quickStart?.description?.trim() || undefined,
+            quickStart: {
+              enabled: true,
+              rank: profile.quickStart?.rank,
+              label: profile.quickStart?.label?.trim() || undefined,
+              description: profile.quickStart?.description?.trim() || undefined,
+            },
+          }))
+        : [];
+      setQuickStartProfiles(mappedQuickStarts);
     }
 
     setLoading(false);
@@ -337,7 +378,7 @@ export function useIndustryKeywords() {
     keywords: allKeywords,
     grouped,
     hotKeywords,
-    workflowSeeds,
+    quickStartProfiles,
     loading,
     error,
     refresh: fetchKeywords,

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -3732,6 +3732,15 @@ export interface paths {
                                 status: "active" | "paused" | "archived";
                                 location: string;
                                 keywords: string[];
+                                /** @enum {string} */
+                                origin: "system" | "workspace";
+                                readOnly: boolean;
+                                quickStart?: {
+                                    enabled: boolean;
+                                    rank?: number;
+                                    label?: string;
+                                    description?: string;
+                                };
                             }[];
                         };
                     };

--- a/apps/web/src/pages/DebugConfig.test.tsx
+++ b/apps/web/src/pages/DebugConfig.test.tsx
@@ -41,6 +41,12 @@ vi.mock('sonner', () => ({
   },
 }))
 
+vi.mock('@/contexts/WorkspaceContext', () => ({
+  useWorkspace: () => ({
+    slug: 'dev',
+  }),
+}))
+
 function renderSettingsRoute(initialEntry: string) {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
@@ -313,14 +319,15 @@ describe('System settings routes', () => {
     expect(screen.getByRole('button', { name: 'Add Keyword' })).toBeInTheDocument()
   })
 
-  it('renders workflow seed rows in the keywords route', async () => {
+  it('routes landing quick-start ownership to search profiles from the keywords page', async () => {
     renderSettingsRoute('/dev/system/settings/keywords')
 
     await waitFor(() => {
-      expect(screen.getByText('Workflow Seeds')).toBeInTheDocument()
-      expect(screen.getByText('China · Job5156 · CNC 销售')).toBeInTheDocument()
+      expect(screen.getByText('Landing quick starts')).toBeInTheDocument()
+      expect(screen.getByText('Legacy workflow-seed config remains for compatibility only. The search-first landing page now reads its quick starts from Search Profiles instead.')).toBeInTheDocument()
+      expect(screen.getByText('The seeded China Job5156 and Malaysia SEEK quick starts now live in Search Profiles. Manage landing-entry presets and scheduled collectors there instead of in workflow-seed settings.')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Malaysia · SEEK · CNC Sales')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/system/profiles')
   })
 })

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -36,26 +36,26 @@ vi.mock('@/components/search/MigrationBanner', () => ({
 vi.mock('@/components/search/SearchHero', () => ({
   SearchHero: ({
     hotKeywords,
-    onApplyWorkflowSeed,
+    onApplyQuickStart,
     onToggleHotKeyword,
     queryInput,
     onApplyExtractedKeywords,
-    workflowSeeds,
+    quickStarts,
   }: {
     hotKeywords?: Array<{ keyword: string }>
-    onApplyWorkflowSeed?: (seed: {
+    onApplyQuickStart?: (seed: {
       keywords: string[]
       location: string
     }) => void
     onToggleHotKeyword?: (keyword: string) => void
     queryInput: string
     onApplyExtractedKeywords: (keywords: string[]) => void
-    workflowSeeds?: Array<{ label: string }>
+    quickStarts?: Array<{ label: string }>
   }) => (
     <div>
       <div>Landing Hero {queryInput}</div>
       <div>
-        Landing Hero Seeds {workflowSeeds?.length ?? 0} Hot{' '}
+        Landing Hero Seeds {quickStarts?.length ?? 0} Hot{' '}
         {hotKeywords?.length ?? 0}
       </div>
       <button
@@ -69,13 +69,13 @@ vi.mock('@/components/search/SearchHero', () => ({
       <button
         type="button"
         onClick={() =>
-          onApplyWorkflowSeed?.({
+          onApplyQuickStart?.({
             keywords: ['CNC', 'Sales'],
             location: 'Kuala Lumpur MY',
           })
         }
       >
-        Apply Hero Workflow Seed
+        Apply Hero Quick Start
       </button>
       <button type="button" onClick={() => onToggleHotKeyword?.('CNC')}>
         Toggle Hero Hot Keyword
@@ -355,7 +355,7 @@ describe('ResumeSearchPage', () => {
     vi.clearAllMocks()
     useIndustryKeywordsMock.mockReturnValue({
       hotKeywords: [],
-      workflowSeeds: [],
+      quickStartProfiles: [],
     })
     useAiSearchSummaryMock.mockReturnValue({
       generatedAt: undefined,
@@ -389,7 +389,7 @@ describe('ResumeSearchPage', () => {
     expect(state.submitSearch).toHaveBeenCalledWith(expectedQuery)
   })
 
-  it('wires workflow seed and hot keyword handlers into the landing hero', async () => {
+  it('wires profile quick-start and hot keyword handlers into the landing hero', async () => {
     const user = userEvent.setup()
     const state = createResumeSearchState({
       queryInput: 'machine tools',
@@ -397,13 +397,16 @@ describe('ResumeSearchPage', () => {
     useResumeSearchStateMock.mockReturnValue(state)
     useIndustryKeywordsMock.mockReturnValue({
       hotKeywords: [{ id: 'hot-1', keyword: 'CNC' }],
-      workflowSeeds: [
+      quickStartProfiles: [
         {
-          id: 'workflow-1',
+          id: 'profile-1',
           label: 'Malaysia · SEEK · CNC Sales',
           market: 'MY',
           location: 'Kuala Lumpur MY',
           keywords: ['CNC', 'Sales'],
+          quickStart: {
+            enabled: true,
+          },
         },
       ],
     })
@@ -413,7 +416,7 @@ describe('ResumeSearchPage', () => {
     expect(screen.getByText('Landing Hero Seeds 1 Hot 1')).toBeInTheDocument()
 
     await user.click(
-      screen.getByRole('button', { name: 'Apply Hero Workflow Seed' }),
+      screen.getByRole('button', { name: 'Apply Hero Quick Start' }),
     )
     expect(state.setQueryInput).toHaveBeenCalledWith(
       formatKeywordQuery(['CNC', 'Sales']),

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -18,7 +18,7 @@ import { useResumeSearchState } from '@/hooks/useResumeSearchState'
 export function ResumeSearchPage() {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [filtersOpen, setFiltersOpen] = useState(false)
-  const { hotKeywords, workflowSeeds } = useIndustryKeywords()
+  const { hotKeywords, quickStartProfiles } = useIndustryKeywords()
   const {
     activeQuery,
     activeSort,
@@ -90,7 +90,7 @@ export function ResumeSearchPage() {
     submitSearch(query)
   }
 
-  const applyWorkflowSeed = (seed: {
+  const applyQuickStart = (seed: {
     keywords: string[]
     location: string
   }) => {
@@ -165,11 +165,11 @@ export function ResumeSearchPage() {
           queryInput={queryInput}
           recentSearches={recentSearches}
           recentSearchesLoading={searchHistoryLoading}
-          workflowSeeds={workflowSeeds}
+          quickStarts={quickStartProfiles}
           hotKeywords={hotKeywords}
           onApplyRecentSearch={applyRecentSearch}
           onApplyExtractedKeywords={applyExtractedKeywords}
-          onApplyWorkflowSeed={applyWorkflowSeed}
+          onApplyQuickStart={applyQuickStart}
           onToggleHotKeyword={toggleHotKeyword}
           onChangeQuery={setQueryInput}
           onClearQuery={clearSearch}

--- a/apps/web/src/pages/SearchProfilesPage.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.tsx
@@ -250,13 +250,23 @@ export function SearchProfilesPage() {
   }, [])
 
   const handleEdit = useCallback(async (profileId: string) => {
+    const summary = profiles.find((profile) => profile.id === profileId)
+    if (summary?.readOnly) {
+      toast.error(t('searchProfiles.readOnlyEdit', { defaultValue: 'Seeded profiles are managed from Search Profiles config and are read-only in this workspace UI.' }))
+      return
+    }
     setEditingProfileId(profileId)
     setEditorOpen(true)
-  }, [])
+  }, [profiles, t])
 
   const handleDelete = useCallback((profileId: string) => {
+    const summary = profiles.find((profile) => profile.id === profileId)
+    if (summary?.readOnly) {
+      toast.error(t('searchProfiles.readOnlyDelete', { defaultValue: 'Seeded profiles cannot be deleted from the workspace UI.' }))
+      return
+    }
     setDeletingProfileId(profileId)
-  }, [])
+  }, [profiles, t])
 
   const confirmDelete = useCallback(async () => {
     if (!deletingProfileId) {
@@ -398,7 +408,7 @@ export function SearchProfilesPage() {
     <div className="space-y-6">
       <PageHeader
         title={t('searchProfiles.title', { defaultValue: 'Search Profiles' })}
-        description={t('searchProfiles.subtitle', { defaultValue: 'Manage scheduled profile-based resume searches.' })}
+        description={t('searchProfiles.subtitle', { defaultValue: 'Manage landing quick starts and scheduled profile-based resume searches.' })}
         actions={
           <>
             <Button variant="outline" onClick={() => void loadProfiles()} disabled={loading}>

--- a/apps/web/src/pages/system-settings/SystemSettingsKeywordsPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsKeywordsPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { Badge } from '@/components/ui/badge'
@@ -14,24 +15,20 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Select } from '@/components/ui/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import {
   createEmptyCustomKeywordForm,
-  createEmptyWorkflowSeedForm,
   customKeywordToForm,
   parseBrandKeywordsPayload,
   parseCustomKeywordsPayload,
-  workflowSeedToForm,
   type BrandKeywordItem,
   type CustomKeywordCategory,
   type CustomKeywordFormState,
-  type CustomKeywordWorkflowSeed,
   type CustomKeywordTag,
   type KeywordMarket,
-  type WorkflowSeedFormState,
   useSettingsRequestJson,
 } from '@/pages/system-settings/lib'
+import { useWorkspace } from '@/contexts/WorkspaceContext'
 
 const MARKET_OPTIONS: Array<{ value: KeywordMarket; label: string }> = [
   { value: 'CN', label: 'CN' },
@@ -40,12 +37,12 @@ const MARKET_OPTIONS: Array<{ value: KeywordMarket; label: string }> = [
 
 export function SystemSettingsKeywordsPage() {
   const { t } = useTranslation()
+  const { slug } = useWorkspace()
   const { requestJson } = useSettingsRequestJson()
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [customKeywordTags, setCustomKeywordTags] = useState<CustomKeywordTag[]>([])
   const [customKeywordCategories, setCustomKeywordCategories] = useState<CustomKeywordCategory[]>([])
-  const [workflowSeeds, setWorkflowSeeds] = useState<CustomKeywordWorkflowSeed[]>([])
   const [brandKeywords, setBrandKeywords] = useState<BrandKeywordItem[]>([])
   const [customKeywordDialogOpen, setCustomKeywordDialogOpen] = useState(false)
   const [editingCustomKeywordId, setEditingCustomKeywordId] = useState<string | null>(null)
@@ -53,12 +50,6 @@ export function SystemSettingsKeywordsPage() {
   const [savingCustomKeyword, setSavingCustomKeyword] = useState(false)
   const [deleteCustomKeywordTargetId, setDeleteCustomKeywordTargetId] = useState<string | null>(null)
   const [deletingCustomKeyword, setDeletingCustomKeyword] = useState(false)
-  const [workflowSeedDialogOpen, setWorkflowSeedDialogOpen] = useState(false)
-  const [editingWorkflowSeedId, setEditingWorkflowSeedId] = useState<string | null>(null)
-  const [workflowSeedForm, setWorkflowSeedForm] = useState<WorkflowSeedFormState>(createEmptyWorkflowSeedForm)
-  const [savingWorkflowSeed, setSavingWorkflowSeed] = useState(false)
-  const [deleteWorkflowSeedTargetId, setDeleteWorkflowSeedTargetId] = useState<string | null>(null)
-  const [deletingWorkflowSeed, setDeletingWorkflowSeed] = useState(false)
 
   const loadCustomKeywords = useCallback(async () => {
     const payload = await requestJson('/api/config/custom-keywords')
@@ -69,7 +60,6 @@ export function SystemSettingsKeywordsPage() {
 
     setCustomKeywordTags(parsed.tags)
     setCustomKeywordCategories(parsed.categories)
-    setWorkflowSeeds(parsed.workflowSeeds)
   }, [requestJson])
 
   const loadBrandKeywords = useCallback(async () => {
@@ -184,103 +174,6 @@ export function SystemSettingsKeywordsPage() {
       setDeletingCustomKeyword(false)
     }
   }, [deleteCustomKeywordTargetId, loadCustomKeywords, requestJson, t])
-
-  const openAddWorkflowSeedDialog = useCallback(() => {
-    setEditingWorkflowSeedId(null)
-    setWorkflowSeedForm(createEmptyWorkflowSeedForm())
-    setWorkflowSeedDialogOpen(true)
-  }, [])
-
-  const openEditWorkflowSeedDialog = useCallback((seed: CustomKeywordWorkflowSeed) => {
-    setEditingWorkflowSeedId(seed.id)
-    setWorkflowSeedForm(workflowSeedToForm(seed))
-    setWorkflowSeedDialogOpen(true)
-  }, [])
-
-  const buildWorkflowSeedFromForm = useCallback((): CustomKeywordWorkflowSeed => {
-    const id = workflowSeedForm.id.trim()
-    const label = workflowSeedForm.label.trim()
-    const location = workflowSeedForm.location.trim()
-    const keywords = workflowSeedForm.keywords
-      .split(/[,，\n]+/)
-      .map((item) => item.trim())
-      .filter((item) => item.length > 0)
-    const collectUrl = workflowSeedForm.collectUrl.trim()
-    const market = workflowSeedForm.market
-    const collectionSourceType = workflowSeedForm.collectionSourceType
-
-    if (!id || !label || keywords.length === 0) {
-      throw new Error('Missing required workflow seed fields')
-    }
-
-    return {
-      id,
-      label,
-      market,
-      location,
-      keywords,
-      collectionSource: collectUrl
-        ? {
-            type: collectionSourceType,
-            exactUrl: collectUrl,
-          }
-        : {
-            type: collectionSourceType,
-          },
-      collectUrl: collectUrl || undefined,
-      visible: workflowSeedForm.visible,
-    }
-  }, [workflowSeedForm])
-
-  const handleSaveWorkflowSeed = useCallback(async () => {
-    setSavingWorkflowSeed(true)
-
-    try {
-      const workflowSeed = buildWorkflowSeedFromForm()
-
-      if (editingWorkflowSeedId) {
-        await requestJson(`/api/config/custom-keywords/workflow-seeds/${encodeURIComponent(editingWorkflowSeedId)}`, {
-          method: 'PUT',
-          body: JSON.stringify(workflowSeed),
-        })
-      } else {
-        await requestJson('/api/config/custom-keywords/workflow-seeds', {
-          method: 'POST',
-          body: JSON.stringify(workflowSeed),
-        })
-      }
-
-      await loadCustomKeywords()
-      setWorkflowSeedDialogOpen(false)
-      toast.success(t('debugConfig.saved'))
-    } catch (error) {
-      console.error('Failed to save workflow seed', error)
-      toast.error(t('debugConfig.saveError'))
-    } finally {
-      setSavingWorkflowSeed(false)
-    }
-  }, [buildWorkflowSeedFromForm, editingWorkflowSeedId, loadCustomKeywords, requestJson, t])
-
-  const handleDeleteWorkflowSeed = useCallback(async () => {
-    if (!deleteWorkflowSeedTargetId) {
-      return
-    }
-
-    setDeletingWorkflowSeed(true)
-    try {
-      await requestJson(`/api/config/custom-keywords/workflow-seeds/${encodeURIComponent(deleteWorkflowSeedTargetId)}`, {
-        method: 'DELETE',
-      })
-      await loadCustomKeywords()
-      setDeleteWorkflowSeedTargetId(null)
-      toast.success(t('debugConfig.saved'))
-    } catch (error) {
-      console.error('Failed to delete workflow seed', error)
-      toast.error(t('debugConfig.saveError'))
-    } finally {
-      setDeletingWorkflowSeed(false)
-    }
-  }, [deleteWorkflowSeedTargetId, loadCustomKeywords, requestJson, t])
 
   return (
     <div className="space-y-6">
@@ -409,93 +302,31 @@ export function SystemSettingsKeywordsPage() {
           <CardHeader>
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div>
-                <CardTitle>{t('quickStart.workflows', { defaultValue: 'Workflow Seeds' })}</CardTitle>
+                <CardTitle>{t('quickStart.workflows', { defaultValue: 'Landing quick starts' })}</CardTitle>
                 <CardDescription>
                   {t('debugConfig.workflowSeedsDescription', {
-                    defaultValue: 'Manage CN and MY quick-start presets used by the resume workflow panel.',
+                    defaultValue: 'Search-first landing quick starts now come from Search Profiles so the same seeded searches can power scheduled collectors.',
                   })}
                 </CardDescription>
               </div>
-              <div className="flex items-center gap-2">
-                <Badge variant="secondary">{workflowSeeds.length}</Badge>
-                <Button size="sm" onClick={openAddWorkflowSeedDialog}>
-                  {t('debugConfig.addWorkflowSeed', { defaultValue: 'Add Seed' })}
-                </Button>
-              </div>
+              <Link
+                className="inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+                to={`/${slug}/system/profiles`}
+              >
+                {t('searchProfiles.title', { defaultValue: 'Open Search Profiles' })}
+              </Link>
             </div>
           </CardHeader>
-          <CardContent>
-            <div className="rounded-md border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{t('debugConfig.customKeywordId')}</TableHead>
-                    <TableHead>{t('debugConfig.workflowSeedLabel', { defaultValue: 'Label' })}</TableHead>
-                    <TableHead>{t('debugConfig.workflowSeedMarket', { defaultValue: 'Market' })}</TableHead>
-                    <TableHead>{t('debugConfig.workflowSeedLocation', { defaultValue: 'Location' })}</TableHead>
-                    <TableHead>{t('debugConfig.workflowSeedKeywords', { defaultValue: 'Keywords' })}</TableHead>
-                    <TableHead>{t('debugConfig.workflowSeedStatus', { defaultValue: 'Status' })}</TableHead>
-                    <TableHead className="text-right">{t('jdManagement.table.actions')}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {workflowSeeds.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={7} className="py-6 text-center text-muted-foreground">
-                        {loading ? t('trends.loading') : t('debug.none')}
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    workflowSeeds.map((seed) => (
-                      <TableRow key={seed.id} className={seed.visible === false ? 'opacity-60' : undefined}>
-                        <TableCell className="font-mono text-xs">{seed.id}</TableCell>
-                        <TableCell className="font-medium">{seed.label}</TableCell>
-                        <TableCell>
-                          <Badge variant="outline" className="text-xs">
-                            {seed.market}
-                          </Badge>
-                        </TableCell>
-                        <TableCell>{seed.location || '-'}</TableCell>
-                        <TableCell className="max-w-[240px] whitespace-normal break-words text-xs text-muted-foreground">
-                          {seed.keywords.join(', ')}
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex flex-col gap-1">
-                            <Badge variant={seed.source === 'system' ? 'secondary' : 'outline'} className="w-fit text-xs">
-                              {seed.source ?? 'workspace'}
-                            </Badge>
-                            <Badge variant={seed.visible === false ? 'secondary' : 'default'} className="w-fit text-xs">
-                              {seed.visible === false ? 'Hidden' : 'Visible'}
-                            </Badge>
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex justify-end gap-2">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => {
-                                openEditWorkflowSeedDialog(seed)
-                              }}
-                            >
-                              {t('debugConfig.editWorkflowSeed', { defaultValue: 'Edit Seed' })}
-                            </Button>
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              onClick={() => {
-                                setDeleteWorkflowSeedTargetId(seed.id)
-                              }}
-                            >
-                              {t('debugConfig.deleteWorkflowSeed', { defaultValue: 'Delete Seed' })}
-                            </Button>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  )}
-                </TableBody>
-              </Table>
+          <CardContent className="space-y-4">
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+              {t('debugConfig.workflowSeedsLegacyNotice', {
+                defaultValue: 'Legacy workflow-seed config remains for compatibility only. The search-first landing page now reads its quick starts from Search Profiles instead.',
+              })}
+            </div>
+            <div className="rounded-md border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+              {t('debugConfig.workflowSeedsMigrationSummary', {
+                defaultValue: 'The seeded China Job5156 and Malaysia SEEK quick starts now live in Search Profiles. Manage landing-entry presets and scheduled collectors there instead of in workflow-seed settings.',
+              })}
             </div>
           </CardContent>
         </Card>
@@ -669,135 +500,6 @@ export function SystemSettingsKeywordsPage() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={workflowSeedDialogOpen} onOpenChange={setWorkflowSeedDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              {editingWorkflowSeedId ? t('debugConfig.editWorkflowSeed', { defaultValue: 'Edit Seed' }) : t('debugConfig.addWorkflowSeed', { defaultValue: 'Add Seed' })}
-            </DialogTitle>
-          </DialogHeader>
-
-          <div className="grid gap-3 py-2">
-            <div className="space-y-1">
-              <p className="text-xs text-muted-foreground">{t('debugConfig.customKeywordId')}</p>
-              <Input
-                value={workflowSeedForm.id}
-                onChange={(event) => {
-                  setWorkflowSeedForm((current) => ({ ...current, id: event.target.value }))
-                }}
-                disabled={Boolean(editingWorkflowSeedId)}
-              />
-            </div>
-            <div className="space-y-1">
-              <p className="text-xs text-muted-foreground">{t('debugConfig.workflowSeedLabel', { defaultValue: 'Label' })}</p>
-              <Input
-                value={workflowSeedForm.label}
-                onChange={(event) => {
-                  setWorkflowSeedForm((current) => ({ ...current, label: event.target.value }))
-                }}
-              />
-            </div>
-            <div className="space-y-1">
-              <p className="text-xs text-muted-foreground">{t('debugConfig.workflowSeedMarket', { defaultValue: 'Market' })}</p>
-              <Select
-                value={workflowSeedForm.market}
-                onChange={(event) => {
-                  setWorkflowSeedForm((current) => ({
-                    ...current,
-                    market: event.target.value === 'MY' ? 'MY' : 'CN',
-                  }))
-                }}
-                options={MARKET_OPTIONS}
-              />
-            </div>
-            <div className="space-y-1">
-              <p className="text-xs text-muted-foreground">{t('debugConfig.workflowSeedLocation', { defaultValue: 'Location' })}</p>
-              <Input
-                value={workflowSeedForm.location}
-                onChange={(event) => {
-                  setWorkflowSeedForm((current) => ({ ...current, location: event.target.value }))
-                }}
-                placeholder={t('debugConfig.workflowSeedLocationPlaceholder', { defaultValue: 'Optional location' })}
-              />
-            </div>
-            <div className="space-y-1">
-              <p className="text-xs text-muted-foreground">{t('debugConfig.workflowSeedKeywords', { defaultValue: 'Keywords' })}</p>
-              <Input
-                value={workflowSeedForm.keywords}
-                onChange={(event) => {
-                  setWorkflowSeedForm((current) => ({ ...current, keywords: event.target.value }))
-                }}
-                placeholder={t('debugConfig.workflowSeedKeywordsPlaceholder', {
-                  defaultValue: 'Sales Engineer, Sales Manager',
-                })}
-              />
-            </div>
-            <div className="space-y-1">
-              <p className="text-xs text-muted-foreground">{t('debugConfig.workflowSeedCollectionSource', { defaultValue: 'Collection source' })}</p>
-              <Select
-                value={workflowSeedForm.collectionSourceType}
-                onChange={(event) => {
-                  setWorkflowSeedForm((current) => ({
-                    ...current,
-                    collectionSourceType: event.target.value === 'seek' ? 'seek' : 'job5156',
-                  }))
-                }}
-                options={[
-                  { value: 'job5156', label: 'job5156' },
-                  { value: 'seek', label: 'seek' },
-                ]}
-              />
-            </div>
-            <div className="space-y-1">
-              <p className="text-xs text-muted-foreground">{t('debugConfig.workflowSeedCollectUrl', { defaultValue: 'Collect URL' })}</p>
-              <Input
-                value={workflowSeedForm.collectUrl}
-                onChange={(event) => {
-                  setWorkflowSeedForm((current) => ({ ...current, collectUrl: event.target.value }))
-                }}
-                placeholder={t('debugConfig.workflowSeedCollectUrlPlaceholder', {
-                  defaultValue: 'Optional base or collect URL',
-                })}
-              />
-            </div>
-            <label className="flex items-center gap-2 text-sm">
-              <Checkbox
-                checked={workflowSeedForm.visible}
-                onCheckedChange={(checked) => {
-                  setWorkflowSeedForm((current) => ({
-                    ...current,
-                    visible: checked === true,
-                  }))
-                }}
-              />
-              <span>{t('debugConfig.workflowSeedVisible', { defaultValue: 'Visible' })}</span>
-            </label>
-          </div>
-
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setWorkflowSeedDialogOpen(false)
-              }}
-              disabled={savingWorkflowSeed}
-            >
-              {t('jdManagement.cancel')}
-            </Button>
-            <Button
-              onClick={() => {
-                handleSaveWorkflowSeed().catch((error) => {
-                  console.error('Unexpected handleSaveWorkflowSeed failure', error)
-                })
-              }}
-              disabled={savingWorkflowSeed}
-            >
-              {savingWorkflowSeed ? `${t('debugConfig.save')}...` : t('debugConfig.save')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
       <Dialog
         open={deleteCustomKeywordTargetId !== null}
         onOpenChange={(open) => {
@@ -845,52 +547,6 @@ export function SystemSettingsKeywordsPage() {
         </DialogContent>
       </Dialog>
 
-      <Dialog
-        open={deleteWorkflowSeedTargetId !== null}
-        onOpenChange={(open) => {
-          if (!open && !deletingWorkflowSeed) {
-            setDeleteWorkflowSeedTargetId(null)
-          }
-        }}
-      >
-        <DialogContent
-          onEscapeKeyDown={(event) => {
-            if (deletingWorkflowSeed) {
-              event.preventDefault()
-            }
-          }}
-          onPointerDownOutside={(event) => {
-            if (deletingWorkflowSeed) {
-              event.preventDefault()
-            }
-          }}
-        >
-          <DialogHeader>
-            <DialogTitle>{t('debugConfig.deleteWorkflowSeed', { defaultValue: 'Delete Seed' })}</DialogTitle>
-            <DialogDescription>{t('debugConfig.confirmDelete')}</DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setDeleteWorkflowSeedTargetId(null)}
-              disabled={deletingWorkflowSeed}
-            >
-              {t('common.cancel', { defaultValue: 'Cancel' })}
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={() => {
-                handleDeleteWorkflowSeed().catch((error) => {
-                  console.error('Unexpected handleDeleteWorkflowSeed failure', error)
-                })
-              }}
-              disabled={deletingWorkflowSeed}
-            >
-              {t('debugConfig.deleteWorkflowSeed', { defaultValue: 'Delete Seed' })}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   )
 }

--- a/config/search-profiles/job5156-cn-cnc-sales.yaml
+++ b/config/search-profiles/job5156-cn-cnc-sales.yaml
@@ -1,0 +1,39 @@
+id: job5156-cn-cnc-sales
+name: China Job5156 CNC Sales
+description: China-wide Job5156 CNC sales search profile used for the landing quick start
+createdAt: "2026-03-28"
+updatedAt: "2026-03-28"
+status: active
+
+location: China
+keywords:
+  - CNC
+  - 销售
+
+jobDescription: lathe-sales
+
+filters:
+  minExperience: 2
+  maxExperience: null
+  locations:
+    - China
+
+schedule:
+  enabled: true
+  cron: "0 9 * * 1-5"
+  timezone: Asia/Shanghai
+  maxCandidates: 200
+
+sources:
+  - type: job5156
+    enabled: true
+    priority: 1
+  - type: seek
+    enabled: false
+    priority: 2
+
+quickStart:
+  enabled: true
+  rank: 1
+  label: China · Job5156 · CNC 销售
+  description: CNC, 销售 · China

--- a/config/search-profiles/seek-malaysia-sales.yaml
+++ b/config/search-profiles/seek-malaysia-sales.yaml
@@ -42,3 +42,9 @@ session:
   retention:
     mode: until-closed
     archiveAfterDays: 90
+
+quickStart:
+  enabled: true
+  rank: 2
+  label: Malaysia · SEEK · CNC Sales
+  description: CNC, Sales · Kuala Lumpur MY


### PR DESCRIPTION
## Summary
- move landing quick starts to Search Profiles instead of legacy workflow seeds
- expose seeded system profiles through /api/search-profiles with quick-start metadata
- remove duplicate workflow-seed settings UI and point ownership to Search Profiles

## Testing
- bun run --filter @trends/web typecheck
- bun run --filter @trends/api typecheck
- bunx vitest run apps/api/src/routes/search-profiles.test.ts
- cd apps/web && bunx vitest run src/components/search/SearchHero.test.tsx src/pages/ResumeSearchPage.test.tsx src/hooks/useIndustryKeywords.test.tsx src/pages/DebugConfig.test.tsx src/pages/SearchProfilesPage.test.tsx src/components/search/MigrationBanner.test.tsx
- make check