### PR TITLE
fix: point migration banner to quick-start view

### DIFF
--- a/apps/web/src/components/search/MigrationBanner.test.tsx
+++ b/apps/web/src/components/search/MigrationBanner.test.tsx
@@ -30,7 +30,7 @@ describe('MigrationBanner', () => {
       expect(screen.getByText('Search Profiles still exist, but the primary resume route is now search-first.')).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/system/profiles')
+    expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/system/profiles?view=quick-starts')
   })
 
   it('persists dismissal in local storage', async () => {

--- a/apps/web/src/components/search/MigrationBanner.tsx
+++ b/apps/web/src/components/search/MigrationBanner.tsx
@@ -27,7 +27,7 @@ export function MigrationBanner() {
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <Link className="inline-flex h-9 items-center rounded-md border border-sky-200 bg-white px-3 text-sm font-medium" to={`/${slug}/system/profiles`}>
+        <Link className="inline-flex h-9 items-center rounded-md border border-sky-200 bg-white px-3 text-sm font-medium" to={`/${slug}/system/profiles?view=quick-starts`}>
           Open Search Profiles
         </Link>
         <Button

--- a/apps/web/src/pages/DebugConfig.test.tsx
+++ b/apps/web/src/pages/DebugConfig.test.tsx
@@ -328,6 +328,6 @@ describe('System settings routes', () => {
       expect(screen.getByText('The seeded China Job5156 and Malaysia SEEK quick starts now live in Search Profiles. Manage landing-entry presets and scheduled collectors there instead of in workflow-seed settings.')).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/system/profiles')
+    expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/system/profiles?view=quick-starts')
   })
 })

--- a/apps/web/src/pages/SearchProfilesPage.test.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.test.tsx
@@ -5,10 +5,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { SearchProfilesPage } from './SearchProfilesPage'
 
-const { getMock, postMock, deleteMock, setSearchParamsMock, toastSuccessMock, toastErrorMock, tMock } = vi.hoisted(() => ({
+const { getMock, postMock, deleteMock, routerState, setSearchParamsMock, toastSuccessMock, toastErrorMock, tMock } = vi.hoisted(() => ({
   getMock: vi.fn(),
   postMock: vi.fn(),
   deleteMock: vi.fn(),
+  routerState: {
+    search: '',
+  },
   setSearchParamsMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
@@ -16,7 +19,7 @@ const { getMock, postMock, deleteMock, setSearchParamsMock, toastSuccessMock, to
 }))
 
 vi.mock('react-router-dom', () => ({
-  useSearchParams: () => [new URLSearchParams(), setSearchParamsMock],
+  useSearchParams: () => [new URLSearchParams(routerState.search), setSearchParamsMock],
 }))
 
 vi.mock('react-i18next', () => ({
@@ -86,7 +89,13 @@ vi.mock('@/components/ui/dialog', () => ({
 }))
 
 vi.mock('@/components/PageHeader', () => ({
-  PageHeader: ({ title }: { title?: string }) => <div>{title}</div>,
+  PageHeader: ({ title, description, actions }: { title?: string; description?: string; actions?: ReactNode }) => (
+    <div>
+      <div>{title}</div>
+      <div>{description}</div>
+      <div>{actions}</div>
+    </div>
+  ),
 }))
 
 vi.mock('@/components/SearchProfileEditorDialog', () => ({
@@ -97,6 +106,7 @@ describe('SearchProfilesPage run behavior', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     vi.clearAllMocks()
+    routerState.search = ''
     vi.spyOn(globalThis, 'setInterval').mockImplementation(() => 1 as never)
     getMock.mockImplementation(async (path: string) => {
       if (path === '/api/search-profiles') {
@@ -331,5 +341,75 @@ describe('SearchProfilesPage run behavior', () => {
       expect(getMock.mock.calls.filter(([path]) => path === '/api/search-profiles/profile-1/status')).toHaveLength(2)
     })
     expect(toastSuccessMock).toHaveBeenCalledWith('Profile run started')
+  })
+
+  it('filters to landing quick starts when opened from the quick-start view', async () => {
+    routerState.search = 'view=quick-starts'
+
+    getMock.mockImplementation(async (path: string) => {
+      if (path === '/api/search-profiles') {
+        return {
+          data: {
+            success: true,
+            profiles: [
+              {
+                id: 'profile-1',
+                name: 'Quick Start Profile',
+                filename: 'profile-1.yaml',
+                updatedAt: '2026-03-17T00:00:00.000Z',
+                status: 'active',
+                location: 'China',
+                keywords: ['CNC', '销售'],
+                origin: 'system',
+                readOnly: true,
+                quickStart: {
+                  enabled: true,
+                },
+              },
+              {
+                id: 'profile-2',
+                name: 'Scheduled Only Profile',
+                filename: 'profile-2.yaml',
+                updatedAt: '2026-03-17T00:00:00.000Z',
+                status: 'active',
+                location: 'Dongguan',
+                keywords: ['车床', '销售'],
+                origin: 'workspace',
+                readOnly: false,
+              },
+            ],
+          },
+        }
+      }
+
+      if (path.endsWith('/status')) {
+        return {
+          data: {
+            success: true,
+            status: null,
+          },
+        }
+      }
+
+      return {
+        data: {
+          success: true,
+          profile: {
+            id: 'profile-1',
+            name: 'Quick Start Profile',
+            status: 'active',
+            location: 'China',
+            keywords: ['CNC', '销售'],
+          },
+        },
+      }
+    })
+
+    render(<SearchProfilesPage />)
+
+    expect(await screen.findByText('This filtered view shows only profiles with landing quick-start metadata enabled.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Run Quick Start Profile' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Run Scheduled Only Profile' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show All Profiles' })).toBeInTheDocument()
   })
 })

--- a/apps/web/src/pages/SearchProfilesPage.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.tsx
@@ -111,6 +111,10 @@ function buildScheduleLabel(profile?: SearchProfileDetails): string {
   return profile.schedule.cron || 'enabled'
 }
 
+function isQuickStartProfile(profile: SearchProfileSummary): boolean {
+  return profile.quickStart?.enabled === true
+}
+
 export function SearchProfilesPage() {
   const { t } = useTranslation()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -393,8 +397,14 @@ export function SearchProfilesPage() {
     setSearchParams(nextParams, { replace: true })
   }, [handleEdit, profiles, searchParams, setSearchParams])
 
+  const showQuickStartsOnly = searchParams.get('view') === 'quick-starts'
+
   const cards = useMemo(() => {
-    return profiles.map((profile) => {
+    const visibleProfiles = showQuickStartsOnly
+      ? profiles.filter(isQuickStartProfile)
+      : profiles
+
+    return visibleProfiles.map((profile) => {
       const detail = profileDetails[profile.id]
       return {
         profile,
@@ -402,19 +412,32 @@ export function SearchProfilesPage() {
         runStatus: runStatuses[profile.id],
       }
     })
-  }, [profileDetails, profiles, runStatuses])
+  }, [profileDetails, profiles, runStatuses, showQuickStartsOnly])
+
+  const handleShowAllProfiles = useCallback(() => {
+    const nextParams = new URLSearchParams(searchParams)
+    nextParams.delete('view')
+    setSearchParams(nextParams, { replace: true })
+  }, [searchParams, setSearchParams])
 
   return (
     <div className="space-y-6">
       <PageHeader
         title={t('searchProfiles.title', { defaultValue: 'Search Profiles' })}
-        description={t('searchProfiles.subtitle', { defaultValue: 'Manage landing quick starts and scheduled profile-based resume searches.' })}
+        description={showQuickStartsOnly
+          ? t('searchProfiles.quickStartsSubtitle', { defaultValue: 'Showing landing quick starts only. Open all profiles to manage scheduled collectors and non-landing searches.' })
+          : t('searchProfiles.subtitle', { defaultValue: 'Manage landing quick starts and scheduled profile-based resume searches.' })}
         actions={
           <>
             <Button variant="outline" onClick={() => void loadProfiles()} disabled={loading}>
               <RefreshCw className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
               {t('searchProfiles.refresh', { defaultValue: 'Refresh' })}
             </Button>
+            {showQuickStartsOnly ? (
+              <Button variant="outline" onClick={handleShowAllProfiles}>
+                {t('searchProfiles.showAll', { defaultValue: 'Show All Profiles' })}
+              </Button>
+            ) : null}
             <Button onClick={handleCreate}>
               <Plus className="h-4 w-4 mr-2" />
               {t('searchProfiles.create', { defaultValue: 'Create Profile' })}
@@ -422,6 +445,14 @@ export function SearchProfilesPage() {
           </>
         }
       />
+
+      {showQuickStartsOnly ? (
+        <Card>
+          <CardContent className="pt-6 text-sm text-muted-foreground">
+            {t('searchProfiles.quickStartsNotice', { defaultValue: 'This filtered view shows only profiles with landing quick-start metadata enabled.' })}
+          </CardContent>
+        </Card>
+      ) : null}
 
       {loading ? (
         <Card>
@@ -432,10 +463,16 @@ export function SearchProfilesPage() {
       ) : cards.length === 0 ? (
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">{t('searchProfiles.emptyTitle', { defaultValue: 'No profiles yet' })}</CardTitle>
+            <CardTitle className="text-base">
+              {showQuickStartsOnly
+                ? t('searchProfiles.quickStartsEmptyTitle', { defaultValue: 'No landing quick starts yet' })
+                : t('searchProfiles.emptyTitle', { defaultValue: 'No profiles yet' })}
+            </CardTitle>
           </CardHeader>
           <CardContent className="text-sm text-muted-foreground">
-            {t('searchProfiles.emptyDescription', { defaultValue: 'Create your first profile to enable one-click and scheduled runs.' })}
+            {showQuickStartsOnly
+              ? t('searchProfiles.quickStartsEmptyDescription', { defaultValue: 'Enable landing quick-start metadata on a profile to surface it on the search landing page.' })
+              : t('searchProfiles.emptyDescription', { defaultValue: 'Create your first profile to enable one-click and scheduled runs.' })}
           </CardContent>
         </Card>
       ) : (

--- a/apps/web/src/pages/system-settings/SystemSettingsKeywordsPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsKeywordsPage.tsx
@@ -311,7 +311,7 @@ export function SystemSettingsKeywordsPage() {
               </div>
               <Link
                 className="inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-                to={`/${slug}/system/profiles`}
+                to={`/${slug}/system/profiles?view=quick-starts`}
               >
                 {t('searchProfiles.title', { defaultValue: 'Open Search Profiles' })}
               </Link>


### PR DESCRIPTION
## Summary\n- point the search-first landing migration banner at the quick-start-only Search Profiles view\n- keep the landing-page management path aligned with the two quick-start cards verified in-browser\n- update the migration banner test expectation\n\n## Testing\n- bunx vitest run src/pages/SearchProfilesPage.test.tsx src/pages/DebugConfig.test.tsx src/components/search/MigrationBanner.test.tsx\n- make check\n- DevTools MCP screen verify on hosted dev target