### PR TITLE
feat(search-profiles): unify quick starts into workspace-managed profiles

### DIFF
--- a/apps/api/src/routes/search-profiles.test.ts
+++ b/apps/api/src/routes/search-profiles.test.ts
@@ -74,7 +74,62 @@ function getUpdateCall(calls: ConvexCall[]): ConvexCall {
   return updateCall
 }
 
+function getCreateCalls(calls: ConvexCall[]): ConvexCall[] {
+  return calls.filter((call) => call.pathName === 'search_profiles:create')
+}
+
 const runStatusFilePath = path.join(searchProfileService.projectRoot, 'output', 'search-profile-runs.json')
+const seededDongguanProfile = {
+  id: 'dongguan-lathe-sales',
+  name: '东莞车床销售招聘',
+  description: '东莞地区车床销售工程师岗位自动化招聘',
+  createdAt: '2026-02-06',
+  updatedAt: '2026-02-06',
+  status: 'active' as const,
+  location: '东莞',
+  keywords: ['车床', '销售', 'CNC', '数控'],
+  jobDescription: 'lathe-sales',
+  filterPreset: 'sales-mid',
+  filters: {
+    minExperience: 2,
+    maxExperience: null,
+    education: ['中专', '大专', '本科'],
+    salaryRange: {
+      min: 8000,
+      max: 20000,
+      currency: 'CNY',
+      period: 'month',
+    },
+    locations: ['东莞', '广州', '深圳'],
+  },
+  schedule: {
+    enabled: true,
+    cron: '0 9 * * 1-5',
+    timezone: 'Asia/Hong_Kong',
+    maxCandidates: 200,
+    notifyOnlyOnNew: true,
+  },
+  sources: [
+    {
+      type: 'job5156',
+      enabled: true,
+      priority: 1,
+    },
+    {
+      type: 'manual_upload',
+      enabled: true,
+      priority: 2,
+    },
+  ],
+  session: {
+    scope: 'per-position',
+    resetTriggers: ['/archive', '/close-position'],
+    retention: {
+      mode: 'until-closed',
+      archiveAfterDays: 90,
+    },
+  },
+}
 
 function removeRunStatusFile(): void {
   if (fs.existsSync(runStatusFilePath)) {
@@ -87,12 +142,42 @@ describe('search-profiles list route', () => {
     vi.restoreAllMocks()
   })
 
-  it('includes seeded system profiles with landing quick-start metadata', async () => {
+  it('materializes seeded template profiles into editable workspace records', async () => {
+    const records: Array<Record<string, unknown>> = []
+
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
       const call = parseConvexCall(input, init)
 
       if (call.pathName === 'search_profiles:list') {
-        return convexSuccess([])
+        return convexSuccess(records)
+      }
+
+      if (call.pathName === 'search_profiles:create') {
+        if (!isRecord(call.args.profile)) {
+          throw new Error('Expected profile payload for seed materialization')
+        }
+
+        const logicalId = typeof call.args.profile.id === 'string' ? call.args.profile.id : `profile-${records.length + 1}`
+        const filters = isRecord(call.args.profile.filters) ? call.args.profile.filters : {}
+        const filterLocations = Array.isArray(filters.locations) ? filters.locations : []
+        const now = Date.now()
+        const record = {
+          _id: `search_profiles-${records.length + 1}`,
+          name: call.args.profile.name,
+          profileId: logicalId,
+          criteria: {
+            keywords: call.args.profile.keywords,
+            locations: filterLocations.length > 0
+              ? filterLocations
+              : [call.args.profile.location].filter(Boolean),
+          },
+          profile: call.args.profile,
+          workspaceSlug: call.args.workspaceSlug,
+          createdAt: now,
+          updatedAt: now,
+        }
+        records.push(record)
+        return convexSuccess(record)
       }
 
       throw new Error(`Unexpected convex path: ${call.pathName}`)
@@ -113,8 +198,6 @@ describe('search-profiles list route', () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: 'job5156-cn-cnc-sales',
-          origin: 'system',
-          readOnly: true,
           quickStart: expect.objectContaining({
             enabled: true,
             rank: 1,
@@ -123,8 +206,6 @@ describe('search-profiles list route', () => {
         }),
         expect.objectContaining({
           id: 'seek-malaysia-sales',
-          origin: 'system',
-          readOnly: true,
           quickStart: expect.objectContaining({
             enabled: true,
             rank: 2,
@@ -133,6 +214,149 @@ describe('search-profiles list route', () => {
         }),
       ]),
     )
+    expect(records).toHaveLength(3)
+  })
+
+  it('exposes scheduled runtime profiles from workspace-managed storage across known workspaces', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+
+      if (call.pathName === 'search_profiles:list') {
+        const workspaceSlug = typeof call.args.workspaceSlug === 'string' ? call.args.workspaceSlug : 'dev'
+
+        if (workspaceSlug === 'dev') {
+          return convexSuccess([
+            {
+              _id: 'search_profiles-dev-1',
+              name: 'China Job5156 CNC Sales',
+              profileId: 'job5156-cn-cnc-sales',
+              criteria: {
+                keywords: ['CNC', '销售'],
+                locations: ['China'],
+              },
+              profile: {
+                id: 'job5156-cn-cnc-sales',
+                name: 'China Job5156 CNC Sales',
+                status: 'active',
+                location: 'China',
+                keywords: ['CNC', '销售'],
+                schedule: {
+                  enabled: true,
+                  cron: '0 9 * * 1-5',
+                  maxCandidates: 200,
+                },
+              },
+              workspaceSlug: 'dev',
+            },
+            {
+              _id: 'search_profiles-dev-2',
+              name: 'SEEK Malaysia CNC Sales',
+              profileId: 'seek-malaysia-sales',
+              criteria: {
+                keywords: ['CNC', 'Sales'],
+                locations: ['Kuala Lumpur MY'],
+              },
+              profile: {
+                id: 'seek-malaysia-sales',
+                name: 'SEEK Malaysia CNC Sales',
+                status: 'active',
+                location: 'Kuala Lumpur MY',
+                keywords: ['CNC', 'Sales'],
+                schedule: {
+                  enabled: false,
+                },
+              },
+              workspaceSlug: 'dev',
+            },
+            {
+              _id: 'search_profiles-dev-3',
+              name: '东莞车床销售招聘',
+              profileId: 'dongguan-lathe-sales',
+              criteria: {
+                keywords: ['车床', '销售', 'CNC', '数控'],
+                locations: ['东莞', '广州', '深圳'],
+              },
+              profile: {
+                id: 'dongguan-lathe-sales',
+                name: '东莞车床销售招聘',
+                status: 'active',
+                location: '东莞',
+                keywords: ['车床', '销售', 'CNC', '数控'],
+                schedule: {
+                  enabled: true,
+                  cron: '0 9 * * 1-5',
+                  maxCandidates: 200,
+                },
+              },
+              workspaceSlug: 'dev',
+            },
+          ])
+        }
+
+        if (workspaceSlug === 'hr') {
+          return convexSuccess([
+            {
+              _id: 'search_profiles-hr-1',
+              name: 'HR resume ops',
+              profileId: 'hr-profile-1',
+              criteria: {
+                keywords: ['招聘', '简历'],
+                locations: ['东莞'],
+              },
+              profile: {
+                id: 'hr-profile-1',
+                name: 'HR resume ops',
+                status: 'active',
+                location: '东莞',
+                keywords: ['招聘', '简历'],
+                schedule: {
+                  enabled: true,
+                  cron: '*/30 * * * *',
+                  maxCandidates: 50,
+                },
+              },
+              workspaceSlug: 'hr',
+            },
+          ])
+        }
+
+        return convexSuccess([])
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`)
+    })
+
+    const app = createApp()
+    const response = await app.request('/api/search-profiles/runtime', {
+      headers: {
+        'X-Workspace-Slug': 'dev',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+
+    expect(payload).toEqual({
+      success: true,
+      items: expect.arrayContaining([
+        expect.objectContaining({
+          workspaceSlug: 'dev',
+          profileId: 'job5156-cn-cnc-sales',
+          cron: '0 9 * * 1-5',
+        }),
+        expect.objectContaining({
+          workspaceSlug: 'dev',
+          profileId: 'dongguan-lathe-sales',
+          cron: '0 9 * * 1-5',
+        }),
+        expect.objectContaining({
+          workspaceSlug: 'hr',
+          profileId: 'hr-profile-1',
+          cron: '*/30 * * * *',
+        }),
+      ]),
+    })
+    expect(payload.items).toHaveLength(3)
   })
 })
 
@@ -216,13 +440,42 @@ describe('search-profiles run route', () => {
 
   it('dispatches normalized spaced profile keywords when request keyword is omitted', async () => {
     const calls: ConvexCall[] = []
+    let materialized = false
 
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
       const call = parseConvexCall(input, init)
       calls.push(call)
 
       if (call.pathName === 'search_profiles:getById') {
-        return convexSuccess(null)
+        if (!materialized) {
+          return convexSuccess(null)
+        }
+
+        return convexSuccess({
+          _id: 'search_profiles-seeded-1',
+          profileId: 'dongguan-lathe-sales',
+          name: '东莞车床销售招聘',
+          profile: seededDongguanProfile,
+          criteria: {
+            keywords: ['车床', '销售', 'CNC', '数控'],
+            locations: ['东莞', '广州', '深圳'],
+          },
+          workspaceSlug: 'dev',
+        })
+      }
+      if (call.pathName === 'search_profiles:create') {
+        materialized = true
+        return convexSuccess({
+          _id: 'search_profiles-seeded-1',
+          profileId: 'dongguan-lathe-sales',
+          name: '东莞车床销售招聘',
+          profile: call.args.profile,
+          criteria: {
+            keywords: ['车床', '销售', 'CNC', '数控'],
+            locations: ['东莞', '广州', '深圳'],
+          },
+          workspaceSlug: 'dev',
+        })
       }
       if (call.pathName === 'resume_tasks:dispatch') {
         return convexSuccess('task-concat-default')
@@ -259,13 +512,42 @@ describe('search-profiles run route', () => {
 
   it('uses explicit request keyword without rewriting it', async () => {
     const calls: ConvexCall[] = []
+    let materialized = false
 
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
       const call = parseConvexCall(input, init)
       calls.push(call)
 
       if (call.pathName === 'search_profiles:getById') {
-        return convexSuccess(null)
+        if (!materialized) {
+          return convexSuccess(null)
+        }
+
+        return convexSuccess({
+          _id: 'search_profiles-seeded-1',
+          profileId: 'dongguan-lathe-sales',
+          name: '东莞车床销售招聘',
+          profile: seededDongguanProfile,
+          criteria: {
+            keywords: ['车床', '销售', 'CNC', '数控'],
+            locations: ['东莞', '广州', '深圳'],
+          },
+          workspaceSlug: 'dev',
+        })
+      }
+      if (call.pathName === 'search_profiles:create') {
+        materialized = true
+        return convexSuccess({
+          _id: 'search_profiles-seeded-1',
+          profileId: 'dongguan-lathe-sales',
+          name: '东莞车床销售招聘',
+          profile: call.args.profile,
+          criteria: {
+            keywords: ['车床', '销售', 'CNC', '数控'],
+            locations: ['东莞', '广州', '深圳'],
+          },
+          workspaceSlug: 'dev',
+        })
       }
       if (call.pathName === 'resume_tasks:dispatch') {
         return convexSuccess('task-explicit-keyword')
@@ -304,13 +586,42 @@ describe('search-profiles run route', () => {
 
   it('passes age range overrides to Convex dispatch when provided', async () => {
     const calls: ConvexCall[] = []
+    let materialized = false
 
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
       const call = parseConvexCall(input, init)
       calls.push(call)
 
       if (call.pathName === 'search_profiles:getById') {
-        return convexSuccess(null)
+        if (!materialized) {
+          return convexSuccess(null)
+        }
+
+        return convexSuccess({
+          _id: 'search_profiles-seeded-1',
+          profileId: 'dongguan-lathe-sales',
+          name: '东莞车床销售招聘',
+          profile: seededDongguanProfile,
+          criteria: {
+            keywords: ['车床', '销售', 'CNC', '数控'],
+            locations: ['东莞', '广州', '深圳'],
+          },
+          workspaceSlug: 'dev',
+        })
+      }
+      if (call.pathName === 'search_profiles:create') {
+        materialized = true
+        return convexSuccess({
+          _id: 'search_profiles-seeded-1',
+          profileId: 'dongguan-lathe-sales',
+          name: '东莞车床销售招聘',
+          profile: call.args.profile,
+          criteria: {
+            keywords: ['车床', '销售', 'CNC', '数控'],
+            locations: ['东莞', '广州', '深圳'],
+          },
+          workspaceSlug: 'dev',
+        })
       }
       if (call.pathName === 'resume_tasks:dispatch') {
         return convexSuccess('task-age-range')
@@ -437,6 +748,13 @@ describe('search-profiles status route', () => {
       },
     })
     expect(calls[1]).toMatchObject({
+      pathName: 'search_profiles:getById',
+      args: {
+        id: 'shared-profile',
+        workspaceSlug: 'hr',
+      },
+    })
+    expect(calls[2]).toMatchObject({
       pathName: 'resume_tasks:getById',
       args: {
         taskId: 'task-hr',
@@ -512,6 +830,100 @@ describe('search-profiles status route', () => {
 describe('search-profiles update route', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  it('materializes a seeded template profile into workspace storage before updating it', async () => {
+    const calls: ConvexCall[] = []
+    const existingCreatedAt = Date.now() - 1000
+    let seededRecord: Record<string, unknown> | null = null
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+      calls.push(call)
+
+      if (call.pathName === 'search_profiles:getById') {
+        return convexSuccess(seededRecord)
+      }
+
+      if (call.pathName === 'search_profiles:create') {
+        if (!isRecord(call.args.profile)) {
+          throw new Error('Expected seeded profile payload')
+        }
+
+        seededRecord = {
+          _id: 'search_profiles-seeded-1',
+          name: call.args.profile.name,
+          profileId: call.args.profile.id,
+          criteria: {
+            keywords: call.args.profile.keywords,
+            locations: [call.args.profile.location].filter(Boolean),
+          },
+          profile: call.args.profile,
+          workspaceSlug: 'dev',
+          createdAt: existingCreatedAt,
+          updatedAt: existingCreatedAt,
+        }
+        return convexSuccess(seededRecord)
+      }
+
+      if (call.pathName === 'search_profiles:update') {
+        if (!isRecord(call.args.profile) || !seededRecord) {
+          throw new Error('Expected updated seeded profile payload')
+        }
+
+        seededRecord = {
+          ...seededRecord,
+          name: call.args.profile.name,
+          criteria: {
+            keywords: call.args.profile.keywords,
+            locations: [call.args.profile.location].filter(Boolean),
+          },
+          profile: call.args.profile,
+          updatedAt: Date.now(),
+        }
+        return convexSuccess(seededRecord)
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`)
+    })
+
+    const app = createApp()
+    const response = await app.request('/api/search-profiles/job5156-cn-cnc-sales', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Workspace-Slug': 'dev',
+      },
+      body: JSON.stringify({
+        name: 'China Job5156 CNC Sales',
+        location: 'China',
+        keywords: ['CNC', '销售', '机床'],
+        status: 'active',
+        quickStart: {
+          enabled: true,
+          rank: 1,
+          label: 'China · Job5156 · CNC 销售',
+        },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(getCreateCalls(calls)).toHaveLength(1)
+
+    const updateCall = getUpdateCall(calls)
+    expect(updateCall.args.id).toBe('search_profiles-seeded-1')
+    expect(isRecord(updateCall.args.profile)).toBe(true)
+    if (!isRecord(updateCall.args.profile)) {
+      throw new Error('Expected updated profile payload')
+    }
+    expect(updateCall.args.profile.id).toBe('job5156-cn-cnc-sales')
+    expect(updateCall.args.profile.seedSource).toBe('config/search-profiles')
+    expect(updateCall.args.profile.keywords).toEqual(['CNC', '销售', '机床'])
+
+    const payload = await response.json()
+    expect(payload.success).toBe(true)
+    expect(payload.profile.id).toBe('job5156-cn-cnc-sales')
+    expect(payload.profile.keywords).toEqual(['CNC', '销售', '机床'])
   })
 
   it('syncs linked custom JD auto_match keywords without moving other filters under auto_match', async () => {
@@ -905,5 +1317,121 @@ describe('search-profiles update route', () => {
       throw new Error('Expected record payload')
     }
     expect(updateCall.args.profile.location).toBe('')
+  })
+})
+
+describe('search-profiles delete route', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('tombstones a materialized seeded profile so it does not reappear on the next list', async () => {
+    const calls: ConvexCall[] = []
+    const records: Array<Record<string, unknown>> = []
+
+    function buildCriteria(profile: Record<string, unknown>) {
+      const filters = isRecord(profile.filters) ? profile.filters : {}
+      const filterLocations = Array.isArray(filters.locations) ? filters.locations : []
+      return {
+        keywords: Array.isArray(profile.keywords) ? profile.keywords : [],
+        locations: filterLocations.length > 0
+          ? filterLocations
+          : [profile.location].filter(Boolean),
+      }
+    }
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+      calls.push(call)
+
+      if (call.pathName === 'search_profiles:list') {
+        return convexSuccess(records)
+      }
+
+      if (call.pathName === 'search_profiles:getById') {
+        const found = records.find((record) => (
+          String(record._id) === call.args.id
+          || record.profileId === call.args.id
+        )) ?? null
+        return convexSuccess(found)
+      }
+
+      if (call.pathName === 'search_profiles:create') {
+        if (!isRecord(call.args.profile)) {
+          throw new Error('Expected profile payload for seeded create')
+        }
+
+        const profile = call.args.profile
+        const record = {
+          _id: `search_profiles-${records.length + 1}`,
+          name: profile.name,
+          profileId: profile.id,
+          criteria: buildCriteria(profile),
+          profile,
+          workspaceSlug: call.args.workspaceSlug,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        }
+        records.push(record)
+        return convexSuccess(record)
+      }
+
+      if (call.pathName === 'search_profiles:update') {
+        const existingIndex = records.findIndex((record) => String(record._id) === call.args.id)
+        if (existingIndex < 0 || !isRecord(call.args.profile)) {
+          throw new Error('Expected existing seeded record for update')
+        }
+
+        const nextRecord = {
+          ...records[existingIndex],
+          name: call.args.profile.name,
+          criteria: buildCriteria(call.args.profile),
+          profile: call.args.profile,
+          updatedAt: Date.now(),
+        }
+        records.splice(existingIndex, 1, nextRecord)
+        return convexSuccess(nextRecord)
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`)
+    })
+
+    const app = createApp()
+    const deleteResponse = await app.request('/api/search-profiles/seek-malaysia-sales', {
+      method: 'DELETE',
+      headers: {
+        'X-Workspace-Slug': 'dev',
+      },
+    })
+
+    expect(deleteResponse.status).toBe(200)
+    expect(await deleteResponse.json()).toEqual({ success: true })
+
+    const deleteUpdateCall = getUpdateCall(calls)
+    expect(isRecord(deleteUpdateCall.args.profile)).toBe(true)
+    if (!isRecord(deleteUpdateCall.args.profile)) {
+      throw new Error('Expected tombstone profile payload')
+    }
+    expect(deleteUpdateCall.args.profile.id).toBe('seek-malaysia-sales')
+    expect(deleteUpdateCall.args.profile.seedSource).toBe('config/search-profiles')
+    expect(typeof deleteUpdateCall.args.profile.deletedAt).toBe('number')
+
+    const listResponse = await app.request('/api/search-profiles', {
+      headers: {
+        'X-Workspace-Slug': 'dev',
+      },
+    })
+
+    expect(listResponse.status).toBe(200)
+    const listPayload = await listResponse.json()
+    expect(listPayload.success).toBe(true)
+    expect(listPayload.profiles).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'seek-malaysia-sales',
+        }),
+      ]),
+    )
+    expect(getCreateCalls(calls)).toHaveLength(3)
   })
 })

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -6,7 +6,13 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import { generateStructuredJobDescriptionContent } from "@trends/shared";
+import {
+    findWorkspaceSearchProfileTemplate,
+    generateStructuredJobDescriptionContent,
+    getWorkspaceSearchProfileTemplates,
+    isValidWorkspace,
+    WORKSPACE_TEAMS,
+} from "@trends/shared";
 
 import {
     matchSearchProfilesByKeywords,
@@ -21,13 +27,10 @@ const app = new OpenAPIHono();
 const ProfileSummarySchema = z.object({
     id: z.string(),
     name: z.string(),
-    filename: z.string(),
     updatedAt: z.string(),
     status: z.enum(["active", "paused", "archived"]),
     location: z.string(),
     keywords: z.array(z.string()),
-    origin: z.enum(["system", "workspace"]),
-    readOnly: z.boolean(),
     quickStart: z.object({
         enabled: z.boolean(),
         rank: z.number().optional(),
@@ -58,6 +61,17 @@ const AutoMatchResponseSchema = z.object({
 });
 
 const ProfilePayloadSchema = z.record(z.unknown());
+const ProfileRuntimeItemSchema = z.object({
+    workspaceSlug: z.string().min(1),
+    profileId: z.string(),
+    name: z.string(),
+    cron: z.string(),
+    profile: ProfilePayloadSchema,
+});
+const ProfilesRuntimeResponseSchema = z.object({
+    success: z.literal(true),
+    items: z.array(ProfileRuntimeItemSchema),
+});
 
 const RunProfileRequestSchema = z.object({
     keyword: z.string().optional(),
@@ -353,6 +367,7 @@ async function getCollectionTaskStatus(taskId: string): Promise<Partial<ProfileR
 type ConvexSearchProfileRecord = {
     _id?: unknown;
     name?: unknown;
+    profileId?: unknown;
     profile?: unknown;
     criteria?: unknown;
     workspaceSlug?: unknown;
@@ -380,6 +395,8 @@ type JobDescriptionSyncPayload = {
 };
 
 const DEFAULT_WORKSPACE_SLUG = "dev";
+const CONFIG_SEED_SOURCE = "config/search-profiles";
+const KNOWN_WORKSPACE_SLUGS = Object.keys(WORKSPACE_TEAMS).filter(isValidWorkspace);
 
 function belongsToWorkspace(recordWorkspaceSlug: unknown, workspaceSlug: string): boolean {
     const normalizedRecordWorkspace = readString(recordWorkspaceSlug);
@@ -411,13 +428,50 @@ function buildProfileRunKeyword(value: string | undefined, profileKeywords: stri
     return normalizeKeywordList(profileKeywords).join(" ");
 }
 
+function readProfilePayload(record: ConvexSearchProfileRecord): Record<string, unknown> {
+    return isRecord(record.profile) ? record.profile : {};
+}
+
+function readLogicalProfileId(record: ConvexSearchProfileRecord): string | null {
+    const profilePayload = readProfilePayload(record);
+    const explicitId = readString(record.profileId) ?? readString(profilePayload.id);
+    if (explicitId) {
+        return searchProfileService.normalizeProfileIdentifier(explicitId);
+    }
+    return record._id ? String(record._id) : null;
+}
+
+function readDeletedAt(record: ConvexSearchProfileRecord): number | undefined {
+    const profilePayload = readProfilePayload(record);
+    return readNumber(profilePayload.deletedAt);
+}
+
+function isSeededFromConfig(record: ConvexSearchProfileRecord): boolean {
+    const profilePayload = readProfilePayload(record);
+    return readString(profilePayload.seedSource) === CONFIG_SEED_SOURCE;
+}
+
+function toStoredProfilePayload(
+    profile: SearchProfile,
+    options?: {
+        seededFromConfig?: boolean;
+        deletedAt?: number;
+    }
+): Record<string, unknown> {
+    return {
+        ...profile,
+        ...(options?.seededFromConfig ? { seedSource: CONFIG_SEED_SOURCE } : {}),
+        ...(typeof options?.deletedAt === "number" ? { deletedAt: options.deletedAt } : {}),
+    };
+}
+
 function toSearchProfile(record: ConvexSearchProfileRecord): SearchProfile | null {
-    const profileId = record._id ? String(record._id) : "";
+    const profileId = readLogicalProfileId(record) ?? "";
     if (!profileId) {
         return null;
     }
 
-    const profilePayload = isRecord(record.profile) ? record.profile : {};
+    const profilePayload = readProfilePayload(record);
     const criteria = isRecord(record.criteria) ? record.criteria : {};
     const criteriaKeywords = normalizeKeywordList(criteria.keywords);
     const criteriaLocations = normalizeKeywordList(criteria.locations);
@@ -454,6 +508,14 @@ function toSearchProfile(record: ConvexSearchProfileRecord): SearchProfile | nul
     return normalized;
 }
 
+type ResolvedCustomProfileRecord = {
+    storageId: string;
+    logicalId: string;
+    profile: SearchProfile;
+    seededFromConfig: boolean;
+    deletedAt?: number;
+};
+
 async function callConvex(
     type: "query" | "mutation",
     pathName: string,
@@ -483,24 +545,124 @@ async function callConvex(
     return payload.value;
 }
 
-async function listCustomProfiles(workspaceSlug: string): Promise<SearchProfile[]> {
+async function listCustomProfileRecords(
+    workspaceSlug: string,
+    options?: {
+        includeDeleted?: boolean;
+    }
+): Promise<ResolvedCustomProfileRecord[]> {
     const value = await callConvex("query", "search_profiles:list", { workspaceSlug });
     if (!Array.isArray(value)) {
         return [];
     }
 
-    return value
+    const records: ResolvedCustomProfileRecord[] = [];
+    value
         .filter((item): item is ConvexSearchProfileRecord => isRecord(item))
-        .map((item) => toSearchProfile(item))
-        .filter((item): item is SearchProfile => item !== null);
+        .forEach((item) => {
+            const profile = toSearchProfile(item);
+            const storageId = item._id ? String(item._id) : "";
+            const logicalId = profile?.id ?? "";
+            if (!profile || !storageId || !logicalId) {
+                return;
+            }
+
+            const deletedAt = readDeletedAt(item);
+            if (!options?.includeDeleted && typeof deletedAt === "number") {
+                return;
+            }
+
+            records.push({
+                storageId,
+                logicalId,
+                profile,
+                seededFromConfig: isSeededFromConfig(item),
+                ...(typeof deletedAt === "number" ? { deletedAt } : {}),
+            });
+        });
+
+    return records;
+}
+
+async function listCustomProfiles(workspaceSlug: string): Promise<SearchProfile[]> {
+    const records = await listCustomProfileRecords(workspaceSlug);
+    return records.map((record) => record.profile);
 }
 
 async function getCustomProfile(id: string, workspaceSlug: string): Promise<SearchProfile | null> {
+    const record = await findCustomProfileRecordById(id, workspaceSlug);
+    return record?.profile ?? null;
+}
+
+async function findCustomProfileRecordById(
+    id: string,
+    workspaceSlug: string,
+    options?: {
+        includeDeleted?: boolean;
+    }
+): Promise<ResolvedCustomProfileRecord | null> {
     const value = await callConvex("query", "search_profiles:getById", { id, workspaceSlug });
     if (!isRecord(value)) {
         return null;
     }
-    return toSearchProfile(value);
+
+    const record = value as ConvexSearchProfileRecord;
+    const profile = toSearchProfile(record);
+    const storageId = record._id ? String(record._id) : "";
+    const logicalId = profile?.id ?? "";
+    if (!profile || !storageId || !logicalId) {
+        return null;
+    }
+
+    const deletedAt = readDeletedAt(record);
+    if (!options?.includeDeleted && typeof deletedAt === "number") {
+        return null;
+    }
+
+    return {
+        storageId,
+        logicalId,
+        profile,
+        seededFromConfig: isSeededFromConfig(record),
+        deletedAt,
+    };
+}
+
+async function ensureWorkspaceSeedProfiles(workspaceSlug: string): Promise<void> {
+    const existingRecords = await listCustomProfileRecords(workspaceSlug, { includeDeleted: true });
+    const existingIds = new Set(existingRecords.map((record) => record.logicalId));
+
+    for (const template of getWorkspaceSearchProfileTemplates(workspaceSlug)) {
+        const profile = searchProfileService.normalizeProfileInput(template.profile);
+        const logicalId = searchProfileService.normalizeProfileIdentifier(profile.id);
+        if (existingIds.has(logicalId)) {
+            continue;
+        }
+
+        await createCustomProfile(
+            toStoredProfilePayload(profile, { seededFromConfig: true }),
+            workspaceSlug,
+        );
+        existingIds.add(logicalId);
+    }
+}
+
+async function ensureWorkspaceProfileById(id: string, workspaceSlug: string): Promise<void> {
+    const existing = await findCustomProfileRecordById(id, workspaceSlug, { includeDeleted: true });
+    if (existing) {
+        return;
+    }
+
+    const template = findWorkspaceSearchProfileTemplate(id, workspaceSlug);
+    if (!template) {
+        return;
+    }
+
+    const profile = searchProfileService.normalizeProfileInput(template.profile);
+    await createCustomProfile(
+        toStoredProfilePayload(profile, { seededFromConfig: true }),
+        workspaceSlug,
+    );
 }
 
 async function getLinkedCustomJobDescription(
@@ -559,7 +721,7 @@ async function buildJobDescriptionSyncPayload(
 }
 
 async function createCustomProfile(
-    profile: SearchProfile,
+    profile: unknown,
     workspaceSlug: string,
     jobDescriptionSync?: JobDescriptionSyncPayload
 ): Promise<SearchProfile> {
@@ -581,7 +743,7 @@ async function createCustomProfile(
 
 async function updateCustomProfile(
     id: string,
-    profile: SearchProfile,
+    profile: unknown,
     workspaceSlug: string,
     jobDescriptionSync?: JobDescriptionSyncPayload
 ): Promise<SearchProfile> {
@@ -620,11 +782,12 @@ async function loadProfileById(id: string, workspaceSlug: string): Promise<Searc
         return custom;
     }
 
-    try {
-        return searchProfileService.loadProfile(id, workspaceSlug);
-    } catch {
+    const template = findWorkspaceSearchProfileTemplate(id, workspaceSlug);
+    if (!template) {
         return null;
     }
+
+    return searchProfileService.normalizeProfileInput(template.profile);
 }
 
 function compareProfileSummaries(
@@ -642,11 +805,30 @@ function compareProfileSummaries(
         return left.quickStart?.enabled ? -1 : 1;
     }
 
-    if (left.origin !== right.origin) {
-        return left.origin === "system" ? -1 : 1;
-    }
-
     return right.updatedAt.localeCompare(left.updatedAt);
+}
+
+function hasRuntimeSchedule(
+    profile: SearchProfile
+): profile is SearchProfile & { schedule: NonNullable<SearchProfile["schedule"]> } {
+    return profile.status === "active"
+        && profile.schedule?.enabled === true
+        && typeof profile.schedule.cron === "string"
+        && profile.schedule.cron.trim().length > 0;
+}
+
+function toProfileRuntimeItem(workspaceSlug: string, profile: SearchProfile): z.infer<typeof ProfileRuntimeItemSchema> {
+    const profilePayload: Record<string, unknown> = {
+        ...profile,
+    };
+
+    return {
+        workspaceSlug,
+        profileId: profile.id,
+        name: profile.name,
+        cron: profile.schedule!.cron!,
+        profile: profilePayload,
+    };
 }
 
 // ============================================================
@@ -673,6 +855,7 @@ const statsRoute = createRoute({
 });
 
 app.openapi(statsRoute, async (c) => {
+    await ensureWorkspaceSeedProfiles(c.var.workspaceSlug);
     const profiles = await listCustomProfiles(c.var.workspaceSlug);
     const stats = {
         total: profiles.length,
@@ -707,43 +890,59 @@ const listRoute = createRoute({
 });
 
 app.openapi(listRoute, async (c) => {
+    await ensureWorkspaceSeedProfiles(c.var.workspaceSlug);
     const workspaceProfiles = await listCustomProfiles(c.var.workspaceSlug);
-    const systemProfiles = searchProfileService.listProfiles(c.var.workspaceSlug)
-        .map((profileFile) => ({
-            id: profileFile.id,
-            name: profileFile.name,
-            filename: profileFile.filename,
-            updatedAt: profileFile.updatedAt,
-            status: profileFile.status,
-            location: profileFile.location,
-            keywords: profileFile.keywords,
-            origin: "system" as const,
-            readOnly: true,
-            quickStart: profileFile.quickStart,
-        }));
     const workspaceSummaries = workspaceProfiles.map((profile) => ({
         id: profile.id,
         name: profile.name,
-        filename: `${profile.id}.yaml`,
         updatedAt: profile.updatedAt ?? profile.createdAt ?? new Date().toISOString(),
         status: profile.status,
         location: profile.location,
         keywords: profile.keywords,
-        origin: "workspace" as const,
-        readOnly: false,
         quickStart: profile.quickStart,
     }));
 
     const summariesById = new Map<string, z.infer<typeof ProfileSummarySchema>>();
-    for (const summary of systemProfiles) {
-        summariesById.set(summary.id, summary);
-    }
     for (const summary of workspaceSummaries) {
         summariesById.set(summary.id, summary);
     }
 
     const summaries = Array.from(summariesById.values()).sort(compareProfileSummaries);
     return c.json({ success: true, profiles: summaries } as const);
+});
+
+const runtimeProfilesRoute = createRoute({
+    method: "get",
+    path: "/runtime",
+    tags: ["Search Profiles"],
+    summary: "List enabled runtime search profiles across known workspaces for worker scheduling",
+    responses: {
+        200: {
+            description: "Runtime search profile list",
+            content: {
+                "application/json": {
+                    schema: ProfilesRuntimeResponseSchema,
+                },
+            },
+        },
+    },
+});
+
+app.openapi(runtimeProfilesRoute, async (c) => {
+    const workspaceItems = await Promise.all(
+        KNOWN_WORKSPACE_SLUGS.map(async (workspaceSlug) => {
+            await ensureWorkspaceSeedProfiles(workspaceSlug);
+            const profiles = await listCustomProfiles(workspaceSlug);
+            return profiles
+                .filter(hasRuntimeSchedule)
+                .map((profile) => toProfileRuntimeItem(workspaceSlug, profile));
+        }),
+    );
+
+    return c.json({
+        success: true as const,
+        items: workspaceItems.flat(),
+    }, 200);
 });
 
 // ============================================================
@@ -778,10 +977,9 @@ const autoMatchRoute = createRoute({
 
 app.openapi(autoMatchRoute, async (c) => {
     const { keywords, location } = c.req.valid("json");
+    await ensureWorkspaceSeedProfiles(c.var.workspaceSlug);
     const customProfiles = await listCustomProfiles(c.var.workspaceSlug);
-    const customMatch = matchProfiles(customProfiles, keywords, location);
-    const systemMatch = searchProfileService.findByKeywords(keywords, location, c.var.workspaceSlug);
-    const result = customMatch.confidence >= systemMatch.confidence ? customMatch : systemMatch;
+    const result = matchProfiles(customProfiles, keywords, location);
 
     return c.json({
         success: true,
@@ -942,6 +1140,7 @@ app.openapi(runProfileRoute, async (c) => {
     const { id } = c.req.valid("param");
     const workspaceSlug = c.var.workspaceSlug;
 
+    await ensureWorkspaceProfileById(id, workspaceSlug);
     const profile = await loadProfileById(id, workspaceSlug);
     if (!profile) {
         return c.json({ success: false as const, error: `Profile not found: ${id}` }, 404);
@@ -1013,34 +1212,6 @@ app.openapi(runProfileRoute, async (c) => {
 });
 
 // ============================================================
-// POST /api/search-profiles/reload
-// ============================================================
-const reloadRoute = createRoute({
-    method: "post",
-    path: "/reload",
-    tags: ["Search Profiles"],
-    summary: "Clear cache and reload profiles",
-    responses: {
-        200: {
-            description: "Cache cleared",
-            content: {
-                "application/json": {
-                    schema: z.object({
-                        success: z.literal(true),
-                        message: z.string(),
-                    }),
-                },
-            },
-        },
-    },
-});
-
-app.openapi(reloadRoute, (c) => {
-    searchProfileService.clearCache();
-    return c.json({ success: true, message: "Profile cache cleared" } as const);
-});
-
-// ============================================================
 // GET /api/search-profiles/:id/status
 // ============================================================
 const getProfileStatusRoute = createRoute({
@@ -1091,6 +1262,7 @@ app.openapi(getProfileStatusRoute, async (c) => {
     const { id } = c.req.valid("param");
     const workspaceSlug = c.var.workspaceSlug;
 
+    await ensureWorkspaceProfileById(id, workspaceSlug);
     const profile = await loadProfileById(id, workspaceSlug);
     if (!profile) {
         return c.json({ success: false as const, error: `Profile not found: ${id}` }, 404);
@@ -1172,6 +1344,7 @@ const getRoute = createRoute({
 
 app.openapi(getRoute, async (c) => {
     const { id } = c.req.valid("param");
+    await ensureWorkspaceProfileById(id, c.var.workspaceSlug);
     const profile = await loadProfileById(id, c.var.workspaceSlug);
     if (!profile) {
         return c.json({ success: false as const, error: `Profile not found: ${id}` }, 404);
@@ -1252,31 +1425,33 @@ app.openapi(updateProfileRoute, async (c) => {
     const payload = c.req.valid("json");
 
     try {
-        const existingCustom = await getCustomProfile(id, c.var.workspaceSlug);
+        await ensureWorkspaceProfileById(id, c.var.workspaceSlug);
+        const existingCustom = await findCustomProfileRecordById(id, c.var.workspaceSlug);
         if (!existingCustom) {
-            const systemProfile = await loadProfileById(id, c.var.workspaceSlug);
-            if (systemProfile) {
-                return c.json({ success: false as const, error: "System profiles are read-only" }, 403);
-            }
             return c.json({ success: false as const, error: `Profile not found: ${id}` }, 404);
         }
 
         const now = new Date().toISOString();
         const normalized = searchProfileService.normalizeProfileInput(
             {
-                ...existingCustom,
+                ...existingCustom.profile,
                 ...(isRecord(payload) ? payload : {}),
-                id: existingCustom.id,
-                createdAt: existingCustom.createdAt ?? now,
+                id: existingCustom.profile.id,
+                createdAt: existingCustom.profile.createdAt ?? now,
                 updatedAt: now,
             },
-            existingCustom
+            existingCustom.profile
         );
-        normalized.id = existingCustom.id;
+        normalized.id = existingCustom.profile.id;
         searchProfileService.validateProfile(normalized);
 
         const jobDescriptionSync = await buildJobDescriptionSyncPayload(normalized, c.var.workspaceSlug);
-        const profile = await updateCustomProfile(existingCustom.id, normalized, c.var.workspaceSlug, jobDescriptionSync);
+        const profile = await updateCustomProfile(
+            existingCustom.storageId,
+            toStoredProfilePayload(normalized, { seededFromConfig: existingCustom.seededFromConfig }),
+            c.var.workspaceSlug,
+            jobDescriptionSync,
+        );
         return c.json({ success: true as const, profile }, 200);
     } catch (error) {
         const message = error instanceof Error ? error.message : "Failed to update profile";
@@ -1330,15 +1505,24 @@ const deleteProfileRoute = createRoute({
 
 app.openapi(deleteProfileRoute, async (c) => {
     const { id } = c.req.valid("param");
-    const deleted = await deleteCustomProfile(id, c.var.workspaceSlug);
+    await ensureWorkspaceProfileById(id, c.var.workspaceSlug);
+    const existingCustom = await findCustomProfileRecordById(id, c.var.workspaceSlug);
 
-    if (deleted) {
+    if (existingCustom) {
+        if (existingCustom.seededFromConfig) {
+            await updateCustomProfile(
+                existingCustom.storageId,
+                toStoredProfilePayload(existingCustom.profile, {
+                    seededFromConfig: true,
+                    deletedAt: Date.now(),
+                }),
+                c.var.workspaceSlug,
+            );
+        } else {
+            await deleteCustomProfile(existingCustom.storageId, c.var.workspaceSlug);
+        }
+
         return c.json({ success: true as const }, 200);
-    }
-
-    const systemProfile = await loadProfileById(id, c.var.workspaceSlug);
-    if (systemProfile) {
-        return c.json({ success: false as const, error: "System profiles are read-only" }, 403);
     }
 
     return c.json({ success: false as const, error: `Profile not found: ${id}` }, 404);

--- a/apps/api/src/services/search-profile-service.ts
+++ b/apps/api/src/services/search-profile-service.ts
@@ -1,18 +1,14 @@
 /**
  * Search Profile Service
  *
- * Loads and manages search profiles from config/search-profiles/*.yaml
- * Supports auto-matching JD based on keywords and filter preset application
+ * Normalizes, validates, and keyword-matches search profile payloads.
  */
 
-import fs from "node:fs";
 import path from "node:path";
 
 import { normalizeKeywordPhrases } from "@trends/shared";
-import { parse as parseYaml } from "yaml";
 
 import { findProjectRoot } from "./db.js";
-import { DataNotFoundError } from "./errors.js";
 
 // Types
 export interface SearchProfile {
@@ -113,18 +109,6 @@ export interface SearchProfile {
             archiveAfterDays?: number;
         };
     };
-}
-
-export interface SearchProfileFile {
-    id: string;
-    name: string;
-    description?: string;
-    filename: string;
-    updatedAt: string;
-    status: "active" | "paused" | "archived";
-    location: string;
-    keywords: string[];
-    quickStart?: SearchProfile["quickStart"];
 }
 
 export interface AutoMatchResult {
@@ -284,13 +268,6 @@ function normalizeProfileId(rawId: string): string {
         .replace(/^-|-$/g, "");
 
     return normalized || "profile";
-}
-
-const DEFAULT_WORKSPACE_SLUG = "dev";
-
-function normalizeWorkspaceSlug(rawSlug?: string): string {
-    const normalized = rawSlug?.trim();
-    return normalized && normalized.length > 0 ? normalized : DEFAULT_WORKSPACE_SLUG;
 }
 
 function parseFilters(value: unknown): SearchProfile["filters"] | undefined {
@@ -556,59 +533,9 @@ function isSeekRecommendedCandidatesUrl(value: string | undefined): boolean {
 
 export class SearchProfileService {
     readonly projectRoot: string;
-    private cache: Map<string, SearchProfile> = new Map();
 
     constructor(projectRoot?: string) {
         this.projectRoot = projectRoot ? path.resolve(projectRoot) : findProjectRoot();
-    }
-
-    private getProfilesBaseDir(): string {
-        return path.join(this.projectRoot, "config", "search-profiles");
-    }
-
-    private getProfilesWorkspaceDir(workspaceSlug?: string): string {
-        const normalizedWorkspace = normalizeWorkspaceSlug(workspaceSlug);
-        const baseDir = this.getProfilesBaseDir();
-        if (normalizedWorkspace === DEFAULT_WORKSPACE_SLUG) {
-            return baseDir;
-        }
-        return path.join(baseDir, normalizedWorkspace);
-    }
-
-    private getProfilesListDirs(workspaceSlug?: string): string[] {
-        const normalizedWorkspace = normalizeWorkspaceSlug(workspaceSlug);
-        const baseDir = this.getProfilesBaseDir();
-        if (normalizedWorkspace === DEFAULT_WORKSPACE_SLUG) {
-            return [baseDir];
-        }
-        return [baseDir, this.getProfilesWorkspaceDir(normalizedWorkspace)];
-    }
-
-    private getProfilesLookupDirs(workspaceSlug?: string): string[] {
-        const normalizedWorkspace = normalizeWorkspaceSlug(workspaceSlug);
-        const baseDir = this.getProfilesBaseDir();
-        if (normalizedWorkspace === DEFAULT_WORKSPACE_SLUG) {
-            return [baseDir];
-        }
-        return [this.getProfilesWorkspaceDir(normalizedWorkspace), baseDir];
-    }
-
-    private findExistingProfilePath(id: string, workspaceSlug?: string): string | null {
-        const profileDirs = this.getProfilesLookupDirs(workspaceSlug);
-        for (const profilesDir of profileDirs) {
-            const candidates = [
-                path.join(profilesDir, `${id}.yaml`),
-                path.join(profilesDir, `${id}.yml`),
-            ];
-
-            for (const candidate of candidates) {
-                if (fs.existsSync(candidate)) {
-                    return candidate;
-                }
-            }
-        }
-
-        return null;
     }
 
     private coerceProfile(input: unknown, fallback?: SearchProfile): SearchProfile {
@@ -678,21 +605,6 @@ export class SearchProfileService {
         };
     }
 
-    private readProfileFromFile(filePath: string, fallbackId: string): SearchProfile {
-        const content = fs.readFileSync(filePath, "utf8");
-        const parsed = parseYaml(content);
-        const fallback: SearchProfile = {
-            id: fallbackId,
-            name: fallbackId,
-            status: "active",
-            location: "",
-            keywords: [],
-        };
-        const profile = this.coerceProfile(parsed, fallback);
-        profile.id = normalizeProfileId(profile.id || fallbackId);
-        return profile;
-    }
-
     private ensureRequiredCoreFields(profile: SearchProfile): void {
         if (!profile.id) {
             throw new Error("Profile id is required");
@@ -726,113 +638,6 @@ export class SearchProfileService {
         }
     }
 
-    private getCacheKey(workspaceSlug: string, profileId: string): string {
-        return `${workspaceSlug}:${profileId}`;
-    }
-
-    /**
-     * List all profile files
-     */
-    listProfiles(workspaceSlug?: string): SearchProfileFile[] {
-        const entriesById = new Map<string, SearchProfileFile>();
-
-        for (const dir of this.getProfilesListDirs(workspaceSlug)) {
-            if (!fs.existsSync(dir)) {
-                continue;
-            }
-
-            for (const filename of fs.readdirSync(dir).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))) {
-                const filePath = path.join(dir, filename);
-                const stat = fs.statSync(filePath);
-                const fallbackId = filename.replace(/\.(yaml|yml)$/i, "");
-                const profile = this.readProfileFromFile(filePath, fallbackId);
-
-                entriesById.set(profile.id, {
-                    id: profile.id,
-                    name: profile.name,
-                    description: profile.description,
-                    filename,
-                    updatedAt: stat.mtime.toISOString(),
-                    status: profile.status,
-                    location: profile.location,
-                    keywords: profile.keywords,
-                    quickStart: profile.quickStart,
-                } satisfies SearchProfileFile);
-            }
-        }
-
-        return Array.from(entriesById.values()).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-    }
-
-    /**
-     * Load a single profile by ID
-     */
-    loadProfile(id: string, workspaceSlug?: string): SearchProfile {
-        const normalizedWorkspace = normalizeWorkspaceSlug(workspaceSlug);
-        const normalizedId = normalizeProfileId(id);
-        const cacheKey = this.getCacheKey(normalizedWorkspace, normalizedId);
-
-        const cachedProfile = this.cache.get(cacheKey);
-        if (cachedProfile) {
-            return cachedProfile;
-        }
-
-        const existingPath = this.findExistingProfilePath(normalizedId, normalizedWorkspace);
-        if (!existingPath) {
-            const available = this.listProfiles(normalizedWorkspace).map((p) => p.id).join(", ");
-            throw new DataNotFoundError(`Search profile not found: ${normalizedId}`, {
-                suggestion: available ? `Available: ${available}` : "No search profiles available",
-            });
-        }
-
-        const profile = this.readProfileFromFile(existingPath, normalizedId);
-        this.cache.set(cacheKey, profile);
-        return profile;
-    }
-
-    /**
-     * Get effective filters (merge preset with custom filters)
-     */
-    getEffectiveFilters(profile: SearchProfile, presets: Record<string, unknown>): SearchProfile["filters"] {
-        const preset = profile.filterPreset ? presets[profile.filterPreset] : undefined;
-
-        return {
-            ...(isRecord(preset) ? parseFilters(preset) : {}),
-            ...profile.filters,
-        };
-    }
-
-    /**
-     * Find profile by keywords (auto-match)
-     */
-    findByKeywords(keywords: string[], location?: string, workspaceSlug?: string): AutoMatchResult {
-        const normalizedWorkspace = normalizeWorkspaceSlug(workspaceSlug);
-        const profiles = this.listProfiles(normalizedWorkspace)
-            .filter((p) => p.status === "active")
-            .map((profileFile) => this.loadProfile(profileFile.id, normalizedWorkspace));
-
-        return matchSearchProfilesByKeywords(profiles, keywords, location);
-    }
-
-    /**
-     * Clear cache
-     */
-    clearCache(): void {
-        this.cache.clear();
-    }
-
-    /**
-     * Get profile count
-     */
-    getStats(workspaceSlug?: string): { total: number; active: number; paused: number; archived: number } {
-        const profiles = this.listProfiles(workspaceSlug);
-        return {
-            total: profiles.length,
-            active: profiles.filter((p) => p.status === "active").length,
-            paused: profiles.filter((p) => p.status === "paused").length,
-            archived: profiles.filter((p) => p.status === "archived").length,
-        };
-    }
 }
 
 // Singleton

--- a/apps/web/src/components/ProfileCard.tsx
+++ b/apps/web/src/components/ProfileCard.tsx
@@ -7,13 +7,10 @@ import { Badge } from '@/components/ui/badge'
 export type SearchProfileSummary = {
   id: string
   name: string
-  filename: string
   updatedAt: string
   status: 'active' | 'paused' | 'archived'
   location: string
   keywords: string[]
-  origin: 'system' | 'workspace'
-  readOnly: boolean
   quickStart?: {
     enabled: boolean
     rank?: number
@@ -55,10 +52,6 @@ function statusBadgeVariant(status: SearchProfileSummary['status']): 'default' |
   return 'outline'
 }
 
-function originBadgeLabel(origin: SearchProfileSummary['origin']): string {
-  return origin === 'system' ? 'seeded' : 'workspace'
-}
-
 function runStatusLabel(status: SearchProfileRunStatus['taskStatus']): string {
   if (status === 'pending') return 'pending'
   if (status === 'processing') return 'running'
@@ -90,7 +83,6 @@ export function ProfileCard({
             {profile.quickStart?.enabled ? (
               <Badge variant="secondary">quick start</Badge>
             ) : null}
-            <Badge variant="outline">{originBadgeLabel(profile.origin)}</Badge>
             <Badge variant={statusBadgeVariant(profile.status)}>{profile.status}</Badge>
           </div>
         </div>
@@ -127,7 +119,6 @@ export function ProfileCard({
           size="sm"
           variant="outline"
           onClick={() => onEdit(profile.id)}
-          disabled={profile.readOnly}
         >
           <Pencil className="h-3.5 w-3.5 mr-1" />
           Edit
@@ -136,7 +127,6 @@ export function ProfileCard({
           size="sm"
           variant="outline"
           onClick={() => onDelete(profile.id)}
-          disabled={profile.readOnly}
         >
           <Trash2 className="h-3.5 w-3.5 mr-1" />
           Delete

--- a/apps/web/src/components/search/MigrationBanner.test.tsx
+++ b/apps/web/src/components/search/MigrationBanner.test.tsx
@@ -30,7 +30,8 @@ describe('MigrationBanner', () => {
       expect(screen.getByText('Search Profiles still exist, but the primary resume route is now search-first.')).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/system/profiles?view=quick-starts')
+    expect(screen.getByText('Use this page for fast keyword review. Use Search Profiles when you need landing quick starts, scheduled collectors, and JD-driven setup in one place.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/system/profiles')
   })
 
   it('persists dismissal in local storage', async () => {

--- a/apps/web/src/components/search/MigrationBanner.tsx
+++ b/apps/web/src/components/search/MigrationBanner.tsx
@@ -23,11 +23,11 @@ export function MigrationBanner() {
       <div className="space-y-1">
         <div className="font-medium">Search Profiles still exist, but the primary resume route is now search-first.</div>
         <div className="text-sky-800/80">
-          Use this page for fast keyword review. Use Search Profiles when you need landing quick starts, scheduled collectors, and JD-driven setup.
+          Use this page for fast keyword review. Use Search Profiles when you need landing quick starts, scheduled collectors, and JD-driven setup in one place.
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <Link className="inline-flex h-9 items-center rounded-md border border-sky-200 bg-white px-3 text-sm font-medium" to={`/${slug}/system/profiles?view=quick-starts`}>
+        <Link className="inline-flex h-9 items-center rounded-md border border-sky-200 bg-white px-3 text-sm font-medium" to={`/${slug}/system/profiles`}>
           Open Search Profiles
         </Link>
         <Button

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -378,7 +378,7 @@
   "searchProfiles": {
     "nav": "Search Profiles",
     "title": "Search Profiles",
-    "subtitle": "Manage scheduled profile-based resume searches.",
+    "subtitle": "Manage landing quick starts and scheduled profile-based resume searches.",
     "refresh": "Refresh",
     "create": "Create Profile",
     "loading": "Loading profiles...",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -378,7 +378,7 @@
   "searchProfiles": {
     "nav": "搜索配置",
     "title": "搜索配置",
-    "subtitle": "管理基于配置文件的定时简历搜索。",
+    "subtitle": "管理落地页快捷入口和定时简历搜索配置。",
     "refresh": "刷新",
     "create": "新建配置",
     "loading": "正在加载配置...",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -378,7 +378,7 @@
   "searchProfiles": {
     "nav": "搜尋配置",
     "title": "搜尋配置",
-    "subtitle": "管理基於配置檔的定時簡歷搜尋。",
+    "subtitle": "管理落地頁快捷入口和定時簡歷搜尋配置。",
     "refresh": "刷新",
     "create": "新增配置",
     "loading": "正在載入配置...",

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -3726,15 +3726,11 @@ export interface paths {
                             profiles: {
                                 id: string;
                                 name: string;
-                                filename: string;
                                 updatedAt: string;
                                 /** @enum {string} */
                                 status: "active" | "paused" | "archived";
                                 location: string;
                                 keywords: string[];
-                                /** @enum {string} */
-                                origin: "system" | "workspace";
-                                readOnly: boolean;
                                 quickStart?: {
                                     enabled: boolean;
                                     rank?: number;
@@ -3794,6 +3790,54 @@ export interface paths {
                 };
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/search-profiles/runtime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List enabled runtime search profiles across known workspaces for worker scheduling */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Runtime search profile list */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            items: {
+                                workspaceSlug: string;
+                                profileId: string;
+                                name: string;
+                                cron: string;
+                                profile: {
+                                    [key: string]: unknown;
+                                };
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -3962,46 +4006,6 @@ export interface paths {
                             /** @enum {boolean} */
                             success: false;
                             error: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/search-profiles/reload": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Clear cache and reload profiles */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Cache cleared */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: true;
-                            message: string;
                         };
                     };
                 };

--- a/apps/web/src/pages/DebugConfig.test.tsx
+++ b/apps/web/src/pages/DebugConfig.test.tsx
@@ -325,9 +325,9 @@ describe('System settings routes', () => {
     await waitFor(() => {
       expect(screen.getByText('Landing quick starts')).toBeInTheDocument()
       expect(screen.getByText('Legacy workflow-seed config remains for compatibility only. The search-first landing page now reads its quick starts from Search Profiles instead.')).toBeInTheDocument()
-      expect(screen.getByText('The seeded China Job5156 and Malaysia SEEK quick starts now live in Search Profiles. Manage landing-entry presets and scheduled collectors there instead of in workflow-seed settings.')).toBeInTheDocument()
+      expect(screen.getByText('Search Profiles is now the single page for landing quick starts and other profiles. The China Job5156 and Malaysia SEEK starter profiles are materialized into workspace-managed storage there, so you can edit them directly.')).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/system/profiles?view=quick-starts')
+    expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/system/profiles')
   })
 })

--- a/apps/web/src/pages/SearchProfilesPage.test.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.test.tsx
@@ -117,7 +117,6 @@ describe('SearchProfilesPage run behavior', () => {
               {
                 id: 'profile-1',
                 name: 'Profile 1',
-                filename: 'profile-1.yaml',
                 updatedAt: '2026-03-17T00:00:00.000Z',
                 status: 'active',
                 location: 'Kuala Lumpur MY',
@@ -162,7 +161,6 @@ describe('SearchProfilesPage run behavior', () => {
               {
                 id: 'profile-1',
                 name: 'Seek profile',
-                filename: 'seek-profile.yaml',
                 updatedAt: '2026-03-17T00:00:00.000Z',
                 status: 'active',
                 location: 'Kuala Lumpur MY',
@@ -258,7 +256,6 @@ describe('SearchProfilesPage run behavior', () => {
               {
                 id: 'profile-1',
                 name: 'Job5156 profile',
-                filename: 'job5156-profile.yaml',
                 updatedAt: '2026-03-17T00:00:00.000Z',
                 status: 'active',
                 location: '东莞',
@@ -343,7 +340,7 @@ describe('SearchProfilesPage run behavior', () => {
     expect(toastSuccessMock).toHaveBeenCalledWith('Profile run started')
   })
 
-  it('filters to landing quick starts when opened from the quick-start view', async () => {
+  it('keeps the legacy quick-start view URL on the unified page', async () => {
     routerState.search = 'view=quick-starts'
 
     getMock.mockImplementation(async (path: string) => {
@@ -355,13 +352,10 @@ describe('SearchProfilesPage run behavior', () => {
               {
                 id: 'profile-1',
                 name: 'Quick Start Profile',
-                filename: 'profile-1.yaml',
                 updatedAt: '2026-03-17T00:00:00.000Z',
                 status: 'active',
                 location: 'China',
                 keywords: ['CNC', '销售'],
-                origin: 'system',
-                readOnly: true,
                 quickStart: {
                   enabled: true,
                 },
@@ -369,13 +363,10 @@ describe('SearchProfilesPage run behavior', () => {
               {
                 id: 'profile-2',
                 name: 'Scheduled Only Profile',
-                filename: 'profile-2.yaml',
                 updatedAt: '2026-03-17T00:00:00.000Z',
                 status: 'active',
                 location: 'Dongguan',
                 keywords: ['车床', '销售'],
-                origin: 'workspace',
-                readOnly: false,
               },
             ],
           },
@@ -407,9 +398,16 @@ describe('SearchProfilesPage run behavior', () => {
 
     render(<SearchProfilesPage />)
 
-    expect(await screen.findByText('This filtered view shows only profiles with landing quick-start metadata enabled.')).toBeInTheDocument()
+    expect(await screen.findByText('Manage landing quick starts and scheduled profile-based resume searches.')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Run Quick Start Profile' })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Run Scheduled Only Profile' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Show All Profiles' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Run Scheduled Only Profile' })).toBeInTheDocument()
+    expect(screen.queryByText('This filtered view shows only profiles with landing quick-start metadata enabled.')).not.toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(setSearchParamsMock).toHaveBeenCalledWith(expect.any(URLSearchParams), { replace: true })
+    })
+
+    const [nextParams] = setSearchParamsMock.mock.calls[0]
+    expect(nextParams.toString()).toBe('')
   })
 })

--- a/apps/web/src/pages/SearchProfilesPage.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.tsx
@@ -111,10 +111,6 @@ function buildScheduleLabel(profile?: SearchProfileDetails): string {
   return profile.schedule.cron || 'enabled'
 }
 
-function isQuickStartProfile(profile: SearchProfileSummary): boolean {
-  return profile.quickStart?.enabled === true
-}
-
 export function SearchProfilesPage() {
   const { t } = useTranslation()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -248,29 +244,29 @@ export function SearchProfilesPage() {
     }
   }, [])
 
+  useEffect(() => {
+    if (searchParams.get('view') !== 'quick-starts') {
+      return
+    }
+
+    const nextParams = new URLSearchParams(searchParams)
+    nextParams.delete('view')
+    setSearchParams(nextParams, { replace: true })
+  }, [searchParams, setSearchParams])
+
   const handleCreate = useCallback(() => {
     setEditingProfileId(null)
     setEditorOpen(true)
   }, [])
 
   const handleEdit = useCallback(async (profileId: string) => {
-    const summary = profiles.find((profile) => profile.id === profileId)
-    if (summary?.readOnly) {
-      toast.error(t('searchProfiles.readOnlyEdit', { defaultValue: 'Seeded profiles are managed from Search Profiles config and are read-only in this workspace UI.' }))
-      return
-    }
     setEditingProfileId(profileId)
     setEditorOpen(true)
-  }, [profiles, t])
+  }, [])
 
   const handleDelete = useCallback((profileId: string) => {
-    const summary = profiles.find((profile) => profile.id === profileId)
-    if (summary?.readOnly) {
-      toast.error(t('searchProfiles.readOnlyDelete', { defaultValue: 'Seeded profiles cannot be deleted from the workspace UI.' }))
-      return
-    }
     setDeletingProfileId(profileId)
-  }, [profiles, t])
+  }, [])
 
   const confirmDelete = useCallback(async () => {
     if (!deletingProfileId) {
@@ -397,14 +393,8 @@ export function SearchProfilesPage() {
     setSearchParams(nextParams, { replace: true })
   }, [handleEdit, profiles, searchParams, setSearchParams])
 
-  const showQuickStartsOnly = searchParams.get('view') === 'quick-starts'
-
   const cards = useMemo(() => {
-    const visibleProfiles = showQuickStartsOnly
-      ? profiles.filter(isQuickStartProfile)
-      : profiles
-
-    return visibleProfiles.map((profile) => {
+    return profiles.map((profile) => {
       const detail = profileDetails[profile.id]
       return {
         profile,
@@ -412,32 +402,19 @@ export function SearchProfilesPage() {
         runStatus: runStatuses[profile.id],
       }
     })
-  }, [profileDetails, profiles, runStatuses, showQuickStartsOnly])
-
-  const handleShowAllProfiles = useCallback(() => {
-    const nextParams = new URLSearchParams(searchParams)
-    nextParams.delete('view')
-    setSearchParams(nextParams, { replace: true })
-  }, [searchParams, setSearchParams])
+  }, [profileDetails, profiles, runStatuses])
 
   return (
     <div className="space-y-6">
       <PageHeader
         title={t('searchProfiles.title', { defaultValue: 'Search Profiles' })}
-        description={showQuickStartsOnly
-          ? t('searchProfiles.quickStartsSubtitle', { defaultValue: 'Showing landing quick starts only. Open all profiles to manage scheduled collectors and non-landing searches.' })
-          : t('searchProfiles.subtitle', { defaultValue: 'Manage landing quick starts and scheduled profile-based resume searches.' })}
+        description={t('searchProfiles.subtitle', { defaultValue: 'Manage landing quick starts and scheduled profile-based resume searches.' })}
         actions={
           <>
             <Button variant="outline" onClick={() => void loadProfiles()} disabled={loading}>
               <RefreshCw className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
               {t('searchProfiles.refresh', { defaultValue: 'Refresh' })}
             </Button>
-            {showQuickStartsOnly ? (
-              <Button variant="outline" onClick={handleShowAllProfiles}>
-                {t('searchProfiles.showAll', { defaultValue: 'Show All Profiles' })}
-              </Button>
-            ) : null}
             <Button onClick={handleCreate}>
               <Plus className="h-4 w-4 mr-2" />
               {t('searchProfiles.create', { defaultValue: 'Create Profile' })}
@@ -445,14 +422,6 @@ export function SearchProfilesPage() {
           </>
         }
       />
-
-      {showQuickStartsOnly ? (
-        <Card>
-          <CardContent className="pt-6 text-sm text-muted-foreground">
-            {t('searchProfiles.quickStartsNotice', { defaultValue: 'This filtered view shows only profiles with landing quick-start metadata enabled.' })}
-          </CardContent>
-        </Card>
-      ) : null}
 
       {loading ? (
         <Card>
@@ -464,15 +433,11 @@ export function SearchProfilesPage() {
         <Card>
           <CardHeader>
             <CardTitle className="text-base">
-              {showQuickStartsOnly
-                ? t('searchProfiles.quickStartsEmptyTitle', { defaultValue: 'No landing quick starts yet' })
-                : t('searchProfiles.emptyTitle', { defaultValue: 'No profiles yet' })}
+              {t('searchProfiles.emptyTitle', { defaultValue: 'No profiles yet' })}
             </CardTitle>
           </CardHeader>
           <CardContent className="text-sm text-muted-foreground">
-            {showQuickStartsOnly
-              ? t('searchProfiles.quickStartsEmptyDescription', { defaultValue: 'Enable landing quick-start metadata on a profile to surface it on the search landing page.' })
-              : t('searchProfiles.emptyDescription', { defaultValue: 'Create your first profile to enable one-click and scheduled runs.' })}
+            {t('searchProfiles.emptyDescription', { defaultValue: 'Create your first profile to enable one-click and scheduled runs.' })}
           </CardContent>
         </Card>
       ) : (

--- a/apps/web/src/pages/system-settings/SystemSettingsKeywordsPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsKeywordsPage.tsx
@@ -305,13 +305,13 @@ export function SystemSettingsKeywordsPage() {
                 <CardTitle>{t('quickStart.workflows', { defaultValue: 'Landing quick starts' })}</CardTitle>
                 <CardDescription>
                   {t('debugConfig.workflowSeedsDescription', {
-                    defaultValue: 'Search-first landing quick starts now come from Search Profiles so the same seeded searches can power scheduled collectors.',
+                    defaultValue: 'Search-first landing quick starts now live in the same Search Profiles workspace registry as every other profile.',
                   })}
                 </CardDescription>
               </div>
               <Link
                 className="inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-                to={`/${slug}/system/profiles?view=quick-starts`}
+                to={`/${slug}/system/profiles`}
               >
                 {t('searchProfiles.title', { defaultValue: 'Open Search Profiles' })}
               </Link>
@@ -325,7 +325,7 @@ export function SystemSettingsKeywordsPage() {
             </div>
             <div className="rounded-md border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
               {t('debugConfig.workflowSeedsMigrationSummary', {
-                defaultValue: 'The seeded China Job5156 and Malaysia SEEK quick starts now live in Search Profiles. Manage landing-entry presets and scheduled collectors there instead of in workflow-seed settings.',
+                defaultValue: 'Search Profiles is now the single page for landing quick starts and other profiles. The China Job5156 and Malaysia SEEK starter profiles are materialized into workspace-managed storage there, so you can edit them directly.',
               })}
             </div>
           </CardContent>

--- a/apps/worker/profile_loader.py
+++ b/apps/worker/profile_loader.py
@@ -1,75 +1,56 @@
-
-import glob
 import logging
-import os
-import yaml
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
+
+from apps.worker.tasks import _request_json, _worker_api_base_url
 
 logger = logging.getLogger(__name__)
 
+
 class ProfileLoader:
-    def __init__(self, config_dir: str = "config/search-profiles"):
-        self.config_dir = config_dir
+    def __init__(self, api_base_url: Optional[str] = None):
+        self.api_base_url = _worker_api_base_url(api_base_url)
 
     def load_profiles(self) -> List[Dict[str, Any]]:
         """
-        Load all enabled search profiles from the config directory.
-        Returns a list of profile dictionaries containing:
-        - id: Profile ID
-        - schedule: Active runtime schedule metadata
-        - limit: Max resumes to collect (legacy compatibility alias)
-        - location: Target location
-        - keywords: Search keywords
+        Load enabled scheduled search profiles from the API runtime view.
+
+        Returns profile payloads that match the existing worker dispatch contract.
         """
-        profiles = []
-        pattern = os.path.join(self.config_dir, "*.yaml")
-        
-        for filepath in glob.glob(pattern):
-            try:
-                with open(filepath, "r") as f:
-                    data = yaml.safe_load(f)
-                    
-                if not data:
-                    continue
-                    
-                # Skip if no schedule or disabled
-                schedule = data.get("schedule", {})
-                if not schedule.get("enabled", False):
-                    continue
-                    
-                cron = schedule.get("cron")
-                if not cron:
-                    logger.warning(f"Profile {filepath} enabled but missing cron expression")
-                    continue
 
-                max_candidates = schedule.get("maxCandidates")
-                if max_candidates is None:
-                    max_candidates = schedule.get("limit", 50)
+        response = _request_json(f"{self.api_base_url}/api/search-profiles/runtime")
+        if response.get("success") is not True:
+            raise RuntimeError(f"Search profile runtime request failed: {response}")
 
-                runtime_schedule = {
-                    "enabled": True,
-                    "cron": cron,
-                    "timezone": schedule.get("timezone"),
-                    "maxCandidates": max_candidates,
-                    "notifyOnlyOnNew": schedule.get("notifyOnlyOnNew"),
-                }
-                    
-                profile = {
-                    "id": data.get("id"),
-                    "name": data.get("name"),
-                    "cron": cron,
-                    "limit": max_candidates,
-                    "schedule": runtime_schedule,
-                    "location": data.get("location"),
-                    "keywords": data.get("keywords", []),
-                    "filters": data.get("filters"),
-                    "job_description": data.get("jobDescription"),
-                    "filepath": filepath
-                }
-                profiles.append(profile)
-                logger.info(f"Loaded profile: {profile['id']} (Cron: {cron})")
-                
-            except Exception as e:
-                logger.error(f"Failed to load profile {filepath}: {e}")
-                
+        raw_items = response.get("items")
+        if not isinstance(raw_items, list):
+            raise RuntimeError("Search profile runtime payload is missing items[]")
+
+        profiles: List[Dict[str, Any]] = []
+        for raw_item in raw_items:
+            if not isinstance(raw_item, dict):
+                continue
+
+            workspace_slug = str(raw_item.get("workspaceSlug") or "").strip()
+            profile = raw_item.get("profile")
+            cron = str(raw_item.get("cron") or "").strip()
+            if not workspace_slug or not cron or not isinstance(profile, dict):
+                continue
+
+            profile_id = str(profile.get("id") or raw_item.get("profileId") or "").strip()
+            name = str(profile.get("name") or raw_item.get("name") or profile_id).strip()
+            location = str(profile.get("location") or "").strip()
+            keywords = profile.get("keywords")
+            schedule = profile.get("schedule")
+
+            if not profile_id or not name or not location or not isinstance(keywords, list) or not isinstance(schedule, dict):
+                continue
+
+            normalized_profile = dict(profile)
+            normalized_profile["id"] = profile_id
+            normalized_profile["name"] = name
+            normalized_profile["cron"] = cron
+            normalized_profile["workspaceSlug"] = workspace_slug
+            profiles.append(normalized_profile)
+            logger.info("Loaded runtime profile: %s (%s)", profile_id, cron)
+
         return profiles

--- a/apps/worker/scheduler.py
+++ b/apps/worker/scheduler.py
@@ -274,9 +274,7 @@ class WorkerScheduler:
     def load_profile_jobs(self) -> None:
         """Load and schedule jobs from search profiles."""
         try:
-            # Determine config directory (relative to project root)
-            # Assuming CWD is project root
-            loader = ProfileLoader(config_dir="config/search-profiles")
+            loader = ProfileLoader()
             profiles = loader.load_profiles()
             
             for profile in profiles:

--- a/packages/convex/convex/search_profiles.ts
+++ b/packages/convex/convex/search_profiles.ts
@@ -46,6 +46,40 @@ function readStringArray(value: unknown): string[] {
   return Array.from(new Set(normalized));
 }
 
+function readProfileId(record: {
+  profileId?: string;
+  profile?: unknown;
+}): string | undefined {
+  const direct = readString(record.profileId);
+  if (direct) {
+    return direct;
+  }
+
+  const profile = asRecord(record.profile);
+  return readString(profile?.id);
+}
+
+function findSearchProfileRecordById(
+  records: Array<{
+    _id: Id<"search_profiles">;
+    name: string;
+    workspaceSlug?: string;
+    profileId?: string;
+    profile?: unknown;
+  }>,
+  id: string,
+  workspaceSlug: string,
+) {
+  const normalizedId = id.trim();
+  return records.find((record) => (
+    belongsToWorkspace(record.workspaceSlug, workspaceSlug)
+    && (
+      String(record._id) === normalizedId
+      || readProfileId(record) === normalizedId
+    )
+  ));
+}
+
 function normalizeCriteria(profile: unknown): { keywords: string[]; locations: string[] } {
   const record = asRecord(profile);
   if (!record) {
@@ -151,11 +185,8 @@ export const getById = query({
   handler: async (ctx, args) => {
     const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
     const records = await ctx.db.query("search_profiles").collect();
-    const found = records.find((record) => String(record._id) === args.id);
+    const found = findSearchProfileRecordById(records, args.id, workspaceSlug);
     if (!found) {
-      return null;
-    }
-    if (!belongsToWorkspace(found.workspaceSlug, workspaceSlug)) {
       return null;
     }
     return found;
@@ -202,12 +233,9 @@ export const update = mutation({
   handler: async (ctx, args) => {
     const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
     const records = await ctx.db.query("search_profiles").collect();
-    const existing = records.find((record) => String(record._id) === args.id);
+    const existing = findSearchProfileRecordById(records, args.id, workspaceSlug);
     if (!existing) {
       throw new Error(`Search profile not found: ${args.id}`);
-    }
-    if (!belongsToWorkspace(existing.workspaceSlug, workspaceSlug)) {
-      throw new Error("Cannot update search profile from another workspace");
     }
 
     const profile = asRecord(args.profile);
@@ -238,11 +266,8 @@ export const remove = mutation({
   handler: async (ctx, args) => {
     const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
     const records = await ctx.db.query("search_profiles").collect();
-    const existing = records.find((record) => String(record._id) === args.id);
+    const existing = findSearchProfileRecordById(records, args.id, workspaceSlug);
     if (!existing) {
-      return false;
-    }
-    if (!belongsToWorkspace(existing.workspaceSlug, workspaceSlug)) {
       return false;
     }
 

--- a/packages/convex/convex/seed.ts
+++ b/packages/convex/convex/seed.ts
@@ -3,8 +3,10 @@ import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import {
+  buildSearchProfileCriteria,
   buildLatestWorkHistoryEvidence,
   generateStructuredJobDescriptionContent,
+  getWorkspaceSearchProfileTemplates,
 } from "@trends/shared";
 import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
 import { deriveResumeIdentity } from "./lib/resume_identity";
@@ -567,48 +569,15 @@ export const seedWorkspaceDemoData = mutation({
       },
     ];
 
-    const searchProfiles = [
-      {
-        name: "CNC 销售-China",
-        criteria: {
-          keywords: ["CNC", "销售"],
-          locations: ["China"],
-        },
-        profile: {
-          name: "CNC 销售-China",
-          status: "active" as const,
-          location: "China",
-          keywords: ["CNC", "销售"],
-          filters: {
-            minExperience: 1,
-            minAge: 25,
-            maxAge: 35,
-          },
-        },
-        workspaceSlug: "dev",
-        lastRunAt: seededAt - 3_600_000,
-      },
-      {
-        name: "CNC Sales-MY",
-        criteria: {
-          keywords: ["CNC", "Sales"],
-          locations: ["Kuala Lumpur MY"],
-        },
-        profile: {
-          name: "CNC Sales-MY",
-          status: "active" as const,
-          location: "Kuala Lumpur MY",
-          keywords: ["CNC", "Sales"],
-          filters: {
-            minExperience: 1,
-            minAge: 25,
-            maxAge: 35,
-          },
-        },
-        workspaceSlug: "dev",
-        lastRunAt: seededAt - 1_800_000,
-      },
-    ];
+    const searchProfiles = getWorkspaceSearchProfileTemplates("dev").map((template) => ({
+      name: template.profile.name,
+      criteria: buildSearchProfileCriteria(template.profile),
+      profile: template.profile,
+      workspaceSlug: template.workspaceSlug,
+      lastRunAt: typeof template.seedLastRunOffsetMs === "number"
+        ? seededAt - template.seedLastRunOffsetMs
+        : undefined,
+    }));
 
     const screeningSessions = [
       {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,3 +12,4 @@ export * from "./resume-id.js";
 export * from "./system-debug-metadata.js";
 export * from "./keyword-query.js";
 export * from "./summaries.js";
+export * from "./search-profile-templates.js";

--- a/packages/shared/src/search-profile-templates.ts
+++ b/packages/shared/src/search-profile-templates.ts
@@ -1,0 +1,249 @@
+export const DEFAULT_TEMPLATE_WORKSPACE_SLUG = "dev";
+
+export type SharedSearchProfileTemplate = {
+  workspaceSlug?: string;
+  profile: {
+    id: string;
+    name: string;
+    description?: string;
+    createdAt?: string;
+    updatedAt?: string;
+    status: "active" | "paused" | "archived";
+    location: string;
+    keywords: string[];
+    requiredKeywords?: string[];
+    jobDescription?: string;
+    filterPreset?: string;
+    filters?: {
+      minExperience?: number;
+      maxExperience?: number | null;
+      minAge?: number;
+      maxAge?: number;
+      education?: string[];
+      salaryRange?: {
+        min?: number;
+        max?: number;
+        currency?: string;
+        period?: string;
+      };
+      locations?: string[];
+    };
+    schedule?: {
+      enabled: boolean;
+      cron?: string;
+      timezone?: string;
+      maxCandidates?: number;
+      notifyOnlyOnNew?: boolean;
+    };
+    sources?: Array<{
+      type: string;
+      enabled: boolean;
+      priority?: number;
+      jobUrl?: string;
+    }>;
+    quickStart?: {
+      enabled: boolean;
+      rank?: number;
+      label?: string;
+      description?: string;
+    };
+    session?: {
+      scope?: string;
+      resetTriggers?: string[];
+      retention?: {
+        mode?: string;
+        archiveAfterDays?: number;
+      };
+    };
+  };
+  seedLastRunOffsetMs?: number;
+};
+
+export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
+  {
+    workspaceSlug: DEFAULT_TEMPLATE_WORKSPACE_SLUG,
+    seedLastRunOffsetMs: 3_600_000,
+    profile: {
+      id: "job5156-cn-cnc-sales",
+      name: "China Job5156 CNC Sales",
+      description: "China-wide Job5156 CNC sales search profile used for the landing quick start",
+      createdAt: "2026-03-28",
+      updatedAt: "2026-03-28",
+      status: "active",
+      location: "China",
+      keywords: ["CNC", "销售"],
+      jobDescription: "lathe-sales",
+      filters: {
+        minExperience: 2,
+        maxExperience: null,
+        locations: ["China"],
+      },
+      schedule: {
+        enabled: true,
+        cron: "0 9 * * 1-5",
+        timezone: "Asia/Shanghai",
+        maxCandidates: 200,
+      },
+      sources: [
+        {
+          type: "job5156",
+          enabled: true,
+          priority: 1,
+        },
+        {
+          type: "seek",
+          enabled: false,
+          priority: 2,
+        },
+      ],
+      quickStart: {
+        enabled: true,
+        rank: 1,
+        label: "China · Job5156 · CNC 销售",
+        description: "CNC, 销售 · China",
+      },
+    },
+  },
+  {
+    workspaceSlug: DEFAULT_TEMPLATE_WORKSPACE_SLUG,
+    seedLastRunOffsetMs: 1_800_000,
+    profile: {
+      id: "seek-malaysia-sales",
+      name: "SEEK Malaysia CNC Sales",
+      description: "Malaysia SEEK workflow for Kuala Lumpur CNC sales hiring",
+      createdAt: "2026-03-17",
+      updatedAt: "2026-03-20",
+      status: "active",
+      location: "Kuala Lumpur MY",
+      keywords: ["CNC", "Sales"],
+      requiredKeywords: ["machine tools"],
+      jobDescription: "seek-malaysia-sales",
+      filters: {
+        minExperience: 2,
+        maxExperience: null,
+        maxAge: 45,
+        locations: ["Kuala Lumpur MY", "Malaysia"],
+      },
+      schedule: {
+        enabled: false,
+        timezone: "Asia/Kuala_Lumpur",
+        maxCandidates: 120,
+      },
+      sources: [
+        {
+          type: "seek",
+          enabled: true,
+          priority: 1,
+          jobUrl: "https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1",
+        },
+        {
+          type: "job5156",
+          enabled: false,
+          priority: 2,
+        },
+      ],
+      session: {
+        scope: "per-position",
+        retention: {
+          mode: "until-closed",
+          archiveAfterDays: 90,
+        },
+      },
+      quickStart: {
+        enabled: true,
+        rank: 2,
+        label: "Malaysia · SEEK · CNC Sales",
+        description: "CNC, Sales · Kuala Lumpur MY",
+      },
+    },
+  },
+  {
+    workspaceSlug: DEFAULT_TEMPLATE_WORKSPACE_SLUG,
+    seedLastRunOffsetMs: 900_000,
+    profile: {
+      id: "dongguan-lathe-sales",
+      name: "东莞车床销售招聘",
+      description: "东莞地区车床销售工程师岗位自动化招聘",
+      createdAt: "2026-02-06",
+      updatedAt: "2026-02-06",
+      status: "active",
+      location: "东莞",
+      keywords: ["车床", "销售", "CNC", "数控"],
+      jobDescription: "lathe-sales",
+      filterPreset: "sales-mid",
+      filters: {
+        minExperience: 2,
+        maxExperience: null,
+        education: ["中专", "大专", "本科"],
+        salaryRange: {
+          min: 8000,
+          max: 20000,
+          currency: "CNY",
+          period: "month",
+        },
+        locations: ["东莞", "广州", "深圳"],
+      },
+      schedule: {
+        enabled: true,
+        cron: "0 9 * * 1-5",
+        timezone: "Asia/Hong_Kong",
+        maxCandidates: 200,
+        notifyOnlyOnNew: true,
+      },
+      sources: [
+        {
+          type: "job5156",
+          enabled: true,
+          priority: 1,
+        },
+        {
+          type: "manual_upload",
+          enabled: true,
+          priority: 2,
+        },
+      ],
+      session: {
+        scope: "per-position",
+        resetTriggers: ["/archive", "/close-position"],
+        retention: {
+          mode: "until-closed",
+          archiveAfterDays: 90,
+        },
+      },
+    },
+  },
+];
+
+export function normalizeTemplateWorkspaceSlug(workspaceSlug?: string): string {
+  const normalized = workspaceSlug?.trim();
+  return normalized && normalized.length > 0 ? normalized : DEFAULT_TEMPLATE_WORKSPACE_SLUG;
+}
+
+export function buildSearchProfileCriteria(profile: SharedSearchProfileTemplate["profile"]) {
+  const filterLocations = Array.isArray(profile.filters?.locations)
+    ? profile.filters.locations.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    : [];
+  const locations = Array.from(new Set([profile.location, ...filterLocations].filter((item) => item && item.trim().length > 0)));
+
+  return {
+    keywords: [...profile.keywords],
+    locations,
+  };
+}
+
+export function getWorkspaceSearchProfileTemplates(workspaceSlug?: string): SharedSearchProfileTemplate[] {
+  const normalizedWorkspaceSlug = normalizeTemplateWorkspaceSlug(workspaceSlug);
+  return SEARCH_PROFILE_TEMPLATES.filter((template) => (
+    normalizeTemplateWorkspaceSlug(template.workspaceSlug) === normalizedWorkspaceSlug
+  ));
+}
+
+export function findWorkspaceSearchProfileTemplate(
+  id: string,
+  workspaceSlug?: string,
+): SharedSearchProfileTemplate | null {
+  const normalizedId = id.trim().toLowerCase();
+  return getWorkspaceSearchProfileTemplates(workspaceSlug).find((template) => (
+    template.profile.id.trim().toLowerCase() === normalizedId
+  )) ?? null;
+}

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -3,59 +3,111 @@ from __future__ import annotations
 from apps.worker.profile_loader import ProfileLoader
 
 
-def test_load_profiles_uses_schedule_max_candidates(tmp_path) -> None:
-    config_dir = tmp_path / "profiles"
-    config_dir.mkdir()
-    (config_dir / "profile.yaml").write_text(
-        """
-id: summary-ready
-name: Summary Ready
-location: 东莞
-keywords:
-  - CNC
-schedule:
-  enabled: true
-  cron: "0 9 * * 1-5"
-  timezone: Asia/Hong_Kong
-  maxCandidates: 120
-  notifyOnlyOnNew: true
-""".strip(),
-        encoding="utf-8",
-    )
+def test_load_profiles_uses_runtime_api_payload(monkeypatch) -> None:
+    seen_url: list[str] = []
 
-    profiles = ProfileLoader(config_dir=str(config_dir)).load_profiles()
+    def fake_request_json(url: str):
+        seen_url.append(url)
+        return {
+            "success": True,
+            "items": [
+                {
+                    "workspaceSlug": "dev",
+                    "profileId": "job5156-cn-cnc-sales",
+                    "name": "China Job5156 CNC Sales",
+                    "cron": "0 9 * * 1-5",
+                    "profile": {
+                        "id": "job5156-cn-cnc-sales",
+                        "name": "China Job5156 CNC Sales",
+                        "location": "China",
+                        "keywords": ["CNC", "销售"],
+                        "schedule": {
+                            "enabled": True,
+                            "cron": "0 9 * * 1-5",
+                            "timezone": "Asia/Shanghai",
+                            "maxCandidates": 120,
+                            "notifyOnlyOnNew": True,
+                        },
+                    },
+                },
+            ],
+        }
 
+    monkeypatch.setattr("apps.worker.profile_loader._request_json", fake_request_json)
+
+    profiles = ProfileLoader(api_base_url="http://worker-api.test").load_profiles()
+
+    assert seen_url == ["http://worker-api.test/api/search-profiles/runtime"]
     assert len(profiles) == 1
-    assert profiles[0]["limit"] == 120
+    assert profiles[0]["id"] == "job5156-cn-cnc-sales"
+    assert profiles[0]["workspaceSlug"] == "dev"
+    assert profiles[0]["cron"] == "0 9 * * 1-5"
     assert profiles[0]["schedule"] == {
         "enabled": True,
         "cron": "0 9 * * 1-5",
-        "timezone": "Asia/Hong_Kong",
+        "timezone": "Asia/Shanghai",
         "maxCandidates": 120,
         "notifyOnlyOnNew": True,
     }
 
 
-def test_load_profiles_keeps_legacy_schedule_limit_fallback(tmp_path) -> None:
-    config_dir = tmp_path / "profiles"
-    config_dir.mkdir()
-    (config_dir / "legacy.yaml").write_text(
-        """
-id: legacy-limit
-name: Legacy Limit
-location: 东莞
-keywords:
-  - 销售
-schedule:
-  enabled: true
-  cron: "0 8 * * 1-5"
-  limit: 80
-""".strip(),
-        encoding="utf-8",
+def test_load_profiles_ignores_malformed_runtime_items(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "apps.worker.profile_loader._request_json",
+        lambda url: {
+            "success": True,
+            "items": [
+                {
+                    "workspaceSlug": "dev",
+                    "profileId": "missing-location",
+                    "name": "Missing Location",
+                    "cron": "0 9 * * 1-5",
+                    "profile": {
+                        "id": "missing-location",
+                        "keywords": ["CNC"],
+                        "schedule": {"enabled": True, "cron": "0 9 * * 1-5"},
+                    },
+                },
+                {
+                    "workspaceSlug": "dev",
+                    "profileId": "valid-profile",
+                    "name": "Valid Profile",
+                    "cron": "*/30 * * * *",
+                    "profile": {
+                        "id": "valid-profile",
+                        "name": "Valid Profile",
+                        "location": "东莞",
+                        "keywords": ["招聘", "简历"],
+                        "schedule": {"enabled": True, "cron": "*/30 * * * *"},
+                    },
+                },
+                {
+                    "workspaceSlug": "",
+                    "profileId": "missing-workspace",
+                    "name": "Missing Workspace",
+                    "cron": "0 8 * * 1-5",
+                    "profile": {
+                        "id": "missing-workspace",
+                        "name": "Missing Workspace",
+                        "location": "东莞",
+                        "keywords": ["销售"],
+                        "schedule": {"enabled": True, "cron": "0 8 * * 1-5"},
+                    },
+                },
+            ],
+        },
     )
 
-    profiles = ProfileLoader(config_dir=str(config_dir)).load_profiles()
+    profiles = ProfileLoader(api_base_url="http://worker-api.test").load_profiles()
 
-    assert len(profiles) == 1
-    assert profiles[0]["limit"] == 80
-    assert profiles[0]["schedule"]["maxCandidates"] == 80
+    assert profiles == [
+        {
+            "id": "valid-profile",
+            "name": "Valid Profile",
+            "location": "东莞",
+            "keywords": ["招聘", "简历"],
+            "schedule": {"enabled": True, "cron": "*/30 * * * *"},
+            "cron": "*/30 * * * *",
+            "workspaceSlug": "dev",
+        },
+    ]

--- a/tests/test_resume_tasks.py
+++ b/tests/test_resume_tasks.py
@@ -262,6 +262,71 @@ def test_list_summary_profiles_runtime_normalizes_payload(monkeypatch) -> None:
     ]
 
 
+def test_worker_scheduler_load_profile_jobs_schedules_runtime_profiles(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    constructed: list[bool] = []
+
+    class FakeLoader:
+        def __init__(self) -> None:
+            constructed.append(True)
+
+        def load_profiles(self) -> list[dict[str, Any]]:
+            return [
+                {
+                    "id": "job5156-cn-cnc-sales",
+                    "cron": "0 9 * * 1-5",
+                    "location": "China",
+                    "keywords": ["CNC", "销售"],
+                    "workspaceSlug": "dev",
+                    "schedule": {"enabled": True, "cron": "0 9 * * 1-5"},
+                },
+            ]
+
+    monkeypatch.setattr(worker_scheduler, "ProfileLoader", FakeLoader)
+
+    scheduler = worker_scheduler.WorkerScheduler(timezone="UTC")
+    monkeypatch.setattr(scheduler, "add_custom_job", lambda **kwargs: calls.append(kwargs))
+
+    scheduler.load_profile_jobs()
+
+    assert constructed == [True]
+    assert calls == [
+        {
+            "func": worker_scheduler.run_resume_crawl_task,
+            "job_id": "crawl_profile_job5156-cn-cnc-sales",
+            "cron_expression": "0 9 * * 1-5",
+            "profile": {
+                "id": "job5156-cn-cnc-sales",
+                "cron": "0 9 * * 1-5",
+                "location": "China",
+                "keywords": ["CNC", "销售"],
+                "workspaceSlug": "dev",
+                "schedule": {"enabled": True, "cron": "0 9 * * 1-5"},
+            },
+        },
+    ]
+
+
+def test_worker_scheduler_load_profile_jobs_logs_and_skips_loader_failures(monkeypatch, caplog) -> None:
+    class BrokenLoader:
+        def __init__(self) -> None:
+            pass
+
+        def load_profiles(self) -> list[dict[str, Any]]:
+            raise RuntimeError("runtime unavailable")
+
+    monkeypatch.setattr(worker_scheduler, "ProfileLoader", BrokenLoader)
+
+    scheduler = worker_scheduler.WorkerScheduler(timezone="UTC")
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(scheduler, "add_custom_job", lambda **kwargs: calls.append(kwargs))
+
+    scheduler.load_profile_jobs()
+
+    assert calls == []
+    assert "Failed to load profile jobs: runtime unavailable" in caplog.text
+
+
 def test_add_workspace_summary_job_requires_cron(monkeypatch) -> None:
     calls: list[dict[str, Any]] = []
 


### PR DESCRIPTION
## Summary
- unify Search Profiles into one canonical `/system/profiles` surface and canonicalize legacy `?view=quick-starts` URLs back to that page
- materialize seeded quick-start templates into workspace-managed editable profiles so the seeded rows can be edited and deleted from the UI
- switch worker scheduled profile loading to the runtime API and remove stale YAML-backed reload/origin/read-only semantics
- add API, worker, and web coverage for the unified profile flow

## Validation
- `npm test -- apps/api/src/routes/search-profiles.test.ts`
- `npm test -- apps/api/src/services/search-profile-service.test.ts`
- `npm --workspace @trends/web test -- src/pages/SearchProfilesPage.test.tsx`
- `npm --workspace @trends/web test -- src/pages/DebugConfig.test.tsx`
- `uv run pytest tests/test_profile_loader.py tests/test_resume_tasks.py`
- `make check`