### PR TITLE
feat(search-profiles): add QuickStart toggle and collection mode

### DIFF
--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -18,6 +18,7 @@ import {
 import { config } from "./config.js";
 
 const JOB5156_HOST = "hr.job5156.com";
+const EHIRE_51JOB_HOST = "ehire.51job.com";
 const RESUME_IMPORT_CONVEX_BATCH_SIZE = 200;
 
 type ResumeImportMetadata = z.infer<typeof ResumeImportMetadataSchema>;
@@ -174,6 +175,9 @@ function resolveResumeSource(metadata: ResumeImportMetadata): string {
   const sourceKey = normalizeSourceHost(metadata.sourceKey);
   if (sourceKey === "job5156") {
     return JOB5156_HOST;
+  }
+  if (sourceKey === "51job") {
+    return EHIRE_51JOB_HOST;
   }
 
   try {

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -297,6 +297,9 @@ function inferResumeSource(metadata?: ResumeMetadata): string | undefined {
   if (sourceKey === "seek") {
     return "seek";
   }
+  if (sourceKey === "51job") {
+    return "ehire.51job.com";
+  }
 
   return undefined;
 }

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -49,10 +49,12 @@ const AUTO_LOCATION_PARAM = "location";
 const AUTO_KEYWORD_MODE_PARAM = "tr_kw_mode";
 const SAMPLE_NAME_PARAM = "tr_sample_name";
 const JOB5156_HOST = "hr.job5156.com";
+const EHIRE_51JOB_HOST = "ehire.51job.com";
 const SEEK_HOST_SUFFIX = ".employer.seek.com";
 const JOB5156_PROFILE_URL_PREFIX = `https://${JOB5156_HOST}/resume/view/`;
 const SOURCE_KEYS = {
   JOB5156: "job5156",
+  JOB51: "51job",
   SEEK: "seek",
   UNKNOWN: "unknown",
 };
@@ -75,6 +77,7 @@ const LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY = "latestAutoSyncSummaries";
 
 const apiSnapshot = {
   searchRows: null,
+  job51SearchRows: null,
   attachInfo: null,
   chatInfo: null,
   insightInfo: null,
@@ -380,6 +383,7 @@ function buildExportMetadata(resumes) {
 function getCurrentSourceKey() {
   const hostname = window.location.hostname.toLowerCase();
   if (hostname === JOB5156_HOST) return SOURCE_KEYS.JOB5156;
+  if (hostname === EHIRE_51JOB_HOST) return SOURCE_KEYS.JOB51;
   if (hostname.endsWith(SEEK_HOST_SUFFIX)) return SOURCE_KEYS.SEEK;
   return SOURCE_KEYS.UNKNOWN;
 }
@@ -394,6 +398,9 @@ function isJob5156DetailPage() {
 function getApiSnapshotCount() {
   if (Array.isArray(apiSnapshot.searchRows)) {
     return apiSnapshot.searchRows.length;
+  }
+  if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+    return Array.isArray(apiSnapshot.job51SearchRows) ? apiSnapshot.job51SearchRows.length : 0;
   }
   if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
     return getSeekSnapshotCount();
@@ -512,6 +519,9 @@ function isJob5156DetailRootReady(root, pathname) {
 }
 
 function isExtractionReady() {
+  if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+    return Array.isArray(apiSnapshot.job51SearchRows) && apiSnapshot.job51SearchRows.length > 0;
+  }
   if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
     return isSeekSnapshotReady();
   }
@@ -2176,6 +2186,30 @@ function updateApiSnapshot(message) {
     }
     return;
   }
+  if (kind === "job51search") {
+    const rows =
+      payload?.data?.list ||
+      payload?.data?.items ||
+      payload?.data?.rows ||
+      payload?.list ||
+      payload?.items ||
+      payload?.rows ||
+      (Array.isArray(payload?.data) ? payload.data : null) ||
+      (Array.isArray(payload) ? payload : null);
+    if (Array.isArray(rows)) {
+      apiSnapshot.job51SearchRows = rows;
+      apiSnapshot.lastSearchAt = apiSnapshot.lastUpdatedAt;
+      try {
+        document.documentElement.setAttribute(
+          "data-tr-api-rows",
+          String(getApiSnapshotCount()),
+        );
+      } catch {
+        // ignore
+      }
+    }
+    return;
+  }
   if (kind === "attach") {
     apiSnapshot.attachInfo = payload?.data?.attachResumeInfo || null;
     return;
@@ -2625,7 +2659,49 @@ function extractSeekResumes() {
   });
 }
 
+function extract51JobResumes() {
+  if (!Array.isArray(apiSnapshot.job51SearchRows)) return [];
+  return apiSnapshot.job51SearchRows.map((row, index) => {
+    const str = (v) => (v != null ? String(v) : "");
+    const name = str(row?.name || row?.userName || row?.candidateName || row?.fullName);
+    const age = str(row?.age || row?.realAge);
+    const experience = str(row?.workYear || row?.workYears || row?.experienceYears || row?.experience);
+    const education = str(row?.education || row?.educationLevel || row?.degree || row?.eduLevel);
+    const location = str(row?.location || row?.workCity || row?.city || row?.workLocation);
+    const jobIntention = str(row?.jobIntention || row?.desiredJob || row?.expectedPosition || row?.targetJob || row?.searchJob);
+    const expectedSalary = str(row?.expectedSalary || row?.desiredSalary || row?.expectSalary || row?.salaryExpect);
+    const activityStatus = str(row?.activityStatus || row?.lastLoginTime || row?.activeTime || row?.refreshTime);
+    const selfIntro = str(row?.selfIntro || row?.advantage || row?.profile || row?.highlight);
+    const resumeId = str(row?.resumeId || row?.resumeNo || row?.resumekey || row?.id);
+    const perUserId = str(row?.perUserId || row?.userId || row?.candidateId || row?.memberId);
+    const externalId = resumeId || perUserId;
+    const profileUrl = str(row?.profileUrl || row?.resumeUrl)
+      || (resumeId ? `https://${EHIRE_51JOB_HOST}/resume/${resumeId}` : "");
+    return {
+      name,
+      age,
+      experience,
+      education,
+      location,
+      jobIntention,
+      expectedSalary,
+      activityStatus,
+      selfIntro,
+      resumeId: resumeId || undefined,
+      perUserId: perUserId || undefined,
+      externalId: externalId || undefined,
+      profileUrl,
+      pageIndex: index + 1,
+      rawData: row,
+      extractedAt: new Date().toISOString(),
+    };
+  });
+}
+
 function extractResumes() {
+  if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+    return extract51JobResumes();
+  }
   if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
     if (isSeekProfileMode()) {
       if (hasSeekProfileSnapshot()) {

--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -3,7 +3,7 @@
     "name": "智通直聘 Resume Collector",
     "version": "1.1.1",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzXCTw+8W8khXUpXqILIfM0F25TlMaVr6f879wMLp71zoe+LoiZjzmfK3h41TuepIu41qzGUMLt1K1ap6YUCrg78Iq4UgWsJ/Bg43JZ0nlCig6pwE6Xihsg+oVjmKSKB2YkjjWnZRWv1Qx9Q0Jpvtv0OHGCldxfd5beB/BaKDpZalXVPoU++9he1SeKN9rZO/I8LZV57kJ539r938+LDPb+69LTQFDMpg+uFOUUlh8XaA2JAO+IySqDn32QTXFuGxwP4EcSKJibu7qo4E2SqyWMKvLh4RVZDvfLDqXNq6jD/y+zY3aS9FeWfn3uFS5QPwRjlv9JyNpSKgY63KMX+oRQIDAQAB",
-    "description": "Extract resume data from Job5156 and Seek for the Trends Resume Screening System",
+    "description": "Extract resume data from Job5156, Seek, and 51job eHire for the Trends Resume Screening System",
     "permissions": [
         "activeTab",
         "scripting",
@@ -14,7 +14,8 @@
     "host_permissions": [
         "*://hr.job5156.com/*",
         "*://hk.employer.seek.com/*",
-        "*://my.employer.seek.com/*"
+        "*://my.employer.seek.com/*",
+        "*://ehire.51job.com/*"
     ],
     "background": {
         "service_worker": "background.js"
@@ -38,7 +39,8 @@
                 "*://hk.employer.seek.com/candidates/recommended*",
                 "*://my.employer.seek.com/candidates/recommended*",
                 "*://hk.employer.seek.com/talentsearch/profile*",
-                "*://my.employer.seek.com/talentsearch/profile*"
+                "*://my.employer.seek.com/talentsearch/profile*",
+                "*://ehire.51job.com/Revision/talent/search*"
             ],
             "js": [
                 "page-hook.js"
@@ -53,7 +55,8 @@
                 "*://hk.employer.seek.com/candidates/recommended*",
                 "*://my.employer.seek.com/candidates/recommended*",
                 "*://hk.employer.seek.com/talentsearch/profile*",
-                "*://my.employer.seek.com/talentsearch/profile*"
+                "*://my.employer.seek.com/talentsearch/profile*",
+                "*://ehire.51job.com/Revision/talent/search*"
             ],
             "js": [
                 "seek-auto-sync-window.js",
@@ -73,7 +76,8 @@
             "matches": [
                 "*://hr.job5156.com/*",
                 "*://hk.employer.seek.com/*",
-                "*://my.employer.seek.com/*"
+                "*://my.employer.seek.com/*",
+                "*://ehire.51job.com/*"
             ]
         }
     ],

--- a/apps/browser-extension/page-hook.js
+++ b/apps/browser-extension/page-hook.js
@@ -55,6 +55,25 @@
       return { kind: "insight", sourceKey: "job5156" };
     if (url.includes("/api/search/resume/v2"))
       return { kind: "search", sourceKey: "job5156" };
+    if (url.includes("ehire.51job.com")) {
+      try {
+        const pathname = new URL(url).pathname.toLowerCase();
+        if (
+          pathname.includes("/talent/search") ||
+          pathname.includes("/talent/list") ||
+          pathname.includes("/resume/search") ||
+          pathname.includes("/resume/list") ||
+          pathname.includes("/candidate/search") ||
+          pathname.includes("/candidate/list") ||
+          pathname.includes("/search/talent") ||
+          pathname.includes("/search/resume")
+        ) {
+          return { kind: "job51search", sourceKey: "51job" };
+        }
+      } catch {
+        // ignore
+      }
+    }
     if (url.includes("/graphql")) {
       const recommendedOperation = findGraphqlOperation(
         requestBody,
@@ -179,6 +198,7 @@
     const hostname = window.location.hostname.toLowerCase();
     if (hostname === "hr.job5156.com") return "job5156";
     if (hostname.endsWith(".employer.seek.com")) return "seek";
+    if (hostname === "ehire.51job.com") return "51job";
     return "unknown";
   };
   const parsePositiveInt = (value) => {
@@ -348,7 +368,9 @@
     const cardCount =
       sourceKey === "seek"
         ? Math.max(apiSnapshotCount, getSeekCardCount())
-        : document.querySelectorAll(".list-content__li_part").length;
+        : sourceKey === "51job"
+          ? apiSnapshotCount
+          : document.querySelectorAll(".list-content__li_part").length;
 
     return {
       extensionLoaded: readAttr("data-tr-resume-hook") === "true",
@@ -356,7 +378,7 @@
       sourceKey,
       apiSnapshotCount,
       domReady:
-        sourceKey === "seek"
+        sourceKey === "seek" || sourceKey === "51job"
           ? apiSnapshotCount > 0
           : document.querySelector(
               ".el-checkbox-group.resume-search-item-list-content-block",
@@ -417,7 +439,8 @@
     const originalFetch = trWindow.fetch;
     trWindow.fetch = function (...args) {
       const requestUrl = normalizeUrl(args[0]);
-      if (!isGraphqlRequest(requestUrl)) {
+      const is51jobFetch = requestUrl.includes("ehire.51job.com");
+      if (!isGraphqlRequest(requestUrl) && !is51jobFetch) {
         return originalFetch.apply(this, args);
       }
 

--- a/apps/web/src/components/CollectResumesButton.tsx
+++ b/apps/web/src/components/CollectResumesButton.tsx
@@ -116,7 +116,7 @@ export function CollectResumesButton({
             exactUrl: seekSource?.exactUrl,
           }
         : {
-            type: SEARCH_PROFILE_SOURCE_TYPES.job5156,
+            type: selectedSourceType,
           },
       location: normalizedLocation,
       keywords: normalizedKeywords,
@@ -172,6 +172,10 @@ export function CollectResumesButton({
       label: t('quickStart.collectSourceJob5156', 'China · Job5156'),
     },
     {
+      value: SEARCH_PROFILE_SOURCE_TYPES.job51,
+      label: t('quickStart.collectSourceJob51', 'China · 51job eHire'),
+    },
+    {
       value: SEARCH_PROFILE_SOURCE_TYPES.seek,
       label: t('quickStart.collectSourceSeek', 'Malaysia · SEEK'),
     },
@@ -192,9 +196,12 @@ export function CollectResumesButton({
   }
 
   const handleSourceChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    const nextType = event.target.value === SEARCH_PROFILE_SOURCE_TYPES.seek
+    const rawValue = event.target.value
+    const nextType = rawValue === SEARCH_PROFILE_SOURCE_TYPES.seek
       ? SEARCH_PROFILE_SOURCE_TYPES.seek
-      : SEARCH_PROFILE_SOURCE_TYPES.job5156
+      : rawValue === SEARCH_PROFILE_SOURCE_TYPES.job51
+        ? SEARCH_PROFILE_SOURCE_TYPES.job51
+        : SEARCH_PROFILE_SOURCE_TYPES.job5156
 
     if (nextType === SEARCH_PROFILE_SOURCE_TYPES.seek) {
       onCollectionSourceChange?.({
@@ -205,7 +212,7 @@ export function CollectResumesButton({
     }
 
     onCollectionSourceChange?.({
-      type: SEARCH_PROFILE_SOURCE_TYPES.job5156,
+      type: nextType,
     })
   }
 

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -93,6 +93,8 @@ type ProfileFormState = {
 type SourceFormState = {
     job5156Enabled: boolean
     job5156Priority: string
+    job51Enabled: boolean
+    job51Priority: string
     seekEnabled: boolean
     seekPriority: string
     seekJobUrl: string
@@ -114,6 +116,8 @@ const DEFAULT_FORM: ProfileFormState = {
 const DEFAULT_SOURCES_FORM: SourceFormState = {
     job5156Enabled: true,
     job5156Priority: '1',
+    job51Enabled: false,
+    job51Priority: '3',
     seekEnabled: false,
     seekPriority: '2',
     seekJobUrl: '',
@@ -186,11 +190,14 @@ function toSourcesFormState(sources: SearchProfileSource[] | undefined): SourceF
     }
 
     const job5156Source = sources.find((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.job5156)
+    const job51Source = sources.find((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.job51)
     const seekSource = sources.find((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.seek)
 
     return {
         job5156Enabled: job5156Source?.enabled ?? DEFAULT_SOURCES_FORM.job5156Enabled,
         job5156Priority: normalizeSourcePriority(job5156Source?.priority) || DEFAULT_SOURCES_FORM.job5156Priority,
+        job51Enabled: job51Source?.enabled ?? DEFAULT_SOURCES_FORM.job51Enabled,
+        job51Priority: normalizeSourcePriority(job51Source?.priority) || DEFAULT_SOURCES_FORM.job51Priority,
         seekEnabled: seekSource?.enabled ?? DEFAULT_SOURCES_FORM.seekEnabled,
         seekPriority: normalizeSourcePriority(seekSource?.priority) || DEFAULT_SOURCES_FORM.seekPriority,
         seekJobUrl: seekSource?.jobUrl ?? DEFAULT_SOURCES_FORM.seekJobUrl,
@@ -212,6 +219,7 @@ function splitKnownSources(sources: SearchProfileSource[] | undefined): {
         known: toSourcesFormState(sources),
         additional: sources.filter((source) => (
             source.type !== SEARCH_PROFILE_SOURCE_TYPES.job5156
+            && source.type !== SEARCH_PROFILE_SOURCE_TYPES.job51
             && source.type !== SEARCH_PROFILE_SOURCE_TYPES.seek
         )),
     }
@@ -224,6 +232,12 @@ function buildSourcesPayload(sourceForm: SourceFormState, additionalSources: Sea
         type: SEARCH_PROFILE_SOURCE_TYPES.job5156,
         enabled: sourceForm.job5156Enabled,
         priority: parseOptionalNumber(sourceForm.job5156Priority),
+    })
+
+    sources.push({
+        type: SEARCH_PROFILE_SOURCE_TYPES.job51,
+        enabled: sourceForm.job51Enabled,
+        priority: parseOptionalNumber(sourceForm.job51Priority),
     })
 
     sources.push({
@@ -653,6 +667,38 @@ export function SearchProfileEditorDialog({
                                         onChange={(event) => setSourceForm((previous) => ({
                                             ...previous,
                                             job5156Priority: event.target.value,
+                                        }))}
+                                        className="h-8 w-24"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="rounded-md border p-3">
+                            <div className="flex items-center justify-between gap-3">
+                                <div className="flex items-center gap-2">
+                                    <Checkbox
+                                        id="profile-source-job51"
+                                        checked={sourceForm.job51Enabled}
+                                        onCheckedChange={(checked) => setSourceForm((previous) => ({
+                                            ...previous,
+                                            job51Enabled: checked === true,
+                                        }))}
+                                    />
+                                    <Label htmlFor="profile-source-job51">51job eHire</Label>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <Label htmlFor="profile-source-job51-priority" className="text-sm text-muted-foreground">
+                                        {t('searchProfiles.fields.priority', { defaultValue: 'Priority' })}
+                                    </Label>
+                                    <Input
+                                        id="profile-source-job51-priority"
+                                        type="number"
+                                        min={1}
+                                        value={sourceForm.job51Priority}
+                                        onChange={(event) => setSourceForm((previous) => ({
+                                            ...previous,
+                                            job51Priority: event.target.value,
                                         }))}
                                         className="h-8 w-24"
                                     />

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -13,6 +13,7 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Select } from '@/components/ui/select'
 import {
     SEARCH_PROFILE_SOURCE_TYPES,
     isSeekRecommendedCandidatesUrl,
@@ -50,6 +51,8 @@ export type SearchProfileDetails = {
         maxCandidates?: number
     }
     sources?: SearchProfileSource[]
+    quickStart?: { enabled: boolean; rank?: number; label?: string; description?: string }
+    collectionMode?: 'head' | 'headless'
 }
 
 type ProfileResponse = {
@@ -88,6 +91,8 @@ type ProfileFormState = {
     maxAge: string
     cron: string
     enabled: boolean
+    quickStartEnabled: boolean
+    collectionMode: 'head' | 'headless'
 }
 
 type SourceFormState = {
@@ -111,6 +116,8 @@ const DEFAULT_FORM: ProfileFormState = {
     maxAge: '',
     cron: '0 9 * * 1-5',
     enabled: true,
+    quickStartEnabled: false,
+    collectionMode: 'head',
 }
 
 const DEFAULT_SOURCES_FORM: SourceFormState = {
@@ -262,6 +269,8 @@ function toFormState(profile: SearchProfileDetails): ProfileFormState {
         maxAge: typeof profile.filters?.maxAge === 'number' ? String(profile.filters.maxAge) : '',
         cron: profile.schedule?.cron || '',
         enabled: profile.status === 'active',
+        quickStartEnabled: profile.quickStart?.enabled ?? false,
+        collectionMode: profile.collectionMode ?? 'head',
     }
 }
 
@@ -498,6 +507,8 @@ export function SearchProfileEditorDialog({
                 cron: form.cron.trim() || undefined,
             },
             sources,
+            quickStart: { enabled: form.quickStartEnabled },
+            collectionMode: form.collectionMode,
         }
 
         setSubmitting(true)
@@ -757,6 +768,28 @@ export function SearchProfileEditorDialog({
                                 </div>
                             ) : null}
                         </div>
+                    </div>
+
+                    <div className="grid gap-2">
+                        <Label htmlFor="profile-collection-mode">{t('searchProfiles.fields.collectionMode', { defaultValue: 'Collection Mode' })}</Label>
+                        <Select
+                            id="profile-collection-mode"
+                            value={form.collectionMode}
+                            onChange={(event) => setForm((previous) => ({ ...previous, collectionMode: event.target.value as 'head' | 'headless' }))}
+                            options={[
+                                { value: 'head', label: t('searchProfiles.fields.collectionModeHead', { defaultValue: 'Open tabs (default)' }) },
+                                { value: 'headless', label: t('searchProfiles.fields.collectionModeHeadless', { defaultValue: 'Legacy headless crawler' }) },
+                            ]}
+                        />
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <Checkbox
+                            checked={form.quickStartEnabled}
+                            onCheckedChange={(checked) => setForm((previous) => ({ ...previous, quickStartEnabled: checked === true }))}
+                            id="profile-quickstart"
+                        />
+                        <Label htmlFor="profile-quickstart">{t('searchProfiles.fields.quickStart', { defaultValue: 'Show in QuickStart' })}</Label>
                     </div>
 
                     <div className="flex items-center gap-2">

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -2139,7 +2139,7 @@ export function useResumeListState(loadSearchHistory = false) {
     ))
     // Clear collectUrl when switching to non-Seek sources to prevent stale URL interference
     if (nextSource.type !== 'seek') {
-      setSessionCollectUrl((current) => (current ?? undefined) === current ? current : undefined)
+      setSessionCollectUrl(undefined)
     }
   }, [setSessionCollectUrl, setSessionCollectionSource])
 

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -2137,7 +2137,11 @@ export function useResumeListState(loadSearchHistory = false) {
         ? current
         : nextSource
     ))
-  }, [setSessionCollectionSource])
+    // Clear collectUrl when switching to non-Seek sources to prevent stale URL interference
+    if (nextSource.type !== 'seek') {
+      setSessionCollectUrl((current) => (current ?? undefined) === current ? current : undefined)
+    }
+  }, [setSessionCollectUrl, setSessionCollectionSource])
 
   const handleSaveCurrentSearch = useCallback(async () => {
     const title = buildSearchHistoryTitle(sessionLocation, sessionKeywords, jobDescriptionId)

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -1,6 +1,7 @@
 import { formatKeywordQuery, normalizeKeywordPhrases } from '@trends/shared'
 
 const JOB5156_SEARCH_URL = 'https://hr.job5156.com/search'
+const EHIRE_51JOB_SEARCH_URL = 'https://ehire.51job.com/Revision/talent/search'
 const SEEK_TALENT_SEARCH_URL = 'https://my.employer.seek.com/candidates/recommended'
 const SEEK_HOST_SUFFIX = '.employer.seek.com'
 const SEEK_RECOMMENDED_PATH = '/candidates/recommended'
@@ -16,11 +17,13 @@ const CHINA_ROOT_LOCATION_LABELS = new Set([
 
 export const SEARCH_PROFILE_SOURCE_TYPES = {
   job5156: 'job5156',
+  job51: '51job',
   seek: 'seek',
 } as const
 
 export type CollectionSourceType =
   | typeof SEARCH_PROFILE_SOURCE_TYPES.job5156
+  | typeof SEARCH_PROFILE_SOURCE_TYPES.job51
   | typeof SEARCH_PROFILE_SOURCE_TYPES.seek
 
 export type CollectionSource = {
@@ -74,7 +77,9 @@ function normalizeOptionalPositiveInt(value: number | undefined): number | undef
 }
 
 function isCollectionSourceType(value: string | undefined): value is CollectionSourceType {
-  return value === SEARCH_PROFILE_SOURCE_TYPES.job5156 || value === SEARCH_PROFILE_SOURCE_TYPES.seek
+  return value === SEARCH_PROFILE_SOURCE_TYPES.job5156
+    || value === SEARCH_PROFILE_SOURCE_TYPES.job51
+    || value === SEARCH_PROFILE_SOURCE_TYPES.seek
 }
 
 function compareSourcePriority(left: SearchProfileSource, right: SearchProfileSource): number {
@@ -241,6 +246,10 @@ export function getSearchProfileCollectionSource(
     }) ?? { type: SEARCH_PROFILE_SOURCE_TYPES.seek }
   }
 
+  if (source.type === SEARCH_PROFILE_SOURCE_TYPES.job51) {
+    return { type: SEARCH_PROFILE_SOURCE_TYPES.job51 }
+  }
+
   return { type: SEARCH_PROFILE_SOURCE_TYPES.job5156 }
 }
 
@@ -365,6 +374,52 @@ export function buildJob5156CollectUrl({
   return url.toString()
 }
 
+export function buildJob51CollectUrl({
+  location,
+  keywords,
+  collectLimit,
+  maxPages,
+  minAge,
+  maxAge,
+}: BuildJob5156CollectUrlInput): string | null {
+  const normalizedKeywords = normalizeKeywords(keywords)
+  if (normalizedKeywords.length === 0) {
+    return null
+  }
+
+  const url = new URL(EHIRE_51JOB_SEARCH_URL)
+  const normalizedLocation = location.trim()
+
+  url.searchParams.set('keyword', formatKeywordQuery(normalizedKeywords))
+  if (normalizedLocation.length > 0 && !isChinaRootLocationLabel(normalizedLocation)) {
+    url.searchParams.set('location', normalizedLocation)
+  }
+
+  url.searchParams.set('tr_auto_sync', 'true')
+
+  const normalizedCollectLimit = normalizeOptionalPositiveInt(collectLimit)
+  if (typeof normalizedCollectLimit === 'number') {
+    url.searchParams.set('tr_limit', String(normalizedCollectLimit))
+  }
+
+  const normalizedMaxPages = normalizeOptionalPositiveInt(maxPages)
+  if (typeof normalizedMaxPages === 'number') {
+    url.searchParams.set('tr_max_pages', String(normalizedMaxPages))
+  }
+
+  const normalizedMinAge = normalizeOptionalPositiveInt(minAge)
+  if (typeof normalizedMinAge === 'number') {
+    url.searchParams.set('tr_min_age', String(normalizedMinAge))
+  }
+
+  const normalizedMaxAge = normalizeOptionalPositiveInt(maxAge)
+  if (typeof normalizedMaxAge === 'number') {
+    url.searchParams.set('tr_max_age', String(normalizedMaxAge))
+  }
+
+  return url.toString()
+}
+
 export function buildCollectionLaunchUrl({
   source,
   location,
@@ -377,6 +432,17 @@ export function buildCollectionLaunchUrl({
   if (source.type === SEARCH_PROFILE_SOURCE_TYPES.seek) {
     return buildSeekCollectUrl({
       baseUrl: source.exactUrl,
+      location,
+      keywords,
+      collectLimit,
+      maxPages,
+      minAge,
+      maxAge,
+    })
+  }
+
+  if (source.type === SEARCH_PROFILE_SOURCE_TYPES.job51) {
+    return buildJob51CollectUrl({
       location,
       keywords,
       collectLimit,

--- a/apps/web/src/pages/SearchProfilesPage.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.tsx
@@ -12,9 +12,10 @@ import { PageHeader } from '@/components/PageHeader'
 import { SearchProfileEditorDialog, type SearchProfileDetails } from '@/components/SearchProfileEditorDialog'
 import {
   SEARCH_PROFILE_SOURCE_TYPES,
-  buildSeekCollectUrl,
+  buildCollectionLaunchUrl,
   getActiveSearchProfileSource,
   isSeekRecommendedCandidatesUrl,
+  type CollectionSourceType,
 } from '@/lib/search-profile-sources'
 
 type ListProfilesResponse = {
@@ -303,14 +304,21 @@ export function SearchProfilesPage() {
     }
     const activeSource = getActiveSearchProfileSource(detail.sources)
 
-    if (activeSource?.type === SEARCH_PROFILE_SOURCE_TYPES.seek) {
-      if (!isSeekRecommendedCandidatesUrl(activeSource.jobUrl)) {
-        toast.error(t('searchProfiles.seekJobUrlMissing', { defaultValue: 'Seek Run Now requires an exact Seek recommended candidates URL.' }))
-        return
+    const isHeadMode = !detail.collectionMode || detail.collectionMode === 'head'
+
+    if (isHeadMode && activeSource) {
+      if (activeSource.type === SEARCH_PROFILE_SOURCE_TYPES.seek) {
+        if (!isSeekRecommendedCandidatesUrl(activeSource.jobUrl)) {
+          toast.error(t('searchProfiles.seekJobUrlMissing', { defaultValue: 'Seek Run Now requires an exact Seek recommended candidates URL.' }))
+          return
+        }
       }
 
-      const launchUrl = buildSeekCollectUrl({
-        baseUrl: activeSource.jobUrl,
+      const launchUrl = buildCollectionLaunchUrl({
+        source: {
+          type: activeSource.type as CollectionSourceType,
+          exactUrl: activeSource.jobUrl,
+        },
         location: detail.location,
         keywords: detail.keywords,
         collectLimit: detail.schedule?.maxCandidates ?? DEFAULT_PROFILE_RUN_LIMIT,
@@ -320,12 +328,12 @@ export function SearchProfilesPage() {
       })
 
       if (!launchUrl) {
-        toast.error(t('searchProfiles.seekRunError', { defaultValue: 'Failed to build Seek launch URL.' }))
+        toast.error(t('searchProfiles.buildUrlError', { defaultValue: 'Failed to build collection URL.' }))
         return
       }
 
       window.open(launchUrl, '_blank', 'noopener,noreferrer')
-      toast.success(t('searchProfiles.seekRunSuccess', { defaultValue: 'Opened Seek collection in a new tab' }))
+      toast.success(t('searchProfiles.openTabSuccess', { defaultValue: 'Opened collection in a new tab' }))
       return
     }
 

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -332,7 +332,7 @@ export default defineSchema({
             keywords: v.array(v.string()),
             jobDescriptionId: v.optional(v.string()),
             collectionSource: v.optional(v.object({
-                type: v.union(v.literal("job5156"), v.literal("seek")),
+                type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
                 exactUrl: v.optional(v.string()),
             })),
             collectUrl: v.optional(v.string()),
@@ -353,7 +353,7 @@ export default defineSchema({
         keywords: v.array(v.string()),
         jobDescriptionId: v.optional(v.string()),
         collectionSource: v.optional(v.object({
-            type: v.union(v.literal("job5156"), v.literal("seek")),
+            type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
             exactUrl: v.optional(v.string()),
         })),
         collectUrl: v.optional(v.string()),

--- a/packages/convex/convex/sessions.ts
+++ b/packages/convex/convex/sessions.ts
@@ -4,7 +4,7 @@ import { mutation, query, type MutationCtx } from "./_generated/server";
 export const DEFAULT_WORKSPACE_SLUG = "dev";
 
 type CollectionSource = {
-    type: "job5156" | "seek";
+    type: "job5156" | "51job" | "seek";
     exactUrl?: string;
 };
 
@@ -43,7 +43,7 @@ function normalizeCollectionSource(
     legacyCollectUrl?: string,
 ): CollectionSource | undefined {
     const type = input?.type;
-    if (type === "job5156") {
+    if (type === "job5156" || type === "51job") {
         return { type };
     }
 
@@ -190,7 +190,7 @@ export const saveSession = mutation({
         keywords: v.array(v.string()),
         jobDescriptionId: v.optional(v.string()),
         collectionSource: v.optional(v.object({
-            type: v.union(v.literal("job5156"), v.literal("seek")),
+            type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
             exactUrl: v.optional(v.string()),
         })),
         collectUrl: v.optional(v.string()),
@@ -360,7 +360,7 @@ export const saveSearchHistory = mutation({
         keywords: v.array(v.string()),
         jobDescriptionId: v.optional(v.string()),
         collectionSource: v.optional(v.object({
-            type: v.union(v.literal("job5156"), v.literal("seek")),
+            type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
             exactUrl: v.optional(v.string()),
         })),
         collectUrl: v.optional(v.string()),


### PR DESCRIPTION
## Summary
- Add QuickStart visibility toggle (`quickStart.enabled`) to profile editor
- Add collection mode (`collectionMode: 'head' | 'headless'`) to control Run Now behavior:
  - `head` (default): opens a new tab via `buildCollectionLaunchUrl` for any source (Seek, Job5156, 51job)
  - `headless`: uses existing backend worker dispatch

## Changes
- `SearchProfileEditorDialog.tsx`: Added `quickStart` and `collectionMode` fields to types, form state, defaults, `toFormState()`, save payload, and UI controls
- `SearchProfilesPage.tsx`: Updated `handleRunNow()` to open a tab for any source when in `head` mode; `headless` mode falls back to API dispatch

## Test plan
- [ ] Open a profile in the editor → confirm "Show in QuickStart" checkbox and "Collection mode" select appear
- [ ] Toggle QuickStart on, save → reload page → card shows "quick start" badge
- [ ] Set mode to "Open tabs", save a Job5156 profile → Run Now opens Job5156 collection URL
- [ ] Set mode to "Legacy headless", save → Run Now uses API dispatch (spinner/polling appears)