### PR TITLE
fix(extension): fix 51job eHire resume extraction and API capture

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -2668,34 +2668,75 @@ function extract51JobResumes() {
   if (!Array.isArray(apiSnapshot.job51SearchRows)) return [];
   return apiSnapshot.job51SearchRows.map((row, index) => {
     const str = (v) => (v != null ? String(v) : "");
-    const name = str(row?.name || row?.userName || row?.candidateName || row?.fullName);
-    const age = str(row?.age || row?.realAge);
-    const experience = str(row?.workYear || row?.workYears || row?.experienceYears || row?.experience);
-    const education = str(row?.education || row?.educationLevel || row?.degree || row?.eduLevel);
-    const location = str(row?.location || row?.workCity || row?.city || row?.workLocation);
-    const jobIntention = str(row?.jobIntention || row?.desiredJob || row?.expectedPosition || row?.targetJob || row?.searchJob);
-    const expectedSalary = str(row?.expectedSalary || row?.desiredSalary || row?.expectSalary || row?.salaryExpect);
-    const activityStatus = str(row?.activityStatus || row?.lastLoginTime || row?.activeTime || row?.refreshTime);
-    const selfIntro = str(row?.selfIntro || row?.advantage || row?.profile || row?.highlight);
-    const resumeId = str(row?.resumeId || row?.resumeNo || row?.resumekey || row?.id);
-    const perUserId = str(row?.perUserId || row?.userId || row?.candidateId || row?.memberId);
-    const externalId = resumeId || perUserId;
-    const profileUrl = str(row?.profileUrl || row?.resumeUrl)
-      || (resumeId ? `https://${EHIRE_51JOB_HOST}/resume/${resumeId}` : "");
+    const stripHtml = (v) => str(v).replace(/<[^>]+>/g, "").trim();
+
+    const base = row?.base_info || {};
+    const recentWork = row?.recent_work_info || {};
+    const jobInt = row?.job_intention || {};
+    const resumeKey = str(row?.userid);
+
+    const name = stripHtml(base?.resume_name);
+    const sex = str(base?.sex_value);
+    const age = str(base?.age);
+    const experience = stripHtml(base?.work_year_value);
+    const education = stripHtml(base?.top_degree_value);
+    const location = stripHtml(base?.area_value);
+    const school = stripHtml(base?.top_school_name);
+    const major = stripHtml(base?.top_major_value);
+    const gender = sex;
+    const jobIntention = stripHtml(jobInt?.expect_work_function_value);
+    const expectedSalary = stripHtml(jobInt?.new_expect_salary);
+    const activityStatus = stripHtml(row?.active_type);
+    const recentCompany = stripHtml(recentWork?.recent_company);
+    const recentPosition = stripHtml(recentWork?.recent_position);
+    const resumeSnippet = stripHtml(row?.resume_slicing);
+
+    const workHistory = Array.isArray(row?.work_list)
+      ? row.work_list.map((w) => ({
+          raw: stripHtml(`${w.company_name} ${w.start_time} - ${w.end_time} ${w.job_name}`),
+          companyName: stripHtml(w.company_name),
+          jobTitle: stripHtml(w.job_name),
+          startDate: str(w.start_time),
+          endDate: str(w.end_time),
+          description: stripHtml(w.job_name),
+        }))
+      : [];
+
+    const profileEducation = Array.isArray(row?.education_list)
+      ? row.education_list.map((e) => ({
+          institution: stripHtml(e.school),
+          qualification: stripHtml(e.degree_value),
+          fieldOfStudy: stripHtml(e.major_value),
+          startDate: str(e.start_time),
+          endDate: str(e.end_time),
+        }))
+      : [];
+
+    const profileUrl = resumeKey
+      ? `https://${EHIRE_51JOB_HOST}/Revision/talent/search?userid=${resumeKey}`
+      : "";
+
     return {
       name,
+      gender,
       age,
       experience,
       education,
       location,
+      school,
+      major,
       jobIntention,
       expectedSalary,
       activityStatus,
-      selfIntro,
-      resumeId: resumeId || undefined,
-      perUserId: perUserId || undefined,
-      externalId: externalId || undefined,
+      recentCompany,
+      recentPosition,
+      resumeSnippet,
+      resumeId: resumeKey || undefined,
+      perUserId: undefined,
+      externalId: resumeKey || undefined,
       profileUrl,
+      workHistory,
+      profileEducation,
       pageIndex: index + 1,
       rawData: row,
       extractedAt: new Date().toISOString(),

--- a/apps/browser-extension/page-hook.js
+++ b/apps/browser-extension/page-hook.js
@@ -55,7 +55,6 @@
       return { kind: "insight", sourceKey: "job5156" };
     if (url.includes("/api/search/resume/v2"))
       return { kind: "search", sourceKey: "job5156" };
-<<<<<<< HEAD
     if (url.includes("ehire.51job.com") || url.includes("ehirej.51job.com")) {
       try {
         const pathname = new URL(url).pathname.toLowerCase();
@@ -440,7 +439,6 @@
     const originalFetch = trWindow.fetch;
     trWindow.fetch = function (...args) {
       const requestUrl = normalizeUrl(args[0]);
-<<<<<<< HEAD
       const is51jobFetch = requestUrl.includes("ehire.51job.com") || requestUrl.includes("ehirej.51job.com");
       if (!isGraphqlRequest(requestUrl) && !is51jobFetch) {
         return originalFetch.apply(this, args);


### PR DESCRIPTION
## Summary
- Remove orphaned `<<<<<<< HEAD` conflict markers in `page-hook.js` that broke 51job eHire API capture
- Rewrite `extract51JobResumes()` to use correct nested API response fields:
  - `base_info.resume_name` → `name`, `base_info.age` → `age`, etc.
  - `userid` → `resumeId` (unique per-user identifier for deduplication)
  - `work_list` → structured `workHistory`
  - `education_list` → structured `profileEducation`
  - All HTML tags stripped from resume fields

## Root Cause
Previously, extraction used flat field names (`row.name`, `row.age`) that didn't match the deeply nested 51job API response structure (`row.base_info.resume_name`, `row.base_info.age`). This resulted in empty fields for all resumes, causing all 50 candidates to deduplicate to ~2 entries with identity `"externalId:unknown"`.

## Test Results
- **Before**: 2 resumes submitted per page (deduped to unknown identity)
- **After**: 50/50 resumes captured with full data, unique `userid`-based identities

## Test plan
- [ ] Reload extension on `chrome://extensions`
- [ ] Navigate to 51job eHire search page
- [ ] Trigger search (with `?keyword=` param or click search button)
- [ ] Verify `apiSnapshotCount` = 50 via DevTools: `window.__TR_RESUME_DATA__.status()`
- [ ] Verify extracted resumes have names: `window.__TR_RESUME_DATA__.extract()[0].name` → `"袁先生"`
- [ ] Trigger sync: `window.__TR_RESUME_DATA__.syncToServer()`
- [ ] Verify `submitted: 50` response
- [ ] Verify Convex contains 50 resumes with non-empty fields