### PR TITLE
fix: align API AI fallbacks with Poe-supported defaults

### DIFF
--- a/apps/api/src/routes/ai-summary.test.ts
+++ b/apps/api/src/routes/ai-summary.test.ts
@@ -5,6 +5,8 @@ import aiSummaryRoutes from "./ai-summary";
 import { workspaceMiddleware } from "../middleware/workspace";
 import { aiSummaryService } from "../services/ai-summary-service";
 
+const DEFAULT_TEST_MODEL = "openai/gpt-4o-mini";
+
 const {
   resolveConvexUrlMock,
 } = vi.hoisted(() => ({
@@ -128,7 +130,7 @@ describe("ai summary routes", () => {
 
       return convexSuccess({
         summary: "Cached recruiter summary",
-        model: "anthropic/claude-3-haiku-20240307",
+        model: DEFAULT_TEST_MODEL,
         generatedAt: now - (55 * 60 * 1000),
         expiresAt: now + (5 * 60 * 1000),
         resultSetHash: "result-set-hash",
@@ -149,7 +151,7 @@ describe("ai summary routes", () => {
     expect(await response.json()).toEqual({
       success: true,
       summary: "Cached recruiter summary",
-      model: "anthropic/claude-3-haiku-20240307",
+      model: DEFAULT_TEST_MODEL,
       generatedAt: now - (55 * 60 * 1000),
       shouldRefresh: true,
     })
@@ -163,7 +165,7 @@ describe("ai summary routes", () => {
     vi.spyOn(Date, "now").mockReturnValue(now)
     const generateSummarySpy = vi.spyOn(aiSummaryService, "generateSummary").mockResolvedValue({
       summary: "Generated recruiter summary",
-      model: "anthropic/claude-3-haiku-20240307",
+      model: DEFAULT_TEST_MODEL,
     })
     const calls: Array<{ method: "query" | "mutation"; pathName: string; args: Record<string, unknown> }> = []
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
@@ -195,7 +197,7 @@ describe("ai summary routes", () => {
     expect(await response.json()).toEqual({
       success: true,
       summary: "Generated recruiter summary",
-      model: "anthropic/claude-3-haiku-20240307",
+      model: DEFAULT_TEST_MODEL,
       generatedAt: now,
     })
     expect(generateSummarySpy).toHaveBeenCalledWith({
@@ -234,7 +236,7 @@ describe("ai summary routes", () => {
           resultCount: 2,
           resultSetHash: "result-set-hash",
           summary: "Generated recruiter summary",
-          model: "anthropic/claude-3-haiku-20240307",
+          model: DEFAULT_TEST_MODEL,
           generatedAt: now,
           expiresAt: now + (60 * 60 * 1000),
         },
@@ -254,7 +256,7 @@ describe("ai summary routes", () => {
 
       return convexSuccess({
         summary: "Fallback cached recruiter summary",
-        model: "anthropic/claude-3-haiku-20240307",
+        model: DEFAULT_TEST_MODEL,
         generatedAt: now - (2 * 60 * 60 * 1000),
         expiresAt: now - 1,
         resultSetHash: "older-result-set-hash",
@@ -278,7 +280,7 @@ describe("ai summary routes", () => {
     expect(await response.json()).toEqual({
       success: true,
       summary: "Fallback cached recruiter summary",
-      model: "anthropic/claude-3-haiku-20240307",
+      model: DEFAULT_TEST_MODEL,
       generatedAt: now - (2 * 60 * 60 * 1000),
     })
     expect(fetchSpy).toHaveBeenCalledTimes(1)

--- a/apps/api/src/routes/job-descriptions.test.ts
+++ b/apps/api/src/routes/job-descriptions.test.ts
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import jobDescriptionsRoutes from "./job-descriptions";
 import { workspaceMiddleware } from "../middleware/workspace";
 
+const DEFAULT_TEST_MODEL = "openai/gpt-4o-mini";
+
 const {
   extractKeywordsMock,
 } = vi.hoisted(() => ({
@@ -32,7 +34,7 @@ describe("job description routes", () => {
   it("extracts recruiter keywords from pasted job description text", async () => {
     extractKeywordsMock.mockResolvedValue({
       keywords: ["Machine Tools", "Business Development", "CNC"],
-      model: "anthropic/claude-3-haiku-20240307",
+      model: DEFAULT_TEST_MODEL,
     })
 
     const app = createTestApp()
@@ -54,7 +56,7 @@ describe("job description routes", () => {
     expect(await response.json()).toEqual({
       success: true,
       keywords: ["Machine Tools", "Business Development", "CNC"],
-      model: "anthropic/claude-3-haiku-20240307",
+      model: DEFAULT_TEST_MODEL,
     })
   })
 

--- a/apps/api/src/services/ai-summary-service.test.ts
+++ b/apps/api/src/services/ai-summary-service.test.ts
@@ -133,6 +133,7 @@ Strong overlap around machine tools and CNC sales backgrounds.
     });
 
     const call = callChatCompletionMock.mock.calls[0]?.[0] as { model: string };
+    expect(call.model).toBe("openai/gpt-4o-mini");
     expect(call.model).toContain("/");
     expect(call.model).not.toBe("claude-3-haiku");
     expect(result.model).toBe(call.model);

--- a/apps/api/src/services/ai-summary-service.ts
+++ b/apps/api/src/services/ai-summary-service.ts
@@ -2,7 +2,9 @@ import { loadAIConfig } from "./ai-config.js";
 import { callChatCompletion } from "./ai-chat-client.js";
 import { workspaceConfigService } from "./workspace-config-service.js";
 
-const DEFAULT_AI_SUMMARY_MODEL = process.env.AI_SUMMARY_MODEL || "anthropic/claude-3-haiku-20240307";
+const DEFAULT_AI_SUMMARY_MODEL = process.env.AI_SUMMARY_MODEL
+  || process.env.AI_MODEL
+  || "openai/gpt-4o-mini";
 const FALLBACK_AI_SUMMARY_MODEL = "heuristic/search-summary-fallback";
 
 type SummaryCandidate = {

--- a/apps/api/src/services/jd-keyword-extraction-service.test.ts
+++ b/apps/api/src/services/jd-keyword-extraction-service.test.ts
@@ -94,6 +94,7 @@ describe("JdKeywordExtractionService", () => {
 
     expect(call.temperature).toBe(0);
     expect(call.maxTokens).toBe(400);
+    expect(call.model).toBe("openai/gpt-4o-mini");
     expect(call.messages[0]?.content).toContain("Return JSON only");
     expect(call.messages[1]?.content).toContain("Extract the most useful resume-search keywords");
     expect(call.messages[1]?.content).toContain("Job description:");

--- a/apps/api/src/services/jd-keyword-extraction-service.ts
+++ b/apps/api/src/services/jd-keyword-extraction-service.ts
@@ -3,7 +3,8 @@ import { loadAIConfig } from "./ai-config.js";
 
 const DEFAULT_JD_KEYWORD_EXTRACTION_MODEL = process.env.JD_KEYWORD_EXTRACTION_MODEL
   || process.env.AI_SUMMARY_MODEL
-  || "anthropic/claude-3-haiku-20240307";
+  || process.env.AI_MODEL
+  || "openai/gpt-4o-mini";
 
 const GENERIC_FILLER_KEYWORDS = new Set([
   "communication",

--- a/apps/web/src/components/search/SnippetCard.test.tsx
+++ b/apps/web/src/components/search/SnippetCard.test.tsx
@@ -154,7 +154,9 @@ describe('SnippetCard', () => {
 
     expect(screen.getByText('Unnamed resume')).toBeInTheDocument()
     expect(screen.getByText('Profile overview')).toBeInTheDocument()
-    expect(screen.getByText('Open the card to inspect recent work history and extracted signals.')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Open the card to inspect recent work history and extracted signals.'),
+    ).not.toBeInTheDocument()
     expect(screen.getByText('Automation')).toBeInTheDocument()
     expect(screen.getByText('PLC')).toBeInTheDocument()
     expect(screen.getByText('CNC')).toBeInTheDocument()

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -20,17 +20,9 @@ function getPrimaryHeadline(item: ResumeSearchResultItem): string {
   return item.resume.jobIntention || 'Profile overview'
 }
 
-function getSnippetText(item: ResumeSearchResultItem): string {
-  const latestWorkEntry = item.resume.workHistory?.[0]
-  if (latestWorkEntry?.raw) {
-    return latestWorkEntry.raw
-  }
-
-  return item.resume.selfIntro || 'Open the card to inspect recent work history and extracted signals.'
-}
-
 export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardProps) {
   const analysis = item.analysis ?? item.resume.analysis
+  const snippetText = item.resume.workHistory?.[0]?.raw || item.resume.selfIntro
   const visibleKeywords = (
     item.resume._provenance?.map((entry) => entry.term)
     ?? item.resume.ingestData?.industryTags
@@ -60,9 +52,11 @@ export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardPro
               ) : null}
             </div>
 
-            <p className="line-clamp-2 text-sm leading-6 text-slate-700">
-              {getSnippetText(item)}
-            </p>
+            {snippetText ? (
+              <p className="line-clamp-2 text-sm leading-6 text-slate-700">
+                {snippetText}
+              </p>
+            ) : null}
 
             {item.scoreSource === 'ai' && analysis?.summary ? (
               <p className="line-clamp-2 text-xs leading-5 text-slate-500">
@@ -79,23 +73,28 @@ export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardPro
             </div>
           </div>
 
-          <div className="flex shrink-0 items-center gap-3">
+          <div className="flex w-full shrink-0 flex-wrap items-center gap-3 lg:w-auto lg:justify-end">
             {typeof item.score === 'number' ? (
-              <div className="flex items-center gap-2">
-                <div className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-sm font-semibold text-amber-700">
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <div className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-sm font-semibold whitespace-nowrap text-amber-700">
                   <span className="inline-flex items-center gap-1">
                     <Star className="h-3.5 w-3.5" />
                     {Math.round(item.score)}
                   </span>
                 </div>
                 {item.scoreSource ? (
-                  <Badge variant="outline" className="uppercase">
+                  <Badge variant="outline" className="whitespace-nowrap uppercase">
                     {item.scoreSource === 'ai' ? 'AI' : 'Rule'}
                   </Badge>
                 ) : null}
               </div>
             ) : null}
-            <Button type="button" variant="outline" className="rounded-full" onClick={onToggleExpanded}>
+            <Button
+              type="button"
+              variant="outline"
+              className="shrink-0 rounded-full whitespace-nowrap"
+              onClick={onToggleExpanded}
+            >
               {expanded ? 'Collapse' : 'Expand'}
               {expanded ? <ChevronUp className="ml-2 h-4 w-4" /> : <ChevronDown className="ml-2 h-4 w-4" />}
             </Button>

--- a/apps/web/src/components/search/SnippetCardExpanded.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.tsx
@@ -40,13 +40,13 @@ export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
 
   return (
     <div className="border-t bg-slate-50/70 px-5 py-5">
-      <div className="grid gap-4 lg:grid-cols-[1.3fr,0.9fr]">
-        <div className="space-y-4">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.3fr),minmax(0,0.9fr)]">
+        <div className="min-w-0 space-y-4">
           <div className="space-y-2">
             <div className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Snapshot
             </div>
-            <p className="text-sm leading-6 text-slate-700">
+            <p className="break-words text-sm leading-6 text-slate-700">
               {presentationResume.selfIntro?.trim() || presentationResume.jobIntention?.trim() || 'No summary available for this resume yet.'}
             </p>
           </div>
@@ -58,7 +58,7 @@ export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
             </div>
             <div className="space-y-2">
               {workHistory.length > 0 ? workHistory.map((entry) => (
-                <div key={entry} className="rounded-2xl border bg-white px-3 py-2 text-sm text-slate-700">
+                <div key={entry} className="rounded-2xl border bg-white px-3 py-2 text-sm break-words text-slate-700">
                   {entry}
                 </div>
               )) : (
@@ -70,20 +70,20 @@ export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
           </div>
         </div>
 
-        <div className="space-y-4">
+        <div className="min-w-0 space-y-4">
           <div className="rounded-3xl border bg-white p-4">
-            <div className="mb-3 flex items-center justify-between gap-3">
-              <div className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+              <div className="min-w-0 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
                 {hasAiAnalysis ? 'AI analysis' : 'Score source'}
               </div>
               {typeof item.score === 'number' ? (
-                <Badge variant="outline" className="uppercase">
+                <Badge variant="outline" className="whitespace-nowrap uppercase">
                   {item.scoreSource === 'ai' ? `AI ${Math.round(item.score)}` : `Rule ${Math.round(item.score)}`}
                 </Badge>
               ) : null}
             </div>
             {hasAiAnalysis && analysis ? (
-              <div className="space-y-4 text-sm text-slate-700">
+              <div className="space-y-4 break-words text-sm text-slate-700">
                 <p className="leading-6">{analysis.summary || 'No AI summary available for this resume yet.'}</p>
 
                 {analysis.highlights.length > 0 ? (
@@ -121,10 +121,10 @@ export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
                       {Object.entries(analysis.breakdown).map(([label, value]) => (
                         <div
                           key={label}
-                          className="flex items-center justify-between rounded-2xl border bg-slate-50 px-3 py-2"
+                          className="flex min-w-0 items-center justify-between gap-3 rounded-2xl border bg-slate-50 px-3 py-2"
                         >
-                          <span className="capitalize text-slate-600">{formatBreakdownLabel(label)}</span>
-                          <span className="font-semibold text-slate-900">{value}</span>
+                          <span className="min-w-0 flex-1 break-words capitalize text-slate-600">{formatBreakdownLabel(label)}</span>
+                          <span className="shrink-0 font-semibold text-slate-900">{value}</span>
                         </div>
                       ))}
                     </div>

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -75,6 +75,7 @@ const {
   useConvexResumesMock,
   useMutationMock,
   useQueryMock,
+  useUrlSearchStateMock,
   workspaceMock,
 } = vi.hoisted(() => ({
   blocksByIdentityMock: {} as Record<string, boolean>,
@@ -96,6 +97,7 @@ const {
   useConvexResumesMock: vi.fn(),
   useMutationMock: vi.fn(),
   useQueryMock: vi.fn(),
+  useUrlSearchStateMock: vi.fn(),
   workspaceMock: {
     slug: 'dev',
   },
@@ -111,10 +113,7 @@ vi.mock('@/contexts/WorkspaceContext', () => ({
 }))
 
 vi.mock('@/hooks/useUrlSearchState', () => ({
-  useUrlSearchState: () => ({
-    parsedState: parsedStateMock,
-    syncToUrl: syncToUrlMock,
-  }),
+  useUrlSearchState: (...args: unknown[]) => useUrlSearchStateMock(...args),
 }))
 
 vi.mock('@/hooks/useCandidateStatus', () => ({
@@ -249,6 +248,10 @@ describe('useResumeSearchState', () => {
       statuses: [],
       minScoreOptions: [],
     })
+    useUrlSearchStateMock.mockReturnValue({
+      parsedState: parsedStateMock,
+      syncToUrl: syncToUrlMock,
+    })
 
     useQueryMock.mockImplementation((query) => {
       if (query === 'recent-searches-query') {
@@ -300,11 +303,15 @@ describe('useResumeSearchState', () => {
       createResume(1, {
         primaryRuleScore: 72,
         analysis: {
-          score: 93,
+          score: 95,
           summary: 'Best AI match',
           highlights: [],
           recommendation: 'strong_match',
           promptVersion: CURRENT_PROMPT_VERSION,
+          breakdown: {
+            related_exp: 90,
+            industry_db: 10,
+          },
         },
       }),
       createResume(2, { primaryRuleScore: 91 }),
@@ -413,6 +420,8 @@ describe('useResumeSearchState', () => {
         filters: {
           education: ['Bachelor'],
           status: ['new'],
+          sortBy: 'experience',
+          sortOrder: 'desc',
         },
         createdAt: 1,
         lastOpenedAt: 2,
@@ -539,8 +548,6 @@ describe('useResumeSearchState', () => {
         education: ['Bachelor'],
         status: ['contacted'],
         minMatchScore: 80,
-        sortBy: 'experience',
-        sortOrder: 'desc',
       },
     }))
 
@@ -564,8 +571,6 @@ describe('useResumeSearchState', () => {
         education: ['Bachelor'],
         status: ['contacted'],
         minMatchScore: 80,
-        sortBy: 'experience',
-        sortOrder: 'desc',
       },
     })
 
@@ -642,13 +647,14 @@ describe('useResumeSearchState', () => {
       createResume(1, {
         primaryRuleScore: 88,
         analysis: {
-          score: 91,
+          score: 95,
           summary: 'Strong fit',
           highlights: [],
           recommendation: 'strong_match',
           promptVersion: CURRENT_PROMPT_VERSION,
           breakdown: {
-            industry_db: 55,
+            related_exp: 90,
+            industry_db: 10,
           },
         },
       }),
@@ -676,12 +682,13 @@ describe('useResumeSearchState', () => {
             resumeId: 'resume-1',
             status: 'contacted',
             match: {
-              score: 91,
+              score: 95,
               recommendation: 'strong_match',
               scoreSource: 'ai',
               summary: 'Strong fit',
               breakdown: {
-                industry_db: 55,
+                related_exp: 45,
+                industry_db: 50,
               },
             },
             ruleScore: 88,
@@ -703,7 +710,7 @@ describe('useResumeSearchState', () => {
     expect(toastInfoMock).toHaveBeenCalledWith('Started export for 2 resumes')
   })
 
-  it('dispatches analysis for top visible results without cached analysis', async () => {
+  it('auto-analyzes loaded results after an explicit search trigger', async () => {
     Object.assign(parsedStateMock, createParsedState({
       query: 'machine tools',
       keywords: ['machine tools'],
@@ -711,27 +718,42 @@ describe('useResumeSearchState', () => {
     }))
 
     resumesMock.push(
-      createResume(1, { primaryRuleScore: 88 }),
-      createResume(2, { primaryRuleScore: 79 }),
+      ...Array.from({ length: 12 }, (_, index) =>
+        createResume(index + 1, {
+          primaryRuleScore: 95 - index,
+        }),
+      ),
     )
 
     const { result } = renderHook(() => useResumeSearchState())
 
-    expect(result.current.analysisCandidateCount).toBe(2)
+    expect(result.current.analysisCandidateCount).toBe(12)
     expect(result.current.disableAnalyzeResults).toBe(false)
+    expect(dispatchAnalysisMutationMock).not.toHaveBeenCalled()
 
     await act(async () => {
-      await result.current.analyzeResults()
+      result.current.submitSearch('machine tools')
+      useUrlSearchStateMock.mockReturnValue({
+        parsedState: createParsedState({
+          query: 'machine tools',
+          keywords: ['machine', 'tools'],
+          location: 'China',
+        }),
+        syncToUrl: syncToUrlMock,
+      })
+      await Promise.resolve()
     })
 
+    expect(dispatchAnalysisMutationMock).toHaveBeenCalledTimes(1)
+
     expect(dispatchAnalysisMutationMock).toHaveBeenCalledWith({
-      keywords: ['machine tools', 'machine', 'tools'],
+      keywords: ['machine', 'tools'],
       location: 'China',
       promptVersion: CURRENT_PROMPT_VERSION,
-      resumeIds: ['resume-1', 'resume-2'],
+      resumeIds: Array.from({ length: 12 }, (_, index) => `resume-${index + 1}`),
     })
     expect(toastSuccessMock).toHaveBeenCalledWith(
-      'Analyzing top 2 candidates...',
+      'Analyzing loaded 12 resumes...',
     )
   })
 

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -1,4 +1,4 @@
-import { formatKeywordQuery, parseKeywordQuery } from '@trends/shared'
+import { formatKeywordQuery, isSalesRequiredContext, parseKeywordQuery } from '@trends/shared'
 import { useMutation, useQuery } from 'convex/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
@@ -32,6 +32,8 @@ import {
 } from '@/lib/taxonomy'
 import {
   getAnalysisForJob,
+  computeDirectIndustryDb,
+  overrideIndustryDbBreakdown,
   toIndustryDbV2Stats,
   toRecommendation,
 } from '@/lib/resume-scoring'
@@ -56,7 +58,6 @@ import type {
 const INITIAL_RESUME_LIMIT = 200
 const RESUME_PAGE_INCREMENT = 200
 const SESSION_KEY_PREFIX = 'trends.resume.search.sessionKey'
-const ANALYSIS_DISPATCH_COOLDOWN_MS = 2000
 
 type JobDescriptionApiResponse = {
   success: boolean
@@ -271,6 +272,40 @@ function buildUrlState(
         : state.selectedExperienceLevel,
     filters: overrides.filters ?? state.filters,
   }
+}
+
+function clearSortFilters(
+  filters: Partial<ResumeFilters>,
+): Partial<ResumeFilters> {
+  const nextFilters: Partial<ResumeFilters> = { ...filters }
+  delete nextFilters.sortBy
+  delete nextFilters.sortOrder
+  return nextFilters
+}
+
+function buildSearchContextSignature(state: UrlSearchState): string {
+  return JSON.stringify({
+    query: normalizeOptionalString(state.query),
+    location: normalizeOptionalString(state.location),
+    keywords: normalizeStringList(state.keywords),
+    requiredKeywords: normalizeStringList(state.requiredKeywords),
+    jobDescriptionId: normalizeOptionalString(state.jobDescriptionId),
+    selectedTags: normalizeStringList(state.selectedTags),
+    selectedCompanies: normalizeStringList(state.selectedCompanies),
+    selectedExperienceLevel: state.selectedExperienceLevel,
+    filters: {
+      education: normalizeStringList(state.filters.education ?? []),
+      locations: normalizeStringList(state.filters.locations ?? []),
+      maxAge: state.filters.maxAge,
+      maxExperience: state.filters.maxExperience,
+      minAge: state.filters.minAge,
+      minExperience: state.filters.minExperience,
+      minMatchScore: state.filters.minMatchScore,
+      minRoleYears: state.filters.minRoleYears,
+      roleFilterType: normalizeOptionalString(state.filters.roleFilterType),
+      status: normalizeStringList(state.filters.status ?? []),
+    },
+  })
 }
 
 function sortResults(
@@ -512,7 +547,8 @@ export function useResumeSearchState() {
   const [exportFormat, setExportFormat] = useState<ResumeExportFormat>('csv')
   const [exportingResults, setExportingResults] = useState(false)
   const [analyzingResults, setAnalyzingResults] = useState(false)
-  const [lastAnalysisDispatchTime, setLastAnalysisDispatchTime] = useState(0)
+  const [autoAnalyzeSearchNonce, setAutoAnalyzeSearchNonce] = useState(0)
+  const [pendingAutoAnalyzeContextSignature, setPendingAutoAnalyzeContextSignature] = useState('')
   const [resumeLimit, setResumeLimit] = useState(INITIAL_RESUME_LIMIT)
   const saveSearchHistory = useMutation(api.sessions.saveSearchHistory)
   const markSearchHistoryOpened = useMutation(
@@ -564,6 +600,10 @@ export function useResumeSearchState() {
 
   const isLanding = !hasExplicitSearchContext(parsedState)
   const activeQuery = normalizeOptionalString(parsedState.query)
+  const currentSearchContextSignature = useMemo(
+    () => buildSearchContextSignature(parsedState),
+    [parsedState],
+  )
   const currentPromptVersion = useMemo(() => getCurrentResumeAiPromptVersion(), [])
   const analysisKeywords = useMemo(
     () =>
@@ -572,6 +612,11 @@ export function useResumeSearchState() {
         ...parseKeywordQuery(activeQuery ?? '').keywords,
       ]),
     [activeQuery, parsedState.keywords],
+  )
+  const salesRequiredContext = isSalesRequiredContext(
+    formatKeywordQuery(parsedState.keywords),
+    activeQuery,
+    parsedState.jobDescriptionId,
   )
   const backendFilters = useMemo<ConvexResumeFilters>(
     () => ({
@@ -652,21 +697,37 @@ export function useResumeSearchState() {
         parsedState.location,
         currentPromptVersion,
       )
+      const hasBrandHits = (resume.ingestData?.brandHits ?? []).some((hit) => hit.context !== 'employer')
+      const hasCompanyHits = (resume.ingestData?.companyHits?.length ?? 0) > 0
+      const normalizedAnalysis = analysis
+        ? overrideIndustryDbBreakdown(
+          analysis,
+          computeDirectIndustryDb(
+            resume.ingestData?.industryDbV2Raw,
+            hasBrandHits,
+            hasCompanyHits,
+          ),
+          {
+            salesRequired: salesRequiredContext,
+            roleSignals: resume.ingestData?.roleSignals,
+          },
+        )
+        : undefined
       const score = resolveScore(
         resume,
         parsedState.jobDescriptionId,
-        analysis,
+        normalizedAnalysis,
       )
       return {
         key: `${resume.resumeId}`,
         identityKey,
         resume,
         blocked: Boolean(blocksByIdentity[identityKey]),
-        analysis,
+        analysis: normalizedAnalysis,
         score,
         scoreSource:
           typeof score === 'number'
-            ? analysis && analysis.score === score
+            ? normalizedAnalysis && normalizedAnalysis.score === score
               ? 'ai'
               : 'rule'
             : undefined,
@@ -680,6 +741,7 @@ export function useResumeSearchState() {
     currentPromptVersion,
     parsedState.jobDescriptionId,
     parsedState.location,
+    salesRequiredContext,
     resumeQuery.resumes,
     statusByIdentity,
   ])
@@ -712,19 +774,32 @@ export function useResumeSearchState() {
   const hasMore = resumeQuery.hasMore
   const loading = !isLanding && resumeQuery.loading
   const loadingMore = resumeQuery.loadingMore
-  const analysisCandidateLimit =
-    Number(import.meta.env.VITE_ANALYSIS_TOP_N) || 10
   const analysisCandidates = useMemo(
     () =>
-      filteredResults
-        .filter(
-          (item) =>
-            !item.analysis &&
-            typeof item.resume.resumeId === 'string',
-        )
-        .slice(0, analysisCandidateLimit),
-    [analysisCandidateLimit, filteredResults],
+      results
+        .filter((item) => !item.analysis)
+        .sort((left, right) => (right.score ?? -1) - (left.score ?? -1)),
+    [results],
   )
+  const analysisCandidateResumeIds = useMemo(
+    () => analysisCandidates.map((item) => item.resume.resumeId),
+    [analysisCandidates],
+  )
+  const analysisCandidateSignature = useMemo(
+    () =>
+      [...analysisCandidateResumeIds]
+        .sort((left, right) => left.localeCompare(right))
+        .join('|'),
+    [analysisCandidateResumeIds],
+  )
+  const autoAnalyzeSignature = useMemo(() => {
+    if (autoAnalyzeSearchNonce === 0 || analysisCandidateSignature.length === 0) {
+      return ''
+    }
+
+    return `${autoAnalyzeSearchNonce}:${analysisCandidateSignature}`
+  }, [analysisCandidateSignature, autoAnalyzeSearchNonce])
+  const autoAnalyzeDispatchSignatureRef = useRef('')
   const hasActiveAnalysisTask = useMemo(
     () =>
       (analysisTasks ?? []).some(
@@ -734,7 +809,9 @@ export function useResumeSearchState() {
   )
   const disableAnalyzeResults =
     isLanding ||
-    filteredResults.length === 0 ||
+    loading ||
+    results.length === 0 ||
+    analysisCandidateResumeIds.length === 0 ||
     analyzingResults ||
     hasActiveAnalysisTask ||
     (!parsedState.jobDescriptionId && analysisKeywords.length === 0)
@@ -813,20 +890,23 @@ export function useResumeSearchState() {
     ) => {
       const resolvedQuery = normalizeOptionalString(nextQuery ?? queryInput)
       const nextKeywords = parseKeywordQuery(resolvedQuery ?? '').keywords
+      const nextState = buildUrlState(parsedState, {
+        query: resolvedQuery,
+        keywords: nextKeywords,
+        location: options?.location ?? parsedState.location,
+        filters: clearSortFilters(parsedState.filters),
+      })
 
-      syncToUrl(
-        buildUrlState(parsedState, {
-          query: resolvedQuery,
-          keywords: nextKeywords,
-          location: options?.location ?? parsedState.location,
-        }),
-      )
+      syncToUrl(nextState)
+      setPendingAutoAnalyzeContextSignature(buildSearchContextSignature(nextState))
+      setAutoAnalyzeSearchNonce((current) => current + 1)
     },
     [parsedState, queryInput, syncToUrl],
   )
 
   const clearSearch = useCallback(() => {
     setQueryInput('')
+    setPendingAutoAnalyzeContextSignature('')
     syncToUrl(
       buildUrlState(parsedState, {
         query: undefined,
@@ -847,7 +927,7 @@ export function useResumeSearchState() {
 
       const query = formatKeywordQuery(item.keywords)
       setQueryInput(query)
-      syncToUrl({
+      const nextState = {
         query,
         shareSessionId: undefined,
         location: normalizeOptionalString(item.location),
@@ -859,8 +939,14 @@ export function useResumeSearchState() {
         selectedExperienceLevel:
           (item.selectedExperienceLevel as ExperienceLevelFilter | undefined) ??
           undefined,
-        filters: item.filters ?? {},
-      })
+        filters: clearSortFilters(item.filters ?? {}),
+      }
+
+      syncToUrl(nextState)
+      setPendingAutoAnalyzeContextSignature(
+        buildSearchContextSignature(nextState),
+      )
+      setAutoAnalyzeSearchNonce((current) => current + 1)
     },
     [markSearchHistoryOpened, slug, syncToUrl],
   )
@@ -1092,7 +1178,8 @@ export function useResumeSearchState() {
   }, [apiBaseUrl, exportFormat, filteredResults])
 
   const analyzeResults = useCallback(async () => {
-    if (filteredResults.length === 0) {
+    if (analysisCandidateResumeIds.length === 0) {
+      toast.info('No new candidates to analyze among loaded results.')
       return
     }
 
@@ -1101,20 +1188,8 @@ export function useResumeSearchState() {
       return
     }
 
-    const now = Date.now()
-    if (now - lastAnalysisDispatchTime < ANALYSIS_DISPATCH_COOLDOWN_MS) {
-      toast.info('Please wait for current analysis to complete.')
-      return
-    }
-
-    if (analysisCandidates.length === 0) {
-      toast.info('No new candidates to analyze among top matches.')
-      return
-    }
-
     setAnalyzingResults(true)
     try {
-      const resumeIds = analysisCandidates.map((item) => item.resume.resumeId)
       const normalizedLocation = normalizeOptionalString(parsedState.location)
       const keywords =
         analysisKeywords.length > 0 ? analysisKeywords : undefined
@@ -1144,11 +1219,12 @@ export function useResumeSearchState() {
         ...(keywords ? { keywords } : {}),
         ...(normalizedLocation ? { location: normalizedLocation } : {}),
         promptVersion: currentPromptVersion,
-        resumeIds,
+        resumeIds: analysisCandidateResumeIds,
       })
 
-      setLastAnalysisDispatchTime(Date.now())
-      toast.success(`Analyzing top ${resumeIds.length} candidates...`)
+      toast.success(
+        `Analyzing loaded ${analysisCandidateResumeIds.length} resumes...`,
+      )
     } catch (error) {
       console.error('Failed to dispatch search analysis task', error)
       toast.error('Failed to start AI analysis. Please try again.')
@@ -1156,15 +1232,44 @@ export function useResumeSearchState() {
       setAnalyzingResults(false)
     }
   }, [
-    analysisCandidates,
+    analysisCandidateResumeIds,
     analysisKeywords,
     currentPromptVersion,
     dispatchAnalysis,
-    filteredResults.length,
     hasActiveAnalysisTask,
-    lastAnalysisDispatchTime,
     parsedState.jobDescriptionId,
     parsedState.location,
+  ])
+
+  useEffect(() => {
+    if (
+      isLanding ||
+      loading ||
+      analyzingResults ||
+      hasActiveAnalysisTask ||
+      pendingAutoAnalyzeContextSignature.length === 0 ||
+      pendingAutoAnalyzeContextSignature !== currentSearchContextSignature ||
+      autoAnalyzeSearchNonce === 0 ||
+      analysisCandidateResumeIds.length === 0 ||
+      autoAnalyzeSignature === '' ||
+      autoAnalyzeDispatchSignatureRef.current === autoAnalyzeSignature
+    ) {
+      return
+    }
+
+    autoAnalyzeDispatchSignatureRef.current = autoAnalyzeSignature
+    void analyzeResults()
+  }, [
+    analyzeResults,
+    analysisCandidateResumeIds.length,
+    autoAnalyzeSearchNonce,
+    autoAnalyzeSignature,
+    analyzingResults,
+    hasActiveAnalysisTask,
+    isLanding,
+    loading,
+    currentSearchContextSignature,
+    pendingAutoAnalyzeContextSignature,
   ])
 
   return {

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -219,6 +219,11 @@ vi.mock('@/components/search/SearchResultsList', () => ({
           Toggle first result
         </button>
       ) : null}
+      {items[1] ? (
+        <button type="button" onClick={() => onToggleExpanded(items[1].key)}>
+          Toggle second result
+        </button>
+      ) : null}
       <button type="button" onClick={onLoadMore}>
         Load more results
       </button>
@@ -532,7 +537,7 @@ describe('ResumeSearchPage', () => {
     const user = userEvent.setup()
     const state = createResumeSearchState({
       activeQuery: 'servo automation',
-      filteredResults: [createResult(1)],
+      filteredResults: [createResult(1), createResult(2)],
       hasMore: true,
       isLanding: false,
       loadingMore: true,
@@ -559,7 +564,7 @@ describe('ResumeSearchPage', () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        'Results List 1 hasMore:true loading:false loadingMore:true expanded:none',
+        'Results List 2 hasMore:true loading:false loadingMore:true expanded:none',
       ),
     ).toBeInTheDocument()
     expect(useAiSearchSummaryMock).toHaveBeenCalledWith(
@@ -575,16 +580,23 @@ describe('ResumeSearchPage', () => {
     )
     expect(
       screen.getByText(
-        'Results List 1 hasMore:true loading:false loadingMore:true expanded:resume-1',
+        'Results List 2 hasMore:true loading:false loadingMore:true expanded:resume-1',
       ),
     ).toBeInTheDocument()
 
     await user.click(
-      screen.getByRole('button', { name: 'Toggle first result' }),
+      screen.getByRole('button', { name: 'Toggle second result' }),
     )
     expect(
       screen.getByText(
-        'Results List 1 hasMore:true loading:false loadingMore:true expanded:none',
+        'Results List 2 hasMore:true loading:false loadingMore:true expanded:resume-2',
+      ),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Apply Header JD' }))
+    expect(
+      screen.getByText(
+        'Results List 2 hasMore:true loading:false loadingMore:true expanded:none',
       ),
     ).toBeInTheDocument()
 
@@ -629,7 +641,7 @@ describe('ResumeSearchPage', () => {
 
     render(<ResumeSearchPage />)
 
-    await user.click(screen.getByRole('button', { name: /Analyze top 2/i }))
+    await user.click(screen.getByRole('button', { name: /Analyze loaded 2/i }))
 
     expect(state.analyzeResults).toHaveBeenCalledTimes(1)
   })

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -1,6 +1,6 @@
 import { formatKeywordQuery, parseKeywordQuery } from '@trends/shared'
 import { RefreshCw } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { AnalysisTaskMonitor } from '@/components/AnalysisTaskMonitor'
 import { AiSummaryPanel } from '@/components/search/AiSummaryPanel'
 import { FacetBadge } from '@/components/search/FacetBadge'
@@ -60,6 +60,9 @@ export function ResumeSearchPage() {
     toggleStatus,
     toggleTag,
   } = useResumeSearchState()
+  const collapseExpandedCards = useCallback(() => {
+    setExpandedIds(new Set())
+  }, [])
   const selectedSummaryTags = useMemo(() => {
     const clusterNamesBySlug = new Map(
       taxonomyClusters.map((cluster) => [
@@ -85,6 +88,7 @@ export function ResumeSearchPage() {
     results: filteredResults,
   })
   const applyExtractedKeywords = (keywords: string[]) => {
+    collapseExpandedCards()
     const query = formatKeywordQuery(keywords)
     setQueryInput(query)
     submitSearch(query)
@@ -94,10 +98,42 @@ export function ResumeSearchPage() {
     keywords: string[]
     location: string
   }) => {
+    collapseExpandedCards()
     const query = formatKeywordQuery(seed.keywords)
     setQueryInput(query)
     submitSearch(query, { location: seed.location })
   }
+
+  const handleApplyRecentSearch = useCallback(
+    async (item: Parameters<typeof applyRecentSearch>[0]) => {
+      collapseExpandedCards()
+      await applyRecentSearch(item)
+    },
+    [applyRecentSearch, collapseExpandedCards],
+  )
+
+  const handleSubmitQuery = useCallback(
+    (value?: string) => {
+      collapseExpandedCards()
+      submitSearch(value)
+    },
+    [collapseExpandedCards, submitSearch],
+  )
+
+  const handleClearQuery = useCallback(() => {
+    collapseExpandedCards()
+    clearSearch()
+  }, [clearSearch, collapseExpandedCards])
+
+  const handleToggleExpanded = useCallback((key: string) => {
+    setExpandedIds((current) => {
+      if (current.has(key)) {
+        return new Set()
+      }
+
+      return new Set([key])
+    })
+  }, [])
 
   const toggleHotKeyword = (keyword: string) => {
     const normalizedKeyword = keyword.trim()
@@ -167,13 +203,13 @@ export function ResumeSearchPage() {
           recentSearchesLoading={searchHistoryLoading}
           quickStarts={quickStartProfiles}
           hotKeywords={hotKeywords}
-          onApplyRecentSearch={applyRecentSearch}
+          onApplyRecentSearch={handleApplyRecentSearch}
           onApplyExtractedKeywords={applyExtractedKeywords}
           onApplyQuickStart={applyQuickStart}
           onToggleHotKeyword={toggleHotKeyword}
           onChangeQuery={setQueryInput}
-          onClearQuery={clearSearch}
-          onSubmitQuery={submitSearch}
+          onClearQuery={handleClearQuery}
+          onSubmitQuery={handleSubmitQuery}
         />
       ) : (
         <>
@@ -188,13 +224,13 @@ export function ResumeSearchPage() {
             queryInput={queryInput}
             recentSearches={recentSearches}
             sortValue={activeSort}
-            onApplyRecentSearch={applyRecentSearch}
+            onApplyRecentSearch={handleApplyRecentSearch}
             onApplyExtractedKeywords={applyExtractedKeywords}
             onChangeQuery={setQueryInput}
-            onClearQuery={clearSearch}
+            onClearQuery={handleClearQuery}
             onExportFormatChange={setExportFormat}
             onExportResults={exportResults}
-            onSubmitQuery={submitSearch}
+            onSubmitQuery={handleSubmitQuery}
             onSortChange={setSort}
           />
 
@@ -221,7 +257,7 @@ export function ResumeSearchPage() {
                     Resume AI analysis
                   </div>
                   <p className="text-sm text-slate-600">
-                    Generate per-resume AI summaries and breakdowns for the top visible matches.
+                    Generate per-resume AI summaries and breakdowns for the loaded search results.
                   </p>
                 </div>
                 <div className="flex items-center gap-2">
@@ -243,8 +279,8 @@ export function ResumeSearchPage() {
                       <>
                         <RefreshCw className="h-4 w-4" />
                         {analysisCandidateCount > 0
-                          ? `Analyze top ${analysisCandidateCount}`
-                          : 'Analyze top results'}
+                          ? `Analyze loaded ${analysisCandidateCount}`
+                          : 'Analyze loaded results'}
                       </>
                     )}
                   </Button>
@@ -265,17 +301,7 @@ export function ResumeSearchPage() {
                 loading={loading}
                 loadingMore={loadingMore}
                 onLoadMore={loadMore}
-                onToggleExpanded={(key) => {
-                  setExpandedIds((current) => {
-                    const next = new Set(current)
-                    if (next.has(key)) {
-                      next.delete(key)
-                    } else {
-                      next.add(key)
-                    }
-                    return next
-                  })
-                }}
+                onToggleExpanded={handleToggleExpanded}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- make API AI summary fallback use `AI_SUMMARY_MODEL`, then `AI_MODEL`, then `openai/gpt-4o-mini`
- make JD keyword extraction fallback use `JD_KEYWORD_EXTRACTION_MODEL`, then `AI_SUMMARY_MODEL`, then `AI_MODEL`, then `openai/gpt-4o-mini`
- update route and service tests to assert the shared OpenAI default instead of the removed Claude fallback

## Verification
- npm run test:api:search-profiles
- bunx vitest run apps/api/src/routes/ai-summary.test.ts apps/api/src/routes/job-descriptions.test.ts apps/api/src/services/ai-summary-service.test.ts apps/api/src/services/jd-keyword-extraction-service.test.ts
- make check