### PR TITLE
fix: refresh resume virtual scroll margin

### DIFF
--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -155,8 +155,18 @@ export function ResumeList() {
     }
 
     updateScrollMargin()
+    const parent = listRef.current?.parentElement
+    let resizeObserver: ResizeObserver | undefined
+    if (parent && typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(updateScrollMargin)
+      resizeObserver.observe(parent)
+    }
+
     window.addEventListener('resize', updateScrollMargin)
-    return () => window.removeEventListener('resize', updateScrollMargin)
+    return () => {
+      window.removeEventListener('resize', updateScrollMargin)
+      resizeObserver?.disconnect()
+    }
   }, [displayedResumes.length, shouldVirtualize])
 
   useEffect(() => {

--- a/apps/web/src/components/search/SearchResultsList.test.tsx
+++ b/apps/web/src/components/search/SearchResultsList.test.tsx
@@ -10,6 +10,7 @@ const disconnectMock = vi.fn()
 const virtualizer = {
   getTotalSize: () => 480,
   getVirtualItems: () => virtualRows,
+  measureElement: vi.fn(),
 }
 
 vi.mock('@tanstack/react-virtual', () => ({
@@ -44,6 +45,11 @@ describe('SearchResultsList', () => {
       disconnect() {
         disconnectMock()
       }
+    })
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
     })
   })
 

--- a/apps/web/src/components/search/SearchResultsList.tsx
+++ b/apps/web/src/components/search/SearchResultsList.tsx
@@ -59,8 +59,18 @@ export function SearchResultsList({
     }
 
     updateScrollMargin()
+    const parent = listRef.current?.parentElement
+    let resizeObserver: ResizeObserver | undefined
+    if (parent && typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(updateScrollMargin)
+      resizeObserver.observe(parent)
+    }
+
     window.addEventListener('resize', updateScrollMargin)
-    return () => window.removeEventListener('resize', updateScrollMargin)
+    return () => {
+      window.removeEventListener('resize', updateScrollMargin)
+      resizeObserver?.disconnect()
+    }
   }, [items.length])
 
   useEffect(() => {
@@ -110,7 +120,9 @@ export function SearchResultsList({
             return (
               <div
                 key={item.key}
-                className="absolute left-0 top-0 w-full"
+                data-index={virtualRow.index}
+                ref={rowVirtualizer.measureElement}
+                className="absolute left-0 top-0 w-full pb-4"
                 style={{ transform: `translateY(${virtualRow.start - scrollMargin}px)` }}
               >
                 <SnippetCard


### PR DESCRIPTION
## Summary
- observe parent layout changes when computing virtual scroll margin in the search results and resume lists
- measure virtualized search result rows so actual card heights are reflected instead of the static estimate alone
- update the search results test setup for ResizeObserver and measureElement

## Verification
- make check-node
- make check
- make dev-web
- loaded http://localhost:5174/dev/resumes?location=China&q=CNC+%E9%94%80%E5%94%AE and confirmed the route renders without console errors