### PR TITLE
feat: add AI mode toggle to resume search

### DIFF
--- a/apps/web/src/components/search/SearchResultsList.test.tsx
+++ b/apps/web/src/components/search/SearchResultsList.test.tsx
@@ -11,10 +11,15 @@ const virtualizer = {
   getTotalSize: () => 480,
   getVirtualItems: () => virtualRows,
   measureElement: vi.fn(),
+  measure: vi.fn(),
 }
+const useWindowVirtualizerMock = vi.fn((options: unknown) => {
+  void options
+  return virtualizer
+})
 
 vi.mock('@tanstack/react-virtual', () => ({
-  useWindowVirtualizer: () => virtualizer,
+  useWindowVirtualizer: (options: unknown) => useWindowVirtualizerMock(options),
 }))
 
 vi.mock('@/components/search/SnippetCard', () => ({
@@ -128,6 +133,43 @@ describe('SearchResultsList', () => {
     expect(screen.queryByText('resume-0:collapsed')).not.toBeInTheDocument()
   })
 
+  it('uses stable item keys and remeasures when virtualized items change', () => {
+    const items = Array.from({ length: 45 }, (_, index) => createItem(index))
+    const { rerender } = render(
+      <SearchResultsList
+        expandedIds={new Set()}
+        hasMore={false}
+        items={items}
+        onLoadMore={vi.fn()}
+        onToggleExpanded={vi.fn()}
+      />
+    )
+
+    expect(useWindowVirtualizerMock).toHaveBeenCalled()
+    const firstCall = useWindowVirtualizerMock.mock.calls[0]
+    expect(firstCall).toBeDefined()
+    const firstCallOptions = firstCall?.[0] as unknown as { getItemKey: (index: number) => string | number }
+    expect(firstCallOptions.getItemKey(1)).toBe('resume-1')
+
+    virtualizer.measure.mockClear()
+    const reversedItems = [...items].reverse()
+    rerender(
+      <SearchResultsList
+        expandedIds={new Set()}
+        hasMore={false}
+        items={reversedItems}
+        onLoadMore={vi.fn()}
+        onToggleExpanded={vi.fn()}
+      />
+    )
+
+    const latestCall = useWindowVirtualizerMock.mock.lastCall
+    expect(latestCall).toBeDefined()
+    const latestCallOptions = latestCall?.[0] as unknown as { getItemKey: (index: number) => string | number }
+    expect(latestCallOptions.getItemKey(0)).toBe('resume-44')
+    expect(virtualizer.measure).toHaveBeenCalledTimes(1)
+  })
+
   it('subtracts the measured scroll margin from virtual row placement', async () => {
     virtualRows = [{ index: 0, start: 120 }]
     vi.spyOn(HTMLElement.prototype, 'offsetTop', 'get').mockReturnValue(80)
@@ -181,6 +223,33 @@ describe('SearchResultsList', () => {
 
     expect(screen.getByText('resume-0:collapsed')).toBeInTheDocument()
     expect(screen.getByText('resume-1:expanded')).toBeInTheDocument()
+    expect(screen.getByText('resume-44:collapsed')).toBeInTheDocument()
+    expect(screen.getByText('End of results')).toBeInTheDocument()
+  })
+
+  it('renders the full non-virtualized list when AI summaries are present', () => {
+    const items = Array.from({ length: 45 }, (_, index) => ({
+      ...createItem(index),
+      analysis: {
+        analyzedAt: Date.now(),
+        highlights: [],
+        recommendation: 'match',
+        score: 90,
+        summary: `AI summary ${index}`,
+      },
+    }))
+
+    render(
+      <SearchResultsList
+        expandedIds={new Set()}
+        hasMore={false}
+        items={items}
+        onLoadMore={vi.fn()}
+        onToggleExpanded={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('resume-0:collapsed')).toBeInTheDocument()
     expect(screen.getByText('resume-44:collapsed')).toBeInTheDocument()
     expect(screen.getByText('End of results')).toBeInTheDocument()
   })

--- a/apps/web/src/components/search/SearchResultsList.tsx
+++ b/apps/web/src/components/search/SearchResultsList.tsx
@@ -44,11 +44,13 @@ export function SearchResultsList({
   const listRef = useRef<HTMLDivElement | null>(null)
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
   const [scrollMargin, setScrollMargin] = useState(0)
-  const shouldVirtualize = items.length > 40 && expandedIds.size === 0
+  const hasAiSummaries = items.some((item) => Boolean((item.analysis ?? item.resume.analysis)?.summary))
+  const shouldVirtualize = items.length > 40 && expandedIds.size === 0 && !hasAiSummaries
 
   const rowVirtualizer = useWindowVirtualizer({
     count: items.length,
     estimateSize: () => 182,
+    getItemKey: (index) => items[index]?.key ?? index,
     overscan: 6,
     scrollMargin,
   })
@@ -72,6 +74,14 @@ export function SearchResultsList({
       resizeObserver?.disconnect()
     }
   }, [items.length])
+
+  useEffect(() => {
+    if (!shouldVirtualize) {
+      return
+    }
+
+    rowVirtualizer.measure()
+  }, [items, rowVirtualizer, shouldVirtualize])
 
   useEffect(() => {
     if (!hasMore || loadingMore) {

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -757,6 +757,138 @@ describe('useResumeSearchState', () => {
     )
   })
 
+  it('tracks AI mode stats and disables manual analysis while original mode is selected', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'machine tools',
+      keywords: ['machine tools'],
+      location: 'Malaysia',
+    }))
+
+    resumesMock.push(
+      createResume(1, {
+        analysis: {
+          score: 92,
+          summary: 'Strong fit',
+          highlights: [],
+          recommendation: 'strong_match',
+          promptVersion: CURRENT_PROMPT_VERSION,
+          breakdown: {
+            related_exp: 50,
+            industry_db: 42,
+          },
+        },
+        ingestData: {
+          industryTags: ['Machine Tools', 'Automation'],
+          synonymHits: [],
+          brandHits: [],
+          companyHits: [],
+          ruleScores: {},
+          experienceLevel: 'senior',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+        },
+      }),
+      createResume(2, {
+        analysis: {
+          score: 78,
+          summary: 'Solid fit',
+          highlights: [],
+          recommendation: 'match',
+          promptVersion: CURRENT_PROMPT_VERSION,
+          breakdown: {
+            related_exp: 40,
+            industry_db: 38,
+          },
+        },
+        ingestData: {
+          industryTags: ['Machine Tools', 'Automation'],
+          synonymHits: [],
+          brandHits: [],
+          companyHits: [],
+          ruleScores: {},
+          experienceLevel: 'senior',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+        },
+      }),
+      createResume(3),
+    )
+
+    const { result } = renderHook(() => useResumeSearchState())
+    const analyzedResults = result.current.results.filter(
+      (item) => typeof item.analysis?.score === 'number',
+    )
+    const expectedAvgScore = Number(
+      (
+        analyzedResults.reduce(
+          (sum, item) => sum + (item.analysis?.score ?? 0),
+          0,
+        ) / analyzedResults.length
+      ).toFixed(2),
+    )
+
+    expect(result.current.aiModeEnabled).toBe(true)
+    expect(result.current.aiModeStats).toEqual({
+      avgScore: expectedAvgScore,
+      matched: analyzedResults.length,
+      processed: result.current.results.length,
+    })
+    expect(result.current.disableAnalyzeResults).toBe(false)
+
+    act(() => {
+      result.current.setAiModeEnabled(false)
+    })
+
+    expect(result.current.aiModeEnabled).toBe(false)
+    expect(result.current.disableAnalyzeResults).toBe(true)
+  })
+
+  it('does not auto-analyze or defer a suppressed run when AI mode is disabled', async () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'machine tools',
+      keywords: ['machine tools'],
+      location: 'China',
+    }))
+
+    resumesMock.push(
+      ...Array.from({ length: 12 }, (_, index) =>
+        createResume(index + 1, {
+          primaryRuleScore: 95 - index,
+        }),
+      ),
+    )
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    act(() => {
+      result.current.setAiModeEnabled(false)
+    })
+
+    await act(async () => {
+      result.current.submitSearch('machine tools')
+      useUrlSearchStateMock.mockReturnValue({
+        parsedState: createParsedState({
+          query: 'machine tools',
+          keywords: ['machine', 'tools'],
+          location: 'China',
+        }),
+        syncToUrl: syncToUrlMock,
+      })
+      await Promise.resolve()
+    })
+
+    expect(dispatchAnalysisMutationMock).not.toHaveBeenCalled()
+    expect(result.current.disableAnalyzeResults).toBe(true)
+
+    await act(async () => {
+      result.current.setAiModeEnabled(true)
+      await Promise.resolve()
+    })
+
+    expect(result.current.disableAnalyzeResults).toBe(false)
+    expect(dispatchAnalysisMutationMock).not.toHaveBeenCalled()
+  })
+
   it('clears only facet filters while preserving the active search context', () => {
     Object.assign(parsedStateMock, createParsedState({
       query: 'machine tools',

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -544,6 +544,7 @@ export function useResumeSearchState() {
   const [queryInput, setQueryInput] = useState(
     () => parsedState.query ?? formatKeywordQuery(parsedState.keywords),
   )
+  const [aiModeEnabled, setAiModeEnabled] = useState(true)
   const [exportFormat, setExportFormat] = useState<ResumeExportFormat>('csv')
   const [exportingResults, setExportingResults] = useState(false)
   const [analyzingResults, setAnalyzingResults] = useState(false)
@@ -800,6 +801,30 @@ export function useResumeSearchState() {
     return `${autoAnalyzeSearchNonce}:${analysisCandidateSignature}`
   }, [analysisCandidateSignature, autoAnalyzeSearchNonce])
   const autoAnalyzeDispatchSignatureRef = useRef('')
+  const aiModeStats = useMemo(() => {
+    const analyzedResults = results.filter(
+      (item) => typeof item.analysis?.score === 'number',
+    )
+
+    if (analyzedResults.length === 0) {
+      return undefined
+    }
+
+    const avgScore = Number(
+      (
+        analyzedResults.reduce(
+          (sum, item) => sum + (item.analysis?.score ?? 0),
+          0,
+        ) / analyzedResults.length
+      ).toFixed(2),
+    )
+
+    return {
+      avgScore,
+      matched: analyzedResults.length,
+      processed: results.length,
+    }
+  }, [results])
   const hasActiveAnalysisTask = useMemo(
     () =>
       (analysisTasks ?? []).some(
@@ -808,6 +833,7 @@ export function useResumeSearchState() {
     [analysisTasks],
   )
   const disableAnalyzeResults =
+    !aiModeEnabled ||
     isLanding ||
     loading ||
     results.length === 0 ||
@@ -881,6 +907,26 @@ export function useResumeSearchState() {
     return () => window.clearTimeout(timer)
   }, [isLanding, parsedState, results, saveSearchHistory, sessionKey, slug])
 
+  useEffect(() => {
+    if (aiModeEnabled) {
+      return
+    }
+
+    setPendingAutoAnalyzeContextSignature('')
+  }, [aiModeEnabled])
+
+  const armAutoAnalyze = useCallback((nextState: UrlSearchState) => {
+    if (!aiModeEnabled) {
+      setPendingAutoAnalyzeContextSignature('')
+      return
+    }
+
+    setPendingAutoAnalyzeContextSignature(
+      buildSearchContextSignature(nextState),
+    )
+    setAutoAnalyzeSearchNonce((current) => current + 1)
+  }, [aiModeEnabled])
+
   const submitSearch = useCallback(
     (
       nextQuery?: string,
@@ -898,10 +944,9 @@ export function useResumeSearchState() {
       })
 
       syncToUrl(nextState)
-      setPendingAutoAnalyzeContextSignature(buildSearchContextSignature(nextState))
-      setAutoAnalyzeSearchNonce((current) => current + 1)
+      armAutoAnalyze(nextState)
     },
-    [parsedState, queryInput, syncToUrl],
+    [armAutoAnalyze, parsedState, queryInput, syncToUrl],
   )
 
   const clearSearch = useCallback(() => {
@@ -943,12 +988,9 @@ export function useResumeSearchState() {
       }
 
       syncToUrl(nextState)
-      setPendingAutoAnalyzeContextSignature(
-        buildSearchContextSignature(nextState),
-      )
-      setAutoAnalyzeSearchNonce((current) => current + 1)
+      armAutoAnalyze(nextState)
     },
-    [markSearchHistoryOpened, slug, syncToUrl],
+    [armAutoAnalyze, markSearchHistoryOpened, slug, syncToUrl],
   )
 
   const setSelectedTags = useCallback(
@@ -1243,6 +1285,7 @@ export function useResumeSearchState() {
 
   useEffect(() => {
     if (
+      !aiModeEnabled ||
       isLanding ||
       loading ||
       analyzingResults ||
@@ -1261,6 +1304,7 @@ export function useResumeSearchState() {
     void analyzeResults()
   }, [
     analyzeResults,
+    aiModeEnabled,
     analysisCandidateResumeIds.length,
     autoAnalyzeSearchNonce,
     autoAnalyzeSignature,
@@ -1277,6 +1321,8 @@ export function useResumeSearchState() {
     activeSort,
     analysisCandidateCount: analysisCandidates.length,
     analyzeResults,
+    aiModeEnabled,
+    aiModeStats,
     applyRecentSearch,
     analyzingResults,
     clearFacetFilters,
@@ -1301,6 +1347,7 @@ export function useResumeSearchState() {
     selectedRawTags,
     searchHistoryLoading: recentSearchHistoryRecords === undefined,
     setMinScoreFilter,
+    setAiModeEnabled,
     setExportFormat,
     setQueryInput,
     setSelectedCompanies,

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -235,6 +235,33 @@ vi.mock('@/components/AnalysisTaskMonitor', () => ({
   AnalysisTaskMonitor: () => <div>Analysis Task Monitor</div>,
 }))
 
+vi.mock('@/components/ModeToggle', () => ({
+  ModeToggle: ({
+    aiStats,
+    mode,
+    onModeChange,
+  }: {
+    aiStats?: { avgScore: number; matched: number; processed?: number }
+    mode: 'ai' | 'original'
+    onModeChange: (mode: 'ai' | 'original') => void
+  }) => (
+    <div>
+      <div>
+        Mode Toggle {mode} stats:
+        {aiStats
+          ? `${aiStats.matched}/${aiStats.processed ?? aiStats.matched}/${aiStats.avgScore}`
+          : 'none'}
+      </div>
+      <button
+        type="button"
+        onClick={() => onModeChange(mode === 'ai' ? 'original' : 'ai')}
+      >
+        Switch Mode
+      </button>
+    </div>
+  ),
+}))
+
 function createResume(index: number): ConvexResumeItem {
   return {
     resumeId: `resume-${index}` as ConvexResumeItem['resumeId'],
@@ -303,6 +330,8 @@ function createResumeSearchState(overrides: Record<string, unknown> = {}) {
     activeSort: 'score',
     analysisCandidateCount: 0,
     analyzeResults: vi.fn(),
+    aiModeEnabled: true,
+    aiModeStats: undefined,
     analyzingResults: false,
     applyRecentSearch: vi.fn(),
     clearFacetFilters: vi.fn(),
@@ -334,6 +363,7 @@ function createResumeSearchState(overrides: Record<string, unknown> = {}) {
     searchHistoryLoading: false,
     selectedClusterTags: [] as string[],
     selectedRawTags: [] as string[],
+    setAiModeEnabled: vi.fn(),
     setExportFormat: vi.fn(),
     setMinScoreFilter: vi.fn(),
     setQueryInput: vi.fn(),
@@ -443,6 +473,11 @@ describe('ResumeSearchPage', () => {
     const user = userEvent.setup()
     const state = createResumeSearchState({
       activeQuery: 'machine tools',
+      aiModeStats: {
+        avgScore: 88.5,
+        matched: 1,
+        processed: 2,
+      },
       filterCount: 3,
       filteredResults: [createResult(1), createResult(2)],
       isLanding: false,
@@ -501,6 +536,7 @@ describe('ResumeSearchPage', () => {
       screen.getByText('AI Summary Summary text generated:123 loading:false'),
     ).toBeInTheDocument()
     expect(screen.getByText('Resume AI analysis')).toBeInTheDocument()
+    expect(screen.getByText('Mode Toggle ai stats:1/2/88.5')).toBeInTheDocument()
     expect(screen.getByText('Analysis Task Monitor')).toBeInTheDocument()
 
     expect(useAiSearchSummaryMock).toHaveBeenCalledWith(
@@ -644,5 +680,40 @@ describe('ResumeSearchPage', () => {
     await user.click(screen.getByRole('button', { name: /Analyze loaded 2/i }))
 
     expect(state.analyzeResults).toHaveBeenCalledTimes(1)
+  })
+
+  it('wires the AI mode toggle and keeps the analyze button disabled while original mode is selected', async () => {
+    const user = userEvent.setup()
+    const state = createResumeSearchState({
+      activeQuery: 'CNC Sales',
+      analysisCandidateCount: 2,
+      aiModeEnabled: false,
+      aiModeStats: {
+        avgScore: 90,
+        matched: 2,
+        processed: 4,
+      },
+      disableAnalyzeResults: false,
+      filteredResults: [createResult(1)],
+      isLanding: false,
+      setAiModeEnabled: vi.fn(),
+    })
+    useResumeSearchStateMock.mockReturnValue(state)
+
+    render(<ResumeSearchPage />)
+
+    expect(
+      screen.getByText('Mode Toggle original stats:none'),
+    ).toBeInTheDocument()
+
+    const analyzeButton = screen.getByRole('button', {
+      name: /Analyze loaded 2/i,
+    })
+    expect(analyzeButton).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: 'Switch Mode' }))
+
+    expect(state.setAiModeEnabled).toHaveBeenCalledWith(true)
+    expect(state.analyzeResults).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -2,6 +2,7 @@ import { formatKeywordQuery, parseKeywordQuery } from '@trends/shared'
 import { RefreshCw } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { AnalysisTaskMonitor } from '@/components/AnalysisTaskMonitor'
+import { ModeToggle } from '@/components/ModeToggle'
 import { AiSummaryPanel } from '@/components/search/AiSummaryPanel'
 import { FacetBadge } from '@/components/search/FacetBadge'
 import { FacetSidebar } from '@/components/search/FacetSidebar'
@@ -24,6 +25,8 @@ export function ResumeSearchPage() {
     activeSort,
     analysisCandidateCount,
     analyzeResults,
+    aiModeEnabled,
+    aiModeStats,
     analyzingResults,
     applyRecentSearch,
     clearFacetFilters,
@@ -47,6 +50,7 @@ export function ResumeSearchPage() {
     searchHistoryLoading,
     selectedClusterTags,
     selectedRawTags,
+    setAiModeEnabled,
     setExportFormat,
     setMinScoreFilter,
     setQueryInput,
@@ -260,12 +264,17 @@ export function ResumeSearchPage() {
                     Generate per-resume AI summaries and breakdowns for the loaded search results.
                   </p>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  <ModeToggle
+                    mode={aiModeEnabled ? 'ai' : 'original'}
+                    onModeChange={(mode) => setAiModeEnabled(mode === 'ai')}
+                    aiStats={aiModeEnabled ? aiModeStats : undefined}
+                  />
                   <Button
                     type="button"
                     size="sm"
                     className="h-10 gap-2 rounded-full px-4"
-                    disabled={disableAnalyzeResults}
+                    disabled={disableAnalyzeResults || !aiModeEnabled}
                     onClick={() => {
                       void analyzeResults()
                     }}


### PR DESCRIPTION
## Summary
- add always-visible AI/original mode toggle to the resume search results card
- gate auto-analysis and manual analysis dispatch on the toggle state, and surface AI stats for analyzed loaded results
- cover the new hook and page behavior with focused resume search tests

## Verification
- bun --cwd apps/web test src/hooks/useResumeSearchState.test.tsx src/pages/ResumeSearchPage.test.tsx
- make check