### PR TITLE
feat: move AI mode switch into landing search row

### DIFF
--- a/apps/web/src/components/ModeToggle.test.tsx
+++ b/apps/web/src/components/ModeToggle.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { ModeToggle } from './ModeToggle'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === 'resumes.mode.ai') {
+        return 'AI Mode'
+      }
+
+      return key
+    },
+  }),
+}))
+
+describe('ModeToggle', () => {
+  it('renders AI mode text with a switch and badge when enabled', () => {
+    render(
+      <ModeToggle
+        mode="ai"
+        onModeChange={vi.fn()}
+        aiStats={{ avgScore: 91.5, matched: 3, processed: 5 }}
+      />,
+    )
+
+    expect(screen.getByText('AI Mode')).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'AI Mode' })).toBeChecked()
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('toggles between ai and original states', async () => {
+    const user = userEvent.setup()
+    const onModeChange = vi.fn()
+
+    render(<ModeToggle mode="original" onModeChange={onModeChange} />)
+
+    const switchToggle = screen.getByRole('switch', { name: 'AI Mode' })
+    expect(switchToggle).not.toBeChecked()
+
+    await user.click(switchToggle)
+
+    expect(onModeChange).toHaveBeenCalledWith('ai')
+  })
+})

--- a/apps/web/src/components/ModeToggle.tsx
+++ b/apps/web/src/components/ModeToggle.tsx
@@ -1,3 +1,4 @@
+import { Check } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
 
@@ -10,42 +11,44 @@ interface ModeToggleProps {
 
 export function ModeToggle({ mode, onModeChange, aiStats, disabled }: ModeToggleProps) {
   const { t } = useTranslation()
-
-  const options = [
-    { value: 'ai' as const, label: t('resumes.mode.ai') },
-    { value: 'original' as const, label: t('resumes.mode.original') },
-  ]
+  const isAiMode = mode === 'ai'
 
   return (
     <div className="flex flex-wrap items-center gap-3">
-      <div className="inline-flex items-center rounded-full border bg-muted p-1 text-sm">
-        {options.map((option) => {
-          const active = mode === option.value
-          return (
-            <button
-              key={option.value}
-              type="button"
-              onClick={() => onModeChange(option.value)}
-              disabled={disabled}
-              className={cn(
-                'px-3 py-1 rounded-full transition',
-                active ? 'bg-background shadow text-foreground' : 'text-muted-foreground',
-                disabled && 'opacity-60'
-              )}
-            >
-              {option.label}
-            </button>
-          )
-        })}
-      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={isAiMode}
+        onClick={() => onModeChange(isAiMode ? 'original' : 'ai')}
+        disabled={disabled}
+        className={cn(
+          'inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/90 px-2.5 py-1.5 text-sm shadow-sm transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2',
+          disabled && 'cursor-not-allowed opacity-60',
+        )}
+      >
+        <span
+          className={cn(
+            'relative inline-flex h-6 w-11 shrink-0 rounded-full border transition-colors duration-200 ease-out',
+            isAiMode
+              ? 'border-sky-500 bg-sky-500'
+              : 'border-slate-300 bg-slate-300',
+          )}
+        >
+          <span
+            className={cn(
+              'pointer-events-none absolute left-0.5 top-0.5 grid h-5 w-5 place-items-center rounded-full bg-white shadow-sm transition-transform duration-200 ease-out',
+              isAiMode ? 'translate-x-5' : 'translate-x-0',
+            )}
+          >
+            {isAiMode ? <Check className="h-3.5 w-3.5 text-sky-600" /> : null}
+          </span>
+        </span>
+        <span className="font-medium text-slate-900">{t('resumes.mode.ai')}</span>
+      </button>
 
-      {mode === 'ai' && aiStats ? (
-        <span className="text-xs text-muted-foreground">
-          {t('resumes.matching.stats', {
-            matched: aiStats.matched,
-            processed: aiStats.processed ?? aiStats.matched,
-            avgScore: aiStats.avgScore,
-          })}
+      {isAiMode && aiStats ? (
+        <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-sky-500 px-2 text-xs font-semibold text-white">
+          {aiStats.matched}
         </span>
       ) : null}
     </div>

--- a/apps/web/src/components/search/SearchHero.test.tsx
+++ b/apps/web/src/components/search/SearchHero.test.tsx
@@ -4,6 +4,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SearchHero } from '@/components/search/SearchHero'
 import type { ResumeSearchRecentItem } from '@/components/search/search-types'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === 'resumes.mode.ai') {
+        return 'AI Mode'
+      }
+
+      return key
+    },
+  }),
+}))
+
 type SearchHeroProps = Parameters<typeof SearchHero>[0]
 
 vi.mock('@/components/search/GoogleSearchBar', () => ({
@@ -92,8 +104,10 @@ function buildHotKeyword(
 
 function renderSearchHero(overrides: Partial<SearchHeroProps> = {}) {
   const props: SearchHeroProps = {
+    aiModeEnabled: true,
     loading: false,
     queryInput: '',
+    onAiModeChange: vi.fn(),
     recentSearches: [],
     recentSearchesLoading: false,
     quickStarts: undefined,
@@ -129,6 +143,7 @@ describe('SearchHero', () => {
     expect(
       screen.getByText('Search Bar machine tools idle 0'),
     ).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'AI Mode' })).toBeChecked()
   })
 
   it('shows the empty state when there are no recent searches', () => {
@@ -215,6 +230,19 @@ describe('SearchHero', () => {
     expect(onClearQuery).toHaveBeenCalledTimes(1)
     expect(onApplyExtractedKeywords).toHaveBeenCalledWith(['lathe', 'cnc'])
     expect(onSubmitQuery).toHaveBeenCalledWith('submitted')
+  })
+
+  it('forwards AI mode toggle changes to the parent handler', async () => {
+    const user = userEvent.setup()
+    const onAiModeChange = vi.fn()
+
+    renderSearchHero({
+      onAiModeChange,
+    })
+
+    await user.click(screen.getByRole('switch', { name: 'AI Mode' }))
+
+    expect(onAiModeChange).toHaveBeenCalledWith(false)
   })
 
   it('renders quick-start cards from profile-backed quick starts', () => {

--- a/apps/web/src/components/search/SearchHero.tsx
+++ b/apps/web/src/components/search/SearchHero.tsx
@@ -1,4 +1,5 @@
 import { Clock3, Zap } from 'lucide-react'
+import { ModeToggle } from '@/components/ModeToggle'
 import { GoogleSearchBar } from '@/components/search/GoogleSearchBar'
 import { Card, CardContent } from '@/components/ui/card'
 import type { ResumeSearchRecentItem } from '@/components/search/search-types'
@@ -20,6 +21,8 @@ type SearchHeroHotKeyword = {
 type SearchHeroProps = {
   loading?: boolean
   queryInput: string
+  aiModeEnabled: boolean
+  aiModeStats?: { avgScore: number; matched: number; processed?: number }
   recentSearches: ResumeSearchRecentItem[]
   recentSearchesLoading?: boolean
   quickStarts?: SearchHeroQuickStart[]
@@ -28,6 +31,7 @@ type SearchHeroProps = {
   onApplyExtractedKeywords: (keywords: string[]) => void
   onApplyQuickStart?: (seed: { keywords: string[]; location: string }) => void
   onToggleHotKeyword?: (keyword: string) => void
+  onAiModeChange: (enabled: boolean) => void
   onChangeQuery: (value: string) => void
   onClearQuery: () => void
   onSubmitQuery: (value?: string) => void
@@ -62,6 +66,8 @@ function deduplicateHotKeywords(
 export function SearchHero({
   loading = false,
   queryInput,
+  aiModeEnabled,
+  aiModeStats,
   recentSearches,
   recentSearchesLoading = false,
   quickStarts = [],
@@ -70,6 +76,7 @@ export function SearchHero({
   onApplyExtractedKeywords,
   onApplyQuickStart,
   onToggleHotKeyword,
+  onAiModeChange,
   onChangeQuery,
   onClearQuery,
   onSubmitQuery,
@@ -78,18 +85,28 @@ export function SearchHero({
 
   return (
     <section className="rounded-[2rem] border bg-white px-6 py-8 shadow-[0_28px_80px_-60px_rgba(15,23,42,0.5)] sm:px-10 sm:py-10">
-      <div className="mx-auto flex max-w-4xl flex-col gap-6">
-        <div className="mx-auto w-full max-w-3xl">
-          <GoogleSearchBar
-            value={queryInput}
-            loading={loading}
-            recentSearches={recentSearches}
-            onApplyRecentSearch={onApplyRecentSearch}
-            onApplyExtractedKeywords={onApplyExtractedKeywords}
-            onChange={onChangeQuery}
-            onClear={onClearQuery}
-            onSubmit={onSubmitQuery}
-          />
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+        <div className="flex w-full flex-col gap-3 lg:flex-row lg:items-center lg:gap-4">
+          <div className="min-w-0 flex-1">
+            <GoogleSearchBar
+              value={queryInput}
+              loading={loading}
+              recentSearches={recentSearches}
+              onApplyRecentSearch={onApplyRecentSearch}
+              onApplyExtractedKeywords={onApplyExtractedKeywords}
+              onChange={onChangeQuery}
+              onClear={onClearQuery}
+              onSubmit={onSubmitQuery}
+            />
+          </div>
+
+          <div className="self-end lg:self-center">
+            <ModeToggle
+              mode={aiModeEnabled ? 'ai' : 'original'}
+              onModeChange={(mode) => onAiModeChange(mode === 'ai')}
+              aiStats={aiModeStats}
+            />
+          </div>
         </div>
 
         {quickStarts.length > 0 ? (

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -35,18 +35,24 @@ vi.mock('@/components/search/MigrationBanner', () => ({
 
 vi.mock('@/components/search/SearchHero', () => ({
   SearchHero: ({
+    aiModeEnabled,
+    aiModeStats,
     hotKeywords,
     onApplyQuickStart,
+    onAiModeChange,
     onToggleHotKeyword,
     queryInput,
     onApplyExtractedKeywords,
     quickStarts,
   }: {
+    aiModeEnabled: boolean
+    aiModeStats?: { avgScore: number; matched: number; processed?: number }
     hotKeywords?: Array<{ keyword: string }>
     onApplyQuickStart?: (seed: {
       keywords: string[]
       location: string
     }) => void
+    onAiModeChange: (enabled: boolean) => void
     onToggleHotKeyword?: (keyword: string) => void
     queryInput: string
     onApplyExtractedKeywords: (keywords: string[]) => void
@@ -80,6 +86,17 @@ vi.mock('@/components/search/SearchHero', () => ({
       <button type="button" onClick={() => onToggleHotKeyword?.('CNC')}>
         Toggle Hero Hot Keyword
       </button>
+      <button
+        type="button"
+        role="switch"
+        aria-label="AI Mode"
+        aria-checked={aiModeEnabled}
+        onClick={() => onAiModeChange(!aiModeEnabled)}
+      >
+        {aiModeEnabled ? 'On' : 'Off'}
+      </button>
+      <span>AI Mode</span>
+      {aiModeEnabled && aiModeStats ? <span>{aiModeStats.matched}</span> : null}
     </div>
   ),
 }))
@@ -245,19 +262,18 @@ vi.mock('@/components/ModeToggle', () => ({
     mode: 'ai' | 'original'
     onModeChange: (mode: 'ai' | 'original') => void
   }) => (
-    <div>
-      <div>
-        Mode Toggle {mode} stats:
-        {aiStats
-          ? `${aiStats.matched}/${aiStats.processed ?? aiStats.matched}/${aiStats.avgScore}`
-          : 'none'}
-      </div>
+    <div className="flex items-center gap-2">
       <button
         type="button"
+        role="switch"
+        aria-label="AI Mode"
+        aria-checked={mode === 'ai'}
         onClick={() => onModeChange(mode === 'ai' ? 'original' : 'ai')}
       >
-        Switch Mode
+        {mode === 'ai' ? 'On' : 'Off'}
       </button>
+      <span>AI Mode</span>
+      {mode === 'ai' && aiStats ? <span>{aiStats.matched}</span> : null}
     </div>
   ),
 }))
@@ -411,6 +427,8 @@ describe('ResumeSearchPage', () => {
     expect(screen.getByText('Migration Banner')).toBeInTheDocument()
     expect(screen.getByText('Landing Hero machine tools')).toBeInTheDocument()
     expect(screen.getByText('Landing Hero Seeds 0 Hot 0')).toBeInTheDocument()
+    expect(screen.getByText('AI Mode')).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'AI Mode' })).toBeChecked()
     expect(screen.queryByText(/Header /)).not.toBeInTheDocument()
     expect(screen.queryByText(/Results List/)).not.toBeInTheDocument()
 
@@ -422,6 +440,9 @@ describe('ResumeSearchPage', () => {
     ])
     expect(state.setQueryInput).toHaveBeenCalledWith(expectedQuery)
     expect(state.submitSearch).toHaveBeenCalledWith(expectedQuery)
+
+    await user.click(screen.getByRole('switch', { name: 'AI Mode' }))
+    expect(state.setAiModeEnabled).toHaveBeenCalledWith(false)
   })
 
   it('wires profile quick-start and hot keyword handlers into the landing hero', async () => {
@@ -536,7 +557,9 @@ describe('ResumeSearchPage', () => {
       screen.getByText('AI Summary Summary text generated:123 loading:false'),
     ).toBeInTheDocument()
     expect(screen.getByText('Resume AI analysis')).toBeInTheDocument()
-    expect(screen.getByText('Mode Toggle ai stats:1/2/88.5')).toBeInTheDocument()
+    expect(screen.getByText('AI Mode')).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'AI Mode' })).toBeChecked()
+    expect(screen.getByText('1')).toBeInTheDocument()
     expect(screen.getByText('Analysis Task Monitor')).toBeInTheDocument()
 
     expect(useAiSearchSummaryMock).toHaveBeenCalledWith(
@@ -703,15 +726,16 @@ describe('ResumeSearchPage', () => {
     render(<ResumeSearchPage />)
 
     expect(
-      screen.getByText('Mode Toggle original stats:none'),
+      screen.getByText('AI Mode'),
     ).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'AI Mode' })).not.toBeChecked()
 
     const analyzeButton = screen.getByRole('button', {
       name: /Analyze loaded 2/i,
     })
     expect(analyzeButton).toBeDisabled()
 
-    await user.click(screen.getByRole('button', { name: 'Switch Mode' }))
+    await user.click(screen.getByRole('switch', { name: 'AI Mode' }))
 
     expect(state.setAiModeEnabled).toHaveBeenCalledWith(true)
     expect(state.analyzeResults).not.toHaveBeenCalled()

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -201,6 +201,8 @@ export function ResumeSearchPage() {
 
       {isLanding ? (
         <SearchHero
+          aiModeEnabled={aiModeEnabled}
+          aiModeStats={aiModeStats}
           loading={loading}
           queryInput={queryInput}
           recentSearches={recentSearches}
@@ -211,6 +213,7 @@ export function ResumeSearchPage() {
           onApplyExtractedKeywords={applyExtractedKeywords}
           onApplyQuickStart={applyQuickStart}
           onToggleHotKeyword={toggleHotKeyword}
+          onAiModeChange={setAiModeEnabled}
           onChangeQuery={setQueryInput}
           onClearQuery={handleClearQuery}
           onSubmitQuery={handleSubmitQuery}
@@ -268,7 +271,7 @@ export function ResumeSearchPage() {
                   <ModeToggle
                     mode={aiModeEnabled ? 'ai' : 'original'}
                     onModeChange={(mode) => setAiModeEnabled(mode === 'ai')}
-                    aiStats={aiModeEnabled ? aiModeStats : undefined}
+                    aiStats={aiModeStats}
                   />
                   <Button
                     type="button"


### PR DESCRIPTION
Move the localized AI mode switch inline with the landing search row, keep the same control in results, and simplify duplicate stats wiring.\n\nValidation:\n- bun --cwd apps/web test src/components/ModeToggle.test.tsx src/components/search/SearchHero.test.tsx src/pages/ResumeSearchPage.test.tsx\n- make check