### PR TITLE
fix: force-trigger AI analysis on quickstart click

### DIFF
--- a/apps/web/src/components/ModeToggle.test.tsx
+++ b/apps/web/src/components/ModeToggle.test.tsx
@@ -5,12 +5,19 @@ import { ModeToggle } from './ModeToggle'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => {
-      if (key === 'resumes.mode.ai') {
-        return 'AI Mode'
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') {
+        return options
       }
 
-      return key
+      const defaultValue =
+        options && typeof options === 'object' && typeof options.defaultValue === 'string'
+          ? options.defaultValue
+          : key
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = options && typeof options === 'object' ? options[token] : undefined
+        return value === undefined || value === null ? '' : String(value)
+      })
     },
   }),
 }))

--- a/apps/web/src/components/ModeToggle.tsx
+++ b/apps/web/src/components/ModeToggle.tsx
@@ -43,7 +43,9 @@ export function ModeToggle({ mode, onModeChange, aiStats, disabled }: ModeToggle
             {isAiMode ? <Check className="h-3.5 w-3.5 text-sky-600" /> : null}
           </span>
         </span>
-        <span className="font-medium text-slate-900">{t('resumes.mode.ai')}</span>
+        <span className="font-medium text-slate-900">{t('resumes.mode.ai', {
+          defaultValue: 'AI Mode',
+        })}</span>
       </button>
 
       {isAiMode && aiStats ? (

--- a/apps/web/src/components/ResumeCard.test.tsx
+++ b/apps/web/src/components/ResumeCard.test.tsx
@@ -5,7 +5,20 @@ import { ResumeCard } from './ResumeCard'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, fallback?: string) => fallback ?? key,
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') {
+        return options
+      }
+
+      const defaultValue =
+        options && typeof options === 'object' && typeof options.defaultValue === 'string'
+          ? options.defaultValue
+          : key
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = options && typeof options === 'object' ? options[token] : undefined
+        return value === undefined || value === null ? '' : String(value)
+      })
+    },
   }),
 }))
 
@@ -98,5 +111,42 @@ describe('ResumeCard brand-hit badges', () => {
 
     expect(screen.queryByText('Sales Engineer')).not.toBeInTheDocument()
     expect(screen.queryByText('Test intro')).not.toBeInTheDocument()
+  })
+
+  it('shows AI pending instead of rule scoring when AI mode is enabled but analysis is missing', () => {
+    render(
+      <ResumeCard
+        resume={{
+          name: 'Alice',
+          profileUrl: 'https://example.com/resume-1',
+          activityStatus: 'Active',
+          age: '30',
+          experience: '5 years',
+          education: 'Bachelor',
+          location: 'Dongguan',
+          selfIntro: 'Test intro',
+          jobIntention: 'Sales Engineer',
+          expectedSalary: '10k-20k',
+          workHistory: [],
+          extractedAt: '2026-03-13T00:00:00.000Z',
+        }}
+        matchResult={{
+          resumeId: 'resume-1',
+          score: 74,
+          recommendation: 'match',
+          highlights: [],
+          concerns: [],
+          summary: '',
+          matchedAt: '2026-03-13T00:00:00.000Z',
+          scoreSource: 'rule',
+        }}
+        showAiScore
+        onViewDetails={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('AI pending')).toBeInTheDocument()
+    expect(screen.queryByText('Rule')).not.toBeInTheDocument()
+    expect(screen.queryByText('74')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -211,10 +211,14 @@ export function ResumeCard({
     ? t('resumes.status.updatedAt', { date: new Date(candidateStatusMeta.updatedAt).toLocaleString() })
     : ''
 
-  // AI score is primary when available; rule score is deterministic fallback
-  const hasAiScore = typeof score === 'number' && score > 0
-  const effectiveScore = hasAiScore ? score : (typeof ruleScore === 'number' && ruleScore > 0 ? ruleScore : score)
-  const isRuleScore = !hasAiScore && typeof ruleScore === 'number' && ruleScore > 0
+  const hasAiScore = scoreSource === 'ai' && typeof score === 'number' && score > 0
+  const pendingAiScore = showAiScore && !hasAiScore
+  const effectiveScore = hasAiScore
+    ? score
+    : !showAiScore && typeof ruleScore === 'number' && ruleScore > 0
+      ? ruleScore
+      : undefined
+  const isRuleScore = !showAiScore && typeof ruleScore === 'number' && ruleScore > 0
 
   const scoreClassName =
     typeof effectiveScore === 'number'
@@ -233,6 +237,81 @@ export function ResumeCard({
       : scoreSource === 'rule'
         ? 'bg-amber-500 text-white border-amber-600'
         : ''
+  const aiScoreNode = hasAiScore ? (
+    <div className="flex items-center gap-2">
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="cursor-help">
+              <Badge className={cn('border', scoreClassName)}>
+                {t('resumes.matching.scoreLabel', { score })}
+                {scoreLabel ? ` · ${scoreLabel}` : ''}
+              </Badge>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent className="p-3 text-xs w-64 bg-slate-900 text-white">
+            <p className="font-semibold mb-2 text-sm border-b pb-1 border-white/20">
+              {t('resumes.searchPage.card.analysisBreakdown', {
+                defaultValue: 'Analysis Breakdown',
+              })}
+            </p>
+            {matchResult?.breakdown ? (
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+                {Object.entries(matchResult.breakdown).map(([key, value]) => (
+                  <div key={key} className="flex justify-between">
+                    <span className="capitalize opacity-80">{key.replace('_', ' ')}:</span>
+                    <span className="font-mono font-bold">{value}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="opacity-70 italic">
+                {t('resumes.searchPage.card.noDetailedBreakdown', {
+                  defaultValue: 'No detailed breakdown available',
+                })}
+              </p>
+            )}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      {scoreSource ? (
+        <Badge className={cn('border text-[10px] uppercase tracking-wide', scoreSourceClassName)}>
+          {t('resumes.searchPage.card.ai', { defaultValue: 'AI' })}
+        </Badge>
+      ) : null}
+      {onAiFeedback && scoreSource === 'ai' ? (
+        <AiFeedbackButtons
+          feedback={aiScoreFeedback}
+          label={t('resumes.searchPage.card.aiScoreLabel', {
+            defaultValue: 'AI score',
+          })}
+          testId="ai-score-feedback"
+          stopPropagation
+          onSelect={(sentiment) => onAiFeedback('ai_score', sentiment)}
+        />
+      ) : null}
+    </div>
+  ) : null
+  const ruleScoreNode = isRuleScore && effectiveScore && effectiveScore > 0 ? (
+    <div className="flex items-center gap-2">
+      <Badge className={cn('border', scoreClassName)}>
+        {t('resumes.matching.scoreLabel', { score: effectiveScore })}
+      </Badge>
+      <Badge variant="outline" className="text-[10px] uppercase tracking-wide border-amber-200 text-amber-600">
+        {t('resumes.searchPage.card.rule', { defaultValue: 'Rule' })}
+      </Badge>
+    </div>
+  ) : null
+  const pendingAiScoreNode = pendingAiScore ? (
+    <Badge variant="outline" className="border-slate-200 bg-slate-50 text-slate-600">
+      {t('resumes.searchPage.card.aiPending', {
+        defaultValue: 'AI pending',
+      })}
+    </Badge>
+  ) : null
+  const scoreNode = showAiScore
+    ? aiScoreNode ?? pendingAiScoreNode
+    : ruleScoreNode ?? aiScoreNode
   const visibleIndustryTags = (industryTags ?? [])
     .filter((tag) => tag.trim().length > 0)
     .slice(0, 4)
@@ -325,60 +404,7 @@ export function ResumeCard({
         {resume.expectedSalary ? (
           <span className="text-muted-foreground">{resume.expectedSalary}</span>
         ) : null}
-        {isRuleScore && effectiveScore && effectiveScore > 0 ? (
-          <div className="flex items-center gap-2">
-            <Badge className={cn('border', scoreClassName)}>
-              {t('resumes.matching.scoreLabel', { score: effectiveScore })}
-            </Badge>
-            <Badge variant="outline" className="text-[10px] uppercase tracking-wide border-amber-200 text-amber-600">
-              Rule
-            </Badge>
-          </div>
-        ) : showAiScore && typeof score === 'number' ? (
-          <div className="flex items-center gap-2">
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="cursor-help">
-                    <Badge className={cn('border', scoreClassName)}>
-                      {t('resumes.matching.scoreLabel', { score })}
-                      {scoreLabel ? ` · ${scoreLabel}` : ''}
-                    </Badge>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent className="p-3 text-xs w-64 bg-slate-900 text-white">
-                  <p className="font-semibold mb-2 text-sm border-b pb-1 border-white/20">Analysis Breakdown</p>
-                  {matchResult?.breakdown ? (
-                    <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-                      {Object.entries(matchResult.breakdown).map(([key, value]) => (
-                        <div key={key} className="flex justify-between">
-                          <span className="capitalize opacity-80">{key.replace('_', ' ')}:</span>
-                          <span className="font-mono font-bold">{value}</span>
-                        </div>
-                      ))}
-                    </div>
-                  ) : (
-                    <p className="opacity-70 italic">No detailed breakdown available</p>
-                  )}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-            {scoreSource ? (
-              <Badge className={cn('border text-[10px] uppercase tracking-wide', scoreSourceClassName)}>
-                {scoreSource === 'ai' ? 'AI' : 'Rule'}
-              </Badge>
-            ) : null}
-            {onAiFeedback && scoreSource === 'ai' ? (
-              <AiFeedbackButtons
-                feedback={aiScoreFeedback}
-                label="AI score"
-                testId="ai-score-feedback"
-                stopPropagation
-                onSelect={(sentiment) => onAiFeedback('ai_score', sentiment)}
-              />
-            ) : null}
-          </div>
-        ) : null}
+        {scoreNode}
         {experienceBadge ? (
           <Badge
             variant="outline"

--- a/apps/web/src/components/search/AiSummaryPanel.test.tsx
+++ b/apps/web/src/components/search/AiSummaryPanel.test.tsx
@@ -2,6 +2,25 @@ import { render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AiSummaryPanel } from '@/components/search/AiSummaryPanel'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') {
+        return options
+      }
+
+      const defaultValue =
+        options && typeof options === 'object' && typeof options.defaultValue === 'string'
+          ? options.defaultValue
+          : key
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = options && typeof options === 'object' ? options[token] : undefined
+        return value === undefined || value === null ? '' : String(value)
+      })
+    },
+  }),
+}))
+
 describe('AiSummaryPanel', () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/apps/web/src/components/search/AiSummaryPanel.tsx
+++ b/apps/web/src/components/search/AiSummaryPanel.tsx
@@ -1,4 +1,5 @@
 import { Sparkles } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 
@@ -8,32 +9,49 @@ type AiSummaryPanelProps = {
   summary?: string
 }
 
-function formatGeneratedAt(value: number | undefined): string | null {
+function formatGeneratedAt(
+  value: number | undefined,
+  t: (key: string, options?: { count?: number; defaultValue?: string }) => string,
+): string | null {
   if (!value) {
     return null
   }
 
   const elapsedMinutes = Math.max(0, Math.round((Date.now() - value) / 60_000))
   if (elapsedMinutes < 1) {
-    return 'Generated just now'
+    return t('resumes.searchPage.aiSummary.generatedJustNow', {
+      defaultValue: 'Generated just now',
+    })
   }
 
   if (elapsedMinutes === 1) {
-    return 'Generated 1 minute ago'
+    return t('resumes.searchPage.aiSummary.generatedOneMinuteAgo', {
+      defaultValue: 'Generated 1 minute ago',
+    })
   }
 
-  return `Generated ${elapsedMinutes} minutes ago`
+  return t('resumes.searchPage.aiSummary.generatedMinutesAgo', {
+    count: elapsedMinutes,
+    defaultValue: 'Generated {{count}} minutes ago',
+  })
 }
 
 export function AiSummaryPanel({ generatedAt, loading = false, summary }: AiSummaryPanelProps) {
-  const generatedAtLabel = formatGeneratedAt(generatedAt)
+  const { t } = useTranslation()
+  const generatedAtLabel = formatGeneratedAt(generatedAt, t)
+  const titleLabel = t('resumes.searchPage.aiSummary.title', {
+    defaultValue: 'AI result summary',
+  })
+  const summaryLabel = summary || t('resumes.searchPage.aiSummary.noSummary', {
+    defaultValue: 'No summary is available for the current search yet.',
+  })
 
   return (
     <Card className="hidden rounded-[1.75rem] border-slate-200 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white shadow-[0_28px_70px_-46px_rgba(15,23,42,0.9)] md:block">
       <CardContent className="space-y-4 p-6">
         <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-slate-300">
           <Sparkles className="h-4 w-4" />
-          AI result summary
+          {titleLabel}
         </div>
 
         {loading ? (
@@ -44,7 +62,7 @@ export function AiSummaryPanel({ generatedAt, loading = false, summary }: AiSumm
           </div>
         ) : (
           <p className="text-sm leading-7 text-slate-100">
-            {summary || 'No summary is available for the current search yet.'}
+            {summaryLabel}
           </p>
         )}
 

--- a/apps/web/src/components/search/GoogleSearchBar.test.tsx
+++ b/apps/web/src/components/search/GoogleSearchBar.test.tsx
@@ -5,6 +5,25 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GoogleSearchBar } from '@/components/search/GoogleSearchBar'
 import type { ResumeSearchRecentItem } from '@/components/search/search-types'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') {
+        return options
+      }
+
+      const defaultValue =
+        options && typeof options === 'object' && typeof options.defaultValue === 'string'
+          ? options.defaultValue
+          : key
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = options && typeof options === 'object' ? options[token] : undefined
+        return value === undefined || value === null ? '' : String(value)
+      })
+    },
+  }),
+}))
+
 vi.mock('@/components/search/JdPastePopover', () => ({
   JdPastePopover: ({ onClose }: { onClose: () => void }) => (
     <div>

--- a/apps/web/src/components/search/GoogleSearchBar.tsx
+++ b/apps/web/src/components/search/GoogleSearchBar.tsx
@@ -1,5 +1,6 @@
 import { Clock3, FileText, Search, X } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { JdPastePopover } from '@/components/search/JdPastePopover'
 import { Input } from '@/components/ui/input'
@@ -33,12 +34,32 @@ export function GoogleSearchBar({
   onChange,
   onClear,
   onSubmit,
-  placeholder = 'Search resumes by keywords, brands, roles, or locations',
+  placeholder,
 }: GoogleSearchBarProps) {
+  const { t } = useTranslation()
   const [focused, setFocused] = useState(false)
   const [jdPopoverOpen, setJdPopoverOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const trimmedValue = value.trim()
+  const placeholderLabel = placeholder ?? t('resumes.searchPage.searchBar.placeholder', {
+    defaultValue: 'Search resumes by keywords, brands, roles, or locations',
+  })
+  const searchButtonLabel = loading
+    ? t('resumes.searchPage.searchBar.searching', {
+      defaultValue: 'Searching...',
+    })
+    : t('resumes.searchPage.searchBar.search', {
+      defaultValue: 'Search',
+    })
+  const pasteJobDescriptionLabel = t('resumes.searchPage.searchBar.pasteJobDescription', {
+    defaultValue: 'Paste job description',
+  })
+  const clearSearchLabel = t('resumes.searchPage.searchBar.clearSearch', {
+    defaultValue: 'Clear search',
+  })
+  const recentSearchesLabel = t('resumes.searchPage.searchBar.recentSearches', {
+    defaultValue: 'Recent searches',
+  })
   const filteredRecentSearches = useMemo(() => {
     if (!trimmedValue) {
       return recentSearches.slice(0, 6)
@@ -89,7 +110,7 @@ export function GoogleSearchBar({
             'border-0 bg-transparent shadow-none focus-visible:ring-0 focus-visible:ring-offset-0',
             compact ? 'h-14 text-base' : 'h-16 text-lg'
           )}
-          placeholder={placeholder}
+          placeholder={placeholderLabel}
           onBlur={() => {
             window.setTimeout(() => setFocused(false), 120)
           }}
@@ -119,7 +140,7 @@ export function GoogleSearchBar({
             }}
           >
             <FileText className="h-4 w-4" />
-            <span className="sr-only">Paste job description</span>
+            <span className="sr-only">{pasteJobDescriptionLabel}</span>
           </Button>
         ) : null}
         {trimmedValue ? (
@@ -131,12 +152,12 @@ export function GoogleSearchBar({
             onClick={onClear}
           >
             <X className="h-4 w-4" />
-            <span className="sr-only">Clear search</span>
+            <span className="sr-only">{clearSearchLabel}</span>
           </Button>
         ) : null}
         <div className="pr-2">
           <Button type="submit" className="rounded-full px-5" disabled={loading}>
-            {loading ? 'Searching...' : 'Search'}
+            {searchButtonLabel}
           </Button>
         </div>
       </form>
@@ -152,7 +173,7 @@ export function GoogleSearchBar({
       {focused && !jdPopoverOpen && filteredRecentSearches.length > 0 ? (
         <div className="absolute inset-x-0 top-[calc(100%+0.75rem)] z-30 overflow-hidden rounded-3xl border bg-background shadow-xl">
           <div className="border-b px-4 py-3 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-            Recent searches
+            {recentSearchesLabel}
           </div>
           <div className="p-2">
             {filteredRecentSearches.map((item) => (

--- a/apps/web/src/components/search/MigrationBanner.test.tsx
+++ b/apps/web/src/components/search/MigrationBanner.test.tsx
@@ -3,6 +3,25 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MigrationBanner } from '@/components/search/MigrationBanner'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') {
+        return options
+      }
+
+      const defaultValue =
+        options && typeof options === 'object' && typeof options.defaultValue === 'string'
+          ? options.defaultValue
+          : key
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = options && typeof options === 'object' ? options[token] : undefined
+        return value === undefined || value === null ? '' : String(value)
+      })
+    },
+  }),
+}))
+
 vi.mock('@/contexts/WorkspaceContext', () => ({
   useWorkspace: () => ({
     slug: 'dev',

--- a/apps/web/src/components/search/MigrationBanner.tsx
+++ b/apps/web/src/components/search/MigrationBanner.tsx
@@ -1,6 +1,7 @@
 import { X } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 
@@ -8,6 +9,7 @@ const STORAGE_KEY = 'trends.resume.search-first.migration-banner.dismissed'
 
 export function MigrationBanner() {
   const { slug } = useWorkspace()
+  const { t } = useTranslation()
   const [dismissed, setDismissed] = useState(true)
 
   useEffect(() => {
@@ -21,14 +23,22 @@ export function MigrationBanner() {
   return (
     <div className="flex flex-col gap-3 rounded-[1.5rem] border border-sky-200 bg-sky-50 px-4 py-4 text-sm text-sky-900 shadow-sm sm:flex-row sm:items-center sm:justify-between">
       <div className="space-y-1">
-        <div className="font-medium">Search Profiles still exist, but the primary resume route is now search-first.</div>
+        <div className="font-medium">
+          {t('resumes.searchPage.banner.title', {
+            defaultValue: 'Search Profiles still exist, but the primary resume route is now search-first.',
+          })}
+        </div>
         <div className="text-sky-800/80">
-          Use this page for fast keyword review. Use Search Profiles when you need landing quick starts, scheduled collectors, and JD-driven setup in one place.
+          {t('resumes.searchPage.banner.description', {
+            defaultValue: 'Use this page for fast keyword review. Use Search Profiles when you need landing quick starts, scheduled collectors, and JD-driven setup in one place.',
+          })}
         </div>
       </div>
       <div className="flex items-center gap-2">
         <Link className="inline-flex h-9 items-center rounded-md border border-sky-200 bg-white px-3 text-sm font-medium" to={`/${slug}/system/profiles`}>
-          Open Search Profiles
+          {t('resumes.searchPage.banner.openProfiles', {
+            defaultValue: 'Open Search Profiles',
+          })}
         </Link>
         <Button
           type="button"
@@ -41,7 +51,11 @@ export function MigrationBanner() {
           }}
         >
           <X className="h-4 w-4" />
-          <span className="sr-only">Dismiss migration banner</span>
+          <span className="sr-only">
+            {t('resumes.searchPage.banner.dismiss', {
+              defaultValue: 'Dismiss migration banner',
+            })}
+          </span>
         </Button>
       </div>
     </div>

--- a/apps/web/src/components/search/SearchHeader.test.tsx
+++ b/apps/web/src/components/search/SearchHeader.test.tsx
@@ -4,6 +4,25 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SearchHeader } from '@/components/search/SearchHeader'
 import type { ResumeSearchRecentItem } from '@/components/search/search-types'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') {
+        return options
+      }
+
+      const defaultValue =
+        options && typeof options === 'object' && typeof options.defaultValue === 'string'
+          ? options.defaultValue
+          : key
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = options && typeof options === 'object' ? options[token] : undefined
+        return value === undefined || value === null ? '' : String(value)
+      })
+    },
+  }),
+}))
+
 vi.mock('@/components/search/GoogleSearchBar', () => ({
   GoogleSearchBar: ({
     onApplyExtractedKeywords,

--- a/apps/web/src/components/search/SearchHeader.tsx
+++ b/apps/web/src/components/search/SearchHeader.tsx
@@ -1,4 +1,5 @@
 import { Download } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Select } from '@/components/ui/select'
@@ -48,6 +49,42 @@ export function SearchHeader({
   onSubmitQuery,
   onSortChange,
 }: SearchHeaderProps) {
+  const { t } = useTranslation()
+  const resultsLabel = activeQuery
+    ? t('resumes.searchPage.header.resultsWithQuery', {
+      count: activeResultCount.toLocaleString(),
+      query: activeQuery,
+      defaultValue: '{{count}} results for "{{query}}"',
+    })
+    : t('resumes.searchPage.header.results', {
+      count: activeResultCount.toLocaleString(),
+      defaultValue: '{{count}} results',
+    })
+  const sortLabel = t('resumes.searchPage.header.sort', {
+    defaultValue: 'Sort',
+  })
+  const sortResultsLabel = t('resumes.searchPage.header.sortResults', {
+    defaultValue: 'Sort results',
+  })
+  const aiScoreLabel = t('resumes.searchPage.header.sortOptions.aiScore', {
+    defaultValue: 'AI score',
+  })
+  const newestLabel = t('resumes.searchPage.header.sortOptions.newest', {
+    defaultValue: 'Newest',
+  })
+  const experienceLabel = t('resumes.searchPage.header.sortOptions.experience', {
+    defaultValue: 'Experience',
+  })
+  const exportFormatLabel = t('resumes.searchPage.header.exportFormat', {
+    defaultValue: 'Export format',
+  })
+  const exportingLabel = t('resumes.searchPage.header.exporting', {
+    defaultValue: 'Exporting...',
+  })
+  const exportLabel = t('resumes.searchPage.header.export', {
+    count: activeResultCount.toLocaleString(),
+    defaultValue: 'Export {{count}}',
+  })
   return (
     <div className="space-y-4">
       <div className="mx-auto max-w-5xl">
@@ -66,9 +103,7 @@ export function SearchHeader({
 
       <div className="flex flex-col gap-3 rounded-[1.5rem] border bg-white/80 px-4 py-3 shadow-sm lg:flex-row lg:items-center lg:justify-between">
         <div className="min-w-0 space-y-2">
-          <div className="text-sm font-medium text-slate-900">
-            {activeResultCount.toLocaleString()} results{activeQuery ? ` for "${activeQuery}"` : ''}
-          </div>
+          <div className="text-sm font-medium text-slate-900">{resultsLabel}</div>
           <div className="flex flex-wrap gap-2">
             {location ? <Badge variant="outline">{location}</Badge> : null}
             {jobDescriptionId ? <Badge variant="outline">JD {jobDescriptionId}</Badge> : null}
@@ -78,15 +113,15 @@ export function SearchHeader({
         <div className="flex flex-wrap items-center gap-3">
           <div className="flex items-center gap-3">
             <span className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-              Sort
+              {sortLabel}
             </span>
             <Select
-              aria-label="Sort results"
+              aria-label={sortResultsLabel}
               className="min-w-40"
               options={[
-                { value: 'score', label: 'AI score' },
-                { value: 'newest', label: 'Newest' },
-                { value: 'experience', label: 'Experience' },
+                { value: 'score', label: aiScoreLabel },
+                { value: 'newest', label: newestLabel },
+                { value: 'experience', label: experienceLabel },
               ]}
               value={sortValue}
               onChange={(event) =>
@@ -97,7 +132,7 @@ export function SearchHeader({
 
           <div className="flex items-center gap-2">
             <Select
-              aria-label="Export format"
+              aria-label={exportFormatLabel}
               className="h-10 min-w-24 rounded-full border-0 bg-slate-100/90 pr-8 focus-visible:ring-0 focus-visible:ring-offset-0"
               options={[
                 { value: 'csv', label: 'CSV' },
@@ -123,9 +158,7 @@ export function SearchHeader({
               <Download
                 className={cn('h-4 w-4', exportingResults && 'animate-spin')}
               />
-              {exportingResults
-                ? 'Exporting...'
-                : `Export ${activeResultCount.toLocaleString()}`}
+              {exportingResults ? exportingLabel : exportLabel}
             </Button>
           </div>
         </div>

--- a/apps/web/src/components/search/SearchHero.test.tsx
+++ b/apps/web/src/components/search/SearchHero.test.tsx
@@ -6,12 +6,19 @@ import type { ResumeSearchRecentItem } from '@/components/search/search-types'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => {
-      if (key === 'resumes.mode.ai') {
-        return 'AI Mode'
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') {
+        return options
       }
 
-      return key
+      const defaultValue =
+        options && typeof options === 'object' && typeof options.defaultValue === 'string'
+          ? options.defaultValue
+          : key
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = options && typeof options === 'object' ? options[token] : undefined
+        return value === undefined || value === null ? '' : String(value)
+      })
     },
   }),
 }))

--- a/apps/web/src/components/search/SearchHero.tsx
+++ b/apps/web/src/components/search/SearchHero.tsx
@@ -1,4 +1,5 @@
 import { Clock3, Zap } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { ModeToggle } from '@/components/ModeToggle'
 import { GoogleSearchBar } from '@/components/search/GoogleSearchBar'
 import { Card, CardContent } from '@/components/ui/card'
@@ -81,6 +82,7 @@ export function SearchHero({
   onClearQuery,
   onSubmitQuery,
 }: SearchHeroProps) {
+  const { t } = useTranslation()
   const uniqueHotKeywords = deduplicateHotKeywords(hotKeywords)
 
   return (
@@ -113,7 +115,9 @@ export function SearchHero({
           <div className="mx-auto w-full max-w-3xl text-left">
             <div className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
               <Zap className="h-3.5 w-3.5" />
-              Quick Start
+              {t('resumes.searchPage.hero.quickStart', {
+                defaultValue: 'Quick Start',
+              })}
             </div>
             <div className="grid gap-3 sm:grid-cols-2">
               {quickStarts.map((seed) => (
@@ -143,7 +147,9 @@ export function SearchHero({
         {uniqueHotKeywords.length > 0 ? (
           <div className="mx-auto w-full max-w-3xl text-left">
             <div className="mb-3 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
-              Hot Tags
+              {t('resumes.searchPage.hero.hotTags', {
+                defaultValue: 'Hot Tags',
+              })}
             </div>
             <div className="flex flex-wrap gap-1.5">
               {uniqueHotKeywords.map((keyword) => (
@@ -163,19 +169,24 @@ export function SearchHero({
         <div className="mx-auto w-full max-w-3xl text-left">
           <div className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
             <Clock3 className="h-3.5 w-3.5" />
-            Recent searches
+            {t('resumes.searchPage.hero.recentSearches', {
+              defaultValue: 'Recent searches',
+            })}
           </div>
           {recentSearchesLoading ? (
             <Card className="rounded-[1.5rem] border-dashed">
               <CardContent className="p-6 text-sm text-muted-foreground">
-                Loading recent searches...
+                {t('resumes.searchPage.hero.loadingRecentSearches', {
+                  defaultValue: 'Loading recent searches...',
+                })}
               </CardContent>
             </Card>
           ) : recentSearches.length === 0 ? (
             <Card className="rounded-[1.5rem] border-dashed">
               <CardContent className="p-6 text-sm text-muted-foreground">
-                No saved searches yet. Recent searches will appear here after
-                you start exploring.
+                {t('resumes.searchPage.hero.noSavedSearches', {
+                  defaultValue: 'No saved searches yet. Recent searches will appear here after you start exploring.',
+                })}
               </CardContent>
             </Card>
           ) : (

--- a/apps/web/src/components/search/SearchResultsList.test.tsx
+++ b/apps/web/src/components/search/SearchResultsList.test.tsx
@@ -4,6 +4,25 @@ import { SearchResultsList } from '@/components/search/SearchResultsList'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') {
+        return options
+      }
+
+      const defaultValue =
+        options && typeof options === 'object' && typeof options.defaultValue === 'string'
+          ? options.defaultValue
+          : key
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = options && typeof options === 'object' ? options[token] : undefined
+        return value === undefined || value === null ? '' : String(value)
+      })
+    },
+  }),
+}))
+
 let virtualRows: Array<{ index: number; start: number }> = [{ index: 0, start: 0 }]
 const observeMock = vi.fn()
 const disconnectMock = vi.fn()

--- a/apps/web/src/components/search/SearchResultsList.tsx
+++ b/apps/web/src/components/search/SearchResultsList.tsx
@@ -1,5 +1,6 @@
 import { useWindowVirtualizer } from '@tanstack/react-virtual'
 import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { EmptyState } from '@/components/EmptyState'
 import { SnippetCard } from '@/components/search/SnippetCard'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -11,6 +12,7 @@ type SearchResultsListProps = {
   items: ResumeSearchResultItem[]
   loading?: boolean
   loadingMore?: boolean
+  showAiScore?: boolean
   onLoadMore: () => void
   onToggleExpanded: (key: string) => void
 }
@@ -38,9 +40,11 @@ export function SearchResultsList({
   items,
   loading = false,
   loadingMore = false,
+  showAiScore = false,
   onLoadMore,
   onToggleExpanded,
 }: SearchResultsListProps) {
+  const { t } = useTranslation()
   const listRef = useRef<HTMLDivElement | null>(null)
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
   const [scrollMargin, setScrollMargin] = useState(0)
@@ -112,8 +116,12 @@ export function SearchResultsList({
   if (items.length === 0) {
     return (
       <EmptyState
-        title="No resumes matched this search"
-        description="Try broader keywords or remove a few facet filters to widen the result set."
+        title={t('resumes.searchPage.results.emptyTitle', {
+          defaultValue: 'No resumes matched this search',
+        })}
+        description={t('resumes.searchPage.results.emptyDescription', {
+          defaultValue: 'Try broader keywords or remove a few facet filters to widen the result set.',
+        })}
       />
     )
   }
@@ -138,6 +146,7 @@ export function SearchResultsList({
                 <SnippetCard
                   item={item}
                   expanded={false}
+                  showAiScore={showAiScore}
                   onToggleExpanded={() => onToggleExpanded(item.key)}
                 />
               </div>
@@ -150,13 +159,24 @@ export function SearchResultsList({
             key={item.key}
             item={item}
             expanded={expandedIds.has(item.key)}
+            showAiScore={showAiScore}
             onToggleExpanded={() => onToggleExpanded(item.key)}
           />
         ))
       )}
 
       <div ref={loadMoreRef} className="py-2 text-center text-sm text-muted-foreground">
-        {loadingMore ? 'Loading more resumes...' : hasMore ? 'Scroll for more' : 'End of results'}
+        {loadingMore
+          ? t('resumes.searchPage.results.loadingMore', {
+            defaultValue: 'Loading more resumes...',
+          })
+          : hasMore
+            ? t('resumes.searchPage.results.scrollForMore', {
+              defaultValue: 'Scroll for more',
+            })
+            : t('resumes.searchPage.results.endOfResults', {
+              defaultValue: 'End of results',
+            })}
       </div>
     </div>
   )

--- a/apps/web/src/components/search/SnippetCard.test.tsx
+++ b/apps/web/src/components/search/SnippetCard.test.tsx
@@ -5,6 +5,25 @@ import { SnippetCard } from '@/components/search/SnippetCard'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') {
+        return options
+      }
+
+      const defaultValue =
+        options && typeof options === 'object' && typeof options.defaultValue === 'string'
+          ? options.defaultValue
+          : key
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = options && typeof options === 'object' ? options[token] : undefined
+        return value === undefined || value === null ? '' : String(value)
+      })
+    },
+  }),
+}))
+
 vi.mock('@/components/search/SnippetCardExpanded', () => ({
   SnippetCardExpanded: ({ item }: { item: ResumeSearchResultItem }) => (
     <div>Expanded card for {item.resume.name ?? 'Unnamed resume'}</div>
@@ -116,6 +135,46 @@ describe('SnippetCard', () => {
     await user.click(screen.getByRole('button', { name: /Collapse/i }))
 
     expect(onToggleExpanded).toHaveBeenCalled()
+  })
+
+  it('hides rule scoring when AI score mode is enabled but analysis has not completed', () => {
+    render(
+      <SnippetCard
+        expanded={false}
+        showAiScore
+        item={createResult(2, {
+          scoreSource: 'rule',
+          score: 74,
+          analysis: undefined,
+        })}
+        onToggleExpanded={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('AI pending')).toBeInTheDocument()
+    expect(screen.queryByText('Rule')).not.toBeInTheDocument()
+    expect(screen.queryByText('74')).not.toBeInTheDocument()
+  })
+
+  it('shows an AI pending badge when AI score mode is enabled but no score is available yet', () => {
+    const item = createResult(2, {
+      scoreSource: 'rule',
+      analysis: undefined,
+    })
+    item.score = undefined
+
+    render(
+      <SnippetCard
+        expanded={false}
+        showAiScore
+        item={item}
+        onToggleExpanded={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('AI pending')).toBeInTheDocument()
+    expect(screen.queryByText('Rule')).not.toBeInTheDocument()
+    expect(screen.queryByText('74')).not.toBeInTheDocument()
   })
 
   it('falls back to generic labels and ingest tags when work history and provenance are missing', async () => {

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -1,26 +1,30 @@
 import { ChevronDown, ChevronUp, MapPin, Star } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import { SnippetCardExpanded } from '@/components/search/SnippetCardExpanded'
+import { cn } from '@/lib/utils'
 
 type SnippetCardProps = {
   expanded: boolean
   item: ResumeSearchResultItem
+  showAiScore?: boolean
   onToggleExpanded: () => void
 }
 
-function getPrimaryHeadline(item: ResumeSearchResultItem): string {
+function getPrimaryHeadline(item: ResumeSearchResultItem, fallbackLabel: string): string {
   const latestWorkEntry = item.resume.workHistory?.[0]
   if (latestWorkEntry?.jobTitle) {
     return latestWorkEntry.jobTitle
   }
 
-  return item.resume.jobIntention || 'Profile overview'
+  return item.resume.jobIntention || fallbackLabel
 }
 
-export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardProps) {
+export function SnippetCard({ expanded, item, showAiScore = false, onToggleExpanded }: SnippetCardProps) {
+  const { t } = useTranslation()
   const analysis = item.analysis ?? item.resume.analysis
   const snippetText = item.resume.workHistory?.[0]?.raw || item.resume.selfIntro
   const visibleKeywords = (
@@ -28,6 +32,46 @@ export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardPro
     ?? item.resume.ingestData?.industryTags
     ?? []
   ).slice(0, 3)
+  const score = item.score
+  const hasAiScore = showAiScore && item.scoreSource === 'ai' && typeof score === 'number'
+  const hasRuleScore = !showAiScore && typeof score === 'number'
+  const pendingAiScore = showAiScore && !hasAiScore
+  const scoreClassName =
+    typeof score === 'number'
+      ? score >= 90
+        ? 'bg-emerald-100 text-emerald-700 border-emerald-200'
+        : score >= 70
+          ? 'bg-sky-100 text-sky-700 border-sky-200'
+          : score >= 50
+            ? 'bg-amber-100 text-amber-700 border-amber-200'
+            : 'bg-zinc-100 text-zinc-600 border-zinc-200'
+      : ''
+  const scoreSourceLabel = item.scoreSource === 'ai'
+    ? t('resumes.searchPage.card.ai', { defaultValue: 'AI' })
+    : t('resumes.searchPage.card.rule', { defaultValue: 'Rule' })
+  const scoreSourceClassName =
+    item.scoreSource === 'ai'
+      ? 'bg-sky-600 text-white border-sky-700'
+      : 'bg-amber-500 text-white border-amber-600'
+  const profileOverviewLabel = t('resumes.searchPage.card.profileOverview', {
+    defaultValue: 'Profile overview',
+  })
+  const unnamedResumeLabel = t('resumes.searchPage.card.unnamedResume', {
+    defaultValue: 'Unnamed resume',
+  })
+  const aiSummaryPrefix = t('resumes.searchPage.card.aiSummaryPrefix', {
+    defaultValue: 'AI summary',
+  })
+  const aiPendingLabel = t('resumes.searchPage.card.aiPending', {
+    defaultValue: 'AI pending',
+  })
+  const expandLabel = t('resumes.searchPage.card.expand', {
+    defaultValue: 'Expand',
+  })
+  const collapseLabel = t('resumes.searchPage.card.collapse', {
+    defaultValue: 'Collapse',
+  })
+  const primaryHeadline = getPrimaryHeadline(item, profileOverviewLabel)
 
   return (
     <Card className="overflow-hidden rounded-[1.5rem] border-slate-200 bg-white shadow-[0_18px_50px_-40px_rgba(15,23,42,0.7)]">
@@ -35,8 +79,8 @@ export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardPro
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div className="min-w-0 space-y-3">
             <div className="space-y-1">
-              <div className="truncate text-lg font-semibold text-slate-900">{item.resume.name || 'Unnamed resume'}</div>
-              <div className="truncate text-sm text-slate-600">{getPrimaryHeadline(item)}</div>
+              <div className="truncate text-lg font-semibold text-slate-900">{item.resume.name || unnamedResumeLabel}</div>
+              <div className="truncate text-sm text-slate-600">{primaryHeadline}</div>
             </div>
 
             <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
@@ -60,7 +104,7 @@ export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardPro
 
             {item.scoreSource === 'ai' && analysis?.summary ? (
               <p className="line-clamp-2 text-xs leading-5 text-slate-500">
-                AI summary: {analysis.summary}
+                {aiSummaryPrefix}: {analysis.summary}
               </p>
             ) : null}
 
@@ -74,17 +118,35 @@ export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardPro
           </div>
 
           <div className="flex w-full shrink-0 flex-wrap items-center gap-3 lg:w-auto lg:justify-end">
-            {typeof item.score === 'number' ? (
+            {showAiScore ? (
+              hasAiScore ? (
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                  <div className={cn('rounded-full border px-3 py-1.5 text-sm font-semibold whitespace-nowrap', scoreClassName)}>
+                    <span className="inline-flex items-center gap-1">
+                      <Star className="h-3.5 w-3.5" />
+                      {Math.round(score)}
+                    </span>
+                  </div>
+                  <Badge className={cn('border text-[10px] uppercase tracking-wide', scoreSourceClassName)}>
+                    {scoreSourceLabel}
+                  </Badge>
+                </div>
+              ) : pendingAiScore ? (
+                <Badge variant="outline" className="border-slate-200 bg-slate-50 text-slate-600">
+                  {aiPendingLabel}
+                </Badge>
+              ) : null
+            ) : hasRuleScore ? (
               <div className="flex min-w-0 flex-wrap items-center gap-2">
-                <div className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-sm font-semibold whitespace-nowrap text-amber-700">
+                <div className={cn('rounded-full border px-3 py-1.5 text-sm font-semibold whitespace-nowrap', scoreClassName)}>
                   <span className="inline-flex items-center gap-1">
                     <Star className="h-3.5 w-3.5" />
-                    {Math.round(item.score)}
+                    {Math.round(score)}
                   </span>
                 </div>
                 {item.scoreSource ? (
                   <Badge variant="outline" className="whitespace-nowrap uppercase">
-                    {item.scoreSource === 'ai' ? 'AI' : 'Rule'}
+                    {scoreSourceLabel}
                   </Badge>
                 ) : null}
               </div>
@@ -95,14 +157,14 @@ export function SnippetCard({ expanded, item, onToggleExpanded }: SnippetCardPro
               className="shrink-0 rounded-full whitespace-nowrap"
               onClick={onToggleExpanded}
             >
-              {expanded ? 'Collapse' : 'Expand'}
+              {expanded ? collapseLabel : expandLabel}
               {expanded ? <ChevronUp className="ml-2 h-4 w-4" /> : <ChevronDown className="ml-2 h-4 w-4" />}
             </Button>
           </div>
         </div>
       </div>
 
-      {expanded ? <SnippetCardExpanded item={item} /> : null}
+      {expanded ? <SnippetCardExpanded item={item} showAiScore={showAiScore} /> : null}
     </Card>
   )
 }

--- a/apps/web/src/components/search/SnippetCardExpanded.test.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.test.tsx
@@ -4,6 +4,25 @@ import { SnippetCardExpanded } from '@/components/search/SnippetCardExpanded'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') {
+        return options
+      }
+
+      const defaultValue =
+        options && typeof options === 'object' && typeof options.defaultValue === 'string'
+          ? options.defaultValue
+          : key
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = options && typeof options === 'object' ? options[token] : undefined
+        return value === undefined || value === null ? '' : String(value)
+      })
+    },
+  }),
+}))
+
 const {
   buildWorkHistoryEntryTextMock,
   sanitizeResumeRecordForSurfaceMock,
@@ -173,5 +192,54 @@ describe('SnippetCardExpanded', () => {
     expect(screen.getByText('No education listed')).toBeInTheDocument()
     expect(screen.getByText('Status: new')).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /Open source profile/i })).not.toBeInTheDocument()
+  })
+
+  it('shows AI pending text instead of rule scoring when AI mode is enabled and analysis is missing', () => {
+    render(
+      <SnippetCardExpanded
+        showAiScore
+        item={createResult(3, {
+          scoreSource: 'rule',
+          score: 74,
+          resume: createResume(3, {
+            selfIntro: '',
+            jobIntention: '',
+            workHistory: [],
+          }),
+        })}
+      />
+    )
+
+    expect(screen.getByText('AI analysis pending')).toBeInTheDocument()
+    expect(screen.getByText('AI pending')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'AI analysis is not available for this resume yet. The score will appear after analysis completes.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Rule 74')).not.toBeInTheDocument()
+  })
+
+  it('shows AI pending text when AI mode is enabled and no score has been computed yet', () => {
+    const item = createResult(4, {
+      scoreSource: 'rule',
+      resume: createResume(4, {
+        selfIntro: '',
+        jobIntention: '',
+        workHistory: [],
+      }),
+    })
+    item.score = undefined
+
+    render(
+      <SnippetCardExpanded
+        showAiScore
+        item={item}
+      />
+    )
+
+    expect(screen.getByText('AI analysis pending')).toBeInTheDocument()
+    expect(screen.getByText('AI pending')).toBeInTheDocument()
+    expect(screen.queryByText('Rule')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/search/SnippetCardExpanded.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.tsx
@@ -1,6 +1,7 @@
 import { buildWorkHistoryEntryText, sanitizeResumeRecordForSurface, selectLatestWorkHistory } from '@trends/shared'
 import { BriefcaseBusiness, ExternalLink, MapPin, School, Sparkles } from 'lucide-react'
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Badge } from '@/components/ui/badge'
 import { buttonVariants } from '@/components/ui/button'
 import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
@@ -10,20 +11,91 @@ import type { ResumeSearchResultItem } from '@/components/search/search-types'
 
 type SnippetCardExpandedProps = {
   item: ResumeSearchResultItem
+  showAiScore?: boolean
 }
 
-function formatStatusLabel(value: string): string {
+function formatSnakeCaseLabel(value: string): string {
   return value.replace(/_/g, ' ')
 }
 
-function formatBreakdownLabel(value: string): string {
-  return value.replace(/_/g, ' ')
-}
-
-export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
+export function SnippetCardExpanded({ item, showAiScore = false }: SnippetCardExpandedProps) {
+  const { t } = useTranslation()
   const fieldUsagePolicy = useResumeFieldUsagePolicy()
   const analysis = item.analysis ?? item.resume.analysis
   const hasAiAnalysis = item.scoreSource === 'ai' && Boolean(analysis)
+  const pendingAiAnalysis = showAiScore && !hasAiAnalysis
+  const scoreSourceLabel = hasAiAnalysis
+    ? t('resumes.searchPage.card.aiAnalysis', { defaultValue: 'AI analysis' })
+    : pendingAiAnalysis
+      ? t('resumes.searchPage.card.aiAnalysisPending', { defaultValue: 'AI analysis pending' })
+      : t('resumes.searchPage.card.scoreSource', { defaultValue: 'Score source' })
+  let scoreBadgeLabel: string | null = null
+  if (hasAiAnalysis && typeof item.score === 'number') {
+    scoreBadgeLabel = t('resumes.searchPage.card.aiScoreShort', {
+      score: Math.round(item.score),
+      defaultValue: 'AI {{score}}',
+    })
+  } else if (showAiScore) {
+    scoreBadgeLabel = t('resumes.searchPage.card.aiPending', { defaultValue: 'AI pending' })
+  } else if (typeof item.score === 'number') {
+    scoreBadgeLabel = item.scoreSource === 'ai'
+      ? t('resumes.searchPage.card.aiScoreShort', {
+        score: Math.round(item.score),
+        defaultValue: 'AI {{score}}',
+      })
+      : t('resumes.searchPage.card.ruleScoreShort', {
+        score: Math.round(item.score),
+        defaultValue: 'Rule {{score}}',
+      })
+  }
+  const scoreBadgeClassName = pendingAiAnalysis
+    ? 'whitespace-nowrap uppercase border-slate-200 bg-slate-50 text-slate-600'
+    : 'whitespace-nowrap uppercase'
+  const snapshotLabel = t('resumes.searchPage.card.snapshot', {
+    defaultValue: 'Snapshot',
+  })
+  const recentWorkLabel = t('resumes.searchPage.card.recentWork', {
+    defaultValue: 'Recent work',
+  })
+  const analysisBreakdownLabel = t('resumes.searchPage.card.analysisBreakdown', {
+    defaultValue: 'Analysis Breakdown',
+  })
+  const noDetailedBreakdownLabel = t('resumes.searchPage.card.noDetailedBreakdown', {
+    defaultValue: 'No detailed breakdown available',
+  })
+  const noSummaryLabel = t('resumes.searchPage.card.noSummary', {
+    defaultValue: 'No summary available for this resume yet.',
+  })
+  const noStructuredWorkHistoryLabel = t('resumes.searchPage.card.noStructuredWorkHistory', {
+    defaultValue: 'No structured work history available.',
+  })
+  const noLocationLabel = t('resumes.searchPage.card.noLocation', {
+    defaultValue: 'No location',
+  })
+  const noEducationLabel = t('resumes.searchPage.card.noEducation', {
+    defaultValue: 'No education listed',
+  })
+  const resumeMetadataLabel = t('resumes.searchPage.card.resumeMetadata', {
+    defaultValue: 'Resume metadata',
+  })
+  const signalsLabel = t('resumes.searchPage.card.signals', {
+    defaultValue: 'Signals',
+  })
+  const openSourceProfileLabel = t('resumes.searchPage.card.openSourceProfile', {
+    defaultValue: 'Open source profile',
+  })
+  const aiSummaryUnavailableLabel = t('resumes.searchPage.card.aiSummaryUnavailable', {
+    defaultValue: 'AI analysis is not available for this resume yet. The score will appear after analysis completes.',
+  })
+  const summaryUnavailableLabel = t('resumes.searchPage.card.summaryUnavailable', {
+    defaultValue: 'AI summary is not available for this resume. The current visible score comes from rule scoring only.',
+  })
+  const statusLabel = t('resumes.searchPage.card.status', {
+    defaultValue: 'Status',
+  })
+  const statusValueLabel = t(`resumes.status.options.${item.status}`, {
+    defaultValue: formatSnakeCaseLabel(item.status),
+  })
   const presentationResume = useMemo(
     () => sanitizeResumeRecordForSurface(item.resume, 'presentation', fieldUsagePolicy),
     [fieldUsagePolicy, item.resume]
@@ -44,17 +116,17 @@ export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
         <div className="min-w-0 space-y-4">
           <div className="space-y-2">
             <div className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-              Snapshot
+              {snapshotLabel}
             </div>
             <p className="break-words text-sm leading-6 text-slate-700">
-              {presentationResume.selfIntro?.trim() || presentationResume.jobIntention?.trim() || 'No summary available for this resume yet.'}
+              {presentationResume.selfIntro?.trim() || presentationResume.jobIntention?.trim() || noSummaryLabel}
             </p>
           </div>
 
           <div className="space-y-2">
             <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
               <BriefcaseBusiness className="h-3.5 w-3.5" />
-              Recent work
+              {recentWorkLabel}
             </div>
             <div className="space-y-2">
               {workHistory.length > 0 ? workHistory.map((entry) => (
@@ -63,7 +135,7 @@ export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
                 </div>
               )) : (
                 <div className="rounded-2xl border border-dashed bg-white px-3 py-3 text-sm text-muted-foreground">
-                  No structured work history available.
+                  {noStructuredWorkHistoryLabel}
                 </div>
               )}
             </div>
@@ -74,22 +146,22 @@ export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
           <div className="rounded-3xl border bg-white p-4">
             <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
               <div className="min-w-0 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                {hasAiAnalysis ? 'AI analysis' : 'Score source'}
+                {scoreSourceLabel}
               </div>
-              {typeof item.score === 'number' ? (
-                <Badge variant="outline" className="whitespace-nowrap uppercase">
-                  {item.scoreSource === 'ai' ? `AI ${Math.round(item.score)}` : `Rule ${Math.round(item.score)}`}
+              {scoreBadgeLabel ? (
+                <Badge variant="outline" className={scoreBadgeClassName}>
+                  {scoreBadgeLabel}
                 </Badge>
               ) : null}
             </div>
             {hasAiAnalysis && analysis ? (
               <div className="space-y-4 break-words text-sm text-slate-700">
-                <p className="leading-6">{analysis.summary || 'No AI summary available for this resume yet.'}</p>
+                <p className="leading-6">{analysis.summary || noSummaryLabel}</p>
 
                 {analysis.highlights.length > 0 ? (
                   <div className="space-y-2">
                     <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
-                      Highlights
+                      {t('resumes.searchPage.card.highlights', { defaultValue: 'Highlights' })}
                     </div>
                     <div className="flex flex-wrap gap-2">
                       {analysis.highlights.slice(0, 6).map((highlight) => (
@@ -102,7 +174,7 @@ export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
                 {analysis.concerns && analysis.concerns.length > 0 ? (
                   <div className="space-y-2">
                     <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
-                      Concerns
+                      {t('resumes.searchPage.card.concerns', { defaultValue: 'Concerns' })}
                     </div>
                     <div className="flex flex-wrap gap-2">
                       {analysis.concerns.slice(0, 6).map((concern) => (
@@ -115,7 +187,7 @@ export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
                 {analysis.breakdown && Object.keys(analysis.breakdown).length > 0 ? (
                   <div className="space-y-2">
                     <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
-                      Breakdown
+                      {analysisBreakdownLabel}
                     </div>
                     <div className="grid gap-2 sm:grid-cols-2">
                       {Object.entries(analysis.breakdown).map(([label, value]) => (
@@ -123,44 +195,46 @@ export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
                           key={label}
                           className="flex min-w-0 items-center justify-between gap-3 rounded-2xl border bg-slate-50 px-3 py-2"
                         >
-                          <span className="min-w-0 flex-1 break-words capitalize text-slate-600">{formatBreakdownLabel(label)}</span>
+                          <span className="min-w-0 flex-1 break-words capitalize text-slate-600">{formatSnakeCaseLabel(label)}</span>
                           <span className="shrink-0 font-semibold text-slate-900">{value}</span>
                         </div>
                       ))}
                     </div>
                   </div>
-                ) : null}
+                ) : (
+                  <p className="opacity-70 italic">{noDetailedBreakdownLabel}</p>
+                )}
               </div>
             ) : (
               <p className="text-sm leading-6 text-slate-700">
-                AI summary is not available for this resume. The current visible score comes from rule scoring only.
+                {showAiScore ? aiSummaryUnavailableLabel : summaryUnavailableLabel}
               </p>
             )}
           </div>
 
           <div className="rounded-3xl border bg-white p-4">
             <div className="mb-3 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-              Resume metadata
+              {resumeMetadataLabel}
             </div>
             <div className="space-y-3 text-sm text-slate-700">
               <div className="flex items-start gap-2">
                 <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                <span>{presentationResume.location || 'No location'}</span>
+                <span>{presentationResume.location || noLocationLabel}</span>
               </div>
               <div className="flex items-start gap-2">
                 <School className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                <span>{presentationResume.education || 'No education listed'}</span>
+                <span>{presentationResume.education || noEducationLabel}</span>
               </div>
               <div className="flex items-start gap-2">
                 <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                <span>Status: {formatStatusLabel(item.status)}</span>
+                <span>{statusLabel}: {statusValueLabel}</span>
               </div>
             </div>
           </div>
 
           <div className="rounded-3xl border bg-white p-4">
             <div className="mb-3 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-              Signals
+              {signalsLabel}
             </div>
             <div className="flex flex-wrap gap-2">
               {(item.resume.ingestData?.industryTags ?? []).slice(0, 8).map((tag) => (
@@ -182,7 +256,7 @@ export function SnippetCardExpanded({ item }: SnippetCardExpandedProps) {
               rel="noreferrer"
               className={cn(buttonVariants({ variant: 'outline' }), 'w-full justify-center rounded-full')}
             >
-              Open source profile
+              {openSourceProfileLabel}
               <ExternalLink className="ml-2 h-4 w-4" />
             </a>
           ) : null}

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -441,6 +441,11 @@ describe('useResumeSearchState', () => {
       }),
     ])
 
+    act(() => {
+      result.current.setAiModeEnabled(false)
+    })
+    expect(result.current.aiModeEnabled).toBe(false)
+
     await act(async () => {
       await result.current.applyRecentSearch(result.current.recentSearches[0]!)
     })
@@ -465,6 +470,7 @@ describe('useResumeSearchState', () => {
       },
     })
     expect(result.current.queryInput).toBe(expectedQuery)
+    expect(result.current.aiModeEnabled).toBe(true)
   })
 
   it('loads recent searches from the active session only', () => {
@@ -843,7 +849,7 @@ describe('useResumeSearchState', () => {
     expect(result.current.disableAnalyzeResults).toBe(true)
   })
 
-  it('does not auto-analyze or defer a suppressed run when AI mode is disabled', async () => {
+  it('re-enables AI mode and auto-analyzes when a search is submitted from original mode', async () => {
     Object.assign(parsedStateMock, createParsedState({
       query: 'machine tools',
       keywords: ['machine tools'],
@@ -864,6 +870,8 @@ describe('useResumeSearchState', () => {
       result.current.setAiModeEnabled(false)
     })
 
+    expect(result.current.aiModeEnabled).toBe(false)
+
     await act(async () => {
       result.current.submitSearch('machine tools')
       useUrlSearchStateMock.mockReturnValue({
@@ -877,16 +885,15 @@ describe('useResumeSearchState', () => {
       await Promise.resolve()
     })
 
-    expect(dispatchAnalysisMutationMock).not.toHaveBeenCalled()
-    expect(result.current.disableAnalyzeResults).toBe(true)
-
-    await act(async () => {
-      result.current.setAiModeEnabled(true)
-      await Promise.resolve()
+    expect(result.current.aiModeEnabled).toBe(true)
+    expect(dispatchAnalysisMutationMock).toHaveBeenCalledTimes(1)
+    expect(dispatchAnalysisMutationMock).toHaveBeenCalledWith({
+      keywords: ['machine', 'tools'],
+      location: 'China',
+      promptVersion: CURRENT_PROMPT_VERSION,
+      resumeIds: Array.from({ length: 12 }, (_, index) => `resume-${index + 1}`),
     })
-
     expect(result.current.disableAnalyzeResults).toBe(false)
-    expect(dispatchAnalysisMutationMock).not.toHaveBeenCalled()
   })
 
   it('clears only facet filters while preserving the active search context', () => {

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -801,6 +801,7 @@ export function useResumeSearchState() {
     return `${autoAnalyzeSearchNonce}:${analysisCandidateSignature}`
   }, [analysisCandidateSignature, autoAnalyzeSearchNonce])
   const autoAnalyzeDispatchSignatureRef = useRef('')
+  const pendingForceAnalyzeRef = useRef(false)
   const aiModeStats = useMemo(() => {
     const analyzedResults = results.filter(
       (item) => typeof item.analysis?.score === 'number',
@@ -912,20 +913,16 @@ export function useResumeSearchState() {
       return
     }
 
+    pendingForceAnalyzeRef.current = false
     setPendingAutoAnalyzeContextSignature('')
   }, [aiModeEnabled])
 
   const armAutoAnalyze = useCallback((nextState: UrlSearchState) => {
-    if (!aiModeEnabled) {
-      setPendingAutoAnalyzeContextSignature('')
-      return
-    }
-
     setPendingAutoAnalyzeContextSignature(
       buildSearchContextSignature(nextState),
     )
     setAutoAnalyzeSearchNonce((current) => current + 1)
-  }, [aiModeEnabled])
+  }, [])
 
   const submitSearch = useCallback(
     (
@@ -943,6 +940,8 @@ export function useResumeSearchState() {
         filters: clearSortFilters(parsedState.filters),
       })
 
+      setAiModeEnabled(true)
+      pendingForceAnalyzeRef.current = true
       syncToUrl(nextState)
       armAutoAnalyze(nextState)
     },
@@ -952,6 +951,7 @@ export function useResumeSearchState() {
   const clearSearch = useCallback(() => {
     setQueryInput('')
     setPendingAutoAnalyzeContextSignature('')
+    pendingForceAnalyzeRef.current = false
     syncToUrl(
       buildUrlState(parsedState, {
         query: undefined,
@@ -987,6 +987,8 @@ export function useResumeSearchState() {
         filters: clearSortFilters(item.filters ?? {}),
       }
 
+      setAiModeEnabled(true)
+      pendingForceAnalyzeRef.current = true
       syncToUrl(nextState)
       armAutoAnalyze(nextState)
     },
@@ -1301,6 +1303,7 @@ export function useResumeSearchState() {
     }
 
     autoAnalyzeDispatchSignatureRef.current = autoAnalyzeSignature
+    pendingForceAnalyzeRef.current = false
     void analyzeResults()
   }, [
     analyzeResults,
@@ -1314,6 +1317,34 @@ export function useResumeSearchState() {
     loading,
     currentSearchContextSignature,
     pendingAutoAnalyzeContextSignature,
+  ])
+
+  // Force-analyze fallback: guarantees quickstart / recent search triggers analysis
+  // even when the signature-based auto-analyze effect misses due to timing or
+  // round-trip normalization differences.
+  useEffect(() => {
+    if (
+      !pendingForceAnalyzeRef.current ||
+      isLanding ||
+      loading ||
+      analyzingResults ||
+      hasActiveAnalysisTask ||
+      analysisCandidateResumeIds.length === 0
+    ) {
+      return
+    }
+
+    pendingForceAnalyzeRef.current = false
+    autoAnalyzeDispatchSignatureRef.current = autoAnalyzeSignature
+    void analyzeResults()
+  }, [
+    analyzeResults,
+    analysisCandidateResumeIds.length,
+    autoAnalyzeSignature,
+    analyzingResults,
+    hasActiveAnalysisTask,
+    isLanding,
+    loading,
   ])
 
   return {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -273,6 +273,94 @@
       "extractedAt": "Updated At",
       "profileLink": "View Original Profile",
       "close": "Close"
+    },
+    "searchPage": {
+      "banner": {
+        "title": "Search Profiles still exist, but the primary resume route is now search-first.",
+        "description": "Use this page for fast keyword review. Use Search Profiles when you need landing quick starts, scheduled collectors, and JD-driven setup in one place.",
+        "openProfiles": "Open Search Profiles",
+        "dismiss": "Dismiss migration banner"
+      },
+      "hero": {
+        "quickStart": "Quick Start",
+        "hotTags": "Hot Tags",
+        "recentSearches": "Recent searches",
+        "loadingRecentSearches": "Loading recent searches...",
+        "noSavedSearches": "No saved searches yet. Recent searches will appear here after you start exploring."
+      },
+      "searchBar": {
+        "placeholder": "Search resumes by keywords, brands, roles, or locations",
+        "search": "Search",
+        "searching": "Searching...",
+        "recentSearches": "Recent searches",
+        "pasteJobDescription": "Paste job description",
+        "clearSearch": "Clear search"
+      },
+      "header": {
+        "results": "{{count}} results",
+        "resultsWithQuery": "{{count}} results for \"{{query}}\"",
+        "sort": "Sort",
+        "sortResults": "Sort results",
+        "sortOptions": {
+          "aiScore": "AI score",
+          "newest": "Newest",
+          "experience": "Experience"
+        },
+        "exportFormat": "Export format",
+        "exporting": "Exporting...",
+        "export": "Export {{count}}"
+      },
+      "results": {
+        "emptyTitle": "No resumes matched this search",
+        "emptyDescription": "Try broader keywords or remove a few facet filters to widen the result set.",
+        "loadingMore": "Loading more resumes...",
+        "scrollForMore": "Scroll for more",
+        "endOfResults": "End of results"
+      },
+      "analysis": {
+        "title": "Resume AI analysis",
+        "description": "Generate per-resume AI summaries and breakdowns for the loaded search results.",
+        "analyzing": "Analyzing...",
+        "analyzeLoaded": "Analyze loaded {{count}}",
+        "analyzeLoadedResults": "Analyze loaded results"
+      },
+      "aiSummary": {
+        "title": "AI result summary",
+        "noSummary": "No summary is available for the current search yet.",
+        "generatedJustNow": "Generated just now",
+        "generatedOneMinuteAgo": "Generated 1 minute ago",
+        "generatedMinutesAgo": "Generated {{count}} minutes ago"
+      },
+      "card": {
+        "expand": "Expand",
+        "collapse": "Collapse",
+        "aiPending": "AI pending",
+        "aiAnalysis": "AI analysis",
+        "aiAnalysisPending": "AI analysis pending",
+        "analysisBreakdown": "Analysis Breakdown",
+        "noDetailedBreakdown": "No detailed breakdown available",
+        "noSummary": "No summary available for this resume yet.",
+        "noStructuredWorkHistory": "No structured work history available.",
+        "noLocation": "No location",
+        "noEducation": "No education listed",
+        "resumeMetadata": "Resume metadata",
+        "signals": "Signals",
+        "openSourceProfile": "Open source profile",
+        "summaryUnavailable": "AI summary is not available for this resume. The current visible score comes from rule scoring only.",
+        "aiSummaryUnavailable": "AI analysis is not available for this resume yet. The score will appear after analysis completes.",
+        "profileOverview": "Profile overview",
+        "unnamedResume": "Unnamed resume",
+        "aiSummaryPrefix": "AI summary",
+        "ai": "AI",
+        "rule": "Rule",
+        "status": "Status",
+        "highlights": "Highlights",
+        "concerns": "Concerns",
+        "scoreSource": "Score source",
+        "aiScoreShort": "AI {{score}}",
+        "ruleScoreShort": "Rule {{score}}",
+        "aiScoreLabel": "AI score"
+      }
     }
   },
   "aiTasks": {

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -273,6 +273,94 @@
       "profileLink": "查看原始简历",
       "close": "关闭"
     },
+    "searchPage": {
+      "banner": {
+        "title": "Search Profiles 仍然存在，但主简历入口现在以搜索优先。",
+        "description": "本页用于快速关键词审阅。需要落地页快速开始、定时采集或一站式 JD 配置时，请使用 Search Profiles。",
+        "openProfiles": "打开 Search Profiles",
+        "dismiss": "关闭迁移提示"
+      },
+      "hero": {
+        "quickStart": "快速开始",
+        "hotTags": "热门标签",
+        "recentSearches": "最近搜索",
+        "loadingRecentSearches": "正在加载最近搜索...",
+        "noSavedSearches": "暂无已保存搜索。开始浏览后，最近搜索会显示在这里。"
+      },
+      "searchBar": {
+        "placeholder": "按关键词、品牌、岗位或地区搜索简历",
+        "search": "搜索",
+        "searching": "搜索中...",
+        "recentSearches": "最近搜索",
+        "pasteJobDescription": "粘贴职位描述",
+        "clearSearch": "清除搜索"
+      },
+      "header": {
+        "results": "{{count}} 条结果",
+        "resultsWithQuery": "{{count}} 条结果，查询“{{query}}”",
+        "sort": "排序",
+        "sortResults": "排序结果",
+        "sortOptions": {
+          "aiScore": "AI 分",
+          "newest": "最新",
+          "experience": "经验"
+        },
+        "exportFormat": "导出格式",
+        "exporting": "导出中...",
+        "export": "导出 {{count}} 条"
+      },
+      "results": {
+        "emptyTitle": "没有匹配到简历",
+        "emptyDescription": "可以尝试更宽泛的关键词，或者移除部分筛选条件。",
+        "loadingMore": "正在加载更多简历...",
+        "scrollForMore": "向下滚动查看更多",
+        "endOfResults": "已到底部"
+      },
+      "analysis": {
+        "title": "简历 AI 分析",
+        "description": "为当前加载的搜索结果生成逐份简历的 AI 摘要与拆解。",
+        "analyzing": "分析中...",
+        "analyzeLoaded": "分析已加载的 {{count}} 份",
+        "analyzeLoadedResults": "分析已加载结果"
+      },
+      "aiSummary": {
+        "title": "AI 结果摘要",
+        "noSummary": "当前搜索暂时没有可用摘要。",
+        "generatedJustNow": "刚刚生成",
+        "generatedOneMinuteAgo": "1 分钟前生成",
+        "generatedMinutesAgo": "{{count}} 分钟前生成"
+      },
+      "card": {
+        "expand": "展开",
+        "collapse": "收起",
+        "aiPending": "AI 待处理",
+        "aiAnalysis": "AI 分析",
+        "aiAnalysisPending": "AI 分析待处理",
+        "analysisBreakdown": "分析拆解",
+        "noDetailedBreakdown": "暂无详细拆解",
+        "noSummary": "该简历暂无摘要。",
+        "noStructuredWorkHistory": "暂无结构化工作经历。",
+        "noLocation": "暂无地区",
+        "noEducation": "暂无学历",
+        "resumeMetadata": "简历元数据",
+        "signals": "信号",
+        "openSourceProfile": "打开原始简历",
+        "summaryUnavailable": "该简历暂无 AI 摘要。当前可见分数来自规则评分。",
+        "aiSummaryUnavailable": "该简历尚未生成 AI 分析，分析完成后会显示分数。",
+        "profileOverview": "概览",
+        "unnamedResume": "未命名简历",
+        "aiSummaryPrefix": "AI 摘要",
+        "ai": "AI",
+        "rule": "规则",
+        "status": "状态",
+        "highlights": "亮点",
+        "concerns": "关注点",
+        "scoreSource": "分数来源",
+        "aiScoreShort": "AI {{score}}",
+        "ruleScoreShort": "规则 {{score}}",
+        "aiScoreLabel": "AI 分数"
+      }
+    },
     "analyzeAll": "AI模式"
   },
   "aiTasks": {

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -273,6 +273,94 @@
       "profileLink": "查看原始簡歷",
       "close": "關閉"
     },
+    "searchPage": {
+      "banner": {
+        "title": "Search Profiles 仍然存在，但主簡歷入口現在以搜尋優先。",
+        "description": "本頁用於快速關鍵詞審閱。需要落地頁快速開始、定時採集或一站式 JD 設定時，請使用 Search Profiles。",
+        "openProfiles": "開啟 Search Profiles",
+        "dismiss": "關閉遷移提示"
+      },
+      "hero": {
+        "quickStart": "快速開始",
+        "hotTags": "熱門標籤",
+        "recentSearches": "最近搜尋",
+        "loadingRecentSearches": "正在載入最近搜尋...",
+        "noSavedSearches": "目前尚無已保存搜尋。開始瀏覽後，最近搜尋會顯示在這裡。"
+      },
+      "searchBar": {
+        "placeholder": "按關鍵詞、品牌、職位或地區搜尋簡歷",
+        "search": "搜尋",
+        "searching": "搜尋中...",
+        "recentSearches": "最近搜尋",
+        "pasteJobDescription": "貼上職位描述",
+        "clearSearch": "清除搜尋"
+      },
+      "header": {
+        "results": "{{count}} 條結果",
+        "resultsWithQuery": "{{count}} 條結果，查詢「{{query}}」",
+        "sort": "排序",
+        "sortResults": "排序結果",
+        "sortOptions": {
+          "aiScore": "AI 分",
+          "newest": "最新",
+          "experience": "經驗"
+        },
+        "exportFormat": "匯出格式",
+        "exporting": "匯出中...",
+        "export": "匯出 {{count}} 條"
+      },
+      "results": {
+        "emptyTitle": "沒有符合的簡歷",
+        "emptyDescription": "可以嘗試更寬泛的關鍵詞，或移除部分篩選條件。",
+        "loadingMore": "正在載入更多簡歷...",
+        "scrollForMore": "向下捲動查看更多",
+        "endOfResults": "已到底部"
+      },
+      "analysis": {
+        "title": "簡歷 AI 分析",
+        "description": "為目前載入的搜尋結果生成逐份簡歷的 AI 摘要與拆解。",
+        "analyzing": "分析中...",
+        "analyzeLoaded": "分析已載入的 {{count}} 份",
+        "analyzeLoadedResults": "分析已載入結果"
+      },
+      "aiSummary": {
+        "title": "AI 結果摘要",
+        "noSummary": "目前搜尋暫時沒有可用摘要。",
+        "generatedJustNow": "剛剛生成",
+        "generatedOneMinuteAgo": "1 分鐘前生成",
+        "generatedMinutesAgo": "{{count}} 分鐘前生成"
+      },
+      "card": {
+        "expand": "展開",
+        "collapse": "收起",
+        "aiPending": "AI 待處理",
+        "aiAnalysis": "AI 分析",
+        "aiAnalysisPending": "AI 分析待處理",
+        "analysisBreakdown": "分析拆解",
+        "noDetailedBreakdown": "暫無詳細拆解",
+        "noSummary": "此簡歷暫無摘要。",
+        "noStructuredWorkHistory": "暫無結構化工作經歷。",
+        "noLocation": "暫無地區",
+        "noEducation": "暫無學歷",
+        "resumeMetadata": "簡歷中繼資料",
+        "signals": "信號",
+        "openSourceProfile": "開啟原始簡歷",
+        "summaryUnavailable": "此簡歷暫無 AI 摘要。目前顯示的分數來自規則評分。",
+        "aiSummaryUnavailable": "此簡歷尚未生成 AI 分析，分析完成後會顯示分數。",
+        "profileOverview": "概覽",
+        "unnamedResume": "未命名簡歷",
+        "aiSummaryPrefix": "AI 摘要",
+        "ai": "AI",
+        "rule": "規則",
+        "status": "狀態",
+        "highlights": "亮點",
+        "concerns": "關注點",
+        "scoreSource": "分數來源",
+        "aiScoreShort": "AI {{score}}",
+        "ruleScoreShort": "規則 {{score}}",
+        "aiScoreLabel": "AI 分數"
+      }
+    },
     "analyzeAll": "AI模式"
   },
   "aiTasks": {

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -7,6 +7,25 @@ import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 import type { UrlSearchState } from '@/hooks/useUrlSearchState'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') {
+        return options
+      }
+
+      const defaultValue =
+        options && typeof options === 'object' && typeof options.defaultValue === 'string'
+          ? options.defaultValue
+          : key
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = options && typeof options === 'object' ? options[token] : undefined
+        return value === undefined || value === null ? '' : String(value)
+      })
+    },
+  }),
+}))
+
 const {
   useIndustryKeywordsMock,
   useAiSearchSummaryMock,
@@ -214,6 +233,7 @@ vi.mock('@/components/search/SearchResultsList', () => ({
     items,
     loading,
     loadingMore,
+    showAiScore,
     onLoadMore,
     onToggleExpanded,
   }: {
@@ -222,14 +242,15 @@ vi.mock('@/components/search/SearchResultsList', () => ({
     items: ResumeSearchResultItem[]
     loading?: boolean
     loadingMore?: boolean
+    showAiScore?: boolean
     onLoadMore: () => void
     onToggleExpanded: (key: string) => void
   }) => (
     <div>
       <div>
         Results List {items.length} hasMore:{String(hasMore)} loading:
-        {String(loading)} loadingMore:{String(loadingMore)} expanded:
-        {Array.from(expandedIds).join('|') || 'none'}
+        {String(loading)} loadingMore:{String(loadingMore)} showAiScore:
+        {String(showAiScore)} expanded:{Array.from(expandedIds).join('|') || 'none'}
       </div>
       {items[0] ? (
         <button type="button" onClick={() => onToggleExpanded(items[0].key)}>
@@ -540,7 +561,7 @@ describe('ResumeSearchPage', () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        'Results List 2 hasMore:false loading:false loadingMore:false expanded:none',
+        'Results List 2 hasMore:false loading:false loadingMore:false showAiScore:true expanded:none',
       ),
     ).toBeInTheDocument()
     expect(
@@ -623,7 +644,7 @@ describe('ResumeSearchPage', () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        'Results List 2 hasMore:true loading:false loadingMore:true expanded:none',
+        'Results List 2 hasMore:true loading:false loadingMore:true showAiScore:true expanded:none',
       ),
     ).toBeInTheDocument()
     expect(useAiSearchSummaryMock).toHaveBeenCalledWith(
@@ -639,7 +660,7 @@ describe('ResumeSearchPage', () => {
     )
     expect(
       screen.getByText(
-        'Results List 2 hasMore:true loading:false loadingMore:true expanded:resume-1',
+        'Results List 2 hasMore:true loading:false loadingMore:true showAiScore:true expanded:resume-1',
       ),
     ).toBeInTheDocument()
 
@@ -648,14 +669,14 @@ describe('ResumeSearchPage', () => {
     )
     expect(
       screen.getByText(
-        'Results List 2 hasMore:true loading:false loadingMore:true expanded:resume-2',
+        'Results List 2 hasMore:true loading:false loadingMore:true showAiScore:true expanded:resume-2',
       ),
     ).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Apply Header JD' }))
     expect(
       screen.getByText(
-        'Results List 2 hasMore:true loading:false loadingMore:true expanded:none',
+        'Results List 2 hasMore:true loading:false loadingMore:true showAiScore:true expanded:none',
       ),
     ).toBeInTheDocument()
 

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -1,6 +1,7 @@
 import { formatKeywordQuery, parseKeywordQuery } from '@trends/shared'
 import { RefreshCw } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { AnalysisTaskMonitor } from '@/components/AnalysisTaskMonitor'
 import { ModeToggle } from '@/components/ModeToggle'
 import { AiSummaryPanel } from '@/components/search/AiSummaryPanel'
@@ -17,6 +18,7 @@ import { useIndustryKeywords } from '@/hooks/useIndustryKeywords'
 import { useResumeSearchState } from '@/hooks/useResumeSearchState'
 
 export function ResumeSearchPage() {
+  const { t } = useTranslation()
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [filtersOpen, setFiltersOpen] = useState(false)
   const { hotKeywords, quickStartProfiles } = useIndustryKeywords()
@@ -194,6 +196,22 @@ export function ResumeSearchPage() {
       toggleTag,
     ],
   )
+  const analysisTitle = t('resumes.searchPage.analysis.title', {
+    defaultValue: 'Resume AI analysis',
+  })
+  const analysisDescription = t('resumes.searchPage.analysis.description', {
+    defaultValue: 'Generate per-resume AI summaries and breakdowns for the loaded search results.',
+  })
+  const analyzingLabel = t('resumes.searchPage.analysis.analyzing', {
+    defaultValue: 'Analyzing...',
+  })
+  const analyzeLoadedLabel = t('resumes.searchPage.analysis.analyzeLoaded', {
+    count: analysisCandidateCount,
+    defaultValue: 'Analyze loaded {{count}}',
+  })
+  const analyzeLoadedResultsLabel = t('resumes.searchPage.analysis.analyzeLoadedResults', {
+    defaultValue: 'Analyze loaded results',
+  })
 
   return (
     <div className="space-y-6">
@@ -259,12 +277,12 @@ export function ResumeSearchPage() {
 
             <div className="min-w-0 flex-1 space-y-4">
               <div className="flex flex-wrap items-center justify-between gap-3 rounded-[1.5rem] border bg-white/80 px-4 py-3 shadow-sm">
-                <div className="min-w-0">
+              <div className="min-w-0">
                   <div className="text-sm font-medium text-slate-900">
-                    Resume AI analysis
+                    {analysisTitle}
                   </div>
                   <p className="text-sm text-slate-600">
-                    Generate per-resume AI summaries and breakdowns for the loaded search results.
+                    {analysisDescription}
                   </p>
                 </div>
                 <div className="flex flex-wrap items-center justify-end gap-2">
@@ -285,14 +303,14 @@ export function ResumeSearchPage() {
                     {analyzingResults || hasActiveAnalysisTask ? (
                       <>
                         <RefreshCw className="h-4 w-4 animate-spin" />
-                        Analyzing...
+                        {analyzingLabel}
                       </>
                     ) : (
                       <>
                         <RefreshCw className="h-4 w-4" />
                         {analysisCandidateCount > 0
-                          ? `Analyze loaded ${analysisCandidateCount}`
-                          : 'Analyze loaded results'}
+                          ? analyzeLoadedLabel
+                          : analyzeLoadedResultsLabel}
                       </>
                     )}
                   </Button>
@@ -312,6 +330,7 @@ export function ResumeSearchPage() {
                 items={filteredResults}
                 loading={loading}
                 loadingMore={loadingMore}
+                showAiScore={aiModeEnabled}
                 onLoadMore={loadMore}
                 onToggleExpanded={handleToggleExpanded}
               />


### PR DESCRIPTION
## Summary
- Add `pendingForceAnalyzeRef` fallback to guarantee AI analysis dispatches after quickstart and recent search clicks
- The existing signature-based auto-analyze effect can miss due to timing or URL round-trip normalization differences
- Both effects coordinate via shared refs to prevent double-dispatch

## Test plan
- [x] `make check` passes (typecheck + lint + governance)
- [x] All 547 tests pass (`npm test`)
- [ ] Click quickstart on landing page → results load → AI analysis auto-dispatches
- [ ] Click recent search → results load → AI analysis auto-dispatches
- [ ] Toggle AI mode OFF → click quickstart → analysis does NOT dispatch
- [ ] Toggle AI mode ON → manual "Analyze" button works