### PR TITLE
feat: enrich 51job resumes and localize detail UI

### DIFF
--- a/apps/api/src/routes/config.test.ts
+++ b/apps/api/src/routes/config.test.ts
@@ -340,6 +340,22 @@ describe('config route workspace access', () => {
     expect(payload.metadata.capabilities.some((item: { id: string }) => item.id === 'cli-system-inspect')).toBe(true)
   })
 
+  it('loads resume display limits payload', async () => {
+    const app = createTestApp()
+    const response = await app.request('/api/config/resume-display-limits', {
+      headers: {
+        'X-Workspace-Slug': 'hr',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      success: true,
+      latestWorkHistoryLimit: 3,
+      source: 'packages/shared/src/work-history-evidence.ts',
+    })
+  })
+
   it('loads config source detail by key', async () => {
     const getSourceSpy = vi.spyOn(configSourceInspector, 'getSource').mockReturnValue({
       key: 'resume-skills',

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -11,6 +11,7 @@ import {
   INGEST_BRAND_CONTEXT_LABELS,
   INGEST_BRAND_ROLE_LABELS,
   INGEST_BRAND_SOURCE_LABELS,
+  LATEST_WORK_HISTORY_LIMIT,
   SETTINGS_NAV_ITEMS,
   SYSTEM_SETTINGS_NAV_ITEMS,
   SYSTEM_CAPABILITY_DESCRIPTORS,
@@ -189,6 +190,11 @@ const SystemMetadataSchema = z.object({
     keywordVariantBody: z.string(),
   }),
   capabilities: z.array(CapabilityDescriptorSchema),
+});
+const ResumeDisplayLimitsSchema = z.object({
+  success: z.literal(true),
+  latestWorkHistoryLimit: z.number().int().nonnegative(),
+  source: z.string(),
 });
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -724,6 +730,24 @@ app.get("/system-metadata", async (c) => {
   } catch (error) {
     console.error("Failed to load system metadata", error);
     return c.json({ success: false as const, error: "Failed to load system metadata" }, 500);
+  }
+});
+
+app.get("/resume-display-limits", async (c) => {
+  try {
+    const payload = {
+      success: true as const,
+      latestWorkHistoryLimit: LATEST_WORK_HISTORY_LIMIT,
+      source: "packages/shared/src/work-history-evidence.ts",
+    };
+    const parsed = ResumeDisplayLimitsSchema.safeParse(payload);
+    if (!parsed.success) {
+      return c.json({ success: false as const, error: "Invalid resume display limits response" }, 500);
+    }
+    return c.json(parsed.data, 200);
+  } catch (error) {
+    console.error("Failed to load resume display limits", error);
+    return c.json({ success: false as const, error: "Failed to load resume display limits" }, 500);
   }
 });
 

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -119,6 +119,7 @@ export const ResumeImportRestoreStateSchema = z
 
 const ResumeStructuredDetailsShape = {
   profileEducation: z.array(ResumeImportProfileEducationSchema).optional(),
+  projectExperience: z.array(ResumeImportWorkHistorySchema).optional(),
   skills: z.array(z.union([z.string(), ResumeImportSkillDetailSchema])).optional(),
   languages: z.array(z.union([z.string(), ResumeImportLanguageDetailSchema])).optional(),
   licences: z.array(z.union([z.string(), ResumeImportLicenceDetailSchema])).optional(),
@@ -177,6 +178,7 @@ export const ResumeItemSchema = z
   .object({
     name: z.string().openapi({ example: "Alex Chen" }),
     profileUrl: z.string().openapi({ example: "https://hr.job5156.com/resume/view/123" }),
+    source: z.string().optional().openapi({ example: "hr.job5156.com" }),
     activityStatus: z.string().openapi({ example: "Active today" }),
     age: z.string().openapi({ example: "28" }),
     experience: z.string().openapi({ example: "5 years" }),
@@ -265,6 +267,7 @@ export const ResumeImportItemSchema = z
     profileId: z.union([z.string(), z.number()]).pipe(z.coerce.string()).optional(),
     profileType: z.string().optional(),
     externalId: z.string().optional(),
+    source: z.string().optional().openapi({ example: "hr.job5156.com" }),
     sourceHost: z.string().optional().openapi({ example: "hr.job5156.com" }),
     tags: z.array(z.string()).optional().openapi({ example: ["sales", "job5156"] }),
     name: z.string().openapi({ example: "Alex Chen" }),

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -137,6 +137,7 @@ function toResumeItem(value: unknown): ResumeItem | null {
   return {
     name: toStringValue(value.name),
     profileUrl: toStringValue(value.profileUrl),
+    source: toStringValue(value.source) || undefined,
     activityStatus: toStringValue(value.activityStatus),
     age: toStringValue(value.age),
     experience: toStringValue(value.experience),
@@ -147,6 +148,7 @@ function toResumeItem(value: unknown): ResumeItem | null {
     jobIntention: toStringValue(value.jobIntention),
     expectedSalary: toStringValue(value.expectedSalary),
     workHistory: toWorkHistory(value.workHistory),
+    projectExperience: toWorkHistory(value.projectExperience),
     extractedAt: toStringValue(value.extractedAt),
     resumeId: toStringValue(value.resumeId) || undefined,
     perUserId: toOptionalId(value.perUserId),
@@ -162,11 +164,13 @@ function hasResumeSignal(item: ResumeItem): boolean {
     || item.jobIntention
     || item.selfIntro
     || item.profileUrl
+    || item.source
     || item.resumeId
     || item.perUserId
     || item.profileId
     || item.externalId
     || item.workHistory.length > 0
+    || item.projectExperience?.length
   );
 }
 
@@ -249,12 +253,14 @@ function getLatestWorkHistory(workHistory: ResumeWorkHistoryItem[] | undefined):
 function createSearchText(item: ResumeItem): string {
   const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
   const latestWorkHistory = getLatestWorkHistory(item.workHistory);
+  const latestProjectExperience = getLatestWorkHistory(item.projectExperience ?? []);
   const parts = [
     item.name,
     item.education,
     locationText,
     item.expectedSalary,
     ...latestWorkHistory.map((entry) => buildWorkHistoryEntryText(entry)),
+    ...latestProjectExperience.map((entry) => buildWorkHistoryEntryText(entry)),
   ];
 
   return normalizeText(parts.join(" "));

--- a/apps/api/src/services/resume-index.ts
+++ b/apps/api/src/services/resume-index.ts
@@ -95,12 +95,14 @@ function extractCompanies(workHistory: ResumeWorkHistoryItem[]): string[] {
 function createSearchText(item: ResumeItem): string {
   const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
   const latestWorkHistory = getLatestWorkHistory(item.workHistory);
+  const latestProjectExperience = getLatestWorkHistory(item.projectExperience ?? []);
   const parts = [
     item.name,
     item.education,
     locationText,
     item.expectedSalary,
     ...latestWorkHistory.map((entry) => buildWorkHistoryEntryText(entry)),
+    ...latestProjectExperience.map((entry) => buildWorkHistoryEntryText(entry)),
   ];
 
   return normalizeText(parts.join(" "));

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -247,12 +247,14 @@ function countOccurrences(haystack: string, needle: string): number {
 function buildSearchText(item: ResumeItem): string {
   const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
   const latestWorkHistory = selectLatestWorkHistory(item.workHistory);
+  const latestProjectExperience = selectLatestWorkHistory(item.projectExperience ?? []);
   const parts = [
     item.name,
     item.education,
     locationText,
     item.expectedSalary,
     ...latestWorkHistory.map((entry) => buildWorkHistoryEntryText(entry)),
+    ...latestProjectExperience.map((entry) => buildWorkHistoryEntryText(entry)),
   ];
   return parts.join(" ").toLowerCase();
 }

--- a/apps/api/src/types/resume.ts
+++ b/apps/api/src/types/resume.ts
@@ -63,6 +63,7 @@ export type ResumeIngestData = {
 export type ResumeItem = {
   name: string;
   profileUrl: string;
+  source?: string;
   activityStatus: string;
   age: string;
   experience: string;
@@ -73,6 +74,7 @@ export type ResumeItem = {
   jobIntention: string;
   expectedSalary: string;
   workHistory: ResumeWorkHistoryItem[];
+  projectExperience?: ResumeWorkHistoryItem[];
   profileEducation?: ResumeProfileEducationItem[];
   skills?: Array<string | ResumeSkillDetail>;
   languages?: Array<string | ResumeLanguageDetail>;

--- a/apps/browser-extension/background.js
+++ b/apps/browser-extension/background.js
@@ -174,6 +174,75 @@ function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function getRuntimeLastError() {
+    return Reflect.get(chrome.runtime, 'lastError');
+}
+
+function createTab(url, active = false) {
+    return new Promise((resolve, reject) => {
+        chrome.tabs.create({ url, active }, (tab) => {
+            const lastError = getRuntimeLastError();
+            if (lastError) {
+                reject(new Error(lastError.message || String(lastError)));
+                return;
+            }
+            resolve(tab);
+        });
+    });
+}
+
+function removeTab(tabId) {
+    return new Promise((resolve) => {
+        if (!Number.isFinite(tabId)) {
+            resolve();
+            return;
+        }
+        chrome.tabs.remove(tabId, () => {
+            resolve();
+        });
+    });
+}
+
+function sendMessageToTab(tabId, message) {
+    return new Promise((resolve, reject) => {
+        chrome.tabs.sendMessage(tabId, message, undefined, (response) => {
+            const lastError = getRuntimeLastError();
+            if (lastError) {
+                reject(new Error(lastError.message || String(lastError)));
+                return;
+            }
+            resolve(response);
+        });
+    });
+}
+
+async function waitForJob51ResumeDetail(tabId, timeoutMs = 20000) {
+    const deadline = Date.now() + timeoutMs;
+    let lastError = null;
+
+    while (Date.now() < deadline) {
+        try {
+            const response = await sendMessageToTab(tabId, {
+                action: 'extractCurrentPage',
+            });
+            if (response?.success && Array.isArray(response.data) && response.data.length > 0) {
+                return response.data;
+            }
+            lastError = null;
+        } catch (error) {
+            lastError = error;
+        }
+
+        await sleep(1000);
+    }
+
+    if (lastError) {
+        throw lastError;
+    }
+
+    throw new Error('Timed out waiting for Job51 resume detail');
+}
+
 function storageLocalGet(defaults) {
     return new Promise((resolve) => {
         chrome.storage.local.get(defaults, (items) => resolve(items || {}));
@@ -274,6 +343,33 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         })();
 
         return true; // Keep channel open for async response
+    }
+
+    if (request.action === 'collectJob51ResumeDetail') {
+        (async () => {
+            const resumeId = typeof request.resumeId === 'string' ? request.resumeId.trim() : '';
+            if (!resumeId) {
+                sendResponse({ success: false, error: 'Missing resume id' });
+                return;
+            }
+
+            const detailUrl = `https://ehire.51job.com/Revision/talent/resume/detail?contentType=&resumeId=${encodeURIComponent(resumeId)}`;
+            let tab = null;
+            try {
+                tab = await createTab(detailUrl, false);
+                const data = await waitForJob51ResumeDetail(tab.id);
+                sendResponse({ success: true, data });
+            } catch (error) {
+                console.error('🎯 [BG] Failed to collect Job51 resume detail:', error);
+                sendResponse({ success: false, error: error.message });
+            } finally {
+                if (tab?.id !== undefined && tab?.id !== null) {
+                    await removeTab(tab.id);
+                }
+            }
+        })();
+
+        return true;
     }
 
     if (request.action === 'diagnoseDownloads') {

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -80,6 +80,9 @@ const PAGE_BRIDGE_REQUEST_ATTR = "data-tr-resume-bridge-request";
 const PAGE_BRIDGE_RESPONSE_ATTR = "data-tr-resume-bridge-response";
 const JOB5156_DETAIL_FETCH_TIMEOUT_MS = 5000;
 const JOB5156_DETAIL_FETCH_CONCURRENCY = 5;
+const JOB51_DETAIL_FETCH_TIMEOUT_MS = 8000;
+const JOB51_DETAIL_FETCH_CONCURRENCY = 1;
+const JOB51_DETAIL_FETCH_DELAY_MS = 20000;
 const DEFAULT_SEEK_PAGE_SIZE = 20;
 const LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY = "latestAutoSyncSummaries";
 
@@ -87,6 +90,8 @@ const apiSnapshot = {
   searchRows: null,
   job51SearchRows: null,
   job51Total: null,
+  job51AuthContext: null,
+  job51DetailPayload: null,
   attachInfo: null,
   chatInfo: null,
   insightInfo: null,
@@ -429,11 +434,60 @@ function isJob5156DetailPage() {
   );
 }
 
+function isJob51DetailPage() {
+  return (
+    getCurrentSourceKey() === SOURCE_KEYS.JOB51 &&
+    /\/Revision\/talent\/resume\/detail/i.test(window.location.pathname)
+  );
+}
+
+function isJob51DetailReady() {
+  return isJob51DetailPage() && !!apiSnapshot.job51DetailPayload;
+}
+
+function normalizeJob51AuthContext(requestHeaders, request) {
+  const headers =
+    requestHeaders && typeof requestHeaders === "object" ? requestHeaders : {};
+  const requestBody = request && typeof request === "object" ? request : {};
+  const pick = (...keys) => {
+    for (const key of keys) {
+      const headerValue = headers[key] ?? headers[key.toLowerCase()];
+      if (typeof headerValue === "string" && headerValue.trim()) {
+        return headerValue.trim();
+      }
+      const requestValue = requestBody[key];
+      if (typeof requestValue === "string" && requestValue.trim()) {
+        return requestValue.trim();
+      }
+    }
+    return "";
+  };
+
+  const accesstoken = pick("accesstoken", "access-token", "accessToken");
+  const guid = pick("guid");
+  const property = pick("property");
+  const sign = pick("sign");
+
+  if (!accesstoken && !guid && !property && !sign) {
+    return null;
+  }
+
+  return {
+    ...(accesstoken ? { accesstoken } : {}),
+    ...(guid ? { guid } : {}),
+    ...(property ? { property } : {}),
+    ...(sign ? { sign } : {}),
+  };
+}
+
 function getApiSnapshotCount() {
   if (Array.isArray(apiSnapshot.searchRows)) {
     return apiSnapshot.searchRows.length;
   }
   if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+    if (isJob51DetailPage()) {
+      return isJob51DetailReady() ? 1 : 0;
+    }
     return Array.isArray(apiSnapshot.job51SearchRows)
       ? apiSnapshot.job51SearchRows.length
       : 0;
@@ -705,7 +759,7 @@ function isJob5156DetailRootReady(root, pathname) {
 
 function isExtractionReady() {
   if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
-    return hasJob51SearchSnapshot();
+    return isJob51DetailPage() ? isJob51DetailReady() : hasJob51SearchSnapshot();
   }
   if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
     return isSeekSnapshotReady();
@@ -1980,6 +2034,245 @@ async function enrichJob5156SearchResumesWithDetail(resumes) {
   return enriched;
 }
 
+function isJob51RateLimitedErrorMessage(message) {
+  const normalized = normalizeResumeText(String(message || ""));
+  return (
+    normalized.includes("搜索访问太快") ||
+    normalized.includes("请60分钟后再试") ||
+    normalized.includes("访问频率限制") ||
+    normalized.includes("频率限制") ||
+    normalized.toLowerCase().includes("rate limit")
+  );
+}
+
+function isJob51RateLimitedPayload(payload) {
+  if (!payload) return false;
+  const candidates = [
+    payload.error,
+    payload.message,
+    payload.msg,
+    payload.detail,
+    payload.data?.error,
+    payload.data?.message,
+    payload.data?.msg,
+    payload.data?.detail,
+  ];
+  return candidates.some((value) => isJob51RateLimitedErrorMessage(value));
+}
+
+async function collectJob51DetailFromBackground(resumeId) {
+  try {
+    const response = await chrome.runtime.sendMessage({
+      action: "collectJob51ResumeDetail",
+      resumeId,
+    });
+    if (response?.success) {
+      return {
+        payload: response.data ?? response.payload ?? response.resume ?? null,
+        rateLimited: false,
+      };
+    }
+    const errorMessage = response?.error ? String(response.error) : "";
+    return {
+      payload: null,
+      rateLimited: isJob51RateLimitedErrorMessage(errorMessage),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error || "");
+    return {
+      payload: null,
+      rateLimited: isJob51RateLimitedErrorMessage(message),
+    };
+  }
+}
+
+async function fetch51JobResumeDetail(resumeId) {
+  const normalizedResumeId = normalizeJob51Text(resumeId);
+  if (!normalizedResumeId) {
+    return { payload: null, rateLimited: false };
+  }
+
+  const authContext = apiSnapshot.job51AuthContext;
+  const requestBody = {
+    resume_id: normalizedResumeId,
+    resumeId: normalizedResumeId,
+    userid: normalizedResumeId,
+    lan: "c",
+    timestamp: Date.now(),
+    ...(authContext?.property ? { property: authContext.property } : {}),
+    ...(authContext?.sign ? { sign: authContext.sign } : {}),
+  };
+
+  if (authContext?.accesstoken || authContext?.guid || authContext?.property) {
+    const headers = {
+      Accept: "application/json, text/plain, */*",
+      "Content-Type": "application/json",
+      ...(authContext.accesstoken ? { accesstoken: authContext.accesstoken } : {}),
+      ...(authContext.guid ? { guid: authContext.guid } : {}),
+      ...(authContext.property ? { property: authContext.property } : {}),
+    };
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(
+      () => controller.abort(),
+      JOB51_DETAIL_FETCH_TIMEOUT_MS,
+    );
+
+    try {
+      const response = await fetch(
+        "https://ehirej.51job.com/resumedtl/getresume",
+        {
+          method: "POST",
+          credentials: "include",
+          headers,
+          body: JSON.stringify(requestBody),
+          signal: controller.signal,
+        },
+      );
+
+      if (response.status === 403) {
+        return { payload: null, rateLimited: true };
+      }
+
+      if (response.ok) {
+        const payload = await response.json().catch(() => null);
+        if (isJob51RateLimitedPayload(payload)) {
+          return { payload: null, rateLimited: true };
+        }
+        if (payload) {
+          return { payload, rateLimited: false };
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error || "");
+      if (isJob51RateLimitedErrorMessage(message)) {
+        return { payload: null, rateLimited: true };
+      }
+      if (error instanceof DOMException && error.name === "AbortError") {
+        console.warn("🎯 [Auto Sync] Direct Job51 detail fetch timed out:", normalizedResumeId);
+      } else {
+        console.warn("🎯 [Auto Sync] Direct Job51 detail fetch failed:", normalizedResumeId, error);
+      }
+    } finally {
+      window.clearTimeout(timeoutId);
+    }
+  }
+
+  return collectJob51DetailFromBackground(normalizedResumeId);
+}
+
+async function enrich51JobSearchResumeWithDetail(resume, extractedAt) {
+  if (!resume || typeof resume !== "object") {
+    return {
+      resume: null,
+      enriched: false,
+      rateLimited: false,
+    };
+  }
+
+  const fallbackResume = {
+    ...resume,
+    extractedAt: resume.extractedAt || extractedAt,
+  };
+  const resumeId =
+    normalizeJob51Text(resume.resumeId) ||
+    normalizeJob51Text(resume.perUserId) ||
+    "";
+
+  if (!resumeId) {
+    return {
+      resume: fallbackResume,
+      enriched: false,
+      rateLimited: false,
+    };
+  }
+
+  try {
+    const detailResult = await fetch51JobResumeDetail(resumeId);
+    if (!detailResult?.payload) {
+      return {
+        resume: fallbackResume,
+        enriched: false,
+        rateLimited: !!detailResult?.rateLimited,
+      };
+    }
+
+    const detailResume = buildJob51DetailResumeFromPayload(detailResult.payload, {
+      resumeId,
+      profileUrl: fallbackResume.profileUrl || "",
+    })[0] || null;
+
+    if (!detailResume) {
+      return {
+        resume: fallbackResume,
+        enriched: false,
+        rateLimited: !!detailResult.rateLimited,
+      };
+    }
+
+    return {
+      resume: {
+        ...fallbackResume,
+        ...detailResume,
+        extractedAt: fallbackResume.extractedAt,
+        pageIndex: fallbackResume.pageIndex,
+        pageNumber: fallbackResume.pageNumber,
+        workHistory: detailResume.workHistory || [],
+        projectExperience: detailResume.projectExperience || [],
+        profileEducation: detailResume.profileEducation || [],
+        skills: detailResume.skills || [],
+        licences: detailResume.licences || [],
+      },
+      enriched: true,
+      rateLimited: !!detailResult.rateLimited,
+    };
+  } catch (error) {
+    console.warn(
+      "🎯 [Auto Sync] Failed to enrich Job51 detail resume:",
+      resumeId,
+      error,
+    );
+    return {
+      resume: fallbackResume,
+      enriched: false,
+      rateLimited: false,
+    };
+  }
+}
+
+async function enrich51JobSearchResumesWithDetail(resumes) {
+  if (!Array.isArray(resumes) || resumes.length === 0) return [];
+
+  const extractedAt = new Date().toISOString();
+  const enriched = [];
+  let enrichedCount = 0;
+
+  for (let index = 0; index < resumes.length; index += JOB51_DETAIL_FETCH_CONCURRENCY) {
+    const result = await enrich51JobSearchResumeWithDetail(
+      resumes[index],
+      extractedAt,
+    );
+    if (result?.resume) {
+      enriched.push(result.resume);
+    }
+    if (result?.enriched) {
+      enrichedCount += 1;
+    }
+    console.log(
+      `51job detail enrichment: ${index + 1}/${resumes.length} (${enrichedCount} enriched)`,
+    );
+
+    if (result?.rateLimited) {
+      break;
+    }
+
+    if (index < resumes.length - 1) {
+      await delay(JOB51_DETAIL_FETCH_DELAY_MS);
+    }
+  }
+
+  return enriched;
+}
+
 function extractSeekProfileResume() {
   const profile = apiSnapshot.seekProfile;
   if (!profile || typeof profile !== "object") return [];
@@ -2348,7 +2641,7 @@ function extractProfileUrl(card, apiRow) {
 }
 
 function updateApiSnapshot(message) {
-  const { kind, payload, url, sourceKey, operationName, request } = message;
+  const { kind, payload, url, sourceKey, operationName, request, requestHeaders } = message;
   apiSnapshot.lastUpdatedAt = new Date().toISOString();
   if (url) apiSnapshot.lastUrl = url;
   apiSnapshot.lastSourceKey = sourceKey || null;
@@ -2384,6 +2677,13 @@ function updateApiSnapshot(message) {
     return;
   }
   if (kind === "job51search") {
+    const authContext = normalizeJob51AuthContext(requestHeaders, request);
+    if (authContext) {
+      apiSnapshot.job51AuthContext = {
+        ...(apiSnapshot.job51AuthContext || {}),
+        ...authContext,
+      };
+    }
     const total = getJob51TotalFromPayload(payload);
     if (typeof total === "number") {
       apiSnapshot.job51Total = total;
@@ -2402,6 +2702,25 @@ function updateApiSnapshot(message) {
       } catch {
         // ignore
       }
+    }
+    return;
+  }
+  if (kind === "job51detail") {
+    const authContext = normalizeJob51AuthContext(requestHeaders, request);
+    if (authContext) {
+      apiSnapshot.job51AuthContext = {
+        ...(apiSnapshot.job51AuthContext || {}),
+        ...authContext,
+      };
+    }
+    apiSnapshot.job51DetailPayload = payload || null;
+    try {
+      document.documentElement.setAttribute(
+        "data-tr-api-rows",
+        String(getApiSnapshotCount()),
+      );
+    } catch {
+      // ignore
     }
     return;
   }
@@ -3005,14 +3324,14 @@ function extract51JobResumes() {
         uniqueSkillTags.join("、"),
     );
     const resumeId = str(
-      baseInfo.accountid ||
+      row?.userid ||
         row?.resumeId ||
         row?.resumeNo ||
         row?.resumekey ||
         row?.id,
     );
     const perUserId = str(
-      row?.userid ||
+      baseInfo.accountid ||
         row?.real_userid ||
         row?.perUserId ||
         row?.userId ||
@@ -3035,6 +3354,7 @@ function extract51JobResumes() {
       perUserId: perUserId || undefined,
       externalId: externalId || undefined,
       profileUrl: profileUrl || undefined,
+      source: EHIRE_51JOB_HOST,
       workHistory,
       pageIndex: index + 1,
       rawData: row,
@@ -3043,7 +3363,509 @@ function extract51JobResumes() {
   });
 }
 
+function getJob51DetailRoot(payload) {
+  if (!payload) return null;
+  if (Array.isArray(payload)) {
+    for (const entry of payload) {
+      const root = getJob51DetailRoot(entry);
+      if (root) return root;
+    }
+    return null;
+  }
+  if (typeof payload !== "object") return null;
+  const record = payload;
+  const candidates = [
+    record.data,
+    record.result,
+    record.resume,
+    record.detail,
+    record.resumeInfo,
+    record.resumeDetail,
+    record.resumeViewVo,
+    record.resume_view_vo,
+    record.resumeVo,
+    record.cnVo,
+    record.content,
+  ];
+  for (const candidate of candidates) {
+    const root = getJob51DetailRoot(candidate);
+    if (root) return root;
+  }
+  return record;
+}
+
+function readJob51Text(...values) {
+  for (const value of values) {
+    if (typeof value === "string") {
+      const text = normalizeJob51Text(value);
+      if (text) return text;
+    } else if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value);
+    }
+  }
+  return "";
+}
+
+function readJob51MultilineText(...values) {
+  for (const value of values) {
+    if (typeof value === "string") {
+      const text = normalizeJob51MultilineText(value);
+      if (text) return text;
+    }
+  }
+  return "";
+}
+
+function normalizeJob51DateLike(value) {
+  const text = readJob51Text(value);
+  if (!text) return "";
+  if (["至今", "目前", "今"].includes(text)) return "至今";
+  return text
+    .replace(/[./年]/g, "-")
+    .replace(/月/g, "")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function readJob51Array(record, keys) {
+  if (!record || typeof record !== "object") return [];
+  for (const key of keys) {
+    const value = record[key];
+    if (Array.isArray(value)) return value;
+  }
+  return [];
+}
+
+function buildJob51ExperienceEntry(item, kind) {
+  if (!item || typeof item !== "object") return null;
+
+  const isProject = kind === "project";
+  const companyName = readJob51Text(
+    item.company_name,
+    item.companyName,
+    item.com_name,
+    item.comName,
+    item.company,
+    isProject ? item.project_name : undefined,
+    isProject ? item.projectName : undefined,
+    isProject ? item.project : undefined,
+  );
+  const jobTitle = readJob51Text(
+    item.work_func_value,
+    item.job_name,
+    item.jobName,
+    item.position,
+    item.jobTitle,
+    isProject ? item.project_role : undefined,
+    isProject ? item.role : undefined,
+    isProject ? item.responsibility : undefined,
+  );
+  const startDate = normalizeJob51DateLike(
+    item.start_time ??
+      item.startDate ??
+      item.begin ??
+      item.start_date ??
+      item.fromDate ??
+      item.time_begin,
+  );
+  const endDate = normalizeJob51DateLike(
+    item.end_time ??
+      item.endDate ??
+      item.end ??
+      item.end_date ??
+      item.toDate ??
+      item.time_end,
+  );
+  const durationLabel = readJob51Text(
+    item.working_years,
+    item.duration,
+    item.timeDiff,
+    item.time_diff,
+    item.period,
+    item.durationLabel,
+  );
+  const description = readJob51MultilineText(
+    item.workdescribe,
+    item.work_describe,
+    item.workDescription,
+    item.description,
+    item.desc,
+    item.detail,
+    item.content,
+    isProject ? item.project_desc : undefined,
+    isProject ? item.projectDescribe : undefined,
+  );
+  const metaParts = [
+    item.industry_tag,
+    item.company_size_value,
+    item.work_type_value,
+    item.section,
+    item.department,
+    item.project_name,
+  ]
+    .map((value) => readJob51Text(value))
+    .filter(Boolean);
+  const raw = buildWorkHistoryRawParts([
+    [startDate, endDate].filter(Boolean).join("~"),
+    durationLabel ? `(${durationLabel})` : "",
+    companyName,
+    jobTitle,
+    ...metaParts,
+    description,
+  ]);
+
+  if (!raw && !description && !companyName && !jobTitle) return null;
+
+  return {
+    raw: raw || description || buildWorkHistoryRawParts([companyName, jobTitle, startDate, endDate]),
+    companyName: companyName || undefined,
+    jobTitle: jobTitle || undefined,
+    description: description || undefined,
+    startDate: startDate || undefined,
+    endDate: endDate || undefined,
+  };
+}
+
+function buildJob51EducationEntry(item) {
+  if (!item || typeof item !== "object") return null;
+
+  const institution = readJob51Text(
+    item.school_name,
+    item.schoolName,
+    item.school,
+    item.institution,
+    item.university,
+    item.college,
+  );
+  const qualification = readJob51Text(
+    item.degree_value,
+    item.degree,
+    item.degreeStr,
+    item.qualification,
+    item.education,
+  );
+  const fieldOfStudy = readJob51Text(
+    item.major,
+    item.major_name,
+    item.speciality,
+    item.field_of_study,
+    item.subject,
+  );
+  const description = readJob51MultilineText(
+    item.describe,
+    item.description,
+    item.detail,
+    item.content,
+  );
+  const startDate = normalizeJob51DateLike(
+    item.start_date ?? item.begin ?? item.startTime ?? item.enrollYear,
+  );
+  const endDate = normalizeJob51DateLike(
+    item.end_date ?? item.end ?? item.endTime ?? item.graduationYear,
+  );
+
+  if (!institution && !qualification && !fieldOfStudy && !description) {
+    return null;
+  }
+
+  return {
+    institution: institution || undefined,
+    qualification: qualification || undefined,
+    fieldOfStudy: fieldOfStudy || undefined,
+    description: description || undefined,
+    startDate: startDate || undefined,
+    endDate: endDate || undefined,
+  };
+}
+
+function buildJob51SkillEntry(item) {
+  if (typeof item === "string") {
+    const text = normalizeJob51Text(item);
+    return text || null;
+  }
+  if (!item || typeof item !== "object") return null;
+
+  const name = readJob51Text(item.skill_name, item.name, item.label, item.skill, item.tag);
+  if (!name) return null;
+
+  const level = readJob51Text(item.level, item.skill_level, item.proficiency);
+  const yearsOfExperience =
+    typeof item.yearsOfExperience === "number" && Number.isFinite(item.yearsOfExperience)
+      ? item.yearsOfExperience
+      : typeof item.years === "number" && Number.isFinite(item.years)
+        ? item.years
+        : typeof item.years === "string" && item.years.trim()
+          ? item.years.trim()
+          : undefined;
+
+  if (!level && yearsOfExperience === undefined) {
+    return name;
+  }
+
+  return {
+    name,
+    ...(level ? { level } : {}),
+    ...(yearsOfExperience === undefined ? {} : { yearsOfExperience }),
+  };
+}
+
+function buildJob51LicenceEntry(item) {
+  if (typeof item === "string") {
+    const text = normalizeJob51Text(item);
+    return text ? { name: text } : null;
+  }
+  if (!item || typeof item !== "object") return null;
+
+  const name = readJob51Text(
+    item.name,
+    item.cert_name,
+    item.certificate_name,
+    item.training_name,
+    item.course_name,
+    item.title,
+  );
+  if (!name) return null;
+
+  const authority = readJob51Text(
+    item.authority,
+    item.organization,
+    item.issuing_org,
+    item.issuingOrganisationName,
+    item.school,
+    item.company,
+  );
+  const issuedAt = normalizeJob51DateLike(
+    item.issuedAt ?? item.issue_date ?? item.issued_date ?? item.start_date ?? item.startTime,
+  );
+  const expiresAt = normalizeJob51DateLike(
+    item.expiresAt ?? item.expire_date ?? item.expired_date ?? item.end_date ?? item.endTime,
+  );
+
+  return {
+    name,
+    ...(authority ? { authority } : {}),
+    ...(issuedAt ? { issuedAt } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+  };
+}
+
+function buildJob51DetailResumeFromPayload(payload, options = {}) {
+  const root = getJob51DetailRoot(payload);
+  if (!root) return [];
+
+  const resumeId = readJob51Text(
+    options.resumeId,
+    root.resumeId,
+    root.resume_id,
+    root.userid,
+    root.userId,
+    root.user_id,
+    root.id,
+    root.base_info?.userid,
+    root.base_info?.resumeId,
+  );
+  const perUserId = readJob51Text(
+    root.accountid,
+    root.accountId,
+    root.account_id,
+    root.base_info?.accountid,
+    root.base_info?.accountId,
+    root.base_info?.account_id,
+    root.userid,
+    root.userId,
+    root.user_id,
+  );
+  const profileUrl = normalizeJob51Text(
+    options.profileUrl ||
+      (resumeId
+        ? `https://${EHIRE_51JOB_HOST}/Revision/talent/resume/detail?contentType=&resumeId=${encodeURIComponent(resumeId)}`
+        : ""),
+  );
+  const baseInfo =
+    root.base_info && typeof root.base_info === "object" ? root.base_info : {};
+  const jobIntentionInfo =
+    root.job_intention && typeof root.job_intention === "object"
+      ? root.job_intention
+      : {};
+  const recentWorkInfo =
+    root.recent_work_info && typeof root.recent_work_info === "object"
+      ? root.recent_work_info
+      : {};
+  const workHistory = readJob51Array(root, [
+    "work",
+    "work_list",
+    "workInfoVoList",
+    "workHistory",
+    "work_experience",
+    "workExperience",
+  ])
+    .map((item) => buildJob51ExperienceEntry(item, "work"))
+    .filter(Boolean);
+  const projectExperience = readJob51Array(root, [
+    "project",
+    "project_list",
+    "projectInfoVoList",
+    "projectExperience",
+    "project_experience",
+  ])
+    .map((item) => buildJob51ExperienceEntry(item, "project"))
+    .filter(Boolean);
+  const profileEducation = readJob51Array(root, [
+    "education",
+    "education_list",
+    "educationInfoVoList",
+    "profileEducation",
+    "educationHistory",
+  ])
+    .map((item) => buildJob51EducationEntry(item))
+    .filter(Boolean);
+  const skills = readJob51Array(root, [
+    "itskill",
+    "skill",
+    "skills",
+    "skill_list",
+    "label_sorted_skill_tag_list",
+    "label_list",
+  ])
+    .map((item) => buildJob51SkillEntry(item))
+    .filter(Boolean);
+  const licences = [
+    ...readJob51Array(root, ["certification", "certifications", "certificate", "certificates"]),
+    ...readJob51Array(root, ["train", "training", "train_list", "trainings"]),
+  ]
+    .map((item) => buildJob51LicenceEntry(item))
+    .filter(Boolean);
+
+  const name = readJob51Text(
+    root.name,
+    root.userName,
+    root.user_name,
+    root.resume_name,
+    root.realName,
+    root.candidateName,
+    root.fullName,
+    baseInfo.resume_name,
+    baseInfo.name,
+    baseInfo.userName,
+  );
+  const age = readJob51Text(root.age, root.realAge, baseInfo.age);
+  const experience = readJob51Text(
+    baseInfo.work_year_value,
+    root.workYear,
+    root.workYears,
+    root.experienceYears,
+    root.experience,
+    recentWorkInfo?.recent_position,
+  );
+  const education = readJob51Text(
+    baseInfo.top_degree_value,
+    root.top_degree_value,
+    root.education,
+    root.degree,
+    root.degreeValue,
+  );
+  const location = readJob51Text(
+    jobIntentionInfo.expect_job_area_value,
+    root.jobIntention?.expect_job_area_value,
+    baseInfo.area_value,
+    root.location,
+    root.workCity,
+    root.city,
+    root.workLocation,
+  );
+  const jobIntention = readJob51Text(
+    jobIntentionInfo.expect_work_function_value,
+    jobIntentionInfo.expected_work_function_value,
+    root.jobIntention?.expect_work_function_value,
+    root.jobIntention?.expected_work_function_value,
+    recentWorkInfo.recent_position,
+    root.jobIntention,
+    root.job_name,
+    root.desiredJob,
+    root.expectedPosition,
+    root.targetJob,
+    root.searchJob,
+  );
+  const expectedSalary = readJob51Text(
+    jobIntentionInfo.new_expect_salary,
+    jobIntentionInfo.expect_salary,
+    root.expectedSalary,
+    root.desiredSalary,
+    root.expectSalary,
+    root.salaryStr,
+    root.salary,
+  );
+  const activityStatus = readJob51Text(
+    root.active_type,
+    root.activityStatus,
+    root.lastLoginTime,
+    root.last_login_time,
+    baseInfo.active_type,
+    baseInfo.jobStateStr,
+  );
+  const selfIntro = readJob51MultilineText(
+    root.selfintro,
+    root.selfIntro,
+    root.resume_slicing,
+    root.advantage,
+    root.profile,
+    root.summary,
+    root.resumeSummary,
+    root.highlight,
+    root.professionSkill,
+    jobIntentionInfo.professionSkill,
+  );
+  const normalizedAge = age ? (age.includes("岁") ? age : `${age}岁`) : "";
+  const externalId = resumeId || perUserId;
+  const pageIndex = 1;
+  const source = EHIRE_51JOB_HOST;
+
+  if (!resumeId && !name && !jobIntention && !selfIntro && workHistory.length === 0) {
+    return [];
+  }
+
+  return [
+    {
+      name,
+      age: normalizedAge,
+      experience,
+      education,
+      location,
+      jobIntention,
+      expectedSalary,
+      activityStatus,
+      selfIntro,
+      resumeId: resumeId || undefined,
+      perUserId: perUserId || undefined,
+      externalId: externalId || undefined,
+      profileUrl: profileUrl || undefined,
+      source,
+      workHistory,
+      projectExperience:
+        projectExperience.length > 0 ? projectExperience : undefined,
+      profileEducation:
+        profileEducation.length > 0 ? profileEducation : undefined,
+      skills: skills.length > 0 ? skills : undefined,
+      licences: licences.length > 0 ? licences : undefined,
+      pageIndex,
+      rawData: root,
+      extractedAt: new Date().toISOString(),
+    },
+  ];
+}
+
+function extractJob51DetailResume() {
+  if (!isJob51DetailPage() || !isJob51DetailReady()) return [];
+  return filterResumesByAgeRange(buildJob51DetailResumeFromPayload(apiSnapshot.job51DetailPayload, {
+    resumeId: new URL(window.location.href).searchParams.get("resumeId") || undefined,
+    profileUrl: window.location.href,
+  }));
+}
+
 function extractResumes() {
+  if (isJob51DetailPage()) {
+    return filterResumesByAgeRange(extractJob51DetailResume());
+  }
   if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
     return extract51JobResumes();
   }
@@ -3153,6 +3975,39 @@ function extractResumesRaw(options = {}) {
 
       return payload;
     }
+  }
+
+  if (isJob51DetailPage() && isJob51DetailReady()) {
+    const detailResumes = extractJob51DetailResume();
+    const detailResume = detailResumes[0] || null;
+    const payload = {
+      url: window.location.href,
+      extractedAt: new Date().toISOString(),
+      count: detailResumes.length,
+      cards: [
+        {
+          index: 1,
+          resumeId: detailResume?.resumeId || "",
+          perUserId: detailResume?.perUserId || "",
+          text: JSON.stringify(detailResume?.rawData || apiSnapshot.job51DetailPayload, null, 2),
+        },
+      ],
+      api: {
+        lastSearchAt: apiSnapshot.lastSearchAt,
+        lastUpdatedAt: apiSnapshot.lastUpdatedAt,
+        searchRowCount: detailResumes.length,
+        sourceKey: SOURCE_KEYS.JOB51,
+        operationName: apiSnapshot.lastOperationName,
+        request: apiSnapshot.job51AuthContext,
+        payload: apiSnapshot.job51DetailPayload,
+      },
+    };
+
+    if (includePage) {
+      payload.pageHtml = document.documentElement.outerHTML;
+    }
+
+    return payload;
   }
 
   const detailResumes = isJob5156DetailPage()
@@ -3373,6 +4228,15 @@ function getPaginationInfo() {
   const sourceKey = getCurrentSourceKey();
   if (sourceKey === SOURCE_KEYS.SEEK) {
     return getSeekPaginationInfo();
+  }
+
+  if (isJob51DetailPage()) {
+    return {
+      currentPage: 1,
+      totalPages: 1,
+      totalItems: isJob51DetailReady() ? 1 : 0,
+      hasNextPage: false,
+    };
   }
 
   if (sourceKey === SOURCE_KEYS.JOB51) {
@@ -3998,6 +4862,7 @@ async function waitForExtractionData({ timeoutMs = 30000, minCount = 1 } = {}) {
 function clearCapturedResultsForNextPage() {
   apiSnapshot.searchRows = null;
   apiSnapshot.job51SearchRows = null;
+  apiSnapshot.job51DetailPayload = null;
   if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
     apiSnapshot.seekRecommendedCandidates = null;
     apiSnapshot.seekRecommendedRequest = null;
@@ -4946,6 +5811,14 @@ async function syncCurrentPageToServer(resumesOverride) {
   const shouldEnrichFromCurrentPage = !Array.isArray(resumesOverride);
   if (
     shouldEnrichFromCurrentPage &&
+    getCurrentSourceKey() === SOURCE_KEYS.JOB51 &&
+    !isJob51DetailPage() &&
+    resumes.length > 0
+  ) {
+    resumes = await enrich51JobSearchResumesWithDetail(resumes);
+  }
+  if (
+    shouldEnrichFromCurrentPage &&
     getCurrentSourceKey() === SOURCE_KEYS.JOB5156 &&
     !isJob5156DetailPage() &&
     resumes.length > 0
@@ -5168,6 +6041,13 @@ async function runAutoSyncIfEnabled() {
         resumes = resumes.slice(0, pageSelection.remainingCapacity);
       }
       lastSelectedCount = isSeekListPage ? resumes.length : null;
+      if (
+        getCurrentSourceKey() === SOURCE_KEYS.JOB51 &&
+        !isJob51DetailPage() &&
+        resumes.length > 0
+      ) {
+        resumes = await enrich51JobSearchResumesWithDetail(resumes);
+      }
       if (
         getCurrentSourceKey() === SOURCE_KEYS.JOB5156 &&
         !isJob5156DetailPage() &&
@@ -5652,6 +6532,13 @@ async function collectSnapshotPayload(options = {}) {
       pageResumes = pageResumes.slice(0, pageSelection.remainingCapacity);
     }
 
+    if (
+      sourceKey === SOURCE_KEYS.JOB51 &&
+      !isJob51DetailPage() &&
+      pageResumes.length > 0
+    ) {
+      pageResumes = await enrich51JobSearchResumesWithDetail(pageResumes);
+    }
     if (
       sourceKey === SOURCE_KEYS.JOB5156 &&
       !isJob5156DetailPage() &&

--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -15,7 +15,8 @@
         "*://hr.job5156.com/*",
         "*://hk.employer.seek.com/*",
         "*://my.employer.seek.com/*",
-        "*://ehire.51job.com/*"
+        "*://ehire.51job.com/*",
+        "*://ehirej.51job.com/*"
     ],
     "background": {
         "service_worker": "background.js"
@@ -40,7 +41,8 @@
                 "*://my.employer.seek.com/candidates/recommended*",
                 "*://hk.employer.seek.com/talentsearch/profile*",
                 "*://my.employer.seek.com/talentsearch/profile*",
-                "*://ehire.51job.com/Revision/talent/search*"
+                "*://ehire.51job.com/Revision/talent/search*",
+                "*://ehire.51job.com/Revision/talent/resume/detail*"
             ],
             "js": [
                 "page-hook.js"
@@ -56,7 +58,8 @@
                 "*://my.employer.seek.com/candidates/recommended*",
                 "*://hk.employer.seek.com/talentsearch/profile*",
                 "*://my.employer.seek.com/talentsearch/profile*",
-                "*://ehire.51job.com/Revision/talent/search*"
+                "*://ehire.51job.com/Revision/talent/search*",
+                "*://ehire.51job.com/Revision/talent/resume/detail*"
             ],
             "js": [
                 "seek-auto-sync-window.js",

--- a/apps/browser-extension/page-hook.js
+++ b/apps/browser-extension/page-hook.js
@@ -45,6 +45,50 @@
     return query.includes("talentSearchRecommendedCandidatesV2");
   };
 
+  const headersToObject = (headers) => {
+    if (!headers) {
+      return {};
+    }
+
+    const result = {};
+    if (typeof Headers !== "undefined" && headers instanceof Headers) {
+      headers.forEach((value, key) => {
+        result[key.toLowerCase()] = value;
+      });
+      return result;
+    }
+
+    if (Array.isArray(headers)) {
+      for (const entry of headers) {
+        if (!Array.isArray(entry) || entry.length < 2) continue;
+        const [key, value] = entry;
+        if (typeof key !== "string") continue;
+        result[key.toLowerCase()] = Array.isArray(value) ? value.join(", ") : String(value);
+      }
+      return result;
+    }
+
+    if (typeof headers === "object") {
+      for (const [key, value] of Object.entries(headers)) {
+        result[key.toLowerCase()] = Array.isArray(value) ? value.join(", ") : String(value);
+      }
+    }
+
+    return result;
+  };
+
+  const mergeRequestHeaders = (...sources) => {
+    const merged = {};
+    for (const source of sources) {
+      const headers = headersToObject(source);
+      for (const [key, value] of Object.entries(headers)) {
+        if (typeof value !== "string") continue;
+        merged[key] = value;
+      }
+    }
+    return merged;
+  };
+
   const classify = (url, requestBody) => {
     if (!url) return null;
     if (url.includes("/api/search/resume/v2/attach/resume/info"))
@@ -58,6 +102,9 @@
     if (url.includes("ehire.51job.com") || url.includes("ehirej.51job.com")) {
       try {
         const pathname = new URL(url).pathname.toLowerCase();
+        if (pathname.includes("/resumedtl/getresume")) {
+          return { kind: "job51detail", sourceKey: "51job" };
+        }
         if (
           pathname.includes("/talent_hunt_resume_list") ||
           pathname.includes("/talent/search") ||
@@ -179,7 +226,7 @@
     };
   };
 
-  const capture = (classification, url, payload) => {
+  const capture = (classification, url, payload, requestHeaders, request) => {
     if (!classification || !payload) return;
     post({
       kind: classification.kind,
@@ -190,7 +237,12 @@
       request:
         classification.sourceKey === "seek"
           ? sanitizeSeekRequestBody(classification.operation)
-          : undefined,
+          : request && typeof request === "object"
+            ? request
+            : undefined,
+      requestHeaders: requestHeaders && typeof requestHeaders === "object"
+        ? requestHeaders
+        : undefined,
     });
   };
 
@@ -444,14 +496,20 @@
         requestUrl.includes("ehire.51job.com") ||
         requestUrl.includes("ehirej.51job.com");
       if (!isGraphqlRequest(requestUrl) && !is51jobFetch) {
-        return originalFetch.apply(this, args);
-      }
+      return originalFetch.apply(this, args);
+    }
 
-      return Promise.resolve(parseRequestBody(args[0], args[1])).then(
-        (requestBody) => {
-          const nextPageIndex = trWindow.__trJob51NextPage;
-          const shouldRewriteJob51Request =
-            is51jobFetch &&
+    return Promise.resolve(parseRequestBody(args[0], args[1])).then(
+      (requestBody) => {
+        const requestHeaders = mergeRequestHeaders(
+          typeof Request !== "undefined" && args[0] instanceof Request
+            ? args[0].headers
+            : undefined,
+          typeof args[1] === "object" && args[1] !== null ? args[1].headers : undefined,
+        );
+        const nextPageIndex = trWindow.__trJob51NextPage;
+        const shouldRewriteJob51Request =
+          is51jobFetch &&
             requestUrl.includes("talent_hunt_resume_list") &&
             typeof nextPageIndex === "number" &&
             nextPageIndex > 1 &&
@@ -481,7 +539,7 @@
                 res
                   .clone()
                   .json()
-                  .then((data) => capture(classification, requestUrl, data))
+                  .then((data) => capture(classification, requestUrl, data, requestHeaders, requestBody))
                   .catch(() => {});
               }
             } catch {
@@ -496,11 +554,29 @@
 
   const originalOpen = XMLHttpRequest.prototype.open;
   const originalSend = XMLHttpRequest.prototype.send;
+  const originalSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
   XMLHttpRequest.prototype.open = function (method, url, ...rest) {
-    /** @type {XMLHttpRequest & { __tr_url?: string, __tr_body?: unknown }} */ (
+    /** @type {XMLHttpRequest & { __tr_url?: string, __tr_body?: unknown, __tr_requestHeaders?: Record<string, string> }} */ (
       this
     ).__tr_url = url;
+    /** @type {XMLHttpRequest & { __tr_requestHeaders?: Record<string, string> }} */ (
+      this
+    ).__tr_requestHeaders = {};
     return originalOpen.call(this, method, url, ...rest);
+  };
+  XMLHttpRequest.prototype.setRequestHeader = function (name, value) {
+    /** @type {XMLHttpRequest & { __tr_requestHeaders?: Record<string, string> }} */ (
+      this
+    ).__tr_requestHeaders ||= {};
+    if (typeof name === "string") {
+      const headers = /** @type {XMLHttpRequest & { __tr_requestHeaders?: Record<string, string> }} */ (
+        this
+      ).__tr_requestHeaders;
+      const key = name.toLowerCase();
+      const nextValue = String(value);
+      headers[key] = headers[key] ? `${headers[key]}, ${nextValue}` : nextValue;
+    }
+    return originalSetRequestHeader.call(this, name, value);
   };
   XMLHttpRequest.prototype.send = function (...args) {
     const body = args[0];
@@ -510,7 +586,7 @@
     this.addEventListener("load", function () {
       try {
         const request =
-          /** @type {XMLHttpRequest & { __tr_url?: string, __tr_body?: unknown }} */ (
+          /** @type {XMLHttpRequest & { __tr_url?: string, __tr_body?: unknown, __tr_requestHeaders?: Record<string, string> }} */ (
             this
           );
         const url = normalizeUrl(request.__tr_url);
@@ -526,7 +602,7 @@
           }
         }
         if (!data) return;
-        capture(classification, url, data);
+        capture(classification, url, data, request.__tr_requestHeaders, request.__tr_body);
       } catch {
         // ignore
       }

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -12,6 +12,7 @@ import type { ExperienceLevelFilter } from '@/hooks/useUrlSearchState'
 import { cn } from '@/lib/utils'
 import {
   formatRoleYears,
+  getResumeContentLocale,
   getResumeSourceLabel,
   getRoleLabel,
   getRoleRelevantYears,
@@ -199,6 +200,10 @@ export function ResumeCard({
   const profileUrl = resume.profileUrl?.trim()
   const hasProfileUrl = isSafeProfileUrl(profileUrl)
   const sourceLabel = getResumeSourceLabel(resume)
+  const contentLocale = getResumeContentLocale(resume)
+  const industryVerifiedSuffix = t('resumes.card.industryVerifiedSuffix', {
+    defaultValue: ' (Industry verified)',
+  })
 
   const score = matchResult?.score
   const recommendation = matchResult?.recommendation
@@ -338,8 +343,13 @@ export function ResumeCard({
   const verifiedRoleYears = primaryRoleSignal ? getRoleVerifiedYears(primaryRoleSignal) : 0
   const roleRelevantYears = primaryRoleSignal ? getRoleRelevantYears(primaryRoleSignal) : 0
   const displayRoleYears = verifiedRoleYears > 0 ? verifiedRoleYears : roleRelevantYears
+  const roleTypeLabel = primaryRoleSignal
+    ? t(`resumes.roleLabels.${primaryRoleSignal.type}`, {
+        defaultValue: getRoleLabel(primaryRoleSignal.type),
+      })
+    : ''
   const roleEvidenceLabel = primaryRoleSignal
-    ? `${getRoleLabel(primaryRoleSignal.type)}${formatRoleYears(displayRoleYears)}${verifiedRoleYears > 0 ? '(行业验证)' : ''}`
+    ? `${roleTypeLabel}${formatRoleYears(displayRoleYears)}${verifiedRoleYears > 0 ? industryVerifiedSuffix : ''}`
     : null
   const normalizedExperienceLevel = experienceLevel?.trim().toLowerCase()
   const experienceLevelForClick: ExperienceLevelFilter | undefined =
@@ -356,21 +366,21 @@ export function ResumeCard({
   const experienceBadge =
     normalizedExperienceLevel === 'senior'
       ? {
-        label: '资深',
+        label: t('resumes.experienceLevel.senior', { defaultValue: 'Senior' }),
         className: isExperienceLevelActive
           ? 'border-orange-700 bg-orange-600 text-white'
           : 'border-orange-200 bg-orange-50 text-orange-700',
       }
       : normalizedExperienceLevel === 'mid'
         ? {
-          label: '中级',
+          label: t('resumes.experienceLevel.mid', { defaultValue: 'Mid' }),
           className: isExperienceLevelActive
             ? 'border-teal-700 bg-teal-600 text-white'
             : 'border-teal-200 bg-teal-50 text-teal-700',
         }
         : normalizedExperienceLevel === 'junior'
           ? {
-            label: '初级',
+            label: t('resumes.experienceLevel.junior', { defaultValue: 'Junior' }),
             className: isExperienceLevelActive
               ? 'border-zinc-700 bg-zinc-600 text-white'
               : 'border-zinc-200 bg-zinc-50 text-zinc-600',
@@ -380,20 +390,21 @@ export function ResumeCard({
   return (
     <div
       className="mb-3 overflow-hidden rounded-lg border bg-card"
+      lang={contentLocale}
       data-testid="resume-card"
       data-role-types={(roleTypes ?? []).join(',')}
     >
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b bg-muted/50 px-4 py-2 text-sm">
-        <span className="text-muted-foreground">求职意向</span>
+        <span className="text-muted-foreground">{t('resumes.columns.intention')}</span>
         <span className="font-medium">{jobIntention}</span>
         {isReviewed && (
           <Badge variant="outline" className="bg-blue-50 text-blue-600 border-blue-200 text-[10px]">
-            {t('resumes.status.reviewed', '已查阅')}
+            {t('resumes.status.reviewed', { defaultValue: 'Reviewed' })}
           </Badge>
         )}
         {blocked ? (
           <Badge variant="outline" className="bg-red-50 text-red-700 border-red-300 text-[10px]">
-            已屏蔽
+            {t('resumes.card.blocked', { defaultValue: 'Blocked' })}
           </Badge>
         ) : null}
         {sourceLabel ? (
@@ -439,21 +450,22 @@ export function ResumeCard({
               </TooltipTrigger>
               <TooltipContent className="max-w-[320px] text-xs">
                 <div className="space-y-1">
-                  <p className="font-semibold">{getRoleLabel(primaryRoleSignal.type)}</p>
-                  <p>相关年限: {formatRoleYears(roleRelevantYears)}</p>
-                  {verifiedRoleYears > 0 ? <p>行业验证: {formatRoleYears(verifiedRoleYears)}</p> : null}
-                  <p>命中信号: {primaryRoleSignal.matchedSignals.slice(0, 6).join(' / ') || '--'}</p>
+                  <p className="font-semibold">{roleTypeLabel}</p>
+                  <p>{t('resumes.card.relatedYears', { years: formatRoleYears(roleRelevantYears), defaultValue: 'Related years: {{years}}' })}</p>
+                  {verifiedRoleYears > 0 ? (
+                    <p>{t('resumes.card.industryVerified', { years: formatRoleYears(verifiedRoleYears), defaultValue: 'Industry verified: {{years}}' })}</p>
+                  ) : null}
+                  <p>{t('resumes.card.matchedSignals', { signals: primaryRoleSignal.matchedSignals.slice(0, 6).join(' / ') || '--', defaultValue: 'Matched signals: {{signals}}' })}</p>
                   {primaryRoleSignal.matchedWorkEntries && primaryRoleSignal.matchedWorkEntries.length > 0 ? (
-                    <p>
-                      命中经历:
-                      {' '}
-                      {primaryRoleSignal.matchedWorkEntries
+                    <p>{t('resumes.card.matchedExperience', {
+                      experience: primaryRoleSignal.matchedWorkEntries
                         .slice(0, 2)
                         .map((entry) =>
                           [entry.companyName, entry.jobTitle, formatRoleYears(entry.years)].filter(Boolean).join(' · ')
                         )
-                        .join('；')}
-                    </p>
+                        .join('；'),
+                      defaultValue: 'Matched experience: {{experience}}',
+                    })}</p>
                   ) : null}
                 </div>
               </TooltipContent>
@@ -626,7 +638,7 @@ export function ResumeCard({
                 className="gap-2"
               >
                 <Ban className="h-3.5 w-3.5" />
-                {blocked ? '取消屏蔽' : '屏蔽'}
+                {blocked ? t('resumes.card.unblock', { defaultValue: 'Unblock' }) : t('resumes.card.block', { defaultValue: 'Block' })}
               </Button>
               <Button
                 variant="outline"
@@ -660,7 +672,7 @@ export function ResumeCard({
                 requirements: jobDescription.requirements || ''
               } : {
                 id: jobDescriptionId || 'default',
-                title: 'Current Position',
+                title: t('resumes.card.currentPosition', { defaultValue: 'Current Position' }),
                 requirements: ''
               }}
               analysis={matchResult}
@@ -735,15 +747,15 @@ export function ResumeCard({
       <Dialog open={blockDialogOpen} onOpenChange={setBlockDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>屏蔽候选人</DialogTitle>
+            <DialogTitle>{t('resumes.card.blockCandidate', { defaultValue: 'Block candidate' })}</DialogTitle>
             <DialogDescription>
-              为“屏蔽候选人”添加备注（选填）
+              {t('resumes.card.blockCandidateDescription', { defaultValue: 'Add an optional note before blocking this candidate.' })}
             </DialogDescription>
           </DialogHeader>
           <Input
             value={blockNoteInput}
             onChange={(e) => setBlockNoteInput(e.target.value)}
-            placeholder="备注"
+            placeholder={t('resumes.card.notePlaceholder', { defaultValue: 'Note' })}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 e.preventDefault()
@@ -771,15 +783,18 @@ export function ResumeCard({
       <Dialog open={commentDialogOpen} onOpenChange={setCommentDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>备注 (Notes)</DialogTitle>
+            <DialogTitle>{t('resumes.card.notesTitle', { defaultValue: 'Notes' })}</DialogTitle>
             <DialogDescription>
-              为候选人“{resume.name || '--'}”添加备注。
+              {t('resumes.card.notesDescription', {
+                name: resume.name || '--',
+                defaultValue: 'Add a note for {{name}}.',
+              })}
             </DialogDescription>
           </DialogHeader>
           <Input
             value={commentNoteInput}
             onChange={(e) => setCommentNoteInput(e.target.value)}
-            placeholder="输入备注..."
+            placeholder={t('resumes.card.notePlaceholderInput', { defaultValue: 'Enter note...' })}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 e.preventDefault()
@@ -791,7 +806,7 @@ export function ResumeCard({
           />
           <DialogFooter>
             <Button variant="outline" onClick={() => setCommentDialogOpen(false)}>
-              {t('common.cancel', '取消')}
+              {t('common.cancel', 'Cancel')}
             </Button>
             <Button
               onClick={() => {
@@ -800,7 +815,7 @@ export function ResumeCard({
                 setCommentDialogOpen(false)
               }}
             >
-              {t('common.confirm', '确认')}
+              {t('common.confirm', 'Confirm')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -14,7 +14,7 @@ import { Badge } from '@/components/ui/badge'
 import { AiFeedbackButtons } from '@/components/AiFeedbackButtons'
 import type { ResumeItem } from '@/hooks/useResumes'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
-import { formatRoleYears, getResumeSourceLabel, getRoleLabel, hasIngestData, isSafeProfileUrl } from '@/lib/resume-scoring'
+import { formatRoleYears, getResumeContentLocale, getResumeSourceLabel, getRoleLabel, hasIngestData, isSafeProfileUrl } from '@/lib/resume-scoring'
 import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
 
 import type { AiFeedbackSentiment, AiFeedbackTarget, MatchingResult } from '@/types/resume'
@@ -66,6 +66,7 @@ export function ResumeDetail({
     () => (resume ? sanitizeResumeRecordForSurface(resume, 'presentation', fieldUsagePolicy) : null),
     [fieldUsagePolicy, resume],
   )
+  const contentLocale = getResumeContentLocale(resume)
 
   const workHistory = useMemo(() => {
     if (!presentationResume?.workHistory?.length) return []
@@ -131,12 +132,13 @@ export function ResumeDetail({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         data-testid="resume-detail-content"
+        lang={contentLocale}
         className="max-h-[90vh] w-[calc(100vw-1.5rem)] max-w-2xl overflow-y-auto p-4 sm:w-full sm:p-6 md:max-w-3xl lg:max-w-4xl"
       >
         <DialogHeader>
           <DialogTitle>{t('resumes.detail.title')}</DialogTitle>
           <DialogDescription className="sr-only">
-            {t('resumes.detail.description', 'Review resume details and AI analysis summary.')}
+            {t('resumes.detail.description', { defaultValue: 'Review resume details and AI analysis summary.' })}
           </DialogDescription>
         </DialogHeader>
 
@@ -208,7 +210,7 @@ export function ResumeDetail({
                 <p className="font-medium">{displayResume.activityStatus || '--'}</p>
               </div>
               <div>
-                <p className="text-muted-foreground">ID</p>
+                <p className="text-muted-foreground">{t('resumes.detail.id', { defaultValue: 'ID' })}</p>
                 <p className="font-medium">
                   {[displayResume.resumeId, displayResume.perUserId].filter(Boolean).join(' / ') || '--'}
                 </p>
@@ -256,13 +258,13 @@ export function ResumeDetail({
                                 variant="outline"
                                 className={annotation.industryVerified ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : ''}
                               >
-                                {getRoleLabel(annotation.type)}
+                                {t(`resumes.roleLabels.${annotation.type}`, { defaultValue: getRoleLabel(annotation.type) })}
                                 {' '}
                                 {formatRoleYears(annotation.years)}
                               </Badge>
                               {annotation.industryVerified ? (
                                 <Badge variant="outline" className="border-emerald-200 bg-emerald-50 text-emerald-700">
-                                  行业验证
+                                  {t('resumes.detail.industryVerified', { defaultValue: 'Industry verified' })}
                                 </Badge>
                               ) : null}
                               {annotation.matchedSignals.map((signal) => (
@@ -287,7 +289,7 @@ export function ResumeDetail({
             <div className="rounded-lg border bg-slate-50 dark:bg-slate-900 p-4">
               <div className="flex items-center justify-between mb-2">
                 <h3 className="font-semibold flex items-center gap-2">
-                  AI Analysis
+                  {t('resumes.detail.aiAnalysis', { defaultValue: 'AI Analysis' })}
                   <Badge variant={matchResult.score >= 80 ? 'default' : matchResult.score >= 60 ? 'secondary' : 'outline'}>
                     {matchResult.score} 分
                   </Badge>
@@ -297,7 +299,7 @@ export function ResumeDetail({
                   {onAiFeedback ? (
                     <AiFeedbackButtons
                       feedback={aiScoreFeedback}
-                      label="AI score"
+                      label={t('resumes.detail.aiScoreLabel', { defaultValue: 'AI score' })}
                       testId="detail-ai-score-feedback"
                       onSelect={(sentiment) => onAiFeedback('ai_score', sentiment)}
                     />
@@ -307,10 +309,10 @@ export function ResumeDetail({
               {(matchResult.promptVersion != null || matchResult.locale) && (
                 <div className="flex items-center gap-3 mb-3 text-[11px] text-muted-foreground">
                   {matchResult.promptVersion != null && (
-                    <span>Prompt v{matchResult.promptVersion}</span>
+                    <span>{t('resumes.detail.promptVersion', { version: matchResult.promptVersion, defaultValue: 'Prompt v{{version}}' })}</span>
                   )}
                   {matchResult.locale && (
-                    <span>Language: {RESUME_AI_PROMPT_LOCALE_TO_NATURAL_LANGUAGE[matchResult.locale as keyof typeof RESUME_AI_PROMPT_LOCALE_TO_NATURAL_LANGUAGE] ?? matchResult.locale}</span>
+                    <span>{t('resumes.detail.language', { defaultValue: 'Language:' })} {RESUME_AI_PROMPT_LOCALE_TO_NATURAL_LANGUAGE[matchResult.locale as keyof typeof RESUME_AI_PROMPT_LOCALE_TO_NATURAL_LANGUAGE] ?? matchResult.locale}</span>
                   )}
                 </div>
               )}
@@ -322,7 +324,7 @@ export function ResumeDetail({
               <div className={`mb-3 grid gap-4 ${matchResult.highlights?.length && matchResult.concerns?.length ? 'grid-cols-1 lg:grid-cols-2' : 'grid-cols-1'}`}>
                 {matchResult.highlights && matchResult.highlights.length > 0 && (
                   <div>
-                    <h4 className="text-xs font-semibold text-green-600 mb-1">Highlights</h4>
+                    <h4 className="text-xs font-semibold text-green-600 mb-1">{t('resumes.detail.highlights', { defaultValue: 'Highlights' })}</h4>
                     <ul className="list-disc list-inside text-xs text-muted-foreground">
                       {matchResult.highlights.map((h, i) => <li key={i}>{h}</li>)}
                     </ul>
@@ -330,7 +332,7 @@ export function ResumeDetail({
                 )}
                 {matchResult.concerns && matchResult.concerns.length > 0 && (
                   <div>
-                    <h4 className="text-xs font-semibold text-red-600 mb-1">Concerns</h4>
+                    <h4 className="text-xs font-semibold text-red-600 mb-1">{t('resumes.detail.concerns', { defaultValue: 'Concerns' })}</h4>
                     <ul className="list-disc list-inside text-xs text-muted-foreground">
                       {matchResult.concerns.map((c, i) => <li key={i}>{c}</li>)}
                     </ul>
@@ -340,7 +342,7 @@ export function ResumeDetail({
 
               {matchResult.breakdown && (
                 <div className="bg-background rounded p-2 border">
-                  <h4 className="text-xs font-semibold mb-2">Detailed Breakdown</h4>
+                  <h4 className="text-xs font-semibold mb-2">{t('resumes.detail.detailedBreakdown', { defaultValue: 'Detailed Breakdown' })}</h4>
                   <div
                     data-testid="resume-detail-breakdown-grid"
                     className="grid grid-cols-2 gap-2 text-center md:grid-cols-3 xl:grid-cols-5"
@@ -356,10 +358,10 @@ export function ResumeDetail({
               )}
               {onAiFeedback ? (
                 <div className="mt-3 flex flex-col gap-2 border-t border-slate-200 pt-3 dark:border-slate-800 sm:flex-row sm:items-center sm:justify-end">
-                  <span className="text-xs text-muted-foreground sm:mr-3">Summary Feedback</span>
+                  <span className="text-xs text-muted-foreground sm:mr-3">{t('resumes.detail.summaryFeedback', { defaultValue: 'Summary Feedback' })}</span>
                   <AiFeedbackButtons
                     feedback={aiSummaryFeedback}
-                    label="AI summary"
+                    label={t('resumes.detail.aiSummaryLabel', { defaultValue: 'AI summary' })}
                     testId="detail-ai-summary-feedback"
                     onSelect={(sentiment) => onAiFeedback('ai_summary', sentiment)}
                   />

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -6,6 +6,7 @@ import { Card } from '@/components/ui/card'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import { SnippetCardExpanded } from '@/components/search/SnippetCardExpanded'
 import { cn } from '@/lib/utils'
+import { getResumeContentLocale } from '@/lib/resume-scoring'
 
 type SnippetCardProps = {
   expanded: boolean
@@ -25,6 +26,7 @@ function getPrimaryHeadline(item: ResumeSearchResultItem, fallbackLabel: string)
 
 export function SnippetCard({ expanded, item, showAiScore = false, onToggleExpanded }: SnippetCardProps) {
   const { t } = useTranslation()
+  const contentLocale = getResumeContentLocale(item.resume)
   const analysis = item.analysis ?? item.resume.analysis
   const snippetText = item.resume.workHistory?.[0]?.raw || item.resume.selfIntro
   const visibleKeywords = (
@@ -74,7 +76,7 @@ export function SnippetCard({ expanded, item, showAiScore = false, onToggleExpan
   const primaryHeadline = getPrimaryHeadline(item, profileOverviewLabel)
 
   return (
-    <Card className="overflow-hidden rounded-[1.5rem] border-slate-200 bg-white shadow-[0_18px_50px_-40px_rgba(15,23,42,0.7)]">
+    <Card className="overflow-hidden rounded-[1.5rem] border-slate-200 bg-white shadow-[0_18px_50px_-40px_rgba(15,23,42,0.7)]" lang={contentLocale}>
       <div className="space-y-4 px-5 py-5">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div className="min-w-0 space-y-3">

--- a/apps/web/src/components/search/SnippetCardExpanded.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { buttonVariants } from '@/components/ui/button'
 import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
 import { cn } from '@/lib/utils'
-import { isSafeProfileUrl } from '@/lib/resume-scoring'
+import { getResumeContentLocale, isSafeProfileUrl } from '@/lib/resume-scoring'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 
 type SnippetCardExpandedProps = {
@@ -21,6 +21,7 @@ function formatSnakeCaseLabel(value: string): string {
 export function SnippetCardExpanded({ item, showAiScore = false }: SnippetCardExpandedProps) {
   const { t } = useTranslation()
   const fieldUsagePolicy = useResumeFieldUsagePolicy()
+  const contentLocale = getResumeContentLocale(item.resume)
   const analysis = item.analysis ?? item.resume.analysis
   const hasAiAnalysis = item.scoreSource === 'ai' && Boolean(analysis)
   const pendingAiAnalysis = showAiScore && !hasAiAnalysis
@@ -111,7 +112,7 @@ export function SnippetCardExpanded({ item, showAiScore = false }: SnippetCardEx
   const hasProfileUrl = isSafeProfileUrl(profileUrl)
 
   return (
-    <div className="border-t bg-slate-50/70 px-5 py-5">
+    <div className="border-t bg-slate-50/70 px-5 py-5" lang={contentLocale}>
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1.3fr),minmax(0,0.9fr)]">
         <div className="min-w-0 space-y-4">
           <div className="space-y-2">

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -253,6 +253,14 @@ function buildMockSearchText(doc: ResumeListDocLike): string {
           return [entry.raw, entry.companyName, entry.jobTitle, entry.description]
         })
       : []),
+    ...toStringArray(Array.isArray(content.projectExperience)
+      ? content.projectExperience.flatMap((entry) => {
+          if (!isRecord(entry)) {
+            return []
+          }
+          return [entry.raw, entry.companyName, entry.jobTitle, entry.description]
+        })
+      : []),
   ]
 
   return fragments

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -15,6 +15,17 @@
     "reviewPackets": "Review packets",
     "jds": "JDs"
   },
+  "common": {
+    "loading": "Loading",
+    "loadingMore": "Loading more...",
+    "refresh": "Refresh",
+    "retry": "Retry",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "close": "Close",
+    "collapse": "Collapse",
+    "expand": "Expand"
+  },
   "jdManagement": {
     "title": "Job Description Management",
     "subtitle": "Manage System and Custom Job Descriptions for AI Analysis.",
@@ -268,11 +279,52 @@
     },
     "detail": {
       "title": "Resume Details",
+      "description": "Review resume details and AI analysis summary.",
       "workHistory": "Work History",
       "selfIntro": "Self Introduction",
       "extractedAt": "Updated At",
       "profileLink": "View Original Profile",
-      "close": "Close"
+      "close": "Close",
+      "id": "ID",
+      "aiAnalysis": "AI Analysis",
+      "language": "Language:",
+      "highlights": "Highlights",
+      "concerns": "Concerns",
+      "detailedBreakdown": "Detailed Breakdown",
+      "summaryFeedback": "Summary Feedback",
+      "industryVerified": "Industry verified",
+      "aiScoreLabel": "AI score",
+      "aiSummaryLabel": "AI summary",
+      "promptVersion": "Prompt v{{version}}"
+    },
+    "experienceLevel": {
+      "senior": "Senior",
+      "mid": "Mid",
+      "junior": "Junior"
+    },
+    "roleLabels": {
+      "sales": "Sales",
+      "engineer": "Engineering",
+      "operator": "Operations",
+      "technician": "Technical",
+      "manager": "Management"
+    },
+    "card": {
+      "industryVerifiedSuffix": " (Industry verified)",
+      "relatedYears": "Related years: {{years}}",
+      "industryVerified": "Industry verified: {{years}}",
+      "matchedSignals": "Matched signals: {{signals}}",
+      "matchedExperience": "Matched experience: {{experience}}",
+      "unblock": "Unblock",
+      "block": "Block",
+      "blocked": "Blocked",
+      "blockCandidate": "Block candidate",
+      "blockCandidateDescription": "Add an optional note before blocking this candidate.",
+      "notePlaceholder": "Note",
+      "notePlaceholderInput": "Enter note...",
+      "notesTitle": "Notes",
+      "notesDescription": "Add a note for {{name}}.",
+      "currentPosition": "Current Position"
     },
     "searchPage": {
       "banner": {
@@ -687,6 +739,10 @@
     "customKeywordCategory": "Category",
     "configSources": "Config Sources",
     "configSourcesDescription": "Inspect allowlisted resume config files and prompt sources in read-only mode.",
+    "resumeDisplayLimits": "Resume display limits",
+    "resumeDisplayLimitsDescription": "Read-only limits used by resume presentation logic.",
+    "latestWorkHistoryEntries": "Latest work history entries",
+    "resumeDisplayLimitsSource": "Source file",
     "configSourcesLoadError": "Failed to load config source",
     "configSourceLabel": "Source",
     "configSourceType": "Type",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -15,6 +15,17 @@
     "reviewPackets": "评审包",
     "jds": "职位"
   },
+  "common": {
+    "loading": "加载中...",
+    "loadingMore": "正在加载更多...",
+    "refresh": "刷新",
+    "retry": "重试",
+    "cancel": "取消",
+    "confirm": "确认",
+    "close": "关闭",
+    "collapse": "收起",
+    "expand": "展开"
+  },
   "jdManagement": {
     "title": "职位描述管理",
     "subtitle": "管理系统预设和自定义的职位描述，用于 AI 分析。",
@@ -267,11 +278,52 @@
     },
     "detail": {
       "title": "简历详情",
+      "description": "查看简历详情和 AI 分析摘要。",
       "workHistory": "工作经历",
       "selfIntro": "自我介绍",
       "extractedAt": "更新时间",
       "profileLink": "查看原始简历",
-      "close": "关闭"
+      "close": "关闭",
+      "id": "ID",
+      "aiAnalysis": "AI 分析",
+      "language": "语言：",
+      "highlights": "亮点",
+      "concerns": "关注点",
+      "detailedBreakdown": "详细拆解",
+      "summaryFeedback": "摘要反馈",
+      "industryVerified": "行业验证",
+      "aiScoreLabel": "AI 分数",
+      "aiSummaryLabel": "AI 摘要",
+      "promptVersion": "提示词 v{{version}}"
+    },
+    "experienceLevel": {
+      "senior": "资深",
+      "mid": "中级",
+      "junior": "初级"
+    },
+    "roleLabels": {
+      "sales": "销售",
+      "engineer": "工程",
+      "operator": "操作",
+      "technician": "技术",
+      "manager": "管理"
+    },
+    "card": {
+      "industryVerifiedSuffix": "（行业验证）",
+      "relatedYears": "相关年限：{{years}}",
+      "industryVerified": "行业验证：{{years}}",
+      "matchedSignals": "命中信号：{{signals}}",
+      "matchedExperience": "命中经历：{{experience}}",
+      "unblock": "取消屏蔽",
+      "block": "屏蔽",
+      "blocked": "已屏蔽",
+      "blockCandidate": "屏蔽候选人",
+      "blockCandidateDescription": "为屏蔽候选人添加可选备注。",
+      "notePlaceholder": "备注",
+      "notePlaceholderInput": "输入备注...",
+      "notesTitle": "备注",
+      "notesDescription": "为 {{name}} 添加备注。",
+      "currentPosition": "当前职位"
     },
     "searchPage": {
       "banner": {
@@ -687,6 +739,10 @@
     "customKeywordCategory": "类别",
     "configSources": "配置来源",
     "configSourcesDescription": "以只读方式查看允许暴露的简历配置文件与提示词来源。",
+    "resumeDisplayLimits": "简历展示限制",
+    "resumeDisplayLimitsDescription": "用于简历展示逻辑的只读限制。",
+    "latestWorkHistoryEntries": "最新工作经历条数",
+    "resumeDisplayLimitsSource": "来源文件",
     "configSourcesLoadError": "加载配置来源失败",
     "configSourceLabel": "来源",
     "configSourceType": "类型",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -15,6 +15,17 @@
     "reviewPackets": "評審包",
     "jds": "職位"
   },
+  "common": {
+    "loading": "載入中...",
+    "loadingMore": "正在載入更多...",
+    "refresh": "刷新",
+    "retry": "重試",
+    "cancel": "取消",
+    "confirm": "確認",
+    "close": "關閉",
+    "collapse": "收起",
+    "expand": "展開"
+  },
   "jdManagement": {
     "title": "職位描述管理",
     "subtitle": "管理系統預設和自定義的職位描述，用於 AI 分析。",
@@ -267,11 +278,52 @@
     },
     "detail": {
       "title": "簡歷詳情",
+      "description": "檢視簡歷詳情和 AI 分析摘要。",
       "workHistory": "工作經歷",
       "selfIntro": "自我介紹",
       "extractedAt": "更新時間",
       "profileLink": "查看原始簡歷",
-      "close": "關閉"
+      "close": "關閉",
+      "id": "ID",
+      "aiAnalysis": "AI 分析",
+      "language": "語言：",
+      "highlights": "亮點",
+      "concerns": "關注點",
+      "detailedBreakdown": "詳細拆解",
+      "summaryFeedback": "摘要回饋",
+      "industryVerified": "產業驗證",
+      "aiScoreLabel": "AI 分數",
+      "aiSummaryLabel": "AI 摘要",
+      "promptVersion": "提示詞 v{{version}}"
+    },
+    "experienceLevel": {
+      "senior": "資深",
+      "mid": "中級",
+      "junior": "初級"
+    },
+    "roleLabels": {
+      "sales": "銷售",
+      "engineer": "工程",
+      "operator": "操作",
+      "technician": "技術",
+      "manager": "管理"
+    },
+    "card": {
+      "industryVerifiedSuffix": "（產業驗證）",
+      "relatedYears": "相關年限：{{years}}",
+      "industryVerified": "產業驗證：{{years}}",
+      "matchedSignals": "命中信號：{{signals}}",
+      "matchedExperience": "命中經歷：{{experience}}",
+      "unblock": "取消封鎖",
+      "block": "封鎖",
+      "blocked": "已封鎖",
+      "blockCandidate": "封鎖候選人",
+      "blockCandidateDescription": "為封鎖候選人新增可選備註。",
+      "notePlaceholder": "備註",
+      "notePlaceholderInput": "輸入備註...",
+      "notesTitle": "備註",
+      "notesDescription": "為 {{name}} 新增備註。",
+      "currentPosition": "目前職位"
     },
     "searchPage": {
       "banner": {
@@ -687,6 +739,10 @@
     "customKeywordCategory": "類別",
     "configSources": "配置來源",
     "configSourcesDescription": "以唯讀方式查看允許暴露的履歷配置檔與提示詞來源。",
+    "resumeDisplayLimits": "履歷展示限制",
+    "resumeDisplayLimitsDescription": "用於履歷展示邏輯的唯讀限制。",
+    "latestWorkHistoryEntries": "最新工作經歷條數",
+    "resumeDisplayLimitsSource": "來源檔案",
     "configSourcesLoadError": "載入配置來源失敗",
     "configSourceLabel": "來源",
     "configSourceType": "類型",

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -6930,6 +6930,20 @@ export interface components {
             /** @example 2018 */
             endDate?: string;
         };
+        ResumeImportWorkHistory: {
+            /** @example 2021-03 ~ 2023-08 Example Co. - Sales Manager */
+            raw?: string;
+            /** @example Example Co. */
+            companyName?: string;
+            /** @example Sales Manager */
+            jobTitle?: string;
+            /** @example Managed CNC machine tool accounts across the region. */
+            description?: string;
+            /** @example 2021-03 */
+            startDate?: string;
+            /** @example 2023-08 */
+            endDate?: string;
+        };
         ResumeImportSkillDetail: {
             /** @example CNC */
             name: string;
@@ -7056,6 +7070,8 @@ export interface components {
             name: string;
             /** @example https://hr.job5156.com/resume/view/123 */
             profileUrl: string;
+            /** @example hr.job5156.com */
+            source?: string;
             /** @example Active today */
             activityStatus: string;
             /** @example 28 */
@@ -7075,6 +7091,7 @@ export interface components {
             expectedSalary: string;
             workHistory: components["schemas"]["ResumeWorkHistory"][];
             profileEducation?: components["schemas"]["ResumeImportProfileEducation"][];
+            projectExperience?: components["schemas"]["ResumeImportWorkHistory"][];
             skills?: (string | components["schemas"]["ResumeImportSkillDetail"])[];
             languages?: (string | components["schemas"]["ResumeImportLanguageDetail"])[];
             licences?: (string | components["schemas"]["ResumeImportLicenceDetail"])[];
@@ -7425,20 +7442,6 @@ export interface components {
             /** @example Navigate to sourceUrl, then add ?tr_auto_export=json */
             reproduction?: string;
         };
-        ResumeImportWorkHistory: {
-            /** @example 2021-03 ~ 2023-08 Example Co. - Sales Manager */
-            raw?: string;
-            /** @example Example Co. */
-            companyName?: string;
-            /** @example Sales Manager */
-            jobTitle?: string;
-            /** @example Managed CNC machine tool accounts across the region. */
-            description?: string;
-            /** @example 2021-03 */
-            startDate?: string;
-            /** @example 2023-08 */
-            endDate?: string;
-        };
         ResumeImportRestoreState: {
             /** @example 1763917200000 */
             crawledAt?: number;
@@ -7456,6 +7459,8 @@ export interface components {
             profileId?: string | number;
             profileType?: string;
             externalId?: string;
+            /** @example hr.job5156.com */
+            source?: string;
             /** @example hr.job5156.com */
             sourceHost?: string;
             /**
@@ -7484,6 +7489,7 @@ export interface components {
             selfIntro?: string;
             workHistory?: components["schemas"]["ResumeImportWorkHistory"][];
             profileEducation?: components["schemas"]["ResumeImportProfileEducation"][];
+            projectExperience?: components["schemas"]["ResumeImportWorkHistory"][];
             skills?: (string | components["schemas"]["ResumeImportSkillDetail"])[];
             languages?: (string | components["schemas"]["ResumeImportLanguageDetail"])[];
             licences?: (string | components["schemas"]["ResumeImportLicenceDetail"])[];

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -42,6 +42,15 @@ export type ResumeRoleSignalLike = {
   verifyIn: string
 }
 
+export type ResumeScoringWorkHistoryItem = {
+  raw?: string
+  companyName?: string
+  jobTitle?: string
+  description?: string
+  startDate?: string
+  endDate?: string
+}
+
 const VALID_RECOMMENDATIONS: Recommendation[] = ['strong_match', 'match', 'potential', 'no_match']
 const ROLE_LABELS: Record<string, string> = {
   sales: '销售',
@@ -170,6 +179,22 @@ export function getResumeSourceLabel(resume: unknown): string | undefined {
   return normalizeOptionalString(resume.source)
 }
 
+export function getResumeContentLocale(resume: unknown): string | undefined {
+  const source = getResumeSourceLabel(resume)?.toLowerCase()
+  if (!source) {
+    return undefined
+  }
+
+  if (source.includes('51job')) {
+    return 'zh-Hans'
+  }
+  if (source.includes('job5156')) {
+    return 'zh-Hant'
+  }
+
+  return undefined
+}
+
 export function buildResumeKey(resume: ResumeItem, index: number): string {
   return resolveResumeId(resume, index)
 }
@@ -181,7 +206,8 @@ export function buildRuleScoringText(resume: {
   experience?: string
   location?: string
   selfIntro?: string
-  workHistory?: ResumeItem['workHistory']
+  workHistory?: ResumeScoringWorkHistoryItem[]
+  projectExperience?: ResumeScoringWorkHistoryItem[]
   tags?: string[]
 }): string {
   return [
@@ -192,6 +218,7 @@ export function buildRuleScoringText(resume: {
     resume.location,
     resume.selfIntro,
     ...buildLatestWorkHistoryEvidence(resume.workHistory).lines,
+    ...(resume.projectExperience ?? []).map((entry) => entry?.raw || [entry?.companyName, entry?.jobTitle, entry?.description].filter(Boolean).join(' ')),
     resume.tags?.join(' '),
   ]
     .filter((item): item is string => Boolean(item))

--- a/apps/web/src/pages/system-settings/SystemSettingsConfigSourcesPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsConfigSourcesPage.tsx
@@ -19,6 +19,10 @@ export function SystemSettingsConfigSourcesPage() {
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [configSourceGroups, setConfigSourceGroups] = useState<ConfigSourceGroupSummary[]>([])
+  const [resumeDisplayLimits, setResumeDisplayLimits] = useState<{
+    latestWorkHistoryLimit: number
+    source: string
+  } | null>(null)
   const [selectedConfigSourceKey, setSelectedConfigSourceKey] = useState<string | null>(null)
   const [selectedConfigSourceDetail, setSelectedConfigSourceDetail] = useState<ConfigSourceDetail | null>(null)
 
@@ -53,12 +57,31 @@ export function SystemSettingsConfigSourcesPage() {
     setLoadError(null)
 
     try {
+      const resumeDisplayLimitsPromise = requestJson('/api/config/resume-display-limits').catch((error) => {
+        console.error('Failed to load resume display limits', error)
+        return null
+      })
       const payload = await requestJson('/api/config/source-groups')
       const parsed = parseConfigSourceGroupsPayload(payload)
       if (!parsed) {
         throw new Error('Invalid config source groups response')
       }
       setConfigSourceGroups(parsed)
+
+      const resumeDisplayLimitsPayload = await resumeDisplayLimitsPromise
+      if (
+        resumeDisplayLimitsPayload
+        && typeof resumeDisplayLimitsPayload === 'object'
+        && (resumeDisplayLimitsPayload as { success?: unknown }).success === true
+        && typeof (resumeDisplayLimitsPayload as { latestWorkHistoryLimit?: unknown }).latestWorkHistoryLimit === 'number'
+      ) {
+        setResumeDisplayLimits({
+          latestWorkHistoryLimit: (resumeDisplayLimitsPayload as { latestWorkHistoryLimit: number }).latestWorkHistoryLimit,
+          source: typeof (resumeDisplayLimitsPayload as { source?: unknown }).source === 'string'
+            ? (resumeDisplayLimitsPayload as { source: string }).source
+            : 'packages/shared/src/work-history-evidence.ts',
+        })
+      }
     } catch (error) {
       console.error('Failed to load config source groups', error)
       setLoadError(t('resumes.error'))
@@ -139,6 +162,25 @@ export function SystemSettingsConfigSourcesPage() {
           {loadError}
         </div>
       )}
+
+      {resumeDisplayLimits ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t('debugConfig.resumeDisplayLimits', { defaultValue: 'Resume display limits' })}</CardTitle>
+            <CardDescription>{t('debugConfig.resumeDisplayLimitsDescription', { defaultValue: 'Read-only limits used by resume presentation logic.' })}</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <p className="text-sm text-muted-foreground">{t('debugConfig.latestWorkHistoryEntries', { defaultValue: 'Latest work history entries' })}</p>
+              <p className="text-lg font-semibold">{resumeDisplayLimits.latestWorkHistoryLimit}</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">{t('debugConfig.resumeDisplayLimitsSource', { defaultValue: 'Source file' })}</p>
+              <p className="font-mono text-xs text-muted-foreground">{resumeDisplayLimits.source}</p>
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
 
       <Card>
         <CardHeader>

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -62,10 +62,12 @@ export type ResumeDigitalIdentity = {
 };
 
 export type NormalizedResumeFields = {
+  source?: string;
   profileUrl: string;
   location?: string;
   locationHierarchy?: LocationHierarchy;
   workHistory: ResumeWorkHistoryItem[];
+  projectExperience?: ResumeWorkHistoryItem[];
   profileEducation?: ResumeProfileEducationItem[];
   skills?: Array<string | ResumeSkillDetail>;
   languages?: Array<string | ResumeLanguageDetail>;
@@ -529,10 +531,12 @@ export function normalizeSharedResumeFields(record: Record<string, unknown>, sou
   const location = toTrimmedString(record.location) || formatLocationHierarchyLabel(locationHierarchy);
 
   return {
+    source: toTrimmedString(source) || toTrimmedString(record.source),
     profileUrl: normalizeProfileUrlForDisplay(record.profileUrl, source),
     ...(location ? { location } : {}),
     ...(locationHierarchy ? { locationHierarchy } : {}),
     workHistory: normalizeWorkHistory(record.workHistory),
+    projectExperience: normalizeWorkHistory(record.projectExperience ?? record.project ?? record.projects),
     profileEducation: normalizeProfileEducation(record.profileEducation),
     skills: normalizeStringOrObjectArray(record.skills, normalizeSkillDetail),
     languages: normalizeStringOrObjectArray(record.languages, normalizeLanguageDetail),


### PR DESCRIPTION
## Summary
- Add 51job resume detail enrichment with auth-context capture, direct fetch, and background-tab fallback
- Fix 51job resume ID mapping and detail-page extraction support
- Localize resume detail strings and add source-aware content language hints
- Expose latest work history limit in system settings

## Validation
- make check
- bunx vitest run apps/api/src/routes/config.test.ts
- npm --workspace @trends/web test -- src/lib/resume-scoring.test.ts
- npm --workspace @trends/web test -- src/components/ResumeCard.test.tsx
- npm --workspace @trends/web test -- src/components/ResumeDetail.test.tsx
- npm --workspace @trends/web test -- src/hooks/useResumeListState.test.tsx