### PR TITLE
feat: add 51job parity collection support

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -55,6 +55,8 @@ const JOB5156_HOST = "hr.job5156.com";
 const EHIRE_51JOB_HOST = "ehire.51job.com";
 const SEEK_HOST_SUFFIX = ".employer.seek.com";
 const JOB5156_PROFILE_URL_PREFIX = `https://${JOB5156_HOST}/resume/view/`;
+const EHIRE_51JOB_PROFILE_URL_PREFIX =
+  "https://ehire.51job.com/Revision/talent/resume/detail?contentType=&resumeId=";
 const SOURCE_KEYS = {
   JOB5156: "job5156",
   JOB51: "51job",
@@ -85,6 +87,11 @@ const JOB51_DETAIL_FETCH_CONCURRENCY = 1;
 const JOB51_DETAIL_FETCH_DELAY_MS = 20000;
 const DEFAULT_SEEK_PAGE_SIZE = 20;
 const LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY = "latestAutoSyncSummaries";
+const DEFAULT_COLLECTION_GUARDS = {
+  job5156: "experience,jobIntention,selfIntro",
+  "51job": "",
+  seek: "",
+};
 
 const apiSnapshot = {
   searchRows: null,
@@ -325,6 +332,13 @@ async function getCollectionLimits() {
 }
 
 function resolveJob51CollectionLimits(limit, maxPages) {
+  const params = new URLSearchParams(window.location.search || "");
+  if (params.get("tr_unsafe_limits") === "1") {
+    return {
+      limit: limit > 0 ? limit : JOB51_SAFE_LIMIT,
+      maxPages: maxPages > 0 ? maxPages : JOB51_SAFE_MAX_PAGES,
+    };
+  }
   return {
     limit: limit > 0 ? Math.min(limit, JOB51_SAFE_LIMIT) : JOB51_SAFE_LIMIT,
     maxPages:
@@ -1992,21 +2006,69 @@ async function enrichSingleJob5156SearchResumeWithDetail(resume, extractedAt) {
   }
 }
 
-function applyJob5156CollectionGuards(resume) {
-  if (!resume || typeof resume !== "object") return null;
+const GUARD_FIELD_NAMES = new Set([
+  "experience",
+  "jobIntention",
+  "selfIntro",
+  "expectedSalary",
+  "workHistory",
+  "profileEducation",
+  "projectExperience",
+  "skills",
+  "licences",
+]);
+const GUARD_ARRAY_FIELD_NAMES = new Set([
+  "workHistory",
+  "profileEducation",
+  "projectExperience",
+  "skills",
+  "licences",
+]);
 
-  return {
-    ...resume,
-    experience: "",
-    jobIntention: "",
-    selfIntro: "",
-  };
+async function loadCollectionGuards() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(
+      { collectionGuards: DEFAULT_COLLECTION_GUARDS },
+      (items) => resolve(items.collectionGuards || {}),
+    );
+  });
+}
+
+function parseGuardFieldNames(csv) {
+  if (!csv || typeof csv !== "string") return [];
+  return Array.from(
+    new Set(
+      csv
+        .split(",")
+        .map((field) => field.trim())
+        .filter((field) => GUARD_FIELD_NAMES.has(field)),
+    ),
+  );
+}
+
+function applyCollectionGuards(resume, guardFieldNames) {
+  if (
+    !resume ||
+    typeof resume !== "object" ||
+    !Array.isArray(guardFieldNames) ||
+    guardFieldNames.length === 0
+  ) {
+    return resume;
+  }
+
+  const guarded = { ...resume };
+  for (const field of guardFieldNames) {
+    guarded[field] = GUARD_ARRAY_FIELD_NAMES.has(field) ? [] : "";
+  }
+  return guarded;
 }
 
 async function enrichJob5156SearchResumesWithDetail(resumes) {
   if (!Array.isArray(resumes) || resumes.length === 0) return [];
 
   const extractedAt = new Date().toISOString();
+  const collectionGuards = await loadCollectionGuards();
+  const guardFields = parseGuardFieldNames(collectionGuards?.job5156);
   const enriched = [];
 
   for (
@@ -2027,7 +2089,7 @@ async function enrichJob5156SearchResumesWithDetail(resumes) {
     enriched.push(
       ...batchResults
         .filter(Boolean)
-        .map((resume) => applyJob5156CollectionGuards(resume)),
+        .map((resume) => applyCollectionGuards(resume, guardFields)),
     );
   }
 
@@ -2243,6 +2305,8 @@ async function enrich51JobSearchResumesWithDetail(resumes) {
   if (!Array.isArray(resumes) || resumes.length === 0) return [];
 
   const extractedAt = new Date().toISOString();
+  const collectionGuards = await loadCollectionGuards();
+  const guardFields = parseGuardFieldNames(collectionGuards?.[SOURCE_KEYS.JOB51]);
   const enriched = [];
   let enrichedCount = 0;
 
@@ -2252,7 +2316,7 @@ async function enrich51JobSearchResumesWithDetail(resumes) {
       extractedAt,
     );
     if (result?.resume) {
-      enriched.push(result.resume);
+      enriched.push(applyCollectionGuards(result.resume, guardFields));
     }
     if (result?.enriched) {
       enrichedCount += 1;
@@ -3339,7 +3403,9 @@ function extract51JobResumes() {
         row?.memberId,
     );
     const externalId = resumeId || perUserId;
-    const profileUrl = normalizeJob51Text(row?.profileUrl || row?.resumeUrl);
+    const profileUrl = resumeId
+      ? EHIRE_51JOB_PROFILE_URL_PREFIX + encodeURIComponent(resumeId)
+      : normalizeJob51Text(row?.profileUrl || row?.resumeUrl);
     return {
       name,
       age,
@@ -3678,7 +3744,7 @@ function buildJob51DetailResumeFromPayload(payload, options = {}) {
   const profileUrl = normalizeJob51Text(
     options.profileUrl ||
       (resumeId
-        ? `https://${EHIRE_51JOB_HOST}/Revision/talent/resume/detail?contentType=&resumeId=${encodeURIComponent(resumeId)}`
+        ? `${EHIRE_51JOB_PROFILE_URL_PREFIX}${encodeURIComponent(resumeId)}`
         : ""),
   );
   const baseInfo =

--- a/apps/browser-extension/options.html
+++ b/apps/browser-extension/options.html
@@ -155,6 +155,34 @@
           <div class="hint">0 = 不限制</div>
         </div>
 
+        <div class="field">
+          <div class="label">采集字段过滤 (Collection Field Guards)</div>
+          <textarea
+            id="guard-job5156"
+            class="input"
+            rows="2"
+            placeholder="experience,jobIntention,selfIntro"
+          ></textarea>
+          <div class="hint">job5156</div>
+          <textarea
+            id="guard-51job"
+            class="input"
+            rows="2"
+            placeholder=""
+          ></textarea>
+          <div class="hint">51job</div>
+          <textarea
+            id="guard-seek"
+            class="input"
+            rows="2"
+            placeholder=""
+          ></textarea>
+          <div class="hint">seek</div>
+          <div class="hint">
+            逗号分隔字段名: experience, jobIntention, selfIntro, expectedSalary, workHistory, profileEducation
+          </div>
+        </div>
+
         <div class="row">
           <button id="btn-test" class="btn btn-secondary">
             <span class="icon">🔌</span>

--- a/apps/browser-extension/options.js
+++ b/apps/browser-extension/options.js
@@ -9,6 +9,9 @@
   const keywordModeSpacedInput = /** @type {HTMLInputElement | null} */ ($("keyword-mode-spaced"));
   const collectLimitInput = /** @type {HTMLInputElement | null} */ ($("collect-limit"));
   const maxPagesInput = /** @type {HTMLInputElement | null} */ ($("max-pages"));
+  const guardJob5156Input = /** @type {HTMLTextAreaElement | null} */ ($("guard-job5156"));
+  const guard51jobInput = /** @type {HTMLTextAreaElement | null} */ ($("guard-51job"));
+  const guardSeekInput = /** @type {HTMLTextAreaElement | null} */ ($("guard-seek"));
   const btnTest = /** @type {HTMLButtonElement | null} */ ($("btn-test"));
   const btnSave = /** @type {HTMLButtonElement | null} */ ($("btn-save"));
   const statusDot = /** @type {HTMLElement | null} */ ($("status-dot"));
@@ -18,6 +21,11 @@
   const DEFAULT_SERVER_URL = "https://trends.pt-mes.com";
   const DEFAULT_KEYWORD_MODE = "concat";
   const KEYWORD_MODE_SPACED = "spaced";
+  const DEFAULT_COLLECTION_GUARDS = {
+    job5156: "experience,jobIntention,selfIntro",
+    "51job": "",
+    seek: "",
+  };
 
   function normalizeKeywordMode(value) {
     return value === KEYWORD_MODE_SPACED ? KEYWORD_MODE_SPACED : DEFAULT_KEYWORD_MODE;
@@ -26,6 +34,15 @@
   function normalizeCollectionLimit(value) {
     const parsed = Number.parseInt(String(value || "").trim(), 10);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  }
+
+  function normalizeGuardCsv(value) {
+    if (typeof value !== "string") return "";
+    return value
+      .split(",")
+      .map((field) => field.trim())
+      .filter(Boolean)
+      .join(",");
   }
 
   function showMessage(text, type) {
@@ -98,13 +115,20 @@
   async function loadConfig() {
     return new Promise((resolve) => {
       chrome.storage.local.get(
-        { serverUrl: "", serverToken: "", keywordMode: DEFAULT_KEYWORD_MODE, collectLimit: 0, maxPages: 0 },
+        {
+          serverUrl: "",
+          serverToken: "",
+          keywordMode: DEFAULT_KEYWORD_MODE,
+          collectLimit: 0,
+          maxPages: 0,
+          collectionGuards: DEFAULT_COLLECTION_GUARDS,
+        },
         (items) => resolve(items),
       );
     });
   }
 
-  async function saveConfig(serverUrl, serverToken, keywordMode, collectLimit, maxPages) {
+  async function saveConfig(serverUrl, serverToken, keywordMode, collectLimit, maxPages, collectionGuards) {
     return new Promise((resolve) => {
       chrome.storage.local.set(
         {
@@ -113,6 +137,11 @@
           keywordMode: normalizeKeywordMode(keywordMode),
           collectLimit: normalizeCollectionLimit(collectLimit),
           maxPages: normalizeCollectionLimit(maxPages),
+          collectionGuards: {
+            job5156: normalizeGuardCsv(collectionGuards?.job5156) || DEFAULT_COLLECTION_GUARDS.job5156,
+            "51job": normalizeGuardCsv(collectionGuards?.["51job"]),
+            seek: normalizeGuardCsv(collectionGuards?.seek),
+          },
         },
         () => resolve(true),
       );
@@ -120,14 +149,18 @@
   }
 
   document.addEventListener("DOMContentLoaded", async () => {
-    const items = /** @type {{ serverUrl?: string; serverToken?: string; keywordMode?: string; collectLimit?: number; maxPages?: number }} */ (await loadConfig());
+    const items = /** @type {{ serverUrl?: string; serverToken?: string; keywordMode?: string; collectLimit?: number; maxPages?: number; collectionGuards?: { job5156?: string; "51job"?: string; seek?: string } }} */ (await loadConfig());
     const keywordMode = normalizeKeywordMode(items.keywordMode);
+    const collectionGuards = items.collectionGuards || DEFAULT_COLLECTION_GUARDS;
     if (serverUrlInput) serverUrlInput.value = items.serverUrl || DEFAULT_SERVER_URL;
     if (serverTokenInput) serverTokenInput.value = items.serverToken || "";
     if (keywordModeConcatInput) keywordModeConcatInput.checked = keywordMode !== KEYWORD_MODE_SPACED;
     if (keywordModeSpacedInput) keywordModeSpacedInput.checked = keywordMode === KEYWORD_MODE_SPACED;
     if (collectLimitInput) collectLimitInput.value = String(normalizeCollectionLimit(items.collectLimit));
     if (maxPagesInput) maxPagesInput.value = String(normalizeCollectionLimit(items.maxPages));
+    if (guardJob5156Input) guardJob5156Input.value = collectionGuards.job5156 || DEFAULT_COLLECTION_GUARDS.job5156;
+    if (guard51jobInput) guard51jobInput.value = collectionGuards["51job"] || "";
+    if (guardSeekInput) guardSeekInput.value = collectionGuards.seek || "";
 
     setConnectionStatus(false, "未测试");
 
@@ -155,7 +188,11 @@
         const keywordMode = keywordModeSpacedInput?.checked ? KEYWORD_MODE_SPACED : DEFAULT_KEYWORD_MODE;
         const collectLimit = collectLimitInput?.value || "";
         const maxPages = maxPagesInput?.value || "";
-        await saveConfig(serverUrl, serverToken, keywordMode, collectLimit, maxPages);
+        await saveConfig(serverUrl, serverToken, keywordMode, collectLimit, maxPages, {
+          job5156: guardJob5156Input?.value || "",
+          "51job": guard51jobInput?.value || "",
+          seek: guardSeekInput?.value || "",
+        });
         showMessage("✅ 已保存", "success");
         if (btnSave) btnSave.disabled = false;
       });

--- a/packages/cli/cmd/resume_debug.go
+++ b/packages/cli/cmd/resume_debug.go
@@ -63,6 +63,7 @@ type workflowDatasetVerificationRequest struct {
 	Limit            int
 	Top              int
 	JobDescriptionID string
+	FieldCoverage    bool
 }
 
 type workflowDatasetSourceCountRow struct {
@@ -81,6 +82,20 @@ type workflowDatasetVisibleResumeRow struct {
 	ProfileURL       string `json:"profileUrl,omitempty"`
 }
 
+type workflowDatasetFieldCoverageRow struct {
+	SourceKey                 string  `json:"sourceKey"`
+	ResumeCount               int     `json:"resumeCount"`
+	ProfileURLPct             float64 `json:"profileUrlPct"`
+	ResumeIDPct               float64 `json:"resumeIdPct"`
+	WorkHistoryPct            float64 `json:"workHistoryPct"`
+	WorkHistoryDescriptionPct float64 `json:"workHistoryDescriptionPct"`
+	ProfileEducationPct       float64 `json:"profileEducationPct"`
+	JobIntentionPct           float64 `json:"jobIntentionPct"`
+	ExpectedSalaryPct         float64 `json:"expectedSalaryPct"`
+	SelfIntroPct              float64 `json:"selfIntroPct"`
+	SkillsPct                 float64 `json:"skillsPct"`
+}
+
 type workflowDatasetVerificationReport struct {
 	Query                    string                            `json:"query"`
 	Location                 string                            `json:"location,omitempty"`
@@ -97,6 +112,7 @@ type workflowDatasetVerificationReport struct {
 	VisibleCount             int                               `json:"visibleCount"`
 	VisibleBySourceHost      []workflowDatasetSourceCountRow   `json:"visibleBySourceHost"`
 	VisibleBySourceKey       []workflowDatasetSourceCountRow   `json:"visibleBySourceKey"`
+	FieldCoverageBySource    []workflowDatasetFieldCoverageRow `json:"fieldCoverageBySource,omitempty"`
 	VisibleResumes           []workflowDatasetVisibleResumeRow `json:"visibleResumes"`
 }
 
@@ -214,6 +230,9 @@ var runWorkflowDatasetVerifier = func(ctx context.Context, request workflowDatas
 	}
 	if value := strings.TrimSpace(request.JobDescriptionID); value != "" {
 		args = append(args, "--job-description", value)
+	}
+	if request.FieldCoverage {
+		args = append(args, "--field-coverage")
 	}
 
 	stdout, stderr, err := runBunScript(ctx, projectRoot, scriptPath, args, nil)
@@ -581,6 +600,7 @@ func newResumeDebugWorkflowDatasetCmd() *cobra.Command {
 		jobDescriptionID string
 		limit            int
 		top              int
+		fieldCoverage    bool
 	)
 
 	cmd := &cobra.Command{
@@ -608,6 +628,7 @@ func newResumeDebugWorkflowDatasetCmd() *cobra.Command {
 				Limit:            limit,
 				Top:              top,
 				JobDescriptionID: strings.TrimSpace(jobDescriptionID),
+				FieldCoverage:    fieldCoverage,
 			})
 			if err != nil {
 				return err
@@ -652,6 +673,47 @@ func newResumeDebugWorkflowDatasetCmd() *cobra.Command {
 				)
 			}
 
+			if fieldCoverage && len(report.FieldCoverageBySource) > 0 {
+				coverageHeaders := []string{
+					"source_key",
+					"count",
+					"profile_url",
+					"resume_id",
+					"work_history",
+					"work_history_desc",
+					"profile_education",
+					"job_intention",
+					"expected_salary",
+					"self_intro",
+					"skills",
+				}
+				coverageRows := make([][]string, 0, len(report.FieldCoverageBySource))
+				for _, row := range report.FieldCoverageBySource {
+					coverageRows = append(coverageRows, []string{
+						row.SourceKey,
+						strconv.Itoa(row.ResumeCount),
+						formatWorkflowDatasetCoveragePercent(row.ProfileURLPct),
+						formatWorkflowDatasetCoveragePercent(row.ResumeIDPct),
+						formatWorkflowDatasetCoveragePercent(row.WorkHistoryPct),
+						formatWorkflowDatasetCoveragePercent(row.WorkHistoryDescriptionPct),
+						formatWorkflowDatasetCoveragePercent(row.ProfileEducationPct),
+						formatWorkflowDatasetCoveragePercent(row.JobIntentionPct),
+						formatWorkflowDatasetCoveragePercent(row.ExpectedSalaryPct),
+						formatWorkflowDatasetCoveragePercent(row.SelfIntroPct),
+						formatWorkflowDatasetCoveragePercent(row.SkillsPct),
+					})
+				}
+				if options.Output == "table" {
+					fmt.Fprintln(cmd.OutOrStdout(), "Field coverage by source:")
+				}
+				if err := writeOutput(cmd, coverageHeaders, coverageRows, report.FieldCoverageBySource); err != nil {
+					return err
+				}
+				if options.Output == "table" {
+					fmt.Fprintln(cmd.OutOrStdout())
+				}
+			}
+
 			if len(rows) == 0 && options.Output == "table" {
 				return writeMessage(cmd, "No visible resumes after workflow filters")
 			}
@@ -666,6 +728,7 @@ func newResumeDebugWorkflowDatasetCmd() *cobra.Command {
 	cmd.Flags().StringVar(&jobDescriptionID, "job-description", "", "Optional job description ID for score display")
 	cmd.Flags().IntVar(&limit, "limit", 200, "Maximum resumes to scan")
 	cmd.Flags().IntVar(&top, "top", 10, "Maximum visible resumes to print")
+	cmd.Flags().BoolVar(&fieldCoverage, "field-coverage", false, "Include source-level field coverage percentages")
 	return cmd
 }
 
@@ -854,6 +917,10 @@ func formatWorkflowDatasetCounts(rows []workflowDatasetSourceCountRow) string {
 		parts = append(parts, fmt.Sprintf("%s:%d", row.Key, row.Count))
 	}
 	return strings.Join(parts, ", ")
+}
+
+func formatWorkflowDatasetCoveragePercent(value float64) string {
+	return fmt.Sprintf("%.1f%%", value)
 }
 
 func writeResumeMatchTable(cmd *cobra.Command, response *client.ResumeMatchResponse, displayMap map[string]resumeDisplayRow) error {

--- a/packages/cli/cmd/resume_debug_test.go
+++ b/packages/cli/cmd/resume_debug_test.go
@@ -156,6 +156,9 @@ func TestResumeDebugWorkflowDatasetCommandWritesJSON(t *testing.T) {
 		if request.JobDescriptionID != "seek-malaysia-sales" {
 			t.Fatalf("unexpected job description: %q", request.JobDescriptionID)
 		}
+		if !request.FieldCoverage {
+			t.Fatal("expected field coverage to be enabled")
+		}
 		if request.Limit != 250 || request.Top != 5 {
 			t.Fatalf("unexpected scan config: limit=%d top=%d", request.Limit, request.Top)
 		}
@@ -173,6 +176,13 @@ func TestResumeDebugWorkflowDatasetCommandWritesJSON(t *testing.T) {
 			},
 			QueryMatchCount: 6,
 			VisibleCount:    1,
+			FieldCoverageBySource: []workflowDatasetFieldCoverageRow{
+				{
+					SourceKey:     "seek",
+					ResumeCount:   1,
+					ProfileURLPct: 100,
+				},
+			},
 			VisibleBySourceKey: []workflowDatasetSourceCountRow{
 				{Key: "seek", Count: 1},
 			},
@@ -200,6 +210,7 @@ func TestResumeDebugWorkflowDatasetCommandWritesJSON(t *testing.T) {
 		"--job-description", "seek-malaysia-sales",
 		"--limit", "250",
 		"--top", "5",
+		"--field-coverage",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -238,6 +249,21 @@ func TestResumeDebugWorkflowDatasetCommandWritesTable(t *testing.T) {
 			VisibleBySourceKey: []workflowDatasetSourceCountRow{
 				{Key: "seek", Count: 1},
 			},
+			FieldCoverageBySource: []workflowDatasetFieldCoverageRow{
+				{
+					SourceKey:                 "job5156",
+					ResumeCount:               191,
+					ProfileURLPct:             75,
+					ResumeIDPct:               90,
+					WorkHistoryPct:            60,
+					WorkHistoryDescriptionPct: 40,
+					ProfileEducationPct:       20,
+					JobIntentionPct:           50,
+					ExpectedSalaryPct:         35,
+					SelfIntroPct:              10,
+					SkillsPct:                 5,
+				},
+			},
 			VisibleResumes: []workflowDatasetVisibleResumeRow{
 				{
 					ResumeID:         "resume-1",
@@ -255,7 +281,7 @@ func TestResumeDebugWorkflowDatasetCommandWritesTable(t *testing.T) {
 	var output bytes.Buffer
 	cmd.SetOut(&output)
 	cmd.SetErr(&output)
-	cmd.SetArgs([]string{"--query", "CNC Sales"})
+	cmd.SetArgs([]string{"--query", "CNC Sales", "--field-coverage"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("resume debug workflow-dataset command failed: %v", err)
@@ -264,6 +290,9 @@ func TestResumeDebugWorkflowDatasetCommandWritesTable(t *testing.T) {
 	text := output.String()
 	if !strings.Contains(text, "Query: CNC Sales | Workspace: dev | Query matches: 6 | Visible after filters: 1") {
 		t.Fatalf("unexpected summary output: %s", text)
+	}
+	if !strings.Contains(text, "Field coverage by source:") || !strings.Contains(text, "75.0%") {
+		t.Fatalf("unexpected coverage output: %s", text)
 	}
 	if !strings.Contains(text, "Yap Kae Wen") || !strings.Contains(text, "seek") || !strings.Contains(text, "86") {
 		t.Fatalf("unexpected table output: %s", text)

--- a/packages/cli/cmd/resume_snapshot.go
+++ b/packages/cli/cmd/resume_snapshot.go
@@ -12,16 +12,18 @@ import (
 )
 
 type resumeSnapshotRequest struct {
-	APIURL      string
-	Workspace   string
-	Count       int
-	MaxPages    int
-	OutDir      string
-	Sources     []string
-	Job5156URL  string
-	SeekURL     string
-	ManualFile  string
-	CDPEndpoint string
+	APIURL       string
+	Workspace    string
+	Count        int
+	MaxPages     int
+	OutDir       string
+	Sources      []string
+	Job5156URL   string
+	Job51URL     string
+	SeekURL      string
+	ManualFile   string
+	CDPEndpoint  string
+	UnsafeLimits bool
 }
 
 type resumeSnapshotManualImportSummary struct {
@@ -112,6 +114,9 @@ func buildResumeSnapshotScriptArgs(request resumeSnapshotRequest) []string {
 	if value := strings.TrimSpace(request.Job5156URL); value != "" {
 		args = append(args, "--job5156-url", value)
 	}
+	if value := strings.TrimSpace(request.Job51URL); value != "" {
+		args = append(args, "--51job-url", value)
+	}
 	if value := strings.TrimSpace(request.SeekURL); value != "" {
 		args = append(args, "--seek-url", value)
 	}
@@ -120,6 +125,9 @@ func buildResumeSnapshotScriptArgs(request resumeSnapshotRequest) []string {
 	}
 	if value := strings.TrimSpace(request.CDPEndpoint); value != "" {
 		args = append(args, "--cdp-endpoint", value)
+	}
+	if request.UnsafeLimits {
+		args = append(args, "--unsafe-limits")
 	}
 
 	return args
@@ -176,14 +184,16 @@ func buildResumeSnapshotOutput(result *resumeSnapshotResult) resumeSummaryOutput
 
 func newResumeSnapshotCmd() *cobra.Command {
 	var (
-		count       int
-		maxPages    int
-		outDir      string
-		sources     []string
-		job5156URL  string
-		seekURL     string
-		manualFile  string
-		cdpEndpoint string
+		count        int
+		maxPages     int
+		outDir       string
+		sources      []string
+		job5156URL   string
+		job51URL     string
+		seekURL      string
+		manualFile   string
+		cdpEndpoint  string
+		unsafeLimits bool
 	)
 
 	cmd := &cobra.Command{
@@ -200,16 +210,18 @@ func newResumeSnapshotCmd() *cobra.Command {
 
 			options := currentOptions()
 			response, err := runResumeSnapshot(context.Background(), resumeSnapshotRequest{
-				APIURL:      options.APIURL,
-				Workspace:   options.Workspace,
-				Count:       count,
-				MaxPages:    maxPages,
-				OutDir:      outDir,
-				Sources:     sources,
-				Job5156URL:  job5156URL,
-				SeekURL:     seekURL,
-				ManualFile:  manualFile,
-				CDPEndpoint: cdpEndpoint,
+				APIURL:       options.APIURL,
+				Workspace:    options.Workspace,
+				Count:        count,
+				MaxPages:     maxPages,
+				OutDir:       outDir,
+				Sources:      sources,
+				Job5156URL:   job5156URL,
+				Job51URL:     job51URL,
+				SeekURL:      seekURL,
+				ManualFile:   manualFile,
+				CDPEndpoint:  cdpEndpoint,
+				UnsafeLimits: unsafeLimits,
 			})
 			if err != nil {
 				return err
@@ -220,14 +232,16 @@ func newResumeSnapshotCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringArrayVar(&sources, "source", nil, "Snapshot source alias (repeatable): job5156|seek|51job-manual")
+	cmd.Flags().StringArrayVar(&sources, "source", nil, "Snapshot source alias (repeatable): job5156|seek|51job|51job-manual")
 	cmd.Flags().IntVar(&count, "count", 0, "Resumes per source (default: snapshot script default)")
 	cmd.Flags().IntVar(&maxPages, "max-pages", 0, "Browser pages per source collection (default: snapshot script default)")
 	cmd.Flags().StringVar(&outDir, "out-dir", "", "Output directory (default: snapshot script default)")
 	cmd.Flags().StringVar(&job5156URL, "job5156-url", "", "Override the Job5156 source URL")
+	cmd.Flags().StringVar(&job51URL, "51job-url", "", "Override the 51job source URL")
 	cmd.Flags().StringVar(&seekURL, "seek-url", "", "Override the SEEK source URL")
 	cmd.Flags().StringVar(&manualFile, "manual-file", "", "Override the manual 51job archive path")
 	cmd.Flags().StringVar(&cdpEndpoint, "cdp-endpoint", "", "Override the Chrome DevTools endpoint or port")
+	cmd.Flags().BoolVar(&unsafeLimits, "unsafe-limits", false, "Allow live 51job launches to bypass extension safe caps")
 
 	return cmd
 }

--- a/packages/cli/cmd/resume_snapshot_test.go
+++ b/packages/cli/cmd/resume_snapshot_test.go
@@ -29,17 +29,23 @@ func TestResumeSnapshotCommandPassesFlagsAndWritesJSON(t *testing.T) {
 		if request.MaxPages != 8 {
 			t.Fatalf("unexpected max pages: %d", request.MaxPages)
 		}
-		if len(request.Sources) != 2 || request.Sources[0] != "job5156" || request.Sources[1] != "51job-manual" {
+		if len(request.Sources) != 3 || request.Sources[0] != "job5156" || request.Sources[1] != "51job" || request.Sources[2] != "51job-manual" {
 			t.Fatalf("unexpected sources: %+v", request.Sources)
 		}
 		if request.OutDir != "output/resume-backups/custom" {
 			t.Fatalf("unexpected out dir: %q", request.OutDir)
+		}
+		if request.Job51URL != "https://ehire.51job.com/Revision/talent/search" {
+			t.Fatalf("unexpected 51job url: %q", request.Job51URL)
 		}
 		if request.ManualFile != "~/Downloads/51job.rar" {
 			t.Fatalf("unexpected manual file: %q", request.ManualFile)
 		}
 		if request.CDPEndpoint != "http://127.0.0.1:9333" {
 			t.Fatalf("unexpected cdp endpoint: %q", request.CDPEndpoint)
+		}
+		if !request.UnsafeLimits {
+			t.Fatal("expected unsafe limits to be enabled")
 		}
 
 		return &resumeSnapshotResult{
@@ -69,12 +75,15 @@ func TestResumeSnapshotCommandPassesFlagsAndWritesJSON(t *testing.T) {
 	cmd.SetErr(&output)
 	cmd.SetArgs([]string{
 		"--source", "job5156",
+		"--source", "51job",
 		"--source", "51job-manual",
 		"--count", "25",
 		"--max-pages", "8",
 		"--out-dir", "output/resume-backups/custom",
+		"--51job-url", "https://ehire.51job.com/Revision/talent/search",
 		"--manual-file", "~/Downloads/51job.rar",
 		"--cdp-endpoint", "http://127.0.0.1:9333",
+		"--unsafe-limits",
 	})
 
 	if err := cmd.Execute(); err != nil {

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -38,6 +38,25 @@ function toOptionalStringValue(value: unknown): string | undefined {
     return normalized.length > 0 ? normalized : undefined;
 }
 
+function hasNonEmptyArray(value: unknown): boolean {
+    return Array.isArray(value) && value.length > 0;
+}
+
+function readRecordArray(value: unknown): Record<string, unknown>[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return value.filter(isRecord);
+}
+
+function hasResumeFieldValue(content: Record<string, unknown>, keys: string[]): boolean {
+    return keys.some((key) => Boolean(toOptionalStringValue(content[key])));
+}
+
+function hasWorkHistoryDescriptionEntries(value: unknown): boolean {
+    return readRecordArray(value).some((entry) => Boolean(toOptionalStringValue(entry.description)));
+}
+
 function toRuleScores(value: unknown): Record<string, number> {
     if (!isRecord(value)) {
         return {};
@@ -181,6 +200,20 @@ export type ResumeWorkflowDatasetRow = {
     content?: {
         profileType?: string;
     };
+};
+
+export type ResumeFieldCoverageDatasetRow = {
+    source: Doc<"resumes">["source"];
+    profileType?: string;
+    profileUrl: boolean;
+    resumeId: boolean;
+    workHistoryCount: number;
+    workHistoryHasDescription: boolean;
+    profileEducation: boolean;
+    jobIntention: boolean;
+    expectedSalary: boolean;
+    selfIntro: boolean;
+    skills: boolean;
 };
 
 type ResumeBackupRow = {
@@ -1643,6 +1676,45 @@ export const listWorkflowDatasetPage = query({
                 return {
                     source: resume.source,
                     ...(profileType ? { content: { profileType } } : {}),
+                };
+            }),
+        };
+    },
+});
+
+export const listFieldCoverageDatasetPage = query({
+    args: {
+        cursor: v.optional(v.string()),
+        limit: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const page = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.limit),
+            });
+
+        return {
+            continueCursor: page.continueCursor,
+            isDone: page.isDone,
+            page: page.page.map((resume): ResumeFieldCoverageDatasetRow => {
+                const content = isRecord(resume.content) ? resume.content : {};
+                const profileType = toOptionalStringValue(content.profileType);
+                const workHistory = readRecordArray(content.workHistory);
+                return {
+                    source: resume.source,
+                    ...(profileType ? { profileType } : {}),
+                    profileUrl: hasResumeFieldValue(content, ["profileUrl", "profile_url", "profileURL", "url"]),
+                    resumeId: hasResumeFieldValue(content, ["resumeId"]),
+                    workHistoryCount: workHistory.length,
+                    workHistoryHasDescription: hasWorkHistoryDescriptionEntries(workHistory),
+                    profileEducation: hasNonEmptyArray(content.profileEducation),
+                    jobIntention: hasResumeFieldValue(content, ["jobIntention"]),
+                    expectedSalary: hasResumeFieldValue(content, ["expectedSalary"]),
+                    selfIntro: hasResumeFieldValue(content, ["selfIntro"]),
+                    skills: hasNonEmptyArray(content.skills),
                 };
             }),
         };

--- a/scripts/resume/collect_browser_source.py
+++ b/scripts/resume/collect_browser_source.py
@@ -29,11 +29,13 @@ DEFAULT_MAX_PAGES = 10
 
 SOURCE_URLS = {
     "job5156": "https://hr.job5156.com/search?keyword=CNC+%E9%94%80%E5%94%AE&tr_min_age=25&tr_max_age=40",
+    "51job": "https://ehire.51job.com/Revision/talent/search",
     "seek": "https://hk.employer.seek.com/candidates/recommended?jobId=90842915",
 }
 
 SOURCE_HOSTS = {
     "job5156": "hr.job5156.com",
+    "51job": "ehire.51job.com",
     "seek": "hk.employer.seek.com",
 }
 
@@ -79,6 +81,9 @@ def is_supported_source_page(source: str, page_url: str) -> bool:
     if source == "job5156":
         return hostname == "hr.job5156.com" and pathname == "/search"
 
+    if source == "51job":
+        return hostname == "ehire.51job.com" and "/talent/search" in pathname
+
     if source == "seek":
         return hostname.endswith(".employer.seek.com") and pathname == "/candidates/recommended"
 
@@ -94,6 +99,13 @@ def describe_unsupported_source_page(source: str, page_url: str, page_title: str
         return (
             "SEEK requires an employer account selection before candidate pages are available. "
             f"Complete the account selection in Chrome, let it land on /candidates/recommended, then rerun. "
+            f"Requested page: {search_url}. Current page: {page_url}"
+        )
+
+    if source == "51job" and ("/login" in pathname or "login" in page_url.lower()):
+        return (
+            "51job redirected to a login page before the talent search results were available. "
+            "Log in inside Chrome, reopen the talent search page, then rerun. "
             f"Requested page: {search_url}. Current page: {page_url}"
         )
 

--- a/scripts/resume/snapshot-source-backups.test.ts
+++ b/scripts/resume/snapshot-source-backups.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { readPortableBackupFile } from "./operator-utils.ts";
 import {
+  DEFAULT_51JOB_URL,
   DEFAULT_JOB5156_URL,
   DEFAULT_SEEK_URL,
   SOURCE_HOSTS,
@@ -49,18 +50,24 @@ function baseOptions(
     outDir: path.join(repoRoot, "output", "resume-backups"),
     sources: [source],
     job5156Url: DEFAULT_JOB5156_URL,
+    job51Url: DEFAULT_51JOB_URL,
     seekUrl: DEFAULT_SEEK_URL,
     manualFile: "~/Downloads/51job.rar",
     cdpEndpoint: "http://127.0.0.1:9222",
     waitTimeoutSec: 600,
+    unsafeLimits: false,
   };
 }
 
 function createCollectedPayload(
-  alias: "job5156" | "seek",
+  alias: "job5156" | "seek" | "51job",
   count: number,
 ): Record<string, unknown> {
-  const sourceUrl = alias === "seek" ? DEFAULT_SEEK_URL : DEFAULT_JOB5156_URL;
+  const sourceUrl = alias === "seek"
+    ? DEFAULT_SEEK_URL
+    : alias === "51job"
+      ? DEFAULT_51JOB_URL
+      : DEFAULT_JOB5156_URL;
   return {
     metadata: {
       sourceUrl,
@@ -94,6 +101,7 @@ describe("snapshot-source-backups", () => {
     expect(resolveRequestedSources([])).toEqual([
       "job5156",
       "seek",
+      "51job",
       "51job-manual",
     ]);
   });
@@ -199,6 +207,59 @@ describe("snapshot-source-backups", () => {
     expect(written.metadata.totalResumes).toBe(20);
     expect(written.resumes).toHaveLength(20);
     expect(written.resumes[0]?.sourceHost).toBe(SOURCE_HOSTS.seek);
+  });
+
+  it("adds the unsafe limit override to live 51job launches", async () => {
+    const repoRoot = await createTestRepoRoot();
+    repoRoots.push(repoRoot);
+    const exec = vi.fn(async (_command: string, args: string[]) => {
+      const launchUrl = String(args[args.indexOf("--url") + 1] || "");
+      if (args.includes("--check-only")) {
+        return {
+          stdout: JSON.stringify({
+            mode: "check",
+            source: "51job",
+            sourceHost: SOURCE_HOSTS["51job"],
+            url: launchUrl,
+            status: { sourceKey: "51job" },
+          }),
+          stderr: "",
+        };
+      }
+
+      return {
+        stdout: JSON.stringify({
+          mode: "collect",
+          source: "51job",
+          sourceHost: SOURCE_HOSTS["51job"],
+          url: launchUrl,
+          status: { sourceKey: "51job" },
+          payload: createCollectedPayload("51job", 20),
+        }),
+        stderr: "",
+      };
+    });
+
+    const result = await runSnapshotSourceBackups(
+      {
+        ...baseOptions(repoRoot, "51job"),
+        unsafeLimits: true,
+      },
+      {
+        now: fixedNow,
+        exec,
+        log: () => undefined,
+        resolveUserHomeDirectory: async () => "/Users/tester",
+      },
+    );
+
+    expect(result.sources[0]).toMatchObject({
+      alias: "51job",
+      sourceHost: SOURCE_HOSTS["51job"],
+      launchUrl: `${DEFAULT_51JOB_URL}?tr_unsafe_limits=1`,
+      count: 20,
+      observedCount: 20,
+    });
   });
 
   it("fails and leaves no output file when the collected snapshot is short", async () => {

--- a/scripts/resume/snapshot-source-backups.ts
+++ b/scripts/resume/snapshot-source-backups.ts
@@ -24,15 +24,17 @@ const DEFAULT_OUT_DIR = "output/resume-backups";
 const DEFAULT_MANUAL_FILE = "~/Downloads/51job.rar";
 const DEFAULT_JOB5156_URL =
   "https://hr.job5156.com/search?keyword=CNC+%E9%94%80%E5%94%AE&tr_min_age=25&tr_max_age=40";
+const DEFAULT_51JOB_URL = "https://ehire.51job.com/Revision/talent/search";
 const DEFAULT_SEEK_URL =
   "https://hk.employer.seek.com/candidates/recommended?jobId=90842915";
 
-export const SOURCE_ALIASES = ["job5156", "seek", "51job-manual"] as const;
+export const SOURCE_ALIASES = ["job5156", "seek", "51job", "51job-manual"] as const;
 export type SourceAlias = (typeof SOURCE_ALIASES)[number];
 
 const SOURCE_HOSTS: Record<SourceAlias, string> = {
   job5156: "hr.job5156.com",
   seek: "hk.employer.seek.com",
+  "51job": "ehire.51job.com",
   "51job-manual": "51job-manual",
 };
 
@@ -44,10 +46,12 @@ type SnapshotCliArgs = {
   outDir: string;
   sources: SourceAlias[];
   job5156Url: string;
+  job51Url: string;
   seekUrl: string;
   manualFile: string;
   cdpEndpoint: string;
   waitTimeoutSec: number;
+  unsafeLimits: boolean;
 };
 
 export type SnapshotOptions = SnapshotCliArgs & {
@@ -121,7 +125,7 @@ export type SnapshotRunSummary = {
   sources: SnapshotSourceResult[];
 };
 
-type BrowserSourceAlias = Extract<SourceAlias, "job5156" | "seek">;
+type BrowserSourceAlias = Extract<SourceAlias, "job5156" | "51job" | "seek">;
 
 type ManualSnapshotPayloadResult = {
   payload: ResumeBackupEnvelope;
@@ -148,17 +152,19 @@ function usage(): string {
     "Usage: bun run scripts/resume/snapshot-source-backups.ts [options]",
     "",
     "Options:",
-    "  --source <alias>           Repeatable source alias: job5156 | seek | 51job-manual",
+    "  --source <alias>           Repeatable source alias: job5156 | seek | 51job | 51job-manual",
     `  --count <number>           Resumes per source (default: ${DEFAULT_COUNT})`,
     `  --max-pages <number>       Browser pages per source collection (default: ${DEFAULT_MAX_PAGES})`,
     `  --api-url <url>            Retained for CLI compatibility (default: ${resolveApiUrl()})`,
     `  --workspace <slug>         Retained for CLI compatibility (default: ${resolveWorkspace()})`,
     `  --out-dir <path>           Output directory (default: ${DEFAULT_OUT_DIR})`,
     `  --job5156-url <url>        Direct Job5156 source URL (default: ${DEFAULT_JOB5156_URL})`,
+    `  --51job-url <url>          Direct 51job source URL (default: ${DEFAULT_51JOB_URL})`,
     `  --seek-url <url>           Direct SEEK source URL (default: ${DEFAULT_SEEK_URL})`,
     `  --manual-file <path>       Manual 51job archive path (default: ${DEFAULT_MANUAL_FILE})`,
     `  --cdp-endpoint <value>     Chrome DevTools endpoint or port (default: ${DEFAULT_CDP_ENDPOINT})`,
     `  --wait-timeout-sec <n>     Retained for CLI compatibility (default: ${DEFAULT_WAIT_TIMEOUT_SEC})`,
+    "  --unsafe-limits            Allow live 51job launches to bypass extension safe caps",
     "  --open-browser             Deprecated no-op retained for CLI compatibility",
     "  --help                     Show this help",
   ].join("\n");
@@ -260,6 +266,7 @@ export function parseCliArgs(argv: string[]): SnapshotCliArgs {
     sources: resolveRequestedSources(readCliValues(argv, "source")),
     job5156Url:
       readCliValue(argv, "job5156-url")?.trim() || DEFAULT_JOB5156_URL,
+    job51Url: readCliValue(argv, "51job-url")?.trim() || DEFAULT_51JOB_URL,
     seekUrl: readCliValue(argv, "seek-url")?.trim() || DEFAULT_SEEK_URL,
     manualFile:
       readCliValue(argv, "manual-file")?.trim() || DEFAULT_MANUAL_FILE,
@@ -269,6 +276,7 @@ export function parseCliArgs(argv: string[]): SnapshotCliArgs {
       readCliValue(argv, "wait-timeout-sec"),
       DEFAULT_WAIT_TIMEOUT_SEC,
     ),
+    unsafeLimits: hasCliFlag(argv, "unsafe-limits"),
   };
 }
 
@@ -598,6 +606,15 @@ function buildSourceLaunchUrl(
   if (alias === "job5156") {
     return options.job5156Url;
   }
+  if (alias === "51job") {
+    const launchUrl = options.job51Url;
+    if (!options.unsafeLimits) {
+      return launchUrl;
+    }
+    const parsedUrl = new URL(launchUrl);
+    parsedUrl.searchParams.set("tr_unsafe_limits", "1");
+    return parsedUrl.toString();
+  }
   if (alias === "seek") {
     return options.seekUrl;
   }
@@ -766,6 +783,7 @@ if (isMainModule) {
 }
 
 export {
+  DEFAULT_51JOB_URL,
   DEFAULT_JOB5156_URL,
   DEFAULT_MANUAL_FILE,
   DEFAULT_SEEK_URL,

--- a/scripts/resume/verify-workflow-dataset.test.ts
+++ b/scripts/resume/verify-workflow-dataset.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { countByKey, getResumeSourceKey, matchesWorkflowFilters } from "./verify-workflow-dataset.ts";
+import {
+  buildFieldCoverageReport,
+  countByKey,
+  getResumeSourceKey,
+  matchesWorkflowFilters,
+} from "./verify-workflow-dataset.ts";
 
 describe("verify workflow dataset helpers", () => {
   it("derives source keys from source hosts and profile types", () => {
@@ -61,6 +66,79 @@ describe("verify workflow dataset helpers", () => {
     expect(rows).toEqual([
       { key: "my.employer.seek.com", count: 2 },
       { key: "unknown", count: 1 },
+    ]);
+  });
+
+  it("builds field coverage summaries with a dedicated live 51job bucket", () => {
+    const rows = buildFieldCoverageReport([
+      {
+        source: "ehire.51job.com",
+        profileType: "51job",
+        profileUrl: true,
+        resumeId: true,
+        workHistoryCount: 1,
+        workHistoryHasDescription: false,
+        profileEducation: false,
+        jobIntention: true,
+        expectedSalary: false,
+        selfIntro: false,
+        skills: false,
+      },
+      {
+        source: "ehire.51job.com",
+        profileType: "51job",
+        profileUrl: false,
+        resumeId: true,
+        workHistoryCount: 0,
+        workHistoryHasDescription: false,
+        profileEducation: false,
+        jobIntention: false,
+        expectedSalary: false,
+        selfIntro: false,
+        skills: true,
+      },
+      {
+        source: "my.employer.seek.com",
+        profileType: "seek",
+        profileUrl: true,
+        resumeId: false,
+        workHistoryCount: 1,
+        workHistoryHasDescription: true,
+        profileEducation: true,
+        jobIntention: true,
+        expectedSalary: true,
+        selfIntro: false,
+        skills: true,
+      },
+    ]);
+
+    expect(rows).toEqual([
+      {
+        sourceKey: "51job",
+        resumeCount: 2,
+        profileUrlPct: 50,
+        resumeIdPct: 100,
+        workHistoryPct: 50,
+        workHistoryDescriptionPct: 0,
+        profileEducationPct: 0,
+        jobIntentionPct: 50,
+        expectedSalaryPct: 0,
+        selfIntroPct: 0,
+        skillsPct: 50,
+      },
+      {
+        sourceKey: "seek",
+        resumeCount: 1,
+        profileUrlPct: 100,
+        resumeIdPct: 0,
+        workHistoryPct: 100,
+        workHistoryDescriptionPct: 100,
+        profileEducationPct: 100,
+        jobIntentionPct: 100,
+        expectedSalaryPct: 100,
+        selfIntroPct: 0,
+        skillsPct: 100,
+      },
     ]);
   });
 });

--- a/scripts/resume/verify-workflow-dataset.ts
+++ b/scripts/resume/verify-workflow-dataset.ts
@@ -38,6 +38,20 @@ type ResumeDoc = {
 
 type WorkflowDatasetPageRow = Pick<ResumeDoc, "source" | "content">;
 
+type FieldCoverageDatasetPageRow = {
+  source: string;
+  profileType?: string;
+  profileUrl: boolean;
+  resumeId: boolean;
+  workHistoryCount: number;
+  workHistoryHasDescription: boolean;
+  profileEducation: boolean;
+  jobIntention: boolean;
+  expectedSalary: boolean;
+  selfIntro: boolean;
+  skills: boolean;
+};
+
 type SearchResult = {
   resume: ResumeDoc;
   provenance: Array<{
@@ -57,6 +71,7 @@ type CliOptions = {
   limit: number;
   top: number;
   jobDescriptionId?: string;
+  fieldCoverage: boolean;
   json: boolean;
 };
 
@@ -76,6 +91,20 @@ type VisibleResumeRow = {
   profileUrl?: string;
 };
 
+type FieldCoverageSourceSummary = {
+  sourceKey: string;
+  resumeCount: number;
+  profileUrlPct: number;
+  resumeIdPct: number;
+  workHistoryPct: number;
+  workHistoryDescriptionPct: number;
+  profileEducationPct: number;
+  jobIntentionPct: number;
+  expectedSalaryPct: number;
+  selfIntroPct: number;
+  skillsPct: number;
+};
+
 type WorkflowVerificationReport = {
   query: string;
   location?: string;
@@ -92,6 +121,7 @@ type WorkflowVerificationReport = {
   visibleCount: number;
   visibleBySourceHost: SourceCountRow[];
   visibleBySourceKey: SourceCountRow[];
+  fieldCoverageBySource?: FieldCoverageSourceSummary[];
   visibleResumes: VisibleResumeRow[];
 };
 
@@ -150,6 +180,7 @@ function parseCliOptions(): CliOptions {
     limit: parsePositiveInteger(readCliValue("limit"), DEFAULT_LIMIT, "limit"),
     top: parsePositiveInteger(readCliValue("top"), DEFAULT_TOP, "top"),
     jobDescriptionId: toOptionalString(readCliValue("job-description")),
+    fieldCoverage: hasCliFlag("field-coverage"),
     json: hasCliFlag("json"),
   };
 }
@@ -159,6 +190,24 @@ export function getResumeSourceKey(resume: ResumeDoc): string | undefined {
     sourceKey: resume.content?.profileType,
     source: resume.source,
   });
+}
+
+function resolveFieldCoverageSourceKey(row: FieldCoverageDatasetPageRow): string {
+  const sourceKey = resolveResumeAnalysisSourceKey({
+    sourceKey: row.profileType,
+    source: row.source,
+  });
+  if (sourceKey) {
+    return sourceKey;
+  }
+
+  const normalizedProfileType = toOptionalString(row.profileType)?.toLowerCase();
+  const normalizedSource = toOptionalString(row.source)?.toLowerCase();
+  if (normalizedProfileType === "51job" || normalizedSource === "ehire.51job.com") {
+    return "51job";
+  }
+
+  return normalizedProfileType ?? normalizedSource ?? "unknown";
 }
 
 export function matchesWorkflowFilters(
@@ -257,6 +306,99 @@ async function listWorkflowDatasetRows(client: ConvexHttpClient): Promise<Workfl
   }
 }
 
+async function listFieldCoverageDatasetRows(client: ConvexHttpClient): Promise<FieldCoverageDatasetPageRow[]> {
+  const rows: FieldCoverageDatasetPageRow[] = [];
+  let cursor: string | undefined;
+
+  while (true) {
+    const page = await client.query(api.resumes.listFieldCoverageDatasetPage, {
+      limit: WORKFLOW_DATASET_PAGE_SIZE,
+      ...(cursor ? { cursor } : {}),
+    });
+
+    rows.push(...(page.page as FieldCoverageDatasetPageRow[]));
+
+    if (page.isDone) {
+      return rows;
+    }
+
+    cursor = typeof page.continueCursor === "string" && page.continueCursor.length > 0
+      ? page.continueCursor
+      : undefined;
+    if (!cursor) {
+      throw new Error("listFieldCoverageDatasetPage returned an unfinished page without a continueCursor");
+    }
+  }
+}
+
+function toCoveragePercent(matchedCount: number, totalCount: number): number {
+  if (totalCount <= 0) {
+    return 0;
+  }
+  return Math.round((matchedCount / totalCount) * 1000) / 10;
+}
+
+export function buildFieldCoverageReport(rows: FieldCoverageDatasetPageRow[]): FieldCoverageSourceSummary[] {
+  const grouped = new Map<string, {
+    resumeCount: number;
+    profileUrlCount: number;
+    resumeIdCount: number;
+    workHistoryCount: number;
+    workHistoryDescriptionCount: number;
+    profileEducationCount: number;
+    jobIntentionCount: number;
+    expectedSalaryCount: number;
+    selfIntroCount: number;
+    skillsCount: number;
+  }>();
+
+  for (const row of rows) {
+    const sourceKey = resolveFieldCoverageSourceKey(row);
+    const current = grouped.get(sourceKey) ?? {
+      resumeCount: 0,
+      profileUrlCount: 0,
+      resumeIdCount: 0,
+      workHistoryCount: 0,
+      workHistoryDescriptionCount: 0,
+      profileEducationCount: 0,
+      jobIntentionCount: 0,
+      expectedSalaryCount: 0,
+      selfIntroCount: 0,
+      skillsCount: 0,
+    };
+    current.resumeCount += 1;
+    if (row.profileUrl) current.profileUrlCount += 1;
+    if (row.resumeId) current.resumeIdCount += 1;
+    if (row.workHistoryCount > 0) current.workHistoryCount += 1;
+    if (row.workHistoryHasDescription) current.workHistoryDescriptionCount += 1;
+    if (row.profileEducation) current.profileEducationCount += 1;
+    if (row.jobIntention) current.jobIntentionCount += 1;
+    if (row.expectedSalary) current.expectedSalaryCount += 1;
+    if (row.selfIntro) current.selfIntroCount += 1;
+    if (row.skills) current.skillsCount += 1;
+    grouped.set(sourceKey, current);
+  }
+
+  return Array.from(grouped.entries())
+    .map(([sourceKey, counts]) => {
+      const resumeCount = counts.resumeCount;
+      return {
+        sourceKey,
+        resumeCount,
+        profileUrlPct: toCoveragePercent(counts.profileUrlCount, resumeCount),
+        resumeIdPct: toCoveragePercent(counts.resumeIdCount, resumeCount),
+        workHistoryPct: toCoveragePercent(counts.workHistoryCount, resumeCount),
+        workHistoryDescriptionPct: toCoveragePercent(counts.workHistoryDescriptionCount, resumeCount),
+        profileEducationPct: toCoveragePercent(counts.profileEducationCount, resumeCount),
+        jobIntentionPct: toCoveragePercent(counts.jobIntentionCount, resumeCount),
+        expectedSalaryPct: toCoveragePercent(counts.expectedSalaryCount, resumeCount),
+        selfIntroPct: toCoveragePercent(counts.selfIntroCount, resumeCount),
+        skillsPct: toCoveragePercent(counts.skillsCount, resumeCount),
+      };
+    })
+    .sort((left, right) => right.resumeCount - left.resumeCount || left.sourceKey.localeCompare(right.sourceKey));
+}
+
 function toVisibleResumeRow(
   resume: ResumeDoc,
   jobDescriptionId: string | undefined,
@@ -301,6 +443,9 @@ function printReport(report: WorkflowVerificationReport): void {
   console.log(`Visible count after source/location filters: ${report.visibleCount}`);
   console.log(`Visible by source host: ${formatCounts(report.visibleBySourceHost)}`);
   console.log(`Visible by source key: ${formatCounts(report.visibleBySourceKey)}`);
+  if (report.fieldCoverageBySource?.length) {
+    console.log(`Field coverage by source: ${report.fieldCoverageBySource.map((row) => `${row.sourceKey}:${row.resumeCount}`).join(", ")}`);
+  }
 
   if (report.visibleResumes.length === 0) {
     console.log("Visible resumes: none");
@@ -325,9 +470,10 @@ function printReport(report: WorkflowVerificationReport): void {
 export async function buildWorkflowVerificationReport(options: CliOptions): Promise<WorkflowVerificationReport> {
   const client = new ConvexHttpClient(options.convexUrl);
 
-  const [allResumes, keywordExpansion] = await Promise.all([
+  const [allResumes, keywordExpansion, fieldCoverageRows] = await Promise.all([
     listWorkflowDatasetRows(client),
     fetchKeywordExpansion(options.apiBaseUrl, options.workspace, options.query),
+    options.fieldCoverage ? listFieldCoverageDatasetRows(client) : Promise.resolve(undefined),
   ]);
   const totalResumeCount = allResumes.length;
 
@@ -374,6 +520,7 @@ export async function buildWorkflowVerificationReport(options: CliOptions): Prom
     visibleCount: visibleMatches.length,
     visibleBySourceHost: countByKey(visibleMatches, (resume) => resume.source),
     visibleBySourceKey: countByKey(visibleMatches, getResumeSourceKey),
+    ...(fieldCoverageRows ? { fieldCoverageBySource: buildFieldCoverageReport(fieldCoverageRows) } : {}),
     visibleResumes,
   };
 }


### PR DESCRIPTION
## Summary
- construct live 51job profile URLs in the extension and make collection guards configurable per source
- add live 51job snapshot support with an unsafe-limits override through the browser collector and Go CLI
- add Convex-backed field coverage reporting plus workflow dataset CLI output and tests

## Testing
- bunx vitest run scripts/resume/verify-workflow-dataset.test.ts scripts/resume/snapshot-source-backups.test.ts
- go test ./cmd -run 'TestResumeSnapshotCommand|TestResumeDebugWorkflowDatasetCommand'
- uv run python -m py_compile scripts/resume/collect_browser_source.py
- make check