### PR TITLE
fix: reduce 51job detail enrichment timing and enforce single tab per source

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -68,7 +68,7 @@ const KEYWORD_MODE_CONCAT = "concat";
 const KEYWORD_MODE_SPACED = "spaced";
 const JOB51_SAFE_LIMIT = 50;
 const JOB51_SAFE_MAX_PAGES = 1;
-const JOB51_PAGE_COOLDOWN_MS = 20000;
+const JOB51_PAGE_COOLDOWN_MS = 8000;
 const JOB51_RATE_LIMIT_ERROR_MESSAGE =
   "51job 已触发访问频率限制，请60分钟后再试";
 let autoExportTriggered = false;
@@ -83,8 +83,8 @@ const PAGE_BRIDGE_RESPONSE_ATTR = "data-tr-resume-bridge-response";
 const JOB5156_DETAIL_FETCH_TIMEOUT_MS = 5000;
 const JOB5156_DETAIL_FETCH_CONCURRENCY = 5;
 const JOB51_DETAIL_FETCH_TIMEOUT_MS = 8000;
-const JOB51_DETAIL_FETCH_CONCURRENCY = 1;
-const JOB51_DETAIL_FETCH_DELAY_MS = 20000;
+const JOB51_DETAIL_FETCH_CONCURRENCY = 2;
+const JOB51_DETAIL_FETCH_DELAY_MS = 5000;
 const DEFAULT_SEEK_PAGE_SIZE = 20;
 const LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY = "latestAutoSyncSummaries";
 const DEFAULT_COLLECTION_GUARDS = {
@@ -2380,34 +2380,48 @@ async function enrich51JobSearchResumesWithDetail(resumes, options = {}) {
   const enriched = [];
   let enrichedCount = 0;
 
+  let rateLimited = false;
+
   for (
-    let index = 0;
-    index < resumes.length;
-    index += JOB51_DETAIL_FETCH_CONCURRENCY
+    let start = 0;
+    start < resumes.length;
+    start += JOB51_DETAIL_FETCH_CONCURRENCY
   ) {
-    if (!shouldContinue()) {
+    if (!shouldContinue() || rateLimited) {
       break;
     }
 
-    const result = await enrich51JobSearchResumeWithDetail(
-      resumes[index],
-      extractedAt,
+    const batch = resumes.slice(
+      start,
+      start + JOB51_DETAIL_FETCH_CONCURRENCY,
     );
-    if (result?.resume) {
-      enriched.push(applyCollectionGuards(result.resume, guardFields));
+    const batchResults = await Promise.all(
+      batch.map((resume) =>
+        enrich51JobSearchResumeWithDetail(resume, extractedAt),
+      ),
+    );
+
+    for (const result of batchResults) {
+      if (result?.resume) {
+        enriched.push(applyCollectionGuards(result.resume, guardFields));
+      }
+      if (result?.enriched) {
+        enrichedCount += 1;
+      }
+      if (result?.rateLimited) {
+        rateLimited = true;
+      }
     }
-    if (result?.enriched) {
-      enrichedCount += 1;
-    }
+
     console.log(
-      `51job detail enrichment: ${index + 1}/${resumes.length} (${enrichedCount} enriched)`,
+      `51job detail enrichment: ${Math.min(start + batch.length, resumes.length)}/${resumes.length} (${enrichedCount} enriched)`,
     );
 
-    if (result?.rateLimited || !shouldContinue()) {
+    if (rateLimited || !shouldContinue()) {
       break;
     }
 
-    if (index < resumes.length - 1) {
+    if (start + JOB51_DETAIL_FETCH_CONCURRENCY < resumes.length) {
       await delay(JOB51_DETAIL_FETCH_DELAY_MS);
     }
   }

--- a/apps/web/src/components/CollectResumesButton.tsx
+++ b/apps/web/src/components/CollectResumesButton.tsx
@@ -195,7 +195,7 @@ export function CollectResumesButton({
       return
     }
 
-    window.open(launchUrl, '_blank', 'noopener,noreferrer')
+    window.open(launchUrl, `trends-collect-${selectedSourceType}`, 'noopener,noreferrer')
   }
 
   const handleMaxPagesChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/apps/web/src/pages/SearchProfilesPage.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.tsx
@@ -367,7 +367,7 @@ export function SearchProfilesPage() {
       }
 
       setRunningIds((previous) => new Set(previous).add(profileId))
-      window.open(launchUrl, '_blank', 'noopener,noreferrer')
+      window.open(launchUrl, `trends-collect-${activeSource.type}`, 'noopener,noreferrer')
       toast.success(t('searchProfiles.openTabSuccess', { defaultValue: 'Opened collection in a new tab' }))
       const existingTimer = headModeResetTimersRef.current[profileId]
       if (existingTimer) {


### PR DESCRIPTION
## Summary
- Reduce 51job detail enrichment delay from 20s to 5s and increase concurrency from 1 to 2, cutting backfill time from ~13min to ~2-3min for 39 resumes
- Fix enrichment loop to properly batch with `Promise.all` (was processing one resume per step despite concurrency > 1)
- Reduce page cooldown from 20s to 8s
- Use named window targets (`trends-collect-{sourceType}`) instead of `_blank` so clicking Run from profiles page reuses the existing tab for that source

## Test plan
- [ ] Reload extension on ehire.51job.com, trigger collection, verify enrichment logs show batches of 2 with ~5s gaps
- [ ] Click Run from `/dev/system/profiles` twice rapidly — verify only one tab opens per source
- [ ] Click Run for different source types — verify separate tabs (one per source type)
- [ ] `make check` passes, `npm test` 550/550 green