### PR TITLE
Speed up 51job detail backfills for large crawler runs

### DIFF
--- a/apps/browser-extension/content-job51-config.test.ts
+++ b/apps/browser-extension/content-job51-config.test.ts
@@ -1,0 +1,135 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const CONTENT_FILE_URL = new URL("./content.js", import.meta.url);
+const CONTENT_SOURCE_PROMISE = readFile(CONTENT_FILE_URL, "utf8");
+
+type Job51Helpers = {
+  resolveJob51CollectionLimits: (limit: number, maxPages: number) => {
+    limit: number;
+    maxPages: number;
+  };
+  resolveJob51DetailFetchDelayMs: () => number;
+};
+
+function extractConstNumber(source: string, name: string): number {
+  const match = source.match(new RegExp(`const ${name} = (\\d+);`));
+  if (!match?.[1]) {
+    throw new Error(`Failed to extract constant ${name}`);
+  }
+  return Number(match[1]);
+}
+
+function extractFunctionSource(source: string, name: string): string {
+  const signature = `function ${name}(`;
+  const start = source.indexOf(signature);
+  if (start < 0) {
+    throw new Error(`Failed to find function ${name}`);
+  }
+
+  const bodyStart = source.indexOf("{", start);
+  if (bodyStart < 0) {
+    throw new Error(`Failed to find function body for ${name}`);
+  }
+
+  let depth = 1;
+  for (let index = bodyStart + 1; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(start, index + 1);
+      }
+    }
+  }
+
+  throw new Error(`Failed to extract function source for ${name}`);
+}
+
+async function loadJob51Helpers(search: string): Promise<Job51Helpers> {
+  const source = await CONTENT_SOURCE_PROMISE;
+  const job51SafeLimit = extractConstNumber(source, "JOB51_SAFE_LIMIT");
+  const job51SafeMaxPages = extractConstNumber(source, "JOB51_SAFE_MAX_PAGES");
+  const defaultDelay = extractConstNumber(source, "JOB51_DETAIL_FETCH_DELAY_MS");
+  const unsafeDelay = extractConstNumber(
+    source,
+    "JOB51_DETAIL_FETCH_UNSAFE_DELAY_MS",
+  );
+
+  const hasUnsafeSource = extractFunctionSource(
+    source,
+    "hasJob51UnsafeLimitsOverride",
+  );
+  const resolveLimitsSource = extractFunctionSource(
+    source,
+    "resolveJob51CollectionLimits",
+  );
+  const resolveDelaySource = extractFunctionSource(
+    source,
+    "resolveJob51DetailFetchDelayMs",
+  );
+
+  const factory = new Function(
+    "window",
+    "JOB51_SAFE_LIMIT",
+    "JOB51_SAFE_MAX_PAGES",
+    "JOB51_DETAIL_FETCH_DELAY_MS",
+    "JOB51_DETAIL_FETCH_UNSAFE_DELAY_MS",
+    `${hasUnsafeSource}
+${resolveLimitsSource}
+${resolveDelaySource}
+return {
+  resolveJob51CollectionLimits,
+  resolveJob51DetailFetchDelayMs,
+};`,
+  ) as (
+    window: { location: { search: string } },
+    job51SafeLimit: number,
+    job51SafeMaxPages: number,
+    defaultDelay: number,
+    unsafeDelay: number,
+  ) => Job51Helpers;
+
+  return factory(
+    { location: { search } },
+    job51SafeLimit,
+    job51SafeMaxPages,
+    defaultDelay,
+    unsafeDelay,
+  );
+}
+
+describe("job51 content config", () => {
+  it("keeps standard runs capped and uses the conservative delay", async () => {
+    const helpers = await loadJob51Helpers("?keyword=CNC");
+
+    expect(helpers.resolveJob51CollectionLimits(200, 5)).toEqual({
+      limit: 50,
+      maxPages: 1,
+    });
+    expect(helpers.resolveJob51CollectionLimits(0, 0)).toEqual({
+      limit: 50,
+      maxPages: 1,
+    });
+    expect(helpers.resolveJob51DetailFetchDelayMs()).toBe(5000);
+  });
+
+  it("unlocks larger unsafe runs and uses the faster unsafe delay", async () => {
+    const helpers = await loadJob51Helpers("?keyword=CNC&tr_unsafe_limits=1");
+
+    expect(helpers.resolveJob51CollectionLimits(200, 5)).toEqual({
+      limit: 200,
+      maxPages: 5,
+    });
+    expect(helpers.resolveJob51CollectionLimits(0, 0)).toEqual({
+      limit: 50,
+      maxPages: 1,
+    });
+    expect(helpers.resolveJob51DetailFetchDelayMs()).toBe(1000);
+  });
+});

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -85,6 +85,7 @@ const JOB5156_DETAIL_FETCH_CONCURRENCY = 5;
 const JOB51_DETAIL_FETCH_TIMEOUT_MS = 8000;
 const JOB51_DETAIL_FETCH_CONCURRENCY = 2;
 const JOB51_DETAIL_FETCH_DELAY_MS = 5000;
+const JOB51_DETAIL_FETCH_UNSAFE_DELAY_MS = 1000;
 const DEFAULT_SEEK_PAGE_SIZE = 20;
 const LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY = "latestAutoSyncSummaries";
 const DEFAULT_COLLECTION_GUARDS = {
@@ -335,9 +336,13 @@ async function getCollectionLimits() {
   });
 }
 
-function resolveJob51CollectionLimits(limit, maxPages) {
+function hasJob51UnsafeLimitsOverride() {
   const params = new URLSearchParams(window.location.search || "");
-  if (params.get("tr_unsafe_limits") === "1") {
+  return params.get("tr_unsafe_limits") === "1";
+}
+
+function resolveJob51CollectionLimits(limit, maxPages) {
+  if (hasJob51UnsafeLimitsOverride()) {
     return {
       limit: limit > 0 ? limit : JOB51_SAFE_LIMIT,
       maxPages: maxPages > 0 ? maxPages : JOB51_SAFE_MAX_PAGES,
@@ -350,6 +355,12 @@ function resolveJob51CollectionLimits(limit, maxPages) {
         ? Math.min(maxPages, JOB51_SAFE_MAX_PAGES)
         : JOB51_SAFE_MAX_PAGES,
   };
+}
+
+function resolveJob51DetailFetchDelayMs() {
+  return hasJob51UnsafeLimitsOverride()
+    ? JOB51_DETAIL_FETCH_UNSAFE_DELAY_MS
+    : JOB51_DETAIL_FETCH_DELAY_MS;
 }
 
 function buildExportFilename() {
@@ -2369,6 +2380,11 @@ async function enrich51JobSearchResumesWithDetail(resumes, options = {}) {
   if (!Array.isArray(resumes) || resumes.length === 0) return [];
 
   const extractedAt = new Date().toISOString();
+  const interBatchDelayMs =
+    typeof options.interBatchDelayMs === "number" &&
+    Number.isFinite(options.interBatchDelayMs)
+      ? options.interBatchDelayMs
+      : resolveJob51DetailFetchDelayMs();
   const collectionGuards = await loadCollectionGuards();
   const guardFields = parseGuardFieldNames(
     collectionGuards?.[SOURCE_KEYS.JOB51],
@@ -2422,7 +2438,7 @@ async function enrich51JobSearchResumesWithDetail(resumes, options = {}) {
     }
 
     if (start + JOB51_DETAIL_FETCH_CONCURRENCY < resumes.length) {
-      await delay(JOB51_DETAIL_FETCH_DELAY_MS);
+      await delay(interBatchDelayMs);
     }
   }
 
@@ -6077,6 +6093,8 @@ function queueJob51DetailBackfill(resumes, context = {}) {
     runId !== null && runId !== job51DetailBackfillRunId;
 
   const task = async () => {
+    const detailFetchDelayMs = resolveJob51DetailFetchDelayMs();
+
     if (isCancelled()) {
       console.log("51job detail backfill skipped", {
         count: resumes.length,
@@ -6090,9 +6108,12 @@ function queueJob51DetailBackfill(resumes, context = {}) {
       count: resumes.length,
       currentPage: context.currentPage,
       totalPages: context.totalPages,
+      delayMs: detailFetchDelayMs,
+      concurrency: JOB51_DETAIL_FETCH_CONCURRENCY,
     });
 
     const enrichedResumes = await enrich51JobSearchResumesWithDetail(resumes, {
+      interBatchDelayMs: detailFetchDelayMs,
       shouldContinue: () => !isCancelled(),
     });
     if (!Array.isArray(enrichedResumes) || enrichedResumes.length === 0) {


### PR DESCRIPTION
## Summary
- keep standard 51job collection conservative while shortening the unsafe large-run detail backfill delay
- resolve the active 51job backfill delay once per queued task and include it in queue logs
- add regression coverage for safe vs unsafe 51job limit/delay behavior

## Testing
- make check
- bun x vitest run apps/browser-extension/content-job51-config.test.ts scripts/resume/snapshot-source-backups.test.ts
- bun run --filter '@trends/browser-extension' lint
- live 51job collect() sanity check via DevTools accessor
