### PR TITLE
Extend resume snapshot limit coverage for 200+ requests

### DIFF
--- a/apps/browser-extension/content-job51-config.test.ts
+++ b/apps/browser-extension/content-job51-config.test.ts
@@ -105,10 +105,10 @@ return {
 }
 
 describe("job51 content config", () => {
-  it("keeps standard runs capped and uses the conservative delay", async () => {
+  it("keeps 200+ standard runs capped and uses the conservative delay", async () => {
     const helpers = await loadJob51Helpers("?keyword=CNC");
 
-    expect(helpers.resolveJob51CollectionLimits(200, 5)).toEqual({
+    expect(helpers.resolveJob51CollectionLimits(250, 8)).toEqual({
       limit: 50,
       maxPages: 1,
     });
@@ -119,12 +119,12 @@ describe("job51 content config", () => {
     expect(helpers.resolveJob51DetailFetchDelayMs()).toBe(5000);
   });
 
-  it("unlocks larger unsafe runs and uses the faster unsafe delay", async () => {
+  it("unlocks 200+ unsafe runs and uses the faster unsafe delay", async () => {
     const helpers = await loadJob51Helpers("?keyword=CNC&tr_unsafe_limits=1");
 
-    expect(helpers.resolveJob51CollectionLimits(200, 5)).toEqual({
-      limit: 200,
-      maxPages: 5,
+    expect(helpers.resolveJob51CollectionLimits(250, 8)).toEqual({
+      limit: 250,
+      maxPages: 8,
     });
     expect(helpers.resolveJob51CollectionLimits(0, 0)).toEqual({
       limit: 50,

--- a/packages/cli/cmd/resume_snapshot_test.go
+++ b/packages/cli/cmd/resume_snapshot_test.go
@@ -23,7 +23,7 @@ func TestResumeSnapshotCommandPassesFlagsAndWritesJSON(t *testing.T) {
 		if request.Workspace != "ops" {
 			t.Fatalf("unexpected workspace: %q", request.Workspace)
 		}
-		if request.Count != 25 {
+		if request.Count != 250 {
 			t.Fatalf("unexpected count: %d", request.Count)
 		}
 		if request.MaxPages != 8 {
@@ -55,14 +55,14 @@ func TestResumeSnapshotCommandPassesFlagsAndWritesJSON(t *testing.T) {
 			RepoRoot:       "/repo",
 			RunStamp:       "20260323-010203",
 			OutputDir:      "output/resume-backups/20260323-010203",
-			CountPerSource: 25,
+			CountPerSource: 250,
 			Sources: []resumeSnapshotSourceResult{
 				{
 					Alias:         "job5156",
 					SourceHost:    "hr.job5156.com",
-					File:          "output/resume-backups/20260323-010203/resume-backup-job5156-top25-20260323-010203.json",
-					Count:         25,
-					ObservedCount: 25,
+					File:          "output/resume-backups/20260323-010203/resume-backup-job5156-top250-20260323-010203.json",
+					Count:         250,
+					ObservedCount: 250,
 					LaunchURL:     "https://hr.job5156.com/search",
 				},
 			},
@@ -77,7 +77,7 @@ func TestResumeSnapshotCommandPassesFlagsAndWritesJSON(t *testing.T) {
 		"--source", "job5156",
 		"--source", "51job",
 		"--source", "51job-manual",
-		"--count", "25",
+		"--count", "250",
 		"--max-pages", "8",
 		"--out-dir", "output/resume-backups/custom",
 		"--51job-url", "https://ehire.51job.com/Revision/talent/search",

--- a/scripts/resume/snapshot-source-backups.test.ts
+++ b/scripts/resume/snapshot-source-backups.test.ts
@@ -27,13 +27,14 @@ function fixedNow(): Date {
 function buildExpectedFilePath(
   repoRoot: string,
   alias: SnapshotOptions["sources"][number],
+  count = 20,
 ): string {
   return path.join(
     repoRoot,
     "output",
     "resume-backups",
     "20260320-120000",
-    `resume-backup-${alias}-top20-20260320-120000.json`,
+    `resume-backup-${alias}-top${count}-20260320-120000.json`,
   );
 }
 
@@ -209,7 +210,7 @@ describe("snapshot-source-backups", () => {
     expect(written.resumes[0]?.sourceHost).toBe(SOURCE_HOSTS.seek);
   });
 
-  it("adds the unsafe limit override to live 51job launches", async () => {
+  it("adds the unsafe limit override to 200+ live 51job launches", async () => {
     const repoRoot = await createTestRepoRoot();
     repoRoots.push(repoRoot);
     const exec = vi.fn(async (_command: string, args: string[]) => {
@@ -234,7 +235,7 @@ describe("snapshot-source-backups", () => {
           sourceHost: SOURCE_HOSTS["51job"],
           url: launchUrl,
           status: { sourceKey: "51job" },
-          payload: createCollectedPayload("51job", 20),
+          payload: createCollectedPayload("51job", 250),
         }),
         stderr: "",
       };
@@ -243,6 +244,9 @@ describe("snapshot-source-backups", () => {
     const result = await runSnapshotSourceBackups(
       {
         ...baseOptions(repoRoot, "51job"),
+        count: 250,
+        maxPages: 8,
+        job51Url: `${DEFAULT_51JOB_URL}?keyword=CNC`,
         unsafeLimits: true,
       },
       {
@@ -256,10 +260,16 @@ describe("snapshot-source-backups", () => {
     expect(result.sources[0]).toMatchObject({
       alias: "51job",
       sourceHost: SOURCE_HOSTS["51job"],
-      launchUrl: `${DEFAULT_51JOB_URL}?tr_unsafe_limits=1`,
-      count: 20,
-      observedCount: 20,
+      launchUrl: `${DEFAULT_51JOB_URL}?keyword=CNC&tr_unsafe_limits=1`,
+      count: 250,
+      observedCount: 250,
     });
+    expect(exec).toHaveBeenCalledTimes(2);
+    for (const [, args] of exec.mock.calls) {
+      expect(args[args.indexOf("--limit") + 1]).toBe("250");
+      expect(args[args.indexOf("--max-pages") + 1]).toBe("8");
+    }
+    await access(buildExpectedFilePath(repoRoot, "51job", 250));
   });
 
   it("fails and leaves no output file when the collected snapshot is short", async () => {


### PR DESCRIPTION
## Summary
- extend the 51job config tests to assert capped and unsafe behavior for 200+ requests
- verify the snapshot backup runner forwards oversized 51job limit/max-page values and writes the expected top250 artifact
- update the CLI regression test to cover a 250-count snapshot request end to end

## Testing
- bun test apps/browser-extension/content-job51-config.test.ts scripts/resume/snapshot-source-backups.test.ts
- go test ./cmd -run TestResumeSnapshotCommand
- make check