### PR TITLE
Improve 51job detail parsing and explicit extended-limit launches

### DIFF
--- a/apps/api/src/services/search-profile-service.ts
+++ b/apps/api/src/services/search-profile-service.ts
@@ -59,6 +59,7 @@ export interface SearchProfile {
         enabled: boolean;
         priority?: number;
         jobUrl?: string;
+        unsafeLimits?: boolean;
     }>;
 
     // Landing page quick start

--- a/apps/browser-extension/content-job51-detail-parser.test.ts
+++ b/apps/browser-extension/content-job51-detail-parser.test.ts
@@ -1,0 +1,254 @@
+import { readFile } from 'node:fs/promises'
+
+import { describe, expect, it } from 'vitest'
+
+const CONTENT_FILE_URL = new URL('./content.js', import.meta.url)
+const FIXTURE_FILE_URL = new URL('./job51-detail-parser.fixture.json', import.meta.url)
+const CONTENT_SOURCE_PROMISE = readFile(CONTENT_FILE_URL, 'utf8')
+const FIXTURE_PROMISE = readFile(FIXTURE_FILE_URL, 'utf8').then((text) => JSON.parse(text) as Record<string, unknown>)
+
+type Job51ParserHelpers = {
+  filterResumesByAgeRange: (resumes: Array<Record<string, unknown>>) => Array<Record<string, unknown>>
+  buildJob51DetailResumeFromPayload: (payload: Record<string, unknown>, options?: Record<string, unknown>) => Array<Record<string, unknown>>
+}
+
+function extractFunctionSource(source: string, name: string): string {
+  const signature = `function ${name}(`
+  const start = source.indexOf(signature)
+  if (start < 0) {
+    throw new Error(`Failed to find function ${name}`)
+  }
+
+  const paramsStart = source.indexOf('(', start)
+  if (paramsStart < 0) {
+    throw new Error(`Failed to find parameter list for ${name}`)
+  }
+
+  let paramsDepth = 1
+  let paramsEnd = -1
+  for (let index = paramsStart + 1; index < source.length; index += 1) {
+    const char = source[index]
+    if (char === '(') {
+      paramsDepth += 1
+      continue
+    }
+    if (char === ')') {
+      paramsDepth -= 1
+      if (paramsDepth === 0) {
+        paramsEnd = index
+        break
+      }
+    }
+  }
+  if (paramsEnd < 0) {
+    throw new Error(`Failed to find end of parameter list for ${name}`)
+  }
+
+  const bodyStart = source.indexOf('{', paramsEnd)
+  if (bodyStart < 0) {
+    throw new Error(`Failed to find function body for ${name}`)
+  }
+
+  let depth = 1
+  for (let index = bodyStart + 1; index < source.length; index += 1) {
+    const char = source[index]
+    if (char === '{') {
+      depth += 1
+      continue
+    }
+    if (char === '}') {
+      depth -= 1
+      if (depth === 0) {
+        return source.slice(start, index + 1)
+      }
+    }
+  }
+
+  throw new Error(`Failed to extract function source for ${name}`)
+}
+
+async function loadHelpers(search: string): Promise<Job51ParserHelpers> {
+  const source = await CONTENT_SOURCE_PROMISE
+  const functionNames = [
+    'normalizeOptionalPositiveInt',
+    'parseAgeNumber',
+    'getAgeRangeFromUrl',
+    'filterResumesByAgeRange',
+    'normalizeResumeText',
+    'normalizeResumeMultilineText',
+    'stripHtmlTags',
+    'normalizeJob51Text',
+    'normalizeJob51MultilineText',
+    'buildWorkHistoryRawParts',
+    'getJob51DetailRoot',
+    'readJob51Text',
+    'readJob51MultilineText',
+    'normalizeJob51DateLike',
+    'readJob51Array',
+    'buildJob51ExperienceEntry',
+    'buildJob51EducationEntry',
+    'buildJob51SkillEntry',
+    'buildJob51LicenceEntry',
+    'buildJob51DetailResumeFromPayload',
+  ]
+  const snippets = functionNames.map((name) => extractFunctionSource(source, name)).join('\n')
+
+  const factory = new Function(
+    'window',
+    'AUTO_MIN_AGE_PARAM',
+    'AUTO_MAX_AGE_PARAM',
+    'EHIRE_51JOB_HOST',
+    'EHIRE_51JOB_PROFILE_URL_PREFIX',
+    `${snippets}
+return {
+  filterResumesByAgeRange,
+  buildJob51DetailResumeFromPayload,
+}`,
+  ) as (
+    window: { location: { search: string } },
+    autoMinAgeParam: string,
+    autoMaxAgeParam: string,
+    sourceHost: string,
+    profileUrlPrefix: string,
+  ) => Job51ParserHelpers
+
+  return factory(
+    { location: { search } },
+    'tr_min_age',
+    'tr_max_age',
+    'ehire.51job.com',
+    'https://ehire.51job.com/Revision/talent/resume/detail?contentType=&resumeId=',
+  )
+}
+
+describe('job51 detail parser', () => {
+  it('keeps 51job extraction-time age filtering active for URL-supplied ranges', async () => {
+    const helpers = await loadHelpers('?tr_min_age=30&tr_max_age=35')
+
+    expect(helpers.filterResumesByAgeRange([
+      { name: 'A', age: '29岁' },
+      { name: 'B', age: '32岁' },
+      { name: 'C', age: '36岁' },
+      { name: 'D', age: 'unknown' },
+    ])).toEqual([
+      { name: 'B', age: '32岁' },
+    ])
+  })
+
+  it('parses alternate 51job detail work-history arrays and preserves detailed descriptions', async () => {
+    const helpers = await loadHelpers('')
+    const fixture = await FIXTURE_PROMISE
+
+    const [resume] = helpers.buildJob51DetailResumeFromPayload(fixture, {
+      profileUrl: 'https://ehire.51job.com/Revision/talent/resume/detail?contentType=&resumeId=123456',
+    })
+
+    expect(resume).toMatchObject({
+      resumeId: '123456',
+      perUserId: 'u-789',
+      name: '张三',
+      age: '32岁',
+      experience: '9年',
+      education: '本科',
+      location: '东莞',
+      jobIntention: '销售经理',
+      expectedSalary: '20000元/月',
+    })
+    expect(resume.workHistory).toEqual([
+      expect.objectContaining({
+        companyName: '东莞市某机械有限公司',
+        jobTitle: '高级销售工程师',
+        startDate: '2021-03',
+        endDate: '至今',
+      }),
+    ])
+    expect(String(resume.workHistory?.[0]?.description || '')).toContain('开发华南客户')
+    expect(String(resume.workHistory?.[0]?.description || '')).toContain('维护大客户关系')
+    expect(String(resume.workHistory?.[0]?.description || '')).toContain('负责机床销售和渠道拓展')
+  })
+
+  it('does not treat recent_position as the total experience fallback on detail pages', async () => {
+    const helpers = await loadHelpers('')
+
+    const [resume] = helpers.buildJob51DetailResumeFromPayload({
+      data: {
+        base_info: {
+          userid: '9988',
+          resume_name: '李四',
+        },
+        recent_work_info: {
+          recent_position: '销售总监',
+        },
+        workExperienceList: [
+          {
+            companyName: '深圳某设备有限公司',
+            position: '销售经理',
+            startDate: '2020.01',
+            endDate: '至今',
+          },
+        ],
+      },
+    })
+
+    expect(resume?.experience).toBe('')
+    expect(resume?.jobIntention).toBe('销售总监')
+  })
+
+  it('parses the current live 51job detail payload shape with workyear and jobintention arrays', async () => {
+    const helpers = await loadHelpers('')
+
+    const [resume] = helpers.buildJob51DetailResumeFromPayload({
+      data: {
+        resumeid: '975386637',
+        accountid: '121430648',
+        username: '袁先生',
+        displayage: '37岁',
+        workyear: '9',
+        activetimelabel: '2026.02.03',
+        jobintention: [
+          {
+            expectfuncname: '销售经理',
+            newdisplayexpectsalary: '8千-1.2万/月',
+            expectarea: [{ provincecity: '洛阳', county: '' }],
+          },
+        ],
+        highestdegree: {
+          degree: '大专',
+        },
+        work: [
+          {
+            compname: '苏州德扬数控机械有限公司',
+            position: '销售工程师',
+            workdescribe: '负责河南区域CNC销售工作，年销售任务达标。',
+            worktime: '4年3个月',
+            timefrom: '2022.01',
+            timeto: '至今',
+            workindustry: '机械/设备/重工',
+            companysize: '150-500人',
+            companytype: '民营',
+          },
+        ],
+      },
+    })
+
+    expect(resume).toMatchObject({
+      name: '袁先生',
+      age: '37岁',
+      experience: '9',
+      education: '大专',
+      location: '洛阳',
+      jobIntention: '销售经理',
+      expectedSalary: '8千-1.2万/月',
+      activityStatus: '2026.02.03',
+    })
+    expect(resume.workHistory).toEqual([
+      expect.objectContaining({
+        companyName: '苏州德扬数控机械有限公司',
+        jobTitle: '销售工程师',
+        startDate: '2022-01',
+        endDate: '至今',
+      }),
+    ])
+    expect(String(resume.workHistory?.[0]?.description || '')).toContain('负责河南区域CNC销售工作')
+  })
+})

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -3596,6 +3596,29 @@ function readJob51MultilineText(...values) {
     if (typeof value === "string") {
       const text = normalizeJob51MultilineText(value);
       if (text) return text;
+      continue;
+    }
+    if (Array.isArray(value)) {
+      const text = value
+        .map((entry) =>
+          typeof entry === "string"
+            ? normalizeJob51MultilineText(entry)
+            : entry && typeof entry === "object"
+              ? readJob51MultilineText(
+                  entry.text,
+                  entry.value,
+                  entry.content,
+                  entry.description,
+                  entry.desc,
+                  entry.detail,
+                  entry.duty,
+                  entry.responsibility,
+                )
+              : "",
+        )
+        .filter(Boolean)
+        .join("\n");
+      if (text) return text;
     }
   }
   return "";
@@ -3628,6 +3651,8 @@ function buildJob51ExperienceEntry(item, kind) {
   const companyName = readJob51Text(
     item.company_name,
     item.companyName,
+    item.compname,
+    item.comp_name,
     item.com_name,
     item.comName,
     item.company,
@@ -3637,6 +3662,9 @@ function buildJob51ExperienceEntry(item, kind) {
   );
   const jobTitle = readJob51Text(
     item.work_func_value,
+    item.workfunc,
+    item.workfunc_str,
+    item.work_func_str,
     item.job_name,
     item.jobName,
     item.position,
@@ -3651,7 +3679,8 @@ function buildJob51ExperienceEntry(item, kind) {
       item.begin ??
       item.start_date ??
       item.fromDate ??
-      item.time_begin,
+      item.time_begin ??
+      item.timefrom,
   );
   const endDate = normalizeJob51DateLike(
     item.end_time ??
@@ -3659,31 +3688,60 @@ function buildJob51ExperienceEntry(item, kind) {
       item.end ??
       item.end_date ??
       item.toDate ??
-      item.time_end,
+      item.time_end ??
+      item.timeto,
   );
   const durationLabel = readJob51Text(
     item.working_years,
+    item.worktime,
     item.duration,
     item.timeDiff,
     item.time_diff,
     item.period,
     item.durationLabel,
   );
-  const description = readJob51MultilineText(
-    item.workdescribe,
-    item.work_describe,
-    item.workDescription,
-    item.description,
-    item.desc,
-    item.detail,
-    item.content,
-    isProject ? item.project_desc : undefined,
-    isProject ? item.projectDescribe : undefined,
-  );
+  const description = Array.from(
+    new Set(
+      [
+        item.workdescribe,
+        item.work_describe,
+        item.workDescription,
+        item.work_content,
+        item.workContent,
+        item.work_detail,
+        item.workDetail,
+        item.workDuty,
+        item.work_duty,
+        item.duty,
+        item.duties,
+        item.responsibility,
+        item.responsibilities,
+        item.responsibility_text,
+        item.responsibilityText,
+        item.responsibility_list,
+        item.responsibilityList,
+        item.duty_list,
+        item.dutyList,
+        item.description,
+        item.desc,
+        item.detail,
+        item.content,
+        item.achievement,
+        item.achievements,
+        isProject ? item.project_desc : undefined,
+        isProject ? item.projectDescribe : undefined,
+      ]
+        .map((value) => readJob51MultilineText(value))
+        .filter(Boolean),
+    ),
+  ).join("\n");
   const metaParts = [
     item.industry_tag,
+    item.workindustry,
     item.company_size_value,
+    item.companysize,
     item.work_type_value,
+    item.companytype,
     item.section,
     item.department,
     item.project_name,
@@ -3720,6 +3778,7 @@ function buildJob51EducationEntry(item) {
   const institution = readJob51Text(
     item.school_name,
     item.schoolName,
+    item.schoolname,
     item.school,
     item.institution,
     item.university,
@@ -3727,6 +3786,7 @@ function buildJob51EducationEntry(item) {
   );
   const qualification = readJob51Text(
     item.degree_value,
+    item.degreename,
     item.degree,
     item.degreeStr,
     item.qualification,
@@ -3734,6 +3794,7 @@ function buildJob51EducationEntry(item) {
   );
   const fieldOfStudy = readJob51Text(
     item.major,
+    item.degreemajor,
     item.major_name,
     item.speciality,
     item.field_of_study,
@@ -3746,10 +3807,10 @@ function buildJob51EducationEntry(item) {
     item.content,
   );
   const startDate = normalizeJob51DateLike(
-    item.start_date ?? item.begin ?? item.startTime ?? item.enrollYear,
+    item.start_date ?? item.begin ?? item.startTime ?? item.enrollYear ?? item.timefrom,
   );
   const endDate = normalizeJob51DateLike(
-    item.end_date ?? item.end ?? item.endTime ?? item.graduationYear,
+    item.end_date ?? item.end ?? item.endTime ?? item.graduationYear ?? item.timeto,
   );
 
   if (!institution && !qualification && !fieldOfStudy && !description) {
@@ -3886,6 +3947,15 @@ function buildJob51DetailResumeFromPayload(payload, options = {}) {
   );
   const baseInfo =
     root.base_info && typeof root.base_info === "object" ? root.base_info : {};
+  const liveJobIntention =
+    Array.isArray(root.jobintention) && root.jobintention[0] &&
+    typeof root.jobintention[0] === "object"
+      ? root.jobintention[0]
+      : {};
+  const liveHighestDegree =
+    root.highestdegree && typeof root.highestdegree === "object"
+      ? root.highestdegree
+      : {};
   const jobIntentionInfo =
     root.job_intention && typeof root.job_intention === "object"
       ? root.job_intention
@@ -3898,9 +3968,15 @@ function buildJob51DetailResumeFromPayload(payload, options = {}) {
     "work",
     "work_list",
     "workInfoVoList",
+    "workInfoList",
+    "work_info",
+    "work_info_list",
     "workHistory",
+    "work_history",
     "work_experience",
     "workExperience",
+    "workExperienceList",
+    "work_exp_list",
   ])
     .map((item) => buildJob51ExperienceEntry(item, "work"))
     .filter(Boolean);
@@ -3908,8 +3984,10 @@ function buildJob51DetailResumeFromPayload(payload, options = {}) {
     "project",
     "project_list",
     "projectInfoVoList",
+    "projectInfoList",
     "projectExperience",
     "project_experience",
+    "projectExperienceList",
   ])
     .map((item) => buildJob51ExperienceEntry(item, "project"))
     .filter(Boolean);
@@ -3948,6 +4026,7 @@ function buildJob51DetailResumeFromPayload(payload, options = {}) {
     root.name,
     root.userName,
     root.user_name,
+    root.username,
     root.resume_name,
     root.realName,
     root.candidateName,
@@ -3956,26 +4035,43 @@ function buildJob51DetailResumeFromPayload(payload, options = {}) {
     baseInfo.name,
     baseInfo.userName,
   );
-  const age = readJob51Text(root.age, root.realAge, baseInfo.age);
+  const age = readJob51Text(root.age, root.realAge, root.displayage, baseInfo.age);
   const experience = readJob51Text(
     baseInfo.work_year_value,
+    baseInfo.workYear,
+    baseInfo.workYears,
+    root.work_year_value,
+    root.workyear,
     root.workYear,
     root.workYears,
     root.experienceYears,
     root.experience,
-    recentWorkInfo?.recent_position,
+    recentWorkInfo?.working_years,
   );
   const education = readJob51Text(
     baseInfo.top_degree_value,
     root.top_degree_value,
+    liveHighestDegree.degree,
     root.education,
     root.degree,
     root.degreeValue,
   );
   const location = readJob51Text(
     jobIntentionInfo.expect_job_area_value,
+    Array.isArray(liveJobIntention.expectarea)
+      ? liveJobIntention.expectarea
+          .map((item) =>
+            item && typeof item === "object"
+              ? readJob51Text(item.provincecity, item.county)
+              : "",
+          )
+          .filter(Boolean)
+          .join(",")
+      : undefined,
     root.jobIntention?.expect_job_area_value,
     baseInfo.area_value,
+    root.area,
+    root.areaprovincecity,
     root.location,
     root.workCity,
     root.city,
@@ -3984,11 +4080,15 @@ function buildJob51DetailResumeFromPayload(payload, options = {}) {
   const jobIntention = readJob51Text(
     jobIntentionInfo.expect_work_function_value,
     jobIntentionInfo.expected_work_function_value,
+    liveJobIntention.expectfuncname,
+    liveJobIntention.expectposition,
     root.jobIntention?.expect_work_function_value,
     root.jobIntention?.expected_work_function_value,
     recentWorkInfo.recent_position,
+    root.recentwork?.workname,
     root.jobIntention,
     root.job_name,
+    root.jobname,
     root.desiredJob,
     root.expectedPosition,
     root.targetJob,
@@ -3997,6 +4097,8 @@ function buildJob51DetailResumeFromPayload(payload, options = {}) {
   const expectedSalary = readJob51Text(
     jobIntentionInfo.new_expect_salary,
     jobIntentionInfo.expect_salary,
+    liveJobIntention.newdisplayexpectsalary,
+    liveJobIntention.displayexpectsalary,
     root.expectedSalary,
     root.desiredSalary,
     root.expectSalary,
@@ -4006,6 +4108,8 @@ function buildJob51DetailResumeFromPayload(payload, options = {}) {
   const activityStatus = readJob51Text(
     root.active_type,
     root.activityStatus,
+    root.activetimelabel,
+    root.activetime,
     root.lastLoginTime,
     root.last_login_time,
     baseInfo.active_type,
@@ -5615,12 +5719,7 @@ function resolveAgeFilterActions(selectBox) {
 }
 
 async function autoApplyAgeFilterFromUrl() {
-  if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
-    const range = getAgeRangeFromUrl();
-    setAutoAgeAttributes("skipped", range.minAge, range.maxAge);
-    return;
-  }
-
+  const sourceKey = getCurrentSourceKey();
   const range = getAgeRangeFromUrl();
   if (!range.enabled) {
     setAutoAgeAttributes("skipped");
@@ -5644,6 +5743,13 @@ async function autoApplyAgeFilterFromUrl() {
 
   const ageBlock = findAgeFilterBlock();
   if (!ageBlock) {
+    if (sourceKey === SOURCE_KEYS.JOB51) {
+      setAutoAgeAttributes("filtered-only", minAge, maxAge);
+      console.warn(
+        "🎯 [Auto Age] 51job age filter control not found; relying on extracted resume filtering.",
+      );
+      return;
+    }
     setAutoAgeAttributes("failed", minAge, maxAge);
     console.warn(
       "🎯 [Auto Age] Age filter control not found; skipping native age filter apply.",
@@ -5655,6 +5761,13 @@ async function autoApplyAgeFilterFromUrl() {
     timeoutMs: 5000,
   });
   if (!selectBox) {
+    if (sourceKey === SOURCE_KEYS.JOB51) {
+      setAutoAgeAttributes("filtered-only", minAge, maxAge);
+      console.warn(
+        "🎯 [Auto Age] 51job age filter dropdown did not open; relying on extracted resume filtering.",
+      );
+      return;
+    }
     setAutoAgeAttributes("failed", minAge, maxAge);
     console.warn("🎯 [Auto Age] Failed to open age filter dropdown.");
     return;
@@ -5663,6 +5776,16 @@ async function autoApplyAgeFilterFromUrl() {
   const { minInput, maxInput, confirmButton, cancelButton } =
     resolveAgeFilterActions(selectBox);
   if (!minInput || !maxInput || !confirmButton) {
+    if (sourceKey === SOURCE_KEYS.JOB51) {
+      setAutoAgeAttributes("filtered-only", minAge, maxAge);
+      if (cancelButton) {
+        cancelButton.click();
+      }
+      console.warn(
+        "🎯 [Auto Age] 51job age filter inputs/buttons not found; relying on extracted resume filtering.",
+      );
+      return;
+    }
     setAutoAgeAttributes("failed", minAge, maxAge);
     if (cancelButton) {
       cancelButton.click();

--- a/apps/browser-extension/job51-detail-parser.fixture.json
+++ b/apps/browser-extension/job51-detail-parser.fixture.json
@@ -1,0 +1,40 @@
+{
+  "data": {
+    "base_info": {
+      "userid": "123456",
+      "accountid": "u-789",
+      "resume_name": "张三",
+      "age": "32",
+      "work_year_value": "9年",
+      "top_degree_value": "本科",
+      "area_value": "东莞"
+    },
+    "job_intention": {
+      "expect_work_function_value": "销售经理",
+      "expect_job_area_value": "东莞",
+      "expect_salary": "20000元/月"
+    },
+    "recent_work_info": {
+      "recent_position": "区域销售经理"
+    },
+    "workExperienceList": [
+      {
+        "startDate": "2021.03",
+        "endDate": "至今",
+        "companyName": "东莞市某机械有限公司",
+        "position": "高级销售工程师",
+        "responsibility_list": [
+          "开发华南客户",
+          "维护大客户关系"
+        ],
+        "workDetail": "负责机床销售和渠道拓展"
+      }
+    ],
+    "educationInfoVoList": [
+      {
+        "schoolName": "广东工业大学",
+        "degree": "本科"
+      }
+    ]
+  }
+}

--- a/apps/web/src/components/SearchProfileEditorDialog.test.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.test.tsx
@@ -307,6 +307,40 @@ describe('SearchProfileEditorDialog JD hydration', () => {
     })
   })
 
+  it('persists explicit 51job extended-limit settings in the profile payload', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <SearchProfileEditorDialog
+        open
+        onOpenChange={vi.fn()}
+        profileId={null}
+      />
+    )
+
+    await user.type(screen.getByLabelText('Name'), '51job extended profile')
+    await user.type(screen.getByLabelText('关键词:'), '"Sales Engineer" OR "Sales Manager"')
+    await user.click(screen.getByLabelText('51job eHire'))
+    await user.click(screen.getByLabelText('Allow extended 51job collection limits'))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledWith('/api/search-profiles', {
+        body: expect.objectContaining({
+          keywords: ['Sales Engineer', 'Sales Manager'],
+          sources: expect.arrayContaining([
+            expect.objectContaining({
+              type: '51job',
+              enabled: true,
+              priority: 3,
+              unsafeLimits: true,
+            }),
+          ]),
+        }),
+      })
+    })
+  })
+
   it('sends explicit null clears for optional linkage fields on save', async () => {
     const user = userEvent.setup()
     const onSaved = vi.fn()

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -100,6 +100,7 @@ type SourceFormState = {
     job5156Priority: string
     job51Enabled: boolean
     job51Priority: string
+    job51UnsafeLimits: boolean
     seekEnabled: boolean
     seekPriority: string
     seekJobUrl: string
@@ -125,6 +126,7 @@ const DEFAULT_SOURCES_FORM: SourceFormState = {
     job5156Priority: '1',
     job51Enabled: false,
     job51Priority: '3',
+    job51UnsafeLimits: false,
     seekEnabled: false,
     seekPriority: '2',
     seekJobUrl: '',
@@ -205,6 +207,7 @@ function toSourcesFormState(sources: SearchProfileSource[] | undefined): SourceF
         job5156Priority: normalizeSourcePriority(job5156Source?.priority) || DEFAULT_SOURCES_FORM.job5156Priority,
         job51Enabled: job51Source?.enabled ?? DEFAULT_SOURCES_FORM.job51Enabled,
         job51Priority: normalizeSourcePriority(job51Source?.priority) || DEFAULT_SOURCES_FORM.job51Priority,
+        job51UnsafeLimits: job51Source?.unsafeLimits === true,
         seekEnabled: seekSource?.enabled ?? DEFAULT_SOURCES_FORM.seekEnabled,
         seekPriority: normalizeSourcePriority(seekSource?.priority) || DEFAULT_SOURCES_FORM.seekPriority,
         seekJobUrl: seekSource?.jobUrl ?? DEFAULT_SOURCES_FORM.seekJobUrl,
@@ -245,6 +248,7 @@ function buildSourcesPayload(sourceForm: SourceFormState, additionalSources: Sea
         type: SEARCH_PROFILE_SOURCE_TYPES.job51,
         enabled: sourceForm.job51Enabled,
         priority: parseOptionalNumber(sourceForm.job51Priority),
+        ...(sourceForm.job51UnsafeLimits ? { unsafeLimits: true } : {}),
     })
 
     sources.push({
@@ -715,6 +719,30 @@ export function SearchProfileEditorDialog({
                                     />
                                 </div>
                             </div>
+
+                            {sourceForm.job51Enabled ? (
+                                <div className="mt-3 grid gap-2">
+                                    <div className="flex items-center gap-2">
+                                        <Checkbox
+                                            id="profile-source-job51-unsafe-limits"
+                                            checked={sourceForm.job51UnsafeLimits}
+                                            onCheckedChange={(checked) => setSourceForm((previous) => ({
+                                                ...previous,
+                                                job51UnsafeLimits: checked === true,
+                                            }))}
+                                        />
+                                        <Label htmlFor="profile-source-job51-unsafe-limits">
+                                            {t('searchProfiles.fields.job51UnsafeLimits', { defaultValue: 'Allow extended 51job collection limits' })}
+                                        </Label>
+                                    </div>
+                                    <span className="text-xs text-muted-foreground">
+                                        {t(
+                                            'searchProfiles.fields.job51UnsafeLimitsHint',
+                                            { defaultValue: 'Opt in to larger 51job runs by appending tr_unsafe_limits=1 instead of the default 50 resumes / 1 page cap.' },
+                                        )}
+                                    </span>
+                                </div>
+                            ) : null}
                         </div>
 
                         <div className="rounded-md border p-3">

--- a/apps/web/src/lib/search-profile-sources.test.ts
+++ b/apps/web/src/lib/search-profile-sources.test.ts
@@ -148,6 +148,26 @@ describe('search-profile-sources', () => {
     expect(url.searchParams.get('tr_max_age')).toBe('40')
   })
 
+  it('allows larger 51job launch URLs when unsafe limits are explicitly enabled', () => {
+    const collectUrl = buildJob51CollectUrl({
+      location: '东莞',
+      keywords: ['CNC', '销售'],
+      collectLimit: 250,
+      maxPages: 8,
+      minAge: 25,
+      maxAge: 40,
+      unsafeLimits: true,
+    })
+
+    expect(collectUrl).not.toBeNull()
+    const url = new URL(collectUrl as string)
+    expect(url.searchParams.get('tr_limit')).toBe('250')
+    expect(url.searchParams.get('tr_max_pages')).toBe('8')
+    expect(url.searchParams.get('tr_unsafe_limits')).toBe('1')
+    expect(url.searchParams.get('tr_min_age')).toBe('25')
+    expect(url.searchParams.get('tr_max_age')).toBe('40')
+  })
+
   it('preserves legacy seek exact URLs as a collection source fallback', () => {
     const legacySource = getLegacyCollectionSource('https://my.employer.seek.com/candidates/recommended?jobId=9&pageNumber=1')
 

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -31,6 +31,7 @@ export type CollectionSourceType =
 export type CollectionSource = {
   type: CollectionSourceType
   exactUrl?: string
+  unsafeLimits?: boolean
 }
 
 export type SearchProfileSource = {
@@ -38,6 +39,7 @@ export type SearchProfileSource = {
   enabled: boolean
   priority?: number
   jobUrl?: string
+  unsafeLimits?: boolean
 }
 
 type BuildSeekCollectUrlInput = {
@@ -120,8 +122,19 @@ export function normalizeCollectionSource(
     : undefined
 
   return exactUrl
-    ? { type: value.type, exactUrl }
-    : { type: value.type }
+    ? {
+        type: value.type,
+        exactUrl,
+        ...(value.type === SEARCH_PROFILE_SOURCE_TYPES.job51 && value.unsafeLimits === true
+          ? { unsafeLimits: true }
+          : {}),
+      }
+    : {
+        type: value.type,
+        ...(value.type === SEARCH_PROFILE_SOURCE_TYPES.job51 && value.unsafeLimits === true
+          ? { unsafeLimits: true }
+          : {}),
+      }
 }
 
 export function getLegacyCollectionSource(collectUrl: string | undefined): CollectionSource | undefined {
@@ -161,7 +174,12 @@ export function stripCollectionSourceExactUrl(
     return undefined
   }
 
-  return { type: normalized.type }
+  return {
+    type: normalized.type,
+    ...(normalized.type === SEARCH_PROFILE_SOURCE_TYPES.job51 && normalized.unsafeLimits === true
+      ? { unsafeLimits: true }
+      : {}),
+  }
 }
 
 export function normalizeSeekJobUrl(value: string | undefined): string | undefined {
@@ -383,7 +401,8 @@ export function buildJob51CollectUrl({
   maxPages,
   minAge,
   maxAge,
-}: BuildJob5156CollectUrlInput): string | null {
+  unsafeLimits,
+}: BuildJob5156CollectUrlInput & { unsafeLimits?: boolean }): string | null {
   const normalizedKeywords = normalizeKeywords(keywords)
   if (normalizedKeywords.length === 0) {
     return null
@@ -400,17 +419,26 @@ export function buildJob51CollectUrl({
   url.searchParams.set('tr_auto_sync', 'true')
 
   const normalizedCollectLimit = normalizeOptionalPositiveInt(collectLimit)
-  const job51CollectLimit =
-    typeof normalizedCollectLimit === 'number'
+  const job51CollectLimit = unsafeLimits === true
+    ? (typeof normalizedCollectLimit === 'number'
+      ? normalizedCollectLimit
+      : JOB51_SAFE_LAUNCH_LIMIT)
+    : (typeof normalizedCollectLimit === 'number'
       ? Math.min(normalizedCollectLimit, JOB51_SAFE_LAUNCH_LIMIT)
-      : JOB51_SAFE_LAUNCH_LIMIT
+      : JOB51_SAFE_LAUNCH_LIMIT)
   const normalizedMaxPages = normalizeOptionalPositiveInt(maxPages)
-  const job51MaxPages =
-    typeof normalizedMaxPages === 'number'
+  const job51MaxPages = unsafeLimits === true
+    ? (typeof normalizedMaxPages === 'number'
+      ? normalizedMaxPages
+      : JOB51_SAFE_LAUNCH_MAX_PAGES)
+    : (typeof normalizedMaxPages === 'number'
       ? Math.min(normalizedMaxPages, JOB51_SAFE_LAUNCH_MAX_PAGES)
-      : JOB51_SAFE_LAUNCH_MAX_PAGES
+      : JOB51_SAFE_LAUNCH_MAX_PAGES)
   url.searchParams.set('tr_limit', String(job51CollectLimit))
   url.searchParams.set('tr_max_pages', String(job51MaxPages))
+  if (unsafeLimits === true) {
+    url.searchParams.set('tr_unsafe_limits', '1')
+  }
 
   const normalizedMinAge = normalizeOptionalPositiveInt(minAge)
   if (typeof normalizedMinAge === 'number') {
@@ -454,6 +482,7 @@ export function buildCollectionLaunchUrl({
       maxPages,
       minAge,
       maxAge,
+      unsafeLimits: source.unsafeLimits,
     })
   }
 

--- a/apps/web/src/pages/SearchProfilesPage.test.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.test.tsx
@@ -334,6 +334,94 @@ describe('SearchProfilesPage run behavior', () => {
     expect(toastSuccessMock).toHaveBeenCalledWith('Opened collection in a new tab')
   })
 
+  it('opens 51job profiles with explicit extended limits when the source enables them', async () => {
+    const user = userEvent.setup()
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    getMock.mockImplementation(async (path: string) => {
+      if (path === '/api/search-profiles') {
+        return {
+          data: {
+            success: true,
+            profiles: [
+              {
+                id: 'profile-unsafe-1',
+                name: '51job extended profile',
+                updatedAt: '2026-03-17T00:00:00.000Z',
+                status: 'active',
+                location: '东莞',
+                keywords: ['CNC', '销售'],
+              },
+            ],
+          },
+        }
+      }
+
+      if (path === '/api/search-profiles/profile-unsafe-1') {
+        return {
+          data: {
+            success: true,
+            profile: {
+              id: 'profile-unsafe-1',
+              name: '51job extended profile',
+              status: 'active',
+              location: '东莞',
+              keywords: ['CNC', '销售'],
+              filters: {
+                minAge: 25,
+                maxAge: 40,
+              },
+              schedule: {
+                enabled: true,
+                cron: '0 9 * * 1-5',
+                maxCandidates: 250,
+              },
+              sources: [
+                {
+                  type: '51job',
+                  enabled: true,
+                  priority: 1,
+                  unsafeLimits: true,
+                },
+              ],
+            },
+          },
+        }
+      }
+
+      if (path === '/api/search-profiles/profile-unsafe-1/status') {
+        return {
+          data: {
+            success: true,
+            status: null,
+          },
+        }
+      }
+
+      return {
+        data: {
+          success: true,
+        },
+      }
+    })
+
+    render(<SearchProfilesPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Run 51job extended profile' }))
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledTimes(1)
+    })
+
+    const openedUrl = new URL(String(openSpy.mock.calls[0]?.[0]))
+    expect(`${openedUrl.origin}${openedUrl.pathname}`).toBe('https://ehire.51job.com/Revision/talent/search')
+    expect(openedUrl.searchParams.get('tr_limit')).toBe('250')
+    expect(openedUrl.searchParams.get('tr_max_pages')).toBe('10')
+    expect(openedUrl.searchParams.get('tr_unsafe_limits')).toBe('1')
+    expect(openedUrl.searchParams.get('tr_min_age')).toBe('25')
+    expect(openedUrl.searchParams.get('tr_max_age')).toBe('40')
+  })
+
   it('opens Job5156 profiles in a new tab when head-mode collection is enabled', async () => {
     const user = userEvent.setup()
     const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)

--- a/apps/web/src/pages/SearchProfilesPage.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.tsx
@@ -351,6 +351,7 @@ export function SearchProfilesPage() {
         source: {
           type: activeSource.type as CollectionSourceType,
           exactUrl: activeSource.jobUrl,
+          unsafeLimits: activeSource.unsafeLimits,
         },
         location: detail.location,
         keywords: detail.keywords,


### PR DESCRIPTION
## Summary
- align the 51job detail parser with the live payload shape for experience, job intention, education, location, activity status, and work-history fields
- add a profile-managed explicit opt-in for extended 51job launch limits while preserving the default 50 resumes / 1 page cap
- clarify 51job age-filter behavior by surfacing a `filtered-only` fallback status when native controls are unavailable

## Testing
- bun test apps/browser-extension/content-job51-config.test.ts apps/browser-extension/content-job51-detail-parser.test.ts
- npm --workspace @trends/web run test -- src/lib/search-profile-sources.test.ts src/pages/SearchProfilesPage.test.tsx src/components/SearchProfileEditorDialog.test.tsx
- bun run --filter '@trends/web' typecheck
- bun run --filter '@trends/browser-extension' typecheck
- bun run --filter '@trends/web' --filter '@trends/browser-extension' lint
- make check
- live 51job detail/search validation via Chrome DevTools after reloading the unpacked extension
