### PR TITLE
Add a CLI helper for 51job detail inspection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 		build-static build-static-fresh build-extension-zip serve-static \
 		i18n-check i18n-sync i18n-convert i18n-translate i18n-build \
 		refresh-sample refresh-sample-manual prefetch-convex chrome-debug \
+		debug-51job-detail \
 		seed seed-full seed-force seed-clear seed-clear-workspace seed-clear-dev \
 		seed-clear-demo-resumes \
 		backup-resumes restore-resumes restore-resumes-restart clear-resume-analyses clear-resume-analyses-restart \
@@ -887,6 +888,14 @@ refresh-sample-manual:
 	@echo ""
 	@echo "The exported file includes metadata for reproduction."
 
+# Inspect one synced 51job resume's parsed detail fields/workHistory via Trends CLI
+debug-51job-detail:
+	@if [ -z "$(RESUME_ID)" ]; then \
+		echo "Usage: make debug-51job-detail RESUME_ID=<resume-id> [RAW_PATH=/tmp/51job-<resume-id>-raw.json]"; \
+		exit 1; \
+	fi
+	./scripts/debug-51job-detail.sh "$(RESUME_ID)" "$(RAW_PATH)"
+
 # Start Chrome with remote debugging on port 9222 (for CDP/MCP)
 chrome-debug:
 	@chmod +x scripts/chrome-debug.sh
@@ -1159,6 +1168,7 @@ help:
 	@echo "  verify-dev-resume-latency Run strict local /dev/resumes regression gate against latest artifact"
 	@echo "  refresh-sample Auto-refresh resume sample data via CDP"
 	@echo "  refresh-sample-manual Show manual instructions for refreshing resume sample data"
+	@echo "  debug-51job-detail Inspect one synced 51job resume via Trends CLI backup"
 	@echo "  chrome-debug   Start Google Chrome with remote debugging (port 9222)"
 	@echo "  clean          Remove generated/cached files"
 	@echo "  check [TARGET=codex|agents|all] Run validation checks (Python + Node + governance skill validation)"
@@ -1205,6 +1215,8 @@ help:
 	@echo "  ALLOW_EMPTY    Allow empty resume samples (set to 1)"
 	@echo "  KEYWORD        Search keyword for refresh-sample / verify / benchmark"
 	@echo "  SAMPLE         Sample name for refresh-sample (default: sample-initial)"
+	@echo "  RESUME_ID      51job resumeId for make debug-51job-detail"
+	@echo "  RAW_PATH       Optional raw detail payload JSON path for make debug-51job-detail"
 	@echo "  LOCATION       Location filter for refresh-sample / verify / benchmark"
 	@echo "  RUNS           Benchmark measured runs per mode (default: 10, matrix: 3)"
 	@echo "  WARMUP         Benchmark warmup runs per mode (default: 1, matrix: 0)"

--- a/scripts/debug-51job-detail.sh
+++ b/scripts/debug-51job-detail.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/debug-51job-detail.sh <resume-id> [raw-json-path]
+
+Description:
+  Uses the Trends CLI to back up one synced 51job resume and print the core
+  parsed fields plus workHistory. If a raw 51job detail payload JSON path is
+  provided, the script also prints the most relevant raw fields side by side.
+
+Examples:
+  scripts/debug-51job-detail.sh 975386637
+  scripts/debug-51job-detail.sh 975386637 /tmp/51job-975386637-raw.json
+
+Notes:
+  - The parsed half comes from:
+      ./bin/trends resume backup --resume-id <id> --source-host ehire.51job.com
+  - The raw half is optional because the current Trends CLI does not expose the
+    browser extension's captured job51DetailPayload directly.
+  - To create the raw JSON file from the browser detail page console:
+      copy(JSON.stringify(window.__TR_RESUME_DATA__.getApiSnapshot().job51DetailPayload, null, 2))
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+RESUME_ID="${1:-}"
+RAW_PATH="${2:-}"
+
+if [[ -z "$RESUME_ID" ]]; then
+  usage
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required for this helper." >&2
+  exit 1
+fi
+
+OUT="/tmp/51job-${RESUME_ID}.json"
+
+./bin/trends resume backup \
+  --resume-id "$RESUME_ID" \
+  --source-host ehire.51job.com \
+  --out "$OUT"
+
+if [[ ! -s "$OUT" ]]; then
+  echo "ERROR: backup file missing or empty: $OUT" >&2
+  exit 1
+fi
+
+if ! jq -e '.. | .resumeId? // empty' "$OUT" >/dev/null 2>&1; then
+  echo "ERROR: no parsed synced resume found for resumeId=$RESUME_ID" >&2
+  echo "Hint: sync or collect the resume into Trends first, then rerun this helper." >&2
+  exit 1
+fi
+
+echo "=== Parsed core fields ==="
+jq '.. | {resumeId, name, experience, jobIntention, education, location, activityStatus}? | select(. != {})' "$OUT"
+
+echo
+echo "=== Parsed workHistory ==="
+jq '.. | .workHistory? // empty' "$OUT"
+
+if [[ -n "$RAW_PATH" ]]; then
+  if [[ ! -s "$RAW_PATH" ]]; then
+    echo >&2
+    echo "ERROR: raw payload path was provided but is missing or empty: $RAW_PATH" >&2
+    exit 1
+  fi
+
+  echo
+  echo "=== Raw detail payload fields ==="
+  jq '{
+    displayage: .data.displayage,
+    workyear: .data.workyear,
+    jobintention: .data.jobintention,
+    highestdegree: .data.highestdegree,
+    activetimelabel: .data.activetimelabel,
+    work: .data.work
+  }' "$RAW_PATH"
+else
+  echo
+  echo "=== Raw payload compare skipped ==="
+  echo "Provide a raw payload JSON path as the second argument to compare parsed vs raw."
+fi


### PR DESCRIPTION
## Summary
- add `scripts/debug-51job-detail.sh` to inspect one synced 51job resume's parsed detail fields and workHistory through the Trends CLI
- add `make debug-51job-detail RESUME_ID=<id> [RAW_PATH=...]` as a convenience wrapper
- document the target in `make help` output

## Verification
- bash -n scripts/debug-51job-detail.sh
- ./scripts/debug-51job-detail.sh --help
- make debug-51job-detail RESUME_ID= --dry-run
- make help
- make check