### PR TITLE
Ignore location-like 51job company placeholders

### DIFF
--- a/apps/browser-extension/content-job51-detail-parser.test.ts
+++ b/apps/browser-extension/content-job51-detail-parser.test.ts
@@ -79,6 +79,7 @@ async function loadHelpers(search: string): Promise<Job51ParserHelpers> {
     'stripHtmlTags',
     'normalizeJob51Text',
     'normalizeJob51MultilineText',
+    'isLikelyJob51LocationPlaceholderCompanyName',
     'buildWorkHistoryRawParts',
     'getJob51DetailRoot',
     'readJob51Text',
@@ -250,5 +251,71 @@ describe('job51 detail parser', () => {
       }),
     ])
     expect(String(resume.workHistory?.[0]?.description || '')).toContain('负责河南区域CNC销售工作')
+  })
+
+  it('drops location-like company placeholders while preserving detailed work descriptions', async () => {
+    const helpers = await loadHelpers('')
+
+    const [resume] = helpers.buildJob51DetailResumeFromPayload({
+      data: {
+        resumeid: '219816768',
+        username: '王先生',
+        displayage: '30岁',
+        workyear: '10',
+        activetimelabel: '1小时前活跃',
+        jobintention: [
+          {
+            expectfuncname: '销售工程师',
+            newdisplayexpectsalary: '8千-1.2万/月',
+            expectarea: [{ provincecity: '宁波', county: '' }],
+          },
+        ],
+        highestdegree: {
+          degree: '中技/中专',
+        },
+        work: [
+          {
+            compname: '宁波',
+            position: '销售工程师',
+            workindustry: '汽车研发/制造',
+            workdescribe: '机床销售、机床知识： 熟悉CNC数控机床、加工中心、车床、铣床、磨床等的工作原理及应用场景；了解发那科（FANUC）、西门子（SIEMENS）等主流数控系统。',
+            worktime: '3年6个月',
+            timefrom: '2022.10',
+            timeto: '至今',
+          },
+          {
+            compname: '宁波丰申智能装备有限公司',
+            position: '销售工程师',
+            workdescribe: '大客户销售、解决方案式销售、商务谈判、合同管理、市场分析。',
+            worktime: '4年6个月',
+            timefrom: '2021.10',
+            timeto: '至今',
+          },
+        ],
+      },
+    })
+
+    expect(resume).toMatchObject({
+      name: '王先生',
+      experience: '10',
+      jobIntention: '销售工程师',
+      education: '中技/中专',
+      location: '宁波',
+      activityStatus: '1小时前活跃',
+    })
+    expect(resume.workHistory).toEqual([
+      expect.objectContaining({
+        companyName: undefined,
+        jobTitle: '销售工程师',
+        startDate: '2022-10',
+        endDate: '至今',
+      }),
+      expect.objectContaining({
+        companyName: '宁波丰申智能装备有限公司',
+        jobTitle: '销售工程师',
+      }),
+    ])
+    expect(String(resume.workHistory?.[0]?.description || '')).toContain('机床销售、机床知识')
+    expect(String(resume.workHistory?.[0]?.raw || '')).not.toContain('· 宁波 ·')
   })
 })

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -1202,6 +1202,21 @@ function normalizeJob51MultilineText(value) {
   return normalizeResumeMultilineText(stripHtmlTags(value));
 }
 
+function isLikelyJob51LocationPlaceholderCompanyName(value) {
+  const text = normalizeJob51Text(value);
+  if (!text) return false;
+  if (
+    /(公司|集团|科技|机械|工业|实业|设备|自动化|贸易|精密|制造|电子|机电|工具|刀具|技术|股份|责任|有限|厂|大学|学院|学校|中心|医院|门诊|商贸|材料|模具|液压|传感)/u
+      .test(text)
+  ) {
+    return false;
+  }
+  if (!/^[\u4e00-\u9fa5]{2,4}$/u.test(text)) {
+    return false;
+  }
+  return true;
+}
+
 function normalizeResumeMultilineText(value) {
   if (typeof value !== "string") return "";
   return value
@@ -3648,7 +3663,7 @@ function buildJob51ExperienceEntry(item, kind) {
   if (!item || typeof item !== "object") return null;
 
   const isProject = kind === "project";
-  const companyName = readJob51Text(
+  const rawCompanyName = readJob51Text(
     item.company_name,
     item.companyName,
     item.compname,
@@ -3660,6 +3675,9 @@ function buildJob51ExperienceEntry(item, kind) {
     isProject ? item.projectName : undefined,
     isProject ? item.project : undefined,
   );
+  const companyName = isLikelyJob51LocationPlaceholderCompanyName(rawCompanyName)
+    ? ""
+    : rawCompanyName;
   const jobTitle = readJob51Text(
     item.work_func_value,
     item.workfunc,


### PR DESCRIPTION
## Summary
- add a conservative 51job parser guard for short location-like `compname` values
- keep detailed work-history descriptions intact while omitting weak employer placeholders
- add regression coverage for the live payload shape that used `宁波` as the first row company

## Verification
- bun test apps/browser-extension/content-job51-detail-parser.test.ts apps/browser-extension/content-job51-config.test.ts
- make check
- live 51job detail-page validation for resumeId 219816768
- live sync + Trends CLI re-check with ./scripts/debug-51job-detail.sh 219816768