### PR TITLE
Add resume detail work history lookup to the CLI

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../app";
 import { MatchStorage, type StoredMatch } from "../services/match-storage";
+import { ResumeService } from "../services/resume-service";
 import { SessionManager } from "../services/session-manager";
 
 type ConvexCall = {
@@ -135,6 +136,138 @@ function buildStoredMatch(
 describe("resume routes", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("returns sample-backed resume detail with full work history", async () => {
+    vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
+      items: [
+        {
+          name: "Alice",
+          profileUrl: "https://example.com/alice",
+          source: "ehire.51job.com",
+          activityStatus: "Active today",
+          age: "32岁",
+          experience: "8年",
+          education: "本科",
+          location: "东莞",
+          selfIntro: "熟悉CNC设备销售与客户跟进。",
+          jobIntention: "销售经理",
+          expectedSalary: "20K",
+          workHistory: [
+            {
+              raw: "2021-03 ~ 至今 Example Co. Sales Manager",
+              companyName: "Example Co.",
+              jobTitle: "Sales Manager",
+              description: "Managed CNC accounts.",
+              startDate: "2021-03",
+              endDate: "至今",
+            },
+          ],
+          extractedAt: "2026-04-02T00:00:00.000Z",
+          resumeId: "sample-resume-1",
+          externalId: "sample-resume-1",
+        },
+      ],
+      sample: {
+        name: "sample-initial",
+        filename: "sample-initial.json",
+        updatedAt: "2026-04-02T00:00:00.000Z",
+        size: 123,
+      },
+      metadata: undefined,
+      indexes: new Map(),
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes/sample-resume-1?source=sample");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toEqual(
+      expect.objectContaining({
+        success: true,
+        source: "sample",
+        sample: expect.objectContaining({ name: "sample-initial" }),
+        data: expect.objectContaining({
+          resumeId: "sample-resume-1",
+          name: "Alice",
+          workHistory: [
+            expect.objectContaining({
+              companyName: "Example Co.",
+              description: "Managed CNC accounts.",
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("returns convex-backed resume detail with full work history", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      if (call.pathName !== "resumes:getResumeDetail") {
+        throw new Error(`Unexpected convex path: ${call.pathName}`);
+      }
+      expect(call.args).toEqual({ resumeId: "resume-live-1" });
+      return convexSuccess({
+        _id: "resume-live-1",
+        source: "seek",
+        content: {
+          name: "Alice",
+          profileUrl: "https://example.com/alice",
+          activityStatus: "Active today",
+          age: "32岁",
+          experience: "8年",
+          education: "本科",
+          location: "东莞",
+          selfIntro: "熟悉CNC设备销售与客户跟进。",
+          jobIntention: "销售经理",
+          expectedSalary: "20K",
+          workHistory: [
+            {
+              raw: "2021-03 ~ 至今 Example Co. Sales Manager",
+              companyName: "Example Co.",
+              jobTitle: "Sales Manager",
+              description: "Managed CNC accounts.",
+              startDate: "2021-03",
+              endDate: "至今",
+            },
+          ],
+          extractedAt: "2026-04-02T00:00:00.000Z",
+          resumeId: "resume-live-1",
+          externalId: "resume-live-1",
+        },
+        ingestData: {
+          companyHits: ["fanuc"],
+        },
+      });
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes/resume-live-1?source=convex");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toEqual(
+      expect.objectContaining({
+        success: true,
+        source: "convex",
+        data: expect.objectContaining({
+          resumeId: "resume-live-1",
+          name: "Alice",
+          source: "seek",
+          workHistory: [
+            expect.objectContaining({
+              companyName: "Example Co.",
+              description: "Managed CNC accounts.",
+            }),
+          ],
+          ingestData: expect.objectContaining({
+            companyHits: ["fanuc"],
+          }),
+        }),
+      }),
+    );
   });
 
   it("returns convex-backed live query results and expansion metadata", async () => {

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -7,6 +7,8 @@ import path from "node:path";
 import {
   ResumesQuerySchema,
   ResumesResponseSchema,
+  ResumeDetailPathParamSchema,
+  ResumeDetailResponseSchema,
   ResumeKeywordExpansionQuerySchema,
   ResumeKeywordExpansionResponseSchema,
   ResumeSamplesResponseSchema,
@@ -541,10 +543,52 @@ function toResumeItemFromRecord(record: Record<string, unknown>, source?: string
       .map((entry) => normalizeWorkHistoryEntry(entry))
       .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
     : [];
+  const projectExperience = Array.isArray(record.projectExperience)
+    ? record.projectExperience
+      .map((entry) => normalizeWorkHistoryEntry(entry))
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    : [];
+  const profileEducation = Array.isArray(record.profileEducation)
+    ? record.profileEducation
+      .map((entry) => {
+        if (!isRecord(entry)) {
+          return null;
+        }
+
+        const institution = toStringValue(entry.institution) || undefined;
+        const qualification = toStringValue(entry.qualification) || undefined;
+        const fieldOfStudy = toStringValue(entry.fieldOfStudy) || undefined;
+        const description = toStringValue(entry.description) || undefined;
+        const startDate = toStringValue(entry.startDate) || undefined;
+        const endDate = toStringValue(entry.endDate) || undefined;
+
+        if (
+          !institution
+          && !qualification
+          && !fieldOfStudy
+          && !description
+          && !startDate
+          && !endDate
+        ) {
+          return null;
+        }
+
+        return {
+          ...(institution ? { institution } : {}),
+          ...(qualification ? { qualification } : {}),
+          ...(fieldOfStudy ? { fieldOfStudy } : {}),
+          ...(description ? { description } : {}),
+          ...(startDate ? { startDate } : {}),
+          ...(endDate ? { endDate } : {}),
+        };
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    : [];
 
   return {
     name: toStringValue(record.name),
     profileUrl,
+    ...(toStringValue(record.source) || source ? { source: toStringValue(record.source) || source } : {}),
     activityStatus: toStringValue(record.activityStatus),
     age: toStringValue(record.age),
     experience: toStringValue(record.experience),
@@ -554,6 +598,8 @@ function toResumeItemFromRecord(record: Record<string, unknown>, source?: string
     jobIntention: toStringValue(record.jobIntention),
     expectedSalary: toStringValue(record.expectedSalary),
     workHistory,
+    ...(projectExperience.length > 0 ? { projectExperience } : {}),
+    ...(profileEducation.length > 0 ? { profileEducation } : {}),
     extractedAt: toStringValue(record.extractedAt),
     ingestData: buildResumeIngestData(record.ingestData),
     resumeId: toStringValue(record.resumeId) || undefined,
@@ -2595,6 +2641,124 @@ app.openapi(getResumesRoute, (c) => {
   }
 });
 
+function findSampleResumeByIdentifier(items: ResumeItem[], resumeId: string): ResumeItem | null {
+  const normalizedResumeId = resumeId.trim();
+  if (!normalizedResumeId) {
+    return null;
+  }
+
+  for (const [index, item] of items.entries()) {
+    if (resolveResumeId(item, index) === normalizedResumeId) {
+      return item;
+    }
+  }
+
+  return null;
+}
+
+async function getConvexResumeDetail(resumeId: string): Promise<ResumeItem | null> {
+  const value = await callConvexQuery("resumes:getResumeDetail", { resumeId });
+  if (value === null) {
+    return null;
+  }
+  if (!isRecord(value)) {
+    throw new Error("Invalid resume detail response from Convex");
+  }
+
+  const content = isRecord(value.content) ? value.content : {};
+  const source = toStringValue(value.source) || undefined;
+  const resume = toResumeItemFromRecord(content, source);
+  const ingestData = buildResumeIngestData(value.ingestData);
+
+  return ingestData
+    ? {
+        ...resume,
+        ingestData,
+      }
+    : resume;
+}
+
+const getResumeDetailRoute = createRoute({
+  method: "get",
+  path: "/api/resumes/{resumeId}",
+  tags: ["resumes"],
+  summary: "Get one resume with detailed work experience",
+  description: "Returns one resume including structured work history for UI or CLI inspection",
+  request: {
+    params: ResumeDetailPathParamSchema,
+    query: ResumesQuerySchema.pick({
+      sample: true,
+      source: true,
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ResumeDetailResponseSchema,
+        },
+      },
+      description: "Resume detail",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: SimpleErrorSchema,
+        },
+      },
+      description: "Resume not found",
+    },
+  },
+});
+
+app.openapi(getResumeDetailRoute, async (c) => {
+  const resumeId = c.req.param("resumeId").trim();
+  const { sample, source } = c.req.valid("query");
+  const sampleName = sample?.trim() || undefined;
+
+  if (source === "convex") {
+    const resume = await getConvexResumeDetail(resumeId);
+    if (!resume) {
+      return c.json({
+        success: false as const,
+        error: `Resume not found: ${resumeId}`,
+      }, 404);
+    }
+
+    return c.json({
+      success: true as const,
+      source,
+      data: resume,
+    }, 200);
+  }
+
+  try {
+    const { items, sample: sampleInfo } = resumeService.loadSample(sampleName);
+    const resume = findSampleResumeByIdentifier(items, resumeId);
+    if (!resume) {
+      return c.json({
+        success: false as const,
+        error: `Resume not found: ${resumeId}`,
+      }, 404);
+    }
+
+    return c.json({
+      success: true as const,
+      source,
+      sample: sampleInfo,
+      data: resume,
+    }, 200);
+  } catch (error) {
+    if (error instanceof DataNotFoundError) {
+      return c.json({
+        success: false as const,
+        error: error.message,
+      }, 404);
+    }
+    throw error;
+  }
+});
+
 const matchResumesRoute = createRoute({
   method: "post",
   path: "/api/resumes/match",
@@ -2801,7 +2965,7 @@ app.openapi(matchResumesRoute, async (c) => {
       }
 
       return c.json(
-        {
+        MatchResponseSchema.parse({
           success: true as const,
           mode,
           streamPath: mode === "hybrid" ? "/api/resumes/match-stream" : undefined,
@@ -2814,7 +2978,7 @@ app.openapi(matchResumesRoute, async (c) => {
           }),
           results,
           stats,
-        },
+        }),
         200
       );
     }
@@ -2894,7 +3058,7 @@ app.openapi(matchResumesRoute, async (c) => {
     }
 
     return c.json(
-      {
+      MatchResponseSchema.parse({
         success: true as const,
         mode: "ai_only",
         query: buildMatchQueryMetadata({
@@ -2905,7 +3069,7 @@ app.openapi(matchResumesRoute, async (c) => {
         }),
         results: finalResults,
         stats,
-      },
+      }),
       200
     );
   } catch (error) {
@@ -4176,7 +4340,7 @@ app.openapi(rescoreResumeMatchesRoute, async (c) => {
   }
 
   return c.json(
-    {
+    MatchResponseSchema.parse({
       success: true as const,
       mode: "rules_only",
       query: buildMatchQueryMetadata({
@@ -4189,7 +4353,7 @@ app.openapi(rescoreResumeMatchesRoute, async (c) => {
       }),
       results,
       stats: computeStats(results, Date.now() - startTime, 0),
-    },
+    }),
     200
   );
 });

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -570,6 +570,22 @@ export const ResumesResponseSchema = z
   })
   .openapi("ResumesResponse");
 
+export const ResumeDetailPathParamSchema = z.object({
+  resumeId: z.string().openapi({
+    param: { name: "resumeId", in: "path" },
+    example: "resume-live-1",
+  }),
+});
+
+export const ResumeDetailResponseSchema = z
+  .object({
+    success: z.literal(true),
+    source: z.enum(["sample", "convex"]),
+    sample: ResumeSampleSchema.optional(),
+    data: ResumeItemSchema,
+  })
+  .openapi("ResumeDetailResponse");
+
 export const ResumeKeywordExpansionQuerySchema = z.object({
   q: z
     .string()

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -762,6 +762,63 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/resumes/{resumeId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get one resume with detailed work experience
+         * @description Returns one resume including structured work history for UI or CLI inspection
+         */
+        get: {
+            parameters: {
+                query?: {
+                    sample?: string;
+                    source?: "sample" | "convex";
+                };
+                header?: never;
+                path: {
+                    resumeId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Resume detail */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ResumeDetailResponse"];
+                    };
+                };
+                /** @description Resume not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/resumes/match": {
         parameters: {
             query?: never;
@@ -7138,6 +7195,14 @@ export interface components {
                 };
             };
             data: components["schemas"]["ResumeItem"][];
+        };
+        ResumeDetailResponse: {
+            /** @enum {boolean} */
+            success: true;
+            /** @enum {string} */
+            source: "sample" | "convex";
+            sample?: components["schemas"]["ResumeSample"];
+            data: components["schemas"]["ResumeItem"];
         };
         /** @enum {string} */
         ResumeResultSource: "sample" | "convex";

--- a/packages/cli/cmd/resume.go
+++ b/packages/cli/cmd/resume.go
@@ -24,6 +24,7 @@ func newResumeCmd() *cobra.Command {
 
 	resumeCmd.AddCommand(
 		newResumeListCmd(),
+		newResumeShowCmd(),
 		newResumeSearchCmd(),
 		newResumeMatchCmd(),
 		newResumeSnapshotCmd(),
@@ -68,6 +69,39 @@ func newResumeListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum resumes to fetch")
+	return cmd
+}
+
+func newResumeShowCmd() *cobra.Command {
+	var sample string
+	var source string
+
+	cmd := &cobra.Command{
+		Use:   "show <resume-id>",
+		Short: "Show one resume with detailed work experience",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := newAPIClient().GetResumeDetail(
+				context.Background(),
+				args[0],
+				sample,
+				source,
+			)
+			if err != nil {
+				return err
+			}
+
+			if currentOptions().Output == "json" {
+				return writeOutput(cmd, nil, nil, response)
+			}
+
+			return writeResumeDetailOutput(cmd, response)
+		},
+	}
+
+	cmd.Flags().StringVar(&sample, "sample", "", "Optional sample name when source=sample")
+	cmd.Flags().StringVar(&source, "source", "sample", "Resume source: sample|convex")
+
 	return cmd
 }
 
@@ -348,6 +382,98 @@ func buildResumeManualImportOutput(response *client.ResumeManualImportResponse) 
 		Headers: headers,
 		Rows:    rows,
 	}
+}
+
+func writeResumeDetailOutput(cmd *cobra.Command, response *client.ResumeDetailResponse) error {
+	item := response.Data
+	out := cmd.OutOrStdout()
+
+	if _, err := fmt.Fprintf(
+		out,
+		"ID: %s\nName: %s\nSource: %s\nIntention: %s\nLocation: %s\nExperience: %s\nEducation: %s\nActivity: %s\nSalary: %s\nProfile: %s\n",
+		coalesceString(item.ResumeID, item.PerUserID, item.ProfileID, item.ExternalID),
+		fallbackDisplayValue(item.Name),
+		fallbackDisplayValue(response.Source),
+		fallbackDisplayValue(item.JobIntention),
+		fallbackDisplayValue(item.Location),
+		fallbackDisplayValue(item.Experience),
+		fallbackDisplayValue(item.Education),
+		fallbackDisplayValue(item.ActivityStatus),
+		fallbackDisplayValue(item.ExpectedSalary),
+		fallbackDisplayValue(item.ProfileURL),
+	); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(item.SelfIntro) != "" {
+		if _, err := fmt.Fprintf(out, "\nSelf Intro:\n%s\n", item.SelfIntro); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintln(out, "\nWork History:"); err != nil {
+		return err
+	}
+	if len(item.WorkHistory) == 0 {
+		if _, err := fmt.Fprintln(out, "- --"); err != nil {
+			return err
+		}
+	} else {
+		for index, entry := range item.WorkHistory {
+			if _, err := fmt.Fprintf(out, "%d. %s\n", index+1, formatResumeWorkHistoryEntry(entry)); err != nil {
+				return err
+			}
+			if description := strings.TrimSpace(entry.Description); description != "" {
+				if _, err := fmt.Fprintf(out, "%s\n", indentMultiline(description, "   ")); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func fallbackDisplayValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "--"
+	}
+	return value
+}
+
+func formatResumeWorkHistoryEntry(entry client.ResumeWorkHistoryItem) string {
+	parts := make([]string, 0, 4)
+
+	dateRange := strings.TrimSpace(strings.Join([]string{
+		strings.TrimSpace(entry.StartDate),
+		strings.TrimSpace(entry.EndDate),
+	}, " ~ "))
+	dateRange = strings.TrimSpace(strings.Trim(dateRange, "~ "))
+	if dateRange != "" {
+		parts = append(parts, dateRange)
+	}
+
+	if company := strings.TrimSpace(entry.CompanyName); company != "" {
+		parts = append(parts, company)
+	}
+	if title := strings.TrimSpace(entry.JobTitle); title != "" {
+		parts = append(parts, title)
+	}
+	if len(parts) == 0 && strings.TrimSpace(entry.Raw) != "" {
+		return entry.Raw
+	}
+	if len(parts) == 0 {
+		return "--"
+	}
+	return strings.Join(parts, " | ")
+}
+
+func indentMultiline(text string, prefix string) string {
+	lines := strings.Split(text, "\n")
+	for index, line := range lines {
+		lines[index] = prefix + line
+	}
+	return strings.Join(lines, "\n")
 }
 
 type resumeDisplayRow struct {

--- a/packages/cli/cmd/resume_test.go
+++ b/packages/cli/cmd/resume_test.go
@@ -54,6 +54,64 @@ func TestResumeSearchCommandSupportsConvexSource(t *testing.T) {
 	}
 }
 
+func TestResumeShowCommandWritesDetailedWorkHistory(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/resume-1" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("source"); got != "convex" {
+			t.Fatalf("expected source=convex, got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(client.ResumeDetailResponse{
+			Success: true,
+			Source:  "convex",
+			Data: client.ResumeItem{
+				ResumeID:       "resume-1",
+				Name:           "Alice",
+				JobIntention:   "Sales",
+				Location:       "Dongguan",
+				Experience:     "8 years",
+				Education:      "Bachelor",
+				ActivityStatus: "Active today",
+				ExpectedSalary: "20K",
+				ProfileURL:     "https://example.com/alice",
+				SelfIntro:      "Strong CNC sales background.",
+				WorkHistory: []client.ResumeWorkHistoryItem{
+					{
+						Raw:         "2021-03 ~ 至今 Example Co. Sales Manager",
+						CompanyName: "Example Co.",
+						JobTitle:    "Sales Manager",
+						Description: "Managed CNC machine accounts.\nClosed key projects.",
+						StartDate:   "2021-03",
+						EndDate:     "至今",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "hr")
+	setCLIOutput(t, "table")
+
+	cmd := newResumeShowCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"resume-1", "--source", "convex"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume show command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "Work History:") ||
+		!strings.Contains(text, "Example Co. | Sales Manager") ||
+		!strings.Contains(text, "Managed CNC machine accounts.") {
+		t.Fatalf("unexpected command output: %s", text)
+	}
+}
+
 func TestResumeMatchCommandWritesJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/resumes/match" {

--- a/packages/cli/internal/client/api.go
+++ b/packages/cli/internal/client/api.go
@@ -10,16 +10,42 @@ import (
 )
 
 type ResumeItem struct {
-	ResumeID       string `json:"resumeId"`
-	PerUserID      string `json:"perUserId"`
-	ProfileID      string `json:"profileId"`
-	ExternalID     string `json:"externalId"`
-	Name           string `json:"name"`
-	JobIntention   string `json:"jobIntention"`
-	Location       string `json:"location"`
-	Experience     string `json:"experience"`
-	Education      string `json:"education"`
-	ExpectedSalary string `json:"expectedSalary"`
+	ResumeID          string                       `json:"resumeId"`
+	PerUserID         string                       `json:"perUserId"`
+	ProfileID         string                       `json:"profileId"`
+	ExternalID        string                       `json:"externalId"`
+	Name              string                       `json:"name"`
+	JobIntention      string                       `json:"jobIntention"`
+	Location          string                       `json:"location"`
+	Experience        string                       `json:"experience"`
+	Education         string                       `json:"education"`
+	ExpectedSalary    string                       `json:"expectedSalary"`
+	ProfileURL        string                       `json:"profileUrl"`
+	Source            string                       `json:"source"`
+	ActivityStatus    string                       `json:"activityStatus"`
+	SelfIntro         string                       `json:"selfIntro"`
+	WorkHistory       []ResumeWorkHistoryItem      `json:"workHistory"`
+	ProjectExperience []ResumeWorkHistoryItem      `json:"projectExperience,omitempty"`
+	ProfileEducation  []ResumeProfileEducationItem `json:"profileEducation,omitempty"`
+	ExtractedAt       string                       `json:"extractedAt"`
+}
+
+type ResumeWorkHistoryItem struct {
+	Raw         string `json:"raw"`
+	CompanyName string `json:"companyName,omitempty"`
+	JobTitle    string `json:"jobTitle,omitempty"`
+	Description string `json:"description,omitempty"`
+	StartDate   string `json:"startDate,omitempty"`
+	EndDate     string `json:"endDate,omitempty"`
+}
+
+type ResumeProfileEducationItem struct {
+	Institution   string `json:"institution,omitempty"`
+	Qualification string `json:"qualification,omitempty"`
+	FieldOfStudy  string `json:"fieldOfStudy,omitempty"`
+	Description   string `json:"description,omitempty"`
+	StartDate     string `json:"startDate,omitempty"`
+	EndDate       string `json:"endDate,omitempty"`
 }
 
 type ResumeSample struct {
@@ -42,6 +68,13 @@ type ResumesResponse struct {
 	Data    []ResumeItem   `json:"data"`
 	Sample  *ResumeSample  `json:"sample,omitempty"`
 	Summary ResumesSummary `json:"summary"`
+}
+
+type ResumeDetailResponse struct {
+	Success bool          `json:"success"`
+	Source  string        `json:"source"`
+	Sample  *ResumeSample `json:"sample,omitempty"`
+	Data    ResumeItem    `json:"data"`
 }
 
 type JobDescriptionFile struct {
@@ -215,15 +248,15 @@ type ResumeMatchDebugProvenance struct {
 }
 
 type ResumeMatchDebugRoleSignal struct {
-	Type                         string   `json:"type"`
-	MatchedSignals               []string `json:"matchedSignals"`
-	SignalCount                  int      `json:"signalCount"`
-	Occurrences                  int      `json:"occurrences"`
-	Years                        float64  `json:"years"`
-	IndustryVerifiedYears        float64  `json:"industryVerifiedYears"`
-	RoleRelevantYears            *float64 `json:"roleRelevantYears,omitempty"`
+	Type                          string   `json:"type"`
+	MatchedSignals                []string `json:"matchedSignals"`
+	SignalCount                   int      `json:"signalCount"`
+	Occurrences                   int      `json:"occurrences"`
+	Years                         float64  `json:"years"`
+	IndustryVerifiedYears         float64  `json:"industryVerifiedYears"`
+	RoleRelevantYears             *float64 `json:"roleRelevantYears,omitempty"`
 	IndustryVerifiedRelevantYears *float64 `json:"industryVerifiedRelevantYears,omitempty"`
-	VerifyIn                     string   `json:"verifyIn"`
+	VerifyIn                      string   `json:"verifyIn"`
 }
 
 type ResumeMatchDebugBrandHit struct {
@@ -250,19 +283,19 @@ type MatchStats struct {
 }
 
 type ResumeMatchResult struct {
-	ResumeID         string             `json:"resumeId"`
-	JobDescriptionID string             `json:"jobDescriptionId"`
-	Score            int                `json:"score"`
-	Recommendation   string             `json:"recommendation"`
-	Highlights       []string           `json:"highlights"`
-	Concerns         []string           `json:"concerns"`
-	Summary          string             `json:"summary"`
-	Breakdown        map[string]int     `json:"breakdown,omitempty"`
-	ScoreSource      string             `json:"scoreSource,omitempty"`
-	MatchedAt        string             `json:"matchedAt"`
-	SessionID        string             `json:"sessionId,omitempty"`
-	UserID           string             `json:"userId,omitempty"`
-	Debug            *ResumeMatchDebug  `json:"debug,omitempty"`
+	ResumeID         string            `json:"resumeId"`
+	JobDescriptionID string            `json:"jobDescriptionId"`
+	Score            int               `json:"score"`
+	Recommendation   string            `json:"recommendation"`
+	Highlights       []string          `json:"highlights"`
+	Concerns         []string          `json:"concerns"`
+	Summary          string            `json:"summary"`
+	Breakdown        map[string]int    `json:"breakdown,omitempty"`
+	ScoreSource      string            `json:"scoreSource,omitempty"`
+	MatchedAt        string            `json:"matchedAt"`
+	SessionID        string            `json:"sessionId,omitempty"`
+	UserID           string            `json:"userId,omitempty"`
+	Debug            *ResumeMatchDebug `json:"debug,omitempty"`
 }
 
 type ResumeMatchRequest struct {
@@ -324,6 +357,28 @@ func (c *Client) ListResumes(ctx context.Context, limit int, query string, sourc
 
 func (c *Client) SearchResumes(ctx context.Context, query string, limit int, source string) (*ResumesResponse, error) {
 	return c.ListResumes(ctx, limit, query, source)
+}
+
+func (c *Client) GetResumeDetail(ctx context.Context, resumeID string, sample string, source string) (*ResumeDetailResponse, error) {
+	values := url.Values{}
+	if strings.TrimSpace(sample) != "" {
+		values.Set("sample", strings.TrimSpace(sample))
+	}
+	values.Set("source", normalizeResumeSource(source))
+
+	endpoint := fmt.Sprintf("%s/api/resumes/%s", c.APIURL, url.PathEscape(strings.TrimSpace(resumeID)))
+	if encoded := values.Encode(); encoded != "" {
+		endpoint = fmt.Sprintf("%s?%s", endpoint, encoded)
+	}
+
+	var response ResumeDetailResponse
+	if err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("resume detail request was not successful")
+	}
+	return &response, nil
 }
 
 func (c *Client) MatchResumes(ctx context.Context, request ResumeMatchRequest) (*ResumeMatchResponse, error) {


### PR DESCRIPTION
## Summary
- add a new `GET /api/resumes/{resumeId}` endpoint for detailed resume lookup
- add `trends resume show <resume-id>` to print structured work history from sample or convex sources
- extend API/CLI tests and regenerate the web API types

## Verification
- npm test -- apps/api/src/routes/resumes.test.ts
- cd packages/cli && go test ./...
- make check
