### PR TITLE
Fix resume skills-version route shadowing

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -342,6 +342,20 @@ describe("resume routes", () => {
     }));
   });
 
+  it("keeps the static skills-version route from being shadowed by resume detail lookup", async () => {
+    const app = createApp();
+    const response = await app.request("/api/resumes/skills-version");
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toEqual(
+      expect.objectContaining({
+        success: true,
+        version: expect.any(Number),
+      }),
+    );
+  });
+
   it("returns read-only convex query scores with debug metadata", async () => {
     const createSessionSpy = vi.spyOn(SessionManager.prototype, "createSession");
     const saveMatchesSpy = vi.spyOn(MatchStorage.prototype, "saveMatches");

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -2678,87 +2678,6 @@ async function getConvexResumeDetail(resumeId: string): Promise<ResumeItem | nul
     : resume;
 }
 
-const getResumeDetailRoute = createRoute({
-  method: "get",
-  path: "/api/resumes/{resumeId}",
-  tags: ["resumes"],
-  summary: "Get one resume with detailed work experience",
-  description: "Returns one resume including structured work history for UI or CLI inspection",
-  request: {
-    params: ResumeDetailPathParamSchema,
-    query: ResumesQuerySchema.pick({
-      sample: true,
-      source: true,
-    }),
-  },
-  responses: {
-    200: {
-      content: {
-        "application/json": {
-          schema: ResumeDetailResponseSchema,
-        },
-      },
-      description: "Resume detail",
-    },
-    404: {
-      content: {
-        "application/json": {
-          schema: SimpleErrorSchema,
-        },
-      },
-      description: "Resume not found",
-    },
-  },
-});
-
-app.openapi(getResumeDetailRoute, async (c) => {
-  const resumeId = c.req.param("resumeId").trim();
-  const { sample, source } = c.req.valid("query");
-  const sampleName = sample?.trim() || undefined;
-
-  if (source === "convex") {
-    const resume = await getConvexResumeDetail(resumeId);
-    if (!resume) {
-      return c.json({
-        success: false as const,
-        error: `Resume not found: ${resumeId}`,
-      }, 404);
-    }
-
-    return c.json({
-      success: true as const,
-      source,
-      data: resume,
-    }, 200);
-  }
-
-  try {
-    const { items, sample: sampleInfo } = resumeService.loadSample(sampleName);
-    const resume = findSampleResumeByIdentifier(items, resumeId);
-    if (!resume) {
-      return c.json({
-        success: false as const,
-        error: `Resume not found: ${resumeId}`,
-      }, 404);
-    }
-
-    return c.json({
-      success: true as const,
-      source,
-      sample: sampleInfo,
-      data: resume,
-    }, 200);
-  } catch (error) {
-    if (error instanceof DataNotFoundError) {
-      return c.json({
-        success: false as const,
-        error: error.message,
-      }, 404);
-    }
-    throw error;
-  }
-});
-
 const matchResumesRoute = createRoute({
   method: "post",
   path: "/api/resumes/match",
@@ -4797,6 +4716,87 @@ app.post("/api/resumes/learning-feedback", async (c) => {
 app.get("/api/resumes/skills-version", (c) => {
   const version = skillsKnowledgeService.getVersion();
   return c.json({ success: true, version }, 200);
+});
+
+const getResumeDetailRoute = createRoute({
+  method: "get",
+  path: "/api/resumes/{resumeId}",
+  tags: ["resumes"],
+  summary: "Get one resume with detailed work experience",
+  description: "Returns one resume including structured work history for UI or CLI inspection",
+  request: {
+    params: ResumeDetailPathParamSchema,
+    query: ResumesQuerySchema.pick({
+      sample: true,
+      source: true,
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ResumeDetailResponseSchema,
+        },
+      },
+      description: "Resume detail",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: SimpleErrorSchema,
+        },
+      },
+      description: "Resume not found",
+    },
+  },
+});
+
+app.openapi(getResumeDetailRoute, async (c) => {
+  const resumeId = c.req.param("resumeId").trim();
+  const { sample, source } = c.req.valid("query");
+  const sampleName = sample?.trim() || undefined;
+
+  if (source === "convex") {
+    const resume = await getConvexResumeDetail(resumeId);
+    if (!resume) {
+      return c.json({
+        success: false as const,
+        error: `Resume not found: ${resumeId}`,
+      }, 404);
+    }
+
+    return c.json({
+      success: true as const,
+      source,
+      data: resume,
+    }, 200);
+  }
+
+  try {
+    const { items, sample: sampleInfo } = resumeService.loadSample(sampleName);
+    const resume = findSampleResumeByIdentifier(items, resumeId);
+    if (!resume) {
+      return c.json({
+        success: false as const,
+        error: `Resume not found: ${resumeId}`,
+      }, 404);
+    }
+
+    return c.json({
+      success: true as const,
+      source,
+      sample: sampleInfo,
+      data: resume,
+    }, 200);
+  } catch (error) {
+    if (error instanceof DataNotFoundError) {
+      return c.json({
+        success: false as const,
+        error: error.message,
+      }, 404);
+    }
+    throw error;
+  }
 });
 
 app.post("/api/resumes/trigger-reingest", async (c) => {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -762,63 +762,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/resumes/{resumeId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get one resume with detailed work experience
-         * @description Returns one resume including structured work history for UI or CLI inspection
-         */
-        get: {
-            parameters: {
-                query?: {
-                    sample?: string;
-                    source?: "sample" | "convex";
-                };
-                header?: never;
-                path: {
-                    resumeId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Resume detail */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ResumeDetailResponse"];
-                    };
-                };
-                /** @description Resume not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/resumes/match": {
         parameters: {
             query?: never;
@@ -1907,6 +1850,63 @@ export interface paths {
                 };
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/resumes/{resumeId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get one resume with detailed work experience
+         * @description Returns one resume including structured work history for UI or CLI inspection
+         */
+        get: {
+            parameters: {
+                query?: {
+                    sample?: string;
+                    source?: "sample" | "convex";
+                };
+                header?: never;
+                path: {
+                    resumeId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Resume detail */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ResumeDetailResponse"];
+                    };
+                };
+                /** @description Resume not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -7196,14 +7196,6 @@ export interface components {
             };
             data: components["schemas"]["ResumeItem"][];
         };
-        ResumeDetailResponse: {
-            /** @enum {boolean} */
-            success: true;
-            /** @enum {string} */
-            source: "sample" | "convex";
-            sample?: components["schemas"]["ResumeSample"];
-            data: components["schemas"]["ResumeItem"];
-        };
         /** @enum {string} */
         ResumeResultSource: "sample" | "convex";
         MatchBreakdown: {
@@ -7981,6 +7973,14 @@ export interface components {
              * @example https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=***
              */
             webhookUrl?: string;
+        };
+        ResumeDetailResponse: {
+            /** @enum {boolean} */
+            success: true;
+            /** @enum {string} */
+            source: "sample" | "convex";
+            sample?: components["schemas"]["ResumeSample"];
+            data: components["schemas"]["ResumeItem"];
         };
         ResumeFilters: {
             minExperience?: number;


### PR DESCRIPTION
## Summary
- fix route ordering so GET /api/resumes/skills-version is no longer shadowed by GET /api/resumes/{resumeId}
- keep the resume detail API contract intact while restoring the static skills-version endpoint
- add a regression test and regenerate web API types

## Verification
- npm test -- apps/api/src/routes/resumes.test.ts
- curl http://localhost:3000/api/resumes/skills-version
- make check
