### PR TITLE
Fix 51job detail enrichment: timestamp and error handling

### DIFF
--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -17,6 +17,10 @@ import {
   resolveJob51DetailFetchDelayMs,
 } from "./lib/job51-collection-config";
 import {
+  collectJob5156SectionItemsByHeading,
+  isMeaningfulJob5156WorkHistoryEntry,
+} from "./lib/job5156-detail-utils";
+import {
   buildWorkHistoryRawParts,
   normalizeResumeMultilineText,
   normalizeResumeText,
@@ -1484,30 +1488,18 @@ function buildJob5156DetailWorkHistoryItem(item) {
   };
 }
 
-function collectSectionItemsByHeading(root, headingPattern) {
-  if (!(root instanceof Element)) return [];
-
-  const sections = Array.from(
-    root.querySelectorAll(
-      'section, .section, .resume-section, .module, .card, .block, .resume-view-layout, [class*="section"], [class*="module"], [class*="block"]',
-    ),
+function collectSectionItemsByHeading(
+  root,
+  headingPattern,
+  primarySelectors = [],
+  fallbackSelectors = [],
+) {
+  return collectJob5156SectionItemsByHeading(
+    root,
+    headingPattern,
+    primarySelectors,
+    fallbackSelectors,
   );
-  for (const section of sections) {
-    const heading = normalizeResumeText(
-      section.querySelector(
-        'h1, h2, h3, h4, .title, .section-title, .module-title, .resume-view-layout__title, [class*="title"]',
-      )?.textContent,
-    );
-    if (heading && headingPattern.test(heading)) {
-      return Array.from(
-        section.querySelectorAll(
-          '.resume-work__info, .resume-education__info, .work-item, .school-item, li, .item, [class*="item"]',
-        ),
-      );
-    }
-  }
-
-  return [];
 }
 
 function buildJob5156DetailResumeFromRoot(root, options = {}) {
@@ -1546,15 +1538,38 @@ function buildJob5156DetailResumeFromRoot(root, options = {}) {
   const workItems = collectSectionItemsByHeading(
     root,
     /工作经历|工作经验|工作履历/u,
+    [
+      ".resume-work__info",
+      ".work-item",
+      ".work-block",
+      '[class*="work-item"]',
+      '[class*="work-block"]',
+    ],
+    [
+      ":scope > li",
+      ":scope > .item",
+      ':scope > [class*="item"]',
+    ],
   );
   const educationItems = collectSectionItemsByHeading(
     root,
     /教育经历|教育背景|学习经历/u,
+    [
+      ".resume-education__info",
+      ".school-item",
+      '[class*="education"]',
+      '[class*="school"]',
+    ],
+    [
+      ":scope > li",
+      ":scope > .item",
+      ':scope > [class*="item"]',
+    ],
   );
   const seenWorkHistory = new Set();
   const workHistory = workItems
     .map((item) => buildJob5156DetailWorkHistoryItem(item))
-    .filter((item) => item && (item.raw.length > 5 || item.description))
+    .filter((item) => item && isMeaningfulJob5156WorkHistoryEntry(item))
     .filter((item) => {
       const signature = [
         item.companyName || "",

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -2091,6 +2091,19 @@ function isJob51RateLimitedPayload(payload) {
   return candidates.some((value) => isJob51RateLimitedErrorMessage(value));
 }
 
+function isJob51DetailApiErrorPayload(payload) {
+  if (!payload || typeof payload !== "object") return false;
+  if (payload.result === "0" || payload.result === 0) return true;
+  return (
+    typeof payload.code === "string" &&
+    payload.code.length > 0 &&
+    payload.code !== "200" &&
+    payload.code !== "0" &&
+    typeof payload.msg === "string" &&
+    payload.msg.length > 0
+  );
+}
+
 async function collectJob51DetailFromBackground(resumeId) {
   try {
     const response = await chrome.runtime.sendMessage({
@@ -2130,7 +2143,7 @@ async function fetch51JobResumeDetail(resumeId) {
     resumeId: normalizedResumeId,
     userid: normalizedResumeId,
     lan: "c",
-    timestamp: Date.now(),
+    timestamp: Math.floor(Date.now() / 1000),
     ...(authContext?.property ? { property: authContext.property } : {}),
     ...(authContext?.sign ? { sign: authContext.sign } : {}),
   };
@@ -2172,7 +2185,14 @@ async function fetch51JobResumeDetail(resumeId) {
         if (isJob51RateLimitedPayload(payload)) {
           return { payload: null, rateLimited: true };
         }
-        if (payload) {
+        if (isJob51DetailApiErrorPayload(payload)) {
+          console.warn(
+            "🎯 [Auto Sync] Job51 detail API error, falling back to background:",
+            normalizedResumeId,
+            payload?.code,
+            payload?.msg,
+          );
+        } else if (payload) {
           return { payload, rateLimited: false };
         }
       }

--- a/apps/browser-extension/src/lib/__tests__/job5156-detail-utils.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/job5156-detail-utils.test.ts
@@ -1,0 +1,69 @@
+import { JSDOM } from 'jsdom'
+import { describe, expect, it } from 'vitest'
+
+import {
+  collectJob5156SectionItemsByHeading,
+  isMeaningfulJob5156WorkHistoryEntry,
+} from '../job5156-detail-utils'
+
+describe('job5156-detail-utils', () => {
+  it('prefers structured work-history containers over generic nested items', () => {
+    const dom = new JSDOM(`
+      <main>
+        <section class="resume-view-layout">
+          <h2 class="resume-view-layout__title">工作经历</h2>
+          <div class="resume-work__info">
+            <div class="resume-work__row-1">
+              <span class="time-diff">2019-04~至今（6年11月）</span>
+              <div class="flex flex-1">
+                <span class="pointer">东莞宝力机械</span>
+                <span>销售经理</span>
+              </div>
+            </div>
+          </div>
+          <div class="item">(2年11月)</div>
+          <li>(11月)</li>
+          <div class="resume-education__info">2020~2023广东南方职业学院商务英语本科</div>
+        </section>
+      </main>
+    `)
+
+    const workItems = collectJob5156SectionItemsByHeading(
+      dom.window.document.body,
+      /工作经历|工作经验|工作履历/u,
+      ['.resume-work__info', '.work-item', '.work-block', '[class*="work-item"]', '[class*="work-block"]'],
+      [':scope > li', ':scope > .item', ':scope > [class*="item"]'],
+    )
+
+    expect(workItems).toHaveLength(1)
+    expect(
+      workItems[0] && typeof workItems[0] === 'object' && 'className' in workItems[0]
+        ? String(workItems[0].className)
+        : '',
+    ).toContain('resume-work__info')
+  })
+
+  it('rejects placeholder-only and education-like work-history candidates', () => {
+    expect(isMeaningfulJob5156WorkHistoryEntry({ raw: '(2年11月)' })).toBe(false)
+    expect(isMeaningfulJob5156WorkHistoryEntry({ raw: '(11月)' })).toBe(false)
+    expect(
+      isMeaningfulJob5156WorkHistoryEntry({
+        raw: '2020~2023广东南方职业学院商务英语本科',
+        startDate: '2020',
+        endDate: '2023',
+      }),
+    ).toBe(false)
+  })
+
+  it('keeps structured work-history candidates with company, title, and date evidence', () => {
+    expect(
+      isMeaningfulJob5156WorkHistoryEntry({
+        raw: '2019-04~至今(6年11月) 东莞宝力机械 销售经理',
+        companyName: '东莞宝力机械',
+        jobTitle: '销售经理',
+        startDate: '2019-04',
+        endDate: '至今',
+      }),
+    ).toBe(true)
+  })
+})

--- a/apps/browser-extension/src/lib/job5156-detail-utils.ts
+++ b/apps/browser-extension/src/lib/job5156-detail-utils.ts
@@ -1,0 +1,162 @@
+// @ts-nocheck
+import { normalizeResumeText } from './resume-text-utils'
+
+const SECTION_SELECTORS = [
+  'section',
+  '.section',
+  '.resume-section',
+  '.module',
+  '.card',
+  '.block',
+  '.resume-view-layout',
+  '[class*="section"]',
+  '[class*="module"]',
+  '[class*="block"]',
+]
+
+const HEADING_SELECTOR = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  '.title',
+  '.section-title',
+  '.module-title',
+  '.resume-view-layout__title',
+  '[class*="title"]',
+].join(', ')
+
+const WORK_HISTORY_PLACEHOLDER_PATTERN = /^[（(]?\d+(?:年(?:\d+个?月?)?|个月?|月)?[）)]?$/u
+const EDUCATION_LIKE_PATTERN = /(本科|大专|中专|硕士|博士|研究生|MBA|EMBA|学校|学院|大学|学历)/u
+const WORK_LIKE_PATTERN = /(公司|经理|工程师|销售|主管|总监|主任|技术|客户|负责|部门|离职原因|CNC|数控|机械|设备|项目)/iu
+const DATE_LIKE_PATTERN = /(?:19|20)\d{2}(?:[-./年]\d{1,2})?|至今|目前|present|current/iu
+
+/**
+ * @param {unknown} value
+ * @returns {value is Element}
+ */
+function isElement(value) {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && 'nodeType' in value
+      && value.nodeType === 1
+      && 'querySelectorAll' in value
+  )
+}
+
+/**
+ * @param {Element} root
+ * @param {string} selector
+ * @returns {Element[]}
+ */
+function queryAllSafe(root, selector) {
+  try {
+    return Array.from(root.querySelectorAll(selector)).filter(isElement)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * @param {unknown} root
+ * @param {RegExp} headingPattern
+ * @param {string[]} primarySelectors
+ * @param {string[]} [fallbackSelectors]
+ * @returns {Element[]}
+ */
+export function collectJob5156SectionItemsByHeading(
+  root,
+  headingPattern,
+  primarySelectors,
+  fallbackSelectors = [],
+) {
+  if (!isElement(root)) {
+    return []
+  }
+
+  const sections = queryAllSafe(root, SECTION_SELECTORS.join(', '))
+  for (const section of sections) {
+    const currentSection = /** @type {Element} */ (section)
+    const heading = normalizeResumeText(currentSection.querySelector(HEADING_SELECTOR)?.textContent || '')
+    if (!heading || !headingPattern.test(heading)) {
+      continue
+    }
+
+    for (const selector of primarySelectors) {
+      const matches = queryAllSafe(currentSection, selector)
+      if (matches.length > 0) {
+        return matches
+      }
+    }
+
+    for (const selector of fallbackSelectors) {
+      const matches = queryAllSafe(currentSection, selector)
+      if (matches.length > 0) {
+        return matches
+      }
+    }
+
+    break
+  }
+
+  return []
+}
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isPlaceholderDurationText(value) {
+  const normalized = value.replace(/[\s·]+/g, '')
+  return WORK_HISTORY_PLACEHOLDER_PATTERN.test(normalized)
+}
+
+/**
+ * @param {{
+ *   raw?: string
+ *   companyName?: string
+ *   jobTitle?: string
+ *   description?: string
+ *   startDate?: string
+ *   endDate?: string
+ * } | null | undefined} entry
+ * @returns {boolean}
+ */
+export function isMeaningfulJob5156WorkHistoryEntry(entry) {
+  if (!entry) {
+    return false
+  }
+
+  const companyName = normalizeResumeText(entry.companyName || '')
+  const jobTitle = normalizeResumeText(entry.jobTitle || '')
+  const description = normalizeResumeText(entry.description || '')
+  const startDate = normalizeResumeText(entry.startDate || '')
+  const endDate = normalizeResumeText(entry.endDate || '')
+  const raw = normalizeResumeText(entry.raw || '')
+  const text = [raw, description].filter(Boolean).join(' ')
+  const hasIdentity = Boolean(companyName || jobTitle || description)
+  const hasDate = DATE_LIKE_PATTERN.test(`${startDate} ${endDate}`.trim())
+
+  if (hasIdentity) {
+    return true
+  }
+
+  if (!text) {
+    return false
+  }
+
+  if (isPlaceholderDurationText(text)) {
+    return false
+  }
+
+  if (EDUCATION_LIKE_PATTERN.test(text) && !WORK_LIKE_PATTERN.test(text) && !companyName && !jobTitle) {
+    return false
+  }
+
+  if (hasDate && text.length > 0) {
+    return true
+  }
+
+  return true
+}

--- a/apps/web/src/components/ResumeDetail.test.tsx
+++ b/apps/web/src/components/ResumeDetail.test.tsx
@@ -71,6 +71,46 @@ describe('ResumeDetail latest work history', () => {
     expect(screen.queryByText('Oldest Co · Old Role')).not.toBeInTheDocument()
   })
 
+  it('filters placeholder-only and education-like rows from work history', () => {
+    render(
+      <ResumeDetail
+        open
+        onOpenChange={vi.fn()}
+        resume={{
+          name: 'Alice',
+          profileUrl: 'https://example.com/resume-1',
+          activityStatus: 'Active',
+          age: '30',
+          experience: '5 years',
+          education: 'Bachelor',
+          location: 'Dongguan',
+          selfIntro: 'Test intro',
+          jobIntention: 'Sales Engineer',
+          expectedSalary: '10k-20k',
+          workHistory: [
+            { raw: '(2年11月)' },
+            { raw: '(11月)' },
+            { raw: '2020~2023广东南方职业学院商务英语本科' },
+            {
+              raw: '2019-04 ~ 至今 (6年11月) 东莞宝力机械 销售经理 负责机床销售与客户维护',
+              companyName: '东莞宝力机械',
+              jobTitle: '销售经理',
+              startDate: '2019-04',
+              endDate: '至今',
+              description: '负责机床销售与客户维护',
+            },
+          ],
+          extractedAt: '2026-03-13T00:00:00.000Z',
+        }}
+      />,
+    )
+
+    expect(screen.getByText('东莞宝力机械 · 销售经理')).toBeInTheDocument()
+    expect(screen.queryByText('(2年11月)')).not.toBeInTheDocument()
+    expect(screen.queryByText('(11月)')).not.toBeInTheDocument()
+    expect(screen.queryByText('2020~2023广东南方职业学院商务英语本科')).not.toBeInTheDocument()
+  })
+
   it('keeps excluded presentation fields hidden when expanded', async () => {
     const user = userEvent.setup()
 

--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -49,6 +49,40 @@ function matchesStructuredWorkEntry(
   return Boolean(companyMatches || titleMatches)
 }
 
+function shouldRenderResumeDetailWorkHistoryEntry(
+  entry: ReturnType<typeof normalizeWorkHistoryEntry>,
+): boolean {
+  if (!entry) {
+    return false
+  }
+
+  if (entry.companyName || entry.jobTitle || entry.description) {
+    return true
+  }
+
+  const raw = entry.raw?.trim() ?? ''
+  if (!raw) {
+    return false
+  }
+
+  const normalizedRaw = raw.replace(/[\s·]+/g, '')
+  if (/^[（(]?\d+(?:年(?:\d+个?月?)?|个月?|月)?[）)]?$/u.test(normalizedRaw)) {
+    return false
+  }
+
+  if (/(本科|大专|中专|硕士|博士|研究生|MBA|EMBA|学校|学院|大学|学历)/u.test(raw)
+    && !/(公司|经理|工程师|销售|主管|总监|主任|技术|客户|负责|部门|离职原因|CNC|数控|机械|设备|项目)/iu.test(raw)) {
+    return false
+  }
+
+  const dateRange = buildWorkHistoryDateRange(entry.startDate, entry.endDate)
+  if (dateRange) {
+    return true
+  }
+
+  return true
+}
+
 export function ResumeDetail({
   resume,
   matchResult,
@@ -71,6 +105,8 @@ export function ResumeDetail({
   const workHistory = useMemo(() => {
     if (!presentationResume?.workHistory?.length) return []
     return selectLatestWorkHistory(presentationResume.workHistory)
+      .map((entry) => normalizeWorkHistoryEntry(entry))
+      .filter((entry): entry is NonNullable<typeof entry> => shouldRenderResumeDetailWorkHistoryEntry(entry))
   }, [presentationResume])
   const workHistoryAnnotations = useMemo(() => {
     if (!resume || !hasIngestData(resume)) {


### PR DESCRIPTION
## Summary
- Fixed `fetch51JobResumeDetail` sending `Date.now()` (13-digit milliseconds) instead of `Math.floor(Date.now() / 1000)` (10-digit seconds) as the 51job detail API expects
- Added `isJob51DetailApiErrorPayload` to detect API-level error responses (HTTP 200 with `result: "0"` or non-200 `code`) that were silently treated as valid data
- Error payloads now fall through to `collectJob51DetailFromBackground` instead of being returned as "valid" payloads

## Root Cause
The 51job detail API at `ehirej.51job.com/resumedtl/getresume` returned `{result: "0", code: "Q0011", msg: "timestamp参数错误"}` because of the wrong timestamp format. This HTTP 200 error response bypassed rate-limit detection and was returned as a "valid" payload. `buildJob51DetailResumeFromPayload` found no usable data root, enrichment fell back to search-only data, and the backfill sync sent identical content — so Convex skipped the content update (same hash).

## Test plan
- [x] `make check` passes
- [x] `npm test` — 604 tests pass
- [ ] Manual: load 51job search page, trigger sync, verify console shows enrichment with actual work descriptions
- [ ] Manual: verify Convex stored resumes have `workHistory[].description` populated from detail API