### PR TITLE
Drop stale sign from 51job direct detail fetch

### DIFF
--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -2145,7 +2145,6 @@ async function fetch51JobResumeDetail(resumeId) {
     lan: "c",
     timestamp: Math.floor(Date.now() / 1000),
     ...(authContext?.property ? { property: authContext.property } : {}),
-    ...(authContext?.sign ? { sign: authContext.sign } : {}),
   };
 
   if (authContext?.accesstoken || authContext?.guid || authContext?.property) {


### PR DESCRIPTION
## Summary
- Removed stale `sign` parameter from `fetch51JobResumeDetail` request body
- The 51job API computes `sign` per-request from current timestamp + params; reusing a captured `sign` always fails with `"sign签名不正确"`
- Auth is already provided via `accesstoken`, `guid`, `property` headers and cookies

## Context
Follow-up to #545 (timestamp fix). With the correct timestamp format, the sign mismatch was exposed — every direct detail fetch returned `{result:"0", code:"Q0001", msg:"sign签名不正确"}`. Confirmed via network interception: the page's own `getresume` call computes a unique sign per request, while the extension reused a stale one.

## Test plan
- [x] `npm test` — 604 pass
- [x] `make check` — pass
- [ ] Reload extension, navigate to 51job search with `tr_auto_sync=true`, verify `getresume` calls return `result:"1"` instead of sign errors