### PR TITLE
fix: pass age filters through quick start collect

### DIFF
--- a/apps/api/src/routes/search-profiles.test.ts
+++ b/apps/api/src/routes/search-profiles.test.ts
@@ -187,6 +187,11 @@ describe('search-profiles list route', () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: 'job5156-cn-cnc-sales',
+          filters: expect.objectContaining({
+            minAge: 25,
+            maxAge: 40,
+            minExperience: 2,
+          }),
           sources: expect.arrayContaining([
             expect.objectContaining({
               type: 'job5156',
@@ -201,6 +206,11 @@ describe('search-profiles list route', () => {
         }),
         expect.objectContaining({
           id: '51job-cn-cnc-sales',
+          filters: expect.objectContaining({
+            minAge: 25,
+            maxAge: 40,
+            minExperience: 2,
+          }),
           sources: expect.arrayContaining([
             expect.objectContaining({
               type: '51job',
@@ -215,6 +225,10 @@ describe('search-profiles list route', () => {
         }),
         expect.objectContaining({
           id: 'seek-malaysia-sales',
+          filters: expect.objectContaining({
+            maxAge: 45,
+            minExperience: 2,
+          }),
           sources: expect.arrayContaining([
             expect.objectContaining({
               type: 'seek',

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -44,6 +44,12 @@ const ProfileSummarySchema = z.object({
         label: z.string().optional(),
         description: z.string().optional(),
     }).optional(),
+    filters: z.object({
+        minAge: z.number().optional(),
+        maxAge: z.number().optional(),
+        minExperience: z.number().optional(),
+        maxExperience: z.number().optional(),
+    }).optional(),
 });
 
 const StatsSchema = z.object({
@@ -908,6 +914,14 @@ app.openapi(listRoute, async (c) => {
         keywords: profile.keywords,
         sources: profile.sources,
         quickStart: profile.quickStart,
+        filters: profile.filters
+            ? {
+                minAge: readNumber(profile.filters.minAge),
+                maxAge: readNumber(profile.filters.maxAge),
+                minExperience: readNumber(profile.filters.minExperience),
+                maxExperience: readNumber(profile.filters.maxExperience),
+            }
+            : undefined,
     }));
 
     const summariesById = new Map<string, z.infer<typeof ProfileSummarySchema>>();

--- a/apps/web/src/components/search/SearchHero.test.tsx
+++ b/apps/web/src/components/search/SearchHero.test.tsx
@@ -348,10 +348,33 @@ describe('SearchHero', () => {
       'trends-collect-seek',
       'noopener,noreferrer',
     )
+    const openedUrl = new URL(String(openSpy.mock.calls[0]?.[0]))
+    expect(openedUrl.searchParams.get('tr_min_age')).toBeNull()
+    expect(openedUrl.searchParams.get('tr_max_age')).toBeNull()
     expect(screen.getByRole('link', { name: 'Edit' })).toHaveAttribute(
       'href',
       '/dev/system/profiles',
     )
+  })
+
+  it('includes age filters in collect shortcuts when quick-start constraints are present', async () => {
+    const user = userEvent.setup()
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+    renderSearchHero({
+      quickStarts: [
+        buildQuickStart({
+          minAge: 25,
+          maxAge: 40,
+        }),
+      ],
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Collect' }))
+
+    const openedUrl = new URL(String(openSpy.mock.calls[0]?.[0]))
+    expect(openedUrl.searchParams.get('tr_min_age')).toBe('25')
+    expect(openedUrl.searchParams.get('tr_max_age')).toBe('40')
   })
 
   it('adds 51job detail wait semantics to quick-start collect launches', async () => {

--- a/apps/web/src/components/search/SearchHero.tsx
+++ b/apps/web/src/components/search/SearchHero.tsx
@@ -14,6 +14,8 @@ type SearchHeroQuickStart = {
   location: string
   keywords: string[]
   description?: string
+  minAge?: number
+  maxAge?: number
   profileId?: string
   source?: {
     type: CollectionSourceType
@@ -140,6 +142,8 @@ export function SearchHero({
                       },
                       location: seed.location,
                       keywords: seed.keywords,
+                      minAge: seed.minAge,
+                      maxAge: seed.maxAge,
                     })
                   : null
 

--- a/apps/web/src/hooks/useIndustryKeywords.test.tsx
+++ b/apps/web/src/hooks/useIndustryKeywords.test.tsx
@@ -94,6 +94,11 @@ describe('useIndustryKeywords', () => {
                   rank: 1,
                   label: 'China · Job5156 · CNC 销售',
                 },
+                filters: {
+                  minAge: 25,
+                  maxAge: 40,
+                  minExperience: 2,
+                },
               },
             ],
           },
@@ -126,6 +131,8 @@ describe('useIndustryKeywords', () => {
         id: 'job5156-cn-cnc-sales',
         label: 'China · Job5156 · CNC 销售',
         location: 'China',
+        minAge: 25,
+        maxAge: 40,
         source: {
           type: 'job5156',
         },

--- a/apps/web/src/hooks/useIndustryKeywords.ts
+++ b/apps/web/src/hooks/useIndustryKeywords.ts
@@ -85,6 +85,8 @@ export type SearchProfileQuickStart = {
   location: string;
   keywords: string[];
   description?: string;
+  minAge?: number;
+  maxAge?: number;
   source?: {
     type: CollectionSourceType;
     jobUrl?: string;
@@ -122,6 +124,12 @@ type SearchProfilesResponse = {
       rank?: number;
       label?: string;
       description?: string;
+    };
+    filters?: {
+      minAge?: number;
+      maxAge?: number;
+      minExperience?: number;
+      maxExperience?: number;
     };
   }>;
 };
@@ -341,6 +349,8 @@ export function useIndustryKeywords() {
               location: profile.location,
               keywords: profile.keywords,
               description: profile.quickStart?.description?.trim() || undefined,
+              minAge: typeof profile.filters?.minAge === "number" ? profile.filters.minAge : undefined,
+              maxAge: typeof profile.filters?.maxAge === "number" ? profile.filters.maxAge : undefined,
               source: collectionSource
                 ? {
                     type: collectionSource.type,

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -3801,6 +3801,12 @@ export interface paths {
                                     label?: string;
                                     description?: string;
                                 };
+                                filters?: {
+                                    minAge?: number;
+                                    maxAge?: number;
+                                    minExperience?: number;
+                                    maxExperience?: number;
+                                };
                             }[];
                         };
                     };


### PR DESCRIPTION
## Summary
- expose search profile filters on the list summary response and regenerate the web API types
- carry quick-start age constraints through useIndustryKeywords into SearchHero collect launches
- add route, hook, and SearchHero regression coverage for present and absent age params

## Testing
- bunx vitest run apps/api/src/routes/search-profiles.test.ts
- cd apps/web && bunx vitest run src/hooks/useIndustryKeywords.test.tsx src/components/search/SearchHero.test.tsx
- bun run check
- make check-node
- make check