### PR TITLE
fix(convex): add paginated backfillAge migration for large dataset support

### DIFF
--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -604,6 +604,40 @@ export const backfillAge = mutation({
     },
 });
 
+export const backfillAgePaginated = mutation({
+    args: {
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const resumes = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.batchSize),
+            });
+        let updated = 0;
+
+        for (const resume of resumes.page) {
+            const parsedAge = parseAgeFromContent(resume.content);
+            if (parsedAge === null || resume.age === parsedAge) {
+                continue;
+            }
+
+            await ctx.db.patch(resume._id, { age: parsedAge });
+            updated += 1;
+        }
+
+        return {
+            scannedResumes: resumes.page.length,
+            updatedResumes: updated,
+            hasMore: !resumes.isDone,
+            cursor: resumes.isDone ? null : resumes.continueCursor,
+        };
+    },
+});
+
 export const backfillWorkspaceSlugs = mutation({
     args: {},
     handler: async (ctx) => {


### PR DESCRIPTION
## Summary
- add a paginated `backfillAgePaginated` migration for large resume datasets
- keep the existing `backfillAge` mutation unchanged for smaller datasets
- preserve the existing batch-size and cursor conventions used by other Convex migrations

## Test Plan
- make check
- curl -s -X POST "http://127.0.0.1:3000/api/resumes/backup" -H "Content-Type: application/json" -H "X-Workspace-Slug: dev" -d {} | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["metadata"]["totalResumes"])'
- curl "http://127.0.0.1:3000/api/resumes?source=convex&limit=10"