### PR TITLE
fix(web): honor analysis top-n in search dispatch

### DIFF
--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -36,7 +36,11 @@ import {
   type UrlSearchState,
 } from '@/hooks/useUrlSearchState'
 import { rawApiClient } from '@/lib/api-helpers'
-import { getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey } from '@/lib/analysis-utils'
+import {
+  getCurrentResumeAiPromptVersion,
+  resolveAnalysisTopN,
+  resolveResumeAnalysisSourceKey,
+} from '@/lib/analysis-utils'
 import { submitResumeExportDownload, type ResumeExportRequestBody } from '@/lib/resume-export'
 import { isResumeHomeResetState } from '@/lib/resume-home-navigation'
 import type { ResumeSearchShareState, SearchHistoryItem } from '@/hooks/useSession'
@@ -1425,7 +1429,7 @@ export function useResumeListState(loadSearchHistory = false) {
             sourceKey: resolveAnalysisSourceKeyForResume(resume, sessionCollectionSource),
           })
         )
-        .slice(0, Number(import.meta.env.VITE_ANALYSIS_TOP_N) || 10)
+        .slice(0, resolveAnalysisTopN(import.meta.env.VITE_ANALYSIS_TOP_N))
 
       if (candidatesToAnalyze.length === 0) {
         toast.info(t('aiTasks.noNewCandidates', 'No new candidates to analyze among top matches.'))

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -215,6 +215,7 @@ describe('useResumeSearchState', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers()
+    vi.unstubAllEnvs()
     localStorage.clear()
 
     workspaceMock.slug = 'dev'
@@ -287,6 +288,10 @@ describe('useResumeSearchState', () => {
     }))
     exportDownloadMock.mockResolvedValue(undefined)
     dispatchAnalysisMutationMock.mockResolvedValue('analysis-task-1')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   afterEach(() => {
@@ -717,6 +722,8 @@ describe('useResumeSearchState', () => {
   })
 
   it('auto-analyzes loaded results after an explicit search trigger', async () => {
+    vi.stubEnv('VITE_ANALYSIS_TOP_N', '10')
+
     Object.assign(parsedStateMock, createParsedState({
       query: 'machine tools',
       keywords: ['machine tools'],
@@ -756,10 +763,54 @@ describe('useResumeSearchState', () => {
       keywords: ['machine', 'tools'],
       location: 'China',
       promptVersion: CURRENT_PROMPT_VERSION,
-      resumeIds: Array.from({ length: 12 }, (_, index) => `resume-${index + 1}`),
+      resumeIds: Array.from({ length: 10 }, (_, index) => `resume-${index + 1}`),
     })
     expect(toastSuccessMock).toHaveBeenCalledWith(
-      'Analyzing loaded 12 resumes...',
+      'Analyzing loaded 10 resumes...',
+    )
+  })
+
+  it('caps auto-analysis dispatch by VITE_ANALYSIS_TOP_N', async () => {
+    vi.stubEnv('VITE_ANALYSIS_TOP_N', '10')
+
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'machine tools',
+      keywords: ['machine tools'],
+      location: 'China',
+    }))
+
+    resumesMock.push(
+      ...Array.from({ length: 12 }, (_, index) =>
+        createResume(index + 1, {
+          primaryRuleScore: 95 - index,
+        }),
+      ),
+    )
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    await act(async () => {
+      result.current.submitSearch('machine tools')
+      useUrlSearchStateMock.mockReturnValue({
+        parsedState: createParsedState({
+          query: 'machine tools',
+          keywords: ['machine', 'tools'],
+          location: 'China',
+        }),
+        syncToUrl: syncToUrlMock,
+      })
+      await Promise.resolve()
+    })
+
+    expect(dispatchAnalysisMutationMock).toHaveBeenCalledTimes(1)
+    expect(dispatchAnalysisMutationMock).toHaveBeenCalledWith({
+      keywords: ['machine', 'tools'],
+      location: 'China',
+      promptVersion: CURRENT_PROMPT_VERSION,
+      resumeIds: Array.from({ length: 10 }, (_, index) => `resume-${index + 1}`),
+    })
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      'Analyzing loaded 10 resumes...',
     )
   })
 
@@ -850,6 +901,8 @@ describe('useResumeSearchState', () => {
   })
 
   it('re-enables AI mode and auto-analyzes when a search is submitted from original mode', async () => {
+    vi.stubEnv('VITE_ANALYSIS_TOP_N', '10')
+
     Object.assign(parsedStateMock, createParsedState({
       query: 'machine tools',
       keywords: ['machine tools'],
@@ -891,7 +944,7 @@ describe('useResumeSearchState', () => {
       keywords: ['machine', 'tools'],
       location: 'China',
       promptVersion: CURRENT_PROMPT_VERSION,
-      resumeIds: Array.from({ length: 12 }, (_, index) => `resume-${index + 1}`),
+      resumeIds: Array.from({ length: 10 }, (_, index) => `resume-${index + 1}`),
     })
     expect(result.current.disableAnalyzeResults).toBe(false)
   })

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -39,6 +39,7 @@ import {
 } from '@/lib/resume-scoring'
 import {
   getCurrentResumeAiPromptVersion,
+  resolveAnalysisTopN,
   resolveResumeAnalysisSourceKey,
 } from '@/lib/analysis-utils'
 import { resolveCollectionSource } from '@/lib/search-profile-sources'
@@ -783,7 +784,10 @@ export function useResumeSearchState() {
     [results],
   )
   const analysisCandidateResumeIds = useMemo(
-    () => analysisCandidates.map((item) => item.resume.resumeId),
+    () =>
+      analysisCandidates
+        .slice(0, resolveAnalysisTopN(import.meta.env.VITE_ANALYSIS_TOP_N))
+        .map((item) => item.resume.resumeId),
     [analysisCandidates],
   )
   const analysisCandidateSignature = useMemo(

--- a/apps/web/src/lib/analysis-utils.test.ts
+++ b/apps/web/src/lib/analysis-utils.test.ts
@@ -5,6 +5,7 @@ import {
   buildResumeAnalysisStorageKey,
   deriveAnalysisLookupKey,
   isResumeAnalysisKeyForJobDescription,
+  resolveAnalysisTopN,
   resolveResumeAnalysisSourceKey,
 } from './analysis-utils'
 
@@ -55,6 +56,22 @@ describe('deriveAnalysisLookupKey', () => {
 
   it('returns empty key when no context is provided', () => {
     expect(deriveAnalysisLookupKey(undefined, [])).toBe('')
+  })
+})
+
+describe('resolveAnalysisTopN', () => {
+  it('uses the default when the env value is missing or invalid', () => {
+    expect(resolveAnalysisTopN(undefined)).toBe(10)
+    expect(resolveAnalysisTopN('')).toBe(10)
+    expect(resolveAnalysisTopN('abc')).toBe(10)
+    expect(resolveAnalysisTopN(0)).toBe(10)
+  })
+
+  it('accepts positive values and clamps oversized limits', () => {
+    expect(resolveAnalysisTopN('10')).toBe(10)
+    expect(resolveAnalysisTopN('200')).toBe(200)
+    expect(resolveAnalysisTopN(12.9)).toBe(12)
+    expect(resolveAnalysisTopN('999')).toBe(500)
   })
 })
 

--- a/apps/web/src/lib/analysis-utils.ts
+++ b/apps/web/src/lib/analysis-utils.ts
@@ -7,3 +7,21 @@ export {
   isResumeAnalysisKeyForJobDescription,
   resolveResumeAnalysisSourceKey,
 } from '@trends/shared'
+
+const DEFAULT_ANALYSIS_TOP_N = 10
+const MAX_ANALYSIS_TOP_N = 500
+
+export function resolveAnalysisTopN(envValue: unknown): number {
+  const parsed =
+    typeof envValue === 'number'
+      ? envValue
+      : typeof envValue === 'string'
+        ? Number(envValue.trim())
+        : Number.NaN
+
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_ANALYSIS_TOP_N
+  }
+
+  return Math.min(Math.floor(parsed), MAX_ANALYSIS_TOP_N)
+}


### PR DESCRIPTION
## Summary
- add a shared frontend helper to parse and clamp VITE_ANALYSIS_TOP_N
- apply the same top-N cap to both search-result analysis dispatch and resume-list analysis dispatch
- add regression coverage for the env-controlled cap and the parsing helper

## Verification
- make check
- npm --workspace @trends/web test -- useResumeListState.test.tsx useResumeSearchState.test.tsx analysis-utils.test.ts
