### PR TITLE
refactor: inline buildTagEnvelope into buildTaggingEnvelope

### DIFF
--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -58,16 +58,6 @@ export interface IngestResult {
   skillsVersion: number;
 }
 
-export type TagEnvelopeSource = "rule" | "ai";
-
-export interface TagEnvelopeEntry {
-  tag: string;
-  source: TagEnvelopeSource;
-  confidence: number;
-  evidence: string[];
-  version: number;
-}
-
 export type TaggingProvenanceStage =
   | "industry_taxonomy"
   | "synonym_expansion"
@@ -78,7 +68,7 @@ export type TaggingProvenanceStage =
 
 export interface TaggingEnvelopeEntry {
   tag: string;
-  source: TagEnvelopeSource;
+  source: "rule" | "ai";
   confidence: number;
   version: number;
   provenance: {
@@ -488,7 +478,7 @@ export class IngestComputeService {
 
     // 6. Get skills version
     const skillsVersion = this.skillsKnowledgeService.getVersion();
-    const tagEnvelope = this.buildTagEnvelope(
+    const taggingEnvelope = this.buildTaggingEnvelope(
       industryTags,
       synonymHits,
       companyHits,
@@ -496,8 +486,8 @@ export class IngestComputeService {
       roleSignals,
       experienceLevel,
       skillsVersion,
+      computedAt,
     );
-    const taggingEnvelope = this.buildTaggingEnvelope(tagEnvelope, computedAt);
 
     return {
       resumeId,
@@ -764,12 +754,13 @@ export class IngestComputeService {
     return foundMatch;
   }
 
-  private upsertTagEnvelopeEntry(
-    entryMap: Map<string, TagEnvelopeEntry>,
+  private upsertTaggingEnvelopeEntry(
+    entryMap: Map<string, TaggingEnvelopeEntry>,
     tag: string,
     confidence: number,
     evidence: string[],
     version: number,
+    stage: TaggingProvenanceStage,
   ): void {
     const normalizedTag = tag.trim().toLowerCase();
     if (!normalizedTag) {
@@ -791,8 +782,12 @@ export class IngestComputeService {
         tag: normalizedTag,
         source: "rule",
         confidence: boundedConfidence,
-        evidence: normalizedEvidence,
         version,
+        provenance: {
+          stage,
+          generatedBy: "ingest-compute-service",
+          evidence: normalizedEvidence.length > 0 ? normalizedEvidence : [`tag:${normalizedTag}`],
+        },
       });
       return;
     }
@@ -804,13 +799,13 @@ export class IngestComputeService {
     existing.version = Math.max(existing.version, version);
     existing.source = "rule";
     for (const hint of normalizedEvidence) {
-      if (!existing.evidence.includes(hint)) {
-        existing.evidence.push(hint);
+      if (!existing.provenance.evidence.includes(hint)) {
+        existing.provenance.evidence.push(hint);
       }
     }
   }
 
-  private buildTagEnvelope(
+  private buildTaggingEnvelope(
     industryTags: string[],
     synonymHits: string[],
     companyHits: string[],
@@ -818,26 +813,29 @@ export class IngestComputeService {
     roleSignals: RoleSignalSummary[],
     experienceLevel: string,
     skillsVersion: number,
-  ): TagEnvelopeEntry[] {
-    const envelope = new Map<string, TagEnvelopeEntry>();
+    generatedAt: number,
+  ): TaggingEnvelope {
+    const envelope = new Map<string, TaggingEnvelopeEntry>();
 
     for (const tag of industryTags) {
-      this.upsertTagEnvelopeEntry(
+      this.upsertTaggingEnvelopeEntry(
         envelope,
         `industry:${tag}`,
         85,
         [`industryTag:${tag}`],
         skillsVersion,
+        "industry_taxonomy",
       );
     }
 
     for (const hit of synonymHits) {
-      this.upsertTagEnvelopeEntry(
+      this.upsertTaggingEnvelopeEntry(
         envelope,
         `synonym:${hit}`,
         70,
         [`synonymHit:${hit}`],
         skillsVersion,
+        "synonym_expansion",
       );
     }
 
@@ -847,12 +845,13 @@ export class IngestComputeService {
         .slice(0, 6)
         .flatMap((hit) => [`brandSource:${hit.source}`, `brandContext:${hit.context}`]);
 
-      this.upsertTagEnvelopeEntry(
+      this.upsertTaggingEnvelopeEntry(
         envelope,
         `company:${company}`,
         80,
         evidence.length > 0 ? evidence : [`companyHit:${company}`],
         skillsVersion,
+        "company_pattern_match",
       );
     }
 
@@ -878,12 +877,13 @@ export class IngestComputeService {
         ...Array.from(contexts).map((ctx) => `brandContext:${ctx}`),
       ];
 
-      this.upsertTagEnvelopeEntry(
+      this.upsertTaggingEnvelopeEntry(
         envelope,
         `brand:${brand}`,
         65,
         evidence,
         skillsVersion,
+        "company_pattern_match",
       );
     }
 
@@ -898,26 +898,28 @@ export class IngestComputeService {
         ...signal.matchedSignals.slice(0, 6).map((matched) => `signal:${matched}`),
       ];
 
-      this.upsertTagEnvelopeEntry(
+      this.upsertTaggingEnvelopeEntry(
         envelope,
         `role:${signal.type}`,
         confidence,
         evidence,
         skillsVersion,
+        "role_signal_aggregation",
       );
     }
 
     if (experienceLevel && experienceLevel !== "unknown") {
-      this.upsertTagEnvelopeEntry(
+      this.upsertTaggingEnvelopeEntry(
         envelope,
         `experience:${experienceLevel}`,
         75,
         [`experienceLevel:${experienceLevel}`],
         skillsVersion,
+        "experience_signal_detection",
       );
     }
 
-    return Array.from(envelope.values())
+    const entries = Array.from(envelope.values())
       .sort((left, right) => {
         if (right.confidence !== left.confidence) {
           return right.confidence - left.confidence;
@@ -925,26 +927,6 @@ export class IngestComputeService {
         return left.tag.localeCompare(right.tag);
       })
       .slice(0, 120);
-  }
-
-  private buildTaggingEnvelope(
-    tagEnvelope: TagEnvelopeEntry[],
-    generatedAt: number,
-  ): TaggingEnvelope {
-    const entries = tagEnvelope.map((entry) => {
-      const evidence = Array.from(new Set(entry.evidence.map((item) => item.trim()).filter((item) => item.length > 0)));
-      return {
-        tag: entry.tag,
-        source: entry.source,
-        confidence: entry.confidence,
-        version: entry.version,
-        provenance: {
-          stage: inferTaggingStage(entry.tag),
-          generatedBy: "ingest-compute-service" as const,
-          evidence: evidence.length > 0 ? evidence : [`tag:${entry.tag}`],
-        },
-      };
-    });
 
     return {
       schemaVersion: 1,

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -23,16 +23,26 @@ import { resolveResumeScanBatchSize } from "./resumes";
 
 const SEEK_HOST_SUFFIX = ".employer.seek.com";
 const SEEK_RECOMMENDED_PATH = "/candidates/recommended";
+const JOB51_EHIRE_HOST = "ehire.51job.com";
 
-function collectionSourceFromCollectUrl(collectUrl: string): { type: "seek"; exactUrl: string } | undefined {
+type CollectionSourceValue =
+    | { type: "seek"; exactUrl: string }
+    | { type: "51job"; exactUrl: string }
+    | { type: "job5156" };
+
+function collectionSourceFromCollectUrl(collectUrl: string): CollectionSourceValue | undefined {
     try {
         const url = new URL(collectUrl);
-        if (
-            url.protocol === "https:" &&
-            url.hostname.toLowerCase().endsWith(SEEK_HOST_SUFFIX) &&
-            url.pathname.replace(/\/+$/, "") === SEEK_RECOMMENDED_PATH
-        ) {
+        if (url.protocol !== "https:") return undefined;
+        const hostname = url.hostname.toLowerCase();
+        if (hostname.endsWith(SEEK_HOST_SUFFIX) && url.pathname.replace(/\/+$/, "") === SEEK_RECOMMENDED_PATH) {
             return { type: "seek", exactUrl: url.toString() };
+        }
+        if (hostname === JOB51_EHIRE_HOST) {
+            return { type: "51job", exactUrl: url.toString() };
+        }
+        if (hostname === JOB5156_HOST) {
+            return { type: "job5156" };
         }
     } catch {
         // Not a valid URL


### PR DESCRIPTION
## Summary
- Remove the intermediate `TagEnvelopeEntry[]` / `buildTagEnvelope` step and build `TaggingEnvelope` directly with provenance metadata
- Each tag category now gets an explicit provenance stage (`industry_taxonomy`, `synonym_expansion`, `company_pattern_match`, `role_signal_aggregation`, `experience_signal_detection`)
- Extend `collectionSourceFromCollectUrl` in migrations to handle 51job (`ehire.51job.com`) and job5156 (`hr.job5156.com`) URLs

## Test plan
- [x] `make check` passes (typecheck, lint, policy sync, skill validation)
- [ ] Verify ingest-compute pipeline still produces valid taggingEnvelope output
- [ ] Verify `backfillCollectionSource` migration handles all three source types