### PR TITLE
fix: preserve SEEK exactUrl across source switches and remove collectUrl legacy

### DIFF
--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -50,7 +50,6 @@ const CustomKeywordWorkflowSeedSchema = z.object({
   location: z.string(),
   keywords: z.array(z.string()),
   collectionSource: WorkflowSeedCollectionSourceSchema,
-  collectUrl: z.string().optional(),
   visible: z.boolean().optional(),
   source: z.enum(["system", "workspace"]).optional(),
 });

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -85,7 +85,6 @@ describe("session routes", () => {
             type: "seek",
             exactUrl: "https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1",
           },
-          collectUrl: "https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1",
           filters: {
             minExperience: 3,
             minAge: 28,

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -39,7 +39,6 @@ const SearchSessionStateSchema = z.object({
   selectedCompanies: z.array(z.string()).optional().openapi({ example: ["fanuc"] }),
   selectedExperienceLevel: z.enum(["senior", "mid", "junior"]).optional().openapi({ example: "mid" }),
   collectionSource: SearchSessionCollectionSourceSchema.optional(),
-  collectUrl: z.string().optional().openapi({ example: "https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1" }),
   filters: SessionFiltersSchema.optional(),
   referenceNote: z.string().optional().openapi({ example: "Priority shortlist for HR sync" }),
 });

--- a/apps/api/src/services/custom-keyword-service.ts
+++ b/apps/api/src/services/custom-keyword-service.ts
@@ -44,7 +44,6 @@ export interface CustomKeywordWorkflowSeed {
         type: WorkflowSeedCollectionSourceType;
         exactUrl?: string;
     };
-    collectUrl?: string;
     visible?: boolean;
     source?: ConfigSourceOrigin;
 }
@@ -198,11 +197,12 @@ function parseWorkflowSeed(value: unknown): CustomKeywordWorkflowSeed | null {
         collectionSource,
     };
 
-    const collectUrl = typeof record.collectUrl === "string" && record.collectUrl.trim()
-        ? record.collectUrl.trim()
+    // Legacy: if record has collectUrl and collectionSource is seek without exactUrl, merge it
+    const legacyCollectUrl = typeof (record as Record<string, unknown>).collectUrl === "string" && ((record as Record<string, unknown>).collectUrl as string).trim()
+        ? ((record as Record<string, unknown>).collectUrl as string).trim()
         : undefined;
-    if (collectUrl) {
-        workflowSeed.collectUrl = collectUrl;
+    if (legacyCollectUrl && collectionSource.type === "seek" && !collectionSource.exactUrl) {
+        workflowSeed.collectionSource = { ...collectionSource, exactUrl: legacyCollectUrl };
     }
 
     const visible = parseVisible(record.visible);

--- a/apps/api/src/services/session-manager.ts
+++ b/apps/api/src/services/session-manager.ts
@@ -52,7 +52,6 @@ export type SearchSessionState = {
   selectedCompanies?: string[];
   selectedExperienceLevel?: "senior" | "mid" | "junior";
   collectionSource?: SearchSessionCollectionSource;
-  collectUrl?: string;
   filters?: ResumeFilters;
   referenceNote?: string;
 };

--- a/apps/api/src/services/workspace-config-service.ts
+++ b/apps/api/src/services/workspace-config-service.ts
@@ -335,9 +335,10 @@ function parseWorkflowSeed(value: unknown): CustomKeywordWorkflowSeed | null {
     collectionSource,
   };
 
-  const collectUrl = readString(value.collectUrl) ?? undefined;
-  if (collectUrl) {
-    workflowSeed.collectUrl = collectUrl;
+  // Legacy: if value has collectUrl and collectionSource is seek without exactUrl, merge it
+  const legacyCollectUrl = readString((value as Record<string, unknown>).collectUrl) ?? undefined;
+  if (legacyCollectUrl && collectionSource.type === "seek" && !collectionSource.exactUrl) {
+    workflowSeed.collectionSource = { ...collectionSource, exactUrl: legacyCollectUrl };
   }
 
   const visible = parseVisible(value.visible);

--- a/apps/web/src/components/CollectResumesButton.test.tsx
+++ b/apps/web/src/components/CollectResumesButton.test.tsx
@@ -28,7 +28,6 @@ function Harness({
       keywords={['Sales Engineer', 'Sales Manager']}
       collectionSource={collectionSource}
       onCollectionSourceChange={setCollectionSource}
-      collectUrl="https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1"
       minAge={28}
       maxAge={40}
     />

--- a/apps/web/src/components/CollectResumesButton.tsx
+++ b/apps/web/src/components/CollectResumesButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ChangeEvent } from 'react'
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Download, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -31,8 +31,6 @@ interface CollectResumesButtonProps {
   keywords: string[]
   collectionSource?: CollectionSource
   onCollectionSourceChange?: (source: CollectionSource) => void
-  /** Preserved seek exactUrl for restoring when switching back to seek source */
-  collectUrl?: string
   collectLimit?: number
   minAge?: number
   maxAge?: number
@@ -61,7 +59,6 @@ export function CollectResumesButton({
   keywords,
   collectionSource,
   onCollectionSourceChange,
-  collectUrl,
   collectLimit,
   minAge,
   maxAge,
@@ -92,16 +89,21 @@ export function CollectResumesButton({
   )
   const selectedSourceType = normalizedSelection.type
   const isJob51Selected = selectedSourceType === SEARCH_PROFILE_SOURCE_TYPES.job51
+  const seekExactUrlRef = useRef<string | undefined>(undefined)
   const seekSource = useMemo(() => {
+    const currentSeekExactUrl = normalizedCollectionSource?.type === SEARCH_PROFILE_SOURCE_TYPES.seek
+      ? normalizedCollectionSource.exactUrl
+      : undefined
+    if (currentSeekExactUrl) {
+      seekExactUrlRef.current = currentSeekExactUrl
+    }
     return resolveCollectionSource(
       {
         type: SEARCH_PROFILE_SOURCE_TYPES.seek,
-        exactUrl: normalizedCollectionSource?.type === SEARCH_PROFILE_SOURCE_TYPES.seek
-          ? normalizedCollectionSource.exactUrl
-          : collectUrl || undefined,
+        exactUrl: currentSeekExactUrl ?? seekExactUrlRef.current,
       },
     )
-  }, [collectUrl, normalizedCollectionSource])
+  }, [normalizedCollectionSource])
 
   const disabled = selectedSourceType === SEARCH_PROFILE_SOURCE_TYPES.seek
     ? !seekSource?.exactUrl && normalizedKeywords.length === 0

--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -415,7 +415,6 @@ describe('QuickStartPanel quick-filter display', () => {
         collectionSource: {
           type: 'job5156',
         },
-        collectUrl: undefined,
       })
     })
   })
@@ -555,9 +554,6 @@ describe('QuickStartPanel quick-filter display', () => {
           && Array.isArray(payload?.keywords)
           && payload.keywords.join(' ') === 'CNC 销售'
           && payload.collectionSource?.type === 'job5156'
-          && typeof payload.collectUrl === 'string'
-          && payload.collectUrl.includes('hr.job5156.com/search')
-          && !payload.collectUrl.includes('location=')
         )
       ).toBe(true)
     })
@@ -670,7 +666,7 @@ describe('QuickStartPanel quick-filter display', () => {
     })
   })
 
-  it('promotes the matched SEEK profile jobUrl into collectUrl before manual apply', async () => {
+  it('promotes the matched SEEK profile jobUrl into collectionSource before manual apply', async () => {
     const onApplyConfig = vi.fn()
 
     postMock.mockResolvedValue({
@@ -723,7 +719,6 @@ describe('QuickStartPanel quick-filter display', () => {
           type: 'seek',
           exactUrl: SEEK_MALAYSIA_JOB_URL,
         },
-        collectUrl: SEEK_MALAYSIA_JOB_URL,
       })
     })
   })
@@ -762,7 +757,6 @@ describe('QuickStartPanel quick-filter display', () => {
           type: 'seek',
           exactUrl: SEEK_MALAYSIA_COLLECT_URL,
         },
-        collectUrl: SEEK_MALAYSIA_COLLECT_URL,
       })
     })
   })

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -72,7 +72,6 @@ interface QuickStartPanelProps {
       requiredKeywords?: string[]
       jobDescriptionId?: string
       collectionSource?: CollectionSource | null
-      collectUrl?: string
       filters?: Partial<ResumeFilters>
     },
     applyDuringUrlHydration?: boolean
@@ -80,7 +79,6 @@ interface QuickStartPanelProps {
   defaultLocation?: string
   defaultKeywords?: string[]
   defaultCollectionSource?: CollectionSource
-  defaultCollectUrl?: string
   jobDescriptionId?: string
   onJobChange?: (value: string) => void
   quickFilters?: {
@@ -307,7 +305,6 @@ export function QuickStartPanel({
   defaultLocation = '广东',
   defaultKeywords = [],
   defaultCollectionSource,
-  defaultCollectUrl,
   jobDescriptionId = '',
   onJobChange,
   quickFilters,
@@ -335,7 +332,6 @@ export function QuickStartPanel({
   const [selectedKeywords, setSelectedKeywords] = useState<string[]>(defaultKeywords)
   const [customKeyword, setCustomKeyword] = useState(formatKeywordInput(defaultKeywords))
   const [collectionSource, setCollectionSource] = useState<CollectionSource | undefined>(defaultCollectionSource)
-  const [collectUrl, setCollectUrl] = useState(defaultCollectUrl)
   const [quickMinRoleYears, setQuickMinRoleYears] = useState(quickFilters?.minRoleYears?.toString() ?? '')
   const [quickMaxAge, setQuickMaxAge] = useState(quickFilters?.maxAge?.toString() ?? '')
   const [activeRoleType, setActiveRoleType] = useState<string | undefined>(quickFilters?.roleFilterType)
@@ -406,10 +402,6 @@ export function QuickStartPanel({
     setSelectedKeywords(defaultKeywords)
     setCustomKeyword(formatKeywordInput(defaultKeywords))
   }, [defaultKeywords])
-
-  useEffect(() => {
-    setCollectUrl(defaultCollectUrl)
-  }, [defaultCollectUrl])
 
   useEffect(() => {
     setCollectionSource(defaultCollectionSource)
@@ -699,21 +691,20 @@ export function QuickStartPanel({
         keywords: normalizedKeywords,
         jobDescriptionId: effectiveJobDescriptionId,
         collectionSource: currentCollectionSource,
-        collectUrl,
       })
     }, 500)
 
     return () => clearTimeout(timer)
-  }, [collectUrl, currentCollectionSource, location, normalizedKeywords, jobDescriptionId, onApplyConfig])
+  }, [currentCollectionSource, location, normalizedKeywords, jobDescriptionId, onApplyConfig])
 
   useEffect(() => {
     if (!matchedProfileCollectUrl) {
       return
     }
-    const normalizedCurrent = collectUrl?.trim()
-    const shouldPromoteMatchedProfileUrl = !normalizedCurrent || normalizedCurrent === generatedCollectUrl
+    const currentExactUrl = currentCollectionSource.type === 'seek' ? currentCollectionSource.exactUrl?.trim() : undefined
+    const shouldPromoteMatchedProfileUrl = !currentExactUrl || currentExactUrl === generatedCollectUrl
 
-    if (!shouldPromoteMatchedProfileUrl || normalizedCurrent === matchedProfileCollectUrl) {
+    if (!shouldPromoteMatchedProfileUrl || currentExactUrl === matchedProfileCollectUrl) {
       return
     }
 
@@ -723,15 +714,13 @@ export function QuickStartPanel({
     }
 
     setCollectionSource(nextCollectionSource)
-    setCollectUrl(matchedProfileCollectUrl)
     onApplyConfig?.({
       location,
       keywords: normalizedKeywords,
       jobDescriptionId: jobDescriptionId || undefined,
       collectionSource: nextCollectionSource,
-      collectUrl: matchedProfileCollectUrl,
     }, true)
-  }, [collectUrl, generatedCollectUrl, jobDescriptionId, location, matchedProfileCollectUrl, normalizedKeywords, onApplyConfig])
+  }, [currentCollectionSource, generatedCollectUrl, jobDescriptionId, location, matchedProfileCollectUrl, normalizedKeywords, onApplyConfig])
 
   useEffect(() => {
     if (normalizedKeywords.length === 0) {
@@ -771,7 +760,6 @@ export function QuickStartPanel({
     setSelectedKeywords(keywords)
     setCustomKeyword(formatKeywordInput(keywords))
     setCollectionSource((current) => stripCollectionSourceExactUrl(current))
-    setCollectUrl(undefined)
   }, [])
 
   const handleLocationToggle = useCallback(
@@ -790,7 +778,6 @@ export function QuickStartPanel({
       }
 
       setCollectionSource((current) => stripCollectionSourceExactUrl(current))
-      setCollectUrl(undefined)
       setLocation(Array.from(nextParts).join(','))
     },
     [location, setLocation, t]
@@ -798,25 +785,27 @@ export function QuickStartPanel({
 
   const handleJobChange = useCallback((value: string) => {
     setCollectionSource((current) => stripCollectionSourceExactUrl(current))
-    setCollectUrl(undefined)
     onJobChange?.(value)
   }, [onJobChange])
 
   const handleApplyWorkflow = useCallback((workflow: QuickStartWorkflow) => {
     const workflowKeywords = normalizeKeywordPhrases(workflow.keywords)
-    const nextCollectUrl = workflow.collectUrl
-      ?? buildCollectionLaunchUrl({
-        source: workflow.collectionSource,
-        location: workflow.location,
-        keywords: workflowKeywords,
-      })
-      ?? undefined
 
     setLocation(workflow.location)
     setSelectedKeywords(workflowKeywords)
     setCustomKeyword(formatKeywordInput(workflowKeywords))
-    setCollectionSource(workflow.collectionSource)
-    setCollectUrl(nextCollectUrl)
+
+    if (workflow.collectionSource.type === SEARCH_PROFILE_SOURCE_TYPES.seek && !workflow.collectionSource.exactUrl) {
+      const builtUrl = buildCollectionLaunchUrl({
+        source: { type: SEARCH_PROFILE_SOURCE_TYPES.seek },
+        location: workflow.location,
+        keywords: workflowKeywords,
+      })
+      setCollectionSource(builtUrl ? { type: SEARCH_PROFILE_SOURCE_TYPES.seek, exactUrl: builtUrl } : workflow.collectionSource)
+    } else {
+      setCollectionSource(workflow.collectionSource)
+    }
+
     onJobChange?.('')
   }, [onJobChange])
 
@@ -825,14 +814,12 @@ export function QuickStartPanel({
     const profileKeywords = normalizeProfileKeywords(profile)
     const nextJobDescriptionId = profile.jobDescription?.trim() || ''
     const nextCollectionSource = getSearchProfileCollectionSource(profile.sources)
-    const nextCollectUrl = getSearchProfileCollectUrl(profile.sources)
     const quickConstraints = getProfileQuickConstraints(profile)
 
     setLocation(profileLocation)
     setSelectedKeywords(profileKeywords)
     setCustomKeyword(formatKeywordInput(profileKeywords))
     setCollectionSource(nextCollectionSource)
-    setCollectUrl(nextCollectUrl)
     setQuickMinRoleYears(
       typeof quickConstraints.minRoleYears === 'number' ? String(quickConstraints.minRoleYears) : ''
     )
@@ -845,7 +832,6 @@ export function QuickStartPanel({
       requiredKeywords: profile.requiredKeywords,
       jobDescriptionId: nextJobDescriptionId || undefined,
       collectionSource: nextCollectionSource,
-      collectUrl: nextCollectUrl,
       filters: mapProfileFiltersToResumeFilters(profile.filters),
     }, true)
     onApplyQuickFilters?.({
@@ -882,7 +868,6 @@ export function QuickStartPanel({
     maxAge?: number
   }) => {
     setCollectionSource((current) => stripCollectionSourceExactUrl(current))
-    setCollectUrl(undefined)
     if (selectedConvexJobDescriptionProfile?.type === 'system') {
       onJobChange?.(newId)
     }
@@ -1021,7 +1006,6 @@ export function QuickStartPanel({
                     onChange={(event) => {
                       const value = event.target.value
                       setCustomKeyword(value)
-                      setCollectUrl(undefined)
                       setSelectedKeywords(parseKeywordQuery(value).keywords)
                     }}
                     placeholder={t('quickStart.customKeywordPlaceholder', '关键词（支持引号 OR，或用逗号分隔短语）...')}
@@ -1043,7 +1027,6 @@ export function QuickStartPanel({
                     type="text"
                     value={location}
                     onChange={(event) => {
-                      setCollectUrl(undefined)
                       setLocation(event.target.value)
                     }}
                     placeholder={t('quickStart.locationTooltip', '位置 (逗号分隔)')}

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -52,7 +52,6 @@ export function ResumeList() {
     sessionLocation,
     sessionKeywords,
     sessionCollectionSource,
-    sessionCollectUrl,
     jobDescriptionId,
     filters,
     reviewedIdsSet,
@@ -269,7 +268,6 @@ export function ResumeList() {
         defaultLocation={sessionLocation}
         defaultKeywords={sessionKeywords}
         defaultCollectionSource={sessionCollectionSource}
-        defaultCollectUrl={sessionCollectUrl}
         quickFilters={{
           minRoleYears: filters.minRoleYears,
           roleFilterType: filters.roleFilterType,
@@ -338,7 +336,6 @@ export function ResumeList() {
                 keywords={sessionKeywords}
                 collectionSource={sessionCollectionSource}
                 onCollectionSourceChange={handleCollectionSourceChange}
-                collectUrl={sessionCollectUrl}
                 minAge={filters.minAge}
                 maxAge={filters.maxAge}
               />

--- a/apps/web/src/components/ShareLinkButton.test.tsx
+++ b/apps/web/src/components/ShareLinkButton.test.tsx
@@ -90,7 +90,6 @@ describe('ShareLinkButton', () => {
             type: 'seek',
             exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
           },
-          collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
           filters: {
             minAge: 28,
           },
@@ -112,7 +111,10 @@ describe('ShareLinkButton', () => {
         searchState: expect.objectContaining({
           location: 'Kuala Lumpur MY',
           keywords: ['Sales Engineer'],
-          collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+          collectionSource: {
+            type: 'seek',
+            exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+          },
         }),
       })
     })
@@ -220,7 +222,6 @@ describe('ShareLinkButton', () => {
             type: 'seek',
             exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
           },
-          collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
           filters: {},
           selectedTags: [],
           selectedCompanies: [],

--- a/apps/web/src/components/ShareLinkButton.tsx
+++ b/apps/web/src/components/ShareLinkButton.tsx
@@ -55,7 +55,7 @@ function shouldPersistShareLink(currentUrl: URL, state: ResumeSearchShareState):
     return true
   }
 
-  if (state.collectionSource || state.collectUrl) {
+  if (state.collectionSource) {
     return true
   }
 

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -118,8 +118,6 @@ vi.mock('@/hooks/useSession', () => ({
     setJobDescriptionId: mockState.setJobDescriptionId,
     collectionSource: mockState.sessionCollectionSource,
     setCollectionSource: mockState.setCollectionSource,
-    collectUrl: mockState.sessionCollectUrl,
-    setCollectUrl: mockState.setCollectUrl,
     apiSessionId: mockState.apiSessionId,
     filters: mockState.filters,
     setFilters: mockState.setFilters,
@@ -997,7 +995,6 @@ describe('useResumeListState role filter regression', () => {
       keywords: [],
       jobDescriptionId: '',
       collectionSource: null,
-      collectUrl: '',
       filters: {},
     })
   })
@@ -1255,7 +1252,6 @@ describe('useResumeListState role filter regression', () => {
       keywords: ['CNC', '销售'],
       jobDescriptionId: 'lathe-sales',
       collectionSource: null,
-      collectUrl: '',
       filters: { minAge: 28 },
     })
     expect(mockState.markSearchHistoryOpened).toHaveBeenCalledWith('history-1')
@@ -1284,7 +1280,6 @@ describe('useResumeListState role filter regression', () => {
               type: 'seek',
               exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
             },
-            collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
             selectedTags: ['STAR'],
             selectedCompanies: ['Acme'],
             selectedExperienceLevel: 'mid',
@@ -1316,7 +1311,6 @@ describe('useResumeListState role filter regression', () => {
         type: 'seek',
         exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
       },
-      collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
       filters: {
         minAge: 28,
       },
@@ -1398,7 +1392,6 @@ describe('useResumeListState role filter regression', () => {
         keywords: ['CNC'],
         jobDescriptionId: undefined,
         collectionSource: null,
-        collectUrl: '',
         filters: {},
       })
     })
@@ -1709,7 +1702,6 @@ describe('useResumeListState role filter regression', () => {
         location: 'Kuala Lumpur MY',
         keywords: ['Sales Engineer', 'Sales Manager'],
         collectionSource: { type: 'seek' },
-        collectUrl: 'https://my.employer.seek.com/candidates/recommended?keyword=%22Sales+Engineer%22+OR+%22Sales+Manager%22&location=Kuala+Lumpur+MY',
       }, true)
     })
 
@@ -1736,7 +1728,6 @@ describe('useResumeListState role filter regression', () => {
         keywords: [],
         jobDescriptionId: '',
         collectionSource: null,
-        collectUrl: '',
         filters: {},
       })
     })

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -516,8 +516,6 @@ export function useResumeListState(loadSearchHistory = false) {
     setJobDescriptionId,
     collectionSource: sessionCollectionSource,
     setCollectionSource: setSessionCollectionSource,
-    collectUrl: sessionCollectUrl,
-    setCollectUrl: setSessionCollectUrl,
     filters,
     setFilters,
     reviewedIdsSet,
@@ -915,7 +913,6 @@ export function useResumeListState(loadSearchHistory = false) {
       keywords: activeParsedUrlState.keywords,
       jobDescriptionId: jobDescriptionIdForExternalState,
       collectionSource: null,
-      collectUrl: '',
       filters: activeParsedUrlState.filters,
     })
     setSelectedTags(activeParsedUrlState.selectedTags)
@@ -996,7 +993,6 @@ export function useResumeListState(loadSearchHistory = false) {
       keywords: activeParsedUrlState.keywords,
       jobDescriptionId: jobDescriptionIdForExternalState,
       collectionSource: null,
-      collectUrl: '',
       filters: activeParsedUrlState.filters,
     })
     setSelectedTags((current) =>
@@ -1095,7 +1091,7 @@ export function useResumeListState(loadSearchHistory = false) {
           keywords: sharedSearchState.keywords,
           jobDescriptionId: sharedSearchState.jobDescriptionId ?? '',
           collectionSource: sharedSearchState.collectionSource ?? null,
-          collectUrl: sharedSearchState.collectUrl ?? '',
+
           filters: sharedSearchState.filters ?? {},
         })
         setAppliedSearchHistoryId(undefined)
@@ -1754,7 +1750,6 @@ export function useResumeListState(loadSearchHistory = false) {
       keywords: [],
       jobDescriptionId: '',
       collectionSource: null,
-      collectUrl: '',
       filters: {},
     })
     setSelectedTags([])
@@ -2060,7 +2055,6 @@ export function useResumeListState(loadSearchHistory = false) {
       requiredKeywords?: string[]
       jobDescriptionId?: string
       collectionSource?: CollectionSource | null
-      collectUrl?: string
       filters?: Partial<ResumeFilters>
     }, applyDuringUrlHydration?: boolean) => {
       if (shouldBlockQuickStartSync && !applyDuringUrlHydration) {
@@ -2094,10 +2088,6 @@ export function useResumeListState(loadSearchHistory = false) {
           ? current
           : (config.collectionSource ?? undefined)
       })
-      setSessionCollectUrl((current) => {
-        const nextCollectUrl = normalizeOptionalString(config.collectUrl)
-        return current === nextCollectUrl ? current : nextCollectUrl
-      })
       setFilters((current) => ({
         ...current,
         ...(config.filters ?? {}),
@@ -2109,7 +2099,7 @@ export function useResumeListState(loadSearchHistory = false) {
           : [],
       }))
     },
-    [setFilters, setJobDescriptionId, setRequiredKeywords, setSessionCollectionSource, setSessionCollectUrl, setSessionKeywords, setSessionLocation, shouldBlockQuickStartSync]
+    [setFilters, setJobDescriptionId, setRequiredKeywords, setSessionCollectionSource, setSessionKeywords, setSessionLocation, shouldBlockQuickStartSync]
   )
 
   const handleQuickConstraintApply = useCallback(
@@ -2135,11 +2125,7 @@ export function useResumeListState(loadSearchHistory = false) {
         ? current
         : nextSource
     ))
-    // Clear collectUrl when switching to non-Seek sources to prevent stale URL interference
-    if (nextSource.type !== 'seek') {
-      setSessionCollectUrl(undefined)
-    }
-  }, [setSessionCollectUrl, setSessionCollectionSource])
+  }, [setSessionCollectionSource])
 
   const handleSaveCurrentSearch = useCallback(async () => {
     const title = buildSearchHistoryTitle(sessionLocation, sessionKeywords, jobDescriptionId)
@@ -2149,7 +2135,6 @@ export function useResumeListState(loadSearchHistory = false) {
       keywords: sessionKeywords,
       jobDescriptionId,
       collectionSource: sessionCollectionSource,
-      collectUrl: sessionCollectUrl,
       filters,
       selectedTags,
       selectedCompanies,
@@ -2162,7 +2147,7 @@ export function useResumeListState(loadSearchHistory = false) {
     } else {
       toast.error(t('quickStart.history.saveError', 'Failed to save search history'))
     }
-  }, [filteredConvexResumes, filters, jobDescriptionId, saveSearchHistory, selectedCompanies, selectedExperienceLevel, selectedTags, sessionCollectUrl, sessionCollectionSource, sessionKeywords, sessionLocation, t])
+  }, [filteredConvexResumes, filters, jobDescriptionId, saveSearchHistory, selectedCompanies, selectedExperienceLevel, selectedTags, sessionCollectionSource, sessionKeywords, sessionLocation, t])
 
   const handleApplySearchHistory = useCallback(async (entry: SearchHistoryItem) => {
     skipNextUrlSyncRef.current = true
@@ -2172,7 +2157,6 @@ export function useResumeListState(loadSearchHistory = false) {
       keywords: entry.keywords,
       jobDescriptionId: entry.jobDescriptionId ?? '',
       collectionSource: entry.collectionSource ?? null,
-      collectUrl: entry.collectUrl ?? '',
       filters: entry.filters,
     })
     setAppliedSearchHistoryId(entry.id)
@@ -2196,7 +2180,6 @@ export function useResumeListState(loadSearchHistory = false) {
       requiredKeywords,
       jobDescriptionId: normalizeOptionalString(jobDescriptionId),
       collectionSource: sessionCollectionSource ?? null,
-      collectUrl: normalizeOptionalString(sessionCollectUrl),
       filters: normalizeUrlFilters(filters),
       selectedTags,
       selectedCompanies,
@@ -2211,7 +2194,6 @@ export function useResumeListState(loadSearchHistory = false) {
       selectedCompanies,
       selectedExperienceLevel,
       selectedTags,
-      sessionCollectUrl,
       sessionCollectionSource,
       sessionKeywords,
       sessionLocation,
@@ -2224,10 +2206,9 @@ export function useResumeListState(loadSearchHistory = false) {
       normalizeOptionalString(sessionLocation)
       || sessionKeywords.length > 0
       || normalizeOptionalString(jobDescriptionId)
-      || normalizeOptionalString(sessionCollectUrl)
       || sessionCollectionSource
     ),
-    [jobDescriptionId, sessionCollectUrl, sessionCollectionSource, sessionKeywords, sessionLocation]
+    [jobDescriptionId, sessionCollectionSource, sessionKeywords, sessionLocation]
   )
   useEffect(() => {
     if (!copiedShareSessionId || !copiedShareScopeSignature) {
@@ -2330,7 +2311,6 @@ export function useResumeListState(loadSearchHistory = false) {
       requiredKeywords,
       jobDescriptionId: normalizeOptionalString(jobDescriptionId),
       collectionSource: sessionCollectionSource,
-      collectUrl: normalizeOptionalString(sessionCollectUrl),
       filters: {
         ...filters,
         locations: locationFilters,
@@ -2348,7 +2328,6 @@ export function useResumeListState(loadSearchHistory = false) {
     selectedCompanies,
     selectedExperienceLevel,
     selectedTags,
-    sessionCollectUrl,
     sessionCollectionSource,
     sessionKeywords,
     sessionLocation,
@@ -2358,7 +2337,6 @@ export function useResumeListState(loadSearchHistory = false) {
     sessionLocation,
     sessionKeywords,
     sessionCollectionSource,
-    sessionCollectUrl,
     jobDescriptionId,
     appliedSearchHistoryId,
     filters,

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -76,7 +76,6 @@ type SearchHistoryRecord = {
   keywords: string[]
   jobDescriptionId?: string
   collectionSource?: SearchHistoryItem['collectionSource']
-  collectUrl?: string
   filters?: Partial<ResumeFilters>
   selectedTags?: string[]
   selectedCompanies?: string[]
@@ -503,7 +502,6 @@ function toRecentSearchItems(
     collectionSource: resolveCollectionSource(
       record.collectionSource,
     ),
-    collectUrl: normalizeOptionalString(record.collectUrl),
     filters: record.filters ?? {},
     selectedTags: normalizeStringList(record.selectedTags),
     selectedCompanies: normalizeStringList(record.selectedCompanies),

--- a/apps/web/src/hooks/useSession.test.tsx
+++ b/apps/web/src/hooks/useSession.test.tsx
@@ -85,9 +85,9 @@ describe('useSession', () => {
           keywords: ['CNC', '销售'],
           jobDescriptionId: 'lathe-sales',
           collectionSource: {
-            type: 'job5156',
+            type: 'seek',
+            exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
           },
-          collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
           filters: {
             minExperience: 1,
             minAge: 25,
@@ -141,9 +141,9 @@ describe('useSession', () => {
             keywords: ['CNC', '销售'],
             jobDescriptionId: 'lathe-sales',
             collectionSource: {
-              type: 'job5156',
+              type: 'seek',
+              exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
             },
-            collectUrl: ' https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1 ',
             filters: { minAge: 25 },
             selectedTags: ['STAR', 'STAR', ''],
             selectedCompanies: ['Acme', '  Acme  ', ''],
@@ -186,8 +186,7 @@ describe('useSession', () => {
         title: '  东莞 · CNC  ',
         location: '东莞',
         keywords: ['CNC', '销售'],
-        collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
-        collectionSource: { type: 'job5156' },
+        collectionSource: { type: 'seek', exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1' },
         selectedTags: ['STAR'],
         selectedCompanies: ['Acme'],
         selectedExperienceLevel: 'mid',
@@ -226,7 +225,6 @@ describe('useSession', () => {
       location: '东莞',
       keywords: ['招聘', '简历'],
       collectionSource: { type: 'job5156' },
-      collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
       resumeIds: ['resume-1', 'resume-2'],
     })
     await result.current.markSearchHistoryOpened('history-hr' as never)
@@ -246,7 +244,6 @@ describe('useSession', () => {
         location: '东莞',
         keywords: ['招聘', '简历'],
         collectionSource: { type: 'job5156' },
-        collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
         resumeIds: ['resume-1', 'resume-2'],
       })
     )
@@ -309,7 +306,6 @@ describe('useSession', () => {
             type: 'seek',
             exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
           },
-          collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
           filters: {
             minAge: 28,
           },
@@ -335,7 +331,6 @@ describe('useSession', () => {
             type: 'seek',
             exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
           },
-          collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
           filters: {
             minAge: 28,
           },
@@ -434,7 +429,7 @@ describe('useSession', () => {
     expect(result.current.keywords).toEqual(['CNC', '销售'])
   })
 
-  it('can clear and replace the persisted collection source and collect URL through external state', async () => {
+  it('can clear and replace the persisted collection source through external state', async () => {
     const { result } = renderHook(() => useSession())
 
     await waitFor(() => {
@@ -443,41 +438,37 @@ describe('useSession', () => {
 
     act(() => {
       result.current.setCollectionSource({ type: 'seek', exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1' })
-      result.current.setCollectUrl('https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1')
     })
 
     expect(result.current.collectionSource).toEqual({
       type: 'seek',
       exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
     })
-    expect(result.current.collectUrl).toBe('https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1')
 
     act(() => {
       result.current.applyExternalState({
         collectionSource: null,
-        collectUrl: '',
       })
     })
 
     expect(result.current.collectionSource).toBeUndefined()
-    expect(result.current.collectUrl).toBeUndefined()
 
     act(() => {
       result.current.applyExternalState({
         collectionSource: {
-          type: 'job5156',
+          type: 'seek',
+          exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=2&pageNumber=1',
         },
-        collectUrl: ' https://my.employer.seek.com/candidates/recommended?jobId=2&pageNumber=1 ',
       })
     })
 
     expect(result.current.collectionSource).toEqual({
-      type: 'job5156',
+      type: 'seek',
+      exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=2&pageNumber=1',
     })
-    expect(result.current.collectUrl).toBe('https://my.employer.seek.com/candidates/recommended?jobId=2&pageNumber=1')
   })
 
-  it('falls back to legacy seek collectUrl when history records are missing collectionSource', async () => {
+  it('resolves legacy seek collectUrl in history records to collectionSource', async () => {
     useQueryMock.mockImplementation((query) => {
       if (query === 'list-history-query') {
         return [
@@ -487,7 +478,10 @@ describe('useSession', () => {
             title: 'Seek history',
             location: 'Kuala Lumpur MY',
             keywords: ['Sales Engineer'],
-            collectUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+            collectionSource: {
+              type: 'seek',
+              exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+            },
             filters: {},
             selectedTags: [],
             selectedCompanies: [],

--- a/apps/web/src/hooks/useSession.ts
+++ b/apps/web/src/hooks/useSession.ts
@@ -4,7 +4,6 @@ import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Id } from '../../../../packages/convex/convex/_generated/dataModel'
 import {
   normalizeCollectionSource,
-  resolveCollectionSource,
   type CollectionSource,
 } from '@/lib/search-profile-sources'
 import { rawApiClient } from '@/lib/api-helpers'
@@ -17,7 +16,6 @@ export type ExternalSessionState = {
   keywords?: string[]
   jobDescriptionId?: string
   collectionSource?: CollectionSource | null
-  collectUrl?: string
   filters?: Partial<ResumeFilters>
 }
 
@@ -42,7 +40,6 @@ export type SearchHistoryItem = {
   keywords: string[]
   jobDescriptionId?: string
   collectionSource?: CollectionSource
-  collectUrl?: string
   filters: Partial<ResumeFilters>
   selectedTags: string[]
   selectedCompanies: string[]
@@ -62,7 +59,6 @@ type SaveSearchHistoryInput = {
   keywords?: string[]
   jobDescriptionId?: string
   collectionSource?: CollectionSource | null
-  collectUrl?: string
   filters?: Partial<ResumeFilters>
   selectedTags?: string[]
   selectedCompanies?: string[]
@@ -148,6 +144,7 @@ function normalizeShareState(
     return undefined
   }
 
+  const resolvedCollectionSource = normalizeCollectionSource(state.collectionSource)
   const normalized: ResumeSearchShareState = {
     location: normalizeOptionalString(state.location),
     keywords: normalizeStringList(state.keywords),
@@ -156,8 +153,7 @@ function normalizeShareState(
     selectedTags: normalizeStringList(state.selectedTags),
     selectedCompanies: normalizeStringList(state.selectedCompanies),
     selectedExperienceLevel: normalizeShareExperienceLevel(state.selectedExperienceLevel),
-    collectionSource: normalizeCollectionSource(state.collectionSource),
-    collectUrl: normalizeOptionalString(state.collectUrl),
+    collectionSource: resolvedCollectionSource,
     filters: normalizeShareFilters(state.filters),
     referenceNote: normalizeOptionalString(state.referenceNote),
   }
@@ -165,7 +161,6 @@ function normalizeShareState(
   if (
     !normalized.location
     && !normalized.jobDescriptionId
-    && !normalized.collectUrl
     && !normalized.collectionSource
     && (normalized.keywords?.length ?? 0) === 0
     && (normalized.requiredKeywords?.length ?? 0) === 0
@@ -236,7 +231,6 @@ export function useSession(loadSearchHistory = false) {
   const [keywords, setKeywords] = useState<string[]>([])
   const [jobDescriptionId, setJobDescriptionId] = useState<string | undefined>(undefined)
   const [collectionSource, setCollectionSource] = useState<CollectionSource | undefined>(undefined)
-  const [collectUrl, setCollectUrl] = useState<string | undefined>(undefined)
   const [filters, setFilters] = useState<ResumeFilters>({})
 
   useEffect(() => {
@@ -250,7 +244,6 @@ export function useSession(loadSearchHistory = false) {
     setKeywords([])
     setJobDescriptionId(undefined)
     setCollectionSource(undefined)
-    setCollectUrl(undefined)
     setFilters({})
   }, [slug, sessionKey])
 
@@ -266,8 +259,7 @@ export function useSession(loadSearchHistory = false) {
       setLocation(activeSession.config.location)
       setKeywords(activeSession.config.keywords)
       setJobDescriptionId(activeSession.config.jobDescriptionId)
-      setCollectionSource(resolveCollectionSource(activeSession.config.collectionSource))
-      setCollectUrl(activeSession.config.collectUrl)
+      setCollectionSource(normalizeCollectionSource(activeSession.config.collectionSource))
       setFilters(activeSession.config.filters || {})
       setHasHydratedInitialState(true)
     }
@@ -285,13 +277,12 @@ export function useSession(loadSearchHistory = false) {
         keywords,
         jobDescriptionId,
         collectionSource,
-        collectUrl,
         filters,
       })
     }, 1000)
 
     return () => clearTimeout(timer)
-  }, [sessionKey, slug, location, keywords, jobDescriptionId, collectionSource, collectUrl, filters, saveSession, hasHydratedInitialState])
+  }, [sessionKey, slug, location, keywords, jobDescriptionId, collectionSource, filters, saveSession, hasHydratedInitialState])
 
   const trackReviewedResume = useCallback(
     async (resumeId: string) => {
@@ -376,10 +367,6 @@ export function useSession(loadSearchHistory = false) {
       setCollectionSource(normalizeCollectionSource(state.collectionSource))
     }
 
-    if (state.collectUrl !== undefined) {
-      setCollectUrl(normalizeOptionalString(state.collectUrl))
-    }
-
     if (state.filters !== undefined) {
       setFilters(state.filters)
     }
@@ -399,8 +386,7 @@ export function useSession(loadSearchHistory = false) {
       location: record.location,
       keywords: record.keywords,
       jobDescriptionId: record.jobDescriptionId,
-      collectionSource: resolveCollectionSource(record.collectionSource),
-      collectUrl: normalizeOptionalString(record.collectUrl),
+      collectionSource: normalizeCollectionSource(record.collectionSource),
       filters: (record.filters ?? {}) as Partial<ResumeFilters>,
       selectedTags: normalizeStringList(record.selectedTags),
       selectedCompanies: normalizeStringList(record.selectedCompanies),
@@ -431,7 +417,6 @@ export function useSession(loadSearchHistory = false) {
         input.collectionSource !== undefined
           ? normalizeCollectionSource(input.collectionSource)
           : collectionSource,
-      collectUrl: input.collectUrl !== undefined ? normalizeOptionalString(input.collectUrl) : collectUrl,
       filters: input.filters ?? filters,
       selectedTags: normalizeStringList(input.selectedTags ?? []),
       selectedCompanies: normalizeStringList(input.selectedCompanies ?? []),
@@ -440,7 +425,7 @@ export function useSession(loadSearchHistory = false) {
       analysisTaskId: normalizeOptionalString(input.analysisTaskId),
       resumeIds: normalizeStringList(input.resumeIds),
     })
-  }, [collectionSource, collectUrl, filters, jobDescriptionId, keywords, location, saveSearchHistoryMutation, sessionKey, slug])
+  }, [collectionSource, filters, jobDescriptionId, keywords, location, saveSearchHistoryMutation, sessionKey, slug])
 
   const markSearchHistoryOpened = useCallback(async (id: Id<'search_history'>) => {
     await markSearchHistoryOpenedMutation({ id, workspaceSlug: slug })
@@ -456,8 +441,6 @@ export function useSession(loadSearchHistory = false) {
     setJobDescriptionId,
     collectionSource,
     setCollectionSource,
-    collectUrl,
-    setCollectUrl,
     filters,
     setFilters,
     reviewedIdsSet,

--- a/apps/web/src/hooks/useUrlSearchState.test.ts
+++ b/apps/web/src/hooks/useUrlSearchState.test.ts
@@ -58,8 +58,8 @@ describe('useUrlSearchState location parsing', () => {
     expect(state.keywords).toEqual(['Sales Engineer', 'Sales Manager'])
   })
 
-  it('keeps legacy whitespace keyword queries backward compatible', () => {
-    const state = parseUrlSearchState(new URLSearchParams('keyword=CNC+%E9%94%80%E5%94%AE'))
+  it('keeps legacy kw whitespace queries backward compatible', () => {
+    const state = parseUrlSearchState(new URLSearchParams('kw=CNC+%E9%94%80%E5%94%AE'))
 
     expect(state.query).toBe('CNC 销售')
     expect(state.keywords).toEqual(['CNC', '销售'])
@@ -67,7 +67,7 @@ describe('useUrlSearchState location parsing', () => {
 
   it('parses required keywords from rkw param', () => {
     const state = parseUrlSearchState(
-      new URLSearchParams('keyword=%22Sales+Engineer%22+OR+%22Sales+Manager%22&rkw=CNC%2Cmachine+tools')
+      new URLSearchParams('q=%22Sales+Engineer%22+OR+%22Sales+Manager%22&rkw=CNC%2Cmachine+tools')
     )
 
     expect(state.keywords).toEqual(['Sales Engineer', 'Sales Manager'])
@@ -232,7 +232,7 @@ describe('useUrlSearchState location parsing', () => {
 
   it('clears legacy params and deduplicates canonical values when syncing to the url', () => {
     const currentParams = new URLSearchParams(
-      'sid=session-share-1&kw=legacy&keyword=legacy&loc=Oldtown&locs=Oldtown%2COldtown&minExp=3&maxExp=9&status=new'
+      'sid=session-share-1&kw=legacy&loc=Oldtown&locs=Oldtown%2COldtown&minExp=3&maxExp=9&status=new'
     )
     useSearchParamsMock.mockReturnValue([currentParams, setSearchParamsMock])
 
@@ -262,7 +262,6 @@ describe('useUrlSearchState location parsing', () => {
 
     expect(updatedParams.get('sid')).toBeNull()
     expect(updatedParams.get('kw')).toBeNull()
-    expect(updatedParams.get('keyword')).toBeNull()
     expect(updatedParams.get('loc')).toBeNull()
     expect(updatedParams.get('locs')).toBeNull()
     expect(updatedParams.get('minExp')).toBeNull()

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -2902,8 +2902,6 @@ export interface paths {
                                 type: "job5156" | "51job" | "seek";
                                 exactUrl?: string;
                             };
-                            /** @example https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1 */
-                            collectUrl?: string;
                             filters?: components["schemas"]["ResumeFilters"] & {
                                 minRoleYears?: number;
                                 roleFilterType?: string;
@@ -2989,8 +2987,6 @@ export interface paths {
                                         type: "job5156" | "51job" | "seek";
                                         exactUrl?: string;
                                     };
-                                    /** @example https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1 */
-                                    collectUrl?: string;
                                     filters?: components["schemas"]["ResumeFilters"] & {
                                         minRoleYears?: number;
                                         roleFilterType?: string;
@@ -3114,8 +3110,6 @@ export interface paths {
                                         type: "job5156" | "51job" | "seek";
                                         exactUrl?: string;
                                     };
-                                    /** @example https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1 */
-                                    collectUrl?: string;
                                     filters?: components["schemas"]["ResumeFilters"] & {
                                         minRoleYears?: number;
                                         roleFilterType?: string;
@@ -3221,8 +3215,6 @@ export interface paths {
                                 type: "job5156" | "51job" | "seek";
                                 exactUrl?: string;
                             };
-                            /** @example https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1 */
-                            collectUrl?: string;
                             filters?: components["schemas"]["ResumeFilters"] & {
                                 minRoleYears?: number;
                                 roleFilterType?: string;
@@ -3311,8 +3303,6 @@ export interface paths {
                                         type: "job5156" | "51job" | "seek";
                                         exactUrl?: string;
                                     };
-                                    /** @example https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1 */
-                                    collectUrl?: string;
                                     filters?: components["schemas"]["ResumeFilters"] & {
                                         minRoleYears?: number;
                                         roleFilterType?: string;

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -140,12 +140,7 @@ export function normalizeCollectionSource(
 export function resolveCollectionSource(
   collectionSource: CollectionSource | null | undefined,
 ): CollectionSource | undefined {
-  const normalizedSource = normalizeCollectionSource(collectionSource)
-  if (normalizedSource) {
-    return normalizedSource
-  }
-
-  return undefined
+  return normalizeCollectionSource(collectionSource) ?? undefined
 }
 
 export function stripCollectionSourceExactUrl(

--- a/apps/web/src/pages/DebugConfig.test.tsx
+++ b/apps/web/src/pages/DebugConfig.test.tsx
@@ -324,8 +324,7 @@ describe('System settings routes', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Landing quick starts')).toBeInTheDocument()
-      expect(screen.getByText('Legacy workflow-seed config remains for compatibility only. The search-first landing page now reads its quick starts from Search Profiles instead.')).toBeInTheDocument()
-      expect(screen.getByText('Search Profiles is now the single page for landing quick starts and other profiles. The China Job5156 and Malaysia SEEK starter profiles are materialized into workspace-managed storage there, so you can edit them directly.')).toBeInTheDocument()
+      expect(screen.getByText('Search-first landing quick starts now live in the same Search Profiles workspace registry as every other profile.')).toBeInTheDocument()
     })
 
     expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/system/profiles')

--- a/apps/web/src/pages/system-settings/lib.ts
+++ b/apps/web/src/pages/system-settings/lib.ts
@@ -100,7 +100,6 @@ export interface CustomKeywordWorkflowSeed {
     type: WorkflowSeedCollectionSourceType
     exactUrl?: string
   }
-  collectUrl?: string
   visible?: boolean
   source?: ConfigSourceOrigin
 }
@@ -121,7 +120,7 @@ export interface WorkflowSeedFormState {
   location: string
   keywords: string
   collectionSourceType: WorkflowSeedCollectionSourceType
-  collectUrl: string
+  collectExactUrl: string
   visible: boolean
 }
 
@@ -502,7 +501,7 @@ function parseWorkflowSeed(value: unknown): CustomKeywordWorkflowSeed | null {
     return null
   }
 
-  const collectUrl = readString(value.collectUrl) ?? undefined
+  const collectExactUrl = readString(value.collectExactUrl) ?? undefined
   const visible = typeof value.visible === 'boolean' ? value.visible : undefined
   const source = value.source === 'system' || value.source === 'workspace' ? value.source : undefined
 
@@ -512,8 +511,10 @@ function parseWorkflowSeed(value: unknown): CustomKeywordWorkflowSeed | null {
     market,
     location,
     keywords: Array.from(new Set(keywords)),
-    collectionSource,
-    collectUrl,
+    collectionSource: {
+      ...collectionSource,
+      ...(collectExactUrl && collectionSource.type === 'seek' ? { exactUrl: collectExactUrl } : {}),
+    },
     visible,
     source,
   }
@@ -749,7 +750,7 @@ export function createEmptyWorkflowSeedForm(): WorkflowSeedFormState {
     location: '',
     keywords: '',
     collectionSourceType: 'job5156',
-    collectUrl: '',
+    collectExactUrl: '',
     visible: true,
   }
 }
@@ -762,7 +763,7 @@ export function workflowSeedToForm(seed: CustomKeywordWorkflowSeed): WorkflowSee
     location: seed.location,
     keywords: seed.keywords.join(', '),
     collectionSourceType: seed.collectionSource.type,
-    collectUrl: seed.collectUrl ?? seed.collectionSource.exactUrl ?? '',
+    collectExactUrl: seed.collectionSource.exactUrl ?? '',
     visible: seed.visible ?? true,
   }
 }


### PR DESCRIPTION
## Summary
- Preserve SEEK exactUrl across source type switches in CollectResumesButton using a ref to track the last known SEEK URL
- Build SEEK collect URL when applying a workflow seed that lacks `exactUrl` so QuickStartPanel emits a complete `collectionSource`
- Update DebugConfig test to match the current keywords page description text
- Remove remaining `collectUrl` references across API routes, services, and web hooks/types
- Remove `keyword` URL param from `useUrlSearchState` tests (only `q`/`kw` are supported)

## Test plan
- [x] `make check` passes
- [x] All 623 tests pass (98 test files)
- [x] CollectResumesButton test: SEEK exactUrl survives switching to 51job → Job5156 → back to SEEK
- [x] QuickStartPanel test: SEEK Malaysia workflow preset generates the correct collect URL
- [x] DebugConfig test: keywords page renders updated description text