### PR TITLE
fix: remove v0.1 legacy param aliases and collectUrl shims, fix 51job source handling

### DIFF
--- a/apps/api/src/services/custom-keyword-service.ts
+++ b/apps/api/src/services/custom-keyword-service.ts
@@ -197,14 +197,6 @@ function parseWorkflowSeed(value: unknown): CustomKeywordWorkflowSeed | null {
         collectionSource,
     };
 
-    // Legacy: if record has collectUrl and collectionSource is seek without exactUrl, merge it
-    const legacyCollectUrl = typeof (record as Record<string, unknown>).collectUrl === "string" && ((record as Record<string, unknown>).collectUrl as string).trim()
-        ? ((record as Record<string, unknown>).collectUrl as string).trim()
-        : undefined;
-    if (legacyCollectUrl && collectionSource.type === "seek" && !collectionSource.exactUrl) {
-        workflowSeed.collectionSource = { ...collectionSource, exactUrl: legacyCollectUrl };
-    }
-
     const visible = parseVisible(record.visible);
     if (visible !== undefined) {
         workflowSeed.visible = visible;

--- a/apps/api/src/services/workspace-config-service.ts
+++ b/apps/api/src/services/workspace-config-service.ts
@@ -335,12 +335,6 @@ function parseWorkflowSeed(value: unknown): CustomKeywordWorkflowSeed | null {
     collectionSource,
   };
 
-  // Legacy: if value has collectUrl and collectionSource is seek without exactUrl, merge it
-  const legacyCollectUrl = readString((value as Record<string, unknown>).collectUrl) ?? undefined;
-  if (legacyCollectUrl && collectionSource.type === "seek" && !collectionSource.exactUrl) {
-    workflowSeed.collectionSource = { ...collectionSource, exactUrl: legacyCollectUrl };
-  }
-
   const visible = parseVisible(value.visible);
   if (visible !== undefined) {
     workflowSeed.visible = visible;

--- a/apps/web/src/components/CollectResumesButton.test.tsx
+++ b/apps/web/src/components/CollectResumesButton.test.tsx
@@ -101,4 +101,22 @@ describe('CollectResumesButton', () => {
       'noopener,noreferrer'
     )
   })
+
+  it('calls onCollectionSourceChange with 51job type when 51job is selected', async () => {
+    const user = userEvent.setup()
+    const onCollectionSourceChange = vi.fn()
+
+    render(
+      <CollectResumesButton
+        location="东莞"
+        keywords={['CNC']}
+        collectionSource={{ type: 'job5156' }}
+        onCollectionSourceChange={onCollectionSourceChange}
+      />
+    )
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Source' }), '51job')
+
+    expect(onCollectionSourceChange).toHaveBeenCalledWith({ type: '51job' })
+  })
 })

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -708,10 +708,10 @@ export function QuickStartPanel({
       return
     }
 
-    const nextCollectionSource: CollectionSource = {
-      type: 'seek',
-      exactUrl: matchedProfileCollectUrl,
-    }
+    const matchedSource = getSearchProfileCollectionSource(autoMatchResult?.profile.sources)
+    const nextCollectionSource: CollectionSource = matchedSource?.type === 'seek'
+      ? { type: 'seek', exactUrl: matchedProfileCollectUrl }
+      : (matchedSource ?? { type: SEARCH_PROFILE_SOURCE_TYPES.job5156 })
 
     setCollectionSource(nextCollectionSource)
     onApplyConfig?.({
@@ -720,7 +720,7 @@ export function QuickStartPanel({
       jobDescriptionId: jobDescriptionId || undefined,
       collectionSource: nextCollectionSource,
     }, true)
-  }, [currentCollectionSource, generatedCollectUrl, jobDescriptionId, location, matchedProfileCollectUrl, normalizedKeywords, onApplyConfig])
+  }, [autoMatchResult?.profile.sources, currentCollectionSource, generatedCollectUrl, jobDescriptionId, location, matchedProfileCollectUrl, normalizedKeywords, onApplyConfig])
 
   useEffect(() => {
     if (normalizedKeywords.length === 0) {

--- a/apps/web/src/hooks/useUrlSearchState.test.ts
+++ b/apps/web/src/hooks/useUrlSearchState.test.ts
@@ -28,8 +28,8 @@ describe('useUrlSearchState location parsing', () => {
     expect(result.current.parsedState.shareSessionId).toBe('session-share-1')
   })
 
-  it('detects legacy keyword params and jd params as explicit url search state', () => {
-    useSearchParamsMock.mockReturnValue([new URLSearchParams('kw=CNC+Sales&jd=jd-123'), setSearchParamsMock])
+  it('detects keyword params and jd params as explicit url search state', () => {
+    useSearchParamsMock.mockReturnValue([new URLSearchParams('q=CNC+Sales&jd=jd-123'), setSearchParamsMock])
 
     const { result } = renderHook(() => useUrlSearchState())
 
@@ -58,8 +58,8 @@ describe('useUrlSearchState location parsing', () => {
     expect(state.keywords).toEqual(['Sales Engineer', 'Sales Manager'])
   })
 
-  it('keeps legacy kw whitespace queries backward compatible', () => {
-    const state = parseUrlSearchState(new URLSearchParams('kw=CNC+%E9%94%80%E5%94%AE'))
+  it('parses spaced queries from q param', () => {
+    const state = parseUrlSearchState(new URLSearchParams('q=CNC+%E9%94%80%E5%94%AE'))
 
     expect(state.query).toBe('CNC 销售')
     expect(state.keywords).toEqual(['CNC', '销售'])
@@ -230,9 +230,9 @@ describe('useUrlSearchState location parsing', () => {
     expect(state.query).toBe('machine tools')
   })
 
-  it('clears legacy params and deduplicates canonical values when syncing to the url', () => {
+  it('deduplicates canonical values when syncing to the url', () => {
     const currentParams = new URLSearchParams(
-      'sid=session-share-1&kw=legacy&loc=Oldtown&locs=Oldtown%2COldtown&minExp=3&maxExp=9&status=new'
+      'sid=session-share-1&q=legacy&location=Oldtown&minRoleYears=3&maxRoleYears=9&status=new'
     )
     useSearchParamsMock.mockReturnValue([currentParams, setSearchParamsMock])
 
@@ -261,11 +261,6 @@ describe('useUrlSearchState location parsing', () => {
     const updatedParams = updater(currentParams) as URLSearchParams
 
     expect(updatedParams.get('sid')).toBeNull()
-    expect(updatedParams.get('kw')).toBeNull()
-    expect(updatedParams.get('loc')).toBeNull()
-    expect(updatedParams.get('locs')).toBeNull()
-    expect(updatedParams.get('minExp')).toBeNull()
-    expect(updatedParams.get('maxExp')).toBeNull()
 
     expect(updatedParams.get('location')).toBe('Dongguan,Shenzhen')
     expect(updatedParams.get('q')).toBe('CNC Sales')

--- a/apps/web/src/hooks/useUrlSearchState.ts
+++ b/apps/web/src/hooks/useUrlSearchState.ts
@@ -5,16 +5,12 @@ import type { CandidateStatus, ResumeFilters } from '@/types/resume'
 
 const KNOWN_PARAM_KEYS = [
   'q',
-  'loc',
   'location',
-  'kw',
   'jd',
   'tags',
   'co',
   'rkw',
   'exp',
-  'minExp',
-  'maxExp',
   'minRoleYears',
   'maxRoleYears',
   'roleType',
@@ -22,7 +18,6 @@ const KNOWN_PARAM_KEYS = [
   'maxAge',
   'edu',
   'minScore',
-  'locs',
   'status',
   'sort',
   'order',
@@ -41,16 +36,6 @@ export type UrlSearchState = {
   selectedCompanies: string[]
   selectedExperienceLevel?: ExperienceLevelFilter
   filters: Partial<ResumeFilters>
-}
-
-function getFirstParam(searchParams: URLSearchParams, keys: string[]): string | null {
-  for (const key of keys) {
-    const value = searchParams.get(key)
-    if (value !== null) {
-      return value
-    }
-  }
-  return null
 }
 
 function parseKeywordParam(value: string | null): string[] {
@@ -188,15 +173,11 @@ export function hasKnownUrlSearchParams(searchParams: URLSearchParams): boolean 
 export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchState {
   const shareSessionIdRaw = searchParams.get('sid')
   const shareSessionId = shareSessionIdRaw?.trim() || undefined
-  const queryRaw = getFirstParam(searchParams, ['q', 'kw'])
+  const queryRaw = searchParams.get('q')
   const query = queryRaw?.trim() || undefined
-  const locationRaw = getFirstParam(searchParams, ['loc', 'location'])
+  const locationRaw = searchParams.get('location')
   const normalizedLocation = locationRaw?.trim() || ''
-  const locationFromLocationParam = normalizeUniqueValues(parseLocationParam(normalizedLocation))
-  const locationFromLocsParam = normalizeUniqueValues(parseCsvParam(searchParams.get('locs')))
-  const effectiveLocations = locationFromLocsParam.length > 0
-    ? locationFromLocsParam
-    : locationFromLocationParam
+  const effectiveLocations = normalizeUniqueValues(parseLocationParam(normalizedLocation))
   const location = normalizedLocation || (effectiveLocations.length > 0 ? effectiveLocations.join(',') : undefined)
   const keywords = normalizeUniqueValues(parseKeywordParam(query ?? null))
   const requiredKeywords = normalizeUniqueValues(parseCsvParam(searchParams.get('rkw')))
@@ -208,7 +189,7 @@ export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchSta
 
   const filters: Partial<ResumeFilters> = {}
 
-  const maxExperience = parseNumberParam(getFirstParam(searchParams, ['maxRoleYears', 'maxExp']))
+  const maxExperience = parseNumberParam(searchParams.get('maxRoleYears'))
   if (typeof maxExperience === 'number') {
     filters.maxExperience = maxExperience
   }
@@ -218,7 +199,7 @@ export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchSta
     filters.education = education
   }
 
-  const minRoleYears = parseNumberParam(getFirstParam(searchParams, ['minRoleYears', 'minExp']))
+  const minRoleYears = parseNumberParam(searchParams.get('minRoleYears'))
   if (typeof minRoleYears === 'number') {
     filters.minRoleYears = minRoleYears
     filters.minExperience = minRoleYears
@@ -280,7 +261,6 @@ export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchSta
 export function useUrlSearchState() {
   const [searchParams, setSearchParams] = useSearchParams()
   const hasKeywordParam = searchParams.has('q')
-    || searchParams.has('kw')
   const hasJobDescriptionParam = searchParams.has('jd')
 
   const hasUrlParams = useMemo(

--- a/apps/web/src/lib/search-profile-sources.test.ts
+++ b/apps/web/src/lib/search-profile-sources.test.ts
@@ -64,6 +64,17 @@ describe('search-profile-sources', () => {
     })
   })
 
+  it('returns the active launchable collection source for 51job profiles', () => {
+    const collectionSource = getSearchProfileCollectionSource([
+      { type: 'manual_upload', enabled: true, priority: 1 },
+      { type: SEARCH_PROFILE_SOURCE_TYPES.job51, enabled: true, priority: 2 },
+    ])
+
+    expect(collectionSource).toEqual({
+      type: SEARCH_PROFILE_SOURCE_TYPES.job51,
+    })
+  })
+
   it('uses enabled priority order when selecting the active source', () => {
     const activeSource = getActiveSearchProfileSource([
       { type: SEARCH_PROFILE_SOURCE_TYPES.seek, enabled: true, priority: 2 },
@@ -189,10 +200,20 @@ describe('search-profile-sources', () => {
       keywords: ['CNC'],
       maxPages: 2,
     })
+    const job51Url = buildCollectionLaunchUrl({
+      source: {
+        type: SEARCH_PROFILE_SOURCE_TYPES.job51,
+      },
+      location: '东莞',
+      keywords: ['CNC'],
+      maxPages: 2,
+    })
 
     expect(seekUrl).toContain('jobId=90842915')
     expect(seekUrl).toContain('tr_max_pages=2')
     expect(job5156Url).toContain('hr.job5156.com/search')
     expect(job5156Url).toContain('tr_max_pages=2')
+    expect(job51Url).toContain('ehire.51job.com/Revision/talent/search')
+    expect(job51Url).toContain('tr_max_pages=1')
   })
 })

--- a/packages/convex/convex/__tests__/seed-workspace-demo-data.test.ts
+++ b/packages/convex/convex/__tests__/seed-workspace-demo-data.test.ts
@@ -81,10 +81,9 @@ type SearchHistoryRecord = RecordWithId & {
   keywords: string[]
   jobDescriptionId?: string
   collectionSource?: {
-    type: 'job5156' | 'seek'
+    type: 'job5156' | '51job' | 'seek'
     exactUrl?: string
   }
-  collectUrl?: string
   filters?: Record<string, unknown>
   selectedTags?: string[]
   selectedCompanies?: string[]


### PR DESCRIPTION
## Summary
- Remove v0.1-era backward-compatible URL param aliases (`kw`, `loc`, `locs`, `minExp`, `maxExp`) from `useUrlSearchState` parse path — only canonical names accepted now
- Remove legacy `collectUrl` backward-compat shims from `workspace-config-service` and `custom-keyword-service`
- Fix QuickStartPanel URL promotion to preserve actual source type instead of always forcing `'seek'` for matched profile URLs
- Fix stale type union in Convex seed test missing `'51job'`
- Add 51job test coverage for `search-profile-sources`, `CollectResumesButton` callback

## Test plan
- [x] All 623 tests pass across 98 test files
- [x] `make check` passes (typecheck, lint, governance)
- [x] New 51job test cases cover `getSearchProfileCollectionSource`, `onCollectionSourceChange`, and `buildCollectionLaunchUrl`