### PR TITLE
fix: remove collectUrl from Convex, add 51job market map and tests

### DIFF
--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -29,6 +29,18 @@ const SEEK_MALAYSIA_WORKFLOW_SEED = {
   visible: true,
 }
 
+const JOB51_WORKFLOW_SEED = {
+  id: 'job51-cn-cnc-sales',
+  label: 'China · 51job · CNC 销售',
+  market: 'CN',
+  location: '东莞',
+  keywords: ['CNC', '销售'],
+  collectionSource: {
+    type: '51job',
+  },
+  visible: true,
+}
+
 const SEEK_MALAYSIA_PROFILE = {
   id: 'seek-malaysia-sales',
   name: 'SEEK Malaysia CNC Sales',
@@ -145,6 +157,7 @@ describe('QuickStartPanel quick-filter display', () => {
                 visible: true,
               },
               SEEK_MALAYSIA_WORKFLOW_SEED,
+              JOB51_WORKFLOW_SEED,
             ],
           },
         }
@@ -756,6 +769,43 @@ describe('QuickStartPanel quick-filter display', () => {
         collectionSource: {
           type: 'seek',
           exactUrl: SEEK_MALAYSIA_COLLECT_URL,
+        },
+      })
+    })
+  })
+
+  it('applies the 51job workflow preset with collectionSource type 51job', async () => {
+    const user = userEvent.setup()
+    const onApplyConfig = vi.fn()
+
+    render(
+      <QuickStartPanel
+        defaultLocation=""
+        defaultKeywords={[]}
+        jobDescriptionId=""
+        onApplyConfig={onApplyConfig}
+        onJobChange={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: JOB51_WORKFLOW_SEED.label })
+      ).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: JOB51_WORKFLOW_SEED.label }))
+
+    expect(screen.getByRole('textbox', { name: '位置' })).toHaveValue('东莞')
+    expect(screen.getByDisplayValue(JOB51_WORKFLOW_SEED.keywords.join(' '))).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(onApplyConfig).toHaveBeenLastCalledWith({
+        location: '东莞',
+        keywords: JOB51_WORKFLOW_SEED.keywords,
+        jobDescriptionId: undefined,
+        collectionSource: {
+          type: '51job',
         },
       })
     })

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -20,6 +20,7 @@ import {
   buildCollectionLaunchUrl,
   getSearchProfileCollectionSource,
   getSearchProfileCollectUrl,
+  getCollectionSourceMarket,
   resolveCollectionSource,
   stripCollectionSourceExactUrl,
   SEARCH_PROFILE_SOURCE_TYPES,
@@ -598,7 +599,7 @@ export function QuickStartPanel({
     () => resolveCollectionSource(collectionSource) ?? { type: SEARCH_PROFILE_SOURCE_TYPES.job5156 },
     [collectionSource]
   )
-  const currentMarket: KeywordMarket = currentCollectionSource.type === SEARCH_PROFILE_SOURCE_TYPES.seek ? 'MY' : 'CN'
+  const currentMarket: KeywordMarket = getCollectionSourceMarket(currentCollectionSource.type)
   const generatedCollectUrl = useMemo(
     () => buildCollectionLaunchUrl({
       source: currentCollectionSource,

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -587,6 +587,35 @@ describe('useResumeListState role filter regression', () => {
     expect(getDisplayedResumeNames()).toEqual(['Manual Candidate'])
   })
 
+  it('gives live 51job resumes their own review lane separate from job5156', () => {
+    mockState.sessionCollectionSource = { type: '51job' }
+    mockState.convexResumes = [
+      buildResume({
+        id: 'job51-1',
+        name: '51job Live Candidate',
+        source: 'ehire.51job.com',
+        profileType: '51job',
+        roleSignals: [],
+      }),
+      buildResume({
+        id: 'job5156-1',
+        name: 'Job5156 Candidate',
+        source: 'hr.job5156.com',
+        profileType: 'job5156',
+        roleSignals: [],
+      }),
+      buildResume({
+        id: 'seek-1',
+        name: 'Seek Candidate',
+        source: 'my.employer.seek.com',
+        profileType: 'seek',
+        roleSignals: [],
+      }),
+    ]
+
+    expect(getDisplayedResumeNames()).toEqual(['51job Live Candidate'])
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     capturedExportPayload = null

--- a/apps/web/src/hooks/useSession.test.tsx
+++ b/apps/web/src/hooks/useSession.test.tsx
@@ -468,7 +468,7 @@ describe('useSession', () => {
     })
   })
 
-  it('resolves legacy seek collectUrl in history records to collectionSource', async () => {
+  it('preserves seek collectionSource exactUrl from history records', async () => {
     useQueryMock.mockImplementation((query) => {
       if (query === 'list-history-query') {
         return [
@@ -509,6 +509,48 @@ describe('useSession', () => {
     expect(result.current.searchHistory[0]?.collectionSource).toEqual({
       type: 'seek',
       exactUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1&pageNumber=1',
+    })
+  })
+
+  it('preserves 51job collectionSource from history records without exactUrl', async () => {
+    useQueryMock.mockImplementation((query) => {
+      if (query === 'list-history-query') {
+        return [
+          {
+            _id: 'history-51job',
+            sessionKey: 'session-51job',
+            title: '东莞 · CNC 销售',
+            location: '东莞',
+            keywords: ['CNC', '销售'],
+            collectionSource: {
+              type: '51job',
+            },
+            filters: { minAge: 25, maxAge: 35 },
+            selectedTags: [],
+            selectedCompanies: [],
+            createdAt: 1,
+          },
+        ]
+      }
+
+      return {
+        config: {
+          location: '',
+          keywords: [],
+          filters: {},
+        },
+        reviewedResumeIds: [],
+      }
+    })
+
+    const { result } = renderHook(() => useSession(true))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.searchHistory[0]?.collectionSource).toEqual({
+      type: '51job',
     })
   })
 })

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -34,6 +34,16 @@ export type CollectionSource = {
   unsafeLimits?: boolean
 }
 
+const SOURCE_MARKET_MAP: Record<CollectionSourceType, 'CN' | 'MY'> = {
+  [SEARCH_PROFILE_SOURCE_TYPES.job5156]: 'CN',
+  [SEARCH_PROFILE_SOURCE_TYPES.job51]: 'CN',
+  [SEARCH_PROFILE_SOURCE_TYPES.seek]: 'MY',
+}
+
+export function getCollectionSourceMarket(sourceType: CollectionSourceType): 'CN' | 'MY' {
+  return SOURCE_MARKET_MAP[sourceType]
+}
+
 export type SearchProfileSource = {
   type: string
   enabled: boolean

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -21,96 +21,9 @@ import { parseAgeFromContent } from "./lib/age";
 import { DEFAULT_WORKSPACE_SLUG } from "./sessions";
 import { resolveResumeScanBatchSize } from "./resumes";
 
-const SEEK_HOST_SUFFIX = ".employer.seek.com";
-const SEEK_RECOMMENDED_PATH = "/candidates/recommended";
 const JOB5156_HOST = "hr.job5156.com";
-const JOB51_EHIRE_HOST = "ehire.51job.com";
 const MANUAL_51JOB_SOURCE = "51job-manual";
 const PROFILE_URL_CONTENT_KEYS = ["profileUrl", "profile_url", "profileURL", "url"];
-
-type CollectionSourceValue =
-    | { type: "seek"; exactUrl: string }
-    | { type: "51job"; exactUrl: string }
-    | { type: "job5156" };
-
-function collectionSourceFromCollectUrl(collectUrl: string): CollectionSourceValue | undefined {
-    try {
-        const url = new URL(collectUrl);
-        if (url.protocol !== "https:") return undefined;
-        const hostname = url.hostname.toLowerCase();
-        if (hostname.endsWith(SEEK_HOST_SUFFIX) && url.pathname.replace(/\/+$/, "") === SEEK_RECOMMENDED_PATH) {
-            return { type: "seek", exactUrl: url.toString() };
-        }
-        if (hostname === JOB51_EHIRE_HOST) {
-            return { type: "51job", exactUrl: url.toString() };
-        }
-        if (hostname === JOB5156_HOST) {
-            return { type: "job5156" };
-        }
-    } catch {
-        // Not a valid URL
-    }
-    return undefined;
-}
-
-export const backfillCollectionSource = mutation({
-    args: {
-        table: v.union(v.literal("screening_sessions"), v.literal("search_history")),
-        cursor: v.optional(v.string()),
-        batchSize: v.optional(v.number()),
-    },
-    handler: async (ctx, args) => {
-        const batch = resolveResumeScanBatchSize(args.batchSize);
-        const records = await ctx.db
-            .query(args.table)
-            .order("desc")
-            .paginate({
-                cursor: args.cursor ?? null,
-                numItems: batch,
-            });
-
-        let count = 0;
-        for (const record of records.page) {
-            const config = args.table === "screening_sessions"
-                ? (record as Doc<"screening_sessions">).config
-                : null;
-
-            const existingSource = config
-                ? config.collectionSource
-                : (record as Doc<"search_history">).collectionSource;
-
-            if (existingSource) continue;
-
-            const collectUrl = config
-                ? config.collectUrl
-                : (record as Doc<"search_history">).collectUrl;
-
-            if (!collectUrl) continue;
-
-            const source = collectionSourceFromCollectUrl(collectUrl);
-            if (!source) continue;
-
-            if (config) {
-                await ctx.db.patch(record._id, {
-                    config: { ...config, collectionSource: source },
-                });
-            } else {
-                await ctx.db.patch(record._id, {
-                    collectionSource: source,
-                } as Partial<Doc<"search_history">>);
-            }
-            count++;
-        }
-
-        return {
-            table: args.table,
-            scanned: records.page.length,
-            updated: count,
-            hasMore: !records.isDone,
-            cursor: records.isDone ? null : records.continueCursor,
-        };
-    },
-});
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null;

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -327,7 +327,6 @@ export default defineSchema({
                 type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
                 exactUrl: v.optional(v.string()),
             })),
-            collectUrl: v.optional(v.string()),
             filters: v.optional(v.any()), // Stores ResumeFilters object
         }),
         reviewedResumeIds: v.array(v.string()), // IDs of resumes seen/acted upon
@@ -348,7 +347,6 @@ export default defineSchema({
             type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
             exactUrl: v.optional(v.string()),
         })),
-        collectUrl: v.optional(v.string()),
         filters: v.optional(v.any()),
         selectedTags: v.optional(v.array(v.string())),
         selectedCompanies: v.optional(v.array(v.string())),

--- a/packages/convex/convex/seed.ts
+++ b/packages/convex/convex/seed.ts
@@ -624,7 +624,6 @@ export const seedWorkspaceDemoData = mutation({
         type: "job5156" | "51job" | "seek";
         exactUrl?: string;
       };
-      collectUrl?: string;
       filters?: Record<string, unknown>;
       selectedTags?: string[];
       selectedCompanies?: string[];
@@ -987,7 +986,6 @@ export const seedWorkspaceDemoData = mutation({
           existing.jobDescriptionId !== item.jobDescriptionId ||
           stableSerialize(existing.collectionSource ?? null) !==
             stableSerialize(item.collectionSource ?? null) ||
-          existing.collectUrl !== item.collectUrl ||
           stableSerialize(existing.filters ?? {}) !==
             stableSerialize(item.filters ?? {}) ||
           stableSerialize(existing.selectedTags ?? []) !==
@@ -1004,7 +1002,6 @@ export const seedWorkspaceDemoData = mutation({
             keywords: item.keywords,
             jobDescriptionId: item.jobDescriptionId,
             collectionSource: item.collectionSource,
-            collectUrl: item.collectUrl,
             filters: item.filters,
             selectedTags: item.selectedTags,
             selectedCompanies: item.selectedCompanies,
@@ -1025,7 +1022,6 @@ export const seedWorkspaceDemoData = mutation({
         keywords: item.keywords,
         jobDescriptionId: item.jobDescriptionId,
         collectionSource: item.collectionSource,
-        collectUrl: item.collectUrl,
         filters: item.filters,
         selectedTags: item.selectedTags,
         selectedCompanies: item.selectedCompanies,

--- a/packages/convex/convex/sessions.ts
+++ b/packages/convex/convex/sessions.ts
@@ -192,7 +192,6 @@ export const saveSession = mutation({
             type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
             exactUrl: v.optional(v.string()),
         })),
-        collectUrl: v.optional(v.string()),
         filters: v.optional(v.any()),
     },
     handler: async (ctx, args) => {
@@ -212,7 +211,6 @@ export const saveSession = mutation({
                 keywords: args.keywords,
                 jobDescriptionId: args.jobDescriptionId,
                 collectionSource: normalizeCollectionSource(args.collectionSource),
-                collectUrl: normalizeOptionalString(args.collectUrl),
                 filters: args.filters,
             },
             workspaceSlug,
@@ -362,7 +360,6 @@ export const saveSearchHistory = mutation({
             type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
             exactUrl: v.optional(v.string()),
         })),
-        collectUrl: v.optional(v.string()),
         filters: v.optional(v.any()),
         selectedTags: v.optional(v.array(v.string())),
         selectedCompanies: v.optional(v.array(v.string())),
@@ -379,7 +376,6 @@ export const saveSearchHistory = mutation({
         const title = normalizeOptionalString(args.title) ?? buildHistoryTitle(location, keywords);
         const jobDescriptionId = normalizeOptionalString(args.jobDescriptionId);
         const collectionSource = normalizeCollectionSource(args.collectionSource);
-        const collectUrl = normalizeOptionalString(args.collectUrl);
         const selectedTags = normalizeStringList(args.selectedTags);
         const selectedCompanies = normalizeStringList(args.selectedCompanies);
         const selectedExperienceLevel = normalizeOptionalString(args.selectedExperienceLevel);
@@ -395,7 +391,6 @@ export const saveSearchHistory = mutation({
             keywords,
             jobDescriptionId,
             collectionSource,
-            collectUrl,
             filters: args.filters,
             selectedTags,
             selectedCompanies,


### PR DESCRIPTION
## Summary
- Remove `collectUrl` field from Convex schema (`screening_sessions.config`, `search_history`), mutations (`saveSession`, `saveSearchHistory`), seed data, and the orphaned `backfillCollectionSource` migration
- Add explicit `SOURCE_MARKET_MAP` constant and `getCollectionSourceMarket()` to replace fragile ternary `seek ? 'MY' : 'CN'` inference in QuickStartPanel
- Add 51job workflow seed test, collection source persistence test, and review lane separation test
- Remove unused constants from migrations.ts (`SEEK_HOST_SUFFIX`, `SEEK_RECOMMENDED_PATH`, `JOB51_EHIRE_HOST`)

## Test plan
- [x] `make check` passes (typecheck, lint, API contract sync, governance)
- [x] `npm test` passes (623/623 tests)
- [x] New 51job workflow seed test in QuickStartPanel
- [x] New 51job collection source persistence test in useSession
- [x] New 51job review lane test in useResumeListState