### PR TITLE
fix: use shared resolveResumeAnalysisSourceKey in API, add 51job test coverage

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -104,7 +104,7 @@ import { formatIsoOffsetInTimezone } from "../services/timezone.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { BrandDisplayResolver } from "../services/brand-display-resolver.js";
 
-import { buildKeywordAnalysisId, getCurrentResumeAiPromptVersion } from "@trends/shared";
+import { buildKeywordAnalysisId, getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey } from "@trends/shared";
 import type { ResumeItem } from "../types/resume.js";
 import type { ResumeIndex } from "../services/resume-index.js";
 
@@ -2146,7 +2146,7 @@ function buildAiResumePayload(item: {
     companyHits: item.companyHits,
     roleSignals: item.roleSignals,
     workHistory: buildLatestWorkHistoryEvidence(latestWorkHistory).lines.join("\n") || undefined,
-    sourceKey: item.resume.profileType === "seek" ? "seek" : item.resume.profileType,
+    sourceKey: resolveResumeAnalysisSourceKey({ sourceKey: item.resume.profileType }),
   };
 }
 

--- a/apps/web/src/components/CollectResumesButton.test.tsx
+++ b/apps/web/src/components/CollectResumesButton.test.tsx
@@ -119,4 +119,29 @@ describe('CollectResumesButton', () => {
 
     expect(onCollectionSourceChange).toHaveBeenCalledWith({ type: '51job' })
   })
+
+  it('launches 51job collection URL when 51job is the initial source', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Harness
+        initialCollectionSource={{ type: '51job' }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: 'Source' })).toHaveValue('51job')
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Collect' }))
+
+    const launchedUrl = new URL(openMock.mock.calls[0]?.[0] as string)
+    expect(`${launchedUrl.origin}${launchedUrl.pathname}`).toBe('https://ehire.51job.com/Revision/talent/search')
+    expect(launchedUrl.searchParams.get('keyword')).toBe('"Sales Engineer" OR "Sales Manager"')
+    expect(launchedUrl.searchParams.get('location')).toBe('Kuala Lumpur MY')
+    expect(launchedUrl.searchParams.get('tr_auto_sync')).toBe('true')
+    expect(launchedUrl.searchParams.get('tr_max_pages')).toBe('1')
+    expect(launchedUrl.searchParams.get('tr_min_age')).toBe('28')
+    expect(launchedUrl.searchParams.get('tr_max_age')).toBe('40')
+  })
 })

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -8,6 +8,7 @@ import { getCurrentResumeAiPromptVersion } from '@/lib/analysis-utils'
 import { useResumeListState } from './useResumeListState'
 import type { ConvexResumeFilters, ConvexResumeSortBy } from '@/hooks/useConvexResumes'
 import { buildRuleScoringText } from '@/lib/resume-scoring'
+import type { CollectionSource } from '@/lib/search-profile-sources'
 
 let capturedExportPayload: unknown = null
 const createObjectUrlMock = vi.fn(() => 'blob:mock')
@@ -33,7 +34,7 @@ const mockState = vi.hoisted(() => ({
   sessionLocation: '广东',
   sessionKeywords: [] as string[],
   sessionJobDescriptionId: undefined as string | undefined,
-  sessionCollectionSource: undefined as { type: 'job5156' | '51job' | 'seek'; exactUrl?: string } | undefined,
+  sessionCollectionSource: undefined as CollectionSource | undefined,
   sessionCollectUrl: '' as string,
   blocksByIdentity: {} as Record<string, { identityKey: string }>,
   statusByIdentity: {} as Record<string, CandidateStatusRecord>,


### PR DESCRIPTION
## Summary
- Replace implicit seek-ternary (`profileType === "seek" ? "seek" : profileType`) in resumes API `sourceKey` mapping with `resolveResumeAnalysisSourceKey` from `@trends/shared` for explicit 51job handling
- Import canonical `CollectionSource` type in `useResumeListState.test.tsx` instead of inline type union
- Add `CollectResumesButton` test verifying 51job initial source produces correct `ehire.51job.com` launch URL with age filters

## Test plan
- [x] `make check` passes
- [x] `npm test` passes (623/623)
- [x] New 51job initial source launch URL test in CollectResumesButton