### PR TITLE
Fix recent work history limit sync

### DIFF
--- a/apps/web/src/components/search/SnippetCardExpanded.test.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.test.tsx
@@ -214,6 +214,25 @@ describe('SnippetCardExpanded', () => {
     expect(screen.queryByRole('link', { name: /Open source profile/i })).not.toBeInTheDocument()
   })
 
+  it('uses the shared latest-work-history limit instead of overriding it locally', () => {
+    render(
+      <SnippetCardExpanded
+        item={createResult(6, {
+          resume: createResume(6, {
+            workHistory: [
+              { companyName: 'Current Co', jobTitle: 'Current Role', raw: 'Current raw' },
+              { companyName: 'Recent Co', jobTitle: 'Recent Role', raw: 'Recent raw' },
+              { companyName: 'Middle Co', jobTitle: 'Middle Role', raw: 'Middle raw' },
+              { companyName: 'Older Co', jobTitle: 'Older Role', raw: 'Older raw' },
+            ],
+          }),
+        })}
+      />
+    )
+
+    expect(selectLatestWorkHistoryMock).toHaveBeenCalledWith(expect.any(Array))
+  })
+
   it('shows AI pending text instead of rule scoring when AI mode is enabled and analysis is missing', () => {
     render(
       <SnippetCardExpanded

--- a/apps/web/src/components/search/SnippetCardExpanded.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.tsx
@@ -131,7 +131,7 @@ export function SnippetCardExpanded({ item, showAiScore = false, onViewDetails }
     [fieldUsagePolicy, item.resume]
   )
   const workHistory = useMemo(
-    () => selectLatestWorkHistory(presentationResume.workHistory, { limit: 4 })
+    () => selectLatestWorkHistory(presentationResume.workHistory)
       .map((entry) => normalizeWorkHistoryEntry(entry))
       .filter((entry): entry is NonNullable<ReturnType<typeof normalizeWorkHistoryEntry>> => entry !== null),
     [presentationResume.workHistory]

--- a/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
+++ b/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { listWithIngestDataPaginated } from "../resumes";
+import { getResumeDetail, listWithIngestDataPaginated } from "../resumes";
 
 type ConvexHandler<TArgs, TResult> = {
   _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
@@ -28,6 +28,9 @@ type PaginatedResult = {
 
 const handler = (
   listWithIngestDataPaginated as unknown as ConvexHandler<PaginatedArgs, PaginatedResult>
+)._handler;
+const getResumeDetailHandler = (
+  getResumeDetail as unknown as ConvexHandler<{ resumeId: string }, unknown>
 )._handler;
 
 function buildResumeDoc(id: string, primaryRuleScore: number, ruleScores?: Record<string, number>) {
@@ -237,5 +240,46 @@ describe("listWithIngestDataPaginated", () => {
     expect(result.page).toHaveLength(1);
     expect((result.page[0] as { content: { name: string } }).content.name).toBe("Alice");
     expect(result.continueCursor).toBe("cursor-next");
+  });
+});
+
+describe("getResumeDetail", () => {
+  it("projects only the shared latest three work history entries", async () => {
+    const resume = {
+      _id: "resume-1",
+      externalId: "test:resume-1",
+      source: "test",
+      tags: [],
+      crawledAt: Date.now(),
+      content: {
+        name: "Alice",
+        workHistory: [
+          { companyName: "Oldest Co", jobTitle: "Oldest Role", startDate: "2018-01", endDate: "2019-01", raw: "Oldest raw" },
+          { companyName: "Recent Co", jobTitle: "Recent Role", startDate: "2023-01", endDate: "2024-01", raw: "Recent raw" },
+          { companyName: "Current Co", jobTitle: "Current Role", startDate: "2024-02", endDate: "至今", raw: "Current raw" },
+          { companyName: "Middle Co", jobTitle: "Middle Role", startDate: "2021-01", endDate: "2022-01", raw: "Middle raw" },
+        ],
+      },
+    };
+
+    const result = await getResumeDetailHandler({
+      db: {
+        get: async () => resume,
+      },
+    }, {
+      resumeId: "resume-1",
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      content: expect.objectContaining({
+        workHistory: [
+          expect.objectContaining({ companyName: "Current Co", jobTitle: "Current Role" }),
+          expect.objectContaining({ companyName: "Recent Co", jobTitle: "Recent Role" }),
+          expect.objectContaining({ companyName: "Middle Co", jobTitle: "Middle Role" }),
+        ],
+      }),
+    }));
+    expect((result as { content: { workHistory: Array<{ companyName?: string }> } }).content.workHistory).toHaveLength(3);
+    expect((result as { content: { workHistory: Array<{ companyName?: string }> } }).content.workHistory.some((entry) => entry.companyName === "Oldest Co")).toBe(false);
   });
 });

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -553,7 +553,7 @@ function projectResumeListContent(resume: Doc<"resumes">): Record<string, unknow
 
 function projectResumeDetailContent(resume: Doc<"resumes">): Record<string, unknown> {
     const content = isRecord(resume.content) ? resume.content : {};
-    const workHistory = Array.isArray(content.workHistory) ? content.workHistory : [];
+    const workHistory = selectLatestWorkHistory(content.workHistory);
     return projectResumeBaseContent(resume, workHistory);
 }
 


### PR DESCRIPTION
## Summary\n- remove the expanded search card's local four-entry override so it uses the shared latest-work-history limit\n- trim the Convex detail projection to the same shared latest-three work-history slice\n- add regression coverage for both the web component and Convex detail query\n\n## Testing\n- npm --workspace @trends/web run test -- SnippetCardExpanded.test.tsx\n- npm --workspace @trends/web run test -- ResumeDetail.test.tsx\n- npm --workspace @trends/web run test -- ResumeCard.test.tsx\n- npm test -- packages/convex/convex/__tests__/resumes-paginated-default.test.ts\n- make check