### PR TITLE
Add push/pull sample snapshot scripts and Makefile targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ output/*
 !output/benchmarks/
 output/benchmarks/*
 !output/benchmarks/.gitkeep
+output/resume-samples/
+!output/resume-samples/.gitkeep
 # Logs
 *.log
 logs/

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,8 @@ output/*
 !output/benchmarks/
 output/benchmarks/*
 !output/benchmarks/.gitkeep
-output/resume-samples/
+!output/resume-samples/
+output/resume-samples/*
 !output/resume-samples/.gitkeep
 # Logs
 *.log

--- a/Makefile
+++ b/Makefile
@@ -387,6 +387,30 @@ restore-resumes-restart:
 	@$(MAKE) restore-resumes API_URL="$(API_URL)" WORKSPACE="$(WORKSPACE)" FILE="$(FILE)" MODE="$(MODE)" YES="$(YES)"
 	@$(MAKE) dev-convex-refresh
 
+# Push latest resume snapshot to the sample repo (karlcc/trends-resume-samples)
+push-sample-snapshots:
+	@SAMPLE_REPO="$${SAMPLE_REPO:-karlcc/trends-resume-samples}" \
+	SNAPSHOT_DIR="$${SNAPSHOT_DIR:-}"; \
+	if command -v bun >/dev/null 2>&1; then \
+		bun run scripts/resume/push-sample-snapshots.ts; \
+	else \
+		npx tsx scripts/resume/push-sample-snapshots.ts; \
+	fi
+
+# Pull resume snapshots from the sample repo into output/resume-samples
+pull-sample-snapshots:
+	@SAMPLE_REPO="$${SAMPLE_REPO:-karlcc/trends-resume-samples}" \
+	OUT_DIR="$${OUT_DIR:-}"; \
+	if command -v bun >/dev/null 2>&1; then \
+		bun run scripts/resume/pull-sample-snapshots.ts; \
+	else \
+		npx tsx scripts/resume/pull-sample-snapshots.ts; \
+	fi
+
+# Pull snapshots and restore in one step
+restore-sample-snapshots: pull-sample-snapshots
+	@$(MAKE) restore-resumes FILE=output/resume-samples
+
 # Clear resume AI analyses directly in Convex, batching large datasets safely
 clear-resume-analyses:
 	@batch_size="$${BATCH_SIZE:-50}"; \

--- a/Makefile
+++ b/Makefile
@@ -387,7 +387,7 @@ restore-resumes-restart:
 	@$(MAKE) restore-resumes API_URL="$(API_URL)" WORKSPACE="$(WORKSPACE)" FILE="$(FILE)" MODE="$(MODE)" YES="$(YES)"
 	@$(MAKE) dev-convex-refresh
 
-# Push latest resume snapshot to the sample repo (karlcc/trends-resume-samples)
+# Push latest resume snapshot to the sample repo (ptdevhk/trends-resume-samples)
 push-sample-snapshots:
 	@SAMPLE_REPO="$${SAMPLE_REPO:-ptdevhk/trends-resume-samples}" \
 	SNAPSHOT_DIR="$${SNAPSHOT_DIR:-}"; \

--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ restore-resumes-restart:
 
 # Push latest resume snapshot to the sample repo (karlcc/trends-resume-samples)
 push-sample-snapshots:
-	@SAMPLE_REPO="$${SAMPLE_REPO:-karlcc/trends-resume-samples}" \
+	@SAMPLE_REPO="$${SAMPLE_REPO:-ptdevhk/trends-resume-samples}" \
 	SNAPSHOT_DIR="$${SNAPSHOT_DIR:-}"; \
 	if command -v bun >/dev/null 2>&1; then \
 		bun run scripts/resume/push-sample-snapshots.ts; \
@@ -399,7 +399,7 @@ push-sample-snapshots:
 
 # Pull resume snapshots from the sample repo into output/resume-samples
 pull-sample-snapshots:
-	@SAMPLE_REPO="$${SAMPLE_REPO:-karlcc/trends-resume-samples}" \
+	@SAMPLE_REPO="$${SAMPLE_REPO:-ptdevhk/trends-resume-samples}" \
 	OUT_DIR="$${OUT_DIR:-}"; \
 	if command -v bun >/dev/null 2>&1; then \
 		bun run scripts/resume/pull-sample-snapshots.ts; \

--- a/scripts/resume/pull-sample-snapshots.ts
+++ b/scripts/resume/pull-sample-snapshots.ts
@@ -6,7 +6,7 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFileCallback);
 
-const DEFAULT_SAMPLE_REPO = "karlcc/trends-resume-samples";
+const DEFAULT_SAMPLE_REPO = "ptdevhk/trends-resume-samples";
 const DEFAULT_OUT_DIR = "output/resume-samples";
 
 function resolveRepoRoot(): string {

--- a/scripts/resume/pull-sample-snapshots.ts
+++ b/scripts/resume/pull-sample-snapshots.ts
@@ -2,15 +2,17 @@ import { execFile as execFileCallback } from "node:child_process";
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFileCallback);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const DEFAULT_SAMPLE_REPO = "ptdevhk/trends-resume-samples";
 const DEFAULT_OUT_DIR = "output/resume-samples";
 
 function resolveRepoRoot(): string {
-  return path.resolve(import.meta.dirname, "../..");
+  return path.resolve(__dirname, "../..");
 }
 
 function resolveSampleRepo(): string {
@@ -68,7 +70,7 @@ async function mkdtemp(prefix: string): Promise<string> {
 }
 
 const isMainModule = process.argv[1]
-  ? path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)
+  ? path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
   : false;
 
 if (isMainModule) {

--- a/scripts/resume/pull-sample-snapshots.ts
+++ b/scripts/resume/pull-sample-snapshots.ts
@@ -1,0 +1,79 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFileCallback);
+
+const DEFAULT_SAMPLE_REPO = "karlcc/trends-resume-samples";
+const DEFAULT_OUT_DIR = "output/resume-samples";
+
+function resolveRepoRoot(): string {
+  return path.resolve(import.meta.dirname, "../..");
+}
+
+function resolveSampleRepo(): string {
+  return process.env.SAMPLE_REPO?.trim() || DEFAULT_SAMPLE_REPO;
+}
+
+function resolveOutDir(): string {
+  const override = process.env.OUT_DIR?.trim();
+  const resolved = override || DEFAULT_OUT_DIR;
+  return path.isAbsolute(resolved) ? resolved : path.resolve(resolveRepoRoot(), resolved);
+}
+
+async function main(): Promise<void> {
+  const repoRoot = resolveRepoRoot();
+  const sampleRepo = resolveSampleRepo();
+  const outDir = resolveOutDir();
+
+  console.log(`Sample repo: ${sampleRepo}`);
+  console.log(`Output dir:  ${outDir}`);
+
+  const tempDir = await mkdtemp("trends-pull-samples-");
+  try {
+    console.log(`Cloning ${sampleRepo}...`);
+    await execFileAsync("git", ["clone", "--depth=1", `https://github.com/${sampleRepo}.git`, tempDir]);
+
+    const snapshotsDir = path.join(tempDir, "snapshots");
+    const files = await readdir(snapshotsDir).catch(() => [] as string[]);
+    const jsonFiles = files.filter((f) => f.endsWith(".json")).sort();
+
+    if (jsonFiles.length === 0) {
+      throw new Error(`no .json files found in snapshots/ directory of ${sampleRepo}`);
+    }
+
+    await mkdir(outDir, { recursive: true });
+
+    for (const fileName of jsonFiles) {
+      const srcPath = path.join(snapshotsDir, fileName);
+      const destPath = path.join(outDir, fileName);
+      const content = await readFile(srcPath, "utf8");
+      await writeFile(destPath, content, "utf8");
+      console.log(`  ${fileName}`);
+    }
+
+    console.log(`\nPulled ${jsonFiles.length} snapshot file(s) to ${outDir}`);
+    console.log(`\nTo restore, run:\n  make restore-resumes FILE=${outDir}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function mkdtemp(prefix: string): Promise<string> {
+  const dir = path.join(os.tmpdir(), prefix + Math.random().toString(36).slice(2));
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+const isMainModule = process.argv[1]
+  ? path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)
+  : false;
+
+if (isMainModule) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/resume/push-sample-snapshots.ts
+++ b/scripts/resume/push-sample-snapshots.ts
@@ -1,0 +1,208 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFileCallback);
+
+const DEFAULT_SAMPLE_REPO = "karlcc/trends-resume-samples";
+const DEFAULT_BACKUPS_DIR = "output/resume-backups";
+
+function resolveRepoRoot(): string {
+  return path.resolve(import.meta.dirname, "../..");
+}
+
+function resolveSampleRepo(): string {
+  return process.env.SAMPLE_REPO?.trim() || DEFAULT_SAMPLE_REPO;
+}
+
+function resolveSnapshotDir(): string {
+  const override = process.env.SNAPSHOT_DIR?.trim();
+  if (override) {
+    return path.isAbsolute(override) ? override : path.resolve(resolveRepoRoot(), override);
+  }
+  return "";
+}
+
+async function findLatestSnapshotDir(backupsDir: string): Promise<string> {
+  const entries = await readdir(backupsDir, { withFileTypes: true });
+  const dirs = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => /^\d{8}-\d{6}$/.test(name))
+    .sort();
+
+  if (dirs.length === 0) {
+    throw new Error(`no snapshot directories found in ${backupsDir}`);
+  }
+
+  for (let i = dirs.length - 1; i >= 0; i--) {
+    const candidate = path.join(backupsDir, dirs[i]);
+    const files = await readdir(candidate);
+    const jsonFiles = files.filter((f) => f.endsWith(".json"));
+    if (jsonFiles.length > 0) {
+      return candidate;
+    }
+  }
+
+  throw new Error(`no snapshot directories with .json files found in ${backupsDir}`);
+}
+
+async function execGit(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout.trim();
+}
+
+interface SnapshotFile {
+  name: string;
+  resumeCount: number;
+  source: string;
+}
+
+function parseResumeCount(raw: string): number {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      const resumes = (parsed as Record<string, unknown>).resumes;
+      if (Array.isArray(resumes)) return resumes.length;
+      const data = (parsed as Record<string, unknown>).data;
+      if (Array.isArray(data)) return data.length;
+    }
+    return 0;
+  } catch {
+    return 0;
+  }
+}
+
+function extractSource(fileName: string): string {
+  const match = /^resume-backup-(.+)-top\d+-/.exec(fileName);
+  return match ? match[1] : "unknown";
+}
+
+async function generateReadme(snapshotFiles: SnapshotFile[], timestamp: string): Promise<string> {
+  const totalResumes = snapshotFiles.reduce((sum, f) => sum + f.resumeCount, 0);
+  const lines = [
+    "# Trends Resume Sample Snapshots",
+    "",
+    `Last updated: ${new Date().toISOString()}`,
+    `Source timestamp: ${timestamp}`,
+    `Total resume files: ${snapshotFiles.length}`,
+    `Total resumes: ${totalResumes}`,
+    "",
+    "## Files",
+    "",
+    "| File | Source | Resumes |",
+    "|------|--------|---------|",
+  ];
+
+  for (const f of snapshotFiles) {
+    lines.push(`| ${f.name} | ${f.source} | ${f.resumeCount} |`);
+  }
+
+  lines.push("");
+  lines.push("## Usage");
+  lines.push("");
+  lines.push("```bash");
+  lines.push("# Pull snapshots into local environment");
+  lines.push("make pull-sample-snapshots");
+  lines.push("");
+  lines.push("# Pull and restore in one step");
+  lines.push("make restore-sample-snapshots");
+  lines.push("```");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  const repoRoot = resolveRepoRoot();
+  const sampleRepo = resolveSampleRepo();
+  const backupsDir = path.resolve(repoRoot, DEFAULT_BACKUPS_DIR);
+
+  const snapshotDir = resolveSnapshotDir() || await findLatestSnapshotDir(backupsDir);
+  const timestamp = path.basename(snapshotDir);
+
+  console.log(`Snapshot dir: ${snapshotDir}`);
+  console.log(`Sample repo:  ${sampleRepo}`);
+
+  const snapshotFiles = await readdir(snapshotDir);
+  const jsonFiles = snapshotFiles.filter((f) => f.endsWith(".json")).sort();
+
+  if (jsonFiles.length === 0) {
+    throw new Error(`no .json files found in ${snapshotDir}`);
+  }
+
+  const tempDir = await mkdtemp("trends-push-samples-");
+  try {
+    console.log(`Cloning ${sampleRepo}...`);
+    await execFileAsync("git", ["clone", "--depth=1", `https://github.com/${sampleRepo}.git`, tempDir]);
+
+    const snapshotsDir = path.join(tempDir, "snapshots");
+    await mkdir(snapshotsDir, { recursive: true });
+
+    const existingFiles = await readdir(snapshotsDir).catch(() => [] as string[]);
+    for (const f of existingFiles) {
+      await rm(path.join(snapshotsDir, f), { recursive: true, force: true });
+    }
+
+    const fileSummaries: SnapshotFile[] = [];
+    for (const fileName of jsonFiles) {
+      const srcPath = path.join(snapshotDir, fileName);
+      const destPath = path.join(snapshotsDir, fileName);
+      const content = await readFile(srcPath, "utf8");
+      await writeFile(destPath, content, "utf8");
+
+      fileSummaries.push({
+        name: fileName,
+        resumeCount: parseResumeCount(content),
+        source: extractSource(fileName),
+      });
+    }
+
+    const readme = await generateReadme(fileSummaries, timestamp);
+    await writeFile(path.join(tempDir, "README.md"), readme, "utf8");
+
+    await execGit(["add", "-A"], tempDir);
+
+    const diffResult = await execGit(["diff", "--cached", "--quiet"], tempDir).then(
+      () => "no-changes",
+      (err: unknown) => {
+        if (err instanceof Error && err.message.includes("non-zero")) return "has-changes";
+        throw err;
+      },
+    );
+
+    if (diffResult === "no-changes") {
+      console.log("No changes to push — snapshots are up to date.");
+      return;
+    }
+
+    await execGit(["commit", "-m", `Update sample snapshots from ${timestamp}`], tempDir);
+    await execGit(["push", "origin", "main"], tempDir);
+
+    console.log(`Pushed ${jsonFiles.length} snapshot file(s) to ${sampleRepo}`);
+    for (const f of fileSummaries) {
+      console.log(`  ${f.name} (${f.source}, ${f.resumeCount} resumes)`);
+    }
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function mkdtemp(prefix: string): Promise<string> {
+  const dir = path.join(os.tmpdir(), prefix + Math.random().toString(36).slice(2));
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+const isMainModule = process.argv[1]
+  ? path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)
+  : false;
+
+if (isMainModule) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/resume/push-sample-snapshots.ts
+++ b/scripts/resume/push-sample-snapshots.ts
@@ -2,15 +2,17 @@ import { execFile as execFileCallback } from "node:child_process";
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFileCallback);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const DEFAULT_SAMPLE_REPO = "ptdevhk/trends-resume-samples";
 const DEFAULT_BACKUPS_DIR = "output/resume-backups";
 
 function resolveRepoRoot(): string {
-  return path.resolve(import.meta.dirname, "../..");
+  return path.resolve(__dirname, "../..");
 }
 
 function resolveSampleRepo(): string {
@@ -165,15 +167,14 @@ async function main(): Promise<void> {
 
     await execGit(["add", "-A"], tempDir);
 
-    const diffResult = await execGit(["diff", "--cached", "--quiet"], tempDir).then(
-      () => "no-changes",
-      (err: unknown) => {
-        if (err instanceof Error && err.message.includes("non-zero")) return "has-changes";
-        throw err;
-      },
-    );
+    let hasChanges = false;
+    try {
+      await execGit(["diff", "--cached", "--quiet"], tempDir);
+    } catch {
+      hasChanges = true;
+    }
 
-    if (diffResult === "no-changes") {
+    if (!hasChanges) {
       console.log("No changes to push — snapshots are up to date.");
       return;
     }
@@ -197,7 +198,7 @@ async function mkdtemp(prefix: string): Promise<string> {
 }
 
 const isMainModule = process.argv[1]
-  ? path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)
+  ? path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
   : false;
 
 if (isMainModule) {

--- a/scripts/resume/push-sample-snapshots.ts
+++ b/scripts/resume/push-sample-snapshots.ts
@@ -6,7 +6,7 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFileCallback);
 
-const DEFAULT_SAMPLE_REPO = "karlcc/trends-resume-samples";
+const DEFAULT_SAMPLE_REPO = "ptdevhk/trends-resume-samples";
 const DEFAULT_BACKUPS_DIR = "output/resume-backups";
 
 function resolveRepoRoot(): string {


### PR DESCRIPTION
## Summary
- Add `scripts/resume/push-sample-snapshots.ts` — pushes latest resume snapshot dir to `karlcc/trends-resume-samples` repo with auto-generated README manifest
- Add `scripts/resume/pull-sample-snapshots.ts` — pulls snapshots from the sample repo into `output/resume-samples/`
- Add Makefile targets: `push-sample-snapshots`, `pull-sample-snapshots`, `restore-sample-snapshots` (pull + restore in one step)
- Add `.gitignore` entry for `output/resume-samples/` (pulled data, not tracked)

## Test plan
- [ ] Create the GitHub repo: `gh repo create karlcc/trends-resume-samples --private`
- [ ] Run `make push-sample-snapshots` — verify files appear in the repo
- [ ] Delete local `output/resume-samples/`, run `make pull-sample-snapshots` — verify files restored
- [ ] Run `make restore-sample-snapshots` — verify resumes imported into dev workspace