### PR TITLE
fix: handle 至今 (present) end date in parseRoleYears

### DIFF
--- a/apps/api/src/services/work-history.ts
+++ b/apps/api/src/services/work-history.ts
@@ -32,6 +32,23 @@ export function parseRoleYears(raw: string): number {
     }
   }
 
+  // Handle 至今/present as end date: compute duration from start date to now.
+  // Covers 51job-live format "YYYY-MM~至今 · ..." where endDate has no year digits.
+  const presentEndMatch = text.match(/(\d{4})[-./年](\d{1,2})?[^0-9]*(?:至今|目前|今|present|current|now|ongoing)/iu);
+  if (presentEndMatch) {
+    const startYear = Number(presentEndMatch[1]);
+    const startMonth = Number(presentEndMatch[2] || 1);
+    const now = new Date();
+    const endYear = now.getFullYear();
+    const endMonth = now.getMonth() + 1;
+    if (Number.isFinite(startYear) && Number.isFinite(startMonth)) {
+      const monthDiff = (endYear - startYear) * 12 + (endMonth - startMonth);
+      if (monthDiff > 0) {
+        return monthDiff / 12;
+      }
+    }
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
## Summary
- `parseRoleYears` range regex requires two 4-digit end years — `至今` has none, so `YYYY-MM~至今` always returned 0
- 51job-live resumes use this format without the `(7年5月)` duration hint that job5156/manual resumes embed
- 9/20 51job-live resumes had sales `roleRelevantYears=0`, causing wrong `minRoleYears` filter results and suppressed scores
- Added a present-end branch: match `YYYY-MM~至今/present/current` and compute from start date to current date
- Explicit duration `(Nyear Mmonth)` and concrete end-date ranges still take precedence (no change to existing behavior)

## Test plan
- [ ] `npm test apps/api/src/services/ingest-compute-service.test.ts` — all 34 pass
- [ ] `make check-node` — typecheck + lint clean
- [ ] After merge: `make trigger-reingest` to recompute roleSignals for existing 51job-live resumes