### PR TITLE
fix: treat minExperience=0 as no minimum in resume list filter

### DIFF
--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -751,12 +751,13 @@ function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFil
 
     const content = isRecord(resume.content) ? resume.content : {};
 
-    if (filters.minExperience !== undefined || filters.maxExperience !== undefined) {
+    const effectiveMinExperience = (filters.minExperience ?? 0) > 0 ? filters.minExperience : undefined;
+    if (effectiveMinExperience !== undefined || filters.maxExperience !== undefined) {
         const experience = parseExperienceYears(toStringValue(content.experience));
         if (experience === null) {
             return false;
         }
-        if (filters.minExperience !== undefined && experience < filters.minExperience) {
+        if (effectiveMinExperience !== undefined && experience < effectiveMinExperience) {
             return false;
         }
         if (filters.maxExperience !== undefined && experience > filters.maxExperience) {


### PR DESCRIPTION
## Summary
- `minRoleYears=0` in the URL maps to `minExperience=0` in the Convex query filter
- `matchesResumeListFilters` was entering the experience check when `minExperience=0` and excluding all resumes with empty/null `experience` fields
- job5156 resumes all have `experience: ""`, so `minRoleYears=0` in the URL caused 0 results
- Fix: treat `minExperience=0` as "no minimum" (equivalent to undefined) so resumes with unknown experience are only excluded when a genuine positive minimum (e.g. `minExperience=2`) is set

## Test plan
- [ ] Verify `minRoleYears=0` in the URL returns resumes with empty `experience` fields
- [ ] Verify `minRoleYears=2` still correctly filters out resumes with less than 2 years
- [ ] CI checks pass