### PR TITLE
fix: treat minExperience=0 as no minimum in resume list filter

### DIFF
--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -571,12 +571,13 @@ export class ResumeService {
 
   filterResumes<T extends ResumeItem>(items: T[], filters?: ResumeFilters): T[] {
     if (!filters) return items;
+    const effectiveMinExperience = (filters.minExperience ?? 0) > 0 ? filters.minExperience : undefined;
 
     return items.filter((item) => {
-      if (filters.minExperience !== undefined || filters.maxExperience !== undefined) {
+      if (effectiveMinExperience !== undefined || filters.maxExperience !== undefined) {
         const experience = parseExperienceYears(item.experience);
         if (experience === null) return false;
-        if (filters.minExperience !== undefined && experience < filters.minExperience) return false;
+        if (effectiveMinExperience !== undefined && experience < effectiveMinExperience) return false;
         if (filters.maxExperience !== undefined && experience > filters.maxExperience) return false;
       }
 

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -618,7 +618,7 @@ export function useResumeListState(loadSearchHistory = false) {
   )
   const convexSourceFilters = useMemo<ConvexResumeFilters | undefined>(() => {
     const normalized: ConvexResumeFilters = {
-      ...(typeof filters.minExperience === 'number' ? { minExperience: filters.minExperience } : {}),
+      ...(typeof filters.minExperience === 'number' && filters.minExperience > 0 ? { minExperience: filters.minExperience } : {}),
       ...(typeof filters.maxExperience === 'number' ? { maxExperience: filters.maxExperience } : {}),
       ...(Array.isArray(filters.education) && filters.education.length > 0 ? { education: filters.education } : {}),
       ...(Array.isArray(filters.skills) && filters.skills.length > 0 ? { skills: filters.skills } : {}),
@@ -1182,7 +1182,7 @@ export function useResumeListState(loadSearchHistory = false) {
     }
 
     const minExperience = filters.minExperience
-    if (typeof minExperience === 'number') {
+    if (typeof minExperience === 'number' && minExperience > 0) {
       result = result.filter((resume: ScoredConvexResume) => parseExperienceYears(resume.experience) >= minExperience)
     }
 
@@ -2063,7 +2063,7 @@ export function useResumeListState(loadSearchHistory = false) {
     }) => {
       setFilters((current) => ({
         ...current,
-        minExperience: constraints.minRoleYears,
+        minExperience: (constraints.minRoleYears ?? 0) > 0 ? constraints.minRoleYears : undefined,
         minRoleYears: constraints.minRoleYears,
         roleFilterType: normalizeOptionalString(constraints.roleFilterType),
         maxAge: constraints.maxAge,

--- a/apps/web/src/hooks/useUrlSearchState.ts
+++ b/apps/web/src/hooks/useUrlSearchState.ts
@@ -202,7 +202,9 @@ export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchSta
   const minRoleYears = parseNumberParam(searchParams.get('minRoleYears'))
   if (typeof minRoleYears === 'number') {
     filters.minRoleYears = minRoleYears
-    filters.minExperience = minRoleYears
+    if (minRoleYears > 0) {
+      filters.minExperience = minRoleYears
+    }
   }
 
   const roleFilterType = searchParams.get('roleType')?.trim()
@@ -315,7 +317,7 @@ export function useUrlSearchState() {
         const canonicalMinRoleYears =
           typeof state.filters.minRoleYears === 'number' && Number.isFinite(state.filters.minRoleYears)
             ? state.filters.minRoleYears
-            : (typeof state.filters.minExperience === 'number' && Number.isFinite(state.filters.minExperience)
+            : (typeof state.filters.minExperience === 'number' && Number.isFinite(state.filters.minExperience) && state.filters.minExperience > 0
                 ? state.filters.minExperience
                 : undefined)
         if (typeof canonicalMinRoleYears === 'number') {

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -751,12 +751,13 @@ function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFil
 
     const content = isRecord(resume.content) ? resume.content : {};
 
-    if (filters.minExperience !== undefined || filters.maxExperience !== undefined) {
+    const effectiveMinExperience = (filters.minExperience ?? 0) > 0 ? filters.minExperience : undefined;
+    if (effectiveMinExperience !== undefined || filters.maxExperience !== undefined) {
         const experience = parseExperienceYears(toStringValue(content.experience));
         if (experience === null) {
             return false;
         }
-        if (filters.minExperience !== undefined && experience < filters.minExperience) {
+        if (effectiveMinExperience !== undefined && experience < effectiveMinExperience) {
             return false;
         }
         if (filters.maxExperience !== undefined && experience > filters.maxExperience) {

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -647,7 +647,7 @@ function normalizeResumeListFilters(filters: ResumeListFilterArgs | undefined): 
     const locations = filters.locations?.map((value) => value.trim()).filter((value) => value.length > 0);
 
     const normalized: ResumeListFilterArgs = {
-        ...(filters.minExperience === undefined ? {} : { minExperience: filters.minExperience }),
+        ...((filters.minExperience ?? 0) > 0 ? { minExperience: filters.minExperience } : {}),
         ...(filters.maxExperience === undefined ? {} : { maxExperience: filters.maxExperience }),
         ...(education && education.length > 0 ? { education } : {}),
         ...(skills && skills.length > 0 ? { skills } : {}),
@@ -751,13 +751,12 @@ function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFil
 
     const content = isRecord(resume.content) ? resume.content : {};
 
-    const effectiveMinExperience = (filters.minExperience ?? 0) > 0 ? filters.minExperience : undefined;
-    if (effectiveMinExperience !== undefined || filters.maxExperience !== undefined) {
+    if (filters.minExperience !== undefined || filters.maxExperience !== undefined) {
         const experience = parseExperienceYears(toStringValue(content.experience));
         if (experience === null) {
             return false;
         }
-        if (effectiveMinExperience !== undefined && experience < effectiveMinExperience) {
+        if (filters.minExperience !== undefined && experience < filters.minExperience) {
             return false;
         }
         if (filters.maxExperience !== undefined && experience > filters.maxExperience) {


### PR DESCRIPTION
## Summary
- Fix `minExperience=0` being treated as a valid filter instead of "no minimum", causing resumes with no experience data to be excluded
- Update Convex query, API service, and frontend hooks to consistently treat `0` as unset for the minimum experience filter

## Test plan
- [ ] Verify resume list with minExperience=0 returns all resumes (no filtering)
- [ ] Verify resume list with minExperience>0 correctly filters by experience
- [ ] Verify URL state correctly round-trips 0 as no filter