### PR TITLE
fix: enforce sales role years in resume search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,7 +409,7 @@ pull-sample-snapshots:
 
 # Pull snapshots and restore in one step
 restore-sample-snapshots: pull-sample-snapshots
-	@$(MAKE) restore-resumes FILE=output/resume-samples
+	@$(MAKE) restore-resumes FILE=output/resume-samples RECOMPUTE_DERIVED_FIELDS=1
 
 # Clear resume AI analyses directly in Convex, batching large datasets safely
 clear-resume-analyses:

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -117,6 +117,12 @@ export const ResumeImportRestoreStateSchema = z
   })
   .openapi("ResumeImportRestoreState");
 
+export const ResumeImportOptionsSchema = z
+  .object({
+    recomputeDerivedFields: z.boolean().optional().openapi({ example: true }),
+  })
+  .openapi("ResumeImportOptions");
+
 const ResumeStructuredDetailsShape = {
   profileEducation: z.array(ResumeImportProfileEducationSchema).optional(),
   projectExperience: z.array(ResumeImportWorkHistorySchema).optional(),
@@ -294,6 +300,7 @@ export const ResumeImportRequestSchema = z
     metadata: ResumeImportMetadataSchema,
     resumes: z.array(ResumeImportItemSchema).optional(),
     data: z.array(ResumeImportItemSchema).optional(),
+    options: ResumeImportOptionsSchema.optional(),
   })
   .superRefine((value, ctx) => {
     if (!value.resumes && !value.data) {

--- a/apps/api/src/services/ingest-compute-service.test.ts
+++ b/apps/api/src/services/ingest-compute-service.test.ts
@@ -493,6 +493,33 @@ describe("IngestComputeService", () => {
     expect(salesRole?.years).toBeGreaterThan(3);
   });
 
+  it("should use extractedAt as a stable anchor for ongoing role years", () => {
+    const ongoingResume = {
+      data: [
+        {
+          ...SAMPLE_RESUME_CNC_SALES.data[0],
+          extractedAt: "2026-02-21T10:00:00.000Z",
+          workHistory: [
+            {
+              raw: "2021-03~至今 东莞精密机械有限公司销售主管",
+              companyName: "东莞精密机械有限公司",
+              jobTitle: "销售主管",
+              startDate: "2021-03",
+              endDate: "至今",
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = service.computeOne("resume-ongoing", ongoingResume);
+    const salesRole = result.roleSignals.find((item) => item.type === "sales");
+    const index = buildResumeIndex(ongoingResume.data[0], 0);
+
+    expect(index.experienceYears).toBeCloseTo(4.9, 1);
+    expect(salesRole?.years).toBeCloseTo(4.92, 1);
+  });
+
   it("should build tagging envelope with confidence and provenance", () => {
     const result = service.computeOne("resume-123", SAMPLE_RESUME_CNC_SALES);
 

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -395,6 +395,14 @@ interface RoleSignalMatch {
   source: RoleSignalMatchSource;
 }
 
+function resolveRoleYearsAnchor(item: ResumeItem): Date {
+  const extractedAt = item.extractedAt ? Date.parse(item.extractedAt) : Number.NaN;
+  if (Number.isFinite(extractedAt)) {
+    return new Date(extractedAt);
+  }
+  return new Date();
+}
+
 /**
  * Build a single ResumeIndex from a ResumeItem
  * (extracted helper from ResumeIndexService.buildIndex)
@@ -405,12 +413,13 @@ export function buildResumeIndex(item: ResumeItem, index: number): ResumeIndex {
   const searchText = createSearchText(item);
   const companies = extractCompanies(latestWorkHistory);
   const evidenceText = buildLatestWorkHistoryEvidence(latestWorkHistory).text;
+  const roleYearsAnchor = resolveRoleYearsAnchor(item);
 
   // For ingest compute, we don't need full skill extraction
   // We just need the basic fields for rule scoring
   return {
     resumeId,
-    experienceYears: computeWorkHistoryYears(latestWorkHistory),
+    experienceYears: computeWorkHistoryYears(latestWorkHistory, roleYearsAnchor),
     educationLevel: normalizeEducationLevel(item.education),
     locationCity: item.locationHierarchy?.city
       || item.locationHierarchy?.province
@@ -465,7 +474,8 @@ export class IngestComputeService {
       companyHits,
       brandHits
     );
-    const roleSignals = this.computeRoleSignals(latestWorkHistory);
+    const roleYearsAnchor = resolveRoleYearsAnchor(item);
+    const roleSignals = this.computeRoleSignals(latestWorkHistory, roleYearsAnchor);
     const companyPatternAliasTokens = this.buildCompanyAliasTokens(companyHits, brandHits);
 
     // 4. Compute ruleScores for all active JDs
@@ -583,7 +593,7 @@ export class IngestComputeService {
   }
 
 
-  private computeRoleSignals(workHistory: ResumeWorkHistoryItem[]): RoleSignalSummary[] {
+  private computeRoleSignals(workHistory: ResumeWorkHistoryItem[], anchorDate: Date): RoleSignalSummary[] {
     if (!Array.isArray(workHistory) || workHistory.length === 0) {
       return [];
     }
@@ -605,7 +615,7 @@ export class IngestComputeService {
       }
 
       const normalizedEntry = normalizeWorkHistoryEntry(entry);
-      const years = Number(computeEntryRoleYears(entry).toFixed(2));
+      const years = Number(computeEntryRoleYears(entry, anchorDate).toFixed(2));
 
       const companyName = normalizedEntry?.companyName || extractCompanyFromWorkHistory(entry) || undefined;
       const jobTitle = normalizedEntry?.jobTitle || undefined;

--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -36,6 +36,10 @@ type ConvexResumeRestoreState = {
   analyses?: unknown;
 };
 
+export type ResumeImportOptions = {
+  recomputeDerivedFields?: boolean;
+};
+
 type ConvexResumeSubmitItem = {
   externalId: string;
   content: unknown;
@@ -50,6 +54,7 @@ export type NormalizedResumeImportPayload = {
   resumes: ResumeImportItem[];
   source: string;
   tags: string[];
+  options: ResumeImportOptions;
   convexResumes: ConvexResumeSubmitItem[];
 };
 
@@ -192,7 +197,10 @@ function normalizeCandidateId(value: string | undefined): string | null {
   return normalizeOptionalString(value);
 }
 
-function normalizeRestoreState(value: ResumeImportRestoreState | undefined): ConvexResumeRestoreState | undefined {
+function normalizeRestoreState(
+  value: ResumeImportRestoreState | undefined,
+  options: ResumeImportOptions = {},
+): ConvexResumeRestoreState | undefined {
   if (!value) {
     return undefined;
   }
@@ -202,25 +210,27 @@ function normalizeRestoreState(value: ResumeImportRestoreState | undefined): Con
     normalized.crawledAt = value.crawledAt;
   }
 
-  const searchText = normalizeOptionalString(value.searchText);
-  if (searchText) {
-    normalized.searchText = searchText;
-  }
+  if (!options.recomputeDerivedFields) {
+    const searchText = normalizeOptionalString(value.searchText);
+    if (searchText) {
+      normalized.searchText = searchText;
+    }
 
-  if (typeof value.primaryRuleScore === "number" && Number.isFinite(value.primaryRuleScore)) {
-    normalized.primaryRuleScore = value.primaryRuleScore;
-  }
+    if (typeof value.primaryRuleScore === "number" && Number.isFinite(value.primaryRuleScore)) {
+      normalized.primaryRuleScore = value.primaryRuleScore;
+    }
 
-  if (value.ingestData !== undefined) {
-    normalized.ingestData = value.ingestData;
-  }
+    if (value.ingestData !== undefined) {
+      normalized.ingestData = value.ingestData;
+    }
 
-  if (value.analysis !== undefined) {
-    normalized.analysis = value.analysis;
-  }
+    if (value.analysis !== undefined) {
+      normalized.analysis = value.analysis;
+    }
 
-  if (value.analyses !== undefined) {
-    normalized.analyses = value.analyses;
+    if (value.analyses !== undefined) {
+      normalized.analyses = value.analyses;
+    }
   }
 
   return Object.keys(normalized).length > 0 ? normalized : undefined;
@@ -330,6 +340,9 @@ export function normalizeResumeImportPayload(input: ResumeImportRequest): Normal
   const parsedInput = ResumeImportRequestSchema.parse(input);
   const metadata = normalizeImportMetadata(parsedInput.metadata);
   const resumes = parsedInput.resumes ?? parsedInput.data ?? [];
+  const options: ResumeImportOptions = {
+    recomputeDerivedFields: parsedInput.options?.recomputeDerivedFields === true,
+  };
   const tag = normalizeOptionalString(metadata.searchProfileId) ?? normalizeOptionalString(metadata.keyword);
   const defaultTags = tag ? [tag] : [];
   const source = resolveResumeSource(metadata);
@@ -347,7 +360,7 @@ export function normalizeResumeImportPayload(input: ResumeImportRequest): Normal
       hash,
       source: itemSource,
       tags: itemTags,
-      restoreState: normalizeRestoreState(resume.restoreState),
+      restoreState: normalizeRestoreState(resume.restoreState, options),
     };
   });
 
@@ -356,6 +369,7 @@ export function normalizeResumeImportPayload(input: ResumeImportRequest): Normal
     resumes,
     source,
     tags: defaultTags,
+    options,
     convexResumes,
   };
 }

--- a/apps/api/src/services/work-history.ts
+++ b/apps/api/src/services/work-history.ts
@@ -9,7 +9,11 @@ function computeMonthsDiff(startYear: number, startMonth: number, endYear: numbe
   return diff > 0 ? diff / 12 : 0;
 }
 
-export function parseRoleYears(raw: string): number {
+function resolveAnchorDate(anchorDate: Date | undefined): Date {
+  return anchorDate ?? new Date();
+}
+
+export function parseRoleYears(raw: string, anchorDate?: Date): number {
   const text = raw.trim();
   if (!text) {
     return 0;
@@ -45,9 +49,9 @@ export function parseRoleYears(raw: string): number {
   if (presentEndMatch) {
     const startYear = Number(presentEndMatch[1]);
     const startMonth = Number(presentEndMatch[2] || 1);
-    const now = new Date();
-    const endYear = now.getFullYear();
-    const endMonth = now.getMonth() + 1;
+    const resolvedAnchorDate = resolveAnchorDate(anchorDate);
+    const endYear = resolvedAnchorDate.getFullYear();
+    const endMonth = resolvedAnchorDate.getMonth() + 1;
     if (Number.isFinite(startYear) && Number.isFinite(startMonth)) {
       const years = computeMonthsDiff(startYear, startMonth, endYear, endMonth);
       if (years > 0) {
@@ -59,18 +63,18 @@ export function parseRoleYears(raw: string): number {
   return 0;
 }
 
-export function computeEntryRoleYears(entry: ResumeWorkHistoryItem): number {
+export function computeEntryRoleYears(entry: ResumeWorkHistoryItem, anchorDate?: Date): number {
   const normalized = normalizeWorkHistoryEntry(entry);
   if (!normalized) {
     return 0;
   }
 
-  const dateRangeYears = parseRoleYears(buildWorkHistoryDateRange(normalized.startDate, normalized.endDate));
+  const dateRangeYears = parseRoleYears(buildWorkHistoryDateRange(normalized.startDate, normalized.endDate), anchorDate);
   if (dateRangeYears > 0) {
     return dateRangeYears;
   }
 
-  return parseRoleYears(normalized.raw || "");
+  return parseRoleYears(normalized.raw || "", anchorDate);
 }
 
 const COMPANY_PATTERN = /([\u4e00-\u9fa5A-Za-z0-9()（）·.&\-]{2,40}(?:公司|集团|科技|机械|设备|自动化|股份|有限|厂|行))/;
@@ -98,11 +102,11 @@ export function extractCompanyFromWorkHistory(entry: ResumeWorkHistoryItem): str
   return firstToken || "";
 }
 
-export function computeWorkHistoryYears(workHistory: ResumeWorkHistoryItem[]): number | null {
+export function computeWorkHistoryYears(workHistory: ResumeWorkHistoryItem[], anchorDate?: Date): number | null {
   if (!workHistory.length) return null;
   let total = 0;
   for (const entry of workHistory) {
-    total += computeEntryRoleYears(entry);
+    total += computeEntryRoleYears(entry, anchorDate);
   }
   return total > 0 ? Number(total.toFixed(1)) : null;
 }

--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -478,23 +478,35 @@ describe('QuickStartPanel quick-filter display', () => {
   })
 
   it('does not derive minRoleYears from profile.filters.minExperience', async () => {
+    const user = userEvent.setup()
     const onApplyQuickFilters = vi.fn()
 
+    postMock.mockResolvedValue({
+      data: {
+        success: true,
+        profileId: 'profile-1',
+        confidence: 1,
+        matchedKeywords: ['cnc'],
+      },
+    })
     getMock.mockImplementation(async (path: string) => {
-      if (path.includes('/api/config/custom-keywords')) {
+      if (path.includes('/api/search-profiles/profile-1')) {
         return {
           data: {
             success: true,
-            tags: [],
-            categories: [],
-            systemLocations: [],
-            workflowSeeds: [],
+            profile: {
+              id: 'profile-1',
+              name: 'CNC Profile',
+              status: 'active' as const,
+              location: '广东',
+              keywords: ['CNC'],
+              filters: {
+                minExperience: 3,
+                maxAge: 35,
+              },
+            },
           },
         }
-      }
-      if (path.includes('/api/search-profiles/auto-match')) {
-        // No auto-matched profile, so getProfileQuickConstraints won't be called
-        return { data: { success: true, profileId: undefined, confidence: 0, matchedKeywords: [] } }
       }
       return {
         data: {
@@ -513,12 +525,17 @@ describe('QuickStartPanel quick-filter display', () => {
       />
     )
 
-    // Auto-match returns no profile, so getProfileQuickConstraints is never invoked.
-    // The key invariant: minRoleYears must NOT be derived from profile.filters.minExperience.
-    // Since no profile is auto-matched, no quick filters will be applied at all.
-    expect(
-      onApplyQuickFilters.mock.calls.some(([value]) => typeof value?.minRoleYears === 'number')
-    ).toBe(false)
+    await waitFor(() => {
+      expect(screen.getByText('CNC Profile')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Use this config' }))
+
+    expect(onApplyQuickFilters).toHaveBeenCalledWith({
+      minRoleYears: undefined,
+      roleFilterType: undefined,
+      maxAge: 35,
+    })
   })
 
   it('still auto-fills JD defaults for a manual JD selection', async () => {

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -15,6 +15,8 @@ export type ConvexResumeSortBy = 'experience' | 'extractedAt'
 export type ConvexResumeFilters = {
   minExperience?: number
   maxExperience?: number
+  minRoleYears?: number
+  roleFilterType?: string
   education?: string[]
   skills?: string[]
   requiredKeywords?: string[]

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -448,7 +448,7 @@ describe('useResumeSearchState', () => {
     ])
   })
 
-  it('sends only minExperience/maxExperience to backend filters, not minRoleYears', () => {
+  it('sends role-year filters to backend filters', () => {
     Object.assign(parsedStateMock, createParsedState({
       query: 'CNC',
       keywords: ['CNC'],
@@ -471,9 +471,250 @@ describe('useResumeSearchState', () => {
         filters: expect.objectContaining({
           minExperience: 5,
           maxExperience: 12,
+          minRoleYears: 3,
         }),
       }),
     )
+  })
+
+  it('forwards role-year filters to backend and applies role-year local filtering', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'CNC',
+      keywords: ['CNC'],
+      filters: {
+        minRoleYears: 3,
+        roleFilterType: 'sales',
+        minExperience: 5,
+        maxExperience: 12,
+      },
+    }))
+
+    resumesMock.push(
+      createResume(1, {
+        ingestData: {
+          industryTags: ['Machine Tools'],
+          synonymHits: [],
+          brandHits: [],
+          companyHits: ['FANUC'],
+          ruleScores: {},
+          experienceLevel: 'senior',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+          roleSignals: [
+            {
+              type: 'sales',
+              matchedSignals: ['销售'],
+              signalCount: 1,
+              occurrences: 1,
+              years: 4,
+              industryVerifiedYears: 0,
+              roleRelevantYears: 4,
+              verifyIn: 'workHistory',
+            },
+          ],
+        },
+      }),
+      createResume(2, {
+        ingestData: {
+          industryTags: ['Machine Tools'],
+          synonymHits: [],
+          brandHits: [],
+          companyHits: ['FANUC'],
+          ruleScores: {},
+          experienceLevel: 'senior',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+          roleSignals: [
+            {
+              type: 'sales',
+              matchedSignals: ['销售'],
+              signalCount: 1,
+              occurrences: 1,
+              years: 2,
+              industryVerifiedYears: 0,
+              roleRelevantYears: 2,
+              verifyIn: 'workHistory',
+            },
+          ],
+        },
+      }),
+    )
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(useConvexResumesMock).toHaveBeenCalledWith(
+      expect.any(Number),
+      'CNC',
+      undefined,
+      expect.objectContaining({
+        filters: expect.objectContaining({
+          minExperience: 5,
+          maxExperience: 12,
+          minRoleYears: 3,
+          roleFilterType: 'sales',
+        }),
+      }),
+    )
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1'])
+  })
+
+  it('infers sales role filtering from sales keyword searches when minRoleYears is set', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'CNC 销售',
+      keywords: ['CNC', '销售'],
+      filters: {
+        minRoleYears: 5,
+      },
+    }))
+
+    resumesMock.push(
+      createResume(1, {
+        ingestData: {
+          industryTags: ['Machine Tools'],
+          synonymHits: [],
+          brandHits: [],
+          companyHits: ['FANUC'],
+          ruleScores: {},
+          experienceLevel: 'senior',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+          roleSignals: [
+            {
+              type: 'sales',
+              matchedSignals: ['销售', '销售工程师'],
+              signalCount: 2,
+              occurrences: 1,
+              years: 3.17,
+              industryVerifiedYears: 0,
+              roleRelevantYears: 3.17,
+              verifyIn: 'workHistory',
+            },
+            {
+              type: 'engineer',
+              matchedSignals: ['工程师', '编程'],
+              signalCount: 2,
+              occurrences: 2,
+              years: 8.67,
+              industryVerifiedYears: 5.5,
+              roleRelevantYears: 8.67,
+              verifyIn: 'workHistory',
+            },
+          ],
+        },
+      }),
+      createResume(2, {
+        ingestData: {
+          industryTags: ['Machine Tools'],
+          synonymHits: [],
+          brandHits: [],
+          companyHits: ['FANUC'],
+          ruleScores: {},
+          experienceLevel: 'senior',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+          roleSignals: [
+            {
+              type: 'sales',
+              matchedSignals: ['销售', '销售工程师'],
+              signalCount: 2,
+              occurrences: 2,
+              years: 6.2,
+              industryVerifiedYears: 0,
+              roleRelevantYears: 6.2,
+              verifyIn: 'workHistory',
+            },
+            {
+              type: 'engineer',
+              matchedSignals: ['工程师'],
+              signalCount: 1,
+              occurrences: 1,
+              years: 2,
+              industryVerifiedYears: 0,
+              roleRelevantYears: 2,
+              verifyIn: 'workHistory',
+            },
+          ],
+        },
+      }),
+    )
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(useConvexResumesMock).toHaveBeenCalledWith(
+      expect.any(Number),
+      'CNC 销售',
+      undefined,
+      expect.objectContaining({
+        filters: expect.objectContaining({
+          minRoleYears: 5,
+          roleFilterType: 'sales',
+        }),
+      }),
+    )
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-2'])
+  })
+
+  it('keeps an explicit role type over inferred sales intent', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'CNC 销售',
+      keywords: ['CNC', '销售'],
+      filters: {
+        minRoleYears: 5,
+        roleFilterType: 'engineer',
+      },
+    }))
+
+    resumesMock.push(
+      createResume(1, {
+        ingestData: {
+          industryTags: ['Machine Tools'],
+          synonymHits: [],
+          brandHits: [],
+          companyHits: ['FANUC'],
+          ruleScores: {},
+          experienceLevel: 'senior',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+          roleSignals: [
+            {
+              type: 'sales',
+              matchedSignals: ['销售'],
+              signalCount: 1,
+              occurrences: 1,
+              years: 3.17,
+              industryVerifiedYears: 0,
+              roleRelevantYears: 3.17,
+              verifyIn: 'workHistory',
+            },
+            {
+              type: 'engineer',
+              matchedSignals: ['工程师'],
+              signalCount: 1,
+              occurrences: 2,
+              years: 8.67,
+              industryVerifiedYears: 5.5,
+              roleRelevantYears: 8.67,
+              verifyIn: 'workHistory',
+            },
+          ],
+        },
+      }),
+    )
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(useConvexResumesMock).toHaveBeenCalledWith(
+      expect.any(Number),
+      'CNC 销售',
+      undefined,
+      expect.objectContaining({
+        filters: expect.objectContaining({
+          minRoleYears: 5,
+          roleFilterType: 'engineer',
+        }),
+      }),
+    )
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1'])
   })
 
   it('normalizes a recent search and syncs it back to canonical url state when applied', async () => {

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -121,6 +121,35 @@ function normalizeStringList(values: string[] | undefined): string[] {
   return normalized
 }
 
+function queryImpliesSalesRole(
+  query: string | undefined,
+  keywords: string[],
+): boolean {
+  const normalizedTokens = normalizeStringList([
+    ...keywords,
+    ...parseKeywordQuery(query ?? '').keywords,
+  ]).map((value) => value.toLowerCase())
+
+  return normalizedTokens.some((token) => (
+    token === 'sales'
+    || token.includes('sales')
+    || token.includes('销售')
+  ))
+}
+
+function resolveEffectiveRoleFilterType(state: UrlSearchState): string | undefined {
+  const explicitRoleFilterType = normalizeOptionalString(state.filters.roleFilterType)
+  if (explicitRoleFilterType) {
+    return explicitRoleFilterType
+  }
+
+  if (typeof state.filters.minRoleYears !== 'number') {
+    return undefined
+  }
+
+  return queryImpliesSalesRole(state.query, state.keywords) ? 'sales' : undefined
+}
+
 function resolveScore(
   resume: ConvexResumeItem,
   jobDescriptionId: string | undefined,
@@ -218,7 +247,9 @@ function hasExplicitSearchContext(state: UrlSearchState): boolean {
     typeof state.filters.minMatchScore === 'number' ||
     typeof state.filters.minExperience === 'number' ||
     typeof state.filters.maxExperience === 'number' ||
-    (state.filters.locations?.length ?? 0) > 0,
+    typeof state.filters.minRoleYears === 'number' ||
+    Boolean(normalizeOptionalString(state.filters.roleFilterType)) ||
+    (state.filters.locations?.length ?? 0) > 0
   )
 }
 
@@ -384,6 +415,43 @@ function buildSearchExportEntry(
   }
 }
 
+function getRoleYears(
+  resume: ConvexResumeItem,
+  roleType: string | undefined,
+): number {
+  const roleSignals = resume.ingestData?.roleSignals
+  if (!Array.isArray(roleSignals) || roleSignals.length === 0) {
+    return 0
+  }
+
+  const normalizedRoleType = normalizeOptionalString(roleType)?.toLowerCase() ?? ''
+  if (!normalizedRoleType) {
+    return roleSignals.reduce((maxYears, signal) => {
+      const relevantYears =
+        typeof signal.roleRelevantYears === 'number' && Number.isFinite(signal.roleRelevantYears)
+          ? signal.roleRelevantYears
+          : signal.years
+      if (typeof relevantYears !== 'number' || !Number.isFinite(relevantYears)) {
+        return maxYears
+      }
+      return Math.max(maxYears, relevantYears)
+    }, 0)
+  }
+
+  const roleSignal = roleSignals.find(
+    (signal) => signal.type.trim().toLowerCase() === normalizedRoleType,
+  )
+  const relevantYears =
+    typeof roleSignal?.roleRelevantYears === 'number' && Number.isFinite(roleSignal.roleRelevantYears)
+      ? roleSignal.roleRelevantYears
+      : roleSignal?.years
+  if (!roleSignal || typeof relevantYears !== 'number' || !Number.isFinite(relevantYears)) {
+    return 0
+  }
+
+  return relevantYears
+}
+
 function matchesLocalFilters(
   item: ResumeSearchResultItem,
   state: UrlSearchState,
@@ -471,6 +539,13 @@ function matchesLocalFilters(
 
   if (typeof minScore === 'number' && (item.score ?? 0) < minScore) {
     return false
+  }
+
+  if (typeof state.filters.minRoleYears === 'number') {
+    const roleYears = getRoleYears(item.resume, state.filters.roleFilterType)
+    if (roleYears < state.filters.minRoleYears) {
+      return false
+    }
   }
 
   if (typeof state.filters.minAge === 'number') {
@@ -590,6 +665,8 @@ export function useResumeSearchState() {
     parsedState.filters.maxExperience,
     parsedState.filters.minExperience,
     parsedState.filters.minMatchScore,
+    parsedState.filters.minRoleYears,
+    parsedState.filters.roleFilterType,
     parsedState.filters.status,
     parsedState.jobDescriptionId,
     parsedState.location,
@@ -606,6 +683,10 @@ export function useResumeSearchState() {
     () => buildSearchContextSignature(parsedState),
     [parsedState],
   )
+  const effectiveRoleFilterType = useMemo(
+    () => resolveEffectiveRoleFilterType(parsedState),
+    [parsedState],
+  )
   const currentPromptVersion = useMemo(() => getCurrentResumeAiPromptVersion(), [])
   const analysisKeywords = useMemo(
     () =>
@@ -619,13 +700,17 @@ export function useResumeSearchState() {
     () => ({
       minExperience: parsedState.filters.minExperience,
       maxExperience: parsedState.filters.maxExperience,
+      minRoleYears: parsedState.filters.minRoleYears,
+      roleFilterType: effectiveRoleFilterType,
       requiredKeywords: parsedState.requiredKeywords,
       locations: parsedState.filters.locations,
     }),
     [
+      effectiveRoleFilterType,
       parsedState.filters.locations,
       parsedState.filters.maxExperience,
       parsedState.filters.minExperience,
+      parsedState.filters.minRoleYears,
       parsedState.requiredKeywords,
     ],
   )
@@ -744,7 +829,13 @@ export function useResumeSearchState() {
         results.filter((item) =>
           matchesLocalFilters(
             item,
-            parsedState,
+            {
+              ...parsedState,
+              filters: {
+                ...parsedState.filters,
+                roleFilterType: effectiveRoleFilterType,
+              },
+            },
             selectedRawTags,
             selectedClusterTags,
             taxonomyResolver,
@@ -754,6 +845,7 @@ export function useResumeSearchState() {
       ),
     [
       activeSort,
+      effectiveRoleFilterType,
       parsedState,
       results,
       selectedClusterTags,

--- a/apps/web/src/hooks/useUrlSearchState.test.ts
+++ b/apps/web/src/hooks/useUrlSearchState.test.ts
@@ -80,6 +80,14 @@ describe('useUrlSearchState location parsing', () => {
     expect(state.shareSessionId).toBe('session-share-1')
   })
 
+  it('round-trips role-year filter type in url state', () => {
+    const state = parseUrlSearchState(new URLSearchParams('q=CNC&minRoleYears=3&roleType=sales'))
+
+    expect(state.query).toBe('CNC')
+    expect(state.filters.minRoleYears).toBe(3)
+    expect(state.filters.roleFilterType).toBe('sales')
+  })
+
   it('serializes canonical OR phrase queries when syncing to the URL', () => {
     const currentParams = new URLSearchParams()
     useSearchParamsMock.mockReturnValue([currentParams, setSearchParamsMock])
@@ -190,8 +198,7 @@ describe('useUrlSearchState location parsing', () => {
     expect(updatedParams.get('sort')).toBe('experience')
     expect(updatedParams.get('order')).toBe('desc')
 
-    // minRoleYears and minExperience are now decoupled: syncing emits minRoleYears only,
-    // so parsing the output restores minRoleYears but not minExperience
+    // minRoleYears no longer implies a minExperience value in parsed state
     const reparsedState = parseUrlSearchState(updatedParams)
     expect(reparsedState.filters.minRoleYears).toBe(5)
     expect(reparsedState.filters.minExperience).toBeUndefined()
@@ -329,7 +336,6 @@ describe('minRoleYears and minExperience are decoupled', () => {
     const [updater] = setSearchParamsMock.mock.calls[0] ?? []
     const updatedParams = updater(new URLSearchParams()) as URLSearchParams
     expect(updatedParams.get('minRoleYears')).toBe('3')
-    expect(updatedParams.get('minRoleYears')).not.toBeNull()
     // minExperience is not emitted when only minRoleYears is set
   })
 

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -7557,10 +7557,15 @@ export interface components {
             extractedAt?: string;
             restoreState?: components["schemas"]["ResumeImportRestoreState"];
         };
+        ResumeImportOptions: {
+            /** @example true */
+            recomputeDerivedFields?: boolean;
+        };
         ResumeImportRequest: {
             metadata: components["schemas"]["ResumeImportMetadata"];
             resumes?: components["schemas"]["ResumeImportItem"][];
             data?: components["schemas"]["ResumeImportItem"][];
+            options?: components["schemas"]["ResumeImportOptions"];
         };
         ResumeManualImportSource: {
             /** @example 51job-manual */

--- a/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
+++ b/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
@@ -13,6 +13,8 @@ type PaginatedArgs = {
   sortOrder?: "asc" | "desc";
   minExperience?: number;
   maxExperience?: number;
+  minRoleYears?: number;
+  roleFilterType?: string;
   education?: string[];
   skills?: string[];
   locations?: string[];
@@ -240,6 +242,88 @@ describe("listWithIngestDataPaginated", () => {
     expect(result.page).toHaveLength(1);
     expect((result.page[0] as { content: { name: string } }).content.name).toBe("Alice");
     expect(result.continueCursor).toBe("cursor-next");
+  });
+
+  it("filters by minRoleYears for the requested role type", async () => {
+    const resumeA = {
+      ...buildResumeDoc("resume-a", 90),
+      content: { name: "Alice" },
+      ingestData: {
+        ruleScores: {},
+        industryTags: [],
+        experienceLevel: "mid",
+        computedAt: 1,
+        skillsVersion: 1,
+        roleSignals: [
+          {
+            type: "sales",
+            matchedSignals: ["销售"],
+            signalCount: 1,
+            occurrences: 1,
+            years: 6.2,
+            roleRelevantYears: 6.2,
+            verifyIn: "workHistory",
+          },
+        ],
+      },
+    };
+    const resumeB = {
+      ...buildResumeDoc("resume-b", 80),
+      content: { name: "Bob" },
+      ingestData: {
+        ruleScores: {},
+        industryTags: [],
+        experienceLevel: "mid",
+        computedAt: 1,
+        skillsVersion: 1,
+        roleSignals: [
+          {
+            type: "sales",
+            matchedSignals: ["销售"],
+            signalCount: 1,
+            occurrences: 1,
+            years: 3.1,
+            roleRelevantYears: 3.1,
+            verifyIn: "workHistory",
+          },
+          {
+            type: "engineer",
+            matchedSignals: ["工程师"],
+            signalCount: 1,
+            occurrences: 1,
+            years: 8.5,
+            roleRelevantYears: 8.5,
+            verifyIn: "workHistory",
+          },
+        ],
+      },
+    };
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => ({
+              paginate: async () => ({
+                page: [resumeA, resumeB],
+                continueCursor: "cursor-next",
+                isDone: false,
+              }),
+              take: async () => [],
+            }),
+          }),
+        }),
+      },
+    };
+
+    const result = await handler(ctx, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      minRoleYears: 5,
+      roleFilterType: "sales",
+    });
+
+    expect(result.page).toHaveLength(1);
+    expect((result.page[0] as { content: { name: string } }).content.name).toBe("Alice");
   });
 });
 

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -291,6 +291,8 @@ type ResumeListProjectedDoc = {
 type ResumeListFilterArgs = {
     minExperience?: number;
     maxExperience?: number;
+    minRoleYears?: number;
+    roleFilterType?: string;
     education?: string[];
     skills?: string[];
     requiredKeywords?: string[];
@@ -645,10 +647,13 @@ function normalizeResumeListFilters(filters: ResumeListFilterArgs | undefined): 
         .map((value) => value.toLowerCase())
         .filter((value) => value.length > 0);
     const locations = filters.locations?.map((value) => value.trim()).filter((value) => value.length > 0);
+    const roleFilterType = toOptionalStringValue(filters.roleFilterType)?.toLowerCase();
 
     const normalized: ResumeListFilterArgs = {
         ...((filters.minExperience ?? 0) > 0 ? { minExperience: filters.minExperience } : {}),
         ...(filters.maxExperience === undefined ? {} : { maxExperience: filters.maxExperience }),
+        ...((filters.minRoleYears ?? 0) > 0 ? { minRoleYears: filters.minRoleYears } : {}),
+        ...(roleFilterType ? { roleFilterType } : {}),
         ...(education && education.length > 0 ? { education } : {}),
         ...(skills && skills.length > 0 ? { skills } : {}),
         ...(requiredKeywords.length > 0 ? { requiredKeywords } : {}),
@@ -744,6 +749,36 @@ function matchesAllRequiredKeywords(text: string, requiredKeywords: string[] | u
     return normalizedKeywords.every((keyword) => haystack.includes(keyword));
 }
 
+function getResumeRoleYears(resume: Doc<"resumes">, roleType: string | undefined): number {
+    const roleSignals = resume.ingestData?.roleSignals;
+    if (!Array.isArray(roleSignals) || roleSignals.length === 0) {
+        return 0;
+    }
+
+    const normalizedRoleType = toOptionalStringValue(roleType)?.toLowerCase() ?? "";
+    if (!normalizedRoleType) {
+        return roleSignals.reduce((maxYears, signal) => {
+            const relevantYears = typeof signal.roleRelevantYears === "number" && Number.isFinite(signal.roleRelevantYears)
+                ? signal.roleRelevantYears
+                : signal.years;
+            if (typeof relevantYears !== "number" || !Number.isFinite(relevantYears)) {
+                return maxYears;
+            }
+            return Math.max(maxYears, relevantYears);
+        }, 0);
+    }
+
+    const roleSignal = roleSignals.find((signal) => signal.type.trim().toLowerCase() === normalizedRoleType);
+    const relevantYears = typeof roleSignal?.roleRelevantYears === "number" && Number.isFinite(roleSignal.roleRelevantYears)
+        ? roleSignal.roleRelevantYears
+        : roleSignal?.years;
+    if (!roleSignal || typeof relevantYears !== "number" || !Number.isFinite(relevantYears)) {
+        return 0;
+    }
+
+    return relevantYears;
+}
+
 function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFilterArgs | undefined): boolean {
     if (!filters) {
         return true;
@@ -761,6 +796,13 @@ function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFil
             return false;
         }
         if (filters.maxExperience !== undefined && experience > filters.maxExperience) {
+            return false;
+        }
+    }
+
+    if ((filters.minRoleYears ?? 0) > 0) {
+        const roleYears = getResumeRoleYears(resume, filters.roleFilterType);
+        if (roleYears < filters.minRoleYears!) {
             return false;
         }
     }
@@ -1551,6 +1593,8 @@ export const listWithIngestDataPage = query({
         sortOrder: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
         minExperience: v.optional(v.number()),
         maxExperience: v.optional(v.number()),
+        minRoleYears: v.optional(v.number()),
+        roleFilterType: v.optional(v.string()),
         education: v.optional(v.array(v.string())),
         skills: v.optional(v.array(v.string())),
         requiredKeywords: v.optional(v.array(v.string())),
@@ -1575,6 +1619,8 @@ export const listWithIngestDataPaginated = query({
         sortOrder: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
         minExperience: v.optional(v.number()),
         maxExperience: v.optional(v.number()),
+        minRoleYears: v.optional(v.number()),
+        roleFilterType: v.optional(v.string()),
         education: v.optional(v.array(v.string())),
         skills: v.optional(v.array(v.string())),
         requiredKeywords: v.optional(v.array(v.string())),
@@ -1877,6 +1923,8 @@ export const searchWithTagExpansionPage = query({
         sortOrder: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
         minExperience: v.optional(v.number()),
         maxExperience: v.optional(v.number()),
+        minRoleYears: v.optional(v.number()),
+        roleFilterType: v.optional(v.string()),
         education: v.optional(v.array(v.string())),
         skills: v.optional(v.array(v.string())),
         requiredKeywords: v.optional(v.array(v.string())),
@@ -1915,6 +1963,8 @@ export const searchWithTagExpansionPaginated = query({
         sortOrder: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
         minExperience: v.optional(v.number()),
         maxExperience: v.optional(v.number()),
+        minRoleYears: v.optional(v.number()),
+        roleFilterType: v.optional(v.string()),
         education: v.optional(v.array(v.string())),
         skills: v.optional(v.array(v.string())),
         requiredKeywords: v.optional(v.array(v.string())),
@@ -1953,6 +2003,8 @@ export const searchWithTagExpansionScanPage = query({
         }))),
         minExperience: v.optional(v.number()),
         maxExperience: v.optional(v.number()),
+        minRoleYears: v.optional(v.number()),
+        roleFilterType: v.optional(v.string()),
         education: v.optional(v.array(v.string())),
         skills: v.optional(v.array(v.string())),
         requiredKeywords: v.optional(v.array(v.string())),

--- a/scripts/resume/restore-resumes.ts
+++ b/scripts/resume/restore-resumes.ts
@@ -34,13 +34,14 @@ type RestoreResetSummary = {
   deleted: Record<string, number>;
 };
 
-export type RestoreRunSummary = {
+type RestoreRunSummary = {
   success: true;
   apiUrl: string;
   workspace: string;
   inputPath: string;
   mode: RestoreMode;
   reset: boolean;
+  recomputeDerivedFields: boolean;
   resetResult?: Record<string, unknown>;
   files: RestoreFileSummary[];
 };
@@ -75,11 +76,13 @@ function usage(): string {
     "  make restore-resumes FILE=/abs/path/resume-backup.json [WORKSPACE=dev] [API_URL=http://localhost:3000]",
     "  make restore-resumes FILE=/abs/path/resume-backups/20260321-015304 [WORKSPACE=dev] [API_URL=http://localhost:3000]",
     "  make restore-resumes FILE=/abs/path/resume-backup.json MODE=replace YES=1 [WORKSPACE=dev] [API_URL=http://localhost:3000]",
+    "  make restore-resumes FILE=/abs/path/resume-backup.json RECOMPUTE_DERIVED_FIELDS=1 [WORKSPACE=dev] [API_URL=http://localhost:3000]",
     "",
     "Environment:",
     "  FILE        Required backup file path or directory containing backup files",
     "  MODE        Optional restore mode: upsert | replace (default: upsert)",
     "  YES         Required when MODE=replace; set YES=1 to confirm destructive reset",
+    "  RECOMPUTE_DERIVED_FIELDS  Optional; set to 1 to drop preserved computed fields and force current ingest recomputation",
     "  WORKSPACE   Optional workspace slug (default: dev)",
     "  API_URL     Optional API URL (default: http://localhost:3000)",
   ].join("\n");
@@ -248,6 +251,7 @@ export async function runRestoreResumes(
     filePath: string;
     mode: RestoreMode;
     confirm: boolean;
+    recomputeDerivedFields: boolean;
   },
   runtime: RestoreRuntime = { fetch: globalThis.fetch },
 ): Promise<RestoreRunSummary> {
@@ -273,7 +277,10 @@ export async function runRestoreResumes(
       params.apiUrl,
       params.workspace,
       "/api/resumes/import",
-      payload,
+      {
+        ...payload,
+        ...(params.recomputeDerivedFields ? { options: { recomputeDerivedFields: true } } : {}),
+      },
       runtime,
     );
     const importResult = await parseJsonRecord(
@@ -294,6 +301,7 @@ export async function runRestoreResumes(
     inputPath: params.filePath,
     mode: params.mode,
     reset: params.mode === "replace",
+    recomputeDerivedFields: params.recomputeDerivedFields,
     resetResult,
     files,
   };
@@ -306,6 +314,7 @@ async function main(): Promise<void> {
     filePath: process.env.FILE?.trim() || "",
     mode: resolveMode(process.env.MODE),
     confirm: parseTruthy(process.env.YES),
+    recomputeDerivedFields: parseTruthy(process.env.RECOMPUTE_DERIVED_FIELDS),
   });
 
   console.log(JSON.stringify(summary, null, 2));


### PR DESCRIPTION
## Summary
- infer an effective `sales` role filter for `/dev/resumes` searches when the query contains `sales` or `销售` and `minRoleYears` is set without an explicit role type
- keep backend/local role-year filtering aligned, add Convex coverage for explicit role-type filtering, and preserve explicit override behavior
- make sample snapshot restore recompute derived fields and anchor ongoing-role year calculations to `extractedAt` for deterministic re-ingest verification

## Verification
- bun --cwd apps/web vitest run src/hooks/useResumeSearchState.test.tsx
- bun --cwd apps/web vitest run src/hooks/useUrlSearchState.test.ts
- bun --cwd apps/web vitest run src/components/QuickStartPanel.test.tsx
- bun vitest run packages/convex/convex/__tests__/resumes-paginated-default.test.ts
- bun vitest run apps/api/src/services/ingest-compute-service.test.ts
- bun vitest run apps/api/src/services/resume-import-service.test.ts
- bun vitest run scripts/resume/restore-resumes.test.ts
- make check