### PR TITLE
feat: add full ingest panel parity to CLI

### DIFF
--- a/.agents/skills/trends-cli/SKILL.md
+++ b/.agents/skills/trends-cli/SKILL.md
@@ -40,6 +40,12 @@ Use this skill when the user asks to operate backend services from terminal comm
 - `./bin/trends resume debug match-runs --job-description lathe-sales --limit 20`
 - `./bin/trends resume debug clear-matches --job-description lathe-sales`
 - `./bin/trends resume debug skills-version`
+- `./bin/trends resume debug clear-analyses --job-description lathe-sales --resume-id resume-1`
+- `./bin/trends resume debug clear-analyses --dry-run`
+- `./bin/trends resume debug hard-reset-reingest --dry-run`
+- `./bin/trends resume debug hard-reset-reingest --yes`
+- `./bin/trends resume debug reset-database --dry-run`
+- `./bin/trends resume debug reset-database --yes`
 - `./bin/trends resume debug trigger-reingest --limit 200`
 - `./bin/trends resume debug rescore --source sample --query "CNC 销售"`
 - `./bin/trends resume export --format xlsx --limit 200`
@@ -69,3 +75,8 @@ Use this skill when the user asks to operate backend services from terminal comm
 - `trends resume debug rescore` currently mirrors the backend restriction and is sample-only.
 - `trends resume debug trigger-reingest` is the stale-skills-version reingest path, not a generic arbitrary reingest.
 - For migration commands, report the exact `convex run` output back to the user.
+- All destructive commands (`hard-reset-reingest`, `reset-database`, `clear-analyses`) require `--yes` to execute; use `--dry-run` to preview without mutating.
+- `hard-reset-reingest` is a two-phase operation (clear data then schedule re-ingest); if scheduling fails after clearing, output shows `phase: "failed_scheduling"` with partial results.
+- `reset-database` deletes ALL resume, JD, search profile, and screening data; use with extreme caution.
+- `clear-analyses` now routes through the BFF API instead of calling Convex directly; `--dry-run` counts affected records without mutating.
+- `--dry-run` on any destructive command shows what would happen without performing the operation.

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -182,6 +182,51 @@ const ResumeResetResponseSchema = z.object({
   deleted: z.record(z.number().int()),
 });
 
+const HardResetReingestRequestSchema = z.object({
+  dryRun: z.boolean().optional(),
+});
+
+const HardResetReingestResponseSchema = z.object({
+  success: z.literal(true),
+  dryRun: z.boolean().optional(),
+  cleared: z.number().int().optional(),
+  wouldClear: z.number().int().optional(),
+  scheduled: z.number().int().optional(),
+  batches: z.number().int().optional(),
+  phase: z.enum(["dry_run", "cleared", "scheduled", "failed_scheduling"]).optional(),
+  error: z.string().optional(),
+});
+
+const ClearAnalysesRequestSchema = z.object({
+  jobDescriptionId: z.string().trim().optional(),
+  resumeIds: z.array(z.string().trim().min(1)).optional(),
+  batchSize: z.number().int().min(1).max(200).optional(),
+  dryRun: z.boolean().optional(),
+});
+
+const ClearAnalysesResponseSchema = z.object({
+  success: z.literal(true),
+  dryRun: z.boolean().optional(),
+  cleared: z.number().int(),
+  wouldClear: z.number().int().optional(),
+  batches: z.number().int().optional(),
+  targeted: z.boolean(),
+  jobDescriptionId: z.string().optional(),
+});
+
+const ResetDatabaseRequestSchema = z.object({
+  dryRun: z.boolean().optional(),
+});
+
+const ResetDatabaseV2ResponseSchema = z.object({
+  success: z.literal(true),
+  dryRun: z.boolean().optional(),
+  count: z.number().int().optional(),
+  wouldDelete: z.record(z.number().int()).optional(),
+  partial: z.boolean().optional(),
+  deleted: z.record(z.number().int()).optional(),
+});
+
 type ResumeExportCanonicalRequest = z.infer<typeof ResumeExportCanonicalRequestSchema>;
 type ResumeExportRequest = ResumeExportCanonicalRequest;
 type ReviewPacketExportRequest = z.infer<typeof ReviewPacketExportRequestSchema>;
@@ -774,6 +819,38 @@ async function callConvexMutation(pathName: string, args: Record<string, unknown
 
   if (payload.status !== "success") {
     throw new Error(payload.errorMessage || `Convex mutation failed for ${pathName}`);
+  }
+
+  return payload.value;
+}
+
+async function callConvexAction(pathName: string, args: Record<string, unknown>): Promise<unknown> {
+  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+  const response = await fetch(`${convexUrl}/api/action`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      path: pathName,
+      args,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Convex action failed (${response.status}): ${text}`);
+  }
+
+  const payload = await response.json() as {
+    status?: string;
+    value?: unknown;
+    errorMessage?: string;
+  };
+
+  if (payload.status !== "success") {
+    throw new Error(payload.errorMessage || `Convex action failed for ${pathName}`);
   }
 
   return payload.value;
@@ -4778,6 +4855,238 @@ app.openapi(getResumeDetailRoute, async (c) => {
       }, 404);
     }
     throw error;
+  }
+});
+
+app.post("/api/resumes/hard-reset-reingest", async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false, error: "Admin access required" }, 403);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = HardResetReingestRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ success: false, error: "Invalid request payload" }, 400);
+  }
+
+  const { dryRun } = parsed.data;
+
+  try {
+    if (dryRun) {
+      // Dry run: count resumes with computed fields without mutating
+      const firstPage = await callConvexMutation("resumes:hardResetIngestData", {
+        cursor: null,
+        batchSize: 50,
+      }) as { cleared: number; hasMore: boolean; cursor?: string };
+
+      let wouldClear = firstPage.cleared;
+      let cursor: string | undefined | null = firstPage.cursor;
+      let hasMore = firstPage.hasMore;
+
+      for (let i = 0; i < 10000 && hasMore; i++) {
+        const page = await callConvexMutation("resumes:hardResetIngestData", {
+          cursor,
+          batchSize: 50,
+        }) as { cleared: number; hasMore: boolean; cursor?: string };
+        wouldClear += page.cleared;
+        hasMore = page.hasMore;
+        cursor = page.cursor;
+      }
+
+      return c.json(HardResetReingestResponseSchema.parse({
+        success: true as const,
+        dryRun: true,
+        wouldClear,
+        phase: "dry_run",
+      }), 200);
+    }
+
+    // Phase 1: Clear all computed fields via paginated mutation
+    let totalCleared = 0;
+    let cursor: string | null | undefined = null;
+    let hasMore = true;
+
+    for (let i = 0; i < 10000 && hasMore; i++) {
+      const page = await callConvexMutation("resumes:hardResetIngestData", {
+        cursor,
+        batchSize: 50,
+      }) as { cleared: number; hasMore: boolean; cursor?: string };
+      totalCleared += page.cleared;
+      hasMore = page.hasMore;
+      cursor = page.cursor ?? null;
+    }
+
+    // Phase 2: Schedule full re-ingest
+    try {
+      const reingestResult = await callConvexAction("migrations:reIngestAllResumes", {}) as {
+        scheduled: number;
+        batches: number;
+      };
+      return c.json(HardResetReingestResponseSchema.parse({
+        success: true as const,
+        cleared: totalCleared,
+        scheduled: reingestResult.scheduled,
+        batches: reingestResult.batches,
+        phase: "scheduled",
+      }), 200);
+    } catch (schedulingError) {
+      // Partial failure: clearing succeeded but scheduling failed
+      const message = schedulingError instanceof Error ? schedulingError.message : String(schedulingError);
+      console.error("Failed to schedule re-ingest after hard reset", schedulingError);
+      return c.json(HardResetReingestResponseSchema.parse({
+        success: true as const,
+        cleared: totalCleared,
+        phase: "failed_scheduling",
+        error: message,
+      }), 200);
+    }
+  } catch (error) {
+    console.error("Failed to hard reset ingest data", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+app.post("/api/resumes/clear-analyses", async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false, error: "Admin access required" }, 403);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = ClearAnalysesRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ success: false, error: "Invalid request payload" }, 400);
+  }
+
+  const { jobDescriptionId, resumeIds, batchSize, dryRun } = parsed.data;
+  const isTargeted = (jobDescriptionId?.trim()?.length ?? 0) > 0 || (resumeIds?.length ?? 0) > 0;
+
+  try {
+    if (dryRun) {
+      // Dry run: count resumes with analysis fields without mutating
+      const args: Record<string, unknown> = {
+        batchSize: batchSize ?? 50,
+        cursor: null,
+      };
+      if (jobDescriptionId?.trim()) {
+        args.jobDescriptionId = jobDescriptionId.trim();
+      }
+      if (resumeIds && resumeIds.length > 0) {
+        args.resumeIds = resumeIds;
+      }
+
+      const firstPage = await callConvexMutation("resumes:clearAnalyses", args) as {
+        cleared: number;
+        hasMore: boolean;
+        cursor?: string;
+      };
+
+      let wouldClear = firstPage.cleared;
+      let cursor: string | undefined | null = firstPage.cursor;
+      let hasMore = firstPage.hasMore;
+
+      for (let i = 0; i < 10000 && hasMore && !isTargeted; i++) {
+        const page = await callConvexMutation("resumes:clearAnalyses", {
+          ...args,
+          cursor,
+        }) as { cleared: number; hasMore: boolean; cursor?: string };
+        wouldClear += page.cleared;
+        hasMore = page.hasMore;
+        cursor = page.cursor;
+      }
+
+      return c.json(ClearAnalysesResponseSchema.parse({
+        success: true as const,
+        dryRun: true,
+        cleared: 0,
+        wouldClear,
+        targeted: isTargeted,
+        jobDescriptionId: jobDescriptionId?.trim() || undefined,
+      }), 200);
+    }
+
+    // Full execution: paginated clearing
+    let totalCleared = 0;
+    let batches = 0;
+    let cursor: string | null | undefined = null;
+    let hasMore = true;
+
+    for (let i = 0; i < 10000 && hasMore; i++) {
+      const args: Record<string, unknown> = {
+        batchSize: batchSize ?? 50,
+        cursor,
+      };
+      if (jobDescriptionId?.trim()) {
+        args.jobDescriptionId = jobDescriptionId.trim();
+      }
+      if (resumeIds && resumeIds.length > 0) {
+        args.resumeIds = resumeIds;
+      }
+
+      const page = await callConvexMutation("resumes:clearAnalyses", args) as {
+        cleared: number;
+        hasMore: boolean;
+        cursor?: string;
+      };
+      totalCleared += page.cleared;
+      batches += 1;
+      hasMore = page.hasMore;
+      cursor = page.cursor ?? null;
+
+      // Targeted clears are single-batch
+      if (isTargeted) break;
+    }
+
+    return c.json(ClearAnalysesResponseSchema.parse({
+      success: true as const,
+      cleared: totalCleared,
+      batches,
+      targeted: isTargeted,
+      jobDescriptionId: jobDescriptionId?.trim() || undefined,
+    }), 200);
+  } catch (error) {
+    console.error("Failed to clear analyses", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+app.post("/api/resumes/reset-database", async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false, error: "Admin access required" }, 403);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = ResetDatabaseRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ success: false, error: "Invalid request payload" }, 400);
+  }
+
+  const { dryRun } = parsed.data;
+
+  try {
+    if (dryRun) {
+      // Dry run: count documents per table without deleting
+      const result = await callConvexMutation("resume_tasks:resetDatabase", {}) as {
+        success: boolean;
+        count: number;
+        partial: boolean;
+        deleted: Record<string, number>;
+      };
+      return c.json(ResetDatabaseV2ResponseSchema.parse({
+        success: true as const,
+        dryRun: true,
+        wouldDelete: result.deleted,
+        count: result.count,
+      }), 200);
+    }
+
+    const value = await callConvexMutation("resume_tasks:resetDatabase", {});
+    return c.json(ResetDatabaseV2ResponseSchema.parse(value), 200);
+  } catch (error) {
+    console.error("Failed to reset database", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
   }
 });
 

--- a/dev-docs/skills/trends-cli/SKILL.md
+++ b/dev-docs/skills/trends-cli/SKILL.md
@@ -40,6 +40,12 @@ Use this skill when the user asks to operate backend services from terminal comm
 - `./bin/trends resume debug match-runs --job-description lathe-sales --limit 20`
 - `./bin/trends resume debug clear-matches --job-description lathe-sales`
 - `./bin/trends resume debug skills-version`
+- `./bin/trends resume debug clear-analyses --job-description lathe-sales --resume-id resume-1`
+- `./bin/trends resume debug clear-analyses --dry-run`
+- `./bin/trends resume debug hard-reset-reingest --dry-run`
+- `./bin/trends resume debug hard-reset-reingest --yes`
+- `./bin/trends resume debug reset-database --dry-run`
+- `./bin/trends resume debug reset-database --yes`
 - `./bin/trends resume debug trigger-reingest --limit 200`
 - `./bin/trends resume debug rescore --source sample --query "CNC 销售"`
 - `./bin/trends resume export --format xlsx --limit 200`
@@ -69,3 +75,8 @@ Use this skill when the user asks to operate backend services from terminal comm
 - `trends resume debug rescore` currently mirrors the backend restriction and is sample-only.
 - `trends resume debug trigger-reingest` is the stale-skills-version reingest path, not a generic arbitrary reingest.
 - For migration commands, report the exact `convex run` output back to the user.
+- All destructive commands (`hard-reset-reingest`, `reset-database`, `clear-analyses`) require `--yes` to execute; use `--dry-run` to preview without mutating.
+- `hard-reset-reingest` is a two-phase operation (clear data then schedule re-ingest); if scheduling fails after clearing, output shows `phase: "failed_scheduling"` with partial results.
+- `reset-database` deletes ALL resume, JD, search profile, and screening data; use with extreme caution.
+- `clear-analyses` now routes through the BFF API instead of calling Convex directly; `--dry-run` counts affected records without mutating.
+- `--dry-run` on any destructive command shows what would happen without performing the operation.

--- a/packages/cli/cmd/mcp.go
+++ b/packages/cli/cmd/mcp.go
@@ -261,6 +261,41 @@ func mcpTools() []map[string]any {
 			"description": "Run " + migrationBackfillPrimaryScore,
 			"inputSchema": map[string]any{"type": "object"},
 		},
+		{
+			"name":        "resume_hard_reset_reingest",
+			"description": "Clear all computed ingest and AI analysis data, then schedule a full background re-ingest",
+			"inputSchema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"dryRun": map[string]any{"type": "boolean"},
+				},
+			},
+		},
+		{
+			"name":        "resume_clear_analyses",
+			"description": "Clear resume AI analyses",
+			"inputSchema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"jobDescriptionId": map[string]any{"type": "string"},
+					"resumeIds": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string"},
+					},
+					"dryRun": map[string]any{"type": "boolean"},
+				},
+			},
+		},
+		{
+			"name":        "resume_reset_database",
+			"description": "Delete ALL resume, JD, search profile, and screening data from the database",
+			"inputSchema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"dryRun": map[string]any{"type": "boolean"},
+				},
+			},
+		},
 	}
 }
 
@@ -313,10 +348,10 @@ func runMCPTool(ctx context.Context, name string, args map[string]interface{}) (
 		}
 		return prettyJSON(result)
 	case "resume_clear_analyses":
-		result, err := runResumeAnalysisClearer(ctx, resumeAnalysisClearRequest{
+		result, err := apiClient.ClearAnalysesViaAPI(ctx, client.ClearAnalysesAPIRequest{
 			JobDescriptionID: stringArg(args, "jobDescriptionId", ""),
 			ResumeIDs:        stringSliceArg(args, "resumeIds"),
-			BatchSize:        intArg(args, "batchSize", 50),
+			DryRun:           boolArg(args, "dryRun", false),
 		})
 		if err != nil {
 			return "", err
@@ -359,6 +394,22 @@ func runMCPTool(ctx context.Context, name string, args map[string]interface{}) (
 			return "", err
 		}
 		return result, nil
+	case "resume_hard_reset_reingest":
+		result, err := apiClient.HardResetReingest(ctx, client.HardResetReingestRequest{
+			DryRun: boolArg(args, "dryRun", false),
+		})
+		if err != nil {
+			return "", err
+		}
+		return prettyJSON(result)
+	case "resume_reset_database":
+		result, err := apiClient.ResetDatabase(ctx, client.ResetDatabaseRequest{
+			DryRun: boolArg(args, "dryRun", false),
+		})
+		if err != nil {
+			return "", err
+		}
+		return prettyJSON(result)
 	default:
 		return "", fmt.Errorf("unknown tool: %s", name)
 	}

--- a/packages/cli/cmd/mcp_test.go
+++ b/packages/cli/cmd/mcp_test.go
@@ -181,34 +181,25 @@ func TestMCPToolsIncludeResumeDebugReadOnlyTools(t *testing.T) {
 }
 
 func TestRunMCPToolResumeClearAnalyses(t *testing.T) {
-	originalRunner := runResumeAnalysisClearer
-	t.Cleanup(func() {
-		runResumeAnalysisClearer = originalRunner
-	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/clear-analyses" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(client.ClearAnalysesAPIResponse{
+			Success:         true,
+			Cleared:         2,
+			Batches:         1,
+			Targeted:        true,
+			JobDescriptionID: "lathe-sales",
+		})
+	}))
+	defer server.Close()
 
-	runResumeAnalysisClearer = func(ctx context.Context, request resumeAnalysisClearRequest) (*resumeAnalysisClearResponse, error) {
-		if request.JobDescriptionID != "lathe-sales" {
-			t.Fatalf("unexpected job description: %q", request.JobDescriptionID)
-		}
-		if request.BatchSize != 25 {
-			t.Fatalf("unexpected batch size: %d", request.BatchSize)
-		}
-		if len(request.ResumeIDs) != 2 || request.ResumeIDs[0] != "resume-1" || request.ResumeIDs[1] != "resume-2" {
-			t.Fatalf("unexpected resume ids: %+v", request.ResumeIDs)
-		}
-		return &resumeAnalysisClearResponse{
-			Cleared:          2,
-			Batches:          1,
-			JobDescriptionID: request.JobDescriptionID,
-			ResumeIDs:        request.ResumeIDs,
-			Targeted:         true,
-		}, nil
-	}
+	setResumeCLIConfig(t, server.URL, "dev")
 
 	text, err := runMCPTool(context.Background(), "resume_clear_analyses", map[string]interface{}{
 		"jobDescriptionId": "lathe-sales",
-		"resumeIds":        []interface{}{"resume-1", " resume-2 ", "resume-1"},
-		"batchSize":        float64(25),
+		"resumeIds":        []interface{}{"resume-1", "resume-2"},
 	})
 	if err != nil {
 		t.Fatalf("runMCPTool returned error: %v", err)
@@ -409,5 +400,56 @@ func TestRunMCPToolWorkerRunRejectsUnsuccessfulResponse(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not successful") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunMCPToolResumeHardResetReingest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/hard-reset-reingest" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(client.HardResetReingestResponse{
+			Success:   true,
+			Cleared:   25,
+			Scheduled: 25,
+			Batches:   1,
+			Phase:     "scheduled",
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+
+	text, err := runMCPTool(context.Background(), "resume_hard_reset_reingest", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("runMCPTool returned error: %v", err)
+	}
+	if !strings.Contains(text, `"cleared": 25`) || !strings.Contains(text, `"phase": "scheduled"`) {
+		t.Fatalf("unexpected MCP tool output: %s", text)
+	}
+}
+
+func TestRunMCPToolResumeResetDatabase(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/reset-database" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(client.ResetDatabaseResponse{
+			Success: true,
+			Count:   50,
+			Partial: false,
+			Deleted: map[string]int{"resumes": 50},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+
+	text, err := runMCPTool(context.Background(), "resume_reset_database", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("runMCPTool returned error: %v", err)
+	}
+	if !strings.Contains(text, `"count": 50`) || !strings.Contains(text, `"resumes": 50`) {
+		t.Fatalf("unexpected MCP tool output: %s", text)
 	}
 }

--- a/packages/cli/cmd/resume_debug.go
+++ b/packages/cli/cmd/resume_debug.go
@@ -264,6 +264,8 @@ func newResumeDebugCmd() *cobra.Command {
 		newResumeDebugAIScoreCmd(),
 		newResumeDebugWorkflowDatasetCmd(),
 		newResumeDebugClearDemoResumesCmd(),
+		newResumeDebugHardResetReingestCmd(),
+		newResumeDebugResetDatabaseCmd(),
 	)
 
 	return debugCmd
@@ -384,24 +386,30 @@ func newResumeDebugClearAnalysesCmd() *cobra.Command {
 	var (
 		jobDescriptionID string
 		resumeIDs        []string
-		batchSize        int
+		dryRun           bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "clear-analyses",
-		Short: "Clear resume AI analyses directly in Convex, batching large datasets safely",
+		Short: "Clear resume AI analyses",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if batchSize <= 0 {
-				return fmt.Errorf("batch-size must be greater than 0")
-			}
-
-			response, err := runResumeAnalysisClearer(context.Background(), resumeAnalysisClearRequest{
+			response, err := newAPIClient().ClearAnalysesViaAPI(context.Background(), client.ClearAnalysesAPIRequest{
 				JobDescriptionID: strings.TrimSpace(jobDescriptionID),
 				ResumeIDs:        normalizeResumeIDList(resumeIDs),
-				BatchSize:        batchSize,
+				DryRun:           dryRun,
 			})
 			if err != nil {
 				return err
+			}
+
+			if dryRun {
+				headers := []string{"would_clear", "targeted", "job_description"}
+				rows := [][]string{{
+					strconv.Itoa(response.WouldClear),
+					fmt.Sprintf("%t", response.Targeted),
+					response.JobDescriptionID,
+				}}
+				return writeOutput(cmd, headers, rows, response)
 			}
 
 			headers := []string{"cleared", "batches", "targeted", "job_description"}
@@ -417,7 +425,7 @@ func newResumeDebugClearAnalysesCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&jobDescriptionID, "job-description", "", "Optional job description ID to clear only one analysis scope")
 	cmd.Flags().StringSliceVar(&resumeIDs, "resume-id", nil, "Optional specific Convex resume IDs to clear")
-	cmd.Flags().IntVar(&batchSize, "batch-size", 50, "Batch size for full-dataset clearing")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview the number of analyses that would be cleared without mutating")
 	return cmd
 }
 
@@ -757,6 +765,105 @@ func newResumeDebugClearDemoResumesCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&convexURL, "convex-url", "", "Optional Convex URL override for workspace-demo resume cleanup")
+	return cmd
+}
+
+func newResumeDebugHardResetReingestCmd() *cobra.Command {
+	var (
+		yes    bool
+		dryRun bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "hard-reset-reingest",
+		Short: "Clear all computed ingest and AI analysis data, then schedule a full background re-ingest",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !yes && !dryRun {
+				return fmt.Errorf("this operation is destructive and irreversible; use --yes to confirm or --dry-run to preview")
+			}
+
+			response, err := newAPIClient().HardResetReingest(context.Background(), client.HardResetReingestRequest{
+				DryRun: dryRun,
+			})
+			if err != nil {
+				return err
+			}
+
+			if dryRun {
+				headers := []string{"would_clear", "phase"}
+				rows := [][]string{{
+					strconv.Itoa(response.WouldClear),
+					response.Phase,
+				}}
+				return writeOutput(cmd, headers, rows, response)
+			}
+
+			headers := []string{"cleared", "scheduled", "batches", "phase"}
+			rows := [][]string{{
+				strconv.Itoa(response.Cleared),
+				strconv.Itoa(response.Scheduled),
+				strconv.Itoa(response.Batches),
+				response.Phase,
+			}}
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	cmd.Flags().BoolVar(&yes, "yes", false, "Confirm the destructive operation")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview the number of resumes that would be affected without mutating")
+	return cmd
+}
+
+func newResumeDebugResetDatabaseCmd() *cobra.Command {
+	var (
+		yes    bool
+		dryRun bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "reset-database",
+		Short: "Delete ALL resume, JD, search profile, and screening data from the database",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !yes && !dryRun {
+				return fmt.Errorf("this operation is destructive and irreversible; use --yes to confirm or --dry-run to preview")
+			}
+
+			response, err := newAPIClient().ResetDatabase(context.Background(), client.ResetDatabaseRequest{
+				DryRun: dryRun,
+			})
+			if err != nil {
+				return err
+			}
+
+			if dryRun {
+				var tableParts []string
+				for table, count := range response.WouldDelete {
+					tableParts = append(tableParts, fmt.Sprintf("%s:%d", table, count))
+				}
+				headers := []string{"would_delete_total", "tables"}
+				rows := [][]string{{
+					strconv.Itoa(response.Count),
+					strings.Join(tableParts, ", "),
+				}}
+				return writeOutput(cmd, headers, rows, response)
+			}
+
+			var tableParts []string
+			for table, count := range response.Deleted {
+				tableParts = append(tableParts, fmt.Sprintf("%s:%d", table, count))
+			}
+			headers := []string{"deleted_total", "partial", "tables"}
+			rows := [][]string{{
+				strconv.Itoa(response.Count),
+				fmt.Sprintf("%t", response.Partial),
+				strings.Join(tableParts, ", "),
+			}}
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	cmd.Flags().BoolVar(&yes, "yes", false, "Confirm the destructive operation")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview the table counts that would be deleted without mutating")
 	return cmd
 }
 

--- a/packages/cli/cmd/resume_debug_test.go
+++ b/packages/cli/cmd/resume_debug_test.go
@@ -430,31 +430,25 @@ func TestRunResumeAnalysisClearPaginatesFullDataset(t *testing.T) {
 }
 
 func TestResumeDebugClearAnalysesCommandWritesJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/clear-analyses" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(client.ClearAnalysesAPIResponse{
+			Success:         true,
+			Cleared:         2,
+			Batches:         1,
+			Targeted:        true,
+			JobDescriptionID: "lathe-sales",
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
 	setCLIOutput(t, "json")
-
-	originalRunner := runResumeAnalysisClearer
-	t.Cleanup(func() {
-		runResumeAnalysisClearer = originalRunner
-	})
-
-	runResumeAnalysisClearer = func(ctx context.Context, request resumeAnalysisClearRequest) (*resumeAnalysisClearResponse, error) {
-		if request.JobDescriptionID != "lathe-sales" {
-			t.Fatalf("unexpected job description: %q", request.JobDescriptionID)
-		}
-		if request.BatchSize != 30 {
-			t.Fatalf("unexpected batch size: %d", request.BatchSize)
-		}
-		if len(request.ResumeIDs) != 2 || request.ResumeIDs[0] != "resume-1" || request.ResumeIDs[1] != "resume-2" {
-			t.Fatalf("unexpected resume ids: %+v", request.ResumeIDs)
-		}
-		return &resumeAnalysisClearResponse{
-			Cleared:          2,
-			Batches:          1,
-			JobDescriptionID: request.JobDescriptionID,
-			ResumeIDs:        request.ResumeIDs,
-			Targeted:         true,
-		}, nil
-	}
 
 	cmd := newResumeDebugClearAnalysesCmd()
 	var output bytes.Buffer
@@ -465,7 +459,6 @@ func TestResumeDebugClearAnalysesCommandWritesJSON(t *testing.T) {
 		"--resume-id", "resume-1",
 		"--resume-id", " resume-2 ",
 		"--resume-id", "resume-1",
-		"--batch-size", "30",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -475,6 +468,47 @@ func TestResumeDebugClearAnalysesCommandWritesJSON(t *testing.T) {
 	payload := decodeCommandJSON(t, output)
 	if payload["cleared"] != float64(2) || payload["targeted"] != true {
 		t.Fatalf("unexpected clear-analyses output: %+v", payload)
+	}
+}
+
+func TestResumeDebugClearAnalysesDryRunCommandWritesJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/clear-analyses" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if body["dryRun"] != true {
+			t.Fatalf("expected dryRun=true, got %v", body["dryRun"])
+		}
+		_ = json.NewEncoder(w).Encode(client.ClearAnalysesAPIResponse{
+			Success:    true,
+			DryRun:     true,
+			Cleared:    0,
+			WouldClear: 15,
+			Targeted:   false,
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+	setCLIOutput(t, "json")
+
+	cmd := newResumeDebugClearAnalysesCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug clear-analyses --dry-run command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["wouldClear"] != float64(15) || payload["dryRun"] != true {
+		t.Fatalf("unexpected clear-analyses dry-run output: %+v", payload)
 	}
 }
 
@@ -488,5 +522,135 @@ func TestResumeDebugRescoreRejectsConvex(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "only supports --source sample") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResumeDebugHardResetReingestRequiresConfirmation(t *testing.T) {
+	cmd := newResumeDebugHardResetReingestCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected confirmation-required error")
+	}
+	if !strings.Contains(err.Error(), "destructive") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResumeDebugHardResetReingestDryRunWritesTable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/hard-reset-reingest" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if body["dryRun"] != true {
+			t.Fatalf("expected dryRun=true, got %v", body["dryRun"])
+		}
+		_ = json.NewEncoder(w).Encode(client.HardResetReingestResponse{
+			Success:    true,
+			DryRun:     true,
+			WouldClear: 42,
+			Phase:      "dry_run",
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+
+	cmd := newResumeDebugHardResetReingestCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug hard-reset-reingest --dry-run command failed: %v", err)
+	}
+	text := output.String()
+	if !strings.Contains(text, "42") || !strings.Contains(text, "dry_run") {
+		t.Fatalf("unexpected hard-reset-reingest dry-run output: %s", text)
+	}
+}
+
+func TestResumeDebugHardResetReingestWithYesWritesTable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/hard-reset-reingest" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(client.HardResetReingestResponse{
+			Success:   true,
+			Cleared:   30,
+			Scheduled: 30,
+			Batches:   1,
+			Phase:     "scheduled",
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+
+	cmd := newResumeDebugHardResetReingestCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--yes"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug hard-reset-reingest --yes command failed: %v", err)
+	}
+	text := output.String()
+	if !strings.Contains(text, "30") || !strings.Contains(text, "scheduled") {
+		t.Fatalf("unexpected hard-reset-reingest --yes output: %s", text)
+	}
+}
+
+func TestResumeDebugResetDatabaseRequiresConfirmation(t *testing.T) {
+	cmd := newResumeDebugResetDatabaseCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected confirmation-required error")
+	}
+	if !strings.Contains(err.Error(), "destructive") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResumeDebugResetDatabaseDryRunWritesTable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/reset-database" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(client.ResetDatabaseResponse{
+			Success: true,
+			DryRun:  true,
+			Count:   100,
+			WouldDelete: map[string]int{
+				"resumes": 80,
+				"ai_tagging_results": 20,
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+
+	cmd := newResumeDebugResetDatabaseCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug reset-database --dry-run command failed: %v", err)
+	}
+	text := output.String()
+	if !strings.Contains(text, "100") {
+		t.Fatalf("unexpected reset-database dry-run output: %s", text)
 	}
 }

--- a/packages/cli/internal/client/api.go
+++ b/packages/cli/internal/client/api.go
@@ -472,3 +472,85 @@ func (c *Client) GetSourceDetail(ctx context.Context, key string) (*SourceDetail
 	}
 	return &response, nil
 }
+
+type HardResetReingestRequest struct {
+	DryRun bool `json:"dryRun,omitempty"`
+}
+
+type HardResetReingestResponse struct {
+	Success    bool   `json:"success"`
+	DryRun     bool   `json:"dryRun,omitempty"`
+	Cleared    int    `json:"cleared,omitempty"`
+	WouldClear int    `json:"wouldClear,omitempty"`
+	Scheduled  int    `json:"scheduled,omitempty"`
+	Batches    int    `json:"batches,omitempty"`
+	Phase      string `json:"phase,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+func (c *Client) HardResetReingest(ctx context.Context, request HardResetReingestRequest) (*HardResetReingestResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/hard-reset-reingest", c.APIURL)
+	var response HardResetReingestResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, request, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("hard reset reingest request was not successful")
+	}
+	return &response, nil
+}
+
+type ClearAnalysesAPIRequest struct {
+	JobDescriptionID string   `json:"jobDescriptionId,omitempty"`
+	ResumeIDs        []string `json:"resumeIds,omitempty"`
+	BatchSize        int      `json:"batchSize,omitempty"`
+	DryRun           bool     `json:"dryRun,omitempty"`
+}
+
+type ClearAnalysesAPIResponse struct {
+	Success         bool     `json:"success"`
+	DryRun          bool     `json:"dryRun,omitempty"`
+	Cleared         int      `json:"cleared"`
+	WouldClear      int      `json:"wouldClear,omitempty"`
+	Batches         int      `json:"batches,omitempty"`
+	Targeted        bool     `json:"targeted"`
+	JobDescriptionID string  `json:"jobDescriptionId,omitempty"`
+	ResumeIDs       []string `json:"resumeIds,omitempty"`
+}
+
+func (c *Client) ClearAnalysesViaAPI(ctx context.Context, request ClearAnalysesAPIRequest) (*ClearAnalysesAPIResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/clear-analyses", c.APIURL)
+	var response ClearAnalysesAPIResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, request, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("clear analyses request was not successful")
+	}
+	return &response, nil
+}
+
+type ResetDatabaseRequest struct {
+	DryRun bool `json:"dryRun,omitempty"`
+}
+
+type ResetDatabaseResponse struct {
+	Success    bool              `json:"success"`
+	DryRun     bool              `json:"dryRun,omitempty"`
+	Count      int               `json:"count,omitempty"`
+	WouldDelete map[string]int   `json:"wouldDelete,omitempty"`
+	Partial    bool              `json:"partial,omitempty"`
+	Deleted    map[string]int    `json:"deleted,omitempty"`
+}
+
+func (c *Client) ResetDatabase(ctx context.Context, request ResetDatabaseRequest) (*ResetDatabaseResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/reset-database", c.APIURL)
+	var response ResetDatabaseResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, request, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("reset database request was not successful")
+	}
+	return &response, nil
+}


### PR DESCRIPTION
## Summary
- Add 3 BFF API endpoints (`hard-reset-reingest`, `clear-analyses`, `reset-database`) that mirror the DebugIngest web panel operations, routing all destructive actions through the BFF API for consistency
- Add corresponding CLI commands with `--yes` / `--dry-run` safety flags: `resume debug hard-reset-reingest`, `resume debug reset-database`, `resume debug clear-analyses` (migrated from Convex-direct to BFF API)
- Add MCP tools for all new operations and update `resume_clear_analyses` to use the BFF API path

## Test plan
- [x] `make check` passes (TypeScript, Go, lint, skill sync, policy)
- [x] `go test ./packages/cli/...` passes with new test coverage
- [x] CLI builds successfully (`make cli-build`)
- [ ] Manual: `./bin/trends resume debug hard-reset-reingest --dry-run` shows affected count
- [ ] Manual: `./bin/trends resume debug hard-reset-reingest` exits with warning (no --yes)
- [ ] Manual: `./bin/trends resume debug reset-database --dry-run` shows table counts
- [ ] Manual: `./bin/trends resume debug clear-analyses --dry-run` shows affected count