### PR TITLE
feat: add resume analyze CLI and analysis-tasks status

### DIFF
--- a/.agents/skills/trends-cli/SKILL.md
+++ b/.agents/skills/trends-cli/SKILL.md
@@ -47,6 +47,10 @@ Use this skill when the user asks to operate backend services from terminal comm
 - `./bin/trends resume debug reset-database --dry-run`
 - `./bin/trends resume debug reset-database --yes`
 - `./bin/trends resume debug trigger-reingest --limit 200`
+- `./bin/trends resume analyze --query "CNC 销售" --limit 50`
+- `./bin/trends resume analyze --job-description lathe-sales --dry-run`
+- `./bin/trends resume analyze --query "CNC Sales" --min-experience 3 --locations "Dongguan,Shenzhen"`
+- `./bin/trends resume debug analysis-tasks`
 - `./bin/trends resume debug rescore --source sample --query "CNC 销售"`
 - `./bin/trends resume export --format xlsx --limit 200`
 - `./bin/trends jd list`
@@ -80,3 +84,8 @@ Use this skill when the user asks to operate backend services from terminal comm
 - `reset-database` deletes ALL resume, JD, search profile, and screening data; use with extreme caution.
 - `clear-analyses` now routes through the BFF API instead of calling Convex directly; `--dry-run` counts affected records without mutating.
 - `--dry-run` on any destructive command shows what would happen without performing the operation.
+- `resume analyze` dispatches the production Convex AI analysis pipeline; results are stored per-resume in the `analyses` map.
+- Use `--dry-run` on `resume analyze` to preview candidate count without dispatching analysis.
+- Check analysis task status with `resume debug analysis-tasks`.
+- `resume analyze` is fire-and-forget; the Convex backend processes analysis asynchronously.
+- Either `--query` or `--job-description` is required for `resume analyze`; both can be combined.

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -39,6 +39,9 @@ import {
   ResumeMatchesQuerySchema,
   MatchRunsResponseSchema,
   MatchRunsQuerySchema,
+  AnalyzeRequestSchema,
+  AnalyzeResponseSchema,
+  AnalysisTasksResponseSchema,
 } from "../schemas/index.js";
 import { config } from "../services/config.js";
 import { ResumeService, parseExperienceYears, type ResumeFilters } from "../services/resume-service.js";
@@ -5119,6 +5122,193 @@ app.post("/api/resumes/ingest-compute", async (c) => {
     const results = ingestComputeService.computeBatch(resumes);
     return c.json({ success: true, results }, 200);
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+app.post("/api/resumes/analyze", async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = AnalyzeRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ success: false, error: "Invalid request payload" }, 400);
+  }
+
+  const {
+    query,
+    jobDescriptionId,
+    location,
+    minExperience,
+    maxExperience,
+    education,
+    skills,
+    requiredKeywords,
+    locations: locationFilters,
+    minSalary,
+    maxSalary,
+    limit,
+    dryRun,
+  } = parsed.data;
+
+  const normalizedQuery = query?.trim() || "";
+  const normalizedJobDescriptionId = jobDescriptionId?.trim() || "";
+
+  if (!normalizedQuery && !normalizedJobDescriptionId) {
+    return c.json(
+      { success: false, error: "Either query or jobDescriptionId is required" },
+      400,
+    );
+  }
+
+  try {
+    // Search phase: find matching resume IDs via Convex
+    const searchArgs: Record<string, unknown> = {
+      query: normalizedQuery,
+      keywordGroups: [],
+      mode: "OR",
+      ...(normalizedJobDescriptionId ? { jobDescriptionId: normalizedJobDescriptionId } : {}),
+      ...(minExperience !== undefined ? { minExperience } : {}),
+      ...(maxExperience !== undefined ? { maxExperience } : {}),
+      ...(education && education.length > 0 ? { education } : {}),
+      ...(skills && skills.length > 0 ? { skills } : {}),
+      ...(requiredKeywords && requiredKeywords.length > 0 ? { requiredKeywords } : {}),
+      ...(locationFilters && locationFilters.length > 0 ? { locations: locationFilters } : {}),
+      ...(minSalary !== undefined ? { minSalary } : {}),
+      ...(maxSalary !== undefined ? { maxSalary } : {}),
+      paginationOpts: { numItems: limit, cursor: null },
+    };
+
+    const searchResult = (await callConvexQuery(
+      "resumes:searchWithTagExpansionPaginated",
+      searchArgs,
+    )) as {
+      page: Array<{ resume: { _id: string }; provenance?: unknown }>;
+      continuationCursor: string | null;
+    };
+
+    const resumeIds = (searchResult.page ?? []).map((item) => item.resume._id);
+
+    if (dryRun) {
+      return c.json(
+        AnalyzeResponseSchema.parse({
+          success: true,
+          dryRun: true,
+          resumeCount: resumeIds.length,
+          config: {
+            ...(normalizedJobDescriptionId
+              ? { jobDescriptionId: normalizedJobDescriptionId }
+              : {}),
+            ...(normalizedQuery ? { keywords: normalizedQuery.split(/[\s,，、]+/).filter(Boolean) } : {}),
+            ...(location ? { location } : {}),
+          },
+        }),
+        200,
+      );
+    }
+
+    if (resumeIds.length === 0) {
+      return c.json(
+        AnalyzeResponseSchema.parse({
+          success: true,
+          resumeCount: 0,
+          config: {
+            ...(normalizedJobDescriptionId
+              ? { jobDescriptionId: normalizedJobDescriptionId }
+              : {}),
+            ...(normalizedQuery ? { keywords: normalizedQuery.split(/[\s,，、]+/).filter(Boolean) } : {}),
+            ...(location ? { location } : {}),
+          },
+        }),
+        200,
+      );
+    }
+
+    // Resolve JD content for the LLM prompt
+    let jobDescriptionTitle: string | undefined;
+    let jobDescriptionContent: string | undefined;
+
+    if (normalizedJobDescriptionId) {
+      try {
+        const jdData = jobService.loadFile(normalizedJobDescriptionId);
+        jobDescriptionTitle = jdData.title;
+        jobDescriptionContent = jdData.content;
+      } catch {
+        // JD file not found locally — the Convex dispatch will use keywords only
+      }
+    }
+
+    const keywords = normalizedQuery
+      ? normalizedQuery.split(/[\s,，、]+/).filter(Boolean)
+      : undefined;
+
+    // Dispatch phase: call Convex mutation to create analysis task
+    const dispatchResult = (await callConvexMutation("analysis_tasks:dispatch", {
+      ...(normalizedJobDescriptionId
+        ? { jobDescriptionId: normalizedJobDescriptionId }
+        : {}),
+      ...(jobDescriptionTitle ? { jobDescriptionTitle } : {}),
+      ...(jobDescriptionContent ? { jobDescriptionContent } : {}),
+      ...(keywords && keywords.length > 0 ? { keywords } : {}),
+      ...(location ? { location } : {}),
+      resumeIds,
+    })) as string;
+
+    return c.json(
+      AnalyzeResponseSchema.parse({
+        success: true,
+        taskId: dispatchResult,
+        resumeCount: resumeIds.length,
+        config: {
+          ...(normalizedJobDescriptionId
+            ? { jobDescriptionId: normalizedJobDescriptionId }
+            : {}),
+          ...(keywords && keywords.length > 0 ? { keywords } : {}),
+          ...(location ? { location } : {}),
+        },
+      }),
+      200,
+    );
+  } catch (error) {
+    console.error("Failed to dispatch analysis", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+app.get("/api/resumes/analysis-tasks", async (c) => {
+  try {
+    const tasks = (await callConvexQuery("analysis_tasks:list", {})) as Array<{
+      _id: string;
+      status: string;
+      _creationTime: number;
+      config?: {
+        jobDescriptionId?: string;
+        jobDescriptionTitle?: string;
+        keywords?: string[];
+        location?: string;
+        promptVersion?: number;
+        resumeCount?: number;
+      };
+      progress?: { current?: number; total?: number; skipped?: number };
+      results?: {
+        analyzed?: number;
+        failed?: number;
+        avgScore?: number;
+        highScoreCount?: number;
+      };
+      lastStatus?: string;
+      error?: string;
+    }>;
+
+    return c.json(
+      AnalysisTasksResponseSchema.parse({
+        success: true,
+        tasks,
+      }),
+      200,
+    );
+  } catch (error) {
+    console.error("Failed to list analysis tasks", error);
     const message = error instanceof Error ? error.message : String(error);
     return c.json({ success: false, error: message }, 500);
   }

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -1202,3 +1202,76 @@ export const MatchRunsResponseSchema = z
     runs: z.array(MatchRunSchema),
   })
   .openapi("MatchRunsResponse");
+
+export const AnalyzeRequestSchema = z.object({
+  query: z.string().optional().openapi({ example: "CNC 销售" }),
+  jobDescriptionId: z.string().optional().openapi({ example: "lathe-sales" }),
+  location: z.string().optional().openapi({ example: "东莞" }),
+  minExperience: z.number().min(0).optional().openapi({ example: 3 }),
+  maxExperience: z.number().min(0).optional().openapi({ example: 10 }),
+  education: z.array(z.string()).optional().openapi({ example: ["bachelor", "master"] }),
+  skills: z.array(z.string()).optional().openapi({ example: ["CNC", "FANUC"] }),
+  requiredKeywords: z.array(z.string()).optional().openapi({ example: ["machine tools"] }),
+  locations: z.array(z.string()).optional().openapi({ example: ["东莞", "深圳"] }),
+  minSalary: z.number().min(0).optional().openapi({ example: 5000 }),
+  maxSalary: z.number().min(0).optional().openapi({ example: 15000 }),
+  limit: z.number().min(1).max(500).default(50).openapi({ example: 50 }),
+  dryRun: z.boolean().default(false).openapi({ example: false }),
+});
+
+export const AnalyzeResponseSchema = z
+  .object({
+    success: z.literal(true),
+    dryRun: z.boolean().optional(),
+    taskId: z.string().optional(),
+    resumeCount: z.number(),
+    skippedCount: z.number().optional(),
+    config: z
+      .object({
+        jobDescriptionId: z.string().optional(),
+        keywords: z.array(z.string()).optional(),
+        location: z.string().optional(),
+      })
+      .optional(),
+  })
+  .openapi("AnalyzeResponse");
+
+export const AnalysisTaskConfigSchema = z.object({
+  jobDescriptionId: z.string().optional(),
+  jobDescriptionTitle: z.string().optional(),
+  keywords: z.array(z.string()).optional(),
+  location: z.string().optional(),
+  promptVersion: z.number().optional(),
+  resumeCount: z.number().optional(),
+});
+
+export const AnalysisTaskProgressSchema = z.object({
+  current: z.number().optional(),
+  total: z.number().optional(),
+  skipped: z.number().optional(),
+});
+
+export const AnalysisTaskResultsSchema = z.object({
+  analyzed: z.number().optional(),
+  failed: z.number().optional(),
+  avgScore: z.number().optional(),
+  highScoreCount: z.number().optional(),
+});
+
+export const AnalysisTaskSchema = z.object({
+  _id: z.string(),
+  status: z.enum(["pending", "processing", "completed", "failed", "cancelled"]),
+  _creationTime: z.number(),
+  config: AnalysisTaskConfigSchema.optional(),
+  progress: AnalysisTaskProgressSchema.optional(),
+  results: AnalysisTaskResultsSchema.optional(),
+  lastStatus: z.string().optional(),
+  error: z.string().optional(),
+});
+
+export const AnalysisTasksResponseSchema = z
+  .object({
+    success: z.literal(true),
+    tasks: z.array(AnalysisTaskSchema),
+  })
+  .openapi("AnalysisTasksResponse");

--- a/dev-docs/skills/trends-cli/SKILL.md
+++ b/dev-docs/skills/trends-cli/SKILL.md
@@ -47,6 +47,10 @@ Use this skill when the user asks to operate backend services from terminal comm
 - `./bin/trends resume debug reset-database --dry-run`
 - `./bin/trends resume debug reset-database --yes`
 - `./bin/trends resume debug trigger-reingest --limit 200`
+- `./bin/trends resume analyze --query "CNC 销售" --limit 50`
+- `./bin/trends resume analyze --job-description lathe-sales --dry-run`
+- `./bin/trends resume analyze --query "CNC Sales" --min-experience 3 --locations "Dongguan,Shenzhen"`
+- `./bin/trends resume debug analysis-tasks`
 - `./bin/trends resume debug rescore --source sample --query "CNC 销售"`
 - `./bin/trends resume export --format xlsx --limit 200`
 - `./bin/trends jd list`
@@ -80,3 +84,8 @@ Use this skill when the user asks to operate backend services from terminal comm
 - `reset-database` deletes ALL resume, JD, search profile, and screening data; use with extreme caution.
 - `clear-analyses` now routes through the BFF API instead of calling Convex directly; `--dry-run` counts affected records without mutating.
 - `--dry-run` on any destructive command shows what would happen without performing the operation.
+- `resume analyze` dispatches the production Convex AI analysis pipeline; results are stored per-resume in the `analyses` map.
+- Use `--dry-run` on `resume analyze` to preview candidate count without dispatching analysis.
+- Check analysis task status with `resume debug analysis-tasks`.
+- `resume analyze` is fire-and-forget; the Convex backend processes analysis asynchronously.
+- Either `--query` or `--job-description` is required for `resume analyze`; both can be combined.

--- a/packages/cli/cmd/mcp.go
+++ b/packages/cli/cmd/mcp.go
@@ -296,6 +296,33 @@ func mcpTools() []map[string]any {
 				},
 			},
 		},
+		{
+			"name":        "resume_analyze",
+			"description": "Dispatch AI analysis for resumes matching search criteria",
+			"inputSchema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"query":             map[string]any{"type": "string"},
+					"jobDescriptionId":  map[string]any{"type": "string"},
+					"location":          map[string]any{"type": "string"},
+					"locations":         map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+					"minExperience":     map[string]any{"type": "integer", "minimum": 0},
+					"maxExperience":     map[string]any{"type": "integer", "minimum": 0},
+					"education":         map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+					"skills":            map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+					"requiredKeywords":  map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+					"minSalary":         map[string]any{"type": "integer", "minimum": 0},
+					"maxSalary":         map[string]any{"type": "integer", "minimum": 0},
+					"limit":             map[string]any{"type": "integer", "minimum": 1, "maximum": 500},
+					"dryRun":            map[string]any{"type": "boolean"},
+				},
+			},
+		},
+		{
+			"name":        "analysis_tasks",
+			"description": "List recent analysis tasks with status and progress",
+			"inputSchema": map[string]any{"type": "object"},
+		},
 	}
 }
 
@@ -410,6 +437,32 @@ func runMCPTool(ctx context.Context, name string, args map[string]interface{}) (
 			return "", err
 		}
 		return prettyJSON(result)
+	case "resume_analyze":
+		analyzeResult, err := apiClient.AnalyzeResumes(ctx, client.AnalyzeRequest{
+			Query:            stringArg(args, "query", ""),
+			JobDescriptionID: stringArg(args, "jobDescriptionId", ""),
+			Location:         stringArg(args, "location", ""),
+			MinExperience:    intArg(args, "minExperience", 0),
+			MaxExperience:    intArg(args, "maxExperience", 0),
+			Education:        stringSliceArg(args, "education"),
+			Skills:           stringSliceArg(args, "skills"),
+			RequiredKeywords: stringSliceArg(args, "requiredKeywords"),
+			Locations:        stringSliceArg(args, "locations"),
+			MinSalary:        intArg(args, "minSalary", 0),
+			MaxSalary:        intArg(args, "maxSalary", 0),
+			Limit:            intArg(args, "limit", 50),
+			DryRun:           boolArg(args, "dryRun", false),
+		})
+		if err != nil {
+			return "", err
+		}
+		return prettyJSON(analyzeResult)
+	case "analysis_tasks":
+		tasksResult, err := apiClient.ListAnalysisTasks(ctx)
+		if err != nil {
+			return "", err
+		}
+		return prettyJSON(tasksResult)
 	default:
 		return "", fmt.Errorf("unknown tool: %s", name)
 	}

--- a/packages/cli/cmd/mcp_test.go
+++ b/packages/cli/cmd/mcp_test.go
@@ -453,3 +453,99 @@ func TestRunMCPToolResumeResetDatabase(t *testing.T) {
 		t.Fatalf("unexpected MCP tool output: %s", text)
 	}
 }
+
+func TestMCPToolsIncludeResumeAnalyzeAndAnalysisTasks(t *testing.T) {
+	tools := mcpTools()
+	names := make(map[string]bool, len(tools))
+	for _, tool := range tools {
+		name, _ := tool["name"].(string)
+		names[name] = true
+	}
+
+	for _, required := range []string{"resume_analyze", "analysis_tasks"} {
+		if !names[required] {
+			t.Fatalf("missing MCP tool %q", required)
+		}
+	}
+}
+
+func TestRunMCPToolResumeAnalyze(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/analyze" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if body["query"] != "CNC 销售" {
+			t.Fatalf("expected query=CNC 销售, got %v", body["query"])
+		}
+		if body["dryRun"] != true {
+			t.Fatalf("expected dryRun=true, got %v", body["dryRun"])
+		}
+		_ = json.NewEncoder(w).Encode(client.AnalyzeResponse{
+			Success:      true,
+			DryRun:        true,
+			ResumeCount:   42,
+			SkippedCount:  5,
+			Config: &client.AnalyzeConfig{
+				Keywords: []string{"CNC", "销售"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+
+	text, err := runMCPTool(context.Background(), "resume_analyze", map[string]interface{}{
+		"query":  "CNC 销售",
+		"dryRun": true,
+	})
+	if err != nil {
+		t.Fatalf("runMCPTool returned error: %v", err)
+	}
+	if !strings.Contains(text, `"resumeCount": 42`) || !strings.Contains(text, `"dryRun": true`) {
+		t.Fatalf("unexpected MCP tool output: %s", text)
+	}
+}
+
+func TestRunMCPToolAnalysisTasks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/analysis-tasks" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(client.AnalysisTasksResponse{
+			Success: true,
+			Tasks: []client.AnalysisTask{
+				{
+					ID:     "task-1",
+					Status: "completed",
+					Config: &client.AnalysisTaskConfig{
+						Keywords:    []string{"CNC"},
+						ResumeCount: 10,
+					},
+					Results: &client.AnalysisTaskResults{
+						Analyzed:      10,
+						AvgScore:      85.5,
+						HighScoreCount: 3,
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+
+	text, err := runMCPTool(context.Background(), "analysis_tasks", nil)
+	if err != nil {
+		t.Fatalf("runMCPTool returned error: %v", err)
+	}
+	if !strings.Contains(text, `"_id": "task-1"`) || !strings.Contains(text, `"status": "completed"`) {
+		t.Fatalf("unexpected MCP tool output: %s", text)
+	}
+}

--- a/packages/cli/cmd/resume.go
+++ b/packages/cli/cmd/resume.go
@@ -27,6 +27,7 @@ func newResumeCmd() *cobra.Command {
 		newResumeShowCmd(),
 		newResumeSearchCmd(),
 		newResumeMatchCmd(),
+		newResumeAnalyzeCmd(),
 		newResumeSnapshotCmd(),
 		newResumeManualImportCmd(),
 		newResumeBackupCmd(),
@@ -218,6 +219,128 @@ func newResumeMatchCmd() *cobra.Command {
 	cmd.Flags().StringVar(&mode, "mode", "rules_only", "Match mode: rules_only|hybrid|ai_only")
 
 	return cmd
+}
+
+func newResumeAnalyzeCmd() *cobra.Command {
+	var (
+		query            string
+		jobDescriptionID string
+		location         string
+		locationFilters  string
+		minExperience    int
+		maxExperience    int
+		education        string
+		skills           string
+		requiredKeywords string
+		minSalary        int
+		maxSalary        int
+		limit            int
+		dryRun           bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "analyze",
+		Short: "Dispatch AI analysis for resumes matching search criteria",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(query) == "" && strings.TrimSpace(jobDescriptionID) == "" {
+				return fmt.Errorf("query or job-description is required")
+			}
+
+			var educationSlice []string
+			if strings.TrimSpace(education) != "" {
+				educationSlice = splitCSV(education)
+			}
+			var skillsSlice []string
+			if strings.TrimSpace(skills) != "" {
+				skillsSlice = splitCSV(skills)
+			}
+			var requiredKeywordsSlice []string
+			if strings.TrimSpace(requiredKeywords) != "" {
+				requiredKeywordsSlice = splitCSV(requiredKeywords)
+			}
+			var locationsSlice []string
+			if strings.TrimSpace(locationFilters) != "" {
+				locationsSlice = splitCSV(locationFilters)
+			}
+
+			request := client.AnalyzeRequest{
+				Query:            strings.TrimSpace(query),
+				JobDescriptionID: strings.TrimSpace(jobDescriptionID),
+				Location:         strings.TrimSpace(location),
+				MinExperience:    minExperience,
+				MaxExperience:    maxExperience,
+				Education:        educationSlice,
+				Skills:           skillsSlice,
+				RequiredKeywords: requiredKeywordsSlice,
+				Locations:       locationsSlice,
+				MinSalary:        minSalary,
+				MaxSalary:        maxSalary,
+				Limit:            limit,
+				DryRun:           dryRun,
+			}
+
+			response, err := newAPIClient().AnalyzeResumes(context.Background(), request)
+			if err != nil {
+				return err
+			}
+
+			if currentOptions().Output == "json" {
+				return writeOutput(cmd, nil, nil, response)
+			}
+
+			return writeAnalyzeTable(cmd, response)
+		},
+	}
+
+	cmd.Flags().StringVarP(&query, "query", "q", "", "Keyword search query")
+	cmd.Flags().StringVar(&jobDescriptionID, "job-description", "", "Job description ID")
+	cmd.Flags().StringVar(&location, "location", "", "Location filter")
+	cmd.Flags().StringVar(&locationFilters, "locations", "", "Location filter (CSV for multiple)")
+	cmd.Flags().IntVar(&minExperience, "min-experience", 0, "Min years experience")
+	cmd.Flags().IntVar(&maxExperience, "max-experience", 0, "Max years experience")
+	cmd.Flags().StringVar(&education, "education", "", "Education filter (CSV: bachelor,master)")
+	cmd.Flags().StringVar(&skills, "skills", "", "Skills filter (CSV)")
+	cmd.Flags().StringVar(&requiredKeywords, "required-keywords", "", "Required keywords AND filter (CSV)")
+	cmd.Flags().IntVar(&minSalary, "min-salary", 0, "Min salary")
+	cmd.Flags().IntVar(&maxSalary, "max-salary", 0, "Max salary")
+	cmd.Flags().IntVar(&limit, "limit", 50, "Max candidates to analyze (1-500)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview candidate count without dispatching")
+
+	return cmd
+}
+
+func splitCSV(input string) []string {
+	parts := strings.Split(input, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func writeAnalyzeTable(cmd *cobra.Command, response *client.AnalyzeResponse) error {
+	fmt.Fprintf(cmd.OutOrStdout(), "Candidates: %d\n", response.ResumeCount)
+	if response.DryRun {
+		fmt.Fprintf(cmd.OutOrStdout(), "Mode: dry-run (no analysis dispatched)\n")
+	} else if response.TaskID != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Task ID: %s\n", response.TaskID)
+	}
+	if response.Config != nil {
+		if response.Config.JobDescriptionID != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "Job Description: %s\n", response.Config.JobDescriptionID)
+		}
+		if len(response.Config.Keywords) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Keywords: %s\n", strings.Join(response.Config.Keywords, ", "))
+		}
+		if response.Config.Location != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "Location: %s\n", response.Config.Location)
+		}
+	}
+	return nil
 }
 
 func newResumeExportCmd() *cobra.Command {

--- a/packages/cli/cmd/resume_debug.go
+++ b/packages/cli/cmd/resume_debug.go
@@ -266,6 +266,7 @@ func newResumeDebugCmd() *cobra.Command {
 		newResumeDebugClearDemoResumesCmd(),
 		newResumeDebugHardResetReingestCmd(),
 		newResumeDebugResetDatabaseCmd(),
+		newResumeDebugAnalysisTasksCmd(),
 	)
 
 	return debugCmd
@@ -1077,6 +1078,71 @@ func validateResumeMatchRequest(request client.ResumeMatchRequest) error {
 	}
 	if normalizeResumeSourceFlag(request.Source) == "convex" && persist {
 		return fmt.Errorf("source=convex only supports --persist=false")
+	}
+
+	return nil
+}
+
+func newResumeDebugAnalysisTasksCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "analysis-tasks",
+		Short: "List recent AI analysis tasks and their status",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := newAPIClient().ListAnalysisTasks(context.Background())
+			if err != nil {
+				return err
+			}
+
+			if currentOptions().Output == "json" {
+				return writeOutput(cmd, nil, nil, response)
+			}
+
+			return writeAnalysisTasksTable(cmd, response)
+		},
+	}
+
+	return cmd
+}
+
+func writeAnalysisTasksTable(cmd *cobra.Command, response *client.AnalysisTasksResponse) error {
+	if len(response.Tasks) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "No analysis tasks found.\n")
+		return nil
+	}
+
+	for _, task := range response.Tasks {
+		label := task.Config.JobDescriptionTitle
+		if label == "" && len(task.Config.Keywords) > 0 {
+			label = strings.Join(task.Config.Keywords, ", ")
+		}
+		if label == "" {
+			label = task.Config.JobDescriptionID
+		}
+
+		status := task.Status
+		if task.Progress != nil && task.Progress.Total > 0 {
+			status = fmt.Sprintf("%s (%d/%d", task.Status, task.Progress.Current, task.Progress.Total)
+			if task.Progress.Skipped > 0 {
+				status += fmt.Sprintf(", skipped: %d", task.Progress.Skipped)
+			}
+			status += ")"
+		}
+
+		line := fmt.Sprintf("%s  %s", task.ID, status)
+		if label != "" {
+			line += fmt.Sprintf("  %s", label)
+		}
+		if task.Config.Location != "" {
+			line += fmt.Sprintf("  [%s]", task.Config.Location)
+		}
+		if task.Results != nil && task.Status == "completed" {
+			line += fmt.Sprintf("  analyzed=%d avg=%.0f", task.Results.Analyzed, task.Results.AvgScore)
+		}
+		if task.Error != "" {
+			line += fmt.Sprintf("  error=%s", task.Error)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", line)
 	}
 
 	return nil

--- a/packages/cli/cmd/resume_debug_test.go
+++ b/packages/cli/cmd/resume_debug_test.go
@@ -621,6 +621,125 @@ func TestResumeDebugResetDatabaseRequiresConfirmation(t *testing.T) {
 	}
 }
 
+func TestResumeDebugAnalysisTasksCommandWritesJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/analysis-tasks" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(client.AnalysisTasksResponse{
+			Success: true,
+			Tasks: []client.AnalysisTask{
+				{
+					ID:        "task-1",
+					Status:    "completed",
+					CreatedAt: 1710000000000,
+					Config: &client.AnalysisTaskConfig{
+						JobDescriptionTitle: "CNC Sales",
+						Keywords:            []string{"CNC"},
+						Location:            "Dongguan",
+						ResumeCount:         25,
+					},
+					Results: &client.AnalysisTaskResults{
+						Analyzed:       25,
+						AvgScore:       82.5,
+						HighScoreCount: 5,
+					},
+				},
+				{
+					ID:     "task-2",
+					Status: "running",
+					Config: &client.AnalysisTaskConfig{
+						Keywords:    []string{"Sales"},
+						ResumeCount: 10,
+					},
+					Progress: &client.AnalysisTaskProgress{
+						Current: 5,
+						Total:   10,
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+	setCLIOutput(t, "json")
+
+	cmd := newResumeDebugAnalysisTasksCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug analysis-tasks command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	tasks, ok := payload["tasks"].([]any)
+	if !ok || len(tasks) != 2 {
+		t.Fatalf("unexpected tasks in output: %+v", payload)
+	}
+}
+
+func TestResumeDebugAnalysisTasksCommandWritesTable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/analysis-tasks" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(client.AnalysisTasksResponse{
+			Success: true,
+			Tasks: []client.AnalysisTask{
+				{
+					ID:     "task-1",
+					Status: "completed",
+					Config: &client.AnalysisTaskConfig{
+						JobDescriptionTitle: "CNC Sales",
+						Location:            "Dongguan",
+						ResumeCount:         25,
+					},
+					Results: &client.AnalysisTaskResults{
+						Analyzed:  25,
+						AvgScore:  82.5,
+						HighScoreCount: 5,
+					},
+				},
+				{
+					ID:     "task-2",
+					Status: "running",
+					Config: &client.AnalysisTaskConfig{
+						Keywords:    []string{"Sales"},
+						ResumeCount: 10,
+					},
+					Progress: &client.AnalysisTaskProgress{
+						Current: 5,
+						Total:   10,
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+
+	cmd := newResumeDebugAnalysisTasksCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug analysis-tasks command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "task-1") || !strings.Contains(text, "CNC Sales") {
+		t.Fatalf("unexpected analysis-tasks table output: %s", text)
+	}
+	if !strings.Contains(text, "task-2") || !strings.Contains(text, "running") || !strings.Contains(text, "5/10") {
+		t.Fatalf("unexpected analysis-tasks table output (task-2): %s", text)
+	}
+}
+
 func TestResumeDebugResetDatabaseDryRunWritesTable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/resumes/reset-database" {

--- a/packages/cli/cmd/resume_test.go
+++ b/packages/cli/cmd/resume_test.go
@@ -229,6 +229,102 @@ func TestResumeManualImportCommandWritesTableSummary(t *testing.T) {
 	}
 }
 
+func TestResumeAnalyzeCommandRequiresQueryOrJD(t *testing.T) {
+	cmd := newResumeAnalyzeCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected query or job-description required error")
+	}
+	if !strings.Contains(err.Error(), "query or job-description is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResumeAnalyzeCommandDryRunWritesJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/analyze" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(client.AnalyzeResponse{
+			Success:      true,
+			DryRun:        true,
+			ResumeCount:   42,
+			SkippedCount:  5,
+			Config: &client.AnalyzeConfig{
+				Keywords: []string{"CNC", "销售"},
+				Location: "Dongguan",
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+	setCLIOutput(t, "json")
+
+	cmd := newResumeAnalyzeCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--query", "CNC 销售", "--location", "Dongguan", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume analyze command failed: %v", err)
+	}
+
+	payload := decodeCommandJSON(t, output)
+	if payload["resumeCount"] != float64(42) || payload["dryRun"] != true {
+		t.Fatalf("unexpected analyze output: %+v", payload)
+	}
+}
+
+func TestResumeAnalyzeCommandWithJDWritesTable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/analyze" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if body["jobDescriptionId"] != "cnc-sales" {
+			t.Fatalf("expected jobDescriptionId=cnc-sales, got %v", body["jobDescriptionId"])
+		}
+		_ = json.NewEncoder(w).Encode(client.AnalyzeResponse{
+			Success:      true,
+			TaskID:       "task-abc",
+			ResumeCount:  30,
+			SkippedCount: 2,
+			Config: &client.AnalyzeConfig{
+				JobDescriptionID: "cnc-sales",
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+	setCLIOutput(t, "table")
+
+	cmd := newResumeAnalyzeCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--job-description", "cnc-sales"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume analyze command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "30") || !strings.Contains(text, "task-abc") || !strings.Contains(text, "cnc-sales") {
+		t.Fatalf("unexpected analyze table output: %s", text)
+	}
+}
+
 func TestResumeManualImportCommandRejectsZeroLimitWhenExplicitlySet(t *testing.T) {
 	cmd := newResumeManualImportCmd()
 	cmd.SetArgs([]string{"sample.rar", "--limit", "0"})

--- a/packages/cli/internal/client/api.go
+++ b/packages/cli/internal/client/api.go
@@ -554,3 +554,96 @@ func (c *Client) ResetDatabase(ctx context.Context, request ResetDatabaseRequest
 	}
 	return &response, nil
 }
+
+type AnalyzeRequest struct {
+	Query            string   `json:"query,omitempty"`
+	JobDescriptionID string   `json:"jobDescriptionId,omitempty"`
+	Location         string   `json:"location,omitempty"`
+	MinExperience    int      `json:"minExperience,omitempty"`
+	MaxExperience    int      `json:"maxExperience,omitempty"`
+	Education        []string `json:"education,omitempty"`
+	Skills           []string `json:"skills,omitempty"`
+	RequiredKeywords []string `json:"requiredKeywords,omitempty"`
+	Locations       []string `json:"locations,omitempty"`
+	MinSalary        int      `json:"minSalary,omitempty"`
+	MaxSalary        int      `json:"maxSalary,omitempty"`
+	Limit            int      `json:"limit,omitempty"`
+	DryRun           bool     `json:"dryRun,omitempty"`
+}
+
+type AnalyzeConfig struct {
+	JobDescriptionID string   `json:"jobDescriptionId,omitempty"`
+	Keywords         []string `json:"keywords,omitempty"`
+	Location         string   `json:"location,omitempty"`
+}
+
+type AnalyzeResponse struct {
+	Success      bool          `json:"success"`
+	DryRun       bool          `json:"dryRun,omitempty"`
+	TaskID       string        `json:"taskId,omitempty"`
+	ResumeCount  int           `json:"resumeCount"`
+	SkippedCount int           `json:"skippedCount,omitempty"`
+	Config       *AnalyzeConfig `json:"config,omitempty"`
+}
+
+func (c *Client) AnalyzeResumes(ctx context.Context, request AnalyzeRequest) (*AnalyzeResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/analyze", c.APIURL)
+	var response AnalyzeResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, request, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("analyze request was not successful")
+	}
+	return &response, nil
+}
+
+type AnalysisTaskProgress struct {
+	Current int `json:"current,omitempty"`
+	Total   int `json:"total,omitempty"`
+	Skipped int `json:"skipped,omitempty"`
+}
+
+type AnalysisTaskResults struct {
+	Analyzed      int     `json:"analyzed,omitempty"`
+	Failed       int     `json:"failed,omitempty"`
+	AvgScore      float64 `json:"avgScore,omitempty"`
+	HighScoreCount int    `json:"highScoreCount,omitempty"`
+}
+
+type AnalysisTaskConfig struct {
+	JobDescriptionID    string   `json:"jobDescriptionId,omitempty"`
+	JobDescriptionTitle string   `json:"jobDescriptionTitle,omitempty"`
+	Keywords            []string `json:"keywords,omitempty"`
+	Location            string   `json:"location,omitempty"`
+	PromptVersion       int      `json:"promptVersion,omitempty"`
+	ResumeCount         int      `json:"resumeCount,omitempty"`
+}
+
+type AnalysisTask struct {
+	ID           string               `json:"_id"`
+	Status       string               `json:"status"`
+	CreatedAt    int64                `json:"_creationTime"`
+	Config       *AnalysisTaskConfig  `json:"config,omitempty"`
+	Progress     *AnalysisTaskProgress `json:"progress,omitempty"`
+	Results      *AnalysisTaskResults  `json:"results,omitempty"`
+	LastStatus   string               `json:"lastStatus,omitempty"`
+	Error        string               `json:"error,omitempty"`
+}
+
+type AnalysisTasksResponse struct {
+	Success bool           `json:"success"`
+	Tasks   []AnalysisTask `json:"tasks"`
+}
+
+func (c *Client) ListAnalysisTasks(ctx context.Context) (*AnalysisTasksResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/analysis-tasks", c.APIURL)
+	var response AnalysisTasksResponse
+	if err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("list analysis tasks request was not successful")
+	}
+	return &response, nil
+}


### PR DESCRIPTION
## Summary
- Add `resume analyze` CLI command to dispatch production Convex AI analysis pipeline with search parameters (query, JD, location, experience, education, skills, salary filters)
- Add `resume debug analysis-tasks` CLI command to check dispatched analysis task status
- Add BFF API endpoints: `POST /api/resumes/analyze` (two-phase: search + dispatch) and `GET /api/resumes/analysis-tasks`
- Add MCP tools: `resume_analyze` and `analysis_tasks`
- Add Go client types and methods for both endpoints
- Update SKILL.md with new commands and rules

## Test plan
- [x] `make check` passes
- [x] All Go tests pass (`go test ./...` in packages/cli)
- [x] `resume analyze` without query/JD shows validation error
- [x] `resume analyze --dry-run` previews candidate count without dispatching
- [x] `resume analyze --job-description cnc-sales` dispatches analysis
- [x] `resume debug analysis-tasks` shows recent tasks with status
- [x] MCP tools `resume_analyze` and `analysis_tasks` return correct responses