### PR TITLE
fix: 4 regressions in resume analyze pipeline

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -4776,6 +4776,44 @@ app.post("/api/resumes/learning-feedback", async (c) => {
 });
 
 app.get("/api/resumes/skills-version", (c) => {
+app.get("/api/resumes/analysis-tasks", async (c) => {
+  try {
+    const tasks = (await callConvexQuery("analysis_tasks:list", {})) as Array<{
+      _id: string;
+      status: string;
+      _creationTime: number;
+      config?: {
+        jobDescriptionId?: string;
+        jobDescriptionTitle?: string;
+        keywords?: string[];
+        location?: string;
+        promptVersion?: number;
+        resumeCount?: number;
+      };
+      progress?: { current?: number; total?: number; skipped?: number };
+      results?: {
+        analyzed?: number;
+        failed?: number;
+        avgScore?: number;
+        highScoreCount?: number;
+      };
+      lastStatus?: string;
+      error?: string;
+    }>;
+
+    return c.json(
+      AnalysisTasksResponseSchema.parse({
+        success: true,
+        tasks,
+      }),
+      200,
+    );
+  } catch (error) {
+    console.error("Failed to list analysis tasks", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
   const version = skillsKnowledgeService.getVersion();
   return c.json({ success: true, version }, 200);
 });
@@ -5171,10 +5209,19 @@ app.post("/api/resumes/analyze", async (c) => {
   };
 
   try {
+    const canonicalKeywordQuery = normalizedQuery
+      ? formatKeywordQuery(normalizeKeywords(parseKeywordQuery(normalizedQuery).keywords))
+      : "";
+    const keywordExpansion = resumeService.expandSearchQuery(canonicalKeywordQuery);
+
     const searchArgs: Record<string, unknown> = {
-      query: normalizedQuery,
-      keywordGroups: [],
-      mode: "OR",
+      query: canonicalKeywordQuery || normalizedQuery,
+      keywordGroups: keywordExpansion?.groups ?? [],
+      mode: keywordExpansion?.mode ?? "OR",
+      sourceMappings: Object.entries(keywordExpansion?.sourceMapping ?? {}).map(([term, expandedFrom]) => ({
+        term,
+        expandedFrom,
+      })),
       ...(normalizedJobDescriptionId ? { jobDescriptionId: normalizedJobDescriptionId } : {}),
       ...(minExperience !== undefined ? { minExperience } : {}),
       ...(maxExperience !== undefined ? { maxExperience } : {}),
@@ -5261,43 +5308,5 @@ app.post("/api/resumes/analyze", async (c) => {
   }
 });
 
-app.get("/api/resumes/analysis-tasks", async (c) => {
-  try {
-    const tasks = (await callConvexQuery("analysis_tasks:list", {})) as Array<{
-      _id: string;
-      status: string;
-      _creationTime: number;
-      config?: {
-        jobDescriptionId?: string;
-        jobDescriptionTitle?: string;
-        keywords?: string[];
-        location?: string;
-        promptVersion?: number;
-        resumeCount?: number;
-      };
-      progress?: { current?: number; total?: number; skipped?: number };
-      results?: {
-        analyzed?: number;
-        failed?: number;
-        avgScore?: number;
-        highScoreCount?: number;
-      };
-      lastStatus?: string;
-      error?: string;
-    }>;
-
-    return c.json(
-      AnalysisTasksResponseSchema.parse({
-        success: true,
-        tasks,
-      }),
-      200,
-    );
-  } catch (error) {
-    console.error("Failed to list analysis tasks", error);
-    const message = error instanceof Error ? error.message : String(error);
-    return c.json({ success: false, error: message }, 500);
-  }
-});
 
 export default app;

--- a/scripts/e2e-smoke.ts
+++ b/scripts/e2e-smoke.ts
@@ -137,7 +137,9 @@ async function runCollectUrlKeywordModeTest(page: Page) {
         }) as typeof window.open;
     });
 
-    await page.getByLabel(/采集页数上限|採集頁數上限|Collect page limit/i).fill('3');
+    const collectPageLimitInput = page.getByLabel(/采集页数上限|採集頁數上限|Collect page limit/i);
+    await collectPageLimitInput.waitFor({ state: 'visible' });
+    await collectPageLimitInput.fill('3');
     await page.getByRole('button', { name: /采集|Collect/i }).click();
 
     const openedUrls = await page.evaluate(() => {

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -373,7 +373,6 @@ async def process_task(task, client: httpx.AsyncClient):
                 "deduped": 0,
                 "identityDeduped": 0,
                 "identityMatched": 0,
-                "legacyExternalIdMatched": 0,
                 "inserted": 0,
                 "updated": 0,
                 "unchanged": 0,
@@ -402,7 +401,6 @@ async def process_task(task, client: httpx.AsyncClient):
                     submit_stats["deduped"] = int(submit_result.get("deduped", 0))
                     submit_stats["identityDeduped"] = int(submit_result.get("identityDeduped", 0))
                     submit_stats["identityMatched"] = int(submit_result.get("identityMatched", 0))
-                    submit_stats["legacyExternalIdMatched"] = int(submit_result.get("legacyExternalIdMatched", 0))
                     submit_stats["inserted"] = int(submit_result.get("inserted", 0))
                     submit_stats["updated"] = int(submit_result.get("updated", 0))
                     submit_stats["unchanged"] = int(submit_result.get("unchanged", 0))
@@ -455,7 +453,6 @@ async def process_task(task, client: httpx.AsyncClient):
                     "deduped": submit_stats["deduped"],
                     "identityDeduped": submit_stats.get("identityDeduped", 0),
                     "identityMatched": submit_stats.get("identityMatched", 0),
-                    "legacyExternalIdMatched": submit_stats.get("legacyExternalIdMatched", 0),
                     "inserted": submit_stats["inserted"],
                     "updated": submit_stats["updated"],
                     "unchanged": submit_stats["unchanged"],


### PR DESCRIPTION
## Summary
- **Route shadowing**: `GET /api/resumes/analysis-tasks` was registered after `GET /api/resumes/{resumeId}`, so the dynamic route captured "analysis-tasks" as a resumeId and returned 404. Moved the static route before the dynamic one.
- **Zero candidates**: `POST /api/resumes/analyze` hardcoded `keywordGroups: []`, which triggers an early-return in Convex's `searchWithTagExpansionPaginated` (zero keywordGroups = zero results). Now calls `resumeService.expandSearchQuery()` to produce proper keyword groups + sourceMappings, matching the existing search route behavior.
- **Worker validator mismatch**: Worker sent `legacyExternalIdMatched` (a dead field never in the Convex schema) in `resume_tasks:complete`. Removed from the worker's stats tracking and payload.
- **E2E timeout**: Added `waitFor({state:'visible'})` before filling the Collect page limit input to handle dialog animation timing.

## Test plan
- [ ] `make cli-build` — compiles
- [ ] `./bin/trends resume debug analysis-tasks` — returns task list (not 404)
- [ ] `./bin/trends resume analyze --query "销售" --limit 5 --dry-run` — returns resumeCount > 0
- [ ] `go test ./packages/cli/...` — all pass
- [ ] `make check` — all pass