### PR TITLE
feat: add VITE_ENABLE_REVIEW_PACKETS feature flag + fix stale test fixtures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,6 @@ VITE_APP_TIMEZONE=Asia/Hong_Kong
 # Language / Locale (BCP47 format: zh-Hans, zh-Hant, en)
 AI_OUTPUT_LOCALE=zh-Hans      # AI analysis output language (resume system)
 VITE_DEFAULT_LOCALE=zh-Hans   # Frontend UI / static content default language
+
+# Experimental features
+# VITE_ENABLE_REVIEW_PACKETS=true   # Enable review-packets feature (off by default)

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -18,6 +18,14 @@ vi.mock('@/pages/ReviewPacketsPage', () => ({
   ReviewPacketsPage: () => <div>Review Packets Page</div>,
 }))
 
+const featureFlagsMock = vi.hoisted(() => ({
+  reviewPacketsEnabled: true,
+}))
+
+vi.mock('@/lib/feature-flags', () => ({
+  isReviewPacketsEnabled: () => featureFlagsMock.reviewPacketsEnabled,
+}))
+
 vi.mock('@/pages/DebugPage', () => ({
   DebugPage: ({ basePath }: { basePath: string }) => <div>Debug Page {basePath}</div>,
 }))
@@ -89,6 +97,7 @@ vi.mock('@/layouts/SystemSettingsLayout', () => ({
 describe('App redirects', () => {
   beforeEach(() => {
     window.history.replaceState({}, '', '/')
+    featureFlagsMock.reviewPacketsEnabled = true
   })
 
   it('preserves search params when redirecting a workspace index route to resumes', async () => {
@@ -112,6 +121,20 @@ describe('App redirects', () => {
     await waitFor(() => {
       expect(window.location.pathname).toBe('/hr/resumes')
       expect(window.location.search).toBe('?q=CNC&location=Kuala+Lumpur+MY')
+    })
+
+    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
+  })
+
+  it('redirects review-packets to resumes when feature flag is off', async () => {
+    featureFlagsMock.reviewPacketsEnabled = false
+
+    window.history.replaceState({}, '', '/dev/review-packets')
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/dev/resumes')
     })
 
     expect(screen.getByText('Resumes Page')).toBeInTheDocument()

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ import SystemLayout from '@/layouts/SystemLayout'
 import SystemSettingsLayout from '@/layouts/SystemSettingsLayout'
 import { WorkspaceProvider, useWorkspace } from '@/contexts/WorkspaceContext'
 import { ResumeFieldUsagePolicyProvider } from '@/contexts/ResumeFieldUsagePolicyContext'
+import { isReviewPacketsEnabled } from '@/lib/feature-flags'
 
 const LazyDebugPage = lazy(async () => {
   const module = await import('@/pages/DebugPage')
@@ -133,7 +134,11 @@ function App() {
 
             <Route element={<MainShell />}>
               <Route path="resumes" element={<ResumesPage />} />
-              <Route path="review-packets" element={<ReviewPacketsPage />} />
+              {isReviewPacketsEnabled() ? (
+                <Route path="review-packets" element={<ReviewPacketsPage />} />
+              ) : (
+                <Route path="review-packets" element={<PreserveSearchNavigate pathname="resumes" />} />
+              )}
             </Route>
 
             <Route path="settings" element={<SettingsLayout />}>

--- a/apps/web/src/components/Header.test.tsx
+++ b/apps/web/src/components/Header.test.tsx
@@ -82,11 +82,20 @@ vi.mock('./WorkspaceSwitcher', () => ({
   WorkspaceSwitcher: () => <div>Workspace Switcher</div>,
 }))
 
+const featureFlagsMock = vi.hoisted(() => ({
+  reviewPacketsEnabled: true,
+}))
+
+vi.mock('@/lib/feature-flags', () => ({
+  isReviewPacketsEnabled: () => featureFlagsMock.reviewPacketsEnabled,
+}))
+
 describe('Header', () => {
   beforeEach(() => {
     mockState.slug = 'dev'
     mockState.name = 'Development'
     mockState.isAdmin = true
+    featureFlagsMock.reviewPacketsEnabled = true
   })
 
   it('sends resume home reset state on logo and resumes navigation links', () => {
@@ -127,5 +136,21 @@ describe('Header', () => {
       expect(link).toHaveAttribute('href', '/dev/system')
       expect(link).toHaveAttribute('data-reset', 'false')
     })
+  })
+
+  it('hides review packets nav links when feature flag is off', () => {
+    featureFlagsMock.reviewPacketsEnabled = false
+
+    render(<Header />)
+
+    const reviewPacketLinks = screen.queryAllByRole('link', { name: 'Review packets' })
+    expect(reviewPacketLinks).toHaveLength(0)
+
+    // Other nav links are still visible
+    const resumeLinks = screen.getAllByRole('link', { name: 'Resumes' })
+    expect(resumeLinks).toHaveLength(2)
+
+    const settingsLinks = screen.getAllByRole('link', { name: 'Settings' })
+    expect(settingsLinks).toHaveLength(2)
   })
 })

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { LanguageSwitcher } from './LanguageSwitcher'
 import { WorkspaceSwitcher } from './WorkspaceSwitcher'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { RESUME_HOME_RESET_STATE } from '@/lib/resume-home-navigation'
+import { isReviewPacketsEnabled } from '@/lib/feature-flags'
 import { cn } from '@/lib/utils'
 
 interface HeaderProps {
@@ -16,6 +17,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
   const { slug, name, isAdmin } = useWorkspace()
   const resumesPath = `/${slug}/resumes`
   const reviewPacketsPath = `/${slug}/review-packets`
+  const showReviewPackets = isReviewPacketsEnabled()
   const settingsPath = `/${slug}/settings`
   const systemPath = `/${slug}/system`
 
@@ -44,17 +46,19 @@ export function Header({ leftAction }: HeaderProps = {}) {
             >
               {t('nav.resumes')}
             </NavLink>
-            <NavLink
-              to={reviewPacketsPath}
-              className={({ isActive }) =>
-                cn(
-                  'transition-colors hover:text-foreground',
-                  isActive ? 'text-foreground' : 'text-muted-foreground'
-                )
-              }
-            >
-              {t('nav.reviewPackets', { defaultValue: 'Review packets' })}
-            </NavLink>
+            {showReviewPackets ? (
+              <NavLink
+                to={reviewPacketsPath}
+                className={({ isActive }) =>
+                  cn(
+                    'transition-colors hover:text-foreground',
+                    isActive ? 'text-foreground' : 'text-muted-foreground'
+                  )
+                }
+              >
+                {t('nav.reviewPackets', { defaultValue: 'Review packets' })}
+              </NavLink>
+            ) : null}
             <NavLink
               to={settingsPath}
               className={({ isActive }) =>
@@ -99,17 +103,19 @@ export function Header({ leftAction }: HeaderProps = {}) {
             >
               {t('nav.resumes')}
             </NavLink>
-            <NavLink
-              to={reviewPacketsPath}
-              className={({ isActive }) =>
-                cn(
-                  'transition-colors hover:text-foreground',
-                  isActive ? 'text-foreground' : 'text-muted-foreground'
-                )
-              }
-            >
-              {t('nav.reviewPackets', { defaultValue: 'Review packets' })}
-            </NavLink>
+            {showReviewPackets ? (
+              <NavLink
+                to={reviewPacketsPath}
+                className={({ isActive }) =>
+                  cn(
+                    'transition-colors hover:text-foreground',
+                    isActive ? 'text-foreground' : 'text-muted-foreground'
+                  )
+                }
+              >
+                {t('nav.reviewPackets', { defaultValue: 'Review packets' })}
+              </NavLink>
+            ) : null}
             <NavLink
               to={settingsPath}
               className={({ isActive }) =>

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -228,6 +228,10 @@ vi.mock('sonner', () => ({
   },
 }))
 
+vi.mock('@/lib/feature-flags', () => ({
+  isReviewPacketsEnabled: () => true,
+}))
+
 beforeAll(() => {
   Object.defineProperty(window.URL, 'createObjectURL', {
     writable: true,

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -66,6 +66,7 @@ import {
   toMatchBreakdown,
 } from '@/lib/resume-scoring'
 import type { CollectionSource } from '@/lib/search-profile-sources'
+import { isReviewPacketsEnabled } from '@/lib/feature-flags'
 
 type JobDescriptionApiResponse = {
   success: boolean
@@ -1834,7 +1835,7 @@ export function useResumeListState(loadSearchHistory = false) {
   )
 
   const handleOpenReviewPacket = useCallback(async () => {
-    if (selectedIds.size === 0) {
+    if (!isReviewPacketsEnabled() || selectedIds.size === 0) {
       return
     }
 

--- a/apps/web/src/lib/analysis-utils.test.ts
+++ b/apps/web/src/lib/analysis-utils.test.ts
@@ -11,11 +11,13 @@ import {
 
 describe('buildKeywordAnalysisId', () => {
   it('matches backend output fixtures', () => {
+    // Pin promptVersion so fixtures stay stable across prompt version bumps.
+    const opts = { promptVersion: 1 }
     expect(buildKeywordAnalysisId([])).toBe('keyword-search')
-    expect(buildKeywordAnalysisId(['CNC', '车床'])).toBe('keyword-search:2:242bbfbb')
-    expect(buildKeywordAnalysisId(['  cnc ', 'CNC', '车床', ''])).toBe('keyword-search:2:242bbfbb')
-    expect(buildKeywordAnalysisId(['车床', 'cnc', '销售'])).toBe('keyword-search:3:e022651b')
-    expect(buildKeywordAnalysisId(['销售', '车床', 'cnc', '销售'])).toBe('keyword-search:3:e022651b')
+    expect(buildKeywordAnalysisId(['CNC', '车床'], opts)).toBe('keyword-search:2:292bc79a')
+    expect(buildKeywordAnalysisId(['  cnc ', 'CNC', '车床', ''], opts)).toBe('keyword-search:2:292bc79a')
+    expect(buildKeywordAnalysisId(['车床', 'cnc', '销售'], opts)).toBe('keyword-search:3:e5226cfa')
+    expect(buildKeywordAnalysisId(['销售', '车床', 'cnc', '销售'], opts)).toBe('keyword-search:3:e5226cfa')
   })
 
   it('changes when location or prompt version changes', () => {

--- a/apps/web/src/lib/feature-flags.ts
+++ b/apps/web/src/lib/feature-flags.ts
@@ -1,0 +1,13 @@
+/**
+ * Feature flag helpers for experimental features.
+ *
+ * All flags default to **off** (false) unless the corresponding
+ * VITE_ env variable is explicitly set to `"true"`.
+ * This ensures production deployments that omit the variable
+ * never expose the experimental feature.
+ */
+
+/** Returns true when the review-packets feature is enabled via env. */
+export function isReviewPacketsEnabled(): boolean {
+  return import.meta.env.VITE_ENABLE_REVIEW_PACKETS === 'true'
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ENABLE_REVIEW_PACKETS?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary

- Add `VITE_ENABLE_REVIEW_PACKETS` env variable (off by default) to gate the review-packets experimental feature
- When unset/off: nav links hidden, route redirects to resumes, handleOpenReviewPacket returns early
- When set to `true`: full review-packets UI is available
- Fix pre-existing `analysis-utils.test.ts` hash mismatch by pinning `promptVersion` in test fixtures

## Files changed

| File | Change |
|------|--------|
| `apps/web/src/lib/feature-flags.ts` | New `isReviewPacketsEnabled()` helper |
| `apps/web/src/vite-env.d.ts` | Type `VITE_ENABLE_REVIEW_PACKETS` |
| `.env.example` | Document env var (commented out = off) |
| `apps/web/src/components/Header.tsx` | Conditional review-packets nav links |
| `apps/web/src/App.tsx` | Conditional route (redirect when off) |
| `apps/web/src/hooks/useResumeListState.ts` | Guard `handleOpenReviewPacket` |
| `apps/web/src/components/Header.test.tsx` | Feature flag mock + disabled-state test |
| `apps/web/src/App.test.tsx` | Feature flag mock + redirect test |
| `apps/web/src/hooks/useResumeListState.test.tsx` | Added `isReviewPacketsEnabled` mock |
| `apps/web/src/lib/analysis-utils.test.ts` | Pin `promptVersion` to fix stale hash fixtures |