### PR TITLE
feat: add AI summary feature flag + skip hook work when disabled

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,4 @@ VITE_DEFAULT_LOCALE=zh-Hans   # Frontend UI / static content default language
 
 # Experimental features
 # VITE_ENABLE_REVIEW_PACKETS=true   # Enable review-packets feature (off by default)
+# VITE_ENABLE_RESUME_AI_SUMMARY=true # Enable resume search AI result summary panel (off by default)

--- a/apps/web/src/hooks/useAiSearchSummary.test.tsx
+++ b/apps/web/src/hooks/useAiSearchSummary.test.tsx
@@ -95,6 +95,23 @@ describe('useAiSearchSummary', () => {
     vi.useRealTimers()
   })
 
+  it('does not request a summary when enabled is false', async () => {
+    const { result } = renderHook(() => useAiSearchSummary({
+      enabled: false,
+      query: 'machine tools',
+      results: [createResult(1)],
+      selectedCompanies: ['FANUC'],
+      selectedTags: ['Machine Tools'],
+    }))
+
+    await advanceDebounceWindow(2500)
+
+    expect(postMock).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(false)
+    expect(result.current.summary).toBeUndefined()
+    expect(result.current.generatedAt).toBeUndefined()
+  })
+
   it('does not request a summary when the query is blank or there are no results', async () => {
     const { rerender, result } = renderHook(
       (props: Parameters<typeof useAiSearchSummary>[0]) => useAiSearchSummary(props),

--- a/apps/web/src/hooks/useAiSearchSummary.ts
+++ b/apps/web/src/hooks/useAiSearchSummary.ts
@@ -3,6 +3,7 @@ import { rawApiClient } from '@/lib/api-helpers'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 
 type UseAiSearchSummaryArgs = {
+  enabled?: boolean
   jobDescriptionId?: string
   location?: string
   query?: string
@@ -47,6 +48,7 @@ function buildSnippet(item: ResumeSearchResultItem): string {
 }
 
 export function useAiSearchSummary({
+  enabled = true,
   jobDescriptionId,
   location,
   query,
@@ -60,6 +62,10 @@ export function useAiSearchSummary({
   const [loading, setLoading] = useState(false)
 
   const payload = useMemo(() => {
+    if (!enabled) {
+      return null
+    }
+
     const normalizedQuery = query?.trim()
     if (!normalizedQuery || results.length === 0) {
       return null
@@ -98,7 +104,7 @@ export function useAiSearchSummary({
     }
 
     return payloadValue
-  }, [jobDescriptionId, location, query, results, selectedCompanies, selectedExperienceLevel, selectedTags])
+  }, [enabled, jobDescriptionId, location, query, results, selectedCompanies, selectedExperienceLevel, selectedTags])
 
   useEffect(() => {
     let active = true

--- a/apps/web/src/lib/feature-flags.ts
+++ b/apps/web/src/lib/feature-flags.ts
@@ -7,7 +7,10 @@
  * never expose the experimental feature.
  */
 
-/** Returns true when the review-packets feature is enabled via env. */
 export function isReviewPacketsEnabled(): boolean {
   return import.meta.env.VITE_ENABLE_REVIEW_PACKETS === 'true'
+}
+
+export function isResumeAiSummaryEnabled(): boolean {
+  return import.meta.env.VITE_ENABLE_RESUME_AI_SUMMARY === 'true'
 }

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -51,6 +51,14 @@ const {
   useResumeSearchStateMock: vi.fn(),
 }))
 
+const featureFlagsMock = vi.hoisted(() => ({
+  resumeAiSummaryEnabled: false,
+}))
+
+vi.mock('@/lib/feature-flags', () => ({
+  isResumeAiSummaryEnabled: () => featureFlagsMock.resumeAiSummaryEnabled,
+}))
+
 vi.mock('@/hooks/useAiSearchSummary', () => ({
   useAiSearchSummary: (...args: unknown[]) => useAiSearchSummaryMock(...args),
 }))
@@ -513,6 +521,7 @@ function createResumeSearchState(overrides: Record<string, unknown> = {}) {
 describe('ResumeSearchPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    featureFlagsMock.resumeAiSummaryEnabled = false
     useIndustryKeywordsMock.mockReturnValue({
       hotKeywords: [],
       quickStartProfiles: [],
@@ -641,6 +650,7 @@ describe('ResumeSearchPage', () => {
 
   it('renders the active results shell, maps cluster names for AI summary, and opens the mobile filter sheet from the badge', async () => {
     const user = userEvent.setup()
+    featureFlagsMock.resumeAiSummaryEnabled = true
     const state = createResumeSearchState({
       activeQuery: 'machine tools',
       aiModeStats: {
@@ -743,6 +753,7 @@ describe('ResumeSearchPage', () => {
 
   it('falls back to cluster slugs for AI summary tags and preserves local result-shell state interactions', async () => {
     const user = userEvent.setup()
+    featureFlagsMock.resumeAiSummaryEnabled = true
     const state = createResumeSearchState({
       activeQuery: 'servo automation',
       filteredResults: [createResult(1), createResult(2)],
@@ -810,6 +821,26 @@ describe('ResumeSearchPage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Load more results' }))
     expect(state.loadMore).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the AI summary panel when the dedicated summary feature flag is off', () => {
+    const state = createResumeSearchState({
+      activeQuery: 'CNC Sales',
+      filteredResults: [createResult(1)],
+      isLanding: false,
+    })
+    useResumeSearchStateMock.mockReturnValue(state)
+    useAiSearchSummaryMock.mockReturnValue({
+      generatedAt: 123,
+      loading: false,
+      summary: 'Summary text',
+    })
+
+    render(<ResumeSearchPage />)
+
+    expect(
+      screen.queryByText('AI Summary Summary text generated:123 loading:false'),
+    ).not.toBeInTheDocument()
   })
 
   it('wires header export controls into the search-state actions', async () => {

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -16,9 +16,11 @@ import { Button } from '@/components/ui/button'
 import { useAiSearchSummary } from '@/hooks/useAiSearchSummary'
 import { useIndustryKeywords } from '@/hooks/useIndustryKeywords'
 import { useResumeSearchState } from '@/hooks/useResumeSearchState'
+import { isResumeAiSummaryEnabled } from '@/lib/feature-flags'
 
 export function ResumeSearchPage() {
   const { t } = useTranslation()
+  const resumeAiSummaryEnabled = isResumeAiSummaryEnabled()
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [filtersOpen, setFiltersOpen] = useState(false)
   const { hotKeywords, quickStartProfiles } = useIndustryKeywords()
@@ -95,6 +97,7 @@ export function ResumeSearchPage() {
     ]
   }, [selectedClusterTags, selectedRawTags, taxonomyClusters])
   const aiSummary = useAiSearchSummary({
+    enabled: resumeAiSummaryEnabled,
     query: activeQuery,
     location: parsedState.location,
     jobDescriptionId: parsedState.jobDescriptionId,
@@ -338,11 +341,13 @@ export function ResumeSearchPage() {
                 </div>
               </div>
 
-              <AiSummaryPanel
-                generatedAt={aiSummary.generatedAt}
-                loading={aiSummary.loading}
-                summary={aiSummary.summary}
-              />
+              {resumeAiSummaryEnabled && (
+                <AiSummaryPanel
+                  generatedAt={aiSummary.generatedAt}
+                  loading={aiSummary.loading}
+                  summary={aiSummary.summary}
+                />
+              )}
 
               <BulkActionBar
                 totalCount={filteredResults.length}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_ENABLE_REVIEW_PACKETS?: string
+  readonly VITE_ENABLE_RESUME_AI_SUMMARY?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Add `VITE_ENABLE_RESUME_AI_SUMMARY` feature flag to gate the AI summary panel on the resume search page (off by default)
- Add `enabled` option to `useAiSearchSummary` hook — when `false`, short-circuits payload computation and skips the debounced HTTP POST, eliminating wasted network requests and unnecessary React state updates when the feature is off
- Simplify conditional render from ternary to `&&`; remove WHAT-comments from feature-flags.ts

## Test plan
- [x] New test: "does not request a summary when enabled is false" — verifies no HTTP POST fires when `enabled: false`
- [x] New test: "hides the AI summary panel when the dedicated summary feature flag is off" — verifies panel DOM is absent
- [x] Existing AI-summary tests pass with `featureFlagsMock.resumeAiSummaryEnabled` toggled appropriately
- [x] `make check` passes