### PR TITLE
feat: add archive/unarchive for resumes (soft-delete)

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -221,6 +221,11 @@ const ResetDatabaseRequestSchema = z.object({
   dryRun: z.boolean().optional(),
 });
 
+const ArchiveResumesRequestSchema = z.object({
+  resumeIds: z.array(z.string()).min(1),
+  action: z.union([z.literal("archive"), z.literal("unarchive")]),
+});
+
 const ResetDatabaseV2ResponseSchema = z.object({
   success: z.literal(true),
   dryRun: z.boolean().optional(),
@@ -5126,6 +5131,44 @@ app.post("/api/resumes/reset-database", async (c) => {
     return c.json(ResetDatabaseV2ResponseSchema.parse(value), 200);
   } catch (error) {
     console.error("Failed to reset database", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+app.post("/api/resumes/archive", async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false, error: "Admin access required" }, 403);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = ArchiveResumesRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ success: false, error: "Invalid request payload" }, 400);
+  }
+
+  const { resumeIds, action } = parsed.data;
+
+  try {
+    if (action === "archive") {
+      const result = await callConvexMutation("resumes:archiveResumes", { resumeIds }) as {
+        requested: number;
+        archived: number;
+        alreadyArchived: number;
+        missingResumeIds: string[];
+      };
+      return c.json({ success: true, ...result }, 200);
+    } else {
+      const result = await callConvexMutation("resumes:unarchiveResumes", { resumeIds }) as {
+        requested: number;
+        unarchived: number;
+        notArchived: number;
+        missingResumeIds: string[];
+      };
+      return c.json({ success: true, ...result }, 200);
+    }
+  } catch (error) {
+    console.error("Failed to archive/unarchive resumes", error);
     const message = error instanceof Error ? error.message : String(error);
     return c.json({ success: false, error: message }, 500);
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -21,6 +21,7 @@ const LazyDebugJDs = lazy(() => import('@/pages/DebugJDs'))
 const LazyDebugAI = lazy(() => import('@/pages/DebugAI'))
 const LazyDebugConfig = lazy(() => import('@/pages/DebugConfig'))
 const LazyDebugIngest = lazy(() => import('@/pages/DebugIngest'))
+const LazyArchivedResumes = lazy(() => import('@/pages/ArchivedResumes'))
 const LazyDebugAiTaggingResults = lazy(() => import('@/pages/DebugAiTaggingResults'))
 
 const LazyBlacklistPage = lazy(async () => {
@@ -265,6 +266,14 @@ function App() {
                 element={(
                   <RouteSuspense>
                     <LazyDebugIngest />
+                  </RouteSuspense>
+                )}
+              />
+              <Route
+                path="archived"
+                element={(
+                  <RouteSuspense>
+                    <LazyArchivedResumes />
                   </RouteSuspense>
                 )}
               />

--- a/apps/web/src/pages/ArchivedResumes.tsx
+++ b/apps/web/src/pages/ArchivedResumes.tsx
@@ -1,0 +1,244 @@
+import { useMemo, useState } from 'react'
+import { sanitizeResumeRecordForSurface } from '@trends/shared'
+import { useMutation, usePaginatedQuery } from 'convex/react'
+import { api } from '../../../../packages/convex/convex/_generated/api'
+import { useTranslation } from 'react-i18next'
+import { Archive, ArchiveRestore } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { PageHeader } from '@/components/PageHeader'
+import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
+
+type ArchivedResume = {
+  resumeId: string
+  externalId: string
+  name: string
+  jobIntention: string
+  location: string
+  isArchived?: boolean
+  archivedAt?: number
+}
+
+function getSearchTarget(resume: ArchivedResume): string {
+  return [resume.externalId, resume.name, resume.jobIntention, resume.location]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join(' ')
+    .toLowerCase()
+}
+
+function formatTimestamp(value: number | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return '--'
+  }
+  return new Date(value).toLocaleString()
+}
+
+const PAGE_SIZE = 100
+
+export default function ArchivedResumes() {
+  const { t } = useTranslation()
+  const fieldUsagePolicy = useResumeFieldUsagePolicy()
+
+  const {
+    results: paginatedResumes,
+    status,
+    loadMore,
+  } = usePaginatedQuery(api.resumes.listArchivedDiagnostics, {}, { initialNumItems: PAGE_SIZE })
+
+  const unarchiveResumesMutation = useMutation(api.resumes.unarchiveResumes)
+
+  const [search, setSearch] = useState('')
+  const [selectedResumeIds, setSelectedResumeIds] = useState<Set<string>>(new Set())
+  const [unarchiving, setUnarchiving] = useState(false)
+
+  const resumes = useMemo(
+    () => paginatedResumes.map((resume) => sanitizeResumeRecordForSurface(resume, 'debug', fieldUsagePolicy)),
+    [fieldUsagePolicy, paginatedResumes],
+  )
+
+  const filteredResumes = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    if (!query) return resumes as ArchivedResume[]
+    return (resumes as ArchivedResume[]).filter((resume) => getSearchTarget(resume).includes(query))
+  }, [resumes, search])
+
+  const visibleResumeIds = useMemo(() => filteredResumes.map((r) => String(r.resumeId)), [filteredResumes])
+  const allVisibleSelected = visibleResumeIds.length > 0 && visibleResumeIds.every((id) => selectedResumeIds.has(id))
+  const someVisibleSelected = visibleResumeIds.some((id) => selectedResumeIds.has(id))
+
+  const toggleSelectResume = (resumeId: string, selected: boolean) => {
+    setSelectedResumeIds((previous) => {
+      const next = new Set(previous)
+      if (selected) {
+        next.add(resumeId)
+      } else {
+        next.delete(resumeId)
+      }
+      return next
+    })
+  }
+
+  const toggleSelectAllVisible = (selected: boolean) => {
+    setSelectedResumeIds((previous) => {
+      const next = new Set(previous)
+      if (selected) {
+        visibleResumeIds.forEach((id) => next.add(id))
+      } else {
+        visibleResumeIds.forEach((id) => next.delete(id))
+      }
+      return next
+    })
+  }
+
+  const unarchiveResumes = async (resumeIds: string[]) => {
+    if (resumeIds.length === 0 || unarchiving) {
+      return
+    }
+    setUnarchiving(true)
+    try {
+      const result = await unarchiveResumesMutation({ resumeIds })
+      const unarchivedIdSet = new Set(resumeIds)
+      setSelectedResumeIds((previous) => {
+        const next = new Set([...previous].filter((id) => !unarchivedIdSet.has(id)))
+        return next.size === previous.size ? previous : next
+      })
+      if (result.unarchived > 0) {
+        toast.success(t('archivedResumes.restoreSuccess', { count: result.unarchived, defaultValue: `Restored ${result.unarchived} resume(s)` }))
+      } else {
+        toast.info(t('archivedResumes.restoreNothing', { defaultValue: 'No resumes to restore' }))
+      }
+    } catch (error) {
+      console.error('Failed to restore resumes', error)
+      toast.error(t('archivedResumes.restoreFailed', { defaultValue: 'Failed to restore resumes' }))
+    } finally {
+      setUnarchiving(false)
+    }
+  }
+
+  const loading = status === 'LoadingFirstPage'
+  const canLoadMore = status === 'CanLoadMore'
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={
+          <>
+            <Archive className="h-6 w-6 text-primary" />
+            {t('archivedResumes.title', { defaultValue: 'Archived Resumes' })}
+          </>
+        }
+        description={t('archivedResumes.subtitle', { defaultValue: 'View and restore archived resumes.' })}
+      />
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder={t('archivedResumes.searchPlaceholder', { defaultValue: 'Search by name / intention / location...' })}
+          className="max-w-xl"
+        />
+        <Button
+          variant="outline"
+          onClick={() => void unarchiveResumes([...selectedResumeIds])}
+          disabled={selectedResumeIds.size === 0 || unarchiving}
+        >
+          <ArchiveRestore className={`mr-2 h-4 w-4 ${unarchiving ? 'animate-spin' : ''}`} />
+          {t('archivedResumes.restoreSelected', {
+            count: selectedResumeIds.size,
+            defaultValue: `Restore Selected (${selectedResumeIds.size})`,
+          })}
+        </Button>
+      </div>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[48px]">
+                <Checkbox
+                  checked={allVisibleSelected ? true : someVisibleSelected ? 'indeterminate' : false}
+                  onCheckedChange={(checked) => toggleSelectAllVisible(checked === true)}
+                  aria-label={t('bulkActions.selectAll', { defaultValue: 'Select all' })}
+                  disabled={visibleResumeIds.length === 0 || unarchiving}
+                />
+              </TableHead>
+              <TableHead>{t('resumes.columns.name', { defaultValue: 'Name' })}</TableHead>
+              <TableHead>{t('resumes.columns.intention', { defaultValue: 'Intention' })}</TableHead>
+              <TableHead>{t('resumes.columns.location', { defaultValue: 'Location' })}</TableHead>
+              <TableHead>{t('archivedResumes.archivedAt', { defaultValue: 'Archived At' })}</TableHead>
+              <TableHead>{t('debugIngest.status', { defaultValue: 'Status' })}</TableHead>
+              <TableHead className="text-right">{t('resumes.columns.actions', { defaultValue: 'Actions' })}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center text-muted-foreground">
+                  {t('resumes.loading', { defaultValue: 'Loading...' })}
+                </TableCell>
+              </TableRow>
+            ) : filteredResumes.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center text-muted-foreground">
+                  {t('archivedResumes.noResults', { defaultValue: 'No archived resumes found' })}
+                </TableCell>
+              </TableRow>
+            ) : (
+              filteredResumes.map((resume) => {
+                const resumeId = String(resume.resumeId)
+                const isSelected = selectedResumeIds.has(resumeId)
+
+                return (
+                  <TableRow key={resumeId} data-state={isSelected ? 'selected' : undefined}>
+                    <TableCell>
+                      <Checkbox
+                        checked={isSelected}
+                        onCheckedChange={(checked) => toggleSelectResume(resumeId, checked === true)}
+                        aria-label={resumeId}
+                        disabled={unarchiving}
+                      />
+                    </TableCell>
+                    <TableCell>{resume.name || '--'}</TableCell>
+                    <TableCell>{resume.jobIntention || '--'}</TableCell>
+                    <TableCell>{resume.location || '--'}</TableCell>
+                    <TableCell>{formatTimestamp(resume.archivedAt)}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className="border-zinc-200 bg-zinc-50 text-zinc-600">
+                        {t('archivedResumes.archivedBadge', { defaultValue: 'Archived' })}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="hover:text-emerald-600 hover:bg-emerald-50"
+                        onClick={() => void unarchiveResumes([resumeId])}
+                        disabled={unarchiving}
+                      >
+                        <ArchiveRestore className="mr-2 h-4 w-4" />
+                        {t('archivedResumes.restore', { defaultValue: 'Restore' })}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                )
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex justify-end">
+        <Button variant="outline" onClick={() => loadMore(PAGE_SIZE)} disabled={!canLoadMore}>
+          {status === 'LoadingMore'
+            ? t('resumes.loading', { defaultValue: 'Loading...' })
+            : t('debugIngest.loadMore', { defaultValue: 'Load More' })}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/DebugIngest.tsx
+++ b/apps/web/src/pages/DebugIngest.tsx
@@ -9,7 +9,7 @@ import {
 import { useAction, useMutation, usePaginatedQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import { useTranslation } from 'react-i18next'
-import { RefreshCw, Database, ChevronDown, ChevronRight, Trash2 } from 'lucide-react'
+import { RefreshCw, Database, ChevronDown, ChevronRight, Trash2, Archive } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -27,6 +27,8 @@ type IngestDiagnosticsResume = {
   name: string
   jobIntention: string
   location: string
+  isArchived?: boolean
+  archivedAt?: number
   ingestData?: {
     industryTags: string[]
     companyHits: string[]
@@ -153,6 +155,7 @@ export default function DebugIngest() {
   const hardResetIngestDataMutation = useMutation(api.resumes.hardResetIngestData)
   const resetDatabaseMutation = useMutation(api.resume_tasks.resetDatabase)
   const deleteResumesMutation = useMutation(api.resumes.deleteResumes)
+  const archiveResumesMutation = useMutation(api.resumes.archiveResumes)
 
   const [search, setSearch] = useState('')
   const [skillsVersion, setSkillsVersion] = useState<number | null>(null)
@@ -161,6 +164,7 @@ export default function DebugIngest() {
   const [selectedResumeIds, setSelectedResumeIds] = useState<Set<string>>(new Set())
   const [resumePendingDelete, setResumePendingDelete] = useState<IngestDiagnosticsResume | null>(null)
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false)
+  const [archivingResumes, setArchivingResumes] = useState(false)
   const [reingesting, setReingesting] = useState(false)
   const [clearingAnalyses, setClearingAnalyses] = useState(false)
   const [hardResetting, setHardResetting] = useState(false)
@@ -469,6 +473,38 @@ export default function DebugIngest() {
     }
   }, [createDeleteSummaryMessage, deleteResumesMutation, deletingResumes, t])
 
+  const archiveResumes = useCallback(async (resumeIds: string[]) => {
+    if (resumeIds.length === 0 || archivingResumes) {
+      return
+    }
+
+    setArchivingResumes(true)
+    try {
+      const result = await archiveResumesMutation({ resumeIds })
+      const archivedIdSet = new Set(resumeIds)
+
+      setSelectedResumeIds((previous) => {
+        const next = new Set([...previous].filter((resumeId) => !archivedIdSet.has(resumeId)))
+        return next.size === previous.size ? previous : next
+      })
+      setExpandedIds((previous) => {
+        const nextIds = [...previous].filter((resumeId) => !archivedIdSet.has(resumeId))
+        return nextIds.length === previous.size ? previous : new Set(nextIds)
+      })
+
+      if (result.archived > 0) {
+        toast.success(t('debugIngest.archiveSuccess', { count: result.archived, defaultValue: `Archived ${result.archived} resume(s)` }))
+      } else {
+        toast.info(t('debugIngest.archiveAlreadyDone', { defaultValue: 'Resumes already archived' }))
+      }
+    } catch (error) {
+      console.error('Failed to archive resumes', error)
+      toast.error(t('debugIngest.archiveFailed', { defaultValue: 'Failed to archive resumes' }))
+    } finally {
+      setArchivingResumes(false)
+    }
+  }, [archiveResumesMutation, archivingResumes, t])
+
   const confirmSingleDelete = useCallback(() => {
     if (!resumePendingDelete) {
       return
@@ -482,6 +518,13 @@ export default function DebugIngest() {
     }
     void deleteResumes([...selectedResumeIds])
   }, [deleteResumes, selectedResumeIds])
+
+  const archiveSelected = useCallback(() => {
+    if (selectedResumeIds.size === 0 || archivingResumes) {
+      return
+    }
+    void archiveResumes([...selectedResumeIds])
+  }, [archiveResumes, archivingResumes, selectedResumeIds])
 
   return (
     <div className="space-y-6">
@@ -547,14 +590,14 @@ export default function DebugIngest() {
           {t('debugIngest.reingest', { defaultValue: 'Trigger Re-ingest' })}
         </Button>
         <Button
-          variant="destructive"
-          onClick={() => setBulkDeleteDialogOpen(true)}
-          disabled={selectedResumeIds.size === 0 || deletingResumes}
+          variant="outline"
+          onClick={archiveSelected}
+          disabled={selectedResumeIds.size === 0 || archivingResumes}
         >
-          <Trash2 className={`mr-2 h-4 w-4 ${deletingResumes ? 'animate-spin' : ''}`} />
-          {t('debugIngest.deleteSelected', {
+          <Archive className={`mr-2 h-4 w-4 ${archivingResumes ? 'animate-spin' : ''}`} />
+          {t('debugIngest.archiveSelected', {
             count: selectedResumeIds.size,
-            defaultValue: `Delete Selected (${selectedResumeIds.size})`,
+            defaultValue: `Archive Selected (${selectedResumeIds.size})`,
           })}
         </Button>
         <Button variant="destructive" onClick={() => void clearAnalyses()} disabled={clearingAnalyses}>
@@ -860,12 +903,12 @@ export default function DebugIngest() {
                           type="button"
                           variant="ghost"
                           size="sm"
-                          className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                          onClick={() => setResumePendingDelete(resume)}
-                          disabled={deletingResumes}
+                          className="hover:text-primary hover:bg-primary/10"
+                          onClick={() => archiveResumes([resumeId])}
+                          disabled={archivingResumes}
                         >
-                          <Trash2 className="mr-2 h-4 w-4" />
-                          {t('common.delete', { defaultValue: 'Delete' })}
+                          <Archive className="mr-2 h-4 w-4" />
+                          {t('common.archive', { defaultValue: 'Archive' })}
                         </Button>
                       </TableCell>
                     </TableRow>

--- a/apps/web/src/types/resume.ts
+++ b/apps/web/src/types/resume.ts
@@ -10,6 +10,7 @@ export type ResumeFilters = {
   locations?: string[]
   status?: CandidateStatus[]
   showBlocked?: boolean
+  showArchived?: boolean
   minSalary?: number
   maxSalary?: number
   minMatchScore?: number

--- a/packages/cli/cmd/resume.go
+++ b/packages/cli/cmd/resume.go
@@ -35,6 +35,8 @@ func newResumeCmd() *cobra.Command {
 		newResumeDeployBackupCmd(),
 		newResumeExportCmd(),
 		newResumeDebugCmd(),
+		newResumeArchiveCmd(),
+		newResumeUnarchiveCmd(),
 	)
 
 	return resumeCmd
@@ -706,6 +708,56 @@ func resumeIdentifier(item client.ResumeItem, index int) string {
 		return item.ExternalID
 	}
 	return fmt.Sprintf("resume-%d", index+1)
+}
+
+func newResumeArchiveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "archive <id> [<id>...]",
+		Short: "Archive one or more resumes (soft-delete)",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := newAPIClient().ArchiveResumes(context.Background(), args)
+			if err != nil {
+				return fmt.Errorf("archive resumes: %w", err)
+			}
+			return writeOutput(cmd,
+				[]string{"requested", "archived", "already_archived", "missing"},
+				[][]string{{
+					strconv.Itoa(response.Requested),
+					strconv.Itoa(response.Archived),
+					strconv.Itoa(response.AlreadyArchived),
+					strings.Join(response.MissingIDs, ", "),
+				}},
+				response,
+			)
+		},
+	}
+	return cmd
+}
+
+func newResumeUnarchiveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unarchive <id> [<id>...]",
+		Short: "Restore one or more archived resumes",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := newAPIClient().UnarchiveResumes(context.Background(), args)
+			if err != nil {
+				return fmt.Errorf("unarchive resumes: %w", err)
+			}
+			return writeOutput(cmd,
+				[]string{"requested", "unarchived", "not_archived", "missing"},
+				[][]string{{
+					strconv.Itoa(response.Requested),
+					strconv.Itoa(response.Unarchived),
+					strconv.Itoa(response.NotArchived),
+					strings.Join(response.MissingIDs, ", "),
+				}},
+				response,
+			)
+		},
+	}
+	return cmd
 }
 
 func extractFilename(contentDisposition string) string {

--- a/packages/cli/internal/client/api.go
+++ b/packages/cli/internal/client/api.go
@@ -555,6 +555,39 @@ func (c *Client) ResetDatabase(ctx context.Context, request ResetDatabaseRequest
 	return &response, nil
 }
 
+type ArchiveResumesRequest struct {
+	ResumeIDs []string `json:"resumeIds"`
+	Action    string   `json:"action"`
+}
+
+type ArchiveResumesResponse struct {
+	Success        bool     `json:"success"`
+	Requested      int      `json:"requested"`
+	Archived       int      `json:"archived,omitempty"`
+	AlreadyArchived int     `json:"alreadyArchived,omitempty"`
+	Unarchived     int      `json:"unarchived,omitempty"`
+	NotArchived    int      `json:"notArchived,omitempty"`
+	MissingIDs     []string `json:"missingResumeIds,omitempty"`
+}
+
+func (c *Client) ArchiveResumes(ctx context.Context, resumeIDs []string) (*ArchiveResumesResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/archive", c.APIURL)
+	var response ArchiveResumesResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, ArchiveResumesRequest{ResumeIDs: resumeIDs, Action: "archive"}, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) UnarchiveResumes(ctx context.Context, resumeIDs []string) (*ArchiveResumesResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/archive", c.APIURL)
+	var response ArchiveResumesResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, ArchiveResumesRequest{ResumeIDs: resumeIDs, Action: "unarchive"}, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
 type AnalyzeRequest struct {
 	Query            string   `json:"query,omitempty"`
 	JobDescriptionID string   `json:"jobDescriptionId,omitempty"`

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -171,6 +171,8 @@ export type IngestDiagnosticsRow = {
     name: string;
     jobIntention: string;
     location: string;
+    isArchived?: boolean;
+    archivedAt?: number;
     ingestData?: {
         industryTags: string[];
         companyHits: string[];
@@ -229,6 +231,8 @@ type ResumeBackupRow = {
     ingestData?: Doc<"resumes">["ingestData"];
     analysis?: Doc<"resumes">["analysis"];
     analyses?: Doc<"resumes">["analyses"];
+    isArchived?: boolean;
+    archivedAt?: number;
 };
 
 type ResumeBackupFilterArgs = {
@@ -254,6 +258,8 @@ type ResumeListProjectedDoc = {
     analysis?: Doc<"resumes">["analysis"];
     analyses?: Doc<"resumes">["analyses"];
     primaryRuleScore?: number;
+    isArchived?: boolean;
+    archivedAt?: number;
     ingestData?: {
         industryTags: string[];
         brandHits?: Array<{
@@ -301,6 +307,7 @@ type ResumeListFilterArgs = {
     locations?: string[];
     minSalary?: number;
     maxSalary?: number;
+    showArchived?: boolean;
 };
 
 type ResumeListSortBy = "name" | "experience" | "extractedAt";
@@ -431,6 +438,8 @@ export function projectIngestDiagnosticsRow(
         externalId: string;
         content: unknown;
         ingestData?: Doc<"resumes">["ingestData"];
+        isArchived?: boolean;
+        archivedAt?: number;
     }
 ): IngestDiagnosticsRow {
     const content = isRecord(resume.content) ? resume.content : {};
@@ -443,6 +452,7 @@ export function projectIngestDiagnosticsRow(
         name: toStringValue(content.name),
         jobIntention: toStringValue(content.jobIntention),
         location: toStringValue(content.location) || formatLocationHierarchyLabel(locationHierarchy),
+        ...(resume.isArchived === true ? { isArchived: true, archivedAt: resume.archivedAt } : {}),
         ingestData: ingestData ? {
             industryTags: ingestData.industryTags,
             companyHits: ingestData.companyHits ?? [],
@@ -631,6 +641,7 @@ function projectResumeListDoc(resume: Doc<"resumes">): ResumeListProjectedDoc {
         ...(resume.analysis ? { analysis: resume.analysis } : {}),
         ...(resume.analyses ? { analyses: resume.analyses } : {}),
         ...(resume.primaryRuleScore === undefined ? {} : { primaryRuleScore: resume.primaryRuleScore }),
+        ...(resume.isArchived === true ? { isArchived: true, archivedAt: resume.archivedAt } : {}),
         ...(resume.ingestData ? { ingestData: projectResumeListIngestData(resume.ingestData) } : {}),
     };
 }
@@ -648,6 +659,7 @@ function projectResumeDetailDoc(resume: Doc<"resumes">): ResumeListProjectedDoc 
         ...(resume.analysis ? { analysis: resume.analysis } : {}),
         ...(resume.analyses ? { analyses: resume.analyses } : {}),
         ...(resume.primaryRuleScore === undefined ? {} : { primaryRuleScore: resume.primaryRuleScore }),
+        ...(resume.isArchived === true ? { isArchived: true, archivedAt: resume.archivedAt } : {}),
         ...(resume.ingestData ? { ingestData: projectResumeListIngestData(resume.ingestData) } : {}),
     };
 }
@@ -676,6 +688,7 @@ function normalizeResumeListFilters(filters: ResumeListFilterArgs | undefined): 
         ...(locations && locations.length > 0 ? { locations } : {}),
         ...(filters.minSalary === undefined ? {} : { minSalary: filters.minSalary }),
         ...(filters.maxSalary === undefined ? {} : { maxSalary: filters.maxSalary }),
+        ...(filters.showArchived ? { showArchived: true } : {}),
     };
 
     return Object.keys(normalized).length > 0 ? normalized : undefined;
@@ -775,6 +788,9 @@ function getResumeRoleYears(resume: Doc<"resumes">, roleType: string | undefined
 }
 
 function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFilterArgs | undefined): boolean {
+    if (!filters?.showArchived && resume.isArchived === true) {
+        return false;
+    }
     if (!filters) {
         return true;
     }
@@ -993,6 +1009,7 @@ function projectResumeBackupRow(resume: Doc<"resumes">): ResumeBackupRow {
         ingestData: resume.ingestData,
         analysis: resume.analysis,
         analyses: resume.analyses,
+        ...(resume.isArchived === true ? { isArchived: true, archivedAt: resume.archivedAt } : {}),
     };
 }
 
@@ -1269,6 +1286,7 @@ async function runListWithIngestDataPageQuery(
         .query("resumes")
         .withIndex("by_primaryRuleScore")
         .order("desc")
+        .filter((q) => q.neq(q.field("isArchived"), true))
         .take(overfetchLimit);
     const sorted = sortResumeDocs(candidates, {
         jobDescriptionId,
@@ -1333,6 +1351,7 @@ async function runSearchWithTagExpansionPageQuery(
         ? await ctx.db
             .query("resumes")
             .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery))
+            .filter((q) => q.neq(q.field("isArchived"), true))
             .take(takeLimit)
         : [];
 
@@ -1492,7 +1511,7 @@ export const list = query({
     args: { limit: v.optional(v.number()) },
     handler: async (ctx, args) => {
         const limit = args.limit || DEFAULT_RESUME_LIMIT;
-        return await ctx.db.query("resumes").order("desc").take(limit);
+        return await ctx.db.query("resumes").order("desc").filter((q) => q.neq(q.field("isArchived"), true)).take(limit);
     },
 });
 
@@ -1539,6 +1558,7 @@ export const listWithIngestData = query({
             .query("resumes")
             .withIndex("by_primaryRuleScore")
             .order("desc")
+            .filter((q) => q.neq(q.field("isArchived"), true))
             .take(overfetchLimit);
         return sortByIngestRuleScore(candidates, jobDescriptionId)
             .slice(0, limit)
@@ -1557,6 +1577,7 @@ export const getSummaryWindow = query({
             .withIndex("by_crawledAt", (q) =>
                 q.gte("crawledAt", args.fromTimestamp).lt("crawledAt", args.toTimestamp)
             )
+            .filter((q) => q.neq(q.field("isArchived"), true))
             .collect();
 
         const bySource = new Map<string, number>();
@@ -1643,6 +1664,7 @@ export const listWithIngestDataPaginated = query({
                 .query("resumes")
                 .withIndex("by_primaryRuleScore")
                 .order("desc")
+                .filter((q) => q.neq(q.field("isArchived"), true))
                 .paginate({
                     ...args.paginationOpts,
                     numItems,
@@ -1683,6 +1705,29 @@ export const listIngestDiagnostics = query({
             .query("resumes")
             .withIndex("by_primaryRuleScore")
             .order("desc")
+            .filter((q) => q.neq(q.field("isArchived"), true))
+            .paginate({
+                ...args.paginationOpts,
+                numItems: Math.min(args.paginationOpts.numItems, MAX_INGEST_DIAGNOSTICS_PAGE_SIZE),
+            });
+
+        return {
+            ...page,
+            page: page.page.map(projectIngestDiagnosticsRow),
+        };
+    },
+});
+
+export const listArchivedDiagnostics = query({
+    args: {
+        paginationOpts: paginationOptsValidator,
+    },
+    handler: async (ctx, args) => {
+        const page = await ctx.db
+            .query("resumes")
+            .withIndex("by_primaryRuleScore")
+            .order("desc")
+            .filter((q) => q.eq(q.field("isArchived"), true))
             .paginate({
                 ...args.paginationOpts,
                 numItems: Math.min(args.paginationOpts.numItems, MAX_INGEST_DIAGNOSTICS_PAGE_SIZE),
@@ -1704,6 +1749,7 @@ export const listWorkflowDatasetPage = query({
         const page = await ctx.db
             .query("resumes")
             .order("desc")
+            .filter((q) => q.neq(q.field("isArchived"), true))
             .paginate({
                 cursor: args.cursor ?? null,
                 numItems: resolveResumeScanBatchSize(args.limit),
@@ -1733,6 +1779,7 @@ export const listFieldCoverageDatasetPage = query({
         const page = await ctx.db
             .query("resumes")
             .order("desc")
+            .filter((q) => q.neq(q.field("isArchived"), true))
             .paginate({
                 cursor: args.cursor ?? null,
                 numItems: resolveResumeScanBatchSize(args.limit),
@@ -1776,6 +1823,7 @@ export const search = query({
         const matches = await ctx.db
             .query("resumes")
             .withSearchIndex("search_body", (q) => q.search("searchText", args.query))
+            .filter((q) => q.neq(q.field("isArchived"), true))
             .take(fetchLimit);
 
         // Convex full-text search uses OR. Post-filter to enforce AND.
@@ -1803,6 +1851,7 @@ export const searchWithIngestData = query({
         const matches = await ctx.db
             .query("resumes")
             .withSearchIndex("search_body", (q) => q.search("searchText", args.query))
+            .filter((q) => q.neq(q.field("isArchived"), true))
             .take(fetchLimit);
 
         // Convex full-text search uses OR. Post-filter to enforce AND.
@@ -1863,6 +1912,7 @@ export const searchWithTagExpansion = query({
             ? await ctx.db
                 .query("resumes")
                 .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery))
+                .filter((q) => q.neq(q.field("isArchived"), true))
                 .take(fetchLimit)
             : [];
 
@@ -2557,6 +2607,121 @@ export const deleteResumes = mutation({
             missingResumeIds: [...missingResumeIds, ...missingExistingResumeIds],
             deletedAiTaggingResults,
             patchedScreeningSessions,
+        };
+    },
+});
+
+export const archiveResumes = mutation({
+    args: {
+        resumeIds: v.array(v.string()),
+    },
+    returns: v.object({
+        requested: v.number(),
+        archived: v.number(),
+        alreadyArchived: v.number(),
+        missingResumeIds: v.array(v.string()),
+    }),
+    handler: async (ctx, args) => {
+        const requestedResumeIds = normalizeRequestedResumeIds(args.resumeIds);
+        if (requestedResumeIds.length === 0) {
+            return { requested: 0, archived: 0, alreadyArchived: 0, missingResumeIds: [] };
+        }
+
+        const resolvedEntries = requestedResumeIds.map((resumeId) => ({
+            requestedResumeId: resumeId,
+            normalizedResumeId: ctx.db.normalizeId("resumes", resumeId),
+        }));
+        const missingResumeIds = resolvedEntries
+            .filter((entry) => entry.normalizedResumeId === null)
+            .map((entry) => entry.requestedResumeId);
+        const normalizedResumeIds = resolvedEntries
+            .flatMap((entry) => (entry.normalizedResumeId ? [entry.normalizedResumeId] : []));
+
+        if (normalizedResumeIds.length === 0) {
+            return { requested: requestedResumeIds.length, archived: 0, alreadyArchived: 0, missingResumeIds };
+        }
+
+        const resumes = await Promise.all(normalizedResumeIds.map((resumeId) => ctx.db.get(resumeId)));
+        const existingResumes = resumes.filter((resume): resume is NonNullable<typeof resume> => resume !== null);
+        const existingResumeIdStrings = new Set(existingResumes.map((resume) => String(resume._id)));
+        const missingExistingResumeIds = resolvedEntries
+            .filter((entry) => entry.normalizedResumeId !== null && !existingResumeIdStrings.has(String(entry.normalizedResumeId)))
+            .map((entry) => entry.requestedResumeId);
+
+        let archived = 0;
+        let alreadyArchived = 0;
+        const now = Date.now();
+        await Promise.all(existingResumes.map(async (resume) => {
+            if (resume.isArchived === true) {
+                alreadyArchived += 1;
+                return;
+            }
+            await ctx.db.patch(resume._id, { isArchived: true, archivedAt: now });
+            archived += 1;
+        }));
+
+        return {
+            requested: requestedResumeIds.length,
+            archived,
+            alreadyArchived,
+            missingResumeIds: [...missingResumeIds, ...missingExistingResumeIds],
+        };
+    },
+});
+
+export const unarchiveResumes = mutation({
+    args: {
+        resumeIds: v.array(v.string()),
+    },
+    returns: v.object({
+        requested: v.number(),
+        unarchived: v.number(),
+        notArchived: v.number(),
+        missingResumeIds: v.array(v.string()),
+    }),
+    handler: async (ctx, args) => {
+        const requestedResumeIds = normalizeRequestedResumeIds(args.resumeIds);
+        if (requestedResumeIds.length === 0) {
+            return { requested: 0, unarchived: 0, notArchived: 0, missingResumeIds: [] };
+        }
+
+        const resolvedEntries = requestedResumeIds.map((resumeId) => ({
+            requestedResumeId: resumeId,
+            normalizedResumeId: ctx.db.normalizeId("resumes", resumeId),
+        }));
+        const missingResumeIds = resolvedEntries
+            .filter((entry) => entry.normalizedResumeId === null)
+            .map((entry) => entry.requestedResumeId);
+        const normalizedResumeIds = resolvedEntries
+            .flatMap((entry) => (entry.normalizedResumeId ? [entry.normalizedResumeId] : []));
+
+        if (normalizedResumeIds.length === 0) {
+            return { requested: requestedResumeIds.length, unarchived: 0, notArchived: 0, missingResumeIds };
+        }
+
+        const resumes = await Promise.all(normalizedResumeIds.map((resumeId) => ctx.db.get(resumeId)));
+        const existingResumes = resumes.filter((resume): resume is NonNullable<typeof resume> => resume !== null);
+        const existingResumeIdStrings = new Set(existingResumes.map((resume) => String(resume._id)));
+        const missingExistingResumeIds = resolvedEntries
+            .filter((entry) => entry.normalizedResumeId !== null && !existingResumeIdStrings.has(String(entry.normalizedResumeId)))
+            .map((entry) => entry.requestedResumeId);
+
+        let unarchived = 0;
+        let notArchived = 0;
+        await Promise.all(existingResumes.map(async (resume) => {
+            if (resume.isArchived !== true) {
+                notArchived += 1;
+                return;
+            }
+            await ctx.db.patch(resume._id, { isArchived: undefined, archivedAt: undefined });
+            unarchived += 1;
+        }));
+
+        return {
+            requested: requestedResumeIds.length,
+            unarchived,
+            notArchived,
+            missingResumeIds: [...missingResumeIds, ...missingExistingResumeIds],
         };
     },
 });

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -97,6 +97,9 @@ export default defineSchema({
 
         primaryRuleScore: v.optional(v.number()),
 
+        isArchived: v.optional(v.boolean()),
+        archivedAt: v.optional(v.number()),
+
         // Pre-computed Ingest Data (M3)
         ingestData: v.optional(v.object({
             evidenceText: v.optional(v.string()),


### PR DESCRIPTION
## Summary
- Add `isArchived` / `archivedAt` optional fields to `resumes` schema for soft-delete support
- Add `archiveResumes` and `unarchiveResumes` Convex mutations (no cascade to tagging results or screening sessions)
- Filter archived resumes from all default queries via `.filter()` + `matchesResumeListFilters` gate
- Replace per-row and bulk delete actions with archive on DebugIngest page
- Add dedicated `/dev/system/archived` page for viewing/restoring archived resumes
- Add CLI commands `trends resume archive` / `trends resume unarchive`
- Add `POST /api/resumes/archive` API endpoint (admin-gated)
- Hard-delete remains available as admin-only action

## Test plan
- [ ] Verify resumes display as before on `/dev/system/ingest` (none archived initially)
- [ ] Archive a resume via UI → verify it disappears from default view
- [ ] Open `/dev/system/archived` → verify archived resumes appear with Archived badge
- [ ] Restore an archived resume → verify it reappears in default view
- [ ] `trends resume archive <id>` works via CLI
- [ ] `trends resume unarchive <id>` works via CLI
- [ ] `make check` passes