### PR TITLE
feat: add diagnostics endpoint with source-key filtering

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -360,6 +360,64 @@ describe("resume routes", () => {
     );
   });
 
+  it("lists diagnostics rows with archived and source-key filters", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:listArchivedDiagnostics") {
+        expect(call.args).toEqual(expect.objectContaining({
+          sourceKeys: ["51job-manual", "seek"],
+        }));
+        return convexSuccess({
+          page: [
+            {
+              resumeId: "resume-archived-1",
+              externalId: "external-1",
+              source: "51job-manual",
+              sourceKey: "51job-manual",
+              name: "张三",
+              jobIntention: "销售工程师",
+              location: "东莞",
+              archivedAt: 1_700_000_000_000,
+              isArchived: true,
+            },
+          ],
+          continueCursor: "",
+          isDone: true,
+        });
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request(
+      "/api/resumes/diagnostics?archived=true&sourceKey=51job-manual&sourceKey=seek&limit=25"
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toEqual(expect.objectContaining({
+      success: true,
+      summary: expect.objectContaining({
+        archived: true,
+        limit: 25,
+      }),
+      data: [
+        expect.objectContaining({
+          resumeId: "resume-archived-1",
+          sourceKey: "51job-manual",
+        }),
+      ],
+    }));
+    expect(calls[0]).toEqual(expect.objectContaining({
+      pathName: "resumes:listArchivedDiagnostics",
+    }));
+  });
+
   it("returns read-only convex query scores with debug metadata", async () => {
     const createSessionSpy = vi.spyOn(SessionManager.prototype, "createSession");
     const saveMatchesSpy = vi.spyOn(MatchStorage.prototype, "saveMatches");

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -9,6 +9,8 @@ import {
   ResumesResponseSchema,
   ResumeDetailPathParamSchema,
   ResumeDetailResponseSchema,
+  ResumeDiagnosticsQuerySchema,
+  ResumeDiagnosticsResponseSchema,
   ResumeKeywordExpansionQuerySchema,
   ResumeKeywordExpansionResponseSchema,
   ResumeSamplesResponseSchema,
@@ -107,7 +109,7 @@ import { formatIsoOffsetInTimezone } from "../services/timezone.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { BrandDisplayResolver } from "../services/brand-display-resolver.js";
 
-import { buildKeywordAnalysisId, getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey } from "@trends/shared";
+import { buildKeywordAnalysisId, getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey, resolveResumeDiagnosticsSourceKey } from "@trends/shared";
 import type { ResumeItem } from "../types/resume.js";
 import type { ResumeIndex } from "../services/resume-index.js";
 
@@ -721,6 +723,19 @@ function normalizeResumeBackupFilterValues(values: string[] | undefined): string
 function normalizeResumeBackupSourceHosts(values: string[] | undefined): string[] | undefined {
   const normalized = normalizeResumeBackupFilterValues(values);
   return normalized?.map((value) => value.toLowerCase());
+}
+
+function normalizeResumeDiagnosticsSourceKeys(values: string[] | undefined): string[] | undefined {
+  if (!values?.length) {
+    return undefined;
+  }
+
+  const resolved = Array.from(new Set(
+    values
+      .map((value) => resolveResumeDiagnosticsSourceKey({ sourceKey: value.trim(), source: value.trim() }))
+  ));
+
+  return resolved.length > 0 ? resolved : undefined;
 }
 
 function prepareResumeCandidate(params: {
@@ -4820,6 +4835,76 @@ app.get("/api/resumes/analysis-tasks", async (c) => {
 app.get("/api/resumes/skills-version", (c) => {
   const version = skillsKnowledgeService.getVersion();
   return c.json({ success: true, version }, 200);
+});
+
+const listResumeDiagnosticsRoute = createRoute({
+  method: "get",
+  path: "/api/resumes/diagnostics",
+  tags: ["resumes"],
+  summary: "List resume diagnostics rows with optional archived/source filters",
+  request: {
+    query: ResumeDiagnosticsQuerySchema,
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ResumeDiagnosticsResponseSchema,
+        },
+      },
+      description: "Diagnostics rows",
+    },
+  },
+});
+
+app.openapi(listResumeDiagnosticsRoute, async (c) => {
+  const {
+    archived,
+    sourceKey,
+    limit,
+  } = c.req.valid("query");
+
+  const includeArchived = archived === true;
+  const requestedLimit = Math.min(Math.max(limit ?? 100, 1), 500);
+  const normalizedSourceKeys = normalizeResumeDiagnosticsSourceKeys(sourceKey);
+  const pathName = includeArchived ? "resumes:listArchivedDiagnostics" : "resumes:listIngestDiagnostics";
+  const rows: unknown[] = [];
+  let cursor: string | null = null;
+
+  for (let rounds = 0; rounds < 100 && rows.length < requestedLimit; rounds += 1) {
+    const value = await callConvexQuery(pathName, {
+      paginationOpts: {
+        cursor,
+        numItems: Math.min(requestedLimit - rows.length, 100),
+      },
+      ...(normalizedSourceKeys ? { sourceKeys: normalizedSourceKeys } : {}),
+    });
+
+    if (!isConvexPaginatedQueryPage(value)) {
+      throw new Error(`Unexpected diagnostics page payload for ${pathName}`);
+    }
+
+    rows.push(...value.page);
+    if (value.isDone) {
+      break;
+    }
+
+    cursor = value.continueCursor ?? null;
+    if (!cursor) {
+      break;
+    }
+  }
+
+  return c.json(ResumeDiagnosticsResponseSchema.parse({
+    success: true as const,
+    summary: {
+      archived: includeArchived,
+      ...(normalizedSourceKeys ? { sourceKeys: normalizedSourceKeys } : {}),
+      returned: rows.length,
+      limit: requestedLimit,
+    },
+    data: rows,
+  }), 200);
 });
 
 const getResumeDetailRoute = createRoute({

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -594,6 +594,70 @@ export const ResumeDetailResponseSchema = z
   })
   .openapi("ResumeDetailResponse");
 
+export const ResumeDiagnosticsQuerySchema = z.object({
+  archived: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((value) => value === "true")
+    .openapi({
+      param: { name: "archived", in: "query" },
+      example: "true",
+    }),
+  sourceKey: z
+    .union([z.string(), z.array(z.string())])
+    .optional()
+    .transform((value) => {
+      if (!value) {
+        return undefined;
+      }
+      if (Array.isArray(value)) {
+        return value.map((item) => item.trim()).filter((item) => item.length > 0);
+      }
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? [trimmed] : undefined;
+    })
+    .openapi({
+      param: { name: "sourceKey", in: "query" },
+      example: "51job-manual",
+    }),
+  limit: z
+    .string()
+    .optional()
+    .transform((value) => (value ? parseInt(value, 10) : undefined))
+    .pipe(z.number().min(1).max(500).optional())
+    .openapi({
+      param: { name: "limit", in: "query" },
+      example: "100",
+    }),
+});
+
+export const ResumeDiagnosticsItemSchema = z
+  .object({
+    resumeId: z.string(),
+    externalId: z.string(),
+    source: z.string(),
+    sourceKey: z.string(),
+    name: z.string(),
+    jobIntention: z.string(),
+    location: z.string(),
+    isArchived: z.boolean().optional(),
+    archivedAt: z.number().optional(),
+  })
+  .openapi("ResumeDiagnosticsItem");
+
+export const ResumeDiagnosticsResponseSchema = z
+  .object({
+    success: z.literal(true),
+    summary: z.object({
+      archived: z.boolean(),
+      sourceKeys: z.array(z.string()).optional(),
+      returned: z.number().int(),
+      limit: z.number().int(),
+    }),
+    data: z.array(ResumeDiagnosticsItemSchema),
+  })
+  .openapi("ResumeDiagnosticsResponse");
+
 export const ResumeKeywordExpansionQuerySchema = z.object({
   q: z
     .string()

--- a/apps/web/src/components/SourceFacetSelect.tsx
+++ b/apps/web/src/components/SourceFacetSelect.tsx
@@ -1,0 +1,51 @@
+import type { ChangeEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Label } from '@/components/ui/label'
+
+export type SourceFacet = {
+  key: string
+  label: string
+  count: number
+}
+
+interface SourceFacetSelectProps {
+  id: string
+  facets: SourceFacet[] | undefined
+  value: string[]
+  onChange: (value: string[]) => void
+}
+
+export function SourceFacetSelect({ id, facets, value, onChange }: SourceFacetSelectProps) {
+  const { t } = useTranslation()
+
+  const options = (Array.isArray(facets) ? facets : []).map((item) => ({
+    value: item.key,
+    label: `${item.label} (${item.count})`,
+  }))
+
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    onChange(Array.from(event.target.selectedOptions).map((option) => option.value))
+  }
+
+  return (
+    <div className="flex min-w-[220px] flex-col gap-1">
+      <Label htmlFor={id}>
+        {t('debugIngest.sourceFilter', { defaultValue: 'Source Filter' })}
+      </Label>
+      <select
+        id={id}
+        multiple
+        value={value}
+        onChange={handleChange}
+        className="min-h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        aria-label={t('debugIngest.sourceFilter', { defaultValue: 'Source Filter' })}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -1856,6 +1856,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/resumes/diagnostics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List resume diagnostics rows with optional archived/source filters */
+        get: {
+            parameters: {
+                query?: {
+                    archived?: "true" | "false";
+                    sourceKey?: string | string[];
+                    limit?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Diagnostics rows */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ResumeDiagnosticsResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/resumes/{resumeId}": {
         parameters: {
             query?: never;
@@ -7902,6 +7942,28 @@ export interface components {
              * @example https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=***
              */
             webhookUrl?: string;
+        };
+        ResumeDiagnosticsItem: {
+            resumeId: string;
+            externalId: string;
+            source: string;
+            sourceKey: string;
+            name: string;
+            jobIntention: string;
+            location: string;
+            isArchived?: boolean;
+            archivedAt?: number;
+        };
+        ResumeDiagnosticsResponse: {
+            /** @enum {boolean} */
+            success: true;
+            summary: {
+                archived: boolean;
+                sourceKeys?: string[];
+                returned: number;
+                limit: number;
+            };
+            data: components["schemas"]["ResumeDiagnosticsItem"][];
         };
         ResumeDetailResponse: {
             /** @enum {boolean} */

--- a/apps/web/src/pages/ArchivedResumes.test.tsx
+++ b/apps/web/src/pages/ArchivedResumes.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ArchivedResumes from './ArchivedResumes'
+
+const loadMore = vi.fn()
+type SourceFacetRow = {
+  key: string
+  label: string
+  count: number
+}
+type PaginatedQueryMockResult = {
+  results: Array<Record<string, unknown>>
+  status: string
+  isLoading: boolean
+  loadMore: typeof loadMore
+}
+const unarchiveResumesMutation = vi.fn(async () => ({
+  requested: 0,
+  unarchived: 0,
+  notArchived: 0,
+  missingResumeIds: [],
+}))
+
+const usePaginatedQueryMock = vi.fn<
+  (query: unknown, args: unknown, options: unknown) => PaginatedQueryMockResult
+>(() => ({
+  results: [],
+  status: 'Exhausted',
+  isLoading: false,
+  loadMore,
+}))
+const useQueryMock = vi.fn<(query: unknown, args: unknown) => SourceFacetRow[] | undefined>(() => [])
+
+vi.mock('convex/react', () => ({
+  usePaginatedQuery: (query: unknown, args: unknown, options: unknown) => usePaginatedQueryMock(query, args, options),
+  useQuery: (query: unknown, args: unknown) => useQueryMock(query, args),
+  useMutation: () => unarchiveResumesMutation,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: string | { defaultValue?: string; [key: string]: unknown }) => {
+      if (typeof options === 'string') {
+        return options
+      }
+      if (options?.defaultValue) {
+        return options.defaultValue.replace(/\{\{(\w+)\}\}/g, (_match, key: string) => String(options[key] ?? `{{${key}}}`))
+      }
+      return _key
+    },
+  }),
+}))
+
+describe('ArchivedResumes source filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    usePaginatedQueryMock.mockReturnValue({
+      results: [],
+      status: 'Exhausted',
+      isLoading: false,
+      loadMore,
+    })
+    useQueryMock.mockReturnValue([
+      { key: 'seek', label: 'SEEK', count: 2 },
+      { key: '51job-manual', label: '51job manual', count: 1 },
+    ])
+  })
+
+  it('forwards selected source keys to the archived diagnostics query', async () => {
+    const user = userEvent.setup()
+    render(<ArchivedResumes />)
+
+    const sourceFilter = screen.getByLabelText('Source Filter')
+    await user.selectOptions(sourceFilter, ['seek', '51job-manual'])
+
+    await waitFor(() => {
+      expect(usePaginatedQueryMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          sourceKeys: ['seek', '51job-manual'],
+        }),
+        expect.anything(),
+      )
+    })
+  })
+})

--- a/apps/web/src/pages/ArchivedResumes.tsx
+++ b/apps/web/src/pages/ArchivedResumes.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { sanitizeResumeRecordForSurface } from '@trends/shared'
-import { useMutation, usePaginatedQuery } from 'convex/react'
+import { useMutation, usePaginatedQuery, useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import { useTranslation } from 'react-i18next'
 import { Archive, ArchiveRestore } from 'lucide-react'
@@ -12,10 +12,13 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { PageHeader } from '@/components/PageHeader'
 import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
+import { SourceFacetSelect, type SourceFacet } from '@/components/SourceFacetSelect'
 
 type ArchivedResume = {
   resumeId: string
   externalId: string
+  source: string
+  sourceKey: string
   name: string
   jobIntention: string
   location: string
@@ -24,7 +27,7 @@ type ArchivedResume = {
 }
 
 function getSearchTarget(resume: ArchivedResume): string {
-  return [resume.externalId, resume.name, resume.jobIntention, resume.location]
+  return [resume.externalId, resume.source, resume.sourceKey, resume.name, resume.jobIntention, resume.location]
     .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
     .join(' ')
     .toLowerCase()
@@ -42,12 +45,18 @@ const PAGE_SIZE = 100
 export default function ArchivedResumes() {
   const { t } = useTranslation()
   const fieldUsagePolicy = useResumeFieldUsagePolicy()
+  const [selectedSourceKeys, setSelectedSourceKeys] = useState<string[]>([])
+  const sourceFacets = useQuery(api.resumes.listDiagnosticsSourceFacets, { archived: true }) as SourceFacet[] | undefined
 
   const {
     results: paginatedResumes,
     status,
     loadMore,
-  } = usePaginatedQuery(api.resumes.listArchivedDiagnostics, {}, { initialNumItems: PAGE_SIZE })
+  } = usePaginatedQuery(
+    api.resumes.listArchivedDiagnostics,
+    selectedSourceKeys.length > 0 ? { sourceKeys: selectedSourceKeys } : {},
+    { initialNumItems: PAGE_SIZE }
+  )
 
   const unarchiveResumesMutation = useMutation(api.resumes.unarchiveResumes)
 
@@ -141,6 +150,12 @@ export default function ArchivedResumes() {
           placeholder={t('archivedResumes.searchPlaceholder', { defaultValue: 'Search by name / intention / location...' })}
           className="max-w-xl"
         />
+        <SourceFacetSelect
+          id="archived-resume-source-filter"
+          facets={sourceFacets}
+          value={selectedSourceKeys}
+          onChange={setSelectedSourceKeys}
+        />
         <Button
           variant="outline"
           onClick={() => void unarchiveResumes([...selectedResumeIds])}
@@ -169,6 +184,7 @@ export default function ArchivedResumes() {
               <TableHead>{t('resumes.columns.name', { defaultValue: 'Name' })}</TableHead>
               <TableHead>{t('resumes.columns.intention', { defaultValue: 'Intention' })}</TableHead>
               <TableHead>{t('resumes.columns.location', { defaultValue: 'Location' })}</TableHead>
+              <TableHead>{t('resumes.columns.source', { defaultValue: 'Source' })}</TableHead>
               <TableHead>{t('archivedResumes.archivedAt', { defaultValue: 'Archived At' })}</TableHead>
               <TableHead>{t('debugIngest.status', { defaultValue: 'Status' })}</TableHead>
               <TableHead className="text-right">{t('resumes.columns.actions', { defaultValue: 'Actions' })}</TableHead>
@@ -177,13 +193,13 @@ export default function ArchivedResumes() {
           <TableBody>
             {loading ? (
               <TableRow>
-                <TableCell colSpan={7} className="text-center text-muted-foreground">
+                <TableCell colSpan={8} className="text-center text-muted-foreground">
                   {t('resumes.loading', { defaultValue: 'Loading...' })}
                 </TableCell>
               </TableRow>
             ) : filteredResumes.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={7} className="text-center text-muted-foreground">
+                <TableCell colSpan={8} className="text-center text-muted-foreground">
                   {t('archivedResumes.noResults', { defaultValue: 'No archived resumes found' })}
                 </TableCell>
               </TableRow>
@@ -205,6 +221,7 @@ export default function ArchivedResumes() {
                     <TableCell>{resume.name || '--'}</TableCell>
                     <TableCell>{resume.jobIntention || '--'}</TableCell>
                     <TableCell>{resume.location || '--'}</TableCell>
+                    <TableCell>{resume.sourceKey || resume.source || '--'}</TableCell>
                     <TableCell>{formatTimestamp(resume.archivedAt)}</TableCell>
                     <TableCell>
                       <Badge variant="outline" className="border-zinc-200 bg-zinc-50 text-zinc-600">

--- a/apps/web/src/pages/DebugIngest.test.tsx
+++ b/apps/web/src/pages/DebugIngest.test.tsx
@@ -41,19 +41,26 @@ type PaginatedQueryMockResult = {
   isLoading: boolean
   loadMore: typeof loadMore
 }
+type SourceFacetRow = {
+  key: string
+  label: string
+  count: number
+}
 
-const usePaginatedQueryMock = vi.fn<() => PaginatedQueryMockResult>(() => ({
+const usePaginatedQueryMock = vi.fn<(query: unknown, args: unknown, options: unknown) => PaginatedQueryMockResult>(() => ({
   results: [],
   status: 'Exhausted',
   isLoading: false,
   loadMore,
 }))
+const useQueryMock = vi.fn<(query: unknown, args: unknown) => SourceFacetRow[] | undefined>(() => [])
 
 let actionHookCallCount = 0
 let mutationHookCallCount = 0
 
 vi.mock('convex/react', () => ({
-  usePaginatedQuery: () => usePaginatedQueryMock(),
+  usePaginatedQuery: (query: unknown, args: unknown, options: unknown) => usePaginatedQueryMock(query, args, options),
+  useQuery: (query: unknown, args: unknown) => useQueryMock(query, args),
   useAction: () => {
     const action = [backfillIngestDataAction, reIngestStaleSkillsVersionAction, reIngestAllResumesAction][actionHookCallCount % 3]
     actionHookCallCount += 1
@@ -98,6 +105,10 @@ describe('DebugIngest reset database dialog', () => {
       isLoading: false,
       loadMore,
     })
+    useQueryMock.mockReturnValue([
+      { key: 'job5156', label: 'Job5156', count: 3 },
+      { key: '51job-manual', label: '51job manual', count: 1 },
+    ])
     globalThis.fetch = vi.fn(async () => ({
       ok: true,
       status: 200,
@@ -140,7 +151,7 @@ describe('DebugIngest reset database dialog', () => {
 
     expect(screen.getByText('Loaded Resumes')).toBeInTheDocument()
     expect(screen.queryByText('销售工程师')).not.toBeInTheDocument()
-    expect(screen.getByText('--')).toBeInTheDocument()
+    expect(screen.getAllByText('--').length).toBeGreaterThan(0)
 
     const loadMoreButton = screen.getByRole('button', { name: 'Load More' })
     expect(loadMoreButton).toBeEnabled()
@@ -370,5 +381,23 @@ describe('DebugIngest reset database dialog', () => {
       expect(archiveResumesMutation).toHaveBeenCalledWith({ resumeIds: ['resume-1'] })
     })
     expect(toast.success).toHaveBeenCalledWith('Archived 1 resume(s)')
+  })
+
+  it('forwards selected source keys to the diagnostics query', async () => {
+    const user = userEvent.setup()
+    render(<DebugIngest />)
+
+    const sourceFilter = screen.getByLabelText('Source Filter')
+    await user.selectOptions(sourceFilter, ['job5156', '51job-manual'])
+
+    await waitFor(() => {
+      expect(usePaginatedQueryMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          sourceKeys: ['job5156', '51job-manual'],
+        }),
+        expect.anything(),
+      )
+    })
   })
 })

--- a/apps/web/src/pages/DebugIngest.tsx
+++ b/apps/web/src/pages/DebugIngest.tsx
@@ -6,7 +6,7 @@ import {
   INGEST_BRAND_SOURCE_LABELS,
   sanitizeResumeRecordForSurface,
 } from '@trends/shared'
-import { useAction, useMutation, usePaginatedQuery } from 'convex/react'
+import { useAction, useMutation, usePaginatedQuery, useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import { useTranslation } from 'react-i18next'
 import { RefreshCw, Database, ChevronDown, ChevronRight, Trash2, Archive } from 'lucide-react'
@@ -20,10 +20,13 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { PageHeader } from '@/components/PageHeader'
 import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
+import { SourceFacetSelect, type SourceFacet } from '@/components/SourceFacetSelect'
 
 type IngestDiagnosticsResume = {
   resumeId: string
   externalId: string
+  source: string
+  sourceKey: string
   name: string
   jobIntention: string
   location: string
@@ -67,6 +70,8 @@ const INGEST_DIAGNOSTICS_PAGE_SIZE = 100
 function getSearchTarget(resume: IngestDiagnosticsResume): string {
   return [
     resume.externalId,
+    resume.source,
+    resume.sourceKey,
     resume.name,
     resume.jobIntention,
     resume.location,
@@ -143,11 +148,17 @@ function formatTaggingEntry(entry: {
 export default function DebugIngest() {
   const { t } = useTranslation()
   const fieldUsagePolicy = useResumeFieldUsagePolicy()
+  const [selectedSourceKeys, setSelectedSourceKeys] = useState<string[]>([])
+  const sourceFacets = useQuery(api.resumes.listDiagnosticsSourceFacets, { archived: false }) as SourceFacet[] | undefined
   const {
     results: paginatedResumes,
     status,
     loadMore,
-  } = usePaginatedQuery(api.resumes.listIngestDiagnostics, {}, { initialNumItems: INGEST_DIAGNOSTICS_PAGE_SIZE })
+  } = usePaginatedQuery(
+    api.resumes.listIngestDiagnostics,
+    selectedSourceKeys.length > 0 ? { sourceKeys: selectedSourceKeys } : {},
+    { initialNumItems: INGEST_DIAGNOSTICS_PAGE_SIZE }
+  )
   const backfillIngestData = useAction(api.migrations.backfillIngestData)
   const reIngestStaleSkillsVersion = useAction(api.migrations.reIngestStaleSkillsVersion)
   const reIngestAllResumes = useAction(api.migrations.reIngestAllResumes)
@@ -581,6 +592,12 @@ export default function DebugIngest() {
           placeholder={t('debugIngest.searchPlaceholder', { defaultValue: 'Search by name / intention / location...' })}
           className="max-w-xl"
         />
+        <SourceFacetSelect
+          id="debug-ingest-source-filter"
+          facets={sourceFacets}
+          value={selectedSourceKeys}
+          onChange={setSelectedSourceKeys}
+        />
         <Button variant="outline" onClick={() => void loadSkillsVersion()} disabled={versionLoading}>
           <RefreshCw className={`mr-2 h-4 w-4 ${versionLoading ? 'animate-spin' : ''}`} />
           {t('common.refresh', { defaultValue: 'Refresh' })}
@@ -829,6 +846,7 @@ export default function DebugIngest() {
               <TableHead>{t('resumes.columns.name', { defaultValue: 'Name' })}</TableHead>
               <TableHead>{t('resumes.columns.intention', { defaultValue: 'Intention' })}</TableHead>
               <TableHead>{t('resumes.columns.location', { defaultValue: 'Location' })}</TableHead>
+              <TableHead>{t('resumes.columns.source', { defaultValue: 'Source' })}</TableHead>
               <TableHead>{t('debugIngest.skillsVersion', { defaultValue: 'Skills Version' })}</TableHead>
               <TableHead>{t('debugIngest.computedAt', { defaultValue: 'Computed At' })}</TableHead>
               <TableHead>{t('debugIngest.status', { defaultValue: 'Status' })}</TableHead>
@@ -838,13 +856,13 @@ export default function DebugIngest() {
           <TableBody>
             {loading ? (
               <TableRow>
-                <TableCell colSpan={9} className="text-center text-muted-foreground">
+                <TableCell colSpan={10} className="text-center text-muted-foreground">
                   {t('resumes.loading', { defaultValue: 'Loading...' })}
                 </TableCell>
               </TableRow>
             ) : filteredResumes.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={9} className="text-center text-muted-foreground">
+                <TableCell colSpan={10} className="text-center text-muted-foreground">
                   {t('debugIngest.noResults', { defaultValue: 'No resumes found' })}
                 </TableCell>
               </TableRow>
@@ -881,6 +899,7 @@ export default function DebugIngest() {
                       <TableCell>{resume.name || '--'}</TableCell>
                       <TableCell>{resume.jobIntention || '--'}</TableCell>
                       <TableCell>{resume.location || '--'}</TableCell>
+                      <TableCell>{resume.sourceKey || resume.source || '--'}</TableCell>
                       <TableCell>{ingestData?.skillsVersion ?? '--'}</TableCell>
                       <TableCell>{formatTimestamp(ingestData?.computedAt)}</TableCell>
                       <TableCell>
@@ -914,7 +933,7 @@ export default function DebugIngest() {
                     </TableRow>
                     {isExpanded ? (
                       <TableRow>
-                        <TableCell colSpan={9} className="bg-muted/20">
+                        <TableCell colSpan={10} className="bg-muted/20">
                           {ingestData ? (
                             <div className="grid gap-2 text-sm md:grid-cols-2">
                               <div>

--- a/packages/cli/cmd/resume_debug.go
+++ b/packages/cli/cmd/resume_debug.go
@@ -263,6 +263,7 @@ func newResumeDebugCmd() *cobra.Command {
 		newResumeDebugTriggerReingestCmd(),
 		newResumeDebugAIScoreCmd(),
 		newResumeDebugWorkflowDatasetCmd(),
+		newResumeDebugDiagnosticsCmd(),
 		newResumeDebugClearDemoResumesCmd(),
 		newResumeDebugHardResetReingestCmd(),
 		newResumeDebugResetDatabaseCmd(),
@@ -738,6 +739,61 @@ func newResumeDebugWorkflowDatasetCmd() *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", 200, "Maximum resumes to scan")
 	cmd.Flags().IntVar(&top, "top", 10, "Maximum visible resumes to print")
 	cmd.Flags().BoolVar(&fieldCoverage, "field-coverage", false, "Include source-level field coverage percentages")
+	return cmd
+}
+
+func newResumeDebugDiagnosticsCmd() *cobra.Command {
+	var (
+		archived   bool
+		sourceKeys []string
+		limit      int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "diagnostics",
+		Short: "List ingest/archive diagnostics rows with optional source-key filters",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := newAPIClient().ListResumeDiagnostics(context.Background(), client.ResumeDiagnosticsQuery{
+				Archived:   archived,
+				SourceKeys: sourceKeys,
+				Limit:      limit,
+			})
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"resume_id", "source_key", "source_host", "name", "intention", "location", "archived"}
+			rows := make([][]string, 0, len(response.Data))
+			for _, item := range response.Data {
+				rows = append(rows, []string{
+					item.ResumeID,
+					item.SourceKey,
+					item.Source,
+					item.Name,
+					item.JobIntention,
+					item.Location,
+					strconv.FormatBool(item.IsArchived),
+				})
+			}
+
+			if currentOptions().Output == "table" {
+				fmt.Fprintf(
+					cmd.OutOrStdout(),
+					"Diagnostics summary: archived=%t sourceKeys=%s returned=%d limit=%d\n\n",
+					response.Summary.Archived,
+					strings.Join(response.Summary.SourceKeys, ","),
+					response.Summary.Returned,
+					response.Summary.Limit,
+				)
+			}
+
+			return writeOutput(cmd, headers, rows, response)
+		},
+	}
+
+	cmd.Flags().BoolVar(&archived, "archived", false, "List archived resumes instead of active ingest rows")
+	cmd.Flags().StringArrayVar(&sourceKeys, "source-key", nil, "Source key filter (repeatable): job5156|51job|seek|51job-manual|unknown")
+	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum diagnostics rows to return")
 	return cmd
 }
 

--- a/packages/cli/cmd/resume_debug_test.go
+++ b/packages/cli/cmd/resume_debug_test.go
@@ -299,6 +299,73 @@ func TestResumeDebugWorkflowDatasetCommandWritesTable(t *testing.T) {
 	}
 }
 
+func TestResumeDebugDiagnosticsCommandWritesTable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/resumes/diagnostics" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if got := r.URL.Query().Get("archived"); got != "true" {
+			t.Fatalf("expected archived=true, got %q", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "5" {
+			t.Fatalf("expected limit=5, got %q", got)
+		}
+		sourceKeys := r.URL.Query()["sourceKey"]
+		if len(sourceKeys) != 2 || sourceKeys[0] != "51job-manual" || sourceKeys[1] != "seek" {
+			t.Fatalf("unexpected source keys: %+v", sourceKeys)
+		}
+
+		_ = json.NewEncoder(w).Encode(client.ResumeDiagnosticsResponse{
+			Success: true,
+			Data: []client.ResumeDiagnosticsItem{
+				{
+					ResumeID:    "resume-1",
+					ExternalID:  "external-1",
+					Name:        "张三",
+					JobIntention:"销售工程师",
+					Location:    "东莞",
+					Source:      "51job-manual",
+					SourceKey:   "51job-manual",
+					IsArchived:  true,
+					ArchivedAt:  1700000000000,
+				},
+			},
+			Summary: client.ResumeDiagnosticsSummary{
+				Archived: true,
+				Returned: 1,
+				Limit:    5,
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "dev")
+	setCLIOutput(t, "table")
+
+	cmd := newResumeDebugDiagnosticsCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{
+		"--archived",
+		"--source-key", "51job-manual",
+		"--source-key", "seek",
+		"--limit", "5",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug diagnostics command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "resume-1") || !strings.Contains(text, "51job-manual") || !strings.Contains(text, "archived=true") {
+		t.Fatalf("unexpected diagnostics output: %s", text)
+	}
+}
+
 func TestResumeDebugClearDemoResumesCommandWritesJSON(t *testing.T) {
 	setCLIOutput(t, "json")
 

--- a/packages/cli/internal/client/resume_debug.go
+++ b/packages/cli/internal/client/resume_debug.go
@@ -73,6 +73,54 @@ type ResumeTriggerReingestResponse struct {
 	HasMore        bool `json:"hasMore"`
 }
 
+type ResumeDiagnosticsQuery struct {
+	Archived   bool
+	SourceKeys []string
+	Limit      int
+}
+
+type ResumeDiagnosticsSummary struct {
+	Archived   bool     `json:"archived"`
+	SourceKeys []string `json:"sourceKeys,omitempty"`
+	Returned   int      `json:"returned"`
+	Limit      int      `json:"limit"`
+}
+
+type ResumeDiagnosticsItem struct {
+	ResumeID    string `json:"resumeId"`
+	ExternalID  string `json:"externalId"`
+	Source      string `json:"source"`
+	SourceKey   string `json:"sourceKey"`
+	Name        string `json:"name"`
+	JobIntention string `json:"jobIntention"`
+	Location    string `json:"location"`
+	IsArchived  bool   `json:"isArchived,omitempty"`
+	ArchivedAt  int64  `json:"archivedAt,omitempty"`
+}
+
+type ResumeDiagnosticsResponse struct {
+	Success bool                     `json:"success"`
+	Summary ResumeDiagnosticsSummary `json:"summary"`
+	Data    []ResumeDiagnosticsItem  `json:"data"`
+}
+
+func normalizeSourceKeys(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		trimmed := strings.ToLower(strings.TrimSpace(value))
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
+}
+
 func (c *Client) ListResumeMatches(ctx context.Context, sessionID, jobDescriptionID string) (*ResumeMatchesResponse, error) {
 	values := url.Values{}
 	if strings.TrimSpace(sessionID) != "" {
@@ -186,6 +234,31 @@ func (c *Client) TriggerResumeReingest(ctx context.Context, limit int) (*ResumeT
 	}
 	if !response.Success {
 		return nil, fmt.Errorf("resume trigger reingest request was not successful")
+	}
+	return &response, nil
+}
+
+func (c *Client) ListResumeDiagnostics(ctx context.Context, query ResumeDiagnosticsQuery) (*ResumeDiagnosticsResponse, error) {
+	values := url.Values{}
+	values.Set("archived", strconv.FormatBool(query.Archived))
+	if query.Limit > 0 {
+		values.Set("limit", strconv.Itoa(query.Limit))
+	}
+	for _, sourceKey := range normalizeSourceKeys(query.SourceKeys) {
+		values.Add("sourceKey", sourceKey)
+	}
+
+	endpoint := fmt.Sprintf("%s/api/resumes/diagnostics", c.APIURL)
+	if encoded := values.Encode(); encoded != "" {
+		endpoint = fmt.Sprintf("%s?%s", endpoint, encoded)
+	}
+
+	var response ResumeDiagnosticsResponse
+	if err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("resume diagnostics request was not successful")
 	}
 	return &response, nil
 }

--- a/packages/cli/internal/client/resume_debug_test.go
+++ b/packages/cli/internal/client/resume_debug_test.go
@@ -77,6 +77,38 @@ func TestResumeDebugClientEndpoints(t *testing.T) {
 				CurrentVersion: 9,
 				HasMore:        true,
 			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/resumes/diagnostics":
+			if got := r.URL.Query().Get("archived"); got != "true" {
+				t.Fatalf("expected archived=true, got %q", got)
+			}
+			if got := r.URL.Query().Get("limit"); got != "10" {
+				t.Fatalf("expected limit=10, got %q", got)
+			}
+			sourceKeys := r.URL.Query()["sourceKey"]
+			if len(sourceKeys) != 2 || sourceKeys[0] != "51job-manual" || sourceKeys[1] != "seek" {
+				t.Fatalf("unexpected source keys: %+v", sourceKeys)
+			}
+			_ = json.NewEncoder(w).Encode(ResumeDiagnosticsResponse{
+				Success: true,
+				Data: []ResumeDiagnosticsItem{
+					{
+						ResumeID:    "resume-1",
+						ExternalID:  "external-1",
+						Name:        "张三",
+						JobIntention:"销售工程师",
+						Location:    "东莞",
+						Source:      "51job-manual",
+						SourceKey:   "51job-manual",
+						IsArchived:  true,
+						ArchivedAt:  1700000000000,
+					},
+				},
+				Summary: ResumeDiagnosticsSummary{
+					Archived: true,
+					Returned: 1,
+					Limit:    10,
+				},
+			})
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
@@ -140,5 +172,17 @@ func TestResumeDebugClientEndpoints(t *testing.T) {
 	}
 	if reingest.Scheduled != 150 || !reingest.HasMore {
 		t.Fatalf("unexpected reingest response: %+v", reingest)
+	}
+
+	diagnostics, err := c.ListResumeDiagnostics(context.Background(), ResumeDiagnosticsQuery{
+		Archived:   true,
+		SourceKeys: []string{"51job-manual", "seek"},
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("ListResumeDiagnostics returned error: %v", err)
+	}
+	if diagnostics.Summary.Returned != 1 || len(diagnostics.Data) != 1 {
+		t.Fatalf("unexpected diagnostics response: %+v", diagnostics)
 	}
 }

--- a/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
+++ b/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+    buildDiagnosticsSourceFacetRows,
+    matchesDiagnosticsSourceKeys,
     projectIngestDiagnosticsRow,
     resolveListWithIngestWindow,
     resolveResumeScanBatchSize,
@@ -57,6 +59,7 @@ describe("projectIngestDiagnosticsRow", () => {
         const row = projectIngestDiagnosticsRow({
             _id: "resume-1",
             externalId: "ext-1",
+            source: "51job-manual",
             content: {
                 name: "赵先生",
                 jobIntention: "销售工程师",
@@ -106,6 +109,8 @@ describe("projectIngestDiagnosticsRow", () => {
         expect(row).toEqual({
             resumeId: "resume-1",
             externalId: "ext-1",
+            source: "51job-manual",
+            sourceKey: "51job-manual",
             name: "赵先生",
             jobIntention: "销售工程师",
             location: "东莞",
@@ -143,6 +148,7 @@ describe("projectIngestDiagnosticsRow", () => {
         const row = projectIngestDiagnosticsRow({
             _id: "resume-2",
             externalId: "ext-2",
+            source: "hr.job5156.com",
             content: {
                 name: "赵先生",
                 jobIntention: "销售工程师",
@@ -154,5 +160,43 @@ describe("projectIngestDiagnosticsRow", () => {
         });
 
         expect(row.location).toBe("广东东莞");
+    });
+});
+
+describe("matchesDiagnosticsSourceKeys", () => {
+    it("matches grouped keys and keeps 51job-manual separate", () => {
+        expect(matchesDiagnosticsSourceKeys({
+            source: "51job-manual",
+            content: { profileType: "51job-manual" },
+        }, new Set(["51job-manual"]))).toBe(true);
+
+        expect(matchesDiagnosticsSourceKeys({
+            source: "51job-manual",
+            content: { profileType: "51job-manual" },
+        }, new Set(["job5156"]))).toBe(false);
+
+        expect(matchesDiagnosticsSourceKeys({
+            source: "hr.job5156.com",
+            content: { profileType: "job5156" },
+        }, new Set(["job5156"]))).toBe(true);
+    });
+});
+
+describe("buildDiagnosticsSourceFacetRows", () => {
+    it("groups rows by diagnostics source key and sorts by count desc then key", () => {
+        const rows = buildDiagnosticsSourceFacetRows([
+            { source: "51job-manual", content: { profileType: "51job-manual" } },
+            { source: "hr.job5156.com", content: { profileType: "job5156" } },
+            { source: "hr.job5156.com", content: { profileType: "job5156" } },
+            { source: "my.employer.seek.com", content: { profileType: "seek" } },
+            { source: "unknown-host.local", content: {} },
+        ]);
+
+        expect(rows).toEqual([
+            { key: "job5156", label: "Job5156", count: 2 },
+            { key: "51job-manual", label: "51job manual", count: 1 },
+            { key: "seek", label: "SEEK", count: 1 },
+            { key: "unknown", label: "Unknown", count: 1 },
+        ]);
     });
 });

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -13,6 +13,7 @@ import {
     isResumeAnalysisKeyForJobDescription,
     isLocationMatch,
     normalizeKeywordPhrases,
+    resolveResumeDiagnosticsSourceKey,
     normalizeResumeLocationHierarchy,
     resolveResumeAnalysisSourceKey,
     selectLatestWorkHistory,
@@ -168,6 +169,8 @@ type IngestDiagnosticsTaggingEntry = {
 export type IngestDiagnosticsRow = {
     resumeId: string;
     externalId: string;
+    source: string;
+    sourceKey: string;
     name: string;
     jobIntention: string;
     location: string;
@@ -191,6 +194,12 @@ export type ResumeScanRow = {
     ingestData: Doc<"resumes">["ingestData"];
     primaryRuleScore: Doc<"resumes">["primaryRuleScore"];
     searchText: Doc<"resumes">["searchText"];
+};
+
+export type DiagnosticsSourceFacetRow = {
+    key: string;
+    label: string;
+    count: number;
 };
 
 export type ResumeUsageScanRow = {
@@ -366,6 +375,10 @@ const FILTERED_PAGINATE_OVERFETCH_MULTIPLIER = 3;
 const MAX_SAFE_JD_PAGINATE_SCAN = 250;
 const MAX_INGEST_DIAGNOSTICS_PAGE_SIZE = 100;
 const MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES = 8;
+const DIAGNOSTICS_SOURCE_FILTER_SCAN_ROUNDS = 8;
+const DIAGNOSTICS_SOURCE_FILTER_BATCH_MULTIPLIER = 3;
+const DIAGNOSTICS_SOURCE_FACET_SCAN_PAGE_SIZE = 200;
+const MAX_DIAGNOSTICS_SOURCE_FACET_SCAN_ROWS = 5_000;
 const DEFAULT_RESUME_SCAN_BATCH_SIZE = 25;
 const MAX_RESUME_SCAN_BATCH_SIZE = 50;
 const DEFAULT_RESUME_BACKUP_PAGE_SIZE = 25;
@@ -416,6 +429,83 @@ function projectIngestDiagnosticsTaggingEntries(
     })) ?? [];
 }
 
+function normalizeDiagnosticsSourceFilterValues(values: string[] | undefined): string[] | undefined {
+    if (!Array.isArray(values)) {
+        return undefined;
+    }
+
+    const normalized = Array.from(new Set(values
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0)
+        .map((value) => resolveResumeDiagnosticsSourceKey({ sourceKey: value, source: value }))
+    ));
+
+    return normalized.length > 0 ? normalized : undefined;
+}
+
+export function resolveDiagnosticsSourceKeyForResume(
+    resume: {
+        source: string;
+        content: unknown;
+    }
+): string {
+    const content = isRecord(resume.content) ? resume.content : {};
+    return resolveResumeDiagnosticsSourceKey({
+        sourceKey: toOptionalStringValue(content.profileType),
+        source: resume.source,
+    });
+}
+
+function resolveDiagnosticsSourceLabel(sourceKey: string): string {
+    switch (sourceKey) {
+        case "job5156":
+            return "Job5156";
+        case "51job":
+            return "51job";
+        case "51job-manual":
+            return "51job manual";
+        case "seek":
+            return "SEEK";
+        default:
+            return "Unknown";
+    }
+}
+
+export function matchesDiagnosticsSourceKeys(
+    resume: {
+        source: string;
+        content: unknown;
+    },
+    sourceKeys: Set<string> | undefined
+): boolean {
+    if (!sourceKeys || sourceKeys.size === 0) {
+        return true;
+    }
+
+    return sourceKeys.has(resolveDiagnosticsSourceKeyForResume(resume));
+}
+
+export function buildDiagnosticsSourceFacetRows(
+    input: Array<{ source: string; content: unknown }> | Map<string, number>
+): DiagnosticsSourceFacetRow[] {
+    const counts = input instanceof Map ? input : new Map<string, number>();
+
+    if (Array.isArray(input)) {
+        for (const resume of input) {
+            const sourceKey = resolveDiagnosticsSourceKeyForResume(resume);
+            counts.set(sourceKey, (counts.get(sourceKey) ?? 0) + 1);
+        }
+    }
+
+    return Array.from(counts.entries())
+        .map(([key, count]) => ({
+            key,
+            label: resolveDiagnosticsSourceLabel(key),
+            count,
+        }))
+        .sort((left, right) => right.count - left.count || left.key.localeCompare(right.key));
+}
+
 function normalizeRequestedResumeIds(resumeIds: string[]): string[] {
     const normalizedIds: string[] = [];
     const seen = new Set<string>();
@@ -436,6 +526,7 @@ export function projectIngestDiagnosticsRow(
     resume: {
         _id: string;
         externalId: string;
+        source: string;
         content: unknown;
         ingestData?: Doc<"resumes">["ingestData"];
         isArchived?: boolean;
@@ -449,6 +540,11 @@ export function projectIngestDiagnosticsRow(
     return {
         resumeId: resume._id,
         externalId: resume.externalId,
+        source: resume.source,
+        sourceKey: resolveDiagnosticsSourceKeyForResume({
+            source: resume.source,
+            content: resume.content,
+        }),
         name: toStringValue(content.name),
         jobIntention: toStringValue(content.jobIntention),
         location: toStringValue(content.location) || formatLocationHierarchyLabel(locationHierarchy),
@@ -1696,47 +1792,151 @@ export const listWithIngestDataPaginated = query({
     },
 });
 
+function buildDiagnosticsBaseQuery(ctx: QueryCtx, archived: boolean) {
+    return ctx.db
+        .query("resumes")
+        .withIndex("by_primaryRuleScore")
+        .order("desc")
+        .filter((q) => archived ? q.eq(q.field("isArchived"), true) : q.neq(q.field("isArchived"), true));
+}
+
+async function runDiagnosticsPageQuery(
+    ctx: QueryCtx,
+    args: {
+        archived: boolean;
+        paginationOpts: {
+            cursor: string | null;
+            numItems: number;
+        };
+        sourceKeys?: string[];
+    }
+): Promise<{
+    page: IngestDiagnosticsRow[];
+    continueCursor: string;
+    isDone: boolean;
+}> {
+    const requestedPageSize = Math.min(args.paginationOpts.numItems, MAX_INGEST_DIAGNOSTICS_PAGE_SIZE);
+    const normalizedSourceKeys = normalizeDiagnosticsSourceFilterValues(args.sourceKeys);
+    if (!normalizedSourceKeys || normalizedSourceKeys.length === 0) {
+        const page = await buildDiagnosticsBaseQuery(ctx, args.archived).paginate({
+            ...args.paginationOpts,
+            numItems: requestedPageSize,
+        });
+
+        return {
+            page: page.page.map(projectIngestDiagnosticsRow),
+            continueCursor: page.continueCursor,
+            isDone: page.isDone,
+        };
+    }
+
+    const sourceKeySet = new Set(normalizedSourceKeys);
+    const scanBatchSize = Math.min(
+        Math.max(requestedPageSize * DIAGNOSTICS_SOURCE_FILTER_BATCH_MULTIPLIER, requestedPageSize),
+        MAX_INGEST_DIAGNOSTICS_PAGE_SIZE * DIAGNOSTICS_SOURCE_FILTER_BATCH_MULTIPLIER,
+    );
+
+    const matched: Doc<"resumes">[] = [];
+    let cursor = args.paginationOpts.cursor;
+    let isDone = false;
+    let rounds = 0;
+
+    while (matched.length < requestedPageSize && rounds < DIAGNOSTICS_SOURCE_FILTER_SCAN_ROUNDS) {
+        const page = await buildDiagnosticsBaseQuery(ctx, args.archived).paginate({
+            cursor,
+            numItems: scanBatchSize,
+        });
+        rounds += 1;
+
+        for (const resume of page.page) {
+            if (!matchesDiagnosticsSourceKeys(resume, sourceKeySet)) {
+                continue;
+            }
+
+            matched.push(resume);
+            if (matched.length >= requestedPageSize) {
+                break;
+            }
+        }
+
+        isDone = page.isDone;
+        cursor = page.continueCursor || null;
+        if (isDone || !cursor) {
+            break;
+        }
+    }
+
+    const reachedScanLimit = rounds >= DIAGNOSTICS_SOURCE_FILTER_SCAN_ROUNDS
+        && matched.length < requestedPageSize
+        && !isDone;
+
+    return {
+        page: matched.map(projectIngestDiagnosticsRow),
+        continueCursor: cursor ?? "",
+        isDone: reachedScanLimit ? false : isDone || !cursor,
+    };
+}
+
 export const listIngestDiagnostics = query({
     args: {
         paginationOpts: paginationOptsValidator,
+        sourceKeys: v.optional(v.array(v.string())),
     },
     handler: async (ctx, args) => {
-        const page = await ctx.db
-            .query("resumes")
-            .withIndex("by_primaryRuleScore")
-            .order("desc")
-            .filter((q) => q.neq(q.field("isArchived"), true))
-            .paginate({
-                ...args.paginationOpts,
-                numItems: Math.min(args.paginationOpts.numItems, MAX_INGEST_DIAGNOSTICS_PAGE_SIZE),
-            });
-
-        return {
-            ...page,
-            page: page.page.map(projectIngestDiagnosticsRow),
-        };
+        return runDiagnosticsPageQuery(ctx, {
+            archived: false,
+            paginationOpts: args.paginationOpts,
+            sourceKeys: args.sourceKeys,
+        });
     },
 });
 
 export const listArchivedDiagnostics = query({
     args: {
         paginationOpts: paginationOptsValidator,
+        sourceKeys: v.optional(v.array(v.string())),
     },
     handler: async (ctx, args) => {
-        const page = await ctx.db
-            .query("resumes")
-            .withIndex("by_primaryRuleScore")
-            .order("desc")
-            .filter((q) => q.eq(q.field("isArchived"), true))
-            .paginate({
-                ...args.paginationOpts,
-                numItems: Math.min(args.paginationOpts.numItems, MAX_INGEST_DIAGNOSTICS_PAGE_SIZE),
+        return runDiagnosticsPageQuery(ctx, {
+            archived: true,
+            paginationOpts: args.paginationOpts,
+            sourceKeys: args.sourceKeys,
+        });
+    },
+});
+
+export const listDiagnosticsSourceFacets = query({
+    args: {
+        archived: v.optional(v.boolean()),
+    },
+    handler: async (ctx, args) => {
+        const archived = args.archived === true;
+        const counts = new Map<string, number>();
+        let scannedCount = 0;
+        let cursor: string | null = null;
+        let isDone = false;
+
+        while (!isDone && scannedCount < MAX_DIAGNOSTICS_SOURCE_FACET_SCAN_ROWS) {
+            const page = await buildDiagnosticsBaseQuery(ctx, archived).paginate({
+                cursor,
+                numItems: DIAGNOSTICS_SOURCE_FACET_SCAN_PAGE_SIZE,
             });
 
-        return {
-            ...page,
-            page: page.page.map(projectIngestDiagnosticsRow),
-        };
+            for (const resume of page.page) {
+                const sourceKey = resolveDiagnosticsSourceKeyForResume(resume);
+                counts.set(sourceKey, (counts.get(sourceKey) ?? 0) + 1);
+            }
+
+            scannedCount += page.page.length;
+            isDone = page.isDone;
+            cursor = page.continueCursor || null;
+
+            if (!cursor) {
+                break;
+            }
+        }
+
+        return buildDiagnosticsSourceFacetRows(counts);
     },
 });
 

--- a/packages/shared/src/__tests__/analysis-key.test.ts
+++ b/packages/shared/src/__tests__/analysis-key.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { isSalesRequiredContext } from "../analysis-key";
+import {
+  isSalesRequiredContext,
+  resolveResumeDiagnosticsSourceKey,
+} from "../analysis-key";
 
 describe("isSalesRequiredContext", () => {
   it("detects common English sales-title phrases", () => {
@@ -19,5 +22,24 @@ describe("isSalesRequiredContext", () => {
   it("does not classify non-sales technical titles as sales", () => {
     expect(isSalesRequiredContext("应用工程师")).toBe(false);
     expect(isSalesRequiredContext("机械工程师")).toBe(false);
+  });
+});
+
+describe("resolveResumeDiagnosticsSourceKey", () => {
+  it("keeps manual 51job imports as their own diagnostics key", () => {
+    expect(resolveResumeDiagnosticsSourceKey({ source: "51job-manual" })).toBe("51job-manual");
+    expect(resolveResumeDiagnosticsSourceKey({ sourceKey: "51job-manual" })).toBe("51job-manual");
+  });
+
+  it("maps live source hosts to grouped diagnostics keys", () => {
+    expect(resolveResumeDiagnosticsSourceKey({ source: "hr.job5156.com" })).toBe("job5156");
+    expect(resolveResumeDiagnosticsSourceKey({ source: "ehire.51job.com" })).toBe("51job");
+    expect(resolveResumeDiagnosticsSourceKey({ source: "my.employer.seek.com" })).toBe("seek");
+  });
+
+  it("returns unknown for unmatched source values", () => {
+    expect(resolveResumeDiagnosticsSourceKey({ source: "manual.51job.com" })).toBe("unknown");
+    expect(resolveResumeDiagnosticsSourceKey({ source: "unknown-host.example.com" })).toBe("unknown");
+    expect(resolveResumeDiagnosticsSourceKey({ source: "" })).toBe("unknown");
   });
 });

--- a/packages/shared/src/analysis-key.ts
+++ b/packages/shared/src/analysis-key.ts
@@ -68,6 +68,10 @@ function normalizeJobDescriptionId(value: string | undefined): string {
 }
 
 export type ResumeAnalysisSourceKey = "job5156" | "51job" | "seek";
+export type ResumeDiagnosticsSourceKey =
+  | ResumeAnalysisSourceKey
+  | "51job-manual"
+  | "unknown";
 
 export function normalizeResumeAnalysisSourceKey(
   value: string | null | undefined
@@ -100,6 +104,49 @@ export function normalizeResumeAnalysisSourceKey(
   }
 
   return undefined;
+}
+
+function normalizeResumeDiagnosticsSourceKey(
+  value: string | null | undefined
+): ResumeDiagnosticsSourceKey | undefined {
+  const normalized = normalizeText(value ?? undefined);
+  if (!normalized) {
+    return undefined;
+  }
+
+  if (normalized === MANUAL_51JOB_SOURCE_TOKEN) {
+    return MANUAL_51JOB_SOURCE_TOKEN;
+  }
+
+  if (normalized === "seek" || normalized.endsWith(SEEK_HOST_SUFFIX)) {
+    return "seek";
+  }
+
+  if (
+    normalized === JOB51_SOURCE_KEY
+    || normalized === JOB51_HOST_TOKEN
+    || normalized.endsWith(JOB51_HOST_TOKEN)
+  ) {
+    return "51job";
+  }
+
+  if (
+    normalized === "job5156"
+    || normalized.includes(JOB5156_HOST_TOKEN)
+  ) {
+    return "job5156";
+  }
+
+  return undefined;
+}
+
+export function resolveResumeDiagnosticsSourceKey(scope?: {
+  sourceKey?: string | null;
+  source?: string | null;
+}): ResumeDiagnosticsSourceKey {
+  return normalizeResumeDiagnosticsSourceKey(scope?.sourceKey)
+    ?? normalizeResumeDiagnosticsSourceKey(scope?.source)
+    ?? "unknown";
 }
 
 export function resolveResumeAnalysisSourceKey(scope?: {


### PR DESCRIPTION
## Summary
- Add `/api/resumes/diagnostics` endpoint with `archived`, `sourceKey`, and `limit` query params
- Add Convex `listDiagnosticsSourceFacets` query and source-key canonicalization via `resolveResumeDiagnosticsSourceKey` from `@trends/shared`
- Add CLI `resume debug diagnostics` command with `--archived`, `--source-key`, `--limit` flags
- Add `SourceFacetSelect` shared component for DebugIngest and ArchivedResumes pages
- Simplify pass: API normalizer delegates to canonical resolver; Convex facet scan counts inline instead of accumulating content blobs; extracted shared component to deduplicate UI code

## Test plan
- [x] `npx vitest run apps/api/src/routes/resumes.test.ts` — 26 passed
- [x] `npx vitest run packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts` — 10 passed
- [x] `npx vitest run packages/shared/src/__tests__/analysis-key.test.ts` — 6 passed
- [x] `cd apps/web && npx vitest run src/pages/DebugIngest.test.tsx` — 10 passed
- [x] `cd packages/cli && go test ./cmd/... ./internal/client/...` — passed
- [x] TypeScript check passes (`npx tsc --noEmit -p apps/web/tsconfig.json`)