### PR TITLE
fix: add --local-force-upgrade to convex service and deploy

### DIFF
--- a/deploy/systemd/trends-convex.service
+++ b/deploy/systemd/trends-convex.service
@@ -13,7 +13,7 @@ Environment=NODE_ENV=production
 Environment=CONVEX_AGENT_MODE=anonymous
 UnsetEnvironment=TZ
 ExecStartPre=/usr/bin/bash /opt/trends/scripts/prefetch-convex-backend.sh
-ExecStart=/usr/bin/npx convex dev --local
+ExecStart=/usr/bin/npx convex dev --local --local-force-upgrade
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1254,7 +1254,7 @@ setup_convex_local() {
     systemctl stop trends-convex.service 2>/dev/null || true
 
     log_info "Pushing Convex schema/functions to local backend..."
-    run_as_service_user "set -a && [ -f '$CONFIG_DIR/env' ] && source '$CONFIG_DIR/env' && set +a && cd '$convex_dir' && export CONVEX_AGENT_MODE=anonymous && env -u TZ npx convex dev --local --once"
+    run_as_service_user "set -a && [ -f '$CONFIG_DIR/env' ] && source '$CONFIG_DIR/env' && set +a && cd '$convex_dir' && export CONVEX_AGENT_MODE=anonymous && env -u TZ npx convex dev --local --once --local-force-upgrade"
 
     # Now start the persistent backend service.
     log_info "Starting Convex local backend service..."


### PR DESCRIPTION
## Summary
- `deploy/systemd/trends-convex.service`: add `--local-force-upgrade` to `ExecStart`
- `scripts/install.sh`: add `--local-force-upgrade` to the one-shot `convex dev --local --once` deploy push

## Why
Convex CLI prompts interactively when the local backend binary is older than the CLI version expects. Non-interactive systemd/deploy contexts can't answer → `trends-convex` crashes on start. `--local-force-upgrade` silently upgrades the binary. The dev `package.json` scripts already use this flag; we just missed it in the production paths.

## Test plan
- [ ] `make check` passes
- [ ] Deploy to ptcloud succeeds without Convex prompt error