### PR TITLE
fix: allow legacy tagEnvelope in schema for production migration

### DIFF
--- a/deploy/systemd/trends-convex.service
+++ b/deploy/systemd/trends-convex.service
@@ -13,7 +13,7 @@ Environment=NODE_ENV=production
 Environment=CONVEX_AGENT_MODE=anonymous
 UnsetEnvironment=TZ
 ExecStartPre=/usr/bin/bash /opt/trends/scripts/prefetch-convex-backend.sh
-ExecStart=/usr/bin/npx convex dev --local
+ExecStart=/usr/bin/npx convex dev --local --local-force-upgrade
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -157,6 +157,8 @@ export default defineSchema({
                     }),
                 })),
             })),
+            // Legacy field: migrated to taggingEnvelope; retained for documents not yet migrated.
+            tagEnvelope: v.optional(v.any()),
             ruleScores: v.any(),          // Record<string, number> — JD ID → score
             experienceLevel: v.string(),  // "senior" | "mid" | "junior" | "unknown"
             computedAt: v.number(),

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1254,7 +1254,7 @@ setup_convex_local() {
     systemctl stop trends-convex.service 2>/dev/null || true
 
     log_info "Pushing Convex schema/functions to local backend..."
-    run_as_service_user "set -a && [ -f '$CONFIG_DIR/env' ] && source '$CONFIG_DIR/env' && set +a && cd '$convex_dir' && export CONVEX_AGENT_MODE=anonymous && env -u TZ npx convex dev --local --once"
+    run_as_service_user "set -a && [ -f '$CONFIG_DIR/env' ] && source '$CONFIG_DIR/env' && set +a && cd '$convex_dir' && export CONVEX_AGENT_MODE=anonymous && env -u TZ npx convex dev --local --once --local-force-upgrade"
 
     # Now start the persistent backend service.
     log_info "Starting Convex local backend service..."


### PR DESCRIPTION
## Summary
- Adds `tagEnvelope: v.optional(v.any())` to `ingestData` in `schema.ts`

## Why
Production Convex documents still carry the old `tagEnvelope` field (array form) from before the rename to `taggingEnvelope`. Convex's strict object validator rejects these documents during schema push, blocking every deploy. This field is already handled by the `migrateTagEnvelopeToTaggingEnvelope` migration but that migration can't run until the schema push succeeds first.

## After this merges
Run `migrateTagEnvelopeToTaggingEnvelope` on production to fully migrate remaining documents; `tagEnvelope` can then be removed from the schema in a follow-up.

## Test plan
- [ ] `make check` passes
- [ ] `convex dev --local --once --local-force-upgrade` succeeds on ptcloud