### PR TITLE
fix: retain 3 legacy fields in schema for production documents

### DIFF
--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -32,6 +32,7 @@ export default defineSchema({
             deduped: v.number(),
             identityDeduped: v.optional(v.number()),
             identityMatched: v.optional(v.number()),
+            legacyExternalIdMatched: v.optional(v.number()), // Legacy field; retained for old records.
             inserted: v.number(),
             updated: v.number(),
             unchanged: v.number(),
@@ -337,6 +338,7 @@ export default defineSchema({
                 type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
                 exactUrl: v.optional(v.string()),
             })),
+            collectUrl: v.optional(v.string()), // Legacy field; use collectionSource.exactUrl instead.
             filters: v.optional(v.any()), // Stores ResumeFilters object
         }),
         reviewedResumeIds: v.array(v.string()), // IDs of resumes seen/acted upon
@@ -357,6 +359,7 @@ export default defineSchema({
             type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
             exactUrl: v.optional(v.string()),
         })),
+        collectUrl: v.optional(v.string()), // Legacy field; use collectionSource.exactUrl instead.
         filters: v.optional(v.any()),
         selectedTags: v.optional(v.array(v.string())),
         selectedCompanies: v.optional(v.array(v.string())),


### PR DESCRIPTION
## Summary
Adds 3 more legacy optional fields to prevent Convex schema push failures on production:
- `imports.results.legacyExternalIdMatched: v.optional(v.number())`
- `screening_sessions.config.collectUrl: v.optional(v.string())`
- `search_history.collectUrl: v.optional(v.string())`

## Why
Same issue as #598 — production documents have fields removed in recent schema cleanup. Convex strict validator rejects them, blocking deploy. These fields are superseded by newer equivalents but can't be removed until all old documents are migrated or overwritten.

## Test plan
- [ ] `make check` passes
- [ ] `convex dev --local --once --local-force-upgrade` on ptcloud completes without schema errors