### PR TITLE
fix: use npm ci for deterministic prod installs

### DIFF
--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -32,6 +32,7 @@ export default defineSchema({
             deduped: v.number(),
             identityDeduped: v.optional(v.number()),
             identityMatched: v.optional(v.number()),
+            legacyExternalIdMatched: v.optional(v.number()), // Legacy field; retained for old records.
             inserted: v.number(),
             updated: v.number(),
             unchanged: v.number(),
@@ -337,6 +338,7 @@ export default defineSchema({
                 type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
                 exactUrl: v.optional(v.string()),
             })),
+            collectUrl: v.optional(v.string()), // Legacy field; use collectionSource.exactUrl instead.
             filters: v.optional(v.any()), // Stores ResumeFilters object
         }),
         reviewedResumeIds: v.array(v.string()), // IDs of resumes seen/acted upon
@@ -357,6 +359,7 @@ export default defineSchema({
             type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
             exactUrl: v.optional(v.string()),
         })),
+        collectUrl: v.optional(v.string()), // Legacy field; use collectionSource.exactUrl instead.
         filters: v.optional(v.any()),
         selectedTags: v.optional(v.array(v.string())),
         selectedCompanies: v.optional(v.array(v.string())),

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -913,7 +913,7 @@ sync_dependencies() {
     run_as_service_user "cd '$INSTALL_DIR' && uv sync"
 
     log_info "Installing Node dependencies..."
-    run_as_service_user "cd '$INSTALL_DIR' && npm install"
+    run_as_service_user "cd '$INSTALL_DIR' && npm ci"
 }
 
 build_shared_artifact() {


### PR DESCRIPTION
## Summary
- `scripts/install.sh`: `sync_dependencies` now uses `npm ci` instead of `npm install`

## Why
`npm install` upgrades packages within semver ranges, causing non-deterministic builds. On ptcloud, this upgraded `react-router-dom` from `7.13.2` (locked) to `7.14.1`, which introduced stricter TypeScript types and broke the web build. `npm ci` strictly follows `package-lock.json`.

## Test plan
- [ ] `make check` passes
- [ ] deploy to ptcloud builds web successfully