### PR TITLE
fix(web): annotate remaining implicit-any callback params in components and pages

### DIFF
--- a/apps/web/src/components/FilterPanel.tsx
+++ b/apps/web/src/components/FilterPanel.tsx
@@ -330,7 +330,7 @@ export function FilterPanel({
               <label className="flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border border-border/70 bg-background px-3 py-2.5 text-sm text-foreground/80 hover:text-foreground">
                 <Checkbox
                   checked={showBlocked}
-                  onCheckedChange={(checked) => setShowBlocked(checked === true)}
+                  onCheckedChange={(checked: boolean | 'indeterminate') => setShowBlocked(checked === true)}
                 />
                 {t('resumes.filters.showBlocked')}
               </label>

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -37,7 +37,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
             <NavLink
               to={resumesPath}
               state={RESUME_HOME_RESET_STATE}
-              className={({ isActive }) =>
+              className={({ isActive }: { isActive: boolean }) =>
                 cn(
                   'transition-colors hover:text-foreground',
                   isActive ? 'text-foreground' : 'text-muted-foreground'
@@ -49,7 +49,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
             {showReviewPackets ? (
               <NavLink
                 to={reviewPacketsPath}
-                className={({ isActive }) =>
+                className={({ isActive }: { isActive: boolean }) =>
                   cn(
                     'transition-colors hover:text-foreground',
                     isActive ? 'text-foreground' : 'text-muted-foreground'
@@ -61,7 +61,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
             ) : null}
             <NavLink
               to={settingsPath}
-              className={({ isActive }) =>
+              className={({ isActive }: { isActive: boolean }) =>
                 cn(
                   'transition-colors hover:text-foreground',
                   isActive ? 'text-foreground' : 'text-muted-foreground'
@@ -73,7 +73,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
             {isAdmin ? (
               <NavLink
                 to={systemPath}
-                className={({ isActive }) =>
+                className={({ isActive }: { isActive: boolean }) =>
                   cn(
                     'transition-colors hover:text-foreground',
                     isActive ? 'text-foreground' : 'text-muted-foreground'
@@ -94,7 +94,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
             <NavLink
               to={resumesPath}
               state={RESUME_HOME_RESET_STATE}
-              className={({ isActive }) =>
+              className={({ isActive }: { isActive: boolean }) =>
                 cn(
                   'transition-colors hover:text-foreground',
                   isActive ? 'text-foreground' : 'text-muted-foreground'
@@ -106,7 +106,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
             {showReviewPackets ? (
               <NavLink
                 to={reviewPacketsPath}
-                className={({ isActive }) =>
+                className={({ isActive }: { isActive: boolean }) =>
                   cn(
                     'transition-colors hover:text-foreground',
                     isActive ? 'text-foreground' : 'text-muted-foreground'
@@ -118,7 +118,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
             ) : null}
             <NavLink
               to={settingsPath}
-              className={({ isActive }) =>
+              className={({ isActive }: { isActive: boolean }) =>
                 cn(
                   'transition-colors hover:text-foreground',
                   isActive ? 'text-foreground' : 'text-muted-foreground'
@@ -130,7 +130,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
             {isAdmin ? (
               <NavLink
                 to={systemPath}
-                className={({ isActive }) =>
+                className={({ isActive }: { isActive: boolean }) =>
                   cn(
                     'transition-colors hover:text-foreground',
                     isActive ? 'text-foreground' : 'text-muted-foreground'

--- a/apps/web/src/components/ResumeTable.tsx
+++ b/apps/web/src/components/ResumeTable.tsx
@@ -69,7 +69,7 @@ export function ResumeTable({ items, onViewDetails }: ResumeTableProps) {
           <TableHead className="w-10">
             <Checkbox
               checked={isIndeterminate ? 'indeterminate' : allSelected}
-              onCheckedChange={(value) => toggleAll(Boolean(value))}
+              onCheckedChange={(value: boolean | 'indeterminate') => toggleAll(Boolean(value))}
               aria-label={t('resumes.columns.select')}
             />
           </TableHead>
@@ -92,7 +92,7 @@ export function ResumeTable({ items, onViewDetails }: ResumeTableProps) {
               <TableCell>
                 <Checkbox
                   checked={Boolean(selected[rowId])}
-                  onCheckedChange={(value) => toggleRow(rowId, Boolean(value))}
+                  onCheckedChange={(value: boolean | 'indeterminate') => toggleRow(rowId, Boolean(value))}
                   aria-label={t('resumes.columns.select')}
                 />
               </TableCell>

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -706,7 +706,7 @@ export function SearchProfileEditorDialog({
                                     <Checkbox
                                         id="profile-source-job5156"
                                         checked={sourceForm.job5156Enabled}
-                                        onCheckedChange={(checked) => setSourceForm((previous) => ({
+                                        onCheckedChange={(checked: boolean | 'indeterminate') => setSourceForm((previous) => ({
                                             ...previous,
                                             job5156Enabled: checked === true,
                                         }))}
@@ -738,7 +738,7 @@ export function SearchProfileEditorDialog({
                                     <Checkbox
                                         id="profile-source-job51"
                                         checked={sourceForm.job51Enabled}
-                                        onCheckedChange={(checked) => setSourceForm((previous) => ({
+                                        onCheckedChange={(checked: boolean | 'indeterminate') => setSourceForm((previous) => ({
                                             ...previous,
                                             job51Enabled: checked === true,
                                         }))}
@@ -848,7 +848,7 @@ export function SearchProfileEditorDialog({
                                     <Checkbox
                                         id="profile-source-seek"
                                         checked={sourceForm.seekEnabled}
-                                        onCheckedChange={(checked) => setSourceForm((previous) => ({
+                                        onCheckedChange={(checked: boolean | 'indeterminate') => setSourceForm((previous) => ({
                                             ...previous,
                                             seekEnabled: checked === true,
                                         }))}
@@ -911,7 +911,7 @@ export function SearchProfileEditorDialog({
                     <div className="flex items-center gap-2">
                         <Checkbox
                             checked={form.quickStartEnabled}
-                            onCheckedChange={(checked) => setForm((previous) => ({ ...previous, quickStartEnabled: checked === true }))}
+                            onCheckedChange={(checked: boolean | 'indeterminate') => setForm((previous) => ({ ...previous, quickStartEnabled: checked === true }))}
                             id="profile-quickstart"
                         />
                         <Label htmlFor="profile-quickstart">{t('searchProfiles.fields.quickStart', { defaultValue: 'Show in QuickStart' })}</Label>
@@ -920,7 +920,7 @@ export function SearchProfileEditorDialog({
                     <div className="flex items-center gap-2">
                         <Checkbox
                             checked={form.enabled}
-                            onCheckedChange={(checked) => setForm((previous) => ({ ...previous, enabled: checked === true }))}
+                            onCheckedChange={(checked: boolean | 'indeterminate') => setForm((previous) => ({ ...previous, enabled: checked === true }))}
                             id="profile-enabled"
                         />
                         <Label htmlFor="profile-enabled">{t('searchProfiles.fields.enabled', { defaultValue: 'Enabled' })}</Label>

--- a/apps/web/src/components/ShareLinkButton.tsx
+++ b/apps/web/src/components/ShareLinkButton.tsx
@@ -205,7 +205,7 @@ export function ShareLinkButton({ shareTitle, state, ensureApiSession, onCopySta
         分享
       </Button>
 
-      <Dialog open={fallbackPayload !== null} onOpenChange={(open) => {
+      <Dialog open={fallbackPayload !== null} onOpenChange={(open: boolean) => {
         if (!open) {
           setFallbackPayload(null)
         }

--- a/apps/web/src/layouts/SystemSettingsLayout.tsx
+++ b/apps/web/src/layouts/SystemSettingsLayout.tsx
@@ -31,7 +31,7 @@ export default function SystemSettingsLayout() {
               key={item.id}
               to={item.href}
               end={item.id === 'overview'}
-              className={({ isActive }) =>
+              className={({ isActive }: { isActive: boolean }) =>
                 cn(
                   'rounded-full border px-3 py-1 text-sm transition-colors',
                   isActive ? 'bg-foreground text-background' : 'text-muted-foreground hover:text-foreground'

--- a/apps/web/src/pages/ArchivedResumes.tsx
+++ b/apps/web/src/pages/ArchivedResumes.tsx
@@ -177,7 +177,7 @@ export default function ArchivedResumes() {
               <TableHead className="w-[48px]">
                 <Checkbox
                   checked={allVisibleSelected ? true : someVisibleSelected ? 'indeterminate' : false}
-                  onCheckedChange={(checked) => toggleSelectAllVisible(checked === true)}
+                  onCheckedChange={(checked: boolean | 'indeterminate') => toggleSelectAllVisible(checked === true)}
                   aria-label={t('bulkActions.selectAll', { defaultValue: 'Select all' })}
                   disabled={visibleResumeIds.length === 0 || unarchiving}
                 />
@@ -214,7 +214,7 @@ export default function ArchivedResumes() {
                     <TableCell>
                       <Checkbox
                         checked={isSelected}
-                        onCheckedChange={(checked) => toggleSelectResume(resumeId, checked === true)}
+                        onCheckedChange={(checked: boolean | 'indeterminate') => toggleSelectResume(resumeId, checked === true)}
                         aria-label={resumeId}
                         disabled={unarchiving}
                       />

--- a/apps/web/src/pages/BlacklistPage.tsx
+++ b/apps/web/src/pages/BlacklistPage.tsx
@@ -223,7 +223,7 @@ export function BlacklistPage() {
                   <TableHead className="w-[42px]">
                     <Checkbox
                       checked={allVisibleSelected ? true : someVisibleSelected ? 'indeterminate' : false}
-                      onCheckedChange={(checked) => toggleAllVisible(checked === true)}
+                      onCheckedChange={(checked: boolean | 'indeterminate') => toggleAllVisible(checked === true)}
                       aria-label={t('bulkActions.selectAll', { defaultValue: 'Select all' })}
                       data-testid="blacklist-select-all"
                     />
@@ -246,7 +246,7 @@ export function BlacklistPage() {
                       <TableCell>
                         <Checkbox
                           checked={selectedIdentityKeys.includes(item.identityKey)}
-                          onCheckedChange={(checked) => toggleOne(item.identityKey, checked === true)}
+                          onCheckedChange={(checked: boolean | 'indeterminate') => toggleOne(item.identityKey, checked === true)}
                           aria-label={item.identityKey}
                           data-testid="blacklist-row-checkbox"
                         />

--- a/apps/web/src/pages/DebugConfig.tsx
+++ b/apps/web/src/pages/DebugConfig.tsx
@@ -140,19 +140,19 @@ export default function DebugConfig() {
 
       <Dialog
         open={resetDatabaseDialogOpen}
-        onOpenChange={(open) => {
+        onOpenChange={(open: boolean) => {
           if (!resettingDatabase) {
             setResetDatabaseDialogOpen(open)
           }
         }}
       >
         <DialogContent
-          onEscapeKeyDown={(event) => {
+          onEscapeKeyDown={(event: { preventDefault: () => void }) => {
             if (resettingDatabase) {
               event.preventDefault()
             }
           }}
-          onPointerDownOutside={(event) => {
+          onPointerDownOutside={(event: { preventDefault: () => void }) => {
             if (resettingDatabase) {
               event.preventDefault()
             }

--- a/apps/web/src/pages/DebugIngest.tsx
+++ b/apps/web/src/pages/DebugIngest.tsx
@@ -656,19 +656,19 @@ export default function DebugIngest() {
 
       <Dialog
         open={hardResetDialogOpen}
-        onOpenChange={(open) => {
+        onOpenChange={(open: boolean) => {
           if (!hardResetting) {
             setHardResetDialogOpen(open)
           }
         }}
       >
         <DialogContent
-          onEscapeKeyDown={(event) => {
+          onEscapeKeyDown={(event: { preventDefault: () => void }) => {
             if (hardResetting) {
               event.preventDefault()
             }
           }}
-          onPointerDownOutside={(event) => {
+          onPointerDownOutside={(event: { preventDefault: () => void }) => {
             if (hardResetting) {
               event.preventDefault()
             }
@@ -704,19 +704,19 @@ export default function DebugIngest() {
 
       <Dialog
         open={resetDialogOpen}
-        onOpenChange={(open) => {
+        onOpenChange={(open: boolean) => {
           if (!resettingDatabase) {
             setResetDialogOpen(open)
           }
         }}
       >
         <DialogContent
-          onEscapeKeyDown={(event) => {
+          onEscapeKeyDown={(event: { preventDefault: () => void }) => {
             if (resettingDatabase) {
               event.preventDefault()
             }
           }}
-          onPointerDownOutside={(event) => {
+          onPointerDownOutside={(event: { preventDefault: () => void }) => {
             if (resettingDatabase) {
               event.preventDefault()
             }
@@ -752,19 +752,19 @@ export default function DebugIngest() {
 
       <Dialog
         open={resumePendingDelete !== null}
-        onOpenChange={(open) => {
+        onOpenChange={(open: boolean) => {
           if (!deletingResumes && !open) {
             setResumePendingDelete(null)
           }
         }}
       >
         <DialogContent
-          onEscapeKeyDown={(event) => {
+          onEscapeKeyDown={(event: { preventDefault: () => void }) => {
             if (deletingResumes) {
               event.preventDefault()
             }
           }}
-          onPointerDownOutside={(event) => {
+          onPointerDownOutside={(event: { preventDefault: () => void }) => {
             if (deletingResumes) {
               event.preventDefault()
             }
@@ -803,19 +803,19 @@ export default function DebugIngest() {
 
       <Dialog
         open={bulkDeleteDialogOpen}
-        onOpenChange={(open) => {
+        onOpenChange={(open: boolean) => {
           if (!deletingResumes) {
             setBulkDeleteDialogOpen(open)
           }
         }}
       >
         <DialogContent
-          onEscapeKeyDown={(event) => {
+          onEscapeKeyDown={(event: { preventDefault: () => void }) => {
             if (deletingResumes) {
               event.preventDefault()
             }
           }}
-          onPointerDownOutside={(event) => {
+          onPointerDownOutside={(event: { preventDefault: () => void }) => {
             if (deletingResumes) {
               event.preventDefault()
             }


### PR DESCRIPTION
## Summary
- Fixes ~37 TypeScript implicit-any errors in components and pages that weren't covered by #601
- Same root cause: Radix UI onCheckedChange/onOpenChange and react-router NavLink className callbacks need explicit param types when React 18 is hoisted at root

## Files fixed
- `components/FilterPanel.tsx` — Checkbox onCheckedChange
- `components/Header.tsx` — NavLink className (8 instances)
- `components/ResumeTable.tsx` — Checkbox onCheckedChange (2)
- `components/SearchProfileEditorDialog.tsx` — Checkbox onCheckedChange (5)
- `components/ShareLinkButton.tsx` — Dialog onOpenChange
- `layouts/SystemSettingsLayout.tsx` — NavLink className
- `pages/ArchivedResumes.tsx` — Checkbox onCheckedChange (2)
- `pages/BlacklistPage.tsx` — Checkbox onCheckedChange (2)
- `pages/DebugConfig.tsx` — Dialog onOpenChange + event handlers
- `pages/DebugIngest.tsx` — Dialog onOpenChange + event handlers (4 dialogs)

## Test plan
- [ ] `tsc -b` passes in `apps/web` after merge
- [ ] Build succeeds on ptcloud preview server