### PR TITLE
fix: surface pending tasks in list + headless collector experimental flag

### DIFF
--- a/apps/api/src/routes/search-profiles.test.ts
+++ b/apps/api/src/routes/search-profiles.test.ts
@@ -392,11 +392,13 @@ describe('search-profiles list route', () => {
 describe('search-profiles run route', () => {
   beforeEach(() => {
     removeRunStatusFile()
+    process.env.ENABLE_HEADLESS_COLLECTOR = 'true'
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
     removeRunStatusFile()
+    delete process.env.ENABLE_HEADLESS_COLLECTOR
   })
 
   it('uses workspace-scoped custom profiles for hr runs', async () => {

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -1159,6 +1159,13 @@ const runProfileRoute = createRoute({
 });
 
 app.openapi(runProfileRoute, async (c) => {
+    if (process.env.ENABLE_HEADLESS_COLLECTOR !== "true") {
+        return c.json({
+            success: false as const,
+            error: "Headless collector is not available in this environment.",
+        }, 403);
+    }
+
     const { id } = c.req.valid("param");
     const workspaceSlug = c.var.workspaceSlug;
 

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -1,4 +1,5 @@
 import { formatKeywordInput, inferKeywordQueryMode, normalizeKeywordPhrases, parseKeywordQuery } from '@trends/shared'
+import { isHeadlessCollectorEnabled } from '@/lib/feature-flags'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from 'convex/react'
 import { useTranslation } from 'react-i18next'
@@ -903,9 +904,12 @@ export function SearchProfileEditorDialog({
                             onChange={(event) => setForm((previous) => ({ ...previous, collectionMode: event.target.value as 'head' | 'headless' }))}
                             options={[
                                 { value: 'head', label: t('searchProfiles.fields.collectionModeHead', { defaultValue: 'Open tabs (default)' }) },
-                                { value: 'headless', label: t('searchProfiles.fields.collectionModeHeadless', { defaultValue: 'Background crawler' }) },
+                                ...(isHeadlessCollectorEnabled() ? [{ value: 'headless', label: t('searchProfiles.fields.collectionModeHeadless', { defaultValue: 'Background crawler (experimental)' }) }] : []),
                             ]}
                         />
+                        {!isHeadlessCollectorEnabled() && form.collectionMode === 'headless' && (
+                            <p className="text-xs text-amber-600">{t('searchProfiles.fields.headlessDisabled', { defaultValue: 'Background crawler is disabled. Set VITE_ENABLE_HEADLESS_COLLECTOR=true to enable.' })}</p>
+                        )}
                     </div>
 
                     <div className="flex items-center gap-2">

--- a/apps/web/src/lib/feature-flags.ts
+++ b/apps/web/src/lib/feature-flags.ts
@@ -14,3 +14,7 @@ export function isReviewPacketsEnabled(): boolean {
 export function isResumeAiSummaryEnabled(): boolean {
   return import.meta.env.VITE_ENABLE_RESUME_AI_SUMMARY === 'true'
 }
+
+export function isHeadlessCollectorEnabled(): boolean {
+  return import.meta.env.VITE_ENABLE_HEADLESS_COLLECTOR === 'true'
+}

--- a/apps/web/src/pages/SearchProfilesPage.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.tsx
@@ -4,6 +4,7 @@ import { Plus, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { rawApiClient } from '@/lib/api-helpers'
+import { isHeadlessCollectorEnabled } from '@/lib/feature-flags'
 import { ProfileCard, type SearchProfileRunStatus, type SearchProfileSummary } from '@/components/ProfileCard'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -417,6 +418,13 @@ export function SearchProfilesPage() {
       headModeResetTimersRef.current[profileId] = setTimeout(() => {
         clearHeadModePendingRun(profileId)
       }, 2000)
+      return
+    }
+
+    // Headless (background crawler) path — guard with feature flag
+    if (!isHeadlessCollectorEnabled()) {
+      runNowLocksRef.current.delete(profileId)
+      toast.error(t('searchProfiles.headlessDisabled', { defaultValue: 'Background crawler is not enabled. Set VITE_ENABLE_HEADLESS_COLLECTOR=true to use headless collection.' }))
       return
     }
 

--- a/apps/worker/resume_tasks.py
+++ b/apps/worker/resume_tasks.py
@@ -124,6 +124,13 @@ def run_resume_crawl_task(profile: Dict[str, Any]) -> bool:
     the web/API critical path (collection_tasks -> scraper worker -> resumes).
     """
 
+    if os.environ.get("ENABLE_HEADLESS_COLLECTOR") != "true":
+        logger.info(
+            "[Task] Headless collector disabled; skipping scheduled dispatch for profile %s",
+            profile.get("id"),
+        )
+        return False
+
     profile_id = str(profile.get("id") or "")
     location = str(profile.get("location") or "").strip()
 

--- a/apps/worker/scheduler.py
+++ b/apps/worker/scheduler.py
@@ -273,6 +273,10 @@ class WorkerScheduler:
 
     def load_profile_jobs(self) -> None:
         """Load and schedule jobs from search profiles."""
+        if os.environ.get("ENABLE_HEADLESS_COLLECTOR") != "true":
+            logger.info("Headless collector disabled; skipping profile job registration")
+            return
+
         try:
             loader = ProfileLoader()
             profiles = loader.load_profiles()

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -109,10 +109,24 @@ function applyRestoreStateFields(
 export const list = query({
     args: {},
     handler: async (ctx) => {
-        return await ctx.db
+        // Always include all active tasks (pending/processing) regardless of age
+        const pendingTasks = await ctx.db
+            .query("collection_tasks")
+            .withIndex("by_status", (q) => q.eq("status", "pending"))
+            .collect();
+        const processingTasks = await ctx.db
+            .query("collection_tasks")
+            .withIndex("by_status", (q) => q.eq("status", "processing"))
+            .collect();
+        // Plus the 20 most recent finished tasks
+        const activeIds = new Set([...pendingTasks, ...processingTasks].map(t => t._id));
+        const recent = await ctx.db
             .query("collection_tasks")
             .order("desc")
             .take(20);
+        const finishedRecent = recent.filter(t => !activeIds.has(t._id));
+        return [...pendingTasks, ...processingTasks, ...finishedRecent]
+            .sort((a, b) => b._creationTime - a._creationTime);
     },
 });
 

--- a/scripts/test-headless-flag.sh
+++ b/scripts/test-headless-flag.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# test-headless-flag.sh — Verify 3-layer headless collector feature flag
+#
+# Prerequisites:
+#   - API dev server running (make dev-api)
+#   - At least one search profile exists
+#
+# Usage:
+#   bash scripts/test-headless-flag.sh
+set -euo pipefail
+
+API_BASE="${API_BASE:-http://localhost:3001}"
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local desc="$1"
+  local haystack="$2"
+  local needle="$3"
+  if printf '%s\n' "$haystack" | grep -Fq "$needle"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "    expected to find: $needle"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_status() {
+  local desc="$1"
+  local actual="$2"
+  local expected="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  PASS: $desc (HTTP $actual)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got HTTP $actual, expected $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== Headless collector feature flag test ==="
+
+# --- Worker layer tests (no server needed) ---
+echo ""
+echo "Layer: Worker (Python)"
+
+echo "  Test 1: Worker skips dispatch when ENABLE_HEADLESS_COLLECTOR is unset"
+WORKER_OUT=$(ENABLE_HEADLESS_COLLECTOR= python3 -c "
+import os, sys, logging
+logging.basicConfig(level=logging.DEBUG, stream=sys.stderr, force=True)
+os.chdir('$PWD')
+sys.path.insert(0, '.')
+from apps.worker.resume_tasks import run_resume_crawl_task
+result = run_resume_crawl_task({'id': 'test-flag-off', 'location': 'Singapore', 'keywords': ['dev']})
+print(f'RESULT={result}')
+" 2>&1 || true)
+assert_contains "worker returns False when flag off" "$WORKER_OUT" "RESULT=False"
+assert_contains "worker logs skip message" "$WORKER_OUT" "Headless collector disabled"
+
+echo "  Test 2: Worker attempts dispatch when ENABLE_HEADLESS_COLLECTOR=true"
+WORKER_ON_OUT=$(ENABLE_HEADLESS_COLLECTOR=true python3 -c "
+import os, sys, logging
+logging.basicConfig(level=logging.DEBUG, stream=sys.stderr, force=True)
+os.chdir('$PWD')
+sys.path.insert(0, '.')
+from apps.worker.resume_tasks import run_resume_crawl_task
+result = run_resume_crawl_task({'id': 'test-flag-on', 'location': 'Singapore', 'keywords': ['dev']})
+print(f'RESULT={result}')
+" 2>&1 || true)
+# With flag on, it should attempt Convex dispatch (fails if Convex not running — that's OK)
+# The key assertion: it does NOT log the "disabled" skip message
+if printf '%s\n' "$WORKER_ON_OUT" | grep -Fq "Headless collector disabled"; then
+  echo "  FAIL: worker should not skip when flag is on"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: worker does not skip when flag is on"
+  PASS=$((PASS + 1))
+fi
+# It should either log "Dispatching profile crawl" (Convex up) or fail on Convex URL (not running) or return True/False
+if printf '%s\n' "$WORKER_ON_OUT" | grep -Fq "Dispatching profile crawl" || printf '%s\n' "$WORKER_ON_OUT" | grep -Fq "CONVEX_URL" || printf '%s\n' "$WORKER_ON_OUT" | grep -Fq "RESULT=True" || printf '%s\n' "$WORKER_ON_OUT" | grep -Fq "RESULT=False"; then
+  echo "  PASS: worker attempts dispatch when flag is on"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: worker did not attempt dispatch when flag is on"
+  echo "    output: $WORKER_ON_OUT"
+  FAIL=$((FAIL + 1))
+fi
+
+# --- API layer tests (requires dev server) ---
+echo ""
+echo "Layer: API (Node/Hono)"
+
+# Find a profile ID to test with
+PROFILE_ID=""
+PROFILE_LIST=$(curl -sf "$API_BASE/api/search-profiles" 2>/dev/null || echo '{"items":[]}')
+if echo "$PROFILE_LIST" | python3 -c "import sys,json; items=json.load(sys.stdin).get('items',[]); print(items[0]['id'] if items else '')" 2>/dev/null | grep -q .; then
+  PROFILE_ID=$(echo "$PROFILE_LIST" | python3 -c "import sys,json; items=json.load(sys.stdin).get('items',[]); print(items[0]['id'] if items else '')")
+fi
+
+if [ -z "$PROFILE_ID" ]; then
+  echo "  SKIP: No search profile found — create one via UI to enable API layer tests"
+  echo "  (Worker tests above already passed without server)"
+else
+  echo "  Using profile ID: $PROFILE_ID"
+
+  echo "  Test 3: API returns 403 when ENABLE_HEADLESS_COLLECTOR is not set"
+  API_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_BASE/api/search-profiles/$PROFILE_ID/run" -H "Content-Type: application/json" -d '{}' 2>/dev/null || echo "000")
+  assert_status "API rejects /run with 403" "$API_RESPONSE" "403"
+
+  echo "  Test 4: API 403 body contains headless-disabled error"
+  API_BODY=$(curl -sf -X POST "$API_BASE/api/search-profiles/$PROFILE_ID/run" -H "Content-Type: application/json" -d '{}' 2>/dev/null || echo '{}')
+  assert_contains "API error mentions headless collector" "$API_BODY" "not available"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- **Task list fix**: `resume_tasks.list` was limited to `.take(20)` ordered desc. Tasks older than the 20 most-recent records became invisible — notably pending tasks that piled up before a batch of cancellations. Now always fetches all pending/processing tasks via index first, then appends the 20 most-recent finished ones.
- **Headless experimental flag (3-layer enforcement)**: System-wide opt-in flag, default off. Each layer blocks headless collection independently:
  - **Frontend** (`VITE_ENABLE_HEADLESS_COLLECTOR`): Hides "Background crawler" option in profile editor; blocks Run Now in SearchProfilesPage with toast error; shows amber warning on existing headless profiles.
  - **API** (`ENABLE_HEADLESS_COLLECTOR`): `POST /api/search-profiles/:id/run` returns 403 when flag is off, blocking external/cURL calls.
  - **Worker** (`ENABLE_HEADLESS_COLLECTOR`): Scheduler skips profile job registration at init time; `run_resume_crawl_task` early-returns as defense-in-depth. Prevents cron-triggered headless dispatches.

## How to enable headless
Add to deployment env (or `.env.local` for dev):
```
ENABLE_HEADLESS_COLLECTOR=true
VITE_ENABLE_HEADLESS_COLLECTOR=true   # frontend (Vite build-time)
```
Production `.env.production` includes the flag commented out with `# exp:` tag — uncomment to opt in.

## Test plan
- [ ] Operations page shows pending tasks (with Cancel button) even when they predate the 20 most-recent finished tasks
- [ ] Profile editor Collection Mode dropdown shows only "Open tabs (default)" when flag is off
- [ ] Clicking Run Now on a headless profile shows error toast when flag is off
- [ ] `POST /api/search-profiles/:id/run` returns 403 when `ENABLE_HEADLESS_COLLECTOR` is unset
- [ ] Worker `run_resume_crawl_task` returns `False` without dispatching when flag is off
- [ ] Worker scheduler `load_profile_jobs` skips registration when flag is off
- [ ] `bash scripts/test-headless-flag.sh` passes (worker layer tests)
- [ ] Existing profiles with `collectionMode: 'headless'` show amber warning in editor when flag is off