### PR TITLE
feat: full restore with candidate actions/status backup and reset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ English-first guidance; Chinese notes are short clarifications.
 - BFF/API: Hono + OpenAPI (`apps/api`).
 - Worker: FastAPI scheduler/REST (`apps/worker`).
 - Data/compute path: Convex (`packages/convex`).
+- Candidate state is split: `candidate_actions` (star/archive/shortlist/reject/note/contact) in SQLite `output/resume_screening.db`; `candidate_status` (pipeline enum) in Convex.
 - Runtime sources include crawler output (`output/*.db`) and resume samples.
 
 ## Execution Priority
@@ -97,57 +98,45 @@ English-first guidance; Chinese notes are short clarifications.
 - CI: use `npm` / `npx` only.
 - Python dependency/runtime tooling: `uv`.
 
-### Start Development
+### Local dev stack
 ```bash
-make install-deps                           # Sync repo project skills into .agents/.claude and install configured global skills via the skills CLI
-CONVEX_MIRROR_MODE=mirror-first make install-deps  # Optional: mirror-first Convex prefetch during bootstrap
-make sync-project-skills                    # Refresh committed project skill artifacts after editing dev-docs/skills/*
-make install-global-skills                  # Reinstall configured external global skills from config/skills/install.yaml (direct npx skills add -g tree URLs)
-make prefetch-convex                        # Prefetch local Convex backend + dashboard cache
-CONVEX_MIRROR_MODE=mirror-first make prefetch-convex  # Optional: try configured mirrors before GitHub
-make dev                # Full local stack
-make dev-fast           # UI-focused fast profile
-make dev-critical       # Critical path profile
-make dev-backend        # Backend-focused profile
-./scripts/dev.sh --help # Full dev service-profile plus CI=true/1 for Convex startup/prefetch and related env contract
+make install-deps                                    # Bootstrap (skills + deps + bin/trends + Convex prefetch)
+make dev                # Full local stack (alias preserved)
+make dev-fast           # UI-focused
+make dev-critical / dev-backend
+make dev-web / dev-api / dev-worker / dev-api-worker / dev-mcp / dev-crawl
+./scripts/dev.sh --help
 ```
 
-### Start Single Services
+### Local checks & tooling
 ```bash
-make dev-web
-make dev-api
-make dev-worker
-make dev-api-worker
-make dev-mcp
-make dev-crawl
-```
-
-### Deployment
-```bash
-make prod-install                                # Install the production stack from the current checkout (JDs only)
-ENV_FILE=.env.production make prod-deploy-check  # Dry run the deploy precheck against the target env
-CONVEX_MIRROR_MODE=mirror-first make prod-deploy # Optional: mirror-first Convex prefetch during upgrade
-make restore-sample-snapshots                    # Optional: pull + restore fresh sample resume snapshots for dev
-./scripts/install.sh --help                 # Full install/upgrade modes plus CI=true/1 for production prefetch and related env knobs
-```
-
-### Verification
-```bash
-make check                  # Default: validate committed project skill sync plus ~/.codex/skills governance install
-make check TARGET=all       # Optional: validate governance installs in both skill roots
-make check-build TARGET=all # Optional: include build validation after dual-root governance checks
-make check-node
-make check-python
+make check                  # validate + governance + project skill sync
+make check TARGET=all       # dual-root governance
+make check-node / check-python
 npm test
-npm run verify:critical-path
-npm run test:api:search-profiles
-npm run test:worker:resume-tasks
+npm --workspace @trends/web run gen:api   # after API schema edits
 ```
 
-### API Contract / Client Sync
-Use when API route/schema changed:
+### Remote backup (laptop -> prod via SSH)
 ```bash
-npm --workspace @trends/web run gen:api
+make remote-backup-prod                          # SSH tunnel -> backup -> close (alias: backup-prod)
+make remote-backup-prod SSH_HOST=myhost WORKSPACE=hr
+```
+
+### Restore to local dev (laptop-only)
+```bash
+make local-restore-from-prod FILE=output/resume-backups/resumes-prod-<...>.tar.gz
+# MODE=replace YES=1 preset; auto-writes safety pre-backup; skip with SKIP_AUTO_BACKUP=1
+# For merge mode: make restore-resumes FILE=... MODE=merge
+# Go CLI: trends resume full-restore <path>
+```
+
+### On prod host (after `ssh ptcloud && cd /opt/trends`)
+```bash
+make on-prod-deploy-check        # dry run (alias: prod-deploy-check / deploy-check)
+make on-prod-deploy              # full upgrade (alias: prod-deploy / deploy)
+make on-prod-install             # first-time systemd install (alias: prod-install / install)
+make on-prod-refresh-env         # refresh env + rebuild web bundle (alias: refresh-env)
 ```
 
 ### Governance Sync (only when policy block changes)
@@ -175,6 +164,11 @@ TARGET=all make sync-agent-governance  # Optional: run policy sync + governance 
 - Do not modify `README.md` unless explicitly requested.
 - Do not add docs/comments unless explicitly requested.
 - Keep changes minimal, testable, and scoped to user request.
+
+### Known Gotchas
+- After editing `apps/api/src/schemas/*.ts`, stage `apps/web/src/lib/api-types.ts` too — `make check` regenerates it and fails `git diff --exit-code` otherwise.
+- `make clear-resumes` may raise `OptimisticConcurrencyControlFailure` when scheduled Convex jobs overlap; just re-run until `partial:false`.
+- Local Convex dev backend rate-limits at ~4 MiB writes/sec; large restores (2k+ resumes) can hit `TooManyWrites 429` — wait ~30-60s between retry attempts.
 
 ## Current Engineering Direction (Stable Snapshot)
 - Resume screening is the primary product path.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 # TrendRadar Development Makefile
 
-.PHONY: dev dev-samples dev-fast dev-critical dev-backend dev-clean dev-mcp dev-crawl dev-convex dev-convex-stop dev-convex-restart dev-convex-refresh dev-convex-ensure dev-convex-status dev-web dev-api dev-worker dev-api-worker run crawl mcp mcp-http \
-		worker worker-once prod-install prod-deploy prod-deploy-check install deploy deploy-check install-deps uninstall fetch-docs clean check help docker docker-build docker-down \
+.PHONY: dev dev-samples dev-fast dev-critical dev-backend dev-clean dev-mcp dev-crawl dev-convex dev-convex-stop dev-convex-restart dev-convex-refresh dev-convex-ensure dev-convex-status dev-web dev-api dev-worker dev-api-worker \
+		local-run-crawler local-run-mcp local-run-mcp-http local-run-worker local-run-worker-once run crawl mcp mcp-http worker worker-once \
+		on-prod-install on-prod-deploy on-prod-deploy-check on-prod-uninstall on-prod-refresh-env prod-install prod-deploy prod-deploy-check install deploy deploy-check uninstall refresh-env \
+		install-deps fetch-docs clean check help docker docker-build docker-down \
 		check-python check-node check-build \
 		test test-python test-node test-resume test-extension-keyword-mode test-api-search-profiles test-worker-resume-tasks test-collect-url-smoke \
 		build-static build-static-fresh build-extension-zip serve-static \
@@ -10,7 +12,7 @@
 		debug-51job-detail \
 		seed seed-full seed-force seed-clear seed-clear-workspace seed-clear-dev \
 		seed-clear-demo-resumes \
-		backup-resumes restore-resumes restore-resumes-restart clear-resume-analyses clear-resume-analyses-restart \
+		backup-resumes restore-resumes remote-backup-prod backup-prod local-restore-from-prod restore-from-prod restore-resumes-restart clear-resume-analyses clear-resume-analyses-restart \
 		clear-resumes \
 		cli-build cli-install cli-test \
 		sync-agent-policy check-agent-policy sync-project-skills check-project-skills install-global-skills install-agent-skill check-agent-skill sync-agent-governance \
@@ -284,61 +286,66 @@ dev-worker:
 # Production
 # =============================================================================
 
-# Production run (writes root index.html for GitHub Pages)
-run:
+# Local run: production-mode on laptop (NOT on prod host)
+local-run-crawler:
 	uv run python -m trendradar
 
-# Run crawler (alias for run)
-crawl:
-	uv run python -m trendradar
+run: local-run-crawler
+crawl: local-run-crawler
 
-# MCP server (STDIO mode - for MCP clients over stdio)
-mcp:
+local-run-mcp:
 	uv run python -m mcp_server.server
 
-# MCP server (HTTP mode - for web-based clients)
-mcp-http:
+mcp: local-run-mcp
+
+local-run-mcp-http:
 	uv run python -m mcp_server.server --transport http --port 3333
 
-# Worker scheduler (production mode)
-worker:
+mcp-http: local-run-mcp-http
+
+local-run-worker:
 	uv run python -m apps.worker
 
-# Worker scheduler (run once and exit)
-worker-once:
+worker: local-run-worker
+
+local-run-worker-once:
 	uv run python -m apps.worker --once
 
+worker-once: local-run-worker-once
+
 # =============================================================================
-# Deployment
+# On-prod host (ssh in first: ssh <host> && cd /opt/trends && make <target>)
 # =============================================================================
 
-# Install as systemd services (production) — seeds JDs only + runs migrations
-prod-install:
+# Runs on prod host ONLY. Install as systemd services — seeds JDs only + runs migrations
+on-prod-install:
 	sudo REPO_URL="$${REPO_URL:-}" ENV_FILE="$${ENV_FILE:-.env.production}" WORKSPACE_DIR="$$(pwd)" INSTALL_BRANCH="$${INSTALL_BRANCH:-}" ALLOW_NODE_DOWNGRADE="$${ALLOW_NODE_DOWNGRADE:-}" ./scripts/install.sh install
 
-# Backwards-compatible alias for prod-install
-install: prod-install
+prod-install: on-prod-install
+install: on-prod-install
 
-# Preflight workspace branch, snapshot Convex, then pull/rebuild/restart production services (JDs only)
-prod-deploy:
+# Runs on prod host ONLY. Preflight workspace branch, snapshot Convex, then pull/rebuild/restart production services (JDs only)
+on-prod-deploy:
 	sudo REPO_URL="$${REPO_URL:-}" ENV_FILE="$${ENV_FILE:-.env.production}" WORKSPACE_DIR="$$(pwd)" INSTALL_BRANCH="$${INSTALL_BRANCH:-}" FORCE="$${FORCE:-}" ALLOW_NODE_DOWNGRADE="$${ALLOW_NODE_DOWNGRADE:-}" ./scripts/install.sh upgrade
 
-# Backwards-compatible alias for prod-deploy
-deploy: prod-deploy
+prod-deploy: on-prod-deploy
+deploy: on-prod-deploy
 
-# Show whether deploy would skip, refresh env only, or run a full upgrade
-prod-deploy-check:
+# Runs on prod host ONLY. Show whether deploy would skip, refresh env only, or run a full upgrade
+on-prod-deploy-check:
 	sudo REPO_URL="$${REPO_URL:-}" ENV_FILE="$${ENV_FILE:-.env.production}" WORKSPACE_DIR="$$(pwd)" INSTALL_BRANCH="$${INSTALL_BRANCH:-}" FORCE="$${FORCE:-}" ALLOW_NODE_DOWNGRADE="$${ALLOW_NODE_DOWNGRADE:-}" ./scripts/install.sh upgrade-check
 
-# Backwards-compatible alias for prod-deploy-check
-deploy-check: prod-deploy-check
+prod-deploy-check: on-prod-deploy-check
+deploy-check: on-prod-deploy-check
 
-# Remove systemd services
-uninstall:
+# Runs on prod host ONLY. Remove systemd services
+on-prod-uninstall:
 	sudo ENV_FILE="$${ENV_FILE:-.env.production}" WORKSPACE_DIR="$$(pwd)" ./scripts/install.sh uninstall
 
-# Refresh runtime env and rebuild the production frontend bundle
-refresh-env:
+uninstall: on-prod-uninstall
+
+# Runs on prod host ONLY. Refresh runtime env and rebuild the production frontend bundle
+on-prod-refresh-env:
 	@if [ ! -f .env.production ]; then echo "Error: .env.production not found"; exit 1; fi
 	sudo cp .env.production /etc/trends/env; \
 	sudo cp .env.production /opt/trends/.env.production; \
@@ -360,6 +367,9 @@ refresh-env:
 	sudo systemctl is-active --quiet trends-worker-api && echo "  trends-worker-api: active" || echo "  trends-worker-api: FAILED"; \
 	sudo systemctl is-active --quiet trends-mcp && echo "  trends-mcp: active" || echo "  trends-mcp: FAILED"
 
+refresh-env: on-prod-refresh-env
+
+# Dual-target: follows $API_URL. Defaults to http://localhost:3000 (local).
 # Backup live resume records to a portable JSON or .tar.gz file
 backup-resumes:
 	@API_URL="$${API_URL:-$${TRENDS_API_URL:-http://localhost:3000}}" \
@@ -387,6 +397,40 @@ restore-resumes:
 		npx tsx scripts/resume/restore-resumes.ts; \
 	fi
 
+# One-liner: SSH tunnel → backup prod workspace → close tunnel
+# Defaults: SSH_HOST=ptcloud, TUNNEL_PORT=13000, WORKSPACE=dev
+# OUT defaults to output/resume-backups/resumes-prod-<workspace>-<timestamp>.tar.gz
+# Runs on LAPTOP; opens SSH tunnel to remote prod API.
+# One-liner: SSH tunnel → backup prod workspace → close tunnel
+# Defaults: SSH_HOST=ptcloud, TUNNEL_PORT=13000, WORKSPACE=dev
+# OUT defaults to output/resume-backups/resumes-prod-<workspace>-<timestamp>.tar.gz
+remote-backup-prod:
+	@SSH_HOST="$${SSH_HOST:-ptcloud}"; \
+	TUNNEL_PORT="$${TUNNEL_PORT:-13000}"; \
+	WORKSPACE="$${WORKSPACE:-dev}"; \
+	OUT="$${OUT:-output/resume-backups/resumes-prod-$${WORKSPACE}-$$(date +%Y%m%d-%H%M%S).tar.gz}"; \
+	mkdir -p "$$(dirname "$$OUT")"; \
+	echo "→ opening tunnel $$TUNNEL_PORT → $$SSH_HOST:3000"; \
+	ssh -f -N -L "$$TUNNEL_PORT:127.0.0.1:3000" "$$SSH_HOST" || { echo "ssh tunnel failed"; exit 1; }; \
+	trap "kill $$(lsof -ti:$$TUNNEL_PORT) 2>/dev/null || true" EXIT; \
+	API_URL="http://127.0.0.1:$$TUNNEL_PORT" WORKSPACE="$$WORKSPACE" OUT="$$OUT" \
+		$(MAKE) --no-print-directory backup-resumes
+
+backup-prod: remote-backup-prod
+
+# One-liner: clear dev, replace-restore from FILE (auto-backup enabled, MODE=replace YES=1 preset)
+# Required: FILE=<path to .tar.gz or .json>
+# Defaults: WORKSPACE=dev, API_URL=http://localhost:3000
+local-restore-from-prod:
+	@if [ -z "$(FILE)" ]; then echo "FILE=<path> is required"; exit 1; fi
+	@echo "→ clearing dev resumes (loop until partial:false)"
+	@while $(MAKE) --no-print-directory clear-resumes 2>&1 | tee /tmp/clear-resumes.out | grep -q '"partial": true'; do :; done
+	@$(MAKE) --no-print-directory restore-resumes FILE="$(FILE)" MODE=replace YES=1 \
+		API_URL="$${API_URL:-http://localhost:3000}" WORKSPACE="$${WORKSPACE:-dev}"
+
+restore-from-prod: local-restore-from-prod
+
+# Dual-target: follows $API_URL. Defaults to http://localhost:3000 (local).
 # Restore resume records, then restart local Convex to release retained restore RSS
 restore-resumes-restart:
 	@$(MAKE) dev-convex-ensure
@@ -1122,7 +1166,7 @@ help:
 	@echo ""
 	@echo "Usage: make <target>"
 	@echo ""
-	@echo "Development (Full Experience):"
+	@echo "Local dev stack (runs on your laptop):"
 	@echo "  dev            Start all services (MCP + crawler + apps/*)"
 	@echo "  dev-samples    Start dev stack with sample resume snapshots from the sample repo"
 	@echo "  dev-fast       Start fast UI loop (Convex + API + web)"
@@ -1133,106 +1177,62 @@ help:
 	@echo "  dev-crawl      Run crawler only (no long-running services)"
 	@echo "  dev-convex     Start only local Convex dev backend"
 	@echo "  dev-convex-stop Stop local Convex listeners on ports 3210/3211 and the default Convex tmux session"
-	@echo "                 Use this when large restored datasets keep local Convex RSS high and you do not need it running"
 	@echo "  dev-convex-restart Restart only local Convex dev backend (foreground)"
 	@echo "  dev-convex-refresh Refresh local Convex in detached tmux mode when tmux is available"
-	@echo "                 Best for recovering from an unreachable local backend; large restored datasets may still settle at high RSS"
 	@echo "  dev-convex-ensure Start local Convex only when http://127.0.0.1:3210 is currently unreachable"
 	@echo "  dev-convex-status Show local Convex listeners, process RSS, state size, resume count, and backlog"
 	@echo "  dev-web        Start React frontend (Vite on port 5173)"
 	@echo "  dev-api        Start Hono BFF API server (port 3000)"
 	@echo "  dev-api-worker Start FastAPI worker REST API (port 8000)"
 	@echo "  dev-worker     Start worker scheduler (run now + verbose)"
-	@echo "                 See ./scripts/dev.sh --help for service profiles, CI=true/1, and Convex startup/env knobs"
 	@echo ""
-	@echo "Production:"
-	@echo "  run            Run crawler (production mode, full output)"
-	@echo "  crawl          Run crawler (alias for run)"
-	@echo "  mcp            Start MCP server (STDIO mode)"
-	@echo "  mcp-http       Start MCP server (HTTP on port 3333)"
-	@echo "  worker         Start worker scheduler (default: every 30 min)"
-	@echo "  worker-once    Run worker once and exit"
+	@echo "Local run (production-mode on your laptop, NOT on prod host):"
+	@echo "  local-run-crawler  Run crawler (alias: run/crawl)"
+	@echo "  local-run-mcp      Start MCP server, STDIO mode (alias: mcp)"
+	@echo "  local-run-mcp-http Start MCP server, HTTP on port 3333 (alias: mcp-http)"
+	@echo "  local-run-worker   Start worker scheduler (alias: worker)"
+	@echo "  local-run-worker-once Run worker once and exit (alias: worker-once)"
 	@echo ""
-	@echo "Deployment:"
-	@echo "  prod-install   Install as systemd services (requires sudo)"
-	@echo "  prod-deploy    Preflight workspace git, snapshot Convex, and best-effort write resumes-<workspace>.tar.gz before skip/env-refresh/full upgrade; seeds JDs only (requires sudo)"
-	@echo "  prod-deploy-check Dry run deploy precheck with workspace git status but without rebuilding"
-	@echo "  install / deploy / deploy-check Aliases for prod-install / prod-deploy / prod-deploy-check"
-	@echo "  refresh-env    Refresh env, sync frontend build vars, and rebuild the production web bundle"
-	@echo "  backup-resumes Export live resume records to a portable JSON or .tar.gz backup"
-	@echo "  restore-resumes Restore resume records from a portable backup file or snapshot directory"
-	@echo "                 Uses API_URL/TRENDS_API_URL, WORKSPACE=dev, and OUT/FILE/LIMIT/SOURCE_HOSTS/RESUME_IDS/MODE/YES"
-	@echo "                 Example: make restore-resumes FILE=/abs/path/resume-backup.json"
-	@echo "                 Example: make restore-resumes FILE=/abs/path/output/resume-backups/20260321-015304"
-	@echo "                 Example: make restore-resumes FILE=/abs/path/resume-backup.json MODE=replace YES=1"
-	@echo "  restore-resumes-restart Restore resumes, then restart local Convex to drop retained restore RSS"
-	@echo "                 Uses the same arguments as restore-resumes; ensures local Convex is up first, then refreshes it afterward"
-	@echo "                 Example: make restore-resumes-restart FILE=/abs/path/resume-backup.json"
-	@echo "  clear-resume-analyses Clear AI analyses in Convex in safe batches for large restored datasets"
-	@echo "                 Uses BATCH_SIZE=50 by default, optional JOB_DESCRIPTION=<id>, optional RESUME_IDS=a,b,c, and JSON=1"
-	@echo "                 Example: make clear-resume-analyses JSON=1"
-	@echo "                 Example: make clear-resume-analyses JOB_DESCRIPTION=lathe-sales BATCH_SIZE=25 JSON=1"
-	@echo "  clear-resume-analyses-restart Clear AI analyses, then restart local Convex to drop retained RSS"
-	@echo "                 Uses the same arguments as clear-resume-analyses; ensures local Convex is up first, then refreshes it afterward"
-	@echo "                 Example: make clear-resume-analyses-restart JSON=1"
-	@echo "  uninstall      Remove systemd services (requires sudo)"
-	@echo "                 See ./scripts/install.sh --help for branch preflight, rollback backups, CI=true/1, and env knobs"
-	@echo "  docker         Start Docker containers"
-	@echo "  docker-build   Build and start Docker containers"
-	@echo "  docker-down    Stop Docker containers"
+	@echo "Remote (laptop -> remote host via SSH tunnel):"
+	@echo "  remote-backup-prod One-shot: SSH tunnel -> backup prod -> close tunnel"
+	@echo "                    Defaults: SSH_HOST=ptcloud, WORKSPACE=dev, OUT=timestamped (alias: backup-prod)"
+	@echo "                    Example: make remote-backup-prod SSH_HOST=myhost WORKSPACE=hr"
 	@echo ""
-	@echo "Static Site:"
-	@echo "  build-static       Build static site from existing output"
-	@echo "  build-static-fresh Run crawler first, then build static site"
-	@echo "  build-extension-zip Build browser extension zip + metadata for web download"
-	@echo "  serve-static       Serve static site locally (port 8000)"
+	@echo "Dual-target (follows $API_URL; defaults to localhost):"
+	@echo "  backup-resumes     Export resumes to portable backup"
+	@echo "  restore-resumes    Restore resumes from backup file (MODE=replace|merge, YES=1 for replace)"
+	@echo "  restore-resumes-restart Restore + restart local Convex"
 	@echo ""
-	@echo "i18n (Internationalization):"
-	@echo "  i18n-check     Check locale files for missing/extra keys"
-	@echo "  i18n-sync      Auto-fix missing keys with placeholders"
-	@echo "  i18n-convert   Convert zh-Hant to zh-Hans (OpenCC)"
-	@echo "  i18n-translate Translate zh-Hant to English (AI)"
-	@echo "  i18n-build     Build static sites for all locales"
+	@echo "Restore to local dev (laptop-only):"
+	@echo "  local-restore-from-prod One-shot: clear dev + replace-restore from FILE (alias: restore-from-prod)"
+	@echo "                         MODE=replace YES=1 preset; auto-writes safety pre-backup"
+	@echo "                         Example: make local-restore-from-prod FILE=output/resume-backups/resumes-prod-dev-...tar.gz"
 	@echo ""
-	@echo "Dependencies:"
-	@echo "  install-deps [CONVEX_MIRROR_MODE=off|fallback|mirror-first]"
-	@echo "               Install deps, ensure the Go toolchain, build bin/trends, prefetch Convex assets, sync repo project skills, and install configured global skills via the skills CLI"
-	@echo "               Global skill URLs come from config/skills/install.yaml and use direct skill tree paths"
-	@echo "               See ./scripts/install-deps.sh --help for CI=true/1 and additional prefetch env knobs"
-	@echo "  prefetch-convex [CONVEX_MIRROR_MODE=off|fallback|mirror-first] Prefetch Convex local backend + dashboard assets"
-	@echo "                 See ./scripts/prefetch-convex-backend.sh --help for CI=true/1, mirror bases, timeout, and curl env knobs"
+	@echo "On prod host (ssh in first: ssh <host> && cd /opt/trends):"
+	@echo "  on-prod-install        Install as systemd services, requires sudo (alias: prod-install/install)"
+	@echo "  on-prod-deploy         Preflight + snapshot + upgrade, requires sudo (alias: prod-deploy/deploy)"
+	@echo "  on-prod-deploy-check   Dry run deploy precheck (alias: prod-deploy-check/deploy-check)"
+	@echo "  on-prod-refresh-env    Refresh env + rebuild web bundle (alias: refresh-env)"
+	@echo "  on-prod-uninstall      Remove systemd services, requires sudo (alias: uninstall)"
+	@echo "                         See ./scripts/install.sh --help for branch preflight, rollback backups, CI=true/1"
 	@echo ""
-	@echo "CLI:"
-	@echo "  cli-build      Build Go CLI to bin/trends"
-	@echo "  cli-install    Install Go CLI to GOPATH/bin"
-	@echo "  cli-test       Run Go CLI tests"
-	@echo ""
-	@echo "Documentation:"
-	@echo "  fetch-docs     Fetch latest upstream documentation"
-	@echo "  sync-agent-policy Sync generated dev-docs/AGENTS.md from canonical AGENTS policy"
-	@echo "  check-agent-policy Validate generated dev-docs/AGENTS.md is up to date"
-	@echo "  sync-project-skills Sync committed project skills from dev-docs/skills into .agents/skills + .claude/skills"
-	@echo "  check-project-skills Validate project skill structure and committed sync drift"
-	@echo "  install-global-skills Install configured external global skills from config/skills/install.yaml"
-	@echo "  install-agent-skill [TARGET=codex|agents|all] Install governance skill into the selected skills dir"
-	@echo "  check-agent-skill [TARGET=codex|agents|all] Validate governance skill, command, rules file, and installed copy drift"
-	@echo "  install-skill SKILL=<name> [TARGET=codex|agents|all] Install any repo skill into the selected skills dir"
-	@echo "  validate-skill SKILL=<name> Validate skill structure from SKILL.md frontmatter"
-	@echo "  check-skill-install SKILL=<name> [TARGET=codex|agents|all] Validate installed skill sync with repo source"
-	@echo "  install-test-plan-skill [TARGET=codex|agents|all] Install resume-qa-hybrid-mcp into the selected skills dir"
-	@echo "  check-test-plan-skill [TARGET=codex|agents|all] Validate resume-qa-hybrid-mcp skill + installed drift"
-	@echo "  install-browser-ext-skill [TARGET=codex|agents|all] Install browser-extension-dev into the selected skills dir"
-	@echo "  check-browser-ext-skill [TARGET=codex|agents|all] Validate browser-extension-dev skill + installed drift"
-	@echo "  sync-agent-governance [TARGET=codex|agents|all] Run policy sync + governance skill install"
-	@echo "                     Skill roots honor CODEX_HOME and AGENTS_HOME when set"
+	@echo "Local tooling:"
+	@echo "  check / test              Validate / test the repo"
+	@echo "  check-node / check-python / check-build"
+	@echo "  install-deps              Install deps + build bin/trends + prefetch Convex"
+	@echo "  prefetch-convex           Prefetch Convex local backend + dashboard"
+	@echo "  cli-build / cli-install / cli-test"
+	@echo "  docker / docker-build / docker-down"
+	@echo "  build-static / build-static-fresh / build-extension-zip / serve-static"
+	@echo "  fetch-docs"
+	@echo "  i18n-check / i18n-sync / i18n-convert / i18n-translate / i18n-build"
+	@echo "  sync-agent-* / install-*-skill / check-*-skill / validate-skill"
 	@echo ""
 	@echo "Utilities:"
 	@echo "  resume-search   Search resumes via the Go CLI"
-	@echo "                 Uses QUERY='CNC 销售' (or Q=...), optional SOURCE=sample|convex, LIMIT=50, JSON=1, API_URL, WORKSPACE"
-	@echo "                 Example: make resume-search QUERY='CNC 销售' SOURCE=convex"
+	@echo "                 Uses QUERY=, optional SOURCE=sample|convex, LIMIT=50, JSON=1, API_URL, WORKSPACE"
 	@echo "  resume-show     Show one resume with detailed work history via the Go CLI"
-	@echo "                 Uses ID=<resume-id> (or RESUME_ID=...), optional SOURCE=sample|convex, SAMPLE=<sample-name>, JSON=1, API_URL, WORKSPACE"
-	@echo "                 Example: make resume-show ID=resume-live-1 SOURCE=convex"
+	@echo "                 Uses ID=<resume-id>, optional SOURCE=sample|convex, JSON=1, API_URL, WORKSPACE"
 	@echo "  seed           Seed Convex with system job descriptions"
 	@echo "  seed-full      Seed Convex with system job descriptions + sample resumes"
 	@echo "  seed-force     Force seed Convex even if DB is not empty"

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -187,6 +187,67 @@ const ResumeResetResponseSchema = z.object({
   deleted: z.record(z.number().int()),
 });
 
+const ResetCandidateActionsRequestSchema = z.object({
+  workspaceSlug: z.string().optional(),
+});
+
+const ResetCandidateActionsResponseSchema = z.object({
+  success: z.literal(true),
+  deleted: z.number().int(),
+});
+
+const resetCandidateActionsRoute = createRoute({
+  method: "post",
+  path: "/api/resumes/candidate-actions/reset",
+  tags: ["resumes"],
+  summary: "Reset candidate actions for a workspace",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: ResetCandidateActionsRequestSchema,
+        },
+      },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ResetCandidateActionsResponseSchema,
+        },
+      },
+      description: "Reset result",
+    },
+    403: {
+      content: { "application/json": { schema: ResumeImportErrorSchema } },
+      description: "Admin access required",
+    },
+    500: {
+      content: { "application/json": { schema: ResumeImportErrorSchema } },
+      description: "Reset failed",
+    },
+  },
+});
+
+app.openapi(resetCandidateActionsRoute, async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  }
+
+  try {
+    const request = c.req.valid("json");
+    const workspaceSlug = request.workspaceSlug || c.var.workspaceSlug;
+    const deleted = actionStorage.clearActionsForWorkspace(workspaceSlug, true);
+    return c.json(ResetCandidateActionsResponseSchema.parse({ success: true, deleted }), 200);
+  } catch (error) {
+    console.error("Failed to reset candidate actions", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false as const, error: message }, 500);
+  }
+});
+
 const HardResetReingestRequestSchema = z.object({
   dryRun: z.boolean().optional(),
 });
@@ -4073,7 +4134,7 @@ app.openapi(importResumesRoute, async (c) => {
 
   try {
     const payload = c.req.valid("json");
-    const result = await submitResumeImport(payload);
+    const result = await submitResumeImport(payload, c.var.workspaceSlug);
     return c.json(result, 200);
   } catch (error) {
     console.error("Failed to import resumes", error);
@@ -4221,6 +4282,32 @@ app.openapi(backupResumesRoute, async (c) => {
 
     const limited = typeof request.limit === "number" ? selectedEntries.slice(0, request.limit) : selectedEntries;
     const generatedAt = new Date().toISOString();
+
+    const resumeIds = limited.map((entry) => entry.resumeId);
+    const candidateActions = actionStorage.listActionsForBackup({
+      workspaceSlug: c.var.workspaceSlug,
+      resumeIds,
+    });
+
+    let candidateStatus: Array<{
+      identityKey: string;
+      status: string;
+      notes?: string;
+      updatedBy?: string;
+      updatedAt: number;
+      history?: Array<{ status: string; updatedAt: number; notes?: string }>;
+    }> = [];
+    try {
+      const statusResponse = await callConvexQuery("candidate_status:listForBackup", {
+        workspaceSlug: c.var.workspaceSlug,
+      });
+      if (Array.isArray(statusResponse)) {
+        candidateStatus = statusResponse;
+      }
+    } catch (error) {
+      console.error("Failed to query candidate_status for backup", error);
+    }
+
     c.header("Content-Disposition", `attachment; filename="resume-backup-${generatedAt.replace(/[:.]/g, "-")}.json"`);
     c.header("Cache-Control", "no-store");
     return c.json(ResumeImportRequestSchema.parse({
@@ -4229,8 +4316,11 @@ app.openapi(backupResumesRoute, async (c) => {
         generatedBy: "trends-api backup",
         generatedAt,
         totalResumes: limited.length,
+        version: "2",
       },
       resumes: limited.map((entry) => entry.payload),
+      candidateActions,
+      candidateStatus,
     }), 200);
   } catch (error) {
     console.error("Failed to backup resumes", error);

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -253,6 +253,7 @@ export const ResumeImportMetadataSchema = z
   .object({
     sourceUrl: z.string().url().openapi({ example: "https://hr.job5156.com/search?keyword=销售" }),
     generatedBy: z.string().openapi({ example: "browser-extension@1.0.0" }),
+    version: z.string().optional().openapi({ example: "2" }),
     sourceKey: z.string().optional().openapi({ example: "seek" }),
     sourceHost: z.string().optional().openapi({ example: "hk.employer.seek.com" }),
     keyword: z.string().optional().openapi({ example: "销售" }),
@@ -296,18 +297,65 @@ export const ResumeImportItemSchema = z
   })
   .openapi("ResumeImportItem");
 
+export const CandidateActionBackupSchema = z
+  .object({
+    resumeId: z.string().openapi({ example: "R123456" }),
+    actionType: z.enum([
+      "star",
+      "shortlist",
+      "reject",
+      "archive",
+      "note",
+      "contact",
+      "ai_score_like",
+      "ai_score_unlike",
+      "ai_summary_like",
+      "ai_summary_unlike",
+    ]).openapi({ example: "archive" }),
+    actionData: z.record(z.unknown()).optional().openapi({ example: { scopeId: "session-123" } }),
+    scopeId: z.string().optional().openapi({ example: "session-123" }),
+    createdAt: z.string().openapi({ example: "2026-03-15T10:30:00+08:00" }),
+  })
+  .openapi("CandidateActionBackup");
+
+export const CandidateStatusBackupSchema = z
+  .object({
+    identityKey: z.string().openapi({ example: "profileUrl:https://hr.job5156.com/resume/view/123" }),
+    status: z.enum([
+      "new",
+      "contacted",
+      "interviewing",
+      "interviewed_pass",
+      "interviewed_reject",
+      "offer",
+      "hired",
+      "withdrawn",
+    ]).openapi({ example: "interviewing" }),
+    notes: z.string().optional().openapi({ example: "Strong candidate" }),
+    updatedBy: z.string().optional().openapi({ example: "hr.lead" }),
+    updatedAt: z.number().openapi({ example: 1710489600000 }),
+    history: z.array(z.object({
+      status: z.string(),
+      updatedAt: z.number(),
+      notes: z.string().optional(),
+    })).optional(),
+  })
+  .openapi("CandidateStatusBackup");
+
 export const ResumeImportRequestSchema = z
   .object({
     metadata: ResumeImportMetadataSchema,
     resumes: z.array(ResumeImportItemSchema).optional(),
     data: z.array(ResumeImportItemSchema).optional(),
     options: ResumeImportOptionsSchema.optional(),
+    candidateActions: z.array(CandidateActionBackupSchema).optional(),
+    candidateStatus: z.array(CandidateStatusBackupSchema).optional(),
   })
   .superRefine((value, ctx) => {
-    if (!value.resumes && !value.data) {
+    if (!value.resumes && !value.data && !value.candidateActions && !value.candidateStatus) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "Expected resumes or data array",
+        message: "Expected resumes, data, candidateActions, or candidateStatus array",
         path: ["resumes"],
       });
     }

--- a/apps/api/src/services/action-storage.ts
+++ b/apps/api/src/services/action-storage.ts
@@ -48,6 +48,32 @@ const AI_JOB_DESCRIPTION_WHERE_SQL = `
   )
 `;
 
+const WORKSPACE_JOIN_SQL = `
+  LEFT JOIN search_sessions persisted_session
+    ON persisted_session.id = ca.session_id
+  LEFT JOIN search_sessions scoped_session
+    ON scoped_session.id = json_extract(ca.action_data, '$.scopeId')
+  LEFT JOIN review_packet_runs persisted_packet
+    ON persisted_packet.id = CASE
+      WHEN ca.session_id LIKE 'review-packet:%' THEN substr(ca.session_id, 15)
+      ELSE NULL
+    END
+  LEFT JOIN review_packet_runs scoped_packet
+    ON scoped_packet.id = CASE
+      WHEN json_extract(ca.action_data, '$.scopeId') LIKE 'review-packet:%'
+        THEN substr(json_extract(ca.action_data, '$.scopeId'), 15)
+      ELSE NULL
+    END`;
+
+const WORKSPACE_COALESCE_SQL = `COALESCE(
+  persisted_session.workspace_slug,
+  scoped_session.workspace_slug,
+  persisted_packet.workspace_slug,
+  scoped_packet.workspace_slug
+)`;
+
+const WORKSPACE_MATCH_OR_ORPHAN_SQL = `(${WORKSPACE_COALESCE_SQL} = ? OR ${WORKSPACE_COALESCE_SQL} IS NULL)`;
+
 export function actionTypeGroup(actionType: string): ActionTypeGroup {
   if (AI_SCORE_TYPE_SET.has(actionType)) return "ai_score";
   if (AI_SUMMARY_TYPE_SET.has(actionType)) return "ai_summary";
@@ -295,4 +321,147 @@ export class ActionStorage {
 
     return Boolean(row);
   }
+
+  listActionsForBackup(params: {
+    workspaceSlug: string;
+    resumeIds?: string[];
+  }): CandidateActionBackupRow[] {
+    const { workspaceSlug, resumeIds } = params;
+
+    if (resumeIds && resumeIds.length > 0) {
+      const placeholders = resumeIds.map(() => "?").join(",");
+      const rows = this.db
+        .prepare(
+          `
+          SELECT ca.resume_id, ca.action_type, ca.action_data, ca.session_id, ca.created_at
+          FROM candidate_actions ca
+          ${WORKSPACE_JOIN_SQL}
+          WHERE (${WORKSPACE_MATCH_OR_ORPHAN_SQL} OR ca.resume_id IN (${placeholders}))
+          ORDER BY ca.created_at ASC
+          `
+        )
+        .all(workspaceSlug, ...resumeIds) as Record<string, unknown>[];
+
+      return rows.map((row) => normalizeBackupRow(row));
+    }
+
+    const rows = this.db
+      .prepare(
+        `
+        SELECT ca.resume_id, ca.action_type, ca.action_data, ca.session_id, ca.created_at
+        FROM candidate_actions ca
+        ${WORKSPACE_JOIN_SQL}
+        WHERE ${WORKSPACE_MATCH_OR_ORPHAN_SQL}
+        ORDER BY ca.created_at ASC
+        `
+      )
+      .all(workspaceSlug) as Record<string, unknown>[];
+
+    return rows.map((row) => normalizeBackupRow(row));
+  }
+
+  replayActions(params: {
+    actions: CandidateActionBackupRow[];
+    mode: "replace" | "merge";
+  }): { replayed: number; deduped: number } {
+    const { actions, mode } = params;
+    const insert = this.db.prepare(
+      `INSERT INTO candidate_actions (resume_id, action_type, action_data, created_at) VALUES (?, ?, ?, ?)`
+    );
+
+    const replayInTransaction = this.db.transaction((actions: CandidateActionBackupRow[]) => {
+      if (mode === "merge") {
+        const resumeIds = [...new Set(actions.map((a) => a.resumeId))];
+        const placeholders = resumeIds.map(() => "?").join(",");
+        const existing = this.db
+          .prepare(
+            `SELECT resume_id, action_type, action_data, created_at FROM candidate_actions WHERE resume_id IN (${placeholders})`
+          )
+          .all(...resumeIds) as Record<string, unknown>[];
+
+        const existingKeys = new Set(
+          existing.map((row) =>
+            `${String(row.resume_id)}|${String(row.action_type)}|${String(row.created_at)}|${String(row.action_data ?? "")}`
+          )
+        );
+
+        let replayed = 0;
+        let deduped = 0;
+        for (const action of actions) {
+          const actionDataJson = action.actionData ? JSON.stringify(action.actionData) : null;
+          const key = `${action.resumeId}|${action.actionType}|${action.createdAt}|${actionDataJson ?? ""}`;
+          if (existingKeys.has(key)) {
+            deduped++;
+            continue;
+          }
+          insert.run(action.resumeId, action.actionType, actionDataJson, action.createdAt);
+          replayed++;
+        }
+        return { replayed, deduped };
+      }
+
+      for (const action of actions) {
+        const actionDataJson = action.actionData ? JSON.stringify(action.actionData) : null;
+        insert.run(action.resumeId, action.actionType, actionDataJson, action.createdAt);
+      }
+
+      return { replayed: actions.length, deduped: 0 };
+    });
+
+    return replayInTransaction(actions);
+  }
+
+  clearActionsForWorkspace(workspaceSlug: string, includeOrphans?: boolean): number {
+    const whereClause = includeOrphans
+      ? WORKSPACE_MATCH_OR_ORPHAN_SQL
+      : `${WORKSPACE_COALESCE_SQL} = ?`;
+
+    const result = this.db
+      .prepare(
+        `
+        DELETE FROM candidate_actions
+        WHERE id IN (
+          SELECT ca.id FROM candidate_actions ca
+          ${WORKSPACE_JOIN_SQL}
+          WHERE ${whereClause}
+        )
+        `
+      )
+      .run(workspaceSlug);
+    return Number(result.changes);
+  }
+}
+
+export type CandidateActionBackupRow = {
+  resumeId: string;
+  actionType: CandidateActionType;
+  actionData?: Record<string, unknown>;
+  scopeId?: string;
+  createdAt: string;
+};
+
+function normalizeBackupRow(row: Record<string, unknown>): CandidateActionBackupRow {
+  const sessionId = typeof row.session_id === "string" ? row.session_id : undefined;
+  const actionDataRaw = row.action_data;
+  let actionData: Record<string, unknown> | undefined;
+  if (typeof actionDataRaw === "string" && actionDataRaw.trim()) {
+    try {
+      actionData = JSON.parse(actionDataRaw) as Record<string, unknown>;
+    } catch {
+      actionData = undefined;
+    }
+  } else if (typeof actionDataRaw === "object" && actionDataRaw !== null) {
+    actionData = actionDataRaw as Record<string, unknown>;
+  }
+
+  const scopeId = (actionData?.scopeId as string | undefined)
+    || (sessionId?.startsWith("review-packet:") ? sessionId : undefined);
+
+  return {
+    resumeId: String(row.resume_id),
+    actionType: String(row.action_type) as CandidateActionType,
+    ...(actionData ? { actionData } : {}),
+    ...(scopeId ? { scopeId } : {}),
+    createdAt: String(row.created_at),
+  };
 }

--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -16,6 +16,7 @@ import {
   ResumeSubmitSummarySchema,
 } from "../schemas/resumes.js";
 import { config } from "./config.js";
+import { ActionStorage, type CandidateActionBackupRow } from "./action-storage.js";
 
 const JOB5156_HOST = "hr.job5156.com";
 const EHIRE_51JOB_HOST = "ehire.51job.com";
@@ -389,6 +390,110 @@ export async function submitNormalizedResumeImport(
   });
 }
 
-export async function submitResumeImport(input: ResumeImportRequest): Promise<ResumeSubmitSummary> {
-  return submitNormalizedResumeImport(normalizeResumeImportPayload(input));
+export type CandidateStateReplayResult = {
+  statusReplayed: number;
+  actionsReplayed: number;
+  actionsDeduped: number;
+};
+
+export async function replayCandidateState(params: {
+  candidateStatus?: Array<{
+    identityKey: string;
+    status: string;
+    notes?: string;
+    updatedBy?: string;
+    updatedAt: number;
+    history?: Array<{ status: string; updatedAt: number; notes?: string }>;
+  }>;
+  candidateActions?: CandidateActionBackupRow[];
+  workspaceSlug: string;
+  mode: "replace" | "merge";
+}): Promise<CandidateStateReplayResult> {
+  const { candidateStatus, candidateActions, workspaceSlug, mode } = params;
+  const result: CandidateStateReplayResult = {
+    statusReplayed: 0,
+    actionsReplayed: 0,
+    actionsDeduped: 0,
+  };
+
+  if (candidateStatus && candidateStatus.length > 0) {
+    const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+    for (const entry of candidateStatus) {
+      try {
+        const response = await fetch(`${convexUrl}/api/mutation`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify({
+            path: "candidate_status:upsert",
+            args: {
+              workspaceSlug,
+              identityKey: entry.identityKey,
+              status: entry.status,
+              notes: entry.notes,
+              updatedBy: entry.updatedBy,
+            },
+          }),
+        });
+
+        if (response.ok) {
+          result.statusReplayed++;
+        } else {
+          console.error("candidate_status:upsert failed", {
+            identityKey: entry.identityKey,
+            status: response.status,
+          });
+        }
+      } catch (error) {
+        console.error("candidate_status:upsert error", {
+          identityKey: entry.identityKey,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  if (candidateActions && candidateActions.length > 0) {
+    const actionStorage = new ActionStorage(config.projectRoot);
+    const replayResult = actionStorage.replayActions({
+      actions: candidateActions,
+      mode,
+    });
+    result.actionsReplayed = replayResult.replayed;
+    result.actionsDeduped = replayResult.deduped;
+  }
+
+  return result;
+}
+
+export async function submitResumeImport(input: ResumeImportRequest, workspaceSlug?: string): Promise<{
+  success: true;
+  submitted: number;
+  inserted: number;
+  updated: number;
+  unchanged: number;
+  deduped: number;
+  statusReplayed: number;
+  actionsReplayed: number;
+  actionsDeduped: number;
+}> {
+  const normalized = normalizeResumeImportPayload(input);
+  const resumeResult = await submitNormalizedResumeImport(normalized);
+
+  const resolvedWorkspace = workspaceSlug ?? "dev";
+  const stateResult = await replayCandidateState({
+    candidateStatus: input.candidateStatus,
+    candidateActions: input.candidateActions,
+    workspaceSlug: resolvedWorkspace,
+    mode: "merge",
+  });
+
+  return {
+    ...resumeResult,
+    statusReplayed: stateResult.statusReplayed,
+    actionsReplayed: stateResult.actionsReplayed,
+    actionsDeduped: stateResult.actionsDeduped,
+  };
 }

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -623,6 +623,78 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/resumes/candidate-actions/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reset candidate actions for a workspace */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        workspaceSlug?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Reset result */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            deleted: number;
+                        };
+                    };
+                };
+                /** @description Admin access required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Reset failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/resumes/samples": {
         parameters: {
             query?: never;
@@ -7513,6 +7585,8 @@ export interface components {
             sourceUrl: string;
             /** @example browser-extension@1.0.0 */
             generatedBy: string;
+            /** @example 2 */
+            version?: string;
             /** @example seek */
             sourceKey?: string;
             /** @example hk.employer.seek.com */
@@ -7603,11 +7677,54 @@ export interface components {
             /** @example true */
             recomputeDerivedFields?: boolean;
         };
+        CandidateActionBackup: {
+            /** @example R123456 */
+            resumeId: string;
+            /**
+             * @example archive
+             * @enum {string}
+             */
+            actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
+            /**
+             * @example {
+             *       "scopeId": "session-123"
+             *     }
+             */
+            actionData?: {
+                [key: string]: unknown;
+            };
+            /** @example session-123 */
+            scopeId?: string;
+            /** @example 2026-03-15T10:30:00+08:00 */
+            createdAt: string;
+        };
+        CandidateStatusBackup: {
+            /** @example profileUrl:https://hr.job5156.com/resume/view/123 */
+            identityKey: string;
+            /**
+             * @example interviewing
+             * @enum {string}
+             */
+            status: "new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "offer" | "hired" | "withdrawn";
+            /** @example Strong candidate */
+            notes?: string;
+            /** @example hr.lead */
+            updatedBy?: string;
+            /** @example 1710489600000 */
+            updatedAt: number;
+            history?: {
+                status: string;
+                updatedAt: number;
+                notes?: string;
+            }[];
+        };
         ResumeImportRequest: {
             metadata: components["schemas"]["ResumeImportMetadata"];
             resumes?: components["schemas"]["ResumeImportItem"][];
             data?: components["schemas"]["ResumeImportItem"][];
             options?: components["schemas"]["ResumeImportOptions"];
+            candidateActions?: components["schemas"]["CandidateActionBackup"][];
+            candidateStatus?: components["schemas"]["CandidateStatusBackup"][];
         };
         ResumeManualImportSource: {
             /** @example 51job-manual */

--- a/packages/cli/cmd/resume.go
+++ b/packages/cli/cmd/resume.go
@@ -32,6 +32,7 @@ func newResumeCmd() *cobra.Command {
 		newResumeManualImportCmd(),
 		newResumeBackupCmd(),
 		newResumeRestoreCmd(),
+		newResumeFullRestoreCmd(),
 		newResumeDeployBackupCmd(),
 		newResumeExportCmd(),
 		newResumeDebugCmd(),

--- a/packages/cli/cmd/resume_backup_test.go
+++ b/packages/cli/cmd/resume_backup_test.go
@@ -187,6 +187,21 @@ func TestResumeRestoreCommandReplaceModeResetsUntilCompleteBeforeImport(t *testi
 		callOrder = append(callOrder, r.URL.Path)
 
 		switch r.URL.Path {
+		case "/api/resumes/backup":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"metadata": map[string]any{
+					"sourceUrl":    "http://example.com/api/resumes/backup",
+					"generatedBy":  "test",
+					"generatedAt":  "2026-04-21T00:00:00Z",
+					"totalResumes": 0,
+				},
+				"resumes": []any{},
+			})
+		case "/api/resumes/candidate-actions/reset":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"deleted": 0,
+			})
 		case "/api/resumes/reset":
 			resetCalls += 1
 			if resetCalls == 1 {
@@ -213,12 +228,15 @@ func TestResumeRestoreCommandReplaceModeResetsUntilCompleteBeforeImport(t *testi
 				t.Fatalf("expected metadata object: %+v", payload)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"success":   true,
-				"submitted": 1,
-				"inserted":  1,
-				"updated":   0,
-				"unchanged": 0,
-				"deduped":   0,
+				"success":         true,
+				"submitted":       1,
+				"inserted":        1,
+				"updated":         0,
+				"unchanged":       0,
+				"deduped":         0,
+				"statusReplayed":  0,
+				"actionsReplayed": 0,
+				"actionsDeduped":  0,
 			})
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
@@ -243,7 +261,7 @@ func TestResumeRestoreCommandReplaceModeResetsUntilCompleteBeforeImport(t *testi
 		t.Fatalf("resume restore command failed: %v", err)
 	}
 
-	if len(callOrder) != 3 || callOrder[0] != "/api/resumes/reset" || callOrder[1] != "/api/resumes/reset" || callOrder[2] != "/api/resumes/import" {
+	if len(callOrder) != 5 || callOrder[0] != "/api/resumes/backup" || callOrder[1] != "/api/resumes/reset" || callOrder[2] != "/api/resumes/reset" || callOrder[3] != "/api/resumes/candidate-actions/reset" || callOrder[4] != "/api/resumes/import" {
 		t.Fatalf("unexpected call order: %+v", callOrder)
 	}
 	if !strings.Contains(output.String(), `"mode": "replace"`) {
@@ -288,6 +306,21 @@ func TestResumeRestoreCommandAcceptsSnapshotDirectoryInDeterministicOrder(t *tes
 		callOrder = append(callOrder, r.URL.Path)
 
 		switch r.URL.Path {
+		case "/api/resumes/backup":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"metadata": map[string]any{
+					"sourceUrl":    "http://example.com/api/resumes/backup",
+					"generatedBy":  "test",
+					"generatedAt":  "2026-04-21T00:00:00Z",
+					"totalResumes": 0,
+				},
+				"resumes": []any{},
+			})
+		case "/api/resumes/candidate-actions/reset":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"deleted": 0,
+			})
 		case "/api/resumes/reset":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"success": true,
@@ -342,7 +375,7 @@ func TestResumeRestoreCommandAcceptsSnapshotDirectoryInDeterministicOrder(t *tes
 		t.Fatalf("resume restore command failed: %v", err)
 	}
 
-	if len(callOrder) != 4 || callOrder[0] != "/api/resumes/reset" {
+	if len(callOrder) != 6 || callOrder[0] != "/api/resumes/backup" || callOrder[1] != "/api/resumes/reset" {
 		t.Fatalf("unexpected call order: %+v", callOrder)
 	}
 	if want := []string{"job-1", "seek-1", "manual-1"}; strings.Join(importedResumeIDs, ",") != strings.Join(want, ",") {
@@ -403,6 +436,21 @@ func TestResumeDeployBackupRestorePrefersCompressedArtifactInLatestRunDir(t *tes
 		callOrder = append(callOrder, r.URL.Path)
 
 		switch r.URL.Path {
+		case "/api/resumes/backup":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"metadata": map[string]any{
+					"sourceUrl":    "http://example.com/api/resumes/backup",
+					"generatedBy":  "test",
+					"generatedAt":  "2026-04-21T00:00:00Z",
+					"totalResumes": 0,
+				},
+				"resumes": []any{},
+			})
+		case "/api/resumes/candidate-actions/reset":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"deleted": 0,
+			})
 		case "/api/resumes/reset":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"success": true,
@@ -424,12 +472,15 @@ func TestResumeDeployBackupRestorePrefersCompressedArtifactInLatestRunDir(t *tes
 				t.Fatalf("unexpected imported resume payload: %+v", payload)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"success":   true,
-				"submitted": 1,
-				"inserted":  1,
-				"updated":   0,
-				"unchanged": 0,
-				"deduped":   0,
+				"success":         true,
+				"submitted":       1,
+				"inserted":        1,
+				"updated":         0,
+				"unchanged":       0,
+				"deduped":         0,
+				"statusReplayed":  0,
+				"actionsReplayed": 0,
+				"actionsDeduped":  0,
 			})
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
@@ -454,7 +505,7 @@ func TestResumeDeployBackupRestorePrefersCompressedArtifactInLatestRunDir(t *tes
 		t.Fatalf("resume deploy-backup restore command failed: %v", err)
 	}
 
-	if len(callOrder) != 2 || callOrder[0] != "/api/resumes/reset" || callOrder[1] != "/api/resumes/import" {
+	if len(callOrder) != 4 || callOrder[0] != "/api/resumes/backup" || callOrder[1] != "/api/resumes/reset" || callOrder[2] != "/api/resumes/candidate-actions/reset" || callOrder[3] != "/api/resumes/import" {
 		t.Fatalf("unexpected call order: %+v", callOrder)
 	}
 
@@ -510,6 +561,21 @@ func TestResumeDeployBackupRestoreFallsBackToLegacyJSON(t *testing.T) {
 		callOrder = append(callOrder, r.URL.Path)
 
 		switch r.URL.Path {
+		case "/api/resumes/backup":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"metadata": map[string]any{
+					"sourceUrl":    "http://example.com/api/resumes/backup",
+					"generatedBy":  "test",
+					"generatedAt":  "2026-04-21T00:00:00Z",
+					"totalResumes": 0,
+				},
+				"resumes": []any{},
+			})
+		case "/api/resumes/candidate-actions/reset":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"deleted": 0,
+			})
 		case "/api/resumes/reset":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"success": true,
@@ -531,12 +597,15 @@ func TestResumeDeployBackupRestoreFallsBackToLegacyJSON(t *testing.T) {
 				t.Fatalf("unexpected imported resume payload: %+v", payload)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"success":   true,
-				"submitted": 1,
-				"inserted":  1,
-				"updated":   0,
-				"unchanged": 0,
-				"deduped":   0,
+				"success":         true,
+				"submitted":       1,
+				"inserted":        1,
+				"updated":         0,
+				"unchanged":       0,
+				"deduped":         0,
+				"statusReplayed":  0,
+				"actionsReplayed": 0,
+				"actionsDeduped":  0,
 			})
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
@@ -561,7 +630,7 @@ func TestResumeDeployBackupRestoreFallsBackToLegacyJSON(t *testing.T) {
 		t.Fatalf("resume deploy-backup restore command failed: %v", err)
 	}
 
-	if len(callOrder) != 2 || callOrder[0] != "/api/resumes/reset" || callOrder[1] != "/api/resumes/import" {
+	if len(callOrder) != 4 || callOrder[0] != "/api/resumes/backup" || callOrder[1] != "/api/resumes/reset" || callOrder[2] != "/api/resumes/candidate-actions/reset" || callOrder[3] != "/api/resumes/import" {
 		t.Fatalf("unexpected call order: %+v", callOrder)
 	}
 

--- a/packages/cli/internal/client/resume_backup.go
+++ b/packages/cli/internal/client/resume_backup.go
@@ -21,12 +21,15 @@ type ResumeBackupRequest struct {
 }
 
 type ResumeSubmitSummary struct {
-	Success   bool `json:"success"`
-	Submitted int  `json:"submitted"`
-	Inserted  int  `json:"inserted"`
-	Updated   int  `json:"updated"`
-	Unchanged int  `json:"unchanged"`
-	Deduped   int  `json:"deduped"`
+	Success         bool `json:"success"`
+	Submitted       int  `json:"submitted"`
+	Inserted        int  `json:"inserted"`
+	Updated         int  `json:"updated"`
+	Unchanged       int  `json:"unchanged"`
+	Deduped         int  `json:"deduped"`
+	StatusReplayed  int  `json:"statusReplayed"`
+	ActionsReplayed int  `json:"actionsReplayed"`
+	ActionsDeduped  int  `json:"actionsDeduped"`
 }
 
 type ResumeResetResponse struct {
@@ -112,6 +115,26 @@ func (c *Client) ResetResumes(ctx context.Context) (*ResumeResetResponse, error)
 	}
 	if !response.Success {
 		return nil, fmt.Errorf("resume reset request was not successful")
+	}
+	return &response, nil
+}
+
+type ResetCandidateActionsResponse struct {
+	Success bool `json:"success"`
+	Deleted int  `json:"deleted"`
+}
+
+func (c *Client) ResetCandidateActions(ctx context.Context, workspaceSlug string) (*ResetCandidateActionsResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/resumes/candidate-actions/reset", c.APIURL)
+
+	request := map[string]string{"workspaceSlug": workspaceSlug}
+
+	var response ResetCandidateActionsResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint, request, &response); err != nil {
+		return nil, err
+	}
+	if !response.Success {
+		return nil, fmt.Errorf("candidate actions reset request was not successful")
 	}
 	return &response, nil
 }

--- a/packages/convex/convex/candidate_status.ts
+++ b/packages/convex/convex/candidate_status.ts
@@ -13,6 +13,27 @@ function normalizeIdentityKey(value: string): string {
     return value.trim();
 }
 
+export const listForBackup = query({
+    args: {
+        workspaceSlug: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+        const rows = await ctx.db
+            .query("candidate_status")
+            .withIndex("by_workspace_status", (q) => q.eq("workspaceSlug", workspaceSlug))
+            .collect();
+        return rows.map((row) => ({
+            identityKey: row.identityKey,
+            status: row.status,
+            notes: row.notes,
+            updatedBy: row.updatedBy,
+            updatedAt: row.updatedAt,
+            history: row.history,
+        }));
+    },
+});
+
 export const list = query({
     args: {
         workspaceSlug: v.optional(v.string()),

--- a/scripts/resume/restore-resumes.ts
+++ b/scripts/resume/restore-resumes.ts
@@ -13,9 +13,11 @@ type RestorePayload = {
   metadata?: Record<string, unknown>;
   resumes?: unknown[];
   data?: unknown[];
+  candidateActions?: unknown[];
+  candidateStatus?: unknown[];
 };
 
-type RestoreMode = "upsert" | "replace";
+type RestoreMode = "replace" | "merge";
 
 type RestoreRuntime = {
   fetch: typeof fetch;
@@ -42,6 +44,7 @@ type RestoreRunSummary = {
   mode: RestoreMode;
   reset: boolean;
   recomputeDerivedFields: boolean;
+  autoBackupPath?: string;
   resetResult?: Record<string, unknown>;
   files: RestoreFileSummary[];
 };
@@ -63,9 +66,12 @@ function readResumeArray(payload: RestorePayload): unknown[] {
 }
 
 function resolveMode(value: string | undefined): RestoreMode {
-  const normalized = value?.trim().toLowerCase() || "upsert";
-  if (normalized !== "upsert" && normalized !== "replace") {
-    throw usageError(`invalid restore mode ${JSON.stringify(value)} (expected upsert|replace)`);
+  const normalized = value?.trim().toLowerCase() || "replace";
+  if (normalized === "upsert") {
+    return "merge";
+  }
+  if (normalized !== "replace" && normalized !== "merge") {
+    throw usageError(`invalid restore mode ${JSON.stringify(value)} (expected replace|merge; upsert is an alias for merge)`);
   }
   return normalized;
 }
@@ -76,12 +82,14 @@ function usage(): string {
     "  make restore-resumes FILE=/abs/path/resume-backup.json [WORKSPACE=dev] [API_URL=http://localhost:3000]",
     "  make restore-resumes FILE=/abs/path/resume-backups/20260321-015304 [WORKSPACE=dev] [API_URL=http://localhost:3000]",
     "  make restore-resumes FILE=/abs/path/resume-backup.json MODE=replace YES=1 [WORKSPACE=dev] [API_URL=http://localhost:3000]",
+    "  make restore-resumes FILE=/abs/path/resume-backup.json MODE=merge [WORKSPACE=dev] [API_URL=http://localhost:3000]",
     "  make restore-resumes FILE=/abs/path/resume-backup.json RECOMPUTE_DERIVED_FIELDS=1 [WORKSPACE=dev] [API_URL=http://localhost:3000]",
     "",
     "Environment:",
     "  FILE        Required backup file path or directory containing backup files",
-    "  MODE        Optional restore mode: upsert | replace (default: upsert)",
+    "  MODE        Optional restore mode: replace | merge (default: replace; upsert is an alias for merge)",
     "  YES         Required when MODE=replace; set YES=1 to confirm destructive reset",
+    "  SKIP_AUTO_BACKUP  Optional; set to 1 to skip auto-backup before replace reset",
     "  RECOMPUTE_DERIVED_FIELDS  Optional; set to 1 to drop preserved computed fields and force current ingest recomputation",
     "  WORKSPACE   Optional workspace slug (default: dev)",
     "  API_URL     Optional API URL (default: http://localhost:3000)",
@@ -150,8 +158,11 @@ function parseRestorePayload(raw: string): RestorePayload {
 }
 
 function validateRestorePayload(parsed: RestorePayload): void {
-  if (!isRecord(parsed.metadata) || readResumeArray(parsed).length === 0) {
-    throw new Error("invalid backup file: missing metadata or resume array");
+  const hasResumes = readResumeArray(parsed).length > 0;
+  const hasActions = Array.isArray(parsed.candidateActions) && parsed.candidateActions.length > 0;
+  const hasStatus = Array.isArray(parsed.candidateStatus) && parsed.candidateStatus.length > 0;
+  if (!isRecord(parsed.metadata) || (!hasResumes && !hasActions && !hasStatus)) {
+    throw new Error("invalid backup file: missing metadata or any data array");
   }
 }
 
@@ -244,6 +255,50 @@ async function resetResumesFully(
   }
 }
 
+async function autoBackupBeforeReplace(
+  apiUrl: string,
+  workspace: string,
+  runtime: RestoreRuntime,
+): Promise<string> {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const autoBackupPath = `output/resume-backups/auto-pre-restore-${workspace}-${timestamp}.json`;
+
+  const backupResponse = await postJson(
+    apiUrl,
+    workspace,
+    "/api/resumes/backup",
+    {},
+    runtime,
+  );
+
+  if (!backupResponse.ok) {
+    const text = await backupResponse.text();
+    throw new Error(`auto-backup failed (${backupResponse.status}): ${text.trim() || "no response body"} — aborting replace. Set SKIP_AUTO_BACKUP=1 to override.`);
+  }
+
+  const backupData = await backupResponse.text();
+  const fs = await import("node:fs/promises");
+  await fs.writeFile(autoBackupPath, backupData, "utf8");
+
+  return autoBackupPath;
+}
+
+async function resetCandidateActions(
+  apiUrl: string,
+  workspace: string,
+  runtime: RestoreRuntime,
+): Promise<number> {
+  const response = await postJson(
+    apiUrl,
+    workspace,
+    "/api/resumes/candidate-actions/reset",
+    { workspaceSlug: workspace },
+    runtime,
+  );
+  const result = await parseJsonRecord(response, "candidate-actions reset failed");
+  return typeof result.deleted === "number" ? result.deleted : 0;
+}
+
 export async function runRestoreResumes(
   params: {
     apiUrl: string;
@@ -252,6 +307,7 @@ export async function runRestoreResumes(
     mode: RestoreMode;
     confirm: boolean;
     recomputeDerivedFields: boolean;
+    skipAutoBackup?: boolean;
   },
   runtime: RestoreRuntime = { fetch: globalThis.fetch },
 ): Promise<RestoreRunSummary> {
@@ -261,9 +317,24 @@ export async function runRestoreResumes(
 
   const restorePaths = await resolveRestorePaths(params.filePath);
 
+  let autoBackupPath: string | undefined;
   let resetResult: Record<string, unknown> | undefined;
   if (params.mode === "replace") {
+    if (!params.skipAutoBackup) {
+      autoBackupPath = await autoBackupBeforeReplace(
+        params.apiUrl,
+        params.workspace,
+        runtime,
+      );
+    }
+
     resetResult = await resetResumesFully(
+      params.apiUrl,
+      params.workspace,
+      runtime,
+    );
+
+    await resetCandidateActions(
       params.apiUrl,
       params.workspace,
       runtime,
@@ -302,6 +373,7 @@ export async function runRestoreResumes(
     mode: params.mode,
     reset: params.mode === "replace",
     recomputeDerivedFields: params.recomputeDerivedFields,
+    autoBackupPath,
     resetResult,
     files,
   };
@@ -315,6 +387,7 @@ async function main(): Promise<void> {
     mode: resolveMode(process.env.MODE),
     confirm: parseTruthy(process.env.YES),
     recomputeDerivedFields: parseTruthy(process.env.RECOMPUTE_DERIVED_FIELDS),
+    skipAutoBackup: parseTruthy(process.env.SKIP_AUTO_BACKUP),
   });
 
   console.log(JSON.stringify(summary, null, 2));


### PR DESCRIPTION
## Summary
- **API**: add `POST /api/resumes/candidate-actions/reset` endpoint; extend backup response to include `candidateActions` + `candidateStatus`; wire workspace-scoped import in `submitResumeImport`
- **Convex**: add `listForBackup` query to `candidate_status`
- **CLI client**: add `ResetCandidateActions` method; extend `ResumeSubmitSummary` with `StatusReplayed`/`ActionsReplayed`/`ActionsDeduped`
- **CLI**: add `full-restore` command; restore now auto-backs-up before replace, resets candidate actions, and replays actions/status from backup
- **Script**: `restore-resumes` supports auto-backup, candidate-actions reset, `merge` mode alias (upsert→merge rename), `SKIP_AUTO_BACKUP` flag
- **Tests**: update mock handlers and call-order assertions for new API endpoints

## Test plan
- [x] Go CLI builds and all tests pass (`go build ./...`, `go test ./cmd/`)
- [ ] `make check` passes in CI