### PR TITLE
fix(tests): update assertions for full-restore feature fields

### DIFF
--- a/apps/api/src/routes/resume-import.test.ts
+++ b/apps/api/src/routes/resume-import.test.ts
@@ -161,6 +161,9 @@ describe("resume import route", () => {
       updated: 0,
       unchanged: 0,
       deduped: 0,
+      statusReplayed: 0,
+      actionsReplayed: 0,
+      actionsDeduped: 0,
     });
     expect(calls).toHaveLength(1);
     expect(calls[0]?.args).toMatchObject({
@@ -244,6 +247,9 @@ describe("resume import route", () => {
       updated: 0,
       unchanged: 0,
       deduped: 0,
+      statusReplayed: 0,
+      actionsReplayed: 0,
+      actionsDeduped: 0,
     });
     expect(calls).toHaveLength(1);
     expect(calls[0]?.args).toMatchObject({
@@ -359,6 +365,9 @@ describe("resume import route", () => {
       updated: 0,
       unchanged: 0,
       deduped: 0,
+      statusReplayed: 0,
+      actionsReplayed: 0,
+      actionsDeduped: 0,
     });
     expect(calls).toHaveLength(1);
     expect(calls[0]?.args).toMatchObject({

--- a/apps/api/src/routes/resume-submit.test.ts
+++ b/apps/api/src/routes/resume-submit.test.ts
@@ -125,6 +125,9 @@ describe("resume submit route", () => {
       updated: 0,
       unchanged: 0,
       deduped: 0,
+      statusReplayed: 0,
+      actionsReplayed: 0,
+      actionsDeduped: 0,
     });
 
     expect(calls).toHaveLength(1);
@@ -242,6 +245,9 @@ describe("resume submit route", () => {
       updated: 0,
       unchanged: 0,
       deduped: 0,
+      statusReplayed: 0,
+      actionsReplayed: 0,
+      actionsDeduped: 0,
     });
 
     expect(calls).toHaveLength(1);

--- a/apps/api/src/routes/resumes-backup.test.ts
+++ b/apps/api/src/routes/resumes-backup.test.ts
@@ -70,6 +70,10 @@ describe("resume backup and reset routes", () => {
       const call = parseConvexCall(input, init);
       calls.push(call);
 
+      if (call.endpoint === "query" && call.pathName === "candidate_status:listForBackup") {
+        return convexSuccess([]);
+      }
+
       if (call.endpoint === "query" && call.pathName === "resumes:listForBackup") {
         expect(call.args).toEqual({
           paginationOpts: {
@@ -173,7 +177,7 @@ describe("resume backup and reset routes", () => {
         },
       },
     }));
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(2);
     expect(calls[0]?.pathName).toBe("resumes:listForBackup");
   });
 
@@ -183,6 +187,10 @@ describe("resume backup and reset routes", () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const call = parseConvexCall(input, init);
       calls.push(call);
+
+      if (call.endpoint === "query" && call.pathName === "candidate_status:listForBackup") {
+        return convexSuccess([]);
+      }
 
       if (call.endpoint === "query" && call.pathName === "resumes:listForBackup") {
         if (calls.length === 1) {
@@ -278,7 +286,7 @@ describe("resume backup and reset routes", () => {
     const payload = await response.json();
     expect(payload.metadata.totalResumes).toBe(2);
     expect(payload.resumes.map((item: { name: string }) => item.name)).toEqual(["Alice", "Bob"]);
-    expect(calls).toHaveLength(2);
+    expect(calls).toHaveLength(3);
   });
 
   it("blocks resume backup for non-admin workspaces", async () => {

--- a/apps/api/src/services/resume-import-service.test.ts
+++ b/apps/api/src/services/resume-import-service.test.ts
@@ -490,6 +490,9 @@ describe("resume-import-service", () => {
       updated: 0,
       unchanged: 0,
       deduped: 0,
+      statusReplayed: 0,
+      actionsReplayed: 0,
+      actionsDeduped: 0,
     });
     expect(calls).toHaveLength(1);
     expect(calls[0]?.pathName).toBe("resume_tasks:submitResumes");
@@ -576,6 +579,9 @@ describe("resume-import-service", () => {
       updated: 0,
       unchanged: 0,
       deduped: 0,
+      statusReplayed: 0,
+      actionsReplayed: 0,
+      actionsDeduped: 0,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `statusReplayed: 0`, `actionsReplayed: 0`, `actionsDeduped: 0` to `toEqual` assertions in resume-import, resume-submit, and resume-import-service tests broken by #607
- Add `candidate_status:listForBackup` mock handler in resumes-backup tests and update Convex call count assertions (backup route now also fetches candidate status)

## Test plan
- [x] All previously-broken assertions now pass locally
- [x] Pre-existing failures (install-deploy-safety, compat-v0.1.0, Convex filter tests) unchanged — same 17 failures as main baseline