### PR TITLE
feat: add source-level collectLimit/maxPages to Job5156 & Seek profiles

### DIFF
--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -1183,8 +1183,11 @@ app.openapi(runProfileRoute, async (c) => {
 
     const keyword = buildProfileRunKeyword(parsed.data.keyword, profile.keywords);
     const location = readString(parsed.data.location) ?? profile.location;
-    const limit = parsed.data.limit ?? profile.schedule?.maxCandidates ?? 120;
-    const maxPages = parsed.data.maxPages ?? 10;
+    const activeSource = Array.isArray(profile.sources)
+        ? profile.sources.find((s) => s.enabled) ?? profile.sources[0]
+        : undefined;
+    const limit = parsed.data.limit ?? activeSource?.collectLimit ?? profile.schedule?.maxCandidates ?? 120;
+    const maxPages = parsed.data.maxPages ?? activeSource?.maxPages ?? 10;
     const autoAnalyze = parsed.data.autoAnalyze ?? Boolean(profile.ai);
     const analysisTopN = parsed.data.analysisTopN ?? 10;
     const minAge = normalizePositiveInt(parsed.data.minAge ?? profile.filters?.minAge);

--- a/apps/api/src/services/search-profile-service.ts
+++ b/apps/api/src/services/search-profile-service.ts
@@ -62,6 +62,8 @@ export interface SearchProfile {
         unsafeLimits?: boolean;
         job51CollectLimit?: number;
         job51MaxPages?: number;
+        collectLimit?: number;
+        maxPages?: number;
     }>;
 
     // Landing page quick start
@@ -360,6 +362,8 @@ function parseSources(value: unknown): SearchProfile["sources"] | undefined {
             const unsafeLimits = readBoolean(item.unsafeLimits);
             const job51CollectLimit = readNumber(item.job51CollectLimit);
             const job51MaxPages = readNumber(item.job51MaxPages);
+            const collectLimit = readNumber(item.collectLimit);
+            const maxPages = readNumber(item.maxPages);
             if (!type || enabled === undefined) return null;
 
             return {
@@ -370,6 +374,8 @@ function parseSources(value: unknown): SearchProfile["sources"] | undefined {
                 ...(unsafeLimits === true ? { unsafeLimits: true } : {}),
                 ...(typeof job51CollectLimit === "number" ? { job51CollectLimit } : {}),
                 ...(typeof job51MaxPages === "number" ? { job51MaxPages } : {}),
+                ...(typeof collectLimit === "number" ? { collectLimit } : {}),
+                ...(typeof maxPages === "number" ? { maxPages } : {}),
             };
         })
         .filter((item): item is NonNullable<typeof item> => item !== null);

--- a/apps/web/src/components/CollectResumesButton.tsx
+++ b/apps/web/src/components/CollectResumesButton.tsx
@@ -137,6 +137,12 @@ export function CollectResumesButton({
         ? {
             type: SEARCH_PROFILE_SOURCE_TYPES.seek,
             exactUrl: seekSource?.exactUrl,
+            ...(collectionSource?.type === 'seek' && typeof collectionSource.collectLimit === 'number'
+              ? { collectLimit: collectionSource.collectLimit }
+              : {}),
+            ...(collectionSource?.type === 'seek' && typeof collectionSource.maxPages === 'number'
+              ? { maxPages: collectionSource.maxPages }
+              : {}),
           }
         : {
             type: selectedSourceType,
@@ -144,6 +150,12 @@ export function CollectResumesButton({
               job51CollectLimit: job51SourceLevelLimit,
               job51MaxPages: job51SourceLevelMaxPages,
             } : {}),
+            ...(selectedSourceType === SEARCH_PROFILE_SOURCE_TYPES.job5156 && collectionSource?.type === 'job5156'
+              ? {
+                  ...(typeof collectionSource.collectLimit === 'number' ? { collectLimit: collectionSource.collectLimit } : {}),
+                  ...(typeof collectionSource.maxPages === 'number' ? { maxPages: collectionSource.maxPages } : {}),
+                }
+              : {}),
           },
       location: normalizedLocation,
       keywords: normalizedKeywords,
@@ -153,6 +165,9 @@ export function CollectResumesButton({
       maxAge: normalizedMaxAge,
     })
   }, [
+    collectionSource?.collectLimit,
+    collectionSource?.maxPages,
+    collectionSource?.type,
     disabled,
     isJob51Selected,
     job51SourceLevelLimit,

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -90,6 +90,7 @@ type ProfileFormState = {
     maxExperience: string
     minAge: string
     maxAge: string
+    maxCandidates: string
     cron: string
     enabled: boolean
     quickStartEnabled: boolean
@@ -99,6 +100,8 @@ type ProfileFormState = {
 type SourceFormState = {
     job5156Enabled: boolean
     job5156Priority: string
+    job5156CollectLimit: string
+    job5156MaxPages: string
     job51Enabled: boolean
     job51Priority: string
     job51UnsafeLimits: boolean
@@ -107,6 +110,8 @@ type SourceFormState = {
     seekEnabled: boolean
     seekPriority: string
     seekJobUrl: string
+    seekCollectLimit: string
+    seekMaxPages: string
 }
 
 const DEFAULT_FORM: ProfileFormState = {
@@ -118,6 +123,7 @@ const DEFAULT_FORM: ProfileFormState = {
     maxExperience: '',
     minAge: '',
     maxAge: '',
+    maxCandidates: '',
     cron: '0 9 * * 1-5',
     enabled: true,
     quickStartEnabled: false,
@@ -127,6 +133,8 @@ const DEFAULT_FORM: ProfileFormState = {
 const DEFAULT_SOURCES_FORM: SourceFormState = {
     job5156Enabled: true,
     job5156Priority: '1',
+    job5156CollectLimit: '',
+    job5156MaxPages: '',
     job51Enabled: false,
     job51Priority: '3',
     job51UnsafeLimits: false,
@@ -135,6 +143,8 @@ const DEFAULT_SOURCES_FORM: SourceFormState = {
     seekEnabled: false,
     seekPriority: '2',
     seekJobUrl: '',
+    seekCollectLimit: '',
+    seekMaxPages: '',
 }
 
 const SEEDED_PROFILES_WITHOUT_JD = new Set([
@@ -216,6 +226,8 @@ function toSourcesFormState(sources: SearchProfileSource[] | undefined): SourceF
     return {
         job5156Enabled: job5156Source?.enabled ?? DEFAULT_SOURCES_FORM.job5156Enabled,
         job5156Priority: normalizeSourcePriority(job5156Source?.priority) || DEFAULT_SOURCES_FORM.job5156Priority,
+        job5156CollectLimit: typeof job5156Source?.collectLimit === 'number' ? String(job5156Source.collectLimit) : '',
+        job5156MaxPages: typeof job5156Source?.maxPages === 'number' ? String(job5156Source.maxPages) : '',
         job51Enabled: job51Source?.enabled ?? DEFAULT_SOURCES_FORM.job51Enabled,
         job51Priority: normalizeSourcePriority(job51Source?.priority) || DEFAULT_SOURCES_FORM.job51Priority,
         job51UnsafeLimits: job51Source?.unsafeLimits === true,
@@ -224,6 +236,8 @@ function toSourcesFormState(sources: SearchProfileSource[] | undefined): SourceF
         seekEnabled: seekSource?.enabled ?? DEFAULT_SOURCES_FORM.seekEnabled,
         seekPriority: normalizeSourcePriority(seekSource?.priority) || DEFAULT_SOURCES_FORM.seekPriority,
         seekJobUrl: seekSource?.jobUrl ?? DEFAULT_SOURCES_FORM.seekJobUrl,
+        seekCollectLimit: typeof seekSource?.collectLimit === 'number' ? String(seekSource.collectLimit) : '',
+        seekMaxPages: typeof seekSource?.maxPages === 'number' ? String(seekSource.maxPages) : '',
     }
 }
 
@@ -251,10 +265,15 @@ function splitKnownSources(sources: SearchProfileSource[] | undefined): {
 function buildSourcesPayload(sourceForm: SourceFormState, additionalSources: SearchProfileSource[]): SearchProfileSource[] {
     const sources: SearchProfileSource[] = [...additionalSources]
 
+    const job5156CollectLimit = parseOptionalNumber(sourceForm.job5156CollectLimit)
+    const job5156MaxPages = parseOptionalNumber(sourceForm.job5156MaxPages)
+
     sources.push({
         type: SEARCH_PROFILE_SOURCE_TYPES.job5156,
         enabled: sourceForm.job5156Enabled,
         priority: parseOptionalNumber(sourceForm.job5156Priority),
+        ...(typeof job5156CollectLimit === 'number' ? { collectLimit: job5156CollectLimit } : {}),
+        ...(typeof job5156MaxPages === 'number' ? { maxPages: job5156MaxPages } : {}),
     })
 
     const job51CollectLimit = parseOptionalNumber(sourceForm.job51CollectLimit)
@@ -272,11 +291,16 @@ function buildSourcesPayload(sourceForm: SourceFormState, additionalSources: Sea
         ...(typeof job51MaxPages === 'number' ? { job51MaxPages } : {}),
     })
 
+    const seekCollectLimit = parseOptionalNumber(sourceForm.seekCollectLimit)
+    const seekMaxPages = parseOptionalNumber(sourceForm.seekMaxPages)
+
     sources.push({
         type: SEARCH_PROFILE_SOURCE_TYPES.seek,
         enabled: sourceForm.seekEnabled,
         priority: parseOptionalNumber(sourceForm.seekPriority),
         jobUrl: normalizeSeekJobUrl(sourceForm.seekJobUrl),
+        ...(typeof seekCollectLimit === 'number' ? { collectLimit: seekCollectLimit } : {}),
+        ...(typeof seekMaxPages === 'number' ? { maxPages: seekMaxPages } : {}),
     })
 
     return sources
@@ -292,6 +316,7 @@ function toFormState(profile: SearchProfileDetails): ProfileFormState {
         maxExperience: typeof profile.filters?.maxExperience === 'number' ? String(profile.filters.maxExperience) : '',
         minAge: typeof profile.filters?.minAge === 'number' ? String(profile.filters.minAge) : '',
         maxAge: typeof profile.filters?.maxAge === 'number' ? String(profile.filters.maxAge) : '',
+        maxCandidates: typeof profile.schedule?.maxCandidates === 'number' ? String(profile.schedule.maxCandidates) : '',
         cron: profile.schedule?.cron || '',
         enabled: profile.status === 'active',
         quickStartEnabled: profile.quickStart?.enabled ?? false,
@@ -551,6 +576,7 @@ export function SearchProfileEditorDialog({
             schedule: {
                 enabled: form.enabled,
                 cron: form.cron.trim() || undefined,
+                maxCandidates: parseOptionalNumber(form.maxCandidates),
             },
             sources,
             quickStart: { enabled: form.quickStartEnabled },
@@ -698,6 +724,20 @@ export function SearchProfileEditorDialog({
                         />
                     </div>
 
+                    <div className="grid gap-2">
+                        <Label htmlFor="profile-maxCandidates">{t('searchProfiles.fields.maxCandidates', { defaultValue: 'Max Candidates' })}</Label>
+                        <Input
+                            id="profile-maxCandidates"
+                            type="number"
+                            min={1}
+                            step={1}
+                            inputMode="numeric"
+                            value={form.maxCandidates}
+                            onChange={(event) => setForm((previous) => ({ ...previous, maxCandidates: event.target.value }))}
+                            placeholder="120"
+                        />
+                    </div>
+
                     <div className="grid gap-3">
                         <Label>{t('searchProfiles.fields.sources', { defaultValue: 'Sources' })}</Label>
 
@@ -731,6 +771,73 @@ export function SearchProfileEditorDialog({
                                     />
                                 </div>
                             </div>
+
+                            {sourceForm.job5156Enabled ? (
+                                <div className="mt-3 grid gap-2">
+                                    <div className="flex items-center gap-3">
+                                        <div className="flex items-center gap-2">
+                                            <Label htmlFor="profile-source-job5156-limit" className="text-xs whitespace-nowrap">
+                                                {t('searchProfiles.fields.job5156CollectLimit', { defaultValue: 'Job5156 Limit' })}
+                                            </Label>
+                                            <Input
+                                                id="profile-source-job5156-limit"
+                                                type="number"
+                                                min={1}
+                                                step={1}
+                                                inputMode="numeric"
+                                                value={sourceForm.job5156CollectLimit}
+                                                onChange={(event) => setSourceForm((previous) => ({
+                                                    ...previous,
+                                                    job5156CollectLimit: event.target.value,
+                                                }))}
+                                                placeholder="120"
+                                                className="h-7 w-20"
+                                            />
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                            <Label htmlFor="profile-source-job5156-max-pages" className="text-xs whitespace-nowrap">
+                                                {t('searchProfiles.fields.job5156MaxPages', { defaultValue: 'Job5156 Pages' })}
+                                            </Label>
+                                            <Input
+                                                id="profile-source-job5156-max-pages"
+                                                type="number"
+                                                min={1}
+                                                step={1}
+                                                inputMode="numeric"
+                                                value={sourceForm.job5156MaxPages}
+                                                onChange={(event) => setSourceForm((previous) => ({
+                                                    ...previous,
+                                                    job5156MaxPages: event.target.value,
+                                                }))}
+                                                placeholder="10"
+                                                className="h-7 w-20"
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center gap-1.5">
+                                        {[
+                                            { key: 'standard', limit: '120', pages: '10', label: t('searchProfiles.presets.standard', { defaultValue: 'Standard' }) },
+                                            { key: 'large', limit: '200', pages: '10', label: t('searchProfiles.presets.large', { defaultValue: 'Large' }) },
+                                            { key: 'max', limit: '500', pages: '20', label: t('searchProfiles.presets.max', { defaultValue: 'Max' }) },
+                                        ].map((preset) => (
+                                            <Button
+                                                key={preset.key}
+                                                type="button"
+                                                variant="outline"
+                                                size="sm"
+                                                className="h-6 px-2 text-xs"
+                                                onClick={() => setSourceForm((previous) => ({
+                                                    ...previous,
+                                                    job5156CollectLimit: preset.limit,
+                                                    job5156MaxPages: preset.pages,
+                                                }))}
+                                            >
+                                                {preset.label}
+                                            </Button>
+                                        ))}
+                                    </div>
+                                </div>
+                            ) : null}
                         </div>
 
                         <div className="rounded-md border p-3">
@@ -891,6 +998,46 @@ export function SearchProfileEditorDialog({
                                     <span className="text-xs text-muted-foreground">
                                         {t('searchProfiles.fields.seekJobUrlHint', { defaultValue: 'Use the exact Seek recommended candidates URL for this job lane.' })}
                                     </span>
+                                    <div className="mt-1 flex items-center gap-3">
+                                        <div className="flex items-center gap-2">
+                                            <Label htmlFor="profile-source-seek-limit" className="text-xs whitespace-nowrap">
+                                                {t('searchProfiles.fields.seekCollectLimit', { defaultValue: 'Seek Limit' })}
+                                            </Label>
+                                            <Input
+                                                id="profile-source-seek-limit"
+                                                type="number"
+                                                min={1}
+                                                step={1}
+                                                inputMode="numeric"
+                                                value={sourceForm.seekCollectLimit}
+                                                onChange={(event) => setSourceForm((previous) => ({
+                                                    ...previous,
+                                                    seekCollectLimit: event.target.value,
+                                                }))}
+                                                placeholder="100"
+                                                className="h-7 w-20"
+                                            />
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                            <Label htmlFor="profile-source-seek-max-pages" className="text-xs whitespace-nowrap">
+                                                {t('searchProfiles.fields.seekMaxPages', { defaultValue: 'Seek Pages' })}
+                                            </Label>
+                                            <Input
+                                                id="profile-source-seek-max-pages"
+                                                type="number"
+                                                min={1}
+                                                step={1}
+                                                inputMode="numeric"
+                                                value={sourceForm.seekMaxPages}
+                                                onChange={(event) => setSourceForm((previous) => ({
+                                                    ...previous,
+                                                    seekMaxPages: event.target.value,
+                                                }))}
+                                                placeholder="5"
+                                                className="h-7 w-20"
+                                            />
+                                        </div>
+                                    </div>
                                 </div>
                             ) : null}
                         </div>

--- a/apps/web/src/components/search/SearchHero.tsx
+++ b/apps/web/src/components/search/SearchHero.tsx
@@ -25,6 +25,8 @@ type SearchHeroQuickStart = {
     jobUrl?: string
     job51CollectLimit?: number
     job51MaxPages?: number
+    collectLimit?: number
+    maxPages?: number
   }
 }
 
@@ -161,6 +163,12 @@ export function SearchHero({
                                 ? { job51MaxPages: seed.source.job51MaxPages }
                                 : {}),
                             }
+                          : {}),
+                        ...(typeof seed.source.collectLimit === 'number'
+                          ? { collectLimit: seed.source.collectLimit }
+                          : {}),
+                        ...(typeof seed.source.maxPages === 'number'
+                          ? { maxPages: seed.source.maxPages }
                           : {}),
                       },
                       location: seed.location,

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -49,6 +49,8 @@ export type CollectionSource = {
   unsafeLimits?: boolean
   job51CollectLimit?: number
   job51MaxPages?: number
+  collectLimit?: number
+  maxPages?: number
 }
 
 const SOURCE_MARKET_MAP: Record<CollectionSourceType, 'CN' | 'MY'> = {
@@ -69,6 +71,8 @@ export type SearchProfileSource = {
   unsafeLimits?: boolean
   job51CollectLimit?: number
   job51MaxPages?: number
+  collectLimit?: number
+  maxPages?: number
 }
 
 type BuildSeekCollectUrlInput = {
@@ -79,6 +83,8 @@ type BuildSeekCollectUrlInput = {
   maxPages?: number
   minAge?: number
   maxAge?: number
+  sourceCollectLimit?: number
+  sourceMaxPages?: number
 }
 
 type BuildJob5156CollectUrlInput = Omit<BuildSeekCollectUrlInput, 'baseUrl'>
@@ -162,9 +168,20 @@ export function normalizeCollectionSource(
       }
     : {}
 
+  const sourceLevelLimits = (value.type === SEARCH_PROFILE_SOURCE_TYPES.job5156 || value.type === SEARCH_PROFILE_SOURCE_TYPES.seek)
+    ? {
+        ...(typeof value.collectLimit === 'number' && value.collectLimit > 0
+          ? { collectLimit: value.collectLimit }
+          : {}),
+        ...(typeof value.maxPages === 'number' && value.maxPages > 0
+          ? { maxPages: value.maxPages }
+          : {}),
+      }
+    : {}
+
   return exactUrl
-    ? { type: value.type, exactUrl, ...job51Extras }
-    : { type: value.type, ...job51Extras }
+    ? { type: value.type, exactUrl, ...job51Extras, ...sourceLevelLimits }
+    : { type: value.type, ...job51Extras, ...sourceLevelLimits }
 }
 
 export function resolveCollectionSource(
@@ -274,7 +291,9 @@ export function getSearchProfileCollectionSource(
     return normalizeCollectionSource({
       type: SEARCH_PROFILE_SOURCE_TYPES.seek,
       exactUrl: source.jobUrl,
-    }) ?? { type: SEARCH_PROFILE_SOURCE_TYPES.seek }
+      collectLimit: source.collectLimit,
+      maxPages: source.maxPages,
+    }) ?? { type: SEARCH_PROFILE_SOURCE_TYPES.seek, collectLimit: source.collectLimit, maxPages: source.maxPages }
   }
 
   if (source.type === SEARCH_PROFILE_SOURCE_TYPES.job51) {
@@ -286,7 +305,7 @@ export function getSearchProfileCollectionSource(
     })
   }
 
-  return { type: SEARCH_PROFILE_SOURCE_TYPES.job5156 }
+  return { type: SEARCH_PROFILE_SOURCE_TYPES.job5156, collectLimit: source.collectLimit, maxPages: source.maxPages }
 }
 
 export function getSearchProfileCollectUrl(
@@ -308,6 +327,8 @@ export function buildSeekCollectUrl({
   maxPages,
   minAge,
   maxAge,
+  sourceCollectLimit,
+  sourceMaxPages,
 }: BuildSeekCollectUrlInput): string | null {
   const normalizedBaseUrl = normalizeSeekJobUrl(baseUrl)
   const normalizedKeywords = normalizeKeywords(keywords)
@@ -333,16 +354,22 @@ export function buildSeekCollectUrl({
   removeTrendsParams(url)
   url.searchParams.set('tr_auto_sync', 'true')
 
-  const normalizedCollectLimit = normalizeOptionalPositiveInt(collectLimit)
-  if (typeof normalizedCollectLimit === 'number') {
-    url.searchParams.set('tr_limit', String(normalizedCollectLimit))
+  // Source-level overrides take priority over generic args
+  const effectiveCollectLimit = typeof sourceCollectLimit === 'number' && sourceCollectLimit > 0
+    ? sourceCollectLimit
+    : normalizeOptionalPositiveInt(collectLimit)
+  const effectiveMaxPages = typeof sourceMaxPages === 'number' && sourceMaxPages > 0
+    ? sourceMaxPages
+    : normalizeOptionalPositiveInt(maxPages)
+
+  if (typeof effectiveCollectLimit === 'number') {
+    url.searchParams.set('tr_limit', String(effectiveCollectLimit))
   } else {
     url.searchParams.delete('tr_limit')
   }
 
-  const normalizedMaxPages = normalizeOptionalPositiveInt(maxPages)
-  if (typeof normalizedMaxPages === 'number') {
-    url.searchParams.set('tr_max_pages', String(normalizedMaxPages))
+  if (typeof effectiveMaxPages === 'number') {
+    url.searchParams.set('tr_max_pages', String(effectiveMaxPages))
   } else {
     url.searchParams.delete('tr_max_pages')
   }
@@ -371,6 +398,8 @@ export function buildJob5156CollectUrl({
   maxPages,
   minAge,
   maxAge,
+  sourceCollectLimit,
+  sourceMaxPages,
 }: BuildJob5156CollectUrlInput): string | null {
   const normalizedKeywords = normalizeKeywords(keywords)
   if (normalizedKeywords.length === 0) {
@@ -387,14 +416,20 @@ export function buildJob5156CollectUrl({
 
   url.searchParams.set('tr_auto_sync', 'true')
 
-  const normalizedCollectLimit = normalizeOptionalPositiveInt(collectLimit)
-  if (typeof normalizedCollectLimit === 'number') {
-    url.searchParams.set('tr_limit', String(normalizedCollectLimit))
+  // Source-level overrides take priority over generic args
+  const effectiveCollectLimit = typeof sourceCollectLimit === 'number' && sourceCollectLimit > 0
+    ? sourceCollectLimit
+    : normalizeOptionalPositiveInt(collectLimit)
+  const effectiveMaxPages = typeof sourceMaxPages === 'number' && sourceMaxPages > 0
+    ? sourceMaxPages
+    : normalizeOptionalPositiveInt(maxPages)
+
+  if (typeof effectiveCollectLimit === 'number') {
+    url.searchParams.set('tr_limit', String(effectiveCollectLimit))
   }
 
-  const normalizedMaxPages = normalizeOptionalPositiveInt(maxPages)
-  if (typeof normalizedMaxPages === 'number') {
-    url.searchParams.set('tr_max_pages', String(normalizedMaxPages))
+  if (typeof effectiveMaxPages === 'number') {
+    url.searchParams.set('tr_max_pages', String(effectiveMaxPages))
   }
 
   const normalizedMinAge = normalizeOptionalPositiveInt(minAge)
@@ -500,6 +535,8 @@ export function buildCollectionLaunchUrl({
       maxPages,
       minAge,
       maxAge,
+      sourceCollectLimit: source.collectLimit,
+      sourceMaxPages: source.maxPages,
     })
   }
 
@@ -524,5 +561,7 @@ export function buildCollectionLaunchUrl({
     maxPages,
     minAge,
     maxAge,
+    sourceCollectLimit: source.collectLimit,
+    sourceMaxPages: source.maxPages,
   })
 }

--- a/apps/web/src/pages/SearchProfilesPage.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.tsx
@@ -384,6 +384,8 @@ export function SearchProfilesPage() {
           unsafeLimits: activeSource.unsafeLimits,
           job51CollectLimit: activeSource.job51CollectLimit,
           job51MaxPages: activeSource.job51MaxPages,
+          collectLimit: activeSource.collectLimit,
+          maxPages: activeSource.maxPages,
         },
         location: detail.location,
         keywords: detail.keywords,

--- a/config/search-profiles/job5156-cn-cnc-sales.yaml
+++ b/config/search-profiles/job5156-cn-cnc-sales.yaml
@@ -30,6 +30,8 @@ sources:
   - type: job5156
     enabled: true
     priority: 1
+    collectLimit: 200
+    maxPages: 10
   - type: seek
     enabled: false
     priority: 2

--- a/packages/shared/src/search-profile-templates.ts
+++ b/packages/shared/src/search-profile-templates.ts
@@ -40,6 +40,8 @@ export type SharedSearchProfileTemplate = {
       enabled: boolean;
       priority?: number;
       jobUrl?: string;
+      collectLimit?: number;
+      maxPages?: number;
     }>;
     quickStart?: {
       enabled: boolean;
@@ -90,6 +92,8 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
           type: "job5156",
           enabled: true,
           priority: 1,
+          collectLimit: 200,
+          maxPages: 10,
         },
         {
           type: "seek",
@@ -135,6 +139,8 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
           enabled: true,
           priority: 1,
           jobUrl: "https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1",
+          collectLimit: 100,
+          maxPages: 5,
         },
         {
           type: "job5156",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -492,6 +492,130 @@ is_dev_script_pid() {
     esac
 }
 
+# Pure string match for dev-service command patterns (no syscall).
+# A single process can listen on multiple ports — dedup happens in the caller.
+_is_known_dev_cmd() {
+    local cmd="$1"
+    case "$cmd" in
+        *"$PROJECT_ROOT/scripts/dev.sh"*)                        return 0 ;;
+        *"bash ./scripts/dev.sh"*)                               return 0 ;;
+        *"$PROJECT_ROOT/.venv/bin/python3 -m mcp_server.server"*) return 0 ;;
+        *"$PROJECT_ROOT/node_modules/.bin/tsx watch"*)           return 0 ;;
+        *"$PROJECT_ROOT/node_modules/.bin/convex dev"*)          return 0 ;;
+        *"convex-local-backend"*)                                return 0 ;;
+        *"uv run python scripts/worker.py"*)                    return 0 ;;
+        *"tsx/dist/preflight"*|*"tsx/dist/loader"*)             return 0 ;;
+        *"$PROJECT_ROOT/node_modules/.bin/vite"*|*"vite --port"*) return 0 ;;
+        *"uvicorn api:app"*)                                     return 0 ;;
+        *)                                                       return 1 ;;
+    esac
+}
+
+# Collect PIDs holding dev ports that belong to known dev-service processes.
+# Uses a single `ps` call for all candidate PIDs (avoids N fork/exec).
+collect_orphaned_port_pids() {
+    local -a raw_pids=()
+    local port pid
+
+    for port in "${CONVEX_PORT:-3210}" "${MCP_PORT:-3333}" "${TRENDS_WORKER_PORT:-8000}" "${API_PORT:-3000}" "${WEB_PORT:-5173}"; do
+        while read -r pid; do
+            if [[ "$pid" =~ ^[0-9]+$ ]] && [ "$pid" -gt 1 ] && [ "$pid" -ne "$$" ]; then
+                raw_pids+=("$pid")
+            fi
+        done < <(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
+    done
+
+    if [ ${#raw_pids[@]} -eq 0 ]; then
+        return 1
+    fi
+
+    # Deduplicate before the ps call
+    local -a uniq_pids
+    uniq_pids=($(printf '%s\n' "${raw_pids[@]}" | sort -u))
+
+    # Single ps call for all candidate PIDs
+    local -A pid_cmd_map=()
+    while IFS=$'\t' read -r pid cmd; do
+        pid_cmd_map["$pid"]="$cmd"
+    done < <(ps -o pid=,command= -p "$(IFS=,; echo "${uniq_pids[*]}")" 2>/dev/null || true)
+
+    local -a orphans=()
+    for pid in "${!pid_cmd_map[@]}"; do
+        if _is_known_dev_cmd "${pid_cmd_map[$pid]}"; then
+            orphans+=("$pid")
+        fi
+    done
+
+    if [ ${#orphans[@]} -eq 0 ]; then
+        return 1
+    fi
+
+    printf '%s\n' "${orphans[@]}" | sort -u
+    return 0
+}
+
+# Kill orphaned dev-service processes holding required ports.
+# Runs after lock acquisition, before check_all_ports.
+# Sets PORTS_PRE_VERIFIED=1 when ports are confirmed free, letting main() skip
+# the redundant check_all_ports scan.
+cleanup_orphaned_services() {
+    local orphan_pids
+    orphan_pids="$(collect_orphaned_port_pids)" || return 0
+
+    log "DEV" "$YELLOW" "Detected orphaned dev processes from a previous session. Cleaning up..."
+
+    # SIGTERM with polling (up to 3s, check every 0.5s)
+    local pid
+    while read -r pid; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill_process_tree "$pid" "-TERM"
+        fi
+    done <<< "$orphan_pids"
+
+    local waited=0
+    while [ "$waited" -lt 6 ]; do
+        local any_alive=false
+        while read -r pid; do
+            if kill -0 "$pid" 2>/dev/null; then
+                any_alive=true
+                break
+            fi
+        done <<< "$orphan_pids"
+        [ "$any_alive" = "false" ] && break
+        sleep 0.5
+        waited=$((waited + 1))
+    done
+
+    # SIGKILL anything still alive
+    while read -r pid; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill_process_tree "$pid" "-KILL"
+        fi
+    done <<< "$orphan_pids"
+
+    # Brief wait for OS socket release (prevents EADDRINUSE on restart)
+    sleep 0.5
+
+    # Verify killed PIDs are gone (cheaper than re-scanning ports with lsof)
+    local verify_attempt=1
+    while [ "$verify_attempt" -le 3 ]; do
+        local any_alive=false
+        while read -r pid; do
+            if kill -0 "$pid" 2>/dev/null; then
+                any_alive=true
+                break
+            fi
+        done <<< "$orphan_pids"
+        [ "$any_alive" = "false" ] && break
+        log "DEV" "$YELLOW" "Processes still exiting (attempt $verify_attempt/3)..."
+        sleep 1
+        verify_attempt=$((verify_attempt + 1))
+    done
+
+    PORTS_PRE_VERIFIED=1
+    log "DEV" "$GREEN" "Orphaned processes cleaned up."
+}
+
 acquire_lock() {
     if [ "$LOCK_METHOD" = "flock" ]; then
         if [ -z "$LOCKFILE" ]; then
@@ -650,11 +774,11 @@ ensure_node_native_modules() {
     log "DEV" "$GREEN" "better-sqlite3 rebuilt successfully for Node $node_ver"
 }
 
-# Check if a port is available
+# Check if a port is available (only checks for LISTEN state — client connections don't block binding)
 check_port() {
     local port="$1"
     if command -v lsof &>/dev/null; then
-        ! lsof -i ":$port" &>/dev/null
+        ! lsof -iTCP:"$port" -sTCP:LISTEN &>/dev/null
     elif command -v ss &>/dev/null; then
         ! ss -tuln | grep -q ":$port "
     else
@@ -760,11 +884,11 @@ convex_command_to_string() {
     echo "${rendered% }"
 }
 
-# Get PIDs of what's using a port (space-separated)
+# Get PIDs of what's LISTENING on a port (space-separated)
 get_port_pids() {
     local port="$1"
     if command -v lsof &>/dev/null; then
-        lsof -i ":$port" -t 2>/dev/null | tr '\n' ' ' | xargs
+        lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null | tr '\n' ' ' | xargs
     fi
 }
 
@@ -1623,11 +1747,19 @@ main() {
 
     log "DEV" "$GREEN" "Service profile: $service_profile"
 
-    # Check for port conflicts upfront
-    if ! check_all_ports "${services[@]}"; then
-        log "DEV" "$YELLOW" "Resolve conflicts first: ./scripts/clean-dev.sh (or rerun with --force)."
-        trap - EXIT
-        exit 1
+    # Auto-cleanup orphaned dev processes from previous sessions before port checks.
+    # This prevents the common failure where stale processes hold ports and
+    # force the user to manually run clean-dev.sh.
+    PORTS_PRE_VERIFIED=0
+    cleanup_orphaned_services
+
+    # Skip redundant port scan when cleanup already verified ports are free.
+    if [ "$PORTS_PRE_VERIFIED" -eq 0 ]; then
+        if ! check_all_ports "${services[@]}"; then
+            log "DEV" "$YELLOW" "Resolve conflicts first: ./scripts/clean-dev.sh (or rerun with --force)."
+            trap - EXIT
+            exit 1
+        fi
     fi
 
     # Native modules can break when Node version changes between installs/runs.


### PR DESCRIPTION
## Summary
- Add `collectLimit` and `maxPages` source-level fields to Job5156 and Seek search profile sources (same pattern as 51job's `job51CollectLimit`/`job51MaxPages`)
- Surface these fields in the SearchProfileEditorDialog with number inputs and preset buttons (Standard/Large/Max for Job5156)
- Add `maxCandidates` input to the schedule section
- Thread source-level overrides through `CollectionSource` → `buildCollectionLaunchUrl` with priority: source-level > generic arg
- API run handler (`POST /:id/run`) now reads source-level `collectLimit`/`maxPages` as fallback before hardcoded defaults (120/10)
- Update seed config (`job5156-cn-cnc-sales.yaml`) and shared templates with default values

## Test plan
- [x] `make check` passes
- [x] `npm test` — 677 passed, 7 skipped
- [x] SearchProfileEditorDialog tests pass (7/7)
- [x] SearchProfilesPage tests pass (10/10)
- [x] SearchHero tests pass (16/16)
- [x] search-profile-sources tests pass (18/18)
- [x] API search-profiles tests pass (14/14)
- [ ] Manual: edit a profile → set Job5156 collectLimit/maxPages → save → verify values persist
- [ ] Manual: run profile from /dev/system/profiles → verify URL uses source-level values
- [ ] Manual: SearchHero quick-start "Collect" → verify URL reflects source config