### PR TITLE
Add missing i18n keys for search hero buttons

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -354,7 +354,9 @@
         "hotTags": "Hot Tags",
         "recentSearches": "Recent searches",
         "loadingRecentSearches": "Loading recent searches...",
-        "noSavedSearches": "No saved searches yet. Recent searches will appear here after you start exploring."
+        "noSavedSearches": "No saved searches yet. Recent searches will appear here after you start exploring.",
+        "collect": "Collect",
+        "editProfile": "Edit"
       },
       "searchBar": {
         "placeholder": "Search resumes by keywords, brands, roles, or locations",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -353,7 +353,9 @@
         "hotTags": "热门标签",
         "recentSearches": "最近搜索",
         "loadingRecentSearches": "正在加载最近搜索...",
-        "noSavedSearches": "暂无已保存搜索。开始浏览后，最近搜索会显示在这里。"
+        "noSavedSearches": "暂无已保存搜索。开始浏览后，最近搜索会显示在这里。",
+        "collect": "采集",
+        "editProfile": "编辑"
       },
       "searchBar": {
         "placeholder": "按关键词、品牌、岗位或地区搜索简历",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -353,7 +353,9 @@
         "hotTags": "熱門標籤",
         "recentSearches": "最近搜尋",
         "loadingRecentSearches": "正在載入最近搜尋...",
-        "noSavedSearches": "目前尚無已保存搜尋。開始瀏覽後，最近搜尋會顯示在這裡。"
+        "noSavedSearches": "目前尚無已保存搜尋。開始瀏覽後，最近搜尋會顯示在這裡。",
+        "collect": "採集",
+        "editProfile": "編輯"
       },
       "searchBar": {
         "placeholder": "按關鍵詞、品牌、職位或地區搜尋簡歷",


### PR DESCRIPTION
## Summary
- Add `collect` and `editProfile` keys to `resumes.searchPage.hero` block in all 3 locale files (zh-Hant, zh-Hans, en)
- Fixes runtime `i18next::translator: missingKey zh-Hans` warnings seen on `/dev/resumes`

## Test plan
- [x] `make i18n-check` passes (739 keys, 0 missing/extra)
- [x] E2E Playwright: `/dev/resumes` console shows zero `missingKey` warnings after fix
- [ ] Visual: hero area shows 采集/编辑 labels (zh-Hans) instead of English fallback