### PR TITLE
fix(convex): remove legacy collectUrl from schema

### DIFF
--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -338,7 +338,6 @@ export default defineSchema({
                 type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
                 exactUrl: v.optional(v.string()),
             })),
-            collectUrl: v.optional(v.string()), // Legacy field; use collectionSource.exactUrl instead.
             filters: v.optional(v.any()), // Stores ResumeFilters object
         }),
         reviewedResumeIds: v.array(v.string()), // IDs of resumes seen/acted upon
@@ -359,7 +358,6 @@ export default defineSchema({
             type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
             exactUrl: v.optional(v.string()),
         })),
-        collectUrl: v.optional(v.string()), // Legacy field; use collectionSource.exactUrl instead.
         filters: v.optional(v.any()),
         selectedTags: v.optional(v.array(v.string())),
         selectedCompanies: v.optional(v.array(v.string())),


### PR DESCRIPTION
## Summary
- `collectUrl` was documented as fully removed in PRs #559/#561/#562, but two `v.optional(v.string())` definitions with "Legacy field" comments remained in `packages/convex/convex/schema.ts` on both `screening_sessions` and `search_history` tables.
- No runtime code reads or writes these fields; `collectionSource.exactUrl` is the replacement.
- Removes the dead fields so the schema matches the documented state.

## Test plan
- [x] `make check` clean (typecheck, lint, governance all pass)
- [ ] Post-deploy: Convex will auto-migrate existing rows that have `collectUrl` data — the field simply disappears from the schema; no data loss for the replacement `collectionSource.exactUrl` field.