### PR TITLE
Add locale to analysis storage key for source+locale coexistence

### DIFF
--- a/apps/web/src/lib/analysis-utils.test.ts
+++ b/apps/web/src/lib/analysis-utils.test.ts
@@ -125,4 +125,30 @@ describe('source-aware analysis helpers', () => {
     expect(resolveResumeAnalysisSourceKey({ sourceKey: '51job' })).toBe('51job')
     expect(resolveResumeAnalysisSourceKey({ source: 'ehire.51job.com' })).toBe('51job')
   })
+
+  it('builds locale-aware storage keys when locale is provided', () => {
+    expect(buildResumeAnalysisStorageKey('jd-lathe-sales', { locale: 'en' }))
+      .toBe('locale:en|analysis:jd-lathe-sales')
+  })
+
+  it('builds source+locale storage keys when both are provided', () => {
+    expect(buildResumeAnalysisStorageKey('jd-lathe-sales', { sourceKey: 'seek', locale: 'en' }))
+      .toBe('source:seek|locale:en|analysis:jd-lathe-sales')
+  })
+
+  it('returns legacy key when neither sourceKey nor locale is provided', () => {
+    expect(buildResumeAnalysisStorageKey('jd-lathe-sales')).toBe('jd-lathe-sales')
+  })
+
+  it('normalizes locale whitespace and casing', () => {
+    expect(buildResumeAnalysisStorageKey('jd-lathe-sales', { locale: '  ZH-HANS  ' }))
+      .toBe('locale:zh-hans|analysis:jd-lathe-sales')
+  })
+
+  it('returns source+locale lookup keys before the legacy key', () => {
+    expect(buildResumeAnalysisLookupKeys('jd-lathe-sales', [], { sourceKey: 'seek', locale: 'en' })).toEqual([
+      'source:seek|locale:en|analysis:jd-lathe-sales',
+      'jd-lathe-sales',
+    ])
+  })
 })

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -184,6 +184,7 @@ export function getAnalysisForJob(
     location?: string
     promptVersion?: number
     sourceKey?: string
+    locale?: string
   }
 ): ConvexResumeAnalysis | undefined {
   const lookupKeys = buildResumeAnalysisLookupKeys(jobDescriptionId, keywords, options)

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -2438,6 +2438,7 @@ export const updateAnalysis = internalMutation({
         const analyses = resume.analyses || {};
         const analysisKey = buildResumeAnalysisStorageKey(args.analysis.jobDescriptionId, {
             sourceKey: resolveResumeAnalysisSourceKey({ source: resume.source }),
+            locale: args.analysis.locale,
         });
 
         analyses[analysisKey] = args.analysis;
@@ -2475,6 +2476,7 @@ export const updateAnalysisBatch = internalMutation({
             const analyses = resume.analyses || {};
             const analysisKey = buildResumeAnalysisStorageKey(update.analysis.jobDescriptionId, {
                 sourceKey: resolveResumeAnalysisSourceKey({ source: resume.source }),
+                locale: update.analysis.locale,
             });
             analyses[analysisKey] = update.analysis;
 

--- a/packages/shared/src/analysis-key.ts
+++ b/packages/shared/src/analysis-key.ts
@@ -53,6 +53,7 @@ export type AnalysisKeywordKeyOptions = {
   location?: string;
   promptVersion?: number;
   sourceKey?: string;
+  locale?: string;
 };
 
 function getPromptVersionFallback(): number {
@@ -169,15 +170,25 @@ export function buildResumeAnalysisStorageKey(
   jobDescriptionId: string | undefined,
   options?: {
     sourceKey?: string;
+    locale?: string;
   }
 ): string {
   const normalizedJobDescriptionId = normalizeJobDescriptionId(jobDescriptionId);
   const sourceKey = resolveResumeAnalysisSourceKey({ sourceKey: options?.sourceKey });
-  if (!sourceKey) {
+  const normalizedLocale = normalizeText(options?.locale);
+  if (!sourceKey && !normalizedLocale) {
     return normalizedJobDescriptionId;
   }
 
-  return `source:${sourceKey}|analysis:${normalizedJobDescriptionId}`;
+  const parts: string[] = [];
+  if (sourceKey) {
+    parts.push(`source:${sourceKey}`);
+  }
+  if (normalizedLocale) {
+    parts.push(`locale:${normalizedLocale}`);
+  }
+  parts.push(`analysis:${normalizedJobDescriptionId}`);
+  return parts.join("|");
 }
 
 export function buildResumeAnalysisLookupKeys(
@@ -187,13 +198,13 @@ export function buildResumeAnalysisLookupKeys(
 ): string[] {
   if (jobDescriptionId) {
     const legacyKey = normalizeJobDescriptionId(jobDescriptionId);
-    const sourceAwareKey = buildResumeAnalysisStorageKey(jobDescriptionId, { sourceKey: options?.sourceKey });
+    const sourceAwareKey = buildResumeAnalysisStorageKey(jobDescriptionId, { sourceKey: options?.sourceKey, locale: options?.locale });
     return sourceAwareKey === legacyKey ? [legacyKey] : [sourceAwareKey, legacyKey];
   }
 
   if (keywords.length > 0) {
     const legacyKey = buildKeywordAnalysisId(keywords, options);
-    const sourceAwareKey = buildResumeAnalysisStorageKey(legacyKey, { sourceKey: options?.sourceKey });
+    const sourceAwareKey = buildResumeAnalysisStorageKey(legacyKey, { sourceKey: options?.sourceKey, locale: options?.locale });
     return sourceAwareKey === legacyKey ? [legacyKey] : [sourceAwareKey, legacyKey];
   }
 


### PR DESCRIPTION
## Summary
- `buildResumeAnalysisStorageKey` now accepts an optional `locale` parameter
- When locale is provided, the key includes `locale:<value>` in the composite key (e.g. `source:seek|locale:en|analysis:<jdId>`)
- This prevents `Seek -> en` and `Job5156 -> zh-Hans` analyses from overwriting each other for the same resume and JD
- `updateAnalysis` and `updateAnalysisBatch` in `resumes.ts` now pass `args.analysis.locale` into the storage key builder
- `resume-scoring.ts` now accepts and forwards `locale` in options
- `AnalysisKeywordKeyOptions` type extended with optional `locale` field
- 5 new test cases covering locale-only, source+locale, normalization, and lookup key fallback

## Background
The 2026-03-20 progress review identified that analyses were cached only by `jobDescriptionId`, then PR #367 added source-aware keys. However, locale was stored *on the analysis object* but was not part of the storage key itself, meaning same-source different-locale analyses would still collide.

## Test plan
- [x] `bunx vitest run packages/shared/src/` — 46 passed
- [x] `bunx vitest run src/lib/analysis-utils.test.ts` (web) — 19 passed (5 new)
- [x] `bunx vitest run src/lib/resume-scoring.test.ts` — 34 passed
- [x] `make check` — all checks passed
- [ ] Manual: re-analyze a resume with a different locale and confirm separate cache entries