### PR TITLE
Add server-side source filter to Convex resume list queries

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -25,6 +25,7 @@ export type ConvexResumeFilters = {
   locations?: string[]
   minSalary?: number
   maxSalary?: number
+  sources?: string[]
 }
 
 export type ConvexResumeAnalysis = {

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -679,6 +679,7 @@ export function useResumeSearchState() {
       maxAge: parsedState.filters.maxAge,
       requiredKeywords: parsedState.requiredKeywords,
       locations: parsedState.filters.locations,
+      sources: parsedState.selectedSources.length > 0 ? parsedState.selectedSources : undefined,
     }),
     [
       effectiveRoleFilterType,
@@ -689,6 +690,7 @@ export function useResumeSearchState() {
       parsedState.filters.minExperience,
       parsedState.filters.minRoleYears,
       parsedState.requiredKeywords,
+      parsedState.selectedSources,
     ],
   )
   const activeSort = resolveSortValue(parsedState.filters)

--- a/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
+++ b/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
@@ -22,6 +22,7 @@ type PaginatedArgs = {
   locations?: string[];
   minSalary?: number;
   maxSalary?: number;
+  sources?: string[];
 };
 
 type PaginatedResult = {
@@ -51,6 +52,7 @@ type SearchPaginatedArgs = {
   locations?: string[];
   minSalary?: number;
   maxSalary?: number;
+  sources?: string[];
 };
 
 type SearchPaginatedResult = {
@@ -817,5 +819,97 @@ describe("searchWithTagExpansionPaginated", () => {
     expect((result.page[0] as { resume: { _id: string } }).resume._id).toBe("resume-a");
     expect(result.continueCursor).toBe("cursor-next");
     expect(result.isDone).toBe(false);
+  });
+});
+
+describe("listWithIngestDataPaginated source filter", () => {
+  it("filters resumes by source keys", async () => {
+    const resumeA = { ...buildResumeDoc("resume-a", 90), source: "hr.job5156.com", sourceKey: "job5156" };
+    const resumeB = { ...buildResumeDoc("resume-b", 80), source: "hk.employer.seek.com", sourceKey: "seek" };
+    const resumeC = { ...buildResumeDoc("resume-c", 70), source: "ehire.51job.com", sourceKey: "51job" };
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => withFilterPassthrough({
+              paginate: async () => ({
+                page: [resumeA, resumeB, resumeC],
+                continueCursor: "cursor-next",
+                isDone: false,
+              }),
+              take: async () => [],
+            }),
+          }),
+        }),
+      },
+    };
+
+    const result = await handler(ctx, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      sources: ["job5156"],
+    });
+
+    expect(result.page).toHaveLength(1);
+    expect((result.page[0] as { _id: string })._id).toBe("resume-a");
+  });
+
+  it("returns all resumes when sources is empty or undefined", async () => {
+    const resumeA = { ...buildResumeDoc("resume-a", 90), source: "hr.job5156.com" };
+    const resumeB = { ...buildResumeDoc("resume-b", 80), source: "hk.employer.seek.com" };
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => withFilterPassthrough({
+              paginate: async () => ({
+                page: [resumeA, resumeB],
+                continueCursor: "cursor-next",
+                isDone: false,
+              }),
+              take: async () => [],
+            }),
+          }),
+        }),
+      },
+    };
+
+    const result = await handler(ctx, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      sources: [],
+    });
+
+    expect(result.page).toHaveLength(2);
+  });
+
+  it("matches resumes by source hostname when sourceKey is not set", async () => {
+    const resumeA = { ...buildResumeDoc("resume-a", 90), source: "hr.job5156.com" };
+    const resumeB = { ...buildResumeDoc("resume-b", 80), source: "hk.employer.seek.com" };
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => withFilterPassthrough({
+              paginate: async () => ({
+                page: [resumeA, resumeB],
+                continueCursor: "",
+                isDone: true,
+              }),
+              take: async () => [],
+            }),
+          }),
+        }),
+      },
+    };
+
+    const result = await handler(ctx, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      sources: ["seek"],
+    });
+
+    expect(result.page).toHaveLength(1);
+    expect((result.page[0] as { _id: string })._id).toBe("resume-b");
   });
 });

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -321,6 +321,7 @@ type ResumeListFilterArgs = {
     minSalary?: number;
     maxSalary?: number;
     showArchived?: boolean;
+    sources?: string[];
 };
 
 type ResumeListSortBy = "name" | "experience" | "extractedAt";
@@ -775,6 +776,7 @@ function normalizeResumeListFilters(filters: ResumeListFilterArgs | undefined): 
         .map((value) => value.toLowerCase())
         .filter((value) => value.length > 0);
     const locations = filters.locations?.map((value) => value.trim()).filter((value) => value.length > 0);
+    const sources = filters.sources?.map((value) => value.trim().toLowerCase()).filter((value) => value.length > 0);
     const roleFilterType = toOptionalStringValue(filters.roleFilterType)?.toLowerCase();
     const minAge = typeof filters.minAge === "number" && Number.isFinite(filters.minAge) && filters.minAge > 0
         ? Math.trunc(filters.minAge)
@@ -797,6 +799,7 @@ function normalizeResumeListFilters(filters: ResumeListFilterArgs | undefined): 
         ...(filters.minSalary === undefined ? {} : { minSalary: filters.minSalary }),
         ...(filters.maxSalary === undefined ? {} : { maxSalary: filters.maxSalary }),
         ...(filters.showArchived ? { showArchived: true } : {}),
+        ...(sources && sources.length > 0 ? { sources } : {}),
     };
 
     return Object.keys(normalized).length > 0 ? normalized : undefined;
@@ -993,6 +996,14 @@ function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFil
             if (minSalary !== undefined && minSalary > filters.maxSalary) {
                 return false;
             }
+        }
+    }
+
+    if (filters.sources?.length) {
+        const resumeSourceKey = resume.sourceKey
+            ?? resolveResumeAnalysisSourceKey({ source: resume.source });
+        if (!resumeSourceKey || !filters.sources.includes(resumeSourceKey)) {
+            return false;
         }
     }
 
@@ -1790,6 +1801,7 @@ export const listWithIngestDataPaginated = query({
         locations: v.optional(v.array(v.string())),
         minSalary: v.optional(v.number()),
         maxSalary: v.optional(v.number()),
+        sources: v.optional(v.array(v.string())),
     },
     handler: async (ctx, args) => {
         const filters = normalizeResumeListFilters(args);
@@ -2275,6 +2287,7 @@ export const searchWithTagExpansionPaginated = query({
         locations: v.optional(v.array(v.string())),
         minSalary: v.optional(v.number()),
         maxSalary: v.optional(v.number()),
+        sources: v.optional(v.array(v.string())),
     },
     handler: async (ctx, args) => {
         if (!args.jobDescriptionId?.trim() && !args.sortBy) {


### PR DESCRIPTION
## Summary
- Adds `sources?: string[]` to `ResumeListFilterArgs` and both paginated Convex query handlers (`listWithIngestDataPaginated`, `searchWithTagExpansionPaginated`)
- Server-side source filter matches by `resume.sourceKey` (preferred) or resolves analysis source key from `resume.source` hostname
- Web `useResumeSearchState` now passes `selectedSources` to backend via `backendFilters`, moving source filtering from client-only to server-side
- 3 new test cases: filter by source keys, pass-through for empty sources, hostname-based matching when sourceKey absent

## Test plan
- [x] 3 new unit tests in `resumes-paginated-default.test.ts` pass
- [x] All 26 Convex test files pass (159 tests)
- [x] All 6 shared package test files pass (46 tests)
- [x] `make check` passes cleanly