### PR TITLE
Add Seek -> en content locale resolution to getResumeContentLocale

### DIFF
--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -8,6 +8,7 @@ import {
   computeNormalizedIndustryDbScore,
   getAnalysisForJob,
   getPrecomputedRuleScore,
+  getResumeContentLocale,
   hasIngestData,
   isAutoFilteredAnalysis,
   overrideIndustryDbBreakdown,
@@ -484,5 +485,23 @@ describe('resume-scoring', () => {
       score: 79,
       summary: 'manual lane keyword cache',
     }))
+  })
+})
+
+describe('getResumeContentLocale', () => {
+  it('returns zh-Hans for 51job sources', () => {
+    expect(getResumeContentLocale({ source: 'ehire.51job.com' })).toBe('zh-Hans')
+  })
+
+  it('returns zh-Hant for job5156 sources', () => {
+    expect(getResumeContentLocale({ source: 'hr.job5156.com' })).toBe('zh-Hant')
+  })
+
+  it('returns en for Seek sources', () => {
+    expect(getResumeContentLocale({ source: 'hk.employer.seek.com' })).toBe('en')
+  })
+
+  it('returns undefined when source is missing', () => {
+    expect(getResumeContentLocale({})).toBeUndefined()
   })
 })

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -256,6 +256,9 @@ export function getResumeContentLocale(resume: unknown): string | undefined {
   if (source.includes('job5156')) {
     return 'zh-Hant'
   }
+  if (source.includes('seek')) {
+    return 'en'
+  }
 
   return undefined
 }


### PR DESCRIPTION
## Summary
- `getResumeContentLocale` now returns `'en'` for Seek-sourced resumes, matching the 2026-03-13 design note contract (`Seek -> en`).
- Previously only 51job (`zh-Hans`) and Job5156 (`zh-Hant`) were mapped; Seek returned `undefined`.
- This also enables the `lang="en"` attribute on ResumeCard for Seek resumes, improving screen reader behavior.
- 4 new test cases for `getResumeContentLocale` covering all three source types plus missing source.

## Test plan
- [x] 4 new unit tests in `resume-scoring.test.ts` pass
- [x] All 38 resume-scoring tests pass
- [x] `make check` passes cleanly