### PR TITLE
Add visible content-locale badge to ResumeCard

### DIFF
--- a/apps/web/src/components/ResumeCard.test.tsx
+++ b/apps/web/src/components/ResumeCard.test.tsx
@@ -149,4 +149,54 @@ describe('ResumeCard brand-hit badges', () => {
     expect(screen.queryByText('Rule')).not.toBeInTheDocument()
     expect(screen.queryByText('74')).not.toBeInTheDocument()
   })
+
+  it('shows a content-locale badge when the resume source maps to a locale', () => {
+    render(
+      <ResumeCard
+        resume={{
+          name: 'Bob',
+          profileUrl: 'https://hk.employer.seek.com/candidates/123',
+          activityStatus: 'Active',
+          age: '28',
+          experience: '3 years',
+          education: 'Bachelor',
+          location: 'Kuala Lumpur',
+          selfIntro: 'Experienced sales engineer',
+          jobIntention: 'Sales Engineer',
+          expectedSalary: '8k-12k',
+          workHistory: [],
+          extractedAt: '2026-03-13T00:00:00.000Z',
+          source: 'hk.employer.seek.com',
+        }}
+        onViewDetails={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('EN')).toBeInTheDocument()
+  })
+
+  it('does not show a content-locale badge when no locale is resolved', () => {
+    render(
+      <ResumeCard
+        resume={{
+          name: 'Charlie',
+          profileUrl: 'https://example.com/resume-1',
+          activityStatus: 'Active',
+          age: '35',
+          experience: '10 years',
+          education: 'Master',
+          location: 'Shenzhen',
+          selfIntro: 'Experienced engineer',
+          jobIntention: 'CNC Engineer',
+          expectedSalary: '15k-25k',
+          workHistory: [],
+          extractedAt: '2026-03-13T00:00:00.000Z',
+        }}
+        onViewDetails={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText('EN')).not.toBeInTheDocument()
+    expect(screen.queryByText('ZH')).not.toBeInTheDocument()
+  })
 })

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -396,6 +396,11 @@ export function ResumeCard({
             {sourceLabel}
           </Badge>
         ) : null}
+        {contentLocale ? (
+          <Badge variant="outline" className="border-zinc-200 bg-zinc-50 text-zinc-500 text-[10px]">
+            {contentLocale.startsWith('zh') ? 'ZH' : contentLocale.toUpperCase()}
+          </Badge>
+        ) : null}
         {resume.expectedSalary ? (
           <span className="text-muted-foreground">{resume.expectedSalary}</span>
         ) : null}


### PR DESCRIPTION
## Summary
- Adds a visible content-locale badge ("EN"/"ZH") next to the source badge in ResumeCard
- Resolves design recommendation #5 sub-item: "optional content-locale badge" from the 2026-03-13 source-aware review locale design note
- `getResumeContentLocale` already resolves locale from resume source (51job→zh-Hans, job5156→zh-Hant, seek→en); this PR surfaces it visually

## Test plan
- [x] ResumeCard.test.tsx: verifies "EN" badge appears for Seek source resumes
- [x] ResumeCard.test.tsx: verifies no locale badge when source is missing/unresolvable
- [x] All 6 ResumeCard tests pass
- [x] `make check` passes