### PR TITLE
fix: merge overlapping work-history date ranges in computeWorkHistoryYears

### DIFF
--- a/apps/api/src/services/work-history.test.ts
+++ b/apps/api/src/services/work-history.test.ts
@@ -67,16 +67,38 @@ describe('computeWorkHistoryYears', () => {
     expect(result!).toBeCloseTo(5, 0)
   })
 
-  it('overcounts overlapping date ranges (known gap)', () => {
+  it('merges overlapping date ranges instead of overcounting', () => {
     const entries: ResumeWorkHistoryItem[] = [
       { companyName: 'A', jobTitle: 'Engineer', startDate: '2020-01', endDate: '2024-01' },
       { companyName: 'B', jobTitle: 'Sales', startDate: '2022-01', endDate: '2024-06' },
     ]
     // True span: 2020-01 to 2024-06 = ~4.4 years
-    // Naive sum: 4 + 2.5 = 6.5 years (overcounts ~2 years of overlap)
+    // Naive sum would be 4 + 2.5 = 6.5 years (overcounts ~2 years of overlap)
     const result = computeWorkHistoryYears(entries)
     expect(result).not.toBeNull()
-    expect(result!).toBeGreaterThan(4.4) // confirms overcounting
+    expect(result!).toBeCloseTo(4.4, 0)
+  })
+
+  it('merges fully nested date ranges', () => {
+    const entries: ResumeWorkHistoryItem[] = [
+      { companyName: 'A', jobTitle: 'Engineer', startDate: '2018-01', endDate: '2024-01' },
+      { companyName: 'B', jobTitle: 'Sales', startDate: '2020-01', endDate: '2022-01' },
+    ]
+    // B is fully nested inside A; total span is just A = 6 years
+    const result = computeWorkHistoryYears(entries)
+    expect(result).not.toBeNull()
+    expect(result!).toBeCloseTo(6, 0)
+  })
+
+  it('merges adjacent but non-overlapping entries without dedup', () => {
+    const entries: ResumeWorkHistoryItem[] = [
+      { companyName: 'A', jobTitle: 'Engineer', startDate: '2018-01', endDate: '2020-01' },
+      { companyName: 'B', jobTitle: 'Sales', startDate: '2021-01', endDate: '2024-01' },
+    ]
+    // No overlap: 2 + 3 = 5 years
+    const result = computeWorkHistoryYears(entries)
+    expect(result).not.toBeNull()
+    expect(result!).toBeCloseTo(5, 0)
   })
 
   it('returns null when all entries yield zero years', () => {

--- a/apps/api/src/services/work-history.ts
+++ b/apps/api/src/services/work-history.ts
@@ -104,9 +104,111 @@ export function extractCompanyFromWorkHistory(entry: ResumeWorkHistoryItem): str
 
 export function computeWorkHistoryYears(workHistory: ResumeWorkHistoryItem[], anchorDate?: Date): number | null {
   if (!workHistory.length) return null;
-  let total = 0;
+
+  const resolvedAnchor = resolveAnchorDate(anchorDate);
+
+  // Collect date intervals as [startMonth, endMonth] in month units
+  const intervals: Array<[number, number]> = [];
   for (const entry of workHistory) {
-    total += computeEntryRoleYears(entry, anchorDate);
+    const normalized = normalizeWorkHistoryEntry(entry);
+    if (!normalized) continue;
+
+    // Try structured date fields first
+    const startDate = normalized.startDate;
+    const endDate = normalized.endDate;
+    const startMonthNum = parseYearMonth(startDate);
+
+    if (startMonthNum !== null) {
+      const endMonthNum = endDate
+        ? parseYearMonth(endDate, resolvedAnchor)
+        : null;
+      const effectiveEnd = endMonthNum ?? (resolvedAnchor.getFullYear() * 12 + resolvedAnchor.getMonth() + 1);
+      if (effectiveEnd > startMonthNum) {
+        intervals.push([startMonthNum, effectiveEnd]);
+        continue;
+      }
+    }
+
+    // Fallback: extract interval from raw text via parseRoleYears-style date parsing
+    const rawInterval = parseRawDateInterval(normalized.raw || "", resolvedAnchor);
+    if (rawInterval) {
+      intervals.push(rawInterval);
+    }
   }
-  return total > 0 ? Number(total.toFixed(1)) : null;
+
+  if (!intervals.length) return null;
+
+  // Merge overlapping intervals and sum unique months
+  intervals.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  let totalMonths = 0;
+  let currentStart = intervals[0][0];
+  let currentEnd = intervals[0][1];
+
+  for (let i = 1; i < intervals.length; i++) {
+    const [start, end] = intervals[i];
+    if (start <= currentEnd) {
+      currentEnd = Math.max(currentEnd, end);
+    } else {
+      totalMonths += currentEnd - currentStart;
+      currentStart = start;
+      currentEnd = end;
+    }
+  }
+  totalMonths += currentEnd - currentStart;
+
+  const years = totalMonths / 12;
+  return years > 0 ? Number(years.toFixed(1)) : null;
+}
+
+function parseRawDateInterval(raw: string, anchorDate: Date): [number, number] | null {
+  const text = raw.trim();
+  if (!text) return null;
+
+  // Match date-range patterns in raw text: "YYYY-MM~YYYY-MM" or "YYYY年M月~YYYY年M月"
+  const range = text.match(/(\d{4})[-./年](\d{1,2})?.*?[~至到-]\s*(\d{4})(?:[-./年](\d{1,2}))?/u);
+  if (range) {
+    const startYear = Number(range[1]);
+    const startMonth = Number(range[2] || 1);
+    const endYear = Number(range[3]);
+    const endMonth = Number(range[4] || 1);
+    if ([startYear, startMonth, endYear, endMonth].every(Number.isFinite)) {
+      const start = startYear * 12 + startMonth;
+      const end = endYear * 12 + endMonth;
+      if (end > start) return [start, end];
+    }
+  }
+
+  // Handle 至今/present patterns in raw text
+  const presentMatch = text.match(PRESENT_END_PATTERN);
+  if (presentMatch) {
+    const startYear = Number(presentMatch[1]);
+    const startMonth = Number(presentMatch[2] || 1);
+    if (Number.isFinite(startYear) && Number.isFinite(startMonth)) {
+      const start = startYear * 12 + startMonth;
+      const end = anchorDate.getFullYear() * 12 + anchorDate.getMonth() + 1;
+      if (end > start) return [start, end];
+    }
+  }
+
+  return null;
+}
+
+function parseYearMonth(value: string | undefined, anchorDate?: Date): number | null {
+  if (!value) return null;
+  const normalized = value.trim();
+
+  // Handle 至今/present markers
+  if (/^(?:至今|目前|今|present|current|now|ongoing)$/iu.test(normalized)) {
+    const resolved = resolveAnchorDate(anchorDate);
+    return resolved.getFullYear() * 12 + resolved.getMonth() + 1;
+  }
+
+  const match = normalized.match(/^((?:19|20)\d{2})(?:[-./年](\d{1,2}))?/u);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2] || 1);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || month < 1 || month > 12) return null;
+
+  return year * 12 + month;
 }


### PR DESCRIPTION
## Summary
- Fix `computeWorkHistoryYears` to merge overlapping date intervals instead of naively summing per-entry years
- Add raw-text date interval extraction as fallback when structured `startDate`/`endDate` fields are absent
- Update test expectations from "confirms overcounting" to correct merged values

## Test plan
- [x] New tests for overlapping, fully nested, and non-overlapping entries all pass
- [x] Existing `ingest-compute-service.test.ts` still passes (sample data has non-overlapping entries)
- [x] Full API test suite (384 tests) passes
- [x] Full root test suite (424 tests) passes
- [x] Typecheck passes