### PR TITLE
fix: use locale-aware name sorting instead of hardcoded zh-Hans-CN

### DIFF
--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -59,6 +59,7 @@ import {
   buildResumeKey,
   computeDirectIndustryDb,
   getAnalysisForJob,
+  getNameSortLocale,
   hasIngestData,
   isAutoFilteredAnalysis,
   overrideIndustryDbBreakdown,
@@ -1631,7 +1632,8 @@ export function useResumeListState(loadSearchHistory = false) {
 
     return [...enrichedResumes].sort((a, b) => {
       if (sortBy === 'name') {
-        return a.resume.name.localeCompare(b.resume.name, 'zh-Hans-CN') * direction
+        const locale = getNameSortLocale(a.resume)
+        return a.resume.name.localeCompare(b.resume.name, locale) * direction
       }
 
       if (sortBy === 'experience') {

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -9,6 +9,7 @@ import {
   getAnalysisForJob,
   getPrecomputedRuleScore,
   getResumeContentLocale,
+  getNameSortLocale,
   hasIngestData,
   isAutoFilteredAnalysis,
   overrideIndustryDbBreakdown,
@@ -503,5 +504,23 @@ describe('getResumeContentLocale', () => {
 
   it('returns undefined when source is missing', () => {
     expect(getResumeContentLocale({})).toBeUndefined()
+  })
+})
+
+describe('getNameSortLocale', () => {
+  it('returns en for Seek sources', () => {
+    expect(getNameSortLocale({ source: 'hk.employer.seek.com' })).toBe('en')
+  })
+
+  it('returns zh-Hans-CN for 51job sources', () => {
+    expect(getNameSortLocale({ source: 'ehire.51job.com' })).toBe('zh-Hans-CN')
+  })
+
+  it('returns zh-Hans-CN for job5156 sources', () => {
+    expect(getNameSortLocale({ source: 'hr.job5156.com' })).toBe('zh-Hans-CN')
+  })
+
+  it('returns zh-Hans-CN when source is missing', () => {
+    expect(getNameSortLocale({})).toBe('zh-Hans-CN')
   })
 })

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -263,6 +263,19 @@ export function getResumeContentLocale(resume: unknown): string | undefined {
   return undefined
 }
 
+/**
+ * Returns the appropriate locale for name sorting/collation.
+ * Uses content locale when available, falls back to zh-Hans-CN
+ * for backward compatibility with Chinese-source-only datasets.
+ */
+export function getNameSortLocale(resume: unknown): string {
+  const contentLocale = getResumeContentLocale(resume)
+  if (contentLocale?.startsWith('en')) {
+    return 'en'
+  }
+  return 'zh-Hans-CN'
+}
+
 export function buildResumeKey(resume: ResumeItem, index: number): string {
   return resolveResumeId(resume, index)
 }


### PR DESCRIPTION
## Summary
- Seek resumes with English names were sorted using Chinese locale collation (`zh-Hans-CN`)
- Add `getNameSortLocale()` which resolves sort locale from content locale — English sources get `'en'`, Chinese sources get `'zh-Hans-CN'`, unknown defaults to `'zh-Hans-CN'`
- Update `useResumeListState` name sort comparator to use `getNameSortLocale`

## Test plan
- [x] 4 new tests for `getNameSortLocale` (en, zh-Hans, zh-Hant, undefined)
- [x] Existing `useResumeListState.test.tsx` (53 tests) all pass
- [x] Full test suite (428 tests) passes