### PR TITLE
fix: replace hardcoded Chinese 分 score unit with i18n scoreLabel key

### DIFF
--- a/apps/web/src/components/FilterPanel.tsx
+++ b/apps/web/src/components/FilterPanel.tsx
@@ -87,7 +87,7 @@ export function FilterPanel({
       else items.push(`≤${filters.maxAge}岁`)
     }
 
-    if (filters.minMatchScore) items.push(`≥${filters.minMatchScore}分`)
+    if (filters.minMatchScore) items.push(t('resumes.matching.scoreLabel', { score: `≥${filters.minMatchScore}` }))
 
     if (filters.skills?.length) items.push(filters.skills.join(', '))
     if (filters.locations?.length) items.push(filters.locations.join(', '))

--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -362,7 +362,7 @@ export function ResumeDetail({
                 <h3 className="font-semibold flex items-center gap-2">
                   {t('resumes.detail.aiAnalysis', { defaultValue: 'AI Analysis' })}
                   <Badge variant={matchResult.score >= 80 ? 'default' : matchResult.score >= 60 ? 'secondary' : 'outline'}>
-                    {matchResult.score} 分
+                    {t('resumes.matching.scoreLabel', { score: matchResult.score })}
                   </Badge>
                   <span className="text-xs text-muted-foreground uppercase tracking-wider font-bold">
                     {scoreLabel}


### PR DESCRIPTION
## Summary
- `ResumeDetail.tsx` score badge used hardcoded `{matchResult.score} 分` instead of the existing i18n `scoreLabel` key
- `FilterPanel.tsx` minMatchScore chip used hardcoded `≥N分` instead of the same key
- Both now use `t('resumes.matching.scoreLabel')` which renders `N pts` in English and `N分` in Chinese

## Test plan
- [x] All 428 tests pass
- [x] FilterPanel test passes
- [x] ResumeDetail tests pass
- [x] English locale shows "pts", Chinese locale shows "分"