### PR TITLE
Make formatRoleYears locale-aware instead of hardcoded 年

### DIFF
--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -332,7 +332,7 @@ export function ResumeCard({
       })
     : ''
   const roleEvidenceLabel = primaryRoleSignal
-    ? `${roleTypeLabel}${formatRoleYears(displayRoleYears)}${verifiedRoleYears > 0 ? industryVerifiedSuffix : ''}`
+    ? `${roleTypeLabel}${formatRoleYears(displayRoleYears, contentLocale)}${verifiedRoleYears > 0 ? industryVerifiedSuffix : ''}`
     : null
   const normalizedExperienceLevel = experienceLevel?.trim().toLowerCase()
   const experienceLevelForClick: ExperienceLevelFilter | undefined =
@@ -440,9 +440,9 @@ export function ResumeCard({
               <TooltipContent className="max-w-[320px] text-xs">
                 <div className="space-y-1">
                   <p className="font-semibold">{roleTypeLabel}</p>
-                  <p>{t('resumes.card.relatedYears', { years: formatRoleYears(roleRelevantYears), defaultValue: 'Related years: {{years}}' })}</p>
+                  <p>{t('resumes.card.relatedYears', { years: formatRoleYears(roleRelevantYears, contentLocale), defaultValue: 'Related years: {{years}}' })}</p>
                   {verifiedRoleYears > 0 ? (
-                    <p>{t('resumes.card.industryVerified', { years: formatRoleYears(verifiedRoleYears), defaultValue: 'Industry verified: {{years}}' })}</p>
+                    <p>{t('resumes.card.industryVerified', { years: formatRoleYears(verifiedRoleYears, contentLocale), defaultValue: 'Industry verified: {{years}}' })}</p>
                   ) : null}
                   <p>{t('resumes.card.matchedSignals', { signals: primaryRoleSignal.matchedSignals.slice(0, 6).join(' / ') || '--', defaultValue: 'Matched signals: {{signals}}' })}</p>
                   {primaryRoleSignal.matchedWorkEntries && primaryRoleSignal.matchedWorkEntries.length > 0 ? (
@@ -450,7 +450,7 @@ export function ResumeCard({
                       experience: primaryRoleSignal.matchedWorkEntries
                         .slice(0, 2)
                         .map((entry) =>
-                          [entry.companyName, entry.jobTitle, formatRoleYears(entry.years)].filter(Boolean).join(' · ')
+                          [entry.companyName, entry.jobTitle, formatRoleYears(entry.years, contentLocale)].filter(Boolean).join(' · ')
                         )
                         .join('；'),
                       defaultValue: 'Matched experience: {{experience}}',

--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -331,7 +331,7 @@ export function ResumeDetail({
                               >
                                 {t(`resumes.roleLabels.${annotation.type}`, { defaultValue: getRoleLabel(annotation.type) })}
                                 {' '}
-                                {formatRoleYears(annotation.years)}
+                                {formatRoleYears(annotation.years, contentLocale)}
                               </Badge>
                               {annotation.industryVerified ? (
                                 <Badge variant="outline" className="border-emerald-200 bg-emerald-50 text-emerald-700">

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -6,6 +6,7 @@ import {
   buildRuleScoringText,
   computeDirectIndustryDb,
   computeNormalizedIndustryDbScore,
+  formatRoleYears,
   getAnalysisForJob,
   getPrecomputedRuleScore,
   getResumeContentLocale,
@@ -522,5 +523,30 @@ describe('getNameSortLocale', () => {
 
   it('returns zh-Hans-CN when source is missing', () => {
     expect(getNameSortLocale({})).toBe('zh-Hans-CN')
+  })
+})
+
+describe('formatRoleYears', () => {
+  it('formats years with Chinese suffix by default', () => {
+    expect(formatRoleYears(3)).toBe('3年')
+    expect(formatRoleYears(2.5)).toBe('2.5年')
+  })
+
+  it('formats years with English suffix for en locale', () => {
+    expect(formatRoleYears(3, 'en')).toBe('3 years')
+    expect(formatRoleYears(2.5, 'en')).toBe('2.5 years')
+  })
+
+  it('uses singular "year" for exactly 1 year in English', () => {
+    expect(formatRoleYears(1, 'en')).toBe('1 year')
+  })
+
+  it('returns "0年" for zero/negative years by default', () => {
+    expect(formatRoleYears(0)).toBe('0年')
+    expect(formatRoleYears(-1)).toBe('0年')
+  })
+
+  it('returns "0 years" for zero/negative years in English', () => {
+    expect(formatRoleYears(0, 'en')).toBe('0 years')
   })
 })

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -137,14 +137,19 @@ export function getRoleLabel(type: string): string {
   return ROLE_LABELS[normalized] ?? type
 }
 
-export function formatRoleYears(years: number): string {
+export function formatRoleYears(years: number, locale?: string): string {
   if (!Number.isFinite(years) || years <= 0) {
-    return '0年'
+    return locale?.startsWith('en') ? '0 years' : '0年'
   }
 
   const rounded = Math.round(years * 10) / 10
   const label = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1)
-  return `${label.replace(/\.0$/, '')}年`
+  const value = label.replace(/\.0$/, '')
+
+  if (locale?.startsWith('en')) {
+    return years === 1 ? '1 year' : `${value} years`
+  }
+  return `${value}年`
 }
 
 export function getRoleRelevantYears(signal: Pick<ResumeRoleSignalLike, 'roleRelevantYears' | 'years'>): number {


### PR DESCRIPTION
## Summary
- `formatRoleYears` now accepts an optional `locale` parameter: `"3年"` for Chinese (default, unchanged) vs `"3 years"` / `"1 year"` for English
- All call sites in `ResumeCard` and `ResumeDetail` now pass `contentLocale` so Seek resumes display English year suffixes

## Test plan
- [x] `npm test` — 703 tests pass
- [x] `make check` — all checks pass
- [x] New tests: 5 `formatRoleYears` locale tests (Chinese default, English plural/singular, zero years)