### PR TITLE
fix: extract filter helpers from useResumeListState for testability

### DIFF
--- a/apps/web/src/hooks/resume-filter-helpers.test.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest'
+import type { CandidateStatus } from '@/types/resume'
+
+import {
+  getRoleYears,
+  matchesAllRequiredKeywords,
+  matchesEducationFilter,
+  normalizeFilterToken,
+  parseSalaryRange,
+  toStatusFilterList,
+} from './resume-filter-helpers.js'
+
+import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+
+describe('normalizeFilterToken', () => {
+  it('trims and lowercases input', () => {
+    expect(normalizeFilterToken('  CNC  ')).toBe('cnc')
+  })
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(normalizeFilterToken('   ')).toBe('')
+  })
+
+  it('lowercases Chinese text', () => {
+    // Chinese has no case; returns trimmed
+    expect(normalizeFilterToken(' 销售 ')).toBe('销售')
+  })
+})
+
+describe('matchesEducationFilter', () => {
+  it('returns true when no education levels are selected', () => {
+    expect(matchesEducationFilter('本科', [])).toBe(true)
+  })
+
+  it('matches bachelor education (本科) against bachelor filter', () => {
+    expect(matchesEducationFilter('本科', ['bachelor'])).toBe(true)
+  })
+
+  it('matches master education (硕士) against master filter', () => {
+    expect(matchesEducationFilter('硕士', ['master'])).toBe(true)
+  })
+
+  it('does not match high school against bachelor filter', () => {
+    expect(matchesEducationFilter('高中', ['bachelor'])).toBe(false)
+  })
+
+  it('returns false when education value is undefined and filters are set', () => {
+    expect(matchesEducationFilter(undefined, ['bachelor'])).toBe(false)
+  })
+
+  it('matches when any selected level matches', () => {
+    expect(matchesEducationFilter('大专', ['bachelor', 'associate'])).toBe(true)
+  })
+
+  it('matches phd filter against 博士', () => {
+    expect(matchesEducationFilter('博士', ['phd'])).toBe(true)
+  })
+
+  it('matches English "bachelor" against bachelor filter', () => {
+    expect(matchesEducationFilter('bachelor degree', ['bachelor'])).toBe(true)
+  })
+})
+
+describe('parseSalaryRange', () => {
+  it('parses a simple salary range string', () => {
+    const result = parseSalaryRange('10-20')
+    expect(result).not.toBeNull()
+    expect(result!.min).toBe(10)
+    expect(result!.max).toBe(20)
+  })
+
+  it('parses a single numeric value', () => {
+    const result = parseSalaryRange('15')
+    expect(result).not.toBeNull()
+    expect(result!.min).toBe(15)
+    expect(result!.max).toBeUndefined()
+  })
+
+  it('returns null for empty string', () => {
+    expect(parseSalaryRange('')).toBeNull()
+  })
+
+  it('returns null for 面议 (negotiable)', () => {
+    expect(parseSalaryRange('面议')).toBeNull()
+  })
+
+  it('returns null for undefined input', () => {
+    expect(parseSalaryRange(undefined)).toBeNull()
+  })
+
+  it('parses salary with spaces', () => {
+    const result = parseSalaryRange('10 - 20')
+    expect(result).not.toBeNull()
+    expect(result!.min).toBe(10)
+  })
+
+  it('parses salary with decimal values', () => {
+    const result = parseSalaryRange('12.5-18.5')
+    expect(result).not.toBeNull()
+    expect(result!.min).toBe(12.5)
+    expect(result!.max).toBe(18.5)
+  })
+})
+
+describe('toStatusFilterList', () => {
+  it('returns empty array for undefined input', () => {
+    expect(toStatusFilterList(undefined)).toEqual([])
+  })
+
+  it('filters to only valid candidate statuses', () => {
+    const result = toStatusFilterList(['new', 'hired'] as CandidateStatus[])
+    // Invalid values like 'invalid' would be filtered out by the type system
+    // and by the function's runtime guard
+    expect(result).toEqual(['hired', 'new'])
+  })
+
+  it('deduplicates statuses', () => {
+    const result = toStatusFilterList(['new', 'new', 'hired'] as Array<'new' | 'hired'>)
+    expect(result).toEqual(['hired', 'new'])
+  })
+
+  it('sorts statuses alphabetically', () => {
+    const result = toStatusFilterList(['hired', 'new', 'contacted'] as Array<'hired' | 'new' | 'contacted'>)
+    expect(result).toEqual(['contacted', 'hired', 'new'])
+  })
+
+  it('accepts all valid statuses', () => {
+    const all = ['new', 'contacted', 'interviewing', 'interviewed_pass', 'interviewed_reject', 'offer', 'hired', 'withdrawn'] as const
+    const result = toStatusFilterList([...all])
+    expect(result).toHaveLength(8)
+  })
+})
+
+describe('getRoleYears', () => {
+  function makeResume(roleSignals: Array<{ type: string; years: number; roleRelevantYears?: number }>): Pick<ConvexResumeItem, 'ingestData'> {
+    return {
+      ingestData: {
+        evidenceText: '',
+        industryTags: [],
+        synonymHits: [],
+        brandHits: [],
+        companyHits: [],
+        industryDbV2Raw: 0,
+        roleSignals: roleSignals.map((s) => ({
+          type: s.type,
+          matchedSignals: [],
+          signalCount: 1,
+          occurrences: 1,
+          years: s.years,
+          industryVerifiedYears: 0,
+          verifyIn: '',
+          ...(s.roleRelevantYears !== undefined ? { roleRelevantYears: s.roleRelevantYears } : {}),
+        })),
+        ruleScores: {},
+        experienceLevel: 'mid',
+        computedAt: 0,
+        skillsVersion: 1,
+      },
+    }
+  }
+
+  it('returns 0 when ingestData has no roleSignals', () => {
+    const resume = makeResume([])
+    expect(getRoleYears(resume, '')).toBe(0)
+  })
+
+  it('returns max years across all signals when roleType is empty', () => {
+    const resume = makeResume([
+      { type: 'sales', years: 5 },
+      { type: 'engineer', years: 8 },
+    ])
+    expect(getRoleYears(resume, '')).toBe(8)
+  })
+
+  it('returns roleRelevantYears when available for matching roleType', () => {
+    const resume = makeResume([
+      { type: 'sales', years: 8, roleRelevantYears: 5 },
+    ])
+    expect(getRoleYears(resume, 'sales')).toBe(5)
+  })
+
+  it('falls back to years when roleRelevantYears is absent for matching roleType', () => {
+    const resume = makeResume([
+      { type: 'sales', years: 6 },
+    ])
+    expect(getRoleYears(resume, 'sales')).toBe(6)
+  })
+
+  it('returns 0 when no signal matches the specified roleType', () => {
+    const resume = makeResume([
+      { type: 'engineer', years: 10 },
+    ])
+    expect(getRoleYears(resume, 'sales')).toBe(0)
+  })
+
+  it('ignores NaN and Infinity roleRelevantYears', () => {
+    const resume = makeResume([
+      { type: 'sales', years: 5, roleRelevantYears: NaN },
+    ])
+    expect(getRoleYears(resume, 'sales')).toBe(5)
+  })
+
+  it('is case-insensitive for roleType matching', () => {
+    const resume = makeResume([
+      { type: 'Sales', years: 7 },
+    ])
+    expect(getRoleYears(resume, 'sales')).toBe(7)
+  })
+})
+
+describe('matchesAllRequiredKeywords', () => {
+  it('returns true when requiredKeywords is empty', () => {
+    expect(matchesAllRequiredKeywords('some text', [])).toBe(true)
+  })
+
+  it('returns true when all keywords are present in text', () => {
+    expect(matchesAllRequiredKeywords('CNC 销售工程师', ['CNC', '销售'])).toBe(true)
+  })
+
+  it('returns false when any keyword is missing from text', () => {
+    expect(matchesAllRequiredKeywords('CNC 工程师', ['CNC', '销售'])).toBe(false)
+  })
+
+  it('returns false for empty text with non-empty keywords', () => {
+    expect(matchesAllRequiredKeywords('', ['CNC'])).toBe(false)
+  })
+
+  it('is case-insensitive for keyword matching', () => {
+    expect(matchesAllRequiredKeywords('cnc engineer', ['CNC'])).toBe(true)
+  })
+
+  it('ignores whitespace-only keywords', () => {
+    expect(matchesAllRequiredKeywords('CNC', ['CNC', '  '])).toBe(true)
+  })
+})

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -1,0 +1,130 @@
+import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+
+import type { CandidateStatus } from '@/types/resume'
+
+const EDUCATION_KEYWORDS: Record<string, string[]> = {
+  high_school: ['高中', '中专', '技校', 'high school'],
+  associate: ['大专', '专科', 'associate'],
+  bachelor: ['本科', '学士', 'bachelor'],
+  master: ['硕士', '研究生', 'master'],
+  phd: ['博士', 'phd', 'doctor'],
+}
+
+export function normalizeFilterToken(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+export function matchesEducationFilter(educationValue: string | undefined, selectedEducation: string[]): boolean {
+  if (selectedEducation.length === 0) {
+    return true
+  }
+
+  const normalizedEducation = normalizeFilterToken(educationValue ?? '')
+  if (!normalizedEducation) {
+    return false
+  }
+
+  return selectedEducation.some((level) => {
+    const keywords = EDUCATION_KEYWORDS[level]
+    if (!keywords || keywords.length === 0) {
+      return false
+    }
+
+    return keywords.some((keyword) => normalizedEducation.includes(normalizeFilterToken(keyword)))
+  })
+}
+
+export function parseSalaryRange(value: string | undefined): { min?: number; max?: number } | null {
+  if (!value) {
+    return null
+  }
+
+  const normalized = value.replace(/\s/g, '')
+  if (!normalized || /面议/.test(normalized)) {
+    return null
+  }
+
+  const match = normalized.match(/(\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?/)
+  if (!match) {
+    return null
+  }
+
+  const min = Number(match[1])
+  const max = match[2] ? Number(match[2]) : undefined
+  if (Number.isNaN(min)) {
+    return null
+  }
+
+  return { min, max }
+}
+
+export function toStatusFilterList(values: CandidateStatus[] | undefined): CandidateStatus[] {
+  if (!Array.isArray(values)) {
+    return []
+  }
+
+  const unique = new Set<CandidateStatus>()
+  values.forEach((value) => {
+    if (
+      value === 'new'
+      || value === 'contacted'
+      || value === 'interviewing'
+      || value === 'interviewed_pass'
+      || value === 'interviewed_reject'
+      || value === 'offer'
+      || value === 'hired'
+      || value === 'withdrawn'
+    ) {
+      unique.add(value)
+    }
+  })
+  return Array.from(unique).sort()
+}
+
+export function getRoleYears(resume: Pick<ConvexResumeItem, 'ingestData'>, roleType: string): number {
+  const roleSignals = resume.ingestData?.roleSignals
+  if (!Array.isArray(roleSignals) || roleSignals.length === 0) {
+    return 0
+  }
+
+  const normalizedRoleType = normalizeFilterToken(roleType)
+  if (!normalizedRoleType) {
+    return roleSignals.reduce((maxYears, signal) => {
+      const relevantYears =
+        typeof signal.roleRelevantYears === 'number' && Number.isFinite(signal.roleRelevantYears)
+          ? signal.roleRelevantYears
+          : signal.years
+      if (typeof relevantYears !== 'number' || !Number.isFinite(relevantYears)) {
+        return maxYears
+      }
+      return Math.max(maxYears, relevantYears)
+    }, 0)
+  }
+
+  const roleSignal = roleSignals.find((signal) => normalizeFilterToken(signal.type) === normalizedRoleType)
+  const relevantYears =
+    typeof roleSignal?.roleRelevantYears === 'number' && Number.isFinite(roleSignal.roleRelevantYears)
+      ? roleSignal.roleRelevantYears
+      : roleSignal?.years
+  if (!roleSignal || typeof relevantYears !== 'number' || !Number.isFinite(relevantYears)) {
+    return 0
+  }
+  return relevantYears
+}
+
+export function matchesAllRequiredKeywords(text: string, requiredKeywords: string[]): boolean {
+  const normalizedKeywords = requiredKeywords
+    .map((keyword) => normalizeFilterToken(keyword))
+    .filter((keyword) => keyword.length > 0)
+
+  if (normalizedKeywords.length === 0) {
+    return true
+  }
+
+  const haystack = text.trim().toLowerCase()
+  if (!haystack) {
+    return false
+  }
+
+  return normalizedKeywords.every((keyword) => haystack.includes(keyword))
+}

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -28,6 +28,14 @@ import { useCandidateActions } from '@/hooks/useCandidateActions'
 import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
 import { useCandidateStatus, type CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 import {
+  getRoleYears,
+  matchesAllRequiredKeywords,
+  matchesEducationFilter,
+  normalizeFilterToken,
+  parseSalaryRange,
+  toStatusFilterList,
+} from '@/hooks/resume-filter-helpers'
+import {
   hasKnownUrlSearchParams,
   parseUrlSearchState,
   useUrlSearchState,
@@ -265,10 +273,6 @@ function taskMatchesCurrentSearch(
   return false
 }
 
-function normalizeFilterToken(value: string): string {
-  return value.trim().toLowerCase()
-}
-
 function getResumeLocationText(
   resume: { location?: string; locationHierarchy?: { country: string; province?: string; city?: string; district?: string } }
 ): string {
@@ -315,60 +319,6 @@ function getResumeIdentityKey(resume: ConvexResumeItem, fallback: string): strin
   return fallback
 }
 
-function toStatusFilterList(values: CandidateStatus[] | undefined): CandidateStatus[] {
-  if (!Array.isArray(values)) {
-    return []
-  }
-
-  const unique = new Set<CandidateStatus>()
-  values.forEach((value) => {
-    if (
-      value === 'new'
-      || value === 'contacted'
-      || value === 'interviewing'
-      || value === 'interviewed_pass'
-      || value === 'interviewed_reject'
-      || value === 'offer'
-      || value === 'hired'
-      || value === 'withdrawn'
-    ) {
-      unique.add(value)
-    }
-  })
-  return Array.from(unique).sort()
-}
-
-function getRoleYears(resume: ConvexResumeItem, roleType: string): number {
-  const roleSignals = resume.ingestData?.roleSignals
-  if (!Array.isArray(roleSignals) || roleSignals.length === 0) {
-    return 0
-  }
-
-  const normalizedRoleType = normalizeFilterToken(roleType)
-  if (!normalizedRoleType) {
-    return roleSignals.reduce((maxYears, signal) => {
-      const relevantYears =
-        typeof signal.roleRelevantYears === 'number' && Number.isFinite(signal.roleRelevantYears)
-          ? signal.roleRelevantYears
-          : signal.years
-      if (typeof relevantYears !== 'number' || !Number.isFinite(relevantYears)) {
-        return maxYears
-      }
-      return Math.max(maxYears, relevantYears)
-    }, 0)
-  }
-
-  const roleSignal = roleSignals.find((signal) => normalizeFilterToken(signal.type) === normalizedRoleType)
-  const relevantYears =
-    typeof roleSignal?.roleRelevantYears === 'number' && Number.isFinite(roleSignal.roleRelevantYears)
-      ? roleSignal.roleRelevantYears
-      : roleSignal?.years
-  if (!roleSignal || typeof relevantYears !== 'number' || !Number.isFinite(relevantYears)) {
-    return 0
-  }
-  return relevantYears
-}
-
 function parseExtractedAt(value: string | undefined): number {
   if (!value) {
     return 0
@@ -376,58 +326,6 @@ function parseExtractedAt(value: string | undefined): number {
 
   const timestamp = Date.parse(value)
   return Number.isFinite(timestamp) ? timestamp : 0
-}
-
-const EDUCATION_KEYWORDS: Record<string, string[]> = {
-  high_school: ['高中', '中专', '技校', 'high school'],
-  associate: ['大专', '专科', 'associate'],
-  bachelor: ['本科', '学士', 'bachelor'],
-  master: ['硕士', '研究生', 'master'],
-  phd: ['博士', 'phd', 'doctor'],
-}
-
-function matchesEducationFilter(educationValue: string | undefined, selectedEducation: string[]): boolean {
-  if (selectedEducation.length === 0) {
-    return true
-  }
-
-  const normalizedEducation = normalizeFilterToken(educationValue ?? '')
-  if (!normalizedEducation) {
-    return false
-  }
-
-  return selectedEducation.some((level) => {
-    const keywords = EDUCATION_KEYWORDS[level]
-    if (!keywords || keywords.length === 0) {
-      return false
-    }
-
-    return keywords.some((keyword) => normalizedEducation.includes(normalizeFilterToken(keyword)))
-  })
-}
-
-function parseSalaryRange(value: string | undefined): { min?: number; max?: number } | null {
-  if (!value) {
-    return null
-  }
-
-  const normalized = value.replace(/\s/g, '')
-  if (!normalized || /面议/.test(normalized)) {
-    return null
-  }
-
-  const match = normalized.match(/(\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?/)
-  if (!match) {
-    return null
-  }
-
-  const min = Number(match[1])
-  const max = match[2] ? Number(match[2]) : undefined
-  if (Number.isNaN(min)) {
-    return null
-  }
-
-  return { min, max }
 }
 
 function buildResumeFilterSearchText(resume: ConvexResumeItem): string {
@@ -443,23 +341,6 @@ function buildResumeFilterSearchText(resume: ConvexResumeItem): string {
     .map((value) => value.trim().toLowerCase())
     .filter((value) => value.length > 0)
     .join(' ')
-}
-
-function matchesAllRequiredKeywords(text: string, requiredKeywords: string[]): boolean {
-  const normalizedKeywords = normalizeKeywordPhrases(requiredKeywords)
-    .map((keyword) => normalizeFilterToken(keyword))
-    .filter((keyword) => keyword.length > 0)
-
-  if (normalizedKeywords.length === 0) {
-    return true
-  }
-
-  const haystack = text.trim().toLowerCase()
-  if (!haystack) {
-    return false
-  }
-
-  return normalizedKeywords.every((keyword) => haystack.includes(keyword))
 }
 
 export function useResumeListState(loadSearchHistory = false) {


### PR DESCRIPTION
## Summary
- Extract 6 pure filter functions from `useResumeListState.ts` into `resume-filter-helpers.ts`: `normalizeFilterToken`, `matchesEducationFilter`, `parseSalaryRange`, `toStatusFilterList`, `getRoleYears`, `matchesAllRequiredKeywords`
- Add 36 direct unit tests covering all extracted functions with edge cases
- `useResumeListState.ts` now imports from `resume-filter-helpers` instead of defining inline

## Test plan
- [x] `npx vitest run src/hooks/resume-filter-helpers.test.ts` — 36/36 pass
- [x] `npx vitest run src/hooks/useResumeListState.test.tsx` — 53/53 pass (refactoring preserves behavior)
- [x] `make check` — all checks pass