### PR TITLE
fix: extract more pure filter helpers with 25 tests

### DIFF
--- a/apps/web/src/hooks/resume-filter-helpers.test.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from 'vitest'
 import type { CandidateStatus } from '@/types/resume'
 
 import {
+  areKeywordListsEqual,
   getRoleYears,
   matchesAllRequiredKeywords,
   matchesEducationFilter,
   normalizeFilterToken,
+  normalizeKeywordFingerprint,
+  parseExtractedAt,
+  parseSerializedStringArray,
   parseSalaryRange,
+  toExperienceLevel,
   toStatusFilterList,
 } from './resume-filter-helpers.js'
 
@@ -231,5 +236,118 @@ describe('matchesAllRequiredKeywords', () => {
 
   it('ignores whitespace-only keywords', () => {
     expect(matchesAllRequiredKeywords('CNC', ['CNC', '  '])).toBe(true)
+  })
+})
+
+describe('normalizeKeywordFingerprint', () => {
+  it('returns empty string for undefined', () => {
+    expect(normalizeKeywordFingerprint(undefined)).toBe('')
+  })
+
+  it('returns empty string for empty array', () => {
+    expect(normalizeKeywordFingerprint([])).toBe('')
+  })
+
+  it('normalizes, deduplicates, sorts and joins keywords', () => {
+    // 'CNC' and 'cnc' should dedup; sorted alphabetically
+    expect(normalizeKeywordFingerprint(['销售', 'CNC', 'cnc'])).toBe('cnc|销售')
+  })
+
+  it('trims whitespace from keywords', () => {
+    expect(normalizeKeywordFingerprint(['  CNC  ', ' 销售 '])).toBe('cnc|销售')
+  })
+})
+
+describe('areKeywordListsEqual', () => {
+  it('returns true for two undefined lists', () => {
+    expect(areKeywordListsEqual(undefined, undefined)).toBe(true)
+  })
+
+  it('returns true for identical keyword arrays', () => {
+    expect(areKeywordListsEqual(['CNC', '销售'], ['CNC', '销售'])).toBe(true)
+  })
+
+  it('returns true for same keywords in different order', () => {
+    expect(areKeywordListsEqual(['销售', 'CNC'], ['CNC', '销售'])).toBe(true)
+  })
+
+  it('returns true for case-insensitive match', () => {
+    expect(areKeywordListsEqual(['cnc'], ['CNC'])).toBe(true)
+  })
+
+  it('returns false for different keywords', () => {
+    expect(areKeywordListsEqual(['CNC'], ['销售'])).toBe(false)
+  })
+
+  it('returns false when one is empty and the other is not', () => {
+    expect(areKeywordListsEqual([], ['CNC'])).toBe(false)
+  })
+})
+
+describe('parseExtractedAt', () => {
+  it('returns 0 for undefined', () => {
+    expect(parseExtractedAt(undefined)).toBe(0)
+  })
+
+  it('returns 0 for empty string', () => {
+    expect(parseExtractedAt('')).toBe(0)
+  })
+
+  it('returns 0 for invalid date string', () => {
+    expect(parseExtractedAt('not-a-date')).toBe(0)
+  })
+
+  it('parses valid ISO date string to timestamp', () => {
+    const result = parseExtractedAt('2026-04-24T00:00:00.000Z')
+    expect(result).toBeGreaterThan(0)
+    expect(typeof result).toBe('number')
+  })
+})
+
+describe('parseSerializedStringArray', () => {
+  it('parses valid JSON string array', () => {
+    expect(parseSerializedStringArray('["a","b","c"]')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns empty array for invalid JSON', () => {
+    expect(parseSerializedStringArray('not-json')).toEqual([])
+  })
+
+  it('filters out non-string items', () => {
+    expect(parseSerializedStringArray('[1, "ok", null, true]')).toEqual(['ok'])
+  })
+
+  it('returns empty array for JSON non-array', () => {
+    expect(parseSerializedStringArray('{"key":"val"}')).toEqual([])
+  })
+})
+
+describe('toExperienceLevel', () => {
+  it('returns undefined for undefined', () => {
+    expect(toExperienceLevel(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for empty string', () => {
+    expect(toExperienceLevel('')).toBeUndefined()
+  })
+
+  it('returns "senior" for "senior"', () => {
+    expect(toExperienceLevel('senior')).toBe('senior')
+  })
+
+  it('returns "mid" for "mid"', () => {
+    expect(toExperienceLevel('mid')).toBe('mid')
+  })
+
+  it('returns "junior" for "junior"', () => {
+    expect(toExperienceLevel('junior')).toBe('junior')
+  })
+
+  it('is case-insensitive', () => {
+    expect(toExperienceLevel('Senior')).toBe('senior')
+  })
+
+  it('returns undefined for unrecognized value', () => {
+    expect(toExperienceLevel('expert')).toBeUndefined()
   })
 })

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -1,4 +1,6 @@
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+import { normalizeKeywordPhrases } from '@trends/shared'
+import type { ExperienceLevelFilter } from '@/hooks/useUrlSearchState'
 
 import type { CandidateStatus } from '@/types/resume'
 
@@ -127,4 +129,49 @@ export function matchesAllRequiredKeywords(text: string, requiredKeywords: strin
   }
 
   return normalizedKeywords.every((keyword) => haystack.includes(keyword))
+}
+
+export function normalizeKeywordFingerprint(keywords: readonly string[] | undefined): string {
+  if (!Array.isArray(keywords) || keywords.length === 0) {
+    return ''
+  }
+
+  return normalizeKeywordPhrases([...keywords])
+    .map((keyword) => keyword.toLowerCase())
+    .sort()
+    .join('|')
+}
+
+export function areKeywordListsEqual(left: readonly string[] | undefined, right: readonly string[] | undefined): boolean {
+  return normalizeKeywordFingerprint(left) === normalizeKeywordFingerprint(right)
+}
+
+export function parseExtractedAt(value: string | undefined): number {
+  if (!value) {
+    return 0
+  }
+
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+export function parseSerializedStringArray(value: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+export function toExperienceLevel(value: string | undefined): ExperienceLevelFilter | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const normalized = normalizeFilterToken(value)
+  if (normalized === 'senior') return 'senior'
+  if (normalized === 'mid') return 'mid'
+  if (normalized === 'junior') return 'junior'
+  return undefined
 }

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -6,7 +6,6 @@ import {
   formatKeywordQuery,
   formatLocationHierarchySearchText,
   isLocationMatch,
-  normalizeKeywordPhrases,
   selectLatestWorkHistory,
 } from '@trends/shared'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -28,20 +27,25 @@ import { useCandidateActions } from '@/hooks/useCandidateActions'
 import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
 import { useCandidateStatus, type CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 import {
+  areKeywordListsEqual,
   getRoleYears,
   matchesAllRequiredKeywords,
   matchesEducationFilter,
   normalizeFilterToken,
+  normalizeKeywordFingerprint,
+  parseExtractedAt,
   parseSalaryRange,
+  parseSerializedStringArray,
+  toExperienceLevel,
   toStatusFilterList,
 } from '@/hooks/resume-filter-helpers'
 import {
   hasKnownUrlSearchParams,
   parseUrlSearchState,
   useUrlSearchState,
-  type ExperienceLevelFilter,
   type UrlSearchState,
 } from '@/hooks/useUrlSearchState'
+import type { ExperienceLevelFilter } from '@/hooks/useUrlSearchState'
 import { rawApiClient } from '@/lib/api-helpers'
 import {
   getCurrentResumeAiPromptVersion,
@@ -111,21 +115,6 @@ type EnrichedResume = {
 }
 
 type AnalysisTaskDoc = Doc<'analysis_tasks'>
-
-function normalizeKeywordFingerprint(keywords: readonly string[] | undefined): string {
-  if (!Array.isArray(keywords) || keywords.length === 0) {
-    return ''
-  }
-
-  return normalizeKeywordPhrases([...keywords])
-    .map((keyword) => keyword.toLowerCase())
-    .sort()
-    .join('|')
-}
-
-function areKeywordListsEqual(left: readonly string[] | undefined, right: readonly string[] | undefined): boolean {
-  return normalizeKeywordFingerprint(left) === normalizeKeywordFingerprint(right)
-}
 
 function appendKeywordToken(current: string[], token: string): string[] {
   const normalizedToken = token.trim()
@@ -290,42 +279,12 @@ function resolveAnalysisSourceKeyForResume(
     })
 }
 
-function parseSerializedStringArray(value: string): string[] {
-  try {
-    const parsed: unknown = JSON.parse(value)
-    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : []
-  } catch {
-    return []
-  }
-}
-
-function toExperienceLevel(value: string | undefined): ExperienceLevelFilter | undefined {
-  if (!value) {
-    return undefined
-  }
-
-  const normalized = normalizeFilterToken(value)
-  if (normalized === 'senior') return 'senior'
-  if (normalized === 'mid') return 'mid'
-  if (normalized === 'junior') return 'junior'
-  return undefined
-}
-
 function getResumeIdentityKey(resume: ConvexResumeItem, fallback: string): string {
   const identityKey = resume.identityKey?.trim()
   if (identityKey) {
     return identityKey
   }
   return fallback
-}
-
-function parseExtractedAt(value: string | undefined): number {
-  if (!value) {
-    return 0
-  }
-
-  const timestamp = Date.parse(value)
-  return Number.isFinite(timestamp) ? timestamp : 0
 }
 
 function buildResumeFilterSearchText(resume: ConvexResumeItem): string {


### PR DESCRIPTION
## Summary
- Extract 5 pure functions from `useResumeListState.ts` into `resume-filter-helpers.ts`: `normalizeKeywordFingerprint`, `areKeywordListsEqual`, `parseExtractedAt`, `parseSerializedStringArray`, `toExperienceLevel`
- Add 25 direct unit tests (61 total in file, up from 36)
- Remove unused `normalizeKeywordPhrases` import from `useResumeListState.ts`

## Test plan
- [x] 61 unit tests pass in `resume-filter-helpers.test.ts`
- [x] 53 integration tests still pass in `useResumeListState.test.tsx`
- [x] `make check` passes (typecheck + lint + governance)