### PR TITLE
fix: extract 5 more utility helpers into resume-filter-helpers

### DIFF
--- a/apps/web/src/hooks/resume-filter-helpers.test.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.test.ts
@@ -2,15 +2,20 @@ import { describe, expect, it } from 'vitest'
 import type { CandidateStatus } from '@/types/resume'
 
 import {
+  appendKeywordToken,
   areKeywordListsEqual,
   getRoleYears,
   matchesAllRequiredKeywords,
   matchesEducationFilter,
+  normalizeFilterList,
   normalizeFilterToken,
   normalizeKeywordFingerprint,
+  normalizeOptionalNumber,
+  normalizeOptionalString,
   parseExtractedAt,
   parseSerializedStringArray,
   parseSalaryRange,
+  serializeLocationFilter,
   toExperienceLevel,
   toStatusFilterList,
 } from './resume-filter-helpers.js'
@@ -349,5 +354,106 @@ describe('toExperienceLevel', () => {
 
   it('returns undefined for unrecognized value', () => {
     expect(toExperienceLevel('expert')).toBeUndefined()
+  })
+})
+
+describe('normalizeOptionalNumber', () => {
+  it('returns undefined for undefined', () => {
+    expect(normalizeOptionalNumber(undefined)).toBeUndefined()
+  })
+
+  it('returns the number for finite values', () => {
+    expect(normalizeOptionalNumber(5)).toBe(5)
+  })
+
+  it('returns undefined for NaN', () => {
+    expect(normalizeOptionalNumber(NaN)).toBeUndefined()
+  })
+
+  it('returns undefined for Infinity', () => {
+    expect(normalizeOptionalNumber(Infinity)).toBeUndefined()
+  })
+
+  it('returns undefined for negative Infinity', () => {
+    expect(normalizeOptionalNumber(-Infinity)).toBeUndefined()
+  })
+
+  it('returns 0 for zero', () => {
+    expect(normalizeOptionalNumber(0)).toBe(0)
+  })
+})
+
+describe('normalizeOptionalString', () => {
+  it('returns undefined for undefined', () => {
+    expect(normalizeOptionalString(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for empty string', () => {
+    expect(normalizeOptionalString('')).toBeUndefined()
+  })
+
+  it('returns undefined for whitespace-only string', () => {
+    expect(normalizeOptionalString('   ')).toBeUndefined()
+  })
+
+  it('returns trimmed string for valid input', () => {
+    expect(normalizeOptionalString('  CNC  ')).toBe('CNC')
+  })
+})
+
+describe('normalizeFilterList', () => {
+  it('returns undefined for undefined', () => {
+    expect(normalizeFilterList(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for empty array', () => {
+    expect(normalizeFilterList([])).toBeUndefined()
+  })
+
+  it('normalizes, deduplicates, and sorts tokens', () => {
+    expect(normalizeFilterList(['CNC', 'cnc', '销售'])).toEqual(['cnc', '销售'])
+  })
+
+  it('filters out empty and whitespace tokens', () => {
+    expect(normalizeFilterList(['CNC', '', '  '])).toEqual(['cnc'])
+  })
+})
+
+describe('serializeLocationFilter', () => {
+  it('returns empty string for undefined', () => {
+    expect(serializeLocationFilter(undefined)).toBe('')
+  })
+
+  it('returns empty string for empty array', () => {
+    expect(serializeLocationFilter([])).toBe('')
+  })
+
+  it('joins trimmed values with comma', () => {
+    expect(serializeLocationFilter(['  广东  ', '深圳'])).toBe('广东,深圳')
+  })
+
+  it('deduplicates case-insensitively but preserves first occurrence casing', () => {
+    const result = serializeLocationFilter(['Guangdong', 'guangdong'])
+    expect(result).toBe('Guangdong')
+  })
+
+  it('filters out empty and whitespace-only values', () => {
+    expect(serializeLocationFilter(['广东', '', '  ', '深圳'])).toBe('广东,深圳')
+  })
+})
+
+describe('appendKeywordToken', () => {
+  it('appends trimmed token to array', () => {
+    expect(appendKeywordToken(['CNC'], ' 销售 ')).toEqual(['CNC', '销售'])
+  })
+
+  it('returns unchanged array for whitespace-only token', () => {
+    const arr = ['CNC']
+    expect(appendKeywordToken(arr, '   ')).toBe(arr)
+  })
+
+  it('returns unchanged array for empty token', () => {
+    const arr = ['CNC']
+    expect(appendKeywordToken(arr, '')).toBe(arr)
   })
 })

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -175,3 +175,67 @@ export function toExperienceLevel(value: string | undefined): ExperienceLevelFil
   if (normalized === 'junior') return 'junior'
   return undefined
 }
+
+export function normalizeOptionalNumber(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+export function normalizeOptionalString(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : undefined
+}
+
+export function normalizeFilterList(values: string[] | undefined): string[] | undefined {
+  if (!Array.isArray(values) || values.length === 0) {
+    return undefined
+  }
+
+  const seen = new Set<string>()
+  const normalized: string[] = []
+
+  values.forEach((value) => {
+    const token = normalizeFilterToken(value)
+    if (!token || seen.has(token)) {
+      return
+    }
+    seen.add(token)
+    normalized.push(token)
+  })
+
+  return normalized.sort()
+}
+
+export function serializeLocationFilter(values: string[] | undefined): string {
+  if (!Array.isArray(values) || values.length === 0) {
+    return ''
+  }
+
+  const seen = new Set<string>()
+  const normalized: string[] = []
+
+  values.forEach((value) => {
+    const trimmed = value.trim()
+    const key = trimmed.toLowerCase()
+    if (!trimmed || seen.has(key)) {
+      return
+    }
+
+    seen.add(key)
+    normalized.push(trimmed)
+  })
+
+  return normalized.join(',')
+}
+
+export function appendKeywordToken(current: string[], token: string): string[] {
+  const normalizedToken = token.trim()
+  if (!normalizedToken) {
+    return current
+  }
+
+  return [...current, normalizedToken]
+}

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -28,14 +28,19 @@ import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
 import { useCandidateStatus, type CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 import {
   areKeywordListsEqual,
+  appendKeywordToken,
   getRoleYears,
   matchesAllRequiredKeywords,
   matchesEducationFilter,
+  normalizeFilterList,
   normalizeFilterToken,
   normalizeKeywordFingerprint,
+  normalizeOptionalNumber,
+  normalizeOptionalString,
   parseExtractedAt,
   parseSalaryRange,
   parseSerializedStringArray,
+  serializeLocationFilter,
   toExperienceLevel,
   toStatusFilterList,
 } from '@/hooks/resume-filter-helpers'
@@ -116,73 +121,9 @@ type EnrichedResume = {
 
 type AnalysisTaskDoc = Doc<'analysis_tasks'>
 
-function appendKeywordToken(current: string[], token: string): string[] {
-  const normalizedToken = token.trim()
-  if (!normalizedToken) {
-    return current
-  }
-
-  return [...current, normalizedToken]
-}
-
-function normalizeOptionalNumber(value: number | undefined): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
-}
-
-function normalizeOptionalString(value: string | undefined): string | undefined {
-  if (!value) {
-    return undefined
-  }
-
-  const normalized = value.trim()
-  return normalized.length > 0 ? normalized : undefined
-}
-
-function normalizeFilterList(values: string[] | undefined): string[] | undefined {
-  if (!Array.isArray(values) || values.length === 0) {
-    return undefined
-  }
-
-  const seen = new Set<string>()
-  const normalized: string[] = []
-
-  values.forEach((value) => {
-    const token = normalizeFilterToken(value)
-    if (!token || seen.has(token)) {
-      return
-    }
-    seen.add(token)
-    normalized.push(token)
-  })
-
-  return normalized.sort()
-}
-
 function resolveWorkspaceSlugFromPathname(pathname: string): string {
   const slug = pathname.split('/').filter(Boolean)[0]
   return slug && slug.length > 0 ? slug : 'dev'
-}
-
-function serializeLocationFilter(values: string[] | undefined): string {
-  if (!Array.isArray(values) || values.length === 0) {
-    return ''
-  }
-
-  const seen = new Set<string>()
-  const normalized: string[] = []
-
-  values.forEach((value) => {
-    const trimmed = value.trim()
-    const key = trimmed.toLowerCase()
-    if (!trimmed || seen.has(key)) {
-      return
-    }
-
-    seen.add(key)
-    normalized.push(trimmed)
-  })
-
-  return normalized.join(',')
 }
 
 function normalizeUrlFilters(filters: Partial<ResumeFilters>): Partial<ResumeFilters> {


### PR DESCRIPTION
## Summary
- Extract `normalizeOptionalNumber`, `normalizeOptionalString`, `normalizeFilterList`, `serializeLocationFilter`, `appendKeywordToken` from `useResumeListState.ts` into `resume-filter-helpers.ts`
- Add 22 new direct unit tests (83 total in file, up from 61)
- Remove all 5 inline definitions from the hook, replacing with imports from the helpers module

## Test plan
- [x] 83 unit tests pass in `resume-filter-helpers.test.ts`
- [x] 53 integration tests pass in `useResumeListState.test.tsx`
- [x] `make check` passes (typecheck + lint + governance + skill sync)