### PR TITLE
fix: extract taskMatchesCurrentSearch and buildSearchHistoryTitle into resume-filter-helpers

### DIFF
--- a/apps/web/src/hooks/resume-filter-helpers.test.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.test.ts
@@ -5,6 +5,7 @@ import {
   appendKeywordToken,
   areKeywordListsEqual,
   areUrlFiltersEqual,
+  buildSearchHistoryTitle,
   getRoleYears,
   matchesAllRequiredKeywords,
   matchesEducationFilter,
@@ -19,6 +20,7 @@ import {
   parseSerializedStringArray,
   parseSalaryRange,
   serializeLocationFilter,
+  taskMatchesCurrentSearch,
   toExperienceLevel,
   toStatusFilterList,
 } from './resume-filter-helpers.js'
@@ -599,5 +601,82 @@ describe('areUrlFiltersEqual', () => {
     const left: Partial<ResumeFilters> = { roleFilterType: '  Sales  ' }
     const right: Partial<ResumeFilters> = { roleFilterType: 'Sales' }
     expect(areUrlFiltersEqual(left, right)).toBe(true)
+  })
+})
+
+describe('taskMatchesCurrentSearch', () => {
+  it('returns false for completed task', () => {
+    const task = { status: 'completed', config: { promptVersion: 10 } }
+    expect(taskMatchesCurrentSearch(task, undefined, [], '', 10)).toBe(false)
+  })
+
+  it('matches by jobDescriptionId with same promptVersion and location', () => {
+    const task = {
+      status: 'pending',
+      config: { jobDescriptionId: 'jd-1', promptVersion: 10, location: ' 广东 ' },
+    }
+    expect(taskMatchesCurrentSearch(task, 'jd-1', [], '广东', 10)).toBe(true)
+  })
+
+  it('rejects JD match when promptVersion differs', () => {
+    const task = {
+      status: 'pending',
+      config: { jobDescriptionId: 'jd-1', promptVersion: 8, location: undefined },
+    }
+    expect(taskMatchesCurrentSearch(task, 'jd-1', [], '', 10)).toBe(false)
+  })
+
+  it('matches by keywords with same fingerprint, promptVersion, and location', () => {
+    const task = {
+      status: 'processing',
+      config: { keywords: ['CNC', '销售'], promptVersion: 10, location: '深圳' },
+    }
+    expect(taskMatchesCurrentSearch(task, '', ['销售', 'CNC'], '深圳', 10)).toBe(true)
+  })
+
+  it('rejects keyword match when fingerprints differ', () => {
+    const task = {
+      status: 'pending',
+      config: { keywords: ['CNC'], promptVersion: 10, location: '' },
+    }
+    expect(taskMatchesCurrentSearch(task, '', ['销售'], '', 10)).toBe(false)
+  })
+
+  it('returns false when both JD and keywords are empty', () => {
+    const task = {
+      status: 'pending',
+      config: { promptVersion: 10, location: '' },
+    }
+    expect(taskMatchesCurrentSearch(task, '', [], '', 10)).toBe(false)
+  })
+
+  it('rejects keyword match when session has no keywords', () => {
+    const task = {
+      status: 'pending',
+      config: { keywords: ['CNC'], promptVersion: 10, location: '' },
+    }
+    expect(taskMatchesCurrentSearch(task, '', [], '', 10)).toBe(false)
+  })
+})
+
+describe('buildSearchHistoryTitle', () => {
+  it('returns "Untitled search" for empty inputs', () => {
+    expect(buildSearchHistoryTitle('', [], undefined)).toBe('Untitled search')
+  })
+
+  it('joins location and keywords with separator', () => {
+    expect(buildSearchHistoryTitle(' 广东 ', ['CNC', '销售'], undefined)).toBe('广东 · CNC 销售')
+  })
+
+  it('uses jobDescriptionId when no keywords', () => {
+    expect(buildSearchHistoryTitle('', [], '  jd-1  ')).toBe('jd-1')
+  })
+
+  it('prefers keywords over jobDescriptionId', () => {
+    expect(buildSearchHistoryTitle('', ['CNC'], 'jd-1')).toBe('CNC')
+  })
+
+  it('combines location and jobDescriptionId', () => {
+    expect(buildSearchHistoryTitle('深圳', [], 'jd-1')).toBe('深圳 · jd-1')
   })
 })

--- a/apps/web/src/hooks/resume-filter-helpers.test.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.test.ts
@@ -4,6 +4,7 @@ import type { CandidateStatus } from '@/types/resume'
 import {
   appendKeywordToken,
   areKeywordListsEqual,
+  areUrlFiltersEqual,
   getRoleYears,
   matchesAllRequiredKeywords,
   matchesEducationFilter,
@@ -12,6 +13,8 @@ import {
   normalizeKeywordFingerprint,
   normalizeOptionalNumber,
   normalizeOptionalString,
+  normalizeUrlFilters,
+  normalizeUrlSearchStateValue,
   parseExtractedAt,
   parseSerializedStringArray,
   parseSalaryRange,
@@ -21,6 +24,7 @@ import {
 } from './resume-filter-helpers.js'
 
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+import type { ResumeFilters } from '@/types/resume'
 
 describe('normalizeFilterToken', () => {
   it('trims and lowercases input', () => {
@@ -455,5 +459,145 @@ describe('appendKeywordToken', () => {
   it('returns unchanged array for empty token', () => {
     const arr = ['CNC']
     expect(appendKeywordToken(arr, '')).toBe(arr)
+  })
+})
+
+describe('normalizeUrlFilters', () => {
+  it('normalizes all fields to their default values for empty input', () => {
+    const result = normalizeUrlFilters({})
+    expect(result.minExperience).toBeUndefined()
+    expect(result.maxExperience).toBeUndefined()
+    expect(result.minRoleYears).toBeUndefined()
+    expect(result.roleFilterType).toBeUndefined()
+    expect(result.minAge).toBeUndefined()
+    expect(result.maxAge).toBeUndefined()
+    expect(result.education).toBeUndefined()
+    expect(result.status).toEqual([])
+    expect(result.minMatchScore).toBeUndefined()
+    expect(result.locations).toBeUndefined()
+    expect(result.sortBy).toBeUndefined()
+    expect(result.sortOrder).toBeUndefined()
+  })
+
+  it('normalizes all number fields', () => {
+    const result = normalizeUrlFilters({
+      minExperience: 5,
+      maxExperience: NaN,
+      minRoleYears: 3,
+      minAge: 0,
+      maxAge: Infinity,
+      minMatchScore: undefined,
+    })
+    expect(result.minExperience).toBe(5)
+    expect(result.maxExperience).toBeUndefined()
+    expect(result.minRoleYears).toBe(3)
+    expect(result.minAge).toBe(0)
+    expect(result.maxAge).toBeUndefined()
+    expect(result.minMatchScore).toBeUndefined()
+  })
+
+  it('normalizes string and list fields', () => {
+    const result = normalizeUrlFilters({
+      roleFilterType: '  Sales  ',
+      education: ['Bachelor', 'bachelor', 'Master'],
+      locations: [' 广东 ', '深圳'],
+      status: ['new', 'hired'] as CandidateStatus[],
+    })
+    expect(result.roleFilterType).toBe('Sales')
+    expect(result.education).toEqual(['bachelor', 'master'])
+    expect(result.locations).toEqual(['广东', '深圳'])
+    expect(result.status).toEqual(['hired', 'new'])
+  })
+
+  it('passes through sortBy and sortOrder unchanged', () => {
+    const result = normalizeUrlFilters({
+      sortBy: 'score',
+      sortOrder: 'desc',
+    })
+    expect(result.sortBy).toBe('score')
+    expect(result.sortOrder).toBe('desc')
+  })
+})
+
+describe('normalizeUrlSearchStateValue', () => {
+  it('returns defaults for undefined input', () => {
+    const result = normalizeUrlSearchStateValue(undefined)
+    expect(result.shareSessionId).toBeUndefined()
+    expect(result.query).toBeUndefined()
+    expect(result.location).toBeUndefined()
+    expect(result.keywords).toEqual([])
+    expect(result.requiredKeywords).toEqual([])
+    expect(result.jobDescriptionId).toBeUndefined()
+    expect(result.selectedTags).toEqual([])
+    expect(result.selectedCompanies).toEqual([])
+    expect(result.selectedSources).toEqual([])
+    expect(result.selectedExperienceLevel).toBeUndefined()
+    expect(result.filters).toEqual({})
+  })
+
+  it('normalizes string fields and preserves arrays', () => {
+    const result = normalizeUrlSearchStateValue({
+      shareSessionId: '  abc  ',
+      query: 'CNC',
+      location: '  广东  ',
+      keywords: ['CNC', '销售'],
+      requiredKeywords: ['5轴'],
+      jobDescriptionId: '  jd-1  ',
+      selectedTags: ['tag1'],
+      selectedCompanies: ['co1'],
+      selectedSources: ['job5156'],
+      selectedExperienceLevel: 'senior',
+      filters: { minExperience: 5 },
+    })
+    expect(result.shareSessionId).toBe('abc')
+    expect(result.query).toBe('CNC')
+    expect(result.location).toBe('广东')
+    expect(result.keywords).toEqual(['CNC', '销售'])
+    expect(result.requiredKeywords).toEqual(['5轴'])
+    expect(result.jobDescriptionId).toBe('jd-1')
+    expect(result.selectedExperienceLevel).toBe('senior')
+    expect(result.filters).toEqual({ minExperience: 5 })
+  })
+
+  it('replaces non-array keywords with empty array', () => {
+    const result = normalizeUrlSearchStateValue({
+      keywords: 'not-an-array' as unknown as string[],
+    })
+    expect(result.keywords).toEqual([])
+  })
+
+  it('preserves empty filters as empty object', () => {
+    const result = normalizeUrlSearchStateValue({ filters: {} })
+    expect(result.filters).toEqual({})
+  })
+})
+
+describe('areUrlFiltersEqual', () => {
+  it('returns true for two empty filter objects', () => {
+    expect(areUrlFiltersEqual({}, {})).toBe(true)
+  })
+
+  it('returns true for semantically equal filters ignoring order', () => {
+    const left: Partial<ResumeFilters> = { education: ['Bachelor', 'Master'], minExperience: 5 }
+    const right: Partial<ResumeFilters> = { education: ['Master', 'Bachelor'], minExperience: 5 }
+    expect(areUrlFiltersEqual(left, right)).toBe(true)
+  })
+
+  it('returns false for different filters', () => {
+    const left: Partial<ResumeFilters> = { minExperience: 5 }
+    const right: Partial<ResumeFilters> = { minExperience: 10 }
+    expect(areUrlFiltersEqual(left, right)).toBe(false)
+  })
+
+  it('treats NaN and undefined as equal for number fields', () => {
+    const left: Partial<ResumeFilters> = { maxExperience: NaN }
+    const right: Partial<ResumeFilters> = { maxExperience: undefined }
+    expect(areUrlFiltersEqual(left, right)).toBe(true)
+  })
+
+  it('treats whitespace and trimmed strings as equal', () => {
+    const left: Partial<ResumeFilters> = { roleFilterType: '  Sales  ' }
+    const right: Partial<ResumeFilters> = { roleFilterType: 'Sales' }
+    expect(areUrlFiltersEqual(left, right)).toBe(true)
   })
 })

--- a/apps/web/src/hooks/resume-filter-helpers.test.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.test.ts
@@ -2,15 +2,20 @@ import { describe, expect, it } from 'vitest'
 import type { CandidateStatus } from '@/types/resume'
 
 import {
+  appendKeywordToken,
   areKeywordListsEqual,
   getRoleYears,
   matchesAllRequiredKeywords,
   matchesEducationFilter,
+  normalizeFilterList,
   normalizeFilterToken,
   normalizeKeywordFingerprint,
+  normalizeOptionalNumber,
+  normalizeOptionalString,
   parseExtractedAt,
   parseSerializedStringArray,
   parseSalaryRange,
+  serializeLocationFilter,
   toExperienceLevel,
   toStatusFilterList,
 } from './resume-filter-helpers.js'
@@ -349,5 +354,106 @@ describe('toExperienceLevel', () => {
 
   it('returns undefined for unrecognized value', () => {
     expect(toExperienceLevel('expert')).toBeUndefined()
+  })
+})
+
+describe('normalizeOptionalNumber', () => {
+  it('returns undefined for undefined', () => {
+    expect(normalizeOptionalNumber(undefined)).toBeUndefined()
+  })
+
+  it('returns the number for finite values', () => {
+    expect(normalizeOptionalNumber(5)).toBe(5)
+  })
+
+  it('returns undefined for NaN', () => {
+    expect(normalizeOptionalNumber(NaN)).toBeUndefined()
+  })
+
+  it('returns undefined for Infinity', () => {
+    expect(normalizeOptionalNumber(Infinity)).toBeUndefined()
+  })
+
+  it('returns undefined for negative Infinity', () => {
+    expect(normalizeOptionalNumber(-Infinity)).toBeUndefined()
+  })
+
+  it('returns 0 for zero', () => {
+    expect(normalizeOptionalNumber(0)).toBe(0)
+  })
+})
+
+describe('normalizeOptionalString', () => {
+  it('returns undefined for undefined', () => {
+    expect(normalizeOptionalString(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for empty string', () => {
+    expect(normalizeOptionalString('')).toBeUndefined()
+  })
+
+  it('returns undefined for whitespace-only string', () => {
+    expect(normalizeOptionalString('   ')).toBeUndefined()
+  })
+
+  it('returns trimmed string for valid input', () => {
+    expect(normalizeOptionalString('  CNC  ')).toBe('CNC')
+  })
+})
+
+describe('normalizeFilterList', () => {
+  it('returns undefined for undefined', () => {
+    expect(normalizeFilterList(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for empty array', () => {
+    expect(normalizeFilterList([])).toBeUndefined()
+  })
+
+  it('normalizes, deduplicates, and sorts tokens', () => {
+    expect(normalizeFilterList(['CNC', 'cnc', '销售'])).toEqual(['cnc', '销售'])
+  })
+
+  it('filters out empty and whitespace tokens', () => {
+    expect(normalizeFilterList(['CNC', '', '  '])).toEqual(['cnc'])
+  })
+})
+
+describe('serializeLocationFilter', () => {
+  it('returns empty string for undefined', () => {
+    expect(serializeLocationFilter(undefined)).toBe('')
+  })
+
+  it('returns empty string for empty array', () => {
+    expect(serializeLocationFilter([])).toBe('')
+  })
+
+  it('joins trimmed values with comma', () => {
+    expect(serializeLocationFilter(['  广东  ', '深圳'])).toBe('广东,深圳')
+  })
+
+  it('deduplicates case-insensitively but preserves first occurrence casing', () => {
+    const result = serializeLocationFilter(['Guangdong', 'guangdong'])
+    expect(result).toBe('Guangdong')
+  })
+
+  it('filters out empty and whitespace-only values', () => {
+    expect(serializeLocationFilter(['广东', '', '  ', '深圳'])).toBe('广东,深圳')
+  })
+})
+
+describe('appendKeywordToken', () => {
+  it('appends trimmed token to array', () => {
+    expect(appendKeywordToken(['CNC'], ' 销售 ')).toEqual(['CNC', '销售'])
+  })
+
+  it('returns unchanged array for whitespace-only token', () => {
+    const arr = ['CNC']
+    expect(appendKeywordToken(arr, '   ')).toBe(arr)
+  })
+
+  it('returns unchanged array for empty token', () => {
+    const arr = ['CNC']
+    expect(appendKeywordToken(arr, '')).toBe(arr)
   })
 })

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -175,3 +175,67 @@ export function toExperienceLevel(value: string | undefined): ExperienceLevelFil
   if (normalized === 'junior') return 'junior'
   return undefined
 }
+
+export function normalizeOptionalNumber(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+export function normalizeOptionalString(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : undefined
+}
+
+export function normalizeFilterList(values: string[] | undefined): string[] | undefined {
+  if (!Array.isArray(values) || values.length === 0) {
+    return undefined
+  }
+
+  const seen = new Set<string>()
+  const normalized: string[] = []
+
+  values.forEach((value) => {
+    const token = normalizeFilterToken(value)
+    if (!token || seen.has(token)) {
+      return
+    }
+    seen.add(token)
+    normalized.push(token)
+  })
+
+  return normalized.sort()
+}
+
+export function serializeLocationFilter(values: string[] | undefined): string {
+  if (!Array.isArray(values) || values.length === 0) {
+    return ''
+  }
+
+  const seen = new Set<string>()
+  const normalized: string[] = []
+
+  values.forEach((value) => {
+    const trimmed = value.trim()
+    const key = trimmed.toLowerCase()
+    if (!trimmed || seen.has(key)) {
+      return
+    }
+
+    seen.add(key)
+    normalized.push(trimmed)
+  })
+
+  return normalized.join(',')
+}
+
+export function appendKeywordToken(current: string[], token: string): string[] {
+  const normalizedToken = token.trim()
+  if (!normalizedToken) {
+    return current
+  }
+
+  return [...current, normalizedToken]
+}

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -1,8 +1,8 @@
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 import { normalizeKeywordPhrases } from '@trends/shared'
-import type { ExperienceLevelFilter } from '@/hooks/useUrlSearchState'
+import type { ExperienceLevelFilter, UrlSearchState } from '@/hooks/useUrlSearchState'
 
-import type { CandidateStatus } from '@/types/resume'
+import type { CandidateStatus, ResumeFilters } from '@/types/resume'
 
 const EDUCATION_KEYWORDS: Record<string, string[]> = {
   high_school: ['高中', '中专', '技校', 'high school'],
@@ -238,4 +238,41 @@ export function appendKeywordToken(current: string[], token: string): string[] {
   }
 
   return [...current, normalizedToken]
+}
+
+export function normalizeUrlFilters(filters: Partial<ResumeFilters>): Partial<ResumeFilters> {
+  return {
+    minExperience: normalizeOptionalNumber(filters.minExperience),
+    maxExperience: normalizeOptionalNumber(filters.maxExperience),
+    minRoleYears: normalizeOptionalNumber(filters.minRoleYears),
+    roleFilterType: normalizeOptionalString(filters.roleFilterType),
+    minAge: normalizeOptionalNumber(filters.minAge),
+    maxAge: normalizeOptionalNumber(filters.maxAge),
+    education: normalizeFilterList(filters.education),
+    status: toStatusFilterList(filters.status),
+    minMatchScore: normalizeOptionalNumber(filters.minMatchScore),
+    locations: normalizeFilterList(filters.locations),
+    sortBy: filters.sortBy,
+    sortOrder: filters.sortOrder,
+  }
+}
+
+export function normalizeUrlSearchStateValue(state: Partial<UrlSearchState> | undefined): UrlSearchState {
+  return {
+    shareSessionId: normalizeOptionalString(state?.shareSessionId),
+    query: normalizeOptionalString(state?.query),
+    location: normalizeOptionalString(state?.location),
+    keywords: Array.isArray(state?.keywords) ? state.keywords : [],
+    requiredKeywords: Array.isArray(state?.requiredKeywords) ? state.requiredKeywords : [],
+    jobDescriptionId: normalizeOptionalString(state?.jobDescriptionId),
+    selectedTags: Array.isArray(state?.selectedTags) ? state.selectedTags : [],
+    selectedCompanies: Array.isArray(state?.selectedCompanies) ? state.selectedCompanies : [],
+    selectedSources: Array.isArray(state?.selectedSources) ? state.selectedSources : [],
+    selectedExperienceLevel: state?.selectedExperienceLevel,
+    filters: state?.filters ?? {},
+  }
+}
+
+export function areUrlFiltersEqual(left: Partial<ResumeFilters>, right: Partial<ResumeFilters>): boolean {
+  return JSON.stringify(normalizeUrlFilters(left)) === JSON.stringify(normalizeUrlFilters(right))
 }

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -1,5 +1,5 @@
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
-import { normalizeKeywordPhrases } from '@trends/shared'
+import { formatKeywordQuery, normalizeKeywordPhrases } from '@trends/shared'
 import type { ExperienceLevelFilter, UrlSearchState } from '@/hooks/useUrlSearchState'
 
 import type { CandidateStatus, ResumeFilters } from '@/types/resume'
@@ -275,4 +275,54 @@ export function normalizeUrlSearchStateValue(state: Partial<UrlSearchState> | un
 
 export function areUrlFiltersEqual(left: Partial<ResumeFilters>, right: Partial<ResumeFilters>): boolean {
   return JSON.stringify(normalizeUrlFilters(left)) === JSON.stringify(normalizeUrlFilters(right))
+}
+
+export interface AnalysisTaskMatchContext {
+  status: string
+  config: {
+    jobDescriptionId?: string
+    keywords?: string[]
+    location?: string
+    promptVersion?: number
+  }
+}
+
+export function taskMatchesCurrentSearch(
+  task: AnalysisTaskMatchContext,
+  jobDescriptionId: string | undefined,
+  sessionKeywords: string[],
+  location: string,
+  promptVersion: number
+): boolean {
+  if (task.status !== 'pending' && task.status !== 'processing') {
+    return false
+  }
+
+  const normalizedJobDescriptionId = (jobDescriptionId ?? '').trim()
+  if (normalizedJobDescriptionId && task.config.jobDescriptionId === normalizedJobDescriptionId) {
+    return task.config.promptVersion === promptVersion
+      && normalizeOptionalString(task.config.location) === normalizeOptionalString(location)
+  }
+
+  if (sessionKeywords.length > 0 && task.config.keywords?.length) {
+    const normalizedSessionKeywords = normalizeKeywordFingerprint(sessionKeywords)
+    const normalizedTaskKeywords = normalizeKeywordFingerprint(task.config.keywords)
+    return (
+      normalizedSessionKeywords.length > 0
+      && normalizedSessionKeywords === normalizedTaskKeywords
+      && task.config.promptVersion === promptVersion
+      && normalizeOptionalString(task.config.location) === normalizeOptionalString(location)
+    )
+  }
+
+  return false
+}
+
+export function buildSearchHistoryTitle(location: string, keywords: string[], jobDescriptionId?: string): string {
+  const normalizedLocation = location.trim()
+  const normalizedKeywords = formatKeywordQuery(keywords).trim()
+  const normalizedJobDescriptionId = normalizeOptionalString(jobDescriptionId)
+  const primarySubject = normalizedKeywords || normalizedJobDescriptionId || ''
+  const parts = [normalizedLocation, primarySubject].filter((value) => value.length > 0)
+  return parts.join(' · ') || 'Untitled search'
 }

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -11,7 +11,6 @@ import {
 import { useLocation, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { api } from '../../../../packages/convex/convex/_generated/api'
-import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
 import { useResumes, type ResumeItem } from '@/hooks/useResumes'
 import {
   CONVEX_RESUME_PAGE_SIZE,
@@ -30,11 +29,11 @@ import {
   areKeywordListsEqual,
   areUrlFiltersEqual,
   appendKeywordToken,
+  buildSearchHistoryTitle,
   getRoleYears,
   matchesAllRequiredKeywords,
   matchesEducationFilter,
   normalizeFilterToken,
-  normalizeKeywordFingerprint,
   normalizeOptionalString,
   normalizeUrlFilters,
   normalizeUrlSearchStateValue,
@@ -42,6 +41,7 @@ import {
   parseSalaryRange,
   parseSerializedStringArray,
   serializeLocationFilter,
+  taskMatchesCurrentSearch,
   toExperienceLevel,
   toStatusFilterList,
 } from '@/hooks/resume-filter-helpers'
@@ -119,51 +119,9 @@ type EnrichedResume = {
   action?: CandidateActionType | undefined
 }
 
-type AnalysisTaskDoc = Doc<'analysis_tasks'>
-
 function resolveWorkspaceSlugFromPathname(pathname: string): string {
   const slug = pathname.split('/').filter(Boolean)[0]
   return slug && slug.length > 0 ? slug : 'dev'
-}
-
-function buildSearchHistoryTitle(location: string, keywords: string[], jobDescriptionId?: string): string {
-  const normalizedLocation = location.trim()
-  const normalizedKeywords = formatKeywordQuery(keywords).trim()
-  const normalizedJobDescriptionId = normalizeOptionalString(jobDescriptionId)
-  const primarySubject = normalizedKeywords || normalizedJobDescriptionId || ''
-  const parts = [normalizedLocation, primarySubject].filter((value) => value.length > 0)
-  return parts.join(' · ') || 'Untitled search'
-}
-
-function taskMatchesCurrentSearch(
-  task: AnalysisTaskDoc,
-  jobDescriptionId: string | undefined,
-  sessionKeywords: string[],
-  location: string,
-  promptVersion: number
-): boolean {
-  if (task.status !== 'pending' && task.status !== 'processing') {
-    return false
-  }
-
-  const normalizedJobDescriptionId = (jobDescriptionId ?? '').trim()
-  if (normalizedJobDescriptionId && task.config.jobDescriptionId === normalizedJobDescriptionId) {
-    return task.config.promptVersion === promptVersion
-      && normalizeOptionalString(task.config.location) === normalizeOptionalString(location)
-  }
-
-  if (sessionKeywords.length > 0 && task.config.keywords?.length) {
-    const normalizedSessionKeywords = normalizeKeywordFingerprint(sessionKeywords)
-    const normalizedTaskKeywords = normalizeKeywordFingerprint(task.config.keywords)
-    return (
-      normalizedSessionKeywords.length > 0
-      && normalizedSessionKeywords === normalizedTaskKeywords
-      && task.config.promptVersion === promptVersion
-      && normalizeOptionalString(task.config.location) === normalizeOptionalString(location)
-    )
-  }
-
-  return false
 }
 
 function getResumeLocationText(

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -28,15 +28,16 @@ import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
 import { useCandidateStatus, type CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 import {
   areKeywordListsEqual,
+  areUrlFiltersEqual,
   appendKeywordToken,
   getRoleYears,
   matchesAllRequiredKeywords,
   matchesEducationFilter,
-  normalizeFilterList,
   normalizeFilterToken,
   normalizeKeywordFingerprint,
-  normalizeOptionalNumber,
   normalizeOptionalString,
+  normalizeUrlFilters,
+  normalizeUrlSearchStateValue,
   parseExtractedAt,
   parseSalaryRange,
   parseSerializedStringArray,
@@ -48,7 +49,6 @@ import {
   hasKnownUrlSearchParams,
   parseUrlSearchState,
   useUrlSearchState,
-  type UrlSearchState,
 } from '@/hooks/useUrlSearchState'
 import type { ExperienceLevelFilter } from '@/hooks/useUrlSearchState'
 import { rawApiClient } from '@/lib/api-helpers'
@@ -126,39 +126,6 @@ function resolveWorkspaceSlugFromPathname(pathname: string): string {
   return slug && slug.length > 0 ? slug : 'dev'
 }
 
-function normalizeUrlFilters(filters: Partial<ResumeFilters>): Partial<ResumeFilters> {
-  return {
-    minExperience: normalizeOptionalNumber(filters.minExperience),
-    maxExperience: normalizeOptionalNumber(filters.maxExperience),
-    minRoleYears: normalizeOptionalNumber(filters.minRoleYears),
-    roleFilterType: normalizeOptionalString(filters.roleFilterType),
-    minAge: normalizeOptionalNumber(filters.minAge),
-    maxAge: normalizeOptionalNumber(filters.maxAge),
-    education: normalizeFilterList(filters.education),
-    status: toStatusFilterList(filters.status),
-    minMatchScore: normalizeOptionalNumber(filters.minMatchScore),
-    locations: normalizeFilterList(filters.locations),
-    sortBy: filters.sortBy,
-    sortOrder: filters.sortOrder,
-  }
-}
-
-function normalizeUrlSearchStateValue(state: Partial<UrlSearchState> | undefined): UrlSearchState {
-  return {
-    shareSessionId: normalizeOptionalString(state?.shareSessionId),
-    query: normalizeOptionalString(state?.query),
-    location: normalizeOptionalString(state?.location),
-    keywords: Array.isArray(state?.keywords) ? state.keywords : [],
-    requiredKeywords: Array.isArray(state?.requiredKeywords) ? state.requiredKeywords : [],
-    jobDescriptionId: normalizeOptionalString(state?.jobDescriptionId),
-    selectedTags: Array.isArray(state?.selectedTags) ? state.selectedTags : [],
-    selectedCompanies: Array.isArray(state?.selectedCompanies) ? state.selectedCompanies : [],
-    selectedSources: Array.isArray(state?.selectedSources) ? state.selectedSources : [],
-    selectedExperienceLevel: state?.selectedExperienceLevel,
-    filters: state?.filters ?? {},
-  }
-}
-
 function buildSearchHistoryTitle(location: string, keywords: string[], jobDescriptionId?: string): string {
   const normalizedLocation = location.trim()
   const normalizedKeywords = formatKeywordQuery(keywords).trim()
@@ -166,10 +133,6 @@ function buildSearchHistoryTitle(location: string, keywords: string[], jobDescri
   const primarySubject = normalizedKeywords || normalizedJobDescriptionId || ''
   const parts = [normalizedLocation, primarySubject].filter((value) => value.length > 0)
   return parts.join(' · ') || 'Untitled search'
-}
-
-function areUrlFiltersEqual(left: Partial<ResumeFilters>, right: Partial<ResumeFilters>): boolean {
-  return JSON.stringify(normalizeUrlFilters(left)) === JSON.stringify(normalizeUrlFilters(right))
 }
 
 function taskMatchesCurrentSearch(

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -28,14 +28,19 @@ import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
 import { useCandidateStatus, type CandidateStatusRecord } from '@/hooks/useCandidateStatus'
 import {
   areKeywordListsEqual,
+  appendKeywordToken,
   getRoleYears,
   matchesAllRequiredKeywords,
   matchesEducationFilter,
+  normalizeFilterList,
   normalizeFilterToken,
   normalizeKeywordFingerprint,
+  normalizeOptionalNumber,
+  normalizeOptionalString,
   parseExtractedAt,
   parseSalaryRange,
   parseSerializedStringArray,
+  serializeLocationFilter,
   toExperienceLevel,
   toStatusFilterList,
 } from '@/hooks/resume-filter-helpers'
@@ -116,73 +121,9 @@ type EnrichedResume = {
 
 type AnalysisTaskDoc = Doc<'analysis_tasks'>
 
-function appendKeywordToken(current: string[], token: string): string[] {
-  const normalizedToken = token.trim()
-  if (!normalizedToken) {
-    return current
-  }
-
-  return [...current, normalizedToken]
-}
-
-function normalizeOptionalNumber(value: number | undefined): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
-}
-
-function normalizeOptionalString(value: string | undefined): string | undefined {
-  if (!value) {
-    return undefined
-  }
-
-  const normalized = value.trim()
-  return normalized.length > 0 ? normalized : undefined
-}
-
-function normalizeFilterList(values: string[] | undefined): string[] | undefined {
-  if (!Array.isArray(values) || values.length === 0) {
-    return undefined
-  }
-
-  const seen = new Set<string>()
-  const normalized: string[] = []
-
-  values.forEach((value) => {
-    const token = normalizeFilterToken(value)
-    if (!token || seen.has(token)) {
-      return
-    }
-    seen.add(token)
-    normalized.push(token)
-  })
-
-  return normalized.sort()
-}
-
 function resolveWorkspaceSlugFromPathname(pathname: string): string {
   const slug = pathname.split('/').filter(Boolean)[0]
   return slug && slug.length > 0 ? slug : 'dev'
-}
-
-function serializeLocationFilter(values: string[] | undefined): string {
-  if (!Array.isArray(values) || values.length === 0) {
-    return ''
-  }
-
-  const seen = new Set<string>()
-  const normalized: string[] = []
-
-  values.forEach((value) => {
-    const trimmed = value.trim()
-    const key = trimmed.toLowerCase()
-    if (!trimmed || seen.has(key)) {
-      return
-    }
-
-    seen.add(key)
-    normalized.push(trimmed)
-  })
-
-  return normalized.join(',')
 }
 
 function normalizeUrlFilters(filters: Partial<ResumeFilters>): Partial<ResumeFilters> {


### PR DESCRIPTION
## Summary
- Extract `taskMatchesCurrentSearch` and `buildSearchHistoryTitle` from `useResumeListState.ts` into `resume-filter-helpers.ts`
- Add 12 new direct unit tests (108 total in file, up from 96)
- Remove 3 unused imports (`normalizeKeywordFingerprint`, `Doc`, `AnalysisTaskDoc` type)
- `taskMatchesCurrentSearch` uses a new `AnalysisTaskMatchContext` interface for type safety

## Test plan
- [x] 108 unit tests pass in `resume-filter-helpers.test.ts`
- [x] 53 integration tests pass in `useResumeListState.test.tsx`
- [x] `make check` passes (typecheck + lint + governance + skill sync)