### PR TITLE
fix: extract getResumeLocationText, resolveAnalysisSourceKeyForResume, getResumeIdentityKey

### DIFF
--- a/apps/web/src/hooks/resume-filter-helpers.test.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.test.ts
@@ -6,6 +6,8 @@ import {
   areKeywordListsEqual,
   areUrlFiltersEqual,
   buildSearchHistoryTitle,
+  getResumeIdentityKey,
+  getResumeLocationText,
   getRoleYears,
   matchesAllRequiredKeywords,
   matchesEducationFilter,
@@ -19,6 +21,7 @@ import {
   parseExtractedAt,
   parseSerializedStringArray,
   parseSalaryRange,
+  resolveAnalysisSourceKeyForResume,
   serializeLocationFilter,
   taskMatchesCurrentSearch,
   toExperienceLevel,
@@ -679,5 +682,78 @@ describe('buildSearchHistoryTitle', () => {
 
   it('combines location and jobDescriptionId', () => {
     expect(buildSearchHistoryTitle('深圳', [], 'jd-1')).toBe('深圳 · jd-1')
+  })
+})
+
+describe('getResumeLocationText', () => {
+  it('returns empty string when no location data', () => {
+    expect(getResumeLocationText({})).toBe('')
+  })
+
+  it('returns locationHierarchy text when available', () => {
+    expect(getResumeLocationText({
+      locationHierarchy: { country: 'CN', province: '广东', city: '深圳' },
+      location: '广东省深圳市',
+    })).toBe('CN 广东 深圳')
+  })
+
+  it('falls back to location string when no hierarchy', () => {
+    expect(getResumeLocationText({ location: '广东省深圳市' })).toBe('广东省深圳市')
+  })
+
+  it('returns empty string when hierarchy is empty and location is empty', () => {
+    expect(getResumeLocationText({ location: '', locationHierarchy: { country: '' } })).toBe('')
+  })
+})
+
+describe('resolveAnalysisSourceKeyForResume', () => {
+  it('returns collectionSource type when available', () => {
+    const result = resolveAnalysisSourceKeyForResume(
+      { source: 'job5156', profileType: 'profile' },
+      { type: '51job' },
+    )
+    expect(result).toBe('51job')
+  })
+
+  it('falls back to resolveResumeAnalysisSourceKey when no collectionSource', () => {
+    const result = resolveAnalysisSourceKeyForResume(
+      { source: 'job5156' },
+      undefined,
+    )
+    expect(result).toBe('job5156')
+  })
+
+  it('returns undefined when no collectionSource and no recognized source', () => {
+    const result = resolveAnalysisSourceKeyForResume(
+      { source: 'unknown' },
+      undefined,
+    )
+    expect(result).toBeUndefined()
+  })
+
+  it('uses profileType as sourceKey for resolveResumeAnalysisSourceKey', () => {
+    const result = resolveAnalysisSourceKeyForResume(
+      { source: 'job5156', profileType: 'seek' },
+      undefined,
+    )
+    expect(result).toBe('seek')
+  })
+})
+
+describe('getResumeIdentityKey', () => {
+  it('returns identityKey when present', () => {
+    expect(getResumeIdentityKey({ identityKey: '  abc-123  ' } as ConvexResumeItem, 'fallback')).toBe('abc-123')
+  })
+
+  it('returns fallback when identityKey is empty string', () => {
+    expect(getResumeIdentityKey({ identityKey: '' } as ConvexResumeItem, 'fallback')).toBe('fallback')
+  })
+
+  it('returns fallback when identityKey is whitespace-only', () => {
+    expect(getResumeIdentityKey({ identityKey: '   ' } as ConvexResumeItem, 'fallback')).toBe('fallback')
+  })
+
+  it('returns fallback when identityKey is undefined', () => {
+    expect(getResumeIdentityKey({} as ConvexResumeItem, 'fallback')).toBe('fallback')
   })
 })

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -1,8 +1,10 @@
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
-import { formatKeywordQuery, normalizeKeywordPhrases } from '@trends/shared'
+import { formatKeywordQuery, formatLocationHierarchySearchText, normalizeKeywordPhrases } from '@trends/shared'
+import { resolveResumeAnalysisSourceKey } from '@trends/shared'
 import type { ExperienceLevelFilter, UrlSearchState } from '@/hooks/useUrlSearchState'
 
 import type { CandidateStatus, ResumeFilters } from '@/types/resume'
+import type { CollectionSource } from '@/lib/search-profile-sources'
 
 const EDUCATION_KEYWORDS: Record<string, string[]> = {
   high_school: ['高中', '中专', '技校', 'high school'],
@@ -326,4 +328,29 @@ export function buildSearchHistoryTitle(location: string, keywords: string[], jo
   const primarySubject = normalizedKeywords || normalizedJobDescriptionId || ''
   const parts = [normalizedLocation, primarySubject].filter((value) => value.length > 0)
   return parts.join(' · ') || 'Untitled search'
+}
+
+export function getResumeLocationText(
+  resume: { location?: string; locationHierarchy?: { country: string; province?: string; city?: string; district?: string } }
+): string {
+  return formatLocationHierarchySearchText(resume.locationHierarchy) || resume.location || ''
+}
+
+export function resolveAnalysisSourceKeyForResume(
+  resume: Pick<ConvexResumeItem, 'source'> & { profileType?: string },
+  collectionSource: CollectionSource | undefined,
+): string | undefined {
+  return collectionSource?.type
+    ?? resolveResumeAnalysisSourceKey({
+      sourceKey: resume.profileType,
+      source: resume.source,
+    })
+}
+
+export function getResumeIdentityKey(resume: ConvexResumeItem, fallback: string): string {
+  const identityKey = resume.identityKey?.trim()
+  if (identityKey) {
+    return identityKey
+  }
+  return fallback
 }

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -4,7 +4,6 @@ import { useMutation, useQuery } from 'convex/react'
 import {
   buildWorkHistoryEntryText,
   formatKeywordQuery,
-  formatLocationHierarchySearchText,
   isLocationMatch,
   selectLatestWorkHistory,
 } from '@trends/shared'
@@ -30,6 +29,8 @@ import {
   areUrlFiltersEqual,
   appendKeywordToken,
   buildSearchHistoryTitle,
+  getResumeIdentityKey,
+  getResumeLocationText,
   getRoleYears,
   matchesAllRequiredKeywords,
   matchesEducationFilter,
@@ -40,6 +41,7 @@ import {
   parseExtractedAt,
   parseSalaryRange,
   parseSerializedStringArray,
+  resolveAnalysisSourceKeyForResume,
   serializeLocationFilter,
   taskMatchesCurrentSearch,
   toExperienceLevel,
@@ -55,7 +57,6 @@ import { rawApiClient } from '@/lib/api-helpers'
 import {
   getCurrentResumeAiPromptVersion,
   resolveAnalysisTopN,
-  resolveResumeAnalysisSourceKey,
 } from '@/lib/analysis-utils'
 import { submitResumeExportDownload, type ResumeExportRequestBody } from '@/lib/resume-export'
 import { getResumeAge, parseExperienceYears } from '@/lib/resume-filtering'
@@ -124,30 +125,6 @@ function resolveWorkspaceSlugFromPathname(pathname: string): string {
   return slug && slug.length > 0 ? slug : 'dev'
 }
 
-function getResumeLocationText(
-  resume: { location?: string; locationHierarchy?: { country: string; province?: string; city?: string; district?: string } }
-): string {
-  return formatLocationHierarchySearchText(resume.locationHierarchy) || resume.location || ''
-}
-
-function resolveAnalysisSourceKeyForResume(
-  resume: Pick<ConvexResumeItem, 'source'> & { profileType?: string },
-  collectionSource: CollectionSource | undefined,
-): string | undefined {
-  return collectionSource?.type
-    ?? resolveResumeAnalysisSourceKey({
-      sourceKey: resume.profileType,
-      source: resume.source,
-    })
-}
-
-function getResumeIdentityKey(resume: ConvexResumeItem, fallback: string): string {
-  const identityKey = resume.identityKey?.trim()
-  if (identityKey) {
-    return identityKey
-  }
-  return fallback
-}
 
 function buildResumeFilterSearchText(resume: ConvexResumeItem): string {
   const parts = [


### PR DESCRIPTION
## Summary
- Extract 3 pure utility functions from `useResumeListState.ts` into `resume-filter-helpers.ts` with 12 direct unit tests
- Remove now-unused imports (`formatLocationHierarchySearchText`, `resolveResumeAnalysisSourceKey`)
- Functions extracted: `getResumeLocationText`, `resolveAnalysisSourceKeyForResume`, `getResumeIdentityKey`

## Test plan
- [x] 120 unit tests in `resume-filter-helpers.test.ts` all green
- [x] 53 integration tests in `useResumeListState.test.tsx` all green
- [x] `make check` passes