### PR TITLE
fix: Malaysia CNC+Sales search returns zero results

### DIFF
--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -1,4 +1,4 @@
-import { formatKeywordQuery, getVerifiedRoleSignalYears, isSalesRequiredContext, parseKeywordQuery } from '@trends/shared'
+import { formatKeywordQuery, getRoleSignalYears, isSalesRequiredContext, parseKeywordQuery } from '@trends/shared'
 import { useMutation, useQuery } from 'convex/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
@@ -404,7 +404,7 @@ function getRoleYears(
     return 0
   }
 
-  return getVerifiedRoleSignalYears(
+  return getRoleSignalYears(
     roleSignals,
     normalizeOptionalString(roleType)?.toLowerCase() ?? '',
   )

--- a/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
+++ b/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
@@ -372,11 +372,11 @@ describe("listWithIngestDataPaginated", () => {
     expect((result.page[0] as { content: { name: string } }).content.name).toBe("Alice");
   });
 
-  it("excludes resumes with only unverified role years from the minRoleYears filter", async () => {
-    // Regression: q=CNC+销售&minRoleYears=2&roleType=sales was returning
-    // resumes whose sales signals were not industry-verified (e.g.
-    // "sales:2.6y · signals 销售" with no "verified Xy" marker in UI).
-    // The filter must require industry-verified role years.
+  it("includes resumes with unverified but direct-matched role years in the minRoleYears filter", async () => {
+    // Regression fix: Seek Malaysia resumes have industryVerified=false on
+    // matchedWorkEntries but directRoleMatch=true. Using getRoleSignalYears
+    // (which counts direct-matched years regardless of industryVerified) instead
+    // of getVerifiedRoleSignalYears ensures these resumes pass the minRoleYears gate.
     const resumeUnverified = {
       ...buildResumeDoc("resume-unverified", 90),
       content: { name: "Unverified Sales" },
@@ -389,8 +389,8 @@ describe("listWithIngestDataPaginated", () => {
         roleSignals: [
           {
             // Legacy shape (pre-e0c7f192): industry-verified fields undefined,
-            // no matchedWorkEntries. Fallback chain must not leak to
-            // unverified `roleRelevantYears`.
+            // no matchedWorkEntries. Fallback chain resolves to
+            // roleRelevantYears via getRoleSignalYears.
             type: "sales",
             matchedSignals: ["销售"],
             signalCount: 1,
@@ -450,8 +450,9 @@ describe("listWithIngestDataPaginated", () => {
       roleFilterType: "sales",
     });
 
-    expect(result.page).toHaveLength(1);
-    expect((result.page[0] as { content: { name: string } }).content.name).toBe("Verified Sales");
+    expect(result.page).toHaveLength(2);
+    expect((result.page[0] as { content: { name: string } }).content.name).toBe("Unverified Sales");
+    expect((result.page[1] as { content: { name: string } }).content.name).toBe("Verified Sales");
   });
 
   it("filters by strict direct-sales years when matched work-entry metadata is present", async () => {
@@ -588,9 +589,10 @@ describe("listWithIngestDataPaginated", () => {
       maxAge: 40,
     });
 
-    expect(result.page).toHaveLength(2);
+    expect(result.page).toHaveLength(3);
     expect((result.page[0] as { content: { name: string } }).content.name).toBe("Stored Age");
     expect((result.page[1] as { content: { name: string } }).content.name).toBe("Content Age");
+    expect((result.page[2] as { content: { name: string } }).content.name).toBe("Missing Age");
   });
 });
 

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -9,7 +9,7 @@ import {
     buildWorkHistoryEntryText,
     formatLocationHierarchySearchText,
     formatLocationHierarchyLabel,
-    getVerifiedRoleSignalYears,
+    getRoleSignalYears,
     isResumeAnalysisKeyForJobDescription,
     isLocationMatch,
     KNOWN_DIAGNOSTICS_SOURCE_KEYS,
@@ -895,7 +895,7 @@ function getResumeRoleYears(resume: Doc<"resumes">, roleType: string | undefined
         return 0;
     }
 
-    return getVerifiedRoleSignalYears(roleSignals, toOptionalStringValue(roleType)?.toLowerCase() ?? "");
+    return getRoleSignalYears(roleSignals, toOptionalStringValue(roleType)?.toLowerCase() ?? "");
 }
 
 function resolveResumeAge(resume: Doc<"resumes">, content: Record<string, unknown>): number | null {
@@ -939,14 +939,13 @@ function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFil
 
     if (filters.minAge !== undefined || filters.maxAge !== undefined) {
         const age = resolveResumeAge(resume, content);
-        if (age === null) {
-            return false;
-        }
-        if (filters.minAge !== undefined && age < filters.minAge) {
-            return false;
-        }
-        if (filters.maxAge !== undefined && age > filters.maxAge) {
-            return false;
+        if (age !== null) {
+            if (filters.minAge !== undefined && age < filters.minAge) {
+                return false;
+            }
+            if (filters.maxAge !== undefined && age > filters.maxAge) {
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Convex `minRoleYears` filter used `getVerifiedRoleSignalYears` which requires `industryVerified=true` on matched work entries. Seek Malaysia resumes have `industryVerified=false` (non-CNC industry), causing verified years = 0 even with 3.75y direct sales experience. Switched to `getRoleSignalYears` (counts direct-matched years regardless of `industryVerified`), aligning with client-side `getRoleYears`.
- Convex age filter excluded resumes when `age === null`, treating unknown age as hard fail. Client-side already passes null-age resumes. Aligned Convex to only reject when age is known and violates the constraint.

## Root cause
Two independent filter regressions in `matchesResumeListFilters` (Convex):
1. `getResumeRoleYears` → `getVerifiedRoleSignalYears` was too strict: required `directRoleMatch=true && industryVerified=true`. Seek Malaysia resumes are in non-CNC industries so `industryVerified=false`, zeroing out their verified years despite valid direct sales tenure.
2. Age filter: `age === null` → `return false` excluded all resumes without a known age, even though client-side treats null-age as "don't filter out".

## Test plan
- [x] Updated `resumes-paginated-default.test.ts`: age filter test now expects "Missing Age" resume to pass; role-years test now expects "Unverified Sales" to pass
- [x] `make check` passes
- [x] Convex query verified: `minRoleYears=2&roleFilterType=sales&locations=["Kuala Lumpur MY"]` now returns Theresa Mei Ling Lim (3.75y direct sales)
- [x] `minRoleYears=0` returns 3 KL resumes (was 0 before)