### PR TITLE
fix: update search-profiles test minExperience to match YAML source

### DIFF
--- a/apps/api/src/routes/search-profiles.test.ts
+++ b/apps/api/src/routes/search-profiles.test.ts
@@ -90,7 +90,7 @@ const seededJob51Profile = {
   keywords: ['CNC', '销售'],
   jobDescription: 'lathe-sales',
   filters: {
-    minExperience: 2,
+    minExperience: 1,
     maxExperience: null,
     locations: ['China'],
   },
@@ -190,7 +190,7 @@ describe('search-profiles list route', () => {
           filters: expect.objectContaining({
             minAge: 25,
             maxAge: 40,
-            minExperience: 2,
+            minExperience: 1,
           }),
           sources: expect.arrayContaining([
             expect.objectContaining({
@@ -209,7 +209,7 @@ describe('search-profiles list route', () => {
           filters: expect.objectContaining({
             minAge: 25,
             maxAge: 40,
-            minExperience: 2,
+            minExperience: 1,
           }),
           sources: expect.arrayContaining([
             expect.objectContaining({
@@ -227,7 +227,7 @@ describe('search-profiles list route', () => {
           id: 'seek-malaysia-sales',
           filters: expect.objectContaining({
             maxAge: 45,
-            minExperience: 2,
+            minExperience: 1,
           }),
           sources: expect.arrayContaining([
             expect.objectContaining({


### PR DESCRIPTION
## Summary
- Update `apps/api/src/routes/search-profiles.test.ts` to expect `minExperience: 1` instead of `2`, matching the YAML canonical source updated in #656/#657

## Why
PR #657 changed YAML → generated TS templates to use `minExperience: 1`, but the API test was missed. CI test `materializes seeded template profiles into editable workspace records` failed because it still expected `minExperience: 2`.

## Test plan
- [x] `npm run test:api:search-profiles` passes locally