### PR TITLE
feat: auto-resurrect soft-deleted config profiles when template changes

### DIFF
--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import {
+    computeTemplateHash,
     findWorkspaceSearchProfileTemplate,
     generateStructuredJobDescriptionContent,
     getWorkspaceSearchProfileTemplates,
@@ -459,6 +460,11 @@ function readDeletedAt(record: ConvexSearchProfileRecord): number | undefined {
     return readNumber(profilePayload.deletedAt);
 }
 
+function readTemplateHash(record: ConvexSearchProfileRecord): string | undefined {
+    const profilePayload = readProfilePayload(record);
+    return readString(profilePayload.templateHash);
+}
+
 function isSeededFromConfig(record: ConvexSearchProfileRecord): boolean {
     const profilePayload = readProfilePayload(record);
     return readString(profilePayload.seedSource) === CONFIG_SEED_SOURCE;
@@ -469,12 +475,14 @@ function toStoredProfilePayload(
     options?: {
         seededFromConfig?: boolean;
         deletedAt?: number;
+        templateHash?: string;
     }
 ): Record<string, unknown> {
     return {
         ...profile,
         ...(options?.seededFromConfig ? { seedSource: CONFIG_SEED_SOURCE } : {}),
         ...(typeof options?.deletedAt === "number" ? { deletedAt: options.deletedAt } : {}),
+        ...(options?.templateHash ? { templateHash: options.templateHash } : {}),
     };
 }
 
@@ -526,6 +534,7 @@ type ResolvedCustomProfileRecord = {
     logicalId: string;
     profile: SearchProfile;
     seededFromConfig: boolean;
+    templateHash?: string;
     deletedAt?: number;
 };
 
@@ -590,6 +599,7 @@ async function listCustomProfileRecords(
                 logicalId,
                 profile,
                 seededFromConfig: isSeededFromConfig(item),
+                templateHash: readTemplateHash(item),
                 ...(typeof deletedAt === "number" ? { deletedAt } : {}),
             });
         });
@@ -637,43 +647,81 @@ async function findCustomProfileRecordById(
         logicalId,
         profile,
         seededFromConfig: isSeededFromConfig(record),
+        templateHash: readTemplateHash(record),
         deletedAt,
     };
 }
 
 async function ensureWorkspaceSeedProfiles(workspaceSlug: string): Promise<void> {
     const existingRecords = await listCustomProfileRecords(workspaceSlug, { includeDeleted: true });
-    const existingIds = new Set(existingRecords.map((record) => record.logicalId));
+    const existingByLogicalId = new Map<string, ResolvedCustomProfileRecord>(
+        existingRecords.map((record) => [record.logicalId, record]),
+    );
 
     for (const template of getWorkspaceSearchProfileTemplates(workspaceSlug)) {
         const profile = searchProfileService.normalizeProfileInput(template.profile);
         const logicalId = searchProfileService.normalizeProfileIdentifier(profile.id);
-        if (existingIds.has(logicalId)) {
+        const currentHash = computeTemplateHash(template.profile);
+        const existing = existingByLogicalId.get(logicalId);
+
+        if (!existing) {
+            await createCustomProfile(
+                toStoredProfilePayload(profile, { seededFromConfig: true, templateHash: currentHash }),
+                workspaceSlug,
+            );
             continue;
         }
 
-        await createCustomProfile(
-            toStoredProfilePayload(profile, { seededFromConfig: true }),
+        const isSoftDeleted = typeof existing.deletedAt === "number";
+        if (!isSoftDeleted) {
+            continue;
+        }
+
+        const hashMatches = existing.templateHash === currentHash;
+        if (hashMatches) {
+            continue;
+        }
+
+        await updateCustomProfile(
+            existing.storageId,
+            toStoredProfilePayload(profile, { seededFromConfig: true, templateHash: currentHash }),
             workspaceSlug,
         );
-        existingIds.add(logicalId);
     }
 }
 
 async function ensureWorkspaceProfileById(id: string, workspaceSlug: string): Promise<void> {
     const existing = await findCustomProfileRecordById(id, workspaceSlug, { includeDeleted: true });
-    if (existing) {
-        return;
-    }
-
     const template = findWorkspaceSearchProfileTemplate(id, workspaceSlug);
     if (!template) {
         return;
     }
 
+    const currentHash = computeTemplateHash(template.profile);
+
+    if (!existing) {
+        const profile = searchProfileService.normalizeProfileInput(template.profile);
+        await createCustomProfile(
+            toStoredProfilePayload(profile, { seededFromConfig: true, templateHash: currentHash }),
+            workspaceSlug,
+        );
+        return;
+    }
+
+    const isSoftDeleted = typeof existing.deletedAt === "number";
+    if (!isSoftDeleted) {
+        return;
+    }
+
+    const hashMatches = existing.templateHash === currentHash;
+    if (hashMatches) {
+        return;
+    }
+
     const profile = searchProfileService.normalizeProfileInput(template.profile);
-    await createCustomProfile(
-        toStoredProfilePayload(profile, { seededFromConfig: true }),
+    await updateCustomProfile(
+        existing.storageId,
+        toStoredProfilePayload(profile, { seededFromConfig: true, templateHash: currentHash }),
         workspaceSlug,
     );
 }
@@ -1546,6 +1594,7 @@ app.openapi(deleteProfileRoute, async (c) => {
                 existingCustom.storageId,
                 toStoredProfilePayload(existingCustom.profile, {
                     seededFromConfig: true,
+                    templateHash: existingCustom.templateHash,
                     deletedAt: Date.now(),
                 }),
                 c.var.workspaceSlug,

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -4,7 +4,9 @@ import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import {
     buildLatestWorkHistoryEvidence,
+    computeTemplateHash,
     formatLocationHierarchyLabel,
+    getWorkspaceSearchProfileTemplates,
     normalizeJob5156ProfileUrlForDisplay,
     normalizeResumeLocationHierarchy,
     normalizeWorkHistoryEntry,
@@ -1392,6 +1394,58 @@ export const backfillSourceKey = mutation({
             updatedResumes: updated,
             hasMore: !resumes.isDone,
             cursor: resumes.isDone ? null : resumes.continueCursor,
+        };
+    },
+});
+
+export const backfillSearchProfileTemplateHash = mutation({
+    args: {
+        cursor: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const profiles = await ctx.db
+            .query("search_profiles")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: 100,
+            });
+
+        const templates = getWorkspaceSearchProfileTemplates("dev");
+        const templateById = new Map(
+            templates.map((t) => [t.profile.id, t]),
+        );
+
+        let updated = 0;
+        for (const profile of profiles.page) {
+            const profileData = isRecord(profile.profile) ? profile.profile : {};
+            const existingHash = typeof profileData.templateHash === "string" ? profileData.templateHash : undefined;
+            if (existingHash) {
+                continue;
+            }
+
+            const profileId = profile.profileId ?? (typeof profileData.id === "string" ? profileData.id : "");
+            const template = templateById.get(profileId);
+            if (!template) {
+                continue;
+            }
+
+            const seedSource = typeof profileData.seedSource === "string" ? profileData.seedSource : "";
+            if (seedSource !== "config/search-profiles") {
+                continue;
+            }
+
+            const currentHash = computeTemplateHash(template.profile);
+            const merged = { ...profileData, templateHash: currentHash };
+            await ctx.db.patch(profile._id, { profile: merged });
+            updated += 1;
+        }
+
+        return {
+            scanned: profiles.page.length,
+            updated,
+            hasMore: !profiles.isDone,
+            cursor: profiles.isDone ? null : profiles.continueCursor,
         };
     },
 });

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -189,6 +189,7 @@ export default defineSchema({
         createdAt: v.optional(v.number()),
         updatedAt: v.optional(v.number()),
         workspaceSlug: v.optional(v.string()),
+        templateHash: v.optional(v.string()),
     }).index("by_workspace", ["workspaceSlug"]),
 
     // Custom Job Descriptions

--- a/packages/shared/src/generated/search-profile-templates.ts
+++ b/packages/shared/src/generated/search-profile-templates.ts
@@ -267,3 +267,23 @@ export function findWorkspaceSearchProfileTemplate(
     template.profile.id.trim().toLowerCase() === normalizedId
   )) ?? null;
 }
+
+export function computeTemplateHash(profile: SharedSearchProfileTemplate["profile"]): string {
+  const canonical = JSON.stringify(profile, (_key, value) => {
+    if (value === undefined || value === null) return undefined;
+    if (Array.isArray(value)) return [...value].sort();
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      return Object.keys(value).sort().reduce<Record<string, unknown>>((acc, k) => {
+        acc[k] = value[k as keyof typeof value];
+        return acc;
+      }, {});
+    }
+    return value;
+  });
+  let hash = 0;
+  for (let i = 0; i < canonical.length; i++) {
+    const chr = canonical.charCodeAt(i);
+    hash = ((hash << 5) - hash + chr) | 0;
+  }
+  return "sp-" + Math.abs(hash).toString(36);
+}

--- a/scripts/resume/sync-search-profile-templates.ts
+++ b/scripts/resume/sync-search-profile-templates.ts
@@ -353,6 +353,26 @@ export function findWorkspaceSearchProfileTemplate(
     template.profile.id.trim().toLowerCase() === normalizedId
   )) ?? null;
 }
+
+export function computeTemplateHash(profile: SharedSearchProfileTemplate["profile"]): string {
+  const canonical = JSON.stringify(profile, (_key, value) => {
+    if (value === undefined || value === null) return undefined;
+    if (Array.isArray(value)) return [...value].sort();
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      return Object.keys(value).sort().reduce<Record<string, unknown>>((acc, k) => {
+        acc[k] = value[k as keyof typeof value];
+        return acc;
+      }, {});
+    }
+    return value;
+  });
+  let hash = 0;
+  for (let i = 0; i < canonical.length; i++) {
+    const chr = canonical.charCodeAt(i);
+    hash = ((hash << 5) - hash + chr) | 0;
+  }
+  return "sp-" + Math.abs(hash).toString(36);
+}
 `;
 }
 


### PR DESCRIPTION
## Summary
- Add `templateHash` to Convex `search_profiles` schema for tracking which template version a config-seeded record was created from
- Add `computeTemplateHash()` utility to shared generated templates
- Update seed logic: if a config-seeded profile is soft-deleted and its template hash differs from current YAML, re-activate with new data. If hash matches, stay deleted (user intent preserved)
- Add `backfillSearchProfileTemplateHash` migration for existing records
- Preserve `templateHash` on soft-delete to enable future auto-resurrect

## Why
After deploying updated YAML templates (e.g., `minExperience: 1`), soft-deleted profiles stayed stale because `ensureWorkspaceSeedProfiles()` skipped any existing record by logicalId. The hash comparison ensures template changes self-heal while respecting explicit deletes when nothing changed.

## Test plan
- [x] `make check` passes (all checks including new search-profile-templates check)
- [x] `npm run test:api:search-profiles` passes (14/14)
- [x] Hash is deterministic and detects profile data changes