### PR TITLE
fix: precomputed verifiedRoleYears for minRoleYears filter

### DIFF
--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -1,6 +1,7 @@
 import {
   buildLatestWorkHistoryEvidence,
   buildWorkHistoryEntryText,
+  computeVerifiedRoleYears,
   formatLocationHierarchySearchText,
   normalizeResumeLocationHierarchy,
   normalizeWorkHistoryEntry,
@@ -49,6 +50,7 @@ export interface IngestResult {
   industryDbV2Raw: number;
   industryDbV2RawComponents: IndustryDbV2RawComponents;
   roleSignals: RoleSignalSummary[];
+  verifiedRoleYears: Record<string, number>;
   taggingEnvelope: TaggingEnvelope;
   companyPatternAliasTokens: string;
   ruleScores: Record<string, number>;  // jdId → score (0-100)
@@ -544,6 +546,7 @@ export class IngestComputeService {
       industryDbV2Raw,
       industryDbV2RawComponents,
       roleSignals,
+      verifiedRoleYears: computeVerifiedRoleYears(roleSignals),
       taggingEnvelope,
       companyPatternAliasTokens,
       ruleScores,

--- a/docs/superpowers/plans/2026-04-24-direct-role-years-precomputed-field-plan.md
+++ b/docs/superpowers/plans/2026-04-24-direct-role-years-precomputed-field-plan.md
@@ -1,0 +1,199 @@
+# verifiedRoleYears Precomputed Field — minRoleYears Hardening Plan
+
+Date: 2026-04-24
+Author: agent (with karl)
+Supersedes-semantics-of: PR #655 (`fix: use getRoleSignalYears for minRoleYears filter ...`)
+Related prior plan: `docs/superpowers/plans/2026-04-15-sales-role-detection-and-relatedexp-hardening-plan.md`
+Related observations: S2308 (*Malaysia CNC Sales zero-result: industryVerified=false kills verifiedYears calculation*)
+
+## Decision (2026-04-24, confirmed by karl)
+
+**Strict industry-verified gating.** `minRoleYears` gates on `industryVerifiedRelevantYears ?? industryVerifiedYears` only. This matches the `verified Xy` number shown in the `roleEvidence` export column (`apps/api/src/services/export-service.ts:125-146`).
+
+**Consequence: Seek Malaysia resumes with `industryVerified=false` will be rejected.** This reverses PR #655's permissive behavior. Fixing upstream `industryVerified=false` for real Seek Malaysia salespeople is a **separate** workstream, not part of this plan.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:test-driven-development`. Every step lands a red test first, then makes it green. Do NOT skip the red phase.
+
+---
+
+## Problem
+
+`minRoleYears` + `roleFilterType=sales` is supposed to gate on the **industry-verified** `verified Xy` number that operators see in the `roleEvidence` export column. Today it does not.
+
+Current call chain in `packages/convex/convex/resumes.ts:933`:
+
+```
+matchesResumeListFilters
+  → getResumeRoleYears(resume, roleType)            (resumes.ts:892)
+    → getRoleSignalYears(roleSignals, roleType)     (packages/shared/src/analysis-key.ts:329)
+```
+
+`getRoleSignalYears` fallback chain (`analysis-key.ts:361-366`):
+
+```
+industryVerifiedRelevantYears
+?? roleRelevantYears       // unverified; admits adjacent/support
+?? industryVerifiedYears
+?? years                   // RAW TOTAL EXPERIENCE
+?? 0
+```
+
+A resume with only `years=10` (no roleSignal match for sales, no industry-verified evidence) currently passes `minRoleYears=10&roleType=sales`. A resume showing `sales:4.9y · signals 业务` (no `verified` chip) falls back to 4.9 rather than using 0. Both contradict the operator's mental model that `minRoleYears` equals the `verified Xy` value.
+
+PR #655 chose the permissive helper to keep Seek Malaysia resumes (`industryVerified=false`, observation S2308) in results. Karl confirmed 2026-04-24 that strict verified gating is the correct semantic — upstream `industryVerified=false` for real Malaysian salespeople is a **separate** bug to fix in its own workstream.
+
+**We need a single, unambiguous source of truth that:**
+1. Gates on the exact `verified Xy` value displayed in `roleEvidence`.
+2. Rejects resumes with only unverified `roleRelevantYears` or raw `years`.
+3. Cannot be re-broken by a future engineer picking the wrong helper.
+
+---
+
+## Decision
+
+Add a precomputed field `ingestData.verifiedRoleYears: Record<string, number>` populated at ingest. The filter reads this field directly. No helper, no fallback chain, no second opinion.
+
+### Why not alternative approaches
+
+| Option | Why rejected |
+|---|---|
+| Swap to `getVerifiedRoleSignalYears` only (no field) | Two helpers remain with subtly different rules — next engineer picks wrong one again |
+| Tighten `getRoleSignalYears` fallback (drop `?? years`) | Same as above; also keeps unverified `roleRelevantYears` in the filter path |
+| DB index / query tuning | Doesn't touch semantics |
+| Add `strict` flag to `getRoleSignalYears` | Runtime branching still invites wrong callsite choice |
+| `directRoleYears` (directRoleMatch only) | Rejected 2026-04-24 by karl: he wants the UI's `verified Xy` number, which is industry-verified, not title-verified |
+
+### Semantic contract (the only rule readers need to remember)
+
+> `ingestData.verifiedRoleYears[roleType]` = `industryVerifiedRelevantYears ?? industryVerifiedYears ?? 0`, read from the `roleSignal` whose `type === roleType`.
+>
+> Requires `industryVerified === true` in the upstream signal computation.
+>
+> `minRoleYears` filter passes iff `verifiedRoleYears[roleType] >= minRoleYears`.
+>
+> Missing field ⇒ 0 ⇒ rejected.
+
+---
+
+## Files Touched (ordered)
+
+1. **Tests first**
+   - `packages/convex/convex/__tests__/resumes-paginated-default.test.ts` — add regression tests.
+   - `packages/shared/src/analysis-key.test.ts` (create if missing, else add) — lock `computeVerifiedRoleYears` helper semantics.
+
+2. **Shared helper**
+   - `packages/shared/src/analysis-key.ts` — add `computeVerifiedRoleYears(roleSignals)` returning `Record<string, number>`. Later: drop `?? years` from `getRoleSignalYears` fallback.
+
+3. **Schema**
+   - `packages/convex/convex/schema.ts` — add `verifiedRoleYears: v.optional(v.record(v.string(), v.number()))` to the `ingestData` validator.
+
+4. **Ingest / store**
+   - Wherever `ingestData` is assembled for resume writes — search for `roleSignals:` assignment, add `verifiedRoleYears: computeVerifiedRoleYears(roleSignals)` next to it. Likely sites: `packages/convex/convex/resumes.ts`, `apps/api/src/services/resume-service.ts`, any analysis task that rewrites `ingestData`.
+
+5. **Filter**
+   - `packages/convex/convex/resumes.ts:933` — replace `getResumeRoleYears` call with `resume.ingestData?.verifiedRoleYears?.[roleType] ?? 0`.
+
+6. **Migration**
+   - `packages/convex/convex/migrations.ts` — paginated backfill (repo convention, see memory entry *"all resume-scanning migrations use .paginate()"*).
+
+7. **Cleanup**
+   - `packages/shared/src/analysis-key.ts` — remove `?? years` (raw total) from `getRoleSignalYears` fallback; audit remaining callers. If no callsite needs the unverified `roleRelevantYears` path, deprecate that branch with a comment pointing at this plan.
+
+---
+
+## Tasks (checkbox-tracked)
+
+### Task 1 — Feature branch + plan snapshot
+- [ ] Branch: `fix/min-role-years-direct-role-years-field`
+- [ ] This plan already saved at `docs/superpowers/plans/2026-04-24-direct-role-years-precomputed-field-plan.md`
+
+### Task 2 — Red: filter regression tests
+Add to `packages/convex/convex/__tests__/resumes-paginated-default.test.ts`:
+
+- [ ] **verified-only resume passes**: resume with `ingestData.verifiedRoleYears: { sales: 5 }`. `minRoleYears:1, roleFilterType:"sales"` → resume included.
+- [ ] **roleRelevantYears-only rejected**: resume with a `roleSignals: [{ type:"sales", roleRelevantYears:10, industryVerifiedRelevantYears: undefined }]`, no `verifiedRoleYears` field → **rejected** by `minRoleYears:1, roleFilterType:"sales"`.
+- [ ] **raw-years-only rejected**: resume with `ingestData.roleSignals=[]`, `years=10`, no `verifiedRoleYears` → **rejected** by `minRoleYears:1, roleFilterType:"sales"`.
+- [ ] **Seek Malaysia rejected (documented consequence)**: resume with `roleSignals: [{ type:"sales", matchedWorkEntries:[{ directRoleMatch:true, industryVerified:false, years:3 }] }]`, no `industryVerifiedRelevantYears` → **rejected**. Test comment must point at this plan so reviewers know the rejection is intentional and the fix is an upstream industryVerified repair.
+
+Run tests; they must fail before next task.
+
+### Task 3 — Red: shared helper test
+- [ ] Add `computeVerifiedRoleYears` case in analysis-key tests: mixed signals (sales with `industryVerifiedRelevantYears:5`, engineering with `industryVerifiedYears:3` only, adjacent with only `roleRelevantYears:7`) → expect `{sales: 5, engineering: 3}`. The role with only `roleRelevantYears` must NOT appear — never fall back to unverified years.
+
+### Task 4 — Green: implement helper
+- [ ] In `packages/shared/src/analysis-key.ts`, add:
+  ```ts
+  export function computeVerifiedRoleYears(
+    roleSignals: AnalysisRoleSignalLike[] | undefined
+  ): Record<string, number>
+  ```
+  For each signal, resolve `industryVerifiedRelevantYears ?? industryVerifiedYears ?? 0`. Key by `signal.type.trim().toLowerCase()`. Drop entries where the resolved value is 0. Never read `years` or `roleRelevantYears`. Mirrors the numerator used by `formatRoleEvidence` (`apps/api/src/services/export-service.ts:133`) so the UI `verified Xy` chip and the filter stay in lockstep.
+- [ ] Export from `packages/shared/src/index.ts` if that's the barrel.
+- [ ] Run shared test → green.
+
+### Task 5 — Green: schema + ingest population
+- [ ] `packages/convex/convex/schema.ts` — add optional `verifiedRoleYears` to `ingestData`.
+- [ ] Every writer of `ingestData` calls `computeVerifiedRoleYears(roleSignals)` and stores the result. Identify all sites via Grep for `roleSignals:` assignments in `packages/` and `apps/`, and check each that assigns `roleSignals`.
+- [ ] Existing ingest tests must still pass.
+
+### Task 6 — Green: filter swap
+- [ ] `packages/convex/convex/resumes.ts:933`:
+  ```ts
+  if ((filters.minRoleYears ?? 0) > 0) {
+      const key = (filters.roleFilterType ?? "").trim().toLowerCase() || "sales";
+      const y = resume.ingestData?.verifiedRoleYears?.[key] ?? 0;
+      if (y < filters.minRoleYears!) return false;
+  }
+  ```
+- [ ] Delete `getResumeRoleYears` helper if no callers remain.
+- [ ] Regression tests from Task 2 → green.
+
+### Task 7 — Backfill migration
+- [ ] Add paginated migration to `packages/convex/convex/migrations.ts` named `backfillDirectRoleYears`. For each resume:
+  - Compute `computeVerifiedRoleYears(ingestData?.roleSignals)`.
+  - Patch only if result differs from existing `ingestData.verifiedRoleYears`.
+- [ ] Follow the repo's paginated migration convention (see existing migrations in the same file).
+
+### Task 8 — Cleanup / prevention
+- [ ] Remove `?? years` branch from `getRoleSignalYears` in `analysis-key.ts:361-366`. Add doc comment on the function warning readers that this is a **ranking/display helper** and must NOT be used for hard filters — point at this plan.
+- [ ] Audit remaining `getRoleSignalYears` callers (from Grep earlier: `packages/convex/convex/resumes.ts`, the same file's tests, `apps/web/src/hooks/useResumeSearchState.ts`, `packages/shared/src/analysis-key.ts`). For each, confirm ranking/display usage is OK with the narrowed fallback.
+- [ ] Update the 2026-04-15 plan doc (`docs/superpowers/plans/2026-04-15-sales-role-detection-and-relatedexp-hardening-plan.md`) with a short pointer to this plan's outcome so the next reader follows this trail instead of rediscovering #655.
+
+### Task 9 — Validation + ship
+- [ ] `make check` — must pass.
+- [ ] `make check TARGET=all` if governance changed (not expected here).
+- [ ] Commit, push feature branch, open PR titled `fix: precomputed verifiedRoleYears for minRoleYears filter`.
+- [ ] `gh pr merge <n> --squash --auto`.
+
+---
+
+## Regression-Prevention Invariants
+
+After this lands, the following must be true and tested:
+
+1. **The filter reads exactly one field.** Grep in `resumes.ts`: `minRoleYears` should appear only near `verifiedRoleYears`. If a future PR adds another `getRoleSignalYears`/`getVerifiedRoleSignalYears` call to the filter path, code review catches it.
+2. **`computeVerifiedRoleYears` never reads `years` or `roleRelevantYears`.** A unit test pins this by supplying a resume with those two fields set and `industryVerifiedRelevantYears`/`industryVerifiedYears` absent — expected output `{}`.
+3. **Backfill is idempotent.** Running the migration twice produces the same state.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Ingest writers miss populating the new field → 0-results regression | Paginated backfill covers existing data; Task 5 audit covers all write sites; filter treats missing field as 0 which is the safe default (no one over-passes). |
+| Other callers of `getRoleSignalYears` depend on `?? years` (Task 8 cleanup) | Audit step in Task 8. If any legitimate display usage needs raw years as a last resort, keep the branch but gate behind an explicit `{ allowRawYears: true }` option. |
+| Backfill write rate hits Convex local dev 4 MiB/s limit | Existing paginated-migration infra handles this; backfill runs in prod manually via standard migration workflow. |
+
+---
+
+## Sources Used
+
+- Local files:
+  - `packages/convex/convex/resumes.ts:892-899, 933-938`
+  - `packages/shared/src/analysis-key.ts:267-327, 329-388`
+  - `packages/convex/convex/__tests__/resumes-paginated-default.test.ts:374-390`
+  - `docs/superpowers/plans/2026-04-15-sales-role-detection-and-relatedexp-hardening-plan.md:64`
+  - Git log: `e8e7e042` (PR #655), `64ce563c` (PR #613), `84464d70`
+- Context7: none (repo-internal refactor, no library API question).
+- Web: none.

--- a/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
+++ b/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
@@ -372,11 +372,16 @@ describe("listWithIngestDataPaginated", () => {
     expect((result.page[0] as { content: { name: string } }).content.name).toBe("Alice");
   });
 
-  it("includes resumes with unverified but direct-matched role years in the minRoleYears filter", async () => {
-    // Regression fix: Seek Malaysia resumes have industryVerified=false on
-    // matchedWorkEntries but directRoleMatch=true. Using getRoleSignalYears
-    // (which counts direct-matched years regardless of industryVerified) instead
-    // of getVerifiedRoleSignalYears ensures these resumes pass the minRoleYears gate.
+  it("rejects resumes with unverified role years from minRoleYears (strict verified gating)", async () => {
+    // Plan: docs/superpowers/plans/2026-04-24-direct-role-years-precomputed-field-plan.md
+    //
+    // Semantic contract (2026-04-24): minRoleYears gates on the same
+    // `verified Xy` number shown in the `roleEvidence` export column —
+    // `industryVerifiedRelevantYears ?? industryVerifiedYears`. Resumes
+    // with only `roleRelevantYears`/`years` (no industry verification) are
+    // rejected. This intentionally reverses PR #655's permissive behavior.
+    // Fixing upstream `industryVerified=false` for real Seek Malaysia
+    // salespeople is a separate workstream.
     const resumeUnverified = {
       ...buildResumeDoc("resume-unverified", 90),
       content: { name: "Unverified Sales" },
@@ -388,9 +393,6 @@ describe("listWithIngestDataPaginated", () => {
         skillsVersion: 1,
         roleSignals: [
           {
-            // Legacy shape (pre-e0c7f192): industry-verified fields undefined,
-            // no matchedWorkEntries. Fallback chain resolves to
-            // roleRelevantYears via getRoleSignalYears.
             type: "sales",
             matchedSignals: ["销售"],
             signalCount: 1,
@@ -411,6 +413,7 @@ describe("listWithIngestDataPaginated", () => {
         experienceLevel: "mid",
         computedAt: 1,
         skillsVersion: 1,
+        verifiedRoleYears: { sales: 3 },
         roleSignals: [
           {
             type: "sales",
@@ -450,9 +453,105 @@ describe("listWithIngestDataPaginated", () => {
       roleFilterType: "sales",
     });
 
-    expect(result.page).toHaveLength(2);
-    expect((result.page[0] as { content: { name: string } }).content.name).toBe("Unverified Sales");
-    expect((result.page[1] as { content: { name: string } }).content.name).toBe("Verified Sales");
+    expect(result.page).toHaveLength(1);
+    expect((result.page[0] as { content: { name: string } }).content.name).toBe("Verified Sales");
+  });
+
+  it("rejects resumes with only signal.years (raw) from minRoleYears filter", async () => {
+    // Plan: docs/superpowers/plans/2026-04-24-direct-role-years-precomputed-field-plan.md
+    //
+    // Prevents regression where `getRoleSignalYears` fallback returned raw
+    // `signal.years` when no verified field was present — admitting resumes
+    // whose role signal carried raw career total as "role years".
+    const resumeRaw = {
+      ...buildResumeDoc("resume-raw-years", 90),
+      content: { name: "Raw Years" },
+      ingestData: {
+        ruleScores: {},
+        industryTags: [],
+        experienceLevel: "mid",
+        computedAt: 1,
+        skillsVersion: 1,
+        roleSignals: [
+          {
+            type: "sales",
+            matchedSignals: [],
+            signalCount: 0,
+            occurrences: 0,
+            years: 10,
+            verifyIn: "workHistory",
+          },
+        ],
+      },
+    };
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => withFilterPassthrough({
+              paginate: async () => ({
+                page: [resumeRaw],
+                continueCursor: "cursor-next",
+                isDone: false,
+              }),
+              take: async () => [],
+            }),
+          }),
+        }),
+      },
+    };
+
+    const result = await handler(ctx, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      minRoleYears: 1,
+      roleFilterType: "sales",
+    });
+
+    expect(result.page).toHaveLength(0);
+  });
+
+  it("reads ingestData.verifiedRoleYears directly when present (stored field is the source of truth)", async () => {
+    // Plan: docs/superpowers/plans/2026-04-24-direct-role-years-precomputed-field-plan.md
+    const resumeStored = {
+      ...buildResumeDoc("resume-stored", 90),
+      content: { name: "Stored Verified" },
+      ingestData: {
+        ruleScores: {},
+        industryTags: [],
+        experienceLevel: "mid",
+        computedAt: 1,
+        skillsVersion: 1,
+        verifiedRoleYears: { sales: 5 },
+        // Intentionally no roleSignals — filter must read the stored field.
+      },
+    };
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            order: () => withFilterPassthrough({
+              paginate: async () => ({
+                page: [resumeStored],
+                continueCursor: "cursor-next",
+                isDone: false,
+              }),
+              take: async () => [],
+            }),
+          }),
+        }),
+      },
+    };
+
+    const result = await handler(ctx, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      minRoleYears: 3,
+      roleFilterType: "sales",
+    });
+
+    expect(result.page).toHaveLength(1);
+    expect((result.page[0] as { content: { name: string } }).content.name).toBe("Stored Verified");
   });
 
   it("filters by strict direct-sales years when matched work-entry metadata is present", async () => {

--- a/packages/convex/convex/ingest_agent.ts
+++ b/packages/convex/convex/ingest_agent.ts
@@ -103,6 +103,7 @@ export const processNewResumes = internalAction({
           industryDbV2Raw: item.industryDbV2Raw,
           industryDbV2RawComponents: item.industryDbV2RawComponents || undefined,
           roleSignals: item.roleSignals || [],
+          verifiedRoleYears: item.verifiedRoleYears || undefined,
           taggingEnvelope: item.taggingEnvelope || undefined,
           ruleScores: item.ruleScores,
           experienceLevel: item.experienceLevel,

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -5,6 +5,7 @@ import { v } from "convex/values";
 import {
     buildLatestWorkHistoryEvidence,
     computeTemplateHash,
+    computeVerifiedRoleYears,
     formatLocationHierarchyLabel,
     getWorkspaceSearchProfileTemplates,
     normalizeJob5156ProfileUrlForDisplay,
@@ -1397,6 +1398,71 @@ export const backfillSourceKey = mutation({
         };
     },
 });
+
+/**
+ * Backfill `ingestData.verifiedRoleYears` from existing `ingestData.roleSignals`.
+ *
+ * See plan: docs/superpowers/plans/2026-04-24-direct-role-years-precomputed-field-plan.md
+ *
+ * Idempotent: compares the computed map against the existing value and only
+ * patches when the result differs.
+ */
+export const backfillVerifiedRoleYears = mutation({
+    args: {
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const resumes = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.batchSize),
+            });
+
+        let updated = 0;
+        for (const resume of resumes.page) {
+            if (!resume.ingestData) continue;
+
+            const computed = computeVerifiedRoleYears(resume.ingestData.roleSignals);
+            const existing = resume.ingestData.verifiedRoleYears;
+
+            if (shallowEqualNumberRecord(existing, computed)) continue;
+
+            await ctx.db.patch(resume._id, {
+                ingestData: {
+                    ...resume.ingestData,
+                    verifiedRoleYears: computed,
+                },
+            });
+            updated += 1;
+        }
+
+        return {
+            scannedResumes: resumes.page.length,
+            updatedResumes: updated,
+            hasMore: !resumes.isDone,
+            cursor: resumes.isDone ? null : resumes.continueCursor,
+        };
+    },
+});
+
+function shallowEqualNumberRecord(
+    a: Record<string, number> | undefined,
+    b: Record<string, number>,
+): boolean {
+    if (!a) {
+        return Object.keys(b).length === 0;
+    }
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) return false;
+    for (const key of aKeys) {
+        if (a[key] !== b[key]) return false;
+    }
+    return true;
+}
 
 export const backfillSearchProfileTemplateHash = mutation({
     args: {

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -9,7 +9,7 @@ import {
     buildWorkHistoryEntryText,
     formatLocationHierarchySearchText,
     formatLocationHierarchyLabel,
-    getRoleSignalYears,
+    getVerifiedRoleSignalYears,
     isResumeAnalysisKeyForJobDescription,
     isLocationMatch,
     KNOWN_DIAGNOSTICS_SOURCE_KEYS,
@@ -889,13 +889,36 @@ function matchesAllRequiredKeywords(text: string, requiredKeywords: string[] | u
     return normalizedKeywords.every((keyword) => haystack.includes(keyword));
 }
 
+/**
+ * Resolve the verified role-years value used by the `minRoleYears` filter.
+ *
+ * Preference order:
+ *   1. Precomputed `ingestData.verifiedRoleYears[roleType]` (populated at
+ *      ingest time and by the paginated backfill migration).
+ *   2. Live compute via `getVerifiedRoleSignalYears` — same semantics as the
+ *      stored projection. Guards the transition window before backfill
+ *      completes, and old resumes whose `ingestData` has not been rewritten.
+ *
+ * Never consults unverified `roleRelevantYears` or raw `years`. See plan:
+ * docs/superpowers/plans/2026-04-24-direct-role-years-precomputed-field-plan.md
+ */
 function getResumeRoleYears(resume: Doc<"resumes">, roleType: string | undefined): number {
+    const key = toOptionalStringValue(roleType)?.toLowerCase() ?? "";
+    if (!key) {
+        return 0;
+    }
+
+    const stored = resume.ingestData?.verifiedRoleYears?.[key];
+    if (typeof stored === "number" && Number.isFinite(stored)) {
+        return stored;
+    }
+
     const roleSignals = resume.ingestData?.roleSignals;
     if (!Array.isArray(roleSignals) || roleSignals.length === 0) {
         return 0;
     }
 
-    return getRoleSignalYears(roleSignals, toOptionalStringValue(roleType)?.toLowerCase() ?? "");
+    return getVerifiedRoleSignalYears(roleSignals, key);
 }
 
 function resolveResumeAge(resume: Doc<"resumes">, content: Record<string, unknown>): number | null {
@@ -2561,6 +2584,7 @@ export const updateIngestData = internalMutation({
             experienceLevel: v.string(),
             computedAt: v.number(),
             skillsVersion: v.number(),
+            verifiedRoleYears: v.optional(v.record(v.string(), v.number())),
         }),
         companyPatternAliasTokens: v.optional(v.string()),
         primaryRuleScore: v.optional(v.number()),
@@ -2653,6 +2677,7 @@ export const updateIngestDataBatch = internalMutation({
                 experienceLevel: v.string(),
                 computedAt: v.number(),
                 skillsVersion: v.number(),
+                verifiedRoleYears: v.optional(v.record(v.string(), v.number())),
             }),
             companyPatternAliasTokens: v.optional(v.string()),
             primaryRuleScore: v.optional(v.number()),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -164,6 +164,12 @@ export default defineSchema({
             experienceLevel: v.string(),  // "senior" | "mid" | "junior" | "unknown"
             computedAt: v.number(),
             skillsVersion: v.number(),
+            // Precomputed projection of verified role years keyed by role type
+            // ("sales", "engineer", etc.). Populated via computeVerifiedRoleYears
+            // at ingest time and backfilled by migrations.backfillVerifiedRoleYears.
+            // Semantics locked by plan:
+            // docs/superpowers/plans/2026-04-24-direct-role-years-precomputed-field-plan.md
+            verifiedRoleYears: v.optional(v.record(v.string(), v.number())),
         })),
     })
         .index("by_externalId", ["externalId"])

--- a/packages/shared/src/__tests__/analysis-key.test.ts
+++ b/packages/shared/src/__tests__/analysis-key.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  computeVerifiedRoleYears,
   isSalesRequiredContext,
   resolveResumeDiagnosticsSourceKey,
 } from "../analysis-key";
@@ -41,5 +42,56 @@ describe("resolveResumeDiagnosticsSourceKey", () => {
     expect(resolveResumeDiagnosticsSourceKey({ source: "manual.51job.com" })).toBe("unknown");
     expect(resolveResumeDiagnosticsSourceKey({ source: "unknown-host.example.com" })).toBe("unknown");
     expect(resolveResumeDiagnosticsSourceKey({ source: "" })).toBe("unknown");
+  });
+});
+
+describe("computeVerifiedRoleYears", () => {
+  it("projects industryVerifiedRelevantYears by role type", () => {
+    const result = computeVerifiedRoleYears([
+      {
+        type: "sales",
+        verifyIn: "workHistory",
+        industryVerifiedRelevantYears: 5,
+        industryVerifiedYears: 5,
+      },
+      {
+        type: "engineer",
+        verifyIn: "workHistory",
+        industryVerifiedYears: 3,
+      },
+    ]);
+
+    expect(result).toEqual({ sales: 5, engineer: 3 });
+  });
+
+  it("never reads unverified roleRelevantYears or raw years", () => {
+    const result = computeVerifiedRoleYears([
+      {
+        type: "sales",
+        verifyIn: "workHistory",
+        years: 10,
+        roleRelevantYears: 7,
+      },
+    ]);
+
+    expect(result).toEqual({});
+  });
+
+  it("drops entries whose verified value resolves to 0", () => {
+    const result = computeVerifiedRoleYears([
+      {
+        type: "sales",
+        verifyIn: "workHistory",
+        industryVerifiedRelevantYears: 0,
+        industryVerifiedYears: 0,
+      },
+    ]);
+
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object for undefined / empty input", () => {
+    expect(computeVerifiedRoleYears(undefined)).toEqual({});
+    expect(computeVerifiedRoleYears([])).toEqual({});
   });
 });

--- a/packages/shared/src/analysis-key.ts
+++ b/packages/shared/src/analysis-key.ts
@@ -326,6 +326,49 @@ export function getVerifiedRoleSignalYears(
   return resolveVerifiedYears(matched);
 }
 
+/**
+ * Precomputed projection of verified role years, keyed by normalized role
+ * type (lower-cased, trimmed). Used to populate `ingestData.verifiedRoleYears`
+ * at ingest time so the `minRoleYears` filter can gate on a single field
+ * without re-walking `roleSignals`.
+ *
+ * Uses the same `getVerifiedRoleSignalYears` semantics: only
+ * `industryVerified=true` entries or the `industryVerifiedRelevantYears` /
+ * `industryVerifiedYears` aggregate fields contribute. Never falls back to
+ * raw `years` or unverified `roleRelevantYears`.
+ *
+ * Plan: docs/superpowers/plans/2026-04-24-direct-role-years-precomputed-field-plan.md
+ */
+export function computeVerifiedRoleYears(
+  roleSignals: AnalysisRoleSignalLike[] | undefined
+): Record<string, number> {
+  if (!Array.isArray(roleSignals) || roleSignals.length === 0) {
+    return {};
+  }
+
+  const out: Record<string, number> = {};
+  for (const signal of roleSignals) {
+    const key = signal.type?.trim().toLowerCase();
+    if (!key) {
+      continue;
+    }
+    const years = getVerifiedRoleSignalYears([signal], key);
+    if (years > 0) {
+      out[key] = years;
+    }
+  }
+  return out;
+}
+
+/**
+ * Ranking / display helper — returns the "best available" years estimate
+ * for a role signal. May include unverified `roleRelevantYears`.
+ *
+ * WARNING: Do NOT use this for the `minRoleYears` filter or any hard gate.
+ * Filter callers MUST use `getVerifiedRoleSignalYears` or read
+ * `ingestData.verifiedRoleYears` directly. See plan:
+ * docs/superpowers/plans/2026-04-24-direct-role-years-precomputed-field-plan.md
+ */
 export function getRoleSignalYears(
   roleSignals: AnalysisRoleSignalLike[] | undefined,
   roleType: string,
@@ -362,7 +405,6 @@ export function getRoleSignalYears(
       signal.industryVerifiedRelevantYears
       ?? signal.roleRelevantYears
       ?? signal.industryVerifiedYears
-      ?? signal.years
       ?? 0;
 
     return Number.isFinite(years) ? years : 0;


### PR DESCRIPTION
## Summary
- `minRoleYears` now gates on the same `verified Xy` value rendered in the `roleEvidence` export column. Previously `getRoleSignalYears`'s fallback chain admitted unverified `roleRelevantYears` and raw `signal.years`, letting resumes with no industry-verified sales experience pass the filter (reversing PR #655's permissive behavior, per plan decision 2026-04-24).
- New precomputed `ingestData.verifiedRoleYears: Record<string, number>`, populated from `industryVerifiedRelevantYears ?? industryVerifiedYears` at ingest. Filter reads it directly, with a live-compute fallback via `getVerifiedRoleSignalYears` for pre-backfill resumes.
- Paginated `backfillVerifiedRoleYears` migration keeps existing rows in sync; idempotent (no-op when map matches).
- `getRoleSignalYears` JSDoc now warns readers it is ranking/display only, and its `?? signal.years` fallback is removed. A new `computeVerifiedRoleYears` helper plus shared tests lock the "never reads raw years or roleRelevantYears" invariant.

Plan: `docs/superpowers/plans/2026-04-24-direct-role-years-precomputed-field-plan.md`

**Known consequence (accepted):** Seek Malaysia resumes with `industryVerified=false` (observation S2308) will now be rejected — upstream industryVerified repair is a separate workstream.

## Test plan
- [x] `make check` passes.
- [x] New regression tests in `packages/convex/convex/__tests__/resumes-paginated-default.test.ts` lock verified-only pass, unverified reject, raw-years reject, precomputed-field pass.
- [x] New `computeVerifiedRoleYears` tests in `packages/shared/src/__tests__/analysis-key.test.ts` pin strict semantics.
- [ ] After deploy, run `backfillVerifiedRoleYears` paginated migration in prod and confirm no diffs remain.