### PR TITLE
fix: search pagination overfetch under post-filters

### DIFF
--- a/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
+++ b/packages/convex/convex/__tests__/resumes-paginated-default.test.ts
@@ -921,6 +921,104 @@ describe("searchWithTagExpansionPaginated", () => {
     expect(result.continueCursor).toBe("cursor-next");
     expect(result.isDone).toBe(false);
   });
+
+  it("overfetches by FILTERED_PAGINATE_OVERFETCH_MULTIPLIER when filters are active", async () => {
+    const requestedNumItems = 50;
+    let capturedNumItems: number | undefined;
+
+    const resume = {
+      ...buildResumeDoc("resume-x", 50),
+      age: 30,
+      searchText: "cnc 销售",
+      content: { name: "Resume X" },
+      ingestData: {
+        ruleScores: {},
+        industryTags: [],
+        experienceLevel: "mid",
+        computedAt: 1,
+        skillsVersion: 1,
+        verifiedRoleYears: { sales: 3 },
+        roleSignals: [],
+      },
+    };
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withSearchIndex: () => ({
+            filter: () => ({
+              paginate: async (opts: { cursor: string | null; numItems: number }) => {
+                capturedNumItems = opts.numItems;
+                return {
+                  page: [resume],
+                  continueCursor: "",
+                  isDone: true,
+                };
+              },
+            }),
+          }),
+        }),
+      },
+    };
+
+    await searchPaginatedHandler(ctx, {
+      paginationOpts: { cursor: null, numItems: requestedNumItems },
+      query: "CNC 销售",
+      keywordGroups: [
+        { original: "cnc", variants: ["cnc"] },
+        { original: "销售", variants: ["销售"] },
+      ],
+      mode: "AND",
+      minRoleYears: 1,
+      roleFilterType: "sales",
+    });
+
+    // With filters active, the scan should overfetch 3x the requested page size
+    expect(capturedNumItems).toBe(requestedNumItems * 3);
+  });
+
+  it("does not overfetch when no filters are active", async () => {
+    const requestedNumItems = 50;
+    let capturedNumItems: number | undefined;
+
+    const resume = {
+      ...buildResumeDoc("resume-y", 50),
+      searchText: "cnc 销售",
+      content: { name: "Resume Y" },
+    };
+
+    const ctx = {
+      db: {
+        query: () => ({
+          withSearchIndex: () => ({
+            filter: () => ({
+              paginate: async (opts: { cursor: string | null; numItems: number }) => {
+                capturedNumItems = opts.numItems;
+                return {
+                  page: [resume],
+                  continueCursor: "",
+                  isDone: true,
+                };
+              },
+            }),
+          }),
+        }),
+      },
+    };
+
+    await searchPaginatedHandler(ctx, {
+      paginationOpts: { cursor: null, numItems: requestedNumItems },
+      query: "CNC 销售",
+      keywordGroups: [
+        { original: "cnc", variants: ["cnc"] },
+        { original: "销售", variants: ["销售"] },
+      ],
+      mode: "AND",
+    });
+
+    // Without filters, scan should equal the requested page size (no overfetch)
+    expect(capturedNumItems).toBe(requestedNumItems);
+  });
 });
 
 describe("listWithIngestDataPaginated source filter", () => {

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -378,6 +378,7 @@ export const MAX_SAFE_LIST_WITH_INGEST_LIMIT = 2000;
 export const MAX_SAFE_LIST_WITH_INGEST_OVERFETCH = 4000;
 const FILTERED_PAGINATE_OVERFETCH_MULTIPLIER = 3;
 const MAX_SAFE_JD_PAGINATE_SCAN = 250;
+const MAX_SAFE_SEARCH_PAGINATE_SCAN = 600;
 const MAX_INGEST_DIAGNOSTICS_PAGE_SIZE = 100;
 const MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES = 8;
 const DIAGNOSTICS_SOURCE_FILTER_BATCH_MULTIPLIER = 3;
@@ -1610,10 +1611,11 @@ async function runSearchWithTagExpansionScanPageQuery(
         (args.sourceMappings ?? []).map((entry) => [entry.term, entry.expandedFrom])
     );
     const searchQuery = buildTagExpansionSearchQuery(keywordGroups, mode);
-    const pageSize = Math.min(
-        Math.max(Math.trunc(args.paginationOpts.numItems), 1),
-        MAX_SAFE_JD_PAGINATE_SCAN,
-    );
+    const requestedPageSize = Math.max(Math.trunc(args.paginationOpts.numItems), 1);
+    const hasActiveFilters = filters !== undefined;
+    const pageSize = hasActiveFilters
+        ? Math.min(requestedPageSize * FILTERED_PAGINATE_OVERFETCH_MULTIPLIER, MAX_SAFE_SEARCH_PAGINATE_SCAN)
+        : Math.min(requestedPageSize, MAX_SAFE_SEARCH_PAGINATE_SCAN);
 
     const searchPage = searchQuery
         ? await ctx.db


### PR DESCRIPTION
## Summary
- Apply `FILTERED_PAGINATE_OVERFETCH_MULTIPLIER` (3×) to `runSearchWithTagExpansionScanPageQuery` when filters are active, capped by new `MAX_SAFE_SEARCH_PAGINATE_SCAN = 600`
- The search path was missing the overfetch that `listWithIngestDataPaginated` already has, causing sparse pages (~15 survivors) after PR #660's strict `verifiedRoleYears` gating rejects ~88% of hits post-fetch
- Add regression tests locking: (1) 3× overfetch when filters active, (2) no overfetch when filters absent

## Root cause
`searchWithTagExpansionPaginated` → `runSearchWithTagExpansionScanPageQuery` at `resumes.ts:1613-1616` set `pageSize = min(numItems, 250)` with no overfetch multiplier. With post-page `matchesResumeListFilters` dropping most hits, pages looked empty. Sibling `listWithIngestDataPaginated` at line 1842 already applies `requestedPageSize * 3`.

## Test plan
- [x] `make check` passes
- [x] New unit test: overfetch multiplier activates when `minRoleYears`/`roleFilterType` filters present
- [x] New unit test: no overfetch when filters absent
- [ ] Local UI: `http://localhost:5173/dev/resumes?location=China&q=CNC+销售&minRoleYears=1&roleType=sales&minAge=25&maxAge=40` should show ≥~50 results on first page (was ~15)

## Post-merge note
If `backfillVerifiedRoleYears` has not been run on prod yet, invoke:
```
npx convex run migrations:backfillVerifiedRoleYears --prod
```
This precomputes `verifiedRoleYears` for all existing resumes so the filter short-circuits on the stored field rather than live-computing from `roleSignals` each query.