### PR TITLE
fix: send minRoleYears/roleFilterType/minAge/maxAge to Convex server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,6 +602,13 @@ install-deps:
 prefetch-convex:
 	./scripts/prefetch-convex-backend.sh
 
+# Upgrade Convex CLI package and local backend binary
+# Usage: make upgrade-convex VERSION=1.36.0
+#        make upgrade-convex VERSION=1.36.0 ENV=prod
+#        make upgrade-convex VERSION=1.36.0 TIMEOUT=120
+upgrade-convex:
+	./scripts/upgrade-convex.sh "$(VERSION)" $(if $(ENV),--env $(ENV),) $(if $(TIMEOUT),--timeout $(TIMEOUT),)
+
 # =============================================================================
 # Documentation
 # =============================================================================

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,7 +26,7 @@
     "@trends/shared": "*",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
-    "convex": "^1.31.7",
+    "convex": "^1.36.0",
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.4",
     "i18next": "^25.8.13",

--- a/apps/web/src/hooks/resume-filter-helpers.test.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.test.ts
@@ -151,7 +151,13 @@ describe('toStatusFilterList', () => {
 })
 
 describe('getRoleYears', () => {
-  function makeResume(roleSignals: Array<{ type: string; years: number; roleRelevantYears?: number }>): Pick<ConvexResumeItem, 'ingestData'> {
+  function makeResume(roleSignals: Array<{
+    type: string
+    years: number
+    industryVerifiedYears?: number
+    industryVerifiedRelevantYears?: number
+    matchedWorkEntries?: Array<{ years: number; directRoleMatch: boolean; industryVerified: boolean; matchedSignals: string[] }>
+  }>, verifiedRoleYears?: Record<string, number>): Pick<ConvexResumeItem, 'ingestData'> {
     return {
       ingestData: {
         evidenceText: '',
@@ -166,10 +172,20 @@ describe('getRoleYears', () => {
           signalCount: 1,
           occurrences: 1,
           years: s.years,
-          industryVerifiedYears: 0,
+          industryVerifiedYears: s.industryVerifiedYears ?? 0,
+          ...(s.industryVerifiedRelevantYears !== undefined ? { industryVerifiedRelevantYears: s.industryVerifiedRelevantYears } : {}),
+          ...(s.matchedWorkEntries
+            ? {
+                matchedWorkEntries: s.matchedWorkEntries.map((e) => ({
+                  ...e,
+                  matchedSignals: e.industryVerified ? ['verified'] : [],
+                  ...(e.directRoleMatch ? { companyName: 'Test Co', jobTitle: 'Test Title' } : {}),
+                })),
+              }
+            : {}),
           verifyIn: '',
-          ...(s.roleRelevantYears !== undefined ? { roleRelevantYears: s.roleRelevantYears } : {}),
         })),
+        ...(verifiedRoleYears ? { verifiedRoleYears } : {}),
         ruleScores: {},
         experienceLevel: 'mid',
         computedAt: 0,
@@ -183,45 +199,51 @@ describe('getRoleYears', () => {
     expect(getRoleYears(resume, '')).toBe(0)
   })
 
-  it('returns max years across all signals when roleType is empty', () => {
-    const resume = makeResume([
-      { type: 'sales', years: 5 },
-      { type: 'engineer', years: 8 },
-    ])
-    expect(getRoleYears(resume, '')).toBe(8)
-  })
-
-  it('returns roleRelevantYears when available for matching roleType', () => {
-    const resume = makeResume([
-      { type: 'sales', years: 8, roleRelevantYears: 5 },
-    ])
+  it('prefers precomputed verifiedRoleYears when available', () => {
+    const resume = makeResume(
+      [{ type: 'sales', years: 8, industryVerifiedYears: 0 }],
+      { sales: 5 },
+    )
     expect(getRoleYears(resume, 'sales')).toBe(5)
   })
 
-  it('falls back to years when roleRelevantYears is absent for matching roleType', () => {
+  it('falls back to getVerifiedRoleSignalYears via industryVerifiedRelevantYears', () => {
     const resume = makeResume([
-      { type: 'sales', years: 6 },
+      { type: 'sales', years: 8, industryVerifiedRelevantYears: 4 },
     ])
-    expect(getRoleYears(resume, 'sales')).toBe(6)
+    expect(getRoleYears(resume, 'sales')).toBe(4)
+  })
+
+  it('sums verified work entry years when matchedWorkEntries are present', () => {
+    const resume = makeResume([{
+      type: 'sales',
+      years: 8,
+      matchedWorkEntries: [
+        { years: 3, directRoleMatch: true, industryVerified: true, matchedSignals: ['verified'] },
+        { years: 2, directRoleMatch: true, industryVerified: false, matchedSignals: [] },
+      ],
+    }])
+    expect(getRoleYears(resume, 'sales')).toBe(3)
   })
 
   it('returns 0 when no signal matches the specified roleType', () => {
     const resume = makeResume([
-      { type: 'engineer', years: 10 },
+      { type: 'engineer', years: 10, industryVerifiedYears: 10 },
     ])
     expect(getRoleYears(resume, 'sales')).toBe(0)
   })
 
-  it('ignores NaN and Infinity roleRelevantYears', () => {
+  it('returns max verified years across all signals when roleType is empty', () => {
     const resume = makeResume([
-      { type: 'sales', years: 5, roleRelevantYears: NaN },
+      { type: 'sales', years: 5, industryVerifiedRelevantYears: 5 },
+      { type: 'engineer', years: 8, industryVerifiedRelevantYears: 8 },
     ])
-    expect(getRoleYears(resume, 'sales')).toBe(5)
+    expect(getRoleYears(resume, '')).toBe(8)
   })
 
   it('is case-insensitive for roleType matching', () => {
     const resume = makeResume([
-      { type: 'Sales', years: 7 },
+      { type: 'Sales', years: 7, industryVerifiedRelevantYears: 7 },
     ])
     expect(getRoleYears(resume, 'sales')).toBe(7)
   })

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -1,5 +1,5 @@
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
-import { formatKeywordQuery, formatLocationHierarchySearchText, normalizeKeywordPhrases } from '@trends/shared'
+import { formatKeywordQuery, formatLocationHierarchySearchText, getVerifiedRoleSignalYears, normalizeKeywordPhrases } from '@trends/shared'
 import { resolveResumeAnalysisSourceKey } from '@trends/shared'
 import type { ExperienceLevelFilter, UrlSearchState } from '@/hooks/useUrlSearchState'
 
@@ -91,29 +91,30 @@ export function getRoleYears(resume: Pick<ConvexResumeItem, 'ingestData'>, roleT
     return 0
   }
 
+  // Use verified-only years when a specific role type is given, matching
+  // the server-side getResumeRoleYears / getVerifiedRoleSignalYears logic.
   const normalizedRoleType = normalizeFilterToken(roleType)
-  if (!normalizedRoleType) {
-    return roleSignals.reduce((maxYears, signal) => {
-      const relevantYears =
-        typeof signal.roleRelevantYears === 'number' && Number.isFinite(signal.roleRelevantYears)
-          ? signal.roleRelevantYears
-          : signal.years
-      if (typeof relevantYears !== 'number' || !Number.isFinite(relevantYears)) {
-        return maxYears
-      }
-      return Math.max(maxYears, relevantYears)
-    }, 0)
+  if (normalizedRoleType) {
+    const stored = resume.ingestData?.verifiedRoleYears?.[normalizedRoleType]
+    if (typeof stored === 'number' && Number.isFinite(stored)) {
+      return stored
+    }
+    return getVerifiedRoleSignalYears(roleSignals, normalizedRoleType)
   }
 
-  const roleSignal = roleSignals.find((signal) => normalizeFilterToken(signal.type) === normalizedRoleType)
-  const relevantYears =
-    typeof roleSignal?.roleRelevantYears === 'number' && Number.isFinite(roleSignal.roleRelevantYears)
-      ? roleSignal.roleRelevantYears
-      : roleSignal?.years
-  if (!roleSignal || typeof relevantYears !== 'number' || !Number.isFinite(relevantYears)) {
-    return 0
-  }
-  return relevantYears
+  // No specific role type: return the best verified years across all signals
+  return roleSignals.reduce((maxYears, signal) => {
+    const key = normalizeFilterToken(signal.type)
+    if (!key) {
+      return maxYears
+    }
+    const stored = resume.ingestData?.verifiedRoleYears?.[key]
+    if (typeof stored === 'number' && Number.isFinite(stored) && stored > maxYears) {
+      return stored
+    }
+    const verified = getVerifiedRoleSignalYears(roleSignals, key)
+    return Math.max(maxYears, verified)
+  }, 0)
 }
 
 export function matchesAllRequiredKeywords(text: string, requiredKeywords: string[]): boolean {

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -80,6 +80,7 @@ export type ConvexIngestData = {
     }>
     verifyIn: string
   }>
+  verifiedRoleYears?: Record<string, number>
   taggingEnvelope?: {
     schemaVersion: number
     generatedAt: number
@@ -161,6 +162,7 @@ type ResumeListDocLike = {
       }>
       verifyIn: string
     }>
+    verifiedRoleYears?: Record<string, number>
     ruleScores: unknown
     experienceLevel: string
     computedAt: number
@@ -604,6 +606,14 @@ function parseIngestData(value: unknown): ConvexIngestData | undefined {
           })
           .filter((item): item is NonNullable<typeof item> => item !== null)
       : undefined,
+    ...(isRecord(value.verifiedRoleYears)
+      ? {
+          verifiedRoleYears: Object.fromEntries(
+            Object.entries(value.verifiedRoleYears)
+              .filter((entry): entry is [string, number] => typeof entry[1] === 'number' && Number.isFinite(entry[1])),
+          ),
+        }
+      : {}),
     taggingEnvelope,
     ruleScores: parseRuleScores(value.ruleScores),
     experienceLevel: toStringValue(value.experienceLevel) || 'unknown',

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -302,6 +302,10 @@ export function useResumeListState(loadSearchHistory = false) {
     const normalized: ConvexResumeFilters = {
       ...(typeof filters.minExperience === 'number' && filters.minExperience > 0 ? { minExperience: filters.minExperience } : {}),
       ...(typeof filters.maxExperience === 'number' ? { maxExperience: filters.maxExperience } : {}),
+      ...(typeof filters.minRoleYears === 'number' && filters.minRoleYears > 0 ? { minRoleYears: filters.minRoleYears } : {}),
+      ...(filters.roleFilterType ? { roleFilterType: filters.roleFilterType } : {}),
+      ...(typeof filters.minAge === 'number' ? { minAge: filters.minAge } : {}),
+      ...(typeof filters.maxAge === 'number' ? { maxAge: filters.maxAge } : {}),
       ...(Array.isArray(filters.education) && filters.education.length > 0 ? { education: filters.education } : {}),
       ...(Array.isArray(filters.skills) && filters.skills.length > 0 ? { skills: filters.skills } : {}),
       ...(requiredKeywords.length > 0 ? { requiredKeywords } : {}),
@@ -311,7 +315,7 @@ export function useResumeListState(loadSearchHistory = false) {
     }
 
     return Object.keys(normalized).length > 0 ? normalized : undefined
-  }, [filters.education, filters.locations, filters.maxExperience, filters.maxSalary, filters.minExperience, filters.minSalary, filters.skills, requiredKeywords])
+  }, [filters.education, filters.locations, filters.maxAge, filters.maxExperience, filters.maxSalary, filters.minAge, filters.minExperience, filters.minRoleYears, filters.minSalary, filters.roleFilterType, filters.skills, requiredKeywords])
   const convexQueryScopeKey = useMemo(
     () => JSON.stringify({
       jobDescriptionId: jobDescriptionId?.trim() ?? '',

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -1,4 +1,4 @@
-import { formatKeywordQuery, getRoleSignalYears, isSalesRequiredContext, parseKeywordQuery } from '@trends/shared'
+import { formatKeywordQuery, getVerifiedRoleSignalYears, isSalesRequiredContext, parseKeywordQuery } from '@trends/shared'
 import { useMutation, useQuery } from 'convex/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
@@ -404,10 +404,27 @@ function getRoleYears(
     return 0
   }
 
-  return getRoleSignalYears(
-    roleSignals,
-    normalizeOptionalString(roleType)?.toLowerCase() ?? '',
-  )
+  const normalizedRoleType = normalizeOptionalString(roleType)?.toLowerCase() ?? ''
+  if (normalizedRoleType) {
+    const stored = resume.ingestData?.verifiedRoleYears?.[normalizedRoleType]
+    if (typeof stored === 'number' && Number.isFinite(stored)) {
+      return stored
+    }
+    return getVerifiedRoleSignalYears(roleSignals, normalizedRoleType)
+  }
+
+  return roleSignals.reduce((maxYears, signal) => {
+    const key = (signal.type ?? '').trim().toLowerCase()
+    if (!key) {
+      return maxYears
+    }
+    const stored = resume.ingestData?.verifiedRoleYears?.[key]
+    if (typeof stored === 'number' && Number.isFinite(stored) && stored > maxYears) {
+      return stored
+    }
+    const verified = getVerifiedRoleSignalYears(roleSignals, key)
+    return Math.max(maxYears, verified)
+  }, 0)
 }
 
 function matchesLocalFilters(

--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
         "@trends/shared": "*",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
-        "convex": "^1.31.7",
+        "convex": "^1.36.0",
         "date-fns": "^4.1.0",
         "dotenv": "^17.2.4",
         "i18next": "^25.8.13",
@@ -115,7 +115,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@trends/shared": "*",
-        "convex": "^1.31.7",
+        "convex": "^1.36.0",
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -660,7 +660,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "convex": ["convex@1.31.7", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-PtNMe1mAIOvA8Yz100QTOaIdgt2rIuWqencVXrb4McdhxBHZ8IJ1eXTnrgCC9HydyilGT1pOn+KNqT14mqn9fQ=="],
+    "convex": ["convex@1.36.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-NVnwNqU+h8jyPuS0Itvj4MPH9c2yF+tA/RNoSDpCqiLhmYD4+kZxm0dDkVM0QDzz66wem9NqheBb9YQGsHwzBQ=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -1285,6 +1285,8 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 

--- a/deploy/systemd/trends-convex.service
+++ b/deploy/systemd/trends-convex.service
@@ -11,11 +11,14 @@ WorkingDirectory=/opt/trends/packages/convex
 EnvironmentFile=-/etc/trends/env
 Environment=NODE_ENV=production
 Environment=CONVEX_AGENT_MODE=anonymous
+Environment=CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS=90
 UnsetEnvironment=TZ
 ExecStartPre=/usr/bin/bash /opt/trends/scripts/prefetch-convex-backend.sh
-# Warm the cached backend so the following `convex dev --local` boot fits
-# inside the CLI's hardcoded 30s port-bind timeout. The prewarm script exits
-# cleanly and releases port 3210 before ExecStart runs.
+# Warm the cached backend so the subsequent `convex dev --local` boot is faster.
+# The prewarm script exits cleanly and releases port 3210 before ExecStart runs.
+# CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS overrides the CLI's default startup
+# deadline (available in Convex CLI >= 1.36.0); prewarm remains useful to
+# reduce perceived startup latency from ~30s to ~5s.
 ExecStartPre=/usr/bin/bash /opt/trends/scripts/convex-prewarm.sh
 ExecStart=/usr/bin/npx convex dev --local --local-force-upgrade
 Restart=on-failure

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -723,6 +723,7 @@ function projectResumeListIngestData(
                 })),
             }
             : {}),
+        ...(ingestData.verifiedRoleYears ? { verifiedRoleYears: ingestData.verifiedRoleYears } : {}),
         ruleScores: ingestData.ruleScores,
         experienceLevel: ingestData.experienceLevel,
         computedAt: ingestData.computedAt,

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@trends/convex",
-    "version": "0.2.0",
-    "private": true,
-    "type": "module",
-    "scripts": {
-        "dev": "env -u TZ convex dev --local --local-force-upgrade",
-        "predev": "env -u TZ convex dev --once --local --local-force-upgrade",
-        "build": "convex codegen",
-        "typecheck": "tsc --noEmit"
-    },
-    "dependencies": {
-        "@trends/shared": "*",
-        "convex": "^1.31.7"
-    },
-    "devDependencies": {
-        "typescript": "^5.9.3"
-    }
+  "name": "@trends/convex",
+  "version": "0.2.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "env -u TZ convex dev --local --local-force-upgrade",
+    "predev": "env -u TZ convex dev --once --local --local-force-upgrade",
+    "build": "convex codegen",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@trends/shared": "*",
+    "convex": "^1.36.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
 }

--- a/scripts/convex-prewarm.sh
+++ b/scripts/convex-prewarm.sh
@@ -8,12 +8,15 @@
 # When the anonymous local backend has been idle long enough that its Tantivy
 # search indexes are flagged "TooOld", the backend rebuilds them during startup
 # before binding port 3210. On modest hardware that rebuild can take 28-40s.
-# Convex CLI kills the backend at 30s and retries forever (both locally via
-# `make dev` and in production via the trends-convex systemd unit with
-# Restart=on-failure).
+# Convex CLI kills the backend after its startup deadline (default 30s in CLI
+# < 1.36.0, configurable via CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS in
+# CLI >= 1.36.0) and retries (both locally via `make dev` and in production
+# via the trends-convex systemd unit with Restart=on-failure).
 #
 # Prewarming once, standalone, with no CLI timer, lets the rebuild complete.
 # After graceful shutdown, subsequent boots bind port 3210 in a few seconds.
+# Even with a longer startup timeout configured, prewarm remains useful to
+# reduce perceived startup latency from ~30s to ~5s.
 #
 # Safety
 # ------

--- a/scripts/upgrade-convex.sh
+++ b/scripts/upgrade-convex.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+# Upgrades the Convex npm package and local backend binary across environments.
+#
+# Handles three environments:
+#   dev        macOS local dev (auto-detected) — bun install, local prefetch
+#   linux-dev  Linux dev VM                   — npm install, local prefetch
+#   prod       Linux prod (ptcloud)           — patches package.json, prints manual steps
+#
+# Also writes CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS to .env.local,
+# which is the official override for the CLI's startup timeout (available in
+# Convex CLI >= 1.36.0).
+#
+# Usage:
+#   scripts/upgrade-convex.sh 1.36.0
+#   scripts/upgrade-convex.sh 1.36.0 --dry-run
+#   scripts/upgrade-convex.sh 1.36.0 --env prod
+#   scripts/upgrade-convex.sh 1.36.0 --clean-cache --timeout 120
+#   make upgrade-convex VERSION=1.36.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LOG_PREFIX="[convex-upgrade]"
+
+log() { printf '%s %s\n' "$LOG_PREFIX" "$*"; }
+warn() { printf '%s WARN: %s\n' "$LOG_PREFIX" "$*" >&2; }
+error() { printf '%s ERROR: %s\n' "$LOG_PREFIX" "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+ENV=""
+VERSION=""
+DRY_RUN=""
+TIMEOUT_SECS="90"
+NO_TIMEOUT=""
+NO_PREFETCH=""
+CLEAN_CACHE=""
+SKIP_INSTALL=""
+
+# ---------------------------------------------------------------------------
+# Helpers (duplicated with attribution — same functions exist in install.sh,
+# dev.sh, convex-prewarm.sh, prefetch-convex-backend.sh)
+# ---------------------------------------------------------------------------
+
+has_bun() { command -v bun >/dev/null 2>&1; }
+
+# upsert_env_var_in_file — from install.sh:1088 (portable awk-based)
+upsert_env_var_in_file() {
+    local file_path="$1"
+    local key="$2"
+    local value="$3"
+    local tmp_file=""
+
+    mkdir -p "$(dirname "$file_path")"
+    if [[ ! -f "$file_path" ]]; then
+        touch "$file_path"
+    fi
+
+    tmp_file="$(mktemp)"
+    awk -v key="$key" -v value="$value" '
+        BEGIN { updated = 0 }
+        $0 ~ "^[[:space:]]*" key "=" {
+            print key "=" value
+            updated = 1
+            next
+        }
+        { print }
+        END {
+            if (updated == 0) {
+                print key "=" value
+            }
+        }
+    ' "$file_path" > "$tmp_file"
+    mv "$tmp_file" "$file_path"
+}
+
+# cache_binaries_dir — from convex-prewarm.sh:66 (full Windows support)
+cache_binaries_dir() {
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+        MINGW*|MSYS*|CYGWIN*)
+            if [ -n "${LOCALAPPDATA:-}" ]; then
+                echo "${LOCALAPPDATA}/convex/binaries"; return
+            fi
+            if [ -n "${USERPROFILE:-}" ]; then
+                echo "${USERPROFILE}/AppData/Local/convex/binaries"; return
+            fi
+            echo "${HOME}/AppData/Local/convex/binaries"; return
+            ;;
+    esac
+    echo "${HOME}/.cache/convex/binaries"
+}
+
+# binary_name — from convex-prewarm.sh:80
+binary_name() {
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+        MINGW*|MSYS*|CYGWIN*) echo "convex-local-backend.exe" ;;
+        *) echo "convex-local-backend" ;;
+    esac
+}
+
+# patch_convex_dep — patch "convex" dependency in a package.json file.
+# Uses env vars to avoid shell-variable injection into JS strings.
+patch_convex_dep() {
+    local target_version="$1"
+    shift
+    for pkg_path in "$@"; do
+        PKG_PATH="$pkg_path" NEW_VER="$target_version" node -e '
+            const fs = require("node:fs");
+            const pkg = JSON.parse(fs.readFileSync(process.env.PKG_PATH, "utf8"));
+            pkg.dependencies.convex = process.env.NEW_VER;
+            fs.writeFileSync(process.env.PKG_PATH, JSON.stringify(pkg, null, 2) + "\n");
+        '
+    done
+}
+
+# read_json_field — read a field from a JSON file via env var.
+# Usage: read_json_field <file> <dotpath>  e.g. read_json_field pkg.json dependencies.convex
+read_json_field() {
+    PKG_PATH="$1" FIELD="$2" node -e '
+        const pkg = JSON.parse(require("node:fs").readFileSync(process.env.PKG_PATH, "utf8"));
+        const parts = process.env.FIELD.split(".");
+        let v = pkg;
+        for (const p of parts) v = v[p];
+        console.log(v ?? "NOT_FOUND");
+    '
+}
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+
+usage() {
+    cat <<EOF
+Usage: $0 <version> [options]
+
+Upgrades the Convex npm package and prefetches the matching local backend binary.
+
+Arguments:
+  <version>     Target Convex version, e.g. 1.36.0 (caret prefix added automatically)
+
+Options:
+  --env ENV     Environment: dev (macOS), linux-dev, prod (default: auto-detect)
+  --dry-run     Print all steps without side effects
+  --timeout N   Value for CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS (default: 90)
+  --no-timeout  Skip writing the timeout env var
+  --no-prefetch Skip running prefetch-convex-backend.sh
+  --clean-cache Remove old cached backend binaries after upgrade
+  --skip-install Skip bun/npm install (only patch package.json + env)
+  --help        Show this help
+
+Environment auto-detection (when --env is not specified):
+  macOS  → dev
+  Linux  → linux-dev
+  prod   → requires explicit --env prod
+
+Examples:
+  $0 1.36.0                        # Upgrade on macOS dev
+  $0 1.36.0 --dry-run              # Preview changes
+  $0 1.36.0 --env prod             # Show manual prod steps
+  $0 1.36.0 --clean-cache          # Remove old binaries from cache
+  $0 1.36.0 --timeout 120         # Set 120s startup timeout
+  make upgrade-convex VERSION=1.36.0
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --env)
+            [[ $# -lt 2 ]] && { error "--env requires a value"; exit 1; }
+            ENV="$2"; shift 2 ;;
+        --dry-run)
+            DRY_RUN=1; shift ;;
+        --timeout)
+            [[ $# -lt 2 ]] && { error "--timeout requires a value"; exit 1; }
+            TIMEOUT_SECS="$2"; shift 2 ;;
+        --no-timeout)
+            NO_TIMEOUT=1; shift ;;
+        --no-prefetch)
+            NO_PREFETCH=1; shift ;;
+        --clean-cache)
+            CLEAN_CACHE=1; shift ;;
+        --skip-install)
+            SKIP_INSTALL=1; shift ;;
+        --help|-h)
+            usage; exit 0 ;;
+        -*)
+            error "Unknown option: $1"; usage; exit 1 ;;
+        *)
+            if [[ -z "$VERSION" ]]; then
+                VERSION="$1"; shift
+            else
+                error "Unexpected argument: $1"; usage; exit 1
+            fi ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validate inputs
+# ---------------------------------------------------------------------------
+
+if [[ -z "$VERSION" ]]; then
+    error "Version argument is required (e.g. 1.36.0)"
+    usage; exit 1
+fi
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._]+)?$ ]]; then
+    error "Invalid version format: $VERSION (expected semver like 1.36.0)"
+    exit 1
+fi
+
+if [[ -z "$ENV" ]]; then
+    case "$(uname -s)" in
+        Darwin) ENV="dev" ;;
+        Linux)  ENV="linux-dev" ;;
+        *)      ENV="dev" ;;
+    esac
+    log "Auto-detected environment: $ENV"
+fi
+
+case "$ENV" in
+    dev|linux-dev|prod) ;;
+    *) error "Unknown environment: $ENV (expected dev, linux-dev, or prod)"; exit 1 ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Resolve file paths & compute once-reused values
+# ---------------------------------------------------------------------------
+
+WEB_PKG_JSON="$PROJECT_ROOT/apps/web/package.json"
+CONVEX_PKG_JSON="$PROJECT_ROOT/packages/convex/package.json"
+CONVEX_ENV_LOCAL="$PROJECT_ROOT/packages/convex/.env.local"
+PREFETCH_SCRIPT="$PROJECT_ROOT/scripts/prefetch-convex-backend.sh"
+NODE_MODULES_CONVEX_PKG="$PROJECT_ROOT/node_modules/convex/package.json"
+CACHE_DIR="$(cache_binaries_dir)"
+BIN_NAME="$(binary_name)"
+
+for f in "$WEB_PKG_JSON" "$CONVEX_PKG_JSON"; do
+    if [[ ! -f "$f" ]]; then
+        error "Missing package.json: $f"
+        exit 1
+    fi
+done
+
+# If the user passed a bare version like "1.36.0", prepend "^" to match
+# the caret-range convention used in both package.json files.
+if [[ "$VERSION" =~ ^[0-9] ]]; then
+    CARET_VERSION="^${VERSION}"
+else
+    CARET_VERSION="$VERSION"
+fi
+
+log "Target version: $CARET_VERSION (package.json) → resolves to ≥$VERSION"
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+if [[ "${DRY_RUN:-}" ]]; then
+    CURRENT_WEB_CONVEX="$(read_json_field "$WEB_PKG_JSON" "dependencies.convex")"
+    CURRENT_CONVEX_CONVEX="$(read_json_field "$CONVEX_PKG_JSON" "dependencies.convex")"
+
+    log "=== DRY RUN — no changes will be made ==="
+    log ""
+    log "Steps that would be executed:"
+    log "  1. Patch apps/web/package.json: convex $CURRENT_WEB_CONVEX → $CARET_VERSION"
+    log "  2. Patch packages/convex/package.json: convex $CURRENT_CONVEX_CONVEX → $CARET_VERSION"
+    if [[ "$ENV" != "prod" ]]; then
+        if [[ ! "${SKIP_INSTALL:-}" ]]; then
+            if [[ "$ENV" == "dev" ]] && has_bun; then
+                log "  3. Run: bun install"
+            else
+                log "  3. Run: npm install"
+            fi
+        fi
+        log "  4. Read resolved version from node_modules/convex/package.json"
+        if [[ ! "${NO_PREFETCH:-}" ]]; then
+            log "  5. Run: scripts/prefetch-convex-backend.sh"
+        fi
+        if [[ ! "${NO_TIMEOUT:-}" ]]; then
+            log "  6. Write CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS=$TIMEOUT_SECS to packages/convex/.env.local"
+        fi
+        if [[ "${CLEAN_CACHE:-}" ]]; then
+            log "  7. Clean old binaries from $CACHE_DIR/ (keep new version only)"
+        fi
+        log "  8. Verify installed version, cached binary, timeout env var"
+    else
+        log "  3. Print manual prod deployment instructions (no remote changes)"
+    fi
+    log ""
+    log "=== DRY RUN complete ==="
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Patch package.json files
+# ---------------------------------------------------------------------------
+
+log "Patching convex → $CARET_VERSION in package.json files"
+patch_convex_dep "$CARET_VERSION" "$WEB_PKG_JSON" "$CONVEX_PKG_JSON"
+
+# ---------------------------------------------------------------------------
+# Environment-specific flow
+# ---------------------------------------------------------------------------
+
+if [[ "$ENV" == "prod" ]]; then
+    log ""
+    log "=== Production Upgrade Instructions (ptcloud) ==="
+    log ""
+    log "The package.json files have been patched locally."
+    log "Complete the production upgrade with these manual steps:"
+    log ""
+    log "  1. Commit and push the package.json changes:"
+    log "     git add apps/web/package.json packages/convex/package.json package-lock.json"
+    log "     git commit -m 'chore: upgrade convex to $CARET_VERSION'"
+    log "     git push"
+    log ""
+    log "  2. Deploy to ptcloud:"
+    log "     ssh ptcloud && cd /opt/trends && sudo make on-prod-deploy"
+    log ""
+    log "  3. Add startup timeout to production env config:"
+    log "     # Add to /etc/trends/env:"
+    log "     CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS=$TIMEOUT_SECS"
+    log ""
+    log "  4. Restart the Convex service:"
+    log "     sudo systemctl restart trends-convex.service"
+    log ""
+    log "  5. Verify:"
+    log "     sudo systemctl status trends-convex.service"
+    log "     curl -s http://127.0.0.1:3210/version"
+    log ""
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Dev / Linux-dev flow
+# ---------------------------------------------------------------------------
+
+if [[ ! "${SKIP_INSTALL:-}" ]]; then
+    if [[ "$ENV" == "dev" ]] && has_bun; then
+        log "Running: bun install"
+        (cd "$PROJECT_ROOT" && bun install)
+    else
+        log "Running: npm install"
+        (cd "$PROJECT_ROOT" && npm install)
+    fi
+else
+    log "Skipping install (--skip-install)"
+fi
+
+RESOLVED_VERSION="$(read_json_field "$NODE_MODULES_CONVEX_PKG" "version")"
+log "Resolved installed version: $RESOLVED_VERSION"
+
+if [[ ! "${NO_PREFETCH:-}" ]]; then
+    if [[ -x "$PREFETCH_SCRIPT" ]]; then
+        log "Prefetching Convex backend binary..."
+        if ! "$PREFETCH_SCRIPT"; then
+            warn "Prefetch failed — backend will download on first 'make dev'"
+        fi
+    else
+        warn "Prefetch script not found: $PREFETCH_SCRIPT"
+    fi
+else
+    log "Skipping prefetch (--no-prefetch)"
+fi
+
+if [[ ! "${NO_TIMEOUT:-}" ]]; then
+    log "Writing CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS=$TIMEOUT_SECS to $CONVEX_ENV_LOCAL"
+    upsert_env_var_in_file "$CONVEX_ENV_LOCAL" "CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS" "$TIMEOUT_SECS"
+else
+    log "Skipping timeout env var (--no-timeout)"
+fi
+
+if [[ "${CLEAN_CACHE:-}" ]]; then
+    if [[ -d "$CACHE_DIR" ]]; then
+        log "Cleaning old backend binaries from $CACHE_DIR (keeping $RESOLVED_VERSION)"
+        find "$CACHE_DIR" -mindepth 1 -maxdepth 1 -type d | while IFS= read -r dir; do
+            dirname="$(basename "$dir")"
+            # Keep precompiled-* dirs — dev.sh pins --local-backend-version to them
+            if [[ "$dirname" == "$RESOLVED_VERSION" ]] || [[ "$dirname" == precompiled-* ]]; then
+                log "  Keeping: $dirname"
+            else
+                log "  Removing: $dirname"
+                rm -rf "$dir"
+            fi
+        done
+    else
+        log "Cache directory does not exist: $CACHE_DIR"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+
+VERIFY_OK=""
+
+if [[ "$RESOLVED_VERSION" != "NOT_FOUND" && -n "$RESOLVED_VERSION" ]]; then
+    log "Verify: node_modules/convex version=$RESOLVED_VERSION ✓"
+else
+    warn "Verify: could not read resolved version from node_modules"
+    VERIFY_OK=1
+fi
+
+BINARY_FOUND=""
+for search_dir in "$CACHE_DIR/$RESOLVED_VERSION" "$CACHE_DIR"/precompiled-*; do
+    if [[ -x "$search_dir/$BIN_NAME" ]]; then
+        log "Verify: cached binary at $search_dir/$BIN_NAME ✓"
+        BINARY_FOUND=1
+        break
+    fi
+done
+if [[ ! "${BINARY_FOUND:-}" ]]; then
+    warn "Verify: no cached binary found for version $RESOLVED_VERSION"
+    VERIFY_OK=1
+fi
+
+if [[ ! "${NO_TIMEOUT:-}" ]]; then
+    if grep -q "CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS=$TIMEOUT_SECS" "$CONVEX_ENV_LOCAL" 2>/dev/null; then
+        log "Verify: CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS=$TIMEOUT_SECS in .env.local ✓"
+    else
+        warn "Verify: CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS not found in .env.local"
+        VERIFY_OK=1
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+log ""
+if [[ ! "${VERIFY_OK:-}" ]]; then
+    log "=== Upgrade complete ==="
+else
+    log "=== Upgrade complete (with warnings) ==="
+fi
+log ""
+log "  Package version:  $CARET_VERSION"
+log "  Resolved version: $RESOLVED_VERSION"
+log "  Environment:      $ENV"
+log "  Timeout:          CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS=$TIMEOUT_SECS"
+log ""
+log "Next steps:"
+log "  1. Test: make dev"
+log "  2. Commit: git add apps/web/package.json packages/convex/package.json package-lock.json"
+log "             git commit -m 'chore: upgrade convex to $CARET_VERSION'"
+log ""
+if [[ "${VERIFY_OK:-}" ]]; then
+    log "Rollback (if needed):"
+    log "  git checkout -- apps/web/package.json packages/convex/package.json package-lock.json"
+    log "  bun install  # or npm install"
+fi


### PR DESCRIPTION
## Summary

- Add `minRoleYears`, `roleFilterType`, `minAge`, `maxAge` to `convexSourceFilters` so they're sent to the Convex server (was missing 4 of 12 fields)
- Align client-side `getRoleYears` with server-side verified-only semantics (`getVerifiedRoleSignalYears` + precomputed `verifiedRoleYears`) instead of loose `roleRelevantYears`/`years`
- Project `verifiedRoleYears` through `projectResumeListIngestData` and parse it in the client so `getRoleYears` can read the precomputed field
- Add `verifiedRoleYears` to `ConvexIngestData` type and parsing in `useConvexResumes`
- Update `getRoleYears` tests to verify verified-only behavior

## Root Cause

`convexSourceFilters` in `useResumeListState.ts:301-313` only included 8 of 12 `ConvexResumeFilters` fields. The 4 missing fields (`minRoleYears`, `roleFilterType`, `minAge`, `maxAge`) were never sent to the Convex server, causing:

1. **No overfetch**: Server saw no filters → `hasActiveFilters=false` → no 3x multiplier → scanned only 200 from search index
2. **Loose client filter**: Client used `getRoleYears` (counts `roleRelevantYears`/`years` — unverified) which passes ~6x more resumes than the server's strict `getVerifiedRoleSignalYears`

Result: URL `/dev/resumes?location=China&q=CNC+销售&minRoleYears=1&roleType=sales&minAge=25&maxAge=40` showed only ~15 results instead of 46.

## Test plan

- [ ] Open `/dev/resumes?location=China&q=CNC+销售&minRoleYears=1&roleType=sales&minAge=25&maxAge=40` — should show 46+ results across pages
- [ ] `make check` passes
- [ ] `vitest run` passes for `resume-filter-helpers.test.ts`
- [ ] Verify `backfillVerifiedRoleYears` has been run on target deployment (optional — fallback works without it)