### PR TITLE
Move search profiles to settings, array workspaceSlug, fix soft-delete resurrection

### DIFF
--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -673,20 +673,9 @@ async function ensureWorkspaceSeedProfiles(workspaceSlug: string): Promise<void>
         }
 
         const isSoftDeleted = typeof existing.deletedAt === "number";
-        if (!isSoftDeleted) {
+        if (isSoftDeleted) {
             continue;
         }
-
-        const hashMatches = existing.templateHash === currentHash;
-        if (hashMatches) {
-            continue;
-        }
-
-        await updateCustomProfile(
-            existing.storageId,
-            toStoredProfilePayload(profile, { seededFromConfig: true, templateHash: currentHash }),
-            workspaceSlug,
-        );
     }
 }
 
@@ -709,21 +698,9 @@ async function ensureWorkspaceProfileById(id: string, workspaceSlug: string): Pr
     }
 
     const isSoftDeleted = typeof existing.deletedAt === "number";
-    if (!isSoftDeleted) {
+    if (isSoftDeleted) {
         return;
     }
-
-    const hashMatches = existing.templateHash === currentHash;
-    if (hashMatches) {
-        return;
-    }
-
-    const profile = searchProfileService.normalizeProfileInput(template.profile);
-    await updateCustomProfile(
-        existing.storageId,
-        toStoredProfilePayload(profile, { seededFromConfig: true, templateHash: currentHash }),
-        workspaceSlug,
-    );
 }
 
 async function getLinkedCustomJobDescription(

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -152,6 +152,14 @@ function App() {
                   </RouteSuspense>
                 )}
               />
+              <Route
+                path="profiles"
+                element={(
+                  <RouteSuspense>
+                    <LazySearchProfilesPage />
+                  </RouteSuspense>
+                )}
+              />
             </Route>
 
             <Route
@@ -226,14 +234,6 @@ function App() {
                 element={(
                   <RouteSuspense>
                     <LazyDebugJDs />
-                  </RouteSuspense>
-                )}
-              />
-              <Route
-                path="profiles"
-                element={(
-                  <RouteSuspense>
-                    <LazySearchProfilesPage />
                   </RouteSuspense>
                 )}
               />

--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -678,7 +678,7 @@ describe('QuickStartPanel quick-filter display', () => {
 
     await user.click(screen.getByRole('button', { name: 'Modify' }))
 
-    expect(navigateMock).toHaveBeenCalledWith('/dev/system/profiles?edit=seek-malaysia-sales')
+    expect(navigateMock).toHaveBeenCalledWith('/dev/settings/profiles?edit=seek-malaysia-sales')
   })
 
   it('shows auto-match with keywords only when location is blank', async () => {

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -862,7 +862,7 @@ export function QuickStartPanel({
 
     const nextParams = new URLSearchParams()
     nextParams.set('edit', profileId)
-    navigate(`/${slug}/system/profiles?${nextParams.toString()}`)
+    navigate(`/${slug}/settings/profiles?${nextParams.toString()}`)
   }, [autoMatchResult?.profile.id, navigate, slug])
 
   const handleJdEditorSaveSuccess = useCallback((newId: string, savedFields?: {

--- a/apps/web/src/components/SettingsSidebar.tsx
+++ b/apps/web/src/components/SettingsSidebar.tsx
@@ -5,7 +5,7 @@ import {
   type SurfaceNavDefinition,
 } from '@trends/shared'
 import { Link, useLocation } from 'react-router-dom'
-import { Ban, Home, X } from 'lucide-react'
+import { Ban, Home, Search, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
@@ -23,6 +23,7 @@ type NavItem = SurfaceNavDefinition & {
 const NAV_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   home: Home,
   blocks: Ban,
+  profiles: Search,
 }
 
 interface SettingsSidebarProps {

--- a/apps/web/src/components/SystemSidebar.tsx
+++ b/apps/web/src/components/SystemSidebar.tsx
@@ -34,7 +34,6 @@ const NAV_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   home: Home,
   settings: Settings,
   jds: FileText,
-  profiles: FileText,
   summaries: BarChart3,
   'ai-debugger': Brain,
   'ai-tagging': Brain,

--- a/apps/web/src/components/search/SearchHero.test.tsx
+++ b/apps/web/src/components/search/SearchHero.test.tsx
@@ -385,7 +385,7 @@ describe('SearchHero', () => {
     expect(openedUrl.searchParams.get('tr_max_age')).toBeNull()
     expect(screen.getByRole('link', { name: 'Edit' })).toHaveAttribute(
       'href',
-      '/dev/system/profiles',
+      '/dev/settings/profiles',
     )
   })
 
@@ -444,7 +444,7 @@ describe('SearchHero', () => {
 
     expect(screen.getByRole('link', { name: 'Edit' })).toHaveAttribute(
       'href',
-      '/dev/system/profiles?edit=profile%2051job',
+      '/dev/settings/profiles?edit=profile%2051job',
     )
   })
   it('clicking a hot keyword chip calls onToggleHotKeyword', async () => {

--- a/apps/web/src/components/search/SearchHero.tsx
+++ b/apps/web/src/components/search/SearchHero.tsx
@@ -235,7 +235,7 @@ export function SearchHero({
                       </button>
                       <Link
                         className="inline-flex items-center justify-center rounded-full border border-transparent px-3 py-1.5 text-xs font-medium text-slate-600 transition-colors hover:border-slate-200 hover:bg-white hover:text-slate-900"
-                        to={seed.profileId ? `/${slug}/system/profiles?edit=${encodeURIComponent(seed.profileId)}` : `/${slug}/system/profiles`}
+                        to={seed.profileId ? `/${slug}/settings/profiles?edit=${encodeURIComponent(seed.profileId)}` : `/${slug}/settings/profiles`}
                       >
                         {t('resumes.searchPage.hero.editProfile', {
                           defaultValue: 'Edit',

--- a/apps/web/src/pages/DebugConfig.test.tsx
+++ b/apps/web/src/pages/DebugConfig.test.tsx
@@ -327,6 +327,6 @@ describe('System settings routes', () => {
       expect(screen.getByText('Search-first landing quick starts now live in the same Search Profiles workspace registry as every other profile.')).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/system/profiles')
+    expect(screen.getByRole('link', { name: 'Open Search Profiles' })).toHaveAttribute('href', '/dev/settings/profiles')
   })
 })

--- a/apps/web/src/pages/system-settings/SystemSettingsKeywordsPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsKeywordsPage.tsx
@@ -311,7 +311,7 @@ export function SystemSettingsKeywordsPage() {
               </div>
               <Link
                 className="inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-                to={`/${slug}/system/profiles`}
+                to={`/${slug}/settings/profiles`}
               >
                 {t('searchProfiles.title', { defaultValue: 'Open Search Profiles' })}
               </Link>

--- a/config/search-profiles/51job-cn-cnc-sales.yaml
+++ b/config/search-profiles/51job-cn-cnc-sales.yaml
@@ -4,7 +4,7 @@ description: China-wide 51job CNC sales search profile used for the landing quic
 createdAt: "2026-04-02"
 updatedAt: "2026-04-09"
 status: active
-workspaceSlug: dev
+workspaceSlug: [dev, hr]
 seedLastRunOffsetMs: 900000
 
 location: China

--- a/config/search-profiles/job5156-cn-cnc-sales.yaml
+++ b/config/search-profiles/job5156-cn-cnc-sales.yaml
@@ -4,7 +4,7 @@ description: China-wide Job5156 CNC sales search profile used for the landing qu
 createdAt: "2026-03-28"
 updatedAt: "2026-03-28"
 status: active
-workspaceSlug: dev
+workspaceSlug: [dev, hr]
 seedLastRunOffsetMs: 3600000
 
 location: China

--- a/config/search-profiles/seek-malaysia-sales.yaml
+++ b/config/search-profiles/seek-malaysia-sales.yaml
@@ -4,7 +4,7 @@ description: Malaysia SEEK workflow for nationwide CNC sales hiring
 createdAt: "2026-03-17"
 updatedAt: "2026-04-24"
 status: active
-workspaceSlug: dev
+workspaceSlug: [dev, hr]
 seedLastRunOffsetMs: 1800000
 
 location: Malaysia

--- a/packages/shared/src/generated/search-profile-templates.ts
+++ b/packages/shared/src/generated/search-profile-templates.ts
@@ -121,6 +121,59 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
     }
   },
   {
+    "workspaceSlug": "hr",
+    "seedLastRunOffsetMs": 3600000,
+    "profile": {
+      "id": "job5156-cn-cnc-sales",
+      "name": "China Job5156 CNC Sales",
+      "description": "China-wide Job5156 CNC sales search profile used for the landing quick start",
+      "createdAt": "2026-03-28",
+      "updatedAt": "2026-03-28",
+      "status": "active",
+      "location": "China",
+      "keywords": [
+        "CNC",
+        "销售"
+      ],
+      "jobDescription": "lathe-sales",
+      "filters": {
+        "minExperience": 1,
+        "maxExperience": null,
+        "minAge": 25,
+        "maxAge": 40,
+        "locations": [
+          "China"
+        ]
+      },
+      "schedule": {
+        "enabled": false,
+        "cron": "0 9 * * 1-5",
+        "timezone": "Asia/Shanghai",
+        "maxCandidates": 200
+      },
+      "sources": [
+        {
+          "type": "job5156",
+          "enabled": true,
+          "priority": 1,
+          "collectLimit": 200,
+          "maxPages": 10
+        },
+        {
+          "type": "seek",
+          "enabled": false,
+          "priority": 2
+        }
+      ],
+      "quickStart": {
+        "enabled": true,
+        "rank": 1,
+        "label": "China · Job5156 · CNC 销售",
+        "description": "CNC, 销售 · China"
+      }
+    }
+  },
+  {
     "workspaceSlug": "dev",
     "seedLastRunOffsetMs": 900000,
     "profile": {
@@ -171,7 +224,119 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
     }
   },
   {
+    "workspaceSlug": "hr",
+    "seedLastRunOffsetMs": 900000,
+    "profile": {
+      "id": "51job-cn-cnc-sales",
+      "name": "China 51job CNC Sales",
+      "description": "China-wide 51job CNC sales search profile used for the landing quick start",
+      "createdAt": "2026-04-02",
+      "updatedAt": "2026-04-09",
+      "status": "active",
+      "location": "China",
+      "keywords": [
+        "CNC",
+        "销售"
+      ],
+      "filters": {
+        "minExperience": 1,
+        "maxExperience": null,
+        "minAge": 25,
+        "maxAge": 40,
+        "locations": [
+          "China"
+        ]
+      },
+      "schedule": {
+        "enabled": false,
+        "cron": "0 9 * * 1-5",
+        "timezone": "Asia/Shanghai",
+        "maxCandidates": 200
+      },
+      "sources": [
+        {
+          "type": "51job",
+          "enabled": true,
+          "priority": 1
+        },
+        {
+          "type": "job5156",
+          "enabled": false,
+          "priority": 2
+        }
+      ],
+      "quickStart": {
+        "enabled": true,
+        "rank": 2,
+        "label": "China · 51job · CNC 销售",
+        "description": "CNC, 销售 · China"
+      }
+    }
+  },
+  {
     "workspaceSlug": "dev",
+    "seedLastRunOffsetMs": 1800000,
+    "profile": {
+      "id": "seek-malaysia-sales",
+      "name": "SEEK Malaysia CNC Sales",
+      "description": "Malaysia SEEK workflow for nationwide CNC sales hiring",
+      "createdAt": "2026-03-17",
+      "updatedAt": "2026-04-24",
+      "status": "active",
+      "location": "Malaysia",
+      "keywords": [
+        "CNC",
+        "Sales"
+      ],
+      "requiredKeywords": [
+        "machine tools"
+      ],
+      "jobDescription": "seek-malaysia-sales",
+      "filters": {
+        "minExperience": 1,
+        "maxExperience": null,
+        "maxAge": 45,
+        "locations": [
+          "Malaysia"
+        ]
+      },
+      "schedule": {
+        "enabled": false,
+        "timezone": "Asia/Kuala_Lumpur",
+        "maxCandidates": 120
+      },
+      "sources": [
+        {
+          "type": "seek",
+          "enabled": true,
+          "priority": 1,
+          "jobUrl": "https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1",
+          "collectLimit": 100,
+          "maxPages": 5
+        },
+        {
+          "type": "job5156",
+          "enabled": false,
+          "priority": 2
+        }
+      ],
+      "quickStart": {
+        "enabled": true,
+        "rank": 3,
+        "label": "Malaysia · SEEK · CNC Sales",
+        "description": "CNC, Sales · Malaysia"
+      },
+      "session": {
+        "scope": "per-position",
+        "retention": {
+          "mode": "until-closed",
+          "archiveAfterDays": 90
+        }
+      }
+    }
+  },
+  {
+    "workspaceSlug": "hr",
     "seedLastRunOffsetMs": 1800000,
     "profile": {
       "id": "seek-malaysia-sales",

--- a/packages/shared/src/system-debug-metadata.ts
+++ b/packages/shared/src/system-debug-metadata.ts
@@ -234,13 +234,6 @@ export const SYSTEM_NAV_ITEMS: SurfaceNavDefinition[] = [
     matchesSuffixes: ["/system/jds"],
   },
   {
-    id: "profiles",
-    titleKey: "searchProfiles.nav",
-    defaultTitle: "Search Profiles",
-    hrefSuffix: "/system/profiles",
-    matchesSuffixes: ["/system/profiles"],
-  },
-  {
     id: "summaries",
     titleKey: "summaries.nav",
     defaultTitle: "Summary Runs",
@@ -305,6 +298,13 @@ export const SETTINGS_NAV_ITEMS: SurfaceNavDefinition[] = [
     defaultTitle: "Blacklist",
     hrefSuffix: "/settings/blocks",
     matchesSuffixes: ["/settings/blocks"],
+  },
+  {
+    id: "profiles",
+    titleKey: "searchProfiles.nav",
+    defaultTitle: "Search Profiles",
+    hrefSuffix: "/settings/profiles",
+    matchesSuffixes: ["/settings/profiles"],
   },
 ];
 

--- a/scripts/e2e-deep-scan.mjs
+++ b/scripts/e2e-deep-scan.mjs
@@ -42,7 +42,7 @@ const SCENARIOS = [
     }
   },
   {
-    path: '/dev/system/profiles', label: 'Search Profiles',
+    path: '/dev/settings/profiles', label: 'Search Profiles',
     interactions: async (page) => {
       const firstRow = await page.locator('[class*="card"], [role="row"], button').nth(2);
       if (await firstRow.count() > 0) { await firstRow.click({ timeout: 1500 }).catch(()=>{}); await page.waitForTimeout(2000); }

--- a/scripts/resume/sync-search-profile-templates.ts
+++ b/scripts/resume/sync-search-profile-templates.ts
@@ -77,7 +77,7 @@ type Profile = {
 };
 
 type Template = {
-  workspaceSlug: string;
+  workspaceSlugs: string[];
   seedLastRunOffsetMs?: number;
   profile: Profile;
 };
@@ -94,6 +94,17 @@ function readString(value: unknown): string | undefined {
 
 function readNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readWorkspaceSlugs(value: unknown): string[] {
+  // Array form: workspaceSlug: [dev, hr]
+  const asArray = readStringArray(value);
+  if (asArray && asArray.length > 0) return asArray;
+  // Scalar form: workspaceSlug: dev
+  const asString = readString(value);
+  if (asString) return [asString];
+  // Default
+  return ["dev"];
 }
 
 function readStringArray(value: unknown): string[] | undefined {
@@ -206,7 +217,7 @@ function parseTemplate(raw: unknown, fileName: string): Template | null {
     ? raw.sources.map(parseSource).filter((s: ProfileSource | null): s is ProfileSource => s !== null)
     : undefined;
   return {
-    workspaceSlug: readString(raw.workspaceSlug) ?? "dev",
+    workspaceSlugs: readWorkspaceSlugs(raw.workspaceSlug),
     seedLastRunOffsetMs: readNumber(raw.seedLastRunOffsetMs),
     profile: {
       id,
@@ -229,11 +240,17 @@ function parseTemplate(raw: unknown, fileName: string): Template | null {
   };
 }
 
+type FlatTemplate = {
+  workspaceSlug: string;
+  seedLastRunOffsetMs?: number;
+  profile: Profile;
+};
+
 // --- Rendering ---
 
 const SOURCE_DIR_RELATIVE = "config/search-profiles";
 
-function sortTemplates(templates: Template[]): Template[] {
+function sortTemplates(templates: FlatTemplate[]): FlatTemplate[] {
   return [...templates].sort((a, b) => {
     const rankA = a.profile.quickStart?.enabled ? (a.profile.quickStart?.rank ?? 999) : 999;
     const rankB = b.profile.quickStart?.enabled ? (b.profile.quickStart?.rank ?? 999) : 999;
@@ -242,7 +259,7 @@ function sortTemplates(templates: Template[]): Template[] {
   });
 }
 
-function renderGeneratedFile(templates: Template[]): string {
+function renderGeneratedFile(templates: FlatTemplate[]): string {
   const sorted = sortTemplates(templates);
 
   // Remove undefined values for clean JSON output
@@ -425,12 +442,24 @@ async function run(): Promise<void> {
     if (template) templates.push(template);
   }
 
+  // Fan out array workspaceSlugs into flat per-slug entries
+  const flatTemplates: FlatTemplate[] = [];
+  for (const template of templates) {
+    for (const slug of template.workspaceSlugs) {
+      flatTemplates.push({
+        workspaceSlug: slug,
+        seedLastRunOffsetMs: template.seedLastRunOffsetMs,
+        profile: template.profile,
+      });
+    }
+  }
+
   if (templates.length === 0) {
     console.error("No valid search profile templates found");
     process.exit(1);
   }
 
-  const expected = renderGeneratedFile(templates);
+  const expected = renderGeneratedFile(flatTemplates);
 
   if (checkMode) {
     const current = await readFile(outputPath, "utf8");


### PR DESCRIPTION
## Summary
- Move profiles page from `/:teamSlug/system/profiles` to `/:teamSlug/settings/profiles` — HR team can now access it without admin gate
- Support `workspaceSlug: [dev, hr]` array syntax in YAML config; sync script fans out into separate per-slug template entries (3 profiles × 2 workspaces = 6 generated entries)
- Fix `ensureWorkspaceSeedProfiles` and `ensureWorkspaceProfileById` to never resurrect soft-deleted config profiles on redeploy, even when template hash changes

## Test plan
- [ ] `make check` passes
- [ ] Navigate to `/hr/settings/profiles` — HR sees the 3 predefined profiles
- [ ] Navigate to `/dev/settings/profiles` — dev also sees the 3 predefined profiles
- [ ] Soft-delete a config profile, re-seed, confirm it stays deleted
- [ ] Existing vitest tests pass (URL references updated)