### PR TITLE
fix(convex): replace formula-primary scoring with LLM-primary hybrid

### DIFF
--- a/packages/convex/convex/__tests__/analysis-strict-evidence.test.ts
+++ b/packages/convex/convex/__tests__/analysis-strict-evidence.test.ts
@@ -269,9 +269,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-      }
     );
 
     expect(normalized.breakdown?.related_exp).toBe(80);
@@ -316,9 +313,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-      }
     );
 
     // directRoleMatch=false means "项目工程师" got sales signal from description,
@@ -366,9 +360,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-      }
     );
 
     expect(normalized.breakdown?.related_exp).toBe(80);
@@ -408,9 +399,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-      }
     );
 
     expect(normalized.score).toBe(90);
@@ -466,10 +454,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-        keywords: ["cnc", "销售"],
-      }
     );
 
     // Insurance sales is domain-irrelevant to CNC sales — cap at 15
@@ -517,10 +501,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-        keywords: ["cnc", "销售"],
-      }
     );
 
     // Industry-verified CNC sales — no ceiling
@@ -571,10 +551,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-        keywords: ["cnc", "销售"],
-      }
     );
 
     // FANUC brand hit with product context proves CNC domain — no ceiling
@@ -628,10 +604,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-        keywords: ["cnc", "销售"],
-      }
     );
 
     // Technical-only brand hits from CNC operator work do not prove sales domain overlap
@@ -681,10 +653,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-        keywords: ["cnc", "销售"],
-      }
     );
 
     // Industry tags from CNC technician work + domain-irrelevant company (insurance)
@@ -734,10 +702,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-        keywords: ["cnc", "销售"],
-      }
     );
 
     // Industry tags + direct sales role at a domain-relevant company (machinery trading)
@@ -788,10 +752,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-        keywords: ["cnc", "销售"],
-      }
     );
 
     // AI gave 22 but floor of 60 applies: unverified + domain tags + no irrelevant company
@@ -840,10 +800,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-        keywords: ["cnc", "销售"],
-      }
     );
 
     // Insurance company → domain-irrelevant → no floor, ceiling caps at 15
@@ -892,10 +848,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-        keywords: ["cnc", "销售"],
-      }
     );
 
     // No direct sales title → floor doesn't apply; also noDirectSalesRoleCap zeros it out
@@ -943,10 +895,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-        keywords: ["cnc", "销售"],
-      }
     );
 
     // Industry-verified sales gets the 80 floor (higher than 60)
@@ -994,10 +942,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-        keywords: ["cnc", "销售"],
-      }
     );
 
     // Industry-verified sales at a machinery company — no ceiling applies
@@ -1042,10 +986,6 @@ describe("normalizeResume strict evidence", () => {
           ],
         },
       } as unknown,
-      {
-        targetRoleType: "sales",
-        keywords: ["销售"],
-      }
     );
 
     // Sales-only keyword — no domain ceiling applies.
@@ -1065,7 +1005,6 @@ describe("normalizeResume strict evidence", () => {
           breakdown: { related_exp: 80, industry_db: 10 },
         },
         { ingestData: { industryDbV2Raw: 10, companyHits: ["TestCo"], brandHits: [{ context: "employer" }], roleSignals: [{ type: "sales", years: 5, roleRelevantYears: 5, industryVerifiedYears: 5, matchedSignals: ["销售"] }] } } as unknown,
-        { targetRoleType: "sales" }
       );
       // normalizeAnalysisResult replaces empty summaries with a fallback
       expect(normalized.summary).not.toBe("");
@@ -1082,7 +1021,6 @@ describe("normalizeResume strict evidence", () => {
           breakdown: { related_exp: 80, industry_db: 10 },
         },
         { ingestData: { industryDbV2Raw: 10, companyHits: ["TestCo"], brandHits: [{ context: "employer" }], roleSignals: [{ type: "sales", years: 5, roleRelevantYears: 5, industryVerifiedYears: 5, matchedSignals: ["销售"] }] } } as unknown,
-        { targetRoleType: "sales" }
       );
       // normalizeAnalysisResult replaces empty/whitespace summaries with a fallback
       expect(normalized.summary).not.toBe("   ");
@@ -1099,7 +1037,6 @@ describe("normalizeResume strict evidence", () => {
           breakdown: { related_exp: 40, industry_db: 0 },
         },
         { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
-        {}
       );
       // recommendation "potential" matches, but score 75 in prose != computed score
       // The actual computed score = round(40*0.5) + 0 = 20
@@ -1118,7 +1055,6 @@ describe("normalizeResume strict evidence", () => {
           breakdown: { related_exp: 80, industry_db: 10 },
         },
         { ingestData: { industryDbV2Raw: 10, companyHits: ["TestCo"], brandHits: [{ context: "employer" }], roleSignals: [{ type: "sales", years: 5, roleRelevantYears: 5, industryVerifiedYears: 5, matchedSignals: ["销售"] }] } } as unknown,
-        { targetRoleType: "sales" }
       );
       // score 90 matches, but recommendation "match" should be "strong_match" (>=85)
       expect(normalized.recommendation).toBe("strong_match");
@@ -1137,7 +1073,6 @@ describe("normalizeResume strict evidence", () => {
           breakdown: { related_exp: 80, industry_db: 10 },
         },
         { ingestData: { industryDbV2Raw: 10, companyHits: ["TestCo"], brandHits: [{ context: "employer" }], roleSignals: [{ type: "sales", years: 5, roleRelevantYears: 5, industryVerifiedYears: 5, matchedSignals: ["销售"] }] } } as unknown,
-        { targetRoleType: "sales" }
       );
       expect(normalized.summary).toBe(originalSummary);
     });
@@ -1152,7 +1087,6 @@ describe("normalizeResume strict evidence", () => {
           breakdown: { related_exp: 20, industry_db: 0 },
         },
         { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
-        {}
       );
       // Both score and recommendation mismatch → English canonical line appended
       expect(normalized.summary).toContain("Normalized result: score 10, recommendation no_match");
@@ -1168,7 +1102,6 @@ describe("normalizeResume strict evidence", () => {
           breakdown: { related_exp: 80, industry_db: 0 },
         },
         { ingestData: { industryDbV2Raw: 10, companyHits: ["深圳市创世纪机械有限公司"], brandHits: [{ context: "employer" }], roleSignals: [{ type: "sales", years: 3.8, roleRelevantYears: 3.8, industryVerifiedYears: 3.8, matchedSignals: ["销售工程师"] }] } } as unknown,
-        { targetRoleType: "sales" }
       );
       expect(normalized.summary).toContain("系统归一化结果：score 90，recommendation strong_match");
     });
@@ -1183,7 +1116,6 @@ describe("normalizeResume strict evidence", () => {
       const normalized = normalizeAnalysisResult(
         { score: 0, recommendation: "no_match", summary: "ok", highlights: [], breakdown: { related_exp: 70, industry_db: 0 } },
         { ingestData: { industryDbV2Raw: 0, companyHits: ["some-company"], brandHits: [], roleSignals: [] } } as unknown,
-        {}
       );
       expect(normalized.score).toBe(85);
       expect(normalized.recommendation).toBe("strong_match");
@@ -1194,7 +1126,6 @@ describe("normalizeResume strict evidence", () => {
       const normalized = normalizeAnalysisResult(
         { score: 0, recommendation: "no_match", summary: "ok", highlights: [], breakdown: { related_exp: 68, industry_db: 0 } },
         { ingestData: { industryDbV2Raw: 0, companyHits: ["some-company"], brandHits: [], roleSignals: [] } } as unknown,
-        {}
       );
       expect(normalized.score).toBe(84);
       expect(normalized.recommendation).toBe("match");
@@ -1205,7 +1136,6 @@ describe("normalizeResume strict evidence", () => {
       const normalized = normalizeAnalysisResult(
         { score: 0, recommendation: "no_match", summary: "ok", highlights: [], breakdown: { related_exp: 80, industry_db: 0 } },
         { ingestData: { industryDbV2Raw: 30, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
-        {}
       );
       expect(normalized.score).toBe(70);
       expect(normalized.recommendation).toBe("match");
@@ -1216,7 +1146,6 @@ describe("normalizeResume strict evidence", () => {
       const normalized = normalizeAnalysisResult(
         { score: 0, recommendation: "no_match", summary: "ok", highlights: [], breakdown: { related_exp: 78, industry_db: 0 } },
         { ingestData: { industryDbV2Raw: 30, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
-        {}
       );
       expect(normalized.score).toBe(69);
       expect(normalized.recommendation).toBe("potential");
@@ -1227,7 +1156,6 @@ describe("normalizeResume strict evidence", () => {
       const normalized = normalizeAnalysisResult(
         { score: 0, recommendation: "no_match", summary: "ok", highlights: [], breakdown: { related_exp: 80, industry_db: 0 } },
         { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
-        {}
       );
       expect(normalized.score).toBe(40);
       expect(normalized.recommendation).toBe("potential");
@@ -1238,7 +1166,6 @@ describe("normalizeResume strict evidence", () => {
       const normalized = normalizeAnalysisResult(
         { score: 0, recommendation: "no_match", summary: "ok", highlights: [], breakdown: { related_exp: 78, industry_db: 0 } },
         { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
-        {}
       );
       expect(normalized.score).toBe(39);
       expect(normalized.recommendation).toBe("no_match");
@@ -1273,7 +1200,6 @@ describe("normalizeResume strict evidence", () => {
             }],
           },
         } as unknown,
-        { targetRoleType: "sales", keywords: ["CNC", "销售"] }
       );
       // Domain-irrelevant ceiling should cap related_exp at 15
       expect(normalized.breakdown?.related_exp).toBeLessThanOrEqual(15);
@@ -1306,7 +1232,6 @@ describe("normalizeResume strict evidence", () => {
             }],
           },
         } as unknown,
-        { targetRoleType: "sales", keywords: ["CNC", "销售"] }
       );
       expect(normalized.breakdown?.related_exp).toBeLessThanOrEqual(15);
     });
@@ -1345,7 +1270,6 @@ describe("normalizeResume strict evidence", () => {
             }],
           },
         } as unknown,
-        { targetRoleType: "sales", keywords: ["CNC", "销售"] }
       );
       // "cnc" keyword maps to "machinery" tag → unverified floor should apply → related_exp ≥ 60
       expect(normalized.breakdown?.related_exp).toBeGreaterThanOrEqual(60);
@@ -1380,7 +1304,6 @@ describe("normalizeResume strict evidence", () => {
             }],
           },
         } as unknown,
-        { targetRoleType: "sales", keywords: ["CNC", "销售"] }
       );
       // "机械" tag → "machinery", "cnc" keyword → "machinery" → match → floor applies
       expect(normalized.breakdown?.related_exp).toBeGreaterThanOrEqual(60);
@@ -1414,7 +1337,6 @@ describe("normalizeResume strict evidence", () => {
             }],
           },
         } as unknown,
-        { targetRoleType: "sales", keywords: ["CNC", "销售"] }
       );
       // "cnc" maps to "machinery" but resume has "software" tag — no overlap → no floor
       expect(normalized.breakdown?.related_exp).toBeLessThanOrEqual(22);
@@ -1450,7 +1372,6 @@ describe("normalizeResume strict evidence", () => {
             }],
           },
         } as unknown,
-        { targetRoleType: "sales", keywords: ["CNC", "销售"] }
       );
       // No direct sales title (directRoleMatch=false) → cap at 0
       expect(normalized.breakdown?.related_exp).toBe(0);
@@ -1484,7 +1405,6 @@ describe("normalizeResume strict evidence", () => {
             }],
           },
         } as unknown,
-        { targetRoleType: "sales", keywords: ["CNC", "销售"] }
       );
       // Has direct sales title + verified 3y → 80 floor applies, cap does not
       expect(normalized.breakdown?.related_exp).toBeGreaterThanOrEqual(80);

--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -5,7 +5,6 @@ import { v } from "convex/values";
 import {
     buildKeywordAnalysisId as buildSharedKeywordAnalysisId,
     getCurrentResumeAiPromptVersion,
-    isSalesRequiredContext,
 } from "@trends/shared";
 import {
     buildKeywordMatchingRules,
@@ -156,21 +155,6 @@ function normalizeKeywords(keywords: string[]): string[] {
     );
 }
 
-function inferTargetRoleType(config: {
-    keywords?: string[];
-    jobDescriptionTitle?: string;
-    jobDescriptionContent?: string;
-}): "sales" | undefined {
-    if (isSalesRequiredContext(
-        ...(config.keywords ?? []),
-        config.jobDescriptionTitle,
-        config.jobDescriptionContent
-    )) {
-        return "sales";
-    }
-
-    return undefined;
-}
 
 function stableHash(seed: string): string {
     let hash = 2166136261;
@@ -291,11 +275,6 @@ async function analyzeOneResume(
         ? buildKeywordMatchingRules(normalizedKeywords, locale)
         : (isEnglishLocale ? "Use the default scoring rules." : "使用默认评分标准");
     const normalizedResume = normalizeResume(resume, { locale });
-    const targetRoleType = inferTargetRoleType({
-        keywords: normalizedKeywords,
-        jobDescriptionTitle: config.jobDescriptionTitle,
-        jobDescriptionContent: config.jobDescriptionContent,
-    });
 
     const prompt = hydrateUserPrompt(
         getUserPromptTemplate(locale),
@@ -315,10 +294,7 @@ async function analyzeOneResume(
         try {
             const rawResult = await callLLM(messages, apiKey);
             const parsedResult = parseLlmResult(rawResult);
-            const normalizedResult = normalizeAnalysisResult(parsedResult, resume, {
-                targetRoleType,
-                keywords: normalizedKeywords,
-            });
+            const normalizedResult = normalizeAnalysisResult(parsedResult, resume);
             return {
                 ...normalizedResult,
                 locale,

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -1,13 +1,10 @@
 /// <reference path="./convex-env.d.ts" />
 import {
     DEFAULT_RESUME_AI_PROMPT_LOCALE,
-    FALLBACK_INDUSTRY_KEYWORDS,
-    INDUSTRY_DISPLAY_NAME_TO_TAG,
     buildResumeAiSystemPrompt,
     getResumeAiLocaleText,
     getResumeAiPromptDefinition,
     getResumeAiUserPromptTemplate,
-    isSalesRequiredContext,
     resolveResumeAnalysisSourceKey,
     sanitizeResumeRecordForSurface,
     resolveResumeAiPromptLocale,
@@ -231,323 +228,6 @@ function normalizeSummaryConsistency(
     return next;
 }
 
-function inferSalesRelatedExpFloor(resume: unknown): number | undefined {
-    const ingestData = getResumeIngestData(resume);
-    if (!Array.isArray(ingestData.roleSignals)) {
-        return undefined;
-    }
-
-    for (const rawSignal of ingestData.roleSignals) {
-        if (!isRecord(rawSignal)) {
-            continue;
-        }
-
-        const type = typeof rawSignal.type === "string" ? rawSignal.type.trim().toLowerCase() : "";
-        if (type !== "sales") {
-            continue;
-        }
-
-        const verifiedYears = toNumber(rawSignal.industryVerifiedYears) ?? 0;
-        const verifiedRelevantYears = toNumber(rawSignal.industryVerifiedRelevantYears) ?? 0;
-        const workEntries = Array.isArray(rawSignal.matchedWorkEntries)
-            ? rawSignal.matchedWorkEntries.filter((rawEntry): rawEntry is Record<string, unknown> => isRecord(rawEntry))
-            : [];
-        const hasDirectRoleEvidence = workEntries.some((rawEntry) => rawEntry.directRoleMatch === true);
-
-        // The 80 floor only applies to industry-verified sales; unverified direct-role
-        // sales are handled by the AI (prompt rules 12/13) and inferUnverifiedDomainRelevantSalesFloor.
-        const hasIndustryVerifiedSales = verifiedYears > 0 || verifiedRelevantYears > 0
-            || workEntries.some((rawEntry) => rawEntry.industryVerified === true);
-
-        if (hasDirectRoleEvidence && !hasIndustryVerifiedSales) {
-            // Unverified direct-role: 80 floor doesn't apply; 60 floor or 15 ceiling
-            // may apply via other inference functions.
-            continue;
-        }
-
-        // Industry-verified sales with 3+ years → floor of 80
-        const relevantYears = Math.max(verifiedYears, toNumber(rawSignal.roleRelevantYears) ?? toNumber(rawSignal.years) ?? 0);
-        if (hasIndustryVerifiedSales && relevantYears >= 3) {
-            return 80;
-        }
-    }
-
-    return undefined;
-}
-
-/**
- * Caps related_exp at 15 when domain+sales keywords are combined but the candidate's
- * sales has no domain evidence. Bypassed by: industry-verified sales, verified entries,
- * sales-relevant brand hits, or industry tags + direct sales at a non-irrelevant company.
- * Returns 15 or undefined if no cap applies.
- */
-function inferDomainIrrelevantSalesCeiling(
-    resume: unknown,
-    keywords: string[],
-): number | undefined {
-    const ingestData = getResumeIngestData(resume);
-    if (!Array.isArray(ingestData.roleSignals)) {
-        return undefined;
-    }
-
-    // Only applies when there are both sales and non-sales keywords
-    const salesKeywords = keywords.filter((kw) => isSalesRequiredContext(kw));
-    const domainKeywords = keywords.filter((kw) => !isSalesRequiredContext(kw));
-    if (salesKeywords.length === 0 || domainKeywords.length === 0) {
-        return undefined;
-    }
-
-    // Check if candidate has any industry-verified sales signal or
-    // sales work entries at industry-verified companies
-    const salesSignal = ingestData.roleSignals.find((rawSignal) => {
-        if (!isRecord(rawSignal)) return false;
-        return typeof rawSignal.type === "string"
-            && rawSignal.type.trim().toLowerCase() === "sales";
-    });
-
-    if (!salesSignal || !isRecord(salesSignal)) {
-        // No sales signal at all — ceiling doesn't apply (floor won't either)
-        return undefined;
-    }
-
-    // Signal-level: industry-verified sales years
-    const hasIndustryVerifiedSalesYears = (toNumber(salesSignal.industryVerifiedRelevantYears) ?? 0) > 0
-        || (toNumber(salesSignal.industryVerifiedYears) ?? 0) > 0;
-
-    // Entry-level: sales work entries at industry-verified companies
-    const workEntries = Array.isArray(salesSignal.matchedWorkEntries)
-        ? salesSignal.matchedWorkEntries.filter((rawEntry): rawEntry is Record<string, unknown> => isRecord(rawEntry))
-        : [];
-    const hasIndustryVerifiedSalesEntry = workEntries.some(
-        (entry) => entry.industryVerified === true
-    );
-
-    // Only brand hits with sales-relevant context bypass the ceiling;
-    // technical-only brand hits from non-sales roles don't prove sales domain overlap.
-    const hasSalesRelevantBrandHits = (() => {
-        if (!Array.isArray(ingestData.brandHits) || ingestData.brandHits.length === 0) {
-            return false;
-        }
-        if (hasIndustryVerifiedSalesEntry) return true;
-        const salesRelevantContexts = new Set(["product", "dealer", "agent", "distributor"]);
-        return ingestData.brandHits.some((item) => {
-            if (!isRecord(item)) return false;
-            const context = typeof item.context === "string" ? item.context.trim().toLowerCase() : "";
-            if (context === "employer" || context === "technical") return false;
-            return salesRelevantContexts.has(context) || context === "both" || context === "";
-        });
-    })();
-
-    // Industry tags + direct sales at a non-irrelevant company → tags likely
-    // reflect the sales role's domain (tags alone can come from non-sales roles).
-    const industryTags = Array.isArray(ingestData.industryTags)
-        ? ingestData.industryTags.filter((tag): tag is string => typeof tag === "string")
-        : [];
-    const hasDomainIndustryTag = industryTags.length > 0 && domainKeywords.some(
-        (kw) => keywordMapsToIndustryTag(kw, industryTags),
-    );
-    const hasDomainIrrelevantSalesEntry = workEntries.some((entry) =>
-        isDomainIrrelevantSalesEntry(entry),
-    );
-
-    // If any domain-evidence path confirms relevance, no ceiling.
-    if (hasIndustryVerifiedSalesYears || hasIndustryVerifiedSalesEntry || hasSalesRelevantBrandHits) {
-        return undefined;
-    }
-    // Industry tags + direct sales role + no domain-irrelevant company →
-    // tags likely reflect the sales role's domain (e.g. sales engineer at a
-    // machinery trading company). Let the AI decide with prompt guidance.
-    if (hasDomainIndustryTag && !hasDomainIrrelevantSalesEntry) {
-        return undefined;
-    }
-
-    // Candidate has sales signal but no domain evidence —
-    // the sales experience is likely domain-irrelevant
-    return 15;
-}
-
-/**
- * Keywords that clearly indicate a company or role is in a sector unrelated
- * to the machinery/CNC domain. Used to prevent industry tags from non-sales
- * roles from bypassing the domain-irrelevant ceiling.
- */
-const DOMAIN_IRRELEVANT_SALES_KEYWORDS = [
-    // Insurance / finance
-    "保险", "人寿", "金融", "投资", "证券", "银行", "理财",
-    // Real estate
-    "房地产", "地产", "置业", "房产",
-    // Education / training
-    "教育", "培训", "学校",
-    // Medical / healthcare
-    "医疗", "医院", "医药",
-    // Consumer / food / clothing
-    "食品", "餐饮", "服装", "化妆品",
-    // Job-title-level negative signals (e.g. "保险代理人")
-    "保险代理", "保险销售", "置业顾问",
-];
-
-/**
- * Checks whether a sales work entry is at a company or in a role that is
- * clearly unrelated to the machinery/CNC domain, based on negative keyword
- * matching against company name and job title.
- */
-function isDomainIrrelevantSalesEntry(entry: Record<string, unknown>): boolean {
-    const companyName = typeof entry.companyName === "string" ? entry.companyName : "";
-    const jobTitle = typeof entry.jobTitle === "string" ? entry.jobTitle : "";
-    const text = `${companyName} ${jobTitle}`.toLowerCase();
-    return DOMAIN_IRRELEVANT_SALES_KEYWORDS.some((kw) => text.includes(kw.toLowerCase()));
-}
-
-/**
- * Checks whether a search keyword maps to any of the resume's industry tags
- * through the FALLBACK_INDUSTRY_KEYWORDS taxonomy.
- * e.g. "cnc" maps to "machinery"; if the resume has "machinery" industryTag → match.
- *
- * Handles both English tag IDs (e.g. "machinery") and Chinese displayNames
- * (e.g. "机械") stored in ingestData.industryTags.
- */
-function keywordMapsToIndustryTag(keyword: string, resumeIndustryTags: string[]): boolean {
-    const kwLower = keyword.trim().toLowerCase();
-    if (!kwLower) return false;
-
-    // Normalize resume tags: map Chinese displayNames to English tag IDs
-    const normalizedTags = new Set<string>();
-    for (const tag of resumeIndustryTags) {
-        const tagLower = tag.toLowerCase();
-        normalizedTags.add(tagLower);
-        // Map Chinese displayName to canonical English tag ID
-        const mappedTag = INDUSTRY_DISPLAY_NAME_TO_TAG[tag];
-        if (mappedTag) {
-            normalizedTags.add(mappedTag.toLowerCase());
-        }
-    }
-
-    // Direct tag match (e.g. keyword="machinery" matches tag="machinery")
-    if (normalizedTags.has(kwLower)) return true;
-
-    // Check if the keyword is one of the taxonomy keywords that maps to a resume tag
-    for (const [tag, keywords] of Object.entries(FALLBACK_INDUSTRY_KEYWORDS)) {
-        if (!normalizedTags.has(tag.toLowerCase())) continue;
-        if (keywords.some((kw) => kw.toLowerCase() === kwLower)) return true;
-    }
-
-    return false;
-}
-
-/**
- * Floor of 60 for unverified sales when domain evidence suggests relevance
- * (industry tags overlap + direct sales title + no domain-irrelevant company).
- * Mirrors the ceiling bypass: if ceiling doesn't apply, this floor prevents
- * the AI from under-scoring (typically ~20-30 instead of 60-80).
- * Returns 60 or undefined if no floor applies.
- */
-function inferUnverifiedDomainRelevantSalesFloor(
-    resume: unknown,
-    keywords: string[],
-): number | undefined {
-    const ingestData = getResumeIngestData(resume);
-    if (!Array.isArray(ingestData.roleSignals)) {
-        return undefined;
-    }
-
-    // Only applies when there are both sales and domain keywords
-    const salesKeywords = keywords.filter((kw) => isSalesRequiredContext(kw));
-    const domainKeywords = keywords.filter((kw) => !isSalesRequiredContext(kw));
-    if (salesKeywords.length === 0 || domainKeywords.length === 0) {
-        return undefined;
-    }
-
-    const salesSignal = ingestData.roleSignals.find((rawSignal) => {
-        if (!isRecord(rawSignal)) return false;
-        return typeof rawSignal.type === "string"
-            && rawSignal.type.trim().toLowerCase() === "sales";
-    });
-
-    if (!salesSignal || !isRecord(salesSignal)) {
-        return undefined;
-    }
-
-    // Must have a direct sales role title
-    const workEntries = Array.isArray(salesSignal.matchedWorkEntries)
-        ? salesSignal.matchedWorkEntries.filter((rawEntry): rawEntry is Record<string, unknown> => isRecord(rawEntry))
-        : [];
-    const hasDirectSalesTitle = workEntries.some((entry) => entry.directRoleMatch === true);
-    if (!hasDirectSalesTitle) {
-        return undefined;
-    }
-
-    // Must NOT have industry-verified sales (those get the 80 floor already)
-    const hasIndustryVerifiedSales = (toNumber(salesSignal.industryVerifiedRelevantYears) ?? 0) > 0
-        || (toNumber(salesSignal.industryVerifiedYears) ?? 0) > 0
-        || workEntries.some((entry) => entry.industryVerified === true);
-    if (hasIndustryVerifiedSales) {
-        return undefined;
-    }
-
-    // Must have industry tags overlapping with domain keywords
-    const industryTags = Array.isArray(ingestData.industryTags)
-        ? ingestData.industryTags.filter((tag): tag is string => typeof tag === "string")
-        : [];
-    const hasDomainIndustryTag = industryTags.length > 0 && domainKeywords.some(
-        (kw) => keywordMapsToIndustryTag(kw, industryTags),
-    );
-    if (!hasDomainIndustryTag) {
-        return undefined;
-    }
-
-    // Sales entries must NOT be at domain-irrelevant companies
-    const hasDomainIrrelevantSalesEntry = workEntries.some((entry) =>
-        isDomainIrrelevantSalesEntry(entry),
-    );
-    if (hasDomainIrrelevantSalesEntry) {
-        return undefined;
-    }
-
-    return 60;
-}
-
-/**
- * Caps related_exp to 0 when all sales entries have directRoleMatch=false
- * (sales signal from descriptions only). Bypassed when the floor was already
- * applied or any entry has directRoleMatch=true.
- * Returns 0 or undefined.
- */
-function inferNoDirectSalesRoleCap(resume: unknown, precomputedFloor?: number): number | undefined {
-    const ingestData = getResumeIngestData(resume);
-    if (!Array.isArray(ingestData.roleSignals)) {
-        return undefined;
-    }
-
-    const salesSignals = (ingestData.roleSignals as unknown[]).filter((raw): raw is Record<string, unknown> => {
-        if (!isRecord(raw)) return false;
-        const type = typeof raw.type === "string" ? raw.type.trim().toLowerCase() : "";
-        return type === "sales";
-    });
-
-    if (salesSignals.length === 0) {
-        return 0;
-    }
-
-    // If the floor condition is met, the cap does not apply
-    if (precomputedFloor !== undefined) {
-        return undefined;
-    }
-
-    // Any direct sales title → don't zero out (wrong industry handled by ceiling)
-    const hasDirectSalesTitle = salesSignals.some((rawSignal) => {
-        const workEntries = Array.isArray(rawSignal.matchedWorkEntries)
-            ? rawSignal.matchedWorkEntries.filter((rawEntry): rawEntry is Record<string, unknown> => isRecord(rawEntry))
-            : [];
-        return workEntries.some((rawEntry) => rawEntry.directRoleMatch === true);
-    });
-    if (hasDirectSalesTitle) {
-        return undefined;
-    }
-
-    // No direct sales job title — sales signal came from descriptions only — cap at 0
-    return 0;
-}
-
 
 export function normalizeAnalysisResult(
     result: {
@@ -559,10 +239,6 @@ export function normalizeAnalysisResult(
         breakdown?: unknown;
     },
     resume: unknown,
-    options?: {
-        targetRoleType?: "sales";
-        keywords?: string[];
-    },
 ): {
     score: number;
     recommendation: AnalysisRecommendation;
@@ -572,34 +248,17 @@ export function normalizeAnalysisResult(
     breakdown: Record<string, number>;
 } {
     const breakdown = parseNumericBreakdown(result.breakdown);
-    let relatedExpRaw = clamp(toNumber(breakdown?.related_exp) ?? 0, 0, 100);
-    if (options?.targetRoleType === "sales") {
-        const floor = inferSalesRelatedExpFloor(resume);
-        if (floor !== undefined) {
-            relatedExpRaw = Math.max(relatedExpRaw, floor);
-        }
-        // Keyword-dependent floor/ceiling (order-safe with noDirectSalesCap below:
-        // min is commutative, so the order of floor/ceiling/cap application
-        // doesn't affect the final result)
-        if (Array.isArray(options.keywords) && options.keywords.length > 0) {
-            const unverifiedFloor = inferUnverifiedDomainRelevantSalesFloor(resume, options.keywords);
-            if (unverifiedFloor !== undefined) {
-                relatedExpRaw = Math.max(relatedExpRaw, unverifiedFloor);
-            }
-            const ceiling = inferDomainIrrelevantSalesCeiling(resume, options.keywords);
-            if (ceiling !== undefined) {
-                relatedExpRaw = Math.min(relatedExpRaw, ceiling);
-            }
-        }
-        // No-direct-sales-role cap: zeros out description-only sales signals
-        const noDirectSalesCap = inferNoDirectSalesRoleCap(resume, floor);
-        if (noDirectSalesCap !== undefined) {
-            relatedExpRaw = Math.min(relatedExpRaw, noDirectSalesCap);
-        }
-    }
-    const relatedExpWeightedContribution = Math.round(relatedExpRaw * RELATED_EXP_WEIGHT);
+    const llmRelatedExp = toNumber(breakdown?.related_exp);
     const industryDb = computeDirectIndustryDbScoreFromResume(resume);
-    const score = clamp(relatedExpWeightedContribution + industryDb, 0, 100);
+
+    if (llmRelatedExp === undefined) {
+        console.warn("LLM related_exp invalid, falling back to related_exp=0");
+    }
+
+    // LLM-primary: trust LLM's related_exp, combine with rule-based industry_db
+    const relatedExpRaw = clamp(llmRelatedExp ?? 0, 0, 100);
+    const score = clamp(Math.round(relatedExpRaw * RELATED_EXP_WEIGHT) + industryDb, 0, 100);
+
     const recommendation = recommendationFromScore(score);
     const rawSummary = typeof result.summary === "string" && result.summary.trim().length > 0
         ? result.summary
@@ -977,14 +636,9 @@ export const analyzeResume = action({
             console.error("LLM Call failed:", e);
             throw new Error("Failed to analyze resume with AI.");
         }
-        const normalizedKeywords = (args.keywords ?? [])
-            .map((k) => k.trim().toLowerCase())
-            .filter((k) => k.length > 0);
-        const targetRoleType = isSalesRequiredContext(...normalizedKeywords) ? "sales" as const : undefined;
         const result = normalizeAnalysisResult(
             isRecord(rawResult) ? rawResult : {},
             resume,
-            normalizedKeywords.length > 0 ? { targetRoleType, keywords: normalizedKeywords } : undefined,
         );
 
         // 4. Update Resume with result


### PR DESCRIPTION
## Summary
- Replaced formula-primary scoring with LLM-primary hybrid in `normalizeAnalysisResult()`
- LLM computes `related_exp` (subjective judgment), rules compute `industry_db` (objective/deterministic)
- Score = `LLM.related_exp * 0.5 + industry_db`
- Removed 4 guardrail functions that overrode LLM judgment (floors/ceilings)
- Net: -450 lines across 3 files

## Problem
Accumulated guardrails caused score-text misalignment: high scores contradicted analysis text saying "partial match" or "unsuitable". Each new guardrail created edge cases requiring more rules — overfitting.

## Changes
- `packages/convex/convex/analyze.ts` — rewrote `normalizeAnalysisResult`, removed guardrail functions
- `packages/convex/convex/analysis_tasks.ts` — removed dead `inferTargetRoleType` and unused imports
- `packages/convex/convex/__tests__/analysis-strict-evidence.test.ts` — updated test call sites

## Test plan
- [ ] `make check-node` passes (0 errors)
- [ ] Verify with production snapshot: candidates #1-4 from `resumes-export-2026-04-29.csv`
- [ ] Monitor formula-vs-LLM delta in production logs after deploy