### PR TITLE
feat(web): add 5-star user rating on resume cards

### DIFF
--- a/apps/api/src/routes/actions.ts
+++ b/apps/api/src/routes/actions.ts
@@ -13,6 +13,7 @@ const ActionTypeSchema = z.enum([
   "archive",
   "note",
   "contact",
+  "rating",
   "ai_score_like",
   "ai_score_unlike",
   "ai_summary_like",

--- a/apps/api/src/services/action-storage.ts
+++ b/apps/api/src/services/action-storage.ts
@@ -9,6 +9,7 @@ export type CandidateActionType =
   | "archive"
   | "note"
   | "contact"
+  | "rating"
   | "ai_score_like"
   | "ai_score_unlike"
   | "ai_summary_like"
@@ -19,7 +20,7 @@ export type CandidateActionType =
  * Primary candidate actions (star/shortlist/reject/archive/note/contact) form one group,
  * while each AI feedback dimension forms its own group so they coexist.
  */
-export type ActionTypeGroup = "primary" | "ai_score" | "ai_summary";
+export type ActionTypeGroup = "primary" | "rating" | "ai_score" | "ai_summary";
 
 const AI_SCORE_TYPES = ["ai_score_like", "ai_score_unlike"] as const;
 const AI_SUMMARY_TYPES = ["ai_summary_like", "ai_summary_unlike"] as const;
@@ -29,6 +30,7 @@ const AI_SUMMARY_TYPE_SET: ReadonlySet<string> = new Set(AI_SUMMARY_TYPES);
 const AI_FEEDBACK_TYPES_SQL = AI_FEEDBACK_TYPES.map((actionType) => `'${actionType}'`).join(", ");
 const ACTION_GROUP_CASE_SQL = `
   CASE
+    WHEN action_type = 'rating' THEN 'rating'
     WHEN action_type IN ('ai_score_like', 'ai_score_unlike') THEN 'ai_score'
     WHEN action_type IN ('ai_summary_like', 'ai_summary_unlike') THEN 'ai_summary'
     ELSE 'primary'
@@ -75,6 +77,7 @@ const WORKSPACE_COALESCE_SQL = `COALESCE(
 const WORKSPACE_MATCH_OR_ORPHAN_SQL = `(${WORKSPACE_COALESCE_SQL} = ? OR ${WORKSPACE_COALESCE_SQL} IS NULL)`;
 
 export function actionTypeGroup(actionType: string): ActionTypeGroup {
+  if (actionType === "rating") return "rating";
   if (AI_SCORE_TYPE_SET.has(actionType)) return "ai_score";
   if (AI_SUMMARY_TYPE_SET.has(actionType)) return "ai_summary";
   return "primary";

--- a/apps/api/src/services/summaries/summary-data-service.ts
+++ b/apps/api/src/services/summaries/summary-data-service.ts
@@ -70,6 +70,7 @@ const ACTION_LABELS: Record<CandidateActionType, string> = {
   archive: "Archive",
   note: "Note",
   contact: "Contact",
+  rating: "Rating",
   ai_score_like: "AI Score Like",
   ai_score_unlike: "AI Score Unlike",
   ai_summary_like: "AI Summary Like",

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { AiFeedbackButtons } from '@/components/AiFeedbackButtons'
+import { StarRating } from '@/components/StarRating'
 import type { ResumeItem } from '@/hooks/useResumes'
 import type { AiFeedbackSentiment, AiFeedbackTarget, CandidateActionType, CandidateStatus, MatchingResult } from '@/types/resume'
 import type { ExperienceLevelFilter } from '@/lib/resume-scoring'
@@ -77,6 +78,8 @@ interface ResumeCardProps {
   isReviewed?: boolean
   aiScoreFeedback?: AiFeedbackSentiment
   onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
+  userRating?: number
+  onRating?: (rating: number) => void
 }
 
 const STATUS_OPTIONS: Array<{ value: CandidateStatus; labelKey: string }> = [
@@ -159,6 +162,8 @@ export function ResumeCard({
   isReviewed,
   aiScoreFeedback,
   onAiFeedback,
+  userRating,
+  onRating,
   industryTags,
   companyHits,
   brandHits,
@@ -547,6 +552,7 @@ export function ResumeCard({
               </TooltipProvider>
             ) : null}
             <div className="ml-auto flex items-center gap-2">
+              <StarRating value={userRating} onChange={onRating} size={14} />
               <div className="flex items-center gap-1">
                 <Button
                   variant={actionType === 'star' ? 'default' : 'ghost'}

--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -12,6 +12,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { AiFeedbackButtons } from '@/components/AiFeedbackButtons'
+import { StarRating } from '@/components/StarRating'
 import type { ResumeItem } from '@/hooks/useResumes'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 import { formatRoleYears, getExperienceBadge, getResumeContentLocale, getResumeSourceLabel, getRoleLabel, hasIngestData, isSafeProfileUrl, summarizeBrandHits } from '@/lib/resume-scoring'
@@ -30,6 +31,8 @@ interface ResumeDetailProps {
   aiScoreFeedback?: AiFeedbackSentiment
   aiSummaryFeedback?: AiFeedbackSentiment
   onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
+  userRating?: number
+  onRating?: (rating: number) => void
 }
 
 function normalizeEvidenceValue(value: string | undefined): string {
@@ -94,6 +97,8 @@ export function ResumeDetail({
   aiScoreFeedback,
   aiSummaryFeedback,
   onAiFeedback,
+  userRating,
+  onRating,
 }: ResumeDetailProps) {
   const { t } = useTranslation()
   const fieldUsagePolicy = useResumeFieldUsagePolicy()
@@ -375,6 +380,7 @@ export function ResumeDetail({
                       onSelect={(sentiment) => onAiFeedback('ai_score', sentiment)}
                     />
                   ) : null}
+                  <StarRating value={userRating} onChange={onRating} size={14} />
                 </h3>
               </div>
               {(matchResult.promptVersion != null || matchResult.locale) && (

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -121,7 +121,9 @@ export function ResumeList() {
     ensureApiSession,
     handleShareSessionCopied,
     handleAiFeedback,
+    handleRating,
     getAiFeedback,
+    ratingsByResume,
   } = useResumeListState(historyRequested)
   useEffect(() => {
     if (!activeLoading) {
@@ -249,6 +251,8 @@ export function ResumeList() {
         showAiScore={entry.match?.scoreSource === 'ai'}
         actionType={entry.action}
         onAction={(action) => handleCardAction(entry.key, action)}
+        userRating={entry.userRating}
+        onRating={(rating) => handleRating(entry.key, rating)}
         blocked={entry.blocked}
         candidateStatus={entry.status}
         candidateStatusMeta={entry.statusMeta ? {
@@ -551,6 +555,8 @@ export function ResumeList() {
             aiScoreFeedback={detailKey ? getAiFeedback(detailKey, 'ai_score') : undefined}
             aiSummaryFeedback={detailKey ? getAiFeedback(detailKey, 'ai_summary') : undefined}
             onAiFeedback={detailKey ? (target, sentiment) => handleAiFeedback(detailKey, target, sentiment) : undefined}
+            userRating={detailKey ? ratingsByResume[detailKey] : undefined}
+            onRating={detailKey ? (rating) => handleRating(detailKey, rating) : undefined}
           />
         </Suspense>
       ) : null}

--- a/apps/web/src/components/StarRating.tsx
+++ b/apps/web/src/components/StarRating.tsx
@@ -1,0 +1,38 @@
+import { Star } from 'lucide-react'
+
+export function StarRating({
+  value,
+  onChange,
+  size = 16,
+}: {
+  value?: number
+  onChange?: (rating: number) => void
+  size?: number
+}) {
+  return (
+    <div className="flex items-center gap-0.5" role="group" aria-label="User rating">
+      {[1, 2, 3, 4, 5].map((star) => {
+        const filled = typeof value === 'number' && star <= value
+        return (
+          <button
+            key={star}
+            type="button"
+            className="p-0 leading-none"
+            onClick={(e) => {
+              e.stopPropagation()
+              onChange?.(value === star ? 0 : star)
+            }}
+            aria-label={`${star} star${star > 1 ? 's' : ''}`}
+          >
+            <Star
+              size={size}
+              className={filled
+                ? 'fill-amber-400 text-amber-400'
+                : 'text-slate-300 hover:text-amber-300'}
+            />
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/components/search/SearchResultsList.tsx
+++ b/apps/web/src/components/search/SearchResultsList.tsx
@@ -27,8 +27,10 @@ type SearchResultsListProps = {
   // Candidate management props
   selectedIds?: Set<string>
   actionsByResume?: Record<string, CandidateActionType>
+  ratingsByResume?: Record<string, number>
   onToggleSelect?: (key: string) => void
   onAction?: (resumeId: string, actionType: CandidateActionType) => void
+  onRating?: (resumeId: string, rating: number) => void
   onCandidateStatusChange?: (identityKey: string, status: CandidateStatus, notes?: string) => void
   onToggleBlock?: (identityKey: string, blocked: boolean, reason?: string) => void
   onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
@@ -63,8 +65,10 @@ export function SearchResultsList({
   onToggleExpanded,
   selectedIds,
   actionsByResume,
+  ratingsByResume,
   onToggleSelect,
   onAction,
+  onRating,
   onCandidateStatusChange,
   onToggleBlock,
 }: SearchResultsListProps) {
@@ -163,6 +167,8 @@ export function SearchResultsList({
     onSelect: onToggleSelect ? () => onToggleSelect(item.key) : undefined,
     actionType: actionsByResume?.[item.resume.resumeId],
     onAction,
+    userRating: ratingsByResume?.[item.resume.resumeId],
+    onRating,
     onCandidateStatusChange,
     onToggleBlock,
   })
@@ -245,6 +251,8 @@ export function SearchResultsList({
               }
             }}
             loading={detailResumeLoading}
+            userRating={ratingsByResume?.[detailItem.resume.resumeId]}
+            onRating={onRating ? (rating) => onRating(detailItem.resume.resumeId, rating) : undefined}
           />
         </Suspense>
       ) : null}

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/tooltip'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import { SnippetCardExpanded } from '@/components/search/SnippetCardExpanded'
+import { StarRating } from '@/components/StarRating'
 import { getResumeContentLocale, getResumeSourceLabel, getExperienceBadge, isSafeProfileUrl, summarizeBrandHits } from '@/lib/resume-scoring'
 import { useBrandDisplayMap } from '@/hooks/useBrandDisplayMap'
 import { cn } from '@/lib/utils'
@@ -37,6 +38,8 @@ type SnippetCardProps = {
   onSelect?: () => void
   actionType?: CandidateActionType
   onAction?: (resumeId: string, actionType: CandidateActionType) => void
+  userRating?: number
+  onRating?: (resumeId: string, rating: number) => void
   onCandidateStatusChange?: (identityKey: string, status: CandidateStatus, notes?: string) => void
   onToggleBlock?: (identityKey: string, blocked: boolean, reason?: string) => void
   aiScoreFeedback?: AiFeedbackSentiment
@@ -84,6 +87,8 @@ export function SnippetCard({
   onSelect,
   actionType,
   onAction,
+  userRating,
+  onRating,
   onCandidateStatusChange,
   onToggleBlock,
 }: SnippetCardProps) {
@@ -308,6 +313,7 @@ export function SnippetCard({
 
             {/* Action buttons - pushed to the right */}
             <div className="ml-auto flex items-center gap-1">
+              <StarRating value={userRating} onChange={onRating ? (rating) => onRating(item.resume.resumeId, rating) : undefined} size={14} />
               {onAction ? (
                 <Button
                   variant={actionType === 'star' ? 'default' : 'ghost'}

--- a/apps/web/src/hooks/useCandidateActions.ts
+++ b/apps/web/src/hooks/useCandidateActions.ts
@@ -24,9 +24,16 @@ function setFeedbackState(
   }
 }
 
+function extractRating(action: CandidateAction): number | undefined {
+  if (action.actionType !== 'rating') return undefined
+  const rating = action.actionData?.rating
+  return typeof rating === 'number' && rating >= 0 && rating <= 5 ? rating : undefined
+}
+
 export function useCandidateActions(sessionId?: string, jobDescriptionId?: string, enabled: boolean = true) {
   const [actionsByResume, setActionsByResume] = useState<Record<string, CandidateActionType>>({})
   const [aiFeedbackByResume, setAiFeedbackByResume] = useState<Record<string, AiFeedbackState>>({})
+  const [ratingsByResume, setRatingsByResume] = useState<Record<string, number>>({})
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -56,8 +63,17 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
 
     const nextActionsByResume: Record<string, CandidateActionType> = {}
     let nextAiFeedbackByResume: Record<string, AiFeedbackState> = {}
+    const nextRatingsByResume: Record<string, number> = {}
 
     ;(data.actions ?? []).forEach((action) => {
+      const rating = extractRating(action)
+      if (rating !== undefined) {
+        if (rating > 0) {
+          nextRatingsByResume[action.resumeId] = rating
+        }
+        return
+      }
+
       const feedback = actionToAiFeedback(action.actionType)
       if (feedback) {
         nextAiFeedbackByResume = setFeedbackState(
@@ -74,6 +90,7 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
 
     setActionsByResume(nextActionsByResume)
     setAiFeedbackByResume(nextAiFeedbackByResume)
+    setRatingsByResume(nextRatingsByResume)
     setLoading(false)
   }, [enabled, jobDescriptionId, sessionId])
 
@@ -93,21 +110,34 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
         },
       })
 
-      if (apiError || !data?.success) {
+      if (apiError || !data?.success || !data.action) {
         setError('Failed to save action')
         return null
       }
 
-      const feedback = actionToAiFeedback(payload.actionType)
-      if (feedback) {
-        setAiFeedbackByResume((prev) =>
-          setFeedbackState(prev, payload.resumeId, feedback.target, feedback.sentiment)
-        )
+      const rating = extractRating(data.action)
+      if (rating !== undefined) {
+        if (rating === 0) {
+          setRatingsByResume((prev) => {
+            const next = { ...prev }
+            delete next[payload.resumeId]
+            return next
+          })
+        } else {
+          setRatingsByResume((prev) => ({ ...prev, [payload.resumeId]: rating }))
+        }
       } else {
-        setActionsByResume((prev) => ({
-          ...prev,
-          [payload.resumeId]: payload.actionType,
-        }))
+        const feedback = actionToAiFeedback(payload.actionType)
+        if (feedback) {
+          setAiFeedbackByResume((prev) =>
+            setFeedbackState(prev, payload.resumeId, feedback.target, feedback.sentiment)
+          )
+        } else {
+          setActionsByResume((prev) => ({
+            ...prev,
+            [payload.resumeId]: payload.actionType,
+          }))
+        }
       }
 
       return data.action ?? null
@@ -139,6 +169,7 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
     if (!enabled || !sessionId) {
       setActionsByResume({})
       setAiFeedbackByResume({})
+      setRatingsByResume({})
     }
   }, [enabled, sessionId])
 
@@ -146,6 +177,7 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
     actions: actionsByResume,
     actionsByResume,
     aiFeedbackByResume,
+    ratingsByResume,
     loading,
     error,
     reload: loadActions,

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -119,6 +119,7 @@ type EnrichedResume = {
   match?: MatchingResult
   ruleScore?: number
   action?: CandidateActionType | undefined
+  userRating?: number
 }
 
 function resolveWorkspaceSlugFromPathname(pathname: string): string {
@@ -343,7 +344,7 @@ export function useResumeListState(loadSearchHistory = false) {
   }, [convexLoading, mode])
 
   const auxiliaryResumeDataEnabled = mode !== 'ai' || hasCompletedInitialConvexLoad
-  const { actions, saveAction, getAiFeedback } = useCandidateActions(
+  const { actions, ratingsByResume, saveAction, getAiFeedback } = useCandidateActions(
     sessionActionScope,
     jobDescriptionId,
     auxiliaryResumeDataEnabled,
@@ -1259,6 +1260,7 @@ export function useResumeListState(loadSearchHistory = false) {
           match,
           ruleScore: resume._ruleScore || 0,
           action: actions[resumeKey],
+          userRating: ratingsByResume[resumeKey],
         }
       })
     }
@@ -1275,10 +1277,12 @@ export function useResumeListState(loadSearchHistory = false) {
         match: undefined,
         ruleScore: 0,
         action: actions[resumeKey],
+        userRating: ratingsByResume[resumeKey],
       }
     })
   }, [
     actions,
+    ratingsByResume,
     blocksByIdentity,
     currentPromptVersion,
     filteredConvexResumes,
@@ -1624,6 +1628,29 @@ export function useResumeListState(loadSearchHistory = false) {
         })
     },
     [jobDescriptionId, saveAction, t]
+  )
+
+  const handleRating = useCallback(
+    (resumeId: string, rating: number) => {
+      void saveAction({
+        resumeId,
+        actionType: 'rating',
+        actionData: { rating },
+      })
+        .then((result) => {
+          if (result) {
+            toast.success(rating === 0 ? '评分已清除' : `评分已保存: ${rating}星`)
+            return
+          }
+
+          toast.error('Failed to save rating')
+        })
+        .catch((error: unknown) => {
+          console.error('Rating save failed', error)
+          toast.error('Failed to save rating')
+        })
+    },
+    [saveAction]
   )
 
   const handleToggleBlock = useCallback(
@@ -2026,7 +2053,9 @@ export function useResumeListState(loadSearchHistory = false) {
     handleOpenReviewPacket,
     handleCardAction,
     handleAiFeedback,
+    handleRating,
     getAiFeedback,
+    ratingsByResume,
     handleToggleBlock,
     handleCandidateStatusChange,
     handleResetAll,

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -661,7 +661,7 @@ export function useResumeSearchState() {
   })
   const { statusByIdentity, updateStatus: updateCandidateStatus } = useCandidateStatus(true)
   const { blocksByIdentity, blockCandidates, unblockCandidate } = useCandidateBlocks(true)
-  const { actions: actionsByResume, saveAction, getAiFeedback } = useCandidateActions(sessionKey, parsedState.jobDescriptionId)
+  const { actions: actionsByResume, ratingsByResume, saveAction, getAiFeedback } = useCandidateActions(sessionKey, parsedState.jobDescriptionId)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const apiBaseUrl = useMemo(() => {
     const rawBaseUrl = import.meta.env.VITE_API_URL || '/api'
@@ -1634,6 +1634,13 @@ export function useResumeSearchState() {
     [saveAction],
   )
 
+  const handleRating = useCallback(
+    async (resumeId: string, rating: number) => {
+      await saveAction({ resumeId, actionType: 'rating', actionData: { rating } })
+    },
+    [saveAction],
+  )
+
   const handleCandidateStatusChange = useCallback(
     async (identityKey: string, status: CandidateStatus, notes?: string) => {
       await updateCandidateStatus(identityKey, status, notes)
@@ -1734,9 +1741,11 @@ export function useResumeSearchState() {
     loadMore,
     // Candidate management
     actionsByResume,
+    ratingsByResume,
     getAiFeedback,
     handleBulkAction,
     handleCandidateAction,
+    handleRating,
     handleCandidateStatusChange,
     handleToggleBlock,
     highScoreCount,

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -3453,7 +3453,7 @@ export interface paths {
                                 sessionId?: string;
                                 resumeId: string;
                                 /** @enum {string} */
-                                actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
+                                actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "rating" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
                                 actionData?: {
                                     [key: string]: unknown;
                                 };
@@ -3480,7 +3480,7 @@ export interface paths {
                         sessionId?: string;
                         resumeId: string;
                         /** @enum {string} */
-                        actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
+                        actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "rating" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
                         actionData?: {
                             [key: string]: unknown;
                         };
@@ -3503,7 +3503,7 @@ export interface paths {
                                 sessionId?: string;
                                 resumeId: string;
                                 /** @enum {string} */
-                                actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
+                                actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "rating" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
                                 actionData?: {
                                     [key: string]: unknown;
                                 };

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -72,8 +72,10 @@ export function ResumeSearchPage() {
     toggleTag,
     // Candidate management
     actionsByResume,
+    ratingsByResume,
     handleBulkAction,
     handleCandidateAction,
+    handleRating,
     handleCandidateStatusChange,
     handleToggleBlock,
     highScoreCount,
@@ -402,8 +404,10 @@ export function ResumeSearchPage() {
                 onToggleExpanded={handleToggleExpanded}
                 selectedIds={selectedIds}
                 actionsByResume={actionsByResume}
+                ratingsByResume={ratingsByResume}
                 onToggleSelect={toggleSelectItem}
                 onAction={handleCandidateAction}
+                onRating={handleRating}
                 onCandidateStatusChange={handleCandidateStatusChange}
                 onToggleBlock={handleToggleBlock}
               />

--- a/apps/web/src/types/resume.ts
+++ b/apps/web/src/types/resume.ts
@@ -109,6 +109,7 @@ export type CandidateActionType =
   | 'archive'
   | 'note'
   | 'contact'
+  | 'rating'
   | 'ai_score_like'
   | 'ai_score_unlike'
   | 'ai_summary_like'


### PR DESCRIPTION
## Summary
- Add clickable 5-star rating component (`StarRating`) to resume cards in both list and search views
- Ratings persist via `candidate_actions` table as a new `'rating'` action group, coexisting independently with star/shortlist/reject and AI feedback
- Click a star to rate (1-5), click the same star again to clear (0)

## Changes

**API layer:**
- `action-storage.ts` — new `'rating'` action type and `'rating'` action group in `ACTION_GROUP_CASE_SQL`
- `routes/actions.ts` — added `'rating'` to `ActionTypeSchema` Zod enum
- `summary-data-service.ts` — added `'rating'` to `ACTION_LABELS`
- `api-types.ts` — regenerated with `'rating'` in action type enum

**Web layer:**
- `StarRating.tsx` — new 5-star clickable component with aria labels
- `useCandidateActions.ts` — `ratingsByResume` state, `extractRating` helper (handles 0=clear)
- `useResumeListState.ts` — `handleRating` callback with toast feedback, `userRating` in entry mapping
- `useResumeSearchState.ts` — `handleRating` callback, `ratingsByResume` exposed
- `ResumeCard.tsx` — renders `StarRating` in action bar
- `ResumeDetail.tsx` — renders `StarRating` in score header
- `SnippetCard.tsx` — renders `StarRating` in action bar
- `SearchResultsList.tsx` — passes rating props to cards and detail view
- `ResumeList.tsx` — passes rating props to cards and detail view
- `ResumeSearchPage.tsx` — wires `ratingsByResume` and `handleRating` to `SearchResultsList`

## Test plan
- [ ] Click stars on a resume card in list view → rating persists after page reload
- [ ] Click same star again → rating clears (no stars filled)
- [ ] Rating works in both list view and search view
- [ ] Rating persists across session reloads
- [ ] `make check` passes