### PR TITLE
feat(api): monthly new candidates digest summary

### DIFF
--- a/apps/api/src/routes/actions.ts
+++ b/apps/api/src/routes/actions.ts
@@ -13,6 +13,7 @@ const ActionTypeSchema = z.enum([
   "archive",
   "note",
   "contact",
+  "rating",
   "ai_score_like",
   "ai_score_unlike",
   "ai_summary_like",

--- a/apps/api/src/routes/summaries.ts
+++ b/apps/api/src/routes/summaries.ts
@@ -24,7 +24,7 @@ const summaryDataService = new SummaryDataService();
 const summaryRenderer = new SummaryRenderer();
 const workspaceSummaryRunStorage = new WorkspaceSummaryRunStorage();
 const KNOWN_WORKSPACE_SLUGS = Object.keys(WORKSPACE_TEAMS).filter(isValidWorkspace);
-const SummaryPeriodSchema = z.enum(["daily", "weekly"]);
+const SummaryPeriodSchema = z.enum(["daily", "weekly", "monthly"]);
 const WorkspaceSlugSchema = z.string().min(1);
 
 const SummaryCountEntrySchema = z.object({
@@ -894,14 +894,14 @@ app.openapi(runRoute, async (c) => {
       endAt: body.endAt,
     });
     preview = summaryDispatcher.buildPreview(report, {
-      templateId: body.templateId,
+      templateId,
     });
     triggerSource = body.triggerSource ?? "api_manual";
     const runId = randomUUID();
     const dispatched = await summaryDispatcher.dispatch(report, {
       channel: body.channel,
       dryRun: body.dryRun,
-      templateId: body.templateId,
+      templateId,
       to: body.to,
       subject: body.subject,
       webhookUrl: body.webhookUrl,

--- a/apps/api/src/services/action-storage.ts
+++ b/apps/api/src/services/action-storage.ts
@@ -9,6 +9,7 @@ export type CandidateActionType =
   | "archive"
   | "note"
   | "contact"
+  | "rating"
   | "ai_score_like"
   | "ai_score_unlike"
   | "ai_summary_like"
@@ -19,7 +20,7 @@ export type CandidateActionType =
  * Primary candidate actions (star/shortlist/reject/archive/note/contact) form one group,
  * while each AI feedback dimension forms its own group so they coexist.
  */
-export type ActionTypeGroup = "primary" | "ai_score" | "ai_summary";
+export type ActionTypeGroup = "primary" | "rating" | "ai_score" | "ai_summary";
 
 const AI_SCORE_TYPES = ["ai_score_like", "ai_score_unlike"] as const;
 const AI_SUMMARY_TYPES = ["ai_summary_like", "ai_summary_unlike"] as const;
@@ -29,6 +30,7 @@ const AI_SUMMARY_TYPE_SET: ReadonlySet<string> = new Set(AI_SUMMARY_TYPES);
 const AI_FEEDBACK_TYPES_SQL = AI_FEEDBACK_TYPES.map((actionType) => `'${actionType}'`).join(", ");
 const ACTION_GROUP_CASE_SQL = `
   CASE
+    WHEN action_type = 'rating' THEN 'rating'
     WHEN action_type IN ('ai_score_like', 'ai_score_unlike') THEN 'ai_score'
     WHEN action_type IN ('ai_summary_like', 'ai_summary_unlike') THEN 'ai_summary'
     ELSE 'primary'
@@ -75,6 +77,7 @@ const WORKSPACE_COALESCE_SQL = `COALESCE(
 const WORKSPACE_MATCH_OR_ORPHAN_SQL = `(${WORKSPACE_COALESCE_SQL} = ? OR ${WORKSPACE_COALESCE_SQL} IS NULL)`;
 
 export function actionTypeGroup(actionType: string): ActionTypeGroup {
+  if (actionType === "rating") return "rating";
   if (AI_SCORE_TYPE_SET.has(actionType)) return "ai_score";
   if (AI_SUMMARY_TYPE_SET.has(actionType)) return "ai_summary";
   return "primary";

--- a/apps/api/src/services/summaries/summary-data-service.ts
+++ b/apps/api/src/services/summaries/summary-data-service.ts
@@ -1,6 +1,7 @@
 import type {
   SummaryComparison,
   SummaryCountEntry,
+  SummaryNewCandidate,
   SummaryPeriod,
   SummaryReport,
   SummaryScopes,
@@ -177,6 +178,25 @@ function buildWindow(params: {
     const currentStart = new Date(currentEnd.getTime() - DAY_MS);
     const previousEnd = currentStart;
     const previousStart = new Date(previousEnd.getTime() - DAY_MS);
+    return {
+      current: buildWindowRange(currentStart, currentEnd, params.timezone),
+      previous: buildWindowRange(previousStart, previousEnd, params.timezone),
+    };
+  }
+
+  if (params.period === "monthly") {
+    const localAnchor = getLocalDatePartsInTimezone(anchorDate, params.timezone);
+    const currentMonthStart = { year: localAnchor.year, month: localAnchor.month, day: 1 };
+    const nextMonth = localAnchor.month === 12
+      ? { year: localAnchor.year + 1, month: 1, day: 1 }
+      : { year: localAnchor.year, month: localAnchor.month + 1, day: 1 };
+    const previousMonth = localAnchor.month === 1
+      ? { year: localAnchor.year - 1, month: 12, day: 1 }
+      : { year: localAnchor.year, month: localAnchor.month - 1, day: 1 };
+    const currentStart = resolveLocalMidnightUtc(currentMonthStart, params.timezone);
+    const currentEnd = resolveLocalMidnightUtc(nextMonth, params.timezone);
+    const previousStart = resolveLocalMidnightUtc(previousMonth, params.timezone);
+    const previousEnd = currentStart;
     return {
       current: buildWindowRange(currentStart, currentEnd, params.timezone),
       previous: buildWindowRange(previousStart, previousEnd, params.timezone),
@@ -377,12 +397,15 @@ export class SummaryDataService {
       timezone: config.timezone,
     });
 
-    const [currentMetrics, previousMetrics] = await Promise.all([
+    const [currentMetrics, previousMetrics, newCandidates] = await Promise.all([
       this.buildWindowMetrics(params.workspaceSlug, windows.current),
       this.buildWindowMetrics(params.workspaceSlug, windows.previous),
+      params.period === "monthly"
+        ? this.loadNewCandidates(windows.current.fromTimestamp, windows.current.toTimestamp)
+        : Promise.resolve(undefined),
     ]);
 
-    return {
+    const report: SummaryReport = {
       workspaceSlug: params.workspaceSlug,
       period: params.period,
       generatedAt: formatIsoOffsetInTimezone(this.now(), config.timezone),
@@ -400,6 +423,15 @@ export class SummaryDataService {
         "Workspace activity totals cover candidate-status updates and persisted workspace-linked actions only.",
       ],
     };
+
+    if (newCandidates) {
+      report.newCandidates = newCandidates;
+      report.notes.push(
+        `Monthly digest includes ${newCandidates.length} new candidates from the window.`,
+      );
+    }
+
+    return report;
   }
 
   private async buildWindowMetrics(
@@ -522,5 +554,43 @@ export class SummaryDataService {
         count: entry.count,
       })),
     };
+  }
+
+  private async loadNewCandidates(
+    fromTimestamp: number,
+    toTimestamp: number,
+  ): Promise<SummaryNewCandidate[]> {
+    const value = await this.queryConvex("resumes:listNewForWindow", {
+      fromTimestamp,
+      toTimestamp,
+      limit: 200,
+    });
+
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    const candidates: SummaryNewCandidate[] = [];
+    for (const item of value) {
+      if (!isRecord(item)) continue;
+      const resumeId = readString(item.resumeId);
+      const source = readString(item.source);
+      const crawledAt = readNumber(item.crawledAt);
+      if (!resumeId || !source || !crawledAt) continue;
+
+      candidates.push({
+        resumeId,
+        name: readString(item.name) || undefined,
+        source,
+        location: readString(item.location) || undefined,
+        experience: readString(item.experience) || undefined,
+        education: readString(item.education) || undefined,
+        score: readNumber(item.score) || undefined,
+        recommendation: readString(item.recommendation) || undefined,
+        crawledAt: formatIsoOffsetInTimezone(new Date(crawledAt), config.timezone),
+      });
+    }
+
+    return candidates;
   }
 }

--- a/apps/api/src/services/summaries/summary-data-service.ts
+++ b/apps/api/src/services/summaries/summary-data-service.ts
@@ -70,6 +70,7 @@ const ACTION_LABELS: Record<CandidateActionType, string> = {
   archive: "Archive",
   note: "Note",
   contact: "Contact",
+  rating: "Rating",
   ai_score_like: "AI Score Like",
   ai_score_unlike: "AI Score Unlike",
   ai_summary_like: "AI Summary Like",

--- a/apps/api/src/services/summaries/summary-dispatcher.ts
+++ b/apps/api/src/services/summaries/summary-dispatcher.ts
@@ -2,6 +2,7 @@ import type { SummaryChannel, SummaryReport } from "@trends/shared";
 
 import { notificationService } from "../notification-service.js";
 import { notificationTemplateService } from "../notification-template-service.js";
+import { getDefaultTemplateId, getSummaryTitle } from "./summary-shared.js";
 import { summaryTelegramBridge } from "./summary-telegram-bridge.js";
 
 type SummaryDispatcherDependencies = {
@@ -33,12 +34,6 @@ export type SummaryDispatchResult = SummaryDispatchPreview & {
   delivery?: Record<string, unknown>;
 };
 
-const DEFAULT_TEMPLATE_ID = "summary-daily";
-
-function getSummaryTitle(report: Pick<SummaryReport, "period">): string {
-  return report.period === "weekly" ? "Weekly Ops Summary" : "Daily Ops Summary";
-}
-
 function escapeHtml(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -63,7 +58,7 @@ function buildTemplateData(report: SummaryReport): Record<string, unknown> {
   return {
     ...report,
     timestamp: report.generatedAt,
-    summaryTitle: getSummaryTitle(report),
+    summaryTitle: getSummaryTitle(report.period),
   };
 }
 
@@ -79,7 +74,7 @@ export class SummaryDispatcher {
   }
 
   buildPreview(report: SummaryReport, request: Pick<SummaryDispatchRequest, "templateId">): SummaryDispatchPreview {
-    const templateId = request.templateId?.trim() || DEFAULT_TEMPLATE_ID;
+    const templateId = request.templateId?.trim() || getDefaultTemplateId(report.period);
     const rendered = this.templates.render(templateId, buildTemplateData(report));
 
     return {
@@ -106,7 +101,7 @@ export class SummaryDispatcher {
         throw new Error("Email recipient is required");
       }
 
-      const subject = request.subject?.trim() || preview.subject || `${getSummaryTitle(report)} (${report.workspaceSlug})`;
+      const subject = request.subject?.trim() || preview.subject || `${getSummaryTitle(report.period)} (${report.workspaceSlug})`;
       const delivery = await this.notifications.sendEmail({
         to: request.to,
         subject,

--- a/apps/api/src/services/summaries/summary-renderer.ts
+++ b/apps/api/src/services/summaries/summary-renderer.ts
@@ -1,4 +1,6 @@
-import type { SummaryCountEntry, SummaryPeriod, SummaryReport } from "@trends/shared";
+import type { SummaryCountEntry, SummaryNewCandidate, SummaryReport } from "@trends/shared";
+
+import { getSummaryTitle } from "./summary-shared.js";
 
 function renderCountList(entries: SummaryCountEntry[]): string[] {
   if (entries.length === 0) {
@@ -8,12 +10,23 @@ function renderCountList(entries: SummaryCountEntry[]): string[] {
   return entries.map((entry) => `- ${entry.label}: ${entry.count}`);
 }
 
-function getSummaryTitle(period: SummaryPeriod): string {
-  return period === "weekly" ? "Weekly Ops Summary" : "Daily Ops Summary";
-}
-
 function formatDelta(value: number): string {
   return value > 0 ? `+${value}` : String(value);
+}
+
+function renderCandidateList(candidates: SummaryNewCandidate[]): string[] {
+  if (candidates.length === 0) {
+    return ["- No new candidates in this period"];
+  }
+  const lines: string[] = [];
+  for (const c of candidates) {
+    const parts = [c.name || c.resumeId, c.source];
+    if (c.location) parts.push(c.location);
+    if (c.experience) parts.push(`${c.experience}yr`);
+    if (typeof c.score === "number") parts.push(`score:${c.score}`);
+    lines.push(`- ${parts.join(" | ")}`);
+  }
+  return lines;
 }
 
 export class SummaryRenderer {
@@ -65,6 +78,13 @@ export class SummaryRenderer {
           `- Workspace activity shortlist delta: ${formatDelta(comparison.totalsDelta.workspaceActivity.shortlistActions)}`,
           `- Workspace activity reject delta: ${formatDelta(comparison.totalsDelta.workspaceActivity.rejectActions)}`,
           `- Workspace activity contact delta: ${formatDelta(comparison.totalsDelta.workspaceActivity.contactActions)}`,
+          ``,
+        ]
+        : []),
+      ...(report.newCandidates
+        ? [
+          `## New Candidates (${report.newCandidates.length})`,
+          ...renderCandidateList(report.newCandidates),
           ``,
         ]
         : []),

--- a/apps/api/src/services/summaries/summary-shared.ts
+++ b/apps/api/src/services/summaries/summary-shared.ts
@@ -1,0 +1,17 @@
+import type { SummaryPeriod, SummaryReport } from "@trends/shared";
+
+export const PERIOD_TEMPLATES: Record<SummaryPeriod, string> = {
+  daily: "summary-daily",
+  weekly: "summary-daily",
+  monthly: "summary-monthly",
+};
+
+export function getSummaryTitle(period: SummaryPeriod): string {
+  if (period === "weekly") return "Weekly Ops Summary";
+  if (period === "monthly") return "Monthly New Candidates Digest";
+  return "Daily Ops Summary";
+}
+
+export function getDefaultTemplateId(period: SummaryPeriod): string {
+  return PERIOD_TEMPLATES[period] ?? "summary-daily";
+}

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { AiFeedbackButtons } from '@/components/AiFeedbackButtons'
+import { StarRating } from '@/components/StarRating'
 import type { ResumeItem } from '@/hooks/useResumes'
 import type { AiFeedbackSentiment, AiFeedbackTarget, CandidateActionType, CandidateStatus, MatchingResult } from '@/types/resume'
 import type { ExperienceLevelFilter } from '@/lib/resume-scoring'
@@ -77,6 +78,8 @@ interface ResumeCardProps {
   isReviewed?: boolean
   aiScoreFeedback?: AiFeedbackSentiment
   onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
+  userRating?: number
+  onRating?: (rating: number) => void
 }
 
 const STATUS_OPTIONS: Array<{ value: CandidateStatus; labelKey: string }> = [
@@ -159,6 +162,8 @@ export function ResumeCard({
   isReviewed,
   aiScoreFeedback,
   onAiFeedback,
+  userRating,
+  onRating,
   industryTags,
   companyHits,
   brandHits,
@@ -547,6 +552,7 @@ export function ResumeCard({
               </TooltipProvider>
             ) : null}
             <div className="ml-auto flex items-center gap-2">
+              <StarRating value={userRating} onChange={onRating} size={14} />
               <div className="flex items-center gap-1">
                 <Button
                   variant={actionType === 'star' ? 'default' : 'ghost'}

--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -12,6 +12,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { AiFeedbackButtons } from '@/components/AiFeedbackButtons'
+import { StarRating } from '@/components/StarRating'
 import type { ResumeItem } from '@/hooks/useResumes'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
 import { formatRoleYears, getExperienceBadge, getResumeContentLocale, getResumeSourceLabel, getRoleLabel, hasIngestData, isSafeProfileUrl, summarizeBrandHits } from '@/lib/resume-scoring'
@@ -30,6 +31,8 @@ interface ResumeDetailProps {
   aiScoreFeedback?: AiFeedbackSentiment
   aiSummaryFeedback?: AiFeedbackSentiment
   onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
+  userRating?: number
+  onRating?: (rating: number) => void
 }
 
 function normalizeEvidenceValue(value: string | undefined): string {
@@ -94,6 +97,8 @@ export function ResumeDetail({
   aiScoreFeedback,
   aiSummaryFeedback,
   onAiFeedback,
+  userRating,
+  onRating,
 }: ResumeDetailProps) {
   const { t } = useTranslation()
   const fieldUsagePolicy = useResumeFieldUsagePolicy()
@@ -375,6 +380,7 @@ export function ResumeDetail({
                       onSelect={(sentiment) => onAiFeedback('ai_score', sentiment)}
                     />
                   ) : null}
+                  <StarRating value={userRating} onChange={onRating} size={14} />
                 </h3>
               </div>
               {(matchResult.promptVersion != null || matchResult.locale) && (

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -121,7 +121,9 @@ export function ResumeList() {
     ensureApiSession,
     handleShareSessionCopied,
     handleAiFeedback,
+    handleRating,
     getAiFeedback,
+    ratingsByResume,
   } = useResumeListState(historyRequested)
   useEffect(() => {
     if (!activeLoading) {
@@ -249,6 +251,8 @@ export function ResumeList() {
         showAiScore={entry.match?.scoreSource === 'ai'}
         actionType={entry.action}
         onAction={(action) => handleCardAction(entry.key, action)}
+        userRating={entry.userRating}
+        onRating={(rating) => handleRating(entry.key, rating)}
         blocked={entry.blocked}
         candidateStatus={entry.status}
         candidateStatusMeta={entry.statusMeta ? {
@@ -551,6 +555,8 @@ export function ResumeList() {
             aiScoreFeedback={detailKey ? getAiFeedback(detailKey, 'ai_score') : undefined}
             aiSummaryFeedback={detailKey ? getAiFeedback(detailKey, 'ai_summary') : undefined}
             onAiFeedback={detailKey ? (target, sentiment) => handleAiFeedback(detailKey, target, sentiment) : undefined}
+            userRating={detailKey ? ratingsByResume[detailKey] : undefined}
+            onRating={detailKey ? (rating) => handleRating(detailKey, rating) : undefined}
           />
         </Suspense>
       ) : null}

--- a/apps/web/src/components/StarRating.tsx
+++ b/apps/web/src/components/StarRating.tsx
@@ -1,0 +1,38 @@
+import { Star } from 'lucide-react'
+
+export function StarRating({
+  value,
+  onChange,
+  size = 16,
+}: {
+  value?: number
+  onChange?: (rating: number) => void
+  size?: number
+}) {
+  return (
+    <div className="flex items-center gap-0.5" role="group" aria-label="User rating">
+      {[1, 2, 3, 4, 5].map((star) => {
+        const filled = typeof value === 'number' && star <= value
+        return (
+          <button
+            key={star}
+            type="button"
+            className="p-0 leading-none"
+            onClick={(e) => {
+              e.stopPropagation()
+              onChange?.(value === star ? 0 : star)
+            }}
+            aria-label={`${star} star${star > 1 ? 's' : ''}`}
+          >
+            <Star
+              size={size}
+              className={filled
+                ? 'fill-amber-400 text-amber-400'
+                : 'text-slate-300 hover:text-amber-300'}
+            />
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/components/search/SearchResultsList.tsx
+++ b/apps/web/src/components/search/SearchResultsList.tsx
@@ -27,8 +27,10 @@ type SearchResultsListProps = {
   // Candidate management props
   selectedIds?: Set<string>
   actionsByResume?: Record<string, CandidateActionType>
+  ratingsByResume?: Record<string, number>
   onToggleSelect?: (key: string) => void
   onAction?: (resumeId: string, actionType: CandidateActionType) => void
+  onRating?: (resumeId: string, rating: number) => void
   onCandidateStatusChange?: (identityKey: string, status: CandidateStatus, notes?: string) => void
   onToggleBlock?: (identityKey: string, blocked: boolean, reason?: string) => void
   onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
@@ -63,8 +65,10 @@ export function SearchResultsList({
   onToggleExpanded,
   selectedIds,
   actionsByResume,
+  ratingsByResume,
   onToggleSelect,
   onAction,
+  onRating,
   onCandidateStatusChange,
   onToggleBlock,
 }: SearchResultsListProps) {
@@ -163,6 +167,8 @@ export function SearchResultsList({
     onSelect: onToggleSelect ? () => onToggleSelect(item.key) : undefined,
     actionType: actionsByResume?.[item.resume.resumeId],
     onAction,
+    userRating: ratingsByResume?.[item.resume.resumeId],
+    onRating,
     onCandidateStatusChange,
     onToggleBlock,
   })
@@ -245,6 +251,8 @@ export function SearchResultsList({
               }
             }}
             loading={detailResumeLoading}
+            userRating={ratingsByResume?.[detailItem.resume.resumeId]}
+            onRating={onRating ? (rating) => onRating(detailItem.resume.resumeId, rating) : undefined}
           />
         </Suspense>
       ) : null}

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/tooltip'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import { SnippetCardExpanded } from '@/components/search/SnippetCardExpanded'
+import { StarRating } from '@/components/StarRating'
 import { getResumeContentLocale, getResumeSourceLabel, getExperienceBadge, isSafeProfileUrl, summarizeBrandHits } from '@/lib/resume-scoring'
 import { useBrandDisplayMap } from '@/hooks/useBrandDisplayMap'
 import { cn } from '@/lib/utils'
@@ -37,6 +38,8 @@ type SnippetCardProps = {
   onSelect?: () => void
   actionType?: CandidateActionType
   onAction?: (resumeId: string, actionType: CandidateActionType) => void
+  userRating?: number
+  onRating?: (resumeId: string, rating: number) => void
   onCandidateStatusChange?: (identityKey: string, status: CandidateStatus, notes?: string) => void
   onToggleBlock?: (identityKey: string, blocked: boolean, reason?: string) => void
   aiScoreFeedback?: AiFeedbackSentiment
@@ -84,6 +87,8 @@ export function SnippetCard({
   onSelect,
   actionType,
   onAction,
+  userRating,
+  onRating,
   onCandidateStatusChange,
   onToggleBlock,
 }: SnippetCardProps) {
@@ -308,6 +313,7 @@ export function SnippetCard({
 
             {/* Action buttons - pushed to the right */}
             <div className="ml-auto flex items-center gap-1">
+              <StarRating value={userRating} onChange={onRating ? (rating) => onRating(item.resume.resumeId, rating) : undefined} size={14} />
               {onAction ? (
                 <Button
                   variant={actionType === 'star' ? 'default' : 'ghost'}

--- a/apps/web/src/hooks/useCandidateActions.ts
+++ b/apps/web/src/hooks/useCandidateActions.ts
@@ -24,9 +24,16 @@ function setFeedbackState(
   }
 }
 
+function extractRating(action: CandidateAction): number | undefined {
+  if (action.actionType !== 'rating') return undefined
+  const rating = action.actionData?.rating
+  return typeof rating === 'number' && rating >= 0 && rating <= 5 ? rating : undefined
+}
+
 export function useCandidateActions(sessionId?: string, jobDescriptionId?: string, enabled: boolean = true) {
   const [actionsByResume, setActionsByResume] = useState<Record<string, CandidateActionType>>({})
   const [aiFeedbackByResume, setAiFeedbackByResume] = useState<Record<string, AiFeedbackState>>({})
+  const [ratingsByResume, setRatingsByResume] = useState<Record<string, number>>({})
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -56,8 +63,17 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
 
     const nextActionsByResume: Record<string, CandidateActionType> = {}
     let nextAiFeedbackByResume: Record<string, AiFeedbackState> = {}
+    const nextRatingsByResume: Record<string, number> = {}
 
     ;(data.actions ?? []).forEach((action) => {
+      const rating = extractRating(action)
+      if (rating !== undefined) {
+        if (rating > 0) {
+          nextRatingsByResume[action.resumeId] = rating
+        }
+        return
+      }
+
       const feedback = actionToAiFeedback(action.actionType)
       if (feedback) {
         nextAiFeedbackByResume = setFeedbackState(
@@ -74,6 +90,7 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
 
     setActionsByResume(nextActionsByResume)
     setAiFeedbackByResume(nextAiFeedbackByResume)
+    setRatingsByResume(nextRatingsByResume)
     setLoading(false)
   }, [enabled, jobDescriptionId, sessionId])
 
@@ -93,21 +110,34 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
         },
       })
 
-      if (apiError || !data?.success) {
+      if (apiError || !data?.success || !data.action) {
         setError('Failed to save action')
         return null
       }
 
-      const feedback = actionToAiFeedback(payload.actionType)
-      if (feedback) {
-        setAiFeedbackByResume((prev) =>
-          setFeedbackState(prev, payload.resumeId, feedback.target, feedback.sentiment)
-        )
+      const rating = extractRating(data.action)
+      if (rating !== undefined) {
+        if (rating === 0) {
+          setRatingsByResume((prev) => {
+            const next = { ...prev }
+            delete next[payload.resumeId]
+            return next
+          })
+        } else {
+          setRatingsByResume((prev) => ({ ...prev, [payload.resumeId]: rating }))
+        }
       } else {
-        setActionsByResume((prev) => ({
-          ...prev,
-          [payload.resumeId]: payload.actionType,
-        }))
+        const feedback = actionToAiFeedback(payload.actionType)
+        if (feedback) {
+          setAiFeedbackByResume((prev) =>
+            setFeedbackState(prev, payload.resumeId, feedback.target, feedback.sentiment)
+          )
+        } else {
+          setActionsByResume((prev) => ({
+            ...prev,
+            [payload.resumeId]: payload.actionType,
+          }))
+        }
       }
 
       return data.action ?? null
@@ -139,6 +169,7 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
     if (!enabled || !sessionId) {
       setActionsByResume({})
       setAiFeedbackByResume({})
+      setRatingsByResume({})
     }
   }, [enabled, sessionId])
 
@@ -146,6 +177,7 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
     actions: actionsByResume,
     actionsByResume,
     aiFeedbackByResume,
+    ratingsByResume,
     loading,
     error,
     reload: loadActions,

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -119,6 +119,7 @@ type EnrichedResume = {
   match?: MatchingResult
   ruleScore?: number
   action?: CandidateActionType | undefined
+  userRating?: number
 }
 
 function resolveWorkspaceSlugFromPathname(pathname: string): string {
@@ -343,7 +344,7 @@ export function useResumeListState(loadSearchHistory = false) {
   }, [convexLoading, mode])
 
   const auxiliaryResumeDataEnabled = mode !== 'ai' || hasCompletedInitialConvexLoad
-  const { actions, saveAction, getAiFeedback } = useCandidateActions(
+  const { actions, ratingsByResume, saveAction, getAiFeedback } = useCandidateActions(
     sessionActionScope,
     jobDescriptionId,
     auxiliaryResumeDataEnabled,
@@ -1259,6 +1260,7 @@ export function useResumeListState(loadSearchHistory = false) {
           match,
           ruleScore: resume._ruleScore || 0,
           action: actions[resumeKey],
+          userRating: ratingsByResume[resumeKey],
         }
       })
     }
@@ -1275,10 +1277,12 @@ export function useResumeListState(loadSearchHistory = false) {
         match: undefined,
         ruleScore: 0,
         action: actions[resumeKey],
+        userRating: ratingsByResume[resumeKey],
       }
     })
   }, [
     actions,
+    ratingsByResume,
     blocksByIdentity,
     currentPromptVersion,
     filteredConvexResumes,
@@ -1624,6 +1628,29 @@ export function useResumeListState(loadSearchHistory = false) {
         })
     },
     [jobDescriptionId, saveAction, t]
+  )
+
+  const handleRating = useCallback(
+    (resumeId: string, rating: number) => {
+      void saveAction({
+        resumeId,
+        actionType: 'rating',
+        actionData: { rating },
+      })
+        .then((result) => {
+          if (result) {
+            toast.success(rating === 0 ? '评分已清除' : `评分已保存: ${rating}星`)
+            return
+          }
+
+          toast.error('Failed to save rating')
+        })
+        .catch((error: unknown) => {
+          console.error('Rating save failed', error)
+          toast.error('Failed to save rating')
+        })
+    },
+    [saveAction]
   )
 
   const handleToggleBlock = useCallback(
@@ -2026,7 +2053,9 @@ export function useResumeListState(loadSearchHistory = false) {
     handleOpenReviewPacket,
     handleCardAction,
     handleAiFeedback,
+    handleRating,
     getAiFeedback,
+    ratingsByResume,
     handleToggleBlock,
     handleCandidateStatusChange,
     handleResetAll,

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -661,7 +661,7 @@ export function useResumeSearchState() {
   })
   const { statusByIdentity, updateStatus: updateCandidateStatus } = useCandidateStatus(true)
   const { blocksByIdentity, blockCandidates, unblockCandidate } = useCandidateBlocks(true)
-  const { actions: actionsByResume, saveAction, getAiFeedback } = useCandidateActions(sessionKey, parsedState.jobDescriptionId)
+  const { actions: actionsByResume, ratingsByResume, saveAction, getAiFeedback } = useCandidateActions(sessionKey, parsedState.jobDescriptionId)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const apiBaseUrl = useMemo(() => {
     const rawBaseUrl = import.meta.env.VITE_API_URL || '/api'
@@ -1634,6 +1634,13 @@ export function useResumeSearchState() {
     [saveAction],
   )
 
+  const handleRating = useCallback(
+    async (resumeId: string, rating: number) => {
+      await saveAction({ resumeId, actionType: 'rating', actionData: { rating } })
+    },
+    [saveAction],
+  )
+
   const handleCandidateStatusChange = useCallback(
     async (identityKey: string, status: CandidateStatus, notes?: string) => {
       await updateCandidateStatus(identityKey, status, notes)
@@ -1734,9 +1741,11 @@ export function useResumeSearchState() {
     loadMore,
     // Candidate management
     actionsByResume,
+    ratingsByResume,
     getAiFeedback,
     handleBulkAction,
     handleCandidateAction,
+    handleRating,
     handleCandidateStatusChange,
     handleToggleBlock,
     highScoreCount,

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -5323,7 +5323,7 @@ export interface paths {
                                 };
                                 request: {
                                     /** @enum {string} */
-                                    period: "daily" | "weekly";
+                                    period: "daily" | "weekly" | "monthly";
                                     /** @enum {string} */
                                     channel: "email" | "wechat_work" | "feishu" | "telegram";
                                     dryRun: boolean;
@@ -5371,7 +5371,7 @@ export interface paths {
                         };
                         request: {
                             /** @enum {string} */
-                            period: "daily" | "weekly";
+                            period: "daily" | "weekly" | "monthly";
                             /** @enum {string} */
                             channel: "email" | "wechat_work" | "feishu" | "telegram";
                             dryRun: boolean;
@@ -5402,7 +5402,7 @@ export interface paths {
                                 };
                                 request: {
                                     /** @enum {string} */
-                                    period: "daily" | "weekly";
+                                    period: "daily" | "weekly" | "monthly";
                                     /** @enum {string} */
                                     channel: "email" | "wechat_work" | "feishu" | "telegram";
                                     dryRun: boolean;
@@ -5494,7 +5494,7 @@ export interface paths {
                                 name: string;
                                 cron: string;
                                 /** @enum {string} */
-                                period: "daily" | "weekly";
+                                period: "daily" | "weekly" | "monthly";
                                 /** @enum {string} */
                                 channel: "email" | "wechat_work" | "feishu" | "telegram";
                                 dryRun: boolean;
@@ -5552,7 +5552,7 @@ export interface paths {
                                 };
                                 request: {
                                     /** @enum {string} */
-                                    period: "daily" | "weekly";
+                                    period: "daily" | "weekly" | "monthly";
                                     /** @enum {string} */
                                     channel: "email" | "wechat_work" | "feishu" | "telegram";
                                     dryRun: boolean;
@@ -5614,7 +5614,7 @@ export interface paths {
                         };
                         request: {
                             /** @enum {string} */
-                            period: "daily" | "weekly";
+                            period: "daily" | "weekly" | "monthly";
                             /** @enum {string} */
                             channel: "email" | "wechat_work" | "feishu" | "telegram";
                             dryRun: boolean;
@@ -5645,7 +5645,7 @@ export interface paths {
                                 };
                                 request: {
                                     /** @enum {string} */
-                                    period: "daily" | "weekly";
+                                    period: "daily" | "weekly" | "monthly";
                                     /** @enum {string} */
                                     channel: "email" | "wechat_work" | "feishu" | "telegram";
                                     dryRun: boolean;
@@ -5782,7 +5782,7 @@ export interface paths {
                          * @default daily
                          * @enum {string}
                          */
-                        period?: "daily" | "weekly";
+                        period?: "daily" | "weekly" | "monthly";
                         /** Format: date-time */
                         endAt?: string;
                     };
@@ -5801,7 +5801,7 @@ export interface paths {
                             report: {
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                period: "daily" | "weekly";
+                                period: "daily" | "weekly" | "monthly";
                                 generatedAt: string;
                                 window: {
                                     startAt: string;
@@ -5907,7 +5907,7 @@ export interface paths {
                                 id: string;
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                period: "daily" | "weekly";
+                                period: "daily" | "weekly" | "monthly";
                                 /** @enum {string} */
                                 triggerSource: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
                                 /** @enum {string} */
@@ -5923,7 +5923,7 @@ export interface paths {
                                 report: {
                                     workspaceSlug: string;
                                     /** @enum {string} */
-                                    period: "daily" | "weekly";
+                                    period: "daily" | "weekly" | "monthly";
                                     generatedAt: string;
                                     window: {
                                         startAt: string;
@@ -6102,7 +6102,7 @@ export interface paths {
                          * @default daily
                          * @enum {string}
                          */
-                        period?: "daily" | "weekly";
+                        period?: "daily" | "weekly" | "monthly";
                         /** Format: date-time */
                         endAt?: string;
                         /** @enum {string} */
@@ -6140,7 +6140,7 @@ export interface paths {
                             report: {
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                period: "daily" | "weekly";
+                                period: "daily" | "weekly" | "monthly";
                                 generatedAt: string;
                                 window: {
                                     startAt: string;
@@ -6272,7 +6272,7 @@ export interface paths {
                                 id: string;
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                period: "daily" | "weekly";
+                                period: "daily" | "weekly" | "monthly";
                                 /** @enum {string} */
                                 triggerSource: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
                                 /** @enum {string} */
@@ -6288,7 +6288,7 @@ export interface paths {
                                 report: {
                                     workspaceSlug: string;
                                     /** @enum {string} */
-                                    period: "daily" | "weekly";
+                                    period: "daily" | "weekly" | "monthly";
                                     generatedAt: string;
                                     window: {
                                         startAt: string;
@@ -6474,7 +6474,7 @@ export interface paths {
                                 id: string;
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                period: "daily" | "weekly";
+                                period: "daily" | "weekly" | "monthly";
                                 /** @enum {string} */
                                 triggerSource: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
                                 /** @enum {string} */
@@ -6490,7 +6490,7 @@ export interface paths {
                                 report: {
                                     workspaceSlug: string;
                                     /** @enum {string} */
-                                    period: "daily" | "weekly";
+                                    period: "daily" | "weekly" | "monthly";
                                     generatedAt: string;
                                     window: {
                                         startAt: string;
@@ -6665,7 +6665,7 @@ export interface paths {
                                 id: string;
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                period: "daily" | "weekly";
+                                period: "daily" | "weekly" | "monthly";
                                 /** @enum {string} */
                                 triggerSource: "api_preview" | "api_manual" | "worker_manual" | "worker_schedule";
                                 /** @enum {string} */
@@ -6681,7 +6681,7 @@ export interface paths {
                                 report: {
                                     workspaceSlug: string;
                                     /** @enum {string} */
-                                    period: "daily" | "weekly";
+                                    period: "daily" | "weekly" | "monthly";
                                     generatedAt: string;
                                     window: {
                                         startAt: string;

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -3453,7 +3453,7 @@ export interface paths {
                                 sessionId?: string;
                                 resumeId: string;
                                 /** @enum {string} */
-                                actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
+                                actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "rating" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
                                 actionData?: {
                                     [key: string]: unknown;
                                 };
@@ -3480,7 +3480,7 @@ export interface paths {
                         sessionId?: string;
                         resumeId: string;
                         /** @enum {string} */
-                        actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
+                        actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "rating" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
                         actionData?: {
                             [key: string]: unknown;
                         };
@@ -3503,7 +3503,7 @@ export interface paths {
                                 sessionId?: string;
                                 resumeId: string;
                                 /** @enum {string} */
-                                actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
+                                actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "rating" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
                                 actionData?: {
                                     [key: string]: unknown;
                                 };

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -72,8 +72,10 @@ export function ResumeSearchPage() {
     toggleTag,
     // Candidate management
     actionsByResume,
+    ratingsByResume,
     handleBulkAction,
     handleCandidateAction,
+    handleRating,
     handleCandidateStatusChange,
     handleToggleBlock,
     highScoreCount,
@@ -402,8 +404,10 @@ export function ResumeSearchPage() {
                 onToggleExpanded={handleToggleExpanded}
                 selectedIds={selectedIds}
                 actionsByResume={actionsByResume}
+                ratingsByResume={ratingsByResume}
                 onToggleSelect={toggleSelectItem}
                 onAction={handleCandidateAction}
+                onRating={handleRating}
                 onCandidateStatusChange={handleCandidateStatusChange}
                 onToggleBlock={handleToggleBlock}
               />

--- a/apps/web/src/types/resume.ts
+++ b/apps/web/src/types/resume.ts
@@ -109,6 +109,7 @@ export type CandidateActionType =
   | 'archive'
   | 'note'
   | 'contact'
+  | 'rating'
   | 'ai_score_like'
   | 'ai_score_unlike'
   | 'ai_summary_like'

--- a/apps/worker/tasks.py
+++ b/apps/worker/tasks.py
@@ -22,7 +22,7 @@ from trendradar.utils.time import get_configured_time
 
 logger = logging.getLogger(__name__)
 
-VALID_SUMMARY_PERIODS = {"daily", "weekly"}
+VALID_SUMMARY_PERIODS = {"daily", "weekly", "monthly"}
 VALID_SUMMARY_CHANNELS = {"email", "wechat_work", "feishu", "telegram"}
 
 

--- a/config/notifications/summary-monthly.md
+++ b/config/notifications/summary-monthly.md
@@ -1,0 +1,45 @@
+---
+subject: "{{summaryTitle}} {{workspaceSlug}}"
+---
+
+# {{summaryTitle}}
+
+- Workspace: {{workspaceSlug}}
+- Period: {{period}}
+- Generated: {{generatedAt}}
+- Window: {{window.startAt}} → {{window.endAt}}
+- Timezone: {{window.timezone}}
+
+{{#if scopes.sharedIngest}}
+## Ingest Summary
+- New resumes: {{scopes.sharedIngest.totals.newResumes}}
+{{/if}}
+
+{{#if newCandidates}}
+## New Candidates ({{newCandidates.length}})
+{{#each newCandidates}}
+- **{{this.name}}** | {{this.source}}{{#if this.location}} | {{this.location}}{{/if}}{{#if this.experience}} | {{this.experience}}yr{{/if}}{{#if this.education}} | {{this.education}}{{/if}}{{#if this.score}} | score: {{this.score}}{{/if}}
+{{/each}}
+{{/if}}
+
+{{#if scopes.workspaceActivity}}
+## Workspace Activity
+- Status updates: {{scopes.workspaceActivity.totals.candidateStatusUpdates}}
+- Shortlisted: {{scopes.workspaceActivity.totals.shortlistActions}}
+- Rejected: {{scopes.workspaceActivity.totals.rejectActions}}
+- Contacted: {{scopes.workspaceActivity.totals.contactActions}}
+{{/if}}
+
+{{#if comparison}}
+## Previous Period Comparison
+- New resumes delta: {{comparison.totalsDelta.sharedIngest.newResumes}}
+{{/if}}
+
+{{#if notes}}
+## Notes
+{{#each notes}}
+- {{this}}
+{{/each}}
+{{/if}}
+
+_Generated at {{timestamp}}_

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -1880,6 +1880,42 @@ export const getSummaryWindow = query({
     },
 });
 
+export const listNewForWindow = query({
+    args: {
+        fromTimestamp: v.number(),
+        toTimestamp: v.number(),
+        limit: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const maxResults = Math.min(args.limit ?? 100, 500);
+        const rows = await ctx.db
+            .query("resumes")
+            .withIndex("by_crawledAt", (q) =>
+                q.gte("crawledAt", args.fromTimestamp).lt("crawledAt", args.toTimestamp)
+            )
+            .filter((q) => q.neq(q.field("isArchived"), true))
+            .order("desc")
+            .take(maxResults);
+
+        return rows.map((row) => {
+            const content = isRecord(row.content) ? row.content : {};
+            const analysis = isRecord(row.analysis) ? row.analysis : undefined;
+
+            return {
+                resumeId: String(row._id),
+                name: toOptionalStringValue(content.name),
+                source: toStringValue(row.source) || "unknown",
+                location: toOptionalStringValue(content.location),
+                experience: toOptionalStringValue(content.experience),
+                education: toOptionalStringValue(content.education),
+                score: typeof analysis?.score === "number" ? analysis.score : undefined,
+                recommendation: typeof analysis?.recommendation === "string" ? analysis.recommendation : undefined,
+                crawledAt: row.crawledAt,
+            };
+        });
+    },
+});
+
 export const listWithIngestDataPage = query({
     args: {
         limit: v.optional(v.number()),

--- a/packages/shared/src/summaries.ts
+++ b/packages/shared/src/summaries.ts
@@ -1,4 +1,4 @@
-export type SummaryPeriod = "daily" | "weekly";
+export type SummaryPeriod = "daily" | "weekly" | "monthly";
 
 export type SummaryChannel = "email" | "wechat_work" | "feishu" | "telegram";
 
@@ -59,6 +59,18 @@ export type SummaryScopes = {
   };
 };
 
+export type SummaryNewCandidate = {
+  resumeId: string;
+  name?: string;
+  source: string;
+  location?: string;
+  experience?: string;
+  education?: string;
+  score?: number;
+  recommendation?: string;
+  crawledAt: string;
+};
+
 export type SummaryReport = {
   workspaceSlug: string;
   period: SummaryPeriod;
@@ -74,6 +86,7 @@ export type SummaryReport = {
   };
   scopes?: SummaryScopes;
   notes: string[];
+  newCandidates?: SummaryNewCandidate[];
 };
 
 export type SummaryPreviewRequest = {


### PR DESCRIPTION
## Summary
- Extends summary infrastructure to support a "monthly" period with individual candidate listings
- Adds `listNewForWindow` Convex query that returns resume records (not just counts) for a time window
- Adds `summary-monthly.md` Mustache template showing candidates with name, source, location, experience, education, score
- Auto-selects `summary-monthly` template when period is monthly
- Extracts duplicated `getSummaryTitle` to shared module, fixes month window to use calendar boundaries

## Changes
- `packages/shared/src/summaries.ts` — Add `SummaryNewCandidate` type, extend `SummaryPeriod` to include "monthly"
- `packages/convex/convex/resumes.ts` — Add `listNewForWindow` query using `toOptionalStringValue`
- `apps/api/src/services/summaries/summary-data-service.ts` — Add `loadNewCandidates()`, fix month boundaries, parallelize with metrics
- `apps/api/src/services/summaries/summary-shared.ts` — NEW: extracted `getSummaryTitle`, `getDefaultTemplateId`
- `apps/api/src/services/summaries/summary-dispatcher.ts` — Use shared module, resolve default template by period
- `apps/api/src/services/summaries/summary-renderer.ts` — Use shared module, render candidate list section
- `apps/api/src/routes/summaries.ts` — Add "monthly" to Zod schema, remove route-level template default
- `apps/worker/tasks.py` — Add "monthly" to `VALID_SUMMARY_PERIODS`
- `config/notifications/summary-monthly.md` — NEW: Mustache template for monthly digest

## Test plan
- [ ] `make check` passes (typecheck, lint, governance)
- [ ] Verify monthly summary renders candidate list in dry-run mode
- [ ] Verify daily/weekly summaries still work unchanged
- [ ] Verify template auto-selection: monthly period uses `summary-monthly` template