### PR TITLE
fix(convex): replace unbounded .collect() with indexed queries

### DIFF
--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -322,14 +322,20 @@ export const list = query({
 export const getSummary = query({
     args: {},
     handler: async (ctx) => {
-        const tasks = await ctx.db.query("analysis_tasks").collect();
+        const [pending, processing, completed, failed, cancelled] = await Promise.all([
+            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "pending")).collect(),
+            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "processing")).collect(),
+            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "completed")).collect(),
+            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "failed")).collect(),
+            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "cancelled")).collect(),
+        ]);
         return {
-            total: tasks.length,
-            pending: tasks.filter((task) => task.status === "pending").length,
-            processing: tasks.filter((task) => task.status === "processing").length,
-            completed: tasks.filter((task) => task.status === "completed").length,
-            failed: tasks.filter((task) => task.status === "failed").length,
-            cancelled: tasks.filter((task) => task.status === "cancelled").length,
+            total: pending.length + processing.length + completed.length + failed.length + cancelled.length,
+            pending: pending.length,
+            processing: processing.length,
+            completed: completed.length,
+            failed: failed.length,
+            cancelled: cancelled.length,
         };
     },
 });

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -697,15 +697,21 @@ export const submitResumes = mutation({
 export const getSummary = query({
     args: {},
     handler: async (ctx) => {
-        const tasks = await ctx.db.query("collection_tasks").collect();
+        const [pending, processing, completed, failed, cancelled] = await Promise.all([
+            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "pending")).collect(),
+            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "processing")).collect(),
+            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "completed")).collect(),
+            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "failed")).collect(),
+            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "cancelled")).collect(),
+        ]);
         const stats = {
-            total: tasks.length,
-            pending: tasks.filter(t => t.status === "pending").length,
-            processing: tasks.filter(t => t.status === "processing").length,
-            completed: tasks.filter(t => t.status === "completed").length,
-            failed: tasks.filter(t => t.status === "failed").length,
-            cancelled: tasks.filter(t => t.status === "cancelled").length,
-            activeWorkers: Array.from(new Set(tasks.filter(t => t.status === "processing").map(t => t.workerId).filter(Boolean))).length
+            total: pending.length + processing.length + completed.length + failed.length + cancelled.length,
+            pending: pending.length,
+            processing: processing.length,
+            completed: completed.length,
+            failed: failed.length,
+            cancelled: cancelled.length,
+            activeWorkers: Array.from(new Set(processing.map(t => t.workerId).filter(Boolean))).length
         };
         return stats;
     },

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -3349,16 +3349,22 @@ export const deleteResumes = mutation({
         }
 
         const deletedResumeIdStrings = new Set(existingResumeIds.map((resumeId) => String(resumeId)));
-        const screeningSessions = await ctx.db.query("screening_sessions").collect();
         let patchedScreeningSessions = 0;
-        for (const session of screeningSessions) {
-            const reviewedResumeIds = session.reviewedResumeIds.filter((resumeId) => !deletedResumeIdStrings.has(resumeId));
-            if (reviewedResumeIds.length === session.reviewedResumeIds.length) {
-                continue;
-            }
+        let cursor = null;
+        let isDone = false;
+        while (!isDone) {
+            const result = await ctx.db.query("screening_sessions").paginate({ numItems: 100, cursor });
+            for (const session of result.page) {
+                const reviewedResumeIds = session.reviewedResumeIds.filter((resumeId) => !deletedResumeIdStrings.has(resumeId));
+                if (reviewedResumeIds.length === session.reviewedResumeIds.length) {
+                    continue;
+                }
 
-            await ctx.db.patch(session._id, { reviewedResumeIds });
-            patchedScreeningSessions += 1;
+                await ctx.db.patch(session._id, { reviewedResumeIds });
+                patchedScreeningSessions += 1;
+            }
+            cursor = result.continueCursor;
+            isDone = result.isDone;
         }
 
         for (const resume of existingResumes) {


### PR DESCRIPTION
## Summary
- Replace unbounded `.collect()` in `getSummary` functions with 5 parallel indexed queries per status
- Replace `screening_sessions.collect()` with paginated loop (100 docs/batch)
- All 3 HIGH severity findings from Convex query audit resolved

## Changes
| File | Change |
|------|--------|
| `resume_tasks.ts` | `getSummary`: indexed queries per status instead of full table scan |
| `analysis_tasks.ts` | `getSummary`: same pattern |
| `resumes.ts` | screening_sessions cleanup: paginated loop instead of `.collect()` |

## Why
Unbounded `.collect()` on growing tables risks hitting Convex's 16 MiB per-query read limit. The `screening_sessions` table grows with every user session; `collection_tasks` and `analysis_tasks` grow with every crawl/analysis run.

## Test plan
- [x] `make check-node` passes (0 errors)
- [ ] Verify `getSummary` returns correct counts in dev
- [ ] Verify screening session cleanup still patches correctly