### PR TITLE
feat: pagination safety, CWV assertions, Server-Timing headers

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -30,6 +30,7 @@ import {
 } from "./routes/index.js";
 import { config } from "./services/config.js";
 import { workspaceMiddleware } from "./middleware/workspace.js";
+import { serverTimingMiddleware } from "./middleware/server-timing.js";
 
 export const openApiConfig = {
   openapi: "3.1.0",
@@ -64,6 +65,7 @@ export function createApp() {
   const app = new OpenAPIHono();
 
   // Middleware
+  app.use("*", serverTimingMiddleware);
   app.use(
     "*",
     cors({

--- a/apps/api/src/middleware/server-timing.ts
+++ b/apps/api/src/middleware/server-timing.ts
@@ -1,0 +1,12 @@
+import type { MiddlewareHandler } from "hono";
+
+/**
+ * Adds `Server-Timing` response header with total request duration.
+ * Browser DevTools shows this in the Network tab Timing section.
+ */
+export const serverTimingMiddleware: MiddlewareHandler = async (c, next) => {
+    const start = performance.now();
+    await next();
+    const dur = Math.round(performance.now() - start);
+    c.header("Server-Timing", `total;dur=${dur}`);
+};

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -379,6 +379,11 @@ export const MAX_SAFE_LIST_WITH_INGEST_LIMIT = 2000;
 export const MAX_SAFE_LIST_WITH_INGEST_OVERFETCH = 4000;
 const FILTERED_PAGINATE_OVERFETCH_MULTIPLIER = 3;
 const MAX_SAFE_JD_PAGINATE_SCAN = 250;
+
+// Safety margins: half of Convex's 16 MiB read / 32K scan limits.
+// Forces automatic page splitting before hitting hard limits.
+const PAGINATE_MAX_BYTES_READ = 8 * 1024 * 1024; // 8 MiB
+const PAGINATE_MAX_ROWS_READ = 16_000;
 // Convex enforces 16 MiB total data read per query function.
 // Resume docs average ~27KB but some exceed 500KB on later search index pages.
 // With post-filter attrition (filtered path), overfetch is needed but output shrinks.
@@ -1663,6 +1668,8 @@ async function runSearchWithTagExpansionScanPageQuery(
             .paginate({
                 ...args.paginationOpts,
                 numItems: pageSize,
+                maximumBytesRead: PAGINATE_MAX_BYTES_READ,
+                maximumRowsRead: PAGINATE_MAX_ROWS_READ,
             })
         : {
             page: [] as Doc<"resumes">[],
@@ -1735,6 +1742,8 @@ export const fieldCoverage = query({
             .paginate({
                 cursor: args.cursor ?? null,
                 numItems: args.batchSize ?? 200,
+                maximumBytesRead: PAGINATE_MAX_BYTES_READ,
+                maximumRowsRead: PAGINATE_MAX_ROWS_READ,
             });
 
         let missingSearchText = 0;
@@ -1814,6 +1823,8 @@ export const listForBackup = query({
             .paginate({
                 ...args.paginationOpts,
                 numItems: pageSize,
+                maximumBytesRead: PAGINATE_MAX_BYTES_READ,
+                maximumRowsRead: PAGINATE_MAX_ROWS_READ,
             });
 
         const filtered = applyResumeBackupFilters(page.page, filterSets).sort(compareResumeBackupRows);
@@ -1989,6 +2000,8 @@ export const listWithIngestDataPaginated = query({
                 .paginate({
                     ...args.paginationOpts,
                     numItems,
+                    maximumBytesRead: PAGINATE_MAX_BYTES_READ,
+                    maximumRowsRead: PAGINATE_MAX_ROWS_READ,
                 });
 
             const filtered = filters
@@ -2627,6 +2640,8 @@ export const scanResumePageByTime = query({
             .paginate({
                 cursor: args.cursor ?? null,
                 numItems,
+                maximumBytesRead: PAGINATE_MAX_BYTES_READ,
+                maximumRowsRead: PAGINATE_MAX_ROWS_READ,
             });
         return {
             docs: page.page.map((doc) => ({
@@ -2664,6 +2679,8 @@ export const scanResumePageSlim = query({
             .paginate({
                 cursor: args.cursor ?? null,
                 numItems,
+                maximumBytesRead: PAGINATE_MAX_BYTES_READ,
+                maximumRowsRead: PAGINATE_MAX_ROWS_READ,
             });
         return {
             docs: page.page.map((doc) => ({
@@ -2736,6 +2753,8 @@ export const collectSearchIndexDocIds = internalQuery({
             .paginate({
                 cursor: args.cursor ?? null,
                 numItems: Math.min(args.numItems ?? 256, 256),
+                maximumBytesRead: PAGINATE_MAX_BYTES_READ,
+                maximumRowsRead: PAGINATE_MAX_ROWS_READ,
             });
         return {
             ids: page.page.map((doc) => String(doc._id)),

--- a/scripts/e2e-smoke.ts
+++ b/scripts/e2e-smoke.ts
@@ -1,4 +1,4 @@
-import { connectToChrome, waitForToast, DEFAULT_OPTIONS } from './e2e-utils';
+import { connectToChrome, waitForToast, DEFAULT_OPTIONS, measureWebVitals } from './e2e-utils';
 import { Locator, Page, expect } from '@playwright/test';
 import { ConvexHttpClient } from 'convex/browser';
 import { makeFunctionReference } from 'convex/server';
@@ -271,6 +271,10 @@ async function runCollectionTest(page: Page) {
 
 async function runSearchTest(page: Page) {
     console.log('Testing Critical Path 2: Search & Filter...');
+
+    // Set up CWV observers before navigation (buffered: true catches early entries)
+    const vitals = await measureWebVitals(page);
+
     await page.goto(`${DEFAULT_OPTIONS.baseUrl}/dev/resumes`);
     await page.setViewportSize(SMOKE_VIEWPORT);
 
@@ -308,6 +312,28 @@ async function runSearchTest(page: Page) {
         return hasCheckbox || hasEmptyState;
     }, { timeout: 15000 }).toBe(true);
     console.log('✅ Search & Filter test passed.');
+
+    // Collect and assert Core Web Vitals
+    const cwv = await vitals.collect();
+    console.log('📊 Core Web Vitals:', cwv);
+
+    const CWV_THRESHOLDS = { ttfb: 800, lcp: 2500, cls: 0.1, fcp: 1800 };
+    if (cwv.ttfb !== null) {
+        expect(cwv.ttfb).toBeLessThan(CWV_THRESHOLDS.ttfb);
+        console.log(`  ✓ TTFB: ${cwv.ttfb.toFixed(0)}ms (threshold: ${CWV_THRESHOLDS.ttfb}ms)`);
+    }
+    if (cwv.lcp !== null) {
+        expect(cwv.lcp).toBeLessThan(CWV_THRESHOLDS.lcp);
+        console.log(`  ✓ LCP: ${cwv.lcp.toFixed(0)}ms (threshold: ${CWV_THRESHOLDS.lcp}ms)`);
+    }
+    if (cwv.cls !== null) {
+        expect(cwv.cls).toBeLessThan(CWV_THRESHOLDS.cls);
+        console.log(`  ✓ CLS: ${cwv.cls.toFixed(3)} (threshold: ${CWV_THRESHOLDS.cls})`);
+    }
+    if (cwv.fcp !== null) {
+        expect(cwv.fcp).toBeLessThan(CWV_THRESHOLDS.fcp);
+        console.log(`  ✓ FCP: ${cwv.fcp.toFixed(0)}ms (threshold: ${CWV_THRESHOLDS.fcp}ms)`);
+    }
 }
 
 async function runAnalysisTest(page: Page) {

--- a/scripts/e2e-utils.ts
+++ b/scripts/e2e-utils.ts
@@ -12,6 +12,82 @@ export const DEFAULT_OPTIONS: E2EOptions = {
     timeout: 30000,
 };
 
+export interface WebVitals {
+    ttfb: number | null;
+    lcp: number | null;
+    cls: number | null;
+    fcp: number | null;
+}
+
+/**
+ * Inject PerformanceObserver scripts and collect Core Web Vitals.
+ * Must be called BEFORE navigation (observers need `buffered: true` to catch early entries).
+ * Call `collect()` after the page has settled to retrieve measured values.
+ */
+export async function measureWebVitals(page: Page): Promise<{ collect: () => Promise<WebVitals> }> {
+    // Set up observers before navigation so they capture all entries
+    await page.evaluate(() => {
+        const w = window as typeof window & {
+            __cwv_ttfb?: number | null;
+            __cwv_lcp?: number | null;
+            __cwv_cls?: number | null;
+            __cwv_fcp?: number | null;
+        };
+        w.__cwv_ttfb = null;
+        w.__cwv_lcp = null;
+        w.__cwv_cls = null;
+        w.__cwv_fcp = null;
+
+        // TTFB from navigation timing
+        new PerformanceObserver((list) => {
+            const nav = list.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+            if (nav) w.__cwv_ttfb = nav.responseStart - nav.fetchStart;
+        }).observe({ type: 'navigation', buffered: true });
+
+        // LCP — last entry wins
+        new PerformanceObserver((list) => {
+            const entries = list.getEntries();
+            if (entries.length > 0) w.__cwv_lcp = entries[entries.length - 1].startTime;
+        }).observe({ type: 'largest-contentful-paint', buffered: true });
+
+        // CLS — sum of non-user-input layout shifts
+        new PerformanceObserver((list) => {
+            let clsSum = 0;
+            for (const entry of list.getEntries()) {
+                const ls = entry as PerformanceEntry & { hadRecentInput?: boolean; value?: number };
+                if (!ls.hadRecentInput && ls.value) clsSum += ls.value;
+            }
+            w.__cwv_cls = (w.__cwv_cls ?? 0) + clsSum;
+        }).observe({ type: 'layout-shift', buffered: true });
+
+        // FCP
+        new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+                if (entry.name === 'first-contentful-paint') w.__cwv_fcp = entry.startTime;
+            }
+        }).observe({ type: 'paint', buffered: true });
+    });
+
+    return {
+        async collect(): Promise<WebVitals> {
+            return page.evaluate(() => {
+                const w = window as typeof window & {
+                    __cwv_ttfb?: number | null;
+                    __cwv_lcp?: number | null;
+                    __cwv_cls?: number | null;
+                    __cwv_fcp?: number | null;
+                };
+                return {
+                    ttfb: w.__cwv_ttfb ?? null,
+                    lcp: w.__cwv_lcp ?? null,
+                    cls: w.__cwv_cls ?? null,
+                    fcp: w.__cwv_fcp ?? null,
+                };
+            });
+        },
+    };
+}
+
 export async function connectToChrome(options: E2EOptions = DEFAULT_OPTIONS) {
     try {
         const browser = await chromium.connectOverCDP(`http://127.0.0.1:${options.port}`);


### PR DESCRIPTION
## Summary
- Add `maximumBytesRead` (8 MiB) and `maximumRowsRead` (16K) safety to 7 critical `.paginate()` calls in `resumes.ts` — prevents production 16 MiB read limit crashes
- Add `PerformanceObserver`-based Core Web Vitals measurement (TTFB, LCP, CLS, FCP) to E2E smoke test search flow with threshold assertions
- Add `Server-Timing` response header middleware to Hono BFF for per-request timing visibility in browser DevTools

## Test plan
- [x] `make check-node` — 0 errors, 5 pre-existing lint warnings
- [x] `Server-Timing` header verified on BFF `/health` endpoint
- [ ] `make e2e` — requires full dev stack (Convex + Chrome)

## Files changed
- `packages/convex/convex/resumes.ts` — pagination safety margins
- `scripts/e2e-utils.ts` — `measureWebVitals()` helper
- `scripts/e2e-smoke.ts` — CWV assertions in search test
- `apps/api/src/middleware/server-timing.ts` — NEW: Server-Timing middleware
- `apps/api/src/app.ts` — register middleware

Refs: queries/resume-search-e2e-next-recommendations.md