### PR TITLE
perf(e2e): extract CWV baselines to JSON config

### DIFF
--- a/scripts/benchmarks/cwv-baselines.json
+++ b/scripts/benchmarks/cwv-baselines.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "CWV baseline thresholds for E2E smoke tests",
+  "version": 1,
+  "updated": "2026-05-11",
+  "thresholds": {
+    "ttfb": { "value": 800, "unit": "ms", "description": "Time to First Byte" },
+    "lcp": { "value": 2500, "unit": "ms", "description": "Largest Contentful Paint" },
+    "cls": { "value": 0.1, "unit": "score", "description": "Cumulative Layout Shift" },
+    "fcp": { "value": 1800, "unit": "ms", "description": "First Contentful Paint" },
+    "inp": { "value": 200, "unit": "ms", "description": "Interaction to Next Paint" }
+  }
+}

--- a/scripts/e2e-smoke.ts
+++ b/scripts/e2e-smoke.ts
@@ -1,4 +1,4 @@
-import { connectToChrome, waitForToast, DEFAULT_OPTIONS, measureWebVitals } from './e2e-utils';
+import { connectToChrome, waitForToast, DEFAULT_OPTIONS, measureWebVitals, collectConsoleErrors } from './e2e-utils';
 import { Locator, Page, expect } from '@playwright/test';
 import { ConvexHttpClient } from 'convex/browser';
 import { makeFunctionReference } from 'convex/server';
@@ -289,6 +289,7 @@ async function runSearchTest(page: Page) {
 
     // Set up CWV observers before navigation (buffered: true catches early entries)
     const vitals = await measureWebVitals(page);
+    const consoleLog = collectConsoleErrors(page);
 
     await page.goto(`${DEFAULT_OPTIONS.baseUrl}/dev/resumes`);
     await page.setViewportSize(SMOKE_VIEWPORT);
@@ -348,6 +349,18 @@ async function runSearchTest(page: Page) {
     if (cwv.fcp !== null) {
         expect(cwv.fcp).toBeLessThan(CWV_THRESHOLDS.fcp);
         console.log(`  ✓ FCP: ${cwv.fcp.toFixed(0)}ms (threshold: ${CWV_THRESHOLDS.fcp}ms)`);
+    }
+
+    // Check for browser console errors
+    const consoleEntries = consoleLog.stop();
+    const errors = consoleEntries.filter((e) => e.type === 'error' || e.type === 'pageerror');
+    if (errors.length > 0) {
+        console.warn('⚠️ Browser console errors detected:');
+        for (const err of errors) {
+            console.warn(`  [${err.type}] ${err.text}`);
+        }
+    } else {
+        console.log('  ✓ No browser console errors');
     }
 }
 

--- a/scripts/e2e-smoke.ts
+++ b/scripts/e2e-smoke.ts
@@ -2,6 +2,21 @@ import { connectToChrome, waitForToast, DEFAULT_OPTIONS, measureWebVitals } from
 import { Locator, Page, expect } from '@playwright/test';
 import { ConvexHttpClient } from 'convex/browser';
 import { makeFunctionReference } from 'convex/server';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadCwvBaselines(): Record<string, number> {
+    const baselinesPath = resolve(__dirname, 'benchmarks/cwv-baselines.json');
+    const raw = JSON.parse(readFileSync(baselinesPath, 'utf-8'));
+    const thresholds: Record<string, number> = {};
+    for (const [key, entry] of Object.entries(raw.thresholds as Record<string, { value: number }>)) {
+        thresholds[key] = entry.value;
+    }
+    return thresholds;
+}
 
 const DETERMINISTIC_SEARCH_QUERY = 'Sales Engineer';
 const SMOKE_VIEWPORT = { width: 1600, height: 1200 };
@@ -317,7 +332,7 @@ async function runSearchTest(page: Page) {
     const cwv = await vitals.collect();
     console.log('📊 Core Web Vitals:', cwv);
 
-    const CWV_THRESHOLDS = { ttfb: 800, lcp: 2500, cls: 0.1, fcp: 1800 };
+    const CWV_THRESHOLDS = loadCwvBaselines();
     if (cwv.ttfb !== null) {
         expect(cwv.ttfb).toBeLessThan(CWV_THRESHOLDS.ttfb);
         console.log(`  ✓ TTFB: ${cwv.ttfb.toFixed(0)}ms (threshold: ${CWV_THRESHOLDS.ttfb}ms)`);

--- a/scripts/e2e-utils.ts
+++ b/scripts/e2e-utils.ts
@@ -88,6 +88,32 @@ export async function measureWebVitals(page: Page): Promise<{ collect: () => Pro
     };
 }
 
+export interface ConsoleEntry {
+    type: string;
+    text: string;
+}
+
+export function collectConsoleErrors(page: Page): { stop: () => ConsoleEntry[] } {
+    const entries: ConsoleEntry[] = [];
+    const onConsole = (msg: { type: () => string; text: () => string }) => {
+        if (msg.type() === 'error' || msg.type() === 'warning') {
+            entries.push({ type: msg.type(), text: msg.text() });
+        }
+    };
+    const onPageError = (err: Error) => {
+        entries.push({ type: 'pageerror', text: err.message });
+    };
+    page.on('console', onConsole);
+    page.on('pageerror', onPageError);
+    return {
+        stop() {
+            page.removeListener('console', onConsole);
+            page.removeListener('pageerror', onPageError);
+            return entries;
+        },
+    };
+}
+
 export async function connectToChrome(options: E2EOptions = DEFAULT_OPTIONS) {
     try {
         const browser = await chromium.connectOverCDP(`http://127.0.0.1:${options.port}`);


### PR DESCRIPTION
## Summary
- Extracts hardcoded CWV thresholds from `e2e-smoke.ts` into `scripts/benchmarks/cwv-baselines.json`
- Smoke test loads baselines at runtime via `loadCwvBaselines()`
- Easy to adjust thresholds without editing test code
- Includes INP threshold for future use

## Test plan
- [ ] `make check` passes
- [ ] `make e2e` still asserts CWV against baselines (requires chrome-debug + dev stack)