### PR TITLE
perf(web): React.memo on SnippetCard + stable callbacks

### DIFF
--- a/apps/web/src/components/search/SearchResultsList.test.tsx
+++ b/apps/web/src/components/search/SearchResultsList.test.tsx
@@ -49,11 +49,11 @@ vi.mock('@/components/search/SnippetCard', () => ({
   }: {
     expanded: boolean
     item: ResumeSearchResultItem
-    onViewDetails?: () => void
+    onViewDetails?: (item: ResumeSearchResultItem) => void
   }) => (
     <div>
       <div>{`${item.key}:${expanded ? 'expanded' : 'collapsed'}`}</div>
-      <button type="button" onClick={onViewDetails}>view-details-{item.key}</button>
+      <button type="button" onClick={() => onViewDetails?.(item)}>view-details-{item.key}</button>
     </div>
   ),
 }))

--- a/apps/web/src/components/search/SearchResultsList.tsx
+++ b/apps/web/src/components/search/SearchResultsList.tsx
@@ -81,9 +81,9 @@ export function SearchResultsList({
   const shouldVirtualize = items.length > 40 && expandedIds.size === 0 && !hasAiSummaries
   const expandedKey = expandedIds.values().next().value
   const expandedSourceItem = items.find((item) => item.key === expandedKey) ?? null
-  const expandedResumeId = expandedSourceItem?.resume.resumeId ?? null
+  const expandedResumeId = expandedSourceItem?.resume?.resumeId ?? null
   const { resume: expandedResumeFromConvex } = useConvexResumeDetail(expandedResumeId)
-  const detailResumeId = detailItem?.resume.resumeId ?? null
+  const detailResumeId = detailItem?.resume?.resumeId ?? null
   const { resume: detailResumeFromConvex, loading: detailResumeLoading } = useConvexResumeDetail(detailResumeId)
   const resolvedDetailResume = detailResumeFromConvex ?? detailItem?.resume ?? null
 

--- a/apps/web/src/components/search/SearchResultsList.tsx
+++ b/apps/web/src/components/search/SearchResultsList.tsx
@@ -1,5 +1,5 @@
 import { useWindowVirtualizer } from '@tanstack/react-virtual'
-import { lazy, Suspense, useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { EmptyState } from '@/components/EmptyState'
 import { useConvexResumeDetail } from '@/hooks/useConvexResumes'
@@ -94,6 +94,10 @@ export function SearchResultsList({
     overscan: 6,
     scrollMargin,
   })
+
+  const handleViewDetails = useCallback((item: ResumeSearchResultItem) => {
+    setDetailItem(item)
+  }, [])
 
   useEffect(() => {
     const updateScrollMargin = () => {
@@ -192,10 +196,11 @@ export function SearchResultsList({
               >
                 <SnippetCard
                   item={item}
+                  itemKey={item.key}
                   expanded={false}
                   showAiScore={showAiScore}
-                  onToggleExpanded={() => onToggleExpanded(item.key)}
-                  onViewDetails={() => setDetailItem(item)}
+                  onToggleExpanded={onToggleExpanded}
+                  onViewDetails={handleViewDetails}
                   {...cardProps(item)}
                 />
               </div>
@@ -216,10 +221,11 @@ export function SearchResultsList({
             <SnippetCard
               key={item.key}
               item={presentationItem}
+              itemKey={item.key}
               expanded={expandedIds.has(item.key)}
               showAiScore={showAiScore}
-              onToggleExpanded={() => onToggleExpanded(item.key)}
-              onViewDetails={() => setDetailItem(presentationItem)}
+              onToggleExpanded={onToggleExpanded}
+              onViewDetails={handleViewDetails}
               {...cardProps(presentationItem)}
             />
           )

--- a/apps/web/src/components/search/SnippetCard.test.tsx
+++ b/apps/web/src/components/search/SnippetCard.test.tsx
@@ -120,6 +120,7 @@ describe('SnippetCard', () => {
             recommendation: 'strong_match',
           },
         })}
+        itemKey="result-1"
         onToggleExpanded={onToggleExpanded}
       />
     )
@@ -159,6 +160,7 @@ describe('SnippetCard', () => {
           score: 74,
           analysis: undefined,
         })}
+        itemKey="result-2"
         onToggleExpanded={vi.fn()}
       />
     )
@@ -180,6 +182,7 @@ describe('SnippetCard', () => {
         expanded={false}
         showAiScore
         item={item}
+        itemKey="result-2"
         onToggleExpanded={vi.fn()}
       />
     )
@@ -219,6 +222,7 @@ describe('SnippetCard', () => {
             _provenance: undefined,
           }),
         })}
+        itemKey="result-2"
         onToggleExpanded={onToggleExpanded}
       />
     )

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -4,7 +4,7 @@ import {
   ChevronUp,
   Star,
 } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -30,9 +30,10 @@ import type { CandidateActionType, CandidateStatus, AiFeedbackSentiment, AiFeedb
 type SnippetCardProps = {
   expanded: boolean
   item: ResumeSearchResultItem
+  itemKey: string
   showAiScore?: boolean
-  onToggleExpanded: () => void
-  onViewDetails?: () => void
+  onToggleExpanded: (key: string) => void
+  onViewDetails?: (item: ResumeSearchResultItem) => void
   // Candidate management props
   selected?: boolean
   onSelect?: () => void
@@ -77,9 +78,10 @@ function getPrimaryHeadline(item: ResumeSearchResultItem, fallbackLabel: string)
   return item.resume.jobIntention || fallbackLabel
 }
 
-export function SnippetCard({
+export const SnippetCard = memo(function SnippetCard({
   expanded,
   item,
+  itemKey,
   showAiScore = false,
   onToggleExpanded,
   onViewDetails,
@@ -325,14 +327,14 @@ export function SnippetCard({
                   <Star className="h-4 w-4" />
                 </Button>
               ) : null}
-              <Button variant="ghost" size="sm" className="h-8" onClick={onViewDetails}>
+              <Button variant="ghost" size="sm" className="h-8" onClick={() => onViewDetails?.(item)}>
                 {t('resumes.actions.view', { defaultValue: '查看详情' })}
               </Button>
               <Button
                 type="button"
                 variant="outline"
                 className="shrink-0 rounded-full whitespace-nowrap h-8"
-                onClick={onToggleExpanded}
+                onClick={() => onToggleExpanded(itemKey)}
               >
                 {expanded ? collapseLabel : expandLabel}
                 {expanded ? <ChevronUp className="ml-1 h-4 w-4" /> : <ChevronDown className="ml-1 h-4 w-4" />}
@@ -390,7 +392,7 @@ export function SnippetCard({
         <SnippetCardExpanded
           item={item}
           showAiScore={showAiScore}
-          onViewDetails={onViewDetails}
+          onViewDetails={onViewDetails ? () => onViewDetails(item) : undefined}
           actionType={actionType}
           onAction={onAction}
           candidateStatus={candidateStatus}
@@ -544,4 +546,4 @@ export function SnippetCard({
       </Dialog>
     </Card>
   )
-}
+})


### PR DESCRIPTION
## Summary
- Wrap SnippetCard in `React.memo` to prevent re-renders when props are stable
- Eliminate inline arrow functions in SearchResultsList that created new closures per item per render
- SnippetCard now accepts `itemKey` + stable callback refs (`onToggleExpanded(key)`, `onViewDetails(item)`)
- Update tests to include required `itemKey` prop

## Impact
Prevents unnecessary re-renders of search result cards when filter state changes — the main INP-sensitive path. Combined with `useTransition` (PR #681) and `useDeferredValue` (PR #684), filter toggles should feel instant.

## Test plan
- [ ] `make check` passes
- [ ] `npm test` passes (SnippetCard tests updated)
- [ ] Search results render correctly
- [ ] Expand/collapse cards work
- [ ] View details modal works