### PR TITLE
fix(convex): use by_workspace index on search_profiles queries

### DIFF
--- a/apps/web/src/components/ProfileCard.tsx
+++ b/apps/web/src/components/ProfileCard.tsx
@@ -1,4 +1,4 @@
-import { formatDistanceToNow } from 'date-fns'
+import { formatDistanceToNow } from 'date-fns/formatDistanceToNow'
 import { Play, Pencil, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'

--- a/apps/web/src/components/SchedulerStatus.tsx
+++ b/apps/web/src/components/SchedulerStatus.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
-import { formatDistanceToNow } from 'date-fns'
+import { formatDistanceToNow } from 'date-fns/formatDistanceToNow'
 import { useTranslation } from 'react-i18next'
 
 interface WorkerStatus {

--- a/packages/convex/convex/search_profiles.ts
+++ b/packages/convex/convex/search_profiles.ts
@@ -166,14 +166,15 @@ export const list = query({
   },
   handler: async (ctx, args) => {
     const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
-    const records = await ctx.db.query("search_profiles").collect();
-    return records
-      .filter((record) => belongsToWorkspace(record.workspaceSlug, workspaceSlug))
-      .sort((left, right) => {
-        const leftUpdated = left.updatedAt ?? left.lastRunAt ?? left._creationTime;
-        const rightUpdated = right.updatedAt ?? right.lastRunAt ?? right._creationTime;
-        return rightUpdated - leftUpdated;
-      });
+    const records = await ctx.db
+      .query("search_profiles")
+      .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
+      .collect();
+    return records.sort((left, right) => {
+      const leftUpdated = left.updatedAt ?? left.lastRunAt ?? left._creationTime;
+      const rightUpdated = right.updatedAt ?? right.lastRunAt ?? right._creationTime;
+      return rightUpdated - leftUpdated;
+    });
   },
 });
 
@@ -184,7 +185,10 @@ export const getById = query({
   },
   handler: async (ctx, args) => {
     const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
-    const records = await ctx.db.query("search_profiles").collect();
+    const records = await ctx.db
+      .query("search_profiles")
+      .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
+      .collect();
     const found = findSearchProfileRecordById(records, args.id, workspaceSlug);
     if (!found) {
       return null;
@@ -232,7 +236,10 @@ export const update = mutation({
   },
   handler: async (ctx, args) => {
     const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
-    const records = await ctx.db.query("search_profiles").collect();
+    const records = await ctx.db
+      .query("search_profiles")
+      .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
+      .collect();
     const existing = findSearchProfileRecordById(records, args.id, workspaceSlug);
     if (!existing) {
       throw new Error(`Search profile not found: ${args.id}`);
@@ -265,7 +272,10 @@ export const remove = mutation({
   },
   handler: async (ctx, args) => {
     const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
-    const records = await ctx.db.query("search_profiles").collect();
+    const records = await ctx.db
+      .query("search_profiles")
+      .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
+      .collect();
     const existing = findSearchProfileRecordById(records, args.id, workspaceSlug);
     if (!existing) {
       return false;


### PR DESCRIPTION
## Summary
- Replace unbounded `.collect()` + JS `.filter()` with `.withIndex("by_workspace")` in 4 search_profiles handlers
- `list`, `getById`, `update`, `delete` now scope queries to the workspace instead of scanning all profiles
- Prevents unnecessary full-table scans as profile count grows

## Test plan
- [ ] `make check` passes
- [ ] Search profiles load correctly per workspace