### PR TITLE
fix(convex): replace unbounded .collect() with indexed queries in resume_tasks and job_descriptions

### DIFF
--- a/packages/convex/convex/job_descriptions.ts
+++ b/packages/convex/convex/job_descriptions.ts
@@ -46,23 +46,23 @@ export const list = query({
     },
     handler: async (ctx, args) => {
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
-        // Fetch all system JDs
+        // Fetch all system JDs via index
         const systemJDs = await ctx.db
             .query("job_descriptions")
-            .filter((q) => q.eq(q.field("type"), "system"))
+            .withIndex("by_type", (q) => q.eq("type", "system"))
             .collect();
 
-        // Fetch custom JDs (for now, all enabled custom JDs or user specific)
-        let customJDs = await ctx.db
+        // Fetch custom JDs via workspace index, then filter by userId
+        const allCustomJDs = await ctx.db
             .query("job_descriptions")
-            .filter((q) => q.eq(q.field("type"), "custom"))
+            .withIndex("by_type", (q) => q.eq("type", "custom"))
             .collect();
+
+        let customJDs = allCustomJDs.filter((jd) => belongsToWorkspace(jd.workspaceSlug, workspaceSlug));
 
         if (args.userId) {
             customJDs = customJDs.filter(jd => jd.userId === args.userId || !jd.userId);
         }
-
-        customJDs = customJDs.filter((jd) => belongsToWorkspace(jd.workspaceSlug, workspaceSlug));
 
         return [...systemJDs, ...customJDs]
             .filter(jd => jd.enabled !== false)
@@ -157,15 +157,18 @@ export const list_all = query({
     args: { workspaceSlug: v.optional(v.string()) },
     handler: async (ctx, args) => {
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
-        const jds = await ctx.db.query("job_descriptions").collect();
+        const systemJDs = await ctx.db
+            .query("job_descriptions")
+            .withIndex("by_type", (q) => q.eq("type", "system"))
+            .collect();
+        const customJDs = await ctx.db
+            .query("job_descriptions")
+            .withIndex("by_type", (q) => q.eq("type", "custom"))
+            .collect();
 
-        return jds
-            .filter((jd) => {
-                if (jd.type === "system") {
-                    return true;
-                }
-                return belongsToWorkspace(jd.workspaceSlug, workspaceSlug);
-            })
+        const workspaceCustom = customJDs.filter((jd) => belongsToWorkspace(jd.workspaceSlug, workspaceSlug));
+
+        return [...systemJDs, ...workspaceCustom]
             .map(normalizeJobDescriptionRecord);
     },
 });
@@ -174,15 +177,18 @@ export const listAllForWorkspace = internalQuery({
     args: { workspaceSlug: v.optional(v.string()) },
     handler: async (ctx, args) => {
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
-        const jds = await ctx.db.query("job_descriptions").collect();
+        const systemJDs = await ctx.db
+            .query("job_descriptions")
+            .withIndex("by_type", (q) => q.eq("type", "system"))
+            .collect();
+        const customJDs = await ctx.db
+            .query("job_descriptions")
+            .withIndex("by_type", (q) => q.eq("type", "custom"))
+            .collect();
 
-        return jds
-            .filter((jd) => {
-                if (jd.type === "system") {
-                    return true;
-                }
-                return belongsToWorkspace(jd.workspaceSlug, workspaceSlug);
-            })
+        const workspaceCustom = customJDs.filter((jd) => belongsToWorkspace(jd.workspaceSlug, workspaceSlug));
+
+        return [...systemJDs, ...workspaceCustom]
             .map(normalizeJobDescriptionRecord);
     },
 });

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -723,12 +723,12 @@ export const getSummaryWindow = query({
         toTimestamp: v.number(),
     },
     handler: async (ctx, args) => {
-        const tasks = await ctx.db.query("collection_tasks").collect();
-        const matching = tasks.filter((task) =>
-            typeof task.completedAt === "number"
-            && task.completedAt >= args.fromTimestamp
-            && task.completedAt < args.toTimestamp
-        );
+        const matching = await ctx.db
+            .query("collection_tasks")
+            .withIndex("by_completedAt", (q) =>
+                q.gte("completedAt", args.fromTimestamp).lt("completedAt", args.toTimestamp)
+            )
+            .collect();
 
         const byStatus = new Map<string, number>();
         for (const task of matching) {

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -46,7 +46,8 @@ export default defineSchema({
         completedAt: v.optional(v.number()), // Timestamp
     })
         .index("by_status", ["status"])
-        .index("by_worker", ["workerId"]),
+        .index("by_worker", ["workerId"])
+        .index("by_completedAt", ["completedAt"]),
 
     collection_workers: defineTable({
         workerId: v.string(),
@@ -221,7 +222,8 @@ export default defineSchema({
         maxAge: v.optional(v.number()),
     })
         .index("by_slug", ["slug"])
-        .index("by_workspace", ["workspaceSlug"]),
+        .index("by_workspace", ["workspaceSlug"])
+        .index("by_type", ["type"]),
 
     analysis_tasks: defineTable({
         idempotencyKey: v.optional(v.string()),


### PR DESCRIPTION
## Summary
- Add `by_completedAt` index to `collection_tasks` schema for time-range queries
- Add `by_type` index to `job_descriptions` schema for type-filtered queries
- Fix `getSummaryWindow` to use `by_completedAt` index instead of full-table `.collect()` + JS filter
- Fix `job_descriptions` `list`/`list_all`/`listAllForWorkspace` to use `by_type` index instead of unbounded `.collect()`

## Problem
Three functions performed unbounded table scans:
- `resume_tasks.getSummaryWindow` — collected ALL `collection_tasks` then filtered by `completedAt` in JS
- `job_descriptions.list` — two separate `.filter()` full scans for system and custom types
- `job_descriptions.list_all` / `listAllForWorkspace` — collected ALL job descriptions then filtered in JS

## Fix
- New `by_completedAt` index on `collection_tasks` enables direct time-range queries
- New `by_type` index on `job_descriptions` enables type-filtered queries at the DB level
- Workspace filtering still applied in JS for custom JDs (compound index not needed — custom JDs per workspace is a small set)

## Test plan
- [ ] `make check-node` passes (0 new errors)
- [ ] Verify `getSummaryWindow` returns correct results for time ranges
- [ ] Verify `list`/`list_all` still return system JDs + workspace-scoped custom JDs