### PR TITLE
perf(web): React.memo on ProfileCard to skip re-renders during polling

### DIFF
--- a/apps/web/src/components/ProfileCard.tsx
+++ b/apps/web/src/components/ProfileCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { Play, Pencil, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -61,7 +62,7 @@ function runStatusLabel(status: SearchProfileRunStatus['taskStatus']): string {
   return 'unknown'
 }
 
-export function ProfileCard({
+export const ProfileCard = memo(function ProfileCard({
   profile,
   scheduleLabel,
   runStatus,
@@ -134,4 +135,4 @@ export function ProfileCard({
       </CardFooter>
     </Card>
   )
-}
+})


### PR DESCRIPTION
## Summary
- Wrap `ProfileCard` export in `React.memo` to prevent unnecessary re-renders

## Problem
`ProfileCard` is rendered in a list on `SearchProfilesPage` which polls for run status updates every 30s. Without memo, every card re-renders on each poll cycle even when its props haven't changed.

## Fix
- Wrapped component in `React.memo` — shallow prop comparison skips re-renders when profile data, schedule label, run status, and callbacks are unchanged
- Parent already provides stable references: callbacks via `useCallback`, cards array via `useMemo`

## Test plan
- [ ] `make check-node` passes
- [ ] ProfileCards render correctly on SearchProfilesPage
- [ ] Polling updates only re-render cards with changed run status