### PR TITLE
fix(test+ci): unblock all PR CI — missing mock + i18n salary keys

### DIFF
--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -187,6 +187,7 @@ vi.mock('@/hooks/useConvexResumes', () => ({
 vi.mock('@/hooks/useCandidateActions', () => ({
   useCandidateActions: () => ({
     actions: {},
+    ratingsByResume: {},
     aiFeedbackByResume: {},
     saveAction: mockState.saveAction,
     getAiFeedback: () => undefined,

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -380,6 +380,8 @@
         "status": "Candidate Status",
         "matchScore": "Match Score",
         "sources": "Source Channel",
+        "salary": "Expected Salary",
+        "salaryUnit": "k",
         "minRoleYears": "Relevant Experience",
         "ageRange": "Age Range",
         "ageUnit": "yrs",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -379,6 +379,8 @@
         "status": "候选人状态",
         "matchScore": "匹配分",
         "sources": "来源渠道",
+        "salary": "期望薪资",
+        "salaryUnit": "k",
         "minRoleYears": "相关工作年限",
         "ageRange": "年龄范围",
         "ageUnit": "岁",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -379,6 +379,8 @@
         "status": "候選人狀態",
         "matchScore": "匹配分",
         "sources": "來源渠道",
+        "salary": "期望薪資",
+        "salaryUnit": "k",
         "minRoleYears": "相關工作經驗",
         "ageRange": "年齡範圍",
         "ageUnit": "歲",


### PR DESCRIPTION
## Summary
- Add missing `ratingsByResume: {}` to `useCandidateActions` mock in `useResumeListState.test.tsx`
- Add missing `salary`/`salaryUnit` i18n keys to all 3 locale files (zh-Hant, zh-Hans, en)

## Problem
Two pre-existing CI failures were blocking all PRs:
1. **test**: 48 tests in `useResumeListState.test.tsx` failing with `TypeError: Cannot read properties of undefined (reading 'resume-ideal-cnc-sales')` — mock missing `ratingsByResume`
2. **i18n-check**: `resumes.searchPage.facets.salary` and `resumes.searchPage.facets.salaryUnit` used in `FacetSidebar.tsx` but missing from locale files

## Test plan
- [ ] `npx vitest run src/hooks/useResumeListState.test.tsx` — 53/53 pass
- [ ] `uv run python scripts/i18n/sync_keys.py` — "All locales are in sync!"
- [ ] Unblocks CI for all open PRs (#682-#689)