### PR TITLE
fix(convex): reduce remaining unbounded .collect() calls

### DIFF
--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -344,16 +344,13 @@ export const failStalePending = mutation({
         const staleThreshold = now - staleMs;
         const pendingTasks = await ctx.db
             .query("collection_tasks")
-            .withIndex("by_status", (q) => q.eq("status", "pending"))
+            .withIndex("by_status", (q) => q.eq("status", "pending").lt("_creationTime", staleThreshold))
             .collect();
 
         let failed = 0;
         const failedTaskIds: string[] = [];
 
         for (const task of pendingTasks) {
-            if (task._creationTime > staleThreshold) {
-                continue;
-            }
 
             await ctx.db.patch(task._id, {
                 status: "failed",
@@ -700,9 +697,9 @@ export const getSummary = query({
         const [pending, processing, completed, failed, cancelled] = await Promise.all([
             ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "pending")).collect(),
             ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "processing")).collect(),
-            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "completed")).collect(),
-            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "failed")).collect(),
-            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "cancelled")).collect(),
+            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "completed")).order("desc").take(100),
+            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "failed")).order("desc").take(100),
+            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "cancelled")).order("desc").take(100),
         ]);
         const stats = {
             total: pending.length + processing.length + completed.length + failed.length + cancelled.length,

--- a/packages/convex/convex/search_profiles.ts
+++ b/packages/convex/convex/search_profiles.ts
@@ -185,6 +185,16 @@ export const getById = query({
   },
   handler: async (ctx, args) => {
     const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
+    // Fast path: try direct document lookup by Convex _id
+    try {
+      const direct = await ctx.db.get(args.id as Id<"search_profiles">);
+      if (direct && belongsToWorkspace(direct.workspaceSlug, workspaceSlug)) {
+        return direct;
+      }
+    } catch {
+      // Not a valid Convex ID — fall through to profileId lookup
+    }
+    // Slow path: scan workspace profiles for matching profileId
     const records = await ctx.db
       .query("search_profiles")
       .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
@@ -236,11 +246,23 @@ export const update = mutation({
   },
   handler: async (ctx, args) => {
     const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
-    const records = await ctx.db
-      .query("search_profiles")
-      .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
-      .collect();
-    const existing = findSearchProfileRecordById(records, args.id, workspaceSlug);
+    // Fast path: try direct document lookup by Convex _id
+    let existing: { _id: Id<"search_profiles">; name: string; profileId?: string; profile?: unknown } | undefined;
+    try {
+      const direct = await ctx.db.get(args.id as Id<"search_profiles">);
+      if (direct && belongsToWorkspace(direct.workspaceSlug, workspaceSlug)) {
+        existing = direct;
+      }
+    } catch {
+      // Not a valid Convex ID — fall through
+    }
+    if (!existing) {
+      const records = await ctx.db
+        .query("search_profiles")
+        .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
+        .collect();
+      existing = findSearchProfileRecordById(records, args.id, workspaceSlug);
+    }
     if (!existing) {
       throw new Error(`Search profile not found: ${args.id}`);
     }
@@ -272,11 +294,23 @@ export const remove = mutation({
   },
   handler: async (ctx, args) => {
     const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
-    const records = await ctx.db
-      .query("search_profiles")
-      .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
-      .collect();
-    const existing = findSearchProfileRecordById(records, args.id, workspaceSlug);
+    // Fast path: try direct document lookup by Convex _id
+    let existing: { _id: Id<"search_profiles"> } | undefined;
+    try {
+      const direct = await ctx.db.get(args.id as Id<"search_profiles">);
+      if (direct && belongsToWorkspace(direct.workspaceSlug, workspaceSlug)) {
+        existing = direct;
+      }
+    } catch {
+      // Not a valid Convex ID — fall through
+    }
+    if (!existing) {
+      const records = await ctx.db
+        .query("search_profiles")
+        .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
+        .collect();
+      existing = findSearchProfileRecordById(records, args.id, workspaceSlug);
+    }
     if (!existing) {
       return false;
     }


### PR DESCRIPTION
## Summary
- `resume_tasks.getSummary`: add `.take(100)` to completed/failed/cancelled queries (these grow unboundedly; pending/processing stay collect since small)
- `resume_tasks.markStalePendingAsFailed`: filter by `_creationTime` in query instead of collecting all pending tasks and post-filtering in JS
- `search_profiles.getById/update/remove`: try `ctx.db.get()` first (fast path for Convex `_id`), fall back to workspace index scan only when needed

## Test plan
- [ ] `make check` passes
- [ ] Search profiles CRUD still works (create, get, update, delete)
- [ ] Collection task summary still shows correct counts
- [ ] Stale pending reconciliation still marks old tasks as failed