### PR TITLE
fix(convex): reduce unbounded collects in taxonomy, analysis, sessions

### DIFF
--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -325,9 +325,9 @@ export const getSummary = query({
         const [pending, processing, completed, failed, cancelled] = await Promise.all([
             ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "pending")).collect(),
             ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "processing")).collect(),
-            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "completed")).collect(),
-            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "failed")).collect(),
-            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "cancelled")).collect(),
+            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "completed")).order("desc").take(100),
+            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "failed")).order("desc").take(100),
+            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "cancelled")).order("desc").take(100),
         ]);
         return {
             total: pending.length + processing.length + completed.length + failed.length + cancelled.length,

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -3369,16 +3369,18 @@ export const deleteResumes = mutation({
         }
 
         let deletedAiTaggingResults = 0;
+        // Collect all tagging results for all resumeIds in one pass, then batch delete
+        const allTaggingResults: Array<{ _id: Id<"ai_tagging_results"> }> = [];
         for (const resumeId of existingResumeIds) {
             const taggingResults = await ctx.db
                 .query("ai_tagging_results")
                 .withIndex("by_resume_profile", (q) => q.eq("resumeId", resumeId))
                 .collect();
-
-            for (const taggingResult of taggingResults) {
-                await ctx.db.delete(taggingResult._id);
-                deletedAiTaggingResults += 1;
-            }
+            allTaggingResults.push(...taggingResults);
+        }
+        for (const taggingResult of allTaggingResults) {
+            await ctx.db.delete(taggingResult._id);
+            deletedAiTaggingResults += 1;
         }
 
         const deletedResumeIdStrings = new Set(existingResumeIds.map((resumeId) => String(resumeId)));

--- a/packages/convex/convex/sessions.ts
+++ b/packages/convex/convex/sessions.ts
@@ -298,12 +298,13 @@ export const listSearchHistory = query({
         const records = await ctx.db
             .query("search_history")
             .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
-            .collect();
+            .order("desc")
+            .take(200);
 
         const cohorts = await ctx.db
             .query("industry_db_cohorts")
             .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
-            .collect();
+            .take(200);
         const cohortBySearchHistoryId = new Map(cohorts.map((cohort) => [String(cohort.searchHistoryId), cohort]));
 
         return sortByHistoryRecency(records

--- a/packages/convex/convex/taxonomy_clusters.ts
+++ b/packages/convex/convex/taxonomy_clusters.ts
@@ -185,7 +185,8 @@ export const suggest = mutation({
             existingClusters.flatMap((cluster) => cluster.tags.map((tag) => tag.trim().toLowerCase()))
         );
 
-        const resumes = await ctx.db.query("resumes").collect();
+        // Sample recent resumes for tag aggregation (no need to scan entire table)
+        const resumes = await ctx.db.query("resumes").order("desc").take(500);
         const tagCounts = new Map<string, number>();
         for (const resume of resumes) {
             const seen = new Set<string>();


### PR DESCRIPTION
## Summary
- `taxonomy_clusters.ts`: replace unbounded `.collect()` of ALL resumes with `.take(500)` — samples recent resumes for tag aggregation
- `analysis_tasks.ts getSummary`: add `.take(100)` to completed/failed/cancelled queries (same pattern as PR #691)
- `resumes.ts`: separate collect and delete phases in ai_tagging_results cleanup (avoids interleaving reads/writes)
- `sessions.ts listSearchHistory`: add `.take(200)` to search_history and industry_db_cohorts queries

## Test plan
- [ ] `make check` passes
- [ ] Taxonomy cluster suggestions still generate correctly
- [ ] Analysis task summary shows correct counts
- [ ] Search history still loads in sessions page
- [ ] Resume cleanup/deletion still works