### PR TITLE
feat(web): security hardening, retry logic, and ARIA improvements

### DIFF
--- a/apps/web/src/components/search/FacetGroup.tsx
+++ b/apps/web/src/components/search/FacetGroup.tsx
@@ -54,6 +54,7 @@ export function FacetGroup({
               <button
                 key={`${title}-${item.value}`}
                 type="button"
+                aria-pressed={active}
                 className={cn(
                   'rounded-full border px-3 py-1.5 text-sm transition-colors',
                   active

--- a/apps/web/src/components/search/GoogleSearchBar.test.tsx
+++ b/apps/web/src/components/search/GoogleSearchBar.test.tsx
@@ -226,7 +226,7 @@ describe('GoogleSearchBar', () => {
     })
 
     await user.click(screen.getByPlaceholderText('Search resumes by keywords, brands, roles, or locations'))
-    await user.click(screen.getByRole('button', { name: /CNC Sales/i }))
+    await user.click(screen.getByRole('option', { name: /CNC Sales/i }))
 
     expect(onApplyRecentSearch).toHaveBeenCalledWith(recentItem)
   })

--- a/apps/web/src/components/search/GoogleSearchBar.tsx
+++ b/apps/web/src/components/search/GoogleSearchBar.tsx
@@ -172,7 +172,7 @@ export function GoogleSearchBar({
       ) : null}
 
       {focused && !jdPopoverOpen && filteredRecentSearches.length > 0 ? (
-        <div className="absolute inset-x-0 top-[calc(100%+0.75rem)] z-30 overflow-hidden rounded-3xl border bg-background shadow-xl">
+        <div className="absolute inset-x-0 top-[calc(100%+0.75rem)] z-30 overflow-hidden rounded-3xl border bg-background shadow-xl" role="listbox" aria-label={recentSearchesLabel}>
           <div className="border-b px-4 py-3 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
             {recentSearchesLabel}
           </div>
@@ -181,6 +181,7 @@ export function GoogleSearchBar({
               <button
                 key={item.id}
                 type="button"
+                role="option"
                 className="flex w-full items-start gap-3 rounded-2xl px-3 py-3 text-left transition-colors hover:bg-muted"
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() => {

--- a/apps/web/src/components/search/SearchResultsList.test.tsx
+++ b/apps/web/src/components/search/SearchResultsList.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SearchResultsList } from '@/components/search/SearchResultsList'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+import { useConvexResumeDetail } from '@/hooks/useConvexResumes'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -307,11 +308,17 @@ describe('SearchResultsList', () => {
   })
 
   it('opens the internal resume detail modal from a search result card', async () => {
+    const item = createItem(0)
+    vi.mocked(useConvexResumeDetail).mockReturnValue({
+      resume: item.resume as unknown as ReturnType<typeof useConvexResumeDetail>['resume'],
+      loading: false,
+    })
+
     render(
       <SearchResultsList
         expandedIds={new Set(['resume-0'])}
         hasMore={false}
-        items={[createItem(0)]}
+        items={[item]}
         onLoadMore={vi.fn()}
         onToggleExpanded={vi.fn()}
       />,

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -3,6 +3,7 @@ import { normalizeProfileUrlForDisplay, normalizeSharedResumeFields, parseKeywor
 import { usePaginatedQuery, useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
+import { withRetry } from '@/lib/retry'
 import { rawApiClient } from '@/lib/api-helpers'
 import type { ResumeItem } from './useResumes'
 
@@ -840,20 +841,23 @@ function useBffAndModeSearch(
       ...(jobDescriptionId ? { jobDescriptionId } : {}),
     }
 
-    void rawApiClient
-      .GET<{
-        success: boolean
-        summary?: {
-          total?: number
-          mode?: string
-          keywordGroups?: Array<{ original: string; variants: string[] }>
-          expandedTo?: string[]
-          sourceMapping?: Record<string, string>
-        }
-        data?: Array<Record<string, unknown>>
-      }>('/api/resumes', {
-        params: { query: queryParams },
-      })
+    void withRetry(
+      () => rawApiClient
+        .GET<{
+          success: boolean
+          summary?: {
+            total?: number
+            mode?: string
+            keywordGroups?: Array<{ original: string; variants: string[] }>
+            expandedTo?: string[]
+            sourceMapping?: Record<string, string>
+          }
+          data?: Array<Record<string, unknown>>
+        }>('/api/resumes', {
+          params: { query: queryParams },
+        }),
+      { maxRetries: 2, baseDelayMs: 800 },
+    )
       .then(({ data, error }) => {
         if (!active) return
         if (error || !data?.success || !Array.isArray(data.data)) {
@@ -973,25 +977,28 @@ export function useConvexResumes(
     }
 
     setExpansionLoading(true)
-    void rawApiClient
-      .GET<{
-        success: boolean
-        summary?: {
-          groups?: Array<{
-            original: string
-            variants: string[]
-          }>
-          mode?: 'AND' | 'OR'
-          expandedTo?: string[]
-          sourceMapping?: Record<string, string>
-        }
-      }>('/api/resumes/keyword-expansion', {
-        params: {
-          query: {
-            q: normalizedQuery,
+    void withRetry(
+      () => rawApiClient
+        .GET<{
+          success: boolean
+          summary?: {
+            groups?: Array<{
+              original: string
+              variants: string[]
+            }>
+            mode?: 'AND' | 'OR'
+            expandedTo?: string[]
+            sourceMapping?: Record<string, string>
+          }
+        }>('/api/resumes/keyword-expansion', {
+          params: {
+            query: {
+              q: normalizedQuery,
+            },
           },
-        },
-      })
+        }),
+      { maxRetries: 2, baseDelayMs: 600 },
+    )
       .then(({ data, error }) => {
         if (!active) {
           return

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -261,7 +261,11 @@ export function isAutoFilteredAnalysis(analysis: ConvexResumeAnalysis | undefine
 
 export function isSafeProfileUrl(value: string | undefined): value is string {
   if (!value) return false
-  return value.startsWith('http://') || value.startsWith('https://')
+  const lower = value.toLowerCase()
+  if (lower.startsWith('javascript:') || lower.startsWith('data:') || lower.startsWith('vbscript:')) {
+    return false
+  }
+  return lower.startsWith('http://') || lower.startsWith('https://')
 }
 
 export function getResumeSourceLabel(resume: unknown): string | undefined {

--- a/apps/web/src/lib/retry.ts
+++ b/apps/web/src/lib/retry.ts
@@ -1,0 +1,35 @@
+/**
+ * Retry an async function with exponential backoff.
+ * Returns the result of the first successful call, or throws after all retries are exhausted.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: { maxRetries?: number; baseDelayMs?: number; signal?: AbortSignal } = {},
+): Promise<T> {
+  const { maxRetries = 2, baseDelayMs = 1000, signal } = options;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (attempt < maxRetries && !signal?.aborted) {
+        const delay = baseDelayMs * 2 ** attempt;
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, delay);
+          signal?.addEventListener('abort', () => {
+            clearTimeout(timer);
+            reject(new DOMException('Aborted', 'AbortError'));
+          }, { once: true });
+        });
+      }
+    }
+  }
+
+  throw lastError;
+}


### PR DESCRIPTION
## Summary
- **Security**: Harden `isSafeProfileUrl` to block `javascript:`, `data:`, `vbscript:` schemes
- **Reliability**: Add `withRetry` utility with exponential backoff; wrap BFF search and keyword expansion API calls with 2 retries before falling back to empty results
- **Accessibility**: Add `role="listbox"` / `role="option"` to recent-searches dropdown, `aria-pressed` to facet filter pills

## Test plan
- [ ] `make check` passes
- [ ] Search still works with recent searches dropdown
- [ ] Facet filters still toggle correctly
- [ ] BFF search retries on transient failures (verify in network tab)
- [ ] `isSafeProfileUrl` rejects `javascript:alert(1)` URLs