### PR TITLE
fix(convex): compound indexes and bounded queries

### DIFF
--- a/packages/convex/convex/ai_summary_cache.ts
+++ b/packages/convex/convex/ai_summary_cache.ts
@@ -55,17 +55,27 @@ export const cleanupExpired = internalMutation({
     },
     handler: async (ctx, args) => {
         const now = args.now ?? Date.now();
-        const expiredRecords = await ctx.db
+        let deleted = 0;
+
+        // Batch deletes to avoid unbounded collect
+        let batch = await ctx.db
             .query("ai_summary_cache")
             .withIndex("by_expires_at", (q) => q.lte("expiresAt", now))
-            .collect();
+            .take(100);
 
-        for (const record of expiredRecords) {
-            await ctx.db.delete(record._id);
+        while (batch.length > 0) {
+            for (const record of batch) {
+                await ctx.db.delete(record._id);
+            }
+            deleted += batch.length;
+            batch = await ctx.db
+                .query("ai_summary_cache")
+                .withIndex("by_expires_at", (q) => q.lte("expiresAt", now))
+                .take(100);
         }
 
         return {
-            deleted: expiredRecords.length,
+            deleted,
         };
     },
 });

--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -323,8 +323,8 @@ export const getSummary = query({
     args: {},
     handler: async (ctx) => {
         const [pending, processing, completed, failed, cancelled] = await Promise.all([
-            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "pending")).collect(),
-            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "processing")).collect(),
+            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "pending")).take(100),
+            ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "processing")).take(100),
             ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "completed")).order("desc").take(100),
             ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "failed")).order("desc").take(100),
             ctx.db.query("analysis_tasks").withIndex("by_status", q => q.eq("status", "cancelled")).order("desc").take(100),

--- a/packages/convex/convex/job_descriptions.ts
+++ b/packages/convex/convex/job_descriptions.ts
@@ -52,19 +52,18 @@ export const list = query({
             .withIndex("by_type", (q) => q.eq("type", "system"))
             .collect();
 
-        // Fetch custom JDs via workspace index, then filter by userId
-        const allCustomJDs = await ctx.db
+        // Fetch custom JDs filtered by workspace via compound index
+        const customJDs = await ctx.db
             .query("job_descriptions")
-            .withIndex("by_type", (q) => q.eq("type", "custom"))
+            .withIndex("by_type_workspace", (q) => q.eq("type", "custom").eq("workspaceSlug", workspaceSlug))
             .collect();
 
-        let customJDs = allCustomJDs.filter((jd) => belongsToWorkspace(jd.workspaceSlug, workspaceSlug));
-
+        let filtered = customJDs;
         if (args.userId) {
-            customJDs = customJDs.filter(jd => jd.userId === args.userId || !jd.userId);
+            filtered = customJDs.filter(jd => jd.userId === args.userId || !jd.userId);
         }
 
-        return [...systemJDs, ...customJDs]
+        return [...systemJDs, ...filtered]
             .filter(jd => jd.enabled !== false)
             .map(normalizeJobDescriptionRecord)
             .sort((a, b) => b.lastModified - a.lastModified);
@@ -163,12 +162,10 @@ export const list_all = query({
             .collect();
         const customJDs = await ctx.db
             .query("job_descriptions")
-            .withIndex("by_type", (q) => q.eq("type", "custom"))
+            .withIndex("by_type_workspace", (q) => q.eq("type", "custom").eq("workspaceSlug", workspaceSlug))
             .collect();
 
-        const workspaceCustom = customJDs.filter((jd) => belongsToWorkspace(jd.workspaceSlug, workspaceSlug));
-
-        return [...systemJDs, ...workspaceCustom]
+        return [...systemJDs, ...customJDs]
             .map(normalizeJobDescriptionRecord);
     },
 });
@@ -183,12 +180,10 @@ export const listAllForWorkspace = internalQuery({
             .collect();
         const customJDs = await ctx.db
             .query("job_descriptions")
-            .withIndex("by_type", (q) => q.eq("type", "custom"))
+            .withIndex("by_type_workspace", (q) => q.eq("type", "custom").eq("workspaceSlug", workspaceSlug))
             .collect();
 
-        const workspaceCustom = customJDs.filter((jd) => belongsToWorkspace(jd.workspaceSlug, workspaceSlug));
-
-        return [...systemJDs, ...workspaceCustom]
+        return [...systemJDs, ...customJDs]
             .map(normalizeJobDescriptionRecord);
     },
 });

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -169,11 +169,11 @@ export const list = query({
         const pendingTasks = await ctx.db
             .query("collection_tasks")
             .withIndex("by_status", (q) => q.eq("status", "pending"))
-            .collect();
+            .take(100);
         const processingTasks = await ctx.db
             .query("collection_tasks")
             .withIndex("by_status", (q) => q.eq("status", "processing"))
-            .collect();
+            .take(100);
         // Plus the 20 most recent finished tasks
         const activeIds = new Set([...pendingTasks, ...processingTasks].map(t => t._id));
         const recent = await ctx.db
@@ -345,7 +345,7 @@ export const failStalePending = mutation({
         const pendingTasks = await ctx.db
             .query("collection_tasks")
             .withIndex("by_status", (q) => q.eq("status", "pending").lt("_creationTime", staleThreshold))
-            .collect();
+            .take(100);
 
         let failed = 0;
         const failedTaskIds: string[] = [];

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -223,7 +223,8 @@ export default defineSchema({
     })
         .index("by_slug", ["slug"])
         .index("by_workspace", ["workspaceSlug"])
-        .index("by_type", ["type"]),
+        .index("by_type", ["type"])
+        .index("by_type_workspace", ["type", "workspaceSlug"]),
 
     analysis_tasks: defineTable({
         idempotencyKey: v.optional(v.string()),
@@ -359,7 +360,8 @@ export default defineSchema({
     })
         .index("by_sessionKey", ["sessionKey"])
         .index("by_status", ["status"])
-        .index("by_workspace", ["workspaceSlug"]),
+        .index("by_workspace", ["workspaceSlug"])
+        .index("by_sessionKey_status", ["sessionKey", "status"]),
 
     search_history: defineTable({
         sessionKey: v.string(),

--- a/packages/convex/convex/sessions.ts
+++ b/packages/convex/convex/sessions.ts
@@ -166,8 +166,7 @@ export const getActiveSession = query({
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
         const sessions = await ctx.db
             .query("screening_sessions")
-            .withIndex("by_sessionKey", (q) => q.eq("sessionKey", args.sessionKey))
-            .filter((q) => q.eq(q.field("status"), "active"))
+            .withIndex("by_sessionKey_status", (q) => q.eq("sessionKey", args.sessionKey).eq("status", "active"))
             .collect();
 
         const filtered = sessions
@@ -198,8 +197,7 @@ export const saveSession = mutation({
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
         const existingSessions = await ctx.db
             .query("screening_sessions")
-            .withIndex("by_sessionKey", (q) => q.eq("sessionKey", args.sessionKey))
-            .filter((q) => q.eq(q.field("status"), "active"))
+            .withIndex("by_sessionKey_status", (q) => q.eq("sessionKey", args.sessionKey).eq("status", "active"))
             .collect();
         const existing = existingSessions.find((session) => belongsToWorkspace(session.workspaceSlug, workspaceSlug));
 
@@ -242,8 +240,7 @@ export const addReviewedItem = mutation({
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
         const sessions = await ctx.db
             .query("screening_sessions")
-            .withIndex("by_sessionKey", (q) => q.eq("sessionKey", args.sessionKey))
-            .filter((q) => q.eq(q.field("status"), "active"))
+            .withIndex("by_sessionKey_status", (q) => q.eq("sessionKey", args.sessionKey).eq("status", "active"))
             .collect();
         const session = sessions.find((item) => belongsToWorkspace(item.workspaceSlug, workspaceSlug));
 
@@ -277,8 +274,7 @@ export const archiveSession = mutation({
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
         const sessions = await ctx.db
             .query("screening_sessions")
-            .withIndex("by_sessionKey", (q) => q.eq("sessionKey", args.sessionKey))
-            .filter((q) => q.eq(q.field("status"), "active"))
+            .withIndex("by_sessionKey_status", (q) => q.eq("sessionKey", args.sessionKey).eq("status", "active"))
             .collect();
         const session = sessions.find((item) => belongsToWorkspace(item.workspaceSlug, workspaceSlug));
 


### PR DESCRIPTION
## Summary
- Add `by_type_workspace` compound index to `job_descriptions` — eliminates full-table collect + JS filter for workspace-scoped queries
- Add `by_sessionKey_status` compound index to `screening_sessions` — replaces `.filter()` after index scan with direct compound lookup
- Bound remaining unbounded `.collect()` calls in `analysis_tasks.getSummary`, `resume_tasks.list`, `resume_tasks.failStalePending` with `.take(100)`
- Batch `ai_summary_cache.cleanupExpired` deletes in `.take(100)` loop to avoid unbounded collect

## Test plan
- [ ] `make check-node` passes (0 errors)
- [ ] CI tests pass
- [ ] Verify JD list/list_all/listAllForWorkspace still return correct results
- [ ] Verify session getActiveSession/saveSession/addReviewedItem/archiveSession still work