### PR TITLE
fix(web): add retry to exact-keyword-match API call

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -1161,23 +1161,26 @@ export function useConvexResumes(
       }
     }
 
-    void rawApiClient
-      .POST<{
-        success: boolean
-        results?: Array<{
-          resumeId: string
-          score: number
-          recommendation: string
-        }>
-      }>('/api/resumes/match', {
-        body: {
-          source: 'convex',
-          persist: false,
-          mode: 'rules_only',
-          jobDescriptionId: normalizedJobDescriptionId,
-          resumeIds: exactKeywordResumeIds,
-        },
-      })
+    void withRetry(() =>
+      rawApiClient
+        .POST<{
+          success: boolean
+          results?: Array<{
+            resumeId: string
+            score: number
+            recommendation: string
+          }>
+        }>('/api/resumes/match', {
+          body: {
+            source: 'convex',
+            persist: false,
+            mode: 'rules_only',
+            jobDescriptionId: normalizedJobDescriptionId,
+            resumeIds: exactKeywordResumeIds,
+          },
+        }),
+      { maxRetries: 2, baseDelayMs: 600 }
+    )
       .then(({ data, error }) => {
         if (!active) {
           return


### PR DESCRIPTION
## Summary
- Wrap `/api/resumes/match` POST with `withRetry` (2 retries, 600ms base delay)
- This was the only fetch in `useConvexResumes.ts` without retry logic
- Transient failures previously produced empty match scores silently

## Test plan
- [ ] TypeScript check passes
- [ ] CI tests pass