### PR TITLE
fix(convex): bound candidate queries and fix bulkUpsert N+1

### DIFF
--- a/apps/web/src/components/search/SnippetCardExpanded.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.tsx
@@ -336,6 +336,7 @@ export function SnippetCardExpanded({
                 <div className="flex items-center justify-between gap-3 text-sm text-slate-700">
                   <span className="font-medium text-xs">{statusLabel}</span>
                   <select
+                    aria-label={statusLabel}
                     className="flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                     value={candidateStatus}
                     onChange={(event) => {

--- a/packages/convex/convex/candidate_blocks.ts
+++ b/packages/convex/convex/candidate_blocks.ts
@@ -21,7 +21,7 @@ export const list = query({
         return await ctx.db
             .query("candidate_blocks")
             .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
-            .collect();
+            .take(500);
     },
 });
 
@@ -136,13 +136,15 @@ export const bulkUpsert = mutation({
         let inserted = 0;
         const now = Date.now();
 
+        // Fetch all existing blocks for this workspace in one query
+        const existingBlocks = await ctx.db
+            .query("candidate_blocks")
+            .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
+            .take(500);
+        const existingMap = new Map(existingBlocks.map((block) => [block.identityKey, block]));
+
         for (const identityKey of identityKeys) {
-            const existing = await ctx.db
-                .query("candidate_blocks")
-                .withIndex("by_workspace_identity", (q) =>
-                    q.eq("workspaceSlug", workspaceSlug).eq("identityKey", identityKey)
-                )
-                .unique();
+            const existing = existingMap.get(identityKey);
 
             if (existing) {
                 await ctx.db.patch(existing._id, {

--- a/packages/convex/convex/candidate_status.ts
+++ b/packages/convex/convex/candidate_status.ts
@@ -22,7 +22,7 @@ export const listForBackup = query({
         const rows = await ctx.db
             .query("candidate_status")
             .withIndex("by_workspace_status", (q) => q.eq("workspaceSlug", workspaceSlug))
-            .collect();
+            .take(1000);
         return rows.map((row) => ({
             identityKey: row.identityKey,
             status: row.status,
@@ -43,7 +43,7 @@ export const list = query({
         return await ctx.db
             .query("candidate_status")
             .withIndex("by_workspace_status", (q) => q.eq("workspaceSlug", workspaceSlug))
-            .collect();
+            .take(500);
     },
 });
 


### PR DESCRIPTION
## Summary
- Bound `candidate_blocks.list` and `candidate_status.list` with `.take(500)` to prevent unbounded collects
- Bound `candidate_status.listForBackup` with `.take(1000)` for backup safety
- Replace N+1 per-key queries in `candidate_blocks.bulkUpsert` with single workspace fetch + in-memory Map lookup
- Add `aria-label` to SnippetCardExpanded status select dropdown

## Test plan
- [ ] `make check-node` passes
- [ ] CI tests pass
- [ ] Candidate block/status operations still work correctly