### PR TITLE
fix: bound remaining unbounded queries + ResumeCard memo

### DIFF
--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -31,7 +31,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { useMemo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
 import { OutreachModal } from './OutreachModal'
 import { Select } from '@/components/ui/select'
@@ -142,7 +142,7 @@ export function ResumeCardSkeleton() {
 }
 
 
-export function ResumeCard({
+export const ResumeCard = memo(function ResumeCard({
   resume,
   onViewDetails,
   matchResult,
@@ -802,4 +802,4 @@ export function ResumeCard({
       </Dialog>
     </div>
   )
-}
+})

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -695,8 +695,8 @@ export const getSummary = query({
     args: {},
     handler: async (ctx) => {
         const [pending, processing, completed, failed, cancelled] = await Promise.all([
-            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "pending")).collect(),
-            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "processing")).collect(),
+            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "pending")).take(500),
+            ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "processing")).take(500),
             ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "completed")).order("desc").take(100),
             ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "failed")).order("desc").take(100),
             ctx.db.query("collection_tasks").withIndex("by_status", q => q.eq("status", "cancelled")).order("desc").take(100),

--- a/packages/convex/convex/sessions.ts
+++ b/packages/convex/convex/sessions.ts
@@ -337,7 +337,7 @@ export const recentSearches = query({
         const records = await ctx.db
             .query("search_history")
             .withIndex("by_sessionKey", (q) => q.eq("sessionKey", args.sessionKey))
-            .collect();
+            .take(limit * 2);
 
         return sortByHistoryRecency(records
             .filter((record) => belongsToWorkspace(record.workspaceSlug, workspaceSlug)))


### PR DESCRIPTION
## Summary
- `sessions.recentSearches`: replace `.collect()` with `.take(limit * 2)` to bound search_history query
- `resume_tasks.getSummary`: replace pending/processing `.collect()` with `.take(500)`
- `ResumeCard`: wrap in `React.memo` to skip re-renders when rendered in list loops

## Test plan
- [x] `make check-node` passes (0 errors)