### PR TITLE
fix: parallelize deleteResumes queries + RunItem memo

### DIFF
--- a/apps/web/src/components/MatchRunHistory.tsx
+++ b/apps/web/src/components/MatchRunHistory.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { CheckCircle2, ChevronDown, ChevronUp, Clock, Loader2, XCircle } from 'lucide-react'
 import { useMatchRunHistory, type MatchRunItem } from '@/hooks/useMatchRunHistory'
@@ -37,7 +37,7 @@ function runModeLabel(mode: MatchRunItem['mode']): string {
   return 'Hybrid'
 }
 
-function RunItem({ run }: { run: MatchRunItem }) {
+const RunItem = memo(function RunItem({ run }: { run: MatchRunItem }) {
   const { t } = useTranslation()
   const total = Math.max(run.totalCount, 1)
   const current = Math.min(Math.max(run.processedCount, 0), total)
@@ -94,7 +94,7 @@ function RunItem({ run }: { run: MatchRunItem }) {
       ) : null}
     </div>
   )
-}
+})
 
 export function MatchRunHistory({ sessionId, jobDescriptionId }: MatchRunHistoryProps) {
   const { t } = useTranslation()

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -3369,14 +3369,18 @@ export const deleteResumes = mutation({
         }
 
         let deletedAiTaggingResults = 0;
-        // Collect all tagging results for all resumeIds in one pass, then batch delete
+        // Collect all tagging results for all resumeIds in parallel, then batch delete
         const allTaggingResults: Array<{ _id: Id<"ai_tagging_results"> }> = [];
-        for (const resumeId of existingResumeIds) {
-            const taggingResults = await ctx.db
-                .query("ai_tagging_results")
-                .withIndex("by_resume_profile", (q) => q.eq("resumeId", resumeId))
-                .collect();
-            allTaggingResults.push(...taggingResults);
+        const taggingBatches = await Promise.all(
+            existingResumeIds.map((resumeId) =>
+                ctx.db
+                    .query("ai_tagging_results")
+                    .withIndex("by_resume_profile", (q) => q.eq("resumeId", resumeId))
+                    .collect()
+            )
+        );
+        for (const batch of taggingBatches) {
+            allTaggingResults.push(...batch);
         }
         for (const taggingResult of allTaggingResults) {
             await ctx.db.delete(taggingResult._id);


### PR DESCRIPTION
## Summary
- `resumes.deleteResumes`: replace sequential N+1 queries with `Promise.all` for `ai_tagging_results` cleanup
- `MatchRunHistory`: wrap `RunItem` in `React.memo` to skip re-renders in list

## Test plan
- [x] `make check-node` passes (0 errors)