### PR TITLE
fix: bound remaining unbounded .collect() calls

### DIFF
--- a/packages/convex/convex/search_profiles.ts
+++ b/packages/convex/convex/search_profiles.ts
@@ -169,7 +169,7 @@ export const list = query({
     const records = await ctx.db
       .query("search_profiles")
       .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
-      .collect();
+      .take(200);
     return records.sort((left, right) => {
       const leftUpdated = left.updatedAt ?? left.lastRunAt ?? left._creationTime;
       const rightUpdated = right.updatedAt ?? right.lastRunAt ?? right._creationTime;
@@ -198,7 +198,7 @@ export const getById = query({
     const records = await ctx.db
       .query("search_profiles")
       .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
-      .collect();
+      .take(500);
     const found = findSearchProfileRecordById(records, args.id, workspaceSlug);
     if (!found) {
       return null;
@@ -260,7 +260,7 @@ export const update = mutation({
       const records = await ctx.db
         .query("search_profiles")
         .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
-        .collect();
+        .take(500);
       existing = findSearchProfileRecordById(records, args.id, workspaceSlug);
     }
     if (!existing) {
@@ -308,7 +308,7 @@ export const remove = mutation({
       const records = await ctx.db
         .query("search_profiles")
         .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
-        .collect();
+        .take(500);
       existing = findSearchProfileRecordById(records, args.id, workspaceSlug);
     }
     if (!existing) {

--- a/packages/convex/convex/sessions.ts
+++ b/packages/convex/convex/sessions.ts
@@ -167,7 +167,7 @@ export const getActiveSession = query({
         const sessions = await ctx.db
             .query("screening_sessions")
             .withIndex("by_sessionKey_status", (q) => q.eq("sessionKey", args.sessionKey).eq("status", "active"))
-            .collect();
+            .take(10);
 
         const filtered = sessions
             .filter((session) => belongsToWorkspace(session.workspaceSlug, workspaceSlug))
@@ -241,7 +241,7 @@ export const addReviewedItem = mutation({
         const sessions = await ctx.db
             .query("screening_sessions")
             .withIndex("by_sessionKey_status", (q) => q.eq("sessionKey", args.sessionKey).eq("status", "active"))
-            .collect();
+            .take(10);
         const session = sessions.find((item) => belongsToWorkspace(item.workspaceSlug, workspaceSlug));
 
         if (!session) {
@@ -275,7 +275,7 @@ export const archiveSession = mutation({
         const sessions = await ctx.db
             .query("screening_sessions")
             .withIndex("by_sessionKey_status", (q) => q.eq("sessionKey", args.sessionKey).eq("status", "active"))
-            .collect();
+            .take(10);
         const session = sessions.find((item) => belongsToWorkspace(item.workspaceSlug, workspaceSlug));
 
         if (session) {

--- a/packages/convex/convex/taxonomy_clusters.ts
+++ b/packages/convex/convex/taxonomy_clusters.ts
@@ -71,11 +71,11 @@ export const list = query({
                 .withIndex("by_workspace_status", (q) =>
                     q.eq("workspaceSlug", workspaceSlug).eq("status", args.status as TaxonomyStatus)
                 )
-                .collect()
+                .take(500)
             : await ctx.db
                 .query("taxonomy_clusters")
                 .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
-                .collect();
+                .take(500);
 
         return records.sort((left, right) => {
             if (left.status !== right.status) {
@@ -180,7 +180,7 @@ export const suggest = mutation({
         const existingClusters = await ctx.db
             .query("taxonomy_clusters")
             .withIndex("by_workspace", (q) => q.eq("workspaceSlug", workspaceSlug))
-            .collect();
+            .take(500);
         const clusteredTags = new Set(
             existingClusters.flatMap((cluster) => cluster.tags.map((tag) => tag.trim().toLowerCase()))
         );


### PR DESCRIPTION
## Summary
- `taxonomy_clusters.list`/`listByWorkspace`: `.collect()` → `.take(500)`
- `sessions`: 4 handlers with `.collect()` → `.take(10)` (only need one session per query)
- `search_profiles.list`: `.collect()` → `.take(200)`
- `search_profiles.getById`/`update`/`remove` fallback scans: `.collect()` → `.take(500)`

## Test plan
- [x] `make check-node` passes (0 errors)