### PR TITLE
feat(convex): add filterFields to search index + fix rating enum

### DIFF
--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -309,6 +309,7 @@ export const CandidateActionBackupSchema = z
       "archive",
       "note",
       "contact",
+      "rating",
       "ai_score_like",
       "ai_score_unlike",
       "ai_summary_like",

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -7653,7 +7653,7 @@ export interface components {
              * @example archive
              * @enum {string}
              */
-            actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
+            actionType: "star" | "shortlist" | "reject" | "archive" | "note" | "contact" | "rating" | "ai_score_like" | "ai_score_unlike" | "ai_summary_like" | "ai_summary_unlike";
             /**
              * @example {
              *       "scopeId": "session-123"

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -1556,8 +1556,7 @@ async function runSearchWithTagExpansionPageQuery(
     const matches = searchQuery
         ? await ctx.db
             .query("resumes")
-            .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery))
-            .filter((q) => q.neq(q.field("isArchived"), true))
+            .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery).eq("isArchived", undefined))
             .take(takeLimit)
         : [];
 
@@ -1663,8 +1662,7 @@ async function runSearchWithTagExpansionScanPageQuery(
     const searchPage = searchQuery
         ? await ctx.db
             .query("resumes")
-            .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery))
-            .filter((q) => q.neq(q.field("isArchived"), true))
+            .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery).eq("isArchived", undefined))
             .paginate({
                 ...args.paginationOpts,
                 numItems: pageSize,
@@ -2272,8 +2270,7 @@ export const search = query({
 
         const matches = await ctx.db
             .query("resumes")
-            .withSearchIndex("search_body", (q) => q.search("searchText", args.query))
-            .filter((q) => q.neq(q.field("isArchived"), true))
+            .withSearchIndex("search_body", (q) => q.search("searchText", args.query).eq("isArchived", undefined))
             .take(fetchLimit);
 
         // Convex full-text search uses OR. Post-filter to enforce AND.
@@ -2300,8 +2297,7 @@ export const searchWithIngestData = query({
 
         const matches = await ctx.db
             .query("resumes")
-            .withSearchIndex("search_body", (q) => q.search("searchText", args.query))
-            .filter((q) => q.neq(q.field("isArchived"), true))
+            .withSearchIndex("search_body", (q) => q.search("searchText", args.query).eq("isArchived", undefined))
             .take(fetchLimit);
 
         // Convex full-text search uses OR. Post-filter to enforce AND.
@@ -2361,8 +2357,7 @@ export const searchWithTagExpansion = query({
         const matches = searchQuery
             ? await ctx.db
                 .query("resumes")
-                .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery))
-                .filter((q) => q.neq(q.field("isArchived"), true))
+                .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery).eq("isArchived", undefined))
                 .take(fetchLimit)
             : [];
 
@@ -2756,8 +2751,7 @@ export const collectSearchIndexDocIds = internalQuery({
     handler: async (ctx, args) => {
         const page = await ctx.db
             .query("resumes")
-            .withSearchIndex("search_body", (q) => q.search("searchText", args.searchQuery))
-            .filter((q) => q.neq(q.field("isArchived"), true))
+            .withSearchIndex("search_body", (q) => q.search("searchText", args.searchQuery).eq("isArchived", undefined))
             .paginate({
                 cursor: args.cursor ?? null,
                 numItems: Math.min(args.numItems ?? 256, 256),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -185,6 +185,7 @@ export default defineSchema({
         .index("by_sourceKey", ["sourceKey"])
         .searchIndex("search_body", {
             searchField: "searchText",
+            filterFields: ["isArchived"],
         }),
 
     // Optional: Search Profiles (if we want to store user configs)


### PR DESCRIPTION
## Summary
- Add `filterFields: ["isArchived"]` to `search_body` search index in Convex schema
- Replace post-query `.filter()` with index-backed `.eq("isArchived", undefined)` on all 6 search index queries
- Add `"rating"` to `CandidateActionBackupSchema` enum for v0.2.0 HR feedback restore

## Impact
Search index optimization moves isArchived filtering from post-query evaluation to index-level pruning, reducing document reads per search query. The `rating` enum fix enables restore of prod v0.2.0 data with HR feedback actions.

## Test plan
- [x] `make check-node` passes (0 errors, 5 pre-existing warnings)
- [ ] Verify search results still exclude archived resumes after deploy