### PR TITLE
perf: lazy-load OutreachModal and SearchAssistantDrawer

### DIFF
--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -1,5 +1,5 @@
 import { formatKeywordInput, isSalesRequiredContext, normalizeKeywordPhrases, parseKeywordQuery } from '@trends/shared'
-import { useCallback, useEffect, useMemo, useRef, useState, type ComponentProps } from 'react'
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState, type ComponentProps } from 'react'
 import { MessageSquareMore, Pencil, RotateCcw } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
@@ -7,7 +7,8 @@ import { useQuery } from 'convex/react'
 import { JobDescriptionSelect } from './JobDescriptionSelect'
 import { JobDescriptionEditor } from './JobDescriptionEditor'
 import { KeywordChips } from './KeywordChips'
-import { SearchAssistantDrawer } from './SearchAssistantDrawer'
+
+const SearchAssistantDrawer = lazy(() => import('./SearchAssistantDrawer').then((m) => ({ default: m.SearchAssistantDrawer })))
 import { type SearchProfileDetails, type SearchProfileFilters } from './SearchProfileEditorDialog'
 import { rawApiClient } from '@/lib/api-helpers'
 import { Button } from '@/components/ui/button'
@@ -1335,38 +1336,40 @@ export function QuickStartPanel({
         onSaveSuccess={handleJdEditorSaveSuccess}
       />
 
-      <SearchAssistantDrawer
-        open={assistantOpen}
-        onOpenChange={setAssistantOpen}
-        location={location}
-        keywords={normalizedKeywords}
-        jobDescriptionId={jobDescriptionId}
-        workflows={workflowSeeds.map((workflow) => ({
-          id: workflow.id,
-          label: workflow.label,
-          location: workflow.location,
-          keywords: normalizeKeywordPhrases(workflow.keywords),
-        }))}
-        onApplyWorkflow={(workflow) => {
-          const nextWorkflow = workflowSeeds.find((item) => item.id === workflow.id)
-          if (!nextWorkflow) {
-            return
-          }
-          handleApplyWorkflow(nextWorkflow)
-        }}
-        matching={matching}
-        matchedProfile={autoMatchResult ? {
-          name: autoMatchResult.profile.name,
-          confidence: autoMatchResult.confidence,
-          jobDescriptionId: autoMatchResult.profile.jobDescription,
-          matchedKeywords: autoMatchResult.matchedKeywords,
-          filterSummary: getFilterSummary(autoMatchResult.profile, yearsLabel, ageUnit),
-        } : null}
-        onUseMatchedProfile={handleUseMatchedConfig}
-        historyItems={assistantHistory}
-        historyLoading={assistantHistoryLoading}
-        onApplyHistoryItem={onApplyAssistantHistory}
-      />
+      <Suspense fallback={null}>
+        <SearchAssistantDrawer
+          open={assistantOpen}
+          onOpenChange={setAssistantOpen}
+          location={location}
+          keywords={normalizedKeywords}
+          jobDescriptionId={jobDescriptionId}
+          workflows={workflowSeeds.map((workflow) => ({
+            id: workflow.id,
+            label: workflow.label,
+            location: workflow.location,
+            keywords: normalizeKeywordPhrases(workflow.keywords),
+          }))}
+          onApplyWorkflow={(workflow) => {
+            const nextWorkflow = workflowSeeds.find((item) => item.id === workflow.id)
+            if (!nextWorkflow) {
+              return
+            }
+            handleApplyWorkflow(nextWorkflow)
+          }}
+          matching={matching}
+          matchedProfile={autoMatchResult ? {
+            name: autoMatchResult.profile.name,
+            confidence: autoMatchResult.confidence,
+            jobDescriptionId: autoMatchResult.profile.jobDescription,
+            matchedKeywords: autoMatchResult.matchedKeywords,
+            filterSummary: getFilterSummary(autoMatchResult.profile, yearsLabel, ageUnit),
+          } : null}
+          onUseMatchedProfile={handleUseMatchedConfig}
+          historyItems={assistantHistory}
+          historyLoading={assistantHistoryLoading}
+          onApplyHistoryItem={onApplyAssistantHistory}
+        />
+      </Suspense>
     </div>
   )
 }

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -31,9 +31,10 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { memo, useMemo, useState } from 'react'
+import { Suspense, lazy, memo, useMemo, useState } from 'react'
 import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
-import { OutreachModal } from './OutreachModal'
+
+const OutreachModal = lazy(() => import('./OutreachModal').then((m) => ({ default: m.OutreachModal })))
 import { Select } from '@/components/ui/select'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
@@ -643,21 +644,23 @@ export const ResumeCard = memo(function ResumeCard({
               </Button>
             </div>
 
-            <OutreachModal
-              isOpen={showOutreach}
-              onClose={() => setShowOutreach(false)}
-              resume={resume}
-              jobDescription={jobDescription ? {
-                ...jobDescription,
-                requirements: jobDescription.requirements || ''
-              } : {
-                id: jobDescriptionId || 'default',
-                title: t('resumes.card.currentPosition', { defaultValue: 'Current Position' }),
-                requirements: ''
-              }}
-              analysis={matchResult}
-              onSuccess={() => onAction?.('contact')}
-            />
+            <Suspense fallback={null}>
+              <OutreachModal
+                isOpen={showOutreach}
+                onClose={() => setShowOutreach(false)}
+                resume={resume}
+                jobDescription={jobDescription ? {
+                  ...jobDescription,
+                  requirements: jobDescription.requirements || ''
+                } : {
+                  id: jobDescriptionId || 'default',
+                  title: t('resumes.card.currentPosition', { defaultValue: 'Current Position' }),
+                  requirements: ''
+                }}
+                analysis={matchResult}
+                onSuccess={() => onAction?.('contact')}
+              />
+            </Suspense>
           </div>
           <div className="text-sm text-muted-foreground">
             {resume.age || '--'} | {resume.experience || '--'} | {resume.education || '--'} |{' '}


### PR DESCRIPTION
## Summary
- Convert OutreachModal to `React.lazy()` in ResumeCard.tsx
- Convert SearchAssistantDrawer to `React.lazy()` in QuickStartPanel.tsx
- Both modals are rarely shown but were eagerly imported, adding ~500 lines to initial bundle
- Deferred loading until user actually opens the modal

## Test plan
- [x] `make check-node` passes (0 errors)
- [ ] Open outreach modal from ResumeCard — should load and render correctly
- [ ] Open search assistant drawer from QuickStartPanel — should load and render correctly