### PR TITLE
fix: add scroll-padding-top for sticky header focus visibility

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -53,6 +53,9 @@
   * {
     @apply border-border;
   }
+  html {
+    scroll-padding-top: 3.5rem;
+  }
   body {
     @apply bg-background text-foreground;
   }


### PR DESCRIPTION
## Summary
- Adds `scroll-padding-top: 3.5rem` to the `html` element in global CSS
- Fixes WCAG 2.4.11 (Focus Not Obscured) — the sticky header (h-14/56px, z-50) can obscure focused elements when keyboard navigation triggers browser auto-scroll

## Test plan
- [x] `make check-node` passes (0 errors, 5 pre-existing warnings)
- [ ] Verify with keyboard navigation: Tab through search results and confirm focused elements scroll below the header