### PR TITLE
fix: useStableQuery to eliminate loading flashes on navigation

### DIFF
--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -1,6 +1,6 @@
 import { formatKeywordQuery, getVerifiedRoleSignalYears, isSalesRequiredContext, parseKeywordQuery } from '@trends/shared'
 import { hasMatchingRoleSignal, matchesSalaryFilter } from '@/hooks/resume-filter-helpers'
-import { useMutation, useQuery } from 'convex/react'
+import { useMutation } from 'convex/react'
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { api } from '../../../../packages/convex/convex/_generated/api'
@@ -8,6 +8,7 @@ import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { useCandidateActions } from '@/hooks/useCandidateActions'
 import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
 import { useCandidateStatus } from '@/hooks/useCandidateStatus'
+import { useStableQuery } from '@/hooks/useStableQuery'
 import {
   useConvexResumes,
   type ConvexResumeFilters,
@@ -649,13 +650,13 @@ export function useResumeSearchState() {
     api.sessions.markSearchHistoryOpened,
   )
   const dispatchAnalysis = useMutation(api.analysis_tasks.dispatch)
-  const analysisTasks = useQuery(api.analysis_tasks.list)
-  const recentSearchHistoryRecords = useQuery(api.sessions.recentSearches, {
+  const analysisTasks = useStableQuery(api.analysis_tasks.list)
+  const recentSearchHistoryRecords = useStableQuery(api.sessions.recentSearches, {
     sessionKey,
     workspaceSlug: slug,
     limit: 10,
   })
-  const taxonomyClusterRecords = useQuery(api.taxonomy_clusters.list, {
+  const taxonomyClusterRecords = useStableQuery(api.taxonomy_clusters.list, {
     workspaceSlug: slug,
     status: 'active',
   })

--- a/apps/web/src/hooks/useStableQuery.ts
+++ b/apps/web/src/hooks/useStableQuery.ts
@@ -1,0 +1,23 @@
+import { useRef } from 'react'
+import { useQuery } from 'convex/react'
+import type { FunctionReference, FunctionReturnType, OptionalRestArgs } from 'convex/server'
+
+/**
+ * Wraps Convex `useQuery` to hold stale data during transitions.
+ * When a component remounts (e.g., back/forward navigation), `useQuery`
+ * returns `undefined` while re-subscribing — causing a loading flash.
+ * This hook returns the last non-undefined result instead.
+ */
+export function useStableQuery<Query extends FunctionReference<'query'>>(
+  query: Query,
+  ...args: OptionalRestArgs<Query>
+): FunctionReturnType<Query> | undefined {
+  const result = useQuery(query, ...args)
+  const stableRef = useRef(result)
+
+  if (result !== undefined) {
+    stableRef.current = result
+  }
+
+  return stableRef.current
+}


### PR DESCRIPTION
## Summary
- Adds `useStableQuery` hook — wraps Convex `useQuery` with a React ref that holds the last non-undefined result
- When navigating back to the search page, `useQuery` returns `undefined` while re-subscribing — this hook returns stale data instead, eliminating the loading flash
- Applied to 3 search page queries: `analysisTasks`, `recentSearches`, `taxonomyClusters`

## Test plan
- [x] `make check-node` passes (0 errors, 5 pre-existing warnings)
- [ ] Navigate to search page, click into a resume detail, press browser back — verify no loading spinner appears for recent searches and taxonomy clusters