### PR TITLE
fix: prefers-reduced-motion + aria-live result count (WCAG 2.3.3, 4.1.3)

### DIFF
--- a/apps/web/src/components/search/SearchHeader.tsx
+++ b/apps/web/src/components/search/SearchHeader.tsx
@@ -82,6 +82,9 @@ export function SearchHeader({
       <div className="flex flex-col gap-3 rounded-[1.5rem] border bg-white/80 px-4 py-3 shadow-sm lg:flex-row lg:items-center lg:justify-between">
         <div className="min-w-0 space-y-2">
           <div className="text-sm font-medium text-slate-900">{resultsLabel}</div>
+          <div role="status" aria-live="polite" className="sr-only">
+            {loading ? '' : resultsLabel}
+          </div>
           <div className="flex flex-wrap gap-2">
             {location ? <Badge variant="outline">{location}</Badge> : null}
             {jobDescriptionId ? <Badge variant="outline">JD {jobDescriptionId}</Badge> : null}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -60,3 +60,14 @@
     @apply bg-background text-foreground;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `@media (prefers-reduced-motion: reduce)` CSS rule to disable all animations/transitions for motion-sensitive users (WCAG 2.3.3)
- Adds `aria-live="polite"` region in SearchHeader to announce search result count to screen readers (WCAG 4.1.3)
- Only announces after loading completes, not during typing

## Test plan
- [x] `make check-node` passes (0 errors, 5 pre-existing warnings)
- [ ] Enable "Reduce motion" in OS settings, verify skeleton loaders and spinners are static
- [ ] With screen reader, perform a search and verify result count is announced