### PR TITLE
feat: daily cron to sweep stuck tasks after 24h

### DIFF
--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -793,3 +793,29 @@ export const processAnalysisTask = internalAction({
         }
     },
 });
+
+/**
+ * Sweep tasks stuck in "processing" for >24 hours back to "failed".
+ * Called by the daily cron job to prevent silent pipeline stalls.
+ */
+export const sweepStuckTasks = internalMutation({
+    args: {},
+    handler: async (ctx) => {
+        const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+        const stuck = await ctx.db
+            .query("analysis_tasks")
+            .withIndex("by_status", (q) => q.eq("status", "processing"))
+            .filter((q) => q.lt(q.field("startedAt"), cutoff))
+            .take(100);
+
+        for (const task of stuck) {
+            await ctx.db.patch(task._id, {
+                status: "failed",
+                error: "Swept: stuck in processing for >24h",
+                completedAt: Date.now(),
+            });
+        }
+
+        return { swept: stuck.length };
+    },
+});

--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -10,4 +10,18 @@ crons.interval(
     {},
 );
 
+crons.daily(
+    "sweep stuck analysis tasks",
+    { hourUTC: 3, minuteUTC: 0 },
+    internal.analysis_tasks.sweepStuckTasks,
+    {},
+);
+
+crons.daily(
+    "sweep stuck collection tasks",
+    { hourUTC: 3, minuteUTC: 15 },
+    internal.resume_tasks.sweepStuckTasks,
+    {},
+);
+
 export default crons;

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -835,3 +835,28 @@ export const resetDatabase = mutation({
         };
     },
 });
+
+/**
+ * Sweep collection tasks stuck in "processing" for >24 hours back to "failed".
+ * Called by the daily cron job to prevent silent pipeline stalls.
+ */
+export const sweepStuckTasks = internalMutation({
+    args: {},
+    handler: async (ctx) => {
+        const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+        const stuck = await ctx.db
+            .query("collection_tasks")
+            .withIndex("by_status", (q) => q.eq("status", "processing"))
+            .filter((q) => q.lt(q.field("startedAt"), cutoff))
+            .take(100);
+
+        for (const task of stuck) {
+            await ctx.db.patch(task._id, {
+                status: "failed",
+                error: "Swept: stuck in processing for >24h",
+            });
+        }
+
+        return { swept: stuck.length };
+    },
+});


### PR DESCRIPTION
## Summary
- Adds two daily Convex cron jobs that sweep tasks stuck in "processing" for >24 hours back to "failed"
- `analysis_tasks.sweepStuckTasks` runs at 3:00 UTC daily
- `resume_tasks.sweepStuckTasks` runs at 3:15 UTC daily
- Both use `.take(100)` to bound query size and set a descriptive error message
- Follows existing cron pattern from `ai_summary_cache.cleanupExpired`

## Test plan
- [x] `make check-node` passes (0 errors, 5 pre-existing warnings)
- [x] Convex TypeScript check passes
- [ ] Verify cron jobs appear in Convex dashboard after deploy
- [ ] Verify a task stuck >24h gets swept to "failed" with the error message