### PR TITLE
feat: add CSP report-only headers and security hardening middleware

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { prettyJSON } from "hono/pretty-json";
+import { secureHeaders } from "hono/secure-headers";
 
 import {
   healthRoutes,
@@ -66,6 +67,22 @@ export function createApp() {
 
   // Middleware
   app.use("*", serverTimingMiddleware);
+  app.use("*", secureHeaders({
+    contentSecurityPolicyReportOnly: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      imgSrc: ["'self'", "data:", "blob:"],
+      connectSrc: ["'self'", "*.convex.cloud"],
+      objectSrc: ["'none'"],
+      frameAncestors: ["'none'"],
+      baseUri: ["'self'"],
+      formAction: ["'self'"],
+    },
+    xFrameOptions: "DENY",
+    xContentTypeOptions: "nosniff",
+    referrerPolicy: "strict-origin-when-cross-origin",
+  }));
   app.use(
     "*",
     cors({


### PR DESCRIPTION
## Summary
- Add Hono `secureHeaders` middleware with CSP in Report-Only mode
- Enforce X-Frame-Options DENY, X-Content-Type-Options nosniff, strict referrer policy
- CSP rules cover default-src, script-src, style-src, img-src, connect-src (Convex), object-src, frame-ancestors, base-uri, form-action

## Test plan
- [x] `make check-node` passes (0 errors)
- [ ] Verify /doc and /health endpoints return security headers
- [ ] Verify CSP-Report-Only header present in responses