### PR TITLE
feat: add search term highlighting in result cards

### DIFF
--- a/apps/web/src/components/search/SearchResultsList.tsx
+++ b/apps/web/src/components/search/SearchResultsList.tsx
@@ -44,6 +44,8 @@ type SearchResultsListProps = {
   onToggleBlock?: (identityKey: string, blocked: boolean, reason?: string) => void
   onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
   getAiFeedback?: (resumeId: string, target: AiFeedbackTarget) => AiFeedbackSentiment | undefined
+  /** Raw search query text for highlighting matches in result cards */
+  searchQuery?: string
 }
 
 function SearchResultsSkeleton() {
@@ -80,6 +82,7 @@ export function SearchResultsList({
   onRating,
   onCandidateStatusChange,
   onToggleBlock,
+  searchQuery,
 }: SearchResultsListProps) {
   const { t } = useTranslation()
   const listRef = useRef<HTMLDivElement | null>(null)
@@ -277,6 +280,7 @@ export function SearchResultsList({
                     showAiScore={showAiScore}
                     onToggleExpanded={onToggleExpanded}
                     onViewDetails={handleViewDetails}
+                    searchQuery={searchQuery}
                     {...cardProps(item)}
                   />
                 </ErrorBoundary>
@@ -308,6 +312,7 @@ export function SearchResultsList({
                   showAiScore={showAiScore}
                   onToggleExpanded={onToggleExpanded}
                   onViewDetails={handleViewDetails}
+                  searchQuery={searchQuery}
                   {...cardProps(presentationItem)}
                 />
               </ErrorBoundary>

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -23,6 +23,7 @@ import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import { SnippetCardExpanded } from '@/components/search/SnippetCardExpanded'
 import { StarRating } from '@/components/StarRating'
 import { getResumeContentLocale, getResumeSourceLabel, getExperienceBadge, isSafeProfileUrl, summarizeBrandHits } from '@/lib/resume-scoring'
+import { highlightTerms } from '@/lib/highlight'
 import { useBrandDisplayMap } from '@/hooks/useBrandDisplayMap'
 import { cn } from '@/lib/utils'
 import type { CandidateActionType, CandidateStatus, AiFeedbackSentiment, AiFeedbackTarget } from '@/types/resume'
@@ -45,6 +46,8 @@ type SnippetCardProps = {
   onToggleBlock?: (identityKey: string, blocked: boolean, reason?: string) => void
   aiScoreFeedback?: AiFeedbackSentiment
   onAiFeedback?: (target: AiFeedbackTarget, sentiment: AiFeedbackSentiment) => void
+  /** Raw search query text for highlighting matches in the card */
+  searchQuery?: string
 }
 
 const STATUS_OPTIONS: Array<{ value: CandidateStatus; labelKey: string }> = [
@@ -93,11 +96,16 @@ export const SnippetCard = memo(function SnippetCard({
   onRating,
   onCandidateStatusChange,
   onToggleBlock,
+  searchQuery,
 }: SnippetCardProps) {
   const { t } = useTranslation()
   const contentLocale = getResumeContentLocale(item.resume)
   const resumeSourceLabel = getResumeSourceLabel(item.resume)
   const analysis = item.analysis ?? item.resume.analysis
+  const searchTerms = useMemo(
+    () => (searchQuery ? searchQuery.split(/\s+/).filter(Boolean) : []),
+    [searchQuery],
+  )
   const visibleKeywords = (
     item.resume.ingestData?.industryTags
     ?? item.resume._provenance?.map((entry) => entry.term)
@@ -301,10 +309,10 @@ export const SnippetCard = memo(function SnippetCard({
                 target="_blank"
                 rel="noreferrer"
               >
-                {item.resume.name || unnamedResumeLabel}
+                {highlightTerms(item.resume.name || unnamedResumeLabel, searchTerms)}
               </a>
             ) : (
-              <span className="font-semibold text-slate-900">{item.resume.name || unnamedResumeLabel}</span>
+              <span className="font-semibold text-slate-900">{highlightTerms(item.resume.name || unnamedResumeLabel, searchTerms)}</span>
             )}
             {item.resume.activityStatus ? (
               <Badge variant="secondary">{item.resume.activityStatus}</Badge>
@@ -345,11 +353,11 @@ export const SnippetCard = memo(function SnippetCard({
 
           {/* Demographics row */}
           <div className="text-sm text-muted-foreground">
-            {item.resume.age || '--'} | {item.resume.experience || '--'} | {item.resume.education || '--'} | {item.resume.location || '--'}
+            {item.resume.age || '--'} | {item.resume.experience || '--'} | {highlightTerms(item.resume.education || '--', searchTerms)} | {highlightTerms(item.resume.location || '--', searchTerms)}
           </div>
 
           {/* Headline / self-intro snippet */}
-          <div className="truncate text-sm text-slate-600">{primaryHeadline}</div>
+          <div className="truncate text-sm text-slate-600">{highlightTerms(primaryHeadline, searchTerms)}</div>
 
           {item.scoreSource === 'ai' && analysis?.summary ? (
             <p className="line-clamp-2 text-xs leading-5 text-slate-500">

--- a/apps/web/src/lib/highlight.tsx
+++ b/apps/web/src/lib/highlight.tsx
@@ -1,0 +1,35 @@
+import { Fragment } from 'react'
+
+/**
+ * Highlight matching segments of `text` that match any of the provided `terms`.
+ * Returns React elements with `<mark>` tags around matched substrings.
+ * Case-insensitive matching. If terms is empty or text is falsy, returns the raw text.
+ */
+export function highlightTerms(
+  text: string | null | undefined,
+  terms: string[],
+): React.ReactNode {
+  if (!text || terms.length === 0) return text ?? null
+
+  const escaped = terms
+    .filter((t) => t.trim().length > 0)
+    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+
+  if (escaped.length === 0) return text
+
+  const pattern = new RegExp(`(${escaped.join('|')})`, 'gi')
+  const parts = text.split(pattern)
+
+  if (parts.length === 1) return text
+
+  return parts.map((part, i) => {
+    if (!part) return null
+    return pattern.test(part) ? (
+      <mark key={i} className="bg-yellow-200/70 rounded-sm px-0.5">
+        {part}
+      </mark>
+    ) : (
+      <Fragment key={i}>{part}</Fragment>
+    )
+  })
+}

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -434,6 +434,7 @@ export function ResumeSearchPage() {
                   onRating={handleRating}
                   onCandidateStatusChange={handleCandidateStatusChange}
                   onToggleBlock={handleToggleBlock}
+                  searchQuery={queryInput}
                 />
               </ErrorBoundary>
             </div>


### PR DESCRIPTION
## Summary
- Add `highlightTerms` utility that wraps matched substrings in `<mark>` tags
- Thread `searchQuery` prop from `ResumeSearchPage` → `SearchResultsList` → `SnippetCard`
- Highlight matching terms in resume name, education, location, and headline text
- Case-insensitive matching with regex-safe term escaping

## Test plan
- [x] `make check-node` passes (0 errors)
- [ ] Search for a term and verify it appears highlighted in result cards
- [ ] Verify highlighting works for Chinese and English terms