### PR TITLE
feat: add PerformanceObserver for long task detection

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Outlet, Route, Routes, useLocation } from 'rea
 import { Toaster } from 'sonner'
 import { Header } from '@/components/Header'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
+import { LongTaskObserver } from '@/hooks/useLongTaskObserver'
 import { ResumesPage } from '@/pages/ResumesPage'
 import { ReviewPacketsPage } from '@/pages/ReviewPacketsPage'
 import SettingsLayout from '@/layouts/SettingsLayout'
@@ -128,6 +129,7 @@ function WorkspaceDebugPage() {
 function App() {
   return (
     <BrowserRouter>
+      <LongTaskObserver />
       <ErrorBoundary>
         <Routes>
           <Route path="/:teamSlug" element={<WorkspaceShell />}>

--- a/apps/web/src/hooks/useLongTaskObserver.ts
+++ b/apps/web/src/hooks/useLongTaskObserver.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+
+/**
+ * Observes long tasks (>50ms) on the main thread using the Long Tasks API.
+ * Logs warnings in development, silently no-ops if the API is unavailable.
+ * Mount <LongTaskObserver /> once at the app root.
+ */
+export function useLongTaskObserver() {
+  useEffect(() => {
+    if (typeof PerformanceObserver === 'undefined') return
+
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if (import.meta.env.DEV) {
+          console.warn(
+            `[longtask] ${Math.round(entry.duration)}ms at ${entry.startTime.toFixed(0)}ms`,
+            entry,
+          )
+        }
+      }
+    })
+
+    try {
+      observer.observe({ type: 'longtask', buffered: true })
+    } catch {
+      // Long Tasks API not supported in this browser
+      return
+    }
+
+    return () => observer.disconnect()
+  }, [])
+}
+
+/** Mount this component once at the app root to enable long-task detection. */
+export function LongTaskObserver() {
+  useLongTaskObserver()
+  return null
+}


### PR DESCRIPTION
## Summary
- Add `LongTaskObserver` component using the Long Tasks API
- Detects main thread tasks >50ms and logs warnings in dev mode
- Helps identify janky interactions during development
- Gracefully no-ops in browsers without Long Tasks API support

## Test plan
- [x] `make check-node` passes (0 errors)
- [ ] Open dev tools and verify longtask warnings appear for slow operations