### PR TITLE
feat: add copy-link button for search result sharing

### DIFF
--- a/apps/web/src/components/search/SearchHeader.tsx
+++ b/apps/web/src/components/search/SearchHeader.tsx
@@ -1,5 +1,8 @@
 import { useTranslation } from 'react-i18next'
+import { Link } from 'lucide-react'
+import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Select } from '@/components/ui/select'
 import { GoogleSearchBar } from '@/components/search/GoogleSearchBar'
 import type { ResumeSearchRecentItem, SearchSortValue } from '@/components/search/search-types'
@@ -110,6 +113,22 @@ export function SearchHeader({
               }
             />
           </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 gap-1.5"
+            onClick={() => {
+              navigator.clipboard.writeText(window.location.href).then(() => {
+                toast.success(t('resumes.searchPage.header.linkCopied', { defaultValue: '链接已复制' }))
+              })
+            }}
+            aria-label={t('resumes.searchPage.header.copyLink', { defaultValue: '复制搜索链接' })}
+          >
+            <Link className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">
+              {t('resumes.searchPage.header.copyLink', { defaultValue: '复制链接' })}
+            </span>
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add "Copy link" button in search header next to sort controls
- Copies current URL (with query + filters) to clipboard via `navigator.clipboard`
- Shows toast notification on success using sonner
- Responsive: icon-only on mobile, icon+text on sm+ breakpoints

## Test plan
- [x] `make check-node` passes (0 errors)
- [ ] Click "Copy link" and verify URL is copied to clipboard
- [ ] Verify toast notification appears