### PR TITLE
feat: add feature-based chunk splitting for search and settings

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -15,6 +15,25 @@ export default defineConfig({
       output: {
         manualChunks(id) {
           if (!id.includes('node_modules')) {
+            // Feature-based app code splitting
+            if (
+              id.includes('/components/search/') ||
+              id.includes('/hooks/useConvexResumes') ||
+              id.includes('/hooks/useResumeSearchState') ||
+              id.includes('/hooks/useStableQuery') ||
+              id.includes('/lib/highlight') ||
+              id.includes('/lib/resume-scoring') ||
+              id.includes('/lib/retry')
+            ) {
+              return 'search-feature'
+            }
+            if (
+              id.includes('/pages/Settings') ||
+              id.includes('/layouts/Settings') ||
+              id.includes('/pages/SystemSettings')
+            ) {
+              return 'settings-feature'
+            }
             return undefined
           }
 


### PR DESCRIPTION
## Summary
- Add feature-based `manualChunks` to Vite config for app code splitting
- `search-feature` chunk: search components, Convex resume hooks, scoring/retry utils
- `settings-feature` chunk: settings pages and layouts
- Non-search pages no longer download search-specific JavaScript

## Test plan
- [x] `make check-node` passes (0 errors)
- [ ] `vite build` produces separate search-feature and settings-feature chunks