### PR TITLE
ci: add Convex schema drift detection to checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -84,3 +84,13 @@ jobs:
 
       - name: Run checks + build validation
         run: make check-build
+
+      - name: Check Convex schema drift
+        run: |
+          cd packages/convex
+          npx convex codegen --typecheck disable
+          cd ../..
+          git diff --exit-code packages/convex/convex/_generated/ || {
+            echo "::error::Convex generated types are stale. Run 'cd packages/convex && npx convex codegen' and commit the changes."
+            exit 1
+          }


### PR DESCRIPTION
## Summary
- Add CI step to detect Convex schema drift
- Runs `npx convex codegen --typecheck disable` and checks for diff in `_generated/`
- Fails the build if generated types are stale, with clear error message

## Test plan
- [x] CI step added to `checks.yml` verify job
- [ ] Verify CI fails when `_generated/` types are out of sync