### PR TITLE
feat: add BM25 field boosting for search relevance

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -84,3 +84,13 @@ jobs:
 
       - name: Run checks + build validation
         run: make check-build
+
+      - name: Check Convex schema drift
+        run: |
+          cd packages/convex
+          npx convex codegen --typecheck disable
+          cd ../..
+          git diff --exit-code packages/convex/convex/_generated/ || {
+            echo "::error::Convex generated types are stale. Run 'cd packages/convex && npx convex codegen' and commit the changes."
+            exit 1
+          }

--- a/packages/convex/convex/search_text.ts
+++ b/packages/convex/convex/search_text.ts
@@ -146,21 +146,38 @@ function toTextFragments(value: unknown): string[] {
     return [];
 }
 
+// Field boost weights: higher values = more repetitions in searchText = higher BM25 weight
+const FIELD_BOOST: Record<string, number> = {
+    skills: 2,
+    desiredPosition: 2,
+    name: 1,
+    education: 1,
+    workHistory: 1,
+    companies: 1,
+    summary: 1,
+    expectedSalary: 1,
+    locationHierarchy: 1,
+};
+
 function collectPriorityFragments(content: UnknownRecord): string[] {
     const parts: string[] = [];
     for (const key of PRIORITY_KEYS) {
+        let fragments: string[] = [];
         if (key === "locationHierarchy") {
             const locationHierarchy = formatLocationHierarchySearchText(content[key] as LocationHierarchy | null | undefined);
             if (locationHierarchy) {
-                parts.push(locationHierarchy);
+                fragments = [locationHierarchy];
             }
-            continue;
+        } else if (key === "workHistory") {
+            fragments = buildLatestWorkHistoryEvidence(content[key]).lines;
+        } else {
+            fragments = toTextFragments(content[key]);
         }
-        if (key === "workHistory") {
-            parts.push(...buildLatestWorkHistoryEvidence(content[key]).lines);
-            continue;
+        // Repeat fragments based on field boost weight for BM25 weighting
+        const boost = FIELD_BOOST[key] ?? 1;
+        for (let i = 0; i < boost; i++) {
+            parts.push(...fragments);
         }
-        parts.push(...toTextFragments(content[key]));
     }
     return parts;
 }


### PR DESCRIPTION
## Summary
- Add configurable `FIELD_BOOST` map to `search_text.ts`
- Skills and desiredPosition repeated 2x in `searchText` for higher BM25 weight
- Other priority fields (name, education, workHistory, companies, summary) remain at 1x
- All 5 existing search-text tests pass

## Test plan
- [x] `make check-node` passes (0 errors)
- [x] `vitest search-text.test.ts` passes (5/5)
- [ ] Search for a skill term and verify boosted results appear higher