### PR TITLE
feat: instrument search analytics from Convex search path

### DIFF
--- a/apps/api/src/routes/search-analytics.ts
+++ b/apps/api/src/routes/search-analytics.ts
@@ -142,4 +142,46 @@ app.openapi(synonymSuggestionsRoute, (c) => {
   return c.json({ success: true as const, suggestions }, 200);
 });
 
+const logSearchRoute = createRoute({
+  method: "post",
+  path: "/log",
+  tags: ["Search Analytics"],
+  summary: "Log a search query event from the client",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            query: z.string(),
+            resultCount: z.number().int().min(0),
+            topScore: z.number().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Event logged",
+      content: {
+        "application/json": {
+          schema: z.object({
+            success: z.literal(true),
+          }),
+        },
+      },
+    },
+  },
+});
+
+app.openapi(logSearchRoute, (c) => {
+  const body = c.req.valid("json");
+  searchEventLogger.logSearchQuery({
+    query: body.query,
+    resultCount: body.resultCount,
+    topScore: body.topScore,
+  });
+  return c.json({ success: true as const }, 200);
+});
+
 export default app;

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -3,6 +3,7 @@ import { hasMatchingRoleSignal, matchesSalaryFilter } from '@/hooks/resume-filte
 import { useMutation } from 'convex/react'
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
+import { logSearchEvent } from '@/lib/search-analytics'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { useCandidateActions } from '@/hooks/useCandidateActions'
@@ -894,6 +895,19 @@ export function useResumeSearchState() {
   const hasMore = resumeQuery.hasMore
   const loading = !isLanding && resumeQuery.loading
   const loadingMore = resumeQuery.loadingMore
+
+  // Log search analytics (fire-and-forget, debounced by query change)
+  const lastLoggedQueryRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (activeQuery && !loading && filteredResults.length >= 0 && lastLoggedQueryRef.current !== activeQuery) {
+      lastLoggedQueryRef.current = activeQuery
+      logSearchEvent({
+        query: activeQuery,
+        resultCount: filteredResults.length,
+        topScore: filteredResults[0]?.score ?? undefined,
+      })
+    }
+  }, [activeQuery, filteredResults, loading])
   const analysisCandidates = useMemo(
     () =>
       filteredResults

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4573,6 +4573,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/search-analytics/log": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Log a search query event from the client */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        query: string;
+                        resultCount: number;
+                        topScore?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Event logged */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/scoring-evaluation/report": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/search-analytics.ts
+++ b/apps/web/src/lib/search-analytics.ts
@@ -1,0 +1,27 @@
+import { apiBaseUrl } from './api-client'
+
+/**
+ * Log a search query event to the BFF analytics endpoint.
+ * Fire-and-forget — errors are silently ignored.
+ */
+export function logSearchEvent(params: {
+  query: string
+  resultCount: number
+  topScore?: number
+}): void {
+  const workspace = document.querySelector<HTMLMetaElement>('meta[name="workspace-slug"]')?.content
+    ?? window.location.pathname.split('/')[1]
+    ?? 'default'
+
+  fetch(`${apiBaseUrl}/api/search-analytics/log`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Workspace-Slug': workspace,
+    },
+    body: JSON.stringify(params),
+    keepalive: true,
+  }).catch(() => {
+    // Fire-and-forget — ignore network errors
+  })
+}


### PR DESCRIPTION
## Summary
- Add POST `/api/search-analytics/log` endpoint to BFF search analytics routes
- Create `logSearchEvent` utility (fire-and-forget with `keepalive`)
- Wire up `useResumeSearchState` to log after each Convex search completes
- Debounce logging via ref to avoid duplicate events on re-renders
- Complements existing BFF-side logging for API-driven searches

## Test plan
- [x] `make check-node` passes (0 errors)
- [ ] Search on frontend and verify event appears in `/api/search-analytics/summary`