### PR TITLE
feat: add web-vitals RUM for production CWV monitoring

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -28,6 +28,7 @@ import {
   notificationRoutes,
   workerRoutes,
   summariesRoutes,
+  webVitalsRoutes,
 } from "./routes/index.js";
 import { config } from "./services/config.js";
 import { workspaceMiddleware } from "./middleware/workspace.js";
@@ -119,6 +120,7 @@ export function createApp() {
   app.route("/api/config", configRoutes);
   app.route("/api/notifications", notificationRoutes);
   app.route("/api/summaries", summariesRoutes);
+  app.route("/api/web-vitals", webVitalsRoutes);
 
   // OpenAPI documentation endpoint
   app.doc("/doc", openApiConfig);

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -21,3 +21,4 @@ export { default as configRoutes } from "./config.js";
 export { default as notificationRoutes } from "./notifications.js";
 export { default as workerRoutes } from "./worker.js";
 export { default as summariesRoutes } from "./summaries.js";
+export { default as webVitalsRoutes } from "./web-vitals.js";

--- a/apps/api/src/routes/search-analytics.ts
+++ b/apps/api/src/routes/search-analytics.ts
@@ -142,4 +142,46 @@ app.openapi(synonymSuggestionsRoute, (c) => {
   return c.json({ success: true as const, suggestions }, 200);
 });
 
+const logSearchRoute = createRoute({
+  method: "post",
+  path: "/log",
+  tags: ["Search Analytics"],
+  summary: "Log a search query event from the client",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            query: z.string(),
+            resultCount: z.number().int().min(0),
+            topScore: z.number().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Event logged",
+      content: {
+        "application/json": {
+          schema: z.object({
+            success: z.literal(true),
+          }),
+        },
+      },
+    },
+  },
+});
+
+app.openapi(logSearchRoute, (c) => {
+  const body = c.req.valid("json");
+  searchEventLogger.logSearchQuery({
+    query: body.query,
+    resultCount: body.resultCount,
+    topScore: body.topScore,
+  });
+  return c.json({ success: true as const }, 200);
+});
+
 export default app;

--- a/apps/api/src/routes/web-vitals.ts
+++ b/apps/api/src/routes/web-vitals.ts
@@ -1,0 +1,100 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+
+import { config } from "../services/config.js";
+import { WebVitalsLogger } from "../services/web-vitals-logger.js";
+
+const app = new OpenAPIHono();
+const webVitalsLogger = new WebVitalsLogger(config.projectRoot);
+
+const MetricSchema = z.object({
+  name: z.string(),
+  value: z.number(),
+  rating: z.enum(["good", "needs-improvement", "poor"]),
+  id: z.string(),
+  navigationType: z.string(),
+});
+
+const reportRoute = createRoute({
+  method: "post",
+  path: "/report",
+  tags: ["Web Vitals"],
+  summary: "Report a Core Web Vitals metric from the client",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: MetricSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Metric logged",
+      content: {
+        "application/json": {
+          schema: z.object({
+            success: z.literal(true),
+          }),
+        },
+      },
+    },
+  },
+});
+
+app.openapi(reportRoute, (c) => {
+  const body = c.req.valid("json");
+  const workspace =
+    c.req.header("X-Workspace-Slug") ?? "default";
+  webVitalsLogger.logMetric({
+    ...body,
+    workspace,
+    timestamp: Date.now(),
+  });
+  return c.json({ success: true as const }, 200);
+});
+
+const summaryRoute = createRoute({
+  method: "get",
+  path: "/summary",
+  tags: ["Web Vitals"],
+  summary: "Get aggregated Web Vitals summary",
+  request: {
+    query: z.object({
+      hours: z.coerce.number().int().min(1).max(168).optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Web Vitals summary",
+      content: {
+        "application/json": {
+          schema: z.object({
+            success: z.literal(true),
+            summary: z.object({
+              totalReports: z.number().int(),
+              metrics: z.record(
+                z.object({
+                  p50: z.number(),
+                  p75: z.number(),
+                  p95: z.number(),
+                  good: z.number().int(),
+                  needsImprovement: z.number().int(),
+                  poor: z.number().int(),
+                })
+              ),
+            }),
+          }),
+        },
+      },
+    },
+  },
+});
+
+app.openapi(summaryRoute, (c) => {
+  const { hours } = c.req.valid("query");
+  const summary = webVitalsLogger.getSummary(hours ?? 24);
+  return c.json({ success: true as const, summary }, 200);
+});
+
+export default app;

--- a/apps/api/src/services/web-vitals-logger.ts
+++ b/apps/api/src/services/web-vitals-logger.ts
@@ -1,0 +1,169 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { findProjectRoot } from "./db.js";
+
+export interface WebVitalMetric {
+  name: string;
+  value: number;
+  rating: "good" | "needs-improvement" | "poor";
+  id: string;
+  navigationType: string;
+  workspace: string;
+  timestamp: number;
+}
+
+export interface MetricSummary {
+  p50: number;
+  p75: number;
+  p95: number;
+  good: number;
+  needsImprovement: number;
+  poor: number;
+}
+
+export interface WebVitalsSummary {
+  totalReports: number;
+  metrics: Record<string, MetricSummary>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized ? normalized : null;
+}
+
+function readNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return null;
+}
+
+function parseMetric(value: unknown): WebVitalMetric | null {
+  if (!isRecord(value)) return null;
+
+  const name = readString(value.name);
+  const valueNum = readNumber(value.value);
+  const rating = readString(value.rating);
+  const id = readString(value.id);
+  const navigationType = readString(value.navigationType);
+  const workspace = readString(value.workspace);
+  const timestamp = readNumber(value.timestamp);
+
+  if (
+    !name ||
+    valueNum === null ||
+    !id ||
+    !navigationType ||
+    !workspace ||
+    timestamp === null
+  ) {
+    return null;
+  }
+
+  if (rating !== "good" && rating !== "needs-improvement" && rating !== "poor") {
+    return null;
+  }
+
+  return { name, value: valueNum, rating, id, navigationType, workspace, timestamp };
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, index)];
+}
+
+export class WebVitalsLogger {
+  readonly projectRoot: string;
+
+  constructor(projectRoot?: string) {
+    this.projectRoot = projectRoot ? path.resolve(projectRoot) : findProjectRoot();
+  }
+
+  private getOutputDir(): string {
+    return path.join(this.projectRoot, "output");
+  }
+
+  private getLogPath(): string {
+    return path.join(this.getOutputDir(), "web-vitals.jsonl");
+  }
+
+  private ensureOutputDir(): void {
+    const outputDir = this.getOutputDir();
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+  }
+
+  logMetric(metric: WebVitalMetric): void {
+    this.ensureOutputDir();
+    fs.appendFileSync(
+      this.getLogPath(),
+      `${JSON.stringify(metric)}\n`,
+      "utf8",
+    );
+  }
+
+  private readMetrics(sinceTimestamp?: number): WebVitalMetric[] {
+    const logPath = this.getLogPath();
+    if (!fs.existsSync(logPath)) {
+      return [];
+    }
+
+    const content = fs.readFileSync(logPath, "utf8");
+    const metrics: WebVitalMetric[] = [];
+
+    for (const line of content.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        const metric = parseMetric(parsed);
+        if (metric) {
+          if (!sinceTimestamp || metric.timestamp >= sinceTimestamp) {
+            metrics.push(metric);
+          }
+        }
+      } catch {
+        // Skip malformed lines.
+      }
+    }
+
+    return metrics;
+  }
+
+  getSummary(hours = 24): WebVitalsSummary {
+    const sinceTimestamp = Date.now() - hours * 60 * 60 * 1000;
+    const metrics = this.readMetrics(sinceTimestamp);
+
+    const byName = new Map<string, WebVitalMetric[]>();
+    for (const metric of metrics) {
+      const group = byName.get(metric.name) ?? [];
+      group.push(metric);
+      byName.set(metric.name, group);
+    }
+
+    const result: Record<string, MetricSummary> = {};
+
+    for (const [name, group] of byName) {
+      const values = group.map((m) => m.value).sort((a, b) => a - b);
+      result[name] = {
+        p50: percentile(values, 50),
+        p75: percentile(values, 75),
+        p95: percentile(values, 95),
+        good: group.filter((m) => m.rating === "good").length,
+        needsImprovement: group.filter((m) => m.rating === "needs-improvement").length,
+        poor: group.filter((m) => m.rating === "poor").length,
+      };
+    }
+
+    return { totalReports: metrics.length, metrics: result };
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,7 +38,8 @@
     "react-i18next": "^14.1.0",
     "react-router-dom": "^7.13.1",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^2.2.0"
+    "tailwind-merge": "^2.2.0",
+    "web-vitals": "^5.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -3,6 +3,7 @@ import { hasMatchingRoleSignal, matchesSalaryFilter } from '@/hooks/resume-filte
 import { useMutation } from 'convex/react'
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
+import { logSearchEvent } from '@/lib/search-analytics'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { useCandidateActions } from '@/hooks/useCandidateActions'
@@ -894,6 +895,19 @@ export function useResumeSearchState() {
   const hasMore = resumeQuery.hasMore
   const loading = !isLanding && resumeQuery.loading
   const loadingMore = resumeQuery.loadingMore
+
+  // Log search analytics (fire-and-forget, debounced by query change)
+  const lastLoggedQueryRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (activeQuery && !loading && filteredResults.length >= 0 && lastLoggedQueryRef.current !== activeQuery) {
+      lastLoggedQueryRef.current = activeQuery
+      logSearchEvent({
+        query: activeQuery,
+        resultCount: filteredResults.length,
+        topScore: filteredResults[0]?.score ?? undefined,
+      })
+    }
+  }, [activeQuery, filteredResults, loading])
   const analysisCandidates = useMemo(
     () =>
       filteredResults

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -6884,6 +6884,110 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/web-vitals/report": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Report a Core Web Vitals metric from the client */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name: string;
+                        value: number;
+                        /** @enum {string} */
+                        rating: "good" | "needs-improvement" | "poor";
+                        id: string;
+                        navigationType: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Metric logged */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/web-vitals/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get aggregated Web Vitals summary */
+        get: {
+            parameters: {
+                query?: {
+                    hours?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Web Vitals summary */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            summary: {
+                                totalReports: number;
+                                metrics: {
+                                    [key: string]: {
+                                        p50: number;
+                                        p75: number;
+                                        p95: number;
+                                        good: number;
+                                        needsImprovement: number;
+                                        poor: number;
+                                    };
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4573,6 +4573,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/search-analytics/log": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Log a search query event from the client */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        query: string;
+                        resultCount: number;
+                        topScore?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Event logged */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/scoring-evaluation/report": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/search-analytics.ts
+++ b/apps/web/src/lib/search-analytics.ts
@@ -1,0 +1,27 @@
+import { apiBaseUrl } from './api-client'
+
+/**
+ * Log a search query event to the BFF analytics endpoint.
+ * Fire-and-forget — errors are silently ignored.
+ */
+export function logSearchEvent(params: {
+  query: string
+  resultCount: number
+  topScore?: number
+}): void {
+  const workspace = document.querySelector<HTMLMetaElement>('meta[name="workspace-slug"]')?.content
+    ?? window.location.pathname.split('/')[1]
+    ?? 'default'
+
+  fetch(`${apiBaseUrl}/api/search-analytics/log`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Workspace-Slug': workspace,
+    },
+    body: JSON.stringify(params),
+    keepalive: true,
+  }).catch(() => {
+    // Fire-and-forget — ignore network errors
+  })
+}

--- a/apps/web/src/lib/web-vitals.ts
+++ b/apps/web/src/lib/web-vitals.ts
@@ -1,0 +1,47 @@
+import { onCLS, onINP, onLCP, onFCP, onTTFB } from 'web-vitals'
+import type { Metric } from 'web-vitals'
+import { apiBaseUrl } from './api-client'
+
+/**
+ * Report Core Web Vitals to the BFF analytics endpoint.
+ * Fire-and-forget — errors are silently ignored.
+ * Only runs in production.
+ */
+function reportMetric(metric: Metric): void {
+  if (!import.meta.env.PROD) {
+    console.debug('[web-vitals]', metric.name, metric.value, metric)
+    return
+  }
+
+  const workspace =
+    document.querySelector<HTMLMetaElement>('meta[name="workspace-slug"]')?.content ??
+    window.location.pathname.split('/')[1] ??
+    'default'
+
+  const body = JSON.stringify({
+    name: metric.name,
+    value: metric.value,
+    rating: metric.rating,
+    id: metric.id,
+    navigationType: metric.navigationType,
+  })
+
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon(`${apiBaseUrl}/api/web-vitals/report`, new Blob([body], { type: 'application/json' }))
+  } else {
+    fetch(`${apiBaseUrl}/api/web-vitals/report`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': workspace },
+      body,
+      keepalive: true,
+    }).catch(() => {})
+  }
+}
+
+export function initWebVitals(): void {
+  onLCP(reportMetric)
+  onCLS(reportMetric)
+  onINP(reportMetric)
+  onFCP(reportMetric)
+  onTTFB(reportMetric)
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,8 +3,11 @@ import { createRoot } from 'react-dom/client'
 import './i18n'
 import './styles/globals.css'
 import App from './App.tsx'
+import { initWebVitals } from './lib/web-vitals'
 
 import { ConvexProvider, ConvexReactClient } from 'convex/react'
+
+initWebVitals()
 
 const convexUrl = import.meta.env.VITE_CONVEX_URL
 const convex = convexUrl ? new ConvexReactClient(convexUrl) : null


### PR DESCRIPTION
## Summary
- Added `web-vitals` (5.2.0) to instrument LCP, CLS, INP, FCP, TTFB reporting
- New BFF endpoint `POST /api/web-vitals/report` receives metrics via `sendBeacon` (fire-and-forget)
- `WebVitalsLogger` service logs to `output/web-vitals.jsonl` with p50/p75/p95 aggregation via `GET /api/web-vitals/summary`
- Dev mode logs metrics to console only (no network calls)
- Item #95 from recommendations

## Test plan
- [x] `make check-node` passes
- [ ] Verify dev mode: open app, check console for `[web-vitals]` entries
- [ ] Verify prod mode: check `output/web-vitals.jsonl` after page loads
- [ ] Verify `GET /api/web-vitals/summary` returns aggregated stats