### PR TITLE
feat: add in-memory rate limiting on API routes

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -33,6 +33,7 @@ import {
 import { config } from "./services/config.js";
 import { workspaceMiddleware } from "./middleware/workspace.js";
 import { serverTimingMiddleware } from "./middleware/server-timing.js";
+import { rateLimit } from "./middleware/rate-limit.js";
 
 export const openApiConfig = {
   openapi: "3.1.0",
@@ -94,6 +95,9 @@ export function createApp() {
   app.use("*", logger());
   app.use("*", prettyJSON());
   app.use("*", workspaceMiddleware);
+
+  // Rate limiting on API routes (100 req/min per IP)
+  app.use("/api/*", rateLimit({ limit: 100, windowMs: 60_000 }));
 
   // Mount routes
   app.route("/", healthRoutes);

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,0 +1,82 @@
+import type { MiddlewareHandler } from "hono";
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+export interface RateLimitOptions {
+  /** Maximum requests per window. Default: 100 */
+  limit?: number;
+  /** Window duration in milliseconds. Default: 60_000 (1 minute) */
+  windowMs?: number;
+  /** Extract client key from the request. Default: IP from X-Forwarded-For or 'unknown' */
+  keyExtractor?: (c: { req: { header: (name: string) => string | undefined } }) => string;
+}
+
+const DEFAULT_OPTIONS: Required<RateLimitOptions> = {
+  limit: 100,
+  windowMs: 60_000,
+  keyExtractor: (c) => {
+    const forwarded = c.req.header("X-Forwarded-For");
+    if (forwarded) {
+      return forwarded.split(",")[0]?.trim() ?? "unknown";
+    }
+    return c.req.header("X-Real-Ip") ?? "unknown";
+  },
+};
+
+/**
+ * In-memory sliding-window rate limiter for Hono.
+ * No external dependencies — suitable for single-instance deployments.
+ */
+export function rateLimit(options?: RateLimitOptions): MiddlewareHandler {
+  const limit = options?.limit ?? DEFAULT_OPTIONS.limit;
+  const windowMs = options?.windowMs ?? DEFAULT_OPTIONS.windowMs;
+  const keyExtractor = options?.keyExtractor ?? DEFAULT_OPTIONS.keyExtractor;
+
+  const store = new Map<string, RateLimitEntry>();
+
+  // Periodic cleanup of expired entries (every 60s)
+  const cleanupInterval = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of store) {
+      if (now >= entry.resetAt) {
+        store.delete(key);
+      }
+    }
+  }, 60_000);
+
+  // Allow the interval to not keep the process alive in tests
+  if (cleanupInterval.unref) {
+    cleanupInterval.unref();
+  }
+
+  return async (c, next) => {
+    const key = keyExtractor(c);
+    const now = Date.now();
+
+    let entry = store.get(key);
+    if (!entry || now >= entry.resetAt) {
+      entry = { count: 0, resetAt: now + windowMs };
+      store.set(key, entry);
+    }
+
+    entry.count += 1;
+
+    const remaining = Math.max(0, limit - entry.count);
+    c.header("X-RateLimit-Limit", String(limit));
+    c.header("X-RateLimit-Remaining", String(remaining));
+    c.header("X-RateLimit-Reset", String(Math.ceil(entry.resetAt / 1000)));
+
+    if (entry.count > limit) {
+      c.header("Retry-After", String(Math.ceil((entry.resetAt - now) / 1000)));
+      return c.json(
+        { success: false as const, error: "Too many requests" },
+        429,
+      );
+    }
+
+    await next();
+  };
+}


### PR DESCRIPTION
## Summary
- Added sliding-window rate limiter middleware (100 req/min per IP) on all `/api/*` routes
- Returns `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers
- Returns 429 with `Retry-After` header on excess
- No new dependencies — in-memory `Map` with periodic cleanup
- Item #90 from recommendations

## Test plan
- [x] `make check-node` passes
- [ ] Verify rate limit headers appear in API responses
- [ ] Verify 429 response after exceeding limit