### PR TITLE
feat: axe-core a11y audit in E2E + bundle baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,10 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "@vitest/coverage-v8": "^4.1.1",
+    "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.0.10",
+    "@vitest/coverage-v8": "^4.1.1",
     "playwright": "^1.58.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/scripts/benchmarks/bundle-baselines.json
+++ b/scripts/benchmarks/bundle-baselines.json
@@ -1,0 +1,17 @@
+{
+  "generated": "2026-05-12",
+  "tool": "vite build",
+  "chunks": {
+    "react-vendor": { "bytes": 267508, "gzipEstimate": 85000 },
+    "search-feature": { "bytes": 212656, "gzipEstimate": 68000 },
+    "index": { "bytes": 180161, "gzipEstimate": 60440 },
+    "ui-vendor": { "bytes": 90823, "gzipEstimate": 25930 },
+    "convex-vendor": { "bytes": 61455, "gzipEstimate": 17370 },
+    "i18n-vendor": { "bytes": 57297, "gzipEstimate": 18310 },
+    "radix-vendor": { "bytes": 55982, "gzipEstimate": 18360 },
+    "settings-feature": { "bytes": 6390, "gzipEstimate": 2220 }
+  },
+  "totalJS": 1120000,
+  "totalCSS": 59035,
+  "notes": "Baseline after PR #722 feature-based chunk splitting. search-feature includes search components, hooks, scoring utils."
+}

--- a/scripts/e2e-smoke.ts
+++ b/scripts/e2e-smoke.ts
@@ -5,6 +5,7 @@ import { makeFunctionReference } from 'convex/server';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import AxeBuilder from '@axe-core/playwright';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -387,6 +388,21 @@ async function runSearchTest(page: Page) {
         }
     } else {
         console.log('  ✓ No browser console errors');
+    }
+
+    // Accessibility audit with axe-core
+    const a11yResults = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .analyze();
+
+    if (a11yResults.violations.length > 0) {
+        console.warn(`⚠️ ${a11yResults.violations.length} accessibility violations found:`);
+        for (const violation of a11yResults.violations) {
+            console.warn(`  [${violation.impact}] ${violation.id}: ${violation.description} (${violation.nodes.length} elements)`);
+        }
+        // Don't fail the build on a11y warnings — just report
+    } else {
+        console.log('  ✓ No WCAG 2.1 AA accessibility violations');
     }
 }
 


### PR DESCRIPTION
## Summary
- Added `@axe-core/playwright` to `runSearchTest()` for automated WCAG 2.1 AA violation detection
- Reports violations as warnings (non-blocking) after CWV and console error checks
- Saves bundle size baseline (`scripts/benchmarks/bundle-baselines.json`) from PR #722 chunk splitting
- Items #91 and #79 from recommendations

## Test plan
- [x] `make check-node` passes
- [ ] `make e2e` — verify axe-core runs and reports in smoke test output