### PR TITLE
feat: add Sentry client-side error tracking

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@sentry/react": "^10.52.0",
     "@tanstack/react-virtual": "^3.13.23",
     "@trends/shared": "*",
     "class-variance-authority": "^0.7.0",

--- a/apps/web/src/lib/sentry.ts
+++ b/apps/web/src/lib/sentry.ts
@@ -1,0 +1,33 @@
+import * as Sentry from "@sentry/react";
+
+export function initSentry(): void {
+  const dsn = import.meta.env.VITE_SENTRY_DSN;
+  if (!dsn) {
+    return;
+  }
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.MODE ?? "development",
+    tracesSampleRate: 0.2,
+    replaysSessionSampleRate: 0,
+    replaysOnErrorSampleRate: 1.0,
+    integrations: [
+      Sentry.browserTracingIntegration(),
+    ],
+    beforeSend(event) {
+      // Strip sensitive query params from URLs
+      if (event.request?.url) {
+        try {
+          const url = new URL(event.request.url);
+          url.searchParams.delete("token");
+          url.searchParams.delete("key");
+          event.request.url = url.toString();
+        } catch {
+          // Invalid URL — leave as-is
+        }
+      }
+      return event;
+    },
+  });
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,9 +4,11 @@ import './i18n'
 import './styles/globals.css'
 import App from './App.tsx'
 import { initWebVitals } from './lib/web-vitals'
+import { initSentry } from './lib/sentry'
 
 import { ConvexProvider, ConvexReactClient } from 'convex/react'
 
+initSentry()
 initWebVitals()
 
 const convexUrl = import.meta.env.VITE_CONVEX_URL


### PR DESCRIPTION
## Summary
- Added `@sentry/react` (10.52.0) with `BrowserTracing` integration
- Initializes only when `VITE_SENTRY_DSN` env var is set (no-op otherwise)
- Strips sensitive query params (`token`, `key`) from error report URLs
- `tracesSampleRate: 0.2` in production for performance monitoring
- Item #88 from recommendations

## Test plan
- [x] `make check-node` passes
- [ ] Set `VITE_SENTRY_DSN` and verify errors appear in Sentry dashboard
- [ ] Verify no-op when `VITE_SENTRY_DSN` is unset