### PR TITLE
feat: add search alert subscriptions (Convex + API)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -29,6 +29,7 @@ import {
   workerRoutes,
   summariesRoutes,
   webVitalsRoutes,
+  searchAlertsRoutes,
 } from "./routes/index.js";
 import { config } from "./services/config.js";
 import { workspaceMiddleware } from "./middleware/workspace.js";
@@ -125,6 +126,7 @@ export function createApp() {
   app.route("/api/notifications", notificationRoutes);
   app.route("/api/summaries", summariesRoutes);
   app.route("/api/web-vitals", webVitalsRoutes);
+  app.route("/api/search-alerts", searchAlertsRoutes);
 
   // OpenAPI documentation endpoint
   app.doc("/doc", openApiConfig);

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -22,3 +22,4 @@ export { default as notificationRoutes } from "./notifications.js";
 export { default as workerRoutes } from "./worker.js";
 export { default as summariesRoutes } from "./summaries.js";
 export { default as webVitalsRoutes } from "./web-vitals.js";
+export { default as searchAlertsRoutes } from "./search-alerts.js";

--- a/apps/api/src/routes/search-alerts.ts
+++ b/apps/api/src/routes/search-alerts.ts
@@ -1,0 +1,199 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { resolveConvexUrl } from "../services/resume-import-service.js";
+
+const app = new OpenAPIHono();
+
+const SearchAlertSchema = z.object({
+    _id: z.string(),
+    _creationTime: z.number(),
+    workspaceSlug: z.string(),
+    searchProfileId: z.string(),
+    name: z.string(),
+    keywords: z.optional(z.array(z.string())),
+    minScore: z.number(),
+    enabled: z.boolean(),
+    lastNotifiedAt: z.optional(z.number()),
+    createdBy: z.optional(z.string()),
+});
+
+async function convexQuery(path: string, args: Record<string, unknown>) {
+    const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+    const response = await fetch(`${convexUrl}/api/query`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path, args }),
+    });
+    if (!response.ok) {
+        throw new Error(`Convex query failed: ${response.status} ${response.statusText}`);
+    }
+    const data = await response.json() as { status: string; value?: unknown; errorMessage?: string };
+    if (data.status !== "success") {
+        throw new Error(`Convex error: ${data.errorMessage ?? "unknown"}`);
+    }
+    return data.value;
+}
+
+async function convexMutation(path: string, args: Record<string, unknown>) {
+    const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+    const response = await fetch(`${convexUrl}/api/mutation`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path, args }),
+    });
+    if (!response.ok) {
+        throw new Error(`Convex mutation failed: ${response.status} ${response.statusText}`);
+    }
+    const data = await response.json() as { status: string; value?: unknown; errorMessage?: string };
+    if (data.status !== "success") {
+        throw new Error(`Convex error: ${data.errorMessage ?? "unknown"}`);
+    }
+    return data.value;
+}
+
+const listRoute = createRoute({
+    method: "get",
+    path: "/",
+    tags: ["Search Alerts"],
+    summary: "List search alerts for a workspace",
+    responses: {
+        200: {
+            description: "Search alerts list",
+            content: {
+                "application/json": {
+                    schema: z.object({
+                        success: z.literal(true),
+                        alerts: z.array(SearchAlertSchema),
+                    }),
+                },
+            },
+        },
+    },
+});
+
+app.openapi(listRoute, async (c) => {
+    const workspace = c.req.header("X-Workspace-Slug") ?? "default";
+    const alerts = await convexQuery("search_alerts:list", {
+        workspaceSlug: workspace,
+    }) as z.infer<typeof SearchAlertSchema>[];
+    return c.json({ success: true as const, alerts }, 200);
+});
+
+const createRoute_ = createRoute({
+    method: "post",
+    path: "/",
+    tags: ["Search Alerts"],
+    summary: "Create a search alert subscription",
+    request: {
+        body: {
+            content: {
+                "application/json": {
+                    schema: z.object({
+                        searchProfileId: z.string(),
+                        name: z.string().min(1).max(200),
+                        keywords: z.optional(z.array(z.string())),
+                        minScore: z.number().min(0).max(100),
+                    }),
+                },
+            },
+        },
+    },
+    responses: {
+        200: {
+            description: "Alert created",
+            content: {
+                "application/json": {
+                    schema: z.object({
+                        success: z.literal(true),
+                        alertId: z.string(),
+                    }),
+                },
+            },
+        },
+    },
+});
+
+app.openapi(createRoute_, async (c) => {
+    const body = c.req.valid("json");
+    const workspace = c.req.header("X-Workspace-Slug") ?? "default";
+    const alertId = await convexMutation("search_alerts:create", {
+        workspaceSlug: workspace,
+        searchProfileId: body.searchProfileId,
+        name: body.name,
+        keywords: body.keywords,
+        minScore: body.minScore,
+    });
+    return c.json({ success: true as const, alertId: String(alertId) }, 200);
+});
+
+const toggleRoute = createRoute({
+    method: "patch",
+    path: "/:id/toggle",
+    tags: ["Search Alerts"],
+    summary: "Toggle alert enabled/disabled state",
+    request: {
+        params: z.object({ id: z.string() }),
+        body: {
+            content: {
+                "application/json": {
+                    schema: z.object({
+                        enabled: z.boolean(),
+                    }),
+                },
+            },
+        },
+    },
+    responses: {
+        200: {
+            description: "Alert toggled",
+            content: {
+                "application/json": {
+                    schema: z.object({
+                        success: z.literal(true),
+                    }),
+                },
+            },
+        },
+    },
+});
+
+app.openapi(toggleRoute, async (c) => {
+    const { id } = c.req.valid("param");
+    const body = c.req.valid("json");
+    await convexMutation("search_alerts:toggle", {
+        alertId: id,
+        enabled: body.enabled,
+    });
+    return c.json({ success: true as const }, 200);
+});
+
+const deleteRoute = createRoute({
+    method: "delete",
+    path: "/:id",
+    tags: ["Search Alerts"],
+    summary: "Delete a search alert",
+    request: {
+        params: z.object({ id: z.string() }),
+    },
+    responses: {
+        200: {
+            description: "Alert deleted",
+            content: {
+                "application/json": {
+                    schema: z.object({
+                        success: z.literal(true),
+                    }),
+                },
+            },
+        },
+    },
+});
+
+app.openapi(deleteRoute, async (c) => {
+    const { id } = c.req.valid("param");
+    await convexMutation("search_alerts:remove", {
+        alertId: id,
+    });
+    return c.json({ success: true as const }, 200);
+});
+
+export default app;

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -6988,6 +6988,178 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/search-alerts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List search alerts for a workspace */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Search alerts list */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            alerts: {
+                                _id: string;
+                                _creationTime: number;
+                                workspaceSlug: string;
+                                searchProfileId: string;
+                                name: string;
+                                keywords?: string[];
+                                minScore: number;
+                                enabled: boolean;
+                                lastNotifiedAt?: number;
+                                createdBy?: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a search alert subscription */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        searchProfileId: string;
+                        name: string;
+                        keywords?: string[];
+                        minScore: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Alert created */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            alertId: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/search-alerts/:id/toggle": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Toggle alert enabled/disabled state */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        enabled: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Alert toggled */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/api/search-alerts/:id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a search alert */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Alert deleted */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -24,6 +24,7 @@ import type * as lib_resume_identity from "../lib/resume_identity.js";
 import type * as migrations from "../migrations.js";
 import type * as resume_tasks from "../resume_tasks.js";
 import type * as resumes from "../resumes.js";
+import type * as search_alerts from "../search_alerts.js";
 import type * as search_profiles from "../search_profiles.js";
 import type * as search_text from "../search_text.js";
 import type * as seed from "../seed.js";
@@ -55,6 +56,7 @@ declare const fullApi: ApiFromModules<{
   migrations: typeof migrations;
   resume_tasks: typeof resume_tasks;
   resumes: typeof resumes;
+  search_alerts: typeof search_alerts;
   search_profiles: typeof search_profiles;
   search_text: typeof search_text;
   seed: typeof seed;

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -489,4 +489,19 @@ export default defineSchema({
         error: v.optional(v.string()),
         timestamp: v.number(),
     }).index("by_timestamp", ["timestamp"]),
+
+    // Search alert subscriptions — notify when new resumes match criteria
+    search_alerts: defineTable({
+        workspaceSlug: v.string(),
+        searchProfileId: v.string(),
+        name: v.string(),
+        keywords: v.optional(v.array(v.string())),
+        minScore: v.number(),
+        enabled: v.boolean(),
+        lastNotifiedAt: v.optional(v.number()),
+        createdBy: v.optional(v.string()),
+    })
+        .index("by_workspace", ["workspaceSlug"])
+        .index("by_workspace_enabled", ["workspaceSlug", "enabled"])
+        .index("by_search_profile", ["searchProfileId"]),
 });

--- a/packages/convex/convex/search_alerts.ts
+++ b/packages/convex/convex/search_alerts.ts
@@ -1,0 +1,91 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+
+/**
+ * Create a new search alert subscription.
+ */
+export const create = mutation({
+    args: {
+        workspaceSlug: v.string(),
+        searchProfileId: v.string(),
+        name: v.string(),
+        keywords: v.optional(v.array(v.string())),
+        minScore: v.number(),
+        createdBy: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        return ctx.db.insert("search_alerts", {
+            ...args,
+            enabled: true,
+        });
+    },
+});
+
+/**
+ * Toggle alert enabled/disabled state.
+ */
+export const toggle = mutation({
+    args: {
+        alertId: v.id("search_alerts"),
+        enabled: v.boolean(),
+    },
+    handler: async (ctx, args) => {
+        await ctx.db.patch(args.alertId, { enabled: args.enabled });
+    },
+});
+
+/**
+ * Delete a search alert.
+ */
+export const remove = mutation({
+    args: {
+        alertId: v.id("search_alerts"),
+    },
+    handler: async (ctx, args) => {
+        await ctx.db.delete(args.alertId);
+    },
+});
+
+/**
+ * List all alerts for a workspace.
+ */
+export const list = query({
+    args: {
+        workspaceSlug: v.string(),
+    },
+    handler: async (ctx, args) => {
+        return ctx.db
+            .query("search_alerts")
+            .withIndex("by_workspace", (q) => q.eq("workspaceSlug", args.workspaceSlug))
+            .collect();
+    },
+});
+
+/**
+ * List enabled alerts for a workspace (used by ingest matching).
+ */
+export const listEnabled = query({
+    args: {
+        workspaceSlug: v.string(),
+    },
+    handler: async (ctx, args) => {
+        return ctx.db
+            .query("search_alerts")
+            .withIndex("by_workspace_enabled", (q) =>
+                q.eq("workspaceSlug", args.workspaceSlug).eq("enabled", true)
+            )
+            .collect();
+    },
+});
+
+/**
+ * Mark an alert as notified (updates lastNotifiedAt).
+ */
+export const markNotified = mutation({
+    args: {
+        alertId: v.id("search_alerts"),
+    },
+    handler: async (ctx, args) => {
+        await ctx.db.patch(args.alertId, { lastNotifiedAt: Date.now() });
+    },
+});


### PR DESCRIPTION
## Summary
- Added `search_alerts` Convex table with indexes by workspace, enabled state, and search profile
- CRUD mutations: `create`, `toggle`, `remove`, `list`, `listEnabled`, `markNotified`
- REST API at `/api/search-alerts` with GET/POST/PATCH/DELETE endpoints
- Follow-up items: matching logic on ingest completion, notification dispatch via existing adapters
- Item #100 from recommendations

## Test plan
- [x] `make check-node` passes
- [ ] Create alert via POST /api/search-alerts, verify it appears in GET
- [ ] Toggle and delete alerts, verify state changes