### PR TITLE
fix: bound unbounded queries, fix dual-state render, add a11y polish

### DIFF
--- a/apps/web/src/components/search/SearchHeader.tsx
+++ b/apps/web/src/components/search/SearchHeader.tsx
@@ -120,6 +120,8 @@ export function SearchHeader({
             onClick={() => {
               navigator.clipboard.writeText(window.location.href).then(() => {
                 toast.success(t('resumes.searchPage.header.linkCopied', { defaultValue: '链接已复制' }))
+              }).catch(() => {
+                toast.error(t('resumes.searchPage.header.copyFailed', { defaultValue: '复制失败' }))
               })
             }}
             aria-label={t('resumes.searchPage.header.copyLink', { defaultValue: '复制搜索链接' })}

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -343,6 +343,7 @@ export const SnippetCard = memo(function SnippetCard({
                 variant="outline"
                 className="shrink-0 rounded-full whitespace-nowrap h-8"
                 aria-expanded={expanded}
+                aria-controls={`snippet-details-${itemKey}`}
                 onClick={() => onToggleExpanded(itemKey)}
               >
                 {expanded ? collapseLabel : expandLabel}
@@ -398,6 +399,7 @@ export const SnippetCard = memo(function SnippetCard({
       </div>
 
       {expanded ? (
+        <div id={`snippet-details-${itemKey}`}>
         <SnippetCardExpanded
           item={item}
           showAiScore={showAiScore}
@@ -428,6 +430,7 @@ export const SnippetCard = memo(function SnippetCard({
             setCommentDialogOpen(true)
           }}
         />
+        </div>
       ) : null}
 
       {/* Status note prompt dialog (for reject/withdraw) */}

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -802,7 +802,6 @@ function useBffAndModeSearch(
   refetchTrigger?: number,
 ): BffAndModeResult {
   const [result, setResult] = useState<BffAndModeResult>({ resumes: [], total: 0, expansion: null, loading: false })
-  const [loading, setLoading] = useState(false)
 
   // Serialize filters to a stable string so the effect doesn't re-run
   // on every render when the caller passes an inline object literal.
@@ -816,11 +815,10 @@ function useBffAndModeSearch(
 
     if (!enabled || !normalizedQuery || !keywordExpansion || keywordExpansion.mode !== 'AND' || expansionLoading) {
       setResult({ resumes: [], total: 0, expansion: null, loading: false })
-      setLoading(false)
       return () => { active = false }
     }
 
-    setLoading(true)
+    setResult((prev) => ({ ...prev, loading: true }))
     const queryParams: Record<string, string | number | boolean | undefined> = {
       q: normalizedQuery,
       source: 'convex',
@@ -899,27 +897,24 @@ function useBffAndModeSearch(
           resumes,
           total: data.summary?.total ?? resumes.length,
           expansion: keywordExpansion,
-          loading: true,
+          loading: false,
         })
       })
       .catch((err: unknown) => {
         console.error('BFF AND-mode search failed', err)
         if (active) {
-          setResult({ resumes: [], total: 0, expansion: keywordExpansion, loading: true })
+          setResult({ resumes: [], total: 0, expansion: keywordExpansion, loading: false })
         }
-      })
-      .finally(() => {
-        if (active) setLoading(false)
       })
 
     return () => { active = false }
   }, [enabled, expansionLoading, filtersKey, jobDescriptionId, keywordExpansion, normalizedQuery, refetchTrigger])
 
   return {
-    ...(loading && result.resumes.length === 0
+    ...(result.loading && result.resumes.length === 0
       ? { resumes: [], total: 0, expansion: keywordExpansion }
       : result),
-    loading,
+    loading: result.loading,
   }
 }
 

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -1867,7 +1867,7 @@ export const getSummaryWindow = query({
                 q.gte("crawledAt", args.fromTimestamp).lt("crawledAt", args.toTimestamp)
             )
             .filter((q) => q.neq(q.field("isArchived"), true))
-            .collect();
+            .take(10000);
 
         const bySource = new Map<string, number>();
         for (const row of rows) {
@@ -3363,18 +3363,23 @@ export const deleteResumes = mutation({
         }
 
         let deletedAiTaggingResults = 0;
-        // Collect all tagging results for all resumeIds in parallel, then batch delete
+        // Collect all tagging results for all resumeIds in batches of 50 to avoid
+        // unbounded concurrent queries that can exhaust Convex limits.
+        const BATCH_SIZE = 50;
         const allTaggingResults: Array<{ _id: Id<"ai_tagging_results"> }> = [];
-        const taggingBatches = await Promise.all(
-            existingResumeIds.map((resumeId) =>
-                ctx.db
-                    .query("ai_tagging_results")
-                    .withIndex("by_resume_profile", (q) => q.eq("resumeId", resumeId))
-                    .collect()
-            )
-        );
-        for (const batch of taggingBatches) {
-            allTaggingResults.push(...batch);
+        for (let i = 0; i < existingResumeIds.length; i += BATCH_SIZE) {
+            const batchIds = existingResumeIds.slice(i, i + BATCH_SIZE);
+            const taggingBatches = await Promise.all(
+                batchIds.map((resumeId) =>
+                    ctx.db
+                        .query("ai_tagging_results")
+                        .withIndex("by_resume_profile", (q) => q.eq("resumeId", resumeId))
+                        .collect()
+                )
+            );
+            for (const batch of taggingBatches) {
+                allTaggingResults.push(...batch);
+            }
         }
         for (const taggingResult of allTaggingResults) {
             await ctx.db.delete(taggingResult._id);


### PR DESCRIPTION
## Summary
- Bounded `getSummaryWindow` `.collect()` with `.take(10000)` to prevent memory exhaustion on wide time ranges
- Batched tagging cleanup `Promise.all` into groups of 50 to avoid unbounded concurrent queries
- Merged dual `useState` (`result` + `loading`) in `useBffAndModeSearch` to eliminate double re-renders per response
- Added `.catch()` on `clipboard.writeText` for insecure contexts (HTTP, non-focused tabs)
- Added `aria-controls` linking expand button to expanded content region

## Test plan
- [x] `make check-node` passes
- [x] Pre-existing test failures unrelated to changes (verified by stashing and re-running)