### PR TITLE
fix: load CJK fonts for Chinese resume display (#499)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>趨勢 Trends</title>
   </head>
   <body>

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -66,8 +66,13 @@ export default {
           "Helvetica Neue",
           "Arial",
           "Noto Sans",
+          /* CJK system fonts — covers macOS, Windows, Android, Linux */
+          "PingFang SC",
+          "Hiragino Sans GB",
+          "Microsoft YaHei",
           "Noto Sans SC",
           "Noto Sans TC",
+          "WenQuanYi Micro Hei",
           "sans-serif",
         ],
       },


### PR DESCRIPTION
## Summary
- Chinese text in resume cards renders as replacement characters (�) on systems without CJK fonts installed
- Tailwind config referenced `Noto Sans SC`/`Noto Sans TC` but the fonts were never actually loaded
- Added system CJK font fallbacks to the font stack: PingFang SC (macOS), Microsoft YaHei (Windows), WenQuanYi Micro Hei (Linux)
- Added Google Fonts `<link>` for Inter, Noto Sans SC, and Noto Sans TC with `display=swap` as universal fallback

## Root Cause
The `fontFamily.sans` stack in `tailwind.config.js` listed CJK font names but no `@font-face`, Google Fonts link, or local font files existed. Browsers on systems without these fonts installed fell back to generic `sans-serif` which lacks CJK glyphs.

## Test plan
- [ ] Verify Chinese text renders correctly on /dev/resumes page
- [ ] Verify font loading in DevTools Network tab (fonts.googleapis.com requests)
- [ ] Verify no layout shift from font loading (display=swap)
- [ ] Verify on macOS, Windows, and Linux environments

Closes #499