### PR TITLE
fix: resolve 3 P1 and 4 P2 search UI bugs

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>趨勢 Trends</title>
   </head>
   <body>

--- a/apps/web/src/components/search/FacetSidebar.tsx
+++ b/apps/web/src/components/search/FacetSidebar.tsx
@@ -91,6 +91,7 @@ function MinRoleYearsGroup({
   const [customOpen, setCustomOpen] = useState(typeof minRoleYears === 'number' && !isPreset)
   const [customText, setCustomText] = useState(isPreset || minRoleYears == null ? '' : String(minRoleYears))
   const inputRef = useRef<HTMLInputElement>(null)
+  const formRef = useRef<HTMLFormElement>(null)
 
   const submitCustomValue = useCallback((rawValue: string) => {
     const parsed = Number(rawValue)
@@ -103,6 +104,15 @@ function MinRoleYearsGroup({
     setCustomOpen(false)
     setCustomText('')
   }, [onSetMinRoleYears])
+
+  const handleBlur = useCallback(() => {
+    requestAnimationFrame(() => {
+      if (formRef.current && !formRef.current.contains(document.activeElement)) {
+        setCustomOpen(false)
+        setCustomText('')
+      }
+    })
+  }, [])
 
   return (
     <div className="space-y-3">
@@ -131,6 +141,7 @@ function MinRoleYearsGroup({
         })}
         {customOpen ? (
           <form
+            ref={formRef}
             className="inline-flex items-center gap-1"
             onSubmit={(event) => {
               event.preventDefault()
@@ -144,11 +155,7 @@ function MinRoleYearsGroup({
               className="h-7 w-14 px-2 text-sm"
               value={customText}
               onChange={(event) => setCustomText(event.target.value)}
-              onBlur={() => {
-                // Only close without submitting - user can click checkmark to apply
-                setCustomOpen(false)
-                setCustomText('')
-              }}
+              onBlur={handleBlur}
               autoFocus
             />
             <span className="text-sm text-slate-500">+</span>
@@ -228,6 +235,17 @@ function RangeFilterGroup({
   const [customMax, setCustomMax] = useState(activePreset || (valueMin == null && valueMax == null) ? '' : (typeof valueMax === 'number' ? String(valueMax) : ''))
   const minRef = useRef<HTMLInputElement>(null)
   const maxRef = useRef<HTMLInputElement>(null)
+  const formRef = useRef<HTMLFormElement>(null)
+
+  const handleRangeBlur = useCallback(() => {
+    requestAnimationFrame(() => {
+      if (formRef.current && !formRef.current.contains(document.activeElement)) {
+        setCustomOpen(false)
+        setCustomMin('')
+        setCustomMax('')
+      }
+    })
+  }, [])
 
   const submitCustomValues = useCallback(() => {
     const rawMin = minRef.current?.value ?? String(customMin)
@@ -283,6 +301,7 @@ function RangeFilterGroup({
         })}
         {customOpen ? (
           <form
+            ref={formRef}
             className="inline-flex items-center gap-1"
             onSubmit={(event) => {
               event.preventDefault()
@@ -297,11 +316,7 @@ function RangeFilterGroup({
               className="h-7 w-12 px-2 text-sm"
               value={customMin}
               onChange={(event) => setCustomMin(event.target.value)}
-              onBlur={() => {
-                setCustomOpen(false)
-                setCustomMin('')
-                setCustomMax('')
-              }}
+              onBlur={handleRangeBlur}
               onKeyDown={(e) => { if (e.key === 'Enter') submitCustomValues() }}
               autoFocus
             />
@@ -314,11 +329,7 @@ function RangeFilterGroup({
               className="h-7 w-12 px-2 text-sm"
               value={customMax}
               onChange={(event) => setCustomMax(event.target.value)}
-              onBlur={() => {
-                setCustomOpen(false)
-                setCustomMin('')
-                setCustomMax('')
-              }}
+              onBlur={handleRangeBlur}
               onKeyDown={(e) => { if (e.key === 'Enter') submitCustomValues() }}
             />
             <span className="text-sm text-slate-500">{unitSuffix}</span>

--- a/apps/web/src/components/search/SearchHeader.tsx
+++ b/apps/web/src/components/search/SearchHeader.tsx
@@ -86,7 +86,7 @@ export function SearchHeader({
         <div className="min-w-0 space-y-2">
           <div className="text-sm font-medium text-slate-900">{resultsLabel}</div>
           <div role="status" aria-live="polite" className="sr-only">
-            {loading ? '' : resultsLabel}
+            {loading ? t('resumes.searchPage.header.loading', { defaultValue: '正在加载...' }) : resultsLabel}
           </div>
           <div className="flex flex-wrap gap-2">
             {location ? <Badge variant="outline">{location}</Badge> : null}

--- a/apps/web/src/hooks/useAiMatching.ts
+++ b/apps/web/src/hooks/useAiMatching.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { rawApiClient } from '@/lib/api-helpers'
 import type { MatchStats, MatchingResult } from '@/types/resume'
 
@@ -96,14 +96,16 @@ export function useAiMatching() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [progress, setProgress] = useState<StreamProgress | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
 
-  const consumeMatchStream = useCallback(async (payload: MatchRequest) => {
+  const consumeMatchStream = useCallback(async (payload: MatchRequest, signal?: AbortSignal) => {
     const response = await fetch(`${baseUrl}/api/resumes/match-stream`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(payload),
+      signal,
     })
 
     if (!response.ok || !response.body) {
@@ -114,66 +116,75 @@ export function useAiMatching() {
     const decoder = new TextDecoder()
     let buffer = ''
 
-    while (true) {
-      const { value, done } = await reader.read()
-      if (done) break
-
-      buffer += decoder.decode(value, { stream: true })
-
+    try {
       while (true) {
-        const markerIndex = buffer.indexOf('\n\n')
-        if (markerIndex < 0) break
+        const { value, done } = await reader.read()
+        if (done) break
 
-        const block = buffer.slice(0, markerIndex)
-        buffer = buffer.slice(markerIndex + 2)
+        buffer += decoder.decode(value, { stream: true })
 
-        const parsed = parseSseBlock(block)
-        if (!parsed) continue
+        while (true) {
+          const markerIndex = buffer.indexOf('\n\n')
+          if (markerIndex < 0) break
 
-        if (parsed.event === 'rules') {
-          const data = parsed.data as StreamRulesPayload
-          if (Array.isArray(data.results) && data.results.length > 0) {
-            setResults(data.results)
-            setStats(calcStats(data.results))
+          const block = buffer.slice(0, markerIndex)
+          buffer = buffer.slice(markerIndex + 2)
+
+          const parsed = parseSseBlock(block)
+          if (!parsed) continue
+
+          if (parsed.event === 'rules') {
+            const data = parsed.data as StreamRulesPayload
+            if (Array.isArray(data.results) && data.results.length > 0) {
+              setResults(data.results)
+              setStats(calcStats(data.results))
+            }
+            if (data.progress) {
+              setProgress(data.progress)
+            }
+            continue
           }
-          if (data.progress) {
-            setProgress(data.progress)
+
+          if (parsed.event === 'result') {
+            const data = parsed.data as StreamResultPayload
+            if (!data.result) continue
+
+            setResults((prev) => {
+              const next = mergeResult(prev, data.result)
+              setStats(calcStats(next))
+              return next
+            })
+
+            if (data.progress) {
+              setProgress(data.progress)
+            }
+            continue
           }
-          continue
-        }
 
-        if (parsed.event === 'result') {
-          const data = parsed.data as StreamResultPayload
-          if (!data.result) continue
-
-          setResults((prev) => {
-            const next = mergeResult(prev, data.result)
-            setStats(calcStats(next))
-            return next
-          })
-
-          if (data.progress) {
-            setProgress(data.progress)
+          if (parsed.event === 'done') {
+            const data = parsed.data as StreamDonePayload
+            setStats(data.stats ?? null)
+            setProgress(null)
+            return
           }
-          continue
-        }
 
-        if (parsed.event === 'done') {
-          const data = parsed.data as StreamDonePayload
-          setStats(data.stats ?? null)
-          setProgress(null)
-          return
-        }
-
-        if (parsed.event === 'error') {
-          const payload = parsed.data as { message?: string }
-          throw new Error(payload.message || 'Stream failed')
+          if (parsed.event === 'error') {
+            const payload = parsed.data as { message?: string }
+            throw new Error(payload.message || 'Stream failed')
+          }
         }
       }
+    } finally {
+      reader.releaseLock()
     }
   }, [])
 
   const matchAll = useCallback(async (payload: MatchRequest) => {
+    // Cancel any in-flight stream
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
     setLoading(true)
     setError(null)
     setProgress(null)
@@ -206,8 +217,12 @@ export function useAiMatching() {
         await consumeMatchStream({
           ...payload,
           mode,
-        })
+        }, controller.signal)
       } catch (streamError) {
+        if (streamError instanceof DOMException && streamError.name === 'AbortError') {
+          // Stream was intentionally cancelled
+          return data
+        }
         console.error('Match stream failed', streamError)
         setError('AI streaming updates failed')
       }

--- a/apps/web/src/hooks/useAiSearchSummary.ts
+++ b/apps/web/src/hooks/useAiSearchSummary.ts
@@ -137,7 +137,7 @@ export function useAiSearchSummary({
       setGeneratedAt(data.generatedAt)
       setLoading(false)
 
-      if (data.shouldRefresh && !forceRefresh) {
+      if (data.shouldRefresh && !forceRefresh && active) {
         void requestSummary(true)
       }
     }

--- a/apps/web/src/hooks/useCandidateActions.ts
+++ b/apps/web/src/hooks/useCandidateActions.ts
@@ -108,6 +108,7 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
       const rating = extractRatingFromActionType(payload.actionType, payload.actionData)
       const previousRating = ratingsByResume[payload.resumeId]
       const previousAction = actionsByResume[payload.resumeId]
+      const previousFeedback = aiFeedbackByResume[payload.resumeId]
 
       if (rating !== undefined) {
         if (rating === 0) {
@@ -158,15 +159,28 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
             })
           }
         } else {
-          setActionsByResume((prev) => {
-            const next = { ...prev }
-            if (previousAction) {
-              next[payload.resumeId] = previousAction
-            } else {
-              delete next[payload.resumeId]
-            }
-            return next
-          })
+          const feedback = actionToAiFeedback(payload.actionType)
+          if (feedback) {
+            setAiFeedbackByResume((prev) => {
+              const next = { ...prev }
+              if (previousFeedback) {
+                next[payload.resumeId] = previousFeedback
+              } else {
+                delete next[payload.resumeId]
+              }
+              return next
+            })
+          } else {
+            setActionsByResume((prev) => {
+              const next = { ...prev }
+              if (previousAction) {
+                next[payload.resumeId] = previousAction
+              } else {
+                delete next[payload.resumeId]
+              }
+              return next
+            })
+          }
         }
         setError('Failed to save action')
         return null

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -859,7 +859,7 @@ function useBffAndModeSearch(
       .then(({ data, error }) => {
         if (!active) return
         if (error || !data?.success || !Array.isArray(data.data)) {
-          setResult({ resumes: [], total: 0, expansion: keywordExpansion, loading: true })
+          setResult({ resumes: [], total: 0, expansion: keywordExpansion, loading: false })
           return
         }
 

--- a/apps/web/src/lib/highlight.tsx
+++ b/apps/web/src/lib/highlight.tsx
@@ -17,7 +17,7 @@ export function highlightTerms(
 
   if (escaped.length === 0) return text
 
-  const pattern = new RegExp(`(${escaped.join('|')})`, 'gi')
+  const pattern = new RegExp(`(${escaped.join('|')})`, 'i')
   const parts = text.split(pattern)
 
   if (parts.length === 1) return text

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -66,8 +66,13 @@ export default {
           "Helvetica Neue",
           "Arial",
           "Noto Sans",
+          /* CJK system fonts — covers macOS, Windows, Android, Linux */
+          "PingFang SC",
+          "Hiragino Sans GB",
+          "Microsoft YaHei",
           "Noto Sans SC",
           "Noto Sans TC",
+          "WenQuanYi Micro Hei",
           "sans-serif",
         ],
       },


### PR DESCRIPTION
## Summary
- **P1**: `useAiSearchSummary` recursive retry fires after unmount — added `active` guard
- **P1**: `useAiMatching` SSE stream reader never released — added AbortController + `releaseLock()`
- **P1**: `FacetSidebar` range inputs discard values on Tab — deferred blur with `requestAnimationFrame`
- **P2**: `useCandidateActions` optimistic revert missing `aiFeedbackByResume` — save and restore on error
- **P2**: `useConvexResumes` sets `loading: true` on BFF error — changed to `loading: false`
- **P2**: `highlightTerms` regex `lastIndex` bug — removed global flag (split doesn't need it)
- **P2**: `SearchHeader` aria-live announces empty string during loading — announce loading state instead

## Test plan
- [ ] Tab between min/max range inputs in FacetSidebar — values preserved
- [ ] AI search summary loading/unmount — no stale closure errors in console
- [ ] AI matching stream — verify connection closes on navigation
- [ ] Candidate action failure — verify feedback reverts in UI
- [ ] BFF search error — verify loading spinner clears
- [ ] Search with highlighted terms — verify all matches highlighted (not alternating)
- [ ] Screen reader announces "正在加载..." during search