### PR TITLE
fix: handle 万 unit in parseSalaryRange

### DIFF
--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -658,8 +658,9 @@ export function parseSalaryRange(value: string): { min?: number; max?: number; c
   if (!normalized || /面议/.test(normalized)) return null;
   const match = normalized.match(/(\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?/);
   if (!match) return null;
-  const min = Number(match[1]);
-  const max = match[2] ? Number(match[2]) : undefined;
+  const multiplier = /万/.test(normalized) ? 10 : 1;
+  const min = Number(match[1]) * multiplier;
+  const max = match[2] ? Number(match[2]) * multiplier : undefined;
   if (Number.isNaN(min)) return null;
   const periodMatch = normalized.match(/\/(月|年)/);
   const period = periodMatch ? (periodMatch[1] === "年" ? "year" : "month") : undefined;

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -53,8 +53,9 @@ export function parseSalaryRange(value: string | undefined): { min?: number; max
     return null
   }
 
-  const min = Number(match[1])
-  const max = match[2] ? Number(match[2]) : undefined
+  const multiplier = /万/.test(normalized) ? 10 : 1
+  const min = Number(match[1]) * multiplier
+  const max = match[2] ? Number(match[2]) * multiplier : undefined
   if (Number.isNaN(min)) {
     return null
   }

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -870,8 +870,9 @@ function parseSalaryRange(value: string): { min?: number; max?: number } | null 
     if (!match) {
         return null;
     }
-    const min = Number(match[1]);
-    const max = match[2] ? Number(match[2]) : undefined;
+    const multiplier = /万/.test(normalized) ? 10 : 1;
+    const min = Number(match[1]) * multiplier;
+    const max = match[2] ? Number(match[2]) * multiplier : undefined;
     if (Number.isNaN(min)) {
         return null;
     }


### PR DESCRIPTION
## Summary
- `parseSalaryRange` in 3 locations (Convex, API, frontend) extracted raw numbers without unit conversion
- "2.8-4.2万/月" parsed as min=2.8 instead of min=28, causing resumes with salaries up to 70k CNY to incorrectly pass a ≤25k filter
- Added multiplier: 万 → ×10 (values are in k-CNY units)

## Files changed
- `packages/convex/convex/resumes.ts` — Convex backend filter
- `apps/api/src/services/resume-service.ts` — API service
- `apps/web/src/hooks/resume-filter-helpers.ts` — Frontend helpers

## Test plan
- [ ] Verify "2.8-4.2万/月" parses as {min: 28, max: 42}
- [ ] Verify "15-20k" still parses as {min: 15, max: 20} (no regression)
- [ ] Verify "面议" still returns null
- [ ] `make check` passes