### PR TITLE
fix: handle 万 unit in salary parsing + update SearchHeader test for aria-live

### DIFF
--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -658,8 +658,9 @@ export function parseSalaryRange(value: string): { min?: number; max?: number; c
   if (!normalized || /面议/.test(normalized)) return null;
   const match = normalized.match(/(\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?/);
   if (!match) return null;
-  const min = Number(match[1]);
-  const max = match[2] ? Number(match[2]) : undefined;
+  const multiplier = /万/.test(normalized) ? 10 : 1;
+  const min = Number(match[1]) * multiplier;
+  const max = match[2] ? Number(match[2]) * multiplier : undefined;
   if (Number.isNaN(min)) return null;
   const periodMatch = normalized.match(/\/(月|年)/);
   const period = periodMatch ? (periodMatch[1] === "年" ? "year" : "month") : undefined;

--- a/apps/web/src/components/search/SearchHeader.test.tsx
+++ b/apps/web/src/components/search/SearchHeader.test.tsx
@@ -105,7 +105,7 @@ describe('SearchHeader', () => {
     )
 
     expect(screen.getByText('Search Header Bar compact machine tools idle 1')).toBeInTheDocument()
-    expect(screen.getByText('为"machine tools"找到 1,250 条结果')).toBeInTheDocument()
+    expect(screen.getAllByText('为"machine tools"找到 1,250 条结果')[0]).toBeInTheDocument()
     expect(screen.getByText('Malaysia')).toBeInTheDocument()
     expect(screen.getByText('JD lathe-sales')).toBeInTheDocument()
 
@@ -133,7 +133,7 @@ describe('SearchHeader', () => {
       />
     )
 
-    expect(screen.getByText('找到 3 条结果')).toBeInTheDocument()
+    expect(screen.getAllByText('找到 3 条结果')[0]).toBeInTheDocument()
   })
 
   it('forwards header search-bar callbacks to the parent handlers', async () => {
@@ -189,7 +189,7 @@ describe('SearchHeader', () => {
       />
     )
 
-    expect(screen.getByText('为"machine tools"找到 7 条结果')).toBeInTheDocument()
+    expect(screen.getAllByText('为"machine tools"找到 7 条结果')[0]).toBeInTheDocument()
     expect(screen.queryByText('Malaysia')).not.toBeInTheDocument()
     expect(screen.queryByText(/JD /)).not.toBeInTheDocument()
   })

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -53,8 +53,9 @@ export function parseSalaryRange(value: string | undefined): { min?: number; max
     return null
   }
 
-  const min = Number(match[1])
-  const max = match[2] ? Number(match[2]) : undefined
+  const multiplier = /万/.test(normalized) ? 10 : 1
+  const min = Number(match[1]) * multiplier
+  const max = match[2] ? Number(match[2]) * multiplier : undefined
   if (Number.isNaN(min)) {
     return null
   }

--- a/config/search-profiles/51job-cn-cnc-sales.yaml
+++ b/config/search-profiles/51job-cn-cnc-sales.yaml
@@ -19,6 +19,8 @@ filters:
   maxAge: 40
   locations:
     - China
+  salaryRange:
+    max: 25
 
 schedule:
   enabled: false

--- a/config/search-profiles/job5156-cn-cnc-sales.yaml
+++ b/config/search-profiles/job5156-cn-cnc-sales.yaml
@@ -21,6 +21,8 @@ filters:
   maxAge: 40
   locations:
     - China
+  salaryRange:
+    max: 25
 
 schedule:
   enabled: false

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -870,8 +870,9 @@ function parseSalaryRange(value: string): { min?: number; max?: number } | null 
     if (!match) {
         return null;
     }
-    const min = Number(match[1]);
-    const max = match[2] ? Number(match[2]) : undefined;
+    const multiplier = /万/.test(normalized) ? 10 : 1;
+    const min = Number(match[1]) * multiplier;
+    const max = match[2] ? Number(match[2]) * multiplier : undefined;
     if (Number.isNaN(min)) {
         return null;
     }

--- a/packages/shared/src/generated/search-profile-templates.ts
+++ b/packages/shared/src/generated/search-profile-templates.ts
@@ -90,7 +90,10 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
         "maxAge": 40,
         "locations": [
           "China"
-        ]
+        ],
+        "salaryRange": {
+          "max": 25
+        }
       },
       "schedule": {
         "enabled": false,
@@ -143,7 +146,10 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
         "maxAge": 40,
         "locations": [
           "China"
-        ]
+        ],
+        "salaryRange": {
+          "max": 25
+        }
       },
       "schedule": {
         "enabled": false,
@@ -195,7 +201,10 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
         "maxAge": 40,
         "locations": [
           "China"
-        ]
+        ],
+        "salaryRange": {
+          "max": 25
+        }
       },
       "schedule": {
         "enabled": false,
@@ -245,7 +254,10 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
         "maxAge": 40,
         "locations": [
           "China"
-        ]
+        ],
+        "salaryRange": {
+          "max": 25
+        }
       },
       "schedule": {
         "enabled": false,


### PR DESCRIPTION
## Summary
- Handle 万 (ten-thousand) unit in `parseSalaryRange` across API, web hooks, and Convex layers
- Add `maxSalary=25` to CNC sales search profiles (51job, job5156)
- Update SearchHeader test to use `getAllByText` for aria-live region duplicates

## Test plan
- [x] `make check` passes (0 errors)
- [ ] Verify salary parsing: "15-25万/年" → {min: 150, max: 250, period: "year"}
- [ ] Verify SearchHeader test passes with aria-live regions