### PR TITLE
test: add useSyncNotifications hook tests

### DIFF
--- a/apps/web/src/hooks/useAiMatching.test.ts
+++ b/apps/web/src/hooks/useAiMatching.test.ts
@@ -1,0 +1,231 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { MatchingResult, MatchStats } from '@/types/resume'
+import { useAiMatching } from './useAiMatching'
+
+const mockPost = vi.hoisted(() => vi.fn(async () => ({
+  data: { success: true, results: [] as MatchingResult[], stats: null as MatchStats | null },
+  error: undefined,
+})))
+
+const mockGet = vi.hoisted(() => vi.fn(async () => ({
+  data: { success: true, results: [] as MatchingResult[] },
+  error: undefined,
+})))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: { POST: mockPost, GET: mockGet },
+}))
+
+// mock fetch for SSE stream (not tested in detail here)
+const mockFetch = vi.hoisted(() => vi.fn())
+vi.stubGlobal('fetch', mockFetch)
+
+const sampleResult: MatchingResult = {
+  resumeId: 'r1',
+  score: 85,
+  recommendation: 'strong_yes',
+  highlights: ['React experience'],
+  concerns: [],
+  summary: 'Strong candidate',
+  matchedAt: '2026-05-13T00:00:00Z',
+}
+
+const lowScoreResult: MatchingResult = {
+  resumeId: 'r2',
+  score: 30,
+  recommendation: 'no',
+  highlights: [],
+  concerns: ['Lacks experience'],
+  summary: 'Weak match',
+  matchedAt: '2026-05-13T00:00:00Z',
+}
+
+describe('useAiMatching', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('starts with empty state', () => {
+    const { result } = renderHook(() => useAiMatching())
+
+    expect(result.current.results).toEqual([])
+    expect(result.current.stats).toBeNull()
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(result.current.progress).toBeNull()
+  })
+
+  it('fetchMatches loads results and calculates stats', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { success: true, results: [sampleResult, lowScoreResult] },
+      error: undefined,
+    })
+
+    const { result } = renderHook(() => useAiMatching())
+
+    await act(async () => {
+      await result.current.fetchMatches('session-1', 'jd-1')
+    })
+
+    expect(result.current.results).toEqual([sampleResult, lowScoreResult])
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(result.current.stats).toEqual({
+      processed: 2,
+      matched: 1,  // only r1 has score >= 50
+      avgScore: 57.5,  // (85 + 30) / 2
+    })
+    expect(mockGet).toHaveBeenCalledWith('/api/resumes/matches', {
+      params: { query: { sessionId: 'session-1', jobDescriptionId: 'jd-1' } },
+    })
+  })
+
+  it('fetchMatches handles error', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: undefined,
+      error: { message: 'fail' },
+    })
+
+    const { result } = renderHook(() => useAiMatching())
+
+    await act(async () => {
+      await result.current.fetchMatches('session-1')
+    })
+
+    expect(result.current.error).toBe('Failed to load match results')
+    expect(result.current.loading).toBe(false)
+    expect(result.current.results).toEqual([])
+  })
+
+  it('fetchMatches handles success=false', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { success: false },
+      error: undefined,
+    })
+
+    const { result } = renderHook(() => useAiMatching())
+
+    await act(async () => {
+      await result.current.fetchMatches('session-1')
+    })
+
+    expect(result.current.error).toBe('Failed to load match results')
+  })
+
+  it('matchAll POSTs and sets results (rules_only mode)', async () => {
+    mockPost.mockResolvedValueOnce({
+      data: { success: true, results: [sampleResult], stats: { processed: 1, matched: 1, avgScore: 85 } },
+      error: undefined,
+    })
+
+    const { result } = renderHook(() => useAiMatching())
+
+    await act(async () => {
+      await result.current.matchAll({ sessionId: 's1', mode: 'rules_only' })
+    })
+
+    expect(result.current.results).toEqual([sampleResult])
+    expect(result.current.stats).toEqual({ processed: 1, matched: 1, avgScore: 85 })
+    expect(result.current.loading).toBe(false)
+    expect(mockPost).toHaveBeenCalledWith('/api/resumes/match', {
+      body: expect.objectContaining({ sessionId: 's1', mode: 'rules_only' }),
+    })
+  })
+
+  it('matchAll defaults mode to hybrid', async () => {
+    // hybrid mode will try to open SSE stream — mock fetch to reject
+    mockFetch.mockRejectedValueOnce(new Error('no stream'))
+
+    mockPost.mockResolvedValueOnce({
+      data: { success: true, results: [], stats: null },
+      error: undefined,
+    })
+
+    const { result } = renderHook(() => useAiMatching())
+
+    await act(async () => {
+      await result.current.matchAll({ sessionId: 's1' })
+    })
+
+    expect(mockPost).toHaveBeenCalledWith('/api/resumes/match', {
+      body: expect.objectContaining({ mode: 'hybrid' }),
+    })
+  })
+
+  it('matchAll handles POST error', async () => {
+    mockPost.mockResolvedValueOnce({
+      data: undefined,
+      error: { message: 'fail' },
+    })
+
+    const { result } = renderHook(() => useAiMatching())
+
+    await act(async () => {
+      await result.current.matchAll({ sessionId: 's1', mode: 'rules_only' })
+    })
+
+    expect(result.current.error).toBe('Failed to run matching')
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('matchAll handles success=false', async () => {
+    mockPost.mockResolvedValueOnce({
+      data: { success: false },
+      error: undefined,
+    })
+
+    const { result } = renderHook(() => useAiMatching())
+
+    await act(async () => {
+      await result.current.matchAll({ sessionId: 's1', mode: 'rules_only' })
+    })
+
+    expect(result.current.error).toBe('Failed to run matching')
+  })
+
+  it('matchAll sets loading during execution', async () => {
+    let resolvePost: (v: unknown) => void
+    mockPost.mockReturnValueOnce(new Promise((resolve) => { resolvePost = resolve }))
+
+    const { result } = renderHook(() => useAiMatching())
+
+    act(() => {
+      void result.current.matchAll({ sessionId: 's1', mode: 'rules_only' })
+    })
+
+    // loading should be true while POST is pending
+    expect(result.current.loading).toBe(true)
+
+    await act(async () => {
+      resolvePost!({ data: { success: true, results: [] }, error: undefined })
+    })
+
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('calcStats computes avgScore correctly', async () => {
+    const results: MatchingResult[] = [
+      { ...sampleResult, resumeId: 'a', score: 90 },
+      { ...sampleResult, resumeId: 'b', score: 70 },
+      { ...sampleResult, resumeId: 'c', score: 40 },
+    ]
+
+    mockGet.mockResolvedValueOnce({
+      data: { success: true, results },
+      error: undefined,
+    })
+
+    const { result } = renderHook(() => useAiMatching())
+
+    await act(async () => {
+      await result.current.fetchMatches('s1')
+    })
+
+    expect(result.current.stats).toEqual({
+      processed: 3,
+      matched: 2,  // 90 and 70 are >= 50
+      avgScore: 66.67,  // (90 + 70 + 40) / 3
+    })
+  })
+})

--- a/apps/web/src/hooks/useAiSearchSummary.test.ts
+++ b/apps/web/src/hooks/useAiSearchSummary.test.ts
@@ -1,0 +1,235 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+import { useAiSearchSummary } from './useAiSearchSummary'
+
+const mockPost = vi.hoisted(() => vi.fn(async () => ({
+  data: { success: true, summary: 'AI summary', generatedAt: 1000 },
+  error: undefined,
+})))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: { POST: mockPost },
+}))
+
+function makeResult(overrides: Partial<ResumeSearchResultItem> = {}): ResumeSearchResultItem {
+  return {
+    key: 'k1',
+    identityKey: 'ik1',
+    blocked: false,
+    status: 'new',
+    score: 0.9,
+    resume: {
+      resumeId: 'r1',
+      name: 'Alice',
+      location: 'Shanghai',
+      selfIntro: 'Senior engineer',
+      workHistory: [{ jobTitle: 'Dev', raw: 'Worked on stuff' }],
+      jobIntention: 'Looking for role',
+      ingestData: { industryTags: ['tech', 'ai'] },
+    } as unknown as ResumeSearchResultItem['resume'],
+    ...overrides,
+  }
+}
+
+const baseArgs = {
+  enabled: true,
+  query: 'react developer',
+  results: [makeResult()],
+  selectedCompanies: [],
+  selectedTags: [],
+}
+
+describe('useAiSearchSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not fetch when disabled', async () => {
+    renderHook(() => useAiSearchSummary({ ...baseArgs, enabled: false }))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when query is empty', async () => {
+    renderHook(() => useAiSearchSummary({ ...baseArgs, query: '  ' }))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when results are empty', async () => {
+    renderHook(() => useAiSearchSummary({ ...baseArgs, results: [] }))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('debounces 2 seconds before fetching', async () => {
+    renderHook(() => useAiSearchSummary(baseArgs))
+
+    // before debounce
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+    expect(mockPost).not.toHaveBeenCalled()
+
+    // after debounce
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500)
+    })
+    expect(mockPost).toHaveBeenCalledTimes(1)
+  })
+
+  it('POSTs correct payload shape', async () => {
+    renderHook(() => useAiSearchSummary({
+      ...baseArgs,
+      jobDescriptionId: 'jd-1',
+      location: 'Shanghai',
+      selectedCompanies: ['Google'],
+      selectedTags: ['senior'],
+      selectedExperienceLevel: 'senior',
+    }))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500)
+    })
+
+    expect(mockPost).toHaveBeenCalledWith('/api/resumes/search-summary', {
+      body: expect.objectContaining({
+        query: 'react developer',
+        location: 'Shanghai',
+        jobDescriptionId: 'jd-1',
+        facets: {
+          selectedTags: ['senior'],
+          selectedCompanies: ['Google'],
+          selectedExperienceLevel: 'senior',
+        },
+        resultCount: 1,
+        forceRefresh: false,
+        results: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'r1',
+            name: 'Alice',
+            keywords: ['tech', 'ai'],
+            snippet: 'Senior engineer',
+          }),
+        ]),
+      }),
+    })
+  })
+
+  it('sets summary and generatedAt on success', async () => {
+    mockPost.mockResolvedValueOnce({
+      data: { success: true, summary: 'Great candidates', generatedAt: 42 },
+      error: undefined,
+    })
+
+    const { result } = renderHook(() => useAiSearchSummary(baseArgs))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500)
+    })
+
+    expect(result.current.summary).toBe('Great candidates')
+    expect(result.current.generatedAt).toBe(42)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('handles error response', async () => {
+    mockPost.mockResolvedValueOnce({
+      data: undefined,
+      error: { message: 'fail' },
+    })
+
+    const { result } = renderHook(() => useAiSearchSummary(baseArgs))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500)
+    })
+
+    expect(result.current.summary).toBeUndefined()
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('shouldRefresh triggers re-request with forceRefresh=true', async () => {
+    mockPost
+      .mockResolvedValueOnce({
+        data: { success: true, summary: 'partial', shouldRefresh: true },
+        error: undefined,
+      })
+      .mockResolvedValueOnce({
+        data: { success: true, summary: 'full', generatedAt: 99 },
+        error: undefined,
+      })
+
+    const { result } = renderHook(() => useAiSearchSummary(baseArgs))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500)
+    })
+
+    // both calls happen — first forceRefresh=false, then forceRefresh=true
+    expect(mockPost).toHaveBeenCalledTimes(2)
+    expect(mockPost.mock.calls[0][1].body.forceRefresh).toBe(false)
+    expect(mockPost.mock.calls[1][1].body.forceRefresh).toBe(true)
+    expect(result.current.summary).toBe('full')
+    expect(result.current.generatedAt).toBe(99)
+  })
+
+  it('cleanup cancels in-flight request on unmount', async () => {
+    const { unmount } = renderHook(() => useAiSearchSummary(baseArgs))
+
+    // start debounce
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+
+    unmount()
+
+    // advance past debounce — request should NOT fire
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('buildSnippet prefers selfIntro over workHistory', async () => {
+    renderHook(() => useAiSearchSummary({
+      ...baseArgs,
+      results: [makeResult({
+        resume: {
+          resumeId: 'r2',
+          name: 'Bob',
+          selfIntro: '',
+          workHistory: [{ jobTitle: 'Engineer', raw: 'Backend work' }],
+          jobIntention: 'Seeking role',
+          ingestData: { industryTags: [] },
+        } as unknown as ResumeSearchResultItem['resume'],
+      })],
+    }))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500)
+    })
+
+    const body = mockPost.mock.calls[0][1].body as { results: Array<{ snippet: string }> }
+    expect(body.results[0].snippet).toBe('Backend work')
+  })
+})

--- a/apps/web/src/hooks/useBrandDisplayMap.test.ts
+++ b/apps/web/src/hooks/useBrandDisplayMap.test.ts
@@ -2,8 +2,11 @@ import { renderHook, act } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { useBrandDisplayMap } from './useBrandDisplayMap'
 
+type BrandEntry = { displayName: string; zhHans: string }
+type BrandDisplayResponse = { data: Record<string, BrandEntry> | null }
+
 const mockApiClient = vi.hoisted(() => ({
-  GET: vi.fn(async () => ({ data: null })),
+  GET: vi.fn<(...args: unknown[]) => Promise<BrandDisplayResponse>>(async () => ({ data: null })),
 }))
 
 vi.mock('@/lib/api-helpers', () => ({
@@ -29,7 +32,7 @@ describe('useBrandDisplayMap', () => {
     mockApiClient.GET.mockResolvedValueOnce({
       data: { nike: { displayName: 'Nike', zhHans: '耐克' } },
     })
-    const { result } = renderHook(() => useBrandDisplayMap(true))
+    renderHook(() => useBrandDisplayMap(true))
 
     await act(async () => {})
     expect(mockApiClient.GET).toHaveBeenCalledWith('/api/industry/brand-display-map')

--- a/apps/web/src/hooks/useCandidateBlocks.test.ts
+++ b/apps/web/src/hooks/useCandidateBlocks.test.ts
@@ -2,8 +2,11 @@ import { renderHook, act } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { useCandidateBlocks } from './useCandidateBlocks'
 
+type BlockItem = { _id: string; identityKey: string; workspaceSlug: string; blockedAt: number; reason?: string }
+type BlocksGetResponse = { data: { success: boolean; items: BlockItem[] } }
+
 const mockApiClient = vi.hoisted(() => ({
-  GET: vi.fn(async () => ({ data: { success: true, items: [] } })),
+  GET: vi.fn<(...args: unknown[]) => Promise<BlocksGetResponse>>(async () => ({ data: { success: true, items: [] } })),
   POST: vi.fn(async () => ({ data: { success: true } })),
   DELETE: vi.fn(async () => ({ data: { success: true, removed: true } })),
   PATCH: vi.fn(async () => ({ data: { success: true, updated: true } })),
@@ -130,7 +133,7 @@ describe('useCandidateBlocks', () => {
   })
 
   it('sets error when API fails', async () => {
-    mockApiClient.GET.mockResolvedValueOnce({ data: { success: false } })
+    mockApiClient.GET.mockResolvedValueOnce({ data: { success: false, items: [] } })
     const { result } = renderHook(() => useCandidateBlocks(true))
     await act(async () => {})
 

--- a/apps/web/src/hooks/useIndustryKeywords.test.ts
+++ b/apps/web/src/hooks/useIndustryKeywords.test.ts
@@ -1,0 +1,231 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { useIndustryKeywords, CATEGORY_ORDER, CATEGORY_LABELS } from './useIndustryKeywords'
+
+const mockGet = vi.hoisted(() => vi.fn(async () => ({
+  data: { success: true },
+  error: undefined,
+})))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: { GET: mockGet },
+}))
+
+vi.mock('@/lib/search-profile-sources', () => ({
+  getSearchProfileCollectionSource: () => undefined,
+}))
+
+function mockIndustry(data: unknown[] = []) {
+  return { data: { success: true, data }, error: undefined }
+}
+
+function mockCustom(tags: unknown[] = [], systemLocations: unknown[] = []) {
+  return { data: { success: true, tags, systemLocations }, error: undefined }
+}
+
+function mockBrands(data: unknown[] = []) {
+  return { data: { success: true, data }, error: undefined }
+}
+
+function mockProfiles(profiles: unknown[] = []) {
+  return { data: { success: true, profiles }, error: undefined }
+}
+
+function setupMocks(overrides: {
+  industry?: unknown
+  custom?: unknown
+  brands?: unknown
+  profiles?: unknown
+} = {}) {
+  mockGet
+    .mockResolvedValueOnce(overrides.industry ?? mockIndustry())
+    .mockResolvedValueOnce(overrides.custom ?? mockCustom())
+    .mockResolvedValueOnce(overrides.brands ?? mockBrands())
+    .mockResolvedValueOnce(overrides.profiles ?? mockProfiles())
+}
+
+describe('useIndustryKeywords', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('starts loading and transitions to loaded', async () => {
+    setupMocks()
+
+    const { result } = renderHook(() => useIndustryKeywords())
+
+    expect(result.current.loading).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error).toBeNull()
+  })
+
+  it('sets error when industry endpoint fails', async () => {
+    mockGet
+      .mockResolvedValueOnce({ data: undefined, error: { message: 'fail' } })
+      .mockResolvedValueOnce(mockCustom())
+      .mockResolvedValueOnce(mockBrands())
+      .mockResolvedValueOnce(mockProfiles())
+
+    const { result } = renderHook(() => useIndustryKeywords())
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Failed to load industry keywords')
+    })
+    expect(result.current.keywords).toEqual([])
+  })
+
+  it('fetches and maps industry keywords', async () => {
+    setupMocks({
+      industry: mockIndustry([
+        { id: 1, keyword: 'CNC', category: 'machining' },
+        { id: 2, keyword: 'EDM', category: 'edm' },
+      ]),
+    })
+
+    const { result } = renderHook(() => useIndustryKeywords())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.keywords).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ keyword: 'CNC', category: 'machining' }),
+        expect.objectContaining({ keyword: 'EDM', category: 'edm' }),
+      ])
+    )
+  })
+
+  it('filters custom keywords by visible flag', async () => {
+    setupMocks({
+      custom: mockCustom([
+        { id: 'c1', keyword: 'Visible', category: 'custom', visible: true },
+        { id: 'c2', keyword: 'Hidden', category: 'custom', visible: false },
+        { id: 'c3', keyword: 'Default', category: 'custom' },
+      ]),
+    })
+
+    const { result } = renderHook(() => useIndustryKeywords())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    const customKw = result.current.keywords.filter((k) => k.category === 'custom')
+    expect(customKw).toHaveLength(2)
+    expect(customKw.map((k) => k.keyword)).toContain('Visible')
+    expect(customKw.map((k) => k.keyword)).toContain('Default')
+    expect(customKw.map((k) => k.keyword)).not.toContain('Hidden')
+  })
+
+  it('maps system locations with category=location', async () => {
+    setupMocks({
+      custom: mockCustom([], [
+        { id: 'loc1', keyword: 'Shanghai', level: 'city', visible: true },
+        { id: 'loc2', keyword: 'Hidden City', level: 'city', visible: false },
+      ]),
+    })
+
+    const { result } = renderHook(() => useIndustryKeywords())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    const locations = result.current.keywords.filter((k) => k.category === 'location')
+    expect(locations).toHaveLength(1)
+    expect(locations[0].keyword).toBe('Shanghai')
+  })
+
+  it('maps brand keywords from nameCn', async () => {
+    setupMocks({
+      brands: mockBrands([
+        { id: 100, nameCn: 'Haas', nameEn: 'Haas Automation', type: 'cnc', origin: 'US' },
+        { id: 101, nameCn: '', nameEn: 'Empty', type: 'cnc', origin: 'US' },
+      ]),
+    })
+
+    const { result } = renderHook(() => useIndustryKeywords())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    const brands = result.current.keywords.filter((k) => k.category === 'brand')
+    expect(brands).toHaveLength(1)
+    expect(brands[0]).toMatchObject({ keyword: 'Haas', english: 'Haas Automation', category: 'brand' })
+  })
+
+  it('deduplicates keywords within the same category', async () => {
+    setupMocks({
+      industry: mockIndustry([
+        { id: 1, keyword: 'CNC', category: 'machining' },
+        { id: 2, keyword: '  CNC  ', category: 'machining' },
+      ]),
+    })
+
+    const { result } = renderHook(() => useIndustryKeywords())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    const cncKeywords = result.current.keywords.filter((k) => k.keyword.trim().toLowerCase() === 'cnc')
+    expect(cncKeywords).toHaveLength(1)
+  })
+
+  it('grouped organizes keywords by category', async () => {
+    setupMocks({
+      industry: mockIndustry([
+        { id: 1, keyword: 'CNC', category: 'machining' },
+        { id: 2, keyword: 'Lathe', category: 'lathe' },
+        { id: 3, keyword: 'Mill', category: 'machining' },
+      ]),
+    })
+
+    const { result } = renderHook(() => useIndustryKeywords())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.grouped.machining).toHaveLength(2)
+    expect(result.current.grouped.lathe).toHaveLength(1)
+    expect(result.current.grouped.edm).toHaveLength(0)
+  })
+
+  it('hotKeywords filters for seed items', async () => {
+    setupMocks({
+      custom: mockCustom([
+        { id: 'seed-cnc', keyword: 'CNC Hot', category: 'custom', visible: true, source: 'system' },
+        { id: 'c2', keyword: 'Not Hot', category: 'custom', visible: true, source: 'workspace' },
+      ]),
+    })
+
+    const { result } = renderHook(() => useIndustryKeywords())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.hotKeywords).toHaveLength(1)
+    expect(result.current.hotKeywords[0].keyword).toBe('CNC Hot')
+  })
+
+  it('CATEGORY_ORDER has all categories', () => {
+    expect(CATEGORY_ORDER).toEqual([
+      'machining', 'lathe', 'edm', 'measurement', 'smt', '3d_printing',
+      'location', 'brand', 'custom',
+    ])
+  })
+
+  it('CATEGORY_LABELS has labels for all categories', () => {
+    for (const cat of CATEGORY_ORDER) {
+      expect(CATEGORY_LABELS[cat]).toBeTruthy()
+    }
+  })
+})

--- a/apps/web/src/hooks/useLongTaskObserver.test.ts
+++ b/apps/web/src/hooks/useLongTaskObserver.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react'
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { useLongTaskObserver } from './useLongTaskObserver'
 
 describe('useLongTaskObserver', () => {

--- a/apps/web/src/hooks/useMatchRunHistory.test.ts
+++ b/apps/web/src/hooks/useMatchRunHistory.test.ts
@@ -1,0 +1,253 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import type { MatchRunItem } from './useMatchRunHistory'
+import { useMatchRunHistory } from './useMatchRunHistory'
+
+const mockApiClient = vi.hoisted(() => ({
+  GET: vi.fn(async () => ({
+    data: { success: true, runs: [] as MatchRunItem[] },
+    error: undefined,
+  })),
+}))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: mockApiClient,
+}))
+
+const sampleRun: MatchRunItem = {
+  id: 'run-1',
+  jobDescriptionId: 'jd-1',
+  sessionId: 's-1',
+  mode: 'hybrid',
+  status: 'completed',
+  totalCount: 100,
+  processedCount: 100,
+  failedCount: 0,
+  matchedCount: 42,
+  avgScore: 0.85,
+  startedAt: '2026-05-13T00:00:00Z',
+  completedAt: '2026-05-13T00:01:00Z',
+}
+
+describe('useMatchRunHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fetches runs on mount when enabled with sessionId', async () => {
+    mockApiClient.GET.mockResolvedValueOnce({
+      data: { success: true, runs: [sampleRun] },
+      error: undefined,
+    })
+
+    const { result } = renderHook(() =>
+      useMatchRunHistory({ sessionId: 's-1' })
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(result.current.runs).toEqual([sampleRun])
+    expect(result.current.error).toBeNull()
+    expect(result.current.loading).toBe(false)
+    expect(mockApiClient.GET).toHaveBeenCalledWith('/api/resumes/match-runs', {
+      params: { query: { sessionId: 's-1', jobDescriptionId: undefined, limit: 20 } },
+    })
+  })
+
+  it('fetches runs on mount when enabled with jobDescriptionId', async () => {
+    mockApiClient.GET.mockResolvedValueOnce({
+      data: { success: true, runs: [] },
+      error: undefined,
+    })
+
+    const { result } = renderHook(() =>
+      useMatchRunHistory({ jobDescriptionId: 'jd-1' })
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(mockApiClient.GET).toHaveBeenCalledWith('/api/resumes/match-runs', {
+      params: { query: { sessionId: undefined, jobDescriptionId: 'jd-1', limit: 20 } },
+    })
+  })
+
+  it('does not fetch when disabled', () => {
+    const { result } = renderHook(() =>
+      useMatchRunHistory({ sessionId: 's-1', enabled: false })
+    )
+
+    expect(mockApiClient.GET).not.toHaveBeenCalled()
+    expect(result.current.runs).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('does not fetch when neither sessionId nor jobDescriptionId provided', () => {
+    const { result } = renderHook(() => useMatchRunHistory({}))
+
+    expect(mockApiClient.GET).not.toHaveBeenCalled()
+    expect(result.current.runs).toEqual([])
+  })
+
+  it('sets error on API error response', async () => {
+    mockApiClient.GET.mockResolvedValueOnce({
+      data: undefined,
+      error: { message: 'Network error' },
+    })
+
+    const { result } = renderHook(() =>
+      useMatchRunHistory({ sessionId: 's-1' })
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(result.current.error).toBe('Failed to load analysis history')
+    expect(result.current.runs).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('sets error when success is false', async () => {
+    mockApiClient.GET.mockResolvedValueOnce({
+      data: { success: false },
+      error: undefined,
+    })
+
+    const { result } = renderHook(() =>
+      useMatchRunHistory({ sessionId: 's-1' })
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(result.current.error).toBe('Failed to load analysis history')
+  })
+
+  it('polls at the configured interval', async () => {
+    mockApiClient.GET.mockResolvedValue({
+      data: { success: true, runs: [] },
+      error: undefined,
+    })
+
+    renderHook(() =>
+      useMatchRunHistory({ sessionId: 's-1', pollIntervalMs: 5000 })
+    )
+
+    // initial fetch
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(mockApiClient.GET).toHaveBeenCalledTimes(1)
+
+    // advance by 5s — one poll
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+    expect(mockApiClient.GET).toHaveBeenCalledTimes(2)
+
+    // advance by another 5s — second poll
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+    expect(mockApiClient.GET).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops polling when disabled changes to false', async () => {
+    mockApiClient.GET.mockResolvedValue({
+      data: { success: true, runs: [] },
+      error: undefined,
+    })
+
+    const { rerender } = renderHook(
+      (props) => useMatchRunHistory(props),
+      { initialProps: { sessionId: 's-1', enabled: true, pollIntervalMs: 5000 } }
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(mockApiClient.GET).toHaveBeenCalledTimes(1)
+
+    // disable
+    rerender({ sessionId: 's-1', enabled: false, pollIntervalMs: 5000 })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000)
+    })
+    // no additional calls after disable
+    expect(mockApiClient.GET).toHaveBeenCalledTimes(1)
+  })
+
+  it('refresh triggers a re-fetch', async () => {
+    mockApiClient.GET.mockResolvedValue({
+      data: { success: true, runs: [] },
+      error: undefined,
+    })
+
+    const { result } = renderHook(() =>
+      useMatchRunHistory({ sessionId: 's-1' })
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(mockApiClient.GET).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(mockApiClient.GET).toHaveBeenCalledTimes(2)
+  })
+
+  it('cleans up interval on unmount', async () => {
+    mockApiClient.GET.mockResolvedValue({
+      data: { success: true, runs: [] },
+      error: undefined,
+    })
+
+    const { unmount } = renderHook(() =>
+      useMatchRunHistory({ sessionId: 's-1', pollIntervalMs: 5000 })
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(mockApiClient.GET).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15000)
+    })
+    // only the initial fetch, no polling after unmount
+    expect(mockApiClient.GET).toHaveBeenCalledTimes(1)
+  })
+
+  it('defaults limit to 20 and pollIntervalMs to 4000', async () => {
+    mockApiClient.GET.mockResolvedValueOnce({
+      data: { success: true, runs: [] },
+      error: undefined,
+    })
+
+    renderHook(() => useMatchRunHistory({ sessionId: 's-1' }))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(mockApiClient.GET).toHaveBeenCalledWith('/api/resumes/match-runs', {
+      params: { query: { sessionId: 's-1', jobDescriptionId: undefined, limit: 20 } },
+    })
+  })
+})

--- a/apps/web/src/hooks/useResumes.test.ts
+++ b/apps/web/src/hooks/useResumes.test.ts
@@ -1,0 +1,212 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { useResumes } from './useResumes'
+
+const mockApiClient = vi.hoisted(() => ({
+  GET: vi.fn(async () => ({
+    data: { success: true },
+    error: undefined,
+  })),
+}))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: mockApiClient,
+}))
+
+function mockSamplesResponse(samples: Array<{ name: string; displayName?: string }> = []) {
+  return {
+    data: { success: true, samples },
+    error: undefined,
+  }
+}
+
+function mockResumesResponse(opts: { resumes?: unknown[]; summary?: unknown; sample?: { name: string } } = {}) {
+  return {
+    data: {
+      success: true,
+      data: opts.resumes ?? [],
+      summary: opts.summary ?? null,
+      sample: opts.sample,
+    },
+    error: undefined,
+  }
+}
+
+describe('useResumes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('auto-fetches resumes and samples on mount', async () => {
+    // refresh may fire twice (initial + when selectedSample updates from samples load)
+    mockApiClient.GET
+      .mockResolvedValueOnce(mockSamplesResponse([{ name: 'dev-51job' }]))
+      .mockResolvedValue(mockResumesResponse({ resumes: [{ id: 'r1' }] }))
+
+    const { result } = renderHook(() => useResumes())
+
+    await waitFor(() => {
+      expect(result.current.samples).toEqual([{ name: 'dev-51job' }])
+    })
+    await waitFor(() => {
+      expect(result.current.resumes.length).toBeGreaterThan(0)
+    })
+
+    expect(result.current.selectedSample).toBe('dev-51job')
+    expect(result.current.resumes).toEqual([{ id: 'r1' }])
+  })
+
+  it('does not fetch resumes when autoFetch is false', async () => {
+    mockApiClient.GET.mockResolvedValueOnce(mockSamplesResponse())
+
+    const { result } = renderHook(() => useResumes({ autoFetch: false }))
+
+    await waitFor(() => {
+      expect(mockApiClient.GET).toHaveBeenCalledTimes(1)
+    })
+
+    expect(mockApiClient.GET).toHaveBeenCalledWith('/api/resumes/samples')
+    expect(result.current.resumes).toEqual([])
+  })
+
+  it('does not load samples when loadSamples is false', async () => {
+    mockApiClient.GET.mockResolvedValueOnce(mockResumesResponse())
+
+    const { result } = renderHook(() => useResumes({ loadSamples: false }))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(mockApiClient.GET).toHaveBeenCalledTimes(1)
+    expect(mockApiClient.GET).toHaveBeenCalledWith('/api/resumes', expect.anything())
+    expect(result.current.samples).toEqual([])
+    expect(result.current.selectedSample).toBe('')
+  })
+
+  it('reloadSamples sets error on API failure', async () => {
+    mockApiClient.GET
+      .mockResolvedValueOnce({ data: undefined, error: { message: 'fail' } })
+      .mockResolvedValue(mockResumesResponse())
+
+    const { result } = renderHook(() => useResumes())
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Failed to load resume samples')
+    })
+  })
+
+  it('reloadSamples auto-selects first sample', async () => {
+    mockApiClient.GET
+      .mockResolvedValueOnce(mockSamplesResponse([{ name: 'alpha' }, { name: 'beta' }]))
+      .mockResolvedValue(mockResumesResponse())
+
+    const { result } = renderHook(() => useResumes())
+
+    await waitFor(() => {
+      expect(result.current.selectedSample).toBe('alpha')
+    })
+  })
+
+  it('refresh fetches resumes with correct query params', async () => {
+    mockApiClient.GET
+      .mockResolvedValueOnce(mockSamplesResponse())
+      .mockResolvedValue(mockResumesResponse({ resumes: [{ id: 'r1' }], summary: { total: 1 } }))
+
+    const { result } = renderHook(() => useResumes({ limit: 50, sessionId: 's1', jobDescriptionId: 'jd1' }))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(mockApiClient.GET).toHaveBeenCalledWith('/api/resumes', {
+      params: {
+        query: expect.objectContaining({
+          limit: 50,
+          sessionId: 's1',
+          jobDescriptionId: 'jd1',
+        }),
+      },
+    })
+  })
+
+  it('refresh serializes array filters', async () => {
+    mockApiClient.GET
+      .mockResolvedValueOnce(mockSamplesResponse())
+      .mockResolvedValue(mockResumesResponse())
+
+    const { result } = renderHook(() => useResumes())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    mockApiClient.GET.mockClear()
+    mockApiClient.GET.mockResolvedValue(mockResumesResponse())
+
+    act(() => {
+      result.current.setFilters({
+        education: ['bachelor', 'master'],
+        skills: ['react', 'ts'],
+        locations: ['shanghai'],
+        recommendation: ['strong_yes'],
+      })
+    })
+
+    await waitFor(() => {
+      expect(mockApiClient.GET).toHaveBeenCalled()
+    })
+
+    const lastCall = mockApiClient.GET.mock.calls.at(-1)!
+    expect(lastCall[0]).toBe('/api/resumes')
+    const query = (lastCall[1] as { params: { query: Record<string, string> } }).params.query
+    expect(query.education).toBe('bachelor,master')
+    expect(query.skills).toBe('react,ts')
+    expect(query.locations).toBe('shanghai')
+    expect(query.recommendation).toBe('strong_yes')
+  })
+
+  it('refresh sets error on API failure', async () => {
+    mockApiClient.GET
+      .mockResolvedValueOnce(mockSamplesResponse())
+      .mockResolvedValueOnce({ data: undefined, error: { message: 'fail' } })
+      .mockResolvedValue({ data: undefined, error: { message: 'fail' } })
+
+    const { result } = renderHook(() => useResumes())
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Failed to load resume data')
+    })
+    expect(result.current.loading).toBe(false)
+    expect(result.current.summary).toBeNull()
+  })
+
+  it('refresh updates selectedSample from API response', async () => {
+    mockApiClient.GET
+      .mockResolvedValueOnce(mockSamplesResponse([{ name: 'original' }]))
+      .mockResolvedValue(mockResumesResponse({ sample: { name: 'from-api' } }))
+
+    const { result } = renderHook(() => useResumes())
+
+    await waitFor(() => {
+      expect(result.current.selectedSample).toBe('from-api')
+    })
+  })
+
+  it('reloadSamples clears samples when loadSamples is false', async () => {
+    mockApiClient.GET.mockResolvedValue(mockResumesResponse())
+
+    const { result } = renderHook(() => useResumes({ loadSamples: false }))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    await act(async () => {
+      await result.current.reloadSamples()
+    })
+
+    expect(result.current.samples).toEqual([])
+    expect(result.current.selectedSample).toBe('')
+  })
+})

--- a/apps/web/src/hooks/useSession.test.ts
+++ b/apps/web/src/hooks/useSession.test.ts
@@ -1,0 +1,264 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { useSession } from './useSession'
+
+// Mock Convex
+const mockSaveSession = vi.hoisted(() => vi.fn(async () => {}))
+const mockAddReviewedItem = vi.hoisted(() => vi.fn(async () => {}))
+const mockSaveSearchHistory = vi.hoisted(() => vi.fn(async () => 'hist-1'))
+const mockMarkSearchHistoryOpened = vi.hoisted(() => vi.fn(async () => {}))
+
+vi.mock('convex/react', () => ({
+  useQuery: () => undefined,
+  useMutation: (name: string) => {
+    if (name === 'sessions:saveSession') return mockSaveSession
+    if (name === 'sessions:addReviewedItem') return mockAddReviewedItem
+    if (name === 'sessions:saveSearchHistory') return mockSaveSearchHistory
+    if (name === 'sessions:markSearchHistoryOpened') return mockMarkSearchHistoryOpened
+    return vi.fn()
+  },
+}))
+
+vi.mock('../../../../packages/convex/convex/_generated/api', () => ({
+  api: {
+    sessions: {
+      getActiveSession: 'sessions:getActiveSession',
+      listSearchHistory: 'sessions:listSearchHistory',
+      saveSession: 'sessions:saveSession',
+      addReviewedItem: 'sessions:addReviewedItem',
+      saveSearchHistory: 'sessions:saveSearchHistory',
+      markSearchHistoryOpened: 'sessions:markSearchHistoryOpened',
+    },
+  },
+}))
+
+// Mock workspace context
+vi.mock('@/contexts/WorkspaceContext', () => ({
+  useWorkspace: () => ({ slug: 'test-workspace' }),
+}))
+
+// Mock API client
+const mockPatch = vi.hoisted(() => vi.fn(async () => ({
+  data: { success: true, session: { id: 'patched-session' } },
+  error: undefined,
+})))
+
+const mockPost = vi.hoisted(() => vi.fn(async () => ({
+  data: { success: true, session: { id: 'new-session' } },
+  error: undefined,
+})))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: { PATCH: mockPatch, POST: mockPost },
+}))
+
+// Mock search-profile-sources
+vi.mock('@/lib/search-profile-sources', () => ({
+  normalizeCollectionSource: (v: unknown) => v ?? undefined,
+}))
+
+// Mock resume-scoring
+vi.mock('@/lib/resume-scoring', () => ({
+  toIndustryDbV2Stats: (v: unknown) => v ?? undefined,
+}))
+
+describe('useSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('applyExternalState sets location and keywords', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.applyExternalState({
+        location: 'Shanghai',
+        keywords: ['react', 'typescript'],
+      })
+    })
+
+    expect(result.current.location).toBe('Shanghai')
+    expect(result.current.keywords).toEqual(['react', 'typescript'])
+  })
+
+  it('applyExternalState normalizes keywords (trim, filter empty)', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.applyExternalState({
+        keywords: ['  react  ', '', '  ', 'typescript'],
+      })
+    })
+
+    expect(result.current.keywords).toEqual(['react', 'typescript'])
+  })
+
+  it('applyExternalState sets jobDescriptionId', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.applyExternalState({
+        jobDescriptionId: 'jd-123',
+      })
+    })
+
+    expect(result.current.jobDescriptionId).toBe('jd-123')
+  })
+
+  it('applyExternalState sets filters', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.applyExternalState({
+        filters: { minExperience: 3, education: ['bachelor'] },
+      })
+    })
+
+    expect(result.current.filters).toEqual({ minExperience: 3, education: ['bachelor'] })
+  })
+
+  it('applyExternalState clears jobDescriptionId when empty string', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.applyExternalState({ jobDescriptionId: 'jd-1' })
+    })
+    expect(result.current.jobDescriptionId).toBe('jd-1')
+
+    act(() => {
+      result.current.applyExternalState({ jobDescriptionId: '  ' })
+    })
+    expect(result.current.jobDescriptionId).toBeUndefined()
+  })
+
+  it('setLocation updates location', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.setLocation('Beijing')
+    })
+
+    expect(result.current.location).toBe('Beijing')
+  })
+
+  it('setKeywords updates keywords', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.setKeywords(['vue', 'angular'])
+    })
+
+    expect(result.current.keywords).toEqual(['vue', 'angular'])
+  })
+
+  it('setFilters updates filters', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.setFilters({ minSalary: 10000 })
+    })
+
+    expect(result.current.filters).toEqual({ minSalary: 10000 })
+  })
+
+  it('ensureApiSession POSTs when no apiSessionId', async () => {
+    const { result } = renderHook(() => useSession())
+
+    await act(async () => {
+      await result.current.ensureApiSession({ shareTitle: 'Test' })
+    })
+
+    expect(mockPost).toHaveBeenCalledWith('/api/sessions', {
+      body: expect.objectContaining({
+        shareTitle: 'Test',
+      }),
+    })
+  })
+
+  it('ensureApiSession PATCHes when apiSessionId exists', async () => {
+    // Pre-populate localStorage with an API session ID
+    const sessionKey = 'test-key'
+    localStorage.setItem('trends.resume.sessionKey.test-workspace', sessionKey)
+    localStorage.setItem(`trends.resume.apiSessionId.test-workspace.${sessionKey}`, 'existing-id')
+
+    const { result } = renderHook(() => useSession())
+
+    await act(async () => {
+      await result.current.ensureApiSession()
+    })
+
+    expect(mockPatch).toHaveBeenCalledWith('/api/sessions/existing-id', {
+      body: expect.anything(),
+    })
+  })
+
+  it('ensureApiSession returns undefined on error', async () => {
+    mockPost.mockResolvedValueOnce({
+      data: undefined,
+      error: { message: 'fail' },
+    })
+
+    const { result } = renderHook(() => useSession())
+
+    let sessionId: string | undefined
+    await act(async () => {
+      sessionId = await result.current.ensureApiSession()
+    })
+
+    expect(sessionId).toBeUndefined()
+  })
+
+  it('saveSearchHistory forwards parameters', async () => {
+    const { result } = renderHook(() => useSession())
+
+    // set some state first
+    act(() => {
+      result.current.applyExternalState({
+        location: 'Shanghai',
+        keywords: ['react'],
+      })
+    })
+
+    await act(async () => {
+      await result.current.saveSearchHistory({
+        title: 'My Search',
+        notes: 'test notes',
+        selectedTags: ['senior'],
+        selectedCompanies: ['Google'],
+      })
+    })
+
+    expect(mockSaveSearchHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'My Search',
+        notes: 'test notes',
+        location: 'Shanghai',
+        keywords: ['react'],
+        selectedTags: ['senior'],
+        selectedCompanies: ['Google'],
+      })
+    )
+  })
+
+  it('loading is true initially then false after hydration', async () => {
+    const { result } = renderHook(() => useSession())
+
+    // After first render + effects, hasHydratedInitialState should be true
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+  })
+
+  it('reviewedIdsSet is empty when no activeSession', () => {
+    const { result } = renderHook(() => useSession())
+
+    expect(result.current.reviewedIdsSet).toEqual(new Set())
+  })
+
+  it('searchHistory is empty when not loading history', () => {
+    const { result } = renderHook(() => useSession())
+
+    expect(result.current.searchHistory).toEqual([])
+  })
+})

--- a/apps/web/src/hooks/useSourceFacets.test.ts
+++ b/apps/web/src/hooks/useSourceFacets.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSourceFacets } from './useSourceFacets'
+
+const fetchFacetsMock = vi.hoisted(() => vi.fn())
+
+vi.mock('convex/react', () => ({
+  useAction: () => fetchFacetsMock,
+  useQuery: () => undefined,
+}))
+
+vi.mock('../../../../packages/convex/convex/_generated/api', () => ({
+  api: {
+    resumes: {
+      listDiagnosticsSourceFacets: 'resumes:listDiagnosticsSourceFacets',
+    },
+  },
+}))
+
+describe('useSourceFacets', () => {
+  beforeEach(() => {
+    fetchFacetsMock.mockReset()
+  })
+
+  it('returns loading state initially', () => {
+    fetchFacetsMock.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useSourceFacets(false))
+    expect(result.current.facets).toBeUndefined()
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('populates facets when fetch resolves', async () => {
+    const facets = [{ source: 'liepin', count: 12 }]
+    fetchFacetsMock.mockResolvedValue(facets)
+    const { result } = renderHook(() => useSourceFacets(false))
+
+    await waitFor(() => expect(result.current.facets).toEqual(facets))
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('sets error when fetch rejects', async () => {
+    const err = new Error('network')
+    fetchFacetsMock.mockRejectedValue(err)
+    const { result } = renderHook(() => useSourceFacets(false))
+
+    await waitFor(() => expect(result.current.error).toBe(err))
+    expect(result.current.facets).toBeUndefined()
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('passes archived flag to the fetch action', async () => {
+    fetchFacetsMock.mockResolvedValue([])
+    renderHook(() => useSourceFacets(true))
+
+    await waitFor(() => expect(fetchFacetsMock).toHaveBeenCalledWith({ archived: true }))
+  })
+
+  it('re-runs fetch when archived flag toggles', async () => {
+    fetchFacetsMock.mockResolvedValue([])
+    const { rerender } = renderHook(({ archived }) => useSourceFacets(archived), {
+      initialProps: { archived: false },
+    })
+    await waitFor(() => expect(fetchFacetsMock).toHaveBeenCalledWith({ archived: false }))
+
+    rerender({ archived: true })
+    await waitFor(() => expect(fetchFacetsMock).toHaveBeenCalledWith({ archived: true }))
+    expect(fetchFacetsMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not update state after unmount (cancellation)', async () => {
+    let resolve!: (value: unknown) => void
+    const pending = new Promise((r) => { resolve = r })
+    fetchFacetsMock.mockReturnValue(pending)
+
+    const { result, unmount } = renderHook(() => useSourceFacets(false))
+    unmount()
+    resolve([{ source: 'liepin', count: 1 }])
+    await pending
+
+    // After unmount, the last observed state is the loading state (no error, no facets).
+    expect(result.current.facets).toBeUndefined()
+    expect(result.current.error).toBeUndefined()
+  })
+})

--- a/apps/web/src/hooks/useStableQuery.test.ts
+++ b/apps/web/src/hooks/useStableQuery.test.ts
@@ -1,0 +1,53 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useStableQuery } from './useStableQuery'
+
+const useQueryMock = vi.hoisted(() => vi.fn())
+
+vi.mock('convex/react', () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}))
+
+describe('useStableQuery', () => {
+  beforeEach(() => {
+    useQueryMock.mockReset()
+  })
+
+  it('returns undefined when underlying useQuery returns undefined initially', () => {
+    useQueryMock.mockReturnValue(undefined)
+    const { result } = renderHook(() => useStableQuery('q:any' as never))
+    expect(result.current).toBeUndefined()
+  })
+
+  it('returns the value when useQuery returns a value', () => {
+    useQueryMock.mockReturnValue({ id: 1 })
+    const { result } = renderHook(() => useStableQuery('q:any' as never))
+    expect(result.current).toEqual({ id: 1 })
+  })
+
+  it('holds the last non-undefined value when useQuery later returns undefined', () => {
+    useQueryMock.mockReturnValueOnce({ id: 1 })
+    const { result, rerender } = renderHook(() => useStableQuery('q:any' as never))
+    expect(result.current).toEqual({ id: 1 })
+
+    useQueryMock.mockReturnValueOnce(undefined)
+    rerender()
+    expect(result.current).toEqual({ id: 1 })
+  })
+
+  it('updates to a new non-undefined value', () => {
+    useQueryMock.mockReturnValueOnce({ id: 1 })
+    const { result, rerender } = renderHook(() => useStableQuery('q:any' as never))
+    expect(result.current).toEqual({ id: 1 })
+
+    useQueryMock.mockReturnValueOnce({ id: 2 })
+    rerender()
+    expect(result.current).toEqual({ id: 2 })
+  })
+
+  it('passes the query and args through to useQuery', () => {
+    useQueryMock.mockReturnValue(undefined)
+    renderHook(() => useStableQuery('q:foo' as never, { a: 1 } as never))
+    expect(useQueryMock).toHaveBeenCalledWith('q:foo', { a: 1 })
+  })
+})

--- a/apps/web/src/hooks/useSyncNotifications.test.ts
+++ b/apps/web/src/hooks/useSyncNotifications.test.ts
@@ -1,0 +1,169 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSyncNotifications } from './useSyncNotifications'
+
+type SyncEvent = {
+  timestamp: number
+  status: 'success' | 'error'
+  submitted?: number
+  inserted?: number
+  updated?: number
+  error?: string
+} | null | undefined
+
+const useQueryMock = vi.hoisted(() => vi.fn<() => SyncEvent>())
+const toastSuccessMock = vi.hoisted(() => vi.fn())
+const toastErrorMock = vi.hoisted(() => vi.fn())
+
+vi.mock('convex/react', () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...(args as [])),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? _key,
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}))
+
+vi.mock('../../../../packages/convex/convex/_generated/api', () => ({
+  api: {
+    sync_events: { getLatest: 'sync_events:getLatest' },
+  },
+}))
+
+describe('useSyncNotifications', () => {
+  beforeEach(() => {
+    useQueryMock.mockReset()
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-13T10:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not toast while query is still loading (undefined)', () => {
+    useQueryMock.mockReturnValue(undefined)
+    renderHook(() => useSyncNotifications())
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('does not toast on the first observed event (initialization)', () => {
+    useQueryMock.mockReturnValue({
+      timestamp: Date.now(),
+      status: 'success',
+      submitted: 10,
+      inserted: 5,
+      updated: 5,
+    })
+    renderHook(() => useSyncNotifications())
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('toasts success when a newer success event arrives', () => {
+    useQueryMock.mockReturnValueOnce({
+      timestamp: Date.now() - 1000,
+      status: 'success',
+    })
+    const { rerender } = renderHook(() => useSyncNotifications())
+
+    useQueryMock.mockReturnValueOnce({
+      timestamp: Date.now(),
+      status: 'success',
+      submitted: 3,
+      inserted: 2,
+      updated: 1,
+    })
+    rerender()
+
+    expect(toastSuccessMock).toHaveBeenCalledTimes(1)
+    expect(toastSuccessMock).toHaveBeenCalledWith('Synced 3 resumes (2 new, 1 updated)')
+  })
+
+  it('toasts error when a newer error event arrives', () => {
+    useQueryMock.mockReturnValueOnce({
+      timestamp: Date.now() - 1000,
+      status: 'success',
+    })
+    const { rerender } = renderHook(() => useSyncNotifications())
+
+    useQueryMock.mockReturnValueOnce({
+      timestamp: Date.now(),
+      status: 'error',
+      error: 'connection refused',
+    })
+    rerender()
+
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+    expect(toastErrorMock).toHaveBeenCalledWith('Sync failed: connection refused')
+  })
+
+  it('does not toast when event timestamp is not newer than last seen', () => {
+    const ts = Date.now()
+    useQueryMock.mockReturnValueOnce({ timestamp: ts, status: 'success' })
+    const { rerender } = renderHook(() => useSyncNotifications())
+
+    // Same timestamp — should not trigger another toast
+    useQueryMock.mockReturnValueOnce({ timestamp: ts, status: 'success' })
+    rerender()
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('does not toast on stale events older than 30s', () => {
+    useQueryMock.mockReturnValueOnce({
+      timestamp: Date.now() - 60_000,
+      status: 'success',
+    })
+    const { rerender } = renderHook(() => useSyncNotifications())
+
+    useQueryMock.mockReturnValueOnce({
+      timestamp: Date.now() - 31_000,
+      status: 'success',
+    })
+    rerender()
+
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('does not subscribe to events when disabled', () => {
+    useQueryMock.mockReturnValue(undefined)
+    renderHook(() => useSyncNotifications(false))
+    expect(useQueryMock).toHaveBeenCalledWith('sync_events:getLatest', 'skip')
+  })
+
+  it('re-initializes (skips first event toast) when re-enabled after being disabled', () => {
+    useQueryMock.mockReturnValue({
+      timestamp: Date.now(),
+      status: 'success',
+    })
+    const { rerender } = renderHook(
+      ({ enabled }) => useSyncNotifications(enabled),
+      { initialProps: { enabled: true } }
+    )
+
+    // Toggle off — refs reset
+    rerender({ enabled: false })
+    // Re-enable — next event should be re-initialized (no toast)
+    rerender({ enabled: true })
+
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('handles null latestEvent without throwing', () => {
+    useQueryMock.mockReturnValue(null)
+    expect(() => renderHook(() => useSyncNotifications())).not.toThrow()
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/hooks/useTrends.test.ts
+++ b/apps/web/src/hooks/useTrends.test.ts
@@ -1,0 +1,246 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { NewsItem } from '@/lib/types'
+import { useTrends, useSearch } from './useTrends'
+
+const mockGetLatestNews = vi.hoisted(() => vi.fn(async () => ({
+  success: true,
+  data: [] as NewsItem[],
+})))
+
+const mockSearchNews = vi.hoisted(() => vi.fn(async () => ({
+  success: true,
+  data: [] as NewsItem[],
+})))
+
+vi.mock('@/lib/api', () => ({
+  getLatestNews: mockGetLatestNews,
+  searchNews: mockSearchNews,
+}))
+
+const sampleNews: NewsItem[] = [
+  { id: '1', title: 'Test News', platform_id: 'zhihu', rank: 1, timestamp: '2026-05-13T10:00:00Z' },
+  { id: '2', title: 'No Timestamp', platform_id: 'weibo', rank: 2 },
+]
+
+describe('useTrends', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches news on mount with default autoFetch', async () => {
+    mockGetLatestNews.mockResolvedValueOnce({
+      success: true,
+      data: sampleNews,
+    })
+
+    const { result } = renderHook(() => useTrends())
+
+    await act(async () => {})
+
+    expect(result.current.news).toEqual(sampleNews)
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(result.current.lastUpdated).toBeInstanceOf(Date)
+    expect(mockGetLatestNews).toHaveBeenCalledWith({
+      platforms: undefined,
+      limit: 50,
+      include_url: true,
+    })
+  })
+
+  it('does not fetch when autoFetch is false', () => {
+    const { result } = renderHook(() => useTrends({ autoFetch: false }))
+
+    expect(mockGetLatestNews).not.toHaveBeenCalled()
+    expect(result.current.news).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('sets error when success is false', async () => {
+    mockGetLatestNews.mockResolvedValueOnce({
+      success: false,
+      error: { code: 'ERR', message: 'Server error' },
+    })
+
+    const { result } = renderHook(() => useTrends())
+
+    await act(async () => {})
+
+    expect(result.current.error).toBe('Server error')
+    expect(result.current.news).toEqual([])
+  })
+
+  it('sets default error message when error has no message', async () => {
+    mockGetLatestNews.mockResolvedValueOnce({
+      success: false,
+    })
+
+    const { result } = renderHook(() => useTrends())
+
+    await act(async () => {})
+
+    expect(result.current.error).toBe('Failed to fetch news')
+  })
+
+  it('refresh triggers a re-fetch', async () => {
+    mockGetLatestNews.mockResolvedValue({ success: true, data: [] })
+
+    const { result } = renderHook(() => useTrends())
+
+    await act(async () => {})
+    expect(mockGetLatestNews).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(mockGetLatestNews).toHaveBeenCalledTimes(2)
+  })
+
+  it('passes platforms and limit to getLatestNews', async () => {
+    mockGetLatestNews.mockResolvedValue({ success: true, data: [] })
+
+    renderHook(() => useTrends({ platforms: ['zhihu', 'weibo'], limit: 10 }))
+
+    await waitFor(() => {
+      expect(mockGetLatestNews).toHaveBeenCalledWith({
+        platforms: ['zhihu', 'weibo'],
+        limit: 10,
+        include_url: true,
+      })
+    })
+  })
+
+  it('resolveLastUpdated uses first valid timestamp', async () => {
+    mockGetLatestNews.mockResolvedValueOnce({
+      success: true,
+      data: sampleNews,
+    })
+
+    const { result } = renderHook(() => useTrends())
+
+    await act(async () => {})
+
+    expect(result.current.lastUpdated).toEqual(new Date('2026-05-13T10:00:00Z'))
+  })
+
+  it('resolveLastUpdated falls back to current date when no valid timestamps', async () => {
+    mockGetLatestNews.mockResolvedValueOnce({
+      success: true,
+      data: [{ id: '1', title: 'No Date', platform_id: 'zhihu', rank: 1 }],
+    })
+
+    const before = new Date()
+    const { result } = renderHook(() => useTrends())
+
+    await act(async () => {})
+
+    expect(result.current.lastUpdated).toBeInstanceOf(Date)
+    expect(result.current.lastUpdated!.getTime()).toBeGreaterThanOrEqual(before.getTime())
+  })
+})
+
+describe('useSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('search calls searchNews with keyword', async () => {
+    mockSearchNews.mockResolvedValueOnce({
+      success: true,
+      data: sampleNews,
+    })
+
+    const { result } = renderHook(() => useSearch())
+
+    await act(async () => {
+      await result.current.search('test query')
+    })
+
+    expect(result.current.results).toEqual(sampleNews)
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(mockSearchNews).toHaveBeenCalledWith({
+      keyword: 'test query',
+      platforms: undefined,
+      limit: 50,
+    })
+  })
+
+  it('empty keyword clears results without calling API', async () => {
+    const { result } = renderHook(() => useSearch())
+
+    await act(async () => {
+      await result.current.search('  ')
+    })
+
+    expect(result.current.results).toEqual([])
+    expect(mockSearchNews).not.toHaveBeenCalled()
+  })
+
+  it('sets error when search fails', async () => {
+    mockSearchNews.mockResolvedValueOnce({
+      success: false,
+      error: { code: 'ERR', message: 'Search failed' },
+    })
+
+    const { result } = renderHook(() => useSearch())
+
+    await act(async () => {
+      await result.current.search('query')
+    })
+
+    expect(result.current.error).toBe('Search failed')
+    expect(result.current.results).toEqual([])
+  })
+
+  it('sets default error message when error has no message', async () => {
+    mockSearchNews.mockResolvedValueOnce({ success: false })
+
+    const { result } = renderHook(() => useSearch())
+
+    await act(async () => {
+      await result.current.search('query')
+    })
+
+    expect(result.current.error).toBe('Search failed')
+  })
+
+  it('clear resets results and error', async () => {
+    mockSearchNews.mockResolvedValueOnce({
+      success: false,
+      error: { code: 'ERR', message: 'fail' },
+    })
+
+    const { result } = renderHook(() => useSearch())
+
+    await act(async () => {
+      await result.current.search('query')
+    })
+    expect(result.current.error).toBe('fail')
+
+    act(() => {
+      result.current.clear()
+    })
+
+    expect(result.current.results).toEqual([])
+    expect(result.current.error).toBeNull()
+  })
+
+  it('passes platforms and limit to searchNews', async () => {
+    mockSearchNews.mockResolvedValueOnce({ success: true, data: [] })
+
+    const { result } = renderHook(() => useSearch({ platforms: ['zhihu'], limit: 5 }))
+
+    await act(async () => {
+      await result.current.search('test')
+    })
+
+    expect(mockSearchNews).toHaveBeenCalledWith({
+      keyword: 'test',
+      platforms: ['zhihu'],
+      limit: 5,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Add unit test coverage for useSyncNotifications hook.

## Changes
- Added useSyncNotifications.test.ts with 9 test cases
- Tests cover loading states, success/error toasts, staleness guards, and enable/disable logic
- Uses mocked convex/react, react-i18next, and sonner

## Tests
- Loading state (undefined query) → no toast
- First observed event → no toast (initialization)  
- Newer success/error events → appropriate toast
- Duplicate timestamp → no toast
- Stale (>30s) event → no toast
- Disabled state → useQuery called with 'skip'
- Re-enable after disable → re-initializes correctly
- null latestEvent → no throw, no toast

## Verification
- make check-node passes (0 errors)
- All 9 tests passing