### PR TITLE
fix: restore over-trimmed useSession tests

### DIFF
--- a/apps/web/src/hooks/useSession.test.ts
+++ b/apps/web/src/hooks/useSession.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { useSession } from './useSession'
 
@@ -29,6 +29,26 @@ vi.mock('../../../../packages/convex/convex/_generated/api', () => ({
       markSearchHistoryOpened: 'sessions:markSearchHistoryOpened',
     },
   },
+}))
+
+// Mock API client
+type SessionApiResponse = {
+  data?: { session: { id: string } } & Record<string, unknown>
+  error?: { message: string } | undefined
+}
+
+const mockPatch = vi.hoisted(() => vi.fn(async (): Promise<SessionApiResponse> => ({
+  data: { success: true, session: { id: 'patched-session' } },
+  error: undefined,
+})))
+
+const mockPost = vi.hoisted(() => vi.fn(async (): Promise<SessionApiResponse> => ({
+  data: { success: true, session: { id: 'new-session' } },
+  error: undefined,
+})))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: { PATCH: mockPatch, POST: mockPost },
 }))
 
 // Mock workspace context
@@ -107,5 +127,112 @@ describe('useSession', () => {
         location: 'Shanghai',
       },
     })
+  })
+
+  it('applyExternalState sets filters', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.applyExternalState({
+        filters: { minExperience: 3, education: ['bachelor'] },
+      })
+    })
+
+    expect(result.current.filters).toEqual({ minExperience: 3, education: ['bachelor'] })
+  })
+
+  it('applyExternalState clears jobDescriptionId when empty string', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.applyExternalState({ jobDescriptionId: 'jd-1' })
+    })
+    expect(result.current.jobDescriptionId).toBe('jd-1')
+
+    act(() => {
+      result.current.applyExternalState({ jobDescriptionId: '' })
+    })
+
+    expect(result.current.jobDescriptionId).toBe('')
+  })
+
+  it('setLocation updates location', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.setLocation('Beijing')
+    })
+
+    expect(result.current.location).toBe('Beijing')
+  })
+
+  it('setKeywords updates keywords', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.setKeywords(['vue', 'angular'])
+    })
+
+    expect(result.current.keywords).toEqual(['vue', 'angular'])
+  })
+
+  it('setFilters updates filters', () => {
+    const { result } = renderHook(() => useSession())
+
+    act(() => {
+      result.current.setFilters({ minSalary: 10000 })
+    })
+
+    expect(result.current.filters).toEqual({ minSalary: 10000 })
+  })
+
+  it('ensureApiSession POSTs when no apiSessionId', async () => {
+    const { result } = renderHook(() => useSession())
+
+    let sessionId: string | undefined
+    await act(async () => {
+      sessionId = await result.current.ensureApiSession({ shareTitle: 'Test' })
+    })
+
+    expect(mockPost).toHaveBeenCalledWith('/api/sessions', expect.objectContaining({
+      body: expect.objectContaining({ shareTitle: 'Test' }),
+    }))
+    expect(sessionId).toBe('new-session')
+  })
+
+  it('ensureApiSession returns undefined on error', async () => {
+    mockPost.mockResolvedValueOnce({
+      data: undefined,
+      error: { message: 'fail' },
+    })
+
+    const { result } = renderHook(() => useSession())
+
+    let sessionId: string | undefined
+    await act(async () => {
+      sessionId = await result.current.ensureApiSession()
+    })
+
+    expect(sessionId).toBeUndefined()
+  })
+
+  it('loading becomes false after hydration', async () => {
+    const { result } = renderHook(() => useSession())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+  })
+
+  it('reviewedIdsSet is empty Set initially', () => {
+    const { result } = renderHook(() => useSession())
+
+    expect(result.current.reviewedIdsSet).toEqual(new Set())
+  })
+
+  it('searchHistory is empty array initially', () => {
+    const { result } = renderHook(() => useSession())
+
+    expect(result.current.searchHistory).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
Re-add ensureApiSession, setLocation, setKeywords, setFilters tests that were removed alongside invalid tests in the fix-cicd-checks cycle.

## Test plan
- [ ] `make check` passes