### PR TITLE
fix: replace localStorage.clearItem with removeItem in useSession tests

### DIFF
--- a/apps/web/src/hooks/useSession.test.ts
+++ b/apps/web/src/hooks/useSession.test.ts
@@ -69,7 +69,7 @@ vi.mock('@/lib/resume-scoring', () => ({
 describe('useSession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    localStorage.clearItem('convex_session_id')
+    localStorage.removeItem('convex_session_id')
   })
 
   it('applyExternalState sets location and keywords', () => {


### PR DESCRIPTION
## Summary\n\nFixes CI failure on main. `localStorage.clearItem` does not exist — should be `localStorage.removeItem`. This was causing 13 test failures in `useSession.test.ts` and blocking the CI pipeline.\n\n## Before/After\n- `npx vitest run`: 9 failed → 2 failed (remaining 2 are pre-existing Convex backend test failures)\n- `make check`: passes