### PR TITLE
fix: update useSession and useAiSearchSummary test assertions for API compatibility

### DIFF
--- a/apps/web/src/hooks/useAiSearchSummary.test.ts
+++ b/apps/web/src/hooks/useAiSearchSummary.test.ts
@@ -196,9 +196,9 @@ describe('useAiSearchSummary', () => {
 
     // both calls happen — first forceRefresh=false, then forceRefresh=true
     expect(mockPost).toHaveBeenCalledTimes(2)
-    const calls = mockPost.mock.calls as unknown as Array<[{ body: { forceRefresh: boolean } }]>
-    expect(calls[0][0].body.forceRefresh).toBe(false)
-    expect(calls[1][0].body.forceRefresh).toBe(true)
+    const calls = mockPost.mock.calls as unknown as Array<[string, { body: { forceRefresh: boolean } }]>
+    expect(calls[0]?.[1]?.body?.forceRefresh).toBe(false)
+    expect(calls[1]?.[1]?.body?.forceRefresh).toBe(true)
     expect(result.current.summary).toBe('full')
     expect(result.current.generatedAt).toBe(99)
   })
@@ -240,7 +240,7 @@ describe('useAiSearchSummary', () => {
       await vi.advanceTimersByTimeAsync(2500)
     })
 
-    const calls = mockPost.mock.calls as unknown as Array<[{ body: { results: Array<{ snippet: string }> } }]>
-    expect(calls[0][0].body.results[0].snippet).toBe('Backend work')
+    const calls = mockPost.mock.calls as unknown as Array<[string, { body: { results: Array<{ snippet: string }> } }]>
+    expect(calls[0]?.[1]?.body?.results?.[0]?.snippet).toBe('Backend work')
   })
 })

--- a/apps/web/src/hooks/useSession.test.ts
+++ b/apps/web/src/hooks/useSession.test.ts
@@ -69,7 +69,7 @@ vi.mock('@/lib/resume-scoring', () => ({
 describe('useSession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    localStorage.clearItem('convex_session_id')
+    localStorage.removeItem('convex_session_id')
   })
 
   it('applyExternalState sets location and keywords', () => {

--- a/apps/web/src/hooks/useSession.test.ts
+++ b/apps/web/src/hooks/useSession.test.ts
@@ -121,11 +121,21 @@ describe('useSession', () => {
     })
 
     expect(mockSaveSearchHistory).toHaveBeenCalledWith({
-      sessionId: expect.any(String),
-      searchData: {
-        keywords: ['react'],
-        location: 'Shanghai',
-      },
+      sessionKey: expect.any(String),
+      workspaceSlug: 'test-workspace',
+      keywords: ['react'],
+      location: 'Shanghai',
+      filters: {},
+      resumeIds: [],
+      selectedCompanies: [],
+      selectedTags: [],
+      title: undefined,
+      notes: undefined,
+      collectionSource: undefined,
+      collectionTaskId: undefined,
+      analysisTaskId: undefined,
+      jobDescriptionId: undefined,
+      selectedExperienceLevel: undefined,
     })
   })
 
@@ -153,7 +163,7 @@ describe('useSession', () => {
       result.current.applyExternalState({ jobDescriptionId: '' })
     })
 
-    expect(result.current.jobDescriptionId).toBe('')
+    expect(result.current.jobDescriptionId).toBeUndefined()
   })
 
   it('setLocation updates location', () => {
@@ -201,6 +211,10 @@ describe('useSession', () => {
   })
 
   it('ensureApiSession returns undefined on error', async () => {
+    mockPatch.mockResolvedValueOnce({
+      data: undefined,
+      error: { message: 'patch-fail' },
+    })
     mockPost.mockResolvedValueOnce({
       data: undefined,
       error: { message: 'fail' },


### PR DESCRIPTION
## Summary\n\nFixes 5 remaining CI test failures in useSession and useAiSearchSummary tests. These are pre-existing test assertion drift where mock call signatures and expected values no longer match the hook implementations.\n\n## Changes\n- `useSession.test.ts`: Updated `saveSearchHistory` assertion to flat arg format, fixed `applyExternalState clears jobDescriptionId` to expect undefined, fixed `ensureApiSession returns undefined` to fail PATCH first\n- `useAiSearchSummary.test.ts`: Fixed `calls[0][0].body` → `calls[0][1].body` (second argument is options, not first), fixed type assertions\n\n## CI Impact\n- `npx vitest run`: 9 failed → 0 failed frontend tests (only 2 pre-existing Convex backend failures remain)