### PR TITLE
fix: add tsx symlink workaround for convex codegen CI step

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -87,6 +87,9 @@ jobs:
 
       - name: Check Convex schema drift
         run: |
+          # Ensure tsx is accessible where convex expects it (npm hoisting workaround)
+          mkdir -p packages/convex/node_modules/.bin
+          ln -sf ../../../node_modules/.bin/tsx packages/convex/node_modules/.bin/tsx
           cd packages/convex
           npx convex codegen --typecheck disable
           cd ../..


### PR DESCRIPTION
## Summary\n\nFixes the `Checks` CI workflow failure on main. The `convex` package's binary references `tsx` at `convex/node_modules/.bin/tsx` but npm hoists it to the root `node_modules/.bin/tsx`. This causes the `npx convex codegen` step to fail with `tsx: No such file or directory`.\n\n## Fix\nAdd a symlink from `packages/convex/node_modules/.bin/tsx` → `../../../node_modules/.bin/tsx` before running `convex codegen`.\n\n## CI Impact\nFixes the `Checks` workflow — `Tests` workflow was already passing.