### PR TITLE
fix: correct parseSalaryRange 万 multiplier and sync search profile salary range to raw CNY

### DIFF
--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -658,7 +658,7 @@ export function parseSalaryRange(value: string): { min?: number; max?: number; c
   if (!normalized || /面议/.test(normalized)) return null;
   const match = normalized.match(/(\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?/);
   if (!match) return null;
-  const multiplier = /万/.test(normalized) ? 10 : 1;
+  const multiplier = /万/.test(normalized) ? 10000 : 1;
   const min = Number(match[1]) * multiplier;
   const max = match[2] ? Number(match[2]) * multiplier : undefined;
   if (Number.isNaN(min)) return null;

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -53,7 +53,7 @@ export function parseSalaryRange(value: string | undefined): { min?: number; max
     return null
   }
 
-  const multiplier = /万/.test(normalized) ? 10 : 1
+  const multiplier = /万/.test(normalized) ? 10000 : 1
   const min = Number(match[1]) * multiplier
   const max = match[2] ? Number(match[2]) * multiplier : undefined
   if (Number.isNaN(min)) {

--- a/config/search-profiles/51job-cn-cnc-sales.yaml
+++ b/config/search-profiles/51job-cn-cnc-sales.yaml
@@ -20,7 +20,7 @@ filters:
   locations:
     - China
   salaryRange:
-    max: 25
+    max: 25000
 
 schedule:
   enabled: false

--- a/config/search-profiles/job5156-cn-cnc-sales.yaml
+++ b/config/search-profiles/job5156-cn-cnc-sales.yaml
@@ -22,7 +22,7 @@ filters:
   locations:
     - China
   salaryRange:
-    max: 25
+    max: 25000
 
 schedule:
   enabled: false

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -870,7 +870,7 @@ function parseSalaryRange(value: string): { min?: number; max?: number } | null 
     if (!match) {
         return null;
     }
-    const multiplier = /万/.test(normalized) ? 10 : 1;
+    const multiplier = /万/.test(normalized) ? 10000 : 1;
     const min = Number(match[1]) * multiplier;
     const max = match[2] ? Number(match[2]) * multiplier : undefined;
     if (Number.isNaN(min)) {

--- a/packages/shared/src/generated/search-profile-templates.ts
+++ b/packages/shared/src/generated/search-profile-templates.ts
@@ -92,7 +92,7 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
           "China"
         ],
         "salaryRange": {
-          "max": 25
+          "max": 25000
         }
       },
       "schedule": {
@@ -148,7 +148,7 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
           "China"
         ],
         "salaryRange": {
-          "max": 25
+          "max": 25000
         }
       },
       "schedule": {
@@ -203,7 +203,7 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
           "China"
         ],
         "salaryRange": {
-          "max": 25
+          "max": 25000
         }
       },
       "schedule": {
@@ -256,7 +256,7 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
           "China"
         ],
         "salaryRange": {
-          "max": 25
+          "max": 25000
         }
       },
       "schedule": {


### PR DESCRIPTION
## Summary
- Fix parseSalaryRange 万 multiplier: ×10 → ×10000
- Update search profile salary range from `max: 25` (万-based) to `max: 25000` (raw CNY monthly)
- Verified: "3万" → 30000 (was 30), "20000-25000" → 20000-25000

## Test plan
- [x] `make check` — passes
- [x] Verified salary filter behavior with test values