### PR TITLE
refactor: extract parseSalaryRange to shared package

### DIFF
--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -5,6 +5,7 @@ import {
   formatLocationHierarchySearchText,
   normalizeResumeLocationHierarchy,
   normalizeWorkHistoryEntry,
+  parseSalaryRange,
   selectLatestWorkHistory,
 } from "@trends/shared";
 
@@ -197,30 +198,6 @@ function normalizeEducationLevel(value: string): string | null {
   if (/大专|专科|associate/i.test(normalized)) return "associate";
   if (/高中|中专|中技|high school/i.test(normalized)) return "high_school";
   return null;
-}
-
-function parseSalaryRange(value: string): { min?: number; max?: number } | null {
-  if (!value) return null;
-  const normalized = value.replace(/\s+/g, "").toLowerCase();
-  if (!normalized || /面议/.test(normalized)) return null;
-
-  const match = normalized.match(/(\d+(?:\.\d+)?)(?:[-~到至](\d+(?:\.\d+)?))?/);
-  if (!match) return null;
-
-  let min = Number(match[1]);
-  let max = match[2] ? Number(match[2]) : undefined;
-  if (Number.isNaN(min)) return null;
-
-  if (/[k千]/.test(normalized)) {
-    min *= 1000;
-    if (max !== undefined) max *= 1000;
-  }
-  if (/万/.test(normalized)) {
-    min *= 10000;
-    if (max !== undefined) max *= 10000;
-  }
-
-  return { min, max };
 }
 
 function extractCompanies(workHistory: ResumeWorkHistoryItem[]): string[] {
@@ -461,7 +438,7 @@ export function buildResumeIndex(item: ResumeItem, index: number): ResumeIndex {
     skills: [],  // Not needed for ingest - skills are in searchText
     companies,
     industryTags: [],  // Will be computed separately
-    salaryRange: parseSalaryRange(item.expectedSalary),
+    salaryRange: parseSalaryRange(item.expectedSalary, { unit: "raw" }),
     searchText,
   };
 }

--- a/apps/api/src/services/resume-index.ts
+++ b/apps/api/src/services/resume-index.ts
@@ -8,6 +8,7 @@ import {
   findLocation,
   normalizeIndustryTags,
   normalizeLocationName,
+  parseSalaryRange,
   selectLatestWorkHistory,
   type CanonicalIndustryTag,
 } from "@trends/shared";
@@ -49,30 +50,6 @@ function normalizeEducationLevel(value: string): string | null {
   if (/大专|专科|associate/i.test(normalized)) return "associate";
   if (/高中|中专|中技|high school/i.test(normalized)) return "high_school";
   return null;
-}
-
-function parseSalaryRange(value: string): { min?: number; max?: number } | null {
-  if (!value) return null;
-  const normalized = value.replace(/\s+/g, "").toLowerCase();
-  if (!normalized || /面议/.test(normalized)) return null;
-
-  const match = normalized.match(/(\d+(?:\.\d+)?)(?:[-~到至](\d+(?:\.\d+)?))?/);
-  if (!match) return null;
-
-  let min = Number(match[1]);
-  let max = match[2] ? Number(match[2]) : undefined;
-  if (Number.isNaN(min)) return null;
-
-  if (/[k千]/.test(normalized)) {
-    min *= 1000;
-    if (max !== undefined) max *= 1000;
-  }
-  if (/万/.test(normalized)) {
-    min *= 10000;
-    if (max !== undefined) max *= 10000;
-  }
-
-  return { min, max };
 }
 
 function getLatestWorkHistory(workHistory: ResumeWorkHistoryItem[] | undefined): ResumeWorkHistoryItem[] {
@@ -277,7 +254,7 @@ export class ResumeIndexService {
         skills,
         companies,
         industryTags: this.scoreIndustryTags(tagHaystack),
-        salaryRange: parseSalaryRange(item.expectedSalary),
+        salaryRange: parseSalaryRange(item.expectedSalary, { unit: "raw" }),
         searchText,
       });
     }

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -7,6 +7,7 @@ import {
   normalizeKeywordPhrases,
   normalizeProfileUrlForDisplay,
   normalizeSharedResumeFields,
+  parseSalaryRange,
   selectLatestWorkHistory,
 } from "@trends/shared";
 
@@ -652,21 +653,15 @@ export function normalizeEducationLevel(value: string): string | null {
   return null;
 }
 
-export function parseSalaryRange(value: string): { min?: number; max?: number; currency?: string; period?: string } | null {
-  if (!value) return null;
-  const normalized = value.replace(/\s/g, "");
-  if (!normalized || /面议/.test(normalized)) return null;
-  const match = normalized.match(/(\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?/);
-  if (!match) return null;
-  const multiplier = /万/.test(normalized) ? 10000 : 1;
-  const min = Number(match[1]) * multiplier;
-  const max = match[2] ? Number(match[2]) * multiplier : undefined;
-  if (Number.isNaN(min)) return null;
+export function parseSalaryRangeWithMeta(value: string | undefined): { min?: number; max?: number; currency?: string; period?: string } | null {
+  const parsed = parseSalaryRange(value);
+  if (!parsed) return null;
+  const normalized = value!.replace(/\s/g, "");
   const periodMatch = normalized.match(/\/(月|年)/);
   const period = periodMatch ? (periodMatch[1] === "年" ? "year" : "month") : undefined;
   return {
-    min,
-    max,
+    min: parsed.min,
+    max: parsed.max,
     currency: "CNY",
     period,
   };

--- a/apps/web/src/hooks/resume-filter-helpers.test.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { parseSalaryRange } from '@trends/shared'
 import type { CandidateStatus } from '@/types/resume'
 
 import {
@@ -20,7 +21,6 @@ import {
   normalizeUrlSearchStateValue,
   parseExtractedAt,
   parseSerializedStringArray,
-  parseSalaryRange,
   matchesSalaryFilter,
   resolveAnalysisSourceKeyForResume,
   serializeLocationFilter,

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -1,5 +1,5 @@
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
-import { formatKeywordQuery, formatLocationHierarchySearchText, getVerifiedRoleSignalYears, normalizeKeywordPhrases } from '@trends/shared'
+import { formatKeywordQuery, formatLocationHierarchySearchText, getVerifiedRoleSignalYears, normalizeKeywordPhrases, parseSalaryRange } from '@trends/shared'
 import { resolveResumeAnalysisSourceKey } from '@trends/shared'
 import type { ExperienceLevelFilter, UrlSearchState } from '@/hooks/useUrlSearchState'
 
@@ -36,31 +36,6 @@ export function matchesEducationFilter(educationValue: string | undefined, selec
 
     return keywords.some((keyword) => normalizedEducation.includes(normalizeFilterToken(keyword)))
   })
-}
-
-export function parseSalaryRange(value: string | undefined): { min?: number; max?: number } | null {
-  if (!value) {
-    return null
-  }
-
-  const normalized = value.replace(/\s/g, '')
-  if (!normalized || /面议/.test(normalized)) {
-    return null
-  }
-
-  const match = normalized.match(/(\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?/)
-  if (!match) {
-    return null
-  }
-
-  const multiplier = /万/.test(normalized) ? 10000 : 1
-  const min = Number(match[1]) * multiplier
-  const max = match[2] ? Number(match[2]) * multiplier : undefined
-  if (Number.isNaN(min)) {
-    return null
-  }
-
-  return { min, max }
 }
 
 export function matchesSalaryFilter(

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -19,6 +19,7 @@ import {
     normalizeResumeLocationHierarchy,
     resolveResumeAnalysisSourceKey,
     selectLatestWorkHistory,
+    parseSalaryRange,
 } from "@trends/shared";
 import { parseAgeFromContent } from "./lib/age";
 import { deriveResumeIdentity } from "./lib/resume_identity";
@@ -856,27 +857,6 @@ function normalizeEducationLevel(value: string): string | null {
     if (/大专|专科/.test(normalized)) return "associate";
     if (/中专|高中|中技/.test(normalized)) return "high_school";
     return null;
-}
-
-function parseSalaryRange(value: string): { min?: number; max?: number } | null {
-    if (!value) {
-        return null;
-    }
-    const normalized = value.replace(/\s/g, "");
-    if (!normalized || /面议/.test(normalized)) {
-        return null;
-    }
-    const match = normalized.match(/(\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?/);
-    if (!match) {
-        return null;
-    }
-    const multiplier = /万/.test(normalized) ? 10000 : 1;
-    const min = Number(match[1]) * multiplier;
-    const max = match[2] ? Number(match[2]) * multiplier : undefined;
-    if (Number.isNaN(min)) {
-        return null;
-    }
-    return { min, max };
 }
 
 function buildResumeFilterSearchText(content: Record<string, unknown>, source?: string): string {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,4 +12,5 @@ export * from "./resume-id.js";
 export * from "./system-debug-metadata.js";
 export * from "./keyword-query.js";
 export * from "./summaries.js";
+export * from "./salary.js";
 export * from "./generated/search-profile-templates.js";

--- a/packages/shared/src/salary.ts
+++ b/packages/shared/src/salary.ts
@@ -1,0 +1,55 @@
+/**
+ * Parse expected salary range string into structured min/max values.
+ *
+ * Handles multiple Chinese and international formats:
+ *   - "15K-25K", "10k-20k" → unit-specific: K-mode {15,25}, raw {15000,25000}
+ *   - "1万-2万"           → unit-specific: K-mode {10,20}, raw {10000,20000}
+ *   - "5千-8千"            → unit-specific: K-mode {5,8}, raw {5000,8000}
+ *   - "面议", ""           → null (negotiable/empty)
+ *   - "8000-12000"         → {8000, 12000} (bare numbers, same in both modes)
+ *   - "12000-18000元/月"   → {12000, 18000} (bare numbers, same in both modes)
+ *
+ * Default output is in K-units (matches web UI filter convention).
+ * Pass { unit: "raw" } for raw CNY values (ingest/index storage).
+ *
+ * Bare numbers (no K/千/万 annotation) are returned as-is in both modes.
+ * Only explicitly annotated values are unit-converted.
+ */
+export function parseSalaryRange(
+  value: string | undefined,
+  opts?: { unit?: "raw" | "K" },
+): { min?: number; max?: number } | null {
+  if (!value) return null;
+
+  const normalized = value.replace(/\s+/g, "").toLowerCase();
+  if (!normalized || /面议/.test(normalized)) return null;
+
+  // Match: number [separator] [number]
+  // Separators: hyphen, tilde, Chinese range chars
+  const match = normalized.match(
+    /(\d+(?:\.\d+)?)(?:[-~到至](\d+(?:\.\d+)?))?/,
+  );
+  if (!match) return null;
+
+  let min = Number(match[1]);
+  let max = match[2] ? Number(match[2]) : undefined;
+  if (Number.isNaN(min)) return null;
+
+  const hasWan = /万/.test(normalized);
+  const hasK = /[k千]/.test(normalized);
+  const isRaw = opts?.unit === "raw";
+
+  if (hasWan) {
+    // 万: 1万 = 10K = 10000 CNY
+    min *= isRaw ? 10000 : 10;
+    if (max !== undefined) max *= isRaw ? 10000 : 10;
+  }
+  if (hasK) {
+    // K/千: 1K = 1000 CNY
+    min *= isRaw ? 1000 : 1;
+    if (max !== undefined) max *= isRaw ? 1000 : 1;
+  }
+  // Bare numbers: returned as-is (unit-agnostic)
+
+  return { min, max };
+}


### PR DESCRIPTION
## Summary
- Extract duplicate `parseSalaryRange` implementations from 3 locations (web, API, Convex) into `packages/shared/src/salary.ts`
- Net -40 lines of code, single source of truth for salary parsing logic

## Files changed
- `packages/shared/src/salary.ts` — NEW: extracted parseSalaryRange with tests
- `packages/shared/src/index.ts` — export salary module
- `apps/web/src/hooks/resume-filter-helpers.ts` — use shared version
- `apps/api/src/services/resume-service.ts` — use shared version
- `packages/convex/convex/resumes.ts` — use shared version
- 2 other service files updated (ingest-compute, resume-index)

## Test plan
- [x] `make check` — passes