### PR TITLE
feat: seek.com Basic Talent Search collection lane

### DIFF
--- a/apps/api/src/routes/search-profiles.test.ts
+++ b/apps/api/src/routes/search-profiles.test.ts
@@ -233,6 +233,14 @@ describe('search-profiles list route', () => {
             expect.objectContaining({
               type: 'seek',
               enabled: true,
+              mode: 'recommended',
+            }),
+            expect.objectContaining({
+              type: 'seek',
+              enabled: true,
+              mode: 'talentsearch',
+              collectLimit: 500,
+              maxPages: 25,
             }),
           ]),
           quickStart: expect.objectContaining({

--- a/apps/api/src/services/search-profile-service.test.ts
+++ b/apps/api/src/services/search-profile-service.test.ts
@@ -105,3 +105,45 @@ describe('SearchProfileService keyword normalization', () => {
     expect(upperCaseMatch.confidence).toBeGreaterThan(0.3)
   })
 })
+
+describe('SearchProfileService seek source validation', () => {
+  it('rejects enabled seek source with mode/URL mismatch', () => {
+    const svc = new SearchProfileService()
+    expect(() =>
+      svc.validateProfile({
+        id: 'test-mismatch',
+        name: 'Test',
+        status: 'active',
+        location: 'MY',
+        keywords: ['x'],
+        sources: [{
+          type: 'seek',
+          enabled: true,
+          priority: 1,
+          mode: 'recommended',
+          jobUrl: 'https://hk.employer.seek.com/talentsearch?keywords=x',
+        }],
+      } as SearchProfile)
+    ).toThrow(/mode|recommended|talentsearch/i)
+  })
+
+  it('accepts enabled seek source with mode=talentsearch and matching URL', () => {
+    const svc = new SearchProfileService()
+    expect(() =>
+      svc.validateProfile({
+        id: 'test-ts',
+        name: 'Test',
+        status: 'active',
+        location: 'MY',
+        keywords: ['x'],
+        sources: [{
+          type: 'seek',
+          enabled: true,
+          priority: 1,
+          mode: 'talentsearch',
+          jobUrl: 'https://hk.employer.seek.com/talentsearch?keywords=x',
+        }],
+      } as SearchProfile)
+    ).not.toThrow()
+  })
+})

--- a/apps/api/src/services/search-profile-service.ts
+++ b/apps/api/src/services/search-profile-service.ts
@@ -64,6 +64,7 @@ export interface SearchProfile {
         job51MaxPages?: number;
         collectLimit?: number;
         maxPages?: number;
+        mode?: string;
     }>;
 
     // Landing page quick start
@@ -364,6 +365,7 @@ function parseSources(value: unknown): SearchProfile["sources"] | undefined {
             const job51MaxPages = readNumber(item.job51MaxPages);
             const collectLimit = readNumber(item.collectLimit);
             const maxPages = readNumber(item.maxPages);
+            const mode = readString(item.mode);
             if (!type || enabled === undefined) return null;
 
             return {
@@ -376,6 +378,7 @@ function parseSources(value: unknown): SearchProfile["sources"] | undefined {
                 ...(typeof job51MaxPages === "number" ? { job51MaxPages } : {}),
                 ...(typeof collectLimit === "number" ? { collectLimit } : {}),
                 ...(typeof maxPages === "number" ? { maxPages } : {}),
+                ...(mode !== undefined ? { mode } : {}),
             };
         })
         .filter((item): item is NonNullable<typeof item> => item !== null);

--- a/apps/api/src/services/search-profile-service.ts
+++ b/apps/api/src/services/search-profile-service.ts
@@ -549,6 +549,27 @@ function isSeekRecommendedCandidatesUrl(value: string | undefined): boolean {
     }
 }
 
+function isSeekTalentSearchUrl(value: string | undefined): boolean {
+    if (!value) {
+        return false;
+    }
+    try {
+        const url = new URL(value);
+        return url.protocol === "https:"
+            && url.hostname.toLowerCase().endsWith(".employer.seek.com")
+            && url.pathname.replace(/\/+$/, "") === "/talentsearch"
+            && url.search.length > 0;
+    } catch {
+        return false;
+    }
+}
+
+function resolveSeekModeFromUrl(value: string | undefined): "recommended" | "talentsearch" | null {
+    if (isSeekTalentSearchUrl(value)) return "talentsearch";
+    if (isSeekRecommendedCandidatesUrl(value)) return "recommended";
+    return null;
+}
+
 export class SearchProfileService {
     readonly projectRoot: string;
 
@@ -646,13 +667,20 @@ export class SearchProfileService {
     validateProfile(profile: SearchProfile): void {
         this.ensureRequiredCoreFields(profile);
 
-        const invalidSeekSource = profile.sources?.find((source) => (
-            source.type === "seek"
-            && source.enabled
-            && !isSeekRecommendedCandidatesUrl(source.jobUrl)
-        ));
+        const invalidSeekSource = profile.sources?.find((source) => {
+            if (source.type !== "seek" || !source.enabled) {
+                return false;
+            }
+            const declaredMode: "recommended" | "talentsearch" =
+                source.mode === "talentsearch" ? "talentsearch" : "recommended";
+            const urlMode = resolveSeekModeFromUrl(source.jobUrl);
+            return urlMode === null || urlMode !== declaredMode;
+        });
         if (invalidSeekSource) {
-            throw new Error("Enabled Seek source requires an exact Seek recommended candidates URL");
+            const declared = invalidSeekSource.mode === "talentsearch" ? "talentsearch" : "recommended";
+            throw new Error(
+                `Enabled Seek source requires a valid Seek ${declared} URL`,
+            );
         }
     }
 

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -4495,17 +4495,18 @@
     }
   }
   __name(enrichSingleSeekResumeWithDetail, "enrichSingleSeekResumeWithDetail");
-  async function enrichSeekRecommendedResumesWithDetail(resumes) {
+  async function enrichSeekResumesWithDetail(resumes) {
     if (!Array.isArray(resumes) || resumes.length === 0) return [];
     if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return resumes;
     if (isSeekProfileMode()) return resumes;
+    if (getCurrentSeekMode() === "talentsearch") return resumes;
     const enriched = [];
     for (const resume of resumes) {
       enriched.push(await enrichSingleSeekResumeWithDetail(resume));
     }
     return enriched;
   }
-  __name(enrichSeekRecommendedResumesWithDetail, "enrichSeekRecommendedResumesWithDetail");
+  __name(enrichSeekResumesWithDetail, "enrichSeekResumesWithDetail");
   function waitForPagination({ timeoutMs = 8e3 } = {}) {
     if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
       return Promise.resolve(true);
@@ -5449,7 +5450,7 @@
       resumes = await enrichJob5156SearchResumesWithDetail(resumes);
     }
     if (shouldEnrichFromCurrentPage && getCurrentSourceKey() === SOURCE_KEYS.SEEK && !isSeekProfileMode() && resumes.length > 0) {
-      resumes = await enrichSeekRecommendedResumesWithDetail(resumes);
+      resumes = await enrichSeekResumesWithDetail(resumes);
     }
     const metadata = buildSubmitMetadata({
       seekCaptureMode: Array.isArray(resumesOverride) && window.location.pathname.includes("/candidates/recommended") ? "graphql-list" : void 0
@@ -5660,7 +5661,7 @@
           resumes = await enrichJob5156SearchResumesWithDetail(resumes);
         }
         if (getCurrentSourceKey() === SOURCE_KEYS.SEEK && !isSeekProfileMode() && resumes.length > 0) {
-          resumes = await enrichSeekRecommendedResumesWithDetail(resumes);
+          resumes = await enrichSeekResumesWithDetail(resumes);
         }
         if (resumes.length <= 0) {
           const ageRange = getCurrentAgeRange();
@@ -6052,7 +6053,7 @@
         pageResumes = await enrichJob5156SearchResumesWithDetail(pageResumes);
       }
       if (sourceKey === SOURCE_KEYS.SEEK && !isSeekProfileMode() && pageResumes.length > 0) {
-        pageResumes = await enrichSeekRecommendedResumesWithDetail(pageResumes);
+        pageResumes = await enrichSeekResumesWithDetail(pageResumes);
       }
       lastPageResumeCount = pageResumes.length;
       if (pageResumes.length > 0) {

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -4342,6 +4342,8 @@
       apiSnapshot.seekRecommendedRequest = null;
       apiSnapshot.seekProfile = null;
       apiSnapshot.seekProfileRequest = null;
+      apiSnapshot.seekTalentSearch = null;
+      apiSnapshot.seekTalentSearchRequest = null;
     }
   }
   __name(clearCapturedResultsForNextPage, "clearCapturedResultsForNextPage");

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -1479,6 +1479,10 @@
     return apiSnapshot.seekRecommendedRequest;
   }
   __name(getSeekRecommendedRequest, "getSeekRecommendedRequest");
+  function getSeekTalentSearchRequest() {
+    return apiSnapshot.seekTalentSearchRequest;
+  }
+  __name(getSeekTalentSearchRequest, "getSeekTalentSearchRequest");
   function getSeekProfileRequest() {
     return apiSnapshot.seekProfileRequest || apiSnapshot.seekRecommendedRequest;
   }
@@ -3412,6 +3416,47 @@
     });
   }
   __name(extractSeekResumes, "extractSeekResumes");
+  function extractSeekTalentSearchResumes() {
+    const candidates = Array.isArray(apiSnapshot.seekTalentSearch) ? apiSnapshot.seekTalentSearch : [];
+    const request = getSeekTalentSearchRequest();
+    const requestInput = request?.variables?.input;
+    const language = request?.variables?.language;
+    const url = new URL(window.location.href);
+    const currentPage = typeof requestInput?.pageNumber === "number" ? requestInput.pageNumber : normalizeOptionalPositiveInt(url.searchParams.get("pageNumber")) || 1;
+    return candidates.map((node, index) => {
+      const profileId = typeof node?.profileGuid === "string" && node.profileGuid ? node.profileGuid : typeof node?.id === "string" && node.id ? node.id : "";
+      if (!profileId) return null;
+      const firstName = typeof node?.firstName === "string" ? node.firstName.trim() : "";
+      const lastName = typeof node?.lastName === "string" ? node.lastName.trim() : "";
+      const currentJobTitle = typeof node?.currentJobTitle === "string" ? node.currentJobTitle.trim() : "";
+      const currentLocation = typeof node?.currentLocation === "string" ? node.currentLocation.trim() : "";
+      const lastModifiedDurationLabel = typeof node?.lastModifiedDurationLabel === "string" ? node.lastModifiedDurationLabel : "";
+      const workHistory = Array.isArray(node?.workHistories) ? node.workHistories.map((item) => buildSeekWorkHistoryItem(item)).filter(Boolean) : [];
+      return {
+        profileId,
+        profileType: "seek",
+        externalId: profileId ? `${window.location.hostname.toLowerCase()}:profile:${profileId}` : "",
+        name: [firstName, lastName].filter(Boolean).join(" ").trim(),
+        profileUrl: buildSeekProfileUrl(profileId, void 0),
+        activityStatus: lastModifiedDurationLabel,
+        age: "",
+        experience: "",
+        education: "",
+        location: currentLocation,
+        jobIntention: currentJobTitle,
+        expectedSalary: "",
+        selfIntro: "",
+        workHistory,
+        extractedAt: (/* @__PURE__ */ new Date()).toISOString(),
+        pageIndex: index + 1,
+        source: window.location.hostname.toLowerCase(),
+        searchProfileId: "",
+        language: typeof language === "string" ? language : "",
+        pageNumber: currentPage
+      };
+    }).filter(Boolean);
+  }
+  __name(extractSeekTalentSearchResumes, "extractSeekTalentSearchResumes");
   function extract51JobResumes() {
     if (!Array.isArray(apiSnapshot.job51SearchRows)) return [];
     return apiSnapshot.job51SearchRows.map((row, index) => {
@@ -3544,6 +3589,9 @@
         }
         return [];
       }
+      if (hasSeekTalentSearchSnapshot()) {
+        return extractSeekTalentSearchResumes();
+      }
       if (hasSeekListSnapshot()) {
         return extractSeekResumes();
       }
@@ -3575,7 +3623,9 @@
     if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
       const seekProfile = isSeekProfileMode() && hasSeekProfileSnapshot() ? apiSnapshot.seekProfile : null;
       const seekProfileIdentity = seekProfile ? getSeekCandidateIdentity(seekProfile) : null;
-      const candidates = !seekProfile && hasSeekListSnapshot() ? apiSnapshot.seekRecommendedCandidates : [];
+      const seekTalentSearchCandidates = !seekProfile && hasSeekTalentSearchSnapshot() ? apiSnapshot.seekTalentSearch : null;
+      const candidates = seekTalentSearchCandidates || (!seekProfile && hasSeekListSnapshot() ? apiSnapshot.seekRecommendedCandidates : []);
+      const seekRequest = seekProfile ? getSeekProfileRequest() : seekTalentSearchCandidates ? getSeekTalentSearchRequest() : getSeekRecommendedRequest();
       const cards = seekProfile ? [
         {
           index: 1,
@@ -3584,7 +3634,8 @@
           text: JSON.stringify(seekProfile, null, 2)
         }
       ] : candidates.map((candidate, index) => {
-        const { profileId, profileType } = getSeekCandidateIdentity(candidate);
+        const profileId = seekTalentSearchCandidates ? typeof candidate?.profileGuid === "string" && candidate.profileGuid ? candidate.profileGuid : "" : getSeekCandidateIdentity(candidate).profileId;
+        const profileType = SEEK_PROFILE_TYPE;
         return {
           index: index + 1,
           profileId,
@@ -3604,7 +3655,7 @@
             searchRowCount: cards.length,
             sourceKey: SOURCE_KEYS.SEEK,
             operationName: apiSnapshot.lastOperationName,
-            request: seekProfile ? getSeekProfileRequest() : getSeekRecommendedRequest()
+            request: seekProfile ? getSeekProfileRequest() : seekRequest
           }
         };
         if (includePage) {

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -2804,8 +2804,11 @@
   function buildSeekCollectionContext(options = {}) {
     const normalizedOptions = typeof options === "object" && options ? options : {};
     const captureModeOverride = normalizedOptions.captureModeOverride;
+    const seekMode = getCurrentSeekMode();
+    const isTalentSearchList = seekMode === "talentsearch";
     const useProfileMode = captureModeOverride ? captureModeOverride === "graphql-profile" : isSeekProfileMode();
-    const request = useProfileMode ? getSeekProfileRequest() : getSeekRecommendedRequest();
+    const talentSearchRequest = isTalentSearchList ? apiSnapshot.seekTalentSearchRequest : null;
+    const request = talentSearchRequest ?? (useProfileMode ? getSeekProfileRequest() : getSeekRecommendedRequest());
     const requestInput = request?.variables?.input;
     const language = request?.variables?.language;
     const url = new URL(window.location.href);
@@ -2815,17 +2818,71 @@
     const jobIdFromUrl = normalizeOptionalPositiveInt(
       url.searchParams.get("jobId")
     );
-    const captureMode = captureModeOverride || (useProfileMode && apiSnapshot.seekProfile ? "graphql-profile" : "graphql-list");
-    const defaultOperation = captureMode === "graphql-profile" ? "GetTalentSearchProfileCompleteV2" : "GetTalentSearchRecommendedCandidates";
-    return {
+    const captureMode = captureModeOverride || (isTalentSearchList ? "graphql-talentsearch" : useProfileMode && apiSnapshot.seekProfile ? "graphql-profile" : "graphql-list");
+    const defaultOperation = captureMode === "graphql-profile" ? "GetTalentSearchProfileCompleteV2" : captureMode === "graphql-talentsearch" ? "SearchProfilesByNaturalLanguage" : "GetTalentSearchRecommendedCandidates";
+    const context = {
       captureMode,
       operation: apiSnapshot.lastOperationName || defaultOperation,
-      jobId: requestInput?.jobId != null ? String(requestInput.jobId) : jobIdFromUrl != null ? String(jobIdFromUrl) : void 0,
-      searchId: typeof requestInput?.searchId === "string" ? requestInput.searchId : void 0,
-      pageNumber: typeof requestInput?.page === "number" ? requestInput.page : pageNumberFromUrl ?? void 0,
-      language: typeof language === "string" ? language : void 0,
       profileType: SEEK_PROFILE_TYPE
     };
+    if (seekMode) {
+      context.seekMode = seekMode;
+    }
+    if (typeof language === "string") {
+      context.language = language;
+    }
+    if (isTalentSearchList) {
+      if (typeof requestInput?.pageNumber === "number") {
+        context.pageNumber = requestInput.pageNumber;
+      } else if (pageNumberFromUrl != null) {
+        context.pageNumber = pageNumberFromUrl;
+      }
+      if (typeof requestInput?.originalNaturalLanguageQuery === "string") {
+        context.searchQuery = requestInput.originalNaturalLanguageQuery;
+      }
+      if (typeof requestInput?.countryCode === "string") {
+        context.market = requestInput.countryCode;
+      }
+      if (Array.isArray(requestInput?.roleTitles?.values)) {
+        context.roleTitles = requestInput.roleTitles.values;
+      }
+      if (Array.isArray(requestInput?.keywords?.values)) {
+        context.keywords = requestInput.keywords.values;
+      }
+      if (typeof requestInput?.keywords?.matchAll === "boolean") {
+        context.matchAll = requestInput.keywords.matchAll;
+      }
+      if (typeof requestInput?.sortBy === "string") {
+        context.sortBy = requestInput.sortBy;
+      }
+      if (typeof requestInput?.salary?.frequency === "string") {
+        context.salaryType = requestInput.salary.frequency;
+      }
+      if (typeof requestInput?.salary?.range?.minimum === "number") {
+        context.minSalary = requestInput.salary.range.minimum;
+      }
+      if (typeof requestInput?.salary?.includeUnspecified === "boolean") {
+        context.salaryUnspecified = requestInput.salary.includeUnspecified;
+      }
+      if (typeof requestInput?.searchId === "string") {
+        context.searchId = requestInput.searchId;
+      }
+    } else {
+      if (requestInput?.jobId != null) {
+        context.jobId = String(requestInput.jobId);
+      } else if (jobIdFromUrl != null) {
+        context.jobId = String(jobIdFromUrl);
+      }
+      if (typeof requestInput?.searchId === "string") {
+        context.searchId = requestInput.searchId;
+      }
+      if (typeof requestInput?.page === "number") {
+        context.pageNumber = requestInput.page;
+      } else if (pageNumberFromUrl != null) {
+        context.pageNumber = pageNumberFromUrl;
+      }
+    }
+    return context;
   }
   __name(buildSeekCollectionContext, "buildSeekCollectionContext");
   function getExtensionGeneratedBy() {

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -1,0 +1,6150 @@
+(() => {
+  var __defProp = Object.defineProperty;
+  var __name = (target, value) => __defProp(target, "name", { value, configurable: true });
+
+  // src/lib/job51-age-filter.ts
+  function normalizeOptionalPositiveInt(value) {
+    const parsed = Number.parseInt(String(value ?? "").trim(), 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return null;
+    return parsed;
+  }
+  __name(normalizeOptionalPositiveInt, "normalizeOptionalPositiveInt");
+  function parseAgeNumber(value) {
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return Math.trunc(value);
+    }
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const withSuffix = trimmed.match(/^(\d+)\s*岁$/u);
+    if (withSuffix && withSuffix[1]) {
+      const parsed = Number.parseInt(withSuffix[1], 10);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+    }
+    const plainNumber = trimmed.match(/^(\d{1,3})$/u);
+    if (plainNumber && plainNumber[1]) {
+      const parsed = Number.parseInt(plainNumber[1], 10);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+    }
+    return null;
+  }
+  __name(parseAgeNumber, "parseAgeNumber");
+  function getAgeRangeFromUrl(search = "", minAgeParam = "tr_min_age", maxAgeParam = "tr_max_age") {
+    const params = new URLSearchParams(search || "");
+    const minAge = normalizeOptionalPositiveInt(params.get(minAgeParam));
+    const maxAge = normalizeOptionalPositiveInt(params.get(maxAgeParam));
+    const enabled = minAge !== null || maxAge !== null;
+    return {
+      enabled,
+      minAge: minAge !== null ? minAge : void 0,
+      maxAge: maxAge !== null ? maxAge : void 0
+    };
+  }
+  __name(getAgeRangeFromUrl, "getAgeRangeFromUrl");
+  function filterResumesByAgeRange(resumes, search = "", minAgeParam = "tr_min_age", maxAgeParam = "tr_max_age") {
+    if (!Array.isArray(resumes)) return [];
+    const range = getAgeRangeFromUrl(search, minAgeParam, maxAgeParam);
+    if (!range.enabled) return resumes;
+    const minAge = range.minAge;
+    const maxAge = range.maxAge;
+    return resumes.filter((resume) => {
+      const age = parseAgeNumber(resume?.age);
+      if (age === null) return false;
+      if (typeof minAge === "number" && age < minAge) return false;
+      if (typeof maxAge === "number" && age > maxAge) return false;
+      return true;
+    });
+  }
+  __name(filterResumesByAgeRange, "filterResumesByAgeRange");
+
+  // src/lib/resume-text-utils.ts
+  function normalizeResumeText(value) {
+    return typeof value === "string" ? value.replace(/[\u3000\s]+/g, " ").trim() : "";
+  }
+  __name(normalizeResumeText, "normalizeResumeText");
+  function stripHtmlTags(value) {
+    return typeof value === "string" ? value.replace(/<[^>]*>/g, " ") : "";
+  }
+  __name(stripHtmlTags, "stripHtmlTags");
+  function normalizeResumeMultilineText(value) {
+    if (typeof value !== "string") return "";
+    return value.replace(/\r\n?/g, "\n").split("\n").map((line) => line.replace(/[\u3000\t ]+/g, " ").trim()).filter(Boolean).join("\n");
+  }
+  __name(normalizeResumeMultilineText, "normalizeResumeMultilineText");
+  function buildWorkHistoryRawParts(parts) {
+    return parts.filter(Boolean).join(" \xB7 ");
+  }
+  __name(buildWorkHistoryRawParts, "buildWorkHistoryRawParts");
+
+  // src/lib/job51-detail-parser.ts
+  var EHIRE_51JOB_HOST = "ehire.51job.com";
+  var EHIRE_51JOB_PROFILE_URL_PREFIX = "https://ehire.51job.com/Revision/talent/resume/detail?contentType=&resumeId=";
+  var JOB51_DETAIL_ROOT_CANDIDATE_KEYS = [
+    "data",
+    "result",
+    "resume",
+    "detail",
+    "resumeInfo",
+    "resumeDetail",
+    "resumeViewVo",
+    "resume_view_vo",
+    "resumeVo",
+    "cnVo",
+    "content"
+  ];
+  var PROVINCE_TOKENS = /* @__PURE__ */ new Set([
+    "\u5317\u4EAC",
+    "\u5929\u6D25",
+    "\u4E0A\u6D77",
+    "\u91CD\u5E86",
+    "\u6CB3\u5317",
+    "\u5C71\u897F",
+    "\u8FBD\u5B81",
+    "\u5409\u6797",
+    "\u9ED1\u9F99\u6C5F",
+    "\u6C5F\u82CF",
+    "\u6D59\u6C5F",
+    "\u5B89\u5FBD",
+    "\u798F\u5EFA",
+    "\u6C5F\u897F",
+    "\u5C71\u4E1C",
+    "\u6CB3\u5357",
+    "\u6E56\u5317",
+    "\u6E56\u5357",
+    "\u5E7F\u4E1C",
+    "\u6D77\u5357",
+    "\u56DB\u5DDD",
+    "\u8D35\u5DDE",
+    "\u4E91\u5357",
+    "\u9655\u897F",
+    "\u7518\u8083",
+    "\u9752\u6D77",
+    "\u53F0\u6E7E",
+    "\u5185\u8499\u53E4",
+    "\u5E7F\u897F",
+    "\u897F\u85CF",
+    "\u5B81\u590F",
+    "\u65B0\u7586",
+    "\u9999\u6E2F",
+    "\u6FB3\u95E8"
+  ]);
+  function normalizeProvinceToken(value) {
+    if (!value) return "";
+    return normalizeJob51Text(value).replace(/特别行政区$/g, "").replace(/壮族自治区$/g, "").replace(/回族自治区$/g, "").replace(/维吾尔自治区$/g, "").replace(/自治区$/g, "").replace(/省$/g, "").replace(/市$/g, "");
+  }
+  __name(normalizeProvinceToken, "normalizeProvinceToken");
+  function normalizeJob51Text(value) {
+    return normalizeResumeText(stripHtmlTags(value));
+  }
+  __name(normalizeJob51Text, "normalizeJob51Text");
+  function normalizeJob51MultilineText(value) {
+    return normalizeResumeMultilineText(stripHtmlTags(value));
+  }
+  __name(normalizeJob51MultilineText, "normalizeJob51MultilineText");
+  function isLikelyJob51LocationPlaceholderCompanyName(value) {
+    const text = normalizeJob51Text(value);
+    if (!text) return false;
+    if (/(公司|集团|科技|机械|工业|实业|设备|自动化|贸易|精密|制造|电子|机电|工具|刀具|技术|股份|责任|有限|厂|大学|学院|学校|中心|医院|门诊|商贸|材料|模具|液压|传感)/u.test(text)) {
+      return false;
+    }
+    const provinceToken = normalizeProvinceToken(text);
+    if (provinceToken && PROVINCE_TOKENS.has(provinceToken)) return true;
+    const compactLocation = text.replace(/[省市区县镇乡]$/u, "");
+    return /^[\u4e00-\u9fa5]{2,4}$/u.test(compactLocation);
+  }
+  __name(isLikelyJob51LocationPlaceholderCompanyName, "isLikelyJob51LocationPlaceholderCompanyName");
+  function getJob51DetailRoot(payload) {
+    if (!payload) return null;
+    if (Array.isArray(payload)) {
+      for (const entry of payload) {
+        const root = getJob51DetailRoot(entry);
+        if (root) return root;
+      }
+      return null;
+    }
+    if (typeof payload !== "object") return null;
+    const record = payload;
+    const candidates = JOB51_DETAIL_ROOT_CANDIDATE_KEYS.map((key) => record[key]);
+    for (const candidate of candidates) {
+      const root = getJob51DetailRoot(candidate);
+      if (root) return root;
+    }
+    if (JOB51_DETAIL_ROOT_CANDIDATE_KEYS.some(
+      (key) => Object.prototype.hasOwnProperty.call(record, key)
+    )) {
+      return null;
+    }
+    return record;
+  }
+  __name(getJob51DetailRoot, "getJob51DetailRoot");
+  function readJob51Text(...values) {
+    for (const value of values) {
+      if (typeof value === "string") {
+        const text = normalizeJob51Text(value);
+        if (text) return text;
+      } else if (typeof value === "number" && Number.isFinite(value)) {
+        return String(value);
+      }
+    }
+    return "";
+  }
+  __name(readJob51Text, "readJob51Text");
+  function readJob51MultilineText(...values) {
+    for (const value of values) {
+      if (typeof value === "string") {
+        const text = normalizeJob51MultilineText(value);
+        if (text) return text;
+        continue;
+      }
+      if (Array.isArray(value)) {
+        const text = value.map(
+          (entry) => typeof entry === "string" ? normalizeJob51MultilineText(entry) : entry && typeof entry === "object" ? readJob51MultilineText(
+            entry.text,
+            entry.value,
+            entry.content,
+            entry.description,
+            entry.desc,
+            entry.detail,
+            entry.duty,
+            entry.responsibility
+          ) : ""
+        ).filter(Boolean).join("\n");
+        if (text) return text;
+      }
+    }
+    return "";
+  }
+  __name(readJob51MultilineText, "readJob51MultilineText");
+  function normalizeJob51DateLike(value) {
+    const text = readJob51Text(value);
+    if (!text) return "";
+    if (["\u81F3\u4ECA", "\u76EE\u524D", "\u4ECA"].includes(text)) return "\u81F3\u4ECA";
+    return text.replace(/[./年]/g, "-").replace(/月/g, "").replace(/-{2,}/g, "-").replace(/^-|-$/g, "");
+  }
+  __name(normalizeJob51DateLike, "normalizeJob51DateLike");
+  function readJob51Array(record, keys) {
+    if (!record || typeof record !== "object") return [];
+    for (const key of keys) {
+      const value = record[key];
+      if (Array.isArray(value)) return value;
+    }
+    return [];
+  }
+  __name(readJob51Array, "readJob51Array");
+  function buildJob51ExperienceEntry(item, kind = "work") {
+    if (!item || typeof item !== "object") return null;
+    const isProject = kind === "project";
+    const rawCompanyName = readJob51Text(
+      item.company_name,
+      item.companyName,
+      item.compname,
+      item.comp_name,
+      item.com_name,
+      item.comName,
+      item.company,
+      isProject ? item.project_name : void 0,
+      isProject ? item.projectName : void 0,
+      isProject ? item.project : void 0
+    );
+    const companyName = isLikelyJob51LocationPlaceholderCompanyName(rawCompanyName) ? "" : rawCompanyName;
+    const jobTitle = readJob51Text(
+      item.work_func_value,
+      item.workfunc,
+      item.workfunc_str,
+      item.work_func_str,
+      item.job_name,
+      item.jobName,
+      item.position,
+      item.jobTitle,
+      isProject ? item.project_role : void 0,
+      isProject ? item.role : void 0,
+      isProject ? item.responsibility : void 0
+    );
+    const startDate = normalizeJob51DateLike(
+      item.start_time ?? item.startDate ?? item.begin ?? item.start_date ?? item.fromDate ?? item.time_begin ?? item.timefrom
+    );
+    const endDate = normalizeJob51DateLike(
+      item.end_time ?? item.endDate ?? item.end ?? item.end_date ?? item.toDate ?? item.time_end ?? item.timeto
+    );
+    const durationLabel = readJob51Text(
+      item.working_years,
+      item.worktime,
+      item.duration,
+      item.timeDiff,
+      item.time_diff,
+      item.period,
+      item.durationLabel
+    );
+    const description = Array.from(
+      new Set(
+        [
+          item.workdescribe,
+          item.work_describe,
+          item.workDescription,
+          item.work_content,
+          item.workContent,
+          item.work_detail,
+          item.workDetail,
+          item.workDuty,
+          item.work_duty,
+          item.duty,
+          item.duties,
+          item.responsibility,
+          item.responsibilities,
+          item.responsibility_text,
+          item.responsibilityText,
+          item.responsibility_list,
+          item.responsibilityList,
+          item.duty_list,
+          item.dutyList,
+          item.description,
+          item.desc,
+          item.detail,
+          item.content,
+          item.achievement,
+          item.achievements,
+          isProject ? item.project_desc : void 0,
+          isProject ? item.projectDescribe : void 0
+        ].map((value) => readJob51MultilineText(value)).flatMap((value) => value.split("\n")).map((value) => value.trim()).filter(Boolean)
+      )
+    ).join("\n");
+    const metaParts = [
+      item.industry_tag,
+      item.workindustry,
+      item.company_size_value,
+      item.companysize,
+      item.work_type_value,
+      item.companytype,
+      item.section,
+      item.department,
+      item.project_name
+    ].map((value) => readJob51Text(value)).filter(Boolean);
+    const raw = buildWorkHistoryRawParts([
+      [startDate, endDate].filter(Boolean).join("~"),
+      durationLabel ? `(${durationLabel})` : "",
+      companyName,
+      jobTitle,
+      ...metaParts,
+      description
+    ]);
+    if (!raw && !description && !companyName && !jobTitle) return null;
+    return {
+      raw: raw || description || buildWorkHistoryRawParts([companyName, jobTitle, startDate, endDate]),
+      companyName: companyName || void 0,
+      jobTitle: jobTitle || void 0,
+      description: description || void 0,
+      startDate: startDate || void 0,
+      endDate: endDate || void 0
+    };
+  }
+  __name(buildJob51ExperienceEntry, "buildJob51ExperienceEntry");
+  function buildJob51EducationEntry(item) {
+    if (!item || typeof item !== "object") return null;
+    const institution = readJob51Text(
+      item.school_name,
+      item.schoolName,
+      item.schoolname,
+      item.school,
+      item.institution,
+      item.university,
+      item.college
+    );
+    const qualification = readJob51Text(
+      item.degree_value,
+      item.degreename,
+      item.degree,
+      item.degreeStr,
+      item.qualification,
+      item.education
+    );
+    const fieldOfStudy = readJob51Text(
+      item.major,
+      item.degreemajor,
+      item.major_name,
+      item.speciality,
+      item.field_of_study,
+      item.subject
+    );
+    const description = readJob51MultilineText(
+      item.describe,
+      item.description,
+      item.detail,
+      item.content
+    );
+    const startDate = normalizeJob51DateLike(
+      item.start_date ?? item.begin ?? item.startTime ?? item.enrollYear ?? item.timefrom
+    );
+    const endDate = normalizeJob51DateLike(
+      item.end_date ?? item.end ?? item.endTime ?? item.graduationYear ?? item.timeto
+    );
+    if (!institution && !qualification && !fieldOfStudy && !description) {
+      return null;
+    }
+    return {
+      institution: institution || void 0,
+      qualification: qualification || void 0,
+      fieldOfStudy: fieldOfStudy || void 0,
+      description: description || void 0,
+      startDate: startDate || void 0,
+      endDate: endDate || void 0
+    };
+  }
+  __name(buildJob51EducationEntry, "buildJob51EducationEntry");
+  function buildJob51SkillEntry(item) {
+    if (typeof item === "string") {
+      const text = normalizeJob51Text(item);
+      return text || null;
+    }
+    if (!item || typeof item !== "object") return null;
+    const name = readJob51Text(
+      item.skill_name,
+      item.name,
+      item.label,
+      item.skill,
+      item.tag
+    );
+    if (!name) return null;
+    const level = readJob51Text(item.level, item.skill_level, item.proficiency);
+    const yearsOfExperience = typeof item.yearsOfExperience === "number" && Number.isFinite(item.yearsOfExperience) ? item.yearsOfExperience : typeof item.years === "number" && Number.isFinite(item.years) ? item.years : typeof item.years === "string" && item.years.trim() ? item.years.trim() : void 0;
+    if (!level && yearsOfExperience === void 0) {
+      return name;
+    }
+    return {
+      name,
+      ...level ? { level } : {},
+      ...yearsOfExperience === void 0 ? {} : { yearsOfExperience }
+    };
+  }
+  __name(buildJob51SkillEntry, "buildJob51SkillEntry");
+  function buildJob51LicenceEntry(item) {
+    if (typeof item === "string") {
+      const text = normalizeJob51Text(item);
+      return text ? { name: text } : null;
+    }
+    if (!item || typeof item !== "object") return null;
+    const name = readJob51Text(
+      item.name,
+      item.cert_name,
+      item.certificate_name,
+      item.training_name,
+      item.course_name,
+      item.title
+    );
+    if (!name) return null;
+    const authority = readJob51Text(
+      item.authority,
+      item.organization,
+      item.issuing_org,
+      item.issuingOrganisationName,
+      item.school,
+      item.company
+    );
+    const issuedAt = normalizeJob51DateLike(
+      item.issuedAt ?? item.issue_date ?? item.issued_date ?? item.start_date ?? item.startTime
+    );
+    const expiresAt = normalizeJob51DateLike(
+      item.expiresAt ?? item.expire_date ?? item.expired_date ?? item.end_date ?? item.endTime
+    );
+    return {
+      name,
+      ...authority ? { authority } : {},
+      ...issuedAt ? { issuedAt } : {},
+      ...expiresAt ? { expiresAt } : {}
+    };
+  }
+  __name(buildJob51LicenceEntry, "buildJob51LicenceEntry");
+  function buildJob51DetailResumeFromPayload(payload, options = {}) {
+    const root = getJob51DetailRoot(payload);
+    if (!root) return [];
+    const normalizedOptions = options && typeof options === "object" ? options : {};
+    const optionResumeId = Reflect.get(normalizedOptions, "resumeId");
+    const optionProfileUrl = Reflect.get(normalizedOptions, "profileUrl");
+    const resumeId = readJob51Text(
+      optionResumeId,
+      root.resumeid,
+      root.resumeId,
+      root.resume_id,
+      root.userid,
+      root.userId,
+      root.user_id,
+      root.id,
+      root.base_info?.resumeid,
+      root.base_info?.userid,
+      root.base_info?.resumeId
+    );
+    const perUserId = readJob51Text(
+      root.accountid,
+      root.accountId,
+      root.account_id,
+      root.base_info?.accountid,
+      root.base_info?.accountId,
+      root.base_info?.account_id,
+      root.userid,
+      root.userId,
+      root.user_id
+    );
+    const profileUrl = normalizeJob51Text(
+      optionProfileUrl || (resumeId ? `${EHIRE_51JOB_PROFILE_URL_PREFIX}${encodeURIComponent(resumeId)}` : "")
+    );
+    const baseInfo = root.base_info && typeof root.base_info === "object" ? root.base_info : {};
+    const liveJobIntention = Array.isArray(root.jobintention) && root.jobintention[0] && typeof root.jobintention[0] === "object" ? root.jobintention[0] : {};
+    const liveHighestDegree = root.highestdegree && typeof root.highestdegree === "object" ? root.highestdegree : {};
+    const jobIntentionInfo = root.job_intention && typeof root.job_intention === "object" ? root.job_intention : {};
+    const recentWorkInfo = root.recent_work_info && typeof root.recent_work_info === "object" ? root.recent_work_info : {};
+    const workHistory = readJob51Array(root, [
+      "work",
+      "work_list",
+      "workInfoVoList",
+      "workInfoList",
+      "work_info",
+      "work_info_list",
+      "workHistory",
+      "work_history",
+      "work_experience",
+      "workExperience",
+      "workExperienceList",
+      "work_exp_list"
+    ]).map((item) => buildJob51ExperienceEntry(item, "work")).filter(Boolean);
+    const projectExperience = readJob51Array(root, [
+      "project",
+      "project_list",
+      "projectInfoVoList",
+      "projectInfoList",
+      "projectExperience",
+      "project_experience",
+      "projectExperienceList"
+    ]).map((item) => buildJob51ExperienceEntry(item, "project")).filter(Boolean);
+    const profileEducation = readJob51Array(root, [
+      "education",
+      "education_list",
+      "educationInfoVoList",
+      "profileEducation",
+      "educationHistory"
+    ]).map((item) => buildJob51EducationEntry(item)).filter(Boolean);
+    const skills = readJob51Array(root, [
+      "itskill",
+      "skill",
+      "skills",
+      "skill_list",
+      "label_sorted_skill_tag_list",
+      "label_list"
+    ]).map((item) => buildJob51SkillEntry(item)).filter(Boolean);
+    const licences = [
+      ...readJob51Array(root, [
+        "certification",
+        "certifications",
+        "certificate",
+        "certificates"
+      ]),
+      ...readJob51Array(root, ["train", "training", "train_list", "trainings"])
+    ].map((item) => buildJob51LicenceEntry(item)).filter(Boolean);
+    const name = readJob51Text(
+      root.name,
+      root.userName,
+      root.user_name,
+      root.username,
+      root.resume_name,
+      root.realName,
+      root.candidateName,
+      root.fullName,
+      baseInfo.resume_name,
+      baseInfo.name,
+      baseInfo.userName
+    );
+    const age = readJob51Text(root.age, root.realAge, root.displayage, baseInfo.age);
+    const experience = readJob51Text(
+      baseInfo.work_year_value,
+      baseInfo.workYear,
+      baseInfo.workYears,
+      root.work_year_value,
+      root.workyear,
+      root.workYear,
+      root.workYears,
+      root.experienceYears,
+      root.experience,
+      recentWorkInfo?.working_years
+    );
+    const education = readJob51Text(
+      baseInfo.top_degree_value,
+      root.top_degree_value,
+      liveHighestDegree.degree,
+      root.education,
+      root.degree,
+      root.degreeValue
+    );
+    const location = readJob51Text(
+      jobIntentionInfo.expect_job_area_value,
+      Array.isArray(liveJobIntention.expectarea) ? liveJobIntention.expectarea.map(
+        (item) => item && typeof item === "object" ? readJob51Text(item.provincecity, item.county) : ""
+      ).filter(Boolean).join(",") : void 0,
+      root.jobIntention?.expect_job_area_value,
+      baseInfo.area_value,
+      root.area,
+      root.areaprovincecity,
+      root.location,
+      root.workCity,
+      root.city,
+      root.workLocation
+    );
+    const jobIntention = readJob51Text(
+      jobIntentionInfo.expect_work_function_value,
+      jobIntentionInfo.expected_work_function_value,
+      liveJobIntention.expectfuncname,
+      liveJobIntention.expectposition,
+      root.jobIntention?.expect_work_function_value,
+      root.jobIntention?.expected_work_function_value,
+      recentWorkInfo.recent_position,
+      root.recentwork?.workname,
+      root.jobIntention,
+      root.job_name,
+      root.jobname,
+      root.desiredJob,
+      root.expectedPosition,
+      root.targetJob,
+      root.searchJob
+    );
+    const expectedSalary = readJob51Text(
+      jobIntentionInfo.new_expect_salary,
+      jobIntentionInfo.expect_salary,
+      liveJobIntention.newdisplayexpectsalary,
+      liveJobIntention.displayexpectsalary,
+      root.expectedSalary,
+      root.desiredSalary,
+      root.expectSalary,
+      root.salaryStr,
+      root.salary
+    );
+    const activityStatus = readJob51Text(
+      root.active_type,
+      root.activityStatus,
+      root.activetimelabel,
+      root.activetime,
+      root.lastLoginTime,
+      root.last_login_time,
+      baseInfo.active_type,
+      baseInfo.jobStateStr
+    );
+    const selfIntro = readJob51MultilineText(
+      root.selfintro,
+      root.selfIntro,
+      root.resume_slicing,
+      root.advantage,
+      root.profile,
+      root.summary,
+      root.resumeSummary,
+      root.highlight,
+      root.professionSkill,
+      jobIntentionInfo.professionSkill
+    );
+    const normalizedAge = age ? age.includes("\u5C81") ? age : `${age}\u5C81` : "";
+    const externalId = resumeId || perUserId;
+    const pageIndex = 1;
+    const source = EHIRE_51JOB_HOST;
+    if (!resumeId && !name && !jobIntention && !selfIntro && workHistory.length === 0) {
+      return [];
+    }
+    return [
+      {
+        name,
+        age: normalizedAge,
+        experience,
+        education,
+        location,
+        jobIntention,
+        expectedSalary,
+        activityStatus,
+        selfIntro,
+        resumeId: resumeId || void 0,
+        perUserId: perUserId || void 0,
+        externalId: externalId || void 0,
+        profileUrl: profileUrl || void 0,
+        source,
+        workHistory,
+        projectExperience: projectExperience.length > 0 ? projectExperience : void 0,
+        profileEducation: profileEducation.length > 0 ? profileEducation : void 0,
+        skills: skills.length > 0 ? skills : void 0,
+        licences: licences.length > 0 ? licences : void 0,
+        pageIndex,
+        rawData: root,
+        extractedAt: (/* @__PURE__ */ new Date()).toISOString()
+      }
+    ];
+  }
+  __name(buildJob51DetailResumeFromPayload, "buildJob51DetailResumeFromPayload");
+
+  // src/lib/job51-collection-config.ts
+  var JOB51_SAFE_LIMIT = 50;
+  var JOB51_SAFE_MAX_PAGES = 1;
+  var JOB51_DETAIL_FETCH_DELAY_MS = 5e3;
+  var JOB51_DETAIL_FETCH_UNSAFE_DELAY_MS = 1e3;
+  function hasJob51UnsafeLimitsOverride(search = "") {
+    const params = new URLSearchParams(search || "");
+    return params.get("tr_unsafe_limits") === "1";
+  }
+  __name(hasJob51UnsafeLimitsOverride, "hasJob51UnsafeLimitsOverride");
+  function resolveJob51CollectionLimits(limit, maxPages, search = "") {
+    if (hasJob51UnsafeLimitsOverride(search)) {
+      return {
+        limit: limit > 0 ? limit : JOB51_SAFE_LIMIT,
+        maxPages: maxPages > 0 ? maxPages : JOB51_SAFE_MAX_PAGES
+      };
+    }
+    return {
+      limit: limit > 0 ? Math.min(limit, JOB51_SAFE_LIMIT) : JOB51_SAFE_LIMIT,
+      maxPages: maxPages > 0 ? Math.min(maxPages, JOB51_SAFE_MAX_PAGES) : JOB51_SAFE_MAX_PAGES
+    };
+  }
+  __name(resolveJob51CollectionLimits, "resolveJob51CollectionLimits");
+  function resolveJob51DetailFetchDelayMs(search = "") {
+    return hasJob51UnsafeLimitsOverride(search) ? JOB51_DETAIL_FETCH_UNSAFE_DELAY_MS : JOB51_DETAIL_FETCH_DELAY_MS;
+  }
+  __name(resolveJob51DetailFetchDelayMs, "resolveJob51DetailFetchDelayMs");
+  function resolveJob51AutoSyncDetailWaitMode(search = "") {
+    const params = new URLSearchParams(search || "");
+    const mode = normalizeResumeText(params.get("tr_job51_detail_wait") || "").toLowerCase();
+    if (mode === "page1" || mode === "all") {
+      return mode;
+    }
+    return "background";
+  }
+  __name(resolveJob51AutoSyncDetailWaitMode, "resolveJob51AutoSyncDetailWaitMode");
+
+  // src/lib/job5156-detail-utils.ts
+  var SECTION_SELECTORS = [
+    "section",
+    ".section",
+    ".resume-section",
+    ".module",
+    ".card",
+    ".block",
+    ".resume-view-layout",
+    '[class*="section"]',
+    '[class*="module"]',
+    '[class*="block"]'
+  ];
+  var HEADING_SELECTOR = [
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    ".title",
+    ".section-title",
+    ".module-title",
+    ".resume-view-layout__title",
+    '[class*="title"]'
+  ].join(", ");
+  var WORK_HISTORY_PLACEHOLDER_PATTERN = /^[（(]?\d+(?:年(?:\d+个?月?)?|个月?|月)?[）)]?$/u;
+  var EDUCATION_LIKE_PATTERN = /(本科|大专|中专|硕士|博士|研究生|MBA|EMBA|学校|学院|大学|学历)/u;
+  var WORK_LIKE_PATTERN = /(公司|经理|工程师|销售|主管|总监|主任|技术|客户|负责|部门|离职原因|CNC|数控|机械|设备|项目)/iu;
+  var DATE_LIKE_PATTERN = /(?:19|20)\d{2}(?:[-./年]\d{1,2})?|至今|目前|present|current/iu;
+  function isElement(value) {
+    return Boolean(
+      value && typeof value === "object" && "nodeType" in value && value.nodeType === 1 && "querySelectorAll" in value
+    );
+  }
+  __name(isElement, "isElement");
+  function queryAllSafe(root, selector) {
+    try {
+      return Array.from(root.querySelectorAll(selector)).filter(isElement);
+    } catch {
+      return [];
+    }
+  }
+  __name(queryAllSafe, "queryAllSafe");
+  function collectJob5156SectionItemsByHeading(root, headingPattern, primarySelectors, fallbackSelectors = []) {
+    if (!isElement(root)) {
+      return [];
+    }
+    const sections = queryAllSafe(root, SECTION_SELECTORS.join(", "));
+    for (const section of sections) {
+      const currentSection = (
+        /** @type {Element} */
+        section
+      );
+      const heading = normalizeResumeText(currentSection.querySelector(HEADING_SELECTOR)?.textContent || "");
+      if (!heading || !headingPattern.test(heading)) {
+        continue;
+      }
+      for (const selector of primarySelectors) {
+        const matches = queryAllSafe(currentSection, selector);
+        if (matches.length > 0) {
+          return matches;
+        }
+      }
+      for (const selector of fallbackSelectors) {
+        const matches = queryAllSafe(currentSection, selector);
+        if (matches.length > 0) {
+          return matches;
+        }
+      }
+      break;
+    }
+    return [];
+  }
+  __name(collectJob5156SectionItemsByHeading, "collectJob5156SectionItemsByHeading");
+  function isPlaceholderDurationText(value) {
+    const normalized = value.replace(/[\s·]+/g, "");
+    return WORK_HISTORY_PLACEHOLDER_PATTERN.test(normalized);
+  }
+  __name(isPlaceholderDurationText, "isPlaceholderDurationText");
+  function isMeaningfulJob5156WorkHistoryEntry(entry) {
+    if (!entry) {
+      return false;
+    }
+    const companyName = normalizeResumeText(entry.companyName || "");
+    const jobTitle = normalizeResumeText(entry.jobTitle || "");
+    const description = normalizeResumeText(entry.description || "");
+    const startDate = normalizeResumeText(entry.startDate || "");
+    const endDate = normalizeResumeText(entry.endDate || "");
+    const raw = normalizeResumeText(entry.raw || "");
+    const text = [raw, description].filter(Boolean).join(" ");
+    const hasIdentity = Boolean(companyName || jobTitle || description);
+    const hasDate = DATE_LIKE_PATTERN.test(`${startDate} ${endDate}`.trim());
+    if (hasIdentity) {
+      return true;
+    }
+    if (!text) {
+      return false;
+    }
+    if (isPlaceholderDurationText(text)) {
+      return false;
+    }
+    if (EDUCATION_LIKE_PATTERN.test(text) && !WORK_LIKE_PATTERN.test(text) && !companyName && !jobTitle) {
+      return false;
+    }
+    if (hasDate && text.length > 0) {
+      return true;
+    }
+    return true;
+  }
+  __name(isMeaningfulJob5156WorkHistoryEntry, "isMeaningfulJob5156WorkHistoryEntry");
+
+  // src/content.ts
+  var SELECTORS = {
+    listContainer: ".el-checkbox-group.resume-search-item-list-content-block",
+    resumeCard: ".list-content__li_part",
+    name: ".item-title-part1 a.name, a.name",
+    activityStatus: ".date-type-diff-text-block",
+    basicInfoRow: ".basic-line",
+    basicInfoItem: ".basic-line__text",
+    locationItem: ".resume-search-item-search-addre__span",
+    locationFallbackItem: ".text-truncate.text-center",
+    selfIntro: ".basic-keywords",
+    topRow: ".list-content__li__up-block",
+    topRowText: ".up-block__look-text",
+    workHistory: ".work-block",
+    workItem: ".work-item",
+    pagination: ".el-pagination",
+    nextPageBtn: ".el-pagination .btn-next",
+    seekPagination: 'nav[aria-label="Pagination of results"]',
+    searchInput: ".el-autocomplete input.el-input__inner",
+    searchButton: ".resume-search-item-search-input-block__input-button",
+    // 51job eHire selectors
+    job51SearchInput: ".talent_search_keywords_input input.el-input__inner",
+    job51SearchButton: "button.search_button",
+    // Area selector (location filter modal)
+    areaTrigger: ".resume-search-item-search-addre",
+    areaModal: ".area-selector-item-block",
+    areaProvinceBlock: ".area-selector-item-block__content__down__blcok:first-child",
+    areaCityBlock: ".area-selector-item-block__content__down__blcok:nth-child(2)",
+    areaDistrictBlock: ".area-selector-item-block__content__down__blcok:nth-child(3)",
+    areaItem: ".down__blcok__select",
+    areaDistrictItem: ".down__block__big-select__block",
+    areaConfirmBtn: ".area-selector-item-block__footer .button-block.blue",
+    areaCancelBtn: ".area-selector-item-block__footer .button-block:not(.blue)",
+    areaSelectedCount: ".content__up__number__select"
+  };
+  var AUTO_EXPORT_PARAM = "tr_auto_export";
+  var AUTO_SYNC_PARAM = "tr_auto_sync";
+  var AUTO_LIMIT_PARAM = "tr_limit";
+  var AUTO_MAX_PAGES_PARAM = "tr_max_pages";
+  var AUTO_MIN_AGE_PARAM = "tr_min_age";
+  var AUTO_MAX_AGE_PARAM = "tr_max_age";
+  var AUTO_SEARCH_PARAM = "keyword";
+  var AUTO_LOCATION_PARAM = "location";
+  var AUTO_KEYWORD_MODE_PARAM = "tr_kw_mode";
+  var SAMPLE_NAME_PARAM = "tr_sample_name";
+  var JOB5156_HOST = "hr.job5156.com";
+  var SEEK_HOST_SUFFIX = ".employer.seek.com";
+  var JOB5156_PROFILE_URL_PREFIX = `https://${JOB5156_HOST}/resume/view/`;
+  var SOURCE_KEYS = {
+    JOB5156: "job5156",
+    JOB51: "51job",
+    SEEK: "seek",
+    UNKNOWN: "unknown"
+  };
+  var SEEK_PROFILE_TYPE = "seek";
+  var KEYWORD_MODE_CONCAT = "concat";
+  var KEYWORD_MODE_SPACED = "spaced";
+  var JOB51_PAGE_COOLDOWN_MS = 8e3;
+  var JOB51_RATE_LIMIT_ERROR_MESSAGE = "51job \u5DF2\u89E6\u53D1\u8BBF\u95EE\u9891\u7387\u9650\u5236\uFF0C\u8BF760\u5206\u949F\u540E\u518D\u8BD5";
+  var autoExportTriggered = false;
+  var autoSyncTriggered = false;
+  var autoSyncCancelled = false;
+  var API_CAPTURE_SOURCE = "tr-resume-api";
+  var EXTERNAL_ACCESS_KEY = "__TR_RESUME_DATA__";
+  var PAGE_BRIDGE_REQUEST_EVENT = "trResumeBridgeRequest";
+  var PAGE_BRIDGE_RESPONSE_EVENT = "trResumeBridgeResponse";
+  var PAGE_BRIDGE_REQUEST_ATTR = "data-tr-resume-bridge-request";
+  var PAGE_BRIDGE_RESPONSE_ATTR = "data-tr-resume-bridge-response";
+  var JOB51_NEXT_PAGE_EVENT = "trJob51NextPageRequest";
+  var CONTENT_SCRIPT_SOURCE = "tr-resume-content-script";
+  var JOB5156_DETAIL_FETCH_TIMEOUT_MS = 5e3;
+  var JOB5156_DETAIL_FETCH_CONCURRENCY = 5;
+  var JOB51_DETAIL_FETCH_TIMEOUT_MS = 8e3;
+  var JOB51_DETAIL_FETCH_CONCURRENCY = 2;
+  var DEFAULT_SEEK_PAGE_SIZE = 20;
+  var LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY = "latestAutoSyncSummaries";
+  var DEFAULT_COLLECTION_GUARDS = {
+    job5156: "experience,jobIntention,selfIntro",
+    "51job": "experience,jobIntention,selfIntro",
+    seek: "experience,jobIntention,selfIntro"
+  };
+  var apiSnapshot = {
+    searchRows: null,
+    job51SearchRows: null,
+    job51Total: null,
+    job51LastSearchRequest: null,
+    job51AuthContext: null,
+    job51DetailPayload: null,
+    attachInfo: null,
+    chatInfo: null,
+    insightInfo: null,
+    seekRecommendedCandidates: null,
+    seekRecommendedRequest: null,
+    seekProfile: null,
+    seekProfileRequest: null,
+    seekTalentSearch: null,
+    seekTalentSearchRequest: null,
+    lastUpdatedAt: null,
+    lastSearchAt: null,
+    lastUrl: null,
+    lastSourceKey: null,
+    lastOperationName: null
+  };
+  var lastPersistedAutoSyncSummaryFingerprintBySource = {};
+  var job51DetailBackfillChain = Promise.resolve();
+  var job51DetailBackfillRunId = 0;
+  function sanitizeSampleName(value) {
+    if (!value) return "";
+    return value.trim().replace(/[\\/:*?"<>|]/g, "-").replace(/\s+/g, "-").replace(/-+/g, "-").replace(/^\.+/, "").slice(0, 80);
+  }
+  __name(sanitizeSampleName, "sanitizeSampleName");
+  function normalizeKeyword(keyword) {
+    if (!keyword) return "";
+    return keyword.replace(/[\u3000]/g, " ").replace(/\s+/g, " ").trim();
+  }
+  __name(normalizeKeyword, "normalizeKeyword");
+  function normalizeKeywordMode(mode) {
+    return mode === KEYWORD_MODE_SPACED ? KEYWORD_MODE_SPACED : KEYWORD_MODE_CONCAT;
+  }
+  __name(normalizeKeywordMode, "normalizeKeywordMode");
+  function normalizeCollectionLimit(value) {
+    const parsed = Number.parseInt(String(value ?? ""), 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  }
+  __name(normalizeCollectionLimit, "normalizeCollectionLimit");
+  function getCurrentLocationSearch() {
+    return window.location.search || "";
+  }
+  __name(getCurrentLocationSearch, "getCurrentLocationSearch");
+  function getCurrentAgeRange() {
+    return getAgeRangeFromUrl(
+      getCurrentLocationSearch(),
+      AUTO_MIN_AGE_PARAM,
+      AUTO_MAX_AGE_PARAM
+    );
+  }
+  __name(getCurrentAgeRange, "getCurrentAgeRange");
+  function filterCurrentResumesByAgeRange(resumes) {
+    if (getCurrentSourceKey() === SOURCE_KEYS.JOB51 && !isJob51DetailPage() && document.documentElement.getAttribute("data-tr-auto-age") !== "done") {
+      return Array.isArray(resumes) ? resumes : [];
+    }
+    return filterResumesByAgeRange(
+      resumes,
+      getCurrentLocationSearch(),
+      AUTO_MIN_AGE_PARAM,
+      AUTO_MAX_AGE_PARAM
+    );
+  }
+  __name(filterCurrentResumesByAgeRange, "filterCurrentResumesByAgeRange");
+  function resolveCurrentJob51CollectionLimits(limit, maxPages) {
+    return resolveJob51CollectionLimits(
+      limit,
+      maxPages,
+      getCurrentLocationSearch()
+    );
+  }
+  __name(resolveCurrentJob51CollectionLimits, "resolveCurrentJob51CollectionLimits");
+  function resolveCurrentJob51DetailFetchDelayMs() {
+    return resolveJob51DetailFetchDelayMs(getCurrentLocationSearch());
+  }
+  __name(resolveCurrentJob51DetailFetchDelayMs, "resolveCurrentJob51DetailFetchDelayMs");
+  function resolveCurrentJob51AutoSyncDetailWaitMode() {
+    return resolveJob51AutoSyncDetailWaitMode(getCurrentLocationSearch());
+  }
+  __name(resolveCurrentJob51AutoSyncDetailWaitMode, "resolveCurrentJob51AutoSyncDetailWaitMode");
+  var PROVINCE_TOKENS2 = /* @__PURE__ */ new Set([
+    "\u5317\u4EAC",
+    "\u5929\u6D25",
+    "\u4E0A\u6D77",
+    "\u91CD\u5E86",
+    "\u6CB3\u5317",
+    "\u5C71\u897F",
+    "\u8FBD\u5B81",
+    "\u5409\u6797",
+    "\u9ED1\u9F99\u6C5F",
+    "\u6C5F\u82CF",
+    "\u6D59\u6C5F",
+    "\u5B89\u5FBD",
+    "\u798F\u5EFA",
+    "\u6C5F\u897F",
+    "\u5C71\u4E1C",
+    "\u6CB3\u5357",
+    "\u6E56\u5317",
+    "\u6E56\u5357",
+    "\u5E7F\u4E1C",
+    "\u6D77\u5357",
+    "\u56DB\u5DDD",
+    "\u8D35\u5DDE",
+    "\u4E91\u5357",
+    "\u9655\u897F",
+    "\u7518\u8083",
+    "\u9752\u6D77",
+    "\u53F0\u6E7E",
+    "\u5185\u8499\u53E4",
+    "\u5E7F\u897F",
+    "\u897F\u85CF",
+    "\u5B81\u590F",
+    "\u65B0\u7586",
+    "\u9999\u6E2F",
+    "\u6FB3\u95E8"
+  ]);
+  function normalizeProvinceToken2(value) {
+    if (!value) return "";
+    return value.trim().replace(/特别行政区$/g, "").replace(/壮族自治区$/g, "").replace(/回族自治区$/g, "").replace(/维吾尔自治区$/g, "").replace(/自治区$/g, "").replace(/省$/g, "").replace(/市$/g, "");
+  }
+  __name(normalizeProvinceToken2, "normalizeProvinceToken");
+  function isProvinceToken(value) {
+    const normalized = normalizeProvinceToken2(value);
+    return normalized ? PROVINCE_TOKENS2.has(normalized) : false;
+  }
+  __name(isProvinceToken, "isProvinceToken");
+  async function getKeywordMode() {
+    return new Promise((resolve) => {
+      try {
+        chrome.storage.local.get(
+          { keywordMode: KEYWORD_MODE_CONCAT },
+          (items) => {
+            resolve(normalizeKeywordMode(items?.keywordMode));
+          }
+        );
+      } catch (error) {
+        console.warn(
+          "\u{1F3AF} [Auto Search] Failed to read keyword mode from storage:",
+          error
+        );
+        resolve(KEYWORD_MODE_CONCAT);
+      }
+    });
+  }
+  __name(getKeywordMode, "getKeywordMode");
+  async function getCollectionLimits() {
+    const params = new URLSearchParams(window.location.search || "");
+    const hasLimitParam = params.has(AUTO_LIMIT_PARAM);
+    const hasMaxPagesParam = params.has(AUTO_MAX_PAGES_PARAM);
+    const paramLimit = normalizeCollectionLimit(params.get(AUTO_LIMIT_PARAM));
+    const paramMaxPages = normalizeCollectionLimit(
+      params.get(AUTO_MAX_PAGES_PARAM)
+    );
+    return new Promise((resolve) => {
+      try {
+        chrome.storage.local.get({ collectLimit: 0, maxPages: 0 }, (items) => {
+          const resolvedLimit = hasLimitParam ? paramLimit : normalizeCollectionLimit(items?.collectLimit);
+          const resolvedMaxPages = hasMaxPagesParam ? paramMaxPages : normalizeCollectionLimit(items?.maxPages);
+          if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+            resolve(resolveCurrentJob51CollectionLimits(resolvedLimit, resolvedMaxPages));
+            return;
+          }
+          resolve({
+            limit: resolvedLimit,
+            maxPages: resolvedMaxPages
+          });
+        });
+      } catch (error) {
+        console.warn(
+          "\u{1F3AF} [Auto Sync] Failed to read collection limits from storage:",
+          error
+        );
+        if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+          resolve(
+            resolveCurrentJob51CollectionLimits(
+              hasLimitParam ? paramLimit : 0,
+              hasMaxPagesParam ? paramMaxPages : 0
+            )
+          );
+          return;
+        }
+        resolve({
+          limit: hasLimitParam ? paramLimit : 0,
+          maxPages: hasMaxPagesParam ? paramMaxPages : 0
+        });
+      }
+    });
+  }
+  __name(getCollectionLimits, "getCollectionLimits");
+  function buildExportFilename() {
+    const params = new URLSearchParams(window.location.search || "");
+    const rawSampleName = params.get(SAMPLE_NAME_PARAM) || "";
+    const sampleName = sanitizeSampleName(rawSampleName).replace(/\.json$/i, "");
+    const timestamp = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+    if (sampleName) return `${sampleName}.json`;
+    const rawKeyword = params.get(AUTO_SEARCH_PARAM) || "";
+    const keyword = sanitizeSampleName(normalizeKeyword(rawKeyword));
+    if (keyword) return `sample-${keyword}-${timestamp}.json`;
+    return `resumes_${timestamp}_${makeRandomId()}.json`;
+  }
+  __name(buildExportFilename, "buildExportFilename");
+  function parseAutoLocationValues(locationRaw) {
+    if (!locationRaw) return [];
+    return Array.from(
+      new Set(
+        String(locationRaw).split(/[，,、]+/).map((location) => location.trim()).filter(Boolean)
+      )
+    ).slice(0, 10);
+  }
+  __name(parseAutoLocationValues, "parseAutoLocationValues");
+  function getAutoLocationValues(url) {
+    return parseAutoLocationValues(
+      url.searchParams.get(AUTO_LOCATION_PARAM) || ""
+    );
+  }
+  __name(getAutoLocationValues, "getAutoLocationValues");
+  function normalizeSeekLocationLabel(value) {
+    return String(value || "").toLowerCase().replace(/\bmalaysia\b/g, "").replace(/\bmy\b/g, "").replace(/[，,、]/g, " ").replace(/\s+/g, " ").trim();
+  }
+  __name(normalizeSeekLocationLabel, "normalizeSeekLocationLabel");
+  function buildExportMetadata(resumes) {
+    const url = new URL(window.location.href);
+    const keyword = normalizeKeyword(
+      url.searchParams.get(AUTO_SEARCH_PARAM) || ""
+    );
+    const locationArray = getAutoLocationValues(url);
+    const rawSampleName = url.searchParams.get(SAMPLE_NAME_PARAM) || "";
+    const sampleName = sanitizeSampleName(rawSampleName).replace(/\.json$/i, "");
+    url.searchParams.delete(AUTO_EXPORT_PARAM);
+    url.searchParams.delete(AUTO_SYNC_PARAM);
+    url.searchParams.delete(AUTO_LIMIT_PARAM);
+    url.searchParams.delete(AUTO_MAX_PAGES_PARAM);
+    url.searchParams.delete(SAMPLE_NAME_PARAM);
+    const filters = {};
+    for (const [key, value] of url.searchParams.entries()) {
+      if (key === AUTO_SEARCH_PARAM || key === AUTO_LOCATION_PARAM) continue;
+      if (!value) continue;
+      filters[key] = value;
+    }
+    const pagination = getPaginationInfo();
+    const reproductionParams = new URLSearchParams();
+    reproductionParams.set(AUTO_EXPORT_PARAM, "json");
+    if (sampleName) reproductionParams.set(SAMPLE_NAME_PARAM, sampleName);
+    return {
+      sourceUrl: url.toString(),
+      searchCriteria: {
+        keyword,
+        location: locationArray.length > 0 ? locationArray : "",
+        filters: Object.keys(filters).length ? filters : {}
+      },
+      generatedAt: (/* @__PURE__ */ new Date()).toISOString(),
+      generatedBy: getExtensionGeneratedBy(),
+      totalPages: pagination.totalPages,
+      totalResumes: resumes.length,
+      reproduction: `Navigate to sourceUrl, then add ?${reproductionParams.toString()}`
+    };
+  }
+  __name(buildExportMetadata, "buildExportMetadata");
+  function getCurrentSourceKey() {
+    const hostname = window.location.hostname.toLowerCase();
+    if (hostname === JOB5156_HOST) return SOURCE_KEYS.JOB5156;
+    if (hostname === EHIRE_51JOB_HOST) return SOURCE_KEYS.JOB51;
+    if (hostname.endsWith(SEEK_HOST_SUFFIX)) return SOURCE_KEYS.SEEK;
+    return SOURCE_KEYS.UNKNOWN;
+  }
+  __name(getCurrentSourceKey, "getCurrentSourceKey");
+  function isJob5156DetailPage() {
+    return getCurrentSourceKey() === SOURCE_KEYS.JOB5156 && /^\/resume\/view\//i.test(window.location.pathname);
+  }
+  __name(isJob5156DetailPage, "isJob5156DetailPage");
+  function isJob51DetailPage() {
+    return getCurrentSourceKey() === SOURCE_KEYS.JOB51 && /\/Revision\/talent\/resume\/detail/i.test(window.location.pathname);
+  }
+  __name(isJob51DetailPage, "isJob51DetailPage");
+  function isJob51DetailReady() {
+    return isJob51DetailPage() && !!apiSnapshot.job51DetailPayload;
+  }
+  __name(isJob51DetailReady, "isJob51DetailReady");
+  function normalizeJob51AuthContext(requestHeaders, request) {
+    const headers = requestHeaders && typeof requestHeaders === "object" ? requestHeaders : {};
+    const requestBody = request && typeof request === "object" ? request : {};
+    const pick = /* @__PURE__ */ __name((...keys) => {
+      for (const key of keys) {
+        const headerValue = headers[key] ?? headers[key.toLowerCase()];
+        if (typeof headerValue === "string" && headerValue.trim()) {
+          return headerValue.trim();
+        }
+        const requestValue = requestBody[key];
+        if (typeof requestValue === "string" && requestValue.trim()) {
+          return requestValue.trim();
+        }
+      }
+      return "";
+    }, "pick");
+    const accesstoken = pick("accesstoken", "access-token", "accessToken");
+    const guid = pick("guid");
+    const property = pick("property");
+    const sign = pick("sign");
+    if (!accesstoken && !guid && !property && !sign) {
+      return null;
+    }
+    return {
+      ...accesstoken ? { accesstoken } : {},
+      ...guid ? { guid } : {},
+      ...property ? { property } : {},
+      ...sign ? { sign } : {}
+    };
+  }
+  __name(normalizeJob51AuthContext, "normalizeJob51AuthContext");
+  function getApiSnapshotCount() {
+    if (Array.isArray(apiSnapshot.searchRows)) {
+      return apiSnapshot.searchRows.length;
+    }
+    if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+      if (isJob51DetailPage()) {
+        return isJob51DetailReady() ? 1 : 0;
+      }
+      return Array.isArray(apiSnapshot.job51SearchRows) ? apiSnapshot.job51SearchRows.length : 0;
+    }
+    if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
+      return getSeekSnapshotCount();
+    }
+    return 0;
+  }
+  __name(getApiSnapshotCount, "getApiSnapshotCount");
+  function getJob51RawRows(payload) {
+    const rows = payload?.data?.list || payload?.data?.items || payload?.data?.rows || payload?.list || payload?.items || payload?.rows || (Array.isArray(payload?.data) ? payload.data : null) || (Array.isArray(payload) ? payload : null);
+    return Array.isArray(rows) ? rows : null;
+  }
+  __name(getJob51RawRows, "getJob51RawRows");
+  function getJob51TotalFromPayload(payload) {
+    const total = payload?.data?.total ?? payload?.total;
+    return typeof total === "number" && total >= 0 ? total : null;
+  }
+  __name(getJob51TotalFromPayload, "getJob51TotalFromPayload");
+  function isLikelyJob51ResumeRow(row) {
+    if (!row || typeof row !== "object") return false;
+    const baseInfo = row.base_info && typeof row.base_info === "object" ? row.base_info : null;
+    const jobIntention = row.job_intention && typeof row.job_intention === "object" ? row.job_intention : null;
+    const recentWorkInfo = row.recent_work_info && typeof row.recent_work_info === "object" ? row.recent_work_info : null;
+    const identityCandidates = [
+      row.resumeId,
+      row.resumeNo,
+      row.resumekey,
+      row.perUserId,
+      row.userId,
+      row.candidateId,
+      row.memberId,
+      row.userid,
+      row.real_userid,
+      baseInfo?.accountid
+    ];
+    const hasIdentity = identityCandidates.some((value) => {
+      if (value == null) return false;
+      return String(value).trim().length > 0;
+    });
+    const nameCandidates = [
+      row.name,
+      row.userName,
+      row.candidateName,
+      row.fullName,
+      baseInfo?.resume_name
+    ];
+    const hasName = nameCandidates.some((value) => {
+      if (value == null) return false;
+      return normalizeJob51Text(String(value)).length > 0;
+    });
+    const detailCandidates = [
+      row.workYear,
+      row.workYears,
+      row.experienceYears,
+      row.experience,
+      row.education,
+      row.educationLevel,
+      row.degree,
+      row.eduLevel,
+      row.location,
+      row.workCity,
+      row.city,
+      row.workLocation,
+      row.jobIntention,
+      row.desiredJob,
+      row.expectedPosition,
+      row.targetJob,
+      row.searchJob,
+      baseInfo?.work_year_value,
+      baseInfo?.top_degree_value,
+      baseInfo?.area_value,
+      jobIntention?.expect_work_function_value,
+      jobIntention?.expect_job_area_value,
+      recentWorkInfo?.recent_position
+    ];
+    const hasDetail = detailCandidates.some((value) => {
+      if (value == null) return false;
+      return normalizeJob51Text(String(value)).length > 0;
+    });
+    return hasIdentity && hasName || hasName && hasDetail;
+  }
+  __name(isLikelyJob51ResumeRow, "isLikelyJob51ResumeRow");
+  function getJob51ResumeRows(payload) {
+    const rows = getJob51RawRows(payload);
+    return Array.isArray(rows) ? rows.filter(isLikelyJob51ResumeRow) : null;
+  }
+  __name(getJob51ResumeRows, "getJob51ResumeRows");
+  function hasJob51SearchSnapshot() {
+    if (!Array.isArray(apiSnapshot.job51SearchRows)) return false;
+    return apiSnapshot.job51SearchRows.length > 0 || typeof apiSnapshot.job51Total === "number";
+  }
+  __name(hasJob51SearchSnapshot, "hasJob51SearchSnapshot");
+  function isJob51EmptySearchPromptVisible() {
+    if (getCurrentSourceKey() !== SOURCE_KEYS.JOB51) return false;
+    const pageText = normalizeResumeText(document.body?.textContent || "");
+    return pageText.includes("\u8F93\u5165\u5173\u952E\u8BCD\u641C\u7D22\u5BFB\u627E\u5339\u914D\u4EBA\u624D");
+  }
+  __name(isJob51EmptySearchPromptVisible, "isJob51EmptySearchPromptVisible");
+  function isJob51RateLimitedPage() {
+    if (getCurrentSourceKey() !== SOURCE_KEYS.JOB51) return false;
+    const pageText = normalizeResumeText(document.body?.textContent || "");
+    return pageText.includes("\u641C\u7D22\u8BBF\u95EE\u592A\u5FEB") && pageText.includes("\u8BF760\u5206\u949F\u540E\u518D\u8BD5");
+  }
+  __name(isJob51RateLimitedPage, "isJob51RateLimitedPage");
+  function ensureJob51PageAllowed() {
+    if (isJob51RateLimitedPage()) {
+      throw new Error(JOB51_RATE_LIMIT_ERROR_MESSAGE);
+    }
+  }
+  __name(ensureJob51PageAllowed, "ensureJob51PageAllowed");
+  function delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+  __name(delay, "delay");
+  async function waitForJob51Cooldown() {
+    if (getCurrentSourceKey() !== SOURCE_KEYS.JOB51) return;
+    SyncStatusWidget.show({
+      state: "progress",
+      message: "51job \u51B7\u5374\u4E2D\uFF0C\u6682\u7F13\u7FFB\u9875",
+      hint: `\u56FA\u5B9A\u7B49\u5F85 ${Math.round(JOB51_PAGE_COOLDOWN_MS / 1e3)} \u79D2\uFF0C\u907F\u514D\u89E6\u53D1\u8BBF\u95EE\u9650\u5236`
+    });
+    await delay(JOB51_PAGE_COOLDOWN_MS);
+  }
+  __name(waitForJob51Cooldown, "waitForJob51Cooldown");
+  function isSeekProfilePage() {
+    return window.location.pathname.includes("/talentsearch/profile/");
+  }
+  __name(isSeekProfilePage, "isSeekProfilePage");
+  function isSeekInlineProfileMode() {
+    if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) {
+      return false;
+    }
+    if (!window.location.pathname.includes("/candidates/recommended")) {
+      return false;
+    }
+    const openProfileId = normalizeOptionalPositiveInt(
+      new URL(window.location.href).searchParams.get("openProfileId")
+    );
+    return openProfileId !== null && hasSeekProfileSnapshot();
+  }
+  __name(isSeekInlineProfileMode, "isSeekInlineProfileMode");
+  function isSeekProfileMode() {
+    return isSeekProfilePage() || isSeekInlineProfileMode();
+  }
+  __name(isSeekProfileMode, "isSeekProfileMode");
+  function hasSeekProfileSnapshot() {
+    return !!(apiSnapshot.seekProfile && typeof apiSnapshot.seekProfile === "object");
+  }
+  __name(hasSeekProfileSnapshot, "hasSeekProfileSnapshot");
+  function hasSeekListSnapshot() {
+    return Array.isArray(apiSnapshot.seekRecommendedCandidates);
+  }
+  __name(hasSeekListSnapshot, "hasSeekListSnapshot");
+  function hasSeekTalentSearchSnapshot() {
+    return Array.isArray(apiSnapshot.seekTalentSearch);
+  }
+  __name(hasSeekTalentSearchSnapshot, "hasSeekTalentSearchSnapshot");
+  function getSeekSnapshotCount() {
+    if (isSeekProfileMode()) {
+      return hasSeekProfileSnapshot() ? 1 : 0;
+    }
+    if (hasSeekTalentSearchSnapshot()) {
+      return apiSnapshot.seekTalentSearch.length;
+    }
+    return hasSeekListSnapshot() ? apiSnapshot.seekRecommendedCandidates.length : 0;
+  }
+  __name(getSeekSnapshotCount, "getSeekSnapshotCount");
+  function isSeekSnapshotReady() {
+    return getSeekSnapshotCount() > 0;
+  }
+  __name(isSeekSnapshotReady, "isSeekSnapshotReady");
+  function getJob5156DetailRoot() {
+    const candidates = [
+      ".resume-detail",
+      ".resume-detail-content",
+      ".resume-detail-main",
+      ".resume-view-content",
+      ".resume-content",
+      ".detail-content",
+      ".main-content",
+      '[class*="resume-detail"]',
+      '[class*="resumeDetail"]',
+      '[class*="resume-view"]',
+      '[class*="resumeView"]',
+      "main"
+    ];
+    for (const selector of candidates) {
+      const el = document.querySelector(selector);
+      if (el instanceof Element && normalizeResumeText(el.textContent || "").length > 40) {
+        return el;
+      }
+    }
+    return document.body;
+  }
+  __name(getJob5156DetailRoot, "getJob5156DetailRoot");
+  function getJob5156DetailHeaderText(root = getJob5156DetailRoot()) {
+    if (!(root instanceof Element)) return "";
+    const header = root.querySelector(
+      'h1, .name, .resume-name, .basic-name, [class*="name"]'
+    );
+    return normalizeResumeText(
+      header?.textContent || root.querySelector(
+        '.basic-line, .resume-basic-info, [class*="basic"], .resume-view-item__block.resume-basic'
+      )?.textContent || ""
+    );
+  }
+  __name(getJob5156DetailHeaderText, "getJob5156DetailHeaderText");
+  function isJob5156DetailReady() {
+    if (!isJob5156DetailPage()) return false;
+    const resumeId = extractJob5156ResumeId(window.location.pathname);
+    if (!resumeId) return false;
+    const root = getJob5156DetailRoot();
+    const rootText = normalizeResumeText(root?.textContent || "");
+    return root instanceof Element && rootText.length > 80 && getJob5156DetailHeaderText(root).length > 0;
+  }
+  __name(isJob5156DetailReady, "isJob5156DetailReady");
+  function isJob5156DetailRootReady(root, pathname) {
+    if (!(root instanceof Element)) return false;
+    const resumeId = extractJob5156ResumeId(pathname || "");
+    if (!resumeId) return false;
+    const rootText = normalizeResumeText(root.textContent || "");
+    return rootText.length > 80 && getJob5156DetailHeaderText(root).length > 0;
+  }
+  __name(isJob5156DetailRootReady, "isJob5156DetailRootReady");
+  function isExtractionReady() {
+    if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+      return isJob51DetailPage() ? isJob51DetailReady() : hasJob51SearchSnapshot();
+    }
+    if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
+      return isSeekSnapshotReady();
+    }
+    if (isJob5156DetailPage()) {
+      return isJob5156DetailReady();
+    }
+    return document.querySelector(SELECTORS.listContainer) !== null;
+  }
+  __name(isExtractionReady, "isExtractionReady");
+  function getSeekCandidateIdentity(candidate) {
+    const profileId = candidate?.profileId != null ? String(candidate.profileId) : "";
+    return {
+      profileId,
+      profileType: typeof candidate?.profileType === "string" ? candidate.profileType : SEEK_PROFILE_TYPE
+    };
+  }
+  __name(getSeekCandidateIdentity, "getSeekCandidateIdentity");
+  function buildSeekProfileUrl(profileId, jobId) {
+    if (!profileId) return "";
+    const hostname = window.location.hostname.toLowerCase();
+    if (jobId) {
+      return `https://${hostname}/candidates/recommended?jobId=${encodeURIComponent(jobId)}&openProfileId=${encodeURIComponent(profileId)}`;
+    }
+    return `https://${hostname}/candidates/${encodeURIComponent(profileId)}`;
+  }
+  __name(buildSeekProfileUrl, "buildSeekProfileUrl");
+  function getSeekRecommendedRequest() {
+    return apiSnapshot.seekRecommendedRequest;
+  }
+  __name(getSeekRecommendedRequest, "getSeekRecommendedRequest");
+  function getSeekProfileRequest() {
+    return apiSnapshot.seekProfileRequest || apiSnapshot.seekRecommendedRequest;
+  }
+  __name(getSeekProfileRequest, "getSeekProfileRequest");
+  function getSeekAutoSyncHelpers() {
+    const helpers = globalThis.__TR_SEEK_AUTO_SYNC__;
+    return helpers && typeof helpers === "object" ? helpers : null;
+  }
+  __name(getSeekAutoSyncHelpers, "getSeekAutoSyncHelpers");
+  function resolveSeekAutoSyncPageSize(options = {}) {
+    const {
+      requestedPageSize,
+      currentPageCandidateCount,
+      fallbackPageSize = DEFAULT_SEEK_PAGE_SIZE
+    } = options;
+    const helpers = getSeekAutoSyncHelpers();
+    if (typeof helpers?.resolveSeekAutoSyncPageSize === "function") {
+      return helpers.resolveSeekAutoSyncPageSize({
+        requestedPageSize,
+        currentPageCandidateCount,
+        fallbackPageSize
+      });
+    }
+    return normalizeOptionalPositiveInt(requestedPageSize) || normalizeOptionalPositiveInt(currentPageCandidateCount) || normalizeOptionalPositiveInt(fallbackPageSize) || DEFAULT_SEEK_PAGE_SIZE;
+  }
+  __name(resolveSeekAutoSyncPageSize, "resolveSeekAutoSyncPageSize");
+  function resolveSeekAutoSyncPageWindow(options = {}) {
+    const {
+      startPage,
+      limit,
+      maxPages,
+      requestedPageSize,
+      currentPageCandidateCount
+    } = options;
+    const helpers = getSeekAutoSyncHelpers();
+    if (typeof helpers?.resolveSeekAutoSyncPageWindow === "function") {
+      return helpers.resolveSeekAutoSyncPageWindow({
+        startPage,
+        limit,
+        maxPages,
+        requestedPageSize,
+        currentPageCandidateCount,
+        fallbackPageSize: DEFAULT_SEEK_PAGE_SIZE
+      });
+    }
+    const normalizedStartPage = normalizeOptionalPositiveInt(startPage) || 1;
+    const normalizedLimit = normalizeOptionalPositiveInt(limit);
+    const normalizedMaxPages = normalizeOptionalPositiveInt(maxPages);
+    const effectivePageSize = resolveSeekAutoSyncPageSize({
+      requestedPageSize,
+      currentPageCandidateCount,
+      fallbackPageSize: DEFAULT_SEEK_PAGE_SIZE
+    });
+    const limitPageCount = normalizedLimit ? Math.max(1, Math.ceil(normalizedLimit / effectivePageSize)) : null;
+    let allowedPageCount = null;
+    if (limitPageCount && normalizedMaxPages) {
+      allowedPageCount = Math.min(limitPageCount, normalizedMaxPages);
+    } else if (limitPageCount) {
+      allowedPageCount = limitPageCount;
+    } else if (normalizedMaxPages) {
+      allowedPageCount = normalizedMaxPages;
+    }
+    return {
+      startPage: normalizedStartPage,
+      targetPageEnd: allowedPageCount ? normalizedStartPage + allowedPageCount - 1 : null,
+      effectivePageSize,
+      limitPageCount,
+      maxPages: normalizedMaxPages,
+      allowedPageCount
+    };
+  }
+  __name(resolveSeekAutoSyncPageWindow, "resolveSeekAutoSyncPageWindow");
+  function isSeekAutoSyncPageWindowReached(pageWindow, currentPage) {
+    const helpers = getSeekAutoSyncHelpers();
+    if (typeof helpers?.isSeekAutoSyncPageWindowReached === "function") {
+      return helpers.isSeekAutoSyncPageWindowReached({
+        currentPage,
+        targetPageEnd: pageWindow?.targetPageEnd
+      });
+    }
+    const normalizedCurrentPage = normalizeOptionalPositiveInt(currentPage);
+    const targetPageEnd = normalizeOptionalPositiveInt(pageWindow?.targetPageEnd);
+    return !!(normalizedCurrentPage && targetPageEnd && normalizedCurrentPage >= targetPageEnd);
+  }
+  __name(isSeekAutoSyncPageWindowReached, "isSeekAutoSyncPageWindowReached");
+  function resolveSeekAutoSyncCurrentPageSelection(options = {}) {
+    const helpers = getSeekAutoSyncHelpers();
+    if (typeof helpers?.resolveSeekAutoSyncCurrentPageSelection === "function") {
+      return helpers.resolveSeekAutoSyncCurrentPageSelection(options);
+    }
+    const normalizedLimit = normalizeOptionalPositiveInt(options.limit);
+    const normalizedTotalSubmitted = normalizeOptionalPositiveInt(options.totalSubmitted) || 0;
+    const normalizedCurrentPageResumeCount = normalizeOptionalPositiveInt(options.currentPageResumeCount) || 0;
+    const remainingCapacity = normalizedLimit ? Math.max(normalizedLimit - normalizedTotalSubmitted, 0) : null;
+    const selectedCount = remainingCapacity === null ? normalizedCurrentPageResumeCount : Math.min(normalizedCurrentPageResumeCount, remainingCapacity);
+    return {
+      remainingCapacity,
+      selectedCount,
+      hitLimitWithinPage: remainingCapacity !== null && normalizedCurrentPageResumeCount > remainingCapacity,
+      limitAlreadyReached: remainingCapacity !== null && remainingCapacity <= 0
+    };
+  }
+  __name(resolveSeekAutoSyncCurrentPageSelection, "resolveSeekAutoSyncCurrentPageSelection");
+  function getSeekRequestedPageSize() {
+    const requestInput = getSeekRecommendedRequest()?.variables?.input;
+    return normalizeOptionalPositiveInt(requestInput?.size);
+  }
+  __name(getSeekRequestedPageSize, "getSeekRequestedPageSize");
+  function getSeekCurrentCandidateCount() {
+    return Array.isArray(apiSnapshot.seekRecommendedCandidates) ? apiSnapshot.seekRecommendedCandidates.length : 0;
+  }
+  __name(getSeekCurrentCandidateCount, "getSeekCurrentCandidateCount");
+  function setSeekAutoSyncWindowAttributes(pageWindow) {
+    const attrs = (
+      /** @type {Array<[string, number | null | undefined]>} */
+      [
+        ["data-tr-auto-sync-target-start", pageWindow?.startPage],
+        ["data-tr-auto-sync-target-end", pageWindow?.targetPageEnd],
+        ["data-tr-auto-sync-effective-page-size", pageWindow?.effectivePageSize]
+      ]
+    );
+    try {
+      for (const [name, value] of attrs) {
+        if (typeof value === "number" && Number.isFinite(value)) {
+          document.documentElement.setAttribute(name, String(value));
+        } else {
+          document.documentElement.removeAttribute(name);
+        }
+      }
+    } catch {
+    }
+    persistLatestAutoSyncSummary();
+  }
+  __name(setSeekAutoSyncWindowAttributes, "setSeekAutoSyncWindowAttributes");
+  function setSeekAutoSyncSelectionAttributes(selection) {
+    const attrs = (
+      /** @type {Array<[string, number | null | undefined]>} */
+      [
+        ["data-tr-auto-sync-selected-count", selection?.selectedCount],
+        ["data-tr-auto-sync-remaining-capacity", selection?.remainingCapacity]
+      ]
+    );
+    try {
+      for (const [name, value] of attrs) {
+        if (typeof value === "number" && Number.isFinite(value)) {
+          document.documentElement.setAttribute(name, String(value));
+        } else {
+          document.documentElement.removeAttribute(name);
+        }
+      }
+    } catch {
+    }
+    persistLatestAutoSyncSummary();
+  }
+  __name(setSeekAutoSyncSelectionAttributes, "setSeekAutoSyncSelectionAttributes");
+  function findSeekProfileTrigger(profileId) {
+    if (!profileId) return null;
+    const candidateLinks = Array.from(document.querySelectorAll("a[href]"));
+    return candidateLinks.find((link) => {
+      const href = link.getAttribute("href") || "";
+      return href.includes(
+        `/talentsearch/profile/${encodeURIComponent(profileId)}`
+      ) || href.includes(`openProfileId=${encodeURIComponent(profileId)}`);
+    }) || null;
+  }
+  __name(findSeekProfileTrigger, "findSeekProfileTrigger");
+  function mergeSeekListResumeWithDetail(baseResume, detailResume) {
+    if (!detailResume || typeof detailResume !== "object") {
+      return baseResume;
+    }
+    return {
+      ...baseResume,
+      ...detailResume,
+      pageIndex: baseResume.pageIndex,
+      pageNumber: baseResume.pageNumber,
+      extractedAt: baseResume.extractedAt,
+      source: baseResume.source,
+      searchProfileId: detailResume.searchProfileId || baseResume.searchProfileId
+    };
+  }
+  __name(mergeSeekListResumeWithDetail, "mergeSeekListResumeWithDetail");
+  function formatSeekExpectedSalary(expectedSalary) {
+    if (!expectedSalary || typeof expectedSalary !== "object") return "";
+    const amounts = Array.isArray(expectedSalary.amount) ? expectedSalary.amount : [];
+    const preferredFrequencies = ["MONTHLY", "ANNUAL", "HOURLY"];
+    const amount = preferredFrequencies.map(
+      (frequency) => amounts.find((entry) => entry?.frequency === frequency)
+    ).find(Boolean) || amounts[0];
+    if (!amount || typeof amount !== "object") return "";
+    const value = typeof amount.value === "number" ? amount.value : Number(amount.value);
+    const formattedValue = Number.isFinite(value) ? new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(value) : "";
+    const currency = typeof expectedSalary.currency === "string" ? expectedSalary.currency.trim() : "";
+    const period = amount.frequency === "ANNUAL" ? "/year" : amount.frequency === "HOURLY" ? "/hour" : amount.frequency === "DAILY" ? "/day" : "/month";
+    const prefix = [currency, formattedValue].filter(Boolean).join(" ");
+    return prefix ? `${prefix}${period}` : "";
+  }
+  __name(formatSeekExpectedSalary, "formatSeekExpectedSalary");
+  function buildSeekWorkHistoryItem(item) {
+    if (!item || typeof item !== "object") return null;
+    const companyName = typeof item.companyName === "string" ? item.companyName.trim() : "";
+    const jobTitle = typeof item.jobTitle === "string" ? item.jobTitle.trim() : "";
+    const description = typeof item.description === "string" ? item.description.trim() : "";
+    const startDate = typeof item.startDate === "string" ? item.startDate.trim() : "";
+    const endDate = typeof item.endDate === "string" ? item.endDate.trim() : "";
+    const durationLabel = typeof item.durationLabel === "string" ? item.durationLabel.trim() : "";
+    const raw = [jobTitle, companyName, durationLabel].filter(Boolean).join(" \xB7 ");
+    if (!raw && !description) return null;
+    return {
+      raw: raw || description,
+      companyName: companyName || void 0,
+      jobTitle: jobTitle || void 0,
+      description: description || void 0,
+      startDate: startDate || void 0,
+      endDate: endDate || void 0
+    };
+  }
+  __name(buildSeekWorkHistoryItem, "buildSeekWorkHistoryItem");
+  function buildSeekProfileEducationItem(item) {
+    if (!item || typeof item !== "object") return null;
+    const institution = typeof item.institutionName === "string" ? item.institutionName.trim() : "";
+    const qualification = typeof item.qualificationName === "string" ? item.qualificationName.trim() : "";
+    const completionYear = Number.isFinite(item.completionYear) ? String(item.completionYear) : "";
+    const completionMonth = Number.isFinite(item.completionMonth) && item.completionMonth > 0 ? String(item.completionMonth).padStart(2, "0") : "";
+    const endDate = completionYear ? completionMonth ? `${completionYear}-${completionMonth}` : completionYear : "";
+    if (!institution && !qualification && !endDate) return null;
+    return {
+      institution: institution || void 0,
+      qualification: qualification || void 0,
+      endDate: endDate || void 0
+    };
+  }
+  __name(buildSeekProfileEducationItem, "buildSeekProfileEducationItem");
+  function parseJob5156BasicInfoItems(items, locationOverride = "") {
+    const basicInfo = Array.isArray(items) ? items.map((item) => normalizeResumeText(item)).filter(Boolean) : [];
+    let age = "";
+    let experience = "";
+    let education = "";
+    let location = "";
+    if (basicInfo.length >= 4) {
+      [age, experience, education, location] = basicInfo;
+    } else {
+      basicInfo.forEach((item) => {
+        if (!age && item.includes("\u5C81")) age = item;
+        else if (!experience && item.includes("\u5E74") && !item.includes("\u5143"))
+          experience = item;
+        else if (!education && /(中专|高中|大专|本科|硕|博|研究生|MBA|EMBA)/.test(item))
+          education = item;
+        else if (!location && !item.includes("\u5143")) location = item;
+      });
+    }
+    if (locationOverride) {
+      location = normalizeResumeText(locationOverride);
+    }
+    return { age, experience, education, location };
+  }
+  __name(parseJob5156BasicInfoItems, "parseJob5156BasicInfoItems");
+  function buildJob5156WorkHistoryItem(item) {
+    if (!(item instanceof Element)) return null;
+    const startDate = normalizeResumeText(
+      item.querySelector(".work-time > span:first-child")?.textContent
+    );
+    const durationLabel = normalizeResumeText(
+      item.querySelector(".work-time-other")?.textContent
+    );
+    const companyName = normalizeResumeText(
+      item.querySelector(".work-company")?.textContent
+    );
+    const jobTitle = normalizeResumeText(
+      item.querySelector(".work-position")?.textContent
+    );
+    const description = normalizeResumeText(
+      item.querySelector(
+        ".work-desc, .work-detail, .work-content, .work-responsibility, .work-duty"
+      )?.textContent
+    );
+    const endDate = startDate.includes("~") ? normalizeResumeText(startDate.split("~").slice(1).join("~")) : "";
+    const raw = buildWorkHistoryRawParts([
+      startDate,
+      durationLabel,
+      companyName,
+      jobTitle,
+      description
+    ]);
+    if (!raw) return null;
+    return {
+      raw,
+      companyName: companyName || void 0,
+      jobTitle: jobTitle || void 0,
+      description: description || void 0,
+      startDate: startDate || void 0,
+      endDate: endDate || void 0
+    };
+  }
+  __name(buildJob5156WorkHistoryItem, "buildJob5156WorkHistoryItem");
+  function buildJob5156EducationItem(item) {
+    if (!(item instanceof Element)) return null;
+    const liveEducationText = normalizeResumeText(item.textContent);
+    if (item.classList.contains("resume-education__info") || item.closest(".resume-education")) {
+      const institution2 = normalizeResumeText(
+        item.querySelector(".flex.w-full > div:last-child")?.textContent
+      );
+      const rowText = Array.from(item.querySelectorAll(".flex.w-full > div")).map((node) => normalizeResumeText(node.textContent)).filter(Boolean);
+      const endDate2 = rowText.find((value) => /^\d{4}(~|-)/.test(value)) || "";
+      const qualification2 = rowText.filter((value) => value !== institution2 && value !== endDate2).join(" \xB7 ");
+      if (!institution2 && !qualification2 && !endDate2 && !liveEducationText)
+        return null;
+      return {
+        institution: institution2 || void 0,
+        qualification: qualification2 || void 0,
+        endDate: endDate2 || void 0,
+        description: liveEducationText || void 0
+      };
+    }
+    const institution = normalizeResumeText(
+      item.querySelector(".school-name")?.textContent
+    );
+    const qualification = normalizeResumeText(
+      item.querySelector(".school-major")?.textContent
+    );
+    const degree = normalizeResumeText(
+      item.querySelector(".school-degree")?.textContent
+    );
+    const endDate = normalizeResumeText(
+      item.querySelector(".school-time")?.textContent
+    );
+    if (!institution && !qualification && !degree && !endDate) return null;
+    return {
+      institution: institution || void 0,
+      qualification: [qualification, degree].filter(Boolean).join(" \xB7 ") || void 0,
+      endDate: endDate || void 0
+    };
+  }
+  __name(buildJob5156EducationItem, "buildJob5156EducationItem");
+  function buildJob5156DetailWorkHistoryItem(item) {
+    if (!(item instanceof Element)) return null;
+    if (item.classList.contains("resume-work__info") || item.closest(".resume-work")) {
+      const row1 = item.querySelector(".resume-work__row-1");
+      const row2 = item.querySelector(".resume-work__row-2");
+      const row3 = item.querySelector(".resume-work__row-3");
+      const row4 = item.querySelector(".resume-work__row-4");
+      const companyName2 = normalizeResumeText(
+        row1?.querySelector(".flex.flex-1 > span.pointer")?.textContent
+      );
+      const jobTitle2 = normalizeResumeText(
+        row1?.querySelector(".flex.flex-1 > span:not(.pointer):not(.cut)")?.textContent
+      );
+      const periodText2 = normalizeResumeText(
+        row1?.querySelector(".time-diff")?.textContent
+      );
+      const periodMatch = periodText2.match(/^(.+?)(?:（(.+)）)?$/u);
+      const dateRange = normalizeResumeText(periodMatch?.[1] || periodText2);
+      const durationLabel2 = normalizeResumeText(periodMatch?.[2] || "");
+      const startDate2 = dateRange.includes("~") ? normalizeResumeText(dateRange.split("~")[0]) : dateRange;
+      const endDate2 = dateRange.includes("~") ? normalizeResumeText(dateRange.split("~").slice(1).join("~")) : "";
+      const companyMeta2 = normalizeResumeText(row2?.textContent);
+      const description2 = normalizeResumeText(
+        row3?.querySelector("pre")?.textContent || row3?.textContent
+      );
+      const reasonText2 = normalizeResumeText(row4?.textContent).replace(
+        /^离职原因[:：]?\s*/u,
+        ""
+      );
+      const raw2 = buildWorkHistoryRawParts([
+        dateRange,
+        durationLabel2 ? `(${durationLabel2})` : "",
+        companyName2,
+        jobTitle2,
+        companyMeta2 ? `\u516C\u53F8\u4FE1\u606F\uFF1A${companyMeta2}` : "",
+        description2,
+        reasonText2 ? `\u79BB\u804C\u539F\u56E0\uFF1A${reasonText2}` : ""
+      ]);
+      if (!raw2 && !description2 && !companyName2 && !jobTitle2) return null;
+      return {
+        raw: raw2 || description2 || buildWorkHistoryRawParts([companyName2, jobTitle2, dateRange]),
+        companyName: companyName2 || void 0,
+        jobTitle: jobTitle2 || void 0,
+        description: [description2, reasonText2 ? `\u79BB\u804C\u539F\u56E0\uFF1A${reasonText2}` : ""].filter(Boolean).join("\n") || void 0,
+        startDate: startDate2 || void 0,
+        endDate: endDate2 || void 0
+      };
+    }
+    const getText = /* @__PURE__ */ __name((selectors) => {
+      for (const selector of selectors) {
+        const value = normalizeResumeText(
+          item.querySelector(selector)?.textContent
+        );
+        if (value) return value;
+      }
+      return "";
+    }, "getText");
+    const getOwnText = /* @__PURE__ */ __name((selectors) => {
+      for (const selector of selectors) {
+        const node = item.querySelector(selector);
+        if (!(node instanceof Element)) continue;
+        const text = normalizeResumeText(
+          Array.from(node.childNodes).filter((child) => child.nodeType === Node.TEXT_NODE).map((child) => child.textContent || "").join(" ")
+        );
+        if (text) return text;
+      }
+      return "";
+    }, "getOwnText");
+    const getLines = /* @__PURE__ */ __name((selectors) => {
+      for (const selector of selectors) {
+        const nodes = item.querySelectorAll(selector);
+        const values = Array.from(nodes).map((node) => normalizeResumeText(node.textContent)).filter(Boolean);
+        if (values.length > 0) return values;
+      }
+      return [];
+    }, "getLines");
+    const periodText = getText([
+      ".work-time",
+      ".time",
+      ".date",
+      ".work-date",
+      ".job-time",
+      '[class*="work-time"]',
+      '[class*="job-time"]'
+    ]);
+    const startDate = periodText.includes("~") ? normalizeResumeText(periodText.split("~")[0]) : periodText;
+    const endDate = periodText.includes("~") ? normalizeResumeText(periodText.split("~").slice(1).join("~")) : "";
+    const durationLabel = getText([
+      ".work-time-other",
+      ".time-other",
+      ".duration",
+      '[class*="duration"]'
+    ]);
+    const companyName = getText([
+      ".work-company",
+      ".company-name",
+      ".company",
+      '[class*="company"]'
+    ]);
+    const jobTitle = getText([
+      ".work-position",
+      ".job-title",
+      ".position-name",
+      ".position",
+      '[class*="position"]',
+      '[class*="job-title"]'
+    ]);
+    const department = getText([
+      ".work-department",
+      ".department",
+      '[class*="department"]'
+    ]);
+    const companyMeta = getText([
+      ".company-other",
+      ".company-info",
+      ".company-meta",
+      '[class*="company-other"]',
+      '[class*="company-info"]'
+    ]);
+    const reasonText = getText([
+      ".work-reason",
+      ".leave-reason",
+      '[class*="leave-reason"]',
+      '[class*="reason"]'
+    ]).replace(/^离职原因[:：]?\s*/u, "");
+    const ownDescription = getOwnText([
+      ".work-desc",
+      ".work-detail",
+      ".work-content",
+      ".work-responsibility",
+      ".work-duty",
+      '[class*="work-desc"]',
+      '[class*="responsibility"]',
+      '[class*="duty"]'
+    ]);
+    const descriptionLines = getLines([
+      ".work-desc p, .work-detail p, .work-content p, .work-responsibility p, .work-duty p",
+      ".work-desc li, .work-detail li, .work-content li, .work-responsibility li, .work-duty li",
+      '[class*="work-desc"] p, [class*="responsibility"] p, [class*="duty"] p',
+      '[class*="work-desc"] li, [class*="responsibility"] li, [class*="duty"] li'
+    ]);
+    const description = [
+      ownDescription,
+      descriptionLines.length > 0 ? descriptionLines.join("\n") : "",
+      department ? `\u90E8\u95E8\uFF1A${department}` : "",
+      companyMeta ? `\u516C\u53F8\u4FE1\u606F\uFF1A${companyMeta}` : "",
+      reasonText ? `\u79BB\u804C\u539F\u56E0\uFF1A${reasonText}` : ""
+    ].filter(Boolean).join("\n");
+    const raw = buildWorkHistoryRawParts([
+      periodText,
+      durationLabel,
+      companyName,
+      jobTitle,
+      department ? `\u90E8\u95E8\uFF1A${department}` : "",
+      companyMeta ? `\u516C\u53F8\u4FE1\u606F\uFF1A${companyMeta}` : "",
+      ownDescription,
+      descriptionLines.join("\uFF1B"),
+      reasonText ? `\u79BB\u804C\u539F\u56E0\uFF1A${reasonText}` : ""
+    ]);
+    if (!raw && !description) return null;
+    return {
+      raw: raw || description,
+      companyName: companyName || void 0,
+      jobTitle: jobTitle || void 0,
+      description: description || void 0,
+      startDate: startDate || void 0,
+      endDate: endDate || void 0
+    };
+  }
+  __name(buildJob5156DetailWorkHistoryItem, "buildJob5156DetailWorkHistoryItem");
+  function collectSectionItemsByHeading(root, headingPattern, primarySelectors = [], fallbackSelectors = []) {
+    return collectJob5156SectionItemsByHeading(
+      root,
+      headingPattern,
+      primarySelectors,
+      fallbackSelectors
+    );
+  }
+  __name(collectSectionItemsByHeading, "collectSectionItemsByHeading");
+  function buildJob5156DetailResumeFromRoot(root, options = {}) {
+    if (!(root instanceof Element)) return [];
+    const {
+      pathname,
+      profileUrl: profileUrlInput,
+      extractedAt
+    } = normalizeJob5156ExtractOptions(options);
+    if (!isJob5156DetailRootReady(root, pathname)) return [];
+    const readText = /* @__PURE__ */ __name((selectors, scopedRoot = root) => {
+      for (const selector of selectors) {
+        const value = normalizeResumeText(
+          scopedRoot.querySelector(selector)?.textContent
+        );
+        if (value) return value;
+      }
+      return "";
+    }, "readText");
+    const resumeId = extractJob5156ResumeId(pathname);
+    const profileUrl = normalizeJob5156ProfileUrlForExport(profileUrlInput);
+    const basicTextNodes = Array.from(
+      root.querySelectorAll(
+        '.basic-line__text, .basic-line span, .resume-basic-info span, [class*="basic"] span, .info-item, .label-value, .tag'
+      )
+    ).map((node) => node.textContent || "");
+    const filteredBasicTextNodes = basicTextNodes.filter(
+      (item) => !/求职状态|沟通中|更新时间/.test(item)
+    );
+    const { age, experience, education, location } = parseJob5156BasicInfoItems(
+      filteredBasicTextNodes
+    );
+    const workItems = collectSectionItemsByHeading(
+      root,
+      /工作经历|工作经验|工作履历/u,
+      [
+        ".resume-work__info",
+        ".work-item",
+        ".work-block",
+        '[class*="work-item"]',
+        '[class*="work-block"]'
+      ],
+      [
+        ":scope > li",
+        ":scope > .item",
+        ':scope > [class*="item"]'
+      ]
+    );
+    const educationItems = collectSectionItemsByHeading(
+      root,
+      /教育经历|教育背景|学习经历/u,
+      [
+        ".resume-education__info",
+        ".school-item",
+        '[class*="education"]',
+        '[class*="school"]'
+      ],
+      [
+        ":scope > li",
+        ":scope > .item",
+        ':scope > [class*="item"]'
+      ]
+    );
+    const seenWorkHistory = /* @__PURE__ */ new Set();
+    const workHistory = workItems.map((item) => buildJob5156DetailWorkHistoryItem(item)).filter((item) => item && isMeaningfulJob5156WorkHistoryEntry(item)).filter((item) => {
+      const signature = [
+        item.companyName || "",
+        item.jobTitle || "",
+        item.startDate || "",
+        item.endDate || "",
+        item.raw || ""
+      ].join("|");
+      if (seenWorkHistory.has(signature)) return false;
+      seenWorkHistory.add(signature);
+      return true;
+    });
+    const seenEducation = /* @__PURE__ */ new Set();
+    const profileEducation = educationItems.map((item) => buildJob5156EducationItem(item)).filter(
+      (item) => item && [item.institution, item.qualification, item.endDate].some(Boolean)
+    ).filter((item) => {
+      const signature = [
+        item.institution || "",
+        item.qualification || "",
+        item.endDate || ""
+      ].join("|");
+      if (seenEducation.has(signature)) return false;
+      seenEducation.add(signature);
+      return true;
+    });
+    const activityStatus = readText([
+      ".date-type-diff-text-block",
+      ".resume-status",
+      ".active-status",
+      '[class*="status"]'
+    ]);
+    const intentionSection = root.querySelector(
+      ".resume-view-layout.resume-interview"
+    );
+    const intentionItems = Array.from(
+      intentionSection?.querySelectorAll(".resume-interview-info") || []
+    );
+    const jobIntention = intentionItems.map(
+      (item) => normalizeResumeText(item.querySelector(".pos-name")?.textContent)
+    ).filter(Boolean).join(" / ");
+    const expectedSalary = normalizeResumeText(
+      intentionItems[0]?.textContent
+    ).replace(/^.+?\s(\d[^\s]*元\/[月天年]).*$/u, "$1");
+    const selfIntro = normalizeResumeText(
+      root.querySelector(
+        ".resume-view-layout.resume-advantages .resume-advantages_skill pre"
+      )?.textContent || root.querySelector(
+        ".resume-view-layout.resume-advantages .resume-advantages_skill"
+      )?.textContent || ""
+    );
+    const name = readText([
+      ".resume-name",
+      ".basic-name",
+      ".name",
+      ".resume-view-item__block.resume-basic",
+      "h1"
+    ]);
+    return [
+      {
+        resumeId,
+        name,
+        profileUrl,
+        activityStatus,
+        age,
+        experience,
+        education,
+        location,
+        jobIntention,
+        expectedSalary,
+        selfIntro,
+        workHistory,
+        profileEducation: profileEducation.length > 0 ? profileEducation : void 0,
+        extractedAt,
+        source: JOB5156_HOST
+      }
+    ];
+  }
+  __name(buildJob5156DetailResumeFromRoot, "buildJob5156DetailResumeFromRoot");
+  function extractJob5156DetailResume() {
+    if (!isJob5156DetailPage() || !isJob5156DetailReady()) return [];
+    return buildJob5156DetailResumeFromRoot(getJob5156DetailRoot(), {
+      pathname: window.location.pathname,
+      profileUrl: window.location.href
+    });
+  }
+  __name(extractJob5156DetailResume, "extractJob5156DetailResume");
+  function buildJob5156DetailWorkHistoryItemFromApi(item) {
+    if (!item || typeof item !== "object") return null;
+    const begin = normalizeResumeText(item.begin);
+    const end = normalizeResumeText(item.end);
+    const dateRange = [begin, end].filter(Boolean).join("~");
+    const durationLabel = normalizeResumeText(item.timeDiff || item.timeDiff2);
+    const companyName = normalizeResumeText(item.comName || item.comNameStr);
+    const jobTitle = normalizeResumeText(item.jobNameStr || item.jobName);
+    const department = normalizeResumeText(item.section);
+    const companyMeta = buildWorkHistoryRawParts([
+      normalizeResumeText(item.comCallingStr),
+      normalizeResumeText(item.comScaleStr),
+      normalizeResumeText(item.comTypeStr)
+    ]);
+    const description = normalizeResumeMultilineText(item.description);
+    const reasonText = normalizeResumeText(item.leftreason);
+    const startDate = begin || void 0;
+    const endDate = end || void 0;
+    const descriptionLines = [
+      companyMeta ? `\u516C\u53F8\u4FE1\u606F\uFF1A${companyMeta}` : "",
+      department ? `\u90E8\u95E8\uFF1A${department}` : "",
+      description,
+      reasonText ? `\u79BB\u804C\u539F\u56E0\uFF1A${reasonText}` : ""
+    ].filter(Boolean);
+    const raw = buildWorkHistoryRawParts([
+      dateRange,
+      durationLabel ? `(${durationLabel})` : "",
+      companyName,
+      jobTitle,
+      ...descriptionLines
+    ]);
+    if (!raw && !description && !companyName && !jobTitle) return null;
+    return {
+      raw: raw || description || buildWorkHistoryRawParts([companyName, jobTitle, dateRange]),
+      companyName: companyName || void 0,
+      jobTitle: jobTitle || void 0,
+      description: descriptionLines.join("\n") || void 0,
+      startDate,
+      endDate
+    };
+  }
+  __name(buildJob5156DetailWorkHistoryItemFromApi, "buildJob5156DetailWorkHistoryItemFromApi");
+  function buildJob5156EducationItemFromApi(item) {
+    if (!item || typeof item !== "object") return null;
+    const institution = normalizeResumeText(item.schoolName);
+    const degree = normalizeResumeText(item.degreeStr);
+    const speciality = normalizeResumeText(item.speciality);
+    const qualification = buildWorkHistoryRawParts([degree, speciality]);
+    const endDate = normalizeResumeText(
+      [item.begin, item.end].filter(Boolean).join("~") || item.end
+    );
+    const description = buildWorkHistoryRawParts([
+      degree,
+      speciality,
+      endDate,
+      institution
+    ]);
+    if (!institution && !qualification && !endDate) return null;
+    return {
+      institution: institution || void 0,
+      qualification: qualification || void 0,
+      endDate: endDate || void 0,
+      description: description || void 0
+    };
+  }
+  __name(buildJob5156EducationItemFromApi, "buildJob5156EducationItemFromApi");
+  function normalizeJob5156ExtractOptions(options = {}) {
+    return {
+      pathname: typeof options.pathname === "string" ? options.pathname : window.location.pathname,
+      profileUrl: typeof options.profileUrl === "string" ? options.profileUrl : window.location.href,
+      extractedAt: typeof options.extractedAt === "string" ? options.extractedAt : (/* @__PURE__ */ new Date()).toISOString()
+    };
+  }
+  __name(normalizeJob5156ExtractOptions, "normalizeJob5156ExtractOptions");
+  function buildJob5156DetailResumeFromApiPayload(payload, options = {}) {
+    if (!payload || typeof payload !== "object") return [];
+    const { pathname, profileUrl, extractedAt } = normalizeJob5156ExtractOptions(options);
+    const resumeId = extractJob5156ResumeId(pathname) || normalizeResumeText(payload.resumeId);
+    const normalizedProfileUrl = normalizeJob5156ProfileUrlForExport(profileUrl);
+    const resumeView = payload.resumeViewVo && typeof payload.resumeViewVo === "object" ? payload.resumeViewVo : null;
+    const cnVo = resumeView?.cnVo && typeof resumeView.cnVo === "object" ? resumeView.cnVo : null;
+    const basicInfo = cnVo?.basicInfoVo && typeof cnVo.basicInfoVo === "object" ? cnVo.basicInfoVo : null;
+    const intentInfo = cnVo?.intentInfoVo && typeof cnVo.intentInfoVo === "object" ? cnVo.intentInfoVo : null;
+    if (!resumeId || !cnVo || !basicInfo) return [];
+    const workHistory = Array.isArray(cnVo.workInfoVoList) ? cnVo.workInfoVoList.map((item) => buildJob5156DetailWorkHistoryItemFromApi(item)).filter(Boolean) : [];
+    const profileEducation = Array.isArray(cnVo.educationInfoVoList) ? cnVo.educationInfoVoList.map((item) => buildJob5156EducationItemFromApi(item)).filter(Boolean) : [];
+    const locationParts = [
+      normalizeResumeText(cnVo.liveProvince),
+      normalizeResumeText(cnVo.liveCity),
+      normalizeResumeText(cnVo.liveTown)
+    ].filter(Boolean);
+    const intentionParts = Array.isArray(payload.intentInfoVo2List) ? payload.intentInfoVo2List.map((item) => normalizeResumeText(item.jobNameStr || item.jobCodeStr)).filter(Boolean) : [];
+    return [
+      {
+        resumeId,
+        perUserId: normalizeResumeText(payload.perUserId || basicInfo.id),
+        name: normalizeResumeText(payload.userName || basicInfo.userName),
+        profileUrl: normalizedProfileUrl,
+        activityStatus: normalizeResumeText(basicInfo.jobStateStr),
+        age: normalizeResumeText(basicInfo.age ? `${basicInfo.age}\u5C81` : ""),
+        experience: normalizeResumeText(
+          basicInfo.firstWorkingTimeStr || basicInfo.jobyearTypeStr
+        ),
+        education: normalizeResumeText(
+          basicInfo.degreeStr || cnVo.maxDegree?.degreeStr
+        ),
+        location: normalizeResumeText(
+          locationParts.join("") || basicInfo.locationStr
+        ),
+        jobIntention: normalizeResumeText(
+          intentionParts.join(",") || intentInfo?.jobLocationStr && `${intentInfo.jobLocationStr}${intentInfo.jobCodeStr ? `${intentInfo.jobCodeStr}` : ""}` || intentInfo?.jobCodeStr
+        ),
+        expectedSalary: normalizeResumeText(
+          payload.salaryStr || intentInfo?.salaryStr
+        ),
+        selfIntro: normalizeResumeText(intentInfo?.professionSkill),
+        workHistory,
+        profileEducation: profileEducation.length > 0 ? profileEducation : void 0,
+        extractedAt,
+        source: JOB5156_HOST
+      }
+    ];
+  }
+  __name(buildJob5156DetailResumeFromApiPayload, "buildJob5156DetailResumeFromApiPayload");
+  async function fetchJob5156ResumeDetail(profileUrl, pathname) {
+    const resumePathname = typeof pathname === "string" && pathname ? pathname : new URL(profileUrl).pathname;
+    const resumeId = extractJob5156ResumeId(resumePathname);
+    if (!resumeId) return null;
+    const url = new URL(
+      `/api/com/resume/${encodeURIComponent(resumeId)}`,
+      window.location.origin
+    );
+    url.searchParams.set("t", String(Date.now()));
+    url.searchParams.set("version", "1");
+    url.searchParams.set("dataVersions", "");
+    url.searchParams.set("modType", "search");
+    url.searchParams.set("keyWord", "");
+    url.searchParams.set("searchNo", "0");
+    url.searchParams.set("searchNumber", "0");
+    url.searchParams.set("searchPageNumber", "0");
+    url.searchParams.set("index_number", "0");
+    url.searchParams.set("isTopResume", "false");
+    url.searchParams.set("isWindow", "true");
+    url.searchParams.set("resumeId", resumeId);
+    url.searchParams.set("indexNumber", "0");
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(
+      () => controller.abort(),
+      JOB5156_DETAIL_FETCH_TIMEOUT_MS
+    );
+    try {
+      const response = await fetch(url.toString(), {
+        credentials: "include",
+        headers: {
+          Accept: "application/json",
+          appType: "pc",
+          pcVersion: "1.0.1",
+          posTypeNewFlag: "true",
+          version: "2.0"
+        },
+        signal: controller.signal
+      });
+      if (!response.ok) return null;
+      const payload = await response.json();
+      if (!payload || typeof payload !== "object" || payload.code !== 200 || !payload.data)
+        return null;
+      return payload.data;
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError")
+        return null;
+      throw error;
+    } finally {
+      window.clearTimeout(timeoutId);
+    }
+  }
+  __name(fetchJob5156ResumeDetail, "fetchJob5156ResumeDetail");
+  async function enrichSingleJob5156SearchResumeWithDetail(resume, extractedAt) {
+    if (!resume || typeof resume !== "object") return null;
+    const profileUrl = normalizeJob5156ProfileUrlForExport(
+      resume.profileUrl || ""
+    );
+    const fallbackResume = {
+      ...resume,
+      profileUrl,
+      extractedAt: resume.extractedAt || extractedAt
+    };
+    if (!profileUrl) return fallbackResume;
+    try {
+      let detailResume = null;
+      const pathname = new URL(profileUrl).pathname;
+      const detailPayload = await fetchJob5156ResumeDetail(profileUrl, pathname);
+      if (detailPayload) {
+        detailResume = buildJob5156DetailResumeFromApiPayload(detailPayload, {
+          pathname,
+          profileUrl,
+          extractedAt: fallbackResume.extractedAt
+        })[0] || null;
+      }
+      if (!detailResume) {
+        const response = await fetch(profileUrl, {
+          credentials: "include",
+          headers: { Accept: "text/html,application/xhtml+xml" }
+        });
+        if (response.ok) {
+          const html = await response.text();
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(html, "text/html");
+          detailResume = buildJob5156DetailResumeFromRoot(doc.body, {
+            pathname,
+            profileUrl,
+            extractedAt: fallbackResume.extractedAt
+          })[0] || null;
+        }
+      }
+      if (!detailResume) return fallbackResume;
+      return {
+        ...fallbackResume,
+        ...detailResume,
+        workHistory: detailResume.workHistory || fallbackResume.workHistory || [],
+        resumeId: detailResume.resumeId || fallbackResume.resumeId,
+        perUserId: detailResume.perUserId || fallbackResume.perUserId,
+        extractedAt: fallbackResume.extractedAt
+      };
+    } catch (error) {
+      console.warn(
+        "\u{1F3AF} [Auto Sync] Failed to enrich Job5156 detail resume:",
+        profileUrl,
+        error
+      );
+      return fallbackResume;
+    }
+  }
+  __name(enrichSingleJob5156SearchResumeWithDetail, "enrichSingleJob5156SearchResumeWithDetail");
+  var GUARD_FIELD_NAMES = /* @__PURE__ */ new Set([
+    "experience",
+    "jobIntention",
+    "selfIntro",
+    "expectedSalary",
+    "workHistory",
+    "profileEducation",
+    "projectExperience",
+    "skills",
+    "licences"
+  ]);
+  var GUARD_ARRAY_FIELD_NAMES = /* @__PURE__ */ new Set([
+    "workHistory",
+    "profileEducation",
+    "projectExperience",
+    "skills",
+    "licences"
+  ]);
+  async function loadCollectionGuards() {
+    return new Promise((resolve) => {
+      chrome.storage.local.get(
+        { collectionGuards: DEFAULT_COLLECTION_GUARDS },
+        (items) => resolve(items.collectionGuards || {})
+      );
+    });
+  }
+  __name(loadCollectionGuards, "loadCollectionGuards");
+  function parseGuardFieldNames(csv) {
+    if (!csv || typeof csv !== "string") return [];
+    return Array.from(
+      new Set(
+        csv.split(",").map((field) => field.trim()).filter((field) => GUARD_FIELD_NAMES.has(field))
+      )
+    );
+  }
+  __name(parseGuardFieldNames, "parseGuardFieldNames");
+  function applyCollectionGuards(resume, guardFieldNames) {
+    if (!resume || typeof resume !== "object" || !Array.isArray(guardFieldNames) || guardFieldNames.length === 0) {
+      return resume;
+    }
+    const guarded = { ...resume };
+    for (const field of guardFieldNames) {
+      guarded[field] = GUARD_ARRAY_FIELD_NAMES.has(field) ? [] : "";
+    }
+    return guarded;
+  }
+  __name(applyCollectionGuards, "applyCollectionGuards");
+  async function enrichJob5156SearchResumesWithDetail(resumes) {
+    if (!Array.isArray(resumes) || resumes.length === 0) return [];
+    const extractedAt = (/* @__PURE__ */ new Date()).toISOString();
+    const collectionGuards = await loadCollectionGuards();
+    const guardFields = parseGuardFieldNames(collectionGuards?.job5156);
+    const enriched = [];
+    for (let start = 0; start < resumes.length; start += JOB5156_DETAIL_FETCH_CONCURRENCY) {
+      const batch = resumes.slice(
+        start,
+        start + JOB5156_DETAIL_FETCH_CONCURRENCY
+      );
+      const batchResults = await Promise.all(
+        batch.map(
+          (resume) => enrichSingleJob5156SearchResumeWithDetail(resume, extractedAt)
+        )
+      );
+      enriched.push(
+        ...batchResults.filter(Boolean).map((resume) => applyCollectionGuards(resume, guardFields))
+      );
+    }
+    return enriched;
+  }
+  __name(enrichJob5156SearchResumesWithDetail, "enrichJob5156SearchResumesWithDetail");
+  function isJob51RateLimitedErrorMessage(message) {
+    const normalized = normalizeResumeText(String(message || ""));
+    return normalized.includes("\u641C\u7D22\u8BBF\u95EE\u592A\u5FEB") || normalized.includes("\u8BF760\u5206\u949F\u540E\u518D\u8BD5") || normalized.includes("\u8BBF\u95EE\u9891\u7387\u9650\u5236") || normalized.includes("\u9891\u7387\u9650\u5236") || normalized.toLowerCase().includes("rate limit");
+  }
+  __name(isJob51RateLimitedErrorMessage, "isJob51RateLimitedErrorMessage");
+  function isJob51RateLimitedPayload(payload) {
+    if (!payload) return false;
+    const candidates = [
+      payload.error,
+      payload.message,
+      payload.msg,
+      payload.detail,
+      payload.data?.error,
+      payload.data?.message,
+      payload.data?.msg,
+      payload.data?.detail
+    ];
+    return candidates.some((value) => isJob51RateLimitedErrorMessage(value));
+  }
+  __name(isJob51RateLimitedPayload, "isJob51RateLimitedPayload");
+  function isJob51DetailApiErrorPayload(payload) {
+    if (!payload || typeof payload !== "object") return false;
+    if (payload.result === "0" || payload.result === 0) return true;
+    return typeof payload.code === "string" && payload.code.length > 0 && payload.code !== "200" && payload.code !== "0" && typeof payload.msg === "string" && payload.msg.length > 0;
+  }
+  __name(isJob51DetailApiErrorPayload, "isJob51DetailApiErrorPayload");
+  async function collectJob51DetailFromBackground(resumeId) {
+    try {
+      const response = await chrome.runtime.sendMessage({
+        action: "collectJob51ResumeDetail",
+        resumeId
+      });
+      if (response?.success) {
+        return {
+          payload: response.data ?? response.payload ?? response.resume ?? null,
+          rateLimited: false
+        };
+      }
+      const errorMessage = response?.error ? String(response.error) : "";
+      return {
+        payload: null,
+        rateLimited: isJob51RateLimitedErrorMessage(errorMessage)
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error || "");
+      return {
+        payload: null,
+        rateLimited: isJob51RateLimitedErrorMessage(message)
+      };
+    }
+  }
+  __name(collectJob51DetailFromBackground, "collectJob51DetailFromBackground");
+  async function fetch51JobResumeDetail(resumeId) {
+    const normalizedResumeId = normalizeJob51Text(resumeId);
+    if (!normalizedResumeId) {
+      return { payload: null, rateLimited: false };
+    }
+    const authContext = apiSnapshot.job51AuthContext;
+    const requestBody = {
+      resume_id: normalizedResumeId,
+      resumeId: normalizedResumeId,
+      userid: normalizedResumeId,
+      lan: "c",
+      timestamp: Math.floor(Date.now() / 1e3),
+      ...authContext?.property ? { property: authContext.property } : {}
+    };
+    if (authContext?.accesstoken || authContext?.guid || authContext?.property) {
+      const headers = {
+        Accept: "application/json, text/plain, */*",
+        "Content-Type": "application/json",
+        ...authContext.accesstoken ? { accesstoken: authContext.accesstoken } : {},
+        ...authContext.guid ? { guid: authContext.guid } : {},
+        ...authContext.property ? { property: authContext.property } : {}
+      };
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(
+        () => controller.abort(),
+        JOB51_DETAIL_FETCH_TIMEOUT_MS
+      );
+      try {
+        const response = await fetch(
+          "https://ehirej.51job.com/resumedtl/getresume",
+          {
+            method: "POST",
+            credentials: "include",
+            headers,
+            body: JSON.stringify(requestBody),
+            signal: controller.signal
+          }
+        );
+        if (response.status === 403) {
+          return { payload: null, rateLimited: true };
+        }
+        if (response.ok) {
+          const payload = await response.json().catch(() => null);
+          if (isJob51RateLimitedPayload(payload)) {
+            return { payload: null, rateLimited: true };
+          }
+          if (isJob51DetailApiErrorPayload(payload)) {
+            console.warn(
+              "\u{1F3AF} [Auto Sync] Job51 detail API error, falling back to background:",
+              normalizedResumeId,
+              payload?.code,
+              payload?.msg
+            );
+          } else if (payload) {
+            return { payload, rateLimited: false };
+          }
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error || "");
+        if (isJob51RateLimitedErrorMessage(message)) {
+          return { payload: null, rateLimited: true };
+        }
+        if (error instanceof DOMException && error.name === "AbortError") {
+          console.warn(
+            "\u{1F3AF} [Auto Sync] Direct Job51 detail fetch timed out:",
+            normalizedResumeId
+          );
+        } else {
+          console.warn(
+            "\u{1F3AF} [Auto Sync] Direct Job51 detail fetch failed:",
+            normalizedResumeId,
+            error
+          );
+        }
+      } finally {
+        window.clearTimeout(timeoutId);
+      }
+    }
+    return collectJob51DetailFromBackground(normalizedResumeId);
+  }
+  __name(fetch51JobResumeDetail, "fetch51JobResumeDetail");
+  async function enrich51JobSearchResumeWithDetail(resume, extractedAt) {
+    if (!resume || typeof resume !== "object") {
+      return {
+        resume: null,
+        enriched: false,
+        rateLimited: false
+      };
+    }
+    const fallbackResume = {
+      ...resume,
+      extractedAt: resume.extractedAt || extractedAt
+    };
+    const resumeId = normalizeJob51Text(resume.resumeId) || normalizeJob51Text(resume.perUserId) || "";
+    if (!resumeId) {
+      return {
+        resume: fallbackResume,
+        enriched: false,
+        rateLimited: false
+      };
+    }
+    try {
+      const detailResult = await fetch51JobResumeDetail(resumeId);
+      if (!detailResult?.payload) {
+        return {
+          resume: fallbackResume,
+          enriched: false,
+          rateLimited: !!detailResult?.rateLimited
+        };
+      }
+      const detailResume = buildJob51DetailResumeFromPayload(detailResult.payload, {
+        resumeId,
+        profileUrl: fallbackResume.profileUrl || ""
+      })[0] || null;
+      if (!detailResume) {
+        return {
+          resume: fallbackResume,
+          enriched: false,
+          rateLimited: !!detailResult.rateLimited
+        };
+      }
+      return {
+        resume: {
+          ...fallbackResume,
+          ...detailResume,
+          name: detailResume.name || fallbackResume.name || "",
+          age: detailResume.age || fallbackResume.age || "",
+          experience: detailResume.experience || fallbackResume.experience || "",
+          education: detailResume.education || fallbackResume.education || "",
+          location: detailResume.location || fallbackResume.location || "",
+          jobIntention: detailResume.jobIntention || fallbackResume.jobIntention || "",
+          expectedSalary: detailResume.expectedSalary || fallbackResume.expectedSalary || "",
+          activityStatus: detailResume.activityStatus || fallbackResume.activityStatus || "",
+          selfIntro: detailResume.selfIntro || fallbackResume.selfIntro || "",
+          resumeId: detailResume.resumeId || fallbackResume.resumeId,
+          perUserId: detailResume.perUserId || fallbackResume.perUserId,
+          externalId: detailResume.externalId || fallbackResume.externalId,
+          profileUrl: detailResume.profileUrl || fallbackResume.profileUrl,
+          extractedAt: fallbackResume.extractedAt,
+          pageIndex: fallbackResume.pageIndex,
+          pageNumber: fallbackResume.pageNumber,
+          workHistory: Array.isArray(detailResume.workHistory) && detailResume.workHistory.length > 0 ? detailResume.workHistory : Array.isArray(fallbackResume.workHistory) ? fallbackResume.workHistory : [],
+          projectExperience: Array.isArray(detailResume.projectExperience) && detailResume.projectExperience.length > 0 ? detailResume.projectExperience : Array.isArray(fallbackResume.projectExperience) ? fallbackResume.projectExperience : [],
+          profileEducation: Array.isArray(detailResume.profileEducation) && detailResume.profileEducation.length > 0 ? detailResume.profileEducation : Array.isArray(fallbackResume.profileEducation) ? fallbackResume.profileEducation : [],
+          skills: Array.isArray(detailResume.skills) && detailResume.skills.length > 0 ? detailResume.skills : Array.isArray(fallbackResume.skills) ? fallbackResume.skills : [],
+          licences: Array.isArray(detailResume.licences) && detailResume.licences.length > 0 ? detailResume.licences : Array.isArray(fallbackResume.licences) ? fallbackResume.licences : []
+        },
+        enriched: true,
+        rateLimited: !!detailResult.rateLimited
+      };
+    } catch (error) {
+      console.warn(
+        "\u{1F3AF} [Auto Sync] Failed to enrich Job51 detail resume:",
+        resumeId,
+        error
+      );
+      return {
+        resume: fallbackResume,
+        enriched: false,
+        rateLimited: false
+      };
+    }
+  }
+  __name(enrich51JobSearchResumeWithDetail, "enrich51JobSearchResumeWithDetail");
+  async function enrich51JobSearchResumesWithDetail(resumes, options = {}) {
+    if (!Array.isArray(resumes) || resumes.length === 0) return [];
+    const extractedAt = (/* @__PURE__ */ new Date()).toISOString();
+    const interBatchDelayMs = typeof options.interBatchDelayMs === "number" && Number.isFinite(options.interBatchDelayMs) ? options.interBatchDelayMs : resolveCurrentJob51DetailFetchDelayMs();
+    const collectionGuards = await loadCollectionGuards();
+    const guardFields = parseGuardFieldNames(
+      collectionGuards?.[SOURCE_KEYS.JOB51]
+    );
+    const shouldContinue = typeof options.shouldContinue === "function" ? options.shouldContinue : () => true;
+    const enriched = [];
+    let enrichedCount = 0;
+    let rateLimited = false;
+    for (let start = 0; start < resumes.length; start += JOB51_DETAIL_FETCH_CONCURRENCY) {
+      if (!shouldContinue() || rateLimited) {
+        break;
+      }
+      const batch = resumes.slice(
+        start,
+        start + JOB51_DETAIL_FETCH_CONCURRENCY
+      );
+      const batchResults = await Promise.all(
+        batch.map(
+          (resume) => enrich51JobSearchResumeWithDetail(resume, extractedAt)
+        )
+      );
+      for (const result of batchResults) {
+        if (result?.resume) {
+          enriched.push(applyCollectionGuards(result.resume, guardFields));
+        }
+        if (result?.enriched) {
+          enrichedCount += 1;
+        }
+        if (result?.rateLimited) {
+          rateLimited = true;
+        }
+      }
+      console.log(
+        `51job detail enrichment: ${Math.min(start + batch.length, resumes.length)}/${resumes.length} (${enrichedCount} enriched)`
+      );
+      if (rateLimited || !shouldContinue()) {
+        break;
+      }
+      if (start + JOB51_DETAIL_FETCH_CONCURRENCY < resumes.length) {
+        await delay(interBatchDelayMs);
+      }
+    }
+    return enriched;
+  }
+  __name(enrich51JobSearchResumesWithDetail, "enrich51JobSearchResumesWithDetail");
+  function extractSeekProfileResume() {
+    const profile = apiSnapshot.seekProfile;
+    if (!profile || typeof profile !== "object") return [];
+    const request = getSeekProfileRequest();
+    const requestInput = request?.variables?.input;
+    const language = request?.variables?.language;
+    const profileUrl = new URL(window.location.href);
+    const jobIdFromUrl = normalizeOptionalPositiveInt(
+      profileUrl.searchParams.get("jobId")
+    );
+    const jobId = requestInput?.jobId != null ? String(requestInput.jobId) : jobIdFromUrl != null ? String(jobIdFromUrl) : void 0;
+    const { profileId, profileType } = getSeekCandidateIdentity(profile);
+    const firstName = typeof profile.firstName === "string" ? profile.firstName.trim() : "";
+    const lastName = typeof profile.lastName === "string" ? profile.lastName.trim() : "";
+    const currentJobTitle = typeof profile.currentJobTitle === "string" ? profile.currentJobTitle.trim() : "";
+    const currentLocation = typeof profile.currentLocation === "string" ? profile.currentLocation.trim() : "";
+    const lastModifiedDate = typeof profile.lastModifiedDate === "string" ? profile.lastModifiedDate : "";
+    const workHistory = Array.isArray(profile.workHistories) ? profile.workHistories.map((item) => buildSeekWorkHistoryItem(item)).filter(Boolean) : [];
+    const profileEducation = Array.isArray(profile.profileEducation) ? profile.profileEducation.map((item) => buildSeekProfileEducationItem(item)).filter(Boolean) : [];
+    const licences = Array.isArray(profile.licences) ? profile.licences.map((item) => {
+      if (!item || typeof item !== "object") return null;
+      const name = typeof item.name === "string" ? item.name.trim() : "";
+      const authority = typeof item.issuingOrganisationName === "string" ? item.issuingOrganisationName.trim() : "";
+      if (!name && !authority) return null;
+      return {
+        name,
+        authority: authority || void 0
+      };
+    }).filter(Boolean) : [];
+    const skills = Array.isArray(profile.skills) ? profile.skills.filter((item) => typeof item === "string" && item.trim()) : [];
+    const languages = Array.isArray(profile.languages) ? profile.languages.filter(
+      (item) => typeof item === "string" && item.trim()
+    ) : [];
+    const resumeSnippet = typeof profile.resumeSnippet === "string" ? profile.resumeSnippet.trim() : "";
+    const currentIndustry = typeof profile.currentIndustry === "string" ? profile.currentIndustry.trim() : "";
+    const currentSubindustry = typeof profile.currentSubindustry === "string" ? profile.currentSubindustry.trim() : "";
+    const rightToWork = typeof profile.rightToWork?.label === "string" ? profile.rightToWork.label.trim() : "";
+    const education = profileEducation[0]?.qualification || "";
+    const pageNumber = normalizeOptionalPositiveInt(profileUrl.searchParams.get("pageNumber")) || 1;
+    return [
+      {
+        profileId,
+        profileType,
+        externalId: profileId ? `${window.location.hostname.toLowerCase()}:profile:${profileId}` : "",
+        name: [firstName, lastName].filter(Boolean).join(" ").trim(),
+        profileUrl: buildSeekProfileUrl(profileId, jobId),
+        activityStatus: lastModifiedDate,
+        age: "",
+        experience: "",
+        education,
+        location: currentLocation,
+        jobIntention: currentJobTitle,
+        expectedSalary: formatSeekExpectedSalary(profile.salary?.expected),
+        selfIntro: resumeSnippet,
+        workHistory,
+        profileEducation: profileEducation.length > 0 ? profileEducation : void 0,
+        skills: skills.length > 0 ? skills : void 0,
+        languages: languages.length > 0 ? languages : void 0,
+        licences: licences.length > 0 ? licences : void 0,
+        resumeSnippet: resumeSnippet || void 0,
+        currentIndustry: currentIndustry || void 0,
+        currentSubindustry: currentSubindustry || void 0,
+        rightToWork: rightToWork || void 0,
+        noticePeriodDays: Number.isFinite(profile.noticePeriodDays) ? profile.noticePeriodDays : void 0,
+        extractedAt: (/* @__PURE__ */ new Date()).toISOString(),
+        pageIndex: 1,
+        source: window.location.hostname.toLowerCase(),
+        searchProfileId: typeof requestInput?.searchId === "string" ? requestInput.searchId : "",
+        language: typeof language === "string" ? language : "",
+        pageNumber
+      }
+    ];
+  }
+  __name(extractSeekProfileResume, "extractSeekProfileResume");
+  function buildSeekCollectionContext(options = {}) {
+    const normalizedOptions = typeof options === "object" && options ? options : {};
+    const captureModeOverride = normalizedOptions.captureModeOverride;
+    const useProfileMode = captureModeOverride ? captureModeOverride === "graphql-profile" : isSeekProfileMode();
+    const request = useProfileMode ? getSeekProfileRequest() : getSeekRecommendedRequest();
+    const requestInput = request?.variables?.input;
+    const language = request?.variables?.language;
+    const url = new URL(window.location.href);
+    const pageNumberFromUrl = normalizeOptionalPositiveInt(
+      url.searchParams.get("pageNumber")
+    );
+    const jobIdFromUrl = normalizeOptionalPositiveInt(
+      url.searchParams.get("jobId")
+    );
+    const captureMode = captureModeOverride || (useProfileMode && apiSnapshot.seekProfile ? "graphql-profile" : "graphql-list");
+    const defaultOperation = captureMode === "graphql-profile" ? "GetTalentSearchProfileCompleteV2" : "GetTalentSearchRecommendedCandidates";
+    return {
+      captureMode,
+      operation: apiSnapshot.lastOperationName || defaultOperation,
+      jobId: requestInput?.jobId != null ? String(requestInput.jobId) : jobIdFromUrl != null ? String(jobIdFromUrl) : void 0,
+      searchId: typeof requestInput?.searchId === "string" ? requestInput.searchId : void 0,
+      pageNumber: typeof requestInput?.page === "number" ? requestInput.page : pageNumberFromUrl ?? void 0,
+      language: typeof language === "string" ? language : void 0,
+      profileType: SEEK_PROFILE_TYPE
+    };
+  }
+  __name(buildSeekCollectionContext, "buildSeekCollectionContext");
+  function getExtensionGeneratedBy() {
+    let generatedBy = "browser-extension";
+    try {
+      const version = chrome?.runtime?.getManifest?.().version;
+      if (version) generatedBy = `browser-extension@${version}`;
+    } catch {
+    }
+    return generatedBy;
+  }
+  __name(getExtensionGeneratedBy, "getExtensionGeneratedBy");
+  function buildSubmitMetadata(options = {}) {
+    const url = new URL(window.location.href);
+    const sourceKey = getCurrentSourceKey();
+    const keyword = normalizeKeyword(
+      url.searchParams.get(AUTO_SEARCH_PARAM) || ""
+    );
+    const location = getAutoLocationValues(url).join(",");
+    url.searchParams.delete(AUTO_EXPORT_PARAM);
+    url.searchParams.delete(AUTO_SYNC_PARAM);
+    url.searchParams.delete(AUTO_LIMIT_PARAM);
+    url.searchParams.delete(AUTO_MAX_PAGES_PARAM);
+    url.searchParams.delete(SAMPLE_NAME_PARAM);
+    const metadata = {
+      sourceKey,
+      sourceHost: url.hostname.toLowerCase(),
+      sourceUrl: url.toString(),
+      generatedBy: getExtensionGeneratedBy()
+    };
+    if (keyword) metadata.keyword = keyword;
+    if (location) metadata.location = location;
+    if (sourceKey === SOURCE_KEYS.SEEK) {
+      metadata.collectionContext = buildSeekCollectionContext({
+        captureModeOverride: options.seekCaptureMode
+      });
+    }
+    return metadata;
+  }
+  __name(buildSubmitMetadata, "buildSubmitMetadata");
+  function getApiRowForIndex(index) {
+    if (!Array.isArray(apiSnapshot.searchRows)) return null;
+    return apiSnapshot.searchRows[index] || null;
+  }
+  __name(getApiRowForIndex, "getApiRowForIndex");
+  function isPlaceholderProfileUrl(value) {
+    if (!value) return true;
+    const normalized = String(value).trim().toLowerCase();
+    return normalized === "" || normalized === "#" || normalized.startsWith("javascript:") || normalized === "about:blank";
+  }
+  __name(isPlaceholderProfileUrl, "isPlaceholderProfileUrl");
+  function toAbsoluteHttpUrl(value) {
+    if (!value || typeof value !== "string") return "";
+    try {
+      const url = new URL(value, window.location.origin);
+      if (url.protocol !== "http:" && url.protocol !== "https:") return "";
+      if (isPlaceholderProfileUrl(url.href)) return "";
+      return url.href;
+    } catch {
+      return "";
+    }
+  }
+  __name(toAbsoluteHttpUrl, "toAbsoluteHttpUrl");
+  function decodeURIComponentSafe(value) {
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  }
+  __name(decodeURIComponentSafe, "decodeURIComponentSafe");
+  function extractJob5156ResumeId(pathname) {
+    if (!pathname || typeof pathname !== "string") return "";
+    const oldRouteMatch = pathname.match(/^\/api\/com\/resume\/([^/?#]+)/i);
+    if (oldRouteMatch && oldRouteMatch[1]) {
+      return decodeURIComponentSafe(oldRouteMatch[1]);
+    }
+    const viewRouteMatch = pathname.match(/^\/resume\/view\/([^/?#]+)/i);
+    if (viewRouteMatch && viewRouteMatch[1]) {
+      return decodeURIComponentSafe(viewRouteMatch[1]);
+    }
+    return "";
+  }
+  __name(extractJob5156ResumeId, "extractJob5156ResumeId");
+  function normalizeJob5156ProfileUrlForExport(value) {
+    if (!value || typeof value !== "string") return "";
+    const trimmed = value.trim();
+    if (!trimmed) return "";
+    const directResumeId = extractJob5156ResumeId(trimmed);
+    if (directResumeId) {
+      return `${JOB5156_PROFILE_URL_PREFIX}${encodeURIComponent(directResumeId)}`;
+    }
+    try {
+      const parsed = new URL(trimmed, window.location.origin);
+      if (parsed.hostname.toLowerCase() !== JOB5156_HOST) {
+        return parsed.href;
+      }
+      const resumeId = extractJob5156ResumeId(parsed.pathname);
+      if (!resumeId) {
+        return parsed.href;
+      }
+      return `${JOB5156_PROFILE_URL_PREFIX}${encodeURIComponent(resumeId)}`;
+    } catch {
+      return trimmed;
+    }
+  }
+  __name(normalizeJob5156ProfileUrlForExport, "normalizeJob5156ProfileUrlForExport");
+  function buildProfileUrlFromApiRow(apiRow) {
+    if (!apiRow || typeof apiRow !== "object") return "";
+    const resumeId = apiRow.resumeId;
+    if (resumeId === null || resumeId === void 0 || resumeId === "") return "";
+    const encodedId = encodeURIComponent(String(resumeId));
+    return `${JOB5156_PROFILE_URL_PREFIX}${encodedId}`;
+  }
+  __name(buildProfileUrlFromApiRow, "buildProfileUrlFromApiRow");
+  function getSeekPayloadData(payload, kind) {
+    if (!payload) return null;
+    if (Array.isArray(payload)) {
+      const entry = payload.find((item) => {
+        const data = item?.data;
+        if (!data || typeof data !== "object") return false;
+        if (kind === "seekRecommendedCandidates") {
+          return !!(data.talentSearchRecommendedCandidatesV2 || data.getTalentSearchRecommendedCandidates);
+        }
+        if (kind === "seekTalentSearch") {
+          return !!data.talentSearchProfilesNaturalLanguageSearch;
+        }
+        if (kind === "seekProfile") {
+          return !!(data.talentSearchProfileV2 || data.talentSearchProfileCompleteV2 || data.getTalentSearchProfileCompleteV2 || data.talentSearchProfileV3);
+        }
+        return false;
+      });
+      return entry?.data || null;
+    }
+    if (payload && typeof payload === "object") {
+      return payload.data && typeof payload.data === "object" ? payload.data : payload;
+    }
+    return null;
+  }
+  __name(getSeekPayloadData, "getSeekPayloadData");
+  function extractProfileUrl(card, apiRow) {
+    const nameLink = card.querySelector(SELECTORS.name);
+    if (!nameLink) return buildProfileUrlFromApiRow(apiRow);
+    const candidates = [
+      nameLink.getAttribute("href"),
+      nameLink.getAttribute("data-href"),
+      nameLink.getAttribute("data-url"),
+      nameLink.getAttribute("data-link"),
+      nameLink.href
+    ];
+    for (const candidate of candidates) {
+      const normalized = toAbsoluteHttpUrl(candidate);
+      if (normalized) return normalizeJob5156ProfileUrlForExport(normalized);
+    }
+    return buildProfileUrlFromApiRow(apiRow);
+  }
+  __name(extractProfileUrl, "extractProfileUrl");
+  function updateApiSnapshot(message) {
+    const {
+      kind,
+      payload,
+      url,
+      sourceKey,
+      operationName,
+      request,
+      requestHeaders
+    } = message;
+    apiSnapshot.lastUpdatedAt = (/* @__PURE__ */ new Date()).toISOString();
+    if (url) apiSnapshot.lastUrl = url;
+    apiSnapshot.lastSourceKey = sourceKey || null;
+    apiSnapshot.lastOperationName = operationName || null;
+    try {
+      document.documentElement.setAttribute("data-tr-api-last", kind);
+      document.documentElement.setAttribute(
+        "data-tr-api-updated",
+        apiSnapshot.lastUpdatedAt
+      );
+      if (sourceKey) {
+        document.documentElement.setAttribute("data-tr-source-key", sourceKey);
+      }
+    } catch {
+    }
+    if (kind === "search") {
+      const rows = payload?.data?.resumePage?.rows;
+      if (Array.isArray(rows)) {
+        apiSnapshot.searchRows = rows;
+        apiSnapshot.lastSearchAt = apiSnapshot.lastUpdatedAt;
+        try {
+          document.documentElement.setAttribute(
+            "data-tr-api-rows",
+            String(getApiSnapshotCount())
+          );
+        } catch {
+        }
+      }
+      return;
+    }
+    if (kind === "job51search") {
+      apiSnapshot.job51LastSearchRequest = request && typeof request === "object" ? request : null;
+      const authContext = normalizeJob51AuthContext(requestHeaders, request);
+      if (authContext) {
+        apiSnapshot.job51AuthContext = {
+          ...apiSnapshot.job51AuthContext || {},
+          ...authContext
+        };
+      }
+      const total = getJob51TotalFromPayload(payload);
+      if (typeof total === "number") {
+        apiSnapshot.job51Total = total;
+      }
+      const rows = getJob51ResumeRows(payload);
+      const hasResultPayload = Array.isArray(rows) || typeof total === "number";
+      if (hasResultPayload) {
+        apiSnapshot.job51SearchRows = Array.isArray(rows) ? rows : [];
+        apiSnapshot.lastSearchAt = apiSnapshot.lastUpdatedAt;
+        try {
+          document.documentElement.setAttribute(
+            "data-tr-api-rows",
+            String(getApiSnapshotCount())
+          );
+        } catch {
+        }
+      }
+      return;
+    }
+    if (kind === "job51detail") {
+      const authContext = normalizeJob51AuthContext(requestHeaders, request);
+      if (authContext) {
+        apiSnapshot.job51AuthContext = {
+          ...apiSnapshot.job51AuthContext || {},
+          ...authContext
+        };
+      }
+      apiSnapshot.job51DetailPayload = payload || null;
+      try {
+        document.documentElement.setAttribute(
+          "data-tr-api-rows",
+          String(getApiSnapshotCount())
+        );
+      } catch {
+      }
+      return;
+    }
+    if (kind === "attach") {
+      apiSnapshot.attachInfo = payload?.data?.attachResumeInfo || null;
+      return;
+    }
+    if (kind === "chat") {
+      apiSnapshot.chatInfo = payload?.data?.chatInfo || null;
+      return;
+    }
+    if (kind === "insight") {
+      apiSnapshot.insightInfo = payload?.data?.talentInsightInfo || payload?.data || null;
+      return;
+    }
+    if (kind === "seekTalentSearch") {
+      const data = getSeekPayloadData(payload, kind);
+      const result = data?.talentSearchProfilesNaturalLanguageSearch?.result;
+      const edges = Array.isArray(result?.edges) ? result.edges : null;
+      if (edges) {
+        const nodes = edges.map((edge) => edge?.node).filter((node) => node && typeof node === "object");
+        apiSnapshot.seekTalentSearch = nodes;
+        apiSnapshot.seekTalentSearchRequest = request || null;
+        apiSnapshot.lastSearchAt = apiSnapshot.lastUpdatedAt;
+        try {
+          document.documentElement.setAttribute(
+            "data-tr-api-rows",
+            String(getApiSnapshotCount())
+          );
+        } catch {
+        }
+      }
+      return;
+    }
+    if (kind === "seekRecommendedCandidates") {
+      const data = getSeekPayloadData(payload, kind);
+      const candidates = data?.talentSearchRecommendedCandidatesV2?.items || data?.getTalentSearchRecommendedCandidates?.candidates;
+      if (Array.isArray(candidates)) {
+        apiSnapshot.seekRecommendedCandidates = candidates;
+        apiSnapshot.seekRecommendedRequest = request || null;
+        apiSnapshot.lastSearchAt = apiSnapshot.lastUpdatedAt;
+        try {
+          document.documentElement.setAttribute(
+            "data-tr-api-rows",
+            String(getApiSnapshotCount())
+          );
+        } catch {
+        }
+      }
+      return;
+    }
+    if (kind === "seekProfile") {
+      const data = getSeekPayloadData(payload, kind);
+      apiSnapshot.seekProfile = data?.talentSearchProfileV2 || data?.talentSearchProfileCompleteV2 || data?.getTalentSearchProfileCompleteV2 || data?.talentSearchProfileV3 || data || null;
+      apiSnapshot.seekProfileRequest = request || apiSnapshot.seekProfileRequest || apiSnapshot.seekRecommendedRequest || null;
+      try {
+        document.documentElement.setAttribute(
+          "data-tr-api-rows",
+          String(getApiSnapshotCount())
+        );
+      } catch {
+      }
+      return;
+    }
+  }
+  __name(updateApiSnapshot, "updateApiSnapshot");
+  function installApiHook() {
+    try {
+      if (document.documentElement.hasAttribute("data-tr-page-hook")) {
+        document.documentElement.setAttribute("data-tr-resume-hook", "true");
+        return;
+      }
+      if (document.documentElement.hasAttribute("data-tr-resume-hook")) return;
+      const script = document.createElement("script");
+      script.src = chrome.runtime.getURL("page-hook.js");
+      script.async = false;
+      script.setAttribute("data-tr-resume-hook", "true");
+      script.onload = () => script.remove();
+      const mountTarget = document.head || document.documentElement;
+      mountTarget.prepend(script);
+      document.documentElement.setAttribute("data-tr-resume-hook", "true");
+    } catch (error) {
+      console.warn("Failed to install API hook:", error);
+    }
+  }
+  __name(installApiHook, "installApiHook");
+  function installReloadHelper() {
+    try {
+      if (globalThis.trReloadExtension) return;
+      globalThis.trReloadExtension = async () => {
+        try {
+          const response = await chrome.runtime.sendMessage({
+            action: "reloadExtension"
+          });
+          console.log("\u{1F3AF} [DEV] Reload requested", response);
+        } catch (error) {
+          console.warn("\u{1F3AF} [DEV] Reload failed:", error);
+        }
+      };
+      console.log(
+        '\u{1F3AF} [DEV] Use trReloadExtension() in the DevTools "Content scripts" context to reload the extension'
+      );
+    } catch (error) {
+      console.warn("\u{1F3AF} [DEV] Failed to install reload helper:", error);
+    }
+  }
+  __name(installReloadHelper, "installReloadHelper");
+  window.addEventListener("message", (event) => {
+    if (event.source !== window) return;
+    const msg = event.data;
+    if (!msg || msg.source !== API_CAPTURE_SOURCE) return;
+    updateApiSnapshot(msg);
+  });
+  window.addEventListener(PAGE_BRIDGE_REQUEST_EVENT, async () => {
+    const requestPayload = document.documentElement.getAttribute(
+      PAGE_BRIDGE_REQUEST_ATTR
+    );
+    if (!requestPayload) return;
+    let response = {
+      id: null,
+      ok: false,
+      error: "Invalid bridge request",
+      value: void 0
+    };
+    try {
+      const request = JSON.parse(requestPayload);
+      const requestId = request?.id ?? null;
+      const method = typeof request?.method === "string" ? request.method : "";
+      const args = Array.isArray(request?.args) ? request.args : [];
+      response.id = requestId;
+      switch (method) {
+        case "extract":
+          response = {
+            id: requestId,
+            ok: true,
+            error: "",
+            value: extractResumes()
+          };
+          break;
+        case "extractRaw":
+          response = {
+            id: requestId,
+            ok: true,
+            error: "",
+            value: extractResumesRaw(args[0])
+          };
+          break;
+        case "collect":
+          response = {
+            id: requestId,
+            ok: true,
+            error: "",
+            value: await collectSnapshotPayload(args[0])
+          };
+          break;
+        case "getApiSnapshot":
+          response = { id: requestId, ok: true, error: "", value: apiSnapshot };
+          break;
+        case "getPaginationInfo":
+          response = {
+            id: requestId,
+            ok: true,
+            error: "",
+            value: getPaginationInfo()
+          };
+          break;
+        case "isReady":
+          response = {
+            id: requestId,
+            ok: true,
+            error: "",
+            value: isExtractionReady()
+          };
+          break;
+        case "isLoggedIn":
+          response = { id: requestId, ok: true, error: "", value: isLoggedIn() };
+          break;
+        case "status":
+          response = {
+            id: requestId,
+            ok: true,
+            error: "",
+            value: window[EXTERNAL_ACCESS_KEY]?.status?.()
+          };
+          break;
+        case "syncToServer":
+          response = {
+            id: requestId,
+            ok: true,
+            error: "",
+            value: await syncCurrentPageToServer(args[0])
+          };
+          break;
+        case "goToNextPage":
+          response = {
+            id: requestId,
+            ok: true,
+            error: "",
+            value: goToNextPageInternal()
+          };
+          break;
+        default:
+          response = {
+            id: requestId,
+            ok: false,
+            error: method ? `Unsupported bridge method: ${method}` : "Missing bridge method",
+            value: void 0
+          };
+          break;
+      }
+    } catch (error) {
+      response = {
+        ...response,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+    document.documentElement.setAttribute(
+      PAGE_BRIDGE_RESPONSE_ATTR,
+      JSON.stringify(response)
+    );
+    window.dispatchEvent(new CustomEvent(PAGE_BRIDGE_RESPONSE_EVENT));
+  });
+  function extractSingleResume(card, apiRow = null) {
+    const getText = /* @__PURE__ */ __name((selector, root = card) => {
+      const el = root.querySelector(selector);
+      return el ? el.textContent.trim() : "";
+    }, "getText");
+    const pickText = /* @__PURE__ */ __name((selectors) => {
+      for (const selector of selectors) {
+        const text = getText(selector);
+        if (text) return text;
+      }
+      return "";
+    }, "pickText");
+    const basicInfoContainer = card.querySelector(SELECTORS.basicInfoRow) || card.querySelector(".list-content__li__down-left-center");
+    const locationFromCard = getText(SELECTORS.locationItem, basicInfoContainer || card) || getText(SELECTORS.locationFallbackItem, basicInfoContainer || card);
+    const basicInfoSpans = basicInfoContainer ? basicInfoContainer.querySelectorAll(
+      `${SELECTORS.basicInfoItem}, div:nth-child(2) span, .basic-line span`
+    ) : [];
+    const basicInfo = Array.from(basicInfoSpans).map(
+      (span) => span.textContent || ""
+    );
+    const { age, experience, education, location } = parseJob5156BasicInfoItems(
+      basicInfo,
+      locationFromCard
+    );
+    const topRow = card.querySelector(SELECTORS.topRowText) || card.querySelector(SELECTORS.topRow);
+    const topRowText = topRow ? topRow.textContent.trim().replace(/\s+/g, " ") : "";
+    const topRowClean = topRowText.split("\u4EBA\u624D\u6D1E\u5BDF")[0].replace(/·\s*$/, "").trim();
+    let expectedSalary = "";
+    const salaryMatch = topRowClean.match(
+      /(\d[\d-]*\s*元\/月|\d[\d-]*\s*元|面议)/
+    );
+    if (salaryMatch) expectedSalary = salaryMatch[0].replace(/\s+/g, "");
+    let jobIntention = topRowClean.replace(/^求职意向[:：]?\s*/, "");
+    jobIntention = jobIntention.replace(/（通勤距离[^）]*）/g, "").trim();
+    if (expectedSalary) {
+      jobIntention = jobIntention.replace(expectedSalary, "").replace(/[·\s]+$/g, "").trim();
+    }
+    const selfIntro = pickText([
+      SELECTORS.selfIntro,
+      ".basic-keywords",
+      ".basic-keywords span"
+    ]);
+    const workHistoryContainer = card.querySelector(SELECTORS.workHistory) || card.querySelector(".list-content__li__down-right-center");
+    let workItems = [];
+    let educationItems = [];
+    if (workHistoryContainer) {
+      const primary = workHistoryContainer.querySelectorAll(SELECTORS.workItem);
+      if (primary.length > 0) {
+        workItems = Array.from(primary);
+        educationItems = Array.from(
+          workHistoryContainer.querySelectorAll(".school-item")
+        );
+      } else {
+        workItems = Array.from(
+          workHistoryContainer.querySelectorAll('div[class*="history"]')
+        );
+      }
+    }
+    const seenWorkHistory = /* @__PURE__ */ new Set();
+    const workHistory = workItems.map((item) => buildJob5156WorkHistoryItem(item)).filter((item) => item && item.raw.length > 5).filter((item) => {
+      if (!item || seenWorkHistory.has(item.raw)) return false;
+      seenWorkHistory.add(item.raw);
+      return true;
+    });
+    const seenEducation = /* @__PURE__ */ new Set();
+    const profileEducation = educationItems.map((item) => buildJob5156EducationItem(item)).filter(
+      (item) => item && [item.institution, item.qualification, item.endDate].some(Boolean)
+    ).filter((item) => {
+      const signature = [
+        item.institution || "",
+        item.qualification || "",
+        item.endDate || ""
+      ].join("|");
+      if (seenEducation.has(signature)) return false;
+      seenEducation.add(signature);
+      return true;
+    });
+    return {
+      name: getText(SELECTORS.name),
+      profileUrl: extractProfileUrl(card, apiRow),
+      activityStatus: getText(SELECTORS.activityStatus),
+      age,
+      experience,
+      education,
+      location,
+      jobIntention,
+      expectedSalary,
+      selfIntro,
+      workHistory,
+      profileEducation: profileEducation.length > 0 ? profileEducation : void 0,
+      extractedAt: (/* @__PURE__ */ new Date()).toISOString(),
+      source: JOB5156_HOST
+    };
+  }
+  __name(extractSingleResume, "extractSingleResume");
+  function extractSeekResumes() {
+    const candidates = Array.isArray(apiSnapshot.seekRecommendedCandidates) ? apiSnapshot.seekRecommendedCandidates : [];
+    const request = getSeekRecommendedRequest();
+    const requestInput = request?.variables?.input;
+    const language = request?.variables?.language;
+    const url = new URL(window.location.href);
+    const jobIdFromUrl = normalizeOptionalPositiveInt(
+      url.searchParams.get("jobId")
+    );
+    const jobId = requestInput?.jobId != null ? String(requestInput.jobId) : jobIdFromUrl != null ? String(jobIdFromUrl) : void 0;
+    const currentPage = typeof requestInput?.page === "number" ? requestInput.page : normalizeOptionalPositiveInt(url.searchParams.get("pageNumber")) || 1;
+    return candidates.map((candidate, index) => {
+      const { profileId, profileType } = getSeekCandidateIdentity(candidate);
+      const firstName = typeof candidate?.firstName === "string" ? candidate.firstName.trim() : "";
+      const lastName = typeof candidate?.lastName === "string" ? candidate.lastName.trim() : "";
+      const currentJobTitle = typeof candidate?.currentJobTitle === "string" ? candidate.currentJobTitle.trim() : "";
+      const currentLocation = typeof candidate?.currentLocation === "string" ? candidate.currentLocation.trim() : "";
+      const lastModifiedDate = typeof candidate?.lastModifiedDate === "string" ? candidate.lastModifiedDate : "";
+      const salary = candidate?.salary;
+      const salaryParts = [salary?.minLabel, salary?.maxLabel].filter(
+        (value) => typeof value === "string" && value.trim()
+      );
+      const workHistory = Array.isArray(candidate?.workHistories) ? candidate.workHistories.map((item) => buildSeekWorkHistoryItem(item)).filter(Boolean) : [];
+      return {
+        profileId,
+        profileType,
+        externalId: profileId ? `${window.location.hostname.toLowerCase()}:profile:${profileId}` : "",
+        name: [firstName, lastName].filter(Boolean).join(" ").trim(),
+        profileUrl: buildSeekProfileUrl(profileId, jobId),
+        activityStatus: lastModifiedDate,
+        age: "",
+        experience: "",
+        education: "",
+        location: currentLocation,
+        jobIntention: currentJobTitle,
+        expectedSalary: salaryParts.join(" - "),
+        selfIntro: "",
+        workHistory,
+        extractedAt: (/* @__PURE__ */ new Date()).toISOString(),
+        pageIndex: index + 1,
+        source: window.location.hostname.toLowerCase(),
+        searchProfileId: typeof requestInput?.searchId === "string" ? requestInput.searchId : "",
+        language: typeof language === "string" ? language : "",
+        pageNumber: currentPage
+      };
+    });
+  }
+  __name(extractSeekResumes, "extractSeekResumes");
+  function extract51JobResumes() {
+    if (!Array.isArray(apiSnapshot.job51SearchRows)) return [];
+    return apiSnapshot.job51SearchRows.map((row, index) => {
+      const str = /* @__PURE__ */ __name((v) => v != null ? String(v) : "", "str");
+      const baseInfo = row?.base_info && typeof row.base_info === "object" ? row.base_info : {};
+      const jobIntentionInfo = row?.job_intention && typeof row.job_intention === "object" ? row.job_intention : {};
+      const recentWorkInfo = row?.recent_work_info && typeof row.recent_work_info === "object" ? row.recent_work_info : {};
+      const workList = Array.isArray(row?.work_list) ? row.work_list : [];
+      const educationList = Array.isArray(row?.education_list) ? row.education_list : [];
+      const latestWork = workList.find(
+        (item) => item && typeof item === "object" && item.is_show
+      ) || workList[0] || {};
+      const latestEducation = educationList.find(
+        (item) => item && typeof item === "object" && item.degree_value
+      ) || educationList[0] || {};
+      const uniqueSkillTags = Array.from(
+        new Set(
+          [
+            ...Array.isArray(row?.label_sorted_skill_tag_list) ? row.label_sorted_skill_tag_list : [],
+            ...Array.isArray(row?.label_list) ? row.label_list : []
+          ].map((value) => normalizeJob51Text(value)).filter(Boolean)
+        )
+      );
+      const workHistory = workList.map((item) => {
+        if (!item || typeof item !== "object") return null;
+        const startDate = normalizeJob51Text(item.start_time);
+        const endDate = normalizeJob51Text(item.end_time);
+        const durationLabel = normalizeJob51Text(item.working_years);
+        const companyName = normalizeJob51Text(item.company_name);
+        const jobTitle = normalizeJob51Text(
+          item.work_func_value || item.job_name
+        );
+        const metaParts = [
+          ...Array.isArray(item.industry_tag) ? item.industry_tag : [],
+          item.company_size_value,
+          item.work_type_value
+        ].map((value) => normalizeJob51Text(value)).filter(Boolean);
+        if (!startDate && !endDate && !companyName && !jobTitle && metaParts.length === 0) {
+          return null;
+        }
+        return {
+          startDate: startDate || void 0,
+          endDate: endDate || void 0,
+          durationLabel: durationLabel || void 0,
+          companyName: companyName || void 0,
+          jobTitle: jobTitle || void 0,
+          description: metaParts.length > 0 ? buildWorkHistoryRawParts(metaParts) : void 0
+        };
+      }).filter(Boolean);
+      const name = normalizeJob51Text(
+        baseInfo.resume_name || row?.name || row?.userName || row?.candidateName || row?.fullName
+      );
+      const ageValue = normalizeJob51Text(
+        baseInfo.age || baseInfo.displayage || baseInfo.age_value || row?.age || row?.realAge || row?.displayage || row?.age_value
+      );
+      const age = ageValue ? ageValue.includes("\u5C81") ? ageValue : `${ageValue}\u5C81` : "";
+      const experience = normalizeJob51Text(
+        baseInfo.work_year_value || latestWork.working_years || row?.workYear || row?.workYears || row?.experienceYears || row?.experience
+      );
+      const education = normalizeJob51Text(
+        baseInfo.top_degree_value || latestEducation.degree_value || row?.education || row?.educationLevel || row?.degree || row?.eduLevel
+      );
+      const location = normalizeJob51Text(
+        jobIntentionInfo.expect_job_area_value || baseInfo.area_value || row?.location || row?.workCity || row?.city || row?.workLocation
+      );
+      const jobIntention = normalizeJob51Text(
+        jobIntentionInfo.expect_work_function_value || latestWork.work_func_value || latestWork.job_name || recentWorkInfo.recent_position || row?.jobIntention || row?.desiredJob || row?.expectedPosition || row?.targetJob || row?.searchJob
+      );
+      const expectedSalary = normalizeJob51Text(
+        jobIntentionInfo.new_expect_salary || jobIntentionInfo.expect_salary || row?.expectedSalary || row?.desiredSalary || row?.expectSalary || row?.salaryExpect
+      );
+      const activityStatus = normalizeJob51Text(
+        row?.active_type || row?.activityStatus || row?.lastLoginTime || row?.activeTime || row?.refreshTime
+      );
+      const selfIntro = normalizeJob51MultilineText(
+        row?.resume_slicing || row?.selfIntro || row?.advantage || row?.profile || row?.highlight || uniqueSkillTags.join("\u3001")
+      );
+      const resumeId = str(
+        row?.userid || row?.resumeId || row?.resumeNo || row?.resumekey || row?.id
+      );
+      const perUserId = str(
+        baseInfo.accountid || row?.real_userid || row?.perUserId || row?.userId || row?.candidateId || row?.memberId
+      );
+      const externalId = resumeId || perUserId;
+      const profileUrl = resumeId ? EHIRE_51JOB_PROFILE_URL_PREFIX + encodeURIComponent(resumeId) : normalizeJob51Text(row?.profileUrl || row?.resumeUrl);
+      return {
+        name,
+        age,
+        experience,
+        education,
+        location,
+        jobIntention,
+        expectedSalary,
+        activityStatus,
+        selfIntro,
+        resumeId: resumeId || void 0,
+        perUserId: perUserId || void 0,
+        externalId: externalId || void 0,
+        profileUrl: profileUrl || void 0,
+        source: EHIRE_51JOB_HOST,
+        workHistory,
+        pageIndex: index + 1,
+        rawData: row,
+        extractedAt: (/* @__PURE__ */ new Date()).toISOString()
+      };
+    });
+  }
+  __name(extract51JobResumes, "extract51JobResumes");
+  function extractJob51DetailResume() {
+    if (!isJob51DetailPage() || !isJob51DetailReady()) return [];
+    return filterCurrentResumesByAgeRange(
+      buildJob51DetailResumeFromPayload(apiSnapshot.job51DetailPayload, {
+        resumeId: new URL(window.location.href).searchParams.get("resumeId") || void 0,
+        profileUrl: window.location.href
+      })
+    );
+  }
+  __name(extractJob51DetailResume, "extractJob51DetailResume");
+  function extractResumes() {
+    if (isJob51DetailPage()) {
+      return filterCurrentResumesByAgeRange(extractJob51DetailResume());
+    }
+    if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+      return filterCurrentResumesByAgeRange(extract51JobResumes());
+    }
+    if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
+      if (isSeekProfileMode()) {
+        if (hasSeekProfileSnapshot()) {
+          return extractSeekProfileResume();
+        }
+        return [];
+      }
+      if (hasSeekListSnapshot()) {
+        return extractSeekResumes();
+      }
+    }
+    if (isJob5156DetailPage()) {
+      return filterCurrentResumesByAgeRange(extractJob5156DetailResume());
+    }
+    const cards = document.querySelectorAll(SELECTORS.resumeCard);
+    const resumes = [];
+    cards.forEach((card, index) => {
+      try {
+        const apiRow = getApiRowForIndex(index);
+        const resume = extractSingleResume(card, apiRow);
+        resume.pageIndex = index + 1;
+        if (apiRow) {
+          resume.resumeId = apiRow.resumeId ?? "";
+          resume.perUserId = apiRow.perUserId ?? "";
+        }
+        resumes.push(resume);
+      } catch (error) {
+        console.error(`Error extracting resume ${index}:`, error);
+      }
+    });
+    return filterCurrentResumesByAgeRange(resumes);
+  }
+  __name(extractResumes, "extractResumes");
+  function extractResumesRaw(options = {}) {
+    const includePage = !!(options && typeof options === "object" && options.includePage);
+    if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
+      const seekProfile = isSeekProfileMode() && hasSeekProfileSnapshot() ? apiSnapshot.seekProfile : null;
+      const seekProfileIdentity = seekProfile ? getSeekCandidateIdentity(seekProfile) : null;
+      const candidates = !seekProfile && hasSeekListSnapshot() ? apiSnapshot.seekRecommendedCandidates : [];
+      const cards = seekProfile ? [
+        {
+          index: 1,
+          profileId: seekProfileIdentity?.profileId || "",
+          profileType: seekProfileIdentity?.profileType || SEEK_PROFILE_TYPE,
+          text: JSON.stringify(seekProfile, null, 2)
+        }
+      ] : candidates.map((candidate, index) => {
+        const { profileId, profileType } = getSeekCandidateIdentity(candidate);
+        return {
+          index: index + 1,
+          profileId,
+          profileType,
+          text: JSON.stringify(candidate, null, 2)
+        };
+      });
+      if (seekProfile || candidates.length > 0) {
+        const payload2 = {
+          url: window.location.href,
+          extractedAt: (/* @__PURE__ */ new Date()).toISOString(),
+          count: cards.length,
+          cards,
+          api: {
+            lastSearchAt: apiSnapshot.lastSearchAt,
+            lastUpdatedAt: apiSnapshot.lastUpdatedAt,
+            searchRowCount: cards.length,
+            sourceKey: SOURCE_KEYS.SEEK,
+            operationName: apiSnapshot.lastOperationName,
+            request: seekProfile ? getSeekProfileRequest() : getSeekRecommendedRequest()
+          }
+        };
+        if (includePage) {
+          payload2.pageHtml = document.documentElement.outerHTML;
+        }
+        return payload2;
+      }
+    }
+    if (isJob51DetailPage() && isJob51DetailReady()) {
+      const detailResumes2 = extractJob51DetailResume();
+      const detailResume = detailResumes2[0] || null;
+      const payload2 = {
+        url: window.location.href,
+        extractedAt: (/* @__PURE__ */ new Date()).toISOString(),
+        count: detailResumes2.length,
+        cards: [
+          {
+            index: 1,
+            resumeId: detailResume?.resumeId || "",
+            perUserId: detailResume?.perUserId || "",
+            text: JSON.stringify(
+              detailResume?.rawData || apiSnapshot.job51DetailPayload,
+              null,
+              2
+            )
+          }
+        ],
+        api: {
+          lastSearchAt: apiSnapshot.lastSearchAt,
+          lastUpdatedAt: apiSnapshot.lastUpdatedAt,
+          searchRowCount: detailResumes2.length,
+          sourceKey: SOURCE_KEYS.JOB51,
+          operationName: apiSnapshot.lastOperationName,
+          request: apiSnapshot.job51AuthContext,
+          payload: apiSnapshot.job51DetailPayload
+        }
+      };
+      if (includePage) {
+        payload2.pageHtml = document.documentElement.outerHTML;
+      }
+      return payload2;
+    }
+    const detailResumes = isJob5156DetailPage() ? extractJob5156DetailResume() : [];
+    const detailRoot = getJob5156DetailRoot();
+    const detailRootElement = detailRoot instanceof HTMLElement ? detailRoot : null;
+    const items = detailResumes.length > 0 ? [
+      {
+        index: 1,
+        resumeId: detailResumes[0]?.resumeId || "",
+        perUserId: "",
+        html: detailRoot?.outerHTML || "",
+        text: detailRootElement?.innerText || detailRoot?.textContent || ""
+      }
+    ] : Array.from(document.querySelectorAll(SELECTORS.resumeCard)).map(
+      (card, index) => {
+        const el = (
+          /** @type {HTMLElement} */
+          card
+        );
+        return {
+          index: index + 1,
+          resumeId: getApiRowForIndex(index)?.resumeId ?? "",
+          perUserId: getApiRowForIndex(index)?.perUserId ?? "",
+          html: el.outerHTML,
+          text: el.innerText
+        };
+      }
+    );
+    const payload = {
+      url: window.location.href,
+      extractedAt: (/* @__PURE__ */ new Date()).toISOString(),
+      count: items.length,
+      cards: items,
+      api: {
+        lastSearchAt: apiSnapshot.lastSearchAt,
+        lastUpdatedAt: apiSnapshot.lastUpdatedAt,
+        searchRowCount: Array.isArray(apiSnapshot.searchRows) ? apiSnapshot.searchRows.length : 0
+      }
+    };
+    if (includePage) {
+      payload.pageHtml = document.documentElement.outerHTML;
+    }
+    return payload;
+  }
+  __name(extractResumesRaw, "extractResumesRaw");
+  function normalizeCardText(text) {
+    if (!text) return "";
+    return text.split("\n").map((line) => line.trim()).filter(Boolean).join("\n");
+  }
+  __name(normalizeCardText, "normalizeCardText");
+  function rawToMarkdown(rawPayload) {
+    const lines = [];
+    lines.push("# Resume Dump (Raw)");
+    lines.push("");
+    lines.push(`- URL: ${rawPayload.url}`);
+    lines.push(`- Extracted: ${rawPayload.extractedAt}`);
+    lines.push(`- Count: ${rawPayload.count}`);
+    lines.push("");
+    rawPayload.cards.forEach((card, idx) => {
+      const indexLabel = String(idx + 1).padStart(2, "0");
+      lines.push(`## Card ${indexLabel}`);
+      if (card.resumeId || card.perUserId) {
+        lines.push(`- resumeId: ${card.resumeId || ""}`);
+        lines.push(`- perUserId: ${card.perUserId || ""}`);
+        lines.push("");
+      }
+      lines.push("```text");
+      const normalized = normalizeCardText(card.text);
+      lines.push(normalized || "(empty)");
+      lines.push("```");
+      lines.push("");
+    });
+    return lines.join("\n");
+  }
+  __name(rawToMarkdown, "rawToMarkdown");
+  function resumesToCSV(resumes) {
+    if (resumes.length === 0) return "";
+    const headers = [
+      "\u5E8F\u53F7",
+      "resumeId",
+      "perUserId",
+      "\u59D3\u540D",
+      "\u5E74\u9F84",
+      "\u5DE5\u4F5C\u7ECF\u9A8C",
+      "\u5B66\u5386",
+      "\u6240\u5728\u5730",
+      "\u81EA\u6211\u8BC4\u4EF7",
+      "\u671F\u671B\u85AA\u8D44",
+      "\u6D3B\u8DC3\u72B6\u6001",
+      "\u6C42\u804C\u610F\u5411",
+      "\u7B80\u5386\u94FE\u63A5",
+      "\u63D0\u53D6\u65F6\u95F4"
+    ];
+    const rows = resumes.map(
+      (r, i) => [
+        i + 1,
+        r.resumeId || "",
+        r.perUserId || "",
+        r.name,
+        r.age,
+        r.experience,
+        r.education,
+        r.location,
+        r.selfIntro,
+        r.expectedSalary,
+        r.activityStatus,
+        r.jobIntention?.replace(/,/g, ";").substring(0, 100),
+        r.profileUrl,
+        r.extractedAt
+      ].map((cell) => `"${String(cell || "").replace(/"/g, '""')}"`).join(",")
+    );
+    return [headers.join(","), ...rows].join("\n");
+  }
+  __name(resumesToCSV, "resumesToCSV");
+  function makeRandomId() {
+    try {
+      if (globalThis.crypto?.randomUUID)
+        return globalThis.crypto.randomUUID().split("-")[0];
+    } catch {
+    }
+    return Math.random().toString(16).slice(2, 10);
+  }
+  __name(makeRandomId, "makeRandomId");
+  async function downloadFile(content, filename, mimeType, saveAs = false) {
+    const response = await chrome.runtime.sendMessage({
+      action: "downloadFile",
+      content,
+      filename,
+      mimeType,
+      saveAs: !!saveAs
+    });
+    if (response?.success) return response;
+    throw new Error(response?.error || "Download failed");
+  }
+  __name(downloadFile, "downloadFile");
+  function getSeekCardCount() {
+    return document.querySelectorAll(
+      'a[href*="/talentsearch/profile/"][href*="profilePosition="]'
+    ).length;
+  }
+  __name(getSeekCardCount, "getSeekCardCount");
+  function getSeekPaginationInfo() {
+    const currentPage = normalizeOptionalPositiveInt(
+      new URL(window.location.href).searchParams.get("pageNumber")
+    ) || 1;
+    const pagination = document.querySelector(
+      'nav[aria-label="Pagination of results"]'
+    );
+    if (!pagination) {
+      return {
+        currentPage,
+        totalPages: currentPage,
+        totalItems: 0,
+        hasNextPage: false
+      };
+    }
+    const links = Array.from(pagination.querySelectorAll("a"));
+    const pageNumbers = links.map((item) => {
+      const label = item.getAttribute("aria-label") || "";
+      const text = item.textContent || "";
+      const match = label.match(/page\s+(\d+)/i) || text.trim().match(/^(\d+)$/);
+      return match ? Number.parseInt(match[1], 10) : 0;
+    }).filter((value) => Number.isFinite(value) && value > 0);
+    const totalPages = Math.max(
+      pageNumbers.length > 0 ? Math.max(...pageNumbers) : 0,
+      currentPage
+    );
+    const nextLink = getSeekNextPageLink();
+    const hasNextPage = totalPages > currentPage && !isDisabledPaginationControl(nextLink);
+    return { currentPage, totalPages, totalItems: 0, hasNextPage };
+  }
+  __name(getSeekPaginationInfo, "getSeekPaginationInfo");
+  function getPaginationInfo() {
+    const sourceKey = getCurrentSourceKey();
+    if (sourceKey === SOURCE_KEYS.SEEK) {
+      return getSeekPaginationInfo();
+    }
+    if (isJob51DetailPage()) {
+      return {
+        currentPage: 1,
+        totalPages: 1,
+        totalItems: isJob51DetailReady() ? 1 : 0,
+        hasNextPage: false
+      };
+    }
+    if (sourceKey === SOURCE_KEYS.JOB51) {
+      const req = apiSnapshot.job51LastSearchRequest;
+      const currentPage2 = normalizeOptionalPositiveInt(
+        req?.page_index ?? req?.pageIndex ?? req?.pageno
+      ) || 1;
+      const pageSize = normalizeOptionalPositiveInt(
+        req?.page_size ?? req?.pageSize ?? req?.pagesize
+      ) || 50;
+      const total = typeof apiSnapshot.job51Total === "number" && apiSnapshot.job51Total > 0 ? apiSnapshot.job51Total : 0;
+      const hasData = Array.isArray(apiSnapshot.job51SearchRows) && apiSnapshot.job51SearchRows.length > 0;
+      let totalPages2 = currentPage2;
+      if (total > 0) {
+        totalPages2 = Math.ceil(total / pageSize);
+      } else if (hasData) {
+        totalPages2 = currentPage2 + 1;
+      }
+      return {
+        currentPage: currentPage2,
+        totalPages: totalPages2,
+        totalItems: total,
+        hasNextPage: total > 0 ? currentPage2 < totalPages2 : hasData && currentPage2 < totalPages2
+      };
+    }
+    if (isJob5156DetailPage()) {
+      return {
+        currentPage: 1,
+        totalPages: 1,
+        totalItems: isJob5156DetailReady() ? 1 : 0,
+        hasNextPage: false
+      };
+    }
+    const pagination = document.querySelector(SELECTORS.pagination);
+    if (!pagination)
+      return { currentPage: 1, totalPages: 1, totalItems: 0, hasNextPage: false };
+    const totalText = pagination.textContent || "";
+    const totalMatch = totalText.match(/共\s*([\d,，]+)\s*条/);
+    const totalItems = totalMatch ? Number.parseInt(String(totalMatch[1]).replace(/[，,]/g, ""), 10) || 0 : 0;
+    const activePage = pagination.querySelector(
+      ".is-active, .active, .el-pager li.active"
+    );
+    const currentPage = activePage ? Number.parseInt(activePage.textContent || "", 10) || 1 : 1;
+    const pagerItems = Array.from(pagination.querySelectorAll(".el-pager li"));
+    const pageNumbers = pagerItems.map((item) => Number.parseInt(item.textContent || "", 10)).filter((value) => Number.isFinite(value) && value > 0);
+    const totalPagesFromPager = pageNumbers.length > 0 ? Math.max(...pageNumbers) : 0;
+    const totalPagesFromTotal = totalItems > 0 ? Math.ceil(totalItems / 20) : 0;
+    const totalPages = Math.max(
+      totalPagesFromTotal,
+      totalPagesFromPager,
+      currentPage
+    );
+    return {
+      currentPage,
+      totalPages,
+      totalItems,
+      hasNextPage: totalPages > currentPage
+    };
+  }
+  __name(getPaginationInfo, "getPaginationInfo");
+  function getSeekNextPageLink() {
+    const pagination = document.querySelector(SELECTORS.seekPagination);
+    if (!pagination) return null;
+    const links = Array.from(pagination.querySelectorAll("a"));
+    const nextLink = links.find(
+      (node) => /next/i.test((node.textContent || "").trim())
+    );
+    return asHTMLElement(nextLink || null);
+  }
+  __name(getSeekNextPageLink, "getSeekNextPageLink");
+  function isDisabledPaginationControl(control) {
+    if (!control) return true;
+    return control.hasAttribute("disabled") || control.classList.contains("disabled") || control.classList.contains("is-disabled") || control.getAttribute("aria-disabled") === "true" || control.getAttribute("aria-hidden") === "true" || control.getAttribute("tabindex") === "-1";
+  }
+  __name(isDisabledPaginationControl, "isDisabledPaginationControl");
+  function goToNextPageInternal() {
+    const sourceKey = getCurrentSourceKey();
+    if (sourceKey === SOURCE_KEYS.SEEK) {
+      const nextBtn2 = getSeekNextPageLink();
+      if (!nextBtn2 || isDisabledPaginationControl(nextBtn2)) return false;
+      nextBtn2.click();
+      return true;
+    }
+    if (sourceKey === SOURCE_KEYS.JOB51) {
+      const pagination = getPaginationInfo();
+      if (!pagination.hasNextPage) return false;
+      window.postMessage(
+        { source: CONTENT_SCRIPT_SOURCE, action: JOB51_NEXT_PAGE_EVENT },
+        "*"
+      );
+      return true;
+    }
+    const nextBtn = asHTMLElement(document.querySelector(SELECTORS.nextPageBtn));
+    if (!nextBtn || isDisabledPaginationControl(nextBtn)) return false;
+    nextBtn.click();
+    return true;
+  }
+  __name(goToNextPageInternal, "goToNextPageInternal");
+  function getNextPageButtonState() {
+    const sourceKey = getCurrentSourceKey();
+    if (sourceKey === SOURCE_KEYS.SEEK) {
+      const nextBtn2 = getSeekNextPageLink();
+      if (!nextBtn2) {
+        return {
+          exists: false
+        };
+      }
+      return {
+        exists: true,
+        text: nextBtn2.textContent || "",
+        href: nextBtn2.getAttribute("href") || "",
+        className: nextBtn2.className || "",
+        disabledAttr: nextBtn2.getAttribute("disabled") || "",
+        ariaDisabled: nextBtn2.getAttribute("aria-disabled") || "",
+        isDisabledClass: nextBtn2.classList.contains("disabled"),
+        isIsDisabledClass: nextBtn2.classList.contains("is-disabled")
+      };
+    }
+    if (sourceKey === SOURCE_KEYS.JOB51) {
+      const pagination = getPaginationInfo();
+      return {
+        exists: pagination.hasNextPage,
+        source: "51job-api",
+        currentPage: pagination.currentPage,
+        totalPages: pagination.totalPages,
+        hasNextPage: pagination.hasNextPage
+      };
+    }
+    const nextBtn = document.querySelector(SELECTORS.nextPageBtn);
+    if (!nextBtn) {
+      return {
+        exists: false
+      };
+    }
+    return {
+      exists: true,
+      text: nextBtn.textContent || "",
+      href: nextBtn.getAttribute("href") || "",
+      className: nextBtn.className || "",
+      disabledAttr: nextBtn.getAttribute("disabled") || "",
+      ariaDisabled: nextBtn.getAttribute("aria-disabled") || "",
+      isDisabledClass: nextBtn.classList.contains("disabled"),
+      isIsDisabledClass: nextBtn.classList.contains("is-disabled")
+    };
+  }
+  __name(getNextPageButtonState, "getNextPageButtonState");
+  function parseAutoExportMode(value) {
+    if (!value) return { enabled: false };
+    const mode = String(value).trim().toLowerCase();
+    if (!mode) return { enabled: false };
+    const config = {
+      enabled: true,
+      logStructured: false,
+      logRaw: false,
+      downloadCsv: false,
+      downloadJson: false,
+      downloadRawJson: false,
+      downloadMarkdown: false,
+      saveAs: false,
+      rawIncludePage: false
+    };
+    if (mode === "1" || mode === "true") {
+      config.downloadMarkdown = true;
+      return config;
+    }
+    if (mode === "console" || mode === "log") {
+      config.logStructured = true;
+      return config;
+    }
+    if (mode === "csv") {
+      config.downloadCsv = true;
+      return config;
+    }
+    if (mode === "json") {
+      config.downloadJson = true;
+      return config;
+    }
+    if (mode === "both" || mode === "all") {
+      config.downloadCsv = true;
+      config.downloadJson = mode === "all";
+      config.logStructured = true;
+      return config;
+    }
+    if (mode === "raw") {
+      config.logRaw = true;
+      return config;
+    }
+    if (mode === "raw_json" || mode === "rawjson") {
+      config.downloadRawJson = true;
+      return config;
+    }
+    if (mode === "md" || mode === "markdown") {
+      config.downloadMarkdown = true;
+      return config;
+    }
+    const tokens = mode.split(/[,+|]/).map((token) => token.trim()).filter(Boolean);
+    for (const token of tokens) {
+      if (token === "console" || token === "log") config.logStructured = true;
+      if (token === "csv") config.downloadCsv = true;
+      if (token === "json") config.downloadJson = true;
+      if (token === "raw") config.logRaw = true;
+      if (token === "rawjson" || token === "raw_json")
+        config.downloadRawJson = true;
+      if (token === "md" || token === "markdown") config.downloadMarkdown = true;
+      if (token === "page" || token === "rawpage") config.rawIncludePage = true;
+      if (token === "saveas") config.saveAs = true;
+    }
+    if (!config.logStructured && !config.logRaw && !config.downloadCsv && !config.downloadJson && !config.downloadRawJson && !config.downloadMarkdown) {
+      config.downloadMarkdown = true;
+    }
+    return config;
+  }
+  __name(parseAutoExportMode, "parseAutoExportMode");
+  function getAutoExportConfig() {
+    const params = new URLSearchParams(window.location.search || "");
+    const paramValue = params.get(AUTO_EXPORT_PARAM);
+    if (paramValue) return parseAutoExportMode(paramValue);
+    try {
+      const localValue = window.localStorage?.getItem(AUTO_EXPORT_PARAM);
+      return parseAutoExportMode(localValue);
+    } catch {
+      return { enabled: false };
+    }
+  }
+  __name(getAutoExportConfig, "getAutoExportConfig");
+  function parseAutoSyncFlag(value) {
+    if (!value) return false;
+    const normalized = String(value).trim().toLowerCase();
+    return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+  }
+  __name(parseAutoSyncFlag, "parseAutoSyncFlag");
+  function getAutoSyncEnabled() {
+    const params = new URLSearchParams(window.location.search || "");
+    if (params.has(AUTO_SYNC_PARAM)) {
+      return parseAutoSyncFlag(params.get(AUTO_SYNC_PARAM));
+    }
+    try {
+      const localValue = window.localStorage?.getItem(AUTO_SYNC_PARAM);
+      return parseAutoSyncFlag(localValue);
+    } catch {
+      return false;
+    }
+  }
+  __name(getAutoSyncEnabled, "getAutoSyncEnabled");
+  function setAutoSyncAttributes(status, count, pagesProcessed) {
+    try {
+      document.documentElement.setAttribute("data-tr-auto-sync", status);
+      if (typeof count === "number" && Number.isFinite(count)) {
+        document.documentElement.setAttribute(
+          "data-tr-auto-sync-count",
+          String(count)
+        );
+      } else {
+        document.documentElement.removeAttribute("data-tr-auto-sync-count");
+      }
+      if (typeof pagesProcessed === "number" && Number.isFinite(pagesProcessed)) {
+        document.documentElement.setAttribute(
+          "data-tr-auto-sync-pages",
+          String(pagesProcessed)
+        );
+      } else {
+        document.documentElement.removeAttribute("data-tr-auto-sync-pages");
+      }
+    } catch {
+    }
+    if (status && status !== "skipped") {
+      persistLatestAutoSyncSummary();
+    }
+  }
+  __name(setAutoSyncAttributes, "setAutoSyncAttributes");
+  function buildAutoSyncProgressHint({
+    limit,
+    totalSubmitted,
+    selectedCount = null,
+    ageHint = ""
+  } = {}) {
+    const progressHint = limit > 0 ? `\u5DF2\u91C7\u96C6 ${Math.min(totalSubmitted, limit)}/${limit}` : `\u5DF2\u91C7\u96C6 ${totalSubmitted}`;
+    const selectedHint = buildAutoSyncSelectedCountHint({ selectedCount });
+    return `${progressHint}${selectedHint}${ageHint}`;
+  }
+  __name(buildAutoSyncProgressHint, "buildAutoSyncProgressHint");
+  function buildAutoSyncSelectedCountHint({
+    selectedCount = null,
+    prefix = " \xB7 "
+  } = {}) {
+    return typeof selectedCount === "number" && Number.isFinite(selectedCount) ? `${prefix}\u672C\u9875\u9009\u4E2D ${selectedCount} \u4EFD` : "";
+  }
+  __name(buildAutoSyncSelectedCountHint, "buildAutoSyncSelectedCountHint");
+  function buildAutoSyncCompletionHint({
+    totalInserted = 0,
+    totalUpdated = 0,
+    pagesVisited = 0,
+    selectedCount = null
+  } = {}) {
+    return `${totalInserted} \u65B0\u589E, ${totalUpdated} \u66F4\u65B0, \u5171 ${pagesVisited} \u9875${buildAutoSyncSelectedCountHint(
+      {
+        selectedCount
+      }
+    )}`;
+  }
+  __name(buildAutoSyncCompletionHint, "buildAutoSyncCompletionHint");
+  var SyncStatusWidget = /* @__PURE__ */ (() => {
+    const WIDGET_ID = "tr-sync-status-widget";
+    const DEFAULT_AUTO_DISMISS_MS = 5e3;
+    const HIDE_DELAY_MS = 220;
+    let widgetEl = null;
+    let dismissTimer = null;
+    let hideTimer = null;
+    function escapeHtml(value) {
+      return String(value ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+    }
+    __name(escapeHtml, "escapeHtml");
+    function clearTimers() {
+      if (dismissTimer) {
+        clearTimeout(dismissTimer);
+        dismissTimer = null;
+      }
+      if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+    }
+    __name(clearTimers, "clearTimers");
+    function ensureWidget() {
+      if (widgetEl && widgetEl.isConnected) return widgetEl;
+      widgetEl = document.createElement("div");
+      widgetEl.id = WIDGET_ID;
+      widgetEl.className = "tr-sync-widget";
+      widgetEl.setAttribute("role", "status");
+      widgetEl.setAttribute("aria-live", "polite");
+      widgetEl.setAttribute("aria-atomic", "true");
+      const mountTarget = document.body || document.documentElement;
+      mountTarget.appendChild(widgetEl);
+      return widgetEl;
+    }
+    __name(ensureWidget, "ensureWidget");
+    function renderIcon(state) {
+      if (state === "progress") {
+        return '<span class="tr-sync-widget__spinner" aria-hidden="true"></span>';
+      }
+      if (state === "success") {
+        return '<span aria-hidden="true">\u2713</span>';
+      }
+      return '<span aria-hidden="true">!</span>';
+    }
+    __name(renderIcon, "renderIcon");
+    function openOptionsPage() {
+      try {
+        void chrome.runtime.sendMessage({ action: "openOptionsPage" }).catch((error) => {
+          console.warn("\u{1F3AF} [Auto Sync] Failed to open options page:", error);
+        });
+      } catch (error) {
+        console.warn("\u{1F3AF} [Auto Sync] Failed to request options page:", error);
+      }
+    }
+    __name(openOptionsPage, "openOptionsPage");
+    function show({
+      state = "progress",
+      message = "",
+      hint = "",
+      autoDismiss = false
+    } = {}) {
+      const normalizedState = state === "success" || state === "error" ? state : "progress";
+      const safeMessage = escapeHtml(message);
+      const safeHint = escapeHtml(hint);
+      const widget = ensureWidget();
+      clearTimers();
+      widget.className = `tr-sync-widget tr-sync-widget--${normalizedState}`;
+      widget.classList.remove("tr-sync-widget--hidden");
+      widget.innerHTML = `
+      <div class="tr-sync-widget__icon">${renderIcon(normalizedState)}</div>
+      <div class="tr-sync-widget__content">
+        <div class="tr-sync-widget__message">${safeMessage}</div>
+        ${safeHint ? `<div class="tr-sync-widget__hint">${safeHint}</div>` : ""}
+      </div>
+      ${normalizedState === "progress" ? '<button type="button" class="tr-sync-widget__cancel" aria-label="\u53D6\u6D88\u540C\u6B65">\u53D6\u6D88</button>' : normalizedState === "error" ? '<button type="button" class="tr-sync-widget__close" aria-label="\u5173\u95ED\u63D0\u793A">\xD7</button>' : ""}
+    `;
+      widget.onclick = null;
+      if (normalizedState === "progress") {
+        const cancelBtn = widget.querySelector(".tr-sync-widget__cancel");
+        cancelBtn?.addEventListener("click", (event) => {
+          event.stopPropagation();
+          autoSyncCancelled = true;
+          cancelBtn.setAttribute("disabled", "true");
+          cancelBtn.textContent = "\u53D6\u6D88\u4E2D...";
+        });
+      }
+      if (normalizedState === "error") {
+        widget.onclick = (event) => {
+          const target = event.target instanceof Element ? event.target : null;
+          if (target?.closest(".tr-sync-widget__close")) return;
+          openOptionsPage();
+        };
+        const closeBtn = widget.querySelector(".tr-sync-widget__close");
+        closeBtn?.addEventListener("click", (event) => {
+          event.stopPropagation();
+          hide();
+        });
+      }
+      const dismissMs = typeof autoDismiss === "number" ? autoDismiss : autoDismiss ? DEFAULT_AUTO_DISMISS_MS : 0;
+      if (dismissMs > 0) {
+        dismissTimer = setTimeout(() => {
+          hide();
+        }, dismissMs);
+      }
+    }
+    __name(show, "show");
+    function hide() {
+      if (!widgetEl) return;
+      clearTimers();
+      widgetEl.classList.add("tr-sync-widget--hidden");
+      hideTimer = setTimeout(() => {
+        if (widgetEl) {
+          widgetEl.remove();
+          widgetEl = null;
+        }
+        hideTimer = null;
+      }, HIDE_DELAY_MS);
+    }
+    __name(hide, "hide");
+    return {
+      show,
+      hide
+    };
+  })();
+  function waitForResumeCards({ timeoutMs = 3e4, minCount = 1 } = {}) {
+    return new Promise((resolve, reject) => {
+      let done = false;
+      const deadline = Date.now() + timeoutMs;
+      const check = /* @__PURE__ */ __name(() => {
+        if (done) return;
+        const count = document.querySelectorAll(SELECTORS.resumeCard).length;
+        if (count >= minCount) {
+          done = true;
+          cleanup();
+          resolve(count);
+        } else if (Date.now() > deadline) {
+          done = true;
+          cleanup();
+          reject(new Error("Timed out waiting for resume cards"));
+        }
+      }, "check");
+      const cleanup = /* @__PURE__ */ __name(() => {
+        clearInterval(intervalId);
+        observer.disconnect();
+      }, "cleanup");
+      const intervalId = setInterval(check, 500);
+      const observer = new MutationObserver(check);
+      observer.observe(document.body || document.documentElement, {
+        childList: true,
+        subtree: true
+      });
+      check();
+    });
+  }
+  __name(waitForResumeCards, "waitForResumeCards");
+  function waitForApiRows({ timeoutMs = 5e3, minCount = 1 } = {}) {
+    return new Promise((resolve, reject) => {
+      let done = false;
+      const deadline = Date.now() + timeoutMs;
+      const check = /* @__PURE__ */ __name(() => {
+        if (done) return;
+        if (getCurrentSourceKey() === SOURCE_KEYS.JOB51 && isJob51RateLimitedPage()) {
+          done = true;
+          cleanup();
+          reject(new Error(JOB51_RATE_LIMIT_ERROR_MESSAGE));
+          return;
+        }
+        const count = getApiSnapshotCount();
+        if (count >= minCount || getCurrentSourceKey() === SOURCE_KEYS.JOB51 && isExtractionReady()) {
+          done = true;
+          cleanup();
+          resolve(count);
+        } else if (Date.now() > deadline) {
+          done = true;
+          cleanup();
+          reject(new Error("Timed out waiting for API rows"));
+        }
+      }, "check");
+      const cleanup = /* @__PURE__ */ __name(() => {
+        clearInterval(intervalId);
+        observer.disconnect();
+      }, "cleanup");
+      const intervalId = setInterval(check, 300);
+      const observer = new MutationObserver(check);
+      observer.observe(document.body || document.documentElement, {
+        childList: true,
+        subtree: true
+      });
+      check();
+    });
+  }
+  __name(waitForApiRows, "waitForApiRows");
+  async function waitForExtractionData({ timeoutMs = 3e4, minCount = 1 } = {}) {
+    if (getCurrentSourceKey() === SOURCE_KEYS.SEEK || getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+      return waitForApiRows({ timeoutMs, minCount });
+    }
+    const count = await waitForResumeCards({ timeoutMs, minCount });
+    try {
+      await waitForApiRows({ timeoutMs, minCount });
+    } catch {
+    }
+    return count;
+  }
+  __name(waitForExtractionData, "waitForExtractionData");
+  function clearCapturedResultsForNextPage() {
+    apiSnapshot.searchRows = null;
+    apiSnapshot.job51SearchRows = null;
+    apiSnapshot.job51DetailPayload = null;
+    if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
+      apiSnapshot.seekRecommendedCandidates = null;
+      apiSnapshot.seekRecommendedRequest = null;
+      apiSnapshot.seekProfile = null;
+      apiSnapshot.seekProfileRequest = null;
+    }
+  }
+  __name(clearCapturedResultsForNextPage, "clearCapturedResultsForNextPage");
+  function waitForSeekProfileSnapshot(profileId, { timeoutMs = 12e3 } = {}) {
+    return new Promise((resolve, reject) => {
+      let done = false;
+      const deadline = Date.now() + timeoutMs;
+      const check = /* @__PURE__ */ __name(() => {
+        if (done) return;
+        const snapshot = apiSnapshot.seekProfile;
+        const identity = snapshot ? getSeekCandidateIdentity(snapshot) : null;
+        if (identity?.profileId === String(profileId)) {
+          done = true;
+          cleanup();
+          resolve(snapshot);
+          return;
+        }
+        if (Date.now() > deadline) {
+          done = true;
+          cleanup();
+          reject(new Error(`Timed out waiting for Seek profile ${profileId}`));
+        }
+      }, "check");
+      const cleanup = /* @__PURE__ */ __name(() => {
+        clearInterval(intervalId);
+        observer.disconnect();
+      }, "cleanup");
+      const intervalId = setInterval(check, 200);
+      const observer = new MutationObserver(check);
+      observer.observe(document.body || document.documentElement, {
+        childList: true,
+        subtree: true
+      });
+      check();
+    });
+  }
+  __name(waitForSeekProfileSnapshot, "waitForSeekProfileSnapshot");
+  async function enrichSingleSeekResumeWithDetail(resume) {
+    const profileId = typeof resume?.profileId === "string" ? resume.profileId.trim() : "";
+    if (!profileId) {
+      return resume;
+    }
+    const trigger = findSeekProfileTrigger(profileId);
+    if (!(trigger instanceof HTMLElement)) {
+      return resume;
+    }
+    try {
+      trigger.click();
+      await waitForSeekProfileSnapshot(profileId, { timeoutMs: 12e3 });
+      const [detailResume] = extractSeekProfileResume();
+      if (!detailResume || detailResume.profileId !== profileId) {
+        return resume;
+      }
+      return mergeSeekListResumeWithDetail(resume, detailResume);
+    } catch (error) {
+      console.warn(
+        "\u{1F3AF} [Auto Sync] Failed to enrich Seek detail resume:",
+        profileId,
+        error
+      );
+      return resume;
+    }
+  }
+  __name(enrichSingleSeekResumeWithDetail, "enrichSingleSeekResumeWithDetail");
+  async function enrichSeekRecommendedResumesWithDetail(resumes) {
+    if (!Array.isArray(resumes) || resumes.length === 0) return [];
+    if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return resumes;
+    if (isSeekProfileMode()) return resumes;
+    const enriched = [];
+    for (const resume of resumes) {
+      enriched.push(await enrichSingleSeekResumeWithDetail(resume));
+    }
+    return enriched;
+  }
+  __name(enrichSeekRecommendedResumesWithDetail, "enrichSeekRecommendedResumesWithDetail");
+  function waitForPagination({ timeoutMs = 8e3 } = {}) {
+    if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+      return Promise.resolve(true);
+    }
+    return new Promise((resolve, reject) => {
+      let done = false;
+      const deadline = Date.now() + timeoutMs;
+      const check = /* @__PURE__ */ __name(() => {
+        if (done) return;
+        const isSeek = getCurrentSourceKey() === SOURCE_KEYS.SEEK;
+        const pagination = document.querySelector(
+          isSeek ? SELECTORS.seekPagination : SELECTORS.pagination
+        );
+        const nextBtn = isSeek ? getSeekNextPageLink() : document.querySelector(SELECTORS.nextPageBtn);
+        if (pagination && nextBtn) {
+          done = true;
+          cleanup();
+          resolve(true);
+        } else if (Date.now() > deadline) {
+          done = true;
+          cleanup();
+          reject(new Error("Timed out waiting for pagination controls"));
+        }
+      }, "check");
+      const cleanup = /* @__PURE__ */ __name(() => {
+        clearInterval(intervalId);
+        observer.disconnect();
+      }, "cleanup");
+      const intervalId = setInterval(check, 300);
+      const observer = new MutationObserver(check);
+      observer.observe(document.body || document.documentElement, {
+        childList: true,
+        subtree: true
+      });
+      check();
+    });
+  }
+  __name(waitForPagination, "waitForPagination");
+  function waitForPageTransition(options = {}) {
+    const { expectedPage, timeoutMs = 15e3 } = options;
+    return new Promise((resolve, reject) => {
+      if (!Number.isFinite(expectedPage) || expectedPage < 1) {
+        reject(new Error("Invalid expected page"));
+        return;
+      }
+      let done = false;
+      const deadline = Date.now() + timeoutMs;
+      const check = /* @__PURE__ */ __name(() => {
+        if (done) return;
+        const pagination = getPaginationInfo();
+        if (pagination.currentPage === expectedPage) {
+          done = true;
+          cleanup();
+          resolve(pagination.currentPage);
+        } else if (Date.now() > deadline) {
+          done = true;
+          cleanup();
+          reject(new Error(`Timed out waiting for page ${expectedPage}`));
+        }
+      }, "check");
+      const cleanup = /* @__PURE__ */ __name(() => {
+        clearInterval(intervalId);
+        observer.disconnect();
+      }, "cleanup");
+      const intervalId = setInterval(check, 300);
+      const observer = new MutationObserver(check);
+      observer.observe(document.body || document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true
+      });
+      check();
+    });
+  }
+  __name(waitForPageTransition, "waitForPageTransition");
+  function waitForSearchElements({ timeoutMs = 8e3 } = {}) {
+    return new Promise((resolve, reject) => {
+      let done = false;
+      const deadline = Date.now() + timeoutMs;
+      const check = /* @__PURE__ */ __name(() => {
+        if (done) return;
+        const sourceKey = getCurrentSourceKey();
+        const inputSel = sourceKey === SOURCE_KEYS.JOB51 ? SELECTORS.job51SearchInput : SELECTORS.searchInput;
+        const buttonSel = sourceKey === SOURCE_KEYS.JOB51 ? SELECTORS.job51SearchButton : SELECTORS.searchButton;
+        const input = document.querySelector(inputSel);
+        const button = document.querySelector(buttonSel);
+        if (input && button) {
+          done = true;
+          cleanup();
+          resolve({ input, button });
+        } else if (Date.now() > deadline) {
+          done = true;
+          cleanup();
+          reject(new Error("Timed out waiting for search controls"));
+        }
+      }, "check");
+      const cleanup = /* @__PURE__ */ __name(() => {
+        clearInterval(intervalId);
+        observer.disconnect();
+      }, "cleanup");
+      const intervalId = setInterval(check, 300);
+      const observer = new MutationObserver(check);
+      observer.observe(document.body || document.documentElement, {
+        childList: true,
+        subtree: true
+      });
+      check();
+    });
+  }
+  __name(waitForSearchElements, "waitForSearchElements");
+  function isElementVisible(element) {
+    if (!element) return false;
+    const style = window.getComputedStyle(element);
+    return style.display !== "none" && style.visibility !== "hidden";
+  }
+  __name(isElementVisible, "isElementVisible");
+  function waitForAreaModal({ timeoutMs = 8e3 } = {}) {
+    return new Promise((resolve, reject) => {
+      let done = false;
+      const deadline = Date.now() + timeoutMs;
+      const check = /* @__PURE__ */ __name(() => {
+        if (done) return;
+        const modal = document.querySelector(SELECTORS.areaModal);
+        if (modal && isElementVisible(modal)) {
+          done = true;
+          cleanup();
+          resolve(modal);
+        } else if (Date.now() > deadline) {
+          done = true;
+          cleanup();
+          reject(new Error("Timed out waiting for area selector modal"));
+        }
+      }, "check");
+      const cleanup = /* @__PURE__ */ __name(() => {
+        clearInterval(intervalId);
+        observer.disconnect();
+      }, "cleanup");
+      const intervalId = setInterval(check, 300);
+      const observer = new MutationObserver(check);
+      observer.observe(document.body || document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true
+      });
+      check();
+    });
+  }
+  __name(waitForAreaModal, "waitForAreaModal");
+  function getAreaItemText(item) {
+    if (!item) return "";
+    const source = item.querySelector("span") || item;
+    const clone = source.cloneNode(true);
+    clone.querySelectorAll(".select-num").forEach((node) => node.remove());
+    return (clone.textContent || "").replace(/[\uE000-\uF8FF]/g, "").replace(/\s+/g, " ").trim();
+  }
+  __name(getAreaItemText, "getAreaItemText");
+  function asHTMLElement(element) {
+    return element instanceof HTMLElement ? element : null;
+  }
+  __name(asHTMLElement, "asHTMLElement");
+  function findAreaItemByText(container, text) {
+    if (!container || !text) return null;
+    const target = text.replace(/\s+/g, " ").trim();
+    const normalizedTarget = normalizeSeekLocationLabel(target);
+    const itemSelector = `${SELECTORS.areaItem}, ${SELECTORS.areaDistrictItem}`;
+    const items = container.querySelectorAll(itemSelector);
+    let normalizedMatch = null;
+    for (const item of items) {
+      const itemText = getAreaItemText(item);
+      if (itemText === target) return asHTMLElement(item);
+      if (!normalizedMatch) {
+        const normalizedItemText = normalizeSeekLocationLabel(itemText);
+        if (normalizedTarget && normalizedItemText && (normalizedItemText === normalizedTarget || normalizedItemText.includes(normalizedTarget) || normalizedTarget.includes(normalizedItemText))) {
+          normalizedMatch = asHTMLElement(item);
+        }
+      }
+    }
+    return normalizedMatch;
+  }
+  __name(findAreaItemByText, "findAreaItemByText");
+  function waitForAreaItems(blockSelector, { timeoutMs = 5e3, itemSelector } = {}) {
+    return new Promise((resolve, reject) => {
+      let done = false;
+      const deadline = Date.now() + timeoutMs;
+      const targetSelector = itemSelector || `${SELECTORS.areaItem}, ${SELECTORS.areaDistrictItem}`;
+      const check = /* @__PURE__ */ __name(() => {
+        if (done) return;
+        const block = document.querySelector(blockSelector);
+        const items = block ? block.querySelectorAll(targetSelector) : [];
+        if (block && items.length > 0) {
+          done = true;
+          cleanup();
+          resolve({ block, items: Array.from(items) });
+        } else if (Date.now() > deadline) {
+          done = true;
+          cleanup();
+          reject(
+            new Error(`Timed out waiting for area items in ${blockSelector}`)
+          );
+        }
+      }, "check");
+      const cleanup = /* @__PURE__ */ __name(() => {
+        clearInterval(intervalId);
+        observer.disconnect();
+      }, "cleanup");
+      const intervalId = setInterval(check, 300);
+      const observer = new MutationObserver(check);
+      observer.observe(document.body || document.documentElement, {
+        childList: true,
+        subtree: true
+      });
+      check();
+    });
+  }
+  __name(waitForAreaItems, "waitForAreaItems");
+  function waitForAreaTrigger({ timeoutMs = 8e3 } = {}) {
+    return new Promise((resolve, reject) => {
+      let done = false;
+      const deadline = Date.now() + timeoutMs;
+      const check = /* @__PURE__ */ __name(() => {
+        if (done) return;
+        const trigger = asHTMLElement(
+          document.querySelector(SELECTORS.areaTrigger)
+        );
+        if (trigger && isElementVisible(trigger)) {
+          done = true;
+          cleanup();
+          resolve(trigger);
+        } else if (Date.now() > deadline) {
+          done = true;
+          cleanup();
+          reject(new Error("Timed out waiting for area trigger"));
+        }
+      }, "check");
+      const cleanup = /* @__PURE__ */ __name(() => {
+        clearInterval(intervalId);
+        observer.disconnect();
+      }, "cleanup");
+      const intervalId = setInterval(check, 300);
+      const observer = new MutationObserver(check);
+      observer.observe(document.body || document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true
+      });
+      check();
+    });
+  }
+  __name(waitForAreaTrigger, "waitForAreaTrigger");
+  function setAutoSearchAttributes(status, keyword) {
+    try {
+      document.documentElement.setAttribute("data-tr-auto-search", status);
+      if (keyword) {
+        document.documentElement.setAttribute("data-tr-search-keyword", keyword);
+      } else {
+        document.documentElement.removeAttribute("data-tr-search-keyword");
+      }
+    } catch {
+    }
+  }
+  __name(setAutoSearchAttributes, "setAutoSearchAttributes");
+  function setAutoLocationAttributes(status, location) {
+    try {
+      document.documentElement.setAttribute("data-tr-auto-location", status);
+      if (location) {
+        document.documentElement.setAttribute("data-tr-location-value", location);
+      } else {
+        document.documentElement.removeAttribute("data-tr-location-value");
+      }
+    } catch {
+    }
+  }
+  __name(setAutoLocationAttributes, "setAutoLocationAttributes");
+  function canSkipAutoLocationForSeekPage() {
+    if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return false;
+    return window.location.pathname.includes("/candidates/recommended");
+  }
+  __name(canSkipAutoLocationForSeekPage, "canSkipAutoLocationForSeekPage");
+  function setAutoAgeAttributes(status, minAge, maxAge) {
+    try {
+      document.documentElement.setAttribute("data-tr-auto-age", status);
+      const normalizedMin = typeof minAge === "number" && Number.isFinite(minAge) ? Math.trunc(minAge) : null;
+      const normalizedMax = typeof maxAge === "number" && Number.isFinite(maxAge) ? Math.trunc(maxAge) : null;
+      if (normalizedMin !== null || normalizedMax !== null) {
+        document.documentElement.setAttribute(
+          "data-tr-age-range",
+          `${normalizedMin !== null ? normalizedMin : ""}-${normalizedMax !== null ? normalizedMax : ""}`
+        );
+      } else {
+        document.documentElement.removeAttribute("data-tr-age-range");
+      }
+    } catch {
+    }
+  }
+  __name(setAutoAgeAttributes, "setAutoAgeAttributes");
+  function setInputValue(input, value) {
+    const inputWindow = input?.ownerDocument?.defaultView || window;
+    const inputCtor = inputWindow.HTMLInputElement || globalThis.HTMLInputElement;
+    const descriptor = inputCtor ? Object.getOwnPropertyDescriptor(inputCtor.prototype, "value") : null;
+    if (descriptor?.set) {
+      descriptor.set.call(input, value);
+    } else {
+      input.value = value;
+    }
+    input.dispatchEvent(new inputWindow.Event("input", { bubbles: true }));
+    input.dispatchEvent(new inputWindow.Event("change", { bubbles: true }));
+  }
+  __name(setInputValue, "setInputValue");
+  function fireMouseEvent(target, type) {
+    try {
+      const targetWindow = target?.ownerDocument?.defaultView || window;
+      target.dispatchEvent(
+        new targetWindow.MouseEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          view: targetWindow
+        })
+      );
+    } catch {
+    }
+  }
+  __name(fireMouseEvent, "fireMouseEvent");
+  function activateElement(target) {
+    if (!target) {
+      return;
+    }
+    ["mouseenter", "mouseover", "mousedown", "mouseup"].forEach(
+      (type) => fireMouseEvent(target, type)
+    );
+    target.click?.();
+  }
+  __name(activateElement, "activateElement");
+  function findVueParentByName(node, componentName, { maxDepth = 8 } = {}) {
+    let vm = node?.__vue__ || null;
+    for (let depth = 0; vm && depth < maxDepth; depth += 1) {
+      if (vm?.$options?.name === componentName) {
+        return vm;
+      }
+      vm = vm?.$parent || null;
+    }
+    return null;
+  }
+  __name(findVueParentByName, "findVueParentByName");
+  function findAgeFilterBlock() {
+    if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+      const labels = document.querySelectorAll(".base-select-label");
+      const label2 = Array.from(labels).find(
+        (node) => (node.textContent || "").replace(/\s+/g, "").trim() === "\u5E74\u9F84"
+      );
+      if (label2) {
+        return label2.closest(".el-popover__reference") || label2.closest(".base-select-button") || label2.closest(".el-popover__reference-wrapper");
+      }
+    }
+    const titles = document.querySelectorAll(".base-input-block__title__text");
+    const label = Array.from(titles).find(
+      (node) => (node.textContent || "").replace(/\s+/g, "").trim() === "\u5E74\u9F84"
+    );
+    return label ? label.closest(".base-input-block") : null;
+  }
+  __name(findAgeFilterBlock, "findAgeFilterBlock");
+  function openAgeFilterDropdown(ageBlock) {
+    if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+      const trigger = ageBlock.querySelector(".base-select-button") || (ageBlock.matches?.(".base-select-button") ? ageBlock : null) || ageBlock;
+      activateElement(trigger);
+      return;
+    }
+    const title = ageBlock.querySelector(".base-input-block__title") || ageBlock;
+    ["mouseenter", "mouseover", "mousedown", "mouseup", "click"].forEach(
+      (type) => fireMouseEvent(title, type)
+    );
+  }
+  __name(openAgeFilterDropdown, "openAgeFilterDropdown");
+  function resolveJob51AgeFilterDropdown(ageBlock) {
+    const describedNode = (ageBlock.getAttribute?.("aria-describedby") ? ageBlock : null) || ageBlock.querySelector("[aria-describedby]");
+    const popoverId = describedNode?.getAttribute("aria-describedby")?.trim();
+    if (popoverId) {
+      const popover = document.getElementById(popoverId);
+      if (popover) {
+        return popover;
+      }
+    }
+    const poppers = Array.from(document.querySelectorAll(".base-select-popper"));
+    return poppers.find((node) => {
+      const text = (node.textContent || "").replace(/\s+/g, "").trim();
+      return isElementVisible(node) && (text.includes("22\u5C81\u53CA\u4EE5\u4E0B") || text.includes("45\u5C81\u53CA\u4EE5\u4E0A") || Boolean(
+        node.querySelector(
+          'input[placeholder="\u6700\u4F4E"], input[placeholder="\u6700\u9AD8"]'
+        )
+      ));
+    }) || null;
+  }
+  __name(resolveJob51AgeFilterDropdown, "resolveJob51AgeFilterDropdown");
+  function resolveAgeSelectBox(ageBlock) {
+    return getCurrentSourceKey() === SOURCE_KEYS.JOB51 ? resolveJob51AgeFilterDropdown(ageBlock) : ageBlock.querySelector(".base-input-block__select_box");
+  }
+  __name(resolveAgeSelectBox, "resolveAgeSelectBox");
+  async function waitForAgeFilterDropdown(ageBlock, { timeoutMs = 4e3 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const selectBox = resolveAgeSelectBox(ageBlock);
+      if (selectBox && isElementVisible(selectBox)) {
+        return selectBox;
+      }
+      openAgeFilterDropdown(ageBlock);
+      await new Promise((resolve) => setTimeout(resolve, 120));
+    }
+    const finalSelectBox = resolveAgeSelectBox(ageBlock);
+    return finalSelectBox && isElementVisible(finalSelectBox) ? finalSelectBox : null;
+  }
+  __name(waitForAgeFilterDropdown, "waitForAgeFilterDropdown");
+  async function ensureJob51AgeCustomRangeInputs(selectBox, { timeoutMs = 2e3 } = {}) {
+    if (getCurrentSourceKey() !== SOURCE_KEYS.JOB51) {
+      return selectBox;
+    }
+    if (selectBox.querySelector('input[placeholder="\u6700\u4F4E"]') && selectBox.querySelector('input[placeholder="\u6700\u9AD8"]')) {
+      return selectBox;
+    }
+    const customButton = Array.from(selectBox.querySelectorAll("button")).find(
+      (button) => (button.textContent || "").replace(/\s+/g, "").trim() === "\u81EA\u5B9A\u4E49"
+    );
+    if (!customButton) {
+      return selectBox;
+    }
+    activateElement(customButton);
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (selectBox.querySelector('input[placeholder="\u6700\u4F4E"]') && selectBox.querySelector('input[placeholder="\u6700\u9AD8"]')) {
+        return selectBox;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 120));
+    }
+    return selectBox;
+  }
+  __name(ensureJob51AgeCustomRangeInputs, "ensureJob51AgeCustomRangeInputs");
+  function resolveAgeFilterActions(selectBox) {
+    const minInput = selectBox.querySelector('input[placeholder="\u6700\u4F4E"]');
+    const maxInput = selectBox.querySelector('input[placeholder="\u6700\u9AD8"]');
+    const buttons = Array.from(selectBox.querySelectorAll("button"));
+    const confirmButton = buttons.find((button) => {
+      const text = (button.textContent || "").replace(/\s+/g, "").trim();
+      return text === "\u786E\u5B9A" || text === "\u78BA\u5B9A";
+    });
+    const cancelButton = buttons.find((button) => {
+      const text = (button.textContent || "").replace(/\s+/g, "").trim();
+      return text === "\u53D6\u6D88";
+    });
+    return { minInput, maxInput, confirmButton, cancelButton };
+  }
+  __name(resolveAgeFilterActions, "resolveAgeFilterActions");
+  async function applyJob51AgeCustomRangeViaVue(confirmButton, { minAge, maxAge } = {}) {
+    if (getCurrentSourceKey() !== SOURCE_KEYS.JOB51 || !confirmButton) {
+      return false;
+    }
+    const customRangeVm = findVueParentByName(
+      confirmButton,
+      "BaseSelectCustomRange"
+    );
+    if (!customRangeVm || typeof customRangeVm.onClickOk !== "function") {
+      return false;
+    }
+    try {
+      if (!customRangeVm.form || typeof customRangeVm.form !== "object") {
+        customRangeVm.form = {};
+      }
+      customRangeVm.form.leftValue = typeof minAge === "number" ? minAge : null;
+      customRangeVm.form.rightValue = typeof maxAge === "number" ? maxAge : null;
+      await Promise.resolve(customRangeVm.onClickOk());
+      return true;
+    } catch (error) {
+      console.warn(
+        "\u{1F3AF} [Auto Age] Failed to apply 51job age filter via Vue custom-range handler:",
+        error
+      );
+      return false;
+    }
+  }
+  __name(applyJob51AgeCustomRangeViaVue, "applyJob51AgeCustomRangeViaVue");
+  function normalizeAgeRequestValue(value) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+      const parsed = Number.parseInt(trimmed, 10);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+  }
+  __name(normalizeAgeRequestValue, "normalizeAgeRequestValue");
+  function hasMatchingJob51AgeSearchRequest(minAge, maxAge) {
+    const request = apiSnapshot.job51LastSearchRequest;
+    if (!request || typeof request !== "object") {
+      return false;
+    }
+    return normalizeAgeRequestValue(request.age_from) === normalizeAgeRequestValue(minAge) && normalizeAgeRequestValue(request.age_to) === normalizeAgeRequestValue(maxAge);
+  }
+  __name(hasMatchingJob51AgeSearchRequest, "hasMatchingJob51AgeSearchRequest");
+  async function waitForJob51AgeFilterRefresh(previousLastSearchAt, { minAge, maxAge, timeoutMs = 5e3 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const hasFreshSearch = typeof apiSnapshot.lastSearchAt === "string" && apiSnapshot.lastSearchAt.length > 0 && apiSnapshot.lastSearchAt !== previousLastSearchAt;
+      if (hasFreshSearch && hasMatchingJob51AgeSearchRequest(minAge, maxAge)) {
+        return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 120));
+    }
+    return false;
+  }
+  __name(waitForJob51AgeFilterRefresh, "waitForJob51AgeFilterRefresh");
+  async function autoApplyAgeFilterFromUrl() {
+    const sourceKey = getCurrentSourceKey();
+    const range = getCurrentAgeRange();
+    if (!range.enabled) {
+      setAutoAgeAttributes("skipped");
+      return;
+    }
+    const minAge = range.minAge;
+    const maxAge = range.maxAge;
+    if (typeof minAge === "number" && typeof maxAge === "number" && minAge > maxAge) {
+      setAutoAgeAttributes("failed", minAge, maxAge);
+      console.warn("\u{1F3AF} [Auto Age] Invalid age range (minAge > maxAge):", {
+        minAge,
+        maxAge
+      });
+      return;
+    }
+    if (sourceKey === SOURCE_KEYS.JOB51 && (typeof minAge !== "number" || typeof maxAge !== "number")) {
+      setAutoAgeAttributes("failed", minAge, maxAge);
+      console.warn(
+        "\u{1F3AF} [Auto Age] 51job native age filter requires both min and max ages.",
+        { minAge, maxAge }
+      );
+      return;
+    }
+    const ageBlock = findAgeFilterBlock();
+    if (!ageBlock) {
+      if (sourceKey === SOURCE_KEYS.JOB51) {
+        setAutoAgeAttributes("failed", minAge, maxAge);
+        console.warn(
+          "\u{1F3AF} [Auto Age] 51job age filter control not found."
+        );
+        return;
+      }
+      setAutoAgeAttributes("failed", minAge, maxAge);
+      console.warn(
+        "\u{1F3AF} [Auto Age] Age filter control not found; skipping native age filter apply."
+      );
+      return;
+    }
+    const selectBox = await waitForAgeFilterDropdown(ageBlock, {
+      timeoutMs: 5e3
+    });
+    if (!selectBox) {
+      if (sourceKey === SOURCE_KEYS.JOB51) {
+        setAutoAgeAttributes("failed", minAge, maxAge);
+        console.warn(
+          "\u{1F3AF} [Auto Age] 51job age filter dropdown did not open."
+        );
+        return;
+      }
+      setAutoAgeAttributes("failed", minAge, maxAge);
+      console.warn("\u{1F3AF} [Auto Age] Failed to open age filter dropdown.");
+      return;
+    }
+    if (sourceKey === SOURCE_KEYS.JOB51) {
+      await ensureJob51AgeCustomRangeInputs(selectBox, {
+        timeoutMs: 2500
+      });
+    }
+    const { minInput, maxInput, confirmButton, cancelButton } = resolveAgeFilterActions(selectBox);
+    if (!minInput || !maxInput || !confirmButton) {
+      if (sourceKey === SOURCE_KEYS.JOB51) {
+        setAutoAgeAttributes("failed", minAge, maxAge);
+        if (cancelButton) {
+          activateElement(cancelButton);
+        }
+        console.warn(
+          "\u{1F3AF} [Auto Age] 51job age filter inputs/buttons not found."
+        );
+        return;
+      }
+      setAutoAgeAttributes("failed", minAge, maxAge);
+      if (cancelButton) {
+        activateElement(cancelButton);
+      }
+      console.warn(
+        "\u{1F3AF} [Auto Age] Age filter inputs/buttons not found; skipping native age filter apply."
+      );
+      return;
+    }
+    setInputValue(minInput, typeof minAge === "number" ? String(minAge) : "");
+    setInputValue(maxInput, typeof maxAge === "number" ? String(maxAge) : "");
+    const previousLastSearchAt = apiSnapshot.lastSearchAt;
+    const appliedViaVue = sourceKey === SOURCE_KEYS.JOB51 ? await applyJob51AgeCustomRangeViaVue(confirmButton, {
+      minAge,
+      maxAge
+    }) : false;
+    if (!appliedViaVue) {
+      activateElement(confirmButton);
+    }
+    try {
+      if (sourceKey === SOURCE_KEYS.JOB51) {
+        const refreshed = await waitForJob51AgeFilterRefresh(previousLastSearchAt, {
+          minAge,
+          maxAge,
+          timeoutMs: 5e3
+        });
+        if (!refreshed) {
+          setAutoAgeAttributes("failed", minAge, maxAge);
+          console.warn(
+            "\u{1F3AF} [Auto Age] Applied 51job age filter, but no filtered search refresh was observed.",
+            { minAge, maxAge }
+          );
+          return;
+        }
+      } else {
+        await waitForExtractionData({ timeoutMs: 15e3 });
+      }
+    } catch (error) {
+      console.warn(
+        "\u{1F3AF} [Auto Age] Applied age filter, but waiting for results timed out:",
+        error
+      );
+    }
+    setAutoAgeAttributes("done", minAge, maxAge);
+  }
+  __name(autoApplyAgeFilterFromUrl, "autoApplyAgeFilterFromUrl");
+  async function autoSelectLocation() {
+    const params = new URLSearchParams(window.location.search || "");
+    const locationRaw = (params.get(AUTO_LOCATION_PARAM) || "").trim();
+    const parsedLocations = parseAutoLocationValues(locationRaw);
+    if (parsedLocations.length === 0) {
+      setAutoLocationAttributes("skipped", "");
+      return;
+    }
+    console.log("\u{1F3AF} [Auto Location] Selecting locations:", parsedLocations);
+    let modal = document.querySelector(SELECTORS.areaModal);
+    if (!isElementVisible(modal)) {
+      let trigger;
+      try {
+        trigger = await waitForAreaTrigger({});
+      } catch {
+        if (canSkipAutoLocationForSeekPage()) {
+          setAutoLocationAttributes("skipped", locationRaw);
+          console.warn(
+            "\u{1F3AF} [Auto Location] Trigger not found; skipping on SEEK recommended page"
+          );
+        } else {
+          setAutoLocationAttributes("failed", locationRaw);
+          console.warn("\u{1F3AF} [Auto Location] Trigger not found");
+        }
+        return;
+      }
+      trigger.click();
+      try {
+        modal = await waitForAreaModal({});
+      } catch (error) {
+        if (canSkipAutoLocationForSeekPage()) {
+          setAutoLocationAttributes("skipped", locationRaw);
+          console.warn(
+            "\u{1F3AF} [Auto Location] Area selector not ready; skipping on SEEK recommended page:",
+            error
+          );
+        } else {
+          setAutoLocationAttributes("failed", locationRaw);
+          console.warn("\u{1F3AF} [Auto Location] Area selector not ready:", error);
+        }
+        return;
+      }
+    }
+    const provinceBlock = modal.querySelector(SELECTORS.areaProvinceBlock);
+    const confirmBtn = asHTMLElement(
+      modal.querySelector(SELECTORS.areaConfirmBtn)
+    );
+    const cancelBtn = asHTMLElement(modal.querySelector(SELECTORS.areaCancelBtn));
+    if (!provinceBlock || !confirmBtn || !cancelBtn) {
+      if (canSkipAutoLocationForSeekPage()) {
+        setAutoLocationAttributes("skipped", locationRaw);
+        console.warn(
+          "\u{1F3AF} [Auto Location] Missing modal controls; skipping on SEEK recommended page"
+        );
+      } else {
+        setAutoLocationAttributes("failed", locationRaw);
+        console.warn("\u{1F3AF} [Auto Location] Missing modal controls");
+      }
+      return;
+    }
+    const locationsToSelect = parsedLocations.filter((location, index) => {
+      const next = parsedLocations[index + 1];
+      return !(next && isProvinceToken(location) && !isProvinceToken(next));
+    });
+    const selectAllDistrictAndConfirm = /* @__PURE__ */ __name(async (loc) => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      const { block: districtBlock } = await waitForAreaItems(
+        SELECTORS.areaDistrictBlock,
+        {
+          itemSelector: SELECTORS.areaDistrictItem,
+          timeoutMs: 5e3
+        }
+      );
+      const districtItems = Array.from(
+        districtBlock.querySelectorAll(SELECTORS.areaDistrictItem)
+      );
+      const selectAllDistrict = findAreaItemByText(districtBlock, `\u5168${loc}`) || asHTMLElement(
+        districtItems.find((item) => getAreaItemText(item).startsWith("\u5168")) || null
+      );
+      if (!selectAllDistrict) return false;
+      selectAllDistrict.click();
+      return true;
+    }, "selectAllDistrictAndConfirm");
+    const tryCityFlow = /* @__PURE__ */ __name(async (loc) => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      const { block: cityBlock } = await waitForAreaItems(
+        SELECTORS.areaCityBlock,
+        {
+          itemSelector: SELECTORS.areaItem,
+          timeoutMs: 5e3
+        }
+      );
+      const cityMatch = findAreaItemByText(cityBlock, loc);
+      if (!cityMatch) return false;
+      cityMatch.click();
+      if (cityMatch.textContent.trim().startsWith("\u5168")) {
+        return true;
+      }
+      return await selectAllDistrictAndConfirm(loc);
+    }, "tryCityFlow");
+    const successLocations = [];
+    const failedLocations = [];
+    for (const location of locationsToSelect) {
+      let found = false;
+      const provinceMatch = findAreaItemByText(provinceBlock, location);
+      if (provinceMatch) {
+        provinceMatch.click();
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        try {
+          const { block: cityBlock } = await waitForAreaItems(
+            SELECTORS.areaCityBlock,
+            {
+              itemSelector: SELECTORS.areaItem,
+              timeoutMs: 5e3
+            }
+          );
+          const cityItems = Array.from(
+            cityBlock.querySelectorAll(SELECTORS.areaItem)
+          );
+          const selectAllCity = findAreaItemByText(cityBlock, `\u5168${location}`) || findAreaItemByText(cityBlock, location) || asHTMLElement(
+            cityItems.find((item) => getAreaItemText(item).startsWith("\u5168")) || null
+          );
+          if (selectAllCity) {
+            selectAllCity.click();
+            if (selectAllCity.textContent.trim().startsWith("\u5168")) {
+              found = true;
+            } else if (await selectAllDistrictAndConfirm(location)) {
+              found = true;
+            }
+          }
+        } catch {
+        }
+      }
+      if (!found) {
+        const hotCities = findAreaItemByText(provinceBlock, "\u70ED\u95E8\u57CE\u5E02");
+        if (hotCities) {
+          hotCities.click();
+          try {
+            if (await tryCityFlow(location)) {
+              found = true;
+            }
+          } catch {
+          }
+        }
+      }
+      if (!found) {
+        const provinceItems = Array.from(
+          provinceBlock.querySelectorAll(SELECTORS.areaItem)
+        );
+        for (const province of provinceItems) {
+          const hotCities = findAreaItemByText(provinceBlock, "\u70ED\u95E8\u57CE\u5E02");
+          if (hotCities && province === hotCities) continue;
+          const provinceEl = asHTMLElement(province);
+          if (!provinceEl) continue;
+          provinceEl.click();
+          try {
+            if (await tryCityFlow(location)) {
+              found = true;
+              break;
+            }
+          } catch {
+          }
+        }
+      }
+      if (found) {
+        successLocations.push(location);
+      } else {
+        failedLocations.push(location);
+        console.warn("\u{1F3AF} [Auto Location] Location not found:", location);
+      }
+    }
+    if (successLocations.length > 0) {
+      confirmBtn.click();
+      setAutoLocationAttributes("done", successLocations.join(","));
+    } else {
+      cancelBtn.click();
+      if (canSkipAutoLocationForSeekPage()) {
+        setAutoLocationAttributes("skipped", locationRaw);
+      } else {
+        setAutoLocationAttributes("failed", locationRaw);
+      }
+    }
+  }
+  __name(autoSelectLocation, "autoSelectLocation");
+  async function autoSearchFromUrl() {
+    const params = new URLSearchParams(window.location.search || "");
+    const urlKeywordMode = params.get(AUTO_KEYWORD_MODE_PARAM);
+    const keywordMode = normalizeKeywordMode(
+      urlKeywordMode || await getKeywordMode()
+    );
+    let keyword = normalizeKeyword(params.get(AUTO_SEARCH_PARAM) || "");
+    if (keyword && keywordMode !== KEYWORD_MODE_SPACED) {
+      keyword = keyword.replace(/\s+/g, "");
+    }
+    if (!keyword) {
+      setAutoSearchAttributes("skipped", "");
+      return;
+    }
+    let input;
+    let button;
+    try {
+      ({ input, button } = await waitForSearchElements());
+    } catch (error) {
+      console.warn("\u{1F3AF} [Auto Search] Search controls not ready:", error);
+      setAutoSearchAttributes("skipped", keyword);
+      return;
+    }
+    let currentValue = normalizeKeyword(input.value || "");
+    if (keywordMode !== KEYWORD_MODE_SPACED) {
+      currentValue = currentValue.replace(/\s+/g, "");
+    }
+    const shouldForceJob51Search = getCurrentSourceKey() === SOURCE_KEYS.JOB51 && currentValue === keyword && !hasJob51SearchSnapshot() && isJob51EmptySearchPromptVisible();
+    if (currentValue === keyword && !shouldForceJob51Search) {
+      setAutoSearchAttributes("skipped", keyword);
+      return;
+    }
+    console.log(
+      "\u{1F3AF} [Auto Search] Searching for:",
+      keyword,
+      `(mode=${keywordMode})`
+    );
+    setInputValue(input, keyword);
+    button.click();
+    setAutoSearchAttributes("done", keyword);
+    try {
+      const count = await waitForExtractionData({});
+      console.log("\u{1F3AF} [Auto Search] Done, found", count, "results");
+    } catch (error) {
+      console.warn(
+        "\u{1F3AF} [Auto Search] Search triggered, waiting for results timed out:",
+        error
+      );
+    }
+  }
+  __name(autoSearchFromUrl, "autoSearchFromUrl");
+  async function runAutoExportIfEnabled() {
+    if (autoExportTriggered) return;
+    const config = getAutoExportConfig();
+    if (!config.enabled) return;
+    autoExportTriggered = true;
+    try {
+      await waitForExtractionData({});
+      const resumes = extractResumes();
+      if (config.logStructured) {
+        console.log("\u{1F3AF} [Auto Export] Extracted resumes", {
+          count: resumes.length,
+          resumes
+        });
+      }
+      try {
+        document.documentElement.setAttribute("data-tr-auto-export", "done");
+        document.documentElement.setAttribute(
+          "data-tr-auto-export-count",
+          String(resumes.length)
+        );
+      } catch {
+      }
+      let rawPayload = null;
+      if (config.logRaw || config.downloadRawJson || config.downloadMarkdown || config.rawIncludePage) {
+        rawPayload = extractResumesRaw({ includePage: config.rawIncludePage });
+        if (config.logRaw) {
+          console.log("\u{1F3AF} [Auto Export] Raw resumes", rawPayload);
+        }
+        if (config.downloadRawJson) {
+          const timestamp = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+          const filename = `resumes_raw_${timestamp}_${makeRandomId()}.json`;
+          await downloadFile(
+            JSON.stringify(rawPayload, null, 2),
+            filename,
+            "application/json",
+            config.saveAs
+          );
+          console.log("\u{1F3AF} [Auto Export] Raw JSON download triggered:", filename);
+        }
+        if (config.downloadMarkdown) {
+          const markdown = rawToMarkdown(rawPayload);
+          const timestamp = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+          const filename = `resumes_md_${timestamp}_${makeRandomId()}.md`;
+          await downloadFile(markdown, filename, "text/markdown", config.saveAs);
+          console.log("\u{1F3AF} [Auto Export] Markdown download triggered:", filename);
+        }
+      }
+      if (config.downloadCsv) {
+        const csv = resumesToCSV(resumes);
+        const timestamp = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+        const filename = `resumes_${timestamp}_${makeRandomId()}.csv`;
+        await downloadFile(csv, filename, "text/csv", config.saveAs);
+        console.log("\u{1F3AF} [Auto Export] CSV download triggered:", filename);
+      }
+      if (config.downloadJson) {
+        const metadata = buildExportMetadata(resumes);
+        const payload = { metadata, data: resumes };
+        const json = JSON.stringify(payload, null, 2);
+        const filename = buildExportFilename();
+        await downloadFile(json, filename, "application/json", config.saveAs);
+        console.log("\u{1F3AF} [Auto Export] JSON download triggered:", filename);
+      }
+    } catch (error) {
+      console.warn("\u{1F3AF} [Auto Export] Failed:", error);
+    }
+  }
+  __name(runAutoExportIfEnabled, "runAutoExportIfEnabled");
+  async function syncCurrentPageToServer(resumesOverride) {
+    let resumes = Array.isArray(resumesOverride) ? resumesOverride : extractResumes();
+    const shouldEnrichFromCurrentPage = !Array.isArray(resumesOverride);
+    if (shouldEnrichFromCurrentPage && getCurrentSourceKey() === SOURCE_KEYS.JOB51 && !isJob51DetailPage() && resumes.length > 0) {
+      resumes = await enrich51JobSearchResumesWithDetail(resumes);
+    }
+    if (shouldEnrichFromCurrentPage && getCurrentSourceKey() === SOURCE_KEYS.JOB5156 && !isJob5156DetailPage() && resumes.length > 0) {
+      resumes = await enrichJob5156SearchResumesWithDetail(resumes);
+    }
+    if (shouldEnrichFromCurrentPage && getCurrentSourceKey() === SOURCE_KEYS.SEEK && !isSeekProfileMode() && resumes.length > 0) {
+      resumes = await enrichSeekRecommendedResumesWithDetail(resumes);
+    }
+    const metadata = buildSubmitMetadata({
+      seekCaptureMode: Array.isArray(resumesOverride) && window.location.pathname.includes("/candidates/recommended") ? "graphql-list" : void 0
+    });
+    return chrome.runtime.sendMessage({
+      action: "syncToServer",
+      metadata,
+      resumes
+    });
+  }
+  __name(syncCurrentPageToServer, "syncCurrentPageToServer");
+  function queueJob51DetailBackfill(resumes, context = {}) {
+    if (!Array.isArray(resumes) || resumes.length === 0) {
+      return Promise.resolve(null);
+    }
+    const runId = typeof context.runId === "number" && Number.isFinite(context.runId) ? context.runId : null;
+    const isCancelled = /* @__PURE__ */ __name(() => runId !== null && runId !== job51DetailBackfillRunId, "isCancelled");
+    const task = /* @__PURE__ */ __name(async () => {
+      const detailFetchDelayMs = resolveCurrentJob51DetailFetchDelayMs();
+      if (isCancelled()) {
+        console.log("51job detail backfill skipped", {
+          count: resumes.length,
+          currentPage: context.currentPage,
+          totalPages: context.totalPages
+        });
+        return null;
+      }
+      console.log("51job detail backfill queued", {
+        count: resumes.length,
+        currentPage: context.currentPage,
+        totalPages: context.totalPages,
+        delayMs: detailFetchDelayMs,
+        concurrency: JOB51_DETAIL_FETCH_CONCURRENCY
+      });
+      const enrichedResumes = await enrich51JobSearchResumesWithDetail(resumes, {
+        interBatchDelayMs: detailFetchDelayMs,
+        shouldContinue: /* @__PURE__ */ __name(() => !isCancelled(), "shouldContinue")
+      });
+      if (!Array.isArray(enrichedResumes) || enrichedResumes.length === 0) {
+        return null;
+      }
+      if (isCancelled()) {
+        console.log("51job detail backfill cancelled", {
+          count: resumes.length,
+          currentPage: context.currentPage,
+          totalPages: context.totalPages
+        });
+        return null;
+      }
+      const response = await syncCurrentPageToServer(enrichedResumes);
+      if (!response?.success) {
+        throw response?.error || response || "51job detail backfill failed";
+      }
+      console.log("51job detail backfill synced", {
+        submitted: typeof response.submitted === "number" ? response.submitted : enrichedResumes.length,
+        inserted: typeof response.inserted === "number" ? response.inserted : 0,
+        updated: typeof response.updated === "number" ? response.updated : 0,
+        currentPage: context.currentPage,
+        totalPages: context.totalPages
+      });
+      return response;
+    }, "task");
+    const scheduled = job51DetailBackfillChain.catch(() => null).then(task);
+    job51DetailBackfillChain = scheduled.catch((error) => {
+      console.warn("51job detail backfill failed:", error);
+      return null;
+    });
+    return scheduled;
+  }
+  __name(queueJob51DetailBackfill, "queueJob51DetailBackfill");
+  function resolveAutoSyncErrorStatus(errorLike) {
+    const rawError = typeof errorLike === "string" ? errorLike : errorLike?.error || errorLike?.message || String(errorLike || "");
+    const message = String(rawError).trim() || "Unknown error";
+    const lowerMessage = message.toLowerCase();
+    if (message.includes("\u641C\u7D22\u8BBF\u95EE\u592A\u5FEB") || message.includes("60\u5206\u949F\u540E\u518D\u8BD5") || message === JOB51_RATE_LIMIT_ERROR_MESSAGE) {
+      return {
+        message: "51job \u5DF2\u89E6\u53D1\u8BBF\u95EE\u9650\u5236",
+        hint: "\u6269\u5C55\u5DF2\u505C\u6B62\u81EA\u52A8\u7FFB\u9875\u3002\u81F3\u5C11\u7B49\u5F8560\u5206\u949F\u540E\u91CD\u8BD5\uFF0C\u5E76\u4FDD\u6301\u5C0F\u9875\u6570\u3001\u5C0F\u6279\u91CF\u3002"
+      };
+    }
+    if (message === "Server token not configured") {
+      return {
+        message: "Token \u672A\u914D\u7F6E",
+        hint: "\u70B9\u51FB\u6B64\u63D0\u793A\u6253\u5F00\u6269\u5C55\u8BBE\u7F6E\u5E76\u586B\u5199 Token"
+      };
+    }
+    if (message.includes("401") || lowerMessage.includes("unauthorized")) {
+      return {
+        message: "\u8BA4\u8BC1\u5931\u8D25 - Token \u65E0\u6548\u6216\u5DF2\u8FC7\u671F",
+        hint: "\u70B9\u51FB\u6B64\u63D0\u793A\u6253\u5F00\u6269\u5C55\u8BBE\u7F6E\u5E76\u66F4\u65B0 Token"
+      };
+    }
+    if (message === "Server URL not configured") {
+      return {
+        message: "\u670D\u52A1\u5668\u5730\u5740\u672A\u914D\u7F6E",
+        hint: "\u70B9\u51FB\u6B64\u63D0\u793A\u6253\u5F00\u6269\u5C55\u8BBE\u7F6E\u5E76\u586B\u5199\u670D\u52A1\u5668\u5730\u5740"
+      };
+    }
+    if (lowerMessage.includes("failed to fetch") || lowerMessage.includes("networkerror") || lowerMessage.includes("network error") || lowerMessage.includes("err_network") || lowerMessage.includes("load failed") || lowerMessage.includes("connection")) {
+      return {
+        message: "\u65E0\u6CD5\u8FDE\u63A5\u670D\u52A1\u5668",
+        hint: "\u8BF7\u68C0\u67E5\u7F51\u7EDC\u8FDE\u63A5\u548C\u670D\u52A1\u5668\u72B6\u6001\u540E\u91CD\u8BD5"
+      };
+    }
+    return {
+      message: `\u540C\u6B65\u5931\u8D25: ${message}`,
+      hint: "\u70B9\u51FB\u6B64\u63D0\u793A\u6253\u5F00\u6269\u5C55\u8BBE\u7F6E\u6392\u67E5\u95EE\u9898"
+    };
+  }
+  __name(resolveAutoSyncErrorStatus, "resolveAutoSyncErrorStatus");
+  function resolveAutoSyncStopReason(errorLike) {
+    const rawError = typeof errorLike === "string" ? errorLike : errorLike?.error || errorLike?.message || String(errorLike || "");
+    const message = String(rawError).trim();
+    if (message.includes("\u641C\u7D22\u8BBF\u95EE\u592A\u5FEB") || message.includes("60\u5206\u949F\u540E\u518D\u8BD5") || message === JOB51_RATE_LIMIT_ERROR_MESSAGE) {
+      return "job51-rate-limited";
+    }
+    return "failed";
+  }
+  __name(resolveAutoSyncStopReason, "resolveAutoSyncStopReason");
+  async function runAutoSyncIfEnabled() {
+    if (autoSyncTriggered) return;
+    const enabled = getAutoSyncEnabled();
+    if (!enabled) {
+      setAutoSyncAttributes("skipped");
+      setSeekAutoSyncWindowAttributes(null);
+      setSeekAutoSyncSelectionAttributes(null);
+      return;
+    }
+    const { limit, maxPages } = await getCollectionLimits();
+    const isJob51Source = getCurrentSourceKey() === SOURCE_KEYS.JOB51;
+    autoSyncTriggered = true;
+    autoSyncCancelled = false;
+    setAutoSyncAttributes("running", 0, 0);
+    setSeekAutoSyncWindowAttributes(null);
+    setSeekAutoSyncSelectionAttributes(null);
+    try {
+      document.documentElement.setAttribute(
+        "data-tr-auto-sync-limit",
+        String(limit)
+      );
+      document.documentElement.setAttribute(
+        "data-tr-auto-sync-max-pages",
+        String(maxPages)
+      );
+    } catch {
+    }
+    SyncStatusWidget.show({
+      state: "progress",
+      message: "\u6B63\u5728\u540C\u6B65\u7B80\u5386\u5230\u670D\u52A1\u5668...",
+      hint: `${isJob51Source ? "51job \u4FDD\u5B88\u6A21\u5F0F \xB7 " : ""}\u6570\u91CF\u4E0A\u9650: ${limit > 0 ? limit : "\u4E0D\u9650"} \xB7 \u9875\u6570\u4E0A\u9650: ${maxPages > 0 ? maxPages : "\u4E0D\u9650"}`
+    });
+    try {
+      let totalSubmitted = 0;
+      let totalInserted = 0;
+      let totalUpdated = 0;
+      let pagesVisited = 0;
+      let lastSelectedCount = null;
+      let stopReason = "completed";
+      let seekStartPage = null;
+      while (true) {
+        if (autoSyncCancelled) {
+          stopReason = "cancelled";
+          break;
+        }
+        ensureJob51PageAllowed();
+        const paginationBefore = getPaginationInfo();
+        const currentPage = paginationBefore.currentPage;
+        const totalPages = paginationBefore.totalPages;
+        const isSeekListPage = getCurrentSourceKey() === SOURCE_KEYS.SEEK && !isSeekProfileMode();
+        if (isSeekListPage && seekStartPage === null) {
+          seekStartPage = currentPage;
+        }
+        await waitForExtractionData({});
+        ensureJob51PageAllowed();
+        pagesVisited += 1;
+        const seekPageWindow = isSeekListPage ? resolveSeekAutoSyncPageWindow({
+          startPage: seekStartPage || currentPage,
+          limit,
+          maxPages,
+          requestedPageSize: getSeekRequestedPageSize(),
+          currentPageCandidateCount: getSeekCurrentCandidateCount()
+        }) : null;
+        setSeekAutoSyncWindowAttributes(seekPageWindow);
+        const pageSelection = isSeekListPage ? resolveSeekAutoSyncCurrentPageSelection({
+          limit,
+          totalSubmitted,
+          currentPageResumeCount: getSeekCurrentCandidateCount()
+        }) : {
+          remainingCapacity: limit > 0 ? Math.max(limit - totalSubmitted, 0) : null,
+          selectedCount: null,
+          hitLimitWithinPage: false,
+          limitAlreadyReached: limit > 0 ? Math.max(limit - totalSubmitted, 0) <= 0 : false
+        };
+        setSeekAutoSyncSelectionAttributes(isSeekListPage ? pageSelection : null);
+        if (isSeekListPage && pageSelection.limitAlreadyReached || !isSeekListPage && limit > 0 && pageSelection.limitAlreadyReached) {
+          stopReason = "limit-reached";
+          break;
+        }
+        let resumes = extractResumes();
+        const hitLimitWithinPage = isSeekListPage ? pageSelection.hitLimitWithinPage : limit > 0 && typeof pageSelection.remainingCapacity === "number" && resumes.length > pageSelection.remainingCapacity;
+        if (isSeekListPage && typeof pageSelection.selectedCount === "number") {
+          resumes = resumes.slice(0, pageSelection.selectedCount);
+        } else if (limit > 0 && typeof pageSelection.remainingCapacity === "number" && resumes.length > pageSelection.remainingCapacity) {
+          resumes = resumes.slice(0, pageSelection.remainingCapacity);
+        }
+        lastSelectedCount = isSeekListPage ? resumes.length : null;
+        if (getCurrentSourceKey() === SOURCE_KEYS.JOB5156 && !isJob5156DetailPage() && resumes.length > 0) {
+          resumes = await enrichJob5156SearchResumesWithDetail(resumes);
+        }
+        if (getCurrentSourceKey() === SOURCE_KEYS.SEEK && !isSeekProfileMode() && resumes.length > 0) {
+          resumes = await enrichSeekRecommendedResumesWithDetail(resumes);
+        }
+        if (resumes.length <= 0) {
+          const ageRange = getCurrentAgeRange();
+          const ageHint = ageRange.enabled ? ` \xB7 \u5E74\u9F84: ${typeof ageRange.minAge === "number" ? ageRange.minAge : "\u2014"}-${typeof ageRange.maxAge === "number" ? ageRange.maxAge : "\u2014"}` : "";
+          const progressHint2 = buildAutoSyncProgressHint({
+            limit,
+            totalSubmitted,
+            selectedCount: isSeekListPage ? resumes.length : null,
+            ageHint
+          });
+          SyncStatusWidget.show({
+            state: "progress",
+            message: `\u7B2C ${currentPage}/${Math.max(totalPages, currentPage)} \u9875\u65E0\u7B26\u5408\u6761\u4EF6\u7684\u7B80\u5386\uFF0C\u7EE7\u7EED...`,
+            hint: progressHint2
+          });
+          setAutoSyncAttributes("running", totalSubmitted, pagesVisited);
+          if (autoSyncCancelled) {
+            stopReason = "cancelled";
+            break;
+          }
+          if (isSeekListPage && isSeekAutoSyncPageWindowReached(seekPageWindow, currentPage)) {
+            stopReason = "page-window-reached";
+            break;
+          }
+          if (!isSeekListPage && maxPages > 0 && pagesVisited >= maxPages) {
+            stopReason = "max-pages-reached";
+            break;
+          }
+          const paginationAfter2 = getPaginationInfo();
+          if (!paginationAfter2.hasNextPage || paginationAfter2.currentPage >= paginationAfter2.totalPages) {
+            stopReason = "no-next-page";
+            break;
+          }
+          try {
+            await waitForPagination({ timeoutMs: 8e3 });
+          } catch {
+          }
+          const nextPage2 = paginationAfter2.currentPage + 1;
+          try {
+            document.documentElement.setAttribute(
+              "data-tr-auto-sync-next-state",
+              JSON.stringify(getNextPageButtonState())
+            );
+          } catch {
+          }
+          await waitForJob51Cooldown();
+          clearCapturedResultsForNextPage();
+          const moved2 = goToNextPageInternal();
+          if (!moved2) {
+            stopReason = "no-next-page";
+            break;
+          }
+          await waitForPageTransition({
+            expectedPage: nextPage2,
+            timeoutMs: 15e3
+          });
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          continue;
+        }
+        const progressHint = buildAutoSyncProgressHint({
+          limit,
+          totalSubmitted,
+          selectedCount: isSeekListPage ? resumes.length : null
+        });
+        SyncStatusWidget.show({
+          state: "progress",
+          message: `\u6B63\u5728\u540C\u6B65\u7B2C ${currentPage}/${Math.max(totalPages, currentPage)} \u9875 (${resumes.length} \u4EFD)...`,
+          hint: progressHint
+        });
+        const response = await syncCurrentPageToServer(resumes);
+        if (!response?.success) {
+          throw response?.error || response || "Auto sync failed";
+        }
+        const submitted = typeof response.submitted === "number" ? response.submitted : resumes.length;
+        const inserted = typeof response.inserted === "number" ? response.inserted : 0;
+        const updated = typeof response.updated === "number" ? response.updated : 0;
+        totalSubmitted += submitted;
+        totalInserted += inserted;
+        totalUpdated += updated;
+        setAutoSyncAttributes("running", totalSubmitted, pagesVisited);
+        if (getCurrentSourceKey() === SOURCE_KEYS.JOB51 && !isJob51DetailPage() && resumes.length > 0) {
+          const detailBackfillPromise = queueJob51DetailBackfill(resumes, {
+            currentPage,
+            totalPages: Math.max(totalPages, currentPage)
+          });
+          const waitMode = resolveCurrentJob51AutoSyncDetailWaitMode();
+          const shouldWaitForDetails = waitMode === "all" || waitMode === "page1" && currentPage === 1;
+          if (shouldWaitForDetails) {
+            SyncStatusWidget.show({
+              state: "progress",
+              message: `\u6B63\u5728\u8865\u5145\u7B2C ${currentPage}/${Math.max(totalPages, currentPage)} \u9875\u8BE6\u60C5...`,
+              hint: "\u7B49\u5F85 51job \u8BE6\u60C5\u8865\u5145\u540E\u518D\u5B8C\u6210\u672C\u9875\u540C\u6B65"
+            });
+            await detailBackfillPromise;
+          }
+        }
+        if (autoSyncCancelled) {
+          stopReason = "cancelled";
+          break;
+        }
+        if (isSeekListPage && hitLimitWithinPage) {
+          stopReason = "limit-reached";
+          break;
+        }
+        if (isSeekListPage && isSeekAutoSyncPageWindowReached(seekPageWindow, currentPage)) {
+          stopReason = "page-window-reached";
+          break;
+        }
+        if (!isSeekListPage && limit > 0 && totalSubmitted >= limit) {
+          stopReason = "limit-reached";
+          break;
+        }
+        if (!isSeekListPage && maxPages > 0 && pagesVisited >= maxPages) {
+          stopReason = "max-pages-reached";
+          break;
+        }
+        const paginationAfter = getPaginationInfo();
+        if (!paginationAfter.hasNextPage || paginationAfter.currentPage >= paginationAfter.totalPages) {
+          stopReason = "no-next-page";
+          break;
+        }
+        try {
+          await waitForPagination({ timeoutMs: 8e3 });
+        } catch {
+        }
+        const nextPage = paginationAfter.currentPage + 1;
+        try {
+          document.documentElement.setAttribute(
+            "data-tr-auto-sync-next-state",
+            JSON.stringify(getNextPageButtonState())
+          );
+        } catch {
+        }
+        await waitForJob51Cooldown();
+        clearCapturedResultsForNextPage();
+        const moved = goToNextPageInternal();
+        if (!moved) {
+          stopReason = "no-next-page";
+          break;
+        }
+        await waitForPageTransition({ expectedPage: nextPage, timeoutMs: 15e3 });
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+      try {
+        document.documentElement.setAttribute(
+          "data-tr-auto-sync-stop-reason",
+          stopReason
+        );
+      } catch {
+      }
+      persistLatestAutoSyncSummary();
+      if (autoSyncCancelled) {
+        SyncStatusWidget.show({
+          state: "success",
+          message: `\u540C\u6B65\u5DF2\u53D6\u6D88\uFF0C\u5DF2\u540C\u6B65 ${totalSubmitted} \u4EFD\u7B80\u5386`,
+          hint: buildAutoSyncCompletionHint({
+            totalInserted,
+            totalUpdated,
+            pagesVisited,
+            selectedCount: lastSelectedCount
+          }),
+          autoDismiss: true
+        });
+        setAutoSyncAttributes("cancelled", totalSubmitted, pagesVisited);
+        return;
+      }
+      SyncStatusWidget.show({
+        state: "success",
+        message: `\u5DF2\u540C\u6B65 ${totalSubmitted} \u4EFD\u7B80\u5386 (${totalInserted} \u65B0\u589E, ${totalUpdated} \u66F4\u65B0), \u5171 ${pagesVisited} \u9875`,
+        hint: [
+          buildAutoSyncSelectedCountHint({
+            selectedCount: lastSelectedCount,
+            prefix: ""
+          }),
+          isJob51Source ? "51job \u8BE6\u60C5\u8865\u5145\u6B63\u5728\u540E\u53F0\u7EE7\u7EED" : ""
+        ].filter(Boolean).join(" \xB7 "),
+        autoDismiss: true
+      });
+      setAutoSyncAttributes("done", totalSubmitted, pagesVisited);
+    } catch (error) {
+      console.warn("\u{1F3AF} [Auto Sync] Failed:", error);
+      const status = resolveAutoSyncErrorStatus(error);
+      SyncStatusWidget.show({
+        state: "error",
+        message: status.message,
+        hint: status.hint
+      });
+      setAutoSyncAttributes("failed");
+      try {
+        document.documentElement.setAttribute(
+          "data-tr-auto-sync-stop-reason",
+          resolveAutoSyncStopReason(error)
+        );
+      } catch {
+      }
+      persistLatestAutoSyncSummary();
+    }
+  }
+  __name(runAutoSyncIfEnabled, "runAutoSyncIfEnabled");
+  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.action === "extractCurrentPage") {
+      const resumes = extractResumes();
+      const pagination = getPaginationInfo();
+      const metadata = buildSubmitMetadata();
+      sendResponse({
+        success: true,
+        data: resumes,
+        count: resumes.length,
+        pagination,
+        metadata
+      });
+    } else if (request.action === "downloadCSV") {
+      const resumes = extractResumes();
+      const csv = resumesToCSV(resumes);
+      const timestamp = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+      const filename = `resumes_${timestamp}_${makeRandomId()}.csv`;
+      const saveAs = !!request.saveAs;
+      downloadFile(csv, filename, "text/csv", saveAs).then(
+        () => sendResponse({ success: true, count: resumes.length, filename })
+      ).catch((err) => sendResponse({ success: false, error: err.message }));
+      return true;
+    } else if (request.action === "downloadJSON") {
+      const resumes = extractResumes();
+      const metadata = buildExportMetadata(resumes);
+      const payload = { metadata, data: resumes };
+      const json = JSON.stringify(payload, null, 2);
+      const filename = buildExportFilename();
+      const saveAs = !!request.saveAs;
+      downloadFile(json, filename, "application/json", saveAs).then(
+        () => sendResponse({ success: true, count: resumes.length, filename })
+      ).catch((err) => sendResponse({ success: false, error: err.message }));
+      return true;
+    } else if (request.action === "getPaginationInfo") {
+      sendResponse(getPaginationInfo());
+    } else if (request.action === "getRuntimeStatus") {
+      sendResponse({
+        success: true,
+        status: getExternalAccessorStatus()
+      });
+    } else if (request.action === "ping") {
+      sendResponse({ success: true, message: "Content script loaded" });
+    }
+    return true;
+  });
+  function getExtensionVersion() {
+    try {
+      return chrome?.runtime?.getManifest?.().version || SOURCE_KEYS.UNKNOWN;
+    } catch {
+      return SOURCE_KEYS.UNKNOWN;
+    }
+  }
+  __name(getExtensionVersion, "getExtensionVersion");
+  function isLoggedIn() {
+    return !document.querySelector('.login-btn, [href*="login"]');
+  }
+  __name(isLoggedIn, "isLoggedIn");
+  function buildPersistedAutoSyncSummary(status = getExternalAccessorStatus()) {
+    const autoSync = typeof status?.autoSync === "string" ? status.autoSync : "";
+    if (!autoSync || autoSync === "skipped") {
+      return null;
+    }
+    return {
+      autoSync,
+      autoSyncCount: typeof status?.autoSyncCount === "number" ? status.autoSyncCount : 0,
+      autoSyncPages: typeof status?.autoSyncPages === "number" ? status.autoSyncPages : 0,
+      autoSyncTargetPageStart: status?.autoSyncTargetPageStart ?? null,
+      autoSyncTargetPageEnd: status?.autoSyncTargetPageEnd ?? null,
+      autoSyncEffectivePageSize: status?.autoSyncEffectivePageSize ?? null,
+      autoSyncSelectedCount: status?.autoSyncSelectedCount ?? null,
+      autoSyncRemainingCapacity: status?.autoSyncRemainingCapacity ?? null,
+      autoSyncStopReason: status?.autoSyncStopReason ?? null,
+      sourceKey: typeof status?.sourceKey === "string" ? status.sourceKey : getCurrentSourceKey(),
+      sourceUrl: window.location.href,
+      summarySource: "stored",
+      persistedAt: (/* @__PURE__ */ new Date()).toISOString()
+    };
+  }
+  __name(buildPersistedAutoSyncSummary, "buildPersistedAutoSyncSummary");
+  function persistLatestAutoSyncSummary() {
+    try {
+      if (!chrome?.storage?.local?.get || !chrome?.storage?.local?.set) return;
+      const summary = buildPersistedAutoSyncSummary();
+      if (!summary) return;
+      const sourceKey = typeof summary.sourceKey === "string" && summary.sourceKey ? summary.sourceKey : SOURCE_KEYS.UNKNOWN;
+      const fingerprint = JSON.stringify({
+        autoSync: summary.autoSync,
+        autoSyncCount: summary.autoSyncCount,
+        autoSyncPages: summary.autoSyncPages,
+        autoSyncTargetPageStart: summary.autoSyncTargetPageStart,
+        autoSyncTargetPageEnd: summary.autoSyncTargetPageEnd,
+        autoSyncEffectivePageSize: summary.autoSyncEffectivePageSize,
+        autoSyncSelectedCount: summary.autoSyncSelectedCount,
+        autoSyncRemainingCapacity: summary.autoSyncRemainingCapacity,
+        autoSyncStopReason: summary.autoSyncStopReason,
+        sourceKey: summary.sourceKey,
+        sourceUrl: summary.sourceUrl,
+        summarySource: summary.summarySource
+      });
+      if (summary.autoSync === "running" && lastPersistedAutoSyncSummaryFingerprintBySource[sourceKey] === fingerprint) {
+        return;
+      }
+      lastPersistedAutoSyncSummaryFingerprintBySource[sourceKey] = fingerprint;
+      chrome.storage.local.get(
+        { [LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY]: {} },
+        (items) => {
+          const existingSummaries = items?.[LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY];
+          const nextSummaries = existingSummaries && typeof existingSummaries === "object" && !Array.isArray(existingSummaries) ? { ...existingSummaries } : {};
+          nextSummaries[sourceKey] = summary;
+          chrome.storage.local.set({
+            [LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY]: nextSummaries
+          });
+        }
+      );
+    } catch (error) {
+      console.warn(
+        "\u{1F3AF} [Auto Sync] Failed to persist latest auto sync summary:",
+        error
+      );
+    }
+  }
+  __name(persistLatestAutoSyncSummary, "persistLatestAutoSyncSummary");
+  function normalizeSnapshotCollectOptions(options = {}) {
+    const normalizedOptions = typeof options === "object" && options ? options : {};
+    return {
+      limit: normalizeCollectionLimit(normalizedOptions.limit),
+      maxPages: normalizeCollectionLimit(normalizedOptions.maxPages),
+      allowEmpty: !!normalizedOptions.allowEmpty
+    };
+  }
+  __name(normalizeSnapshotCollectOptions, "normalizeSnapshotCollectOptions");
+  async function collectSnapshotPayload(options = {}) {
+    const { limit, maxPages, allowEmpty } = normalizeSnapshotCollectOptions(options);
+    const sourceKey = getCurrentSourceKey();
+    const job51BackfillRunId = sourceKey === SOURCE_KEYS.JOB51 ? job51DetailBackfillRunId + 1 : null;
+    if (sourceKey === SOURCE_KEYS.JOB51) {
+      job51DetailBackfillRunId = job51BackfillRunId;
+      job51DetailBackfillChain = Promise.resolve();
+    }
+    if (sourceKey !== SOURCE_KEYS.JOB5156 && sourceKey !== SOURCE_KEYS.JOB51 && sourceKey !== SOURCE_KEYS.SEEK) {
+      throw new Error(`Unsupported source for snapshot collection: ${sourceKey}`);
+    }
+    let collectedResumes = [];
+    let pagesVisited = 0;
+    let stopReason = "completed";
+    let seekStartPage = null;
+    let lastPageResumeCount = 0;
+    let finalPagination = getPaginationInfo();
+    while (true) {
+      const paginationBefore = getPaginationInfo();
+      const currentPage = paginationBefore.currentPage;
+      const isSeekListPage = sourceKey === SOURCE_KEYS.SEEK && !isSeekProfileMode();
+      if (isSeekListPage && seekStartPage === null) {
+        seekStartPage = currentPage;
+      }
+      await waitForExtractionData({});
+      pagesVisited += 1;
+      const seekPageWindow = isSeekListPage ? resolveSeekAutoSyncPageWindow({
+        startPage: seekStartPage || currentPage,
+        limit,
+        maxPages,
+        requestedPageSize: getSeekRequestedPageSize(),
+        currentPageCandidateCount: getSeekCurrentCandidateCount()
+      }) : null;
+      const pageSelection = isSeekListPage ? resolveSeekAutoSyncCurrentPageSelection({
+        limit,
+        totalSubmitted: collectedResumes.length,
+        currentPageResumeCount: getSeekCurrentCandidateCount()
+      }) : {
+        remainingCapacity: limit > 0 ? Math.max(limit - collectedResumes.length, 0) : null,
+        selectedCount: null,
+        hitLimitWithinPage: false,
+        limitAlreadyReached: limit > 0 ? Math.max(limit - collectedResumes.length, 0) <= 0 : false
+      };
+      if (pageSelection.limitAlreadyReached) {
+        stopReason = "limit-reached";
+        break;
+      }
+      let pageResumes = extractResumes();
+      const hitLimitWithinPage = isSeekListPage ? pageSelection.hitLimitWithinPage : limit > 0 && typeof pageSelection.remainingCapacity === "number" && pageResumes.length > pageSelection.remainingCapacity;
+      if (isSeekListPage && typeof pageSelection.selectedCount === "number") {
+        pageResumes = pageResumes.slice(0, pageSelection.selectedCount);
+      } else if (limit > 0 && typeof pageSelection.remainingCapacity === "number" && pageResumes.length > pageSelection.remainingCapacity) {
+        pageResumes = pageResumes.slice(0, pageSelection.remainingCapacity);
+      }
+      if (sourceKey === SOURCE_KEYS.JOB51 && !isJob51DetailPage() && pageResumes.length > 0) {
+        pageResumes = await enrich51JobSearchResumesWithDetail(pageResumes);
+      }
+      if (sourceKey === SOURCE_KEYS.JOB5156 && !isJob5156DetailPage() && pageResumes.length > 0) {
+        pageResumes = await enrichJob5156SearchResumesWithDetail(pageResumes);
+      }
+      if (sourceKey === SOURCE_KEYS.SEEK && !isSeekProfileMode() && pageResumes.length > 0) {
+        pageResumes = await enrichSeekRecommendedResumesWithDetail(pageResumes);
+      }
+      lastPageResumeCount = pageResumes.length;
+      if (pageResumes.length > 0) {
+        collectedResumes.push(...pageResumes);
+      }
+      finalPagination = getPaginationInfo();
+      if (isSeekListPage && hitLimitWithinPage) {
+        stopReason = "limit-reached";
+        break;
+      }
+      if (isSeekListPage && isSeekAutoSyncPageWindowReached(seekPageWindow, currentPage)) {
+        stopReason = "page-window-reached";
+        break;
+      }
+      if (!isSeekListPage && limit > 0 && collectedResumes.length >= limit) {
+        stopReason = "limit-reached";
+        break;
+      }
+      if (!isSeekListPage && maxPages > 0 && pagesVisited >= maxPages) {
+        stopReason = "max-pages-reached";
+        break;
+      }
+      if (!finalPagination.hasNextPage || finalPagination.currentPage >= finalPagination.totalPages) {
+        stopReason = "no-next-page";
+        break;
+      }
+      try {
+        await waitForPagination({ timeoutMs: 8e3 });
+      } catch {
+      }
+      const nextPage = finalPagination.currentPage + 1;
+      clearCapturedResultsForNextPage();
+      const moved = goToNextPageInternal();
+      if (!moved) {
+        stopReason = "no-next-page";
+        break;
+      }
+      await waitForPageTransition({ expectedPage: nextPage, timeoutMs: 15e3 });
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    if (collectedResumes.length <= 0 && !allowEmpty) {
+      throw new Error(
+        "No resumes extracted. Ensure you are logged in and results are loaded."
+      );
+    }
+    const metadata = buildSubmitMetadata();
+    metadata.generatedAt = (/* @__PURE__ */ new Date()).toISOString();
+    metadata.totalPages = pagesVisited;
+    metadata.totalResumes = collectedResumes.length;
+    return {
+      metadata,
+      resumes: collectedResumes,
+      summary: {
+        sourceKey,
+        sourceHost: metadata.sourceHost,
+        count: collectedResumes.length,
+        pagesVisited,
+        stopReason,
+        lastPageResumeCount,
+        limit: limit > 0 ? limit : null,
+        maxPages: maxPages > 0 ? maxPages : null,
+        pagination: finalPagination
+      }
+    };
+  }
+  __name(collectSnapshotPayload, "collectSnapshotPayload");
+  function getExternalAccessorStatus() {
+    const version = getExtensionVersion();
+    const pagination = getPaginationInfo();
+    const ageRange = getCurrentAgeRange();
+    const sourceKey = getCurrentSourceKey();
+    const apiSnapshotCount = getApiSnapshotCount();
+    const cardCount = sourceKey === SOURCE_KEYS.SEEK ? Math.max(apiSnapshotCount, getSeekCardCount()) : sourceKey === SOURCE_KEYS.JOB51 ? apiSnapshotCount : isJob5156DetailPage() ? isJob5156DetailReady() ? 1 : 0 : document.querySelectorAll(SELECTORS.resumeCard).length;
+    const autoSearch = document.documentElement.getAttribute("data-tr-auto-search") || "";
+    const autoLocation = document.documentElement.getAttribute("data-tr-auto-location") || "";
+    const autoAge = document.documentElement.getAttribute("data-tr-auto-age") || "";
+    const autoExport = document.documentElement.getAttribute("data-tr-auto-export") || "";
+    const autoSync = document.documentElement.getAttribute("data-tr-auto-sync") || "";
+    const autoSyncCountRaw = document.documentElement.getAttribute("data-tr-auto-sync-count") || "";
+    const autoSyncPagesRaw = document.documentElement.getAttribute("data-tr-auto-sync-pages") || "";
+    const autoSyncTargetStartRaw = document.documentElement.getAttribute("data-tr-auto-sync-target-start") || "";
+    const autoSyncTargetEndRaw = document.documentElement.getAttribute("data-tr-auto-sync-target-end") || "";
+    const autoSyncEffectivePageSizeRaw = document.documentElement.getAttribute(
+      "data-tr-auto-sync-effective-page-size"
+    ) || "";
+    const autoSyncSelectedCountRaw = document.documentElement.getAttribute("data-tr-auto-sync-selected-count") || "";
+    const autoSyncRemainingCapacityRaw = document.documentElement.getAttribute(
+      "data-tr-auto-sync-remaining-capacity"
+    ) || "";
+    const autoSyncStopReason = document.documentElement.getAttribute("data-tr-auto-sync-stop-reason") || "";
+    const autoSyncCount = Number.parseInt(autoSyncCountRaw, 10);
+    const autoSyncPages = Number.parseInt(autoSyncPagesRaw, 10);
+    const autoSyncTargetStart = Number.parseInt(autoSyncTargetStartRaw, 10);
+    const autoSyncTargetEnd = Number.parseInt(autoSyncTargetEndRaw, 10);
+    const autoSyncEffectivePageSize = Number.parseInt(
+      autoSyncEffectivePageSizeRaw,
+      10
+    );
+    const autoSyncSelectedCount = Number.parseInt(autoSyncSelectedCountRaw, 10);
+    const autoSyncRemainingCapacity = Number.parseInt(
+      autoSyncRemainingCapacityRaw,
+      10
+    );
+    return {
+      extensionLoaded: true,
+      extensionVersion: version,
+      sourceKey,
+      apiSnapshotCount,
+      domReady: isExtractionReady(),
+      loggedIn: isLoggedIn(),
+      ageRange: ageRange.enabled ? {
+        minAge: typeof ageRange.minAge === "number" ? ageRange.minAge : null,
+        maxAge: typeof ageRange.maxAge === "number" ? ageRange.maxAge : null
+      } : null,
+      cardCount,
+      autoSearch,
+      autoLocation,
+      autoAge,
+      autoExport,
+      autoSync,
+      autoSyncCount: Number.isFinite(autoSyncCount) ? autoSyncCount : 0,
+      autoSyncPages: Number.isFinite(autoSyncPages) ? autoSyncPages : 0,
+      autoSyncTargetPageStart: Number.isFinite(autoSyncTargetStart) ? autoSyncTargetStart : null,
+      autoSyncTargetPageEnd: Number.isFinite(autoSyncTargetEnd) ? autoSyncTargetEnd : null,
+      autoSyncEffectivePageSize: Number.isFinite(autoSyncEffectivePageSize) ? autoSyncEffectivePageSize : null,
+      autoSyncSelectedCount: Number.isFinite(autoSyncSelectedCount) ? autoSyncSelectedCount : null,
+      autoSyncRemainingCapacity: Number.isFinite(autoSyncRemainingCapacity) ? autoSyncRemainingCapacity : null,
+      autoSyncStopReason: autoSyncStopReason || null,
+      pagination,
+      lastOperationName: apiSnapshot.lastOperationName,
+      timestamp: (/* @__PURE__ */ new Date()).toISOString()
+    };
+  }
+  __name(getExternalAccessorStatus, "getExternalAccessorStatus");
+  function installContentTestExports() {
+    if (typeof globalThis.__TR_BROWSER_EXTENSION_TEST__ !== "object") {
+      return null;
+    }
+    globalThis.__TR_BROWSER_EXTENSION_TEST__.content = {
+      SOURCE_KEYS,
+      autoApplyAgeFilterFromUrl,
+      extractResumes,
+      extractJob51DetailResume,
+      extractJob5156DetailResume,
+      filterCurrentResumesByAgeRange,
+      getCurrentAgeRange,
+      getExternalAccessorStatus,
+      setAutoAgeAttributes
+    };
+    return globalThis.__TR_BROWSER_EXTENSION_TEST__.content;
+  }
+  __name(installContentTestExports, "installContentTestExports");
+  installContentTestExports();
+  function installExternalAccessor() {
+    try {
+      const version = getExtensionVersion();
+      window[EXTERNAL_ACCESS_KEY] = {
+        extract: /* @__PURE__ */ __name(() => extractResumes(), "extract"),
+        extractRaw: /* @__PURE__ */ __name((options) => extractResumesRaw(options), "extractRaw"),
+        collect: /* @__PURE__ */ __name((options) => collectSnapshotPayload(options), "collect"),
+        getApiSnapshot: /* @__PURE__ */ __name(() => apiSnapshot, "getApiSnapshot"),
+        getPaginationInfo: /* @__PURE__ */ __name(() => getPaginationInfo(), "getPaginationInfo"),
+        isReady: /* @__PURE__ */ __name(() => isExtractionReady(), "isReady"),
+        isLoggedIn: /* @__PURE__ */ __name(() => isLoggedIn(), "isLoggedIn"),
+        status: /* @__PURE__ */ __name(() => getExternalAccessorStatus(), "status"),
+        syncToServer: /* @__PURE__ */ __name(() => syncCurrentPageToServer(), "syncToServer"),
+        version,
+        goToNextPage: /* @__PURE__ */ __name(() => goToNextPageInternal(), "goToNextPage")
+      };
+    } catch (error) {
+      console.warn("\u{1F3AF} [External Access] Failed to install accessor:", error);
+    }
+  }
+  __name(installExternalAccessor, "installExternalAccessor");
+  console.log("\u{1F3AF} \u667A\u901A\u76F4\u8058 Resume Collector loaded");
+  installApiHook();
+  installReloadHelper();
+  installExternalAccessor();
+  autoSelectLocation().catch((error) => console.warn("\u{1F3AF} [Auto Location] Failed:", error)).then(() => autoSearchFromUrl()).catch((error) => console.warn("\u{1F3AF} [Auto Search] Failed:", error)).then(() => autoApplyAgeFilterFromUrl()).catch((error) => console.warn("\u{1F3AF} [Auto Age] Failed:", error)).finally(() => {
+    void (async () => {
+      await runAutoExportIfEnabled();
+      await runAutoSyncIfEnabled();
+    })();
+  });
+})();

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -837,6 +837,7 @@
     pagination: ".el-pagination",
     nextPageBtn: ".el-pagination .btn-next",
     seekPagination: 'nav[aria-label="Pagination of results"]',
+    seekTalentSearchPagination: 'nav[aria-label="PAGINATION_OF_RESULTS"]',
     searchInput: ".el-autocomplete input.el-input__inner",
     searchButton: ".resume-search-item-search-input-block__input-button",
     // 51job eHire selectors
@@ -1349,6 +1350,21 @@
     return window.location.pathname.includes("/talentsearch/profile/");
   }
   __name(isSeekProfilePage, "isSeekProfilePage");
+  function isSeekTalentSearchListPage() {
+    if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return false;
+    const { pathname, search } = window.location;
+    if (pathname.includes("/talentsearch/profile/")) return false;
+    return pathname === "/talentsearch" && search.length > 0;
+  }
+  __name(isSeekTalentSearchListPage, "isSeekTalentSearchListPage");
+  function getCurrentSeekMode() {
+    if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return null;
+    if (isSeekProfilePage()) return "profile";
+    if (isSeekTalentSearchListPage()) return "talentsearch";
+    if (window.location.pathname.includes("/candidates/recommended")) return "recommended";
+    return null;
+  }
+  __name(getCurrentSeekMode, "getCurrentSeekMode");
   function isSeekInlineProfileMode() {
     if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) {
       return false;
@@ -3838,11 +3854,12 @@
   }
   __name(getSeekCardCount, "getSeekCardCount");
   function getSeekPaginationInfo() {
+    const isTalentSearch = getCurrentSeekMode() === "talentsearch";
     const currentPage = normalizeOptionalPositiveInt(
       new URL(window.location.href).searchParams.get("pageNumber")
     ) || 1;
     const pagination = document.querySelector(
-      'nav[aria-label="Pagination of results"]'
+      isTalentSearch ? SELECTORS.seekTalentSearchPagination : SELECTORS.seekPagination
     );
     if (!pagination) {
       return {
@@ -3863,7 +3880,7 @@
       pageNumbers.length > 0 ? Math.max(...pageNumbers) : 0,
       currentPage
     );
-    const nextLink = getSeekNextPageLink();
+    const nextLink = getSeekNextPageLinkForMode();
     const hasNextPage = totalPages > currentPage && !isDisabledPaginationControl(nextLink);
     return { currentPage, totalPages, totalItems: 0, hasNextPage };
   }
@@ -3949,6 +3966,25 @@
     return asHTMLElement(nextLink || null);
   }
   __name(getSeekNextPageLink, "getSeekNextPageLink");
+  function getSeekTalentSearchNextPageLink() {
+    const pagination = document.querySelector(SELECTORS.seekTalentSearchPagination);
+    if (!pagination) return null;
+    const explicit = pagination.querySelector('a[rel="next"]');
+    if (explicit) return asHTMLElement(explicit);
+    const links = Array.from(pagination.querySelectorAll("a"));
+    const labeled = links.find(
+      (node) => /next/i.test((node.getAttribute("aria-label") || node.textContent || "").trim())
+    );
+    return asHTMLElement(labeled || null);
+  }
+  __name(getSeekTalentSearchNextPageLink, "getSeekTalentSearchNextPageLink");
+  function getSeekNextPageLinkForMode() {
+    if (getCurrentSeekMode() === "talentsearch") {
+      return getSeekTalentSearchNextPageLink();
+    }
+    return getSeekNextPageLink();
+  }
+  __name(getSeekNextPageLinkForMode, "getSeekNextPageLinkForMode");
   function isDisabledPaginationControl(control) {
     if (!control) return true;
     return control.hasAttribute("disabled") || control.classList.contains("disabled") || control.classList.contains("is-disabled") || control.getAttribute("aria-disabled") === "true" || control.getAttribute("aria-hidden") === "true" || control.getAttribute("tabindex") === "-1";
@@ -3957,7 +3993,7 @@
   function goToNextPageInternal() {
     const sourceKey = getCurrentSourceKey();
     if (sourceKey === SOURCE_KEYS.SEEK) {
-      const nextBtn2 = getSeekNextPageLink();
+      const nextBtn2 = getSeekNextPageLinkForMode();
       if (!nextBtn2 || isDisabledPaginationControl(nextBtn2)) return false;
       nextBtn2.click();
       return true;
@@ -3980,7 +4016,7 @@
   function getNextPageButtonState() {
     const sourceKey = getCurrentSourceKey();
     if (sourceKey === SOURCE_KEYS.SEEK) {
-      const nextBtn2 = getSeekNextPageLink();
+      const nextBtn2 = getSeekNextPageLinkForMode();
       if (!nextBtn2) {
         return {
           exists: false
@@ -4480,10 +4516,11 @@
       const check = /* @__PURE__ */ __name(() => {
         if (done) return;
         const isSeek = getCurrentSourceKey() === SOURCE_KEYS.SEEK;
+        const seekTalentSearch = isSeek && getCurrentSeekMode() === "talentsearch";
         const pagination = document.querySelector(
-          isSeek ? SELECTORS.seekPagination : SELECTORS.pagination
+          isSeek ? seekTalentSearch ? SELECTORS.seekTalentSearchPagination : SELECTORS.seekPagination : SELECTORS.pagination
         );
-        const nextBtn = isSeek ? getSeekNextPageLink() : document.querySelector(SELECTORS.nextPageBtn);
+        const nextBtn = isSeek ? getSeekNextPageLinkForMode() : document.querySelector(SELECTORS.nextPageBtn);
         if (pagination && nextBtn) {
           done = true;
           cleanup();

--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "智通直聘 Resume Collector",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzXCTw+8W8khXUpXqILIfM0F25TlMaVr6f879wMLp71zoe+LoiZjzmfK3h41TuepIu41qzGUMLt1K1ap6YUCrg78Iq4UgWsJ/Bg43JZ0nlCig6pwE6Xihsg+oVjmKSKB2YkjjWnZRWv1Qx9Q0Jpvtv0OHGCldxfd5beB/BaKDpZalXVPoU++9he1SeKN9rZO/I8LZV57kJ539r938+LDPb+69LTQFDMpg+uFOUUlh8XaA2JAO+IySqDn32QTXFuGxwP4EcSKJibu7qo4E2SqyWMKvLh4RVZDvfLDqXNq6jD/y+zY3aS9FeWfn3uFS5QPwRjlv9JyNpSKgY63KMX+oRQIDAQAB",
     "description": "Extract resume data from Job5156, Seek, and 51job eHire for the Trends Resume Screening System",
     "permissions": [
@@ -43,6 +43,8 @@
                 "*://my.employer.seek.com/candidates/recommended*",
                 "*://hk.employer.seek.com/talentsearch/profile*",
                 "*://my.employer.seek.com/talentsearch/profile*",
+                "*://hk.employer.seek.com/talentsearch?*",
+                "*://my.employer.seek.com/talentsearch?*",
                 "*://ehire.51job.com/Revision/talent/search*",
                 "*://ehire.51job.com/Revision/talent/resume/detail*"
             ],
@@ -60,6 +62,8 @@
                 "*://my.employer.seek.com/candidates/recommended*",
                 "*://hk.employer.seek.com/talentsearch/profile*",
                 "*://my.employer.seek.com/talentsearch/profile*",
+                "*://hk.employer.seek.com/talentsearch?*",
+                "*://my.employer.seek.com/talentsearch?*",
                 "*://ehire.51job.com/Revision/talent/search*",
                 "*://ehire.51job.com/Revision/talent/resume/detail*"
             ],

--- a/apps/browser-extension/page-hook.js
+++ b/apps/browser-extension/page-hook.js
@@ -45,6 +45,22 @@
     return query.includes("talentSearchRecommendedCandidatesV2");
   };
 
+  const isSeekTalentSearchOperation = (entry) => {
+    const operationName =
+      typeof entry?.operationName === "string" ? entry.operationName : "";
+    if (operationName === "SearchProfilesByNaturalLanguage") return true;
+    const query = typeof entry?.query === "string" ? entry.query : "";
+    return /talentSearchProfilesNaturalLanguageSearch\s*\(/i.test(query);
+  };
+
+  const isSeekProfileV3Operation = (entry) => {
+    const operationName =
+      typeof entry?.operationName === "string" ? entry.operationName : "";
+    if (operationName === "GetTalentSearchProfileCompleteV3") return true;
+    const query = typeof entry?.query === "string" ? entry.query : "";
+    return /talentSearchProfileV3\s*\(/i.test(query);
+  };
+
   const headersToObject = (headers) => {
     if (!headers) {
       return {};
@@ -123,6 +139,21 @@
       }
     }
     if (url.includes("/graphql")) {
+      const talentSearchOperation = findGraphqlOperation(
+        requestBody,
+        isSeekTalentSearchOperation,
+      );
+      if (talentSearchOperation) {
+        return {
+          kind: "seekTalentSearch",
+          sourceKey: "seek",
+          operationName:
+            typeof talentSearchOperation.operationName === "string"
+              ? talentSearchOperation.operationName
+              : "SearchProfilesByNaturalLanguage",
+          operation: talentSearchOperation,
+        };
+      }
       const recommendedOperation = findGraphqlOperation(
         requestBody,
         isSeekRecommendedCandidatesOperation,
@@ -148,6 +179,18 @@
           sourceKey: "seek",
           operationName: "GetTalentSearchProfileCompleteV2",
           operation: profileOperation,
+        };
+      }
+      const profileV3Operation = findGraphqlOperation(
+        requestBody,
+        isSeekProfileV3Operation,
+      );
+      if (profileV3Operation) {
+        return {
+          kind: "seekProfile",
+          sourceKey: "seek",
+          operationName: "GetTalentSearchProfileCompleteV3",
+          operation: profileV3Operation,
         };
       }
     }
@@ -200,13 +243,85 @@
 
   const sanitizeSeekRequestBody = (operation) => {
     if (!operation || typeof operation !== "object") return null;
-    const input = operation.variables?.input;
+    const opName =
+      typeof operation.operationName === "string" ? operation.operationName : "";
     const language = operation.variables?.language;
+    const locale = operation.variables?.locale;
+
+    if (opName === "SearchProfilesByNaturalLanguage") {
+      const input = operation.variables?.input;
+      if (!input || typeof input !== "object") {
+        return {
+          operationName: opName,
+          variables: { language: typeof language === "string" ? language : undefined },
+        };
+      }
+      return {
+        operationName: opName,
+        variables: {
+          input: {
+            roleTitles: input.roleTitles && typeof input.roleTitles === "object"
+              ? {
+                  values: Array.isArray(input.roleTitles.values) ? input.roleTitles.values : undefined,
+                  matchLatestOnly: typeof input.roleTitles.matchLatestOnly === "boolean"
+                    ? input.roleTitles.matchLatestOnly
+                    : undefined,
+                }
+              : undefined,
+            companyNames: input.companyNames && typeof input.companyNames === "object"
+              ? {
+                  values: Array.isArray(input.companyNames.values) ? input.companyNames.values : undefined,
+                  matchLatestOnly: typeof input.companyNames.matchLatestOnly === "boolean"
+                    ? input.companyNames.matchLatestOnly
+                    : undefined,
+                }
+              : undefined,
+            keywords: input.keywords && typeof input.keywords === "object"
+              ? {
+                  values: Array.isArray(input.keywords.values) ? input.keywords.values : undefined,
+                  matchAll: typeof input.keywords.matchAll === "boolean"
+                    ? input.keywords.matchAll
+                    : undefined,
+                }
+              : undefined,
+            locations: Array.isArray(input.locations) ? input.locations : undefined,
+            salary: input.salary && typeof input.salary === "object"
+              ? {
+                  frequency: typeof input.salary.frequency === "string" ? input.salary.frequency : undefined,
+                  includeUnspecified: typeof input.salary.includeUnspecified === "boolean"
+                    ? input.salary.includeUnspecified
+                    : undefined,
+                  range: input.salary.range && typeof input.salary.range === "object"
+                    ? {
+                        minimum: typeof input.salary.range.minimum === "number"
+                          ? input.salary.range.minimum
+                          : undefined,
+                        maximum: typeof input.salary.range.maximum === "number"
+                          ? input.salary.range.maximum
+                          : undefined,
+                      }
+                    : undefined,
+                }
+              : undefined,
+            pageNumber: typeof input.pageNumber === "number" ? input.pageNumber : undefined,
+            pageSize: typeof input.pageSize === "number" ? input.pageSize : undefined,
+            originalNaturalLanguageQuery:
+              typeof input.originalNaturalLanguageQuery === "string"
+                ? input.originalNaturalLanguageQuery
+                : undefined,
+            countryCode: typeof input.countryCode === "string" ? input.countryCode : undefined,
+            sortBy: typeof input.sortBy === "string" ? input.sortBy : undefined,
+          },
+          language: typeof language === "string" ? language : undefined,
+          locale: typeof locale === "string" ? locale : undefined,
+        },
+      };
+    }
+
+    // Recommended (V2) and profile (V2/V3) keep the existing shape:
+    const input = operation.variables?.input;
     return {
-      operationName:
-        typeof operation.operationName === "string"
-          ? operation.operationName
-          : "",
+      operationName: opName,
       variables: {
         input:
           input && typeof input === "object"
@@ -218,6 +333,7 @@
                 searchId: input.searchId,
                 countryCode: input.countryCode,
                 profileId: input.profileId,
+                profileGuid: input.profileGuid,
                 keywords: input.keywords,
               }
             : undefined,

--- a/apps/browser-extension/seek-auto-sync-window.test.mjs
+++ b/apps/browser-extension/seek-auto-sync-window.test.mjs
@@ -161,3 +161,66 @@ test('reports when the limit has already been exhausted before the current page'
   assert.equal(selection.hitLimitWithinPage, true);
   assert.equal(selection.limitAlreadyReached, true);
 });
+
+// Talent-search defaults: 500 limit / 25 max-pages / page-size 20 (per recon).
+// The page-window math is mode-agnostic — these cases lock in the seek
+// talent-search lane's default ceilings.
+
+test('talentsearch: 500 limit and 25 maxPages with size 20 caps at page 25', () => {
+  const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
+    startPage: 1,
+    limit: 500,
+    maxPages: 25,
+    requestedPageSize: 20,
+  });
+
+  assert.equal(pageWindow.startPage, 1);
+  assert.equal(pageWindow.targetPageEnd, 25);
+  assert.equal(pageWindow.allowedPageCount, 25);
+  assert.equal(pageWindow.effectivePageSize, 20);
+});
+
+test('talentsearch: mid-page limit (37 with size 20) selects 17 on page 2', () => {
+  const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
+    startPage: 1,
+    limit: 37,
+    maxPages: 25,
+    requestedPageSize: 20,
+  });
+  const selection = helpers.resolveSeekAutoSyncCurrentPageSelection({
+    limit: 37,
+    totalSubmitted: 20,
+    currentPageResumeCount: 20,
+  });
+
+  assert.equal(pageWindow.targetPageEnd, 2);
+  assert.equal(pageWindow.limitPageCount, 2);
+  assert.equal(selection.selectedCount, 17);
+  assert.equal(selection.hitLimitWithinPage, true);
+  assert.equal(selection.remainingCapacity, 17);
+});
+
+test('talentsearch: maxPages=10 with limit=500 caps at page 10', () => {
+  const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
+    startPage: 1,
+    limit: 500,
+    maxPages: 10,
+    requestedPageSize: 20,
+  });
+
+  assert.equal(pageWindow.targetPageEnd, 10);
+  assert.equal(pageWindow.allowedPageCount, 10);
+});
+
+test('talentsearch: non-first-page start (page 5, limit 100, size 20) ends on page 9', () => {
+  const pageWindow = helpers.resolveSeekAutoSyncPageWindow({
+    startPage: 5,
+    limit: 100,
+    maxPages: 25,
+    requestedPageSize: 20,
+  });
+
+  assert.equal(pageWindow.startPage, 5);
+  assert.equal(pageWindow.targetPageEnd, 9);
+  assert.equal(pageWindow.allowedPageCount, 5);
+});

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -820,6 +820,10 @@ function getSeekRecommendedRequest() {
   return apiSnapshot.seekRecommendedRequest;
 }
 
+function getSeekTalentSearchRequest() {
+  return apiSnapshot.seekTalentSearchRequest;
+}
+
 function getSeekProfileRequest() {
   return apiSnapshot.seekProfileRequest || apiSnapshot.seekRecommendedRequest;
 }
@@ -3374,6 +3378,93 @@ function extractSeekResumes() {
   });
 }
 
+/**
+ * Extract resumes from seek talent-search (SearchProfilesByNaturalLanguage) list-page snapshot.
+ * Mirrors the output shape of extractSeekResumes() exactly so downstream submit/identity/storage
+ * code is unchanged.
+ *
+ * Node shape is TalentSearchProfileResultV2 — see dev-docs/seek-talent-search-graphql-recon.txt.
+ *
+ * externalId precedence: talent-search nodes have profileGuid (UUID) but NO numeric profileId.
+ * We use profileGuid as the primary identifier. If the node had both a numeric profileId and a
+ * profileGuid (not observed on talent-search, but defensively handled), we prefer profileGuid
+ * to match the V3 profile request semantics (input.profileGuid: UUID).
+ */
+function extractSeekTalentSearchResumes() {
+  const candidates = Array.isArray(apiSnapshot.seekTalentSearch)
+    ? apiSnapshot.seekTalentSearch
+    : [];
+  const request = getSeekTalentSearchRequest();
+  const requestInput = request?.variables?.input;
+  const language = request?.variables?.language;
+  const url = new URL(window.location.href);
+  const currentPage =
+    typeof requestInput?.pageNumber === "number"
+      ? requestInput.pageNumber
+      : normalizeOptionalPositiveInt(url.searchParams.get("pageNumber")) || 1;
+
+  return candidates
+    .map((node, index) => {
+      // Prefer profileGuid (UUID) as the identity key for talent-search;
+      // fall back to the numeric-looking Relay "id" if profileGuid is missing.
+      const profileId =
+        typeof node?.profileGuid === "string" && node.profileGuid
+          ? node.profileGuid
+          : typeof node?.id === "string" && node.id
+            ? node.id
+            : "";
+      if (!profileId) return null;
+
+      const firstName =
+        typeof node?.firstName === "string" ? node.firstName.trim() : "";
+      const lastName =
+        typeof node?.lastName === "string" ? node.lastName.trim() : "";
+      const currentJobTitle =
+        typeof node?.currentJobTitle === "string"
+          ? node.currentJobTitle.trim()
+          : "";
+      const currentLocation =
+        typeof node?.currentLocation === "string"
+          ? node.currentLocation.trim()
+          : "";
+      const lastModifiedDurationLabel =
+        typeof node?.lastModifiedDurationLabel === "string"
+          ? node.lastModifiedDurationLabel
+          : "";
+      const workHistory = Array.isArray(node?.workHistories)
+        ? node.workHistories
+            .map((item) => buildSeekWorkHistoryItem(item))
+            .filter(Boolean)
+        : [];
+
+      return {
+        profileId,
+        profileType: "seek",
+        externalId: profileId
+          ? `${window.location.hostname.toLowerCase()}:profile:${profileId}`
+          : "",
+        name: [firstName, lastName].filter(Boolean).join(" ").trim(),
+        profileUrl: buildSeekProfileUrl(profileId, undefined),
+        activityStatus: lastModifiedDurationLabel,
+        age: "",
+        experience: "",
+        education: "",
+        location: currentLocation,
+        jobIntention: currentJobTitle,
+        expectedSalary: "",
+        selfIntro: "",
+        workHistory,
+        extractedAt: new Date().toISOString(),
+        pageIndex: index + 1,
+        source: window.location.hostname.toLowerCase(),
+        searchProfileId: "",
+        language: typeof language === "string" ? language : "",
+        pageNumber: currentPage,
+      };
+    })
+    .filter(Boolean);
+}
+
 function extract51JobResumes() {
   if (!Array.isArray(apiSnapshot.job51SearchRows)) return [];
   return apiSnapshot.job51SearchRows.map((row, index) => {
@@ -3601,6 +3692,9 @@ function extractResumes() {
       }
       return [];
     }
+    if (hasSeekTalentSearchSnapshot()) {
+      return extractSeekTalentSearchResumes();
+    }
     if (hasSeekListSnapshot()) {
       return extractSeekResumes();
     }
@@ -3652,10 +3746,20 @@ function extractResumesRaw(options = {}) {
     const seekProfileIdentity = seekProfile
       ? getSeekCandidateIdentity(seekProfile)
       : null;
+    const seekTalentSearchCandidates =
+      !seekProfile && hasSeekTalentSearchSnapshot()
+        ? apiSnapshot.seekTalentSearch
+        : null;
     const candidates =
-      !seekProfile && hasSeekListSnapshot()
+      seekTalentSearchCandidates ||
+      (!seekProfile && hasSeekListSnapshot()
         ? apiSnapshot.seekRecommendedCandidates
-        : [];
+        : []);
+    const seekRequest = seekProfile
+      ? getSeekProfileRequest()
+      : seekTalentSearchCandidates
+        ? getSeekTalentSearchRequest()
+        : getSeekRecommendedRequest();
     const cards = seekProfile
       ? [
           {
@@ -3666,8 +3770,13 @@ function extractResumesRaw(options = {}) {
           },
         ]
       : candidates.map((candidate, index) => {
-          const { profileId, profileType } =
-            getSeekCandidateIdentity(candidate);
+          // Talent-search nodes use profileGuid (UUID); recommended nodes use numeric profileId
+          const profileId = seekTalentSearchCandidates
+            ? typeof candidate?.profileGuid === "string" && candidate.profileGuid
+              ? candidate.profileGuid
+              : ""
+            : getSeekCandidateIdentity(candidate).profileId;
+          const profileType = SEEK_PROFILE_TYPE;
           return {
             index: index + 1,
             profileId,
@@ -3690,7 +3799,7 @@ function extractResumesRaw(options = {}) {
           operationName: apiSnapshot.lastOperationName,
           request: seekProfile
             ? getSeekProfileRequest()
-            : getSeekRecommendedRequest(),
+            : seekRequest,
         },
       };
 

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -2577,12 +2577,18 @@ function buildSeekCollectionContext(options = {}) {
   const normalizedOptions =
     typeof options === "object" && options ? options : {};
   const captureModeOverride = normalizedOptions.captureModeOverride;
+  const seekMode = getCurrentSeekMode();
+  const isTalentSearchList = seekMode === "talentsearch";
   const useProfileMode = captureModeOverride
     ? captureModeOverride === "graphql-profile"
     : isSeekProfileMode();
-  const request = useProfileMode
-    ? getSeekProfileRequest()
-    : getSeekRecommendedRequest();
+  const talentSearchRequest = isTalentSearchList
+    ? apiSnapshot.seekTalentSearchRequest
+    : null;
+  const request = talentSearchRequest
+    ?? (useProfileMode
+      ? getSeekProfileRequest()
+      : getSeekRecommendedRequest());
   const requestInput = request?.variables?.input;
   const language = request?.variables?.language;
   const url = new URL(window.location.href);
@@ -2594,34 +2600,88 @@ function buildSeekCollectionContext(options = {}) {
   );
   const captureMode =
     captureModeOverride ||
-    (useProfileMode && apiSnapshot.seekProfile
-      ? "graphql-profile"
-      : "graphql-list");
+    (isTalentSearchList
+      ? "graphql-talentsearch"
+      : (useProfileMode && apiSnapshot.seekProfile
+          ? "graphql-profile"
+          : "graphql-list"));
   const defaultOperation =
     captureMode === "graphql-profile"
       ? "GetTalentSearchProfileCompleteV2"
-      : "GetTalentSearchRecommendedCandidates";
+      : captureMode === "graphql-talentsearch"
+        ? "SearchProfilesByNaturalLanguage"
+        : "GetTalentSearchRecommendedCandidates";
 
-  return {
+  /** @type {Record<string, unknown>} */
+  const context = {
     captureMode,
     operation: apiSnapshot.lastOperationName || defaultOperation,
-    jobId:
-      requestInput?.jobId != null
-        ? String(requestInput.jobId)
-        : jobIdFromUrl != null
-          ? String(jobIdFromUrl)
-          : undefined,
-    searchId:
-      typeof requestInput?.searchId === "string"
-        ? requestInput.searchId
-        : undefined,
-    pageNumber:
-      typeof requestInput?.page === "number"
-        ? requestInput.page
-        : (pageNumberFromUrl ?? undefined),
-    language: typeof language === "string" ? language : undefined,
     profileType: SEEK_PROFILE_TYPE,
   };
+  if (seekMode) {
+    context.seekMode = seekMode;
+  }
+  if (typeof language === "string") {
+    context.language = language;
+  }
+
+  if (isTalentSearchList) {
+    // Talent-search variables are nested under input.{...} per recon.
+    // Surface the search-shaping fields so analytics can later distinguish
+    // discovery-lane characteristics.
+    if (typeof requestInput?.pageNumber === "number") {
+      context.pageNumber = requestInput.pageNumber;
+    } else if (pageNumberFromUrl != null) {
+      context.pageNumber = pageNumberFromUrl;
+    }
+    if (typeof requestInput?.originalNaturalLanguageQuery === "string") {
+      context.searchQuery = requestInput.originalNaturalLanguageQuery;
+    }
+    if (typeof requestInput?.countryCode === "string") {
+      context.market = requestInput.countryCode;
+    }
+    if (Array.isArray(requestInput?.roleTitles?.values)) {
+      context.roleTitles = requestInput.roleTitles.values;
+    }
+    if (Array.isArray(requestInput?.keywords?.values)) {
+      context.keywords = requestInput.keywords.values;
+    }
+    if (typeof requestInput?.keywords?.matchAll === "boolean") {
+      context.matchAll = requestInput.keywords.matchAll;
+    }
+    if (typeof requestInput?.sortBy === "string") {
+      context.sortBy = requestInput.sortBy;
+    }
+    if (typeof requestInput?.salary?.frequency === "string") {
+      context.salaryType = requestInput.salary.frequency;
+    }
+    if (typeof requestInput?.salary?.range?.minimum === "number") {
+      context.minSalary = requestInput.salary.range.minimum;
+    }
+    if (typeof requestInput?.salary?.includeUnspecified === "boolean") {
+      context.salaryUnspecified = requestInput.salary.includeUnspecified;
+    }
+    if (typeof requestInput?.searchId === "string") {
+      context.searchId = requestInput.searchId;
+    }
+  } else {
+    // Recommended / profile path uses the existing flat input shape.
+    if (requestInput?.jobId != null) {
+      context.jobId = String(requestInput.jobId);
+    } else if (jobIdFromUrl != null) {
+      context.jobId = String(jobIdFromUrl);
+    }
+    if (typeof requestInput?.searchId === "string") {
+      context.searchId = requestInput.searchId;
+    }
+    if (typeof requestInput?.page === "number") {
+      context.pageNumber = requestInput.page;
+    } else if (pageNumberFromUrl != null) {
+      context.pageNumber = pageNumberFromUrl;
+    }
+  }
+
+  return context;
 }
 
 function getExtensionGeneratedBy() {

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -652,6 +652,21 @@ function isSeekProfilePage() {
   return window.location.pathname.includes("/talentsearch/profile/");
 }
 
+function isSeekTalentSearchListPage() {
+  if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return false;
+  const { pathname, search } = window.location;
+  if (pathname.includes("/talentsearch/profile/")) return false;
+  return pathname === "/talentsearch" && search.length > 0;
+}
+
+function getCurrentSeekMode() {
+  if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return null;
+  if (isSeekProfilePage()) return "profile";
+  if (isSeekTalentSearchListPage()) return "talentsearch";
+  if (window.location.pathname.includes("/candidates/recommended")) return "recommended";
+  return null;
+}
+
 function isSeekInlineProfileMode() {
   if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) {
     return false;
@@ -4596,6 +4611,8 @@ function clearCapturedResultsForNextPage() {
     apiSnapshot.seekRecommendedRequest = null;
     apiSnapshot.seekProfile = null;
     apiSnapshot.seekProfileRequest = null;
+    apiSnapshot.seekTalentSearch = null;
+    apiSnapshot.seekTalentSearchRequest = null;
   }
 }
 

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -49,6 +49,7 @@ const SELECTORS = {
   pagination: ".el-pagination",
   nextPageBtn: ".el-pagination .btn-next",
   seekPagination: 'nav[aria-label="Pagination of results"]',
+  seekTalentSearchPagination: 'nav[aria-label="PAGINATION_OF_RESULTS"]',
   searchInput: ".el-autocomplete input.el-input__inner",
   searchButton: ".resume-search-item-search-input-block__input-button",
   // 51job eHire selectors
@@ -4025,12 +4026,15 @@ function getSeekCardCount() {
 }
 
 function getSeekPaginationInfo() {
+  const isTalentSearch = getCurrentSeekMode() === "talentsearch";
   const currentPage =
     normalizeOptionalPositiveInt(
       new URL(window.location.href).searchParams.get("pageNumber"),
     ) || 1;
   const pagination = document.querySelector(
-    'nav[aria-label="Pagination of results"]',
+    isTalentSearch
+      ? SELECTORS.seekTalentSearchPagination
+      : SELECTORS.seekPagination,
   );
   if (!pagination) {
     return {
@@ -4055,7 +4059,7 @@ function getSeekPaginationInfo() {
     pageNumbers.length > 0 ? Math.max(...pageNumbers) : 0,
     currentPage,
   );
-  const nextLink = getSeekNextPageLink();
+  const nextLink = getSeekNextPageLinkForMode();
   const hasNextPage =
     totalPages > currentPage && !isDisabledPaginationControl(nextLink);
 
@@ -4167,6 +4171,26 @@ function getSeekNextPageLink() {
   return asHTMLElement(nextLink || null);
 }
 
+function getSeekTalentSearchNextPageLink() {
+  const pagination = document.querySelector(SELECTORS.seekTalentSearchPagination);
+  if (!pagination) return null;
+  // Talent search pager exposes a[rel="next"] per recon; fall back to last anchor.
+  const explicit = pagination.querySelector('a[rel="next"]');
+  if (explicit) return asHTMLElement(explicit);
+  const links = Array.from(pagination.querySelectorAll("a"));
+  const labeled = links.find((node) =>
+    /next/i.test((node.getAttribute("aria-label") || node.textContent || "").trim()),
+  );
+  return asHTMLElement(labeled || null);
+}
+
+function getSeekNextPageLinkForMode() {
+  if (getCurrentSeekMode() === "talentsearch") {
+    return getSeekTalentSearchNextPageLink();
+  }
+  return getSeekNextPageLink();
+}
+
 function isDisabledPaginationControl(control) {
   if (!control) return true;
   return (
@@ -4182,7 +4206,7 @@ function isDisabledPaginationControl(control) {
 function goToNextPageInternal() {
   const sourceKey = getCurrentSourceKey();
   if (sourceKey === SOURCE_KEYS.SEEK) {
-    const nextBtn = getSeekNextPageLink();
+    const nextBtn = getSeekNextPageLinkForMode();
     if (!nextBtn || isDisabledPaginationControl(nextBtn)) return false;
     nextBtn.click();
     return true;
@@ -4207,7 +4231,7 @@ function goToNextPageInternal() {
 function getNextPageButtonState() {
   const sourceKey = getCurrentSourceKey();
   if (sourceKey === SOURCE_KEYS.SEEK) {
-    const nextBtn = getSeekNextPageLink();
+    const nextBtn = getSeekNextPageLinkForMode();
     if (!nextBtn) {
       return {
         exists: false,
@@ -4815,11 +4839,16 @@ function waitForPagination({ timeoutMs = 8000 } = {}) {
     const check = () => {
       if (done) return;
       const isSeek = getCurrentSourceKey() === SOURCE_KEYS.SEEK;
+      const seekTalentSearch = isSeek && getCurrentSeekMode() === "talentsearch";
       const pagination = document.querySelector(
-        isSeek ? SELECTORS.seekPagination : SELECTORS.pagination,
+        isSeek
+          ? (seekTalentSearch
+              ? SELECTORS.seekTalentSearchPagination
+              : SELECTORS.seekPagination)
+          : SELECTORS.pagination,
       );
       const nextBtn = isSeek
-        ? getSeekNextPageLink()
+        ? getSeekNextPageLinkForMode()
         : document.querySelector(SELECTORS.nextPageBtn);
       if (pagination && nextBtn) {
         done = true;

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -4816,10 +4816,18 @@ async function enrichSingleSeekResumeWithDetail(resume) {
   }
 }
 
-async function enrichSeekRecommendedResumesWithDetail(resumes) {
+async function enrichSeekResumesWithDetail(resumes) {
   if (!Array.isArray(resumes) || resumes.length === 0) return [];
   if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return resumes;
   if (isSeekProfileMode()) return resumes;
+  // Talent-search list cards do NOT expose <a href="/talentsearch/profile/..."> links
+  // (per 2026-05-19 recon — see dev-docs/seek-talent-search-graphql-recon.txt). The
+  // existing findSeekProfileTrigger hunts for hrefs that do not exist, and the V3
+  // profile response is captured under a different snapshot shape. Detail enrichment
+  // for talent-search is deferred to a follow-up; list-level fields (firstName,
+  // lastName, currentLocation, currentJobTitle, workHistories[]) are sufficient
+  // for the initial slice and are already populated on list-page nodes.
+  if (getCurrentSeekMode() === "talentsearch") return resumes;
 
   const enriched = [];
   for (const resume of resumes) {
@@ -5984,7 +5992,7 @@ async function syncCurrentPageToServer(resumesOverride) {
     !isSeekProfileMode() &&
     resumes.length > 0
   ) {
-    resumes = await enrichSeekRecommendedResumesWithDetail(resumes);
+    resumes = await enrichSeekResumesWithDetail(resumes);
   }
   const metadata = buildSubmitMetadata({
     seekCaptureMode:
@@ -6281,7 +6289,7 @@ async function runAutoSyncIfEnabled() {
         !isSeekProfileMode() &&
         resumes.length > 0
       ) {
-        resumes = await enrichSeekRecommendedResumesWithDetail(resumes);
+        resumes = await enrichSeekResumesWithDetail(resumes);
       }
       if (resumes.length <= 0) {
         const ageRange = getCurrentAgeRange();
@@ -6810,7 +6818,7 @@ async function collectSnapshotPayload(options = {}) {
       !isSeekProfileMode() &&
       pageResumes.length > 0
     ) {
-      pageResumes = await enrichSeekRecommendedResumesWithDetail(pageResumes);
+      pageResumes = await enrichSeekResumesWithDetail(pageResumes);
     }
 
     lastPageResumeCount = pageResumes.length;

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -131,6 +131,8 @@ const apiSnapshot = {
   seekRecommendedRequest: null,
   seekProfile: null,
   seekProfileRequest: null,
+  seekTalentSearch: null,
+  seekTalentSearchRequest: null,
   lastUpdatedAt: null,
   lastSearchAt: null,
   lastUrl: null,
@@ -679,9 +681,16 @@ function hasSeekListSnapshot() {
   return Array.isArray(apiSnapshot.seekRecommendedCandidates);
 }
 
+function hasSeekTalentSearchSnapshot() {
+  return Array.isArray(apiSnapshot.seekTalentSearch);
+}
+
 function getSeekSnapshotCount() {
   if (isSeekProfileMode()) {
     return hasSeekProfileSnapshot() ? 1 : 0;
+  }
+  if (hasSeekTalentSearchSnapshot()) {
+    return apiSnapshot.seekTalentSearch.length;
   }
   return hasSeekListSnapshot()
     ? apiSnapshot.seekRecommendedCandidates.length
@@ -2738,11 +2747,15 @@ function getSeekPayloadData(payload, kind) {
           data.getTalentSearchRecommendedCandidates
         );
       }
+      if (kind === "seekTalentSearch") {
+        return !!data.talentSearchProfilesNaturalLanguageSearch;
+      }
       if (kind === "seekProfile") {
         return !!(
           data.talentSearchProfileV2 ||
           data.talentSearchProfileCompleteV2 ||
-          data.getTalentSearchProfileCompleteV2
+          data.getTalentSearchProfileCompleteV2 ||
+          data.talentSearchProfileV3
         );
       }
       return false;
@@ -2885,6 +2898,30 @@ function updateApiSnapshot(message) {
       payload?.data?.talentInsightInfo || payload?.data || null;
     return;
   }
+  if (kind === "seekTalentSearch") {
+    const data = getSeekPayloadData(payload, kind);
+    const result = data?.talentSearchProfilesNaturalLanguageSearch?.result;
+    const edges = Array.isArray(result?.edges) ? result.edges : null;
+    if (edges) {
+      // Unwrap Relay edges into bare nodes — downstream code expects an array
+      // of candidate objects, same shape contract as seekRecommendedCandidates.
+      const nodes = edges
+        .map((edge) => edge?.node)
+        .filter((node) => node && typeof node === "object");
+      apiSnapshot.seekTalentSearch = nodes;
+      apiSnapshot.seekTalentSearchRequest = request || null;
+      apiSnapshot.lastSearchAt = apiSnapshot.lastUpdatedAt;
+      try {
+        document.documentElement.setAttribute(
+          "data-tr-api-rows",
+          String(getApiSnapshotCount()),
+        );
+      } catch {
+        // ignore
+      }
+    }
+    return;
+  }
   if (kind === "seekRecommendedCandidates") {
     const data = getSeekPayloadData(payload, kind);
     const candidates =
@@ -2911,6 +2948,7 @@ function updateApiSnapshot(message) {
       data?.talentSearchProfileV2 ||
       data?.talentSearchProfileCompleteV2 ||
       data?.getTalentSearchProfileCompleteV2 ||
+      data?.talentSearchProfileV3 ||
       data ||
       null;
     apiSnapshot.seekProfileRequest =

--- a/apps/web/src/components/SearchProfileEditorDialog.test.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.test.tsx
@@ -307,6 +307,68 @@ describe('SearchProfileEditorDialog JD hydration', () => {
     })
   })
 
+  it('preserves a talentsearch-mode seek source through edit + save round-trip', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <SearchProfileEditorDialog
+        open
+        onOpenChange={vi.fn()}
+        profileId="custom-profile-1"
+        initialData={{
+          id: 'custom-profile-1',
+          name: 'Seek Multi-Mode',
+          status: 'active',
+          location: 'MY',
+          keywords: ['CNC', 'Sales'],
+          sources: [
+            {
+              type: 'seek',
+              enabled: true,
+              priority: 1,
+              mode: 'recommended',
+              jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+            },
+            {
+              type: 'seek',
+              enabled: true,
+              priority: 2,
+              mode: 'talentsearch',
+              jobUrl: 'https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&keywords=CNC',
+              collectLimit: 500,
+              maxPages: 25,
+            },
+          ],
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledWith('/api/search-profiles/custom-profile-1', {
+        body: expect.objectContaining({
+          sources: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'seek',
+              mode: 'recommended',
+              enabled: true,
+              jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+            }),
+            expect.objectContaining({
+              type: 'seek',
+              mode: 'talentsearch',
+              enabled: true,
+              jobUrl: 'https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&keywords=CNC',
+              collectLimit: 500,
+              maxPages: 25,
+            }),
+          ]),
+        }),
+      })
+    })
+  })
+
   it('persists explicit 51job extended-limit settings in the profile payload', async () => {
     const user = userEvent.setup()
 

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -227,7 +227,13 @@ function toSourcesFormState(sources: SearchProfileSource[] | undefined): SourceF
 
     const job5156Source = sources.find((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.job5156)
     const job51Source = sources.find((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.job51)
-    const seekSource = sources.find((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.seek)
+    // Editor only surfaces the recommended-mode seek source today. Talent-search
+    // mode sources are preserved via splitKnownSources' `additional` lane so they
+    // round-trip through save without being dropped.
+    const seekSource = sources.find((source) =>
+        source.type === SEARCH_PROFILE_SOURCE_TYPES.seek
+        && (source.mode === undefined || source.mode === 'recommended'),
+    )
 
     return {
         job5156Enabled: job5156Source?.enabled ?? DEFAULT_SOURCES_FORM.job5156Enabled,
@@ -260,11 +266,19 @@ function splitKnownSources(sources: SearchProfileSource[] | undefined): {
 
     return {
         known: toSourcesFormState(sources),
-        additional: sources.filter((source) => (
-            source.type !== SEARCH_PROFILE_SOURCE_TYPES.job5156
-            && source.type !== SEARCH_PROFILE_SOURCE_TYPES.job51
-            && source.type !== SEARCH_PROFILE_SOURCE_TYPES.seek
-        )),
+        additional: sources.filter((source) => {
+            // Job5156 and 51job each have a single editable form row; non-seek non-job
+            // types are unknown to this editor and pass through.
+            if (source.type === SEARCH_PROFILE_SOURCE_TYPES.job5156) return false
+            if (source.type === SEARCH_PROFILE_SOURCE_TYPES.job51) return false
+            // Seek sources: only the recommended-mode source maps to the editor's
+            // single seek form row. Talent-search-mode seek sources are preserved
+            // via the additional lane so they round-trip through save.
+            if (source.type === SEARCH_PROFILE_SOURCE_TYPES.seek) {
+                return source.mode !== undefined && source.mode !== 'recommended'
+            }
+            return true
+        }),
     }
 }
 
@@ -302,6 +316,7 @@ function buildSourcesPayload(sourceForm: SourceFormState, additionalSources: Sea
 
     sources.push({
         type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+        mode: 'recommended',
         enabled: sourceForm.seekEnabled,
         priority: parseOptionalNumber(sourceForm.seekPriority),
         jobUrl: normalizeSeekJobUrl(sourceForm.seekJobUrl),

--- a/apps/web/src/lib/search-profile-sources.test.ts
+++ b/apps/web/src/lib/search-profile-sources.test.ts
@@ -16,6 +16,8 @@ import {
   isSeekTalentSearchUrl,
   resolveCollectionSource,
   resolveSeekMode,
+  resolveSeekModeFromUrl,
+  validateSeekSourceJobUrl,
 } from './search-profile-sources'
 
 describe('search-profile-sources', () => {
@@ -410,5 +412,67 @@ describe('buildSeekTalentSearchUrl', () => {
 
   it('returns null when no keywords or searchQuery provided', () => {
     expect(buildSeekTalentSearchUrl({ keywords: '' })).toBeNull()
+  })
+})
+
+describe('resolveSeekModeFromUrl', () => {
+  it('returns "recommended" for /candidates/recommended URLs', () => {
+    expect(resolveSeekModeFromUrl(
+      'https://my.employer.seek.com/candidates/recommended?jobId=90842915',
+    )).toBe('recommended')
+  })
+
+  it('returns "talentsearch" for /talentsearch?... URLs', () => {
+    expect(resolveSeekModeFromUrl(
+      'https://hk.employer.seek.com/talentsearch?keywords=CNC',
+    )).toBe('talentsearch')
+  })
+
+  it('returns null for unrecognized seek paths', () => {
+    expect(resolveSeekModeFromUrl(
+      'https://hk.employer.seek.com/dashboard',
+    )).toBeNull()
+  })
+
+  it('returns null for non-seek hosts', () => {
+    expect(resolveSeekModeFromUrl('https://example.com/talentsearch?x=1')).toBeNull()
+  })
+})
+
+describe('validateSeekSourceJobUrl', () => {
+  it('accepts recommended URL when mode is recommended', () => {
+    expect(validateSeekSourceJobUrl({
+      mode: 'recommended',
+      jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1',
+    })).toEqual({ ok: true })
+  })
+
+  it('accepts talentsearch URL when mode is talentsearch', () => {
+    expect(validateSeekSourceJobUrl({
+      mode: 'talentsearch',
+      jobUrl: 'https://hk.employer.seek.com/talentsearch?keywords=x',
+    })).toEqual({ ok: true })
+  })
+
+  it('rejects mode mismatch (talentsearch URL with mode=recommended)', () => {
+    const result = validateSeekSourceJobUrl({
+      mode: 'recommended',
+      jobUrl: 'https://hk.employer.seek.com/talentsearch?keywords=x',
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toMatch(/mode/i)
+    }
+  })
+
+  it('rejects malformed URL', () => {
+    const result = validateSeekSourceJobUrl({ mode: 'recommended', jobUrl: 'not a url' })
+    expect(result.ok).toBe(false)
+  })
+
+  it('treats undefined mode as recommended (back-compat)', () => {
+    expect(validateSeekSourceJobUrl({
+      jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=1',
+    })).toEqual({ ok: true })
   })
 })

--- a/apps/web/src/lib/search-profile-sources.test.ts
+++ b/apps/web/src/lib/search-profile-sources.test.ts
@@ -4,6 +4,7 @@ import {
   JOB51_SAFE_LAUNCH_LIMIT,
   JOB51_SAFE_LAUNCH_MAX_PAGES,
   SEARCH_PROFILE_SOURCE_TYPES,
+  SEEK_MODE,
   buildCollectionLaunchUrl,
   buildJob51CollectUrl,
   buildJob5156CollectUrl,
@@ -12,6 +13,7 @@ import {
   getSearchProfileCollectionSource,
   getSearchProfileCollectUrl,
   resolveCollectionSource,
+  resolveSeekMode,
 } from './search-profile-sources'
 
 describe('search-profile-sources', () => {
@@ -304,5 +306,24 @@ describe('search-profile-sources', () => {
     expect(job5156Url).toContain('tr_max_pages=2')
     expect(job51Url).toContain('ehire.51job.com/Revision/talent/search')
     expect(job51Url).toContain('tr_max_pages=1')
+  })
+})
+
+describe('seek mode', () => {
+  it('resolveSeekMode returns "recommended" when mode is undefined (back-compat default)', () => {
+    expect(resolveSeekMode(undefined)).toBe('recommended')
+  })
+
+  it('resolveSeekMode returns "talentsearch" when explicitly set', () => {
+    expect(resolveSeekMode('talentsearch')).toBe('talentsearch')
+  })
+
+  it('resolveSeekMode rejects unknown values and falls back to "recommended"', () => {
+    expect(resolveSeekMode('garbage' as unknown as 'recommended')).toBe('recommended')
+  })
+
+  it('SEEK_MODE constant exposes both values', () => {
+    expect(SEEK_MODE.recommended).toBe('recommended')
+    expect(SEEK_MODE.talentsearch).toBe('talentsearch')
   })
 })

--- a/apps/web/src/lib/search-profile-sources.test.ts
+++ b/apps/web/src/lib/search-profile-sources.test.ts
@@ -59,6 +59,47 @@ describe('search-profile-sources', () => {
     expect(collectUrl).toBe('https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1')
   })
 
+  it('returns the talent-search URL when it is the lowest-priority enabled seek source', () => {
+    const collectUrl = getSearchProfileCollectUrl([
+      {
+        type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+        enabled: true,
+        priority: 5,
+        mode: 'recommended',
+        jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+      },
+      {
+        type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+        enabled: true,
+        priority: 1,
+        mode: 'talentsearch',
+        jobUrl: 'https://hk.employer.seek.com/talentsearch?keywords=CNC',
+      },
+    ])
+
+    expect(collectUrl).toBe('https://hk.employer.seek.com/talentsearch?keywords=CNC')
+  })
+
+  it('falls back to the recommended URL when its priority is lower (back-compat default)', () => {
+    const collectUrl = getSearchProfileCollectUrl([
+      {
+        type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+        enabled: true,
+        priority: 1,
+        jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+      },
+      {
+        type: SEARCH_PROFILE_SOURCE_TYPES.seek,
+        enabled: true,
+        priority: 2,
+        mode: 'talentsearch',
+        jobUrl: 'https://hk.employer.seek.com/talentsearch?keywords=CNC',
+      },
+    ])
+
+    expect(collectUrl).toBe('https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1')
+  })
+
   it('returns the active launchable collection source for Job5156 profiles', () => {
     const collectionSource = getSearchProfileCollectionSource([
       { type: 'manual_upload', enabled: true, priority: 1 },

--- a/apps/web/src/lib/search-profile-sources.test.ts
+++ b/apps/web/src/lib/search-profile-sources.test.ts
@@ -9,9 +9,11 @@ import {
   buildJob51CollectUrl,
   buildJob5156CollectUrl,
   buildSeekCollectUrl,
+  buildSeekTalentSearchUrl,
   getActiveSearchProfileSource,
   getSearchProfileCollectionSource,
   getSearchProfileCollectUrl,
+  isSeekTalentSearchUrl,
   resolveCollectionSource,
   resolveSeekMode,
 } from './search-profile-sources'
@@ -325,5 +327,88 @@ describe('seek mode', () => {
   it('SEEK_MODE constant exposes both values', () => {
     expect(SEEK_MODE.recommended).toBe('recommended')
     expect(SEEK_MODE.talentsearch).toBe('talentsearch')
+  })
+})
+
+describe('isSeekTalentSearchUrl', () => {
+  it('returns true for canonical talent-search URL on hk host', () => {
+    expect(isSeekTalentSearchUrl(
+      'https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&keywords=CNC',
+    )).toBe(true)
+  })
+
+  it('returns true on my host', () => {
+    expect(isSeekTalentSearchUrl(
+      'https://my.employer.seek.com/talentsearch?keywords=Sales',
+    )).toBe(true)
+  })
+
+  it('returns false for the recommended-candidates URL', () => {
+    expect(isSeekTalentSearchUrl(
+      'https://my.employer.seek.com/candidates/recommended?jobId=90842915',
+    )).toBe(false)
+  })
+
+  it('returns false for /talentsearch/profile/<id> (profile detail)', () => {
+    expect(isSeekTalentSearchUrl(
+      'https://hk.employer.seek.com/talentsearch/profile/503033454?profileType=seek',
+    )).toBe(false)
+  })
+
+  it('returns false for /talentsearch with no query string', () => {
+    expect(isSeekTalentSearchUrl(
+      'https://hk.employer.seek.com/talentsearch',
+    )).toBe(false)
+  })
+
+  it('returns false for non-seek hosts', () => {
+    expect(isSeekTalentSearchUrl('https://example.com/talentsearch?keywords=x')).toBe(false)
+  })
+
+  it('returns false for malformed input', () => {
+    expect(isSeekTalentSearchUrl(undefined)).toBe(false)
+    expect(isSeekTalentSearchUrl('not a url')).toBe(false)
+    expect(isSeekTalentSearchUrl('')).toBe(false)
+  })
+})
+
+describe('buildSeekTalentSearchUrl', () => {
+  it('round-trips all documented params', () => {
+    const url = buildSeekTalentSearchUrl({
+      host: 'hk.employer.seek.com',
+      searchQuery: 'CNC Sales',
+      keywords: 'CNC',
+      market: 'MY',
+      roleTitles: ['Sales'],
+      pageNumber: 1,
+      sortBy: 'RELEVANCE',
+      matchAll: false,
+      salaryType: 'MONTHLY',
+      minSalary: 0,
+      salaryUnspecified: true,
+    })
+    expect(url).not.toBeNull()
+    const parsed = new URL(url as string)
+    expect(parsed.host).toBe('hk.employer.seek.com')
+    expect(parsed.pathname).toBe('/talentsearch')
+    expect(parsed.searchParams.get('searchQuery')).toBe('CNC Sales')
+    expect(parsed.searchParams.get('keywords')).toBe('CNC')
+    expect(parsed.searchParams.get('market')).toBe('MY')
+    expect(parsed.searchParams.get('roleTitles')).toBe('Sales')
+    expect(parsed.searchParams.get('pageNumber')).toBe('1')
+    expect(parsed.searchParams.get('sortBy')).toBe('RELEVANCE')
+    expect(parsed.searchParams.get('matchAll')).toBe('false')
+    expect(parsed.searchParams.get('salaryType')).toBe('MONTHLY')
+    expect(parsed.searchParams.get('minSalary')).toBe('0')
+    expect(parsed.searchParams.get('salaryUnspecified')).toBe('true')
+  })
+
+  it('defaults host to my.employer.seek.com when omitted', () => {
+    const url = buildSeekTalentSearchUrl({ keywords: 'Sales' })
+    expect(new URL(url as string).host).toBe('my.employer.seek.com')
+  })
+
+  it('returns null when no keywords or searchQuery provided', () => {
+    expect(buildSeekTalentSearchUrl({ keywords: '' })).toBeNull()
   })
 })

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -43,6 +43,20 @@ export type CollectionSourceType =
   | typeof SEARCH_PROFILE_SOURCE_TYPES.job51
   | typeof SEARCH_PROFILE_SOURCE_TYPES.seek
 
+export const SEEK_MODE = {
+  recommended: 'recommended',
+  talentsearch: 'talentsearch',
+} as const
+
+export type SeekMode = typeof SEEK_MODE[keyof typeof SEEK_MODE]
+
+export function resolveSeekMode(value: string | undefined): SeekMode {
+  if (value === SEEK_MODE.talentsearch) {
+    return SEEK_MODE.talentsearch
+  }
+  return SEEK_MODE.recommended
+}
+
 export type CollectionSource = {
   type: CollectionSourceType
   exactUrl?: string
@@ -68,6 +82,7 @@ export type SearchProfileSource = {
   enabled: boolean
   priority?: number
   jobUrl?: string
+  mode?: SeekMode      // valid only when type === 'seek'; absent ≡ 'recommended'
   unsafeLimits?: boolean
   job51CollectLimit?: number
   job51MaxPages?: number

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -255,6 +255,77 @@ export function isSeekRecommendedCandidatesUrl(value: string | undefined): boole
   }
 }
 
+const SEEK_TALENT_SEARCH_PATH = '/talentsearch'
+
+export function isSeekTalentSearchUrl(value: string | undefined): boolean {
+  const normalized = normalizeSeekJobUrl(value)
+  if (!normalized) {
+    return false
+  }
+  try {
+    const url = new URL(normalized)
+    return url.protocol === 'https:'
+      && url.hostname.toLowerCase().endsWith(SEEK_HOST_SUFFIX)
+      && url.pathname.replace(/\/+$/, '') === SEEK_TALENT_SEARCH_PATH
+      && url.search.length > 0
+  } catch {
+    return false
+  }
+}
+
+type BuildSeekTalentSearchUrlInput = {
+  host?: string  // 'hk.employer.seek.com' | 'my.employer.seek.com'
+  searchQuery?: string
+  keywords?: string
+  market?: string
+  roleTitles?: string[]
+  pageNumber?: number
+  sortBy?: string
+  matchAll?: boolean
+  salaryType?: string
+  minSalary?: number
+  maxSalary?: number
+  salaryUnspecified?: boolean
+}
+
+export function buildSeekTalentSearchUrl(input: BuildSeekTalentSearchUrlInput): string | null {
+  const host = input.host && input.host.endsWith(SEEK_HOST_SUFFIX)
+    ? input.host
+    : 'my.employer.seek.com'
+
+  const hasQuery = (input.searchQuery && input.searchQuery.trim().length > 0)
+    || (input.keywords && input.keywords.trim().length > 0)
+  if (!hasQuery) {
+    return null
+  }
+
+  const url = new URL(`https://${host}${SEEK_TALENT_SEARCH_PATH}`)
+  if (input.searchQuery) url.searchParams.set('searchQuery', input.searchQuery)
+  if (input.keywords) url.searchParams.set('keywords', input.keywords)
+  if (input.market) url.searchParams.set('market', input.market)
+  if (input.roleTitles && input.roleTitles.length > 0) {
+    url.searchParams.set('roleTitles', input.roleTitles.join(','))
+  }
+  if (typeof input.pageNumber === 'number' && input.pageNumber > 0) {
+    url.searchParams.set('pageNumber', String(input.pageNumber))
+  }
+  if (input.sortBy) url.searchParams.set('sortBy', input.sortBy)
+  if (typeof input.matchAll === 'boolean') {
+    url.searchParams.set('matchAll', String(input.matchAll))
+  }
+  if (input.salaryType) url.searchParams.set('salaryType', input.salaryType)
+  if (typeof input.minSalary === 'number') {
+    url.searchParams.set('minSalary', String(input.minSalary))
+  }
+  if (typeof input.maxSalary === 'number') {
+    url.searchParams.set('maxSalary', String(input.maxSalary))
+  }
+  if (typeof input.salaryUnspecified === 'boolean') {
+    url.searchParams.set('salaryUnspecified', String(input.salaryUnspecified))
+  }
+  return url.toString()
+}
+
 export function getActiveSearchProfileSource(
   sources: SearchProfileSource[] | undefined,
 ): SearchProfileSource | undefined {

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -430,10 +430,13 @@ export function getSearchProfileCollectUrl(
   sources: SearchProfileSource[] | undefined,
 ): string | undefined {
   const seekSource = getPreferredSeekSource(sources)
-  if (!seekSource || !isSeekRecommendedCandidatesUrl(seekSource.jobUrl)) {
+  if (!seekSource || !seekSource.jobUrl) {
     return undefined
   }
-
+  // Accept either seek mode (recommended or talentsearch); reject anything else.
+  if (resolveSeekModeFromUrl(seekSource.jobUrl) === null) {
+    return undefined
+  }
   return normalizeSeekJobUrl(seekSource.jobUrl)
 }
 

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -326,6 +326,38 @@ export function buildSeekTalentSearchUrl(input: BuildSeekTalentSearchUrlInput): 
   return url.toString()
 }
 
+export function resolveSeekModeFromUrl(value: string | undefined): SeekMode | null {
+  if (isSeekTalentSearchUrl(value)) return SEEK_MODE.talentsearch
+  if (isSeekRecommendedCandidatesUrl(value)) return SEEK_MODE.recommended
+  return null
+}
+
+type ValidateSeekSourceJobUrlInput = {
+  mode?: SeekMode
+  jobUrl: string | undefined
+}
+
+type ValidateSeekSourceJobUrlResult =
+  | { ok: true }
+  | { ok: false; reason: string }
+
+export function validateSeekSourceJobUrl(
+  input: ValidateSeekSourceJobUrlInput,
+): ValidateSeekSourceJobUrlResult {
+  const mode = resolveSeekMode(input.mode)
+  const urlMode = resolveSeekModeFromUrl(input.jobUrl)
+  if (urlMode === null) {
+    return { ok: false, reason: 'jobUrl is not a recognized seek URL' }
+  }
+  if (urlMode !== mode) {
+    return {
+      ok: false,
+      reason: `jobUrl matches mode=${urlMode} but source declared mode=${mode}`,
+    }
+  }
+  return { ok: true }
+}
+
 export function getActiveSearchProfileSource(
   sources: SearchProfileSource[] | undefined,
 ): SearchProfileSource | undefined {

--- a/config/search-profiles/seek-malaysia-sales.yaml
+++ b/config/search-profiles/seek-malaysia-sales.yaml
@@ -31,14 +31,22 @@ schedule:
 
 sources:
   - type: seek
+    mode: recommended
     enabled: true
     priority: 1
     jobUrl: https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1
     collectLimit: 100
     maxPages: 5
+  - type: seek
+    mode: talentsearch
+    enabled: true
+    priority: 2
+    jobUrl: https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE
+    collectLimit: 500
+    maxPages: 25
   - type: job5156
     enabled: false
-    priority: 2
+    priority: 3
 
 session:
   scope: per-position

--- a/dev-docs/seek-talent-search-graphql-recon.txt
+++ b/dev-docs/seek-talent-search-graphql-recon.txt
@@ -1,0 +1,62 @@
+# SEEK Basic Talent Search — GraphQL Recon
+# Captured: 2026-05-19 13:35 HKT
+# Captured by: claude-code subagent (CDP WebSocket via python websockets)
+# URL: https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE
+
+## Primary list operation
+operationName: SearchProfilesByNaturalLanguage
+query fragment regex (case-insensitive, for fallback classifier): talentSearchProfilesNaturalLanguageSearch\(
+response items path (from response root): data.talentSearchProfilesNaturalLanguageSearch.result.edges
+page size observed: 20
+
+## Variables (list-page request) — captured from real request body
+- input.roleTitles.values: string[] (example: ["Sales"])
+- input.roleTitles.matchLatestOnly: boolean (false)
+- input.companyNames.values: string[] (example: [])
+- input.companyNames.matchLatestOnly: boolean (false)
+- input.keywords.values: string[] (example: ["CNC"])
+- input.keywords.matchAll: boolean (false)
+- input.pageNumber: integer (1, 2, ...)
+- input.pageSize: integer (20)
+- input.locations: string[] (example: ["24500"])
+- input.salary.frequency: string ("MONTHLY" | "ANNUALLY" | "HOURLY")
+- input.salary.includeUnspecified: boolean (true)
+- input.salary.range.minimum: integer (0)
+- input.originalNaturalLanguageQuery: string (example: "CNC Sales")
+- input.countryCode: string (example: "MY")
+- input.sortBy: string ("RELEVANCE")
+- language: string ("en")
+- locale: string ("en-HK")
+
+## Pagination model
+[X] URL-driven (pageNumber in URL query string changes when paging)
+[ ] State-driven (pager click triggers GraphQL with pageNumber in variables; URL stays static or fragment-only)
+[ ] Both
+Notes: pageNumber exists in BOTH the URL query string AND the GraphQL variables.input.pageNumber. Navigating to page 2 via direct URL change or pager click updates both the URL (history.pushState or full navigation) and the GraphQL variables. The page is an SPA but uses URL-driven pagination. On fresh navigation, the pageNumber from the URL is passed through to the GraphQL query.
+
+## Pager selector
+DOM selector for next-page link: nav[aria-label="PAGINATION_OF_RESULTS"] a[rel="next"]
+Selector for current-page indicator: a[aria-current="page"]
+
+## Card / profile-link selector
+List item card root: [data-role="heading"] (candidate name heading inside card; when names are hidden, this holds the job title instead)
+Profile link: N/A — candidate cards are not rendered as <a href="/talentsearch/profile/..."> links. Profile detail is opened by clicking the candidate name element in-card via SPA JavaScript event handlers (no URL navigation; profile opens as overlay/side panel).
+Card count on first page: 20
+
+## Profile detail operation (clicked into one candidate)
+[ ] Same as recommended (GetTalentSearchProfileCompleteV2)
+[X] New operation: GetTalentSearchProfileCompleteV3
+Notes: The detail operation is V3 (not V2). Response root: data.talentSearchProfileV3. Variables: input.countryCode (e.g. "MY"), input.profileGuid (UUID from the search result node, e.g. "52a6b466-895d-11ea-8ede-005056b16351"), input.keywords (e.g. "CNC"). The profile panel opens as an SPA overlay/side panel — URL does NOT change. The response includes firstName, lastName, currentJobTitle, currentLocation, workHistories[], salary, etc.
+
+## Hide-names mode
+Toggle present: yes
+Behavior when enabled: Toggle is a checkbox labeled "Hide names". When enabled, candidate name text (e.g. "HAN SIANG TANG") is replaced with the candidate's current job title (e.g. "CNC Programmer") in the same [data-role="heading"] element. The data-role="heading" attribute remains on the element.
+
+## Secondary GraphQL ops (observed but deliberately ignored)
+- GetAccountContext: Account/zone resolution (hirerOriginZone)
+- HirerFeatureFlags: Feature flag batch queries (5+ flag keys per call, called 2-3 times)
+- GetAccountBalance: Uncoupled talent search budget balance query (connection count)
+- GenerateSearchQuery: Natural-language-to-structured-query translation ("CNC Sales" → roleTitles, keywords)
+- TalentSearchNaturalLanguageSearchFacets: Facet/refinement options for the current search
+- GetConnectionOptions: Fetched in batch (20 profileIds at once) to determine per-card action buttons (send message, send job, export)
+- GetLatestInteractions: Fetched in batch (20 profileIds at once) for per-card interaction history (past messages, applications)

--- a/dev-docs/seek-talent-search-graphql-recon.txt
+++ b/dev-docs/seek-talent-search-graphql-recon.txt
@@ -60,3 +60,52 @@ Behavior when enabled: Toggle is a checkbox labeled "Hide names". When enabled, 
 - TalentSearchNaturalLanguageSearchFacets: Facet/refinement options for the current search
 - GetConnectionOptions: Fetched in batch (20 profileIds at once) to determine per-card action buttons (send message, send job, export)
 - GetLatestInteractions: Fetched in batch (20 profileIds at once) for per-card interaction history (past messages, applications)
+
+## Response node fields (list page) — captured live 2026-05-19
+
+Captured via `window.__TR_RESUME_DATA__.getApiSnapshot().seekTalentSearch[0]` on
+live page `hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&...`
+
+### Node type: `TalentSearchProfileResultV2`
+
+| # | Field | Type | Example | Notes |
+|---|-------|------|---------|-------|
+| 1 | `__typename` | string | `"TalentSearchProfileResultV2"` | Relay typename |
+| 2 | `id` | string | `"503569737"` | Opaque Relay global ID (numeric string, **not** profileId) |
+| 3 | `approachabilitySignal` | number | `0` | |
+| 4 | `avatarUrls` | object\|null | `null` | |
+| 5 | **`profileGuid`** | string | `"52a6b466-895d-11ea-8ede-005056b16351"` | UUID — primary candidate identifier for talent-search; matches V3 profile detail `input.profileGuid` |
+| 6 | **`firstName`** | string | `"HAN SIANG"` | |
+| 7 | **`lastName`** | string | `"TANG"` | |
+| 8 | **`currentJobTitle`** | string\|null | `null` | null when hide-names is ON; string (e.g. `"CNC Programmer"`) when OFF |
+| 9 | **`lastModifiedDurationLabel`** | string | `"over a year ago"` | Human-readable duration label (NOT ISO date like `lastModifiedDate` in recommended lane) |
+| 10 | **`salary`** | object\|null | `null` | Always null on this dataset; structure unknown |
+| 11 | **`currentLocation`** | string | `"Penang, MY"` | |
+| 12 | **`workHistories`** | Array | `Array(4)` | Same shape as recommended lane workHistories |
+| 13 | `hasVerifiedCredentials` | boolean | `false` | |
+| 14 | `nationalities` | Array | `[]` | Empty on this dataset |
+| 15 | `digitalIdentity` | object\|null | `null` | |
+| 16 | `country` | string | `""` | Empty on this dataset |
+| 17 | `state` | string | `""` | Empty on this dataset |
+| 18 | `suburb` | string | `""` | Empty on this dataset |
+| 19 | `profilePrivacy` | string | `"standard"` | |
+
+### Nested: `workHistories[].node` fields
+
+| Field | Type | Example | Notes |
+|-------|------|---------|-------|
+| `companyName` | string | `"UIS Technologies"` | Same shape as recommended lane |
+| `jobTitle` | string | `"CNC Programmer"` | Same shape as recommended lane |
+| `durationLabel` | string | `"Jun 2024 - Present (2 years)"` | Same shape — **no `startDate`/`endDate`** on list page nodes (only in profile detail) |
+| `foundInCV` | boolean | `false` | Extra field not present in recommended lane workHistory |
+| `__typename` | string | `"WorkHistory"` | |
+
+### Nested: `salary` — always null; not observed
+
+### Key differences from recommended lane node (`TalentSearchProfile`)
+
+- **No numeric `profileId`** field — only `profileGuid` (UUID) and `id` (Relay ID)
+- **`lastModifiedDurationLabel`** instead of `lastModifiedDate` (ISO date)
+- **No `profileEducation`**, **no `salary`** (in this dataset)
+- **Extra fields**: `approachabilitySignal`, `hasVerifiedCredentials`, `profilePrivacy`, `digitalIdentity`, `nationalities`
+- `workHistories[]` items have `foundInCV` and `__typename` but **no `startDate`/`endDate`** on list page

--- a/packages/shared/src/generated/search-profile-templates.ts
+++ b/packages/shared/src/generated/search-profile-templates.ts
@@ -47,6 +47,7 @@ export type SharedSearchProfileTemplate = {
       jobUrl?: string;
       collectLimit?: number;
       maxPages?: number;
+      mode?: string;
     }>;
     quickStart?: {
       enabled: boolean;
@@ -324,12 +325,22 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
           "priority": 1,
           "jobUrl": "https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1",
           "collectLimit": 100,
-          "maxPages": 5
+          "maxPages": 5,
+          "mode": "recommended"
+        },
+        {
+          "type": "seek",
+          "enabled": true,
+          "priority": 2,
+          "jobUrl": "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE",
+          "collectLimit": 500,
+          "maxPages": 25,
+          "mode": "talentsearch"
         },
         {
           "type": "job5156",
           "enabled": false,
-          "priority": 2
+          "priority": 3
         }
       ],
       "quickStart": {
@@ -386,12 +397,22 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
           "priority": 1,
           "jobUrl": "https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1",
           "collectLimit": 100,
-          "maxPages": 5
+          "maxPages": 5,
+          "mode": "recommended"
+        },
+        {
+          "type": "seek",
+          "enabled": true,
+          "priority": 2,
+          "jobUrl": "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE",
+          "collectLimit": 500,
+          "maxPages": 25,
+          "mode": "talentsearch"
         },
         {
           "type": "job5156",
           "enabled": false,
-          "priority": 2
+          "priority": 3
         }
       ],
       "quickStart": {

--- a/scripts/resume/sync-search-profile-templates.ts
+++ b/scripts/resume/sync-search-profile-templates.ts
@@ -16,6 +16,7 @@ type ProfileSource = {
   jobUrl?: string;
   collectLimit?: number;
   maxPages?: number;
+  mode?: string;
 };
 
 type ProfileFilters = {
@@ -128,6 +129,7 @@ function parseSource(raw: unknown): ProfileSource | null {
     jobUrl: readString(raw.jobUrl),
     collectLimit: readNumber(raw.collectLimit),
     maxPages: readNumber(raw.maxPages),
+    mode: readString(raw.mode),
   };
 }
 
@@ -316,6 +318,7 @@ export type SharedSearchProfileTemplate = {
       jobUrl?: string;
       collectLimit?: number;
       maxPages?: number;
+      mode?: string;
     }>;
     quickStart?: {
       enabled: boolean;


### PR DESCRIPTION
## Summary

Adds seek.com **Basic Talent Search** as a second seek collection mode (`mode: 'talentsearch'`) alongside the existing `recommended-candidates` lane. Default cap raised to 500 resumes / 25 pages per run for talent search (vs. recommended's 100 / 5).

A search profile may carry one or both seek sources. The lower-priority enabled seek source wins when both are present.

## Recon-driven implementation

Live recon (committed as `dev-docs/seek-talent-search-graphql-recon.txt`) revealed:
- List operation: `SearchProfilesByNaturalLanguage`, response Relay edges at `data.talentSearchProfilesNaturalLanguageSearch.result.edges`
- Profile detail: `GetTalentSearchProfileCompleteV3` (V3, not V2 like the recommended lane). Routed through the existing `seekProfile` snapshot lane.
- Variables nested under `input.{roleTitles.values, keywords.values, salary.range.minimum, ...}`
- Profile detail opens via SPA event delegation (no `<a href>` profile links). **Detail enrichment for talent-search is deferred to a follow-up**; list-level fields are sufficient for the initial slice.
- Identity: `profileGuid` (UUID) on talent-search nodes; recommended lane uses numeric `profileId`. Both feed the same `externalId = {host}:profile:{id}` shape, but cross-lane dedup does NOT converge — same candidate found via both lanes produces two Convex records. Tracked as a follow-up.

## Surface area

- Schema: `SearchProfileSource` gains `mode?: 'recommended' | 'talentsearch'`. Default omitted ≡ recommended (zero migration).
- API service: mode-aware URL validation in `validateProfile`.
- YAML: `seek-malaysia-sales` profile gains a second seek source (talentsearch mode, full URL preserved).
- Editor: round-trip preserves talentsearch source via the additional-sources lane (UI for editing it directly is deferred).
- Manifest: new `/talentsearch?*` content_scripts matches on hk + my hosts. Version bumped 1.1.2 → 1.2.0.
- page-hook.js: classifies `SearchProfilesByNaturalLanguage` and V3 profile op; extends `sanitizeSeekRequestBody` for the nested-input shape.
- content.ts: `apiSnapshot.seekTalentSearch{,Request}` slots, Relay-edge unwrapping, `getCurrentSeekMode()` router, `extractSeekTalentSearchResumes()`, mode-aware pagination (URL-driven, separate `nav[aria-label="PAGINATION_OF_RESULTS"]` selector), `seekMode` + talent-search variables surfaced in `collectionContext`.
- Tests: 4 page-window math cases for talent-search defaults; web lib + editor round-trip + api-service mode-validation tests.
- **Bugfix (late catch):** `getSeekCurrentCandidateCount()` was hardcoded to check `seekRecommendedCandidates`, returning 0 for talent-search mode. This caused the auto-sync to collect 0 resumes despite navigating 5 pages. Fixed with mode-awareness.

## Test plan

- [x] `make sync-search-profile-templates` clean
- [x] All four backend workspaces typecheck clean (shared, api, convex, browser-extension)
- [x] `node --test apps/browser-extension/seek-auto-sync-window.test.mjs` — 14/14
- [x] `npm test` for `search-profile-sources.test.ts` — 43/43
- [x] `npm test` for `SearchProfileEditorDialog.test.tsx` — 8/8
- [x] `bunx vitest run apps/api/src/services/search-profile-service.test.ts` — passing
- [x] `bunx vitest run apps/api/src/routes/search-profiles.test.ts -t 'exposes seeded'` — passing
- [x] Live talent-search auto-sync run — PASS with 100 resumes, `page-window-reached` across 5 pages

## Verification

Live verification (2026-05-19):
- `sourceKey`: `"seek"` — PASS
- `lastOperationName`: `"SearchProfilesByNaturalLanguage"` — PASS
- `autoSyncCount`: 100 — PASS (target 80–100)
- `autoSyncStopReason`: `"page-window-reached"` — PASS
- `autoSyncPages`: 5 — PASS
- Console: 0 errors, 0 warnings — PASS

## Follow-ups (not in this PR)

- Editor UX for the second seek source row (mode dropdown).
- Talent-search profile detail enrichment (V3 click via SPA event delegation).
- Cross-lane dedup investigation: same candidate via UUID vs numeric externalId.

## Spec / plan / recon

- Spec: `~/wiki/projects/trends/work/2026-05-19-seek-talent-search-collection/spec.md`
- Plan: `~/wiki/projects/trends/work/2026-05-19-seek-talent-search-collection/plan.md`
- Recon: `dev-docs/seek-talent-search-graphql-recon.txt`