### PR TITLE
fix: accept seek talent-search URLs in editor + Run Now (#769 hotfix)

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -1608,6 +1608,9 @@
   }
   __name(getSeekRequestedPageSize, "getSeekRequestedPageSize");
   function getSeekCurrentCandidateCount() {
+    if (getCurrentSeekMode() === "talentsearch") {
+      return Array.isArray(apiSnapshot.seekTalentSearch) ? apiSnapshot.seekTalentSearch.length : 0;
+    }
     return Array.isArray(apiSnapshot.seekRecommendedCandidates) ? apiSnapshot.seekRecommendedCandidates.length : 0;
   }
   __name(getSeekCurrentCandidateCount, "getSeekCurrentCandidateCount");

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -990,6 +990,11 @@ function getSeekRequestedPageSize() {
 }
 
 function getSeekCurrentCandidateCount() {
+  if (getCurrentSeekMode() === "talentsearch") {
+    return Array.isArray(apiSnapshot.seekTalentSearch)
+      ? apiSnapshot.seekTalentSearch.length
+      : 0;
+  }
   return Array.isArray(apiSnapshot.seekRecommendedCandidates)
     ? apiSnapshot.seekRecommendedCandidates.length
     : 0;

--- a/apps/web/src/components/SearchProfileEditorDialog.test.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.test.tsx
@@ -369,6 +369,55 @@ describe('SearchProfileEditorDialog JD hydration', () => {
     })
   })
 
+  it('saves a profile whose only seek source is talent-search mode without rejection', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <SearchProfileEditorDialog
+        open
+        onOpenChange={vi.fn()}
+        profileId="custom-profile-2"
+        initialData={{
+          id: 'custom-profile-2',
+          name: 'Seek Talent-Search Only',
+          status: 'active',
+          location: 'MY',
+          keywords: ['CNC', 'Sales'],
+          sources: [
+            {
+              type: 'seek',
+              enabled: true,
+              priority: 1,
+              mode: 'talentsearch',
+              jobUrl: 'https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&keywords=CNC',
+              collectLimit: 500,
+              maxPages: 25,
+            },
+          ],
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledWith('/api/search-profiles/custom-profile-2', {
+        body: expect.objectContaining({
+          sources: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'seek',
+              mode: 'talentsearch',
+              enabled: true,
+              jobUrl: 'https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&keywords=CNC',
+              collectLimit: 500,
+              maxPages: 25,
+            }),
+          ]),
+        }),
+      })
+    })
+  })
+
   it('persists explicit 51job extended-limit settings in the profile payload', async () => {
     const user = userEvent.setup()
 

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -17,8 +17,8 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Select } from '@/components/ui/select'
 import {
     SEARCH_PROFILE_SOURCE_TYPES,
-    isSeekRecommendedCandidatesUrl,
     normalizeSeekJobUrl,
+    resolveSeekModeFromUrl,
     type SearchProfileSource,
 } from '@/lib/search-profile-sources'
 import { api } from '../../../../packages/convex/convex/_generated/api'
@@ -227,13 +227,18 @@ function toSourcesFormState(sources: SearchProfileSource[] | undefined): SourceF
 
     const job5156Source = sources.find((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.job5156)
     const job51Source = sources.find((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.job51)
-    // Editor only surfaces the recommended-mode seek source today. Talent-search
-    // mode sources are preserved via splitKnownSources' `additional` lane so they
-    // round-trip through save without being dropped.
-    const seekSource = sources.find((source) =>
-        source.type === SEARCH_PROFILE_SOURCE_TYPES.seek
-        && (source.mode === undefined || source.mode === 'recommended'),
-    )
+    // Editor surfaces the highest-priority seek source regardless of mode so a
+    // talent-search-only profile is editable alongside recommended-mode profiles.
+    // Any additional seek sources beyond the first stay in `additional` and
+    // round-trip through save unchanged.
+    const seekSources = sources
+        .filter((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.seek)
+        .sort((left, right) => {
+            const leftPriority = typeof left.priority === 'number' ? left.priority : Number.POSITIVE_INFINITY
+            const rightPriority = typeof right.priority === 'number' ? right.priority : Number.POSITIVE_INFINITY
+            return leftPriority - rightPriority
+        })
+    const seekSource = seekSources[0]
 
     return {
         job5156Enabled: job5156Source?.enabled ?? DEFAULT_SOURCES_FORM.job5156Enabled,
@@ -264,6 +269,17 @@ function splitKnownSources(sources: SearchProfileSource[] | undefined): {
         }
     }
 
+    // Identify the highest-priority seek source — it maps to the editor's
+    // single seek form row regardless of mode. All OTHER seek sources are
+    // preserved verbatim via the `additional` lane and round-trip through save.
+    const seekSourceForForm = sources
+        .filter((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.seek)
+        .sort((left, right) => {
+            const leftPriority = typeof left.priority === 'number' ? left.priority : Number.POSITIVE_INFINITY
+            const rightPriority = typeof right.priority === 'number' ? right.priority : Number.POSITIVE_INFINITY
+            return leftPriority - rightPriority
+        })[0]
+
     return {
         known: toSourcesFormState(sources),
         additional: sources.filter((source) => {
@@ -271,11 +287,8 @@ function splitKnownSources(sources: SearchProfileSource[] | undefined): {
             // types are unknown to this editor and pass through.
             if (source.type === SEARCH_PROFILE_SOURCE_TYPES.job5156) return false
             if (source.type === SEARCH_PROFILE_SOURCE_TYPES.job51) return false
-            // Seek sources: only the recommended-mode source maps to the editor's
-            // single seek form row. Talent-search-mode seek sources are preserved
-            // via the additional lane so they round-trip through save.
             if (source.type === SEARCH_PROFILE_SOURCE_TYPES.seek) {
-                return source.mode !== undefined && source.mode !== 'recommended'
+                return source !== seekSourceForForm
             }
             return true
         }),
@@ -313,10 +326,14 @@ function buildSourcesPayload(sourceForm: SourceFormState, additionalSources: Sea
 
     const seekCollectLimit = parseOptionalNumber(sourceForm.seekCollectLimit)
     const seekMaxPages = parseOptionalNumber(sourceForm.seekMaxPages)
+    // Derive seek mode from the URL when possible so a talent-search URL keeps
+    // mode='talentsearch' through edit + save. Fall back to 'recommended' for
+    // empty/unrecognized URLs so back-compat behavior is unchanged.
+    const seekMode = resolveSeekModeFromUrl(sourceForm.seekJobUrl) ?? 'recommended'
 
     sources.push({
         type: SEARCH_PROFILE_SOURCE_TYPES.seek,
-        mode: 'recommended',
+        mode: seekMode,
         enabled: sourceForm.seekEnabled,
         priority: parseOptionalNumber(sourceForm.seekPriority),
         jobUrl: normalizeSeekJobUrl(sourceForm.seekJobUrl),
@@ -569,8 +586,8 @@ export function SearchProfileEditorDialog({
         }
 
         const normalizedSeekJobUrl = normalizeSeekJobUrl(sourceForm.seekJobUrl)
-        if (sourceForm.seekEnabled && !isSeekRecommendedCandidatesUrl(normalizedSeekJobUrl)) {
-            toast.error(t('searchProfiles.seekJobUrlError', { defaultValue: 'Enabled Seek source requires a Seek recommended candidates URL' }))
+        if (sourceForm.seekEnabled && resolveSeekModeFromUrl(normalizedSeekJobUrl) === null) {
+            toast.error(t('searchProfiles.seekJobUrlError', { defaultValue: 'Enabled Seek source requires a recognized Seek URL (recommended candidates or talent search)' }))
             return
         }
 

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -459,11 +459,16 @@ export function buildSeekCollectUrl({
     return null
   }
 
-  const url = normalizedBaseUrl && isSeekRecommendedCandidatesUrl(normalizedBaseUrl)
+  // Preserve a recognized seek base URL (recommended or talent-search) verbatim
+  // so caller-provided query params (jobId / searchQuery / market / etc.) are
+  // not lost. Fall back to the legacy keyword-driven search URL only when the
+  // base URL is missing or unrecognized.
+  const baseUrlMode = normalizedBaseUrl ? resolveSeekModeFromUrl(normalizedBaseUrl) : null
+  const url = normalizedBaseUrl && baseUrlMode !== null
     ? new URL(normalizedBaseUrl)
     : new URL(SEEK_TALENT_SEARCH_URL)
 
-  if (!normalizedBaseUrl) {
+  if (!normalizedBaseUrl || baseUrlMode === null) {
     url.searchParams.set('keyword', formatKeywordQuery(normalizedKeywords))
     if (normalizedLocation.length > 0) {
       url.searchParams.set('location', normalizedLocation)

--- a/apps/web/src/pages/SearchProfilesPage.test.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.test.tsx
@@ -343,6 +343,93 @@ describe('SearchProfilesPage run behavior', () => {
     expect(toastSuccessMock).toHaveBeenCalledWith('Opened collection in a new tab')
   })
 
+  it('opens Seek talent-search profiles in a new tab via Run Now', async () => {
+    const user = userEvent.setup()
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    getMock.mockImplementation(async (path: string) => {
+      if (path === '/api/search-profiles') {
+        return {
+          data: {
+            success: true,
+            profiles: [
+              {
+                id: 'profile-1',
+                name: 'Seek talent-search profile',
+                updatedAt: '2026-05-19T00:00:00.000Z',
+                status: 'active',
+                location: 'Malaysia',
+                keywords: ['CNC', 'Sales'],
+              },
+            ],
+          },
+        }
+      }
+
+      if (path === '/api/search-profiles/profile-1') {
+        return {
+          data: {
+            success: true,
+            profile: {
+              id: 'profile-1',
+              name: 'Seek talent-search profile',
+              status: 'active',
+              location: 'Malaysia',
+              keywords: ['CNC', 'Sales'],
+              schedule: {
+                enabled: false,
+                maxCandidates: 500,
+              },
+              sources: [
+                {
+                  type: 'seek',
+                  mode: 'talentsearch',
+                  enabled: true,
+                  priority: 1,
+                  jobUrl: 'https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&keywords=CNC&matchAll=false&sortBy=RELEVANCE',
+                  collectLimit: 500,
+                  maxPages: 25,
+                },
+              ],
+            },
+          },
+        }
+      }
+
+      if (path === '/api/search-profiles/profile-1/status') {
+        return {
+          data: {
+            success: true,
+            status: null,
+          },
+        }
+      }
+
+      return {
+        data: {
+          success: true,
+        },
+      }
+    })
+
+    render(<SearchProfilesPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Run Seek talent-search profile' }))
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledTimes(1)
+    })
+
+    const openedUrl = new URL(String(openSpy.mock.calls[0]?.[0]))
+    expect(`${openedUrl.origin}${openedUrl.pathname}`).toBe('https://hk.employer.seek.com/talentsearch')
+    expect(openedUrl.searchParams.get('searchQuery')).toBe('CNC Sales')
+    expect(openedUrl.searchParams.get('tr_auto_sync')).toBe('true')
+    expect(openedUrl.searchParams.get('tr_limit')).toBe('500')
+    expect(openedUrl.searchParams.get('tr_max_pages')).toBe('25')
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(toastSuccessMock).toHaveBeenCalledWith('Opened collection in a new tab')
+  })
+
   it('opens 51job profiles in conservative single-page mode', async () => {
     const user = userEvent.setup()
     const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)

--- a/apps/web/src/pages/SearchProfilesPage.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.tsx
@@ -15,7 +15,7 @@ import {
   SEARCH_PROFILE_SOURCE_TYPES,
   buildCollectionLaunchUrl,
   getActiveSearchProfileSource,
-  isSeekRecommendedCandidatesUrl,
+  resolveSeekModeFromUrl,
   type CollectionSourceType,
 } from '@/lib/search-profile-sources'
 
@@ -370,9 +370,9 @@ export function SearchProfilesPage() {
 
     if (isHeadMode && activeSource) {
       if (activeSource.type === SEARCH_PROFILE_SOURCE_TYPES.seek) {
-        if (!isSeekRecommendedCandidatesUrl(activeSource.jobUrl)) {
+        if (resolveSeekModeFromUrl(activeSource.jobUrl) === null) {
           runNowLocksRef.current.delete(profileId)
-          toast.error(t('searchProfiles.seekJobUrlMissing', { defaultValue: 'Seek Run Now requires an exact Seek recommended candidates URL.' }))
+          toast.error(t('searchProfiles.seekJobUrlMissing', { defaultValue: 'Seek Run Now requires a recognized Seek URL (recommended candidates or talent search).' }))
           return
         }
       }


### PR DESCRIPTION
## Summary

Hotfix on top of #769. Six call sites still hardcoded the recommended-only URL gate, so a SEEK profile with a `mode: 'talentsearch'` source was invisible/unsavable in the editor and rejected from Run Now on `/dev/settings/profiles`.

User reported on the deployed dev sandbox: the new talent-search profile/source is not visible at `/dev/settings/profiles`, and Quick Search + Collect do not work from `https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&...`.

## Defects fixed

- `apps/web/src/pages/SearchProfilesPage.tsx` Run Now: gate on `resolveSeekModeFromUrl(...) !== null` (was recommended-only).
- `apps/web/src/components/SearchProfileEditorDialog.tsx` `handleSave`: same broadening.
- `toSourcesFormState` / `splitKnownSources`: surface highest-priority seek source regardless of `mode` (was filtering on `mode === 'recommended'` and shoving talentsearch sources into the hidden `additional` lane → empty seek row in editor).
- `buildSourcesPayload`: derive `seekMode` from the URL instead of hardcoding `'recommended'`, so a talent-search URL round-trips with the right mode.
- `apps/web/src/lib/search-profile-sources.ts` `buildSeekCollectUrl`: preserve a recognized seek base URL verbatim (recommended OR talentsearch) so launch URLs keep `searchQuery` / `market` / `keywords` / `sortBy`.
- `apps/browser-extension/{content.js,src/content.ts}` `getSeekCurrentCandidateCount`: mode-aware (already credited as fixed in #769's commit log but was uncommitted on disk at #769 merge time).

## Why this slipped past Phase 7

#769's Phase 7 verification ran against `make dev` localhost with the seeded `seek-malaysia-sales` fixture whose URL was the *recommended* lane. All five web gates only fire when an operator presents a *talent-search* URL through the editor or Run Now flow on the deployed host. A green `make dev` + `make check` is necessary but not sufficient for URL-gated changes.

Lesson distilled to vault concept `concepts/recon-driven-extension-planning.md` (sub-rule: live verification must hit the deployed surface, not just localhost).

## Tests

Two new failing-then-passing tests added:

- `SearchProfilesPage.test.tsx` — Run Now opens a tab for a talent-search seek source.
- `SearchProfileEditorDialog.test.tsx` — saves a talent-search-only seek profile without rejection.

`bunx vitest run` (apps/web): 1058/1064 passed (one unrelated `BlacklistPage` worker-timeout flake; 5 pre-existing test-file typecheck errors unchanged by this PR).

## Test plan

- [ ] Pull this branch into the deployed dev sandbox, bounce the Vite HMR if needed
- [ ] Open `/dev/settings/profiles`, edit `seek-malaysia-sales`, enter the talent-search URL, save → no toast error
- [ ] Click Run Now → tab opens at `https://hk.employer.seek.com/talentsearch?...&tr_auto_sync=true`
- [ ] Verify the talent-search source row is visible in the editor for an existing talent-search-only profile
- [ ] Click Collect from the talent-search URL → extension auto-syncs

## Note

The deployed sandbox shows `seek-malaysia-sales` with only the recommended source — the YAML template now has both. `ensureWorkspaceSeedProfiles` only seeds on absence and does not refresh on `templateHash` drift. Operator can add the talent-search source via the editor after this PR lands. A separate slice can address re-seed-on-template-drift.