### PR TITLE
feat(config): add seek-malaysia-talent-search profile (4th Quick Start card)

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -1608,6 +1608,9 @@
   }
   __name(getSeekRequestedPageSize, "getSeekRequestedPageSize");
   function getSeekCurrentCandidateCount() {
+    if (getCurrentSeekMode() === "talentsearch") {
+      return Array.isArray(apiSnapshot.seekTalentSearch) ? apiSnapshot.seekTalentSearch.length : 0;
+    }
     return Array.isArray(apiSnapshot.seekRecommendedCandidates) ? apiSnapshot.seekRecommendedCandidates.length : 0;
   }
   __name(getSeekCurrentCandidateCount, "getSeekCurrentCandidateCount");

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -990,6 +990,11 @@ function getSeekRequestedPageSize() {
 }
 
 function getSeekCurrentCandidateCount() {
+  if (getCurrentSeekMode() === "talentsearch") {
+    return Array.isArray(apiSnapshot.seekTalentSearch)
+      ? apiSnapshot.seekTalentSearch.length
+      : 0;
+  }
   return Array.isArray(apiSnapshot.seekRecommendedCandidates)
     ? apiSnapshot.seekRecommendedCandidates.length
     : 0;

--- a/apps/web/src/components/SearchProfileEditorDialog.test.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.test.tsx
@@ -369,6 +369,55 @@ describe('SearchProfileEditorDialog JD hydration', () => {
     })
   })
 
+  it('saves a profile whose only seek source is talent-search mode without rejection', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <SearchProfileEditorDialog
+        open
+        onOpenChange={vi.fn()}
+        profileId="custom-profile-2"
+        initialData={{
+          id: 'custom-profile-2',
+          name: 'Seek Talent-Search Only',
+          status: 'active',
+          location: 'MY',
+          keywords: ['CNC', 'Sales'],
+          sources: [
+            {
+              type: 'seek',
+              enabled: true,
+              priority: 1,
+              mode: 'talentsearch',
+              jobUrl: 'https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&keywords=CNC',
+              collectLimit: 500,
+              maxPages: 25,
+            },
+          ],
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledWith('/api/search-profiles/custom-profile-2', {
+        body: expect.objectContaining({
+          sources: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'seek',
+              mode: 'talentsearch',
+              enabled: true,
+              jobUrl: 'https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&keywords=CNC',
+              collectLimit: 500,
+              maxPages: 25,
+            }),
+          ]),
+        }),
+      })
+    })
+  })
+
   it('persists explicit 51job extended-limit settings in the profile payload', async () => {
     const user = userEvent.setup()
 

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -17,8 +17,8 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Select } from '@/components/ui/select'
 import {
     SEARCH_PROFILE_SOURCE_TYPES,
-    isSeekRecommendedCandidatesUrl,
     normalizeSeekJobUrl,
+    resolveSeekModeFromUrl,
     type SearchProfileSource,
 } from '@/lib/search-profile-sources'
 import { api } from '../../../../packages/convex/convex/_generated/api'
@@ -227,13 +227,18 @@ function toSourcesFormState(sources: SearchProfileSource[] | undefined): SourceF
 
     const job5156Source = sources.find((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.job5156)
     const job51Source = sources.find((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.job51)
-    // Editor only surfaces the recommended-mode seek source today. Talent-search
-    // mode sources are preserved via splitKnownSources' `additional` lane so they
-    // round-trip through save without being dropped.
-    const seekSource = sources.find((source) =>
-        source.type === SEARCH_PROFILE_SOURCE_TYPES.seek
-        && (source.mode === undefined || source.mode === 'recommended'),
-    )
+    // Editor surfaces the highest-priority seek source regardless of mode so a
+    // talent-search-only profile is editable alongside recommended-mode profiles.
+    // Any additional seek sources beyond the first stay in `additional` and
+    // round-trip through save unchanged.
+    const seekSources = sources
+        .filter((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.seek)
+        .sort((left, right) => {
+            const leftPriority = typeof left.priority === 'number' ? left.priority : Number.POSITIVE_INFINITY
+            const rightPriority = typeof right.priority === 'number' ? right.priority : Number.POSITIVE_INFINITY
+            return leftPriority - rightPriority
+        })
+    const seekSource = seekSources[0]
 
     return {
         job5156Enabled: job5156Source?.enabled ?? DEFAULT_SOURCES_FORM.job5156Enabled,
@@ -264,6 +269,17 @@ function splitKnownSources(sources: SearchProfileSource[] | undefined): {
         }
     }
 
+    // Identify the highest-priority seek source — it maps to the editor's
+    // single seek form row regardless of mode. All OTHER seek sources are
+    // preserved verbatim via the `additional` lane and round-trip through save.
+    const seekSourceForForm = sources
+        .filter((source) => source.type === SEARCH_PROFILE_SOURCE_TYPES.seek)
+        .sort((left, right) => {
+            const leftPriority = typeof left.priority === 'number' ? left.priority : Number.POSITIVE_INFINITY
+            const rightPriority = typeof right.priority === 'number' ? right.priority : Number.POSITIVE_INFINITY
+            return leftPriority - rightPriority
+        })[0]
+
     return {
         known: toSourcesFormState(sources),
         additional: sources.filter((source) => {
@@ -271,11 +287,8 @@ function splitKnownSources(sources: SearchProfileSource[] | undefined): {
             // types are unknown to this editor and pass through.
             if (source.type === SEARCH_PROFILE_SOURCE_TYPES.job5156) return false
             if (source.type === SEARCH_PROFILE_SOURCE_TYPES.job51) return false
-            // Seek sources: only the recommended-mode source maps to the editor's
-            // single seek form row. Talent-search-mode seek sources are preserved
-            // via the additional lane so they round-trip through save.
             if (source.type === SEARCH_PROFILE_SOURCE_TYPES.seek) {
-                return source.mode !== undefined && source.mode !== 'recommended'
+                return source !== seekSourceForForm
             }
             return true
         }),
@@ -313,10 +326,14 @@ function buildSourcesPayload(sourceForm: SourceFormState, additionalSources: Sea
 
     const seekCollectLimit = parseOptionalNumber(sourceForm.seekCollectLimit)
     const seekMaxPages = parseOptionalNumber(sourceForm.seekMaxPages)
+    // Derive seek mode from the URL when possible so a talent-search URL keeps
+    // mode='talentsearch' through edit + save. Fall back to 'recommended' for
+    // empty/unrecognized URLs so back-compat behavior is unchanged.
+    const seekMode = resolveSeekModeFromUrl(sourceForm.seekJobUrl) ?? 'recommended'
 
     sources.push({
         type: SEARCH_PROFILE_SOURCE_TYPES.seek,
-        mode: 'recommended',
+        mode: seekMode,
         enabled: sourceForm.seekEnabled,
         priority: parseOptionalNumber(sourceForm.seekPriority),
         jobUrl: normalizeSeekJobUrl(sourceForm.seekJobUrl),
@@ -569,8 +586,8 @@ export function SearchProfileEditorDialog({
         }
 
         const normalizedSeekJobUrl = normalizeSeekJobUrl(sourceForm.seekJobUrl)
-        if (sourceForm.seekEnabled && !isSeekRecommendedCandidatesUrl(normalizedSeekJobUrl)) {
-            toast.error(t('searchProfiles.seekJobUrlError', { defaultValue: 'Enabled Seek source requires a Seek recommended candidates URL' }))
+        if (sourceForm.seekEnabled && resolveSeekModeFromUrl(normalizedSeekJobUrl) === null) {
+            toast.error(t('searchProfiles.seekJobUrlError', { defaultValue: 'Enabled Seek source requires a recognized Seek URL (recommended candidates or talent search)' }))
             return
         }
 

--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -459,11 +459,16 @@ export function buildSeekCollectUrl({
     return null
   }
 
-  const url = normalizedBaseUrl && isSeekRecommendedCandidatesUrl(normalizedBaseUrl)
+  // Preserve a recognized seek base URL (recommended or talent-search) verbatim
+  // so caller-provided query params (jobId / searchQuery / market / etc.) are
+  // not lost. Fall back to the legacy keyword-driven search URL only when the
+  // base URL is missing or unrecognized.
+  const baseUrlMode = normalizedBaseUrl ? resolveSeekModeFromUrl(normalizedBaseUrl) : null
+  const url = normalizedBaseUrl && baseUrlMode !== null
     ? new URL(normalizedBaseUrl)
     : new URL(SEEK_TALENT_SEARCH_URL)
 
-  if (!normalizedBaseUrl) {
+  if (!normalizedBaseUrl || baseUrlMode === null) {
     url.searchParams.set('keyword', formatKeywordQuery(normalizedKeywords))
     if (normalizedLocation.length > 0) {
       url.searchParams.set('location', normalizedLocation)

--- a/apps/web/src/pages/SearchProfilesPage.test.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.test.tsx
@@ -343,6 +343,93 @@ describe('SearchProfilesPage run behavior', () => {
     expect(toastSuccessMock).toHaveBeenCalledWith('Opened collection in a new tab')
   })
 
+  it('opens Seek talent-search profiles in a new tab via Run Now', async () => {
+    const user = userEvent.setup()
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    getMock.mockImplementation(async (path: string) => {
+      if (path === '/api/search-profiles') {
+        return {
+          data: {
+            success: true,
+            profiles: [
+              {
+                id: 'profile-1',
+                name: 'Seek talent-search profile',
+                updatedAt: '2026-05-19T00:00:00.000Z',
+                status: 'active',
+                location: 'Malaysia',
+                keywords: ['CNC', 'Sales'],
+              },
+            ],
+          },
+        }
+      }
+
+      if (path === '/api/search-profiles/profile-1') {
+        return {
+          data: {
+            success: true,
+            profile: {
+              id: 'profile-1',
+              name: 'Seek talent-search profile',
+              status: 'active',
+              location: 'Malaysia',
+              keywords: ['CNC', 'Sales'],
+              schedule: {
+                enabled: false,
+                maxCandidates: 500,
+              },
+              sources: [
+                {
+                  type: 'seek',
+                  mode: 'talentsearch',
+                  enabled: true,
+                  priority: 1,
+                  jobUrl: 'https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&keywords=CNC&matchAll=false&sortBy=RELEVANCE',
+                  collectLimit: 500,
+                  maxPages: 25,
+                },
+              ],
+            },
+          },
+        }
+      }
+
+      if (path === '/api/search-profiles/profile-1/status') {
+        return {
+          data: {
+            success: true,
+            status: null,
+          },
+        }
+      }
+
+      return {
+        data: {
+          success: true,
+        },
+      }
+    })
+
+    render(<SearchProfilesPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Run Seek talent-search profile' }))
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledTimes(1)
+    })
+
+    const openedUrl = new URL(String(openSpy.mock.calls[0]?.[0]))
+    expect(`${openedUrl.origin}${openedUrl.pathname}`).toBe('https://hk.employer.seek.com/talentsearch')
+    expect(openedUrl.searchParams.get('searchQuery')).toBe('CNC Sales')
+    expect(openedUrl.searchParams.get('tr_auto_sync')).toBe('true')
+    expect(openedUrl.searchParams.get('tr_limit')).toBe('500')
+    expect(openedUrl.searchParams.get('tr_max_pages')).toBe('25')
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(toastSuccessMock).toHaveBeenCalledWith('Opened collection in a new tab')
+  })
+
   it('opens 51job profiles in conservative single-page mode', async () => {
     const user = userEvent.setup()
     const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)

--- a/apps/web/src/pages/SearchProfilesPage.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.tsx
@@ -15,7 +15,7 @@ import {
   SEARCH_PROFILE_SOURCE_TYPES,
   buildCollectionLaunchUrl,
   getActiveSearchProfileSource,
-  isSeekRecommendedCandidatesUrl,
+  resolveSeekModeFromUrl,
   type CollectionSourceType,
 } from '@/lib/search-profile-sources'
 
@@ -370,9 +370,9 @@ export function SearchProfilesPage() {
 
     if (isHeadMode && activeSource) {
       if (activeSource.type === SEARCH_PROFILE_SOURCE_TYPES.seek) {
-        if (!isSeekRecommendedCandidatesUrl(activeSource.jobUrl)) {
+        if (resolveSeekModeFromUrl(activeSource.jobUrl) === null) {
           runNowLocksRef.current.delete(profileId)
-          toast.error(t('searchProfiles.seekJobUrlMissing', { defaultValue: 'Seek Run Now requires an exact Seek recommended candidates URL.' }))
+          toast.error(t('searchProfiles.seekJobUrlMissing', { defaultValue: 'Seek Run Now requires a recognized Seek URL (recommended candidates or talent search).' }))
           return
         }
       }

--- a/config/search-profiles/seek-malaysia-talent-search.yaml
+++ b/config/search-profiles/seek-malaysia-talent-search.yaml
@@ -1,0 +1,51 @@
+id: seek-malaysia-talent-search
+name: SEEK Malaysia CNC Sales — Talent Search
+description: Malaysia SEEK workflow targeting the Basic Talent Search lane (job-independent, ~500/run)
+createdAt: "2026-05-19"
+updatedAt: "2026-05-19"
+status: active
+workspaceSlug: [dev, hr]
+seedLastRunOffsetMs: 1800000
+
+location: Malaysia
+keywords:
+  - CNC
+  - Sales
+
+requiredKeywords:
+  - machine tools
+
+jobDescription: seek-malaysia-sales
+
+filters:
+  minExperience: 1
+  maxExperience: null
+  maxAge: 45
+  locations:
+    - Malaysia
+
+schedule:
+  enabled: false
+  timezone: Asia/Kuala_Lumpur
+  maxCandidates: 500
+
+sources:
+  - type: seek
+    mode: talentsearch
+    enabled: true
+    priority: 1
+    jobUrl: https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE
+    collectLimit: 500
+    maxPages: 25
+
+session:
+  scope: per-position
+  retention:
+    mode: until-closed
+    archiveAfterDays: 90
+
+quickStart:
+  enabled: true
+  rank: 4
+  label: Malaysia · SEEK · CNC Sales (Talent Search)
+  description: CNC, Sales · Malaysia · Talent Search lane

--- a/packages/shared/src/generated/search-profile-templates.ts
+++ b/packages/shared/src/generated/search-profile-templates.ts
@@ -429,6 +429,122 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
         }
       }
     }
+  },
+  {
+    "workspaceSlug": "dev",
+    "seedLastRunOffsetMs": 1800000,
+    "profile": {
+      "id": "seek-malaysia-talent-search",
+      "name": "SEEK Malaysia CNC Sales — Talent Search",
+      "description": "Malaysia SEEK workflow targeting the Basic Talent Search lane (job-independent, ~500/run)",
+      "createdAt": "2026-05-19",
+      "updatedAt": "2026-05-19",
+      "status": "active",
+      "location": "Malaysia",
+      "keywords": [
+        "CNC",
+        "Sales"
+      ],
+      "requiredKeywords": [
+        "machine tools"
+      ],
+      "jobDescription": "seek-malaysia-sales",
+      "filters": {
+        "minExperience": 1,
+        "maxExperience": null,
+        "maxAge": 45,
+        "locations": [
+          "Malaysia"
+        ]
+      },
+      "schedule": {
+        "enabled": false,
+        "timezone": "Asia/Kuala_Lumpur",
+        "maxCandidates": 500
+      },
+      "sources": [
+        {
+          "type": "seek",
+          "enabled": true,
+          "priority": 1,
+          "jobUrl": "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE",
+          "collectLimit": 500,
+          "maxPages": 25,
+          "mode": "talentsearch"
+        }
+      ],
+      "quickStart": {
+        "enabled": true,
+        "rank": 4,
+        "label": "Malaysia · SEEK · CNC Sales (Talent Search)",
+        "description": "CNC, Sales · Malaysia · Talent Search lane"
+      },
+      "session": {
+        "scope": "per-position",
+        "retention": {
+          "mode": "until-closed",
+          "archiveAfterDays": 90
+        }
+      }
+    }
+  },
+  {
+    "workspaceSlug": "hr",
+    "seedLastRunOffsetMs": 1800000,
+    "profile": {
+      "id": "seek-malaysia-talent-search",
+      "name": "SEEK Malaysia CNC Sales — Talent Search",
+      "description": "Malaysia SEEK workflow targeting the Basic Talent Search lane (job-independent, ~500/run)",
+      "createdAt": "2026-05-19",
+      "updatedAt": "2026-05-19",
+      "status": "active",
+      "location": "Malaysia",
+      "keywords": [
+        "CNC",
+        "Sales"
+      ],
+      "requiredKeywords": [
+        "machine tools"
+      ],
+      "jobDescription": "seek-malaysia-sales",
+      "filters": {
+        "minExperience": 1,
+        "maxExperience": null,
+        "maxAge": 45,
+        "locations": [
+          "Malaysia"
+        ]
+      },
+      "schedule": {
+        "enabled": false,
+        "timezone": "Asia/Kuala_Lumpur",
+        "maxCandidates": 500
+      },
+      "sources": [
+        {
+          "type": "seek",
+          "enabled": true,
+          "priority": 1,
+          "jobUrl": "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE",
+          "collectLimit": 500,
+          "maxPages": 25,
+          "mode": "talentsearch"
+        }
+      ],
+      "quickStart": {
+        "enabled": true,
+        "rank": 4,
+        "label": "Malaysia · SEEK · CNC Sales (Talent Search)",
+        "description": "CNC, Sales · Malaysia · Talent Search lane"
+      },
+      "session": {
+        "scope": "per-position",
+        "retention": {
+          "mode": "until-closed",
+          "archiveAfterDays": 90
+        }
+      }
+    }
   }
 ];
 


### PR DESCRIPTION
## Summary

Adds a dedicated talent-search-only seek profile with `quickStart.rank=4` so the deployed dev surface gets a separate Quick Start card for the Basic Talent Search lane, alongside the recommended-mode card on `seek-malaysia-sales` (rank=3).

## Why a separate profile, not a 2nd source under seek-malaysia-sales

Quick Start cards are **one-per-profile**, not one-per-source. To surface a 4th card on `/dev/settings/profiles`, the operator needs a dedicated profile entry. Sources within a profile still round-trip via the editor — the talent-search source can also be added under `seek-malaysia-sales` for a single-card setup. Both paths are useful.

## Defaults

- `collectLimit: 500`, `maxPages: 25` (talent-search ceiling per #769 spec).
- `jobDescription: seek-malaysia-sales` (reuses existing JD).
- `schedule.enabled: false` (operator-launched only).
- `quickStart.rank: 4`, label "Malaysia · SEEK · CNC Sales (Talent Search)".

## Generated artifact

`packages/shared/src/generated/search-profile-templates.ts` regenerated via `make sync-search-profile-templates`. `make check` runs `check-search-profile-templates` to detect drift.

## Depends on

#771 (`fix: accept seek talent-search URLs in editor + Run Now`) — without that, the API service-layer validator rejects talent-search URLs, so this profile wouldn't seed cleanly. Merge order: #771 → this PR.

## Test plan

- [ ] Merge #771 first
- [ ] Pull `main` into the deployed dev sandbox
- [ ] Restart dev server (`ensureWorkspaceSeedProfiles` only inserts on absence — fresh insert needed for the new profile id)
- [ ] Open `/dev/settings/profiles` → see 4th card "Malaysia · SEEK · CNC Sales (Talent Search)"
- [ ] Click Run Now on it → tab opens at `https://hk.employer.seek.com/talentsearch?...&tr_auto_sync=true`
- [ ] Click Quick Start (Hero page) on it → live search runs against the talent-search lane