### PR TITLE
feat(api): re-seed profiles when YAML template drifts (opt-in)

### DIFF
--- a/apps/api/src/routes/search-profiles.test.ts
+++ b/apps/api/src/routes/search-profiles.test.ts
@@ -417,6 +417,186 @@ describe('search-profiles list route', () => {
   })
 })
 
+describe('search-profiles drift re-seed', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.SEARCH_PROFILES_RESEED_ON_DRIFT
+  })
+
+  it('skips refresh and only logs when SEARCH_PROFILES_RESEED_ON_DRIFT is unset', async () => {
+    delete process.env.SEARCH_PROFILES_RESEED_ON_DRIFT
+    const updateCalls: ConvexCall[] = []
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+
+      if (call.pathName === 'search_profiles:list') {
+        return convexSuccess([
+          {
+            _id: 'search_profiles-stale-1',
+            name: 'SEEK Malaysia CNC Sales',
+            profileId: 'seek-malaysia-sales',
+            criteria: {
+              keywords: ['CNC', 'Sales'],
+              locations: ['Malaysia'],
+            },
+            profile: {
+              id: 'seek-malaysia-sales',
+              name: 'SEEK Malaysia CNC Sales',
+              status: 'active',
+              location: 'Malaysia',
+              keywords: ['CNC', 'Sales'],
+              seedSource: 'config/search-profiles',
+              templateHash: 'sha256-stale-old-hash',
+              sources: [
+                {
+                  type: 'seek',
+                  enabled: true,
+                  priority: 1,
+                  jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+                  collectLimit: 100,
+                  maxPages: 5,
+                },
+              ],
+            },
+            workspaceSlug: 'dev',
+          },
+        ])
+      }
+
+      if (call.pathName === 'search_profiles:create') {
+        return convexSuccess({
+          _id: `search_profiles-${Date.now()}`,
+          ...call.args,
+        })
+      }
+
+      if (call.pathName === 'search_profiles:update') {
+        updateCalls.push(call)
+        const profile = isRecord(call.args.profile) ? call.args.profile : {}
+        return convexSuccess({
+          _id: 'search_profiles-stale-1',
+          name: profile.name,
+          profileId: profile.id,
+          criteria: {
+            keywords: profile.keywords,
+            locations: [profile.location].filter(Boolean),
+          },
+          profile,
+          workspaceSlug: call.args.workspaceSlug,
+        })
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`)
+    })
+
+    const app = createApp()
+    const response = await app.request('/api/search-profiles', {
+      headers: { 'X-Workspace-Slug': 'dev' },
+    })
+
+    expect(response.status).toBe(200)
+    expect(updateCalls).toHaveLength(0)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('template drift detected for "seek-malaysia-sales"'),
+    )
+  })
+
+  it('refreshes seeded profile sources/quickStart when SEARCH_PROFILES_RESEED_ON_DRIFT=true and templateHash differs', async () => {
+    process.env.SEARCH_PROFILES_RESEED_ON_DRIFT = 'true'
+    const updateCalls: ConvexCall[] = []
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init)
+
+      if (call.pathName === 'search_profiles:list') {
+        return convexSuccess([
+          {
+            _id: 'search_profiles-stale-1',
+            name: 'SEEK Malaysia CNC Sales',
+            profileId: 'seek-malaysia-sales',
+            criteria: {
+              keywords: ['CNC', 'Sales'],
+              locations: ['Malaysia'],
+            },
+            profile: {
+              id: 'seek-malaysia-sales',
+              name: 'SEEK Malaysia CNC Sales',
+              status: 'active',
+              location: 'Malaysia',
+              keywords: ['CNC', 'Sales'],
+              seedSource: 'config/search-profiles',
+              templateHash: 'sha256-stale-old-hash',
+              sources: [
+                {
+                  type: 'seek',
+                  enabled: true,
+                  priority: 1,
+                  jobUrl: 'https://my.employer.seek.com/candidates/recommended?jobId=90842915&pageNumber=1',
+                  collectLimit: 100,
+                  maxPages: 5,
+                },
+              ],
+            },
+            workspaceSlug: 'dev',
+          },
+        ])
+      }
+
+      if (call.pathName === 'search_profiles:create') {
+        return convexSuccess({
+          _id: `search_profiles-${Date.now()}`,
+          ...call.args,
+        })
+      }
+
+      if (call.pathName === 'search_profiles:update') {
+        updateCalls.push(call)
+        const profile = isRecord(call.args.profile) ? call.args.profile : {}
+        return convexSuccess({
+          _id: 'search_profiles-stale-1',
+          name: profile.name,
+          profileId: profile.id,
+          criteria: {
+            keywords: profile.keywords,
+            locations: [profile.location].filter(Boolean),
+          },
+          profile,
+          workspaceSlug: call.args.workspaceSlug,
+        })
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`)
+    })
+
+    const app = createApp()
+    const response = await app.request('/api/search-profiles', {
+      headers: { 'X-Workspace-Slug': 'dev' },
+    })
+
+    expect(response.status).toBe(200)
+
+    const seekUpdate = updateCalls.find((call) => {
+      const profile = isRecord(call.args.profile) ? call.args.profile : {}
+      return profile.id === 'seek-malaysia-sales'
+    })
+    expect(seekUpdate).toBeDefined()
+    if (!seekUpdate) return
+    const refreshedProfile = isRecord(seekUpdate.args.profile) ? seekUpdate.args.profile : {}
+    expect(refreshedProfile.seedSource).toBe('config/search-profiles')
+    expect(refreshedProfile.templateHash).toBeDefined()
+    expect(refreshedProfile.templateHash).not.toBe('sha256-stale-old-hash')
+    const refreshedSources = Array.isArray(refreshedProfile.sources) ? refreshedProfile.sources : []
+    expect(refreshedSources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'seek', mode: 'recommended' }),
+        expect.objectContaining({ type: 'seek', mode: 'talentsearch' }),
+      ]),
+    )
+  })
+})
+
 describe('search-profiles run route', () => {
   beforeEach(() => {
     removeRunStatusFile()

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -652,11 +652,17 @@ async function findCustomProfileRecordById(
     };
 }
 
+function isReseedOnDriftEnabled(): boolean {
+    const value = process.env.SEARCH_PROFILES_RESEED_ON_DRIFT?.toLowerCase().trim();
+    return value === "true" || value === "1" || value === "yes";
+}
+
 async function ensureWorkspaceSeedProfiles(workspaceSlug: string): Promise<void> {
     const existingRecords = await listCustomProfileRecords(workspaceSlug, { includeDeleted: true });
     const existingByLogicalId = new Map<string, ResolvedCustomProfileRecord>(
         existingRecords.map((record) => [record.logicalId, record]),
     );
+    const reseedOnDrift = isReseedOnDriftEnabled();
 
     for (const template of getWorkspaceSearchProfileTemplates(workspaceSlug)) {
         const profile = searchProfileService.normalizeProfileInput(template.profile);
@@ -676,6 +682,45 @@ async function ensureWorkspaceSeedProfiles(workspaceSlug: string): Promise<void>
         if (isSoftDeleted) {
             continue;
         }
+
+        // Drift detection: seeded profile whose YAML template has changed since
+        // it was inserted. Only refresh when the operator opts in via
+        // SEARCH_PROFILES_RESEED_ON_DRIFT — refresh clobbers any user edits to
+        // the profile's sources / quickStart / filters / schedule, so it must
+        // be explicit. Without the env flag, log the drift and skip.
+        const hasDrift = existing.seededFromConfig
+            && typeof existing.templateHash === "string"
+            && existing.templateHash !== currentHash;
+        if (!hasDrift) {
+            continue;
+        }
+
+        if (!reseedOnDrift) {
+            console.warn(
+                `[search-profiles] template drift detected for "${logicalId}" (workspace=${workspaceSlug}); ` +
+                `set SEARCH_PROFILES_RESEED_ON_DRIFT=true to refresh from YAML automatically, ` +
+                `or PUT the profile manually via the editor.`,
+            );
+            continue;
+        }
+
+        const refreshedProfile = searchProfileService.normalizeProfileInput(
+            { ...profile, id: existing.profile.id },
+            existing.profile,
+        );
+        refreshedProfile.id = existing.profile.id;
+        await updateCustomProfile(
+            existing.storageId,
+            toStoredProfilePayload(refreshedProfile, {
+                seededFromConfig: true,
+                templateHash: currentHash,
+            }),
+            workspaceSlug,
+        );
+        console.warn(
+            `[search-profiles] refreshed "${logicalId}" (workspace=${workspaceSlug}) from YAML template ` +
+            `(hash ${existing.templateHash ?? "unknown"} → ${currentHash}).`,
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

`ensureWorkspaceSeedProfiles` previously only inserted on absence. Once a profile was seeded into Convex, later edits to its YAML template never propagated. The seek talent-search slice (#769) made this acutely visible: the YAML now declares two seek sources, but the deployed `seek-malaysia-sales` Convex record still shows only the original recommended-mode source.

## Behavior

- **Drift detection** runs on every list-fetch: a seeded record (`seedSource: 'config/search-profiles'`) whose stored `templateHash` differs from the YAML's current hash is flagged.
- **Default**: log a warning to `console.warn`, do NOT touch Convex. Operators can react before any refresh happens.
- **Opt-in**: setting `SEARCH_PROFILES_RESEED_ON_DRIFT=true` (env var) flips the warning into a refresh that overwrites the Convex record's `profile` payload from the YAML template (sources, quickStart, filters, schedule, etc.) and updates the stored `templateHash`.

The opt-in gate exists because refresh clobbers any user edits to seeded profiles. Until we have a separate `userEdited` flag distinguishing "operator customized" from "untouched seed", forcing refresh by default would silently lose UI edits.

## Tests

`apps/api/src/routes/search-profiles.test.ts` (new `describe('search-profiles drift re-seed')`):

- env unset → `updateCalls.length === 0`, `console.warn` fires with `'template drift detected for "seek-malaysia-sales"'`.
- env=true → update mutation called with refreshed `sources` (recommended + talentsearch) and a fresh `templateHash`.

Full test file: 16/16 passing.

## Operational notes

- For the deployed dev sandbox, after #771 + #772 merge:
  - With `SEARCH_PROFILES_RESEED_ON_DRIFT=true` in the dev env, restarting the API will refresh `seek-malaysia-sales` to include both seek sources without manual UI editing.
  - Without the flag, the warning lands in API logs and the operator can either edit via UI (with #771's fixes accepting talent-search URLs) or set the flag temporarily.
- For prod, leave the flag unset until the user-edit-vs-seed-edit boundary is tracked explicitly.

## Test plan

- [ ] Merge order: #771 → #772 → this PR
- [ ] In dev sandbox, set `SEARCH_PROFILES_RESEED_ON_DRIFT=true`, restart API
- [ ] Hit `GET /api/search-profiles` → see `seek-malaysia-sales.sources.length === 3` (seek-recommended + seek-talentsearch + job5156)
- [ ] Hit `GET /api/search-profiles` again → no further refresh log lines (templateHash now matches)
- [ ] Unset env, restart, edit YAML, restart again → see drift warning in API logs but no update call

## Follow-up (not in this PR)

- Track `userEdited` flag separately from `seededFromConfig` so prod can opt into automatic refresh without losing operator edits.
- "Reset to template" button on the editor for seeded profiles.