### PR TITLE
fix(web): clean up 21 pre-existing TypeScript errors + unblock BlacklistPage hang

### DIFF
--- a/apps/web/src/components/AnalysisTaskMonitor.test.tsx
+++ b/apps/web/src/components/AnalysisTaskMonitor.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 const mockUseQuery = vi.hoisted(() => vi.fn())
-const mockUseMutation = vi.hoisted(() => vi.fn(() => vi.fn()))
+const mockUseMutation = vi.hoisted(() => vi.fn((..._args: unknown[]) => vi.fn()))
 
 vi.mock('convex/react', () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),

--- a/apps/web/src/components/TaskMonitor.test.tsx
+++ b/apps/web/src/components/TaskMonitor.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 const mockUseQuery = vi.hoisted(() => vi.fn())
-const mockUseMutation = vi.hoisted(() => vi.fn(() => vi.fn()))
+const mockUseMutation = vi.hoisted(() => vi.fn((..._args: unknown[]) => vi.fn()))
 
 vi.mock('convex/react', () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),

--- a/apps/web/src/hooks/useLongTaskObserver.test.tsx
+++ b/apps/web/src/hooks/useLongTaskObserver.test.tsx
@@ -1,5 +1,5 @@
 import { render, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { LongTaskObserver, useLongTaskObserver } from './useLongTaskObserver'
 
 describe('useLongTaskObserver', () => {

--- a/apps/web/src/layouts/SystemSettingsLayout.test.tsx
+++ b/apps/web/src/layouts/SystemSettingsLayout.test.tsx
@@ -42,12 +42,15 @@ describe('SystemSettingsLayout', () => {
       },
     })
     mockResolveSystemSettingsSubpages.mockImplementation((nav: unknown[]) =>
-      nav?.map((item: Record<string, unknown>) => ({
-        id: item.id,
-        titleKey: item.titleKey,
-        defaultTitle: item.defaultTitle,
-        href: item.href,
-      })) ?? []
+      nav?.map((value) => {
+        const item = value as Record<string, unknown>
+        return {
+          id: item.id,
+          titleKey: item.titleKey,
+          defaultTitle: item.defaultTitle,
+          href: item.href,
+        }
+      }) ?? []
     )
   })
 

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -67,7 +67,7 @@ describe('getLatestNews', () => {
       ok: false,
       status: 503,
       json: async () => { throw new Error('not json') },
-    } as Response)
+    } as unknown as Response)
 
     const result = await getLatestNews()
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -29,15 +29,17 @@ export interface NewsItem {
   mobileUrl?: string
 }
 
-export interface ApiResponse<T> {
-  success: boolean
-  data?: T
-  error?: {
-    code: string
-    message: string
-    suggestion?: string
-  }
-}
+export type ApiResponse<T> =
+  | { success: true; data: T; error?: never }
+  | {
+      success: false
+      data?: never
+      error: {
+        code: string
+        message: string
+        suggestion?: string
+      }
+    }
 
 export interface GetLatestNewsParams {
   platforms?: string[]

--- a/apps/web/src/pages/BlacklistPage.test.tsx
+++ b/apps/web/src/pages/BlacklistPage.test.tsx
@@ -5,18 +5,28 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 const mockUnblockCandidate = vi.hoisted(() => vi.fn())
 const mockUpdateBlockReason = vi.hoisted(() => vi.fn())
 
+// Stable hook return value: BlacklistPage has a useEffect with [items] in its
+// dependency list that calls setSelectedIdentityKeys with a freshly filtered
+// array. The real useCandidateBlocks caches `items` via useState so its
+// reference is stable across renders. A naive mock that returns a fresh object
+// on every call triggers an infinite re-render loop and the test process
+// hangs/crashes silently. Hoist the value so it's referentially stable.
+const HOOK_VALUE = vi.hoisted(() => ({
+  items: [
+    { _id: '1', identityKey: 'user-1', workspaceSlug: 'dev', reason: 'Spam', blockedAt: 3000 },
+    { _id: '2', identityKey: 'user-2', workspaceSlug: 'dev', blockedAt: 2000 },
+    { _id: '3', identityKey: 'user-3', workspaceSlug: 'dev', reason: 'Duplicate', blockedAt: 1000 },
+  ],
+  loading: false,
+  error: null as string | null,
+  unblockCandidate: undefined as ReturnType<typeof vi.fn> | undefined,
+  updateBlockReason: undefined as ReturnType<typeof vi.fn> | undefined,
+}))
+HOOK_VALUE.unblockCandidate = mockUnblockCandidate
+HOOK_VALUE.updateBlockReason = mockUpdateBlockReason
+
 vi.mock('@/hooks/useCandidateBlocks', () => ({
-  useCandidateBlocks: () => ({
-    items: [
-      { _id: '1', identityKey: 'user-1', workspaceSlug: 'dev', reason: 'Spam', blockedAt: 3000 },
-      { _id: '2', identityKey: 'user-2', workspaceSlug: 'dev', blockedAt: 2000 },
-      { _id: '3', identityKey: 'user-3', workspaceSlug: 'dev', reason: 'Duplicate', blockedAt: 1000 },
-    ],
-    loading: false,
-    error: null,
-    unblockCandidate: mockUnblockCandidate,
-    updateBlockReason: mockUpdateBlockReason,
-  }),
+  useCandidateBlocks: () => HOOK_VALUE,
 }))
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
@@ -32,14 +42,20 @@ vi.mock('@/components/ui/badge', () => ({
 }))
 
 vi.mock('@/components/ui/button', () => ({
-  Button: ({ children, onClick, disabled, variant, size }: {
+  Button: ({ children, onClick, disabled, variant, size, ...rest }: {
     children?: React.ReactNode
     onClick?: React.MouseEventHandler<HTMLButtonElement>
     disabled?: boolean
     variant?: string
     size?: string
-  }) => (
-    <button onClick={onClick} disabled={disabled} data-variant={variant} data-size={size}>
+  } & Record<string, unknown>) => (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      data-variant={variant}
+      data-size={size}
+      {...rest}
+    >
       {children}
     </button>
   ),
@@ -86,7 +102,7 @@ describe('BlacklistPage', () => {
 
   it('renders the page header', () => {
     render(<BlacklistPage />)
-    expect(screen.getByText(/Blacklist/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/Blacklist/i).length).toBeGreaterThan(0)
   })
 
   it('renders all blocked items in the table', () => {
@@ -119,25 +135,29 @@ describe('BlacklistPage', () => {
     const user = userEvent.setup()
     render(<BlacklistPage />)
 
-    const unblockButtons = screen.getAllByText(/Unblock/i)
-    await user.click(unblockButtons[0])
+    const rowUnblockButtons = screen.getAllByTestId('blacklist-row-unblock')
+    expect(rowUnblockButtons.length).toBe(3)
+    // Rows are sorted by blockedAt desc → first row is user-1 (blockedAt 3000)
+    await user.click(rowUnblockButtons[0])
 
     expect(mockUnblockCandidate).toHaveBeenCalledWith('user-1')
   })
 
-  it('edits block reason inline', async () => {
+  it('edits block reason inline by clicking the reason cell and committing on blur', async () => {
     const user = userEvent.setup()
     render(<BlacklistPage />)
 
-    // Find and click edit button for user who has a reason
-    const editButtons = screen.getAllByText(/Edit/i)
-    await user.click(editButtons[0])
+    // Reason cells are buttons (not labelled "Edit" — the reason text itself is the trigger).
+    // First row is user-1 (Spam, blockedAt 3000).
+    const reasonDisplays = screen.getAllByTestId('blacklist-reason-display')
+    expect(reasonDisplays.length).toBe(3)
+    await user.click(reasonDisplays[0])
 
-    const reasonInput = screen.getByDisplayValue('Spam')
+    const reasonInput = screen.getByTestId('blacklist-reason-input')
     await user.clear(reasonInput)
     await user.type(reasonInput, 'Updated reason')
-
-    await user.click(screen.getByText(/Save/i))
+    // commitReason fires on blur, not via a Save button
+    await user.tab()
 
     expect(mockUpdateBlockReason).toHaveBeenCalledWith('user-1', 'Updated reason')
   })

--- a/apps/web/src/pages/BlacklistPage.test.tsx
+++ b/apps/web/src/pages/BlacklistPage.test.tsx
@@ -32,9 +32,15 @@ vi.mock('@/components/ui/badge', () => ({
 }))
 
 vi.mock('@/components/ui/button', () => ({
-  Button: ({ children, onClick, disabled, variant, size }: Record<string, unknown>) => (
+  Button: ({ children, onClick, disabled, variant, size }: {
+    children?: React.ReactNode
+    onClick?: React.MouseEventHandler<HTMLButtonElement>
+    disabled?: boolean
+    variant?: string
+    size?: string
+  }) => (
     <button onClick={onClick} disabled={disabled} data-variant={variant} data-size={size}>
-      {children as React.ReactNode}
+      {children}
     </button>
   ),
 }))
@@ -48,7 +54,10 @@ vi.mock('@/components/ui/card', () => ({
 }))
 
 vi.mock('@/components/ui/checkbox', () => ({
-  Checkbox: ({ checked, onCheckedChange }: Record<string, unknown>) => (
+  Checkbox: ({ checked, onCheckedChange }: {
+    checked?: boolean
+    onCheckedChange?: (checked: boolean) => void
+  }) => (
     <input type="checkbox" checked={checked} onChange={(e) => onCheckedChange?.(e.target.checked)} />
   ),
 }))

--- a/apps/web/src/pages/TrendsPage.test.tsx
+++ b/apps/web/src/pages/TrendsPage.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 const mockUseTrends = vi.hoisted(() => vi.fn())

--- a/apps/web/src/pages/system-settings/SystemSettingsLocationsPage.test.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsLocationsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 const mockRequestJson = vi.hoisted(() => vi.fn())
 const mockParseCustomKeywordsPayload = vi.hoisted(() => vi.fn())

--- a/apps/web/src/pages/system-settings/SystemSettingsOperationsPage.test.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsOperationsPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 
-const mockUseMutation = vi.hoisted(() => vi.fn(() => vi.fn()))
+const mockUseMutation = vi.hoisted(() => vi.fn((..._args: unknown[]) => vi.fn()))
 const mockToast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }))
 
 vi.mock('convex/react', () => ({


### PR DESCRIPTION
## Summary

`bunx tsc --noEmit` in `apps/web` was failing with **21 errors across 9 test files** on `main`. Plus `BlacklistPage.test.tsx` was silently hanging at runtime (CI cancelled it at the 10-min mark on every PR). This PR drives both to **0**:

- TypeScript errors: 21 → 0
- BlacklistPage runtime: hung 10+ min → 6/6 tests pass in 0.8s

Restores a clean typecheck baseline so future PRs can assert "no new TS errors" and unblocks the slowest test file in the suite.

## Categories fixed

| Category | Count | Files | Fix |
|---|---|---|---|
| TS2556 spread args | 3 | `AnalysisTaskMonitor.test.tsx`, `TaskMonitor.test.tsx`, `SystemSettingsOperationsPage.test.tsx` | Annotate `vi.fn` factory with `(..._args: unknown[]) => ...` |
| TS6133 unused imports | 3 | `useLongTaskObserver.test.tsx`, `TrendsPage.test.tsx`, `SystemSettingsLocationsPage.test.tsx` | Remove unused `afterEach` / `userEvent` |
| TS2345 callback signature | 1 | `SystemSettingsLayout.test.tsx` | Use standard `Array.map` callback shape with explicit cast in body |
| TS18048 possibly-undefined | 9 | `api.test.ts` | Convert `ApiResponse<T>` from non-discriminated to proper discriminated union |
| TS2352 invalid cast | 1 | `api.test.ts` | `as unknown as Response` |
| TS2322/TS2349 typed mocks | 4 | `BlacklistPage.test.tsx` | Replace `Record<string, unknown>` mock prop types with explicit shapes |
| **Runtime hang** | 1 | `BlacklistPage.test.tsx` | See below |

## Notable change: `ApiResponse<T>` discriminated union

`apps/web/src/lib/types.ts`:

```ts
// Before — non-discriminated; `if (result.success)` did NOT narrow `data`
export interface ApiResponse<T> {
  success: boolean
  data?: T
  error?: { code: string; message: string; suggestion?: string }
}

// After — discriminated; narrows correctly
export type ApiResponse<T> =
  | { success: true; data: T; error?: never }
  | { success: false; data?: never; error: { code: string; message: string; suggestion?: string } }
```

Only used in `apps/web/src/lib/api.ts` (`getLatestNews`, `searchNews`) and `apps/web/src/hooks/useTrends.test.ts`. All callers gated on `if (result.success)` already, so behavior is unchanged at runtime — only the type narrowing is improved.

## BlacklistPage runtime hang — root cause + fix

`BlacklistPage.tsx` has:

```ts
useEffect(() => {
  const currentKeys = new Set(items.map(...))
  setSelectedIdentityKeys((previous) => previous.filter(...))
}, [items])
```

The mocked `useCandidateBlocks` returned a fresh object literal (with a new `items` array reference) on every call. Each render → new `items` ref → `useEffect` deps change → setState fires → re-render → repeat. The vitest worker crashed silently after exhausting memory; from outside it looked like an infinite hang.

**Fix:** hoist the hook return value once via `vi.hoisted` so the reference is stable, mirroring how the real `useCandidateBlocks` caches `items` in `useState`.

Bonus: 3 broken test assertions referenced UI text that never existed in `BlacklistPage` (the file had been unrunnable since it was added, so the assertions were never validated against real DOM). Fixed all 3 to use the correct `data-testid` selectors. Also updated the mocked `Button` to spread `...rest` so test ids reach the DOM.

Result: **6/6 tests pass in 0.8s** (was: silent hang, CI cancelled at 10m).

## Test plan

- [x] `bunx tsc --noEmit` in `apps/web` → exit 0
- [x] All fixed test files pass: `api.test.ts` (10/10), `AnalysisTaskMonitor` (8/8), `TaskMonitor` (8/8), `useLongTaskObserver` (9/9), `SystemSettingsLayout` (4/4), `TrendsPage` (5/5), `SystemSettingsLocationsPage` + `SystemSettingsOperationsPage` (12/12), `useTrends.test.ts` (14/14, regression check on `ApiResponse`), `BlacklistPage` (6/6, was hanging)
- [x] No production code touched aside from `types.ts`'s `ApiResponse` discriminated union conversion. `BlacklistPage.tsx` source unchanged — only the test was broken.

## Related

- #775 (CI timeout 10m → 30m): bandaids the symptom of the BlacklistPage hang. With this PR, the underlying hang is gone, so #775's bumped timeout is more about giving the rest of the suite room rather than absorbing this one specific file's flake.