### PR TITLE
ci: bump tests.yml timeout from 10m → 30m

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

The Tests workflow's `test` job has `timeout-minutes: 10`, but the full vitest run (apps/web + apps/api with coverage) takes ~22 minutes locally on a 4-core dev sandbox. CI runs on `ubuntu-latest` (2 cores) — even slower.

Result: every PR fails the `test` job at the 10-min cancellation, with output ending mid-test like:

```
test  Run tests with coverage  ##[error]The operation was canceled.
```

No failing assertion, no useful signal. Confirmed across #769, #771, #772, #773, #774.

This PR bumps the timeout to **30 minutes** so vitest can finish + Codecov upload can run. The other 3 checks (`secret-scan`, `i18n-check`, `verify`) keep their current limits and continue to provide signal.

## Why not shard / parallelize?

A real fix is to split the suite (web vs api, or shard via `vitest --shard 1/4`) and run them in parallel jobs. That's a larger change requiring coverage merging logic and possibly a workflow rewrite. This PR is the **immediate unblock** — bump the timeout, restore signal, then design the parallelization properly.

## Test plan

- [ ] Merge this PR
- [ ] Open a follow-up trivial PR (or watch the next real PR) — confirm `test` job actually runs to completion
- [ ] If it still fails after 30 min, that's a different problem (genuine perf regression or hang) and we revisit with sharding

## Out of scope

- `BlacklistPage.test.tsx` runtime hang — pre-existing, deserves its own diagnosis. Once fixed, total runtime will drop substantially.
- Splitting web vs api into parallel jobs — separate slice.