### PR TITLE
test(useConvexResumes): add age/role filter forwarding and loading state tests

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.list.test.ts
+++ b/apps/web/src/hooks/useConvexResumes.list.test.ts
@@ -236,4 +236,56 @@ describe('useConvexResumes list path', () => {
       maxSalary: 20,
     })
   })
+
+  it('forwards age filters to the paginated list query', () => {
+    renderHook(() => useConvexResumes(200, undefined, 'jd-1', {
+      filters: {
+        minAge: 25,
+        maxAge: 40,
+      },
+    }))
+
+    const listCall = usePaginatedQueryMock.mock.calls.find(([, args]) => args !== 'skip' && !('query' in (args as Record<string, unknown>)))
+
+    expect(listCall?.[1]).toMatchObject({
+      minAge: 25,
+      maxAge: 40,
+    })
+  })
+
+  it('forwards role filters to the paginated list query', () => {
+    renderHook(() => useConvexResumes(200, undefined, 'jd-1', {
+      filters: {
+        minRoleYears: 3,
+        roleFilterType: 'verified',
+      },
+    }))
+
+    const listCall = usePaginatedQueryMock.mock.calls.find(([, args]) => args !== 'skip' && !('query' in (args as Record<string, unknown>)))
+
+    expect(listCall?.[1]).toMatchObject({
+      minRoleYears: 3,
+      roleFilterType: 'verified',
+    })
+  })
+
+  it('returns loading=true while the first page is loading', () => {
+    usePaginatedQueryMock.mockImplementation((_query, args) => ({
+      results: args === 'skip' ? [] : [],
+      status: args === 'skip' ? 'Exhausted' : 'LoadingFirstPage',
+      isLoading: true,
+      loadMore: loadMoreMock,
+    }))
+
+    const { result } = renderHook(() => useConvexResumes(200))
+
+    expect(result.current.loading).toBe(true)
+  })
+
+  it('returns loading=false when disabled', () => {
+    const { result } = renderHook(() => useConvexResumes(200, undefined, undefined, { enabled: false }))
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.resumes).toEqual([])
+  })
 })

--- a/apps/web/src/hooks/useConvexResumes.search.test.ts
+++ b/apps/web/src/hooks/useConvexResumes.search.test.ts
@@ -290,4 +290,100 @@ describe('useConvexResumes AND-mode search', () => {
       sourceMapping: {},
     })
   })
+
+  it('forwards age and role filters to the search query alongside keywords', async () => {
+    rawApiGetMock.mockResolvedValueOnce({
+      data: {
+        success: true,
+        summary: {
+          groups: [{ original: 'cnc', variants: ['cnc'] }],
+          mode: 'OR' as const,
+          expandedTo: ['cnc'],
+          sourceMapping: {},
+        },
+      },
+    })
+    const searchPaginatedResult: PaginatedResult = {
+      results: [buildSearchEntry('resume-1', 'Alice')],
+      status: 'Exhausted',
+      isLoading: false,
+      loadMore: loadMoreMock,
+    }
+    usePaginatedQueryMock.mockImplementation((_query, args) =>
+      args === 'skip' ? skipPaginatedResult : searchPaginatedResult,
+    )
+
+    renderHook(() => useConvexResumes(200, 'CNC', undefined, {
+      filters: {
+        minAge: 25,
+        maxAge: 40,
+        minRoleYears: 3,
+        roleFilterType: 'verified',
+      },
+    }))
+
+    let searchCall: unknown[] | undefined
+    await waitFor(() => {
+      searchCall = usePaginatedQueryMock.mock.calls.find(
+        ([, args]) => args !== 'skip' && typeof args === 'object' && 'query' in (args as Record<string, unknown>),
+      )
+      expect(searchCall).toBeDefined()
+    })
+
+    expect(searchCall?.[1]).toMatchObject({
+      minAge: 25,
+      maxAge: 40,
+      minRoleYears: 3,
+      roleFilterType: 'verified',
+    })
+  })
+
+  it('shows loading=true while keyword expansion is in flight', async () => {
+    let resolveExpansion: (value: unknown) => void
+    const expansionPromise = new Promise((resolve) => { resolveExpansion = resolve })
+    rawApiGetMock.mockImplementation(async (path?: unknown) => {
+      if (path === '/api/resumes') {
+        return {
+          data: {
+            success: true,
+            data: [],
+            summary: { total: 0 },
+          },
+        }
+      }
+      await expansionPromise
+      return {
+        data: {
+          success: true,
+          summary: {
+            groups: [{ original: 'cnc', variants: ['cnc'] }],
+            mode: 'OR' as const,
+            expandedTo: ['cnc'],
+            sourceMapping: {},
+          },
+        },
+      }
+    })
+    usePaginatedQueryMock.mockImplementation((_query, args) =>
+      args === 'skip'
+        ? skipPaginatedResult
+        : { results: [], status: 'LoadingFirstPage' as const, isLoading: true, loadMore: loadMoreMock },
+    )
+
+    const { result } = renderHook(() => useConvexResumes(200, 'CNC'))
+
+    // While expansion is pending, loading should be true
+    expect(result.current.loading).toBe(true)
+
+    // Resolve the expansion and wait for the query to fire
+    resolveExpansion!(null)
+    usePaginatedQueryMock.mockImplementation((_query, args) =>
+      args === 'skip'
+        ? skipPaginatedResult
+        : { results: [], status: 'Exhausted' as const, isLoading: false, loadMore: loadMoreMock },
+    )
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Add 6 test cases covering gaps in useConvexResumes hook test coverage
- Age filters (minAge/maxAge) forwarded to list and search queries
- Role filters (minRoleYears/roleFilterType) forwarded to list query
- Loading state assertions: true during first page load, true during keyword expansion, false when disabled

## Test plan
- [x] All 1,136 tests pass (0 failures)
- [x] `make check-node` passes with 0 errors
- [x] New tests cover filter forwarding paths that were the root cause of recent bugs