### PR TITLE
fix: deduplicate useBrandDisplayMap HTTP requests via context provider

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ import SettingsLayout from '@/layouts/SettingsLayout'
 import SystemLayout from '@/layouts/SystemLayout'
 import SystemSettingsLayout from '@/layouts/SystemSettingsLayout'
 import { WorkspaceProvider, useWorkspace } from '@/contexts/WorkspaceContext'
+import { BrandDisplayMapProvider } from '@/contexts/BrandDisplayMapContext'
 import { ResumeFieldUsagePolicyProvider } from '@/contexts/ResumeFieldUsagePolicyContext'
 import { isReviewPacketsEnabled } from '@/lib/feature-flags'
 
@@ -102,7 +103,9 @@ function WorkspaceShell() {
   return (
     <WorkspaceProvider>
       <ResumeFieldUsagePolicyProvider>
-        <Outlet />
+        <BrandDisplayMapProvider>
+          <Outlet />
+        </BrandDisplayMapProvider>
       </ResumeFieldUsagePolicyProvider>
     </WorkspaceProvider>
   )

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -134,7 +134,7 @@ export function ResumeList() {
   const backgroundEnhancementsEnabled = hasCompletedInitialListLoad
   useSyncNotifications(backgroundEnhancementsEnabled)
   const { slug: workspaceSlug } = useWorkspace()
-  const { resolve: brandDisplayResolve } = useBrandDisplayMap(backgroundEnhancementsEnabled)
+  const { resolve: brandDisplayResolve } = useBrandDisplayMap()
 
   const [detailResume, setDetailResume] = useState<ResumeItem | ConvexResumeItem | null>(null)
   const [detailResumeId, setDetailResumeId] = useState<ConvexResumeItem['resumeId'] | null>(null)

--- a/apps/web/src/contexts/BrandDisplayMapContext.tsx
+++ b/apps/web/src/contexts/BrandDisplayMapContext.tsx
@@ -1,0 +1,57 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { rawApiClient } from '@/lib/api-helpers'
+import { useWorkspace } from './WorkspaceContext'
+
+type BrandDisplayEntry = {
+  displayName: string
+  zhHans: string
+}
+
+type BrandDisplayMap = Record<string, BrandDisplayEntry>
+
+const BrandDisplayMapContext = createContext<BrandDisplayMap | null>(null)
+
+export function BrandDisplayMapProvider({ children }: { children: ReactNode }) {
+  const [map, setMap] = useState<BrandDisplayMap | null>(null)
+  const { slug } = useWorkspace()
+
+  useEffect(() => {
+    let active = true
+    setMap(null)
+
+    rawApiClient
+      .GET<BrandDisplayMap>('/api/industry/brand-display-map')
+      .then(({ data }) => {
+        if (active) setMap(data ?? null)
+      })
+      .catch((err: unknown) => {
+        console.error('Failed to load brand display map', err)
+        if (active) setMap(null)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [slug])
+
+  return (
+    <BrandDisplayMapContext.Provider value={map}>
+      {children}
+    </BrandDisplayMapContext.Provider>
+  )
+}
+
+export function useBrandDisplayMapResolve() {
+  const map = useContext(BrandDisplayMapContext)
+
+  const resolve = useCallback(
+    (brandId: string) => {
+      const key = (brandId ?? '').trim().toLowerCase()
+      if (!key) return ''
+      return map?.[key]?.zhHans ?? brandId.toUpperCase()
+    },
+    [map],
+  )
+
+  return useMemo(() => ({ resolve }), [resolve])
+}

--- a/apps/web/src/hooks/useBrandDisplayMap.test.tsx
+++ b/apps/web/src/hooks/useBrandDisplayMap.test.tsx
@@ -1,5 +1,7 @@
 import { renderHook, act } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { BrandDisplayMapProvider, useBrandDisplayMapResolve } from '@/contexts/BrandDisplayMapContext'
 import { useBrandDisplayMap } from './useBrandDisplayMap'
 
 type BrandEntry = { displayName: string; zhHans: string }
@@ -13,26 +15,29 @@ vi.mock('@/lib/api-helpers', () => ({
   rawApiClient: mockApiClient,
 }))
 
+vi.mock('@/contexts/WorkspaceContext', () => ({
+  useWorkspace: () => ({ slug: 'test' }),
+}))
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <BrandDisplayMapProvider>{children}</BrandDisplayMapProvider>
+}
+
 describe('useBrandDisplayMap', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   it('returns resolve function immediately', () => {
-    const { result } = renderHook(() => useBrandDisplayMap(false))
+    const { result } = renderHook(() => useBrandDisplayMap(), { wrapper })
     expect(typeof result.current.resolve).toBe('function')
   })
 
-  it('does not fetch when disabled', () => {
-    renderHook(() => useBrandDisplayMap(false))
-    expect(mockApiClient.GET).not.toHaveBeenCalled()
-  })
-
-  it('fetches brand display map when enabled', async () => {
+  it('fetches brand display map via provider', async () => {
     mockApiClient.GET.mockResolvedValueOnce({
       data: { nike: { displayName: 'Nike', zhHans: '耐克' } },
     })
-    renderHook(() => useBrandDisplayMap(true))
+    renderHook(() => useBrandDisplayMap(), { wrapper })
 
     await act(async () => {})
     expect(mockApiClient.GET).toHaveBeenCalledWith('/api/industry/brand-display-map')
@@ -42,7 +47,7 @@ describe('useBrandDisplayMap', () => {
     mockApiClient.GET.mockResolvedValueOnce({
       data: { nike: { displayName: 'Nike', zhHans: '耐克' } },
     })
-    const { result } = renderHook(() => useBrandDisplayMap(true))
+    const { result } = renderHook(() => useBrandDisplayMap(), { wrapper })
     await act(async () => {})
 
     expect(result.current.resolve('nike')).toBe('耐克')
@@ -52,7 +57,7 @@ describe('useBrandDisplayMap', () => {
     mockApiClient.GET.mockResolvedValueOnce({
       data: { nike: { displayName: 'Nike', zhHans: '耐克' } },
     })
-    const { result } = renderHook(() => useBrandDisplayMap(true))
+    const { result } = renderHook(() => useBrandDisplayMap(), { wrapper })
     await act(async () => {})
 
     expect(result.current.resolve('adidas')).toBe('ADIDAS')
@@ -60,7 +65,7 @@ describe('useBrandDisplayMap', () => {
 
   it('resolve returns empty string for empty brandId', async () => {
     mockApiClient.GET.mockResolvedValueOnce({ data: {} })
-    const { result } = renderHook(() => useBrandDisplayMap(true))
+    const { result } = renderHook(() => useBrandDisplayMap(), { wrapper })
     await act(async () => {})
 
     expect(result.current.resolve('')).toBe('')
@@ -69,7 +74,7 @@ describe('useBrandDisplayMap', () => {
 
   it('resolve handles null data from API', async () => {
     mockApiClient.GET.mockResolvedValueOnce({ data: null })
-    const { result } = renderHook(() => useBrandDisplayMap(true))
+    const { result } = renderHook(() => useBrandDisplayMap(), { wrapper })
     await act(async () => {})
 
     expect(result.current.resolve('nike')).toBe('NIKE')
@@ -77,9 +82,42 @@ describe('useBrandDisplayMap', () => {
 
   it('resolve handles API error gracefully', async () => {
     mockApiClient.GET.mockRejectedValueOnce(new Error('network'))
-    const { result } = renderHook(() => useBrandDisplayMap(true))
+    const { result } = renderHook(() => useBrandDisplayMap(), { wrapper })
     await act(async () => {})
 
     expect(result.current.resolve('nike')).toBe('NIKE')
+  })
+
+  it('only makes one fetch regardless of how many hooks consume it', async () => {
+    mockApiClient.GET.mockResolvedValueOnce({
+      data: { nike: { displayName: 'Nike', zhHans: '耐克' } },
+    })
+    renderHook(
+      () => ({
+        a: useBrandDisplayMap(),
+        b: useBrandDisplayMap(),
+        c: useBrandDisplayMap(),
+      }),
+      { wrapper },
+    )
+    await act(async () => {})
+
+    expect(mockApiClient.GET).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useBrandDisplayMapResolve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('works directly with provider', async () => {
+    mockApiClient.GET.mockResolvedValueOnce({
+      data: { nike: { displayName: 'Nike', zhHans: '耐克' } },
+    })
+    const { result } = renderHook(() => useBrandDisplayMapResolve(), { wrapper })
+    await act(async () => {})
+
+    expect(result.current.resolve('nike')).toBe('耐克')
   })
 })

--- a/apps/web/src/hooks/useBrandDisplayMap.ts
+++ b/apps/web/src/hooks/useBrandDisplayMap.ts
@@ -1,47 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { rawApiClient } from '@/lib/api-helpers'
+import { useBrandDisplayMapResolve } from '@/contexts/BrandDisplayMapContext'
 
-type BrandDisplayEntry = {
-  displayName: string
-  zhHans: string
-}
-
-type BrandDisplayMap = Record<string, BrandDisplayEntry>
-
-export function useBrandDisplayMap(enabled: boolean = true) {
-  const [map, setMap] = useState<BrandDisplayMap | null>(null)
-
-  useEffect(() => {
-    if (!enabled) {
-      return
-    }
-
-    let mounted = true
-
-    rawApiClient
-      .GET<BrandDisplayMap>('/api/industry/brand-display-map')
-      .then(({ data }) => {
-        if (!mounted) return
-        setMap(data ?? null)
-      })
-      .catch((err: unknown) => {
-        console.error('Failed to load brand display map', err)
-        if (mounted) setMap(null)
-      })
-
-    return () => {
-      mounted = false
-    }
-  }, [enabled])
-
-  const resolve = useCallback(
-    (brandId: string) => {
-      const key = (brandId ?? '').trim().toLowerCase()
-      if (!key) return ''
-      return map?.[key]?.zhHans ?? brandId.toUpperCase()
-    },
-    [map]
-  )
-
-  return useMemo(() => ({ resolve }), [resolve])
+/**
+ * Returns a resolve function that maps brand IDs to display names.
+ * Data is fetched once by BrandDisplayMapProvider (at app level) and shared
+ * across all consumers — no per-component HTTP requests.
+ */
+export function useBrandDisplayMap() {
+  return useBrandDisplayMapResolve()
 }


### PR DESCRIPTION
## Summary
- `useBrandDisplayMap` was called per `SnippetCard`/`SnippetCardExpanded` component, firing N identical requests to `/api/industry/brand-display-map`
- On 429 errors, each component retried independently, causing request storms that starved all other API endpoints → zero resumes displayed
- Fix: Create `BrandDisplayMapContext` that fetches once and shares via React context. The hook now reads from context instead of fetching directly.

## Changes
- **NEW**: `apps/web/src/contexts/BrandDisplayMapContext.tsx` — context provider + `useBrandDisplayMapResolve` hook
- **MODIFIED**: `apps/web/src/hooks/useBrandDisplayMap.ts` — thin shim delegating to context
- **MODIFIED**: `apps/web/src/App.tsx` — wrap with `BrandDisplayMapProvider`
- **MODIFIED**: `apps/web/src/components/ResumeList.tsx` — remove unused `enabled` arg
- **RENAMED**: `useBrandDisplayMap.test.ts` → `.tsx` — updated tests with provider wrapper

## Test plan
- [x] `make check` passes (0 errors, pre-existing warnings only)
- [x] `vitest run src/hooks/useBrandDisplayMap.test.tsx` — 9/9 pass
- [x] Browser verified: 123 results for "CNC Sales" in Malaysia, 0 console errors, no 429 storms