### PR TITLE
feat: seek talentsearch V3 detail enrichment for recommended profile URLs

### DIFF
--- a/apps/api/src/services/feedback-import-service.ts
+++ b/apps/api/src/services/feedback-import-service.ts
@@ -206,6 +206,12 @@ export function normalizeProfileIdentityKey(value: string | undefined, source?: 
     if (profileIdMatch?.[1]) {
       return `profileUrl:${hostname}/candidates/${profileIdMatch[1]}`.toLowerCase();
     }
+
+    // UUID profileGuid (talentsearch): /candidates/{uuid}
+    const uuidMatch = parsed.pathname.match(/\/candidates\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\/|$)/i);
+    if (uuidMatch?.[1]) {
+      return `profileUrl:${hostname}/candidates/${uuidMatch[1]}`.toLowerCase();
+    }
   }
 
   return `profileUrl:${normalizeUrlForIdentity(parsed)}`;

--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -7,6 +7,7 @@ import { z } from "@hono/zod-openapi";
 import {
   formatLocationHierarchyLabel,
   normalizeResumeLocationHierarchy,
+  normalizeSeekProfileUrlForDisplay,
 } from "@trends/shared";
 import {
   ResumeImportItemSchema,
@@ -272,14 +273,40 @@ function buildResumeExternalId(resume: ResumeImportItem, source: string, hash: s
   return `${source}:hash:${hash}`;
 }
 
-function buildNormalizedResumeContent(resume: ResumeImportItem): Record<string, unknown> {
+function buildNormalizedResumeContent(
+  resume: ResumeImportItem,
+  seekContext?: { sourceHost: string; jobId?: string },
+): Record<string, unknown> {
   const { sourceHost: _sourceHost, tags: _tags, ...content } = resume;
   const locationHierarchy = normalizeResumeLocationHierarchy(resume);
   const rawLocation = typeof content.location === "string" ? content.location.trim() : "";
   const location = rawLocation || (locationHierarchy ? formatLocationHierarchyLabel(locationHierarchy) : "");
 
+  // Normalize seek profileUrl to recommended format at import time
+  let profileUrl = content.profileUrl;
+  if (typeof profileUrl === "string" && seekContext?.sourceHost) {
+    const normalized = normalizeSeekProfileUrlForDisplay(profileUrl);
+    if (normalized && normalized !== profileUrl) {
+      // Build recommended URL if we have a jobId
+      if (seekContext.jobId) {
+        try {
+          const parsed = new URL(normalized);
+          const profileIdMatch = parsed.pathname.match(/\/candidates\/(\d+)$/);
+          if (profileIdMatch?.[1]) {
+            profileUrl = `https://${parsed.hostname}/candidates/recommended?jobId=${seekContext.jobId}&openProfileId=${profileIdMatch[1]}`;
+          }
+        } catch {
+          profileUrl = normalized;
+        }
+      } else {
+        profileUrl = normalized;
+      }
+    }
+  }
+
   return {
     ...content,
+    ...(typeof profileUrl === "string" && profileUrl ? { profileUrl } : {}),
     location,
     ...(locationHierarchy ? { locationHierarchy } : {}),
   };
@@ -359,10 +386,16 @@ export function normalizeResumeImportPayload(input: ResumeImportRequest): Normal
   const defaultTags = tag ? [tag] : [];
   const source = resolveResumeSource(metadata);
 
+  const isSeekSource = source.endsWith(".employer.seek.com") || source.toLowerCase() === "seek";
+  const seekJobId = metadata.collectionContext?.jobId;
+
   const convexResumes = resumes.map((resume) => {
     const itemSource = normalizeSourceHost(resume.sourceHost) ?? source;
     const itemTags = normalizeTagList(resume.tags) ?? defaultTags;
-    const content: unknown = buildNormalizedResumeContent(resume);
+    const content: unknown = buildNormalizedResumeContent(
+      resume,
+      isSeekSource ? { sourceHost: itemSource, jobId: seekJobId } : undefined,
+    );
     const hash = crypto.createHash("sha256").update(stableStringify(content), "utf8").digest("hex");
     const externalId = buildResumeExternalId(resume, itemSource, hash);
 

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -1136,14 +1136,70 @@ function findSeekProfileTrigger(profileId) {
   );
 }
 
+/**
+ * Talentsearch cards have no <a> links — candidate name is a [data-role="heading"]
+ * element clicked via SPA event handlers. Find the card matching this profileId
+ * (UUID) by checking data attributes or card index.
+ */
+function findSeekTalentSearchCardTrigger(profileId, resume) {
+  if (!profileId) return null;
+  // Try matching by data-tr-candidate-id attribute (set during extraction)
+  const byAttr = document.querySelector(
+    `[data-tr-candidate-id="${CSS.escape(profileId)}"]`,
+  );
+  if (byAttr instanceof HTMLElement) return byAttr;
+  // Fallback: match heading elements that contain the candidate name.
+  // Talentsearch cards use [data-role="heading"] for the candidate name.
+  const candidateName = typeof resume?.name === "string" ? resume.name.trim() : "";
+  if (candidateName) {
+    const headings = Array.from(
+      document.querySelectorAll('[data-role="heading"]'),
+    );
+    const match = headings.find((h) => {
+      const text = (h.textContent || "").trim();
+      return text === candidateName || text.startsWith(candidateName);
+    });
+    if (match instanceof HTMLElement) return match;
+  }
+  return null;
+}
+
 function mergeSeekListResumeWithDetail(baseResume, detailResume) {
   if (!detailResume || typeof detailResume !== "object") {
     return baseResume;
   }
 
+  // For talentsearch: if V3 detail provides a numeric profileId, use it for
+  // profileUrl construction but preserve the UUID seekProfileGuid
+  const isTalentSearch = getCurrentSeekMode() === "talentsearch";
+  const seekProfileGuid = baseResume.seekProfileGuid || detailResume.seekProfileGuid || undefined;
+  const numericProfileId = isTalentSearch && detailResume.profileId && /^\d+$/.test(detailResume.profileId)
+    ? detailResume.profileId
+    : undefined;
+
+  // If we got a numeric profileId from V3 detail, update the profileUrl
+  let profileUrl = detailResume.profileUrl || baseResume.profileUrl;
+  if (numericProfileId) {
+    // Derive jobId from the current page URL or API request for recommended URL format
+    const seekRequest = getSeekTalentSearchRequest();
+    const requestJobId = seekRequest?.variables?.input?.jobId;
+    const urlJobId = normalizeOptionalPositiveInt(
+      new URL(window.location.href).searchParams.get("jobId"),
+    );
+    const jobId = requestJobId != null
+      ? String(requestJobId)
+      : urlJobId != null
+        ? String(urlJobId)
+        : undefined;
+    profileUrl = buildSeekProfileUrl(numericProfileId, jobId);
+  }
+
   return {
     ...baseResume,
     ...detailResume,
+    ...(seekProfileGuid ? { seekProfileGuid } : {}),
+    ...(numericProfileId ? { profileId: numericProfileId } : {}),
+    ...(profileUrl ? { profileUrl } : {}),
     pageIndex: baseResume.pageIndex,
     pageNumber: baseResume.pageNumber,
     extractedAt: baseResume.extractedAt,
@@ -2528,6 +2584,10 @@ function extractSeekProfileResume() {
         ? String(jobIdFromUrl)
         : undefined;
   const { profileId, profileType } = getSeekCandidateIdentity(profile);
+  const seekProfileGuid =
+    typeof profile.profileGuid === "string" && profile.profileGuid
+      ? profile.profileGuid
+      : undefined;
   const firstName =
     typeof profile.firstName === "string" ? profile.firstName.trim() : "";
   const lastName =
@@ -2604,6 +2664,7 @@ function extractSeekProfileResume() {
     {
       profileId,
       profileType,
+      seekProfileGuid,
       externalId: profileId
         ? `${window.location.hostname.toLowerCase()}:profile:${profileId}`
         : "",
@@ -3535,14 +3596,17 @@ function extractSeekTalentSearchResumes() {
 
   return candidates
     .map((node, index) => {
-      // Prefer profileGuid (UUID) as the identity key for talent-search;
-      // fall back to the numeric-looking Relay "id" if profileGuid is missing.
-      const profileId =
+      // profileGuid (UUID) is the primary identity for talentsearch
+      const profileGuid =
         typeof node?.profileGuid === "string" && node.profileGuid
           ? node.profileGuid
-          : typeof node?.id === "string" && node.id
-            ? node.id
-            : "";
+          : "";
+      // Relay "id" — numeric-looking string, used as fallback
+      const relayId =
+        typeof node?.id === "string" && node.id ? node.id : "";
+      // For talentsearch, profileId = profileGuid (UUID); numeric profileId
+      // may become available after V3 detail enrichment
+      const profileId = profileGuid || relayId;
       if (!profileId) return null;
 
       const firstName =
@@ -3570,6 +3634,7 @@ function extractSeekTalentSearchResumes() {
       return {
         profileId,
         profileType: "seek",
+        seekProfileGuid: profileGuid || undefined,
         externalId: profileId
           ? `${window.location.hostname.toLowerCase()}:profile:${profileId}`
           : "",
@@ -4899,7 +4964,13 @@ function waitForSeekProfileSnapshot(profileId, { timeoutMs = 12000 } = {}) {
       if (done) return;
       const snapshot = apiSnapshot.seekProfile;
       const identity = snapshot ? getSeekCandidateIdentity(snapshot) : null;
-      if (identity?.profileId === String(profileId)) {
+      // Match by profileId (numeric) or profileGuid (UUID for talentsearch)
+      const snapshotGuid =
+        typeof snapshot?.profileGuid === "string" ? snapshot.profileGuid : "";
+      if (
+        identity?.profileId === String(profileId) ||
+        snapshotGuid === String(profileId)
+      ) {
         done = true;
         cleanup();
         resolve(snapshot);
@@ -4934,16 +5005,34 @@ async function enrichSingleSeekResumeWithDetail(resume) {
     return resume;
   }
 
-  const trigger = findSeekProfileTrigger(profileId);
+  const isTalentSearch = getCurrentSeekMode() === "talentsearch";
+  const trigger = isTalentSearch
+    ? findSeekTalentSearchCardTrigger(profileId, resume)
+    : findSeekProfileTrigger(profileId);
   if (!(trigger instanceof HTMLElement)) {
     return resume;
   }
 
   try {
     trigger.click();
-    await waitForSeekProfileSnapshot(profileId, { timeoutMs: 12000 });
+    // For talentsearch, match by profileGuid (UUID); for recommended, match by numeric profileId
+    const matchId = isTalentSearch ? resume.seekProfileGuid || profileId : profileId;
+    await waitForSeekProfileSnapshot(matchId, { timeoutMs: 12000 });
     const [detailResume] = extractSeekProfileResume();
-    if (!detailResume || detailResume.profileId !== profileId) {
+    if (!detailResume) {
+      return resume;
+    }
+    // For talentsearch, verify the detail profile matches by profileGuid or profileId
+    if (isTalentSearch) {
+      const detailGuid = detailResume.seekProfileGuid || "";
+      const detailProfileId = detailResume.profileId || "";
+      if (detailGuid !== profileId && detailProfileId !== profileId) {
+        return resume;
+      }
+      // Merge: talentsearch detail may provide numeric profileId from V3 response
+      return mergeSeekListResumeWithDetail(resume, detailResume);
+    }
+    if (detailResume.profileId !== profileId) {
       return resume;
     }
     return mergeSeekListResumeWithDetail(resume, detailResume);
@@ -4961,14 +5050,6 @@ async function enrichSeekResumesWithDetail(resumes) {
   if (!Array.isArray(resumes) || resumes.length === 0) return [];
   if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return resumes;
   if (isSeekProfileMode()) return resumes;
-  // Talent-search list cards do NOT expose <a href="/talentsearch/profile/..."> links
-  // (per 2026-05-19 recon — see dev-docs/seek-talent-search-graphql-recon.txt). The
-  // existing findSeekProfileTrigger hunts for hrefs that do not exist, and the V3
-  // profile response is captured under a different snapshot shape. Detail enrichment
-  // for talent-search is deferred to a follow-up; list-level fields (firstName,
-  // lastName, currentLocation, currentJobTitle, workHistories[]) are sufficient
-  // for the initial slice and are already populated on list-page nodes.
-  if (getCurrentSeekMode() === "talentsearch") return resumes;
 
   const enriched = [];
   for (const resume of resumes) {

--- a/packages/convex/convex/lib/resume_identity.ts
+++ b/packages/convex/convex/lib/resume_identity.ts
@@ -142,9 +142,16 @@ function normalizeSeekProfileUrlForIdentity(value: string, source: string | unde
         return `${hostname}/candidates/${openProfileIdParam}`.toLowerCase();
     }
 
+    // Numeric profileId: /candidates/{profileId} or /candidates/profiles/{profileId}/...
     const profileIdMatch = parsed.pathname.match(/\/candidates\/(?:profiles\/)?(\d+)(?:\/|$)/i);
     if (profileIdMatch && profileIdMatch[1]) {
         return `${hostname}/candidates/${profileIdMatch[1]}`.toLowerCase();
+    }
+
+    // UUID profileGuid (talentsearch): /candidates/{uuid}
+    const uuidMatch = parsed.pathname.match(/\/candidates\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\/|$)/i);
+    if (uuidMatch && uuidMatch[1]) {
+        return `${hostname}/candidates/${uuidMatch[1]}`.toLowerCase();
     }
 
     return normalizeUrlForIdentity(parsed);

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -83,6 +83,7 @@ export type NormalizedResumeFields = {
 
 const JOB5156_HOST = "hr.job5156.com";
 const JOB5156_PROFILE_URL_PREFIX = `https://${JOB5156_HOST}/resume/view/`;
+const SEEK_HOST_SUFFIX = ".employer.seek.com";
 
 const SOURCE_KEY_TO_COUNTRY: Record<ResumeAnalysisSourceKey, string> = {
   job5156: "中国",
@@ -161,17 +162,82 @@ export function normalizeJob5156ProfileUrlForDisplay(value: string): string {
   return `${JOB5156_PROFILE_URL_PREFIX}${encodeURIComponent(resumeId)}`;
 }
 
+export function normalizeSeekProfileUrlForDisplay(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  let parsed: URL | null = null;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return trimmed;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (!hostname.endsWith(SEEK_HOST_SUFFIX)) {
+    return trimmed;
+  }
+
+  // Already in recommended format — return as-is
+  if (parsed.pathname.toLowerCase() === "/candidates/recommended") {
+    return trimmed;
+  }
+
+  // Extract profileId from URL — supports both numeric and UUID formats
+  let profileId: string | null = null;
+
+  // Numeric pattern: /candidates/{profileId} or /candidates/profiles/{profileId}/...
+  const numericIdMatch = parsed.pathname.match(/\/candidates\/(?:profiles\/)?(\d+)(?:\/|$)/i);
+  if (numericIdMatch?.[1]) {
+    profileId = numericIdMatch[1];
+  }
+
+  // UUID pattern: /candidates/{uuid} (talentsearch mode — no jobId available)
+  if (!profileId) {
+    const uuidIdMatch = parsed.pathname.match(/\/candidates\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\/|$)/i);
+    if (uuidIdMatch?.[1]) {
+      // Talentsearch UUID URLs pass through — cannot build recommended URL without numeric profileId
+      return trimmed;
+    }
+  }
+
+  if (!profileId) {
+    return trimmed;
+  }
+
+  // Fallback: direct path format (no jobId available at display time)
+  return `https://${hostname}/candidates/${profileId}`;
+}
+
 export function normalizeProfileUrlForDisplay(value: unknown, source?: string): string {
   const trimmed = toTrimmedString(value);
   if (!trimmed) {
     return "";
   }
 
-  if (source?.toLowerCase() !== JOB5156_HOST) {
-    return trimmed;
+  const loweredSource = source?.toLowerCase();
+
+  if (loweredSource === JOB5156_HOST) {
+    return normalizeJob5156ProfileUrlForDisplay(trimmed);
   }
 
-  return normalizeJob5156ProfileUrlForDisplay(trimmed);
+  if (loweredSource?.endsWith(SEEK_HOST_SUFFIX)) {
+    return normalizeSeekProfileUrlForDisplay(trimmed);
+  }
+
+  // Also handle seek URLs regardless of source (safety net for mixed data)
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.hostname.toLowerCase().endsWith(SEEK_HOST_SUFFIX)) {
+      return normalizeSeekProfileUrlForDisplay(trimmed);
+    }
+  } catch {
+    // Not a valid URL — pass through
+  }
+
+  return trimmed;
 }
 
 function normalizeStringOrObject<T>(


### PR DESCRIPTION
## Summary
- Enable V3 profile detail enrichment for talentsearch mode — previously skipped via early return
- Capture numeric `profileId` from V3 profile API response (alongside existing UUID `profileGuid`)
- Build recommended-format profile URLs (`/candidates/recommended?jobId=X&openProfileId=Y`) when both numeric profileId and jobId are available
- Add UUID pattern support in identity/display normalization across shared, convex, and api packages
- Add import-time seek profileUrl normalization with jobId from collectionContext

## Problem
400+ talentsearch resumes store UUID-based `profileUrl` values like `https://hk.employer.seek.com/candidates/82a5d7c6-...` which are non-functional. The V3 profile API response includes a numeric `profileId` that enables building the recommended URL format.

## Test plan
- [ ] Verify `make check` passes (done ✅)
- [ ] Test talentsearch import with browser extension — verify V3 detail enrichment triggers and captures numeric profileId
- [ ] Verify recommended URLs resolve to actual candidate profiles when logged into seek
- [ ] Verify UUID-based identity normalization works for existing talentsearch resumes
- [ ] Test import-time normalization with jobId context produces recommended URLs