### PR TITLE
fix: Seek MY search zero results — experience filter + market projection + profile cleanup

### DIFF
--- a/apps/web/src/lib/search-profile-sources.ts
+++ b/apps/web/src/lib/search-profile-sources.ts
@@ -77,15 +77,6 @@ export function getCollectionSourceMarket(sourceType: CollectionSourceType): 'CN
   return SOURCE_MARKET_MAP[sourceType]
 }
 
-/**
- * Derive market from a resume's sourceKey (stored in ingestData).
- * Falls back to "CN" for legacy resumes without market data.
- */
-export function getResumeMarket(sourceKey?: string | null): 'CN' | 'MY' {
-  if (!sourceKey) return 'CN'
-  return SOURCE_MARKET_MAP[sourceKey as CollectionSourceType] ?? 'CN'
-}
-
 export type SearchProfileSource = {
   type: string
   enabled: boolean

--- a/config/search-profiles/seek-malaysia-sales.yaml
+++ b/config/search-profiles/seek-malaysia-sales.yaml
@@ -12,9 +12,6 @@ keywords:
   - CNC
   - Sales
 
-requiredKeywords:
-  - machine tools
-
 jobDescription: seek-malaysia-sales
 
 filters:

--- a/config/search-profiles/seek-malaysia-talent-search.yaml
+++ b/config/search-profiles/seek-malaysia-talent-search.yaml
@@ -12,9 +12,6 @@ keywords:
   - CNC
   - Sales
 
-requiredKeywords:
-  - machine tools
-
 jobDescription: seek-malaysia-sales
 
 filters:

--- a/packages/convex/convex/__tests__/experience-filter-graceful-degradation.test.ts
+++ b/packages/convex/convex/__tests__/experience-filter-graceful-degradation.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import { searchWithTagExpansionPaginated } from "../resumes";
+
+type ConvexHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+type SearchPaginatedArgs = {
+  paginationOpts: { cursor: string | null; numItems: number };
+  query: string;
+  keywordGroups: Array<{ original: string; variants: string[] }>;
+  mode?: "AND" | "OR";
+  sourceMappings?: Array<{ term: string; expandedFrom: string }>;
+  minExperience?: number;
+  maxExperience?: number;
+  minRoleYears?: number;
+  roleFilterType?: string;
+  requiredKeywords?: string[];
+  locations?: string[];
+  sources?: string[];
+};
+
+type SearchPaginatedResult = {
+  page: unknown[];
+  continueCursor: string;
+  isDone: boolean;
+};
+
+const searchPaginatedHandler = (
+  searchWithTagExpansionPaginated as unknown as ConvexHandler<SearchPaginatedArgs, SearchPaginatedResult>
+)._handler;
+
+function buildSeekResumeDoc(id: string, experience: string) {
+    return {
+        _id: id,
+        externalId: `seek:${id}`,
+        source: "seek",
+        tags: [],
+        crawledAt: Date.now(),
+        content: {
+            name: id,
+            experience,
+            workHistory: [
+                { company: "Test Co", title: "Sales", years: "?" },
+            ],
+        },
+        searchText: "cnc sales malaysia",
+        ingestData: {
+            industryTags: ["cnc", "sales"],
+            experienceLevel: "mid",
+            computedAt: 1,
+            skillsVersion: 1,
+            ruleScores: {},
+        },
+        primaryRuleScore: 50,
+    };
+}
+
+function build51jobResumeDoc(id: string, experience: string) {
+    return {
+        _id: id,
+        externalId: `51job:${id}`,
+        source: "51job",
+        tags: [],
+        crawledAt: Date.now(),
+        content: {
+            name: id,
+            experience,
+        },
+        searchText: "cnc sales china",
+        ingestData: {
+            industryTags: ["cnc", "sales"],
+            experienceLevel: "junior",
+            computedAt: 1,
+            skillsVersion: 1,
+            ruleScores: {},
+        },
+        primaryRuleScore: 50,
+    };
+}
+
+function makeSearchCtx(resumes: unknown[]) {
+    return {
+        db: {
+            query: () => ({
+                withSearchIndex: () => {
+                    const paginate = async (opts: { cursor: string | null; numItems: number }) => {
+                        if (opts.cursor) {
+                            return { page: [], continueCursor: "", isDone: true };
+                        }
+                        return { page: resumes, continueCursor: "", isDone: true };
+                    };
+                    return {
+                        paginate,
+                        filter: () => ({
+                            take: async () => resumes,
+                            paginate,
+                        }),
+                    };
+                },
+            }),
+        },
+    };
+}
+
+describe("minExperience filter graceful degradation", () => {
+    it("resumes with empty experience pass minExperience filter (Seek data)", async () => {
+        const resume = buildSeekResumeDoc("seek-1", "");
+        const ctx = makeSearchCtx([resume]);
+
+        const result = await searchPaginatedHandler(ctx, {
+            paginationOpts: { cursor: null, numItems: 10 },
+            query: "cnc sales",
+            keywordGroups: [{ original: "cnc", variants: ["cnc"] }],
+            minExperience: 1,
+        });
+
+        // After fix: empty experience is unknown, so minExperience filter is skipped
+        expect(result.page).toHaveLength(1);
+    });
+
+    it("resumes with unparseable experience pass minExperience filter", async () => {
+        const resume = buildSeekResumeDoc("seek-2", "?");
+        const ctx = makeSearchCtx([resume]);
+
+        const result = await searchPaginatedHandler(ctx, {
+            paginationOpts: { cursor: null, numItems: 10 },
+            query: "cnc sales",
+            keywordGroups: [{ original: "cnc", variants: ["cnc"] }],
+            minExperience: 1,
+        });
+
+        expect(result.page).toHaveLength(1);
+    });
+
+    it("resumes with known low experience are still excluded by minExperience", async () => {
+        const resume = build51jobResumeDoc("51job-1", "应届");
+        const ctx = makeSearchCtx([resume]);
+
+        const result = await searchPaginatedHandler(ctx, {
+            paginationOpts: { cursor: null, numItems: 10 },
+            query: "cnc sales",
+            keywordGroups: [{ original: "cnc", variants: ["cnc"] }],
+            minExperience: 1,
+        });
+
+        // "应届" parses to 0, which is below minExperience: 1 → excluded
+        expect(result.page).toHaveLength(0);
+    });
+
+    it("resumes with unknown experience are excluded by maxExperience", async () => {
+        const resume = buildSeekResumeDoc("seek-3", "");
+        const ctx = makeSearchCtx([resume]);
+
+        const result = await searchPaginatedHandler(ctx, {
+            paginationOpts: { cursor: null, numItems: 10 },
+            query: "cnc sales",
+            keywordGroups: [{ original: "cnc", variants: ["cnc"] }],
+            maxExperience: 5,
+        });
+
+        // Unknown experience + maxExperience → excluded (cannot guarantee cap)
+        expect(result.page).toHaveLength(0);
+    });
+
+    it("resumes with known high experience pass minExperience", async () => {
+        const resume = build51jobResumeDoc("51job-2", "5");
+        const ctx = makeSearchCtx([resume]);
+
+        const result = await searchPaginatedHandler(ctx, {
+            paginationOpts: { cursor: null, numItems: 10 },
+            query: "cnc sales",
+            keywordGroups: [{ original: "cnc", variants: ["cnc"] }],
+            minExperience: 1,
+        });
+
+        expect(result.page).toHaveLength(1);
+    });
+});

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -744,6 +744,7 @@ function projectResumeListIngestData(
         ...(ingestData.verifiedRoleYears ? { verifiedRoleYears: ingestData.verifiedRoleYears } : {}),
         ruleScores: ingestData.ruleScores,
         experienceLevel: ingestData.experienceLevel,
+        ...(ingestData.market === undefined ? {} : { market: ingestData.market }),
         computedAt: ingestData.computedAt,
         skillsVersion: ingestData.skillsVersion,
     };
@@ -968,13 +969,20 @@ function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFil
     if (effectiveMinExperience !== undefined || filters.maxExperience !== undefined) {
         const experience = parseExperienceYears(toStringValue(content.experience));
         if (experience === null) {
-            return false;
-        }
-        if (effectiveMinExperience !== undefined && experience < effectiveMinExperience) {
-            return false;
-        }
-        if (filters.maxExperience !== undefined && experience > filters.maxExperience) {
-            return false;
+            // Unknown experience — skip filter instead of excluding.
+            // Seek talentsearch resumes have empty experience fields;
+            // excluding them when minExperience is set drops all results.
+            // Only apply maxExperience if known.
+            if (filters.maxExperience !== undefined) {
+                return false;
+            }
+        } else {
+            if (effectiveMinExperience !== undefined && experience < effectiveMinExperience) {
+                return false;
+            }
+            if (filters.maxExperience !== undefined && experience > filters.maxExperience) {
+                return false;
+            }
         }
     }
 

--- a/packages/shared/src/generated/search-profile-templates.ts
+++ b/packages/shared/src/generated/search-profile-templates.ts
@@ -301,9 +301,6 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
         "CNC",
         "Sales"
       ],
-      "requiredKeywords": [
-        "machine tools"
-      ],
       "jobDescription": "seek-malaysia-sales",
       "filters": {
         "minExperience": 1,
@@ -371,9 +368,6 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
       "keywords": [
         "CNC",
         "Sales"
-      ],
-      "requiredKeywords": [
-        "machine tools"
       ],
       "jobDescription": "seek-malaysia-sales",
       "filters": {
@@ -443,9 +437,6 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
         "CNC",
         "Sales"
       ],
-      "requiredKeywords": [
-        "machine tools"
-      ],
       "jobDescription": "seek-malaysia-sales",
       "filters": {
         "minExperience": 1,
@@ -499,9 +490,6 @@ export const SEARCH_PROFILE_TEMPLATES: SharedSearchProfileTemplate[] = [
       "keywords": [
         "CNC",
         "Sales"
-      ],
-      "requiredKeywords": [
-        "machine tools"
       ],
       "jobDescription": "seek-malaysia-sales",
       "filters": {


### PR DESCRIPTION
## Summary
- **Experience filter graceful degradation**: When experience is unknown (empty/unparseable like Seek's `""` and `"?"`), skip the minExperience filter instead of excluding the resume. Only maxExperience still excludes unknown-experience resumes (cannot guarantee cap). This fixes the root cause: `minExperience: 1` was dropping ALL 400 Seek resumes because `parseExperienceYears("")` returns `null`.
- **Add market to projection**: `projectResumeListIngestData` now includes the `market` field so the UI can display it (e.g., "MY" for Seek resumes).
- **Remove requiredKeywords from MY profiles**: `seek-malaysia-sales` and `seek-malaysia-talent-search` had `requiredKeywords: ["machine tools"]` which was too restrictive — only ~7 of 124 matching resumes contained "machine tools".
- **Remove dead code**: `getResumeMarket` in `search-profile-sources.ts` was unused duplicate of `deriveMarketFromSourceKey`.

## Root cause
Two compounding issues caused 0 results for seek-malaysia-sales:
1. `parseExperienceYears("")` returns `null` → filter excluded the resume entirely
2. `requiredKeywords: ["machine tools"]` further narrowed results to ~7

Combined, these two filters eliminated all results. The experience filter is the structural issue (Seek data format), while the requiredKeywords was a config mismatch.

## Test plan
- [x] `vitest packages/convex`: PASS (430/430, including 5 new experience filter tests)
- [x] `make check`: PASS
- [x] New tests: empty experience + minExperience = passes through, unparseable experience = passes through, known low experience = still excluded, unknown + maxExperience = excluded, known high experience = passes