### PR TITLE
fix: salary filter graceful degradation + projection field gaps

### DIFF
--- a/packages/convex/convex/__tests__/experience-filter-graceful-degradation.test.ts
+++ b/packages/convex/convex/__tests__/experience-filter-graceful-degradation.test.ts
@@ -19,6 +19,8 @@ type SearchPaginatedArgs = {
   requiredKeywords?: string[];
   locations?: string[];
   sources?: string[];
+  minSalary?: number;
+  maxSalary?: number;
 };
 
 type SearchPaginatedResult = {
@@ -31,7 +33,7 @@ const searchPaginatedHandler = (
   searchWithTagExpansionPaginated as unknown as ConvexHandler<SearchPaginatedArgs, SearchPaginatedResult>
 )._handler;
 
-function buildSeekResumeDoc(id: string, experience: string) {
+function buildSeekResumeDoc(id: string, experience: string, expectedSalary?: string) {
     return {
         _id: id,
         externalId: `seek:${id}`,
@@ -41,6 +43,7 @@ function buildSeekResumeDoc(id: string, experience: string) {
         content: {
             name: id,
             experience,
+            ...(expectedSalary !== undefined ? { expectedSalary } : {}),
             workHistory: [
                 { company: "Test Co", title: "Sales", years: "?" },
             ],
@@ -176,5 +179,52 @@ describe("minExperience filter graceful degradation", () => {
         });
 
         expect(result.page).toHaveLength(1);
+    });
+});
+
+describe("salary filter graceful degradation", () => {
+    it("resumes with empty salary pass minSalary filter (Seek data)", async () => {
+        const resume = buildSeekResumeDoc("seek-sal-1", "", "");
+        const ctx = makeSearchCtx([resume]);
+
+        const result = await searchPaginatedHandler(ctx, {
+            paginationOpts: { cursor: null, numItems: 10 },
+            query: "cnc sales",
+            keywordGroups: [{ original: "cnc", variants: ["cnc"] }],
+            minSalary: 5000,
+        });
+
+        // Unknown salary + minSalary → passes through (might meet the minimum)
+        expect(result.page).toHaveLength(1);
+    });
+
+    it("resumes with unknown salary are excluded by maxSalary", async () => {
+        const resume = buildSeekResumeDoc("seek-sal-2", "", "");
+        const ctx = makeSearchCtx([resume]);
+
+        const result = await searchPaginatedHandler(ctx, {
+            paginationOpts: { cursor: null, numItems: 10 },
+            query: "cnc sales",
+            keywordGroups: [{ original: "cnc", variants: ["cnc"] }],
+            maxSalary: 10000,
+        });
+
+        // Unknown salary + maxSalary → excluded (cannot guarantee cap)
+        expect(result.page).toHaveLength(0);
+    });
+
+    it("resumes with known salary are filtered correctly", async () => {
+        const resume = buildSeekResumeDoc("seek-sal-3", "5", "3000-5000");
+        const ctx = makeSearchCtx([resume]);
+
+        const result = await searchPaginatedHandler(ctx, {
+            paginationOpts: { cursor: null, numItems: 10 },
+            query: "cnc sales",
+            keywordGroups: [{ original: "cnc", variants: ["cnc"] }],
+            minSalary: 6000,
+        });
+
+        // Known salary 5000 < minSalary 6000 → excluded
+        expect(result.page).toHaveLength(0);
     });
 });

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -278,6 +278,8 @@ type ResumeListProjectedDoc = {
     archivedAt?: number;
     ingestData?: {
         industryTags: string[];
+        synonymHits: string[];
+        evidenceText?: string;
         brandHits?: Array<{
             brand: string;
             role: string;
@@ -307,6 +309,7 @@ type ResumeListProjectedDoc = {
         }>;
         ruleScores: unknown;
         experienceLevel: string;
+        market?: string;
         computedAt: number;
         skillsVersion: number;
     };
@@ -701,6 +704,8 @@ function projectResumeListIngestData(
 
     return {
         industryTags: ingestData.industryTags,
+        synonymHits: ingestData.synonymHits,
+        ...(ingestData.evidenceText === undefined ? {} : { evidenceText: ingestData.evidenceText }),
         ...(ingestData.brandHits
             ? {
                 brandHits: ingestData.brandHits.map((hit) => ({
@@ -1045,18 +1050,25 @@ function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFil
     if (filters.minSalary !== undefined || filters.maxSalary !== undefined) {
         const salary = parseSalaryRange(toStringValue(content.expectedSalary));
         if (!salary) {
-            return false;
-        }
-        if (filters.minSalary !== undefined) {
-            const maxSalary = salary.max ?? salary.min;
-            if (maxSalary !== undefined && maxSalary < filters.minSalary) {
+            // Unknown salary — skip salary filter instead of excluding.
+            // Same graceful-degradation pattern as experience filter:
+            // minSalary passes through (candidate might meet it),
+            // maxSalary excludes (cannot guarantee the cap).
+            if (filters.maxSalary !== undefined) {
                 return false;
             }
-        }
-        if (filters.maxSalary !== undefined) {
-            const minSalary = salary.min ?? salary.max;
-            if (minSalary !== undefined && minSalary > filters.maxSalary) {
-                return false;
+        } else {
+            if (filters.minSalary !== undefined) {
+                const maxSalary = salary.max ?? salary.min;
+                if (maxSalary !== undefined && maxSalary < filters.minSalary) {
+                    return false;
+                }
+            }
+            if (filters.maxSalary !== undefined) {
+                const minSalary = salary.min ?? salary.max;
+                if (minSalary !== undefined && minSalary > filters.maxSalary) {
+                    return false;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Salary filter graceful degradation**: When salary is unknown (null/empty), skip the minSalary filter instead of excluding the resume. Only maxSalary still excludes (cannot guarantee cap). This matches the pattern established for the experience filter in PR #788.
- **Add missing projection fields**: `synonymHits` and `evidenceText` added to `projectResumeListIngestData` — these schema fields were invisible to all list views. Also added `market` to the `ResumeListProjectedDoc` type definition.
- **3 new tests**: Salary filter graceful degradation (minSalary passes through, maxSalary excludes, known salary filtered correctly).

## Root cause
The salary filter had the same null-exclusion pattern as the previously-fixed experience filter: `parseSalaryRange` returns falsy for empty strings, and the code unconditionally excluded those resumes. Additionally, `synonymHits` (required `v.array(v.string())` in the schema) and `evidenceText` were never added to the projection, making them invisible to consumers.

## Test plan
- [x] `vitest packages/convex`: PASS (444/444, including 3 new salary filter tests)
- [x] `make check`: PASS