### PR TITLE
fix: zero industryDbV2Raw in market backfill migration for MY resumes

### DIFF
--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -1627,6 +1627,8 @@ export const backfillMarketField = mutation({
                 ingestData: {
                     ...resume.ingestData,
                     market: "MY",
+                    // CN industry DB data doesn't apply to MY market — zero it out
+                    ...(resume.ingestData.industryDbV2Raw ? { industryDbV2Raw: 0 } : {}),
                 } as typeof resume.ingestData,
             });
             updated += 1;


### PR DESCRIPTION
## Summary
- Enhances `backfillMarketField` migration to also zero out `industryDbV2Raw` on Seek MY resumes
- CN industry DB scores shouldn't be stored for MY market resumes — `overrideIndustryDbBreakdown` already zeros them at display time, but stored data should be consistent
- The migration still needs to be run on production (not yet deployed)

## Test plan
- [ ] Run migration locally via Convex dashboard: `backfillMarketField` with `batchSize: 100`
- [ ] Verify MY resumes show `market: "MY"` and `industryDbV2Raw: 0`
- [ ] Verify UI shows industry_db placeholder for MY market