### PR TITLE
fix: align BFF filter behavior with Convex — graceful degradation + education normalization

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -46,7 +46,7 @@ import {
   AnalysisTasksResponseSchema,
 } from "../schemas/index.js";
 import { config } from "../services/config.js";
-import { ResumeService, parseExperienceYears, type ResumeFilters } from "../services/resume-service.js";
+import { ResumeService, normalizeEducationLevel, parseExperienceYears, type ResumeFilters } from "../services/resume-service.js";
 import { DataNotFoundError } from "../services/errors.js";
 import { resolveConvexUrl } from "../services/resume-import-service.js";
 import { AIMatchingService, type MatchingRequest, type MatchingResult } from "../services/ai-matching.js";
@@ -1938,7 +1938,11 @@ function bffMatchesResumeFilters(
   if (typeof filters.minExperience === "number" || typeof filters.maxExperience === "number") {
     const expStr = toStringValue(content.experience) ?? "";
     const expYears = parseExperienceYears(expStr);
-    if (expYears !== null) {
+    if (expYears === null) {
+      // Unknown experience — exclude if maxExperience is set (cannot guarantee cap),
+      // but skip minExperience (resume might meet the minimum).
+      if (typeof filters.maxExperience === "number") return false;
+    } else {
       if (typeof filters.minExperience === "number" && expYears < filters.minExperience) return false;
       if (typeof filters.maxExperience === "number" && expYears > filters.maxExperience) return false;
     }
@@ -1946,7 +1950,8 @@ function bffMatchesResumeFilters(
 
   if (filters.education?.length) {
     const edu = toStringValue(content.education) ?? "";
-    if (!filters.education.some((e) => edu.includes(e))) return false;
+    const level = normalizeEducationLevel(edu);
+    if (!level || !filters.education.includes(level)) return false;
   }
 
   if (filters.skills?.length) {
@@ -1969,7 +1974,11 @@ function bffMatchesResumeFilters(
   if (typeof filters.minSalary === "number" || typeof filters.maxSalary === "number") {
     const salaryStr = toStringValue(content.expectedSalary) ?? "";
     const salaryMatch = salaryStr.match(/(\d+)/);
-    if (salaryMatch) {
+    if (!salaryMatch) {
+      // Unknown salary — exclude if maxSalary is set (cannot guarantee cap),
+      // but skip minSalary (resume might meet the minimum).
+      if (typeof filters.maxSalary === "number") return false;
+    } else {
       const salary = parseInt(salaryMatch[1]!, 10);
       if (typeof filters.minSalary === "number" && salary < filters.minSalary) return false;
       if (typeof filters.maxSalary === "number" && salary > filters.maxSalary) return false;

--- a/apps/api/src/services/resume-service.test.ts
+++ b/apps/api/src/services/resume-service.test.ts
@@ -294,4 +294,212 @@ describe("ResumeService", () => {
     expect(service.searchResumes(items, "sales engineer fanuc")).toEqual([]);
     expect(service.filterResumes(items, { skills: ["fanuc"] })).toEqual([]);
   });
+
+  describe("experience filter graceful degradation", () => {
+    it("resumes with empty experience pass minExperience filter", () => {
+      const root = createFixtureRoot();
+      roots.push(root);
+      const service = new ResumeService(root);
+      const items = [
+        {
+          name: "Seek MY",
+          profileUrl: "https://example.com/seek-my",
+          activityStatus: "Active",
+          age: "",
+          experience: "",
+          education: "",
+          location: "Malaysia",
+          selfIntro: "",
+          jobIntention: "Sales",
+          expectedSalary: "",
+          workHistory: [],
+          extractedAt: "2026-03-20T00:00:00.000Z",
+        },
+      ];
+
+      const filtered = service.filterResumes(items, { minExperience: 1 });
+      expect(filtered).toHaveLength(1);
+    });
+
+    it("resumes with unknown experience are excluded by maxExperience", () => {
+      const root = createFixtureRoot();
+      roots.push(root);
+      const service = new ResumeService(root);
+      const items = [
+        {
+          name: "Seek MY",
+          profileUrl: "https://example.com/seek-my",
+          activityStatus: "Active",
+          age: "",
+          experience: "",
+          education: "",
+          location: "Malaysia",
+          selfIntro: "",
+          jobIntention: "Sales",
+          expectedSalary: "",
+          workHistory: [],
+          extractedAt: "2026-03-20T00:00:00.000Z",
+        },
+      ];
+
+      const filtered = service.filterResumes(items, { maxExperience: 5 });
+      expect(filtered).toHaveLength(0);
+    });
+
+    it("resumes with known low experience are excluded by minExperience", () => {
+      const root = createFixtureRoot();
+      roots.push(root);
+      const service = new ResumeService(root);
+      const items = [
+        {
+          name: "51job Fresh",
+          profileUrl: "https://example.com/51job",
+          activityStatus: "Active",
+          age: "22岁",
+          experience: "应届",
+          education: "本科",
+          location: "东莞",
+          selfIntro: "",
+          jobIntention: "销售",
+          expectedSalary: "",
+          workHistory: [],
+          extractedAt: "2026-03-20T00:00:00.000Z",
+        },
+      ];
+
+      const filtered = service.filterResumes(items, { minExperience: 1 });
+      expect(filtered).toHaveLength(0);
+    });
+  });
+
+  describe("salary filter graceful degradation", () => {
+    it("resumes with empty salary pass minSalary filter", () => {
+      const root = createFixtureRoot();
+      roots.push(root);
+      const service = new ResumeService(root);
+      const items = [
+        {
+          name: "Seek MY",
+          profileUrl: "https://example.com/seek-my",
+          activityStatus: "Active",
+          age: "",
+          experience: "5 years",
+          education: "",
+          location: "Malaysia",
+          selfIntro: "",
+          jobIntention: "Sales",
+          expectedSalary: "",
+          workHistory: [],
+          extractedAt: "2026-03-20T00:00:00.000Z",
+        },
+      ];
+
+      const filtered = service.filterResumes(items, { minSalary: 5000 });
+      expect(filtered).toHaveLength(1);
+    });
+
+    it("resumes with unknown salary are excluded by maxSalary", () => {
+      const root = createFixtureRoot();
+      roots.push(root);
+      const service = new ResumeService(root);
+      const items = [
+        {
+          name: "Seek MY",
+          profileUrl: "https://example.com/seek-my",
+          activityStatus: "Active",
+          age: "",
+          experience: "5 years",
+          education: "",
+          location: "Malaysia",
+          selfIntro: "",
+          jobIntention: "Sales",
+          expectedSalary: "",
+          workHistory: [],
+          extractedAt: "2026-03-20T00:00:00.000Z",
+        },
+      ];
+
+      const filtered = service.filterResumes(items, { maxSalary: 10000 });
+      expect(filtered).toHaveLength(0);
+    });
+  });
+
+  describe("education filter normalization", () => {
+    it("normalizes Chinese education terms to standard levels", () => {
+      const root = createFixtureRoot();
+      roots.push(root);
+      const service = new ResumeService(root);
+      const items = [
+        {
+          name: "Master Degree",
+          profileUrl: "https://example.com/master",
+          activityStatus: "Active",
+          age: "28岁",
+          experience: "5年",
+          education: "硕士",
+          location: "东莞",
+          selfIntro: "",
+          jobIntention: "销售",
+          expectedSalary: "",
+          workHistory: [],
+          extractedAt: "2026-03-20T00:00:00.000Z",
+        },
+      ];
+
+      // "master" matches "硕士" via normalizeEducationLevel
+      const filtered = service.filterResumes(items, { education: ["master"] });
+      expect(filtered).toHaveLength(1);
+    });
+
+    it("excludes resumes whose education doesn't match filter", () => {
+      const root = createFixtureRoot();
+      roots.push(root);
+      const service = new ResumeService(root);
+      const items = [
+        {
+          name: "Associate Degree",
+          profileUrl: "https://example.com/associate",
+          activityStatus: "Active",
+          age: "24岁",
+          experience: "2年",
+          education: "大专",
+          location: "东莞",
+          selfIntro: "",
+          jobIntention: "销售",
+          expectedSalary: "",
+          workHistory: [],
+          extractedAt: "2026-03-20T00:00:00.000Z",
+        },
+      ];
+
+      const filtered = service.filterResumes(items, { education: ["master"] });
+      expect(filtered).toHaveLength(0);
+    });
+
+    it("excludes resumes with unparseable education when filter is set", () => {
+      const root = createFixtureRoot();
+      roots.push(root);
+      const service = new ResumeService(root);
+      const items = [
+        {
+          name: "Seek MY",
+          profileUrl: "https://example.com/seek-my",
+          activityStatus: "Active",
+          age: "",
+          experience: "5 years",
+          education: "Bachelor of Engineering",
+          location: "Malaysia",
+          selfIntro: "",
+          jobIntention: "Sales",
+          expectedSalary: "",
+          workHistory: [],
+          extractedAt: "2026-03-20T00:00:00.000Z",
+        },
+      ];
+
+      // normalizeEducationLevel doesn't recognize English education terms
+      const filtered = service.filterResumes(items, { education: ["bachelor"] });
+      expect(filtered).toHaveLength(0);
+    });
+  });
 });

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -584,9 +584,14 @@ export class ResumeService {
     return items.filter((item) => {
       if (effectiveMinExperience !== undefined || filters.maxExperience !== undefined) {
         const experience = parseExperienceYears(item.experience);
-        if (experience === null) return false;
-        if (effectiveMinExperience !== undefined && experience < effectiveMinExperience) return false;
-        if (filters.maxExperience !== undefined && experience > filters.maxExperience) return false;
+        if (experience === null) {
+          // Unknown experience — exclude if maxExperience is set (cannot guarantee cap),
+          // but skip minExperience (resume might meet the minimum).
+          if (filters.maxExperience !== undefined) return false;
+        } else {
+          if (effectiveMinExperience !== undefined && experience < effectiveMinExperience) return false;
+          if (filters.maxExperience !== undefined && experience > filters.maxExperience) return false;
+        }
       }
 
       if (filters.education?.length) {
@@ -613,14 +618,19 @@ export class ResumeService {
 
       if (filters.minSalary !== undefined || filters.maxSalary !== undefined) {
         const salary = parseSalaryRange(item.expectedSalary);
-        if (!salary) return false;
-        if (filters.minSalary !== undefined) {
-          const maxSalary = salary.max ?? salary.min;
-          if (maxSalary !== undefined && maxSalary < filters.minSalary) return false;
-        }
-        if (filters.maxSalary !== undefined) {
-          const minSalary = salary.min ?? salary.max;
-          if (minSalary !== undefined && minSalary > filters.maxSalary) return false;
+        if (!salary) {
+          // Unknown salary — exclude if maxSalary is set (cannot guarantee cap),
+          // but skip minSalary (resume might meet the minimum).
+          if (filters.maxSalary !== undefined) return false;
+        } else {
+          if (filters.minSalary !== undefined) {
+            const maxSalary = salary.max ?? salary.min;
+            if (maxSalary !== undefined && maxSalary < filters.minSalary) return false;
+          }
+          if (filters.maxSalary !== undefined) {
+            const minSalary = salary.min ?? salary.max;
+            if (minSalary !== undefined && minSalary > filters.maxSalary) return false;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- **Experience/salary graceful degradation**: BFF filters now match Convex behavior — unknown values pass min filters but fail max filters (previously BFF skipped both min and max for unknown values)
- **Education normalization**: BFF AND-mode search path now uses `normalizeEducationLevel()` instead of raw substring matching. A filter for `"master"` now correctly matches `"硕士"` — same as Convex and the BFF OR-mode path
- 8 new tests covering graceful degradation and education normalization

## Test plan
- [x] `vitest apps/api/src/services/resume-service.test.ts` — 14/14 pass (8 new)
- [x] `vitest packages/convex` — 444/444 pass
- [x] `make check` — all checks pass