### PR TITLE
fix: add English education term recognition for MY market resumes

### DIFF
--- a/apps/api/src/services/resume-service.test.ts
+++ b/apps/api/src/services/resume-service.test.ts
@@ -476,7 +476,7 @@ describe("ResumeService", () => {
       expect(filtered).toHaveLength(0);
     });
 
-    it("excludes resumes with unparseable education when filter is set", () => {
+    it("matches English education terms for MY market resumes", () => {
       const root = createFixtureRoot();
       roots.push(root);
       const service = new ResumeService(root);
@@ -497,9 +497,9 @@ describe("ResumeService", () => {
         },
       ];
 
-      // normalizeEducationLevel doesn't recognize English education terms
+      // normalizeEducationLevel now recognizes English education terms
       const filtered = service.filterResumes(items, { education: ["bachelor"] });
-      expect(filtered).toHaveLength(0);
+      expect(filtered).toHaveLength(1);
     });
   });
 });

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -653,13 +653,20 @@ export function parseExperienceYears(value: string): number | null {
 
 export function normalizeEducationLevel(value: string): string | null {
   if (!value) return null;
-  const normalized = value.trim();
+  const normalized = value.trim().toLowerCase();
   if (!normalized) return null;
+  // Chinese education terms
   if (/博士/.test(normalized)) return "phd";
   if (/硕士|研究生/.test(normalized)) return "master";
   if (/本科/.test(normalized)) return "bachelor";
   if (/大专|专科/.test(normalized)) return "associate";
   if (/中专|高中|中技/.test(normalized)) return "high_school";
+  // English education terms (Seek MY market)
+  if (/\bph\.?d\.?\b/.test(normalized) || /\bdoctorate\b/.test(normalized)) return "phd";
+  if (/\bmaster/.test(normalized) || /\bm\.?s\.?\b/.test(normalized) || /\bm\.?a\.?\b/.test(normalized) || /\bmba\b/.test(normalized)) return "master";
+  if (/\bbachelor/.test(normalized) || /\bdegree\b/.test(normalized) || /\bb\.?s\.?\b/.test(normalized) || /\bb\.?a\.?\b/.test(normalized)) return "bachelor";
+  if (/\bdiploma\b/.test(normalized) || /\bassociate\b/.test(normalized)) return "associate";
+  if (/\bhigh school\b/.test(normalized) || /\bspm\b/.test(normalized) || /\bstpm\b/.test(normalized)) return "high_school";
   return null;
 }
 

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -860,15 +860,22 @@ function normalizeEducationLevel(value: string): string | null {
     if (!value) {
         return null;
     }
-    const normalized = value.trim();
+    const normalized = value.trim().toLowerCase();
     if (!normalized) {
         return null;
     }
+    // Chinese education terms
     if (/博士/.test(normalized)) return "phd";
     if (/硕士|研究生/.test(normalized)) return "master";
     if (/本科/.test(normalized)) return "bachelor";
     if (/大专|专科/.test(normalized)) return "associate";
     if (/中专|高中|中技/.test(normalized)) return "high_school";
+    // English education terms (Seek MY market)
+    if (/\bph\.?d\.?\b/.test(normalized) || /\bdoctorate\b/.test(normalized)) return "phd";
+    if (/\bmaster/.test(normalized) || /\bm\.?s\.?\b/.test(normalized) || /\bm\.?a\.?\b/.test(normalized) || /\bmba\b/.test(normalized)) return "master";
+    if (/\bbachelor/.test(normalized) || /\bdegree\b/.test(normalized) || /\bb\.?s\.?\b/.test(normalized) || /\bb\.?a\.?\b/.test(normalized)) return "bachelor";
+    if (/\bdiploma\b/.test(normalized) || /\bassociate\b/.test(normalized)) return "associate";
+    if (/\bhigh school\b/.test(normalized) || /\bspm\b/.test(normalized) || /\bstpm\b/.test(normalized)) return "high_school";
     return null;
 }
 


### PR DESCRIPTION
## Summary
- `normalizeEducationLevel()` only recognized Chinese education terms (博士, 硕士, 本科, etc.)
- Seek MY market resumes use English terms like "Bachelor of Engineering", "Master", "Diploma", "SPM"
- Added English term patterns to both Convex and BFF paths for consistent filter behavior
- Updated test: "Bachelor of Engineering" now correctly maps to "bachelor"

## Test plan
- [x] `vitest apps/api/src/services/resume-service.test.ts` — 14/14 pass (education test updated)
- [x] `vitest packages/convex` — 444/444 pass
- [x] `make check` — all checks pass