### PR TITLE
fix: add 6 missing ingestData fields to BFF projection

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -604,6 +604,8 @@ function buildResumeIngestData(value: unknown): ResumeItem["ingestData"] | undef
   }
 
   const industryTags = toStringArray(value.industryTags);
+  const synonymHits = toStringArray(value.synonymHits);
+  const evidenceText = toStringValue(value.evidenceText) || undefined;
   const companyHits = toStringArray(value.companyHits);
   const brandHits = parseBrandHits(value.brandHits);
   const roleSignals = parseRoleSignals(value.roleSignals);
@@ -611,14 +613,27 @@ function buildResumeIngestData(value: unknown): ResumeItem["ingestData"] | undef
   const experienceLevel = toStringValue(value.experienceLevel) || undefined;
   const normalizedExperienceLevel = experienceLevel?.trim().toLowerCase();
   const meaningfulExperienceLevel = normalizedExperienceLevel && normalizedExperienceLevel !== 'unknown' ? experienceLevel : undefined;
+  const market = toStringValue(value.market) || undefined;
+  const ruleScores = isRecord(value.ruleScores)
+    ? Object.fromEntries(
+        Object.entries(value.ruleScores)
+          .filter((entry): entry is [string, number] => typeof entry[1] === 'number' && Number.isFinite(entry[1])),
+      )
+    : undefined;
+  const computedAt = toOptionalNumber(value.computedAt);
+  const skillsVersion = toOptionalNumber(value.skillsVersion);
 
   if (
     industryTags.length === 0
+    && synonymHits.length === 0
+    && !evidenceText
     && companyHits.length === 0
     && brandHits.length === 0
     && roleSignals.length === 0
     && industryDbV2Raw === undefined
     && !meaningfulExperienceLevel
+    && !market
+    && (!ruleScores || Object.keys(ruleScores).length === 0)
   ) {
     return undefined;
   }
@@ -632,12 +647,18 @@ function buildResumeIngestData(value: unknown): ResumeItem["ingestData"] | undef
 
   return {
     ...(industryTags.length > 0 ? { industryTags } : {}),
+    ...(synonymHits.length > 0 ? { synonymHits } : {}),
+    ...(evidenceText ? { evidenceText } : {}),
     ...(companyHits.length > 0 ? { companyHits } : {}),
     ...(brandHits.length > 0 ? { brandHits } : {}),
     ...(roleSignals.length > 0 ? { roleSignals } : {}),
     ...(industryDbV2Raw === undefined ? {} : { industryDbV2Raw }),
     ...(meaningfulExperienceLevel ? { experienceLevel: meaningfulExperienceLevel } : {}),
     ...(verifiedRoleYears && Object.keys(verifiedRoleYears).length > 0 ? { verifiedRoleYears } : {}),
+    ...(ruleScores && Object.keys(ruleScores).length > 0 ? { ruleScores } : {}),
+    ...(market ? { market } : {}),
+    ...(computedAt !== undefined ? { computedAt } : {}),
+    ...(skillsVersion !== undefined ? { skillsVersion } : {}),
   };
 }
 

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -176,10 +176,18 @@ const ResumeIngestBrandHitSchema = z
 const ResumeIngestDataSchema = z
   .object({
     industryTags: z.array(z.string()).optional().openapi({ example: ["industrial-machinery"] }),
+    synonymHits: z.array(z.string()).optional(),
+    evidenceText: z.string().optional(),
     brandHits: z.array(ResumeIngestBrandHitSchema).optional(),
     companyHits: z.array(z.string()).optional().openapi({ example: ["fanuc"] }),
     industryDbV2Raw: z.number().optional().openapi({ example: 12 }),
     roleSignals: z.array(ResumeIngestRoleSignalSchema).optional(),
+    verifiedRoleYears: z.record(z.string(), z.number()).optional(),
+    ruleScores: z.record(z.string(), z.number()).optional(),
+    experienceLevel: z.string().optional(),
+    market: z.string().optional(),
+    computedAt: z.number().optional(),
+    skillsVersion: z.number().optional(),
   })
   .openapi("ResumeIngestData");
 

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -231,6 +231,8 @@ function normalizeIngestData(value: unknown): ResumeIngestData | undefined {
     ...(brandHits ? { brandHits } : {}),
     ...(companyHits.length > 0 ? { companyHits } : {}),
     ...(roleSignals ? { roleSignals } : {}),
+    ...(isRecord(value.ruleScores) && Object.keys(value.ruleScores).length > 0 ? { ruleScores: value.ruleScores as Record<string, number> } : {}),
+    ...(typeof value.market === 'string' && value.market ? { market: value.market } : {}),
   };
 }
 

--- a/apps/api/src/types/resume.ts
+++ b/apps/api/src/types/resume.ts
@@ -55,11 +55,18 @@ export type ResumeIngestRoleSignal = {
 
 export type ResumeIngestData = {
   industryTags?: string[];
+  synonymHits?: string[];
+  evidenceText?: string;
   brandHits?: ResumeIngestBrandHit[];
   companyHits?: string[];
   industryDbV2Raw?: number;
   roleSignals?: ResumeIngestRoleSignal[];
   verifiedRoleYears?: Record<string, number>;
+  ruleScores?: Record<string, number>;
+  experienceLevel?: string;
+  market?: string;
+  computedAt?: number;
+  skillsVersion?: number;
 };
 
 export type ResumeItem = {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -7506,6 +7506,8 @@ export interface components {
              *     ]
              */
             industryTags?: string[];
+            synonymHits?: string[];
+            evidenceText?: string;
             brandHits?: components["schemas"]["ResumeIngestBrandHit"][];
             /**
              * @example [
@@ -7516,6 +7518,16 @@ export interface components {
             /** @example 12 */
             industryDbV2Raw?: number;
             roleSignals?: components["schemas"]["ResumeIngestRoleSignal"][];
+            verifiedRoleYears?: {
+                [key: string]: number;
+            };
+            ruleScores?: {
+                [key: string]: number;
+            };
+            experienceLevel?: string;
+            market?: string;
+            computedAt?: number;
+            skillsVersion?: number;
         };
         ResumeItem: {
             /** @example Alex Chen */


### PR DESCRIPTION
## Summary
- BFF `buildResumeIngestData` was dropping 6 fields that Convex `projectResumeListIngestData` includes: `synonymHits`, `evidenceText`, `market`, `ruleScores`, `computedAt`, `skillsVersion`
- Most critically, `ruleScores` was missing → `getPrecomputedRuleScore()` in the frontend always returned null for BFF-served data, causing no score badges
- Also missing `market` → MY market graceful degradation couldn't work via BFF path
- Updated: `buildResumeIngestData`, `normalizeIngestData`, `ResumeIngestData` type, `ResumeIngestDataSchema`, regenerated `api-types.ts`

## Test plan
- [x] `make check` — all checks pass
- [x] `vitest packages/convex` — 444/444 pass
- [x] `vitest apps/api` — all pass
- [ ] Verify BFF-served resumes now show `ruleScores` and `market` in the response payload