### PR TITLE
fix: align Convex skills/requiredKeywords filter with BFF

### DIFF
--- a/packages/convex/convex/__tests__/experience-filter-graceful-degradation.test.ts
+++ b/packages/convex/convex/__tests__/experience-filter-graceful-degradation.test.ts
@@ -16,6 +16,7 @@ type SearchPaginatedArgs = {
   maxExperience?: number;
   minRoleYears?: number;
   roleFilterType?: string;
+  skills?: string[];
   requiredKeywords?: string[];
   locations?: string[];
   sources?: string[];
@@ -225,6 +226,113 @@ describe("salary filter graceful degradation", () => {
         });
 
         // Known salary 5000 < minSalary 6000 → excluded
+        expect(result.page).toHaveLength(0);
+    });
+});
+
+describe("skills filter uses full searchText", () => {
+    it("matches skills from full searchText, not just narrow buildResumeFilterSearchText", async () => {
+        // Skill "fanuc" appears in searchText but NOT in name/education/latest-workHistory
+        const resume = {
+            _id: "seek-skill-1",
+            externalId: "seek:skill1",
+            source: "seek",
+            tags: [],
+            crawledAt: Date.now(),
+            content: {
+                name: "Alice",
+                experience: "",
+                education: "Bachelor",
+                workHistory: [{ company: "Test Co", title: "Sales", years: "?" }],
+            },
+            searchText: "alice sales fanuc cnc malaysia", // fanuc is here
+            ingestData: {
+                industryTags: ["cnc", "sales"],
+                experienceLevel: "mid",
+                computedAt: 1,
+                skillsVersion: 1,
+                ruleScores: {},
+            },
+            primaryRuleScore: 50,
+        };
+        const ctx = makeSearchCtx([resume]);
+
+        const result = await searchPaginatedHandler(ctx, {
+            paginationOpts: { cursor: null, numItems: 10 },
+            query: "cnc sales",
+            keywordGroups: [{ original: "cnc", variants: ["cnc"] }],
+            skills: ["fanuc"],
+        });
+
+        // "fanuc" is in searchText but not in name/edu/latest WH → should still match
+        expect(result.page).toHaveLength(1);
+    });
+
+    it("excludes resumes without matching skills in searchText", async () => {
+        const resume = buildSeekResumeDoc("seek-skill-2", "");
+        const ctx = makeSearchCtx([resume]);
+
+        const result = await searchPaginatedHandler(ctx, {
+            paginationOpts: { cursor: null, numItems: 10 },
+            query: "cnc sales",
+            keywordGroups: [{ original: "cnc", variants: ["cnc"] }],
+            skills: ["mazak"],
+        });
+
+        // "mazak" not in searchText → excluded
+        expect(result.page).toHaveLength(0);
+    });
+});
+
+describe("requiredKeywords filter uses full searchText", () => {
+    it("matches required keywords from full searchText", async () => {
+        const resume = {
+            _id: "seek-kw-1",
+            externalId: "seek:kw1",
+            source: "seek",
+            tags: [],
+            crawledAt: Date.now(),
+            content: {
+                name: "Bob",
+                experience: "",
+                education: "Diploma",
+                workHistory: [{ company: "Mfg Co", title: "Engineer", years: "?" }],
+            },
+            searchText: "bob engineer machine tools cnc malaysia", // "machine tools" as phrase
+            ingestData: {
+                industryTags: ["cnc"],
+                experienceLevel: "mid",
+                computedAt: 1,
+                skillsVersion: 1,
+                ruleScores: {},
+            },
+            primaryRuleScore: 50,
+        };
+        const ctx = makeSearchCtx([resume]);
+
+        const result = await searchPaginatedHandler(ctx, {
+            paginationOpts: { cursor: null, numItems: 10 },
+            query: "cnc",
+            keywordGroups: [{ original: "cnc", variants: ["cnc"] }],
+            requiredKeywords: ["machine tools"],
+        });
+
+        // "machine tools" is in searchText but not in narrow buildResumeFilterSearchText → should still match
+        expect(result.page).toHaveLength(1);
+    });
+
+    it("excludes resumes missing required keywords in searchText", async () => {
+        const resume = buildSeekResumeDoc("seek-kw-2", "");
+        const ctx = makeSearchCtx([resume]);
+
+        const result = await searchPaginatedHandler(ctx, {
+            paginationOpts: { cursor: null, numItems: 10 },
+            query: "cnc sales",
+            keywordGroups: [{ original: "cnc", variants: ["cnc"] }],
+            requiredKeywords: ["machine tools"],
+        });
+
+        // "machine tools" not in searchText → excluded
         expect(result.page).toHaveLength(0);
     });
 });

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -1040,15 +1040,18 @@ function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFil
     }
 
     if (filters.skills?.length) {
-        const haystack = buildResumeFilterSearchText(content, resume.source);
-        const hasSkill = filters.skills.some((skill) => haystack.includes(skill));
+        // Use full searchText (includes name, all workHistory, industryTags, synonyms, etc.)
+        // rather than narrow buildResumeFilterSearchText (only latest workHistory).
+        // Aligns with BFF bffMatchesResumeFilters which uses full doc.searchText.
+        const haystack = resume.searchText?.toLowerCase() ?? buildResumeFilterSearchText(content, resume.source);
+        const hasSkill = filters.skills.some((skill) => haystack.includes(skill.toLowerCase()));
         if (!hasSkill) {
             return false;
         }
     }
 
     if (filters.requiredKeywords?.length) {
-        const haystack = buildResumeFilterSearchText(content, resume.source);
+        const haystack = resume.searchText?.toLowerCase() ?? buildResumeFilterSearchText(content, resume.source);
         if (!matchesAllRequiredKeywords(haystack, filters.requiredKeywords)) {
             return false;
         }


### PR DESCRIPTION
## Summary
- Convex `matchesResumeListFilters` used narrow `buildResumeFilterSearchText` (only name, education, location, latest workHistory) for skills and requiredKeywords filters
- BFF uses full `doc.searchText` (all workHistory, industryTags, synonyms, etc.)
- This divergence caused Convex to filter out resumes that BFF would include when skills appeared in non-latest workHistory entries or ingest tokens
- Fix: use `resume.searchText` when available, fall back to narrow haystack; lowercase skill names for case-insensitive matching

## Test plan
- [x] 4 new test cases for skills/requiredKeywords full-searchText behavior
- [x] All 444 Convex tests pass
- [x] All 20 BFF filter alignment tests pass
- [x] `make check` passes