### PR TITLE
fix: add missing i18n key for breakdownLabels.industryDbNotAvailable

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -427,11 +427,7 @@
         "loading": "Loading...",
         "exportFormat": "Export format",
         "exporting": "Exporting...",
-        "export": "Export {{count}}",
-        "loading": "Loading...",
-        "linkCopied": "Link copied",
-        "copyFailed": "Copy failed",
-        "copyLink": "Copy link"
+        "export": "Export {{count}}"
       },
       "results": {
         "emptyTitle": "No resumes matched this search",
@@ -500,7 +496,10 @@
         "industryDb": "Industry DB",
         "industryDbNotAvailable": "Industry DB: Not available for MY market",
         "education": "Education",
-        "location": "Location"
+        "location": "Location",
+        "breakdownLabels": {
+          "industryDbNotAvailable": "Industry DB: Not available for MY market"
+        }
       },
       "error": {
         "searchBar": "Search bar failed to load",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -495,7 +495,10 @@
         "industryDb": "行业库",
         "industryDbNotAvailable": "行业库：MY市场暂不可用",
         "education": "学历",
-        "location": "地点"
+        "location": "地点",
+        "breakdownLabels": {
+          "industryDbNotAvailable": "行业库：MY市场暂不可用"
+        }
       },
       "error": {
         "searchBar": "搜索栏加载失败",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -495,7 +495,10 @@
         "industryDb": "行業庫",
         "industryDbNotAvailable": "行業庫：MY市場暫不可用",
         "education": "學歷",
-        "location": "地點"
+        "location": "地點",
+        "breakdownLabels": {
+          "industryDbNotAvailable": "行業庫：MY市場暫不可用"
+        }
       },
       "error": {
         "searchBar": "搜尋列加載失敗",


### PR DESCRIPTION
## Summary
- CI `i18n-check` was failing because code references `resumes.searchPage.card.breakdownLabels.industryDbNotAvailable` but locale files only had the key at `resumes.searchPage.card.industryDbNotAvailable` (no `breakdownLabels` nesting)
- Added `breakdownLabels.industryDbNotAvailable` under `resumes.searchPage.card` in all 3 locale files (zh-Hant, zh-Hans, en)

## Test plan
- [x] `make i18n-check` passes locally (was failing before)
- [x] `make check` passes
- [x] CI Checks workflow should now pass