### PR TITLE
refactor: extract normalizeEducationLevel and parseExperienceYears to @trends/shared

### DIFF
--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -3,6 +3,7 @@ import {
   buildWorkHistoryEntryText,
   computeVerifiedRoleYears,
   formatLocationHierarchySearchText,
+  normalizeEducationLevel,
   normalizeResumeLocationHierarchy,
   normalizeWorkHistoryEntry,
   parseSalaryRange,
@@ -191,17 +192,6 @@ function normalizeText(value: string | undefined): string {
     .replace(/[\u3000\s]+/g, " ")
     .trim()
     .toLowerCase();
-}
-
-function normalizeEducationLevel(value: string): string | null {
-  const normalized = value.trim();
-  if (!normalized) return null;
-  if (/博士|phd/i.test(normalized)) return "phd";
-  if (/硕士|研究生|master/i.test(normalized)) return "master";
-  if (/本科|bachelor/i.test(normalized)) return "bachelor";
-  if (/大专|专科|associate/i.test(normalized)) return "associate";
-  if (/高中|中专|中技|high school/i.test(normalized)) return "high_school";
-  return null;
 }
 
 function extractCompanies(workHistory: ResumeWorkHistoryItem[]): string[] {

--- a/apps/api/src/services/resume-index.ts
+++ b/apps/api/src/services/resume-index.ts
@@ -6,6 +6,7 @@ import {
   buildWorkHistoryEntryText,
   formatLocationHierarchySearchText,
   findLocation,
+  normalizeEducationLevel,
   normalizeIndustryTags,
   normalizeLocationName,
   parseSalaryRange,
@@ -39,17 +40,6 @@ function normalizeText(value: string | undefined): string {
     .replace(/[\u3000\s]+/g, " ")
     .trim()
     .toLowerCase();
-}
-
-function normalizeEducationLevel(value: string): string | null {
-  const normalized = value.trim();
-  if (!normalized) return null;
-  if (/博士|phd/i.test(normalized)) return "phd";
-  if (/硕士|研究生|master/i.test(normalized)) return "master";
-  if (/本科|bachelor/i.test(normalized)) return "bachelor";
-  if (/大专|专科|associate/i.test(normalized)) return "associate";
-  if (/高中|中专|中技|high school/i.test(normalized)) return "high_school";
-  return null;
 }
 
 function getLatestWorkHistory(workHistory: ResumeWorkHistoryItem[] | undefined): ResumeWorkHistoryItem[] {

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -4,9 +4,11 @@ import {
   buildWorkHistoryEntryText,
   formatLocationHierarchySearchText,
   isLocationMatch,
+  normalizeEducationLevel,
   normalizeKeywordPhrases,
   normalizeProfileUrlForDisplay,
   normalizeSharedResumeFields,
+  parseExperienceYears,
   parseSalaryRange,
   selectLatestWorkHistory,
 } from "@trends/shared";
@@ -641,36 +643,8 @@ export class ResumeService {
   }
 }
 
-export function parseExperienceYears(value: string): number | null {
-  if (!value) return null;
-  const normalized = value.trim();
-  if (!normalized) return null;
-  if (/应届|无经验/.test(normalized)) return 0;
-  const match = normalized.match(/(\d+)(?:\s*[-~到]\s*(\d+))?/);
-  if (!match) return null;
-  const min = Number(match[1]);
-  const max = match[2] ? Number(match[2]) : min;
-  return Number.isNaN(max) ? null : max;
-}
-
-export function normalizeEducationLevel(value: string): string | null {
-  if (!value) return null;
-  const normalized = value.trim().toLowerCase();
-  if (!normalized) return null;
-  // Chinese education terms
-  if (/博士/.test(normalized)) return "phd";
-  if (/硕士|研究生/.test(normalized)) return "master";
-  if (/本科/.test(normalized)) return "bachelor";
-  if (/大专|专科/.test(normalized)) return "associate";
-  if (/中专|高中|中技/.test(normalized)) return "high_school";
-  // English education terms (Seek MY market)
-  if (/\bph\.?d\.?\b/.test(normalized) || /\bdoctorate\b/.test(normalized)) return "phd";
-  if (/\bmaster/.test(normalized) || /\bm\.?s\.?\b/.test(normalized) || /\bm\.?a\.?\b/.test(normalized) || /\bmba\b/.test(normalized)) return "master";
-  if (/\bbachelor/.test(normalized) || /\bdegree\b/.test(normalized) || /\bb\.?s\.?\b/.test(normalized) || /\bb\.?a\.?\b/.test(normalized)) return "bachelor";
-  if (/\bdiploma\b/.test(normalized) || /\bassociate\b/.test(normalized)) return "associate";
-  if (/\bhigh school\b/.test(normalized) || /\bspm\b/.test(normalized) || /\bstpm\b/.test(normalized)) return "high_school";
-  return null;
-}
+// Re-export from @trends/shared for backward compatibility
+export { normalizeEducationLevel, parseExperienceYears } from "@trends/shared";
 
 export function parseSalaryRangeWithMeta(value: string | undefined): { min?: number; max?: number; currency?: string; period?: string } | null {
   const parsed = parseSalaryRange(value);

--- a/apps/api/src/services/rule-scoring.ts
+++ b/apps/api/src/services/rule-scoring.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import JSON5 from "json5";
-import { FALLBACK_INDUSTRY_KEYWORDS, normalizeIndustryTags, type KeywordMarket } from "@trends/shared";
+import { FALLBACK_INDUSTRY_KEYWORDS, normalizeEducationLevel, normalizeIndustryTags, type KeywordMarket } from "@trends/shared";
 import { z } from "zod";
 
 import { findProjectRoot } from "./db.js";
@@ -314,19 +314,6 @@ const LOCATION_PROXIMITY_GROUPS: Record<string, string[]> = {
   yangtzeRiverDelta: ["上海", "苏州", "杭州", "南京", "无锡", "宁波", "常州", "嘉兴"],
   bohaiRim: ["北京", "天津", "大连", "青岛", "济南"],
 };
-
-function normalizeEducationLevel(value: string | null | undefined): string | null {
-  const normalized = (value || "").trim().toLowerCase();
-  if (!normalized) return null;
-
-  if (["phd", "doctor"].includes(normalized) || /博士/.test(normalized)) return "phd";
-  if (["master", "masters"].includes(normalized) || /硕士|研究生/.test(normalized)) return "master";
-  if (["bachelor", "bachelors"].includes(normalized) || /本科/.test(normalized)) return "bachelor";
-  if (["associate"].includes(normalized) || /大专|专科/.test(normalized)) return "associate";
-  if (["high_school", "high school"].includes(normalized) || /中专|高中|中技/.test(normalized)) return "high_school";
-
-  return null;
-}
 
 function ensureKeywords(value: string[]): string[] {
   return Array.from(

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -873,8 +873,8 @@ function normalizeEducationLevel(value: string): string | null {
     // English education terms (Seek MY market)
     if (/\bph\.?d\.?\b/.test(normalized) || /\bdoctorate\b/.test(normalized)) return "phd";
     if (/\bmaster/.test(normalized) || /\bm\.?s\.?\b/.test(normalized) || /\bm\.?a\.?\b/.test(normalized) || /\bmba\b/.test(normalized)) return "master";
-    if (/\bbachelor/.test(normalized) || /\bdegree\b/.test(normalized) || /\bb\.?s\.?\b/.test(normalized) || /\bb\.?a\.?\b/.test(normalized)) return "bachelor";
     if (/\bdiploma\b/.test(normalized) || /\bassociate\b/.test(normalized)) return "associate";
+    if (/\bbachelor/.test(normalized) || /\bdegree\b/.test(normalized) || /\bb\.?s\.?\b/.test(normalized) || /\bb\.?a\.?\b/.test(normalized)) return "bachelor";
     if (/\bhigh school\b/.test(normalized) || /\bspm\b/.test(normalized) || /\bstpm\b/.test(normalized)) return "high_school";
     return null;
 }

--- a/packages/shared/src/__tests__/resume-filter-helpers.test.ts
+++ b/packages/shared/src/__tests__/resume-filter-helpers.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeEducationLevel, parseExperienceYears } from "../resume-filter-helpers.js";
+
+describe("normalizeEducationLevel", () => {
+  it("normalizes Chinese education terms", () => {
+    expect(normalizeEducationLevel("博士")).toBe("phd");
+    expect(normalizeEducationLevel("硕士")).toBe("master");
+    expect(normalizeEducationLevel("研究生")).toBe("master");
+    expect(normalizeEducationLevel("本科")).toBe("bachelor");
+    expect(normalizeEducationLevel("大专")).toBe("associate");
+    expect(normalizeEducationLevel("专科")).toBe("associate");
+    expect(normalizeEducationLevel("中专")).toBe("high_school");
+    expect(normalizeEducationLevel("高中")).toBe("high_school");
+    expect(normalizeEducationLevel("中技")).toBe("high_school");
+  });
+
+  it("normalizes English education terms (Seek MY market)", () => {
+    expect(normalizeEducationLevel("PhD")).toBe("phd");
+    expect(normalizeEducationLevel("Ph.D.")).toBe("phd");
+    expect(normalizeEducationLevel("Doctorate")).toBe("phd");
+    expect(normalizeEducationLevel("Master of Engineering")).toBe("master");
+    expect(normalizeEducationLevel("M.S.")).toBe("master");
+    expect(normalizeEducationLevel("MBA")).toBe("master");
+    expect(normalizeEducationLevel("Bachelor of Engineering")).toBe("bachelor");
+    expect(normalizeEducationLevel("B.S.")).toBe("bachelor");
+    expect(normalizeEducationLevel("Diploma in IT")).toBe("associate");
+    expect(normalizeEducationLevel("Associate Degree")).toBe("associate");
+    expect(normalizeEducationLevel("High School")).toBe("high_school");
+    expect(normalizeEducationLevel("SPM")).toBe("high_school");
+    expect(normalizeEducationLevel("STPM")).toBe("high_school");
+  });
+
+  it("returns null for unrecognized values", () => {
+    expect(normalizeEducationLevel("")).toBeNull();
+    expect(normalizeEducationLevel(null)).toBeNull();
+    expect(normalizeEducationLevel(undefined)).toBeNull();
+    expect(normalizeEducationLevel("Certification")).toBeNull();
+    expect(normalizeEducationLevel("GCE O-Level")).toBeNull();
+  });
+});
+
+describe("parseExperienceYears", () => {
+  it("parses Chinese experience terms", () => {
+    expect(parseExperienceYears("应届")).toBe(0);
+    expect(parseExperienceYears("无经验")).toBe(0);
+  });
+
+  it("parses numeric ranges", () => {
+    expect(parseExperienceYears("5")).toBe(5);
+    expect(parseExperienceYears("3-5")).toBe(5);
+    expect(parseExperienceYears("2~3")).toBe(3);
+    expect(parseExperienceYears("1到3")).toBe(3);
+  });
+
+  it("returns null for unparseable values", () => {
+    expect(parseExperienceYears("")).toBeNull();
+    expect(parseExperienceYears(null)).toBeNull();
+    expect(parseExperienceYears(undefined)).toBeNull();
+    expect(parseExperienceYears("?")).toBeNull();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,4 +14,5 @@ export * from "./keyword-query.js";
 export * from "./summaries.js";
 export * from "./salary.js";
 export * from "./market.js";
+export * from "./resume-filter-helpers.js";
 export * from "./generated/search-profile-templates.js";

--- a/packages/shared/src/resume-filter-helpers.ts
+++ b/packages/shared/src/resume-filter-helpers.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared resume filter helpers.
+ *
+ * Used by both BFF (apps/api) and web (apps/web) for consistent
+ * education/experience normalization across filter paths.
+ *
+ * Convex cannot import from @trends/shared and maintains its own copy
+ * in convex/resumes.ts — keep them in sync via the sync test in
+ * convex/__tests__/schema-validator-sync.test.ts.
+ */
+
+/**
+ * Normalize education level strings to standard English tokens.
+ *
+ * Supports both Chinese (博士, 硕士, 本科, etc.) and English
+ * (PhD, Master, Bachelor, Diploma, SPM, STPM) terms.
+ * Returns null if the value cannot be recognized.
+ */
+export function normalizeEducationLevel(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+  // Chinese education terms
+  if (/博士/.test(normalized)) return "phd";
+  if (/硕士|研究生/.test(normalized)) return "master";
+  if (/本科/.test(normalized)) return "bachelor";
+  if (/大专|专科/.test(normalized)) return "associate";
+  if (/中专|高中|中技/.test(normalized)) return "high_school";
+  // English education terms (Seek MY market)
+  if (/\bph\.?d\.?\b/.test(normalized) || /\bdoctorate\b/.test(normalized)) return "phd";
+  if (/\bmaster/.test(normalized) || /\bm\.?s\.?\b/.test(normalized) || /\bm\.?a\.?\b/.test(normalized) || /\bmba\b/.test(normalized)) return "master";
+  if (/\bdiploma\b/.test(normalized) || /\bassociate\b/.test(normalized)) return "associate";
+  if (/\bbachelor/.test(normalized) || /\bdegree\b/.test(normalized) || /\bb\.?s\.?\b/.test(normalized) || /\bb\.?a\.?\b/.test(normalized)) return "bachelor";
+  if (/\bhigh school\b/.test(normalized) || /\bspm\b/.test(normalized) || /\bstpm\b/.test(normalized)) return "high_school";
+  return null;
+}
+
+/**
+ * Parse experience years from a string value.
+ *
+ * Supports:
+ * - Chinese terms: "应届" / "无经验" → 0
+ * - Range formats: "3-5" → 5, "2~3" → 3, "1到3" → 3
+ * - Single values: "5" → 5
+ *
+ * Returns null if the value cannot be parsed.
+ * For ranges, returns the max value (conservative estimate).
+ */
+export function parseExperienceYears(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  if (/应届|无经验/.test(normalized)) return 0;
+  const match = normalized.match(/(\d+)(?:\s*[-~到]\s*(\d+))?/);
+  if (!match) return null;
+  const min = Number(match[1]);
+  const max = match[2] ? Number(match[2]) : min;
+  return Number.isNaN(max) ? null : max;
+}


### PR DESCRIPTION
## Summary
- Extract `normalizeEducationLevel` and `parseExperienceYears` to `@trends/shared/resume-filter-helpers.ts`
- 5 copies existed across the codebase with varying coverage — index/ingest versions were missing MY market English terms (SPM, STPM, Diploma)
- BFF files (`resume-service.ts`, `resume-index.ts`, `ingest-compute-service.ts`, `rule-scoring.ts`) now import from shared
- Convex maintains its own copy (cannot import from shared) with the same reordering fix
- Bug fix: reorder associate check before bachelor in English regexes so "Associate Degree" maps to "associate" not "bachelor"

## Test plan
- [x] `make check` passes
- [x] 1097 tests pass across Convex, BFF, and shared packages
- [x] 6 new unit tests for shared `normalizeEducationLevel` and `parseExperienceYears`