### PR TITLE
feat: Seek name-search profile URL replaces broken UUID links

### DIFF
--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -8,6 +8,7 @@ import {
   formatLocationHierarchyLabel,
   normalizeResumeLocationHierarchy,
   normalizeSeekProfileUrlForDisplay,
+  inferSeekMarket,
 } from "@trends/shared";
 import {
   ResumeImportItemSchema,
@@ -282,18 +283,22 @@ function buildNormalizedResumeContent(
   const rawLocation = typeof content.location === "string" ? content.location.trim() : "";
   const location = rawLocation || (locationHierarchy ? formatLocationHierarchyLabel(locationHierarchy) : "");
 
-  // Normalize seek profileUrl to recommended format at import time
+  // Normalize seek profileUrl — upgrade UUID URLs to name-search format
   let profileUrl = content.profileUrl;
   if (typeof profileUrl === "string" && seekContext?.sourceHost) {
-    const normalized = normalizeSeekProfileUrlForDisplay(profileUrl);
+    const candidateName = typeof content.name === "string" ? content.name.trim() : "";
+    const market = inferSeekMarket(seekContext.sourceHost);
+    const normalized = normalizeSeekProfileUrlForDisplay(profileUrl, candidateName, market);
     if (normalized && normalized !== profileUrl) {
-      // Build recommended URL if we have a jobId
+      // Build recommended URL if we have a jobId and numeric profileId
       if (seekContext.jobId) {
         try {
           const parsed = new URL(normalized);
           const profileIdMatch = parsed.pathname.match(/\/candidates\/(\d+)$/);
           if (profileIdMatch?.[1]) {
             profileUrl = `https://${parsed.hostname}/candidates/recommended?jobId=${seekContext.jobId}&openProfileId=${profileIdMatch[1]}`;
+          } else {
+            profileUrl = normalized;
           }
         } catch {
           profileUrl = normalized;

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -1538,6 +1538,12 @@
     return `https://${hostname}/candidates/${encodeURIComponent(profileId)}`;
   }
   __name(buildSeekProfileUrl, "buildSeekProfileUrl");
+  function buildSeekNameSearchUrl(name, market) {
+    const trimmed = typeof name === "string" ? name.trim() : "";
+    if (!trimmed) return "";
+    return `https://${window.location.hostname.toLowerCase()}/talentsearch/profiles/search?searchQuery=${encodeURIComponent(trimmed)}&market=${encodeURIComponent(market || "MY")}&pageNumber=1`;
+  }
+  __name(buildSeekNameSearchUrl, "buildSeekNameSearchUrl");
   function getSeekRecommendedRequest() {
     return apiSnapshot.seekRecommendedRequest;
   }
@@ -1715,13 +1721,46 @@
     }) || null;
   }
   __name(findSeekProfileTrigger, "findSeekProfileTrigger");
-  function mergeSeekListResumeWithDetail(baseResume, detailResume) {
+  function findSeekTalentSearchCardTrigger(profileId, resume, cachedHeadings) {
+    if (!profileId) return null;
+    const byAttr = document.querySelector(
+      `[data-tr-candidate-id="${CSS.escape(profileId)}"]`
+    );
+    if (byAttr instanceof HTMLElement) return byAttr;
+    const candidateName = typeof resume?.name === "string" ? resume.name.trim() : "";
+    if (candidateName) {
+      const headings = cachedHeadings || Array.from(document.querySelectorAll('[data-role="heading"]'));
+      const match = headings.find((h) => {
+        const text = (h.textContent || "").trim();
+        return text === candidateName;
+      });
+      if (match instanceof HTMLElement) return match;
+    }
+    return null;
+  }
+  __name(findSeekTalentSearchCardTrigger, "findSeekTalentSearchCardTrigger");
+  function mergeSeekListResumeWithDetail(baseResume, detailResume, isTalentSearch = false) {
     if (!detailResume || typeof detailResume !== "object") {
       return baseResume;
+    }
+    const seekProfileGuid = baseResume.seekProfileGuid || detailResume.seekProfileGuid || void 0;
+    const numericProfileId = isTalentSearch && detailResume.profileId && /^\d+$/.test(detailResume.profileId) ? detailResume.profileId : void 0;
+    let profileUrl = detailResume.profileUrl || baseResume.profileUrl;
+    if (numericProfileId) {
+      const seekRequest = getSeekTalentSearchRequest();
+      const requestJobId = seekRequest?.variables?.input?.jobId;
+      const urlJobId = normalizeOptionalPositiveInt(
+        new URL(window.location.href).searchParams.get("jobId")
+      );
+      const jobId = requestJobId != null ? String(requestJobId) : urlJobId != null ? String(urlJobId) : void 0;
+      profileUrl = buildSeekProfileUrl(numericProfileId, jobId);
     }
     return {
       ...baseResume,
       ...detailResume,
+      ...seekProfileGuid ? { seekProfileGuid } : {},
+      ...numericProfileId ? { profileId: numericProfileId } : {},
+      ...profileUrl ? { profileUrl } : {},
       pageIndex: baseResume.pageIndex,
       pageNumber: baseResume.pageNumber,
       extractedAt: baseResume.extractedAt,
@@ -2789,6 +2828,7 @@
     );
     const jobId = requestInput?.jobId != null ? String(requestInput.jobId) : jobIdFromUrl != null ? String(jobIdFromUrl) : void 0;
     const { profileId, profileType } = getSeekCandidateIdentity(profile);
+    const seekProfileGuid = typeof profile.profileGuid === "string" && profile.profileGuid ? profile.profileGuid : void 0;
     const firstName = typeof profile.firstName === "string" ? profile.firstName.trim() : "";
     const lastName = typeof profile.lastName === "string" ? profile.lastName.trim() : "";
     const currentJobTitle = typeof profile.currentJobTitle === "string" ? profile.currentJobTitle.trim() : "";
@@ -2820,6 +2860,7 @@
       {
         profileId,
         profileType,
+        seekProfileGuid,
         externalId: profileId ? `${window.location.hostname.toLowerCase()}:profile:${profileId}` : "",
         name: [firstName, lastName].filter(Boolean).join(" ").trim(),
         profileUrl: buildSeekProfileUrl(profileId, jobId),
@@ -3547,7 +3588,9 @@
     const url = new URL(window.location.href);
     const currentPage = typeof requestInput?.pageNumber === "number" ? requestInput.pageNumber : normalizeOptionalPositiveInt(url.searchParams.get("pageNumber")) || 1;
     return candidates.map((node, index) => {
-      const profileId = typeof node?.profileGuid === "string" && node.profileGuid ? node.profileGuid : typeof node?.id === "string" && node.id ? node.id : "";
+      const profileGuid = typeof node?.profileGuid === "string" && node.profileGuid ? node.profileGuid : "";
+      const relayId = typeof node?.id === "string" && node.id ? node.id : "";
+      const profileId = profileGuid || relayId;
       if (!profileId) return null;
       const firstName = typeof node?.firstName === "string" ? node.firstName.trim() : "";
       const lastName = typeof node?.lastName === "string" ? node.lastName.trim() : "";
@@ -3558,9 +3601,10 @@
       return {
         profileId,
         profileType: "seek",
+        seekProfileGuid: profileGuid || void 0,
         externalId: profileId ? `${window.location.hostname.toLowerCase()}:profile:${profileId}` : "",
         name: [firstName, lastName].filter(Boolean).join(" ").trim(),
-        profileUrl: buildSeekProfileUrl(profileId, void 0),
+        profileUrl: buildSeekNameSearchUrl([firstName, lastName].filter(Boolean).join(" "), url.searchParams.get("market") || void 0),
         activityStatus: lastModifiedDurationLabel,
         age: "",
         experience: "",
@@ -4556,7 +4600,8 @@
         if (done) return;
         const snapshot = apiSnapshot.seekProfile;
         const identity = snapshot ? getSeekCandidateIdentity(snapshot) : null;
-        if (identity?.profileId === String(profileId)) {
+        const snapshotGuid = typeof snapshot?.profileGuid === "string" ? snapshot.profileGuid : "";
+        if (identity?.profileId === String(profileId) || snapshotGuid === String(profileId)) {
           done = true;
           cleanup();
           resolve(snapshot);
@@ -4582,23 +4627,36 @@
     });
   }
   __name(waitForSeekProfileSnapshot, "waitForSeekProfileSnapshot");
-  async function enrichSingleSeekResumeWithDetail(resume) {
+  async function enrichSingleSeekResumeWithDetail(resume, cachedHeadings) {
     const profileId = typeof resume?.profileId === "string" ? resume.profileId.trim() : "";
     if (!profileId) {
       return resume;
     }
-    const trigger = findSeekProfileTrigger(profileId);
+    const isTalentSearch = getCurrentSeekMode() === "talentsearch";
+    const trigger = isTalentSearch ? findSeekTalentSearchCardTrigger(profileId, resume, cachedHeadings) : findSeekProfileTrigger(profileId);
     if (!(trigger instanceof HTMLElement)) {
       return resume;
     }
     try {
       trigger.click();
-      await waitForSeekProfileSnapshot(profileId, { timeoutMs: 12e3 });
+      const matchId = isTalentSearch ? resume.seekProfileGuid || profileId : profileId;
+      await waitForSeekProfileSnapshot(matchId, { timeoutMs: 12e3 });
       const [detailResume] = extractSeekProfileResume();
-      if (!detailResume || detailResume.profileId !== profileId) {
+      if (!detailResume) {
         return resume;
       }
-      return mergeSeekListResumeWithDetail(resume, detailResume);
+      if (isTalentSearch) {
+        const detailGuid = detailResume.seekProfileGuid || "";
+        const detailProfileId = detailResume.profileId || "";
+        if (detailGuid !== profileId && detailProfileId !== profileId) {
+          return resume;
+        }
+        return mergeSeekListResumeWithDetail(resume, detailResume, isTalentSearch);
+      }
+      if (detailResume.profileId !== profileId) {
+        return resume;
+      }
+      return mergeSeekListResumeWithDetail(resume, detailResume, isTalentSearch);
     } catch (error) {
       console.warn(
         "\u{1F3AF} [Auto Sync] Failed to enrich Seek detail resume:",
@@ -4613,10 +4671,11 @@
     if (!Array.isArray(resumes) || resumes.length === 0) return [];
     if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return resumes;
     if (isSeekProfileMode()) return resumes;
-    if (getCurrentSeekMode() === "talentsearch") return resumes;
+    const isTalentSearch = getCurrentSeekMode() === "talentsearch";
+    const cachedHeadings = isTalentSearch ? Array.from(document.querySelectorAll('[data-role="heading"]')) : null;
     const enriched = [];
     for (const resume of resumes) {
-      enriched.push(await enrichSingleSeekResumeWithDetail(resume));
+      enriched.push(await enrichSingleSeekResumeWithDetail(resume, cachedHeadings));
     }
     return enriched;
   }

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -881,6 +881,12 @@ function buildSeekProfileUrl(profileId, jobId) {
   return `https://${hostname}/candidates/${encodeURIComponent(profileId)}`;
 }
 
+function buildSeekNameSearchUrl(name, market) {
+  const trimmed = typeof name === "string" ? name.trim() : "";
+  if (!trimmed) return "";
+  return `https://${window.location.hostname.toLowerCase()}/talentsearch/profiles/search?searchQuery=${encodeURIComponent(trimmed)}&market=${encodeURIComponent(market || "MY")}&pageNumber=1`;
+}
+
 function getSeekRecommendedRequest() {
   return apiSnapshot.seekRecommendedRequest;
 }
@@ -3637,7 +3643,7 @@ function extractSeekTalentSearchResumes() {
           ? `${window.location.hostname.toLowerCase()}:profile:${profileId}`
           : "",
         name: [firstName, lastName].filter(Boolean).join(" ").trim(),
-        profileUrl: buildSeekProfileUrl(profileId, undefined),
+        profileUrl: buildSeekNameSearchUrl([firstName, lastName].filter(Boolean).join(" "), url.searchParams.get("market") || undefined),
         activityStatus: lastModifiedDurationLabel,
         age: "",
         experience: "",

--- a/apps/web/src/components/search/SnippetCardExpanded.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.tsx
@@ -222,6 +222,10 @@ export function SnippetCardExpanded({
   )
   const profileUrl = item.resume.profileUrl?.trim()
   const hasProfileUrl = isSafeProfileUrl(profileUrl)
+  const isNameSearchUrl = typeof profileUrl === 'string' && profileUrl.includes('/talentsearch/profiles/search')
+  const profileLinkLabel = isNameSearchUrl
+    ? t('resumes.searchPage.card.searchOnSeek', { defaultValue: '在 Seek 搜尋' })
+    : openSourceProfileLabel
   const { resolve: resolveBrand } = useBrandDisplayMap()
   const brandSummary = summarizeBrandHits(item.resume.ingestData?.brandHits)
 
@@ -594,7 +598,7 @@ export function SnippetCardExpanded({
                   rel="noreferrer"
                   className={cn(buttonVariants({ variant: 'outline' }), 'w-full justify-center rounded-xl')}
                 >
-                  {openSourceProfileLabel}
+                  {profileLinkLabel}
                   <ExternalLink className="ml-2 h-4 w-4" />
                 </a>
               ) : null}

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { normalizeProfileUrlForDisplay, normalizeSharedResumeFields, parseKeywordQuery } from '@trends/shared'
+import { normalizeProfileUrlForDisplay, normalizeSharedResumeFields, parseKeywordQuery, inferSeekMarket } from '@trends/shared'
 import { usePaginatedQuery, useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
@@ -640,9 +640,12 @@ function readMockConvexResumePayload(): MockConvexResumePayload | null {
 
 function mapResumeDoc(doc: ResumeListDocLike): ConvexResumeItem {
   const content = isRecord(doc.content) ? doc.content : {}
+  const candidateName = toStringValue(content.name);
+  const seekMarket = doc.source?.includes("seek") ? inferSeekMarket(doc.source) : undefined;
   const profileUrl = normalizeProfileUrlForDisplay(
     content.profileUrl ?? content.profile_url ?? content.profileURL ?? content.url,
-    doc.source
+    doc.source,
+    { name: candidateName, market: seekMarket }
   )
 
   return {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -469,6 +469,7 @@
         "resumeMetadata": "Resume metadata",
         "signals": "Signals",
         "openSourceProfile": "Open source profile",
+        "searchOnSeek": "Search on Seek",
         "summaryUnavailable": "AI summary is not available for this resume. The current visible score comes from rule scoring only.",
         "aiSummaryUnavailable": "AI analysis is not available for this resume yet. The score will appear after analysis completes.",
         "profileOverview": "Profile overview",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -464,6 +464,7 @@
         "resumeMetadata": "简历元数据",
         "signals": "信号",
         "openSourceProfile": "打开原始简历",
+        "searchOnSeek": "在 Seek 搜索",
         "summaryUnavailable": "该简历暂无 AI 摘要。当前可见分数来自规则评分。",
         "aiSummaryUnavailable": "该简历尚未生成 AI 分析，分析完成后会显示分数。",
         "profileOverview": "概览",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -464,6 +464,7 @@
         "resumeMetadata": "簡歷中繼資料",
         "signals": "信號",
         "openSourceProfile": "開啟原始簡歷",
+        "searchOnSeek": "在 Seek 搜尋",
         "summaryUnavailable": "此簡歷暫無 AI 摘要。目前顯示的分數來自規則評分。",
         "aiSummaryUnavailable": "此簡歷尚未生成 AI 分析，分析完成後會顯示分數。",
         "profileOverview": "概覽",

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -4,10 +4,12 @@ import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import {
     buildLatestWorkHistoryEvidence,
+    buildSeekNameSearchUrl,
     computeTemplateHash,
     computeVerifiedRoleYears,
     formatLocationHierarchyLabel,
     getWorkspaceSearchProfileTemplates,
+    inferSeekMarket,
     normalizeJob5156ProfileUrlForDisplay,
     normalizeResumeLocationHierarchy,
     normalizeWorkHistoryEntry,
@@ -1637,6 +1639,62 @@ export const backfillMarketField = mutation({
         return {
             scanned: resumes.page.length,
             updated,
+            hasMore: !resumes.isDone,
+            cursor: resumes.isDone ? null : resumes.continueCursor,
+        };
+    },
+});
+
+export const backfillSeekNameSearchUrls = mutation({
+    args: {
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const resumes = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.batchSize),
+            });
+        let updatedResumes = 0;
+
+        for (const resume of resumes.page) {
+            const source = typeof resume.source === "string" ? resume.source : "";
+            const isSeekSource = source.includes("seek");
+            if (!isSeekSource) continue;
+
+            const content = typeof resume.content === "object" && resume.content !== null ? resume.content as Record<string, unknown> : {};
+            const profileUrl = typeof content.profileUrl === "string" ? content.profileUrl : "";
+
+            // Skip if already name-search URL
+            if (profileUrl.includes("/talentsearch/profiles/search")) continue;
+
+            // Check for UUID pattern
+            const uuidMatch = profileUrl.match(/\/candidates\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\/|$)/i);
+            if (!uuidMatch) continue;
+
+            const name = typeof content.name === "string" ? content.name.trim() : "";
+            if (!name) continue;
+
+            const market = inferSeekMarket(source);
+            const nameSearchUrl = buildSeekNameSearchUrl(name, market);
+            if (!nameSearchUrl) continue;
+
+            const updatedContent = { ...content, profileUrl: nameSearchUrl };
+            const searchText = buildSearchText(updatedContent);
+            await ctx.db.patch(resume._id, {
+                content: updatedContent,
+                searchText,
+            });
+
+            updatedResumes += 1;
+        }
+
+        return {
+            scannedResumes: resumes.page.length,
+            updatedResumes,
             hasMore: !resumes.isDone,
             cursor: resumes.isDone ? null : resumes.continueCursor,
         };

--- a/packages/shared/src/__tests__/resume-normalization.seek-namesearch.test.ts
+++ b/packages/shared/src/__tests__/resume-normalization.seek-namesearch.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildSeekNameSearchUrl, inferSeekMarket } from "../resume-normalization";
+
+describe("buildSeekNameSearchUrl", () => {
+  it("builds name-search URL with name and market", () => {
+    expect(buildSeekNameSearchUrl("Cyan Yap Kin Sun", "MY"))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=Cyan%20Yap%20Kin%20Sun&market=MY&pageNumber=1");
+  });
+
+  it("encodes special characters in name", () => {
+    expect(buildSeekNameSearchUrl("Tan & Associates", "HK"))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=Tan%20%26%20Associates&market=HK&pageNumber=1");
+  });
+
+  it("returns empty string when name is empty", () => {
+    expect(buildSeekNameSearchUrl("", "MY")).toBe("");
+  });
+
+  it("returns empty string when name is whitespace only", () => {
+    expect(buildSeekNameSearchUrl("  ", "MY")).toBe("");
+  });
+
+  it("handles CJK characters in name", () => {
+    expect(buildSeekNameSearchUrl("陈大文", "MY"))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=%E9%99%88%E5%A4%A7%E6%96%87&market=MY&pageNumber=1");
+  });
+
+  it("defaults market to MY when not provided", () => {
+    expect(buildSeekNameSearchUrl("John Doe"))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=John%20Doe&market=MY&pageNumber=1");
+  });
+});
+
+describe("inferSeekMarket", () => {
+  it("returns MY for seek source", () => {
+    expect(inferSeekMarket("hk.employer.seek.com")).toBe("MY");
+  });
+
+  it("returns MY for my.employer.seek.com host", () => {
+    expect(inferSeekMarket("my.employer.seek.com")).toBe("MY");
+  });
+
+  it("returns HK for hk.employer.seek.com with HK indicators", () => {
+    expect(inferSeekMarket("hk.employer.seek.com", "HK")).toBe("HK");
+  });
+
+  it("returns MY by default", () => {
+    expect(inferSeekMarket("unknown")).toBe("MY");
+  });
+});

--- a/packages/shared/src/__tests__/resume-normalization.seek-namesearch.test.ts
+++ b/packages/shared/src/__tests__/resume-normalization.seek-namesearch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildSeekNameSearchUrl, inferSeekMarket } from "../resume-normalization";
+import { buildSeekNameSearchUrl, inferSeekMarket, normalizeSeekProfileUrlForDisplay, normalizeProfileUrlForDisplay } from "../resume-normalization";
 
 describe("buildSeekNameSearchUrl", () => {
   it("builds name-search URL with name and market", () => {
@@ -46,5 +46,47 @@ describe("inferSeekMarket", () => {
 
   it("returns MY by default", () => {
     expect(inferSeekMarket("unknown")).toBe("MY");
+  });
+});
+
+describe("normalizeSeekProfileUrlForDisplay with name-search upgrade", () => {
+  it("upgrades UUID URL to name-search when name is provided", () => {
+    const uuidUrl = "https://hk.employer.seek.com/candidates/82a5d7c6-6fb3-4960-aa78-58159b0c62d1";
+    expect(normalizeSeekProfileUrlForDisplay(uuidUrl, "Cyan Yap Kin Sun", "MY"))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=Cyan%20Yap%20Kin%20Sun&market=MY&pageNumber=1");
+  });
+
+  it("passes UUID URL through unchanged when name is not provided", () => {
+    const uuidUrl = "https://hk.employer.seek.com/candidates/82a5d7c6-6fb3-4960-aa78-58159b0c62d1";
+    expect(normalizeSeekProfileUrlForDisplay(uuidUrl)).toBe(uuidUrl);
+  });
+
+  it("passes UUID URL through unchanged when name is empty", () => {
+    const uuidUrl = "https://hk.employer.seek.com/candidates/82a5d7c6-6fb3-4960-aa78-58159b0c62d1";
+    expect(normalizeSeekProfileUrlForDisplay(uuidUrl, "", "MY")).toBe(uuidUrl);
+  });
+
+  it("keeps recommended URL unchanged even when name is provided", () => {
+    const recUrl = "https://hk.employer.seek.com/candidates/recommended?jobId=123&openProfileId=456";
+    expect(normalizeSeekProfileUrlForDisplay(recUrl, "John Doe", "MY")).toBe(recUrl);
+  });
+
+  it("keeps numeric direct-path URL unchanged", () => {
+    const numUrl = "https://hk.employer.seek.com/candidates/12345";
+    expect(normalizeSeekProfileUrlForDisplay(numUrl, "John Doe", "MY")).toBe(numUrl);
+  });
+});
+
+describe("normalizeProfileUrlForDisplay with name param", () => {
+  it("passes name and market to seek normalizer for seek source", () => {
+    const uuidUrl = "https://hk.employer.seek.com/candidates/82a5d7c6-6fb3-4960-aa78-58159b0c62d1";
+    expect(normalizeProfileUrlForDisplay(uuidUrl, "hk.employer.seek.com", { name: "Cyan Yap", market: "MY" }))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=Cyan%20Yap&market=MY&pageNumber=1");
+  });
+
+  it("works without name/market options (backward compatible)", () => {
+    const numUrl = "https://hk.employer.seek.com/candidates/12345";
+    expect(normalizeProfileUrlForDisplay(numUrl, "hk.employer.seek.com"))
+      .toBe("https://hk.employer.seek.com/candidates/12345");
   });
 });

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -177,7 +177,7 @@ export function normalizeJob5156ProfileUrlForDisplay(value: string): string {
   return `${JOB5156_PROFILE_URL_PREFIX}${encodeURIComponent(resumeId)}`;
 }
 
-export function normalizeSeekProfileUrlForDisplay(value: string): string {
+export function normalizeSeekProfileUrlForDisplay(value: string, name?: string, market?: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
     return "";
@@ -195,6 +195,11 @@ export function normalizeSeekProfileUrlForDisplay(value: string): string {
     return trimmed;
   }
 
+  // Already in name-search format — return as-is
+  if (parsed.pathname.toLowerCase() === "/talentsearch/profiles/search") {
+    return trimmed;
+  }
+
   // Already in recommended format — return as-is
   if (parsed.pathname.toLowerCase() === "/candidates/recommended") {
     return trimmed;
@@ -209,12 +214,13 @@ export function normalizeSeekProfileUrlForDisplay(value: string): string {
     profileId = numericIdMatch[1];
   }
 
-  // UUID pattern: /candidates/{uuid} (talentsearch mode — no jobId available)
+  // UUID pattern: /candidates/{uuid} (talentsearch mode)
   if (!profileId) {
     const uuidMatch = parsed.pathname.match(/\/candidates\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\/|$)/i);
     if (uuidMatch?.[1]) {
-      // Talentsearch UUID URLs pass through — cannot build recommended URL without numeric profileId
-      return trimmed;
+      // Upgrade UUID URL to name-search URL when name is available
+      const nameSearchUrl = buildSeekNameSearchUrl(name || "", market);
+      return nameSearchUrl || trimmed;
     }
   }
 
@@ -226,7 +232,7 @@ export function normalizeSeekProfileUrlForDisplay(value: string): string {
   return `https://${hostname}/candidates/${profileId}`;
 }
 
-export function normalizeProfileUrlForDisplay(value: unknown, source?: string): string {
+export function normalizeProfileUrlForDisplay(value: unknown, source?: string, options?: { name?: string; market?: string }): string {
   const trimmed = toTrimmedString(value);
   if (!trimmed) {
     return "";
@@ -239,14 +245,14 @@ export function normalizeProfileUrlForDisplay(value: unknown, source?: string): 
   }
 
   if (loweredSource?.endsWith(SEEK_HOST_SUFFIX)) {
-    return normalizeSeekProfileUrlForDisplay(trimmed);
+    return normalizeSeekProfileUrlForDisplay(trimmed, options?.name, options?.market);
   }
 
   // Also handle seek URLs regardless of source (safety net for mixed data)
   try {
     const parsed = new URL(trimmed);
     if (parsed.hostname.toLowerCase().endsWith(SEEK_HOST_SUFFIX)) {
-      return normalizeSeekProfileUrlForDisplay(trimmed);
+      return normalizeSeekProfileUrlForDisplay(trimmed, options?.name, options?.market);
     }
   } catch {
     // Not a valid URL — pass through

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -93,7 +93,7 @@ export function buildSeekNameSearchUrl(name: string, market?: string): string {
   return `https://${SEEK_NAME_SEARCH_HOST}/talentsearch/profiles/search?searchQuery=${encodeURIComponent(trimmedName)}&market=${encodeURIComponent(resolvedMarket)}&pageNumber=1`;
 }
 
-export function inferSeekMarket(source: string, hint?: string): string {
+export function inferSeekMarket(_source: string, hint?: string): string {
   if (hint === "HK" || hint === "hk") return "HK";
   // Source hostnames for MY market include both hk. and my. subdomains
   // (Seek routes by market param, not subdomain)

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -84,6 +84,21 @@ export type NormalizedResumeFields = {
 const JOB5156_HOST = "hr.job5156.com";
 const JOB5156_PROFILE_URL_PREFIX = `https://${JOB5156_HOST}/resume/view/`;
 const SEEK_HOST_SUFFIX = ".employer.seek.com";
+const SEEK_NAME_SEARCH_HOST = "hk.employer.seek.com";
+
+export function buildSeekNameSearchUrl(name: string, market?: string): string {
+  const trimmedName = typeof name === "string" ? name.trim() : "";
+  if (!trimmedName) return "";
+  const resolvedMarket = market || "MY";
+  return `https://${SEEK_NAME_SEARCH_HOST}/talentsearch/profiles/search?searchQuery=${encodeURIComponent(trimmedName)}&market=${encodeURIComponent(resolvedMarket)}&pageNumber=1`;
+}
+
+export function inferSeekMarket(source: string, hint?: string): string {
+  if (hint === "HK" || hint === "hk") return "HK";
+  // Source hostnames for MY market include both hk. and my. subdomains
+  // (Seek routes by market param, not subdomain)
+  return "MY";
+}
 
 const SOURCE_KEY_TO_COUNTRY: Record<ResumeAnalysisSourceKey, string> = {
   job5156: "中国",


### PR DESCRIPTION
## Summary
- Replace broken UUID-based `profileUrl` (`/candidates/{uuid}` → 404) with Seek name-search URL for talentsearch resumes
- `buildSeekNameSearchUrl(name, market)` in shared package constructs `/talentsearch/profiles/search?searchQuery={name}&market=MY`
- `normalizeSeekProfileUrlForDisplay` upgraded with optional `name`/`market` params — UUID URLs become name-search when name is available, backward compatible when not
- Convex paginated migration `backfillSeekNameSearchUrls` rewrites 400+ existing UUID-URL resumes
- UI label: "Search on Seek" for name-search URLs, "Open source profile" for direct profile URLs
- i18n keys added for en/zh-Hant/zh-Hans

## Test plan
- [x] 17 unit tests in `resume-normalization.seek-namesearch.test.ts` covering `buildSeekNameSearchUrl`, `inferSeekMarket`, UUID→name-search upgrade, backward compatibility
- [x] `make check` passes (typecheck, lint, 1224 tests, governance)
- [ ] Run `backfillSeekNameSearchUrls` migration on dev Convex to verify existing UUID URLs are rewritten
- [ ] Live verification on pvelxc devsh: click "Search on Seek" on a talentsearch resume → Seek name search opens with candidate in results