### PR TITLE
fix: auto-rebuild @trends/shared when dist is stale in check-node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1115,6 +1115,11 @@ check-python:
 # Node/TypeScript checks (uses Bun locally when available, npm in CI)
 check-node:
 	@echo "Running Node.js checks..."
+	@# Verify @trends/shared dist is not stale (source newer than dist)
+	@if [ -f packages/shared/dist/index.js ] && find packages/shared/src -type f -newer packages/shared/dist/index.js -print -quit | grep -q .; then \
+		echo "Rebuilding @trends/shared (source is newer than dist)..."; \
+		npm run --workspace @trends/shared build; \
+	fi
 	@npm run check:resume-ai-prompts
 	@npm run check:resume-field-usage-policy
 	@npm run check:search-profile-templates


### PR DESCRIPTION
## Summary
- Added stale dist detection to `make check-node`: if `packages/shared/src/` has files newer than `packages/shared/dist/index.js`, automatically rebuilds before running type checks
- Prevents Convex dev server errors ("No matching export for buildSeekNameSearchUrl") and test failures ("parseExperienceYears is not a function") after git pull

## Root Cause
After merging PRs that modify `packages/shared/src/`, the dist is not rebuilt because it's gitignored. When Convex or tests import from `@trends/shared`, they get a stale dist that's missing new exports.

## Test Plan
- [x] `make check` passes (auto-rebuilds when stale)
- [x] `make check` passes (skips rebuild when dist is current)
- [x] Full test suite: 121 files, 1230 tests pass