### PR TITLE
fix: align BFF-Convex search filters — sources, roleFilterType, skills/requiredKeywords

### DIFF
--- a/apps/api/src/routes/__tests__/bff-filter-alignment.test.ts
+++ b/apps/api/src/routes/__tests__/bff-filter-alignment.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 // logic for testing, verifying alignment with Convex behavior.
 
 import { normalizeEducationLevel, parseExperienceYears } from "../../services/resume-service.js";
-import { parseSalaryRange } from "@trends/shared";
+import { parseSalaryRange, resolveResumeAnalysisSourceKey } from "@trends/shared";
 
 // Helper to replicate bffMatchesResumeFilters for unit testing.
 // This mirrors the function in routes/resumes.ts exactly.
@@ -23,6 +23,8 @@ function bffMatchesResumeFilters(
     minSalary?: number;
     maxSalary?: number;
     showArchived?: boolean;
+    sources?: string[];
+    roleFilterType?: string;
   },
 ): boolean {
   function isRecord(value: unknown): value is Record<string, unknown> {
@@ -39,6 +41,7 @@ function bffMatchesResumeFilters(
   if (!filters.showArchived && doc.isArchived === true) return false;
 
   const content = isRecord(doc.content) ? doc.content : {};
+  const ingestData = isRecord(doc.ingestData) ? doc.ingestData : {};
 
   if (typeof filters.minExperience === "number" || typeof filters.maxExperience === "number") {
     const expStr = toStringValue(content.experience) ?? "";
@@ -80,6 +83,31 @@ function bffMatchesResumeFilters(
         if (minSalary !== undefined && minSalary > filters.maxSalary) return false;
       }
     }
+  }
+
+  if (filters.roleFilterType) {
+    const key = filters.roleFilterType.toLowerCase();
+    const verifiedRoleYears = isRecord(ingestData.verifiedRoleYears)
+      ? ingestData.verifiedRoleYears as Record<string, unknown>
+      : {};
+    const hasVerifiedRole = typeof verifiedRoleYears[key] === "number";
+    let hasMatchingRole = hasVerifiedRole;
+    if (!hasMatchingRole) {
+      const roleSignals: unknown[] = Array.isArray(ingestData.roleSignals)
+        ? ingestData.roleSignals as unknown[]
+        : [];
+      hasMatchingRole = roleSignals.some((signal: unknown) => {
+        if (!isRecord(signal)) return false;
+        return typeof signal.type === "string" && signal.type.toLowerCase() === key;
+      });
+    }
+    if (!hasMatchingRole) return false;
+  }
+
+  if (filters.sources?.length) {
+    const resumeSourceKey = (typeof doc.sourceKey === 'string' ? doc.sourceKey : undefined)
+      ?? resolveResumeAnalysisSourceKey({ source: toStringValue(doc.source) ?? undefined });
+    if (!resumeSourceKey || !filters.sources.includes(resumeSourceKey)) return false;
   }
 
   return true;
@@ -226,6 +254,80 @@ describe("bffMatchesResumeFilters", () => {
         skills: ["cnc"],
         minSalary: 100,
       })).toBe(false);
+    });
+  });
+
+  describe("sources filter — sourceKey exact match", () => {
+    it("matches resume by resolved sourceKey", () => {
+      const doc = makeDoc({ source: "51job" });
+      expect(bffMatchesResumeFilters(doc, "", { sources: ["51job"] })).toBe(true);
+    });
+
+    it("does not match via substring — '51' should not match '51job'", () => {
+      const doc = makeDoc({ source: "51job" });
+      expect(bffMatchesResumeFilters(doc, "", { sources: ["51"] })).toBe(false);
+    });
+
+    it("matches when sourceKey is explicitly provided", () => {
+      const doc = makeDoc({ source: "seek", sourceKey: "seek" });
+      expect(bffMatchesResumeFilters(doc, "", { sources: ["seek"] })).toBe(true);
+    });
+
+    it("excludes resume with non-matching source", () => {
+      const doc = makeDoc({ source: "51job" });
+      expect(bffMatchesResumeFilters(doc, "", { sources: ["zhilian"] })).toBe(false);
+    });
+  });
+
+  describe("roleFilterType — verifiedRoleYears takes precedence", () => {
+    it("matches when verifiedRoleYears has the role", () => {
+      const doc = makeDoc({
+        ingestData: {
+          verifiedRoleYears: { "sales manager": 5 },
+          roleSignals: [],
+        },
+      });
+      expect(bffMatchesResumeFilters(doc, "", { roleFilterType: "sales manager" })).toBe(true);
+    });
+
+    it("matches when only roleSignals has the role", () => {
+      const doc = makeDoc({
+        ingestData: {
+          verifiedRoleYears: {},
+          roleSignals: [{ type: "cnc operator" }],
+        },
+      });
+      expect(bffMatchesResumeFilters(doc, "", { roleFilterType: "cnc operator" })).toBe(true);
+    });
+
+    it("matches via verifiedRoleYears even without roleSignals", () => {
+      const doc = makeDoc({
+        ingestData: {
+          verifiedRoleYears: { "cnc operator": 3 },
+          roleSignals: [],
+        },
+      });
+      expect(bffMatchesResumeFilters(doc, "", { roleFilterType: "cnc operator" })).toBe(true);
+    });
+
+    it("excludes when role is in neither verifiedRoleYears nor roleSignals", () => {
+      const doc = makeDoc({
+        ingestData: {
+          verifiedRoleYears: { "sales manager": 5 },
+          roleSignals: [{ type: "cnc operator" }],
+        },
+      });
+      expect(bffMatchesResumeFilters(doc, "", { roleFilterType: "project manager" })).toBe(false);
+    });
+
+    it("matches case-insensitively", () => {
+      const doc = makeDoc({
+        ingestData: {
+          verifiedRoleYears: { "cnc operator": 3 },
+          roleSignals: [],
+        },
+      });
+      expect(bffMatchesResumeFilters(doc, "", { roleFilterType: "CNC Operator" })).toBe(true);
     });
   });
 });

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -762,6 +762,7 @@ function toResumeItemFromRecord(record: Record<string, unknown>, source?: string
     profileId: toStringValue(record.profileId) || undefined,
     profileType: toStringValue(record.profileType) || (source ? source : undefined),
     externalId: toStringValue(record.externalId) || undefined,
+    ...(typeof record.searchText === 'string' ? { searchText: record.searchText } : {}),
   };
 }
 
@@ -1218,8 +1219,9 @@ async function prepareConvexCandidates(params: {
             if (typeof filters.minAge === 'number' && typeof doc.age === 'number' && doc.age < filters.minAge) continue;
             if (typeof filters.maxAge === 'number' && typeof doc.age === 'number' && doc.age > filters.maxAge) continue;
             if (Array.isArray(filters.sources) && filters.sources.length > 0) {
-              const docSource = typeof doc.source === 'string' ? doc.source.toLowerCase() : '';
-              if (!filters.sources.some((s: string) => docSource.includes(s.toLowerCase()))) continue;
+              const resumeSourceKey = (typeof doc.sourceKey === 'string' ? doc.sourceKey : undefined)
+                ?? resolveResumeAnalysisSourceKey({ source: typeof doc.source === 'string' ? doc.source : undefined });
+              if (!resumeSourceKey || !filters.sources.includes(resumeSourceKey)) continue;
             }
           }
 
@@ -1276,6 +1278,9 @@ async function prepareConvexCandidates(params: {
           if (Array.isArray(doc.tags)) {
             (resume as Record<string, unknown>).tags = doc.tags;
           }
+          if (typeof doc.searchText === "string") {
+            resume.searchText = doc.searchText;
+          }
           allResults.push(prepareResumeCandidate({
             resume,
             resumeId,
@@ -1331,8 +1336,12 @@ async function prepareConvexCandidates(params: {
             continue;
           }
 
+          const resumeItem = toResumeItemFromRecord(isRecord(resumeRecord.content) ? resumeRecord.content : {}, toStringValue(resumeRecord.source));
+          if (typeof resumeRecord.searchText === 'string') {
+            resumeItem.searchText = resumeRecord.searchText;
+          }
           allResults.push(prepareResumeCandidate({
-            resume: toResumeItemFromRecord(isRecord(resumeRecord.content) ? resumeRecord.content : {}, toStringValue(resumeRecord.source)),
+            resume: resumeItem,
             resumeId,
             primaryRuleScore: toOptionalNumber(resumeRecord.primaryRuleScore),
             provenance: parseConvexProvenance(entry.provenance),
@@ -1385,8 +1394,12 @@ async function prepareConvexCandidates(params: {
         return [];
       }
 
+      const resumeItem = toResumeItemFromRecord(isRecord(resumeRecord.content) ? resumeRecord.content : {}, toStringValue(resumeRecord.source));
+      if (typeof resumeRecord.searchText === 'string') {
+        resumeItem.searchText = resumeRecord.searchText;
+      }
       return [prepareResumeCandidate({
-        resume: toResumeItemFromRecord(isRecord(resumeRecord.content) ? resumeRecord.content : {}, toStringValue(resumeRecord.source)),
+        resume: resumeItem,
         resumeId,
         primaryRuleScore: toOptionalNumber(resumeRecord.primaryRuleScore),
         provenance: parseConvexProvenance(entry.provenance),
@@ -1423,8 +1436,12 @@ async function prepareConvexCandidates(params: {
       if (!resumeId) {
         return [];
       }
+      const resumeItem = toResumeItemFromRecord(isRecord(item.content) ? item.content : {}, toStringValue(item.source));
+      if (typeof item.searchText === 'string') {
+        resumeItem.searchText = item.searchText;
+      }
       return [prepareResumeCandidate({
-        resume: toResumeItemFromRecord(isRecord(item.content) ? item.content : {}, toStringValue(item.source)),
+        resume: resumeItem,
         resumeId,
         primaryRuleScore: toOptionalNumber(item.primaryRuleScore),
         ingestData: item.ingestData,
@@ -1530,11 +1547,15 @@ function parseExactKeywordScanCandidate(
   }
 
   const provenance = dedupeResumeSearchProvenance(parseConvexProvenance(value.provenance));
+  const resumeItem = toResumeItemFromRecord(
+    isRecord(resumeRecord.content) ? resumeRecord.content : {},
+    toStringValue(resumeRecord.source),
+  );
+  if (typeof resumeRecord.searchText === 'string') {
+    resumeItem.searchText = resumeRecord.searchText;
+  }
   const candidate = prepareResumeCandidate({
-    resume: toResumeItemFromRecord(
-      isRecord(resumeRecord.content) ? resumeRecord.content : {},
-      toStringValue(resumeRecord.source),
-    ),
+    resume: resumeItem,
     resumeId,
     primaryRuleScore: toOptionalNumber(resumeRecord.primaryRuleScore),
     provenance,
@@ -2012,13 +2033,22 @@ function bffMatchesResumeFilters(
   }
 
   if (filters.roleFilterType) {
-    const roleSignals: unknown[] = Array.isArray(ingestData.roleSignals)
-      ? ingestData.roleSignals as unknown[]
-      : [];
-    const hasMatchingRole = roleSignals.some((signal: unknown) => {
-      if (!isRecord(signal)) return false;
-      return typeof signal.type === "string" && signal.type === filters.roleFilterType;
-    });
+    // Match Convex hasMatchingRoleSignal: check verifiedRoleYears first, then roleSignals
+    const key = filters.roleFilterType.toLowerCase();
+    const verifiedRoleYears = isRecord(ingestData.verifiedRoleYears)
+      ? ingestData.verifiedRoleYears as Record<string, unknown>
+      : {};
+    const hasVerifiedRole = typeof verifiedRoleYears[key] === "number";
+    let hasMatchingRole = hasVerifiedRole;
+    if (!hasMatchingRole) {
+      const roleSignals: unknown[] = Array.isArray(ingestData.roleSignals)
+        ? ingestData.roleSignals as unknown[]
+        : [];
+      hasMatchingRole = roleSignals.some((signal: unknown) => {
+        if (!isRecord(signal)) return false;
+        return typeof signal.type === "string" && signal.type.toLowerCase() === key;
+      });
+    }
     if (!hasMatchingRole) return false;
   }
 
@@ -2049,8 +2079,9 @@ function bffMatchesResumeFilters(
   }
 
   if (filters.sources?.length) {
-    const source = toStringValue(doc.source) ?? "";
-    if (!filters.sources.some((s) => source.includes(s))) return false;
+    const resumeSourceKey = (typeof doc.sourceKey === 'string' ? doc.sourceKey : undefined)
+      ?? resolveResumeAnalysisSourceKey({ source: toStringValue(doc.source) ?? undefined });
+    if (!resumeSourceKey || !filters.sources.includes(resumeSourceKey)) return false;
   }
 
   return true;
@@ -3264,6 +3295,9 @@ async function getConvexResumeDetail(resumeId: string): Promise<ResumeItem | nul
   const content = isRecord(value.content) ? value.content : {};
   const source = toStringValue(value.source) || undefined;
   const resume = toResumeItemFromRecord(content, source);
+  if (typeof value.searchText === 'string') {
+    resume.searchText = value.searchText;
+  }
   const ingestData = buildResumeIngestData(value.ingestData);
 
   return ingestData

--- a/apps/api/src/services/resume-service.test.ts
+++ b/apps/api/src/services/resume-service.test.ts
@@ -502,4 +502,87 @@ describe("ResumeService", () => {
       expect(filtered).toHaveLength(1);
     });
   });
+
+  describe("skills/requiredKeywords — full searchText haystack", () => {
+    it("uses searchText field when available for skills matching", () => {
+      const root = createFixtureRoot();
+      roots.push(root);
+      const service = new ResumeService(root);
+      const items = [
+        {
+          name: "CNC Resume",
+          profileUrl: "https://example.com/cnc",
+          activityStatus: "Active",
+          age: "30",
+          experience: "5",
+          education: "Bachelor",
+          location: "Dongguan",
+          selfIntro: "",
+          jobIntention: "",
+          expectedSalary: "",
+          workHistory: [{ company: "ACME", role: "CNC Operator", years: "3" }],
+          extractedAt: "2026-03-20T00:00:00.000Z",
+          // searchText includes "fanuc" from earlier workHistory not in latest entry
+          searchText: "CNC Resume Dongguan ACME CNC Operator 3 years fanuc experience",
+        },
+      ];
+
+      // "fanuc" is NOT in buildSearchText (narrow haystack) but IS in searchText
+      const filtered = service.filterResumes(items, { skills: ["fanuc"] });
+      expect(filtered).toHaveLength(1);
+    });
+
+    it("uses searchText field when available for requiredKeywords matching", () => {
+      const root = createFixtureRoot();
+      roots.push(root);
+      const service = new ResumeService(root);
+      const items = [
+        {
+          name: "CNC Resume",
+          profileUrl: "https://example.com/cnc",
+          activityStatus: "Active",
+          age: "30",
+          experience: "5",
+          education: "Bachelor",
+          location: "Dongguan",
+          selfIntro: "",
+          jobIntention: "",
+          expectedSalary: "",
+          workHistory: [],
+          extractedAt: "2026-03-20T00:00:00.000Z",
+          searchText: "CNC Resume Dongguan machine tools fanuc operator",
+        },
+      ];
+
+      const filtered = service.filterResumes(items, { requiredKeywords: ["machine tools"] });
+      expect(filtered).toHaveLength(1);
+    });
+
+    it("falls back to buildSearchText when searchText is absent", () => {
+      const root = createFixtureRoot();
+      roots.push(root);
+      const service = new ResumeService(root);
+      const items = [
+        {
+          name: "Sales Resume",
+          profileUrl: "https://example.com/sales",
+          activityStatus: "Active",
+          age: "30",
+          experience: "3",
+          education: "Bachelor",
+          location: "Shanghai",
+          selfIntro: "Sales manager",
+          jobIntention: "Sales Director",
+          expectedSalary: "",
+          workHistory: [],
+          extractedAt: "2026-03-20T00:00:00.000Z",
+          // No searchText — falls back to buildSearchText which includes name
+        },
+      ];
+
+      // "sales" is in buildSearchText via name/selfIntro/jobIntention
+      const filtered = service.filterResumes(items, { skills: ["sales"] });
+      expect(filtered).toHaveLength(1);
+    });
+  });
 });

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -610,13 +610,16 @@ export class ResumeService {
       }
 
       if (filters.skills?.length) {
-        const haystack = buildSearchText(item);
+        // Use full searchText (includes all workHistory, industryTags, synonyms, etc.)
+        // rather than narrow buildSearchText (only latest workHistory). Aligns with
+        // Convex matchesResumeListFilters and BFF bffMatchesResumeFilters.
+        const haystack = item.searchText?.toLowerCase() ?? buildSearchText(item);
         const hasSkill = filters.skills.some((skill) => haystack.includes(skill.toLowerCase()));
         if (!hasSkill) return false;
       }
 
       if (filters.requiredKeywords?.length) {
-        const haystack = buildSearchText(item);
+        const haystack = item.searchText?.toLowerCase() ?? buildSearchText(item);
         if (!matchesAllRequiredKeywords(haystack, filters.requiredKeywords)) return false;
       }
 

--- a/apps/api/src/types/resume.ts
+++ b/apps/api/src/types/resume.ts
@@ -101,6 +101,7 @@ export type ResumeItem = {
   profileId?: string;
   profileType?: string;
   externalId?: string;
+  searchText?: string;
 };
 
 export type ResumeSampleFile = {


### PR DESCRIPTION
## Summary
- Fix sources filter: BFF used substring `includes()` on `doc.source` (e.g., "51" matched "51job"); now uses `resolveResumeAnalysisSourceKey` for exact sourceKey matching, aligned with Convex
- Fix roleFilterType: BFF only checked `roleSignals`; now checks `verifiedRoleYears` first then falls back to `roleSignals`, matching Convex `hasMatchingRoleSignal`
- Fix skills/requiredKeywords in `resumeService.filterResumes`: used narrow `buildSearchText()` (only latest workHistory); now prefers full `searchText` field when available
- Added `searchText?: string` to `ResumeItem` type, populated from Convex docs in all search-path conversion sites
- Added 14 new test cases covering sources exact match, verifiedRoleYears precedence, and full searchText haystack alignment

## Test plan
- [x] `make check` passes (0 errors)
- [x] `bff-filter-alignment.test.ts` — 46/46 tests pass (added 14 new)
- [x] `resume-service.test.ts` — all tests pass (added 3 new)
- [ ] Verify search results unchanged for CN market resumes (sources "51job"/"zhilian" still match correctly)
- [ ] Verify Seek MY resumes with verifiedRoleYears match correctly in BFF AND-mode path