### PR TITLE
refactor: rename BFF buildSearchText to buildBffSearchText

### DIFF
--- a/apps/api/src/services/resume-service.test.ts
+++ b/apps/api/src/services/resume-service.test.ts
@@ -527,7 +527,7 @@ describe("ResumeService", () => {
         },
       ];
 
-      // "fanuc" is NOT in buildSearchText (narrow haystack) but IS in searchText
+      // "fanuc" is NOT in buildBffSearchText (narrow haystack) but IS in searchText
       const filtered = service.filterResumes(items, { skills: ["fanuc"] });
       expect(filtered).toHaveLength(1);
     });
@@ -558,7 +558,7 @@ describe("ResumeService", () => {
       expect(filtered).toHaveLength(1);
     });
 
-    it("falls back to buildSearchText when searchText is absent", () => {
+    it("falls back to buildBffSearchText when searchText is absent", () => {
       const root = createFixtureRoot();
       roots.push(root);
       const service = new ResumeService(root);
@@ -576,11 +576,11 @@ describe("ResumeService", () => {
           expectedSalary: "",
           workHistory: [],
           extractedAt: "2026-03-20T00:00:00.000Z",
-          // No searchText — falls back to buildSearchText which includes name
+          // No searchText — falls back to buildBffSearchText which includes name
         },
       ];
 
-      // "sales" is in buildSearchText via name/selfIntro/jobIntention
+      // "sales" is in buildBffSearchText via name/selfIntro/jobIntention
       const filtered = service.filterResumes(items, { skills: ["sales"] });
       expect(filtered).toHaveLength(1);
     });

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -256,10 +256,10 @@ function countOccurrences(haystack: string, needle: string): number {
   return count;
 }
 
-// NOTE: This is the BFF-side narrow haystack (name + latest workHistory only).
-// Convex has a different buildResumeFilterSearchText in convex/resumes.ts that
+// BFF-side narrow haystack (name + latest workHistory/projectExperience only).
+// Different from Convex's buildResumeFilterSearchText (convex/resumes.ts) which
 // uses the full document. When searchText is available, prefer it over this.
-function buildSearchText(item: ResumeItem): string {
+function buildBffSearchText(item: ResumeItem): string {
   const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
   const latestWorkHistory = selectLatestWorkHistory(item.workHistory);
   const latestProjectExperience = selectLatestWorkHistory(item.projectExperience ?? []);
@@ -494,7 +494,7 @@ export class ResumeService {
       const index = indexMap?.get(resumeId);
 
       const name = (item.name || "").toLowerCase();
-      const searchText = index?.searchText || buildSearchText(item);
+      const searchText = index?.searchText || buildBffSearchText(item);
       const companies = index?.companies ?? selectLatestWorkHistory(item.workHistory).map((wh) => extractCompanyFromWorkHistory(wh));
 
       const perKeywordScores = keywordSets.map(({ original, variants }) => {
@@ -614,15 +614,15 @@ export class ResumeService {
 
       if (filters.skills?.length) {
         // Use full searchText (includes all workHistory, industryTags, synonyms, etc.)
-        // rather than narrow buildSearchText (only latest workHistory). Aligns with
+        // rather than narrow buildBffSearchText (only latest workHistory). Aligns with
         // Convex matchesResumeListFilters and BFF bffMatchesResumeFilters.
-        const haystack = item.searchText?.toLowerCase() ?? buildSearchText(item);
+        const haystack = item.searchText?.toLowerCase() ?? buildBffSearchText(item);
         const hasSkill = filters.skills.some((skill) => haystack.includes(skill.toLowerCase()));
         if (!hasSkill) return false;
       }
 
       if (filters.requiredKeywords?.length) {
-        const haystack = item.searchText?.toLowerCase() ?? buildSearchText(item);
+        const haystack = item.searchText?.toLowerCase() ?? buildBffSearchText(item);
         if (!matchesAllRequiredKeywords(haystack, filters.requiredKeywords)) return false;
       }
 

--- a/apps/api/src/services/unified-search-service.ts
+++ b/apps/api/src/services/unified-search-service.ts
@@ -44,7 +44,8 @@ function normalizeToken(value: string): string {
   return value.trim().toLowerCase();
 }
 
-function buildSearchText(item: ResumeItem): string {
+// BFF-side narrow haystack — same logic as resume-service.ts buildBffSearchText.
+function buildBffSearchText(item: ResumeItem): string {
   const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
   const latestWorkHistory = selectLatestWorkHistory(item.workHistory);
   const parts = [
@@ -180,7 +181,7 @@ export class UnifiedSearchService {
       const item = items[i];
       const resumeId = resolveResumeId(item, i);
       const index = options?.indexMap?.get(resumeId);
-      const searchText = index?.searchText || buildSearchText(item);
+      const searchText = index?.searchText || buildBffSearchText(item);
       const companies = index?.companies ?? selectLatestWorkHistory(item.workHistory).map((entry) => extractCompanyFromWorkHistory(entry));
       const industryTags = index?.industryTags ?? [];
       const provenance: UnifiedSearchProvenance[] = [];


### PR DESCRIPTION
## Summary
- Rename `buildSearchText` → `buildBffSearchText` in `resume-service.ts` and `unified-search-service.ts` to disambiguate from Convex's `buildResumeFilterSearchText`
- The BFF version is a narrow haystack (name + latest workHistory only); Convex uses the full document. The same name caused confusion.

## Test plan
- [x] `make check` passes
- [x] All 59 tests pass (resume-service + bff-filter-alignment)