### PR TITLE
fix: strip skills/requiredKeywords from removeServerSideFilters to prevent narrow-haystack exclusion

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -1911,12 +1911,15 @@ function resolveConvexResumeFetchLimit(params: {
 }
 
 function removeServerSideFilters(filters: ResumeFilters): ResumeFilters {
-  // Convex's matchesResumeListFilters already handled these 6 fields,
+  // Convex's matchesResumeListFilters already handled these 8 fields,
   // so strip them to avoid double-filtering. Other fields (experience,
-  // education, salary, skills, requiredKeywords) are intentionally
-  // re-applied by BFF — the double-filter is benign because both paths
-  // use the same searchText field.
-  const { minRoleYears, roleFilterType, minAge, maxAge, sources, locations, ...rest } = filters;
+  // education, salary) are intentionally re-applied by BFF — the
+  // double-filter is benign because both paths use the same content fields.
+  // skills/requiredKeywords were previously re-applied but this created a
+  // bug risk: if searchText is missing on a ResumeItem, BFF falls back to
+  // the narrow buildBffSearchText which could exclude resumes that Convex
+  // correctly included via full searchText.
+  const { minRoleYears, roleFilterType, minAge, maxAge, sources, locations, skills, requiredKeywords, ...rest } = filters;
   return rest;
 }
 


### PR DESCRIPTION
## Summary
- Add `skills` and `requiredKeywords` to `removeServerSideFilters` — Convex already filters these via full `searchText`, so BFF re-filtering is redundant and risky
- Bug risk: if `searchText` is missing on any `ResumeItem`, BFF falls back to the narrow `buildBffSearchText` (name + latest workHistory only), which could exclude resumes that Convex correctly included via the full `searchText` haystack
- Now strips 8 fields total (was 6): minRoleYears, roleFilterType, minAge, maxAge, sources, locations, skills, requiredKeywords

## Test plan
- [x] `make check` passes
- [x] 101 tests pass (resume-service + bff-filter-alignment + schema-validator-sync)
- [ ] Verify OR-mode search still returns correct results for skills/requiredKeywords queries (Convex handles these)