### PR TITLE
fix: add projectExperience to unified-search-service buildBffSearchText

### DIFF
--- a/apps/api/src/services/unified-search-service.ts
+++ b/apps/api/src/services/unified-search-service.ts
@@ -48,12 +48,14 @@ function normalizeToken(value: string): string {
 function buildBffSearchText(item: ResumeItem): string {
   const locationText = formatLocationHierarchySearchText(item.locationHierarchy) || item.location || "";
   const latestWorkHistory = selectLatestWorkHistory(item.workHistory);
+  const latestProjectExperience = selectLatestWorkHistory(item.projectExperience ?? []);
   const parts = [
     item.name,
     item.education,
     locationText,
     item.expectedSalary,
     ...latestWorkHistory.map((entry) => buildWorkHistoryEntryText(entry)),
+    ...latestProjectExperience.map((entry) => buildWorkHistoryEntryText(entry)),
   ];
   return parts.join(" ").toLowerCase();
 }


### PR DESCRIPTION
## Summary
- Add `projectExperience` to `buildBffSearchText` in `unified-search-service.ts`, matching the implementation in `resume-service.ts`
- The function was missing `projectExperience` entries, causing the fallback search text to be narrower for unified search queries

## Test plan
- [x] `make check` passes