### PR TITLE
chore: suppress false-positive react-hooks/exhaustive-deps warnings

### DIFF
--- a/apps/web/src/hooks/useCandidateActions.ts
+++ b/apps/web/src/hooks/useCandidateActions.ts
@@ -188,6 +188,7 @@ export function useCandidateActions(sessionId?: string, jobDescriptionId?: strin
 
       return data.action ?? null
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- setAiFeedbackByResume uses functional update; aiFeedbackByResume not read directly
     [sessionId, ratingsByResume, actionsByResume]
   )
 

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -927,6 +927,7 @@ function useBffAndModeSearch(
       })
 
     return () => { active = false }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- filtersKey captures all filter fields via JSON.stringify
   }, [enabled, expansionLoading, filtersKey, jobDescriptionId, keywordExpansion, normalizedQuery, refetchTrigger])
 
   return {


### PR DESCRIPTION
## Summary
- Suppress false-positive `react-hooks/exhaustive-deps` warnings in `useConvexResumes.ts` and `useCandidateActions.ts`
- `useConvexResumes`: `filtersKey` already captures all filter fields via `JSON.stringify`; listing individual deps is redundant
- `useCandidateActions`: `setAiFeedbackByResume` uses functional update form; `aiFeedbackByResume` is not read directly

## Test plan
- [x] `make check` passes — lint warnings reduced from 7 to 5