### PR TITLE
feat: add roleTitles param to Seek name-search URLs

### DIFF
--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -288,7 +288,8 @@ function buildNormalizedResumeContent(
   if (typeof profileUrl === "string" && seekContext?.sourceHost) {
     const candidateName = typeof content.name === "string" ? content.name.trim() : "";
     const market = inferSeekMarket(seekContext.sourceHost);
-    const normalized = normalizeSeekProfileUrlForDisplay(profileUrl, candidateName, market);
+    const roleTitles = typeof content.jobIntention === "string" ? content.jobIntention.trim() : undefined;
+    const normalized = normalizeSeekProfileUrlForDisplay(profileUrl, candidateName, market, roleTitles);
     if (normalized && normalized !== profileUrl) {
       // Build recommended URL if we have a jobId and numeric profileId
       if (seekContext.jobId) {

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -881,10 +881,12 @@ function buildSeekProfileUrl(profileId, jobId) {
   return `https://${hostname}/candidates/${encodeURIComponent(profileId)}`;
 }
 
-function buildSeekNameSearchUrl(name, market) {
+function buildSeekNameSearchUrl(name, market, roleTitles) {
   const trimmed = typeof name === "string" ? name.trim() : "";
   if (!trimmed) return "";
-  return `https://${window.location.hostname.toLowerCase()}/talentsearch/profiles/search?searchQuery=${encodeURIComponent(trimmed)}&market=${encodeURIComponent(market || "MY")}&pageNumber=1`;
+  const trimmedRoleTitles = typeof roleTitles === "string" ? roleTitles.trim() : "";
+  const roleTitlesParam = trimmedRoleTitles ? `&roleTitles=${encodeURIComponent(trimmedRoleTitles)}` : "";
+  return `https://${window.location.hostname.toLowerCase()}/talentsearch/profiles/search?searchQuery=${encodeURIComponent(trimmed)}&market=${encodeURIComponent(market || "MY")}&pageNumber=1${roleTitlesParam}`;
 }
 
 function getSeekRecommendedRequest() {
@@ -3643,7 +3645,7 @@ function extractSeekTalentSearchResumes() {
           ? `${window.location.hostname.toLowerCase()}:profile:${profileId}`
           : "",
         name: [firstName, lastName].filter(Boolean).join(" ").trim(),
-        profileUrl: buildSeekNameSearchUrl([firstName, lastName].filter(Boolean).join(" "), url.searchParams.get("market") || undefined),
+        profileUrl: buildSeekNameSearchUrl([firstName, lastName].filter(Boolean).join(" "), url.searchParams.get("market") || undefined, currentJobTitle),
         activityStatus: lastModifiedDurationLabel,
         age: "",
         experience: "",

--- a/packages/shared/src/__tests__/resume-normalization.seek-namesearch.test.ts
+++ b/packages/shared/src/__tests__/resume-normalization.seek-namesearch.test.ts
@@ -29,6 +29,26 @@ describe("buildSeekNameSearchUrl", () => {
     expect(buildSeekNameSearchUrl("John Doe"))
       .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=John%20Doe&market=MY&pageNumber=1");
   });
+
+  it("appends roleTitles parameter when provided", () => {
+    expect(buildSeekNameSearchUrl("Kenny Low", "MY", "Sales Manager"))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=Kenny%20Low&market=MY&pageNumber=1&roleTitles=Sales%20Manager");
+  });
+
+  it("encodes special characters in roleTitles", () => {
+    expect(buildSeekNameSearchUrl("John Doe", "MY", "Software Engineer & Architect"))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=John%20Doe&market=MY&pageNumber=1&roleTitles=Software%20Engineer%20%26%20Architect");
+  });
+
+  it("skips roleTitles when empty string", () => {
+    expect(buildSeekNameSearchUrl("John Doe", "MY", ""))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=John%20Doe&market=MY&pageNumber=1");
+  });
+
+  it("skips roleTitles when whitespace only", () => {
+    expect(buildSeekNameSearchUrl("John Doe", "MY", "  "))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=John%20Doe&market=MY&pageNumber=1");
+  });
 });
 
 describe("inferSeekMarket", () => {
@@ -75,6 +95,18 @@ describe("normalizeSeekProfileUrlForDisplay with name-search upgrade", () => {
     const numUrl = "https://hk.employer.seek.com/candidates/12345";
     expect(normalizeSeekProfileUrlForDisplay(numUrl, "John Doe", "MY")).toBe(numUrl);
   });
+
+  it("includes roleTitles when upgrading UUID URL", () => {
+    const uuidUrl = "https://hk.employer.seek.com/candidates/82a5d7c6-6fb3-4960-aa78-58159b0c62d1";
+    expect(normalizeSeekProfileUrlForDisplay(uuidUrl, "Kenny Low", "MY", "Sales Manager"))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=Kenny%20Low&market=MY&pageNumber=1&roleTitles=Sales%20Manager");
+  });
+
+  it("omits roleTitles when not provided", () => {
+    const uuidUrl = "https://hk.employer.seek.com/candidates/82a5d7c6-6fb3-4960-aa78-58159b0c62d1";
+    expect(normalizeSeekProfileUrlForDisplay(uuidUrl, "Kenny Low", "MY"))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=Kenny%20Low&market=MY&pageNumber=1");
+  });
 });
 
 describe("normalizeProfileUrlForDisplay with name param", () => {
@@ -88,5 +120,11 @@ describe("normalizeProfileUrlForDisplay with name param", () => {
     const numUrl = "https://hk.employer.seek.com/candidates/12345";
     expect(normalizeProfileUrlForDisplay(numUrl, "hk.employer.seek.com"))
       .toBe("https://hk.employer.seek.com/candidates/12345");
+  });
+
+  it("passes roleTitles through normalizeProfileUrlForDisplay options", () => {
+    const uuidUrl = "https://hk.employer.seek.com/candidates/82a5d7c6-6fb3-4960-aa78-58159b0c62d1";
+    expect(normalizeProfileUrlForDisplay(uuidUrl, "hk.employer.seek.com", { name: "Kenny Low", market: "MY", roleTitles: "Sales Manager" }))
+      .toBe("https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=Kenny%20Low&market=MY&pageNumber=1&roleTitles=Sales%20Manager");
   });
 });

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -86,11 +86,13 @@ const JOB5156_PROFILE_URL_PREFIX = `https://${JOB5156_HOST}/resume/view/`;
 const SEEK_HOST_SUFFIX = ".employer.seek.com";
 const SEEK_NAME_SEARCH_HOST = "hk.employer.seek.com";
 
-export function buildSeekNameSearchUrl(name: string, market?: string): string {
+export function buildSeekNameSearchUrl(name: string, market?: string, roleTitles?: string): string {
   const trimmedName = typeof name === "string" ? name.trim() : "";
   if (!trimmedName) return "";
   const resolvedMarket = market || "MY";
-  return `https://${SEEK_NAME_SEARCH_HOST}/talentsearch/profiles/search?searchQuery=${encodeURIComponent(trimmedName)}&market=${encodeURIComponent(resolvedMarket)}&pageNumber=1`;
+  const trimmedRoleTitles = typeof roleTitles === "string" ? roleTitles.trim() : "";
+  const roleTitlesParam = trimmedRoleTitles ? `&roleTitles=${encodeURIComponent(trimmedRoleTitles)}` : "";
+  return `https://${SEEK_NAME_SEARCH_HOST}/talentsearch/profiles/search?searchQuery=${encodeURIComponent(trimmedName)}&market=${encodeURIComponent(resolvedMarket)}&pageNumber=1${roleTitlesParam}`;
 }
 
 export function inferSeekMarket(_source: string, hint?: string): string {
@@ -177,7 +179,7 @@ export function normalizeJob5156ProfileUrlForDisplay(value: string): string {
   return `${JOB5156_PROFILE_URL_PREFIX}${encodeURIComponent(resumeId)}`;
 }
 
-export function normalizeSeekProfileUrlForDisplay(value: string, name?: string, market?: string): string {
+export function normalizeSeekProfileUrlForDisplay(value: string, name?: string, market?: string, roleTitles?: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
     return "";
@@ -219,7 +221,7 @@ export function normalizeSeekProfileUrlForDisplay(value: string, name?: string, 
     const uuidMatch = parsed.pathname.match(/\/candidates\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\/|$)/i);
     if (uuidMatch?.[1]) {
       // Upgrade UUID URL to name-search URL when name is available
-      const nameSearchUrl = buildSeekNameSearchUrl(name || "", market);
+      const nameSearchUrl = buildSeekNameSearchUrl(name || "", market, roleTitles);
       return nameSearchUrl || trimmed;
     }
   }
@@ -232,7 +234,7 @@ export function normalizeSeekProfileUrlForDisplay(value: string, name?: string, 
   return `https://${hostname}/candidates/${profileId}`;
 }
 
-export function normalizeProfileUrlForDisplay(value: unknown, source?: string, options?: { name?: string; market?: string }): string {
+export function normalizeProfileUrlForDisplay(value: unknown, source?: string, options?: { name?: string; market?: string; roleTitles?: string }): string {
   const trimmed = toTrimmedString(value);
   if (!trimmed) {
     return "";
@@ -245,14 +247,14 @@ export function normalizeProfileUrlForDisplay(value: unknown, source?: string, o
   }
 
   if (loweredSource?.endsWith(SEEK_HOST_SUFFIX)) {
-    return normalizeSeekProfileUrlForDisplay(trimmed, options?.name, options?.market);
+    return normalizeSeekProfileUrlForDisplay(trimmed, options?.name, options?.market, options?.roleTitles);
   }
 
   // Also handle seek URLs regardless of source (safety net for mixed data)
   try {
     const parsed = new URL(trimmed);
     if (parsed.hostname.toLowerCase().endsWith(SEEK_HOST_SUFFIX)) {
-      return normalizeSeekProfileUrlForDisplay(trimmed, options?.name, options?.market);
+      return normalizeSeekProfileUrlForDisplay(trimmed, options?.name, options?.market, options?.roleTitles);
     }
   } catch {
     // Not a valid URL — pass through


### PR DESCRIPTION
## Summary
- Adds optional `roleTitles` parameter to `buildSeekNameSearchUrl`, `normalizeSeekProfileUrlForDisplay`, and `normalizeProfileUrlForDisplay` in `@trends/shared`
- Browser extension passes `currentJobTitle` as `roleTitles` during talent search capture
- Resume import service passes `jobIntention` as `roleTitles` when normalizing Seek profile URLs
- 6 new test cases covering encoding, empty/whitespace, and UUID upgrade path

## Why
Seek name-search URLs with only `searchQuery={name}&market={mkt}` return too many results (e.g. 23 for "Kenny Low"). Appending `&roleTitles=Sales+Manager` narrows to ~7 matches, making it much easier to identify the correct candidate. Verified live via playwright-cli testing on the Seek talent search page.

## Test plan
- [x] `make check` passes (typecheck + lint + governance across all workspaces)
- [x] 24/24 vitest tests pass in `resume-normalization.seek-namesearch.test.ts`
- [x] SIMPLIFY code review passes with no findings
- [ ] Manual: verify name-search URL with roleTitles narrows results on Seek site