### PR TITLE
fix: pass roleTitles in web display + migration for Seek name-search URLs

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -642,10 +642,11 @@ function mapResumeDoc(doc: ResumeListDocLike): ConvexResumeItem {
   const content = isRecord(doc.content) ? doc.content : {}
   const candidateName = toStringValue(content.name);
   const seekMarket = doc.source?.includes("seek") ? inferSeekMarket(doc.source) : undefined;
+  const jobIntention = toStringValue(content.jobIntention);
   const profileUrl = normalizeProfileUrlForDisplay(
     content.profileUrl ?? content.profile_url ?? content.profileURL ?? content.url,
     doc.source,
-    { name: candidateName, market: seekMarket }
+    { name: candidateName, market: seekMarket, roleTitles: jobIntention || undefined }
   )
 
   return {

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -1668,19 +1668,21 @@ export const backfillSeekNameSearchUrls = mutation({
             const content = typeof resume.content === "object" && resume.content !== null ? resume.content as Record<string, unknown> : {};
             const profileUrl = typeof content.profileUrl === "string" ? content.profileUrl : "";
 
-            // Skip if already name-search URL
-            if (profileUrl.includes("/talentsearch/profiles/search")) continue;
-
-            // Check for UUID pattern
-            const uuidMatch = profileUrl.match(/\/candidates\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\/|$)/i);
-            if (!uuidMatch) continue;
+            // Skip if already name-search URL with roleTitles
+            if (profileUrl.includes("/talentsearch/profiles/search") && profileUrl.includes("roleTitles=")) continue;
 
             const name = typeof content.name === "string" ? content.name.trim() : "";
             if (!name) continue;
 
             const market = inferSeekMarket(source);
-            const nameSearchUrl = buildSeekNameSearchUrl(name, market);
+            const jobIntention = typeof content.jobIntention === "string" ? content.jobIntention.trim() : "";
+            const nameSearchUrl = buildSeekNameSearchUrl(name, market, jobIntention || undefined);
             if (!nameSearchUrl) continue;
+
+            // Rebuild name-search URLs missing roleTitles, or convert UUID URLs
+            const isNameSearchWithoutRoleTitles = profileUrl.includes("/talentsearch/profiles/search") && !profileUrl.includes("roleTitles=");
+            const uuidMatch = profileUrl.match(/\/candidates\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\/|$)/i);
+            if (!isNameSearchWithoutRoleTitles && !uuidMatch) continue;
 
             const updatedContent = { ...content, profileUrl: nameSearchUrl };
             const searchText = buildSearchText(updatedContent);


### PR DESCRIPTION
## Summary
- Web display (`useConvexResumes.ts`) now passes `jobIntention` as `roleTitles` to `normalizeProfileUrlForDisplay` — Seek profile links include `&roleTitles=` for narrower search results (e.g. "Kenny Low" shows ~7 results instead of 23)
- Convex migration (`backfillSeekNameSearchUrls`) now rebuilds name-search URLs that lack `roleTitles`, not just UUID→name-search conversions. Also passes `jobIntention` as the third param to `buildSeekNameSearchUrl`

## Context
PR #807 added the `roleTitles` parameter to `buildSeekNameSearchUrl` and updated the browser extension + import service, but missed the web display hook and the Convex migration.

## Test plan
- [x] `make check` passes (0 errors)
- [x] 24/24 existing seek-namesearch tests pass
- [ ] Manual: navigate to Seek resumes, inspect profile URL contains `&roleTitles=`
- [ ] Manual: click "Search on Seek" — confirm narrowed results
- [ ] Convex migration: run `backfillSeekNameSearchUrls` with paginated calls until `hasMore: false`