### PR TITLE
fix: wrap lazy-loaded drawer assertion in waitFor

### DIFF
--- a/apps/web/src/components/QuickStartPanel.test.tsx
+++ b/apps/web/src/components/QuickStartPanel.test.tsx
@@ -294,7 +294,9 @@ describe('QuickStartPanel quick-filter display', () => {
     await user.click(screen.getByRole('button', { name: 'Assistant' }))
 
     expect(onAssistantOpen).toHaveBeenCalledTimes(1)
-    expect(screen.getByTestId('search-assistant-drawer')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId('search-assistant-drawer')).toBeInTheDocument()
+    })
     expect(screen.getAllByText('广东 · CNC').length).toBeGreaterThan(0)
     expect(screen.getByText('Workflow starts')).toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary
- Fix flaky QuickStartPanel test that failed intermittently under CI load
- Root cause: `SearchAssistantDrawer` is lazy-loaded, but the test asserted `getByTestId` synchronously after clicking the Assistant button
- Fix: wrap the drawer assertion in `waitFor()` so it waits for the lazy component to render

## Test plan
- [x] `vitest run src/components/QuickStartPanel.test.tsx` — 17/17 pass
- [x] `make check` passes