### PR TITLE
fix: add gh repo clone fallback for private sample repos

### DIFF
--- a/scripts/resume/pull-sample-snapshots.ts
+++ b/scripts/resume/pull-sample-snapshots.ts
@@ -36,7 +36,14 @@ async function main(): Promise<void> {
   const tempDir = await mkdtemp("trends-pull-samples-");
   try {
     console.log(`Cloning ${sampleRepo}...`);
-    await execFileAsync("git", ["clone", "--depth=1", `https://github.com/${sampleRepo}.git`, tempDir]);
+    try {
+      await execFileAsync("git", ["clone", "--depth=1", `https://github.com/${sampleRepo}.git`, tempDir]);
+    } catch {
+      // Private repos require auth; fall back to `gh repo clone` which uses
+      // the GitHub CLI credential store (SSH key, token, etc.)
+      console.log("git clone failed — trying gh repo clone for authenticated access...");
+      await execFileAsync("gh", ["repo", "clone", sampleRepo, tempDir, "--", "--depth=1"]);
+    }
 
     const snapshotsDir = path.join(tempDir, "snapshots");
     const files = await readdir(snapshotsDir).catch(() => [] as string[]);

--- a/scripts/resume/push-sample-snapshots.ts
+++ b/scripts/resume/push-sample-snapshots.ts
@@ -138,7 +138,12 @@ async function main(): Promise<void> {
   const tempDir = await mkdtemp("trends-push-samples-");
   try {
     console.log(`Cloning ${sampleRepo}...`);
-    await execFileAsync("git", ["clone", "--depth=1", `https://github.com/${sampleRepo}.git`, tempDir]);
+    try {
+      await execFileAsync("git", ["clone", "--depth=1", `https://github.com/${sampleRepo}.git`, tempDir]);
+    } catch {
+      console.log("git clone failed — trying gh repo clone for authenticated access...");
+      await execFileAsync("gh", ["repo", "clone", sampleRepo, tempDir, "--", "--depth=1"]);
+    }
 
     const snapshotsDir = path.join(tempDir, "snapshots");
     await mkdir(snapshotsDir, { recursive: true });


### PR DESCRIPTION
## Summary
- `pull-sample-snapshots.ts` and `push-sample-snapshots.ts` clone from `ptdevhk/trends-resume-samples` (private repo) which fails without proper git credential configuration
- Add `gh repo clone` as a fallback when `git clone` fails, leveraging the GitHub CLI credential store

## Test plan
- [x] `make check` passes
- [x] `npx tsx scripts/resume/pull-sample-snapshots.ts` succeeds (3 snapshot files pulled)