### PR TITLE
chore(deps): bump i18next to 26.2.0 and @hono/node-server to 2.0.3

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,7 @@
     "openapi:gen": "tsx src/openapi.ts"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.8",
+    "@hono/node-server": "^2.0.3",
     "@hono/zod-openapi": "^0.18.4",
     "@trends/shared": "*",
     "@types/nodemailer": "^7.0.9",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,7 @@
     "convex": "^1.36.0",
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.4",
-    "i18next": "^25.8.13",
+    "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^1.0.1",
     "openapi-fetch": "^0.17.0",


### PR DESCRIPTION
## Summary
- Bump `i18next` from ^25.8.13 to ^26.2.0 (replaces stale dependabot PR #779)
- Bump `@hono/node-server` from ^1.13.8 to ^2.0.3 (replaces stale dependabot PR #777)
- Both PRs #779 and #777 failed on a flaky test that has since been fixed on main (search-profiles.test.ts now correctly expects 4 records, not 3)
- No code changes needed — both bumps are backward-compatible for this project's usage

## Test plan
- [x] `make check` passes (typecheck + lint + verify)
- [x] `vitest run apps/api/src/routes/search-profiles.test.ts` — 16/16 pass