### PR TITLE
test: extract JD editor utils + add 27 test cases

### DIFF
--- a/apps/web/src/components/JobDescriptionEditor.tsx
+++ b/apps/web/src/components/JobDescriptionEditor.tsx
@@ -16,56 +16,17 @@ import {
     DEFAULT_MIN_EXPERIENCE,
     formatKeywordInput,
     generateStructuredJobDescriptionContent,
-    normalizeIndustryTags,
     normalizeOptionalString,
     parseKeywordQuery,
-    type StructuredJobDescriptionSeedFields,
 } from "@trends/shared"
+import {
+    hasStructuredSeedFields,
+    parseOptionalNumber,
+    sanitizeIndustryTags,
+    type StructuredSeedFields,
+} from "@/lib/jd-editor-utils"
 
 const INDUSTRY_TAG_OPTIONS = CANONICAL_INDUSTRY_TAGS
-
-type StructuredSeedFields = StructuredJobDescriptionSeedFields
-
-function parseOptionalNumber(value: string): number | undefined {
-    const normalized = value.trim()
-    if (!normalized) {
-        return undefined
-    }
-    const parsed = Number(normalized)
-    if (!Number.isFinite(parsed)) {
-        return undefined
-    }
-    return Math.trunc(parsed)
-}
-
-function sanitizeIndustryTags(values: string[] | undefined): string[] {
-    return normalizeIndustryTags(values)
-}
-
-function hasStructuredSeedFields(fields: StructuredSeedFields | undefined): boolean {
-    if (!fields) {
-        return false
-    }
-
-    if (normalizeOptionalString(fields.location)) {
-        return true
-    }
-
-    if ((fields.industryTags?.length ?? 0) > 0) {
-        return true
-    }
-
-    if ((fields.customKeywords?.length ?? 0) > 0) {
-        return true
-    }
-
-    return (
-        typeof fields.minExperience === "number"
-        || typeof fields.maxExperience === "number"
-        || typeof fields.minAge === "number"
-        || typeof fields.maxAge === "number"
-    )
-}
 
 interface JobDescriptionEditorProps {
     open: boolean

--- a/apps/web/src/lib/jd-editor-utils.test.ts
+++ b/apps/web/src/lib/jd-editor-utils.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest"
+import {
+  hasStructuredSeedFields,
+  parseOptionalNumber,
+  sanitizeIndustryTags,
+} from "./jd-editor-utils"
+
+describe("parseOptionalNumber", () => {
+  it("returns undefined for empty string", () => {
+    expect(parseOptionalNumber("")).toBeUndefined()
+  })
+
+  it("returns undefined for whitespace-only string", () => {
+    expect(parseOptionalNumber("   ")).toBeUndefined()
+  })
+
+  it("parses integer string", () => {
+    expect(parseOptionalNumber("5")).toBe(5)
+  })
+
+  it("parses negative integer string", () => {
+    expect(parseOptionalNumber("-3")).toBe(-3)
+  })
+
+  it("truncates decimal to integer", () => {
+    expect(parseOptionalNumber("3.7")).toBe(3)
+  })
+
+  it("truncates negative decimal toward zero", () => {
+    expect(parseOptionalNumber("-2.9")).toBe(-2)
+  })
+
+  it("returns undefined for non-numeric string", () => {
+    expect(parseOptionalNumber("abc")).toBeUndefined()
+  })
+
+  it("returns undefined for Infinity", () => {
+    expect(parseOptionalNumber("Infinity")).toBeUndefined()
+  })
+
+  it("trims whitespace before parsing", () => {
+    expect(parseOptionalNumber("  10  ")).toBe(10)
+  })
+
+  it("parses zero", () => {
+    expect(parseOptionalNumber("0")).toBe(0)
+  })
+})
+
+describe("sanitizeIndustryTags", () => {
+  it("returns empty array for undefined input", () => {
+    expect(sanitizeIndustryTags(undefined)).toEqual([])
+  })
+
+  it("returns empty array for empty array input", () => {
+    expect(sanitizeIndustryTags([])).toEqual([])
+  })
+
+  it("normalizes valid canonical tags (lowercase)", () => {
+    const result = sanitizeIndustryTags(["machinery", "software"])
+    expect(result).toContain("machinery")
+    expect(result).toContain("software")
+  })
+
+  it("lowercases and maps legacy tags to canonical", () => {
+    const result = sanitizeIndustryTags(["CNC"])
+    expect(result).toEqual(["machinery"])
+  })
+
+  it("filters out unrecognized tags", () => {
+    const result = sanitizeIndustryTags(["machinery", "InvalidTag123"])
+    expect(result).toEqual(["machinery"])
+  })
+})
+
+describe("hasStructuredSeedFields", () => {
+  it("returns false for undefined input", () => {
+    expect(hasStructuredSeedFields(undefined)).toBe(false)
+  })
+
+  it("returns false when all fields are empty/undefined", () => {
+    expect(hasStructuredSeedFields({
+      location: undefined,
+      industryTags: undefined,
+      customKeywords: undefined,
+      minExperience: undefined,
+      maxExperience: undefined,
+      minAge: undefined,
+      maxAge: undefined,
+    })).toBe(false)
+  })
+
+  it("returns true when location is set", () => {
+    expect(hasStructuredSeedFields({
+      location: "Dongguan",
+    })).toBe(true)
+  })
+
+  it("returns false for whitespace-only location", () => {
+    expect(hasStructuredSeedFields({
+      location: "   ",
+    })).toBe(false)
+  })
+
+  it("returns true when industryTags has items", () => {
+    expect(hasStructuredSeedFields({
+      industryTags: ["Manufacturing"],
+    })).toBe(true)
+  })
+
+  it("returns false when industryTags is empty array", () => {
+    expect(hasStructuredSeedFields({
+      industryTags: [],
+    })).toBe(false)
+  })
+
+  it("returns true when customKeywords has items", () => {
+    expect(hasStructuredSeedFields({
+      customKeywords: ["机床"],
+    })).toBe(true)
+  })
+
+  it("returns true when minExperience is set", () => {
+    expect(hasStructuredSeedFields({
+      minExperience: 3,
+    })).toBe(true)
+  })
+
+  it("returns true when maxExperience is set", () => {
+    expect(hasStructuredSeedFields({
+      maxExperience: 10,
+    })).toBe(true)
+  })
+
+  it("returns true when minAge is set", () => {
+    expect(hasStructuredSeedFields({
+      minAge: 25,
+    })).toBe(true)
+  })
+
+  it("returns true when maxAge is set", () => {
+    expect(hasStructuredSeedFields({
+      maxAge: 40,
+    })).toBe(true)
+  })
+
+  it("returns true when multiple fields are set", () => {
+    expect(hasStructuredSeedFields({
+      location: "Shenzhen",
+      industryTags: ["Manufacturing"],
+      minExperience: 5,
+    })).toBe(true)
+  })
+})

--- a/apps/web/src/lib/jd-editor-utils.ts
+++ b/apps/web/src/lib/jd-editor-utils.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure utility functions for JobDescriptionEditor.
+ *
+ * Extracted from JobDescriptionEditor.tsx for testability.
+ */
+
+import {
+  normalizeIndustryTags,
+  normalizeOptionalString,
+  type StructuredJobDescriptionSeedFields,
+} from "@trends/shared";
+
+export type StructuredSeedFields = StructuredJobDescriptionSeedFields;
+
+export function parseOptionalNumber(value: string): number | undefined {
+  const normalized = value.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed)) {
+    return undefined;
+  }
+  return Math.trunc(parsed);
+}
+
+export function sanitizeIndustryTags(values: string[] | undefined): string[] {
+  return normalizeIndustryTags(values);
+}
+
+export function hasStructuredSeedFields(fields: StructuredSeedFields | undefined): boolean {
+  if (!fields) {
+    return false;
+  }
+
+  if (normalizeOptionalString(fields.location)) {
+    return true;
+  }
+
+  if ((fields.industryTags?.length ?? 0) > 0) {
+    return true;
+  }
+
+  if ((fields.customKeywords?.length ?? 0) > 0) {
+    return true;
+  }
+
+  return (
+    typeof fields.minExperience === "number"
+    || typeof fields.maxExperience === "number"
+    || typeof fields.minAge === "number"
+    || typeof fields.maxAge === "number"
+  );
+}


### PR DESCRIPTION
## Summary
- Extract `parseOptionalNumber`, `sanitizeIndustryTags`, and `hasStructuredSeedFields` from `JobDescriptionEditor.tsx` into `lib/jd-editor-utils.ts`
- Add 27 test cases covering all 3 extracted functions with edge cases
- Update `JobDescriptionEditor` imports to use the new utility module

## Test plan
- [x] `make check` passes
- [x] 27 new tests pass in `apps/web/src/lib/jd-editor-utils.test.ts`
- [x] JobDescriptionEditor behavior unchanged (pure extraction, no logic changes)