### PR TITLE
fix: add English experience signals for Seek EN resume scoring

### DIFF
--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -356,7 +356,7 @@ const DEFAULT_SALES_CONTEXT_SIGNALS = [
 ];
 const DEFAULT_ROLE_SIGNAL_LIBRARY: Record<string, string[]> = {
   sales: Array.from(new Set([...DEFAULT_SALES_DIRECT_TITLE_SIGNALS, ...DEFAULT_SALES_CONTEXT_SIGNALS])),
-  engineer: ["工程师", "设计", "研发", "开发", "编程", "调试", "维修", "技术", "engineer", "developer", "design"],
+  engineer: ["工程师", "设计", "研发", "开发", "编程", "调试", "维修", "技术", "engineer", "developer", "design", "programmer", "machinist", "technician", "cnc operator", "maintenance"],
 };
 const ROLE_SIGNAL_MATCH_WEIGHTS = {
   jobTitle: 2,

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -31,13 +31,17 @@ export function summarizeBrandHits(brandHits: BrandHitLike[] | undefined, maxCou
     .map(([brand]) => brand)
 }
 
-const CHINESE_EXPERIENCE_LEVEL_MAP: Record<string, ExperienceLevelFilter> = {
+const EXPERIENCE_LEVEL_MAP: Record<string, ExperienceLevelFilter> = {
   '资深': 'senior',
   '資深': 'senior',
+  'senior level': 'senior',
   '中级': 'mid',
   '中級': 'mid',
+  'mid level': 'mid',
   '初级': 'junior',
   '初級': 'junior',
+  'junior level': 'junior',
+  'entry level': 'junior',
 }
 
 export type ExperienceLevelFilter = 'senior' | 'mid' | 'junior'
@@ -50,7 +54,7 @@ export function normalizeExperienceLevel(level: string | undefined): ExperienceL
   if (normalized === 'senior') return 'senior'
   if (normalized === 'mid') return 'mid'
   if (normalized === 'junior') return 'junior'
-  const mapped = CHINESE_EXPERIENCE_LEVEL_MAP[level!.trim()]
+  const mapped = EXPERIENCE_LEVEL_MAP[level!.trim().toLowerCase()]
   return mapped
 }
 

--- a/config/resume/skills.en.md
+++ b/config/resume/skills.en.md
@@ -60,15 +60,15 @@ Keyword signals used to infer candidate experience level during ingest.
 
 ### senior
 - displayName: Senior Level
-- keywords: 团队管理, 大客户, 渠道拓展, 主管, 经理, manager, lead, director, 带团队, 培训, 项目管理
+- keywords: 团队管理, 大客户, 渠道拓展, 主管, 经理, manager, lead, director, 带团队, 培训, 项目管理, head of, vp, chief, senior, principal, overseeing, led team, leadership
 
 ### mid
 - displayName: Mid Level
-- keywords: 独立, 熟练, 精通, 负责, 专员, specialist, coordinator, 项目, 方案
+- keywords: 独立, 熟练, 精通, 负责, 专员, specialist, coordinator, 项目, 方案, experienced, proficient, responsible for, managed, intermediate
 
 ### junior
 - displayName: Junior Level
-- keywords: 应届, 实习, 助理, assistant, trainee, intern, 学习, 协助, 初级
+- keywords: 应届, 实习, 助理, assistant, trainee, intern, 学习, 协助, 初级, entry level, fresh graduate, graduate, no experience, beginner
 
 ## Role Signal Policy
 

--- a/config/resume/skills.md
+++ b/config/resume/skills.md
@@ -61,15 +61,15 @@ description: >
 
 ### senior
 - displayName: 资深
-- keywords: 团队管理, 大客户, 渠道拓展, 主管, 经理, manager, lead, director, 带团队, 培训, 项目管理
+- keywords: 团队管理, 大客户, 渠道拓展, 主管, 经理, manager, lead, director, 带团队, 培训, 项目管理, head of, vp, chief, senior, principal, overseeing, led team, leadership
 
 ### mid
 - displayName: 中级
-- keywords: 独立, 熟练, 精通, 负责, 专员, specialist, coordinator, 项目, 方案
+- keywords: 独立, 熟练, 精通, 负责, 专员, specialist, coordinator, 项目, 方案, experienced, proficient, responsible for, managed, intermediate
 
 ### junior
 - displayName: 初级
-- keywords: 应届, 实习, 助理, assistant, trainee, intern, 学习, 协助, 初级
+- keywords: 应届, 实习, 助理, assistant, trainee, intern, 学习, 协助, 初级, entry level, fresh graduate, graduate, no experience, beginner
 
 ## 角色信号策略
 

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -844,7 +844,7 @@ function parseExperienceYears(value: string): number | null {
     if (!normalized) {
         return null;
     }
-    if (/应届|无经验/.test(normalized)) {
+    if (/应届|无经验|fresh grad|entry level|no experience/i.test(normalized)) {
         return 0;
     }
     const match = normalized.match(/(\d+)(?:\s*[-~到]\s*(\d+))?/);

--- a/packages/shared/src/__tests__/resume-filter-helpers.test.ts
+++ b/packages/shared/src/__tests__/resume-filter-helpers.test.ts
@@ -46,6 +46,14 @@ describe("parseExperienceYears", () => {
     expect(parseExperienceYears("无经验")).toBe(0);
   });
 
+  it("parses English zero-experience terms (Seek EN)", () => {
+    expect(parseExperienceYears("fresh graduate")).toBe(0);
+    expect(parseExperienceYears("Fresh Grad")).toBe(0);
+    expect(parseExperienceYears("entry level")).toBe(0);
+    expect(parseExperienceYears("Entry Level")).toBe(0);
+    expect(parseExperienceYears("no experience")).toBe(0);
+  });
+
   it("parses numeric ranges", () => {
     expect(parseExperienceYears("5")).toBe(5);
     expect(parseExperienceYears("3-5")).toBe(5);

--- a/packages/shared/src/resume-filter-helpers.ts
+++ b/packages/shared/src/resume-filter-helpers.ts
@@ -50,7 +50,7 @@ export function parseExperienceYears(value: string | null | undefined): number |
   if (!value) return null;
   const normalized = value.trim();
   if (!normalized) return null;
-  if (/应届|无经验/.test(normalized)) return 0;
+  if (/应届|无经验|fresh grad|entry level|no experience/i.test(normalized)) return 0;
   const match = normalized.match(/(\d+)(?:\s*[-~到]\s*(\d+))?/);
   if (!match) return null;
   const min = Number(match[1]);


### PR DESCRIPTION
## Summary
- Add English keywords to `skills.md` experience signals (senior: head of, vp, chief, senior, principal, overseeing, led team, leadership; mid: experienced, proficient, responsible for, managed, intermediate; junior: entry level, fresh graduate, graduate, no experience, beginner)
- Add English experience level labels to `EXPERIENCE_LEVEL_MAP` (senior level, mid level, junior level, entry level)
- Add English zero-experience patterns to `parseExperienceYears` (fresh grad, entry level, no experience) in both shared and Convex copies
- Add English engineer role signals (programmer, machinist, technician, cnc operator, maintenance)
- Add tests for English zero-experience term parsing

## Problem
Seek (AU/NZ) resumes use English field names and keywords not recognized by the Chinese-biased ingest pipeline, causing `computeExperienceLevel` to return `"unknown"` for all Seek EN resumes.

## Test plan
- [x] `make check` passes
- [x] `resume-filter-helpers.test.ts` — 7/7 pass (including new English zero-experience tests)
- [x] `resume-scoring.test.ts` — 50/50 pass
- [ ] Manual: re-ingest a Seek EN resume and verify experience level is no longer "unknown"