### PR TITLE
chore(deps): upgrade hono, zod-openapi, and zod for security fixes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.3",
-    "@hono/zod-openapi": "^0.18.4",
+    "@hono/zod-openapi": "^1.4.0",
     "@trends/shared": "*",
     "@types/nodemailer": "^7.0.9",
     "better-sqlite3": "^11.0.0",
     "exceljs": "^4.4.0",
     "fflate": "^0.8.2",
-    "hono": "^4.6.16",
+    "hono": "^4.12.21",
     "js-yaml": "^4.1.0",
     "json5": "^2.2.3",
     "mammoth": "^1.12.0",
@@ -27,7 +27,7 @@
     "papaparse": "^5.5.3",
     "pdf-parse": "^2.4.5",
     "yaml": "^2.8.2",
-    "zod": "^3.24.1"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",

--- a/apps/api/src/routes/actions.ts
+++ b/apps/api/src/routes/actions.ts
@@ -26,7 +26,7 @@ const CandidateActionSchema = z.object({
   sessionId: z.string().optional(),
   resumeId: z.string(),
   actionType: ActionTypeSchema,
-  actionData: z.record(z.any()).optional(),
+  actionData: z.record(z.string(), z.any()).optional(),
   createdAt: z.string(),
 });
 
@@ -45,7 +45,7 @@ const CreateActionSchema = z.object({
   sessionId: z.string().optional(),
   resumeId: z.string(),
   actionType: ActionTypeSchema,
-  actionData: z.record(z.any()).optional(),
+  actionData: z.record(z.string(), z.any()).optional(),
 });
 
 const ActionsQuerySchema = z.object({

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -28,7 +28,7 @@ const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const API_ROOT = path.resolve(MODULE_DIR, "../..");
 const REPO_ROOT = path.resolve(API_ROOT, "../..");
 
-const AgentsConfigSchema = z.record(z.unknown());
+const AgentsConfigSchema = z.record(z.string(), z.unknown());
 const KeywordMarketSchema = z.enum(["CN", "MY"]);
 const WorkflowSeedCollectionSourceSchema = z.object({
   type: z.enum(["job5156", "51job", "seek"]),
@@ -78,7 +78,7 @@ const CustomKeywordWorkflowSeedUpdateSchema = CustomKeywordWorkflowSeedSchema;
 const SystemLocationVisibilityUpdateSchema = z.object({
   visible: z.boolean(),
 });
-const RuleWeightsConfigSchema = z.record(z.unknown());
+const RuleWeightsConfigSchema = z.record(z.string(), z.unknown());
 const ResumeFieldUsageSurfaceRulesSchema = z.object({
   analysis: z.boolean().optional(),
   presentation: z.boolean().optional(),
@@ -93,7 +93,7 @@ const ResumeFieldUsagePolicySchema = z.object({
   updatedAt: z.string().optional(),
   description: z.string().optional(),
   sourceFileRelativePath: z.string().optional(),
-  fields: z.record(ResumeFieldUsageFieldSchema).default({}),
+  fields: z.record(z.string(), ResumeFieldUsageFieldSchema).default({}),
 });
 const LearningLogEntrySchema = z.object({
   date: z.string(),

--- a/apps/api/src/routes/filter-presets.ts
+++ b/apps/api/src/routes/filter-presets.ts
@@ -120,7 +120,7 @@ const statsRoute = createRoute({
                         success: z.literal(true),
                         stats: z.object({
                             total: z.number(),
-                            byCategory: z.record(z.number()),
+                            byCategory: z.record(z.string(), z.number()),
                         }),
                     })
                 }

--- a/apps/api/src/routes/industry.ts
+++ b/apps/api/src/routes/industry.ts
@@ -64,7 +64,7 @@ const BrandDisplayEntrySchema = z.object({
     zhHans: z.string(),
 });
 
-const BrandDisplayMapResponseSchema = z.record(BrandDisplayEntrySchema);
+const BrandDisplayMapResponseSchema = z.record(z.string(), BrandDisplayEntrySchema);
 
 const VerifyRequestSchema = z.object({
     type: z.enum(["company", "keyword", "brand"]),

--- a/apps/api/src/routes/job-descriptions.ts
+++ b/apps/api/src/routes/job-descriptions.ts
@@ -52,7 +52,7 @@ const MatchResponseSchema = z.object({
   confidence: z.number(),
   matchedKeywords: z.array(z.string()),
   filterPreset: z.string().optional(),
-  suggestedFilters: z.record(z.unknown()).optional(),
+  suggestedFilters: z.record(z.string(), z.unknown()).optional(),
 });
 
 const ExtractKeywordsResponseSchema = z.object({

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -49,7 +49,7 @@ const templateIdSchema = z
     .max(128)
     .regex(/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/);
 
-const templateDataSchema = z.record(z.unknown());
+const templateDataSchema = z.record(z.string(), z.unknown());
 
 const previewSchema = z.object({
     channel: z.enum(["email", "wechat_work", "feishu"]),

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -186,7 +186,7 @@ const ResumeResetResponseSchema = z.object({
   success: z.literal(true),
   count: z.number().int(),
   partial: z.boolean(),
-  deleted: z.record(z.number().int()),
+  deleted: z.record(z.string(), z.number().int()),
 });
 
 const ResetCandidateActionsRequestSchema = z.object({
@@ -295,9 +295,9 @@ const ResetDatabaseV2ResponseSchema = z.object({
   success: z.literal(true),
   dryRun: z.boolean().optional(),
   count: z.number().int().optional(),
-  wouldDelete: z.record(z.number().int()).optional(),
+  wouldDelete: z.record(z.string(), z.number().int()).optional(),
   partial: z.boolean().optional(),
-  deleted: z.record(z.number().int()).optional(),
+  deleted: z.record(z.string(), z.number().int()).optional(),
 });
 
 type ResumeExportCanonicalRequest = z.infer<typeof ResumeExportCanonicalRequestSchema>;

--- a/apps/api/src/routes/search-analytics.ts
+++ b/apps/api/src/routes/search-analytics.ts
@@ -24,7 +24,7 @@ const SearchSummarySchema = z.object({
       count: z.number().int(),
     })
   ),
-  actionDistribution: z.record(z.number().int()),
+  actionDistribution: z.record(z.string(), z.number().int()),
   dailyTrend: z.array(
     z.object({
       date: z.string(),

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -74,7 +74,7 @@ const AutoMatchResponseSchema = z.object({
     matchedKeywords: z.array(z.string()),
 });
 
-const ProfilePayloadSchema = z.record(z.unknown());
+const ProfilePayloadSchema = z.record(z.string(), z.unknown());
 const ProfileRuntimeItemSchema = z.object({
     workspaceSlug: z.string().min(1),
     profileId: z.string(),

--- a/apps/api/src/routes/web-vitals.ts
+++ b/apps/api/src/routes/web-vitals.ts
@@ -74,6 +74,7 @@ const summaryRoute = createRoute({
             summary: z.object({
               totalReports: z.number().int(),
               metrics: z.record(
+                z.string(),
                 z.object({
                   p50: z.number(),
                   p75: z.number(),

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -231,7 +231,7 @@ export const ResumeSearchCriteriaSchema = z
   .object({
     keyword: z.string().optional().openapi({ example: "销售" }),
     location: z.string().optional().openapi({ example: "东莞" }),
-    filters: z.record(z.string()).optional().openapi({ example: { status: "active" } }),
+    filters: z.record(z.string(), z.string()).optional().openapi({ example: { status: "active" } }),
   })
   .openapi("ResumeSearchCriteria");
 
@@ -323,7 +323,7 @@ export const CandidateActionBackupSchema = z
       "ai_summary_like",
       "ai_summary_unlike",
     ]).openapi({ example: "archive" }),
-    actionData: z.record(z.unknown()).optional().openapi({ example: { scopeId: "session-123" } }),
+    actionData: z.record(z.string(), z.unknown()).optional().openapi({ example: { scopeId: "session-123" } }),
     scopeId: z.string().optional().openapi({ example: "session-123" }),
     createdAt: z.string().openapi({ example: "2026-03-15T10:30:00+08:00" }),
   })
@@ -610,7 +610,7 @@ export const ResumesResponseSchema = z
         expandedTo: z.array(z.string()).optional(),
         mode: z.enum(["AND", "OR"]).optional(),
         keywordGroups: z.array(KeywordGroupSchema).optional(),
-        sourceMapping: z.record(z.string()).optional(),
+        sourceMapping: z.record(z.string(), z.string()).optional(),
       })
       .optional(),
     data: z.array(ResumeItemSchema),
@@ -723,7 +723,7 @@ export const ResumeKeywordExpansionResponseSchema = z
       groups: z.array(KeywordGroupSchema),
       mode: z.enum(["AND", "OR"]),
       expandedTo: z.array(z.string()),
-      sourceMapping: z.record(z.string()),
+      sourceMapping: z.record(z.string(), z.string()),
     }),
   })
   .openapi("ResumeKeywordExpansionResponse");
@@ -846,7 +846,7 @@ export const ResumeExportMatchSchema = z
     recommendation: RecommendationSchema.openapi({ example: "strong_match" }),
     scoreSource: ScoreSourceSchema.optional().openapi({ example: "ai" }),
     summary: z.string().optional().openapi({ example: "Strong CNC sales fit." }),
-    breakdown: z.record(z.number()).optional().openapi({ example: { related_exp: 20, industry_db: 40 } }),
+    breakdown: z.record(z.string(), z.number()).optional().openapi({ example: { related_exp: 20, industry_db: 40 } }),
   })
   .openapi("ResumeExportMatch");
 
@@ -1024,8 +1024,8 @@ export const ReviewPacketRunSchema = z
             reviewedCount: z.number().int(),
             pendingCount: z.number().int(),
             warningCount: z.number().int(),
-            statusBreakdown: z.record(z.number().int()),
-            actionBreakdown: z.record(z.number().int()),
+            statusBreakdown: z.record(z.string(), z.number().int()),
+            actionBreakdown: z.record(z.string(), z.number().int()),
           })
           .optional(),
       })
@@ -1214,7 +1214,7 @@ export const MatchResponseSchema = z
         persisted: z.boolean().optional(),
         keywordGroups: z.array(KeywordGroupSchema).optional(),
         expandedTo: z.array(z.string()).optional(),
-        sourceMapping: z.record(z.string()).optional(),
+        sourceMapping: z.record(z.string(), z.string()).optional(),
         inferredRequiredRoles: z
           .array(
             z.object({

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4964,6 +4964,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
+                    /** @description Filter by category */
                     category?: string;
                 };
                 header?: never;
@@ -7175,6 +7176,17 @@ export interface components {
             /** @example 0.2.1 */
             version?: string;
         };
+        TrendsResponse: {
+            /** @enum {boolean} */
+            success: true;
+            summary?: {
+                description: string;
+                total: number;
+                returned: number;
+                platforms: string | string[];
+            };
+            data: components["schemas"]["TrendItem"][];
+        };
         TrendItem: {
             /** @example OpenAI announces GPT-5 */
             title: string;
@@ -7193,31 +7205,10 @@ export interface components {
             url?: string;
             mobileUrl?: string;
         };
-        TrendsResponse: {
-            /** @enum {boolean} */
-            success: true;
-            summary?: {
-                description: string;
-                total: number;
-                returned: number;
-                platforms: string | string[];
-            };
-            data: components["schemas"]["TrendItem"][];
-        };
         TrendDetailResponse: {
             /** @enum {boolean} */
             success: true;
             data: components["schemas"]["TrendItem"];
-        };
-        Topic: {
-            /** @example AI */
-            keyword: string;
-            /** @example 15 */
-            frequency: number;
-            matched_news?: number;
-            /** @enum {string} */
-            trend?: "rising" | "stable" | "falling";
-            weight_score?: number;
         };
         TopicsResponse: {
             /** @enum {boolean} */
@@ -7229,16 +7220,15 @@ export interface components {
             total_keywords?: number;
             description?: string;
         };
-        SearchResult: {
-            title: string;
-            platform: string;
-            platform_name: string;
-            ranks?: number[];
-            count?: number;
-            avg_rank?: number;
-            url?: string;
-            mobileUrl?: string;
-            date?: string;
+        Topic: {
+            /** @example AI */
+            keyword: string;
+            /** @example 15 */
+            frequency: number;
+            matched_news?: number;
+            /** @enum {string} */
+            trend?: "rising" | "stable" | "falling";
+            weight_score?: number;
         };
         SearchResponse: {
             /** @enum {boolean} */
@@ -7254,16 +7244,16 @@ export interface components {
                 keyword: string;
             };
         };
-        RssItem: {
+        SearchResult: {
             title: string;
-            feed_id: string;
-            feed_name: string;
+            platform: string;
+            platform_name: string;
+            ranks?: number[];
+            count?: number;
+            avg_rank?: number;
             url?: string;
-            published_at?: string;
-            author?: string;
+            mobileUrl?: string;
             date?: string;
-            fetch_time?: string;
-            summary?: string;
         };
         RssResponse: {
             /** @enum {boolean} */
@@ -7277,6 +7267,22 @@ export interface components {
             };
             data: components["schemas"]["RssItem"][];
         };
+        RssItem: {
+            title: string;
+            feed_id: string;
+            feed_name: string;
+            url?: string;
+            published_at?: string;
+            author?: string;
+            date?: string;
+            fetch_time?: string;
+            summary?: string;
+        };
+        ResumeSamplesResponse: {
+            /** @enum {boolean} */
+            success: true;
+            samples: components["schemas"]["ResumeSample"][];
+        };
         ResumeSample: {
             /** @example sample-initial */
             name: string;
@@ -7286,11 +7292,6 @@ export interface components {
             updatedAt: string;
             /** @example 10240 */
             size: number;
-        };
-        ResumeSamplesResponse: {
-            /** @enum {boolean} */
-            success: true;
-            samples: components["schemas"]["ResumeSample"][];
         };
         ResumeKeywordExpansionResponse: {
             /** @enum {boolean} */
@@ -7309,19 +7310,29 @@ export interface components {
                 };
             };
         };
-        ResumeSearchCriteria: {
-            /** @example 销售 */
-            keyword?: string;
-            /** @example 东莞 */
-            location?: string;
-            /**
-             * @example {
-             *       "status": "active"
-             *     }
-             */
-            filters?: {
-                [key: string]: string;
+        ResumesResponse: {
+            /** @enum {boolean} */
+            success: true;
+            sample?: components["schemas"]["ResumeSample"];
+            metadata?: components["schemas"]["ResumeMetadata"];
+            summary?: {
+                total: number;
+                returned: number;
+                query?: string;
+                /** @enum {string} */
+                source?: "sample" | "convex";
+                expandedTo?: string[];
+                /** @enum {string} */
+                mode?: "AND" | "OR";
+                keywordGroups?: {
+                    original: string;
+                    variants: string[];
+                }[];
+                sourceMapping?: {
+                    [key: string]: string;
+                };
             };
+            data: components["schemas"]["ResumeItem"][];
         };
         ResumeMetadata: {
             /** @example https://hr.job5156.com/search?keyword=销售 */
@@ -7337,6 +7348,70 @@ export interface components {
             totalResumes?: number;
             /** @example Navigate to sourceUrl, then add ?tr_auto_export=json */
             reproduction?: string;
+        };
+        ResumeSearchCriteria: {
+            /** @example 销售 */
+            keyword?: string;
+            /** @example 东莞 */
+            location?: string;
+            /**
+             * @example {
+             *       "status": "active"
+             *     }
+             */
+            filters?: {
+                [key: string]: string;
+            };
+        };
+        ResumeItem: {
+            /** @example Alex Chen */
+            name: string;
+            /** @example https://hr.job5156.com/resume/view/123 */
+            profileUrl: string;
+            /** @example hr.job5156.com */
+            source?: string;
+            /** @example Active today */
+            activityStatus: string;
+            /** @example 28 */
+            age: string;
+            /** @example 5 years */
+            experience: string;
+            /** @example Bachelor */
+            education: string;
+            /** @example Shenzhen */
+            location: string;
+            locationHierarchy?: components["schemas"]["ResumeLocationHierarchy"];
+            /** @example 认真敬业，具备团队协作精神 */
+            selfIntro: string;
+            /** @example Sales Manager */
+            jobIntention: string;
+            /** @example 10-15K */
+            expectedSalary: string;
+            workHistory: components["schemas"]["ResumeWorkHistory"][];
+            profileEducation?: components["schemas"]["ResumeImportProfileEducation"][];
+            projectExperience?: components["schemas"]["ResumeImportWorkHistory"][];
+            skills?: (string | components["schemas"]["ResumeImportSkillDetail"])[];
+            languages?: (string | components["schemas"]["ResumeImportLanguageDetail"])[];
+            licences?: (string | components["schemas"]["ResumeImportLicenceDetail"])[];
+            resumeSnippet?: string | components["schemas"]["ResumeImportSnippet"];
+            currentIndustry?: string | components["schemas"]["ResumeImportIndustry"];
+            currentSubindustry?: string | components["schemas"]["ResumeImportIndustry"];
+            rightToWork?: string | boolean | components["schemas"]["ResumeImportRightToWork"];
+            digitalIdentity?: string | components["schemas"]["ResumeImportDigitalIdentity"];
+            noticePeriodDays?: number;
+            ingestData?: components["schemas"]["ResumeIngestData"];
+            /** @example 2026-02-03T10:00:00.000Z */
+            extractedAt: string;
+            /** @example R123456 */
+            resumeId?: string;
+            /** @example U987654 */
+            perUserId?: string;
+            /** @example 503033454 */
+            profileId?: string;
+            /** @example seek */
+            profileType?: string;
+            /** @example seek:profile:503033454 */
+            externalId?: string;
         };
         ResumeLocationHierarchy: {
             /** @example 中国 */
@@ -7444,61 +7519,6 @@ export interface components {
             /** @example https://example.com */
             websiteUrl?: string;
         };
-        ResumeIngestBrandHit: {
-            /** @example fanuc */
-            brand: string;
-            /** @example both */
-            role: string;
-            /** @example workHistory */
-            source: string;
-            /** @example employer */
-            context: string;
-        };
-        ResumeIngestMatchedWorkEntry: {
-            /** @example FANUC */
-            companyName?: string;
-            /** @example Sales Engineer */
-            jobTitle?: string;
-            /** @example 3 */
-            years: number;
-            /** @example true */
-            industryVerified: boolean;
-            /**
-             * @example [
-             *       "sales",
-             *       "cnc"
-             *     ]
-             */
-            matchedSignals: string[];
-            /** @example true */
-            directRoleMatch?: boolean;
-        };
-        ResumeIngestRoleSignal: {
-            /** @example sales */
-            type: string;
-            /**
-             * @example [
-             *       "销售工程师",
-             *       "销售"
-             *     ]
-             */
-            matchedSignals: string[];
-            /** @example 2 */
-            signalCount?: number;
-            /** @example 2 */
-            occurrences?: number;
-            /** @example 5 */
-            years: number;
-            /** @example 5 */
-            industryVerifiedYears?: number;
-            /** @example 5 */
-            roleRelevantYears?: number;
-            /** @example 5 */
-            industryVerifiedRelevantYears?: number;
-            matchedWorkEntries?: components["schemas"]["ResumeIngestMatchedWorkEntry"][];
-            /** @example workHistory */
-            verifyIn: string;
-        };
         ResumeIngestData: {
             /**
              * @example [
@@ -7529,98 +7549,103 @@ export interface components {
             computedAt?: number;
             skillsVersion?: number;
         };
-        ResumeItem: {
-            /** @example Alex Chen */
-            name: string;
-            /** @example https://hr.job5156.com/resume/view/123 */
-            profileUrl: string;
-            /** @example hr.job5156.com */
-            source?: string;
-            /** @example Active today */
-            activityStatus: string;
-            /** @example 28 */
-            age: string;
-            /** @example 5 years */
-            experience: string;
-            /** @example Bachelor */
-            education: string;
-            /** @example Shenzhen */
-            location: string;
-            locationHierarchy?: components["schemas"]["ResumeLocationHierarchy"];
-            /** @example 认真敬业，具备团队协作精神 */
-            selfIntro: string;
-            /** @example Sales Manager */
-            jobIntention: string;
-            /** @example 10-15K */
-            expectedSalary: string;
-            workHistory: components["schemas"]["ResumeWorkHistory"][];
-            profileEducation?: components["schemas"]["ResumeImportProfileEducation"][];
-            projectExperience?: components["schemas"]["ResumeImportWorkHistory"][];
-            skills?: (string | components["schemas"]["ResumeImportSkillDetail"])[];
-            languages?: (string | components["schemas"]["ResumeImportLanguageDetail"])[];
-            licences?: (string | components["schemas"]["ResumeImportLicenceDetail"])[];
-            resumeSnippet?: string | components["schemas"]["ResumeImportSnippet"];
-            currentIndustry?: string | components["schemas"]["ResumeImportIndustry"];
-            currentSubindustry?: string | components["schemas"]["ResumeImportIndustry"];
-            rightToWork?: string | boolean | components["schemas"]["ResumeImportRightToWork"];
-            digitalIdentity?: string | components["schemas"]["ResumeImportDigitalIdentity"];
-            noticePeriodDays?: number;
-            ingestData?: components["schemas"]["ResumeIngestData"];
-            /** @example 2026-02-03T10:00:00.000Z */
-            extractedAt: string;
-            /** @example R123456 */
-            resumeId?: string;
-            /** @example U987654 */
-            perUserId?: string;
-            /** @example 503033454 */
-            profileId?: string;
-            /** @example seek */
-            profileType?: string;
-            /** @example seek:profile:503033454 */
-            externalId?: string;
+        ResumeIngestBrandHit: {
+            /** @example fanuc */
+            brand: string;
+            /** @example both */
+            role: string;
+            /** @example workHistory */
+            source: string;
+            /** @example employer */
+            context: string;
         };
-        ResumesResponse: {
+        ResumeIngestRoleSignal: {
+            /** @example sales */
+            type: string;
+            /**
+             * @example [
+             *       "销售工程师",
+             *       "销售"
+             *     ]
+             */
+            matchedSignals: string[];
+            /** @example 2 */
+            signalCount?: number;
+            /** @example 2 */
+            occurrences?: number;
+            /** @example 5 */
+            years: number;
+            /** @example 5 */
+            industryVerifiedYears?: number;
+            /** @example 5 */
+            roleRelevantYears?: number;
+            /** @example 5 */
+            industryVerifiedRelevantYears?: number;
+            matchedWorkEntries?: components["schemas"]["ResumeIngestMatchedWorkEntry"][];
+            /** @example workHistory */
+            verifyIn: string;
+        };
+        ResumeIngestMatchedWorkEntry: {
+            /** @example FANUC */
+            companyName?: string;
+            /** @example Sales Engineer */
+            jobTitle?: string;
+            /** @example 3 */
+            years: number;
+            /** @example true */
+            industryVerified: boolean;
+            /**
+             * @example [
+             *       "sales",
+             *       "cnc"
+             *     ]
+             */
+            matchedSignals: string[];
+            /** @example true */
+            directRoleMatch?: boolean;
+        };
+        MatchResponse: {
             /** @enum {boolean} */
             success: true;
-            sample?: components["schemas"]["ResumeSample"];
-            metadata?: components["schemas"]["ResumeMetadata"];
-            summary?: {
-                total: number;
-                returned: number;
-                query?: string;
-                /** @enum {string} */
-                source?: "sample" | "convex";
-                expandedTo?: string[];
-                /** @enum {string} */
-                mode?: "AND" | "OR";
+            /** @enum {string} */
+            mode?: "rules_only" | "hybrid" | "ai_only";
+            streamPath?: string;
+            pendingAiCount?: number;
+            query?: {
+                source?: components["schemas"]["ResumeResultSource"];
+                persisted?: boolean;
                 keywordGroups?: {
                     original: string;
                     variants: string[];
                 }[];
+                expandedTo?: string[];
                 sourceMapping?: {
                     [key: string]: string;
                 };
+                inferredRequiredRoles?: {
+                    /** @example sales */
+                    type: string;
+                    /**
+                     * @example [
+                     *       "销售",
+                     *       "业务"
+                     *     ]
+                     */
+                    signals: string[];
+                    /**
+                     * @example workHistory
+                     * @enum {string}
+                     */
+                    verifyIn: "workHistory" | "searchText";
+                    /** @example 2 */
+                    minYears?: number;
+                }[];
             };
-            data: components["schemas"]["ResumeItem"][];
+            results: components["schemas"]["ResumeMatch"][];
+            stats: components["schemas"]["MatchStats"];
         };
         /** @enum {string} */
         ResumeResultSource: "sample" | "convex";
-        MatchBreakdown: {
-            /** @example 20 */
-            skillMatch: number;
-            /** @example 8 */
-            roleMatch?: number;
-            /** @example 18 */
-            experienceMatch: number;
-            /** @example 12 */
-            educationMatch: number;
-            /** @example 15 */
-            locationMatch: number;
-            /** @example 10 */
-            industryMatch: number;
-            /** @example 7 */
-            brandRelevance: number;
-        };
         ResumeMatch: {
             /** @example R123456 */
             resumeId: string;
@@ -7728,52 +7753,28 @@ export interface components {
                 }[];
             };
         };
+        MatchBreakdown: {
+            /** @example 20 */
+            skillMatch: number;
+            /** @example 8 */
+            roleMatch?: number;
+            /** @example 18 */
+            experienceMatch: number;
+            /** @example 12 */
+            educationMatch: number;
+            /** @example 15 */
+            locationMatch: number;
+            /** @example 10 */
+            industryMatch: number;
+            /** @example 7 */
+            brandRelevance: number;
+        };
         MatchStats: {
             processed: number;
             matched: number;
             avgScore: number;
             processingTimeMs?: number;
             pendingAi?: number;
-        };
-        MatchResponse: {
-            /** @enum {boolean} */
-            success: true;
-            /** @enum {string} */
-            mode?: "rules_only" | "hybrid" | "ai_only";
-            streamPath?: string;
-            pendingAiCount?: number;
-            query?: {
-                source?: components["schemas"]["ResumeResultSource"];
-                persisted?: boolean;
-                keywordGroups?: {
-                    original: string;
-                    variants: string[];
-                }[];
-                expandedTo?: string[];
-                sourceMapping?: {
-                    [key: string]: string;
-                };
-                inferredRequiredRoles?: {
-                    /** @example sales */
-                    type: string;
-                    /**
-                     * @example [
-                     *       "销售",
-                     *       "业务"
-                     *     ]
-                     */
-                    signals: string[];
-                    /**
-                     * @example workHistory
-                     * @enum {string}
-                     */
-                    verifyIn: "workHistory" | "searchText";
-                    /** @example 2 */
-                    minYears?: number;
-                }[];
-            };
-            results: components["schemas"]["ResumeMatch"][];
-            stats: components["schemas"]["MatchStats"];
         };
         MatchRequest: {
             /** @example session-123 */
@@ -7818,6 +7819,11 @@ export interface components {
             success: true;
             results: components["schemas"]["ResumeMatch"][];
         };
+        MatchRunsResponse: {
+            /** @enum {boolean} */
+            success: true;
+            runs: components["schemas"]["MatchRun"][];
+        };
         MatchRun: {
             /** @example run-123 */
             id: string;
@@ -7854,11 +7860,6 @@ export interface components {
             /** @example AI provider timeout */
             error?: string;
         };
-        MatchRunsResponse: {
-            /** @enum {boolean} */
-            success: true;
-            runs: components["schemas"]["MatchRun"][];
-        };
         ResumeSubmitSummary: {
             /** @enum {boolean} */
             success: true;
@@ -7868,14 +7869,13 @@ export interface components {
             unchanged: number;
             deduped: number;
         };
-        ResumeImportCollectionContext: {
-            captureMode?: string;
-            operation?: string;
-            jobId?: string | number;
-            searchId?: string;
-            pageNumber?: number | null;
-            language?: string;
-            profileType?: string;
+        ResumeImportRequest: {
+            metadata: components["schemas"]["ResumeImportMetadata"];
+            resumes?: components["schemas"]["ResumeImportItem"][];
+            data?: components["schemas"]["ResumeImportItem"][];
+            options?: components["schemas"]["ResumeImportOptions"];
+            candidateActions?: components["schemas"]["CandidateActionBackup"][];
+            candidateStatus?: components["schemas"]["CandidateStatusBackup"][];
         };
         ResumeImportMetadata: {
             /**
@@ -7908,20 +7908,14 @@ export interface components {
             /** @example Navigate to sourceUrl, then add ?tr_auto_export=json */
             reproduction?: string;
         };
-        ResumeImportRestoreState: {
-            /** @example 1763917200000 */
-            crawledAt?: number;
-            /** @example true */
-            isArchived?: boolean;
-            /** @example 1763917200000 */
-            archivedAt?: number;
-            /** @example alice cnc sales dongguan */
-            searchText?: string;
-            /** @example 85 */
-            primaryRuleScore?: number;
-            ingestData?: unknown;
-            analysis?: unknown;
-            analyses?: unknown;
+        ResumeImportCollectionContext: {
+            captureMode?: string;
+            operation?: string;
+            jobId?: string | number;
+            searchId?: string;
+            pageNumber?: number | null;
+            language?: string;
+            profileType?: string;
         };
         ResumeImportItem: {
             resumeId?: string | number;
@@ -7977,6 +7971,21 @@ export interface components {
             extractedAt?: string;
             restoreState?: components["schemas"]["ResumeImportRestoreState"];
         };
+        ResumeImportRestoreState: {
+            /** @example 1763917200000 */
+            crawledAt?: number;
+            /** @example true */
+            isArchived?: boolean;
+            /** @example 1763917200000 */
+            archivedAt?: number;
+            /** @example alice cnc sales dongguan */
+            searchText?: string;
+            /** @example 85 */
+            primaryRuleScore?: number;
+            ingestData?: unknown;
+            analysis?: unknown;
+            analyses?: unknown;
+        };
         ResumeImportOptions: {
             /** @example true */
             recomputeDerivedFields?: boolean;
@@ -8022,13 +8031,14 @@ export interface components {
                 notes?: string;
             }[];
         };
-        ResumeImportRequest: {
-            metadata: components["schemas"]["ResumeImportMetadata"];
-            resumes?: components["schemas"]["ResumeImportItem"][];
-            data?: components["schemas"]["ResumeImportItem"][];
-            options?: components["schemas"]["ResumeImportOptions"];
-            candidateActions?: components["schemas"]["CandidateActionBackup"][];
-            candidateStatus?: components["schemas"]["CandidateStatusBackup"][];
+        ResumeManualImportResponse: {
+            /** @enum {boolean} */
+            success: true;
+            source: components["schemas"]["ResumeManualImportSource"];
+            summary: components["schemas"]["ResumeManualImportSummary"];
+            files: components["schemas"]["ResumeManualImportFileResult"][];
+            /** @default [] */
+            warnings: string[];
         };
         ResumeManualImportSource: {
             /** @example 51job-manual */
@@ -8069,15 +8079,6 @@ export interface components {
             /** @example Legacy .doc parsing is not supported yet */
             error?: string;
         };
-        ResumeManualImportResponse: {
-            /** @enum {boolean} */
-            success: true;
-            source: components["schemas"]["ResumeManualImportSource"];
-            summary: components["schemas"]["ResumeManualImportSummary"];
-            files: components["schemas"]["ResumeManualImportFileResult"][];
-            /** @default [] */
-            warnings: string[];
-        };
         ResumeManualImportError: {
             /** @enum {boolean} */
             success: false;
@@ -8099,6 +8100,25 @@ export interface components {
             sourceHosts?: string[];
             limit?: number;
         };
+        ResumeExportCanonicalRequest: {
+            /**
+             * @default csv
+             * @example csv
+             * @enum {string}
+             */
+            format: "csv" | "xlsx";
+            source: components["schemas"]["ResumeExportSource"];
+            /** @example sample-initial */
+            sample?: string;
+            /** @example Batch note */
+            userComment?: string;
+            /** @example Internal export */
+            referenceNote?: string;
+            industryDbV2Stats?: components["schemas"]["IndustryDbV2Stats"];
+            /** @example false */
+            debug?: boolean;
+            entries: components["schemas"]["ResumeExportEntryContext"][];
+        };
         /** @enum {string} */
         ResumeExportSource: "sample" | "convex";
         IndustryDbV2Stats: {
@@ -8117,6 +8137,21 @@ export interface components {
             /** @example 6.8 */
             stddev?: number;
             histogram50: number[];
+        };
+        ResumeExportEntryContext: {
+            /** @example resume-1 */
+            resumeId: string;
+            /** @example 72 */
+            ruleScore?: number;
+            /** @example shortlist */
+            action?: string;
+            match?: components["schemas"]["ResumeExportMatch"];
+            /** @example Call back tomorrow */
+            userComment?: string;
+            /** @example Referred by HR */
+            referenceNote?: string;
+            /** @example contacted */
+            status?: string;
         };
         ResumeExportMatch: {
             /** @example 88 */
@@ -8143,42 +8178,13 @@ export interface components {
                 [key: string]: number;
             };
         };
-        ResumeExportEntryContext: {
-            /** @example resume-1 */
-            resumeId: string;
-            /** @example 72 */
-            ruleScore?: number;
-            /** @example shortlist */
-            action?: string;
-            match?: components["schemas"]["ResumeExportMatch"];
-            /** @example Call back tomorrow */
-            userComment?: string;
-            /** @example Referred by HR */
-            referenceNote?: string;
-            /** @example contacted */
-            status?: string;
+        ReviewPacketTrackedExportResponse: {
+            /** @enum {boolean} */
+            success: true;
+            run: components["schemas"]["ReviewPacketRun"];
+            /** @example /api/resumes/review-packets/review-packet-123/download */
+            downloadPath: string;
         };
-        ResumeExportCanonicalRequest: {
-            /**
-             * @default csv
-             * @example csv
-             * @enum {string}
-             */
-            format: "csv" | "xlsx";
-            source: components["schemas"]["ResumeExportSource"];
-            /** @example sample-initial */
-            sample?: string;
-            /** @example Batch note */
-            userComment?: string;
-            /** @example Internal export */
-            referenceNote?: string;
-            industryDbV2Stats?: components["schemas"]["IndustryDbV2Stats"];
-            /** @example false */
-            debug?: boolean;
-            entries: components["schemas"]["ResumeExportEntryContext"][];
-        };
-        /** @enum {string} */
-        ReviewPacketRunStatus: "exported" | "feedback_imported" | "summary_sent" | "failed";
         ReviewPacketRun: {
             /** @example review-packet-123 */
             id: string;
@@ -8244,13 +8250,8 @@ export interface components {
             };
             error?: string;
         };
-        ReviewPacketTrackedExportResponse: {
-            /** @enum {boolean} */
-            success: true;
-            run: components["schemas"]["ReviewPacketRun"];
-            /** @example /api/resumes/review-packets/review-packet-123/download */
-            downloadPath: string;
-        };
+        /** @enum {string} */
+        ReviewPacketRunStatus: "exported" | "feedback_imported" | "summary_sent" | "failed";
         ReviewPacketExportRequest: {
             /**
              * @default csv
@@ -8306,10 +8307,15 @@ export interface components {
             /** @example hr.lead */
             updatedBy?: string;
         };
-        ReviewPacketSummaryCount: {
-            key: string;
-            label: string;
-            count: number;
+        ReviewPacketSummaryPreviewResponse: {
+            /** @enum {boolean} */
+            success: true;
+            run: components["schemas"]["ReviewPacketRun"];
+            /** @enum {string} */
+            channel: "wechat_work";
+            templateId: string;
+            content: string;
+            data: components["schemas"]["ReviewPacketSummaryData"];
         };
         ReviewPacketSummaryData: {
             packetId: string;
@@ -8329,15 +8335,10 @@ export interface components {
             actionBreakdown: components["schemas"]["ReviewPacketSummaryCount"][];
             warnings: string[];
         };
-        ReviewPacketSummaryPreviewResponse: {
-            /** @enum {boolean} */
-            success: true;
-            run: components["schemas"]["ReviewPacketRun"];
-            /** @enum {string} */
-            channel: "wechat_work";
-            templateId: string;
-            content: string;
-            data: components["schemas"]["ReviewPacketSummaryData"];
+        ReviewPacketSummaryCount: {
+            key: string;
+            label: string;
+            count: number;
         };
         ReviewPacketSummaryPreviewRequest: {
             /** @example review-packet-wechat */
@@ -8353,6 +8354,8 @@ export interface components {
             delivery: {
                 errcode?: number;
                 errmsg?: string;
+            } & {
+                [key: string]: unknown;
             };
         };
         ReviewPacketSummarySendRequest: {
@@ -8364,17 +8367,6 @@ export interface components {
              */
             webhookUrl?: string;
         };
-        ResumeDiagnosticsItem: {
-            resumeId: string;
-            externalId: string;
-            source: string;
-            sourceKey: string;
-            name: string;
-            jobIntention: string;
-            location: string;
-            isArchived?: boolean;
-            archivedAt?: number;
-        };
         ResumeDiagnosticsResponse: {
             /** @enum {boolean} */
             success: true;
@@ -8385,6 +8377,17 @@ export interface components {
                 limit: number;
             };
             data: components["schemas"]["ResumeDiagnosticsItem"][];
+        };
+        ResumeDiagnosticsItem: {
+            resumeId: string;
+            externalId: string;
+            source: string;
+            sourceKey: string;
+            name: string;
+            jobIntention: string;
+            location: string;
+            isArchived?: boolean;
+            archivedAt?: number;
         };
         ResumeDetailResponse: {
             /** @enum {boolean} */


### PR DESCRIPTION
## Summary
- Bump hono ^4.6.16 → ^4.12.21 (8 high-severity CVEs in v4.6.16)
- Bump @hono/zod-openapi ^0.18.4 → ^1.4.0 (requires hono >=4.10.0, zod ^4.0.0)
- Bump zod ^3.24.1 → ^4.0.0
- Fix 20 `z.record()` single-arg calls to two-arg form (zod v4 requires explicit key + value schemas)
- Regenerate `api-types.ts` from updated OpenAPI spec

## Test plan
- [x] `make check-node` passes (typecheck clean)
- [x] `make check` passes (governance + policy sync)
- [ ] Verify no runtime regressions in API endpoints