### PR TITLE
fix: graceful degradation for Seek EN resume experience filtering

### DIFF
--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -872,12 +872,25 @@ export function useResumeListState(loadSearchHistory = false) {
 
     const minExperience = filters.minExperience
     if (typeof minExperience === 'number' && minExperience > 0) {
-      result = result.filter((resume: ScoredConvexResume) => parseExperienceYears(resume.experience) >= minExperience)
+      result = result.filter((resume: ScoredConvexResume) => {
+        const expYears = parseExperienceYears(resume.experience)
+        // Unknown experience (0 from empty/unparseable) — skip filter instead
+        // of excluding. Seek resumes have empty experience fields; excluding
+        // them when minExperience is set drops all results. Matches BFF and
+        // Convex graceful degradation.
+        if (expYears === 0 && !resume.experience) return true
+        return expYears >= minExperience
+      })
     }
 
     const maxExperience = filters.maxExperience
     if (typeof maxExperience === 'number') {
-      result = result.filter((resume: ScoredConvexResume) => parseExperienceYears(resume.experience) <= maxExperience)
+      result = result.filter((resume: ScoredConvexResume) => {
+        const expYears = parseExperienceYears(resume.experience)
+        // Unknown experience — cannot guarantee cap, exclude
+        if (expYears === 0 && !resume.experience) return false
+        return expYears <= maxExperience
+      })
     }
 
     const minRoleYears = filters.minRoleYears

--- a/apps/web/src/lib/resume-filtering.test.ts
+++ b/apps/web/src/lib/resume-filtering.test.ts
@@ -37,6 +37,18 @@ describe('parseExperienceYears', () => {
   it('handles whitespace padding', () => {
     expect(parseExperienceYears('  10  ')).toBe(10)
   })
+
+  it('returns 0 for English zero-experience terms (Seek EN)', () => {
+    expect(parseExperienceYears('fresh graduate')).toBe(0)
+    expect(parseExperienceYears('entry level')).toBe(0)
+    expect(parseExperienceYears('no experience')).toBe(0)
+    expect(parseExperienceYears('beginner')).toBe(0)
+  })
+
+  it('returns 0 for Chinese zero-experience terms', () => {
+    expect(parseExperienceYears('应届')).toBe(0)
+    expect(parseExperienceYears('无经验')).toBe(0)
+  })
 })
 
 describe('getResumeAge', () => {

--- a/apps/web/src/lib/resume-filtering.ts
+++ b/apps/web/src/lib/resume-filtering.ts
@@ -8,6 +8,11 @@ export function parseExperienceYears(value: string | undefined): number {
     return 0
   }
 
+  // Recognize zero-experience patterns (Chinese + English)
+  if (/应届|无经验|fresh grad|entry level|no experience|fresh graduate|beginner/i.test(value)) {
+    return 0
+  }
+
   const matched = value.match(/\d+(?:\.\d+)?/)
   if (!matched) {
     return 0

--- a/packages/convex/convex/__tests__/schema-validator-sync.test.ts
+++ b/packages/convex/convex/__tests__/schema-validator-sync.test.ts
@@ -211,7 +211,7 @@ function convexParseExperienceYears(value: string): number | null {
     if (!normalized) {
         return null;
     }
-    if (/应届|无经验/.test(normalized)) {
+    if (/应届|无经验|fresh grad|entry level|no experience|fresh graduate|beginner/i.test(normalized)) {
         return 0;
     }
     const match = normalized.match(/(\d+)(?:\s*[-~到]\s*(\d+))?/);
@@ -269,6 +269,11 @@ describe("parseExperienceYears sync: @trends/shared vs Convex local copy", () =>
         // Chinese
         ["应届", 0],
         ["无经验", 0],
+        // English (Seek EN)
+        ["fresh graduate", 0],
+        ["entry level", 0],
+        ["no experience", 0],
+        ["beginner", 0],
         // Ranges
         ["3-5", 5],
         ["2~3", 3],

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -844,7 +844,7 @@ function parseExperienceYears(value: string): number | null {
     if (!normalized) {
         return null;
     }
-    if (/应届|无经验|fresh grad|entry level|no experience/i.test(normalized)) {
+    if (/应届|无经验|fresh grad|entry level|no experience|fresh graduate|beginner/i.test(normalized)) {
         return 0;
     }
     const match = normalized.match(/(\d+)(?:\s*[-~到]\s*(\d+))?/);

--- a/packages/shared/src/__tests__/resume-filter-helpers.test.ts
+++ b/packages/shared/src/__tests__/resume-filter-helpers.test.ts
@@ -52,6 +52,8 @@ describe("parseExperienceYears", () => {
     expect(parseExperienceYears("entry level")).toBe(0);
     expect(parseExperienceYears("Entry Level")).toBe(0);
     expect(parseExperienceYears("no experience")).toBe(0);
+    expect(parseExperienceYears("beginner")).toBe(0);
+    expect(parseExperienceYears("Beginner")).toBe(0);
   });
 
   it("parses numeric ranges", () => {

--- a/packages/shared/src/resume-filter-helpers.ts
+++ b/packages/shared/src/resume-filter-helpers.ts
@@ -50,7 +50,7 @@ export function parseExperienceYears(value: string | null | undefined): number |
   if (!value) return null;
   const normalized = value.trim();
   if (!normalized) return null;
-  if (/应届|无经验|fresh grad|entry level|no experience/i.test(normalized)) return 0;
+  if (/应届|无经验|fresh grad|entry level|no experience|fresh graduate|beginner/i.test(normalized)) return 0;
   const match = normalized.match(/(\d+)(?:\s*[-~到]\s*(\d+))?/);
   if (!match) return null;
   const min = Number(match[1]);


### PR DESCRIPTION
## Summary
- Fix web frontend minExperience/maxExperience filters dropping all Seek resumes with empty experience fields — aligns with BFF and Convex graceful degradation
- Add English zero-experience patterns (fresh graduate, beginner) to `parseExperienceYears` across all 3 copies (shared, Convex, web)

## Test plan
- [x] `make check` passes
- [x] `resume-filter-helpers.test.ts` — new English patterns verified
- [x] `schema-validator-sync.test.ts` — shared/Convex sync verified  
- [x] `resume-filtering.test.ts` — web patterns verified
- [x] `ingest-compute-service.test.ts` — no regressions

## Root cause
Seek API doesn't provide an experience summary field, so `resume.experience` is empty string. The web filter at `useResumeListState.ts:875` was doing `parseExperienceYears("") >= minExperience` → `0 >= 1` → `false`, dropping all Seek resumes when any minExperience filter was active. BFF and Convex already handled this gracefully by skipping the filter for null/unknown experience.