### PR TITLE
chore(deps): upgrade better-sqlite3 from 11.10.0 to 12.10.0

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,7 @@
     "@hono/zod-openapi": "^1.4.0",
     "@trends/shared": "*",
     "@types/nodemailer": "^7.0.9",
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": "^12.0.0",
     "exceljs": "^4.4.0",
     "fflate": "^0.8.2",
     "hono": "^4.12.21",


### PR DESCRIPTION
## Summary
- Bump `better-sqlite3` from `^11.0.0` to `^12.0.0` (resolved 11.10.0 → 12.10.0)
- Major version bump with **no API breaking changes** — only Node.js runtime floor raised to v20+ (already satisfied by Node v24)
- Includes SQLite engine update (3.51.x → 3.53.x); existing DB files are forward-compatible

## Test plan
- [x] `make check` passes
- [x] `database.test.ts` passes (2/2)
- [ ] CI Checks + Tests pass