### PR TITLE
deps: upgrade vite ^5.4.10 to ^6.4.2 to close Dependabot alert

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -63,7 +63,7 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.54.0",
-    "vite": "^5.4.10",
+    "vite": "^6.4.2",
     "vitest": "^4.0.18"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `vite` constraint from `^5.4.10` to `^6.4.2` in `apps/web/package.json`
- Closes the last remaining Dependabot alert (medium: Vite <=6.4.1)

## Compatibility
- `@vitejs/plugin-react@4.7.0` supports Vite 6.x (peer: `^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0`)
- `vitest@4.x` works with Vite 6.x
- Build verified: `vite build` succeeds in 3.15s

## Test plan
- [x] `make check` passes (0 errors, 5 pre-existing warnings)
- [x] `vite build` succeeds with Vite 6.4.2
- [ ] Confirm Dependabot alert is resolved after merge