### PR TITLE
fix: detect Seek UUID profile URLs and show appropriate UX

### DIFF
--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -149,6 +149,7 @@ export const SnippetCard = memo(function SnippetCard({
   // Profile link
   const profileUrl = item.resume.profileUrl?.trim()
   const hasProfileUrl = isSafeProfileUrl(profileUrl)
+  const isSeekUuidUrl = typeof profileUrl === 'string' && /\.employer\.seek\.com\/candidates\/[0-9a-f]{8}-/i.test(profileUrl)
 
   // Dialog state for status note prompt and block/comment
   const [promptDialogOpen, setPromptDialogOpen] = useState(false)
@@ -304,6 +305,7 @@ export const SnippetCard = memo(function SnippetCard({
                 href={profileUrl}
                 target="_blank"
                 rel="noreferrer"
+                title={isSeekUuidUrl ? 'Requires active Seek session' : undefined}
               >
                 {highlightTerms(item.resume.name || unnamedResumeLabel, searchTerms)}
               </a>

--- a/apps/web/src/components/search/SnippetCardExpanded.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.tsx
@@ -222,8 +222,10 @@ export function SnippetCardExpanded({
   )
   const profileUrl = item.resume.profileUrl?.trim()
   const hasProfileUrl = isSafeProfileUrl(profileUrl)
+  const isSeekUuidUrl = typeof profileUrl === 'string' && /\.employer\.seek\.com\/candidates\/[0-9a-f]{8}-/i.test(profileUrl)
   const isNameSearchUrl = typeof profileUrl === 'string' && profileUrl.includes('/talentsearch/profiles/search')
-  const profileLinkLabel = isNameSearchUrl
+  const isSeekUrl = isNameSearchUrl || isSeekUuidUrl
+  const profileLinkLabel = isSeekUrl
     ? t('resumes.searchPage.card.searchOnSeek', { defaultValue: '在 Seek 搜尋' })
     : openSourceProfileLabel
   const { resolve: resolveBrand } = useBrandDisplayMap()
@@ -596,6 +598,7 @@ export function SnippetCardExpanded({
                   href={profileUrl}
                   target="_blank"
                   rel="noreferrer"
+                  title={isSeekUuidUrl ? t('resumes.searchPage.card.seekSessionRequired', { defaultValue: 'Requires active Seek session' }) : undefined}
                   className={cn(buttonVariants({ variant: 'outline' }), 'w-full justify-center rounded-xl')}
                 >
                   {profileLinkLabel}


### PR DESCRIPTION
## Summary
- Detect UUID-based Seek profile URLs (`/candidates/{uuid}`) that 404 when opened
- Label both UUID and name-search Seek URLs as "Search on Seek" instead of "Open source profile"
- Add tooltip on UUID URLs: "Requires active Seek session"
- The shared `normalizeProfileUrlForDisplay` already upgrades UUIDs to name-search URLs when a name is available; this handles the remaining edge case

## Problem
400+ Seek talentsearch resumes store UUID-based `profileUrl` values that return 404. The normalization in `useConvexResumes.ts` upgrades most of these to working name-search URLs, but resumes without names still get the broken UUID URL.

## Test plan
- [x] `make check` passes (0 errors)
- [x] `vite build` succeeds
- [ ] Manual: View Seek resumes in search results — name-search URLs show "Search on Seek" label
- [ ] Manual: UUID URLs show tooltip "Requires active Seek session"