### PR TITLE
fix: add missing i18n key seekSessionRequired to locale files

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -466,6 +466,7 @@
         "signals": "Signals",
         "openSourceProfile": "Open source profile",
         "searchOnSeek": "Search on Seek",
+        "seekSessionRequired": "Requires active Seek session",
         "summaryUnavailable": "AI summary is not available for this resume. The current visible score comes from rule scoring only.",
         "aiSummaryUnavailable": "AI analysis is not available for this resume yet. The score will appear after analysis completes.",
         "profileOverview": "Profile overview",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -465,6 +465,7 @@
         "signals": "信号",
         "openSourceProfile": "打开原始简历",
         "searchOnSeek": "在 Seek 搜索",
+        "seekSessionRequired": "需要登录 Seek 雇主账户",
         "summaryUnavailable": "该简历暂无 AI 摘要。当前可见分数来自规则评分。",
         "aiSummaryUnavailable": "该简历尚未生成 AI 分析，分析完成后会显示分数。",
         "profileOverview": "概览",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -465,6 +465,7 @@
         "signals": "信號",
         "openSourceProfile": "開啟原始簡歷",
         "searchOnSeek": "在 Seek 搜尋",
+        "seekSessionRequired": "需要登入 Seek 僱主帳戶",
         "summaryUnavailable": "此簡歷暫無 AI 摘要。目前顯示的分數來自規則評分。",
         "aiSummaryUnavailable": "此簡歷尚未生成 AI 分析，分析完成後會顯示分數。",
         "profileOverview": "概覽",


### PR DESCRIPTION
## Summary
- Add `seekSessionRequired` key to en.json, zh-Hant.json, zh-Hans.json
- Key was introduced by PR #829 but missed from locale files, breaking `make i18n-check` in CI

## Test plan
- [x] `make check` passes (0 errors)
- [ ] CI i18n-check job passes