### PR TITLE
fix: add node_modules to vitest exclude

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
     test: {
         environment: "node",
         include: ["apps/**/*.test.ts", "packages/**/*.test.ts", "scripts/**/*.test.ts"],
-        exclude: ["apps/web/**/*.test.ts", "apps/web/**/*.test.tsx", "scripts/test-notifications.test.ts"],
+        exclude: ["apps/web/**/*.test.ts", "apps/web/**/*.test.tsx", "scripts/test-notifications.test.ts", "**/node_modules/**"],
         coverage: {
             provider: "v8",
             reporter: ["text", "html", "clover", "json", "lcov"],


### PR DESCRIPTION
## Summary
- Add `"**/node_modules/**"` to the `exclude` array in `vitest.config.ts` to prevent zod v4's own test files from being picked up as false-positive test failures

## Test plan
- [x] `npm test` — 124 test files, 1463 passing, 0 failures
- [x] `make check` — all checks pass