### PR TITLE
feat: compute experience from workHistory dates when experience field is empty

### DIFF
--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -856,6 +856,65 @@ function parseExperienceYears(value: string): number | null {
     return Number.isNaN(max) ? null : max;
 }
 
+/**
+ * Compute total experience years from workHistory date ranges.
+ * Sums non-overlapping date ranges (merges overlapping periods).
+ * Returns null if no parseable date ranges found.
+ */
+function computeExperienceFromWorkHistory(workHistory: unknown): number | null {
+    if (!Array.isArray(workHistory) || workHistory.length === 0) {
+        return null;
+    }
+    const ranges: Array<{ start: number; end: number }> = [];
+    const now = Date.now();
+    for (const entry of workHistory) {
+        if (typeof entry !== "object" || entry === null) continue;
+        const rec = entry as Record<string, unknown>;
+        const startMs = parseDateToMs(rec.startDate);
+        const endMs = rec.endDate ? parseDateToMs(rec.endDate) : now;
+        if (startMs !== null && endMs !== null && endMs > startMs) {
+            ranges.push({ start: startMs, end: endMs });
+        }
+    }
+    if (ranges.length === 0) {
+        return null;
+    }
+    // Merge overlapping ranges
+    ranges.sort((a, b) => a.start - b.start);
+    const merged: Array<{ start: number; end: number }> = [ranges[0]];
+    for (let i = 1; i < ranges.length; i++) {
+        const last = merged[merged.length - 1];
+        if (ranges[i].start <= last.end) {
+            last.end = Math.max(last.end, ranges[i].end);
+        } else {
+            merged.push(ranges[i]);
+        }
+    }
+    const totalMs = merged.reduce((sum, r) => sum + (r.end - r.start), 0);
+    return Math.round(totalMs / (365.25 * 24 * 60 * 60 * 1000) * 10) / 10;
+}
+
+/** Parse date strings like "2023-06", "2023", "2023-06-15" to epoch ms. */
+function parseDateToMs(value: unknown): number | null {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    // Try YYYY-MM-DD or YYYY-MM or YYYY
+    const match = trimmed.match(/^(\d{4})(?:-(\d{1,2}))?(?:-(\d{1,2}))?$/);
+    if (!match) return null;
+    const year = Number(match[1]);
+    const month = match[2] ? Number(match[2]) - 1 : 0;
+    const day = match[3] ? Number(match[3]) : 1;
+    const ms = Date.UTC(year, month, day);
+    return Number.isNaN(ms) ? null : ms;
+}
+
+function resolveExperienceYears(content: Record<string, unknown>): number | null {
+    const parsed = parseExperienceYears(toStringValue(content.experience));
+    if (parsed !== null) return parsed;
+    return computeExperienceFromWorkHistory(content.workHistory);
+}
+
 function normalizeEducationLevel(value: string): string | null {
     if (!value) {
         return null;
@@ -980,7 +1039,7 @@ function matchesResumeListFilters(resume: Doc<"resumes">, filters: ResumeListFil
 
     const effectiveMinExperience = (filters.minExperience ?? 0) > 0 ? filters.minExperience : undefined;
     if (effectiveMinExperience !== undefined || filters.maxExperience !== undefined) {
-        const experience = parseExperienceYears(toStringValue(content.experience));
+        const experience = resolveExperienceYears(content);
         if (experience === null) {
             // Unknown experience — skip filter instead of excluding.
             // Seek talentsearch resumes have empty experience fields;
@@ -1112,8 +1171,8 @@ function compareResumeListSort(
     const rightContent = isRecord(right.content) ? right.content : {};
 
     if (sortBy === "experience") {
-        const leftExperience = parseExperienceYears(toStringValue(leftContent.experience)) ?? -1;
-        const rightExperience = parseExperienceYears(toStringValue(rightContent.experience)) ?? -1;
+        const leftExperience = resolveExperienceYears(leftContent) ?? -1;
+        const rightExperience = resolveExperienceYears(rightContent) ?? -1;
         const diff = (leftExperience - rightExperience) * direction;
         if (diff !== 0) {
             return diff;


### PR DESCRIPTION
## Summary
- Add `computeExperienceFromWorkHistory` helper that computes total experience years from workHistory `startDate`/`endDate` date ranges
- Add `resolveExperienceYears` that first tries `parseExperienceYears(content.experience)`, then falls back to workHistory computation
- Merge overlapping date ranges to avoid double-counting concurrent positions
- Apply in both `matchesResumeListFilters` and the sort comparison

This fixes the Seek EN resume issue where `content.experience = ""` caused experience to be unknown, even though workHistory had parseable date ranges.

## Test plan
- [x] `npm test` — 124 test files, 1463 passing, 0 failures
- [x] `make check` — all checks pass