### PR TITLE
feat: project computed experience to resume list when content.experience is empty

### DIFF
--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -633,7 +633,11 @@ function projectResumeBaseContent(
         ?? toOptionalStringValue(content.url);
     const activityStatus = toOptionalStringValue(content.activityStatus);
     const age = toOptionalStringValue(content.age);
-    const experience = toOptionalStringValue(content.experience);
+    const experience = toOptionalStringValue(content.experience)
+        ?? (() => {
+            const years = computeExperienceFromWorkHistory(content.workHistory);
+            return years !== null ? `${years} years` : undefined;
+        })();
     const education = toOptionalStringValue(content.education);
     const location = toOptionalStringValue(content.location);
     const selfIntro = toOptionalStringValue(content.selfIntro);


### PR DESCRIPTION
## Summary
- When `content.experience` is empty (common for Seek resumes), fall back to computing experience years from workHistory date ranges and project the computed value (e.g., "5 years") in the list response
- Previously, Seek resumes showed `--` for experience in the UI; now they show the computed value from workHistory dates

## Test plan
- [x] `npm test` — 124 files, 1469 passing, 0 failures
- [x] `make check` — all checks pass
- [x] Existing experience filter graceful degradation tests still pass