### PR TITLE
fix: include convex+shared in make test-coverage and exclude dist dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1204,7 +1204,7 @@ test-coverage:                             ## Run Node.js tests with coverage
 	@echo "Running Node.js tests with coverage..."
 	@npm run --workspace @trends/shared build
 	@cd apps/web && npm run test -- --coverage
-	@npx vitest run --coverage apps/api/src
+	@npx vitest run --coverage apps/api/src packages/convex/convex packages/shared/src
 
 test-resume:                               ## Validate resume fixtures
 	@echo "Validating resume fixtures..."

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
         coverage: {
             provider: "v8",
             reporter: ["text", "html", "clover", "json", "lcov"],
+            exclude: ["**/dist/**", "**/node_modules/**"],
         },
     },
 });


### PR DESCRIPTION
## Summary
- Expand `make test-coverage` to include `packages/convex/convex` and `packages/shared/src` (was only covering `apps/web` and `apps/api/src`)
- Add `**/dist/**` and `**/node_modules/**` to vitest coverage exclusions to prevent compiled JS from polluting coverage reports

## Test plan
- [x] `make check` passes
- [x] `npx vitest run --coverage packages/convex/convex packages/shared/src` reports coverage correctly
- [x] No dist/ files appear in coverage output