### PR TITLE
test: add unit tests for useConvexResumes pure helpers

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.test.ts
+++ b/apps/web/src/hooks/useConvexResumes.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildFallbackKeywordExpansion,
+  matchesKeywordExpansion,
+  parseAnalysesMap,
+  parseAnalysis,
+  parseBrandHits,
+  parseBreakdown,
+  parseIngestData,
+  parseRuleScores,
+  parseTaggingEnvelope,
+  toNumber,
+  toStringArray,
+  toStringValue,
+} from './useConvexResumes'
+
+// ── toStringValue ──────────────────────────────────────────────
+
+describe('toStringValue', () => {
+  it('returns string as-is', () => {
+    expect(toStringValue('hello')).toBe('hello')
+  })
+
+  it('returns number as string', () => {
+    expect(toStringValue(42)).toBe('42')
+  })
+
+  it('returns empty string for null/undefined', () => {
+    expect(toStringValue(null)).toBe('')
+    expect(toStringValue(undefined)).toBe('')
+  })
+
+  it('returns stringified representation for objects', () => {
+    expect(toStringValue({})).toBe('[object Object]')
+  })
+})
+
+// ── toStringArray ──────────────────────────────────────────────
+
+describe('toStringArray', () => {
+  it('returns string array as-is', () => {
+    expect(toStringArray(['a', 'b'])).toEqual(['a', 'b'])
+  })
+
+  it('returns empty array for non-array', () => {
+    expect(toStringArray('not-array')).toEqual([])
+    expect(toStringArray(null)).toEqual([])
+  })
+
+  it('preserves empty strings in array', () => {
+    expect(toStringArray(['a', '', 'b'])).toEqual(['a', '', 'b'])
+  })
+
+  it('filters non-string items', () => {
+    expect(toStringArray(['a', 42, null, 'b'] as unknown[])).toEqual(['a', 'b'])
+  })
+})
+
+// ── toNumber ───────────────────────────────────────────────────
+
+describe('toNumber', () => {
+  it('returns number as-is', () => {
+    expect(toNumber(42)).toBe(42)
+  })
+
+  it('parses numeric strings', () => {
+    expect(toNumber('3.14')).toBe(3.14)
+  })
+
+  it('returns null for non-numeric', () => {
+    expect(toNumber('abc')).toBeNull()
+    expect(toNumber(null)).toBeNull()
+    expect(toNumber(undefined)).toBeNull()
+  })
+
+  it('returns null for NaN', () => {
+    expect(toNumber(NaN)).toBeNull()
+  })
+})
+
+// ── parseBreakdown ─────────────────────────────────────────────
+
+describe('parseBreakdown', () => {
+  it('parses valid breakdown', () => {
+    expect(parseBreakdown({ experience: 8, education: 5 })).toEqual({ experience: 8, education: 5 })
+  })
+
+  it('skips non-numeric values', () => {
+    expect(parseBreakdown({ a: 1, b: 'bad' })).toEqual({ a: 1 })
+  })
+
+  it('returns undefined for non-record', () => {
+    expect(parseBreakdown(null)).toBeUndefined()
+    expect(parseBreakdown('string')).toBeUndefined()
+  })
+
+  it('returns undefined for empty object', () => {
+    expect(parseBreakdown({})).toBeUndefined()
+  })
+})
+
+// ── parseAnalysis ──────────────────────────────────────────────
+
+describe('parseAnalysis', () => {
+  it('parses valid analysis', () => {
+    const result = parseAnalysis({
+      score: 85,
+      summary: 'Good candidate',
+      highlights: ['strong background'],
+      recommendation: 'proceed',
+    })
+    expect(result).toBeDefined()
+    expect(result!.score).toBe(85)
+    expect(result!.summary).toBe('Good candidate')
+    expect(result!.highlights).toEqual(['strong background'])
+    expect(result!.recommendation).toBe('proceed')
+  })
+
+  it('returns undefined for non-record', () => {
+    expect(parseAnalysis(null)).toBeUndefined()
+    expect(parseAnalysis(42)).toBeUndefined()
+  })
+
+  it('returns undefined when score is missing', () => {
+    expect(parseAnalysis({ summary: 'no score' })).toBeUndefined()
+  })
+
+  it('uses defaults for optional fields', () => {
+    const result = parseAnalysis({ score: 70 })
+    expect(result).not.toBeNull()
+    expect(result!.score).toBe(70)
+    expect(result!.summary).toBe('')
+    expect(result!.highlights).toEqual([])
+  })
+})
+
+// ── parseRuleScores ────────────────────────────────────────────
+
+describe('parseRuleScores', () => {
+  it('parses valid rule scores', () => {
+    expect(parseRuleScores({ leadership: 90, technical: 75 })).toEqual({ leadership: 90, technical: 75 })
+  })
+
+  it('skips non-numeric values', () => {
+    expect(parseRuleScores({ a: 10, b: 'bad' })).toEqual({ a: 10 })
+  })
+
+  it('returns empty object for non-record', () => {
+    expect(parseRuleScores(null)).toEqual({})
+  })
+
+  it('returns empty object for empty input', () => {
+    expect(parseRuleScores({})).toEqual({})
+  })
+})
+
+// ── parseBrandHits ─────────────────────────────────────────────
+
+describe('parseBrandHits', () => {
+  it('parses valid brand hits', () => {
+    const input = [{ brand: 'Alibaba', role: 'Engineer', source: 'workHistory', context: 'senior' }]
+    expect(parseBrandHits(input)).toEqual(input)
+  })
+
+  it('filters items with missing required fields', () => {
+    const input = [
+      { brand: 'Alibaba', role: 'Engineer', source: 'workHistory', context: 'senior' },
+      { brand: '', role: 'Engineer', source: 'workHistory', context: 'senior' },
+    ]
+    expect(parseBrandHits(input)).toHaveLength(1)
+  })
+
+  it('returns empty array for non-array', () => {
+    expect(parseBrandHits(null)).toEqual([])
+    expect(parseBrandHits({})).toEqual([])
+  })
+})
+
+// ── parseTaggingEnvelope ───────────────────────────────────────
+
+describe('parseTaggingEnvelope', () => {
+  it('parses valid tagging envelope', () => {
+    const input = {
+      schemaVersion: 1,
+      generatedAt: 1700000000,
+      entries: [
+        {
+          tag: 'python',
+          source: 'skills',
+          confidence: 0.95,
+          version: 2,
+          provenance: { stage: 'verified', generatedBy: 'pipeline', evidence: ['resume line 5'] },
+        },
+      ],
+    }
+    const result = parseTaggingEnvelope(input)
+    expect(result).toBeDefined()
+    expect(result!.entries).toHaveLength(1)
+    expect(result!.entries[0].tag).toBe('python')
+  })
+
+  it('returns undefined for non-record', () => {
+    expect(parseTaggingEnvelope(null)).toBeUndefined()
+  })
+
+  it('returns undefined when schemaVersion or generatedAt missing', () => {
+    expect(parseTaggingEnvelope({ entries: [] })).toBeUndefined()
+  })
+
+  it('returns undefined when no valid entries', () => {
+    const input = { schemaVersion: 1, generatedAt: 1700000000, entries: [{ tag: '' }] }
+    expect(parseTaggingEnvelope(input)).toBeUndefined()
+  })
+})
+
+// ── parseAnalysesMap ───────────────────────────────────────────
+
+describe('parseAnalysesMap', () => {
+  it('parses valid analyses map', () => {
+    const input = {
+      jd1: { score: 80, summary: 'Match', highlights: [], recommendation: 'proceed' },
+    }
+    const result = parseAnalysesMap(input)
+    expect(result).toBeDefined()
+    expect(result!.jd1.score).toBe(80)
+  })
+
+  it('returns undefined for empty map', () => {
+    expect(parseAnalysesMap({})).toBeUndefined()
+  })
+
+  it('returns undefined for non-record', () => {
+    expect(parseAnalysesMap(null)).toBeUndefined()
+  })
+
+  it('skips entries with invalid analysis', () => {
+    const input = { jd1: { noScore: true }, jd2: { score: 70 } }
+    const result = parseAnalysesMap(input)
+    expect(result).toBeDefined()
+    expect(Object.keys(result!)).toEqual(['jd2'])
+  })
+})
+
+// ── parseIngestData ────────────────────────────────────────────
+
+describe('parseIngestData', () => {
+  it('parses valid ingest data', () => {
+    const input = {
+      industryTags: ['tech', 'finance'],
+      synonymHits: ['java'],
+      brandHits: [],
+      companyHits: ['Alibaba'],
+      ruleScores: { tech: 85 },
+      experienceLevel: 'senior',
+    }
+    const result = parseIngestData(input)
+    expect(result).toBeDefined()
+    expect(result!.industryTags).toEqual(['tech', 'finance'])
+    expect(result!.experienceLevel).toBe('senior')
+  })
+
+  it('returns undefined for non-record', () => {
+    expect(parseIngestData(null)).toBeUndefined()
+    expect(parseIngestData('string')).toBeUndefined()
+  })
+
+  it('handles missing optional fields', () => {
+    const input = {
+      industryTags: [],
+      synonymHits: [],
+      brandHits: [],
+      companyHits: [],
+      ruleScores: {},
+      experienceLevel: 'unknown',
+    }
+    const result = parseIngestData(input)
+    expect(result).toBeDefined()
+    expect(result!.computedAt).toBeUndefined()
+    expect(result!.skillsVersion).toBeUndefined()
+  })
+})
+
+// ── buildFallbackKeywordExpansion ──────────────────────────────
+
+describe('buildFallbackKeywordExpansion', () => {
+  it('builds expansion from simple query', () => {
+    const result = buildFallbackKeywordExpansion('java python')
+    expect(result.groups).toHaveLength(2)
+    expect(result.mode).toBe('AND')
+    expect(result.expandedTo).toEqual(['java', 'python'])
+  })
+
+  it('handles OR mode', () => {
+    const result = buildFallbackKeywordExpansion('java OR python')
+    expect(result.mode).toBe('OR')
+  })
+
+  it('trims and lowercases terms', () => {
+    const result = buildFallbackKeywordExpansion('  Java  Python  ')
+    expect(result.expandedTo).toEqual(['java', 'python'])
+  })
+
+  it('filters empty terms', () => {
+    const result = buildFallbackKeywordExpansion('java   python')
+    expect(result.expandedTo).toEqual(['java', 'python'])
+  })
+})
+
+// ── matchesKeywordExpansion ────────────────────────────────────
+
+describe('matchesKeywordExpansion', () => {
+  const expansion = buildFallbackKeywordExpansion('java python')
+
+  it('finds matching terms in search text', () => {
+    const result = matchesKeywordExpansion('experienced java developer', expansion)
+    expect(result).toHaveLength(1)
+    expect(result[0].term).toBe('java')
+    expect(result[0].source).toBe('searchText')
+  })
+
+  it('finds multiple matches', () => {
+    const result = matchesKeywordExpansion('java and python developer', expansion)
+    expect(result).toHaveLength(2)
+  })
+
+  it('returns empty when no terms match', () => {
+    const result = matchesKeywordExpansion('c++ developer', expansion)
+    expect(result).toHaveLength(0)
+  })
+
+  it('deduplicates matching variants in same group', () => {
+    const expansionWithDupes = buildFallbackKeywordExpansion('java')
+    const result = matchesKeywordExpansion('java java java', expansionWithDupes)
+    expect(result).toHaveLength(1)
+  })
+})

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -222,7 +222,7 @@ type ExactKeywordMatchContext = {
   score: number
 }
 
-function buildFallbackKeywordExpansion(query: string): KeywordExpansionSummary {
+export function buildFallbackKeywordExpansion(query: string): KeywordExpansionSummary {
   const parsed = parseKeywordQuery(query)
   const terms = parsed.keywords
     .map((term) => term.trim().toLowerCase())
@@ -277,7 +277,7 @@ function buildMockSearchText(doc: ResumeListDocLike): string {
     .join(' ')
 }
 
-function matchesKeywordExpansion(searchText: string, expansion: KeywordExpansionSummary): SearchProvenance[] {
+export function matchesKeywordExpansion(searchText: string, expansion: KeywordExpansionSummary): SearchProvenance[] {
   const seen = new Set<string>()
   const matches: SearchProvenance[] = []
 
@@ -351,7 +351,7 @@ function filterMockSearchResults(
     .map(stripMatchedGroupCount)
 }
 
-function toStringValue(value: unknown): string {
+export function toStringValue(value: unknown): string {
   if (typeof value === 'string') {
     return value
   }
@@ -361,14 +361,14 @@ function toStringValue(value: unknown): string {
   return String(value)
 }
 
-function toStringArray(value: unknown): string[] {
+export function toStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return []
   }
   return value.filter((item): item is string => typeof item === 'string')
 }
 
-function toNumber(value: unknown): number | null {
+export function toNumber(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value
   }
@@ -381,7 +381,7 @@ function toNumber(value: unknown): number | null {
   return null
 }
 
-function parseBreakdown(value: unknown): Record<string, number> | undefined {
+export function parseBreakdown(value: unknown): Record<string, number> | undefined {
   if (!isRecord(value)) {
     return undefined
   }
@@ -397,7 +397,7 @@ function parseBreakdown(value: unknown): Record<string, number> | undefined {
   return Object.keys(parsed).length ? parsed : undefined
 }
 
-function parseAnalysis(value: unknown): ConvexResumeAnalysis | undefined {
+export function parseAnalysis(value: unknown): ConvexResumeAnalysis | undefined {
   if (!isRecord(value)) {
     return undefined
   }
@@ -422,7 +422,7 @@ function parseAnalysis(value: unknown): ConvexResumeAnalysis | undefined {
   }
 }
 
-function parseRuleScores(value: unknown): Record<string, number> {
+export function parseRuleScores(value: unknown): Record<string, number> {
   if (!isRecord(value)) {
     return {}
   }
@@ -438,7 +438,7 @@ function parseRuleScores(value: unknown): Record<string, number> {
   return parsed
 }
 
-function parseBrandHits(value: unknown): ConvexIngestData['brandHits'] {
+export function parseBrandHits(value: unknown): ConvexIngestData['brandHits'] {
   if (!Array.isArray(value)) {
     return []
   }
@@ -463,7 +463,7 @@ function parseBrandHits(value: unknown): ConvexIngestData['brandHits'] {
     .filter((item): item is NonNullable<typeof item> => item !== null)
 }
 
-function parseTaggingEnvelope(value: unknown): ConvexIngestData['taggingEnvelope'] {
+export function parseTaggingEnvelope(value: unknown): ConvexIngestData['taggingEnvelope'] {
   if (!isRecord(value)) {
     return undefined
   }
@@ -517,7 +517,7 @@ function parseTaggingEnvelope(value: unknown): ConvexIngestData['taggingEnvelope
   }
 }
 
-function parseAnalysesMap(value: unknown): Record<string, ConvexResumeAnalysis> | undefined {
+export function parseAnalysesMap(value: unknown): Record<string, ConvexResumeAnalysis> | undefined {
   if (!isRecord(value)) {
     return undefined
   }
@@ -533,7 +533,7 @@ function parseAnalysesMap(value: unknown): Record<string, ConvexResumeAnalysis> 
   return Object.keys(parsed).length ? parsed : undefined
 }
 
-function parseIngestData(value: unknown): ConvexIngestData | undefined {
+export function parseIngestData(value: unknown): ConvexIngestData | undefined {
   if (!isRecord(value)) {
     return undefined
   }


### PR DESCRIPTION
## Summary
- Export 12 pure parse/match functions from `useConvexResumes.ts` for testability
- Add 46 unit tests covering all exported helpers: `toStringValue`, `toStringArray`, `toNumber`, `parseBreakdown`, `parseAnalysis`, `parseRuleScores`, `parseBrandHits`, `parseTaggingEnvelope`, `parseAnalysesMap`, `parseIngestData`, `buildFallbackKeywordExpansion`, `matchesKeywordExpansion`
- First test coverage for this 1408-line hook (previously 0%)

## Test plan
- [x] `vitest run src/hooks/useConvexResumes.test.ts` — 46/46 pass
- [x] `make check` — all checks pass