### PR TITLE
fix: seek source locale override dead code

### DIFF
--- a/apps/api/src/services/__tests__/locale-utils.test.ts
+++ b/apps/api/src/services/__tests__/locale-utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolveAIOutputLocale } from "../locale-utils.js";
+
+describe("resolveAIOutputLocale", () => {
+    const originalEnv = process.env.AI_OUTPUT_LOCALE;
+
+    beforeEach(() => {
+        delete process.env.AI_OUTPUT_LOCALE;
+    });
+
+    afterEach(() => {
+        if (originalEnv !== undefined) {
+            process.env.AI_OUTPUT_LOCALE = originalEnv;
+        } else {
+            delete process.env.AI_OUTPUT_LOCALE;
+        }
+    });
+
+    it("returns default locale when no env var and no sourceKey", () => {
+        const result = resolveAIOutputLocale();
+        expect(result).toBe("zh-Hans");
+    });
+
+    it("returns 'en' for seek sourceKey regardless of env var", () => {
+        process.env.AI_OUTPUT_LOCALE = "zh-Hans";
+        expect(resolveAIOutputLocale({ sourceKey: "seek" })).toBe("en");
+    });
+
+    it("returns 'en' for seek sourceKey when no env var", () => {
+        expect(resolveAIOutputLocale({ sourceKey: "seek" })).toBe("en");
+    });
+
+    it("returns env var locale for non-seek sources", () => {
+        process.env.AI_OUTPUT_LOCALE = "zh-Hans";
+        expect(resolveAIOutputLocale({ sourceKey: "51job" })).toBe("zh-Hans");
+    });
+
+    it("returns env var locale when no sourceKey provided", () => {
+        process.env.AI_OUTPUT_LOCALE = "zh-Hans";
+        expect(resolveAIOutputLocale()).toBe("zh-Hans");
+    });
+
+    it("seek sourceKey takes priority over env var", () => {
+        process.env.AI_OUTPUT_LOCALE = "zh-Hans";
+        const seekResult = resolveAIOutputLocale({ sourceKey: "seek" });
+        const defaultResult = resolveAIOutputLocale();
+        expect(seekResult).toBe("en");
+        expect(defaultResult).toBe("zh-Hans");
+    });
+});

--- a/apps/api/src/services/locale-utils.ts
+++ b/apps/api/src/services/locale-utils.ts
@@ -10,12 +10,14 @@ export function localeToNaturalLanguage(locale: string): string {
 }
 
 export function resolveAIOutputLocale(scope?: { sourceKey?: string | null }): string {
+    // Source-specific overrides take priority over the env var default.
+    // Without this, AI_OUTPUT_LOCALE=zh-Hans makes the seek→en branch dead code.
+    if (scope?.sourceKey === "seek") {
+        return SEEK_RESUME_AI_OUTPUT_LOCALE;
+    }
     const locale = process.env.AI_OUTPUT_LOCALE?.trim();
     if (locale && locale.length > 0) {
         return locale;
-    }
-    if (scope?.sourceKey === "seek") {
-        return SEEK_RESUME_AI_OUTPUT_LOCALE;
     }
     return DEFAULT_RESUME_AI_PROMPT_LOCALE;
 }

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -55,12 +55,14 @@ export function inferSourceKey(source: string | undefined) {
 
 // For Convex deployments, set AI_OUTPUT_LOCALE via the dashboard or `convex env set`.
 export function resolveAIOutputLocale(scope?: { sourceKey?: string }): string {
+    // Source-specific overrides take priority over the env var default.
+    // Without this, AI_OUTPUT_LOCALE=zh-Hans makes the seek→en branch dead code.
+    if (scope?.sourceKey === "seek") {
+        return "en";
+    }
     const locale = process.env.AI_OUTPUT_LOCALE?.trim();
     if (locale && locale.length > 0) {
         return resolveResumeAiPromptLocale(locale).requestedLocale;
-    }
-    if (scope?.sourceKey === "seek") {
-        return "en";
     }
     return resolveResumeAiPromptLocale(undefined).requestedLocale;
 }


### PR DESCRIPTION
## Summary
- `resolveAIOutputLocale` checked `AI_OUTPUT_LOCALE` env var before source-specific overrides, making the `seek → en` branch dead code when `AI_OUTPUT_LOCALE=zh-Hans` is set in production
- Seek (MY/AU/NZ) resumes were scored with Chinese AI prompts, labels, and output contracts instead of English, causing English "Relevant Experience" sections to be mismatched
- Fix: source-specific locale override (`seek → en`) now takes priority over the env var default in both BFF (`locale-utils.ts`) and Convex (`analyze.ts`) copies

## Test plan
- [x] 6 unit tests for `resolveAIOutputLocale` covering: seek override with/without env var, env var fallback for non-seek sources, priority ordering
- [x] `make check` passes (0 errors)
- [ ] Verify on production that Seek resumes get English AI analysis locale after deploy