### PR TITLE
test: add 38 unit tests for manual-resume-import-service pure functions

### DIFF
--- a/apps/api/src/services/__tests__/manual-resume-import-service.test.ts
+++ b/apps/api/src/services/__tests__/manual-resume-import-service.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeWhitespace,
+  decodeXmlEntities,
+  extractDocxTextFromXml,
+  buildBaseMetadata,
+  getExtension,
+  sanitizeEntryPath,
+  isSupportedResumeFile,
+  ensureFileSizeWithinLimit,
+  fileResultBase,
+  buildImportedResumeCandidate,
+  buildSummary,
+  buildParsedSummary,
+  resolveImportLimit,
+} from "../manual-resume-import-service.js";
+
+describe("normalizeWhitespace", () => {
+  it("replaces carriage returns with newlines", () => {
+    expect(normalizeWhitespace("hello\rworld")).toBe("hello\nworld");
+  });
+  it("removes null bytes", () => {
+    expect(normalizeWhitespace("hello\u0000world")).toBe("helloworld");
+  });
+  it("collapses 3+ consecutive newlines to 2", () => {
+    expect(normalizeWhitespace("a\n\n\nb")).toBe("a\n\nb");
+    expect(normalizeWhitespace("a\n\n\n\n\nb")).toBe("a\n\nb");
+  });
+  it("trims leading and trailing whitespace", () => {
+    expect(normalizeWhitespace("  hello  ")).toBe("hello");
+  });
+  it("preserves single newlines", () => {
+    expect(normalizeWhitespace("a\nb")).toBe("a\nb");
+  });
+  it("preserves double newlines", () => {
+    expect(normalizeWhitespace("a\n\nb")).toBe("a\n\nb");
+  });
+});
+
+describe("decodeXmlEntities", () => {
+  it("decodes named entities", () => {
+    expect(decodeXmlEntities("&amp;")).toBe("&");
+    expect(decodeXmlEntities("&lt;")).toBe("<");
+    expect(decodeXmlEntities("&gt;")).toBe(">");
+    expect(decodeXmlEntities("&quot;")).toBe('"');
+    expect(decodeXmlEntities("&apos;")).toBe("'");
+  });
+  it("decodes hex character references", () => {
+    expect(decodeXmlEntities("&#x41;")).toBe("A");
+    expect(decodeXmlEntities("&#x26;")).toBe("&");
+  });
+  it("decodes decimal character references", () => {
+    expect(decodeXmlEntities("&#65;")).toBe("A");
+    expect(decodeXmlEntities("&#38;")).toBe("&");
+  });
+  it("handles mixed text", () => {
+    expect(decodeXmlEntities("a &lt; b &amp; c &gt; d")).toBe("a < b & c > d");
+  });
+  it("returns original text for non-entity ampersands", () => {
+    expect(decodeXmlEntities("hello &world foo")).toBe("hello &world foo");
+  });
+});
+
+describe("extractDocxTextFromXml", () => {
+  it("extracts text from w:t elements", () => {
+    const xml = '<w:r><w:t>Hello World</w:t></w:r>';
+    expect(extractDocxTextFromXml(xml)).toBe("Hello World");
+  });
+  it("extracts text from multiple w:t elements", () => {
+    const xml = '<w:r><w:t>Hello</w:t></w:r><w:r><w:t>World</w:t></w:r>';
+    expect(extractDocxTextFromXml(xml)).toBe("Hello\nWorld");
+  });
+  it("handles w:br as newline", () => {
+    const xml = '<w:r><w:t>Hello<w:br/>World</w:t></w:r>';
+    expect(extractDocxTextFromXml(xml)).toBe("Hello\nWorld");
+  });
+  it("handles w:tab as tab", () => {
+    const xml = '<w:r><w:t>Hello<w:tab/>World</w:t></w:r>';
+    expect(extractDocxTextFromXml(xml)).toBe("Hello\tWorld");
+  });
+  it("handles XML entities in text", () => {
+    const xml = '<w:r><w:t>A &amp; B</w:t></w:r>';
+    expect(extractDocxTextFromXml(xml)).toBe("A & B");
+  });
+  it("skips empty w:t elements", () => {
+    const xml = '<w:r><w:t>   </w:t></w:r><w:r><w:t>Hello</w:t></w:r>';
+    expect(extractDocxTextFromXml(xml)).toBe("Hello");
+  });
+});
+
+describe("buildBaseMetadata", () => {
+  it("builds metadata with all optional fields", () => {
+    const result = buildBaseMetadata({
+      files: [],
+      keyword: "CNC",
+      location: "深圳",
+      searchProfileId: "sp_123",
+    });
+    expect(result.sourceKey).toBe("51job-manual");
+    expect(result.sourceUrl).toBe("https://www.51job.com/");
+    expect(result.keyword).toBe("CNC");
+    expect(result.location).toBe("深圳");
+    expect(result.searchProfileId).toBe("sp_123");
+    expect(result.collectionContext.captureMode).toBe("manual-upload");
+  });
+  it("omits optional fields when not provided", () => {
+    const result = buildBaseMetadata({ files: [] });
+    expect(result.keyword).toBeUndefined();
+    expect(result.location).toBeUndefined();
+    expect(result.searchProfileId).toBeUndefined();
+  });
+  it("omits optional fields for empty strings", () => {
+    const result = buildBaseMetadata({ files: [], keyword: "", location: "  " });
+    expect(result.keyword).toBeUndefined();
+    expect(result.location).toBeUndefined();
+  });
+});
+
+describe("getExtension", () => {
+  it("returns lowercase extension", () => {
+    expect(getExtension("resume.PDF")).toBe(".pdf");
+    expect(getExtension("file.docx")).toBe(".docx");
+  });
+  it("returns empty string for no extension", () => {
+    expect(getExtension("resume")).toBe("");
+  });
+});
+
+describe("sanitizeEntryPath", () => {
+  it("replaces backslashes with forward slashes", () => {
+    expect(sanitizeEntryPath("folder\\file.docx")).toBe("folder/file.docx");
+  });
+  it("removes leading slashes", () => {
+    expect(sanitizeEntryPath("/root/file.docx")).toBe("root/file.docx");
+    expect(sanitizeEntryPath("///file.docx")).toBe("file.docx");
+  });
+  it("trims whitespace", () => {
+    expect(sanitizeEntryPath("  file.docx  ")).toBe("file.docx");
+  });
+});
+
+describe("isSupportedResumeFile", () => {
+  it("returns true for supported extensions", () => {
+    expect(isSupportedResumeFile("resume.pdf")).toBe(true);
+    expect(isSupportedResumeFile("resume.doc")).toBe(true);
+    expect(isSupportedResumeFile("resume.docx")).toBe(true);
+    expect(isSupportedResumeFile("resume.PDF")).toBe(true);
+  });
+  it("returns false for unsupported extensions", () => {
+    expect(isSupportedResumeFile("resume.txt")).toBe(false);
+    expect(isSupportedResumeFile("image.png")).toBe(false);
+    expect(isSupportedResumeFile("data.xlsx")).toBe(false);
+  });
+});
+
+describe("ensureFileSizeWithinLimit", () => {
+  it("does not throw for files within limit", () => {
+    expect(() => ensureFileSizeWithinLimit("test.pdf", 100, 200)).not.toThrow();
+    expect(() => ensureFileSizeWithinLimit("test.pdf", 200, 200)).not.toThrow();
+  });
+  it("throws for files exceeding limit", () => {
+    expect(() => ensureFileSizeWithinLimit("test.pdf", 201, 200)).toThrow(/exceeds the 0MB limit/);
+  });
+  it("throws for invalid file size", () => {
+    expect(() => ensureFileSizeWithinLimit("test.pdf", -1, 200)).toThrow(/Invalid file size/);
+    expect(() => ensureFileSizeWithinLimit("test.pdf", Infinity, 200)).toThrow(/Invalid file size/);
+    expect(() => ensureFileSizeWithinLimit("test.pdf", NaN, 200)).toThrow(/Invalid file size/);
+  });
+});
+
+describe("fileResultBase", () => {
+  it("builds base file result from enumerated file", () => {
+    const result = fileResultBase({
+      uploadName: "archive.zip",
+      entryPath: "resume.docx",
+      extension: ".docx",
+      data: new Uint8Array(0),
+      extractionMethod: "zip",
+    });
+    expect(result).toEqual({
+      uploadName: "archive.zip",
+      entryPath: "resume.docx",
+      extension: ".docx",
+      warnings: [],
+    });
+  });
+});
+
+describe("buildImportedResumeCandidate", () => {
+  it("builds candidate from file and parsed text", () => {
+    const file = {
+      uploadName: "test.zip",
+      entryPath: "张三_销售.doc",
+      extension: ".doc",
+      data: new Uint8Array(0),
+      extractionMethod: "zip",
+    };
+    // Minimal 51job text that parse51jobManualResume can extract a name from
+    const text = "姓名：张三\n工作经验：5年\n求职意向：销售经理";
+    const result = buildImportedResumeCandidate(file, text, []);
+    expect(result.result.status).toBe("imported");
+    expect(result.resume).toBeDefined();
+    expect(result.resume.profileType).toBe("51job-manual");
+  });
+  it("uses entryPath basename as fallback name", () => {
+    const file = {
+      uploadName: "test.zip",
+      entryPath: "unknown.doc",
+      extension: ".doc",
+      data: new Uint8Array(0),
+      extractionMethod: "direct",
+    };
+    const text = "some unstructured text";
+    const result = buildImportedResumeCandidate(file, text, ["warning1"]);
+    expect(result.result.warnings).toEqual(["warning1"]);
+  });
+});
+
+describe("buildSummary", () => {
+  it("merges parsed and submit summaries", () => {
+    const result = buildSummary(
+      { uploadedFiles: 2, discoveredFiles: 5, parsedResumes: 3, imported: 3, skipped: 1, failed: 1 },
+      { submitted: 3, inserted: 2, updated: 1, unchanged: 0, deduped: 0 },
+    );
+    expect(result).toEqual({
+      uploadedFiles: 2,
+      discoveredFiles: 5,
+      parsedResumes: 3,
+      imported: 3,
+      inserted: 2,
+      updated: 1,
+      unchanged: 0,
+      deduped: 0,
+      skipped: 1,
+      failed: 1,
+    });
+  });
+});
+
+describe("buildParsedSummary", () => {
+  it("counts statuses from file results", () => {
+    const result = buildParsedSummary(2, 5, 3, [
+      { uploadName: "a", entryPath: "a", extension: ".pdf", status: "imported", warnings: [] },
+      { uploadName: "b", entryPath: "b", extension: ".doc", status: "skipped", warnings: [] },
+      { uploadName: "c", entryPath: "c", extension: ".docx", status: "failed", warnings: [], error: "parse error" },
+    ]);
+    expect(result).toEqual({
+      uploadedFiles: 2,
+      discoveredFiles: 5,
+      parsedResumes: 3,
+      imported: 3,
+      skipped: 1,
+      failed: 1,
+    });
+  });
+});
+
+describe("resolveImportLimit", () => {
+  it("returns truncated positive number", () => {
+    expect(resolveImportLimit(10)).toBe(10);
+    expect(resolveImportLimit(10.9)).toBe(10);
+  });
+  it("returns undefined for non-positive results", () => {
+    expect(resolveImportLimit(0)).toBeUndefined();
+    expect(resolveImportLimit(-5)).toBeUndefined();
+  });
+  it("returns undefined for non-finite or non-number", () => {
+    expect(resolveImportLimit(undefined)).toBeUndefined();
+    expect(resolveImportLimit(Infinity)).toBeUndefined();
+    expect(resolveImportLimit(NaN)).toBeUndefined();
+    expect(resolveImportLimit("10" as unknown as number)).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/manual-resume-import-service.ts
+++ b/apps/api/src/services/manual-resume-import-service.ts
@@ -83,11 +83,11 @@ const DOCX_MESSAGE_WARNING_TYPES = new Set(["warning", "error"]);
 const DOCX_TEXT_ENTRY_PATH_PATTERN = /^word\/(?:document|header\d+|footer\d+|footnotes|endnotes)\.xml$/i;
 const DOCX_TEXT_RUN_PATTERN = /<w:t\b[^>]*>((?:(?!<\/w:t>)(?:[^<]|<w:(?:br|cr|tab|noBreakHyphen|softHyphen)\b[^>]*\/>))*)<\/w:t>/gis;
 
-function normalizeWhitespace(value: string): string {
+export function normalizeWhitespace(value: string): string {
   return value.replace(/\r/g, "\n").replace(/\u0000/g, "").replace(/\n{3,}/g, "\n\n").trim();
 }
 
-function decodeXmlEntities(value: string): string {
+export function decodeXmlEntities(value: string): string {
   return value.replace(/&(?:#x([0-9a-fA-F]+)|#(\d+)|amp|lt|gt|quot|apos);/g, (match, hex, decimal) => {
     if (typeof hex === "string") {
       return String.fromCodePoint(Number.parseInt(hex, 16));
@@ -112,7 +112,7 @@ function decodeXmlEntities(value: string): string {
   });
 }
 
-function extractDocxTextFromXml(xml: string): string {
+export function extractDocxTextFromXml(xml: string): string {
   const fragments = Array.from(xml.matchAll(DOCX_TEXT_RUN_PATTERN), (match) => {
     return decodeXmlEntities(match[1])
       .replace(/<w:tab\b[^>]*\/>/g, "\t")
@@ -135,7 +135,7 @@ function extractDocxTextFallback(file: EnumeratedImportFile): string {
   return normalizeWhitespace(text);
 }
 
-function buildBaseMetadata(input: ManualResumeImportInput): ResumeImportMetadata {
+export function buildBaseMetadata(input: ManualResumeImportInput): ResumeImportMetadata {
   const keyword = normalizeOptionalString(input.keyword);
   const location = normalizeOptionalString(input.location);
   const searchProfileId = normalizeOptionalString(input.searchProfileId);
@@ -170,19 +170,19 @@ function toArrayBuffer(value: Uint8Array): ArrayBuffer {
   return copy.buffer;
 }
 
-function getExtension(name: string): string {
+export function getExtension(name: string): string {
   return path.extname(name).toLowerCase();
 }
 
-function sanitizeEntryPath(entryPath: string): string {
+export function sanitizeEntryPath(entryPath: string): string {
   return entryPath.replace(/\\/g, "/").replace(/^\/+/, "").trim();
 }
 
-function isSupportedResumeFile(entryPath: string): boolean {
+export function isSupportedResumeFile(entryPath: string): boolean {
   return SUPPORTED_FILE_EXTENSIONS.has(getExtension(entryPath));
 }
 
-function ensureFileSizeWithinLimit(name: string, size: number, limit: number): void {
+export function ensureFileSizeWithinLimit(name: string, size: number, limit: number): void {
   if (!Number.isFinite(size) || size < 0) {
     throw new Error(`Invalid file size for ${name}`);
   }
@@ -335,7 +335,7 @@ async function enumerateUploadedFiles(files: File[]): Promise<{
   return { entries, fileResults };
 }
 
-function fileResultBase(file: EnumeratedImportFile): Omit<ManualResumeImportFileResult, "status"> {
+export function fileResultBase(file: EnumeratedImportFile): Omit<ManualResumeImportFileResult, "status"> {
   return {
     uploadName: file.uploadName,
     entryPath: file.entryPath,
@@ -344,7 +344,7 @@ function fileResultBase(file: EnumeratedImportFile): Omit<ManualResumeImportFile
   };
 }
 
-function buildImportedResumeCandidate(
+export function buildImportedResumeCandidate(
   file: EnumeratedImportFile,
   text: string,
   warnings: string[],
@@ -529,7 +529,7 @@ async function parseResumeFile(file: EnumeratedImportFile): Promise<ParsedImport
   return parsePdfFile(file);
 }
 
-function buildSummary(
+export function buildSummary(
   parsedSummary: ManualResumeImportBuildSummary,
   submitSummary: ResumeSubmitSummary,
 ): ManualResumeImportSummary {
@@ -547,7 +547,7 @@ function buildSummary(
   };
 }
 
-function buildParsedSummary(
+export function buildParsedSummary(
   uploadedFiles: number,
   discoveredFiles: number,
   parsedResumes: number,
@@ -566,7 +566,7 @@ function buildParsedSummary(
   };
 }
 
-function resolveImportLimit(value: number | undefined): number | undefined {
+export function resolveImportLimit(value: number | undefined): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- Export 13 pure functions from `manual-resume-import-service.ts` (652 lines, previously 0% tested)
- Add 38 unit tests covering XML entity decoding, DOCX text extraction, path sanitization, file size validation, import candidate building, summary construction, and limit resolution
- Continues addressing P2 finding from research scan: API service files lacking test coverage

## Test plan
- [x] 38 unit tests pass (`npx vitest run apps/api/src/services/__tests__/manual-resume-import-service.test.ts`)
- [x] `make check` passes (0 errors)
- [ ] Verify no regressions in manual resume import flow