### PR TITLE
feat: add unit tests for brand-display-resolver pure functions

### DIFF
--- a/apps/api/src/services/__tests__/brand-display-resolver.test.ts
+++ b/apps/api/src/services/__tests__/brand-display-resolver.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  hasChinese,
+  pickPreferredZhHansFromAliases,
+  brandEntryToDisplay,
+} from "../brand-display-resolver.js";
+import type { BrandEntry } from "../industry-data-service.js";
+
+describe("hasChinese", () => {
+  it("returns true for Chinese characters", () => {
+    expect(hasChinese("精雕")).toBe(true);
+    expect(hasChinese("德马吉森精机")).toBe(true);
+  });
+
+  it("returns true for mixed Chinese and ASCII", () => {
+    expect(hasChinese("北京精雕 BJJD")).toBe(true);
+  });
+
+  it("returns false for ASCII only", () => {
+    expect(hasChinese("DMG MORI")).toBe(false);
+    expect(hasChinese("hello")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(hasChinese("")).toBe(false);
+  });
+
+  it("returns false for Japanese katakana only", () => {
+    expect(hasChinese("カタカナ")).toBe(false);
+  });
+
+  it("returns false for numbers and symbols", () => {
+    expect(hasChinese("123!@#")).toBe(false);
+  });
+});
+
+describe("pickPreferredZhHansFromAliases", () => {
+  it("returns the shortest Chinese alias", () => {
+    const result = pickPreferredZhHansFromAliases(["北京精雕", "精雕"]);
+    expect(result).toBe("精雕");
+  });
+
+  it("returns the only Chinese alias", () => {
+    const result = pickPreferredZhHansFromAliases(["DMG", "德马吉"]);
+    expect(result).toBe("德马吉");
+  });
+
+  it("returns null when no Chinese aliases", () => {
+    const result = pickPreferredZhHansFromAliases(["DMG", "MORI"]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty array", () => {
+    expect(pickPreferredZhHansFromAliases([])).toBeNull();
+  });
+
+  it("trims whitespace from aliases", () => {
+    const result = pickPreferredZhHansFromAliases(["  精雕  "]);
+    expect(result).toBe("精雕");
+  });
+
+  it("filters out empty/whitespace-only aliases", () => {
+    const result = pickPreferredZhHansFromAliases(["", "  ", "精雕"]);
+    expect(result).toBe("精雕");
+  });
+
+  it("prefers shorter Chinese alias even when longer appears first", () => {
+    const result = pickPreferredZhHansFromAliases(["德马吉森精机", "德马吉"]);
+    expect(result).toBe("德马吉");
+  });
+});
+
+describe("brandEntryToDisplay", () => {
+  it("uses nameEn as displayName when present", () => {
+    const brand: BrandEntry = { nameCn: "精雕", nameEn: "JingDiao" };
+    const result = brandEntryToDisplay(brand);
+    expect(result.displayName).toBe("JingDiao");
+    expect(result.zhHans).toBe("精雕");
+  });
+
+  it("falls back to nameCn when nameEn is empty", () => {
+    const brand: BrandEntry = { nameCn: "精雕", nameEn: "" };
+    const result = brandEntryToDisplay(brand);
+    expect(result.displayName).toBe("精雕");
+    expect(result.zhHans).toBe("精雕");
+  });
+
+  it("falls back to nameCn when nameEn is whitespace", () => {
+    const brand: BrandEntry = { nameCn: "精雕", nameEn: "  " };
+    const result = brandEntryToDisplay(brand);
+    expect(result.displayName).toBe("精雕");
+  });
+
+  it("trims nameCn for zhHans", () => {
+    const brand: BrandEntry = { nameCn: "  精雕  ", nameEn: "JingDiao" };
+    const result = brandEntryToDisplay(brand);
+    expect(result.zhHans).toBe("精雕");
+  });
+});

--- a/apps/api/src/services/brand-display-resolver.ts
+++ b/apps/api/src/services/brand-display-resolver.ts
@@ -10,7 +10,7 @@ export type BrandDisplayEntry = {
   zhHans: string;
 };
 
-function hasChinese(value: string): boolean {
+export function hasChinese(value: string): boolean {
   // Basic CJK Unified Ideographs range; sufficient for our alias data.
   return /[\u4e00-\u9fff]/u.test(value);
 }
@@ -19,7 +19,7 @@ function normalizeBrandId(value: string): string {
   return normalizeCompanyPatternIdentifier(value);
 }
 
-function pickPreferredZhHansFromAliases(aliases: string[]): string | null {
+export function pickPreferredZhHansFromAliases(aliases: string[]): string | null {
   const candidates = aliases.map((alias) => alias.trim()).filter((alias) => alias && hasChinese(alias));
   if (candidates.length === 0) return null;
 
@@ -31,7 +31,7 @@ function pickPreferredZhHansFromAliases(aliases: string[]): string | null {
   return best;
 }
 
-function brandEntryToDisplay(brand: BrandEntry): BrandDisplayEntry {
+export function brandEntryToDisplay(brand: BrandEntry): BrandDisplayEntry {
   const displayName = brand.nameEn?.trim() || brand.nameCn.trim();
   return { displayName, zhHans: brand.nameCn.trim() };
 }


### PR DESCRIPTION
## Summary
- Export 3 private helpers (`hasChinese`, `pickPreferredZhHansFromAliases`, `brandEntryToDisplay`) from `brand-display-resolver.ts`
- Add 17 unit tests covering CJK character detection, shortest-Chinese-alias selection logic (with length tiebreaker, whitespace trimming, empty filtering), and brand display entry mapping (nameEn fallback, nameCn trimming)

## Test plan
- [x] `npx vitest run apps/api/src/services/__tests__/brand-display-resolver.test.ts` — 17/17 pass
- [x] `make check` — all passed