### PR TITLE
feat: add unit tests for errors and web-vitals-logger

### DIFF
--- a/apps/api/src/services/__tests__/errors.test.ts
+++ b/apps/api/src/services/__tests__/errors.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { DataNotFoundError, FileParseError } from "../errors.js";
+
+describe("DataNotFoundError", () => {
+  it("is an instance of Error", () => {
+    const error = new DataNotFoundError("not found");
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(DataNotFoundError);
+  });
+
+  it("sets name to DataNotFoundError", () => {
+    const error = new DataNotFoundError("not found");
+    expect(error.name).toBe("DataNotFoundError");
+  });
+
+  it("sets message", () => {
+    const error = new DataNotFoundError("No data for 2026-01-01");
+    expect(error.message).toBe("No data for 2026-01-01");
+  });
+
+  it("sets suggestion when provided", () => {
+    const error = new DataNotFoundError("not found", { suggestion: "Run the crawler" });
+    expect(error.suggestion).toBe("Run the crawler");
+  });
+
+  it("leaves suggestion undefined when not provided", () => {
+    const error = new DataNotFoundError("not found");
+    expect(error.suggestion).toBeUndefined();
+  });
+});
+
+describe("FileParseError", () => {
+  it("is an instance of Error", () => {
+    const error = new FileParseError("/path/to/file", "parse failed");
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(FileParseError);
+  });
+
+  it("sets name to FileParseError", () => {
+    const error = new FileParseError("/path/to/file", "parse failed");
+    expect(error.name).toBe("FileParseError");
+  });
+
+  it("sets message", () => {
+    const error = new FileParseError("/path/to/file", "parse failed");
+    expect(error.message).toBe("parse failed");
+  });
+
+  it("sets filepath", () => {
+    const error = new FileParseError("/path/to/file.yaml", "invalid YAML");
+    expect(error.filepath).toBe("/path/to/file.yaml");
+  });
+});

--- a/apps/api/src/services/__tests__/web-vitals-logger.test.ts
+++ b/apps/api/src/services/__tests__/web-vitals-logger.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import {
+  isRecord,
+  readString,
+  readNumber,
+  parseMetric,
+  percentile,
+} from "../web-vitals-logger.js";
+
+describe("isRecord", () => {
+  it("returns true for plain objects", () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+  });
+
+  it("returns false for null", () => {
+    expect(isRecord(null)).toBe(false);
+  });
+
+  it("returns true for arrays (typeof check only)", () => {
+    expect(isRecord([])).toBe(true);
+  });
+
+  it("returns false for primitives", () => {
+    expect(isRecord("string")).toBe(false);
+    expect(isRecord(42)).toBe(false);
+    expect(isRecord(true)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isRecord(undefined)).toBe(false);
+  });
+});
+
+describe("readString", () => {
+  it("returns trimmed string for valid input", () => {
+    expect(readString("  hello  ")).toBe("hello");
+  });
+
+  it("returns null for non-string input", () => {
+    expect(readString(42)).toBeNull();
+    expect(readString(null)).toBeNull();
+    expect(readString(undefined)).toBeNull();
+  });
+
+  it("returns null for empty/whitespace-only string", () => {
+    expect(readString("")).toBeNull();
+    expect(readString("   ")).toBeNull();
+  });
+});
+
+describe("readNumber", () => {
+  it("returns number for finite values", () => {
+    expect(readNumber(42)).toBe(42);
+    expect(readNumber(0)).toBe(0);
+    expect(readNumber(-1.5)).toBe(-1.5);
+  });
+
+  it("returns null for non-number input", () => {
+    expect(readNumber("42")).toBeNull();
+    expect(readNumber(null)).toBeNull();
+    expect(readNumber(undefined)).toBeNull();
+  });
+
+  it("returns null for NaN and Infinity", () => {
+    expect(readNumber(NaN)).toBeNull();
+    expect(readNumber(Infinity)).toBeNull();
+    expect(readNumber(-Infinity)).toBeNull();
+  });
+});
+
+describe("parseMetric", () => {
+  const validInput = {
+    name: "LCP",
+    value: 1.5,
+    rating: "good",
+    id: "v3-abc123",
+    navigationType: "navigate",
+    workspace: "default",
+    timestamp: 1700000000000,
+  };
+
+  it("parses a valid metric", () => {
+    const result = parseMetric(validInput);
+    expect(result).toEqual(validInput);
+  });
+
+  it("returns null for non-object input", () => {
+    expect(parseMetric(null)).toBeNull();
+    expect(parseMetric("string")).toBeNull();
+    expect(parseMetric(42)).toBeNull();
+  });
+
+  it("returns null when name is missing", () => {
+    expect(parseMetric({ ...validInput, name: "" })).toBeNull();
+  });
+
+  it("returns null when value is missing", () => {
+    expect(parseMetric({ ...validInput, value: null })).toBeNull();
+  });
+
+  it("returns null when rating is invalid", () => {
+    expect(parseMetric({ ...validInput, rating: "excellent" })).toBeNull();
+  });
+
+  it("accepts needs-improvement rating", () => {
+    const result = parseMetric({ ...validInput, rating: "needs-improvement" });
+    expect(result?.rating).toBe("needs-improvement");
+  });
+
+  it("accepts poor rating", () => {
+    const result = parseMetric({ ...validInput, rating: "poor" });
+    expect(result?.rating).toBe("poor");
+  });
+
+  it("returns null when id is missing", () => {
+    expect(parseMetric({ ...validInput, id: null })).toBeNull();
+  });
+
+  it("returns null when navigationType is missing", () => {
+    expect(parseMetric({ ...validInput, navigationType: "" })).toBeNull();
+  });
+
+  it("returns null when workspace is missing", () => {
+    expect(parseMetric({ ...validInput, workspace: undefined })).toBeNull();
+  });
+
+  it("returns null when timestamp is missing", () => {
+    expect(parseMetric({ ...validInput, timestamp: NaN })).toBeNull();
+  });
+});
+
+describe("percentile", () => {
+  it("returns 0 for empty array", () => {
+    expect(percentile([], 50)).toBe(0);
+  });
+
+  it("computes p50 (median)", () => {
+    expect(percentile([1, 2, 3, 4, 5], 50)).toBe(3);
+  });
+
+  it("computes p95", () => {
+    const result = percentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 95);
+    expect(result).toBeGreaterThanOrEqual(9);
+    expect(result).toBeLessThanOrEqual(10);
+  });
+
+  it("computes p75", () => {
+    const result = percentile([1, 2, 3, 4], 75);
+    expect(result).toBe(3);
+  });
+
+  it("handles single-element array", () => {
+    expect(percentile([42], 50)).toBe(42);
+    expect(percentile([42], 95)).toBe(42);
+  });
+
+  it("handles p0 and p100", () => {
+    expect(percentile([1, 2, 3], 0)).toBe(1);
+    expect(percentile([1, 2, 3], 100)).toBe(3);
+  });
+});

--- a/apps/api/src/services/web-vitals-logger.ts
+++ b/apps/api/src/services/web-vitals-logger.ts
@@ -27,24 +27,24 @@ export interface WebVitalsSummary {
   metrics: Record<string, MetricSummary>;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function readString(value: unknown): string | null {
+export function readString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const normalized = value.trim();
   return normalized ? normalized : null;
 }
 
-function readNumber(value: unknown): number | null {
+export function readNumber(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
   }
   return null;
 }
 
-function parseMetric(value: unknown): WebVitalMetric | null {
+export function parseMetric(value: unknown): WebVitalMetric | null {
   if (!isRecord(value)) return null;
 
   const name = readString(value.name);
@@ -73,7 +73,7 @@ function parseMetric(value: unknown): WebVitalMetric | null {
   return { name, value: valueNum, rating, id, navigationType, workspace, timestamp };
 }
 
-function percentile(sorted: number[], p: number): number {
+export function percentile(sorted: number[], p: number): number {
   if (sorted.length === 0) return 0;
   const index = Math.ceil((p / 100) * sorted.length) - 1;
   return sorted[Math.max(0, index)];


### PR DESCRIPTION
## Summary
- Add 9 unit tests for `errors.ts`: DataNotFoundError and FileParseError construction, name/message/suggestion/filepath fields, instanceof checks
- Export 5 private helpers from `web-vitals-logger.ts` (`isRecord`, `readString`, `readNumber`, `parseMetric`, `percentile`) and add 28 unit tests covering type guards, string/number parsing with edge cases, web vital metric validation (required fields, valid ratings), and percentile computation (p50/p75/p95, empty/single-element arrays)

## Test plan
- [x] `npx vitest run apps/api/src/services/__tests__/errors.test.ts` — 9/9 pass
- [x] `npx vitest run apps/api/src/services/__tests__/web-vitals-logger.test.ts` — 28/28 pass
- [x] `make check` — all passed