### PR TITLE
test: add 34 unit tests for search_text.ts pure function helpers

### DIFF
--- a/packages/convex/convex/__tests__/search-text-helpers.test.ts
+++ b/packages/convex/convex/__tests__/search-text-helpers.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import {
+  isRecord,
+  normalizeWhitespace,
+  addScriptBoundarySpaces,
+  segmentChineseRuns,
+  toNormalizedSearchTokens,
+  toTextFragments,
+} from "../search_text.js";
+
+// --- isRecord (search_text) ---
+
+describe("isRecord (search_text)", () => {
+  it("returns true for plain objects", () => {
+    expect(isRecord({})).toBe(true);
+  });
+
+  it("returns false for null", () => {
+    expect(isRecord(null)).toBe(false);
+  });
+
+  it("returns true for arrays (no Array.isArray check)", () => {
+    // This isRecord does NOT exclude arrays, matching the analyze.ts pattern
+    expect(isRecord([])).toBe(true);
+  });
+
+  it("returns false for primitives", () => {
+    expect(isRecord("str")).toBe(false);
+    expect(isRecord(42)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
+  });
+});
+
+// --- normalizeWhitespace ---
+
+describe("normalizeWhitespace", () => {
+  it("collapses multiple spaces into one", () => {
+    expect(normalizeWhitespace("hello   world")).toBe("hello world");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(normalizeWhitespace("  hello  ")).toBe("hello");
+  });
+
+  it("handles tabs and newlines", () => {
+    expect(normalizeWhitespace("hello\t\nworld")).toBe("hello world");
+  });
+
+  it("returns empty string for whitespace-only input", () => {
+    expect(normalizeWhitespace("   ")).toBe("");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(normalizeWhitespace("")).toBe("");
+  });
+});
+
+// --- addScriptBoundarySpaces ---
+
+describe("addScriptBoundarySpaces", () => {
+  it("adds space between CJK and Latin characters", () => {
+    expect(addScriptBoundarySpaces("销售Sales")).toBe("销售 Sales");
+    expect(addScriptBoundarySpaces("Sales销售")).toBe("Sales 销售");
+  });
+
+  it("leaves same-script text unchanged", () => {
+    expect(addScriptBoundarySpaces("hello world")).toBe("hello world");
+    expect(addScriptBoundarySpaces("你好世界")).toBe("你好世界");
+  });
+
+  it("adds spaces at multiple boundaries", () => {
+    expect(addScriptBoundarySpaces("CNC机床销售Sales")).toBe("CNC 机床销售 Sales");
+  });
+
+  it("handles empty string", () => {
+    expect(addScriptBoundarySpaces("")).toBe("");
+  });
+});
+
+// --- segmentChineseRuns ---
+
+describe("segmentChineseRuns", () => {
+  it("segments long Chinese runs into words", () => {
+    const result = segmentChineseRuns("机床行业销售经理");
+    // Should contain the original run plus segmented words
+    expect(result).toContain("机床行业销售经理");
+  });
+
+  it("leaves short Chinese text (under 3 chars) unchanged", () => {
+    expect(segmentChineseRuns("你好")).toBe("你好");
+  });
+
+  it("leaves non-Chinese text unchanged", () => {
+    expect(segmentChineseRuns("hello world")).toBe("hello world");
+  });
+
+  it("handles mixed content", () => {
+    const result = segmentChineseRuns("销售经理 3年经验");
+    expect(result).toContain("销售经理");
+  });
+
+  it("handles empty string", () => {
+    expect(segmentChineseRuns("")).toBe("");
+  });
+});
+
+// --- toNormalizedSearchTokens ---
+
+describe("toNormalizedSearchTokens", () => {
+  it("normalizes, deduplicates, and filters tokens", () => {
+    const result = toNormalizedSearchTokens(["  CNC  ", "cnc", "  Sales  ", "A"]);
+    expect(result).toEqual(["cnc", "sales"]);
+  });
+
+  it("filters out tokens shorter than 2 chars", () => {
+    expect(toNormalizedSearchTokens(["A", "AB", "C"])).toEqual(["ab"]);
+  });
+
+  it("returns empty array for undefined input", () => {
+    expect(toNormalizedSearchTokens(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for empty array input", () => {
+    expect(toNormalizedSearchTokens([])).toEqual([]);
+  });
+
+  it("lowercases all tokens", () => {
+    expect(toNormalizedSearchTokens(["CNC", "Fanuc"])).toEqual(["cnc", "fanuc"]);
+  });
+});
+
+// --- toTextFragments ---
+
+describe("toTextFragments", () => {
+  it("extracts string fragments", () => {
+    expect(toTextFragments("hello")).toEqual(["hello"]);
+  });
+
+  it("normalizes whitespace in strings", () => {
+    expect(toTextFragments("  hello   world  ")).toEqual(["hello world"]);
+  });
+
+  it("returns empty for empty/whitespace strings", () => {
+    expect(toTextFragments("")).toEqual([]);
+    expect(toTextFragments("   ")).toEqual([]);
+  });
+
+  it("converts numbers to strings", () => {
+    expect(toTextFragments(42)).toEqual(["42"]);
+    expect(toTextFragments(0)).toEqual(["0"]);
+  });
+
+  it("rejects NaN and Infinity", () => {
+    expect(toTextFragments(NaN)).toEqual([]);
+    expect(toTextFragments(Infinity)).toEqual([]);
+  });
+
+  it("converts booleans to strings", () => {
+    expect(toTextFragments(true)).toEqual(["true"]);
+    expect(toTextFragments(false)).toEqual(["false"]);
+  });
+
+  it("returns empty for null and undefined", () => {
+    expect(toTextFragments(null)).toEqual([]);
+    expect(toTextFragments(undefined)).toEqual([]);
+  });
+
+  it("recursively flattens arrays", () => {
+    expect(toTextFragments(["a", "b", "c"])).toEqual(["a", "b", "c"]);
+  });
+
+  it("recursively extracts from nested objects (sorted keys)", () => {
+    const result = toTextFragments({ b: "x", a: "y" });
+    expect(result).toEqual(["y", "x"]); // keys sorted: a before b
+  });
+
+  it("handles deeply nested structures", () => {
+    const result = toTextFragments({ items: ["a", { name: "b" }] });
+    expect(result).toEqual(["a", "b"]);
+  });
+
+  it("returns empty for unsupported types", () => {
+    expect(toTextFragments(() => {})).toEqual([]);
+    expect(toTextFragments(Symbol("x"))).toEqual([]);
+  });
+});

--- a/packages/convex/convex/search_text.ts
+++ b/packages/convex/convex/search_text.ts
@@ -26,11 +26,11 @@ const EXCLUDED_KEYS = new Set([
 
 type UnknownRecord = Record<string, unknown>;
 
-function isRecord(value: unknown): value is UnknownRecord {
+export function isRecord(value: unknown): value is UnknownRecord {
     return typeof value === "object" && value !== null;
 }
 
-function normalizeWhitespace(value: string): string {
+export function normalizeWhitespace(value: string): string {
     return value.replace(/\s+/g, " ").trim();
 }
 
@@ -38,7 +38,7 @@ const CJK_RANGE = "\\u4e00-\\u9fff\\u3400-\\u4dbf";
 const CJK_CHAR = `[${CJK_RANGE}]`;
 const ASCII_WORD = "[a-zA-Z0-9]";
 
-function addScriptBoundarySpaces(text: string): string {
+export function addScriptBoundarySpaces(text: string): string {
     return text
         .replace(new RegExp(`(${CJK_CHAR})(${ASCII_WORD})`, "g"), "$1 $2")
         .replace(new RegExp(`(${ASCII_WORD})(${CJK_CHAR})`, "g"), "$1 $2");
@@ -49,7 +49,7 @@ const CJK_SEGMENTER = new (Intl as unknown as { Segmenter: new (locale: string, 
     { granularity: "word" },
 );
 
-function segmentChineseRuns(text: string): string {
+export function segmentChineseRuns(text: string): string {
     return text.replace(
         /[\u4e00-\u9fff\u3400-\u4dbf]{3,}/g,
         (run) => {
@@ -64,7 +64,7 @@ function segmentChineseRuns(text: string): string {
     );
 }
 
-function toNormalizedSearchTokens(values: readonly string[] | undefined): string[] {
+export function toNormalizedSearchTokens(values: readonly string[] | undefined): string[] {
     if (!Array.isArray(values) || values.length === 0) {
         return [];
     }
@@ -129,7 +129,7 @@ export function mergeSearchTextWithIngestData(
     return appendMissingSearchTokens(existingSearchText, buildIngestSearchTokens(options));
 }
 
-function toTextFragments(value: unknown): string[] {
+export function toTextFragments(value: unknown): string[] {
     if (value === null || value === undefined) {
         return [];
     }


### PR DESCRIPTION
## Summary
- Export 6 private pure functions from `packages/convex/convex/search_text.ts`: `isRecord`, `normalizeWhitespace`, `addScriptBoundarySpaces`, `segmentChineseRuns`, `toNormalizedSearchTokens`, `toTextFragments`
- 34 tests covering whitespace normalization, CJK/Latin boundary spacing, Chinese text segmentation, search token deduplication/filtering, and recursive text fragment extraction

## Test plan
- [x] `npx vitest run packages/convex/convex/__tests__/search-text-helpers.test.ts` — 34/34 pass
- [x] `make check` — all checks pass