### PR TITLE
test: add 18 unit tests for resume_tasks.ts pure function helpers

### DIFF
--- a/packages/convex/convex/__tests__/resume-tasks-helpers.test.ts
+++ b/packages/convex/convex/__tests__/resume-tasks-helpers.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  mergeTags,
+  normalizeOptionalPositiveInt,
+  shallowEqualNumberRecord,
+  shouldScheduleIngest,
+} from "../resume_tasks.js";
+
+// --- mergeTags ---
+
+describe("mergeTags", () => {
+  it("merges and deduplicates tags", () => {
+    expect(mergeTags(["a", "b"], ["b", "c"])).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles empty existing", () => {
+    expect(mergeTags([], ["a", "b"])).toEqual(["a", "b"]);
+  });
+
+  it("handles empty incoming", () => {
+    expect(mergeTags(["a", "b"], [])).toEqual(["a", "b"]);
+  });
+
+  it("handles both empty", () => {
+    expect(mergeTags([], [])).toEqual([]);
+  });
+
+  it("preserves order (existing first, then new)", () => {
+    expect(mergeTags(["a"], ["b"])).toEqual(["a", "b"]);
+  });
+});
+
+// --- normalizeOptionalPositiveInt ---
+
+describe("normalizeOptionalPositiveInt", () => {
+  it("returns truncated positive integer", () => {
+    expect(normalizeOptionalPositiveInt(5)).toBe(5);
+    expect(normalizeOptionalPositiveInt(5.9)).toBe(5);
+  });
+
+  it("returns undefined for non-positive values", () => {
+    expect(normalizeOptionalPositiveInt(0)).toBeUndefined();
+    expect(normalizeOptionalPositiveInt(-1)).toBeUndefined();
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(normalizeOptionalPositiveInt(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for non-finite values", () => {
+    expect(normalizeOptionalPositiveInt(NaN)).toBeUndefined();
+    expect(normalizeOptionalPositiveInt(Infinity)).toBeUndefined();
+  });
+});
+
+// --- shallowEqualNumberRecord ---
+
+describe("shallowEqualNumberRecord", () => {
+  it("returns true for equal records", () => {
+    expect(shallowEqualNumberRecord({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true);
+  });
+
+  it("returns true for undefined a when b is empty", () => {
+    expect(shallowEqualNumberRecord(undefined, {})).toBe(true);
+  });
+
+  it("returns false for undefined a when b is non-empty", () => {
+    expect(shallowEqualNumberRecord(undefined, { a: 1 })).toBe(false);
+  });
+
+  it("returns false for different values", () => {
+    expect(shallowEqualNumberRecord({ a: 1 }, { a: 2 })).toBe(false);
+  });
+
+  it("returns false for different keys", () => {
+    expect(shallowEqualNumberRecord({ a: 1 }, { b: 1 })).toBe(false);
+  });
+
+  it("returns false for different lengths", () => {
+    expect(shallowEqualNumberRecord({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+  });
+});
+
+// --- shouldScheduleIngest ---
+
+describe("shouldScheduleIngest", () => {
+  it("returns true when no restore state", () => {
+    expect(shouldScheduleIngest(undefined)).toBe(true);
+  });
+
+  it("returns true when ingestData is undefined", () => {
+    expect(shouldScheduleIngest({})).toBe(true);
+  });
+
+  it("returns false when ingestData exists", () => {
+    expect(shouldScheduleIngest({ ingestData: {} as any })).toBe(false);
+  });
+});

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -13,7 +13,7 @@ import { resolveDiagnosticsSourceKeyForResume } from "./resumes";
 const DEFAULT_WORKER_HEALTH_FRESHNESS_MS = 15_000;
 const DEFAULT_STALE_PENDING_MS = 180_000;
 
-function mergeTags(existing: string[], incoming: string[]): string[] {
+export function mergeTags(existing: string[], incoming: string[]): string[] {
     return Array.from(new Set([...existing, ...incoming]));
 }
 
@@ -43,7 +43,7 @@ function applyParsedAgePatch(
     patch.age = parsedAge;
 }
 
-function normalizeOptionalPositiveInt(value: number | undefined): number | undefined {
+export function normalizeOptionalPositiveInt(value: number | undefined): number | undefined {
     if (typeof value !== "number" || !Number.isFinite(value)) {
         return undefined;
     }
@@ -54,7 +54,7 @@ function normalizeOptionalPositiveInt(value: number | undefined): number | undef
     return truncated;
 }
 
-type RestoreState = {
+export type RestoreState = {
     crawledAt?: number;
     isArchived?: boolean;
     archivedAt?: number;
@@ -85,7 +85,7 @@ function resolveStoredSearchText(
     return baseText;
 }
 
-function shallowEqualNumberRecord(
+export function shallowEqualNumberRecord(
     a: Record<string, number> | undefined,
     b: Record<string, number>,
 ): boolean {
@@ -101,7 +101,7 @@ function shallowEqualNumberRecord(
     return true;
 }
 
-function shouldScheduleIngest(restoreState: RestoreState | undefined): boolean {
+export function shouldScheduleIngest(restoreState: RestoreState | undefined): boolean {
     return restoreState?.ingestData === undefined;
 }
 


### PR DESCRIPTION
## Summary
- Export 4 private pure functions from `packages/convex/convex/resume_tasks.ts`: `mergeTags`, `normalizeOptionalPositiveInt`, `shallowEqualNumberRecord`, `shouldScheduleIngest`
- Also export `RestoreState` type
- 18 tests covering tag merging, positive integer normalization, record equality, and ingest scheduling logic

## Test plan
- [x] `npx vitest run packages/convex/convex/__tests__/resume-tasks-helpers.test.ts` — 18/18 pass
- [x] `make check` — all checks pass