### PR TITLE
fix: infer experienceLevel from years when keyword detection fails

### DIFF
--- a/apps/api/src/services/__tests__/ingest-compute-service.test.ts
+++ b/apps/api/src/services/__tests__/ingest-compute-service.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { inferExperienceLevelFromYears } from "../ingest-compute-service.js";
+
+describe("inferExperienceLevelFromYears", () => {
+  it("returns senior for 7+ years", () => {
+    expect(inferExperienceLevelFromYears(7)).toBe("senior");
+    expect(inferExperienceLevelFromYears(10)).toBe("senior");
+    expect(inferExperienceLevelFromYears(30)).toBe("senior");
+  });
+
+  it("returns mid for 3-6 years", () => {
+    expect(inferExperienceLevelFromYears(3)).toBe("mid");
+    expect(inferExperienceLevelFromYears(5)).toBe("mid");
+    expect(inferExperienceLevelFromYears(6)).toBe("mid");
+  });
+
+  it("returns junior for 0-2 years", () => {
+    expect(inferExperienceLevelFromYears(0)).toBe("junior");
+    expect(inferExperienceLevelFromYears(1)).toBe("junior");
+    expect(inferExperienceLevelFromYears(2)).toBe("junior");
+  });
+});

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -498,7 +498,13 @@ export class IngestComputeService {
     const primaryRuleScore = scoreValues.length > 0 ? Math.max(...scoreValues) : 0;
 
     // 5. Compute experienceLevel
-    const experienceLevel = this.computeExperienceLevel(evidenceText);
+    let experienceLevel = this.computeExperienceLevel(evidenceText);
+
+    // Fallback: when keyword signals are ambiguous (e.g. Seek EN resumes with
+    // generic titles lacking seniority keywords), infer from total years.
+    if (experienceLevel === "unknown" && index.experienceYears !== null) {
+      experienceLevel = inferExperienceLevelFromYears(index.experienceYears);
+    }
 
     // 6. Get skills version
     const skillsVersion = this.skillsKnowledgeService.getVersion();
@@ -1416,3 +1422,14 @@ export class IngestComputeService {
 
 // Singleton
 export const ingestComputeService = new IngestComputeService();
+
+/**
+ * Infer experience level from total years of work experience.
+ * Used as fallback when keyword-based detection returns "unknown"
+ * (e.g. Seek EN resumes with generic titles like "CNC Programmer").
+ */
+export function inferExperienceLevelFromYears(years: number): string {
+  if (years >= 7) return "senior";
+  if (years >= 3) return "mid";
+  return "junior";
+}


### PR DESCRIPTION
## Summary
- When `computeExperienceLevel` returns "unknown" (e.g. Seek EN resumes with generic titles like "CNC Programmer"), fall back to inferring from `experienceYears` computed from workHistory date ranges
- Thresholds: >=7 years → senior, >=3 → mid, >0 → junior
- Export `inferExperienceLevelFromYears` as standalone pure function with 3 unit tests

## Root cause
Seek talentsearch list-page resumes only have `companyName` + `jobTitle` in their evidence text (no description). Generic titles without seniority keywords (Manager, Senior, etc.) produce no keyword matches, so `computeExperienceLevel` returns "unknown". The keywords are already bilingual — the issue is missing description text, not missing English keywords.

## Test plan
- [x] `npx vitest run apps/api/src/services/__tests__/ingest-compute-service.test.ts` — 3/3 pass
- [x] `make check` — all checks pass