### PR TITLE
fix: upgrade Seek UUID profile URLs to talentsearch name-search in exports

### DIFF
--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { ExportService } from "./export-service";
 
 import type { ResumeExportEntry, ExportBatchMeta } from "./export-service";
+import { buildSeekNameSearchUrl } from "@trends/shared";
 
 function buildEntry(age: string | undefined): ResumeExportEntry {
   return {
@@ -300,12 +301,33 @@ describe("ExportService", () => {
     expect(headers).toContain("Reference Note");
   });
 
-  it("keeps non-Job5156 profile URLs unchanged during export", async () => {
+  it("upgrades Seek UUID profile URLs to talentsearch name-search URLs in export", async () => {
     const service = new ExportService();
     const entry: ResumeExportEntry = {
       ...buildEntry("27"),
       resume: {
         ...buildEntry("27").resume,
+        name: "KHA LEONG CH'NG",
+        source: "hk.employer.seek.com",
+        profileUrl: "https://hk.employer.seek.com/candidates/891b1444-efa1-11e3-99bd-5e95a6174ad3",
+      },
+    };
+
+    const file = await service.exportResumes("csv", [entry]);
+    const csv = file.content.toString("utf8");
+    const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
+
+    const expectedUrl = buildSeekNameSearchUrl("KHA LEONG CH'NG", "MY");
+    expect(parsed.data[0]?.profileUrl).toBe(expectedUrl);
+  });
+
+  it("keeps Seek UUID profile URL when candidate name is missing", async () => {
+    const service = new ExportService();
+    const entry: ResumeExportEntry = {
+      ...buildEntry("27"),
+      resume: {
+        ...buildEntry("27").resume,
+        name: undefined,
         source: "hk.employer.seek.com",
         profileUrl: "https://hk.employer.seek.com/candidates/503033454",
       },

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -2,6 +2,7 @@ import ExcelJS from "exceljs";
 import Papa from "papaparse";
 import {
   buildWorkHistoryEntryText,
+  inferSeekMarket,
   normalizeProfileUrlForDisplay,
   type ResumeWorkHistoryItem as SharedResumeWorkHistoryItem,
 } from "@trends/shared";
@@ -296,7 +297,15 @@ function toRow(
       .join(", "),
     roleEvidence: formatRoleEvidence(entry.resume.ingestData?.roleSignals),
     matchedWorkEntries: formatMatchedWorkEntries(entry.resume.ingestData?.roleSignals),
-    profileUrl: normalizeProfileUrlForDisplay(entry.resume.profileUrl, entry.resume.source),
+    profileUrl: normalizeProfileUrlForDisplay(
+      entry.resume.profileUrl,
+      entry.resume.source,
+      {
+        name: entry.resume.name,
+        market: entry.resume.source?.includes("seek") ? inferSeekMarket(entry.resume.source) : undefined,
+        roleTitles: entry.resume.workHistory?.[0]?.jobTitle,
+      }
+    ),
     workHistory,
     selfIntro: normalizeString(entry.resume.selfIntro),
     aiSummary: normalizeString(entry.match?.summary),


### PR DESCRIPTION
## Summary
- Export CSV/XLSX `profileUrl` for Seek.com resumes now produces clickable talentsearch URLs instead of session-bound UUID employer portal URLs
- Passes `{ name, market, roleTitles }` options to `normalizeProfileUrlForDisplay` so the shared function can build name-search URLs from candidate data
- Adds 2 tests: Seek URL upgrade with name, and fallback to UUID when name is missing

## Before
`https://hk.employer.seek.com/candidates/891b1444-efa1-11e3-99bd-5e95a6174ad3`

## After
`https://hk.employer.seek.com/talentsearch/profiles/search?searchQuery=KHA%20LEONG%20CH%27NG&market=MY&pageNumber=1`

## Test plan
- [x] `vitest run export-service.test.ts` — 15/15 pass (was 13)
- [x] `make check` — all pass
- [ ] Manual: export a Seek resume CSV and verify profileUrl is a talentsearch URL