### PR TITLE
test: add 28 unit tests for filter-preset-service and data-service

### DIFF
--- a/apps/api/src/services/__tests__/data-service.test.ts
+++ b/apps/api/src/services/__tests__/data-service.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import { DataService, STOPWORDS } from "../data-service.js";
+
+/**
+ * Tests for DataService.extractWordsFromTitle — a pure function
+ * that extracts keywords from news/RSS titles. Imports the real
+ * implementation and STOPWORDS from data-service.ts to avoid
+ * test-source drift.
+ */
+
+const ds = new DataService();
+
+describe("extractWordsFromTitle", () => {
+  it("extracts Chinese keywords from a title", () => {
+    const words = ds.extractWordsFromTitle("新能源汽车销量创历史新高");
+    // Continuous Chinese text is extracted as one block (no word segmentation)
+    expect(words).toContain("新能源汽车销量创历史新高");
+    expect(words).toHaveLength(1);
+  });
+
+  it("extracts English keywords from a title", () => {
+    const words = ds.extractWordsFromTitle("OpenAI releases GPT-5 model");
+    expect(words).toContain("OpenAI");
+    expect(words).toContain("releases");
+    expect(words).toContain("model");
+  });
+
+  it("does not split continuous Chinese text on embedded stopwords", () => {
+    const words = ds.extractWordsFromTitle("中国的新能源汽车已经发布");
+    // The entire string is one continuous Chinese block; stopwords only filter exact matches
+    expect(words).toContain("中国的新能源汽车已经发布");
+    expect(words).not.toContain("的"); // standalone stopword would be filtered
+  });
+
+  it("filters standalone stopwords from space-separated Chinese", () => {
+    const words = ds.extractWordsFromTitle("关注 最新 动态");
+    expect(words).not.toContain("关注");
+    expect(words).not.toContain("最新");
+    expect(words).toContain("动态");
+  });
+
+  it("removes URLs from title before extraction", () => {
+    const words = ds.extractWordsFromTitle("breaking news https://example.com/article/123 more text");
+    expect(words).not.toContainEqual(expect.stringContaining("example"));
+    expect(words).toContain("breaking");
+    expect(words).toContain("news");
+    expect(words).toContain("more");
+    expect(words).toContain("text");
+  });
+
+  it("removes bracketed content from title", () => {
+    const words = ds.extractWordsFromTitle("经济 [视频] 增长报告");
+    expect(words).not.toContain("视频");
+    expect(words).toContain("经济");
+    expect(words).toContain("增长报告");
+  });
+
+  it("removes Chinese punctuation marks", () => {
+    const words = ds.extractWordsFromTitle("「深度」人工智能发展《白皮书》发布");
+    // After punctuation removal, "深度" merges with "人工智能发展" into one block
+    // "发布" is a stopword but part of the continuous block, not filtered
+    expect(words).toContain("深度人工智能发展白皮书发布");
+  });
+
+  it("returns empty array for title with only stopwords", () => {
+    const words = ds.extractWordsFromTitle("的 了 在 是");
+    expect(words).toEqual([]);
+  });
+
+  it("returns empty array for empty string", () => {
+    const words = ds.extractWordsFromTitle("");
+    expect(words).toEqual([]);
+  });
+
+  it("handles mixed Chinese and English title", () => {
+    const words = ds.extractWordsFromTitle("CNC数控机床的AI应用趋势");
+    expect(words).toContain("CNC");
+    // "的" merges with preceding Chinese into one block "数控机床的" — stopword filter is exact-match only
+    expect(words).toContain("数控机床的");
+    expect(words).toContain("AI");
+    expect(words).toContain("应用趋势");
+  });
+
+  it("respects minLength parameter", () => {
+    const words = ds.extractWordsFromTitle("AI CNC 机床", 3);
+    expect(words).not.toContain("AI");   // length 2, below minLength
+    expect(words).toContain("CNC");      // length 3, meets minLength
+    expect(words).not.toContain("机床"); // length 2 Chinese chars, below minLength
+  });
+
+  it("handles title that is only a URL", () => {
+    const words = ds.extractWordsFromTitle("https://example.com/news");
+    expect(words).toEqual([]);
+  });
+
+  it("preserves alphanumeric English tokens", () => {
+    const words = ds.extractWordsFromTitle("GPT4o and Claude3 models released");
+    expect(words).toContain("GPT4o");
+    expect(words).toContain("and");
+    expect(words).toContain("Claude3");
+    expect(words).toContain("models");
+    expect(words).toContain("released");
+  });
+
+  it("extracts keywords from realistic news title with punctuation", () => {
+    const words = ds.extractWordsFromTitle("【突发】特朗普宣布对华加征关税，中方回应");
+    // After 【】 removal, "突发" merges with the following text into one Chinese block
+    // "中方回应" is a continuous Chinese block — "回应" is a stopword but the regex
+    // matches continuous Chinese sequences first, so the whole block passes.
+    expect(words).toContain("突发特朗普宣布对华加征关税");
+    expect(words).toContain("中方回应");
+  });
+
+  it("STOPWORDS set contains expected entries", () => {
+    expect(STOPWORDS.has("的")).toBe(true);
+    expect(STOPWORDS.has("发布")).toBe(true);
+    expect(STOPWORDS.has("关注")).toBe(true);
+    expect(STOPWORDS.has("新能源汽车")).toBe(false);
+  });
+});

--- a/apps/api/src/services/__tests__/filter-preset-service.test.ts
+++ b/apps/api/src/services/__tests__/filter-preset-service.test.ts
@@ -1,0 +1,193 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it, vi, beforeEach, afterAll } from "vitest";
+
+import { FilterPresetService } from "../filter-preset-service";
+
+const FIXTURE_DIR = path.join(__dirname, "__fixtures__", "filter-preset-service");
+
+function writeFixture(content: string): void {
+  fs.mkdirSync(FIXTURE_DIR, { recursive: true });
+  fs.mkdirSync(path.join(FIXTURE_DIR, "config", "resume"), { recursive: true });
+  fs.writeFileSync(
+    path.join(FIXTURE_DIR, "config", "resume", "filter-presets.json5"),
+    content,
+    "utf8"
+  );
+}
+
+function removeFixture(): void {
+  fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+}
+
+const SAMPLE_CONFIG = `{
+  presets: [
+    {
+      id: "sales-entry",
+      name: "Sales Entry",
+      category: "sales",
+      filters: {
+        minExperience: 0,
+        maxExperience: 3,
+        education: ["bachelor"],
+        salaryRange: { min: 5000, max: 10000 }
+      }
+    },
+    {
+      id: "sales-senior",
+      name: "Sales Senior",
+      category: "sales",
+      filters: {
+        minExperience: 5,
+        maxExperience: null,
+        education: ["bachelor", "master"],
+        salaryRange: { min: 15000, max: 35000 }
+      }
+    },
+    {
+      id: "engineer-entry",
+      name: "Engineer Entry",
+      category: "engineering",
+      filters: {
+        minExperience: 0,
+        maxExperience: 3
+      }
+    }
+  ],
+  categories: [
+    { id: "sales", name: "Sales", icon: "briefcase" },
+    { id: "engineering", name: "Engineering", icon: "gear" }
+  ]
+}`;
+
+describe("FilterPresetService", () => {
+  beforeEach(() => {
+    removeFixture();
+  });
+
+  afterAll(() => {
+    removeFixture();
+  });
+
+  it("returns empty presets and categories when config file does not exist", () => {
+    const service = new FilterPresetService(FIXTURE_DIR);
+    expect(service.listPresets()).toEqual([]);
+    expect(service.listCategories()).toEqual([]);
+  });
+
+  it("loads presets from config file", () => {
+    writeFixture(SAMPLE_CONFIG);
+    const service = new FilterPresetService(FIXTURE_DIR);
+
+    const presets = service.listPresets();
+    expect(presets).toHaveLength(3);
+    expect(presets[0]?.id).toBe("sales-entry");
+    expect(presets[1]?.id).toBe("sales-senior");
+    expect(presets[2]?.id).toBe("engineer-entry");
+  });
+
+  it("filters presets by category", () => {
+    writeFixture(SAMPLE_CONFIG);
+    const service = new FilterPresetService(FIXTURE_DIR);
+
+    const salesPresets = service.listPresets("sales");
+    expect(salesPresets).toHaveLength(2);
+    expect(salesPresets.every((p) => p.category === "sales")).toBe(true);
+  });
+
+  it("returns empty array for unknown category", () => {
+    writeFixture(SAMPLE_CONFIG);
+    const service = new FilterPresetService(FIXTURE_DIR);
+
+    expect(service.listPresets("nonexistent")).toEqual([]);
+  });
+
+  it("gets a preset by id", () => {
+    writeFixture(SAMPLE_CONFIG);
+    const service = new FilterPresetService(FIXTURE_DIR);
+
+    const preset = service.getPreset("sales-senior");
+    expect(preset?.name).toBe("Sales Senior");
+    expect(preset?.filters.minExperience).toBe(5);
+    expect(preset?.filters.maxExperience).toBeNull();
+  });
+
+  it("returns undefined for unknown preset id", () => {
+    writeFixture(SAMPLE_CONFIG);
+    const service = new FilterPresetService(FIXTURE_DIR);
+
+    expect(service.getPreset("nonexistent")).toBeUndefined();
+  });
+
+  it("loads categories from config file", () => {
+    writeFixture(SAMPLE_CONFIG);
+    const service = new FilterPresetService(FIXTURE_DIR);
+
+    const categories = service.listCategories();
+    expect(categories).toHaveLength(2);
+    expect(categories[0]?.id).toBe("sales");
+    expect(categories[1]?.id).toBe("engineering");
+  });
+
+  it("computes stats grouped by category", () => {
+    writeFixture(SAMPLE_CONFIG);
+    const service = new FilterPresetService(FIXTURE_DIR);
+
+    const stats = service.getStats();
+    expect(stats.total).toBe(3);
+    expect(stats.byCategory).toEqual({ sales: 2, engineering: 1 });
+  });
+
+  it("caches config after first load", () => {
+    writeFixture(SAMPLE_CONFIG);
+    const service = new FilterPresetService(FIXTURE_DIR);
+
+    const first = service.listPresets();
+    // Modify the file after first load
+    writeFixture(`{ presets: [], categories: [] }`);
+    const second = service.listPresets();
+
+    // Should return cached result, not re-read the modified file
+    expect(second).toEqual(first);
+    expect(second).toHaveLength(3);
+  });
+
+  it("clears cache and re-reads config", () => {
+    writeFixture(SAMPLE_CONFIG);
+    const service = new FilterPresetService(FIXTURE_DIR);
+
+    service.listPresets();
+    writeFixture(`{ presets: [], categories: [] }`);
+    service.clearCache();
+
+    const presets = service.listPresets();
+    expect(presets).toHaveLength(0);
+  });
+
+  it("returns empty stats when no config file exists", () => {
+    const service = new FilterPresetService(FIXTURE_DIR);
+
+    const stats = service.getStats();
+    expect(stats.total).toBe(0);
+    expect(stats.byCategory).toEqual({});
+  });
+
+  it("preserves null maxExperience in preset filters", () => {
+    writeFixture(SAMPLE_CONFIG);
+    const service = new FilterPresetService(FIXTURE_DIR);
+
+    const preset = service.getPreset("sales-senior");
+    expect(preset?.filters.maxExperience).toBeNull();
+  });
+
+  it("handles preset with missing optional filter fields", () => {
+    writeFixture(SAMPLE_CONFIG);
+    const service = new FilterPresetService(FIXTURE_DIR);
+
+    const preset = service.getPreset("engineer-entry");
+    expect(preset?.filters.minExperience).toBe(0);
+    expect(preset?.filters.maxExperience).toBe(3);
+    expect(preset?.filters.education).toBeUndefined();
+    expect(preset?.filters.salaryRange).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/data-service.ts
+++ b/apps/api/src/services/data-service.ts
@@ -6,7 +6,7 @@ import { formatDateInTimezone, formatIsoOffsetInTimezone } from "./timezone.js";
 
 import type { Topic, TrendItem, SearchResultItem, RssItem } from "../types/data.js";
 
-const STOPWORDS = new Set([
+export const STOPWORDS = new Set([
   "的", "了", "在", "是", "我", "有", "和", "就", "不", "人", "都", "一",
   "一个", "上", "也", "很", "到", "说", "要", "去", "你", "会", "着", "没有",
   "看", "好", "自己", "这", "那", "来", "被", "与", "为", "对", "将", "从",
@@ -384,7 +384,7 @@ export class DataService {
     return result;
   }
 
-  private extractWordsFromTitle(title: string, minLength = 2): string[] {
+  extractWordsFromTitle(title: string, minLength = 2): string[] {
     let text = title;
     text = text.replace(/http[s]?:\/\/\S+/g, "");
     text = text.replace(/\[.*?\]/g, "");


### PR DESCRIPTION
## Summary
- 13 unit tests for `FilterPresetService`: listPresets, getPreset, listCategories, getStats, caching, missing config, null maxExperience
- 15 unit tests for `DataService.extractWordsFromTitle`: Chinese/English keyword extraction, stopword filtering, URL removal, punctuation stripping, minLength parameter, mixed-language titles
- Export `STOPWORDS` and `extractWordsFromTitle` from `data-service.ts` for testability (was private)

## Test plan
- [x] `vitest run filter-preset-service.test.ts data-service.test.ts` — 28/28 pass
- [x] `make check` — all pass