### PR TITLE
test: add 10 unit tests for ai-chat-client, resume-id, and query-parser

### DIFF
--- a/apps/api/src/services/__tests__/ai-chat-client.test.ts
+++ b/apps/api/src/services/__tests__/ai-chat-client.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { extractModelName } from "../ai-chat-client.js";
+
+describe("extractModelName", () => {
+  it("strips provider prefix from slash-delimited model IDs", () => {
+    expect(extractModelName("openai/gpt-4o")).toBe("gpt-4o");
+    expect(extractModelName("anthropic/claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
+    expect(extractModelName("deepseek/deepseek-r1")).toBe("deepseek-r1");
+  });
+
+  it("returns the full string when no slash is present", () => {
+    expect(extractModelName("gpt-4o")).toBe("gpt-4o");
+    expect(extractModelName("claude-3-opus")).toBe("claude-3-opus");
+  });
+
+  it("handles multi-segment paths after the first slash", () => {
+    expect(extractModelName("provider/v1/model-name")).toBe("v1/model-name");
+    expect(extractModelName("a/b/c")).toBe("b/c");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(extractModelName("")).toBe("");
+  });
+});

--- a/apps/api/src/services/__tests__/query-parser.test.ts
+++ b/apps/api/src/services/__tests__/query-parser.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSearchQuery } from "../query-parser.js";
+
+describe("parseSearchQuery", () => {
+  it("parses comma-separated keywords", () => {
+    const result = parseSearchQuery("cnc, 机床, 销售");
+    expect(result.keywords.length).toBeGreaterThanOrEqual(3);
+    expect(result.keywords).toContain("cnc");
+  });
+
+  it("lowercases keywords", () => {
+    const result = parseSearchQuery("CNC, FANUC");
+    expect(result.keywords.every((k) => k === k.toLowerCase())).toBe(true);
+  });
+
+  it("handles empty query", () => {
+    const result = parseSearchQuery("");
+    expect(result.keywords).toEqual([]);
+    expect(result.mode).toBe("AND");
+  });
+
+  it("returns OR mode for OR keyword", () => {
+    const result = parseSearchQuery("cnc OR 机床");
+    expect(result.mode).toBe("OR");
+  });
+});

--- a/apps/api/src/services/__tests__/resume-id.test.ts
+++ b/apps/api/src/services/__tests__/resume-id.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveResumeId } from "../resume-id.js";
+
+import type { ResumeItem } from "../../types/resume.js";
+
+function makeResume(overrides: Partial<ResumeItem> = {}): ResumeItem {
+  return {
+    externalId: "job5156:resume:12345",
+    name: "Test User",
+    source: "hr.job5156.com",
+    profileUrl: "https://example.com/resume",
+    workHistory: [],
+    ...overrides,
+  } as ResumeItem;
+}
+
+describe("resolveResumeId", () => {
+  it("resolves to externalId when present", () => {
+    const resume = makeResume({ externalId: "job5156:resume:999" });
+    expect(resolveResumeId(resume, 0)).toBe("job5156:resume:999");
+  });
+
+  it("falls back to name-index when no stable identity fields exist", () => {
+    const resume = makeResume({ externalId: undefined, profileUrl: undefined } as Partial<ResumeItem>);
+    const id = resolveResumeId(resume, 7);
+    expect(id).toContain("7");
+  });
+});


### PR DESCRIPTION
## Summary
- Add 4 tests for `extractModelName` (slash-delimited model ID parsing)
- Add 2 tests for `resolveResumeId` (priority chain fallback delegation)
- Add 4 tests for `parseSearchQuery` (keyword extraction with mode detection)

## Test plan
- [x] `vitest run` — 10/10 pass
- [x] `make check` — all checks pass