### PR TITLE
fix: align BFF experience filter with Convex workHistory date fallback

### DIFF
--- a/apps/api/src/services/bff-filter-utils.ts
+++ b/apps/api/src/services/bff-filter-utils.ts
@@ -11,8 +11,9 @@ import {
   normalizeResumeLocationHierarchy,
   parseSalaryRange,
   resolveResumeAnalysisSourceKey,
+  resolveExperienceYears,
 } from "@trends/shared";
-import { normalizeEducationLevel, parseExperienceYears } from "./resume-service.js";
+import { normalizeEducationLevel } from "./resume-service.js";
 
 // ---------------------------------------------------------------------------
 // Internal helpers (also extracted so tests don't need to replicate them)
@@ -92,7 +93,7 @@ export function bffMatchesResumeFilters(
 
   if (typeof filters.minExperience === "number" || typeof filters.maxExperience === "number") {
     const expStr = toStringValue(content.experience) ?? "";
-    const expYears = parseExperienceYears(expStr);
+    const expYears = resolveExperienceYears(expStr, content.workHistory);
     if (expYears === null) {
       // Unknown experience — exclude if maxExperience is set (cannot guarantee cap),
       // but skip minExperience (resume might meet the minimum).

--- a/packages/shared/src/__tests__/resume-filter-helpers.test.ts
+++ b/packages/shared/src/__tests__/resume-filter-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeEducationLevel, parseExperienceYears } from "../resume-filter-helpers.js";
+import { normalizeEducationLevel, parseExperienceYears, computeExperienceFromWorkHistory, resolveExperienceYears } from "../resume-filter-helpers.js";
 
 describe("normalizeEducationLevel", () => {
   it("normalizes Chinese education terms", () => {
@@ -68,5 +68,99 @@ describe("parseExperienceYears", () => {
     expect(parseExperienceYears(null)).toBeNull();
     expect(parseExperienceYears(undefined)).toBeNull();
     expect(parseExperienceYears("?")).toBeNull();
+  });
+});
+
+describe("computeExperienceFromWorkHistory", () => {
+  it("returns null for empty or non-array input", () => {
+    expect(computeExperienceFromWorkHistory(null)).toBeNull();
+    expect(computeExperienceFromWorkHistory(undefined)).toBeNull();
+    expect(computeExperienceFromWorkHistory([])).toBeNull();
+    expect(computeExperienceFromWorkHistory("not an array")).toBeNull();
+  });
+
+  it("returns null when no entries have parseable dates", () => {
+    expect(computeExperienceFromWorkHistory([{ years: "?" }])).toBeNull();
+    expect(computeExperienceFromWorkHistory([{ startDate: "invalid" }])).toBeNull();
+  });
+
+  it("computes years from a single entry with start and end dates", () => {
+    const result = computeExperienceFromWorkHistory([
+      { startDate: "2020-01", endDate: "2023-01" },
+    ]);
+    expect(result).toBe(3);
+  });
+
+  it("uses current date when endDate is missing", () => {
+    const result = computeExperienceFromWorkHistory([
+      { startDate: "2024-01" },
+    ]);
+    expect(result).toBeGreaterThanOrEqual(1);
+  });
+
+  it("merges overlapping date ranges", () => {
+    const result = computeExperienceFromWorkHistory([
+      { startDate: "2020-01", endDate: "2023-06" },
+      { startDate: "2022-06", endDate: "2024-01" },
+    ]);
+    // Overlapping: 2020-01 to 2024-01 = 4 years
+    expect(result).toBe(4);
+  });
+
+  it("sums non-overlapping date ranges", () => {
+    const result = computeExperienceFromWorkHistory([
+      { startDate: "2018-01", endDate: "2020-01" },
+      { startDate: "2022-01", endDate: "2024-01" },
+    ]);
+    // 2 + 2 = 4 years
+    expect(result).toBe(4);
+  });
+
+  it("handles YYYY format dates", () => {
+    const result = computeExperienceFromWorkHistory([
+      { startDate: "2020", endDate: "2023" },
+    ]);
+    expect(result).toBe(3);
+  });
+});
+
+describe("resolveExperienceYears", () => {
+  it("returns parseExperienceYears result when available", () => {
+    expect(resolveExperienceYears("5", [])).toBe(5);
+    expect(resolveExperienceYears("3-5", [])).toBe(5);
+    expect(resolveExperienceYears("应届", [])).toBe(0);
+  });
+
+  it("falls back to workHistory when experience is null", () => {
+    const result = resolveExperienceYears(null, [
+      { startDate: "2020-01", endDate: "2023-01" },
+    ]);
+    expect(result).toBe(3);
+  });
+
+  it("falls back to workHistory when experience is empty string", () => {
+    const result = resolveExperienceYears("", [
+      { startDate: "2020-01", endDate: "2023-01" },
+    ]);
+    expect(result).toBe(3);
+  });
+
+  it("falls back to workHistory when experience is unparseable", () => {
+    const result = resolveExperienceYears("?", [
+      { startDate: "2020-01", endDate: "2023-01" },
+    ]);
+    expect(result).toBe(3);
+  });
+
+  it("returns null when both experience and workHistory are unparseable", () => {
+    expect(resolveExperienceYears("", [])).toBeNull();
+    expect(resolveExperienceYears(null, [{ years: "?" }])).toBeNull();
+  });
+
+  it("prefers explicit experience value over workHistory computation", () => {
+    // If experience says "2" but workHistory shows 5 years, use 2
+    expect(resolveExperienceYears("2", [
+      { startDate: "2020-01", endDate: "2025-01" },
+    ])).toBe(2);
   });
 });

--- a/packages/shared/src/resume-filter-helpers.ts
+++ b/packages/shared/src/resume-filter-helpers.ts
@@ -57,3 +57,71 @@ export function parseExperienceYears(value: string | null | undefined): number |
   const max = match[2] ? Number(match[2]) : min;
   return Number.isNaN(max) ? null : max;
 }
+
+/**
+ * Parse date strings like "2023-06", "2023", "2023-06-15" to epoch ms.
+ */
+export function parseDateToMs(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const match = trimmed.match(/^(\d{4})(?:-(\d{1,2}))?(?:-(\d{1,2}))?$/);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = match[2] ? Number(match[2]) - 1 : 0;
+  const day = match[3] ? Number(match[3]) : 1;
+  const ms = Date.UTC(year, month, day);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * Compute total experience years from workHistory date ranges.
+ * Merges overlapping ranges to avoid double-counting.
+ * Returns null if no entries have parseable date ranges.
+ */
+export function computeExperienceFromWorkHistory(workHistory: unknown): number | null {
+  if (!Array.isArray(workHistory) || workHistory.length === 0) {
+    return null;
+  }
+  const ranges: Array<{ start: number; end: number }> = [];
+  const now = Date.now();
+  for (const entry of workHistory) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const rec = entry as Record<string, unknown>;
+    const startMs = parseDateToMs(rec.startDate);
+    const endMs = rec.endDate ? parseDateToMs(rec.endDate) : now;
+    if (startMs !== null && endMs !== null && endMs > startMs) {
+      ranges.push({ start: startMs, end: endMs });
+    }
+  }
+  if (ranges.length === 0) {
+    return null;
+  }
+  // Merge overlapping ranges
+  ranges.sort((a, b) => a.start - b.start);
+  const merged: Array<{ start: number; end: number }> = [ranges[0]];
+  for (let i = 1; i < ranges.length; i++) {
+    const last = merged[merged.length - 1];
+    if (ranges[i].start <= last.end) {
+      last.end = Math.max(last.end, ranges[i].end);
+    } else {
+      merged.push(ranges[i]);
+    }
+  }
+  const totalMs = merged.reduce((sum, r) => sum + (r.end - r.start), 0);
+  return Math.round(totalMs / (365.25 * 24 * 60 * 60 * 1000) * 10) / 10;
+}
+
+/**
+ * Resolve experience years with fallback to workHistory date ranges.
+ * If parseExperienceYears returns a value, use it.
+ * Otherwise, compute from workHistory startDate/endDate ranges.
+ */
+export function resolveExperienceYears(
+  experience: string | null | undefined,
+  workHistory: unknown,
+): number | null {
+  const parsed = parseExperienceYears(experience);
+  if (parsed !== null) return parsed;
+  return computeExperienceFromWorkHistory(workHistory);
+}


### PR DESCRIPTION
## Summary
- Add `computeExperienceFromWorkHistory`, `parseDateToMs`, and `resolveExperienceYears` to `@trends/shared` (extracted from Convex local copy in `packages/convex/convex/resumes.ts`)
- Switch `bff-filter-utils.ts` from `parseExperienceYears` to `resolveExperienceYears` so the BFF filter path falls back to computing experience from `workHistory` date ranges when `content.experience` is empty/unparseable
- Add 12 unit tests covering date parsing, overlapping range merging, and the fallback chain

## Problem
The BFF filter path (`bffMatchesResumeFilters`) only called `parseExperienceYears(content.experience)`. The Convex path uses `resolveExperienceYears` which falls back to `computeExperienceFromWorkHistory` when the experience field is empty. This divergence meant Seek resumes with `experience=""` but valid `workHistory` date ranges were treated differently across filter execution paths.

## Test plan
- [x] `packages/shared/src/__tests__/resume-filter-helpers.test.ts` — 20 tests pass (12 new)
- [x] `apps/api/src/services/__tests__/bff-filter-utils.test.ts` — 29 tests pass
- [x] `make check` — all green