### PR TITLE
test: add 61 unit tests for worker Python pure function helpers

### DIFF
--- a/apps/worker/tests/conftest.py
+++ b/apps/worker/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared fixtures for worker tests."""
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def tmp_skills_state(tmp_path: Path):
+    """Provide a temporary skills-version-state.json path and patch the module."""
+    state_file = tmp_path / "skills-version-state.json"
+    with patch("apps.worker.tasks._skills_state_path", return_value=state_file):
+        yield state_file
+
+
+@pytest.fixture
+def mock_api_base():
+    """Return a fake API base URL for HTTP-mocked tests."""
+    return "http://localhost:9999"

--- a/apps/worker/tests/test_resume_tasks.py
+++ b/apps/worker/tests/test_resume_tasks.py
@@ -1,0 +1,134 @@
+"""Unit tests for apps.worker.resume_tasks pure function helpers."""
+
+from pathlib import Path
+from typing import Any, Optional
+from unittest.mock import patch
+
+import pytest
+
+from apps.worker.resume_tasks import (
+    _read_env_var_from_file,
+    _to_positive_int,
+    _to_optional_positive_int,
+)
+
+
+# ---------------------------------------------------------------------------
+# _read_env_var_from_file
+# ---------------------------------------------------------------------------
+
+class TestReadEnvVarFromFile:
+    def test_simple_value(self, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_KEY=my_value\n")
+        assert _read_env_var_from_file(env_file, "MY_KEY") == "my_value"
+
+    def test_quoted_double(self, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text('MY_KEY="my value"\n')
+        assert _read_env_var_from_file(env_file, "MY_KEY") == "my value"
+
+    def test_quoted_single(self, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_KEY='my value'\n")
+        assert _read_env_var_from_file(env_file, "MY_KEY") == "my value"
+
+    def test_export_prefix(self, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("export MY_KEY=exported_val\n")
+        assert _read_env_var_from_file(env_file, "MY_KEY") == "exported_val"
+
+    def test_missing_key(self, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("OTHER_KEY=value\n")
+        assert _read_env_var_from_file(env_file, "MY_KEY") is None
+
+    def test_missing_file(self, tmp_path: Path):
+        missing = tmp_path / "nonexistent"
+        assert _read_env_var_from_file(missing, "MY_KEY") is None
+
+    def test_comment_lines_ignored(self, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("# comment\nMY_KEY=val\n# another\n")
+        assert _read_env_var_from_file(env_file, "MY_KEY") == "val"
+
+    def test_empty_lines_ignored(self, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("\n\nMY_KEY=val\n\n")
+        assert _read_env_var_from_file(env_file, "MY_KEY") == "val"
+
+    def test_empty_value_returns_none(self, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text('MY_KEY=""\n')
+        assert _read_env_var_from_file(env_file, "MY_KEY") is None
+
+    def test_first_match_wins(self, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_KEY=first\nMY_KEY=second\n")
+        assert _read_env_var_from_file(env_file, "MY_KEY") == "first"
+
+    def test_empty_quotes_value_returns_none(self, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_KEY=''\n")
+        assert _read_env_var_from_file(env_file, "MY_KEY") is None
+
+
+# ---------------------------------------------------------------------------
+# _to_positive_int
+# ---------------------------------------------------------------------------
+
+class TestToPositiveInt:
+    def test_valid_positive(self):
+        assert _to_positive_int(5, 10) == 5
+        assert _to_positive_int(100, 10) == 100
+
+    def test_string_number(self):
+        assert _to_positive_int("42", 10) == 42
+
+    def test_zero_returns_fallback(self):
+        assert _to_positive_int(0, 10) == 10
+
+    def test_negative_returns_fallback(self):
+        assert _to_positive_int(-5, 10) == 10
+
+    def test_none_returns_fallback(self):
+        assert _to_positive_int(None, 10) == 10
+
+    def test_non_numeric_string_returns_fallback(self):
+        assert _to_positive_int("abc", 10) == 10
+
+    def test_float_truncates(self):
+        # Python int(3.7) == 3 — truncation, not error
+        assert _to_positive_int(3.7, 10) == 3
+
+    def test_float_string_returns_fallback(self):
+        assert _to_positive_int("3.7", 10) == 10
+
+
+# ---------------------------------------------------------------------------
+# _to_optional_positive_int
+# ---------------------------------------------------------------------------
+
+class TestToOptionalPositiveInt:
+    def test_valid_positive(self):
+        assert _to_optional_positive_int(5) == 5
+        assert _to_optional_positive_int(100) == 100
+
+    def test_string_number(self):
+        assert _to_optional_positive_int("42") == 42
+
+    def test_zero_returns_none(self):
+        assert _to_optional_positive_int(0) is None
+
+    def test_negative_returns_none(self):
+        assert _to_optional_positive_int(-5) is None
+
+    def test_none_returns_none(self):
+        assert _to_optional_positive_int(None) is None
+
+    def test_non_numeric_string_returns_none(self):
+        assert _to_optional_positive_int("abc") is None
+
+    def test_float_truncates(self):
+        # Python int(3.7) == 3 — truncation, not error
+        assert _to_optional_positive_int(3.7) == 3

--- a/apps/worker/tests/test_tasks.py
+++ b/apps/worker/tests/test_tasks.py
@@ -1,0 +1,348 @@
+"""Unit tests for apps.worker.tasks pure function helpers."""
+
+import json
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+from apps.worker.tasks import (
+    normalize_summary_channel,
+    normalize_summary_period,
+    _worker_api_base_url,
+    _load_last_skills_version,
+    _save_last_skills_version,
+    list_summary_profiles_runtime,
+)
+
+
+# ---------------------------------------------------------------------------
+# normalize_summary_period
+# ---------------------------------------------------------------------------
+
+class TestNormalizeSummaryPeriod:
+    def test_valid_periods(self):
+        assert normalize_summary_period("daily") == "daily"
+        assert normalize_summary_period("weekly") == "weekly"
+        assert normalize_summary_period("monthly") == "monthly"
+
+    def test_case_insensitive(self):
+        assert normalize_summary_period("Daily") == "daily"
+        assert normalize_summary_period("WEEKLY") == "weekly"
+        assert normalize_summary_period("Monthly") == "monthly"
+
+    def test_whitespace_trimmed(self):
+        assert normalize_summary_period("  daily  ") == "daily"
+        assert normalize_summary_period("\tweekly\n") == "weekly"
+
+    def test_empty_and_none_fallback(self):
+        assert normalize_summary_period("") == "daily"
+        assert normalize_summary_period(None) == "daily"
+
+    def test_invalid_value_fallback(self):
+        assert normalize_summary_period("yearly") == "daily"
+        assert normalize_summary_period("quarterly") == "daily"
+
+
+# ---------------------------------------------------------------------------
+# normalize_summary_channel
+# ---------------------------------------------------------------------------
+
+class TestNormalizeSummaryChannel:
+    def test_valid_channels(self):
+        assert normalize_summary_channel("email") == "email"
+        assert normalize_summary_channel("wechat_work") == "wechat_work"
+        assert normalize_summary_channel("feishu") == "feishu"
+        assert normalize_summary_channel("telegram") == "telegram"
+
+    def test_case_insensitive(self):
+        assert normalize_summary_channel("Email") == "email"
+        assert normalize_summary_channel("TELEGRAM") == "telegram"
+        assert normalize_summary_channel("FeiShu") == "feishu"
+
+    def test_whitespace_trimmed(self):
+        assert normalize_summary_channel("  telegram  ") == "telegram"
+
+    def test_empty_and_none_fallback(self):
+        assert normalize_summary_channel("") == "telegram"
+        assert normalize_summary_channel(None) == "telegram"
+
+    def test_invalid_value_fallback(self):
+        assert normalize_summary_channel("slack") == "telegram"
+        assert normalize_summary_channel("sms") == "telegram"
+
+
+# ---------------------------------------------------------------------------
+# _worker_api_base_url
+# ---------------------------------------------------------------------------
+
+class TestWorkerApiBaseUrl:
+    def test_default_url(self):
+        with patch.dict("os.environ", {}, clear=True):
+            # Remove TRENDS_API_URL if set
+            import os
+            os.environ.pop("TRENDS_API_URL", None)
+            assert _worker_api_base_url() == "http://localhost:3000"
+
+    def test_env_override(self):
+        with patch.dict("os.environ", {"TRENDS_API_URL": "http://myhost:5000"}):
+            assert _worker_api_base_url() == "http://myhost:5000"
+
+    def test_parameter_override(self):
+        assert _worker_api_base_url("http://custom:9000") == "http://custom:9000"
+
+    def test_trailing_slash_stripped(self):
+        assert _worker_api_base_url("http://host:3000/") == "http://host:3000"
+
+    def test_parameter_overrides_env(self):
+        with patch.dict("os.environ", {"TRENDS_API_URL": "http://env:3000"}):
+            assert _worker_api_base_url("http://param:3000") == "http://param:3000"
+
+
+# ---------------------------------------------------------------------------
+# _load_last_skills_version / _save_last_skills_version
+# ---------------------------------------------------------------------------
+
+class TestSkillsVersionPersistence:
+    def test_load_missing_file(self, tmp_skills_state):
+        assert _load_last_skills_version() is None
+
+    def test_save_and_load_roundtrip(self, tmp_skills_state):
+        _save_last_skills_version(42)
+        assert _load_last_skills_version() == 42
+
+    def test_load_valid_integer(self, tmp_skills_state):
+        tmp_skills_state.write_text(json.dumps({"skillsVersion": 7}))
+        assert _load_last_skills_version() == 7
+
+    def test_load_float_that_is_integer(self, tmp_skills_state):
+        tmp_skills_state.write_text(json.dumps({"skillsVersion": 10.0}))
+        assert _load_last_skills_version() == 10
+
+    def test_load_float_non_integer_returns_none(self, tmp_skills_state):
+        tmp_skills_state.write_text(json.dumps({"skillsVersion": 10.5}))
+        assert _load_last_skills_version() is None
+
+    def test_load_non_dict_returns_none(self, tmp_skills_state):
+        tmp_skills_state.write_text("[]")
+        assert _load_last_skills_version() is None
+
+    def test_load_missing_key_returns_none(self, tmp_skills_state):
+        tmp_skills_state.write_text(json.dumps({"otherKey": 5}))
+        assert _load_last_skills_version() is None
+
+    def test_load_invalid_json_returns_none(self, tmp_skills_state):
+        tmp_skills_state.write_text("not json")
+        assert _load_last_skills_version() is None
+
+    def test_save_creates_parent_dirs(self, tmp_skills_state):
+        # tmp_skills_state is a file in tmp_path — parent already exists
+        _save_last_skills_version(1)
+        assert _load_last_skills_version() == 1
+
+
+# ---------------------------------------------------------------------------
+# list_summary_profiles_runtime (with mocked HTTP)
+# ---------------------------------------------------------------------------
+
+class TestListSummaryProfilesRuntime:
+    def _mock_urlopen(self, response_bytes: bytes):
+        """Create a mock for urllib.request.urlopen that returns given bytes."""
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = response_bytes
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        return mock_response
+
+    def test_basic_profile_list(self, mock_api_base):
+        payload = json.dumps({
+            "success": True,
+            "items": [
+                {
+                    "workspaceSlug": "dev",
+                    "profileId": "p1",
+                    "cron": "0 9 * * *",
+                    "name": "Morning Report",
+                    "channel": "telegram",
+                    "period": "daily",
+                    "dryRun": False,
+                }
+            ],
+        }).encode("utf-8")
+
+        with patch("apps.worker.tasks.urlopen", return_value=self._mock_urlopen(payload)):
+            result = list_summary_profiles_runtime(api_base_url=mock_api_base)
+
+        assert len(result) == 1
+        assert result[0]["workspaceSlug"] == "dev"
+        assert result[0]["profileId"] == "p1"
+        assert result[0]["cron"] == "0 9 * * *"
+        assert result[0]["period"] == "daily"
+        assert result[0]["channel"] == "telegram"
+        assert result[0]["dryRun"] is False
+
+    def test_email_profile_with_recipient(self, mock_api_base):
+        payload = json.dumps({
+            "success": True,
+            "items": [
+                {
+                    "workspaceSlug": "prod",
+                    "profileId": "p2",
+                    "cron": "0 8 * * 1",
+                    "name": "Weekly Email",
+                    "channel": "email",
+                    "period": "weekly",
+                    "dryRun": True,
+                    "to": "team@example.com",
+                    "subject": "Weekly Report",
+                }
+            ],
+        }).encode("utf-8")
+
+        with patch("apps.worker.tasks.urlopen", return_value=self._mock_urlopen(payload)):
+            result = list_summary_profiles_runtime(api_base_url=mock_api_base)
+
+        assert len(result) == 1
+        assert result[0]["channel"] == "email"
+        assert result[0]["to"] == "team@example.com"
+        assert result[0]["subject"] == "Weekly Report"
+        assert result[0]["dryRun"] is True
+
+    def test_email_profile_without_recipient_skipped(self, mock_api_base):
+        payload = json.dumps({
+            "success": True,
+            "items": [
+                {
+                    "workspaceSlug": "dev",
+                    "profileId": "p3",
+                    "cron": "0 9 * * *",
+                    "channel": "email",
+                    "period": "daily",
+                }
+            ],
+        }).encode("utf-8")
+
+        with patch("apps.worker.tasks.urlopen", return_value=self._mock_urlopen(payload)):
+            result = list_summary_profiles_runtime(api_base_url=mock_api_base)
+
+        assert len(result) == 0
+
+    def test_missing_required_fields_skipped(self, mock_api_base):
+        payload = json.dumps({
+            "success": True,
+            "items": [
+                {"workspaceSlug": "dev"},  # missing profileId and cron
+                {"profileId": "p4"},       # missing workspaceSlug and cron
+            ],
+        }).encode("utf-8")
+
+        with patch("apps.worker.tasks.urlopen", return_value=self._mock_urlopen(payload)):
+            result = list_summary_profiles_runtime(api_base_url=mock_api_base)
+
+        assert len(result) == 0
+
+    def test_non_dict_items_skipped(self, mock_api_base):
+        payload = json.dumps({
+            "success": True,
+            "items": ["not a dict", 42, None],
+        }).encode("utf-8")
+
+        with patch("apps.worker.tasks.urlopen", return_value=self._mock_urlopen(payload)):
+            result = list_summary_profiles_runtime(api_base_url=mock_api_base)
+
+        assert len(result) == 0
+
+    def test_template_id_included_when_present(self, mock_api_base):
+        payload = json.dumps({
+            "success": True,
+            "items": [
+                {
+                    "workspaceSlug": "dev",
+                    "profileId": "p5",
+                    "cron": "0 9 * * *",
+                    "channel": "telegram",
+                    "period": "daily",
+                    "templateId": "tpl-001",
+                }
+            ],
+        }).encode("utf-8")
+
+        with patch("apps.worker.tasks.urlopen", return_value=self._mock_urlopen(payload)):
+            result = list_summary_profiles_runtime(api_base_url=mock_api_base)
+
+        assert result[0]["templateId"] == "tpl-001"
+
+    def test_template_id_omitted_when_empty(self, mock_api_base):
+        payload = json.dumps({
+            "success": True,
+            "items": [
+                {
+                    "workspaceSlug": "dev",
+                    "profileId": "p6",
+                    "cron": "0 9 * * *",
+                    "channel": "telegram",
+                    "period": "daily",
+                    "templateId": "",
+                }
+            ],
+        }).encode("utf-8")
+
+        with patch("apps.worker.tasks.urlopen", return_value=self._mock_urlopen(payload)):
+            result = list_summary_profiles_runtime(api_base_url=mock_api_base)
+
+        assert "templateId" not in result[0]
+
+    def test_invalid_channel_normalized(self, mock_api_base):
+        payload = json.dumps({
+            "success": True,
+            "items": [
+                {
+                    "workspaceSlug": "dev",
+                    "profileId": "p7",
+                    "cron": "0 9 * * *",
+                    "channel": "slack",
+                    "period": "daily",
+                }
+            ],
+        }).encode("utf-8")
+
+        with patch("apps.worker.tasks.urlopen", return_value=self._mock_urlopen(payload)):
+            result = list_summary_profiles_runtime(api_base_url=mock_api_base)
+
+        assert result[0]["channel"] == "telegram"  # fallback
+
+    def test_api_failure_raises(self, mock_api_base):
+        payload = json.dumps({"success": False, "error": "bad"}).encode("utf-8")
+
+        with patch("apps.worker.tasks.urlopen", return_value=self._mock_urlopen(payload)):
+            with pytest.raises(RuntimeError, match="Summary profile runtime request failed"):
+                list_summary_profiles_runtime(api_base_url=mock_api_base)
+
+    def test_missing_items_raises(self, mock_api_base):
+        payload = json.dumps({"success": True}).encode("utf-8")
+
+        with patch("apps.worker.tasks.urlopen", return_value=self._mock_urlopen(payload)):
+            with pytest.raises(RuntimeError, match="missing items"):
+                list_summary_profiles_runtime(api_base_url=mock_api_base)
+
+    def test_name_defaults_to_profile_id(self, mock_api_base):
+        payload = json.dumps({
+            "success": True,
+            "items": [
+                {
+                    "workspaceSlug": "dev",
+                    "profileId": "p8",
+                    "cron": "0 9 * * *",
+                    "channel": "telegram",
+                    "period": "daily",
+                }
+            ],
+        }).encode("utf-8")
+
+        with patch("apps.worker.tasks.urlopen", return_value=self._mock_urlopen(payload)):
+            result = list_summary_profiles_runtime(api_base_url=mock_api_base)
+
+        assert result[0]["name"] == "p8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["trendradar", "mcp_server", "packages", "apps"]
+
+[tool.pytest.ini_options]
+testpaths = ["apps/worker/tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]


### PR DESCRIPTION
## Summary
- Adds pytest test infrastructure for `apps/worker/` which previously had **zero test coverage** (2,219 LOC, 10 Python files)
- 61 unit tests covering pure function helpers in `tasks.py` and `resume_tasks.py`
- Adds `[tool.pytest.ini_options]` to `pyproject.toml`

### Test coverage
| Module | Functions tested | Tests |
|--------|-----------------|-------|
| `tasks.py` | `normalize_summary_period`, `normalize_summary_channel`, `_worker_api_base_url`, `_load_last_skills_version`, `_save_last_skills_version`, `list_summary_profiles_runtime` | 38 |
| `resume_tasks.py` | `_read_env_var_from_file`, `_to_positive_int`, `_to_optional_positive_int` | 23 |

### Key test scenarios
- Period/channel normalization: valid values, case-insensitivity, whitespace trimming, invalid/empty fallbacks
- API base URL: env var override, parameter override, trailing slash stripping
- Skills version persistence: save/load roundtrip, missing file, invalid JSON, float-integer coercion
- Summary profiles: valid profile list, email recipient validation, missing required fields, API failure
- Env var file reader: quoted values, export prefix, comments, empty values, first-match-wins
- Integer coercion: positive, zero, negative, None, string, float truncation

## Test plan
- [x] `uv run pytest apps/worker/tests/ -v` — 61/61 passing
- [x] `make check` — all gates passing
- [ ] CI: `npm test` + typecheck + lint

This addresses the P0 research scan finding: Worker Python was flagged 3x as the highest-risk untested surface.