### PR TITLE
fix: remove dead exports and suppress react-refresh context warnings

### DIFF
--- a/apps/web/src/contexts/BrandDisplayMapContext.tsx
+++ b/apps/web/src/contexts/BrandDisplayMapContext.tsx
@@ -41,6 +41,7 @@ export function BrandDisplayMapProvider({ children }: { children: ReactNode }) {
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components -- canonical context pattern: provider + hook
 export function useBrandDisplayMapResolve() {
   const map = useContext(BrandDisplayMapContext)
 

--- a/apps/web/src/contexts/ResumeFieldUsagePolicyContext.tsx
+++ b/apps/web/src/contexts/ResumeFieldUsagePolicyContext.tsx
@@ -53,6 +53,7 @@ export function ResumeFieldUsagePolicyProvider({ children }: { children: ReactNo
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components -- canonical context pattern: provider + hook
 export function useResumeFieldUsagePolicy(): ResumeFieldUsagePolicy {
   return useContext(ResumeFieldUsagePolicyContext)
 }

--- a/apps/web/src/contexts/WorkspaceContext.tsx
+++ b/apps/web/src/contexts/WorkspaceContext.tsx
@@ -42,6 +42,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components -- canonical context pattern: provider + hook
 export function useWorkspace(): WorkspaceContextValue {
   const context = useContext(WorkspaceContext)
   if (!context) {

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -104,8 +104,6 @@ export type ConvexIngestData = {
   skillsVersion?: number
 }
 
-export type ConvexRoleSignal = NonNullable<ConvexIngestData['roleSignals']>[number]
-
 export type ConvexResumeItem = ResumeItem & {
   resumeId: Doc<'resumes'>['_id']
   identityKey?: string

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -402,20 +402,6 @@ function countHistogramSamples(histogram50: number[]): number {
 const INDUSTRY_DB_V2_SCORE_CAP = 50
 const RELATED_EXP_AI_WEIGHT = INDUSTRY_DB_V2_SCORE_CAP / 100
 const INDUSTRY_DB_V2_MIN_NONZERO_SAMPLE_SIZE = 5
-const INDUSTRY_DB_V2_BRAND_SECTION_SCORE = 30
-const INDUSTRY_DB_V2_COMPANY_SECTION_SCORE = 20
-
-export function bumpIndustryDbV2Raw(
-  raw: number | undefined,
-  hasBrandHits: boolean,
-  hasCompanyHits: boolean
-): number {
-  const sectionBump =
-    (hasBrandHits ? INDUSTRY_DB_V2_BRAND_SECTION_SCORE : 0) +
-    (hasCompanyHits ? INDUSTRY_DB_V2_COMPANY_SECTION_SCORE : 0)
-  const safeRaw = typeof raw === 'number' && Number.isFinite(raw) ? clamp(raw, 0, INDUSTRY_DB_V2_SCORE_CAP) : 0
-  return Math.max(safeRaw, sectionBump)
-}
 
 export function computeDirectIndustryDb(
   raw: number | undefined,


### PR DESCRIPTION
## Summary
- Remove unused `ConvexRoleSignal` type export from `useConvexResumes.ts`
- Remove unused `bumpIndustryDbV2Raw` function from `resume-scoring.ts` (canonical implementation with tests lives in `industry-db-batch-stats.ts`)
- Remove the two constants that were only used by the dead function
- Suppress 3 `react-refresh/only-export-components` warnings in context files (canonical React provider + hook pattern)

## Test plan
- [x] `make check` — all checks passed
- [x] ESLint warnings reduced from 5 to 2 (remaining 2 are in shadcn/ui generated components)