### PR TITLE
test: add 27 unit tests for API routes (filter-presets, health, actions)

### DIFF
--- a/apps/api/src/routes/actions.test.ts
+++ b/apps/api/src/routes/actions.test.ts
@@ -1,0 +1,126 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import actionsRoutes from './actions'
+import { workspaceMiddleware } from '../middleware/workspace'
+import { ActionStorage } from '../services/action-storage'
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use('*', workspaceMiddleware)
+  app.route('/', actionsRoutes)
+  return app
+}
+
+const MOCK_ACTION = {
+  id: 1,
+  resumeId: 'resume-123',
+  actionType: 'star' as const,
+  createdAt: new Date().toISOString(),
+}
+
+const MOCK_ACTIONS = [
+  MOCK_ACTION,
+  { id: 2, resumeId: 'resume-456', actionType: 'reject' as const, createdAt: new Date().toISOString() },
+]
+
+describe('actions routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('POST /api/actions', () => {
+    it('creates a star action', async () => {
+      vi.spyOn(ActionStorage.prototype, 'saveAction').mockReturnValue(MOCK_ACTION as never)
+      const app = createTestApp()
+      const response = await app.request('/api/actions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Workspace-Slug': 'dev',
+        },
+        body: JSON.stringify({
+          resumeId: 'resume-123',
+          actionType: 'star',
+        }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.action.actionType).toBe('star')
+    })
+
+    it('creates an action with optional data', async () => {
+      const saveSpy = vi.spyOn(ActionStorage.prototype, 'saveAction').mockReturnValue(MOCK_ACTION as never)
+      const app = createTestApp()
+      await app.request('/api/actions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Workspace-Slug': 'dev',
+        },
+        body: JSON.stringify({
+          resumeId: 'resume-123',
+          actionType: 'note',
+          actionData: { text: 'Great candidate' },
+        }),
+      })
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: 'note',
+          actionData: { text: 'Great candidate' },
+        }),
+      )
+    })
+  })
+
+  describe('GET /api/actions', () => {
+    it('returns latest actions for session', async () => {
+      vi.spyOn(ActionStorage.prototype, 'getLatestActionsForSession').mockReturnValue(MOCK_ACTIONS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/actions?sessionId=session-123', {
+        headers: { 'X-Workspace-Slug': 'dev' },
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.actions).toHaveLength(2)
+    })
+
+    it('returns all actions when latestOnly=false', async () => {
+      vi.spyOn(ActionStorage.prototype, 'getActionsForSession').mockReturnValue(MOCK_ACTIONS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/actions?sessionId=session-123&latestOnly=false', {
+        headers: { 'X-Workspace-Slug': 'dev' },
+      })
+      expect(response.status).toBe(200)
+    })
+
+    it('passes jobDescriptionId when provided', async () => {
+      const getSpy = vi.spyOn(ActionStorage.prototype, 'getLatestActionsForSession').mockReturnValue([] as never)
+      const app = createTestApp()
+      await app.request('/api/actions?sessionId=session-123&jobDescriptionId=lathe-sales', {
+        headers: { 'X-Workspace-Slug': 'dev' },
+      })
+      expect(getSpy).toHaveBeenCalledWith('session-123', 'lathe-sales')
+    })
+
+    it('trims whitespace from jobDescriptionId', async () => {
+      const getSpy = vi.spyOn(ActionStorage.prototype, 'getLatestActionsForSession').mockReturnValue([] as never)
+      const app = createTestApp()
+      await app.request('/api/actions?sessionId=session-123&jobDescriptionId=%20%20lathe%20', {
+        headers: { 'X-Workspace-Slug': 'dev' },
+      })
+      expect(getSpy).toHaveBeenCalledWith('session-123', 'lathe')
+    })
+
+    it('normalizes empty jobDescriptionId to undefined', async () => {
+      const getSpy = vi.spyOn(ActionStorage.prototype, 'getLatestActionsForSession').mockReturnValue([] as never)
+      const app = createTestApp()
+      await app.request('/api/actions?sessionId=session-123&jobDescriptionId=%20%20', {
+        headers: { 'X-Workspace-Slug': 'dev' },
+      })
+      expect(getSpy).toHaveBeenCalledWith('session-123', undefined)
+    })
+  })
+})

--- a/apps/api/src/routes/filter-presets.test.ts
+++ b/apps/api/src/routes/filter-presets.test.ts
@@ -1,0 +1,302 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import filterPresetsRoutes from './filter-presets'
+import { workspaceMiddleware } from '../middleware/workspace'
+import { workspaceConfigService } from '../services/workspace-config-service'
+
+// dev workspace = admin, hr workspace = user
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use('*', workspaceMiddleware)
+  app.route('/api/filter-presets', filterPresetsRoutes)
+  return app
+}
+
+const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
+const USER_HEADERS = { 'X-Workspace-Slug': 'hr' }
+
+const MOCK_PRESETS = {
+  presets: [
+    {
+      id: 'senior-engineer',
+      name: 'Senior Engineer',
+      category: 'engineering',
+      filters: { minExperience: 5, education: ['bachelor'] },
+    },
+    {
+      id: 'junior-engineer',
+      name: 'Junior Engineer',
+      category: 'engineering',
+      filters: { minExperience: 0 },
+    },
+    {
+      id: 'senior-designer',
+      name: 'Senior Designer',
+      category: 'design',
+      filters: { minExperience: 3 },
+    },
+  ],
+  categories: [
+    { id: 'engineering', name: 'Engineering' },
+    { id: 'design', name: 'Design' },
+  ],
+}
+
+describe('filter-presets routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('GET /api/filter-presets', () => {
+    it('returns all presets', async () => {
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.presets).toHaveLength(3)
+    })
+
+    it('filters by category', async () => {
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets?category=engineering', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.presets).toHaveLength(2)
+      expect(body.presets.every((p: { category: string }) => p.category === 'engineering')).toBe(true)
+    })
+
+    it('returns empty when category has no presets', async () => {
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets?category=marketing', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.presets).toHaveLength(0)
+    })
+  })
+
+  describe('GET /api/filter-presets/categories', () => {
+    it('returns categories', async () => {
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets/categories', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.categories).toHaveLength(2)
+    })
+  })
+
+  describe('GET /api/filter-presets/stats', () => {
+    it('returns stats with byCategory counts', async () => {
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets/stats', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.stats.total).toBe(3)
+      expect(body.stats.byCategory.engineering).toBe(2)
+      expect(body.stats.byCategory.design).toBe(1)
+    })
+  })
+
+  describe('GET /api/filter-presets/:id', () => {
+    it('returns preset by id', async () => {
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets/senior-engineer', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.preset.id).toBe('senior-engineer')
+    })
+
+    it('returns 404 for unknown id', async () => {
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets/nonexistent', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(404)
+    })
+  })
+
+  describe('POST /api/filter-presets', () => {
+    it('creates a preset with admin access', async () => {
+      const workspaceConfig = {
+        presets: [...MOCK_PRESETS.presets],
+        categories: [...MOCK_PRESETS.categories],
+      }
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
+      vi.spyOn(workspaceConfigService, 'setWorkspaceFilterPresets').mockResolvedValue(undefined as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          id: 'lead-engineer',
+          name: 'Lead Engineer',
+          category: 'engineering',
+          filters: { minExperience: 8 },
+        }),
+      })
+      expect(response.status).toBe(201)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.preset.id).toBe('lead-engineer')
+    })
+
+    it('rejects creation without admin access (hr workspace)', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...USER_HEADERS },
+        body: JSON.stringify({
+          id: 'lead-engineer',
+          name: 'Lead Engineer',
+          category: 'engineering',
+          filters: { minExperience: 8 },
+        }),
+      })
+      expect(response.status).toBe(403)
+    })
+
+    it('rejects duplicate preset id', async () => {
+      const workspaceConfig = {
+        presets: [...MOCK_PRESETS.presets],
+        categories: [...MOCK_PRESETS.categories],
+      }
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          id: 'senior-engineer',
+          name: 'Duplicate',
+          category: 'engineering',
+          filters: { minExperience: 5 },
+        }),
+      })
+      expect(response.status).toBe(409)
+    })
+
+    it('adds new category if preset has unknown category', async () => {
+      const workspaceConfig = {
+        presets: [...MOCK_PRESETS.presets],
+        categories: [...MOCK_PRESETS.categories],
+      }
+      const setSpy = vi.spyOn(workspaceConfigService, 'setWorkspaceFilterPresets').mockResolvedValue(undefined as never)
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          id: 'sales-lead',
+          name: 'Sales Lead',
+          category: 'sales',
+          filters: {},
+        }),
+      })
+      expect(response.status).toBe(201)
+      const savedConfig = setSpy.mock.calls[0]?.[1] as { categories: { id: string }[] }
+      expect(savedConfig.categories.some((c) => c.id === 'sales')).toBe(true)
+    })
+  })
+
+  describe('PUT /api/filter-presets/:id', () => {
+    it('updates a preset with admin access', async () => {
+      const workspaceConfig = {
+        presets: [...MOCK_PRESETS.presets],
+        categories: [...MOCK_PRESETS.categories],
+      }
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
+      vi.spyOn(workspaceConfigService, 'setWorkspaceFilterPresets').mockResolvedValue(undefined as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets/senior-engineer', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          name: 'Senior Engineer (Updated)',
+          filters: { minExperience: 7 },
+        }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.preset.name).toBe('Senior Engineer (Updated)')
+      expect(body.preset.id).toBe('senior-engineer')
+    })
+
+    it('rejects update without admin access (hr workspace)', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets/senior-engineer', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...USER_HEADERS },
+        body: JSON.stringify({ name: 'Hacked' }),
+      })
+      expect(response.status).toBe(403)
+    })
+
+    it('returns 404 for unknown preset', async () => {
+      const workspaceConfig = {
+        presets: [...MOCK_PRESETS.presets],
+        categories: [...MOCK_PRESETS.categories],
+      }
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets/nonexistent', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ name: 'Test' }),
+      })
+      expect(response.status).toBe(404)
+    })
+  })
+
+  describe('DELETE /api/filter-presets/:id', () => {
+    it('deletes a preset with admin access', async () => {
+      const workspaceConfig = {
+        presets: [...MOCK_PRESETS.presets],
+        categories: [...MOCK_PRESETS.categories],
+      }
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
+      const setSpy = vi.spyOn(workspaceConfigService, 'setWorkspaceFilterPresets').mockResolvedValue(undefined as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets/senior-engineer', {
+        method: 'DELETE',
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const savedConfig = setSpy.mock.calls[0]?.[1] as { presets: { id: string }[] }
+      expect(savedConfig.presets.every((p) => p.id !== 'senior-engineer')).toBe(true)
+    })
+
+    it('rejects delete without admin access (hr workspace)', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets/senior-engineer', {
+        method: 'DELETE',
+        headers: USER_HEADERS,
+      })
+      expect(response.status).toBe(403)
+    })
+
+    it('returns 404 for unknown preset', async () => {
+      const workspaceConfig = {
+        presets: [...MOCK_PRESETS.presets],
+        categories: [...MOCK_PRESETS.categories],
+      }
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
+      const app = createTestApp()
+      const response = await app.request('/api/filter-presets/nonexistent', {
+        method: 'DELETE',
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(404)
+    })
+  })
+})

--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -1,0 +1,49 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import healthRoutes from './health'
+import { workspaceMiddleware } from '../middleware/workspace'
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use('*', workspaceMiddleware)
+  app.route('/', healthRoutes)
+  return app
+}
+
+describe('health routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns healthy status', async () => {
+    const app = createTestApp()
+    const response = await app.request('/health', {
+      headers: { 'X-Workspace-Slug': 'dev' },
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.status).toBe('healthy')
+    expect(body.timestamp).toBeTruthy()
+    expect(body.version).toBeTruthy()
+  })
+
+  it('includes version from config', async () => {
+    const app = createTestApp()
+    const response = await app.request('/health', {
+      headers: { 'X-Workspace-Slug': 'dev' },
+    })
+    const body = await response.json()
+    expect(typeof body.version).toBe('string')
+    expect(body.version.length).toBeGreaterThan(0)
+  })
+
+  it('includes ISO-formatted timestamp', async () => {
+    const app = createTestApp()
+    const response = await app.request('/health', {
+      headers: { 'X-Workspace-Slug': 'dev' },
+    })
+    const body = await response.json()
+    expect(body.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds 27 unit tests for 3 previously untested API route modules
- **filter-presets.test.ts** (18 tests): Full CRUD coverage — list with category filter, categories endpoint, stats with byCategory computation, get by id (200/404), create (201/403/409, auto-add new category), update (200/403/404), delete (200/403/404)
- **health.test.ts** (3 tests): Healthy status response, version field, ISO-formatted timestamp
- **actions.test.ts** (6 tests): Create action, create with optional actionData, list latest/all for session, jobDescriptionId pass-through, whitespace trim/normalize

## Test plan
- [x] `npx vitest run apps/api/src/routes/filter-presets.test.ts apps/api/src/routes/health.test.ts apps/api/src/routes/actions.test.ts` — 27/27 passed
- [x] `make check` — all checks passed
- [x] Admin-gated routes tested with workspace middleware (dev=admin, hr=user)