### PR TITLE
test: add 46 unit tests for scoring-evaluation and industry routes

### DIFF
--- a/apps/api/src/routes/industry.test.ts
+++ b/apps/api/src/routes/industry.test.ts
@@ -1,0 +1,387 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import industryRoutes from './industry'
+import { workspaceMiddleware } from '../middleware/workspace'
+import { IndustryDataService } from '../services/industry-data-service'
+import { BrandDisplayResolver } from '../services/brand-display-resolver'
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use('*', workspaceMiddleware)
+  app.route('/', industryRoutes)
+  return app
+}
+
+const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
+
+const MOCK_COMPANIES = [
+  { id: 1, nameCn: '沈阳机床', nameEn: 'SMTCL', type: 'state_owned', category: 'key_company' as const },
+  { id: 2, nameCn: '大连机床', nameEn: 'Dalian Machine', type: 'state_owned', category: 'key_company' as const },
+  { id: 3, nameCn: '友嘉实业', nameEn: 'FFG', type: 'private', category: 'ites_exhibitor' as const },
+  { id: 4, nameCn: '中贸代理', nameEn: 'Zhongmao Agent', type: 'agent', category: 'agent' as const },
+]
+
+const MOCK_KEYWORDS = [
+  { id: 1, keyword: '车削', english: 'turning', category: 'lathe' as const },
+  { id: 2, keyword: '铣削', english: 'milling', category: 'machining' as const },
+  { id: 3, keyword: '电火花', english: 'EDM', category: 'edm' as const },
+  { id: 4, keyword: '三坐标', english: 'CMM', category: 'measurement' as const },
+]
+
+const MOCK_BRANDS = [
+  { id: 1, nameCn: '马扎克', nameEn: 'Mazak', type: 'cnc', origin: 'international' as const },
+  { id: 2, nameCn: '大连机床', nameEn: 'Dalian', type: 'cnc', origin: 'domestic' as const },
+  { id: 3, nameCn: '天田代理', nameEn: 'Amada Agent', type: 'sheet_metal', origin: 'agent' as const },
+]
+
+const MOCK_STATS = {
+  loadedAt: '2026-05-22T10:00:00.000Z',
+  companiesCount: 4,
+  keywordsCount: 4,
+  brandsCount: 3,
+}
+
+const MOCK_DISPLAY_MAP = {
+  mazak: { displayName: 'Mazak', zhHans: '马扎克' },
+  dalian: { displayName: 'Dalian', zhHans: '大连机床' },
+}
+
+const MOCK_VALIDATION = {
+  valid: true,
+  issues: [],
+  stats: { totalTables: 3, totalRows: 11, tablesWithIssues: 0 },
+}
+
+describe('industry routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('GET /api/industry/stats', () => {
+    it('returns industry data statistics', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'getStats').mockReturnValue(MOCK_STATS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/stats', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.stats.companiesCount).toBe(4)
+      expect(body.stats.keywordsCount).toBe(4)
+      expect(body.stats.brandsCount).toBe(3)
+    })
+  })
+
+  describe('GET /api/industry/companies', () => {
+    it('returns all companies', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadCompanies').mockReturnValue(MOCK_COMPANIES as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/companies', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.count).toBe(4)
+      expect(body.data).toHaveLength(4)
+    })
+
+    it('filters companies by category', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadCompanies').mockReturnValue(MOCK_COMPANIES as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/companies?category=key_company', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.count).toBe(2)
+      expect(body.data.every((c: { category: string }) => c.category === 'key_company')).toBe(true)
+    })
+
+    it('searches companies by Chinese name', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadCompanies').mockReturnValue(MOCK_COMPANIES as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/companies?q=沈阳', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.count).toBe(1)
+      expect(body.data[0].nameCn).toBe('沈阳机床')
+    })
+
+    it('searches companies by English name (case-insensitive)', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadCompanies').mockReturnValue(MOCK_COMPANIES as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/companies?q=smtcl', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.count).toBe(1)
+      expect(body.data[0].nameEn).toBe('SMTCL')
+    })
+
+    it('combines category and search filters', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadCompanies').mockReturnValue(MOCK_COMPANIES as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/companies?category=key_company&q=大连', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.count).toBe(1)
+      expect(body.data[0].nameCn).toBe('大连机床')
+    })
+
+    it('returns empty when search matches nothing', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadCompanies').mockReturnValue(MOCK_COMPANIES as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/companies?q=nonexistent', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.count).toBe(0)
+      expect(body.data).toHaveLength(0)
+    })
+  })
+
+  describe('GET /api/industry/keywords', () => {
+    it('returns all keywords', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadKeywords').mockReturnValue(MOCK_KEYWORDS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/keywords', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.count).toBe(4)
+    })
+
+    it('filters keywords by category', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadKeywords').mockReturnValue(MOCK_KEYWORDS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/keywords?category=lathe', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.count).toBe(1)
+      expect(body.data[0].keyword).toBe('车削')
+    })
+
+    it('returns empty when category has no keywords', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadKeywords').mockReturnValue(MOCK_KEYWORDS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/keywords?category=smt', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.count).toBe(0)
+    })
+  })
+
+  describe('GET /api/industry/brand-display-map', () => {
+    it('returns brand display map', async () => {
+      vi.spyOn(BrandDisplayResolver.prototype, 'toJSON').mockReturnValue(MOCK_DISPLAY_MAP as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/brand-display-map', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.mazak).toBeDefined()
+      expect(body.mazak.displayName).toBe('Mazak')
+      expect(body.mazak.zhHans).toBe('马扎克')
+    })
+  })
+
+  describe('GET /api/industry/brands', () => {
+    it('returns all brands', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadBrands').mockReturnValue(MOCK_BRANDS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/brands', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.count).toBe(3)
+    })
+
+    it('filters brands by origin', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadBrands').mockReturnValue(MOCK_BRANDS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/brands?origin=international', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.count).toBe(1)
+      expect(body.data[0].nameEn).toBe('Mazak')
+    })
+
+    it('searches brands by Chinese name', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadBrands').mockReturnValue(MOCK_BRANDS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/brands?q=马扎克', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.count).toBe(1)
+    })
+
+    it('searches brands by English name (case-insensitive)', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadBrands').mockReturnValue(MOCK_BRANDS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/brands?q=mazak', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.count).toBe(1)
+      expect(body.data[0].nameEn).toBe('Mazak')
+    })
+
+    it('combines origin and search filters', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'loadBrands').mockReturnValue(MOCK_BRANDS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/brands?origin=domestic&q=大连', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.count).toBe(1)
+      expect(body.data[0].origin).toBe('domestic')
+    })
+  })
+
+  describe('POST /api/industry/verify', () => {
+    it('verifies a company', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'verifyCompany').mockReturnValue({
+        verified: true,
+        confidence: 1.0,
+        match: MOCK_COMPANIES[0],
+      } as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ type: 'company', value: '沈阳机床' }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.result.verified).toBe(true)
+      expect(body.result.confidence).toBe(1.0)
+    })
+
+    it('verifies a keyword with category', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'matchKeywords').mockReturnValue([MOCK_KEYWORDS[0]] as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ type: 'keyword', value: '车削', category: 'lathe' }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.result.verified).toBe(true)
+      expect(body.result.confidence).toBe(1.0)
+    })
+
+    it('returns low confidence when keyword has no matches', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'matchKeywords').mockReturnValue([] as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ type: 'keyword', value: 'unknown' }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.result.verified).toBe(false)
+      expect(body.result.confidence).toBe(0.2)
+    })
+
+    it('verifies a brand', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'matchBrands').mockReturnValue([MOCK_BRANDS[0]] as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ type: 'brand', value: 'Mazak' }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.result.verified).toBe(true)
+      expect(body.result.confidence).toBe(1.0)
+    })
+
+    it('rejects invalid verify type', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/industry/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ type: 'invalid', value: 'test' }),
+      })
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('GET /api/industry/validate', () => {
+    it('returns validation result', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'validateFormat').mockReturnValue(MOCK_VALIDATION as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/validate', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.valid).toBe(true)
+      expect(body.issues).toHaveLength(0)
+      expect(body.stats.totalTables).toBe(3)
+    })
+
+    it('returns issues when validation finds problems', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'validateFormat').mockReturnValue({
+        valid: false,
+        issues: [{ section: 'companies', row: 5, issue: 'Missing nameCn', severity: 'error' }],
+        stats: { totalTables: 3, totalRows: 11, tablesWithIssues: 1 },
+      } as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/validate', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.valid).toBe(false)
+      expect(body.issues).toHaveLength(1)
+      expect(body.stats.tablesWithIssues).toBe(1)
+    })
+  })
+
+  describe('POST /api/industry/reload', () => {
+    it('reloads industry data and returns stats', async () => {
+      vi.spyOn(IndustryDataService.prototype, 'reload').mockReturnValue({
+        metadata: MOCK_STATS,
+      } as never)
+      const app = createTestApp()
+      const response = await app.request('/api/industry/reload', {
+        method: 'POST',
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.stats.companiesCount).toBe(4)
+    })
+  })
+})

--- a/apps/api/src/routes/scoring-evaluation.test.ts
+++ b/apps/api/src/routes/scoring-evaluation.test.ts
@@ -1,0 +1,412 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import scoringEvalRoutes from './scoring-evaluation'
+import { workspaceMiddleware } from '../middleware/workspace'
+import { SearchEventAnalyzer } from '../services/search-event-analyzer'
+import { ScoringAutoTuner } from '../services/scoring-auto-tuner'
+import { WeightHistoryService } from '../services/weight-history'
+import { workspaceConfigService } from '../services/workspace-config-service'
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use('*', workspaceMiddleware)
+  app.route('/api/scoring-evaluation', scoringEvalRoutes)
+  return app
+}
+
+const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
+
+const MOCK_REPORT = {
+  periodDays: 14,
+  k: 10,
+  queries: [{ jobDescriptionId: 'jd-1', ndcgAtK: 0.85, shortlistAtK: 0.6 }],
+  zeroResultQueries: [],
+  totalEvents: 42,
+}
+
+const MOCK_METRICS = {
+  jobDescriptionId: 'jd-1',
+  periodDays: 14,
+  k: 10,
+  rankedCount: 50,
+  labeledCount: 20,
+  shortlistCount: 12,
+  rejectCount: 8,
+  ndcgAtK: 0.85,
+  shortlistAtK: 0.6,
+}
+
+const MOCK_CATEGORY_WEIGHTS = {
+  skillMatch: 20,
+  roleMatch: 20,
+  experienceMatch: 15,
+  educationMatch: 10,
+  locationMatch: 10,
+  industryMatch: 15,
+  brandRelevance: 10,
+}
+
+const MOCK_VALIDATION = {
+  jobDescriptionId: 'jd-1',
+  periodDays: 14,
+  k: 10,
+  currentNdcgAtK: 0.85,
+  projectedNdcgAtK: 0.90,
+  currentShortlistAtK: 0.6,
+  projectedShortlistAtK: 0.7,
+}
+
+const MOCK_TUNER_RESULT = {
+  dryRun: false,
+  improvements: [{ jobDescriptionId: 'jd-1', ndcgImprovement: 0.05 }],
+  appliedCount: 1,
+}
+
+const MOCK_HISTORY_ITEMS = [
+  {
+    ts: '2026-05-22T10:00:00.000Z',
+    reason: 'auto-tune',
+    jobDescriptionId: 'jd-1',
+    before: MOCK_CATEGORY_WEIGHTS,
+    after: { ...MOCK_CATEGORY_WEIGHTS, skillMatch: 25 },
+    metrics: { currentNdcgAtK: 0.85, projectedNdcgAtK: 0.90 },
+  },
+  {
+    ts: '2026-05-21T10:00:00.000Z',
+    reason: 'manual',
+    jobDescriptionId: 'jd-2',
+    before: MOCK_CATEGORY_WEIGHTS,
+    after: { ...MOCK_CATEGORY_WEIGHTS, roleMatch: 25 },
+    metrics: { currentNdcgAtK: 0.80, projectedNdcgAtK: 0.85 },
+  },
+]
+
+describe('scoring-evaluation routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('GET /api/scoring-evaluation/report', () => {
+    it('returns scoring analysis report', async () => {
+      vi.spyOn(SearchEventAnalyzer.prototype, 'analyze').mockReturnValue(MOCK_REPORT as never)
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/report', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.report.periodDays).toBe(14)
+    })
+
+    it('passes periodDays and k query params', async () => {
+      const analyzeSpy = vi.spyOn(SearchEventAnalyzer.prototype, 'analyze').mockReturnValue(MOCK_REPORT as never)
+      const app = createTestApp()
+      await app.request('/api/scoring-evaluation/report?periodDays=7&k=5', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(analyzeSpy).toHaveBeenCalledWith({ periodDays: 7, k: 5 })
+    })
+
+    it('uses default values when no query params', async () => {
+      const analyzeSpy = vi.spyOn(SearchEventAnalyzer.prototype, 'analyze').mockReturnValue(MOCK_REPORT as never)
+      const app = createTestApp()
+      await app.request('/api/scoring-evaluation/report', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(analyzeSpy).toHaveBeenCalledWith({})
+    })
+  })
+
+  describe('GET /api/scoring-evaluation/metrics', () => {
+    it('returns ranking metrics for a job description', async () => {
+      vi.spyOn(SearchEventAnalyzer.prototype, 'computeJobMetrics').mockReturnValue(MOCK_METRICS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/metrics?jobDescriptionId=jd-1', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.metrics.jobDescriptionId).toBe('jd-1')
+      expect(body.metrics.ndcgAtK).toBe(0.85)
+    })
+
+    it('passes optional periodDays and k', async () => {
+      const metricsSpy = vi.spyOn(SearchEventAnalyzer.prototype, 'computeJobMetrics').mockReturnValue(MOCK_METRICS as never)
+      const app = createTestApp()
+      await app.request('/api/scoring-evaluation/metrics?jobDescriptionId=jd-1&periodDays=30&k=20', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(metricsSpy).toHaveBeenCalledWith({
+        jobDescriptionId: 'jd-1',
+        periodDays: 30,
+        k: 20,
+      })
+    })
+
+    it('requires jobDescriptionId query param', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/metrics', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('POST /api/scoring-evaluation/validate-weights', () => {
+    it('returns validation report for proposed weights', async () => {
+      vi.spyOn(SearchEventAnalyzer.prototype, 'validateCategoryWeights').mockReturnValue(MOCK_VALIDATION as never)
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/validate-weights', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          jobDescriptionId: 'jd-1',
+          proposedCategoryWeights: MOCK_CATEGORY_WEIGHTS,
+        }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.validation.projectedNdcgAtK).toBe(0.9)
+    })
+
+    it('passes optional periodDays and k', async () => {
+      const validateSpy = vi.spyOn(SearchEventAnalyzer.prototype, 'validateCategoryWeights').mockReturnValue(MOCK_VALIDATION as never)
+      const app = createTestApp()
+      await app.request('/api/scoring-evaluation/validate-weights', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          jobDescriptionId: 'jd-1',
+          proposedCategoryWeights: MOCK_CATEGORY_WEIGHTS,
+          periodDays: 7,
+          k: 5,
+        }),
+      })
+      expect(validateSpy).toHaveBeenCalledWith({
+        jobDescriptionId: 'jd-1',
+        proposedCategoryWeights: MOCK_CATEGORY_WEIGHTS,
+        periodDays: 7,
+        k: 5,
+      })
+    })
+
+    it('returns 500 when validation throws', async () => {
+      vi.spyOn(SearchEventAnalyzer.prototype, 'validateCategoryWeights').mockImplementation(() => {
+        throw new Error('No labeled data for jd-1')
+      })
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/validate-weights', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          jobDescriptionId: 'jd-1',
+          proposedCategoryWeights: MOCK_CATEGORY_WEIGHTS,
+        }),
+      })
+      expect(response.status).toBe(500)
+      const body = await response.json()
+      expect(body.success).toBe(false)
+      expect(body.error).toBe('No labeled data for jd-1')
+    })
+
+    it('rejects missing required fields', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/validate-weights', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({}),
+      })
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('POST /api/scoring-evaluation/run-tuner', () => {
+    it('returns auto-tune result', async () => {
+      vi.spyOn(ScoringAutoTuner.prototype, 'run').mockResolvedValue(MOCK_TUNER_RESULT as never)
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/run-tuner', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ dryRun: true }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.result).toBeDefined()
+    })
+
+    it('passes workspaceSlug from middleware context', async () => {
+      const runSpy = vi.spyOn(ScoringAutoTuner.prototype, 'run').mockResolvedValue(MOCK_TUNER_RESULT as never)
+      const app = createTestApp()
+      await app.request('/api/scoring-evaluation/run-tuner', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({}),
+      })
+      expect(runSpy).toHaveBeenCalledWith(expect.objectContaining({ workspaceSlug: 'dev' }))
+    })
+
+    it('passes all optional parameters', async () => {
+      const runSpy = vi.spyOn(ScoringAutoTuner.prototype, 'run').mockResolvedValue(MOCK_TUNER_RESULT as never)
+      const app = createTestApp()
+      await app.request('/api/scoring-evaluation/run-tuner', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          dryRun: true,
+          periodDays: 30,
+          k: 20,
+          jobDescriptionId: 'jd-1',
+          minLabeledActions: 10,
+          ndcgImprovementThreshold: 0.05,
+          reingestLimit: 100,
+        }),
+      })
+      expect(runSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dryRun: true,
+          periodDays: 30,
+          k: 20,
+          jobDescriptionId: 'jd-1',
+          minLabeledActions: 10,
+          ndcgImprovementThreshold: 0.05,
+          reingestLimit: 100,
+        }),
+      )
+    })
+
+    it('returns 500 when tuner throws', async () => {
+      vi.spyOn(ScoringAutoTuner.prototype, 'run').mockRejectedValue(new Error('Insufficient data'))
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/run-tuner', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({}),
+      })
+      expect(response.status).toBe(500)
+      const body = await response.json()
+      expect(body.success).toBe(false)
+      expect(body.error).toBe('Insufficient data')
+    })
+  })
+
+  describe('GET /api/scoring-evaluation/weight-history', () => {
+    it('returns weight history items', async () => {
+      vi.spyOn(WeightHistoryService.prototype, 'getHistory').mockReturnValue(MOCK_HISTORY_ITEMS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/weight-history', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.items).toHaveLength(2)
+    })
+
+    it('passes limit query param', async () => {
+      const historySpy = vi.spyOn(WeightHistoryService.prototype, 'getHistory').mockReturnValue(MOCK_HISTORY_ITEMS as never)
+      const app = createTestApp()
+      await app.request('/api/scoring-evaluation/weight-history?limit=50', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(historySpy).toHaveBeenCalledWith(50)
+    })
+
+    it('defaults limit to 100 when not provided', async () => {
+      const historySpy = vi.spyOn(WeightHistoryService.prototype, 'getHistory').mockReturnValue([] as never)
+      const app = createTestApp()
+      await app.request('/api/scoring-evaluation/weight-history', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(historySpy).toHaveBeenCalledWith(100)
+    })
+
+    it('returns empty items when no history', async () => {
+      vi.spyOn(WeightHistoryService.prototype, 'getHistory').mockReturnValue([] as never)
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/weight-history', {
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.items).toHaveLength(0)
+    })
+  })
+
+  describe('POST /api/scoring-evaluation/rollback', () => {
+    const MOCK_ROLLBACK_RESULT = {
+      restored: MOCK_HISTORY_ITEMS[0],
+      rollbackEntry: {
+        ts: '2026-05-22T11:00:00.000Z',
+        reason: 'rollback:2026-05-22T10:00:00.000Z',
+        jobDescriptionId: 'jd-1',
+        before: { ...MOCK_CATEGORY_WEIGHTS, skillMatch: 25 },
+        after: MOCK_CATEGORY_WEIGHTS,
+        metrics: {},
+      },
+    }
+
+    it('rolls back to a history entry', async () => {
+      vi.spyOn(WeightHistoryService.prototype, 'rollback').mockResolvedValue(MOCK_ROLLBACK_RESULT as never)
+      vi.spyOn(workspaceConfigService, 'getRuleWeights').mockResolvedValue({
+        categoryWeights: MOCK_CATEGORY_WEIGHTS,
+      } as never)
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/rollback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ entryTs: '2026-05-22T10:00:00.000Z' }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.restored.ts).toBe('2026-05-22T10:00:00.000Z')
+      expect(body.rollbackEntry.reason).toContain('rollback')
+      expect(body.currentCategoryWeights).toEqual(MOCK_CATEGORY_WEIGHTS)
+    })
+
+    it('passes workspaceSlug to rollback', async () => {
+      const rollbackSpy = vi.spyOn(WeightHistoryService.prototype, 'rollback').mockResolvedValue(MOCK_ROLLBACK_RESULT as never)
+      vi.spyOn(workspaceConfigService, 'getRuleWeights').mockResolvedValue({
+        categoryWeights: MOCK_CATEGORY_WEIGHTS,
+      } as never)
+      const app = createTestApp()
+      await app.request('/api/scoring-evaluation/rollback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ entryTs: '2026-05-22T10:00:00.000Z' }),
+      })
+      expect(rollbackSpy).toHaveBeenCalledWith('2026-05-22T10:00:00.000Z', 'dev')
+    })
+
+    it('returns 500 when rollback throws', async () => {
+      vi.spyOn(WeightHistoryService.prototype, 'rollback').mockRejectedValue(
+        new Error('Weight history entry not found: missing-ts'),
+      )
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/rollback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ entryTs: 'missing-ts' }),
+      })
+      expect(response.status).toBe(500)
+      const body = await response.json()
+      expect(body.success).toBe(false)
+      expect(body.error).toContain('not found')
+    })
+
+    it('rejects missing entryTs', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/rollback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({}),
+      })
+      expect(response.status).toBe(400)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add 22 tests for scoring-evaluation routes (report, metrics, validate-weights, run-tuner, weight-history, rollback)
- Add 24 tests for industry routes (stats, companies, keywords, brand-display-map, brands, verify, validate, reload)
- Both files mock service-layer dependencies and test route-level behavior including filtering, search, error handling, and validation

## Test plan
- [x] `npx vitest run apps/api/src/routes/scoring-evaluation.test.ts apps/api/src/routes/industry.test.ts` — 46/46 pass
- [x] `make check` — all checks pass