### PR TITLE
test: add 41 unit tests for notifications, search-alerts, and search-analytics routes

### DIFF
--- a/apps/api/src/routes/notifications.test.ts
+++ b/apps/api/src/routes/notifications.test.ts
@@ -1,0 +1,241 @@
+import { Hono } from 'hono'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import notificationsRoutes from './notifications'
+import { aiMatchingService } from '../services/ai-matching'
+import { notificationService } from '../services/notification-service'
+import { notificationTemplateService } from '../services/notification-template-service'
+
+function createTestApp() {
+  const app = new Hono()
+  app.route('/api/notifications', notificationsRoutes)
+  return app
+}
+
+const MOCK_TEMPLATES = [
+  { id: 'outreach-email', filename: 'outreach-email.md', updatedAt: '2026-05-22T10:00:00Z', size: 512, subject: 'Reaching out' },
+  { id: 'match-alert', filename: 'match-alert.md', updatedAt: '2026-05-22T11:00:00Z', size: 256, subject: 'New match' },
+]
+
+const MOCK_DRAFT = {
+  subject: 'Opportunity at TestCo',
+  body: 'Dear Zhang, we found your profile interesting...',
+}
+
+const MOCK_RENDERED = {
+  subject: 'Match Alert',
+  markdown: 'New match found for **CNC Engineer**',
+}
+
+describe('notifications routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('GET /api/notifications/templates', () => {
+    it('returns template list', async () => {
+      vi.spyOn(notificationTemplateService, 'listTemplates').mockReturnValue(MOCK_TEMPLATES as never)
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/templates')
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.templates).toHaveLength(2)
+      expect(body.templates[0].id).toBe('outreach-email')
+    })
+
+    it('strips body from template items', async () => {
+      vi.spyOn(notificationTemplateService, 'listTemplates').mockReturnValue(MOCK_TEMPLATES as never)
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/templates')
+      const body = await response.json()
+      expect(body.templates[0]).not.toHaveProperty('body')
+    })
+  })
+
+  describe('POST /api/notifications/draft', () => {
+    const validDraft = {
+      resume: { id: 'r1', name: 'Zhang San', jobIntention: 'CNC Engineer' },
+      jobDescription: { title: 'Senior CNC Engineer', requirements: '5+ years experience' },
+      analysis: { score: 85, recommendation: 'match', highlights: ['Strong CNC'], concerns: [], summary: 'Good fit' },
+    }
+
+    it('generates outreach draft', async () => {
+      vi.spyOn(aiMatchingService, 'generateOutreach').mockResolvedValue(MOCK_DRAFT as never)
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/draft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validDraft),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.subject).toBe('Opportunity at TestCo')
+    })
+
+    it('returns 500 when AI service fails', async () => {
+      vi.spyOn(aiMatchingService, 'generateOutreach').mockRejectedValue(new Error('AI unavailable'))
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/draft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validDraft),
+      })
+      expect(response.status).toBe(500)
+      const body = await response.json()
+      expect(body.error).toBe('AI unavailable')
+    })
+
+    it('rejects invalid request body', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/draft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('POST /api/notifications/preview', () => {
+    it('renders email preview with HTML', async () => {
+      vi.spyOn(notificationTemplateService, 'render').mockReturnValue(MOCK_RENDERED as never)
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel: 'email', templateId: 'outreach-email', data: {} }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.channel).toBe('email')
+      expect(body.html).toContain('<pre')
+      expect(body.markdown).toContain('New match')
+    })
+
+    it('renders non-email preview without HTML', async () => {
+      vi.spyOn(notificationTemplateService, 'render').mockReturnValue(MOCK_RENDERED as never)
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel: 'feishu', templateId: 'outreach-email', data: {} }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.channel).toBe('feishu')
+      expect(body.content).toContain('New match')
+      expect(body).not.toHaveProperty('html')
+    })
+
+    it('returns 500 when render fails', async () => {
+      vi.spyOn(notificationTemplateService, 'render').mockImplementation(() => {
+        throw new Error('Template not found')
+      })
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel: 'email', templateId: 'missing', data: {} }),
+      })
+      expect(response.status).toBe(500)
+    })
+  })
+
+  describe('POST /api/notifications/send', () => {
+    it('sends email and returns messageId', async () => {
+      vi.spyOn(notificationService, 'sendEmail').mockResolvedValue({ messageId: 'msg-123' } as never)
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ to: 'test@example.com', subject: 'Hello', body: '<p>Hi</p>' }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.messageId).toBe('msg-123')
+    })
+
+    it('returns 500 when send fails', async () => {
+      vi.spyOn(notificationService, 'sendEmail').mockRejectedValue(new Error('SMTP error'))
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ to: 'test@example.com', subject: 'Hello', body: '<p>Hi</p>' }),
+      })
+      expect(response.status).toBe(500)
+    })
+
+    it('rejects invalid email', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ to: 'not-an-email', subject: 'Hello', body: 'test' }),
+      })
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('POST /api/notifications/send-template', () => {
+    it('sends via email channel', async () => {
+      vi.spyOn(notificationTemplateService, 'render').mockReturnValue(MOCK_RENDERED as never)
+      vi.spyOn(notificationService, 'sendEmail').mockResolvedValue({ messageId: 'msg-456' } as never)
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/send-template', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel: 'email', templateId: 'outreach-email', to: 'test@example.com', data: {} }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.channel).toBe('email')
+      expect(body.messageId).toBe('msg-456')
+    })
+
+    it('sends via wechat_work channel', async () => {
+      vi.spyOn(notificationTemplateService, 'render').mockReturnValue(MOCK_RENDERED as never)
+      vi.spyOn(notificationService, 'sendWechatWorkMarkdown').mockResolvedValue({ errcode: 0 } as never)
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/send-template', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel: 'wechat_work', templateId: 'match-alert', data: {} }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.channel).toBe('wechat_work')
+    })
+
+    it('sends via feishu channel', async () => {
+      vi.spyOn(notificationTemplateService, 'render').mockReturnValue(MOCK_RENDERED as never)
+      vi.spyOn(notificationService, 'sendFeishuText').mockResolvedValue({ code: 0 } as never)
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/send-template', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel: 'feishu', templateId: 'match-alert', data: {} }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.channel).toBe('feishu')
+    })
+
+    it('returns 500 when template render fails', async () => {
+      vi.spyOn(notificationTemplateService, 'render').mockImplementation(() => {
+        throw new Error('Missing template')
+      })
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/send-template', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel: 'email', templateId: 'missing', to: 'test@example.com', data: {} }),
+      })
+      expect(response.status).toBe(500)
+    })
+  })
+})

--- a/apps/api/src/routes/search-alerts.test.ts
+++ b/apps/api/src/routes/search-alerts.test.ts
@@ -1,0 +1,222 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import searchAlertsRoutes from './search-alerts'
+import { workspaceMiddleware } from '../middleware/workspace'
+
+// search-alerts uses a local convexQuery/convexMutation that calls resolveConvexUrl + fetch.
+// We mock the global fetch to intercept Convex HTTP API calls.
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use('*', workspaceMiddleware)
+  app.route('/', searchAlertsRoutes)
+  return app
+}
+
+const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
+
+function mockConvexResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify({ status: 'success', value }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function mockConvexError(message: string, status = 200): Response {
+  return new Response(JSON.stringify({ status: 'error', errorMessage: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const MOCK_ALERTS = [
+  {
+    _id: 'alert-1',
+    _creationTime: Date.now(),
+    workspaceSlug: 'dev',
+    searchProfileId: 'sp-1',
+    name: 'High CNC Matches',
+    keywords: ['CNC', '车削'],
+    minScore: 80,
+    enabled: true,
+    lastNotifiedAt: Date.now() - 86400000,
+    createdBy: 'admin',
+  },
+  {
+    _id: 'alert-2',
+    _creationTime: Date.now(),
+    workspaceSlug: 'dev',
+    searchProfileId: 'sp-2',
+    name: 'New Engineers',
+    keywords: [],
+    minScore: 50,
+    enabled: false,
+  },
+]
+
+describe('search-alerts routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('GET /api/search-alerts/', () => {
+    it('returns alerts for workspace', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockConvexResponse(MOCK_ALERTS) as never)
+      const app = createTestApp()
+      const response = await app.request('/', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.alerts).toHaveLength(2)
+      expect(body.alerts[0]._id).toBe('alert-1')
+    })
+
+    it('passes workspaceSlug to Convex query', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockConvexResponse([]) as never)
+      const app = createTestApp()
+      await app.request('/', { headers: ADMIN_HEADERS })
+      const callBody = JSON.parse(fetchSpy.mock.calls[0]?.[1]?.body as string ?? '{}')
+      expect(callBody.path).toBe('search_alerts:list')
+      expect(callBody.args.workspaceSlug).toBe('dev')
+    })
+
+    it('returns empty array when no alerts', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockConvexResponse([]) as never)
+      const app = createTestApp()
+      const response = await app.request('/', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.alerts).toHaveLength(0)
+    })
+  })
+
+  describe('POST /api/search-alerts/', () => {
+    it('creates an alert', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockConvexResponse('alert-new-1') as never)
+      const app = createTestApp()
+      const response = await app.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          searchProfileId: 'sp-1',
+          name: 'My Alert',
+          keywords: ['test'],
+          minScore: 75,
+        }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.alertId).toBe('alert-new-1')
+    })
+
+    it('passes workspaceSlug and body to Convex mutation', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockConvexResponse('alert-new') as never)
+      const app = createTestApp()
+      await app.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          searchProfileId: 'sp-1',
+          name: 'My Alert',
+          keywords: ['test'],
+          minScore: 75,
+        }),
+      })
+      const callBody = JSON.parse(fetchSpy.mock.calls[0]?.[1]?.body as string ?? '{}')
+      expect(callBody.path).toBe('search_alerts:create')
+      expect(callBody.args.workspaceSlug).toBe('dev')
+      expect(callBody.args.searchProfileId).toBe('sp-1')
+      expect(callBody.args.minScore).toBe(75)
+    })
+
+    it('rejects missing required fields', async () => {
+      const app = createTestApp()
+      const response = await app.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({}),
+      })
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects invalid minScore range', async () => {
+      const app = createTestApp()
+      const response = await app.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          searchProfileId: 'sp-1',
+          name: 'Test',
+          minScore: 150,
+        }),
+      })
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('PATCH /api/search-alerts/:id/toggle', () => {
+    it('toggles alert enabled state', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockConvexResponse(null) as never)
+      const app = createTestApp()
+      const response = await app.request('/alert-1/toggle', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ enabled: false }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+    })
+
+    it('passes alertId and enabled to Convex mutation', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockConvexResponse(null) as never)
+      const app = createTestApp()
+      await app.request('/alert-1/toggle', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ enabled: true }),
+      })
+      const callBody = JSON.parse(fetchSpy.mock.calls[0]?.[1]?.body as string ?? '{}')
+      expect(callBody.path).toBe('search_alerts:toggle')
+      expect(callBody.args.alertId).toBe('alert-1')
+      expect(callBody.args.enabled).toBe(true)
+    })
+
+    it('rejects missing enabled field', async () => {
+      const app = createTestApp()
+      const response = await app.request('/alert-1/toggle', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({}),
+      })
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('DELETE /api/search-alerts/:id', () => {
+    it('deletes an alert', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockConvexResponse(null) as never)
+      const app = createTestApp()
+      const response = await app.request('/alert-1', {
+        method: 'DELETE',
+        headers: ADMIN_HEADERS,
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+    })
+
+    it('passes alertId to Convex mutation', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockConvexResponse(null) as never)
+      const app = createTestApp()
+      await app.request('/alert-1', {
+        method: 'DELETE',
+        headers: ADMIN_HEADERS,
+      })
+      const callBody = JSON.parse(fetchSpy.mock.calls[0]?.[1]?.body as string ?? '{}')
+      expect(callBody.path).toBe('search_alerts:remove')
+      expect(callBody.args.alertId).toBe('alert-1')
+    })
+  })
+})

--- a/apps/api/src/routes/search-analytics.test.ts
+++ b/apps/api/src/routes/search-analytics.test.ts
@@ -1,0 +1,192 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import searchAnalyticsRoutes from './search-analytics'
+import { workspaceMiddleware } from '../middleware/workspace'
+import { SearchEventLogger } from '../services/search-event-logger'
+import { SkillsKnowledgeService } from '../services/skills-knowledge'
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use('*', workspaceMiddleware)
+  app.route('/api/search-analytics', searchAnalyticsRoutes)
+  return app
+}
+
+const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
+
+const MOCK_ZERO_RESULT_ITEMS = [
+  { query: '5轴加工中心', count: 12, lastSeen: '2026-05-22T10:00:00Z' },
+  { query: 'EDM operator', count: 5, lastSeen: '2026-05-21T15:30:00Z' },
+]
+
+const MOCK_SUMMARY = {
+  totalSearches: 150,
+  zeroResultSearches: 30,
+  zeroResultRate: 0.2,
+  topQueries: [{ query: 'CNC', count: 45 }],
+  actionDistribution: { shortlist: 60, reject: 30 },
+  dailyTrend: [{ date: '2026-05-22', searches: 50, zeroResults: 10, shortlist: 20, reject: 15 }],
+}
+
+const MOCK_SYNONYM_SUGGESTIONS = [
+  { query: '5轴', variant: '五轴', canonical: '五轴加工', confidence: 0.85, reason: 'Chinese numeral variant' },
+]
+
+describe('search-analytics routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('GET /api/search-analytics/zero-results', () => {
+    it('returns zero-result queries', async () => {
+      vi.spyOn(SearchEventLogger.prototype, 'getZeroResultSummary').mockReturnValue(MOCK_ZERO_RESULT_ITEMS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/search-analytics/zero-results', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.items).toHaveLength(2)
+      expect(body.items[0].query).toBe('5轴加工中心')
+    })
+
+    it('passes limit query param', async () => {
+      const summarySpy = vi.spyOn(SearchEventLogger.prototype, 'getZeroResultSummary').mockReturnValue([] as never)
+      const app = createTestApp()
+      await app.request('/api/search-analytics/zero-results?limit=10', { headers: ADMIN_HEADERS })
+      expect(summarySpy).toHaveBeenCalledWith(10)
+    })
+
+    it('uses default limit when not provided', async () => {
+      const summarySpy = vi.spyOn(SearchEventLogger.prototype, 'getZeroResultSummary').mockReturnValue([] as never)
+      const app = createTestApp()
+      await app.request('/api/search-analytics/zero-results', { headers: ADMIN_HEADERS })
+      expect(summarySpy).toHaveBeenCalledWith(undefined)
+    })
+  })
+
+  describe('GET /api/search-analytics/summary', () => {
+    it('returns aggregated summary', async () => {
+      vi.spyOn(SearchEventLogger.prototype, 'getSummary').mockReturnValue(MOCK_SUMMARY as never)
+      const app = createTestApp()
+      const response = await app.request('/api/search-analytics/summary', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.summary.totalSearches).toBe(150)
+      expect(body.summary.zeroResultRate).toBe(0.2)
+      expect(body.summary.topQueries).toHaveLength(1)
+      expect(body.summary.dailyTrend).toHaveLength(1)
+    })
+
+    it('passes topQueries and daily params', async () => {
+      const summarySpy = vi.spyOn(SearchEventLogger.prototype, 'getSummary').mockReturnValue(MOCK_SUMMARY as never)
+      const app = createTestApp()
+      await app.request('/api/search-analytics/summary?topQueries=20&daily=30', { headers: ADMIN_HEADERS })
+      expect(summarySpy).toHaveBeenCalledWith({ topQueryLimit: 20, dailyLimit: 30 })
+    })
+
+    it('uses defaults when no params provided', async () => {
+      const summarySpy = vi.spyOn(SearchEventLogger.prototype, 'getSummary').mockReturnValue(MOCK_SUMMARY as never)
+      const app = createTestApp()
+      await app.request('/api/search-analytics/summary', { headers: ADMIN_HEADERS })
+      expect(summarySpy).toHaveBeenCalledWith({})
+    })
+  })
+
+  describe('GET /api/search-analytics/synonym-suggestions', () => {
+    it('returns synonym suggestions', async () => {
+      vi.spyOn(SearchEventLogger.prototype, 'getZeroResultQueries').mockReturnValue(['5轴'] as never)
+      vi.spyOn(SkillsKnowledgeService.prototype, 'generateSynonymSuggestions').mockReturnValue(MOCK_SYNONYM_SUGGESTIONS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/search-analytics/synonym-suggestions', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.suggestions).toHaveLength(1)
+      expect(body.suggestions[0].canonical).toBe('五轴加工')
+    })
+
+    it('passes limit to getZeroResultQueries', async () => {
+      vi.spyOn(SearchEventLogger.prototype, 'getZeroResultQueries').mockReturnValue([] as never)
+      vi.spyOn(SkillsKnowledgeService.prototype, 'generateSynonymSuggestions').mockReturnValue([] as never)
+      const app = createTestApp()
+      await app.request('/api/search-analytics/synonym-suggestions?limit=50', { headers: ADMIN_HEADERS })
+      expect(SearchEventLogger.prototype.getZeroResultQueries).toHaveBeenCalledWith(50)
+    })
+
+    it('defaults limit to 200 when not provided', async () => {
+      vi.spyOn(SearchEventLogger.prototype, 'getZeroResultQueries').mockReturnValue([] as never)
+      vi.spyOn(SkillsKnowledgeService.prototype, 'generateSynonymSuggestions').mockReturnValue([] as never)
+      const app = createTestApp()
+      await app.request('/api/search-analytics/synonym-suggestions', { headers: ADMIN_HEADERS })
+      expect(SearchEventLogger.prototype.getZeroResultQueries).toHaveBeenCalledWith(200)
+    })
+
+    it('returns empty suggestions when no zero-result queries', async () => {
+      vi.spyOn(SearchEventLogger.prototype, 'getZeroResultQueries').mockReturnValue([] as never)
+      vi.spyOn(SkillsKnowledgeService.prototype, 'generateSynonymSuggestions').mockReturnValue([] as never)
+      const app = createTestApp()
+      const response = await app.request('/api/search-analytics/synonym-suggestions', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.suggestions).toHaveLength(0)
+    })
+  })
+
+  describe('POST /api/search-analytics/log', () => {
+    it('logs a search query event', async () => {
+      const logSpy = vi.spyOn(SearchEventLogger.prototype, 'logSearchQuery').mockImplementation(() => {})
+      const app = createTestApp()
+      const response = await app.request('/api/search-analytics/log', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ query: 'CNC operator', resultCount: 25, topScore: 92.5 }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(logSpy).toHaveBeenCalledWith({
+        query: 'CNC operator',
+        resultCount: 25,
+        topScore: 92.5,
+      })
+    })
+
+    it('works without optional topScore', async () => {
+      const logSpy = vi.spyOn(SearchEventLogger.prototype, 'logSearchQuery').mockImplementation(() => {})
+      const app = createTestApp()
+      const response = await app.request('/api/search-analytics/log', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ query: 'test', resultCount: 0 }),
+      })
+      expect(response.status).toBe(200)
+      expect(logSpy).toHaveBeenCalledWith({
+        query: 'test',
+        resultCount: 0,
+        topScore: undefined,
+      })
+    })
+
+    it('rejects missing required fields', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/search-analytics/log', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({}),
+      })
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects negative resultCount', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/search-analytics/log', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({ query: 'test', resultCount: -1 }),
+      })
+      expect(response.status).toBe(400)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add 14 tests for notifications routes (templates, draft, preview, send, send-template across email/wechat_work/feishu channels)
- Add 14 tests for search-alerts routes (list, create, toggle, delete) with Convex HTTP API mocking
- Add 13 tests for search-analytics routes (zero-results, summary, synonym-suggestions, log-search)
- API route test coverage: 8 untested modules → 5 remaining (all trivial proxy routes)

## Test plan
- [x] `npx vitest run apps/api/src/routes/notifications.test.ts apps/api/src/routes/search-alerts.test.ts apps/api/src/routes/search-analytics.test.ts` — 41/41 pass
- [x] `make check` — all checks pass