### PR TITLE
test: add 23 unit tests for proxy API routes (topics, trends, search, rss, web-vitals)

### DIFF
--- a/apps/api/src/routes/rss.test.ts
+++ b/apps/api/src/routes/rss.test.ts
@@ -1,0 +1,72 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import rssRoutes from './rss'
+import { workspaceMiddleware } from '../middleware/workspace'
+import { DataService } from '../services/data-service'
+import { DataNotFoundError } from '../services/errors'
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use('*', workspaceMiddleware)
+  app.route('/', rssRoutes)
+  return app
+}
+
+const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
+
+const MOCK_RSS_ITEMS = [
+  { title: 'Industry Update', feed: '36kr', publishedAt: '2026-05-22T10:00:00Z', url: 'https://example.com/1' },
+  { title: 'Tech News', feed: 'ithome', publishedAt: '2026-05-22T09:00:00Z', url: 'https://example.com/2' },
+]
+
+describe('rss routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('GET /api/rss', () => {
+    it('returns RSS items', async () => {
+      vi.spyOn(DataService.prototype, 'getLatestRss').mockReturnValue(MOCK_RSS_ITEMS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/rss', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.data).toHaveLength(2)
+      expect(body.summary.total).toBe(2)
+    })
+
+    it('passes feed, days, and limit params', async () => {
+      const rssSpy = vi.spyOn(DataService.prototype, 'getLatestRss').mockReturnValue(MOCK_RSS_ITEMS as never)
+      const app = createTestApp()
+      await app.request('/api/rss?feed=36kr,ithome&days=7&limit=20', { headers: ADMIN_HEADERS })
+      expect(rssSpy).toHaveBeenCalledWith(expect.objectContaining({
+        feeds: ['36kr', 'ithome'],
+        days: 7,
+        limit: 20,
+      }))
+    })
+
+    it('returns empty data when DataNotFoundError', async () => {
+      vi.spyOn(DataService.prototype, 'getLatestRss').mockImplementation(() => {
+        throw new DataNotFoundError('No RSS data', { suggestion: 'Run RSS crawler' })
+      })
+      const app = createTestApp()
+      const response = await app.request('/api/rss', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.data).toHaveLength(0)
+      expect(body.summary.description).toContain('Run RSS crawler')
+    })
+
+    it('indicates multi-day range in description', async () => {
+      vi.spyOn(DataService.prototype, 'getLatestRss').mockReturnValue(MOCK_RSS_ITEMS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/rss?days=7', { headers: ADMIN_HEADERS })
+      const body = await response.json()
+      expect(body.summary.description).toContain('last 7 days')
+    })
+  })
+})

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -1,0 +1,81 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import searchRoutes from './search'
+import { workspaceMiddleware } from '../middleware/workspace'
+import { DataService } from '../services/data-service'
+import { DataNotFoundError } from '../services/errors'
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use('*', workspaceMiddleware)
+  app.route('/', searchRoutes)
+  return app
+}
+
+const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
+
+const MOCK_SEARCH_RESULT = {
+  results: [
+    { title: 'CNC Innovation', platform: 'weibo', rank: 1 },
+    { title: 'Smart Factory', platform: 'zhihu', rank: 2 },
+  ],
+  total: 2,
+  total_found: 15,
+  statistics: { keyword: 'CNC', avg_rank: 5.2, platform_distribution: { weibo: 10, zhihu: 5 } },
+}
+
+describe('search routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('GET /api/search', () => {
+    it('returns search results', async () => {
+      vi.spyOn(DataService.prototype, 'searchNewsByKeyword').mockReturnValue(MOCK_SEARCH_RESULT as never)
+      const app = createTestApp()
+      const response = await app.request('/api/search?q=CNC', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.results).toHaveLength(2)
+      expect(body.total).toBe(2)
+    })
+
+    it('passes keyword, platform, and limit to service', async () => {
+      const searchSpy = vi.spyOn(DataService.prototype, 'searchNewsByKeyword').mockReturnValue(MOCK_SEARCH_RESULT as never)
+      const app = createTestApp()
+      await app.request('/api/search?q=CNC&platform=weibo&limit=5', { headers: ADMIN_HEADERS })
+      expect(searchSpy).toHaveBeenCalledWith(expect.objectContaining({
+        keyword: 'CNC',
+        platforms: ['weibo'],
+        limit: 5,
+      }))
+    })
+
+    it('passes date range when start_date and end_date provided', async () => {
+      const searchSpy = vi.spyOn(DataService.prototype, 'searchNewsByKeyword').mockReturnValue(MOCK_SEARCH_RESULT as never)
+      const app = createTestApp()
+      await app.request('/api/search?q=CNC&start_date=2026-05-01&end_date=2026-05-22', { headers: ADMIN_HEADERS })
+      expect(searchSpy).toHaveBeenCalledWith(expect.objectContaining({
+        dateRange: expect.objectContaining({
+          start: expect.any(Date),
+          end: expect.any(Date),
+        }),
+      }))
+    })
+
+    it('returns empty results when DataNotFoundError', async () => {
+      vi.spyOn(DataService.prototype, 'searchNewsByKeyword').mockImplementation(() => {
+        throw new DataNotFoundError('No data')
+      })
+      const app = createTestApp()
+      const response = await app.request('/api/search?q=nonexistent', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.results).toHaveLength(0)
+      expect(body.total).toBe(0)
+    })
+  })
+})

--- a/apps/api/src/routes/topics.test.ts
+++ b/apps/api/src/routes/topics.test.ts
@@ -1,0 +1,70 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import topicsRoutes from './topics'
+import { workspaceMiddleware } from '../middleware/workspace'
+import { DataService } from '../services/data-service'
+import { DataNotFoundError } from '../services/errors'
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use('*', workspaceMiddleware)
+  app.route('/', topicsRoutes)
+  return app
+}
+
+const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
+
+const MOCK_TOPICS_RESULT = {
+  topics: [
+    { keyword: 'CNC', count: 42 },
+    { keyword: '智能制造', count: 28 },
+  ],
+  generated_at: '2026-05-22T12:00:00+08:00',
+  mode: 'daily',
+  extract_mode: 'frequency',
+  total_keywords: 150,
+}
+
+describe('topics routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('GET /api/topics', () => {
+    it('returns trending topics', async () => {
+      vi.spyOn(DataService.prototype, 'getTrendingTopics').mockReturnValue(MOCK_TOPICS_RESULT as never)
+      const app = createTestApp()
+      const response = await app.request('/api/topics', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.topics).toHaveLength(2)
+      expect(body.total_keywords).toBe(150)
+    })
+
+    it('passes top_n, mode, and extract_mode params', async () => {
+      const topicsSpy = vi.spyOn(DataService.prototype, 'getTrendingTopics').mockReturnValue(MOCK_TOPICS_RESULT as never)
+      const app = createTestApp()
+      await app.request('/api/topics?top_n=20&mode=daily&extract_mode=auto_extract', { headers: ADMIN_HEADERS })
+      expect(topicsSpy).toHaveBeenCalledWith(expect.objectContaining({
+        top_n: 20,
+        mode: 'daily',
+        extract_mode: 'auto_extract',
+      }))
+    })
+
+    it('returns empty topics when DataNotFoundError', async () => {
+      vi.spyOn(DataService.prototype, 'getTrendingTopics').mockImplementation(() => {
+        throw new DataNotFoundError('No data')
+      })
+      const app = createTestApp()
+      const response = await app.request('/api/topics', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.topics).toHaveLength(0)
+      expect(body.total_keywords).toBe(0)
+    })
+  })
+})

--- a/apps/api/src/routes/trends.test.ts
+++ b/apps/api/src/routes/trends.test.ts
@@ -1,0 +1,91 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import trendsRoutes from './trends'
+import { workspaceMiddleware } from '../middleware/workspace'
+import { DataService } from '../services/data-service'
+import { DataNotFoundError } from '../services/errors'
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use('*', workspaceMiddleware)
+  app.route('/', trendsRoutes)
+  return app
+}
+
+const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
+
+const MOCK_TRENDS = [
+  { title: 'AI in Manufacturing', platform: 'weibo', rank: 1, url: 'https://example.com/1' },
+  { title: 'CNC Automation', platform: 'zhihu', rank: 2, url: 'https://example.com/2' },
+]
+
+describe('trends routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('GET /api/trends', () => {
+    it('returns latest trends', async () => {
+      vi.spyOn(DataService.prototype, 'getLatestNews').mockReturnValue(MOCK_TRENDS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/trends', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.summary.total).toBe(2)
+      expect(body.data).toHaveLength(2)
+    })
+
+    it('returns trends by date', async () => {
+      vi.spyOn(DataService.prototype, 'getNewsByDate').mockReturnValue(MOCK_TRENDS as never)
+      const app = createTestApp()
+      const response = await app.request('/api/trends?date=2026-05-22', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.summary.description).toContain('2026-05-22')
+    })
+
+    it('returns empty data when DataNotFoundError', async () => {
+      vi.spyOn(DataService.prototype, 'getLatestNews').mockImplementation(() => {
+        throw new DataNotFoundError('No data', { suggestion: 'Run crawler first' })
+      })
+      const app = createTestApp()
+      const response = await app.request('/api/trends', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.data).toHaveLength(0)
+      expect(body.summary.total).toBe(0)
+    })
+
+    it('passes platform and limit params', async () => {
+      const newsSpy = vi.spyOn(DataService.prototype, 'getLatestNews').mockReturnValue(MOCK_TRENDS as never)
+      const app = createTestApp()
+      await app.request('/api/trends?platform=weibo,zhihu&limit=10', { headers: ADMIN_HEADERS })
+      expect(newsSpy).toHaveBeenCalledWith(expect.objectContaining({
+        platforms: ['weibo', 'zhihu'],
+        limit: 10,
+      }))
+    })
+  })
+
+  describe('GET /api/trends/:id', () => {
+    it('returns trend by title', async () => {
+      vi.spyOn(DataService.prototype, 'getTrendByTitle').mockReturnValue(MOCK_TRENDS[0] as never)
+      const app = createTestApp()
+      const response = await app.request('/api/trends/AI%20in%20Manufacturing', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.data.title).toBe('AI in Manufacturing')
+    })
+
+    it('decodes URL-encoded title', async () => {
+      const trendSpy = vi.spyOn(DataService.prototype, 'getTrendByTitle').mockReturnValue(MOCK_TRENDS[0] as never)
+      const app = createTestApp()
+      await app.request('/api/trends/CNC%20Automation', { headers: ADMIN_HEADERS })
+      expect(trendSpy).toHaveBeenCalledWith('CNC Automation', expect.any(Object))
+    })
+  })
+})

--- a/apps/api/src/routes/web-vitals.test.ts
+++ b/apps/api/src/routes/web-vitals.test.ts
@@ -1,0 +1,111 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import webVitalsRoutes from './web-vitals'
+import { workspaceMiddleware } from '../middleware/workspace'
+import { WebVitalsLogger } from '../services/web-vitals-logger'
+
+function createTestApp() {
+  const app = new OpenAPIHono()
+  app.use('*', workspaceMiddleware)
+  app.route('/api/web-vitals', webVitalsRoutes)
+  return app
+}
+
+const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
+
+const MOCK_SUMMARY = {
+  totalReports: 42,
+  metrics: {
+    LCP: { p50: 1.2, p75: 2.1, p95: 3.5, good: 30, needsImprovement: 8, poor: 4 },
+    FID: { p50: 10, p75: 50, p95: 100, good: 35, needsImprovement: 5, poor: 2 },
+  },
+}
+
+describe('web-vitals routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('POST /api/web-vitals/report', () => {
+    it('logs a web vital metric', async () => {
+      const logSpy = vi.spyOn(WebVitalsLogger.prototype, 'logMetric').mockImplementation(() => {})
+      const app = createTestApp()
+      const response = await app.request('/api/web-vitals/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          name: 'LCP',
+          value: 2.5,
+          rating: 'needs-improvement',
+          id: 'v3-abc123',
+          navigationType: 'navigate',
+        }),
+      })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'LCP',
+          value: 2.5,
+          rating: 'needs-improvement',
+          workspace: 'dev',
+        }),
+      )
+    })
+
+    it('rejects invalid rating', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/web-vitals/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({
+          name: 'LCP',
+          value: 2.5,
+          rating: 'invalid',
+          id: 'v3-abc',
+          navigationType: 'navigate',
+        }),
+      })
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects missing required fields', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/web-vitals/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ADMIN_HEADERS },
+        body: JSON.stringify({}),
+      })
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('GET /api/web-vitals/summary', () => {
+    it('returns web vitals summary', async () => {
+      vi.spyOn(WebVitalsLogger.prototype, 'getSummary').mockReturnValue(MOCK_SUMMARY as never)
+      const app = createTestApp()
+      const response = await app.request('/api/web-vitals/summary', { headers: ADMIN_HEADERS })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.summary.totalReports).toBe(42)
+      expect(body.summary.metrics.LCP.p50).toBe(1.2)
+    })
+
+    it('passes hours query param', async () => {
+      const summarySpy = vi.spyOn(WebVitalsLogger.prototype, 'getSummary').mockReturnValue(MOCK_SUMMARY as never)
+      const app = createTestApp()
+      await app.request('/api/web-vitals/summary?hours=48', { headers: ADMIN_HEADERS })
+      expect(summarySpy).toHaveBeenCalledWith(48)
+    })
+
+    it('defaults to 24 hours when not provided', async () => {
+      const summarySpy = vi.spyOn(WebVitalsLogger.prototype, 'getSummary').mockReturnValue(MOCK_SUMMARY as never)
+      const app = createTestApp()
+      await app.request('/api/web-vitals/summary', { headers: ADMIN_HEADERS })
+      expect(summarySpy).toHaveBeenCalledWith(24)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add unit tests for 5 remaining untested API route modules: topics (3), trends (6), search (4), rss (4), web-vitals (5)
- Tests cover happy paths, query param passthrough, DataNotFoundError handling, and input validation
- Fixed topics.test.ts to use valid enum values (`mode=daily`, `extract_mode=auto_extract`)

## Test plan
- [x] `npx vitest run` — 23/23 pass
- [x] `make check` — all checks pass