### PR TITLE
test: add 23 unit tests for summary-renderer and summary-dispatcher

### DIFF
--- a/apps/api/src/services/__tests__/summary-dispatcher.test.ts
+++ b/apps/api/src/services/__tests__/summary-dispatcher.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SummaryReport } from "@trends/shared";
+
+import { SummaryDispatcher } from "../summaries/summary-dispatcher.js";
+
+function makeReport(overrides: Partial<SummaryReport> = {}): SummaryReport {
+  return {
+    workspaceSlug: "test-ws",
+    period: "daily",
+    generatedAt: "2026-05-22T10:00:00Z",
+    window: { startAt: "2026-05-21", endAt: "2026-05-22", timezone: "Asia/Shanghai" },
+    totals: {
+      newResumes: 5,
+      candidateStatusUpdates: 2,
+      shortlistActions: 1,
+      rejectActions: 0,
+      contactActions: 1,
+      collectionTasksCompleted: 4,
+      collectionTasksFailed: 0,
+    },
+    breakdowns: {
+      resumesBySource: [],
+      candidateStatusByValue: [],
+      actionsByType: [],
+      collectionTasksByStatus: [],
+    },
+    notes: [],
+    ...overrides,
+  };
+}
+
+const mockTemplateService = {
+  render: vi.fn().mockReturnValue({ subject: "Daily Summary", markdown: "# Daily Summary\nContent here" }),
+};
+
+const mockNotificationService = {
+  sendEmail: vi.fn().mockResolvedValue({ messageId: "msg-123" }),
+  sendWechatWorkMarkdown: vi.fn().mockResolvedValue({ errcode: 0 }),
+  sendFeishuText: vi.fn().mockResolvedValue({ code: 0 }),
+};
+
+const mockTelegramBridge = {
+  send: vi.fn().mockResolvedValue({ ok: true }),
+};
+
+describe("SummaryDispatcher", () => {
+  const dispatcher = new SummaryDispatcher({
+    notificationTemplateService: mockTemplateService,
+    notificationService: mockNotificationService,
+    telegramBridge: mockTelegramBridge,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- buildPreview ---
+
+  describe("buildPreview", () => {
+    it("uses explicit templateId when provided", () => {
+      const preview = dispatcher.buildPreview(makeReport(), { templateId: "custom-template" });
+      expect(preview.templateId).toBe("custom-template");
+      expect(mockTemplateService.render).toHaveBeenCalledWith("custom-template", expect.any(Object));
+    });
+
+    it("falls back to default templateId when not provided", () => {
+      const preview = dispatcher.buildPreview(makeReport(), {});
+      expect(preview.templateId).toBe("summary-daily");
+    });
+
+    it("falls back to default templateId for blank templateId", () => {
+      const preview = dispatcher.buildPreview(makeReport(), { templateId: "   " });
+      expect(preview.templateId).toBe("summary-daily");
+    });
+
+    it("passes template data with timestamp and summaryTitle", () => {
+      dispatcher.buildPreview(makeReport(), {});
+      const data = mockTemplateService.render.mock.calls[0][1];
+      expect(data.timestamp).toBe("2026-05-22T10:00:00Z");
+      expect(data.summaryTitle).toBe("Daily Ops Summary");
+    });
+  });
+
+  // --- dispatch (dry run) ---
+
+  describe("dispatch (dry run)", () => {
+    it("returns preview without sending on dryRun", async () => {
+      const result = await dispatcher.dispatch(makeReport(), {
+        channel: "email",
+        dryRun: true,
+        to: "test@example.com",
+      });
+      expect(result.dryRun).toBe(true);
+      expect(result.channel).toBe("email");
+      expect(result.content).toBe("# Daily Summary\nContent here");
+      expect(mockNotificationService.sendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- dispatch (email) ---
+
+  describe("dispatch (email)", () => {
+    it("sends email and returns messageId", async () => {
+      const result = await dispatcher.dispatch(makeReport(), {
+        channel: "email",
+        to: "test@example.com",
+      });
+      expect(result.channel).toBe("email");
+      expect(result.delivery?.messageId).toBe("msg-123");
+      expect(mockNotificationService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ to: "test@example.com" }),
+      );
+    });
+
+    it("throws when email recipient is missing", async () => {
+      await expect(
+        dispatcher.dispatch(makeReport(), { channel: "email" }),
+      ).rejects.toThrow("Email recipient is required");
+    });
+
+    it("uses custom subject when provided", async () => {
+      await dispatcher.dispatch(makeReport(), {
+        channel: "email",
+        to: "test@example.com",
+        subject: "Custom Subject",
+      });
+      expect(mockNotificationService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ subject: "Custom Subject" }),
+      );
+    });
+  });
+
+  // --- dispatch (wechat_work) ---
+
+  describe("dispatch (wechat_work)", () => {
+    it("sends wechat work markdown", async () => {
+      const result = await dispatcher.dispatch(makeReport(), {
+        channel: "wechat_work",
+        webhookUrl: "https://example.com/webhook",
+      });
+      expect(result.channel).toBe("wechat_work");
+      expect(mockNotificationService.sendWechatWorkMarkdown).toHaveBeenCalledWith(
+        expect.objectContaining({ webhookUrl: "https://example.com/webhook" }),
+      );
+    });
+  });
+
+  // --- dispatch (feishu) ---
+
+  describe("dispatch (feishu)", () => {
+    it("sends feishu text", async () => {
+      const result = await dispatcher.dispatch(makeReport(), {
+        channel: "feishu",
+        webhookUrl: "https://example.com/feishu",
+      });
+      expect(result.channel).toBe("feishu");
+      expect(mockNotificationService.sendFeishuText).toHaveBeenCalledWith(
+        expect.objectContaining({ webhookUrl: "https://example.com/feishu" }),
+      );
+    });
+  });
+
+  // --- dispatch (telegram) ---
+
+  describe("dispatch (telegram)", () => {
+    it("sends via telegram bridge", async () => {
+      const result = await dispatcher.dispatch(makeReport(), {
+        channel: "telegram",
+        botToken: "bot-token",
+        chatId: "chat-123",
+      });
+      expect(result.channel).toBe("telegram");
+      expect(mockTelegramBridge.send).toHaveBeenCalledWith(
+        expect.objectContaining({ botToken: "bot-token", chatId: "chat-123" }),
+      );
+    });
+  });
+});

--- a/apps/api/src/services/__tests__/summary-renderer.test.ts
+++ b/apps/api/src/services/__tests__/summary-renderer.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+
+import type { SummaryCountEntry, SummaryNewCandidate, SummaryReport } from "@trends/shared";
+
+import { SummaryRenderer } from "../summaries/summary-renderer.js";
+
+// --- renderCountList (private, tested via renderMarkdown) ---
+
+describe("SummaryRenderer.renderMarkdown", () => {
+  const renderer = new SummaryRenderer();
+
+  function makeReport(overrides: Partial<SummaryReport> = {}): SummaryReport {
+    return {
+      workspaceSlug: "test-ws",
+      period: "daily",
+      generatedAt: "2026-05-22T10:00:00Z",
+      window: { startAt: "2026-05-21", endAt: "2026-05-22", timezone: "Asia/Shanghai" },
+      totals: {
+        newResumes: 10,
+        candidateStatusUpdates: 5,
+        shortlistActions: 3,
+        rejectActions: 1,
+        contactActions: 2,
+        collectionTasksCompleted: 8,
+        collectionTasksFailed: 0,
+      },
+      breakdowns: {
+        resumesBySource: [],
+        candidateStatusByValue: [],
+        actionsByType: [],
+        collectionTasksByStatus: [],
+      },
+      notes: [],
+      ...overrides,
+    };
+  }
+
+  it("renders a minimal daily report", () => {
+    const md = renderer.renderMarkdown(makeReport());
+    expect(md).toContain("# Daily Ops Summary");
+    expect(md).toContain("- Workspace: test-ws");
+    expect(md).toContain("- Period: daily");
+    expect(md).toContain("- New resumes: 10");
+    expect(md).toContain("- Shortlist actions: 3");
+    expect(md).toContain("- Collection tasks completed: 8");
+  });
+
+  it("renders weekly title", () => {
+    const md = renderer.renderMarkdown(makeReport({ period: "weekly" }));
+    expect(md).toContain("# Weekly Ops Summary");
+  });
+
+  it("renders monthly title", () => {
+    const md = renderer.renderMarkdown(makeReport({ period: "monthly" }));
+    expect(md).toContain("# Monthly New Candidates Digest");
+  });
+
+  it("renders resume source breakdown", () => {
+    const entries: SummaryCountEntry[] = [
+      { key: "51job", label: "51job", count: 5 },
+      { key: "seek", label: "SEEK", count: 3 },
+    ];
+    const md = renderer.renderMarkdown(makeReport({
+      breakdowns: {
+        ...makeReport().breakdowns,
+        resumesBySource: entries,
+      },
+    }));
+    expect(md).toContain("- 51job: 5");
+    expect(md).toContain("- SEEK: 3");
+  });
+
+  it("renders '- none' for empty breakdown entries", () => {
+    const md = renderer.renderMarkdown(makeReport());
+    expect(md).toContain("- none");
+  });
+
+  it("renders previous period comparison with delta formatting", () => {
+    const md = renderer.renderMarkdown(makeReport({
+      comparison: {
+        previousWindow: { startAt: "2026-05-20", endAt: "2026-05-21", timezone: "Asia/Shanghai" },
+        totalsDelta: {
+          sharedIngest: { newResumes: 3, collectionTasksCompleted: -2, collectionTasksFailed: 0 },
+          workspaceActivity: { candidateStatusUpdates: 1, shortlistActions: -1, rejectActions: 0, contactActions: 5 },
+        },
+      },
+    }));
+    expect(md).toContain("## Previous Period Comparison");
+    expect(md).toContain("+3");
+    expect(md).toContain("-2");
+    expect(md).toContain("-1");
+    expect(md).toContain("+5");
+  });
+
+  it("renders new candidates section", () => {
+    const candidates: SummaryNewCandidate[] = [
+      {
+        resumeId: "r1",
+        name: "张某",
+        source: "51job",
+        location: "东莞",
+        experience: "5",
+        education: "本科",
+        score: 85,
+        recommendation: "strong_match",
+        crawledAt: "2026-05-22",
+      },
+      {
+        resumeId: "r2",
+        source: "seek",
+        crawledAt: "2026-05-22",
+      },
+    ];
+    const md = renderer.renderMarkdown(makeReport({ newCandidates: candidates }));
+    expect(md).toContain("## New Candidates (2)");
+    expect(md).toContain("张某 | 51job | 东莞 | 5yr | score:85");
+    expect(md).toContain("r2 | seek");
+  });
+
+  it("renders 'No new candidates' when list is empty", () => {
+    const md = renderer.renderMarkdown(makeReport({ newCandidates: [] }));
+    expect(md).toContain("## New Candidates (0)");
+    expect(md).toContain("- No new candidates in this period");
+  });
+
+  it("renders notes", () => {
+    const md = renderer.renderMarkdown(makeReport({ notes: ["System healthy", "No alerts"] }));
+    expect(md).toContain("- System healthy");
+    expect(md).toContain("- No alerts");
+  });
+
+  it("omits comparison section when not provided", () => {
+    const md = renderer.renderMarkdown(makeReport());
+    expect(md).not.toContain("Previous Period Comparison");
+  });
+
+  it("omits new candidates section when not provided", () => {
+    const md = renderer.renderMarkdown(makeReport());
+    expect(md).not.toContain("New Candidates");
+  });
+
+  it("uses scoped totals when available", () => {
+    const md = renderer.renderMarkdown(makeReport({
+      scopes: {
+        sharedIngest: {
+          totals: { newResumes: 20, collectionTasksCompleted: 15, collectionTasksFailed: 1 },
+          breakdowns: { resumesBySource: [], collectionTasksByStatus: [] },
+        },
+        workspaceActivity: {
+          totals: { candidateStatusUpdates: 10, shortlistActions: 6, rejectActions: 2, contactActions: 4 },
+          breakdowns: { candidateStatusByValue: [], actionsByType: [] },
+        },
+      },
+    }));
+    expect(md).toContain("- New resumes: 20");
+    expect(md).toContain("- Shortlist actions: 6");
+    expect(md).toContain("- Collection tasks failed: 1");
+  });
+});


### PR DESCRIPTION
## Summary
- Add 12 tests for `SummaryRenderer.renderMarkdown()` — covers daily/weekly/monthly titles, breakdowns, delta formatting, new candidates, notes, scoped totals, comparison section
- Add 11 tests for `SummaryDispatcher` — covers `buildPreview` (template selection, defaults, data), dry-run dispatch, email/wechat_work/feishu/telegram channels, email error handling

## Test plan
- [x] `vitest run` — 23/23 pass
- [x] `make check` — all checks pass