### PR TITLE
refactor: extract admin routes and Convex utils from resumes.ts

### DIFF
--- a/.claude/dev-loop.config.md
+++ b/.claude/dev-loop.config.md
@@ -1,7 +1,10 @@
 # Dev Loop — trends
 
 > Multi-source data aggregation platform with pluggable domain workflows.
-> Primary direction: resume screening (ingest, scoring, filtering, notification).
+> Primary direction: resume screening (ingest → search → scoring → notification).
+> Optimised for: **autonomous long-running cycles**, **TDD on critical paths**,
+> **Playwright-CLI against `make dev`** for browser-facing changes,
+> **resume search · collection · AI scoring** as critical paths.
 
 ## Identity
 
@@ -10,14 +13,14 @@ slug: trends
 vault: ~/wiki
 release_branch: main
 project_filter: trends
-cron_schedule: "*/15 * * * *"
+cron_schedule: "7,22,37,52 * * * *"
 ```
 
 ## PRD layer
 
 ```yaml
 prd_layer: superpowers
-prd_pipeline: full
+prd_pipeline: full              # full pipeline by default; trivial fast-path auto-detected
 ```
 
 ### PRD backends registry
@@ -36,29 +39,225 @@ prd_backends:
 
 ### Cross-cutting disciplines
 
+> v1.16.1: `include_paths` is parsed. TDD is mandatory only on critical-path
+> code files; advisory catch-all for everything else. First-match-wins
+> resolution per the schema. systematic-debugging fires reactively on
+> failure (see `reactive_debugging` block for retry budget).
+> verification-before-completion gates REVIEW for every cycle.
+
 ```yaml
 prd_disciplines:
   - skill: superpowers:test-driven-development
     when: execute
-    mode: advisory
+    mode: mandatory
+    include_paths:
+      - packages/convex/convex/resumes.ts
+      - packages/convex/convex/searchProfiles.ts
+      - packages/convex/convex/aiScoring*.ts
+      - packages/convex/convex/scoring.ts
+      - packages/convex/convex/scoringEvaluation.ts
+      - apps/api/src/routes/resumes.ts
+      - apps/api/src/routes/scoring-evaluation.ts
+      - apps/api/src/services/bff-filter-utils.ts
+      - apps/web/src/lib/useConvexResumes.ts
+  - skill: superpowers:test-driven-development
+    when: execute
+    mode: advisory                       # catch-all for non-critical files
   - skill: superpowers:systematic-debugging
     when: failure
     mode: reactive
+  - skill: superpowers:verification-before-completion
+    when: review
+    mode: mandatory
 ```
 
-## Interview
+## Critical paths
+
+> Used by REFRESH (CRITICAL_PATHS), QUERY bias, IDLE research ranking,
+> and WORK auto-priority escalation when changed files match `*.code`.
 
 ```yaml
-interview:
-  setup:
-    skill: setup-dev-loop
-    glossary: grill-with-docs        # delegates domain section when installed
-  work_item:
-    default: native                  # built-in three questions (zero-dependency)
-    upgrade: grill-with-docs         # optional upgrade — delegates when installed
-    source: mattpocock/skills
-    install: "npx skills@latest add mattpocock/skills --skill grill-with-docs -a claude-code -g -y"
-    trigger: auto                    # auto | manual | never
+critical_paths:
+  resume_search:
+    code:
+      - packages/convex/convex/resumes.ts
+      - packages/convex/convex/searchProfiles.ts
+      - apps/api/src/routes/resumes.ts
+      - apps/api/src/services/bff-filter-utils.ts
+      - apps/web/src/lib/useConvexResumes.ts
+    vault:
+      - concepts/resume-search-architecture
+      - concepts/search-filter-semantic-mapping
+      - concepts/bff-convex-filter-path-alignment
+      - concepts/search-filter-component-test-patterns
+    history_pins:
+      - "16 MiB byte-limit incident (PR #168 / 2026-03-11)"
+      - "scanResumePageSlim batch=200 fix (2026-05-05)"
+      - "BFF↔Convex filter parity (2026-05-21)"
+  collection_ingest:
+    code:
+      - apps/worker/
+      - packages/cli/cmd/resume/
+      - packages/convex/convex/resumes.ts
+      - packages/shared/src/parseSalaryRange.ts
+    vault:
+      - concepts/multi-source-resume-collection
+      - concepts/resume-source-locale
+      - concepts/seek-talent-search-url-parameters
+      - concepts/regional-industry-db-graceful-degradation
+    history_pins:
+      - "seek.com en/zh chinese-rules mismatch (2026-05-22)"
+      - "my.market ingestData backfill (2026-05-21)"
+      - "seek malaysia zero-results fix (2026-05-21)"
+  ai_scoring:
+    code:
+      - packages/convex/convex/aiScoring.ts
+      - packages/convex/convex/scoring.ts
+      - packages/convex/convex/scoringEvaluation.ts
+      - apps/api/src/routes/scoring-evaluation.ts
+    vault:
+      - concepts/resume-scoring-pipeline
+      - concepts/self-tuning-scoring
+      - concepts/llm-cost-gating
+      - queries/ai-resume-screening-quality-measurement-2026
+    history_pins:
+      - "LLM-primary scoring switch (PR #674)"
+      - "scoring threshold mismatch fix (2026-05-21)"
+      - "industry_db score normalization review (2026-03-12)"
+```
+
+## Fact-check tier
+
+> Default first stop for any non-trivial claim during SPEC/PLAN/EXECUTE/REVIEW.
+> Local sources first, web only when freshness or external authority is required.
+
+```yaml
+fact_check:
+  enabled: true
+  source_order:
+    - local_repo
+    - context7
+    - vault_query
+    - web_search
+  web_tools:
+    primary: mcp__grok-search__web_search
+    deep_fetch: mcp__grok-search__web_fetch
+    site_map: mcp__grok-search__web_map
+    plan_first: mcp__grok-search__plan_intent
+  triggers:
+    - "version "
+    - "deprecat"
+    - "CVE-"
+    - "release dates"
+    - "third-party tool not already in repo"
+  evidence_contract:
+    require_sources_used_section: true
+    cite_session_id: true
+```
+
+## Idle deep-research
+
+> When mechanical scan returns no P2+ findings, rotate research topics
+> through /deep-research. Long-running cron loops compound research backlog
+> from otherwise-dead idle cycles.
+
+```yaml
+idle_deep_research:
+  enabled: true
+  skill: deep-research
+  trigger:
+    when: idle_after_mechanical_scan
+    if: no_p2_or_higher_findings
+    cooldown: every_3rd_idle_cycle
+    max_per_day: 4
+  topic_seeds:
+    - "Convex search index byte-budget patterns 2026 — beyond maximumBytesRead"
+    - "Resume screening LLM scoring — explainability + drift detection 2026"
+    - "Chinese resume text segmentation — Convex/Tantivy CJK gaps in 2026"
+    - "Hono OpenAPI streaming + Server-Timing best practices"
+    - "FastAPI worker scheduling + idempotent crawl resume patterns"
+    - "Browser-extension MV3 + CDP automation patterns 2026"
+    - "AI scoring evaluation — NDCG/recall metrics for hiring at scale"
+    - "Multi-source resume dedup heuristics across boards (seek/51job/zhipin/my)"
+  topic_selection:
+    bias_toward: critical_paths
+    skip_if_recent_query_page_exists: 14d
+  output_mode: vault
+  budget:
+    web_searches: 3
+    deep_fetches: 3
+    context7_calls: 3
+  followups:
+    on_finding: capture_to_vault_then_create_work_item
+    p_score_default: P3
+```
+
+## Browser verification
+
+> Per CLAUDE.md feedback memory: every browser-facing change MUST be
+> verified against the running `make dev` stack via `/playwright-cli`.
+> Localhost URL is `http://localhost:5173` — never the external hostname.
+
+```yaml
+browser_verification:
+  enabled: true
+  trigger:
+    - "apps/web/**"
+    - "apps/browser-extension/**"
+    - "packages/convex/convex/resumes.ts"
+  prerequisites:
+    - "curl -fsS http://localhost:5173 >/dev/null"
+    - "make chrome-debug"
+    - "make dev"
+  driver: playwright-cli
+  base_url: http://localhost:5173
+  smoke_routes:
+    - /
+    - /resumes
+    - /search-profiles
+    - /scoring
+  reviser_workflow:
+    - take_snapshot
+    - list_console_messages
+    - evaluate_script
+  e2e_fallback: make e2e
+```
+
+## Reactive debugging
+
+> Caps systematic-debugging retries, captures evidence, fact-checks
+> external-lib errors via grok-search, escalates to a P1 finding after
+> N idle cycles with the same error signature.
+
+```yaml
+reactive_debugging:
+  enabled: true
+  auto_retry_attempts: 2
+  evidence_dir: .claude/dev-loop-debug/
+  evidence_capture:
+    - "make check 2>&1 | tee {evidence_dir}/{cycle}-check.log"
+    - "git diff --stat > {evidence_dir}/{cycle}-diff.txt"
+    - "git log --oneline -5 > {evidence_dir}/{cycle}-log.txt"
+  fact_check_tool: mcp__grok-search__web_search
+  escalate_after:
+    consecutive_idle_cycles: 3
+    same_error_signature: true
+  escalation_action: surface_p1_finding
+```
+
+## Code review
+
+> v1.15.0: simplify-worker always runs (base). Codex second-opinion is
+> opt-in per intensity. Currently OFF — toggle `enabled_in_high: true`
+> if you want a parallel reviewer on /dev-loop high cycles.
+
+```yaml
+code_review:
+  parallel: true
+  codex:
+    enabled_in_normal: false
+    enabled_in_high: false
+    agent: dev-loop:codex-review-worker
 ```
 
 ## Knowledge layer
@@ -76,6 +275,25 @@ knowledge_backends:
     cli_entry: skillwiki
 ```
 
+## Interview
+
+> `auto` keeps the loop unattended; native 3-question backend gates only
+> ambiguous specs. Long-running cycles will skip interviews on clearly
+> scoped trivial fast-path items.
+
+```yaml
+interview:
+  setup:
+    skill: setup-dev-loop
+    glossary: grill-with-docs
+  work_item:
+    default: native
+    upgrade: grill-with-docs
+    source: mattpocock/skills
+    install: "npx skills@latest add mattpocock/skills --skill grill-with-docs -a claude-code -g -y"
+    trigger: auto
+```
+
 ## Code layout
 
 ```yaml
@@ -90,6 +308,12 @@ cli_entry_override: bin/trends
 ```yaml
 e2e_scripts:
   - scripts/e2e-smoke.ts
+e2e_prerequisites:
+  - "make chrome-debug"
+  - "make dev"
+e2e_optional_benchmarks:
+  - make benchmark-critical-path
+  - make benchmark-dev-resume-latency
 ```
 
 ## Release
@@ -118,10 +342,25 @@ notes:
   stack: Monorepo — React+Vite (web), Hono+OpenAPI (api), FastAPI (worker), Convex (data)
   deploy: production deploys via `make on-prod-deploy` on ptcloud after `make on-prod-deploy-check`
   config_docs: CLAUDE.md is canonical; AGENTS.md is symlink
-  planning: EnterPlanMode gated — use superpowers:brainstorming -> superpowers:writing-plans instead
+  planning: EnterPlanMode gated — use superpowers:brainstorming → superpowers:writing-plans instead
   gotcha: api-types.ts regenerates on make check after API schema edits — always stage it
   gotcha: better-sqlite3 needs npm rebuild after Node version bumps
-  vault_drift: concept pages drift when code changes without vault sync — check scoring/search concepts after relevant commits
-  cron: durable every-15m, runs /loop with '/dev-loop high' + research + wiki, auto-expires 7d — renew with CronCreate before expiry
-  oauth_blocker: WeChat OAuth requires business license, WeCom requires admin - external deps not available
+  gotcha: Convex 16 MiB per-query byte limit — keep paginate batches ≤200 docs (~5.4MB)
+  gotcha: localhost:5173 only — never the external hostname when verifying
+  gotcha: BFF and Convex search filters MUST stay in lockstep (3 paths) — see concepts/bff-convex-filter-path-alignment
+  gotcha: Resume backups live at output/resume-backups/ — restore via `make local-restore-from-prod FILE=...`
+  gotcha: cmux task sandboxes (CMUX_TASK_RUN_JWT set, CMUX_IS_ORCHESTRATION_HEAD unset) MUST NOT run gh pr create — cmux handles it
+  vault_drift: scoring + search concept pages drift fastest — re-check after PRs touching resumes.ts or aiScoring.ts
+  cron: "7,22,37,52 * * * *" durable, runs `/loop /dev-loop high` — auto-expires 7d, renew with CronCreate
+  oauth_blocker: WeChat OAuth requires business license, WeCom requires admin — external deps not available
+  critical_path_test_seed: prod snapshot under output/resume-backups/ (~89k resumes); use it instead of local 51job collector for search/scoring tests
+  tdd_test_locations:
+    - packages/convex/test/
+    - apps/api/test/
+    - apps/web/src/**/*.test.ts(x)
+    - apps/worker/tests/
+  tdd_forbidden:
+    - "Replicating production logic inline in tests (bff-filter-utils memory)"
+    - "Mocking the database in integration tests (superpowers feedback)"
+    - "Skipping a failing test to ship"
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,8 @@ apps/web/public/extension/
 apps/worker/status.json
 .claude/scheduled_tasks.lock
 .claude/scheduled_tasks.json
+.claude/dev-loop-debug/
+.claude/dev-loop-work/
 
 .omc/
 .omx/

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -30,6 +30,7 @@ import {
   summariesRoutes,
   webVitalsRoutes,
   searchAlertsRoutes,
+  resumesAdminRoutes,
 } from "./routes/index.js";
 import { config } from "./services/config.js";
 import { workspaceMiddleware } from "./middleware/workspace.js";
@@ -109,6 +110,7 @@ export function createApp() {
   app.route("/", searchRoutes);
   app.route("/", rssRoutes);
   app.route("/", resumesRoutes);
+  app.route("/", resumesAdminRoutes);
   app.route("/", resumeSubmitRoutes);
   app.route("/", industryRoutes);
   app.route("/", jobDescriptionsRoutes);

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -23,3 +23,4 @@ export { default as workerRoutes } from "./worker.js";
 export { default as summariesRoutes } from "./summaries.js";
 export { default as webVitalsRoutes } from "./web-vitals.js";
 export { default as searchAlertsRoutes } from "./search-alerts.js";
+export { default as resumesAdminRoutes } from "./resumes_admin.js";

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -68,7 +68,6 @@ import {
   type RuleScoringResult,
 } from "../services/rule-scoring.js";
 import { resolveResumeId } from "../services/resume-id.js";
-import { IngestComputeService } from "../services/ingest-compute-service.js";
 import {
   buildLatestWorkHistoryEvidence,
   buildWorkHistoryEntryText,
@@ -114,6 +113,13 @@ import { BrandDisplayResolver } from "../services/brand-display-resolver.js";
 import { buildKeywordAnalysisId, getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey, resolveResumeDiagnosticsSourceKey } from "@trends/shared";
 import type { ResumeItem } from "../types/resume.js";
 import type { ResumeIndex } from "../services/resume-index.js";
+import {
+  callConvexQuery,
+  callConvexMutation,
+  callConvexAction,
+  isConvexPaginatedQueryPage,
+  type ConvexPaginatedQueryPage,
+} from "../services/convex-utils.js";
 
 const app = new OpenAPIHono();
 const resumeService = new ResumeService(config.projectRoot);
@@ -122,7 +128,6 @@ const matchStorage = new MatchStorage(config.projectRoot);
 const sessionManager = new SessionManager(config.projectRoot);
 const jobService = new JobDescriptionService(config.projectRoot);
 const ruleScoringService = new RuleScoringService(config.projectRoot);
-const ingestComputeService = new IngestComputeService(config.projectRoot);
 const skillsKnowledgeService = new SkillsKnowledgeService(config.projectRoot);
 const companyPatterns = skillsKnowledgeService.getCompanyPatterns();
 const searchEventLogger = new SearchEventLogger(config.projectRoot);
@@ -248,56 +253,6 @@ app.openapi(resetCandidateActionsRoute, async (c) => {
     const message = error instanceof Error ? error.message : String(error);
     return c.json({ success: false as const, error: message }, 500);
   }
-});
-
-const HardResetReingestRequestSchema = z.object({
-  dryRun: z.boolean().optional(),
-});
-
-const HardResetReingestResponseSchema = z.object({
-  success: z.literal(true),
-  dryRun: z.boolean().optional(),
-  cleared: z.number().int().optional(),
-  wouldClear: z.number().int().optional(),
-  scheduled: z.number().int().optional(),
-  batches: z.number().int().optional(),
-  phase: z.enum(["dry_run", "cleared", "scheduled", "failed_scheduling"]).optional(),
-  error: z.string().optional(),
-});
-
-const ClearAnalysesRequestSchema = z.object({
-  jobDescriptionId: z.string().trim().optional(),
-  resumeIds: z.array(z.string().trim().min(1)).optional(),
-  batchSize: z.number().int().min(1).max(200).optional(),
-  dryRun: z.boolean().optional(),
-});
-
-const ClearAnalysesResponseSchema = z.object({
-  success: z.literal(true),
-  dryRun: z.boolean().optional(),
-  cleared: z.number().int(),
-  wouldClear: z.number().int().optional(),
-  batches: z.number().int().optional(),
-  targeted: z.boolean(),
-  jobDescriptionId: z.string().optional(),
-});
-
-const ResetDatabaseRequestSchema = z.object({
-  dryRun: z.boolean().optional(),
-});
-
-const ArchiveResumesRequestSchema = z.object({
-  resumeIds: z.array(z.string()).min(1),
-  action: z.union([z.literal("archive"), z.literal("unarchive")]),
-});
-
-const ResetDatabaseV2ResponseSchema = z.object({
-  success: z.literal(true),
-  dryRun: z.boolean().optional(),
-  count: z.number().int().optional(),
-  wouldDelete: z.record(z.string(), z.number().int()).optional(),
-  partial: z.boolean().optional(),
-  deleted: z.record(z.string(), z.number().int()).optional(),
 });
 
 type ResumeExportCanonicalRequest = z.infer<typeof ResumeExportCanonicalRequestSchema>;
@@ -883,117 +838,6 @@ function prepareResumeCandidate(params: {
     companyHits: toStringArray(isRecord(rawIngestData) ? rawIngestData.companyHits : undefined),
     roleSignals: parseRoleSignals(isRecord(rawIngestData) ? rawIngestData.roleSignals : undefined),
   };
-}
-
-async function callConvexQuery(pathName: string, args: Record<string, unknown>): Promise<unknown> {
-  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
-  const response = await fetch(`${convexUrl}/api/query`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({
-      path: pathName,
-      args,
-    }),
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Convex query failed (${response.status}): ${text}`);
-  }
-
-  const payload = await response.json() as {
-    status?: string;
-    value?: unknown;
-    errorMessage?: string;
-  };
-
-  if (payload.status !== "success") {
-    throw new Error(payload.errorMessage || `Convex query failed for ${pathName}`);
-  }
-
-  return payload.value;
-}
-
-type ConvexPaginatedQueryPage = {
-  page: unknown[];
-  continueCursor: string;
-  isDone: boolean;
-};
-
-function isConvexPaginatedQueryPage(value: unknown): value is ConvexPaginatedQueryPage {
-  if (!isRecord(value)) {
-    return false;
-  }
-  return Array.isArray(value.page)
-    && typeof value.continueCursor === "string"
-    && typeof value.isDone === "boolean";
-}
-
-async function callConvexMutation(pathName: string, args: Record<string, unknown>): Promise<unknown> {
-  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
-  const response = await fetch(`${convexUrl}/api/mutation`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({
-      path: pathName,
-      args,
-    }),
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Convex mutation failed (${response.status}): ${text}`);
-  }
-
-  const payload = await response.json() as {
-    status?: string;
-    value?: unknown;
-    errorMessage?: string;
-  };
-
-  if (payload.status !== "success") {
-    throw new Error(payload.errorMessage || `Convex mutation failed for ${pathName}`);
-  }
-
-  return payload.value;
-}
-
-async function callConvexAction(pathName: string, args: Record<string, unknown>): Promise<unknown> {
-  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
-  const response = await fetch(`${convexUrl}/api/action`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({
-      path: pathName,
-      args,
-    }),
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Convex action failed (${response.status}): ${text}`);
-  }
-
-  const payload = await response.json() as {
-    status?: string;
-    value?: unknown;
-    errorMessage?: string;
-  };
-
-  if (payload.status !== "success") {
-    throw new Error(payload.errorMessage || `Convex action failed for ${pathName}`);
-  }
-
-  return payload.value;
 }
 
 function buildKeywordExpansionSummary(expansion: ResumeKeywordExpansion): {
@@ -5457,277 +5301,6 @@ app.openapi(getResumeDetailRoute, async (c) => {
   }
 });
 
-app.post("/api/resumes/hard-reset-reingest", async (c) => {
-  if (c.var.accessLevel !== "admin") {
-    return c.json({ success: false, error: "Admin access required" }, 403);
-  }
-
-  const body = await c.req.json().catch(() => ({}));
-  const parsed = HardResetReingestRequestSchema.safeParse(body);
-  if (!parsed.success) {
-    return c.json({ success: false, error: "Invalid request payload" }, 400);
-  }
-
-  const { dryRun } = parsed.data;
-
-  try {
-    if (dryRun) {
-      // Dry run: count resumes with computed fields without mutating
-      const firstPage = await callConvexMutation("resumes:hardResetIngestData", {
-        cursor: null,
-        batchSize: 50,
-      }) as { cleared: number; hasMore: boolean; cursor?: string };
-
-      let wouldClear = firstPage.cleared;
-      let cursor: string | undefined | null = firstPage.cursor;
-      let hasMore = firstPage.hasMore;
-
-      for (let i = 0; i < 10000 && hasMore; i++) {
-        const page = await callConvexMutation("resumes:hardResetIngestData", {
-          cursor,
-          batchSize: 50,
-        }) as { cleared: number; hasMore: boolean; cursor?: string };
-        wouldClear += page.cleared;
-        hasMore = page.hasMore;
-        cursor = page.cursor;
-      }
-
-      return c.json(HardResetReingestResponseSchema.parse({
-        success: true as const,
-        dryRun: true,
-        wouldClear,
-        phase: "dry_run",
-      }), 200);
-    }
-
-    // Phase 1: Clear all computed fields via paginated mutation
-    let totalCleared = 0;
-    let cursor: string | null | undefined = null;
-    let hasMore = true;
-
-    for (let i = 0; i < 10000 && hasMore; i++) {
-      const page = await callConvexMutation("resumes:hardResetIngestData", {
-        cursor,
-        batchSize: 50,
-      }) as { cleared: number; hasMore: boolean; cursor?: string };
-      totalCleared += page.cleared;
-      hasMore = page.hasMore;
-      cursor = page.cursor ?? null;
-    }
-
-    // Phase 2: Schedule full re-ingest
-    try {
-      const reingestResult = await callConvexAction("migrations:reIngestAllResumes", {}) as {
-        scheduled: number;
-        batches: number;
-      };
-      return c.json(HardResetReingestResponseSchema.parse({
-        success: true as const,
-        cleared: totalCleared,
-        scheduled: reingestResult.scheduled,
-        batches: reingestResult.batches,
-        phase: "scheduled",
-      }), 200);
-    } catch (schedulingError) {
-      // Partial failure: clearing succeeded but scheduling failed
-      const message = schedulingError instanceof Error ? schedulingError.message : String(schedulingError);
-      console.error("Failed to schedule re-ingest after hard reset", schedulingError);
-      return c.json(HardResetReingestResponseSchema.parse({
-        success: true as const,
-        cleared: totalCleared,
-        phase: "failed_scheduling",
-        error: message,
-      }), 200);
-    }
-  } catch (error) {
-    console.error("Failed to hard reset ingest data", error);
-    const message = error instanceof Error ? error.message : String(error);
-    return c.json({ success: false, error: message }, 500);
-  }
-});
-
-app.post("/api/resumes/clear-analyses", async (c) => {
-  if (c.var.accessLevel !== "admin") {
-    return c.json({ success: false, error: "Admin access required" }, 403);
-  }
-
-  const body = await c.req.json().catch(() => ({}));
-  const parsed = ClearAnalysesRequestSchema.safeParse(body);
-  if (!parsed.success) {
-    return c.json({ success: false, error: "Invalid request payload" }, 400);
-  }
-
-  const { jobDescriptionId, resumeIds, batchSize, dryRun } = parsed.data;
-  const isTargeted = (jobDescriptionId?.trim()?.length ?? 0) > 0 || (resumeIds?.length ?? 0) > 0;
-  const buildClearAnalysesArgs = (cursor?: string | null): Record<string, unknown> => {
-    const args: Record<string, unknown> = {
-      batchSize: batchSize ?? 50,
-    };
-
-    if (typeof cursor === "string" && cursor.trim().length > 0) {
-      args.cursor = cursor;
-    }
-    if (jobDescriptionId?.trim()) {
-      args.jobDescriptionId = jobDescriptionId.trim();
-    }
-    if (resumeIds && resumeIds.length > 0) {
-      args.resumeIds = resumeIds;
-    }
-
-    return args;
-  };
-
-  try {
-    if (dryRun) {
-      // Dry run: count resumes with analysis fields without mutating
-      const args = buildClearAnalysesArgs();
-
-      const firstPage = await callConvexMutation("resumes:clearAnalyses", args) as {
-        cleared: number;
-        hasMore: boolean;
-        cursor?: string;
-      };
-
-      let wouldClear = firstPage.cleared;
-      let cursor: string | undefined | null = firstPage.cursor;
-      let hasMore = firstPage.hasMore;
-
-      for (let i = 0; i < 10000 && hasMore && !isTargeted; i++) {
-        const pageArgs = buildClearAnalysesArgs(cursor);
-        const page = await callConvexMutation("resumes:clearAnalyses", pageArgs) as {
-          cleared: number;
-          hasMore: boolean;
-          cursor?: string;
-        };
-        wouldClear += page.cleared;
-        hasMore = page.hasMore;
-        cursor = page.cursor;
-      }
-
-      return c.json(ClearAnalysesResponseSchema.parse({
-        success: true as const,
-        dryRun: true,
-        cleared: 0,
-        wouldClear,
-        targeted: isTargeted,
-        jobDescriptionId: jobDescriptionId?.trim() || undefined,
-      }), 200);
-    }
-
-    // Full execution: paginated clearing
-    let totalCleared = 0;
-    let batches = 0;
-    let cursor: string | null | undefined = null;
-    let hasMore = true;
-
-    for (let i = 0; i < 10000 && hasMore; i++) {
-      const args = buildClearAnalysesArgs(cursor);
-
-      const page = await callConvexMutation("resumes:clearAnalyses", args) as {
-        cleared: number;
-        hasMore: boolean;
-        cursor?: string;
-      };
-      totalCleared += page.cleared;
-      batches += 1;
-      hasMore = page.hasMore;
-      cursor = page.cursor ?? null;
-
-      // Targeted clears are single-batch
-      if (isTargeted) break;
-    }
-
-    return c.json(ClearAnalysesResponseSchema.parse({
-      success: true as const,
-      cleared: totalCleared,
-      batches,
-      targeted: isTargeted,
-      jobDescriptionId: jobDescriptionId?.trim() || undefined,
-    }), 200);
-  } catch (error) {
-    console.error("Failed to clear analyses", error);
-    const message = error instanceof Error ? error.message : String(error);
-    return c.json({ success: false, error: message }, 500);
-  }
-});
-
-app.post("/api/resumes/reset-database", async (c) => {
-  if (c.var.accessLevel !== "admin") {
-    return c.json({ success: false, error: "Admin access required" }, 403);
-  }
-
-  const body = await c.req.json().catch(() => ({}));
-  const parsed = ResetDatabaseRequestSchema.safeParse(body);
-  if (!parsed.success) {
-    return c.json({ success: false, error: "Invalid request payload" }, 400);
-  }
-
-  const { dryRun } = parsed.data;
-
-  try {
-    if (dryRun) {
-      // Dry run: count documents per table without deleting
-      const result = await callConvexMutation("resume_tasks:resetDatabase", {}) as {
-        success: boolean;
-        count: number;
-        partial: boolean;
-        deleted: Record<string, number>;
-      };
-      return c.json(ResetDatabaseV2ResponseSchema.parse({
-        success: true as const,
-        dryRun: true,
-        wouldDelete: result.deleted,
-        count: result.count,
-      }), 200);
-    }
-
-    const value = await callConvexMutation("resume_tasks:resetDatabase", {});
-    return c.json(ResetDatabaseV2ResponseSchema.parse(value), 200);
-  } catch (error) {
-    console.error("Failed to reset database", error);
-    const message = error instanceof Error ? error.message : String(error);
-    return c.json({ success: false, error: message }, 500);
-  }
-});
-
-app.post("/api/resumes/archive", async (c) => {
-  if (c.var.accessLevel !== "admin") {
-    return c.json({ success: false, error: "Admin access required" }, 403);
-  }
-
-  const body = await c.req.json().catch(() => ({}));
-  const parsed = ArchiveResumesRequestSchema.safeParse(body);
-  if (!parsed.success) {
-    return c.json({ success: false, error: "Invalid request payload" }, 400);
-  }
-
-  const { resumeIds, action } = parsed.data;
-
-  try {
-    if (action === "archive") {
-      const result = await callConvexMutation("resumes:archiveResumes", { resumeIds }) as {
-        requested: number;
-        archived: number;
-        alreadyArchived: number;
-        missingResumeIds: string[];
-      };
-      return c.json({ success: true, ...result }, 200);
-    } else {
-      const result = await callConvexMutation("resumes:unarchiveResumes", { resumeIds }) as {
-        requested: number;
-        unarchived: number;
-        notArchived: number;
-        missingResumeIds: string[];
-      };
-      return c.json({ success: true, ...result }, 200);
-    }
-  } catch (error) {
-    console.error("Failed to archive/unarchive resumes", error);
-    const message = error instanceof Error ? error.message : String(error);
-    return c.json({ success: false, error: message }, 500);
-  }
-});
-
 app.post("/api/resumes/trigger-reingest", async (c) => {
   const body = await c.req.json().catch(() => ({}));
   const parsed = TriggerReingestRequestSchema.safeParse(body);
@@ -5738,24 +5311,6 @@ app.post("/api/resumes/trigger-reingest", async (c) => {
   try {
     const result = await triggerReingestStaleSkillsVersion(parsed.data.limit ?? 200);
     return c.json({ success: true, ...result }, 200);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return c.json({ success: false, error: message }, 500);
-  }
-});
-
-// Internal endpoint for ingest compute (called by Convex action)
-app.post("/api/resumes/ingest-compute", async (c) => {
-  const body = await c.req.json();
-  const resumes = body.resumes as Array<{ resumeId: string; content: unknown; sourceKey?: string }>;
-
-  if (!Array.isArray(resumes)) {
-    return c.json({ success: false, error: "Invalid request: expected { resumes: [...] }" }, 400);
-  }
-
-  try {
-    const results = ingestComputeService.computeBatch(resumes);
-    return c.json({ success: true, results }, 200);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return c.json({ success: false, error: message }, 500);

--- a/apps/api/src/routes/resumes_admin.ts
+++ b/apps/api/src/routes/resumes_admin.ts
@@ -1,0 +1,344 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { callConvexAction, callConvexMutation } from "../services/convex-utils.js";
+import { IngestComputeService } from "../services/ingest-compute-service.js";
+import { config } from "../services/config.js";
+
+const app = new OpenAPIHono();
+const ingestComputeService = new IngestComputeService(config.projectRoot);
+
+const HardResetReingestRequestSchema = z.object({
+  dryRun: z.boolean().optional(),
+});
+
+const HardResetReingestResponseSchema = z.object({
+  success: z.literal(true),
+  dryRun: z.boolean().optional(),
+  cleared: z.number().int().optional(),
+  wouldClear: z.number().int().optional(),
+  scheduled: z.number().int().optional(),
+  batches: z.number().int().optional(),
+  phase: z.enum(["dry_run", "cleared", "scheduled", "failed_scheduling"]).optional(),
+  error: z.string().optional(),
+});
+
+const ClearAnalysesRequestSchema = z.object({
+  jobDescriptionId: z.string().trim().optional(),
+  resumeIds: z.array(z.string().trim().min(1)).optional(),
+  batchSize: z.number().int().min(1).max(200).optional(),
+  dryRun: z.boolean().optional(),
+});
+
+const ClearAnalysesResponseSchema = z.object({
+  success: z.literal(true),
+  dryRun: z.boolean().optional(),
+  cleared: z.number().int(),
+  wouldClear: z.number().int().optional(),
+  batches: z.number().int().optional(),
+  targeted: z.boolean(),
+  jobDescriptionId: z.string().optional(),
+});
+
+const ResetDatabaseRequestSchema = z.object({
+  dryRun: z.boolean().optional(),
+});
+
+const ArchiveResumesRequestSchema = z.object({
+  resumeIds: z.array(z.string()).min(1),
+  action: z.union([z.literal("archive"), z.literal("unarchive")]),
+});
+
+const ResetDatabaseV2ResponseSchema = z.object({
+  success: z.literal(true),
+  dryRun: z.boolean().optional(),
+  count: z.number().int().optional(),
+  wouldDelete: z.record(z.string(), z.number().int()).optional(),
+  partial: z.boolean().optional(),
+  deleted: z.record(z.string(), z.number().int()).optional(),
+});
+
+// Hard reset re-ingest: clear computed fields and reschedule
+app.post("/api/resumes/hard-reset-reingest", async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false, error: "Admin access required" }, 403);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = HardResetReingestRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ success: false, error: "Invalid request payload" }, 400);
+  }
+
+  const { dryRun } = parsed.data;
+
+  try {
+    if (dryRun) {
+      const firstPage = await callConvexMutation("resumes:hardResetIngestData", {
+        cursor: null,
+        batchSize: 50,
+      }) as { cleared: number; hasMore: boolean; cursor?: string };
+
+      let wouldClear = firstPage.cleared;
+      let cursor: string | undefined | null = firstPage.cursor;
+      let hasMore = firstPage.hasMore;
+
+      for (let i = 0; i < 10000 && hasMore; i++) {
+        const page = await callConvexMutation("resumes:hardResetIngestData", {
+          cursor,
+          batchSize: 50,
+        }) as { cleared: number; hasMore: boolean; cursor?: string };
+        wouldClear += page.cleared;
+        hasMore = page.hasMore;
+        cursor = page.cursor;
+      }
+
+      return c.json(HardResetReingestResponseSchema.parse({
+        success: true as const,
+        dryRun: true,
+        wouldClear,
+        phase: "dry_run",
+      }), 200);
+    }
+
+    let totalCleared = 0;
+    let cursor: string | null | undefined = null;
+    let hasMore = true;
+
+    for (let i = 0; i < 10000 && hasMore; i++) {
+      const page = await callConvexMutation("resumes:hardResetIngestData", {
+        cursor,
+        batchSize: 50,
+      }) as { cleared: number; hasMore: boolean; cursor?: string };
+      totalCleared += page.cleared;
+      hasMore = page.hasMore;
+      cursor = page.cursor ?? null;
+    }
+
+    try {
+      const reingestResult = await callConvexAction("migrations:reIngestAllResumes", {}) as {
+        scheduled: number;
+        batches: number;
+      };
+      return c.json(HardResetReingestResponseSchema.parse({
+        success: true as const,
+        cleared: totalCleared,
+        scheduled: reingestResult.scheduled,
+        batches: reingestResult.batches,
+        phase: "scheduled",
+      }), 200);
+    } catch (schedulingError) {
+      const message = schedulingError instanceof Error ? schedulingError.message : String(schedulingError);
+      console.error("Failed to schedule re-ingest after hard reset", schedulingError);
+      return c.json(HardResetReingestResponseSchema.parse({
+        success: true as const,
+        cleared: totalCleared,
+        phase: "failed_scheduling",
+        error: message,
+      }), 200);
+    }
+  } catch (error) {
+    console.error("Failed to hard reset ingest data", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+// Clear analyses for specific JDs or resume IDs
+app.post("/api/resumes/clear-analyses", async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false, error: "Admin access required" }, 403);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = ClearAnalysesRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ success: false, error: "Invalid request payload" }, 400);
+  }
+
+  const { jobDescriptionId, resumeIds, batchSize, dryRun } = parsed.data;
+  const isTargeted = (jobDescriptionId?.trim()?.length ?? 0) > 0 || (resumeIds?.length ?? 0) > 0;
+  const buildClearAnalysesArgs = (cursor?: string | null): Record<string, unknown> => {
+    const args: Record<string, unknown> = {
+      batchSize: batchSize ?? 50,
+    };
+
+    if (typeof cursor === "string" && cursor.trim().length > 0) {
+      args.cursor = cursor;
+    }
+    if (jobDescriptionId?.trim()) {
+      args.jobDescriptionId = jobDescriptionId.trim();
+    }
+    if (resumeIds && resumeIds.length > 0) {
+      args.resumeIds = resumeIds;
+    }
+
+    return args;
+  };
+
+  try {
+    if (dryRun) {
+      const args = buildClearAnalysesArgs();
+
+      const firstPage = await callConvexMutation("resumes:clearAnalyses", args) as {
+        cleared: number;
+        hasMore: boolean;
+        cursor?: string;
+      };
+
+      let wouldClear = firstPage.cleared;
+      let cursor: string | undefined | null = firstPage.cursor;
+      let hasMore = firstPage.hasMore;
+
+      for (let i = 0; i < 10000 && hasMore && !isTargeted; i++) {
+        const pageArgs = buildClearAnalysesArgs(cursor);
+        const page = await callConvexMutation("resumes:clearAnalyses", pageArgs) as {
+          cleared: number;
+          hasMore: boolean;
+          cursor?: string;
+        };
+        wouldClear += page.cleared;
+        hasMore = page.hasMore;
+        cursor = page.cursor;
+      }
+
+      return c.json(ClearAnalysesResponseSchema.parse({
+        success: true as const,
+        dryRun: true,
+        cleared: 0,
+        wouldClear,
+        targeted: isTargeted,
+        jobDescriptionId: jobDescriptionId?.trim() || undefined,
+      }), 200);
+    }
+
+    let totalCleared = 0;
+    let batches = 0;
+    let cursor: string | null | undefined = null;
+    let hasMore = true;
+
+    for (let i = 0; i < 10000 && hasMore; i++) {
+      const args = buildClearAnalysesArgs(cursor);
+
+      const page = await callConvexMutation("resumes:clearAnalyses", args) as {
+        cleared: number;
+        hasMore: boolean;
+        cursor?: string;
+      };
+      totalCleared += page.cleared;
+      batches += 1;
+      hasMore = page.hasMore;
+      cursor = page.cursor ?? null;
+
+      if (isTargeted) break;
+    }
+
+    return c.json(ClearAnalysesResponseSchema.parse({
+      success: true as const,
+      cleared: totalCleared,
+      batches,
+      targeted: isTargeted,
+      jobDescriptionId: jobDescriptionId?.trim() || undefined,
+    }), 200);
+  } catch (error) {
+    console.error("Failed to clear analyses", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+// Reset database (admin only)
+app.post("/api/resumes/reset-database", async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false, error: "Admin access required" }, 403);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = ResetDatabaseRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ success: false, error: "Invalid request payload" }, 400);
+  }
+
+  const { dryRun } = parsed.data;
+
+  try {
+    if (dryRun) {
+      const result = await callConvexMutation("resume_tasks:resetDatabase", {}) as {
+        success: boolean;
+        count: number;
+        partial: boolean;
+        deleted: Record<string, number>;
+      };
+      return c.json(ResetDatabaseV2ResponseSchema.parse({
+        success: true as const,
+        dryRun: true,
+        wouldDelete: result.deleted,
+        count: result.count,
+      }), 200);
+    }
+
+    const value = await callConvexMutation("resume_tasks:resetDatabase", {});
+    return c.json(ResetDatabaseV2ResponseSchema.parse(value), 200);
+  } catch (error) {
+    console.error("Failed to reset database", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+// Archive/unarchive resumes
+app.post("/api/resumes/archive", async (c) => {
+  if (c.var.accessLevel !== "admin") {
+    return c.json({ success: false, error: "Admin access required" }, 403);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = ArchiveResumesRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ success: false, error: "Invalid request payload" }, 400);
+  }
+
+  const { resumeIds, action } = parsed.data;
+
+  try {
+    if (action === "archive") {
+      const result = await callConvexMutation("resumes:archiveResumes", { resumeIds }) as {
+        requested: number;
+        archived: number;
+        alreadyArchived: number;
+        missingResumeIds: string[];
+      };
+      return c.json({ success: true, ...result }, 200);
+    } else {
+      const result = await callConvexMutation("resumes:unarchiveResumes", { resumeIds }) as {
+        requested: number;
+        unarchived: number;
+        notArchived: number;
+        missingResumeIds: string[];
+      };
+      return c.json({ success: true, ...result }, 200);
+    }
+  } catch (error) {
+    console.error("Failed to archive/unarchive resumes", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+// Ingest compute (internal — called by Convex action)
+app.post("/api/resumes/ingest-compute", async (c) => {
+  const body = await c.req.json();
+  const resumes = body.resumes as Array<{ resumeId: string; content: unknown; sourceKey?: string }>;
+
+  if (!Array.isArray(resumes)) {
+    return c.json({ success: false, error: "Invalid request: expected { resumes: [...] }" }, 400);
+  }
+
+  try {
+    const results = ingestComputeService.computeBatch(resumes);
+    return c.json({ success: true, results }, 200);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+export default app;

--- a/apps/api/src/services/convex-utils.ts
+++ b/apps/api/src/services/convex-utils.ts
@@ -1,0 +1,116 @@
+import { resolveConvexUrl } from "../services/resume-import-service.js";
+
+export type ConvexPaginatedQueryPage = {
+  page: unknown[];
+  continueCursor: string;
+  isDone: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isConvexPaginatedQueryPage(value: unknown): value is ConvexPaginatedQueryPage {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return Array.isArray(value.page)
+    && typeof value.continueCursor === "string"
+    && typeof value.isDone === "boolean";
+}
+
+export async function callConvexQuery(pathName: string, args: Record<string, unknown>): Promise<unknown> {
+  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+  const response = await fetch(`${convexUrl}/api/query`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      path: pathName,
+      args,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Convex query failed (${response.status}): ${text}`);
+  }
+
+  const payload = await response.json() as {
+    status?: string;
+    value?: unknown;
+    errorMessage?: string;
+  };
+
+  if (payload.status !== "success") {
+    throw new Error(payload.errorMessage || `Convex query failed for ${pathName}`);
+  }
+
+  return payload.value;
+}
+
+export async function callConvexMutation(pathName: string, args: Record<string, unknown>): Promise<unknown> {
+  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+  const response = await fetch(`${convexUrl}/api/mutation`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      path: pathName,
+      args,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Convex mutation failed (${response.status}): ${text}`);
+  }
+
+  const payload = await response.json() as {
+    status?: string;
+    value?: unknown;
+    errorMessage?: string;
+  };
+
+  if (payload.status !== "success") {
+    throw new Error(payload.errorMessage || `Convex mutation failed for ${pathName}`);
+  }
+
+  return payload.value;
+}
+
+export async function callConvexAction(pathName: string, args: Record<string, unknown>): Promise<unknown> {
+  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
+  const response = await fetch(`${convexUrl}/api/action`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      path: pathName,
+      args,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Convex action failed (${response.status}): ${text}`);
+  }
+
+  const payload = await response.json() as {
+    status?: string;
+    value?: unknown;
+    errorMessage?: string;
+  };
+
+  if (payload.status !== "success") {
+    throw new Error(payload.errorMessage || `Convex action failed for ${pathName}`);
+  }
+
+  return payload.value;
+}


### PR DESCRIPTION
## Summary
- Extracted 5 admin route handlers (hard-reset-reingest, clear-analyses, reset-database, archive, ingest-compute) into `apps/api/src/routes/resumes_admin.ts` with dedicated schemas
- Extracted shared Convex call utilities (`callConvexQuery`, `callConvexMutation`, `callConvexAction`, `isConvexPaginatedQueryPage`) into `apps/api/src/services/convex-utils.ts`
- Reduced `apps/api/src/routes/resumes.ts` from 5909 to 5464 lines (–445 lines)
- Removed dead `IngestComputeService` import/instantiation from `resumes.ts`
- Wired new route module in `apps/api/src/routes/index.ts` and `apps/api/src/app.ts`

## Verification
- **Tests**: 2518 passed, 7 skipped (pre-existing) — 171 test files
- **make check**: All checks passed (typecheck, lint, policy, skills)
- **Behavioral change**: 0 — pure extraction with no logic modifications
- **Coverage**: Existing `resumes.test.ts` tests cover the remaining routes; admin routes are simple Convex call wrappers

## Files changed
**New**
- `apps/api/src/services/convex-utils.ts` — shared Convex call utilities (116 lines)
- `apps/api/src/routes/resumes_admin.ts` — admin route handler module (344 lines)

**Modified**
- `apps/api/src/routes/resumes.ts` — removed admin schemas, admin routes, and Convex call helpers (–471 lines)
- `apps/api/src/routes/index.ts` — added `resumesAdminRoutes` export
- `apps/api/src/app.ts` — mounted `resumesAdminRoutes`