### PR TITLE
refactor: extract diagnostics routes from resumes.ts (4112→3955 lines)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -30,6 +30,7 @@ import {
   summariesRoutes,
   webVitalsRoutes,
   searchAlertsRoutes,
+  resumesDiagnosticsRoutes,
   resumesAdminRoutes,
   resumesSearchRoutes,
 } from "./routes/index.js";
@@ -110,6 +111,7 @@ export function createApp() {
   app.route("/", topicsRoutes);
   app.route("/", searchRoutes);
   app.route("/", rssRoutes);
+  app.route("/", resumesDiagnosticsRoutes);
   app.route("/", resumesRoutes);
   app.route("/", resumesAdminRoutes);
   app.route("/", resumesSearchRoutes);

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -25,3 +25,4 @@ export { default as webVitalsRoutes } from "./web-vitals.js";
 export { default as searchAlertsRoutes } from "./search-alerts.js";
 export { default as resumesAdminRoutes } from "./resumes_admin.js";
 export { default as resumesSearchRoutes } from "./resumes_search.js";
+export { default as resumesDiagnosticsRoutes } from "./resumes_diagnostics.js";

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -9,8 +9,6 @@ import {
   ResumesResponseSchema,
   ResumeDetailPathParamSchema,
   ResumeDetailResponseSchema,
-  ResumeDiagnosticsQuerySchema,
-  ResumeDiagnosticsResponseSchema,
   ResumeKeywordExpansionQuerySchema,
   ResumeKeywordExpansionResponseSchema,
   ResumeSamplesResponseSchema,
@@ -43,7 +41,6 @@ import {
   MatchRunsQuerySchema,
   AnalyzeRequestSchema,
   AnalyzeResponseSchema,
-  AnalysisTasksResponseSchema,
 } from "../schemas/index.js";
 import { config } from "../services/config.js";
 import { ResumeService, normalizeEducationLevel, parseExperienceYears, type ResumeFilters } from "../services/resume-service.js";
@@ -110,7 +107,7 @@ import { formatIsoOffsetInTimezone } from "../services/timezone.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { BrandDisplayResolver } from "../services/brand-display-resolver.js";
 
-import { buildKeywordAnalysisId, getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey, resolveResumeDiagnosticsSourceKey } from "@trends/shared";
+import { buildKeywordAnalysisId, getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey } from "@trends/shared";
 import type { ResumeItem } from "../types/resume.js";
 import type { ResumeIndex } from "../services/resume-index.js";
 import {
@@ -791,19 +788,6 @@ function normalizeResumeBackupFilterValues(values: string[] | undefined): string
 function normalizeResumeBackupSourceHosts(values: string[] | undefined): string[] | undefined {
   const normalized = normalizeResumeBackupFilterValues(values);
   return normalized?.map((value) => value.toLowerCase());
-}
-
-function normalizeResumeDiagnosticsSourceKeys(values: string[] | undefined): string[] | undefined {
-  if (!values?.length) {
-    return undefined;
-  }
-
-  const resolved = Array.from(new Set(
-    values
-      .map((value) => resolveResumeDiagnosticsSourceKey({ sourceKey: value.trim(), source: value.trim() }))
-  ));
-
-  return resolved.length > 0 ? resolved : undefined;
 }
 
 function prepareResumeCandidate(params: {
@@ -3686,147 +3670,6 @@ app.post("/api/resumes/learning-feedback", async (c) => {
   }
 });
 
-app.get("/api/resumes/analysis-tasks", async (c) => {
-  try {
-    const tasks = (await callConvexQuery("analysis_tasks:list", {})) as Array<{
-      _id: string;
-      status: string;
-      _creationTime: number;
-      config?: {
-        jobDescriptionId?: string;
-        jobDescriptionTitle?: string;
-        keywords?: string[];
-        location?: string;
-        promptVersion?: number;
-        resumeCount?: number;
-      };
-      progress?: { current?: number; total?: number; skipped?: number };
-      results?: {
-        analyzed?: number;
-        failed?: number;
-        avgScore?: number;
-        highScoreCount?: number;
-      };
-      lastStatus?: string;
-      error?: string;
-    }>;
-
-    return c.json(
-      AnalysisTasksResponseSchema.parse({
-        success: true,
-        tasks,
-      }),
-      200,
-    );
-  } catch (error) {
-    console.error("Failed to list analysis tasks", error);
-    const message = error instanceof Error ? error.message : String(error);
-    return c.json({ success: false, error: message }, 500);
-  }
-});
-
-app.get("/api/resumes/skills-version", (c) => {
-  const version = skillsKnowledgeService.getVersion();
-  return c.json({ success: true, version }, 200);
-});
-
-app.get("/api/resumes/field-coverage", async (c) => {
-  const total = { scanned: 0, missingSearchText: 0, missingVerifiedRoleYears: 0, hasRoleSignals: 0 };
-  let cursor: string | null = null;
-
-  for (let i = 0; i < 100; i++) {
-    const batch = await callConvexQuery("resumes:fieldCoverage", {
-      ...(cursor ? { cursor } : {}),
-      batchSize: 200,
-    }) as {
-      scanned: number;
-      missingSearchText: number;
-      missingVerifiedRoleYears: number;
-      hasRoleSignals: number;
-      hasMore: boolean;
-      cursor: string | null;
-    };
-    total.scanned += batch.scanned;
-    total.missingSearchText += batch.missingSearchText;
-    total.missingVerifiedRoleYears += batch.missingVerifiedRoleYears;
-    total.hasRoleSignals += batch.hasRoleSignals;
-
-    if (!batch.hasMore) break;
-    cursor = batch.cursor;
-  }
-
-  return c.json({ success: true, ...total }, 200);
-});
-
-const listResumeDiagnosticsRoute = createRoute({
-  method: "get",
-  path: "/api/resumes/diagnostics",
-  tags: ["resumes"],
-  summary: "List resume diagnostics rows with optional archived/source filters",
-  request: {
-    query: ResumeDiagnosticsQuerySchema,
-  },
-  responses: {
-    200: {
-      content: {
-        "application/json": {
-          schema: ResumeDiagnosticsResponseSchema,
-        },
-      },
-      description: "Diagnostics rows",
-    },
-  },
-});
-
-app.openapi(listResumeDiagnosticsRoute, async (c) => {
-  const {
-    archived,
-    sourceKey,
-    limit,
-  } = c.req.valid("query");
-
-  const includeArchived = archived === true;
-  const requestedLimit = Math.min(Math.max(limit ?? 100, 1), 500);
-  const normalizedSourceKeys = normalizeResumeDiagnosticsSourceKeys(sourceKey);
-  const pathName = includeArchived ? "resumes:listArchivedDiagnostics" : "resumes:listIngestDiagnostics";
-  const rows: unknown[] = [];
-  let cursor: string | null = null;
-
-  for (let rounds = 0; rounds < 100 && rows.length < requestedLimit; rounds += 1) {
-    const value = await callConvexQuery(pathName, {
-      paginationOpts: {
-        cursor,
-        numItems: Math.min(requestedLimit - rows.length, 100),
-      },
-      ...(normalizedSourceKeys ? { sourceKeys: normalizedSourceKeys } : {}),
-    });
-
-    if (!isConvexPaginatedQueryPage(value)) {
-      throw new Error(`Unexpected diagnostics page payload for ${pathName}`);
-    }
-
-    rows.push(...value.page);
-    if (value.isDone) {
-      break;
-    }
-
-    cursor = value.continueCursor ?? null;
-    if (!cursor) {
-      break;
-    }
-  }
-
-  return c.json(ResumeDiagnosticsResponseSchema.parse({
-    success: true as const,
-    summary: {
-      archived: includeArchived,
-      ...(normalizedSourceKeys ? { sourceKeys: normalizedSourceKeys } : {}),
-      returned: rows.length,
-      limit: requestedLimit,
-    },
-    data: rows,
-  }), 200);
-});
 function findSampleResumeByIdentifier(items: ResumeItem[], resumeId: string): ResumeItem | null {
   const normalizedResumeId = resumeId.trim();
   if (!normalizedResumeId) {

--- a/apps/api/src/routes/resumes_diagnostics.ts
+++ b/apps/api/src/routes/resumes_diagnostics.ts
@@ -1,0 +1,170 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { callConvexQuery, isConvexPaginatedQueryPage } from "../services/convex-utils.js";
+import { SkillsKnowledgeService } from "../services/skills-knowledge.js";
+import { config } from "../services/config.js";
+import { resolveResumeDiagnosticsSourceKey } from "@trends/shared";
+import {
+  AnalysisTasksResponseSchema,
+  ResumeDiagnosticsQuerySchema,
+  ResumeDiagnosticsResponseSchema,
+} from "../schemas/index.js";
+
+const app = new OpenAPIHono();
+const skillsKnowledgeService = new SkillsKnowledgeService(config.projectRoot);
+
+function normalizeResumeDiagnosticsSourceKeys(values: string[] | undefined): string[] | undefined {
+  if (!values?.length) {
+    return undefined;
+  }
+
+  const resolved = Array.from(new Set(
+    values
+      .map((value) => resolveResumeDiagnosticsSourceKey({ sourceKey: value.trim(), source: value.trim() }))
+  ));
+
+  return resolved.length > 0 ? resolved : undefined;
+}
+
+app.get("/api/resumes/analysis-tasks", async (c) => {
+  try {
+    const tasks = (await callConvexQuery("analysis_tasks:list", {})) as Array<{
+      _id: string;
+      status: string;
+      _creationTime: number;
+      config?: {
+        jobDescriptionId?: string;
+        jobDescriptionTitle?: string;
+        keywords?: string[];
+        location?: string;
+        promptVersion?: number;
+        resumeCount?: number;
+      };
+      progress?: { current?: number; total?: number; skipped?: number };
+      results?: {
+        analyzed?: number;
+        failed?: number;
+        avgScore?: number;
+        highScoreCount?: number;
+      };
+      lastStatus?: string;
+      error?: string;
+    }>;
+
+    return c.json(
+      AnalysisTasksResponseSchema.parse({
+        success: true,
+        tasks,
+      }),
+      200,
+    );
+  } catch (error) {
+    console.error("Failed to list analysis tasks", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+app.get("/api/resumes/skills-version", (c) => {
+  const version = skillsKnowledgeService.getVersion();
+  return c.json({ success: true, version }, 200);
+});
+
+app.get("/api/resumes/field-coverage", async (c) => {
+  const total = { scanned: 0, missingSearchText: 0, missingVerifiedRoleYears: 0, hasRoleSignals: 0 };
+  let cursor: string | null = null;
+
+  for (let i = 0; i < 100; i++) {
+    const batch = await callConvexQuery("resumes:fieldCoverage", {
+      ...(cursor ? { cursor } : {}),
+      batchSize: 200,
+    }) as {
+      scanned: number;
+      missingSearchText: number;
+      missingVerifiedRoleYears: number;
+      hasRoleSignals: number;
+      hasMore: boolean;
+      cursor: string | null;
+    };
+    total.scanned += batch.scanned;
+    total.missingSearchText += batch.missingSearchText;
+    total.missingVerifiedRoleYears += batch.missingVerifiedRoleYears;
+    total.hasRoleSignals += batch.hasRoleSignals;
+
+    if (!batch.hasMore) break;
+    cursor = batch.cursor;
+  }
+
+  return c.json({ success: true, ...total }, 200);
+});
+
+const listResumeDiagnosticsRoute = createRoute({
+  method: "get",
+  path: "/api/resumes/diagnostics",
+  tags: ["resumes"],
+  summary: "List resume diagnostics rows with optional archived/source filters",
+  request: {
+    query: ResumeDiagnosticsQuerySchema,
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ResumeDiagnosticsResponseSchema,
+        },
+      },
+      description: "Diagnostics rows",
+    },
+  },
+});
+
+app.openapi(listResumeDiagnosticsRoute, async (c) => {
+  const {
+    archived,
+    sourceKey,
+    limit,
+  } = c.req.valid("query");
+
+  const includeArchived = archived === true;
+  const requestedLimit = Math.min(Math.max(limit ?? 100, 1), 500);
+  const normalizedSourceKeys = normalizeResumeDiagnosticsSourceKeys(sourceKey);
+  const pathName = includeArchived ? "resumes:listArchivedDiagnostics" : "resumes:listIngestDiagnostics";
+  const rows: unknown[] = [];
+  let cursor: string | null = null;
+
+  for (let rounds = 0; rounds < 100 && rows.length < requestedLimit; rounds += 1) {
+    const value = await callConvexQuery(pathName, {
+      paginationOpts: {
+        cursor,
+        numItems: Math.min(requestedLimit - rows.length, 100),
+      },
+      ...(normalizedSourceKeys ? { sourceKeys: normalizedSourceKeys } : {}),
+    });
+
+    if (!isConvexPaginatedQueryPage(value)) {
+      throw new Error(`Unexpected diagnostics page payload for ${pathName}`);
+    }
+
+    rows.push(...value.page);
+    if (value.isDone) {
+      break;
+    }
+
+    cursor = value.continueCursor ?? null;
+    if (!cursor) {
+      break;
+    }
+  }
+
+  return c.json(ResumeDiagnosticsResponseSchema.parse({
+    success: true as const,
+    summary: {
+      archived: includeArchived,
+      ...(normalizedSourceKeys ? { sourceKeys: normalizedSourceKeys } : {}),
+      returned: rows.length,
+      limit: requestedLimit,
+    },
+    data: rows,
+  }), 200);
+});
+
+export default app;


### PR DESCRIPTION
## Summary
- Extracted 4 diagnostic route handlers (analysis-tasks, skills-version, field-coverage, list-diagnostics) into `apps/api/src/routes/resumes_diagnostics.ts`
- Reduced `apps/api/src/routes/resumes.ts` from 4112 to 3955 lines (–157 lines)
- Mounted BEFORE resumesRoutes so static diagnostic paths aren't shadowed by the `{resumeId}` dynamic route
- Follows same pattern as resumes_admin.ts and resumes_search.ts

## Verification
- **Tests**: 2589 passed, 7 skipped — 176 test files
- **make check**: TypeScript compiles with zero errors
- **Behavioral change**: 0 — pure extraction with no logic modifications