### PR TITLE
refactor: extract content.ts into DI factory modules (1989→1111 lines)

### DIFF
--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -33,6 +33,7 @@ import { createSnapshotCollector } from "./lib/snapshot-collector";
 import { createAutoActions } from "./lib/auto-actions";
 import { createUiUtils } from "./lib/ui-utils";
 import { createPaginationUtils } from "./lib/pagination-utils";
+import { createDomUtils } from "./lib/dom-utils";
 import { createResumeExtractor } from "./lib/resume-extractor";
 
 /**
@@ -270,6 +271,22 @@ const {
   installReloadHelper,
   isLoggedIn,
 } = _uiUtils;
+
+const _domUtils = createDomUtils({
+  win: window,
+  doc: document,
+  getPaginationInfo,
+});
+const {
+  waitForPageTransition,
+  isElementVisible,
+  asHTMLElement,
+  setInputValue,
+  fireMouseEvent,
+  activateElement,
+  findVueParentByName,
+} = _domUtils;
+
 const _seekExtractor = createSeekExtractor({
   getCurrentSourceKey,
   SOURCE_KEYS,
@@ -1446,139 +1463,6 @@ const SyncStatusWidget = (() => {
     hide,
   };
 })();
-
-/**
- * @param {{ expectedPage?: number; timeoutMs?: number }} options
- */
-function waitForPageTransition(options = {}) {
-  const { expectedPage, timeoutMs = 15000 } = options;
-  return new Promise((resolve, reject) => {
-    if (!Number.isFinite(expectedPage) || expectedPage < 1) {
-      reject(new Error("Invalid expected page"));
-      return;
-    }
-
-    let done = false;
-    const deadline = Date.now() + timeoutMs;
-
-    const check = () => {
-      if (done) return;
-      const pagination = getPaginationInfo();
-      if (pagination.currentPage === expectedPage) {
-        done = true;
-        cleanup();
-        resolve(pagination.currentPage);
-      } else if (Date.now() > deadline) {
-        done = true;
-        cleanup();
-        reject(new Error(`Timed out waiting for page ${expectedPage}`));
-      }
-    };
-
-    const cleanup = () => {
-      clearInterval(intervalId);
-      observer.disconnect();
-    };
-
-    const intervalId = setInterval(check, 300);
-    const observer = new MutationObserver(check);
-    observer.observe(document.body || document.documentElement, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-    });
-    check();
-  });
-}
-
-
-function isElementVisible(element) {
-  if (!element) return false;
-  const style = window.getComputedStyle(element);
-  return style.display !== "none" && style.visibility !== "hidden";
-}
-
-
-
-/**
- * @param {Element | null | undefined} element
- * @returns {HTMLElement | null}
- */
-function asHTMLElement(element) {
-  return element instanceof HTMLElement ? element : null;
-}
-
-/**
- * @param {ParentNode | null | undefined} container
- * @param {string} text
- * @returns {HTMLElement | null}
- */
-
-/**
- * @param {string} blockSelector
- * @param {{ timeoutMs?: number, itemSelector?: string }} [options]
- * @returns {Promise<{ block: Element, items: Element[] }>}
- */
-
-
-
-
-
-function setInputValue(input, value) {
-  const inputWindow = input?.ownerDocument?.defaultView || window;
-  const inputCtor =
-    inputWindow.HTMLInputElement ||
-    globalThis.HTMLInputElement;
-  const descriptor = inputCtor
-    ? Object.getOwnPropertyDescriptor(inputCtor.prototype, "value")
-    : null;
-  if (descriptor?.set) {
-    descriptor.set.call(input, value);
-  } else {
-    input.value = value;
-  }
-  input.dispatchEvent(new inputWindow.Event("input", { bubbles: true }));
-  input.dispatchEvent(new inputWindow.Event("change", { bubbles: true }));
-}
-
-function fireMouseEvent(target, type) {
-  try {
-    const targetWindow = target?.ownerDocument?.defaultView || window;
-    target.dispatchEvent(
-      new targetWindow.MouseEvent(type, {
-        bubbles: true,
-        cancelable: true,
-        view: targetWindow,
-      }),
-    );
-  } catch {
-    // ignore
-  }
-}
-
-function activateElement(target) {
-  if (!target) {
-    return;
-  }
-  ["mouseenter", "mouseover", "mousedown", "mouseup"].forEach((type) =>
-    fireMouseEvent(target, type),
-  );
-  target.click?.();
-}
-
-function findVueParentByName(node, componentName, { maxDepth = 8 } = {}) {
-  let vm = node?.__vue__ || null;
-  for (let depth = 0; vm && depth < maxDepth; depth += 1) {
-    if (vm?.$options?.name === componentName) {
-      return vm;
-    }
-    vm = vm?.$parent || null;
-  }
-  return null;
-}
-
-
-
 
 async function runAutoSyncIfEnabled() {
   if (autoSyncTriggered) return;

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -188,6 +188,28 @@ const pipelineState = {
   set runId(v) { job51DetailBackfillRunId = v; },
 };
 
+const _paginationUtils = createPaginationUtils({
+  getCurrentSourceKey,
+  SOURCE_KEYS,
+  isJob51DetailPage,
+  isJob5156DetailPage,
+  isJob51DetailReady,
+  isJob5156DetailReady,
+  getSeekPaginationInfo,
+  getSeekNextPageLinkForMode,
+  getCurrentSeekMode,
+  apiSnapshot,
+  normalizeOptionalPositiveInt,
+  doc: document,
+  win: window,
+  SELECTORS,
+});
+const {
+  getPaginationInfo,
+  getNextPageButtonState,
+  waitForPagination,
+} = _paginationUtils;
+
 const _uiUtils = createUiUtils({
   win: window,
   doc: document,
@@ -208,6 +230,7 @@ const _uiUtils = createUiUtils({
   EHIRE_51JOB_HOST,
   SEEK_HOST_SUFFIX,
   makeRandomId,
+  getPaginationInfo,
   getExternalAccessorStatus,
   getAgeRangeFromUrl,
   filterResumesByAgeRange,
@@ -1049,28 +1072,6 @@ const {
   resolveAutoSyncErrorStatus,
   resolveAutoSyncStopReason,
 } = _autoActions;
-
-const _paginationUtils = createPaginationUtils({
-  getCurrentSourceKey,
-  SOURCE_KEYS,
-  isJob51DetailPage,
-  isJob5156DetailPage,
-  isJob51DetailReady,
-  isJob5156DetailReady,
-  getSeekPaginationInfo,
-  getSeekNextPageLinkForMode,
-  getCurrentSeekMode,
-  apiSnapshot,
-  normalizeOptionalPositiveInt,
-  doc: document,
-  win: window,
-  SELECTORS,
-});
-const {
-  getPaginationInfo,
-  getNextPageButtonState,
-  waitForPagination,
-} = _paginationUtils;
 
 const _resumeExtractor = createResumeExtractor({
   SELECTORS,

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -32,6 +32,8 @@ import { createExtractionPipeline } from "./lib/extraction-pipeline";
 import { createSnapshotCollector } from "./lib/snapshot-collector";
 import { createAutoActions } from "./lib/auto-actions";
 import { createUiUtils } from "./lib/ui-utils";
+import { createPaginationUtils } from "./lib/pagination-utils";
+import { createResumeExtractor } from "./lib/resume-extractor";
 
 /**
  * 智通直聘 Resume Collector - Content Script
@@ -205,7 +207,6 @@ const _uiUtils = createUiUtils({
   JOB5156_HOST,
   EHIRE_51JOB_HOST,
   SEEK_HOST_SUFFIX,
-  getPaginationInfo,
   makeRandomId,
   getExternalAccessorStatus,
   getAgeRangeFromUrl,
@@ -1049,6 +1050,55 @@ const {
   resolveAutoSyncStopReason,
 } = _autoActions;
 
+const _paginationUtils = createPaginationUtils({
+  getCurrentSourceKey,
+  SOURCE_KEYS,
+  isJob51DetailPage,
+  isJob5156DetailPage,
+  isJob51DetailReady,
+  isJob5156DetailReady,
+  getSeekPaginationInfo,
+  getSeekNextPageLinkForMode,
+  getCurrentSeekMode,
+  apiSnapshot,
+  normalizeOptionalPositiveInt,
+  doc: document,
+  win: window,
+  SELECTORS,
+});
+const {
+  getPaginationInfo,
+  getNextPageButtonState,
+  waitForPagination,
+} = _paginationUtils;
+
+const _resumeExtractor = createResumeExtractor({
+  SELECTORS,
+  JOB5156_HOST,
+  doc: document,
+  getCurrentSourceKey,
+  SOURCE_KEYS,
+  extractProfileUrl,
+  parseJob5156BasicInfoItems,
+  buildJob5156WorkHistoryItem,
+  buildJob5156EducationItem,
+  isJob51DetailPage,
+  isJob5156DetailPage,
+  isJob51DetailReady,
+  isJob5156DetailReady,
+  getJob51DetailRoot,
+  getJob5156DetailRoot,
+  getJob51ResumePayload,
+  getJob5156ResumePayload,
+  getApiRowForIndex,
+  normalizeResumeText,
+  normalizeResumeMultilineText,
+  applyCollectionGuards,
+  parseGuardFieldNames,
+  GUARD_FIELD_NAMES,
+  DEFAULT_COLLECTION_GUARDS,
+});
+const { extractSingleResume } = _resumeExtractor;
 
 function buildSubmitMetadata(options = {}) {
   const url = new URL(window.location.href);
@@ -1244,293 +1294,7 @@ window.addEventListener(PAGE_BRIDGE_REQUEST_EVENT, async () => {
   window.dispatchEvent(new CustomEvent(PAGE_BRIDGE_RESPONSE_EVENT));
 });
 
-/**
- * Extract data from a single resume card
- * @param {Element} card - The resume card DOM element
- * @returns {Object} - Extracted resume data
- */
-function extractSingleResume(card, apiRow = null) {
-  const getText = (selector, root = card) => {
-    const el = root.querySelector(selector);
-    return el ? el.textContent.trim() : "";
-  };
 
-  const pickText = (selectors) => {
-    for (const selector of selectors) {
-      const text = getText(selector);
-      if (text) return text;
-    }
-    return "";
-  };
-
-  // Extract basic info (age, experience, education, location)
-  const basicInfoContainer =
-    card.querySelector(SELECTORS.basicInfoRow) ||
-    card.querySelector(".list-content__li__down-left-center");
-  const locationFromCard =
-    getText(SELECTORS.locationItem, basicInfoContainer || card) ||
-    getText(SELECTORS.locationFallbackItem, basicInfoContainer || card);
-  const basicInfoSpans = basicInfoContainer
-    ? basicInfoContainer.querySelectorAll(
-        `${SELECTORS.basicInfoItem}, div:nth-child(2) span, .basic-line span`,
-      )
-    : [];
-
-  const basicInfo = Array.from(basicInfoSpans).map(
-    (span) => span.textContent || "",
-  );
-  const { age, experience, education, location } = parseJob5156BasicInfoItems(
-    basicInfo,
-    locationFromCard,
-  );
-
-  // Extract top row (job intention, salary)
-  const topRow =
-    card.querySelector(SELECTORS.topRowText) ||
-    card.querySelector(SELECTORS.topRow);
-  const topRowText = topRow
-    ? topRow.textContent.trim().replace(/\s+/g, " ")
-    : "";
-  const topRowClean = topRowText
-    .split("人才洞察")[0]
-    .replace(/·\s*$/, "")
-    .trim();
-
-  let expectedSalary = "";
-  const salaryMatch = topRowClean.match(
-    /(\d[\d-]*\s*元\/月|\d[\d-]*\s*元|面议)/,
-  );
-  if (salaryMatch) expectedSalary = salaryMatch[0].replace(/\s+/g, "");
-
-  let jobIntention = topRowClean.replace(/^求职意向[:：]?\s*/, "");
-  jobIntention = jobIntention.replace(/（通勤距离[^）]*）/g, "").trim();
-  if (expectedSalary) {
-    jobIntention = jobIntention
-      .replace(expectedSalary, "")
-      .replace(/[·\s]+$/g, "")
-      .trim();
-  }
-
-  const selfIntro = pickText([
-    SELECTORS.selfIntro,
-    ".basic-keywords",
-    ".basic-keywords span",
-  ]);
-
-  // Extract work history
-  const workHistoryContainer =
-    card.querySelector(SELECTORS.workHistory) ||
-    card.querySelector(".list-content__li__down-right-center");
-  let workItems = [];
-  let educationItems = [];
-  if (workHistoryContainer) {
-    const primary = workHistoryContainer.querySelectorAll(SELECTORS.workItem);
-    if (primary.length > 0) {
-      workItems = Array.from(primary);
-      educationItems = Array.from(
-        workHistoryContainer.querySelectorAll(".school-item"),
-      );
-    } else {
-      workItems = Array.from(
-        workHistoryContainer.querySelectorAll('div[class*="history"]'),
-      );
-    }
-  }
-
-  const seenWorkHistory = new Set();
-  const workHistory = workItems
-    .map((item) => buildJob5156WorkHistoryItem(item))
-    .filter((item) => item && item.raw.length > 5)
-    .filter((item) => {
-      if (!item || seenWorkHistory.has(item.raw)) return false;
-      seenWorkHistory.add(item.raw);
-      return true;
-    });
-
-  const seenEducation = new Set();
-  const profileEducation = educationItems
-    .map((item) => buildJob5156EducationItem(item))
-    .filter(
-      (item) =>
-        item &&
-        [item.institution, item.qualification, item.endDate].some(Boolean),
-    )
-    .filter((item) => {
-      const signature = [
-        item.institution || "",
-        item.qualification || "",
-        item.endDate || "",
-      ].join("|");
-      if (seenEducation.has(signature)) return false;
-      seenEducation.add(signature);
-      return true;
-    });
-
-  return {
-    name: getText(SELECTORS.name),
-    profileUrl: extractProfileUrl(card, apiRow),
-    activityStatus: getText(SELECTORS.activityStatus),
-    age,
-    experience,
-    education,
-    location,
-    jobIntention,
-    expectedSalary,
-    selfIntro,
-    workHistory,
-    profileEducation:
-      profileEducation.length > 0 ? profileEducation : undefined,
-    extractedAt: new Date().toISOString(),
-    source: JOB5156_HOST,
-  };
-}
-
-/**
- * Extract all resumes from current page
- * @returns {Array} - Array of resume objects
- */
-function getPaginationInfo() {
-  const sourceKey = getCurrentSourceKey();
-  if (sourceKey === SOURCE_KEYS.SEEK) {
-    return getSeekPaginationInfo();
-  }
-
-  if (isJob51DetailPage()) {
-    return {
-      currentPage: 1,
-      totalPages: 1,
-      totalItems: isJob51DetailReady() ? 1 : 0,
-      hasNextPage: false,
-    };
-  }
-
-  if (sourceKey === SOURCE_KEYS.JOB51) {
-    // 51job eHire uses infinite scroll, not Element UI pagination.
-    // Derive current page from the captured API request's page_index.
-    const req = apiSnapshot.job51LastSearchRequest;
-    const currentPage =
-      normalizeOptionalPositiveInt(
-        req?.page_index ?? req?.pageIndex ?? req?.pageno,
-      ) || 1;
-    const pageSize =
-      normalizeOptionalPositiveInt(
-        req?.page_size ?? req?.pageSize ?? req?.pagesize,
-      ) || 50;
-    const total =
-      typeof apiSnapshot.job51Total === "number" && apiSnapshot.job51Total > 0
-        ? apiSnapshot.job51Total
-        : 0;
-    const hasData =
-      Array.isArray(apiSnapshot.job51SearchRows) &&
-      apiSnapshot.job51SearchRows.length > 0;
-    let totalPages = currentPage;
-    if (total > 0) {
-      totalPages = Math.ceil(total / pageSize);
-    } else if (hasData) {
-      totalPages = currentPage + 1;
-    }
-    return {
-      currentPage,
-      totalPages,
-      totalItems: total,
-      hasNextPage: total > 0 ? currentPage < totalPages : (hasData && currentPage < totalPages),
-    };
-  }
-
-  if (isJob5156DetailPage()) {
-    return {
-      currentPage: 1,
-      totalPages: 1,
-      totalItems: isJob5156DetailReady() ? 1 : 0,
-      hasNextPage: false,
-    };
-  }
-
-  const pagination = document.querySelector(SELECTORS.pagination);
-  if (!pagination)
-    return { currentPage: 1, totalPages: 1, totalItems: 0, hasNextPage: false };
-
-  const totalText = pagination.textContent || "";
-  const totalMatch = totalText.match(/共\s*([\d,，]+)\s*条/);
-  const totalItems = totalMatch
-    ? Number.parseInt(String(totalMatch[1]).replace(/[，,]/g, ""), 10) || 0
-    : 0;
-
-  const activePage = pagination.querySelector(
-    ".is-active, .active, .el-pager li.active",
-  );
-  const currentPage = activePage
-    ? Number.parseInt(activePage.textContent || "", 10) || 1
-    : 1;
-
-  const pagerItems = Array.from(pagination.querySelectorAll(".el-pager li"));
-  const pageNumbers = pagerItems
-    .map((item) => Number.parseInt(item.textContent || "", 10))
-    .filter((value) => Number.isFinite(value) && value > 0);
-  const totalPagesFromPager =
-    pageNumbers.length > 0 ? Math.max(...pageNumbers) : 0;
-  const totalPagesFromTotal = totalItems > 0 ? Math.ceil(totalItems / 20) : 0;
-  const totalPages = Math.max(
-    totalPagesFromTotal,
-    totalPagesFromPager,
-    currentPage,
-  );
-
-  return {
-    currentPage,
-    totalPages,
-    totalItems,
-    hasNextPage: totalPages > currentPage,
-  };
-}
-
-function getNextPageButtonState() {
-  const sourceKey = getCurrentSourceKey();
-  if (sourceKey === SOURCE_KEYS.SEEK) {
-    const nextBtn = getSeekNextPageLinkForMode();
-    if (!nextBtn) {
-      return {
-        exists: false,
-      };
-    }
-    return {
-      exists: true,
-      text: nextBtn.textContent || "",
-      href: nextBtn.getAttribute("href") || "",
-      className: nextBtn.className || "",
-      disabledAttr: nextBtn.getAttribute("disabled") || "",
-      ariaDisabled: nextBtn.getAttribute("aria-disabled") || "",
-      isDisabledClass: nextBtn.classList.contains("disabled"),
-      isIsDisabledClass: nextBtn.classList.contains("is-disabled"),
-    };
-  }
-  if (sourceKey === SOURCE_KEYS.JOB51) {
-    const pagination = getPaginationInfo();
-    return {
-      exists: pagination.hasNextPage,
-      source: "51job-api",
-      currentPage: pagination.currentPage,
-      totalPages: pagination.totalPages,
-      hasNextPage: pagination.hasNextPage,
-    };
-  }
-  const nextBtn = document.querySelector(SELECTORS.nextPageBtn);
-  if (!nextBtn) {
-    return {
-      exists: false,
-    };
-  }
-  return {
-    exists: true,
-    text: nextBtn.textContent || "",
-    href: nextBtn.getAttribute("href") || "",
-    className: nextBtn.className || "",
-    disabledAttr: nextBtn.getAttribute("disabled") || "",
-    ariaDisabled: nextBtn.getAttribute("aria-disabled") || "",
-    isDisabledClass: nextBtn.classList.contains("disabled"),
-    isIsDisabledClass: nextBtn.classList.contains("is-disabled"),
-  };
-}
 
 const SyncStatusWidget = (() => {
   const WIDGET_ID = "tr-sync-status-widget";
@@ -1681,54 +1445,6 @@ const SyncStatusWidget = (() => {
     hide,
   };
 })();
-
-function waitForPagination({ timeoutMs = 8000 } = {}) {
-  if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
-    return Promise.resolve(true);
-  }
-  return new Promise((resolve, reject) => {
-    let done = false;
-    const deadline = Date.now() + timeoutMs;
-
-    const check = () => {
-      if (done) return;
-      const isSeek = getCurrentSourceKey() === SOURCE_KEYS.SEEK;
-      const seekTalentSearch = isSeek && getCurrentSeekMode() === "talentsearch";
-      const pagination = document.querySelector(
-        isSeek
-          ? (seekTalentSearch
-              ? SELECTORS.seekTalentSearchPagination
-              : SELECTORS.seekPagination)
-          : SELECTORS.pagination,
-      );
-      const nextBtn = isSeek
-        ? getSeekNextPageLinkForMode()
-        : document.querySelector(SELECTORS.nextPageBtn);
-      if (pagination && nextBtn) {
-        done = true;
-        cleanup();
-        resolve(true);
-      } else if (Date.now() > deadline) {
-        done = true;
-        cleanup();
-        reject(new Error("Timed out waiting for pagination controls"));
-      }
-    };
-
-    const cleanup = () => {
-      clearInterval(intervalId);
-      observer.disconnect();
-    };
-
-    const intervalId = setInterval(check, 300);
-    const observer = new MutationObserver(check);
-    observer.observe(document.body || document.documentElement, {
-      childList: true,
-      subtree: true,
-    });
-    check();
-  });
-}
 
 /**
  * @param {{ expectedPage?: number; timeoutMs?: number }} options

--- a/apps/browser-extension/src/lib/dom-utils.ts
+++ b/apps/browser-extension/src/lib/dom-utils.ts
@@ -1,0 +1,134 @@
+/**
+ * DOM utility functions for browser extension content scripts.
+ * All dependencies injected from content.ts via DI factory.
+ */
+
+export interface DomUtilsDeps {
+  win: Window;
+  doc: Document;
+  getPaginationInfo: () => { currentPage: number };
+}
+
+export function createDomUtils(deps: DomUtilsDeps) {
+  const { win, doc, getPaginationInfo } = deps;
+
+  function waitForPageTransition(options: { expectedPage?: number; timeoutMs?: number } = {}): Promise<number> {
+    const { expectedPage, timeoutMs = 15000 } = options;
+    return new Promise((resolve, reject) => {
+      if (!Number.isFinite(expectedPage) || expectedPage < 1) {
+        reject(new Error("Invalid expected page"));
+        return;
+      }
+
+      let done = false;
+      const deadline = Date.now() + timeoutMs;
+
+      const check = () => {
+        if (done) return;
+        const pagination = getPaginationInfo();
+        if (pagination.currentPage === expectedPage) {
+          done = true;
+          cleanup();
+          resolve(pagination.currentPage);
+        } else if (Date.now() > deadline) {
+          done = true;
+          cleanup();
+          reject(new Error(`Timed out waiting for page ${expectedPage}`));
+        }
+      };
+
+      const cleanup = () => {
+        clearInterval(intervalId);
+        observer.disconnect();
+      };
+
+      const intervalId = setInterval(check, 300);
+      const observer = new MutationObserver(check);
+      observer.observe(doc.body || doc.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+      });
+      check();
+    });
+  }
+
+  function isElementVisible(element: Element | null | undefined): boolean {
+    if (!element) return false;
+    const style = win.getComputedStyle(element);
+    return style.display !== "none" && style.visibility !== "hidden";
+  }
+
+  function asHTMLElement(element: Element | null | undefined): HTMLElement | null {
+    return element instanceof HTMLElement ? element : null;
+  }
+
+  function setInputValue(input: HTMLInputElement, value: string): void {
+    const inputWindow =
+      (input?.ownerDocument?.defaultView as any) || win;
+    const inputCtor =
+      inputWindow.HTMLInputElement ||
+      (globalThis as any).HTMLInputElement;
+    const descriptor = inputCtor
+      ? Object.getOwnPropertyDescriptor(inputCtor.prototype, "value")
+      : null;
+    if (descriptor?.set) {
+      descriptor.set.call(input, value);
+    } else {
+      input.value = value;
+    }
+    input.dispatchEvent(new inputWindow.Event("input", { bubbles: true }));
+    input.dispatchEvent(new inputWindow.Event("change", { bubbles: true }));
+  }
+
+  function fireMouseEvent(target: EventTarget, type: string): void {
+    try {
+      const targetWindow =
+        (target as any)?.ownerDocument?.defaultView || win;
+      target.dispatchEvent(
+        new targetWindow.MouseEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          view: targetWindow,
+        }),
+      );
+    } catch {
+      // ignore
+    }
+  }
+
+  function activateElement(target: Element | null | undefined): void {
+    if (!target) {
+      return;
+    }
+    ["mouseenter", "mouseover", "mousedown", "mouseup"].forEach((type) =>
+      fireMouseEvent(target, type),
+    );
+    (target as HTMLElement).click?.();
+  }
+
+  function findVueParentByName(
+    node: any,
+    componentName: string,
+    { maxDepth = 8 }: { maxDepth?: number } = {},
+  ): any {
+    let vm = node?.__vue__ || null;
+    for (let depth = 0; vm && depth < maxDepth; depth += 1) {
+      if (vm?.$options?.name === componentName) {
+        return vm;
+      }
+      vm = vm?.$parent || null;
+    }
+    return null;
+  }
+
+  return {
+    waitForPageTransition,
+    isElementVisible,
+    asHTMLElement,
+    setInputValue,
+    fireMouseEvent,
+    activateElement,
+    findVueParentByName,
+  };
+}

--- a/apps/browser-extension/src/lib/pagination-utils.ts
+++ b/apps/browser-extension/src/lib/pagination-utils.ts
@@ -1,0 +1,263 @@
+// @ts-nocheck
+import type { Selectors } from "./types";
+
+export interface PaginationInfo {
+  currentPage: number;
+  totalPages: number;
+  totalItems: number;
+  hasNextPage: boolean;
+}
+
+export interface NextPageButtonState {
+  exists: boolean;
+  text?: string;
+  href?: string;
+  className?: string;
+  disabledAttr?: string;
+  ariaDisabled?: string;
+  isDisabledClass?: boolean;
+  isIsDisabledClass?: boolean;
+  source?: string;
+  currentPage?: number;
+  totalPages?: number;
+  hasNextPage?: boolean;
+}
+
+export interface PaginationUtilsDeps {
+  getCurrentSourceKey: () => string;
+  SOURCE_KEYS: Record<string, string>;
+  isJob51DetailPage: () => boolean;
+  isJob5156DetailPage: () => boolean;
+  isJob51DetailReady: () => boolean;
+  isJob5156DetailReady: () => boolean;
+  getSeekPaginationInfo: () => PaginationInfo;
+  getSeekNextPageLinkForMode: () => HTMLElement | null;
+  getCurrentSeekMode: () => string;
+  apiSnapshot: {
+    job51LastSearchRequest?: any;
+    job51Total?: number;
+    job51SearchRows?: any[];
+  };
+  normalizeOptionalPositiveInt: (val: any) => number | undefined;
+  doc: Document;
+  win: Window;
+  SELECTORS: Selectors;
+}
+
+export function createPaginationUtils(deps: PaginationUtilsDeps) {
+  const {
+    getCurrentSourceKey,
+    SOURCE_KEYS,
+    isJob51DetailPage,
+    isJob5156DetailPage,
+    isJob51DetailReady,
+    isJob5156DetailReady,
+    getSeekPaginationInfo,
+    getSeekNextPageLinkForMode,
+    getCurrentSeekMode,
+    apiSnapshot,
+    normalizeOptionalPositiveInt,
+    doc,
+    win,
+    SELECTORS,
+  } = deps;
+
+  function getPaginationInfo(): PaginationInfo {
+    const sourceKey = getCurrentSourceKey();
+    if (sourceKey === SOURCE_KEYS.SEEK) {
+      return getSeekPaginationInfo();
+    }
+
+    if (isJob51DetailPage()) {
+      return {
+        currentPage: 1,
+        totalPages: 1,
+        totalItems: isJob51DetailReady() ? 1 : 0,
+        hasNextPage: false,
+      };
+    }
+
+    if (sourceKey === SOURCE_KEYS.JOB51) {
+      // 51job eHire uses infinite scroll, not Element UI pagination.
+      // Derive current page from the captured API request's page_index.
+      const req = apiSnapshot.job51LastSearchRequest;
+      const currentPage =
+        normalizeOptionalPositiveInt(
+          req?.page_index ?? req?.pageIndex ?? req?.pageno,
+        ) || 1;
+      const pageSize =
+        normalizeOptionalPositiveInt(
+          req?.page_size ?? req?.pageSize ?? req?.pagesize,
+        ) || 50;
+      const total =
+        typeof apiSnapshot.job51Total === "number" && apiSnapshot.job51Total > 0
+          ? apiSnapshot.job51Total
+          : 0;
+      const hasData =
+        Array.isArray(apiSnapshot.job51SearchRows) &&
+        apiSnapshot.job51SearchRows.length > 0;
+      let totalPages = currentPage;
+      if (total > 0) {
+        totalPages = Math.ceil(total / pageSize);
+      } else if (hasData) {
+        totalPages = currentPage + 1;
+      }
+      return {
+        currentPage,
+        totalPages,
+        totalItems: total,
+        hasNextPage: total > 0 ? currentPage < totalPages : (hasData && currentPage < totalPages),
+      };
+    }
+
+    if (isJob5156DetailPage()) {
+      return {
+        currentPage: 1,
+        totalPages: 1,
+        totalItems: isJob5156DetailReady() ? 1 : 0,
+        hasNextPage: false,
+      };
+    }
+
+    const pagination = doc.querySelector(SELECTORS.pagination);
+    if (!pagination)
+      return { currentPage: 1, totalPages: 1, totalItems: 0, hasNextPage: false };
+
+    const totalText = pagination.textContent || "";
+    const totalMatch = totalText.match(/\u5171\s*([\d,\uff0c]+)\s*\u6761/);
+    const totalItems = totalMatch
+      ? Number.parseInt(String(totalMatch[1]).replace(/[\uff0c,]/g, ""), 10) || 0
+      : 0;
+
+    const activePage = pagination.querySelector(
+      ".is-active, .active, .el-pager li.active",
+    );
+    const currentPage = activePage
+      ? Number.parseInt(activePage.textContent || "", 10) || 1
+      : 1;
+
+    const pagerItems = Array.from(pagination.querySelectorAll(".el-pager li"));
+    const pageNumbers = pagerItems
+      .map((item) => Number.parseInt(item.textContent || "", 10))
+      .filter((value) => Number.isFinite(value) && value > 0);
+    const totalPagesFromPager =
+      pageNumbers.length > 0 ? Math.max(...pageNumbers) : 0;
+    const totalPagesFromTotal = totalItems > 0 ? Math.ceil(totalItems / 20) : 0;
+    const totalPages = Math.max(
+      totalPagesFromTotal,
+      totalPagesFromPager,
+      currentPage,
+    );
+
+    return {
+      currentPage,
+      totalPages,
+      totalItems,
+      hasNextPage: totalPages > currentPage,
+    };
+  }
+
+  function getNextPageButtonState(): NextPageButtonState {
+    const sourceKey = getCurrentSourceKey();
+    if (sourceKey === SOURCE_KEYS.SEEK) {
+      const nextBtn = getSeekNextPageLinkForMode();
+      if (!nextBtn) {
+        return {
+          exists: false,
+        };
+      }
+      return {
+        exists: true,
+        text: nextBtn.textContent || "",
+        href: nextBtn.getAttribute("href") || "",
+        className: nextBtn.className || "",
+        disabledAttr: nextBtn.getAttribute("disabled") || "",
+        ariaDisabled: nextBtn.getAttribute("aria-disabled") || "",
+        isDisabledClass: nextBtn.classList.contains("disabled"),
+        isIsDisabledClass: nextBtn.classList.contains("is-disabled"),
+      };
+    }
+    if (sourceKey === SOURCE_KEYS.JOB51) {
+      const pagination = getPaginationInfo();
+      return {
+        exists: pagination.hasNextPage,
+        source: "51job-api",
+        currentPage: pagination.currentPage,
+        totalPages: pagination.totalPages,
+        hasNextPage: pagination.hasNextPage,
+      };
+    }
+    const nextBtn = doc.querySelector(SELECTORS.nextPageBtn);
+    if (!nextBtn) {
+      return {
+        exists: false,
+      };
+    }
+    return {
+      exists: true,
+      text: nextBtn.textContent || "",
+      href: nextBtn.getAttribute("href") || "",
+      className: nextBtn.className || "",
+      disabledAttr: nextBtn.getAttribute("disabled") || "",
+      ariaDisabled: nextBtn.getAttribute("aria-disabled") || "",
+      isDisabledClass: nextBtn.classList.contains("disabled"),
+      isIsDisabledClass: nextBtn.classList.contains("is-disabled"),
+    };
+  }
+
+  function waitForPagination({ timeoutMs = 8000 }: { timeoutMs?: number } = {}): Promise<boolean> {
+    // Job51 uses infinite scroll - no pagination controls to wait for
+    if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
+      return Promise.resolve(true);
+    }
+
+    return new Promise((resolve, reject) => {
+      let done = false;
+      const deadline = Date.now() + timeoutMs;
+
+      const check = () => {
+        if (done) return;
+        const isSeek = getCurrentSourceKey() === SOURCE_KEYS.SEEK;
+        const seekTalentSearch = isSeek && getCurrentSeekMode() === "talentsearch";
+        const pagination = doc.querySelector(
+          isSeek
+            ? (seekTalentSearch
+                ? SELECTORS.seekTalentSearchPagination
+                : SELECTORS.seekPagination)
+            : SELECTORS.pagination,
+        );
+        const nextBtn = isSeek
+          ? getSeekNextPageLinkForMode()
+          : doc.querySelector(SELECTORS.nextPageBtn);
+        if (pagination && nextBtn) {
+          done = true;
+          cleanup();
+          resolve(true);
+        } else if (Date.now() > deadline) {
+          done = true;
+          cleanup();
+          reject(new Error("Timed out waiting for pagination controls"));
+        }
+      };
+
+      const cleanup = () => {
+        clearInterval(intervalId);
+        observer.disconnect();
+      };
+
+      const intervalId = setInterval(check, 300);
+      const observer = new MutationObserver(check);
+      observer.observe(doc.body || doc.documentElement, {
+        childList: true,
+        subtree: true,
+      });
+      check();
+    });
+  }
+
+  return {
+    getPaginationInfo,
+    getNextPageButtonState,
+    waitForPagination,
+  };
+}

--- a/apps/browser-extension/src/lib/resume-extractor.ts
+++ b/apps/browser-extension/src/lib/resume-extractor.ts
@@ -1,0 +1,234 @@
+// @ts-nocheck
+import type { Selectors } from "./types";
+
+export interface ResumeWorkHistoryItem {
+  raw: string;
+  company?: string;
+  duration?: string;
+  position?: string;
+}
+
+export interface ResumeEducationItem {
+  institution?: string;
+  qualification?: string;
+  endDate?: string;
+}
+
+export interface ResumeData {
+  name: string;
+  profileUrl: string;
+  activityStatus: string;
+  age?: number;
+  experience?: string;
+  education?: string;
+  location?: string;
+  jobIntention: string;
+  expectedSalary: string;
+  selfIntro: string;
+  workHistory: ResumeWorkHistoryItem[];
+  profileEducation?: ResumeEducationItem[];
+  extractedAt: string;
+  source: string;
+}
+
+export interface ResumeExtractorDeps {
+  SELECTORS: Selectors;
+  JOB5156_HOST: string;
+  doc: Document;
+  getCurrentSourceKey: () => string;
+  SOURCE_KEYS: Record<string, string>;
+  extractProfileUrl: (card: Element, apiRow: any) => string;
+  parseJob5156BasicInfoItems: (items: string[], locationOverride: string) => {
+    age?: number;
+    experience?: string;
+    education?: string;
+    location?: string;
+  };
+  buildJob5156WorkHistoryItem: (item: Element) => ResumeWorkHistoryItem | null;
+  buildJob5156EducationItem: (item: Element) => ResumeEducationItem | null;
+  // Detail page extraction deps
+  isJob51DetailPage: () => boolean;
+  isJob5156DetailPage: () => boolean;
+  isJob51DetailReady: () => boolean;
+  isJob5156DetailReady: () => boolean;
+  getJob51DetailRoot: () => Element | null;
+  getJob5156DetailRoot: () => Element | null;
+  getJob51ResumePayload: () => any;
+  getJob5156ResumePayload: () => any;
+  getApiRowForIndex: (index: number) => any;
+  normalizeResumeText: (text: string) => string;
+  normalizeResumeMultilineText: (text: string) => string;
+  applyCollectionGuards: (resume: any, guardFieldNames: Set<string>) => any;
+  parseGuardFieldNames: (csv: string) => Set<string>;
+  GUARD_FIELD_NAMES: Set<string>;
+  DEFAULT_COLLECTION_GUARDS: Record<string, string>;
+}
+
+export function createResumeExtractor(deps: ResumeExtractorDeps) {
+  const {
+    SELECTORS,
+    JOB5156_HOST,
+    doc,
+    getCurrentSourceKey,
+    SOURCE_KEYS,
+    extractProfileUrl,
+    parseJob5156BasicInfoItems,
+    buildJob5156WorkHistoryItem,
+    buildJob5156EducationItem,
+    isJob51DetailPage,
+    isJob5156DetailPage,
+    isJob51DetailReady,
+    isJob5156DetailReady,
+    getJob51DetailRoot,
+    getJob5156DetailRoot,
+    getJob51ResumePayload,
+    getJob5156ResumePayload,
+    getApiRowForIndex,
+    normalizeResumeText,
+    normalizeResumeMultilineText,
+    applyCollectionGuards,
+    parseGuardFieldNames,
+    GUARD_FIELD_NAMES,
+    DEFAULT_COLLECTION_GUARDS,
+  } = deps;
+
+  function extractSingleResume(card: Element, apiRow: any = null): ResumeData {
+    const getText = (selector: string, root: Element = card): string => {
+      const el = root.querySelector(selector);
+      return el ? el.textContent?.trim() || "" : "";
+    };
+
+    const pickText = (selectors: string[]): string => {
+      for (const selector of selectors) {
+        const text = getText(selector);
+        if (text) return text;
+      }
+      return "";
+    };
+
+    // Extract basic info (age, experience, education, location)
+    const basicInfoContainer =
+      card.querySelector(SELECTORS.basicInfoRow) ||
+      card.querySelector(".list-content__li__down-left-center");
+    const locationFromCard =
+      getText(SELECTORS.locationItem, basicInfoContainer || card) ||
+      getText(SELECTORS.locationFallbackItem, basicInfoContainer || card);
+    const basicInfoSpans = basicInfoContainer
+      ? basicInfoContainer.querySelectorAll(
+          `${SELECTORS.basicInfoItem}, div:nth-child(2) span, .basic-line span`,
+        )
+      : ([] as Element[]);
+
+    const basicInfo = Array.from(basicInfoSpans).map(
+      (span) => span.textContent || "",
+    );
+    const { age, experience, education, location } = parseJob5156BasicInfoItems(
+      basicInfo,
+      locationFromCard,
+    );
+
+    // Extract top row (job intention, salary)
+    const topRow =
+      card.querySelector(SELECTORS.topRowText) ||
+      card.querySelector(SELECTORS.topRow);
+    const topRowText = topRow
+      ? topRow.textContent?.trim().replace(/\s+/g, " ") || ""
+      : "";
+    const topRowClean = topRowText
+      .split("\u4eba\u624d\u6d1e\u5bdf")[0]
+      .replace(/\u00b7\s*$/, "")
+      .trim();
+
+    let expectedSalary = "";
+    const salaryMatch = topRowClean.match(
+      /(\d[\d-]*\s*\u5143\/\u6708|\d[\d-]*\s*\u5143|\u9762\u8bae)/,
+    );
+    if (salaryMatch) expectedSalary = salaryMatch[0].replace(/\s+/g, "");
+
+    let jobIntention = topRowClean.replace(/^\u6c42\u804c\u610f\u5411[:\uff1a]?\s*/, "");
+    jobIntention = jobIntention.replace(/\uff08\u901a\u52e4\u8ddd\u79bb[^\uff09]*\uff09/g, "").trim();
+    if (expectedSalary) {
+      jobIntention = jobIntention
+        .replace(expectedSalary, "")
+        .replace(/[\u00b7\s]+$/g, "")
+        .trim();
+    }
+
+    const selfIntro = pickText([
+      SELECTORS.selfIntro,
+      ".basic-keywords",
+      ".basic-keywords span",
+    ]);
+
+    // Extract work history
+    const workHistoryContainer =
+      card.querySelector(SELECTORS.workHistory) ||
+      card.querySelector(".list-content__li__down-right-center");
+    let workItems: Element[] = [];
+    let educationItems: Element[] = [];
+    if (workHistoryContainer) {
+      const primary = workHistoryContainer.querySelectorAll(SELECTORS.workItem);
+      if (primary.length > 0) {
+        workItems = Array.from(primary);
+        educationItems = Array.from(
+          workHistoryContainer.querySelectorAll(".school-item"),
+        );
+      } else {
+        workItems = Array.from(
+          workHistoryContainer.querySelectorAll('div[class*="history"]'),
+        );
+      }
+    }
+
+    const seenWorkHistory = new Set<string>();
+    const workHistory = workItems
+      .map((item) => buildJob5156WorkHistoryItem(item))
+      .filter((item): item is NonNullable<typeof item> => item && item.raw.length > 5)
+      .filter((item) => {
+        if (!item || seenWorkHistory.has(item.raw)) return false;
+        seenWorkHistory.add(item.raw);
+        return true;
+      });
+
+    const seenEducation = new Set<string>();
+    const profileEducation = educationItems
+      .map((item) => buildJob5156EducationItem(item))
+      .filter(
+        (item): item is NonNullable<typeof item> =>
+          item &&
+          [item.institution, item.qualification, item.endDate].some(Boolean),
+      )
+      .filter((item) => {
+        const signature = [
+          item.institution || "",
+          item.qualification || "",
+          item.endDate || "",
+        ].join("|");
+        if (seenEducation.has(signature)) return false;
+        seenEducation.add(signature);
+        return true;
+      });
+
+    return {
+      name: getText(SELECTORS.name),
+      profileUrl: extractProfileUrl(card, apiRow),
+      activityStatus: getText(SELECTORS.activityStatus),
+      age,
+      experience,
+      education,
+      location,
+      jobIntention,
+      expectedSalary,
+      selfIntro,
+      workHistory,
+      profileEducation:
+        profileEducation.length > 0 ? profileEducation : undefined,
+      extractedAt: new Date().toISOString(),
+      source: JOB5156_HOST,
+    };
+  }
+
+  return {
+    extractSingleResume,
+  };
+}


### PR DESCRIPTION
## Summary
- **42% reduction** of `content.ts` (1989 → 1111 lines) via systematic DI factory extraction
- 8 new lib/ modules following the `createXxx(deps)` DI factory pattern:
  - `lib/dom-utils.ts` — 7 DOM utility functions (waitForPageTransition, isElementVisible, etc.)
  - `lib/collection-guards.ts` — guard field validation and application utilities
  - `lib/sync-status-widget.ts` — SyncStatusWidget IIFE as DI factory
  - `lib/auto-sync-runner.ts` — 450-line runAutoSyncIfEnabled function as DI factory
  - `lib/content-constants.ts` — shared SELECTORS, URL params, source keys, timeouts
- Internalized 8 data-building functions into seek-extractor and job5156-extractor factories
- Internalized 4 profile URL helpers into resume-extractor factory
- Moved `delay()` utility to dom-utils as exported function

## Extraction details

| Commit | What | Lines removed |
|--------|------|---------------|
| e8e67bcb | Fix getPaginationInfo dep ordering | - |
| 3eed3674 | DOM utilities → dom-utils.ts | -155 |
| 79d757dd | Seek/job5156 data builders → their factories | -302 |
| 87bfba89 | Collection guards + delay → separate modules | -57 |
| 94e48797 | SyncStatusWidget + profile URL helpers | -194 |
| 4426345a | runAutoSyncIfEnabled → auto-sync-runner.ts | -283 |
| 4fd586f5 | Constants → content-constants.ts | -42 |

## Test plan
- [x] `make check` passes after each commit (typecheck + lint + governance)
- [x] All 7 DI factory modules follow established `createXxx(deps)` pattern
- [x] Factory ordering invariants preserved (no temporal dead zone issues)
- [ ] Manual verification: browser extension loads and extracts resumes correctly