### PR TITLE
deps: upgrade convex 1.36→1.39

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,7 @@
     "@trends/shared": "*",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
-    "convex": "^1.36.0",
+    "convex": "^1.39.0",
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.4",
     "i18next": "^26.2.0",

--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
         "@trends/shared": "*",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
-        "convex": "^1.36.0",
+        "convex": "^1.39.0",
         "date-fns": "^4.1.0",
         "dotenv": "^17.2.4",
         "i18next": "^26.2.0",
@@ -118,7 +118,7 @@
       "version": "0.2.1",
       "dependencies": {
         "@trends/shared": "*",
-        "convex": "^1.36.0",
+        "convex": "^1.39.0",
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -723,7 +723,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "convex": ["convex@1.36.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react"], "bin": "bin/main.js" }, "sha512-NVnwNqU+h8jyPuS0Itvj4MPH9c2yF+tA/RNoSDpCqiLhmYD4+kZxm0dDkVM0QDzz66wem9NqheBb9YQGsHwzBQ=="],
+    "convex": ["convex@1.39.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-W+gVXA7BpRF1xLlS1kGTtKVaqd5yonqbGESKiPtIUXjV744GdDz8IG7RVsSY5KzHbgxuJBHKaJYk+92OIHTskQ=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@trends/shared": "*",
-    "convex": "^1.36.0"
+    "convex": "^1.39.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"


### PR DESCRIPTION
## Summary
- Upgrade convex from ^1.36.0 to ^1.39.0 in packages/convex and apps/web
- No API changes required — compatible minor version bump

## Test plan
- [x] `make check` passes on branch
- [ ] Convex dev server starts without errors
- [ ] Existing queries and mutations work as expected