### PR TITLE
fix: strip provider/ prefix from model name in resolveChatCompletionModel

### DIFF
--- a/packages/convex/convex/__tests__/ai-model.test.ts
+++ b/packages/convex/convex/__tests__/ai-model.test.ts
@@ -3,15 +3,12 @@ import { describe, expect, it } from "vitest";
 import { resolveChatCompletionModel } from "../lib/ai_model";
 
 describe("resolveChatCompletionModel", () => {
-    it("strips provider prefixes for Poe chat completions", () => {
-        expect(resolveChatCompletionModel("https://api.poe.com/v1", "openai/gpt-5.3-instant")).toBe("gpt-5.3-instant");
-        expect(resolveChatCompletionModel("https://api.poe.com/v1", "openai/gpt-5-mini")).toBe("gpt-5-mini");
+    it("strips provider prefixes for all API bases", () => {
+        expect(resolveChatCompletionModel("https://api.openai.com/v1", "openai/gpt-5.3-instant")).toBe("gpt-5.3-instant");
+        expect(resolveChatCompletionModel("https://new-api.example.com", "openai/kimi-k2.5")).toBe("kimi-k2.5");
     });
 
-    it("leaves non-Poe model identifiers unchanged", () => {
-        expect(resolveChatCompletionModel("https://api.openai.com/v1", "openai/gpt-5.3-instant")).toBe(
-            "openai/gpt-5.3-instant"
-        );
+    it("leaves model identifiers without a prefix unchanged", () => {
         expect(resolveChatCompletionModel("https://api.openai.com/v1", "gpt-5")).toBe("gpt-5");
     });
 });

--- a/packages/convex/convex/lib/ai_model.ts
+++ b/packages/convex/convex/lib/ai_model.ts
@@ -1,18 +1,6 @@
-function isPoeApiBase(apiBase: string): boolean {
-    try {
-        return new URL(apiBase).hostname === "api.poe.com";
-    } catch {
-        return apiBase.includes("api.poe.com");
-    }
-}
-
-export function resolveChatCompletionModel(apiBase: string, model: string): string {
+export function resolveChatCompletionModel(_apiBase: string, model: string): string {
     const trimmedModel = model.trim();
     if (!trimmedModel) {
-        return trimmedModel;
-    }
-
-    if (!isPoeApiBase(apiBase)) {
         return trimmedModel;
     }
 


### PR DESCRIPTION
## Summary
- Strip provider/ prefix (e.g., "openai/", "anthropic/") from model name before passing to the API in `resolveChatCompletionModel`
- Fixes mismatch where API base returns model names with provider prefix but the API expects bare model names

## Test plan
- [x] `make check` passes on branch
- [ ] Verify AI scoring works with provider-prefixed model names