### PR TITLE
refactor: deep content.ts extraction — internalize functions, extract factories (1989→1111L)

### DIFF
--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -36,6 +36,7 @@ import { createPaginationUtils } from "./lib/pagination-utils";
 import { createDomUtils, delay } from "./lib/dom-utils";
 import { createResumeExtractor } from "./lib/resume-extractor";
 import { createSyncStatusWidget } from "./lib/sync-status-widget";
+import { createAutoSyncRunner } from "./lib/auto-sync-runner";
 import {
   DEFAULT_COLLECTION_GUARDS,
   GUARD_FIELD_NAMES,
@@ -115,8 +116,6 @@ const JOB51_PAGE_COOLDOWN_MS = 8000;
 const JOB51_RATE_LIMIT_ERROR_MESSAGE =
   "51job 已触发访问频率限制，请60分钟后再试";
 let autoExportTriggered = false;
-let autoSyncTriggered = false;
-let autoSyncCancelled = false;
 const API_CAPTURE_SOURCE = "tr-resume-api";
 const EXTERNAL_ACCESS_KEY = "__TR_RESUME_DATA__";
 const PAGE_BRIDGE_REQUEST_EVENT = "trResumeBridgeRequest";
@@ -904,395 +903,113 @@ window.addEventListener(PAGE_BRIDGE_REQUEST_EVENT, async () => {
 
 
 
+const _autoSyncRunnerState = {
+  _autoSyncTriggered: false,
+  _autoSyncCancelled: false,
+};
+
 const SyncStatusWidget = createSyncStatusWidget({
   win: window,
   doc: document,
   chrome,
-  onCancel: () => { autoSyncCancelled = true; },
+  onCancel: () => { _autoSyncRunnerState._autoSyncCancelled = true; },
 });
 
-async function runAutoSyncIfEnabled() {
-  if (autoSyncTriggered) return;
-  const enabled = getAutoSyncEnabled();
-  if (!enabled) {
-    setAutoSyncAttributes("skipped");
-    setSeekAutoSyncWindowAttributes(null);
-    setSeekAutoSyncSelectionAttributes(null);
-    return;
-  }
+const _autoSyncRunner = createAutoSyncRunner({
+  state: _autoSyncRunnerState,
 
-  const { limit, maxPages } = await getCollectionLimits();
-  const isJob51Source = getCurrentSourceKey() === SOURCE_KEYS.JOB51;
+  // Auto-actions helpers
+  getAutoSyncEnabled,
+  setAutoSyncAttributes,
+  resolveAutoSyncErrorStatus,
+  resolveAutoSyncStopReason,
+  runAutoExportIfEnabled,
+  syncCurrentPageToServer,
 
-  autoSyncTriggered = true;
-  autoSyncCancelled = false;
-  setAutoSyncAttributes("running", 0, 0);
-  setSeekAutoSyncWindowAttributes(null);
-  setSeekAutoSyncSelectionAttributes(null);
-  try {
-    document.documentElement.setAttribute(
-      "data-tr-auto-sync-limit",
-      String(limit),
-    );
-    document.documentElement.setAttribute(
-      "data-tr-auto-sync-max-pages",
-      String(maxPages),
-    );
-  } catch {
-    // ignore
-  }
-  SyncStatusWidget.show({
-    state: "progress",
-    message: "正在同步简历到服务器...",
-    hint: `${isJob51Source ? "51job 保守模式 · " : ""}数量上限: ${limit > 0 ? limit : "不限"} · 页数上限: ${maxPages > 0 ? maxPages : "不限"}`,
-  });
+  // Seek extractor
+  setSeekAutoSyncWindowAttributes,
+  setSeekAutoSyncSelectionAttributes,
+  isSeekProfileMode,
+  resolveSeekAutoSyncPageWindow,
+  isSeekAutoSyncPageWindowReached,
+  resolveSeekAutoSyncCurrentPageSelection,
+  getSeekRequestedPageSize,
+  getSeekCurrentCandidateCount,
+  resolveSeekAutoSyncPageSize,
+  enrichSeekResumesWithDetail,
 
-  try {
-    let totalSubmitted = 0;
-    let totalInserted = 0;
-    let totalUpdated = 0;
-    let pagesVisited = 0;
-    let lastSelectedCount = null;
-    let stopReason = "completed";
-    let seekStartPage = null;
+  // Pagination utils
+  getPaginationInfo,
+  waitForPagination,
+  getNextPageButtonState,
 
-    while (true) {
-      if (autoSyncCancelled) {
-        stopReason = "cancelled";
-        break;
-      }
+  // Extraction pipeline
+  waitForExtractionData,
+  extractResumes,
+  goToNextPageInternal,
+  clearCapturedResultsForNextPage,
+  enrich51JobSearchResumesWithDetail,
+  enrichJob5156SearchResumesWithDetail,
+  queueJob51DetailBackfill,
 
-      ensureJob51PageAllowed();
+  // Snapshot collector
+  collectSnapshotPayload,
+  getApiSnapshotCount,
 
-      const paginationBefore = getPaginationInfo();
-      const currentPage = paginationBefore.currentPage;
-      const totalPages = paginationBefore.totalPages;
-      const isSeekListPage =
-        getCurrentSourceKey() === SOURCE_KEYS.SEEK && !isSeekProfileMode();
-      if (isSeekListPage && seekStartPage === null) {
-        seekStartPage = currentPage;
-      }
+  // Resume extractor
+  buildSubmitMetadata,
+  extractProfileUrl,
 
-      try {
-        await waitForExtractionData({});
-      } catch {
-        // waitForExtractionData timed out — SEEK may be rate-limiting or
-        // the page loaded without API rows. Don't abort the entire sync:
-        // let the resumes.length check below handle it (skip to next page).
-        console.warn(
-          "🎯 [Auto Sync] waitForExtractionData timed out — continuing",
-        );
-      }
-      ensureJob51PageAllowed();
+  // Collection guards
+  loadCollectionGuards,
+  parseGuardFieldNames,
+  applyCollectionGuards,
 
-      pagesVisited += 1;
+  // Job51 search extractor
+  ensureJob51PageAllowed,
+  isJob51RateLimitedPage,
+  waitForJob51Cooldown,
 
-      const seekPageWindow = isSeekListPage
-        ? resolveSeekAutoSyncPageWindow({
-            startPage: seekStartPage || currentPage,
-            limit,
-            maxPages,
-            requestedPageSize: getSeekRequestedPageSize(),
-            currentPageCandidateCount: getSeekCurrentCandidateCount(),
-          })
-        : null;
-      setSeekAutoSyncWindowAttributes(seekPageWindow);
+  // Job51 age filter
+  filterResumesByAgeRange,
+  getAgeRangeFromUrl,
+  normalizeOptionalPositiveInt,
 
-      const pageSelection = isSeekListPage
-        ? resolveSeekAutoSyncCurrentPageSelection({
-            limit,
-            totalSubmitted,
-            currentPageResumeCount: getSeekCurrentCandidateCount(),
-          })
-        : {
-            remainingCapacity:
-              limit > 0 ? Math.max(limit - totalSubmitted, 0) : null,
-            selectedCount: null,
-            hitLimitWithinPage: false,
-            limitAlreadyReached:
-              limit > 0 ? Math.max(limit - totalSubmitted, 0) <= 0 : false,
-          };
-      setSeekAutoSyncSelectionAttributes(isSeekListPage ? pageSelection : null);
+  // UI utils
+  buildAutoSyncProgressHint,
+  buildAutoSyncSelectedCountHint,
+  buildAutoSyncCompletionHint,
+  persistLatestAutoSyncSummary,
+  getCurrentAgeRange,
+  resolveCurrentJob51AutoSyncDetailWaitMode,
 
-      if (
-        (isSeekListPage && pageSelection.limitAlreadyReached) ||
-        (!isSeekListPage && limit > 0 && pageSelection.limitAlreadyReached)
-      ) {
-        stopReason = "limit-reached";
-        break;
-      }
+  // Dom utils
+  waitForPageTransition,
+  delay,
 
-      let resumes = extractResumes();
-      const hitLimitWithinPage = isSeekListPage
-        ? pageSelection.hitLimitWithinPage
-        : limit > 0 &&
-          typeof pageSelection.remainingCapacity === "number" &&
-          resumes.length > pageSelection.remainingCapacity;
-      if (isSeekListPage && typeof pageSelection.selectedCount === "number") {
-        resumes = resumes.slice(0, pageSelection.selectedCount);
-      } else if (
-        limit > 0 &&
-        typeof pageSelection.remainingCapacity === "number" &&
-        resumes.length > pageSelection.remainingCapacity
-      ) {
-        resumes = resumes.slice(0, pageSelection.remainingCapacity);
-      }
-      lastSelectedCount = isSeekListPage ? resumes.length : null;
-      if (
-        getCurrentSourceKey() === SOURCE_KEYS.JOB5156 &&
-        !isJob5156DetailPage() &&
-        resumes.length > 0
-      ) {
-        resumes = await enrichJob5156SearchResumesWithDetail(resumes);
-      }
-      if (
-        getCurrentSourceKey() === SOURCE_KEYS.SEEK &&
-        !isSeekProfileMode() &&
-        resumes.length > 0
-      ) {
-        resumes = await enrichSeekResumesWithDetail(resumes);
-      }
-      if (resumes.length <= 0) {
-        const ageRange = getCurrentAgeRange();
-        const ageHint = ageRange.enabled
-          ? ` · 年龄: ${typeof ageRange.minAge === "number" ? ageRange.minAge : "—"}-${typeof ageRange.maxAge === "number" ? ageRange.maxAge : "—"}`
-          : "";
-        const progressHint = buildAutoSyncProgressHint({
-          limit,
-          totalSubmitted,
-          selectedCount: isSeekListPage ? resumes.length : null,
-          ageHint,
-        });
+  // Content.ts scope helpers
+  getCurrentSourceKey,
+  SOURCE_KEYS,
+  getCollectionLimits,
+  getKeywordMode,
 
-        SyncStatusWidget.show({
-          state: "progress",
-          message: `第 ${currentPage}/${Math.max(totalPages, currentPage)} 页无符合条件的简历，继续...`,
-          hint: progressHint,
-        });
-        setAutoSyncAttributes("running", totalSubmitted, pagesVisited);
+  // Job5156 extractor
+  isJob5156DetailPage,
 
-        if (autoSyncCancelled) {
-          stopReason = "cancelled";
-          break;
-        }
-        if (
-          isSeekListPage &&
-          isSeekAutoSyncPageWindowReached(seekPageWindow, currentPage)
-        ) {
-          stopReason = "page-window-reached";
-          break;
-        }
-        if (!isSeekListPage && maxPages > 0 && pagesVisited >= maxPages) {
-          stopReason = "max-pages-reached";
-          break;
-        }
+  // Job51 extractor
+  isJob51DetailPage,
 
-        const paginationAfter = getPaginationInfo();
-        if (
-          !paginationAfter.hasNextPage ||
-          paginationAfter.currentPage >= paginationAfter.totalPages
-        ) {
-          stopReason = "no-next-page";
-          break;
-        }
-        try {
-          await waitForPagination({ timeoutMs: 8000 });
-        } catch {
-          // Some layouts render pagination late or omit it on single-page results.
-        }
-        const nextPage = paginationAfter.currentPage + 1;
-        try {
-          document.documentElement.setAttribute(
-            "data-tr-auto-sync-next-state",
-            JSON.stringify(getNextPageButtonState()),
-          );
-        } catch {
-          // ignore
-        }
-        await waitForJob51Cooldown();
-        clearCapturedResultsForNextPage();
-        const moved = goToNextPageInternal();
-        if (!moved) {
-          stopReason = "no-next-page";
-          break;
-        }
-        await waitForPageTransition({
-          expectedPage: nextPage,
-          timeoutMs: 15000,
-        });
-        await new Promise((resolve) => setTimeout(resolve, 500));
-        continue;
-      }
+  // SyncStatusWidget
+  SyncStatusWidget,
 
-      const progressHint = buildAutoSyncProgressHint({
-        limit,
-        totalSubmitted,
-        selectedCount: isSeekListPage ? resumes.length : null,
-      });
-      SyncStatusWidget.show({
-        state: "progress",
-        message: `正在同步第 ${currentPage}/${Math.max(totalPages, currentPage)} 页 (${resumes.length} 份)...`,
-        hint: progressHint,
-      });
+  // DOM globals
+  document,
+  window,
 
-      const response = await syncCurrentPageToServer(resumes);
-      if (!response?.success) {
-        throw response?.error || response || "Auto sync failed";
-      }
-
-      const submitted =
-        typeof response.submitted === "number"
-          ? response.submitted
-          : resumes.length;
-      const inserted =
-        typeof response.inserted === "number" ? response.inserted : 0;
-      const updated =
-        typeof response.updated === "number" ? response.updated : 0;
-      totalSubmitted += submitted;
-      totalInserted += inserted;
-      totalUpdated += updated;
-      setAutoSyncAttributes("running", totalSubmitted, pagesVisited);
-
-      if (
-        getCurrentSourceKey() === SOURCE_KEYS.JOB51 &&
-        !isJob51DetailPage() &&
-        resumes.length > 0
-      ) {
-        const detailBackfillPromise = queueJob51DetailBackfill(resumes, {
-          currentPage,
-          totalPages: Math.max(totalPages, currentPage),
-        });
-        const waitMode = resolveCurrentJob51AutoSyncDetailWaitMode();
-        const shouldWaitForDetails =
-          waitMode === "all" || (waitMode === "page1" && currentPage === 1);
-        if (shouldWaitForDetails) {
-          SyncStatusWidget.show({
-            state: "progress",
-            message: `正在补充第 ${currentPage}/${Math.max(totalPages, currentPage)} 页详情...`,
-            hint: "等待 51job 详情补充后再完成本页同步",
-          });
-          await detailBackfillPromise;
-        }
-      }
-
-      if (autoSyncCancelled) {
-        stopReason = "cancelled";
-        break;
-      }
-      if (isSeekListPage && hitLimitWithinPage) {
-        stopReason = "limit-reached";
-        break;
-      }
-      if (
-        isSeekListPage &&
-        isSeekAutoSyncPageWindowReached(seekPageWindow, currentPage)
-      ) {
-        stopReason = "page-window-reached";
-        break;
-      }
-      if (!isSeekListPage && limit > 0 && totalSubmitted >= limit) {
-        stopReason = "limit-reached";
-        break;
-      }
-      if (!isSeekListPage && maxPages > 0 && pagesVisited >= maxPages) {
-        stopReason = "max-pages-reached";
-        break;
-      }
-
-      const paginationAfter = getPaginationInfo();
-      if (
-        !paginationAfter.hasNextPage ||
-        paginationAfter.currentPage >= paginationAfter.totalPages
-      ) {
-        stopReason = "no-next-page";
-        break;
-      }
-      try {
-        await waitForPagination({ timeoutMs: 8000 });
-      } catch {
-        // Some layouts render pagination late or omit it on single-page results.
-      }
-      const nextPage = paginationAfter.currentPage + 1;
-      try {
-        document.documentElement.setAttribute(
-          "data-tr-auto-sync-next-state",
-          JSON.stringify(getNextPageButtonState()),
-        );
-      } catch {
-        // ignore
-      }
-      await waitForJob51Cooldown();
-      clearCapturedResultsForNextPage();
-      const moved = goToNextPageInternal();
-      if (!moved) {
-        stopReason = "no-next-page";
-        break;
-      }
-      await waitForPageTransition({ expectedPage: nextPage, timeoutMs: 15000 });
-      await new Promise((resolve) => setTimeout(resolve, 500));
-    }
-
-    try {
-      document.documentElement.setAttribute(
-        "data-tr-auto-sync-stop-reason",
-        stopReason,
-      );
-    } catch {
-      // ignore
-    }
-    persistLatestAutoSyncSummary();
-
-    if (autoSyncCancelled) {
-      SyncStatusWidget.show({
-        state: "success",
-        message: `同步已取消，已同步 ${totalSubmitted} 份简历`,
-        hint: buildAutoSyncCompletionHint({
-          totalInserted,
-          totalUpdated,
-          pagesVisited,
-          selectedCount: lastSelectedCount,
-        }),
-        autoDismiss: true,
-      });
-      setAutoSyncAttributes("cancelled", totalSubmitted, pagesVisited);
-      return;
-    }
-
-    SyncStatusWidget.show({
-      state: "success",
-      message: `已同步 ${totalSubmitted} 份简历 (${totalInserted} 新增, ${totalUpdated} 更新), 共 ${pagesVisited} 页`,
-      hint: [
-        buildAutoSyncSelectedCountHint({
-          selectedCount: lastSelectedCount,
-          prefix: "",
-        }),
-        isJob51Source ? "51job 详情补充正在后台继续" : "",
-      ]
-        .filter(Boolean)
-        .join(" · "),
-      autoDismiss: true,
-    });
-    setAutoSyncAttributes("done", totalSubmitted, pagesVisited);
-  } catch (error) {
-    console.warn("🎯 [Auto Sync] Failed:", error);
-    const status = resolveAutoSyncErrorStatus(error);
-    SyncStatusWidget.show({
-      state: "error",
-      message: status.message,
-      hint: status.hint,
-    });
-    setAutoSyncAttributes("failed");
-    try {
-      document.documentElement.setAttribute(
-        "data-tr-auto-sync-stop-reason",
-        resolveAutoSyncStopReason(error),
-      );
-    } catch {
-      // ignore
-    }
-    persistLatestAutoSyncSummary();
-  }
-}
+  // Browser API
+  chrome,
+});
+const { runAutoSyncIfEnabled } = _autoSyncRunner;
 
 // Listen for messages from popup
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -298,16 +298,11 @@ const _seekExtractor = createSeekExtractor({
   // Extraction deps
   win: window,
   doc: document,
-  buildSeekWorkHistoryItem,
-  buildSeekProfileEducationItem,
-  formatSeekExpectedSalary,
   // Pagination + extraction deps
   asHTMLElement,
   isDisabledPaginationControl,
   // Detail enrichment deps
-  findSeekTalentSearchCardTrigger,
   waitForSeekProfileSnapshot,
-  mergeSeekListResumeWithDetail,
 });
 const {
   isSeekProfilePage,
@@ -468,303 +463,6 @@ function isExtractionReady() {
   return document.querySelector(SELECTORS.listContainer) !== null;
 }
 
-/**
- * Talentsearch cards have no <a> links — candidate name is a [data-role="heading"]
- * element clicked via SPA event handlers. Find the card matching this profileId
- * (UUID) by checking data attributes or card index.
- */
-function findSeekTalentSearchCardTrigger(profileId, resume, cachedHeadings) {
-  if (!profileId) return null;
-  // Try matching by data-tr-candidate-id attribute (set during extraction)
-  const byAttr = document.querySelector(
-    `[data-tr-candidate-id="${CSS.escape(profileId)}"]`,
-  );
-  if (byAttr instanceof HTMLElement) return byAttr;
-  // Fallback: match heading elements that contain the candidate name.
-  // Talentsearch cards use [data-role="heading"] for the candidate name.
-  const candidateName = typeof resume?.name === "string" ? resume.name.trim() : "";
-  if (candidateName) {
-    const headings = cachedHeadings ||
-      Array.from(document.querySelectorAll('[data-role="heading"]'));
-    const match = headings.find((h) => {
-      const text = (h.textContent || "").trim();
-      return text === candidateName;
-    });
-    if (match instanceof HTMLElement) return match;
-  }
-  return null;
-}
-
-function mergeSeekListResumeWithDetail(baseResume, detailResume, isTalentSearch = false) {
-  if (!detailResume || typeof detailResume !== "object") {
-    return baseResume;
-  }
-
-  // For talentsearch: if V3 detail provides a numeric profileId, use it for
-  // profileUrl construction but preserve the UUID seekProfileGuid
-  const seekProfileGuid = baseResume.seekProfileGuid || detailResume.seekProfileGuid || undefined;
-  const numericProfileId = isTalentSearch && detailResume.profileId && /^\d+$/.test(detailResume.profileId)
-    ? detailResume.profileId
-    : undefined;
-
-  // If we got a numeric profileId from V3 detail, update the profileUrl
-  let profileUrl = detailResume.profileUrl || baseResume.profileUrl;
-  if (numericProfileId) {
-    // Derive jobId from the current page URL or API request for recommended URL format
-    const seekRequest = getSeekTalentSearchRequest();
-    const requestJobId = seekRequest?.variables?.input?.jobId;
-    const urlJobId = normalizeOptionalPositiveInt(
-      new URL(window.location.href).searchParams.get("jobId"),
-    );
-    const jobId = requestJobId != null
-      ? String(requestJobId)
-      : urlJobId != null
-        ? String(urlJobId)
-        : undefined;
-    profileUrl = buildSeekProfileUrl(numericProfileId, jobId);
-  }
-
-  return {
-    ...baseResume,
-    ...detailResume,
-    ...(seekProfileGuid ? { seekProfileGuid } : {}),
-    ...(numericProfileId ? { profileId: numericProfileId } : {}),
-    ...(profileUrl ? { profileUrl } : {}),
-    pageIndex: baseResume.pageIndex,
-    pageNumber: baseResume.pageNumber,
-    extractedAt: baseResume.extractedAt,
-    source: baseResume.source,
-    searchProfileId: detailResume.searchProfileId || baseResume.searchProfileId,
-  };
-}
-
-function formatSeekExpectedSalary(expectedSalary) {
-  if (!expectedSalary || typeof expectedSalary !== "object") return "";
-
-  const amounts = Array.isArray(expectedSalary.amount)
-    ? expectedSalary.amount
-    : [];
-  const preferredFrequencies = ["MONTHLY", "ANNUAL", "HOURLY"];
-  const amount =
-    preferredFrequencies
-      .map((frequency) =>
-        amounts.find((entry) => entry?.frequency === frequency),
-      )
-      .find(Boolean) || amounts[0];
-
-  if (!amount || typeof amount !== "object") return "";
-
-  const value =
-    typeof amount.value === "number" ? amount.value : Number(amount.value);
-  const formattedValue = Number.isFinite(value)
-    ? new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(value)
-    : "";
-  const currency =
-    typeof expectedSalary.currency === "string"
-      ? expectedSalary.currency.trim()
-      : "";
-  const period =
-    amount.frequency === "ANNUAL"
-      ? "/year"
-      : amount.frequency === "HOURLY"
-        ? "/hour"
-        : amount.frequency === "DAILY"
-          ? "/day"
-          : "/month";
-
-  const prefix = [currency, formattedValue].filter(Boolean).join(" ");
-  return prefix ? `${prefix}${period}` : "";
-}
-
-function buildSeekWorkHistoryItem(item) {
-  if (!item || typeof item !== "object") return null;
-
-  const companyName =
-    typeof item.companyName === "string" ? item.companyName.trim() : "";
-  const jobTitle =
-    typeof item.jobTitle === "string" ? item.jobTitle.trim() : "";
-  const description =
-    typeof item.description === "string" ? item.description.trim() : "";
-  const startDate =
-    typeof item.startDate === "string" ? item.startDate.trim() : "";
-  const endDate = typeof item.endDate === "string" ? item.endDate.trim() : "";
-  const durationLabel =
-    typeof item.durationLabel === "string" ? item.durationLabel.trim() : "";
-  const raw = [jobTitle, companyName, durationLabel]
-    .filter(Boolean)
-    .join(" · ");
-
-  if (!raw && !description) return null;
-
-  return {
-    raw: raw || description,
-    companyName: companyName || undefined,
-    jobTitle: jobTitle || undefined,
-    description: description || undefined,
-    startDate: startDate || undefined,
-    endDate: endDate || undefined,
-  };
-}
-
-function buildSeekProfileEducationItem(item) {
-  if (!item || typeof item !== "object") return null;
-
-  const institution =
-    typeof item.institutionName === "string" ? item.institutionName.trim() : "";
-  const qualification =
-    typeof item.qualificationName === "string"
-      ? item.qualificationName.trim()
-      : "";
-  const completionYear = Number.isFinite(item.completionYear)
-    ? String(item.completionYear)
-    : "";
-  const completionMonth =
-    Number.isFinite(item.completionMonth) && item.completionMonth > 0
-      ? String(item.completionMonth).padStart(2, "0")
-      : "";
-  const endDate = completionYear
-    ? completionMonth
-      ? `${completionYear}-${completionMonth}`
-      : completionYear
-    : "";
-
-  if (!institution && !qualification && !endDate) return null;
-
-  return {
-    institution: institution || undefined,
-    qualification: qualification || undefined,
-    endDate: endDate || undefined,
-  };
-}
-
-function parseJob5156BasicInfoItems(items, locationOverride = "") {
-  const basicInfo = Array.isArray(items)
-    ? items.map((item) => normalizeResumeText(item)).filter(Boolean)
-    : [];
-
-  let age = "";
-  let experience = "";
-  let education = "";
-  let location = "";
-  if (basicInfo.length >= 4) {
-    [age, experience, education, location] = basicInfo;
-  } else {
-    basicInfo.forEach((item) => {
-      if (!age && item.includes("岁")) age = item;
-      else if (!experience && item.includes("年") && !item.includes("元"))
-        experience = item;
-      else if (
-        !education &&
-        /(中专|高中|大专|本科|硕|博|研究生|MBA|EMBA)/.test(item)
-      )
-        education = item;
-      else if (!location && !item.includes("元")) location = item;
-    });
-  }
-
-  if (locationOverride) {
-    location = normalizeResumeText(locationOverride);
-  }
-
-  return { age, experience, education, location };
-}
-
-function buildJob5156WorkHistoryItem(item) {
-  if (!(item instanceof Element)) return null;
-
-  const startDate = normalizeResumeText(
-    item.querySelector(".work-time > span:first-child")?.textContent,
-  );
-  const durationLabel = normalizeResumeText(
-    item.querySelector(".work-time-other")?.textContent,
-  );
-  const companyName = normalizeResumeText(
-    item.querySelector(".work-company")?.textContent,
-  );
-  const jobTitle = normalizeResumeText(
-    item.querySelector(".work-position")?.textContent,
-  );
-  const description = normalizeResumeText(
-    item.querySelector(
-      ".work-desc, .work-detail, .work-content, .work-responsibility, .work-duty",
-    )?.textContent,
-  );
-  const endDate = startDate.includes("~")
-    ? normalizeResumeText(startDate.split("~").slice(1).join("~"))
-    : "";
-  const raw = buildWorkHistoryRawParts([
-    startDate,
-    durationLabel,
-    companyName,
-    jobTitle,
-    description,
-  ]);
-
-  if (!raw) return null;
-
-  return {
-    raw,
-    companyName: companyName || undefined,
-    jobTitle: jobTitle || undefined,
-    description: description || undefined,
-    startDate: startDate || undefined,
-    endDate: endDate || undefined,
-  };
-}
-
-function buildJob5156EducationItem(item) {
-  if (!(item instanceof Element)) return null;
-
-  const liveEducationText = normalizeResumeText(item.textContent);
-  if (
-    item.classList.contains("resume-education__info") ||
-    item.closest(".resume-education")
-  ) {
-    const institution = normalizeResumeText(
-      item.querySelector(".flex.w-full > div:last-child")?.textContent,
-    );
-    const rowText = Array.from(item.querySelectorAll(".flex.w-full > div"))
-      .map((node) => normalizeResumeText(node.textContent))
-      .filter(Boolean);
-    const endDate = rowText.find((value) => /^\d{4}(~|-)/.test(value)) || "";
-    const qualification = rowText
-      .filter((value) => value !== institution && value !== endDate)
-      .join(" · ");
-
-    if (!institution && !qualification && !endDate && !liveEducationText)
-      return null;
-
-    return {
-      institution: institution || undefined,
-      qualification: qualification || undefined,
-      endDate: endDate || undefined,
-      description: liveEducationText || undefined,
-    };
-  }
-
-  const institution = normalizeResumeText(
-    item.querySelector(".school-name")?.textContent,
-  );
-  const qualification = normalizeResumeText(
-    item.querySelector(".school-major")?.textContent,
-  );
-  const degree = normalizeResumeText(
-    item.querySelector(".school-degree")?.textContent,
-  );
-  const endDate = normalizeResumeText(
-    item.querySelector(".school-time")?.textContent,
-  );
-
-  if (!institution && !qualification && !degree && !endDate) return null;
-
-  return {
-    institution: institution || undefined,
-    qualification:
-      [qualification, degree].filter(Boolean).join(" · ") || undefined,
-    endDate: endDate || undefined,
-  };
-}
-
 const GUARD_FIELD_NAMES = new Set([
   "experience",
   "jobIntention",
@@ -840,9 +538,6 @@ const _job5156Extractor = createJob5156Extractor({
   loadCollectionGuards,
   parseGuardFieldNames,
   applyCollectionGuards,
-  parseJob5156BasicInfoItems,
-  buildJob5156WorkHistoryItem,
-  buildJob5156EducationItem,
   isMeaningfulJob5156WorkHistoryEntry,
   collectJob5156SectionItemsByHeading,
 });
@@ -852,6 +547,9 @@ const {
   getJob5156DetailHeaderText,
   isJob5156DetailReady,
   isJob5156DetailRootReady,
+  parseJob5156BasicInfoItems,
+  buildJob5156WorkHistoryItem,
+  buildJob5156EducationItem,
   buildJob5156DetailWorkHistoryItem,
   buildJob5156DetailResumeFromRoot,
   extractJob5156DetailResume,

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -33,8 +33,16 @@ import { createSnapshotCollector } from "./lib/snapshot-collector";
 import { createAutoActions } from "./lib/auto-actions";
 import { createUiUtils } from "./lib/ui-utils";
 import { createPaginationUtils } from "./lib/pagination-utils";
-import { createDomUtils } from "./lib/dom-utils";
+import { createDomUtils, delay } from "./lib/dom-utils";
 import { createResumeExtractor } from "./lib/resume-extractor";
+import {
+  DEFAULT_COLLECTION_GUARDS,
+  GUARD_FIELD_NAMES,
+  GUARD_ARRAY_FIELD_NAMES,
+  loadCollectionGuards,
+  parseGuardFieldNames,
+  applyCollectionGuards,
+} from "./lib/collection-guards";
 
 /**
  * 智通直聘 Resume Collector - Content Script
@@ -151,11 +159,6 @@ const INITIAL_URL_CAPTURED_PARAMS = (() => {
   }
 })();
 
-const DEFAULT_COLLECTION_GUARDS = {
-  job5156: "experience,jobIntention,selfIntro",
-  "51job": "experience,jobIntention,selfIntro",
-  seek: "experience,jobIntention,selfIntro",
-};
 
 const apiSnapshot = {
   searchRows: null,
@@ -443,10 +446,6 @@ async function getCollectionLimits() {
 
 
 
-function delay(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 
 function isExtractionReady() {
   if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
@@ -463,62 +462,6 @@ function isExtractionReady() {
   return document.querySelector(SELECTORS.listContainer) !== null;
 }
 
-const GUARD_FIELD_NAMES = new Set([
-  "experience",
-  "jobIntention",
-  "selfIntro",
-  "expectedSalary",
-  "workHistory",
-  "profileEducation",
-  "projectExperience",
-  "skills",
-  "licences",
-]);
-const GUARD_ARRAY_FIELD_NAMES = new Set([
-  "workHistory",
-  "profileEducation",
-  "projectExperience",
-  "skills",
-  "licences",
-]);
-
-async function loadCollectionGuards() {
-  return new Promise((resolve) => {
-    chrome.storage.local.get(
-      { collectionGuards: DEFAULT_COLLECTION_GUARDS },
-      (items) => resolve(items.collectionGuards || {}),
-    );
-  });
-}
-
-function parseGuardFieldNames(csv) {
-  if (!csv || typeof csv !== "string") return [];
-  return Array.from(
-    new Set(
-      csv
-        .split(",")
-        .map((field) => field.trim())
-        .filter((field) => GUARD_FIELD_NAMES.has(field)),
-    ),
-  );
-}
-
-function applyCollectionGuards(resume, guardFieldNames) {
-  if (
-    !resume ||
-    typeof resume !== "object" ||
-    !Array.isArray(guardFieldNames) ||
-    guardFieldNames.length === 0
-  ) {
-    return resume;
-  }
-
-  const guarded = { ...resume };
-  for (const field of guardFieldNames) {
-    guarded[field] = GUARD_ARRAY_FIELD_NAMES.has(field) ? [] : "";
-  }
-  return guarded;
-}
 
 const _job5156Extractor = createJob5156Extractor({
   getCurrentSourceKey,

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -35,6 +35,7 @@ import { createUiUtils } from "./lib/ui-utils";
 import { createPaginationUtils } from "./lib/pagination-utils";
 import { createDomUtils, delay } from "./lib/dom-utils";
 import { createResumeExtractor } from "./lib/resume-extractor";
+import { createSyncStatusWidget } from "./lib/sync-status-widget";
 import {
   DEFAULT_COLLECTION_GUARDS,
   GUARD_FIELD_NAMES,
@@ -559,6 +560,51 @@ const {
   waitForJob51AgeFilterRefresh,
 } = _job51SearchExtractor;
 
+const _resumeExtractor = createResumeExtractor({
+  SELECTORS,
+  JOB5156_HOST,
+  doc: document,
+  getCurrentSourceKey,
+  SOURCE_KEYS,
+  parseJob5156BasicInfoItems,
+  buildJob5156WorkHistoryItem,
+  buildJob5156EducationItem,
+  isJob51DetailPage,
+  isJob5156DetailPage,
+  isJob51DetailReady,
+  isJob5156DetailReady,
+  getJob51DetailRoot,
+  getJob5156DetailRoot,
+  getJob51ResumePayload,
+  getJob5156ResumePayload,
+  normalizeResumeText,
+  normalizeResumeMultilineText,
+  applyCollectionGuards,
+  parseGuardFieldNames,
+  GUARD_FIELD_NAMES,
+  DEFAULT_COLLECTION_GUARDS,
+  apiSnapshot,
+  JOB5156_PROFILE_URL_PREFIX,
+  normalizeJob5156ProfileUrlForExport,
+  win: window,
+  normalizeKeyword,
+  AUTO_SEARCH_PARAM,
+  getAutoLocationValues,
+  AUTO_EXPORT_PARAM,
+  AUTO_SYNC_PARAM,
+  AUTO_LIMIT_PARAM,
+  AUTO_MAX_PAGES_PARAM,
+  SAMPLE_NAME_PARAM,
+  getExtensionGeneratedBy,
+  buildSeekCollectionContext,
+});
+const {
+  extractSingleResume,
+  getApiRowForIndex,
+  extractProfileUrl,
+  buildSubmitMetadata,
+} = _resumeExtractor;
+
 const _extractionPipeline = createExtractionPipeline({
   getCurrentSourceKey,
   SOURCE_KEYS,
@@ -731,103 +777,6 @@ const {
   resolveAutoSyncStopReason,
 } = _autoActions;
 
-const _resumeExtractor = createResumeExtractor({
-  SELECTORS,
-  JOB5156_HOST,
-  doc: document,
-  getCurrentSourceKey,
-  SOURCE_KEYS,
-  extractProfileUrl,
-  parseJob5156BasicInfoItems,
-  buildJob5156WorkHistoryItem,
-  buildJob5156EducationItem,
-  isJob51DetailPage,
-  isJob5156DetailPage,
-  isJob51DetailReady,
-  isJob5156DetailReady,
-  getJob51DetailRoot,
-  getJob5156DetailRoot,
-  getJob51ResumePayload,
-  getJob5156ResumePayload,
-  getApiRowForIndex,
-  normalizeResumeText,
-  normalizeResumeMultilineText,
-  applyCollectionGuards,
-  parseGuardFieldNames,
-  GUARD_FIELD_NAMES,
-  DEFAULT_COLLECTION_GUARDS,
-});
-const { extractSingleResume } = _resumeExtractor;
-
-function buildSubmitMetadata(options = {}) {
-  const url = new URL(window.location.href);
-  const sourceKey = getCurrentSourceKey();
-  const keyword = normalizeKeyword(
-    url.searchParams.get(AUTO_SEARCH_PARAM) || "",
-  );
-  const location = getAutoLocationValues(url).join(",");
-
-  url.searchParams.delete(AUTO_EXPORT_PARAM);
-  url.searchParams.delete(AUTO_SYNC_PARAM);
-  url.searchParams.delete(AUTO_LIMIT_PARAM);
-  url.searchParams.delete(AUTO_MAX_PAGES_PARAM);
-  url.searchParams.delete(SAMPLE_NAME_PARAM);
-
-  const metadata = {
-    sourceKey,
-    sourceHost: url.hostname.toLowerCase(),
-    sourceUrl: url.toString(),
-    generatedBy: getExtensionGeneratedBy(),
-  };
-
-  if (keyword) metadata.keyword = keyword;
-  if (location) metadata.location = location;
-  if (sourceKey === SOURCE_KEYS.SEEK) {
-    metadata.collectionContext = buildSeekCollectionContext({
-      captureModeOverride: options.seekCaptureMode,
-    });
-  }
-
-  return metadata;
-}
-
-function getApiRowForIndex(index) {
-  if (!Array.isArray(apiSnapshot.searchRows)) return null;
-  return apiSnapshot.searchRows[index] || null;
-}
-
-function isPlaceholderProfileUrl(value) {
-  if (!value) return true;
-  const normalized = String(value).trim().toLowerCase();
-  return (
-    normalized === "" ||
-    normalized === "#" ||
-    normalized.startsWith("javascript:") ||
-    normalized === "about:blank"
-  );
-}
-
-function extractProfileUrl(card, apiRow) {
-  const nameLink = card.querySelector(SELECTORS.name);
-  if (!nameLink) return buildProfileUrlFromApiRow(apiRow);
-
-  const candidates = [
-    nameLink.getAttribute("href"),
-    nameLink.getAttribute("data-href"),
-    nameLink.getAttribute("data-url"),
-    nameLink.getAttribute("data-link"),
-    nameLink.href,
-  ];
-
-  for (const candidate of candidates) {
-    const normalized = toAbsoluteHttpUrl(candidate);
-    if (normalized) return normalizeJob5156ProfileUrlForExport(normalized);
-  }
-
-  return buildProfileUrlFromApiRow(apiRow);
-}
-
-
 window.addEventListener("message", (event) => {
   if (event.source !== window) return;
   const msg = event.data;
@@ -955,155 +904,12 @@ window.addEventListener(PAGE_BRIDGE_REQUEST_EVENT, async () => {
 
 
 
-const SyncStatusWidget = (() => {
-  const WIDGET_ID = "tr-sync-status-widget";
-  const DEFAULT_AUTO_DISMISS_MS = 5000;
-  const HIDE_DELAY_MS = 220;
-  let widgetEl = null;
-  let dismissTimer = null;
-  let hideTimer = null;
-
-  function escapeHtml(value) {
-    return String(value ?? "")
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;")
-      .replace(/'/g, "&#39;");
-  }
-
-  function clearTimers() {
-    if (dismissTimer) {
-      clearTimeout(dismissTimer);
-      dismissTimer = null;
-    }
-    if (hideTimer) {
-      clearTimeout(hideTimer);
-      hideTimer = null;
-    }
-  }
-
-  function ensureWidget() {
-    if (widgetEl && widgetEl.isConnected) return widgetEl;
-
-    widgetEl = document.createElement("div");
-    widgetEl.id = WIDGET_ID;
-    widgetEl.className = "tr-sync-widget";
-    widgetEl.setAttribute("role", "status");
-    widgetEl.setAttribute("aria-live", "polite");
-    widgetEl.setAttribute("aria-atomic", "true");
-    const mountTarget = document.body || document.documentElement;
-    mountTarget.appendChild(widgetEl);
-    return widgetEl;
-  }
-
-  function renderIcon(state) {
-    if (state === "progress") {
-      return '<span class="tr-sync-widget__spinner" aria-hidden="true"></span>';
-    }
-    if (state === "success") {
-      return '<span aria-hidden="true">✓</span>';
-    }
-    return '<span aria-hidden="true">!</span>';
-  }
-
-  function openOptionsPage() {
-    try {
-      void chrome.runtime
-        .sendMessage({ action: "openOptionsPage" })
-        .catch((error) => {
-          console.warn("🎯 [Auto Sync] Failed to open options page:", error);
-        });
-    } catch (error) {
-      console.warn("🎯 [Auto Sync] Failed to request options page:", error);
-    }
-  }
-
-  function show({
-    state = "progress",
-    message = "",
-    hint = "",
-    autoDismiss = false,
-  } = {}) {
-    const normalizedState =
-      state === "success" || state === "error" ? state : "progress";
-    const safeMessage = escapeHtml(message);
-    const safeHint = escapeHtml(hint);
-    const widget = ensureWidget();
-    clearTimers();
-
-    widget.className = `tr-sync-widget tr-sync-widget--${normalizedState}`;
-    widget.classList.remove("tr-sync-widget--hidden");
-    widget.innerHTML = `
-      <div class="tr-sync-widget__icon">${renderIcon(normalizedState)}</div>
-      <div class="tr-sync-widget__content">
-        <div class="tr-sync-widget__message">${safeMessage}</div>
-        ${safeHint ? `<div class="tr-sync-widget__hint">${safeHint}</div>` : ""}
-      </div>
-      ${
-        normalizedState === "progress"
-          ? '<button type="button" class="tr-sync-widget__cancel" aria-label="取消同步">取消</button>'
-          : normalizedState === "error"
-            ? '<button type="button" class="tr-sync-widget__close" aria-label="关闭提示">×</button>'
-            : ""
-      }
-    `;
-
-    widget.onclick = null;
-    if (normalizedState === "progress") {
-      const cancelBtn = widget.querySelector(".tr-sync-widget__cancel");
-      cancelBtn?.addEventListener("click", (event) => {
-        event.stopPropagation();
-        autoSyncCancelled = true;
-        cancelBtn.setAttribute("disabled", "true");
-        cancelBtn.textContent = "取消中...";
-      });
-    }
-    if (normalizedState === "error") {
-      widget.onclick = (event) => {
-        const target = event.target instanceof Element ? event.target : null;
-        if (target?.closest(".tr-sync-widget__close")) return;
-        openOptionsPage();
-      };
-
-      const closeBtn = widget.querySelector(".tr-sync-widget__close");
-      closeBtn?.addEventListener("click", (event) => {
-        event.stopPropagation();
-        hide();
-      });
-    }
-
-    const dismissMs =
-      typeof autoDismiss === "number"
-        ? autoDismiss
-        : autoDismiss
-          ? DEFAULT_AUTO_DISMISS_MS
-          : 0;
-    if (dismissMs > 0) {
-      dismissTimer = setTimeout(() => {
-        hide();
-      }, dismissMs);
-    }
-  }
-
-  function hide() {
-    if (!widgetEl) return;
-    clearTimers();
-    widgetEl.classList.add("tr-sync-widget--hidden");
-    hideTimer = setTimeout(() => {
-      if (widgetEl) {
-        widgetEl.remove();
-        widgetEl = null;
-      }
-      hideTimer = null;
-    }, HIDE_DELAY_MS);
-  }
-
-  return {
-    show,
-    hide,
-  };
-})();
+const SyncStatusWidget = createSyncStatusWidget({
+  win: window,
+  doc: document,
+  chrome,
+  onCancel: () => { autoSyncCancelled = true; },
+});
 
 async function runAutoSyncIfEnabled() {
   if (autoSyncTriggered) return;

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -45,91 +45,49 @@ import {
   parseGuardFieldNames,
   applyCollectionGuards,
 } from "./lib/collection-guards";
+import {
+  SELECTORS,
+  AUTO_EXPORT_PARAM,
+  AUTO_SYNC_PARAM,
+  AUTO_LIMIT_PARAM,
+  AUTO_MAX_PAGES_PARAM,
+  AUTO_MIN_AGE_PARAM,
+  AUTO_MAX_AGE_PARAM,
+  AUTO_SEARCH_PARAM,
+  AUTO_LOCATION_PARAM,
+  AUTO_KEYWORD_MODE_PARAM,
+  SAMPLE_NAME_PARAM,
+  JOB5156_HOST,
+  SEEK_HOST_SUFFIX,
+  JOB5156_PROFILE_URL_PREFIX,
+  SOURCE_KEYS,
+  SEEK_PROFILE_TYPE,
+  KEYWORD_MODE_CONCAT,
+  KEYWORD_MODE_SPACED,
+  JOB51_PAGE_COOLDOWN_MS,
+  JOB51_RATE_LIMIT_ERROR_MESSAGE,
+  API_CAPTURE_SOURCE,
+  EXTERNAL_ACCESS_KEY,
+  PAGE_BRIDGE_REQUEST_EVENT,
+  PAGE_BRIDGE_RESPONSE_EVENT,
+  PAGE_BRIDGE_REQUEST_ATTR,
+  PAGE_BRIDGE_RESPONSE_ATTR,
+  JOB51_NEXT_PAGE_EVENT,
+  CONTENT_SCRIPT_SOURCE,
+  JOB5156_DETAIL_FETCH_TIMEOUT_MS,
+  JOB5156_DETAIL_FETCH_CONCURRENCY,
+  JOB51_DETAIL_FETCH_TIMEOUT_MS,
+  JOB51_DETAIL_FETCH_CONCURRENCY,
+  DEFAULT_SEEK_PAGE_SIZE,
+  LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY,
+} from "./lib/content-constants";
 
 /**
  * 智通直聘 Resume Collector - Content Script
  * Extracts resume data from hr.job5156.com/search page
  */
 
-// CSS Selectors based on DOM analysis
-const SELECTORS = {
-  listContainer: ".el-checkbox-group.resume-search-item-list-content-block",
-  resumeCard: ".list-content__li_part",
-  name: ".item-title-part1 a.name, a.name",
-  activityStatus: ".date-type-diff-text-block",
-  basicInfoRow: ".basic-line",
-  basicInfoItem: ".basic-line__text",
-  locationItem: ".resume-search-item-search-addre__span",
-  locationFallbackItem: ".text-truncate.text-center",
-  selfIntro: ".basic-keywords",
-  topRow: ".list-content__li__up-block",
-  topRowText: ".up-block__look-text",
-  workHistory: ".work-block",
-  workItem: ".work-item",
-  pagination: ".el-pagination",
-  nextPageBtn: ".el-pagination .btn-next",
-  seekPagination: 'nav[aria-label="Pagination of results"]',
-  seekTalentSearchPagination: 'nav[aria-label="PAGINATION_OF_RESULTS"]',
-  searchInput: ".el-autocomplete input.el-input__inner",
-  searchButton: ".resume-search-item-search-input-block__input-button",
-  // 51job eHire selectors
-  job51SearchInput: ".talent_search_keywords_input input.el-input__inner",
-  job51SearchButton: "button.search_button",
-  // Area selector (location filter modal)
-  areaTrigger: ".resume-search-item-search-addre",
-  areaModal: ".area-selector-item-block",
-  areaProvinceBlock:
-    ".area-selector-item-block__content__down__blcok:first-child",
-  areaCityBlock: ".area-selector-item-block__content__down__blcok:nth-child(2)",
-  areaDistrictBlock:
-    ".area-selector-item-block__content__down__blcok:nth-child(3)",
-  areaItem: ".down__blcok__select",
-  areaDistrictItem: ".down__block__big-select__block",
-  areaConfirmBtn: ".area-selector-item-block__footer .button-block.blue",
-  areaCancelBtn: ".area-selector-item-block__footer .button-block:not(.blue)",
-  areaSelectedCount: ".content__up__number__select",
-};
-
-const AUTO_EXPORT_PARAM = "tr_auto_export";
-const AUTO_SYNC_PARAM = "tr_auto_sync";
-const AUTO_LIMIT_PARAM = "tr_limit";
-const AUTO_MAX_PAGES_PARAM = "tr_max_pages";
-const AUTO_MIN_AGE_PARAM = "tr_min_age";
-const AUTO_MAX_AGE_PARAM = "tr_max_age";
-const AUTO_SEARCH_PARAM = "keyword";
-const AUTO_LOCATION_PARAM = "location";
-const AUTO_KEYWORD_MODE_PARAM = "tr_kw_mode";
-const SAMPLE_NAME_PARAM = "tr_sample_name";
-const JOB5156_HOST = "hr.job5156.com";
-const SEEK_HOST_SUFFIX = ".employer.seek.com";
-const JOB5156_PROFILE_URL_PREFIX = `https://${JOB5156_HOST}/resume/view/`;
-const SOURCE_KEYS = {
-  JOB5156: "job5156",
-  JOB51: "51job",
-  SEEK: "seek",
-  UNKNOWN: "unknown",
-};
-const SEEK_PROFILE_TYPE = "seek";
-const KEYWORD_MODE_CONCAT = "concat";
-const KEYWORD_MODE_SPACED = "spaced";
-const JOB51_PAGE_COOLDOWN_MS = 8000;
-const JOB51_RATE_LIMIT_ERROR_MESSAGE =
-  "51job 已触发访问频率限制，请60分钟后再试";
 let autoExportTriggered = false;
-const API_CAPTURE_SOURCE = "tr-resume-api";
-const EXTERNAL_ACCESS_KEY = "__TR_RESUME_DATA__";
-const PAGE_BRIDGE_REQUEST_EVENT = "trResumeBridgeRequest";
-const PAGE_BRIDGE_RESPONSE_EVENT = "trResumeBridgeResponse";
-const PAGE_BRIDGE_REQUEST_ATTR = "data-tr-resume-bridge-request";
-const PAGE_BRIDGE_RESPONSE_ATTR = "data-tr-resume-bridge-response";
-const JOB51_NEXT_PAGE_EVENT = "trJob51NextPageRequest";
-const CONTENT_SCRIPT_SOURCE = "tr-resume-content-script";
-const JOB5156_DETAIL_FETCH_TIMEOUT_MS = 5000;
-const JOB5156_DETAIL_FETCH_CONCURRENCY = 5;
-const JOB51_DETAIL_FETCH_TIMEOUT_MS = 8000;
-const JOB51_DETAIL_FETCH_CONCURRENCY = 2;
-const DEFAULT_SEEK_PAGE_SIZE = 20;
-const LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY = "latestAutoSyncSummaries";
 
 // Capture auto-sync params from the initial URL at module init (document_start).
 // SEEK's SPA may strip unknown query params via history.replaceState before the

--- a/apps/browser-extension/src/lib/auto-sync-runner.ts
+++ b/apps/browser-extension/src/lib/auto-sync-runner.ts
@@ -1,0 +1,486 @@
+// @ts-nocheck
+/**
+ * Factory: createAutoSyncRunner
+ * Extracts the runAutoSyncIfEnabled orchestration from content.ts into a
+ * dependency-injected module so content.ts stays thin.
+ */
+
+export function createAutoSyncRunner(deps) {
+  const {
+    // Auto-actions helpers
+    getAutoSyncEnabled,
+    setAutoSyncAttributes,
+    resolveAutoSyncErrorStatus,
+    resolveAutoSyncStopReason,
+    runAutoExportIfEnabled,
+    syncCurrentPageToServer,
+
+    // Seek extractor
+    setSeekAutoSyncWindowAttributes,
+    setSeekAutoSyncSelectionAttributes,
+    isSeekProfileMode,
+    resolveSeekAutoSyncPageWindow,
+    isSeekAutoSyncPageWindowReached,
+    resolveSeekAutoSyncCurrentPageSelection,
+    getSeekRequestedPageSize,
+    getSeekCurrentCandidateCount,
+    resolveSeekAutoSyncPageSize,
+    enrichSeekResumesWithDetail,
+
+    // Pagination utils
+    getPaginationInfo,
+    waitForPagination,
+    getNextPageButtonState,
+
+    // Extraction pipeline
+    waitForExtractionData,
+    extractResumes,
+    goToNextPageInternal,
+    clearCapturedResultsForNextPage,
+    enrich51JobSearchResumesWithDetail,
+    enrichJob5156SearchResumesWithDetail,
+    queueJob51DetailBackfill,
+
+    // Snapshot collector
+    collectSnapshotPayload,
+    getApiSnapshotCount,
+
+    // Resume extractor
+    buildSubmitMetadata,
+    extractProfileUrl,
+
+    // Collection guards
+    loadCollectionGuards,
+    parseGuardFieldNames,
+    applyCollectionGuards,
+
+    // Job51 search extractor
+    ensureJob51PageAllowed,
+    isJob51RateLimitedPage,
+    waitForJob51Cooldown,
+
+    // Job51 age filter
+    filterResumesByAgeRange,
+    getAgeRangeFromUrl,
+    normalizeOptionalPositiveInt,
+
+    // UI utils
+    buildAutoSyncProgressHint,
+    buildAutoSyncSelectedCountHint,
+    buildAutoSyncCompletionHint,
+    persistLatestAutoSyncSummary,
+    getCurrentAgeRange,
+    resolveCurrentJob51AutoSyncDetailWaitMode,
+
+    // Dom utils
+    waitForPageTransition,
+    delay,
+
+    // Content.ts scope helpers
+    getCurrentSourceKey,
+    SOURCE_KEYS,
+    getCollectionLimits,
+    getKeywordMode,
+
+    // Job5156 extractor
+    isJob5156DetailPage,
+
+    // Job51 extractor
+    isJob51DetailPage,
+
+    // SyncStatusWidget
+    SyncStatusWidget,
+
+    // DOM globals
+    document,
+    window,
+
+    // Browser API
+    chrome,
+  } = deps;
+
+  async function runAutoSyncIfEnabled() {
+    if (deps.state._autoSyncTriggered) return;
+    const enabled = getAutoSyncEnabled();
+    if (!enabled) {
+      setAutoSyncAttributes("skipped");
+      setSeekAutoSyncWindowAttributes(null);
+      setSeekAutoSyncSelectionAttributes(null);
+      return;
+    }
+
+    const { limit, maxPages } = await getCollectionLimits();
+    const isJob51Source = getCurrentSourceKey() === SOURCE_KEYS.JOB51;
+
+    deps.state._autoSyncTriggered = true;
+    deps.state._autoSyncCancelled = false;
+    setAutoSyncAttributes("running", 0, 0);
+    setSeekAutoSyncWindowAttributes(null);
+    setSeekAutoSyncSelectionAttributes(null);
+    try {
+      document.documentElement.setAttribute(
+        "data-tr-auto-sync-limit",
+        String(limit),
+      );
+      document.documentElement.setAttribute(
+        "data-tr-auto-sync-max-pages",
+        String(maxPages),
+      );
+    } catch {
+      // ignore
+    }
+    SyncStatusWidget.show({
+      state: "progress",
+      message: "正在同步简历到服务器...",
+      hint: `${isJob51Source ? "51job 保守模式 · " : ""}数量上限: ${limit > 0 ? limit : "不限"} · 页数上限: ${maxPages > 0 ? maxPages : "不限"}`,
+    });
+
+    try {
+      let totalSubmitted = 0;
+      let totalInserted = 0;
+      let totalUpdated = 0;
+      let pagesVisited = 0;
+      let lastSelectedCount = null;
+      let stopReason = "completed";
+      let seekStartPage = null;
+
+      while (true) {
+        if (deps.state._autoSyncCancelled) {
+          stopReason = "cancelled";
+          break;
+        }
+
+        ensureJob51PageAllowed();
+
+        const paginationBefore = getPaginationInfo();
+        const currentPage = paginationBefore.currentPage;
+        const totalPages = paginationBefore.totalPages;
+        const isSeekListPage =
+          getCurrentSourceKey() === SOURCE_KEYS.SEEK && !isSeekProfileMode();
+        if (isSeekListPage && seekStartPage === null) {
+          seekStartPage = currentPage;
+        }
+
+        try {
+          await waitForExtractionData({});
+        } catch {
+          // waitForExtractionData timed out — SEEK may be rate-limiting or
+          // the page loaded without API rows. Don't abort the entire sync:
+          // let the resumes.length check below handle it (skip to next page).
+          console.warn(
+            "🎯 [Auto Sync] waitForExtractionData timed out — continuing",
+          );
+        }
+        ensureJob51PageAllowed();
+
+        pagesVisited += 1;
+
+        const seekPageWindow = isSeekListPage
+          ? resolveSeekAutoSyncPageWindow({
+              startPage: seekStartPage || currentPage,
+              limit,
+              maxPages,
+              requestedPageSize: getSeekRequestedPageSize(),
+              currentPageCandidateCount: getSeekCurrentCandidateCount(),
+            })
+          : null;
+        setSeekAutoSyncWindowAttributes(seekPageWindow);
+
+        const pageSelection = isSeekListPage
+          ? resolveSeekAutoSyncCurrentPageSelection({
+              limit,
+              totalSubmitted,
+              currentPageResumeCount: getSeekCurrentCandidateCount(),
+            })
+          : {
+              remainingCapacity:
+                limit > 0 ? Math.max(limit - totalSubmitted, 0) : null,
+              selectedCount: null,
+              hitLimitWithinPage: false,
+              limitAlreadyReached:
+                limit > 0 ? Math.max(limit - totalSubmitted, 0) <= 0 : false,
+            };
+        setSeekAutoSyncSelectionAttributes(isSeekListPage ? pageSelection : null);
+
+        if (
+          (isSeekListPage && pageSelection.limitAlreadyReached) ||
+          (!isSeekListPage && limit > 0 && pageSelection.limitAlreadyReached)
+        ) {
+          stopReason = "limit-reached";
+          break;
+        }
+
+        let resumes = extractResumes();
+        const hitLimitWithinPage = isSeekListPage
+          ? pageSelection.hitLimitWithinPage
+          : limit > 0 &&
+            typeof pageSelection.remainingCapacity === "number" &&
+            resumes.length > pageSelection.remainingCapacity;
+        if (isSeekListPage && typeof pageSelection.selectedCount === "number") {
+          resumes = resumes.slice(0, pageSelection.selectedCount);
+        } else if (
+          limit > 0 &&
+          typeof pageSelection.remainingCapacity === "number" &&
+          resumes.length > pageSelection.remainingCapacity
+        ) {
+          resumes = resumes.slice(0, pageSelection.remainingCapacity);
+        }
+        lastSelectedCount = isSeekListPage ? resumes.length : null;
+        if (
+          getCurrentSourceKey() === SOURCE_KEYS.JOB5156 &&
+          !isJob5156DetailPage() &&
+          resumes.length > 0
+        ) {
+          resumes = await enrichJob5156SearchResumesWithDetail(resumes);
+        }
+        if (
+          getCurrentSourceKey() === SOURCE_KEYS.SEEK &&
+          !isSeekProfileMode() &&
+          resumes.length > 0
+        ) {
+          resumes = await enrichSeekResumesWithDetail(resumes);
+        }
+        if (resumes.length <= 0) {
+          const ageRange = getCurrentAgeRange();
+          const ageHint = ageRange.enabled
+            ? ` · 年龄: ${typeof ageRange.minAge === "number" ? ageRange.minAge : "—"}-${typeof ageRange.maxAge === "number" ? ageRange.maxAge : "—"}`
+            : "";
+          const progressHint = buildAutoSyncProgressHint({
+            limit,
+            totalSubmitted,
+            selectedCount: isSeekListPage ? resumes.length : null,
+            ageHint,
+          });
+
+          SyncStatusWidget.show({
+            state: "progress",
+            message: `第 ${currentPage}/${Math.max(totalPages, currentPage)} 页无符合条件的简历，继续...`,
+            hint: progressHint,
+          });
+          setAutoSyncAttributes("running", totalSubmitted, pagesVisited);
+
+          if (deps.state._autoSyncCancelled) {
+            stopReason = "cancelled";
+            break;
+          }
+          if (
+            isSeekListPage &&
+            isSeekAutoSyncPageWindowReached(seekPageWindow, currentPage)
+          ) {
+            stopReason = "page-window-reached";
+            break;
+          }
+          if (!isSeekListPage && maxPages > 0 && pagesVisited >= maxPages) {
+            stopReason = "max-pages-reached";
+            break;
+          }
+
+          const paginationAfter = getPaginationInfo();
+          if (
+            !paginationAfter.hasNextPage ||
+            paginationAfter.currentPage >= paginationAfter.totalPages
+          ) {
+            stopReason = "no-next-page";
+            break;
+          }
+          try {
+            await waitForPagination({ timeoutMs: 8000 });
+          } catch {
+            // Some layouts render pagination late or omit it on single-page results.
+          }
+          const nextPage = paginationAfter.currentPage + 1;
+          try {
+            document.documentElement.setAttribute(
+              "data-tr-auto-sync-next-state",
+              JSON.stringify(getNextPageButtonState()),
+            );
+          } catch {
+            // ignore
+          }
+          await waitForJob51Cooldown();
+          clearCapturedResultsForNextPage();
+          const moved = goToNextPageInternal();
+          if (!moved) {
+            stopReason = "no-next-page";
+            break;
+          }
+          await waitForPageTransition({
+            expectedPage: nextPage,
+            timeoutMs: 15000,
+          });
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          continue;
+        }
+
+        const progressHint = buildAutoSyncProgressHint({
+          limit,
+          totalSubmitted,
+          selectedCount: isSeekListPage ? resumes.length : null,
+        });
+        SyncStatusWidget.show({
+          state: "progress",
+          message: `正在同步第 ${currentPage}/${Math.max(totalPages, currentPage)} 页 (${resumes.length} 份)...`,
+          hint: progressHint,
+        });
+
+        const response = await syncCurrentPageToServer(resumes);
+        if (!response?.success) {
+          throw response?.error || response || "Auto sync failed";
+        }
+
+        const submitted =
+          typeof response.submitted === "number"
+            ? response.submitted
+            : resumes.length;
+        const inserted =
+          typeof response.inserted === "number" ? response.inserted : 0;
+        const updated =
+          typeof response.updated === "number" ? response.updated : 0;
+        totalSubmitted += submitted;
+        totalInserted += inserted;
+        totalUpdated += updated;
+        setAutoSyncAttributes("running", totalSubmitted, pagesVisited);
+
+        if (
+          getCurrentSourceKey() === SOURCE_KEYS.JOB51 &&
+          !isJob51DetailPage() &&
+          resumes.length > 0
+        ) {
+          const detailBackfillPromise = queueJob51DetailBackfill(resumes, {
+            currentPage,
+            totalPages: Math.max(totalPages, currentPage),
+          });
+          const waitMode = resolveCurrentJob51AutoSyncDetailWaitMode();
+          const shouldWaitForDetails =
+            waitMode === "all" || (waitMode === "page1" && currentPage === 1);
+          if (shouldWaitForDetails) {
+            SyncStatusWidget.show({
+              state: "progress",
+              message: `正在补充第 ${currentPage}/${Math.max(totalPages, currentPage)} 页详情...`,
+              hint: "等待 51job 详情补充后再完成本页同步",
+            });
+            await detailBackfillPromise;
+          }
+        }
+
+        if (deps.state._autoSyncCancelled) {
+          stopReason = "cancelled";
+          break;
+        }
+        if (isSeekListPage && hitLimitWithinPage) {
+          stopReason = "limit-reached";
+          break;
+        }
+        if (
+          isSeekListPage &&
+          isSeekAutoSyncPageWindowReached(seekPageWindow, currentPage)
+        ) {
+          stopReason = "page-window-reached";
+          break;
+        }
+        if (!isSeekListPage && limit > 0 && totalSubmitted >= limit) {
+          stopReason = "limit-reached";
+          break;
+        }
+        if (!isSeekListPage && maxPages > 0 && pagesVisited >= maxPages) {
+          stopReason = "max-pages-reached";
+          break;
+        }
+
+        const paginationAfter = getPaginationInfo();
+        if (
+          !paginationAfter.hasNextPage ||
+          paginationAfter.currentPage >= paginationAfter.totalPages
+        ) {
+          stopReason = "no-next-page";
+          break;
+        }
+        try {
+          await waitForPagination({ timeoutMs: 8000 });
+        } catch {
+          // Some layouts render pagination late or omit it on single-page results.
+        }
+        const nextPage = paginationAfter.currentPage + 1;
+        try {
+          document.documentElement.setAttribute(
+            "data-tr-auto-sync-next-state",
+            JSON.stringify(getNextPageButtonState()),
+          );
+        } catch {
+          // ignore
+        }
+        await waitForJob51Cooldown();
+        clearCapturedResultsForNextPage();
+        const moved = goToNextPageInternal();
+        if (!moved) {
+          stopReason = "no-next-page";
+          break;
+        }
+        await waitForPageTransition({ expectedPage: nextPage, timeoutMs: 15000 });
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+
+      try {
+        document.documentElement.setAttribute(
+          "data-tr-auto-sync-stop-reason",
+          stopReason,
+        );
+      } catch {
+        // ignore
+      }
+      persistLatestAutoSyncSummary();
+
+      if (deps.state._autoSyncCancelled) {
+        SyncStatusWidget.show({
+          state: "success",
+          message: `同步已取消，已同步 ${totalSubmitted} 份简历`,
+          hint: buildAutoSyncCompletionHint({
+            totalInserted,
+            totalUpdated,
+            pagesVisited,
+            selectedCount: lastSelectedCount,
+          }),
+          autoDismiss: true,
+        });
+        setAutoSyncAttributes("cancelled", totalSubmitted, pagesVisited);
+        return;
+      }
+
+      SyncStatusWidget.show({
+        state: "success",
+        message: `已同步 ${totalSubmitted} 份简历 (${totalInserted} 新增, ${totalUpdated} 更新), 共 ${pagesVisited} 页`,
+        hint: [
+          buildAutoSyncSelectedCountHint({
+            selectedCount: lastSelectedCount,
+            prefix: "",
+          }),
+          isJob51Source ? "51job 详情补充正在后台继续" : "",
+        ]
+          .filter(Boolean)
+          .join(" · "),
+        autoDismiss: true,
+      });
+      setAutoSyncAttributes("done", totalSubmitted, pagesVisited);
+    } catch (error) {
+      console.warn("🎯 [Auto Sync] Failed:", error);
+      const status = resolveAutoSyncErrorStatus(error);
+      SyncStatusWidget.show({
+        state: "error",
+        message: status.message,
+        hint: status.hint,
+      });
+      setAutoSyncAttributes("failed");
+      try {
+        document.documentElement.setAttribute(
+          "data-tr-auto-sync-stop-reason",
+          resolveAutoSyncStopReason(error),
+        );
+      } catch {
+        // ignore
+      }
+      persistLatestAutoSyncSummary();
+    }
+  }
+
+  return { runAutoSyncIfEnabled };
+}

--- a/apps/browser-extension/src/lib/collection-guards.ts
+++ b/apps/browser-extension/src/lib/collection-guards.ts
@@ -1,0 +1,78 @@
+// @ts-nocheck
+/**
+ * Collection guard utilities — field validation and guard application
+ * for resume data quality during extraction.
+ */
+
+const DEFAULT_COLLECTION_GUARDS = {
+  job5156: "experience,jobIntention,selfIntro",
+  "51job": "experience,jobIntention,selfIntro",
+  seek: "experience,jobIntention,selfIntro",
+};
+
+const GUARD_FIELD_NAMES = new Set([
+  "experience",
+  "jobIntention",
+  "selfIntro",
+  "expectedSalary",
+  "workHistory",
+  "profileEducation",
+  "projectExperience",
+  "skills",
+  "licences",
+]);
+
+const GUARD_ARRAY_FIELD_NAMES = new Set([
+  "workHistory",
+  "profileEducation",
+  "projectExperience",
+  "skills",
+  "licences",
+]);
+
+async function loadCollectionGuards() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(
+      { collectionGuards: DEFAULT_COLLECTION_GUARDS },
+      (items) => resolve(items.collectionGuards || {}),
+    );
+  });
+}
+
+function parseGuardFieldNames(csv) {
+  if (!csv || typeof csv !== "string") return [];
+  return Array.from(
+    new Set(
+      csv
+        .split(",")
+        .map((field) => field.trim())
+        .filter((field) => GUARD_FIELD_NAMES.has(field)),
+    ),
+  );
+}
+
+function applyCollectionGuards(resume, guardFieldNames) {
+  if (
+    !resume ||
+    typeof resume !== "object" ||
+    !Array.isArray(guardFieldNames) ||
+    guardFieldNames.length === 0
+  ) {
+    return resume;
+  }
+
+  const guarded = { ...resume };
+  for (const field of guardFieldNames) {
+    guarded[field] = GUARD_ARRAY_FIELD_NAMES.has(field) ? [] : "";
+  }
+  return guarded;
+}
+
+export {
+  DEFAULT_COLLECTION_GUARDS,
+  GUARD_FIELD_NAMES,
+  GUARD_ARRAY_FIELD_NAMES,
+  loadCollectionGuards,
+  parseGuardFieldNames,
+  applyCollectionGuards,
+};

--- a/apps/browser-extension/src/lib/content-constants.ts
+++ b/apps/browser-extension/src/lib/content-constants.ts
@@ -1,0 +1,121 @@
+// @ts-nocheck
+/**
+ * Shared content-script constants and CSS selectors.
+ * Extracted from content.ts composition root for reuse across lib/ factories.
+ */
+
+// CSS Selectors based on DOM analysis
+const SELECTORS = {
+  listContainer: ".el-checkbox-group.resume-search-item-list-content-block",
+  resumeCard: ".list-content__li_part",
+  name: ".item-title-part1 a.name, a.name",
+  activityStatus: ".date-type-diff-text-block",
+  basicInfoRow: ".basic-line",
+  basicInfoItem: ".basic-line__text",
+  locationItem: ".resume-search-item-search-addre__span",
+  locationFallbackItem: ".text-truncate.text-center",
+  selfIntro: ".basic-keywords",
+  topRow: ".list-content__li__up-block",
+  topRowText: ".up-block__look-text",
+  workHistory: ".work-block",
+  workItem: ".work-item",
+  pagination: ".el-pagination",
+  nextPageBtn: ".el-pagination .btn-next",
+  seekPagination: 'nav[aria-label="Pagination of results"]',
+  seekTalentSearchPagination: 'nav[aria-label="PAGINATION_OF_RESULTS"]',
+  searchInput: ".el-autocomplete input.el-input__inner",
+  searchButton: ".resume-search-item-search-input-block__input-button",
+  // 51job eHire selectors
+  job51SearchInput: ".talent_search_keywords_input input.el-input__inner",
+  job51SearchButton: "button.search_button",
+  // Area selector (location filter modal)
+  areaTrigger: ".resume-search-item-search-addre",
+  areaModal: ".area-selector-item-block",
+  areaProvinceBlock:
+    ".area-selector-item-block__content__down__blcok:first-child",
+  areaCityBlock: ".area-selector-item-block__content__down__blcok:nth-child(2)",
+  areaDistrictBlock:
+    ".area-selector-item-block__content__down__blcok:nth-child(3)",
+  areaItem: ".down__blcok__select",
+  areaDistrictItem: ".down__block__big-select__block",
+  areaConfirmBtn: ".area-selector-item-block__footer .button-block.blue",
+  areaCancelBtn: ".area-selector-item-block__footer .button-block:not(.blue)",
+  areaSelectedCount: ".content__up__number__select",
+};
+
+const AUTO_EXPORT_PARAM = "tr_auto_export";
+const AUTO_SYNC_PARAM = "tr_auto_sync";
+const AUTO_LIMIT_PARAM = "tr_limit";
+const AUTO_MAX_PAGES_PARAM = "tr_max_pages";
+const AUTO_MIN_AGE_PARAM = "tr_min_age";
+const AUTO_MAX_AGE_PARAM = "tr_max_age";
+const AUTO_SEARCH_PARAM = "keyword";
+const AUTO_LOCATION_PARAM = "location";
+const AUTO_KEYWORD_MODE_PARAM = "tr_kw_mode";
+const SAMPLE_NAME_PARAM = "tr_sample_name";
+const JOB5156_HOST = "hr.job5156.com";
+const SEEK_HOST_SUFFIX = ".employer.seek.com";
+const JOB5156_PROFILE_URL_PREFIX = `https://${JOB5156_HOST}/resume/view/`;
+const SOURCE_KEYS = {
+  JOB5156: "job5156",
+  JOB51: "51job",
+  SEEK: "seek",
+  UNKNOWN: "unknown",
+};
+const SEEK_PROFILE_TYPE = "seek";
+const KEYWORD_MODE_CONCAT = "concat";
+const KEYWORD_MODE_SPACED = "spaced";
+const JOB51_PAGE_COOLDOWN_MS = 8000;
+const JOB51_RATE_LIMIT_ERROR_MESSAGE =
+  "51job 已触发访问频率限制，请60分钟后再试";
+const API_CAPTURE_SOURCE = "tr-resume-api";
+const EXTERNAL_ACCESS_KEY = "__TR_RESUME_DATA__";
+const PAGE_BRIDGE_REQUEST_EVENT = "trResumeBridgeRequest";
+const PAGE_BRIDGE_RESPONSE_EVENT = "trResumeBridgeResponse";
+const PAGE_BRIDGE_REQUEST_ATTR = "data-tr-resume-bridge-request";
+const PAGE_BRIDGE_RESPONSE_ATTR = "data-tr-resume-bridge-response";
+const JOB51_NEXT_PAGE_EVENT = "trJob51NextPageRequest";
+const CONTENT_SCRIPT_SOURCE = "tr-resume-content-script";
+const JOB5156_DETAIL_FETCH_TIMEOUT_MS = 5000;
+const JOB5156_DETAIL_FETCH_CONCURRENCY = 5;
+const JOB51_DETAIL_FETCH_TIMEOUT_MS = 8000;
+const JOB51_DETAIL_FETCH_CONCURRENCY = 2;
+const DEFAULT_SEEK_PAGE_SIZE = 20;
+const LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY = "latestAutoSyncSummaries";
+
+export {
+  SELECTORS,
+  AUTO_EXPORT_PARAM,
+  AUTO_SYNC_PARAM,
+  AUTO_LIMIT_PARAM,
+  AUTO_MAX_PAGES_PARAM,
+  AUTO_MIN_AGE_PARAM,
+  AUTO_MAX_AGE_PARAM,
+  AUTO_SEARCH_PARAM,
+  AUTO_LOCATION_PARAM,
+  AUTO_KEYWORD_MODE_PARAM,
+  SAMPLE_NAME_PARAM,
+  JOB5156_HOST,
+  SEEK_HOST_SUFFIX,
+  JOB5156_PROFILE_URL_PREFIX,
+  SOURCE_KEYS,
+  SEEK_PROFILE_TYPE,
+  KEYWORD_MODE_CONCAT,
+  KEYWORD_MODE_SPACED,
+  JOB51_PAGE_COOLDOWN_MS,
+  JOB51_RATE_LIMIT_ERROR_MESSAGE,
+  API_CAPTURE_SOURCE,
+  EXTERNAL_ACCESS_KEY,
+  PAGE_BRIDGE_REQUEST_EVENT,
+  PAGE_BRIDGE_RESPONSE_EVENT,
+  PAGE_BRIDGE_REQUEST_ATTR,
+  PAGE_BRIDGE_RESPONSE_ATTR,
+  JOB51_NEXT_PAGE_EVENT,
+  CONTENT_SCRIPT_SOURCE,
+  JOB5156_DETAIL_FETCH_TIMEOUT_MS,
+  JOB5156_DETAIL_FETCH_CONCURRENCY,
+  JOB51_DETAIL_FETCH_TIMEOUT_MS,
+  JOB51_DETAIL_FETCH_CONCURRENCY,
+  DEFAULT_SEEK_PAGE_SIZE,
+  LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY,
+};

--- a/apps/browser-extension/src/lib/dom-utils.ts
+++ b/apps/browser-extension/src/lib/dom-utils.ts
@@ -132,3 +132,10 @@ export function createDomUtils(deps: DomUtilsDeps) {
     findVueParentByName,
   };
 }
+
+/**
+ * Simple delay utility for async timing.
+ */
+export function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/browser-extension/src/lib/job5156-extractor.ts
+++ b/apps/browser-extension/src/lib/job5156-extractor.ts
@@ -23,9 +23,6 @@ export function createJob5156Extractor(deps) {
     loadCollectionGuards,
     parseGuardFieldNames,
     applyCollectionGuards,
-    parseJob5156BasicInfoItems,
-    buildJob5156WorkHistoryItem,
-    buildJob5156EducationItem,
     isMeaningfulJob5156WorkHistoryEntry,
     collectJob5156SectionItemsByHeading,
   } = deps;
@@ -873,6 +870,134 @@ export function createJob5156Extractor(deps) {
     }
 
     return enriched;
+  }
+
+  function parseJob5156BasicInfoItems(items, locationOverride = "") {
+    const basicInfo = Array.isArray(items)
+      ? items.map((item) => normalizeResumeText(item)).filter(Boolean)
+      : [];
+
+    let age = "";
+    let experience = "";
+    let education = "";
+    let location = "";
+    if (basicInfo.length >= 4) {
+      [age, experience, education, location] = basicInfo;
+    } else {
+      basicInfo.forEach((item) => {
+        if (!age && item.includes("岁")) age = item;
+        else if (!experience && item.includes("年") && !item.includes("元"))
+          experience = item;
+        else if (
+          !education &&
+          /(中专|高中|大专|本科|硕|博|研究生|MBA|EMBA)/.test(item)
+        )
+          education = item;
+        else if (!location && !item.includes("元")) location = item;
+      });
+    }
+
+    if (locationOverride) {
+      location = normalizeResumeText(locationOverride);
+    }
+
+    return { age, experience, education, location };
+  }
+
+  function buildJob5156WorkHistoryItem(item) {
+    if (!(item instanceof Element)) return null;
+
+    const startDate = normalizeResumeText(
+      item.querySelector(".work-time > span:first-child")?.textContent,
+    );
+    const durationLabel = normalizeResumeText(
+      item.querySelector(".work-time-other")?.textContent,
+    );
+    const companyName = normalizeResumeText(
+      item.querySelector(".work-company")?.textContent,
+    );
+    const jobTitle = normalizeResumeText(
+      item.querySelector(".work-position")?.textContent,
+    );
+    const description = normalizeResumeText(
+      item.querySelector(
+        ".work-desc, .work-detail, .work-content, .work-responsibility, .work-duty",
+      )?.textContent,
+    );
+    const endDate = startDate.includes("~")
+      ? normalizeResumeText(startDate.split("~").slice(1).join("~"))
+      : "";
+    const raw = buildWorkHistoryRawParts([
+      startDate,
+      durationLabel,
+      companyName,
+      jobTitle,
+      description,
+    ]);
+
+    if (!raw) return null;
+
+    return {
+      raw,
+      companyName: companyName || undefined,
+      jobTitle: jobTitle || undefined,
+      description: description || undefined,
+      startDate: startDate || undefined,
+      endDate: endDate || undefined,
+    };
+  }
+
+  function buildJob5156EducationItem(item) {
+    if (!(item instanceof Element)) return null;
+
+    const liveEducationText = normalizeResumeText(item.textContent);
+    if (
+      item.classList.contains("resume-education__info") ||
+      item.closest(".resume-education")
+    ) {
+      const institution = normalizeResumeText(
+        item.querySelector(".flex.w-full > div:last-child")?.textContent,
+      );
+      const rowText = Array.from(item.querySelectorAll(".flex.w-full > div"))
+        .map((node) => normalizeResumeText(node.textContent))
+        .filter(Boolean);
+      const endDate = rowText.find((value) => /^\d{4}(~|-)/.test(value)) || "";
+      const qualification = rowText
+        .filter((value) => value !== institution && value !== endDate)
+        .join(" · ");
+
+      if (!institution && !qualification && !endDate && !liveEducationText)
+        return null;
+
+      return {
+        institution: institution || undefined,
+        qualification: qualification || undefined,
+        endDate: endDate || undefined,
+        description: liveEducationText || undefined,
+      };
+    }
+
+    const institution = normalizeResumeText(
+      item.querySelector(".school-name")?.textContent,
+    );
+    const qualification = normalizeResumeText(
+      item.querySelector(".school-major")?.textContent,
+    );
+    const degree = normalizeResumeText(
+      item.querySelector(".school-degree")?.textContent,
+    );
+    const endDate = normalizeResumeText(
+      item.querySelector(".school-time")?.textContent,
+    );
+
+    if (!institution && !qualification && !degree && !endDate) return null;
+
+    return {
+      institution: institution || undefined,
+      qualification:
+        [qualification, degree].filter(Boolean).join(" · ") || undefined,
+      endDate: endDate || undefined,
+    };
   }
 
   return {

--- a/apps/browser-extension/src/lib/resume-extractor.ts
+++ b/apps/browser-extension/src/lib/resume-extractor.ts
@@ -37,7 +37,6 @@ export interface ResumeExtractorDeps {
   doc: Document;
   getCurrentSourceKey: () => string;
   SOURCE_KEYS: Record<string, string>;
-  extractProfileUrl: (card: Element, apiRow: any) => string;
   parseJob5156BasicInfoItems: (items: string[], locationOverride: string) => {
     age?: number;
     experience?: string;
@@ -55,13 +54,28 @@ export interface ResumeExtractorDeps {
   getJob5156DetailRoot: () => Element | null;
   getJob51ResumePayload: () => any;
   getJob5156ResumePayload: () => any;
-  getApiRowForIndex: (index: number) => any;
   normalizeResumeText: (text: string) => string;
   normalizeResumeMultilineText: (text: string) => string;
   applyCollectionGuards: (resume: any, guardFieldNames: Set<string>) => any;
   parseGuardFieldNames: (csv: string) => Set<string>;
   GUARD_FIELD_NAMES: Set<string>;
   DEFAULT_COLLECTION_GUARDS: Record<string, string>;
+  // Profile URL extraction deps
+  apiSnapshot: { searchRows?: any[] | null; [key: string]: any };
+  JOB5156_PROFILE_URL_PREFIX: string;
+  normalizeJob5156ProfileUrlForExport: (value: string) => string;
+  win: Window;
+  // buildSubmitMetadata deps
+  normalizeKeyword: (value: string) => string;
+  AUTO_SEARCH_PARAM: string;
+  getAutoLocationValues: (url: URL) => string[];
+  AUTO_EXPORT_PARAM: string;
+  AUTO_SYNC_PARAM: string;
+  AUTO_LIMIT_PARAM: string;
+  AUTO_MAX_PAGES_PARAM: string;
+  SAMPLE_NAME_PARAM: string;
+  getExtensionGeneratedBy: () => string;
+  buildSeekCollectionContext: (options?: { captureModeOverride?: string }) => any;
 }
 
 export function createResumeExtractor(deps: ResumeExtractorDeps) {
@@ -71,7 +85,6 @@ export function createResumeExtractor(deps: ResumeExtractorDeps) {
     doc,
     getCurrentSourceKey,
     SOURCE_KEYS,
-    extractProfileUrl,
     parseJob5156BasicInfoItems,
     buildJob5156WorkHistoryItem,
     buildJob5156EducationItem,
@@ -83,14 +96,115 @@ export function createResumeExtractor(deps: ResumeExtractorDeps) {
     getJob5156DetailRoot,
     getJob51ResumePayload,
     getJob5156ResumePayload,
-    getApiRowForIndex,
     normalizeResumeText,
     normalizeResumeMultilineText,
     applyCollectionGuards,
     parseGuardFieldNames,
     GUARD_FIELD_NAMES,
     DEFAULT_COLLECTION_GUARDS,
+    apiSnapshot,
+    JOB5156_PROFILE_URL_PREFIX,
+    normalizeJob5156ProfileUrlForExport,
+    win,
+    normalizeKeyword,
+    AUTO_SEARCH_PARAM,
+    getAutoLocationValues,
+    AUTO_EXPORT_PARAM,
+    AUTO_SYNC_PARAM,
+    AUTO_LIMIT_PARAM,
+    AUTO_MAX_PAGES_PARAM,
+    SAMPLE_NAME_PARAM,
+    getExtensionGeneratedBy,
+    buildSeekCollectionContext,
   } = deps;
+
+  function getApiRowForIndex(index) {
+    if (!Array.isArray(apiSnapshot.searchRows)) return null;
+    return apiSnapshot.searchRows[index] || null;
+  }
+
+  function isPlaceholderProfileUrl(value) {
+    if (!value) return true;
+    const normalized = String(value).trim().toLowerCase();
+    return (
+      normalized === "" ||
+      normalized === "#" ||
+      normalized.startsWith("javascript:") ||
+      normalized === "about:blank"
+    );
+  }
+
+  function toAbsoluteHttpUrl(value) {
+    if (!value || typeof value !== "string") return "";
+    try {
+      const url = new URL(value, win.location.origin);
+      if (url.protocol !== "http:" && url.protocol !== "https:") return "";
+      if (isPlaceholderProfileUrl(url.href)) return "";
+      return url.href;
+    } catch {
+      return "";
+    }
+  }
+
+  function buildProfileUrlFromApiRow(apiRow) {
+    if (!apiRow || typeof apiRow !== "object") return "";
+    const resumeId = apiRow.resumeId;
+    if (resumeId === null || resumeId === undefined || resumeId === "") return "";
+    const encodedId = encodeURIComponent(String(resumeId));
+    return `${JOB5156_PROFILE_URL_PREFIX}${encodedId}`;
+  }
+
+  function extractProfileUrl(card, apiRow) {
+    const nameLink = card.querySelector(SELECTORS.name);
+    if (!nameLink) return buildProfileUrlFromApiRow(apiRow);
+
+    const candidates = [
+      nameLink.getAttribute("href"),
+      nameLink.getAttribute("data-href"),
+      nameLink.getAttribute("data-url"),
+      nameLink.getAttribute("data-link"),
+      nameLink.href,
+    ];
+
+    for (const candidate of candidates) {
+      const normalized = toAbsoluteHttpUrl(candidate);
+      if (normalized) return normalizeJob5156ProfileUrlForExport(normalized);
+    }
+
+    return buildProfileUrlFromApiRow(apiRow);
+  }
+
+  function buildSubmitMetadata(options = {}) {
+    const url = new URL(win.location.href);
+    const sourceKey = getCurrentSourceKey();
+    const keyword = normalizeKeyword(
+      url.searchParams.get(AUTO_SEARCH_PARAM) || "",
+    );
+    const location = getAutoLocationValues(url).join(",");
+
+    url.searchParams.delete(AUTO_EXPORT_PARAM);
+    url.searchParams.delete(AUTO_SYNC_PARAM);
+    url.searchParams.delete(AUTO_LIMIT_PARAM);
+    url.searchParams.delete(AUTO_MAX_PAGES_PARAM);
+    url.searchParams.delete(SAMPLE_NAME_PARAM);
+
+    const metadata = {
+      sourceKey,
+      sourceHost: url.hostname.toLowerCase(),
+      sourceUrl: url.toString(),
+      generatedBy: getExtensionGeneratedBy(),
+    };
+
+    if (keyword) metadata.keyword = keyword;
+    if (location) metadata.location = location;
+    if (sourceKey === SOURCE_KEYS.SEEK) {
+      metadata.collectionContext = buildSeekCollectionContext({
+        captureModeOverride: options.seekCaptureMode,
+      });
+    }
+
+    return metadata;
+  }
 
   function extractSingleResume(card: Element, apiRow: any = null): ResumeData {
     const getText = (selector: string, root: Element = card): string => {
@@ -230,5 +344,9 @@ export function createResumeExtractor(deps: ResumeExtractorDeps) {
 
   return {
     extractSingleResume,
+    getApiRowForIndex,
+    isPlaceholderProfileUrl,
+    extractProfileUrl,
+    buildSubmitMetadata,
   };
 }

--- a/apps/browser-extension/src/lib/seek-extractor.ts
+++ b/apps/browser-extension/src/lib/seek-extractor.ts
@@ -16,16 +16,11 @@ export function createSeekExtractor(deps) {
     // Extraction function deps
     win,
     doc,
-    buildSeekWorkHistoryItem,
-    buildSeekProfileEducationItem,
-    formatSeekExpectedSalary,
     // Pagination + extraction deps
     asHTMLElement,
     isDisabledPaginationControl,
     // Detail enrichment deps
-    findSeekTalentSearchCardTrigger,
     waitForSeekProfileSnapshot,
-    mergeSeekListResumeWithDetail,
   } = deps;
 
   function isSeekProfilePage() {
@@ -860,6 +855,179 @@ export function createSeekExtractor(deps) {
       enriched.push(await enrichSingleSeekResumeWithDetail(resume, cachedHeadings));
     }
     return enriched;
+  }
+
+  // ============================================================================
+  // Internalized extraction helpers (moved from content.ts)
+  // ============================================================================
+
+  /**
+   * Talentsearch cards have no <a> links — candidate name is a [data-role="heading"]
+   * element clicked via SPA event handlers. Find the card matching this profileId
+   * (UUID) by checking data attributes or card index.
+   */
+  function findSeekTalentSearchCardTrigger(profileId, resume, cachedHeadings) {
+    if (!profileId) return null;
+    // Try matching by data-tr-candidate-id attribute (set during extraction)
+    const byAttr = doc.querySelector(
+      `[data-tr-candidate-id="${CSS.escape(profileId)}"]`,
+    );
+    if (byAttr instanceof HTMLElement) return byAttr;
+    // Fallback: match heading elements that contain the candidate name.
+    // Talentsearch cards use [data-role="heading"] for the candidate name.
+    const candidateName = typeof resume?.name === "string" ? resume.name.trim() : "";
+    if (candidateName) {
+      const headings = cachedHeadings ||
+        Array.from(doc.querySelectorAll('[data-role="heading"]'));
+      const match = headings.find((h) => {
+        const text = (h.textContent || "").trim();
+        return text === candidateName;
+      });
+      if (match instanceof HTMLElement) return match;
+    }
+    return null;
+  }
+
+  function mergeSeekListResumeWithDetail(baseResume, detailResume, isTalentSearch = false) {
+    if (!detailResume || typeof detailResume !== "object") {
+      return baseResume;
+    }
+
+    // For talentsearch: if V3 detail provides a numeric profileId, use it for
+    // profileUrl construction but preserve the UUID seekProfileGuid
+    const seekProfileGuid = baseResume.seekProfileGuid || detailResume.seekProfileGuid || undefined;
+    const numericProfileId = isTalentSearch && detailResume.profileId && /^\d+$/.test(detailResume.profileId)
+      ? detailResume.profileId
+      : undefined;
+
+    // If we got a numeric profileId from V3 detail, update the profileUrl
+    let profileUrl = detailResume.profileUrl || baseResume.profileUrl;
+    if (numericProfileId) {
+      // Derive jobId from the current page URL or API request for recommended URL format
+      const seekRequest = getSeekTalentSearchRequest();
+      const requestJobId = seekRequest?.variables?.input?.jobId;
+      const urlJobId = normalizeOptionalPositiveInt(
+        new URL(win.location.href).searchParams.get("jobId"),
+      );
+      const jobId = requestJobId != null
+        ? String(requestJobId)
+        : urlJobId != null
+          ? String(urlJobId)
+          : undefined;
+      profileUrl = buildSeekProfileUrl(numericProfileId, jobId);
+    }
+
+    return {
+      ...baseResume,
+      ...detailResume,
+      ...(seekProfileGuid ? { seekProfileGuid } : {}),
+      ...(numericProfileId ? { profileId: numericProfileId } : {}),
+      ...(profileUrl ? { profileUrl } : {}),
+      pageIndex: baseResume.pageIndex,
+      pageNumber: baseResume.pageNumber,
+      extractedAt: baseResume.extractedAt,
+      source: baseResume.source,
+      searchProfileId: detailResume.searchProfileId || baseResume.searchProfileId,
+    };
+  }
+
+  function formatSeekExpectedSalary(expectedSalary) {
+    if (!expectedSalary || typeof expectedSalary !== "object") return "";
+
+    const amounts = Array.isArray(expectedSalary.amount)
+      ? expectedSalary.amount
+      : [];
+    const preferredFrequencies = ["MONTHLY", "ANNUAL", "HOURLY"];
+    const amount =
+      preferredFrequencies
+        .map((frequency) =>
+          amounts.find((entry) => entry?.frequency === frequency),
+        )
+        .find(Boolean) || amounts[0];
+
+    if (!amount || typeof amount !== "object") return "";
+
+    const value =
+      typeof amount.value === "number" ? amount.value : Number(amount.value);
+    const formattedValue = Number.isFinite(value)
+      ? new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(value)
+      : "";
+    const currency =
+      typeof expectedSalary.currency === "string"
+        ? expectedSalary.currency.trim()
+        : "";
+    const period =
+      amount.frequency === "ANNUAL"
+        ? "/year"
+        : amount.frequency === "HOURLY"
+          ? "/hour"
+          : amount.frequency === "DAILY"
+            ? "/day"
+            : "/month";
+
+    const prefix = [currency, formattedValue].filter(Boolean).join(" ");
+    return prefix ? `${prefix}${period}` : "";
+  }
+
+  function buildSeekWorkHistoryItem(item) {
+    if (!item || typeof item !== "object") return null;
+
+    const companyName =
+      typeof item.companyName === "string" ? item.companyName.trim() : "";
+    const jobTitle =
+      typeof item.jobTitle === "string" ? item.jobTitle.trim() : "";
+    const description =
+      typeof item.description === "string" ? item.description.trim() : "";
+    const startDate =
+      typeof item.startDate === "string" ? item.startDate.trim() : "";
+    const endDate = typeof item.endDate === "string" ? item.endDate.trim() : "";
+    const durationLabel =
+      typeof item.durationLabel === "string" ? item.durationLabel.trim() : "";
+    const raw = [jobTitle, companyName, durationLabel]
+      .filter(Boolean)
+      .join(" · ");
+
+    if (!raw && !description) return null;
+
+    return {
+      raw: raw || description,
+      companyName: companyName || undefined,
+      jobTitle: jobTitle || undefined,
+      description: description || undefined,
+      startDate: startDate || undefined,
+      endDate: endDate || undefined,
+    };
+  }
+
+  function buildSeekProfileEducationItem(item) {
+    if (!item || typeof item !== "object") return null;
+
+    const institution =
+      typeof item.institutionName === "string" ? item.institutionName.trim() : "";
+    const qualification =
+      typeof item.qualificationName === "string"
+        ? item.qualificationName.trim()
+        : "";
+    const completionYear = Number.isFinite(item.completionYear)
+      ? String(item.completionYear)
+      : "";
+    const completionMonth =
+      Number.isFinite(item.completionMonth) && item.completionMonth > 0
+        ? String(item.completionMonth).padStart(2, "0")
+        : "";
+    const endDate = completionYear
+      ? completionMonth
+        ? `${completionYear}-${completionMonth}`
+        : completionYear
+      : "";
+
+    if (!institution && !qualification && !endDate) return null;
+
+    return {
+      institution: institution || undefined,
+      qualification: qualification || undefined,
+      endDate: endDate || undefined,
+    };
   }
 
   return {

--- a/apps/browser-extension/src/lib/sync-status-widget.ts
+++ b/apps/browser-extension/src/lib/sync-status-widget.ts
@@ -1,0 +1,162 @@
+// @ts-nocheck
+/**
+ * Sync status widget for browser extension content scripts.
+ * All dependencies injected from content.ts via DI factory.
+ */
+
+export function createSyncStatusWidget(deps) {
+  const {
+    win,
+    doc,
+    chrome,
+    onCancel,
+  } = deps;
+
+  const WIDGET_ID = "tr-sync-status-widget";
+  const DEFAULT_AUTO_DISMISS_MS = 5000;
+  const HIDE_DELAY_MS = 220;
+  let widgetEl = null;
+  let dismissTimer = null;
+  let hideTimer = null;
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function clearTimers() {
+    if (dismissTimer) {
+      clearTimeout(dismissTimer);
+      dismissTimer = null;
+    }
+    if (hideTimer) {
+      clearTimeout(hideTimer);
+      hideTimer = null;
+    }
+  }
+
+  function ensureWidget() {
+    if (widgetEl && widgetEl.isConnected) return widgetEl;
+
+    widgetEl = doc.createElement("div");
+    widgetEl.id = WIDGET_ID;
+    widgetEl.className = "tr-sync-widget";
+    widgetEl.setAttribute("role", "status");
+    widgetEl.setAttribute("aria-live", "polite");
+    widgetEl.setAttribute("aria-atomic", "true");
+    const mountTarget = doc.body || doc.documentElement;
+    mountTarget.appendChild(widgetEl);
+    return widgetEl;
+  }
+
+  function renderIcon(state) {
+    if (state === "progress") {
+      return '<span class="tr-sync-widget__spinner" aria-hidden="true"></span>';
+    }
+    if (state === "success") {
+      return '<span aria-hidden="true">✓</span>';
+    }
+    return '<span aria-hidden="true">!</span>';
+  }
+
+  function openOptionsPage() {
+    try {
+      void chrome.runtime
+        .sendMessage({ action: "openOptionsPage" })
+        .catch((error) => {
+          console.warn("🎯 [Auto Sync] Failed to open options page:", error);
+        });
+    } catch (error) {
+      console.warn("🎯 [Auto Sync] Failed to request options page:", error);
+    }
+  }
+
+  function show({
+    state = "progress",
+    message = "",
+    hint = "",
+    autoDismiss = false,
+  } = {}) {
+    const normalizedState =
+      state === "success" || state === "error" ? state : "progress";
+    const safeMessage = escapeHtml(message);
+    const safeHint = escapeHtml(hint);
+    const widget = ensureWidget();
+    clearTimers();
+
+    widget.className = `tr-sync-widget tr-sync-widget--${normalizedState}`;
+    widget.classList.remove("tr-sync-widget--hidden");
+    widget.innerHTML = `
+      <div class="tr-sync-widget__icon">${renderIcon(normalizedState)}</div>
+      <div class="tr-sync-widget__content">
+        <div class="tr-sync-widget__message">${safeMessage}</div>
+        ${safeHint ? `<div class="tr-sync-widget__hint">${safeHint}</div>` : ""}
+      </div>
+      ${
+        normalizedState === "progress"
+          ? '<button type="button" class="tr-sync-widget__cancel" aria-label="取消同步">取消</button>'
+          : normalizedState === "error"
+            ? '<button type="button" class="tr-sync-widget__close" aria-label="关闭提示">×</button>'
+            : ""
+      }
+    `;
+
+    widget.onclick = null;
+    if (normalizedState === "progress") {
+      const cancelBtn = widget.querySelector(".tr-sync-widget__cancel");
+      cancelBtn?.addEventListener("click", (event) => {
+        event.stopPropagation();
+        onCancel();
+        cancelBtn.setAttribute("disabled", "true");
+        cancelBtn.textContent = "取消中...";
+      });
+    }
+    if (normalizedState === "error") {
+      widget.onclick = (event) => {
+        const target = event.target instanceof Element ? event.target : null;
+        if (target?.closest(".tr-sync-widget__close")) return;
+        openOptionsPage();
+      };
+
+      const closeBtn = widget.querySelector(".tr-sync-widget__close");
+      closeBtn?.addEventListener("click", (event) => {
+        event.stopPropagation();
+        hide();
+      });
+    }
+
+    const dismissMs =
+      typeof autoDismiss === "number"
+        ? autoDismiss
+        : autoDismiss
+          ? DEFAULT_AUTO_DISMISS_MS
+          : 0;
+    if (dismissMs > 0) {
+      dismissTimer = setTimeout(() => {
+        hide();
+      }, dismissMs);
+    }
+  }
+
+  function hide() {
+    if (!widgetEl) return;
+    clearTimers();
+    widgetEl.classList.add("tr-sync-widget--hidden");
+    hideTimer = setTimeout(() => {
+      if (widgetEl) {
+        widgetEl.remove();
+        widgetEl = null;
+      }
+      hideTimer = null;
+    }, HIDE_DELAY_MS);
+  }
+
+  return {
+    show,
+    hide,
+  };
+}


### PR DESCRIPTION
## Summary
- **44% reduction** of `content.ts` (1989 → 1111 lines) via systematic DI factory extraction and function internalization
- Builds on PR #895 (DOM utils, pagination, resume-extractor) with 5 additional extraction commits:
  - Internalized 8 data-building functions into seek-extractor and job5156-extractor factories
  - Extracted collection guards to `lib/collection-guards.ts`
  - Extracted SyncStatusWidget to `lib/sync-status-widget.ts`
  - Extracted runAutoSyncIfEnabled (450L) to `lib/auto-sync-runner.ts`
  - Extracted shared constants to `lib/content-constants.ts`
  - Moved `delay()` utility to dom-utils as exported function

| Commit | What | Lines removed |
|--------|------|---------------|
| 79d757dd | Seek/job5156 data builders → their factories | -302 |
| 87bfba89 | Collection guards + delay → separate modules | -57 |
| 94e48797 | SyncStatusWidget + profile URL helpers | -194 |
| 4426345a | runAutoSyncIfEnabled → auto-sync-runner.ts | -283 |
| 4fd586f5 | Constants → content-constants.ts | -42 |

## Test plan
- [x] `make check` passes after each commit
- [x] All DI factory modules follow established pattern
- [x] Factory ordering invariants preserved
- [ ] Manual verification: browser extension loads and extracts resumes