### PR TITLE
refactor: deduplicate isRecord checks across 50 files

### DIFF
--- a/apps/api/src/routes/ai-summary.ts
+++ b/apps/api/src/routes/ai-summary.ts
@@ -1,6 +1,7 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { resolveConvexUrl } from "../services/resume-import-service.js";
 import { aiSummaryService } from "../services/ai-summary-service.js";
+import { isRecord } from "@trends/shared";
 
 const AI_SUMMARY_TTL_MS = 60 * 60 * 1000;
 const AI_SUMMARY_STALE_AFTER_MS = 50 * 60 * 1000;
@@ -46,9 +47,6 @@ const SearchSummaryErrorResponseSchema = z.object({
   error: z.string(),
 });
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 async function callConvex(
   type: "query" | "mutation",

--- a/apps/api/src/routes/blocks.ts
+++ b/apps/api/src/routes/blocks.ts
@@ -1,15 +1,15 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@trends/shared";
+
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+
 
 import { config } from "../services/config.js";
 
 const app = new OpenAPIHono();
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;

--- a/apps/api/src/routes/candidate-status.ts
+++ b/apps/api/src/routes/candidate-status.ts
@@ -1,16 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@trends/shared";
+
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+
 
 import { config } from "../services/config.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 
 const app = new OpenAPIHono();
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -16,6 +16,7 @@ import {
   SYSTEM_SETTINGS_NAV_ITEMS,
   SYSTEM_CAPABILITY_DESCRIPTORS,
   SYSTEM_NAV_ITEMS,
+  isRecord,
 } from "@trends/shared";
 import { requireAdmin } from "../middleware/workspace.js";
 import { getMaskedApiKey, loadAIConfig, validateAIConfig } from "../services/ai-config.js";
@@ -196,9 +197,6 @@ const ResumeDisplayLimitsSchema = z.object({
   source: z.string(),
 });
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function readPackageVersion(relativePath: string): string {
   const packageJsonPath = path.resolve(REPO_ROOT, relativePath);

--- a/apps/api/src/routes/job-descriptions.ts
+++ b/apps/api/src/routes/job-descriptions.ts
@@ -4,6 +4,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { jobDescriptionService } from "../services/job-description-service.js";
 import { jdKeywordExtractionService } from "../services/jd-keyword-extraction-service.js";
 import { DataNotFoundError } from "../services/errors.js";
+import { isRecord } from "@trends/shared";
 
 const app = new OpenAPIHono();
 
@@ -82,9 +83,6 @@ type ConvexJobDescriptionRecord = {
   maxAge?: unknown;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -105,7 +105,7 @@ import { formatIsoOffsetInTimezone } from "../services/timezone.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { BrandDisplayResolver } from "../services/brand-display-resolver.js";
 
-import { buildKeywordAnalysisId, getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey } from "@trends/shared";
+import { isRecord, buildKeywordAnalysisId, getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey } from "@trends/shared";
 import type { ResumeItem } from "../types/resume.js";
 import type { ResumeIndex } from "../services/resume-index.js";
 import {
@@ -409,9 +409,6 @@ function normalizeMatchRecommendations(
   return normalized.length > 0 ? normalized : undefined;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function parseConvexProvenance(value: unknown): ResumeSearchProvenance[] | undefined {
   if (!Array.isArray(value)) {

--- a/apps/api/src/routes/resumes_import.ts
+++ b/apps/api/src/routes/resumes_import.ts
@@ -16,7 +16,7 @@ import {
   ResumeSubmitSummarySchema,
 } from "../schemas/index.js";
 import { resolveResumeId } from "../services/resume-id.js";
-import { normalizeWorkHistoryEntry } from "@trends/shared";
+import { isRecord, normalizeWorkHistoryEntry } from "@trends/shared";
 import type { ResumeItem } from "../types/resume.js";
 import {
   buildResumeIngestData,
@@ -28,9 +28,6 @@ import {
 const app = new OpenAPIHono();
 const actionStorage = new ActionStorage(config.projectRoot);
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function toResumeItemFromRecord(record: Record<string, unknown>, source?: string): ResumeItem {
   const profileUrl = toStringValue(

--- a/apps/api/src/routes/resumes_search.ts
+++ b/apps/api/src/routes/resumes_search.ts
@@ -41,7 +41,7 @@ import {
   selectLatestWorkHistory,
 } from "@trends/shared";
 import { bffMatchesResumeFilters } from "../services/bff-filter-utils.js";
-import { buildKeywordAnalysisId, getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey } from "@trends/shared";
+import { isRecord, buildKeywordAnalysisId, getCurrentResumeAiPromptVersion, resolveResumeAnalysisSourceKey } from "@trends/shared";
 import { SkillsKnowledgeService } from "../services/skills-knowledge.js";
 import type { ResumeItem } from "../types/resume.js";
 import type { ResumeIndex } from "../services/resume-index.js";
@@ -253,9 +253,6 @@ function resolveResumeSortOrder(
   return sortOrder || "asc";
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 function parseConvexProvenance(value: unknown): ResumeSearchProvenance[] | undefined {
   if (!Array.isArray(value)) {

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -11,6 +11,7 @@ import {
     findWorkspaceSearchProfileTemplate,
     generateStructuredJobDescriptionContent,
     getWorkspaceSearchProfileTemplates,
+    isRecord,
     isValidWorkspace,
     WORKSPACE_TEAMS,
 } from "@trends/shared";
@@ -130,9 +131,6 @@ const ProfileRunStatusSchema = z.object({
 
 type ProfileRunStatus = z.infer<typeof ProfileRunStatusSchema>;
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null;
-}
 
 function readString(value: unknown): string | undefined {
     return typeof value === "string" && value.trim().length > 0

--- a/apps/api/src/routes/taxonomy.ts
+++ b/apps/api/src/routes/taxonomy.ts
@@ -1,6 +1,7 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { requireAdmin } from "../middleware/workspace.js";
 import { resolveConvexUrl } from "../services/resume-import-service.js";
+import { isRecord } from "@trends/shared";
 
 const app = new OpenAPIHono();
 
@@ -49,9 +50,6 @@ const DeleteTaxonomyParamsSchema = z.object({
 
 type TaxonomyClusterResponse = z.infer<typeof TaxonomyClusterSchema>;
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 async function callConvex(
   type: "query" | "mutation",

--- a/apps/api/src/services/bff-filter-utils.ts
+++ b/apps/api/src/services/bff-filter-utils.ts
@@ -8,6 +8,7 @@ import {
   getVerifiedRoleSignalYears,
   type AnalysisRoleSignalLike,
   isLocationMatch,
+  isRecord,
   normalizeResumeLocationHierarchy,
   parseSalaryRange,
   resolveResumeAnalysisSourceKey,
@@ -19,9 +20,6 @@ import { normalizeEducationLevel } from "./resume-service.js";
 // Internal helpers (also extracted so tests don't need to replicate them)
 // ---------------------------------------------------------------------------
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 export function toStringValue(value: unknown): string {
   if (typeof value === "string") {

--- a/apps/api/src/services/config-source-inspector.ts
+++ b/apps/api/src/services/config-source-inspector.ts
@@ -14,6 +14,7 @@ import {
 import {
   INSPECTABLE_SOURCE_GROUP_DEFINITIONS,
   STATIC_INSPECTABLE_SOURCE_DEFINITIONS,
+  isRecord,
   type ConfigSourceMetadata,
   type InspectableSourceDetail,
   type InspectableSourceGroupSummary,
@@ -45,9 +46,6 @@ export class UnknownConfigSourceError extends Error {
 
 const STATIC_SOURCES: StaticInspectableSourceDefinition[] = STATIC_INSPECTABLE_SOURCE_DEFINITIONS;
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 export function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;

--- a/apps/api/src/services/convex-utils.ts
+++ b/apps/api/src/services/convex-utils.ts
@@ -1,4 +1,5 @@
 import { resolveConvexUrl } from "../services/resume-import-service.js";
+import { isRecord } from "@trends/shared";
 
 export type ConvexPaginatedQueryPage = {
   page: unknown[];
@@ -6,9 +7,6 @@ export type ConvexPaginatedQueryPage = {
   isDone: boolean;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 export function isConvexPaginatedQueryPage(value: unknown): value is ConvexPaginatedQueryPage {
   if (!isRecord(value)) {

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -3,6 +3,7 @@ import {
   buildWorkHistoryEntryText,
   computeVerifiedRoleYears,
   formatLocationHierarchySearchText,
+  isRecord,
   normalizeEducationLevel,
   normalizeResumeLocationHierarchy,
   normalizeWorkHistoryEntry,
@@ -98,9 +99,6 @@ interface VerifiedEmployerMatch {
   companyNameCn: string;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 function toStringValue(value: unknown): string {
   return typeof value === "string" ? value : "";

--- a/apps/api/src/services/job-description-service.ts
+++ b/apps/api/src/services/job-description-service.ts
@@ -1,6 +1,6 @@
 /**
  * Enhanced Job Description Service
- * 
+ *
  * Parses JD files with auto_match frontmatter for minimal-input matching
  */
 
@@ -9,6 +9,7 @@ import path from "node:path";
 import { parse as parseYaml } from "yaml";
 import { findProjectRoot } from "./db.js";
 import { DataNotFoundError } from "./errors.js";
+import { isRecord } from "@trends/shared";
 
 // Types
 export interface AutoMatchConfig {
@@ -53,9 +54,6 @@ export interface JobDescriptionFull extends JobDescriptionFile {
   extractedAt?: string;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function toStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) {

--- a/apps/api/src/services/notification-template-service.ts
+++ b/apps/api/src/services/notification-template-service.ts
@@ -1,8 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@trends/shared";
+
 
 import { parse as parseYaml } from "yaml";
+
 import { z } from "zod";
+
 
 import { findProjectRoot } from "./db.js";
 import { DataNotFoundError, FileParseError } from "./errors.js";
@@ -41,9 +45,6 @@ type RenderContext = {
   index?: number;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function toStringValue(value: unknown): string {
   if (value === null || value === undefined) return "";

--- a/apps/api/src/services/resume-ai-prompt-service.ts
+++ b/apps/api/src/services/resume-ai-prompt-service.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@trends/shared";
+
 
 import { parse as parseYaml } from "yaml";
+
 
 import { findProjectRoot } from "./db.js";
 import { FileParseError } from "./errors.js";
@@ -111,9 +114,6 @@ type CachedVariantLocales = {
   locales: Set<string>;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 function readString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;

--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -6,6 +6,7 @@ import { z } from "@hono/zod-openapi";
 
 import {
   formatLocationHierarchyLabel,
+  isRecord,
   normalizeResumeLocationHierarchy,
   normalizeSeekProfileUrlForDisplay,
   inferSeekMarket,
@@ -63,9 +64,6 @@ export type NormalizedResumeImportPayload = {
   convexResumes: ConvexResumeSubmitItem[];
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 function stableStringify(value: unknown): string {
   if (value === null) return "null";

--- a/apps/api/src/services/resume-ingest-utils.ts
+++ b/apps/api/src/services/resume-ingest-utils.ts
@@ -5,6 +5,7 @@ import type {
   RoleSignalSummary,
 } from "./rule-scoring.js";
 import type { ResumeItem } from "../types/resume.js";
+import { isRecord } from "@trends/shared";
 
 // ── Shared helpers for resume ingest data parsing ────────────────────────
 // These functions handle type-safe extraction of ingest-data fields from
@@ -12,9 +13,6 @@ import type { ResumeItem } from "../types/resume.js";
 // They are duplicated across resumes.ts, resumes_import.ts, and
 // resumes_search.ts — this file is the canonical source.
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 export function toStringValue(value: unknown): string {
   if (typeof value === "string") {

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -4,6 +4,7 @@ import {
   buildWorkHistoryEntryText,
   formatLocationHierarchySearchText,
   isLocationMatch,
+  isRecord,
   normalizeEducationLevel,
   normalizeKeywordPhrases,
   normalizeProfileUrlForDisplay,
@@ -288,9 +289,6 @@ export function matchesAllRequiredKeywords(text: string, requiredKeywords: strin
   return normalizedKeywords.every((keyword) => haystack.includes(keyword));
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 export function inferResumeSource(metadata?: ResumeMetadata): string | undefined {
   const sourceHost = toStringValue(metadata?.sourceHost).toLowerCase();

--- a/apps/api/src/services/scoring-auto-tuner.ts
+++ b/apps/api/src/services/scoring-auto-tuner.ts
@@ -1,10 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@trends/shared";
+
 
 import { findProjectRoot } from "./db.js";
+
 import { getResumeScreeningDb } from "./database.js";
+
 import { type RuleWeightsConfig } from "./rule-scoring.js";
+
 import { spearmanRho } from "./scoring-metrics.js";
+
 import {
   SearchEventAnalyzer,
   scoreFromBreakdown,
@@ -75,9 +81,6 @@ function clampInteger(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, Math.round(value)));
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 const CATEGORY_KEYS: CategoryKey[] = [
   "skillMatch",

--- a/apps/api/src/services/search-event-logger.ts
+++ b/apps/api/src/services/search-event-logger.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@trends/shared";
+
 
 import { findProjectRoot } from "./db.js";
+
 
 export type SearchEventType = "search_query" | "search_zero_results" | "candidate_action";
 
@@ -54,9 +57,6 @@ export function normalizeQuery(value: string): string {
   return value.trim().replace(/\s+/g, " ");
 }
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 export function readString(value: unknown): string | null {
   if (typeof value !== "string") return null;

--- a/apps/api/src/services/search-profile-service.ts
+++ b/apps/api/src/services/search-profile-service.ts
@@ -6,7 +6,7 @@
 
 import path from "node:path";
 
-import { normalizeKeywordPhrases } from "@trends/shared";
+import { isRecord, normalizeKeywordPhrases } from "@trends/shared";
 
 import { findProjectRoot } from "./db.js";
 
@@ -131,9 +131,6 @@ type ProfileQuickStart = NonNullable<SearchProfile["quickStart"]>;
 type ProfileSession = NonNullable<SearchProfile["session"]>;
 type ProfileRetention = NonNullable<ProfileSession["retention"]>;
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function hasOwn(record: Record<string, unknown>, key: string): boolean {
     return Object.prototype.hasOwnProperty.call(record, key);

--- a/apps/api/src/services/skills-knowledge.ts
+++ b/apps/api/src/services/skills-knowledge.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@trends/shared";
+
 
 import { parse as parseYaml } from "yaml";
+
 
 import { FileParseError } from "./errors.js";
 import { findProjectRoot } from "./db.js";
@@ -184,9 +187,6 @@ function extractObservationFrequency(value: string): { normalized: string; count
   };
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 function tokenizeQuery(value: string): string[] {
   return value

--- a/apps/api/src/services/summaries/summary-data-service.ts
+++ b/apps/api/src/services/summaries/summary-data-service.ts
@@ -11,6 +11,7 @@ import type {
   SummaryWorkspaceActivityTotals,
 } from "@trends/shared";
 
+import { isRecord } from "@trends/shared";
 import {
   ActionStorage,
   type CandidateActionType,
@@ -95,9 +96,6 @@ const TASK_STATUS_LABELS: Record<string, string> = {
   cancelled: "Cancelled",
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;

--- a/apps/api/src/services/timezone.ts
+++ b/apps/api/src/services/timezone.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@trends/shared";
+
 
 import yaml from "js-yaml";
+
 
 export const DEFAULT_TIMEZONE = "Asia/Hong_Kong";
 
@@ -17,9 +20,6 @@ type ResolveTimezoneOptions = {
   defaultTimezone?: string;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 export function isValidTimezone(value: string): boolean {
   try {

--- a/apps/api/src/services/web-vitals-logger.ts
+++ b/apps/api/src/services/web-vitals-logger.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@trends/shared";
+
 
 import { findProjectRoot } from "./db.js";
+
 
 export interface WebVitalMetric {
   name: string;
@@ -27,9 +30,6 @@ export interface WebVitalsSummary {
   metrics: Record<string, MetricSummary>;
 }
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 export function readString(value: unknown): string | null {
   if (typeof value !== "string") return null;

--- a/apps/api/src/services/weight-history.ts
+++ b/apps/api/src/services/weight-history.ts
@@ -1,9 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@trends/shared";
+
 
 import { findProjectRoot } from "./db.js";
+
 import { type RuleWeightsConfig } from "./rule-scoring.js";
+
 import { workspaceConfigService } from "./workspace-config-service.js";
+
 
 type RuleCategoryWeights = RuleWeightsConfig["categoryWeights"];
 
@@ -21,9 +26,6 @@ export interface WeightHistoryEntry {
   };
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 export function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);

--- a/apps/api/src/services/workspace-config-service.ts
+++ b/apps/api/src/services/workspace-config-service.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
 import {
+  isRecord,
   parseResumeFieldUsagePolicyOverrides,
   resolveResumeFieldUsagePolicy,
   type ResumeFieldUsagePolicy,
@@ -43,9 +44,6 @@ type WorkspaceConfigEntry = {
   updatedAt: number;
 };
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 export function readString(value: unknown): string | null {
   if (typeof value === "string" && value.trim().length > 0) {

--- a/apps/web/e2e/blacklist.spec.ts
+++ b/apps/web/e2e/blacklist.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test'
+import { isRecord } from "@trends/shared";
 
 type BlockItem = {
   _id: string
@@ -9,9 +10,6 @@ type BlockItem = {
   blockedAt: number
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
 
 async function mockBlocksApi(page: Page, initialItems: BlockItem[]) {
   let items = [...initialItems]

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { normalizeProfileUrlForDisplay, normalizeSharedResumeFields, parseKeywordQuery, inferSeekMarket } from '@trends/shared'
+import { isRecord, normalizeProfileUrlForDisplay, normalizeSharedResumeFields, parseKeywordQuery, inferSeekMarket } from '@trends/shared'
 import { usePaginatedQuery, useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
@@ -234,9 +234,6 @@ export function buildFallbackKeywordExpansion(query: string): KeywordExpansionSu
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
-}
 
 function buildMockSearchText(doc: ResumeListDocLike): string {
   const content = isRecord(doc.content) ? doc.content : {}

--- a/apps/web/src/lib/debug-ai-score-utils.test.ts
+++ b/apps/web/src/lib/debug-ai-score-utils.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { isRecord } from "@trends/shared";
 import {
   clampScore,
   extractBreakdown,
-  isRecord,
   parseBreakdownCandidate,
   readTextField,
   toScore,

--- a/apps/web/src/lib/debug-ai-score-utils.ts
+++ b/apps/web/src/lib/debug-ai-score-utils.ts
@@ -4,6 +4,7 @@
  * Extracted from DebugAI.tsx for testability.
  */
 
+import { isRecord } from "@trends/shared";
 export type BreakdownKey = "experience" | "skills" | "industry_db" | "education" | "location";
 
 export type ScoreBreakdown = Record<BreakdownKey, number>;
@@ -16,9 +17,6 @@ export const EMPTY_BREAKDOWN: ScoreBreakdown = {
   location: 0,
 };
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 export function toScore(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -1,6 +1,7 @@
 import {
   buildLatestWorkHistoryEvidence,
   getCurrentResumeAiPromptVersion,
+  isRecord,
   normalizeOptionalString,
   resolveResumeId,
 } from '@trends/shared'
@@ -380,9 +381,6 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === 'string')
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
-}
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value))

--- a/apps/web/src/lib/taxonomy.ts
+++ b/apps/web/src/lib/taxonomy.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "@trends/shared";
+
 export type TaxonomyClusterSource = 'human' | 'ai' | 'merged'
 export type TaxonomyClusterStatus = 'active' | 'draft' | 'archived'
 
@@ -116,9 +118,6 @@ export function taxonomyClusterToForm(cluster: TaxonomyCluster): TaxonomyCluster
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
-}
 
 export function parseTaxonomyCluster(value: unknown): TaxonomyCluster | null {
   if (!isRecord(value)) {

--- a/apps/web/src/pages/DebugAI.tsx
+++ b/apps/web/src/pages/DebugAI.tsx
@@ -3,6 +3,7 @@ import {
   DEBUG_AI_BREAKDOWN_LABELS,
   DEBUG_AI_KEYWORD_PROMPT_VARIANT,
   getResumeAiPromptDefinition,
+  isRecord,
   sanitizeResumeRecordForSurface,
   type ResumeFieldUsagePolicy,
 } from '@trends/shared'
@@ -21,7 +22,6 @@ import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyCont
 import {
   type BreakdownKey,
   extractBreakdown,
-  isRecord,
   readTextField,
 } from '@/lib/debug-ai-score-utils'
 

--- a/apps/web/src/pages/system-settings/lib.ts
+++ b/apps/web/src/pages/system-settings/lib.ts
@@ -6,7 +6,7 @@ import type {
   InspectableSourceSummary as ConfigSourceSummary,
   SurfaceNavDefinition,
 } from '@trends/shared'
-import { SYSTEM_SETTINGS_NAV_ITEMS } from '@trends/shared'
+import { isRecord, SYSTEM_SETTINGS_NAV_ITEMS } from '@trends/shared'
 import { withWorkspaceHeaders } from '@/lib/workspace-ref'
 
 export type {
@@ -218,9 +218,6 @@ export function resolveSystemSettingsSubpages(
 
 export const SYSTEM_SETTINGS_SUBPAGES = resolveSystemSettingsSubpages(undefined)
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
-}
 
 function readString(value: unknown): string | null {
   if (typeof value === 'string') {

--- a/packages/convex/convex/__tests__/analyze.test.ts
+++ b/packages/convex/convex/__tests__/analyze.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { isRecord } from "@trends/shared";
 import {
-  isRecord,
   toNumber,
   clamp,
   parseNumericBreakdown,

--- a/packages/convex/convex/__tests__/search-text-helpers.test.ts
+++ b/packages/convex/convex/__tests__/search-text-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { isRecord } from "@trends/shared";
 import {
-  isRecord,
   normalizeWhitespace,
   addScriptBoundarySpaces,
   segmentChineseRuns,

--- a/packages/convex/convex/ai_tagging_results.ts
+++ b/packages/convex/convex/ai_tagging_results.ts
@@ -1,5 +1,5 @@
 /// <reference path="./convex-env.d.ts" />
-import { buildLatestWorkHistoryEvidence } from "@trends/shared";
+import { isRecord, buildLatestWorkHistoryEvidence } from "@trends/shared";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { internalAction, internalMutation, internalQuery, mutation, query } from "./_generated/server";
@@ -28,9 +28,6 @@ type RoleSignalSnapshot = {
   verifyIn: string;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 
 export function stableHash(seed: string): string {

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -8,6 +8,7 @@ import {
     resolveResumeAnalysisSourceKey,
     sanitizeResumeRecordForSurface,
     resolveResumeAiPromptLocale,
+    isRecord,
     selectLatestWorkHistory,
     type ResumeFieldUsagePolicy,
     type ResumeFieldUsagePolicyOverrides,
@@ -461,9 +462,6 @@ export function getAiTemperature(): number {
     return 0;
 }
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null;
-}
 
 // Helper to normalize resume data
 export function normalizeResume(

--- a/packages/convex/convex/ingest_agent.ts
+++ b/packages/convex/convex/ingest_agent.ts
@@ -4,6 +4,7 @@ import type { Id } from "./_generated/dataModel";
 import { internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import type { ResumeScanRow } from "./resumes";
+import { isRecord } from "@trends/shared";
 
 interface BrandHit {
   brand: string;
@@ -70,9 +71,6 @@ function getBffApiUrl(): string {
   return process.env.BFF_API_URL || "http://localhost:3000";
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 function isStaleSkillsVersion(resume: ResumeScanRow, currentVersion: number): boolean {
   const version = resume.ingestData?.skillsVersion;

--- a/packages/convex/convex/lib/age.ts
+++ b/packages/convex/convex/lib/age.ts
@@ -1,6 +1,4 @@
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null;
-}
+import { isRecord } from "@trends/shared";
 
 function parseAgeFromString(value: string): number | null {
     const trimmed = value.trim();

--- a/packages/convex/convex/lib/resume_identity.ts
+++ b/packages/convex/convex/lib/resume_identity.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "@trends/shared";
+
 export type ResumeIdentitySource = "profileUrl" | "resumeId" | "perUserId" | "externalId";
 
 export type ResumeIdentityInput = {
@@ -20,9 +22,6 @@ const EXTERNAL_ID_KEYS = ["externalId", "external_id"];
 const JOB5156_HOST = "hr.job5156.com";
 export const SEEK_HOST_SUFFIX = ".employer.seek.com";
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null;
-}
 
 function readString(value: unknown): string | null {
     if (typeof value !== "string") {

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -18,6 +18,7 @@ import {
     parse51jobManualResume,
     shouldPreferManual51jobOptionalField,
     splitManual51jobLines,
+    isRecord,
 } from "@trends/shared";
 
 import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
@@ -30,9 +31,6 @@ const JOB5156_HOST = "hr.job5156.com";
 const MANUAL_51JOB_SOURCE = "51job-manual";
 const PROFILE_URL_CONTENT_KEYS = ["profileUrl", "profile_url", "profileURL", "url"];
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null;
-}
 
 function rewriteJob5156ProfileUrlsInContent(content: unknown): {
     content: Record<string, unknown> | null;

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -23,15 +23,13 @@ import {
     normalizeResumeLocationHierarchy,
     resolveResumeAnalysisSourceKey,
     selectLatestWorkHistory,
+    isRecord,
     parseSalaryRange,
 } from "@trends/shared";
 import { parseAgeFromContent } from "./lib/age";
 import { deriveResumeIdentity } from "./lib/resume_identity";
 import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null;
-}
 
 function toStringValue(value: unknown): string {
     if (typeof value === "string") {

--- a/packages/convex/convex/search_text.ts
+++ b/packages/convex/convex/search_text.ts
@@ -2,8 +2,11 @@ import {
     buildLatestWorkHistoryEvidence,
     formatLocationHierarchySearchText,
     getDisallowedResumeFieldKeys,
+    isRecord,
     type LocationHierarchy,
 } from "@trends/shared";
+
+type UnknownRecord = Record<string, unknown>;
 
 const PRIORITY_KEYS = [
     "name",
@@ -24,11 +27,7 @@ const EXCLUDED_KEYS = new Set([
     ...getDisallowedResumeFieldKeys("analysis"),
 ]);
 
-type UnknownRecord = Record<string, unknown>;
 
-export function isRecord(value: unknown): value is UnknownRecord {
-    return typeof value === "object" && value !== null;
-}
 
 export function normalizeWhitespace(value: string): string {
     return value.replace(/\s+/g, " ").trim();

--- a/packages/shared/src/resume-field-usage-policy.ts
+++ b/packages/shared/src/resume-field-usage-policy.ts
@@ -5,6 +5,7 @@ import {
   type ResumeFieldUsagePolicy,
   type ResumeFieldUsageSurface,
 } from "./generated/resume-field-usage-policy.js";
+import { isRecord } from "./resume-normalization.js";
 
 export type {
   ResumeFieldUsageFieldPolicy,
@@ -20,9 +21,6 @@ export type ResumeFieldUsagePolicyOverrides = {
   fields?: Record<string, ResumeFieldUsageFieldPolicy>;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;

--- a/packages/shared/src/resume-normalization.ts
+++ b/packages/shared/src/resume-normalization.ts
@@ -113,7 +113,7 @@ function inferCountryFromSource(source: unknown): string | undefined {
   return key ? SOURCE_KEY_TO_COUNTRY[key] : undefined;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 

--- a/packages/shared/src/work-history-evidence.ts
+++ b/packages/shared/src/work-history-evidence.ts
@@ -1,10 +1,9 @@
+import { isRecord } from "./resume-normalization.js";
+
 function normalizeWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 function toOptionalString(value: unknown): string | undefined {
   if (typeof value !== "string") {


### PR DESCRIPTION
## Summary
- Replaces duplicate `isRecord` type guard checks with shared implementation across 50 files (82 insertions, 149 deletions)
- Clean merge from `origin/refactor/dedup-isRecord` onto current main

## Test plan
- [x] `make check` passes
- [ ] Verify typecheck across all workspaces
- [ ] Concept-drift flagged files reviewed (migrations.ts, analyze.ts, resumes.ts, ingest_agent.ts, search_text.ts, useConvexResumes.ts)