### PR TITLE
test: add 200 tests for remaining 8 lib modules + remove @ts-nocheck from 2 files

### DIFF
--- a/apps/browser-extension/src/lib/__tests__/auto-sync-runner.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/auto-sync-runner.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { createAutoSyncRunner } from "../auto-sync-runner";
+
+function createMockDeps(overrides = {}) {
+  return {
+    getAutoSyncEnabled: vi.fn(() => true),
+    setAutoSyncAttributes: vi.fn(),
+    resolveAutoSyncErrorStatus: vi.fn(() => ({
+      message: "Error",
+      hint: "Try again",
+    })),
+    resolveAutoSyncStopReason: vi.fn(() => "error"),
+    runAutoExportIfEnabled: vi.fn(),
+    syncCurrentPageToServer: vi.fn(() =>
+      Promise.resolve({ success: true, submitted: 5, inserted: 3, updated: 2 }),
+    ),
+    setSeekAutoSyncWindowAttributes: vi.fn(),
+    setSeekAutoSyncSelectionAttributes: vi.fn(),
+    isSeekProfileMode: vi.fn(() => false),
+    resolveSeekAutoSyncPageWindow: vi.fn(() => null),
+    isSeekAutoSyncPageWindowReached: vi.fn(() => false),
+    resolveSeekAutoSyncCurrentPageSelection: vi.fn(() => ({
+      remainingCapacity: null,
+      selectedCount: null,
+      hitLimitWithinPage: false,
+      limitAlreadyReached: false,
+    })),
+    getSeekRequestedPageSize: vi.fn(() => null),
+    getSeekCurrentCandidateCount: vi.fn(() => 0),
+    resolveSeekAutoSyncPageSize: vi.fn(() => 20),
+    enrichSeekResumesWithDetail: vi.fn((r) => Promise.resolve(r)),
+    getPaginationInfo: vi.fn(() => ({
+      currentPage: 1,
+      totalPages: 1,
+      totalItems: 5,
+      hasNextPage: false,
+    })),
+    waitForPagination: vi.fn(() => Promise.resolve()),
+    getNextPageButtonState: vi.fn(() => ({ disabled: true })),
+    waitForExtractionData: vi.fn(() => Promise.resolve()),
+    extractResumes: vi.fn(() => [{ name: "Test" }]),
+    goToNextPageInternal: vi.fn(() => false),
+    clearCapturedResultsForNextPage: vi.fn(),
+    enrich51JobSearchResumesWithDetail: vi.fn((r) => Promise.resolve(r)),
+    enrichJob5156SearchResumesWithDetail: vi.fn((r) => Promise.resolve(r)),
+    queueJob51DetailBackfill: vi.fn(() => Promise.resolve()),
+    collectSnapshotPayload: vi.fn(() => Promise.resolve({ resumes: [] })),
+    getApiSnapshotCount: vi.fn(() => 0),
+    buildSubmitMetadata: vi.fn(() => ({})),
+    extractProfileUrl: vi.fn(() => ""),
+    loadCollectionGuards: vi.fn(() => Promise.resolve(null)),
+    parseGuardFieldNames: vi.fn(() => []),
+    applyCollectionGuards: vi.fn((r) => r),
+    ensureJob51PageAllowed: vi.fn(),
+    isJob51RateLimitedPage: vi.fn(() => false),
+    waitForJob51Cooldown: vi.fn(() => Promise.resolve()),
+    filterResumesByAgeRange: vi.fn((r) => r),
+    getAgeRangeFromUrl: vi.fn(() => null),
+    normalizeOptionalPositiveInt: vi.fn(() => null),
+    buildAutoSyncProgressHint: vi.fn(() => ""),
+    buildAutoSyncSelectedCountHint: vi.fn(() => ""),
+    buildAutoSyncCompletionHint: vi.fn(() => ""),
+    persistLatestAutoSyncSummary: vi.fn(),
+    getCurrentAgeRange: vi.fn(() => ({ enabled: false })),
+    resolveCurrentJob51AutoSyncDetailWaitMode: vi.fn(() => "background"),
+    waitForPageTransition: vi.fn(() => Promise.resolve()),
+    delay: vi.fn(() => Promise.resolve()),
+    getCurrentSourceKey: vi.fn(() => "job5156"),
+    SOURCE_KEYS: { JOB51: "job51", JOB5156: "job5156", SEEK: "seek" },
+    getCollectionLimits: vi.fn(() => Promise.resolve({ limit: 50, maxPages: 5 })),
+    getKeywordMode: vi.fn(() => "normal"),
+    isJob5156DetailPage: vi.fn(() => false),
+    isJob51DetailPage: vi.fn(() => false),
+    SyncStatusWidget: {
+      show: vi.fn(),
+      hide: vi.fn(),
+    },
+    document: {
+      documentElement: {
+        setAttribute: vi.fn(),
+        getAttribute: vi.fn(() => ""),
+      },
+    },
+    window: {},
+    chrome: {},
+    state: {
+      _autoSyncTriggered: false,
+      _autoSyncCancelled: false,
+    },
+    ...overrides,
+  };
+}
+
+describe("auto-sync-runner", () => {
+  describe("runAutoSyncIfEnabled", () => {
+    it("skips when auto sync is disabled", async () => {
+      const deps = createMockDeps({
+        getAutoSyncEnabled: vi.fn(() => false),
+      });
+      const runner = createAutoSyncRunner(deps);
+      await runner.runAutoSyncIfEnabled();
+      expect(deps.setAutoSyncAttributes).toHaveBeenCalledWith("skipped");
+      expect(deps.SyncStatusWidget.show).not.toHaveBeenCalled();
+    });
+
+    it("skips when already triggered", async () => {
+      const deps = createMockDeps({
+        state: { _autoSyncTriggered: true, _autoSyncCancelled: false },
+      });
+      const runner = createAutoSyncRunner(deps);
+      await runner.runAutoSyncIfEnabled();
+      expect(deps.setAutoSyncAttributes).not.toHaveBeenCalled();
+    });
+
+    it("syncs resumes and shows success", async () => {
+      const deps = createMockDeps();
+      const runner = createAutoSyncRunner(deps);
+      await runner.runAutoSyncIfEnabled();
+
+      expect(deps.state._autoSyncTriggered).toBe(true);
+      expect(deps.setAutoSyncAttributes).toHaveBeenCalledWith("running", 0, 0);
+      expect(deps.syncCurrentPageToServer).toHaveBeenCalled();
+      expect(deps.setAutoSyncAttributes).toHaveBeenCalledWith(
+        "done",
+        5,
+        1,
+      );
+      expect(deps.SyncStatusWidget.show).toHaveBeenCalledWith(
+        expect.objectContaining({ state: "success" }),
+      );
+    });
+
+    it("handles sync failure and shows error", async () => {
+      const deps = createMockDeps({
+        syncCurrentPageToServer: vi.fn(() =>
+          Promise.reject(new Error("Network error")),
+        ),
+      });
+      const runner = createAutoSyncRunner(deps);
+      await runner.runAutoSyncIfEnabled();
+
+      expect(deps.resolveAutoSyncErrorStatus).toHaveBeenCalled();
+      expect(deps.SyncStatusWidget.show).toHaveBeenCalledWith(
+        expect.objectContaining({ state: "error" }),
+      );
+      expect(deps.setAutoSyncAttributes).toHaveBeenCalledWith("failed");
+    });
+
+    it("handles sync failure with error response object", async () => {
+      const deps = createMockDeps({
+        syncCurrentPageToServer: vi.fn(() =>
+          Promise.resolve({ success: false, error: "Server rejected" }),
+        ),
+      });
+      const runner = createAutoSyncRunner(deps);
+      await runner.runAutoSyncIfEnabled();
+
+      expect(deps.resolveAutoSyncErrorStatus).toHaveBeenCalled();
+      expect(deps.SyncStatusWidget.show).toHaveBeenCalledWith(
+        expect.objectContaining({ state: "error" }),
+      );
+    });
+
+    it("cancels sync when state flag set", async () => {
+      let callCount = 0;
+      const deps = createMockDeps({
+        syncCurrentPageToServer: vi.fn(() => {
+          callCount++;
+          if (callCount === 1) {
+            deps.state._autoSyncCancelled = true;
+          }
+          return Promise.resolve({
+            success: true,
+            submitted: 5,
+            inserted: 3,
+            updated: 2,
+          });
+        }),
+        getPaginationInfo: vi.fn(() => ({
+          currentPage: 1,
+          totalPages: 5,
+          totalItems: 50,
+          hasNextPage: true,
+        })),
+        goToNextPageInternal: vi.fn(() => true),
+      });
+      const runner = createAutoSyncRunner(deps);
+      await runner.runAutoSyncIfEnabled();
+
+      expect(deps.setAutoSyncAttributes).toHaveBeenCalledWith(
+        "cancelled",
+        5,
+        1,
+      );
+    });
+
+    it("shows progress widget during sync", async () => {
+      const deps = createMockDeps();
+      const runner = createAutoSyncRunner(deps);
+      await runner.runAutoSyncIfEnabled();
+
+      expect(deps.SyncStatusWidget.show).toHaveBeenCalledWith(
+        expect.objectContaining({ state: "progress" }),
+      );
+    });
+
+    it("sets auto sync limit and max pages attributes", async () => {
+      const deps = createMockDeps();
+      const runner = createAutoSyncRunner(deps);
+      await runner.runAutoSyncIfEnabled();
+
+      expect(deps.document.documentElement.setAttribute).toHaveBeenCalledWith(
+        "data-tr-auto-sync-limit",
+        "50",
+      );
+      expect(deps.document.documentElement.setAttribute).toHaveBeenCalledWith(
+        "data-tr-auto-sync-max-pages",
+        "5",
+      );
+    });
+  });
+});

--- a/apps/browser-extension/src/lib/__tests__/external-accessor.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/external-accessor.test.ts
@@ -1,0 +1,251 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  getExternalAccessorStatus,
+  installExternalAccessor,
+} from "../external-accessor";
+
+function createMockDeps(overrides = {}) {
+  return {
+    getExtensionVersion: vi.fn(() => "1.2.3"),
+    getPaginationInfo: vi.fn(() => ({
+      currentPage: 1,
+      totalPages: 5,
+      totalItems: 50,
+      hasNextPage: true,
+    })),
+    getCurrentAgeRange: vi.fn(() => ({ enabled: true, minAge: 25, maxAge: 40 })),
+    getCurrentSourceKey: vi.fn(() => "job51"),
+    getApiSnapshotCount: vi.fn(() => 10),
+    getSeekCardCount: vi.fn(() => 0),
+    SOURCE_KEYS: { JOB51: "job51", JOB5156: "job5156", SEEK: "seek" },
+    isExtractionReady: vi.fn(() => true),
+    isLoggedIn: vi.fn(() => true),
+    apiSnapshot: { lastOperationName: "searchResumes" },
+    SELECTORS: { resumeCard: ".resume-card" },
+    isJob5156DetailPage: vi.fn(() => false),
+    isJob5156DetailReady: vi.fn(() => false),
+    ...overrides,
+  };
+}
+
+describe("external-accessor", () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute("data-tr-auto-search");
+    document.documentElement.removeAttribute("data-tr-auto-location");
+    document.documentElement.removeAttribute("data-tr-auto-age");
+    document.documentElement.removeAttribute("data-tr-auto-export");
+    document.documentElement.removeAttribute("data-tr-auto-sync");
+    document.documentElement.removeAttribute("data-tr-auto-sync-count");
+    document.documentElement.removeAttribute("data-tr-auto-sync-pages");
+    document.documentElement.removeAttribute("data-tr-auto-sync-target-start");
+    document.documentElement.removeAttribute("data-tr-auto-sync-target-end");
+    document.documentElement.removeAttribute(
+      "data-tr-auto-sync-effective-page-size",
+    );
+    document.documentElement.removeAttribute(
+      "data-tr-auto-sync-selected-count",
+    );
+    document.documentElement.removeAttribute(
+      "data-tr-auto-sync-remaining-capacity",
+    );
+    document.documentElement.removeAttribute("data-tr-auto-sync-stop-reason");
+  });
+
+  describe("getExternalAccessorStatus", () => {
+    it("returns extensionLoaded true", () => {
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.extensionLoaded).toBe(true);
+    });
+
+    it("returns extensionVersion from deps", () => {
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.extensionVersion).toBe("1.2.3");
+    });
+
+    it("returns sourceKey from deps", () => {
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.sourceKey).toBe("job51");
+    });
+
+    it("returns apiSnapshotCount from deps", () => {
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.apiSnapshotCount).toBe(10);
+    });
+
+    it("returns domReady from isExtractionReady", () => {
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.domReady).toBe(true);
+    });
+
+    it("returns loggedIn from isLoggedIn", () => {
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.loggedIn).toBe(true);
+    });
+
+    it("returns ageRange when enabled", () => {
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.ageRange).toEqual({ minAge: 25, maxAge: 40 });
+    });
+
+    it("returns ageRange null when disabled", () => {
+      const status = getExternalAccessorStatus(
+        createMockDeps({
+          getCurrentAgeRange: vi.fn(() => ({ enabled: false })),
+        }),
+      );
+      expect(status.ageRange).toBeNull();
+    });
+
+    it("returns cardCount from apiSnapshotCount for job51", () => {
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.cardCount).toBe(10);
+    });
+
+    it("returns max of apiSnapshotCount and seekCardCount for seek source", () => {
+      const status = getExternalAccessorStatus(
+        createMockDeps({
+          getCurrentSourceKey: vi.fn(() => "seek"),
+          getApiSnapshotCount: vi.fn(() => 8),
+          getSeekCardCount: vi.fn(() => 12),
+        }),
+      );
+      expect(status.cardCount).toBe(12);
+    });
+
+    it("returns 1 for job5156 detail page when ready", () => {
+      const status = getExternalAccessorStatus(
+        createMockDeps({
+          getCurrentSourceKey: vi.fn(() => "job5156"),
+          isJob5156DetailPage: vi.fn(() => true),
+          isJob5156DetailReady: vi.fn(() => true),
+        }),
+      );
+      expect(status.cardCount).toBe(1);
+    });
+
+    it("returns 0 for job5156 detail page when not ready", () => {
+      const status = getExternalAccessorStatus(
+        createMockDeps({
+          getCurrentSourceKey: vi.fn(() => "job5156"),
+          isJob5156DetailPage: vi.fn(() => true),
+          isJob5156DetailReady: vi.fn(() => false),
+        }),
+      );
+      expect(status.cardCount).toBe(0);
+    });
+
+    it("reads auto-sync attributes from DOM", () => {
+      document.documentElement.setAttribute("data-tr-auto-sync", "running");
+      document.documentElement.setAttribute("data-tr-auto-sync-count", "5");
+      document.documentElement.setAttribute("data-tr-auto-sync-pages", "2");
+      document.documentElement.setAttribute(
+        "data-tr-auto-sync-stop-reason",
+        "completed",
+      );
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.autoSync).toBe("running");
+      expect(status.autoSyncCount).toBe(5);
+      expect(status.autoSyncPages).toBe(2);
+      expect(status.autoSyncStopReason).toBe("completed");
+    });
+
+    it("returns 0 for non-numeric auto-sync attributes", () => {
+      document.documentElement.setAttribute("data-tr-auto-sync-count", "abc");
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.autoSyncCount).toBe(0);
+    });
+
+    it("returns null for missing numeric auto-sync attributes", () => {
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.autoSyncTargetPageStart).toBeNull();
+      expect(status.autoSyncTargetPageEnd).toBeNull();
+    });
+
+    it("includes pagination info", () => {
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.pagination).toEqual({
+        currentPage: 1,
+        totalPages: 5,
+        totalItems: 50,
+        hasNextPage: true,
+      });
+    });
+
+    it("includes lastOperationName from apiSnapshot", () => {
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(status.lastOperationName).toBe("searchResumes");
+    });
+
+    it("includes timestamp as ISO string", () => {
+      const status = getExternalAccessorStatus(createMockDeps());
+      expect(typeof status.timestamp).toBe("string");
+      expect(() => new Date(status.timestamp)).not.toThrow();
+    });
+  });
+
+  describe("installExternalAccessor", () => {
+    it("installs accessor on window with expected methods", () => {
+      const key = "__TR_RESUME_DATA__";
+      const mockDeps = {
+        extractResumes: vi.fn(() => ["resume1"]),
+        extractResumesRaw: vi.fn(() => ({ raw: true })),
+        collectSnapshotPayload: vi.fn(() => Promise.resolve({})),
+        apiSnapshot: { data: "test" },
+        getPaginationInfo: vi.fn(() => ({ currentPage: 1 })),
+        isExtractionReady: vi.fn(() => true),
+        isLoggedIn: vi.fn(() => true),
+        getExternalAccessorStatus: vi.fn(() => ({ loaded: true })),
+        syncToServer: vi.fn(() => Promise.resolve()),
+        goToNextPageInternal: vi.fn(() => true),
+        version: "1.0.0",
+      };
+
+      installExternalAccessor(key, mockDeps);
+
+      expect((window as unknown as Record<string, unknown>)[key]).toBeDefined();
+      const accessor = (window as unknown as Record<string, unknown>)[key] as Record<
+        string,
+        unknown
+      >;
+      expect(typeof accessor.extract).toBe("function");
+      expect(typeof accessor.extractRaw).toBe("function");
+      expect(typeof accessor.collect).toBe("function");
+      expect(typeof accessor.getApiSnapshot).toBe("function");
+      expect(typeof accessor.getPaginationInfo).toBe("function");
+      expect(typeof accessor.isReady).toBe("function");
+      expect(typeof accessor.isLoggedIn).toBe("function");
+      expect(typeof accessor.status).toBe("function");
+      expect(typeof accessor.syncToServer).toBe("function");
+      expect(typeof accessor.goToNextPage).toBe("function");
+      expect(accessor.version).toBe("1.0.0");
+    });
+
+    it("extract method calls extractResumes", () => {
+      const key = "__TR_TEST_ACCESSOR__";
+      const extractResumes = vi.fn(() => ["resume1"]);
+      installExternalAccessor(key, {
+        extractResumes,
+        extractResumesRaw: vi.fn(),
+        collectSnapshotPayload: vi.fn(),
+        apiSnapshot: {},
+        getPaginationInfo: vi.fn(),
+        isExtractionReady: vi.fn(),
+        isLoggedIn: vi.fn(),
+        getExternalAccessorStatus: vi.fn(),
+        syncToServer: vi.fn(),
+        goToNextPageInternal: vi.fn(),
+        version: "1.0.0",
+      });
+
+      const accessor = (window as unknown as Record<string, unknown>)[key] as Record<
+        string,
+        () => unknown
+      >;
+      const result = accessor.extract();
+      expect(extractResumes).toHaveBeenCalled();
+      expect(result).toEqual(["resume1"]);
+    });
+  });
+});

--- a/apps/browser-extension/src/lib/__tests__/extraction-pipeline.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/extraction-pipeline.test.ts
@@ -2,11 +2,11 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi } from "vitest";
-import { createExtractionPipeline } from "../extraction-pipeline.js";
+import { createExtractionPipeline, type ExtractionPipelineDeps } from "../extraction-pipeline.js";
 
 const SOURCE_KEYS = { JOB5156: "job5156", JOB51: "51job", SEEK: "seek", UNKNOWN: "unknown" };
 
-function createMockDeps(overrides: Record<string, any> = {}): Record<string, any> {
+function createMockDeps(overrides: Record<string, any> = {}): ExtractionPipelineDeps {
   return {
     getCurrentSourceKey: vi.fn(() => SOURCE_KEYS.JOB5156),
     SOURCE_KEYS,
@@ -25,7 +25,7 @@ function createMockDeps(overrides: Record<string, any> = {}): Record<string, any
     window: window as unknown as Window,
     resolveCurrentJob51DetailFetchDelayMs: vi.fn(() => 1000),
     JOB51_DETAIL_FETCH_CONCURRENCY: 2,
-    enrich51JobSearchResumeWithDetail: vi.fn(async (r: any) => ({ resume: r, enriched: false })),
+    enrich51JobSearchResumeWithDetail: vi.fn(async (r: any) => ({ resume: r, enriched: false, rateLimited: false })),
     syncCurrentPageToServer: vi.fn(async () => ({ success: true })),
     delay: vi.fn(async () => {}),
     pipelineState: { runId: 1, chain: Promise.resolve() },

--- a/apps/browser-extension/src/lib/__tests__/job51-collection-config.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/job51-collection-config.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  JOB51_SAFE_LIMIT,
+  JOB51_SAFE_MAX_PAGES,
+  JOB51_DETAIL_FETCH_DELAY_MS,
+  JOB51_DETAIL_FETCH_UNSAFE_DELAY_MS,
+  hasJob51UnsafeLimitsOverride,
+  resolveJob51CollectionLimits,
+  resolveJob51DetailFetchDelayMs,
+  resolveJob51AutoSyncDetailWaitMode,
+} from "../job51-collection-config";
+
+describe("job51-collection-config", () => {
+  describe("constants", () => {
+    it("exports safe limit as 50", () => {
+      expect(JOB51_SAFE_LIMIT).toBe(50);
+    });
+
+    it("exports safe max pages as 1", () => {
+      expect(JOB51_SAFE_MAX_PAGES).toBe(1);
+    });
+
+    it("exports detail fetch delay as 5000ms", () => {
+      expect(JOB51_DETAIL_FETCH_DELAY_MS).toBe(5000);
+    });
+
+    it("exports unsafe detail fetch delay as 1000ms", () => {
+      expect(JOB51_DETAIL_FETCH_UNSAFE_DELAY_MS).toBe(1000);
+    });
+  });
+
+  describe("hasJob51UnsafeLimitsOverride", () => {
+    it("returns true when tr_unsafe_limits=1", () => {
+      expect(hasJob51UnsafeLimitsOverride("tr_unsafe_limits=1")).toBe(true);
+    });
+
+    it("returns false when tr_unsafe_limits is not 1", () => {
+      expect(hasJob51UnsafeLimitsOverride("tr_unsafe_limits=0")).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(hasJob51UnsafeLimitsOverride("")).toBe(false);
+    });
+
+    it("returns false for unrelated params", () => {
+      expect(hasJob51UnsafeLimitsOverride("keyword=python")).toBe(false);
+    });
+  });
+
+  describe("resolveJob51CollectionLimits", () => {
+    it("clamps limit to safe default without override", () => {
+      const result = resolveJob51CollectionLimits(0, 0, "");
+      expect(result.limit).toBe(JOB51_SAFE_LIMIT);
+      expect(result.maxPages).toBe(JOB51_SAFE_MAX_PAGES);
+    });
+
+    it("clamps large limit to safe max without override", () => {
+      const result = resolveJob51CollectionLimits(200, 10, "");
+      expect(result.limit).toBe(JOB51_SAFE_LIMIT);
+      expect(result.maxPages).toBe(JOB51_SAFE_MAX_PAGES);
+    });
+
+    it("allows requested limit with unsafe override", () => {
+      const result = resolveJob51CollectionLimits(200, 10, "tr_unsafe_limits=1");
+      expect(result.limit).toBe(200);
+      expect(result.maxPages).toBe(10);
+    });
+
+    it("uses safe defaults when limit is 0 even with unsafe override", () => {
+      const result = resolveJob51CollectionLimits(0, 0, "tr_unsafe_limits=1");
+      expect(result.limit).toBe(JOB51_SAFE_LIMIT);
+      expect(result.maxPages).toBe(JOB51_SAFE_MAX_PAGES);
+    });
+
+    it("clamps small limit to safe max without override", () => {
+      const result = resolveJob51CollectionLimits(30, 1, "");
+      expect(result.limit).toBe(30);
+      expect(result.maxPages).toBe(1);
+    });
+  });
+
+  describe("resolveJob51DetailFetchDelayMs", () => {
+    it("returns safe delay without override", () => {
+      expect(resolveJob51DetailFetchDelayMs("")).toBe(JOB51_DETAIL_FETCH_DELAY_MS);
+    });
+
+    it("returns unsafe delay with override", () => {
+      expect(resolveJob51DetailFetchDelayMs("tr_unsafe_limits=1")).toBe(
+        JOB51_DETAIL_FETCH_UNSAFE_DELAY_MS,
+      );
+    });
+  });
+
+  describe("resolveJob51AutoSyncDetailWaitMode", () => {
+    it('returns "background" by default', () => {
+      expect(resolveJob51AutoSyncDetailWaitMode("")).toBe("background");
+    });
+
+    it('returns "page1" when tr_job51_detail_wait=page1', () => {
+      expect(resolveJob51AutoSyncDetailWaitMode("tr_job51_detail_wait=page1")).toBe("page1");
+    });
+
+    it('returns "all" when tr_job51_detail_wait=all', () => {
+      expect(resolveJob51AutoSyncDetailWaitMode("tr_job51_detail_wait=all")).toBe("all");
+    });
+
+    it('returns "background" for unknown mode', () => {
+      expect(resolveJob51AutoSyncDetailWaitMode("tr_job51_detail_wait=unknown")).toBe("background");
+    });
+
+    it("handles whitespace in mode value", () => {
+      expect(resolveJob51AutoSyncDetailWaitMode("tr_job51_detail_wait= page1 ")).toBe("page1");
+    });
+  });
+});

--- a/apps/browser-extension/src/lib/__tests__/job51-search-extractor.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/job51-search-extractor.test.ts
@@ -1,0 +1,368 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+
+import { createJob51SearchExtractor } from "../job51-search-extractor";
+
+function createMockDeps(overrides = {}) {
+  return {
+    getCurrentSourceKey: vi.fn(() => "job51"),
+    SOURCE_KEYS: { JOB51: "job51", JOB5156: "job5156", SEEK: "seek" },
+    apiSnapshot: {},
+    normalizeJob51Text: (v: unknown) =>
+      v == null ? "" : String(v).trim().replace(/\s+/g, " "),
+    normalizeJob51MultilineText: (v: unknown) =>
+      v == null ? "" : String(v).trim().replace(/\s+/g, " "),
+    normalizeResumeText: (v: unknown) =>
+      v == null ? "" : String(v).trim().replace(/\s+/g, " "),
+    buildWorkHistoryRawParts: (parts: string[]) =>
+      parts.filter(Boolean).join(" · "),
+    EHIRE_51JOB_PROFILE_URL_PREFIX: "https://ehire.51job.com/resume/view?resumeId=",
+    EHIRE_51JOB_HOST: "ehire.51job.com",
+    JOB51_PAGE_COOLDOWN_MS: 1000,
+    JOB51_DETAIL_FETCH_TIMEOUT_MS: 10000,
+    JOB51_RATE_LIMIT_ERROR_MESSAGE: "51job rate limit reached",
+    buildJob51DetailResumeFromPayload: vi.fn(() => []),
+    filterCurrentResumesByAgeRange: vi.fn((r) => r),
+    chrome: { runtime: { sendMessage: vi.fn() } },
+    window: { location: { pathname: "/", href: "https://ehire.51job.com/" }, setTimeout: vi.fn(), clearTimeout: vi.fn() },
+    fetch: vi.fn(),
+    delay: vi.fn(),
+    isElementVisible: vi.fn(() => true),
+    activateElement: vi.fn(),
+    findVueParentByName: vi.fn(() => null),
+    ...overrides,
+  };
+}
+
+import { vi } from "vitest";
+
+describe("job51-search-extractor", () => {
+  describe("normalizeJob51AuthContext", () => {
+    it("returns null when no auth fields present", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const result = extractor.normalizeJob51AuthContext({}, {});
+      expect(result).toBeNull();
+    });
+
+    it("extracts accesstoken from headers", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const result = extractor.normalizeJob51AuthContext(
+        { accesstoken: "token123" },
+        {},
+      );
+      expect(result).toEqual({ accesstoken: "token123" });
+    });
+
+    it("extracts accesstoken from request body", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const result = extractor.normalizeJob51AuthContext(
+        {},
+        { accessToken: "token-from-body" },
+      );
+      expect(result).toEqual({ accesstoken: "token-from-body" });
+    });
+
+    it("extracts guid from headers", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const result = extractor.normalizeJob51AuthContext({ guid: "g123" }, {});
+      expect(result).toEqual({ guid: "g123" });
+    });
+
+    it("extracts multiple auth fields", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const result = extractor.normalizeJob51AuthContext(
+        { accesstoken: "t", guid: "g", property: "p", sign: "s" },
+        {},
+      );
+      expect(result).toEqual({
+        accesstoken: "t",
+        guid: "g",
+        property: "p",
+        sign: "s",
+      });
+    });
+
+    it("ignores empty string auth values", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const result = extractor.normalizeJob51AuthContext(
+        { accesstoken: "  ", guid: "" },
+        {},
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getJob51RawRows", () => {
+    it("extracts rows from payload.data.list", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const payload = { data: { list: [{ id: 1 }, { id: 2 }] } };
+      const result = extractor.getJob51RawRows(payload);
+      expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    it("extracts rows from payload.data.items", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const payload = { data: { items: [{ id: 1 }] } };
+      const result = extractor.getJob51RawRows(payload);
+      expect(result).toEqual([{ id: 1 }]);
+    });
+
+    it("extracts rows from payload.data.rows", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const payload = { data: { rows: [{ id: 3 }] } };
+      const result = extractor.getJob51RawRows(payload);
+      expect(result).toEqual([{ id: 3 }]);
+    });
+
+    it("extracts rows from payload.list directly", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const payload = { list: [{ id: 4 }] };
+      const result = extractor.getJob51RawRows(payload);
+      expect(result).toEqual([{ id: 4 }]);
+    });
+
+    it("returns null for non-array rows", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const result = extractor.getJob51RawRows({ data: { list: "not-array" } });
+      expect(result).toBeNull();
+    });
+
+    it("returns null for null payload", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const result = extractor.getJob51RawRows(null);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getJob51TotalFromPayload", () => {
+    it("extracts total from payload.data.total", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const result = extractor.getJob51TotalFromPayload({
+        data: { total: 100 },
+      });
+      expect(result).toBe(100);
+    });
+
+    it("extracts total from payload.total directly", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const result = extractor.getJob51TotalFromPayload({ total: 50 });
+      expect(result).toBe(50);
+    });
+
+    it("returns null for non-number total", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const result = extractor.getJob51TotalFromPayload({ total: "abc" });
+      expect(result).toBeNull();
+    });
+
+    it("returns null for negative total", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const result = extractor.getJob51TotalFromPayload({ total: -1 });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("isLikelyJob51ResumeRow", () => {
+    it("returns false for null", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.isLikelyJob51ResumeRow(null)).toBe(false);
+    });
+
+    it("returns false for non-object", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.isLikelyJob51ResumeRow("string")).toBe(false);
+    });
+
+    it("returns true for row with identity and name", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const row = { resumeId: "123", name: "张三" };
+      expect(extractor.isLikelyJob51ResumeRow(row)).toBe(true);
+    });
+
+    it("returns true for row with name and detail fields", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const row = { name: "张三", experience: "5年" };
+      expect(extractor.isLikelyJob51ResumeRow(row)).toBe(true);
+    });
+
+    it("returns false for row with only identity", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const row = { resumeId: "123" };
+      expect(extractor.isLikelyJob51ResumeRow(row)).toBe(false);
+    });
+
+    it("returns true for row with base_info identity and name", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      const row = {
+        base_info: { accountid: "456", resume_name: "李四" },
+      };
+      expect(extractor.isLikelyJob51ResumeRow(row)).toBe(true);
+    });
+  });
+
+  describe("isJob51RateLimitedErrorMessage", () => {
+    it("detects rate limit in Chinese", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.isJob51RateLimitedErrorMessage("搜索访问太快")).toBe(true);
+      expect(
+        extractor.isJob51RateLimitedErrorMessage("请60分钟后再试"),
+      ).toBe(true);
+      expect(
+        extractor.isJob51RateLimitedErrorMessage("访问频率限制"),
+      ).toBe(true);
+    });
+
+    it("detects rate limit in English", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.isJob51RateLimitedErrorMessage("rate limit")).toBe(true);
+      expect(extractor.isJob51RateLimitedErrorMessage("Rate Limit")).toBe(true);
+    });
+
+    it("returns false for non-rate-limit messages", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.isJob51RateLimitedErrorMessage("success")).toBe(false);
+      expect(extractor.isJob51RateLimitedErrorMessage("")).toBe(false);
+    });
+  });
+
+  describe("isJob51RateLimitedPayload", () => {
+    it("detects rate limit in payload error fields", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(
+        extractor.isJob51RateLimitedPayload({ error: "rate limit" }),
+      ).toBe(true);
+      expect(
+        extractor.isJob51RateLimitedPayload({ message: "搜索访问太快" }),
+      ).toBe(true);
+      expect(
+        extractor.isJob51RateLimitedPayload({ data: { msg: "频率限制" } }),
+      ).toBe(true);
+    });
+
+    it("returns false for null payload", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.isJob51RateLimitedPayload(null)).toBe(false);
+    });
+
+    it("returns false for non-rate-limited payload", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.isJob51RateLimitedPayload({ error: "not found" })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("isJob51DetailApiErrorPayload", () => {
+    it("returns true for result=0", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.isJob51DetailApiErrorPayload({ result: "0" })).toBe(true);
+      expect(extractor.isJob51DetailApiErrorPayload({ result: 0 })).toBe(true);
+    });
+
+    it("returns true for error code with message", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(
+        extractor.isJob51DetailApiErrorPayload({ code: "500", msg: "error" }),
+      ).toBe(true);
+    });
+
+    it("returns false for success code 200", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(
+        extractor.isJob51DetailApiErrorPayload({ code: "200", msg: "ok" }),
+      ).toBe(false);
+    });
+
+    it("returns false for null payload", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.isJob51DetailApiErrorPayload(null)).toBe(false);
+    });
+  });
+
+  describe("normalizeAgeRequestValue", () => {
+    it("returns number as-is when finite", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.normalizeAgeRequestValue(25)).toBe(25);
+    });
+
+    it("parses string to number", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.normalizeAgeRequestValue("30")).toBe(30);
+    });
+
+    it("returns null for empty string", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.normalizeAgeRequestValue("")).toBeNull();
+    });
+
+    it("returns null for NaN string", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.normalizeAgeRequestValue("abc")).toBeNull();
+    });
+
+    it("returns null for Infinity", () => {
+      const extractor = createJob51SearchExtractor(createMockDeps());
+      expect(extractor.normalizeAgeRequestValue(Infinity)).toBeNull();
+    });
+  });
+
+  describe("ensureJob51PageAllowed", () => {
+    it("does not throw when not rate-limited", () => {
+      const extractor = createJob51SearchExtractor(
+        createMockDeps({
+          getCurrentSourceKey: vi.fn(() => "job5156"), // non-job51 source skips check
+        }),
+      );
+      expect(() => extractor.ensureJob51PageAllowed()).not.toThrow();
+    });
+
+    it("throws when rate-limited page detected", () => {
+      // Set up document.body with rate-limit text before creating the extractor
+      const originalBodyText = document.body?.textContent;
+      const div = document.createElement("div");
+      div.textContent = "搜索访问太快请60分钟后再试";
+      document.body?.appendChild(div);
+      try {
+        const extractor = createJob51SearchExtractor(
+          createMockDeps({
+            getCurrentSourceKey: vi.fn(() => "job51"),
+          }),
+        );
+        expect(() => extractor.ensureJob51PageAllowed()).toThrow(
+          "51job rate limit reached",
+        );
+      } finally {
+        div.remove();
+      }
+    });
+  });
+
+  describe("hasJob51SearchSnapshot", () => {
+    it("returns true when job51SearchRows has items", () => {
+      const extractor = createJob51SearchExtractor(
+        createMockDeps({
+          apiSnapshot: { job51SearchRows: [{ id: 1 }] },
+        }),
+      );
+      expect(extractor.hasJob51SearchSnapshot()).toBe(true);
+    });
+
+    it("returns true when job51Total is a number", () => {
+      const extractor = createJob51SearchExtractor(
+        createMockDeps({
+          apiSnapshot: { job51SearchRows: [], job51Total: 100 },
+        }),
+      );
+      expect(extractor.hasJob51SearchSnapshot()).toBe(true);
+    });
+
+    it("returns false when empty and no total", () => {
+      const extractor = createJob51SearchExtractor(
+        createMockDeps({
+          apiSnapshot: { job51SearchRows: [] },
+        }),
+      );
+      expect(extractor.hasJob51SearchSnapshot()).toBe(false);
+    });
+  });
+});

--- a/apps/browser-extension/src/lib/__tests__/job5156-extractor.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/job5156-extractor.test.ts
@@ -1,0 +1,313 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+
+import { createJob5156Extractor } from "../job5156-extractor";
+
+function createMockDeps(overrides = {}) {
+  return {
+    getCurrentSourceKey: vi.fn(() => "job5156"),
+    SOURCE_KEYS: { JOB51: "job51", JOB5156: "job5156", SEEK: "seek" },
+    apiSnapshot: {},
+    normalizeResumeText: (v: unknown) =>
+      v == null ? "" : String(v).trim().replace(/\s+/g, " "),
+    normalizeResumeMultilineText: (v: unknown) =>
+      v == null ? "" : String(v).trim().replace(/\s+/g, " "),
+    buildWorkHistoryRawParts: (parts: string[]) =>
+      parts.filter(Boolean).join(" · "),
+    normalizeOptionalPositiveInt: (v: unknown) => {
+      if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+      if (typeof v === "string") {
+        const n = Number.parseInt(v, 10);
+        return Number.isFinite(n) && n > 0 ? n : null;
+      }
+      return null;
+    },
+    JOB5156_HOST: "hr.job5156.com",
+    JOB5156_PROFILE_URL_PREFIX: "https://hr.job5156.com/resume/view/",
+    JOB5156_DETAIL_FETCH_TIMEOUT_MS: 10000,
+    JOB5156_DETAIL_FETCH_CONCURRENCY: 3,
+    DEFAULT_COLLECTION_GUARDS: {},
+    GUARD_FIELD_NAMES: ["experience", "education"],
+    GUARD_ARRAY_FIELD_NAMES: ["workHistory"],
+    loadCollectionGuards: vi.fn(() => Promise.resolve(null)),
+    parseGuardFieldNames: vi.fn(() => []),
+    applyCollectionGuards: vi.fn((r) => r),
+    isMeaningfulJob5156WorkHistoryEntry: vi.fn(() => true),
+    collectJob5156SectionItemsByHeading: vi.fn(() => []),
+    ...overrides,
+  };
+}
+
+describe("job5156-extractor", () => {
+  describe("extractJob5156ResumeId", () => {
+    it("extracts resumeId from /api/com/resume/ path", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(extractor.extractJob5156ResumeId("/api/com/resume/ABC123")).toBe(
+        "ABC123",
+      );
+    });
+
+    it("extracts resumeId from /resume/view/ path", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(extractor.extractJob5156ResumeId("/resume/view/XYZ789")).toBe(
+        "XYZ789",
+      );
+    });
+
+    it("returns empty string for null/undefined", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(extractor.extractJob5156ResumeId(null as unknown as string)).toBe("");
+      expect(extractor.extractJob5156ResumeId(undefined as unknown as string)).toBe(
+        "",
+      );
+    });
+
+    it("returns empty string for non-matching path", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(extractor.extractJob5156ResumeId("/other/path")).toBe("");
+    });
+
+    it("returns empty string for empty string", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(extractor.extractJob5156ResumeId("")).toBe("");
+    });
+
+    it("handles URI-encoded resumeId", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(
+        extractor.extractJob5156ResumeId("/resume/view/%E4%B8%AD%E6%96%87"),
+      ).toBe("中文");
+    });
+  });
+
+  describe("normalizeJob5156ProfileUrlForExport", () => {
+    it("normalizes /resume/view/ URL to prefix format", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const result = extractor.normalizeJob5156ProfileUrlForExport(
+        "https://hr.job5156.com/resume/view/ABC123",
+      );
+      expect(result).toBe(
+        "https://hr.job5156.com/resume/view/ABC123",
+      );
+    });
+
+    it("returns empty for empty input", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(extractor.normalizeJob5156ProfileUrlForExport("")).toBe("");
+    });
+
+    it("returns empty for whitespace-only input", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(extractor.normalizeJob5156ProfileUrlForExport("   ")).toBe("");
+    });
+
+    it("returns href as-is for non-matching hostname", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const result = extractor.normalizeJob5156ProfileUrlForExport(
+        "https://other.site.com/resume/123",
+      );
+      expect(result).toBe("https://other.site.com/resume/123");
+    });
+  });
+
+  describe("normalizeJob5156ExtractOptions", () => {
+    it("provides defaults for missing options", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const result = extractor.normalizeJob5156ExtractOptions({});
+      expect(typeof result.pathname).toBe("string");
+      expect(typeof result.profileUrl).toBe("string");
+      expect(typeof result.extractedAt).toBe("string");
+      expect(result.pathname).toContain("/");
+    });
+
+    it("uses provided pathname", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const result = extractor.normalizeJob5156ExtractOptions({
+        pathname: "/resume/view/ABC",
+      });
+      expect(result.pathname).toBe("/resume/view/ABC");
+    });
+
+    it("uses provided profileUrl", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const result = extractor.normalizeJob5156ExtractOptions({
+        profileUrl: "https://example.com/profile",
+      });
+      expect(result.profileUrl).toBe("https://example.com/profile");
+    });
+
+    it("uses provided extractedAt", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const result = extractor.normalizeJob5156ExtractOptions({
+        extractedAt: "2026-01-01T00:00:00Z",
+      });
+      expect(result.extractedAt).toBe("2026-01-01T00:00:00Z");
+    });
+  });
+
+  describe("parseJob5156BasicInfoItems", () => {
+    it("parses 4+ items as age, experience, education, location", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const result = extractor.parseJob5156BasicInfoItems([
+        "30岁",
+        "5年",
+        "本科",
+        "深圳",
+      ]);
+      expect(result.age).toBe("30岁");
+      expect(result.experience).toBe("5年");
+      expect(result.education).toBe("本科");
+      expect(result.location).toBe("深圳");
+    });
+
+    it("infers fields from content when less than 4 items", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const result = extractor.parseJob5156BasicInfoItems([
+        "30岁",
+        "本科",
+        "深圳",
+      ]);
+      expect(result.age).toBe("30岁");
+      expect(result.education).toBe("本科");
+    });
+
+    it("uses locationOverride when provided", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const result = extractor.parseJob5156BasicInfoItems(
+        ["30岁", "5年", "本科", "广州"],
+        "深圳",
+      );
+      expect(result.location).toBe("深圳");
+    });
+
+    it("handles empty items array", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const result = extractor.parseJob5156BasicInfoItems([]);
+      expect(result.age).toBe("");
+      expect(result.experience).toBe("");
+    });
+  });
+
+  describe("isJob5156DetailPage", () => {
+    it("returns true for job5156 source on /resume/view/ path", () => {
+      // jsdom defaults to "http://localhost/" — we need to set pathname
+      const originalHref = window.location.href;
+      // Using history.pushState to set the path
+      window.history.pushState({}, "", "/resume/view/ABC123");
+      try {
+        const extractor = createJob5156Extractor(createMockDeps());
+        expect(extractor.isJob5156DetailPage()).toBe(true);
+      } finally {
+        window.history.pushState({}, "", "/");
+      }
+    });
+
+    it("returns false for non-job5156 source", () => {
+      const extractor = createJob5156Extractor(
+        createMockDeps({
+          getCurrentSourceKey: vi.fn(() => "job51"),
+        }),
+      );
+      expect(extractor.isJob5156DetailPage()).toBe(false);
+    });
+  });
+
+  describe("buildJob5156DetailWorkHistoryItemFromApi", () => {
+    it("builds work history from API item", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const result = extractor.buildJob5156DetailWorkHistoryItemFromApi({
+        begin: "2020-01",
+        end: "2023-06",
+        comName: "Test Corp",
+        jobNameStr: "Developer",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.companyName).toBe("Test Corp");
+      expect(result!.jobTitle).toBe("Developer");
+      expect(result!.startDate).toBe("2020-01");
+      expect(result!.endDate).toBe("2023-06");
+    });
+
+    it("returns null for null input", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(
+        extractor.buildJob5156DetailWorkHistoryItemFromApi(null),
+      ).toBeNull();
+    });
+
+    it("returns null for empty object", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(
+        extractor.buildJob5156DetailWorkHistoryItemFromApi({}),
+      ).toBeNull();
+    });
+  });
+
+  describe("buildJob5156EducationItemFromApi", () => {
+    it("builds education item from API data", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const result = extractor.buildJob5156EducationItemFromApi({
+        schoolName: "Test University",
+        degreeStr: "Bachelor",
+        speciality: "Computer Science",
+        begin: "2016",
+        end: "2020",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.institution).toBe("Test University");
+      expect(result!.qualification).toContain("Bachelor");
+    });
+
+    it("returns null for null input", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(
+        extractor.buildJob5156EducationItemFromApi(null),
+      ).toBeNull();
+    });
+
+    it("returns null for empty object", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(
+        extractor.buildJob5156EducationItemFromApi({}),
+      ).toBeNull();
+    });
+  });
+
+  describe("buildJob5156DetailResumeFromApiPayload", () => {
+    it("returns empty array for null payload", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(extractor.buildJob5156DetailResumeFromApiPayload(null)).toEqual([]);
+    });
+
+    it("returns empty array for non-object payload", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      expect(
+        extractor.buildJob5156DetailResumeFromApiPayload("string"),
+      ).toEqual([]);
+    });
+
+    it("returns empty array when resumeId is missing", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const payload = {
+        resumeViewVo: {
+          cnVo: { basicInfoVo: { userName: "Test" } },
+        },
+      };
+      expect(
+        extractor.buildJob5156DetailResumeFromApiPayload(payload),
+      ).toEqual([]);
+    });
+
+    it("returns empty array when cnVo is missing", () => {
+      const extractor = createJob5156Extractor(createMockDeps());
+      const payload = {
+        resumeViewVo: {},
+      };
+      expect(
+        extractor.buildJob5156DetailResumeFromApiPayload(payload, {
+          pathname: "/api/com/resume/123",
+        }),
+      ).toEqual([]);
+    });
+  });
+});

--- a/apps/browser-extension/src/lib/__tests__/seek-extractor.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/seek-extractor.test.ts
@@ -1,0 +1,445 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+
+import { createSeekExtractor } from "../seek-extractor";
+
+function createMockDeps(overrides = {}) {
+  return {
+    getCurrentSourceKey: vi.fn(() => "seek"),
+    SOURCE_KEYS: { JOB51: "job51", JOB5156: "job5156", SEEK: "seek" },
+    apiSnapshot: {
+      seekRecommendedCandidates: [],
+      seekTalentSearch: [],
+      seekProfile: null,
+      seekRecommendedRequest: null,
+      seekTalentSearchRequest: null,
+      seekProfileRequest: null,
+    },
+    normalizeOptionalPositiveInt: (v: unknown) => {
+      if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+      if (typeof v === "string") {
+        const n = Number.parseInt(v, 10);
+        return Number.isFinite(n) && n > 0 ? n : null;
+      }
+      return null;
+    },
+    DEFAULT_SEEK_PAGE_SIZE: 20,
+    SEEK_PROFILE_TYPE: "seek",
+    persistLatestAutoSyncSummary: vi.fn(),
+    win: {
+      location: {
+        pathname: "/candidates/recommended",
+        href: "https://www.seek.com/candidates/recommended",
+        hostname: "www.seek.com",
+        search: "",
+      },
+    },
+    doc: { querySelectorAll: vi.fn(() => []) },
+    asHTMLElement: (el: unknown) => el,
+    isDisabledPaginationControl: vi.fn(() => false),
+    waitForSeekProfileSnapshot: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("seek-extractor", () => {
+  describe("normalizeSeekLocationLabel", () => {
+    it("removes Malaysia and MY", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(extractor.normalizeSeekLocationLabel("Kuala Lumpur, Malaysia")).toBe(
+        "kuala lumpur",
+      );
+      expect(extractor.normalizeSeekLocationLabel("Penang MY")).toBe("penang");
+    });
+
+    it("replaces Chinese punctuation with spaces", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(
+        extractor.normalizeSeekLocationLabel("吉隆坡、槟城、柔佛"),
+      ).toBe("吉隆坡 槟城 柔佛");
+    });
+
+    it("collapses multiple spaces", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(extractor.normalizeSeekLocationLabel("  a   b  ")).toBe("a b");
+    });
+
+    it("returns empty for empty input", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(extractor.normalizeSeekLocationLabel("")).toBe("");
+      expect(extractor.normalizeSeekLocationLabel(null)).toBe("");
+    });
+
+    it("converts to lowercase", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(extractor.normalizeSeekLocationLabel("KUALA LUMPUR")).toBe(
+        "kuala lumpur",
+      );
+    });
+  });
+
+  describe("getSeekCandidateIdentity", () => {
+    it("extracts profileId and profileType from candidate", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.getSeekCandidateIdentity({
+        profileId: "12345",
+        profileType: "seek",
+      });
+      expect(result).toEqual({ profileId: "12345", profileType: "seek" });
+    });
+
+    it("defaults profileType to SEEK_PROFILE_TYPE", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.getSeekCandidateIdentity({ profileId: "123" });
+      expect(result.profileType).toBe("seek");
+    });
+
+    it("converts profileId to string", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.getSeekCandidateIdentity({ profileId: 123 });
+      expect(result.profileId).toBe("123");
+    });
+
+    it("returns empty profileId for null candidate", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.getSeekCandidateIdentity(null);
+      expect(result.profileId).toBe("");
+    });
+  });
+
+  describe("buildSeekProfileUrl", () => {
+    it("builds URL with jobId when provided", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const url = extractor.buildSeekProfileUrl("12345", "678");
+      expect(url).toContain("openProfileId=12345");
+      expect(url).toContain("jobId=678");
+    });
+
+    it("builds URL without jobId", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const url = extractor.buildSeekProfileUrl("12345", undefined);
+      expect(url).toContain("/candidates/12345");
+      expect(url).not.toContain("jobId");
+    });
+
+    it("returns empty string for empty profileId", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(extractor.buildSeekProfileUrl("", undefined)).toBe("");
+      expect(extractor.buildSeekProfileUrl(null as unknown as string, undefined)).toBe("");
+    });
+  });
+
+  describe("buildSeekNameSearchUrl", () => {
+    it("builds search URL with name and market", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const url = extractor.buildSeekNameSearchUrl("John Doe", "MY", undefined);
+      expect(url).toContain("searchQuery=John%20Doe");
+      expect(url).toContain("market=MY");
+      expect(url).toContain("pageNumber=1");
+    });
+
+    it("includes roleTitles when provided", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const url = extractor.buildSeekNameSearchUrl(
+        "John",
+        "MY",
+        "Software Engineer",
+      );
+      expect(url).toContain("roleTitles=Software%20Engineer");
+    });
+
+    it("returns empty string for empty name", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(extractor.buildSeekNameSearchUrl("", "MY", undefined)).toBe("");
+      expect(extractor.buildSeekNameSearchUrl("  ", "MY", undefined)).toBe("");
+    });
+  });
+
+  describe("resolveSeekAutoSyncPageWindow", () => {
+    it("returns start page 1 by default", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.resolveSeekAutoSyncPageWindow({});
+      expect(result.startPage).toBe(1);
+    });
+
+    it("calculates targetPageEnd from limit and page size", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.resolveSeekAutoSyncPageWindow({
+        startPage: 1,
+        limit: 60,
+        requestedPageSize: 20,
+      });
+      expect(result.limitPageCount).toBe(3);
+      expect(result.targetPageEnd).toBe(3);
+    });
+
+    it("respects maxPages when smaller than limitPageCount", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.resolveSeekAutoSyncPageWindow({
+        startPage: 1,
+        limit: 100,
+        maxPages: 2,
+        requestedPageSize: 20,
+      });
+      expect(result.allowedPageCount).toBe(2);
+      expect(result.targetPageEnd).toBe(2);
+    });
+
+    it("returns null targetPageEnd when no limit or maxPages", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.resolveSeekAutoSyncPageWindow({
+        startPage: 1,
+      });
+      expect(result.targetPageEnd).toBeNull();
+    });
+  });
+
+  describe("isSeekAutoSyncPageWindowReached", () => {
+    it("returns true when currentPage >= targetPageEnd", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(
+        extractor.isSeekAutoSyncPageWindowReached(
+          { startPage: 1, targetPageEnd: 3 },
+          3,
+        ),
+      ).toBe(true);
+      expect(
+        extractor.isSeekAutoSyncPageWindowReached(
+          { startPage: 1, targetPageEnd: 3 },
+          4,
+        ),
+      ).toBe(true);
+    });
+
+    it("returns false when currentPage < targetPageEnd", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(
+        extractor.isSeekAutoSyncPageWindowReached(
+          { startPage: 1, targetPageEnd: 3 },
+          2,
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false when targetPageEnd is null", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(
+        extractor.isSeekAutoSyncPageWindowReached(
+          { startPage: 1, targetPageEnd: null },
+          5,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("resolveSeekAutoSyncCurrentPageSelection", () => {
+    it("returns full page when no limit", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.resolveSeekAutoSyncCurrentPageSelection({
+        currentPageResumeCount: 20,
+      });
+      expect(result.remainingCapacity).toBeNull();
+      expect(result.selectedCount).toBe(20);
+      expect(result.hitLimitWithinPage).toBe(false);
+    });
+
+    it("calculates remaining capacity from limit", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.resolveSeekAutoSyncCurrentPageSelection({
+        limit: 50,
+        totalSubmitted: 30,
+        currentPageResumeCount: 20,
+      });
+      expect(result.remainingCapacity).toBe(20);
+      expect(result.selectedCount).toBe(20);
+      expect(result.hitLimitWithinPage).toBe(false);
+    });
+
+    it("detects hitLimitWithinPage", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.resolveSeekAutoSyncCurrentPageSelection({
+        limit: 50,
+        totalSubmitted: 40,
+        currentPageResumeCount: 20,
+      });
+      expect(result.remainingCapacity).toBe(10);
+      expect(result.selectedCount).toBe(10);
+      expect(result.hitLimitWithinPage).toBe(true);
+    });
+
+    it("detects limitAlreadyReached", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.resolveSeekAutoSyncCurrentPageSelection({
+        limit: 50,
+        totalSubmitted: 50,
+        currentPageResumeCount: 20,
+      });
+      expect(result.remainingCapacity).toBe(0);
+      expect(result.limitAlreadyReached).toBe(true);
+    });
+  });
+
+  describe("resolveSeekAutoSyncPageSize", () => {
+    it("returns requestedPageSize when valid", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(extractor.resolveSeekAutoSyncPageSize({ requestedPageSize: 25 })).toBe(25);
+    });
+
+    it("falls back to currentPageCandidateCount", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(
+        extractor.resolveSeekAutoSyncPageSize({ currentPageCandidateCount: 18 }),
+      ).toBe(18);
+    });
+
+    it("falls back to DEFAULT_SEEK_PAGE_SIZE", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(extractor.resolveSeekAutoSyncPageSize({})).toBe(20);
+    });
+  });
+
+  describe("getSeekPayloadData", () => {
+    it("extracts data from array payload for seekRecommendedCandidates", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const payload = [
+        { data: { talentSearchRecommendedCandidatesV2: { items: [] } } },
+      ];
+      const result = extractor.getSeekPayloadData(
+        payload,
+        "seekRecommendedCandidates",
+      );
+      expect(result).toEqual({
+        talentSearchRecommendedCandidatesV2: { items: [] },
+      });
+    });
+
+    it("extracts data from array payload for seekTalentSearch", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const payload = [
+        {
+          data: {
+            talentSearchProfilesNaturalLanguageSearch: { result: {} },
+          },
+        },
+      ];
+      const result = extractor.getSeekPayloadData(payload, "seekTalentSearch");
+      expect(result).toEqual({
+        talentSearchProfilesNaturalLanguageSearch: { result: {} },
+      });
+    });
+
+    it("extracts data from object payload with data key", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const payload = { data: { someKey: "value" } };
+      const result = extractor.getSeekPayloadData(payload, "seekProfile");
+      expect(result).toEqual({ someKey: "value" });
+    });
+
+    it("returns null for null payload", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      expect(extractor.getSeekPayloadData(null, "seekProfile")).toBeNull();
+    });
+  });
+
+  describe("extractSeekProfileResume", () => {
+    it("returns empty array when no profile snapshot", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.extractSeekProfileResume();
+      expect(result).toEqual([]);
+    });
+
+    it("extracts resume from profile snapshot", () => {
+      const extractor = createSeekExtractor(
+        createMockDeps({
+          apiSnapshot: {
+            seekProfile: {
+              profileId: "123",
+              firstName: "John",
+              lastName: "Doe",
+              currentJobTitle: "Engineer",
+              currentLocation: "KL",
+              lastModifiedDate: "2026-01-01",
+            },
+            seekRecommendedRequest: null,
+            seekProfileRequest: null,
+          },
+        }),
+      );
+      const result = extractor.extractSeekProfileResume();
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("John Doe");
+      expect(result[0].jobIntention).toBe("Engineer");
+      expect(result[0].location).toBe("KL");
+    });
+  });
+
+  describe("extractSeekResumes", () => {
+    it("returns empty array when no candidates", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.extractSeekResumes();
+      expect(result).toEqual([]);
+    });
+
+    it("extracts resumes from seekRecommendedCandidates", () => {
+      const extractor = createSeekExtractor(
+        createMockDeps({
+          apiSnapshot: {
+            seekRecommendedCandidates: [
+              {
+                profileId: "1",
+                firstName: "Alice",
+                lastName: "Smith",
+                currentJobTitle: "Manager",
+                currentLocation: "SG",
+              },
+              {
+                profileId: "2",
+                firstName: "Bob",
+                lastName: "Jones",
+                currentJobTitle: "Analyst",
+                currentLocation: "HK",
+              },
+            ],
+            seekRecommendedRequest: null,
+          },
+        }),
+      );
+      const result = extractor.extractSeekResumes();
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe("Alice Smith");
+      expect(result[1].name).toBe("Bob Jones");
+    });
+  });
+
+  describe("extractSeekTalentSearchResumes", () => {
+    it("returns empty array when no talent search data", () => {
+      const extractor = createSeekExtractor(createMockDeps());
+      const result = extractor.extractSeekTalentSearchResumes();
+      expect(result).toEqual([]);
+    });
+
+    it("extracts resumes from seekTalentSearch", () => {
+      const extractor = createSeekExtractor(
+        createMockDeps({
+          apiSnapshot: {
+            seekTalentSearch: [
+              {
+                id: "relay-1",
+                profileGuid: "uuid-abc",
+                firstName: "Carol",
+                lastName: "White",
+                currentJobTitle: "Director",
+                currentLocation: "AU",
+              },
+            ],
+            seekTalentSearchRequest: null,
+          },
+        }),
+      );
+      const result = extractor.extractSeekTalentSearchResumes();
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("Carol White");
+      expect(result[0].profileId).toBe("uuid-abc");
+    });
+  });
+});

--- a/apps/browser-extension/src/lib/__tests__/snapshot-collector.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/snapshot-collector.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { createSnapshotCollector } from "../snapshot-collector";
+
+function createMockDeps(overrides = {}) {
+  return {
+    apiSnapshot: {
+      searchRows: [],
+      job51SearchRows: [],
+      seekRecommendedCandidates: [],
+      seekTalentSearch: [],
+      seekProfile: null,
+      job51AuthContext: null,
+      job51DetailPayload: null,
+    },
+    getCurrentSourceKey: vi.fn(() => "job51"),
+    SOURCE_KEYS: { JOB51: "job51", JOB5156: "job5156", SEEK: "seek" },
+    isJob51DetailPage: vi.fn(() => false),
+    isJob51DetailReady: vi.fn(() => false),
+    getSeekSnapshotCount: vi.fn(() => 0),
+    normalizeJob51AuthContext: vi.fn(() => null),
+    getJob51TotalFromPayload: vi.fn(() => null),
+    getJob51ResumeRows: vi.fn(() => null),
+    getSeekPayloadData: vi.fn(() => null),
+    chrome: { runtime: { getURL: vi.fn(() => "chrome-extension://abc/page-hook.js") } },
+    normalizeCollectionLimit: (v: unknown) =>
+      typeof v === "number" && v > 0 ? v : 0,
+    pipelineState: { runId: 0, chain: Promise.resolve() },
+    waitForExtractionData: vi.fn(() => Promise.resolve()),
+    isSeekProfileMode: vi.fn(() => false),
+    resolveSeekAutoSyncPageWindow: vi.fn(() => null),
+    getSeekRequestedPageSize: vi.fn(() => null),
+    getSeekCurrentCandidateCount: vi.fn(() => 0),
+    resolveSeekAutoSyncCurrentPageSelection: vi.fn(() => ({
+      remainingCapacity: null,
+      selectedCount: null,
+      hitLimitWithinPage: false,
+      limitAlreadyReached: false,
+    })),
+    extractResumes: vi.fn(() => []),
+    enrich51JobSearchResumesWithDetail: vi.fn((r) => Promise.resolve(r)),
+    enrichJob5156SearchResumesWithDetail: vi.fn((r) => Promise.resolve(r)),
+    isJob5156DetailPage: vi.fn(() => false),
+    enrichSeekResumesWithDetail: vi.fn((r) => Promise.resolve(r)),
+    getPaginationInfo: vi.fn(() => ({
+      currentPage: 1,
+      totalPages: 1,
+      totalItems: 0,
+      hasNextPage: false,
+    })),
+    isSeekAutoSyncPageWindowReached: vi.fn(() => false),
+    waitForPagination: vi.fn(() => Promise.resolve()),
+    clearCapturedResultsForNextPage: vi.fn(),
+    goToNextPageInternal: vi.fn(() => false),
+    waitForPageTransition: vi.fn(() => Promise.resolve()),
+    buildSubmitMetadata: vi.fn(() => ({})),
+    delay: vi.fn(() => Promise.resolve()),
+    document: {
+      documentElement: {
+        hasAttribute: vi.fn(() => false),
+        setAttribute: vi.fn(),
+        getAttribute: vi.fn(() => ""),
+      },
+      createElement: vi.fn(() => ({
+        src: "",
+        async: false,
+        setAttribute: vi.fn(),
+        onload: null,
+        remove: vi.fn(),
+      })),
+      head: { prepend: vi.fn() },
+    },
+    ...overrides,
+  };
+}
+
+describe("snapshot-collector", () => {
+  describe("getApiSnapshotCount", () => {
+    it("returns searchRows length when array", () => {
+      const collector = createSnapshotCollector(
+        createMockDeps({
+          apiSnapshot: { searchRows: [1, 2, 3] },
+        }),
+      );
+      expect(collector.getApiSnapshotCount()).toBe(3);
+    });
+
+    it("returns job51SearchRows length for job51 source", () => {
+      const collector = createSnapshotCollector(
+        createMockDeps({
+          apiSnapshot: { searchRows: null, job51SearchRows: [1, 2] },
+        }),
+      );
+      expect(collector.getApiSnapshotCount()).toBe(2);
+    });
+
+    it("returns seek snapshot count for seek source", () => {
+      const collector = createSnapshotCollector(
+        createMockDeps({
+          apiSnapshot: { searchRows: null, job51SearchRows: null },
+          getCurrentSourceKey: vi.fn(() => "seek"),
+          getSeekSnapshotCount: vi.fn(() => 5),
+        }),
+      );
+      expect(collector.getApiSnapshotCount()).toBe(5);
+    });
+
+    it("returns 0 for empty snapshots", () => {
+      const collector = createSnapshotCollector(createMockDeps());
+      expect(collector.getApiSnapshotCount()).toBe(0);
+    });
+
+    it("returns 1 for job51 detail page when ready", () => {
+      const collector = createSnapshotCollector(
+        createMockDeps({
+          apiSnapshot: { searchRows: null, job51SearchRows: null },
+          isJob51DetailPage: vi.fn(() => true),
+          isJob51DetailReady: vi.fn(() => true),
+        }),
+      );
+      expect(collector.getApiSnapshotCount()).toBe(1);
+    });
+
+    it("returns 0 for job51 detail page when not ready", () => {
+      const collector = createSnapshotCollector(
+        createMockDeps({
+          apiSnapshot: { searchRows: null, job51SearchRows: null },
+          isJob51DetailPage: vi.fn(() => true),
+          isJob51DetailReady: vi.fn(() => false),
+        }),
+      );
+      expect(collector.getApiSnapshotCount()).toBe(0);
+    });
+  });
+
+  describe("normalizeSnapshotCollectOptions", () => {
+    it("returns normalized defaults for empty input", () => {
+      const collector = createSnapshotCollector(createMockDeps());
+      const result = collector.normalizeSnapshotCollectOptions();
+      expect(result).toEqual({
+        limit: 0,
+        maxPages: 0,
+        allowEmpty: false,
+      });
+    });
+
+    it("returns normalized options for valid input", () => {
+      const collector = createSnapshotCollector(createMockDeps());
+      const result = collector.normalizeSnapshotCollectOptions({
+        limit: 50,
+        maxPages: 5,
+        allowEmpty: true,
+      });
+      expect(result).toEqual({
+        limit: 50,
+        maxPages: 5,
+        allowEmpty: true,
+      });
+    });
+
+    it("handles non-object input", () => {
+      const collector = createSnapshotCollector(createMockDeps());
+      const result = collector.normalizeSnapshotCollectOptions(null);
+      expect(result).toEqual({
+        limit: 0,
+        maxPages: 0,
+        allowEmpty: false,
+      });
+    });
+  });
+
+  describe("updateApiSnapshot", () => {
+    it("updates searchRows for kind=search", () => {
+      const apiSnapshot = { searchRows: [] } as Record<string, unknown>;
+      const collector = createSnapshotCollector(
+        createMockDeps({ apiSnapshot }),
+      );
+      collector.updateApiSnapshot({
+        kind: "search",
+        payload: { data: { resumePage: { rows: [{ id: 1 }] } } },
+        sourceKey: "job5156",
+      });
+      expect(apiSnapshot.searchRows).toEqual([{ id: 1 }]);
+    });
+
+    it("updates job51SearchRows for kind=job51search", () => {
+      const apiSnapshot = {
+        job51SearchRows: null,
+      } as Record<string, unknown>;
+      const collector = createSnapshotCollector(
+        createMockDeps({
+          apiSnapshot,
+          getJob51TotalFromPayload: () => 100,
+          getJob51ResumeRows: () => [{ id: 1 }],
+        }),
+      );
+      collector.updateApiSnapshot({
+        kind: "job51search",
+        payload: { data: { total: 100, list: [{ id: 1 }] } },
+        sourceKey: "job51",
+      });
+      expect(apiSnapshot.job51SearchRows).toEqual([{ id: 1 }]);
+      expect(apiSnapshot.job51Total).toBe(100);
+    });
+
+    it("updates job51DetailPayload for kind=job51detail", () => {
+      const apiSnapshot = {
+        job51DetailPayload: null,
+      } as Record<string, unknown>;
+      const collector = createSnapshotCollector(
+        createMockDeps({ apiSnapshot }),
+      );
+      collector.updateApiSnapshot({
+        kind: "job51detail",
+        payload: { detail: "data" },
+        sourceKey: "job51",
+      });
+      expect(apiSnapshot.job51DetailPayload).toEqual({ detail: "data" });
+    });
+
+    it("sets lastUrl from message", () => {
+      const apiSnapshot = {} as Record<string, unknown>;
+      const collector = createSnapshotCollector(
+        createMockDeps({ apiSnapshot }),
+      );
+      collector.updateApiSnapshot({
+        kind: "search",
+        url: "https://example.com/api",
+        payload: { data: { resumePage: { rows: [] } } },
+      });
+      expect(apiSnapshot.lastUrl).toBe("https://example.com/api");
+    });
+
+    it("sets lastSourceKey from message", () => {
+      const apiSnapshot = {} as Record<string, unknown>;
+      const collector = createSnapshotCollector(
+        createMockDeps({ apiSnapshot }),
+      );
+      collector.updateApiSnapshot({
+        kind: "search",
+        sourceKey: "job51",
+        payload: { data: { resumePage: { rows: [] } } },
+      });
+      expect(apiSnapshot.lastSourceKey).toBe("job51");
+    });
+
+    it("updates attachInfo for kind=attach", () => {
+      const apiSnapshot = {} as Record<string, unknown>;
+      const collector = createSnapshotCollector(
+        createMockDeps({ apiSnapshot }),
+      );
+      collector.updateApiSnapshot({
+        kind: "attach",
+        payload: { data: { attachResumeInfo: { attached: true } } },
+      });
+      expect(apiSnapshot.attachInfo).toEqual({ attached: true });
+    });
+
+    it("updates chatInfo for kind=chat", () => {
+      const apiSnapshot = {} as Record<string, unknown>;
+      const collector = createSnapshotCollector(
+        createMockDeps({ apiSnapshot }),
+      );
+      collector.updateApiSnapshot({
+        kind: "chat",
+        payload: { data: { chatInfo: { chatId: "123" } } },
+      });
+      expect(apiSnapshot.chatInfo).toEqual({ chatId: "123" });
+    });
+
+    it("updates insightInfo for kind=insight", () => {
+      const apiSnapshot = {} as Record<string, unknown>;
+      const collector = createSnapshotCollector(
+        createMockDeps({ apiSnapshot }),
+      );
+      collector.updateApiSnapshot({
+        kind: "insight",
+        payload: { data: { talentInsightInfo: { score: 95 } } },
+      });
+      expect(apiSnapshot.insightInfo).toEqual({ score: 95 });
+    });
+  });
+
+  describe("installApiHook", () => {
+    it("sets data-tr-resume-hook attribute when page-hook already loaded", () => {
+      const mockDoc = {
+        documentElement: {
+          hasAttribute: vi.fn((attr: string) => attr === "data-tr-page-hook"),
+          setAttribute: vi.fn(),
+        },
+        createElement: vi.fn(),
+      };
+      const collector = createSnapshotCollector(
+        createMockDeps({ document: mockDoc }),
+      );
+      collector.installApiHook();
+      expect(mockDoc.documentElement.setAttribute).toHaveBeenCalledWith(
+        "data-tr-resume-hook",
+        "true",
+      );
+      expect(mockDoc.createElement).not.toHaveBeenCalled();
+    });
+
+    it("skips when resume-hook already installed", () => {
+      const mockDoc = {
+        documentElement: {
+          hasAttribute: vi.fn((attr: string) =>
+            ["data-tr-resume-hook"].includes(attr)),
+          setAttribute: vi.fn(),
+        },
+        createElement: vi.fn(),
+      };
+      const collector = createSnapshotCollector(
+        createMockDeps({ document: mockDoc }),
+      );
+      collector.installApiHook();
+      expect(mockDoc.createElement).not.toHaveBeenCalled();
+    });
+
+    it("creates script element when hook not yet installed", () => {
+      const scriptEl = {
+        src: "",
+        async: false,
+        setAttribute: vi.fn(),
+        onload: null,
+        remove: vi.fn(),
+      };
+      const mockDoc = {
+        documentElement: {
+          hasAttribute: vi.fn(() => false),
+          setAttribute: vi.fn(),
+        },
+        createElement: vi.fn(() => scriptEl),
+        head: { prepend: vi.fn() },
+      };
+      const collector = createSnapshotCollector(
+        createMockDeps({ document: mockDoc }),
+      );
+      collector.installApiHook();
+      expect(mockDoc.createElement).toHaveBeenCalledWith("script");
+      expect(scriptEl.src).toBe(
+        "chrome-extension://abc/page-hook.js",
+      );
+      expect(mockDoc.head.prepend).toHaveBeenCalledWith(scriptEl);
+    });
+  });
+
+  describe("collectSnapshotPayload", () => {
+    it("throws for unsupported source key", async () => {
+      const collector = createSnapshotCollector(
+        createMockDeps({
+          getCurrentSourceKey: vi.fn(() => "unknown"),
+        }),
+      );
+      await expect(collector.collectSnapshotPayload()).rejects.toThrow(
+        "Unsupported source for snapshot collection: unknown",
+      );
+    });
+
+    it("throws when no resumes extracted and allowEmpty is false", async () => {
+      const collector = createSnapshotCollector(
+        createMockDeps({
+          extractResumes: vi.fn(() => []),
+        }),
+      );
+      await expect(
+        collector.collectSnapshotPayload({ allowEmpty: false }),
+      ).rejects.toThrow("No resumes extracted");
+    });
+
+    it("returns empty result when allowEmpty is true", async () => {
+      const collector = createSnapshotCollector(
+        createMockDeps({
+          extractResumes: vi.fn(() => []),
+        }),
+      );
+      const result = await collector.collectSnapshotPayload({
+        allowEmpty: true,
+      });
+      expect(result.resumes).toEqual([]);
+      expect(result.summary.count).toBe(0);
+      expect(result.summary.pagesVisited).toBe(1);
+      expect(result.summary.stopReason).toBe("no-next-page");
+    });
+
+    it("returns collected resumes with metadata", async () => {
+      const mockResumes = [{ name: "Test" }, { name: "Test2" }];
+      const collector = createSnapshotCollector(
+        createMockDeps({
+          extractResumes: vi.fn(() => mockResumes),
+        }),
+      );
+      const result = await collector.collectSnapshotPayload({
+        allowEmpty: true,
+      });
+      expect(result.resumes).toEqual(mockResumes);
+      expect(result.summary.count).toBe(2);
+      expect(result.metadata.totalResumes).toBe(2);
+    });
+  });
+});

--- a/apps/browser-extension/src/lib/__tests__/sync-status-widget.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/sync-status-widget.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { createSyncStatusWidget } from "../sync-status-widget";
+
+function createMockDeps() {
+  return {
+    win: window,
+    doc: document,
+    chrome: { runtime: { sendMessage: vi.fn(() => Promise.resolve()) } },
+    onCancel: vi.fn(),
+  };
+}
+
+describe("sync-status-widget", () => {
+  let widget: ReturnType<typeof createSyncStatusWidget>;
+
+  beforeEach(() => {
+    widget = createSyncStatusWidget(createMockDeps());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    widget.hide();
+    vi.useRealTimers();
+    document.getElementById("tr-sync-status-widget")?.remove();
+  });
+
+  describe("show", () => {
+    it("creates widget element in DOM", () => {
+      widget.show({ state: "progress", message: "Syncing..." });
+      const el = document.getElementById("tr-sync-status-widget");
+      expect(el).not.toBeNull();
+      expect(el!.className).toContain("tr-sync-widget--progress");
+    });
+
+    it("renders success state", () => {
+      widget.show({ state: "success", message: "Done!" });
+      const el = document.getElementById("tr-sync-status-widget");
+      expect(el!.className).toContain("tr-sync-widget--success");
+    });
+
+    it("renders error state", () => {
+      widget.show({ state: "error", message: "Failed!" });
+      const el = document.getElementById("tr-sync-status-widget");
+      expect(el!.className).toContain("tr-sync-widget--error");
+    });
+
+    it("defaults to progress for unknown state", () => {
+      widget.show({ state: "unknown" as "progress", message: "..." });
+      const el = document.getElementById("tr-sync-status-widget");
+      expect(el!.className).toContain("tr-sync-widget--progress");
+    });
+
+    it("escapes HTML in message", () => {
+      widget.show({ state: "progress", message: "<script>alert('xss')</script>" });
+      const el = document.getElementById("tr-sync-status-widget");
+      expect(el!.innerHTML).not.toContain("<script>");
+      expect(el!.innerHTML).toContain("&lt;script&gt;");
+    });
+
+    it("escapes HTML in hint", () => {
+      widget.show({
+        state: "progress",
+        message: "test",
+        hint: "<img src=x onerror=alert(1)>",
+      });
+      const el = document.getElementById("tr-sync-status-widget");
+      expect(el!.innerHTML).not.toContain("<img");
+      expect(el!.innerHTML).toContain("&lt;img");
+    });
+
+    it("shows cancel button for progress state", () => {
+      widget.show({ state: "progress", message: "Syncing..." });
+      const el = document.getElementById("tr-sync-status-widget");
+      const cancelBtn = el!.querySelector(".tr-sync-widget__cancel");
+      expect(cancelBtn).not.toBeNull();
+    });
+
+    it("shows close button for error state", () => {
+      widget.show({ state: "error", message: "Error!" });
+      const el = document.getElementById("tr-sync-status-widget");
+      const closeBtn = el!.querySelector(".tr-sync-widget__close");
+      expect(closeBtn).not.toBeNull();
+    });
+
+    it("does not show cancel button for success state", () => {
+      widget.show({ state: "success", message: "Done!" });
+      const el = document.getElementById("tr-sync-status-widget");
+      const cancelBtn = el!.querySelector(".tr-sync-widget__cancel");
+      expect(cancelBtn).toBeNull();
+    });
+
+    it("auto-dismisses after specified milliseconds", () => {
+      widget.show({
+        state: "success",
+        message: "Done!",
+        autoDismiss: 3000 as unknown as boolean,
+      });
+      expect(document.getElementById("tr-sync-status-widget")).not.toBeNull();
+
+      vi.advanceTimersByTime(3000);
+      // After dismiss timer, hide() is called which adds hidden class and schedules removal
+      const el = document.getElementById("tr-sync-status-widget");
+      expect(el?.classList.contains("tr-sync-widget--hidden")).toBe(true);
+    });
+
+    it("auto-dismisses with DEFAULT_AUTO_DISMISS_MS when autoDismiss is true", () => {
+      widget.show({
+        state: "success",
+        message: "Done!",
+        autoDismiss: true,
+      });
+      expect(document.getElementById("tr-sync-status-widget")).not.toBeNull();
+
+      vi.advanceTimersByTime(5000);
+      const el = document.getElementById("tr-sync-status-widget");
+      expect(el?.classList.contains("tr-sync-widget--hidden")).toBe(true);
+    });
+
+    it("does not auto-dismiss when autoDismiss is false", () => {
+      widget.show({
+        state: "progress",
+        message: "Syncing...",
+        autoDismiss: false,
+      });
+      vi.advanceTimersByTime(10000);
+      const el = document.getElementById("tr-sync-status-widget");
+      expect(el?.classList.contains("tr-sync-widget--hidden")).toBe(false);
+    });
+
+    it("reuses existing widget on subsequent show calls", () => {
+      widget.show({ state: "progress", message: "First" });
+      const el1 = document.getElementById("tr-sync-status-widget");
+      widget.show({ state: "success", message: "Second" });
+      const el2 = document.getElementById("tr-sync-status-widget");
+      expect(el1).toBe(el2);
+    });
+  });
+
+  describe("hide", () => {
+    it("adds hidden class", () => {
+      widget.show({ state: "progress", message: "Syncing..." });
+      widget.hide();
+      const el = document.getElementById("tr-sync-status-widget");
+      expect(el?.classList.contains("tr-sync-widget--hidden")).toBe(true);
+    });
+
+    it("does nothing if widget not shown", () => {
+      expect(() => widget.hide()).not.toThrow();
+    });
+
+    it("removes element after HIDE_DELAY_MS", () => {
+      widget.show({ state: "progress", message: "Syncing..." });
+      widget.hide();
+      expect(document.getElementById("tr-sync-status-widget")).not.toBeNull();
+
+      vi.advanceTimersByTime(220);
+      expect(document.getElementById("tr-sync-status-widget")).toBeNull();
+    });
+  });
+
+  describe("cancel button", () => {
+    it("calls onCancel when clicked", () => {
+      const onCancel = vi.fn();
+      const w = createSyncStatusWidget({
+        win: window,
+        doc: document,
+        chrome: { runtime: { sendMessage: vi.fn() } },
+        onCancel,
+      });
+      w.show({ state: "progress", message: "Syncing..." });
+      const cancelBtn = document.querySelector(
+        ".tr-sync-widget__cancel",
+      ) as HTMLElement;
+      cancelBtn.click();
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/browser-extension/src/lib/__tests__/ui-utils.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/ui-utils.test.ts
@@ -2,11 +2,11 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi } from "vitest";
-import { createUiUtils } from "../ui-utils.js";
+import { createUiUtils, type UiUtilsDeps } from "../ui-utils.js";
 
 const SOURCE_KEYS = { JOB5156: "job5156", JOB51: "51job", SEEK: "seek", UNKNOWN: "unknown" };
 
-function createMockDeps(overrides: Record<string, any> = {}): Record<string, any> {
+function createMockDeps(overrides: Record<string, any> = {}): UiUtilsDeps {
   return {
     win: window as unknown as Window,
     doc: document,
@@ -37,7 +37,7 @@ function createMockDeps(overrides: Record<string, any> = {}): Record<string, any
     isJob51DetailPage: vi.fn(() => false),
     chrome: { runtime: { getManifest: vi.fn(() => ({ version: "1.0.0" })) } } as any,
     ...overrides,
-  } as unknown as Record<string, any>;
+  } as unknown as UiUtilsDeps;
 }
 
 describe("ui-utils", () => {

--- a/apps/browser-extension/src/lib/extraction-pipeline.ts
+++ b/apps/browser-extension/src/lib/extraction-pipeline.ts
@@ -1,10 +1,57 @@
-// @ts-nocheck
 /**
  * Extraction pipeline orchestrators — site-generic wait helpers, pagination,
  * resume extraction dispatch, detail backfill. Dependencies injected from content.ts.
  */
 
-export function createExtractionPipeline(deps) {
+export interface ExtractionPipelineDeps extends Record<string, unknown> {
+  getCurrentSourceKey: () => string;
+  SOURCE_KEYS: Record<string, string>;
+  apiSnapshot: Record<string, unknown>;
+  SELECTORS: Record<string, string>;
+  getApiSnapshotCount: () => number;
+  isExtractionReady: () => boolean;
+  isJob51RateLimitedPage: () => boolean;
+  JOB51_RATE_LIMIT_ERROR_MESSAGE: string;
+  getSeekCandidateIdentity: (candidate: unknown) => { profileId: string; profileType: string };
+  chrome: { storage: { local: { get: (defaults: unknown, cb: (items: unknown) => void) => void } } };
+  DEFAULT_COLLECTION_GUARDS: unknown;
+  CONTENT_SCRIPT_SOURCE: string;
+  JOB51_NEXT_PAGE_EVENT: string;
+  document: Document;
+  window: Window;
+  resolveCurrentJob51DetailFetchDelayMs: () => number;
+  JOB51_DETAIL_FETCH_CONCURRENCY: number;
+  enrich51JobSearchResumeWithDetail: (resume: unknown, extractedAt: string) => Promise<{ resume: unknown; enriched: boolean; rateLimited: boolean }>;
+  syncCurrentPageToServer: (resumes: unknown[]) => Promise<unknown>;
+  delay: (ms: number) => Promise<void>;
+  pipelineState: { runId: number; chain: Promise<unknown> };
+  isJob51DetailPage: () => boolean;
+  filterCurrentResumesByAgeRange: (resumes: unknown) => unknown[];
+  extractJob51DetailResume: () => unknown[];
+  extract51JobResumes: () => unknown[];
+  isSeekProfileMode: () => boolean;
+  hasSeekProfileSnapshot: () => boolean;
+  extractSeekProfileResume: () => unknown[];
+  hasSeekTalentSearchSnapshot: () => boolean;
+  extractSeekTalentSearchResumes: () => unknown[];
+  hasSeekListSnapshot: () => boolean;
+  extractSeekResumes: () => unknown[];
+  isJob5156DetailPage: () => boolean;
+  extractJob5156DetailResume: () => unknown[];
+  getApiRowForIndex: (index: number) => unknown;
+  extractSingleResume: (card: Element, apiRow: unknown) => Record<string, unknown>;
+  isJob51DetailReady: () => boolean;
+  getSeekProfileRequest: () => unknown;
+  getSeekTalentSearchRequest: () => unknown;
+  getSeekRecommendedRequest: () => unknown;
+  SEEK_PROFILE_TYPE: string;
+  getJob5156DetailRoot: () => unknown;
+  getSeekNextPageLinkForMode: () => HTMLElement | null;
+  getPaginationInfo: () => { currentPage: number; totalPages: number; totalItems: number; hasNextPage: boolean };
+  asHTMLElement: (el: unknown) => HTMLElement | null;
+}
+
+export function createExtractionPipeline(deps: ExtractionPipelineDeps) {
   const {
     getCurrentSourceKey,
     SOURCE_KEYS,
@@ -67,7 +114,7 @@ export function createExtractionPipeline(deps) {
     return new Promise((resolve) => {
       chrome.storage.local.get(
         { collectionGuards: DEFAULT_COLLECTION_GUARDS },
-        (items) => resolve(items.collectionGuards || {}),
+        (items) => resolve((items as Record<string, unknown>).collectionGuards || {}),
       );
     });
   }
@@ -239,7 +286,7 @@ export function createExtractionPipeline(deps) {
 
       const check = () => {
         if (done) return;
-        const snapshot = apiSnapshot.seekProfile;
+        const snapshot = apiSnapshot.seekProfile as Record<string, unknown> | null;
         const identity = snapshot ? getSeekCandidateIdentity(snapshot) : null;
         // Match by profileId (numeric) or profileGuid (UUID for talentsearch)
         const snapshotGuid =
@@ -314,7 +361,7 @@ export function createExtractionPipeline(deps) {
 
     cards.forEach((card, index) => {
       try {
-        const apiRow = getApiRowForIndex(index);
+        const apiRow = getApiRowForIndex(index) as Record<string, unknown> | null;
         const resume = extractSingleResume(card, apiRow);
         resume.pageIndex = index + 1;
         if (apiRow) {
@@ -336,7 +383,7 @@ export function createExtractionPipeline(deps) {
    * @param {boolean} [options.includePage=false] - Include full page HTML
    * @returns {Object} - Raw payload
    */
-  function extractResumesRaw(options = {}) {
+  function extractResumesRaw(options: Record<string, unknown> = {}) {
     const includePage = !!(
       options &&
       typeof options === "object" &&
@@ -356,10 +403,10 @@ export function createExtractionPipeline(deps) {
           ? apiSnapshot.seekTalentSearch
           : null;
       const candidates =
-        seekTalentSearchCandidates ||
+        (seekTalentSearchCandidates ||
         (!seekProfile && hasSeekListSnapshot()
           ? apiSnapshot.seekRecommendedCandidates
-          : []);
+          : [])) as unknown[];
       const seekRequest = seekProfile
         ? getSeekProfileRequest()
         : seekTalentSearchCandidates
@@ -375,10 +422,11 @@ export function createExtractionPipeline(deps) {
             },
           ]
         : candidates.map((candidate, index) => {
+            const cand = candidate as Record<string, unknown>;
             // Talent-search nodes use profileGuid (UUID); recommended nodes use numeric profileId
             const profileId = seekTalentSearchCandidates
-              ? typeof candidate?.profileGuid === "string" && candidate.profileGuid
-                ? candidate.profileGuid
+              ? typeof cand?.profileGuid === "string" && cand.profileGuid
+                ? cand.profileGuid
                 : ""
               : getSeekCandidateIdentity(candidate).profileId;
             const profileType = SEEK_PROFILE_TYPE;
@@ -391,7 +439,7 @@ export function createExtractionPipeline(deps) {
           });
 
       if (seekProfile || candidates.length > 0) {
-        const payload = {
+        const payload: Record<string, unknown> = {
           url: win.location.href,
           extractedAt: new Date().toISOString(),
           count: cards.length,
@@ -418,8 +466,8 @@ export function createExtractionPipeline(deps) {
 
     if (isJob51DetailPage() && isJob51DetailReady()) {
       const detailResumes = extractJob51DetailResume();
-      const detailResume = detailResumes[0] || null;
-      const payload = {
+      const detailResume = detailResumes[0] as Record<string, unknown> | null;
+      const payload: Record<string, unknown> = {
         url: win.location.href,
         extractedAt: new Date().toISOString(),
         count: detailResumes.length,
@@ -464,26 +512,27 @@ export function createExtractionPipeline(deps) {
         ? [
             {
               index: 1,
-              resumeId: detailResumes[0]?.resumeId || "",
+              resumeId: (detailResumes[0] as Record<string, unknown>)?.resumeId || "",
               perUserId: "",
-              html: detailRoot?.outerHTML || "",
-              text: detailRootElement?.innerText || detailRoot?.textContent || "",
+              html: (detailRoot as HTMLElement | null)?.outerHTML || "",
+              text: detailRootElement?.innerText || (detailRoot as HTMLElement | null)?.textContent || "",
             },
           ]
         : Array.from(doc.querySelectorAll(SELECTORS.resumeCard)).map(
             (card, index) => {
-              const el = /** @type {HTMLElement} */ (card);
+              const el = card as HTMLElement;
+              const apiRow = getApiRowForIndex(index) as Record<string, unknown> | null;
               return {
                 index: index + 1,
-                resumeId: getApiRowForIndex(index)?.resumeId ?? "",
-                perUserId: getApiRowForIndex(index)?.perUserId ?? "",
+                resumeId: apiRow?.resumeId ?? "",
+                perUserId: apiRow?.perUserId ?? "",
                 html: el.outerHTML,
                 text: el.innerText,
               };
             },
           );
 
-    const payload = {
+    const payload: Record<string, unknown> = {
       url: win.location.href,
       extractedAt: new Date().toISOString(),
       count: items.length,
@@ -533,7 +582,7 @@ export function createExtractionPipeline(deps) {
 
   // --- Detail enrichment / backfill ---
 
-  async function enrich51JobSearchResumesWithDetail(resumes, options = {}) {
+  async function enrich51JobSearchResumesWithDetail(resumes: unknown[], options: Record<string, unknown> = {}) {
     if (!Array.isArray(resumes) || resumes.length === 0) return [];
 
     const extractedAt = new Date().toISOString();
@@ -602,7 +651,7 @@ export function createExtractionPipeline(deps) {
     return enriched;
   }
 
-  function queueJob51DetailBackfill(resumes, context = {}) {
+  function queueJob51DetailBackfill(resumes: unknown[], context: Record<string, unknown> = {}) {
     if (!Array.isArray(resumes) || resumes.length === 0) {
       return Promise.resolve(null);
     }
@@ -650,7 +699,7 @@ export function createExtractionPipeline(deps) {
         return null;
       }
 
-      const response = await syncCurrentPageToServer(enrichedResumes);
+      const response = await syncCurrentPageToServer(enrichedResumes) as Record<string, unknown>;
       if (!response?.success) {
         throw response?.error || response || "51job detail backfill failed";
       }

--- a/apps/browser-extension/src/lib/ui-utils.ts
+++ b/apps/browser-extension/src/lib/ui-utils.ts
@@ -1,10 +1,40 @@
-// @ts-nocheck
 /**
  * UI/utility functions for export, auto-sync, and collection helpers.
  * All dependencies injected from content.ts via DI factory.
  */
 
-export function createUiUtils(deps) {
+export interface UiUtilsDeps extends Record<string, unknown> {
+  win: Window;
+  doc: Document;
+  SOURCE_KEYS: Record<string, string>;
+  AUTO_EXPORT_PARAM: string;
+  AUTO_SYNC_PARAM: string;
+  AUTO_LIMIT_PARAM: string;
+  AUTO_MAX_PAGES_PARAM: string;
+  AUTO_MIN_AGE_PARAM: string;
+  AUTO_MAX_AGE_PARAM: string;
+  AUTO_SEARCH_PARAM: string;
+  AUTO_LOCATION_PARAM: string;
+  SAMPLE_NAME_PARAM: string;
+  KEYWORD_MODE_CONCAT: string;
+  KEYWORD_MODE_SPACED: string;
+  LATEST_AUTO_SYNC_SUMMARIES_STORAGE_KEY: string;
+  JOB5156_HOST: string;
+  EHIRE_51JOB_HOST: string;
+  SEEK_HOST_SUFFIX: string;
+  getPaginationInfo: () => { currentPage: number; totalPages: number; totalItems: number; hasNextPage: boolean };
+  makeRandomId: () => string;
+  getExternalAccessorStatus: () => Record<string, unknown>;
+  getAgeRangeFromUrl: (search: string, minParam: string, maxParam: string) => { enabled: boolean; minAge?: number; maxAge?: number };
+  filterResumesByAgeRange: (resumes: unknown, search: string, minParam: string, maxParam: string) => unknown[];
+  resolveJob51CollectionLimits: (limit: number, maxPages: number, search: string) => { limit: number; maxPages: number };
+  resolveJob51DetailFetchDelayMs: (search: string) => number;
+  resolveJob51AutoSyncDetailWaitMode: (search: string) => string;
+  isJob51DetailPage: () => boolean;
+  chrome: { runtime?: { getManifest?: () => { version: string }; sendMessage?: (message: unknown) => Promise<unknown> }; storage?: { local?: { get?: (defaults: unknown, cb: (items: unknown) => void) => void; set?: (items: unknown) => void } } };
+}
+
+export function createUiUtils(deps: UiUtilsDeps) {
   const {
     // Window/Document
     win,
@@ -269,11 +299,11 @@ export function createUiUtils(deps) {
    * }} [options]
    */
   function buildAutoSyncProgressHint({
-    limit,
-    totalSubmitted,
+    limit = 0,
+    totalSubmitted = 0,
     selectedCount = null,
     ageHint = "",
-  } = {}) {
+  }: { limit?: number | null; totalSubmitted?: number | null; selectedCount?: number | null; ageHint?: string } = {}) {
     const progressHint =
       limit > 0
         ? `\u5df2\u91c7\u96c6 ${Math.min(totalSubmitted, limit)}/${limit}`


### PR DESCRIPTION
## Summary
- Add comprehensive tests for all 8 remaining browser extension lib modules without tests (auto-sync-runner, external-accessor, job51-collection-config, job51-search-extractor, job5156-extractor, seek-extractor, snapshot-collector, sync-status-widget)
- Remove `@ts-nocheck` from `extraction-pipeline.ts` and `ui-utils.ts` by adding `ExtractionPipelineDeps` and `UiUtilsDeps` interfaces with targeted type casts
- Update existing extraction-pipeline and ui-utils test imports for new Deps types

## Test plan
- [x] All 405 browser extension lib tests pass (`npx vitest run apps/browser-extension/src/lib/__tests__/`)
- [x] `make check` passes (typecheck + lint + governance)
- [x] Zero TypeScript errors in browser-extension project
- [x] @ts-nocheck files reduced from 12 to 10