### PR TITLE
refactor: remove @ts-nocheck from all 10 browser extension lib modules

### DIFF
--- a/apps/browser-extension/src/lib/__tests__/auto-actions.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/auto-actions.test.ts
@@ -2,11 +2,11 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi } from "vitest";
-import { createAutoActions } from "../auto-actions.js";
+import { createAutoActions, type AutoActionsDeps } from "../auto-actions.js";
 
 const SOURCE_KEYS = { JOB5156: "job5156", JOB51: "51job", SEEK: "seek", UNKNOWN: "unknown" };
 
-function createMockDeps(overrides: Record<string, any> = {}): Record<string, any> {
+function createMockDeps(overrides: Record<string, unknown> = {}): AutoActionsDeps {
   return {
     activateElement: vi.fn(),
     fireMouseEvent: vi.fn(),
@@ -21,7 +21,7 @@ function createMockDeps(overrides: Record<string, any> = {}): Record<string, any
     applyJob51AgeCustomRangeViaVue: vi.fn(),
     waitForJob51AgeFilterRefresh: vi.fn(),
     waitForExtractionData: vi.fn(),
-    asHTMLElement: vi.fn((el: any) => el),
+    asHTMLElement: vi.fn((el: unknown) => el as HTMLElement | null),
     SELECTORS: {},
     AUTO_LOCATION_PARAM: "location",
     AUTO_SEARCH_PARAM: "keyword",
@@ -39,19 +39,19 @@ function createMockDeps(overrides: Record<string, any> = {}): Record<string, any
     isJob51DetailPage: vi.fn(() => false),
     isJob5156DetailPage: vi.fn(() => false),
     isSeekProfileMode: vi.fn(() => false),
-    enrich51JobSearchResumesWithDetail: vi.fn(async (r: any[]) => r),
-    enrichJob5156SearchResumesWithDetail: vi.fn(async (r: any[]) => r),
-    enrichSeekResumesWithDetail: vi.fn(async (r: any[]) => r),
+    enrich51JobSearchResumesWithDetail: vi.fn(async (r: unknown[]) => r),
+    enrichJob5156SearchResumesWithDetail: vi.fn(async (r: unknown[]) => r),
+    enrichSeekResumesWithDetail: vi.fn(async (r: unknown[]) => r),
     buildSubmitMetadata: vi.fn(() => ({})),
     AUTO_EXPORT_PARAM: "tr_auto_export",
     AUTO_SYNC_PARAM: "tr_auto_sync",
     buildExportMetadata: vi.fn(() => ({})),
     buildExportFilename: vi.fn(() => "resumes.json"),
-    doc: document,
-    win: window as unknown as Window,
-    chrome: { runtime: { sendMessage: vi.fn(), getManifest: vi.fn(() => ({ version: "1.0.0" })) } } as any,
+    document,
+    window: window as unknown as Window,
+    chrome: { runtime: { sendMessage: vi.fn(), getManifest: vi.fn(() => ({ version: "1.0.0" })) } } as unknown as AutoActionsDeps["chrome"],
     ...overrides,
-  };
+  } as AutoActionsDeps;
 }
 
 describe("auto-actions", () => {

--- a/apps/browser-extension/src/lib/__tests__/auto-sync-runner.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/auto-sync-runner.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 
-import { createAutoSyncRunner } from "../auto-sync-runner";
+import { createAutoSyncRunner, type AutoSyncRunnerDeps } from "../auto-sync-runner";
 
-function createMockDeps(overrides = {}) {
+function createMockDeps(overrides: Record<string, unknown> = {}): AutoSyncRunnerDeps {
   return {
     getAutoSyncEnabled: vi.fn(() => true),
     setAutoSyncAttributes: vi.fn(),
@@ -89,7 +89,7 @@ function createMockDeps(overrides = {}) {
       _autoSyncCancelled: false,
     },
     ...overrides,
-  };
+  } as unknown as AutoSyncRunnerDeps;
 }
 
 describe("auto-sync-runner", () => {

--- a/apps/browser-extension/src/lib/__tests__/external-accessor.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/external-accessor.test.ts
@@ -4,9 +4,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   getExternalAccessorStatus,
   installExternalAccessor,
+  type ExternalAccessorDeps,
 } from "../external-accessor";
 
-function createMockDeps(overrides = {}) {
+function createMockDeps(overrides: Record<string, unknown> = {}): ExternalAccessorDeps {
   return {
     getExtensionVersion: vi.fn(() => "1.2.3"),
     getPaginationInfo: vi.fn(() => ({
@@ -26,8 +27,15 @@ function createMockDeps(overrides = {}) {
     SELECTORS: { resumeCard: ".resume-card" },
     isJob5156DetailPage: vi.fn(() => false),
     isJob5156DetailReady: vi.fn(() => false),
+    extractResumes: vi.fn(() => []),
+    extractResumesRaw: vi.fn(() => []),
+    collectSnapshotPayload: vi.fn(() => ({})),
+    syncToServer: vi.fn(async () => ({ success: true })),
+    goToNextPageInternal: vi.fn(() => undefined),
+    version: "1.2.3",
+    getExternalAccessorStatus: vi.fn(() => ({})),
     ...overrides,
-  };
+  } as unknown as ExternalAccessorDeps;
 }
 
 describe("external-accessor", () => {
@@ -199,8 +207,17 @@ describe("external-accessor", () => {
         getExternalAccessorStatus: vi.fn(() => ({ loaded: true })),
         syncToServer: vi.fn(() => Promise.resolve()),
         goToNextPageInternal: vi.fn(() => true),
+        getExtensionVersion: vi.fn(() => "1.0.0"),
+        getCurrentAgeRange: vi.fn(() => ({ enabled: false })),
+        getCurrentSourceKey: vi.fn(() => "job51"),
+        getApiSnapshotCount: vi.fn(() => 0),
+        getSeekCardCount: vi.fn(() => 0),
+        SOURCE_KEYS: { JOB51: "job51", JOB5156: "job5156", SEEK: "seek" },
+        SELECTORS: { resumeCard: ".resume-card" },
+        isJob5156DetailPage: vi.fn(() => false),
+        isJob5156DetailReady: vi.fn(() => false),
         version: "1.0.0",
-      };
+      } as unknown as ExternalAccessorDeps;
 
       installExternalAccessor(key, mockDeps);
 
@@ -236,8 +253,17 @@ describe("external-accessor", () => {
         getExternalAccessorStatus: vi.fn(),
         syncToServer: vi.fn(),
         goToNextPageInternal: vi.fn(),
+        getExtensionVersion: vi.fn(() => "1.0.0"),
+        getCurrentAgeRange: vi.fn(() => ({ enabled: false })),
+        getCurrentSourceKey: vi.fn(() => "job51"),
+        getApiSnapshotCount: vi.fn(() => 0),
+        getSeekCardCount: vi.fn(() => 0),
+        SOURCE_KEYS: { JOB51: "job51", JOB5156: "job5156", SEEK: "seek" },
+        SELECTORS: { resumeCard: ".resume-card" },
+        isJob5156DetailPage: vi.fn(() => false),
+        isJob5156DetailReady: vi.fn(() => false),
         version: "1.0.0",
-      });
+      } as unknown as ExternalAccessorDeps);
 
       const accessor = (window as unknown as Record<string, unknown>)[key] as Record<
         string,

--- a/apps/browser-extension/src/lib/__tests__/job51-search-extractor.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/job51-search-extractor.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
-import { createJob51SearchExtractor } from "../job51-search-extractor";
+import { createJob51SearchExtractor, type Job51SearchExtractorDeps } from "../job51-search-extractor";
 
-function createMockDeps(overrides = {}) {
+function createMockDeps(overrides: Record<string, unknown> = {}): Job51SearchExtractorDeps {
   return {
     getCurrentSourceKey: vi.fn(() => "job51"),
     SOURCE_KEYS: { JOB51: "job51", JOB5156: "job5156", SEEK: "seek" },
@@ -24,17 +24,15 @@ function createMockDeps(overrides = {}) {
     buildJob51DetailResumeFromPayload: vi.fn(() => []),
     filterCurrentResumesByAgeRange: vi.fn((r) => r),
     chrome: { runtime: { sendMessage: vi.fn() } },
-    window: { location: { pathname: "/", href: "https://ehire.51job.com/" }, setTimeout: vi.fn(), clearTimeout: vi.fn() },
+    window: { location: { pathname: "/", href: "https://ehire.51job.com/" }, setTimeout: vi.fn(), clearTimeout: vi.fn(), document: document },
     fetch: vi.fn(),
     delay: vi.fn(),
     isElementVisible: vi.fn(() => true),
     activateElement: vi.fn(),
     findVueParentByName: vi.fn(() => null),
     ...overrides,
-  };
+  } as unknown as Job51SearchExtractorDeps;
 }
-
-import { vi } from "vitest";
 
 describe("job51-search-extractor", () => {
   describe("normalizeJob51AuthContext", () => {

--- a/apps/browser-extension/src/lib/__tests__/job5156-extractor.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/job5156-extractor.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
 
-import { createJob5156Extractor } from "../job5156-extractor";
+import { createJob5156Extractor, type Job5156ExtractorDeps } from "../job5156-extractor";
 
-function createMockDeps(overrides = {}) {
+function createMockDeps(overrides: Record<string, unknown> = {}): Job5156ExtractorDeps {
   return {
     getCurrentSourceKey: vi.fn(() => "job5156"),
     SOURCE_KEYS: { JOB51: "job51", JOB5156: "job5156", SEEK: "seek" },
@@ -35,7 +35,7 @@ function createMockDeps(overrides = {}) {
     isMeaningfulJob5156WorkHistoryEntry: vi.fn(() => true),
     collectJob5156SectionItemsByHeading: vi.fn(() => []),
     ...overrides,
-  };
+  } as unknown as Job5156ExtractorDeps;
 }
 
 describe("job5156-extractor", () => {

--- a/apps/browser-extension/src/lib/__tests__/seek-extractor.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/seek-extractor.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
 
-import { createSeekExtractor } from "../seek-extractor";
+import { createSeekExtractor, type SeekExtractorDeps } from "../seek-extractor";
 
-function createMockDeps(overrides = {}) {
+function createMockDeps(overrides: Record<string, unknown> = {}): SeekExtractorDeps {
   return {
     getCurrentSourceKey: vi.fn(() => "seek"),
     SOURCE_KEYS: { JOB51: "job51", JOB5156: "job5156", SEEK: "seek" },
@@ -34,12 +34,13 @@ function createMockDeps(overrides = {}) {
         search: "",
       },
     },
-    doc: { querySelectorAll: vi.fn(() => []) },
-    asHTMLElement: (el: unknown) => el,
+    doc: { querySelectorAll: vi.fn(() => []), querySelector: vi.fn(() => null) },
+    asHTMLElement: (el: unknown) => el as HTMLElement | null,
     isDisabledPaginationControl: vi.fn(() => false),
     waitForSeekProfileSnapshot: vi.fn(),
+    SELECTORS: { seekPagination: ".seek-pagination", seekTalentSearchPagination: ".seek-ts-pagination" },
     ...overrides,
-  };
+  } as unknown as SeekExtractorDeps;
 }
 
 describe("seek-extractor", () => {

--- a/apps/browser-extension/src/lib/__tests__/snapshot-collector.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/snapshot-collector.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 
-import { createSnapshotCollector } from "../snapshot-collector";
+import { createSnapshotCollector, type SnapshotCollectorDeps } from "../snapshot-collector";
 
-function createMockDeps(overrides = {}) {
+function createMockDeps(overrides: Record<string, unknown> = {}): SnapshotCollectorDeps {
   return {
     apiSnapshot: {
       searchRows: [],
@@ -71,7 +71,7 @@ function createMockDeps(overrides = {}) {
       head: { prepend: vi.fn() },
     },
     ...overrides,
-  };
+  } as unknown as SnapshotCollectorDeps;
 }
 
 describe("snapshot-collector", () => {

--- a/apps/browser-extension/src/lib/__tests__/sync-status-widget.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/sync-status-widget.test.ts
@@ -1,15 +1,15 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { createSyncStatusWidget } from "../sync-status-widget";
+import { createSyncStatusWidget, type SyncStatusWidgetDeps } from "../sync-status-widget";
 
-function createMockDeps() {
+function createMockDeps(): SyncStatusWidgetDeps {
   return {
     win: window,
     doc: document,
     chrome: { runtime: { sendMessage: vi.fn(() => Promise.resolve()) } },
     onCancel: vi.fn(),
-  };
+  } as unknown as SyncStatusWidgetDeps;
 }
 
 describe("sync-status-widget", () => {

--- a/apps/browser-extension/src/lib/auto-actions.ts
+++ b/apps/browser-extension/src/lib/auto-actions.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Auto-actions — automatic age filter, location, search, export, and sync
  * orchestration. Dependencies injected from content.ts.
@@ -6,7 +5,51 @@
  * Created as Phase 4 of content.ts extraction.
  */
 
-export function createAutoActions(deps) {
+export interface AutoActionsDeps extends Record<string, unknown> {
+  activateElement: (el: unknown) => void;
+  fireMouseEvent: (el: unknown, type: string) => void;
+  setInputValue: (el: unknown, value: string) => void;
+  apiSnapshot: Record<string, unknown>;
+  getCurrentSourceKey: () => string;
+  getCurrentAgeRange: () => { enabled: boolean; minAge?: number; maxAge?: number };
+  SOURCE_KEYS: Record<string, string>;
+  isElementVisible: (el: unknown) => boolean;
+  resolveJob51AgeFilterDropdown: (ageBlock: unknown) => unknown;
+  ensureJob51AgeCustomRangeInputs: (selectBox: unknown, options?: Record<string, unknown>) => Promise<void>;
+  applyJob51AgeCustomRangeViaVue: (confirmButton: unknown, options: Record<string, unknown>) => Promise<boolean>;
+  waitForJob51AgeFilterRefresh: (previousLastSearchAt: unknown, options: Record<string, unknown>) => Promise<boolean>;
+  waitForExtractionData: (options?: Record<string, unknown>) => Promise<unknown>;
+  asHTMLElement: (el: unknown) => HTMLElement | null;
+  SELECTORS: Record<string, string>;
+  AUTO_LOCATION_PARAM: string;
+  AUTO_SEARCH_PARAM: string;
+  AUTO_KEYWORD_MODE_PARAM: string;
+  KEYWORD_MODE_SPACED: string;
+  normalizeKeyword: (value: string) => string;
+  normalizeKeywordMode: (mode: string) => string;
+  getKeywordMode: () => Promise<string>;
+  normalizeSeekLocationLabel: (label: string) => string;
+  hasJob51SearchSnapshot: () => boolean;
+  isJob51EmptySearchPromptVisible: () => boolean;
+  parseAutoLocationValues: (raw: string) => string[];
+  extractResumes: () => unknown[];
+  extractResumesRaw: (options?: Record<string, unknown>) => Record<string, unknown>;
+  isJob51DetailPage: () => boolean;
+  isJob5156DetailPage: () => boolean;
+  isSeekProfileMode: () => boolean;
+  enrich51JobSearchResumesWithDetail: (resumes: unknown[]) => Promise<unknown[]>;
+  enrichJob5156SearchResumesWithDetail: (resumes: unknown[]) => Promise<unknown[]>;
+  enrichSeekResumesWithDetail: (resumes: unknown[]) => Promise<unknown[]>;
+  buildSubmitMetadata: (options?: Record<string, unknown>) => Record<string, unknown>;
+  AUTO_EXPORT_PARAM: string;
+  AUTO_SYNC_PARAM: string;
+  buildExportMetadata: (resumes: unknown[]) => Record<string, unknown>;
+  buildExportFilename: () => string;
+  document: Document;
+  window: Window;
+}
+
+export function createAutoActions(deps: AutoActionsDeps) {
   const {
     activateElement,
     fireMouseEvent,
@@ -53,7 +96,7 @@ export function createAutoActions(deps) {
 
   // ── setAutoAgeAttributes ──
 
-  function setAutoAgeAttributes(status, minAge, maxAge) {
+  function setAutoAgeAttributes(status: string, minAge?: number | null, maxAge?: number | null) {
     try {
       doc.documentElement.setAttribute("data-tr-auto-age", status);
       const normalizedMin =
@@ -83,27 +126,27 @@ export function createAutoActions(deps) {
     if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
       const labels = doc.querySelectorAll(".base-select-label");
       const label = Array.from(labels).find(
-        (node) => (node.textContent || "").replace(/\s+/g, "").trim() === "年龄",
+        (node) => ((node as Element).textContent || "").replace(/\s+/g, "").trim() === "年龄",
       );
       if (label) {
         return (
-          label.closest(".el-popover__reference") ||
-          label.closest(".base-select-button") ||
-          label.closest(".el-popover__reference-wrapper")
+          (label as Element).closest(".el-popover__reference") ||
+          (label as Element).closest(".base-select-button") ||
+          (label as Element).closest(".el-popover__reference-wrapper")
         );
       }
     }
 
     const titles = doc.querySelectorAll(".base-input-block__title__text");
     const label = Array.from(titles).find(
-      (node) => (node.textContent || "").replace(/\s+/g, "").trim() === "年龄",
+      (node) => ((node as Element).textContent || "").replace(/\s+/g, "").trim() === "年龄",
     );
-    return label ? label.closest(".base-input-block") : null;
+    return label ? (label as Element).closest(".base-input-block") : null;
   }
 
   // ── openAgeFilterDropdown ──
 
-  function openAgeFilterDropdown(ageBlock) {
+  function openAgeFilterDropdown(ageBlock: Element) {
     if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
       const trigger =
         ageBlock.querySelector(".base-select-button") ||
@@ -121,7 +164,7 @@ export function createAutoActions(deps) {
 
   // ── resolveAgeSelectBox ──
 
-  function resolveAgeSelectBox(ageBlock) {
+  function resolveAgeSelectBox(ageBlock: Element) {
     return getCurrentSourceKey() === SOURCE_KEYS.JOB51
       ? resolveJob51AgeFilterDropdown(ageBlock)
       : ageBlock.querySelector(".base-input-block__select_box");
@@ -129,8 +172,9 @@ export function createAutoActions(deps) {
 
   // ── waitForAgeFilterDropdown ──
 
-  async function waitForAgeFilterDropdown(ageBlock, { timeoutMs = 4000 } = {}) {
-    const deadline = Date.now() + timeoutMs;
+  async function waitForAgeFilterDropdown(ageBlock: Element, { timeoutMs = 4000 }: Record<string, unknown> = {}) {
+    const timeout = typeof timeoutMs === "number" ? timeoutMs : 4000;
+    const deadline = Date.now() + timeout;
     while (Date.now() < deadline) {
       const selectBox = resolveAgeSelectBox(ageBlock);
       if (selectBox && isElementVisible(selectBox)) {
@@ -146,16 +190,16 @@ export function createAutoActions(deps) {
 
   // ── resolveAgeFilterActions ──
 
-  function resolveAgeFilterActions(selectBox) {
+  function resolveAgeFilterActions(selectBox: Element) {
     const minInput = selectBox.querySelector('input[placeholder="最低"]');
     const maxInput = selectBox.querySelector('input[placeholder="最高"]');
     const buttons = Array.from(selectBox.querySelectorAll("button"));
     const confirmButton = buttons.find((button) => {
-      const text = (button.textContent || "").replace(/\s+/g, "").trim();
-      return text === "确定" || text === "確定";
+      const text = (button as HTMLElement).textContent || "";
+      return text.replace(/\s+/g, "").trim() === "确定" || text.replace(/\s+/g, "").trim() === "確定";
     });
     const cancelButton = buttons.find((button) => {
-      const text = (button.textContent || "").replace(/\s+/g, "").trim();
+      const text = ((button as HTMLElement).textContent || "").replace(/\s+/g, "").trim();
       return text === "取消";
     });
 
@@ -232,13 +276,13 @@ export function createAutoActions(deps) {
     }
 
     if (sourceKey === SOURCE_KEYS.JOB51) {
-      await ensureJob51AgeCustomRangeInputs(selectBox, {
+      await ensureJob51AgeCustomRangeInputs(selectBox as Element, {
         timeoutMs: 2500,
       });
     }
 
     const { minInput, maxInput, confirmButton, cancelButton } =
-      resolveAgeFilterActions(selectBox);
+      resolveAgeFilterActions(selectBox as Element);
     if (!minInput || !maxInput || !confirmButton) {
       if (sourceKey === SOURCE_KEYS.JOB51) {
         setAutoAgeAttributes("failed", minAge, maxAge);
@@ -361,10 +405,11 @@ export function createAutoActions(deps) {
 
   // ── waitForSearchElements ──
 
-  function waitForSearchElements({ timeoutMs = 8000 } = {}) {
+  function waitForSearchElements({ timeoutMs = 8000 }: Record<string, unknown> = {}): Promise<{ input: Element; button: Element }> {
+    const timeout = typeof timeoutMs === "number" ? timeoutMs : 8000;
     return new Promise((resolve, reject) => {
       let done = false;
-      const deadline = Date.now() + timeoutMs;
+      const deadline = Date.now() + timeout;
 
       const check = () => {
         if (done) return;
@@ -407,10 +452,11 @@ export function createAutoActions(deps) {
 
   // ── waitForAreaModal ──
 
-  function waitForAreaModal({ timeoutMs = 8000 } = {}) {
+  function waitForAreaModal({ timeoutMs = 8000 }: Record<string, unknown> = {}): Promise<Element> {
+    const timeout = typeof timeoutMs === "number" ? timeoutMs : 8000;
     return new Promise((resolve, reject) => {
       let done = false;
-      const deadline = Date.now() + timeoutMs;
+      const deadline = Date.now() + timeout;
 
       const check = () => {
         if (done) return;
@@ -444,10 +490,10 @@ export function createAutoActions(deps) {
 
   // ── getAreaItemText ──
 
-  function getAreaItemText(item) {
+  function getAreaItemText(item: Element | null) {
     if (!item) return "";
     const source = item.querySelector("span") || item;
-    const clone = source.cloneNode(true);
+    const clone = source.cloneNode(true) as Element;
     clone.querySelectorAll(".select-num").forEach((node) => node.remove());
     return (
       (clone.textContent || "")
@@ -459,7 +505,7 @@ export function createAutoActions(deps) {
 
   // ── findAreaItemByText ──
 
-  function findAreaItemByText(container, text) {
+  function findAreaItemByText(container: Element | null, text: string) {
     if (!container || !text) return null;
     const target = text.replace(/\s+/g, " ").trim();
     const normalizedTarget = normalizeSeekLocationLabel(target);
@@ -488,14 +534,15 @@ export function createAutoActions(deps) {
   // ── waitForAreaItems ──
 
   function waitForAreaItems(
-    blockSelector,
-    { timeoutMs = 5000, itemSelector } = {},
-  ) {
+    blockSelector: string,
+    { timeoutMs = 5000, itemSelector }: Record<string, unknown> = {},
+  ): Promise<{ block: Element; items: Element[] }> {
+    const timeout = typeof timeoutMs === "number" ? timeoutMs : 5000;
     return new Promise((resolve, reject) => {
       let done = false;
-      const deadline = Date.now() + timeoutMs;
+      const deadline = Date.now() + timeout;
       const targetSelector =
-        itemSelector || `${SELECTORS.areaItem}, ${SELECTORS.areaDistrictItem}`;
+        (typeof itemSelector === "string" && itemSelector) || `${SELECTORS.areaItem}, ${SELECTORS.areaDistrictItem}`;
 
       const check = () => {
         if (done) return;
@@ -531,10 +578,11 @@ export function createAutoActions(deps) {
 
   // ── waitForAreaTrigger ──
 
-  function waitForAreaTrigger({ timeoutMs = 8000 } = {}) {
+  function waitForAreaTrigger({ timeoutMs = 8000 }: Record<string, unknown> = {}): Promise<HTMLElement> {
+    const timeout = typeof timeoutMs === "number" ? timeoutMs : 8000;
     return new Promise((resolve, reject) => {
       let done = false;
-      const deadline = Date.now() + timeoutMs;
+      const deadline = Date.now() + timeout;
 
       const check = () => {
         if (done) return;
@@ -570,7 +618,7 @@ export function createAutoActions(deps) {
 
   // ── setAutoSearchAttributes ──
 
-  function setAutoSearchAttributes(status, keyword) {
+  function setAutoSearchAttributes(status: string, keyword?: string) {
     try {
       doc.documentElement.setAttribute("data-tr-auto-search", status);
       if (keyword) {
@@ -585,7 +633,7 @@ export function createAutoActions(deps) {
 
   // ── setAutoLocationAttributes ──
 
-  function setAutoLocationAttributes(status, location) {
+  function setAutoLocationAttributes(status: string, location?: string) {
     try {
       doc.documentElement.setAttribute("data-tr-auto-location", status);
       if (location) {
@@ -1006,7 +1054,7 @@ export function createAutoActions(deps) {
 
   // ── parseAutoExportMode ──
 
-  function parseAutoExportMode(value) {
+  function parseAutoExportMode(value: string | undefined): Record<string, boolean> {
     if (!value) return { enabled: false };
     const mode = String(value).trim().toLowerCase();
     if (!mode) return { enabled: false };

--- a/apps/browser-extension/src/lib/auto-sync-runner.ts
+++ b/apps/browser-extension/src/lib/auto-sync-runner.ts
@@ -1,11 +1,71 @@
-// @ts-nocheck
 /**
  * Factory: createAutoSyncRunner
  * Extracts the runAutoSyncIfEnabled orchestration from content.ts into a
  * dependency-injected module so content.ts stays thin.
  */
 
-export function createAutoSyncRunner(deps) {
+export interface AutoSyncRunnerDeps extends Record<string, unknown> {
+  getAutoSyncEnabled: () => boolean;
+  setAutoSyncAttributes: (status: string, count?: number, pages?: number) => void;
+  resolveAutoSyncErrorStatus: (error: unknown) => { message: string; hint: string };
+  resolveAutoSyncStopReason: (...args: unknown[]) => string;
+  runAutoExportIfEnabled: () => Promise<unknown>;
+  syncCurrentPageToServer: (resumes?: unknown) => Promise<unknown>;
+  setSeekAutoSyncWindowAttributes: (attrs: unknown) => void;
+  setSeekAutoSyncSelectionAttributes: (attrs: unknown) => void;
+  isSeekProfileMode: () => boolean;
+  resolveSeekAutoSyncPageWindow: (options?: unknown) => unknown;
+  isSeekAutoSyncPageWindowReached: (pageWindow?: unknown, currentPage?: number) => boolean;
+  resolveSeekAutoSyncCurrentPageSelection: (options?: unknown) => { remainingCapacity: number | null; selectedCount: number | null; hitLimitWithinPage: boolean; limitAlreadyReached: boolean };
+  getSeekRequestedPageSize: () => number;
+  getSeekCurrentCandidateCount: () => number;
+  resolveSeekAutoSyncPageSize: () => number;
+  enrichSeekResumesWithDetail: (resumes: unknown[]) => Promise<unknown[]>;
+  getPaginationInfo: () => { currentPage: number; totalPages: number; totalItems: number; hasNextPage: boolean };
+  waitForPagination: (options?: unknown) => Promise<unknown>;
+  getNextPageButtonState: () => unknown;
+  waitForExtractionData: (options?: unknown) => Promise<unknown>;
+  extractResumes: () => unknown[];
+  goToNextPageInternal: () => unknown;
+  clearCapturedResultsForNextPage: () => void;
+  enrich51JobSearchResumesWithDetail: (resumes: unknown[]) => Promise<unknown[]>;
+  enrichJob5156SearchResumesWithDetail: (resumes: unknown[]) => Promise<unknown[]>;
+  queueJob51DetailBackfill: (...args: unknown[]) => unknown;
+  collectSnapshotPayload: (options?: unknown) => unknown;
+  getApiSnapshotCount: () => number;
+  buildSubmitMetadata: (options?: unknown) => unknown;
+  extractProfileUrl: (resume: unknown) => string;
+  loadCollectionGuards: () => unknown;
+  parseGuardFieldNames: (csv: string) => Set<string>;
+  applyCollectionGuards: (resume: unknown, fields: Set<string>) => unknown;
+  ensureJob51PageAllowed: () => boolean;
+  isJob51RateLimitedPage: () => boolean;
+  waitForJob51Cooldown: () => Promise<unknown>;
+  filterResumesByAgeRange: (resumes: unknown[]) => unknown[];
+  getAgeRangeFromUrl: (...args: unknown[]) => unknown;
+  normalizeOptionalPositiveInt: (value: unknown) => number;
+  buildAutoSyncProgressHint: (options: Record<string, unknown>) => string;
+  buildAutoSyncSelectedCountHint: (options: Record<string, unknown>) => string;
+  buildAutoSyncCompletionHint: (options: Record<string, unknown>) => string;
+  persistLatestAutoSyncSummary: () => void;
+  getCurrentAgeRange: () => { enabled: boolean; minAge?: number; maxAge?: number };
+  resolveCurrentJob51AutoSyncDetailWaitMode: () => string;
+  waitForPageTransition: (options?: unknown) => Promise<unknown>;
+  delay: (ms: number) => Promise<void>;
+  getCurrentSourceKey: () => string;
+  SOURCE_KEYS: Record<string, string>;
+  getCollectionLimits: () => Promise<Record<string, unknown>>;
+  getKeywordMode: () => string;
+  isJob5156DetailPage: () => boolean;
+  isJob51DetailPage: () => boolean;
+  SyncStatusWidget: { show: (options: Record<string, unknown>) => void; hide: () => void };
+  document: Document;
+  window: Window;
+  chrome: Record<string, unknown>;
+  state: Record<string, unknown>;
+}
+
+export function createAutoSyncRunner(deps: AutoSyncRunnerDeps) {
   const {
     // Auto-actions helpers
     getAutoSyncEnabled,
@@ -100,7 +160,7 @@ export function createAutoSyncRunner(deps) {
   } = deps;
 
   async function runAutoSyncIfEnabled() {
-    if (deps.state._autoSyncTriggered) return;
+    if (deps.state._autoSyncTriggered as boolean) return;
     const enabled = getAutoSyncEnabled();
     if (!enabled) {
       setAutoSyncAttributes("skipped");
@@ -109,11 +169,11 @@ export function createAutoSyncRunner(deps) {
       return;
     }
 
-    const { limit, maxPages } = await getCollectionLimits();
+    const { limit, maxPages } = (await getCollectionLimits()) as { limit: number; maxPages: number };
     const isJob51Source = getCurrentSourceKey() === SOURCE_KEYS.JOB51;
 
-    deps.state._autoSyncTriggered = true;
-    deps.state._autoSyncCancelled = false;
+    deps.state._autoSyncTriggered = true as boolean;
+    deps.state._autoSyncCancelled = false as boolean;
     setAutoSyncAttributes("running", 0, 0);
     setSeekAutoSyncWindowAttributes(null);
     setSeekAutoSyncSelectionAttributes(null);
@@ -323,7 +383,7 @@ export function createAutoSyncRunner(deps) {
           hint: progressHint,
         });
 
-        const response = await syncCurrentPageToServer(resumes);
+        const response = (await syncCurrentPageToServer(resumes)) as Record<string, unknown> | null;
         if (!response?.success) {
           throw response?.error || response || "Auto sync failed";
         }

--- a/apps/browser-extension/src/lib/external-accessor.ts
+++ b/apps/browser-extension/src/lib/external-accessor.ts
@@ -1,10 +1,32 @@
-// @ts-nocheck
 /**
  * External CDP accessor — exposes content script functions via window.__TR_RESUME_DATA__
  * for CDP automation and testing.
  */
 
-export function getExternalAccessorStatus(deps) {
+export interface ExternalAccessorDeps extends Record<string, unknown> {
+  getExtensionVersion: () => string;
+  getPaginationInfo: () => { currentPage: number; totalPages: number; totalItems: number; hasNextPage: boolean };
+  getCurrentAgeRange: () => { enabled: boolean; minAge?: number; maxAge?: number };
+  getCurrentSourceKey: () => string;
+  getApiSnapshotCount: () => number;
+  getSeekCardCount: () => number;
+  SOURCE_KEYS: Record<string, string>;
+  isExtractionReady: () => boolean;
+  isLoggedIn: () => boolean;
+  apiSnapshot: Record<string, unknown>;
+  SELECTORS: Record<string, unknown>;
+  isJob5156DetailPage: () => boolean;
+  isJob5156DetailReady: () => boolean;
+  extractResumes: () => unknown[];
+  extractResumesRaw: (options?: unknown) => unknown[];
+  collectSnapshotPayload: (options?: unknown) => unknown;
+  syncToServer: (resumes?: unknown) => Promise<unknown>;
+  goToNextPageInternal: () => unknown;
+  getExternalAccessorStatus: (deps: ExternalAccessorDeps) => unknown;
+  version: string;
+}
+
+export function getExternalAccessorStatus(deps: ExternalAccessorDeps) {
   const {
     getExtensionVersion,
     getPaginationInfo,
@@ -34,7 +56,7 @@ export function getExternalAccessorStatus(deps) {
           ? isJob5156DetailReady()
             ? 1
             : 0
-          : document.querySelectorAll(SELECTORS.resumeCard).length;
+          : document.querySelectorAll(SELECTORS.resumeCard as string).length;
   const autoSearch =
     document.documentElement.getAttribute("data-tr-auto-search") || "";
   const autoLocation =
@@ -120,12 +142,12 @@ export function getExternalAccessorStatus(deps) {
       : null,
     autoSyncStopReason: autoSyncStopReason || null,
     pagination,
-    lastOperationName: apiSnapshot.lastOperationName,
+    lastOperationName: apiSnapshot.lastOperationName as string | null,
     timestamp: new Date().toISOString(),
   };
 }
 
-export function installExternalAccessor(key, deps) {
+export function installExternalAccessor(key: string, deps: ExternalAccessorDeps) {
   try {
     const {
       extractResumes,
@@ -140,7 +162,7 @@ export function installExternalAccessor(key, deps) {
       goToNextPageInternal,
       version,
     } = deps;
-    window[key] = {
+    (window as unknown as Record<string, unknown>)[key] = {
       extract: () => extractResumes(),
       extractRaw: (options) => extractResumesRaw(options),
       collect: (options) => collectSnapshotPayload(options),
@@ -148,7 +170,7 @@ export function installExternalAccessor(key, deps) {
       getPaginationInfo: () => getPaginationInfo(),
       isReady: () => isExtractionReady(),
       isLoggedIn: () => isLoggedIn(),
-      status: () => getExternalAccessorStatus(),
+      status: () => getExternalAccessorStatus(deps),
       syncToServer: () => syncToServer(),
       version,
       goToNextPage: () => goToNextPageInternal(),

--- a/apps/browser-extension/src/lib/job51-search-extractor.ts
+++ b/apps/browser-extension/src/lib/job51-search-extractor.ts
@@ -1,11 +1,34 @@
-// @ts-nocheck
 /**
  * 51job eHire search-specific utility functions — payload parsing, page detection,
  * rate-limit detection, and auth context extraction. All dependencies injected
  * from content.ts via DI factory pattern.
  */
 
-export function createJob51SearchExtractor(deps) {
+export interface Job51SearchExtractorDeps extends Record<string, unknown> {
+  getCurrentSourceKey: () => string;
+  SOURCE_KEYS: Record<string, string>;
+  apiSnapshot: Record<string, unknown>;
+  normalizeJob51Text: (value: unknown) => string;
+  normalizeJob51MultilineText: (value: unknown) => string;
+  normalizeResumeText: (value: unknown) => string;
+  buildWorkHistoryRawParts: (parts: string[]) => string;
+  EHIRE_51JOB_PROFILE_URL_PREFIX: string;
+  EHIRE_51JOB_HOST: string;
+  JOB51_PAGE_COOLDOWN_MS: number;
+  JOB51_DETAIL_FETCH_TIMEOUT_MS: number;
+  JOB51_RATE_LIMIT_ERROR_MESSAGE: string;
+  buildJob51DetailResumeFromPayload: (payload: unknown, options: Record<string, unknown>) => unknown[];
+  filterCurrentResumesByAgeRange: (resumes: unknown) => unknown[];
+  chrome: { runtime: { sendMessage: (message: unknown) => Promise<unknown> } };
+  window: { location: { pathname: string; href: string }; setTimeout: (cb: () => void, ms: number) => number; clearTimeout: (id: number) => void; document: Document };
+  fetch: (url: string, init?: RequestInit) => Promise<Response>;
+  delay: (ms: number) => Promise<void>;
+  isElementVisible: (el: unknown) => boolean;
+  activateElement: (el: unknown) => void;
+  findVueParentByName: (el: unknown, name: string) => unknown;
+}
+
+export function createJob51SearchExtractor(deps: Job51SearchExtractorDeps) {
   const {
     getCurrentSourceKey,
     SOURCE_KEYS,
@@ -116,28 +139,29 @@ export function createJob51SearchExtractor(deps) {
    * Checks for identity fields (resumeId, perUserId, etc.), name fields,
    * and detail fields (experience, education, location, etc.).
    */
-  function isLikelyJob51ResumeRow(row) {
+  function isLikelyJob51ResumeRow(row: unknown) {
     if (!row || typeof row !== "object") return false;
+    const rec = row as Record<string, unknown>;
     const baseInfo =
-      row.base_info && typeof row.base_info === "object" ? row.base_info : null;
+      rec.base_info && typeof rec.base_info === "object" ? rec.base_info as Record<string, unknown> : null;
     const jobIntention =
-      row.job_intention && typeof row.job_intention === "object"
-        ? row.job_intention
+      rec.job_intention && typeof rec.job_intention === "object"
+        ? rec.job_intention as Record<string, unknown>
         : null;
     const recentWorkInfo =
-      row.recent_work_info && typeof row.recent_work_info === "object"
-        ? row.recent_work_info
+      rec.recent_work_info && typeof rec.recent_work_info === "object"
+        ? rec.recent_work_info as Record<string, unknown>
         : null;
     const identityCandidates = [
-      row.resumeId,
-      row.resumeNo,
-      row.resumekey,
-      row.perUserId,
-      row.userId,
-      row.candidateId,
-      row.memberId,
-      row.userid,
-      row.real_userid,
+      rec.resumeId,
+      rec.resumeNo,
+      rec.resumekey,
+      rec.perUserId,
+      rec.userId,
+      rec.candidateId,
+      rec.memberId,
+      rec.userid,
+      rec.real_userid,
       baseInfo?.accountid,
     ];
     const hasIdentity = identityCandidates.some((value) => {
@@ -145,10 +169,10 @@ export function createJob51SearchExtractor(deps) {
       return String(value).trim().length > 0;
     });
     const nameCandidates = [
-      row.name,
-      row.userName,
-      row.candidateName,
-      row.fullName,
+      rec.name,
+      rec.userName,
+      rec.candidateName,
+      rec.fullName,
       baseInfo?.resume_name,
     ];
     const hasName = nameCandidates.some((value) => {
@@ -156,23 +180,23 @@ export function createJob51SearchExtractor(deps) {
       return normalizeJob51Text(String(value)).length > 0;
     });
     const detailCandidates = [
-      row.workYear,
-      row.workYears,
-      row.experienceYears,
-      row.experience,
-      row.education,
-      row.educationLevel,
-      row.degree,
-      row.eduLevel,
-      row.location,
-      row.workCity,
-      row.city,
-      row.workLocation,
-      row.jobIntention,
-      row.desiredJob,
-      row.expectedPosition,
-      row.targetJob,
-      row.searchJob,
+      rec.workYear,
+      rec.workYears,
+      rec.experienceYears,
+      rec.experience,
+      rec.education,
+      rec.educationLevel,
+      rec.degree,
+      rec.eduLevel,
+      rec.location,
+      rec.workCity,
+      rec.city,
+      rec.workLocation,
+      rec.jobIntention,
+      rec.desiredJob,
+      rec.expectedPosition,
+      rec.targetJob,
+      rec.searchJob,
       baseInfo?.work_year_value,
       baseInfo?.top_degree_value,
       baseInfo?.area_value,
@@ -262,17 +286,19 @@ export function createJob51SearchExtractor(deps) {
    * Checks if an API response payload indicates rate limiting.
    * Searches common error fields (error, message, msg, detail) for rate-limit text.
    */
-  function isJob51RateLimitedPayload(payload) {
+  function isJob51RateLimitedPayload(payload: unknown) {
     if (!payload) return false;
+    const rec = payload as Record<string, unknown>;
+    const data = rec.data as Record<string, unknown> | undefined;
     const candidates = [
-      payload.error,
-      payload.message,
-      payload.msg,
-      payload.detail,
-      payload.data?.error,
-      payload.data?.message,
-      payload.data?.msg,
-      payload.data?.detail,
+      rec.error,
+      rec.message,
+      rec.msg,
+      rec.detail,
+      data?.error,
+      data?.message,
+      data?.msg,
+      data?.detail,
     ];
     return candidates.some((value) => isJob51RateLimitedErrorMessage(value));
   }
@@ -303,7 +329,7 @@ export function createJob51SearchExtractor(deps) {
       const response = await chrome.runtime.sendMessage({
         action: "collectJob51ResumeDetail",
         resumeId,
-      });
+      }) as Record<string, unknown> | null;
       if (response?.success) {
         return {
           payload: response.data ?? response.payload ?? response.resume ?? null,
@@ -335,7 +361,7 @@ export function createJob51SearchExtractor(deps) {
       return { payload: null, rateLimited: false };
     }
 
-    const authContext = apiSnapshot.job51AuthContext;
+    const authContext = apiSnapshot.job51AuthContext as Record<string, unknown> | null | undefined;
     const requestBody = {
       resume_id: normalizedResumeId,
       resumeId: normalizedResumeId,
@@ -350,10 +376,10 @@ export function createJob51SearchExtractor(deps) {
         Accept: "application/json, text/plain, */*",
         "Content-Type": "application/json",
         ...(authContext.accesstoken
-          ? { accesstoken: authContext.accesstoken }
+          ? { accesstoken: authContext.accesstoken as string }
           : {}),
-        ...(authContext.guid ? { guid: authContext.guid } : {}),
-        ...(authContext.property ? { property: authContext.property } : {}),
+        ...(authContext.guid ? { guid: authContext.guid as string } : {}),
+        ...(authContext.property ? { property: authContext.property as string } : {}),
       };
       const controller = new AbortController();
       const timeoutId = win.setTimeout(
@@ -423,7 +449,7 @@ export function createJob51SearchExtractor(deps) {
    * Enriches a single 51job search result resume with detail API data.
    * Fetches detail via fetch51JobResumeDetail and merges fields.
    */
-  async function enrich51JobSearchResumeWithDetail(resume, extractedAt) {
+  async function enrich51JobSearchResumeWithDetail(resume: unknown, extractedAt: string) {
     if (!resume || typeof resume !== "object") {
       return {
         resume: null,
@@ -432,13 +458,14 @@ export function createJob51SearchExtractor(deps) {
       };
     }
 
-    const fallbackResume = {
-      ...resume,
-      extractedAt: resume.extractedAt || extractedAt,
+    const rec = resume as Record<string, unknown>;
+    const fallbackResume: Record<string, unknown> = {
+      ...rec,
+      extractedAt: rec.extractedAt || extractedAt,
     };
     const resumeId =
-      normalizeJob51Text(resume.resumeId) ||
-      normalizeJob51Text(resume.perUserId) ||
+      normalizeJob51Text(rec.resumeId as string) ||
+      normalizeJob51Text(rec.perUserId as string) ||
       "";
 
     if (!resumeId) {
@@ -462,8 +489,8 @@ export function createJob51SearchExtractor(deps) {
       const detailResume =
         buildJob51DetailResumeFromPayload(detailResult.payload, {
           resumeId,
-          profileUrl: fallbackResume.profileUrl || "",
-        })[0] || null;
+          profileUrl: (fallbackResume.profileUrl as string | undefined) || "",
+        })[0] as Record<string, unknown> | null || null;
 
       if (!detailResume) {
         return {
@@ -477,58 +504,58 @@ export function createJob51SearchExtractor(deps) {
         resume: {
           ...fallbackResume,
           ...detailResume,
-          name: detailResume.name || fallbackResume.name || "",
-          age: detailResume.age || fallbackResume.age || "",
-          experience: detailResume.experience || fallbackResume.experience || "",
-          education: detailResume.education || fallbackResume.education || "",
-          location: detailResume.location || fallbackResume.location || "",
+          name: (detailResume.name as string) || (fallbackResume.name as string) || "",
+          age: (detailResume.age as string) || (fallbackResume.age as string) || "",
+          experience: (detailResume.experience as string) || (fallbackResume.experience as string) || "",
+          education: (detailResume.education as string) || (fallbackResume.education as string) || "",
+          location: (detailResume.location as string) || (fallbackResume.location as string) || "",
           jobIntention:
-            detailResume.jobIntention || fallbackResume.jobIntention || "",
+            (detailResume.jobIntention as string) || (fallbackResume.jobIntention as string) || "",
           expectedSalary:
-            detailResume.expectedSalary || fallbackResume.expectedSalary || "",
+            (detailResume.expectedSalary as string) || (fallbackResume.expectedSalary as string) || "",
           activityStatus:
-            detailResume.activityStatus || fallbackResume.activityStatus || "",
-          selfIntro: detailResume.selfIntro || fallbackResume.selfIntro || "",
-          resumeId: detailResume.resumeId || fallbackResume.resumeId,
-          perUserId: detailResume.perUserId || fallbackResume.perUserId,
-          externalId: detailResume.externalId || fallbackResume.externalId,
-          profileUrl: detailResume.profileUrl || fallbackResume.profileUrl,
+            (detailResume.activityStatus as string) || (fallbackResume.activityStatus as string) || "",
+          selfIntro: (detailResume.selfIntro as string) || (fallbackResume.selfIntro as string) || "",
+          resumeId: (detailResume.resumeId as string) || (fallbackResume.resumeId as string),
+          perUserId: (detailResume.perUserId as string) || (fallbackResume.perUserId as string),
+          externalId: (detailResume.externalId as string) || (fallbackResume.externalId as string),
+          profileUrl: (detailResume.profileUrl as string) || (fallbackResume.profileUrl as string),
           extractedAt: fallbackResume.extractedAt,
           pageIndex: fallbackResume.pageIndex,
           pageNumber: fallbackResume.pageNumber,
           workHistory:
             Array.isArray(detailResume.workHistory) &&
             detailResume.workHistory.length > 0
-              ? detailResume.workHistory
+              ? detailResume.workHistory as unknown[]
               : Array.isArray(fallbackResume.workHistory)
-                ? fallbackResume.workHistory
+                ? fallbackResume.workHistory as unknown[]
                 : [],
           projectExperience:
             Array.isArray(detailResume.projectExperience) &&
             detailResume.projectExperience.length > 0
-              ? detailResume.projectExperience
+              ? detailResume.projectExperience as unknown[]
               : Array.isArray(fallbackResume.projectExperience)
-                ? fallbackResume.projectExperience
+                ? fallbackResume.projectExperience as unknown[]
                 : [],
           profileEducation:
             Array.isArray(detailResume.profileEducation) &&
             detailResume.profileEducation.length > 0
-              ? detailResume.profileEducation
+              ? detailResume.profileEducation as unknown[]
               : Array.isArray(fallbackResume.profileEducation)
-                ? fallbackResume.profileEducation
+                ? fallbackResume.profileEducation as unknown[]
                 : [],
           skills:
             Array.isArray(detailResume.skills) && detailResume.skills.length > 0
-              ? detailResume.skills
+              ? detailResume.skills as unknown[]
               : Array.isArray(fallbackResume.skills)
-                ? fallbackResume.skills
+                ? fallbackResume.skills as unknown[]
                 : [],
           licences:
             Array.isArray(detailResume.licences) &&
             detailResume.licences.length > 0
-              ? detailResume.licences
+              ? detailResume.licences as unknown[]
               : Array.isArray(fallbackResume.licences)
-                ? fallbackResume.licences
+                ? fallbackResume.licences as unknown[]
                 : [],
         },
         enriched: true,
@@ -554,21 +581,21 @@ export function createJob51SearchExtractor(deps) {
    */
   function extract51JobResumes() {
     if (!Array.isArray(apiSnapshot.job51SearchRows)) return [];
-    return apiSnapshot.job51SearchRows.map((row, index) => {
-      const str = (v) => (v != null ? String(v) : "");
+    return (apiSnapshot.job51SearchRows as Record<string, unknown>[]).map((row, index) => {
+      const str = (v: unknown) => (v != null ? String(v) : "");
       const baseInfo =
-        row?.base_info && typeof row.base_info === "object" ? row.base_info : {};
+        row?.base_info && typeof row.base_info === "object" ? (row.base_info as Record<string, unknown>) : {};
       const jobIntentionInfo =
         row?.job_intention && typeof row.job_intention === "object"
-          ? row.job_intention
+          ? (row.job_intention as Record<string, unknown>)
           : {};
       const recentWorkInfo =
         row?.recent_work_info && typeof row.recent_work_info === "object"
-          ? row.recent_work_info
+          ? (row.recent_work_info as Record<string, unknown>)
           : {};
-      const workList = Array.isArray(row?.work_list) ? row.work_list : [];
+      const workList = Array.isArray(row?.work_list) ? (row.work_list as Record<string, unknown>[]) : [];
       const educationList = Array.isArray(row?.education_list)
-        ? row.education_list
+        ? (row.education_list as Record<string, unknown>[])
         : [];
       const latestWork =
         workList.find(
@@ -771,10 +798,11 @@ export function createJob51SearchExtractor(deps) {
 
   // ── Vue interaction (age filter) ────────────────────────────
 
-  function resolveJob51AgeFilterDropdown(ageBlock) {
+  function resolveJob51AgeFilterDropdown(ageBlock: unknown) {
+    const el = ageBlock as Element | null;
     const describedNode =
-      (ageBlock.getAttribute?.("aria-describedby") ? ageBlock : null) ||
-      ageBlock.querySelector("[aria-describedby]");
+      (el?.getAttribute?.("aria-describedby") ? el : null) ||
+      el?.querySelector("[aria-describedby]");
     const popoverId = describedNode?.getAttribute("aria-describedby")?.trim();
     if (popoverId) {
       const popover = win.document.getElementById(popoverId);
@@ -801,23 +829,24 @@ export function createJob51SearchExtractor(deps) {
     );
   }
 
-  async function ensureJob51AgeCustomRangeInputs(selectBox, { timeoutMs = 2000 } = {}) {
+  async function ensureJob51AgeCustomRangeInputs(selectBox: unknown, { timeoutMs = 2000 }: { timeoutMs?: number } = {}) {
+    const el = selectBox as Element | null;
     if (getCurrentSourceKey() !== SOURCE_KEYS.JOB51) {
-      return selectBox;
+      return el;
     }
     if (
-      selectBox.querySelector('input[placeholder="最低"]') &&
-      selectBox.querySelector('input[placeholder="最高"]')
+      el?.querySelector('input[placeholder="最低"]') &&
+      el?.querySelector('input[placeholder="最高"]')
     ) {
-      return selectBox;
+      return el;
     }
 
-    const customButton = Array.from(selectBox.querySelectorAll("button")).find(
+    const customButton = Array.from(el?.querySelectorAll("button") || []).find(
       (button) =>
         (button.textContent || "").replace(/\s+/g, "").trim() === "自定义",
     );
     if (!customButton) {
-      return selectBox;
+      return el;
     }
 
     activateElement(customButton);
@@ -825,20 +854,20 @@ export function createJob51SearchExtractor(deps) {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
       if (
-        selectBox.querySelector('input[placeholder="最低"]') &&
-        selectBox.querySelector('input[placeholder="最高"]')
+        el?.querySelector('input[placeholder="最低"]') &&
+        el?.querySelector('input[placeholder="最高"]')
       ) {
-        return selectBox;
+        return el;
       }
       await new Promise((resolve) => setTimeout(resolve, 120));
     }
 
-    return selectBox;
+    return el;
   }
 
   async function applyJob51AgeCustomRangeViaVue(
-    confirmButton,
-    { minAge, maxAge } = {},
+    confirmButton: unknown,
+    { minAge, maxAge }: { minAge?: number; maxAge?: number } = {},
   ) {
     if (getCurrentSourceKey() !== SOURCE_KEYS.JOB51 || !confirmButton) {
       return false;
@@ -847,7 +876,7 @@ export function createJob51SearchExtractor(deps) {
     const customRangeVm = findVueParentByName(
       confirmButton,
       "BaseSelectCustomRange",
-    );
+    ) as Record<string, unknown> | null;
     if (!customRangeVm || typeof customRangeVm.onClickOk !== "function") {
       return false;
     }
@@ -856,9 +885,9 @@ export function createJob51SearchExtractor(deps) {
       if (!customRangeVm.form || typeof customRangeVm.form !== "object") {
         customRangeVm.form = {};
       }
-      customRangeVm.form.leftValue =
+      (customRangeVm.form as Record<string, unknown>).leftValue =
         typeof minAge === "number" ? minAge : null;
-      customRangeVm.form.rightValue =
+      (customRangeVm.form as Record<string, unknown>).rightValue =
         typeof maxAge === "number" ? maxAge : null;
       await Promise.resolve(customRangeVm.onClickOk());
       return true;
@@ -871,7 +900,7 @@ export function createJob51SearchExtractor(deps) {
     }
   }
 
-  function normalizeAgeRequestValue(value) {
+  function normalizeAgeRequestValue(value: unknown) {
     if (typeof value === "number" && Number.isFinite(value)) {
       return value;
     }
@@ -886,8 +915,8 @@ export function createJob51SearchExtractor(deps) {
     return null;
   }
 
-  function hasMatchingJob51AgeSearchRequest(minAge, maxAge) {
-    const request = apiSnapshot.job51LastSearchRequest;
+  function hasMatchingJob51AgeSearchRequest(minAge: unknown, maxAge: unknown) {
+    const request = apiSnapshot.job51LastSearchRequest as Record<string, unknown> | null;
     if (!request || typeof request !== "object") {
       return false;
     }
@@ -900,8 +929,8 @@ export function createJob51SearchExtractor(deps) {
   }
 
   async function waitForJob51AgeFilterRefresh(
-    previousLastSearchAt,
-    { minAge, maxAge, timeoutMs = 5000 } = {},
+    previousLastSearchAt: string | undefined,
+    { minAge, maxAge, timeoutMs = 5000 }: { minAge?: number; maxAge?: number; timeoutMs?: number } = {},
   ) {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {

--- a/apps/browser-extension/src/lib/job5156-detail-utils.ts
+++ b/apps/browser-extension/src/lib/job5156-detail-utils.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { normalizeResumeText } from './resume-text-utils'
 
 const SECTION_SELECTORS = [
@@ -35,7 +34,7 @@ const DATE_LIKE_PATTERN = /(?:19|20)\d{2}(?:[-./年]\d{1,2})?|至今|目前|pres
  * @param {unknown} value
  * @returns {value is Element}
  */
-function isElement(value) {
+function isElement(value: unknown): value is Element {
   return Boolean(
     value
       && typeof value === 'object'
@@ -50,7 +49,7 @@ function isElement(value) {
  * @param {string} selector
  * @returns {Element[]}
  */
-function queryAllSafe(root, selector) {
+function queryAllSafe(root: Element, selector: string): Element[] {
   try {
     return Array.from(root.querySelectorAll(selector)).filter(isElement)
   } catch {
@@ -66,18 +65,18 @@ function queryAllSafe(root, selector) {
  * @returns {Element[]}
  */
 export function collectJob5156SectionItemsByHeading(
-  root,
-  headingPattern,
-  primarySelectors,
-  fallbackSelectors = [],
-) {
+  root: unknown,
+  headingPattern: RegExp,
+  primarySelectors: string[],
+  fallbackSelectors: string[] = [],
+): Element[] {
   if (!isElement(root)) {
     return []
   }
 
   const sections = queryAllSafe(root, SECTION_SELECTORS.join(', '))
   for (const section of sections) {
-    const currentSection = /** @type {Element} */ (section)
+    const currentSection = section as Element
     const heading = normalizeResumeText(currentSection.querySelector(HEADING_SELECTOR)?.textContent || '')
     if (!heading || !headingPattern.test(heading)) {
       continue
@@ -107,7 +106,7 @@ export function collectJob5156SectionItemsByHeading(
  * @param {string} value
  * @returns {boolean}
  */
-function isPlaceholderDurationText(value) {
+function isPlaceholderDurationText(value: string): boolean {
   const normalized = value.replace(/[\s·]+/g, '')
   return WORK_HISTORY_PLACEHOLDER_PATTERN.test(normalized)
 }
@@ -123,7 +122,16 @@ function isPlaceholderDurationText(value) {
  * } | null | undefined} entry
  * @returns {boolean}
  */
-export function isMeaningfulJob5156WorkHistoryEntry(entry) {
+export interface Job5156WorkHistoryEntry {
+  raw?: string;
+  companyName?: string;
+  jobTitle?: string;
+  description?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export function isMeaningfulJob5156WorkHistoryEntry(entry: Job5156WorkHistoryEntry | null | undefined): boolean {
   if (!entry) {
     return false
   }

--- a/apps/browser-extension/src/lib/job5156-extractor.ts
+++ b/apps/browser-extension/src/lib/job5156-extractor.ts
@@ -1,10 +1,36 @@
-// @ts-nocheck
 /**
  * Job5156-specific resume extraction utilities — page detection, DOM parsing,
  * API payload processing, and enrichment. All dependencies injected from content.ts.
  */
 
-export function createJob5156Extractor(deps) {
+export interface Job5156ExtractorDeps extends Record<string, unknown> {
+  getCurrentSourceKey: () => string;
+  SOURCE_KEYS: Record<string, string>;
+  apiSnapshot: Record<string, unknown>;
+  normalizeResumeText: (value: unknown) => string;
+  normalizeResumeMultilineText: (value: unknown) => string;
+  buildWorkHistoryRawParts: (parts: string[]) => string;
+  normalizeOptionalPositiveInt: (value: unknown) => number | null;
+  JOB5156_HOST: string;
+  JOB5156_PROFILE_URL_PREFIX: string;
+  JOB5156_DETAIL_FETCH_TIMEOUT_MS: number;
+  JOB5156_DETAIL_FETCH_CONCURRENCY: number;
+  DEFAULT_COLLECTION_GUARDS: unknown;
+  GUARD_FIELD_NAMES: string[];
+  GUARD_ARRAY_FIELD_NAMES: string[];
+  loadCollectionGuards: () => Promise<unknown>;
+  parseGuardFieldNames: (guards: unknown) => string[];
+  applyCollectionGuards: (resume: unknown, fields: string[]) => unknown;
+  isMeaningfulJob5156WorkHistoryEntry: (entry: unknown) => boolean;
+  collectJob5156SectionItemsByHeading: (
+    root: unknown,
+    headingPattern: RegExp,
+    primarySelectors: string[],
+    fallbackSelectors?: string[],
+  ) => Element[];
+}
+
+export function createJob5156Extractor(deps: Job5156ExtractorDeps) {
   const {
     getCurrentSourceKey,
     SOURCE_KEYS,
@@ -369,7 +395,7 @@ export function createJob5156Extractor(deps) {
     );
   }
 
-  function buildJob5156DetailResumeFromRoot(root, options = {}) {
+  function buildJob5156DetailResumeFromRoot(root, options: Record<string, unknown> = {}) {
     if (!(root instanceof Element)) return [];
 
     const {
@@ -609,7 +635,7 @@ export function createJob5156Extractor(deps) {
     };
   }
 
-  function normalizeJob5156ExtractOptions(options = {}) {
+  function normalizeJob5156ExtractOptions(options: Record<string, unknown> = {}) {
     return {
       pathname:
         typeof options.pathname === "string"
@@ -626,7 +652,7 @@ export function createJob5156Extractor(deps) {
     };
   }
 
-  function buildJob5156DetailResumeFromApiPayload(payload, options = {}) {
+  function buildJob5156DetailResumeFromApiPayload(payload, options: Record<string, unknown> = {}) {
     if (!payload || typeof payload !== "object") return [];
 
     const { pathname, profileUrl, extractedAt } =
@@ -844,7 +870,7 @@ export function createJob5156Extractor(deps) {
 
     const extractedAt = new Date().toISOString();
     const collectionGuards = await loadCollectionGuards();
-    const guardFields = parseGuardFieldNames(collectionGuards?.job5156);
+    const guardFields = parseGuardFieldNames((collectionGuards as Record<string, unknown>)?.job5156);
     const enriched = [];
 
     for (

--- a/apps/browser-extension/src/lib/resume-extractor.ts
+++ b/apps/browser-extension/src/lib/resume-extractor.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Selectors } from "./types";
 
 export interface ResumeWorkHistoryItem {
@@ -31,7 +30,7 @@ export interface ResumeData {
   source: string;
 }
 
-export interface ResumeExtractorDeps {
+export interface ResumeExtractorDeps extends Record<string, unknown> {
   SELECTORS: Selectors;
   JOB5156_HOST: string;
   doc: Document;
@@ -174,7 +173,7 @@ export function createResumeExtractor(deps: ResumeExtractorDeps) {
     return buildProfileUrlFromApiRow(apiRow);
   }
 
-  function buildSubmitMetadata(options = {}) {
+  function buildSubmitMetadata(options: Record<string, unknown> = {}) {
     const url = new URL(win.location.href);
     const sourceKey = getCurrentSourceKey();
     const keyword = normalizeKeyword(
@@ -188,7 +187,7 @@ export function createResumeExtractor(deps: ResumeExtractorDeps) {
     url.searchParams.delete(AUTO_MAX_PAGES_PARAM);
     url.searchParams.delete(SAMPLE_NAME_PARAM);
 
-    const metadata = {
+    const metadata: Record<string, unknown> = {
       sourceKey,
       sourceHost: url.hostname.toLowerCase(),
       sourceUrl: url.toString(),
@@ -199,7 +198,7 @@ export function createResumeExtractor(deps: ResumeExtractorDeps) {
     if (location) metadata.location = location;
     if (sourceKey === SOURCE_KEYS.SEEK) {
       metadata.collectionContext = buildSeekCollectionContext({
-        captureModeOverride: options.seekCaptureMode,
+        captureModeOverride: options.seekCaptureMode as string | undefined,
       });
     }
 

--- a/apps/browser-extension/src/lib/seek-extractor.ts
+++ b/apps/browser-extension/src/lib/seek-extractor.ts
@@ -1,10 +1,25 @@
-// @ts-nocheck
 /**
  * Seek-specific resume extraction utilities — page detection, snapshot query,
  * URL building, and auto-sync helpers. All dependencies injected from content.ts.
  */
 
-export function createSeekExtractor(deps) {
+export interface SeekExtractorDeps extends Record<string, unknown> {
+  getCurrentSourceKey: () => string;
+  SOURCE_KEYS: Record<string, string>;
+  apiSnapshot: Record<string, unknown>;
+  normalizeOptionalPositiveInt: (value: unknown) => number | null;
+  DEFAULT_SEEK_PAGE_SIZE: number;
+  SEEK_PROFILE_TYPE: string;
+  persistLatestAutoSyncSummary: () => void;
+  win: { location: { pathname: string; href: string; hostname: string; search: string } };
+  doc: { querySelector: (selector: string) => Element | null; querySelectorAll: (selector: string) => NodeListOf<Element> };
+  asHTMLElement: (el: unknown) => HTMLElement | null;
+  isDisabledPaginationControl: (el: unknown) => boolean;
+  waitForSeekProfileSnapshot: (matchId: string, options: { timeoutMs: number }) => Promise<void>;
+  SELECTORS: Record<string, string>;
+}
+
+export function createSeekExtractor(deps: SeekExtractorDeps) {
   const {
     getCurrentSourceKey,
     SOURCE_KEYS,
@@ -21,6 +36,8 @@ export function createSeekExtractor(deps) {
     isDisabledPaginationControl,
     // Detail enrichment deps
     waitForSeekProfileSnapshot,
+    // Pagination selectors
+    SELECTORS,
   } = deps;
 
   function isSeekProfilePage() {
@@ -74,10 +91,10 @@ export function createSeekExtractor(deps) {
       return hasSeekProfileSnapshot() ? 1 : 0;
     }
     if (hasSeekTalentSearchSnapshot()) {
-      return apiSnapshot.seekTalentSearch.length;
+      return (apiSnapshot.seekTalentSearch as unknown[]).length;
     }
     return hasSeekListSnapshot()
-      ? apiSnapshot.seekRecommendedCandidates.length
+      ? (apiSnapshot.seekRecommendedCandidates as unknown[]).length
       : 0;
   }
 
@@ -85,19 +102,20 @@ export function createSeekExtractor(deps) {
     return getSeekSnapshotCount() > 0;
   }
 
-  function getSeekCandidateIdentity(candidate) {
+  function getSeekCandidateIdentity(candidate: unknown) {
+    const rec = candidate as Record<string, unknown> | null | undefined;
     const profileId =
-      candidate?.profileId != null ? String(candidate.profileId) : "";
+      rec?.profileId != null ? String(rec.profileId) : "";
     return {
       profileId,
       profileType:
-        typeof candidate?.profileType === "string"
-          ? candidate.profileType
+        typeof rec?.profileType === "string"
+          ? rec.profileType
           : SEEK_PROFILE_TYPE,
     };
   }
 
-  function buildSeekProfileUrl(profileId, jobId) {
+  function buildSeekProfileUrl(profileId: string, jobId: string | undefined) {
     if (!profileId) return "";
     const hostname = window.location.hostname.toLowerCase();
     if (jobId) {
@@ -106,7 +124,7 @@ export function createSeekExtractor(deps) {
     return `https://${hostname}/candidates/${encodeURIComponent(profileId)}`;
   }
 
-  function buildSeekNameSearchUrl(name, market, roleTitles) {
+  function buildSeekNameSearchUrl(name: string, market: string | undefined, roleTitles: string | undefined) {
     const trimmed = typeof name === "string" ? name.trim() : "";
     if (!trimmed) return "";
     const trimmedRoleTitles = typeof roleTitles === "string" ? roleTitles.trim() : "";
@@ -114,7 +132,7 @@ export function createSeekExtractor(deps) {
     return `https://${window.location.hostname.toLowerCase()}/talentsearch/profiles/search?searchQuery=${encodeURIComponent(trimmed)}&market=${encodeURIComponent(market || "MY")}&pageNumber=1${roleTitlesParam}`;
   }
 
-  function normalizeSeekLocationLabel(value) {
+  function normalizeSeekLocationLabel(value: unknown) {
     return String(value || "")
       .toLowerCase()
       .replace(/\bmalaysia\b/g, "")
@@ -148,15 +166,15 @@ export function createSeekExtractor(deps) {
   }
 
   function getSeekRecommendedRequest() {
-    return apiSnapshot.seekRecommendedRequest;
+    return apiSnapshot.seekRecommendedRequest as Record<string, unknown> | null | undefined;
   }
 
   function getSeekTalentSearchRequest() {
-    return apiSnapshot.seekTalentSearchRequest;
+    return apiSnapshot.seekTalentSearchRequest as Record<string, unknown> | null | undefined;
   }
 
   function getSeekProfileRequest() {
-    return apiSnapshot.seekProfileRequest || apiSnapshot.seekRecommendedRequest;
+    return (apiSnapshot.seekProfileRequest || apiSnapshot.seekRecommendedRequest) as Record<string, unknown> | null | undefined;
   }
 
   function getSeekAutoSyncHelpers() {
@@ -164,7 +182,7 @@ export function createSeekExtractor(deps) {
     return helpers && typeof helpers === "object" ? helpers : null;
   }
 
-  function resolveSeekAutoSyncPageSize(options = {}) {
+  function resolveSeekAutoSyncPageSize(options: Record<string, unknown> = {}) {
     const { requestedPageSize, currentPageCandidateCount, fallbackPageSize = DEFAULT_SEEK_PAGE_SIZE } = options;
     const helpers = getSeekAutoSyncHelpers();
     if (typeof helpers?.resolveSeekAutoSyncPageSize === "function") {
@@ -178,7 +196,7 @@ export function createSeekExtractor(deps) {
     );
   }
 
-  function resolveSeekAutoSyncPageWindow(options = {}) {
+  function resolveSeekAutoSyncPageWindow(options: Record<string, unknown> = {}) {
     const { startPage, limit, maxPages, requestedPageSize, currentPageCandidateCount } = options;
     const helpers = getSeekAutoSyncHelpers();
     if (typeof helpers?.resolveSeekAutoSyncPageWindow === "function") {
@@ -200,7 +218,7 @@ export function createSeekExtractor(deps) {
     return { startPage: normalizedStartPage, targetPageEnd: allowedPageCount ? normalizedStartPage + allowedPageCount - 1 : null, effectivePageSize, limitPageCount, maxPages: normalizedMaxPages, allowedPageCount };
   }
 
-  function isSeekAutoSyncPageWindowReached(pageWindow, currentPage) {
+  function isSeekAutoSyncPageWindowReached(pageWindow: Record<string, unknown> | null, currentPage: unknown) {
     const helpers = getSeekAutoSyncHelpers();
     if (typeof helpers?.isSeekAutoSyncPageWindowReached === "function") {
       return helpers.isSeekAutoSyncPageWindowReached({ currentPage, targetPageEnd: pageWindow?.targetPageEnd });
@@ -210,7 +228,7 @@ export function createSeekExtractor(deps) {
     return !!(normalizedCurrentPage && targetPageEnd && normalizedCurrentPage >= targetPageEnd);
   }
 
-  function resolveSeekAutoSyncCurrentPageSelection(options = {}) {
+  function resolveSeekAutoSyncCurrentPageSelection(options: Record<string, unknown> = {}) {
     const helpers = getSeekAutoSyncHelpers();
     if (typeof helpers?.resolveSeekAutoSyncCurrentPageSelection === "function") {
       return helpers.resolveSeekAutoSyncCurrentPageSelection(options);
@@ -224,19 +242,20 @@ export function createSeekExtractor(deps) {
   }
 
   function getSeekRequestedPageSize() {
-    const requestInput = getSeekRecommendedRequest()?.variables?.input;
+    const variables = getSeekRecommendedRequest()?.variables as Record<string, unknown> | undefined;
+    const requestInput = variables?.input as Record<string, unknown> | undefined;
     return normalizeOptionalPositiveInt(requestInput?.size);
   }
 
   function getSeekCurrentCandidateCount() {
     if (getCurrentSeekMode() === "talentsearch") {
-      return Array.isArray(apiSnapshot.seekTalentSearch) ? apiSnapshot.seekTalentSearch.length : 0;
+      return Array.isArray(apiSnapshot.seekTalentSearch) ? (apiSnapshot.seekTalentSearch as unknown[]).length : 0;
     }
-    return Array.isArray(apiSnapshot.seekRecommendedCandidates) ? apiSnapshot.seekRecommendedCandidates.length : 0;
+    return Array.isArray(apiSnapshot.seekRecommendedCandidates) ? (apiSnapshot.seekRecommendedCandidates as unknown[]).length : 0;
   }
 
-  function setSeekAutoSyncWindowAttributes(pageWindow) {
-    const attrs = [
+  function setSeekAutoSyncWindowAttributes(pageWindow: Record<string, unknown> | null) {
+    const attrs: [string, unknown][] = [
       ["data-tr-auto-sync-target-start", pageWindow?.startPage],
       ["data-tr-auto-sync-target-end", pageWindow?.targetPageEnd],
       ["data-tr-auto-sync-effective-page-size", pageWindow?.effectivePageSize],
@@ -253,8 +272,8 @@ export function createSeekExtractor(deps) {
     persistLatestAutoSyncSummary();
   }
 
-  function setSeekAutoSyncSelectionAttributes(selection) {
-    const attrs = [
+  function setSeekAutoSyncSelectionAttributes(selection: Record<string, unknown> | null) {
+    const attrs: [string, unknown][] = [
       ["data-tr-auto-sync-selected-count", selection?.selectedCount],
       ["data-tr-auto-sync-remaining-capacity", selection?.remainingCapacity],
     ];
@@ -270,7 +289,7 @@ export function createSeekExtractor(deps) {
     persistLatestAutoSyncSummary();
   }
 
-  function findSeekProfileTrigger(profileId) {
+  function findSeekProfileTrigger(profileId: string) {
     if (!profileId) return null;
     const candidateLinks = Array.from(document.querySelectorAll("a[href]"));
     return candidateLinks.find((link) => {
@@ -287,12 +306,13 @@ export function createSeekExtractor(deps) {
   // ============================================================================
 
   function extractSeekProfileResume() {
-    const profile = apiSnapshot.seekProfile;
+    const profile = apiSnapshot.seekProfile as Record<string, unknown> | null;
     if (!profile || typeof profile !== "object") return [];
 
     const request = getSeekProfileRequest();
-    const requestInput = request?.variables?.input;
-    const language = request?.variables?.language;
+    const variables = request?.variables as Record<string, unknown> | undefined;
+    const requestInput = variables?.input as Record<string, unknown> | undefined;
+    const language = variables?.language;
     const profileUrl = new URL(win.location.href);
     const jobIdFromUrl = normalizeOptionalPositiveInt(
       profileUrl.searchParams.get("jobId"),
@@ -369,8 +389,8 @@ export function createSeekExtractor(deps) {
         ? profile.currentSubindustry.trim()
         : "";
     const rightToWork =
-      typeof profile.rightToWork?.label === "string"
-        ? profile.rightToWork.label.trim()
+      typeof (profile.rightToWork as Record<string, unknown> | undefined)?.label === "string"
+        ? ((profile.rightToWork as Record<string, unknown>).label as string).trim()
         : "";
     const education = profileEducation[0]?.qualification || "";
     const pageNumber =
@@ -393,7 +413,7 @@ export function createSeekExtractor(deps) {
         education,
         location: currentLocation,
         jobIntention: currentJobTitle,
-        expectedSalary: formatSeekExpectedSalary(profile.salary?.expected),
+        expectedSalary: formatSeekExpectedSalary((profile.salary as Record<string, unknown> | undefined)?.expected),
         selfIntro: resumeSnippet,
         workHistory,
         profileEducation:
@@ -405,8 +425,8 @@ export function createSeekExtractor(deps) {
         currentIndustry: currentIndustry || undefined,
         currentSubindustry: currentSubindustry || undefined,
         rightToWork: rightToWork || undefined,
-        noticePeriodDays: Number.isFinite(profile.noticePeriodDays)
-          ? profile.noticePeriodDays
+        noticePeriodDays: Number.isFinite(profile.noticePeriodDays as number)
+          ? (profile.noticePeriodDays as number)
           : undefined,
         extractedAt: new Date().toISOString(),
         pageIndex: 1,
@@ -421,7 +441,7 @@ export function createSeekExtractor(deps) {
     ];
   }
 
-  function buildSeekCollectionContext(options = {}) {
+  function buildSeekCollectionContext(options: Record<string, unknown> = {}) {
     /** @type {{ captureModeOverride?: string }} */
     const normalizedOptions =
       typeof options === "object" && options ? options : {};
@@ -432,14 +452,15 @@ export function createSeekExtractor(deps) {
       ? captureModeOverride === "graphql-profile"
       : isSeekProfileMode();
     const talentSearchRequest = isTalentSearchList
-      ? apiSnapshot.seekTalentSearchRequest
+      ? apiSnapshot.seekTalentSearchRequest as Record<string, unknown> | null
       : null;
     const request = talentSearchRequest ??
       (useProfileMode
         ? getSeekProfileRequest()
         : getSeekRecommendedRequest());
-    const requestInput = request?.variables?.input;
-    const language = request?.variables?.language;
+    const variables = request?.variables as Record<string, unknown> | undefined;
+    const requestInput = variables?.input as Record<string, unknown> | undefined;
+    const language = variables?.language;
     const url = new URL(win.location.href);
     const pageNumberFromUrl = normalizeOptionalPositiveInt(
       url.searchParams.get("pageNumber"),
@@ -462,7 +483,7 @@ export function createSeekExtractor(deps) {
           : "GetTalentSearchRecommendedCandidates";
 
     /** @type {Record<string, unknown>} */
-    const context = {
+    const context: Record<string, unknown> = {
       captureMode,
       operation: apiSnapshot.lastOperationName || defaultOperation,
       profileType: SEEK_PROFILE_TYPE,
@@ -495,7 +516,7 @@ export function createSeekExtractor(deps) {
     return context;
   }
 
-  function getSeekPayloadData(payload, kind) {
+  function getSeekPayloadData(payload: unknown, kind: string) {
     if (!payload) return null;
 
     if (Array.isArray(payload)) {
@@ -525,8 +546,9 @@ export function createSeekExtractor(deps) {
     }
 
     if (payload && typeof payload === "object") {
-      return payload.data && typeof payload.data === "object"
-        ? payload.data
+      const obj = payload as Record<string, unknown>;
+      return obj.data && typeof obj.data === "object"
+        ? obj.data
         : payload;
     }
 
@@ -543,11 +565,12 @@ export function createSeekExtractor(deps) {
    */
   function extractSeekResumes() {
     const candidates = Array.isArray(apiSnapshot.seekRecommendedCandidates)
-      ? apiSnapshot.seekRecommendedCandidates
+      ? (apiSnapshot.seekRecommendedCandidates as Record<string, unknown>[])
       : [];
     const request = getSeekRecommendedRequest();
-    const requestInput = request?.variables?.input;
-    const language = request?.variables?.language;
+    const variables = request?.variables as Record<string, unknown> | undefined;
+    const requestInput = variables?.input as Record<string, unknown> | undefined;
+    const language = variables?.language;
     const url = new URL(win.location.href);
     const jobIdFromUrl = normalizeOptionalPositiveInt(
       url.searchParams.get("jobId"),
@@ -583,7 +606,7 @@ export function createSeekExtractor(deps) {
         typeof candidate?.lastModifiedDate === "string"
           ? candidate.lastModifiedDate
           : "";
-      const salary = candidate?.salary;
+      const salary = candidate?.salary as Record<string, unknown> | undefined;
       const salaryParts = [salary?.minLabel, salary?.maxLabel].filter(
         (value) => typeof value === "string" && value.trim(),
       );
@@ -628,11 +651,12 @@ export function createSeekExtractor(deps) {
    */
   function extractSeekTalentSearchResumes() {
     const candidates = Array.isArray(apiSnapshot.seekTalentSearch)
-      ? apiSnapshot.seekTalentSearch
+      ? (apiSnapshot.seekTalentSearch as Record<string, unknown>[])
       : [];
     const request = getSeekTalentSearchRequest();
-    const requestInput = request?.variables?.input;
-    const language = request?.variables?.language;
+    const variables = request?.variables as Record<string, unknown> | undefined;
+    const requestInput = variables?.input as Record<string, unknown> | undefined;
+    const language = variables?.language;
     const url = new URL(win.location.href);
     const currentPage =
       typeof requestInput?.pageNumber === "number"
@@ -791,9 +815,10 @@ export function createSeekExtractor(deps) {
   // Seek Detail Enrichment
   // ============================================================================
 
-  async function enrichSingleSeekResumeWithDetail(resume, cachedHeadings) {
+  async function enrichSingleSeekResumeWithDetail(resume: unknown, cachedHeadings: unknown) {
+    const rec = resume as Record<string, unknown> | null | undefined;
     const profileId =
-      typeof resume?.profileId === "string" ? resume.profileId.trim() : "";
+      typeof rec?.profileId === "string" ? rec.profileId.trim() : "";
     if (!profileId) {
       return resume;
     }
@@ -809,16 +834,16 @@ export function createSeekExtractor(deps) {
     try {
       trigger.click();
       // For talentsearch, match by profileGuid (UUID); for recommended, match by numeric profileId
-      const matchId = isTalentSearch ? resume.seekProfileGuid || profileId : profileId;
+      const matchId = isTalentSearch ? (rec?.seekProfileGuid as string) || profileId : profileId;
       await waitForSeekProfileSnapshot(matchId, { timeoutMs: 12000 });
-      const [detailResume] = extractSeekProfileResume();
+      const [detailResume] = extractSeekProfileResume() as (Record<string, unknown> | undefined)[];
       if (!detailResume) {
         return resume;
       }
       // For talentsearch, verify the detail profile matches by profileGuid or profileId
       if (isTalentSearch) {
-        const detailGuid = detailResume.seekProfileGuid || "";
-        const detailProfileId = detailResume.profileId || "";
+        const detailGuid = (detailResume.seekProfileGuid as string) || "";
+        const detailProfileId = (detailResume.profileId as string) || "";
         if (detailGuid !== profileId && detailProfileId !== profileId) {
           return resume;
         }
@@ -839,7 +864,7 @@ export function createSeekExtractor(deps) {
     }
   }
 
-  async function enrichSeekResumesWithDetail(resumes) {
+  async function enrichSeekResumesWithDetail(resumes: unknown[]) {
     if (!Array.isArray(resumes) || resumes.length === 0) return [];
     if (getCurrentSourceKey() !== SOURCE_KEYS.SEEK) return resumes;
     if (isSeekProfileMode()) return resumes;
@@ -866,7 +891,7 @@ export function createSeekExtractor(deps) {
    * element clicked via SPA event handlers. Find the card matching this profileId
    * (UUID) by checking data attributes or card index.
    */
-  function findSeekTalentSearchCardTrigger(profileId, resume, cachedHeadings) {
+  function findSeekTalentSearchCardTrigger(profileId: string, resume: unknown, cachedHeadings: unknown) {
     if (!profileId) return null;
     // Try matching by data-tr-candidate-id attribute (set during extraction)
     const byAttr = doc.querySelector(
@@ -875,9 +900,9 @@ export function createSeekExtractor(deps) {
     if (byAttr instanceof HTMLElement) return byAttr;
     // Fallback: match heading elements that contain the candidate name.
     // Talentsearch cards use [data-role="heading"] for the candidate name.
-    const candidateName = typeof resume?.name === "string" ? resume.name.trim() : "";
+    const candidateName = typeof (resume as Record<string, unknown> | null)?.name === "string" ? ((resume as Record<string, unknown>).name as string).trim() : "";
     if (candidateName) {
-      const headings = cachedHeadings ||
+      const headings = (cachedHeadings as Element[] | null) ||
         Array.from(doc.querySelectorAll('[data-role="heading"]'));
       const match = headings.find((h) => {
         const text = (h.textContent || "").trim();
@@ -888,24 +913,27 @@ export function createSeekExtractor(deps) {
     return null;
   }
 
-  function mergeSeekListResumeWithDetail(baseResume, detailResume, isTalentSearch = false) {
+  function mergeSeekListResumeWithDetail(baseResume: unknown, detailResume: unknown, isTalentSearch = false) {
+    const base = baseResume as Record<string, unknown>;
+    const detail = detailResume as Record<string, unknown>;
     if (!detailResume || typeof detailResume !== "object") {
       return baseResume;
     }
 
     // For talentsearch: if V3 detail provides a numeric profileId, use it for
     // profileUrl construction but preserve the UUID seekProfileGuid
-    const seekProfileGuid = baseResume.seekProfileGuid || detailResume.seekProfileGuid || undefined;
-    const numericProfileId = isTalentSearch && detailResume.profileId && /^\d+$/.test(detailResume.profileId)
-      ? detailResume.profileId
+    const seekProfileGuid = base.seekProfileGuid || detail.seekProfileGuid || undefined;
+    const numericProfileId = isTalentSearch && detail.profileId && /^\d+$/.test(String(detail.profileId))
+      ? String(detail.profileId)
       : undefined;
 
     // If we got a numeric profileId from V3 detail, update the profileUrl
-    let profileUrl = detailResume.profileUrl || baseResume.profileUrl;
+    let profileUrl = detail.profileUrl || base.profileUrl;
     if (numericProfileId) {
       // Derive jobId from the current page URL or API request for recommended URL format
       const seekRequest = getSeekTalentSearchRequest();
-      const requestJobId = seekRequest?.variables?.input?.jobId;
+      const seekVariables = seekRequest?.variables as Record<string, unknown> | undefined;
+      const requestJobId = (seekVariables?.input as Record<string, unknown> | undefined)?.jobId;
       const urlJobId = normalizeOptionalPositiveInt(
         new URL(win.location.href).searchParams.get("jobId"),
       );
@@ -918,24 +946,25 @@ export function createSeekExtractor(deps) {
     }
 
     return {
-      ...baseResume,
-      ...detailResume,
+      ...base,
+      ...detail,
       ...(seekProfileGuid ? { seekProfileGuid } : {}),
       ...(numericProfileId ? { profileId: numericProfileId } : {}),
       ...(profileUrl ? { profileUrl } : {}),
-      pageIndex: baseResume.pageIndex,
-      pageNumber: baseResume.pageNumber,
-      extractedAt: baseResume.extractedAt,
-      source: baseResume.source,
-      searchProfileId: detailResume.searchProfileId || baseResume.searchProfileId,
+      pageIndex: base.pageIndex,
+      pageNumber: base.pageNumber,
+      extractedAt: base.extractedAt,
+      source: base.source,
+      searchProfileId: detail.searchProfileId || base.searchProfileId,
     };
   }
 
-  function formatSeekExpectedSalary(expectedSalary) {
+  function formatSeekExpectedSalary(expectedSalary: unknown) {
     if (!expectedSalary || typeof expectedSalary !== "object") return "";
 
-    const amounts = Array.isArray(expectedSalary.amount)
-      ? expectedSalary.amount
+    const salary = expectedSalary as Record<string, unknown>;
+    const amounts = Array.isArray(salary.amount)
+      ? (salary.amount as Record<string, unknown>[])
       : [];
     const preferredFrequencies = ["MONTHLY", "ANNUAL", "HOURLY"];
     const amount =
@@ -953,8 +982,8 @@ export function createSeekExtractor(deps) {
       ? new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(value)
       : "";
     const currency =
-      typeof expectedSalary.currency === "string"
-        ? expectedSalary.currency.trim()
+      typeof salary.currency === "string"
+        ? salary.currency.trim()
         : "";
     const period =
       amount.frequency === "ANNUAL"
@@ -969,20 +998,21 @@ export function createSeekExtractor(deps) {
     return prefix ? `${prefix}${period}` : "";
   }
 
-  function buildSeekWorkHistoryItem(item) {
+  function buildSeekWorkHistoryItem(item: unknown) {
     if (!item || typeof item !== "object") return null;
 
+    const rec = item as Record<string, unknown>;
     const companyName =
-      typeof item.companyName === "string" ? item.companyName.trim() : "";
+      typeof rec.companyName === "string" ? rec.companyName.trim() : "";
     const jobTitle =
-      typeof item.jobTitle === "string" ? item.jobTitle.trim() : "";
+      typeof rec.jobTitle === "string" ? rec.jobTitle.trim() : "";
     const description =
-      typeof item.description === "string" ? item.description.trim() : "";
+      typeof rec.description === "string" ? rec.description.trim() : "";
     const startDate =
-      typeof item.startDate === "string" ? item.startDate.trim() : "";
-    const endDate = typeof item.endDate === "string" ? item.endDate.trim() : "";
+      typeof rec.startDate === "string" ? rec.startDate.trim() : "";
+    const endDate = typeof rec.endDate === "string" ? rec.endDate.trim() : "";
     const durationLabel =
-      typeof item.durationLabel === "string" ? item.durationLabel.trim() : "";
+      typeof rec.durationLabel === "string" ? rec.durationLabel.trim() : "";
     const raw = [jobTitle, companyName, durationLabel]
       .filter(Boolean)
       .join(" · ");
@@ -999,21 +1029,22 @@ export function createSeekExtractor(deps) {
     };
   }
 
-  function buildSeekProfileEducationItem(item) {
+  function buildSeekProfileEducationItem(item: unknown) {
     if (!item || typeof item !== "object") return null;
 
+    const rec = item as Record<string, unknown>;
     const institution =
-      typeof item.institutionName === "string" ? item.institutionName.trim() : "";
+      typeof rec.institutionName === "string" ? rec.institutionName.trim() : "";
     const qualification =
-      typeof item.qualificationName === "string"
-        ? item.qualificationName.trim()
+      typeof rec.qualificationName === "string"
+        ? rec.qualificationName.trim()
         : "";
-    const completionYear = Number.isFinite(item.completionYear)
-      ? String(item.completionYear)
+    const completionYear = Number.isFinite(rec.completionYear)
+      ? String(rec.completionYear)
       : "";
     const completionMonth =
-      Number.isFinite(item.completionMonth) && item.completionMonth > 0
-        ? String(item.completionMonth).padStart(2, "0")
+      Number.isFinite(rec.completionMonth) && (rec.completionMonth as number) > 0
+        ? String(rec.completionMonth).padStart(2, "0")
         : "";
     const endDate = completionYear
       ? completionMonth

--- a/apps/browser-extension/src/lib/snapshot-collector.ts
+++ b/apps/browser-extension/src/lib/snapshot-collector.ts
@@ -1,10 +1,45 @@
-// @ts-nocheck
 /**
  * Snapshot collector — API state management, message hook installation,
  * and snapshot payload collection. Dependencies injected from content.ts.
  */
 
-export function createSnapshotCollector(deps) {
+export interface SnapshotCollectorDeps extends Record<string, unknown> {
+  apiSnapshot: Record<string, unknown>;
+  getCurrentSourceKey: () => string;
+  SOURCE_KEYS: Record<string, string>;
+  isJob51DetailPage: () => boolean;
+  isJob51DetailReady: () => boolean;
+  getSeekSnapshotCount: () => number;
+  normalizeJob51AuthContext: (headers: unknown, request: unknown) => Record<string, unknown> | null;
+  getJob51TotalFromPayload: (payload: unknown) => number | null;
+  getJob51ResumeRows: (payload: unknown) => unknown[];
+  getSeekPayloadData: (payload: unknown, kind: string) => Record<string, unknown> | null;
+  chrome: Record<string, unknown>;
+  normalizeCollectionLimit: (value: unknown) => number;
+  pipelineState: Record<string, unknown>;
+  waitForExtractionData: (options?: unknown) => Promise<unknown>;
+  isSeekProfileMode: () => boolean;
+  resolveSeekAutoSyncPageWindow: (options: Record<string, unknown>) => unknown;
+  getSeekRequestedPageSize: () => number;
+  getSeekCurrentCandidateCount: () => number;
+  resolveSeekAutoSyncCurrentPageSelection: (options: Record<string, unknown>) => Record<string, unknown>;
+  extractResumes: () => unknown[];
+  enrich51JobSearchResumesWithDetail: (resumes: unknown[]) => Promise<unknown[]>;
+  enrichJob5156SearchResumesWithDetail: (resumes: unknown[]) => Promise<unknown[]>;
+  isJob5156DetailPage: () => boolean;
+  enrichSeekResumesWithDetail: (resumes: unknown[]) => Promise<unknown[]>;
+  getPaginationInfo: () => { currentPage: number; totalPages: number; totalItems: number; hasNextPage: boolean };
+  isSeekAutoSyncPageWindowReached: (pageWindow: unknown, currentPage: number) => boolean;
+  waitForPagination: (options?: unknown) => Promise<unknown>;
+  clearCapturedResultsForNextPage: () => void;
+  goToNextPageInternal: () => unknown;
+  waitForPageTransition: (options: Record<string, unknown>) => Promise<unknown>;
+  buildSubmitMetadata: (options?: unknown) => Record<string, unknown>;
+  delay: (ms: number) => Promise<void>;
+  document: Document;
+}
+
+export function createSnapshotCollector(deps: SnapshotCollectorDeps) {
   const {
     apiSnapshot,
     getCurrentSourceKey,
@@ -45,14 +80,14 @@ export function createSnapshotCollector(deps) {
 
   function getApiSnapshotCount() {
     if (Array.isArray(apiSnapshot.searchRows)) {
-      return apiSnapshot.searchRows.length;
+      return (apiSnapshot.searchRows as unknown[]).length;
     }
     if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
       if (isJob51DetailPage()) {
         return isJob51DetailReady() ? 1 : 0;
       }
       return Array.isArray(apiSnapshot.job51SearchRows)
-        ? apiSnapshot.job51SearchRows.length
+        ? (apiSnapshot.job51SearchRows as unknown[]).length
         : 0;
     }
     if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
@@ -63,7 +98,7 @@ export function createSnapshotCollector(deps) {
 
   // ── normalizeSnapshotCollectOptions ──
 
-  function normalizeSnapshotCollectOptions(options = {}) {
+  function normalizeSnapshotCollectOptions(options: Record<string, unknown> = {}) {
     /** @type {{ limit?: number; maxPages?: number; allowEmpty?: boolean }} */
     const normalizedOptions =
       typeof options === "object" && options ? options : {};
@@ -83,8 +118,8 @@ export function createSnapshotCollector(deps) {
         return;
       }
       if (doc.documentElement.hasAttribute("data-tr-resume-hook")) return;
-      const script = doc.createElement("script");
-      script.src = chrome.runtime.getURL("page-hook.js");
+      const script = doc.createElement("script") as HTMLScriptElement;
+      script.src = (chrome as { runtime: { getURL: (path: string) => string } }).runtime.getURL("page-hook.js");
       script.async = false;
       script.setAttribute("data-tr-resume-hook", "true");
       script.onload = () => script.remove();
@@ -109,17 +144,17 @@ export function createSnapshotCollector(deps) {
     }
   }
 
-  function mergeJob51AuthContext(requestHeaders, request) {
+  function mergeJob51AuthContext(requestHeaders: unknown, request: unknown) {
     const authContext = normalizeJob51AuthContext(requestHeaders, request);
     if (authContext) {
       apiSnapshot.job51AuthContext = {
-        ...(apiSnapshot.job51AuthContext || {}),
+        ...((apiSnapshot.job51AuthContext || {}) as Record<string, unknown>),
         ...authContext,
       };
     }
   }
 
-  function updateApiSnapshot(message) {
+  function updateApiSnapshot(message: Record<string, unknown>) {
     const {
       kind,
       payload,
@@ -129,26 +164,28 @@ export function createSnapshotCollector(deps) {
       request,
       requestHeaders,
     } = message;
+    const p = (payload ?? {}) as Record<string, unknown>;
+    const pd = (p.data ?? {}) as Record<string, unknown>;
     apiSnapshot.lastUpdatedAt = new Date().toISOString();
-    if (url) apiSnapshot.lastUrl = url;
-    apiSnapshot.lastSourceKey = sourceKey || null;
-    apiSnapshot.lastOperationName = operationName || null;
+    if (url) apiSnapshot.lastUrl = url as string;
+    apiSnapshot.lastSourceKey = sourceKey as string || null;
+    apiSnapshot.lastOperationName = operationName as string || null;
 
     try {
-      doc.documentElement.setAttribute("data-tr-api-last", kind);
+      doc.documentElement.setAttribute("data-tr-api-last", kind as string);
       doc.documentElement.setAttribute(
         "data-tr-api-updated",
-        apiSnapshot.lastUpdatedAt,
+        apiSnapshot.lastUpdatedAt as string,
       );
       if (sourceKey) {
-        doc.documentElement.setAttribute("data-tr-source-key", sourceKey);
+        doc.documentElement.setAttribute("data-tr-source-key", sourceKey as string);
       }
     } catch {
       // ignore
     }
 
     if (kind === "search") {
-      const rows = payload?.data?.resumePage?.rows;
+      const rows = ((pd.resumePage ?? {}) as Record<string, unknown>)?.rows;
       if (Array.isArray(rows)) {
         apiSnapshot.searchRows = rows;
         apiSnapshot.lastSearchAt = apiSnapshot.lastUpdatedAt;
@@ -180,21 +217,22 @@ export function createSnapshotCollector(deps) {
       return;
     }
     if (kind === "attach") {
-      apiSnapshot.attachInfo = payload?.data?.attachResumeInfo || null;
+      apiSnapshot.attachInfo = pd.attachResumeInfo || null;
       return;
     }
     if (kind === "chat") {
-      apiSnapshot.chatInfo = payload?.data?.chatInfo || null;
+      apiSnapshot.chatInfo = pd.chatInfo || null;
       return;
     }
     if (kind === "insight") {
       apiSnapshot.insightInfo =
-        payload?.data?.talentInsightInfo || payload?.data || null;
+        pd.talentInsightInfo || p.data || null;
       return;
     }
     if (kind === "seekTalentSearch") {
       const data = getSeekPayloadData(payload, kind);
-      const result = data?.talentSearchProfilesNaturalLanguageSearch?.result;
+      const tsResult = data?.talentSearchProfilesNaturalLanguageSearch as Record<string, unknown> | undefined;
+      const result = tsResult?.result as Record<string, unknown> | undefined;
       const edges = Array.isArray(result?.edges) ? result.edges : null;
       if (edges) {
         // Unwrap Relay edges into bare nodes — downstream code expects an array
@@ -211,9 +249,11 @@ export function createSnapshotCollector(deps) {
     }
     if (kind === "seekRecommendedCandidates") {
       const data = getSeekPayloadData(payload, kind);
+      const v2 = data?.talentSearchRecommendedCandidatesV2 as Record<string, unknown> | undefined;
+      const legacy = data?.getTalentSearchRecommendedCandidates as Record<string, unknown> | undefined;
       const candidates =
-        data?.talentSearchRecommendedCandidatesV2?.items ||
-        data?.getTalentSearchRecommendedCandidates?.candidates;
+        v2?.items ||
+        legacy?.candidates;
       if (Array.isArray(candidates)) {
         apiSnapshot.seekRecommendedCandidates = candidates;
         apiSnapshot.seekRecommendedRequest = request || null;
@@ -250,12 +290,12 @@ export function createSnapshotCollector(deps) {
    *   allowEmpty?: boolean;
    * } | null | undefined} [options]
    */
-  async function collectSnapshotPayload(options = {}) {
+  async function collectSnapshotPayload(options: Record<string, unknown> = {}) {
     const { limit, maxPages, allowEmpty } =
       normalizeSnapshotCollectOptions(options);
     const sourceKey = getCurrentSourceKey();
     const job51BackfillRunId =
-      sourceKey === SOURCE_KEYS.JOB51 ? pipelineState.runId + 1 : null;
+      sourceKey === SOURCE_KEYS.JOB51 ? (pipelineState.runId as number) + 1 : null;
 
     if (sourceKey === SOURCE_KEYS.JOB51) {
       pipelineState.runId = job51BackfillRunId;
@@ -270,12 +310,12 @@ export function createSnapshotCollector(deps) {
       throw new Error(`Unsupported source for snapshot collection: ${sourceKey}`);
     }
 
-    let collectedResumes = [];
+    let collectedResumes: unknown[] = [];
     let pagesVisited = 0;
     let stopReason = "completed";
-    let seekStartPage = null;
+    let seekStartPage: number | null = null;
     let lastPageResumeCount = 0;
-    let finalPagination;
+    let finalPagination: { currentPage: number; totalPages: number; totalItems: number; hasNextPage: boolean };
 
     while (true) {
       finalPagination = getPaginationInfo();
@@ -316,14 +356,14 @@ export function createSnapshotCollector(deps) {
                 : false,
           };
 
-      if (pageSelection.limitAlreadyReached) {
+      if (pageSelection.limitAlreadyReached as boolean) {
         stopReason = "limit-reached";
         break;
       }
 
       let pageResumes = extractResumes();
       const hitLimitWithinPage = isSeekListPage
-        ? pageSelection.hitLimitWithinPage
+        ? pageSelection.hitLimitWithinPage as boolean
         : limit > 0 &&
           typeof pageSelection.remainingCapacity === "number" &&
           pageResumes.length > pageSelection.remainingCapacity;
@@ -428,7 +468,7 @@ export function createSnapshotCollector(deps) {
       resumes: collectedResumes,
       summary: {
         sourceKey,
-        sourceHost: metadata.sourceHost,
+        sourceHost: metadata.sourceHost as string,
         count: collectedResumes.length,
         pagesVisited,
         stopReason,

--- a/apps/browser-extension/src/lib/sync-status-widget.ts
+++ b/apps/browser-extension/src/lib/sync-status-widget.ts
@@ -1,10 +1,16 @@
-// @ts-nocheck
 /**
  * Sync status widget for browser extension content scripts.
  * All dependencies injected from content.ts via DI factory.
  */
 
-export function createSyncStatusWidget(deps) {
+export interface SyncStatusWidgetDeps extends Record<string, unknown> {
+  win: Window;
+  doc: Document;
+  chrome: { runtime?: { sendMessage?: (message: unknown) => Promise<unknown> } };
+  onCancel: () => void;
+}
+
+export function createSyncStatusWidget(deps: SyncStatusWidgetDeps) {
   const {
     win,
     doc,
@@ -15,9 +21,9 @@ export function createSyncStatusWidget(deps) {
   const WIDGET_ID = "tr-sync-status-widget";
   const DEFAULT_AUTO_DISMISS_MS = 5000;
   const HIDE_DELAY_MS = 220;
-  let widgetEl = null;
-  let dismissTimer = null;
-  let hideTimer = null;
+  let widgetEl: HTMLElement | null = null;
+  let dismissTimer: ReturnType<typeof setTimeout> | null = null;
+  let hideTimer: ReturnType<typeof setTimeout> | null = null;
 
   function escapeHtml(value) {
     return String(value ?? "")
@@ -80,7 +86,7 @@ export function createSyncStatusWidget(deps) {
     message = "",
     hint = "",
     autoDismiss = false,
-  } = {}) {
+  }: { state?: string; message?: string; hint?: string; autoDismiss?: boolean | number } = {}) {
     const normalizedState =
       state === "success" || state === "error" ? state : "progress";
     const safeMessage = escapeHtml(message);


### PR DESCRIPTION
## Summary
- Remove `// @ts-nocheck` from all 10 browser extension `lib/` modules by adding typed `Deps` interfaces (extending `Record<string, unknown>`) with proper function signatures and return types
- Add targeted type casts where the code accesses properties on `unknown` values (e.g., `payload.data`, `apiSnapshot` fields, `response.success`)
- Update all test files to import the `Deps` types and cast mock objects accordingly

## Test plan
- [x] All 405 browser extension lib tests pass (`npx vitest run apps/browser-extension/src/lib/__tests__/`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit -p apps/browser-extension/tsconfig.json`)
- [x] `make check-node` passes
- [ ] Only `content.ts` retains `@ts-nocheck` (large orchestrator, separate task)