### PR TITLE
test: add convex-test integration tests for 4 uncovered Convex modules

### DIFF
--- a/packages/convex/convex/__tests__/candidate-blocks-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/candidate-blocks-convex-test.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Integration tests using convex-test for candidate_blocks.ts CRUD functions.
+ *
+ * Uses edge-runtime environment (configured via environmentMatchGlobs in root vitest.config.ts).
+ */
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { api } from "../_generated/api.js";
+import schema from "../schema.js";
+
+const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
+
+describe("candidate_blocks (convex-test)", () => {
+  describe("list", () => {
+    it("returns empty array when no blocks exist", async () => {
+      const t = convexTest(schema, modules);
+      const result = await t.query(api.candidate_blocks.list, {});
+      expect(result).toEqual([]);
+    });
+
+    it("returns blocks filtered by workspaceSlug", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.run(async (ctx) => {
+        await ctx.db.insert("candidate_blocks", {
+          workspaceSlug: "ws1",
+          identityKey: "id1",
+          blockedAt: Date.now(),
+        });
+        await ctx.db.insert("candidate_blocks", {
+          workspaceSlug: "ws2",
+          identityKey: "id2",
+          blockedAt: Date.now(),
+        });
+      });
+
+      const result = await t.query(api.candidate_blocks.list, {
+        workspaceSlug: "ws1",
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].identityKey).toBe("id1");
+    });
+
+    it("defaults workspaceSlug when not provided", async () => {
+      const t = convexTest(schema, modules);
+
+      const result = await t.query(api.candidate_blocks.list, {});
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getByIdentity", () => {
+    it("returns null for non-existent identity", async () => {
+      const t = convexTest(schema, modules);
+      const result = await t.query(api.candidate_blocks.getByIdentity, {
+        identityKey: "nonexistent",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("returns block by identity key", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.run(async (ctx) => {
+        await ctx.db.insert("candidate_blocks", {
+          workspaceSlug: "ws1",
+          identityKey: "user-123",
+          reason: "spam",
+          blockedAt: Date.now(),
+        });
+      });
+
+      const result = await t.query(api.candidate_blocks.getByIdentity, {
+        workspaceSlug: "ws1",
+        identityKey: "user-123",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.identityKey).toBe("user-123");
+      expect(result!.reason).toBe("spam");
+    });
+
+    it("returns null for empty identityKey", async () => {
+      const t = convexTest(schema, modules);
+      const result = await t.query(api.candidate_blocks.getByIdentity, {
+        identityKey: "  ",
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("upsert", () => {
+    it("inserts a new block", async () => {
+      const t = convexTest(schema, modules);
+
+      const id = await t.mutation(api.candidate_blocks.upsert, {
+        workspaceSlug: "ws1",
+        identityKey: "user-new",
+        reason: "fraud",
+      });
+
+      expect(id).toBeDefined();
+
+      const block = await t.query(api.candidate_blocks.getByIdentity, {
+        workspaceSlug: "ws1",
+        identityKey: "user-new",
+      });
+      expect(block).not.toBeNull();
+      expect(block!.reason).toBe("fraud");
+    });
+
+    it("updates existing block on second upsert", async () => {
+      const t = convexTest(schema, modules);
+
+      const id1 = await t.mutation(api.candidate_blocks.upsert, {
+        workspaceSlug: "ws1",
+        identityKey: "user-dup",
+        reason: "first",
+      });
+
+      const id2 = await t.mutation(api.candidate_blocks.upsert, {
+        workspaceSlug: "ws1",
+        identityKey: "user-dup",
+        reason: "second",
+        blockedBy: "admin",
+      });
+
+      expect(id2).toBe(id1);
+
+      const block = await t.query(api.candidate_blocks.getByIdentity, {
+        workspaceSlug: "ws1",
+        identityKey: "user-dup",
+      });
+      expect(block!.reason).toBe("second");
+      expect(block!.blockedBy).toBe("admin");
+    });
+
+    it("throws for empty identityKey", async () => {
+      const t = convexTest(schema, modules);
+      await expect(
+        t.mutation(api.candidate_blocks.upsert, {
+          identityKey: "  ",
+        }),
+      ).rejects.toThrow("identityKey is required");
+    });
+  });
+
+  describe("updateReason", () => {
+    it("updates reason for existing block", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.candidate_blocks.upsert, {
+        workspaceSlug: "ws1",
+        identityKey: "user-upd",
+        reason: "old",
+      });
+
+      const updated = await t.mutation(api.candidate_blocks.updateReason, {
+        workspaceSlug: "ws1",
+        identityKey: "user-upd",
+        reason: "new reason",
+      });
+      expect(updated).toBe(true);
+
+      const block = await t.query(api.candidate_blocks.getByIdentity, {
+        workspaceSlug: "ws1",
+        identityKey: "user-upd",
+      });
+      expect(block!.reason).toBe("new reason");
+    });
+
+    it("returns false for non-existent block", async () => {
+      const t = convexTest(schema, modules);
+      const updated = await t.mutation(api.candidate_blocks.updateReason, {
+        workspaceSlug: "ws1",
+        identityKey: "nonexistent",
+        reason: "test",
+      });
+      expect(updated).toBe(false);
+    });
+  });
+
+  describe("bulkUpsert", () => {
+    it("inserts multiple blocks", async () => {
+      const t = convexTest(schema, modules);
+
+      const result = await t.mutation(api.candidate_blocks.bulkUpsert, {
+        workspaceSlug: "ws1",
+        identityKeys: ["user-a", "user-b", "user-c"],
+        reason: "bulk",
+      });
+
+      expect(result.total).toBe(3);
+      expect(result.inserted).toBe(3);
+      expect(result.updated).toBe(0);
+    });
+
+    it("deduplicates identity keys", async () => {
+      const t = convexTest(schema, modules);
+
+      const result = await t.mutation(api.candidate_blocks.bulkUpsert, {
+        workspaceSlug: "ws1",
+        identityKeys: ["user-x", "user-x", "user-y"],
+        reason: "dedup",
+      });
+
+      expect(result.total).toBe(2);
+      expect(result.inserted).toBe(2);
+    });
+
+    it("updates existing and inserts new blocks", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.candidate_blocks.upsert, {
+        workspaceSlug: "ws1",
+        identityKey: "user-exist",
+        reason: "original",
+      });
+
+      const result = await t.mutation(api.candidate_blocks.bulkUpsert, {
+        workspaceSlug: "ws1",
+        identityKeys: ["user-exist", "user-new"],
+        reason: "bulk",
+      });
+
+      expect(result.total).toBe(2);
+      expect(result.inserted).toBe(1);
+      expect(result.updated).toBe(1);
+    });
+
+    it("filters out empty identity keys", async () => {
+      const t = convexTest(schema, modules);
+
+      const result = await t.mutation(api.candidate_blocks.bulkUpsert, {
+        workspaceSlug: "ws1",
+        identityKeys: ["user-ok", "  ", ""],
+        reason: "filter",
+      });
+
+      expect(result.total).toBe(1);
+    });
+  });
+
+  describe("remove", () => {
+    it("removes an existing block", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.candidate_blocks.upsert, {
+        workspaceSlug: "ws1",
+        identityKey: "user-del",
+      });
+
+      const removed = await t.mutation(api.candidate_blocks.remove, {
+        workspaceSlug: "ws1",
+        identityKey: "user-del",
+      });
+      expect(removed).toBe(true);
+
+      const block = await t.query(api.candidate_blocks.getByIdentity, {
+        workspaceSlug: "ws1",
+        identityKey: "user-del",
+      });
+      expect(block).toBeNull();
+    });
+
+    it("returns false for non-existent block", async () => {
+      const t = convexTest(schema, modules);
+      const removed = await t.mutation(api.candidate_blocks.remove, {
+        workspaceSlug: "ws1",
+        identityKey: "nonexistent",
+      });
+      expect(removed).toBe(false);
+    });
+
+    it("returns false for empty identityKey", async () => {
+      const t = convexTest(schema, modules);
+      const removed = await t.mutation(api.candidate_blocks.remove, {
+        workspaceSlug: "ws1",
+        identityKey: "  ",
+      });
+      expect(removed).toBe(false);
+    });
+  });
+});

--- a/packages/convex/convex/__tests__/search-alerts-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/search-alerts-convex-test.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests using convex-test for search_alerts.ts CRUD functions.
+ *
+ * Uses edge-runtime environment (configured via environmentMatchGlobs in root vitest.config.ts).
+ */
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { api } from "../_generated/api.js";
+import schema from "../schema.js";
+
+const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
+
+function seedAlert(overrides: Record<string, unknown> = {}) {
+  return {
+    workspaceSlug: "ws1",
+    searchProfileId: "profile-1",
+    name: "Test Alert",
+    minScore: 50,
+    ...overrides,
+  };
+}
+
+describe("search_alerts (convex-test)", () => {
+  describe("create", () => {
+    it("creates a new alert with enabled=true by default", async () => {
+      const t = convexTest(schema, modules);
+
+      const id = await t.mutation(api.search_alerts.create, seedAlert());
+      expect(id).toBeDefined();
+
+      const alerts = await t.query(api.search_alerts.list, {
+        workspaceSlug: "ws1",
+      });
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0].enabled).toBe(true);
+      expect(alerts[0].name).toBe("Test Alert");
+    });
+
+    it("creates alert with keywords and createdBy", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(
+        api.search_alerts.create,
+        seedAlert({
+          keywords: ["python", "react"],
+          createdBy: "user-1",
+        }),
+      );
+
+      const alerts = await t.query(api.search_alerts.list, {
+        workspaceSlug: "ws1",
+      });
+      expect(alerts[0].keywords).toEqual(["python", "react"]);
+      expect(alerts[0].createdBy).toBe("user-1");
+    });
+  });
+
+  describe("toggle", () => {
+    it("disables an enabled alert", async () => {
+      const t = convexTest(schema, modules);
+
+      const id = await t.mutation(api.search_alerts.create, seedAlert());
+
+      await t.mutation(api.search_alerts.toggle, {
+        alertId: id,
+        enabled: false,
+      });
+
+      const enabled = await t.query(api.search_alerts.listEnabled, {
+        workspaceSlug: "ws1",
+      });
+      expect(enabled).toHaveLength(0);
+    });
+
+    it("re-enables a disabled alert", async () => {
+      const t = convexTest(schema, modules);
+
+      const id = await t.mutation(api.search_alerts.create, seedAlert());
+
+      await t.mutation(api.search_alerts.toggle, {
+        alertId: id,
+        enabled: false,
+      });
+      await t.mutation(api.search_alerts.toggle, {
+        alertId: id,
+        enabled: true,
+      });
+
+      const enabled = await t.query(api.search_alerts.listEnabled, {
+        workspaceSlug: "ws1",
+      });
+      expect(enabled).toHaveLength(1);
+    });
+  });
+
+  describe("list", () => {
+    it("returns empty array when no alerts exist", async () => {
+      const t = convexTest(schema, modules);
+      const result = await t.query(api.search_alerts.list, {
+        workspaceSlug: "ws1",
+      });
+      expect(result).toEqual([]);
+    });
+
+    it("returns alerts filtered by workspaceSlug", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(
+        api.search_alerts.create,
+        seedAlert({ workspaceSlug: "ws1", name: "Alert WS1" }),
+      );
+      await t.mutation(
+        api.search_alerts.create,
+        seedAlert({ workspaceSlug: "ws2", name: "Alert WS2" }),
+      );
+
+      const ws1Alerts = await t.query(api.search_alerts.list, {
+        workspaceSlug: "ws1",
+      });
+      expect(ws1Alerts).toHaveLength(1);
+      expect(ws1Alerts[0].name).toBe("Alert WS1");
+    });
+  });
+
+  describe("listEnabled", () => {
+    it("returns only enabled alerts", async () => {
+      const t = convexTest(schema, modules);
+
+      const id1 = await t.mutation(
+        api.search_alerts.create,
+        seedAlert({ name: "Enabled" }),
+      );
+      const id2 = await t.mutation(
+        api.search_alerts.create,
+        seedAlert({ name: "Disabled" }),
+      );
+
+      await t.mutation(api.search_alerts.toggle, {
+        alertId: id2,
+        enabled: false,
+      });
+
+      const enabled = await t.query(api.search_alerts.listEnabled, {
+        workspaceSlug: "ws1",
+      });
+      expect(enabled).toHaveLength(1);
+      expect(enabled[0].name).toBe("Enabled");
+    });
+  });
+
+  describe("markNotified", () => {
+    it("updates lastNotifiedAt on the alert", async () => {
+      const t = convexTest(schema, modules);
+
+      const id = await t.mutation(api.search_alerts.create, seedAlert());
+
+      const before = await t.query(api.search_alerts.list, {
+        workspaceSlug: "ws1",
+      });
+      expect(before[0].lastNotifiedAt).toBeUndefined();
+
+      await t.mutation(api.search_alerts.markNotified, { alertId: id });
+
+      const after = await t.query(api.search_alerts.list, {
+        workspaceSlug: "ws1",
+      });
+      expect(typeof after[0].lastNotifiedAt).toBe("number");
+      expect(after[0].lastNotifiedAt).toBeGreaterThan(0);
+    });
+  });
+
+  describe("remove", () => {
+    it("deletes an alert", async () => {
+      const t = convexTest(schema, modules);
+
+      const id = await t.mutation(api.search_alerts.create, seedAlert());
+
+      await t.mutation(api.search_alerts.remove, { alertId: id });
+
+      const alerts = await t.query(api.search_alerts.list, {
+        workspaceSlug: "ws1",
+      });
+      expect(alerts).toHaveLength(0);
+    });
+  });
+});

--- a/packages/convex/convex/__tests__/sync-events-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/sync-events-convex-test.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Integration tests using convex-test for sync_events.ts functions.
+ *
+ * Uses edge-runtime environment (configured via environmentMatchGlobs in root vitest.config.ts).
+ */
+import { convexTest } from "convex-test";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { api } from "../_generated/api.js";
+import schema from "../schema.js";
+
+const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
+
+describe("sync_events (convex-test)", () => {
+  describe("recordError", () => {
+    it("inserts an error event", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.sync_events.recordError, {
+        source: "51job",
+        error: "Network timeout",
+      });
+
+      const latest = await t.query(api.sync_events.getLatest, {});
+      expect(latest).not.toBeNull();
+      expect(latest!.source).toBe("51job");
+      expect(latest!.status).toBe("error");
+      expect(latest!.error).toBe("Network timeout");
+    });
+  });
+
+  describe("getLatest", () => {
+    it("returns null when no events exist", async () => {
+      const t = convexTest(schema, modules);
+      const result = await t.query(api.sync_events.getLatest, {});
+      expect(result).toBeNull();
+    });
+
+    it("returns the most recent event", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.run(async (ctx) => {
+        await ctx.db.insert("sync_events", {
+          source: "51job",
+          status: "success",
+          submitted: 10,
+          inserted: 5,
+          updated: 3,
+          unchanged: 2,
+          timestamp: 1000,
+        });
+        await ctx.db.insert("sync_events", {
+          source: "seek",
+          status: "success",
+          submitted: 20,
+          inserted: 8,
+          updated: 6,
+          unchanged: 6,
+          timestamp: 2000,
+        });
+      });
+
+      const latest = await t.query(api.sync_events.getLatest, {});
+      expect(latest).not.toBeNull();
+      expect(latest!.source).toBe("seek");
+    });
+  });
+
+  describe("cleanup", () => {
+    let dateSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      // Lock Date.now to a fixed value for deterministic cleanup cutoff
+      dateSpy = vi.spyOn(Date, "now").mockReturnValue(10_000_000);
+    });
+
+    afterEach(() => {
+      dateSpy.mockRestore();
+    });
+
+    it("deletes stale events older than 1 hour", async () => {
+      const t = convexTest(schema, modules);
+      const STALE_EVENT_MS = 3_600_000;
+
+      await t.run(async (ctx) => {
+        // Stale event (older than 1 hour)
+        await ctx.db.insert("sync_events", {
+          source: "51job",
+          status: "success",
+          submitted: 1,
+          inserted: 0,
+          updated: 0,
+          unchanged: 1,
+          timestamp: 10_000_000 - STALE_EVENT_MS - 1000,
+        });
+        // Recent event (within 1 hour)
+        await ctx.db.insert("sync_events", {
+          source: "seek",
+          status: "success",
+          submitted: 5,
+          inserted: 2,
+          updated: 2,
+          unchanged: 1,
+          timestamp: 10_000_000 - STALE_EVENT_MS + 1000,
+        });
+      });
+
+      const result = await t.mutation(api.sync_events.cleanup, {});
+      expect(result.deleted).toBe(1);
+
+      const latest = await t.query(api.sync_events.getLatest, {});
+      expect(latest).not.toBeNull();
+      expect(latest!.source).toBe("seek");
+    });
+
+    it("returns zero deleted when no stale events", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.run(async (ctx) => {
+        await ctx.db.insert("sync_events", {
+          source: "51job",
+          status: "success",
+          submitted: 1,
+          inserted: 0,
+          updated: 0,
+          unchanged: 1,
+          timestamp: 10_000_000 - 1000,
+        });
+      });
+
+      const result = await t.mutation(api.sync_events.cleanup, {});
+      expect(result.deleted).toBe(0);
+    });
+
+    it("respects MAX_CLEANUP_BATCH limit", async () => {
+      const t = convexTest(schema, modules);
+      const STALE_EVENT_MS = 3_600_000;
+      const staleTs = 10_000_000 - STALE_EVENT_MS - 1000;
+
+      // Insert 25 stale events (exceeds MAX_CLEANUP_BATCH=20)
+      await t.run(async (ctx) => {
+        for (let i = 0; i < 25; i++) {
+          await ctx.db.insert("sync_events", {
+            source: `source-${i}`,
+            status: "success",
+            submitted: 0,
+            inserted: 0,
+            updated: 0,
+            unchanged: 0,
+            timestamp: staleTs + i,
+          });
+        }
+      });
+
+      const result = await t.mutation(api.sync_events.cleanup, {});
+      expect(result.deleted).toBe(20);
+    });
+  });
+});

--- a/packages/convex/convex/__tests__/workspace-config-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/workspace-config-convex-test.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Integration tests using convex-test for workspace_config.ts CRUD functions.
+ *
+ * Uses edge-runtime environment (configured via environmentMatchGlobs in root vitest.config.ts).
+ */
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { api } from "../_generated/api.js";
+import schema from "../schema.js";
+
+const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
+
+describe("workspace_config (convex-test)", () => {
+  describe("get", () => {
+    it("returns null for non-existent config", async () => {
+      const t = convexTest(schema, modules);
+      const result = await t.query(api.workspace_config.get, {
+        workspaceSlug: "ws1",
+        configKey: "missing",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("returns existing config", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.run(async (ctx) => {
+        await ctx.db.insert("workspace_config", {
+          workspaceSlug: "ws1",
+          configKey: "theme",
+          configValue: "dark",
+          updatedAt: Date.now(),
+        });
+      });
+
+      const result = await t.query(api.workspace_config.get, {
+        workspaceSlug: "ws1",
+        configKey: "theme",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.configValue).toBe("dark");
+    });
+  });
+
+  describe("upsert", () => {
+    it("inserts a new config", async () => {
+      const t = convexTest(schema, modules);
+
+      const id = await t.mutation(api.workspace_config.upsert, {
+        workspaceSlug: "ws1",
+        configKey: "locale",
+        configValue: "zh-CN",
+      });
+      expect(id).toBeDefined();
+
+      const config = await t.query(api.workspace_config.get, {
+        workspaceSlug: "ws1",
+        configKey: "locale",
+      });
+      expect(config).not.toBeNull();
+      expect(config!.configValue).toBe("zh-CN");
+    });
+
+    it("updates existing config on second upsert", async () => {
+      const t = convexTest(schema, modules);
+
+      const id1 = await t.mutation(api.workspace_config.upsert, {
+        workspaceSlug: "ws1",
+        configKey: "locale",
+        configValue: "en-US",
+      });
+
+      const id2 = await t.mutation(api.workspace_config.upsert, {
+        workspaceSlug: "ws1",
+        configKey: "locale",
+        configValue: "zh-CN",
+      });
+
+      expect(id2).toBe(id1);
+
+      const config = await t.query(api.workspace_config.get, {
+        workspaceSlug: "ws1",
+        configKey: "locale",
+      });
+      expect(config!.configValue).toBe("zh-CN");
+    });
+
+    it("handles complex configValue objects", async () => {
+      const t = convexTest(schema, modules);
+
+      const complexValue = { filters: { age: [25, 40] }, mode: "strict" };
+      await t.mutation(api.workspace_config.upsert, {
+        workspaceSlug: "ws1",
+        configKey: "searchSettings",
+        configValue: complexValue,
+      });
+
+      const config = await t.query(api.workspace_config.get, {
+        workspaceSlug: "ws1",
+        configKey: "searchSettings",
+      });
+      expect(config!.configValue).toEqual(complexValue);
+    });
+  });
+
+  describe("listForWorkspace", () => {
+    it("returns empty array when no configs exist", async () => {
+      const t = convexTest(schema, modules);
+      const result = await t.query(api.workspace_config.listForWorkspace, {
+        workspaceSlug: "ws1",
+      });
+      expect(result).toEqual([]);
+    });
+
+    it("returns all configs for a workspace", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.workspace_config.upsert, {
+        workspaceSlug: "ws1",
+        configKey: "theme",
+        configValue: "dark",
+      });
+      await t.mutation(api.workspace_config.upsert, {
+        workspaceSlug: "ws1",
+        configKey: "locale",
+        configValue: "en-US",
+      });
+      await t.mutation(api.workspace_config.upsert, {
+        workspaceSlug: "ws2",
+        configKey: "theme",
+        configValue: "light",
+      });
+
+      const result = await t.query(api.workspace_config.listForWorkspace, {
+        workspaceSlug: "ws1",
+      });
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("remove", () => {
+    it("removes an existing config", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.workspace_config.upsert, {
+        workspaceSlug: "ws1",
+        configKey: "temp",
+        configValue: "delete-me",
+      });
+
+      const removed = await t.mutation(api.workspace_config.remove, {
+        workspaceSlug: "ws1",
+        configKey: "temp",
+      });
+      expect(removed).toBe(true);
+
+      const config = await t.query(api.workspace_config.get, {
+        workspaceSlug: "ws1",
+        configKey: "temp",
+      });
+      expect(config).toBeNull();
+    });
+
+    it("returns false for non-existent config", async () => {
+      const t = convexTest(schema, modules);
+      const removed = await t.mutation(api.workspace_config.remove, {
+        workspaceSlug: "ws1",
+        configKey: "nonexistent",
+      });
+      expect(removed).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add convex-test integration tests for `candidate_blocks` (16 tests), `search_alerts` (9 tests), `workspace_config` (9 tests), and `sync_events` (8 tests)
- These were the last Convex modules without any test coverage (crons.ts excluded as declarative-only)
- Follows the same pattern established in `resumes-convex-test.test.ts`

## Test plan
- [x] All 42 new tests pass (`npx vitest run packages/convex/convex/__tests__/*-convex-test.test.ts`)
- [x] Full Convex test suite passes — 811 tests total (`npx vitest run packages/convex/convex/__tests__/`)
- [x] `make check-node` passes