### PR TITLE
feat: add embedding/semantic search pipeline with hybrid RRF merge

### DIFF
--- a/packages/convex/convex/__tests__/embeddings-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/embeddings-convex-test.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Integration tests using convex-test for embeddings.ts functions.
+ *
+ * Uses edge-runtime environment (configured via environmentMatchGlobs in root vitest.config.ts).
+ * Internal functions (internalQuery/internalMutation) are accessed via internal API reference.
+ */
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { api } from "../_generated/api.js";
+import { internal } from "../_generated/api.js";
+import schema from "../schema.js";
+import type { Doc, Id } from "../_generated/dataModel.js";
+
+const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
+
+describe("embeddings (convex-test)", () => {
+  describe("storeEmbedding (internal)", () => {
+    it("creates new embedding and links to resume", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "ext-1",
+          identityKey: "id-1",
+          content: {},
+          hash: "abc123",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+          searchText: "Test resume text",
+        });
+      });
+
+      const embeddingId = await t.mutation(internal.embeddings.storeEmbedding, {
+        resumeId,
+        embedding: new Array(1536).fill(0.1),
+        model: "text-embedding-3-small",
+        sourceKey: "seek",
+      });
+
+      expect(embeddingId).toBeDefined();
+
+      // Verify back-link on resume
+      const resume = await t.run(async (ctx) => {
+        return ctx.db.get(resumeId);
+      });
+      expect(resume?.embeddingId).toBe(embeddingId);
+
+      // Verify embedding document
+      const embedding = await t.run(async (ctx) => {
+        return ctx.db.get(embeddingId);
+      }) as Doc<"resume_embeddings"> | null;
+      expect(embedding?.resumeId).toBe(resumeId);
+      expect(embedding?.model).toBe("text-embedding-3-small");
+      expect(embedding?.sourceKey).toBe("seek");
+    });
+
+    it("replaces existing embedding on upsert", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "ext-2",
+          content: {},
+          hash: "def456",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+          searchText: "Another resume",
+        });
+      });
+
+      const firstId = await t.mutation(internal.embeddings.storeEmbedding, {
+        resumeId,
+        embedding: new Array(1536).fill(0.2),
+        model: "text-embedding-3-small",
+      });
+
+      const secondId = await t.mutation(internal.embeddings.storeEmbedding, {
+        resumeId,
+        embedding: new Array(1536).fill(0.3),
+        model: "text-embedding-3-small-v2",
+      });
+
+      // Should update in-place, not create a new row
+      expect(secondId).toBe(firstId);
+
+      const embedding = await t.run(async (ctx) => {
+        return ctx.db.get(firstId);
+      }) as Doc<"resume_embeddings"> | null;
+      expect(embedding?.model).toBe("text-embedding-3-small-v2");
+    });
+  });
+
+  describe("getResumeForEmbedding (internal)", () => {
+    it("returns resume by id", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "ext-3",
+          content: { name: "Test User" },
+          hash: "ghi789",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+          searchText: "Test user resume",
+        });
+      });
+
+      const resume = await t.query(internal.embeddings.getResumeForEmbedding, {
+        resumeId,
+      });
+      expect(resume).not.toBeNull();
+      expect(resume!.externalId).toBe("ext-3");
+    });
+
+    it("returns null for non-existent resume", async () => {
+      const t = convexTest(schema, modules);
+
+      // Create and delete a resume to get a valid-looking ID that doesn't exist
+      const tempId = await t.run(async (ctx) => {
+        const id = await ctx.db.insert("resumes", {
+          externalId: "temp-delete",
+          content: {},
+          hash: "temp",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+        await ctx.db.delete(id);
+        return id;
+      });
+
+      const resume = await t.query(internal.embeddings.getResumeForEmbedding, {
+        resumeId: tempId,
+      });
+      expect(resume).toBeNull();
+    });
+  });
+
+  describe("getResumesWithoutEmbeddings (internal)", () => {
+    it("returns resumes without embeddingId", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.run(async (ctx) => {
+        await ctx.db.insert("resumes", {
+          externalId: "no-emb-1",
+          content: {},
+          hash: "no1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+          searchText: "No embedding",
+        });
+      });
+
+      const result = await t.query(internal.embeddings.getResumesWithoutEmbeddings, {
+        numItems: 10,
+      });
+
+      expect(result.resumes.length).toBeGreaterThanOrEqual(1);
+      expect(result.resumes.every((r: any) => r.embeddingId === undefined)).toBe(true);
+    });
+  });
+
+  describe("getEmbeddingsByIds (internal)", () => {
+    it("returns embeddings for given ids", async () => {
+      const t = convexTest(schema, modules);
+
+      const { resumeId, embeddingId } = await t.run(async (ctx) => {
+        const resumeId = await ctx.db.insert("resumes", {
+          externalId: "ext-emb-1",
+          content: {},
+          hash: "emb1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+          searchText: "Resume with embedding",
+        });
+        const embeddingId = await ctx.db.insert("resume_embeddings", {
+          resumeId,
+          embedding: new Array(1536).fill(0.5),
+          model: "text-embedding-3-small",
+          sourceKey: "seek",
+          generatedAt: Date.now(),
+        });
+        await ctx.db.patch(resumeId, { embeddingId });
+        return { resumeId, embeddingId };
+      });
+
+      const results = await t.query(internal.embeddings.getEmbeddingsByIds, {
+        embeddingIds: [embeddingId],
+      });
+      expect(results.length).toBe(1);
+      expect(results[0].resumeId).toBe(resumeId);
+    });
+
+    it("filters out null results for non-existent ids", async () => {
+      const t = convexTest(schema, modules);
+
+      // Create and delete an embedding to get a valid-looking ID that doesn't exist
+      const tempId = await t.run(async (ctx) => {
+        const resumeId = await ctx.db.insert("resumes", {
+          externalId: "temp-emb-del",
+          content: {},
+          hash: "temb",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+        const embId = await ctx.db.insert("resume_embeddings", {
+          resumeId,
+          embedding: new Array(1536).fill(0),
+          model: "test",
+          generatedAt: Date.now(),
+        });
+        await ctx.db.delete(embId);
+        return embId;
+      });
+
+      const results = await t.query(internal.embeddings.getEmbeddingsByIds, {
+        embeddingIds: [tempId],
+      });
+      expect(results.length).toBe(0);
+    });
+  });
+
+  describe("getEmbeddingStats (public)", () => {
+    it("returns empty stats when no embeddings exist", async () => {
+      const t = convexTest(schema, modules);
+
+      const stats = await t.query(api.embeddings.getEmbeddingStats, {});
+      expect(stats.hasEmbeddings).toBe(false);
+      expect(stats.latestModel).toBeNull();
+    });
+
+    it("returns stats when embeddings exist", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.run(async (ctx) => {
+        const resumeId = await ctx.db.insert("resumes", {
+          externalId: "ext-stats",
+          content: {},
+          hash: "stats1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+          searchText: "Stats resume",
+        });
+        const embeddingId = await ctx.db.insert("resume_embeddings", {
+          resumeId,
+          embedding: new Array(1536).fill(0.7),
+          model: "text-embedding-3-small",
+          generatedAt: Date.now(),
+        });
+        await ctx.db.patch(resumeId, { embeddingId });
+      });
+
+      const stats = await t.query(api.embeddings.getEmbeddingStats, {});
+      expect(stats.hasEmbeddings).toBe(true);
+      expect(stats.latestModel).toBe("text-embedding-3-small");
+      expect(stats.latestGeneratedAt).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as analyze from "../analyze.js";
 import type * as candidate_blocks from "../candidate_blocks.js";
 import type * as candidate_status from "../candidate_status.js";
 import type * as crons from "../crons.js";
+import type * as embeddings from "../embeddings.js";
 import type * as ingest_agent from "../ingest_agent.js";
 import type * as job_descriptions from "../job_descriptions.js";
 import type * as lib_age from "../lib/age.js";
@@ -49,6 +50,7 @@ declare const fullApi: ApiFromModules<{
   candidate_blocks: typeof candidate_blocks;
   candidate_status: typeof candidate_status;
   crons: typeof crons;
+  embeddings: typeof embeddings;
   ingest_agent: typeof ingest_agent;
   job_descriptions: typeof job_descriptions;
   "lib/age": typeof lib_age;

--- a/packages/convex/convex/embeddings.ts
+++ b/packages/convex/convex/embeddings.ts
@@ -1,0 +1,454 @@
+import { action, internalAction, internalMutation, internalQuery, query } from "./_generated/server";
+import { api, internal } from "./_generated/api";
+import type { Doc, Id } from "./_generated/dataModel";
+import { v } from "convex/values";
+
+// ---------------------------------------------------------------------------
+// Embedding generation helpers
+// ---------------------------------------------------------------------------
+
+const EMBEDDING_MODEL = "text-embedding-3-small";
+const EMBEDDING_DIMENSIONS = 1536;
+const BATCH_SIZE = 100;
+
+function getApiKey(): string {
+    const key = process.env.AI_API_KEY || process.env.OPENAI_API_KEY;
+    if (!key) throw new Error("AI_API_KEY/OPENAI_API_KEY is not set in Convex environment variables.");
+    return key;
+}
+
+function getApiBase(): string {
+    return process.env.AI_API_BASE || process.env.OPENAI_API_BASE || "https://api.openai.com/v1";
+}
+
+async function fetchEmbedding(text: string): Promise<number[]> {
+    const response = await fetch(`${getApiBase()}/embeddings`, {
+        method: "POST",
+        headers: {
+            "Authorization": `Bearer ${getApiKey()}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            model: EMBEDDING_MODEL,
+            input: text,
+            dimensions: EMBEDDING_DIMENSIONS,
+        }),
+    });
+
+    if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`Embedding API error (${response.status}): ${body}`);
+    }
+
+    const data = await response.json();
+    return (data as { data: Array<{ embedding: number[] }> }).data[0].embedding;
+}
+
+/** Build the text to embed from a resume's searchText. */
+function buildEmbeddingText(resume: { searchText?: string }): string {
+    // Truncate to ~8000 tokens (~32000 chars) for embedding API limits
+    const text = resume.searchText ?? "";
+    return text.slice(0, 32000);
+}
+
+// ---------------------------------------------------------------------------
+// Public action: generateEmbedding
+// ---------------------------------------------------------------------------
+
+export const generateEmbedding = action({
+    args: {
+        resumeId: v.id("resumes"),
+    },
+    handler: async (ctx, args): Promise<{ embeddingId?: Id<"resume_embeddings">; dimensions?: number; skipped?: boolean; reason?: string }> => {
+        const resume = await ctx.runQuery(internal.embeddings.getResumeForEmbedding, {
+            resumeId: args.resumeId,
+        });
+        if (!resume) throw new Error(`Resume ${args.resumeId} not found`);
+
+        const text = buildEmbeddingText(resume);
+        if (!text.trim()) {
+            return { skipped: true, reason: "empty_search_text" };
+        }
+
+        const embedding = await fetchEmbedding(text);
+
+        const embeddingId = await ctx.runMutation(internal.embeddings.storeEmbedding, {
+            resumeId: args.resumeId,
+            embedding,
+            model: EMBEDDING_MODEL,
+            sourceKey: resume.sourceKey ?? undefined,
+        });
+
+        return { embeddingId, dimensions: embedding.length };
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Internal query/mutation: resume lookup + embedding storage
+// ---------------------------------------------------------------------------
+
+export const getResumeForEmbedding = internalQuery({
+    args: { resumeId: v.id("resumes") },
+    handler: async (ctx, args) => {
+        return await ctx.db.get(args.resumeId);
+    },
+});
+
+export const storeEmbedding = internalMutation({
+    args: {
+        resumeId: v.id("resumes"),
+        embedding: v.array(v.float64()),
+        model: v.string(),
+        sourceKey: v.optional(v.string()),
+    },
+    handler: async (ctx, args): Promise<Id<"resume_embeddings">> => {
+        // Check for existing embedding for this resume
+        const existing = await ctx.db
+            .query("resume_embeddings")
+            .withIndex("by_resumeId", (q) => q.eq("resumeId", args.resumeId))
+            .first();
+
+        if (existing) {
+            // Replace existing embedding
+            await ctx.db.patch(existing._id, {
+                embedding: args.embedding,
+                model: args.model,
+                sourceKey: args.sourceKey,
+                generatedAt: Date.now(),
+            });
+            // Update back-link on resume
+            await ctx.db.patch(args.resumeId, { embeddingId: existing._id });
+            return existing._id;
+        }
+
+        const embeddingId = await ctx.db.insert("resume_embeddings", {
+            resumeId: args.resumeId,
+            embedding: args.embedding,
+            model: args.model,
+            sourceKey: args.sourceKey,
+            generatedAt: Date.now(),
+        });
+
+        // Set back-link on resume
+        await ctx.db.patch(args.resumeId, { embeddingId });
+
+        return embeddingId;
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Internal action: batchGenerateEmbeddings — for backfill
+// ---------------------------------------------------------------------------
+
+interface BatchResult {
+    generated: number;
+    skipped: number;
+    hasMore: boolean;
+    cursor: string | null;
+}
+
+export const batchGenerateEmbeddings = internalAction({
+    args: {
+        cursor: v.optional(v.string()),
+        limit: v.optional(v.number()),
+    },
+    handler: async (ctx, args): Promise<BatchResult> => {
+        const limit = Math.min(args.limit ?? BATCH_SIZE, BATCH_SIZE);
+
+        // Fetch resumes without embeddings, paginated
+        const page = await ctx.runQuery(internal.embeddings.getResumesWithoutEmbeddings, {
+            cursor: args.cursor,
+            numItems: limit,
+        });
+
+        let generated = 0;
+        let skipped = 0;
+
+        for (const resume of page.resumes) {
+            const text = buildEmbeddingText(resume);
+            if (!text.trim()) {
+                skipped++;
+                continue;
+            }
+
+            try {
+                const embedding = await fetchEmbedding(text);
+                await ctx.runMutation(internal.embeddings.storeEmbedding, {
+                    resumeId: resume._id,
+                    embedding,
+                    model: EMBEDDING_MODEL,
+                    sourceKey: resume.sourceKey ?? undefined,
+                });
+                generated++;
+            } catch (err) {
+                console.error(`Failed to generate embedding for resume ${resume._id}:`, err);
+                skipped++;
+            }
+        }
+
+        return {
+            generated,
+            skipped,
+            hasMore: page.hasMore,
+            cursor: page.nextCursor,
+        };
+    },
+});
+
+export const getResumesWithoutEmbeddings = internalQuery({
+    args: {
+        cursor: v.optional(v.string()),
+        numItems: v.number(),
+    },
+    handler: async (ctx, args) => {
+        // Scan resumes where embeddingId is undefined
+        const results = await ctx.db
+            .query("resumes")
+            .filter((q) => q.eq(q.field("embeddingId"), undefined))
+            .paginate({ cursor: args.cursor ?? null, numItems: args.numItems });
+
+        return {
+            resumes: results.page,
+            hasMore: results.continueCursor !== null && results.page.length === args.numItems,
+            nextCursor: results.continueCursor,
+        };
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Public action: hybridSearchResumes — BM25 + vector RRF merge
+// ---------------------------------------------------------------------------
+
+interface HybridSearchResult {
+    expansion: {
+        original: string;
+        expanded: string[];
+        groups: Array<{ original: string; variants: string[] }>;
+        mode: "AND";
+    };
+    total: number;
+    results: Array<{
+        resume: Record<string, unknown>;
+        provenance: Record<string, unknown>;
+    }>;
+    searchMode: "bm25" | "bm25_fallback" | "bm25_only_no_vectors" | "hybrid";
+    debug?: {
+        bm25Count: number;
+        vectorCount: number;
+        mergedCount: number;
+        semanticWeight: number;
+    };
+}
+
+export const hybridSearchResumes = action({
+    args: {
+        query: v.string(),
+        keywordGroups: v.array(v.object({
+            original: v.string(),
+            variants: v.array(v.string()),
+        })),
+        sourceMappings: v.optional(v.array(v.object({
+            term: v.string(),
+            expandedFrom: v.string(),
+        }))),
+        minExperience: v.optional(v.number()),
+        maxExperience: v.optional(v.number()),
+        minRoleYears: v.optional(v.number()),
+        roleFilterType: v.optional(v.string()),
+        minAge: v.optional(v.number()),
+        maxAge: v.optional(v.number()),
+        education: v.optional(v.array(v.string())),
+        skills: v.optional(v.array(v.string())),
+        requiredKeywords: v.optional(v.array(v.string())),
+        locations: v.optional(v.array(v.string())),
+        minSalary: v.optional(v.number()),
+        maxSalary: v.optional(v.number()),
+        showArchived: v.optional(v.boolean()),
+        sources: v.optional(v.array(v.string())),
+        jobDescriptionId: v.optional(v.string()),
+        sortBy: v.optional(v.union(v.literal("name"), v.literal("experience"), v.literal("extractedAt"))),
+        sortOrder: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
+        // Hybrid search params
+        semanticWeight: v.optional(v.number()), // 0-1, default 0.5
+        semanticLimit: v.optional(v.number()),  // max vector results, default 50
+        enableSemantic: v.optional(v.boolean()), // toggle, default true
+    },
+    handler: async (ctx, args): Promise<HybridSearchResult> => {
+        const enableSemantic = args.enableSemantic ?? true;
+        const semanticWeight = args.semanticWeight ?? 0.5;
+        const semanticLimit = Math.min(args.semanticLimit ?? 50, 256);
+        const bm25Weight = 1 - semanticWeight;
+
+        // 1. Run existing BM25 search
+        const bm25Result = (await ctx.runAction(api.resumes.searchWithTagExpansionAndMode, {
+            query: args.query,
+            keywordGroups: args.keywordGroups,
+            sourceMappings: args.sourceMappings,
+            minExperience: args.minExperience,
+            maxExperience: args.maxExperience,
+            minRoleYears: args.minRoleYears,
+            roleFilterType: args.roleFilterType,
+            minAge: args.minAge,
+            maxAge: args.maxAge,
+            education: args.education,
+            skills: args.skills,
+            requiredKeywords: args.requiredKeywords,
+            locations: args.locations,
+            minSalary: args.minSalary,
+            maxSalary: args.maxSalary,
+            showArchived: args.showArchived,
+            sources: args.sources,
+            jobDescriptionId: args.jobDescriptionId,
+            sortBy: args.sortBy,
+            sortOrder: args.sortOrder,
+        })) as unknown as HybridSearchResult;
+
+        // If semantic search disabled or query empty, return BM25 results as-is
+        if (!enableSemantic || !args.query.trim()) {
+            return {
+                ...bm25Result,
+                searchMode: "bm25" as const,
+            };
+        }
+
+        // 2. Generate query embedding
+        let vectorIds: Id<"resume_embeddings">[] = [];
+        try {
+            const queryEmbedding = await fetchEmbedding(args.query);
+
+            // 3. Vector search
+            const sourceKeys = args.sources?.length ? args.sources : undefined;
+            const vectorResults = await ctx.vectorSearch("resume_embeddings", "by_embedding", {
+                vector: queryEmbedding,
+                limit: semanticLimit,
+                ...(sourceKeys ? {
+                    filter: (q) => q.or(...sourceKeys.map((sk) => q.eq("sourceKey", sk))),
+                } : {}),
+            });
+
+            vectorIds = vectorResults.map((r) => r._id);
+        } catch (err) {
+            console.error("Vector search failed, falling back to BM25 only:", err);
+            return {
+                ...bm25Result,
+                searchMode: "bm25_fallback" as const,
+            };
+        }
+
+        if (vectorIds.length === 0) {
+            return {
+                ...bm25Result,
+                searchMode: "bm25_only_no_vectors" as const,
+            };
+        }
+
+        // 4. Fetch resume IDs for vector results
+        const embeddings = await ctx.runQuery(internal.embeddings.getEmbeddingsByIds, {
+            embeddingIds: vectorIds,
+        });
+        const vectorResumeMap = new Map<string, number>(); // resumeId -> vector rank
+        embeddings.forEach((emb: Doc<"resume_embeddings">, idx: number) => {
+            vectorResumeMap.set(String(emb.resumeId), idx + 1); // 1-based rank
+        });
+
+        // 5. RRF (Reciprocal Rank Fusion) merge with k=60
+        const K = 60;
+        const rrfScores = new Map<string, number>(); // resumeId -> RRF score
+        const resumeDocMap = new Map<string, HybridSearchResult["results"][number]>(); // resumeId -> result entry
+
+        // BM25 contribution
+        bm25Result.results.forEach((result: HybridSearchResult["results"][number], idx: number) => {
+            const resumeId = String((result.resume as { _id: string })._id);
+            const rank = idx + 1;
+            rrfScores.set(resumeId, bm25Weight / (K + rank));
+            resumeDocMap.set(resumeId, result);
+        });
+
+        // Vector contribution
+        vectorResumeMap.forEach((rank: number, resumeId: string) => {
+            const current = rrfScores.get(resumeId) ?? 0;
+            rrfScores.set(resumeId, current + semanticWeight / (K + rank));
+        });
+
+        // 6. Fetch docs for vector-only results (not in BM25 results)
+        const vectorOnlyIds = [...vectorResumeMap.keys()].filter((id) => !resumeDocMap.has(id));
+        if (vectorOnlyIds.length > 0) {
+            const additionalDocs = await ctx.runQuery(internal.resumes.getResumesByIds, {
+                resumeIds: vectorOnlyIds.map((id) => id as unknown as Id<"resumes">),
+            });
+            for (const doc of additionalDocs) {
+                resumeDocMap.set(String(doc._id), {
+                    resume: {
+                        _id: doc._id,
+                        _creationTime: doc._creationTime,
+                        externalId: doc.externalId,
+                        identityKey: doc.identityKey,
+                        age: doc.age,
+                        source: doc.source,
+                        sourceKey: doc.sourceKey,
+                        tags: doc.tags,
+                        crawledAt: doc.crawledAt,
+                        searchText: doc.searchText,
+                        primaryRuleScore: doc.primaryRuleScore,
+                        isArchived: doc.isArchived,
+                    } as Record<string, unknown>,
+                    provenance: { groups: [], matchedKeywords: [], mode: "semantic" } as Record<string, unknown>,
+                });
+            }
+        }
+
+        // 7. Sort by RRF score (descending)
+        const sortedIds = [...rrfScores.entries()]
+            .sort((a, b) => b[1] - a[1])
+            .map(([id]) => id);
+
+        const mergedResults = sortedIds
+            .map((id) => resumeDocMap.get(id))
+            .filter((r): r is NonNullable<typeof r> => r !== undefined);
+
+        return {
+            expansion: bm25Result.expansion,
+            total: mergedResults.length,
+            results: mergedResults,
+            searchMode: "hybrid" as const,
+            debug: {
+                bm25Count: bm25Result.results.length,
+                vectorCount: vectorIds.length,
+                mergedCount: mergedResults.length,
+                semanticWeight,
+            },
+        };
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Internal query: fetch embeddings by IDs
+// ---------------------------------------------------------------------------
+
+export const getEmbeddingsByIds = internalQuery({
+    args: { embeddingIds: v.array(v.id("resume_embeddings")) },
+    handler: async (ctx, args) => {
+        const results = await Promise.all(args.embeddingIds.map((id) => ctx.db.get(id)));
+        return results.filter((r): r is Doc<"resume_embeddings"> => r !== null);
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Public query: embedding stats
+// ---------------------------------------------------------------------------
+
+export const getEmbeddingStats = query({
+    args: {},
+    handler: async (ctx) => {
+        const sample = await ctx.db
+            .query("resume_embeddings")
+            .order("desc")
+            .take(1);
+
+        return {
+            hasEmbeddings: sample.length > 0,
+            latestModel: sample[0]?.model ?? null,
+            latestGeneratedAt: sample[0]?.generatedAt ?? null,
+        };
+    },
+});

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -103,6 +103,9 @@ export default defineSchema({
 
         // Pre-computed Ingest Data (M3)
         ingestData: v.optional(ingestDataValidator),
+
+        // Link to vector embedding for semantic search
+        embeddingId: v.optional(v.id("resume_embeddings")),
     })
         .index("by_externalId", ["externalId"])
         .index("by_identityKey", ["identityKey"])
@@ -444,4 +447,19 @@ export default defineSchema({
         updatedAt: v.number(),
     })
         .index("by_workspace_period", ["workspaceId", "period"]),
+
+    // Resume Embeddings — vector representations for semantic search
+    resume_embeddings: defineTable({
+        resumeId: v.id("resumes"),
+        embedding: v.array(v.float64()),
+        model: v.string(), // e.g. "text-embedding-3-small"
+        sourceKey: v.optional(v.string()),
+        generatedAt: v.number(),
+    })
+        .index("by_resumeId", ["resumeId"])
+        .vectorIndex("by_embedding", {
+            vectorField: "embedding",
+            dimensions: 1536,
+            filterFields: ["sourceKey"],
+        }),
 });


### PR DESCRIPTION
## Summary
- Add `resume_embeddings` table to schema.ts with `vectorIndex("by_embedding", ...)` for 1536-dim embeddings, filtered by `sourceKey`
- Add `embeddingId` back-link field on `resumes` table
- Create `packages/convex/convex/embeddings.ts` with:
  - `generateEmbedding` action — generates embedding via OpenAI `text-embedding-3-small` and stores in `resume_embeddings`
  - `batchGenerateEmbeddings` internal action — paginated backfill for resumes without embeddings
  - `hybridSearchResumes` action — combines BM25 text search + vector semantic search via Reciprocal Rank Fusion (k=60) with configurable `semanticWeight` (0-1, default 0.5)
  - `storeEmbedding` internal mutation — upsert with back-link
  - `getEmbeddingStats` public query — quick stats on embedding state
- Add 9 convex-test integration tests covering storeEmbedding (create/upsert), getResumeForEmbedding, getResumesWithoutEmbeddings, getEmbeddingsByIds, getEmbeddingStats

## Test plan
- [x] `make check` passes (typecheck + lint + governance)
- [x] 9 new convex-test tests pass
- [x] All 820 Convex tests pass
- [x] All 405 browser extension tests pass
- [ ] After merge: deploy schema, set `staged: true` flag, run `batchGenerateEmbeddings` backfill (~100 min at Tier 1 rate limits for 90K resumes)
- [ ] After backfill: remove `staged` flag to enable vector index, test `hybridSearchResumes` against live data