### PR TITLE
feat: wire audit logging into analysis pipeline + bias audit scheduler

### DIFF
--- a/config/resume/field-usage-policy.json5
+++ b/config/resume/field-usage-policy.json5
@@ -1,14 +1,15 @@
 // Canonical per-surface field-usage policy for normalized resume fields.
 {
-  version: 1,
-  updatedAt: "2026-03-20",
-  description: "Controls which canonical resume fields participate in analysis, presentation, outreach, and debug surfaces without deleting raw stored resume data.",
+  version: 2,
+  updatedAt: "2026-05-24",
+  description: "Controls which canonical resume fields participate in analysis, presentation, outreach, audit, and debug surfaces without deleting raw stored resume data. The 'audit' surface allows protected attributes for compliance logging while keeping them scrubbed from AI analysis.",
   fields: {
     jobIntention: {
       surfaces: {
         analysis: false,
         presentation: false,
         outreach: false,
+        audit: false,
         debug: false,
       },
     },
@@ -17,12 +18,31 @@
         analysis: false,
         presentation: false,
         outreach: false,
+        audit: false,
         debug: false,
       },
     },
     resumeSnippet: {
       surfaces: {
         analysis: false,
+      },
+    },
+    age: {
+      surfaces: {
+        analysis: false,
+        presentation: false,
+        outreach: false,
+        audit: true,
+        debug: false,
+      },
+    },
+    gender: {
+      surfaces: {
+        analysis: false,
+        presentation: false,
+        outreach: false,
+        audit: true,
+        debug: false,
       },
     },
   },

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type * as ai_tagging_results from "../ai_tagging_results.js";
 import type * as analysis_tasks from "../analysis_tasks.js";
 import type * as analyze from "../analyze.js";
 import type * as audit from "../audit.js";
+import type * as bias_audit from "../bias_audit.js";
 import type * as candidate_blocks from "../candidate_blocks.js";
 import type * as candidate_status from "../candidate_status.js";
 import type * as crons from "../crons.js";
@@ -50,6 +51,7 @@ declare const fullApi: ApiFromModules<{
   analysis_tasks: typeof analysis_tasks;
   analyze: typeof analyze;
   audit: typeof audit;
+  bias_audit: typeof bias_audit;
   candidate_blocks: typeof candidate_blocks;
   candidate_status: typeof candidate_status;
   crons: typeof crons;

--- a/packages/convex/convex/ai_tagging_results.ts
+++ b/packages/convex/convex/ai_tagging_results.ts
@@ -8,6 +8,7 @@ import { v } from "convex/values";
 import type { ChatMessage } from "./analyze";
 import { resolveChatCompletionModel } from "./lib/ai_model";
 import { resolveAiTaggingParallelism } from "./lib/parallelism";
+import { computeProtectedAttributeHashes } from "./audit.js";
 
 type RoleFit = "sales_verified" | "sales_unverified" | "operator_only";
 type Recommendation = "strong_match" | "match" | "potential" | "no_match";
@@ -760,6 +761,43 @@ export const drainQueue = internalAction({
             tokensOut,
           },
         });
+
+        // Audit log — EU AI Act compliance for tag decisions
+        try {
+          const protectedHashes = computeProtectedAttributeHashes({
+            age: typeof resume.age === "number" ? resume.age : undefined,
+            source: typeof resume.source === "string" ? resume.source : undefined,
+          });
+
+          await ctx.runMutation(internal.audit.logAnalysisDecision, {
+            resumeId: row.resumeId,
+            identityKey: row.identityKey ?? undefined,
+            workspaceSlug: row.workspaceSlug,
+            decisionType: "tag",
+            actionRef: "ai_tagging_results:drainQueue",
+            inputSnapshot: {
+              profileKey: row.profileKey,
+              promptVersion: row.promptVersion,
+            },
+            modelMeta: {
+              model: row.model,
+              provider: "openai",
+              promptTokens: tokensIn,
+              completionTokens: tokensOut,
+              latencyMs: Date.now() - start,
+            },
+            output: {
+              roleFit: parsed.roleFit,
+              confidence: parsed.confidence,
+              tags: parsed.tags,
+              recommendation: parsed.recommendation,
+            },
+            protectedAttributeHashes: protectedHashes,
+            decidedAt: Date.now(),
+          });
+        } catch (auditError) {
+          console.error("Audit logging failed for tagging:", auditError);
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         await ctx.runMutation(internal.ai_tagging_results.markFailed, {

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -17,6 +17,7 @@ import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
 import { action, internalMutation, type ActionCtx } from "./_generated/server";
 import { resolveChatCompletionModel } from "./lib/ai_model";
+import { computeProtectedAttributeHashes } from "./audit.js";
 
 const DEFAULT_AI_OUTPUT_LOCALE = DEFAULT_RESUME_AI_PROMPT_LOCALE;
 
@@ -656,6 +657,59 @@ export const analyzeResume = action({
                 analyzedAt: Date.now(),
             },
         });
+
+        // 5. Audit log — EU AI Act compliance
+        try {
+            const rawRoot: Record<string, unknown> = isRecord(resume) ? resume : {};
+            const rawContent = isRecord(rawRoot.content) ? rawRoot.content : rawRoot;
+            const scrubbedContent = sanitizeResumeRecordForSurface(rawContent, "analysis");
+            const auditContent = sanitizeResumeRecordForSurface(rawContent, "audit");
+            const scrubbedFields = Object.keys(rawContent).filter(
+                (key) => !(key in scrubbedContent) || scrubbedContent[key] === undefined
+            );
+            const auditAge = auditContent.age ?? rawRoot.age;
+            const protectedHashes = computeProtectedAttributeHashes({
+                age: typeof auditAge === "number" ? auditAge : undefined,
+                gender: typeof auditContent.gender === "string" ? auditContent.gender : undefined,
+                location: typeof rawRoot.source === "string" ? String(rawRoot.source) : undefined,
+                source: typeof resume.source === "string" ? resume.source : undefined,
+            });
+
+            await ctx.runMutation(internal.audit.logAnalysisDecision, {
+                resumeId: args.resumeId,
+                identityKey: resume.identityKey ?? undefined,
+                workspaceSlug: resume.sourceKey ?? "default",
+                decisionType: "score",
+                actionRef: "analyze:analyzeResume",
+                inputSnapshot: {
+                    jobDescriptionId: args.jobDescriptionId,
+                    promptVersion: String(promptVersion),
+                    scrubbedFields: scrubbedFields.length > 0 ? scrubbedFields : undefined,
+                    searchKeywords: args.keywords,
+                },
+                modelMeta: {
+                    model: getAiModel(),
+                    provider: "openai",
+                    apiBase: getAiApiBase(),
+                },
+                output: {
+                    score: result.score,
+                    recommendation: result.recommendation,
+                },
+                protectedAttributeHashes: protectedHashes,
+                explanation: {
+                    summary: `Scored ${result.score}/100 against "${jd.title}". ${result.summary || ""}`,
+                    keyFactors: (result.highlights || []).slice(0, 4).map((h: string) => ({
+                        factor: "highlight",
+                        value: h,
+                    })),
+                },
+                decidedAt: Date.now(),
+            });
+        } catch (auditError) {
+            // Audit logging failure must NOT block the analysis result
+            console.error("Audit logging failed:", auditError);
+        }
 
         return result;
     },

--- a/packages/convex/convex/bias_audit.ts
+++ b/packages/convex/convex/bias_audit.ts
@@ -1,0 +1,237 @@
+import { internalAction, internalMutation, internalQuery, query } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { v } from "convex/values";
+import {
+    computeDemographicParity,
+    computeEqualizedOdds,
+    computeDisparateImpactRatio,
+    type GroupOutcome,
+    type GroupConfusion,
+} from "./lib/bias_metrics.js";
+
+// ---------------------------------------------------------------------------
+// Internal query: queryAuditLogs — fetches audit logs for bias computation
+// ---------------------------------------------------------------------------
+
+export const queryAuditLogs = internalQuery({
+    args: {
+        workspaceSlug: v.string(),
+        decisionType: v.string(),
+    },
+    handler: async (ctx, args) => {
+        return await ctx.db
+            .query("analysis_audit_log")
+            .withIndex("by_workspace_decision", (q) =>
+                q.eq("workspaceSlug", args.workspaceSlug).eq("decisionType", args.decisionType as "score" | "tag" | "rank" | "filter" | "confirm")
+            )
+            .collect();
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Internal action: computeBiasMetrics — scheduled or on-demand
+// ---------------------------------------------------------------------------
+
+interface BiasMetricsResult {
+    status: "ok";
+    workspaceSlug: string;
+    decisionType: string;
+    scoreThreshold: number;
+    totalAuditRecords: number;
+    groupCount: number;
+    demographicParity: {
+        disparityRatio: number;
+        maxDifference: number;
+        passing: boolean;
+        groupRates: Array<{ groupKey: string; rate: number }>;
+    };
+    disparateImpact: Array<{ groupKey: string; ratio: number; referenceGroupKey: string }>;
+    overrideRate: {
+        tprDifference: number;
+        fprDifference: number;
+        passing: boolean;
+    };
+    computedAt: number;
+}
+
+export const computeBiasMetrics = internalAction({
+    args: {
+        workspaceSlug: v.string(),
+        decisionType: v.optional(v.union(
+            v.literal("score"),
+            v.literal("tag"),
+            v.literal("rank"),
+            v.literal("filter"),
+            v.literal("confirm"),
+        )),
+        scoreThreshold: v.optional(v.number()),
+    },
+    handler: async (ctx, args): Promise<BiasMetricsResult | { status: string; count: number; minimumRequired: number; message: string }> => {
+        const workspaceSlug = args.workspaceSlug;
+        const decisionType = args.decisionType ?? "score";
+        const threshold = args.scoreThreshold ?? 70;
+
+        // 1. Fetch all audit logs for this workspace + decision type
+        const auditLogs = await ctx.runQuery(internal.bias_audit.queryAuditLogs, {
+            workspaceSlug,
+            decisionType,
+        }) as Array<{ protectedAttributeHashes?: { ageBracketHash?: string }; output: { score?: number }; outcome?: string }>;
+
+        if (auditLogs.length < 30) {
+            return {
+                status: "insufficient_data",
+                count: auditLogs.length,
+                minimumRequired: 30,
+                message: "Not enough audit records for statistically significant bias analysis.",
+            };
+        }
+
+        // 2. Group by ageBracketHash
+        const groupMap = new Map<string, {
+            total: number;
+            positive: number;
+            scores: number[];
+            outcomes: { accepted: number; overridden: number; pending: number };
+        }>();
+
+        for (const log of auditLogs) {
+            const ageHash = log.protectedAttributeHashes?.ageBracketHash ?? "unknown";
+            const group = groupMap.get(ageHash) ?? {
+                total: 0, positive: 0, scores: [], outcomes: { accepted: 0, overridden: 0, pending: 0 },
+            };
+            group.total++;
+            const score = log.output.score;
+            if (typeof score === "number") {
+                group.scores.push(score);
+                if (score >= threshold) {
+                    group.positive++;
+                }
+            }
+            if (log.outcome === "accepted") group.outcomes.accepted++;
+            else if (log.outcome === "overridden") group.outcomes.overridden++;
+            else group.outcomes.pending++;
+            groupMap.set(ageHash, group);
+        }
+
+        // 3. Compute demographic parity
+        const groups: GroupOutcome[] = [...groupMap.entries()].map(([key, g]) => {
+            const avgScore = g.scores.length > 0
+                ? g.scores.reduce((a, b) => a + b, 0) / g.scores.length
+                : 0;
+            const variance = g.scores.length > 1
+                ? g.scores.reduce((sum, s) => sum + (s - avgScore) ** 2, 0) / (g.scores.length - 1)
+                : 0;
+            return {
+                groupKey: key,
+                total: g.total,
+                positive: g.positive,
+                avgScore,
+                scoreStdDev: Math.sqrt(variance),
+            };
+        });
+
+        const demographicParity = computeDemographicParity(groups);
+
+        // 4. Compute disparate impact (pairwise, largest group as reference)
+        const referenceGroup = groups.reduce((max, g) => g.total > max.total ? g : max, groups[0]);
+        const disparateImpact = groups
+            .filter((g) => g.groupKey !== referenceGroup.groupKey)
+            .map((g) => ({
+                groupKey: g.groupKey,
+                ratio: computeDisparateImpactRatio(g, referenceGroup),
+                referenceGroupKey: referenceGroup.groupKey,
+            }));
+
+        // 5. Compute override rate by group
+        const confusionGroups: GroupConfusion[] = [...groupMap.entries()].map(([key, g]) => ({
+            groupKey: key,
+            truePositives: g.outcomes.accepted,
+            falsePositives: g.outcomes.overridden,
+            trueNegatives: 0,
+            falseNegatives: 0,
+        }));
+        const equalizedOdds = computeEqualizedOdds(confusionGroups);
+
+        // 6. Store results
+        const metrics: BiasMetricsResult = {
+            status: "ok",
+            workspaceSlug,
+            decisionType,
+            scoreThreshold: threshold,
+            totalAuditRecords: auditLogs.length,
+            groupCount: groups.length,
+            demographicParity: {
+                disparityRatio: demographicParity.disparityRatio,
+                maxDifference: demographicParity.maxDifference,
+                passing: demographicParity.passing,
+                groupRates: demographicParity.groupRates,
+            },
+            disparateImpact,
+            overrideRate: {
+                tprDifference: equalizedOdds.tprDifference,
+                fprDifference: equalizedOdds.fprDifference,
+                passing: equalizedOdds.passing,
+            },
+            computedAt: Date.now(),
+        };
+
+        await ctx.runMutation(internal.bias_audit.storeBiasReport, {
+            workspaceSlug,
+            report: metrics,
+        });
+
+        return metrics;
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Internal mutation: storeBiasReport
+// ---------------------------------------------------------------------------
+
+export const storeBiasReport = internalMutation({
+    args: {
+        workspaceSlug: v.string(),
+        report: v.any(),
+    },
+    handler: async (ctx, args) => {
+        const existing = await ctx.db
+            .query("workspace_config")
+            .withIndex("by_workspace_key", (q) =>
+                q.eq("workspaceSlug", args.workspaceSlug).eq("configKey", "bias_audit_report")
+            )
+            .first();
+
+        if (existing) {
+            await ctx.db.patch(existing._id, {
+                configValue: args.report,
+                updatedAt: Date.now(),
+            });
+        } else {
+            await ctx.db.insert("workspace_config", {
+                workspaceSlug: args.workspaceSlug,
+                configKey: "bias_audit_report",
+                configValue: args.report,
+                updatedAt: Date.now(),
+            });
+        }
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Public query: getLatestBiasReport
+// ---------------------------------------------------------------------------
+
+export const getLatestBiasReport = query({
+    args: {
+        workspaceSlug: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const config = await ctx.db
+            .query("workspace_config")
+            .withIndex("by_workspace_key", (q) =>
+                q.eq("workspaceSlug", args.workspaceSlug).eq("configKey", "bias_audit_report")
+            )
+            .first();
+        return config?.configValue ?? null;
+    },
+});

--- a/packages/shared/src/generated/resume-field-usage-policy.ts
+++ b/packages/shared/src/generated/resume-field-usage-policy.ts
@@ -3,7 +3,7 @@
 // Source: config/resume/field-usage-policy.json5
 // Run: make sync-resume-field-usage-policy
 
-export const RESUME_FIELD_USAGE_SURFACES = ["analysis","presentation","outreach","debug"] as const;
+export const RESUME_FIELD_USAGE_SURFACES = ["analysis","presentation","outreach","audit","debug"] as const;
 
 export type ResumeFieldUsageSurface = (typeof RESUME_FIELD_USAGE_SURFACES)[number];
 
@@ -20,16 +20,35 @@ export interface ResumeFieldUsagePolicy {
 }
 
 export const DEFAULT_RESUME_FIELD_USAGE_POLICY = {
-  "version": 1,
-  "updatedAt": "2026-03-20",
-  "description": "Controls which canonical resume fields participate in analysis, presentation, outreach, and debug surfaces without deleting raw stored resume data.",
+  "version": 2,
+  "updatedAt": "2026-05-24",
+  "description": "Controls which canonical resume fields participate in analysis, presentation, outreach, audit, and debug surfaces without deleting raw stored resume data. The 'audit' surface allows protected attributes for compliance logging while keeping them scrubbed from AI analysis.",
   "sourceFileRelativePath": "config/resume/field-usage-policy.json5",
   "fields": {
+    "age": {
+      "surfaces": {
+        "analysis": false,
+        "presentation": false,
+        "outreach": false,
+        "audit": true,
+        "debug": false
+      }
+    },
+    "gender": {
+      "surfaces": {
+        "analysis": false,
+        "presentation": false,
+        "outreach": false,
+        "audit": true,
+        "debug": false
+      }
+    },
     "jobIntention": {
       "surfaces": {
         "analysis": false,
         "presentation": false,
         "outreach": false,
+        "audit": false,
         "debug": false
       }
     },
@@ -43,6 +62,7 @@ export const DEFAULT_RESUME_FIELD_USAGE_POLICY = {
         "analysis": false,
         "presentation": false,
         "outreach": false,
+        "audit": false,
         "debug": false
       }
     }

--- a/scripts/resume/sync-field-usage-policy.ts
+++ b/scripts/resume/sync-field-usage-policy.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 
 import JSON5 from "json5";
 
-const RESUME_FIELD_USAGE_SURFACES = ["analysis", "presentation", "outreach", "debug"] as const;
+const RESUME_FIELD_USAGE_SURFACES = ["analysis", "presentation", "outreach", "audit", "debug"] as const;
 
 type ResumeFieldUsageSurface = (typeof RESUME_FIELD_USAGE_SURFACES)[number];
 type ResumeFieldUsageFieldPolicy = {


### PR DESCRIPTION
## Summary
- Add `"audit"` surface to ResumeFieldUsagePolicy — age/gender are `analysis: false, audit: true`, allowing compliance logging while keeping protected attributes scrubbed from AI prompts
- Wire `logAnalysisDecision` into `analyze.ts` after each LLM scoring call — computes scrubbedFields diff, protectedAttributeHashes, and explanation from analysis result
- Wire audit logging into `ai_tagging_results.ts` drainQueue — logs tag decisions with model metadata and protected attribute hashes
- Create `bias_audit.ts` with:
  - `computeBiasMetrics` internal action — computes demographic parity, disparate impact, and override rate from audit log; stores in `workspace_config`
  - `getLatestBiasReport` public query — retrieves latest bias metrics for a workspace
  - `queryAuditLogs` internal query — fetches audit logs grouped by workspace + decision type
  - `storeBiasReport` internal mutation — upserts bias report into workspace_config

## Test plan
- [x] `make check` passes
- [x] All 1238 tests pass (833 Convex + 405 browser extension)
- [x] TypeScript compiles with zero errors
- [ ] Manual: trigger `computeBiasMetrics` action after audit log has entries, verify report stored
- [ ] Operational: schedule `computeBiasMetrics` via Convex cron for weekly execution