### PR TITLE
feat: wire bias audit cron + extract RRF merge for hybrid search testing

### DIFF
--- a/packages/convex/convex/__tests__/audit-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/audit-convex-test.test.ts
@@ -223,6 +223,73 @@ describe("audit (convex-test)", () => {
       expect(allLogs.length).toBe(2);
     });
   });
+
+  describe("listWorkspaceSlugsWithAuditLogs", () => {
+    it("returns distinct workspace slugs from audit logs", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "slug-r1",
+          content: {},
+          hash: "slug1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+      });
+
+      const now = Date.now();
+      await t.run(async (ctx) => {
+        await ctx.db.insert("analysis_audit_log", {
+          resumeId,
+          workspaceSlug: "ws-alpha",
+          decisionType: "score",
+          actionRef: "analyze:analyzeResume",
+          inputSnapshot: {},
+          modelMeta: { model: "gpt-4", provider: "openai" },
+          output: { score: 80 },
+          outcome: "pending",
+          decidedAt: now,
+          expiresAt: now + 2 * 365 * 24 * 60 * 60 * 1000,
+        });
+        await ctx.db.insert("analysis_audit_log", {
+          resumeId,
+          workspaceSlug: "ws-beta",
+          decisionType: "score",
+          actionRef: "analyze:analyzeResume",
+          inputSnapshot: {},
+          modelMeta: { model: "gpt-4", provider: "openai" },
+          output: { score: 85 },
+          outcome: "pending",
+          decidedAt: now + 1000,
+          expiresAt: now + 2 * 365 * 24 * 60 * 60 * 1000,
+        });
+        // Same workspace slug — should be deduplicated
+        await ctx.db.insert("analysis_audit_log", {
+          resumeId,
+          workspaceSlug: "ws-alpha",
+          decisionType: "tag",
+          actionRef: "ai_tagging_results:tagResume",
+          inputSnapshot: {},
+          modelMeta: { model: "gpt-4", provider: "openai" },
+          output: { tags: ["lead"] },
+          outcome: "pending",
+          decidedAt: now + 2000,
+          expiresAt: now + 2 * 365 * 24 * 60 * 60 * 1000,
+        });
+      });
+
+      const slugs = await t.query(internal.bias_audit.listWorkspaceSlugsWithAuditLogs, {});
+      expect(slugs.sort()).toEqual(["ws-alpha", "ws-beta"]);
+    });
+
+    it("returns empty array when no audit logs exist", async () => {
+      const t = convexTest(schema, modules);
+      const slugs = await t.query(internal.bias_audit.listWorkspaceSlugsWithAuditLogs, {});
+      expect(slugs).toEqual([]);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/convex/convex/__tests__/embeddings-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/embeddings-convex-test.test.ts
@@ -10,6 +10,7 @@ import { api } from "../_generated/api.js";
 import { internal } from "../_generated/api.js";
 import schema from "../schema.js";
 import type { Doc, Id } from "../_generated/dataModel.js";
+import { rrfMerge } from "../embeddings.js";
 
 const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
 
@@ -262,5 +263,124 @@ describe("embeddings (convex-test)", () => {
       expect(stats.latestModel).toBe("text-embedding-3-small");
       expect(stats.latestGeneratedAt).toBeGreaterThan(0);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests for RRF merge logic (pure function, no Convex needed)
+// ---------------------------------------------------------------------------
+
+describe("rrfMerge (unit)", () => {
+  it("merges BM25 and vector results with RRF scoring", () => {
+    const bm25Results = [
+      { id: "r1", data: { name: "Alice" } },
+      { id: "r2", data: { name: "Bob" } },
+      { id: "r3", data: { name: "Carol" } },
+    ];
+    const vectorResults = [
+      { id: "r2" },  // Also in BM25 (rank 2) → gets both scores
+      { id: "r4" },  // Vector-only → gets only semantic score
+      { id: "r1" },  // Also in BM25 (rank 1) → gets both scores
+    ];
+
+    const result = rrfMerge({
+      bm25Results,
+      vectorResults,
+      bm25Weight: 0.5,
+      semanticWeight: 0.5,
+    });
+
+    expect(result.bm25Count).toBe(3);
+    expect(result.vectorCount).toBe(3);
+    expect(result.merged.length).toBe(4); // r1, r2, r3, r4
+
+    // r1 and r2 should rank highest (both BM25 + vector contributions)
+    const topIds = result.merged.slice(0, 2).map((r) => r.id);
+    expect(topIds).toContain("r1");
+    expect(topIds).toContain("r2");
+  });
+
+  it("returns BM25 order when no vector results", () => {
+    const bm25Results = [
+      { id: "r1", data: { name: "Alice" } },
+      { id: "r2", data: { name: "Bob" } },
+    ];
+
+    const result = rrfMerge({
+      bm25Results,
+      vectorResults: [],
+      bm25Weight: 0.5,
+      semanticWeight: 0.5,
+    });
+
+    expect(result.merged.length).toBe(2);
+    expect(result.merged[0].id).toBe("r1");
+    expect(result.merged[1].id).toBe("r2");
+  });
+
+  it("returns vector order when no BM25 results", () => {
+    const vectorResults = [
+      { id: "r1" },
+      { id: "r2" },
+    ];
+
+    const result = rrfMerge({
+      bm25Results: [],
+      vectorResults,
+      bm25Weight: 0.5,
+      semanticWeight: 0.5,
+    });
+
+    expect(result.merged.length).toBe(2);
+    expect(result.merged[0].id).toBe("r1");
+    expect(result.merged[0].data).toEqual({}); // No BM25 data
+  });
+
+  it("applies weight asymmetry correctly", () => {
+    const bm25Results = [
+      { id: "r1", data: {} },
+    ];
+    const vectorResults = [
+      { id: "r2" },
+    ];
+
+    // With 100% BM25 weight, r1 should score higher
+    const bm25Heavy = rrfMerge({
+      bm25Results,
+      vectorResults: [{ id: "r2" }],
+      bm25Weight: 1.0,
+      semanticWeight: 0.0,
+    });
+    expect(bm25Heavy.merged[0].id).toBe("r1");
+
+    // With 100% semantic weight, r2 should score higher
+    const semanticHeavy = rrfMerge({
+      bm25Results,
+      vectorResults: [{ id: "r2" }],
+      bm25Weight: 0.0,
+      semanticWeight: 1.0,
+    });
+    expect(semanticHeavy.merged[0].id).toBe("r2");
+  });
+
+  it("deduplicates when same ID appears in both lists", () => {
+    const bm25Results = [
+      { id: "r1", data: { source: "bm25" } },
+    ];
+    const vectorResults = [
+      { id: "r1" },  // Same resume in both
+    ];
+
+    const result = rrfMerge({
+      bm25Results,
+      vectorResults,
+      bm25Weight: 0.5,
+      semanticWeight: 0.5,
+    });
+
+    expect(result.merged.length).toBe(1);
+    expect(result.merged[0].id).toBe("r1");
+    // Data comes from BM25 (primary source)
+    expect(result.merged[0].data).toEqual({ source: "bm25" });
   });
 });

--- a/packages/convex/convex/bias_audit.ts
+++ b/packages/convex/convex/bias_audit.ts
@@ -10,6 +10,52 @@ import {
 } from "./lib/bias_metrics.js";
 
 // ---------------------------------------------------------------------------
+// Internal query: listWorkspaceSlugsWithAuditLogs — distinct workspace slugs
+// ---------------------------------------------------------------------------
+
+export const listWorkspaceSlugsWithAuditLogs = internalQuery({
+    args: {},
+    handler: async (ctx) => {
+        // Use full table scan — this runs infrequently (weekly cron) and
+        // workspace count is small. Extract distinct slugs from audit logs.
+        const logs = await ctx.db
+            .query("analysis_audit_log")
+            .take(10000);
+        const slugs = new Set<string>();
+        for (const log of logs) {
+            slugs.add(log.workspaceSlug);
+        }
+        return [...slugs];
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Internal action: computeBiasMetricsForAllWorkspaces — cron entry point
+// ---------------------------------------------------------------------------
+
+export const computeBiasMetricsForAllWorkspaces = internalAction({
+    args: {},
+    handler: async (ctx) => {
+        const workspaceSlugs = await ctx.runQuery(internal.bias_audit.listWorkspaceSlugsWithAuditLogs) as string[];
+        const results: Array<{ workspaceSlug: string; status: string }> = [];
+
+        for (const workspaceSlug of workspaceSlugs) {
+            try {
+                const result = await ctx.runAction(internal.bias_audit.computeBiasMetrics, {
+                    workspaceSlug,
+                    decisionType: "score",
+                }) as { status: string };
+                results.push({ workspaceSlug, status: result.status });
+            } catch (error) {
+                results.push({ workspaceSlug, status: `error: ${error instanceof Error ? error.message : String(error)}` });
+            }
+        }
+
+        return results;
+    },
+});
+
+// ---------------------------------------------------------------------------
 // Internal query: queryAuditLogs — fetches audit logs for bias computation
 // ---------------------------------------------------------------------------
 

--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -24,4 +24,11 @@ crons.daily(
     {},
 );
 
+crons.weekly(
+    "compute bias audit metrics",
+    { dayOfWeek: "monday", hourUTC: 4, minuteUTC: 0 },
+    internal.bias_audit.computeBiasMetricsForAllWorkspaces,
+    {},
+);
+
 export default crons;

--- a/packages/convex/convex/embeddings.ts
+++ b/packages/convex/convex/embeddings.ts
@@ -11,6 +11,56 @@ const EMBEDDING_MODEL = "text-embedding-3-small";
 const EMBEDDING_DIMENSIONS = 1536;
 const BATCH_SIZE = 100;
 
+// ---------------------------------------------------------------------------
+// RRF (Reciprocal Rank Fusion) merge — exported for testing
+// ---------------------------------------------------------------------------
+
+const RRF_K = 60;
+
+export function rrfMerge(params: {
+    bm25Results: Array<{ id: string; data: Record<string, unknown> }>;
+    vectorResults: Array<{ id: string }>;
+    bm25Weight: number;
+    semanticWeight: number;
+}): {
+    merged: Array<{ id: string; score: number; data: Record<string, unknown> }>;
+    bm25Count: number;
+    vectorCount: number;
+} {
+    const { bm25Results, vectorResults, bm25Weight, semanticWeight } = params;
+    const rrfScores = new Map<string, number>();
+    const dataMap = new Map<string, Record<string, unknown>>();
+
+    // BM25 contribution
+    bm25Results.forEach((result, idx) => {
+        const rank = idx + 1;
+        rrfScores.set(result.id, bm25Weight / (RRF_K + rank));
+        dataMap.set(result.id, result.data);
+    });
+
+    // Vector contribution
+    vectorResults.forEach((result, idx) => {
+        const rank = idx + 1;
+        const current = rrfScores.get(result.id) ?? 0;
+        rrfScores.set(result.id, current + semanticWeight / (RRF_K + rank));
+    });
+
+    // Sort by RRF score descending
+    const merged = [...rrfScores.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([id, score]) => ({
+            id,
+            score,
+            data: dataMap.get(id) ?? {},
+        }));
+
+    return {
+        merged,
+        bm25Count: bm25Results.length,
+        vectorCount: vectorResults.length,
+    };
+}
+
 function getApiKey(): string {
     const key = process.env.AI_API_KEY || process.env.OPENAI_API_KEY;
     if (!key) throw new Error("AI_API_KEY/OPENAI_API_KEY is not set in Convex environment variables.");
@@ -346,32 +396,34 @@ export const hybridSearchResumes = action({
         const embeddings = await ctx.runQuery(internal.embeddings.getEmbeddingsByIds, {
             embeddingIds: vectorIds,
         });
-        const vectorResumeMap = new Map<string, number>(); // resumeId -> vector rank
-        embeddings.forEach((emb: Doc<"resume_embeddings">, idx: number) => {
-            vectorResumeMap.set(String(emb.resumeId), idx + 1); // 1-based rank
-        });
+        const vectorResults = embeddings.map((emb: Doc<"resume_embeddings">) => ({
+            id: String(emb.resumeId),
+        }));
 
-        // 5. RRF (Reciprocal Rank Fusion) merge with k=60
-        const K = 60;
-        const rrfScores = new Map<string, number>(); // resumeId -> RRF score
-        const resumeDocMap = new Map<string, HybridSearchResult["results"][number]>(); // resumeId -> result entry
+        // 5. RRF merge
+        const bm25Merged = bm25Result.results.map((result: HybridSearchResult["results"][number]) => ({
+            id: String((result.resume as { _id: string })._id),
+            data: result as Record<string, unknown>,
+        }));
 
-        // BM25 contribution
-        bm25Result.results.forEach((result: HybridSearchResult["results"][number], idx: number) => {
-            const resumeId = String((result.resume as { _id: string })._id);
-            const rank = idx + 1;
-            rrfScores.set(resumeId, bm25Weight / (K + rank));
-            resumeDocMap.set(resumeId, result);
-        });
-
-        // Vector contribution
-        vectorResumeMap.forEach((rank: number, resumeId: string) => {
-            const current = rrfScores.get(resumeId) ?? 0;
-            rrfScores.set(resumeId, current + semanticWeight / (K + rank));
+        const { merged: rrfMerged, bm25Count, vectorCount } = rrfMerge({
+            bm25Results: bm25Merged,
+            vectorResults,
+            bm25Weight,
+            semanticWeight,
         });
 
         // 6. Fetch docs for vector-only results (not in BM25 results)
-        const vectorOnlyIds = [...vectorResumeMap.keys()].filter((id) => !resumeDocMap.has(id));
+        const bm25Ids = new Set(bm25Merged.map((r) => r.id));
+        const vectorOnlyIds = vectorResults.map((v) => v.id).filter((id) => !bm25Ids.has(id));
+
+        const resumeDocMap = new Map<string, HybridSearchResult["results"][number]>();
+        // Seed with BM25 results
+        bm25Result.results.forEach((result: HybridSearchResult["results"][number]) => {
+            const resumeId = String((result.resume as { _id: string })._id);
+            resumeDocMap.set(resumeId, result);
+        });
+
         if (vectorOnlyIds.length > 0) {
             const additionalDocs = await ctx.runQuery(internal.resumes.getResumesByIds, {
                 resumeIds: vectorOnlyIds.map((id) => id as unknown as Id<"resumes">),
@@ -397,13 +449,9 @@ export const hybridSearchResumes = action({
             }
         }
 
-        // 7. Sort by RRF score (descending)
-        const sortedIds = [...rrfScores.entries()]
-            .sort((a, b) => b[1] - a[1])
-            .map(([id]) => id);
-
-        const mergedResults = sortedIds
-            .map((id) => resumeDocMap.get(id))
+        // 7. Build merged results from RRF ordering
+        const mergedResults = rrfMerged
+            .map((entry) => resumeDocMap.get(entry.id))
             .filter((r): r is NonNullable<typeof r> => r !== undefined);
 
         return {
@@ -412,8 +460,8 @@ export const hybridSearchResumes = action({
             results: mergedResults,
             searchMode: "hybrid" as const,
             debug: {
-                bm25Count: bm25Result.results.length,
-                vectorCount: vectorIds.length,
+                bm25Count,
+                vectorCount,
                 mergedCount: mergedResults.length,
                 semanticWeight,
             },


### PR DESCRIPTION
## Summary
- Wire `computeBiasMetricsForAllWorkspaces` into weekly Convex cron (Monday 04:00 UTC)
- Add `listWorkspaceSlugsWithAuditLogs` internal query to discover workspaces with audit data
- Extract `rrfMerge()` pure function from `hybridSearchResumes` for testability
- Add 2 convex-test integration tests for workspace slug listing
- Add 5 unit tests for RRF merge logic (merge, empty inputs, weight asymmetry, dedup)

## Test plan
- [x] `npx vitest run packages/convex` — 840 tests passing
- [x] `make check` — all checks passed
- [ ] Deploy to staging and verify cron fires on schedule
- [ ] After production backfill, verify `getLatestBiasReport` returns populated metrics

## Context
Follows PR #918 (audit logging wiring). Completes P1 (bias audit cron) and P2 (hybrid search RRF testability) from next-actions list.