### PR TITLE
feat: add dryRun and delayMs safeguards to batchGenerateEmbeddings

### DIFF
--- a/packages/convex/convex/__tests__/embeddings-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/embeddings-convex-test.test.ts
@@ -227,6 +227,46 @@ describe("embeddings (convex-test)", () => {
     });
   });
 
+  describe("batchGenerateEmbeddings (internal) — dryRun", () => {
+    it("dryRun reports scope without generating embeddings", async () => {
+      const t = convexTest(schema, modules);
+
+      // Insert resumes without embeddings
+      await t.run(async (ctx) => {
+        await ctx.db.insert("resumes", {
+          externalId: "dry-1",
+          content: {},
+          hash: "dry1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+          searchText: "Resume for dry run test",
+        });
+        await ctx.db.insert("resumes", {
+          externalId: "dry-2",
+          content: {},
+          hash: "dry2",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+          searchText: "", // Empty — should be skipped
+        });
+      });
+
+      const result = await t.action(internal.embeddings.batchGenerateEmbeddings, {
+        dryRun: true,
+        limit: 10,
+      });
+
+      // dryRun should not generate any embeddings
+      expect(result.generated).toBe(0);
+      // Should report how many would be generated (1 resume with non-empty searchText)
+      expect(result.wouldGenerate).toBe(1);
+      // All resumes counted as skipped in dryRun
+      expect(result.skipped).toBe(2);
+    });
+  });
+
   describe("getEmbeddingStats (public)", () => {
     it("returns empty stats when no embeddings exist", async () => {
       const t = convexTest(schema, modules);

--- a/packages/convex/convex/embeddings.ts
+++ b/packages/convex/convex/embeddings.ts
@@ -193,6 +193,7 @@ export const storeEmbedding = internalMutation({
 interface BatchResult {
     generated: number;
     skipped: number;
+    wouldGenerate?: number;
     hasMore: boolean;
     cursor: string | null;
 }
@@ -201,9 +202,13 @@ export const batchGenerateEmbeddings = internalAction({
     args: {
         cursor: v.optional(v.string()),
         limit: v.optional(v.number()),
+        dryRun: v.optional(v.boolean()),
+        delayMs: v.optional(v.number()),
     },
     handler: async (ctx, args): Promise<BatchResult> => {
         const limit = Math.min(args.limit ?? BATCH_SIZE, BATCH_SIZE);
+        const dryRun = args.dryRun ?? false;
+        const delayMs = Math.max(args.delayMs ?? 0, 0);
 
         // Fetch resumes without embeddings, paginated
         const page = await ctx.runQuery(internal.embeddings.getResumesWithoutEmbeddings, {
@@ -211,10 +216,25 @@ export const batchGenerateEmbeddings = internalAction({
             numItems: limit,
         });
 
+        // dryRun: report scope without calling the API
+        if (dryRun) {
+            const emptySearchText = page.resumes.filter((r) => !buildEmbeddingText(r).trim()).length;
+            const toEmbed = page.resumes.length - emptySearchText;
+            console.log(`[dryRun] ${toEmbed} resumes would be embedded, ${emptySearchText} skipped (empty searchText), ${page.hasMore ? "more pages available" : "last page"}`);
+            return {
+                generated: 0,
+                skipped: page.resumes.length,
+                wouldGenerate: toEmbed,
+                hasMore: page.hasMore,
+                cursor: page.nextCursor,
+            };
+        }
+
         let generated = 0;
         let skipped = 0;
 
-        for (const resume of page.resumes) {
+        for (let i = 0; i < page.resumes.length; i++) {
+            const resume = page.resumes[i];
             const text = buildEmbeddingText(resume);
             if (!text.trim()) {
                 skipped++;
@@ -230,6 +250,11 @@ export const batchGenerateEmbeddings = internalAction({
                     sourceKey: resume.sourceKey ?? undefined,
                 });
                 generated++;
+
+                // Throttle between API calls to stay within rate limits
+                if (delayMs > 0 && i < page.resumes.length - 1) {
+                    await new Promise((resolve) => setTimeout(resolve, delayMs));
+                }
             } catch (err) {
                 console.error(`Failed to generate embedding for resume ${resume._id}:`, err);
                 skipped++;


### PR DESCRIPTION
## Summary
- Add `dryRun` parameter to `batchGenerateEmbeddings` — previews scope (count of resumes that would be embedded) without calling the OpenAI API
- Add `delayMs` parameter — throttles between API calls to stay within OpenAI rate limits and Convex write limits
- Fix throttle condition: use loop index instead of generated count to avoid spurious delay after last API call when page contains skipped items
- Add `wouldGenerate` field to `BatchResult` for dryRun reporting
- Add convex-test integration test for dryRun mode

## Test plan
- [x] `npx vitest run packages/convex/convex/__tests__/embeddings-convex-test.test.ts` — 15/15 pass
- [x] `make check` — all pass
- [ ] Manual: run `batchGenerateEmbeddings` with `dryRun: true` against a seeded dataset to verify scope reporting
- [ ] Manual: run with `delayMs: 500` to verify throttling between API calls