### PR TITLE
refactor: extract PAGE_BRIDGE listener into lib/page-bridge.ts

### DIFF
--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -35,6 +35,7 @@ import { createUiUtils, type UiUtilsDeps } from "./lib/ui-utils";
 import { createPaginationUtils } from "./lib/pagination-utils";
 import { createDomUtils, delay } from "./lib/dom-utils";
 import { createResumeExtractor, type ResumeExtractorDeps } from "./lib/resume-extractor";
+import { createPageBridge, type PageBridgeDeps } from "./lib/page-bridge";
 import { createSyncStatusWidget } from "./lib/sync-status-widget";
 import { createAutoSyncRunner } from "./lib/auto-sync-runner";
 import {
@@ -73,10 +74,6 @@ import {
   JOB51_RATE_LIMIT_ERROR_MESSAGE,
   API_CAPTURE_SOURCE,
   EXTERNAL_ACCESS_KEY,
-  PAGE_BRIDGE_REQUEST_EVENT,
-  PAGE_BRIDGE_RESPONSE_EVENT,
-  PAGE_BRIDGE_REQUEST_ATTR,
-  PAGE_BRIDGE_RESPONSE_ATTR,
   JOB51_NEXT_PAGE_EVENT,
   CONTENT_SCRIPT_SOURCE,
   JOB5156_DETAIL_FETCH_TIMEOUT_MS,
@@ -783,123 +780,20 @@ window.addEventListener("message", (event) => {
   updateApiSnapshot(msg);
 });
 
-window.addEventListener(PAGE_BRIDGE_REQUEST_EVENT, async () => {
-  const requestPayload = document.documentElement.getAttribute(
-    PAGE_BRIDGE_REQUEST_ATTR,
-  );
-  if (!requestPayload) return;
-
-  let response = {
-    id: null,
-    ok: false,
-    error: "Invalid bridge request",
-    value: undefined,
-  };
-
-  try {
-    const request = JSON.parse(requestPayload);
-    const requestId = request?.id ?? null;
-    const method = typeof request?.method === "string" ? request.method : "";
-    const args = Array.isArray(request?.args) ? request.args : [];
-
-    response.id = requestId;
-
-    switch (method) {
-      case "extract":
-        response = {
-          id: requestId,
-          ok: true,
-          error: "",
-          value: extractResumes(),
-        };
-        break;
-      case "extractRaw":
-        response = {
-          id: requestId,
-          ok: true,
-          error: "",
-          value: extractResumesRaw(args[0]),
-        };
-        break;
-      case "collect":
-        response = {
-          id: requestId,
-          ok: true,
-          error: "",
-          value: await collectSnapshotPayload(args[0]),
-        };
-        break;
-      case "getApiSnapshot":
-        response = { id: requestId, ok: true, error: "", value: apiSnapshot };
-        break;
-      case "getPaginationInfo":
-        response = {
-          id: requestId,
-          ok: true,
-          error: "",
-          value: getPaginationInfo(),
-        };
-        break;
-      case "isReady":
-        response = {
-          id: requestId,
-          ok: true,
-          error: "",
-          value: isExtractionReady(),
-        };
-        break;
-      case "isLoggedIn":
-        response = { id: requestId, ok: true, error: "", value: isLoggedIn() };
-        break;
-      case "status":
-        response = {
-          id: requestId,
-          ok: true,
-          error: "",
-          value: window[EXTERNAL_ACCESS_KEY]?.status?.(),
-        };
-        break;
-      case "syncToServer":
-        response = {
-          id: requestId,
-          ok: true,
-          error: "",
-          value: await syncCurrentPageToServer(args[0]),
-        };
-        break;
-      case "goToNextPage":
-        response = {
-          id: requestId,
-          ok: true,
-          error: "",
-          value: goToNextPageInternal(),
-        };
-        break;
-      default:
-        response = {
-          id: requestId,
-          ok: false,
-          error: method
-            ? `Unsupported bridge method: ${method}`
-            : "Missing bridge method",
-          value: undefined,
-        };
-        break;
-    }
-  } catch (error) {
-    response = {
-      ...response,
-      ok: false,
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
-
-  document.documentElement.setAttribute(
-    PAGE_BRIDGE_RESPONSE_ATTR,
-    JSON.stringify(response),
-  );
-  window.dispatchEvent(new CustomEvent(PAGE_BRIDGE_RESPONSE_EVENT));
+const _pageBridge = createPageBridge({
+  doc: document,
+  win: window as PageBridgeDeps["win"],
+  extractResumes,
+  extractResumesRaw,
+  collectSnapshotPayload,
+  getApiSnapshot: () => apiSnapshot,
+  getPaginationInfo,
+  isExtractionReady,
+  isLoggedIn,
+  syncCurrentPageToServer,
+  goToNextPageInternal,
 });
+_pageBridge.installPageBridgeListener();
 
 
 

--- a/apps/browser-extension/src/lib/page-bridge.ts
+++ b/apps/browser-extension/src/lib/page-bridge.ts
@@ -1,0 +1,170 @@
+import {
+  PAGE_BRIDGE_REQUEST_ATTR,
+  PAGE_BRIDGE_REQUEST_EVENT,
+  PAGE_BRIDGE_RESPONSE_ATTR,
+  PAGE_BRIDGE_RESPONSE_EVENT,
+  EXTERNAL_ACCESS_KEY,
+} from "./content-constants";
+
+export interface PageBridgeDeps {
+  doc: Document;
+  win: Window & { [EXTERNAL_ACCESS_KEY]?: { status?: () => unknown } };
+  extractResumes: () => unknown;
+  extractResumesRaw: (mode?: unknown) => unknown;
+  collectSnapshotPayload: (options?: unknown) => Promise<unknown>;
+  getApiSnapshot: () => unknown;
+  getPaginationInfo: () => unknown;
+  isExtractionReady: () => boolean;
+  isLoggedIn: () => boolean;
+  syncCurrentPageToServer: (resumes?: unknown) => Promise<unknown>;
+  goToNextPageInternal: () => unknown;
+}
+
+export function createPageBridge(deps: PageBridgeDeps) {
+  const {
+    doc,
+    win,
+    extractResumes,
+    extractResumesRaw,
+    collectSnapshotPayload,
+    getApiSnapshot,
+    getPaginationInfo,
+    isExtractionReady,
+    isLoggedIn,
+    syncCurrentPageToServer,
+    goToNextPageInternal,
+  } = deps;
+
+  function installPageBridgeListener() {
+    win.addEventListener(PAGE_BRIDGE_REQUEST_EVENT, async () => {
+      const requestPayload = doc.documentElement.getAttribute(
+        PAGE_BRIDGE_REQUEST_ATTR,
+      );
+      if (!requestPayload) return;
+
+      let response = {
+        id: null as unknown,
+        ok: false,
+        error: "Invalid bridge request",
+        value: undefined as unknown,
+      };
+
+      try {
+        const request = JSON.parse(requestPayload);
+        const requestId = request?.id ?? null;
+        const method =
+          typeof request?.method === "string" ? request.method : "";
+        const args = Array.isArray(request?.args) ? request.args : [];
+
+        response.id = requestId;
+
+        switch (method) {
+          case "extract":
+            response = {
+              id: requestId,
+              ok: true,
+              error: "",
+              value: extractResumes(),
+            };
+            break;
+          case "extractRaw":
+            response = {
+              id: requestId,
+              ok: true,
+              error: "",
+              value: extractResumesRaw(args[0]),
+            };
+            break;
+          case "collect":
+            response = {
+              id: requestId,
+              ok: true,
+              error: "",
+              value: await collectSnapshotPayload(args[0]),
+            };
+            break;
+          case "getApiSnapshot":
+            response = {
+              id: requestId,
+              ok: true,
+              error: "",
+              value: getApiSnapshot(),
+            };
+            break;
+          case "getPaginationInfo":
+            response = {
+              id: requestId,
+              ok: true,
+              error: "",
+              value: getPaginationInfo(),
+            };
+            break;
+          case "isReady":
+            response = {
+              id: requestId,
+              ok: true,
+              error: "",
+              value: isExtractionReady(),
+            };
+            break;
+          case "isLoggedIn":
+            response = {
+              id: requestId,
+              ok: true,
+              error: "",
+              value: isLoggedIn(),
+            };
+            break;
+          case "status":
+            response = {
+              id: requestId,
+              ok: true,
+              error: "",
+              value: win[EXTERNAL_ACCESS_KEY]?.status?.(),
+            };
+            break;
+          case "syncToServer":
+            response = {
+              id: requestId,
+              ok: true,
+              error: "",
+              value: await syncCurrentPageToServer(args[0]),
+            };
+            break;
+          case "goToNextPage":
+            response = {
+              id: requestId,
+              ok: true,
+              error: "",
+              value: goToNextPageInternal(),
+            };
+            break;
+          default:
+            response = {
+              id: requestId,
+              ok: false,
+              error: method
+                ? `Unsupported bridge method: ${method}`
+                : "Missing bridge method",
+              value: undefined,
+            };
+            break;
+        }
+      } catch (error) {
+        response = {
+          ...response,
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+
+      doc.documentElement.setAttribute(
+        PAGE_BRIDGE_RESPONSE_ATTR,
+        JSON.stringify(response),
+      );
+      win.dispatchEvent(new CustomEvent(PAGE_BRIDGE_RESPONSE_EVENT));
+    });
+  }
+
+  return { installPageBridgeListener };
+}


### PR DESCRIPTION
## Summary
- Extract the `window.addEventListener(PAGE_BRIDGE_REQUEST_EVENT, ...)` handler (~116L) from content.ts into `lib/page-bridge.ts` using the established DI factory pattern
- content.ts: 1,151 → 1,045L (-106L, now 86% reduction from original 7,311L)
- No behavior change — factory receives all deps via `createPageBridge(deps)`

## Test plan
- [x] 413/413 browser extension tests pass (excluding 9 pre-existing age-filter regression failures on main)
- [x] `make check` passes