### PR TITLE
chore: unify TypeScript version to ^5.9.3 across all workspaces

### DIFF
--- a/apps/browser-extension/package.json
+++ b/apps/browser-extension/package.json
@@ -20,6 +20,6 @@
     "esbuild": "^0.27.0",
     "eslint": "^10.1.0",
     "globals": "^17.4.0",
-    "typescript": "~5.6.2"
+    "typescript": "^5.9.3"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -61,7 +61,7 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.19",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "~5.6.2",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",
     "vite": "^6.4.2",
     "vitest": "^4.0.18"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,6 +30,6 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "typescript": "^5.7.2"
+    "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Summary
- Unifies TypeScript `devDependencies` to `^5.9.3` across all 5 workspaces
- `packages/shared`: `^5.7.2` → `^5.9.3`
- `apps/browser-extension`: `~5.6.2` → `^5.9.3`
- `apps/web`: `~5.6.2` → `^5.9.3`
- `packages/convex` and `apps/api` were already `^5.9.3`

No functional change — all workspaces already resolve to 5.9.3 via the lockfile. This just aligns declared ranges with reality and removes the confusing `~5.6.2` pins that suggested an older TS was in use.

## Test plan
- [x] `make check` passes (typecheck + lint + governance)
- [x] All convex tests pass (875/875)