### PR TITLE
test: add matchSearchProfilesByKeywords coverage (10 tests)

### DIFF
--- a/apps/api/src/services/search-profile-service.test.ts
+++ b/apps/api/src/services/search-profile-service.test.ts
@@ -147,3 +147,111 @@ describe('SearchProfileService seek source validation', () => {
     ).not.toThrow()
   })
 })
+
+describe('matchSearchProfilesByKeywords', () => {
+  const profiles: SearchProfile[] = [
+    {
+      id: 'cnc-sales',
+      name: 'CNC销售',
+      status: 'active',
+      location: '东莞',
+      keywords: ['CNC', '销售', '机床'],
+    },
+    {
+      id: 'software-dev',
+      name: '软件开发',
+      status: 'active',
+      location: '深圳',
+      keywords: ['Java', 'Python', '全栈'],
+    },
+    {
+      id: 'paused-profile',
+      name: '已暂停',
+      status: 'paused',
+      location: '广州',
+      keywords: ['CNC', '销售'],
+    },
+  ]
+
+  it('returns confidence 0 when input keywords are empty', () => {
+    const result = matchSearchProfilesByKeywords(profiles, [])
+    expect(result.confidence).toBe(0)
+    expect(result.matchedKeywords).toEqual([])
+    expect(result.profile).toBeUndefined()
+  })
+
+  it('matches the best profile by keyword overlap', () => {
+    const result = matchSearchProfilesByKeywords(profiles, ['CNC', '销售'])
+    expect(result.profile?.id).toBe('cnc-sales')
+    expect(result.confidence).toBeGreaterThan(0.3)
+    expect(result.matchedKeywords).toEqual(expect.arrayContaining(['cnc', '销售']))
+  })
+
+  it('skips paused/archived profiles', () => {
+    const result = matchSearchProfilesByKeywords(profiles, ['CNC'])
+    // paused-profile has same keywords but should be skipped
+    expect(result.profile?.id).toBe('cnc-sales')
+  })
+
+  it('returns confidence 0 when no profile exceeds the 0.3 threshold', () => {
+    const result = matchSearchProfilesByKeywords(profiles, ['完全无关的关键词'])
+    expect(result.confidence).toBe(0)
+    expect(result.profile).toBeUndefined()
+  })
+
+  it('adds location bonus when location matches', () => {
+    // Use partial keyword overlap so score < 1.0, allowing the +0.2 bonus to be visible
+    const withLocation = matchSearchProfilesByKeywords(profiles, ['CNC', '无关词'], '东莞')
+    const withoutLocation = matchSearchProfilesByKeywords(profiles, ['CNC', '无关词'])
+    expect(withLocation.confidence).toBeGreaterThan(withoutLocation.confidence)
+  })
+
+  it('does not add location bonus when location does not match', () => {
+    const withLocation = matchSearchProfilesByKeywords(profiles, ['CNC', '无关词'], '深圳')
+    const withoutLocation = matchSearchProfilesByKeywords(profiles, ['CNC', '无关词'])
+    expect(withLocation.confidence).toBe(withoutLocation.confidence)
+  })
+
+  it('caps confidence at 1.0 even with high keyword overlap + location bonus', () => {
+    const result = matchSearchProfilesByKeywords(
+      [{ id: 'p1', name: 'Test', status: 'active', keywords: ['a', 'b', 'c'] }],
+      ['a', 'b', 'c'],
+      'any',
+    )
+    expect(result.confidence).toBeLessThanOrEqual(1)
+  })
+
+  it('handles substring keyword matching (input contains profile keyword)', () => {
+    const localProfiles: SearchProfile[] = [
+      { id: 'p1', name: 'Test', status: 'active', keywords: ['CNC'] },
+    ]
+    const result = matchSearchProfilesByKeywords(localProfiles, ['CNC机床'])
+    expect(result.profile?.id).toBe('p1')
+    expect(result.confidence).toBeGreaterThan(0.3)
+  })
+
+  it('handles substring keyword matching (profile keyword contains input)', () => {
+    const localProfiles: SearchProfile[] = [
+      { id: 'p1', name: 'Test', status: 'active', keywords: ['CNC机床'] },
+    ]
+    const result = matchSearchProfilesByKeywords(localProfiles, ['CNC'])
+    expect(result.profile?.id).toBe('p1')
+    expect(result.confidence).toBeGreaterThan(0.3)
+  })
+
+  it('returns jobDescription and filterPreset from matched profile', () => {
+    const localProfiles: SearchProfile[] = [
+      {
+        id: 'p1',
+        name: 'Test',
+        status: 'active',
+        keywords: ['CNC'],
+        jobDescription: 'jd-abc123',
+        filterPreset: 'machinery-sales',
+      },
+    ]
+    const result = matchSearchProfilesByKeywords(localProfiles, ['CNC'])
+    expect(result.jobDescription).toBe('jd-abc123')
+    expect(result.filterPreset).toBe('machinery-sales')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds 10 tests for the previously-untested `matchSearchProfilesByKeywords` function in `search-profile-service.ts`
- Covers: empty input, best-match selection, paused/archived profile filtering, 0.3 confidence threshold, location bonus, confidence cap at 1.0, bidirectional substring keyword matching, jobDescription/filterPreset passthrough

## Test plan
- [x] `npx vitest run apps/api/src/services/search-profile-service.test.ts` — 16 passed (6 existing + 10 new)
- [x] `npm test` — 3,346 tests pass, 0 failures
- [x] `make check` — all checks passed