### PR TITLE
test: add sessions CRUD and API middleware coverage (27 tests)

### DIFF
--- a/apps/api/src/middleware/__tests__/middleware.test.ts
+++ b/apps/api/src/middleware/__tests__/middleware.test.ts
@@ -1,0 +1,181 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { describe, expect, it, vi } from "vitest";
+
+import { rateLimit } from "../rate-limit";
+import { serverTimingMiddleware } from "../server-timing";
+import { requireAdmin, workspaceMiddleware } from "../workspace";
+
+function createTestApp() {
+  return new OpenAPIHono();
+}
+
+describe("workspaceMiddleware", () => {
+  it("defaults to dev workspace when no header or query is provided", async () => {
+    const app = createTestApp();
+    app.use("*", workspaceMiddleware);
+    app.get("/test", (c) => c.json({ slug: c.var.workspaceSlug, level: c.var.accessLevel }));
+
+    const res = await app.request("/test");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.slug).toBe("dev");
+    expect(body.level).toBe("admin");
+  });
+
+  it("uses X-Workspace-Slug header when provided", async () => {
+    const app = createTestApp();
+    app.use("*", workspaceMiddleware);
+    app.get("/test", (c) => c.json({ slug: c.var.workspaceSlug, level: c.var.accessLevel }));
+
+    const res = await app.request("/test", {
+      headers: { "X-Workspace-Slug": "hr" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.slug).toBe("hr");
+    expect(body.level).toBe("user");
+  });
+
+  it("falls back to workspaceSlug query parameter when header is missing", async () => {
+    const app = createTestApp();
+    app.use("*", workspaceMiddleware);
+    app.get("/test", (c) => c.json({ slug: c.var.workspaceSlug }));
+
+    const res = await app.request("/test?workspaceSlug=hr");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.slug).toBe("hr");
+  });
+
+  it("prioritizes header over query parameter", async () => {
+    const app = createTestApp();
+    app.use("*", workspaceMiddleware);
+    app.get("/test", (c) => c.json({ slug: c.var.workspaceSlug }));
+
+    const res = await app.request("/test?workspaceSlug=hr", {
+      headers: { "X-Workspace-Slug": "dev" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.slug).toBe("dev");
+  });
+
+  it("rejects invalid workspace slugs with 400", async () => {
+    const app = createTestApp();
+    app.use("*", workspaceMiddleware);
+    app.get("/test", (c) => c.text("ok"));
+
+    const res = await app.request("/test", {
+      headers: { "X-Workspace-Slug": "invalid-workspace" },
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid workspace slug");
+  });
+});
+
+describe("requireAdmin", () => {
+  it("allows admin workspaces through", async () => {
+    const app = createTestApp();
+    app.use("*", workspaceMiddleware);
+    app.use("*", requireAdmin);
+    app.get("/test", (c) => c.text("ok"));
+
+    const res = await app.request("/test", {
+      headers: { "X-Workspace-Slug": "dev" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("blocks non-admin workspaces with 403", async () => {
+    const app = createTestApp();
+    app.use("*", workspaceMiddleware);
+    app.use("*", requireAdmin);
+    app.get("/test", (c) => c.text("ok"));
+
+    const res = await app.request("/test", {
+      headers: { "X-Workspace-Slug": "hr" },
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Admin access required");
+  });
+});
+
+describe("rateLimit", () => {
+  it("allows requests within the limit", async () => {
+    const app = createTestApp();
+    app.use("*", rateLimit({ limit: 5, windowMs: 60_000 }));
+    app.get("/test", (c) => c.text("ok"));
+
+    const res = await app.request("/test");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("5");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("4");
+  });
+
+  it("blocks requests that exceed the limit with 429", async () => {
+    const app = createTestApp();
+    const limiter = rateLimit({ limit: 2, windowMs: 60_000, keyExtractor: () => "test-key" });
+    app.use("*", limiter);
+    app.get("/test", (c) => c.text("ok"));
+
+    // First 2 requests should succeed
+    await app.request("/test");
+    await app.request("/test");
+
+    // Third should be blocked
+    const res = await app.request("/test");
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("sets rate limit headers on every response", async () => {
+    const app = createTestApp();
+    app.use("*", rateLimit({ limit: 10, windowMs: 60_000 }));
+    app.get("/test", (c) => c.text("ok"));
+
+    const res = await app.request("/test");
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBeTruthy();
+    expect(res.headers.get("X-RateLimit-Reset")).toBeTruthy();
+  });
+
+  it("uses custom key extractor when provided", async () => {
+    const app = createTestApp();
+    app.use("*", rateLimit({
+      limit: 1,
+      windowMs: 60_000,
+      keyExtractor: (c) => c.req.header("X-API-Key") ?? "anonymous",
+    }));
+    app.get("/test", (c) => c.text("ok"));
+
+    // Request with key A
+    const res1 = await app.request("/test", { headers: { "X-API-Key": "key-a" } });
+    expect(res1.status).toBe(200);
+
+    // Request with key B (different bucket)
+    const res2 = await app.request("/test", { headers: { "X-API-Key": "key-b" } });
+    expect(res2.status).toBe(200);
+
+    // Second request with key A should be blocked
+    const res3 = await app.request("/test", { headers: { "X-API-Key": "key-a" } });
+    expect(res3.status).toBe(429);
+  });
+});
+
+describe("serverTimingMiddleware", () => {
+  it("adds Server-Timing header to responses", async () => {
+    const app = createTestApp();
+    app.use("*", serverTimingMiddleware);
+    app.get("/test", (c) => c.text("ok"));
+
+    const res = await app.request("/test");
+    expect(res.status).toBe(200);
+    const timing = res.headers.get("Server-Timing");
+    expect(timing).toBeTruthy();
+    expect(timing).toMatch(/^total;dur=\d+$/);
+  });
+});

--- a/packages/convex/convex/__tests__/sessions-extended.test.ts
+++ b/packages/convex/convex/__tests__/sessions-extended.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_WORKSPACE_SLUG,
+  addReviewedItem,
+  archiveSession,
+  getActiveSession,
+  markSearchHistoryOpened,
+  saveSearchHistory,
+  saveSession,
+} from "../sessions";
+
+type ConvexHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+const getActiveSessionHandler = (getActiveSession as unknown as ConvexHandler<
+  { sessionKey: string; workspaceSlug?: string },
+  unknown
+>)._handler
+
+const saveSessionHandler = (saveSession as unknown as ConvexHandler<
+  { sessionKey: string; workspaceSlug?: string; location: string; keywords: string[]; jobDescriptionId?: string },
+  string | null
+>)._handler
+
+const addReviewedItemHandler = (addReviewedItem as unknown as ConvexHandler<
+  { sessionKey: string; workspaceSlug?: string; resumeId: string },
+  string | null
+>)._handler
+
+const archiveSessionHandler = (archiveSession as unknown as ConvexHandler<
+  { sessionKey: string; workspaceSlug?: string },
+  null
+>)._handler
+
+const saveSearchHistoryHandler = (saveSearchHistory as unknown as ConvexHandler<
+  { sessionKey: string; workspaceSlug?: string; title?: string; location: string; keywords: string[]; resumeIds?: string[] },
+  string
+>)._handler
+
+const markSearchHistoryOpenedHandler = (markSearchHistoryOpened as unknown as ConvexHandler<
+  { id: string; workspaceSlug?: string },
+  string | null
+>)._handler
+
+type ScreeningSession = {
+  _id: string;
+  sessionKey: string;
+  status: "active" | "archived";
+  workspaceSlug: string;
+  config: { location: string; keywords: string[] };
+  reviewedResumeIds: string[];
+  lastActive: number;
+}
+
+type SearchHistoryRecord = {
+  _id: string;
+  sessionKey: string;
+  title: string;
+  location: string;
+  keywords: string[];
+  workspaceSlug: string;
+  createdAt: number;
+  lastOpenedAt?: number;
+}
+
+function createSessionsDb(sessions: ScreeningSession[] = []) {
+  const patches: Array<{ id: string; patch: Record<string, unknown> }> = []
+  const inserts: Array<{ table: string; doc: Record<string, unknown> }> = []
+
+  return {
+    patches,
+    inserts,
+    db: {
+      query(tableName: string) {
+        if (tableName === "screening_sessions") {
+          return {
+            withIndex(_indexName: string, apply: (q: { eq: (field: string, value: string) => unknown }) => unknown) {
+              const conditions: Array<{ field: string; value: string }> = []
+              apply({
+                eq(field: string, value: string) {
+                  conditions.push({ field, value })
+                  return this
+                },
+              })
+
+              const filtered = sessions.filter((s) =>
+                conditions.every((c) => s[c.field as keyof ScreeningSession] === c.value)
+              )
+
+              return {
+                filter(apply: (q: { eq: (left: unknown, right: unknown) => unknown; field: (name: string) => string }) => unknown) {
+                  const clause = apply({
+                    eq: (left: unknown, right: unknown) => ({ left, right }),
+                    field: (name: string) => name,
+                  }) as { left: string; right: unknown }
+                  const statusFiltered = filtered.filter((s) => s[clause.left as keyof ScreeningSession] === clause.right)
+                  return {
+                    async collect() { return [...statusFiltered] },
+                    async take(_n: number) { return [...statusFiltered].slice(0, _n) },
+                  }
+                },
+                async collect() { return [...filtered] },
+                async take(_n: number) { return [...filtered].slice(0, _n) },
+              }
+            },
+            async collect() { return [...sessions] },
+            async take(_n: number) { return [...sessions].slice(0, _n) },
+          }
+        }
+
+        if (tableName === "search_history") {
+          return {
+            withIndex(_indexName: string, apply: (q: { eq: (field: string, value: string) => unknown }) => unknown) {
+              apply({
+                eq() { return this },
+              })
+              return {
+                order() { return { async take() { return [] } } },
+                async take() { return [] },
+              }
+            },
+            async collect() { return [] },
+            async take() { return [] },
+          }
+        }
+
+        if (tableName === "industry_db_cohorts") {
+          return {
+            withIndex() {
+              return { async take() { return [] } }
+            },
+            async collect() { return [] },
+          }
+        }
+
+        return {
+          async collect() { return [] },
+          async take() { return [] },
+        }
+      },
+      async patch(id: string, patch: Record<string, unknown>) {
+        patches.push({ id, patch })
+        const session = sessions.find((s) => s._id === id)
+        if (session) Object.assign(session, patch)
+      },
+      async insert(table: string, doc: Record<string, unknown>) {
+        inserts.push({ table, doc })
+        return `inserted-${inserts.length}`
+      },
+      async get(id: string) {
+        return sessions.find((s) => s._id === id) ?? null
+      },
+    },
+  }
+}
+
+describe("getActiveSession", () => {
+  it("returns the most recently active session for the given key and workspace", async () => {
+    const sessions: ScreeningSession[] = [
+      { _id: "s1", sessionKey: "key-a", status: "active", workspaceSlug: DEFAULT_WORKSPACE_SLUG, config: { location: "东莞", keywords: [] }, reviewedResumeIds: [], lastActive: 100 },
+      { _id: "s2", sessionKey: "key-a", status: "active", workspaceSlug: DEFAULT_WORKSPACE_SLUG, config: { location: "深圳", keywords: [] }, reviewedResumeIds: [], lastActive: 200 },
+      { _id: "s3", sessionKey: "key-b", status: "active", workspaceSlug: DEFAULT_WORKSPACE_SLUG, config: { location: "广州", keywords: [] }, reviewedResumeIds: [], lastActive: 300 },
+    ]
+    const ctx = createSessionsDb(sessions)
+
+    const result = await getActiveSessionHandler(ctx as never, { sessionKey: "key-a" })
+
+    expect(result).not.toBeNull()
+    expect((result as ScreeningSession)._id).toBe("s2")
+  })
+
+  it("returns null when no active session exists", async () => {
+    const ctx = createSessionsDb([])
+
+    const result = await getActiveSessionHandler(ctx as never, { sessionKey: "nonexistent" })
+
+    expect(result).toBeNull()
+  })
+})
+
+describe("saveSession", () => {
+  it("patches existing active session instead of creating a new one", async () => {
+    const sessions: ScreeningSession[] = [
+      { _id: "s1", sessionKey: "key-a", status: "active", workspaceSlug: DEFAULT_WORKSPACE_SLUG, config: { location: "东莞", keywords: [] }, reviewedResumeIds: [], lastActive: 100 },
+    ]
+    const ctx = createSessionsDb(sessions)
+
+    const result = await saveSessionHandler(ctx as never, {
+      sessionKey: "key-a",
+      location: "深圳",
+      keywords: ["CNC"],
+    })
+
+    expect(result).toBe("s1")
+    expect(ctx.patches).toHaveLength(1)
+    expect(ctx.patches[0].id).toBe("s1")
+    expect(ctx.inserts).toHaveLength(0)
+  })
+
+  it("creates a new session when no active one exists", async () => {
+    const ctx = createSessionsDb([])
+
+    const result = await saveSessionHandler(ctx as never, {
+      sessionKey: "key-new",
+      location: "广州",
+      keywords: ["销售"],
+    })
+
+    expect(result).toBeTruthy()
+    expect(ctx.inserts).toHaveLength(1)
+    expect(ctx.inserts[0].table).toBe("screening_sessions")
+    expect(ctx.patches).toHaveLength(0)
+  })
+})
+
+describe("addReviewedItem", () => {
+  it("adds a resume ID to the reviewed list", async () => {
+    const sessions: ScreeningSession[] = [
+      { _id: "s1", sessionKey: "key-a", status: "active", workspaceSlug: DEFAULT_WORKSPACE_SLUG, config: { location: "东莞", keywords: [] }, reviewedResumeIds: [], lastActive: 100 },
+    ]
+    const ctx = createSessionsDb(sessions)
+
+    const result = await addReviewedItemHandler(ctx as never, {
+      sessionKey: "key-a",
+      resumeId: "resume-1",
+    })
+
+    expect(result).toBe("s1")
+    expect(ctx.patches).toHaveLength(1)
+    expect(ctx.patches[0].patch.reviewedResumeIds).toContain("resume-1")
+  })
+
+  it("does not add duplicate resume IDs", async () => {
+    const sessions: ScreeningSession[] = [
+      { _id: "s1", sessionKey: "key-a", status: "active", workspaceSlug: DEFAULT_WORKSPACE_SLUG, config: { location: "东莞", keywords: [] }, reviewedResumeIds: ["resume-1"], lastActive: 100 },
+    ]
+    const ctx = createSessionsDb(sessions)
+
+    const result = await addReviewedItemHandler(ctx as never, {
+      sessionKey: "key-a",
+      resumeId: "resume-1",
+    })
+
+    expect(result).toBe("s1")
+    expect(ctx.patches).toHaveLength(0)
+  })
+
+  it("returns null when no active session exists", async () => {
+    const ctx = createSessionsDb([])
+
+    const result = await addReviewedItemHandler(ctx as never, {
+      sessionKey: "nonexistent",
+      resumeId: "resume-1",
+    })
+
+    expect(result).toBeNull()
+  })
+})
+
+describe("archiveSession", () => {
+  it("patches the active session to archived status", async () => {
+    const sessions: ScreeningSession[] = [
+      { _id: "s1", sessionKey: "key-a", status: "active", workspaceSlug: DEFAULT_WORKSPACE_SLUG, config: { location: "东莞", keywords: [] }, reviewedResumeIds: [], lastActive: 100 },
+    ]
+    const ctx = createSessionsDb(sessions)
+
+    const result = await archiveSessionHandler(ctx as never, { sessionKey: "key-a" })
+
+    expect(result).toBeNull()
+    expect(ctx.patches).toHaveLength(1)
+    expect(ctx.patches[0].patch.status).toBe("archived")
+  })
+
+  it("does nothing when no active session exists", async () => {
+    const ctx = createSessionsDb([])
+
+    const result = await archiveSessionHandler(ctx as never, { sessionKey: "nonexistent" })
+
+    expect(result).toBeNull()
+    expect(ctx.patches).toHaveLength(0)
+  })
+})
+
+describe("saveSearchHistory", () => {
+  it("creates a search history record with normalized fields", async () => {
+    const ctx = createSessionsDb()
+
+    const result = await saveSearchHistoryHandler(ctx as never, {
+      sessionKey: "session-a",
+      location: "  东莞  ",
+      keywords: [" CNC ", "cnc", "销售", " 销售 "],
+      resumeIds: [],
+    })
+
+    expect(result).toBeTruthy()
+    expect(ctx.inserts).toHaveLength(1)
+    const doc = ctx.inserts[0].doc
+    expect(doc.location).toBe("东莞")
+    // normalizeStringList trims and deduplicates exact matches (case-sensitive)
+    expect(doc.keywords).toEqual(["CNC", "cnc", "销售"])
+    // Title should be auto-generated from location + keywords
+    expect(doc.title).toContain("东莞")
+    expect(doc.workspaceSlug).toBe(DEFAULT_WORKSPACE_SLUG)
+  })
+
+  it("creates a cohort when resumeIds are provided", async () => {
+    const ctx = createSessionsDb()
+
+    // Provide resumeIds — but the db.get won't find them, so cohort will have all zeros
+    const result = await saveSearchHistoryHandler(ctx as never, {
+      sessionKey: "session-a",
+      location: "东莞",
+      keywords: ["CNC"],
+      resumeIds: ["nonexistent-resume"],
+    })
+
+    expect(result).toBeTruthy()
+    // With empty data from get(), buildIndustryDbV2Cohort still creates a cohort entry
+    // (it maps null gets to 0 scores, so size >= 1)
+  })
+
+  it("uses provided title when not empty", async () => {
+    const ctx = createSessionsDb()
+
+    await saveSearchHistoryHandler(ctx as never, {
+      sessionKey: "session-a",
+      title: "Custom Title",
+      location: "东莞",
+      keywords: ["CNC"],
+    })
+
+    const doc = ctx.inserts[0].doc
+    expect(doc.title).toBe("Custom Title")
+  })
+})
+
+describe("markSearchHistoryOpened", () => {
+  it("updates lastOpenedAt for a record in the same workspace", async () => {
+    const searchHistoryRecords: SearchHistoryRecord[] = [
+      { _id: "sh1", sessionKey: "s-a", title: "Test", location: "东莞", keywords: [], workspaceSlug: DEFAULT_WORKSPACE_SLUG, createdAt: 1000 },
+    ]
+    const patches: Array<{ id: string; patch: Record<string, unknown> }> = []
+
+    const ctx = {
+      db: {
+        async get(id: string) {
+          const record = searchHistoryRecords.find((r) => r._id === id)
+          return record ? { ...record, _id: id } : null
+        },
+        async patch(id: string, patch: Record<string, unknown>) {
+          patches.push({ id, patch })
+        },
+      },
+    }
+
+    const result = await markSearchHistoryOpenedHandler(ctx as never, {
+      id: "sh1",
+      workspaceSlug: DEFAULT_WORKSPACE_SLUG,
+    })
+
+    expect(result).toBe("sh1")
+    expect(patches).toHaveLength(1)
+    expect(patches[0].patch.lastOpenedAt).toBeGreaterThan(0)
+  })
+
+  it("returns null when record does not exist", async () => {
+    const ctx = {
+      db: {
+        async get() { return null },
+        async patch() {},
+      },
+    }
+
+    const result = await markSearchHistoryOpenedHandler(ctx as never, {
+      id: "nonexistent",
+      workspaceSlug: DEFAULT_WORKSPACE_SLUG,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it("returns null when record belongs to a different workspace", async () => {
+    const searchHistoryRecords: SearchHistoryRecord[] = [
+      { _id: "sh1", sessionKey: "s-a", title: "Test", location: "东莞", keywords: [], workspaceSlug: "hr", createdAt: 1000 },
+    ]
+
+    const ctx = {
+      db: {
+        async get(id: string) {
+          const record = searchHistoryRecords.find((r) => r._id === id)
+          return record ? { ...record, _id: id } : null
+        },
+        async patch() {},
+      },
+    }
+
+    const result = await markSearchHistoryOpenedHandler(ctx as never, {
+      id: "sh1",
+      workspaceSlug: DEFAULT_WORKSPACE_SLUG,
+    })
+
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds 15 tests for `sessions.ts` covering all 6 untested query/mutation handlers: getActiveSession, saveSession, addReviewedItem, archiveSession, saveSearchHistory, markSearchHistoryOpened
- Adds 12 tests for the 3 API middleware modules (previously zero tests): workspaceMiddleware (5), requireAdmin (2), rateLimit (4), serverTimingMiddleware (1)
- Closes the middleware zero-test gap identified in deep research v3

## Test plan
- [x] `npx vitest run packages/convex/convex/__tests__/sessions-extended.test.ts` — 15 passed
- [x] `npx vitest run apps/api/src/middleware/__tests__/middleware.test.ts` — 12 passed
- [x] `npm test` — 3,388 tests pass, 0 failures
- [x] `make check` — all checks passed