### PR TITLE
feat: replace 21 console.error calls with structured logger in API services

### DIFF
--- a/apps/api/src/services/ai-matching.ts
+++ b/apps/api/src/services/ai-matching.ts
@@ -16,6 +16,7 @@ import {
     type ResumeFieldUsagePolicy,
     type ResumeFieldUsagePolicyOverrides,
 } from "@trends/shared";
+import { logger } from "./logger.js";
 import { aiConfig, validateResumeAIConfig, getMaskedApiKey } from "./ai-config.js";
 import { findProjectRoot } from "./db.js";
 import { localeToNaturalLanguage, resolveAIOutputLocale } from "./locale-utils.js";
@@ -144,7 +145,7 @@ function loadConfiguredConcurrency(): number {
             }
         }
     } catch (error) {
-        console.error("[AI Matching] Failed to read agents config:", error);
+        logger.error("[AI Matching] Failed to read agents config", error, { service: "ai-matching" });
     }
 
     return 5;
@@ -328,7 +329,7 @@ export class AIMatchingService {
             return parsed;
         } catch (error) {
             const errorMessage = toCompactErrorMessage(error);
-            console.error("[AI Matching] Error:", errorMessage);
+            logger.error("[AI Matching] Error", errorMessage, { service: "ai-matching" });
             const localeText = getResumeAiLocaleText(prompt.normalized.locale);
             return {
                 score: 0,
@@ -486,7 +487,7 @@ Return strictly valid JSON:
                 body: parsed.body as string
             };
         } catch (error) {
-            console.error("[AI Outreach] Error:", error);
+            logger.error("[AI Outreach] Error", error, { service: "ai-matching" });
             throw error;
         }
     }
@@ -666,7 +667,7 @@ Return strictly valid JSON:
                 scoreSource: "ai",
             };
         } catch (error) {
-            console.error("[AI Matching] Parse error:", error);
+            logger.error("[AI Matching] Parse error", error, { service: "ai-matching" });
             const localeText = getResumeAiLocaleText(prompt?.normalized.locale);
             return {
                 score: 0,

--- a/apps/api/src/services/ai-summary-service.test.ts
+++ b/apps/api/src/services/ai-summary-service.test.ts
@@ -25,6 +25,9 @@ vi.mock("./workspace-config-service.js", () => ({
   },
 }));
 
+vi.mock("./logger.js");
+
+import { logger } from "./logger.js";
 import { AiSummaryService } from "./ai-summary-service.js";
 
 function createAIConfig(overrides: Partial<ReturnType<typeof loadAIConfigMock>> = {}) {
@@ -142,7 +145,7 @@ Strong overlap around machine tools and CNC sales backgrounds.
   it("fails before the AI call when the runtime has no API key", async () => {
     loadAIConfigMock.mockReturnValue(createAIConfig({ apiKey: "" }));
     getWorkspaceConfigValueMock.mockResolvedValue(undefined);
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logger.error.mockClear();
 
     const service = new AiSummaryService();
     const result = await service.generateSummary({
@@ -167,9 +170,10 @@ Strong overlap around machine tools and CNC sales backgrounds.
     expect(result.summary).toContain('Visible results for "cnc" currently include 1 candidates.');
     expect(result.summary).toContain("Shared themes are strongest around CNC, Sales.");
     expect(result.summary).toContain("Keep the location filter on China");
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
+    expect(logger.error).toHaveBeenCalledWith(
       "AI summary generation unavailable, using heuristic fallback",
       expect.any(Error),
+      { service: "ai-summary-service" },
     );
   });
 
@@ -177,7 +181,7 @@ Strong overlap around machine tools and CNC sales backgrounds.
     loadAIConfigMock.mockReturnValue(createAIConfig());
     getWorkspaceConfigValueMock.mockResolvedValue("anthropic/claude-3-5-haiku-20241022");
     callChatCompletionMock.mockRejectedValue(new Error("provider timeout"));
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logger.error.mockClear();
 
     const service = new AiSummaryService();
     const result = await service.generateSummary({
@@ -209,9 +213,10 @@ Strong overlap around machine tools and CNC sales backgrounds.
     expect(result.summary).toContain('Visible results for "machine tools sales" currently include 2 candidates.');
     expect(result.summary).toContain("Shared themes are strongest around Machine Tools");
     expect(result.summary).toContain("Visible scores range from 87 to 92");
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
+    expect(logger.error).toHaveBeenCalledWith(
       "AI summary generation unavailable, using heuristic fallback",
       expect.any(Error),
+      { service: "ai-summary-service" },
     );
   });
 });

--- a/apps/api/src/services/ai-summary-service.ts
+++ b/apps/api/src/services/ai-summary-service.ts
@@ -1,5 +1,6 @@
 import { loadAIConfig } from "./ai-config.js";
 import { callChatCompletion } from "./ai-chat-client.js";
+import { logger } from "./logger.js";
 import { workspaceConfigService } from "./workspace-config-service.js";
 
 const DEFAULT_AI_SUMMARY_MODEL = process.env.AI_SUMMARY_MODEL
@@ -146,7 +147,7 @@ export class AiSummaryService {
         summary: stripCodeFence(content),
       };
     } catch (error) {
-      console.error("AI summary generation unavailable, using heuristic fallback", error);
+      logger.error("AI summary generation unavailable, using heuristic fallback", error, { service: "ai-summary-service" });
       return {
         model: FALLBACK_AI_SUMMARY_MODEL,
         summary: this.buildFallbackSummary(request),

--- a/apps/api/src/services/custom-keyword-service.ts
+++ b/apps/api/src/services/custom-keyword-service.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
 import { findProjectRoot } from "./db.js";
+import { logger } from "./logger.js";
 
 export type KeywordMarket = "CN" | "MY";
 export type ConfigSourceOrigin = "system" | "workspace";
@@ -418,7 +419,7 @@ export class CustomKeywordService {
                 return left.keyword.localeCompare(right.keyword, "zh-Hans-CN");
             });
         } catch (error) {
-            console.error("Failed to load Job5156 location snapshot", error);
+            logger.error("Failed to load Job5156 location snapshot", error, { service: "custom-keyword-service" });
             return [];
         }
     }

--- a/apps/api/src/services/database.test.ts
+++ b/apps/api/src/services/database.test.ts
@@ -17,6 +17,10 @@ vi.mock("better-sqlite3", () => ({
   default: constructorMock,
 }));
 
+vi.mock("./logger.js");
+
+import { logger } from "./logger.js";
+
 describe("getResumeScreeningDb", () => {
   afterEach(async () => {
     const { resetResumeScreeningDb } = await import("./database");
@@ -46,7 +50,6 @@ describe("getResumeScreeningDb", () => {
       return undefined;
     });
 
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const { getResumeScreeningDb } = await import("./database");
 
     const db = getResumeScreeningDb(process.cwd());
@@ -58,7 +61,7 @@ describe("getResumeScreeningDb", () => {
     expect(pragmaMock).toHaveBeenCalledWith("foreign_keys = ON");
     expect(execMock).toHaveBeenCalledWith(expect.stringContaining("CREATE TABLE IF NOT EXISTS users"));
     expect(execMock).toHaveBeenCalledTimes(1);
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledTimes(1);
   });
 
   it("ignores duplicate column errors during concurrent schema upgrades", async () => {

--- a/apps/api/src/services/database.ts
+++ b/apps/api/src/services/database.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import Database from "better-sqlite3";
 
 import { findProjectRoot } from "./db.js";
+import { logger } from "./logger.js";
 
 const DEFAULT_DB_FILENAME = "resume_screening.db";
 
@@ -27,7 +28,7 @@ function configureResumeScreeningDb(db: Database.Database): void {
       db.pragma("journal_mode = WAL");
     }
   } catch (error) {
-    console.error("Failed to enable WAL for resume screening DB", error);
+    logger.error("Failed to enable WAL for resume screening DB", error, { service: "database" });
     if (getSqliteErrorCode(error) !== "SQLITE_BUSY") {
       throw error;
     }

--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -14,6 +14,7 @@ import {
 } from "@trends/shared";
 
 import { IndustryDataService } from "./industry-data-service.js";
+import { logger } from "./logger.js";
 import { normalizeCompanyPatternIdentifier, SkillsKnowledgeService } from "./skills-knowledge.js";
 import { JobDescriptionService } from "./job-description-service.js";
 import { RuleScoringService, type MatchedWorkEntry, type RoleSignalSummary } from "./rule-scoring.js";
@@ -605,7 +606,7 @@ export class IngestComputeService {
         scores[jd.id] = result.score;
       } catch (error) {
         // Log error but don't fail the whole batch
-        console.error(`Failed to score resume against JD ${jd.name}:`, error);
+        logger.error(`Failed to score resume against JD ${jd.name}`, error, { service: "ingest-compute-service" });
         scores[jd.id] = 0;
       }
     }

--- a/apps/api/src/services/manual-resume-import-service.ts
+++ b/apps/api/src/services/manual-resume-import-service.ts
@@ -12,6 +12,7 @@ import {
   stripManual51jobUnreadableControlCharacters,
 } from "@trends/shared";
 
+import { logger } from "./logger.js";
 import {
   type ResumeImportItem,
   type ResumeImportRequest,
@@ -492,7 +493,7 @@ async function parsePdfFile(file: EnumeratedImportFile): Promise<ParsedImportCan
     };
   } finally {
     await parser.destroy().catch((error) => {
-      console.error("Failed to destroy PDF parser", error);
+      logger.error("Failed to destroy PDF parser", error, { service: "manual-resume-import-service" });
     });
   }
 }

--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -19,6 +19,7 @@ import {
   ResumeSubmitSummarySchema,
 } from "../schemas/resumes.js";
 import { config } from "./config.js";
+import { logger } from "./logger.js";
 import { ActionStorage, type CandidateActionBackupRow } from "./action-storage.js";
 
 const JOB5156_HOST = "hr.job5156.com";
@@ -98,7 +99,7 @@ function readEnvVarFromFile(filePath: string, key: string): string | null {
     }
     return null;
   } catch (error) {
-    console.error("Failed to read env var from file", { filePath, key, error });
+    logger.error("Failed to read env var from file", error, { service: "resume-import-service", filePath, key });
     return null;
   }
 }
@@ -191,7 +192,7 @@ function resolveResumeSource(metadata: ResumeImportMetadata): string {
   try {
     return new URL(metadata.sourceUrl).hostname.toLowerCase();
   } catch (error) {
-    console.error("Failed to parse resume source URL", { sourceUrl: metadata.sourceUrl, error });
+    logger.error("Failed to parse resume source URL", error, { service: "resume-import-service", sourceUrl: metadata.sourceUrl });
     return sourceKey || JOB5156_HOST;
   }
 }
@@ -489,16 +490,10 @@ export async function replayCandidateState(params: {
         if (response.ok) {
           result.statusReplayed++;
         } else {
-          console.error("candidate_status:upsert failed", {
-            identityKey: entry.identityKey,
-            status: response.status,
-          });
+          logger.error("candidate_status:upsert failed", "no error object", { service: "resume-import-service", identityKey: entry.identityKey, status: response.status });
         }
       } catch (error) {
-        console.error("candidate_status:upsert error", {
-          identityKey: entry.identityKey,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        logger.error("candidate_status:upsert error", error, { service: "resume-import-service", identityKey: entry.identityKey });
       }
     }
   }

--- a/apps/api/src/services/resume-index.ts
+++ b/apps/api/src/services/resume-index.ts
@@ -15,6 +15,7 @@ import {
 } from "@trends/shared";
 
 import { findProjectRoot } from "./db.js";
+import { logger } from "./logger.js";
 import { JobDescriptionService } from "./job-description-service.js";
 import { SkillsKnowledgeService } from "./skills-knowledge.js";
 import { resolveResumeId } from "./resume-id.js";
@@ -270,7 +271,7 @@ export class ResumeIndexService {
         return normalizedTags;
       }
     } catch (error) {
-      console.error("Failed to load industry taxonomy for scoring:", error);
+      logger.error("Failed to load industry taxonomy for scoring", error, { service: "resume-index" });
     }
 
     return [];

--- a/apps/api/src/services/rule-scoring.ts
+++ b/apps/api/src/services/rule-scoring.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import { findProjectRoot } from "./db.js";
 import { FilterPresetService } from "./filter-preset-service.js";
+import { logger } from "./logger.js";
 import { JobDescriptionService } from "./job-description-service.js";
 import { SkillsKnowledgeService } from "./skills-knowledge.js";
 import type { MatchingResult } from "./ai-matching.js";
@@ -155,13 +156,13 @@ export function loadRuleWeightsConfig(projectRoot: string): RuleWeightsConfig {
     const raw: unknown = JSON5.parse(content);
     const parsed = parseRuleWeightsOverrides(raw);
     if (!parsed) {
-      console.error("[RuleScoring] Failed to parse rule-weights.json5");
+      logger.error("[RuleScoring] Failed to parse rule-weights.json5", "", { service: "rule-scoring" });
       return DEFAULT_WEIGHTS;
     }
 
     return mergeRuleWeights(parsed);
   } catch (error) {
-    console.error("[RuleScoring] Failed to load rule-weights.json5:", error);
+    logger.error("[RuleScoring] Failed to load rule-weights.json5", error, { service: "rule-scoring" });
     return DEFAULT_WEIGHTS;
   }
 }
@@ -654,7 +655,7 @@ export class RuleScoringService {
         }
       }
     } catch (error) {
-      console.error("[RuleScoring] Failed to infer brand keywords:", error);
+      logger.error("[RuleScoring] Failed to infer brand keywords", error, { service: "rule-scoring" });
     }
 
     return Array.from(matches);

--- a/apps/api/src/services/scoring-auto-tuner.ts
+++ b/apps/api/src/services/scoring-auto-tuner.ts
@@ -5,6 +5,8 @@ import { isRecord } from "@trends/shared";
 
 import { findProjectRoot } from "./db.js";
 
+import { logger } from "./logger.js";
+
 import { getResumeScreeningDb } from "./database.js";
 
 import { type RuleWeightsConfig } from "./rule-scoring.js";
@@ -509,7 +511,7 @@ export class ScoringAutoTuner {
     try {
       reingestTriggered = await this.triggerReingest(reingestLimit);
     } catch (error) {
-      console.error("[ScoringAutoTuner] Failed to trigger re-ingest:", error);
+      logger.error("[ScoringAutoTuner] Failed to trigger re-ingest", error, { service: "scoring-auto-tuner" });
     }
 
     this.writeState({

--- a/apps/api/src/services/workspace-config-service.ts
+++ b/apps/api/src/services/workspace-config-service.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
+import { logger } from "./logger.js";
 import {
   isRecord,
   parseResumeFieldUsagePolicyOverrides,
@@ -668,7 +669,7 @@ export class WorkspaceConfigService {
       });
       return parseWorkspaceConfigEntry(value);
     } catch (error) {
-      console.error("Failed to get workspace config entry", error);
+      logger.error("Failed to get workspace config entry", error, { service: "workspace-config" });
       return null;
     }
   }
@@ -681,7 +682,7 @@ export class WorkspaceConfigService {
         configValue,
       });
     } catch (error) {
-      console.error("Failed to upsert workspace config entry", error);
+      logger.error("Failed to upsert workspace config entry", error, { service: "workspace-config" });
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- Extends the structured logging pattern (from PR #936, which covered 13 route files) to all 10 API service modules
- Replaces 21 `console.error` calls with `logger.error(message, error, { service: "name" })` 
- Services updated: ai-matching (4), resume-import (4), rule-scoring (3), workspace-config (2), database (1), manual-resume-import (1), scoring-auto-tuner (1), resume-index (1), ingest-compute (1), custom-keyword (1), ai-summary (1)
- Test files updated: ai-summary-service.test.ts, database.test.ts (spies migrated from `console.error` to `logger.error`)

## Test plan
- [x] `npx vitest run apps/api/src/services/` — 1,018 tests pass across 68 files
- [x] `npm test` — 3,388 tests pass, 0 failures
- [x] `make check` — all checks passed