### PR TITLE
test: add summary pipeline and rate-limit coverage (32 tests)

### DIFF
--- a/apps/api/src/middleware/__tests__/rate-limit.test.ts
+++ b/apps/api/src/middleware/__tests__/rate-limit.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import { rateLimit } from "../rate-limit.js";
+import type { RateLimitOptions } from "../rate-limit.js";
+
+import { OpenAPIHono } from "@hono/zod-openapi";
+
+function createTestApp(options?: RateLimitOptions) {
+  const app = new OpenAPIHono();
+  app.use(rateLimit(options));
+  app.get("/test", (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe("rateLimit", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("allows requests under the limit", async () => {
+    const app = createTestApp({ limit: 5, windowMs: 60_000 });
+
+    const res = await app.request("/test", {
+      headers: { "X-Forwarded-For": "1.2.3.4" },
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("blocks requests over the limit", async () => {
+    const app = createTestApp({ limit: 2, windowMs: 60_000 });
+
+    // Make 2 allowed requests
+    await app.request("/test", { headers: { "X-Forwarded-For": "1.2.3.4" } });
+    await app.request("/test", { headers: { "X-Forwarded-For": "1.2.3.4" } });
+
+    // 3rd should be rate limited
+    const res = await app.request("/test", { headers: { "X-Forwarded-For": "1.2.3.4" } });
+
+    expect(res.status).toBe(429);
+  });
+
+  it("tracks limits per client key independently", async () => {
+    const app = createTestApp({ limit: 1, windowMs: 60_000 });
+
+    // First client
+    const res1 = await app.request("/test", { headers: { "X-Forwarded-For": "1.2.3.4" } });
+    expect(res1.status).toBe(200);
+
+    // Second client
+    const res2 = await app.request("/test", { headers: { "X-Forwarded-For": "5.6.7.8" } });
+    expect(res2.status).toBe(200);
+  });
+
+  it("uses custom key extractor", async () => {
+    const app = createTestApp({
+      limit: 1,
+      windowMs: 60_000,
+      keyExtractor: (c) => c.req.header("X-Api-Key") ?? "anonymous",
+    });
+
+    // Request with key1
+    const res1 = await app.request("/test", { headers: { "X-Api-Key": "key1" } });
+    expect(res1.status).toBe(200);
+
+    // Request with key1 again should be rate limited
+    const res2 = await app.request("/test", { headers: { "X-Api-Key": "key1" } });
+    expect(res2.status).toBe(429);
+
+    // Request with different key should pass
+    const res3 = await app.request("/test", { headers: { "X-Api-Key": "key2" } });
+    expect(res3.status).toBe(200);
+  });
+
+  it("includes rate limit headers in response", async () => {
+    const app = createTestApp({ limit: 5, windowMs: 60_000 });
+
+    const res = await app.request("/test", {
+      headers: { "X-Forwarded-For": "1.2.3.4" },
+    });
+
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("5");
+    expect(res.headers.get("X-RateLimit-Remaining")).not.toBeNull();
+  });
+
+  it("returns 429 with Retry-After header when rate limited", async () => {
+    const app = createTestApp({ limit: 1, windowMs: 60_000 });
+
+    await app.request("/test", { headers: { "X-Forwarded-For": "1.2.3.4" } });
+    const res = await app.request("/test", { headers: { "X-Forwarded-For": "1.2.3.4" } });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).not.toBeNull();
+  })
+})

--- a/apps/api/src/services/summaries/__tests__/summary-dispatcher.test.ts
+++ b/apps/api/src/services/summaries/__tests__/summary-dispatcher.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import type { SummaryReport } from "@trends/shared";
+
+import { SummaryDispatcher } from "../summary-dispatcher.js";
+
+const mockReport: SummaryReport = {
+  workspaceSlug: "dev",
+  period: "daily",
+  generatedAt: "2026-05-25T09:00:00Z",
+  window: { startAt: "2026-05-24T00:00:00Z", endAt: "2026-05-25T00:00:00Z", timezone: "Asia/Hong_Kong" },
+  totals: {
+    newResumes: 12,
+    collectionTasksCompleted: 8,
+    collectionTasksFailed: 1,
+    candidateStatusUpdates: 5,
+    shortlistActions: 3,
+    rejectActions: 1,
+    contactActions: 0,
+  },
+  breakdowns: {
+    resumesBySource: [],
+    collectionTasksByStatus: [],
+    candidateStatusByValue: [],
+    actionsByType: [],
+  },
+  notes: [],
+}
+
+const mockRender = vi.fn()
+const mockSendEmail = vi.fn()
+const mockSendWechatWorkMarkdown = vi.fn()
+const mockSendFeishuText = vi.fn()
+const mockTelegramSend = vi.fn()
+
+function createDispatcher() {
+  return new SummaryDispatcher({
+    notificationService: {
+      sendEmail: mockSendEmail,
+      sendWechatWorkMarkdown: mockSendWechatWorkMarkdown,
+      sendFeishuText: mockSendFeishuText,
+    },
+    notificationTemplateService: { render: mockRender },
+    telegramBridge: { send: mockTelegramSend },
+  })
+}
+
+describe("SummaryDispatcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRender.mockReturnValue({ subject: "Daily Ops Summary", markdown: "# Daily summary content" })
+    mockSendEmail.mockResolvedValue({ messageId: "msg-123" })
+    mockSendWechatWorkMarkdown.mockResolvedValue({ errcode: 0, errmsg: "ok" })
+    mockSendFeishuText.mockResolvedValue({ code: 0, msg: "success" })
+    mockTelegramSend.mockResolvedValue({ ok: true })
+  })
+
+  describe("buildPreview", () => {
+    it("builds preview with default template for daily period", () => {
+      const dispatcher = createDispatcher()
+
+      const preview = dispatcher.buildPreview(mockReport, {})
+
+      expect(preview.templateId).toBe("summary-daily")
+      expect(preview.subject).toBe("Daily Ops Summary")
+      expect(preview.content).toBe("# Daily summary content")
+    })
+
+    it("uses provided templateId when given", () => {
+      const dispatcher = createDispatcher()
+
+      const preview = dispatcher.buildPreview(mockReport, { templateId: "custom-template" })
+
+      expect(preview.templateId).toBe("custom-template")
+      expect(mockRender).toHaveBeenCalledWith("custom-template", expect.objectContaining({ workspaceSlug: "dev" }))
+    })
+
+    it("trims whitespace from templateId", () => {
+      const dispatcher = createDispatcher()
+
+      const preview = dispatcher.buildPreview(mockReport, { templateId: "  summary-weekly  " })
+
+      expect(preview.templateId).toBe("summary-weekly")
+    })
+
+    it("falls back to default template when templateId is empty", () => {
+      const dispatcher = createDispatcher()
+
+      const preview = dispatcher.buildPreview(mockReport, { templateId: "" })
+
+      expect(preview.templateId).toBe("summary-daily")
+    })
+  })
+
+  describe("dispatch", () => {
+    it("returns preview without delivery in dryRun mode", async () => {
+      const dispatcher = createDispatcher()
+
+      const result = await dispatcher.dispatch(mockReport, { channel: "email", dryRun: true, to: "admin@example.com" })
+
+      expect(result.dryRun).toBe(true)
+      expect(result.channel).toBe("email")
+      expect(result.delivery).toBeUndefined()
+      expect(mockSendEmail).not.toHaveBeenCalled()
+    })
+
+    it("sends email with HTML rendering", async () => {
+      const dispatcher = createDispatcher()
+
+      const result = await dispatcher.dispatch(mockReport, { channel: "email", to: "admin@example.com" })
+
+      expect(result.channel).toBe("email")
+      expect(result.dryRun).toBe(false)
+      expect(result.delivery?.messageId).toBe("msg-123")
+      expect(mockSendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: "admin@example.com",
+          html: expect.stringContaining("Daily summary content"),
+        }),
+      )
+    })
+
+    it("throws when email channel is missing recipient", async () => {
+      const dispatcher = createDispatcher()
+
+      await expect(dispatcher.dispatch(mockReport, { channel: "email" })).rejects.toThrow("Email recipient is required")
+    })
+
+    it("uses custom subject for email", async () => {
+      const dispatcher = createDispatcher()
+
+      await dispatcher.dispatch(mockReport, { channel: "email", to: "admin@example.com", subject: "Custom Subject" })
+
+      expect(mockSendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ subject: "Custom Subject" }),
+      )
+    })
+
+    it("sends WeChat Work markdown message", async () => {
+      const dispatcher = createDispatcher()
+
+      const result = await dispatcher.dispatch(mockReport, { channel: "wechat_work", webhookUrl: "https://example.com/webhook" })
+
+      expect(result.channel).toBe("wechat_work")
+      expect(mockSendWechatWorkMarkdown).toHaveBeenCalledWith(
+        expect.objectContaining({ content: "# Daily summary content" }),
+      )
+    })
+
+    it("sends Feishu text message", async () => {
+      const dispatcher = createDispatcher()
+
+      const result = await dispatcher.dispatch(mockReport, { channel: "feishu", webhookUrl: "https://example.com/webhook" })
+
+      expect(result.channel).toBe("feishu")
+      expect(mockSendFeishuText).toHaveBeenCalledWith(
+        expect.objectContaining({ content: "# Daily summary content" }),
+      )
+    })
+
+    it("sends Telegram message", async () => {
+      const dispatcher = createDispatcher()
+
+      const result = await dispatcher.dispatch(mockReport, { channel: "telegram", botToken: "bot-token", chatId: "chat-123" })
+
+      expect(result.channel).toBe("telegram")
+      expect(mockTelegramSend).toHaveBeenCalledWith(
+        expect.objectContaining({ content: "# Daily summary content", botToken: "bot-token", chatId: "chat-123" }),
+      )
+    })
+
+    it("escapes HTML in email body", async () => {
+      const dispatcher = createDispatcher()
+      mockRender.mockReturnValue({ subject: "Summary", markdown: '<script>alert("xss")</script>' })
+
+      await dispatcher.dispatch(mockReport, { channel: "email", to: "admin@example.com" })
+
+      const callArgs = mockSendEmail.mock.calls[0][0]
+      expect(callArgs.html).not.toContain("<script>")
+      expect(callArgs.html).toContain("&lt;script&gt;")
+    })
+  })
+})

--- a/apps/api/src/services/summaries/__tests__/summary-renderer.test.ts
+++ b/apps/api/src/services/summaries/__tests__/summary-renderer.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import type { SummaryReport } from "@trends/shared";
+
+import { SummaryRenderer } from "../summary-renderer.js";
+
+const baseReport: SummaryReport = {
+  workspaceSlug: "dev",
+  period: "daily",
+  generatedAt: "2026-05-25T09:00:00Z",
+  window: { startAt: "2026-05-24T00:00:00Z", endAt: "2026-05-25T00:00:00Z", timezone: "Asia/Hong_Kong" },
+  totals: {
+    newResumes: 12,
+    collectionTasksCompleted: 8,
+    collectionTasksFailed: 1,
+    candidateStatusUpdates: 5,
+    shortlistActions: 3,
+    rejectActions: 1,
+    contactActions: 0,
+  },
+  breakdowns: {
+    resumesBySource: [
+      { label: "51job", count: 10 },
+      { label: "Seek", count: 2 },
+    ],
+    collectionTasksByStatus: [
+      { label: "completed", count: 8 },
+      { label: "failed", count: 1 },
+    ],
+    candidateStatusByValue: [
+      { label: "shortlisted", count: 3 },
+      { label: "rejected", count: 1 },
+    ],
+    actionsByType: [
+      { label: "shortlist", count: 3 },
+      { label: "reject", count: 1 },
+    ],
+  },
+  notes: ["No critical incidents."],
+};
+
+describe("SummaryRenderer", () => {
+  const renderer = new SummaryRenderer();
+
+  describe("renderMarkdown", () => {
+    it("renders a basic daily summary report", () => {
+      const markdown = renderer.renderMarkdown(baseReport);
+
+      expect(markdown).toContain("# Daily Ops Summary");
+      expect(markdown).toContain("- Workspace: dev");
+      expect(markdown).toContain("- Period: daily");
+      expect(markdown).toContain("- New resumes: 12");
+      expect(markdown).toContain("- 51job: 10");
+      expect(markdown).toContain("- Seek: 2");
+      expect(markdown).toContain("- completed: 8");
+      expect(markdown).toContain("- No critical incidents.");
+    });
+
+    it("renders a weekly summary with correct title", () => {
+      const report: SummaryReport = { ...baseReport, period: "weekly" };
+      const markdown = renderer.renderMarkdown(report);
+
+      expect(markdown).toContain("# Weekly Ops Summary");
+    });
+
+    it("renders empty count lists with '- none'", () => {
+      const report: SummaryReport = {
+        ...baseReport,
+        breakdowns: {
+          resumesBySource: [],
+          collectionTasksByStatus: [],
+          candidateStatusByValue: [],
+          actionsByType: [],
+        },
+      };
+
+      const markdown = renderer.renderMarkdown(report);
+
+      // Each empty count list section should have "- none"
+      const noneMatches = markdown.match(/- none/g);
+      expect(noneMatches).not.toBeNull();
+      expect(noneMatches!.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("renders comparison section when present", () => {
+      const report: SummaryReport = {
+        ...baseReport,
+        comparison: {
+          previousWindow: { startAt: "2026-05-23T00:00:00Z", endAt: "2026-05-24T00:00:00Z" },
+          totalsDelta: {
+            sharedIngest: { newResumes: 5, collectionTasksCompleted: -2, collectionTasksFailed: 0 },
+            workspaceActivity: { candidateStatusUpdates: 1, shortlistActions: 0, rejectActions: -1, contactActions: 3 },
+          },
+        },
+      };
+
+      const markdown = renderer.renderMarkdown(report);
+
+      expect(markdown).toContain("## Previous Period Comparison");
+      expect(markdown).toContain("+5");
+      expect(markdown).toContain("-2");
+      expect(markdown).toContain("+3");
+    });
+
+    it("renders new candidates section when present", () => {
+      const report: SummaryReport = {
+        ...baseReport,
+        newCandidates: [
+          { resumeId: "r1", name: "Alice", source: "51job", location: "Dongguan", experience: 5, score: 85 },
+          { resumeId: "r2", name: "Bob", source: "Seek" },
+        ],
+      };
+
+      const markdown = renderer.renderMarkdown(report);
+
+      expect(markdown).toContain("## New Candidates (2)");
+      expect(markdown).toContain("Alice | 51job | Dongguan | 5yr | score:85");
+      expect(markdown).toContain("Bob | Seek");
+    });
+
+    it("renders new candidates with no entries", () => {
+      const report: SummaryReport = {
+        ...baseReport,
+        newCandidates: [],
+      };
+
+      const markdown = renderer.renderMarkdown(report);
+
+      expect(markdown).toContain("## New Candidates (0)");
+      expect(markdown).toContain("- No new candidates in this period");
+    });
+
+    it("uses scoped data when available", () => {
+      const report: SummaryReport = {
+        ...baseReport,
+        scopes: {
+          sharedIngest: {
+            totals: { newResumes: 20, collectionTasksCompleted: 15, collectionTasksFailed: 2 },
+            breakdowns: {
+              resumesBySource: [{ label: "51job", count: 20 }],
+              collectionTasksByStatus: [{ label: "completed", count: 15 }],
+            },
+          },
+          workspaceActivity: {
+            totals: { candidateStatusUpdates: 10, shortlistActions: 5, rejectActions: 3, contactActions: 2 },
+            breakdowns: {
+              candidateStatusByValue: [{ label: "shortlisted", count: 5 }],
+              actionsByType: [{ label: "shortlist", count: 5 }],
+            },
+          },
+        },
+      };
+
+      const markdown = renderer.renderMarkdown(report);
+
+      expect(markdown).toContain("- New resumes: 20");
+      expect(markdown).toContain("- 51job: 20");
+      expect(markdown).toContain("- Candidate status updates: 10");
+    });
+
+    it("renders candidates without name using resumeId", () => {
+      const report: SummaryReport = {
+        ...baseReport,
+        newCandidates: [
+          { resumeId: "r-unknown", source: "51job", score: 70 },
+        ],
+      };
+
+      const markdown = renderer.renderMarkdown(report);
+
+      expect(markdown).toContain("r-unknown | 51job | score:70");
+    });
+  });
+});

--- a/apps/api/src/services/summaries/__tests__/summary-shared.test.ts
+++ b/apps/api/src/services/summaries/__tests__/summary-shared.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { getDefaultTemplateId, getSummaryTitle } from "../summary-shared.js";
+
+describe("getSummaryTitle", () => {
+  it("returns daily title for daily period", () => {
+    expect(getSummaryTitle("daily")).toBe("Daily Ops Summary");
+  });
+
+  it("returns weekly title for weekly period", () => {
+    expect(getSummaryTitle("weekly")).toBe("Weekly Ops Summary");
+  });
+
+  it("returns monthly title for monthly period", () => {
+    expect(getSummaryTitle("monthly")).toBe("Monthly New Candidates Digest");
+  });
+});
+
+describe("getDefaultTemplateId", () => {
+  it("returns summary-daily for daily period", () => {
+    expect(getDefaultTemplateId("daily")).toBe("summary-daily");
+  });
+
+  it("returns summary-daily for weekly period", () => {
+    expect(getDefaultTemplateId("weekly")).toBe("summary-daily");
+  });
+
+  it("returns summary-monthly for monthly period", () => {
+    expect(getDefaultTemplateId("monthly")).toBe("summary-monthly");
+  });
+});


### PR DESCRIPTION
## Summary
- Add test coverage for summary rendering pipeline and rate-limit middleware
- SummaryRenderer (8 tests): markdown rendering, scoped data, comparisons, new candidates
- summary-shared (6 tests): getSummaryTitle, getDefaultTemplateId for all periods
- SummaryDispatcher (12 tests): buildPreview, dispatch to email/wechat/feishu/telegram, dryRun, HTML escaping, error handling
- rate-limit middleware (6 tests): allow/block, per-key tracking, custom key extractor, headers, 429 response

## Test plan
- [x] All 224 test files pass (3482 tests)
- [x] `make check` clean