### PR TITLE
fix: remove unused import and rename hook-like mock to pass lint

### DIFF
--- a/apps/web/src/pages/DebugAiTaggingResults.test.tsx
+++ b/apps/web/src/pages/DebugAiTaggingResults.test.tsx
@@ -4,14 +4,14 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { BrowserRouter } from 'react-router-dom'
 
 const enqueueBatchMock = vi.hoisted(() => vi.fn())
-const useQueryMock = vi.hoisted(() => vi.fn())
+const queryMock = vi.hoisted(() => vi.fn())
 const useConvexResumesMock = vi.hoisted(() => vi.fn())
 
 vi.mock('convex/react', () => ({
   useMutation: () => enqueueBatchMock,
   useQuery: (ref: string, args: unknown) => {
     if (args === 'skip') return undefined
-    return useQueryMock(ref, args)
+    return queryMock(ref, args)
   },
 }))
 
@@ -141,7 +141,7 @@ describe('DebugAiTaggingResults', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     useConvexResumesMock.mockReturnValue({ resumes: mockResumes, loading: false })
-    useQueryMock.mockImplementation((ref: string) => {
+    queryMock.mockImplementation((ref: string) => {
       if (ref === 'ai:summary') return mockSummary
       if (ref === 'ai:compare') return mockCompareRows
       return undefined
@@ -267,7 +267,7 @@ describe('DebugAiTaggingResults', () => {
   })
 
   it('shows loading state for results', async () => {
-    useQueryMock.mockImplementation((ref: string) => {
+    queryMock.mockImplementation((ref: string) => {
       if (ref === 'ai:summary') return mockSummary
       if (ref === 'ai:compare') return undefined // Loading
       return undefined
@@ -285,7 +285,7 @@ describe('DebugAiTaggingResults', () => {
   })
 
   it('shows no results message', async () => {
-    useQueryMock.mockImplementation((ref: string) => {
+    queryMock.mockImplementation((ref: string) => {
       if (ref === 'ai:summary') return mockSummary
       if (ref === 'ai:compare') return []
       return undefined

--- a/apps/web/src/pages/DebugJDs.test.tsx
+++ b/apps/web/src/pages/DebugJDs.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { BrowserRouter } from 'react-router-dom'


### PR DESCRIPTION
## Summary
- Remove unused `within` import from DebugJDs.test.tsx (TS6133 error)
- Rename `useQueryMock` → `queryMock` in DebugAiTaggingResults.test.tsx to avoid react-hooks/rules-of-hooks false positive

## Test plan
- [x] `make check` passes (typecheck + lint + governance)
- [x] All 224 test files pass (3482 tests)