### PR TITLE
refactor: deduplicate callConvex across 6 API route files

### DIFF
--- a/apps/api/src/routes/ai-summary.ts
+++ b/apps/api/src/routes/ai-summary.ts
@@ -1,7 +1,6 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import { resolveConvexUrl } from "../services/resume-import-service.js";
+import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
 import { aiSummaryService } from "../services/ai-summary-service.js";
-import { isRecord } from "@trends/shared";
 import { logger } from "../services/logger.js";
 
 const AI_SUMMARY_TTL_MS = 60 * 60 * 1000;
@@ -49,33 +48,6 @@ const SearchSummaryErrorResponseSchema = z.object({
 });
 
 
-async function callConvex(
-  type: "query" | "mutation",
-  pathName: string,
-  args: Record<string, unknown>,
-): Promise<unknown> {
-  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
-  const response = await fetch(`${convexUrl}/api/${type}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ path: pathName, args }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Convex ${type} failed (${response.status}): ${await response.text()}`);
-  }
-
-  const payload = await response.json() as unknown;
-  if (!isRecord(payload) || payload.status !== "success") {
-    throw new Error(`Convex ${type} failed for ${pathName}`);
-  }
-
-  return payload.value;
-}
-
 const searchSummaryRoute = createRoute({
   method: "post",
   path: "/api/resumes/search-summary",
@@ -114,7 +86,7 @@ app.openapi(searchSummaryRoute, async (c) => {
   const body = c.req.valid("json");
   const workspaceSlug = c.var.workspaceSlug;
   const now = Date.now();
-  const cached = await callConvex("query", "ai_summary_cache:get", {
+  const cached = await callConvexQuery( "ai_summary_cache:get", {
     workspaceSlug,
     urlHash: body.urlHash,
   }) as {
@@ -154,7 +126,7 @@ app.openapi(searchSummaryRoute, async (c) => {
       results: body.results,
     });
 
-    await callConvex("mutation", "ai_summary_cache:upsert", {
+    await callConvexMutation( "ai_summary_cache:upsert", {
       urlHash: body.urlHash,
       workspaceSlug,
       query: body.query,

--- a/apps/api/src/routes/blocks.ts
+++ b/apps/api/src/routes/blocks.ts
@@ -1,107 +1,13 @@
-import fs from "node:fs";
-import path from "node:path";
 import { isRecord } from "@trends/shared";
 
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
 
-import { config } from "../services/config.js";
+import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
 
 const app = new OpenAPIHono();
 
-
-function readString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
-}
-
-function readEnvVarFromFile(filePath: string, key: string): string | null {
-  if (!fs.existsSync(filePath)) {
-    return null;
-  }
-
-  const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
-    }
-
-    const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
-    if (!match || match[1] !== key) {
-      continue;
-    }
-
-    let value = match[2].trim();
-    const hasDoubleQuotes = value.startsWith("\"") && value.endsWith("\"");
-    const hasSingleQuotes = value.startsWith("'") && value.endsWith("'");
-    if (hasDoubleQuotes || hasSingleQuotes) {
-      value = value.slice(1, -1);
-    }
-
-    return value;
-  }
-
-  return null;
-}
-
-function resolveConvexUrl(): string {
-  if (process.env.CONVEX_URL) {
-    return process.env.CONVEX_URL;
-  }
-  if (process.env.VITE_CONVEX_URL) {
-    return process.env.VITE_CONVEX_URL;
-  }
-
-  const candidateFiles = [
-    path.join(config.projectRoot, "packages", "convex", ".env.local"),
-    path.join(config.projectRoot, "apps", "web", ".env.local"),
-    path.join(config.projectRoot, ".env.local"),
-    path.join(config.projectRoot, ".env"),
-  ];
-
-  for (const filePath of candidateFiles) {
-    const direct = readEnvVarFromFile(filePath, "CONVEX_URL");
-    if (direct) {
-      return direct;
-    }
-    const vite = readEnvVarFromFile(filePath, "VITE_CONVEX_URL");
-    if (vite) {
-      return vite;
-    }
-  }
-
-  return "http://127.0.0.1:3210";
-}
-
-async function callConvex(
-  type: "query" | "mutation",
-  pathName: string,
-  args: Record<string, unknown>
-): Promise<unknown> {
-  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
-  const response = await fetch(`${convexUrl}/api/${type}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ path: pathName, args }),
-  });
-
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(`Convex ${type} failed (${response.status}): ${message}`);
-  }
-
-  const payload = await response.json() as unknown;
-  if (!isRecord(payload) || payload.status !== "success") {
-    const errorMessage = isRecord(payload) ? readString(payload.errorMessage) : undefined;
-    throw new Error(errorMessage ?? `Convex ${type} failed for ${pathName}`);
-  }
-
-  return payload.value;
-}
 
 const CandidateBlockSchema = z.object({
   _id: z.string(),
@@ -170,7 +76,7 @@ const listRoute = createRoute({
 });
 
 app.openapi(listRoute, async (c) => {
-  const value = await callConvex("query", "candidate_blocks:list", {
+  const value = await callConvexQuery( "candidate_blocks:list", {
     workspaceSlug: c.var.workspaceSlug,
   });
   const items = Array.isArray(value) ? value : [];
@@ -211,7 +117,7 @@ app.openapi(upsertRoute, async (c) => {
   }
 
   if (identityKeys.length === 1) {
-    const id = await callConvex("mutation", "candidate_blocks:upsert", {
+    const id = await callConvexMutation( "candidate_blocks:upsert", {
       workspaceSlug: c.var.workspaceSlug,
       identityKey: identityKeys[0],
       reason: body.reason,
@@ -227,7 +133,7 @@ app.openapi(upsertRoute, async (c) => {
     }, 200);
   }
 
-  const result = await callConvex("mutation", "candidate_blocks:bulkUpsert", {
+  const result = await callConvexMutation( "candidate_blocks:bulkUpsert", {
     workspaceSlug: c.var.workspaceSlug,
     identityKeys,
     reason: body.reason,
@@ -274,7 +180,7 @@ app.openapi(patchRoute, async (c) => {
     return c.json({ success: true as const, updated: false }, 200);
   }
 
-  const updated = await callConvex("mutation", "candidate_blocks:updateReason", {
+  const updated = await callConvexMutation( "candidate_blocks:updateReason", {
     workspaceSlug: c.var.workspaceSlug,
     identityKey,
     reason: body.reason,
@@ -301,7 +207,7 @@ const deleteRoute = createRoute({
 
 app.openapi(deleteRoute, async (c) => {
   const query = c.req.valid("query");
-  const removed = await callConvex("mutation", "candidate_blocks:remove", {
+  const removed = await callConvexMutation( "candidate_blocks:remove", {
     workspaceSlug: c.var.workspaceSlug,
     identityKey: query.identityKey,
   });

--- a/apps/api/src/routes/candidate-status.ts
+++ b/apps/api/src/routes/candidate-status.ts
@@ -1,108 +1,14 @@
-import fs from "node:fs";
-import path from "node:path";
 import { isRecord } from "@trends/shared";
 
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
 
-import { config } from "../services/config.js";
+import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 
 const app = new OpenAPIHono();
 
-
-function readString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
-}
-
-function readEnvVarFromFile(filePath: string, key: string): string | null {
-  if (!fs.existsSync(filePath)) {
-    return null;
-  }
-
-  const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
-    }
-
-    const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
-    if (!match || match[1] !== key) {
-      continue;
-    }
-
-    let value = match[2].trim();
-    const hasDoubleQuotes = value.startsWith("\"") && value.endsWith("\"");
-    const hasSingleQuotes = value.startsWith("'") && value.endsWith("'");
-    if (hasDoubleQuotes || hasSingleQuotes) {
-      value = value.slice(1, -1);
-    }
-
-    return value;
-  }
-
-  return null;
-}
-
-function resolveConvexUrl(): string {
-  if (process.env.CONVEX_URL) {
-    return process.env.CONVEX_URL;
-  }
-  if (process.env.VITE_CONVEX_URL) {
-    return process.env.VITE_CONVEX_URL;
-  }
-
-  const candidateFiles = [
-    path.join(config.projectRoot, "packages", "convex", ".env.local"),
-    path.join(config.projectRoot, "apps", "web", ".env.local"),
-    path.join(config.projectRoot, ".env.local"),
-    path.join(config.projectRoot, ".env"),
-  ];
-
-  for (const filePath of candidateFiles) {
-    const direct = readEnvVarFromFile(filePath, "CONVEX_URL");
-    if (direct) {
-      return direct;
-    }
-    const vite = readEnvVarFromFile(filePath, "VITE_CONVEX_URL");
-    if (vite) {
-      return vite;
-    }
-  }
-
-  return "http://127.0.0.1:3210";
-}
-
-async function callConvex(
-  type: "query" | "mutation",
-  pathName: string,
-  args: Record<string, unknown>
-): Promise<unknown> {
-  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
-  const response = await fetch(`${convexUrl}/api/${type}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ path: pathName, args }),
-  });
-
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(`Convex ${type} failed (${response.status}): ${message}`);
-  }
-
-  const payload = await response.json() as unknown;
-  if (!isRecord(payload) || payload.status !== "success") {
-    const errorMessage = isRecord(payload) ? readString(payload.errorMessage) : undefined;
-    throw new Error(errorMessage ?? `Convex ${type} failed for ${pathName}`);
-  }
-
-  return payload.value;
-}
 
 const CandidateStatusEnum = z.enum([
   "new",
@@ -175,7 +81,7 @@ const listRoute = createRoute({
 });
 
 app.openapi(listRoute, async (c) => {
-  const value = await callConvex("query", "candidate_status:list", {
+  const value = await callConvexQuery( "candidate_status:list", {
     workspaceSlug: c.var.workspaceSlug,
   });
   const items = Array.isArray(value)
@@ -208,7 +114,7 @@ const updateRoute = createRoute({
 
 app.openapi(updateRoute, async (c) => {
   const body = c.req.valid("json");
-  await callConvex("mutation", "candidate_status:upsert", {
+  await callConvexMutation( "candidate_status:upsert", {
     workspaceSlug: c.var.workspaceSlug,
     identityKey: body.identityKey,
     status: body.status,
@@ -216,7 +122,7 @@ app.openapi(updateRoute, async (c) => {
     updatedBy: body.updatedBy,
   });
 
-  const item = await callConvex("query", "candidate_status:getByIdentity", {
+  const item = await callConvexQuery( "candidate_status:getByIdentity", {
     workspaceSlug: c.var.workspaceSlug,
     identityKey: body.identityKey,
   });

--- a/apps/api/src/routes/job-descriptions.ts
+++ b/apps/api/src/routes/job-descriptions.ts
@@ -1,11 +1,11 @@
-import fs from "node:fs";
-import path from "node:path";
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { jobDescriptionService } from "../services/job-description-service.js";
 import { jdKeywordExtractionService } from "../services/jd-keyword-extraction-service.js";
 import { DataNotFoundError } from "../services/errors.js";
 import { isRecord } from "@trends/shared";
 import { logger } from "../services/logger.js";
+import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
+import { readString } from "../services/workspace-config-service.js";
 
 const app = new OpenAPIHono();
 
@@ -85,102 +85,8 @@ type ConvexJobDescriptionRecord = {
 };
 
 
-function readString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
-}
-
-function readEnvVarFromFile(filePath: string, key: string): string | null {
-  if (!fs.existsSync(filePath)) {
-    return null;
-  }
-
-  const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
-    }
-
-    const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
-    if (!match || match[1] !== key) {
-      continue;
-    }
-
-    let value = match[2].trim();
-    const hasDoubleQuotes = value.startsWith("\"") && value.endsWith("\"");
-    const hasSingleQuotes = value.startsWith("'") && value.endsWith("'");
-    if (hasDoubleQuotes || hasSingleQuotes) {
-      value = value.slice(1, -1);
-    }
-
-    return value;
-  }
-
-  return null;
-}
-
-function resolveConvexUrl(): string {
-  if (process.env.CONVEX_URL) {
-    return process.env.CONVEX_URL;
-  }
-  if (process.env.VITE_CONVEX_URL) {
-    return process.env.VITE_CONVEX_URL;
-  }
-
-  const projectRoot = jobDescriptionService.projectRoot;
-  const candidateFiles = [
-    path.join(projectRoot, "packages", "convex", ".env.local"),
-    path.join(projectRoot, "apps", "web", ".env.local"),
-    path.join(projectRoot, ".env.local"),
-    path.join(projectRoot, ".env"),
-  ];
-
-  for (const filePath of candidateFiles) {
-    const direct = readEnvVarFromFile(filePath, "CONVEX_URL");
-    if (direct) {
-      return direct;
-    }
-
-    const vite = readEnvVarFromFile(filePath, "VITE_CONVEX_URL");
-    if (vite) {
-      return vite;
-    }
-  }
-
-  return "http://127.0.0.1:3210";
-}
-
-async function callConvex(
-  type: "query" | "mutation",
-  pathName: string,
-  args: Record<string, unknown>
-): Promise<unknown> {
-  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
-  const response = await fetch(`${convexUrl}/api/${type}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ path: pathName, args }),
-  });
-
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(`Convex ${type} failed (${response.status}): ${message}`);
-  }
-
-  const payload = await response.json() as unknown;
-  if (!isRecord(payload) || payload.status !== "success") {
-    const errorMessage = isRecord(payload) ? readString(payload.errorMessage) : undefined;
-    throw new Error(errorMessage ?? `Convex ${type} failed for ${pathName}`);
-  }
-
-  return payload.value;
-}
-
 async function listConvexJobDescriptions(workspaceSlug: string): Promise<ConvexJobDescriptionRecord[]> {
-  const value = await callConvex("query", "job_descriptions:list", { workspaceSlug });
+  const value = await callConvexQuery( "job_descriptions:list", { workspaceSlug });
   if (!Array.isArray(value)) {
     return [];
   }
@@ -212,7 +118,7 @@ function toJobDescriptionFile(item: ConvexJobDescriptionRecord): {
     return null;
   }
 
-  const title = readString(item.title);
+  const title = readString(item.title) ?? undefined;
   const name = readString(item.slug) ?? id;
   const lastModified = typeof item.lastModified === "number" ? item.lastModified : Date.now();
   const enabled = item.enabled === false ? "inactive" : "active";
@@ -240,7 +146,7 @@ function toJobDescriptionFile(item: ConvexJobDescriptionRecord): {
     size: content.length,
     title,
     status: enabled,
-    location: readString(item.location),
+    location: readString(item.location) ?? undefined,
     suggestedFilters,
     autoMatch: customKeywords.length > 0 ? { keywords: customKeywords } : undefined,
   };
@@ -320,7 +226,7 @@ app.openapi(createRouteDef, async (c) => {
       return c.json({ success: false, error: "Overwrite is not supported for read-only system files" }, 400);
     }
 
-    const createdId = await callConvex("mutation", "job_descriptions:create", {
+    const createdId = await callConvexMutation( "job_descriptions:create", {
       title: name,
       content,
       type: "custom",

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -23,6 +23,9 @@ import {
     type SearchProfile,
 } from "../services/search-profile-service.js";
 import { logger } from "../services/logger.js";
+import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
+import { resolveConvexUrl } from "../services/resume-import-service.js";
+import { readString, readNumber } from "../services/workspace-config-service.js";
 
 const app = new OpenAPIHono();
 
@@ -133,21 +136,9 @@ const ProfileRunStatusSchema = z.object({
 type ProfileRunStatus = z.infer<typeof ProfileRunStatusSchema>;
 
 
-function readString(value: unknown): string | undefined {
-    return typeof value === "string" && value.trim().length > 0
-        ? value.trim()
-        : undefined;
-}
-
-function readNumber(value: unknown): number | undefined {
-    return typeof value === "number" && Number.isFinite(value)
-        ? value
-        : undefined;
-}
-
 function toIsoTimestamp(value: unknown): string | undefined {
     const numeric = readNumber(value);
-    if (numeric === undefined) {
+    if (numeric === null) {
         return undefined;
     }
     return new Date(numeric).toISOString();
@@ -209,67 +200,6 @@ function upsertRunStatus(workspaceSlug: string, status: ProfileRunStatus): void 
     writeRunStatusStore(store);
 }
 
-function readEnvVarFromFile(filePath: string, key: string): string | null {
-    if (!fs.existsSync(filePath)) {
-        return null;
-    }
-
-    const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
-    for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed || trimmed.startsWith("#")) {
-            continue;
-        }
-
-        const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
-        if (!match || match[1] !== key) {
-            continue;
-        }
-
-        let value = match[2].trim();
-        const hasDoubleQuotes = value.startsWith("\"") && value.endsWith("\"");
-        const hasSingleQuotes = value.startsWith("'") && value.endsWith("'");
-        if (hasDoubleQuotes || hasSingleQuotes) {
-            value = value.slice(1, -1);
-        }
-
-        return value;
-    }
-
-    return null;
-}
-
-function resolveConvexUrl(): string {
-    if (process.env.CONVEX_URL) {
-        return process.env.CONVEX_URL;
-    }
-    if (process.env.VITE_CONVEX_URL) {
-        return process.env.VITE_CONVEX_URL;
-    }
-
-    const projectRoot = searchProfileService.projectRoot;
-    const candidateFiles = [
-        path.join(projectRoot, "packages", "convex", ".env.local"),
-        path.join(projectRoot, "apps", "web", ".env.local"),
-        path.join(projectRoot, ".env.local"),
-        path.join(projectRoot, ".env"),
-    ];
-
-    for (const filePath of candidateFiles) {
-        const direct = readEnvVarFromFile(filePath, "CONVEX_URL");
-        if (direct) {
-            return direct;
-        }
-
-        const vite = readEnvVarFromFile(filePath, "VITE_CONVEX_URL");
-        if (vite) {
-            return vite;
-        }
-    }
-
-    return "http://127.0.0.1:3210";
-}
-
 async function dispatchCollectionTask(args: {
     keyword: string;
     location: string;
@@ -280,37 +210,10 @@ async function dispatchCollectionTask(args: {
     autoAnalyze: boolean;
     analysisTopN: number;
 }): Promise<{ taskId: string; convexUrl: string }> {
-    const convexUrl = resolveConvexUrl().replace(/\/$/, "");
-    const response = await fetch(`${convexUrl}/api/mutation`, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
-        },
-        body: JSON.stringify({
-            path: "resume_tasks:dispatch",
-            args,
-        }),
-    });
-
-    if (!response.ok) {
-        const text = await response.text();
-        throw new Error(`Convex dispatch failed (${response.status}): ${text}`);
-    }
-
-    const payload = await response.json() as {
-        status?: string;
-        value?: unknown;
-        errorMessage?: string;
-    };
-
-    if (payload.status !== "success") {
-        throw new Error(payload.errorMessage || "Convex mutation failed.");
-    }
-
+    const value = await callConvexMutation("resume_tasks:dispatch", args);
     return {
-        taskId: String(payload.value),
-        convexUrl,
+        taskId: String(value),
+        convexUrl: resolveConvexUrl().replace(/\/$/, ""),
     };
 }
 
@@ -326,39 +229,13 @@ function normalizePositiveInt(value: unknown): number | undefined {
 }
 
 async function getCollectionTaskStatus(taskId: string): Promise<Partial<ProfileRunStatus> | null> {
-    const convexUrl = resolveConvexUrl().replace(/\/$/, "");
-    const response = await fetch(`${convexUrl}/api/query`, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
-        },
-        body: JSON.stringify({
-            path: "resume_tasks:getById",
-            args: { taskId },
-        }),
-    });
+    const value = await callConvexQuery("resume_tasks:getById", { taskId });
 
-    if (!response.ok) {
-        const text = await response.text();
-        throw new Error(`Convex task query failed (${response.status}): ${text}`);
-    }
-
-    const payload = await response.json() as {
-        status?: string;
-        value?: unknown;
-        errorMessage?: string;
-    };
-
-    if (payload.status !== "success") {
-        throw new Error(payload.errorMessage || "Convex query failed.");
-    }
-
-    if (!isRecord(payload.value)) {
+    if (!isRecord(value)) {
         return null;
     }
 
-    const task = payload.value;
+    const task = value;
 
     const results = isRecord(task.results) ? task.results : undefined;
     const progress = isRecord(task.progress) ? task.progress : undefined;
@@ -370,10 +247,10 @@ async function getCollectionTaskStatus(taskId: string): Promise<Partial<ProfileR
   return {
     taskStatus: normalizeTaskStatus(task.status),
     completedAt: toIsoTimestamp(task.completedAt),
-    resultCount: resultCount !== undefined ? Math.round(resultCount) : undefined,
-    extracted: extracted !== undefined ? Math.round(extracted) : undefined,
-    submitted: submitted !== undefined ? Math.round(submitted) : undefined,
-    error: readString(task.error),
+    resultCount: resultCount !== null ? Math.round(resultCount) : undefined,
+    extracted: extracted !== null ? Math.round(extracted) : undefined,
+    submitted: submitted !== null ? Math.round(submitted) : undefined,
+    error: readString(task.error) ?? undefined,
   };
 }
 
@@ -456,12 +333,12 @@ function readLogicalProfileId(record: ConvexSearchProfileRecord): string | null 
 
 function readDeletedAt(record: ConvexSearchProfileRecord): number | undefined {
     const profilePayload = readProfilePayload(record);
-    return readNumber(profilePayload.deletedAt);
+    return readNumber(profilePayload.deletedAt) ?? undefined;
 }
 
 function readTemplateHash(record: ConvexSearchProfileRecord): string | undefined {
     const profilePayload = readProfilePayload(record);
-    return readString(profilePayload.templateHash);
+    return readString(profilePayload.templateHash) ?? undefined;
 }
 
 function isSeededFromConfig(record: ConvexSearchProfileRecord): boolean {
@@ -537,42 +414,13 @@ type ResolvedCustomProfileRecord = {
     deletedAt?: number;
 };
 
-async function callConvex(
-    type: "query" | "mutation",
-    pathName: string,
-    args: Record<string, unknown>
-): Promise<unknown> {
-    const convexUrl = resolveConvexUrl().replace(/\/$/, "");
-    const response = await fetch(`${convexUrl}/api/${type}`, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
-        },
-        body: JSON.stringify({ path: pathName, args }),
-    });
-
-    if (!response.ok) {
-        const text = await response.text();
-        throw new Error(`Convex ${type} failed (${response.status}): ${text}`);
-    }
-
-    const payload = await response.json() as unknown;
-    if (!isRecord(payload) || payload.status !== "success") {
-        const errorMessage = isRecord(payload) ? readString(payload.errorMessage) : undefined;
-        throw new Error(errorMessage ?? `Convex ${type} failed for ${pathName}`);
-    }
-
-    return payload.value;
-}
-
 async function listCustomProfileRecords(
     workspaceSlug: string,
     options?: {
         includeDeleted?: boolean;
     }
 ): Promise<ResolvedCustomProfileRecord[]> {
-    const value = await callConvex("query", "search_profiles:list", { workspaceSlug });
+    const value = await callConvexQuery( "search_profiles:list", { workspaceSlug });
     if (!Array.isArray(value)) {
         return [];
     }
@@ -623,7 +471,7 @@ async function findCustomProfileRecordById(
         includeDeleted?: boolean;
     }
 ): Promise<ResolvedCustomProfileRecord | null> {
-    const value = await callConvex("query", "search_profiles:getById", { id, workspaceSlug });
+    const value = await callConvexQuery( "search_profiles:getById", { id, workspaceSlug });
     if (!isRecord(value)) {
         return null;
     }
@@ -755,7 +603,7 @@ async function getLinkedCustomJobDescription(
 ): Promise<ConvexJobDescriptionRecord | null> {
     let value: unknown;
     try {
-        value = await callConvex("query", "job_descriptions:get", { id });
+        value = await callConvexQuery( "job_descriptions:get", { id });
     } catch {
         return null;
     }
@@ -788,12 +636,12 @@ async function buildJobDescriptionSyncPayload(
     const title = readString(jobDescription.title) ?? profile.name;
     const content = generateStructuredJobDescriptionContent({
         title,
-        location: readString(jobDescription.location),
+        location: readString(jobDescription.location) ?? undefined,
         industryTags: normalizeKeywordList(jobDescription.industryTags),
-        minExperience: readNumber(jobDescription.minExperience),
-        maxExperience: readNumber(jobDescription.maxExperience),
-        minAge: readNumber(jobDescription.minAge),
-        maxAge: readNumber(jobDescription.maxAge),
+        minExperience: readNumber(jobDescription.minExperience) ?? undefined,
+        maxExperience: readNumber(jobDescription.maxExperience) ?? undefined,
+        minAge: readNumber(jobDescription.minAge) ?? undefined,
+        maxAge: readNumber(jobDescription.maxAge) ?? undefined,
         customKeywords: profile.keywords,
     });
 
@@ -809,7 +657,7 @@ async function createCustomProfile(
     workspaceSlug: string,
     jobDescriptionSync?: JobDescriptionSyncPayload
 ): Promise<SearchProfile> {
-    const value = await callConvex("mutation", "search_profiles:create", {
+    const value = await callConvexMutation( "search_profiles:create", {
         profile,
         workspaceSlug,
         jobDescriptionSync,
@@ -831,7 +679,7 @@ async function updateCustomProfile(
     workspaceSlug: string,
     jobDescriptionSync?: JobDescriptionSyncPayload
 ): Promise<SearchProfile> {
-    const value = await callConvex("mutation", "search_profiles:update", {
+    const value = await callConvexMutation( "search_profiles:update", {
         id,
         profile,
         workspaceSlug,
@@ -849,7 +697,7 @@ async function updateCustomProfile(
 }
 
 async function deleteCustomProfile(id: string, workspaceSlug: string): Promise<boolean> {
-    const value = await callConvex("mutation", "search_profiles:remove", {
+    const value = await callConvexMutation( "search_profiles:remove", {
         id,
         workspaceSlug,
     });
@@ -987,10 +835,10 @@ app.openapi(listRoute, async (c) => {
         quickStart: profile.quickStart,
         filters: profile.filters
             ? {
-                minAge: readNumber(profile.filters.minAge),
-                maxAge: readNumber(profile.filters.maxAge),
-                minExperience: readNumber(profile.filters.minExperience),
-                maxExperience: readNumber(profile.filters.maxExperience),
+                minAge: readNumber(profile.filters.minAge) ?? undefined,
+                maxAge: readNumber(profile.filters.maxAge) ?? undefined,
+                minExperience: readNumber(profile.filters.minExperience) ?? undefined,
+                maxExperience: readNumber(profile.filters.maxExperience) ?? undefined,
             }
             : undefined,
     }));

--- a/apps/api/src/routes/taxonomy.ts
+++ b/apps/api/src/routes/taxonomy.ts
@@ -1,6 +1,6 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { requireAdmin } from "../middleware/workspace.js";
-import { resolveConvexUrl } from "../services/resume-import-service.js";
+import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
 import { isRecord } from "@trends/shared";
 import { logger } from "../services/logger.js";
 
@@ -51,33 +51,6 @@ const DeleteTaxonomyParamsSchema = z.object({
 
 type TaxonomyClusterResponse = z.infer<typeof TaxonomyClusterSchema>;
 
-
-async function callConvex(
-  type: "query" | "mutation",
-  pathName: string,
-  args: Record<string, unknown>,
-): Promise<unknown> {
-  const convexUrl = resolveConvexUrl().replace(/\/$/, "");
-  const response = await fetch(`${convexUrl}/api/${type}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ path: pathName, args }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Convex ${type} failed (${response.status}): ${await response.text()}`);
-  }
-
-  const payload = await response.json() as unknown;
-  if (!isRecord(payload) || payload.status !== "success") {
-    throw new Error(`Convex ${type} failed for ${pathName}`);
-  }
-
-  return payload.value;
-}
 
 function toTaxonomyCluster(value: unknown): TaxonomyClusterResponse | null {
   if (!isRecord(value) || typeof value._id !== "string") {
@@ -144,7 +117,7 @@ const listRoute = createRoute({
 
 app.openapi(listRoute, async (c) => {
   try {
-    const value = await callConvex("query", "taxonomy_clusters:list", {
+    const value = await callConvexQuery( "taxonomy_clusters:list", {
       workspaceSlug: c.var.workspaceSlug,
     });
     return c.json({ success: true as const, items: toTaxonomyItems(value) }, 200);
@@ -191,11 +164,11 @@ const upsertRoute = createRoute({
 app.openapi(upsertRoute, async (c) => {
   try {
     const body = c.req.valid("json");
-    await callConvex("mutation", "taxonomy_clusters:upsert", {
+    await callConvexMutation( "taxonomy_clusters:upsert", {
       ...body,
       workspaceSlug: c.var.workspaceSlug,
     });
-    const value = await callConvex("query", "taxonomy_clusters:list", {
+    const value = await callConvexQuery( "taxonomy_clusters:list", {
       workspaceSlug: c.var.workspaceSlug,
     });
     return c.json({ success: true as const, items: toTaxonomyItems(value) }, 200);
@@ -242,7 +215,7 @@ const suggestRoute = createRoute({
 app.openapi(suggestRoute, async (c) => {
   try {
     const body = c.req.valid("json");
-    const value = await callConvex("mutation", "taxonomy_clusters:suggest", {
+    const value = await callConvexMutation( "taxonomy_clusters:suggest", {
       workspaceSlug: c.var.workspaceSlug,
       limit: body.limit,
     });
@@ -284,11 +257,11 @@ const deleteRoute = createRoute({
 app.openapi(deleteRoute, async (c) => {
   try {
     const { id } = c.req.valid("param");
-    await callConvex("mutation", "taxonomy_clusters:remove", {
+    await callConvexMutation( "taxonomy_clusters:remove", {
       id,
       workspaceSlug: c.var.workspaceSlug,
     });
-    const value = await callConvex("query", "taxonomy_clusters:list", {
+    const value = await callConvexQuery( "taxonomy_clusters:list", {
       workspaceSlug: c.var.workspaceSlug,
     });
     return c.json({ success: true as const, items: toTaxonomyItems(value) }, 200);


### PR DESCRIPTION
## Summary
- Replace private `callConvex`/`readString`/`readEnvVarFromFile`/`resolveConvexUrl` implementations in 6 route files with imports from existing `convex-utils.ts` and `workspace-config-service.ts`
- Refactored `dispatchCollectionTask` and `getCollectionTaskStatus` in search-profiles.ts to use shared `callConvexMutation`/`callConvexQuery`
- Net reduction: 432 lines of duplicated code eliminated

## Files changed
- `apps/api/src/routes/blocks.ts` — removed 93-line private helper block, imported from convex-utils
- `apps/api/src/routes/candidate-status.ts` — removed 93-line private helper block, imported from convex-utils
- `apps/api/src/routes/job-descriptions.ts` — removed 93-line private helper block, imported readString from workspace-config-service
- `apps/api/src/routes/search-profiles.ts` — removed 100+ lines, refactored dispatch/status to use shared functions
- `apps/api/src/routes/taxonomy.ts` — removed 26-line callConvex, imported from convex-utils
- `apps/api/src/routes/ai-summary.ts` — removed 26-line callConvex, imported from convex-utils

## Test plan
- [x] All 6 existing route test suites pass (35 tests)
- [x] convex-utils test suite passes (19 tests)
- [x] Full test suite passes (224 files, 3482 tests)
- [x] `make check` passes (typecheck + lint + governance)