### PR TITLE
refactor: extract chrome.runtime.onMessage handler from content.ts

### DIFF
--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -36,6 +36,7 @@ import { createPaginationUtils } from "./lib/pagination-utils";
 import { createDomUtils, delay } from "./lib/dom-utils";
 import { createResumeExtractor, type ResumeExtractorDeps } from "./lib/resume-extractor";
 import { createPageBridge, type PageBridgeDeps } from "./lib/page-bridge";
+import { createChromeMessageHandler, type ChromeMessageHandlerDeps } from "./lib/chrome-message-handler";
 import { createSyncStatusWidget } from "./lib/sync-status-widget";
 import { createAutoSyncRunner } from "./lib/auto-sync-runner";
 import {
@@ -908,61 +909,18 @@ const _autoSyncRunner = createAutoSyncRunner({
 });
 const { runAutoSyncIfEnabled } = _autoSyncRunner;
 
-// Listen for messages from popup
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.action === "extractCurrentPage") {
-    const resumes = extractResumes();
-    const pagination = getPaginationInfo();
-    const metadata = buildSubmitMetadata();
-    sendResponse({
-      success: true,
-      data: resumes,
-      count: resumes.length,
-      pagination,
-      metadata,
-    });
-  } else if (request.action === "downloadCSV") {
-    const resumes = extractResumes();
-    const csv = resumesToCSV(resumes);
-    const timestamp = new Date().toISOString().slice(0, 10);
-    const filename = `resumes_${timestamp}_${makeRandomId()}.csv`;
-    const saveAs = !!request.saveAs;
-
-    // Download via background script (chrome.downloads API preserves filenames)
-    downloadFile(csv, filename, "text/csv", saveAs)
-      .then(() =>
-        sendResponse({ success: true, count: resumes.length, filename }),
-      )
-      .catch((err) => sendResponse({ success: false, error: err.message }));
-    return true; // Keep channel open for async
-  } else if (request.action === "downloadJSON") {
-    const resumes = extractResumes();
-    const metadata = buildExportMetadata(resumes);
-    const payload = { metadata, data: resumes };
-    const json = JSON.stringify(payload, null, 2);
-    const filename = buildExportFilename();
-    const saveAs = !!request.saveAs;
-
-    // Download via background script (chrome.downloads API preserves filenames)
-    downloadFile(json, filename, "application/json", saveAs)
-      .then(() =>
-        sendResponse({ success: true, count: resumes.length, filename }),
-      )
-      .catch((err) => sendResponse({ success: false, error: err.message }));
-    return true; // Keep channel open for async
-  } else if (request.action === "getPaginationInfo") {
-    sendResponse(getPaginationInfo());
-  } else if (request.action === "getRuntimeStatus") {
-    sendResponse({
-      success: true,
-      status: getExternalAccessorStatus(),
-    });
-  } else if (request.action === "ping") {
-    sendResponse({ success: true, message: "Content script loaded" });
-  }
-
-  return true; // Keep channel open for async response
+const _chromeMessageHandler = createChromeMessageHandler({
+  extractResumes,
+  getPaginationInfo,
+  buildSubmitMetadata,
+  resumesToCSV,
+  makeRandomId,
+  downloadFile,
+  buildExportMetadata,
+  buildExportFilename,
+  getExternalAccessorStatus,
 });
+_chromeMessageHandler.installChromeMessageListener();
 
 
 

--- a/apps/browser-extension/src/lib/__tests__/chrome-message-handler.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/chrome-message-handler.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createChromeMessageHandler, type ChromeMessageHandlerDeps } from "../chrome-message-handler.js";
+
+function createMockDeps(overrides: Partial<ChromeMessageHandlerDeps> = {}): ChromeMessageHandlerDeps {
+  return {
+    extractResumes: vi.fn(() => [{ name: "Alice" }]),
+    getPaginationInfo: vi.fn(() => ({ page: 1, total: 10 })),
+    buildSubmitMetadata: vi.fn(() => ({ source: "test" })),
+    resumesToCSV: vi.fn(() => "name\nAlice"),
+    makeRandomId: vi.fn(() => "abc123"),
+    downloadFile: vi.fn(async () => {}),
+    buildExportMetadata: vi.fn(() => ({ exportMeta: true })),
+    buildExportFilename: vi.fn(() => "resumes_test.json"),
+    getExternalAccessorStatus: vi.fn(() => ({ status: "ready" })),
+    ...overrides,
+  };
+}
+
+function sendMessage(action: string, extra: Record<string, unknown> = {}) {
+  const listener = (chrome.runtime.onMessage.addListener as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+  if (!listener) throw new Error("No listener registered");
+  const sendResponse = vi.fn();
+  const result = listener({ action, ...extra }, {}, sendResponse);
+  return { sendResponse, returnResult: result };
+}
+
+describe("createChromeMessageHandler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("chrome", {
+      runtime: {
+        onMessage: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        },
+      },
+    });
+  });
+
+  it("returns object with installChromeMessageListener function", () => {
+    const handler = createChromeMessageHandler(createMockDeps());
+    expect(typeof handler.installChromeMessageListener).toBe("function");
+  });
+
+  it("registers a listener when installChromeMessageListener is called", () => {
+    const handler = createChromeMessageHandler(createMockDeps());
+    handler.installChromeMessageListener();
+    expect(chrome.runtime.onMessage.addListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles extractCurrentPage action", () => {
+    const deps = createMockDeps();
+    const handler = createChromeMessageHandler(deps);
+    handler.installChromeMessageListener();
+
+    const { sendResponse } = sendMessage("extractCurrentPage");
+    expect(deps.extractResumes).toHaveBeenCalled();
+    expect(deps.getPaginationInfo).toHaveBeenCalled();
+    expect(deps.buildSubmitMetadata).toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: [{ name: "Alice" }],
+      count: 1,
+      pagination: { page: 1, total: 10 },
+      metadata: { source: "test" },
+    });
+  });
+
+  it("handles downloadCSV action", () => {
+    const deps = createMockDeps();
+    const handler = createChromeMessageHandler(deps);
+    handler.installChromeMessageListener();
+
+    const { sendResponse, returnResult } = sendMessage("downloadCSV", { saveAs: true });
+    expect(deps.resumesToCSV).toHaveBeenCalledWith([{ name: "Alice" }]);
+    expect(deps.makeRandomId).toHaveBeenCalled();
+    expect(deps.downloadFile).toHaveBeenCalledWith("name\nAlice", expect.stringMatching(/^resumes_\d{4}-\d{2}-\d{2}_abc123\.csv$/), "text/csv", true);
+    expect(returnResult).toBe(true); // async channel kept open
+  });
+
+  it("resolves downloadCSV sendResponse on success", async () => {
+    const deps = createMockDeps();
+    const handler = createChromeMessageHandler(deps);
+    handler.installChromeMessageListener();
+
+    const { sendResponse } = sendMessage("downloadCSV");
+    // Allow microtask to flush
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({ success: true, count: 1, filename: expect.stringMatching(/^resumes_\d{4}-\d{2}-\d{2}_abc123\.csv$/) });
+    });
+  });
+
+  it("resolves downloadCSV sendResponse on failure", async () => {
+    const deps = createMockDeps({
+      downloadFile: vi.fn(async () => { throw new Error("disk full"); }),
+    });
+    const handler = createChromeMessageHandler(deps);
+    handler.installChromeMessageListener();
+
+    const { sendResponse } = sendMessage("downloadCSV");
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({ success: false, error: "disk full" });
+    });
+  });
+
+  it("handles downloadJSON action", () => {
+    const deps = createMockDeps();
+    const handler = createChromeMessageHandler(deps);
+    handler.installChromeMessageListener();
+
+    const { sendResponse, returnResult } = sendMessage("downloadJSON", { saveAs: false });
+    expect(deps.buildExportMetadata).toHaveBeenCalledWith([{ name: "Alice" }]);
+    expect(deps.buildExportFilename).toHaveBeenCalled();
+    expect(returnResult).toBe(true); // async channel kept open
+  });
+
+  it("resolves downloadJSON sendResponse on success", async () => {
+    const deps = createMockDeps();
+    const handler = createChromeMessageHandler(deps);
+    handler.installChromeMessageListener();
+
+    const { sendResponse } = sendMessage("downloadJSON");
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({ success: true, count: 1, filename: "resumes_test.json" });
+    });
+  });
+
+  it("resolves downloadJSON sendResponse on failure", async () => {
+    const deps = createMockDeps({
+      downloadFile: vi.fn(async () => { throw new Error("network error"); }),
+    });
+    const handler = createChromeMessageHandler(deps);
+    handler.installChromeMessageListener();
+
+    const { sendResponse } = sendMessage("downloadJSON");
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({ success: false, error: "network error" });
+    });
+  });
+
+  it("handles getPaginationInfo action", () => {
+    const deps = createMockDeps();
+    const handler = createChromeMessageHandler(deps);
+    handler.installChromeMessageListener();
+
+    const { sendResponse } = sendMessage("getPaginationInfo");
+    expect(deps.getPaginationInfo).toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({ page: 1, total: 10 });
+  });
+
+  it("handles getRuntimeStatus action", () => {
+    const deps = createMockDeps();
+    const handler = createChromeMessageHandler(deps);
+    handler.installChromeMessageListener();
+
+    const { sendResponse } = sendMessage("getRuntimeStatus");
+    expect(deps.getExternalAccessorStatus).toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({ success: true, status: { status: "ready" } });
+  });
+
+  it("handles ping action", () => {
+    const deps = createMockDeps();
+    const handler = createChromeMessageHandler(deps);
+    handler.installChromeMessageListener();
+
+    const { sendResponse } = sendMessage("ping");
+    expect(sendResponse).toHaveBeenCalledWith({ success: true, message: "Content script loaded" });
+  });
+
+  it("returns true for unknown actions to keep channel open", () => {
+    const deps = createMockDeps();
+    const handler = createChromeMessageHandler(deps);
+    handler.installChromeMessageListener();
+
+    const { returnResult } = sendMessage("unknownAction");
+    expect(returnResult).toBe(true);
+  });
+});

--- a/apps/browser-extension/src/lib/chrome-message-handler.ts
+++ b/apps/browser-extension/src/lib/chrome-message-handler.ts
@@ -1,0 +1,84 @@
+export interface ChromeMessageHandlerDeps {
+  extractResumes: () => unknown[];
+  getPaginationInfo: () => unknown;
+  buildSubmitMetadata: () => unknown;
+  resumesToCSV: (resumes: unknown[]) => string;
+  makeRandomId: () => string;
+  downloadFile: (content: string, filename: string, mimeType: string, saveAs: boolean) => Promise<void>;
+  buildExportMetadata: (resumes: unknown[]) => unknown;
+  buildExportFilename: () => string;
+  getExternalAccessorStatus: () => Record<string, unknown>;
+}
+
+export function createChromeMessageHandler(deps: ChromeMessageHandlerDeps) {
+  const {
+    extractResumes,
+    getPaginationInfo,
+    buildSubmitMetadata,
+    resumesToCSV,
+    makeRandomId,
+    downloadFile,
+    buildExportMetadata,
+    buildExportFilename,
+    getExternalAccessorStatus,
+  } = deps;
+
+  function installChromeMessageListener() {
+    chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
+      if (request.action === "extractCurrentPage") {
+        const resumes = extractResumes();
+        const pagination = getPaginationInfo();
+        const metadata = buildSubmitMetadata();
+        sendResponse({
+          success: true,
+          data: resumes,
+          count: resumes.length,
+          pagination,
+          metadata,
+        });
+      } else if (request.action === "downloadCSV") {
+        const resumes = extractResumes();
+        const csv = resumesToCSV(resumes);
+        const timestamp = new Date().toISOString().slice(0, 10);
+        const filename = `resumes_${timestamp}_${makeRandomId()}.csv`;
+        const saveAs = !!request.saveAs;
+
+        // Download via background script (chrome.downloads API preserves filenames)
+        downloadFile(csv, filename, "text/csv", saveAs)
+          .then(() =>
+            sendResponse({ success: true, count: resumes.length, filename }),
+          )
+          .catch((err) => sendResponse({ success: false, error: err.message }));
+        return true; // Keep channel open for async
+      } else if (request.action === "downloadJSON") {
+        const resumes = extractResumes();
+        const metadata = buildExportMetadata(resumes);
+        const payload = { metadata, data: resumes };
+        const json = JSON.stringify(payload, null, 2);
+        const filename = buildExportFilename();
+        const saveAs = !!request.saveAs;
+
+        // Download via background script (chrome.downloads API preserves filenames)
+        downloadFile(json, filename, "application/json", saveAs)
+          .then(() =>
+            sendResponse({ success: true, count: resumes.length, filename }),
+          )
+          .catch((err) => sendResponse({ success: false, error: err.message }));
+        return true; // Keep channel open for async
+      } else if (request.action === "getPaginationInfo") {
+        sendResponse(getPaginationInfo());
+      } else if (request.action === "getRuntimeStatus") {
+        sendResponse({
+          success: true,
+          status: getExternalAccessorStatus(),
+        });
+      } else if (request.action === "ping") {
+        sendResponse({ success: true, message: "Content script loaded" });
+      }
+
+      return true; // Keep channel open for async response
+    });
+  }
+
+  return { installChromeMessageListener };
+}


### PR DESCRIPTION
## Summary
- Extracts the `chrome.runtime.onMessage.addListener` handler (~55L) from `content.ts` into `lib/chrome-message-handler.ts` using the established DI factory pattern
- Adds 13 tests covering all 6 message actions (extractCurrentPage, downloadCSV, downloadJSON, getPaginationInfo, getRuntimeStatus, ping) plus error paths
- Reduces content.ts from 1051L to 1009L

## Test plan
- [x] All 452 browser extension tests pass (was 439, +13 new)
- [x] `make check` passes (typecheck + lint + governance)
- [x] No behavior change — same message handling, just extracted