### PR TITLE
refactor: centralize SimpleErrorSchema into schemas/common.ts

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -22,6 +22,7 @@ import {
   MatchRunsQuerySchema,
   AnalyzeRequestSchema,
   AnalyzeResponseSchema,
+  SimpleErrorSchema,
 } from "../schemas/index.js";
 import { config } from "../services/config.js";
 import { ResumeService, normalizeEducationLevel, parseExperienceYears, type ResumeFilters } from "../services/resume-service.js";
@@ -105,11 +106,6 @@ const MAX_SAFE_CONVEX_POST_FILTER_LIMIT = 2000;
 const MATCH_STORAGE_FILTER_SCAN_BATCH_SIZE = 250;
 
 type MatchMode = "rules_only" | "hybrid" | "ai_only";
-
-const SimpleErrorSchema = z.object({
-  success: z.literal(false),
-  error: z.string(),
-});
 
 const ClearMatchesResponseSchema = z.object({
   success: z.literal(true),

--- a/apps/api/src/routes/resumes_packets.ts
+++ b/apps/api/src/routes/resumes_packets.ts
@@ -18,6 +18,7 @@ import {
   ReviewPacketSummarySendRequestSchema,
   ReviewPacketSummarySendResponseSchema,
   ReviewPacketTrackedExportResponseSchema,
+  SimpleErrorSchema,
 } from "../schemas/index.js";
 import { logger } from "../services/logger.js";
 import { config } from "../services/config.js";
@@ -76,11 +77,6 @@ const feedbackImportService = new FeedbackImportService();
 const feedbackSummaryService = new FeedbackSummaryService();
 const resumeService = new ResumeService(config.projectRoot);
 const searchEventLogger = new SearchEventLogger(config.projectRoot);
-
-const SimpleErrorSchema = z.object({
-  success: z.literal(false),
-  error: z.string(),
-});
 
 // --- Export/packet types ---
 

--- a/apps/api/src/routes/resumes_search.ts
+++ b/apps/api/src/routes/resumes_search.ts
@@ -27,6 +27,7 @@ import {
   ResumeMatchesQuerySchema,
   MatchRunsResponseSchema,
   MatchRunsQuerySchema,
+  SimpleErrorSchema,
 } from "../schemas/index.js";
 import { resolveResumeId } from "../services/resume-id.js";
 import { callConvexQuery, isConvexPaginatedQueryPage } from "../services/convex-utils.js";
@@ -65,11 +66,6 @@ const jobService = new JobDescriptionService(config.projectRoot);
 const ruleScoringService = new RuleScoringService(config.projectRoot);
 const skillsKnowledgeService = new SkillsKnowledgeService(config.projectRoot);
 const searchEventLogger = new SearchEventLogger(config.projectRoot);
-
-const SimpleErrorSchema = z.object({
-  success: z.literal(false),
-  error: z.string(),
-});
 
 const ClearMatchesResponseSchema = z.object({
   success: z.literal(true),

--- a/apps/api/src/schemas/common.ts
+++ b/apps/api/src/schemas/common.ts
@@ -34,6 +34,13 @@ export const DateFilterSchema = z.object({
 });
 
 // Error response schema
+export const SimpleErrorSchema = z
+  .object({
+    success: z.literal(false),
+    error: z.string(),
+  })
+  .openapi("SimpleError");
+
 export const ErrorResponseSchema = z
   .object({
     success: z.literal(false),

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -1000,11 +1000,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Export failed */
@@ -1013,11 +1009,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -1066,11 +1058,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Tracked export failed */
@@ -1079,11 +1067,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -1170,11 +1154,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Run lookup failed */
@@ -1183,11 +1163,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -1235,11 +1211,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Download failed */
@@ -1248,11 +1220,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -1305,11 +1273,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Run not found */
@@ -1318,11 +1282,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Feedback import failed */
@@ -1331,11 +1291,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -1386,11 +1342,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Summary preview failed */
@@ -1399,11 +1351,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -1454,11 +1402,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Summary send failed */
@@ -1467,11 +1411,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -1607,11 +1547,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Session or data not found */
@@ -1620,11 +1556,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -1675,11 +1607,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -1877,11 +1805,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Session or job description not found */
@@ -1890,11 +1814,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -1943,11 +1863,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -7645,6 +7561,11 @@ export interface components {
             resumeIds?: string[];
             sourceHosts?: string[];
             limit?: number;
+        };
+        SimpleError: {
+            /** @enum {boolean} */
+            success: false;
+            error: string;
         };
         ResumeExportCanonicalRequest: {
             /**


### PR DESCRIPTION
## Summary
- Extracts the duplicated `SimpleErrorSchema` (identical `z.object` in 3 route files) into `schemas/common.ts` with `.openapi("SimpleError")` tag
- Removes 4 lines of duplication from each of `resumes.ts`, `resumes_search.ts`, and `resumes_packets.ts`
- Adds `SimpleErrorSchema` to the `schemas/index.ts` barrel export

## Test plan
- [x] `make check` passes
- [x] `npm test` passes (229 files, 3576 tests)
- [x] API types regenerated