### PR TITLE
refactor: centralize duplicated route schemas into schemas/resumes.ts

### DIFF
--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -23,6 +23,8 @@ import {
   AnalyzeRequestSchema,
   AnalyzeResponseSchema,
   SimpleErrorSchema,
+  ClearMatchesResponseSchema,
+  ResumeResetResponseSchema,
 } from "../schemas/index.js";
 import { config } from "../services/config.js";
 import { ResumeService, normalizeEducationLevel, parseExperienceYears, type ResumeFilters } from "../services/resume-service.js";
@@ -117,12 +119,6 @@ const MAX_SAFE_CONVEX_POST_FILTER_SCAN = 250;
 
 type MatchMode = "rules_only" | "hybrid" | "ai_only";
 
-const ClearMatchesResponseSchema = z.object({
-  success: z.literal(true),
-  deleted: z.number().int(),
-  jobDescriptionId: z.string().optional(),
-});
-
 const RescoreRequestSchema = z.object({
   sessionId: z.string().optional(),
   sample: z.string().optional(),
@@ -139,17 +135,7 @@ const MatchRescoreResponseSchema = MatchResponseSchema;
 const TriggerReingestRequestSchema = z.object({
   limit: z.number().int().min(1).max(1000).optional(),
 });
-const ResumeImportErrorSchema = z.object({
-  success: z.literal(false),
-  error: z.string(),
-});
-
-const ResumeResetResponseSchema = z.object({
-  success: z.literal(true),
-  count: z.number().int(),
-  partial: z.boolean(),
-  deleted: z.record(z.string(), z.number().int()),
-});
+const ResumeImportErrorSchema = SimpleErrorSchema;
 
 const ResetCandidateActionsRequestSchema = z.object({
   workspaceSlug: z.string().optional(),

--- a/apps/api/src/routes/resumes_import.ts
+++ b/apps/api/src/routes/resumes_import.ts
@@ -15,6 +15,8 @@ import {
   ResumeManualImportFormSchema,
   ResumeManualImportResponseSchema,
   ResumeSubmitSummarySchema,
+  SimpleErrorSchema,
+  ResumeResetResponseSchema,
 } from "../schemas/index.js";
 import { resolveResumeId } from "../services/resume-id.js";
 import { isRecord, normalizeWorkHistoryEntry } from "@trends/shared";
@@ -184,17 +186,8 @@ function normalizeResumeBackupSourceHosts(values: string[] | undefined): string[
   return normalized?.map((value) => value.toLowerCase());
 }
 
-const ResumeImportErrorSchema = z.object({
-  success: z.literal(false),
-  error: z.string(),
-});
+const ResumeImportErrorSchema = SimpleErrorSchema;
 
-const ResumeResetResponseSchema = z.object({
-  success: z.literal(true),
-  count: z.number().int(),
-  partial: z.boolean(),
-  deleted: z.record(z.string(), z.number().int()),
-});
 const manualImportResumesRoute = createRoute({
   method: "post",
   path: "/api/resumes/manual-import",

--- a/apps/api/src/routes/resumes_search.ts
+++ b/apps/api/src/routes/resumes_search.ts
@@ -28,6 +28,7 @@ import {
   MatchRunsResponseSchema,
   MatchRunsQuerySchema,
   SimpleErrorSchema,
+  ClearMatchesResponseSchema,
 } from "../schemas/index.js";
 import { resolveResumeId } from "../services/resume-id.js";
 import { callConvexQuery, isConvexPaginatedQueryPage } from "../services/convex-utils.js";
@@ -88,12 +89,6 @@ const jobService = new JobDescriptionService(config.projectRoot);
 const ruleScoringService = new RuleScoringService(config.projectRoot);
 const skillsKnowledgeService = new SkillsKnowledgeService(config.projectRoot);
 const searchEventLogger = new SearchEventLogger(config.projectRoot);
-
-const ClearMatchesResponseSchema = z.object({
-  success: z.literal(true),
-  deleted: z.number().int(),
-  jobDescriptionId: z.string().optional(),
-});
 
 const DEFAULT_AI_TOP_N = 20;
 const DEFAULT_CONVEX_RESUME_PAGE_SIZE = 50;

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -1392,3 +1392,22 @@ export const AnalysisTasksResponseSchema = z
     tasks: z.array(AnalysisTaskSchema),
   })
   .openapi("AnalysisTasksResponse");
+
+// Shared route-level schemas (previously duplicated across route files)
+
+export const ClearMatchesResponseSchema = z
+  .object({
+    success: z.literal(true),
+    deleted: z.number().int(),
+    jobDescriptionId: z.string().optional(),
+  })
+  .openapi("ClearMatchesResponse");
+
+export const ResumeResetResponseSchema = z
+  .object({
+    success: z.literal(true),
+    count: z.number().int(),
+    partial: z.boolean(),
+    deleted: z.record(z.string(), z.number().int()),
+  })
+  .openapi("ResumeResetResponse");

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -701,11 +701,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Admin access required */
@@ -714,11 +710,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Import failed */
@@ -727,11 +719,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -847,11 +835,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Requested resume records could not be resolved */
@@ -860,11 +844,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Backup failed */
@@ -873,11 +853,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -913,15 +889,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: true;
-                            count: number;
-                            partial: boolean;
-                            deleted: {
-                                [key: string]: number;
-                            };
-                        };
+                        "application/json": components["schemas"]["ResumeResetResponse"];
                     };
                 };
                 /** @description Admin access required */
@@ -930,11 +898,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Reset failed */
@@ -943,11 +907,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -1466,11 +1426,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
                 /** @description Reset failed */
@@ -1479,11 +1435,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
+                        "application/json": components["schemas"]["SimpleError"];
                     };
                 };
             };
@@ -1888,12 +1840,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: true;
-                            deleted: number;
-                            jobDescriptionId?: string;
-                        };
+                        "application/json": components["schemas"]["ClearMatchesResponse"];
                     };
                 };
             };
@@ -7225,6 +7172,11 @@ export interface components {
             unchanged: number;
             deduped: number;
         };
+        SimpleError: {
+            /** @enum {boolean} */
+            success: false;
+            error: string;
+        };
         ResumeImportRequest: {
             metadata: components["schemas"]["ResumeImportMetadata"];
             resumes?: components["schemas"]["ResumeImportItem"][];
@@ -7562,10 +7514,14 @@ export interface components {
             sourceHosts?: string[];
             limit?: number;
         };
-        SimpleError: {
+        ResumeResetResponse: {
             /** @enum {boolean} */
-            success: false;
-            error: string;
+            success: true;
+            count: number;
+            partial: boolean;
+            deleted: {
+                [key: string]: number;
+            };
         };
         ResumeExportCanonicalRequest: {
             /**
@@ -8317,6 +8273,12 @@ export interface components {
             completedAt?: string;
             /** @example AI provider timeout */
             error?: string;
+        };
+        ClearMatchesResponse: {
+            /** @enum {boolean} */
+            success: true;
+            deleted: number;
+            jobDescriptionId?: string;
         };
         ResumeFilters: {
             minExperience?: number;


### PR DESCRIPTION
## Summary
- Extracts `ClearMatchesResponseSchema` (duplicated in `resumes.ts` and `resumes_search.ts`) into `schemas/resumes.ts`
- Extracts `ResumeResetResponseSchema` (duplicated in `resumes.ts` and `resumes_import.ts`) into `schemas/resumes.ts`
- Replaces `ResumeImportErrorSchema` with `SimpleErrorSchema` where identical (both route files)
- All schemas now have `.openapi()` tags for proper API documentation

## Test plan
- [x] `make check` passes
- [x] `npm test` passes (229 files, 3576 tests)
- [x] API types regenerated