### PR TITLE
refactor: dedup toStringValue/toOptionalNumber/toStringArray across 3 files

### DIFF
--- a/apps/api/src/routes/resumes-packets-helpers.ts
+++ b/apps/api/src/routes/resumes-packets-helpers.ts
@@ -1,4 +1,5 @@
 import type { ResumeItem } from "../types/resume.js";
+import { toStringValue, toOptionalNumber, toStringArray } from "../services/resume-ingest-utils.js";
 
 // --- Pure helper functions for data parsing ---
 
@@ -6,39 +7,8 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function toStringValue(value: unknown): string {
-  if (typeof value === "string") {
-    return value.trim();
-  }
-  if (value === null || value === undefined) {
-    return "";
-  }
-  return String(value).trim();
-}
-
-export function toOptionalNumber(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const parsed = Number(trimmed);
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-export function toStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return value
-    .map((item) => toStringValue(item))
-    .filter(Boolean);
-}
+// Re-exported from canonical source for backward compatibility
+export { toStringValue, toOptionalNumber, toStringArray };
 
 export function toBrandRole(value: unknown): "employer" | "equipment" | "both" | null {
   if (value === "employer" || value === "equipment" || value === "both") {

--- a/apps/api/src/services/bff-filter-utils.ts
+++ b/apps/api/src/services/bff-filter-utils.ts
@@ -17,34 +17,15 @@ import {
 import { normalizeEducationLevel } from "./resume-service.js";
 
 // ---------------------------------------------------------------------------
-// Internal helpers (also extracted so tests don't need to replicate them)
+// Re-exported parse helpers (canonical source: resume-ingest-utils.ts)
 // ---------------------------------------------------------------------------
 
+import { toStringValue, toOptionalNumber } from "./resume-ingest-utils.js";
+export { toStringValue, toOptionalNumber };
 
-export function toStringValue(value: unknown): string {
-  if (typeof value === "string") {
-    return value.trim();
-  }
-  if (value === null || value === undefined) {
-    return "";
-  }
-  return String(value).trim();
-}
-
-export function toOptionalNumber(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const parsed = Number(trimmed);
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
+// ---------------------------------------------------------------------------
+// Internal helpers (also extracted so tests don't need to replicate them)
+// ---------------------------------------------------------------------------
 
 export function parseAgeFromContentField(content: Record<string, unknown>): number | null {
   const ageStr = toStringValue(content.age);


### PR DESCRIPTION
## Summary
- Replaces identical copies of `toStringValue`, `toOptionalNumber`, `toStringArray` in `bff-filter-utils.ts` and `resumes-packets-helpers.ts` with imports from the canonical source (`resume-ingest-utils.ts`)
- ~50 lines of duplication removed
- Backward-compatible: both files re-export the functions so existing consumers don't break

## Test plan
- [x] `make check` passes
- [x] `npm test` passes (230 files, 3704 tests)