### PR TITLE
fix: consolidate admin guard pattern and protect notification send endpoints

### DIFF
--- a/apps/api/src/middleware/workspace.test.ts
+++ b/apps/api/src/middleware/workspace.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 
-import { workspaceMiddleware, requireAdmin } from "./workspace.js";
+import { workspaceMiddleware, requireAdmin, denyIfNotAdmin } from "./workspace.js";
 import { serverTimingMiddleware } from "./server-timing.js";
 
 function createTestApp() {
@@ -139,6 +139,35 @@ describe("requireAdmin", () => {
     const body = await res.json();
     expect(body.success).toBe(false);
     expect(body.error).toContain("Admin access required");
+  });
+
+  it("rejects request without workspace middleware (undefined accessLevel)", async () => {
+    const app = createAdminApp();
+    const res = await app.request("/admin");
+    // Default workspace is dev (admin), so this should pass
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// denyIfNotAdmin
+// ---------------------------------------------------------------------------
+
+describe("denyIfNotAdmin", () => {
+  it("returns false for admin access level", () => {
+    expect(denyIfNotAdmin("admin")).toBe(false);
+  });
+
+  it("returns true for user access level", () => {
+    expect(denyIfNotAdmin("user")).toBe(true);
+  });
+
+  it("returns true for undefined access level", () => {
+    expect(denyIfNotAdmin(undefined)).toBe(true);
+  });
+
+  it("returns true for empty string", () => {
+    expect(denyIfNotAdmin("")).toBe(true);
   });
 });
 

--- a/apps/api/src/middleware/workspace.ts
+++ b/apps/api/src/middleware/workspace.ts
@@ -48,3 +48,9 @@ export const requireAdmin: MiddlewareHandler = async (c, next) => {
   }
   await next();
 };
+
+/** Helper to add admin guard inline in OpenAPI route handlers.
+ *  Returns true if access is denied (handler should return early). */
+export function denyIfNotAdmin(accessLevel: string | undefined): boolean {
+  return accessLevel !== "admin";
+}

--- a/apps/api/src/routes/filter-presets.ts
+++ b/apps/api/src/routes/filter-presets.ts
@@ -4,6 +4,7 @@
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
+import { denyIfNotAdmin } from "../middleware/workspace.js";
 
 const app = new OpenAPIHono();
 
@@ -217,7 +218,7 @@ const createPresetRoute = createRoute({
 });
 
 app.openapi(createPresetRoute, async (c) => {
-    if (c.var.accessLevel !== "admin") {
+    if (denyIfNotAdmin(c.var.accessLevel)) {
         return c.json({ success: false as const, error: "Admin access required" }, 403);
     }
     const payload = c.req.valid("json");
@@ -278,7 +279,7 @@ const updatePresetRoute = createRoute({
 });
 
 app.openapi(updatePresetRoute, async (c) => {
-    if (c.var.accessLevel !== "admin") {
+    if (denyIfNotAdmin(c.var.accessLevel)) {
         return c.json({ success: false as const, error: "Admin access required" }, 403);
     }
     const { id } = c.req.valid("param");
@@ -336,7 +337,7 @@ const deletePresetRoute = createRoute({
 });
 
 app.openapi(deletePresetRoute, async (c) => {
-    if (c.var.accessLevel !== "admin") {
+    if (denyIfNotAdmin(c.var.accessLevel)) {
         return c.json({ success: false as const, error: "Admin access required" }, 403);
     }
     const { id } = c.req.valid("param");

--- a/apps/api/src/routes/job-descriptions.ts
+++ b/apps/api/src/routes/job-descriptions.ts
@@ -6,6 +6,7 @@ import { isRecord } from "@trends/shared";
 import { logger } from "../services/logger.js";
 import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
 import { readString } from "../services/workspace-config-service.js";
+import { denyIfNotAdmin } from "../middleware/workspace.js";
 
 const app = new OpenAPIHono();
 
@@ -217,7 +218,7 @@ const createRouteDef = createRoute({
 });
 
 app.openapi(createRouteDef, async (c) => {
-  if (c.var.accessLevel !== "admin") {
+  if (denyIfNotAdmin(c.var.accessLevel)) {
     return c.json({ success: false, error: "Admin access required" }, 403);
   }
   const { name, content, overwrite } = c.req.valid("json");

--- a/apps/api/src/routes/notifications.test.ts
+++ b/apps/api/src/routes/notifications.test.ts
@@ -5,9 +5,11 @@ import notificationsRoutes from './notifications'
 import { aiMatchingService } from '../services/ai-matching'
 import { notificationService } from '../services/notification-service'
 import { notificationTemplateService } from '../services/notification-template-service'
+import { workspaceMiddleware } from '../middleware/workspace'
 
 function createTestApp() {
   const app = new Hono()
+  app.use('/api/*', workspaceMiddleware)
   app.route('/api/notifications', notificationsRoutes)
   return app
 }
@@ -147,7 +149,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
         body: JSON.stringify({ to: 'test@example.com', subject: 'Hello', body: '<p>Hi</p>' }),
       })
       expect(response.status).toBe(200)
@@ -161,7 +163,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
         body: JSON.stringify({ to: 'test@example.com', subject: 'Hello', body: '<p>Hi</p>' }),
       })
       expect(response.status).toBe(500)
@@ -171,7 +173,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
         body: JSON.stringify({ to: 'not-an-email', subject: 'Hello', body: 'test' }),
       })
       expect(response.status).toBe(400)
@@ -185,7 +187,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send-template', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
         body: JSON.stringify({ channel: 'email', templateId: 'outreach-email', to: 'test@example.com', data: {} }),
       })
       expect(response.status).toBe(200)
@@ -201,7 +203,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send-template', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
         body: JSON.stringify({ channel: 'wechat_work', templateId: 'match-alert', data: {} }),
       })
       expect(response.status).toBe(200)
@@ -216,7 +218,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send-template', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
         body: JSON.stringify({ channel: 'feishu', templateId: 'match-alert', data: {} }),
       })
       expect(response.status).toBe(200)
@@ -232,10 +234,32 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send-template', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
         body: JSON.stringify({ channel: 'email', templateId: 'missing', to: 'test@example.com', data: {} }),
       })
       expect(response.status).toBe(500)
+    })
+  })
+
+  describe('admin guard', () => {
+    it('rejects /send without admin workspace', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'hr' },
+        body: JSON.stringify({ to: 'test@example.com', subject: 'Hello', body: '<p>Hi</p>' }),
+      })
+      expect(response.status).toBe(403)
+    })
+
+    it('rejects /send-template without admin workspace', async () => {
+      const app = createTestApp()
+      const response = await app.request('/api/notifications/send-template', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'hr' },
+        body: JSON.stringify({ channel: 'email', templateId: 'outreach-email', to: 'test@example.com', data: {} }),
+      })
+      expect(response.status).toBe(403)
     })
   })
 })

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -7,6 +7,7 @@ import { notificationService } from "../services/notification-service.js";
 import { notificationTemplateService } from "../services/notification-template-service.js";
 import { config } from "../services/config.js";
 import { formatIsoOffsetInTimezone } from "../services/timezone.js";
+import { requireAdmin } from "../middleware/workspace.js";
 
 const app = new Hono();
 
@@ -189,6 +190,7 @@ app.post(
 // POST /api/notifications/send
 app.post(
     "/send",
+    requireAdmin,
     zValidator("json", sendSchema),
     async (c) => {
         const { to, subject, body } = c.req.valid("json");
@@ -209,6 +211,7 @@ app.post(
 // POST /api/notifications/send-template
 app.post(
     "/send-template",
+    requireAdmin,
     zValidator("json", sendTemplateSchema),
     async (c) => {
         const payload = c.req.valid("json");

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -60,6 +60,7 @@ import { formatIsoOffsetInTimezone } from "../services/timezone.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { BrandDisplayResolver } from "../services/brand-display-resolver.js";
 import { logger } from "../services/logger.js";
+import { requireAdmin } from "../middleware/workspace.js";
 
 import { isRecord } from "@trends/shared";
 import type { ResumeItem } from "../types/resume.js";
@@ -103,6 +104,9 @@ import {
 } from "../services/resume-candidate-prep.js";
 
 const app = new OpenAPIHono();
+app.use("/api/resumes/candidate-actions/reset", requireAdmin);
+app.use("/api/resumes/trigger-reingest", requireAdmin);
+app.use("/api/resumes/analyze", requireAdmin);
 const resumeService = new ResumeService(config.projectRoot);
 const aiService = new AIMatchingService();
 const matchStorage = new MatchStorage(config.projectRoot);
@@ -182,10 +186,6 @@ const resetCandidateActionsRoute = createRoute({
 });
 
 app.openapi(resetCandidateActionsRoute, async (c) => {
-  if (c.var.accessLevel !== "admin") {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
-  }
-
   try {
     const request = c.req.valid("json");
     const workspaceSlug = request.workspaceSlug || c.var.workspaceSlug;

--- a/apps/api/src/routes/resumes_admin.ts
+++ b/apps/api/src/routes/resumes_admin.ts
@@ -3,8 +3,10 @@ import { callConvexAction, callConvexMutation } from "../services/convex-utils.j
 import { IngestComputeService } from "../services/ingest-compute-service.js";
 import { config } from "../services/config.js";
 import { logger } from "../services/logger.js";
+import { requireAdmin } from "../middleware/workspace.js";
 
 const app = new OpenAPIHono();
+app.use("*", requireAdmin);
 const ingestComputeService = new IngestComputeService(config.projectRoot);
 
 const HardResetReingestRequestSchema = z.object({
@@ -59,10 +61,6 @@ const ResetDatabaseV2ResponseSchema = z.object({
 
 // Hard reset re-ingest: clear computed fields and reschedule
 app.post("/api/resumes/hard-reset-reingest", async (c) => {
-  if (c.var.accessLevel !== "admin") {
-    return c.json({ success: false, error: "Admin access required" }, 403);
-  }
-
   const body = await c.req.json().catch(() => ({}));
   const parsed = HardResetReingestRequestSchema.safeParse(body);
   if (!parsed.success) {
@@ -145,10 +143,6 @@ app.post("/api/resumes/hard-reset-reingest", async (c) => {
 
 // Clear analyses for specific JDs or resume IDs
 app.post("/api/resumes/clear-analyses", async (c) => {
-  if (c.var.accessLevel !== "admin") {
-    return c.json({ success: false, error: "Admin access required" }, 403);
-  }
-
   const body = await c.req.json().catch(() => ({}));
   const parsed = ClearAnalysesRequestSchema.safeParse(body);
   if (!parsed.success) {
@@ -248,10 +242,6 @@ app.post("/api/resumes/clear-analyses", async (c) => {
 
 // Reset database (admin only)
 app.post("/api/resumes/reset-database", async (c) => {
-  if (c.var.accessLevel !== "admin") {
-    return c.json({ success: false, error: "Admin access required" }, 403);
-  }
-
   const body = await c.req.json().catch(() => ({}));
   const parsed = ResetDatabaseRequestSchema.safeParse(body);
   if (!parsed.success) {
@@ -287,10 +277,6 @@ app.post("/api/resumes/reset-database", async (c) => {
 
 // Archive/unarchive resumes
 app.post("/api/resumes/archive", async (c) => {
-  if (c.var.accessLevel !== "admin") {
-    return c.json({ success: false, error: "Admin access required" }, 403);
-  }
-
   const body = await c.req.json().catch(() => ({}));
   const parsed = ArchiveResumesRequestSchema.safeParse(body);
   if (!parsed.success) {

--- a/apps/api/src/routes/resumes_import.ts
+++ b/apps/api/src/routes/resumes_import.ts
@@ -7,6 +7,7 @@ import { submitResumeImport } from "../services/resume-import-service.js";
 import { getManualResumeImportMaxUploadBytes, importManualResumes } from "../services/manual-resume-import-service.js";
 import { config } from "../services/config.js";
 import { logger } from "../services/logger.js";
+import { requireAdmin } from "../middleware/workspace.js";
 import {
   ResumeBackupRequestSchema,
   ResumeImportRequestSchema,
@@ -28,6 +29,9 @@ import {
 import { toResumeItemFromRecord } from "../services/resume-candidate-prep.js";
 
 const app = new OpenAPIHono();
+app.use("/api/resumes/import", requireAdmin);
+app.use("/api/resumes/backup", requireAdmin);
+app.use("/api/resumes/reset", requireAdmin);
 const actionStorage = new ActionStorage(config.projectRoot);
 
 // --- Backup-specific helpers ---
@@ -244,10 +248,6 @@ const resetResumesRoute = createRoute({
 });
 
 app.openapi(importResumesRoute, async (c) => {
-  if (c.var.accessLevel !== "admin") {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
-  }
-
   try {
     const payload = c.req.valid("json");
     const result = await submitResumeImport(payload, c.var.workspaceSlug);
@@ -292,10 +292,6 @@ app.openapi(manualImportResumesRoute, async (c) => {
 });
 
 app.openapi(backupResumesRoute, async (c) => {
-  if (c.var.accessLevel !== "admin") {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
-  }
-
   try {
     const request = c.req.valid("json");
     const requestedResumeIds = normalizeResumeBackupFilterValues(request.resumeIds);
@@ -446,10 +442,6 @@ app.openapi(backupResumesRoute, async (c) => {
 });
 
 app.openapi(resetResumesRoute, async (c) => {
-  if (c.var.accessLevel !== "admin") {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
-  }
-
   try {
     const value = await callConvexMutation("resume_tasks:resetDatabase", {});
     return c.json(ResumeResetResponseSchema.parse(value), 200);

--- a/apps/api/src/routes/summaries.ts
+++ b/apps/api/src/routes/summaries.ts
@@ -15,6 +15,7 @@ import { summaryDispatcher } from "../services/summaries/summary-dispatcher.js";
 import { SummaryRenderer } from "../services/summaries/summary-renderer.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { logger } from "../services/logger.js";
+import { denyIfNotAdmin } from "../middleware/workspace.js";
 import {
   WorkspaceSummaryRunStorage,
   type StoredWorkspaceSummaryRun,
@@ -427,7 +428,7 @@ const listProfilesRoute = createRoute({
 });
 
 app.openapi(listProfilesRoute, async (c) => {
-  if (c.var.accessLevel !== "admin") {
+  if (denyIfNotAdmin(c.var.accessLevel)) {
     return c.json({ success: false as const, error: "Admin access required" }, 403);
   }
 
@@ -489,7 +490,7 @@ const createProfileRoute = createRoute({
 });
 
 app.openapi(createProfileRoute, async (c) => {
-  if (c.var.accessLevel !== "admin") {
+  if (denyIfNotAdmin(c.var.accessLevel)) {
     return c.json({ success: false as const, error: "Admin access required" }, 403);
   }
 
@@ -594,7 +595,7 @@ const getProfileRoute = createRoute({
 });
 
 app.openapi(getProfileRoute, async (c) => {
-  if (c.var.accessLevel !== "admin") {
+  if (denyIfNotAdmin(c.var.accessLevel)) {
     return c.json({ success: false as const, error: "Admin access required" }, 403);
   }
 
@@ -668,7 +669,7 @@ const updateProfileRoute = createRoute({
 });
 
 app.openapi(updateProfileRoute, async (c) => {
-  if (c.var.accessLevel !== "admin") {
+  if (denyIfNotAdmin(c.var.accessLevel)) {
     return c.json({ success: false as const, error: "Admin access required" }, 403);
   }
 
@@ -748,7 +749,7 @@ const deleteProfileRoute = createRoute({
 });
 
 app.openapi(deleteProfileRoute, async (c) => {
-  if (c.var.accessLevel !== "admin") {
+  if (denyIfNotAdmin(c.var.accessLevel)) {
     return c.json({ success: false as const, error: "Admin access required" }, 403);
   }
 


### PR DESCRIPTION
## Summary
- Replace scattered inline `c.var.accessLevel !== "admin"` checks with consistent patterns across 7 route files
- Add `denyIfNotAdmin()` helper for OpenAPI Hono route handlers (can't use middleware as 2nd arg to `.openapi()`)
- **NEW: Add `requireAdmin` middleware to `/api/notifications/send` and `/send-template`** — these email-sending endpoints were previously unguarded
- **NEW: Add `requireAdmin` middleware to `/api/resumes/trigger-reingest` and `/api/resumes/analyze`** — LLM-billing endpoints were previously unguarded
- Add admin guard tests for notifications routes and `denyIfNotAdmin` helper

## Security Impact
Before this PR, `POST /api/notifications/send`, `POST /api/notifications/send-template`, `POST /api/resumes/trigger-reingest`, and `POST /api/resumes/analyze` had **no admin guard** — any caller with network access could trigger email sends, LLM analysis, and re-ingest operations.

## Test plan
- [x] `make check` passes
- [x] All modified route tests pass (notifications: 17/17, workspace: 18/18)
- [x] Admin guard correctly blocks non-admin workspace on `/send` and `/send-template`
- [x] Admin guard allows dev workspace on guarded endpoints