### PR TITLE
fix: add 10 MiB body size limit to all API routes

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { prettyJSON } from "hono/pretty-json";
 import { secureHeaders } from "hono/secure-headers";
+import { bodyLimit } from "hono/body-limit";
 
 import {
   healthRoutes,
@@ -104,6 +105,23 @@ export function createApp() {
 
   // Rate limiting on API routes (100 req/min per IP)
   app.use("/api/*", rateLimit({ limit: 100, windowMs: 60_000 }));
+
+  // Body size limit on API routes (10 MiB default — manual-import has its own larger limit)
+  app.use(
+    "/api/*",
+    async (c, next) => {
+      // Skip for manual-import which has its own larger body limit
+      if (c.req.path === "/api/resumes/manual-import") {
+        return next();
+      }
+      return bodyLimit({
+        maxSize: 10 * 1024 * 1024,
+        onError: (c) => {
+          return c.json({ success: false, error: "Request body exceeds 10 MiB limit" }, 413);
+        },
+      })(c, next);
+    },
+  );
 
   // Mount routes
   app.route("/", healthRoutes);


### PR DESCRIPTION
## Summary
- Add global 10 MiB body size limit to all `/api/*` routes via `hono/body-limit`
- Exclude `/api/resumes/manual-import` which has its own larger limit (`getManualResumeImportMaxUploadBytes()`)
- Returns 413 with structured error when limit exceeded

## Security Impact
Without this limit, any POST endpoint accepts unbounded payloads — a DoS vector for:
- LLM-billing endpoints (`/api/resumes/analyze`, `/api/resumes/trigger-reingest`)
- Email-sending endpoints (`/api/notifications/send`)
- Database-mutating endpoints (`/api/resumes/hard-reset-reingest`, `/api/resumes/reset-database`)

## Test plan
- [x] `make check` passes
- [x] All existing route tests pass (same pre-existing failures unrelated to this change)
- [x] Manual-import exclusion verified (path check in middleware)