### PR TITLE
fix: add diagnostic logging to browser extension TS bare catch blocks

### DIFF
--- a/apps/browser-extension/src/lib/auto-actions.ts
+++ b/apps/browser-extension/src/lib/auto-actions.ts
@@ -115,8 +115,8 @@ export function createAutoActions(deps: AutoActionsDeps) {
       } else {
         doc.documentElement.removeAttribute("data-tr-age-range");
       }
-    } catch {
-      // ignore
+    } catch (e) {
+      console.warn("[tr-auto-actions]", "setAutoAgeAttributes: DOM attribute set failed", e?.message || e);
     }
   }
 
@@ -626,8 +626,8 @@ export function createAutoActions(deps: AutoActionsDeps) {
       } else {
         doc.documentElement.removeAttribute("data-tr-search-keyword");
       }
-    } catch {
-      // ignore
+    } catch (e) {
+      console.warn("[tr-auto-actions]", "setAutoSearchAttributes: DOM attribute set failed", e?.message || e);
     }
   }
 
@@ -641,8 +641,8 @@ export function createAutoActions(deps: AutoActionsDeps) {
       } else {
         doc.documentElement.removeAttribute("data-tr-location-value");
       }
-    } catch {
-      // ignore
+    } catch (e) {
+      console.warn("[tr-auto-actions]", "setAutoLocationAttributes: DOM attribute set failed", e?.message || e);
     }
   }
 
@@ -1047,7 +1047,8 @@ export function createAutoActions(deps: AutoActionsDeps) {
   function getExtensionVersion() {
     try {
       return chrome?.runtime?.getManifest?.().version || SOURCE_KEYS.UNKNOWN;
-    } catch {
+    } catch (e) {
+      console.warn("[tr-auto-actions]", "getExtensionVersion: chrome.runtime.getManifest failed", e?.message || e);
       return SOURCE_KEYS.UNKNOWN;
     }
   }
@@ -1147,7 +1148,8 @@ export function createAutoActions(deps: AutoActionsDeps) {
     try {
       const localValue = win.localStorage?.getItem(AUTO_EXPORT_PARAM);
       return parseAutoExportMode(localValue);
-    } catch {
+    } catch (e) {
+      console.warn("[tr-auto-actions]", "getAutoExportConfig: localStorage access failed", e?.message || e);
       return { enabled: false };
     }
   }
@@ -1185,7 +1187,8 @@ export function createAutoActions(deps: AutoActionsDeps) {
     try {
       const localValue = win.localStorage?.getItem(AUTO_SYNC_PARAM);
       return parseAutoSyncFlag(localValue);
-    } catch {
+    } catch (e) {
+      console.warn("[tr-auto-actions]", "getAutoSyncEnabled: localStorage access failed", e?.message || e);
       return false;
     }
   }
@@ -1214,8 +1217,8 @@ export function createAutoActions(deps: AutoActionsDeps) {
           "data-tr-auto-export-count",
           String(resumes.length),
         );
-      } catch {
-        // ignore
+      } catch (e) {
+        console.warn("[tr-auto-actions]", "runAutoExportIfEnabled: DOM attribute set failed", e?.message || e);
       }
 
       let rawPayload = null;
@@ -1269,8 +1272,8 @@ export function createAutoActions(deps: AutoActionsDeps) {
       console.warn("🎯 [Auto Export] Failed:", error);
       try {
         doc.documentElement.setAttribute("data-tr-auto-export", "failed");
-      } catch {
-        // ignore
+      } catch (e) {
+        console.warn("[tr-auto-actions]", "runAutoExportIfEnabled: fallback attribute set failed", e?.message || e);
       }
     }
   }

--- a/apps/browser-extension/src/lib/auto-sync-runner.ts
+++ b/apps/browser-extension/src/lib/auto-sync-runner.ts
@@ -186,8 +186,8 @@ export function createAutoSyncRunner(deps: AutoSyncRunnerDeps) {
         "data-tr-auto-sync-max-pages",
         String(maxPages),
       );
-    } catch {
-      // ignore
+    } catch (e) {
+      console.warn("[tr-auto-sync]", "runAutoSyncIfEnabled: DOM attribute set failed (limit/maxPages)", e?.message || e);
     }
     SyncStatusWidget.show({
       state: "progress",
@@ -345,8 +345,8 @@ export function createAutoSyncRunner(deps: AutoSyncRunnerDeps) {
           }
           try {
             await waitForPagination({ timeoutMs: 8000 });
-          } catch {
-            // Some layouts render pagination late or omit it on single-page results.
+          } catch (e) {
+            console.warn("[tr-auto-sync]", "waitForPagination timed out (empty-resumes branch)", e?.message || e);
           }
           const nextPage = paginationAfter.currentPage + 1;
           try {
@@ -354,8 +354,8 @@ export function createAutoSyncRunner(deps: AutoSyncRunnerDeps) {
               "data-tr-auto-sync-next-state",
               JSON.stringify(getNextPageButtonState()),
             );
-          } catch {
-            // ignore
+          } catch (e) {
+            console.warn("[tr-auto-sync]", "DOM attribute set failed (next-state, empty-resumes)", e?.message || e);
           }
           await waitForJob51Cooldown();
           clearCapturedResultsForNextPage();
@@ -457,8 +457,8 @@ export function createAutoSyncRunner(deps: AutoSyncRunnerDeps) {
         }
         try {
           await waitForPagination({ timeoutMs: 8000 });
-        } catch {
-          // Some layouts render pagination late or omit it on single-page results.
+        } catch (e) {
+          console.warn("[tr-auto-sync]", "waitForPagination timed out (sync-success branch)", e?.message || e);
         }
         const nextPage = paginationAfter.currentPage + 1;
         try {
@@ -466,8 +466,8 @@ export function createAutoSyncRunner(deps: AutoSyncRunnerDeps) {
             "data-tr-auto-sync-next-state",
             JSON.stringify(getNextPageButtonState()),
           );
-        } catch {
-          // ignore
+        } catch (e) {
+          console.warn("[tr-auto-sync]", "DOM attribute set failed (next-state, sync-success)", e?.message || e);
         }
         await waitForJob51Cooldown();
         clearCapturedResultsForNextPage();
@@ -485,8 +485,8 @@ export function createAutoSyncRunner(deps: AutoSyncRunnerDeps) {
           "data-tr-auto-sync-stop-reason",
           stopReason,
         );
-      } catch {
-        // ignore
+      } catch (e) {
+        console.warn("[tr-auto-sync]", "runAutoSyncIfEnabled: DOM attribute set failed (stop-reason)", e?.message || e);
       }
       persistLatestAutoSyncSummary();
 
@@ -535,8 +535,8 @@ export function createAutoSyncRunner(deps: AutoSyncRunnerDeps) {
           "data-tr-auto-sync-stop-reason",
           resolveAutoSyncStopReason(error),
         );
-      } catch {
-        // ignore
+      } catch (e) {
+        console.warn("[tr-auto-sync]", "runAutoSyncIfEnabled: fallback attribute set failed (stop-reason)", e?.message || e);
       }
       persistLatestAutoSyncSummary();
     }


### PR DESCRIPTION
## Summary
- Add `console.warn` with `[tr-auto-actions]` prefix to 8 bare catch blocks in auto-actions.ts
- Add `console.warn` with `[tr-auto-sync]` prefix to 7 bare catch blocks in auto-sync-runner.ts
- Skip noisy per-item loop catches and catches that already have logging

## Impact
When auto-export, auto-sync, or location selection fails, errors are now visible in DevTools instead of silently swallowed.

## Test plan
- [x] `make check` passes
- [x] TypeScript compilation succeeds
- [x] Lint passes