### PR TITLE
test: add 14 convex-test integration tests for task dispatch/cancel/reset

### DIFF
--- a/packages/convex/convex/__tests__/tasks-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/tasks-convex-test.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Integration tests for analysis_tasks and resume_tasks using convex-test.
+ *
+ * Covers the highest-risk untested Convex functions:
+ * - analysis_tasks.dispatch (task creation with idempotency)
+ * - analysis_tasks.cancel (task cancellation)
+ * - resume_tasks.dispatch (collection task creation)
+ * - resume_tasks.cancel (collection task cancellation)
+ * - resume_tasks.resetDatabase (bulk delete with partial/pagination)
+ *
+ * Uses convex-test with real schema validation — no mocks.
+ */
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { api } from "../_generated/api.js";
+import schema from "../schema.js";
+
+const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
+
+// Helper: insert a minimal resume document matching schema requirements
+let _resumeCounter = 0;
+async function insertResume(
+  t: ReturnType<typeof convexTest>,
+  overrides: Record<string, unknown> = {},
+) {
+  _resumeCounter += 1;
+  return t.run(async (ctx) => {
+    return ctx.db.insert("resumes", {
+      externalId: `ext-${_resumeCounter}`,
+      content: { name: "Test User" },
+      hash: `hash-${_resumeCounter}`,
+      tags: [],
+      crawledAt: Date.now(),
+      source: "test",
+      ...overrides,
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// analysis_tasks.dispatch
+// ---------------------------------------------------------------------------
+
+describe("analysis_tasks: dispatch", () => {
+  it("creates an analysis task with keywords", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumeId1 = await insertResume(t);
+    const resumeId2 = await insertResume(t);
+
+    const taskId = await t.mutation(api.analysis_tasks.dispatch, {
+      keywords: ["python", "react"],
+      location: "Shanghai",
+      resumeIds: [resumeId1, resumeId2],
+    });
+
+    expect(taskId).toBeDefined();
+
+    const tasks = await t.run(async (ctx) => {
+      return ctx.db.query("analysis_tasks").collect();
+    });
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].status).toBe("pending");
+    expect(tasks[0].config.keywords).toEqual(["python", "react"]);
+    expect(tasks[0].config.location).toBe("Shanghai");
+    expect(tasks[0].config.resumeCount).toBe(2);
+    expect(tasks[0].idempotencyKey).toBeDefined();
+    expect(tasks[0].jobKey).toBeDefined();
+  });
+
+  it("creates an analysis task with jobDescriptionContent", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumeId = await insertResume(t);
+
+    const taskId = await t.mutation(api.analysis_tasks.dispatch, {
+      jobDescriptionContent: "We need a senior developer...",
+      resumeIds: [resumeId],
+    });
+
+    expect(taskId).toBeDefined();
+
+    const tasks = await t.run(async (ctx) => {
+      return ctx.db.query("analysis_tasks").collect();
+    });
+    expect(tasks[0].config.jobDescriptionContent).toBe("We need a senior developer...");
+  });
+
+  it("throws when neither jobDescriptionContent nor keywords provided", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumeId = await insertResume(t);
+
+    await expect(
+      t.mutation(api.analysis_tasks.dispatch, {
+        resumeIds: [resumeId],
+      }),
+    ).rejects.toThrow("Either jobDescriptionContent or keywords is required");
+  });
+
+  it("deduplicates resume IDs", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumeId = await insertResume(t);
+
+    const taskId = await t.mutation(api.analysis_tasks.dispatch, {
+      keywords: ["test"],
+      resumeIds: [resumeId, resumeId, resumeId],
+    });
+
+    expect(taskId).toBeDefined();
+
+    const tasks = await t.run(async (ctx) => {
+      return ctx.db.query("analysis_tasks").collect();
+    });
+    // Deduped from 3 to 1
+    expect(tasks[0].config.resumeCount).toBe(1);
+  });
+
+  it("returns existing task when idempotency key matches", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumeId = await insertResume(t);
+
+    const first = await t.mutation(api.analysis_tasks.dispatch, {
+      keywords: ["python"],
+      location: "Beijing",
+      resumeIds: [resumeId],
+    });
+
+    const second = await t.mutation(api.analysis_tasks.dispatch, {
+      keywords: ["python"],
+      location: "Beijing",
+      resumeIds: [resumeId],
+    });
+
+    // Same idempotency key → same task returned
+    expect(second).toBe(first);
+
+    const tasks = await t.run(async (ctx) => {
+      return ctx.db.query("analysis_tasks").collect();
+    });
+    expect(tasks).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// analysis_tasks.cancel
+// ---------------------------------------------------------------------------
+
+describe("analysis_tasks: cancel", () => {
+  it("cancels a pending task", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumeId = await insertResume(t);
+    const taskId = await t.mutation(api.analysis_tasks.dispatch, {
+      keywords: ["test"],
+      resumeIds: [resumeId],
+    });
+
+    await t.mutation(api.analysis_tasks.cancel, { taskId });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.status).toBe("cancelled");
+    expect(task?.completedAt).toBeDefined();
+  });
+
+  it("is a no-op for already completed tasks", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumeId = await insertResume(t);
+    const taskId = await t.mutation(api.analysis_tasks.dispatch, {
+      keywords: ["test"],
+      resumeIds: [resumeId],
+    });
+
+    // Manually complete the task
+    await t.run(async (ctx) => {
+      await ctx.db.patch(taskId as any, {
+        status: "completed",
+        completedAt: Date.now(),
+      });
+    });
+
+    await t.mutation(api.analysis_tasks.cancel, { taskId });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    // Should remain completed, not changed to cancelled
+    expect(task?.status).toBe("completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resume_tasks.dispatch
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: dispatch", () => {
+  it("creates a collection task", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await t.mutation(api.resume_tasks.dispatch, {
+      keyword: "python developer",
+      location: "Shanghai",
+      limit: 50,
+    });
+
+    expect(taskId).toBeDefined();
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.status).toBe("pending");
+    expect(task?.config.keyword).toBe("python developer");
+    expect(task?.config.location).toBe("Shanghai");
+    expect(task?.config.limit).toBe(50);
+  });
+
+  it("throws when minAge > maxAge", async () => {
+    const t = convexTest(schema, modules);
+
+    await expect(
+      t.mutation(api.resume_tasks.dispatch, {
+        keyword: "test",
+        location: "test",
+        limit: 10,
+        minAge: 40,
+        maxAge: 25,
+      }),
+    ).rejects.toThrow("minAge cannot be greater than maxAge");
+  });
+
+  it("accepts optional fields", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await t.mutation(api.resume_tasks.dispatch, {
+      keyword: "test",
+      location: "test",
+      limit: 10,
+      maxPages: 5,
+      minAge: 25,
+      maxAge: 40,
+      autoAnalyze: true,
+      analysisTopN: 20,
+    });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.config.maxPages).toBe(5);
+    expect(task?.config.autoAnalyze).toBe(true);
+    expect(task?.config.analysisTopN).toBe(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resume_tasks.cancel
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: cancel", () => {
+  it("cancels a pending collection task", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await t.mutation(api.resume_tasks.dispatch, {
+      keyword: "test",
+      location: "test",
+      limit: 10,
+    });
+
+    await t.mutation(api.resume_tasks.cancel, { taskId });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.status).toBe("cancelled");
+    expect(task?.completedAt).toBeDefined();
+  });
+
+  it("is a no-op for completed tasks", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await t.mutation(api.resume_tasks.dispatch, {
+      keyword: "test",
+      location: "test",
+      limit: 10,
+    });
+
+    // Manually complete
+    await t.run(async (ctx) => {
+      await ctx.db.patch(taskId as any, {
+        status: "completed",
+        completedAt: Date.now(),
+      });
+    });
+
+    await t.mutation(api.resume_tasks.cancel, { taskId });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.status).toBe("completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resume_tasks.resetDatabase
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: resetDatabase", () => {
+  it("deletes all data from reset tables when under batch size", async () => {
+    const t = convexTest(schema, modules);
+
+    // Insert a resume and a collection task
+    await insertResume(t);
+    await t.mutation(api.resume_tasks.dispatch, {
+      keyword: "test",
+      location: "test",
+      limit: 10,
+    });
+
+    const result = await t.mutation(api.resume_tasks.resetDatabase, {});
+
+    expect(result.success).toBe(true);
+    expect(result.partial).toBe(false);
+    expect(result.count).toBeGreaterThanOrEqual(2);
+    expect(result.deleted.resumes).toBeGreaterThanOrEqual(1);
+    expect(result.deleted.collection_tasks).toBeGreaterThanOrEqual(1);
+  });
+
+  it("returns zero count when tables are empty", async () => {
+    const t = convexTest(schema, modules);
+
+    const result = await t.mutation(api.resume_tasks.resetDatabase, {});
+
+    expect(result.success).toBe(true);
+    expect(result.partial).toBe(false);
+    expect(result.count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 14 convex-test integration tests covering 5 previously-untested Convex functions
- Uses `convexTest(schema, modules)` with real schema validation (not mocks)
- Covers: analysis_tasks.dispatch, analysis_tasks.cancel, resume_tasks.dispatch, resume_tasks.cancel, resume_tasks.resetDatabase

## Test plan
- [x] All 14 tests pass (`npx vitest run packages/convex/convex/__tests__/tasks-convex-test.test.ts`)
- [x] `make check` passes (typecheck + lint + governance)
- [ ] Existing test suite unaffected