### PR TITLE
fix: replace v.any() with typed validators for ResumeFilters and breakdown fields

### DIFF
--- a/packages/convex/convex/__tests__/tasks-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/tasks-convex-test.test.ts
@@ -340,3 +340,289 @@ describe("resume_tasks: resetDatabase", () => {
     expect(result.count).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// resume_tasks.claim
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: claim", () => {
+  it("claims the oldest pending task", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await t.mutation(api.resume_tasks.dispatch, {
+      keyword: "test",
+      location: "test",
+      limit: 10,
+    });
+
+    const claimed = await t.mutation(api.resume_tasks.claim, {
+      workerId: "worker-1",
+    });
+
+    expect(claimed).toBeDefined();
+    expect(claimed!._id).toBe(taskId);
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.status).toBe("processing");
+    expect(task?.workerId).toBe("worker-1");
+    expect(task?.startedAt).toBeDefined();
+  });
+
+  it("returns null when no pending tasks", async () => {
+    const t = convexTest(schema, modules);
+
+    const claimed = await t.mutation(api.resume_tasks.claim, {
+      workerId: "worker-1",
+    });
+
+    expect(claimed).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resume_tasks.heartbeat
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: heartbeat", () => {
+  it("creates a new worker on first heartbeat", async () => {
+    const t = convexTest(schema, modules);
+
+    const workerId = await t.mutation(api.resume_tasks.heartbeat, {
+      workerId: "worker-1",
+      state: "idle",
+    });
+
+    expect(workerId).toBeDefined();
+
+    const workers = await t.run(async (ctx) => {
+      return ctx.db.query("collection_workers").collect();
+    });
+    expect(workers).toHaveLength(1);
+    expect(workers[0].workerId).toBe("worker-1");
+    expect(workers[0].state).toBe("idle");
+  });
+
+  it("updates existing worker on subsequent heartbeat", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.resume_tasks.heartbeat, {
+      workerId: "worker-1",
+      state: "idle",
+    });
+
+    await t.mutation(api.resume_tasks.heartbeat, {
+      workerId: "worker-1",
+      state: "processing",
+    });
+
+    const workers = await t.run(async (ctx) => {
+      return ctx.db.query("collection_workers").collect();
+    });
+    expect(workers).toHaveLength(1);
+    expect(workers[0].state).toBe("processing");
+  });
+
+  it("stores activeTaskId and lastError", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await t.mutation(api.resume_tasks.dispatch, {
+      keyword: "test",
+      location: "test",
+      limit: 10,
+    });
+
+    await t.mutation(api.resume_tasks.heartbeat, {
+      workerId: "worker-1",
+      state: "error",
+      activeTaskId: taskId,
+      lastError: "connection timeout",
+    });
+
+    const workers = await t.run(async (ctx) => {
+      return ctx.db.query("collection_workers").collect();
+    });
+    expect(workers[0].state).toBe("error");
+    expect(workers[0].activeTaskId).toBe(taskId);
+    expect(workers[0].lastError).toBe("connection timeout");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resume_tasks.getWorkerHealth
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: getWorkerHealth", () => {
+  it("reports healthy workers", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.resume_tasks.heartbeat, {
+      workerId: "worker-1",
+      state: "idle",
+    });
+
+    const health = await t.query(api.resume_tasks.getWorkerHealth, {});
+
+    expect(health.totalWorkers).toBe(1);
+    expect(health.healthyWorkers).toBe(1);
+    expect(health.workers).toHaveLength(1);
+    expect(health.workers[0].healthy).toBe(true);
+  });
+
+  it("reports unhealthy workers when in error state", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.resume_tasks.heartbeat, {
+      workerId: "worker-1",
+      state: "error",
+      lastError: "crashed",
+    });
+
+    const health = await t.query(api.resume_tasks.getWorkerHealth, {});
+
+    expect(health.totalWorkers).toBe(1);
+    expect(health.healthyWorkers).toBe(0);
+    expect(health.workers[0].healthy).toBe(false);
+  });
+
+  it("returns zeros when no workers exist", async () => {
+    const t = convexTest(schema, modules);
+
+    const health = await t.query(api.resume_tasks.getWorkerHealth, {});
+
+    expect(health.totalWorkers).toBe(0);
+    expect(health.healthyWorkers).toBe(0);
+    expect(health.workers).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resume_tasks.complete
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: complete", () => {
+  it("completes a processing task", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await t.mutation(api.resume_tasks.dispatch, {
+      keyword: "test",
+      location: "test",
+      limit: 10,
+    });
+
+    await t.mutation(api.resume_tasks.claim, { workerId: "worker-1" });
+
+    await t.mutation(api.resume_tasks.complete, {
+      taskId,
+      status: "completed",
+    });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.status).toBe("completed");
+    expect(task?.completedAt).toBeDefined();
+  });
+
+  it("fails a processing task with error", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await t.mutation(api.resume_tasks.dispatch, {
+      keyword: "test",
+      location: "test",
+      limit: 10,
+    });
+
+    await t.mutation(api.resume_tasks.claim, { workerId: "worker-1" });
+
+    await t.mutation(api.resume_tasks.complete, {
+      taskId,
+      status: "failed",
+      error: "network timeout",
+    });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.status).toBe("failed");
+    expect(task?.error).toBe("network timeout");
+  });
+
+  it("is a no-op for cancelled tasks", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await t.mutation(api.resume_tasks.dispatch, {
+      keyword: "test",
+      location: "test",
+      limit: 10,
+    });
+
+    await t.mutation(api.resume_tasks.cancel, { taskId });
+
+    await t.mutation(api.resume_tasks.complete, {
+      taskId,
+      status: "completed",
+    });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    // Should remain cancelled
+    expect(task?.status).toBe("cancelled");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resume_tasks.updateProgress
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: updateProgress", () => {
+  it("updates progress on a processing task", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await t.mutation(api.resume_tasks.dispatch, {
+      keyword: "test",
+      location: "test",
+      limit: 10,
+    });
+
+    await t.mutation(api.resume_tasks.claim, { workerId: "worker-1" });
+
+    await t.mutation(api.resume_tasks.updateProgress, {
+      taskId,
+      current: 5,
+      page: 2,
+      total: 50,
+      lastStatus: "Scraping page 3",
+    });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.progress.current).toBe(5);
+    expect(task?.progress.page).toBe(2);
+    expect(task?.progress.total).toBe(50);
+    expect(task?.lastStatus).toBe("Scraping page 3");
+  });
+
+  it("returns cancelled status for cancelled tasks", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await t.mutation(api.resume_tasks.dispatch, {
+      keyword: "test",
+      location: "test",
+      limit: 10,
+    });
+
+    await t.mutation(api.resume_tasks.cancel, { taskId });
+
+    const result = await t.mutation(api.resume_tasks.updateProgress, {
+      taskId,
+      current: 5,
+      page: 2,
+    });
+
+    expect(result).toEqual({ status: "cancelled" });
+  });
+});

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1,6 +1,6 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { ingestDataValidator, collectionTaskResultsValidator } from "./validators.js";
+import { ingestDataValidator, collectionTaskResultsValidator, resumeFiltersValidator } from "./validators.js";
 
 export default defineSchema({
     // Tasks for resume collection
@@ -69,7 +69,7 @@ export default defineSchema({
             summary: v.string(),
             highlights: v.array(v.string()),
             recommendation: v.string(),
-            breakdown: v.optional(v.any()), // Stores detailed scores per category
+            breakdown: v.optional(v.record(v.string(), v.number())),
             jobDescriptionId: v.optional(v.string()), // Tracks which JD was used for analysis
             promptVersion: v.optional(v.number()),
             locale: v.optional(v.string()),
@@ -220,7 +220,7 @@ export default defineSchema({
         baseline: v.optional(v.object({
             jobDescriptionId: v.optional(v.string()),
             ruleScore: v.number(),
-            breakdown: v.optional(v.any()),
+            breakdown: v.optional(v.record(v.string(), v.number())),
             roleSignals: v.optional(v.array(v.object({
                 type: v.string(),
                 matchedSignals: v.array(v.string()),
@@ -283,7 +283,7 @@ export default defineSchema({
                 type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
                 exactUrl: v.optional(v.string()),
             })),
-            filters: v.optional(v.any()), // Stores ResumeFilters object
+            filters: resumeFiltersValidator,
         }),
         reviewedResumeIds: v.array(v.string()), // IDs of resumes seen/acted upon
         workspaceSlug: v.optional(v.string()),
@@ -305,7 +305,7 @@ export default defineSchema({
             type: v.union(v.literal("job5156"), v.literal("51job"), v.literal("seek")),
             exactUrl: v.optional(v.string()),
         })),
-        filters: v.optional(v.any()),
+        filters: resumeFiltersValidator,
         selectedTags: v.optional(v.array(v.string())),
         selectedCompanies: v.optional(v.array(v.string())),
         selectedExperienceLevel: v.optional(v.string()),

--- a/packages/convex/convex/validators.ts
+++ b/packages/convex/convex/validators.ts
@@ -87,3 +87,37 @@ export const collectionTaskResultsValidator = v.object({
     autoAnalyzed: v.optional(v.number()),
     autoAnalysisTaskId: v.optional(v.string()),
 });
+
+// --- ResumeFilters (screening_sessions.config.filters, search_history.filters) ---
+
+export const resumeFiltersValidator = v.optional(v.object({
+    minExperience: v.optional(v.number()),
+    maxExperience: v.optional(v.number()),
+    education: v.optional(v.array(v.string())),
+    skills: v.optional(v.array(v.string())),
+    locations: v.optional(v.array(v.string())),
+    minSalary: v.optional(v.number()),
+    maxSalary: v.optional(v.number()),
+    minRoleYears: v.optional(v.number()),
+    roleFilterType: v.optional(v.string()),
+    minAge: v.optional(v.number()),
+    maxAge: v.optional(v.number()),
+    sources: v.optional(v.array(v.string())),
+    minMatchScore: v.optional(v.number()),
+    recommendation: v.optional(v.array(v.union(
+        v.literal("strong_match"),
+        v.literal("match"),
+        v.literal("potential"),
+        v.literal("no_match"),
+    ))),
+    sortBy: v.optional(v.union(
+        v.literal("score"),
+        v.literal("name"),
+        v.literal("experience"),
+        v.literal("extractedAt"),
+    )),
+    sortOrder: v.optional(v.union(
+        v.literal("asc"),
+        v.literal("desc"),
+    )),
+}));


### PR DESCRIPTION
## Summary
- Add `resumeFiltersValidator` to validators.ts, replacing `v.any()` in `screening_sessions.config.filters` and `search_history.filters`
- Replace `v.any()` with `v.record(v.string(), v.number())` for `resumes.analysis.breakdown` and `ai_tagging_results.baseline.breakdown`
- Add 13 convex-test integration tests for resume_tasks worker lifecycle (claim, heartbeat, getWorkerHealth, complete, updateProgress)

## Why
Prevents the class of silent schema drift that occurred when the `market` field was added to `ingestData` — typed validators catch new fields that `v.any()` silently accepts. The `resumeFiltersValidator` matches the BFF's `ResumeFiltersSchema` exactly.

## Test plan
- [x] All 27 tests pass in tasks-convex-test.test.ts
- [x] All 23 tests pass in migrations-convex-test.test.ts
- [x] All 9 tests pass in ai-tagging-convex-test.test.ts
- [x] `make check` passes (typecheck + lint + governance)
- [ ] Existing test suite unaffected