### PR TITLE
test: add 9 convex-test integration tests for analysis_tasks state machine

### DIFF
--- a/packages/convex/convex/__tests__/analysis-state-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/analysis-state-convex-test.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Integration tests for analysis_tasks state machine functions using convex-test.
+ *
+ * Covers internal mutation functions:
+ * - markProcessing (pending → processing transition)
+ * - updateProgress (progress tracking with monotonic guards)
+ * - complete (terminal state transition with cancellation guard)
+ *
+ * Uses convex-test with real schema validation — no mocks.
+ */
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { api, internal } from "../_generated/api.js";
+import schema from "../schema.js";
+
+const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
+
+// Helper: insert a minimal resume document matching schema requirements
+let _resumeCounter = 0;
+async function insertResume(
+  t: ReturnType<typeof convexTest>,
+  overrides: Record<string, unknown> = {},
+) {
+  _resumeCounter += 1;
+  return t.run(async (ctx) => {
+    return ctx.db.insert("resumes", {
+      externalId: `ext-${_resumeCounter}`,
+      content: { name: "Test User" },
+      hash: `hash-${_resumeCounter}`,
+      tags: [],
+      crawledAt: Date.now(),
+      source: "test",
+      ...overrides,
+    });
+  });
+}
+
+// Helper: dispatch an analysis task and return the taskId
+async function dispatchAnalysisTask(
+  t: ReturnType<typeof convexTest>,
+  overrides: Record<string, unknown> = {},
+) {
+  const resumeId = await insertResume(t);
+  return t.mutation(api.analysis_tasks.dispatch, {
+    keywords: ["test"],
+    resumeIds: [resumeId],
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// markProcessing
+// ---------------------------------------------------------------------------
+
+describe("analysis_tasks: markProcessing", () => {
+  it("transitions a pending task to processing", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await dispatchAnalysisTask(t);
+
+    const result = await t.mutation(internal.analysis_tasks.markProcessing, {
+      taskId,
+    });
+
+    expect(result).toEqual({ status: "processing" });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.status).toBe("processing");
+    expect(task?.startedAt).toBeDefined();
+  });
+
+  it("returns cancelled status for cancelled tasks", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await dispatchAnalysisTask(t);
+
+    // Cancel the task first
+    await t.mutation(api.analysis_tasks.cancel, { taskId });
+
+    const result = await t.mutation(internal.analysis_tasks.markProcessing, {
+      taskId,
+    });
+
+    expect(result).toEqual({ status: "cancelled" });
+  });
+
+  it("returns null for nonexistent tasks", async () => {
+    const t = convexTest(schema, modules);
+
+    // Create and delete a task to get a valid-format ID that no longer exists
+    const tempResumeId = await insertResume(t);
+    const tempTaskId = await t.mutation(api.analysis_tasks.dispatch, {
+      keywords: ["temp"],
+      resumeIds: [tempResumeId],
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.delete(tempTaskId);
+    });
+
+    const result = await t.mutation(internal.analysis_tasks.markProcessing, {
+      taskId: tempTaskId,
+    });
+
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateProgress
+// ---------------------------------------------------------------------------
+
+describe("analysis_tasks: updateProgress", () => {
+  it("updates progress on a processing task", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await dispatchAnalysisTask(t);
+
+    await t.mutation(internal.analysis_tasks.markProcessing, { taskId });
+
+    const result = await t.mutation(internal.analysis_tasks.updateProgress, {
+      taskId,
+      current: 5,
+      skipped: 1,
+      lastStatus: "Analyzing resume 5",
+    });
+
+    expect(result).toEqual({ status: "processing" });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.progress.current).toBe(5);
+    expect(task?.progress.skipped).toBe(1);
+    expect(task?.lastStatus).toBe("Analyzing resume 5");
+  });
+
+  it("is monotonic — does not decrease current/skipped", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await dispatchAnalysisTask(t);
+
+    await t.mutation(internal.analysis_tasks.markProcessing, { taskId });
+
+    // Set progress to 10
+    await t.mutation(internal.analysis_tasks.updateProgress, {
+      taskId,
+      current: 10,
+      skipped: 3,
+    });
+
+    // Try to set progress to 5 (should be clamped to 10)
+    await t.mutation(internal.analysis_tasks.updateProgress, {
+      taskId,
+      current: 5,
+      skipped: 1,
+    });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.progress.current).toBe(10);
+    expect(task?.progress.skipped).toBe(3);
+  });
+
+  it("returns cancelled status for cancelled tasks", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await dispatchAnalysisTask(t);
+
+    await t.mutation(api.analysis_tasks.cancel, { taskId });
+
+    const result = await t.mutation(internal.analysis_tasks.updateProgress, {
+      taskId,
+      current: 5,
+      skipped: 0,
+    });
+
+    expect(result).toEqual({ status: "cancelled" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// complete
+// ---------------------------------------------------------------------------
+
+describe("analysis_tasks: complete", () => {
+  it("completes a processing task with results", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await dispatchAnalysisTask(t);
+
+    await t.mutation(internal.analysis_tasks.markProcessing, { taskId });
+
+    await t.mutation(internal.analysis_tasks.complete, {
+      taskId,
+      status: "completed",
+      results: {
+        analyzed: 10,
+        skipped: 2,
+        failed: 1,
+        avgScore: 75.5,
+        highScoreCount: 3,
+      },
+    });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.status).toBe("completed");
+    expect(task?.results?.analyzed).toBe(10);
+    expect(task?.completedAt).toBeDefined();
+    expect(task?.lastStatus).toBe("Completed");
+  });
+
+  it("fails a processing task with error", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await dispatchAnalysisTask(t);
+
+    await t.mutation(internal.analysis_tasks.markProcessing, { taskId });
+
+    await t.mutation(internal.analysis_tasks.complete, {
+      taskId,
+      status: "failed",
+      error: "LLM API timeout",
+    });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.status).toBe("failed");
+    expect(task?.error).toBe("LLM API timeout");
+  });
+
+  it("cannot un-cancel a cancelled task", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await dispatchAnalysisTask(t);
+
+    // Cancel the task
+    await t.mutation(api.analysis_tasks.cancel, { taskId });
+
+    // Try to complete it — should remain cancelled
+    await t.mutation(internal.analysis_tasks.complete, {
+      taskId,
+      status: "completed",
+    });
+
+    const task = await t.run(async (ctx) => {
+      return ctx.db.get(taskId);
+    });
+    expect(task?.status).toBe("cancelled");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `analysis-state-convex-test.test.ts` with 9 integration tests for analysis_tasks internal state machine mutations
- Covers `markProcessing` (3 tests): pending→processing transition, cancelled guard, nonexistent ID returns null
- Covers `updateProgress` (3 tests): progress tracking, monotonic guards (Math.max on current/skipped), cancelled guard
- Covers `complete` (3 tests): completed/failed transitions with results/error, un-cancel guard

## Test plan
- [x] `npx vitest run packages/convex/convex/__tests__/analysis-state-convex-test.test.ts` — 9/9 pass
- [x] Full suite: 60 test files, 1164 tests pass
- [x] `make check` passes