### PR TITLE
chore: switch default AI_MODEL to openai/openai-gpt-oss-120b

### DIFF
--- a/apps/api/src/services/__tests__/ai-config.test.ts
+++ b/apps/api/src/services/__tests__/ai-config.test.ts
@@ -240,6 +240,14 @@ describe("validateAIConfig", () => {
     const { validateAIConfig } = await importWithEnv();
     expect(validateAIConfig()).toEqual({ valid: true });
   });
+
+  it("accepts openai/openai-gpt-oss-120b model format", async () => {
+    process.env.AI_ANALYSIS_ENABLED = "true";
+    process.env.AI_API_KEY = "sk-test-key-12345";
+    process.env.AI_MODEL = "openai/openai-gpt-oss-120b";
+    const { validateAIConfig } = await importWithEnv();
+    expect(validateAIConfig()).toEqual({ valid: true });
+  });
 });
 
 describe("validateResumeAIConfig", () => {

--- a/deploy/env.production
+++ b/deploy/env.production
@@ -4,7 +4,7 @@
 # AI and notifications
 AI_API_KEY=
 AI_API_BASE=https://api.poe.com/v1
-AI_MODEL=openai/gpt-5-mini
+AI_MODEL=openai/openai-gpt-oss-120b
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
 S3_ENDPOINT_URL=


### PR DESCRIPTION
## Summary
- Update `deploy/env.production` template: `AI_MODEL` default from `openai/gpt-5-mini` → `openai/openai-gpt-oss-120b`
- Add validation test for `openai/openai-gpt-oss-120b` model format in `ai-config.test.ts`

## Test plan
- [x] `ai-config.test.ts`: 24 tests pass (1 new: `accepts openai/openai-gpt-oss-120b model format`)
- [x] `resolveChatCompletionModel` strips `openai/` prefix correctly (covered in PR #992)
- [ ] Deploy and verify `AI_MODEL=openai/openai-gpt-oss-120b` works with the Poe API gateway