### PR TITLE
feat: replace resumes.analyses v.any() with typed validator bridge + migration

### DIFF
--- a/packages/convex/convex/__tests__/migrations-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/migrations-convex-test.test.ts
@@ -574,3 +574,79 @@ describe("migration: removeScreeningSessionCollectUrl", () => {
     expect(result.total).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// backfillAnalysesValidator
+// ---------------------------------------------------------------------------
+
+describe("migration: backfillAnalysesValidator", () => {
+  it("normalizes analyses entries missing score field", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumeId = await insertResume(t, {
+      analyses: {
+        "source:seek|analysis:jd-1": { summary: "Good candidate", recommendation: "match" },
+        "default": { score: 85, summary: "Solid", recommendation: "strong_match" },
+      },
+    });
+
+    const result = await t.mutation(api.migrations.backfillAnalysesValidator, {});
+
+    expect(result.updatedResumes).toBe(1);
+
+    const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+    const analyses = resume?.analyses as Record<string, Record<string, unknown>>;
+    // Entry with missing score gets score: 0
+    expect(typeof analyses["source:seek|analysis:jd-1"].score).toBe("number");
+    expect(analyses["source:seek|analysis:jd-1"].score).toBe(0);
+    // Preserves other fields
+    expect(analyses["source:seek|analysis:jd-1"].summary).toBe("Good candidate");
+    // Entry that already conformed is untouched
+    expect(analyses["default"].score).toBe(85);
+  });
+
+  it("skips resumes where all analyses already conform", async () => {
+    const t = convexTest(schema, modules);
+
+    await insertResume(t, {
+      analyses: {
+        "default": { score: 90, summary: "Great", recommendation: "strong_match" },
+        "source:seek|analysis:jd-2": { score: 72, summary: "OK" },
+      },
+    });
+
+    const result = await t.mutation(api.migrations.backfillAnalysesValidator, {});
+    expect(result.updatedResumes).toBe(0);
+  });
+
+  it("replaces completely malformed entries with minimal valid object", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumeId = await insertResume(t, {
+      analyses: {
+        bad: "not-an-object",
+        alsoBad: 42,
+        good: { score: 50, summary: "Decent" },
+      },
+    });
+
+    const result = await t.mutation(api.migrations.backfillAnalysesValidator, {});
+    expect(result.updatedResumes).toBe(1);
+
+    const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+    const analyses = resume?.analyses as Record<string, Record<string, unknown>>;
+    expect(analyses.bad).toEqual({ score: 0 });
+    expect(analyses.alsoBad).toEqual({ score: 0 });
+    expect(analyses.good).toEqual({ score: 50, summary: "Decent" });
+  });
+
+  it("skips resumes with no analyses field", async () => {
+    const t = convexTest(schema, modules);
+
+    await insertResume(t, {}); // No analyses
+    await insertResume(t, { analyses: undefined }); // Explicitly undefined
+
+    const result = await t.mutation(api.migrations.backfillAnalysesValidator, {});
+    expect(result.updatedResumes).toBe(0);
+  });
+});

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -1700,3 +1700,68 @@ export const backfillSeekNameSearchUrls = mutation({
         };
     },
 });
+
+/**
+ * Backfill `resumes.analyses` to conform to the typed `analysisResultValidator`.
+ *
+ * The `analyses` field was originally `v.any()`. This migration normalizes each
+ * entry so that every value has at minimum a `score: number` field. Entries that
+ * already conform are left untouched. Non-conforming entries get `score: 0` as
+ * a fallback.
+ *
+ * After this migration runs to completion (no more pages), the `v.any()` bridge
+ * in the schema can be removed, leaving only the strict typed validator.
+ */
+export const backfillAnalysesValidator = mutation({
+    args: {
+        cursor: v.optional(v.string()),
+        batchSize: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const resumes = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: resolveResumeScanBatchSize(args.batchSize),
+            });
+
+        let updated = 0;
+        for (const resume of resumes.page) {
+            if (!resume.analyses || typeof resume.analyses !== "object" || Array.isArray(resume.analyses)) {
+                continue;
+            }
+
+            // Check if all entries already conform (have score:number)
+            const entries = Object.entries(resume.analyses as Record<string, unknown>);
+            const allConform = entries.every(([, val]) =>
+                typeof val === "object" && val !== null && !Array.isArray(val) && typeof (val as Record<string, unknown>).score === "number",
+            );
+            if (allConform) continue;
+
+            // Normalize non-conforming entries
+            const normalized: Record<string, unknown> = {};
+            for (const [key, val] of entries) {
+                if (typeof val === "object" && val !== null && !Array.isArray(val) && typeof (val as Record<string, unknown>).score === "number") {
+                    normalized[key] = val;
+                } else if (typeof val === "object" && val !== null && !Array.isArray(val)) {
+                    // Has structure but missing score — add score: 0
+                    normalized[key] = { ...val, score: 0 };
+                } else {
+                    // Completely malformed — minimal valid entry
+                    normalized[key] = { score: 0 };
+                }
+            }
+
+            await ctx.db.patch(resume._id, { analyses: normalized });
+            updated += 1;
+        }
+
+        return {
+            scannedResumes: resumes.page.length,
+            updatedResumes: updated,
+            hasMore: !resumes.isDone,
+            cursor: resumes.isDone ? null : resumes.continueCursor,
+        };
+    },
+});

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1,6 +1,6 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { ingestDataValidator, collectionTaskResultsValidator, resumeFiltersValidator } from "./validators.js";
+import { ingestDataValidator, collectionTaskResultsValidator, resumeFiltersValidator, analysisResultValidator } from "./validators.js";
 
 export default defineSchema({
     // Tasks for resume collection
@@ -81,7 +81,10 @@ export default defineSchema({
         // Key: `source:<sourceKey>|analysis:<jobDescriptionId>` when the resume source is known,
         //       otherwise the legacy bare `jobDescriptionId` / `default` key.
         // Value: Analysis object (the payload keeps bare jobDescriptionId for compatibility)
-        analyses: v.optional(v.any()),
+        analyses: v.optional(v.union(
+            v.any(),  // Bridge: accepts existing unstructured data
+            v.record(v.string(), analysisResultValidator),  // New: typed analysis results
+        )),
 
         // AI Confirm Score (cost-gated L4 batch confirm pass)
         confirmedScore: v.optional(v.number()),

--- a/packages/convex/convex/validators.ts
+++ b/packages/convex/convex/validators.ts
@@ -88,6 +88,26 @@ export const collectionTaskResultsValidator = v.object({
     autoAnalysisTaskId: v.optional(v.string()),
 });
 
+// --- Analysis result (resumes.analyses values) ---
+
+export const analysisResultValidator = v.object({
+    score: v.number(),
+    summary: v.optional(v.string()),
+    highlights: v.optional(v.array(v.string())),
+    recommendation: v.optional(v.string()),
+    breakdown: v.optional(v.any()),
+    keyFactors: v.optional(v.array(v.object({
+        factor: v.string(),
+        weight: v.optional(v.number()),
+        value: v.string(),
+    }))),
+    jobDescriptionId: v.optional(v.string()),
+    promptVersion: v.optional(v.number()),
+    locale: v.optional(v.string()),
+    queryLocation: v.optional(v.string()),
+    analyzedAt: v.optional(v.number()),
+});
+
 // --- ResumeFilters (screening_sessions.config.filters, search_history.filters) ---
 
 export const resumeFiltersValidator = v.optional(v.object({


### PR DESCRIPTION
## Summary
- Replace `resumes.analyses: v.optional(v.any())` with bridge validator `v.optional(v.union(v.any(), v.record(v.string(), analysisResultValidator)))` that accepts both existing unstructured data and new typed entries
- Add `analysisResultValidator` to `validators.ts` matching the actual analysis result shape (score, summary, highlights, recommendation, breakdown, keyFactors, jobDescriptionId, promptVersion, locale, queryLocation, analyzedAt)
- Add `backfillAnalysesValidator` paginated migration that normalizes non-conforming entries — missing score gets `score: 0`, completely malformed entries get `{ score: 0 }`
- 4 new convex-test migration tests

## Test plan
- [x] `make check` passes (typecheck + lint + governance)
- [x] All 4344 tests pass (4 new migration tests added)
- [ ] Run `backfillAnalysesValidator` migration against staging data
- [ ] After migration completes with no more updates, remove `v.any()` from union to tighten to strict typed validator

## Why bridge pattern?
Convex blocks deployment if any existing document doesn't conform to the schema. The `v.union(v.any(), v.record(...))` bridge lets us deploy the typed validator alongside `v.any()`, run the migration to normalize all documents, then remove `v.any()` in a follow-up PR.