### PR TITLE
test: add 39 tests for bffMatchesResumeFilters (BFF AND-mode filter logic)

### DIFF
--- a/apps/api/src/services/bff-filter-utils.test.ts
+++ b/apps/api/src/services/bff-filter-utils.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for bff-filter-utils.ts — BFF-side resume filter matching.
+ *
+ * Covers bffMatchesResumeFilters and parseAgeFromContentField with
+ * systematic filter combinations that mirror Convex filter behavior.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  bffMatchesResumeFilters,
+  parseAgeFromContentField,
+  type BffResumeFilters,
+} from "../services/bff-filter-utils.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeDoc(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    content: {
+      experience: "5年",
+      education: "本科",
+      expectedSalary: "15k-25k",
+      location: "深圳",
+      skills: ["CNC", "销售"],
+      ...((overrides.content as Record<string, unknown>) ?? {}),
+    },
+    ingestData: {
+      industryTags: ["cnc", "machining", "sales"],
+      verifiedRoleYears: { sales: 5 },
+      ...((overrides.ingestData as Record<string, unknown>) ?? {}),
+    },
+    source: "job5156",
+    sourceKey: "job5156",
+    isArchived: false,
+    ...overrides,
+  };
+}
+
+const BASE_TEXT = "cnc machining sales operator";
+
+// ---------------------------------------------------------------------------
+// parseAgeFromContentField
+// ---------------------------------------------------------------------------
+
+describe("parseAgeFromContentField", () => {
+  it("parses numeric age", () => {
+    expect(parseAgeFromContentField({ age: 32 })).toBe(32);
+  });
+
+  it("parses string age with digits", () => {
+    expect(parseAgeFromContentField({ age: "28岁" })).toBe(28);
+  });
+
+  it("returns null for missing age", () => {
+    expect(parseAgeFromContentField({})).toBeNull();
+  });
+
+  it("returns null for non-numeric age", () => {
+    expect(parseAgeFromContentField({ age: "unknown" })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bffMatchesResumeFilters — archived filter
+// ---------------------------------------------------------------------------
+
+describe("bffMatchesResumeFilters — archived", () => {
+  it("excludes archived resumes by default", () => {
+    const doc = makeDoc({ isArchived: true });
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, {})).toBe(false);
+  });
+
+  it("includes archived resumes when showArchived is true", () => {
+    const doc = makeDoc({ isArchived: true });
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { showArchived: true })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bffMatchesResumeFilters — experience filter
+// ---------------------------------------------------------------------------
+
+describe("bffMatchesResumeFilters — experience", () => {
+  it("passes when minExperience is met", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minExperience: 3 })).toBe(true);
+  });
+
+  it("fails when minExperience is not met", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minExperience: 10 })).toBe(false);
+  });
+
+  it("passes when maxExperience is not exceeded", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { maxExperience: 7 })).toBe(true);
+  });
+
+  it("fails when maxExperience is exceeded", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { maxExperience: 3 })).toBe(false);
+  });
+
+  it("excludes unknown experience when maxExperience is set", () => {
+    const doc = makeDoc({ content: { experience: undefined } });
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { maxExperience: 10 })).toBe(false);
+  });
+
+  it("includes unknown experience when only minExperience is set", () => {
+    const doc = makeDoc({ content: { experience: undefined } });
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minExperience: 1 })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bffMatchesResumeFilters — education filter
+// ---------------------------------------------------------------------------
+
+describe("bffMatchesResumeFilters — education", () => {
+  it("passes when education matches", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { education: ["bachelor"] })).toBe(true);
+  });
+
+  it("fails when education does not match", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { education: ["phd"] })).toBe(false);
+  });
+
+  it("fails when education is missing", () => {
+    const doc = makeDoc({ content: { education: undefined } });
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { education: ["bachelor"] })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bffMatchesResumeFilters — skills filter
+// ---------------------------------------------------------------------------
+
+describe("bffMatchesResumeFilters — skills", () => {
+  it("passes when a skill is found in searchText", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, "cnc machining expert", { skills: ["cnc"] })).toBe(true);
+  });
+
+  it("fails when no skill matches", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, "cnc machining", { skills: ["python"] })).toBe(false);
+  });
+
+  it("matches any skill (OR logic)", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, "cnc machining", { skills: ["python", "cnc"] })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bffMatchesResumeFilters — requiredKeywords filter
+// ---------------------------------------------------------------------------
+
+describe("bffMatchesResumeFilters — requiredKeywords", () => {
+  it("passes when all keywords are found", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, "cnc sales manager", { requiredKeywords: ["cnc", "sales"] })).toBe(true);
+  });
+
+  it("fails when a keyword is missing", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, "cnc operator", { requiredKeywords: ["cnc", "python"] })).toBe(false);
+  });
+
+  it("is case-insensitive when searchText is pre-lowered", () => {
+    const doc = makeDoc();
+    // bffMatchesResumeFilters receives pre-lowered searchText; keywords are lowered internally
+    expect(bffMatchesResumeFilters(doc, "cnc sales", { requiredKeywords: ["CNC", "Sales"] })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bffMatchesResumeFilters — salary filter
+// ---------------------------------------------------------------------------
+
+describe("bffMatchesResumeFilters — salary", () => {
+  it("passes when salary is within range", () => {
+    const doc = makeDoc(); // expectedSalary: "15k-25k" → parseSalaryRange returns {min:15, max:25}
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minSalary: 10, maxSalary: 30 })).toBe(true);
+  });
+
+  it("fails when salary is below minimum", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minSalary: 30 })).toBe(false);
+  });
+
+  it("excludes unknown salary when maxSalary is set", () => {
+    const doc = makeDoc({ content: { expectedSalary: undefined } });
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { maxSalary: 20 })).toBe(false);
+  });
+
+  it("includes unknown salary when only minSalary is set", () => {
+    const doc = makeDoc({ content: { expectedSalary: undefined } });
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minSalary: 10 })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bffMatchesResumeFilters — roleFilterType filter
+// ---------------------------------------------------------------------------
+
+describe("bffMatchesResumeFilters — roleFilterType", () => {
+  it("passes when verifiedRoleYears has matching key", () => {
+    const doc = makeDoc(); // verifiedRoleYears: { sales: 5 }
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { roleFilterType: "sales" })).toBe(true);
+  });
+
+  it("fails when no matching role exists", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { roleFilterType: "engineering" })).toBe(false);
+  });
+
+  it("matches via roleSignals when verifiedRoleYears has no key", () => {
+    const doc = makeDoc({
+      ingestData: {
+        verifiedRoleYears: {},
+        roleSignals: [{ type: "operator", years: 3, verifiedYears: 2, signalCount: 1, occurrences: 1, matchedSignals: [], verifyIn: "searchText" }],
+      },
+    });
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { roleFilterType: "operator" })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bffMatchesResumeFilters — minRoleYears filter
+// ---------------------------------------------------------------------------
+
+describe("bffMatchesResumeFilters — minRoleYears", () => {
+  it("passes when verifiedRoleYears meets minimum", () => {
+    const doc = makeDoc(); // verifiedRoleYears: { sales: 5 }
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minRoleYears: 3, roleFilterType: "sales" })).toBe(true);
+  });
+
+  it("fails when verifiedRoleYears is below minimum", () => {
+    const doc = makeDoc(); // verifiedRoleYears: { sales: 5 }
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minRoleYears: 10, roleFilterType: "sales" })).toBe(false);
+  });
+
+  it("checks any role when roleFilterType is not set", () => {
+    const doc = makeDoc(); // verifiedRoleYears: { sales: 5 }
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minRoleYears: 3 })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bffMatchesResumeFilters — age filter
+// ---------------------------------------------------------------------------
+
+describe("bffMatchesResumeFilters — age", () => {
+  it("passes when age is within range", () => {
+    const doc = makeDoc({ age: 30 });
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minAge: 25, maxAge: 35 })).toBe(true);
+  });
+
+  it("fails when age is below minimum", () => {
+    const doc = makeDoc({ age: 22 });
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minAge: 25 })).toBe(false);
+  });
+
+  it("falls back to content.age when doc.age is not set", () => {
+    const doc = makeDoc({ content: { age: "28岁" } });
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minAge: 25 })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bffMatchesResumeFilters — sources filter
+// ---------------------------------------------------------------------------
+
+describe("bffMatchesResumeFilters — sources", () => {
+  it("passes when source matches", () => {
+    const doc = makeDoc(); // sourceKey: "job5156"
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { sources: ["job5156"] })).toBe(true);
+  });
+
+  it("fails when source does not match", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { sources: ["seek"] })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bffMatchesResumeFilters — combined filters
+// ---------------------------------------------------------------------------
+
+describe("bffMatchesResumeFilters — combined", () => {
+  it("passes with multiple matching filters", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, {
+      minExperience: 3,
+      skills: ["cnc"],
+      sources: ["job5156"],
+    })).toBe(true);
+  });
+
+  it("fails when any single filter fails", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, {
+      minExperience: 3,
+      skills: ["python"],
+      sources: ["job5156"],
+    })).toBe(false);
+  });
+
+  it("passes with no filters (returns all non-archived)", () => {
+    const doc = makeDoc();
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, {})).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 39 tests for `bff-filter-utils.ts` — the BFF-side resume filter matching for AND-mode full-table scan
- Covers all filter dimensions: archived, experience, education, skills, requiredKeywords, salary, roleFilterType, minRoleYears, age, sources
- Includes edge cases: unknown experience/salary handling, verifiedRoleYears fallback to roleSignals, case-insensitive keyword matching
- Also tests `parseAgeFromContentField` helper

## Context
`bff-filter-utils.ts` (180 lines) is on the `resume_search` critical path but had zero test coverage. This file mirrors Convex `matchesResumeListFilters` for the BFF AND-mode execution path — the three-way filter alignment (Convex, BFF AND-mode, BFF OR-mode) must stay in sync.

## Test plan
- [x] `npx vitest run apps/api/src/services/bff-filter-utils.test.ts` — 39/39 pass
- [x] `make check` — all checks pass