### PR TITLE
feat: add BFF explanation endpoint for EU AI Act Art. 13 transparency

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -1632,4 +1632,105 @@ describe("resume routes", () => {
     });
     expect(readOnlyResponse.status).toBe(400);
   });
+
+  describe("POST /api/resumes/explanation", () => {
+    it("returns explanation from Convex when available", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        const call = parseConvexCall(input, init);
+        if (call.pathName !== "audit:getExplanationForCandidate") {
+          throw new Error(`Unexpected convex path: ${call.pathName}`);
+        }
+        expect(call.args).toEqual({ resumeId: "r1", workspaceSlug: "ws1" });
+        return convexSuccess({
+          summary: "Candidate scored 85/100 for CNC operator role.",
+          keyFactors: [
+            { factor: "skill_alignment", value: "5 years CNC experience" },
+            { factor: "experience", value: "8 years total" },
+          ],
+          decidedAt: 1748200000000,
+          decisionType: "score",
+          scrubbedFields: ["age", "gender"],
+          protectedAttributesExcluded: true,
+        });
+      });
+
+      const app = createApp();
+      const response = await app.request("/api/resumes/explanation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ resumeId: "r1", workspaceSlug: "ws1" }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload.success).toBe(true);
+      expect(payload.data.summary).toBe("Candidate scored 85/100 for CNC operator role.");
+      expect(payload.data.keyFactors.length).toBe(2);
+      expect(payload.data.scrubbedFields).toEqual(["age", "gender"]);
+      expect(payload.data.protectedAttributesExcluded).toBe(true);
+    });
+
+    it("returns null data when no explanation exists", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        parseConvexCall(input, init);
+        return convexSuccess(null);
+      });
+
+      const app = createApp();
+      const response = await app.request("/api/resumes/explanation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ resumeId: "r2", workspaceSlug: "ws1" }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload.success).toBe(true);
+      expect(payload.data).toBeNull();
+    });
+
+    it("returns 400 when resumeId is missing", async () => {
+      const app = createApp();
+      const response = await app.request("/api/resumes/explanation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workspaceSlug: "ws1" }),
+      });
+
+      expect(response.status).toBe(400);
+      const payload = await response.json();
+      expect(payload.success).toBe(false);
+    });
+
+    it("returns 400 when workspaceSlug is missing", async () => {
+      const app = createApp();
+      const response = await app.request("/api/resumes/explanation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ resumeId: "r1" }),
+      });
+
+      expect(response.status).toBe(400);
+      const payload = await response.json();
+      expect(payload.success).toBe(false);
+    });
+
+    it("returns 500 when Convex call fails", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+        return new Response(JSON.stringify({ status: "error", errorMessage: "Not found" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+      const app = createApp();
+      const response = await app.request("/api/resumes/explanation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ resumeId: "r1", workspaceSlug: "ws1" }),
+      });
+
+      expect(response.status).toBe(500);
+    });
+  });
 });

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -1249,4 +1249,30 @@ app.post("/api/resumes/analyze", async (c) => {
 });
 
 
+app.post("/api/resumes/explanation", async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const resumeId = typeof body.resumeId === "string" ? body.resumeId.trim() : "";
+  const workspaceSlug = typeof body.workspaceSlug === "string" ? body.workspaceSlug.trim() : "";
+
+  if (!resumeId || !workspaceSlug) {
+    return c.json({ success: false, error: "resumeId and workspaceSlug are required" }, 400);
+  }
+
+  try {
+    const explanation = await callConvexQuery("audit:getExplanationForCandidate", {
+      resumeId,
+      workspaceSlug,
+    });
+
+    if (!explanation) {
+      return c.json({ success: true, data: null }, 200);
+    }
+
+    return c.json({ success: true, data: explanation }, 200);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
 export default app;


### PR DESCRIPTION
## Summary
- Adds `POST /api/resumes/explanation` BFF endpoint exposing the existing Convex `audit:getExplanationForCandidate` query
- Candidates can request an explanation of AI scoring decisions, with scrubbed fields and protected-attribute-exclusion status disclosed
- This addresses EU AI Act Art. 13 (transparency) requirements — the Convex query already strips internal details (weights, model reasoning)
- Adds 5 route tests: success with explanation, null when none exists, missing resumeId (400), missing workspaceSlug (400), Convex error (500)

## EU AI Act compliance
- Art. 12 (logging): Already wired in all 3 AI decision points (PRs #918, #1004)
- Art. 13 (transparency): **This PR** — candidates can request scoring explanations
- Art. 14 (human oversight): Still needs implementation (future work)

## Test plan
- [x] `npx vitest run apps/api/src/routes/resumes.test.ts` — 31/31 passed (5 new)
- [x] `make check` — all passed