### PR TITLE
feat: add BFF audit log endpoints for EU AI Act Art. 14 human oversight

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -1733,4 +1733,171 @@ describe("resume routes", () => {
       expect(response.status).toBe(500);
     });
   });
+
+  describe("POST /api/resumes/audit-logs", () => {
+    it("returns audit logs for a workspace", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        const call = parseConvexCall(input, init);
+        if (call.pathName !== "audit:getAuditLogByWorkspace") {
+          throw new Error(`Unexpected convex path: ${call.pathName}`);
+        }
+        expect(call.args.workspaceSlug).toBe("ws1");
+        return convexSuccess([
+          { _id: "al1", decisionType: "score", outcome: "pending", output: { score: 85 } },
+          { _id: "al2", decisionType: "confirm", outcome: "pending", output: { score: 90 } },
+        ]);
+      });
+
+      const app = createApp();
+      const response = await app.request("/api/resumes/audit-logs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workspaceSlug: "ws1" }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload.success).toBe(true);
+      expect(payload.data.length).toBe(2);
+    });
+
+    it("filters audit logs by decisionType", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        const call = parseConvexCall(input, init);
+        expect(call.args).toEqual({ workspaceSlug: "ws1", decisionType: "score" });
+        return convexSuccess([
+          { _id: "al1", decisionType: "score", outcome: "pending" },
+        ]);
+      });
+
+      const app = createApp();
+      const response = await app.request("/api/resumes/audit-logs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workspaceSlug: "ws1", decisionType: "score" }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload.data.length).toBe(1);
+    });
+
+    it("returns 400 when workspaceSlug is missing", async () => {
+      const app = createApp();
+      const response = await app.request("/api/resumes/audit-logs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 for invalid decisionType", async () => {
+      const app = createApp();
+      const response = await app.request("/api/resumes/audit-logs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workspaceSlug: "ws1", decisionType: "invalid" }),
+      });
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("POST /api/resumes/audit-outcome", () => {
+    it("sets audit outcome to accepted", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        const call = parseConvexCall(input, init, "/api/mutation");
+        expect(call.pathName).toBe("audit:setAuditOutcome");
+        expect(call.args).toEqual({ auditLogId: "al1", outcome: "accepted" });
+        return convexSuccess(null);
+      });
+
+      const app = createApp();
+      const response = await app.request("/api/resumes/audit-outcome", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ auditLogId: "al1", outcome: "accepted" }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload.success).toBe(true);
+    });
+
+    it("sets audit outcome to overridden with setBy", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        const call = parseConvexCall(input, init, "/api/mutation");
+        expect(call.args).toEqual({ auditLogId: "al1", outcome: "overridden", setBy: "reviewer@example.com" });
+        return convexSuccess(null);
+      });
+
+      const app = createApp();
+      const response = await app.request("/api/resumes/audit-outcome", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ auditLogId: "al1", outcome: "overridden", setBy: "reviewer@example.com" }),
+      });
+
+      expect(response.status).toBe(200);
+    });
+
+    it("sets audit outcome to appealed", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        const call = parseConvexCall(input, init, "/api/mutation");
+        expect(call.args.outcome).toBe("appealed");
+        return convexSuccess(null);
+      });
+
+      const app = createApp();
+      const response = await app.request("/api/resumes/audit-outcome", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ auditLogId: "al1", outcome: "appealed" }),
+      });
+
+      expect(response.status).toBe(200);
+    });
+
+    it("returns 400 when auditLogId is missing", async () => {
+      const app = createApp();
+      const response = await app.request("/api/resumes/audit-outcome", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ outcome: "accepted" }),
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 for invalid outcome", async () => {
+      const app = createApp();
+      const response = await app.request("/api/resumes/audit-outcome", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ auditLogId: "al1", outcome: "invalid" }),
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 500 when Convex call fails", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+        return new Response(JSON.stringify({ status: "error", errorMessage: "Not found" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+      const app = createApp();
+      const response = await app.request("/api/resumes/audit-outcome", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ auditLogId: "al1", outcome: "accepted" }),
+      });
+
+      expect(response.status).toBe(500);
+    });
+  });
 });

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -1275,4 +1275,62 @@ app.post("/api/resumes/explanation", async (c) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// Audit log endpoints (EU AI Act Art. 14 human oversight)
+// ---------------------------------------------------------------------------
+
+app.post("/api/resumes/audit-logs", async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const workspaceSlug = typeof body.workspaceSlug === "string" ? body.workspaceSlug.trim() : "";
+  const decisionType = typeof body.decisionType === "string" ? body.decisionType.trim() : undefined;
+
+  if (!workspaceSlug) {
+    return c.json({ success: false, error: "workspaceSlug is required" }, 400);
+  }
+
+  if (decisionType && decisionType !== "score" && decisionType !== "tag" && decisionType !== "confirm") {
+    return c.json({ success: false, error: "decisionType must be 'score', 'tag', or 'confirm'" }, 400);
+  }
+
+  try {
+    const logs = await callConvexQuery("audit:getAuditLogByWorkspace", {
+      workspaceSlug,
+      ...(decisionType ? { decisionType } : {}),
+    });
+
+    return c.json({ success: true, data: logs }, 200);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+app.post("/api/resumes/audit-outcome", async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const auditLogId = typeof body.auditLogId === "string" ? body.auditLogId.trim() : "";
+  const outcome = typeof body.outcome === "string" ? body.outcome.trim() : "";
+  const setBy = typeof body.setBy === "string" ? body.setBy.trim() : undefined;
+
+  if (!auditLogId || !outcome) {
+    return c.json({ success: false, error: "auditLogId and outcome are required" }, 400);
+  }
+
+  if (outcome !== "accepted" && outcome !== "overridden" && outcome !== "appealed") {
+    return c.json({ success: false, error: "outcome must be 'accepted', 'overridden', or 'appealed'" }, 400);
+  }
+
+  try {
+    await callConvexMutation("audit:setAuditOutcome", {
+      auditLogId,
+      outcome,
+      ...(setBy ? { setBy } : {}),
+    });
+
+    return c.json({ success: true }, 200);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
 export default app;


### PR DESCRIPTION
## Summary
- Adds `POST /api/resumes/audit-logs` — list audit logs for a workspace with optional `decisionType` filter
- Adds `POST /api/resumes/audit-outcome` — set audit outcome (accepted/overridden/appealed) with optional `setBy` reviewer
- These enable human reviewers to review AI decisions and record oversight actions, addressing EU AI Act Art. 14 (human oversight)
- Adds 10 route tests covering both endpoints

## EU AI Act compliance progress
- Art. 12 (logging): Done — all 3 AI decision points wired (PRs #918, #1004)
- Art. 13 (transparency): Done — explanation endpoint exposed (PR #1010)
- Art. 14 (human oversight): **This PR** — audit log listing + outcome setting
- Art. 11 (technical documentation): Still needed (future work)

## Test plan
- [x] `npx vitest run apps/api/src/routes/resumes.test.ts` — 41/41 passed (10 new)
- [x] `make check` — all passed