### PR TITLE
feat: add actor identity to audit trail (EU AI Act Art. 12)

### DIFF
--- a/packages/convex/convex/__tests__/audit-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/audit-convex-test.test.ts
@@ -405,6 +405,155 @@ describe("audit (convex-test)", () => {
     });
   });
 
+  describe("actor identity in audit trail (EU AI Act Art. 12)", () => {
+    it("logs actorId and actorRole when provided", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "actor-r1",
+          content: {},
+          hash: "actor1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+          searchText: "Actor test resume",
+        });
+      });
+
+      await t.mutation(internal.audit.logAnalysisDecision, {
+        resumeId,
+        workspaceSlug: "ws-actor",
+        decisionType: "score",
+        actionRef: "analyze:analyzeResume",
+        inputSnapshot: {},
+        modelMeta: { model: "gpt-4-turbo", provider: "openai" },
+        output: { score: 75 },
+        decidedAt: Date.now(),
+        actorId: "system",
+        actorRole: "system",
+      });
+
+      const logs = await t.run(async (ctx) => {
+        return ctx.db
+          .query("analysis_audit_log")
+          .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+          .collect();
+      });
+
+      expect(logs.length).toBe(1);
+      expect(logs[0].actorId).toBe("system");
+      expect(logs[0].actorRole).toBe("system");
+    });
+
+    it("logs admin actor identity", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "actor-admin-r1",
+          content: {},
+          hash: "actor-admin1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+      });
+
+      await t.mutation(internal.audit.logAnalysisDecision, {
+        resumeId,
+        workspaceSlug: "ws-actor-admin",
+        decisionType: "score",
+        actionRef: "analyze:analyzeResume",
+        inputSnapshot: {},
+        modelMeta: { model: "gpt-4", provider: "openai" },
+        output: { score: 88 },
+        decidedAt: Date.now(),
+        actorId: "user_abc123",
+        actorRole: "admin",
+      });
+
+      const logs = await t.run(async (ctx) => {
+        return ctx.db
+          .query("analysis_audit_log")
+          .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+          .collect();
+      });
+
+      expect(logs.length).toBe(1);
+      expect(logs[0].actorId).toBe("user_abc123");
+      expect(logs[0].actorRole).toBe("admin");
+    });
+
+    it("allows optional actor identity (backward compatible)", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "actor-opt-r1",
+          content: {},
+          hash: "actor-opt1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+      });
+
+      await t.mutation(internal.audit.logAnalysisDecision, {
+        resumeId,
+        workspaceSlug: "ws-actor-opt",
+        decisionType: "tag",
+        actionRef: "ai_tagging_results:drainQueue",
+        inputSnapshot: {},
+        modelMeta: { model: "gpt-4", provider: "openai" },
+        output: { tags: ["senior"] },
+        decidedAt: Date.now(),
+        // No actorId/actorRole — backward compatible
+      });
+
+      const logs = await t.run(async (ctx) => {
+        return ctx.db
+          .query("analysis_audit_log")
+          .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+          .collect();
+      });
+
+      expect(logs.length).toBe(1);
+      expect(logs[0].actorId).toBeUndefined();
+      expect(logs[0].actorRole).toBeUndefined();
+    });
+
+    it("rejects invalid actorRole values", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "actor-invalid-r1",
+          content: {},
+          hash: "actor-inv1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+      });
+
+      await expect(
+        t.mutation(internal.audit.logAnalysisDecision, {
+          resumeId,
+          workspaceSlug: "ws-actor-invalid",
+          decisionType: "score",
+          actionRef: "analyze:analyzeResume",
+          inputSnapshot: {},
+          modelMeta: { model: "gpt-4", provider: "openai" },
+          output: { score: 50 },
+          decidedAt: Date.now(),
+          actorId: "user_x",
+          actorRole: "superadmin" as any, // Invalid — not in union
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
   describe("listWorkspaceSlugsWithAuditLogs", () => {
     it("returns distinct workspace slugs from audit logs", async () => {
       const t = convexTest(schema, modules);

--- a/packages/convex/convex/__tests__/migrations-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/migrations-convex-test.test.ts
@@ -1067,3 +1067,130 @@ describe("migration: backfillSeekNameSearchUrls", () => {
     expect(result.updatedResumes).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// backfillAuditLogActorIdentity
+// ---------------------------------------------------------------------------
+
+describe("migration: backfillAuditLogActorIdentity", () => {
+  it("patches audit logs without actorId/actorRole", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumeId = await insertResume(t);
+
+    // Insert an audit log without actor fields (simulates pre-feature data)
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("analysis_audit_log", {
+        resumeId,
+        workspaceSlug: "ws-backfill",
+        decisionType: "score",
+        actionRef: "analyze:analyzeResume",
+        inputSnapshot: {},
+        modelMeta: { model: "gpt-4", provider: "openai" },
+        output: { score: 80 },
+        outcome: "pending",
+        decidedAt: now,
+        expiresAt: now + 2 * 365 * 24 * 60 * 60 * 1000,
+        // No actorId or actorRole — pre-tracking state
+      });
+    });
+
+    const result = await t.mutation(api.migrations.backfillAuditLogActorIdentity, {});
+
+    expect(result.updated).toBeGreaterThanOrEqual(1);
+    expect(result.scanned).toBeGreaterThanOrEqual(1);
+
+    // Verify the audit log now has actor fields
+    const logs = await t.run(async (ctx) => {
+      return ctx.db
+        .query("analysis_audit_log")
+        .withIndex("by_workspace", (q) => q.eq("workspaceSlug", "ws-backfill"))
+        .collect();
+    });
+
+    expect(logs.length).toBe(1);
+    expect(logs[0].actorId).toBe("pre-tracking");
+    expect(logs[0].actorRole).toBe("system");
+  });
+
+  it("skips audit logs that already have actor identity", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumeId = await insertResume(t);
+
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("analysis_audit_log", {
+        resumeId,
+        workspaceSlug: "ws-skip",
+        decisionType: "tag",
+        actionRef: "ai_tagging_results:drainQueue",
+        inputSnapshot: {},
+        modelMeta: { model: "gpt-4", provider: "openai" },
+        output: { tags: ["senior"] },
+        outcome: "pending",
+        decidedAt: now,
+        expiresAt: now + 2 * 365 * 24 * 60 * 60 * 1000,
+        actorId: "system",
+        actorRole: "system",
+      });
+    });
+
+    const result = await t.mutation(api.migrations.backfillAuditLogActorIdentity, {});
+
+    expect(result.updated).toBe(0);
+
+    // Verify the existing actor fields were not changed
+    const logs = await t.run(async (ctx) => {
+      return ctx.db
+        .query("analysis_audit_log")
+        .withIndex("by_workspace", (q) => q.eq("workspaceSlug", "ws-skip"))
+        .collect();
+    });
+
+    expect(logs.length).toBe(1);
+    expect(logs[0].actorId).toBe("system");
+    expect(logs[0].actorRole).toBe("system");
+  });
+
+  it("handles pagination with cursor", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumeId = await insertResume(t);
+
+    const now = Date.now();
+    // Insert 2 audit logs without actor fields
+    await t.run(async (ctx) => {
+      await ctx.db.insert("analysis_audit_log", {
+        resumeId,
+        workspaceSlug: "ws-paginate",
+        decisionType: "score",
+        actionRef: "analyze:analyzeResume",
+        inputSnapshot: {},
+        modelMeta: { model: "gpt-4", provider: "openai" },
+        output: { score: 70 },
+        outcome: "pending",
+        decidedAt: now,
+        expiresAt: now + 2 * 365 * 24 * 60 * 60 * 1000,
+      });
+      await ctx.db.insert("analysis_audit_log", {
+        resumeId,
+        workspaceSlug: "ws-paginate",
+        decisionType: "tag",
+        actionRef: "ai_tagging_results:drainQueue",
+        inputSnapshot: {},
+        modelMeta: { model: "gpt-4", provider: "openai" },
+        output: { tags: ["lead"] },
+        outcome: "pending",
+        decidedAt: now + 1000,
+        expiresAt: now + 2 * 365 * 24 * 60 * 60 * 1000,
+      });
+    });
+
+    const result = await t.mutation(api.migrations.backfillAuditLogActorIdentity, {});
+
+    expect(result.updated).toBe(2);
+    expect(result.scanned).toBe(2);
+  });
+});

--- a/packages/convex/convex/ai_tagging_results.ts
+++ b/packages/convex/convex/ai_tagging_results.ts
@@ -794,6 +794,8 @@ export const drainQueue = internalAction({
             },
             protectedAttributeHashes: protectedHashes,
             decidedAt: Date.now(),
+            actorId: "system",
+            actorRole: "system",
           });
         } catch (auditError) {
           console.error("Audit logging failed for tagging:", auditError);

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -735,6 +735,8 @@ export const analyzeResume = action({
                         })),
                 },
                 decidedAt: Date.now(),
+                actorId: "system",
+                actorRole: "system",
             });
         } catch (auditError) {
             // Audit logging failure must NOT block the analysis result
@@ -961,6 +963,8 @@ export const confirmSearchResults = action({
                                 })),
                         },
                         decidedAt: Date.now(),
+                        actorId: "system",
+                        actorRole: "system",
                     });
                 } catch (auditError) {
                     // Audit logging failure must NOT block the confirm result

--- a/packages/convex/convex/audit.ts
+++ b/packages/convex/convex/audit.ts
@@ -60,6 +60,12 @@ export const logAnalysisDecision = internalMutation({
         })),
         decidedAt: v.number(),
         expiresAt: v.optional(v.number()),
+        actorId: v.optional(v.string()),
+        actorRole: v.optional(v.union(
+            v.literal("admin"),
+            v.literal("operator"),
+            v.literal("system"),
+        )),
     },
     handler: async (ctx, args) => {
         await ctx.db.insert("analysis_audit_log", {
@@ -76,6 +82,8 @@ export const logAnalysisDecision = internalMutation({
             outcome: "pending",
             decidedAt: args.decidedAt,
             expiresAt: args.expiresAt ?? args.decidedAt + 2 * 365 * 24 * 60 * 60 * 1000,
+            actorId: args.actorId,
+            actorRole: args.actorRole,
         });
     },
 });

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -1765,3 +1765,42 @@ export const backfillAnalysesValidator = mutation({
         };
     },
 });
+
+/**
+ * Backfill actorId/actorRole on existing analysis_audit_log records.
+ * Records created before the actor identity feature have no actor fields.
+ * Mark them with actorId: "pre-tracking" and actorRole: "system" so that
+ * every audit record has traceability (EU AI Act Art. 12).
+ */
+export const backfillAuditLogActorIdentity = mutation({
+    args: {
+        cursor: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const logs = await ctx.db
+            .query("analysis_audit_log")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems: 100,
+            });
+
+        let updated = 0;
+        for (const log of logs.page) {
+            if (log.actorId === undefined && log.actorRole === undefined) {
+                await ctx.db.patch(log._id, {
+                    actorId: "pre-tracking",
+                    actorRole: "system",
+                });
+                updated += 1;
+            }
+        }
+
+        return {
+            scanned: logs.page.length,
+            updated,
+            hasMore: !logs.isDone,
+            cursor: logs.isDone ? null : logs.continueCursor,
+        };
+    },
+});

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -555,6 +555,14 @@ export default defineSchema({
             flagReason: v.optional(v.string()),
         })),
 
+        // Actor Identity (EU AI Act Art. 12 — traceability to specific operator)
+        actorId: v.optional(v.string()),
+        actorRole: v.optional(v.union(
+            v.literal("admin"),
+            v.literal("operator"),
+            v.literal("system"),
+        )),
+
         // Timestamps
         decidedAt: v.number(),
         reviewedAt: v.optional(v.number()),


### PR DESCRIPTION
## Summary
- Add `actorId` and `actorRole` fields to `analysis_audit_log` schema for EU AI Act Art. 12 traceability
- Update all 3 production `logAnalysisDecision` call sites to pass `actorId: "system"`, `actorRole: "system"`
- Add paginated migration `backfillAuditLogActorIdentity` to mark pre-existing records with `actorId: "pre-tracking"`, `actorRole: "system"`
- 7 new tests: 4 for actor identity validation, 3 for migration backfill

## Files changed
- `convex/schema.ts` — Added `actorId` (optional string) and `actorRole` (optional union: admin|operator|system)
- `convex/audit.ts` — Added args to `logAnalysisDecision`, pass through to insert
- `convex/analyze.ts` — Updated `analyzeResume` and `confirmSearchResults` call sites
- `convex/ai_tagging_results.ts` — Updated `drainQueue` call site
- `convex/migrations.ts` — Added `backfillAuditLogActorIdentity` migration
- `__tests__/audit-convex-test.test.ts` — 4 new actor identity tests
- `__tests__/migrations-convex-test.test.ts` — 3 new migration tests

## Test plan
- [x] `make check` passes
- [x] `npx vitest run audit-convex-test.test.ts` — 22/22 pass
- [x] `npx vitest run migrations-convex-test.test.ts` — 48/48 pass
- [ ] Run `backfillAuditLogActorIdentity` migration on staging after deploy