### PR TITLE
feat: add audit log retention cleanup cron (EU AI Act/GDPR)

### DIFF
--- a/packages/convex/convex/__tests__/audit-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/audit-convex-test.test.ts
@@ -710,3 +710,126 @@ describe("bias_metrics (unit)", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Audit log retention / cleanup tests
+// ---------------------------------------------------------------------------
+
+describe("audit log retention (EU AI Act / GDPR)", () => {
+  describe("getExpiredAuditLogs", () => {
+    it("returns audit logs with expiresAt before the given timestamp", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "expired-r1",
+          content: {},
+          hash: "expired1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+      });
+
+      const now = Date.now();
+      const twoYearsMs = 2 * 365 * 24 * 60 * 60 * 1000;
+
+      // Insert an expired log (decidedAt 3 years ago, expiresAt 1 year ago)
+      await t.run(async (ctx) => {
+        await ctx.db.insert("analysis_audit_log", {
+          resumeId,
+          workspaceSlug: "ws-expired",
+          decisionType: "score",
+          actionRef: "analyze:analyzeResume",
+          inputSnapshot: {},
+          modelMeta: { model: "gpt-4", provider: "openai" },
+          output: { score: 70 },
+          outcome: "pending",
+          decidedAt: now - 3 * twoYearsMs / 2,
+          expiresAt: now - 1000, // Already expired
+        });
+      });
+
+      // Insert a non-expired log
+      await t.run(async (ctx) => {
+        await ctx.db.insert("analysis_audit_log", {
+          resumeId,
+          workspaceSlug: "ws-expired",
+          decisionType: "tag",
+          actionRef: "ai_tagging_results:drainQueue",
+          inputSnapshot: {},
+          modelMeta: { model: "gpt-4", provider: "openai" },
+          output: { tags: ["senior"] },
+          outcome: "pending",
+          decidedAt: now,
+          expiresAt: now + twoYearsMs, // Not yet expired
+        });
+      });
+
+      const expired = await t.query(internal.audit.getExpiredAuditLogs, {
+        before: now,
+      });
+
+      expect(expired.length).toBe(1);
+      expect(expired[0].decisionType).toBe("score");
+    });
+
+    it("returns empty array when no expired logs exist", async () => {
+      const t = convexTest(schema, modules);
+
+      const expired = await t.query(internal.audit.getExpiredAuditLogs, {
+        before: Date.now(),
+      });
+
+      expect(expired).toEqual([]);
+    });
+  });
+
+  describe("deleteAuditLog", () => {
+    it("deletes an audit log entry", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "delete-r1",
+          content: {},
+          hash: "delete1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+      });
+
+      const now = Date.now();
+      const logId = await t.run(async (ctx) => {
+        return ctx.db.insert("analysis_audit_log", {
+          resumeId,
+          workspaceSlug: "ws-delete",
+          decisionType: "score",
+          actionRef: "analyze:analyzeResume",
+          inputSnapshot: {},
+          modelMeta: { model: "gpt-4", provider: "openai" },
+          output: { score: 50 },
+          outcome: "pending",
+          decidedAt: now,
+          expiresAt: now + 2 * 365 * 24 * 60 * 60 * 1000,
+        });
+      });
+
+      // Verify it exists
+      const before = await t.run(async (ctx) => {
+        return ctx.db.get(logId);
+      });
+      expect(before).not.toBeNull();
+
+      // Delete
+      await t.mutation(internal.audit.deleteAuditLog, { auditLogId: logId });
+
+      // Verify it's gone
+      const after = await t.run(async (ctx) => {
+        return ctx.db.get(logId);
+      });
+      expect(after).toBeNull();
+    });
+  });
+});

--- a/packages/convex/convex/audit.ts
+++ b/packages/convex/convex/audit.ts
@@ -1,4 +1,6 @@
-import { internalMutation, query } from "./_generated/server";
+import { internalMutation, internalQuery, internalAction, query } from "./_generated/server";
+import { internal } from "./_generated/api";
+import type { Doc } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { fnvHash, ageToBracket } from "./lib/bias_metrics.js";
 
@@ -207,3 +209,63 @@ export function computeProtectedAttributeHashes(data: {
         sourceHash: data.source ? fnvHash(data.source) : undefined,
     };
 }
+
+// ---------------------------------------------------------------------------
+// Internal action: cleanupExpiredAuditLogs (2-year retention, GDPR/EU AI Act)
+// ---------------------------------------------------------------------------
+
+export const cleanupExpiredAuditLogs = internalAction({
+    args: {
+        maxDeletes: v.optional(v.number()),
+    },
+    handler: async (ctx, args): Promise<{ deleted: number; checked: number; hasMore: boolean }> => {
+        const maxDeletes = Math.min(args.maxDeletes ?? 500, 2000);
+        const now = Date.now();
+
+        const expired = await ctx.runQuery(internal.audit.getExpiredAuditLogs, {
+            before: now,
+            limit: maxDeletes,
+        });
+
+        let deleted = 0;
+        for (const log of expired) {
+            await ctx.runMutation(internal.audit.deleteAuditLog, {
+                auditLogId: log._id,
+            });
+            deleted += 1;
+        }
+
+        return { deleted, checked: expired.length, hasMore: expired.length === maxDeletes };
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Internal query: getExpiredAuditLogs (used by cleanup action)
+// ---------------------------------------------------------------------------
+
+export const getExpiredAuditLogs = internalQuery({
+    args: {
+        before: v.number(),
+        limit: v.optional(v.number()),
+    },
+    handler: async (ctx, args): Promise<Array<Doc<"analysis_audit_log">>> => {
+        const limit = Math.min(args.limit ?? 500, 2000);
+        return ctx.db
+            .query("analysis_audit_log")
+            .withIndex("by_expires_at", (q) => q.lte("expiresAt", args.before))
+            .take(limit);
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Internal mutation: deleteAuditLog
+// ---------------------------------------------------------------------------
+
+export const deleteAuditLog = internalMutation({
+    args: {
+        auditLogId: v.id("analysis_audit_log"),
+    },
+    handler: async (ctx, args): Promise<void> => {
+        await ctx.db.delete(args.auditLogId);
+    },
+});

--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -38,4 +38,11 @@ crons.interval(
     {},
 );
 
+crons.daily(
+    "cleanup expired audit logs",
+    { hourUTC: 5, minuteUTC: 0 },
+    internal.audit.cleanupExpiredAuditLogs,
+    {},
+);
+
 export default crons;


### PR DESCRIPTION
## Summary
- Add `cleanupExpiredAuditLogs` internal action that deletes audit log entries past their `expiresAt` timestamp
- Add `getExpiredAuditLogs` internal query using `by_expires_at` index for efficient expired record lookup
- Add `deleteAuditLog` internal mutation for individual record deletion
- Wire daily cron at 05:00 UTC to run cleanup (max 500 deletes per run, configurable)

## Files changed
- `convex/audit.ts` — Added 3 new exported functions: `cleanupExpiredAuditLogs`, `getExpiredAuditLogs`, `deleteAuditLog`
- `convex/crons.ts` — Added `cleanup expired audit logs` daily cron
- `__tests__/audit-convex-test.test.ts` — 3 new retention tests

## Test plan
- [x] `make check` passes
- [x] `npx vitest run audit-convex-test.test.ts` — 25/25 pass
- [ ] Monitor cron execution on staging after deploy