### PR TITLE
refactor: type ruleScores and breakdown validators, eliminate 4 v.any()

### DIFF
--- a/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
+++ b/packages/convex/convex/__tests__/resumes-ingest-diagnostics.test.ts
@@ -92,7 +92,6 @@ describe("projectIngestDiagnosticsRow", () => {
                 ruleScores: {
                     jdA: 87,
                     jdB: 42,
-                    invalid: "bad",
                 },
                 experienceLevel: "mid",
                 computedAt: 1_700_000_000_000,

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -825,7 +825,7 @@ export const storeConfirmResult = internalMutation({
             summary: v.string(),
             highlights: v.array(v.string()),
             recommendation: v.string(),
-            breakdown: v.optional(v.any()),
+            breakdown: v.optional(v.record(v.string(), v.number())),
             keyFactors: v.optional(v.array(v.object({
                 factor: v.string(),
                 weight: v.optional(v.number()),

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -2848,7 +2848,7 @@ export const updateAnalysis = internalMutation({
             summary: v.string(),
             highlights: v.array(v.string()),
             recommendation: v.string(),
-            breakdown: v.optional(v.any()),
+            breakdown: v.optional(v.record(v.string(), v.number())),
             keyFactors: v.optional(v.array(v.object({
                 factor: v.string(),
                 weight: v.optional(v.number()),
@@ -2889,7 +2889,7 @@ export const updateAnalysisBatch = internalMutation({
                 summary: v.string(),
                 highlights: v.array(v.string()),
                 recommendation: v.string(),
-                breakdown: v.optional(v.any()),
+                breakdown: v.optional(v.record(v.string(), v.number())),
                 keyFactors: v.optional(v.array(v.object({
                     factor: v.string(),
                     weight: v.optional(v.number()),

--- a/packages/convex/convex/validators.ts
+++ b/packages/convex/convex/validators.ts
@@ -65,7 +65,7 @@ export const ingestDataValidator = v.object({
     })),
     // Legacy field: migrated to taggingEnvelope; retained for documents not yet migrated.
     tagEnvelope: v.optional(v.any()),
-    ruleScores: v.any(),
+    ruleScores: v.record(v.string(), v.number()),
     experienceLevel: v.string(),
     computedAt: v.number(),
     skillsVersion: v.number(),
@@ -95,7 +95,7 @@ export const analysisResultValidator = v.object({
     summary: v.optional(v.string()),
     highlights: v.optional(v.array(v.string())),
     recommendation: v.optional(v.string()),
-    breakdown: v.optional(v.any()),
+    breakdown: v.optional(v.record(v.string(), v.number())),
     keyFactors: v.optional(v.array(v.object({
         factor: v.string(),
         weight: v.optional(v.number()),


### PR DESCRIPTION
## Summary
- Replace `v.any()` with `v.record(v.string(), v.number())` for `ruleScores` and `breakdown` fields
- `ruleScores` in validators.ts: was `v.any()`, now `v.record(v.string(), v.number())`
- `breakdown` in validators.ts, resumes.ts (2x), analyze.ts: was `v.optional(v.any())`, now `v.optional(v.record(v.string(), v.number()))`
- Fix test fixture with invalid string value in ruleScores (was silently accepted by v.any())

## v.any() elimination progress
- Before this session: 24 instances
- sessions.ts (PR #1014): -2 → 22
- This PR: -4 → 18
- Remaining 18 are mostly intentional bridges (content payloads, legacy envelopes, config values)

## Test plan
- [x] `make check` passes
- [x] Full test suite: 4,659 passing across 256 files