### PR TITLE
feat: type resume_tasks.ts restoreState fields (3× v.any() eliminated)

### DIFF
--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -2,7 +2,7 @@ import { internalMutation, mutation, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
-import { collectionTaskResultsValidator } from "./validators.js";
+import { collectionTaskResultsValidator, ingestDataValidator, analysisResultValidator, resumeAnalysisValidator } from "./validators.js";
 import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
 import { computeVerifiedRoleYears } from "@trends/shared";
 import { resolveSubmitResumeParallelism } from "./lib/parallelism";
@@ -456,9 +456,9 @@ export const submitResumes = mutation({
                     archivedAt: v.optional(v.number()),
                     searchText: v.optional(v.string()),
                     primaryRuleScore: v.optional(v.number()),
-                    ingestData: v.optional(v.any()),
-                    analysis: v.optional(v.any()),
-                    analyses: v.optional(v.any()),
+                    ingestData: v.optional(ingestDataValidator),
+                    analysis: v.optional(resumeAnalysisValidator),
+                    analyses: v.optional(v.record(v.string(), analysisResultValidator)),
                 })),
             })
         ),

--- a/packages/convex/convex/validators.ts
+++ b/packages/convex/convex/validators.ts
@@ -108,6 +108,21 @@ export const analysisResultValidator = v.object({
     analyzedAt: v.optional(v.number()),
 });
 
+// --- Resume analysis (resumes.analysis — summary/highlights required) ---
+
+export const resumeAnalysisValidator = v.object({
+    score: v.number(),
+    summary: v.string(),
+    highlights: v.array(v.string()),
+    recommendation: v.string(),
+    breakdown: v.optional(v.record(v.string(), v.number())),
+    jobDescriptionId: v.optional(v.string()),
+    promptVersion: v.optional(v.number()),
+    locale: v.optional(v.string()),
+    queryLocation: v.optional(v.string()),
+    analyzedAt: v.optional(v.number()),
+});
+
 // --- ResumeFilters (screening_sessions.config.filters, search_history.filters) ---
 
 export const resumeFiltersValidator = v.optional(v.object({


### PR DESCRIPTION
## Summary
- Replace `v.any()` on `restoreState.ingestData` with `ingestDataValidator`
- Replace `v.any()` on `restoreState.analysis` with `resumeAnalysisValidator` (new — matches schema's analysis field with required summary/highlights)
- Replace `v.any()` on `restoreState.analyses` with `v.record(v.string(), analysisResultValidator)`
- Add `resumeAnalysisValidator` to `validators.ts` matching the schema's `analysis` field

## Test plan
- [x] `make check` passes (typecheck + lint + governance)
- [x] Convex typecheck passes with new validators
- [ ] Verify restore/backup flow still works with typed restoreState