### PR TITLE
feat: type tagEnvelope validator (v.any() → tagged envelope shape)

### DIFF
--- a/packages/convex/convex/validators.ts
+++ b/packages/convex/convex/validators.ts
@@ -64,7 +64,21 @@ export const ingestDataValidator = v.object({
         })),
     })),
     // Legacy field: migrated to taggingEnvelope; retained for documents not yet migrated.
-    tagEnvelope: v.optional(v.any()),
+    tagEnvelope: v.optional(v.object({
+        schemaVersion: v.number(),
+        generatedAt: v.number(),
+        entries: v.array(v.object({
+            tag: v.string(),
+            source: v.string(),
+            confidence: v.number(),
+            version: v.number(),
+            provenance: v.object({
+                stage: v.string(),
+                generatedBy: v.string(),
+                evidence: v.array(v.string()),
+            }),
+        })),
+    })),
     ruleScores: v.record(v.string(), v.number()),
     experienceLevel: v.string(),
     computedAt: v.number(),


### PR DESCRIPTION
## Summary
- Replace `v.any()` on the legacy `tagEnvelope` field with the same typed validator as `taggingEnvelope`
- Both fields share the same data structure (schemaVersion, generatedAt, entries with tag/source/confidence/version/provenance)
- The only difference is the key name — `tagEnvelope` is the legacy name being migrated to `taggingEnvelope`

## Test plan
- [x] `make check` passes
- [x] Convex typecheck passes