### PR TITLE
fix: tagEnvelope validator must accept legacy array form

### DIFF
--- a/packages/convex/convex/validators.ts
+++ b/packages/convex/convex/validators.ts
@@ -64,21 +64,31 @@ export const ingestDataValidator = v.object({
         })),
     })),
     // Legacy field: migrated to taggingEnvelope; retained for documents not yet migrated.
-    tagEnvelope: v.optional(v.object({
-        schemaVersion: v.number(),
-        generatedAt: v.number(),
-        entries: v.array(v.object({
+    // Accepts both the canonical envelope shape and the legacy bare-array form.
+    tagEnvelope: v.optional(v.union(
+        v.object({
+            schemaVersion: v.number(),
+            generatedAt: v.number(),
+            entries: v.array(v.object({
+                tag: v.string(),
+                source: v.string(),
+                confidence: v.number(),
+                version: v.number(),
+                provenance: v.object({
+                    stage: v.string(),
+                    generatedBy: v.string(),
+                    evidence: v.array(v.string()),
+                }),
+            })),
+        }),
+        v.array(v.object({
             tag: v.string(),
             source: v.string(),
             confidence: v.number(),
             version: v.number(),
-            provenance: v.object({
-                stage: v.string(),
-                generatedBy: v.string(),
-                evidence: v.array(v.string()),
-            }),
+            evidence: v.optional(v.array(v.string())),
         })),
-    })),
+    )),
     ruleScores: v.record(v.string(), v.number()),
     experienceLevel: v.string(),
     computedAt: v.number(),


### PR DESCRIPTION
## Summary
- The `tagEnvelope` field historically had two shapes: canonical envelope object and legacy bare-array form
- Use `v.union()` to accept both, fixing 3 `backfillTaggingEnvelope` migration tests that insert legacy array data
- Without this fix, the typed validator from PR #1019 rejects the legacy array form

## Test plan
- [x] `vitest migrations-convex-test` — 48/48 pass
- [x] Full suite — 4,702/4,702 pass