### PR TITLE
feat: type search_profiles.ts profile args (2× v.any() eliminated)

### DIFF
--- a/packages/convex/convex/search_profiles.ts
+++ b/packages/convex/convex/search_profiles.ts
@@ -207,9 +207,12 @@ export const getById = query({
   },
 });
 
+/** Validator for the profile object passed to create/update. Accepts any plain key-value record. */
+const profileInputValidator = v.record(v.string(), v.any());
+
 export const create = mutation({
   args: {
-    profile: v.any(),
+    profile: profileInputValidator,
     workspaceSlug: v.optional(v.string()),
     jobDescriptionSync: v.optional(jobDescriptionSyncSchema),
   },
@@ -240,7 +243,7 @@ export const create = mutation({
 export const update = mutation({
   args: {
     id: v.string(),
-    profile: v.any(),
+    profile: profileInputValidator,
     workspaceSlug: v.optional(v.string()),
     jobDescriptionSync: v.optional(jobDescriptionSyncSchema),
   },


### PR DESCRIPTION
## Summary
- Replace `v.any()` on `create` and `update` profile args with `v.record(v.string(), v.any())`
- Constrains profile to plain objects (no null/array/primitive) while preserving flexibility for dynamic profile shapes
- Matches BFF `ProfilePayloadSchema = z.record(z.string(), z.unknown())` pattern

## Test plan
- [x] All 1,365 convex tests pass
- [x] All 16 search-profiles BFF tests pass
- [x] TypeScript compiles clean