### PR TITLE
feat: type workspace_config.ts configValue (1× v.any() eliminated)

### DIFF
--- a/packages/convex/convex/workspace_config.ts
+++ b/packages/convex/convex/workspace_config.ts
@@ -16,11 +16,23 @@ export const get = query({
     },
 });
 
+/**
+ * Validator for workspace config values. Accepts any JSON-compatible value
+ * except null: string, number, boolean, array, or record.
+ */
+const configValueValidator = v.union(
+    v.string(),
+    v.number(),
+    v.boolean(),
+    v.array(v.any()),
+    v.record(v.string(), v.any()),
+);
+
 export const upsert = mutation({
     args: {
         workspaceSlug: v.string(),
         configKey: v.string(),
-        configValue: v.any(),
+        configValue: configValueValidator,
     },
     handler: async (ctx, args) => {
         const existing = await ctx.db


### PR DESCRIPTION
## Summary
- Replace `v.any()` on upsert configValue arg with `v.union(v.string(), v.number(), v.boolean(), v.array(v.any()), v.record(v.string(), v.any()))`
- Constrains to JSON-compatible values (no null) while preserving flexibility
- Schema-level `v.any()` remains — requires migration to change

## Test plan
- [x] All 9 workspace-config convex tests pass
- [x] TypeScript compiles clean