### PR TITLE
feat: type resume content in resume_tasks + seed (2× v.any() eliminated)

### DIFF
--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -446,7 +446,7 @@ export const submitResumes = mutation({
         resumes: v.array(
             v.object({
                 externalId: v.string(),
-                content: v.any(),
+                content: v.record(v.string(), v.any()),
                 hash: v.string(),
                 source: v.string(),
                 tags: v.array(v.string()),

--- a/packages/convex/convex/seed.ts
+++ b/packages/convex/convex/seed.ts
@@ -246,7 +246,7 @@ export const seedResumes = mutation({
     resumes: v.array(
       v.object({
         externalId: v.string(),
-        content: v.any(),
+        content: v.record(v.string(), v.any()),
         hash: v.string(),
         source: v.string(),
         tags: v.array(v.string()),


### PR DESCRIPTION
## Summary
- Replace `v.any()` on `content` args in `resume_tasks.ts` submitResumes and `seed.ts` seedResumes with `v.record(v.string(), v.any())`
- Constrains to plain objects (no null/array/primitive) while preserving dynamic content shapes
- Schema-level `content: v.any()` remains — requires migration to change

## Test plan
- [x] All 1,372 convex tests pass
- [x] TypeScript compiles clean