### PR TITLE
feat: type schema-level v.any() fields (3× eliminated)

### DIFF
--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -530,7 +530,7 @@ export const submitResumes = mutation({
                         const patch: {
                             externalId: string;
                             identityKey: string;
-                            content: unknown;
+                            content: Record<string, any>;
                             hash: string;
                             crawledAt: number;
                             source: string;
@@ -600,7 +600,7 @@ export const submitResumes = mutation({
                     const insertPayload: {
                         externalId: string;
                         identityKey: string;
-                        content: unknown;
+                        content: Record<string, any>;
                         hash: string;
                         searchText: string;
                         tags: string[];

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -57,7 +57,7 @@ export default defineSchema({
         externalId: v.string(), // e.g. from job site
         identityKey: v.optional(v.string()),
         age: v.optional(v.number()),
-        content: v.any(), // JSON payload from crawler
+        content: v.record(v.string(), v.any()), // JSON payload from crawler
         hash: v.string(), // Content hash for change detection
         tags: v.array(v.string()), // e.g. search profile IDs
         crawledAt: v.number(),
@@ -132,7 +132,7 @@ export default defineSchema({
             keywords: v.array(v.string()),
             locations: v.array(v.string()),
         }),
-        profile: v.optional(v.any()),
+        profile: v.optional(v.record(v.string(), v.any())),
         lastRunAt: v.optional(v.number()),
         createdAt: v.optional(v.number()),
         updatedAt: v.optional(v.number()),
@@ -376,7 +376,7 @@ export default defineSchema({
     workspace_config: defineTable({
         workspaceSlug: v.string(),
         configKey: v.string(),
-        configValue: v.any(),
+        configValue: v.union(v.string(), v.number(), v.boolean(), v.array(v.any()), v.record(v.string(), v.any())),
         updatedAt: v.number(),
     })
         .index("by_workspace_key", ["workspaceSlug", "configKey"])


### PR DESCRIPTION
## Summary
- Replace 3 schema-level `v.any()` with typed validators:
  - `resumes.content` → `v.record(v.string(), v.any())` 
  - `search_profiles.profile` → `v.optional(v.record(v.string(), v.any()))`
  - `workspace_config.configValue` → `v.union(v.string(), v.number(), v.boolean(), v.array(v.any()), v.record(v.string(), v.any()))`
- Update `resume_tasks.ts` patch/insert payload types from `unknown` to `Record<string, any>` to match new schema type
- Backward-compatible: all existing data already conforms to the new types

## Remaining v.any()
- `analyze.ts:757` — `matchingRules: v.optional(v.any())` — **blocked** (Convex has no `v.unknown()`, values are heterogeneous)
- `migrations.ts` — comment-only references (not actual validators)

## Test plan
- [x] All 1,388 convex tests pass
- [x] TypeScript compiles clean