### PR TITLE
refactor: extract resumes-diagnostics.ts from resumes.ts

### DIFF
--- a/packages/convex/convex/__tests__/resume-tasks-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/resume-tasks-convex-test.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Additional convex-test integration tests for resume_tasks.ts.
+ *
+ * Covers endpoints not tested in tasks-convex-test.test.ts:
+ * - list, getById, failStalePending, getSummary, getSummaryWindow
+ * - submitResumes (full integration with schema validation)
+ */
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { api } from "../_generated/api.js";
+import schema from "../schema.js";
+
+const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
+
+// Helper: insert a minimal collection task
+async function insertTask(
+  t: ReturnType<typeof convexTest>,
+  overrides: Record<string, unknown> = {},
+) {
+  return t.run(async (ctx) => {
+    return ctx.db.insert("collection_tasks", {
+      config: { keyword: "test", location: "Shanghai", limit: 100 },
+      status: "pending",
+      progress: { current: 0, total: 0, page: 0 },
+      ...overrides,
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: list", () => {
+  it("returns pending and processing tasks", async () => {
+    const t = convexTest(schema, modules);
+
+    const id1 = await insertTask(t, { status: "pending" });
+    const id2 = await insertTask(t, { status: "processing", workerId: "w1", startedAt: Date.now() });
+
+    const tasks = await t.query(api.resume_tasks.list, {});
+
+    const ids = tasks.map((task) => task._id);
+    expect(ids).toContain(id1);
+    expect(ids).toContain(id2);
+  });
+
+  it("includes recent finished tasks", async () => {
+    const t = convexTest(schema, modules);
+
+    await insertTask(t, {
+      status: "completed",
+      completedAt: Date.now(),
+      progress: { current: 50, total: 50, page: 3 },
+    });
+
+    const tasks = await t.query(api.resume_tasks.list, {});
+    expect(tasks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("returns empty when no tasks exist", async () => {
+    const t = convexTest(schema, modules);
+
+    const tasks = await t.query(api.resume_tasks.list, {});
+    expect(tasks).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getById
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: getById", () => {
+  it("returns a task by ID", async () => {
+    const t = convexTest(schema, modules);
+
+    const taskId = await insertTask(t, { status: "pending" });
+
+    const task = await t.query(api.resume_tasks.getById, { taskId });
+    expect(task).not.toBeNull();
+    expect(task!._id).toBe(taskId);
+    expect(task!.status).toBe("pending");
+  });
+
+  it("returns null for non-existent task", async () => {
+    const t = convexTest(schema, modules);
+
+    // Create then delete to get an ID that returns null
+    const taskId = await insertTask(t, { status: "pending" });
+    await t.run(async (ctx) => { await ctx.db.delete(taskId); });
+
+    const task = await t.query(api.resume_tasks.getById, { taskId });
+    expect(task).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// failStalePending
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: failStalePending", () => {
+  it("fails stale pending tasks and reports counts", async () => {
+    const t = convexTest(schema, modules);
+
+    // Insert a pending task — failStalePending uses the by_status index
+    // with _creationTime filter. With staleMs=0, the threshold is now(),
+    // so any task created before "now" is eligible.
+    await insertTask(t, { status: "pending" });
+
+    const result = await t.mutation(api.resume_tasks.failStalePending, {
+      staleMs: 0,
+    });
+
+    // The task may or may not be picked up depending on _creationTime precision
+    // in convex-test. At minimum, the result structure should be valid.
+    expect(result).toHaveProperty("checked");
+    expect(result).toHaveProperty("failed");
+    expect(result).toHaveProperty("staleMs");
+    expect(result.staleMs).toBe(0);
+  });
+
+  it("does not fail recent pending tasks with large staleMs", async () => {
+    const t = convexTest(schema, modules);
+
+    await insertTask(t, { status: "pending" });
+
+    // Use a very large staleMs so nothing is stale
+    const result = await t.mutation(api.resume_tasks.failStalePending, {
+      staleMs: 999_999_999,
+    });
+
+    expect(result.failed).toBe(0);
+  });
+
+  it("does not fail tasks in non-pending statuses", async () => {
+    const t = convexTest(schema, modules);
+
+    await insertTask(t, { status: "processing", workerId: "w1", startedAt: Date.now() });
+    await insertTask(t, { status: "completed", completedAt: Date.now(), progress: { current: 50, total: 50, page: 3 } });
+
+    const result = await t.mutation(api.resume_tasks.failStalePending, {
+      staleMs: 0,
+    });
+
+    // failStalePending only queries by status "pending"
+    expect(result.failed).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSummary
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: getSummary", () => {
+  it("returns counts by status", async () => {
+    const t = convexTest(schema, modules);
+
+    await insertTask(t, { status: "pending" });
+    await insertTask(t, { status: "pending" });
+    await insertTask(t, {
+      status: "processing",
+      workerId: "w1",
+      startedAt: Date.now(),
+    });
+
+    const stats = await t.query(api.resume_tasks.getSummary, {});
+
+    expect(stats.pending).toBe(2);
+    expect(stats.processing).toBe(1);
+    expect(stats.total).toBe(3);
+    expect(stats.activeWorkers).toBe(1);
+  });
+
+  it("returns zeros when no tasks exist", async () => {
+    const t = convexTest(schema, modules);
+
+    const stats = await t.query(api.resume_tasks.getSummary, {});
+
+    expect(stats.total).toBe(0);
+    expect(stats.pending).toBe(0);
+    expect(stats.processing).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSummaryWindow
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: getSummaryWindow", () => {
+  it("returns tasks completed within time window", async () => {
+    const t = convexTest(schema, modules);
+
+    const now = Date.now();
+    await insertTask(t, {
+      status: "completed",
+      completedAt: now,
+      progress: { current: 50, total: 50, page: 3 },
+    });
+
+    const result = await t.query(api.resume_tasks.getSummaryWindow, {
+      fromTimestamp: now - 60_000,
+      toTimestamp: now + 60_000,
+    });
+
+    expect(result.total).toBeGreaterThanOrEqual(1);
+    const completedEntry = result.byStatus.find((e) => e.key === "completed");
+    expect(completedEntry?.count).toBeGreaterThanOrEqual(1);
+  });
+
+  it("returns empty when no tasks in window", async () => {
+    const t = convexTest(schema, modules);
+
+    const now = Date.now();
+    const result = await t.query(api.resume_tasks.getSummaryWindow, {
+      fromTimestamp: now - 60_000,
+      toTimestamp: now + 60_000,
+    });
+
+    expect(result.total).toBe(0);
+    expect(result.byStatus).toHaveLength(0);
+  });
+
+  it("sorts byStatus by count descending", async () => {
+    const t = convexTest(schema, modules);
+
+    const now = Date.now();
+    // Insert 2 completed, 1 failed
+    await insertTask(t, {
+      status: "completed",
+      completedAt: now,
+      progress: { current: 50, total: 50, page: 3 },
+    });
+    await insertTask(t, {
+      status: "completed",
+      completedAt: now,
+      progress: { current: 50, total: 50, page: 3 },
+    });
+    await insertTask(t, {
+      status: "failed",
+      completedAt: now,
+      error: "test failure",
+      progress: { current: 10, total: 50, page: 1 },
+    });
+
+    const result = await t.query(api.resume_tasks.getSummaryWindow, {
+      fromTimestamp: now - 60_000,
+      toTimestamp: now + 60_000,
+    });
+
+    expect(result.byStatus.length).toBeGreaterThan(0);
+    if (result.byStatus.length >= 2) {
+      expect(result.byStatus[0].count).toBeGreaterThanOrEqual(result.byStatus[1].count);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitResumes (full convex-test integration)
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: submitResumes", () => {
+  it("inserts new resumes and returns counts", async () => {
+    const t = convexTest(schema, modules);
+
+    const result = await t.mutation(api.resume_tasks.submitResumes, {
+      resumes: [
+        {
+          externalId: "ext-new-1",
+          content: { name: "Alice", title: "Engineer" },
+          hash: "hash-1",
+          source: "test",
+          tags: ["engineering"],
+        },
+      ],
+    });
+
+    expect(result.input).toBe(1);
+    expect(result.inserted).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(result.unchanged).toBe(0);
+  });
+
+  it("updates existing resume when hash changes", async () => {
+    const t = convexTest(schema, modules);
+
+    // First submission
+    await t.mutation(api.resume_tasks.submitResumes, {
+      resumes: [
+        {
+          externalId: "ext-update-1",
+          content: { name: "Bob" },
+          hash: "hash-v1",
+          source: "test",
+          tags: ["sales"],
+        },
+      ],
+    });
+
+    // Second submission with changed hash
+    const result = await t.mutation(api.resume_tasks.submitResumes, {
+      resumes: [
+        {
+          externalId: "ext-update-1",
+          content: { name: "Bob", title: "Senior Sales" },
+          hash: "hash-v2",
+          source: "test",
+          tags: ["sales", "senior"],
+        },
+      ],
+    });
+
+    expect(result.inserted).toBe(0);
+    expect(result.updated).toBe(1);
+    expect(result.unchanged).toBe(0);
+  });
+
+  it("marks unchanged when hash matches and no tag changes", async () => {
+    const t = convexTest(schema, modules);
+
+    // First submission
+    await t.mutation(api.resume_tasks.submitResumes, {
+      resumes: [
+        {
+          externalId: "ext-unchanged-1",
+          content: { name: "Carol" },
+          hash: "hash-same",
+          source: "test",
+          tags: ["marketing"],
+        },
+      ],
+    });
+
+    // Second submission with same hash and same tags
+    const result = await t.mutation(api.resume_tasks.submitResumes, {
+      resumes: [
+        {
+          externalId: "ext-unchanged-1",
+          content: { name: "Carol" },
+          hash: "hash-same",
+          source: "test",
+          tags: ["marketing"],
+        },
+      ],
+    });
+
+    expect(result.unchanged).toBe(1);
+    expect(result.updated).toBe(0);
+  });
+
+  it("merges tags from incoming resume", async () => {
+    const t = convexTest(schema, modules);
+
+    // First submission
+    await t.mutation(api.resume_tasks.submitResumes, {
+      resumes: [
+        {
+          externalId: "ext-tags-1",
+          content: { name: "Dave" },
+          hash: "hash-tags-v1",
+          source: "test",
+          tags: ["python"],
+        },
+      ],
+    });
+
+    // Second submission with new hash and extra tags
+    await t.mutation(api.resume_tasks.submitResumes, {
+      resumes: [
+        {
+          externalId: "ext-tags-1",
+          content: { name: "Dave" },
+          hash: "hash-tags-v2",
+          source: "test",
+          tags: ["django"],
+        },
+      ],
+    });
+
+    // Verify tags are merged
+    const resumes = await t.run(async (ctx) => {
+      return ctx.db
+        .query("resumes")
+        .withIndex("by_externalId", (q) => q.eq("externalId", "ext-tags-1"))
+        .unique();
+    });
+
+    expect(resumes!.tags).toContain("python");
+    expect(resumes!.tags).toContain("django");
+  });
+
+  it("preserves restoreState for migrated resumes", async () => {
+    const t = convexTest(schema, modules);
+
+    const result = await t.mutation(api.resume_tasks.submitResumes, {
+      resumes: [
+        {
+          externalId: "ext-restore-1",
+          content: { name: "Eve" },
+          hash: "hash-restore-1",
+          source: "test",
+          tags: ["engineering"],
+          restoreState: {
+            crawledAt: 1700000000000,
+            isArchived: true,
+            archivedAt: 1700000000000,
+            primaryRuleScore: 85,
+          },
+        },
+      ],
+    });
+
+    expect(result.inserted).toBe(1);
+
+    const resumes = await t.run(async (ctx) => {
+      return ctx.db
+        .query("resumes")
+        .withIndex("by_externalId", (q) => q.eq("externalId", "ext-restore-1"))
+        .unique();
+    });
+
+    expect(resumes!.isArchived).toBe(true);
+    expect(resumes!.archivedAt).toBe(1700000000000);
+    expect(resumes!.crawledAt).toBe(1700000000000);
+    expect(resumes!.primaryRuleScore).toBe(85);
+  });
+
+  it("deduplicates resumes with same identity within batch", async () => {
+    const t = convexTest(schema, modules);
+
+    const result = await t.mutation(api.resume_tasks.submitResumes, {
+      resumes: [
+        {
+          externalId: "ext-dedup-1",
+          content: { name: "Frank" },
+          hash: "hash-dedup-1",
+          source: "test",
+          tags: [],
+        },
+        {
+          externalId: "ext-dedup-1",
+          content: { name: "Frank" },
+          hash: "hash-dedup-1",
+          source: "test",
+          tags: [],
+        },
+      ],
+    });
+
+    // Second entry is deduped (same externalId → same identityKey)
+    expect(result.identityDeduped).toBe(1);
+    expect(result.submitted).toBe(1);
+    expect(result.inserted).toBe(1);
+  });
+
+  it("creates a sync event on submission", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.resume_tasks.submitResumes, {
+      resumes: [
+        {
+          externalId: "ext-sync-1",
+          content: { name: "Grace" },
+          hash: "hash-sync-1",
+          source: "test",
+          tags: [],
+        },
+      ],
+    });
+
+    const events = await t.run(async (ctx) => {
+      return ctx.db.query("sync_events").collect();
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].source).toBe("browser-extension");
+    expect(events[0].status).toBe("success");
+    expect(events[0].inserted).toBe(1);
+  });
+
+  it("handles batch of 5 resumes", async () => {
+    const t = convexTest(schema, modules);
+
+    const resumes = Array.from({ length: 5 }, (_, i) => ({
+      externalId: `ext-batch5-${i}`,
+      content: { name: `Batch User ${i}` },
+      hash: `hash-batch5-${i}`,
+      source: "test",
+      tags: [],
+    }));
+
+    const result = await t.mutation(api.resume_tasks.submitResumes, {
+      resumes,
+    });
+
+    expect(result.input).toBe(5);
+    expect(result.inserted).toBe(5);
+  });
+});

--- a/packages/convex/convex/lib/resumes_diagnostics.ts
+++ b/packages/convex/convex/lib/resumes_diagnostics.ts
@@ -1,0 +1,232 @@
+/**
+ * Diagnostics helpers extracted from resumes.ts.
+ *
+ * Pure functions for resolving diagnostics source keys, building facet rows,
+ * and projecting ingest diagnostics data for UI display.
+ */
+import type { Doc } from "../_generated/dataModel";
+import {
+    normalizeResumeLocationHierarchy,
+    resolveResumeDiagnosticsSourceKey,
+    isRecord,
+    formatLocationHierarchyLabel,
+} from "@trends/shared";
+import {
+    toStringValue,
+    toOptionalStringValue,
+    toRuleScores,
+} from "../resume_helpers.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type IngestDiagnosticsBrandHit = {
+    brand: string;
+    role: string;
+    source: string;
+    context: string;
+};
+
+export type IngestDiagnosticsTaggingEntry = {
+    tag: string;
+    source: string;
+    confidence: number;
+    provenance: {
+        stage: string;
+        evidence: string[];
+    };
+};
+
+export type IngestDiagnosticsRow = {
+    resumeId: string;
+    externalId: string;
+    source: string;
+    sourceKey: string;
+    name: string;
+    jobIntention: string;
+    location: string;
+    isArchived?: boolean;
+    archivedAt?: number;
+    ingestData?: {
+        industryTags: string[];
+        companyHits: string[];
+        brandHits: IngestDiagnosticsBrandHit[];
+        experienceLevel: string;
+        ruleScoreCount: number;
+        computedAt: number;
+        skillsVersion: number;
+        taggingEntries: IngestDiagnosticsTaggingEntry[];
+    };
+};
+
+export type DiagnosticsSourceFacetRow = {
+    key: string;
+    label: string;
+    count: number;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const MAX_INGEST_DIAGNOSTICS_PAGE_SIZE = 100;
+export const MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES = 8;
+export const DIAGNOSTICS_SOURCE_FILTER_BATCH_MULTIPLIER = 3;
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+function countRuleScores(value: unknown): number {
+    return Object.keys(toRuleScores(value)).length;
+}
+
+function resolveDiagnosticsSourceLabel(sourceKey: string): string {
+    switch (sourceKey) {
+        case "job5156":
+            return "Job5156";
+        case "51job":
+            return "51job";
+        case "51job-manual":
+            return "51job manual";
+        case "seek":
+            return "SEEK";
+        default:
+            return "Unknown";
+    }
+}
+
+function projectIngestDiagnosticsBrandHits(
+    brandHits: NonNullable<Doc<"resumes">["ingestData"]>["brandHits"]
+): IngestDiagnosticsBrandHit[] {
+    return (brandHits ?? []).map((hit) => ({
+        brand: hit.brand,
+        role: hit.role,
+        source: hit.source,
+        context: hit.context,
+    }));
+}
+
+function projectIngestDiagnosticsTaggingEntries(
+    taggingEnvelope: NonNullable<Doc<"resumes">["ingestData"]>["taggingEnvelope"]
+): IngestDiagnosticsTaggingEntry[] {
+    return taggingEnvelope?.entries.slice(0, MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES).map((entry) => ({
+        tag: entry.tag,
+        source: entry.source,
+        confidence: entry.confidence,
+        provenance: {
+            stage: entry.provenance.stage,
+            evidence: entry.provenance.evidence,
+        },
+    })) ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Exported helpers
+// ---------------------------------------------------------------------------
+
+export function resolveDiagnosticsSourceKeyForResume(
+    resume: {
+        source: string;
+        content: unknown;
+    }
+): string {
+    const content = isRecord(resume.content) ? resume.content : {};
+    return resolveResumeDiagnosticsSourceKey({
+        sourceKey: toOptionalStringValue(content.profileType),
+        source: resume.source,
+    });
+}
+
+export function normalizeDiagnosticsSourceFilterValues(values: string[] | undefined): string[] | undefined {
+    if (!Array.isArray(values)) {
+        return undefined;
+    }
+
+    const normalized = Array.from(new Set(values
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0)
+        .map((value) => resolveResumeDiagnosticsSourceKey({ sourceKey: value, source: value }))
+    ));
+
+    return normalized.length > 0 ? normalized : undefined;
+}
+
+export function matchesDiagnosticsSourceKeys(
+    resume: {
+        source: string;
+        content: unknown;
+        sourceKey?: string;
+    },
+    sourceKeys: Set<string> | undefined
+): boolean {
+    if (!sourceKeys || sourceKeys.size === 0) {
+        return true;
+    }
+
+    const key = resume.sourceKey ?? resolveDiagnosticsSourceKeyForResume(resume);
+    return sourceKeys.has(key);
+}
+
+export function buildDiagnosticsSourceFacetRows(
+    input: Array<{ source: string; content: unknown }> | Map<string, number>
+): DiagnosticsSourceFacetRow[] {
+    const counts = input instanceof Map ? input : new Map<string, number>();
+
+    if (Array.isArray(input)) {
+        for (const resume of input) {
+            const sourceKey = resolveDiagnosticsSourceKeyForResume(resume);
+            counts.set(sourceKey, (counts.get(sourceKey) ?? 0) + 1);
+        }
+    }
+
+    return Array.from(counts.entries())
+        .map(([key, count]) => ({
+            key,
+            label: resolveDiagnosticsSourceLabel(key),
+            count,
+        }))
+        .sort((left, right) => right.count - left.count || left.key.localeCompare(right.key));
+}
+
+export function projectIngestDiagnosticsRow(
+    resume: {
+        _id: string;
+        externalId: string;
+        source: string;
+        content: unknown;
+        sourceKey?: string;
+        ingestData?: Doc<"resumes">["ingestData"];
+        isArchived?: boolean;
+        archivedAt?: number;
+    }
+): IngestDiagnosticsRow {
+    const content = isRecord(resume.content) ? resume.content : {};
+    const ingestData = resume.ingestData;
+    const locationHierarchy = normalizeResumeLocationHierarchy(content, resume.source);
+
+    return {
+        resumeId: resume._id,
+        externalId: resume.externalId,
+        source: resume.source,
+        sourceKey: resume.sourceKey ?? resolveDiagnosticsSourceKeyForResume({
+            source: resume.source,
+            content: resume.content,
+        }),
+        name: toStringValue(content.name),
+        jobIntention: toStringValue(content.jobIntention),
+        location: toStringValue(content.location) || formatLocationHierarchyLabel(locationHierarchy),
+        ...(resume.isArchived === true ? { isArchived: true, archivedAt: resume.archivedAt } : {}),
+        ingestData: ingestData ? {
+            industryTags: ingestData.industryTags,
+            companyHits: ingestData.companyHits ?? [],
+            brandHits: projectIngestDiagnosticsBrandHits(ingestData.brandHits),
+            experienceLevel: ingestData.experienceLevel,
+            ruleScoreCount: countRuleScores(ingestData.ruleScores),
+            computedAt: ingestData.computedAt,
+            skillsVersion: ingestData.skillsVersion,
+            taggingEntries: projectIngestDiagnosticsTaggingEntries(ingestData.taggingEnvelope),
+        } : undefined,
+    };
+}

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -11,7 +11,6 @@ import {
     computeVerifiedRoleYears,
     computeExperienceFromWorkHistory,
     formatLocationHierarchySearchText,
-    formatLocationHierarchyLabel,
     getVerifiedRoleSignalYears,
     isResumeAnalysisKeyForJobDescription,
     isLocationMatch,
@@ -19,7 +18,6 @@ import {
     normalizeKeywordPhrases,
     normalizeEducationLevel,
     resolveExperienceYears,
-    resolveResumeDiagnosticsSourceKey,
     normalizeResumeLocationHierarchy,
     resolveResumeAnalysisSourceKey,
     selectLatestWorkHistory,
@@ -41,6 +39,20 @@ import {
     splitQueryTokens,
     matchesAllTokens,
 } from "./resume_helpers.js";
+import {
+    resolveDiagnosticsSourceKeyForResume,
+    matchesDiagnosticsSourceKeys,
+    buildDiagnosticsSourceFacetRows,
+    projectIngestDiagnosticsRow,
+    normalizeDiagnosticsSourceFilterValues,
+    MAX_INGEST_DIAGNOSTICS_PAGE_SIZE,
+    MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES,
+    DIAGNOSTICS_SOURCE_FILTER_BATCH_MULTIPLIER,
+    type IngestDiagnosticsBrandHit,
+    type IngestDiagnosticsTaggingEntry,
+    type IngestDiagnosticsRow,
+    type DiagnosticsSourceFacetRow,
+} from "./lib/resumes_diagnostics.js";
 
 // Re-export for backward compatibility
 export {
@@ -55,6 +67,21 @@ export {
     splitQueryTokens,
     matchesAllTokens,
 } from "./resume_helpers.js";
+
+// Re-export diagnostics helpers for backward compatibility
+export {
+    resolveDiagnosticsSourceKeyForResume,
+    matchesDiagnosticsSourceKeys,
+    buildDiagnosticsSourceFacetRows,
+    projectIngestDiagnosticsRow,
+    normalizeDiagnosticsSourceFilterValues,
+} from "./lib/resumes_diagnostics.js";
+export type {
+    IngestDiagnosticsRow,
+    DiagnosticsSourceFacetRow,
+    IngestDiagnosticsBrandHit,
+    IngestDiagnosticsTaggingEntry,
+} from "./lib/resumes_diagnostics.js";
 
 function getIngestRuleScore(resume: Doc<"resumes">, jobDescriptionId: string | undefined): number {
     const ruleScores = toRuleScores(resume.ingestData?.ruleScores);
@@ -97,57 +124,12 @@ type SearchProvenance = {
     expandedFrom?: string;
 };
 
-type IngestDiagnosticsBrandHit = {
-    brand: string;
-    role: string;
-    source: string;
-    context: string;
-};
-
-type IngestDiagnosticsTaggingEntry = {
-    tag: string;
-    source: string;
-    confidence: number;
-    provenance: {
-        stage: string;
-        evidence: string[];
-    };
-};
-
-export type IngestDiagnosticsRow = {
-    resumeId: string;
-    externalId: string;
-    source: string;
-    sourceKey: string;
-    name: string;
-    jobIntention: string;
-    location: string;
-    isArchived?: boolean;
-    archivedAt?: number;
-    ingestData?: {
-        industryTags: string[];
-        companyHits: string[];
-        brandHits: IngestDiagnosticsBrandHit[];
-        experienceLevel: string;
-        ruleScoreCount: number;
-        computedAt: number;
-        skillsVersion: number;
-        taggingEntries: IngestDiagnosticsTaggingEntry[];
-    };
-};
-
 export type ResumeScanRow = {
     _id: Doc<"resumes">["_id"];
     content: Doc<"resumes">["content"];
     ingestData: Doc<"resumes">["ingestData"];
     primaryRuleScore: Doc<"resumes">["primaryRuleScore"];
     searchText: Doc<"resumes">["searchText"];
-};
-
-export type DiagnosticsSourceFacetRow = {
-    key: string;
-    label: string;
-    count: number;
 };
 
 export type ResumeUsageScanRow = {
@@ -344,9 +326,6 @@ const MAX_SAFE_SEARCH_PAGINATE_SCAN_UNFILTERED = 16;
 // Convex search index scans up to 1024 results; 1024 × 27KB = 27MB > 16 MiB.
 // Cap .take() path to 400 docs × 30KB = ~12MB, safely under 16 MiB limit.
 const MAX_SAFE_SEARCH_TAKE_LIMIT = 400;
-const MAX_INGEST_DIAGNOSTICS_PAGE_SIZE = 100;
-const MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES = 8;
-const DIAGNOSTICS_SOURCE_FILTER_BATCH_MULTIPLIER = 3;
 const DEFAULT_RESUME_SCAN_BATCH_SIZE = 25;
 const MAX_RESUME_SCAN_BATCH_SIZE = 50;
 const DEFAULT_RESUME_BACKUP_PAGE_SIZE = 25;
@@ -368,114 +347,6 @@ function dedupeProvenance(items: SearchProvenance[]): SearchProvenance[] {
     return deduped;
 }
 
-function countRuleScores(value: unknown): number {
-    return Object.keys(toRuleScores(value)).length;
-}
-
-function projectIngestDiagnosticsBrandHits(
-    brandHits: NonNullable<Doc<"resumes">["ingestData"]>["brandHits"]
-): IngestDiagnosticsBrandHit[] {
-    return (brandHits ?? []).map((hit) => ({
-        brand: hit.brand,
-        role: hit.role,
-        source: hit.source,
-        context: hit.context,
-    }));
-}
-
-function projectIngestDiagnosticsTaggingEntries(
-    taggingEnvelope: NonNullable<Doc<"resumes">["ingestData"]>["taggingEnvelope"]
-): IngestDiagnosticsTaggingEntry[] {
-    return taggingEnvelope?.entries.slice(0, MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES).map((entry) => ({
-        tag: entry.tag,
-        source: entry.source,
-        confidence: entry.confidence,
-        provenance: {
-            stage: entry.provenance.stage,
-            evidence: entry.provenance.evidence,
-        },
-    })) ?? [];
-}
-
-function normalizeDiagnosticsSourceFilterValues(values: string[] | undefined): string[] | undefined {
-    if (!Array.isArray(values)) {
-        return undefined;
-    }
-
-    const normalized = Array.from(new Set(values
-        .map((value) => value.trim())
-        .filter((value) => value.length > 0)
-        .map((value) => resolveResumeDiagnosticsSourceKey({ sourceKey: value, source: value }))
-    ));
-
-    return normalized.length > 0 ? normalized : undefined;
-}
-
-export function resolveDiagnosticsSourceKeyForResume(
-    resume: {
-        source: string;
-        content: unknown;
-    }
-): string {
-    const content = isRecord(resume.content) ? resume.content : {};
-    return resolveResumeDiagnosticsSourceKey({
-        sourceKey: toOptionalStringValue(content.profileType),
-        source: resume.source,
-    });
-}
-
-function resolveDiagnosticsSourceLabel(sourceKey: string): string {
-    switch (sourceKey) {
-        case "job5156":
-            return "Job5156";
-        case "51job":
-            return "51job";
-        case "51job-manual":
-            return "51job manual";
-        case "seek":
-            return "SEEK";
-        default:
-            return "Unknown";
-    }
-}
-
-export function matchesDiagnosticsSourceKeys(
-    resume: {
-        source: string;
-        content: unknown;
-        sourceKey?: string;
-    },
-    sourceKeys: Set<string> | undefined
-): boolean {
-    if (!sourceKeys || sourceKeys.size === 0) {
-        return true;
-    }
-
-    const key = resume.sourceKey ?? resolveDiagnosticsSourceKeyForResume(resume);
-    return sourceKeys.has(key);
-}
-
-export function buildDiagnosticsSourceFacetRows(
-    input: Array<{ source: string; content: unknown }> | Map<string, number>
-): DiagnosticsSourceFacetRow[] {
-    const counts = input instanceof Map ? input : new Map<string, number>();
-
-    if (Array.isArray(input)) {
-        for (const resume of input) {
-            const sourceKey = resolveDiagnosticsSourceKeyForResume(resume);
-            counts.set(sourceKey, (counts.get(sourceKey) ?? 0) + 1);
-        }
-    }
-
-    return Array.from(counts.entries())
-        .map(([key, count]) => ({
-            key,
-            label: resolveDiagnosticsSourceLabel(key),
-            count,
-        }))
-        .sort((left, right) => right.count - left.count || left.key.localeCompare(right.key));
-}
-
 function normalizeRequestedResumeIds(resumeIds: string[]): string[] {
     const normalizedIds: string[] = [];
     const seen = new Set<string>();
@@ -490,47 +361,6 @@ function normalizeRequestedResumeIds(resumeIds: string[]): string[] {
     }
 
     return normalizedIds;
-}
-
-export function projectIngestDiagnosticsRow(
-    resume: {
-        _id: string;
-        externalId: string;
-        source: string;
-        content: unknown;
-        sourceKey?: string;
-        ingestData?: Doc<"resumes">["ingestData"];
-        isArchived?: boolean;
-        archivedAt?: number;
-    }
-): IngestDiagnosticsRow {
-    const content = isRecord(resume.content) ? resume.content : {};
-    const ingestData = resume.ingestData;
-    const locationHierarchy = normalizeResumeLocationHierarchy(content, resume.source);
-
-    return {
-        resumeId: resume._id,
-        externalId: resume.externalId,
-        source: resume.source,
-        sourceKey: resume.sourceKey ?? resolveDiagnosticsSourceKeyForResume({
-            source: resume.source,
-            content: resume.content,
-        }),
-        name: toStringValue(content.name),
-        jobIntention: toStringValue(content.jobIntention),
-        location: toStringValue(content.location) || formatLocationHierarchyLabel(locationHierarchy),
-        ...(resume.isArchived === true ? { isArchived: true, archivedAt: resume.archivedAt } : {}),
-        ingestData: ingestData ? {
-            industryTags: ingestData.industryTags,
-            companyHits: ingestData.companyHits ?? [],
-            brandHits: projectIngestDiagnosticsBrandHits(ingestData.brandHits),
-            experienceLevel: ingestData.experienceLevel,
-            ruleScoreCount: countRuleScores(ingestData.ruleScores),
-            computedAt: ingestData.computedAt,
-            skillsVersion: ingestData.skillsVersion,
-            taggingEntries: projectIngestDiagnosticsTaggingEntries(ingestData.taggingEnvelope),
-        } : undefined,
-    };
 }
 
 export function resolveListWithIngestWindow(requestedLimit: number | undefined): {


### PR DESCRIPTION
## Summary
- Extract diagnostics types and helpers from resumes.ts (3365L) into `lib/resumes_diagnostics.ts` (232L)
- Moved: `IngestDiagnosticsRow`, `DiagnosticsSourceFacetRow`, `IngestDiagnosticsBrandHit`, `IngestDiagnosticsTaggingEntry` types
- Moved: `resolveDiagnosticsSourceKeyForResume`, `matchesDiagnosticsSourceKeys`, `buildDiagnosticsSourceFacetRows`, `projectIngestDiagnosticsRow`, `normalizeDiagnosticsSourceFilterValues` functions
- All moved symbols re-exported from resumes.ts for backward compatibility
- resumes.ts reduced from 3365 → 3195 lines (5%)

## Test plan
- [x] TypeScript typecheck passes
- [x] All 1,409 convex tests pass
- [x] Full suite: 4,794 passing / 265 files