### PR TITLE
feat: wire setAuditOutcome into confirm flow (EU AI Act Art. 14)

### DIFF
--- a/packages/convex/convex/__tests__/audit-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/audit-convex-test.test.ts
@@ -586,7 +586,7 @@ describe("audit (convex-test)", () => {
         });
       });
 
-      await t.mutation(internal.audit.setAuditOutcome, {
+      await t.mutation(api.audit.setAuditOutcome, {
         auditLogId: logId,
         outcome: "accepted",
         setBy: "admin_abc",
@@ -629,7 +629,7 @@ describe("audit (convex-test)", () => {
         });
       });
 
-      await t.mutation(internal.audit.setAuditOutcome, {
+      await t.mutation(api.audit.setAuditOutcome, {
         auditLogId: logId,
         outcome: "overridden",
         setBy: "operator_xyz",
@@ -670,7 +670,7 @@ describe("audit (convex-test)", () => {
         });
       });
 
-      await t.mutation(internal.audit.setAuditOutcome, {
+      await t.mutation(api.audit.setAuditOutcome, {
         auditLogId: logId,
         outcome: "appealed",
       });
@@ -1032,6 +1032,85 @@ describe("audit log retention (EU AI Act / GDPR)", () => {
         return ctx.db.get(logId);
       });
       expect(after).toBeNull();
+    });
+  });
+
+  describe("logAnalysisDecision returns audit log ID", () => {
+    it("returns the created audit log document ID", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "return-id-r1",
+          content: {},
+          hash: "return-id1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+      });
+
+      const auditLogId = await t.mutation(internal.audit.logAnalysisDecision, {
+        resumeId,
+        workspaceSlug: "ws-return-id",
+        decisionType: "confirm",
+        actionRef: "analyze:confirmSearchResults",
+        inputSnapshot: {},
+        modelMeta: { model: "gpt-4", provider: "openai" },
+        output: { score: 90, recommendation: "strong_match" },
+        decidedAt: Date.now(),
+      });
+
+      expect(auditLogId).toBeDefined();
+
+      const log = await t.run(async (ctx) => ctx.db.get(auditLogId));
+      expect(log).toBeDefined();
+      expect(log!.decisionType).toBe("confirm");
+      expect(log!.outcome).toBe("pending");
+    });
+
+    it("supports confirm-then-set-outcome flow", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "confirm-flow-r1",
+          content: {},
+          hash: "confirm-flow1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+      });
+
+      // Simulate the confirm flow: logAnalysisDecision then setAuditOutcome
+      const auditLogId = await t.mutation(internal.audit.logAnalysisDecision, {
+        resumeId,
+        workspaceSlug: "ws-confirm-flow",
+        decisionType: "confirm",
+        actionRef: "analyze:confirmSearchResults",
+        inputSnapshot: {},
+        modelMeta: { model: "gpt-4", provider: "openai" },
+        output: { score: 90, recommendation: "strong_match" },
+        decidedAt: Date.now(),
+      });
+
+      // Verify initial state is "pending"
+      const beforeSet = await t.run(async (ctx) => ctx.db.get(auditLogId));
+      expect(beforeSet!.outcome).toBe("pending");
+
+      // Set outcome to "accepted" (mimics the automatic wiring in confirmSearchResults)
+      await t.mutation(api.audit.setAuditOutcome, {
+        auditLogId,
+        outcome: "accepted",
+        setBy: "system:confirmSearchResults",
+      });
+
+      const afterSet = await t.run(async (ctx) => ctx.db.get(auditLogId));
+      expect(afterSet!.outcome).toBe("accepted");
+      expect(afterSet!.outcomeSetBy).toBe("system:confirmSearchResults");
+      expect(afterSet!.outcomeSetAt).toBeDefined();
+      expect(afterSet!.reviewedAt).toBeDefined();
     });
   });
 });

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -654,7 +654,7 @@ export const confirmSearchResults = action({
                 try {
                     const { scrubbedFields, protectedHashes } = computeAuditFields(resume as Record<string, unknown>);
 
-                    await ctx.runMutation(internal.audit.logAnalysisDecision, {
+                    const auditLogId = await ctx.runMutation(internal.audit.logAnalysisDecision, {
                         resumeId,
                         identityKey: resume.identityKey ?? undefined,
                         workspaceSlug: args.workspaceId,
@@ -686,6 +686,13 @@ export const confirmSearchResults = action({
                         decidedAt: Date.now(),
                         actorId: "system",
                         actorRole: "system",
+                    });
+
+                    // Mark confirm audit outcome as accepted — human confirmed the decision
+                    await ctx.runMutation(api.audit.setAuditOutcome, {
+                        auditLogId,
+                        outcome: "accepted",
+                        setBy: "system:confirmSearchResults",
                     });
                 } catch (auditError) {
                     // Audit logging failure must NOT block the confirm result

--- a/packages/convex/convex/audit.ts
+++ b/packages/convex/convex/audit.ts
@@ -1,6 +1,6 @@
-import { internalMutation, internalQuery, internalAction, query } from "./_generated/server";
+import { internalMutation, internalQuery, internalAction, query, mutation } from "./_generated/server";
 import { internal } from "./_generated/api";
-import type { Doc } from "./_generated/dataModel";
+import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { fnvHash, ageToBracket } from "./lib/bias_metrics.js";
 
@@ -69,8 +69,8 @@ export const logAnalysisDecision = internalMutation({
             v.literal("system"),
         )),
     },
-    handler: async (ctx, args) => {
-        await ctx.db.insert("analysis_audit_log", {
+    handler: async (ctx, args): Promise<Id<"analysis_audit_log">> => {
+        const auditLogId = await ctx.db.insert("analysis_audit_log", {
             resumeId: args.resumeId,
             identityKey: args.identityKey,
             workspaceSlug: args.workspaceSlug,
@@ -87,6 +87,7 @@ export const logAnalysisDecision = internalMutation({
             actorId: args.actorId,
             actorRole: args.actorRole,
         });
+        return auditLogId;
     },
 });
 
@@ -127,10 +128,10 @@ export const getExplanationForCandidate = query({
 });
 
 // ---------------------------------------------------------------------------
-// Public mutation: setAuditOutcome
+// Public mutation: setAuditOutcome (also callable from BFF for human oversight)
 // ---------------------------------------------------------------------------
 
-export const setAuditOutcome = internalMutation({
+export const setAuditOutcome = mutation({
     args: {
         auditLogId: v.id("analysis_audit_log"),
         outcome: v.union(


### PR DESCRIPTION
## Summary
- `logAnalysisDecision` now returns the audit log document ID (`Id<"analysis_audit_log">`)
- `confirmSearchResults` automatically calls `setAuditOutcome` with outcome `"accepted"` after logging the confirm decision — ensures human-confirmed decisions have their audit trail outcome updated from "pending"
- Changed `setAuditOutcome` from `internalMutation` to public `mutation` so the BFF endpoint `POST /api/resumes/audit-outcome` can call it directly for human override/appeal actions
- Added 2 convex-test integration tests: logAnalysisDecision returns ID, confirm-then-set-outcome flow

## EU AI Act Compliance
This addresses the gap identified in the Cycle 6 research: `setAuditOutcome` had zero production callers, meaning audit log entries were stuck at `outcome: "pending"` forever. Now:
- **Confirm decisions** → outcome auto-set to `"accepted"` (system-initiated)
- **BFF endpoint** → operators can set `"overridden"` or `"appealed"` via `POST /api/resumes/audit-outcome`
- **Score/tag decisions** → remain `"pending"` awaiting human review (correct per Art. 14)

## Test plan
- [x] `npx vitest run packages/convex/` — 74 files, 1477 tests passing
- [x] `npx tsc --noEmit --project packages/convex/tsconfig.json` — clean
- [x] New tests: logAnalysisDecision returns ID, confirm-then-set-outcome flow