### PR TITLE
test: add unit tests for 5 untested lib modules (+74 tests)

### DIFF
--- a/packages/convex/convex/__tests__/ai_model.test.ts
+++ b/packages/convex/convex/__tests__/ai_model.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for lib/ai_model.ts
+ */
+import { describe, expect, it, vi } from "vitest";
+import { resolveChatCompletionModel, warnUnknownModel } from "../lib/ai_model.js";
+
+describe("resolveChatCompletionModel", () => {
+    it("strips provider prefix", () => {
+        expect(resolveChatCompletionModel("https://api.example.com", "openai/gpt-4o")).toBe("gpt-4o");
+        expect(resolveChatCompletionModel("https://api.example.com", "deepseek/deepseek-chat")).toBe("deepseek-chat");
+    });
+
+    it("returns model unchanged when no slash", () => {
+        expect(resolveChatCompletionModel("https://api.example.com", "gpt-4o")).toBe("gpt-4o");
+    });
+
+    it("returns empty string unchanged", () => {
+        expect(resolveChatCompletionModel("https://api.example.com", "")).toBe("");
+    });
+
+    it("returns trimmed whitespace-only string as empty", () => {
+        expect(resolveChatCompletionModel("https://api.example.com", "  ")).toBe("");
+    });
+});
+
+describe("warnUnknownModel", () => {
+    it("returns known models unchanged without warning", () => {
+        const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        expect(warnUnknownModel("gpt-4o")).toBe("gpt-4o");
+        expect(warnUnknownModel("deepseek-chat")).toBe("deepseek-chat");
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
+    });
+
+    it("returns known prefixed models unchanged without warning", () => {
+        const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        expect(warnUnknownModel("openai/gpt-4o")).toBe("openai/gpt-4o");
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
+    });
+
+    it("warns for unknown models but returns them unchanged", () => {
+        const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        expect(warnUnknownModel("claude-3-opus")).toBe("claude-3-opus");
+        expect(spy).toHaveBeenCalledTimes(1);
+        spy.mockRestore();
+    });
+
+    it("does not warn for empty string", () => {
+        const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        expect(warnUnknownModel("")).toBe("");
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
+    });
+});

--- a/packages/convex/convex/__tests__/bias_metrics.test.ts
+++ b/packages/convex/convex/__tests__/bias_metrics.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for lib/bias_metrics.ts
+ */
+import { describe, expect, it } from "vitest";
+import {
+    computeDemographicParity,
+    computeEqualizedOdds,
+    computeDisparateImpactRatio,
+    computePSI,
+    ageToBracket,
+    fnvHash,
+    type GroupOutcome,
+    type GroupConfusion,
+} from "../lib/bias_metrics.js";
+
+// ---------------------------------------------------------------------------
+// ageToBracket
+// ---------------------------------------------------------------------------
+describe("ageToBracket", () => {
+    it("maps ages to correct brackets", () => {
+        expect(ageToBracket(22)).toBe("under_25");
+        expect(ageToBracket(25)).toBe("25-29");
+        expect(ageToBracket(30)).toBe("30-34");
+        expect(ageToBracket(35)).toBe("35-39");
+        expect(ageToBracket(40)).toBe("40-44");
+        expect(ageToBracket(45)).toBe("45-49");
+        expect(ageToBracket(50)).toBe("50_plus");
+        expect(ageToBracket(65)).toBe("50_plus");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fnvHash
+// ---------------------------------------------------------------------------
+describe("fnvHash", () => {
+    it("returns deterministic 8-char hex string", () => {
+        const hash = fnvHash("test");
+        expect(hash).toMatch(/^[0-9a-f]{8}$/);
+        expect(fnvHash("test")).toBe(hash);
+    });
+
+    it("produces different hashes for different inputs", () => {
+        expect(fnvHash("foo")).not.toBe(fnvHash("bar"));
+    });
+});
+
+// ---------------------------------------------------------------------------
+// computeDemographicParity
+// ---------------------------------------------------------------------------
+describe("computeDemographicParity", () => {
+    it("passes four-fifths rule for equal rates", () => {
+        const groups: GroupOutcome[] = [
+            { groupKey: "A", total: 100, positive: 50, avgScore: 70, scoreStdDev: 10 },
+            { groupKey: "B", total: 100, positive: 50, avgScore: 70, scoreStdDev: 10 },
+        ];
+        const result = computeDemographicParity(groups);
+        expect(result.disparityRatio).toBe(1);
+        expect(result.passing).toBe(true);
+        expect(result.maxDifference).toBe(0);
+    });
+
+    it("fails four-fifths rule for disparate rates", () => {
+        const groups: GroupOutcome[] = [
+            { groupKey: "A", total: 100, positive: 80, avgScore: 80, scoreStdDev: 10 },
+            { groupKey: "B", total: 100, positive: 20, avgScore: 40, scoreStdDev: 10 },
+        ];
+        const result = computeDemographicParity(groups);
+        expect(result.disparityRatio).toBe(0.25);
+        expect(result.passing).toBe(false);
+    });
+
+    it("handles zero-total groups", () => {
+        const groups: GroupOutcome[] = [
+            { groupKey: "A", total: 0, positive: 0, avgScore: 0, scoreStdDev: 0 },
+            { groupKey: "B", total: 100, positive: 50, avgScore: 70, scoreStdDev: 10 },
+        ];
+        const result = computeDemographicParity(groups);
+        expect(result.disparityRatio).toBe(0);
+        expect(result.passing).toBe(false);
+    });
+
+    it("passes with clearly above 80% ratio", () => {
+        const groups: GroupOutcome[] = [
+            { groupKey: "A", total: 100, positive: 80, avgScore: 80, scoreStdDev: 10 },
+            { groupKey: "B", total: 100, positive: 70, avgScore: 70, scoreStdDev: 10 },
+        ];
+        const result = computeDemographicParity(groups);
+        expect(result.disparityRatio).toBeCloseTo(0.875, 10);
+        expect(result.passing).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// computeEqualizedOdds
+// ---------------------------------------------------------------------------
+describe("computeEqualizedOdds", () => {
+    it("passes when TPR and FPR are equal across groups", () => {
+        const groups: GroupConfusion[] = [
+            { groupKey: "A", truePositives: 80, falsePositives: 10, trueNegatives: 80, falseNegatives: 20 },
+            { groupKey: "B", truePositives: 40, falsePositives: 5, trueNegatives: 40, falseNegatives: 10 },
+        ];
+        const result = computeEqualizedOdds(groups);
+        expect(result.tprDifference).toBe(0);
+        expect(result.fprDifference).toBe(0);
+        expect(result.passing).toBe(true);
+    });
+
+    it("fails when TPR difference exceeds 0.1", () => {
+        const groups: GroupConfusion[] = [
+            { groupKey: "A", truePositives: 90, falsePositives: 10, trueNegatives: 90, falseNegatives: 10 },
+            { groupKey: "B", truePositives: 10, falsePositives: 10, trueNegatives: 90, falseNegatives: 90 },
+        ];
+        const result = computeEqualizedOdds(groups);
+        expect(result.passing).toBe(false);
+    });
+
+    it("handles zero-total groups", () => {
+        const groups: GroupConfusion[] = [
+            { groupKey: "A", truePositives: 0, falsePositives: 0, trueNegatives: 0, falseNegatives: 0 },
+            { groupKey: "B", truePositives: 50, falsePositives: 5, trueNegatives: 45, falseNegatives: 50 },
+        ];
+        const result = computeEqualizedOdds(groups);
+        expect(result.groupMetrics).toHaveLength(2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// computeDisparateImpactRatio
+// ---------------------------------------------------------------------------
+describe("computeDisparateImpactRatio", () => {
+    it("returns 1 for equal rates", () => {
+        const protectedGroup: GroupOutcome = { groupKey: "A", total: 100, positive: 50, avgScore: 70, scoreStdDev: 10 };
+        const referenceGroup: GroupOutcome = { groupKey: "B", total: 100, positive: 50, avgScore: 70, scoreStdDev: 10 };
+        expect(computeDisparateImpactRatio(protectedGroup, referenceGroup)).toBe(1);
+    });
+
+    it("returns correct ratio for disparate rates", () => {
+        const protectedGroup: GroupOutcome = { groupKey: "A", total: 100, positive: 30, avgScore: 60, scoreStdDev: 10 };
+        const referenceGroup: GroupOutcome = { groupKey: "B", total: 100, positive: 60, avgScore: 75, scoreStdDev: 10 };
+        expect(computeDisparateImpactRatio(protectedGroup, referenceGroup)).toBe(0.5);
+    });
+
+    it("returns 1 when reference group has zero total", () => {
+        const protectedGroup: GroupOutcome = { groupKey: "A", total: 100, positive: 50, avgScore: 70, scoreStdDev: 10 };
+        const referenceGroup: GroupOutcome = { groupKey: "B", total: 0, positive: 0, avgScore: 0, scoreStdDev: 0 };
+        expect(computeDisparateImpactRatio(protectedGroup, referenceGroup)).toBe(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// computePSI
+// ---------------------------------------------------------------------------
+describe("computePSI", () => {
+    it("returns low PSI for identical distributions", () => {
+        const scores = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+        const result = computePSI(scores, scores);
+        expect(result.psi).toBeCloseTo(0, 1);
+        expect(result.driftDetected).toBe(false);
+    });
+
+    it("detects drift for significantly different distributions", () => {
+        const baseline = [10, 20, 30, 40, 50];
+        const current = [80, 85, 90, 95, 100];
+        const result = computePSI(baseline, current);
+        expect(result.driftDetected).toBe(true);
+    });
+
+    it("returns correct bin counts", () => {
+        const baseline = [5, 15, 25, 35, 45, 55, 65, 75, 85, 95];
+        const result = computePSI(baseline, baseline, 10);
+        expect(result.baselineCounts).toHaveLength(10);
+        expect(result.currentCounts).toHaveLength(10);
+    });
+});

--- a/packages/convex/convex/__tests__/resume_identity.test.ts
+++ b/packages/convex/convex/__tests__/resume_identity.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for lib/resume_identity.ts
+ */
+import { describe, expect, it } from "vitest";
+import { deriveResumeIdentity, deriveResumeIdentityKey } from "../lib/resume_identity.js";
+
+describe("deriveResumeIdentity", () => {
+    it("derives identity from profileUrl", () => {
+        const result = deriveResumeIdentity({
+            content: { profileUrl: "https://example.com/profile/123" },
+            externalId: "ext-1",
+        });
+        expect(result.source).toBe("profileUrl");
+        expect(result.identityKey).toMatch(/^profileUrl:/);
+    });
+
+    it("derives identity from resumeId when no profileUrl", () => {
+        const result = deriveResumeIdentity({
+            content: { resumeId: "RES-456" },
+            externalId: "ext-1",
+        });
+        expect(result.source).toBe("resumeId");
+        expect(result.normalizedValue).toBe("res-456");
+    });
+
+    it("derives identity from perUserId when no profileUrl or resumeId", () => {
+        const result = deriveResumeIdentity({
+            content: { perUserId: "USER-789" },
+            externalId: "ext-1",
+        });
+        expect(result.source).toBe("perUserId");
+        expect(result.normalizedValue).toBe("user-789");
+    });
+
+    it("derives identity from externalId when no other candidates", () => {
+        const result = deriveResumeIdentity({
+            content: {},
+            externalId: "EXT-123",
+        });
+        expect(result.source).toBe("externalId");
+        expect(result.normalizedValue).toBe("ext-123");
+    });
+
+    it("prefers profileUrl over other candidates", () => {
+        const result = deriveResumeIdentity({
+            content: {
+                profileUrl: "https://example.com/profile/1",
+                resumeId: "RES-2",
+                perUserId: "USER-3",
+            },
+            externalId: "EXT-4",
+        });
+        expect(result.source).toBe("profileUrl");
+    });
+
+    it("handles non-record content", () => {
+        const result = deriveResumeIdentity({
+            content: "not a record",
+            externalId: "ext-fallback",
+        });
+        expect(result.source).toBe("externalId");
+        expect(result.normalizedValue).toBe("ext-fallback");
+    });
+
+    it("normalizes Job5156 profile URLs", () => {
+        const result = deriveResumeIdentity({
+            content: { profileUrl: "https://hr.job5156.com/resume/view/ABC123" },
+            externalId: "ext-1",
+            source: "51job",
+        });
+        expect(result.source).toBe("profileUrl");
+        expect(result.normalizedValue).toContain("hr.job5156.com");
+    });
+
+    it("normalizes Seek profile URLs", () => {
+        const result = deriveResumeIdentity({
+            content: { profileUrl: "https://talent.employer.seek.com/candidates/12345" },
+            externalId: "ext-1",
+            source: "seek",
+        });
+        expect(result.source).toBe("profileUrl");
+        expect(result.normalizedValue).toContain("employer.seek.com");
+    });
+
+    it("skips javascript: URLs", () => {
+        const result = deriveResumeIdentity({
+            content: { profileUrl: "javascript:;", resumeId: "RES-1" },
+            externalId: "ext-1",
+        });
+        expect(result.source).toBe("resumeId");
+    });
+
+    it("falls back to externalId:unknown for empty inputs", () => {
+        const result = deriveResumeIdentity({
+            content: {},
+            externalId: "",
+        });
+        expect(result.source).toBe("externalId");
+        expect(result.normalizedValue).toBe("unknown");
+    });
+});
+
+describe("deriveResumeIdentityKey", () => {
+    it("returns just the identity key string", () => {
+        const key = deriveResumeIdentityKey({
+            content: { resumeId: "RES-1" },
+            externalId: "ext-1",
+        });
+        expect(key).toMatch(/^resumeId:/);
+    });
+});

--- a/packages/convex/convex/__tests__/resumes_diagnostics.test.ts
+++ b/packages/convex/convex/__tests__/resumes_diagnostics.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for lib/resumes_diagnostics.ts
+ */
+import { describe, expect, it } from "vitest";
+import {
+    resolveDiagnosticsSourceKeyForResume,
+    normalizeDiagnosticsSourceFilterValues,
+    matchesDiagnosticsSourceKeys,
+    buildDiagnosticsSourceFacetRows,
+    projectIngestDiagnosticsRow,
+    MAX_INGEST_DIAGNOSTICS_PAGE_SIZE,
+    MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES,
+    DIAGNOSTICS_SOURCE_FILTER_BATCH_MULTIPLIER,
+} from "../lib/resumes_diagnostics.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+describe("constants", () => {
+    it("has expected values", () => {
+        expect(MAX_INGEST_DIAGNOSTICS_PAGE_SIZE).toBe(100);
+        expect(MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES).toBe(8);
+        expect(DIAGNOSTICS_SOURCE_FILTER_BATCH_MULTIPLIER).toBe(3);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// resolveDiagnosticsSourceKeyForResume
+// ---------------------------------------------------------------------------
+describe("resolveDiagnosticsSourceKeyForResume", () => {
+    it("uses content.profileType when available", () => {
+        const result = resolveDiagnosticsSourceKeyForResume({
+            source: "51job",
+            content: { profileType: "seek" },
+        });
+        expect(result).toBe("seek");
+    });
+
+    it("falls back to source when no profileType", () => {
+        const result = resolveDiagnosticsSourceKeyForResume({
+            source: "51job",
+            content: {},
+        });
+        expect(result).toBe("51job");
+    });
+
+    it("handles non-record content", () => {
+        const result = resolveDiagnosticsSourceKeyForResume({
+            source: "51job",
+            content: null,
+        });
+        expect(result).toBe("51job");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeDiagnosticsSourceFilterValues
+// ---------------------------------------------------------------------------
+describe("normalizeDiagnosticsSourceFilterValues", () => {
+    it("returns undefined for non-array input", () => {
+        expect(normalizeDiagnosticsSourceFilterValues(undefined)).toBeUndefined();
+        expect(normalizeDiagnosticsSourceFilterValues(null as any)).toBeUndefined();
+    });
+
+    it("normalizes and deduplicates values", () => {
+        const result = normalizeDiagnosticsSourceFilterValues(["51job", " 51job ", "seek"]);
+        expect(result).toBeDefined();
+        expect(new Set(result).size).toBe(result!.length);
+    });
+
+    it("returns undefined for all-empty values", () => {
+        expect(normalizeDiagnosticsSourceFilterValues(["", "  "])).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// matchesDiagnosticsSourceKeys
+// ---------------------------------------------------------------------------
+describe("matchesDiagnosticsSourceKeys", () => {
+    it("returns true when no sourceKeys filter", () => {
+        expect(matchesDiagnosticsSourceKeys(
+            { source: "51job", content: {} },
+            undefined
+        )).toBe(true);
+        expect(matchesDiagnosticsSourceKeys(
+            { source: "51job", content: {} },
+            new Set()
+        )).toBe(true);
+    });
+
+    it("returns true when sourceKey matches", () => {
+        expect(matchesDiagnosticsSourceKeys(
+            { source: "51job", content: {}, sourceKey: "51job" },
+            new Set(["51job", "seek"])
+        )).toBe(true);
+    });
+
+    it("returns false when sourceKey does not match", () => {
+        expect(matchesDiagnosticsSourceKeys(
+            { source: "51job", content: {}, sourceKey: "51job" },
+            new Set(["seek"])
+        )).toBe(false);
+    });
+
+    it("derives sourceKey when not present on resume", () => {
+        expect(matchesDiagnosticsSourceKeys(
+            { source: "51job", content: {} },
+            new Set(["51job"])
+        )).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildDiagnosticsSourceFacetRows
+// ---------------------------------------------------------------------------
+describe("buildDiagnosticsSourceFacetRows", () => {
+    it("builds facets from resume array", () => {
+        const resumes = [
+            { source: "51job", content: {} },
+            { source: "51job", content: {} },
+            { source: "seek", content: {} },
+        ];
+        const facets = buildDiagnosticsSourceFacetRows(resumes);
+        expect(facets).toHaveLength(2);
+        expect(facets[0].count).toBe(2); // 51job has 2, sorted first
+    });
+
+    it("builds facets from Map", () => {
+        const counts = new Map([["51job", 5], ["seek", 3]]);
+        const facets = buildDiagnosticsSourceFacetRows(counts);
+        expect(facets).toHaveLength(2);
+        expect(facets[0].key).toBe("51job");
+        expect(facets[0].count).toBe(5);
+    });
+
+    it("sorts by count descending then key ascending", () => {
+        const counts = new Map([["b-source", 3], ["a-source", 3]]);
+        const facets = buildDiagnosticsSourceFacetRows(counts);
+        expect(facets[0].key).toBe("a-source");
+        expect(facets[1].key).toBe("b-source");
+    });
+
+    it("provides human-readable labels", () => {
+        const counts = new Map([["job5156", 1], ["seek", 1]]);
+        const facets = buildDiagnosticsSourceFacetRows(counts);
+        const job5156 = facets.find((f) => f.key === "job5156");
+        const seek = facets.find((f) => f.key === "seek");
+        expect(job5156?.label).toBe("Job5156");
+        expect(seek?.label).toBe("SEEK");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// projectIngestDiagnosticsRow
+// ---------------------------------------------------------------------------
+describe("projectIngestDiagnosticsRow", () => {
+    it("projects a resume without ingestData", () => {
+        const row = projectIngestDiagnosticsRow({
+            _id: "r1",
+            externalId: "ext1",
+            source: "51job",
+            content: { name: "Test User", location: "Shanghai" },
+        });
+        expect(row.resumeId).toBe("r1");
+        expect(row.name).toBe("Test User");
+        expect(row.ingestData).toBeUndefined();
+    });
+
+    it("projects a resume with ingestData", () => {
+        const row = projectIngestDiagnosticsRow({
+            _id: "r2",
+            externalId: "ext2",
+            source: "seek",
+            content: {},
+            ingestData: {
+                industryTags: ["CNC"],
+                companyHits: ["Acme"],
+                brandHits: [],
+                experienceLevel: "senior",
+                computedAt: Date.now(),
+                skillsVersion: 2,
+                taggingEnvelope: {
+                    entries: [
+                        { tag: "CNC", source: "rule", confidence: 0.9, provenance: { stage: "rule", evidence: ["keyword"] } },
+                    ],
+                },
+            },
+        });
+        expect(row.ingestData).toBeDefined();
+        expect(row.ingestData!.industryTags).toEqual(["CNC"]);
+        expect(row.ingestData!.companyHits).toEqual(["Acme"]);
+        expect(row.ingestData!.taggingEntries).toHaveLength(1);
+    });
+
+    it("includes archive fields when archived", () => {
+        const row = projectIngestDiagnosticsRow({
+            _id: "r3",
+            externalId: "ext3",
+            source: "51job",
+            content: {},
+            isArchived: true,
+            archivedAt: 1700000000000,
+        });
+        expect(row.isArchived).toBe(true);
+        expect(row.archivedAt).toBe(1700000000000);
+    });
+
+    it("omits archive fields when not archived", () => {
+        const row = projectIngestDiagnosticsRow({
+            _id: "r4",
+            externalId: "ext4",
+            source: "51job",
+            content: {},
+        });
+        expect(row.isArchived).toBeUndefined();
+    });
+
+    it("limits tagging entries to MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES", () => {
+        const manyEntries = Array.from({ length: 15 }, (_, i) => ({
+            tag: `tag-${i}`,
+            source: "rule",
+            confidence: 0.8,
+            provenance: { stage: "rule", evidence: [] },
+        }));
+        const row = projectIngestDiagnosticsRow({
+            _id: "r5",
+            externalId: "ext5",
+            source: "51job",
+            content: {},
+            ingestData: {
+                industryTags: [],
+                companyHits: [],
+                brandHits: [],
+                experienceLevel: "mid",
+                computedAt: Date.now(),
+                skillsVersion: 1,
+                taggingEnvelope: { entries: manyEntries },
+            },
+        });
+        expect(row.ingestData!.taggingEntries.length).toBeLessThanOrEqual(MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES);
+    });
+});

--- a/packages/convex/convex/__tests__/resumes_tag_expansion.test.ts
+++ b/packages/convex/convex/__tests__/resumes_tag_expansion.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for lib/resumes_tag_expansion.ts
+ */
+import { describe, expect, it } from "vitest";
+import {
+    normalizeTagExpansionKeywordGroups,
+    dedupeProvenance,
+    buildTagExpansionSearchQuery,
+    matchesTagExpansionSearchText,
+    collectSearchTextProvenance,
+    selectTagExpansionAnchorGroup,
+    collectExpandedTerms,
+} from "../lib/resumes_tag_expansion.js";
+
+// ---------------------------------------------------------------------------
+// normalizeTagExpansionKeywordGroups
+// ---------------------------------------------------------------------------
+describe("normalizeTagExpansionKeywordGroups", () => {
+    it("normalizes and deduplicates keyword groups", () => {
+        const result = normalizeTagExpansionKeywordGroups([
+            { original: "CNC", variants: ["cnc", "CNC", "cnc milling"] },
+        ]);
+        expect(result).toHaveLength(1);
+        expect(result[0].original).toBe("cnc");
+        expect(result[0].variants).toContain("cnc");
+        expect(result[0].variants).toContain("cnc milling");
+        // Deduplicated: only one "cnc"
+        expect(result[0].variants.filter((v) => v === "cnc")).toHaveLength(1);
+    });
+
+    it("filters out short variants (< 2 chars)", () => {
+        const result = normalizeTagExpansionKeywordGroups([
+            { original: "AI", variants: ["ai", "a"] },
+        ]);
+        expect(result[0].variants).not.toContain("a");
+    });
+
+    it("filters out groups with no remaining variants", () => {
+        const result = normalizeTagExpansionKeywordGroups([
+            { original: "X", variants: ["x"] }, // "x" is < 2 chars
+        ]);
+        expect(result).toHaveLength(0);
+    });
+
+    it("filters out groups with empty original", () => {
+        const result = normalizeTagExpansionKeywordGroups([
+            { original: "  ", variants: ["cnc"] },
+        ]);
+        expect(result).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// dedupeProvenance
+// ---------------------------------------------------------------------------
+describe("dedupeProvenance", () => {
+    it("removes duplicate provenance entries", () => {
+        const items = [
+            { term: "cnc", source: "searchText" as const },
+            { term: "cnc", source: "searchText" as const },
+            { term: "milling", source: "searchText" as const },
+        ];
+        const result = dedupeProvenance(items);
+        expect(result).toHaveLength(2);
+    });
+
+    it("keeps entries with same term but different source", () => {
+        const items = [
+            { term: "cnc", source: "searchText" as const },
+            { term: "cnc", source: "industryTags" as const },
+        ];
+        const result = dedupeProvenance(items);
+        expect(result).toHaveLength(2);
+    });
+
+    it("keeps entries with same term and source but different expandedFrom", () => {
+        const items = [
+            { term: "cnc", source: "searchText" as const, expandedFrom: "machining" },
+            { term: "cnc", source: "searchText" as const, expandedFrom: "lathe" },
+        ];
+        const result = dedupeProvenance(items);
+        expect(result).toHaveLength(2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// selectTagExpansionAnchorGroup
+// ---------------------------------------------------------------------------
+describe("selectTagExpansionAnchorGroup", () => {
+    it("selects group with fewest variants", () => {
+        const groups = [
+            { original: "cnc", variants: ["cnc", "cnc milling", "cnc lathe"] },
+            { original: "machining", variants: ["machining"] },
+        ];
+        const result = selectTagExpansionAnchorGroup(groups);
+        expect(result.original).toBe("machining");
+    });
+
+    it("breaks ties by longest original name", () => {
+        const groups = [
+            { original: "cnc", variants: ["cnc"] },
+            { original: "cnc machining", variants: ["cnc machining"] },
+        ];
+        const result = selectTagExpansionAnchorGroup(groups);
+        expect(result.original).toBe("cnc machining");
+    });
+
+    it("throws for empty groups", () => {
+        expect(() => selectTagExpansionAnchorGroup([])).toThrow("Keyword groups are required");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// collectExpandedTerms
+// ---------------------------------------------------------------------------
+describe("collectExpandedTerms", () => {
+    it("collects and deduplicates all variants", () => {
+        const groups = [
+            { original: "cnc", variants: ["cnc", "cnc milling"] },
+            { original: "machining", variants: ["machining", "cnc milling"] },
+        ];
+        const result = collectExpandedTerms(groups);
+        expect(result).toHaveLength(3);
+        expect(result).toContain("cnc");
+        expect(result).toContain("cnc milling");
+        expect(result).toContain("machining");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildTagExpansionSearchQuery
+// ---------------------------------------------------------------------------
+describe("buildTagExpansionSearchQuery", () => {
+    it("returns empty for empty groups", () => {
+        expect(buildTagExpansionSearchQuery([], "AND")).toBe("");
+        expect(buildTagExpansionSearchQuery([], "OR")).toBe("");
+    });
+
+    it("AND mode uses anchor group variants", () => {
+        const groups = [
+            { original: "cnc", variants: ["cnc", "cnc milling"] },
+            { original: "machining", variants: ["machining"] },
+        ];
+        const result = buildTagExpansionSearchQuery(groups, "AND");
+        // Anchor group is "machining" (fewest variants)
+        expect(result).toBe("machining");
+    });
+
+    it("OR mode uses all expanded terms", () => {
+        const groups = [
+            { original: "cnc", variants: ["cnc", "cnc milling"] },
+            { original: "machining", variants: ["machining"] },
+        ];
+        const result = buildTagExpansionSearchQuery(groups, "OR");
+        expect(result).toContain("cnc");
+        expect(result).toContain("machining");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// matchesTagExpansionSearchText
+// ---------------------------------------------------------------------------
+describe("matchesTagExpansionSearchText", () => {
+    const groups = [
+        { original: "cnc", variants: ["cnc", "cnc milling"] },
+        { original: "machining", variants: ["machining"] },
+    ];
+
+    it("AND mode requires all groups to match", () => {
+        expect(matchesTagExpansionSearchText("cnc machining expert", groups, "AND")).toBe(true);
+        expect(matchesTagExpansionSearchText("cnc expert", groups, "AND")).toBe(false);
+    });
+
+    it("OR mode requires at least one group to match", () => {
+        expect(matchesTagExpansionSearchText("cnc expert", groups, "OR")).toBe(true);
+        expect(matchesTagExpansionSearchText("welding expert", groups, "OR")).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// collectSearchTextProvenance
+// ---------------------------------------------------------------------------
+describe("collectSearchTextProvenance", () => {
+    it("collects provenance for matched terms", () => {
+        const groups = [
+            { original: "cnc", variants: ["cnc", "cnc milling"] },
+            { original: "machining", variants: ["machining"] },
+        ];
+        const sourceMapping = { cnc: "keyword", "cnc milling": "synonym" };
+        const result = collectSearchTextProvenance("cnc machining expert", groups, sourceMapping);
+        expect(result.length).toBeGreaterThanOrEqual(2);
+        expect(result.some((p) => p.term === "cnc")).toBe(true);
+        expect(result.some((p) => p.term === "machining")).toBe(true);
+    });
+
+    it("skips terms not in search text", () => {
+        const groups = [
+            { original: "cnc", variants: ["cnc"] },
+        ];
+        const result = collectSearchTextProvenance("welding expert", groups, {});
+        expect(result).toHaveLength(0);
+    });
+
+    it("deduplicates terms across groups", () => {
+        const groups = [
+            { original: "cnc", variants: ["cnc"] },
+            { original: "cnc advanced", variants: ["cnc"] },
+        ];
+        const result = collectSearchTextProvenance("cnc", groups, {});
+        expect(result).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for 5 lib modules that previously had zero dedicated test coverage
- ai_model.test.ts (8 tests): resolveChatCompletionModel, warnUnknownModel
- bias_metrics.test.ts (16 tests): demographic parity, equalized odds, disparate impact, PSI, ageToBracket, fnvHash
- resume_identity.test.ts (12 tests): deriveResumeIdentity, deriveResumeIdentityKey, Job5156/Seek URL normalization
- resumes_diagnostics.test.ts (18 tests): source key resolution, facet rows, ingest diagnostics projection
- resumes_tag_expansion.test.ts (20 tests): keyword group normalization, provenance dedup, search query building, text matching

## Test plan
- [x] `npx vitest run packages/convex/` — 79 files, 1551 tests passing
- [x] All 5 new test files pass individually