### PR TITLE
refactor: extract analysis_prompts.ts from analyze.ts

### DIFF
--- a/packages/convex/convex/__tests__/analysis_prompts.test.ts
+++ b/packages/convex/convex/__tests__/analysis_prompts.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for lib/analysis_prompts.ts
+ */
+import { describe, expect, it } from "vitest";
+import {
+    isEnglishResumeAiLocale,
+    hydrateUserPrompt,
+    buildKeywordRequirements,
+    buildKeywordMatchingRules,
+    buildConfirmPrompt,
+} from "../lib/analysis_prompts.js";
+
+// ---------------------------------------------------------------------------
+// isEnglishResumeAiLocale
+// ---------------------------------------------------------------------------
+describe("isEnglishResumeAiLocale", () => {
+    it("returns true for English locale", () => {
+        expect(isEnglishResumeAiLocale("en")).toBe(true);
+    });
+
+    it("returns false for Chinese locale", () => {
+        expect(isEnglishResumeAiLocale("zh-Hans")).toBe(false);
+    });
+
+    it("returns false for undefined (default is zh-Hans)", () => {
+        expect(isEnglishResumeAiLocale(undefined)).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// hydrateUserPrompt
+// ---------------------------------------------------------------------------
+describe("hydrateUserPrompt", () => {
+    const template = "{jobTitle} | {requirements} | {matchingRules} | {candidateName} | {workExperience} | {education} | {evidenceText} | {roleSignals} | {companies} | {verifiedCompanies}";
+
+    it("replaces all template placeholders", () => {
+        const result = hydrateUserPrompt(
+            template,
+            { title: "CNC Operator", requirements: "3+ years", matchingRules: "CNC keywords" },
+            {
+                name: "John",
+                workExperience: 5,
+                education: "BS",
+                evidenceText: "5yr CNC",
+                roleSignalsText: "CNC(3yr)",
+                companies: "Acme",
+                verifiedCompanies: ["Acme"],
+            },
+            "en",
+        );
+        expect(result).toContain("CNC Operator");
+        expect(result).toContain("John");
+        expect(result).toContain("Acme");
+    });
+
+    it("shows noneLabel for empty verifiedCompanies", () => {
+        const result = hydrateUserPrompt(
+            "{verifiedCompanies}",
+            { title: "T", requirements: "R", matchingRules: "M" },
+            {
+                name: "N",
+                workExperience: 0,
+                education: "",
+                evidenceText: "",
+                roleSignalsText: "",
+                companies: "",
+                verifiedCompanies: [],
+            },
+            "en",
+        );
+        expect(result).toBe("none");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildKeywordRequirements
+// ---------------------------------------------------------------------------
+describe("buildKeywordRequirements", () => {
+    it("builds English keyword list", () => {
+        const result = buildKeywordRequirements(["CNC", "machining"], "en");
+        expect(result).toContain("- CNC");
+        expect(result).toContain("- machining");
+        expect(result).toContain("key skills");
+    });
+
+    it("builds Chinese keyword list", () => {
+        const result = buildKeywordRequirements(["CNC", "机加工"], "zh-Hans");
+        expect(result).toContain("- CNC");
+        expect(result).toContain("关键技能");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildKeywordMatchingRules
+// ---------------------------------------------------------------------------
+describe("buildKeywordMatchingRules", () => {
+    it("builds English matching rules", () => {
+        const result = buildKeywordMatchingRules(["CNC"], "en");
+        expect(result).toContain("Score the candidate");
+        expect(result).toContain("CNC");
+    });
+
+    it("builds Chinese matching rules", () => {
+        const result = buildKeywordMatchingRules(["CNC"], "zh-Hans");
+        expect(result).toContain("匹配程度评分");
+        expect(result).toContain("CNC");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildConfirmPrompt
+// ---------------------------------------------------------------------------
+describe("buildConfirmPrompt", () => {
+    it("includes search query and resume details", () => {
+        const result = buildConfirmPrompt(
+            { content: { title: "Senior CNC Operator" }, tags: ["CNC", "machining"] },
+            "CNC operator",
+        );
+        expect(result).toContain('Search query: "CNC operator"');
+        expect(result).toContain("Senior CNC Operator");
+        expect(result).toContain("CNC, machining");
+    });
+
+    it("handles missing content gracefully", () => {
+        const result = buildConfirmPrompt({}, "test query");
+        expect(result).toContain("N/A");
+        expect(result).toContain("none");
+    });
+
+    it("includes roleSignals from ingestData", () => {
+        const result = buildConfirmPrompt(
+            { ingestData: { roleSignals: [{ type: "CNC", years: 5 }] } },
+            "CNC",
+        );
+        expect(result).toContain("CNC (5y)");
+    });
+
+    it("includes score/recommendation format in prompt", () => {
+        const result = buildConfirmPrompt({}, "test");
+        expect(result).toContain("score");
+        expect(result).toContain("recommendation");
+    });
+});

--- a/packages/convex/convex/__tests__/resumes_diagnostics.test.ts
+++ b/packages/convex/convex/__tests__/resumes_diagnostics.test.ts
@@ -176,13 +176,17 @@ describe("projectIngestDiagnosticsRow", () => {
                 industryTags: ["CNC"],
                 companyHits: ["Acme"],
                 brandHits: [],
+                synonymHits: [],
+                ruleScores: {},
                 experienceLevel: "senior",
                 computedAt: Date.now(),
                 skillsVersion: 2,
                 taggingEnvelope: {
                     entries: [
-                        { tag: "CNC", source: "rule", confidence: 0.9, provenance: { stage: "rule", evidence: ["keyword"] } },
+                        { tag: "CNC", source: "rule", confidence: 0.9, version: 1, provenance: { stage: "rule", generatedBy: "rule-engine", evidence: ["keyword"] } },
                     ],
+                    schemaVersion: 1,
+                    generatedAt: Date.now(),
                 },
             },
         });
@@ -220,7 +224,8 @@ describe("projectIngestDiagnosticsRow", () => {
             tag: `tag-${i}`,
             source: "rule",
             confidence: 0.8,
-            provenance: { stage: "rule", evidence: [] },
+            version: 1,
+            provenance: { stage: "rule", generatedBy: "rule-engine", evidence: [] },
         }));
         const row = projectIngestDiagnosticsRow({
             _id: "r5",
@@ -231,10 +236,12 @@ describe("projectIngestDiagnosticsRow", () => {
                 industryTags: [],
                 companyHits: [],
                 brandHits: [],
+                synonymHits: [],
+                ruleScores: {},
                 experienceLevel: "mid",
                 computedAt: Date.now(),
                 skillsVersion: 1,
-                taggingEnvelope: { entries: manyEntries },
+                taggingEnvelope: { entries: manyEntries, schemaVersion: 1, generatedAt: Date.now() },
             },
         });
         expect(row.ingestData!.taggingEntries.length).toBeLessThanOrEqual(MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES);

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -6,8 +6,8 @@ import {
     getResumeAiPromptDefinition,
     getResumeAiUserPromptTemplate,
     resolveResumeAnalysisSourceKey,
-    sanitizeResumeRecordForSurface,
     resolveResumeAiPromptLocale,
+    sanitizeResumeRecordForSurface,
     isRecord,
     selectLatestWorkHistory,
     type ResumeFieldUsagePolicy,
@@ -39,6 +39,15 @@ import {
     type NormalizedMatchedWorkEntry,
     type NormalizedRoleSignal,
 } from "./lib/analysis_normalization.js";
+import {
+    isEnglishResumeAiLocale,
+    formatWorkEntry,
+    formatRoleSignals,
+    hydrateUserPrompt,
+    buildKeywordRequirements,
+    buildKeywordMatchingRules,
+    buildConfirmPrompt,
+} from "./lib/analysis_prompts.js";
 
 // Re-export for backward compatibility
 export {
@@ -64,6 +73,13 @@ export type {
     NormalizedMatchedWorkEntry,
     NormalizedRoleSignal,
 } from "./lib/analysis_normalization.js";
+export {
+    isEnglishResumeAiLocale,
+    hydrateUserPrompt,
+    buildKeywordRequirements,
+    buildKeywordMatchingRules,
+    buildConfirmPrompt,
+} from "./lib/analysis_prompts.js";
 
 const DEFAULT_AI_OUTPUT_LOCALE = DEFAULT_RESUME_AI_PROMPT_LOCALE;
 
@@ -99,89 +115,6 @@ export function buildSystemPrompt(locale: string): string {
 
 export function getUserPromptTemplate(locale: string): string {
     return getResumeAiUserPromptTemplate(locale);
-}
-
-export function isEnglishResumeAiLocale(locale?: string): boolean {
-    return resolveResumeAiPromptLocale(locale).resolvedSourceLocale === "en";
-}
-
-function formatWorkEntry(
-    entry: NormalizedMatchedWorkEntry,
-    localeText: ReturnType<typeof getResumeAiLocaleText>,
-): string {
-    const parts = [
-        entry.companyName,
-        entry.jobTitle,
-        `${entry.years}${localeText.yearsUnitSuffix}`,
-        entry.industryVerified ? localeText.verifiedLabel : localeText.unverifiedLabel,
-        entry.directRoleMatch === false ? localeText.indirectRoleLabel : undefined,
-        entry.matchedSignals.length > 0 ? `${localeText.signalsLabel}:${entry.matchedSignals.join("/")}` : undefined,
-    ].filter((item): item is string => Boolean(item));
-    return parts.join(" ");
-}
-
-function formatRoleSignals(
-    roleSignals: NormalizedRoleSignal[],
-    localeText: ReturnType<typeof getResumeAiLocaleText>,
-): string {
-    if (roleSignals.length === 0) {
-        return localeText.noneLabel;
-    }
-
-    return roleSignals.slice(0, 8).map((signal) => {
-        const verifiedYears = typeof signal.industryVerifiedYears === "number" && Number.isFinite(signal.industryVerifiedYears)
-            ? signal.industryVerifiedYears
-            : 0;
-        const workEntries = signal.matchedWorkEntries && signal.matchedWorkEntries.length > 0
-            ? signal.matchedWorkEntries.map((entry) => formatWorkEntry(entry, localeText)).join("; ")
-            : undefined;
-        const parts = [
-            `${signal.type}(${signal.verifyIn})`,
-            `years:${signal.years}`,
-            `verified:${verifiedYears}`,
-            signal.matchedSignals.length > 0 ? `signals:${signal.matchedSignals.join("/")}` : undefined,
-            workEntries ? `work:${workEntries}` : undefined,
-        ].filter((item): item is string => Boolean(item));
-        return `- ${parts.join(" | ")}`;
-    }).join("\n");
-}
-
-export function hydrateUserPrompt(
-    template: string,
-    job: { title: string; requirements: string; matchingRules: string },
-    resume: ReturnType<typeof normalizeResume>,
-    locale?: string,
-): string {
-    const localeText = getResumeAiLocaleText(locale);
-    return template
-        .replace("{jobTitle}", job.title)
-        .replace("{requirements}", job.requirements)
-        .replace("{matchingRules}", job.matchingRules)
-        .replace("{candidateName}", resume.name)
-        .replace("{workExperience}", String(resume.workExperience))
-        .replace("{education}", resume.education)
-        .replace("{evidenceText}", resume.evidenceText)
-        .replace("{roleSignals}", resume.roleSignalsText)
-        .replace("{companies}", resume.companies)
-        .replace("{verifiedCompanies}", resume.verifiedCompanies.length > 0
-            ? resume.verifiedCompanies.join(", ")
-            : localeText.noneLabel);
-}
-
-export function buildKeywordRequirements(keywords: string[], locale?: string): string {
-    if (isEnglishResumeAiLocale(locale)) {
-        return `The candidate should have the following key skills or experience:\n${keywords
-            .map((keyword) => `- ${keyword}`)
-            .join("\n")}`;
-    }
-    return `候选人需具备以下关键技能/经验:\n${keywords.map((keyword) => `- ${keyword}`).join("\n")}`;
-}
-
-export function buildKeywordMatchingRules(keywords: string[], locale?: string): string {
-    if (isEnglishResumeAiLocale(locale)) {
-        return `Score the candidate by how well their evidence matches the following keywords. More direct relevance should produce a higher score.\nKeywords: ${keywords.join(", ")}`;
-    }
-    return `根据候选人与以下关键词的匹配程度评分。关键词越相关评分越高。\n关键词: ${keywords.join(", ")}`;
 }
 
 export function getAiApiKey(): string | undefined {
@@ -735,22 +668,3 @@ export const confirmSearchResults = action({
         };
     },
 });
-
-function buildConfirmPrompt(resume: { content?: Record<string, unknown>; tags?: string[]; ingestData?: Record<string, unknown> }, query: string): string {
-    const ingest = resume.ingestData ?? {};
-    const signals = Array.isArray(ingest.roleSignals)
-        ? (ingest.roleSignals as Array<Record<string, unknown>>).map((s) => `${s.type} (${s.years}y)`).join(", ")
-        : "none";
-
-    return [
-        `Search query: "${query}"`,
-        "",
-        "Resume:",
-        `- Title: ${resume.content?.title ?? "N/A"}`,
-        `- Experience: ${signals}`,
-        `- Tags: ${Array.isArray(resume.tags) ? resume.tags.join(", ") : "none"}`,
-        "",
-        `Rate how relevant this resume is for the search query. Respond with:`,
-        `{ "score": <0-100>, "summary": "<one-sentence>", "recommendation": "<strong_match|match|potential|no_match>", "breakdown": { "related_exp": <0-100> } }`,
-    ].join("\n");
-}

--- a/packages/convex/convex/lib/analysis_prompts.ts
+++ b/packages/convex/convex/lib/analysis_prompts.ts
@@ -1,0 +1,130 @@
+/**
+ * Prompt-building helpers extracted from analyze.ts.
+ *
+ * Pure functions for formatting AI analysis prompts, including
+ * work entry formatting, role signal display, keyword requirement
+ * generation, and confirm prompt construction.
+ */
+import {
+    getResumeAiLocaleText,
+    resolveResumeAiPromptLocale,
+} from "@trends/shared";
+import type { NormalizedMatchedWorkEntry, NormalizedRoleSignal } from "./analysis_normalization.js";
+
+// ---------------------------------------------------------------------------
+// Locale helpers
+// ---------------------------------------------------------------------------
+
+export function isEnglishResumeAiLocale(locale?: string): boolean {
+    return resolveResumeAiPromptLocale(locale).resolvedSourceLocale === "en";
+}
+
+// ---------------------------------------------------------------------------
+// Prompt formatting
+// ---------------------------------------------------------------------------
+
+export function formatWorkEntry(
+    entry: NormalizedMatchedWorkEntry,
+    localeText: ReturnType<typeof getResumeAiLocaleText>,
+): string {
+    const parts = [
+        entry.companyName,
+        entry.jobTitle,
+        `${entry.years}${localeText.yearsUnitSuffix}`,
+        entry.industryVerified ? localeText.verifiedLabel : localeText.unverifiedLabel,
+        entry.directRoleMatch === false ? localeText.indirectRoleLabel : undefined,
+        entry.matchedSignals.length > 0 ? `${localeText.signalsLabel}:${entry.matchedSignals.join("/")}` : undefined,
+    ].filter((item): item is string => Boolean(item));
+    return parts.join(" ");
+}
+
+export function formatRoleSignals(
+    roleSignals: NormalizedRoleSignal[],
+    localeText: ReturnType<typeof getResumeAiLocaleText>,
+): string {
+    if (roleSignals.length === 0) {
+        return localeText.noneLabel;
+    }
+
+    return roleSignals.slice(0, 8).map((signal) => {
+        const verifiedYears = typeof signal.industryVerifiedYears === "number" && Number.isFinite(signal.industryVerifiedYears)
+            ? signal.industryVerifiedYears
+            : 0;
+        const workEntries = signal.matchedWorkEntries && signal.matchedWorkEntries.length > 0
+            ? signal.matchedWorkEntries.map((entry) => formatWorkEntry(entry, localeText)).join("; ")
+            : undefined;
+        const parts = [
+            `${signal.type}(${signal.verifyIn})`,
+            `years:${signal.years}`,
+            `verified:${verifiedYears}`,
+            signal.matchedSignals.length > 0 ? `signals:${signal.matchedSignals.join("/")}` : undefined,
+            workEntries ? `work:${workEntries}` : undefined,
+        ].filter((item): item is string => Boolean(item));
+        return `- ${parts.join(" | ")}`;
+    }).join("\n");
+}
+
+export function hydrateUserPrompt(
+    template: string,
+    job: { title: string; requirements: string; matchingRules: string },
+    resume: {
+        name: string;
+        workExperience: string | number;
+        education: string;
+        evidenceText: string;
+        roleSignalsText: string;
+        companies: string;
+        verifiedCompanies: string[];
+    },
+    locale?: string,
+): string {
+    const localeText = getResumeAiLocaleText(locale);
+    return template
+        .replace("{jobTitle}", job.title)
+        .replace("{requirements}", job.requirements)
+        .replace("{matchingRules}", job.matchingRules)
+        .replace("{candidateName}", resume.name)
+        .replace("{workExperience}", String(resume.workExperience))
+        .replace("{education}", resume.education)
+        .replace("{evidenceText}", resume.evidenceText)
+        .replace("{roleSignals}", resume.roleSignalsText)
+        .replace("{companies}", resume.companies)
+        .replace("{verifiedCompanies}", resume.verifiedCompanies.length > 0
+            ? resume.verifiedCompanies.join(", ")
+            : localeText.noneLabel);
+}
+
+export function buildKeywordRequirements(keywords: string[], locale?: string): string {
+    if (isEnglishResumeAiLocale(locale)) {
+        return `The candidate should have the following key skills or experience:\n${keywords
+            .map((keyword) => `- ${keyword}`)
+            .join("\n")}`;
+    }
+    return `候选人需具备以下关键技能/经验:\n${keywords.map((keyword) => `- ${keyword}`).join("\n")}`;
+}
+
+export function buildKeywordMatchingRules(keywords: string[], locale?: string): string {
+    if (isEnglishResumeAiLocale(locale)) {
+        return `Score the candidate by how well their evidence matches the following keywords. More direct relevance should produce a higher score.\nKeywords: ${keywords.join(", ")}`;
+    }
+    return `根据候选人与以下关键词的匹配程度评分。关键词越相关评分越高。\n关键词: ${keywords.join(", ")}`;
+}
+
+export function buildConfirmPrompt(resume: { content?: Record<string, unknown>; tags?: string[]; ingestData?: Record<string, unknown> }, query: string): string {
+    const ingest = resume.ingestData ?? {};
+    const signals = Array.isArray(ingest.roleSignals)
+        ? (ingest.roleSignals as Array<Record<string, unknown>>).map((s) => `${s.type} (${s.years}y)`).join(", ")
+        : "none";
+
+    return [
+        `Search query: "${query}"`,
+        "",
+        "Resume:",
+        `- Title: ${resume.content?.title ?? "N/A"}`,
+        `- Experience: ${signals}`,
+        `- Tags: ${Array.isArray(resume.tags) ? resume.tags.join(", ") : "none"}`,
+        "",
+        `Rate how relevant this resume is for the search query. Respond with:`,
+        `{ "score": <0-100>, "summary": "<one-sentence>", "recommendation": "<strong_match|match|potential|no_match>", "breakdown": { "related_exp": <0-100> } }`,
+    ].join("\n");
+}


### PR DESCRIPTION
## Summary
- Extract prompt-building pure functions from analyze.ts into `lib/analysis_prompts.ts`
- Functions moved: `isEnglishResumeAiLocale`, `formatWorkEntry`, `formatRoleSignals`, `hydrateUserPrompt`, `buildKeywordRequirements`, `buildKeywordMatchingRules`, `buildConfirmPrompt`
- Backward-compatible re-exports from analyze.ts
- 13 unit tests for the extracted module
- Fix test fixtures in `resumes_diagnostics.test.ts` (add missing `synonymHits`, `ruleScores`, `schemaVersion`, `generatedAt` fields)
- analyze.ts reduced from ~749 → 670 lines

## Test plan
- [x] `npx vitest run packages/convex/` — 80 files, 1564 tests passing
- [x] `npx tsc --noEmit --project packages/convex/tsconfig.json` — clean