### PR TITLE
feat: add outcome filter to audit log query (EU AI Act Art. 14)

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -1803,6 +1803,38 @@ describe("resume routes", () => {
 
       expect(response.status).toBe(400);
     });
+
+    it("filters audit logs by outcome", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        const call = parseConvexCall(input, init);
+        expect(call.args).toEqual({ workspaceSlug: "ws1", outcome: "pending" });
+        return convexSuccess([
+          { _id: "al1", decisionType: "score", outcome: "pending" },
+        ]);
+      });
+
+      const app = createApp();
+      const response = await app.request("/api/resumes/audit-logs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workspaceSlug: "ws1", outcome: "pending" }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload.data.length).toBe(1);
+    });
+
+    it("returns 400 for invalid outcome", async () => {
+      const app = createApp();
+      const response = await app.request("/api/resumes/audit-logs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workspaceSlug: "ws1", outcome: "invalid" }),
+      });
+
+      expect(response.status).toBe(400);
+    });
   });
 
   describe("POST /api/resumes/audit-outcome", () => {

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -1283,19 +1283,27 @@ app.post("/api/resumes/audit-logs", async (c) => {
   const body = await c.req.json().catch(() => ({}));
   const workspaceSlug = typeof body.workspaceSlug === "string" ? body.workspaceSlug.trim() : "";
   const decisionType = typeof body.decisionType === "string" ? body.decisionType.trim() : undefined;
+  const outcome = typeof body.outcome === "string" ? body.outcome.trim() : undefined;
 
   if (!workspaceSlug) {
     return c.json({ success: false, error: "workspaceSlug is required" }, 400);
   }
 
-  if (decisionType && decisionType !== "score" && decisionType !== "tag" && decisionType !== "confirm") {
-    return c.json({ success: false, error: "decisionType must be 'score', 'tag', or 'confirm'" }, 400);
+  const validDecisionTypes = ["score", "tag", "rank", "filter", "confirm"];
+  if (decisionType && !validDecisionTypes.includes(decisionType)) {
+    return c.json({ success: false, error: `decisionType must be one of: ${validDecisionTypes.join(", ")}` }, 400);
+  }
+
+  const validOutcomes = ["pending", "accepted", "overridden", "appealed"];
+  if (outcome && !validOutcomes.includes(outcome)) {
+    return c.json({ success: false, error: `outcome must be one of: ${validOutcomes.join(", ")}` }, 400);
   }
 
   try {
     const logs = await callConvexQuery("audit:getAuditLogByWorkspace", {
       workspaceSlug,
       ...(decisionType ? { decisionType } : {}),
+      ...(outcome ? { outcome } : {}),
     });
 
     return c.json({ success: true, data: logs }, 200);

--- a/packages/convex/convex/__tests__/audit-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/audit-convex-test.test.ts
@@ -223,6 +223,63 @@ describe("audit (convex-test)", () => {
       });
       expect(allLogs.length).toBe(2);
     });
+
+    it("filters audit logs by outcome", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "outcome-filter-r1",
+          content: {},
+          hash: "outcome-filter1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+      });
+
+      const now = Date.now();
+      await t.run(async (ctx) => {
+        await ctx.db.insert("analysis_audit_log", {
+          resumeId,
+          workspaceSlug: "ws-outcome-filter",
+          decisionType: "score",
+          actionRef: "analyze:analyzeResume",
+          inputSnapshot: {},
+          modelMeta: { model: "gpt-4", provider: "openai" },
+          output: { score: 90 },
+          outcome: "pending",
+          decidedAt: now,
+          expiresAt: now + 2 * 365 * 24 * 60 * 60 * 1000,
+        });
+        await ctx.db.insert("analysis_audit_log", {
+          resumeId,
+          workspaceSlug: "ws-outcome-filter",
+          decisionType: "confirm",
+          actionRef: "analyze:confirmSearchResults",
+          inputSnapshot: {},
+          modelMeta: { model: "gpt-4", provider: "openai" },
+          output: { score: 85 },
+          outcome: "accepted",
+          decidedAt: now + 1000,
+          expiresAt: now + 2 * 365 * 24 * 60 * 60 * 1000,
+        });
+      });
+
+      const pendingLogs = await t.query(api.audit.getAuditLogByWorkspace, {
+        workspaceSlug: "ws-outcome-filter",
+        outcome: "pending",
+      });
+      expect(pendingLogs.length).toBe(1);
+      expect(pendingLogs[0].outcome).toBe("pending");
+
+      const acceptedLogs = await t.query(api.audit.getAuditLogByWorkspace, {
+        workspaceSlug: "ws-outcome-filter",
+        outcome: "accepted",
+      });
+      expect(acceptedLogs.length).toBe(1);
+      expect(acceptedLogs[0].outcome).toBe("accepted");
+    });
   });
 
   describe("confirm audit log (decisionType: confirm)", () => {

--- a/packages/convex/convex/audit.ts
+++ b/packages/convex/convex/audit.ts
@@ -165,10 +165,27 @@ export const getAuditLogByWorkspace = query({
             v.literal("filter"),
             v.literal("confirm"),
         )),
+        outcome: v.optional(v.union(
+            v.literal("pending"),
+            v.literal("accepted"),
+            v.literal("overridden"),
+            v.literal("appealed"),
+        )),
         limit: v.optional(v.number()),
     },
     handler: async (ctx, args) => {
         const limit = Math.min(args.limit ?? 50, 200);
+
+        // Use outcome-indexed query when filtering by outcome (human oversight dashboard)
+        if (args.outcome && !args.decisionType) {
+            return ctx.db
+                .query("analysis_audit_log")
+                .withIndex("by_workspace_outcome", (q) =>
+                    q.eq("workspaceSlug", args.workspaceSlug).eq("outcome", args.outcome!)
+                )
+                .order("desc")
+                .take(limit);
+        }
 
         if (args.decisionType) {
             return ctx.db


### PR DESCRIPTION
## Summary
- Add optional `outcome` parameter to `getAuditLogByWorkspace` Convex query
- Frontend can now query for pending-review entries: `POST /api/resumes/audit-logs { workspaceSlug, outcome: "pending" }`
- Uses the existing `by_workspace_outcome` index for efficient lookups
- BFF endpoint expanded: validates `outcome` (pending/accepted/overridden/appealed) and `decisionType` (now all 5 types)
- +1 convex-test for outcome filtering, +2 BFF tests for outcome parameter

## EU AI Act Compliance
This enables the human oversight dashboard (Art. 14) to:
- Query pending entries requiring human review
- Filter by outcome to track review progress
- Surface entries that have been overridden or appealed

## Test plan
- [x] `npx vitest run packages/convex/` — 80 files, 1565 tests passing
- [x] BFF audit-logs tests — 6/6 passing
- [x] `npx tsc --noEmit --project packages/convex/tsconfig.json` — clean