### PR TITLE
refactor: narrow matchingRules validator from v.any() to typed primitives

### DIFF
--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -55,6 +55,7 @@ import {
     USER_PROMPT_TEMPLATE,
     type ChatMessage,
 } from "./lib/analysis_config.js";
+import { matchingRulesValidator } from "./validators.js";
 
 // Re-export for backward compatibility
 export {
@@ -242,7 +243,7 @@ export const analyzeResume = action({
             title: v.string(),
             requirements: v.string(),
         })),
-        matchingRules: v.optional(v.union(v.string(), v.record(v.string(), v.any()), v.array(v.any()))),
+        matchingRules: matchingRulesValidator,
         jobDescriptionId: v.optional(v.string()), // Added ID
         keywords: v.optional(v.array(v.string())),
     },
@@ -371,7 +372,7 @@ export const analyzeBatch = action({
             title: v.string(),
             requirements: v.string(),
         })),
-        matchingRules: v.optional(v.union(v.string(), v.record(v.string(), v.any()), v.array(v.any()))),
+        matchingRules: matchingRulesValidator,
         jobDescriptionId: v.optional(v.string()),
         keywords: v.optional(v.array(v.string())),
     },

--- a/packages/convex/convex/validators.ts
+++ b/packages/convex/convex/validators.ts
@@ -180,3 +180,8 @@ export const resumeFiltersValidator = v.optional(v.object({
         v.literal("desc"),
     )),
 }));
+
+// --- Matching rules (analyze args) ---
+
+const primitiveValueValidator = v.union(v.string(), v.number(), v.boolean());
+export const matchingRulesValidator = v.optional(v.union(v.string(), v.record(v.string(), primitiveValueValidator), v.array(primitiveValueValidator)));


### PR DESCRIPTION
## Summary
- Replace `v.any()` in `analyze.ts` `matchingRules` args with `matchingRulesValidator` using `v.union(v.string(), v.record(string, primitives), v.array(primitives))`
- Add `primitiveValueValidator` and `matchingRulesValidator` to `validators.ts` as shared building blocks
- Reduces `v.any()` call sites from 12 to 8

## Remaining v.any() sites (8)
These are genuinely untypeable without recursive Convex validators:
- `resumes.content` (3 sites) — arbitrary crawler JSON payloads
- `analyses` bridge (1 site) — migration-dependent, removed after backfill
- `workspace_config.configValue` (3 sites) — generic KV store with deeply nested values (bias reports, filter presets)
- `search_profiles.profile` (1 site) — nested config objects

## Test plan
- [x] `npx tsc --noEmit --project packages/convex/tsconfig.json` — clean
- [x] Full suite: 81 files, 1601 tests pass