### PR TITLE
fix: remove unused imports from re-export-only symbols

### DIFF
--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -28,18 +28,11 @@ import {
     normalizeAnalysisResult,
     parseRoleSignals,
     INDUSTRY_DB_SCORE_CAP,
-    RELATED_EXP_WEIGHT,
-    type AnalysisRecommendation,
-    type KeyFactor,
-    type NormalizedMatchedWorkEntry,
-    type NormalizedRoleSignal,
 } from "./lib/analysis_normalization.js";
 import {
     isEnglishResumeAiLocale,
     formatRoleSignals,
     hydrateUserPrompt,
-    buildKeywordRequirements,
-    buildKeywordMatchingRules,
     buildConfirmPrompt,
 } from "./lib/analysis_prompts.js";
 import {
@@ -51,8 +44,6 @@ import {
     getAiApiBase,
     getAiModel,
     getAiTemperature,
-    SYSTEM_PROMPT,
-    USER_PROMPT_TEMPLATE,
     type ChatMessage,
 } from "./lib/analysis_config.js";
 import { matchingRulesValidator } from "./validators.js";

--- a/packages/convex/convex/lib/analysis_normalization.ts
+++ b/packages/convex/convex/lib/analysis_normalization.ts
@@ -6,7 +6,6 @@
  */
 import {
     isRecord,
-    sanitizeResumeRecordForSurface,
 } from "@trends/shared";
 
 // ---------------------------------------------------------------------------

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -40,18 +40,13 @@ import {
     matchesAllTokens,
 } from "./resume_helpers.js";
 import {
-    resolveDiagnosticsSourceKeyForResume,
     matchesDiagnosticsSourceKeys,
     buildDiagnosticsSourceFacetRows,
     projectIngestDiagnosticsRow,
     normalizeDiagnosticsSourceFilterValues,
     MAX_INGEST_DIAGNOSTICS_PAGE_SIZE,
-    MAX_INGEST_DIAGNOSTICS_TAGGING_ENTRIES,
     DIAGNOSTICS_SOURCE_FILTER_BATCH_MULTIPLIER,
-    type IngestDiagnosticsBrandHit,
-    type IngestDiagnosticsTaggingEntry,
     type IngestDiagnosticsRow,
-    type DiagnosticsSourceFacetRow,
 } from "./lib/resumes_diagnostics.js";
 import {
     normalizeTagExpansionKeywordGroups,
@@ -62,7 +57,6 @@ import {
     matchesTagExpansionSearchText,
     collectSearchTextProvenance,
     type TagExpansionKeywordGroup,
-    type MatchSource,
     type SearchProvenance,
 } from "./lib/resumes_tag_expansion.js";
 


### PR DESCRIPTION
## Summary
- Remove imports of symbols only used in re-export blocks (not in file body) from `analyze.ts`, `resumes.ts`, and `analysis_normalization.ts`
- Symbols are still re-exported via separate `export { ... } from` statements for backward compatibility
- Fixes `make check` typecheck failures (TS6133 unused variable errors)

## Test plan
- [x] `npx tsc --noEmit --project packages/convex/tsconfig.json` — clean
- [x] Full suite: 82 files, 1678 tests pass