### PR TITLE
fix: remove unused INDUSTRY_DB_SCORE_CAP import from analyze.ts

### DIFF
--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -27,7 +27,6 @@ import {
     normalizeSummaryConsistency,
     normalizeAnalysisResult,
     parseRoleSignals,
-    INDUSTRY_DB_SCORE_CAP,
 } from "./lib/analysis_normalization.js";
 import {
     isEnglishResumeAiLocale,


### PR DESCRIPTION
## Summary
- Remove unused `INDUSTRY_DB_SCORE_CAP` import from `analyze.ts` (only used in re-export, not file body)
- Still re-exported via `export { ... } from` for backward compatibility

## Test plan
- [x] `npx tsc --noEmit --project packages/convex/tsconfig.json` — clean