### PR TITLE
fix: remove all unused analysis_normalization imports from analyze.ts

### DIFF
--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -14,17 +14,6 @@ import { action, internalMutation, type ActionCtx } from "./_generated/server";
 import { resolveChatCompletionModel } from "./lib/ai_model";
 import { computeProtectedAttributeHashes } from "./audit.js";
 import {
-    toNumber,
-    clamp,
-    parseKeyFactors,
-    parseNumericBreakdown,
-    hasNonEmployerBrandHits,
-    hasCompanyHits,
-    getResumeIngestData,
-    computeDirectIndustryDbScoreFromResume,
-    recommendationFromScore,
-    hasHanText,
-    normalizeSummaryConsistency,
     normalizeAnalysisResult,
     parseRoleSignals,
 } from "./lib/analysis_normalization.js";


### PR DESCRIPTION
## Summary
- Remove 11 unused imports from `analyze.ts` that were only re-exported, not used in the file body
- Only `normalizeAnalysisResult` and `parseRoleSignals` are actually used
- All symbols still available via re-export statements for backward compatibility

## Test plan
- [x] `npx tsc --noEmit --project packages/convex/tsconfig.json` — clean
- [x] Full suite: 82 files, 1678 tests pass