### PR TITLE
feat: wire setAuditOutcome into AI tagging path (EU AI Act Art. 14)

### DIFF
--- a/packages/convex/convex/__tests__/audit-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/audit-convex-test.test.ts
@@ -1169,5 +1169,52 @@ describe("audit log retention (EU AI Act / GDPR)", () => {
       expect(afterSet!.outcomeSetAt).toBeDefined();
       expect(afterSet!.reviewedAt).toBeDefined();
     });
+
+    it("supports tag-then-set-outcome flow", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "tag-flow-r1",
+          content: {},
+          hash: "tag-flow1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+      });
+
+      // Simulate the tagging flow: logAnalysisDecision then setAuditOutcome
+      const auditLogId = await t.mutation(internal.audit.logAnalysisDecision, {
+        resumeId,
+        workspaceSlug: "ws-tag-flow",
+        decisionType: "tag",
+        actionRef: "ai_tagging_results:drainQueue",
+        inputSnapshot: {
+          profileKey: "default",
+          promptVersion: "v1",
+        },
+        modelMeta: { model: "gpt-4", provider: "openai", promptTokens: 100, completionTokens: 50 },
+        output: { roleFit: "strong", confidence: 0.9, tags: ["senior", "cnc"], recommendation: "strong_match" },
+        decidedAt: Date.now(),
+      });
+
+      // Verify initial state is "pending"
+      const beforeSet = await t.run(async (ctx) => ctx.db.get(auditLogId));
+      expect(beforeSet!.outcome).toBe("pending");
+      expect(beforeSet!.decisionType).toBe("tag");
+
+      // Set outcome to "accepted" (mimics the automatic wiring in drainQueue)
+      await t.mutation(api.audit.setAuditOutcome, {
+        auditLogId,
+        outcome: "accepted",
+        setBy: "system:ai_tagging_results",
+      });
+
+      const afterSet = await t.run(async (ctx) => ctx.db.get(auditLogId));
+      expect(afterSet!.outcome).toBe("accepted");
+      expect(afterSet!.outcomeSetBy).toBe("system:ai_tagging_results");
+      expect(afterSet!.outcomeSetAt).toBeDefined();
+    });
   });
 });

--- a/packages/convex/convex/ai_tagging_results.ts
+++ b/packages/convex/convex/ai_tagging_results.ts
@@ -1,6 +1,6 @@
 /// <reference path="./convex-env.d.ts" />
 import { isRecord, buildLatestWorkHistoryEvidence } from "@trends/shared";
-import { internal } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { internalAction, internalMutation, internalQuery, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
@@ -769,7 +769,7 @@ export const drainQueue = internalAction({
             source: typeof resume.source === "string" ? resume.source : undefined,
           });
 
-          await ctx.runMutation(internal.audit.logAnalysisDecision, {
+          const auditLogId = await ctx.runMutation(internal.audit.logAnalysisDecision, {
             resumeId: row.resumeId,
             identityKey: row.identityKey ?? undefined,
             workspaceSlug: row.workspaceSlug,
@@ -796,6 +796,14 @@ export const drainQueue = internalAction({
             decidedAt: Date.now(),
             actorId: "system",
             actorRole: "system",
+          });
+
+          // Auto-set outcome to "accepted" for successful tag decisions
+          // (Human overrides via setAuditOutcome mutation still possible)
+          await ctx.runMutation(api.audit.setAuditOutcome, {
+            auditLogId,
+            outcome: "accepted",
+            setBy: "system:ai_tagging_results",
           });
         } catch (auditError) {
           console.error("Audit logging failed for tagging:", auditError);


### PR DESCRIPTION
## Summary
- Auto-set audit outcome to "accepted" after successful tag decisions in `drainQueue`
- Matches the pattern already used in `confirmSearchResults` (analyze.ts)
- Human overrides still possible via `setAuditOutcome` mutation
- Adds convex-test for the tag→setAuditOutcome chaining flow

## Context
Deep research cycle 9 identified that `setAuditOutcome` was only wired into the confirm flow, not the tagging flow. This completes the audit outcome coverage for all 3 automated decision types (score, confirm, tag).

## Test plan
- [x] `npx vitest run packages/convex/convex/__tests__/audit-convex-test.test.ts` — 36/36 pass
- [x] `npx tsc --noEmit --project packages/convex/tsconfig.json` — clean