### PR TITLE
feat: wire setAuditOutcome into analyzeResume score path (EU AI Act Art. 14)

### DIFF
--- a/packages/convex/convex/__tests__/audit-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/audit-convex-test.test.ts
@@ -1216,5 +1216,59 @@ describe("audit log retention (EU AI Act / GDPR)", () => {
       expect(afterSet!.outcomeSetBy).toBe("system:ai_tagging_results");
       expect(afterSet!.outcomeSetAt).toBeDefined();
     });
+
+    it("supports score-then-set-outcome flow", async () => {
+      const t = convexTest(schema, modules);
+
+      const resumeId = await t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+          externalId: "score-flow-r1",
+          content: {},
+          hash: "score-flow1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+        });
+      });
+
+      // Simulate the scoring flow: logAnalysisDecision then setAuditOutcome
+      const auditLogId = await t.mutation(internal.audit.logAnalysisDecision, {
+        resumeId,
+        workspaceSlug: "ws-score-flow",
+        decisionType: "score",
+        actionRef: "analyze:analyzeResume",
+        inputSnapshot: {
+          jobDescriptionId: "jd-test",
+          promptVersion: "1",
+        },
+        modelMeta: { model: "gpt-4", provider: "openai", promptTokens: 200, completionTokens: 100 },
+        output: { score: 85, recommendation: "strong_match" },
+        protectedAttributeHashes: {},
+        explanation: {
+          summary: "Scored 85/100 against test JD",
+          keyFactors: [{ factor: "experience", value: "5 years CNC" }],
+        },
+        decidedAt: Date.now(),
+        actorId: "system",
+        actorRole: "system",
+      });
+
+      // Verify initial state is "pending"
+      const beforeSet = await t.run(async (ctx) => ctx.db.get(auditLogId));
+      expect(beforeSet!.outcome).toBe("pending");
+      expect(beforeSet!.decisionType).toBe("score");
+
+      // Set outcome to "accepted" (mimics the automatic wiring in analyzeResume)
+      await t.mutation(api.audit.setAuditOutcome, {
+        auditLogId,
+        outcome: "accepted",
+        setBy: "system:analyzeResume",
+      });
+
+      const afterSet = await t.run(async (ctx) => ctx.db.get(auditLogId));
+      expect(afterSet!.outcome).toBe("accepted");
+      expect(afterSet!.outcomeSetBy).toBe("system:analyzeResume");
+      expect(afterSet!.outcomeSetAt).toBeDefined();
+    });
   });
 });

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -300,7 +300,7 @@ export const analyzeResume = action({
         try {
             const { scrubbedFields, protectedHashes } = computeAuditFields(resume as Record<string, unknown>);
 
-            await ctx.runMutation(internal.audit.logAnalysisDecision, {
+            const auditLogId = await ctx.runMutation(internal.audit.logAnalysisDecision, {
                 resumeId: args.resumeId,
                 identityKey: resume.identityKey ?? undefined,
                 workspaceSlug: resume.sourceKey ?? "default",
@@ -334,6 +334,14 @@ export const analyzeResume = action({
                 decidedAt: Date.now(),
                 actorId: "system",
                 actorRole: "system",
+            });
+
+            // Auto-set outcome to "accepted" for successful score decisions
+            // (Human overrides via setAuditOutcome mutation still possible)
+            await ctx.runMutation(api.audit.setAuditOutcome, {
+                auditLogId,
+                outcome: "accepted",
+                setBy: "system:analyzeResume",
             });
         } catch (auditError) {
             // Audit logging failure must NOT block the analysis result


### PR DESCRIPTION
## Summary
- Auto-set audit outcome to "accepted" after successful score decisions in `analyzeResume`
- Completes audit outcome coverage for all 3 automated decision types:
  - **score** (analyzeResume) — NOW wired
  - **tag** (drainQueue) — wired in #1052
  - **confirm** (confirmSearchResults) — wired in #1041
- Adds convex-test for the score→setAuditOutcome chaining flow

## Test plan
- [x] `npx vitest run packages/convex/convex/__tests__/audit-convex-test.test.ts` — 37/37 pass
- [x] `npx tsc --noEmit --project packages/convex/tsconfig.json` — clean