### PR TITLE
feat: add audit & compliance page (EU AI Act Art. 12-14)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -43,6 +43,11 @@ const LazySummaryRunsPage = lazy(async () => {
 
 const LazySearchAnalyticsPage = lazy(() => import('@/pages/SearchAnalyticsPage'))
 
+const LazyAuditCompliancePage = lazy(async () => {
+  const module = await import('@/pages/AuditCompliancePage')
+  return { default: module.AuditCompliancePage }
+})
+
 const LazySystemSettingsConfigSourcesPage = lazy(async () => {
   const module = await import('@/pages/system-settings/SystemSettingsConfigSourcesPage')
   return { default: module.SystemSettingsConfigSourcesPage }
@@ -287,6 +292,14 @@ function App() {
                 element={(
                   <RouteSuspense>
                     <LazySearchAnalyticsPage />
+                  </RouteSuspense>
+                )}
+              />
+              <Route
+                path="audit-compliance"
+                element={(
+                  <RouteSuspense>
+                    <LazyAuditCompliancePage />
                   </RouteSuspense>
                 )}
               />

--- a/apps/web/src/components/SystemSidebar.tsx
+++ b/apps/web/src/components/SystemSidebar.tsx
@@ -14,6 +14,7 @@ import {
   Database,
   BarChart3,
   Archive,
+  ShieldCheck,
   X,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -41,6 +42,7 @@ const NAV_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   'search-analytics': BarChart3,
   'data-inspector': LayoutDashboard,
   archived: Archive,
+  'audit-compliance': ShieldCheck,
 }
 
 interface SystemSidebarProps {

--- a/apps/web/src/hooks/useAuditLogs.ts
+++ b/apps/web/src/hooks/useAuditLogs.ts
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useState } from 'react'
+import { rawApiClient } from '@/lib/api-helpers'
+
+export type AuditLogEntry = {
+  _id: string
+  resumeId: string
+  identityKey?: string
+  workspaceSlug: string
+  decisionType: 'score' | 'tag' | 'rank' | 'filter' | 'confirm'
+  actionRef: string
+  inputSnapshot: {
+    jobDescriptionId?: string
+    profileKey?: string
+    promptVersion?: string
+    fieldUsagePolicyVersion?: number
+    scrubbedFields?: string[]
+    searchKeywords?: string[]
+    searchLocation?: string
+  }
+  modelMeta: {
+    model: string
+    provider: string
+    apiBase?: string
+    promptTokens?: number
+    completionTokens?: number
+    latencyMs?: number
+  }
+  output: {
+    score?: number
+    recommendation?: string
+    roleFit?: string
+    confidence?: number
+    tags?: string[]
+  }
+  protectedAttributeHashes?: {
+    ageBracketHash?: string
+    genderHash?: string
+    locationHash?: string
+    sourceHash?: string
+  }
+  explanation?: {
+    summary: string
+    keyFactors: Array<{ factor: string; weight?: number; value: string }>
+    modelReasoning?: string
+  }
+  outcome?: 'pending' | 'accepted' | 'overridden' | 'appealed'
+  outcomeSetBy?: string
+  outcomeSetAt?: number
+  anomalyFlags?: {
+    statisticalParityViolation?: boolean
+    disparateImpactViolation?: boolean
+    scoreDriftDetected?: boolean
+    psiValue?: number
+    flagReason?: string
+  }
+  actorId?: string
+  actorRole?: 'admin' | 'operator' | 'system'
+  decidedAt: number
+  reviewedAt?: number
+  expiresAt: number
+}
+
+type AuditLogsResponse = {
+  success: boolean
+  data?: AuditLogEntry[]
+  error?: string
+}
+
+type AuditOutcomeResponse = {
+  success: boolean
+  error?: string
+}
+
+type BiasReportData = Record<string, unknown>
+
+type BiasReportResponse = {
+  success: boolean
+  report?: BiasReportData | null
+  error?: string
+}
+
+export type AuditLogFilters = {
+  decisionType?: string
+  outcome?: string
+}
+
+export function useAuditLogs(workspaceSlug: string, enabled: boolean = true) {
+  const [logs, setLogs] = useState<AuditLogEntry[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [filters, setFilters] = useState<AuditLogFilters>({})
+
+  const load = useCallback(async () => {
+    if (!enabled || !workspaceSlug.trim()) {
+      setLoading(false)
+      setError(null)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    const { data, error: apiError } = await rawApiClient.POST<AuditLogsResponse>(
+      '/api/resumes/audit-logs',
+      {
+        body: {
+          workspaceSlug,
+          ...(filters.decisionType ? { decisionType: filters.decisionType } : {}),
+          ...(filters.outcome ? { outcome: filters.outcome } : {}),
+        },
+      },
+    )
+
+    if (apiError || !data?.success) {
+      setError(data?.error ?? 'Failed to load audit logs')
+      setLoading(false)
+      return
+    }
+
+    setLogs(Array.isArray(data.data) ? data.data : [])
+    setLoading(false)
+  }, [enabled, workspaceSlug, filters.decisionType, filters.outcome])
+
+  const setOutcome = useCallback(
+    async (auditLogId: string, outcome: 'accepted' | 'overridden' | 'appealed', setBy?: string) => {
+      const { data, error: apiError } = await rawApiClient.POST<AuditOutcomeResponse>(
+        '/api/resumes/audit-outcome',
+        { body: { auditLogId, outcome, ...(setBy ? { setBy } : {}) } },
+      )
+
+      if (apiError || !data?.success) {
+        setError(data?.error ?? 'Failed to set audit outcome')
+        return false
+      }
+
+      await load()
+      return true
+    },
+    [load],
+  )
+
+  useEffect(() => {
+    if (!enabled) {
+      setLogs([])
+      return
+    }
+    void load()
+  }, [enabled, load])
+
+  return {
+    logs,
+    loading,
+    error,
+    filters,
+    setFilters,
+    reload: load,
+    setOutcome,
+  }
+}
+
+export function useBiasReport(workspaceSlug: string, enabled: boolean = true) {
+  const [report, setReport] = useState<BiasReportData | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    if (!enabled || !workspaceSlug.trim()) {
+      setLoading(false)
+      setError(null)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    const { data, error: apiError } = await rawApiClient.GET<BiasReportResponse>(
+      '/api/resumes/bias-report',
+      { params: { query: { workspaceSlug } } },
+    )
+
+    if (apiError || !data?.success) {
+      setError(data?.error ?? 'Failed to load bias report')
+      setLoading(false)
+      return
+    }
+
+    setReport(data.report ?? null)
+    setLoading(false)
+  }, [enabled, workspaceSlug])
+
+  useEffect(() => {
+    if (!enabled) {
+      setReport(null)
+      return
+    }
+    void load()
+  }, [enabled, load])
+
+  return {
+    report,
+    loading,
+    error,
+    reload: load,
+  }
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -16,7 +16,8 @@
     "jds": "JDs",
     "archived": "Archived",
     "aiTaggingCompare": "AI Tagging (Compare)",
-    "dataInspector": "Data Inspector"
+    "dataInspector": "Data Inspector",
+    "auditCompliance": "Audit & Compliance"
   },
   "common": {
     "loading": "Loading",
@@ -1332,5 +1333,55 @@
     "feedbackImportSuccess": "Imported {{count}} reviewed rows",
     "summaryCardDescription": "Generate the WeChat summary preview, then send it with the configured template and optional webhook override.",
     "webhookUrlPlaceholder": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=***"
+  },
+  "auditCompliance": {
+    "title": "Audit & Compliance",
+    "description": "EU AI Act compliance dashboard — audit trail, human oversight, and bias monitoring.",
+    "pendingBadge": "{{count}} pending review",
+    "anomalyBadge": "{{count}} anomaly flags",
+    "biasReport": {
+      "title": "Bias Audit Report",
+      "description": "Latest bias metrics report (EU AI Act Art. 12 — monitoring and documentation).",
+      "workspace": "Workspace",
+      "generatedAt": "Generated At",
+      "anomalyDetected": "Anomaly Detected",
+      "noReport": "No bias audit report available yet."
+    },
+    "auditLog": {
+      "title": "Decision Audit Log",
+      "description": "All automated decisions with human oversight tracking (EU AI Act Art. 14).",
+      "empty": "No audit log entries found."
+    },
+    "filters": {
+      "decisionType": "Decision Type",
+      "outcome": "Outcome",
+      "all": "All"
+    },
+    "columns": {
+      "time": "Time",
+      "type": "Type",
+      "action": "Action",
+      "model": "Model",
+      "output": "Output",
+      "outcome": "Outcome",
+      "actor": "Actor",
+      "anomaly": "Anomaly",
+      "actions": "Actions"
+    },
+    "actions": {
+      "review": "Review"
+    },
+    "setOutcome": {
+      "title": "Set Audit Outcome",
+      "description": "Set the human oversight outcome for this automated decision (EU AI Act Art. 14).",
+      "decisionType": "Decision Type",
+      "score": "Score",
+      "recommendation": "Recommendation",
+      "confirm": "Set Outcome"
+    },
+    "toasts": {
+      "outcomeSet": "Audit outcome updated",
+      "outcomeFailed": "Failed to update audit outcome"
+    }
   }
 }

--- a/apps/web/src/pages/AuditCompliancePage.test.tsx
+++ b/apps/web/src/pages/AuditCompliancePage.test.tsx
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowserRouter } from 'react-router-dom'
+import { AuditCompliancePage } from './AuditCompliancePage'
+
+const mockSetOutcome = vi.fn().mockResolvedValue(true)
+
+// Mock the workspace context
+vi.mock('@/contexts/WorkspaceContext', () => ({
+  useWorkspace: () => ({ slug: 'test-workspace', isAdmin: true }),
+}))
+
+// Mock the audit hooks
+const mockLogs = [
+  {
+    _id: 'al1',
+    resumeId: 'r1',
+    workspaceSlug: 'test-workspace',
+    decisionType: 'score' as const,
+    actionRef: 'analyze:analyzeResume',
+    inputSnapshot: {},
+    modelMeta: { model: 'gpt-4', provider: 'openai' },
+    output: { score: 85, recommendation: 'strong_match' },
+    outcome: 'accepted' as const,
+    outcomeSetBy: 'system:analyzeResume',
+    decidedAt: Date.now() - 3600000,
+    expiresAt: Date.now() + 86400000,
+  },
+  {
+    _id: 'al2',
+    resumeId: 'r2',
+    workspaceSlug: 'test-workspace',
+    decisionType: 'tag' as const,
+    actionRef: 'ai_tagging_results:drainQueue',
+    inputSnapshot: {},
+    modelMeta: { model: 'gpt-4', provider: 'openai' },
+    output: { tags: ['senior', 'python'] },
+    decidedAt: Date.now() - 1800000,
+    expiresAt: Date.now() + 86400000,
+  },
+  {
+    _id: 'al3',
+    resumeId: 'r3',
+    workspaceSlug: 'test-workspace',
+    decisionType: 'score' as const,
+    actionRef: 'analyze:analyzeResume',
+    inputSnapshot: {},
+    modelMeta: { model: 'gpt-4', provider: 'openai' },
+    output: { score: 30, recommendation: 'no_match' },
+    anomalyFlags: {
+      statisticalParityViolation: true,
+      flagReason: 'Score disparity detected',
+    },
+    decidedAt: Date.now() - 900000,
+    expiresAt: Date.now() + 86400000,
+  },
+]
+
+vi.mock('@/hooks/useAuditLogs', () => ({
+  useAuditLogs: () => ({
+    logs: mockLogs,
+    loading: false,
+    error: null,
+    filters: {},
+    setFilters: vi.fn(),
+    setOutcome: mockSetOutcome,
+  }),
+  useBiasReport: () => ({
+    report: {
+      generatedAt: Date.now(),
+      workspaceSlug: 'test-workspace',
+      anomalyDetected: true,
+    },
+    loading: false,
+    error: null,
+    reload: vi.fn(),
+  }),
+}))
+
+// Mock sonner
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+function renderPage() {
+  return render(
+    <BrowserRouter>
+      <AuditCompliancePage />
+    </BrowserRouter>,
+  )
+}
+
+describe('AuditCompliancePage', () => {
+  it('renders the page title and description', () => {
+    renderPage()
+    expect(screen.getByTestId('audit-compliance-page')).toBeInTheDocument()
+    expect(screen.getByText('Audit & Compliance')).toBeInTheDocument()
+  })
+
+  it('renders the bias audit report card', () => {
+    renderPage()
+    expect(screen.getByText('Bias Audit Report')).toBeInTheDocument()
+    expect(screen.getByText('test-workspace')).toBeInTheDocument()
+    expect(screen.getByText('Yes')).toBeInTheDocument()
+  })
+
+  it('renders the audit log table with entries', () => {
+    renderPage()
+    expect(screen.getByText('Decision Audit Log')).toBeInTheDocument()
+    expect(screen.getByTestId('audit-log-table')).toBeInTheDocument()
+    expect(screen.getAllByTestId('audit-log-row')).toHaveLength(3)
+  })
+
+  it('shows anomaly flag badge for entries with anomalies', () => {
+    renderPage()
+    const anomalyBadges = screen.getAllByTestId('anomaly-flag')
+    expect(anomalyBadges).toHaveLength(1)
+    expect(anomalyBadges[0]).toHaveTextContent('Score disparity detected')
+  })
+
+  it('shows Review button for pending entries', () => {
+    renderPage()
+    const reviewButtons = screen.getAllByTestId('set-outcome-btn')
+    expect(reviewButtons.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows pending count badge when there are pending entries', () => {
+    renderPage()
+    expect(screen.getByTestId('pending-count-badge')).toBeInTheDocument()
+  })
+
+  it('shows anomaly count badge when there are anomalies', () => {
+    renderPage()
+    expect(screen.getByTestId('anomaly-count-badge')).toBeInTheDocument()
+  })
+
+  it('opens outcome dialog when Review is clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    const reviewBtn = screen.getAllByTestId('set-outcome-btn')[0]
+    await user.click(reviewBtn)
+
+    await waitFor(() => {
+      expect(screen.getByText('Set Audit Outcome')).toBeInTheDocument()
+    })
+  })
+
+  it('calls setOutcome when confirming in dialog', async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    const reviewBtn = screen.getAllByTestId('set-outcome-btn')[0]
+    await user.click(reviewBtn)
+
+    await waitFor(() => {
+      expect(screen.getByText('Set Audit Outcome')).toBeInTheDocument()
+    })
+
+    const confirmBtn = screen.getByText('Set Outcome')
+    await user.click(confirmBtn)
+
+    expect(mockSetOutcome).toHaveBeenCalled()
+  })
+
+  it('renders decision type filter', () => {
+    renderPage()
+    expect(screen.getByTestId('filter-decision-type')).toBeInTheDocument()
+  })
+
+  it('renders outcome filter', () => {
+    renderPage()
+    expect(screen.getByTestId('filter-outcome')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/pages/AuditCompliancePage.tsx
+++ b/apps/web/src/pages/AuditCompliancePage.tsx
@@ -1,0 +1,464 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { PageHeader } from '@/components/PageHeader'
+import { useAuditLogs, useBiasReport } from '@/hooks/useAuditLogs'
+import { useWorkspace } from '@/contexts/WorkspaceContext'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Select } from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+type OutcomeValue = 'accepted' | 'overridden' | 'appealed'
+
+const DECISION_TYPE_FILTER_OPTIONS = [
+  { value: 'all', label: 'All Types' },
+  { value: 'score', label: 'score' },
+  { value: 'tag', label: 'tag' },
+  { value: 'rank', label: 'rank' },
+  { value: 'filter', label: 'filter' },
+  { value: 'confirm', label: 'confirm' },
+]
+
+const OUTCOME_FILTER_OPTIONS = [
+  { value: 'all', label: 'All Outcomes' },
+  { value: 'pending', label: 'pending' },
+  { value: 'accepted', label: 'accepted' },
+  { value: 'overridden', label: 'overridden' },
+  { value: 'appealed', label: 'appealed' },
+]
+
+const OUTCOME_OVERRIDE_OPTIONS: { value: OutcomeValue; label: string }[] = [
+  { value: 'accepted', label: 'accepted' },
+  { value: 'overridden', label: 'overridden' },
+  { value: 'appealed', label: 'appealed' },
+]
+
+const outcomeVariant = (outcome?: string): 'default' | 'secondary' | 'destructive' | 'outline' => {
+  switch (outcome) {
+    case 'accepted':
+      return 'default'
+    case 'overridden':
+      return 'destructive'
+    case 'appealed':
+      return 'secondary'
+    case 'pending':
+      return 'outline'
+    default:
+      return 'outline'
+  }
+}
+
+function OutcomeDialog({
+  open,
+  onClose,
+  onConfirm,
+  entry,
+  loading,
+}: {
+  open: boolean
+  onClose: () => void
+  onConfirm: (outcome: OutcomeValue) => void
+  entry: { _id: string; decisionType: string; output: { score?: number; recommendation?: string } } | null
+  loading: boolean
+}) {
+  const { t } = useTranslation()
+  const [selectedOutcome, setSelectedOutcome] = useState<OutcomeValue>('overridden')
+
+  if (!entry) return null
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {t('auditCompliance.setOutcome.title', { defaultValue: 'Set Audit Outcome' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('auditCompliance.setOutcome.description', {
+              defaultValue:
+                'Set the human oversight outcome for this automated decision (EU AI Act Art. 14).',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 py-2">
+          <div className="text-sm">
+            <span className="text-muted-foreground">
+              {t('auditCompliance.setOutcome.decisionType', { defaultValue: 'Decision Type' })}:
+            </span>{' '}
+            <Badge variant="outline">{entry.decisionType}</Badge>
+          </div>
+          {entry.output.score != null && (
+            <div className="text-sm">
+              <span className="text-muted-foreground">
+                {t('auditCompliance.setOutcome.score', { defaultValue: 'Score' })}:
+              </span>{' '}
+              {entry.output.score}
+            </div>
+          )}
+          {entry.output.recommendation && (
+            <div className="text-sm">
+              <span className="text-muted-foreground">
+                {t('auditCompliance.setOutcome.recommendation', { defaultValue: 'Recommendation' })}:
+              </span>{' '}
+              {entry.output.recommendation}
+            </div>
+          )}
+          <Select
+            value={selectedOutcome}
+            onChange={(e) => setSelectedOutcome(e.target.value as OutcomeValue)}
+            options={OUTCOME_OVERRIDE_OPTIONS}
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </Button>
+          <Button disabled={loading} onClick={() => onConfirm(selectedOutcome)}>
+            {t('auditCompliance.setOutcome.confirm', { defaultValue: 'Set Outcome' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function AuditCompliancePage() {
+  const { t } = useTranslation()
+  const { slug, isAdmin } = useWorkspace()
+  const { logs, loading, error, filters, setFilters, setOutcome } = useAuditLogs(slug, isAdmin)
+  const { report, loading: reportLoading, error: reportError } = useBiasReport(slug, isAdmin)
+
+  const [outcomeDialogEntry, setOutcomeDialogEntry] = useState<
+    (typeof logs)[number] | null
+  >(null)
+  const [settingOutcome, setSettingOutcome] = useState(false)
+
+  const sortedLogs = useMemo(
+    () => [...logs].sort((a, b) => b.decidedAt - a.decidedAt),
+    [logs],
+  )
+
+  const pendingCount = useMemo(
+    () => logs.filter((l) => l.outcome === 'pending' || !l.outcome).length,
+    [logs],
+  )
+
+  const anomalyCount = useMemo(
+    () => logs.filter((l) => l.anomalyFlags && Object.values(l.anomalyFlags).some(Boolean)).length,
+    [logs],
+  )
+
+  const handleSetOutcome = useCallback(
+    async (outcome: OutcomeValue) => {
+      if (!outcomeDialogEntry) return
+      setSettingOutcome(true)
+      const ok = await setOutcome(outcomeDialogEntry._id, outcome, 'human_reviewer')
+      setSettingOutcome(false)
+      if (ok) {
+        toast.success(
+          t('auditCompliance.toasts.outcomeSet', { defaultValue: 'Audit outcome updated' }),
+        )
+        setOutcomeDialogEntry(null)
+      } else {
+        toast.error(
+          t('auditCompliance.toasts.outcomeFailed', {
+            defaultValue: 'Failed to update audit outcome',
+          }),
+        )
+      }
+    },
+    [outcomeDialogEntry, setOutcome, t],
+  )
+
+  const biasReportSummary = useMemo(() => {
+    if (!report || typeof report !== 'object') return null
+    const r = report as Record<string, unknown>
+    return {
+      generatedAt:
+        typeof r.generatedAt === 'number' ? new Date(r.generatedAt).toLocaleString() : undefined,
+      workspaceSlug: typeof r.workspaceSlug === 'string' ? r.workspaceSlug : undefined,
+      anomalyDetected: typeof r.anomalyDetected === 'boolean' ? r.anomalyDetected : undefined,
+    }
+  }, [report])
+
+  return (
+    <div className="space-y-6" data-testid="audit-compliance-page">
+      <PageHeader
+        title={t('auditCompliance.title', { defaultValue: 'Audit & Compliance' })}
+        description={t('auditCompliance.description', {
+          defaultValue:
+            'EU AI Act compliance dashboard — audit trail, human oversight, and bias monitoring.',
+        })}
+        actions={
+          <div className="flex gap-2">
+            {pendingCount > 0 && (
+              <Badge variant="outline" data-testid="pending-count-badge">
+                {t('auditCompliance.pendingBadge', {
+                  defaultValue: '{{count}} pending review',
+                  count: pendingCount,
+                })}
+              </Badge>
+            )}
+            {anomalyCount > 0 && (
+              <Badge variant="destructive" data-testid="anomaly-count-badge">
+                {t('auditCompliance.anomalyBadge', {
+                  defaultValue: '{{count}} anomaly flags',
+                  count: anomalyCount,
+                })}
+              </Badge>
+            )}
+          </div>
+        }
+      />
+
+      {/* Bias Audit Report Summary */}
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {t('auditCompliance.biasReport.title', { defaultValue: 'Bias Audit Report' })}
+          </CardTitle>
+          <CardDescription>
+            {t('auditCompliance.biasReport.description', {
+              defaultValue:
+                'Latest bias metrics report (EU AI Act Art. 12 — monitoring and documentation).',
+            })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {reportLoading ? (
+            <div className="text-sm text-muted-foreground">
+              {t('resumes.loading', { defaultValue: 'Loading...' })}
+            </div>
+          ) : reportError ? (
+            <div className="text-sm text-destructive">{reportError}</div>
+          ) : biasReportSummary ? (
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+              <div>
+                <span className="text-muted-foreground">
+                  {t('auditCompliance.biasReport.workspace', { defaultValue: 'Workspace' })}:
+                </span>{' '}
+                {biasReportSummary.workspaceSlug ?? '-'}
+              </div>
+              <div>
+                <span className="text-muted-foreground">
+                  {t('auditCompliance.biasReport.generatedAt', {
+                    defaultValue: 'Generated At',
+                  })}
+                  :
+                </span>{' '}
+                {biasReportSummary.generatedAt ?? '-'}
+              </div>
+              <div>
+                <span className="text-muted-foreground">
+                  {t('auditCompliance.biasReport.anomalyDetected', {
+                    defaultValue: 'Anomaly Detected',
+                  })}
+                  :
+                </span>{' '}
+                {biasReportSummary.anomalyDetected != null ? (
+                  <Badge variant={biasReportSummary.anomalyDetected ? 'destructive' : 'default'}>
+                    {biasReportSummary.anomalyDetected ? 'Yes' : 'No'}
+                  </Badge>
+                ) : (
+                  '-'
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">
+              {t('auditCompliance.biasReport.noReport', {
+                defaultValue: 'No bias audit report available yet.',
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Audit Log Table */}
+      <Card>
+        <CardHeader className="gap-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <CardTitle>
+                {t('auditCompliance.auditLog.title', { defaultValue: 'Decision Audit Log' })}
+              </CardTitle>
+              <CardDescription>
+                {t('auditCompliance.auditLog.description', {
+                  defaultValue:
+                    'All automated decisions with human oversight tracking (EU AI Act Art. 14).',
+                })}
+              </CardDescription>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Select
+                value={filters.decisionType ?? 'all'}
+                onChange={(e) => setFilters((f) => ({ ...f, decisionType: e.target.value === 'all' ? undefined : e.target.value }))}
+                options={DECISION_TYPE_FILTER_OPTIONS}
+                className="w-[140px]"
+                data-testid="filter-decision-type"
+              />
+              <Select
+                value={filters.outcome ?? 'all'}
+                onChange={(e) => setFilters((f) => ({ ...f, outcome: e.target.value === 'all' ? undefined : e.target.value }))}
+                options={OUTCOME_FILTER_OPTIONS}
+                className="w-[140px]"
+                data-testid="filter-outcome"
+              />
+            </div>
+          </div>
+        </CardHeader>
+
+        <CardContent>
+          {loading ? (
+            <div className="text-sm text-muted-foreground">
+              {t('resumes.loading', { defaultValue: 'Loading...' })}
+            </div>
+          ) : error ? (
+            <div className="text-sm text-destructive">{error}</div>
+          ) : sortedLogs.length === 0 ? (
+            <div className="text-sm text-muted-foreground">
+              {t('auditCompliance.auditLog.empty', {
+                defaultValue: 'No audit log entries found.',
+              })}
+            </div>
+          ) : (
+            <Table data-testid="audit-log-table">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>
+                    {t('auditCompliance.columns.time', { defaultValue: 'Time' })}
+                  </TableHead>
+                  <TableHead>
+                    {t('auditCompliance.columns.type', { defaultValue: 'Type' })}
+                  </TableHead>
+                  <TableHead>
+                    {t('auditCompliance.columns.action', { defaultValue: 'Action' })}
+                  </TableHead>
+                  <TableHead>
+                    {t('auditCompliance.columns.model', { defaultValue: 'Model' })}
+                  </TableHead>
+                  <TableHead>
+                    {t('auditCompliance.columns.output', { defaultValue: 'Output' })}
+                  </TableHead>
+                  <TableHead>
+                    {t('auditCompliance.columns.outcome', { defaultValue: 'Outcome' })}
+                  </TableHead>
+                  <TableHead>
+                    {t('auditCompliance.columns.actor', { defaultValue: 'Actor' })}
+                  </TableHead>
+                  <TableHead>
+                    {t('auditCompliance.columns.anomaly', { defaultValue: 'Anomaly' })}
+                  </TableHead>
+                  <TableHead className="text-right">
+                    {t('auditCompliance.columns.actions', { defaultValue: 'Actions' })}
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sortedLogs.map((entry) => {
+                  const hasAnomaly =
+                    entry.anomalyFlags &&
+                    Object.entries(entry.anomalyFlags).some(
+                      ([k, v]) => k !== 'psiValue' && k !== 'flagReason' && v === true,
+                    )
+                  return (
+                    <TableRow key={entry._id} data-testid="audit-log-row">
+                      <TableCell className="text-xs whitespace-nowrap">
+                        {new Date(entry.decidedAt).toLocaleString()}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline">{entry.decisionType}</Badge>
+                      </TableCell>
+                      <TableCell className="text-xs font-mono max-w-[200px] truncate">
+                        {entry.actionRef}
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        {entry.modelMeta.model}
+                        <br />
+                        <span className="text-muted-foreground">{entry.modelMeta.provider}</span>
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        {entry.output.score != null && (
+                          <>
+                            Score: {entry.output.score}
+                            <br />
+                          </>
+                        )}
+                        {entry.output.recommendation && (
+                          <span>{entry.output.recommendation}</span>
+                        )}
+                        {entry.output.tags && entry.output.tags.length > 0 && (
+                          <span>{entry.output.tags.join(', ')}</span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={outcomeVariant(entry.outcome)}>
+                          {entry.outcome ?? 'pending'}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        {entry.actorRole ?? '-'}
+                        {entry.outcomeSetBy && (
+                          <>
+                            <br />
+                            <span className="text-muted-foreground">{entry.outcomeSetBy}</span>
+                          </>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {hasAnomaly ? (
+                          <Badge variant="destructive" data-testid="anomaly-flag">
+                            {entry.anomalyFlags?.flagReason ?? 'Yes'}
+                          </Badge>
+                        ) : (
+                          <span className="text-muted-foreground">-</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {(!entry.outcome || entry.outcome === 'pending') && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setOutcomeDialogEntry(entry)}
+                            data-testid="set-outcome-btn"
+                          >
+                            {t('auditCompliance.actions.review', { defaultValue: 'Review' })}
+                          </Button>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <OutcomeDialog
+        open={outcomeDialogEntry !== null}
+        onClose={() => setOutcomeDialogEntry(null)}
+        onConfirm={handleSetOutcome}
+        entry={outcomeDialogEntry}
+        loading={settingOutcome}
+      />
+    </div>
+  )
+}

--- a/packages/shared/src/system-debug-metadata.ts
+++ b/packages/shared/src/system-debug-metadata.ts
@@ -282,6 +282,13 @@ export const SYSTEM_NAV_ITEMS: SurfaceNavDefinition[] = [
     hrefSuffix: "/system/archived",
     matchesSuffixes: ["/system/archived"],
   },
+  {
+    id: "audit-compliance",
+    titleKey: "nav.auditCompliance",
+    defaultTitle: "Audit & Compliance",
+    hrefSuffix: "/system/audit-compliance",
+    matchesSuffixes: ["/system/audit-compliance"],
+  },
 ];
 
 export const SETTINGS_NAV_ITEMS: SurfaceNavDefinition[] = [


### PR DESCRIPTION
## Summary
- Adds a frontend compliance dashboard at `/:teamSlug/system/audit-compliance` for EU AI Act Art. 12-14
- **Bias audit report summary card** — shows latest bias metrics, anomaly detection status (Art. 12)
- **Decision audit log table** — lists all automated decisions with filtering by decision type and outcome (Art. 14)
- **Human oversight outcome dialog** — allows reviewers to set accepted/overridden/appealed on pending decisions
- **Anomaly flag badges** — highlights statistical parity violations and score drift
- New hooks: `useAuditLogs` and `useBiasReport` connecting to existing BFF endpoints

This closes the **P0 frontend compliance gap** identified by deep research — previously zero frontend UI for EU AI Act human oversight, bias monitoring, or right to explanation.

## Test plan
- [x] `vitest src/pages/AuditCompliancePage.test.tsx` — 11/11 pass
- [x] `make check` — all clean
- [x] `packages/shared/src/system-debug-metadata.test.ts` — 27/27 pass (new nav item)