### PR TITLE
fix: add zh-Hans/zh-Hant i18n keys for audit compliance + test type fixes

### DIFF
--- a/apps/web/src/hooks/useAuditLogs.test.ts
+++ b/apps/web/src/hooks/useAuditLogs.test.ts
@@ -16,8 +16,8 @@ type AuditLogEntry = {
 }
 
 const mockApiClient = vi.hoisted(() => ({
-  GET: vi.fn(async () => ({ data: { success: true } })),
-  POST: vi.fn(async () => ({ data: { success: true } })),
+  GET: vi.fn(async () => ({ data: { success: true } as Record<string, unknown> })),
+  POST: vi.fn(async () => ({ data: { success: true } as Record<string, unknown> })),
 }))
 
 vi.mock('@/lib/api-helpers', () => ({
@@ -65,7 +65,7 @@ describe('useAuditLogs', () => {
   })
 
   it('does not fetch when workspace slug is empty', async () => {
-    const { result } = renderHook(() => useAuditLogs('', true))
+    renderHook(() => useAuditLogs('', true))
     await act(async () => {})
 
     expect(mockApiClient.POST).not.toHaveBeenCalled()

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -16,7 +16,8 @@
     "jds": "职位",
     "archived": "已归档",
     "aiTaggingCompare": "AI 标注（对比）",
-    "dataInspector": "数据检查"
+    "dataInspector": "数据检查",
+    "auditCompliance": "审计与合规"
   },
   "common": {
     "loading": "加载中...",
@@ -1359,5 +1360,55 @@
     "feedbackImportSuccess": "已导入 {{count}} 行审阅数据",
     "summaryCardDescription": "生成 WeChat 摘要预览，然后使用配置的模板和可选的 webhook 覆盖发送。",
     "webhookUrlPlaceholder": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=***"
+  },
+  "auditCompliance": {
+    "title": "审计与合规",
+    "description": "EU AI Act 合规仪表盘 — 审计追踪、人工监督和偏差监控。",
+    "pendingBadge": "{{count}} 条待审核",
+    "anomalyBadge": "{{count}} 个异常标记",
+    "biasReport": {
+      "title": "偏差审计报告",
+      "description": "最新偏差指标报告（EU AI Act 第12条 — 监控与文档化）。",
+      "workspace": "工作区",
+      "generatedAt": "生成时间",
+      "anomalyDetected": "是否检测到异常",
+      "noReport": "暂无偏差审计报告。"
+    },
+    "auditLog": {
+      "title": "决策审计日志",
+      "description": "所有自动化决策及人工监督追踪（EU AI Act 第14条）。",
+      "empty": "未找到审计日志条目。"
+    },
+    "filters": {
+      "decisionType": "决策类型",
+      "outcome": "结果",
+      "all": "全部"
+    },
+    "columns": {
+      "time": "时间",
+      "type": "类型",
+      "action": "操作",
+      "model": "模型",
+      "output": "输出",
+      "outcome": "结果",
+      "actor": "操作者",
+      "anomaly": "异常",
+      "actions": "操作"
+    },
+    "actions": {
+      "review": "审核"
+    },
+    "setOutcome": {
+      "title": "设置审计结果",
+      "description": "为此自动化决策设置人工监督结果（EU AI Act 第14条）。",
+      "decisionType": "决策类型",
+      "score": "分数",
+      "recommendation": "推荐",
+      "confirm": "确认设置"
+    },
+    "toasts": {
+      "outcomeSet": "审计结果已更新",
+      "outcomeFailed": "更新审计结果失败"
+    }
   }
 }

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -16,7 +16,8 @@
     "jds": "職位",
     "archived": "已歸檔",
     "aiTaggingCompare": "AI 標註（對比）",
-    "dataInspector": "資料檢查"
+    "dataInspector": "資料檢查",
+    "auditCompliance": "稽核與合規"
   },
   "common": {
     "loading": "載入中...",
@@ -1332,5 +1333,55 @@
     "feedbackImportSuccess": "已匯入 {{count}} 行審閱資料",
     "summaryCardDescription": "生成 WeChat 摘要預覽，然後使用配置的模板和可選的 webhook 覆蓋發送。",
     "webhookUrlPlaceholder": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=***"
+  },
+  "auditCompliance": {
+    "title": "稽核與合規",
+    "description": "EU AI Act 合規儀表盤 — 稽核追蹤、人工監督和偏差監控。",
+    "pendingBadge": "{{count}} 條待審核",
+    "anomalyBadge": "{{count}} 個異常標記",
+    "biasReport": {
+      "title": "偏差稽核報告",
+      "description": "最新偏差指標報告（EU AI Act 第12條 — 監控與文檔化）。",
+      "workspace": "工作區",
+      "generatedAt": "生成時間",
+      "anomalyDetected": "是否偵測到異常",
+      "noReport": "暫無偏差稽核報告。"
+    },
+    "auditLog": {
+      "title": "決策稽核日誌",
+      "description": "所有自動化決策及人工監督追蹤（EU AI Act 第14條）。",
+      "empty": "未找到稽核日誌條目。"
+    },
+    "filters": {
+      "decisionType": "決策類型",
+      "outcome": "結果",
+      "all": "全部"
+    },
+    "columns": {
+      "time": "時間",
+      "type": "類型",
+      "action": "操作",
+      "model": "模型",
+      "output": "輸出",
+      "outcome": "結果",
+      "actor": "操作者",
+      "anomaly": "異常",
+      "actions": "操作"
+    },
+    "actions": {
+      "review": "審核"
+    },
+    "setOutcome": {
+      "title": "設置稽核結果",
+      "description": "為此自動化決策設置人工監督結果（EU AI Act 第14條）。",
+      "decisionType": "決策類型",
+      "score": "分數",
+      "recommendation": "推薦",
+      "confirm": "確認設置"
+    },
+    "toasts": {
+      "outcomeSet": "稽核結果已更新",
+      "outcomeFailed": "更新稽核結果失敗"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `auditCompliance` nav key and full section translations for zh-Hans and zh-Hant locales (follow-up to #1055)
- Fixes `useAuditLogs.test.ts` mock types to use `Record<string, unknown>` for strict TypeScript compliance
- Removes unused variable in empty-workspace test case

## Test plan
- [x] `make check` — all clean (typecheck + lint + i18n + governance)
- [x] `vitest src/hooks/useAuditLogs.test.ts` — 11/11 pass