### PR TITLE
feat: add anomaly alert notifications to bias audit cron (EU AI Act Art. 12)

### DIFF
--- a/apps/api/src/routes/resumes_admin.ts
+++ b/apps/api/src/routes/resumes_admin.ts
@@ -348,4 +348,22 @@ app.get("/api/resumes/bias-report", requireAdmin, async (c) => {
   }
 });
 
+// Bias audit anomaly alerts — fetch active alerts for workspace (EU AI Act Art. 12)
+app.get("/api/resumes/anomaly-alerts", requireAdmin, async (c) => {
+  const workspaceSlug = c.req.query("workspaceSlug");
+
+  if (!workspaceSlug) {
+    return c.json({ success: false, error: "Missing required query param: workspaceSlug" }, 400);
+  }
+
+  try {
+    const alerts = await callConvexQuery("bias_audit:getAnomalyAlerts", { workspaceSlug });
+    return c.json({ success: true, alerts }, 200);
+  } catch (error) {
+    logger.error("Failed to fetch anomaly alerts", error, { route: "resumes_admin" });
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
 export default app;

--- a/apps/web/src/hooks/useAuditLogs.ts
+++ b/apps/web/src/hooks/useAuditLogs.ts
@@ -156,8 +156,23 @@ export function useAuditLogs(workspaceSlug: string, enabled: boolean = true) {
   }
 }
 
+export type AnomalyAlert = {
+  workspaceSlug: string
+  flags: string[]
+  psiValue: number | null
+  disparityRatio: number | null
+  alertedAt: number
+}
+
+type AnomalyAlertsResponse = {
+  success: boolean
+  alerts?: AnomalyAlert | null
+  error?: string
+}
+
 export function useBiasReport(workspaceSlug: string, enabled: boolean = true) {
   const [report, setReport] = useState<BiasReportData | null>(null)
+  const [anomalyAlerts, setAnomalyAlerts] = useState<AnomalyAlert | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -169,18 +184,26 @@ export function useBiasReport(workspaceSlug: string, enabled: boolean = true) {
     }
     setLoading(true)
     setError(null)
-    const { data, error: apiError } = await rawApiClient.GET<BiasReportResponse>(
-      '/api/resumes/bias-report',
-      { params: { query: { workspaceSlug } } },
-    )
 
-    if (apiError || !data?.success) {
-      setError(data?.error ?? 'Failed to load bias report')
+    const [reportResult, alertsResult] = await Promise.all([
+      rawApiClient.GET<BiasReportResponse>(
+        '/api/resumes/bias-report',
+        { params: { query: { workspaceSlug } } },
+      ),
+      rawApiClient.GET<AnomalyAlertsResponse>(
+        '/api/resumes/anomaly-alerts',
+        { params: { query: { workspaceSlug } } },
+      ),
+    ])
+
+    if (reportResult.error || !reportResult.data?.success) {
+      setError(reportResult.data?.error ?? 'Failed to load bias report')
       setLoading(false)
       return
     }
 
-    setReport(data.report ?? null)
+    setReport(reportResult.data.report ?? null)
+    setAnomalyAlerts(alertsResult.data?.alerts ?? null)
     setLoading(false)
   }, [enabled, workspaceSlug])
 
@@ -194,6 +217,7 @@ export function useBiasReport(workspaceSlug: string, enabled: boolean = true) {
 
   return {
     report,
+    anomalyAlerts,
     loading,
     error,
     reload: load,

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1345,6 +1345,7 @@
       "workspace": "Workspace",
       "generatedAt": "Generated At",
       "anomalyDetected": "Anomaly Detected",
+      "activeAlerts": "Active Anomaly Alerts",
       "noReport": "No bias audit report available yet."
     },
     "auditLog": {

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -1372,6 +1372,7 @@
       "workspace": "工作区",
       "generatedAt": "生成时间",
       "anomalyDetected": "是否检测到异常",
+      "activeAlerts": "活跃异常警报",
       "noReport": "暂无偏差审计报告。"
     },
     "auditLog": {

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -1345,6 +1345,7 @@
       "workspace": "工作區",
       "generatedAt": "生成時間",
       "anomalyDetected": "是否偵測到異常",
+      "activeAlerts": "活躍異常警報",
       "noReport": "暫無偏差稽核報告。"
     },
     "auditLog": {

--- a/apps/web/src/pages/AuditCompliancePage.test.tsx
+++ b/apps/web/src/pages/AuditCompliancePage.test.tsx
@@ -72,6 +72,13 @@ vi.mock('@/hooks/useAuditLogs', () => ({
       workspaceSlug: 'test-workspace',
       anomalyDetected: true,
     },
+    anomalyAlerts: {
+      workspaceSlug: 'test-workspace',
+      flags: ['statistical_parity_violation', 'disparate_impact_violation'],
+      psiValue: 0.25,
+      disparityRatio: 0.65,
+      alertedAt: Date.now(),
+    },
     loading: false,
     error: null,
     reload: vi.fn(),
@@ -172,5 +179,12 @@ describe('AuditCompliancePage', () => {
   it('renders outcome filter', () => {
     renderPage()
     expect(screen.getByTestId('filter-outcome')).toBeInTheDocument()
+  })
+
+  it('renders anomaly alert banner when alerts are active', () => {
+    renderPage()
+    expect(screen.getByTestId('anomaly-alert-banner')).toBeInTheDocument()
+    expect(screen.getByText('statistical_parity_violation')).toBeInTheDocument()
+    expect(screen.getByText('disparate_impact_violation')).toBeInTheDocument()
   })
 })

--- a/apps/web/src/pages/AuditCompliancePage.tsx
+++ b/apps/web/src/pages/AuditCompliancePage.tsx
@@ -143,7 +143,7 @@ export function AuditCompliancePage() {
   const { t } = useTranslation()
   const { slug, isAdmin } = useWorkspace()
   const { logs, loading, error, filters, setFilters, setOutcome } = useAuditLogs(slug, isAdmin)
-  const { report, loading: reportLoading, error: reportError } = useBiasReport(slug, isAdmin)
+  const { report, anomalyAlerts, loading: reportLoading, error: reportError } = useBiasReport(slug, isAdmin)
 
   const [outcomeDialogEntry, setOutcomeDialogEntry] = useState<
     (typeof logs)[number] | null
@@ -249,37 +249,61 @@ export function AuditCompliancePage() {
           ) : reportError ? (
             <div className="text-sm text-destructive">{reportError}</div>
           ) : biasReportSummary ? (
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
-              <div>
-                <span className="text-muted-foreground">
-                  {t('auditCompliance.biasReport.workspace', { defaultValue: 'Workspace' })}:
-                </span>{' '}
-                {biasReportSummary.workspaceSlug ?? '-'}
+            <div className="space-y-3">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+                <div>
+                  <span className="text-muted-foreground">
+                    {t('auditCompliance.biasReport.workspace', { defaultValue: 'Workspace' })}:
+                  </span>{' '}
+                  {biasReportSummary.workspaceSlug ?? '-'}
+                </div>
+                <div>
+                  <span className="text-muted-foreground">
+                    {t('auditCompliance.biasReport.generatedAt', {
+                      defaultValue: 'Generated At',
+                    })}
+                    :
+                  </span>{' '}
+                  {biasReportSummary.generatedAt ?? '-'}
+                </div>
+                <div>
+                  <span className="text-muted-foreground">
+                    {t('auditCompliance.biasReport.anomalyDetected', {
+                      defaultValue: 'Anomaly Detected',
+                    })}
+                    :
+                  </span>{' '}
+                  {biasReportSummary.anomalyDetected != null ? (
+                    <Badge variant={biasReportSummary.anomalyDetected ? 'destructive' : 'default'}>
+                      {biasReportSummary.anomalyDetected ? 'Yes' : 'No'}
+                    </Badge>
+                  ) : (
+                    '-'
+                  )}
+                </div>
               </div>
-              <div>
-                <span className="text-muted-foreground">
-                  {t('auditCompliance.biasReport.generatedAt', {
-                    defaultValue: 'Generated At',
-                  })}
-                  :
-                </span>{' '}
-                {biasReportSummary.generatedAt ?? '-'}
-              </div>
-              <div>
-                <span className="text-muted-foreground">
-                  {t('auditCompliance.biasReport.anomalyDetected', {
-                    defaultValue: 'Anomaly Detected',
-                  })}
-                  :
-                </span>{' '}
-                {biasReportSummary.anomalyDetected != null ? (
-                  <Badge variant={biasReportSummary.anomalyDetected ? 'destructive' : 'default'}>
-                    {biasReportSummary.anomalyDetected ? 'Yes' : 'No'}
-                  </Badge>
-                ) : (
-                  '-'
-                )}
-              </div>
+              {anomalyAlerts && anomalyAlerts.flags.length > 0 && (
+                <div className="border rounded-md p-3 bg-destructive/5 border-destructive/20" data-testid="anomaly-alert-banner">
+                  <div className="text-sm font-medium text-destructive mb-1">
+                    {t('auditCompliance.biasReport.activeAlerts', { defaultValue: 'Active Anomaly Alerts' })}:
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {anomalyAlerts.flags.map((flag) => (
+                      <Badge key={flag} variant="destructive">{flag}</Badge>
+                    ))}
+                  </div>
+                  {anomalyAlerts.psiValue != null && (
+                    <div className="text-xs text-muted-foreground mt-1">
+                      PSI: {anomalyAlerts.psiValue.toFixed(4)}
+                    </div>
+                  )}
+                  {anomalyAlerts.disparityRatio != null && (
+                    <div className="text-xs text-muted-foreground">
+                      Disparity Ratio: {anomalyAlerts.disparityRatio.toFixed(4)}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           ) : (
             <div className="text-sm text-muted-foreground">

--- a/packages/convex/convex/__tests__/bias-audit-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/bias-audit-convex-test.test.ts
@@ -482,3 +482,108 @@ describe("bias_audit: computeBiasMetricsForAllWorkspaces", () => {
     expect(results).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// storeAnomalyAlert + getAnomalyAlerts
+// ---------------------------------------------------------------------------
+
+describe("bias_audit: storeAnomalyAlert + getAnomalyAlerts", () => {
+  it("stores and retrieves anomaly alerts", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("workspace_config", {
+        workspaceSlug: "ws-alert-test",
+        configKey: "bias_audit_anomaly_alert",
+        configValue: {
+          workspaceSlug: "ws-alert-test",
+          flags: ["statistical_parity_violation", "disparate_impact_violation"],
+          psiValue: 0.25,
+          disparityRatio: 0.65,
+          alertedAt: Date.now(),
+        },
+        updatedAt: Date.now(),
+      });
+    });
+
+    // @ts-ignore — getAnomalyAlerts not yet in generated API
+    const alerts = await t.query(internal.bias_audit.getAnomalyAlerts, {
+      workspaceSlug: "ws-alert-test",
+    });
+
+    expect(alerts).toBeDefined();
+    expect(alerts.flags).toEqual(["statistical_parity_violation", "disparate_impact_violation"]);
+    expect(alerts.psiValue).toBeCloseTo(0.25);
+    expect(alerts.disparityRatio).toBeCloseTo(0.65);
+  });
+
+  it("returns null when no anomaly alerts exist", async () => {
+    const t = convexTest(schema, modules);
+
+    // @ts-ignore — getAnomalyAlerts not yet in generated API
+    const alerts = await t.query(internal.bias_audit.getAnomalyAlerts, {
+      workspaceSlug: "ws-no-alerts",
+    });
+
+    expect(alerts).toBeNull();
+  });
+
+  it("upserts existing anomaly alert", async () => {
+    const t = convexTest(schema, modules);
+    const now = Date.now();
+
+    // Store initial alert
+    // @ts-ignore — storeAnomalyAlert not yet in generated API
+    await t.mutation(internal.bias_audit.storeAnomalyAlert, {
+      workspaceSlug: "ws-upsert",
+      flags: ["statistical_parity_violation"],
+      computedAt: now,
+      psiValue: 0.15,
+      disparityRatio: 0.75,
+    });
+
+    // Verify initial alert
+    // @ts-ignore — getAnomalyAlerts not yet in generated API
+    const first = await t.query(internal.bias_audit.getAnomalyAlerts, {
+      workspaceSlug: "ws-upsert",
+    });
+    expect(first.flags).toEqual(["statistical_parity_violation"]);
+
+    // Store updated alert (should overwrite)
+    // @ts-ignore — storeAnomalyAlert not yet in generated API
+    await t.mutation(internal.bias_audit.storeAnomalyAlert, {
+      workspaceSlug: "ws-upsert",
+      flags: ["statistical_parity_violation", "score_drift_detected"],
+      computedAt: now + 1000,
+      psiValue: 0.35,
+      disparityRatio: 0.70,
+    });
+
+    // @ts-ignore — getAnomalyAlerts not yet in generated API
+    const updated = await t.query(internal.bias_audit.getAnomalyAlerts, {
+      workspaceSlug: "ws-upsert",
+    });
+    expect(updated.flags).toEqual(["statistical_parity_violation", "score_drift_detected"]);
+    expect(updated.psiValue).toBeCloseTo(0.35);
+  });
+
+  it("stores anomaly alert with optional fields omitted", async () => {
+    const t = convexTest(schema, modules);
+
+    // @ts-ignore — storeAnomalyAlert not yet in generated API
+    await t.mutation(internal.bias_audit.storeAnomalyAlert, {
+      workspaceSlug: "ws-minimal",
+      flags: ["score_drift_detected"],
+      computedAt: Date.now(),
+    });
+
+    // @ts-ignore — getAnomalyAlerts not yet in generated API
+    const alerts = await t.query(internal.bias_audit.getAnomalyAlerts, {
+      workspaceSlug: "ws-minimal",
+    });
+    expect(alerts).toBeDefined();
+    expect(alerts.flags).toEqual(["score_drift_detected"]);
+    expect(alerts.psiValue).toBeNull();
+    expect(alerts.disparityRatio).toBeNull();
+  });
+});

--- a/packages/convex/convex/bias_audit.ts
+++ b/packages/convex/convex/bias_audit.ts
@@ -38,15 +38,38 @@ export const computeBiasMetricsForAllWorkspaces = internalAction({
     args: {},
     handler: async (ctx) => {
         const workspaceSlugs = await ctx.runQuery(internal.bias_audit.listWorkspaceSlugsWithAuditLogs) as string[];
-        const results: Array<{ workspaceSlug: string; status: string }> = [];
+        const results: Array<{ workspaceSlug: string; status: string; anomalyDetected?: boolean }> = [];
 
         for (const workspaceSlug of workspaceSlugs) {
             try {
                 const result = await ctx.runAction(internal.bias_audit.computeBiasMetrics, {
                     workspaceSlug,
                     decisionType: "score",
-                }) as { status: string };
-                results.push({ workspaceSlug, status: result.status });
+                }) as BiasMetricsResult | { status: string };
+
+                if ("anomalyFlags" in result) {
+                    const { statisticalParityViolation, disparateImpactViolation, scoreDriftDetected } = result.anomalyFlags;
+                    const hasAnomaly = statisticalParityViolation || disparateImpactViolation || scoreDriftDetected;
+
+                    if (hasAnomaly) {
+                        const flags: string[] = [];
+                        if (statisticalParityViolation) flags.push("statistical_parity_violation");
+                        if (disparateImpactViolation) flags.push("disparate_impact_violation");
+                        if (scoreDriftDetected) flags.push("score_drift_detected");
+
+                        await ctx.runMutation(internal.bias_audit.storeAnomalyAlert, {
+                            workspaceSlug,
+                            flags,
+                            computedAt: result.computedAt,
+                            psiValue: result.scoreDrift.psi,
+                            disparityRatio: result.demographicParity.disparityRatio,
+                        });
+                    }
+
+                    results.push({ workspaceSlug, status: result.status, anomalyDetected: hasAnomaly });
+                } else {
+                    results.push({ workspaceSlug, status: result.status });
+                }
             } catch (error) {
                 results.push({ workspaceSlug, status: `error: ${error instanceof Error ? error.message : String(error)}` });
             }
@@ -355,6 +378,69 @@ export const getLatestBiasReport = query({
             .query("workspace_config")
             .withIndex("by_workspace_key", (q) =>
                 q.eq("workspaceSlug", args.workspaceSlug).eq("configKey", "bias_audit_report")
+            )
+            .first();
+        return config?.configValue ?? null;
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Internal mutation: storeAnomalyAlert — persists anomaly alert after cron
+// ---------------------------------------------------------------------------
+
+export const storeAnomalyAlert = internalMutation({
+    args: {
+        workspaceSlug: v.string(),
+        flags: v.array(v.string()),
+        computedAt: v.number(),
+        psiValue: v.optional(v.number()),
+        disparityRatio: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const existing = await ctx.db
+            .query("workspace_config")
+            .withIndex("by_workspace_key", (q) =>
+                q.eq("workspaceSlug", args.workspaceSlug).eq("configKey", "bias_audit_anomaly_alert")
+            )
+            .first();
+
+        const alertData = {
+            workspaceSlug: args.workspaceSlug,
+            flags: args.flags,
+            psiValue: args.psiValue ?? null,
+            disparityRatio: args.disparityRatio ?? null,
+            alertedAt: args.computedAt,
+        };
+
+        if (existing) {
+            await ctx.db.patch(existing._id, {
+                configValue: alertData,
+                updatedAt: Date.now(),
+            });
+        } else {
+            await ctx.db.insert("workspace_config", {
+                workspaceSlug: args.workspaceSlug,
+                configKey: "bias_audit_anomaly_alert",
+                configValue: alertData,
+                updatedAt: Date.now(),
+            });
+        }
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Public query: getAnomalyAlerts — fetch active anomaly alerts for workspace
+// ---------------------------------------------------------------------------
+
+export const getAnomalyAlerts = query({
+    args: {
+        workspaceSlug: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const config = await ctx.db
+            .query("workspace_config")
+            .withIndex("by_workspace_key", (q) =>
+                q.eq("workspaceSlug", args.workspaceSlug).eq("configKey", "bias_audit_anomaly_alert")
             )
             .first();
         return config?.configValue ?? null;


### PR DESCRIPTION
## Summary
- Wire `storeAnomalyAlert` into `computeBiasMetricsForAllWorkspaces` so anomaly flags detected during bias computation are automatically persisted as alerts
- Add `getAnomalyAlerts` query + `storeAnomalyAlert` internal mutation using `workspace_config` KV store
- Add `GET /api/resumes/anomaly-alerts` BFF endpoint with `requireAdmin` middleware
- Extend `useBiasReport` hook to fetch anomaly alerts in parallel with bias report
- Add anomaly alert banner to AuditCompliancePage with flag badges, PSI value, and disparity ratio
- Add 4 convex-test integration tests for storeAnomalyAlert + getAnomalyAlerts
- Add `activeAlerts` i18n keys in en, zh-Hans, zh-Hant

## Test plan
- [x] `make check` passes (typecheck + lint + governance)
- [x] 4 new convex-test cases: store/retrieve, null response, upsert, optional fields
- [x] AuditCompliancePage.test.tsx includes anomaly alert banner test
- [ ] Manual: verify alert banner renders on Audit & Compliance page when anomaly alert exists
- [ ] Manual: verify anomaly alerts are created automatically when bias cron detects violations