### PR TITLE
refactor: extract resume task helpers to lib/resume_task_helpers.ts

### DIFF
--- a/packages/convex/convex/lib/resume_task_helpers.ts
+++ b/packages/convex/convex/lib/resume_task_helpers.ts
@@ -1,0 +1,174 @@
+/**
+ * Resume task helper functions extracted from resume_tasks.ts.
+ *
+ * Pure functions for merge/dedup, restore state management,
+ * and patch application used by the submitResumes mutation.
+ */
+import type { Doc } from "../_generated/dataModel";
+import { buildSearchText, mergeSearchTextWithIngestData } from "../search_text";
+import { computeVerifiedRoleYears } from "@trends/shared";
+
+// ---------------------------------------------------------------------------
+// Tag merge helpers
+// ---------------------------------------------------------------------------
+
+export function mergeTags(existing: string[], incoming: string[]): string[] {
+    return Array.from(new Set([...existing, ...incoming]));
+}
+
+export function areStringArraysEqual(left: string[], right: string[]): boolean {
+    if (left.length !== right.length) {
+        return false;
+    }
+    for (let index = 0; index < left.length; index += 1) {
+        if (left[index] !== right[index]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Age patch helper
+// ---------------------------------------------------------------------------
+
+export function applyParsedAgePatch(
+    patch: { age?: number },
+    parsedAge: number | null,
+    existingAge?: number,
+): void {
+    if (parsedAge === null) {
+        return;
+    }
+    if (typeof existingAge === "number" && existingAge === parsedAge) {
+        return;
+    }
+    patch.age = parsedAge;
+}
+
+// ---------------------------------------------------------------------------
+// Normalize helpers
+// ---------------------------------------------------------------------------
+
+export function normalizeOptionalPositiveInt(value: number | undefined): number | undefined {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        return undefined;
+    }
+    const truncated = Math.trunc(value);
+    if (truncated <= 0) {
+        return undefined;
+    }
+    return truncated;
+}
+
+// ---------------------------------------------------------------------------
+// Restore state
+// ---------------------------------------------------------------------------
+
+export type RestoreState = {
+    crawledAt?: number;
+    isArchived?: boolean;
+    archivedAt?: number;
+    searchText?: string;
+    primaryRuleScore?: number;
+    ingestData?: Doc<"resumes">["ingestData"];
+    analysis?: Doc<"resumes">["analysis"];
+    analyses?: Doc<"resumes">["analyses"];
+};
+
+export function resolveStoredSearchText(
+    content: unknown,
+    restoreState: RestoreState | undefined,
+): string {
+    const restored = typeof restoreState?.searchText === "string"
+        ? restoreState.searchText.trim()
+        : "";
+    const baseText = restored || buildSearchText(content);
+    // Merge ingest-derived search tokens when available
+    if (restoreState?.ingestData) {
+        return mergeSearchTextWithIngestData(baseText, {
+            industryTags: restoreState.ingestData.industryTags,
+            synonymHits: restoreState.ingestData.synonymHits,
+            brandHits: restoreState.ingestData.brandHits,
+            companyHits: restoreState.ingestData.companyHits,
+        });
+    }
+    return baseText;
+}
+
+export function shallowEqualNumberRecord(
+    a: Record<string, number> | undefined,
+    b: Record<string, number>,
+): boolean {
+    if (!a) {
+        return Object.keys(b).length === 0;
+    }
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) return false;
+    for (const key of aKeys) {
+        if (a[key] !== b[key]) return false;
+    }
+    return true;
+}
+
+export function shouldScheduleIngest(restoreState: RestoreState | undefined): boolean {
+    return restoreState?.ingestData === undefined;
+}
+
+export function applyRestoreStateFields(
+    target: {
+        isArchived?: boolean;
+        archivedAt?: number;
+        primaryRuleScore?: number;
+        ingestData?: Doc<"resumes">["ingestData"];
+        analysis?: Doc<"resumes">["analysis"];
+        analyses?: Doc<"resumes">["analyses"];
+    },
+    restoreState: RestoreState | undefined,
+): void {
+    if (!restoreState) {
+        return;
+    }
+
+    if (typeof restoreState.isArchived === "boolean") {
+        target.isArchived = restoreState.isArchived;
+        if (restoreState.isArchived) {
+            if (typeof restoreState.archivedAt === "number" && Number.isFinite(restoreState.archivedAt)) {
+                target.archivedAt = restoreState.archivedAt;
+            }
+        } else {
+            target.archivedAt = undefined;
+        }
+    } else if (typeof restoreState.archivedAt === "number" && Number.isFinite(restoreState.archivedAt)) {
+        target.archivedAt = restoreState.archivedAt;
+    }
+
+    if (typeof restoreState.primaryRuleScore === "number") {
+        target.primaryRuleScore = restoreState.primaryRuleScore;
+    }
+    if (restoreState.ingestData !== undefined) {
+        const hasRoleSignals = Array.isArray(restoreState.ingestData.roleSignals)
+            && restoreState.ingestData.roleSignals.length > 0;
+        if (hasRoleSignals) {
+            const computed = computeVerifiedRoleYears(restoreState.ingestData.roleSignals);
+            const existing = restoreState.ingestData.verifiedRoleYears;
+            if (!shallowEqualNumberRecord(existing, computed)) {
+                target.ingestData = {
+                    ...restoreState.ingestData,
+                    verifiedRoleYears: computed,
+                };
+            } else {
+                target.ingestData = restoreState.ingestData;
+            }
+        } else {
+            target.ingestData = restoreState.ingestData;
+        }
+    }
+    if (restoreState.analysis !== undefined) {
+        target.analysis = restoreState.analysis;
+    }
+    if (restoreState.analyses !== undefined) {
+        target.analyses = restoreState.analyses;
+    }
+}

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -3,164 +3,31 @@ import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { collectionTaskResultsValidator, ingestDataValidator, analysisResultValidator, resumeAnalysisValidator } from "./validators.js";
-import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
-import { computeVerifiedRoleYears } from "@trends/shared";
 import { resolveSubmitResumeParallelism } from "./lib/parallelism";
 import { deriveResumeIdentity } from "./lib/resume_identity";
 import { parseAgeFromContent } from "./lib/age";
 import { resolveDiagnosticsSourceKeyForResume } from "./resumes";
+import {
+    mergeTags,
+    areStringArraysEqual,
+    applyParsedAgePatch,
+    normalizeOptionalPositiveInt,
+    resolveStoredSearchText,
+    shouldScheduleIngest,
+    applyRestoreStateFields,
+} from "./lib/resume_task_helpers.js";
+
+// Backward-compatible re-exports
+export type { RestoreState } from "./lib/resume_task_helpers.js";
+export {
+    mergeTags,
+    normalizeOptionalPositiveInt,
+    shallowEqualNumberRecord,
+    shouldScheduleIngest,
+} from "./lib/resume_task_helpers.js";
 
 const DEFAULT_WORKER_HEALTH_FRESHNESS_MS = 15_000;
 const DEFAULT_STALE_PENDING_MS = 180_000;
-
-export function mergeTags(existing: string[], incoming: string[]): string[] {
-    return Array.from(new Set([...existing, ...incoming]));
-}
-
-function areStringArraysEqual(left: string[], right: string[]): boolean {
-    if (left.length !== right.length) {
-        return false;
-    }
-    for (let index = 0; index < left.length; index += 1) {
-        if (left[index] !== right[index]) {
-            return false;
-        }
-    }
-    return true;
-}
-
-function applyParsedAgePatch(
-    patch: { age?: number },
-    parsedAge: number | null,
-    existingAge?: number,
-): void {
-    if (parsedAge === null) {
-        return;
-    }
-    if (typeof existingAge === "number" && existingAge === parsedAge) {
-        return;
-    }
-    patch.age = parsedAge;
-}
-
-export function normalizeOptionalPositiveInt(value: number | undefined): number | undefined {
-    if (typeof value !== "number" || !Number.isFinite(value)) {
-        return undefined;
-    }
-    const truncated = Math.trunc(value);
-    if (truncated <= 0) {
-        return undefined;
-    }
-    return truncated;
-}
-
-export type RestoreState = {
-    crawledAt?: number;
-    isArchived?: boolean;
-    archivedAt?: number;
-    searchText?: string;
-    primaryRuleScore?: number;
-    ingestData?: Doc<"resumes">["ingestData"];
-    analysis?: Doc<"resumes">["analysis"];
-    analyses?: Doc<"resumes">["analyses"];
-};
-
-function resolveStoredSearchText(
-    content: unknown,
-    restoreState: RestoreState | undefined,
-): string {
-    const restored = typeof restoreState?.searchText === "string"
-        ? restoreState.searchText.trim()
-        : "";
-    const baseText = restored || buildSearchText(content);
-    // Merge ingest-derived search tokens when available
-    if (restoreState?.ingestData) {
-        return mergeSearchTextWithIngestData(baseText, {
-            industryTags: restoreState.ingestData.industryTags,
-            synonymHits: restoreState.ingestData.synonymHits,
-            brandHits: restoreState.ingestData.brandHits,
-            companyHits: restoreState.ingestData.companyHits,
-        });
-    }
-    return baseText;
-}
-
-export function shallowEqualNumberRecord(
-    a: Record<string, number> | undefined,
-    b: Record<string, number>,
-): boolean {
-    if (!a) {
-        return Object.keys(b).length === 0;
-    }
-    const aKeys = Object.keys(a);
-    const bKeys = Object.keys(b);
-    if (aKeys.length !== bKeys.length) return false;
-    for (const key of aKeys) {
-        if (a[key] !== b[key]) return false;
-    }
-    return true;
-}
-
-export function shouldScheduleIngest(restoreState: RestoreState | undefined): boolean {
-    return restoreState?.ingestData === undefined;
-}
-
-function applyRestoreStateFields(
-    target: {
-        isArchived?: boolean;
-        archivedAt?: number;
-        primaryRuleScore?: number;
-        ingestData?: Doc<"resumes">["ingestData"];
-        analysis?: Doc<"resumes">["analysis"];
-        analyses?: Doc<"resumes">["analyses"];
-    },
-    restoreState: RestoreState | undefined,
-): void {
-    if (!restoreState) {
-        return;
-    }
-
-    if (typeof restoreState.isArchived === "boolean") {
-        target.isArchived = restoreState.isArchived;
-        if (restoreState.isArchived) {
-            if (typeof restoreState.archivedAt === "number" && Number.isFinite(restoreState.archivedAt)) {
-                target.archivedAt = restoreState.archivedAt;
-            }
-        } else {
-            target.archivedAt = undefined;
-        }
-    } else if (typeof restoreState.archivedAt === "number" && Number.isFinite(restoreState.archivedAt)) {
-        target.archivedAt = restoreState.archivedAt;
-    }
-
-    if (typeof restoreState.primaryRuleScore === "number") {
-        target.primaryRuleScore = restoreState.primaryRuleScore;
-    }
-    if (restoreState.ingestData !== undefined) {
-        const hasRoleSignals = Array.isArray(restoreState.ingestData.roleSignals)
-            && restoreState.ingestData.roleSignals.length > 0;
-        if (hasRoleSignals) {
-            const computed = computeVerifiedRoleYears(restoreState.ingestData.roleSignals);
-            const existing = restoreState.ingestData.verifiedRoleYears;
-            if (!shallowEqualNumberRecord(existing, computed)) {
-                target.ingestData = {
-                    ...restoreState.ingestData,
-                    verifiedRoleYears: computed,
-                };
-            } else {
-                target.ingestData = restoreState.ingestData;
-            }
-        } else {
-            target.ingestData = restoreState.ingestData;
-        }
-    }
-    if (restoreState.analysis !== undefined) {
-        target.analysis = restoreState.analysis;
-    }
-    if (restoreState.analyses !== undefined) {
-        target.analyses = restoreState.analyses;
-    }
-}
 
 // List recent tasks for monitoring
 export const list = query({


### PR DESCRIPTION
## Summary
- Extract 9 pure functions and 1 type (`RestoreState`) from `resume_tasks.ts` into `lib/resume_task_helpers.ts`
- Follows established extraction pattern (backward-compatible re-exports, unit tests already exist in `resume-tasks-helpers.test.ts`)
- Reduces `resume_tasks.ts` by ~151 lines

## Extracted functions
`mergeTags`, `areStringArraysEqual`, `applyParsedAgePatch`, `normalizeOptionalPositiveInt`, `resolveStoredSearchText`, `shallowEqualNumberRecord`, `shouldScheduleIngest`, `applyRestoreStateFields`, `RestoreState` type

## Test plan
- [x] `make check` passes
- [x] `resume-tasks-helpers.test.ts` (28 tests) passes
- [x] `resume-tasks-submit.test.ts` (2 tests) passes