### PR TITLE
fix: downgrade console.log to console.debug in production Convex modules

### DIFF
--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -165,7 +165,7 @@ export async function callLLM(messages: ChatMessage[], apiKey: string) {
     const url = `${apiBase}/chat/completions`;
     const model = resolveChatCompletionModel(apiBase, getAiModel());
 
-    console.log(`Calling LLM at ${url} with model ${model}...`);
+    console.debug(`Calling LLM at ${url} with model ${model}...`);
 
     const response = await fetch(url, {
         method: "POST",

--- a/packages/convex/convex/embeddings.ts
+++ b/packages/convex/convex/embeddings.ts
@@ -269,7 +269,7 @@ export const batchGenerateEmbeddings = internalAction({
         if (dryRun) {
             const emptySearchText = page.resumes.filter((r) => !buildEmbeddingText(r).trim()).length;
             const toEmbed = page.resumes.length - emptySearchText;
-            console.log(`[dryRun] ${toEmbed} resumes would be embedded, ${emptySearchText} skipped (empty searchText), ${page.hasMore ? "more pages available" : "last page"}`);
+            console.debug(`[dryRun] ${toEmbed} resumes would be embedded, ${emptySearchText} skipped (empty searchText), ${page.hasMore ? "more pages available" : "last page"}`);
             return {
                 generated: 0,
                 skipped: page.resumes.length,
@@ -359,7 +359,7 @@ export const scheduledBackfill = internalAction({
         }
 
         if (totalGenerated > 0 || totalApiErrors > 0) {
-            console.log(`Scheduled backfill: ${totalGenerated} generated, ${totalApiErrors} API errors, ${batches} batches`);
+            console.debug(`Scheduled backfill: ${totalGenerated} generated, ${totalApiErrors} API errors, ${batches} batches`);
         }
 
         return { generated: totalGenerated, apiErrors: totalApiErrors, batches };

--- a/packages/convex/convex/ingest_agent.ts
+++ b/packages/convex/convex/ingest_agent.ts
@@ -93,7 +93,7 @@ export const processNewResumes = internalAction({
       return { processed: 0, error: null };
     }
 
-    console.log(`[ingest_agent] Processing ${resumeIds.length} resumes...`);
+    console.debug(`[ingest_agent] Processing ${resumeIds.length} resumes...`);
 
     try {
       // 1. Fetch resume documents
@@ -102,7 +102,7 @@ export const processNewResumes = internalAction({
       });
 
       if (resumes.length === 0) {
-        console.log("[ingest_agent] No resumes found");
+        console.debug("[ingest_agent] No resumes found");
         return { processed: 0, error: null };
       }
 
@@ -119,7 +119,7 @@ export const processNewResumes = internalAction({
       const bffUrl = getBffApiUrl();
       const endpoint = `${bffUrl}/api/resumes/ingest-compute`;
 
-      console.log(`[ingest_agent] Calling BFF at ${endpoint}...`);
+      console.debug(`[ingest_agent] Calling BFF at ${endpoint}...`);
 
       const response = await fetch(endpoint, {
         method: "POST",
@@ -206,7 +206,7 @@ export const processNewResumes = internalAction({
         }
       }
 
-      console.log(`[ingest_agent] Successfully processed ${updates.length} resumes`);
+      console.debug(`[ingest_agent] Successfully processed ${updates.length} resumes`);
 
       return { processed: updates.length, error: null };
     } catch (error) {


### PR DESCRIPTION
## Summary
- Replace 7 `console.log` calls with `console.debug` in `analyze.ts`, `ingest_agent.ts`, and `embeddings.ts`
- `console.log` writes to CloudWatch at INFO level in production Convex deployments, potentially leaking sensitive data (model URLs, BFF endpoints, resume counts) and incurring log costs
- `console.debug` is filtered at lower log levels and won't appear in production logs by default

## Affected files
- `analyze.ts` (1 call): LLM invocation URL/model
- `ingest_agent.ts` (4 calls): resume count, BFF endpoint, no-resumes case, success count
- `embeddings.ts` (2 calls): dryRun stats, backfill summary

## Test plan
- [x] `make check` passes
- [x] All 1,700 convex tests pass