### PR TITLE
refactor: extract pagination constants and resolvers from resumes.ts

### DIFF
--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -32,6 +32,7 @@ import type * as lib_resume_identity from "../lib/resume_identity.js";
 import type * as lib_resume_task_helpers from "../lib/resume_task_helpers.js";
 import type * as lib_resumes_diagnostics from "../lib/resumes_diagnostics.js";
 import type * as lib_resumes_list_projections from "../lib/resumes_list_projections.js";
+import type * as lib_resumes_pagination from "../lib/resumes_pagination.js";
 import type * as lib_resumes_tag_expansion from "../lib/resumes_tag_expansion.js";
 import type * as llm_cost from "../llm_cost.js";
 import type * as migrations from "../migrations.js";
@@ -79,6 +80,7 @@ declare const fullApi: ApiFromModules<{
   "lib/resume_task_helpers": typeof lib_resume_task_helpers;
   "lib/resumes_diagnostics": typeof lib_resumes_diagnostics;
   "lib/resumes_list_projections": typeof lib_resumes_list_projections;
+  "lib/resumes_pagination": typeof lib_resumes_pagination;
   "lib/resumes_tag_expansion": typeof lib_resumes_tag_expansion;
   llm_cost: typeof llm_cost;
   migrations: typeof migrations;

--- a/packages/convex/convex/lib/resumes_pagination.ts
+++ b/packages/convex/convex/lib/resumes_pagination.ts
@@ -1,0 +1,132 @@
+/**
+ * Pagination constants and resolver functions for resume queries.
+ *
+ * Extracted from resumes.ts to reduce its size and centralize
+ * pagination logic used across multiple modules.
+ */
+
+// --- Pagination safety constants ---
+
+export const DEFAULT_RESUME_LIMIT = 50;
+export const MAX_SAFE_LIST_WITH_INGEST_LIMIT = 2000;
+export const MAX_SAFE_LIST_WITH_INGEST_OVERFETCH = 4000;
+export const FILTERED_PAGINATE_OVERFETCH_MULTIPLIER = 3;
+export const MAX_SAFE_JD_PAGINATE_SCAN = 250;
+
+// Safety margins: half of Convex's 16 MiB read / 32K scan limits.
+// Forces automatic page splitting before hitting hard limits.
+export const PAGINATE_MAX_BYTES_READ = 8 * 1024 * 1024; // 8 MiB
+export const PAGINATE_MAX_ROWS_READ = 16_000;
+// Convex enforces 16 MiB total data read per query function.
+// Resume docs average ~27KB but some exceed 500KB on later search index pages.
+// With post-filter attrition (filtered path), overfetch is needed but output shrinks.
+// Without attrition (no-filter path), each doc contributes full size to the read budget.
+// 16 × 500KB = ~8MB worst case; 128 × 27KB = ~3.5MB filtered avg — both safe.
+export const MAX_SAFE_SEARCH_PAGINATE_SCAN = 128;
+export const MAX_SAFE_SEARCH_PAGINATE_SCAN_UNFILTERED = 16;
+// Convex search index scans up to 1024 results; 1024 × 27KB = 27MB > 16 MiB.
+// Cap .take() path to 400 docs × 30KB = ~12MB, safely under 16 MiB limit.
+export const MAX_SAFE_SEARCH_TAKE_LIMIT = 400;
+
+const DEFAULT_RESUME_SCAN_BATCH_SIZE = 25;
+export const MAX_RESUME_SCAN_BATCH_SIZE = 50;
+const DEFAULT_RESUME_BACKUP_PAGE_SIZE = 25;
+const MAX_RESUME_BACKUP_PAGE_SIZE = 25;
+
+// --- Resolver functions ---
+
+export function resolveListWithIngestWindow(requestedLimit: number | undefined): {
+    limit: number;
+    overfetchLimit: number;
+} {
+    const limit = Math.min(Math.max(requestedLimit || DEFAULT_RESUME_LIMIT, 1), MAX_SAFE_LIST_WITH_INGEST_LIMIT);
+    return {
+        limit,
+        overfetchLimit: Math.min(Math.max(limit * FILTERED_PAGINATE_OVERFETCH_MULTIPLIER, limit), MAX_SAFE_LIST_WITH_INGEST_OVERFETCH),
+    };
+}
+
+export function resolveSearchWithTagExpansionTakeLimit(params: {
+    limit: number | undefined;
+    offset: number | undefined;
+    hasFilters: boolean;
+    jobDescriptionId?: string;
+}): number {
+    const { offset, pageLimit, overfetchLimit } = resolveListWithIngestPageWindow(params.limit, params.offset);
+    const requestedWindow = offset + pageLimit;
+
+    if (!params.hasFilters && !params.jobDescriptionId?.trim()) {
+        return Math.min(overfetchLimit, MAX_SAFE_SEARCH_TAKE_LIMIT);
+    }
+
+    return Math.min(
+        Math.max(overfetchLimit, requestedWindow, MAX_SAFE_JD_PAGINATE_SCAN),
+        MAX_SAFE_SEARCH_TAKE_LIMIT,
+    );
+}
+
+export function resolveListWithIngestPageWindow(requestedLimit: number | undefined, requestedOffset: number | undefined): {
+    offset: number;
+    pageLimit: number;
+    scanLimit: number;
+    overfetchLimit: number;
+} {
+    const offset = Math.max(Math.trunc(requestedOffset ?? 0), 0);
+    const pageLimit = Math.min(Math.max(requestedLimit || DEFAULT_RESUME_LIMIT, 1), MAX_SAFE_LIST_WITH_INGEST_LIMIT);
+    const { limit: scanLimit, overfetchLimit } = resolveListWithIngestWindow(offset + pageLimit);
+    return {
+        offset,
+        pageLimit,
+        scanLimit,
+        overfetchLimit,
+    };
+}
+
+export function resolvePaginatedResumeOffsetCursor(cursor: string | null | undefined): number {
+    if (!cursor) {
+        return 0;
+    }
+
+    const parsed = Number.parseInt(cursor, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return 0;
+    }
+
+    return parsed;
+}
+
+export function resolvePaginatedResumePageLimit(numItems: number | undefined): number {
+    if (typeof numItems !== "number" || !Number.isFinite(numItems)) {
+        return DEFAULT_RESUME_LIMIT;
+    }
+
+    return Math.min(Math.max(Math.trunc(numItems), 1), MAX_SAFE_LIST_WITH_INGEST_LIMIT);
+}
+
+export function buildPaginatedOffsetResult<T>(page: T[], total: number, offset: number): {
+    page: T[];
+    continueCursor: string;
+    isDone: boolean;
+} {
+    const nextOffset = offset + page.length;
+    const isDone = nextOffset >= total;
+    return {
+        page,
+        continueCursor: isDone ? "" : String(nextOffset),
+        isDone,
+    };
+}
+
+export function resolveResumeScanBatchSize(requestedLimit: number | undefined): number {
+    const normalizedLimit = typeof requestedLimit === "number" && Number.isFinite(requestedLimit)
+        ? Math.trunc(requestedLimit)
+        : DEFAULT_RESUME_SCAN_BATCH_SIZE;
+    return Math.min(Math.max(normalizedLimit, 1), MAX_RESUME_SCAN_BATCH_SIZE);
+}
+
+export function resolveResumeBackupPageSize(requestedLimit: number | undefined): number {
+    const normalizedLimit = typeof requestedLimit === "number" && Number.isFinite(requestedLimit)
+        ? Math.trunc(requestedLimit)
+        : DEFAULT_RESUME_BACKUP_PAGE_SIZE;
+    return Math.min(Math.max(normalizedLimit, 1), MAX_RESUME_BACKUP_PAGE_SIZE);
+}

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -63,6 +63,25 @@ import type {
     SearchWithTagExpansionScanPageArgs,
     DeleteResumesResult,
 } from "./lib/resumes_list_projections.js";
+import {
+    DEFAULT_RESUME_LIMIT,
+    MAX_SAFE_LIST_WITH_INGEST_LIMIT,
+    FILTERED_PAGINATE_OVERFETCH_MULTIPLIER,
+    MAX_SAFE_JD_PAGINATE_SCAN,
+    MAX_RESUME_SCAN_BATCH_SIZE,
+    PAGINATE_MAX_BYTES_READ,
+    PAGINATE_MAX_ROWS_READ,
+    MAX_SAFE_SEARCH_PAGINATE_SCAN,
+    MAX_SAFE_SEARCH_PAGINATE_SCAN_UNFILTERED,
+    resolveListWithIngestWindow,
+    resolveSearchWithTagExpansionTakeLimit,
+    resolveListWithIngestPageWindow,
+    resolvePaginatedResumeOffsetCursor,
+    resolvePaginatedResumePageLimit,
+    buildPaginatedOffsetResult,
+    resolveResumeScanBatchSize,
+    resolveResumeBackupPageSize,
+} from "./lib/resumes_pagination.js";
 
 // Re-export for backward compatibility
 export {
@@ -135,6 +154,29 @@ export type {
     DeleteResumesResult,
 } from "./lib/resumes_list_projections.js";
 
+// Re-export pagination helpers for backward compatibility
+export {
+    DEFAULT_RESUME_LIMIT,
+    MAX_SAFE_LIST_WITH_INGEST_LIMIT,
+    MAX_SAFE_LIST_WITH_INGEST_OVERFETCH,
+    FILTERED_PAGINATE_OVERFETCH_MULTIPLIER,
+    MAX_SAFE_JD_PAGINATE_SCAN,
+    MAX_RESUME_SCAN_BATCH_SIZE,
+    PAGINATE_MAX_BYTES_READ,
+    PAGINATE_MAX_ROWS_READ,
+    MAX_SAFE_SEARCH_PAGINATE_SCAN,
+    MAX_SAFE_SEARCH_PAGINATE_SCAN_UNFILTERED,
+    MAX_SAFE_SEARCH_TAKE_LIMIT,
+    resolveListWithIngestWindow,
+    resolveSearchWithTagExpansionTakeLimit,
+    resolveListWithIngestPageWindow,
+    resolvePaginatedResumeOffsetCursor,
+    resolvePaginatedResumePageLimit,
+    buildPaginatedOffsetResult,
+    resolveResumeScanBatchSize,
+    resolveResumeBackupPageSize,
+} from "./lib/resumes_pagination.js";
+
 export type ResumeScanRow = {
     _id: Doc<"resumes">["_id"];
     content: Doc<"resumes">["content"];
@@ -196,30 +238,6 @@ type ResumeBackupFilterSets = {
     sourceHosts?: Set<string>;
 };
 
-const DEFAULT_RESUME_LIMIT = 50;
-export const MAX_SAFE_LIST_WITH_INGEST_LIMIT = 2000;
-export const MAX_SAFE_LIST_WITH_INGEST_OVERFETCH = 4000;
-const FILTERED_PAGINATE_OVERFETCH_MULTIPLIER = 3;
-const MAX_SAFE_JD_PAGINATE_SCAN = 250;
-
-// Safety margins: half of Convex's 16 MiB read / 32K scan limits.
-// Forces automatic page splitting before hitting hard limits.
-const PAGINATE_MAX_BYTES_READ = 8 * 1024 * 1024; // 8 MiB
-const PAGINATE_MAX_ROWS_READ = 16_000;
-// Convex enforces 16 MiB total data read per query function.
-// Resume docs average ~27KB but some exceed 500KB on later search index pages.
-// With post-filter attrition (filtered path), overfetch is needed but output shrinks.
-// Without attrition (no-filter path), each doc contributes full size to the read budget.
-// 16 × 500KB = ~8MB worst case; 128 × 27KB = ~3.5MB filtered avg — both safe.
-const MAX_SAFE_SEARCH_PAGINATE_SCAN = 128;
-const MAX_SAFE_SEARCH_PAGINATE_SCAN_UNFILTERED = 16;
-// Convex search index scans up to 1024 results; 1024 × 27KB = 27MB > 16 MiB.
-// Cap .take() path to 400 docs × 30KB = ~12MB, safely under 16 MiB limit.
-const MAX_SAFE_SEARCH_TAKE_LIMIT = 400;
-const DEFAULT_RESUME_SCAN_BATCH_SIZE = 25;
-const MAX_RESUME_SCAN_BATCH_SIZE = 50;
-const DEFAULT_RESUME_BACKUP_PAGE_SIZE = 25;
-const MAX_RESUME_BACKUP_PAGE_SIZE = 25;
 
 function normalizeRequestedResumeIds(resumeIds: string[]): string[] {
     const normalizedIds: string[] = [];
@@ -235,102 +253,6 @@ function normalizeRequestedResumeIds(resumeIds: string[]): string[] {
     }
 
     return normalizedIds;
-}
-
-export function resolveListWithIngestWindow(requestedLimit: number | undefined): {
-    limit: number;
-    overfetchLimit: number;
-} {
-    const limit = Math.min(Math.max(requestedLimit || DEFAULT_RESUME_LIMIT, 1), MAX_SAFE_LIST_WITH_INGEST_LIMIT);
-    return {
-        limit,
-        overfetchLimit: Math.min(Math.max(limit * 3, limit), MAX_SAFE_LIST_WITH_INGEST_OVERFETCH),
-    };
-}
-
-export function resolveSearchWithTagExpansionTakeLimit(params: {
-    limit: number | undefined;
-    offset: number | undefined;
-    hasFilters: boolean;
-    jobDescriptionId?: string;
-}): number {
-    const { offset, pageLimit, overfetchLimit } = resolveListWithIngestPageWindow(params.limit, params.offset);
-    const requestedWindow = offset + pageLimit;
-
-    if (!params.hasFilters && !params.jobDescriptionId?.trim()) {
-        return Math.min(overfetchLimit, MAX_SAFE_SEARCH_TAKE_LIMIT);
-    }
-
-    return Math.min(
-        Math.max(overfetchLimit, requestedWindow, MAX_SAFE_JD_PAGINATE_SCAN),
-        MAX_SAFE_SEARCH_TAKE_LIMIT,
-    );
-}
-
-function resolveListWithIngestPageWindow(requestedLimit: number | undefined, requestedOffset: number | undefined): {
-    offset: number;
-    pageLimit: number;
-    scanLimit: number;
-    overfetchLimit: number;
-} {
-    const offset = Math.max(Math.trunc(requestedOffset ?? 0), 0);
-    const pageLimit = Math.min(Math.max(requestedLimit || DEFAULT_RESUME_LIMIT, 1), MAX_SAFE_LIST_WITH_INGEST_LIMIT);
-    const { limit: scanLimit, overfetchLimit } = resolveListWithIngestWindow(offset + pageLimit);
-    return {
-        offset,
-        pageLimit,
-        scanLimit,
-        overfetchLimit,
-    };
-}
-
-function resolvePaginatedResumeOffsetCursor(cursor: string | null | undefined): number {
-    if (!cursor) {
-        return 0;
-    }
-
-    const parsed = Number.parseInt(cursor, 10);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
-        return 0;
-    }
-
-    return parsed;
-}
-
-function resolvePaginatedResumePageLimit(numItems: number | undefined): number {
-    if (typeof numItems !== "number" || !Number.isFinite(numItems)) {
-        return DEFAULT_RESUME_LIMIT;
-    }
-
-    return Math.min(Math.max(Math.trunc(numItems), 1), MAX_SAFE_LIST_WITH_INGEST_LIMIT);
-}
-
-function buildPaginatedOffsetResult<T>(page: T[], total: number, offset: number): {
-    page: T[];
-    continueCursor: string;
-    isDone: boolean;
-} {
-    const nextOffset = offset + page.length;
-    const isDone = nextOffset >= total;
-    return {
-        page,
-        continueCursor: isDone ? "" : String(nextOffset),
-        isDone,
-    };
-}
-
-export function resolveResumeScanBatchSize(requestedLimit: number | undefined): number {
-    const normalizedLimit = typeof requestedLimit === "number" && Number.isFinite(requestedLimit)
-        ? Math.trunc(requestedLimit)
-        : DEFAULT_RESUME_SCAN_BATCH_SIZE;
-    return Math.min(Math.max(normalizedLimit, 1), MAX_RESUME_SCAN_BATCH_SIZE);
-}
-
-function resolveResumeBackupPageSize(requestedLimit: number | undefined): number {
-    const normalizedLimit = typeof requestedLimit === "number" && Number.isFinite(requestedLimit)
-        ? Math.trunc(requestedLimit)
-        : DEFAULT_RESUME_BACKUP_PAGE_SIZE;
-    return Math.min(Math.max(normalizedLimit, 1), MAX_RESUME_BACKUP_PAGE_SIZE);
 }
 
 function projectResumeBackupRow(resume: Doc<"resumes">): ResumeBackupRow {


### PR DESCRIPTION
## Summary
- Extract 12 pagination constants and 8 resolver functions from `resumes.ts` into `lib/resumes_pagination.ts`
- Reduces `resumes.ts` by ~76 net lines (120 removed, 44 added for imports/re-exports)
- All symbols re-exported from `resumes.ts` for backward compatibility — no import changes needed in consumers

## Test plan
- [x] All 1,595 convex tests pass
- [x] `make check` passes (typecheck + lint + governance)
- [x] Re-exports verified: external consumers can still import from `resumes.ts`