### PR TITLE
refactor: extract backup helpers from resumes.ts

### DIFF
--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -30,6 +30,7 @@ import type * as lib_bias_metrics from "../lib/bias_metrics.js";
 import type * as lib_parallelism from "../lib/parallelism.js";
 import type * as lib_resume_identity from "../lib/resume_identity.js";
 import type * as lib_resume_task_helpers from "../lib/resume_task_helpers.js";
+import type * as lib_resumes_backup from "../lib/resumes_backup.js";
 import type * as lib_resumes_diagnostics from "../lib/resumes_diagnostics.js";
 import type * as lib_resumes_list_projections from "../lib/resumes_list_projections.js";
 import type * as lib_resumes_pagination from "../lib/resumes_pagination.js";
@@ -78,6 +79,7 @@ declare const fullApi: ApiFromModules<{
   "lib/parallelism": typeof lib_parallelism;
   "lib/resume_identity": typeof lib_resume_identity;
   "lib/resume_task_helpers": typeof lib_resume_task_helpers;
+  "lib/resumes_backup": typeof lib_resumes_backup;
   "lib/resumes_diagnostics": typeof lib_resumes_diagnostics;
   "lib/resumes_list_projections": typeof lib_resumes_list_projections;
   "lib/resumes_pagination": typeof lib_resumes_pagination;

--- a/packages/convex/convex/lib/resumes_backup.ts
+++ b/packages/convex/convex/lib/resumes_backup.ts
@@ -1,0 +1,173 @@
+/**
+ * Backup helpers for resume export/backup queries.
+ *
+ * Extracted from resumes.ts to reduce its size and centralize
+ * backup projection, filtering, and normalization logic.
+ */
+import type { Doc } from "../_generated/dataModel";
+import { isRecord } from "@trends/shared";
+import { deriveResumeIdentity } from "./resume_identity.js";
+import { toOptionalStringValue } from "../resume_helpers.js";
+
+// --- Types ---
+
+export type ResumeBackupRow = {
+    _id: Doc<"resumes">["_id"];
+    externalId: string;
+    source: string;
+    tags: string[];
+    crawledAt: number;
+    content: Doc<"resumes">["content"];
+    searchText?: Doc<"resumes">["searchText"];
+    primaryRuleScore?: Doc<"resumes">["primaryRuleScore"];
+    ingestData?: Doc<"resumes">["ingestData"];
+    analysis?: Doc<"resumes">["analysis"];
+    analyses?: Doc<"resumes">["analyses"];
+    isArchived?: boolean;
+    archivedAt?: number;
+};
+
+export type ResumeBackupFilterArgs = {
+    resumeIds?: string[];
+    sourceHosts?: string[];
+    limit?: number;
+};
+
+type ResumeBackupFilterSets = {
+    resumeIds?: Set<string>;
+    sourceHosts?: Set<string>;
+};
+
+// --- Projection ---
+
+export function projectResumeBackupRow(resume: Doc<"resumes">): ResumeBackupRow {
+    return {
+        _id: resume._id,
+        externalId: resume.externalId,
+        source: resume.source,
+        tags: resume.tags,
+        crawledAt: resume.crawledAt,
+        content: resume.content,
+        searchText: resume.searchText,
+        primaryRuleScore: resume.primaryRuleScore,
+        ingestData: resume.ingestData,
+        analysis: resume.analysis,
+        analyses: resume.analyses,
+        ...(resume.isArchived === true ? { isArchived: true, archivedAt: resume.archivedAt } : {}),
+    };
+}
+
+// --- Normalization ---
+
+export function normalizeResumeBackupFilterValues(values: string[] | undefined): string[] | undefined {
+    if (!Array.isArray(values)) {
+        return undefined;
+    }
+
+    const normalized = Array.from(new Set(
+        values
+            .map((value) => value.trim())
+            .filter((value) => value.length > 0)
+    ));
+
+    return normalized.length > 0 ? normalized : undefined;
+}
+
+export function normalizeResumeBackupSourceHosts(values: string[] | undefined): string[] | undefined {
+    const normalized = normalizeResumeBackupFilterValues(values);
+    return normalized?.map((value) => value.toLowerCase());
+}
+
+export function normalizeResumeBackupFetchLimit(limit: number | undefined, requestedResumeIds: string[] | undefined): number | undefined {
+    if (requestedResumeIds && requestedResumeIds.length > 0) {
+        return undefined;
+    }
+    return limit;
+}
+
+export function normalizeResumeBackupRequestedLimit(limit: number | undefined): number | undefined {
+    if (typeof limit !== "number" || !Number.isFinite(limit)) {
+        return undefined;
+    }
+    return Math.max(1, Math.trunc(limit));
+}
+
+export function normalizeResumeBackupArgs(args: ResumeBackupFilterArgs): ResumeBackupFilterArgs {
+    return {
+        resumeIds: normalizeResumeBackupFilterValues(args.resumeIds),
+        sourceHosts: normalizeResumeBackupSourceHosts(args.sourceHosts),
+        limit: normalizeResumeBackupRequestedLimit(args.limit),
+    };
+}
+
+// --- Sorting ---
+
+export function compareResumeBackupRows(left: ResumeBackupRow, right: ResumeBackupRow): number {
+    const crawledDiff = right.crawledAt - left.crawledAt;
+    if (crawledDiff !== 0) {
+        return crawledDiff;
+    }
+
+    const externalDiff = left.externalId.localeCompare(right.externalId);
+    if (externalDiff !== 0) {
+        return externalDiff;
+    }
+
+    return String(left._id).localeCompare(String(right._id));
+}
+
+// --- Filtering ---
+
+function createResumeBackupFilterSets(args: ResumeBackupFilterArgs): ResumeBackupFilterSets {
+    return {
+        resumeIds: args.resumeIds && args.resumeIds.length > 0 ? new Set(args.resumeIds) : undefined,
+        sourceHosts: args.sourceHosts && args.sourceHosts.length > 0 ? new Set(args.sourceHosts) : undefined,
+    };
+}
+
+function matchesResumeBackupSourceHosts(resume: Doc<"resumes">, sourceHosts: Set<string> | undefined): boolean {
+    if (!sourceHosts || sourceHosts.size === 0) {
+        return true;
+    }
+    return sourceHosts.has(resume.source.trim().toLowerCase());
+}
+
+function matchesResumeBackupResumeId(resume: Doc<"resumes">, resumeIds: Set<string> | undefined): boolean {
+    if (!resumeIds || resumeIds.size === 0) {
+        return true;
+    }
+
+    const identity = deriveResumeIdentity({
+        content: resume.content,
+        externalId: resume.externalId,
+        source: resume.source,
+    });
+    if (resumeIds.has(resume.externalId) || resumeIds.has(identity.rawValue) || resumeIds.has(identity.normalizedValue)) {
+        return true;
+    }
+
+    const content = isRecord(resume.content) ? resume.content : {};
+    const candidateValues = [
+        toOptionalStringValue(content.resumeId),
+        toOptionalStringValue(content.perUserId),
+        toOptionalStringValue(content.profileId),
+        toOptionalStringValue(content.externalId),
+    ].filter((value): value is string => Boolean(value));
+    return candidateValues.some((value) => resumeIds.has(value));
+}
+
+export function applyResumeBackupFilters(resumes: Doc<"resumes">[], filterSets: ResumeBackupFilterSets): ResumeBackupRow[] {
+    const filtered: ResumeBackupRow[] = [];
+    for (const resume of resumes) {
+        if (!matchesResumeBackupSourceHosts(resume, filterSets.sourceHosts)) {
+            continue;
+        }
+        if (!matchesResumeBackupResumeId(resume, filterSets.resumeIds)) {
+            continue;
+        }
+        filtered.push(projectResumeBackupRow(resume));
+    }
+    return filtered;
+}
+
+export { createResumeBackupFilterSets, matchesResumeBackupSourceHosts, matchesResumeBackupResumeId };

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -13,7 +13,6 @@ import {
     resolveResumeAnalysisSourceKey,
     isRecord,
 } from "@trends/shared";
-import { deriveResumeIdentity } from "./lib/resume_identity";
 import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
 import {
     toStringValue,
@@ -82,6 +81,13 @@ import {
     resolveResumeScanBatchSize,
     resolveResumeBackupPageSize,
 } from "./lib/resumes_pagination.js";
+import {
+    compareResumeBackupRows,
+    createResumeBackupFilterSets,
+    applyResumeBackupFilters,
+    normalizeResumeBackupFetchLimit,
+    normalizeResumeBackupArgs,
+} from "./lib/resumes_backup.js";
 
 // Re-export for backward compatibility
 export {
@@ -177,6 +183,23 @@ export {
     resolveResumeBackupPageSize,
 } from "./lib/resumes_pagination.js";
 
+// Re-export backup helpers for backward compatibility
+export {
+    projectResumeBackupRow,
+    normalizeResumeBackupFilterValues,
+    normalizeResumeBackupSourceHosts,
+    compareResumeBackupRows,
+    createResumeBackupFilterSets,
+    applyResumeBackupFilters,
+    normalizeResumeBackupFetchLimit,
+    normalizeResumeBackupRequestedLimit,
+    normalizeResumeBackupArgs,
+} from "./lib/resumes_backup.js";
+export type {
+    ResumeBackupRow,
+    ResumeBackupFilterArgs,
+} from "./lib/resumes_backup.js";
+
 export type ResumeScanRow = {
     _id: Doc<"resumes">["_id"];
     content: Doc<"resumes">["content"];
@@ -211,34 +234,6 @@ export type ResumeFieldCoverageDatasetRow = {
     skills: boolean;
 };
 
-type ResumeBackupRow = {
-    _id: Doc<"resumes">["_id"];
-    externalId: string;
-    source: string;
-    tags: string[];
-    crawledAt: number;
-    content: Doc<"resumes">["content"];
-    searchText?: Doc<"resumes">["searchText"];
-    primaryRuleScore?: Doc<"resumes">["primaryRuleScore"];
-    ingestData?: Doc<"resumes">["ingestData"];
-    analysis?: Doc<"resumes">["analysis"];
-    analyses?: Doc<"resumes">["analyses"];
-    isArchived?: boolean;
-    archivedAt?: number;
-};
-
-type ResumeBackupFilterArgs = {
-    resumeIds?: string[];
-    sourceHosts?: string[];
-    limit?: number;
-};
-
-type ResumeBackupFilterSets = {
-    resumeIds?: Set<string>;
-    sourceHosts?: Set<string>;
-};
-
-
 function normalizeRequestedResumeIds(resumeIds: string[]): string[] {
     const normalizedIds: string[] = [];
     const seen = new Set<string>();
@@ -253,130 +248,6 @@ function normalizeRequestedResumeIds(resumeIds: string[]): string[] {
     }
 
     return normalizedIds;
-}
-
-function projectResumeBackupRow(resume: Doc<"resumes">): ResumeBackupRow {
-    return {
-        _id: resume._id,
-        externalId: resume.externalId,
-        source: resume.source,
-        tags: resume.tags,
-        crawledAt: resume.crawledAt,
-        content: resume.content,
-        searchText: resume.searchText,
-        primaryRuleScore: resume.primaryRuleScore,
-        ingestData: resume.ingestData,
-        analysis: resume.analysis,
-        analyses: resume.analyses,
-        ...(resume.isArchived === true ? { isArchived: true, archivedAt: resume.archivedAt } : {}),
-    };
-}
-
-function normalizeResumeBackupFilterValues(values: string[] | undefined): string[] | undefined {
-    if (!Array.isArray(values)) {
-        return undefined;
-    }
-
-    const normalized = Array.from(new Set(
-        values
-            .map((value) => value.trim())
-            .filter((value) => value.length > 0)
-    ));
-
-    return normalized.length > 0 ? normalized : undefined;
-}
-
-function normalizeResumeBackupSourceHosts(values: string[] | undefined): string[] | undefined {
-    const normalized = normalizeResumeBackupFilterValues(values);
-    return normalized?.map((value) => value.toLowerCase());
-}
-
-function compareResumeBackupRows(left: ResumeBackupRow, right: ResumeBackupRow): number {
-    const crawledDiff = right.crawledAt - left.crawledAt;
-    if (crawledDiff !== 0) {
-        return crawledDiff;
-    }
-
-    const externalDiff = left.externalId.localeCompare(right.externalId);
-    if (externalDiff !== 0) {
-        return externalDiff;
-    }
-
-    return String(left._id).localeCompare(String(right._id));
-}
-
-function createResumeBackupFilterSets(args: ResumeBackupFilterArgs): ResumeBackupFilterSets {
-    return {
-        resumeIds: args.resumeIds && args.resumeIds.length > 0 ? new Set(args.resumeIds) : undefined,
-        sourceHosts: args.sourceHosts && args.sourceHosts.length > 0 ? new Set(args.sourceHosts) : undefined,
-    };
-}
-
-function matchesResumeBackupSourceHosts(resume: Doc<"resumes">, sourceHosts: Set<string> | undefined): boolean {
-    if (!sourceHosts || sourceHosts.size === 0) {
-        return true;
-    }
-    return sourceHosts.has(resume.source.trim().toLowerCase());
-}
-
-function matchesResumeBackupResumeId(resume: Doc<"resumes">, resumeIds: Set<string> | undefined): boolean {
-    if (!resumeIds || resumeIds.size === 0) {
-        return true;
-    }
-
-    const identity = deriveResumeIdentity({
-        content: resume.content,
-        externalId: resume.externalId,
-        source: resume.source,
-    });
-    if (resumeIds.has(resume.externalId) || resumeIds.has(identity.rawValue) || resumeIds.has(identity.normalizedValue)) {
-        return true;
-    }
-
-    const content = isRecord(resume.content) ? resume.content : {};
-    const candidateValues = [
-        toOptionalStringValue(content.resumeId),
-        toOptionalStringValue(content.perUserId),
-        toOptionalStringValue(content.profileId),
-        toOptionalStringValue(content.externalId),
-    ].filter((value): value is string => Boolean(value));
-    return candidateValues.some((value) => resumeIds.has(value));
-}
-
-function applyResumeBackupFilters(resumes: Doc<"resumes">[], filterSets: ResumeBackupFilterSets): ResumeBackupRow[] {
-    const filtered: ResumeBackupRow[] = [];
-    for (const resume of resumes) {
-        if (!matchesResumeBackupSourceHosts(resume, filterSets.sourceHosts)) {
-            continue;
-        }
-        if (!matchesResumeBackupResumeId(resume, filterSets.resumeIds)) {
-            continue;
-        }
-        filtered.push(projectResumeBackupRow(resume));
-    }
-    return filtered;
-}
-
-function normalizeResumeBackupFetchLimit(limit: number | undefined, requestedResumeIds: string[] | undefined): number | undefined {
-    if (requestedResumeIds && requestedResumeIds.length > 0) {
-        return undefined;
-    }
-    return limit;
-}
-
-function normalizeResumeBackupRequestedLimit(limit: number | undefined): number | undefined {
-    if (typeof limit !== "number" || !Number.isFinite(limit)) {
-        return undefined;
-    }
-    return Math.max(1, Math.trunc(limit));
-}
-
-function normalizeResumeBackupArgs(args: ResumeBackupFilterArgs): ResumeBackupFilterArgs {
-    return {
-        resumeIds: normalizeResumeBackupFilterValues(args.resumeIds),
-        sourceHosts: normalizeResumeBackupSourceHosts(args.sourceHosts),
-        limit: normalizeResumeBackupRequestedLimit(args.limit),
-    };
 }
 
 function compareResumes(


### PR DESCRIPTION
## Summary
- Extract 3 types (`ResumeBackupRow`, `ResumeBackupFilterArgs`, `ResumeBackupFilterSets`) and 11 backup-related functions from `resumes.ts` into `lib/resumes_backup.ts`
- Reduces `resumes.ts` by ~128 net lines (152 removed, 26 added for imports/re-exports)
- All symbols re-exported from `resumes.ts` for backward compatibility — no import changes needed in consumers

## Test plan
- [x] All 1,595 convex tests pass
- [x] `make check` passes (typecheck + lint + governance)
- [x] Re-exports verified: external consumers can still import from `resumes.ts`