### PR TITLE
fix: update BFF string paths after diagnostics extraction

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -381,7 +381,7 @@ describe("resume routes", () => {
       const call = parseConvexCall(input, init);
       calls.push(call);
 
-      if (call.pathName === "resumes:listArchivedDiagnostics") {
+      if (call.pathName === "resumes_diagnostics:listArchivedDiagnostics") {
         expect(call.args).toEqual(expect.objectContaining({
           sourceKeys: ["51job-manual", "seek"],
         }));
@@ -428,7 +428,7 @@ describe("resume routes", () => {
       ],
     }));
     expect(calls[0]).toEqual(expect.objectContaining({
-      pathName: "resumes:listArchivedDiagnostics",
+      pathName: "resumes_diagnostics:listArchivedDiagnostics",
     }));
   });
 

--- a/apps/api/src/routes/resumes_diagnostics.test.ts
+++ b/apps/api/src/routes/resumes_diagnostics.test.ts
@@ -192,7 +192,7 @@ describe("resumes_diagnostics", () => {
       expect(response.status).toBe(200);
       const payload = await response.json();
       expect(payload.success).toBe(true);
-      expect(calls[0].path).toBe("resumes:listArchivedDiagnostics");
+      expect(calls[0].path).toBe("resumes_diagnostics:listArchivedDiagnostics");
     });
   });
 });

--- a/apps/api/src/routes/resumes_diagnostics.ts
+++ b/apps/api/src/routes/resumes_diagnostics.ts
@@ -128,7 +128,7 @@ app.openapi(listResumeDiagnosticsRoute, async (c) => {
   const includeArchived = archived === true;
   const requestedLimit = Math.min(Math.max(limit ?? 100, 1), 500);
   const normalizedSourceKeys = normalizeResumeDiagnosticsSourceKeys(sourceKey);
-  const pathName = includeArchived ? "resumes:listArchivedDiagnostics" : "resumes:listIngestDiagnostics";
+  const pathName = includeArchived ? "resumes_diagnostics:listArchivedDiagnostics" : "resumes_diagnostics:listIngestDiagnostics";
   const rows: unknown[] = [];
   let cursor: string | null = null;
 

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -207,7 +207,6 @@ export {
     listIngestDiagnostics,
     listArchivedDiagnostics,
     listDiagnosticsSourceFacets,
-    countSourceKeyPage,
     listWorkflowDatasetPage,
     listFieldCoverageDatasetPage,
 } from "./resumes_diagnostics.js";


### PR DESCRIPTION
## Summary
- Update BFF Convex path references from `resumes:listArchivedDiagnostics` / `resumes:listIngestDiagnostics` to `resumes_diagnostics:listArchivedDiagnostics` / `resumes_diagnostics:listIngestDiagnostics` in route implementation and tests
- Remove dead `countSourceKeyPage` re-export from `resumes.ts` (it's an `internalQuery` only referenced within `resumes_diagnostics.ts`)

Follow-up to #1081 (diagnostics extraction) addressing simplify-worker findings about BFF string-path coupling.

## Test plan
- [x] `make check` passes
- [x] `vitest run apps/api/src/routes/resumes.test.ts apps/api/src/routes/resumes_diagnostics.test.ts` — 50/50 pass