### PR TITLE
test: add convex-test coverage for 6 untested resumes_mutations functions

### DIFF
--- a/packages/convex/convex/__tests__/resumes-mutations-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/resumes-mutations-convex-test.test.ts
@@ -9,24 +9,9 @@ import { convexTest } from "convex-test";
 import { describe, expect, it } from "vitest";
 import { api, internal } from "../_generated/api.js";
 import schema from "../schema.js";
+import { seedResume } from "./test-helpers.js";
 
 const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
-
-function seedResume(t: ReturnType<typeof convexTest>, overrides: Record<string, unknown> = {}) {
-    return t.run(async (ctx) => {
-        return ctx.db.insert("resumes", {
-            externalId: "test-resume-1",
-            identityKey: "profileUrl:example.com/candidates/1",
-            content: { name: "Test Candidate" },
-            hash: "hash-test",
-            source: "example.com",
-            sourceKey: "test",
-            tags: ["test"],
-            crawledAt: Date.now(),
-            ...overrides,
-        });
-    });
-}
 
 describe("resumes: updateAnalysis", () => {
     it("stores analysis on an existing resume", async () => {

--- a/packages/convex/convex/__tests__/resumes-mutations-extended-convex-test.test.ts
+++ b/packages/convex/convex/__tests__/resumes-mutations-extended-convex-test.test.ts
@@ -1,0 +1,497 @@
+/**
+ * Convex-test coverage for resume mutations — extended:
+ * - updateIngestDataBatch
+ * - listResumeScanBatch
+ * - listResumeUsageBatch
+ * - clearAnalyses
+ * - deleteResumes
+ * - hardResetIngestData
+ */
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { api, internal } from "../_generated/api.js";
+import schema from "../schema.js";
+import { seedResume, MINIMAL_INGEST_DATA } from "./test-helpers.js";
+
+const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
+
+// ---------------------------------------------------------------------------
+// updateIngestDataBatch
+// ---------------------------------------------------------------------------
+
+describe("resumes_mutations: updateIngestDataBatch", () => {
+    it("updates ingestData and rebuilds searchText", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t);
+
+        await t.mutation(internal.resumes_mutations.updateIngestDataBatch, {
+            updates: [{
+                resumeId,
+                ingestData: MINIMAL_INGEST_DATA,
+                primaryRuleScore: 42,
+            }],
+        });
+
+        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+        expect(resume?.ingestData).toBeDefined();
+        expect(resume?.primaryRuleScore).toBe(42);
+        // searchText should be rebuilt from content + ingest tokens
+        expect(resume?.searchText).toContain("cnc");
+    });
+
+    it("merges ingest tokens into existing searchText", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t, { searchText: "existing engineer" });
+
+        await t.mutation(internal.resumes_mutations.updateIngestDataBatch, {
+            updates: [{
+                resumeId,
+                ingestData: {
+                    ...MINIMAL_INGEST_DATA,
+                    industryTags: ["manufacturing", "aerospace"],
+                },
+                companyPatternAliasTokens: "boeing",
+            }],
+        });
+
+        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+        // Should preserve existing searchText base and merge new tokens
+        expect(resume?.searchText).toContain("engineer");
+        expect(resume?.searchText).toContain("aerospace");
+        expect(resume?.searchText).toContain("boeing");
+    });
+
+    it("skips non-existent resume IDs gracefully", async () => {
+        const t = convexTest(schema, modules);
+        const id1 = await seedResume(t, { externalId: "batch-ok" });
+        const doomedId = await seedResume(t, { externalId: "batch-doomed" });
+        await t.run(async (ctx) => { await ctx.db.delete(doomedId); });
+
+        // Should not throw — just skips the missing one
+        await t.mutation(internal.resumes_mutations.updateIngestDataBatch, {
+            updates: [
+                { resumeId: id1, ingestData: MINIMAL_INGEST_DATA, primaryRuleScore: 10 },
+                { resumeId: doomedId, ingestData: MINIMAL_INGEST_DATA },
+            ],
+        });
+
+        const r1 = await t.run(async (ctx) => ctx.db.get(id1));
+        expect(r1?.primaryRuleScore).toBe(10);
+    });
+
+    it("defaults primaryRuleScore to 0 when omitted", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t);
+
+        await t.mutation(internal.resumes_mutations.updateIngestDataBatch, {
+            updates: [{ resumeId, ingestData: MINIMAL_INGEST_DATA }],
+        });
+
+        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+        expect(resume?.primaryRuleScore).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// listResumeScanBatch
+// ---------------------------------------------------------------------------
+
+describe("resumes_mutations: listResumeScanBatch", () => {
+    it("returns empty page when no resumes exist", async () => {
+        const t = convexTest(schema, modules);
+        const result = await t.query(internal.resumes_mutations.listResumeScanBatch, {});
+        expect(result.page).toHaveLength(0);
+        expect(result.isDone).toBe(true);
+    });
+
+    it("returns projected scan rows with selected fields", async () => {
+        const t = convexTest(schema, modules);
+        await seedResume(t, { searchText: "engineer", primaryRuleScore: 30 });
+
+        const result = await t.query(internal.resumes_mutations.listResumeScanBatch, {});
+        expect(result.page).toHaveLength(1);
+        const row = result.page[0];
+        expect(row).toHaveProperty("_id");
+        expect(row).toHaveProperty("content");
+        expect(row).toHaveProperty("primaryRuleScore");
+        expect(row).toHaveProperty("searchText");
+        expect(row.searchText).toBe("engineer");
+        expect(row.primaryRuleScore).toBe(30);
+    });
+
+    it("paginates with cursor", async () => {
+        const t = convexTest(schema, modules);
+        await seedResume(t, { externalId: "scan-1", identityKey: "profileUrl:example.com/candidates/s1" });
+        await seedResume(t, { externalId: "scan-2", identityKey: "profileUrl:example.com/candidates/s2" });
+
+        const page1 = await t.query(internal.resumes_mutations.listResumeScanBatch, { limit: 1 });
+        expect(page1.page).toHaveLength(1);
+        expect(page1.isDone).toBe(false);
+        expect(page1.continueCursor).toBeTruthy();
+
+        const page2 = await t.query(internal.resumes_mutations.listResumeScanBatch, {
+            cursor: page1.continueCursor,
+            limit: 1,
+        });
+        expect(page2.page).toHaveLength(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// listResumeUsageBatch
+// ---------------------------------------------------------------------------
+
+describe("resumes_mutations: listResumeUsageBatch", () => {
+    it("returns empty page when no resumes exist", async () => {
+        const t = convexTest(schema, modules);
+        const result = await t.query(internal.resumes_mutations.listResumeUsageBatch, {});
+        expect(result.page).toHaveLength(0);
+        expect(result.isDone).toBe(true);
+    });
+
+    it("returns analysis and analyses fields only", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t);
+
+        // Set up analysis data
+        await t.mutation(internal.resumes.updateAnalysis, {
+            resumeId,
+            analysis: {
+                score: 75,
+                summary: "Good candidate",
+                highlights: ["experienced"],
+                recommendation: "proceed",
+                jobDescriptionId: "jd-1",
+            },
+        });
+
+        const result = await t.query(internal.resumes_mutations.listResumeUsageBatch, {});
+        expect(result.page).toHaveLength(1);
+        const row = result.page[0];
+        expect(row).toHaveProperty("analysis");
+        expect(row).toHaveProperty("analyses");
+        expect(row.analysis).toBeDefined();
+        // Should NOT have content, searchText, etc.
+        expect(row).not.toHaveProperty("content");
+        expect(row).not.toHaveProperty("searchText");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// clearAnalyses
+// ---------------------------------------------------------------------------
+
+describe("resumes_mutations: clearAnalyses", () => {
+    it("clears all analyses when no jobDescriptionId specified", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t);
+
+        await t.mutation(internal.resumes.updateAnalysis, {
+            resumeId,
+            analysis: {
+                score: 80,
+                summary: "Strong",
+                highlights: ["experienced"],
+                recommendation: "proceed",
+                jobDescriptionId: "jd-1",
+            },
+        });
+
+        const result = await t.mutation(api.resumes_mutations.clearAnalyses, {
+            resumeIds: [resumeId],
+        });
+
+        expect(result.cleared).toBe(1);
+        expect(result.hasMore).toBe(false);
+
+        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+        expect(resume?.analysis).toBeUndefined();
+        expect(resume?.analyses).toBeUndefined();
+    });
+
+    it("clears only matching JD analyses when jobDescriptionId specified", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t);
+
+        // Add analysis for jd-1
+        await t.mutation(internal.resumes.updateAnalysis, {
+            resumeId,
+            analysis: {
+                score: 80,
+                summary: "For JD1",
+                highlights: [],
+                recommendation: "proceed",
+                jobDescriptionId: "jd-1",
+            },
+        });
+
+        // Add analysis for jd-2 (this will become the current analysis)
+        await t.mutation(internal.resumes.updateAnalysis, {
+            resumeId,
+            analysis: {
+                score: 60,
+                summary: "For JD2",
+                highlights: [],
+                recommendation: "potential",
+                jobDescriptionId: "jd-2",
+            },
+        });
+
+        // Clear only jd-1 analyses
+        const result = await t.mutation(api.resumes_mutations.clearAnalyses, {
+            resumeIds: [resumeId],
+            jobDescriptionId: "jd-1",
+        });
+
+        expect(result.cleared).toBe(1);
+
+        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+        // jd-2 analysis should remain as current
+        expect(resume?.analysis?.jobDescriptionId).toBe("jd-2");
+        // jd-1 entry should be removed from analyses map
+        const analysesKeys = Object.keys(resume?.analyses ?? {});
+        const jd1Key = analysesKeys.find((k) => k.includes("jd-1"));
+        expect(jd1Key).toBeUndefined();
+    });
+
+    it("skips resumes that have no analysis data", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t);
+
+        const result = await t.mutation(api.resumes_mutations.clearAnalyses, {
+            resumeIds: [resumeId],
+        });
+
+        expect(result.cleared).toBe(0);
+    });
+
+    it("paginates when no resumeIds provided", async () => {
+        const t = convexTest(schema, modules);
+        await seedResume(t, { externalId: "clear-1", identityKey: "profileUrl:example.com/candidates/c1" });
+        await seedResume(t, {
+            externalId: "clear-2",
+            identityKey: "profileUrl:example.com/candidates/c2",
+            analysis: { score: 50, summary: "Test", highlights: [], recommendation: "skip" },
+        });
+
+        const result = await t.mutation(api.resumes_mutations.clearAnalyses, {
+            batchSize: 1,
+        });
+
+        // Only the second resume has analysis data to clear
+        expect(result.cleared).toBe(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// deleteResumes
+// ---------------------------------------------------------------------------
+
+describe("resumes_mutations: deleteResumes", () => {
+    it("deletes a resume and returns correct counts", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t);
+
+        const result = await t.mutation(api.resumes_mutations.deleteResumes, {
+            resumeIds: [String(resumeId)],
+        });
+
+        expect(result.requested).toBe(1);
+        expect(result.deleted).toBe(1);
+        expect(result.missingResumeIds).toHaveLength(0);
+
+        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+        expect(resume).toBeNull();
+    });
+
+    it("reports missing IDs for invalid resume IDs", async () => {
+        const t = convexTest(schema, modules);
+        const result = await t.mutation(api.resumes_mutations.deleteResumes, {
+            resumeIds: ["not-a-valid-id"],
+        });
+
+        expect(result.requested).toBe(1);
+        expect(result.deleted).toBe(0);
+        expect(result.missingResumeIds).toContain("not-a-valid-id");
+    });
+
+    it("deletes associated ai_tagging_results", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t);
+
+        // Insert an ai_tagging_result linked to this resume
+        await t.run(async (ctx) => {
+            await ctx.db.insert("ai_tagging_results", {
+                resumeId,
+                identityKey: "profileUrl:example.com/candidates/1",
+                workspaceSlug: "dev",
+                profileKey: "test-profile",
+                evidenceHash: "hash-123",
+                promptVersion: "v1",
+                model: "test-model",
+                idempotencyKey: "idem-123",
+                status: "completed",
+                result: {
+                    roleFit: "high",
+                    recommendation: "proceed",
+                    confidence: 0.9,
+                    tags: ["skilled"],
+                    evidenceLines: ["5 years CNC"],
+                },
+                createdAt: Date.now(),
+            });
+        });
+
+        const result = await t.mutation(api.resumes_mutations.deleteResumes, {
+            resumeIds: [String(resumeId)],
+        });
+
+        expect(result.deleted).toBe(1);
+        expect(result.deletedAiTaggingResults).toBe(1);
+    });
+
+    it("patches screening_sessions to remove deleted resume IDs", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t);
+
+        // Insert a screening session referencing this resume
+        await t.run(async (ctx) => {
+            await ctx.db.insert("screening_sessions", {
+                sessionKey: "test-session",
+                status: "active",
+                config: {
+                    location: "Shanghai",
+                    keywords: ["engineer"],
+                    filters: {},
+                },
+                reviewedResumeIds: [String(resumeId), "other-resume-id"],
+                lastActive: Date.now(),
+            });
+        });
+
+        const result = await t.mutation(api.resumes_mutations.deleteResumes, {
+            resumeIds: [String(resumeId)],
+        });
+
+        expect(result.deleted).toBe(1);
+        expect(result.patchedScreeningSessions).toBe(1);
+
+        // Verify the session no longer references the deleted resume
+        const session = await t.run(async (ctx) => {
+            const page = await ctx.db.query("screening_sessions").first();
+            return page;
+        });
+        expect(session?.reviewedResumeIds).not.toContain(String(resumeId));
+        expect(session?.reviewedResumeIds).toContain("other-resume-id");
+    });
+
+    it("deduplicates and trims resume IDs", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t);
+
+        const result = await t.mutation(api.resumes_mutations.deleteResumes, {
+            resumeIds: [String(resumeId), String(resumeId), "  ", ""],
+        });
+
+        expect(result.deleted).toBe(1);
+        // Duplicates and empty strings should be normalized away
+        expect(result.requested).toBe(1);
+    });
+
+    it("returns zero counts for empty input", async () => {
+        const t = convexTest(schema, modules);
+        const result = await t.mutation(api.resumes_mutations.deleteResumes, {
+            resumeIds: [],
+        });
+
+        expect(result.requested).toBe(0);
+        expect(result.deleted).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// hardResetIngestData
+// ---------------------------------------------------------------------------
+
+describe("resumes_mutations: hardResetIngestData", () => {
+    it("clears ingestData, analysis, analyses, primaryRuleScore, and searchText", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t, {
+            ingestData: MINIMAL_INGEST_DATA,
+            searchText: "engineer cnc",
+            primaryRuleScore: 42,
+        });
+
+        await t.mutation(internal.resumes.updateAnalysis, {
+            resumeId,
+            analysis: {
+                score: 80,
+                summary: "Test",
+                highlights: [],
+                recommendation: "proceed",
+            },
+        });
+
+        const result = await t.mutation(api.resumes_mutations.hardResetIngestData, {});
+
+        expect(result.cleared).toBe(1);
+
+        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+        expect(resume?.ingestData).toBeUndefined();
+        expect(resume?.analysis).toBeUndefined();
+        expect(resume?.analyses).toBeUndefined();
+        expect(resume?.primaryRuleScore).toBeUndefined();
+        expect(resume?.searchText).toBeUndefined();
+    });
+
+    it("skips resumes with no computed fields", async () => {
+        const t = convexTest(schema, modules);
+        await seedResume(t); // No ingestData, no analysis, no searchText
+
+        const result = await t.mutation(api.resumes_mutations.hardResetIngestData, {});
+        expect(result.cleared).toBe(0);
+    });
+
+    it("returns hasMore and cursor for pagination", async () => {
+        const t = convexTest(schema, modules);
+        // Create 2 resumes with computed fields
+        await seedResume(t, {
+            externalId: "reset-1",
+            identityKey: "profileUrl:example.com/candidates/r1",
+            searchText: "engineer",
+        });
+        await seedResume(t, {
+            externalId: "reset-2",
+            identityKey: "profileUrl:example.com/candidates/r2",
+            ingestData: MINIMAL_INGEST_DATA,
+        });
+
+        // Request batch size 1 to force pagination
+        const page1 = await t.mutation(api.resumes_mutations.hardResetIngestData, { batchSize: 1 });
+        expect(page1.cleared).toBe(1);
+        expect(page1.hasMore).toBe(true);
+        expect(page1.cursor).toBeTruthy();
+
+        const page2 = await t.mutation(api.resumes_mutations.hardResetIngestData, {
+            cursor: page1.cursor ?? undefined,
+            batchSize: 1,
+        });
+        expect(page2.cleared).toBe(1);
+    });
+
+    it("preserves non-computed fields like content and sourceKey", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t, {
+            ingestData: MINIMAL_INGEST_DATA,
+            searchText: "engineer",
+        });
+
+        await t.mutation(api.resumes_mutations.hardResetIngestData, {});
+
+        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+        // Non-computed fields should be preserved
+        expect(resume?.content).toBeDefined();
+        expect(resume?.sourceKey).toBe("test");
+        expect(resume?.externalId).toBe("test-resume-1");
+    });
+});

--- a/packages/convex/convex/__tests__/test-helpers.ts
+++ b/packages/convex/convex/__tests__/test-helpers.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared test utilities for Convex integration tests.
+ */
+import { convexTest } from "convex-test";
+import schema from "../schema.js";
+
+const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
+
+/**
+ * Create a convexTest instance with the full schema and module glob.
+ */
+export function createTest() {
+    return convexTest(schema, modules);
+}
+
+/**
+ * Insert a minimal resume document into the database for testing.
+ * Returns the resume ID.
+ */
+export function seedResume(t: ReturnType<typeof convexTest>, overrides: Record<string, unknown> = {}) {
+    return t.run(async (ctx) => {
+        return ctx.db.insert("resumes", {
+            externalId: "test-resume-1",
+            identityKey: "profileUrl:example.com/candidates/1",
+            content: { name: "Test Candidate" },
+            hash: "hash-test",
+            source: "example.com",
+            sourceKey: "test",
+            tags: ["test"],
+            crawledAt: Date.now(),
+            ...overrides,
+        });
+    });
+}
+
+/**
+ * Minimal valid ingestData for test seeding.
+ */
+export const MINIMAL_INGEST_DATA = {
+    industryTags: ["manufacturing"],
+    synonymHits: ["cnc"],
+    ruleScores: { skills: 10 },
+    experienceLevel: "senior",
+    computedAt: Date.now(),
+    skillsVersion: 2,
+};


### PR DESCRIPTION
## Summary
- Add 23 integration tests for 6 previously untested mutations in `resumes_mutations.ts`: `updateIngestDataBatch`, `listResumeScanBatch`, `listResumeUsageBatch`, `clearAnalyses`, `deleteResumes`, `hardResetIngestData`
- Extract shared `seedResume` helper and `MINIMAL_INGEST_DATA` into `test-helpers.ts` to eliminate duplication with existing `resumes-mutations-convex-test.test.ts`

## Test plan
- [x] `npx vitest run packages/convex/convex/__tests__/resumes-mutations-extended-convex-test.test.ts` — 23/23 pass
- [x] `npx vitest run packages/convex/convex/__tests__/resumes-mutations-convex-test.test.ts` — 14/14 pass (refactored to use shared helper, no behavior change)
- [x] `make check` — all checks pass
- [ ] Verify CI passes (tests.yml + checks.yml)