### PR TITLE
refactor: eliminate z.any() in industry and actions routes

### DIFF
--- a/apps/api/src/routes/actions.ts
+++ b/apps/api/src/routes/actions.ts
@@ -26,7 +26,7 @@ const CandidateActionSchema = z.object({
   sessionId: z.string().optional(),
   resumeId: z.string(),
   actionType: ActionTypeSchema,
-  actionData: z.record(z.string(), z.any()).optional(),
+  actionData: z.record(z.string(), z.unknown()).optional(),
   createdAt: z.string(),
 });
 
@@ -45,7 +45,7 @@ const CreateActionSchema = z.object({
   sessionId: z.string().optional(),
   resumeId: z.string(),
   actionType: ActionTypeSchema,
-  actionData: z.record(z.string(), z.any()).optional(),
+  actionData: z.record(z.string(), z.unknown()).optional(),
 });
 
 const ActionsQuerySchema = z.object({

--- a/apps/api/src/routes/industry.ts
+++ b/apps/api/src/routes/industry.ts
@@ -72,13 +72,15 @@ const VerifyRequestSchema = z.object({
     category: z.string().optional(),
 });
 
+const IndustryEntrySchema = z.union([CompanyEntrySchema, KeywordEntrySchema, BrandEntrySchema]);
+
 const VerifyResponseSchema = z.object({
     success: z.literal(true),
     result: z.object({
         verified: z.boolean(),
         confidence: z.number(),
-        match: z.any().optional(),
-        matches: z.array(z.any()).optional(),
+        match: IndustryEntrySchema.optional(),
+        matches: z.array(IndustryEntrySchema).optional(),
     }),
 });
 

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -2338,8 +2338,48 @@ export interface paths {
                             result: {
                                 verified: boolean;
                                 confidence: number;
-                                match?: unknown;
-                                matches?: unknown[];
+                                match?: {
+                                    id: number;
+                                    nameCn: string;
+                                    nameEn?: string;
+                                    type: string;
+                                    /** @enum {string} */
+                                    category: "key_company" | "ites_exhibitor" | "agent";
+                                } | {
+                                    id: number;
+                                    keyword: string;
+                                    english?: string;
+                                    /** @enum {string} */
+                                    category: "machining" | "lathe" | "edm" | "measurement" | "smt" | "3d_printing";
+                                } | {
+                                    id: number;
+                                    nameCn: string;
+                                    nameEn?: string;
+                                    type: string;
+                                    /** @enum {string} */
+                                    origin: "international" | "domestic" | "agent";
+                                };
+                                matches?: ({
+                                    id: number;
+                                    nameCn: string;
+                                    nameEn?: string;
+                                    type: string;
+                                    /** @enum {string} */
+                                    category: "key_company" | "ites_exhibitor" | "agent";
+                                } | {
+                                    id: number;
+                                    keyword: string;
+                                    english?: string;
+                                    /** @enum {string} */
+                                    category: "machining" | "lathe" | "edm" | "measurement" | "smt" | "3d_printing";
+                                } | {
+                                    id: number;
+                                    nameCn: string;
+                                    nameEn?: string;
+                                    type: string;
+                                    /** @enum {string} */
+                                    origin: "international" | "domestic" | "agent";
+                                })[];
                             };
                         };
                     };


### PR DESCRIPTION
## Summary
- Replace `z.any()` in industry.ts verify response with typed union schema (`z.union([CompanyEntrySchema, KeywordEntrySchema, BrandEntrySchema])`)
- Replace `z.any()` in actions.ts actionData with `z.unknown()` (genuinely dynamic JSON values)
- Reduces API `z.any()` from 7 to 5 (remaining: 3 Convex bridge types in resumes schemas, 2 file upload patterns)

## Test plan
- [x] `make check` — all checks pass
- [x] OpenAPI spec regenerated