### PR TITLE
refactor: update search-load test imports to use extracted module paths

### DIFF
--- a/packages/convex/convex/__tests__/resumes-search-load.test.ts
+++ b/packages/convex/convex/__tests__/resumes-search-load.test.ts
@@ -1,9 +1,9 @@
 /**
  * Keyword search load and correctness tests.
  *
- * Tests the pure-function helpers used by every keyword search path in
- * resumes.ts: query building, AND/OR matching, provenance tracking,
- * batch-size limits, and edge-case handling.
+ * Tests the pure-function helpers used by every keyword search path:
+ * query building, AND/OR matching, provenance tracking, batch-size limits,
+ * and edge-case handling.
  *
  * These run as vitest unit tests — no live Convex instance required.
  */
@@ -13,8 +13,10 @@ import {
     buildTagExpansionSearchQuery,
     collectSearchTextProvenance,
     matchesTagExpansionSearchText,
+} from "../lib/resumes_tag_expansion.js";
+import {
     resolveListWithIngestWindow,
-} from "../resumes";
+} from "../lib/resumes_pagination.js";
 
 // ── Test fixtures ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Import directly from `lib/resumes_tag_expansion.js` and `lib/resumes_pagination.js` instead of backward-compat re-exports in `resumes.ts`
- Updates doc comment to remove reference to "resumes.ts" since helpers now live in extracted modules

## Test plan
- [x] `npx vitest run packages/convex/convex/__tests__/resumes-search-load.test.ts` — 39/39 pass
- [x] `make check` — all checks pass