### PR TITLE
fix: MY market industry_db floor of 40 with brand/company hit override

### DIFF
--- a/apps/api/src/services/ingest-compute-service.ts
+++ b/apps/api/src/services/ingest-compute-service.ts
@@ -474,19 +474,13 @@ export class IngestComputeService {
     const synonymHits = this.computeSynonymHits(evidenceText);
 
     // 3. Compute field-aware brandHits, then derive companyHits for backward compatibility
-    //    For MY market: skip company/brand verification (CN-only data), keep keyword-based tags
+    //    MY market: run lookup against CN industry DB — international brands (Siemens, Caterpillar)
+    //    may match even without a dedicated MY dataset. No matches → empty arrays naturally.
     const latestWorkHistory = getLatestWorkHistory(item.workHistory);
-    const isIndustryDbAvailable = market !== "MY";
-    const verifiedEmployers = isIndustryDbAvailable
-      ? this.collectVerifiedEmployerMatches(latestWorkHistory)
-      : [];
-    const brandHits = isIndustryDbAvailable
-      ? this.computeBrandHits(latestWorkHistory, index.companies, searchText, verifiedEmployers)
-      : [];
+    const verifiedEmployers = this.collectVerifiedEmployerMatches(latestWorkHistory);
+    const brandHits = this.computeBrandHits(latestWorkHistory, index.companies, searchText, verifiedEmployers);
     const companyHits = verifiedEmployers.map((m) => m.key);
-    const { raw: industryDbV2Raw, components: industryDbV2RawComponents } = isIndustryDbAvailable
-      ? computeIndustryDbV2Raw(companyHits, brandHits)
-      : { raw: 0, components: { companyScore: 0, brandScore: 0, weightedBrandUnits: 0, uniqueCompanies: 0, brandUnitCount: 0 } };
+    const { raw: industryDbV2Raw, components: industryDbV2RawComponents } = computeIndustryDbV2Raw(companyHits, brandHits);
     const roleYearsAnchor = resolveRoleYearsAnchor(item);
     const roleSignals = this.computeRoleSignals(latestWorkHistory, roleYearsAnchor);
     const companyPatternAliasTokens = this.buildCompanyAliasTokens(companyHits, brandHits);

--- a/apps/api/src/services/rule-scoring.test.ts
+++ b/apps/api/src/services/rule-scoring.test.ts
@@ -965,8 +965,9 @@ describe("RuleScoringService", () => {
         const myResult = service.scoreResume(index, context, brandHits, [], "MY");
 
         expect(cnResult.breakdown.brandRelevance).toBeGreaterThan(0);
-        expect(myResult.breakdown.brandRelevance).toBe(0);
-        expect(myResult.score).toBeLessThan(cnResult.score);
+        // MY market now computes brandRelevance normally — international brands match
+        expect(myResult.breakdown.brandRelevance).toBeGreaterThan(0);
+        expect(myResult.breakdown.brandRelevance).toBe(cnResult.breakdown.brandRelevance);
       } finally {
         cleanupFixtureRoot(root);
       }

--- a/apps/api/src/services/rule-scoring.ts
+++ b/apps/api/src/services/rule-scoring.ts
@@ -943,10 +943,9 @@ export class RuleScoringService {
       ? this.weights.brandContextWithTarget
       : this.weights.brandContextNoTarget;
 
-    // MY market: brandRelevance is 0 because industry DB data is CN-only
-    const brandRelevance = market === "MY"
-      ? 0
-      : Math.min(
+    // Brand relevance: computed for all markets including MY.
+    // International brands in the CN DB (e.g., Siemens, Caterpillar) may match MY resumes.
+    const brandRelevance = Math.min(
           categoryWeights.brandRelevance,
           matchedBrandHits.reduce((maxScore, hit) => {
             const baseWeight = contextWeights[hit.context] ?? 0;

--- a/apps/web/src/components/search/SnippetCardExpanded.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.tsx
@@ -32,11 +32,11 @@ function formatSnakeCaseLabel(value: string): string {
   return value.replace(/_/g, ' ')
 }
 
-function BreakdownBar({ breakdown, isMyMarket }: { breakdown: Record<string, number>; isMyMarket?: boolean }) {
+function BreakdownBar({ breakdown, isMyMarket, hasMyIndustryHits }: { breakdown: Record<string, number>; isMyMarket?: boolean; hasMyIndustryHits?: boolean }) {
   const { t } = useTranslation()
   const relatedExp = breakdown.related_exp ?? 0
   const industryDb = breakdown.industry_db ?? 0
-  if (isMyMarket) {
+  if (isMyMarket && !hasMyIndustryHits) {
     return (
       <div className="space-y-1.5">
         <div className="flex h-3 w-full overflow-hidden rounded-full bg-slate-200">
@@ -330,7 +330,11 @@ export function SnippetCardExpanded({
                     <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
                       {analysisBreakdownLabel}
                     </div>
-                    <BreakdownBar breakdown={analysis.breakdown} isMyMarket={item.resume.ingestData?.market === 'MY'} />
+                    <BreakdownBar
+                      breakdown={analysis.breakdown}
+                      isMyMarket={item.resume.ingestData?.market === 'MY'}
+                      hasMyIndustryHits={(item.resume.ingestData?.brandHits?.length ?? 0) + (item.resume.ingestData?.companyHits?.length ?? 0) > 0}
+                    />
                     <div className="grid gap-2 sm:grid-cols-2">
                       {Object.entries(analysis.breakdown).map(([label, value]) => (
                         <div
@@ -504,21 +508,22 @@ export function SnippetCardExpanded({
                     { key: 'location', label: t('resumes.searchPage.card.location', { defaultValue: 'Location' }) },
                   ].map(({ key, label }) => {
                     const isMyMarket = item.resume.ingestData?.market === 'MY'
-                    const isIndustryDbMy = key === 'industry_db' && isMyMarket
-                    const score = isIndustryDbMy ? 0 : ((analysis?.breakdown as Record<string, number> | undefined)?.[key] ?? 0)
+                    const hasMyIndustryHits = isMyMarket && key === 'industry_db' && (item.resume.ingestData?.brandHits?.length ?? 0) + (item.resume.ingestData?.companyHits?.length ?? 0) > 0
+                    const isIndustryDbMyNoHits = key === 'industry_db' && isMyMarket && !hasMyIndustryHits
+                    const score = isIndustryDbMyNoHits ? 0 : ((analysis?.breakdown as Record<string, number> | undefined)?.[key] ?? 0)
                     return (
                       <div key={key} className="space-y-0.5">
                         <div className="flex items-center justify-between text-[11px]">
-                          <span className={isIndustryDbMy ? 'italic text-muted-foreground/60' : 'text-muted-foreground'}>
-                            {isIndustryDbMy
+                          <span className={isIndustryDbMyNoHits ? 'italic text-muted-foreground/60' : 'text-muted-foreground'}>
+                            {isIndustryDbMyNoHits
                               ? t('resumes.searchPage.card.breakdownLabels.industryDbNotAvailable', { defaultValue: 'Industry DB: Not available for MY market' })
                               : label}
                           </span>
-                          {!isIndustryDbMy && (
+                          {!isIndustryDbMyNoHits && (
                             <span className="font-mono text-xs text-muted-foreground">{Math.round(typeof score === 'number' ? score : 0)}</span>
                           )}
                         </div>
-                        {!isIndustryDbMy && (
+                        {!isIndustryDbMyNoHits && (
                           <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
                             <div
                               className="h-full rounded-full bg-primary/60 transition-all"

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -117,7 +117,7 @@
       "experience": "Experience",
       "skills": "Skills",
       "industryDb": "Industry DB",
-      "industryDbNotAvailable": "Industry DB: Not available for MY market",
+      "industryDbNotAvailable": "Industry DB: Floor 40 (no MY data)",
       "education": "Education",
       "location": "Location"
     },
@@ -497,11 +497,11 @@
         "relatedExp": "Related Exp",
         "skills": "Skills",
         "industryDb": "Industry DB",
-        "industryDbNotAvailable": "Industry DB: Not available for MY market",
+        "industryDbNotAvailable": "Industry DB: Floor 40 (no MY data)",
         "education": "Education",
         "location": "Location",
         "breakdownLabels": {
-          "industryDbNotAvailable": "Industry DB: Not available for MY market"
+          "industryDbNotAvailable": "Industry DB: Floor 40 (no MY data)"
         }
       },
       "error": {

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -117,7 +117,7 @@
       "experience": "经验",
       "skills": "技能",
       "industryDb": "行业库",
-      "industryDbNotAvailable": "行业库：MY市场暂不可用",
+      "industryDbNotAvailable": "行业库：保底40（无MY数据）",
       "education": "学历",
       "location": "地区"
     },
@@ -496,11 +496,11 @@
         "relatedExp": "相关经验",
         "skills": "技能",
         "industryDb": "行业库",
-        "industryDbNotAvailable": "行业库：MY市场暂不可用",
+        "industryDbNotAvailable": "行业库：保底40（无MY数据）",
         "education": "学历",
         "location": "地点",
         "breakdownLabels": {
-          "industryDbNotAvailable": "行业库：MY市场暂不可用"
+          "industryDbNotAvailable": "行业库：保底40（无MY数据）"
         }
       },
       "error": {

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -117,7 +117,7 @@
       "experience": "經驗",
       "skills": "技能",
       "industryDb": "產業庫",
-      "industryDbNotAvailable": "產業庫：MY市場暫不可用",
+      "industryDbNotAvailable": "產業庫：保底40（無MY數據）",
       "education": "學歷",
       "location": "地點"
     },

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -398,6 +398,7 @@ function countHistogramSamples(histogram50: number[]): number {
 }
 
 const INDUSTRY_DB_V2_SCORE_CAP = 50
+const MY_INDUSTRY_DB_FLOOR = 40
 const RELATED_EXP_AI_WEIGHT = INDUSTRY_DB_V2_SCORE_CAP / 100
 const INDUSTRY_DB_V2_MIN_NONZERO_SAMPLE_SIZE = 5
 
@@ -533,7 +534,7 @@ export function overrideIndustryDbBreakdown(
   industryDb: number,
   market?: string,
 ): ConvexResumeAnalysis {
-  const effectiveIndustryDb = market === 'MY' ? 0 : industryDb
+  const effectiveIndustryDb = market === 'MY' ? Math.max(MY_INDUSTRY_DB_FLOOR, industryDb) : industryDb
   const normalizedRelatedExp =
     typeof analysis.breakdown?.related_exp === 'number'
       ? Math.round(clamp(analysis.breakdown.related_exp, 0, 100) * RELATED_EXP_AI_WEIGHT)


### PR DESCRIPTION
## Summary
- MY market resumes had `industry_db` hardcoded to 0, capping AI final score at 50 (80+ filter unreachable)
- Implement hybrid floor: `industry_db = 40` for MY without hits, `industry_db = 50` for MY with brand/company hits (same as CN)
- Remove MY gate on brand/company lookup in ingest pipeline — international brands (Siemens, Caterpillar) can now match MY resumes

## Changes
| File | Change |
|------|--------|
| `ingest-compute-service.ts` | Remove `isIndustryDbAvailable = market !== "MY"` gate — run lookup for all markets |
| `rule-scoring.ts` | Remove MY brandRelevance zero-out — compute normally |
| `resume-scoring.ts` | `Math.max(MY_INDUSTRY_DB_FLOOR=40, industryDb)` for MY market |
| `SnippetCardExpanded.tsx` | Show actual score for MY with hits; floor label only when no hits |
| `en.json` / `zh-Hans.json` / `zh-Hant.json` | Update placeholder text |

## Scoring impact
| Resume type | industry_db | AI Score (related_exp=80) |
|-------------|------------|---------------------------|
| CN with brand/company hit | 50 | 90 |
| MY no hits (new floor) | 40 | 80 ✅ |
| MY with international brand hit | 50 | 90 |
| MY before this fix | 0 | 50 ❌ |

## Test plan
- [x] `make check` passes
- [x] All 5065 tests pass (1 test updated: `rule-scoring.test.ts` MY brandRelevance)
- [ ] Verify MY resumes without hits show `industry_db: 40` in UI
- [ ] Verify MY resumes with brand hits show `industry_db: 50` in UI