### PR TITLE
feat: wire bias anomaly notifications to Feishu/WeChat/Email channels

### DIFF
--- a/apps/api/src/routes/resumes_admin.test.ts
+++ b/apps/api/src/routes/resumes_admin.test.ts
@@ -4,6 +4,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import resumesAdminRoutes from "./resumes_admin";
 import { workspaceMiddleware } from "../middleware/workspace";
 
+vi.mock("../services/notification-service", () => ({
+  notificationService: {
+    sendFeishuText: vi.fn().mockResolvedValue({ code: 0, msg: "ok" }),
+    sendWechatWorkMarkdown: vi.fn().mockResolvedValue({ errcode: 0, errmsg: "ok" }),
+    sendEmail: vi.fn().mockResolvedValue({ messageId: "test-123" }),
+  },
+}));
+
 function createTestApp() {
   const app = new OpenAPIHono();
   app.use("*", workspaceMiddleware);
@@ -213,6 +221,87 @@ describe("resumes_admin", () => {
       expect(response.status).toBe(400);
       const payload = await response.json();
       expect(payload.success).toBe(false);
+    });
+  });
+
+  describe("POST /api/resumes/bias-anomaly-notify", () => {
+    it("rejects non-admin access with 403", async () => {
+      const app = createTestApp();
+      const response = await app.request("/api/resumes/bias-anomaly-notify", {
+        method: "POST",
+        headers: { "X-Workspace-Slug": "hr" },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(403);
+    });
+
+    it("returns 400 when workspaceSlug is missing", async () => {
+      const app = createTestApp();
+      const response = await app.request("/api/resumes/bias-anomaly-notify", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(400);
+      const payload = await response.json();
+      expect(payload.error).toContain("workspaceSlug");
+    });
+
+    it("returns 400 for invalid channel", async () => {
+      const app = createTestApp();
+      const response = await app.request("/api/resumes/bias-anomaly-notify", {
+        method: "POST",
+        body: JSON.stringify({ workspaceSlug: "test-ws", channel: "slack" }),
+      });
+
+      expect(response.status).toBe(400);
+      const payload = await response.json();
+      expect(payload.error).toContain("Invalid channel");
+    });
+
+    it("returns notified:false when no active alerts", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        convexSuccess(null),
+      );
+
+      const app = createTestApp();
+      const response = await app.request("/api/resumes/bias-anomaly-notify", {
+        method: "POST",
+        body: JSON.stringify({ workspaceSlug: "test-ws" }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload.success).toBe(true);
+      expect(payload.notified).toBe(false);
+      expect(payload.reason).toContain("No active anomaly alerts");
+    });
+
+    it("sends notification via feishu when channel specified", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        convexSuccess({
+          workspaceSlug: "test-ws",
+          flags: ["disparate_impact_violation"],
+          psiValue: 0.35,
+          disparityRatio: 0.72,
+          alertedAt: Date.now(),
+        }),
+      );
+
+      const app = createTestApp();
+      const response = await app.request("/api/resumes/bias-anomaly-notify", {
+        method: "POST",
+        body: JSON.stringify({ workspaceSlug: "test-ws", channel: "feishu" }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload.success).toBe(true);
+      expect(payload.notified).toBe(true);
+      expect(payload.channels).toHaveLength(1);
+      expect(payload.channels[0].channel).toBe("feishu");
+      expect(payload.channels[0].success).toBe(true);
     });
   });
 });

--- a/apps/api/src/routes/resumes_admin.ts
+++ b/apps/api/src/routes/resumes_admin.ts
@@ -4,6 +4,7 @@ import { IngestComputeService } from "../services/ingest-compute-service.js";
 import { config } from "../services/config.js";
 import { logger } from "../services/logger.js";
 import { requireAdmin } from "../middleware/workspace.js";
+import { notificationService } from "../services/notification-service.js";
 
 const app = new OpenAPIHono();
 // Per-route requireAdmin — do NOT use app.use("*", requireAdmin) here
@@ -361,6 +362,98 @@ app.get("/api/resumes/anomaly-alerts", requireAdmin, async (c) => {
     return c.json({ success: true, alerts }, 200);
   } catch (error) {
     logger.error("Failed to fetch anomaly alerts", error, { route: "resumes_admin" });
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+// Bias anomaly notification — dispatch alerts for active anomalies (EU AI Act Art. 12)
+app.post("/api/resumes/bias-anomaly-notify", requireAdmin, async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const workspaceSlug = typeof body.workspaceSlug === "string" ? body.workspaceSlug.trim() : "";
+  const channel = typeof body.channel === "string" ? body.channel : "";
+
+  if (!workspaceSlug) {
+    return c.json({ success: false, error: "workspaceSlug is required" }, 400);
+  }
+
+  const validChannels = ["feishu", "wechat_work", "email"];
+  if (channel && !validChannels.includes(channel)) {
+    return c.json({ success: false, error: `Invalid channel. Must be one of: ${validChannels.join(", ")}` }, 400);
+  }
+
+  try {
+    const alerts = await callConvexQuery("bias_audit:getAnomalyAlerts", { workspaceSlug }) as {
+      workspaceSlug: string;
+      flags: string[];
+      psiValue: number | null;
+      disparityRatio: number | null;
+      alertedAt: number;
+    } | null;
+
+    if (!alerts || alerts.flags.length === 0) {
+      return c.json({ success: true, notified: false, reason: "No active anomaly alerts" }, 200);
+    }
+
+    const alertDate = new Date(alerts.alertedAt).toISOString();
+    const flagList = alerts.flags.join(", ");
+    const psiNote = alerts.psiValue != null ? `PSI: ${alerts.psiValue.toFixed(4)}` : "";
+    const dirNote = alerts.disparityRatio != null ? `DIR: ${alerts.disparityRatio.toFixed(4)}` : "";
+    const metricsNote = [psiNote, dirNote].filter(Boolean).join(" | ");
+
+    const subject = `[Trends] Bias Anomaly Alert — ${workspaceSlug}`;
+    const textContent = [
+      `Bias Audit Anomaly Alert`,
+      `Workspace: ${workspaceSlug}`,
+      `Flags: ${flagList}`,
+      `Metrics: ${metricsNote}`,
+      `Detected at: ${alertDate}`,
+      ``,
+      `This alert was generated automatically by the weekly bias audit (EU AI Act Art. 12).`,
+      `Please review the Audit & Compliance dashboard for details.`,
+    ].join("\n");
+
+    const channels = channel ? [channel] : validChannels;
+    const results: Array<{ channel: string; success: boolean; error?: string }> = [];
+
+    for (const ch of channels) {
+      try {
+        if (ch === "feishu") {
+          await notificationService.sendFeishuText({ content: textContent });
+          results.push({ channel: ch, success: true });
+        } else if (ch === "wechat_work") {
+          await notificationService.sendWechatWorkMarkdown({ content: textContent });
+          results.push({ channel: ch, success: true });
+        } else if (ch === "email") {
+          const adminEmail = process.env.BIAS_ALERT_EMAIL;
+          if (!adminEmail) {
+            results.push({ channel: ch, success: false, error: "BIAS_ALERT_EMAIL not configured" });
+            continue;
+          }
+          await notificationService.sendEmail({
+            to: adminEmail,
+            subject,
+            html: `<pre>${textContent}</pre>`,
+            text: textContent,
+          });
+          results.push({ channel: ch, success: true });
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger.error(`Failed to send bias anomaly notification via ${ch}`, error, { route: "resumes_admin" });
+        results.push({ channel: ch, success: false, error: msg });
+      }
+    }
+
+    const anySuccess = results.some((r) => r.success);
+    return c.json({
+      success: true,
+      notified: anySuccess,
+      alerts: { flags: alerts.flags, alertedAt: alertDate },
+      channels: results,
+    }, 200);
+  } catch (error) {
+    logger.error("Failed to dispatch bias anomaly notification", error, { route: "resumes_admin" });
     const message = error instanceof Error ? error.message : String(error);
     return c.json({ success: false, error: message }, 500);
   }


### PR DESCRIPTION
## Summary
- Add `POST /api/resumes/bias-anomaly-notify` endpoint that dispatches bias audit anomaly alerts to operators via Feishu, WeChat Work, and Email channels
- Uses existing `NotificationService` (sendFeishuText, sendWechatWorkMarkdown, sendEmail) — no new dependencies
- The weekly bias audit cron (`computeBiasMetricsForAllWorkspaces`) already stores anomaly alerts; this endpoint surfaces them to operators (EU AI Act Art. 12)
- Supports channel selection (feishu, wechat_work, email) or defaults to all configured channels
- 5 test cases covering admin gating, validation, no-alerts state, and feishu dispatch

## Test plan
- [x] `make check` passes (typecheck + lint + governance)
- [x] 5070/5070 tests pass including 5 new bias-anomaly-notify tests
- [ ] Manual: set FEISHU_WEBHOOK_URL env var, call POST /api/resumes/bias-anomaly-notify with workspaceSlug and channel=feishu
- [ ] Manual: verify notification content includes anomaly flags, PSI value, DIR ratio