### PR TITLE
refactor: migrate worker.ts proxy routes to createRoute OpenAPI

### DIFF
--- a/apps/api/src/routes/__tests__/worker-route.test.ts
+++ b/apps/api/src/routes/__tests__/worker-route.test.ts
@@ -1,0 +1,124 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import workerRoutes from "../worker";
+
+function createTestApp() {
+  const app = new OpenAPIHono();
+  app.route("/", workerRoutes);
+  return app;
+}
+
+function workerSuccess(data: unknown, contentType = "application/json"): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "Content-Type": contentType },
+  });
+}
+
+describe("worker routes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("GET /status", () => {
+    it("proxies to worker status endpoint", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        workerSuccess({ status: "idle", uptime: 12345 }),
+      );
+
+      const app = createTestApp();
+      const response = await app.request("/status");
+
+      expect(response.status).toBe(200);
+      const payload = await response.json() as { status: string };
+      expect(payload.status).toBe("idle");
+    });
+
+    it("returns 503 when worker is unreachable", async () => {
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const app = createTestApp();
+      const response = await app.request("/status");
+
+      expect(response.status).toBe(503);
+      const payload = await response.json() as { error: string };
+      expect(payload.error).toContain("Failed to connect");
+    });
+  });
+
+  describe("POST /crawl", () => {
+    it("proxies crawl trigger to worker", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        workerSuccess({ triggered: true }),
+      );
+
+      const app = createTestApp();
+      const response = await app.request("/crawl", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json() as { triggered: boolean };
+      expect(payload.triggered).toBe(true);
+    });
+  });
+
+  describe("POST /run", () => {
+    it("proxies run trigger with default once=true", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        workerSuccess({ started: true }),
+      );
+
+      const app = createTestApp();
+      const response = await app.request("/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(response.status).toBe(200);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("once=true"),
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("proxies run trigger with once=false", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        workerSuccess({ started: true }),
+      );
+
+      const app = createTestApp();
+      const response = await app.request("/run?once=false", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(response.status).toBe(200);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("once=false"),
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
+
+  describe("POST /summary", () => {
+    it("proxies summary with request body", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        workerSuccess({ summary: "done" }),
+      );
+
+      const app = createTestApp();
+      const response = await app.request("/summary", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "daily" }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json() as { summary: string };
+      expect(payload.summary).toBe("done");
+    });
+  });
+});

--- a/apps/api/src/routes/worker.ts
+++ b/apps/api/src/routes/worker.ts
@@ -1,61 +1,111 @@
-import { OpenAPIHono } from "@hono/zod-openapi";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { config } from "../services/config.js";
 import { logger } from "../services/logger.js";
 
 const app = new OpenAPIHono();
 
-async function proxyToWorker(path: string, init: RequestInit): Promise<Response> {
+async function proxyToJson(path: string, init: RequestInit): Promise<{ data: unknown; status: number }> {
     const response = await fetch(`${config.workerUrl}${path}`, init);
-    const body = await response.text();
-    const contentType = response.headers.get("content-type") || "application/json";
-
-    return new Response(body, {
-        status: response.status,
-        headers: {
-            "Content-Type": contentType,
-        },
-    });
+    const text = await response.text();
+    let data: unknown;
+    try {
+        data = JSON.parse(text);
+    } catch {
+        data = text;
+    }
+    return { data, status: response.status };
 }
 
-app.get("/status", async (c) => {
+const SimpleErrorSchema = z.object({ error: z.string() });
+const WorkerRunQuerySchema = z.object({ once: z.string().optional().default("true") });
+
+const statusRoute = createRoute({
+    method: "get",
+    path: "/status",
+    tags: ["worker"],
+    summary: "Get worker status",
+    responses: {
+        200: { content: { "application/json": { schema: z.unknown() } }, description: "Worker status" },
+        503: { content: { "application/json": { schema: SimpleErrorSchema } }, description: "Worker unavailable" },
+    },
+});
+app.openapi(statusRoute, async (c) => {
     try {
-        return await proxyToWorker("/worker/status", { method: "GET" });
+        const { data, status } = await proxyToJson("/worker/status", { method: "GET" });
+        return c.json(data, status as 200);
     } catch (error) {
         logger.error("Failed to proxy to worker status:", error, { route: "worker" });
         return c.json({ error: "Failed to connect to worker API" }, 503);
     }
 });
 
-app.post("/crawl", async (c) => {
+const crawlRoute = createRoute({
+    method: "post",
+    path: "/crawl",
+    tags: ["worker"],
+    summary: "Trigger crawl job",
+    responses: {
+        200: { content: { "application/json": { schema: z.unknown() } }, description: "Crawl triggered" },
+        503: { content: { "application/json": { schema: SimpleErrorSchema } }, description: "Worker unavailable" },
+    },
+});
+app.openapi(crawlRoute, async (c) => {
     try {
-        return await proxyToWorker("/worker/crawl", { method: "POST" });
+        const { data, status } = await proxyToJson("/worker/crawl", { method: "POST" });
+        return c.json(data, status as 200);
     } catch (error) {
         logger.error("Failed to proxy crawl trigger:", error, { route: "worker" });
         return c.json({ error: "Failed to connect to worker API" }, 503);
     }
 });
 
-app.post("/run", async (c) => {
-    const once = c.req.query("once") ?? "true";
+const runRoute = createRoute({
+    method: "post",
+    path: "/run",
+    tags: ["worker"],
+    summary: "Trigger worker run",
+    request: {
+        query: WorkerRunQuerySchema,
+    },
+    responses: {
+        200: { content: { "application/json": { schema: z.unknown() } }, description: "Run triggered" },
+        503: { content: { "application/json": { schema: SimpleErrorSchema } }, description: "Worker unavailable" },
+    },
+});
+app.openapi(runRoute, async (c) => {
+    const { once } = c.req.valid("query");
     try {
-        return await proxyToWorker(`/worker/run?once=${encodeURIComponent(once)}`, { method: "POST" });
+        const { data, status } = await proxyToJson(`/worker/run?once=${encodeURIComponent(once)}`, { method: "POST" });
+        return c.json(data, status as 200);
     } catch (error) {
         logger.error("Failed to proxy worker run trigger:", error, { route: "worker" });
         return c.json({ error: "Failed to connect to worker API" }, 503);
     }
 });
 
-app.post("/summary", async (c) => {
+const summaryRoute = createRoute({
+    method: "post",
+    path: "/summary",
+    tags: ["worker"],
+    summary: "Trigger summary job",
+    request: {
+        body: { content: { "application/json": { schema: z.unknown() } } },
+    },
+    responses: {
+        200: { content: { "application/json": { schema: z.unknown() } }, description: "Summary triggered" },
+        503: { content: { "application/json": { schema: SimpleErrorSchema } }, description: "Worker unavailable" },
+    },
+});
+app.openapi(summaryRoute, async (c) => {
     const body = await c.req.text();
     const contentType = c.req.header("Content-Type") || "application/json";
     try {
-        return await proxyToWorker("/worker/summary", {
+        const { data, status } = await proxyToJson("/worker/summary", {
             method: "POST",
-            headers: {
-                "Content-Type": contentType,
-            },
+            headers: { "Content-Type": contentType },
             body,
         });
+        return c.json(data, status as 200);
     } catch (error) {
         logger.error("Failed to proxy summary trigger:", error, { route: "worker" });
         return c.json({ error: "Failed to connect to worker API" }, 503);

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4997,6 +4997,394 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/worker/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get worker status */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Worker status */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Worker unavailable */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/worker/crawl": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Trigger crawl job */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Crawl triggered */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Worker unavailable */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/worker/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Trigger worker run */
+        post: {
+            parameters: {
+                query?: {
+                    once?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Run triggered */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Worker unavailable */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/worker/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Trigger summary job */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            responses: {
+                /** @description Summary triggered */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Worker unavailable */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/worker/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get worker status */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Worker status */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Worker unavailable */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/worker/crawl": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Trigger crawl job */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Crawl triggered */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Worker unavailable */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/worker/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Trigger worker run */
+        post: {
+            parameters: {
+                query?: {
+                    once?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Run triggered */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Worker unavailable */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/worker/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Trigger summary job */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            responses: {
+                /** @description Summary triggered */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Worker unavailable */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/search-profiles/stats": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Summary
- Convert 4 worker proxy routes (status, crawl, run, summary) from bare `app.get/app.post` to `createRoute()` with Zod schemas
- Replace raw `Response` proxy pattern with JSON parse-and-re-emit via `c.json()` for type-safe createRoute compatibility
- Add 6 unit tests covering all routes including error (503) paths

## Test plan
- [x] `make check` passes
- [x] All 6 worker route tests pass
- [x] OpenAPI spec regenerated and api-types.ts updated