### PR TITLE
refactor: migrate notifications.ts from Hono to OpenAPIHono + createRoute

### DIFF
--- a/apps/api/src/routes/__tests__/notifications-route.test.ts
+++ b/apps/api/src/routes/__tests__/notifications-route.test.ts
@@ -1,0 +1,153 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import notificationsRoutes from "../notifications";
+
+vi.mock("../../services/notification-service", () => ({
+  notificationService: {
+    sendFeishuText: vi.fn().mockResolvedValue({ code: 0, msg: "ok" }),
+    sendWechatWorkMarkdown: vi.fn().mockResolvedValue({ errcode: 0, errmsg: "ok" }),
+    sendEmail: vi.fn().mockResolvedValue({ messageId: "test-123" }),
+  },
+}));
+
+vi.mock("../../services/notification-template-service", () => ({
+  notificationTemplateService: {
+    listTemplates: vi.fn().mockReturnValue([
+      { id: "test-template", filename: "test.md", updatedAt: "2026-01-01", size: 100, subject: "Test" },
+    ]),
+    render: vi.fn().mockReturnValue({ subject: "Rendered", markdown: "Hello {{name}}" }),
+  },
+}));
+
+vi.mock("../../services/ai-matching", () => ({
+  aiMatchingService: {
+    generateOutreach: vi.fn().mockResolvedValue({ subject: "Outreach", body: "Hello" }),
+  },
+}));
+
+function createTestApp() {
+  const app = new OpenAPIHono();
+  app.route("/api/notifications", notificationsRoutes);
+  return app;
+}
+
+const jsonHeaders = (extra: Record<string, string> = {}): Record<string, string> => ({
+  "Content-Type": "application/json",
+  ...extra,
+});
+
+describe("notifications routes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("GET /api/notifications/templates", () => {
+    it("returns template list", async () => {
+      const app = createTestApp();
+      const response = await app.request("/api/notifications/templates");
+
+      expect(response.status).toBe(200);
+      const payload = await response.json() as { templates: Array<{ id: string }> };
+      expect(payload.templates).toHaveLength(1);
+      expect(payload.templates[0].id).toBe("test-template");
+    });
+  });
+
+  describe("POST /api/notifications/draft", () => {
+    it("generates outreach draft", async () => {
+      const app = createTestApp();
+      const response = await app.request("/api/notifications/draft", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({
+          resume: { id: "r1", name: "Alice" },
+          jobDescription: { title: "Engineer", requirements: "5 years exp" },
+          analysis: { score: 85, recommendation: "strong_match", highlights: ["exp"], concerns: [], summary: "Good fit" },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json() as { subject: string };
+      expect(payload.subject).toBe("Outreach");
+    });
+
+    it("returns 400 for invalid body", async () => {
+      const app = createTestApp();
+      const response = await app.request("/api/notifications/draft", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("POST /api/notifications/preview", () => {
+    it("renders email preview", async () => {
+      const app = createTestApp();
+      const response = await app.request("/api/notifications/preview", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({
+          channel: "email",
+          templateId: "test-template",
+          data: { name: "Bob" },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json() as { channel: string };
+      expect(payload.channel).toBe("email");
+    });
+
+    it("renders feishu preview", async () => {
+      const app = createTestApp();
+      const response = await app.request("/api/notifications/preview", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({
+          channel: "feishu",
+          templateId: "test-template",
+          data: { name: "Bob" },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json() as { channel: string; content: string };
+      expect(payload.channel).toBe("feishu");
+      expect(payload.content).toBeDefined();
+    });
+  });
+
+  describe("POST /api/notifications/send", () => {
+    it("rejects non-admin with 403", async () => {
+      const app = createTestApp();
+      const response = await app.request("/api/notifications/send", {
+        method: "POST",
+        headers: jsonHeaders({ "X-Workspace-Slug": "hr" }),
+        body: JSON.stringify({ to: "test@example.com", subject: "Hi", body: "Hello" }),
+      });
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("POST /api/notifications/send-template", () => {
+    it("rejects non-admin with 403", async () => {
+      const app = createTestApp();
+      const response = await app.request("/api/notifications/send-template", {
+        method: "POST",
+        headers: jsonHeaders({ "X-Workspace-Slug": "hr" }),
+        body: JSON.stringify({
+          channel: "feishu",
+          templateId: "test-template",
+          data: { name: "Bob" },
+        }),
+      });
+
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -1,7 +1,5 @@
 
-import { Hono } from "hono";
-import { zValidator } from "@hono/zod-validator";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { aiMatchingService } from "../services/ai-matching.js";
 import { notificationService } from "../services/notification-service.js";
 import { notificationTemplateService } from "../services/notification-template-service.js";
@@ -9,9 +7,10 @@ import { config } from "../services/config.js";
 import { formatIsoOffsetInTimezone } from "../services/timezone.js";
 import { requireAdmin } from "../middleware/workspace.js";
 
-const app = new Hono();
+const app = new OpenAPIHono();
 
-// Schema for generating a draft
+const SimpleErrorSchema = z.object({ error: z.string() });
+
 const draftSchema = z.object({
     resume: z.object({
         id: z.string(),
@@ -37,11 +36,10 @@ const draftSchema = z.object({
     }),
 });
 
-// Schema for sending an email
 const sendSchema = z.object({
     to: z.string().email(),
     subject: z.string(),
-    body: z.string(), // HTML is expected
+    body: z.string(),
 });
 
 const templateIdSchema = z
@@ -50,7 +48,7 @@ const templateIdSchema = z
     .max(128)
     .regex(/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/);
 
-const templateDataSchema = z.record(z.string(), z.unknown());
+const templateDataSchema = z.record(z.string(), z.any());
 
 const previewSchema = z.object({
     channel: z.enum(["email", "wechat_work", "feishu"]),
@@ -131,7 +129,16 @@ function buildTemplateData(data: Record<string, unknown>): Record<string, unknow
 }
 
 // GET /api/notifications/templates
-app.get("/templates", async (c) => {
+const templatesRoute = createRoute({
+    method: "get",
+    path: "/templates",
+    tags: ["notifications"],
+    summary: "List notification templates",
+    responses: {
+        200: { content: { "application/json": { schema: z.object({ templates: z.array(z.object({ id: z.string(), filename: z.string(), updatedAt: z.string(), size: z.number(), subject: z.string().optional() })) }) } }, description: "Templates" },
+    },
+});
+app.openapi(templatesRoute, async (c) => {
     const templates = notificationTemplateService.listTemplates().map((item) => ({
         id: item.id,
         filename: item.filename,
@@ -143,110 +150,146 @@ app.get("/templates", async (c) => {
 });
 
 // POST /api/notifications/draft
-app.post(
-    "/draft",
-    zValidator("json", draftSchema),
-    async (c) => {
-        const { resume, jobDescription, analysis } = c.req.valid("json");
-        try {
-            const draft = await aiMatchingService.generateOutreach(resume, jobDescription, analysis);
-            return c.json(draft);
-        } catch (e: unknown) {
-            return c.json({ error: getErrorMessage(e) }, 500);
-        }
+const draftRoute = createRoute({
+    method: "post",
+    path: "/draft",
+    tags: ["notifications"],
+    summary: "Generate outreach draft",
+    request: {
+        body: { content: { "application/json": { schema: draftSchema } } },
+    },
+    responses: {
+        200: { content: { "application/json": { schema: z.any() } }, description: "Draft generated" },
+        500: { content: { "application/json": { schema: SimpleErrorSchema } }, description: "Generation failed" },
+    },
+});
+app.openapi(draftRoute, async (c) => {
+    const { resume, jobDescription, analysis } = c.req.valid("json");
+    try {
+        const draft = await aiMatchingService.generateOutreach(resume, jobDescription, analysis);
+        return c.json(draft as Record<string, unknown>, 200);
+    } catch (e: unknown) {
+        return c.json({ error: getErrorMessage(e) }, 500);
     }
-);
+});
 
 // POST /api/notifications/preview
-app.post(
-    "/preview",
-    zValidator("json", previewSchema),
-    async (c) => {
-        const { channel, templateId, data } = c.req.valid("json");
-        try {
-            const rendered = notificationTemplateService.render(templateId, buildTemplateData(data));
+const previewRoute = createRoute({
+    method: "post",
+    path: "/preview",
+    tags: ["notifications"],
+    summary: "Preview notification template",
+    request: {
+        body: { content: { "application/json": { schema: previewSchema } } },
+    },
+    responses: {
+        200: { content: { "application/json": { schema: z.any() } }, description: "Preview rendered" },
+        500: { content: { "application/json": { schema: SimpleErrorSchema } }, description: "Render failed" },
+    },
+});
+app.openapi(previewRoute, async (c) => {
+    const { channel, templateId, data } = c.req.valid("json");
+    try {
+        const rendered = notificationTemplateService.render(templateId, buildTemplateData(data));
 
-            if (channel === "email") {
-                return c.json({
-                    channel,
-                    templateId,
-                    subject: rendered.subject ?? "",
-                    markdown: rendered.markdown,
-                    html: renderMarkdownAsHtml(rendered.markdown),
-                });
-            }
-
+        if (channel === "email") {
             return c.json({
                 channel,
                 templateId,
-                content: rendered.markdown,
-            });
-        } catch (e: unknown) {
-            return c.json({ error: getErrorMessage(e) }, 500);
+                subject: rendered.subject ?? "",
+                markdown: rendered.markdown,
+                html: renderMarkdownAsHtml(rendered.markdown),
+            }, 200);
         }
+
+        return c.json({
+            channel,
+            templateId,
+            content: rendered.markdown,
+        }, 200);
+    } catch (e: unknown) {
+        return c.json({ error: getErrorMessage(e) }, 500);
     }
-);
+});
 
 // POST /api/notifications/send
-app.post(
-    "/send",
-    requireAdmin,
-    zValidator("json", sendSchema),
-    async (c) => {
-        const { to, subject, body } = c.req.valid("json");
-        try {
-            const info = await notificationService.sendEmail({
-                to,
-                subject,
-                html: body.replace(/\n/g, "<br>"), // Simple text-to-HTML conversion
-            });
-            const messageId = getMessageId(info);
-            return c.json({ success: true, messageId, preview: messageId ? undefined : "Check server logs" });
-        } catch (e: unknown) {
-            return c.json({ error: getErrorMessage(e) }, 500);
-        }
+const sendRoute = createRoute({
+    method: "post",
+    path: "/send",
+    tags: ["notifications"],
+    summary: "Send email notification",
+    middleware: [requireAdmin] as const,
+    request: {
+        body: { content: { "application/json": { schema: sendSchema } } },
+    },
+    responses: {
+        200: { content: { "application/json": { schema: z.any() } }, description: "Email sent" },
+        500: { content: { "application/json": { schema: SimpleErrorSchema } }, description: "Send failed" },
+    },
+});
+app.openapi(sendRoute, async (c) => {
+    const { to, subject, body } = c.req.valid("json");
+    try {
+        const info = await notificationService.sendEmail({
+            to,
+            subject,
+            html: body.replace(/\n/g, "<br>"),
+        });
+        const messageId = getMessageId(info);
+        return c.json({ success: true, messageId, preview: messageId ? undefined : "Check server logs" }, 200);
+    } catch (e: unknown) {
+        return c.json({ error: getErrorMessage(e) }, 500);
     }
-);
+});
 
 // POST /api/notifications/send-template
-app.post(
-    "/send-template",
-    requireAdmin,
-    zValidator("json", sendTemplateSchema),
-    async (c) => {
-        const payload = c.req.valid("json");
-        try {
-            const rendered = notificationTemplateService.render(payload.templateId, buildTemplateData(payload.data));
+const sendTemplateRoute = createRoute({
+    method: "post",
+    path: "/send-template",
+    tags: ["notifications"],
+    summary: "Send templated notification",
+    middleware: [requireAdmin] as const,
+    request: {
+        body: { content: { "application/json": { schema: sendTemplateSchema } } },
+    },
+    responses: {
+        200: { content: { "application/json": { schema: z.any() } }, description: "Notification sent" },
+        500: { content: { "application/json": { schema: SimpleErrorSchema } }, description: "Send failed" },
+    },
+});
+app.openapi(sendTemplateRoute, async (c) => {
+    const payload = c.req.valid("json");
+    try {
+        const rendered = notificationTemplateService.render(payload.templateId, buildTemplateData(payload.data));
 
-            if (payload.channel === "email") {
-                const subject = payload.subject ?? rendered.subject ?? "";
-                const info = await notificationService.sendEmail({
-                    to: payload.to,
-                    subject,
-                    text: rendered.markdown,
-                    html: renderMarkdownAsHtml(rendered.markdown),
-                });
-                const messageId = getMessageId(info);
-                return c.json({ success: true, channel: payload.channel, messageId });
-            }
+        if (payload.channel === "email") {
+            const subject = payload.subject ?? rendered.subject ?? "";
+            const info = await notificationService.sendEmail({
+                to: payload.to,
+                subject,
+                text: rendered.markdown,
+                html: renderMarkdownAsHtml(rendered.markdown),
+            });
+            const messageId = getMessageId(info);
+            return c.json({ success: true, channel: payload.channel, messageId }, 200);
+        }
 
-            if (payload.channel === "wechat_work") {
-                const result = await notificationService.sendWechatWorkMarkdown({
-                    webhookUrl: payload.webhookUrl,
-                    content: rendered.markdown,
-                });
-                return c.json({ success: true, channel: payload.channel, ...result });
-            }
-
-            const result = await notificationService.sendFeishuText({
+        if (payload.channel === "wechat_work") {
+            const result = await notificationService.sendWechatWorkMarkdown({
                 webhookUrl: payload.webhookUrl,
                 content: rendered.markdown,
             });
-            return c.json({ success: true, channel: payload.channel, ...result });
-        } catch (e: unknown) {
-            return c.json({ error: getErrorMessage(e) }, 500);
+            return c.json({ success: true, channel: payload.channel, ...result }, 200);
         }
+
+        const result = await notificationService.sendFeishuText({
+            webhookUrl: payload.webhookUrl,
+            content: rendered.markdown,
+        });
+        return c.json({ success: true, channel: payload.channel, ...result }, 200);
+    } catch (e: unknown) {
+        return c.json({ error: getErrorMessage(e) }, 500);
     }
-);
+});
 
 export default app;

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -9182,6 +9182,318 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/notifications/templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List notification templates */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Templates */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            templates: {
+                                id: string;
+                                filename: string;
+                                updatedAt: string;
+                                size: number;
+                                subject?: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/notifications/draft": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Generate outreach draft */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        resume: {
+                            id: string;
+                            name: string;
+                            jobIntention?: string;
+                            workExperience?: number;
+                            education?: string;
+                            skills?: string[];
+                            companies?: string[];
+                            summary?: string;
+                        };
+                        jobDescription: {
+                            title: string;
+                            company?: string;
+                            requirements: string;
+                        };
+                        analysis: {
+                            score: number;
+                            /** @enum {string} */
+                            recommendation: "strong_match" | "match" | "potential" | "no_match";
+                            highlights: string[];
+                            concerns: string[];
+                            summary: string;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Draft generated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Generation failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/notifications/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Preview notification template */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        channel: "email" | "wechat_work" | "feishu";
+                        templateId: string;
+                        data: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Preview rendered */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Render failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/notifications/send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send email notification */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** Format: email */
+                        to: string;
+                        subject: string;
+                        body: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Email sent */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Send failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/notifications/send-template": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send templated notification */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        channel: "email";
+                        templateId: string;
+                        /** Format: email */
+                        to: string;
+                        subject?: string;
+                        data: {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        channel: "wechat_work";
+                        templateId: string;
+                        /** Format: uri */
+                        webhookUrl?: string;
+                        data: {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        channel: "feishu";
+                        templateId: string;
+                        /** Format: uri */
+                        webhookUrl?: string;
+                        data: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Notification sent */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Send failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/summaries/profiles": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Summary
- Convert 5 notification routes from `Hono` + `zValidator` to `OpenAPIHono` + `createRoute()`
- Routes: GET /templates, POST /draft, POST /preview, POST /send, POST /send-template
- Migrate `requireAdmin` middleware from inline to createRoute `middleware` field
- Add 7 unit tests covering templates, draft, preview, and admin access gating

## Test plan
- [x] `make check` passes
- [x] All 7 notification route tests pass
- [x] OpenAPI spec regenerated and api-types.ts updated