### PR TITLE
fix: parseIngestData drops market field, breaking MY industry_db floor

### DIFF
--- a/apps/web/src/hooks/useConvexResumes.test.ts
+++ b/apps/web/src/hooks/useConvexResumes.test.ts
@@ -259,6 +259,35 @@ describe('parseIngestData', () => {
     expect(result!.experienceLevel).toBe('senior')
   })
 
+  it('parses market field for MY resumes', () => {
+    const input = {
+      industryTags: [],
+      synonymHits: [],
+      brandHits: [],
+      companyHits: [],
+      ruleScores: {},
+      experienceLevel: 'unknown',
+      market: 'MY',
+    }
+    const result = parseIngestData(input)
+    expect(result).toBeDefined()
+    expect(result!.market).toBe('MY')
+  })
+
+  it('returns undefined market when not present', () => {
+    const input = {
+      industryTags: [],
+      synonymHits: [],
+      brandHits: [],
+      companyHits: [],
+      ruleScores: {},
+      experienceLevel: 'unknown',
+    }
+    const result = parseIngestData(input)
+    expect(result).toBeDefined()
+    expect(result!.market).toBeUndefined()
+  })
+
   it('returns undefined for non-record', () => {
     expect(parseIngestData(null)).toBeUndefined()
     expect(parseIngestData('string')).toBeUndefined()

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -617,6 +617,7 @@ export function parseIngestData(value: unknown): ConvexIngestData | undefined {
     experienceLevel: toStringValue(value.experienceLevel) || 'unknown',
     computedAt,
     skillsVersion,
+    market: toStringValue(value.market) || undefined,
   }
 }
 


### PR DESCRIPTION
## Summary
- `parseIngestData()` in `useConvexResumes.ts` never returned the `market` field from `ingestData`
- `overrideIndustryDbBreakdown` always received `undefined` for market, so `MY_INDUSTRY_DB_FLOOR` (40) never applied
- MY Seek resumes scored without the floor, making the 80+ filter threshold unreachable

## Fix
- Added `market: toStringValue(value.market) || undefined` to the `parseIngestData` return object
- Added two tests: one verifying `market: 'MY'` is parsed correctly, one verifying `market` is `undefined` when absent

## Test plan
- [x] `make check` passes
- [x] New unit tests pass (48/48)
- [ ] Verify `http://localhost:5173/dev/resumes?location=Malaysia&q=CNC+Sales` shows MY floor of 40 for Seek resumes