### PR TITLE
feat: auto-dispatch analysis covers all unanalyzed resumes

### DIFF
--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -57,7 +57,6 @@ import type { ExperienceLevelFilter } from '@/hooks/useUrlSearchState'
 import { rawApiClient } from '@/lib/api-helpers'
 import {
   getCurrentResumeAiPromptVersion,
-  resolveAnalysisTopN,
 } from '@/lib/analysis-utils'
 import { submitResumeExportDownload, type ResumeExportRequestBody } from '@/lib/resume-export'
 import { getResumeAge, parseExperienceYears } from '@/lib/resume-filtering'
@@ -1066,7 +1065,6 @@ export function useResumeListState(loadSearchHistory = false) {
             sourceKey: resolveAnalysisSourceKeyForResume(resume, sessionCollectionSource),
           })
         )
-        .slice(0, resolveAnalysisTopN(import.meta.env.VITE_ANALYSIS_TOP_N))
 
       if (candidatesToAnalyze.length === 0) {
         toast.info(t('aiTasks.noNewCandidates', 'No new candidates to analyze among top matches.'))

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -916,19 +916,21 @@ export function useResumeSearchState() {
         .sort((left, right) => (right.score ?? -1) - (left.score ?? -1)),
     [filteredResults],
   )
+  const analysisTopN = resolveAnalysisTopN(import.meta.env.VITE_ANALYSIS_TOP_N)
   const analysisCandidateResumeIds = useMemo(
-    () =>
-      analysisCandidates
-        .slice(0, resolveAnalysisTopN(import.meta.env.VITE_ANALYSIS_TOP_N))
-        .map((item) => item.resume.resumeId),
+    () => analysisCandidates.map((item) => item.resume.resumeId),
     [analysisCandidates],
+  )
+  const analysisDispatchBatchIds = useMemo(
+    () => analysisCandidateResumeIds.slice(0, analysisTopN),
+    [analysisCandidateResumeIds, analysisTopN],
   )
   const analysisCandidateSignature = useMemo(
     () =>
-      [...analysisCandidateResumeIds]
+      [...analysisDispatchBatchIds]
         .sort((left, right) => left.localeCompare(right))
         .join('|'),
-    [analysisCandidateResumeIds],
+    [analysisDispatchBatchIds],
   )
   const autoAnalyzeSignature = useMemo(() => {
     if (autoAnalyzeSearchNonce === 0 || analysisCandidateSignature.length === 0) {
@@ -1489,7 +1491,7 @@ export function useResumeSearchState() {
   }, [apiBaseUrl, exportFormat, filteredResults]) // selectedIds excluded on purpose — export uses snapshot at call time
 
   const analyzeResults = useCallback(async () => {
-    if (analysisCandidateResumeIds.length === 0) {
+    if (analysisDispatchBatchIds.length === 0) {
       toast.info('No new candidates to analyze among loaded results.')
       return
     }
@@ -1530,11 +1532,14 @@ export function useResumeSearchState() {
         ...(keywords ? { keywords } : {}),
         ...(normalizedLocation ? { location: normalizedLocation } : {}),
         promptVersion: currentPromptVersion,
-        resumeIds: analysisCandidateResumeIds,
+        resumeIds: analysisDispatchBatchIds,
       })
 
+      const remaining = analysisCandidateResumeIds.length - analysisDispatchBatchIds.length
       toast.success(
-        `Analyzing loaded ${analysisCandidateResumeIds.length} resumes...`,
+        remaining > 0
+          ? `Analyzing batch of ${analysisDispatchBatchIds.length} resumes (${remaining} more pending)...`
+          : `Analyzing ${analysisDispatchBatchIds.length} resumes...`,
       )
     } catch (error) {
       console.error('Failed to dispatch search analysis task', error)
@@ -1544,6 +1549,7 @@ export function useResumeSearchState() {
     }
   }, [
     analysisCandidateResumeIds,
+    analysisDispatchBatchIds,
     analysisKeywords,
     currentPromptVersion,
     dispatchAnalysis,


### PR DESCRIPTION
## Summary
- Auto-analyze now iterates batches until ALL unanalyzed resumes are covered (not just one batch of topN)
- `useResumeSearchState`: separates candidate tracking (all) from dispatch batch (topN). After each batch completes, signature rotates and effect re-fires for next batch.
- `useResumeListState`: "Analyze All" button dispatches ALL candidates at once (server handles internal batching)
- Toast shows batch progress: "Analyzing batch of N (M more pending)..."
- `VITE_ANALYSIS_TOP_N` (default 20 dev, 200 prod) now controls **batch size**, not total cap

## Context
On `/dev/resumes?location=Malaysia&q=CNC+Sales`, only 42/139 MY resumes had AI scores. The rest showed "AI 待处理" because auto-dispatch stopped after one batch of 20.

## Test plan
- [x] `make check` passes (typecheck + lint + governance)
- [ ] Navigate to `/dev/resumes?location=Malaysia&q=CNC+Sales` with AI mode on
- [ ] Verify auto-dispatch continues until all 139 resumes have scores
- [ ] Toast shows "Analyzing batch of 200 resumes..." then fires again for remaining
- [ ] No console errors during batch continuation