### PR TITLE
feat: per-workspace export fields configuration

### DIFF
--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -8,6 +8,7 @@ import {
   DEBUG_AI_BREAKDOWN_LABELS,
   DEBUG_AI_KEYWORD_PROMPT_VARIANT,
   DEBUG_PAGE_SECTION_DEFINITIONS,
+  EXPORT_FIELD_KEYS,
   INGEST_BRAND_CONTEXT_LABELS,
   INGEST_BRAND_ROLE_LABELS,
   INGEST_BRAND_SOURCE_LABELS,
@@ -244,6 +245,16 @@ const LearningLogResponseSchema = z.object({
 const LearningLogAppendResponseSchema = z.object({
   success: z.literal(true),
   entry: LearningLogEntrySchema,
+});
+
+const ExportFieldsConfigSchema = z.object({
+  fields: z.array(z.enum(EXPORT_FIELD_KEYS)),
+  includeDebugWhenEnabled: z.boolean().optional(),
+});
+
+const ExportFieldsConfigResponseSchema = z.object({
+  success: z.literal(true),
+  config: ExportFieldsConfigSchema.nullable(),
 });
 
 const SystemMetadataResponseSchema = z.object({
@@ -1205,6 +1216,60 @@ app.openapi(getSourceByKeyRoute, async (c) => {
     }
     logger.error("Failed to load config source", error, { route: "config" });
     return c.json({ success: false as const, error: "Failed to load config source" }, 500);
+  }
+});
+
+// --- Export fields config ---
+
+const getExportFieldsRoute = createRoute({
+  method: "get",
+  path: "/export-fields",
+  tags: ["config"],
+  summary: "Get export fields configuration",
+  responses: {
+    200: { description: "Export fields config", content: { "application/json": { schema: ExportFieldsConfigResponseSchema } } },
+    500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
+  },
+});
+
+app.openapi(getExportFieldsRoute, async (c) => {
+  try {
+    const config = await workspaceConfigService.getExportFieldsConfig(c.var.workspaceSlug);
+    return c.json({ success: true as const, config }, 200);
+  } catch (error) {
+    logger.error("Failed to load export fields config", error, { route: "config" });
+    return c.json({ success: false as const, error: "Failed to load export fields config" }, 500);
+  }
+});
+
+const putExportFieldsRoute = createRoute({
+  method: "put",
+  path: "/export-fields",
+  tags: ["config"],
+  summary: "Update export fields configuration",
+  request: {
+    body: { content: { "application/json": { schema: ExportFieldsConfigSchema } } },
+  },
+  responses: {
+    200: { description: "Updated config", content: { "application/json": { schema: ExportFieldsConfigResponseSchema } } },
+    400: { description: "Invalid payload", content: { "application/json": { schema: ErrorResponseSchema } } },
+    403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
+    500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
+  },
+});
+
+app.openapi(putExportFieldsRoute, async (c) => {
+  if (denyIfNotAdmin(c.var.accessLevel)) {
+    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  }
+  try {
+    const data = c.req.valid("json");
+    await workspaceConfigService.setExportFieldsConfig(c.var.workspaceSlug, data);
+    const config = await workspaceConfigService.getExportFieldsConfig(c.var.workspaceSlug);
+    return c.json({ success: true as const, config }, 200);
+  } catch (error) {
+    logger.error("Failed to update export fields config", error, { route: "config" });
+    return c.json({ success: false as const, error: "Failed to update export fields config" }, 500);
   }
 });
 

--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -243,6 +243,9 @@ describe("resume export route", () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const call = parseConvexCall(input, init);
       calls.push(call);
+      if (call.pathName === "workspace_config:get") {
+        return convexSuccess(null);
+      }
       if (call.pathName === "resumes:getByIdsForExport") {
         return convexSuccess([
           {
@@ -356,8 +359,8 @@ describe("resume export route", () => {
 
     expect(response.status).toBe(200);
     expectAttachmentHeaders(response, "xlsx");
-    expect(calls).toHaveLength(1);
-    expect(calls[0]).toMatchObject({
+    const exportCall = calls.find((c) => c.pathName === "resumes:getByIdsForExport");
+    expect(exportCall).toMatchObject({
       pathName: "resumes:getByIdsForExport",
       args: {
         resumeIds: ["convex-b", "convex-a"],

--- a/apps/api/src/routes/resumes_packets.ts
+++ b/apps/api/src/routes/resumes_packets.ts
@@ -262,9 +262,12 @@ async function resolveExportRequest(
   };
 }
 
-async function buildResumeExportResponse(request: ResumeExportCanonicalRequest) {
+async function buildResumeExportResponse(request: ResumeExportCanonicalRequest, workspaceSlug?: string) {
   const { format, entries, batchMeta, industryDbV2Stats, debug } = await resolveExportRequest(request);
-  const file = await exportService.exportResumes(format, entries, batchMeta, industryDbV2Stats, debug);
+  const fieldConfig = workspaceSlug
+    ? await workspaceConfigService.getExportFieldsConfig(workspaceSlug)
+    : null;
+  const file = await exportService.exportResumes(format, entries, batchMeta, industryDbV2Stats, debug, fieldConfig);
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const filename = `resumes-export-${timestamp}.${file.extension}`;
 
@@ -995,7 +998,7 @@ const sendReviewPacketSummaryRoute = createRoute({
 app.openapi(exportResumesRoute, async (c) => {
   try {
     const request = c.req.valid("json");
-    return await buildResumeExportResponse(request);
+    return await buildResumeExportResponse(request, c.var.workspaceSlug);
   } catch (error) {
     return buildResumeExportErrorResponse(c, error);
   }
@@ -1228,7 +1231,7 @@ const exportDownloadRoute = createRoute({
 app.openapi(exportDownloadRoute, async (c) => {
   try {
     const request = await parseResumeExportDownloadRequest(c);
-    return await buildResumeExportResponse(request);
+    return await buildResumeExportResponse(request, c.var.workspaceSlug);
   } catch (error) {
     return buildResumeExportErrorResponse(c, error);
   }

--- a/apps/api/src/services/export-service.ts
+++ b/apps/api/src/services/export-service.ts
@@ -4,6 +4,7 @@ import {
   buildWorkHistoryEntryText,
   inferSeekMarket,
   normalizeProfileUrlForDisplay,
+  type ExportFieldsConfig,
   type ResumeWorkHistoryItem as SharedResumeWorkHistoryItem,
 } from "@trends/shared";
 import type { BrandDisplayResolver } from "./brand-display-resolver.js";
@@ -357,17 +358,44 @@ const STANDARD_EXCEL_COLUMNS_TAIL: ExcelColumn[] = [
   { header: "Reference Note", key: "referenceNote", width: 36 },
 ];
 
-function getExcelColumns(debug: boolean): ExcelColumn[] {
-  return debug
-    ? [...STANDARD_EXCEL_COLUMNS_HEAD, ...DEBUG_EXCEL_COLUMNS, ...STANDARD_EXCEL_COLUMNS_TAIL]
-    : [...STANDARD_EXCEL_COLUMNS_HEAD, ...STANDARD_EXCEL_COLUMNS_TAIL];
+const ALL_EXCEL_COLUMNS: ExcelColumn[] = [
+  ...STANDARD_EXCEL_COLUMNS_HEAD,
+  ...DEBUG_EXCEL_COLUMNS,
+  ...STANDARD_EXCEL_COLUMNS_TAIL,
+];
+
+const EXCEL_COLUMN_BY_KEY = new Map<string, ExcelColumn>(
+  ALL_EXCEL_COLUMNS.map((col) => [col.key, col]),
+);
+
+const DEBUG_FIELD_KEYS = new Set(DEBUG_EXCEL_COLUMNS.map((col) => col.key));
+
+function getExcelColumns(debug: boolean, fieldConfig?: ExportFieldsConfig | null): ExcelColumn[] {
+  if (!fieldConfig || fieldConfig.fields.length === 0) {
+    // Default behavior: backwards-compatible
+    return debug
+      ? [...STANDARD_EXCEL_COLUMNS_HEAD, ...DEBUG_EXCEL_COLUMNS, ...STANDARD_EXCEL_COLUMNS_TAIL]
+      : [...STANDARD_EXCEL_COLUMNS_HEAD, ...STANDARD_EXCEL_COLUMNS_TAIL];
+  }
+
+  // Build columns from configured field list, preserving config order
+  const columns: ExcelColumn[] = [];
+  for (const key of fieldConfig.fields) {
+    const col = EXCEL_COLUMN_BY_KEY.get(key);
+    if (col) columns.push(col);
+  }
+
+  // Optionally append debug columns not already in the list
+  if (debug && fieldConfig.includeDebugWhenEnabled) {
+    const presentKeys = new Set(columns.map((c) => c.key));
+    for (const col of DEBUG_EXCEL_COLUMNS) {
+      if (!presentKeys.has(col.key)) columns.push(col);
+    }
+  }
+
+  return columns;
 }
 
-function toOutputRow(row: ExportRow, debug: boolean): Omit<ExportRow, "externalId" | "source" | "industryDbV2Raw" | "industryDbV2Normalized" | "ruleScore" | "roleEvidence" | "matchedWorkEntries"> | ExportRow {
-  if (debug) return row;
-  const { externalId: _e, source: _s, industryDbV2Raw: _r, industryDbV2Normalized: _n, ruleScore: _rs, roleEvidence: _re, matchedWorkEntries: _mw, ...standard } = row;
-  return standard;
-}
 
 export type ExportBatchMeta = {
   userComment?: string;
@@ -490,7 +518,8 @@ export class ExportService {
     entries: ResumeExportEntry[],
     batchMeta?: ExportBatchMeta,
     industryDbV2Stats?: IndustryDbV2BatchStats,
-    debug = false
+    debug = false,
+    fieldConfig?: ExportFieldsConfig | null,
   ): Promise<ExportFile> {
     const batchNormalizer = createBatchNormalizer(industryDbV2Stats);
     const rows = entries.map((entry) =>
@@ -505,7 +534,7 @@ export class ExportService {
       )
     );
     if (format === "xlsx") {
-      const content = await this.toXlsx(rows, debug);
+      const content = await this.toXlsx(rows, debug, fieldConfig);
       return {
         extension: "xlsx",
         contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -513,7 +542,14 @@ export class ExportService {
       };
     }
 
-    const outputRows = rows.map((row) => toOutputRow(row, debug));
+    const columns = getExcelColumns(debug, fieldConfig);
+    const outputRows = rows.map((row) => {
+      const filtered: Record<string, string | number | ""> = {};
+      for (const col of columns) {
+        filtered[col.key] = row[col.key];
+      }
+      return filtered;
+    });
     const csv = Papa.unparse(outputRows, { header: true, newline: "\n" });
     return {
       extension: "csv",
@@ -567,11 +603,11 @@ export class ExportService {
     };
   }
 
-  private async toXlsx(rows: ExportRow[], debug: boolean): Promise<Buffer> {
+  private async toXlsx(rows: ExportRow[], debug: boolean, fieldConfig?: ExportFieldsConfig | null): Promise<Buffer> {
     const workbook = new ExcelJS.Workbook();
     const sheet = workbook.addWorksheet("Resumes");
 
-    sheet.columns = getExcelColumns(debug);
+    sheet.columns = getExcelColumns(debug, fieldConfig);
     rows.forEach((row) => sheet.addRow(row));
     sheet.getRow(1).font = { bold: true };
 

--- a/apps/api/src/services/workspace-config-service.ts
+++ b/apps/api/src/services/workspace-config-service.ts
@@ -4,8 +4,11 @@ import JSON5 from "json5";
 import { logger } from "./logger.js";
 import {
   isRecord,
+  EXPORT_FIELD_KEYS,
   parseResumeFieldUsagePolicyOverrides,
   resolveResumeFieldUsagePolicy,
+  type ExportFieldKey,
+  type ExportFieldsConfig,
   type ResumeFieldUsagePolicy,
   type ResumeFieldUsagePolicyOverrides,
   type SummaryChannel,
@@ -557,6 +560,20 @@ export function parseRuleWeightsConfig(value: unknown): RuleWeightsConfigOverrid
   return parseRuleWeightsOverrides(value);
 }
 
+export function parseExportFieldsConfig(value: unknown): ExportFieldsConfig | null {
+  if (!isRecord(value)) return null;
+  const fields = value.fields;
+  if (!Array.isArray(fields)) return null;
+  const validFields = fields.filter(
+    (f): f is ExportFieldKey => typeof f === "string" && (EXPORT_FIELD_KEYS as readonly string[]).includes(f),
+  );
+  if (validFields.length === 0) return null;
+  const includeDebugWhenEnabled = typeof value.includeDebugWhenEnabled === "boolean"
+    ? value.includeDebugWhenEnabled
+    : undefined;
+  return { fields: validFields, includeDebugWhenEnabled };
+}
+
 const CUSTOM_KEYWORDS_KEY = "custom-keywords";
 const AGENT_OVERRIDES_KEY = "agent-overrides";
 const FILTER_PRESETS_KEY = "filter-presets";
@@ -564,6 +581,7 @@ const RULE_WEIGHTS_KEY = "rule-weights";
 const LEARNING_LOG_KEY = "learning-log";
 const RESUME_FIELD_USAGE_POLICY_KEY = "resume-field-usage-policy";
 const SUMMARY_PROFILES_KEY = "summary-profiles";
+const EXPORT_FIELDS_KEY = "export-fields";
 
 export class WorkspaceConfigService {
   readonly projectRoot: string;
@@ -863,6 +881,15 @@ export class WorkspaceConfigService {
   async getResumeFieldUsagePolicy(workspaceSlug: string): Promise<ResumeFieldUsagePolicy> {
     const workspaceConfig = await this.getWorkspaceResumeFieldUsagePolicy(workspaceSlug);
     return resolveResumeFieldUsagePolicy(workspaceConfig);
+  }
+
+  async getExportFieldsConfig(workspaceSlug: string): Promise<ExportFieldsConfig | null> {
+    const entry = await this.getWorkspaceConfigEntry(workspaceSlug, EXPORT_FIELDS_KEY);
+    return parseExportFieldsConfig(entry?.configValue);
+  }
+
+  async setExportFieldsConfig(workspaceSlug: string, config: ExportFieldsConfig): Promise<void> {
+    await this.upsertWorkspaceConfigEntry(workspaceSlug, EXPORT_FIELDS_KEY, config);
   }
 }
 

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -9249,6 +9249,135 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/config/export-fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get export fields configuration */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Export fields config */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            config: {
+                                fields: ("resumeId" | "name" | "jobIntention" | "location" | "experience" | "education" | "age" | "expectedSalary" | "aiScore" | "industryDb" | "relatedExp" | "recommendation" | "ruleScore" | "scoreSource" | "status" | "action" | "industryTags" | "brandHits" | "companyHits" | "profileUrl" | "workHistory" | "selfIntro" | "aiSummary" | "userComment" | "referenceNote" | "externalId" | "source" | "industryDbV2Raw" | "industryDbV2Normalized" | "roleEvidence" | "matchedWorkEntries")[];
+                                includeDebugWhenEnabled?: boolean;
+                            } | null;
+                        };
+                    };
+                };
+                /** @description Server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        /** Update export fields configuration */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        fields: ("resumeId" | "name" | "jobIntention" | "location" | "experience" | "education" | "age" | "expectedSalary" | "aiScore" | "industryDb" | "relatedExp" | "recommendation" | "ruleScore" | "scoreSource" | "status" | "action" | "industryTags" | "brandHits" | "companyHits" | "profileUrl" | "workHistory" | "selfIntro" | "aiSummary" | "userComment" | "referenceNote" | "externalId" | "source" | "industryDbV2Raw" | "industryDbV2Normalized" | "roleEvidence" | "matchedWorkEntries")[];
+                        includeDebugWhenEnabled?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Updated config */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            config: {
+                                fields: ("resumeId" | "name" | "jobIntention" | "location" | "experience" | "education" | "age" | "expectedSalary" | "aiScore" | "industryDb" | "relatedExp" | "recommendation" | "ruleScore" | "scoreSource" | "status" | "action" | "industryTags" | "brandHits" | "companyHits" | "profileUrl" | "workHistory" | "selfIntro" | "aiSummary" | "userComment" | "referenceNote" | "externalId" | "source" | "industryDbV2Raw" | "industryDbV2Normalized" | "roleEvidence" | "matchedWorkEntries")[];
+                                includeDebugWhenEnabled?: boolean;
+                            } | null;
+                        };
+                    };
+                };
+                /** @description Invalid payload */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/notifications/templates": {
         parameters: {
             query?: never;

--- a/packages/shared/src/export-fields-config.ts
+++ b/packages/shared/src/export-fields-config.ts
@@ -1,0 +1,47 @@
+/**
+ * Export fields configuration — per-workspace control over which columns
+ * appear in resume export (CSV/XLSX).
+ */
+
+export const EXPORT_FIELD_KEYS = [
+  "resumeId",
+  "name",
+  "jobIntention",
+  "location",
+  "experience",
+  "education",
+  "age",
+  "expectedSalary",
+  "aiScore",
+  "industryDb",
+  "relatedExp",
+  "recommendation",
+  "ruleScore",
+  "scoreSource",
+  "status",
+  "action",
+  "industryTags",
+  "brandHits",
+  "companyHits",
+  "profileUrl",
+  "workHistory",
+  "selfIntro",
+  "aiSummary",
+  "userComment",
+  "referenceNote",
+  "externalId",
+  "source",
+  "industryDbV2Raw",
+  "industryDbV2Normalized",
+  "roleEvidence",
+  "matchedWorkEntries",
+] as const;
+
+export type ExportFieldKey = (typeof EXPORT_FIELD_KEYS)[number];
+
+export type ExportFieldsConfig = {
+  /** Ordered list of fields to include in export. Empty array = use defaults. */
+  fields: ExportFieldKey[];
+  /** If true, debug fields are appended when debug mode is active, even if not in fields list */
+  includeDebugWhenEnabled?: boolean;
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,3 +15,4 @@ export * from "./salary.js";
 export * from "./market.js";
 export * from "./resume-filter-helpers.js";
 export * from "./generated/search-profile-templates.js";
+export * from "./export-fields-config.js";


### PR DESCRIPTION
## Summary

- Adds configurable field selection for resume exports (CSV/XLSX) via workspace config
- New API endpoints: `GET/PUT /api/config/export-fields` 
- When no config is saved, existing default columns are used (100% backwards-compatible)
- Workspace admins can set an ordered list of field keys to control which columns appear in exports

## Context

Original idea captured 2026-05-22 (`raw/transcripts/2026-05-22-idea-user-team-settings-export-fields`) was archived without ever being promoted to a work item. This PR delivers the full implementation.

## Changes

| Layer | File | Change |
|-------|------|--------|
| Shared | `packages/shared/src/export-fields-config.ts` | NEW: `ExportFieldsConfig` type + `EXPORT_FIELD_KEYS` registry |
| Config Service | `apps/api/src/services/workspace-config-service.ts` | Add `export-fields` key + getter/setter |
| API Routes | `apps/api/src/routes/config.ts` | GET/PUT `/export-fields` endpoints |
| Export Service | `apps/api/src/services/export-service.ts` | Accept optional field config, filter columns |
| Route Wiring | `apps/api/src/routes/resumes_packets.ts` | Load config and pass to export service |
| Types | `apps/web/src/lib/api-types.ts` | Auto-regenerated |
| Tests | `apps/api/src/routes/resumes-export.test.ts` | Handle workspace_config Convex call |

## Test plan

- [x] `make check` passes (typecheck + lint + governance)
- [x] `npm test` passes (268 files, 5108 tests)
- [x] Export with no config set produces existing default columns
- [ ] Manual: PUT config with subset of fields, verify export only includes those columns