### PR TITLE
feat: unify triage actions with pipeline status

### DIFF
--- a/apps/api/src/routes/candidate-status.ts
+++ b/apps/api/src/routes/candidate-status.ts
@@ -13,6 +13,8 @@ const app = new OpenAPIHono();
 
 const CandidateStatusEnum = z.enum([
   "new",
+  "shortlisted",
+  "rejected",
   "contacted",
   "interviewing",
   "interviewed_pass",

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -10,6 +10,8 @@ const sessionManager = new SessionManager(config.projectRoot);
 const SessionStatusSchema = z.enum(["active", "completed", "archived"]);
 const CandidateStatusSchema = z.enum([
   "new",
+  "shortlisted",
+  "rejected",
   "contacted",
   "interviewing",
   "interviewed_pass",
@@ -29,6 +31,7 @@ const SessionFiltersSchema = ResumeFiltersSchema.extend({
   maxAge: z.number().min(0).optional(),
   status: z.array(CandidateStatusSchema).optional(),
   showBlocked: z.boolean().optional(),
+  showRejected: z.boolean().optional(),
 });
 const SearchSessionCollectionSourceSchema = z.object({
   type: z.enum(["job5156", "51job", "seek"]),

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -363,6 +363,8 @@ export const CandidateStatusBackupSchema = z
     identityKey: z.string().openapi({ example: "profileUrl:https://hr.job5156.com/resume/view/123" }),
     status: z.enum([
       "new",
+      "shortlisted",
+      "rejected",
       "contacted",
       "interviewing",
       "interviewed_pass",

--- a/apps/api/src/services/session-manager.ts
+++ b/apps/api/src/services/session-manager.ts
@@ -19,6 +19,7 @@ export type ResumeFilters = {
   locations?: string[];
   status?: CandidateStatus[];
   showBlocked?: boolean;
+  showRejected?: boolean;
   minSalary?: number;
   maxSalary?: number;
   minMatchScore?: number;
@@ -30,6 +31,8 @@ export type ResumeFilters = {
 export type SearchSessionStatus = "active" | "completed" | "archived";
 export type CandidateStatus =
   | "new"
+  | "shortlisted"
+  | "rejected"
   | "contacted"
   | "interviewing"
   | "interviewed_pass"

--- a/apps/web/src/components/BulkActionBar.test.tsx
+++ b/apps/web/src/components/BulkActionBar.test.tsx
@@ -1,14 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
 import { BulkActionBar } from './BulkActionBar'
-
-// Mock useTranslation
-vi.mock('react-i18next', () => ({
-    useTranslation: () => ({
-        t: (_key: string, fallback: string) => fallback,
-    }),
-}))
 
 describe('BulkActionBar', () => {
     const onSelectAll = vi.fn()
@@ -31,7 +25,7 @@ describe('BulkActionBar', () => {
     })
 
     it('renders selection and high score counts', () => {
-        render(<BulkActionBar {...defaultProps} />)
+        render(<MemoryRouter><BulkActionBar {...defaultProps} /></MemoryRouter>)
         expect(screen.getByText('5 / 100')).toBeInTheDocument()
         // Use regex to find text that might be split by elements/newlines in DOM
         expect(screen.getByText(/\(10\)/)).toBeInTheDocument()
@@ -39,7 +33,7 @@ describe('BulkActionBar', () => {
 
     it('triggers selection callbacks', async () => {
         const user = userEvent.setup()
-        render(<BulkActionBar {...defaultProps} />)
+        render(<MemoryRouter><BulkActionBar {...defaultProps} /></MemoryRouter>)
 
         await user.click(screen.getByText('全选'))
         expect(onSelectAll).toHaveBeenCalledTimes(1)
@@ -51,19 +45,19 @@ describe('BulkActionBar', () => {
     it('triggers bulk actions sequentially', async () => {
         const user = userEvent.setup()
         onBulkAction.mockResolvedValue(undefined)
-        render(<BulkActionBar {...defaultProps} />)
+        render(<MemoryRouter><BulkActionBar {...defaultProps} /></MemoryRouter>)
 
         await user.click(screen.getByText('批量入围'))
         expect(onBulkAction).toHaveBeenCalledWith('shortlist')
 
-        await user.click(screen.getByText('批量标星'))
-        expect(onBulkAction).toHaveBeenCalledWith('star')
+        await user.click(screen.getByText('批量拒绝'))
+        expect(onBulkAction).toHaveBeenCalledWith('reject')
     })
 
     it('disables bulk action buttons when nothing is selected', () => {
-        render(<BulkActionBar {...defaultProps} selectedCount={0} />)
+        render(<MemoryRouter><BulkActionBar {...defaultProps} selectedCount={0} /></MemoryRouter>)
         expect(screen.getByText('批量入围').closest('button')).toBeDisabled()
-        expect(screen.getByText('批量标星').closest('button')).toBeDisabled()
+        expect(screen.getByText('批量拒绝').closest('button')).toBeDisabled()
         expect(screen.queryByText('取消选择')).not.toBeInTheDocument()
     })
 })

--- a/apps/web/src/components/BulkActionBar.tsx
+++ b/apps/web/src/components/BulkActionBar.tsx
@@ -7,7 +7,7 @@
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import { CheckCircle, XCircle, Download, Users, Star, Ban } from 'lucide-react'
+import { CheckCircle, XCircle, Download, Users, Ban } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Select } from '@/components/ui/select'
 import { cn } from '@/lib/utils'
@@ -22,7 +22,8 @@ interface BulkActionBarProps {
     onSelectAll?: () => void
     onSelectHighScore?: () => void
     onClearSelection?: () => void
-    onBulkAction?: (action: 'shortlist' | 'reject' | 'star' | 'block' | 'export', format?: ResumeExportFormat) => void
+    // 'shortlist' and 'reject' also sync Convex candidate_status
+    onBulkAction?: (action: 'shortlist' | 'reject' | 'block' | 'export', format?: ResumeExportFormat) => void
     blockedCount?: number
     blocksSettingsPath?: string
     disabled?: boolean
@@ -45,7 +46,7 @@ export function BulkActionBar({
     const { t } = useTranslation()
     const [loading, setLoading] = useState<string | null>(null)
 
-    const handleAction = useCallback(async (action: 'shortlist' | 'reject' | 'star' | 'block' | 'export') => {
+    const handleAction = useCallback(async (action: 'shortlist' | 'reject' | 'block' | 'export') => {
         setLoading(action)
         try {
             if (action === 'export') {
@@ -142,16 +143,6 @@ export function BulkActionBar({
                 >
                     <CheckCircle className={cn('mr-1 h-4 w-4', loading === 'shortlist' && 'animate-spin')} />
                     {t('bulkActions.shortlist', '批量入围')}
-                </Button>
-                <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => handleAction('star')}
-                    disabled={disabled || selectedCount === 0 || loading !== null}
-                    className="text-amber-600 border-amber-200 hover:bg-amber-50"
-                >
-                    <Star className={cn('mr-1 h-4 w-4', loading === 'star' && 'animate-spin')} />
-                    {t('bulkActions.star', '批量标星')}
                 </Button>
                 <Button
                     variant="outline"

--- a/apps/web/src/components/FilterPanel.tsx
+++ b/apps/web/src/components/FilterPanel.tsx
@@ -27,6 +27,8 @@ const EDUCATION_LEVELS = [
 
 const STATUS_OPTIONS: Array<{ value: CandidateStatus; labelKey: string }> = [
   { value: 'new', labelKey: 'resumes.status.options.new' },
+  { value: 'shortlisted', labelKey: 'resumes.status.options.shortlisted' },
+  { value: 'rejected', labelKey: 'resumes.status.options.rejected' },
   { value: 'contacted', labelKey: 'resumes.status.options.contacted' },
   { value: 'interviewing', labelKey: 'resumes.status.options.interviewing' },
   { value: 'interviewed_pass', labelKey: 'resumes.status.options.interviewed_pass' },
@@ -57,6 +59,7 @@ export function FilterPanel({
   const [education, setEducation] = useState<string[]>([])
   const [status, setStatus] = useState<CandidateStatus[]>([])
   const [showBlocked, setShowBlocked] = useState(false)
+  const [showRejected, setShowRejected] = useState(false)
   const [clearing, setClearing] = useState(false)
 
   useEffect(() => {
@@ -70,6 +73,7 @@ export function FilterPanel({
     setEducation(filters.education ?? [])
     setStatus(filters.status ?? [])
     setShowBlocked(filters.showBlocked === true)
+    setShowRejected(filters.showRejected === true)
   }, [filters])
 
   const activeFilterBadges = useMemo(() => {
@@ -101,6 +105,7 @@ export function FilterPanel({
     }
 
     if (filters.showBlocked) items.push(t('resumes.filters.showBlocked'))
+    if (filters.showRejected) items.push(t('resumes.filters.showRejected'))
 
     return items
   }, [filters, t])
@@ -150,6 +155,7 @@ export function FilterPanel({
       education: education.length ? education : undefined,
       status: status.length ? status : undefined,
       showBlocked,
+      showRejected,
     })
   }
 
@@ -165,6 +171,7 @@ export function FilterPanel({
     setEducation([])
     setStatus([])
     setShowBlocked(false)
+    setShowRejected(false)
     onFiltersChange({})
     window.setTimeout(() => setClearing(false), 200)
   }
@@ -327,13 +334,22 @@ export function FilterPanel({
                 ))}
               </div>
 
-              <label className="flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border border-border/70 bg-background px-3 py-2.5 text-sm text-foreground/80 hover:text-foreground">
-                <Checkbox
-                  checked={showBlocked}
-                  onCheckedChange={(checked: boolean | 'indeterminate') => setShowBlocked(checked === true)}
-                />
-                {t('resumes.filters.showBlocked')}
-              </label>
+              <div className="flex flex-col gap-2 sm:flex-row sm:gap-4">
+                <label className="flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border border-border/70 bg-background px-3 py-2.5 text-sm text-foreground/80 hover:text-foreground">
+                  <Checkbox
+                    checked={showRejected}
+                    onCheckedChange={(checked: boolean | 'indeterminate') => setShowRejected(checked === true)}
+                  />
+                  {t('resumes.filters.showRejected')}
+                </label>
+                <label className="flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border border-border/70 bg-background px-3 py-2.5 text-sm text-foreground/80 hover:text-foreground">
+                  <Checkbox
+                    checked={showBlocked}
+                    onCheckedChange={(checked: boolean | 'indeterminate') => setShowBlocked(checked === true)}
+                  />
+                  {t('resumes.filters.showBlocked')}
+                </label>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -88,6 +88,8 @@ interface ResumeCardProps {
 
 const STATUS_OPTIONS: Array<{ value: CandidateStatus; labelKey: string }> = [
   { value: 'new', labelKey: 'resumes.status.options.new' },
+  { value: 'shortlisted', labelKey: 'resumes.status.options.shortlisted' },
+  { value: 'rejected', labelKey: 'resumes.status.options.rejected' },
   { value: 'contacted', labelKey: 'resumes.status.options.contacted' },
   { value: 'interviewing', labelKey: 'resumes.status.options.interviewing' },
   { value: 'interviewed_pass', labelKey: 'resumes.status.options.interviewed_pass' },
@@ -103,6 +105,8 @@ const STATUS_OPTIONS: Array<{ value: CandidateStatus; labelKey: string }> = [
 
 const STATUS_BADGE_CLASS: Record<CandidateStatus, string> = {
   new: 'border-zinc-200 bg-zinc-50 text-zinc-700',
+  shortlisted: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  rejected: 'border-red-200 bg-red-50 text-red-700',
   contacted: 'border-blue-200 bg-blue-50 text-blue-700',
   interviewing: 'border-cyan-200 bg-cyan-50 text-cyan-700',
   interviewed_pass: 'border-emerald-200 bg-emerald-50 text-emerald-700',

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -54,6 +54,8 @@ type SnippetCardProps = {
 
 const STATUS_OPTIONS: Array<{ value: CandidateStatus; labelKey: string }> = [
   { value: 'new', labelKey: 'resumes.status.options.new' },
+  { value: 'shortlisted', labelKey: 'resumes.status.options.shortlisted' },
+  { value: 'rejected', labelKey: 'resumes.status.options.rejected' },
   { value: 'contacted', labelKey: 'resumes.status.options.contacted' },
   { value: 'interviewing', labelKey: 'resumes.status.options.interviewing' },
   { value: 'interviewed_pass', labelKey: 'resumes.status.options.interviewed_pass' },
@@ -69,6 +71,8 @@ const STATUS_OPTIONS: Array<{ value: CandidateStatus; labelKey: string }> = [
 
 const STATUS_BADGE_CLASS: Record<CandidateStatus, string> = {
   new: 'border-zinc-200 bg-zinc-50 text-zinc-700',
+  shortlisted: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  rejected: 'border-red-200 bg-red-50 text-red-700',
   contacted: 'border-blue-200 bg-blue-50 text-blue-700',
   interviewing: 'border-cyan-200 bg-cyan-50 text-cyan-700',
   interviewed_pass: 'border-emerald-200 bg-emerald-50 text-emerald-700',

--- a/apps/web/src/hooks/useFacetCounts.ts
+++ b/apps/web/src/hooks/useFacetCounts.ts
@@ -97,6 +97,8 @@ export function useFacetCounts(
 
     const statusLabels = new Map<string, string>([
       ['new', t('resumes.status.options.new')],
+      ['shortlisted', t('resumes.status.options.shortlisted')],
+      ['rejected', t('resumes.status.options.rejected')],
       ['contacted', t('resumes.status.options.contacted')],
       ['interviewing', t('resumes.status.options.interviewing')],
       ['interviewed_pass', t('resumes.status.options.interviewed_pass')],

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -853,6 +853,15 @@ export function useResumeListState(loadSearchHistory = false) {
       })
     }
 
+    const showRejected = filters.showRejected === true
+    if (!showRejected) {
+      result = result.filter((resume: ScoredConvexResume) => {
+        const identityKey = getResumeIdentityKey(resume, String(resume.resumeId))
+        const status = statusByIdentity[identityKey]?.status ?? 'new'
+        return status !== 'rejected'
+      })
+    }
+
     if (filters.status?.length) {
       const activeStatuses = new Set(toStatusFilterList(filters.status))
       result = result.filter((resume: ScoredConvexResume) => {
@@ -1312,7 +1321,7 @@ export function useResumeListState(loadSearchHistory = false) {
       return enrichedResumes
     }
 
-    const sortBy = filters.sortBy ?? 'score'
+    const sortBy = filters.sortBy ?? 'extractedAt'
     const sortOrder = filters.sortOrder ?? 'desc'
     const direction = sortOrder === 'asc' ? 1 : -1
 
@@ -1446,7 +1455,7 @@ export function useResumeListState(loadSearchHistory = false) {
   }, [])
 
   const handleBulkAction = useCallback(
-    async (action: 'shortlist' | 'reject' | 'star' | 'block' | 'export', format?: ResumeExportFormat) => {
+    async (action: 'shortlist' | 'reject' | 'block' | 'export', format?: ResumeExportFormat) => {
       if (selectedIds.size === 0) return
 
       const selectedEntries = displayedResumes.filter((entry) => selectedIds.has(entry.key))
@@ -1514,14 +1523,25 @@ export function useResumeListState(loadSearchHistory = false) {
             saveAction({ resumeId: entry.key, actionType: action })
           )
         )
-        const actionLabels: Record<string, string> = { shortlist: 'shortlisted', reject: 'rejected', star: 'starred' }
+
+        // Sync candidate_status in Convex for shortlist/reject
+        if (action === 'shortlist' || action === 'reject') {
+          const targetStatus = action === 'shortlist' ? 'shortlisted' : 'rejected'
+          await Promise.all(
+            selectedEntries.map((entry) =>
+              updateCandidateStatus(entry.identityKey, targetStatus)
+            )
+          )
+        }
+
+        const actionLabels: Record<string, string> = { shortlist: 'shortlisted', reject: 'rejected' }
         toast.success(t('bulk.actionDone', { count: selectedEntries.length, action: actionLabels[action] || action, defaultValue: `${selectedEntries.length} resumes ${actionLabels[action] || action}` }))
       } catch (error) {
         console.error('Bulk action failed', error)
         toast.error(t('bulk.actionFailed', { defaultValue: 'Bulk action failed. Please try again.' }))
       }
     },
-    [apiBaseUrl, appliedSearchHistory?.industryDbV2Stats, blockCandidates, bulkExportFormat, displayedResumes, mode, saveAction, selectedIds, selectedSample, sendLearningFeedback, t]
+    [apiBaseUrl, appliedSearchHistory?.industryDbV2Stats, blockCandidates, bulkExportFormat, displayedResumes, mode, saveAction, selectedIds, selectedSample, sendLearningFeedback, t, updateCandidateStatus]
   )
 
   const handleOpenReviewPacket = useCallback(async () => {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -269,6 +269,7 @@
       "locations": "Locations",
       "locationsPlaceholder": "e.g. Dongguan, Shenzhen",
       "status": "Candidate status",
+      "showRejected": "Show rejected candidates",
       "showBlocked": "Show blocked candidates",
       "education": {
         "title": "Education",
@@ -306,6 +307,8 @@
       "notePrompt": "Add notes for \"{{status}}\" (optional)",
       "options": {
         "new": "New candidate",
+        "shortlisted": "Shortlisted",
+        "rejected": "Rejected",
         "contacted": "Contacted",
         "interviewing": "Interviewing",
         "interviewed_pass": "Interview passed",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -268,6 +268,7 @@
       "locations": "地区",
       "locationsPlaceholder": "例如：东莞, 深圳",
       "status": "候选人状态",
+      "showRejected": "显示已拒绝候选人",
       "showBlocked": "显示已屏蔽候选人",
       "education": {
         "title": "学历",
@@ -305,6 +306,8 @@
       "notePrompt": "为“{{status}}”添加备注（选填）",
       "options": {
         "new": "新候选人",
+        "shortlisted": "已入围",
+        "rejected": "已拒绝",
         "contacted": "已联系",
         "interviewing": "面试中",
         "interviewed_pass": "面试通过",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -268,6 +268,7 @@
       "locations": "地點",
       "locationsPlaceholder": "例如：東莞, 深圳",
       "status": "候選人狀態",
+      "showRejected": "顯示已拒絕候選人",
       "showBlocked": "顯示已封鎖候選人",
       "education": {
         "title": "學歷",
@@ -305,6 +306,8 @@
       "notePrompt": "為「{{status}}」新增備註（選填）",
       "options": {
         "new": "新候選人",
+        "shortlisted": "已入圍",
+        "rejected": "已拒絕",
         "contacted": "已聯繫",
         "interviewing": "面試中",
         "interviewed_pass": "面試通過",

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -4204,8 +4204,9 @@ export interface paths {
                         jobDescriptionId?: string;
                         sampleName?: string;
                         filters?: components["schemas"]["ResumeFilters"] & {
-                            status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
+                            status?: ("new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
                             showBlocked?: boolean;
+                            showRejected?: boolean;
                         };
                         shareTitle?: string;
                         searchState?: {
@@ -4249,8 +4250,9 @@ export interface paths {
                                 exactUrl?: string;
                             };
                             filters?: components["schemas"]["ResumeFilters"] & {
-                                status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
+                                status?: ("new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
                                 showBlocked?: boolean;
+                                showRejected?: boolean;
                             };
                             /** @example Priority shortlist for HR sync */
                             referenceNote?: string;
@@ -4280,8 +4282,9 @@ export interface paths {
                                 /** @example sample-initial */
                                 sampleName?: string;
                                 filters?: components["schemas"]["ResumeFilters"] & {
-                                    status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
+                                    status?: ("new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
                                     showBlocked?: boolean;
+                                    showRejected?: boolean;
                                 };
                                 /** @example Kuala Lumpur · Sales Engineer */
                                 shareTitle?: string;
@@ -4326,8 +4329,9 @@ export interface paths {
                                         exactUrl?: string;
                                     };
                                     filters?: components["schemas"]["ResumeFilters"] & {
-                                        status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
+                                        status?: ("new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
                                         showBlocked?: boolean;
+                                        showRejected?: boolean;
                                     };
                                     /** @example Priority shortlist for HR sync */
                                     referenceNote?: string;
@@ -4395,8 +4399,9 @@ export interface paths {
                                 /** @example sample-initial */
                                 sampleName?: string;
                                 filters?: components["schemas"]["ResumeFilters"] & {
-                                    status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
+                                    status?: ("new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
                                     showBlocked?: boolean;
+                                    showRejected?: boolean;
                                 };
                                 /** @example Kuala Lumpur · Sales Engineer */
                                 shareTitle?: string;
@@ -4441,8 +4446,9 @@ export interface paths {
                                         exactUrl?: string;
                                     };
                                     filters?: components["schemas"]["ResumeFilters"] & {
-                                        status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
+                                        status?: ("new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
                                         showBlocked?: boolean;
+                                        showRejected?: boolean;
                                     };
                                     /** @example Priority shortlist for HR sync */
                                     referenceNote?: string;
@@ -4493,8 +4499,9 @@ export interface paths {
                         jobDescriptionId?: string;
                         sampleName?: string;
                         filters?: components["schemas"]["ResumeFilters"] & {
-                            status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
+                            status?: ("new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
                             showBlocked?: boolean;
+                            showRejected?: boolean;
                         };
                         shareTitle?: string | null;
                         searchState?: {
@@ -4538,8 +4545,9 @@ export interface paths {
                                 exactUrl?: string;
                             };
                             filters?: components["schemas"]["ResumeFilters"] & {
-                                status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
+                                status?: ("new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
                                 showBlocked?: boolean;
+                                showRejected?: boolean;
                             };
                             /** @example Priority shortlist for HR sync */
                             referenceNote?: string;
@@ -4572,8 +4580,9 @@ export interface paths {
                                 /** @example sample-initial */
                                 sampleName?: string;
                                 filters?: components["schemas"]["ResumeFilters"] & {
-                                    status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
+                                    status?: ("new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
                                     showBlocked?: boolean;
+                                    showRejected?: boolean;
                                 };
                                 /** @example Kuala Lumpur · Sales Engineer */
                                 shareTitle?: string;
@@ -4618,8 +4627,9 @@ export interface paths {
                                         exactUrl?: string;
                                     };
                                     filters?: components["schemas"]["ResumeFilters"] & {
-                                        status?: ("new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
+                                        status?: ("new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn")[];
                                         showBlocked?: boolean;
+                                        showRejected?: boolean;
                                     };
                                     /** @example Priority shortlist for HR sync */
                                     referenceNote?: string;
@@ -4924,7 +4934,7 @@ export interface paths {
                                 identityKey: string;
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                status: "new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn";
+                                status: "new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn";
                                 notes?: string;
                                 updatedBy?: string;
                                 updatedAt: number;
@@ -4953,7 +4963,7 @@ export interface paths {
                     "application/json": {
                         identityKey: string;
                         /** @enum {string} */
-                        status: "new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn";
+                        status: "new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn";
                         notes?: string;
                         updatedBy?: string;
                     };
@@ -4974,7 +4984,7 @@ export interface paths {
                                 identityKey: string;
                                 workspaceSlug: string;
                                 /** @enum {string} */
-                                status: "new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn";
+                                status: "new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn";
                                 notes?: string;
                                 updatedBy?: string;
                                 updatedAt: number;
@@ -11880,7 +11890,7 @@ export interface components {
              * @example interviewing
              * @enum {string}
              */
-            status: "new" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn";
+            status: "new" | "shortlisted" | "rejected" | "contacted" | "interviewing" | "interviewed_pass" | "interviewed_reject" | "appeal_submitted" | "human_review" | "upheld" | "reversed" | "offer" | "hired" | "withdrawn";
             /** @example Strong candidate */
             notes?: string;
             /** @example hr.lead */

--- a/apps/web/src/types/resume.ts
+++ b/apps/web/src/types/resume.ts
@@ -10,6 +10,7 @@ export type ResumeFilters = {
   locations?: string[]
   status?: CandidateStatus[]
   showBlocked?: boolean
+  showRejected?: boolean
   showArchived?: boolean
   minSalary?: number
   maxSalary?: number
@@ -60,6 +61,8 @@ export type ScoreSource = 'rule' | 'ai'
 export type ResumeExportFormat = 'csv' | 'xlsx'
 export type CandidateStatus =
   | 'new'
+  | 'shortlisted'
+  | 'rejected'
   | 'contacted'
   | 'interviewing'
   | 'interviewed_pass'

--- a/packages/convex/convex/candidate_status.ts
+++ b/packages/convex/convex/candidate_status.ts
@@ -74,6 +74,8 @@ export const upsert = mutation({
         identityKey: v.string(),
         status: v.union(
             v.literal("new"),
+            v.literal("shortlisted"),
+            v.literal("rejected"),
             v.literal("contacted"),
             v.literal("interviewing"),
             v.literal("interviewed_pass"),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -394,6 +394,8 @@ export default defineSchema({
         workspaceSlug: v.string(),
         status: v.union(
             v.literal("new"),
+            v.literal("shortlisted"),
+            v.literal("rejected"),
             v.literal("contacted"),
             v.literal("interviewing"),
             v.literal("interviewed_pass"),

--- a/packages/convex/convex/validators.ts
+++ b/packages/convex/convex/validators.ts
@@ -164,6 +164,8 @@ export const resumeFiltersValidator = v.optional(v.object({
     sources: v.optional(v.array(v.string())),
     status: v.optional(v.array(v.union(
         v.literal("new"),
+        v.literal("shortlisted"),
+        v.literal("rejected"),
         v.literal("contacted"),
         v.literal("interviewing"),
         v.literal("interviewed_pass"),


### PR DESCRIPTION
## Summary

- Bulk shortlist/reject now sync `candidate_status` in Convex so filter counts accurately reflect triage state
- Removed star bulk action (star score / numeric rating remains as separate feature)
- Added `showRejected` toggle — rejected resumes hidden from default view, revealed on demand
- Default sort changed to newest-collected-first (`extractedAt` desc) per spec
- Added `shortlisted` and `rejected` to all status enums (Convex schema, validators, API, types, i18n)

## Test plan

- [x] `npm test` — 268 files, 5108 tests passing
- [x] TypeScript compiles cleanly
- [x] i18n keys in sync across all 3 locales
- [ ] Manual: bulk shortlist resumes → verify sidebar count updates
- [ ] Manual: bulk reject → verify resumes disappear from default view
- [ ] Manual: enable "Show rejected" toggle → verify they reappear