### PR TITLE
fix: remove MY market industry DB placeholder UI (floor of 40 applies)

### DIFF
--- a/apps/web/e2e/my-market-industry-db-placeholder.spec.ts
+++ b/apps/web/e2e/my-market-industry-db-placeholder.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test, type Page } from '@playwright/test'
 
 /**
- * E2E test for MY market industry DB graceful degradation.
- * Verifies that Malaysian resumes show a "Not available for MY market"
- * placeholder instead of an empty industry DB breakdown bar.
+ * E2E test for MY market industry DB floor scoring.
+ * Verifies that Malaysian resumes use the industry_db floor (40)
+ * and render the normal breakdown bar (no placeholder).
  */
 
 const MY_RESUME_MOCK = {
@@ -104,14 +104,14 @@ async function mockResumePageApis(page: Page, resumes: unknown[]) {
   })
 }
 
-test.describe('MY market industry DB placeholder', () => {
-  test('shows "Not available for MY market" placeholder for Malaysian resumes', async ({ page }) => {
+test.describe('MY market industry DB floor scoring', () => {
+  test('does not show "Not available" placeholder for MY resumes — floor applies', async ({ page }) => {
     await mockResumePageApis(page, [MY_RESUME_MOCK])
     await page.goto('/dev/resumes?q=CNC%20Sales')
 
-    // The MY market placeholder should be visible in the expanded card
+    // With industry_db floor of 40, the placeholder should not appear
     const placeholder = page.getByText(/Not available for MY market/i)
-    await expect(placeholder).toBeVisible({ timeout: 15000 })
+    await expect(placeholder).not.toBeVisible({ timeout: 15000 })
   })
 
   test('does not show MY placeholder for CN market resumes', async ({ page }) => {

--- a/apps/web/src/components/search/SnippetCardExpanded.test.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.test.tsx
@@ -420,8 +420,8 @@ describe('SnippetCardExpanded', () => {
     })
   })
 
-  describe('MY market industry DB placeholder', () => {
-    it('shows "Not available for MY market" in breakdown bar for MY resumes', () => {
+  describe('MY market industry DB floor scoring', () => {
+    it('shows breakdown bar with floor value for MY resumes without brand hits', () => {
       render(
         <SnippetCardExpanded
           item={createResult(1, {
@@ -433,7 +433,7 @@ describe('SnippetCardExpanded', () => {
               recommendation: 'match',
               breakdown: {
                 related_exp: 40,
-                industry_db: 0,
+                industry_db: 40,
               },
             },
             resume: createResume(1, {
@@ -454,10 +454,12 @@ describe('SnippetCardExpanded', () => {
         />
       )
 
-      expect(screen.getByText(/Not available for MY market/i)).toBeInTheDocument()
+      // With the floor of 40, no "Not available" placeholder — normal breakdown renders
+      expect(screen.queryByText(/Not available for MY market/i)).not.toBeInTheDocument()
+      expect(screen.getAllByText(/industry db/i).length).toBeGreaterThanOrEqual(1)
     })
 
-    it('shows MY placeholder in debug score dimensions for MY resumes', async () => {
+    it('shows industry_db value in debug score dimensions for MY resumes', async () => {
       const user = userEvent.setup()
       render(
         <SnippetCardExpanded
@@ -468,7 +470,7 @@ describe('SnippetCardExpanded', () => {
               highlights: [],
               concerns: [],
               recommendation: 'match',
-              breakdown: { related_exp: 36, skills: 82, industry_db: 0, education: 70, location: 55 },
+              breakdown: { related_exp: 36, skills: 82, industry_db: 40, education: 70, location: 55 },
             },
             resume: createResume(1, {
               source: 'seek',
@@ -490,9 +492,9 @@ describe('SnippetCardExpanded', () => {
 
       await user.click(screen.getByRole('button', { name: /debug/i }))
 
-      // Debug section should show MY placeholder instead of industry_db bar
-      const myPlaceholders = screen.getAllByText(/Not available for MY market/i)
-      expect(myPlaceholders.length).toBeGreaterThanOrEqual(1)
+      // Debug section should show Industry DB with floor value, not placeholder
+      expect(screen.queryByText(/Not available for MY market/i)).not.toBeInTheDocument()
+      expect(screen.getByText('Industry DB')).toBeInTheDocument()
     })
 
     it('does not show MY placeholder for CN market resumes', () => {

--- a/apps/web/src/components/search/SnippetCardExpanded.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.tsx
@@ -32,32 +32,9 @@ function formatSnakeCaseLabel(value: string): string {
   return value.replace(/_/g, ' ')
 }
 
-function BreakdownBar({ breakdown, isMyMarket, hasMyIndustryHits }: { breakdown: Record<string, number>; isMyMarket?: boolean; hasMyIndustryHits?: boolean }) {
-  const { t } = useTranslation()
+function BreakdownBar({ breakdown }: { breakdown: Record<string, number> }) {
   const relatedExp = breakdown.related_exp ?? 0
   const industryDb = breakdown.industry_db ?? 0
-  if (isMyMarket && !hasMyIndustryHits) {
-    return (
-      <div className="space-y-1.5">
-        <div className="flex h-3 w-full overflow-hidden rounded-full bg-slate-200">
-          <div
-            className="h-full bg-blue-500 transition-all"
-            style={{ width: '100%' }}
-            title={`${formatSnakeCaseLabel('related_exp')}: ${relatedExp}`}
-          />
-        </div>
-        <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-2 w-2 rounded-full bg-blue-500" />
-            {formatSnakeCaseLabel('related_exp')}
-          </span>
-          <span className="italic text-muted-foreground/60">
-            {t('resumes.searchPage.card.breakdownLabels.industryDbNotAvailable', { defaultValue: 'Industry DB: Not available for MY market' })}
-          </span>
-        </div>
-      </div>
-    )
-  }
   const total = relatedExp + industryDb
   if (total <= 0) return null
   const relatedPct = Math.round((relatedExp / total) * 100)
@@ -332,8 +309,6 @@ export function SnippetCardExpanded({
                     </div>
                     <BreakdownBar
                       breakdown={analysis.breakdown}
-                      isMyMarket={item.resume.ingestData?.market === 'MY'}
-                      hasMyIndustryHits={(item.resume.ingestData?.brandHits?.length ?? 0) + (item.resume.ingestData?.companyHits?.length ?? 0) > 0}
                     />
                     <div className="grid gap-2 sm:grid-cols-2">
                       {Object.entries(analysis.breakdown).map(([label, value]) => (
@@ -507,30 +482,21 @@ export function SnippetCardExpanded({
                     { key: 'education', label: t('resumes.searchPage.card.education', { defaultValue: 'Education' }) },
                     { key: 'location', label: t('resumes.searchPage.card.location', { defaultValue: 'Location' }) },
                   ].map(({ key, label }) => {
-                    const isMyMarket = item.resume.ingestData?.market === 'MY'
-                    const hasMyIndustryHits = isMyMarket && key === 'industry_db' && (item.resume.ingestData?.brandHits?.length ?? 0) + (item.resume.ingestData?.companyHits?.length ?? 0) > 0
-                    const isIndustryDbMyNoHits = key === 'industry_db' && isMyMarket && !hasMyIndustryHits
-                    const score = isIndustryDbMyNoHits ? 0 : ((analysis?.breakdown as Record<string, number> | undefined)?.[key] ?? 0)
+                    const score = (analysis?.breakdown as Record<string, number> | undefined)?.[key] ?? 0
                     return (
                       <div key={key} className="space-y-0.5">
                         <div className="flex items-center justify-between text-[11px]">
-                          <span className={isIndustryDbMyNoHits ? 'italic text-muted-foreground/60' : 'text-muted-foreground'}>
-                            {isIndustryDbMyNoHits
-                              ? t('resumes.searchPage.card.breakdownLabels.industryDbNotAvailable', { defaultValue: 'Industry DB: Not available for MY market' })
-                              : label}
+                          <span className="text-muted-foreground">
+                            {label}
                           </span>
-                          {!isIndustryDbMyNoHits && (
-                            <span className="font-mono text-xs text-muted-foreground">{Math.round(typeof score === 'number' ? score : 0)}</span>
-                          )}
+                          <span className="font-mono text-xs text-muted-foreground">{Math.round(typeof score === 'number' ? score : 0)}</span>
                         </div>
-                        {!isIndustryDbMyNoHits && (
-                          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-                            <div
-                              className="h-full rounded-full bg-primary/60 transition-all"
-                              style={{ width: `${Math.min(100, typeof score === 'number' ? score : 0)}%` }}
-                            />
-                          </div>
-                        )}
+                        <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                          <div
+                            className="h-full rounded-full bg-primary/60 transition-all"
+                            style={{ width: `${Math.min(100, typeof score === 'number' ? score : 0)}%` }}
+                          />
+                        </div>
                       </div>
                     )
                   })}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -117,7 +117,6 @@
       "experience": "Experience",
       "skills": "Skills",
       "industryDb": "Industry DB",
-      "industryDbNotAvailable": "Industry DB: Floor 40 (no MY data)",
       "education": "Education",
       "location": "Location"
     },
@@ -504,12 +503,8 @@
         "relatedExp": "Related Exp",
         "skills": "Skills",
         "industryDb": "Industry DB",
-        "industryDbNotAvailable": "Industry DB: Floor 40 (no MY data)",
         "education": "Education",
-        "location": "Location",
-        "breakdownLabels": {
-          "industryDbNotAvailable": "Industry DB: Floor 40 (no MY data)"
-        }
+        "location": "Location"
       },
       "error": {
         "searchBar": "Search bar failed to load",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -117,7 +117,6 @@
       "experience": "经验",
       "skills": "技能",
       "industryDb": "行业库",
-      "industryDbNotAvailable": "行业库：保底40（无MY数据）",
       "education": "学历",
       "location": "地区"
     },
@@ -503,12 +502,8 @@
         "relatedExp": "相关经验",
         "skills": "技能",
         "industryDb": "行业库",
-        "industryDbNotAvailable": "行业库：保底40（无MY数据）",
         "education": "学历",
-        "location": "地点",
-        "breakdownLabels": {
-          "industryDbNotAvailable": "行业库：保底40（无MY数据）"
-        }
+        "location": "地点"
       },
       "error": {
         "searchBar": "搜索栏加载失败",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -117,7 +117,6 @@
       "experience": "經驗",
       "skills": "技能",
       "industryDb": "產業庫",
-      "industryDbNotAvailable": "產業庫：保底40（無MY數據）",
       "education": "學歷",
       "location": "地點"
     },
@@ -503,12 +502,8 @@
         "relatedExp": "相關經驗",
         "skills": "技能",
         "industryDb": "行業庫",
-        "industryDbNotAvailable": "行業庫：MY市場暫不可用",
         "education": "學歷",
-        "location": "地點",
-        "breakdownLabels": {
-          "industryDbNotAvailable": "行業庫：MY市場暫不可用"
-        }
+        "location": "地點"
       },
       "error": {
         "searchBar": "搜尋列加載失敗",


### PR DESCRIPTION
## Summary
- Removed dead "Not available for MY market" placeholder from BreakdownBar and debug section in SnippetCardExpanded
- Removed orphaned `industryDbNotAvailable` i18n keys from all 3 locale files (en, zh-Hans, zh-Hant)
- Updated unit tests and E2E test to verify normal breakdown bar renders for MY market with floor value

## Context
MY market industry_db scoring was updated to use a floor of 40 (`Math.max(40, industryDb)`) in `resume-scoring.ts:537`. Since `analysis.breakdown.industry_db` is now always >= 40 for MY, the placeholder UI was dead code.

## Test plan
- [x] `make check` passes (typecheck + lint + governance)
- [x] SnippetCardExpanded unit tests pass (16/16)
- [ ] E2E test passes (requires `make dev` + `make chrome-debug`)

## Files changed
- `apps/web/src/components/search/SnippetCardExpanded.tsx` — removed BreakdownBar MY placeholder + debug conditional
- `apps/web/src/components/search/SnippetCardExpanded.test.tsx` — updated 3 tests
- `apps/web/e2e/my-market-industry-db-placeholder.spec.ts` — updated E2E assertions
- `apps/web/src/i18n/locales/{en,zh-Hans,zh-Hant}.json` — removed orphaned keys

Net: -47 lines (6 files)