### PR TITLE
fix: replace z.any() in notifications with typed union schema

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -152,8 +152,28 @@ const SendResponseSchema = z.object({
     messageId: z.string().optional(),
     preview: z.string().optional(),
 });
-// send-template has 3 different response shapes (email/wechat/feishu) with spread operators — z.any() is the pragmatic choice
-const SendTemplateResponseSchema = z.any();
+const SendTemplateEmailResponseSchema = z.object({
+    success: z.literal(true),
+    channel: z.literal("email"),
+    messageId: z.string().optional(),
+});
+const SendTemplateWechatResponseSchema = z.object({
+    success: z.literal(true),
+    channel: z.literal("wechat_work"),
+    errcode: z.number(),
+    errmsg: z.string(),
+});
+const SendTemplateFeishuResponseSchema = z.object({
+    success: z.literal(true),
+    channel: z.literal("feishu"),
+    code: z.number(),
+    msg: z.string(),
+});
+const SendTemplateResponseSchema = z.union([
+    SendTemplateEmailResponseSchema,
+    SendTemplateWechatResponseSchema,
+    SendTemplateFeishuResponseSchema,
+]);
 
 // GET /api/notifications/templates
 const templatesRoute = createRoute({

--- a/apps/api/src/services/notification-service.ts
+++ b/apps/api/src/services/notification-service.ts
@@ -180,13 +180,13 @@ export class NotificationService {
 
         const data = parsed.data;
         const code = "code" in data ? data.code : data.StatusCode;
-        const message = "msg" in data ? data.msg : data.StatusMessage;
+        const message = String("msg" in data ? data.msg : data.StatusMessage);
 
         if (!response.ok || code !== 0) {
             throw new Error(`Feishu webhook error: ${message} (code=${code}, HTTP ${response.status})`);
         }
 
-        return data;
+        return { code, msg: message };
     }
 }
 

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -9703,7 +9703,27 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": unknown;
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            /** @enum {string} */
+                            channel: "email";
+                            messageId?: string;
+                        } | {
+                            /** @enum {boolean} */
+                            success: true;
+                            /** @enum {string} */
+                            channel: "wechat_work";
+                            errcode: number;
+                            errmsg: string;
+                        } | {
+                            /** @enum {boolean} */
+                            success: true;
+                            /** @enum {string} */
+                            channel: "feishu";
+                            code: number;
+                            msg: string;
+                        };
                     };
                 };
                 /** @description Send failed */


### PR DESCRIPTION
## Summary
- Replace `SendTemplateResponseSchema = z.any()` with typed `z.union` of 3 channel-specific response schemas
- Normalize `sendFeishuText()` to always return `{ code, msg }` instead of raw webhook union
- Only 2 `z.any()` remain in the API layer (both are file upload schemas — truly needed)

## Context
Deep research scan identified the notifications `z.any()` as the only replaceable instance. The feishu webhook returns two different response shapes (`{code,msg}` vs `{StatusCode,StatusMessage}`) — normalization at the service boundary eliminates the need for `z.any()`.

## Test plan
- [x] `make check` passes (typecheck + lint + OpenAPI generation)
- [ ] Manual test: send test notification via each channel

## Files changed
- `apps/api/src/routes/notifications.ts` — typed union schema
- `apps/api/src/services/notification-service.ts` — feishu response normalization
- `apps/web/src/lib/api-types.ts` — regenerated OpenAPI types

Net: +40 lines (3 files)