### PR TITLE
feat: add EMBEDDING_ENABLED feature flag (default: off)

### DIFF
--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -9769,7 +9769,7 @@ export interface paths {
                             success: true;
                             /** @enum {string} */
                             channel: "email";
-                            messageId: string;
+                            messageId?: string;
                         } | {
                             /** @enum {boolean} */
                             success: true;
@@ -9777,16 +9777,14 @@ export interface paths {
                             channel: "wechat_work";
                             errcode: number;
                             errmsg: string;
-                        } | ({
+                        } | {
                             /** @enum {boolean} */
                             success: true;
                             /** @enum {string} */
                             channel: "feishu";
                             code: number;
                             msg: string;
-                        } & {
-                            [key: string]: unknown;
-                        });
+                        };
                     };
                 };
                 /** @description Send failed */

--- a/packages/convex/__tests__/embeddings-convex-test.test.ts
+++ b/packages/convex/__tests__/embeddings-convex-test.test.ts
@@ -5,11 +5,11 @@
  * Internal functions (internalQuery/internalMutation) are accessed via internal API reference.
  */
 import { createTest } from "./test-helpers.js";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { api } from "../convex/_generated/api.js";
 import { internal } from "../convex/_generated/api.js";
 import type { Doc, Id } from "../convex/_generated/dataModel.js";
-import { rrfMerge } from "../convex/embeddings.js";
+import { rrfMerge, isEmbeddingEnabled } from "../convex/embeddings.js";
 
 
 describe("embeddings (convex-test)", () => {
@@ -371,6 +371,7 @@ describe("embeddings (convex-test)", () => {
   describe("batchGenerateEmbeddings (internal) — dryRun", () => {
     it("dryRun reports scope without generating embeddings", async () => {
       const t = createTest();
+      vi.stubEnv("EMBEDDING_ENABLED", "true");
 
       // Insert resumes without embeddings
       await t.run(async (ctx) => {
@@ -407,6 +408,8 @@ describe("embeddings (convex-test)", () => {
       expect(result.wouldGenerate).toBe(1);
       // All resumes counted as skipped in dryRun
       expect(result.skipped).toBe(2);
+
+      vi.unstubAllEnvs();
     });
   });
 
@@ -446,6 +449,91 @@ describe("embeddings (convex-test)", () => {
       expect(stats.latestModel).toBe("text-embedding-3-small");
       expect(stats.latestGeneratedAt).toBeGreaterThan(0);
     });
+  });
+
+  describe("scheduledBackfill — EMBEDDING_ENABLED gate", () => {
+    it("returns early with zeros when EMBEDDING_ENABLED is not set (default off)", async () => {
+      const t = createTest();
+      vi.stubEnv("EMBEDDING_ENABLED", "");
+
+      const result = await t.action(internal.embeddings.scheduledBackfill, {});
+      expect(result.generated).toBe(0);
+      expect(result.apiErrors).toBe(0);
+      expect(result.batches).toBe(0);
+
+      vi.unstubAllEnvs();
+    });
+
+    it("returns early with zeros when EMBEDDING_ENABLED is false", async () => {
+      const t = createTest();
+      vi.stubEnv("EMBEDDING_ENABLED", "false");
+
+      const result = await t.action(internal.embeddings.scheduledBackfill, {});
+      expect(result.generated).toBe(0);
+      expect(result.apiErrors).toBe(0);
+      expect(result.batches).toBe(0);
+
+      vi.unstubAllEnvs();
+    });
+  });
+
+  describe("batchGenerateEmbeddings — EMBEDDING_ENABLED gate", () => {
+    it("returns early with zeros when EMBEDDING_ENABLED is not set", async () => {
+      const t = createTest();
+      vi.stubEnv("EMBEDDING_ENABLED", "");
+
+      // Insert a resume that would normally be processed
+      await t.run(async (ctx) => {
+        await ctx.db.insert("resumes", {
+          externalId: "gate-1",
+          content: {},
+          hash: "gate1",
+          tags: [],
+          crawledAt: Date.now(),
+          source: "test",
+          searchText: "Gate test resume",
+          needsEmbedding: true,
+        });
+      });
+
+      const result = await t.action(internal.embeddings.batchGenerateEmbeddings, { limit: 10 });
+      expect(result.generated).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(result.hasMore).toBe(false);
+
+      vi.unstubAllEnvs();
+    });
+  });
+});
+
+describe("isEmbeddingEnabled (unit)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns false when EMBEDDING_ENABLED is not set", () => {
+    vi.stubEnv("EMBEDDING_ENABLED", "");
+    expect(isEmbeddingEnabled()).toBe(false);
+  });
+
+  it("returns false when EMBEDDING_ENABLED is 'false'", () => {
+    vi.stubEnv("EMBEDDING_ENABLED", "false");
+    expect(isEmbeddingEnabled()).toBe(false);
+  });
+
+  it("returns true when EMBEDDING_ENABLED is 'true'", () => {
+    vi.stubEnv("EMBEDDING_ENABLED", "true");
+    expect(isEmbeddingEnabled()).toBe(true);
+  });
+
+  it("returns true when EMBEDDING_ENABLED is '1'", () => {
+    vi.stubEnv("EMBEDDING_ENABLED", "1");
+    expect(isEmbeddingEnabled()).toBe(true);
+  });
+
+  it("returns false when EMBEDDING_ENABLED is '0'", () => {
+    vi.stubEnv("EMBEDDING_ENABLED", "0");
+    expect(isEmbeddingEnabled()).toBe(false);
   });
 });
 

--- a/packages/convex/convex/embeddings.ts
+++ b/packages/convex/convex/embeddings.ts
@@ -27,6 +27,18 @@ const EMBEDDING_DIMENSIONS = 1536;
 const BATCH_SIZE = 100;
 
 // ---------------------------------------------------------------------------
+// Feature flag — EMBEDDING_ENABLED
+// Default: OFF. Embeddings require an API that supports /embeddings endpoint.
+// Poe API (current provider) does not support this, so embedding is disabled
+// until a compatible service is configured.
+// ---------------------------------------------------------------------------
+
+export function isEmbeddingEnabled(): boolean {
+    const value = (process.env.EMBEDDING_ENABLED ?? "").toLowerCase().trim();
+    return value === "true" || value === "1";
+}
+
+// ---------------------------------------------------------------------------
 // RRF (Reciprocal Rank Fusion) merge — exported for testing
 // ---------------------------------------------------------------------------
 
@@ -255,6 +267,10 @@ export const batchGenerateEmbeddings = internalAction({
         delayMs: v.optional(v.number()),
     },
     handler: async (ctx, args): Promise<BatchResult> => {
+        if (!isEmbeddingEnabled()) {
+            return { generated: 0, skipped: 0, apiErrors: 0, wouldGenerate: 0, hasMore: false, cursor: null };
+        }
+
         const limit = Math.min(args.limit ?? BATCH_SIZE, BATCH_SIZE);
         const dryRun = args.dryRun ?? false;
         const delayMs = Math.max(args.delayMs ?? 0, 0);
@@ -332,6 +348,10 @@ export const batchGenerateEmbeddings = internalAction({
 export const scheduledBackfill = internalAction({
     args: {},
     handler: async (ctx): Promise<{ generated: number; apiErrors: number; batches: number }> => {
+        if (!isEmbeddingEnabled()) {
+            return { generated: 0, apiErrors: 0, batches: 0 };
+        }
+
         let totalGenerated = 0;
         let totalApiErrors = 0;
         let batches = 0;
@@ -446,7 +466,8 @@ export const hybridSearchResumes = action({
         enableSemantic: v.optional(v.boolean()), // toggle, default true
     },
     handler: async (ctx, args): Promise<HybridSearchResult> => {
-        const enableSemantic = args.enableSemantic ?? true;
+        // System-level gate: embedding disabled means semantic search is off regardless of client request
+        const enableSemantic = isEmbeddingEnabled() && (args.enableSemantic ?? true);
         const semanticWeight = args.semanticWeight ?? 0.5;
         const semanticLimit = Math.min(args.semanticLimit ?? 50, 256);
         const bm25Weight = 1 - semanticWeight;


### PR DESCRIPTION
## Summary
- Embedding/semantic search has been failing with 404 since implementation because Poe API does not support `/embeddings` endpoint
- Gates all embedding operations behind `EMBEDDING_ENABLED` env var (default: **false**) to prevent hourly 404 spam in Convex logs
- When disabled: `scheduledBackfill` returns early, `batchGenerateEmbeddings` returns early, `hybridSearchResumes` falls back to BM25-only
- To enable in the future when a compatible embedding API is available: `npx convex env set EMBEDDING_ENABLED true`

## Test plan
- [x] 5 unit tests for `isEmbeddingEnabled()` truthy/falsy values
- [x] 3 integration tests for gated backfill/batch behavior
- [x] Updated existing dryRun test to set `EMBEDDING_ENABLED=true`
- [x] `make check` passes
- [x] All 29 embedding tests pass

## References
- [Embedding API Poe incompatibility spec](../wiki/projects/trends/work/2026-05-28-embedding-api-poe-incompatibility/spec.md)