### PR TITLE
fix: accept both locations and location URL params for location filter

### DIFF
--- a/apps/web/src/hooks/useUrlSearchState.test.ts
+++ b/apps/web/src/hooks/useUrlSearchState.test.ts
@@ -47,6 +47,20 @@ describe('useUrlSearchState location parsing', () => {
     expect(state.filters.locations).toEqual(['Kuala Lumpur MY'])
   })
 
+  it('accepts locations (plural) URL param to match API schema', () => {
+    const state = parseUrlSearchState(new URLSearchParams('locations=China'))
+
+    expect(state.location).toBe('China')
+    expect(state.filters.locations).toEqual(['China'])
+  })
+
+  it('prefers locations (plural) over location (singular) when both present', () => {
+    const state = parseUrlSearchState(new URLSearchParams('location=Malaysia&locations=China'))
+
+    expect(state.location).toBe('China')
+    expect(state.filters.locations).toEqual(['China'])
+  })
+
   it('parses canonical quoted OR phrase queries without flattening phrases', () => {
     const state = parseUrlSearchState(
       new URLSearchParams('location=Kuala+Lumpur+MY&q=%22Sales+Engineer%22+OR+%22Sales+Manager%22')

--- a/apps/web/src/hooks/useUrlSearchState.ts
+++ b/apps/web/src/hooks/useUrlSearchState.ts
@@ -181,7 +181,7 @@ export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchSta
   const shareSessionId = shareSessionIdRaw?.trim() || undefined
   const queryRaw = searchParams.get('q')
   const query = queryRaw?.trim() || undefined
-  const locationRaw = searchParams.get('location')
+  const locationRaw = searchParams.get('locations') ?? searchParams.get('location')
   const normalizedLocation = locationRaw?.trim() || ''
   const effectiveLocations = normalizeUniqueValues(parseLocationParam(normalizedLocation))
   const location = normalizedLocation || (effectiveLocations.length > 0 ? effectiveLocations.join(',') : undefined)


### PR DESCRIPTION
## Summary
- Accept both `locations` (plural) and `location` (singular) URL params for the location filter
- `locations` takes precedence when both are present
- The API schema expects `locations` (plural), but manual URLs used `location` (singular), causing the filter to be silently ignored

## Root cause
The API schema (`apps/api/src/schemas/resumes.ts:603`) defines the query parameter as `locations` (plural) via `CsvStringArraySchema`, but `useUrlSearchState.ts` only read `location` (singular) from the URL. When a user typed `/dev/resumes?location=China`, the BFF's OpenAPI validation silently dropped it.

The Convex filter and BFF filter logic are correct — the issue was purely a URL parameter naming mismatch.

## Test plan
- [x] `locations=China` (plural) parsed correctly
- [x] `location=China` (singular) still works as fallback
- [x] Both present → `locations` wins
- [x] All 23 existing tests pass
- [x] `make check` passes