### PR TITLE
fix: prevent short Latin alias false positives in location tree (CNC ≠ CN)

### DIFF
--- a/apps/browser-extension/src/lib/seek-extractor.ts
+++ b/apps/browser-extension/src/lib/seek-extractor.ts
@@ -692,6 +692,14 @@ export function createSeekExtractor(deps: SeekExtractorDeps) {
           typeof node?.currentLocation === "string"
             ? node.currentLocation.trim()
             : "";
+        // Fallback to structured country/state/suburb when currentLocation is empty
+        const resolvedLocation = currentLocation
+          || [
+              typeof node?.suburb === "string" ? node.suburb.trim() : "",
+              typeof node?.state === "string" ? node.state.trim() : "",
+              typeof node?.country === "string" ? node.country.trim() : "",
+            ].filter(Boolean).join(", ")
+          || "";
         const lastModifiedDurationLabel =
           typeof node?.lastModifiedDurationLabel === "string"
             ? node.lastModifiedDurationLabel
@@ -719,7 +727,7 @@ export function createSeekExtractor(deps: SeekExtractorDeps) {
           age: "",
           experience: "",
           education: "",
-          location: currentLocation,
+          location: resolvedLocation,
           jobIntention: currentJobTitle,
           expectedSalary: "",
           selfIntro: "",

--- a/packages/shared/src/location-tree.ts
+++ b/packages/shared/src/location-tree.ts
@@ -408,6 +408,30 @@ function pickBestNode(nodeIds: string[], normalizedInput: string): InternalLocat
   return bestNode;
 }
 
+/**
+ * Short Latin aliases (<=3 chars, e.g. "CN", "MY", "HK") must match at
+ * word boundaries to prevent false positives like "CNC" matching "CN".
+ * CJK aliases are exempt — they don't use word boundaries and are
+ * specific enough at 2 chars (e.g. "东莞", "深圳" are unambiguous).
+ */
+const SHORT_LATIN_ALIAS_THRESHOLD = 3;
+
+function isLatinOnly(str: string): boolean {
+  return /^[A-Za-z0-9]+$/.test(str);
+}
+
+function isValidAliasMatch(input: string, alias: string): boolean {
+  if (!input.includes(alias)) {
+    return false;
+  }
+  // Only apply word-boundary restriction to short Latin aliases
+  if (alias.length <= SHORT_LATIN_ALIAS_THRESHOLD && isLatinOnly(alias)) {
+    const pattern = new RegExp(`(?<![A-Za-z0-9])${alias.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?![A-Za-z0-9])`);
+    return pattern.test(input);
+  }
+  return true;
+}
+
 function findLocationNode(name: string): InternalLocationNode | undefined {
   const normalizedInput = normalizeLocationName(name);
   if (!normalizedInput) {
@@ -422,7 +446,7 @@ function findLocationNode(name: string): InternalLocationNode | undefined {
   const candidateNodeIds: string[] = [];
   const seenNodeIds = new Set<string>();
   for (const entry of sortedAliasEntries) {
-    if (!normalizedInput.includes(entry.alias)) {
+    if (!isValidAliasMatch(normalizedInput, entry.alias)) {
       continue;
     }
     if (seenNodeIds.has(entry.nodeId)) {
@@ -448,7 +472,7 @@ function extractLocationNodeIds(value: string): string[] {
   }
 
   for (const entry of sortedAliasEntries) {
-    if (normalizedInput.includes(entry.alias)) {
+    if (isValidAliasMatch(normalizedInput, entry.alias)) {
       matchedNodeIds.add(entry.nodeId);
     }
   }
@@ -678,7 +702,7 @@ export function isLocationMatch(resumeLocation: string, filterName: string): boo
 
   const resumeNodeIds = extractLocationNodeIds(resumeLocation);
   if (resumeNodeIds.length === 0) {
-    return filterNode.aliases.some((alias) => normalizedResume.includes(alias));
+    return filterNode.aliases.some((alias) => isValidAliasMatch(normalizedResume, alias));
   }
 
   return resumeNodeIds.some((nodeId) => isSameOrDescendant(nodeId, filterNode.id));


### PR DESCRIPTION
## Summary
- Short Latin aliases (CN, MY, HK — <=3 chars, ASCII-only) now require word-boundary matches in the location tree
- CJK aliases (东莞, 深圳) are exempt — they don't use word boundaries and are unambiguous
- SEEK extractor falls back to structured `country/state/suburb` API fields when `currentLocation` is null

## Root cause
The location tree used `String.includes()` for ALL alias matching. "CNC Metal Machining" (a Malaysian company name) matched "CN" (China country code), causing MY-market SEEK resumes to be classified as China.

Full bug chain:
1. SEEK API returns `currentLocation: null` for some profiles (but has structured `country: "Malaysia"`, `state: "Selangor"`)
2. Extractor only reads `currentLocation`, sets `location: ""` 
3. Import normalization scans workHistory: `companyName = "CNC Metal Machining"`
4. `"CNC Metal Machining".includes("CN")` → true → resolves to China
5. Resume stored with `locationHierarchy: { country: "中国" }`

## Evidence
Verified via `/playwright-cli` on the live SEEK page:
- SEEK UI shows "Selangor, MY" for Samuel Krishnan
- SEEK API returns `currentLocation: "Selangor, MY"` for profile 1 and `currentLocation: null` + `country: "Malaysia"` for profile 2
- Our DB stored `location: "中国"` for profile 2 due to the CNC→CN false positive

## Test plan
- [x] All 5189 tests pass (including 73 location tests)
- [x] `make check` passes
- [x] `resolveLocationHierarchy("CNC Metal Machining")` → undefined (was: China)
- [x] `isLocationMatch("CNC Metal Machining", "China")` → false (was: true)
- [x] `resolveLocationHierarchy("CN")` → China (exact match still works)
- [x] `resolveLocationHierarchy("东莞精密机械")` → 广东东莞 (CJK unaffected)
- [x] `isLocationMatch("Selangor, MY", "Malaysia")` → true (MY still works)