### PR TITLE
fix: exclude rejected resumes from default search results

### DIFF
--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -1794,6 +1794,50 @@ describe('useResumeSearchState', () => {
     })
   })
 
+  it('excludes rejected resumes by default when no status filter is set', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'CNC 销售',
+      keywords: ['CNC', '销售'],
+    }))
+
+    resumesMock.push(
+      createResume(1, { primaryRuleScore: 95 }),
+      createResume(2, { primaryRuleScore: 90 }),
+      createResume(3, { primaryRuleScore: 85 }),
+    )
+    statusByIdentityMock['identity-1'] = createStatusRecord('identity-1', 'new')
+    statusByIdentityMock['identity-2'] = createStatusRecord('identity-2', 'rejected')
+    statusByIdentityMock['identity-3'] = createStatusRecord('identity-3', 'shortlisted')
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    // rejected is excluded by default; shortlisted and new are kept
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1', 'resume-3'])
+  })
+
+  it('includes rejected resumes when explicitly filtered for', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'CNC 销售',
+      keywords: ['CNC', '销售'],
+      filters: {
+        status: ['rejected'],
+      },
+    }))
+
+    resumesMock.push(
+      createResume(1, { primaryRuleScore: 95 }),
+      createResume(2, { primaryRuleScore: 90 }),
+      createResume(3, { primaryRuleScore: 85 }),
+    )
+    statusByIdentityMock['identity-1'] = createStatusRecord('identity-1', 'new')
+    statusByIdentityMock['identity-2'] = createStatusRecord('identity-2', 'rejected')
+    statusByIdentityMock['identity-3'] = createStatusRecord('identity-3', 'shortlisted')
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-2'])
+  })
+
   it('only grows the resume window when more results are available and not already loading more', () => {
     Object.assign(parsedStateMock, createParsedState({
       query: 'machine tools',

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -438,6 +438,8 @@ function getRoleYears(
   }, 0)
 }
 
+const DEFAULT_EXCLUDED_STATUSES: readonly CandidateStatus[] = ['rejected'] as const
+
 function matchesLocalFilters(
   item: ResumeSearchResultItem,
   state: UrlSearchState,
@@ -539,10 +541,12 @@ function matchesLocalFilters(
     return false
   }
 
-  if (
-    normalizedStatuses.length > 0 &&
-    !normalizedStatuses.includes(item.status)
-  ) {
+  // Default exclusion: hide rejected resumes unless user explicitly filters for them
+  if (normalizedStatuses.length > 0) {
+    if (!normalizedStatuses.includes(item.status)) {
+      return false
+    }
+  } else if (DEFAULT_EXCLUDED_STATUSES.includes(item.status)) {
     return false
   }
 

--- a/apps/web/src/hooks/useUrlSearchState.ts
+++ b/apps/web/src/hooks/useUrlSearchState.ts
@@ -136,10 +136,16 @@ function parseStatusList(value: string | null): CandidateStatus[] {
     .map((item) => item.trim())
     .filter((item): item is CandidateStatus =>
       item === 'new'
+      || item === 'shortlisted'
+      || item === 'rejected'
       || item === 'contacted'
       || item === 'interviewing'
       || item === 'interviewed_pass'
       || item === 'interviewed_reject'
+      || item === 'appeal_submitted'
+      || item === 'human_review'
+      || item === 'upheld'
+      || item === 'reversed'
       || item === 'offer'
       || item === 'hired'
       || item === 'withdrawn'


### PR DESCRIPTION
## Summary

- Adds `DEFAULT_EXCLUDED_STATUSES` constant to `matchesLocalFilters` — when no status filter is set, resumes with `rejected` status are hidden by default
- When user explicitly selects a status facet (e.g. `status=rejected`), the inclusion filter takes over and overrides the default exclusion
- Implements the default-exclusion decision from work item `2026-05-27-unify-triage-pipeline-status`

## Root cause

`matchesLocalFilters` used an inclusion-only check: when `normalizedStatuses` was empty (default), all statuses — including `rejected` — passed through. Live verification confirmed 200 results for CNC 销售 search, all with "Rejected" badges.

## Changes

- `apps/web/src/hooks/useResumeSearchState.ts` — `DEFAULT_EXCLUDED_STATUSES` constant + updated status check logic
- `apps/web/src/hooks/useResumeSearchState.test.tsx` — two new tests: default exclusion + explicit opt-in

## Test plan

- [x] `make check` passes
- [x] Browser-verified: default search shows 0 rejected (they exist as `Rejected200` in facet but hidden)
- [x] No console errors across smoke routes
- [x] Unit tests cover default exclusion and explicit `status=rejected` filter