### PR TITLE
fix: add location fallback to all SEEK extraction paths

### DIFF
--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -1098,6 +1098,11 @@
       const lastName = typeof profile.lastName === "string" ? profile.lastName.trim() : "";
       const currentJobTitle = typeof profile.currentJobTitle === "string" ? profile.currentJobTitle.trim() : "";
       const currentLocation = typeof profile.currentLocation === "string" ? profile.currentLocation.trim() : "";
+      const resolvedLocation = currentLocation || [
+        typeof profile.suburb === "string" ? profile.suburb.trim() : "",
+        typeof profile.state === "string" ? profile.state.trim() : "",
+        typeof profile.country === "string" ? profile.country.trim() : ""
+      ].filter(Boolean).join(", ") || "";
       const lastModifiedDate = typeof profile.lastModifiedDate === "string" ? profile.lastModifiedDate : "";
       const workHistory = Array.isArray(profile.workHistories) ? profile.workHistories.map((item) => buildSeekWorkHistoryItem(item)).filter(Boolean) : [];
       const profileEducation = Array.isArray(profile.profileEducation) ? profile.profileEducation.map((item) => buildSeekProfileEducationItem(item)).filter(Boolean) : [];
@@ -1130,7 +1135,7 @@
           age: "",
           experience: "",
           education,
-          location: currentLocation,
+          location: resolvedLocation,
           jobIntention: currentJobTitle,
           expectedSalary: formatSeekExpectedSalary(profile.salary?.expected),
           selfIntro: resumeSnippet,
@@ -1249,6 +1254,11 @@
         const lastName = typeof candidate?.lastName === "string" ? candidate.lastName.trim() : "";
         const currentJobTitle = typeof candidate?.currentJobTitle === "string" ? candidate.currentJobTitle.trim() : "";
         const currentLocation = typeof candidate?.currentLocation === "string" ? candidate.currentLocation.trim() : "";
+        const resolvedLocation = currentLocation || [
+          typeof candidate?.suburb === "string" ? candidate.suburb.trim() : "",
+          typeof candidate?.state === "string" ? candidate.state.trim() : "",
+          typeof candidate?.country === "string" ? candidate.country.trim() : ""
+        ].filter(Boolean).join(", ") || "";
         const lastModifiedDate = typeof candidate?.lastModifiedDate === "string" ? candidate.lastModifiedDate : "";
         const salary = candidate?.salary;
         const salaryParts = [salary?.minLabel, salary?.maxLabel].filter(
@@ -1265,7 +1275,7 @@
           age: "",
           experience: "",
           education: "",
-          location: currentLocation,
+          location: resolvedLocation,
           jobIntention: currentJobTitle,
           expectedSalary: salaryParts.join(" - "),
           selfIntro: "",

--- a/apps/browser-extension/src/lib/seek-extractor.ts
+++ b/apps/browser-extension/src/lib/seek-extractor.ts
@@ -346,6 +346,14 @@ export function createSeekExtractor(deps: SeekExtractorDeps) {
       typeof profile.currentLocation === "string"
         ? profile.currentLocation.trim()
         : "";
+    // Fallback to structured country/state/suburb when currentLocation is empty
+    const resolvedLocation = currentLocation
+      || [
+          typeof profile.suburb === "string" ? profile.suburb.trim() : "",
+          typeof profile.state === "string" ? profile.state.trim() : "",
+          typeof profile.country === "string" ? profile.country.trim() : "",
+        ].filter(Boolean).join(", ")
+      || "";
     const lastModifiedDate =
       typeof profile.lastModifiedDate === "string"
         ? profile.lastModifiedDate
@@ -417,7 +425,7 @@ export function createSeekExtractor(deps: SeekExtractorDeps) {
         age: "",
         experience: "",
         education,
-        location: currentLocation,
+        location: resolvedLocation,
         jobIntention: currentJobTitle,
         expectedSalary: formatSeekExpectedSalary((profile.salary as Record<string, unknown> | undefined)?.expected),
         selfIntro: resumeSnippet,
@@ -608,6 +616,14 @@ export function createSeekExtractor(deps: SeekExtractorDeps) {
         typeof candidate?.currentLocation === "string"
           ? candidate.currentLocation.trim()
           : "";
+      // Fallback to structured country/state/suburb when currentLocation is empty
+      const resolvedLocation = currentLocation
+        || [
+            typeof candidate?.suburb === "string" ? candidate.suburb.trim() : "",
+            typeof candidate?.state === "string" ? candidate.state.trim() : "",
+            typeof candidate?.country === "string" ? candidate.country.trim() : "",
+          ].filter(Boolean).join(", ")
+        || "";
       const lastModifiedDate =
         typeof candidate?.lastModifiedDate === "string"
           ? candidate.lastModifiedDate
@@ -634,7 +650,7 @@ export function createSeekExtractor(deps: SeekExtractorDeps) {
         age: "",
         experience: "",
         education: "",
-        location: currentLocation,
+        location: resolvedLocation,
         jobIntention: currentJobTitle,
         expectedSalary: salaryParts.join(" - "),
         selfIntro: "",


### PR DESCRIPTION
## Summary
- Add country/state/suburb location fallback to `extractSeekResumes()` and `extractSeekProfileResume()` — matching the existing fallback in `extractSeekTalentSearchResumes()`
- Prevents empty locations when SEEK GraphQL API returns null for `currentLocation`
- Zero risk: fallback is a no-op when `currentLocation` is populated

## Test plan
- [x] `vitest seek-extractor.test.ts` — 42/42 pass
- [x] `make check` — all checks pass
- [x] Browser extension build succeeds