### PR TITLE
fix: clearFacetFilters now resets roleFilterType

### DIFF
--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -1579,6 +1579,8 @@ describe('useResumeSearchState', () => {
       filters: {
         minExperience: 5,
         maxExperience: 12,
+        minRoleYears: 1,
+        roleFilterType: 'sales',
         locations: ['Malaysia'],
         education: ['Bachelor'],
         status: ['contacted'],
@@ -1608,11 +1610,12 @@ describe('useResumeSearchState', () => {
       filters: {
         minExperience: undefined,
         maxExperience: undefined,
+        minRoleYears: undefined,
+        roleFilterType: undefined,
         locations: ['Malaysia'],
         education: undefined,
         status: undefined,
         minMatchScore: undefined,
-        minRoleYears: undefined,
         minAge: undefined,
         maxAge: undefined,
         minSalary: undefined,

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -1452,6 +1452,7 @@ export function useResumeSearchState() {
           education: undefined,
           minMatchScore: undefined,
           minRoleYears: undefined,
+          roleFilterType: undefined,
           minExperience: undefined,
           maxExperience: undefined,
           minAge: undefined,


### PR DESCRIPTION
## Summary
- clearFacetFilters cleared minRoleYears but omitted roleFilterType, leaving a ghost role-type filter after "Clear All" for CN profiles (51job-cn-cnc-sales, job5156-cn-cnc-sales)
- Added `roleFilterType: undefined` to the explicit clear list
- Updated test to verify roleFilterType is cleared with all other facet filters

## Test plan
- [x] `npm test` — 34/34 tests pass in useResumeSearchState
- [x] `make check` — all checks passed