### PR TITLE
fix: harden recommendation-ceiling fallback to fail-closed (no_match)

### DIFF
--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -609,4 +609,18 @@ describe('overrideIndustryDbBreakdown — score/recommendation coherence', () =>
     const result = overrideIndustryDbBreakdown(analysis, 50)
     expect(result.score).toBeGreaterThanOrEqual(85)
   })
+
+  it('clamps unknown recommendation to no_match ceiling (30)', () => {
+    const analysis = {
+      score: 95,
+      recommendation: 'mystery_value' as unknown as 'match',
+      breakdown: { related_exp: 100 },
+      summary: 'Unknown recommendation drift',
+      highlights: [],
+      concerns: [],
+    }
+    const result = overrideIndustryDbBreakdown(analysis, 0)
+    // related_exp clamped to 30 (no_match ceiling) → score = round(30 * 0.5) + 0 = 15
+    expect(result.score).toBeLessThanOrEqual(15)
+  })
 })

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -542,7 +542,7 @@ export function overrideIndustryDbBreakdown(
   market?: string,
 ): ConvexResumeAnalysis {
   const effectiveIndustryDb = market === 'MY' ? Math.max(MY_INDUSTRY_DB_FLOOR, industryDb) : industryDb
-  const recommendationCeiling = RELATED_EXP_CEILING_BY_RECOMMENDATION[analysis.recommendation ?? ''] ?? 100
+  const recommendationCeiling = RELATED_EXP_CEILING_BY_RECOMMENDATION[analysis.recommendation ?? ''] ?? 30
   const rawRelatedExp = typeof analysis.breakdown?.related_exp === 'number' ? analysis.breakdown.related_exp : 0
   const cappedRelatedExp = Math.min(rawRelatedExp, recommendationCeiling)
   const normalizedRelatedExp = Math.round(clamp(cappedRelatedExp, 0, 100) * RELATED_EXP_AI_WEIGHT)

--- a/packages/convex/__tests__/analysis_normalization.test.ts
+++ b/packages/convex/__tests__/analysis_normalization.test.ts
@@ -392,7 +392,7 @@ describe("normalizeSummaryConsistency", () => {
 describe("normalizeAnalysisResult", () => {
     it("computes score from related_exp * weight + industry_db", () => {
         const result = normalizeAnalysisResult(
-            { score: 80, summary: "Test", breakdown: { related_exp: 60 } },
+            { score: 80, summary: "Test", recommendation: "match", breakdown: { related_exp: 60 } },
             { ingestData: { industryDbV2Raw: 30 } },
         );
         expect(result.score).toBe(Math.round(60 * RELATED_EXP_WEIGHT) + 30);
@@ -411,7 +411,7 @@ describe("normalizeAnalysisResult", () => {
 
     it("clamps related_exp to 0-100 before weighting", () => {
         const result = normalizeAnalysisResult(
-            { breakdown: { related_exp: 200 } },
+            { recommendation: "match", breakdown: { related_exp: 200 } },
             {},
         );
         // related_exp clamped to 100, then score = round(100 * 0.5) + 0 = 50
@@ -421,7 +421,7 @@ describe("normalizeAnalysisResult", () => {
 
     it("derives recommendation from score", () => {
         const result = normalizeAnalysisResult(
-            { breakdown: { related_exp: 100 } },
+            { recommendation: "match", breakdown: { related_exp: 100 } },
             { ingestData: { industryDbV2Raw: 35 } },
         );
         // score = round(100 * 0.5) + 35 = 85 → strong_match
@@ -453,6 +453,65 @@ describe("normalizeAnalysisResult", () => {
         );
         expect(result.keyFactors).toHaveLength(1);
         expect(result.keyFactors[0].factor).toBe("exp");
+    });
+
+    describe("recommendation ceiling — fail-closed defaults", () => {
+        it("unknown recommendation string clamps related_exp to no_match ceiling (30)", () => {
+            const result = normalizeAnalysisResult(
+                { recommendation: "weak_potential", breakdown: { related_exp: 100 } },
+                {},
+            );
+            // related_exp clamped to 30 → score = round(30 * 0.5) + 0 = 15
+            expect(result.score).toBeLessThanOrEqual(15);
+        });
+
+        it("null recommendation clamps to no_match ceiling", () => {
+            const result = normalizeAnalysisResult(
+                { recommendation: null as unknown as string, breakdown: { related_exp: 100 } },
+                {},
+            );
+            expect(result.score).toBeLessThanOrEqual(15);
+        });
+
+        it("undefined recommendation clamps to no_match ceiling", () => {
+            const result = normalizeAnalysisResult(
+                { breakdown: { related_exp: 100 } },
+                {},
+            );
+            expect(result.score).toBeLessThanOrEqual(15);
+        });
+
+        it("empty-string recommendation clamps to no_match ceiling", () => {
+            const result = normalizeAnalysisResult(
+                { recommendation: "", breakdown: { related_exp: 100 } },
+                {},
+            );
+            expect(result.score).toBeLessThanOrEqual(15);
+        });
+
+        it("numeric recommendation clamps to no_match ceiling", () => {
+            const result = normalizeAnalysisResult(
+                { recommendation: 42 as unknown as string, breakdown: { related_exp: 100 } },
+                {},
+            );
+            expect(result.score).toBeLessThanOrEqual(15);
+        });
+
+        it("valid recommendation values use their ceiling, not the fallback", () => {
+            const cases: Array<[string, number]> = [
+                ["strong_match", 100],
+                ["match", 100],
+                ["potential", 60],
+                ["no_match", 30],
+            ];
+            for (const [rec, ceiling] of cases) {
+                const result = normalizeAnalysisResult(
+                    { recommendation: rec, breakdown: { related_exp: 100 } },
+                    {},
+                );
+                expect(result.score).toBe(Math.round(ceiling * RELATED_EXP_WEIGHT));
+            }
+        });
     });
 });
 

--- a/packages/convex/convex/lib/analysis_normalization.ts
+++ b/packages/convex/convex/lib/analysis_normalization.ts
@@ -341,7 +341,10 @@ export function normalizeAnalysisResult(
 
     const relatedExpRaw = clamp(llmRelatedExp ?? 0, 0, 100);
     const llmRecommendation = toLLMRecommendation(result.recommendation);
-    const relatedExpCeiling = RELATED_EXP_CEILING_BY_RECOMMENDATION[llmRecommendation ?? "match"];
+    if (llmRecommendation === undefined && result.recommendation !== undefined) {
+        console.warn("unknown LLM recommendation; defaulting to no_match ceiling", { recommendation: result.recommendation });
+    }
+    const relatedExpCeiling = RELATED_EXP_CEILING_BY_RECOMMENDATION[llmRecommendation ?? "no_match"];
     const cappedRelatedExp = clamp(relatedExpRaw, 0, relatedExpCeiling);
     const score = clamp(Math.round(cappedRelatedExp * RELATED_EXP_WEIGHT) + industryDb, 0, 100);
 


### PR DESCRIPTION
## Summary
- Changes ceiling-table fallback from `?? "match"` (uncapped) to `?? "no_match"` (ceiling=30)
- Prevents silent score inflation when LLM emits unknown/null/empty recommendation
- Logs unknown values for operator visibility
- Client-side parity in `resume-scoring.ts`

## Test plan
- [x] RED: 5 fail-closed tests fail with `?? "match"` default
- [x] GREEN: All 68 Convex + 54 web tests pass with `?? "no_match"` default
- [x] `make check` passes