### PR TITLE
fix: profileFiltersById reads SEARCH_PROFILE_TEMPLATES not stale Convex data

### DIFF
--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -1,4 +1,4 @@
-import { formatKeywordInput, isSalesRequiredContext, normalizeKeywordPhrases, parseKeywordQuery } from '@trends/shared'
+import { formatKeywordInput, isSalesRequiredContext, normalizeKeywordPhrases, parseKeywordQuery, SEARCH_PROFILE_TEMPLATES } from '@trends/shared'
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState, type ComponentProps } from 'react'
 import { MessageSquareMore, Pencil, RotateCcw } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
@@ -361,19 +361,17 @@ export function QuickStartPanel({
   const [showJdEditor, setShowJdEditor] = useState(false)
   const [assistantOpen, setAssistantOpen] = useState(false)
   const [workflowSeeds, setWorkflowSeeds] = useState<QuickStartWorkflow[]>([])
-  const convexProfiles = useQuery(api.search_profiles.list, { workspaceSlug: slug })
   const profileFiltersById = useMemo(() => {
-    if (!convexProfiles) return new Map<string, SearchProfileFilters>()
     const map = new Map<string, SearchProfileFilters>()
-    for (const doc of convexProfiles) {
-      const profileId = typeof doc?.profile?.id === 'string' ? doc.profile.id : undefined
-      const filters = (doc?.profile?.filters && typeof doc.profile.filters === 'object' && !Array.isArray(doc.profile.filters)) ? doc.profile.filters as SearchProfileFilters : undefined
-      if (profileId && filters) {
-        map.set(profileId, filters)
+    for (const template of SEARCH_PROFILE_TEMPLATES) {
+      const profileId = template.profile.id
+      const filters = template.profile.filters
+      if (profileId && filters && typeof filters === 'object' && !Array.isArray(filters)) {
+        map.set(profileId, filters as SearchProfileFilters)
       }
     }
     return map
-  }, [convexProfiles])
+  }, [])
   const normalizedJobDescriptionId = jobDescriptionId.trim()
   const normalizedDefaultLocation = defaultLocation.trim()
   const normalizedDefaultKeywordsSignature = normalizeKeywordPhrases(defaultKeywords).join('\u0000')


### PR DESCRIPTION
## Summary

- `QuickStartPanel.profileFiltersById` was reading profile filters from `api.search_profiles.list` (Convex DB), which stores the raw profile blob set at last seed time
- After PR #1134 changed the CN market YAMLs from `minExperience: 1` to `minRoleYears: 1` + `roleFilterType: sales`, the Convex blob was never re-seeded — it still had the old `minExperience: 1` field
- `handleApplyWorkflow` passed stale `filters.minExperience: 1` into `setFilters` → URL showed `?minExp=1` instead of `?minRoleYears=1&roleType=sales`
- Fix: build `profileFiltersById` from `SEARCH_PROFILE_TEMPLATES` (generated from YAML at build time — always canonical). Removes the `convexProfiles` `useQuery` that was only used for this map.

## Test plan

- [ ] Click China Job5156 or 51job QuickStart card → URL should contain `minRoleYears=1&roleType=sales&minAge=25&maxAge=40`
- [ ] No `minExp` param in URL
- [ ] `make check` passes