### PR TITLE
fix: add crawledAt window tests and searchText refresh observability

### DIFF
--- a/packages/convex/__tests__/resumes-summary-window-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-summary-window-convex-test.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Convex-test coverage for resumes.ts summary-window queries:
+ * - getSummaryWindow: returns total + bySource breakdown for resumes in crawledAt window
+ * - listNewForWindow: returns resume list for resumes in crawledAt window
+ *
+ * Regression tests for the listNewForWindow-broken investigation (2026-05-29):
+ * both functions use the by_crawledAt index and must not filter on any status field.
+ */
+import { createTest } from "./test-helpers.js";
+import { describe, expect, it } from "vitest";
+import { api } from "../convex/_generated/api.js";
+
+const NOW = 1_780_000_000_000;
+const ONE_HOUR = 3_600_000;
+
+describe("resumes: getSummaryWindow", () => {
+    it("returns zero total when no resumes exist in window", async () => {
+        const t = createTest();
+        const result = await t.query(api.resumes.getSummaryWindow, {
+            fromTimestamp: NOW - ONE_HOUR,
+            toTimestamp: NOW,
+        });
+        expect(result.total).toBe(0);
+        expect(result.bySource).toEqual([]);
+    });
+
+    it("counts resumes whose crawledAt falls within the window", async () => {
+        const t = createTest();
+
+        await t.run(async (ctx) => {
+            await ctx.db.insert("resumes", {
+                externalId: "ext-in-window-1",
+                content: { name: "Wang Xiansheng" },
+                hash: "hash-1",
+                tags: [],
+                crawledAt: NOW - 100,
+                source: "51job.com",
+            });
+            await ctx.db.insert("resumes", {
+                externalId: "ext-in-window-2",
+                content: { name: "Yang Nushi" },
+                hash: "hash-2",
+                tags: [],
+                crawledAt: NOW - 200,
+                source: "51job.com",
+            });
+            // Outside window — crawledAt too old
+            await ctx.db.insert("resumes", {
+                externalId: "ext-outside-window",
+                content: { name: "Old Candidate" },
+                hash: "hash-old",
+                tags: [],
+                crawledAt: NOW - ONE_HOUR - 1,
+                source: "51job.com",
+            });
+        });
+
+        const result = await t.query(api.resumes.getSummaryWindow, {
+            fromTimestamp: NOW - ONE_HOUR,
+            toTimestamp: NOW,
+        });
+        expect(result.total).toBe(2);
+        expect(result.bySource).toHaveLength(1);
+        expect(result.bySource[0]).toEqual({ key: "51job.com", count: 2 });
+    });
+
+    it("excludes archived resumes from the count", async () => {
+        const t = createTest();
+
+        await t.run(async (ctx) => {
+            await ctx.db.insert("resumes", {
+                externalId: "ext-active",
+                content: {},
+                hash: "hash-a",
+                tags: [],
+                crawledAt: NOW - 50,
+                source: "seek.com",
+            });
+            await ctx.db.insert("resumes", {
+                externalId: "ext-archived",
+                content: {},
+                hash: "hash-b",
+                tags: [],
+                crawledAt: NOW - 60,
+                source: "seek.com",
+                isArchived: true,
+            });
+        });
+
+        const result = await t.query(api.resumes.getSummaryWindow, {
+            fromTimestamp: NOW - ONE_HOUR,
+            toTimestamp: NOW,
+        });
+        expect(result.total).toBe(1);
+    });
+
+    it("groups by source in descending count order", async () => {
+        const t = createTest();
+
+        await t.run(async (ctx) => {
+            for (let i = 1; i <= 3; i++) {
+                await ctx.db.insert("resumes", {
+                    externalId: `seek-${i}`,
+                    content: {},
+                    hash: `h-seek-${i}`,
+                    tags: [],
+                    crawledAt: NOW - i * 10,
+                    source: "seek.com",
+                });
+            }
+            await ctx.db.insert("resumes", {
+                externalId: "51job-1",
+                content: {},
+                hash: "h-51job-1",
+                tags: [],
+                crawledAt: NOW - 100,
+                source: "51job.com",
+            });
+        });
+
+        const result = await t.query(api.resumes.getSummaryWindow, {
+            fromTimestamp: NOW - ONE_HOUR,
+            toTimestamp: NOW,
+        });
+        expect(result.total).toBe(4);
+        expect(result.bySource[0]!.key).toBe("seek.com");
+        expect(result.bySource[0]!.count).toBe(3);
+        expect(result.bySource[1]!.key).toBe("51job.com");
+        expect(result.bySource[1]!.count).toBe(1);
+    });
+});
+
+describe("resumes: listNewForWindow", () => {
+    it("returns empty list when no resumes exist in window", async () => {
+        const t = createTest();
+        const result = await t.query(api.resumes.listNewForWindow, {
+            fromTimestamp: NOW - ONE_HOUR,
+            toTimestamp: NOW,
+        });
+        expect(result).toEqual([]);
+    });
+
+    it("returns resumes whose crawledAt falls within the window", async () => {
+        const t = createTest();
+
+        await t.run(async (ctx) => {
+            await ctx.db.insert("resumes", {
+                externalId: "ext-new-1",
+                content: { name: "Wang Xiansheng", location: "Shanghai" },
+                hash: "hash-new-1",
+                tags: [],
+                crawledAt: NOW - 100,
+                source: "51job.com",
+            });
+            await ctx.db.insert("resumes", {
+                externalId: "ext-new-2",
+                content: { name: "Yang Nushi", experience: "5年" },
+                hash: "hash-new-2",
+                tags: [],
+                crawledAt: NOW - 200,
+                source: "51job.com",
+            });
+        });
+
+        const result = await t.query(api.resumes.listNewForWindow, {
+            fromTimestamp: NOW - ONE_HOUR,
+            toTimestamp: NOW,
+        });
+        expect(result).toHaveLength(2);
+        expect(result.every((r) => r.crawledAt >= NOW - ONE_HOUR)).toBe(true);
+        expect(result.some((r) => r.name === "Wang Xiansheng")).toBe(true);
+        expect(result.some((r) => r.name === "Yang Nushi")).toBe(true);
+    });
+
+    it("does not filter on any status field — returns regardless of candidate status", async () => {
+        // Regression test: previous investigation found count=0 despite known recent resumes.
+        // The function must return ALL resumes in the crawledAt window, ignoring any
+        // Convex-side status/candidateStatus field (which is never populated — workflow
+        // status lives in SQLite candidate_status).
+        const t = createTest();
+
+        await t.run(async (ctx) => {
+            await ctx.db.insert("resumes", {
+                externalId: "ext-no-status",
+                content: { name: "No Status Candidate" },
+                hash: "hash-no-status",
+                tags: [],
+                crawledAt: NOW - 50,
+                source: "51job.com",
+                // No status field — simulates production resumes where status is null
+            });
+        });
+
+        const result = await t.query(api.resumes.listNewForWindow, {
+            fromTimestamp: NOW - ONE_HOUR,
+            toTimestamp: NOW,
+        });
+        expect(result).toHaveLength(1);
+        expect(result[0]!.source).toBe("51job.com");
+    });
+
+    it("excludes archived resumes", async () => {
+        const t = createTest();
+
+        await t.run(async (ctx) => {
+            await ctx.db.insert("resumes", {
+                externalId: "ext-live",
+                content: {},
+                hash: "hash-live",
+                tags: [],
+                crawledAt: NOW - 50,
+                source: "seek.com",
+            });
+            await ctx.db.insert("resumes", {
+                externalId: "ext-archived",
+                content: {},
+                hash: "hash-arch",
+                tags: [],
+                crawledAt: NOW - 60,
+                source: "seek.com",
+                isArchived: true,
+            });
+        });
+
+        const result = await t.query(api.resumes.listNewForWindow, {
+            fromTimestamp: NOW - ONE_HOUR,
+            toTimestamp: NOW,
+        });
+        expect(result).toHaveLength(1);
+        expect(result[0]!.resumeId).toBeDefined();
+    });
+
+    it("respects the limit parameter", async () => {
+        const t = createTest();
+
+        await t.run(async (ctx) => {
+            for (let i = 0; i < 5; i++) {
+                await ctx.db.insert("resumes", {
+                    externalId: `ext-limit-${i}`,
+                    content: {},
+                    hash: `hash-limit-${i}`,
+                    tags: [],
+                    crawledAt: NOW - i * 10,
+                    source: "seek.com",
+                });
+            }
+        });
+
+        const result = await t.query(api.resumes.listNewForWindow, {
+            fromTimestamp: NOW - ONE_HOUR,
+            toTimestamp: NOW,
+            limit: 3,
+        });
+        expect(result).toHaveLength(3);
+    });
+});

--- a/packages/convex/__tests__/submit-resumes-searchtext-drift-convex-test.test.ts
+++ b/packages/convex/__tests__/submit-resumes-searchtext-drift-convex-test.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Convex-test coverage for searchText refresh tracking in submitResumes.
+ *
+ * Regression tests for the searchtext-rejected-count-drift investigation (2026-05-29):
+ * When a hash-changed resume gets a new searchText, the sync_event must record
+ * searchTextRefreshed > 0 so operators can correlate with candidate_status in SQLite.
+ */
+import { createTest } from "./test-helpers.js";
+import { describe, expect, it } from "vitest";
+import { api } from "../convex/_generated/api.js";
+
+describe("resume_tasks: submitResumes — searchTextRefreshed tracking", () => {
+    it("records searchTextRefreshed=0 when no resumes are hash-changed", async () => {
+        const t = createTest();
+
+        // First submission — all inserts, no hash changes
+        await t.mutation(api.resume_tasks.submitResumes, {
+            resumes: [
+                {
+                    externalId: "ext-fresh",
+                    content: { name: "New Candidate" },
+                    hash: "hash-v1",
+                    source: "51job.com",
+                    tags: [],
+                },
+            ],
+        });
+
+        const event = await t.run(async (ctx) => {
+            return ctx.db
+                .query("sync_events")
+                .withIndex("by_timestamp")
+                .order("desc")
+                .first();
+        });
+
+        expect(event).toBeDefined();
+        expect(event!.inserted).toBe(1);
+        expect(event!.updated).toBe(0);
+        expect(event!.searchTextRefreshed).toBe(0);
+    });
+
+    it("records searchTextRefreshed=1 when a hash-changed resume gets a new searchText", async () => {
+        const t = createTest();
+
+        // Seed an existing resume without searchText
+        await t.run(async (ctx) => {
+            await ctx.db.insert("resumes", {
+                externalId: "ext-existing",
+                identityKey: "externalId:ext-existing",
+                content: { name: "Existing Candidate" },
+                hash: "hash-v1",
+                source: "51job.com",
+                tags: [],
+                crawledAt: Date.now() - 10_000,
+                // No searchText — will gain one on hash-changed update
+            });
+        });
+
+        // Submit same resume with a different hash and enriched content (adds searchText)
+        await t.mutation(api.resume_tasks.submitResumes, {
+            resumes: [
+                {
+                    externalId: "ext-existing",
+                    content: { name: "Existing Candidate", skills: "CNC 数控" },
+                    hash: "hash-v2",
+                    source: "51job.com",
+                    tags: [],
+                },
+            ],
+        });
+
+        const event = await t.run(async (ctx) => {
+            return ctx.db
+                .query("sync_events")
+                .withIndex("by_timestamp")
+                .order("desc")
+                .first();
+        });
+
+        expect(event).toBeDefined();
+        expect(event!.updated).toBe(1);
+        expect(event!.searchTextRefreshed).toBe(1);
+    });
+
+    it("records correct searchTextRefreshed count across a mixed batch", async () => {
+        const t = createTest();
+
+        // Seed 2 existing resumes
+        await t.run(async (ctx) => {
+            await ctx.db.insert("resumes", {
+                externalId: "ext-a",
+                identityKey: "externalId:ext-a",
+                content: { name: "Candidate A" },
+                hash: "hash-a-v1",
+                source: "51job.com",
+                tags: [],
+                crawledAt: Date.now() - 10_000,
+            });
+            await ctx.db.insert("resumes", {
+                externalId: "ext-b",
+                identityKey: "externalId:ext-b",
+                content: { name: "Candidate B" },
+                hash: "hash-b-v1",
+                source: "51job.com",
+                tags: [],
+                crawledAt: Date.now() - 20_000,
+                searchText: "cnc",
+            });
+        });
+
+        // Submit batch: 1 new, ext-a hash-changed, ext-b hash-changed
+        await t.mutation(api.resume_tasks.submitResumes, {
+            resumes: [
+                {
+                    externalId: "ext-new",
+                    content: { name: "New Candidate" },
+                    hash: "hash-new",
+                    source: "51job.com",
+                    tags: [],
+                },
+                {
+                    externalId: "ext-a",
+                    content: { name: "Candidate A", skills: "CNC" },
+                    hash: "hash-a-v2",
+                    source: "51job.com",
+                    tags: [],
+                },
+                {
+                    externalId: "ext-b",
+                    content: { name: "Candidate B", skills: "数控 销售" },
+                    hash: "hash-b-v2",
+                    source: "51job.com",
+                    tags: [],
+                },
+            ],
+        });
+
+        const event = await t.run(async (ctx) => {
+            return ctx.db
+                .query("sync_events")
+                .withIndex("by_timestamp")
+                .order("desc")
+                .first();
+        });
+
+        expect(event).toBeDefined();
+        expect(event!.inserted).toBe(1);
+        expect(event!.updated).toBe(2);
+        // Both ext-a and ext-b were hash-changed and got new searchText
+        expect(event!.searchTextRefreshed).toBe(2);
+    });
+});

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -360,6 +360,7 @@ export const submitResumes = mutation({
         let inserted = 0;
         let updated = 0;
         let unchanged = 0;
+        let searchTextRefreshed = 0;
         let nextIndex = 0;
         const parallelism = resolveSubmitResumeParallelism(resumes.length);
         const ingestProcessIds: Id<"resumes">[] = [];
@@ -426,6 +427,7 @@ export const submitResumes = mutation({
                         applyParsedAgePatch(patch, parsedAge, existing.age);
                         await ctx.db.patch(existing._id, patch);
                         updated += 1;
+                        searchTextRefreshed += 1;
                         if (shouldScheduleIngest(restoreState)) {
                             ingestProcessIds.push(existing._id);
                         }
@@ -526,6 +528,7 @@ export const submitResumes = mutation({
             inserted,
             updated,
             unchanged,
+            searchTextRefreshed,
             timestamp: now,
         });
 

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -428,6 +428,7 @@ export default defineSchema({
         inserted: v.number(),
         updated: v.number(),
         unchanged: v.number(),
+        searchTextRefreshed: v.optional(v.number()),
         error: v.optional(v.string()),
         timestamp: v.number(),
     }).index("by_timestamp", ["timestamp"]),


### PR DESCRIPTION
## Summary

Addresses two ingest audit findings from 2026-05-29:

- **listNewForwindow-broken** (medium): Confirmed `getSummaryWindow` and `listNewForWindow` already use pure `crawledAt` window queries with no status field dependency. Added 9 regression tests covering count accuracy, bySource breakdown, archived exclusion, limit behavior, and the cross-store status-agnosticism contract.
- **searchtext-rejected-count-drift** (low): Added `searchTextRefreshed` counter to `sync_events` so operators can see when hash-changed resume updates silently refreshed `searchText` (Option C — observe before guarding). Counter tracks all hash-changed updates; operators cross-reference with SQLite `candidate_status` for rejected-specific analysis. Added 3 tests.

## Changes

- `packages/convex/convex/schema.ts` — adds `searchTextRefreshed: v.optional(v.number())` to `sync_events`
- `packages/convex/convex/resume_tasks.ts` — increments `searchTextRefreshed` in hash-changed update path; includes in sync_event insert
- `packages/convex/__tests__/resumes-summary-window-convex-test.test.ts` — NEW: 9 tests for `getSummaryWindow` and `listNewForWindow`
- `packages/convex/__tests__/submit-resumes-searchtext-drift-convex-test.test.ts` — NEW: 3 tests for `searchTextRefreshed` tracking

## Test plan

- [ ] `npm test` passes — all 12 new tests GREEN
- [ ] `make check` passes — typecheck, lint, governance clean