### PR TITLE
feat: sticky bulk-action bar + id/name filter in FacetSidebar

### DIFF
--- a/apps/web/src/components/search/FacetSidebar.test.tsx
+++ b/apps/web/src/components/search/FacetSidebar.test.tsx
@@ -95,6 +95,7 @@ describe('FacetSidebar', () => {
         onToggleTag={vi.fn()}
         selectedSources={[]}
         onToggleSource={vi.fn()}
+        onSetIdOrNameSearch={vi.fn()}
       />
     )
 
@@ -139,6 +140,7 @@ describe('FacetSidebar', () => {
         onToggleTag={onToggleTag}
         selectedSources={[]}
         onToggleSource={vi.fn()}
+        onSetIdOrNameSearch={vi.fn()}
       />
     )
 
@@ -190,6 +192,7 @@ describe('FacetSidebar', () => {
         onToggleTag={vi.fn()}
         selectedSources={[]}
         onToggleSource={vi.fn()}
+        onSetIdOrNameSearch={vi.fn()}
       />
     )
 
@@ -232,6 +235,7 @@ describe('FacetSidebar', () => {
         onToggleTag={vi.fn()}
         selectedSources={[]}
         onToggleSource={vi.fn()}
+        onSetIdOrNameSearch={vi.fn()}
       />
     )
 
@@ -271,6 +275,7 @@ describe('FacetSidebar', () => {
         onToggleTag={vi.fn()}
         selectedSources={[]}
         onToggleSource={vi.fn()}
+        onSetIdOrNameSearch={vi.fn()}
       />
     )
 
@@ -315,6 +320,7 @@ describe('FacetSidebar', () => {
         onToggleTag={vi.fn()}
         selectedSources={[]}
         onToggleSource={vi.fn()}
+        onSetIdOrNameSearch={vi.fn()}
       />
     )
 
@@ -362,6 +368,7 @@ describe('FacetSidebar', () => {
         onToggleTag={vi.fn()}
         selectedSources={[]}
         onToggleSource={vi.fn()}
+        onSetIdOrNameSearch={vi.fn()}
       />
     )
 

--- a/apps/web/src/components/search/FacetSidebar.test.tsx
+++ b/apps/web/src/components/search/FacetSidebar.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { FacetSidebar } from '@/components/search/FacetSidebar'
 import type { FacetCounts } from '@/components/search/search-types'
+import type { CandidateStatus } from '@/types/resume'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -370,5 +371,71 @@ describe('FacetSidebar', () => {
     // Re-click deselects
     await user.click(screen.getByRole('button', { name: '25-40' }))
     expect(onSetAgeRange).toHaveBeenCalledWith(undefined, undefined)
+  })
+})
+
+describe('idOrNameSearch filter input', () => {
+  function buildProps() {
+    return {
+      facetCounts: buildFacetCounts(),
+      selectedBrands: [],
+      selectedClusters: [],
+      selectedCompanies: [],
+      selectedEducation: [],
+      selectedExperienceLevel: undefined as undefined,
+      selectedSources: [],
+      selectedStatuses: [] as CandidateStatus[],
+      selectedTags: [],
+      onClearAll: vi.fn(),
+      onSetAgeRange: vi.fn(),
+      onSetExperienceLevel: vi.fn(),
+      onSetMinRoleYears: vi.fn(),
+      onSetMinScore: vi.fn(),
+      onSetSalaryRange: vi.fn(),
+      onToggleBrand: vi.fn(),
+      onToggleCluster: vi.fn(),
+      onToggleCompany: vi.fn(),
+      onToggleEducation: vi.fn(),
+      onToggleSource: vi.fn(),
+      onToggleStatus: vi.fn(),
+      onToggleTag: vi.fn(),
+      idOrNameSearch: undefined as string | undefined,
+      onSetIdOrNameSearch: vi.fn(),
+    }
+  }
+
+  it('renders the id/name search input placeholder', () => {
+    render(<FacetSidebar {...buildProps()} embedded />)
+    expect(screen.getByPlaceholderText('ID · 候选人姓名')).toBeInTheDocument()
+  })
+
+  it('shows current idOrNameSearch value', () => {
+    render(<FacetSidebar {...buildProps()} embedded idOrNameSearch="abc123" />)
+    expect(screen.getByDisplayValue('abc123')).toBeInTheDocument()
+  })
+
+  it('calls onSetIdOrNameSearch when typing', async () => {
+    const user = userEvent.setup()
+    const onSetIdOrNameSearch = vi.fn()
+    render(<FacetSidebar {...buildProps()} embedded onSetIdOrNameSearch={onSetIdOrNameSearch} />)
+    const input = screen.getByPlaceholderText('ID · 候选人姓名')
+    await user.type(input, 'x')
+    expect(onSetIdOrNameSearch).toHaveBeenCalledWith('x')
+  })
+
+  it('shows clear button only when value present', () => {
+    const { rerender } = render(<FacetSidebar {...buildProps()} embedded idOrNameSearch={undefined} />)
+    expect(screen.queryByRole('button', { name: /clear/i })).not.toBeInTheDocument()
+
+    rerender(<FacetSidebar {...buildProps()} embedded idOrNameSearch="abc" />)
+    expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument()
+  })
+
+  it('calls onSetIdOrNameSearch with undefined when clear button clicked', async () => {
+    const user = userEvent.setup()
+    const onSetIdOrNameSearch = vi.fn()
+    render(<FacetSidebar {...buildProps()} embedded idOrNameSearch="abc" onSetIdOrNameSearch={onSetIdOrNameSearch} />)
+    await user.click(screen.getByRole('button', { name: /clear/i }))
+    expect(onSetIdOrNameSearch).toHaveBeenCalledWith(undefined)
   })
 })

--- a/apps/web/src/components/search/FacetSidebar.tsx
+++ b/apps/web/src/components/search/FacetSidebar.tsx
@@ -41,6 +41,8 @@ export type FacetSidebarProps = {
   onToggleSource: (value: string) => void
   onToggleStatus: (value: CandidateStatus) => void
   onToggleTag: (value: string) => void
+  idOrNameSearch?: string
+  onSetIdOrNameSearch: (value: string | undefined) => void
 }
 
 function PillGroup<T extends string | number>({
@@ -400,6 +402,8 @@ export function FacetSidebar({
   onToggleSource,
   onToggleStatus,
   onToggleTag,
+  idOrNameSearch,
+  onSetIdOrNameSearch,
 }: FacetSidebarProps) {
   const { t } = useTranslation()
   const content = (
@@ -412,6 +416,27 @@ export function FacetSidebar({
         <button type="button" className="text-sm text-muted-foreground hover:text-foreground" onClick={onClearAll}>
           {t('common.reset', { defaultValue: '重置' })}
         </button>
+      </div>
+
+      {/* Id / name search */}
+      <div className="relative">
+        <Input
+          type="text"
+          placeholder="ID · 候选人姓名"
+          value={idOrNameSearch ?? ''}
+          onChange={(e) => onSetIdOrNameSearch(e.target.value || undefined)}
+          className="pr-7 text-sm"
+        />
+        {idOrNameSearch && (
+          <button
+            type="button"
+            aria-label="clear"
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            onClick={() => onSetIdOrNameSearch(undefined)}
+          >
+            ×
+          </button>
+        )}
       </div>
 
       <FacetGroup

--- a/apps/web/src/components/search/MobileFilterSheet.test.tsx
+++ b/apps/web/src/components/search/MobileFilterSheet.test.tsx
@@ -108,6 +108,7 @@ function buildProps(overrides: Partial<ComponentProps<typeof MobileFilterSheet>>
     selectedSources: [],
     onToggleBrand: vi.fn(),
     onToggleSource: vi.fn(),
+    onSetIdOrNameSearch: vi.fn(),
     ...overrides,
   }
 }

--- a/apps/web/src/hooks/resume-filter-helpers.test.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.test.ts
@@ -830,3 +830,37 @@ describe('getResumeIdentityKey', () => {
     expect(getResumeIdentityKey({} as ConvexResumeItem, 'fallback')).toBe('fallback')
   })
 })
+
+describe('idOrNameSearch filter logic', () => {
+  function matchesIdOrName(
+    resumeId: string,
+    name: string,
+    needle: string | undefined,
+  ): boolean {
+    if (!needle || needle.trim() === '') return true
+    const n = needle.trim().toLowerCase()
+    return (
+      resumeId.toLowerCase().includes(n) ||
+      (name ?? '').toLowerCase().includes(n)
+    )
+  }
+
+  it('returns true when needle is absent', () => {
+    expect(matchesIdOrName('id-abc', '张三', undefined)).toBe(true)
+  })
+
+  it('matches partial resumeId (case-insensitive)', () => {
+    expect(matchesIdOrName('ResID-abc123', '张三', 'abc')).toBe(true)
+    expect(matchesIdOrName('ResID-abc123', '张三', 'xyz')).toBe(false)
+  })
+
+  it('matches partial candidate name (case-insensitive)', () => {
+    expect(matchesIdOrName('id-1', 'John Smith', 'smith')).toBe(true)
+    expect(matchesIdOrName('id-1', '王小明', '小明')).toBe(true)
+    expect(matchesIdOrName('id-1', 'John Smith', 'jones')).toBe(false)
+  })
+
+  it('returns true when needle is blank string', () => {
+    expect(matchesIdOrName('id-1', 'John', '  ')).toBe(true)
+  })
+})

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -589,6 +589,15 @@ function matchesLocalFilters(
     return false
   }
 
+  const idOrNameNeedle = state.filters.idOrNameSearch?.trim().toLowerCase()
+  if (idOrNameNeedle) {
+    const resumeIdStr = String(item.resume.resumeId).toLowerCase()
+    const nameStr = (item.resume.name ?? '').toLowerCase()
+    if (!resumeIdStr.includes(idOrNameNeedle) && !nameStr.includes(idOrNameNeedle)) {
+      return false
+    }
+  }
+
   return true
 }
 
@@ -1421,6 +1430,20 @@ export function useResumeSearchState() {
     [parsedState, syncToUrl],
   )
 
+  const setIdOrNameSearchFilter = useCallback(
+    (idOrNameSearch: string | undefined) => {
+      syncToUrl(
+        buildUrlState(parsedState, {
+          filters: {
+            ...parsedState.filters,
+            idOrNameSearch: idOrNameSearch?.trim() || undefined,
+          },
+        }),
+      )
+    },
+    [parsedState, syncToUrl],
+  )
+
   const setSort = useCallback(
     (sortValue: SearchSortValue) => {
       const nextFilters: Partial<ResumeFilters> = {
@@ -1460,6 +1483,7 @@ export function useResumeSearchState() {
           minSalary: undefined,
           maxSalary: undefined,
           status: undefined,
+          idOrNameSearch: undefined,
         },
       }),
     )
@@ -1783,6 +1807,7 @@ export function useResumeSearchState() {
     setAgeRangeFilter,
     setSalaryRangeFilter,
     setMinScoreFilter,
+    setIdOrNameSearchFilter,
     setAiModeEnabled,
     setExportFormat,
     setQueryInput,

--- a/apps/web/src/hooks/useUrlSearchState.test.ts
+++ b/apps/web/src/hooks/useUrlSearchState.test.ts
@@ -553,3 +553,15 @@ describe('minExperience URL param round-trip', () => {
     expect(updatedParams.get('minExp')).toBe('1')
   })
 })
+
+describe('idOrNameSearch (idn) URL param', () => {
+  it('parses idn param into filters.idOrNameSearch', () => {
+    const state = parseUrlSearchState(new URLSearchParams('idn=abc123'))
+    expect(state.filters.idOrNameSearch).toBe('abc123')
+  })
+
+  it('returns undefined for idOrNameSearch when idn param absent', () => {
+    const state = parseUrlSearchState(new URLSearchParams('q=sales'))
+    expect(state.filters.idOrNameSearch).toBeUndefined()
+  })
+})

--- a/apps/web/src/hooks/useUrlSearchState.ts
+++ b/apps/web/src/hooks/useUrlSearchState.ts
@@ -26,6 +26,7 @@ const KNOWN_PARAM_KEYS = [
   'status',
   'sort',
   'order',
+  'idn',
 ] as const
 
 export type ExperienceLevelFilter = 'senior' | 'mid' | 'junior'
@@ -273,6 +274,12 @@ export function parseUrlSearchState(searchParams: URLSearchParams): UrlSearchSta
     filters.sortOrder = sortOrder
   }
 
+  const idOrNameSearchRaw = searchParams.get('idn')
+  const idOrNameSearch = idOrNameSearchRaw?.trim() || undefined
+  if (idOrNameSearch) {
+    filters.idOrNameSearch = idOrNameSearch
+  }
+
   return {
     shareSessionId,
     query,
@@ -395,6 +402,12 @@ export function useUrlSearchState() {
 
         if (state.filters.sortOrder) {
           setParam(nextParams, 'order', state.filters.sortOrder)
+        }
+
+        if (state.filters.idOrNameSearch && state.filters.idOrNameSearch.trim().length > 0) {
+          setParam(nextParams, 'idn', state.filters.idOrNameSearch.trim())
+        } else {
+          nextParams.delete('idn')
         }
 
         if (nextParams.toString() === prevParams.toString()) {

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -56,6 +56,7 @@ export function ResumeSearchPage() {
     selectedRawTags,
     setAiModeEnabled,
     setExportFormat,
+    setIdOrNameSearchFilter,
     setMinRoleYearsFilter,
     setAgeRangeFilter,
     setSalaryRangeFilter,
@@ -192,6 +193,14 @@ export function ResumeSearchPage() {
     setQueryInput(nextQuery)
   }
 
+  const handleBulkActionWithScroll = useCallback(
+    (...args: Parameters<typeof handleBulkAction>) => {
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+      return handleBulkAction(...args)
+    },
+    [handleBulkAction],
+  )
+
   const mobileFilterProps = useMemo(
     () => ({
       facetCounts,
@@ -222,10 +231,14 @@ export function ResumeSearchPage() {
       onToggleStatus: toggleStatus,
       onSetMinScore: setMinScoreFilter,
       onClearAll: clearFacetFilters,
+      idOrNameSearch: parsedState.filters.idOrNameSearch,
+      onSetIdOrNameSearch: setIdOrNameSearchFilter,
     }),
     [
       clearFacetFilters,
       facetCounts,
+      parsedState.filters.idOrNameSearch,
+      setIdOrNameSearchFilter,
       parsedState.filters.education,
       parsedState.filters.minMatchScore,
       parsedState.filters.minRoleYears,
@@ -403,20 +416,22 @@ export function ResumeSearchPage() {
                 </ErrorBoundary>
               )}
 
-              <BulkActionBar
-                totalCount={filteredResults.length}
-                selectedCount={selectedIds.size}
-                highScoreCount={highScoreCount}
-                exportFormat={exportFormat}
-                onExportFormatChange={setExportFormat}
-                onSelectAll={selectAll}
-                onSelectHighScore={() => selectHighScore()}
-                onClearSelection={clearSelection}
-                onBulkAction={handleBulkAction}
-                statusFilter={parsedState.filters.status}
-                onStatusToggle={toggleStatus}
-                statusFacetCounts={facetCounts?.statuses?.reduce((acc, { value, count }) => ({ ...acc, [value]: count }), {} as Record<string, number>)}
-              />
+              <div className="sticky top-0 z-20 -mx-1 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 px-1 py-1">
+                <BulkActionBar
+                  totalCount={filteredResults.length}
+                  selectedCount={selectedIds.size}
+                  highScoreCount={highScoreCount}
+                  exportFormat={exportFormat}
+                  onExportFormatChange={setExportFormat}
+                  onSelectAll={selectAll}
+                  onSelectHighScore={() => selectHighScore()}
+                  onClearSelection={clearSelection}
+                  onBulkAction={handleBulkActionWithScroll}
+                  statusFilter={parsedState.filters.status}
+                  onStatusToggle={toggleStatus}
+                  statusFacetCounts={facetCounts?.statuses?.reduce((acc, { value, count }) => ({ ...acc, [value]: count }), {} as Record<string, number>)}
+                />
+              </div>
 
               <ErrorBoundary fallback={<InlineErrorFallback message={errorResultsLabel} retryLabel={reloadPageLabel} onRetry={() => window.location.reload()} />}>
                 <SearchResultsList

--- a/apps/web/src/types/resume.ts
+++ b/apps/web/src/types/resume.ts
@@ -15,6 +15,7 @@ export type ResumeFilters = {
   minSalary?: number
   maxSalary?: number
   minMatchScore?: number
+  idOrNameSearch?: string
   recommendation?: Recommendation[]
   sortBy?: 'score' | 'name' | 'experience' | 'extractedAt'
   sortOrder?: 'asc' | 'desc'


### PR DESCRIPTION
## Summary

- **Sticky BulkActionBar**: wraps the bulk-action bar (已选择 count + status chips + 批量入围/拒绝/屏蔽 buttons) in a `sticky top-0 z-20` container with backdrop-blur so it remains visible while scrolling
- **Scroll-to-top on bulk action**: clicking any bulk action (shortlist, reject, block, export) smoothly scrolls the page back to top
- **ResumeId / candidate-name filter**: new text input at the top of `FacetSidebar` (above match score) that filters the resume list in real-time by partial `resumeId` or candidate `name` match (case-insensitive, URL-persisted via `?idn=`)

## Changes

| File | Change |
|---|---|
| `apps/web/src/types/resume.ts` | Add `idOrNameSearch?: string` to `ResumeFilters` |
| `apps/web/src/hooks/useUrlSearchState.ts` | Add `idn` URL param (parse + write) |
| `apps/web/src/hooks/useResumeSearchState.ts` | Filter logic in `matchesLocalFilters`; `setIdOrNameSearchFilter` callback; clear in `clearFacetFilters` |
| `apps/web/src/components/search/FacetSidebar.tsx` | New text input with clear button above match score |
| `apps/web/src/pages/ResumeSearchPage.tsx` | Sticky BulkActionBar wrapper; scroll-to-top; `mobileFilterProps` wired |

## Test plan

- [x] `npm --workspace @trends/web test -- --run`: **1419 passed (140 test files)**
- [x] `make check`: **All checks passed** (typecheck + lint + governance)
- [ ] Browser: FacetSidebar shows "ID · 候选人姓名" input at top; typing filters list; × clears
- [ ] Browser: select resumes, scroll down — BulkActionBar stays pinned
- [ ] Browser: click 批量拒绝 — page scrolls back to top