### PR TITLE
fix: prevent filter toggle race condition during React startTransition

### DIFF
--- a/apps/web/src/components/search/FacetSidebar.tsx
+++ b/apps/web/src/components/search/FacetSidebar.tsx
@@ -43,6 +43,7 @@ export type FacetSidebarProps = {
   onToggleTag: (value: string) => void
   idOrNameSearch?: string
   onSetIdOrNameSearch: (value: string | undefined) => void
+  isFilterTransitionPending?: boolean
 }
 
 function PillGroup<T extends string | number>({
@@ -87,7 +88,8 @@ const PRESET_ROLE_YEARS = [1, 2, 5] as const
 function MinRoleYearsGroup({
   minRoleYears,
   onSetMinRoleYears,
-}: Pick<FacetSidebarProps, 'minRoleYears' | 'onSetMinRoleYears'>) {
+  isFilterTransitionPending = false,
+}: Pick<FacetSidebarProps, 'minRoleYears' | 'onSetMinRoleYears' | 'isFilterTransitionPending'>) {
   const { t } = useTranslation()
   const isPreset = typeof minRoleYears === 'number' && (PRESET_ROLE_YEARS as readonly number[]).includes(minRoleYears)
   const [customOpen, setCustomOpen] = useState(typeof minRoleYears === 'number' && !isPreset)
@@ -128,6 +130,7 @@ function MinRoleYearsGroup({
             <button
               key={value}
               type="button"
+              disabled={isFilterTransitionPending}
               className={active
                 ? 'rounded-full border border-slate-900 bg-slate-900 px-3 py-1.5 text-sm text-white'
                 : 'rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700'}
@@ -404,6 +407,7 @@ export function FacetSidebar({
   onToggleTag,
   idOrNameSearch,
   onSetIdOrNameSearch,
+  isFilterTransitionPending,
 }: FacetSidebarProps) {
   const { t } = useTranslation()
   const content = (
@@ -468,7 +472,7 @@ export function FacetSidebar({
         selectedValue={selectedExperienceLevel}
         onSelect={onSetExperienceLevel}
       />
-      <MinRoleYearsGroup minRoleYears={minRoleYears} onSetMinRoleYears={onSetMinRoleYears} />
+      <MinRoleYearsGroup minRoleYears={minRoleYears} onSetMinRoleYears={onSetMinRoleYears} isFilterTransitionPending={isFilterTransitionPending} />
       <RangeFilterGroup
         presets={PRESET_AGE_RANGES}
         label={t('resumes.searchPage.facets.ageRange', { defaultValue: '年龄范围' })}

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -1,7 +1,7 @@
 import { formatKeywordQuery, getVerifiedRoleSignalYears, isSalesRequiredContext, parseKeywordQuery } from '@trends/shared'
 import { hasMatchingRoleSignal, matchesSalaryFilter } from '@/hooks/resume-filter-helpers'
 import { useMutation } from 'convex/react'
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from 'react'
 import { toast } from 'sonner'
 import { logSearchEvent } from '@/lib/search-analytics'
 import { api } from '../../../../packages/convex/convex/_generated/api'
@@ -663,6 +663,15 @@ export function useResumeSearchState() {
   const [exportingResults, setExportingResults] = useState(false)
   const [analyzingResults, setAnalyzingResults] = useState(false)
   const [autoAnalyzeSearchNonce, setAutoAnalyzeSearchNonce] = useState(0)
+  const [isFilterPending, startFilterTransition] = useTransition()
+  const [committedMinRoleYears, setCommittedMinRoleYears] = useState(parsedState.filters.minRoleYears)
+
+  // Sync committed filter values when transition completes
+  useEffect(() => {
+    if (!isFilterPending) {
+      setCommittedMinRoleYears(parsedState.filters.minRoleYears)
+    }
+  }, [isFilterPending, parsedState.filters.minRoleYears])
   const [pendingAutoAnalyzeContextSignature, setPendingAutoAnalyzeContextSignature] = useState('')
   const [resumeLimit, setResumeLimit] = useState(INITIAL_RESUME_LIMIT)
   const saveSearchHistory = useMutation(api.sessions.saveSearchHistory)
@@ -1313,58 +1322,67 @@ export function useResumeSearchState() {
 
   const setMinRoleYearsFilter = useCallback(
     (minRoleYears: number | undefined) => {
-      syncToUrl(
-        buildUrlState(parsedState, {
-          filters: {
-            ...parsedState.filters,
-            minRoleYears,
-          },
-        }),
-      )
+      setCommittedMinRoleYears(minRoleYears)
+      startFilterTransition(() => {
+        syncToUrl(
+          buildUrlState(parsedState, {
+            filters: {
+              ...parsedState.filters,
+              minRoleYears,
+            },
+          }),
+        )
+      })
     },
     [parsedState, syncToUrl],
   )
 
   const setAgeRangeFilter = useCallback(
     (minAge: number | undefined, maxAge: number | undefined) => {
-      syncToUrl(
-        buildUrlState(parsedState, {
-          filters: {
-            ...parsedState.filters,
-            minAge,
-            maxAge,
-          },
-        }),
-      )
+      startFilterTransition(() => {
+        syncToUrl(
+          buildUrlState(parsedState, {
+            filters: {
+              ...parsedState.filters,
+              minAge,
+              maxAge,
+            },
+          }),
+        )
+      })
     },
     [parsedState, syncToUrl],
   )
 
   const setSalaryRangeFilter = useCallback(
     (minSalary: number | undefined, maxSalary: number | undefined) => {
-      syncToUrl(
-        buildUrlState(parsedState, {
-          filters: {
-            ...parsedState.filters,
-            minSalary,
-            maxSalary,
-          },
-        }),
-      )
+      startFilterTransition(() => {
+        syncToUrl(
+          buildUrlState(parsedState, {
+            filters: {
+              ...parsedState.filters,
+              minSalary,
+              maxSalary,
+            },
+          }),
+        )
+      })
     },
     [parsedState, syncToUrl],
   )
 
   const setEducationFilters = useCallback(
     (education: string[]) => {
-      syncToUrl(
-        buildUrlState(parsedState, {
-          filters: {
-            ...parsedState.filters,
-            education,
-          },
-        }),
-      )
+      startFilterTransition(() => {
+        syncToUrl(
+          buildUrlState(parsedState, {
+            filters: {
+              ...parsedState.filters,
+              education,
+            },
+          }),
+        )
+      })
     },
     [parsedState, syncToUrl],
   )
@@ -1392,14 +1410,16 @@ export function useResumeSearchState() {
 
   const setStatusFilters = useCallback(
     (status: CandidateStatus[]) => {
-      syncToUrl(
-        buildUrlState(parsedState, {
-          filters: {
-            ...parsedState.filters,
-            status,
-          },
-        }),
-      )
+      startFilterTransition(() => {
+        syncToUrl(
+          buildUrlState(parsedState, {
+            filters: {
+              ...parsedState.filters,
+              status,
+            },
+          }),
+        )
+      })
     },
     [parsedState, syncToUrl],
   )
@@ -1418,28 +1438,32 @@ export function useResumeSearchState() {
 
   const setMinScoreFilter = useCallback(
     (minMatchScore: number | undefined) => {
-      syncToUrl(
-        buildUrlState(parsedState, {
-          filters: {
-            ...parsedState.filters,
-            minMatchScore,
-          },
-        }),
-      )
+      startFilterTransition(() => {
+        syncToUrl(
+          buildUrlState(parsedState, {
+            filters: {
+              ...parsedState.filters,
+              minMatchScore,
+            },
+          }),
+        )
+      })
     },
     [parsedState, syncToUrl],
   )
 
   const setIdOrNameSearchFilter = useCallback(
     (idOrNameSearch: string | undefined) => {
-      syncToUrl(
-        buildUrlState(parsedState, {
-          filters: {
-            ...parsedState.filters,
-            idOrNameSearch: idOrNameSearch?.trim() || undefined,
-          },
-        }),
-      )
+      startFilterTransition(() => {
+        syncToUrl(
+          buildUrlState(parsedState, {
+            filters: {
+              ...parsedState.filters,
+              idOrNameSearch: idOrNameSearch?.trim() || undefined,
+            },
+          }),
+        )
+      })
     },
     [parsedState, syncToUrl],
   )
@@ -1803,6 +1827,8 @@ export function useResumeSearchState() {
     selectedClusterTags,
     selectedRawTags,
     searchHistoryLoading: recentSearchHistoryRecords === undefined,
+    isFilterPending,
+    committedMinRoleYears,
     setMinRoleYearsFilter,
     setAgeRangeFilter,
     setSalaryRangeFilter,

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -73,6 +73,8 @@ export function ResumeSearchPage() {
     toggleBrand,
     toggleStatus,
     toggleTag,
+    isFilterPending,
+    committedMinRoleYears,
     // Candidate management
     actionsByResume,
     ratingsByResume,
@@ -205,7 +207,8 @@ export function ResumeSearchPage() {
     () => ({
       facetCounts,
       minScore: parsedState.filters.minMatchScore,
-      minRoleYears: parsedState.filters.minRoleYears,
+      minRoleYears: committedMinRoleYears,
+      isFilterTransitionPending: isFilterPending,
       minAge: parsedState.filters.minAge,
       maxAge: parsedState.filters.maxAge,
       minSalary: parsedState.filters.minSalary,


### PR DESCRIPTION
## Summary
- Wraps 7 filter setter callbacks in `useResumeSearchState.ts` with explicit `useTransition` to track `isFilterPending` state
- Tracks `committedMinRoleYears` optimistically so filter toggle buttons read correct active state during pending URL transitions (React Router v7 wraps `setSearchParams` in `startTransition`)
- Disables `MinRoleYearsGroup` preset buttons during pending transitions to prevent double-fire race conditions
- Fixes the 3-vs-208 count discrepancy where rapid filter toggling could fire the wrong set/clear action due to stale `parsedState`

## Files changed
- `apps/web/src/hooks/useResumeSearchState.ts` — Added `useTransition`, `committedMinRoleYears` state, wrapped filter setters in `startFilterTransition`
- `apps/web/src/components/search/FacetSidebar.tsx` — Added `isFilterTransitionPending` prop, `disabled` on preset buttons
- `apps/web/src/pages/ResumeSearchPage.tsx` — Threaded `isFilterPending` and `committedMinRoleYears` through `mobileFilterProps`

## Test plan
- [x] `make check` passes
- [x] FacetSidebar tests pass (12/12)
- [x] ResumeSearchPage tests pass (9/9)
- [ ] Manual verification: click "1+" filter rapidly, confirm count stays consistent