### PR TITLE
fix: add loaded-count indicator to FacetSidebar for status count context

### DIFF
--- a/apps/web/src/components/search/FacetSidebar.tsx
+++ b/apps/web/src/components/search/FacetSidebar.tsx
@@ -44,6 +44,7 @@ export type FacetSidebarProps = {
   idOrNameSearch?: string
   onSetIdOrNameSearch: (value: string | undefined) => void
   isFilterTransitionPending?: boolean
+  loadedCount?: number
 }
 
 function PillGroup<T extends string | number>({
@@ -408,10 +409,16 @@ export function FacetSidebar({
   idOrNameSearch,
   onSetIdOrNameSearch,
   isFilterTransitionPending,
+  loadedCount,
 }: FacetSidebarProps) {
   const { t } = useTranslation()
   const content = (
     <div className="space-y-6">
+      {loadedCount !== undefined && loadedCount > 0 && (
+        <div className="text-xs text-muted-foreground">
+          {t('resumes.searchPage.facets.loadedCount', { defaultValue: `显示前 ${loadedCount} 条结果中的筛选统计` })}
+        </div>
+      )}
       <div className="flex items-center justify-between">
         <div>
           <div className="text-sm font-semibold text-slate-900">{t('resumes.searchPage.facets.filtersTitle', { defaultValue: '筛选条件' })}</div>

--- a/apps/web/src/components/search/FacetSidebar.tsx
+++ b/apps/web/src/components/search/FacetSidebar.tsx
@@ -416,7 +416,7 @@ export function FacetSidebar({
     <div className="space-y-6">
       {loadedCount !== undefined && loadedCount > 0 && (
         <div className="text-xs text-muted-foreground">
-          {t('resumes.searchPage.facets.loadedCount', { defaultValue: `显示前 ${loadedCount} 条结果中的筛选统计` })}
+          {t('resumes.searchPage.facets.loadedCount', { count: loadedCount, defaultValue: `显示前 ${loadedCount} 条结果中的筛选统计` })}
         </div>
       )}
       <div className="flex items-center justify-between">

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -376,6 +376,7 @@
         "filtersTitle": "Filters",
         "filtersDescription": "Refine your search results.",
         "filtersDescriptionMobile": "Refine your search results.",
+        "loadedCount": "Showing counts for the first {{count}} results",
         "emptyLabel": "No options available",
         "showLess": "Show less",
         "showMore": "Show {{count}} more",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -375,6 +375,7 @@
         "filtersTitle": "筛选条件",
         "filtersDescription": "在当前搜索结果中进一步精确筛选。",
         "filtersDescriptionMobile": "在当前搜索结果中进一步精确筛选。",
+        "loadedCount": "显示前 {{count}} 条结果中的筛选统计",
         "emptyLabel": "暂无可用选项",
         "showLess": "收起",
         "showMore": "展开剩余 {{count}} 项",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -375,6 +375,7 @@
         "filtersTitle": "篩選條件",
         "filtersDescription": "在當前搜索結果中進一步精確篩選。",
         "filtersDescriptionMobile": "在當前搜索結果中進一步精確篩選。",
+        "loadedCount": "顯示前 {{count}} 條結果中的篩選統計",
         "emptyLabel": "暫無可用選項",
         "showLess": "收起",
         "showMore": "展開剩餘 {{count}} 項",

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -209,6 +209,7 @@ export function ResumeSearchPage() {
       minScore: parsedState.filters.minMatchScore,
       minRoleYears: committedMinRoleYears,
       isFilterTransitionPending: isFilterPending,
+      loadedCount: filteredResults.length,
       minAge: parsedState.filters.minAge,
       maxAge: parsedState.filters.maxAge,
       minSalary: parsedState.filters.minSalary,


### PR DESCRIPTION
## Summary
- Adds `loadedCount` prop to `FacetSidebar` showing a contextual note at the top: "显示前 N 条结果中的筛选统计"
- Passes `filteredResults.length` as `loadedCount` from `ResumeSearchPage`
- Helps users understand that facet status counts (new/rejected/shortlisted) are computed over the loaded window, not the full matching pool

## Background
Status facet counts are computed client-side over `INITIAL_RESUME_LIMIT = 200` loaded resumes, not the full filtered pool. When new resumes are collected, counts shift unpredictably as new entries push old ones off the 200-resume window. This indicator provides context without requiring API changes (server-side facet counts are a follow-up item).

## Files changed
- `apps/web/src/components/search/FacetSidebar.tsx` — Added `loadedCount` prop, display element
- `apps/web/src/pages/ResumeSearchPage.tsx` — Pass `filteredResults.length` to FacetSidebar

## Test plan
- [x] `make check` passes
- [x] FacetSidebar tests pass (12/12)
- [x] ResumeSearchPage tests pass (9/9)