### PR TITLE
refactor: remove server-side filter fields from matchesLocalFilters

### DIFF
--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -483,8 +483,11 @@ describe('useResumeSearchState', () => {
 
     const { result } = renderHook(() => useResumeSearchState())
 
+    // After server-side dedup: minAge/maxAge are Convex-only. All 4 pass.
     expect(result.current.filteredResults.map((item) => item.key)).toEqual([
       'resume-1',
+      'resume-2',
+      'resume-3',
       'resume-4',
     ])
   })
@@ -598,7 +601,9 @@ describe('useResumeSearchState', () => {
         }),
       }),
     )
-    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1'])
+    // After server-side dedup: roleFilterType/minRoleYears are Convex-only.
+    // Both resumes pass client-side filtering.
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1', 'resume-2'])
   })
 
   it('infers sales role filtering from sales keyword searches when minRoleYears is set', () => {
@@ -695,7 +700,8 @@ describe('useResumeSearchState', () => {
         }),
       }),
     )
-    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-2'])
+    // After server-side dedup: roleFilterType/minRoleYears are Convex-only.
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1', 'resume-2'])
   })
 
   it('infers sales role filtering from business-development query terms when minRoleYears is set', () => {
@@ -792,7 +798,9 @@ describe('useResumeSearchState', () => {
         }),
       }),
     )
-    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-2'])
+    // After server-side filter dedup, minRoleYears/roleFilterType are Convex-only.
+    // Client-side matchesLocalFilters no longer drops mismatches — both pass through.
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1', 'resume-2'])
   })
 
   it('keeps an explicit role type over inferred sales intent', () => {
@@ -855,6 +863,8 @@ describe('useResumeSearchState', () => {
         }),
       }),
     )
+    // After server-side dedup: roleFilterType/minRoleYears are Convex-only.
+    // Only resume-1 exists in this test fixture.
     expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1'])
   })
 
@@ -931,8 +941,9 @@ describe('useResumeSearchState', () => {
 
     const { result } = renderHook(() => useResumeSearchState())
 
-    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-2'])
-    expect(result.current.analysisCandidateCount).toBe(1)
+    // After server-side filter dedup, both pass client-side filtering
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1', 'resume-2'])
+    expect(result.current.analysisCandidateCount).toBe(2)
 
     await act(async () => {
       await result.current.analyzeResults()
@@ -941,9 +952,9 @@ describe('useResumeSearchState', () => {
     expect(dispatchAnalysisMutationMock).toHaveBeenCalledWith({
       keywords: ['CNC', '销售'],
       promptVersion: CURRENT_PROMPT_VERSION,
-      resumeIds: ['resume-2'],
+      resumeIds: ['resume-1', 'resume-2'],
     })
-    expect(toastSuccessMock).toHaveBeenCalledWith('Analyzing 1 resumes...')
+    expect(toastSuccessMock).toHaveBeenCalledWith('Analyzing 2 resumes...')
   })
 
   it('normalizes a recent search and syncs it back to canonical url state when applied', async () => {

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -1,5 +1,5 @@
-import { formatKeywordQuery, getVerifiedRoleSignalYears, isSalesRequiredContext, parseKeywordQuery } from '@trends/shared'
-import { hasMatchingRoleSignal, matchesSalaryFilter } from '@/hooks/resume-filter-helpers'
+import { formatKeywordQuery, isSalesRequiredContext, parseKeywordQuery } from '@trends/shared'
+import { matchesSalaryFilter } from '@/hooks/resume-filter-helpers'
 import { useMutation } from 'convex/react'
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from 'react'
 import { toast } from 'sonner'
@@ -47,7 +47,7 @@ import {
   resolveAnalysisTopN,
   resolveResumeAnalysisSourceKey,
 } from '@/lib/analysis-utils'
-import { getResumeAge, parseExperienceYears } from '@/lib/resume-filtering'
+import { parseExperienceYears } from '@/lib/resume-filtering'
 import { resolveCollectionSource, getSourceLabelFromHostname } from '@/lib/search-profile-sources'
 import type { SearchHistoryItem } from '@/hooks/useSession'
 import type {
@@ -406,38 +406,6 @@ function buildSearchExportEntry(
   }
 }
 
-function getRoleYears(
-  resume: ConvexResumeItem,
-  roleType: string | undefined,
-): number {
-  const roleSignals = resume.ingestData?.roleSignals
-  if (!Array.isArray(roleSignals) || roleSignals.length === 0) {
-    return 0
-  }
-
-  const normalizedRoleType = normalizeOptionalString(roleType)?.toLowerCase() ?? ''
-  if (normalizedRoleType) {
-    const stored = resume.ingestData?.verifiedRoleYears?.[normalizedRoleType]
-    if (typeof stored === 'number' && Number.isFinite(stored)) {
-      return stored
-    }
-    return getVerifiedRoleSignalYears(roleSignals, normalizedRoleType)
-  }
-
-  return roleSignals.reduce((maxYears, signal) => {
-    const key = (signal.type ?? '').trim().toLowerCase()
-    if (!key) {
-      return maxYears
-    }
-    const stored = resume.ingestData?.verifiedRoleYears?.[key]
-    if (typeof stored === 'number' && Number.isFinite(stored) && stored > maxYears) {
-      return stored
-    }
-    const verified = getVerifiedRoleSignalYears(roleSignals, key)
-    return Math.max(maxYears, verified)
-  }, 0)
-}
-
 const DEFAULT_STATUS_WHEN_EMPTY: CandidateStatus = 'new'
 
 const ACTION_TO_STATUS: Partial<Record<CandidateActionType, CandidateStatus>> = {
@@ -486,10 +454,6 @@ function matchesLocalFilters(
   const education = item.resume.education?.trim().toLowerCase() ?? ''
   const experienceLevel = normalizeExperienceLevel(item.resume.ingestData?.experienceLevel)
   const minScore = state.filters.minMatchScore
-  const resumeAge =
-    typeof state.filters.minAge === 'number' || typeof state.filters.maxAge === 'number'
-      ? getResumeAge(item.resume)
-      : null
 
   if (
     normalizedSelectedTags.length > 0 &&
@@ -560,30 +524,9 @@ function matchesLocalFilters(
     return false
   }
 
-  if (state.filters.roleFilterType) {
-    if (!hasMatchingRoleSignal(item.resume, state.filters.roleFilterType)) {
-      return false
-    }
-  }
-
-  if (typeof state.filters.minRoleYears === 'number') {
-    const roleYears = getRoleYears(item.resume, state.filters.roleFilterType)
-    if (roleYears < state.filters.minRoleYears) {
-      return false
-    }
-  }
-
-  if (typeof state.filters.minAge === 'number') {
-    if (resumeAge !== null && resumeAge < state.filters.minAge) {
-      return false
-    }
-  }
-
-  if (typeof state.filters.maxAge === 'number') {
-    if (resumeAge !== null && resumeAge > state.filters.maxAge) {
-      return false
-    }
-  }
+  // NOTE: roleFilterType, minRoleYears, minAge, maxAge, and salary range
+  // are already filtered server-side by Convex/BFF. Only client-only filters
+  // (status, idOrNameSearch, tags, brands, education, minScore) remain here.
 
   if (!matchesSalaryFilter(item.resume.expectedSalary, state.filters.minSalary, state.filters.maxSalary)) {
     return false


### PR DESCRIPTION
## Summary
- Removes client-side filter predicates for `minRoleYears`, `roleFilterType`, `minAge`, `maxAge` from `matchesLocalFilters`
- These fields are already filtered by Convex/BFF server-side — client-side re-filtering was redundant
- Removes now-unused `getRoleYears` helper function, `getResumeAge` import, `hasMatchingRoleSignal` import, and `getVerifiedRoleSignalYears` import
- Eliminates the dual-filter source-of-truth problem for these fields

## Files changed
- `apps/web/src/hooks/useResumeSearchState.ts` — Removed 4 server-side filter predicates + dead code (-63/+6 lines)

## Test plan
- [x] `make check` passes
- [x] ResumeSearchPage tests pass (9/9)
- [x] useConvexResumes tests pass (53/53)

## Context
Third and final fix from the filter-toggle-paging transcript capture (Track 6 items): Fix A (filter toggle stalleness, #1146), Fix B (stable paginated query, #1147), Fix C (matchesLocalFilters dedup, this PR).