### PR TITLE
fix: make legacy search profile adoption permanent

### DIFF
--- a/apps/api/src/routes/search-profiles.test.ts
+++ b/apps/api/src/routes/search-profiles.test.ts
@@ -143,7 +143,7 @@ describe("search-profiles legacy adoption", () => {
         expect((profilePayload.templateHash as string).length).toBeGreaterThan(0);
     });
 
-    it("skips legacy unstamped profiles when SEARCH_PROFILES_RESEED_ON_DRIFT is not set", async () => {
+    it("adopts legacy unstamped profiles unconditionally (no flag required)", async () => {
         delete process.env.SEARCH_PROFILES_RESEED_ON_DRIFT;
 
         const legacyConvexRecord = {
@@ -181,6 +181,20 @@ describe("search-profiles legacy adoption", () => {
             if (call.pathName === "search_profiles:list") {
                 return convexSuccess([legacyConvexRecord]);
             }
+            if (call.pathName === "search_profiles:update") {
+                // Return a valid record that toSearchProfile can parse
+                return convexSuccess({
+                    _id: "storage-id-1",
+                    profileId: "test-legacy-profile",
+                    name: "Test Legacy Profile",
+                    profile: {
+                        id: "test-legacy-profile",
+                        seedSource: "config/search-profiles",
+                        filters: { minRoleYears: 1, roleFilterType: "sales" },
+                    },
+                    criteria: { keywords: ["CNC", "Sales"], locations: ["China"] },
+                });
+            }
             throw new Error(`Unexpected convex path: ${call.pathName}`);
         });
 
@@ -191,9 +205,12 @@ describe("search-profiles legacy adoption", () => {
 
         expect(response.status).toBe(200);
 
-        // No update mutation should be called
+        // Legacy profiles are always adopted — no flag required
         const updateCalls = calls.filter((c) => c.pathName === "search_profiles:update");
-        expect(updateCalls).toHaveLength(0);
+        expect(updateCalls).toHaveLength(1);
+        const profilePayload = updateCalls[0]!.args.profile as Record<string, unknown>;
+        expect(profilePayload.seedSource).toBe("config/search-profiles");
+        expect(typeof profilePayload.templateHash).toBe("string");
     });
 
     it("does not adopt already-stamped profiles (normal drift path)", async () => {

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -544,15 +544,9 @@ async function ensureWorkspaceSeedProfiles(workspaceSlug: string): Promise<void>
             && existing.logicalId === logicalId;
 
         if (isLegacyUnstamped) {
-            if (!reseedOnDrift) {
-                logger.warn(
-                    `legacy unstamped profile "${logicalId}" (workspace=${workspaceSlug}) detected; ` +
-                    `set SEARCH_PROFILES_RESEED_ON_DRIFT=true to adopt and stamp from YAML automatically.`,
-                    { route: "search-profiles" },
-                );
-                continue;
-            }
-
+            // Always adopt — legacy unstamped profiles were auto-seeded from config
+            // before the stamping mechanism was added. They have no user edits to
+            // protect, so it's safe to refresh from YAML unconditionally.
             const refreshedProfile = searchProfileService.normalizeProfileInput(
                 { ...profile, id: existing.profile.id },
                 existing.profile,
@@ -569,6 +563,29 @@ async function ensureWorkspaceSeedProfiles(workspaceSlug: string): Promise<void>
             logger.warn(
                 `adopted legacy profile "${logicalId}" (workspace=${workspaceSlug}): ` +
                 `stamped seedSource + templateHash, refreshed filters from YAML.`,
+                { route: "search-profiles" },
+            );
+            continue;
+        }
+
+        // Half-stamped fix: seeded profile with seedSource but no templateHash.
+        // This happens when a profile was PUT via the API editor (which stamps
+        // seedSource) before the templateHash field was added to the PUT path.
+        // Always safe to stamp — no user edits are clobbered.
+        const isHalfStamped = existing.seededFromConfig
+            && !existing.templateHash;
+
+        if (isHalfStamped) {
+            await updateCustomProfile(
+                existing.storageId,
+                toStoredProfilePayload(existing.profile, {
+                    seededFromConfig: true,
+                    templateHash: currentHash,
+                }),
+                workspaceSlug,
+            );
+            logger.warn(
+                `stamped missing templateHash on half-stamped profile "${logicalId}" (workspace=${workspaceSlug}).`,
                 { route: "search-profiles" },
             );
             continue;


### PR DESCRIPTION
## Summary
- Legacy unstamped search profiles (no `seedSource`/`templateHash`) are now always adopted from YAML on API startup — no `SEARCH_PROFILES_RESEED_ON_DRIFT` flag required
- Adds half-stamped fix: profiles with `seedSource` but missing `templateHash` get stamped automatically
- This permanently fixes the recurring Quick Start chip URL regression where stale `minExperience` filters persisted after prod restores

## Root cause
The `ensureWorkspaceSeedProfiles` code path required `SEARCH_PROFILES_RESEED_ON_DRIFT=true` to adopt legacy profiles. But this flag was only in `.env.example` (not `.env`), so after every `make local-restore-from-prod` or preview restore, the stale `minExperience` filters persisted and chips generated wrong URLs like `?minExp=1` instead of `?minRoleYears=1&roleType=sales`.

## Changes
- `apps/api/src/routes/search-profiles.ts`: Legacy adoption is now unconditional; added half-stamped templateHash fix
- `apps/api/src/routes/search-profiles.test.ts`: Updated test expectations for new behavior

## Test plan
- [x] All 3 search-profiles tests pass
- [x] Verified via `/playwright-cli` that both Quick Start chips generate correct URLs
- [x] Verified Convex state shows all 4 profiles fully stamped (seedSource + templateHash)
- [ ] Preview redeploy to verify on ptcloud