### PR TITLE
fix: add requireAdmin auth gating to resumes_packets and search_profiles routes

### DIFF
--- a/apps/api/src/routes/__tests__/resumes-packets-route.test.ts
+++ b/apps/api/src/routes/__tests__/resumes-packets-route.test.ts
@@ -119,7 +119,7 @@ describe("resumes packets route", () => {
     const app = createApp();
 
     const response = await app.request("/api/resumes/review-packets", {
-      headers: { "X-Workspace-Slug": "hr" },
+      headers: { "X-Workspace-Slug": "dev" },
     });
 
     expect(response.status).toBe(200);
@@ -135,7 +135,7 @@ describe("resumes packets route", () => {
     const storage = new ReviewPacketStorage(root);
     storage.createRun({
       id: "run-1",
-      workspaceSlug: "hr",
+      workspaceSlug: "dev",
       source: "convex",
       format: "csv",
       totalCount: 2,
@@ -143,7 +143,7 @@ describe("resumes packets route", () => {
     });
     storage.createRun({
       id: "run-2",
-      workspaceSlug: "hr",
+      workspaceSlug: "dev",
       source: "convex",
       format: "xlsx",
       totalCount: 1,
@@ -152,7 +152,7 @@ describe("resumes packets route", () => {
 
     const app = createApp();
     const response = await app.request("/api/resumes/review-packets", {
-      headers: { "X-Workspace-Slug": "hr" },
+      headers: { "X-Workspace-Slug": "dev" },
     });
 
     expect(response.status).toBe(200);
@@ -169,13 +169,13 @@ describe("resumes packets route", () => {
     const { createApp, ReviewPacketStorage } = await loadModules(root);
 
     const storage = new ReviewPacketStorage(root);
-    storage.createRun({ id: "run-lim-1", workspaceSlug: "hr", source: "convex", format: "csv", totalCount: 1, items: [] });
-    storage.createRun({ id: "run-lim-2", workspaceSlug: "hr", source: "convex", format: "csv", totalCount: 1, items: [] });
-    storage.createRun({ id: "run-lim-3", workspaceSlug: "hr", source: "convex", format: "csv", totalCount: 1, items: [] });
+    storage.createRun({ id: "run-lim-1", workspaceSlug: "dev", source: "convex", format: "csv", totalCount: 1, items: [] });
+    storage.createRun({ id: "run-lim-2", workspaceSlug: "dev", source: "convex", format: "csv", totalCount: 1, items: [] });
+    storage.createRun({ id: "run-lim-3", workspaceSlug: "dev", source: "convex", format: "csv", totalCount: 1, items: [] });
 
     const app = createApp();
     const response = await app.request("/api/resumes/review-packets?limit=2", {
-      headers: { "X-Workspace-Slug": "hr" },
+      headers: { "X-Workspace-Slug": "dev" },
     });
 
     expect(response.status).toBe(200);
@@ -195,7 +195,7 @@ describe("resumes packets route", () => {
     const storage = new ReviewPacketStorage(root);
     storage.createRun({
       id: "my-run",
-      workspaceSlug: "hr",
+      workspaceSlug: "dev",
       source: "convex",
       format: "xlsx",
       totalCount: 3,
@@ -205,7 +205,7 @@ describe("resumes packets route", () => {
 
     const app = createApp();
     const response = await app.request("/api/resumes/review-packets/my-run", {
-      headers: { "X-Workspace-Slug": "hr" },
+      headers: { "X-Workspace-Slug": "dev" },
     });
 
     expect(response.status).toBe(200);
@@ -222,7 +222,7 @@ describe("resumes packets route", () => {
     const app = createApp();
 
     const response = await app.request("/api/resumes/review-packets/nonexistent", {
-      headers: { "X-Workspace-Slug": "hr" },
+      headers: { "X-Workspace-Slug": "dev" },
     });
 
     expect(response.status).toBe(404);
@@ -242,7 +242,7 @@ describe("resumes packets route", () => {
     const storage = new ReviewPacketStorage(root);
     storage.createRun({
       id: "csv-run",
-      workspaceSlug: "hr",
+      workspaceSlug: "dev",
       source: "convex",
       format: "csv",
       totalCount: 1,
@@ -255,7 +255,7 @@ describe("resumes packets route", () => {
     fs.writeFileSync(path.join(packetDir, "review-packet-csv-run.csv"), "Resume ID,Name\nr1,Alice\n", "utf8");
 
     const app = createApp();
-    const response = await app.request("/api/resumes/review-packets/csv-run/download?workspaceSlug=hr");
+    const response = await app.request("/api/resumes/review-packets/csv-run/download?workspaceSlug=dev");
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("text/csv; charset=utf-8");
@@ -275,7 +275,7 @@ describe("resumes packets route", () => {
     const storage = new ReviewPacketStorage(root);
     storage.createRun({
       id: "xlsx-run",
-      workspaceSlug: "hr",
+      workspaceSlug: "dev",
       source: "convex",
       format: "xlsx",
       totalCount: 1,
@@ -288,7 +288,7 @@ describe("resumes packets route", () => {
     fs.writeFileSync(path.join(packetDir, "review-packet-xlsx-run.xlsx"), "fake-xlsx-content");
 
     const app = createApp();
-    const response = await app.request("/api/resumes/review-packets/xlsx-run/download?workspaceSlug=hr");
+    const response = await app.request("/api/resumes/review-packets/xlsx-run/download?workspaceSlug=dev");
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe(
@@ -304,7 +304,7 @@ describe("resumes packets route", () => {
     const { createApp } = await loadModules(root);
     const app = createApp();
 
-    const response = await app.request("/api/resumes/review-packets/nonexistent/download?workspaceSlug=hr");
+    const response = await app.request("/api/resumes/review-packets/nonexistent/download?workspaceSlug=dev");
 
     expect(response.status).toBe(404);
     const payload = await response.json() as { success: boolean; error: string };
@@ -319,7 +319,7 @@ describe("resumes packets route", () => {
     const storage = new ReviewPacketStorage(root);
     storage.createRun({
       id: "missing-file",
-      workspaceSlug: "hr",
+      workspaceSlug: "dev",
       source: "convex",
       format: "csv",
       totalCount: 1,
@@ -327,7 +327,7 @@ describe("resumes packets route", () => {
     });
 
     const app = createApp();
-    const response = await app.request("/api/resumes/review-packets/missing-file/download?workspaceSlug=hr");
+    const response = await app.request("/api/resumes/review-packets/missing-file/download?workspaceSlug=dev");
 
     expect(response.status).toBe(404);
     const payload = await response.json() as { success: boolean; error: string };
@@ -346,7 +346,7 @@ describe("resumes packets route", () => {
     const storage = new ReviewPacketStorage(root);
     storage.createRun({
       id: "fb-no-file",
-      workspaceSlug: "hr",
+      workspaceSlug: "dev",
       source: "convex",
       format: "csv",
       totalCount: 1,
@@ -358,7 +358,7 @@ describe("resumes packets route", () => {
     const app = createApp();
     const response = await app.request("/api/resumes/review-packets/fb-no-file/feedback-import", {
       method: "POST",
-      headers: { "X-Workspace-Slug": "hr" },
+      headers: { "X-Workspace-Slug": "dev" },
       body: formData,
     });
 
@@ -375,7 +375,7 @@ describe("resumes packets route", () => {
     const app = createApp();
     const response = await app.request("/api/resumes/review-packets/nonexistent-fb/feedback-import", {
       method: "POST",
-      headers: { "X-Workspace-Slug": "hr" },
+      headers: { "X-Workspace-Slug": "dev" },
       body: formData,
     });
 
@@ -398,7 +398,7 @@ describe("resumes packets route", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Workspace-Slug": "hr",
+        "X-Workspace-Slug": "dev",
       },
       body: JSON.stringify({}),
     });
@@ -422,7 +422,7 @@ describe("resumes packets route", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Workspace-Slug": "hr",
+        "X-Workspace-Slug": "dev",
       },
       body: JSON.stringify({ observation: "Test observation" }),
     });
@@ -456,7 +456,7 @@ describe("resumes packets route", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Workspace-Slug": "hr",
+        "X-Workspace-Slug": "dev",
       },
       body: JSON.stringify({ observation: "synonym_suggestion: fenc -> fanuc" }),
     });
@@ -516,7 +516,7 @@ describe("resumes packets route", () => {
     const app = createApp();
     const response = await app.request("/api/resumes/export/download", {
       method: "POST",
-      headers: { "X-Workspace-Slug": "hr" },
+      headers: { "X-Workspace-Slug": "dev" },
       body: formData,
     });
 

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -1228,11 +1228,15 @@ const getExportFieldsRoute = createRoute({
   summary: "Get export fields configuration",
   responses: {
     200: { description: "Export fields config", content: { "application/json": { schema: ExportFieldsConfigResponseSchema } } },
+    403: { description: "Admin access required", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
   },
 });
 
 app.openapi(getExportFieldsRoute, async (c) => {
+  if (denyIfNotAdmin(c.var.accessLevel)) {
+    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  }
   try {
     const config = await workspaceConfigService.getExportFieldsConfig(c.var.workspaceSlug);
     return c.json({ success: true as const, config }, 200);

--- a/apps/api/src/routes/resumes_packets.ts
+++ b/apps/api/src/routes/resumes_packets.ts
@@ -21,6 +21,7 @@ import {
   SimpleErrorSchema,
 } from "../schemas/index.js";
 import { logger } from "../services/logger.js";
+import { requireAdmin } from "../middleware/workspace.js";
 import { config } from "../services/config.js";
 import { ResumeService } from "../services/resume-service.js";
 import { DataNotFoundError } from "../services/errors.js";
@@ -65,6 +66,11 @@ import {
 } from "./resumes-packets-helpers.js";
 
 const app = new OpenAPIHono();
+app.use("/api/resumes/export", requireAdmin);
+app.use("/api/resumes/export/*", requireAdmin);
+app.use("/api/resumes/review-packets", requireAdmin);
+app.use("/api/resumes/review-packets/*", requireAdmin);
+app.use("/api/resumes/learning-feedback", requireAdmin);
 const skillsKnowledgeService = new SkillsKnowledgeService(config.projectRoot);
 const companyPatterns = skillsKnowledgeService.getCompanyPatterns();
 const exportService = new ExportService(

--- a/apps/api/src/routes/review-packets.test.ts
+++ b/apps/api/src/routes/review-packets.test.ts
@@ -122,7 +122,7 @@ describe("review packet routes", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Workspace-Slug": "hr",
+        "X-Workspace-Slug": "dev",
       },
       body: JSON.stringify({
         format: "csv",
@@ -147,10 +147,10 @@ describe("review packet routes", () => {
     expect(payload.run.jobDescriptionId).toBe("lathe-sales");
 
     const storage = new ReviewPacketStorage(root);
-    const stored = storage.getRun(payload.run.id, "hr");
+    const stored = storage.getRun(payload.run.id, "dev");
     expect(stored?.items.map((item) => item.resumeId)).toEqual(["resume-b", "resume-a"]);
 
-    const download = await app.request(`${payload.downloadPath}?workspaceSlug=hr`);
+    const download = await app.request(`${payload.downloadPath}?workspaceSlug=dev`);
     expect(download.status).toBe(200);
     const parsed = Papa.parse<Record<string, string>>(await download.text(), { header: true });
     expect(parsed.meta.fields).toContain("Resume ID");
@@ -168,7 +168,7 @@ describe("review packet routes", () => {
     const storage = new ReviewPacketStorage(root);
     storage.createRun({
       id: "packet-import",
-      workspaceSlug: "hr",
+      workspaceSlug: "dev",
       source: "convex",
       format: "xlsx",
       totalCount: 1,
@@ -210,7 +210,7 @@ describe("review packet routes", () => {
     const response = await app.request("/api/resumes/review-packets/packet-import/feedback-import", {
       method: "POST",
       headers: {
-        "X-Workspace-Slug": "hr",
+        "X-Workspace-Slug": "dev",
       },
       body: formData,
     });
@@ -230,7 +230,7 @@ describe("review packet routes", () => {
     expect(calls[0]).toMatchObject({
       pathName: "candidate_status:upsert",
       args: {
-        workspaceSlug: "hr",
+        workspaceSlug: "dev",
         identityKey: "profileUrl:my.employer.seek.com/candidates/503033454",
         status: "interviewed_pass",
         notes: "Strong manager fit",
@@ -256,7 +256,7 @@ describe("review packet routes", () => {
     const storage = new ReviewPacketStorage(root);
     storage.createRun({
       id: "packet-summary",
-      workspaceSlug: "hr",
+      workspaceSlug: "dev",
       source: "convex",
       format: "xlsx",
       totalCount: 2,
@@ -324,7 +324,7 @@ describe("review packet routes", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Workspace-Slug": "hr",
+        "X-Workspace-Slug": "dev",
       },
       body: JSON.stringify({}),
     });
@@ -345,7 +345,7 @@ describe("review packet routes", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Workspace-Slug": "hr",
+        "X-Workspace-Slug": "dev",
       },
       body: JSON.stringify({}),
     });

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -23,11 +23,14 @@ import {
     type SearchProfile,
 } from "../services/search-profile-service.js";
 import { logger } from "../services/logger.js";
+import { requireAdmin } from "../middleware/workspace.js";
 import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
 import { resolveConvexUrl } from "../services/resume-import-service.js";
 import { readString, readNumber } from "../services/workspace-config-service.js";
 
 const app = new OpenAPIHono();
+app.use("/api/search-profiles", requireAdmin);
+app.use("/api/search-profiles/*", requireAdmin);
 
 // Schemas
 const ProfileSummarySchema = z.object({

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -9357,6 +9357,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Admin access required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Server error */
                 500: {
                     headers: {


### PR DESCRIPTION
## Summary

- Gate all 10 routes in `resumes_packets.ts` (export, review-packets, learning-feedback) with `requireAdmin`
- Gate all 10 routes in `search-profiles.ts` (CRUD, run, auto-match, stats) with `requireAdmin`
- Add `denyIfNotAdmin` to GET `/api/config/export-fields` (PUT was already gated in PR #1118)
- Add 403 response type to OpenAPI spec for export-fields endpoint

## Background

Track 1 of the v0.3.0 release plan identified 40/55 routes across 5 audited files with NO auth middleware. This PR addresses 20 routes in 2 files (the most exposed: PII export, review packets, learning feedback, profile management). The remaining 8 routes in `resumes.ts` and `candidate-status.ts` require new middleware (`requireWorkspaceAccess`, `requireCandidateSession`) and will be addressed in a follow-up PR.

## Test plan

- [x] All 5199 tests pass (271 test files)
- [x] TypeScript typecheck passes
- [x] `resumes_packets.test.ts` updated to use dev workspace (admin access)
- [x] `review-packets.test.ts` updated to use dev workspace (admin access)
- [x] `search-profiles.test.ts` passes (already used dev workspace)
- [x] `blocks.test.ts` passes (ungated route, not affected)