### PR TITLE
fix: gate resumes_diagnostics routes + wire check-route-auth into make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1101,7 +1101,7 @@ fresh-env: clean clean-db
 	@echo "Fresh environment ready."
 
 # Run all validation checks (Python + Node.js + project skill sync + governance skill validation; honors TARGET=all)
-check: check-python check-node check-project-skills check-agent-policy check-agent-skill check-concept-drift
+check: check-python check-node check-project-skills check-agent-policy check-agent-skill check-concept-drift check-route-auth
 	@echo "All checks passed"
 
 # Auth gating lint — verify API route files have auth middleware

--- a/apps/api/src/routes/resumes_diagnostics.test.ts
+++ b/apps/api/src/routes/resumes_diagnostics.test.ts
@@ -195,4 +195,15 @@ describe("resumes_diagnostics", () => {
       expect(calls[0].path).toBe("resumes_diagnostics:listArchivedDiagnostics");
     });
   });
+
+  describe("workspace access control", () => {
+    it("rejects non-admin workspace with 403", async () => {
+      const app = createTestApp();
+      const response = await app.request("/api/resumes/analysis-tasks", {
+        headers: { "X-Workspace-Slug": "hr" },
+      });
+
+      expect(response.status).toBe(403);
+    });
+  });
 });

--- a/apps/api/src/routes/resumes_diagnostics.ts
+++ b/apps/api/src/routes/resumes_diagnostics.ts
@@ -9,8 +9,13 @@ import {
   ResumeDiagnosticsQuerySchema,
   ResumeDiagnosticsResponseSchema,
 } from "../schemas/index.js";
+import { requireAdmin } from "../middleware/workspace.js";
 
 const app = new OpenAPIHono();
+app.use("/api/resumes/analysis-tasks", requireAdmin);
+app.use("/api/resumes/skills-version", requireAdmin);
+app.use("/api/resumes/field-coverage", requireAdmin);
+app.use("/api/resumes/diagnostics", requireAdmin);
 const skillsKnowledgeService = new SkillsKnowledgeService(config.projectRoot);
 
 const SimpleErrorSchema = z.object({ success: z.literal(false), error: z.string() });

--- a/scripts/check-route-auth.sh
+++ b/scripts/check-route-auth.sh
@@ -26,9 +26,8 @@ SKIP_FILES=(
   "sessions.ts"
   "actions.ts"
   "web-vitals.ts"
-  # Resume search/match/diagnostics (workspace-scoped read paths)
+  # Resume search/match (workspace-scoped read paths)
   "resumes_search.ts"
-  "resumes_diagnostics.ts"
   "resumes_match.ts"
   # Public submission endpoints (browser extension, candidate-facing)
   "resume-submit.ts"
@@ -39,8 +38,6 @@ SKIP_FILES=(
   # Internal worker endpoints (own auth via WORKER_SECRET)
   "worker.ts"
   "blocks.ts"
-  # TODO: remove after PR #1152 merges (adds requireAdmin to list + update routes)
-  "candidate-status.ts"
 )
 
 is_skipped() {


### PR DESCRIPTION
## Summary
- Adds `requireAdmin` middleware to all 4 routes in `resumes_diagnostics.ts` (analysis-tasks, skills-version, field-coverage, diagnostics) — closes Gap 9 from v0.3.0 release plan
- Adds 403 rejection test for non-admin workspace access
- Removes `candidate-status.ts` and `resumes_diagnostics.ts` from `check-route-auth` skip list (both now have auth gating)
- Wires `check-route-auth` into `make check` target — new route files must have auth or be in the skip list

## Test plan
- [x] `npx vitest run apps/api/src/routes/resumes_diagnostics.test.ts` — 8/8 pass
- [x] `bash scripts/check-route-auth.sh` — OK
- [x] `make check` — all checks passed