### PR TITLE
fix: use correct i18n key path for status filter chips in BulkActionBar

### DIFF
--- a/apps/web/src/components/BulkActionBar.tsx
+++ b/apps/web/src/components/BulkActionBar.tsx
@@ -126,7 +126,7 @@ export function BulkActionBar({
                                         : 'border-border text-muted-foreground hover:bg-muted',
                                 )}
                             >
-                                {t(`status.${status}`, status)}
+                                {t(`resumes.status.options.${status}`, status)}
                                 {typeof count === 'number' && count > 0 && (
                                     <span className="ml-1 opacity-70">{count}</span>
                                 )}


### PR DESCRIPTION
## Summary
- Fix i18n key path for status filter chip labels in `BulkActionBar.tsx`
- Changed `status.${status}` → `resumes.status.options.${status}` to match locale file structure
- Eliminates `missingKey` console warnings and shows proper translated labels ("New candidate", "Shortlisted", "Rejected")

## Test plan
- [x] Verified 0 missingKey console warnings after fix
- [x] Status chips display correct translated labels on `/resumes` page
- [x] Both China CNC Sales profiles produce correct filter URLs with all params