### PR TITLE
fix: remove incorrect minExperience→minRoleYears mapping in JD hydration

### DIFF
--- a/apps/web/src/components/SearchProfileEditorDialog.test.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.test.tsx
@@ -233,7 +233,7 @@ describe('SearchProfileEditorDialog JD hydration', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('地区:')).toHaveValue('广东,江苏')
       expect(screen.getByLabelText('关键词:')).toHaveValue('车床 销售')
-      expect(screen.getByLabelText('Relevant Experience (yrs)')).toHaveValue(2)
+      expect(screen.getByLabelText('Relevant Experience (yrs)')).toHaveValue(1)
       expect(screen.getByLabelText('Max Exp (yrs)')).toHaveValue(5)
       expect(screen.getByLabelText('最低年龄')).toHaveValue(25)
       expect(screen.getByLabelText('最高年龄')).toHaveValue(38)

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -505,13 +505,10 @@ export function SearchProfileEditorDialog({
                 selectedConvexJobDescription.title
             )
             const location = toLocationText(undefined, selectedConvexJobDescriptionDetail?.location)
-            const minExperience = selectedConvexJobDescriptionDetail?.minExperience
-
             setForm((previous) => ({
                 ...previous,
                 location: location ?? previous.location,
                 keywordsText,
-                minRoleYears: typeof minExperience === 'number' ? String(minExperience) : DEFAULT_FORM.minRoleYears,
                 maxExperience: toNumericText(selectedConvexJobDescriptionDetail?.maxExperience),
                 minAge: toNumericText(selectedConvexJobDescriptionDetail?.minAge),
                 maxAge: toNumericText(selectedConvexJobDescriptionDetail?.maxAge),
@@ -541,7 +538,7 @@ export function SearchProfileEditorDialog({
                 const location = toLocationText(undefined, item.location)
                 const minRoleYears = typeof item.requiredRoles?.[0]?.min_years === 'number'
                     ? item.requiredRoles[0].min_years
-                    : suggestedFilters?.minExperience
+                    : undefined
 
                 setForm((previous) => ({
                     ...previous,


### PR DESCRIPTION
## Summary
- JD minExperience (total career years) was incorrectly mapped to minRoleYears (role-specific years) during form hydration
- Convex JD hydration: minRoleYears no longer overwritten by minExperience; keeps current value or default (1)
- System JD hydration: only requiredRoles[0].min_years (genuinely role-specific) maps to minRoleYears
- Follow-up advisory fix from PR #1161

## Test plan
- [x] make check passes
- [x] SearchProfileEditorDialog.test.tsx — 9/9 pass