### PR TITLE
fix: extend JSON validator chain from 4 to 6 levels for deep ingestData nesting

### DIFF
--- a/packages/convex/convex/validators.ts
+++ b/packages/convex/convex/validators.ts
@@ -204,12 +204,14 @@ const jsonL1 = v.union(jsonPrimitive, v.array(jsonPrimitive), v.record(v.string(
 const jsonL2 = v.union(jsonPrimitive, v.array(jsonL1), v.record(v.string(), jsonL1));
 const jsonL3 = v.union(jsonPrimitive, v.array(jsonL2), v.record(v.string(), jsonL2));
 const jsonL4 = v.union(jsonPrimitive, v.array(jsonL3), v.record(v.string(), jsonL3));
+const jsonL5 = v.union(jsonPrimitive, v.array(jsonL4), v.record(v.string(), jsonL4));
+const jsonL6 = v.union(jsonPrimitive, v.array(jsonL5), v.record(v.string(), jsonL5));
 
-/** Accepts any JSON-safe value up to 4 levels of nesting (string|number|boolean|null leaves). */
-export const jsonValueValidator = v.union(jsonPrimitive, v.array(jsonL4), v.record(v.string(), jsonL4));
+/** Accepts any JSON-safe value up to 6 levels of nesting (string|number|boolean|null leaves). */
+export const jsonValueValidator = v.union(jsonPrimitive, v.array(jsonL6), v.record(v.string(), jsonL6));
 
 /** Accepts a record<string, JSON> — for content, profile, and similar semi-structured fields. */
-export const jsonRecordValidator = v.record(v.string(), jsonL4);
+export const jsonRecordValidator = v.record(v.string(), jsonL6);
 
 // --- Matching rules (analyze args) ---
 


### PR DESCRIPTION
## Summary
- Extend `jsonRecordValidator` and `jsonValueValidator` in `packages/convex/convex/validators.ts` from `jsonL4` (4 levels) to `jsonL6` (6 levels)
- Fixes Convex schema validation failure when restoring prod data backups where `ingestData` inside `content` has deeply nested structures (`roleSignals[].matchedWorkEntries[].matchedSignals[]`)

## Root cause
`content` field on the `resumes` table uses `jsonRecordValidator` which chains JSON depth to `jsonL4`. After ingest migrations populate `ingestData` inside `content`, the actual data reaches 6 levels of nesting. Convex rejects these documents during schema validation.

## Test plan
- [x] `make check` passes (typecheck + lint + governance)
- [ ] Migration test: `scripts/migration-test-run.sh` Phase 2 should no longer fail on schema validation