### PR TITLE
fix: extend JSON validator chain to jsonL8 for 7-level deep content nesting

### DIFF
--- a/packages/convex/convex/validators.ts
+++ b/packages/convex/convex/validators.ts
@@ -206,12 +206,14 @@ const jsonL3 = v.union(jsonPrimitive, v.array(jsonL2), v.record(v.string(), json
 const jsonL4 = v.union(jsonPrimitive, v.array(jsonL3), v.record(v.string(), jsonL3));
 const jsonL5 = v.union(jsonPrimitive, v.array(jsonL4), v.record(v.string(), jsonL4));
 const jsonL6 = v.union(jsonPrimitive, v.array(jsonL5), v.record(v.string(), jsonL5));
+const jsonL7 = v.union(jsonPrimitive, v.array(jsonL6), v.record(v.string(), jsonL6));
+const jsonL8 = v.union(jsonPrimitive, v.array(jsonL7), v.record(v.string(), jsonL7));
 
-/** Accepts any JSON-safe value up to 6 levels of nesting (string|number|boolean|null leaves). */
-export const jsonValueValidator = v.union(jsonPrimitive, v.array(jsonL6), v.record(v.string(), jsonL6));
+/** Accepts any JSON-safe value up to 8 levels of nesting (string|number|boolean|null leaves). */
+export const jsonValueValidator = v.union(jsonPrimitive, v.array(jsonL8), v.record(v.string(), jsonL8));
 
 /** Accepts a record<string, JSON> — for content, profile, and similar semi-structured fields. */
-export const jsonRecordValidator = v.record(v.string(), jsonL6);
+export const jsonRecordValidator = v.record(v.string(), jsonL8);
 
 // --- Matching rules (analyze args) ---
 


### PR DESCRIPTION
## Summary
- PR #1163 extended to jsonL6 but still failed — prod data has 7-level deep nesting from content.values()
- Path: content → ingestData → roleSignals[] → [0] → matchedWorkEntries[] → [0] → matchedSignals[] → [0]
- Extend chain to jsonL8 (2-level safety margin)

## Verified
- `make dev-critical` with local Convex: zero schema validation errors
- Previously: `Schema validation failed. Document ... does not match the schema. Path: .content.values()`