### PR TITLE
test: add migration validation scripts and fix dev infrastructure

### DIFF
--- a/packages/convex/convex/validators.ts
+++ b/packages/convex/convex/validators.ts
@@ -206,12 +206,13 @@ const jsonL3 = v.union(jsonPrimitive, v.array(jsonL2), v.record(v.string(), json
 const jsonL4 = v.union(jsonPrimitive, v.array(jsonL3), v.record(v.string(), jsonL3));
 const jsonL5 = v.union(jsonPrimitive, v.array(jsonL4), v.record(v.string(), jsonL4));
 const jsonL6 = v.union(jsonPrimitive, v.array(jsonL5), v.record(v.string(), jsonL5));
+const jsonL7 = v.union(jsonPrimitive, v.array(jsonL6), v.record(v.string(), jsonL6));
 
-/** Accepts any JSON-safe value up to 6 levels of nesting (string|number|boolean|null leaves). */
-export const jsonValueValidator = v.union(jsonPrimitive, v.array(jsonL6), v.record(v.string(), jsonL6));
+/** Accepts any JSON-safe value up to 7 levels of nesting (string|number|boolean|null leaves). */
+export const jsonValueValidator = v.union(jsonPrimitive, v.array(jsonL7), v.record(v.string(), jsonL7));
 
 /** Accepts a record<string, JSON> — for content, profile, and similar semi-structured fields. */
-export const jsonRecordValidator = v.record(v.string(), jsonL6);
+export const jsonRecordValidator = v.record(v.string(), jsonL7);
 
 // --- Matching rules (analyze args) ---
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -506,7 +506,7 @@ _is_known_dev_cmd() {
         *"uv run python scripts/worker.py"*)                    return 0 ;;
         *"tsx/dist/preflight"*|*"tsx/dist/loader"*)             return 0 ;;
         *"$PROJECT_ROOT/node_modules/.bin/vite"*|*"vite --port"*) return 0 ;;
-        *"uvicorn api:app"*)                                     return 0 ;;
+        *"uvicorn"*"api:app"*)                                    return 0 ;;
         *)                                                       return 1 ;;
     esac
 }
@@ -1169,9 +1169,9 @@ start_worker() {
         fi
 
         log "WORKER" "$CYAN" "Starting FastAPI worker on http://localhost:$port"
-        cd "$PROJECT_ROOT/apps/worker"
-        
-        local cmd="uv run uvicorn api:app --reload --port $port"
+        cd "$PROJECT_ROOT"
+
+        local cmd="uv run uvicorn apps.worker.api:app --reload --reload-dir apps/worker --port $port"
 
         eval "$cmd" > >(tee "$(service_log_path "worker")" | stream_service_logs "worker" "$CYAN") 2>&1 &
         SERVICE_PIDS["worker"]=$!

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -324,6 +324,12 @@ fi
 echo "Installing Python dependencies..."
 uv sync
 
+# Verify critical Python imports; reinstall if corrupted (e.g. fastmcp-slim missing modules)
+if ! "$PROJECT_ROOT/.venv/bin/python" -c "from fastmcp import FastMCP; from litellm import completion" 2>/dev/null; then
+    echo "Python environment corrupted — reinstalling..."
+    uv sync --reinstall-package fastmcp --reinstall-package litellm
+fi
+
 echo "Installing Node.js dependencies..."
 if is_ci_env; then
     npm install

--- a/scripts/migration-test-run.sh
+++ b/scripts/migration-test-run.sh
@@ -1,0 +1,275 @@
+#!/bin/bash
+# Migration test: v0.2.1 backup → v0.3.0 upgrade
+# Usage: scripts/migration-test-run.sh [PHASE]
+# PHASE: 1 = v0.2.1 restore + baseline
+#        2 = upgrade to HEAD + migrate + verify
+#        all = both phases (default)
+#
+# Prerequisites:
+#   - Backup file at output/resume-backups/resumes-prod-dev-20260512-111129.tar.gz
+#   - bun, node, npx available
+#   - Ports 3210/3211/3000/5173 free (script kills stale processes)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+BACKUP_FILE="output/resume-backups/resumes-prod-dev-20260512-111129.tar.gz"
+CONVEX_PORT=3210
+BASE_URL="http://localhost:3000"
+RESULTS_DIR="output/migration-test-results"
+PHASE="${1:-all}"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+LOG="$RESULTS_DIR/migration-test-$TIMESTAMP.log"
+ORIGINAL_BRANCH=""
+DEV_PID=""
+
+mkdir -p "$RESULTS_DIR"
+
+log() { echo "[$(date +%H:%M:%S)] $*" | tee -a "$LOG"; }
+
+cleanup() {
+    log "Cleaning up..."
+    kill_dev_ports
+    if [ -n "$ORIGINAL_BRANCH" ]; then
+        git checkout "$ORIGINAL_BRANCH" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# Kill processes listening on dev ports (Convex 3210/3211, API 3000, Vite 5173)
+kill_dev_ports() {
+    for port in 3210 3211 3000 5173; do
+        pids=$(lsof -tiTCP:$port -sTCP:LISTEN 2>/dev/null) || true
+        if [ -n "$pids" ]; then
+            log "  Killing port $port PIDs: $pids"
+            echo "$pids" | xargs kill 2>/dev/null || true
+        fi
+    done
+    sleep 3
+}
+
+wait_for_convex() {
+    local max_wait=90
+    local waited=0
+    log "Waiting for Convex at http://127.0.0.1:$CONVEX_PORT..."
+    while ! curl -fsS "http://127.0.0.1:$CONVEX_PORT/version" >/dev/null 2>&1; do
+        sleep 2
+        waited=$((waited + 2))
+        if [ $waited -ge $max_wait ]; then
+            log "ERROR: Convex not ready after ${max_wait}s"
+            return 1
+        fi
+    done
+    log "Convex ready after ${waited}s"
+}
+
+wait_for_api() {
+    local max_wait=120
+    local waited=0
+    log "Waiting for API at $BASE_URL..."
+    while ! curl -fsS "$BASE_URL/api/health" >/dev/null 2>&1 && ! curl -fsS "$BASE_URL" >/dev/null 2>&1; do
+        sleep 2
+        waited=$((waited + 2))
+        if [ $waited -ge $max_wait ]; then
+            log "ERROR: API not ready after ${max_wait}s"
+            return 1
+        fi
+    done
+    log "API ready after ${waited}s"
+}
+
+install_and_build() {
+    log "Installing dependencies..."
+    if command -v bun >/dev/null 2>&1; then
+        bun install 2>&1 | tail -5 | tee -a "$LOG"
+    else
+        npm install --legacy-peer-deps 2>&1 | tail -5 | tee -a "$LOG"
+    fi
+    # Build shared package (required before API/Convex can start)
+    if command -v bun >/dev/null 2>&1; then
+        bun run --filter '@trends/shared' build 2>&1 | tail -3 | tee -a "$LOG"
+    else
+        npm --workspace @trends/shared run build 2>&1 | tail -3 | tee -a "$LOG"
+    fi
+}
+
+run_migrations() {
+    log "Running v0.3.0 migration sequence..."
+    local migrations=(
+        backfillSourceKey
+        backfillTaggingEnvelope
+        backfillWorkspaceSlugs
+        backfillJob5156ProfileUrls
+        backfillJob5156WorkHistoryEducation
+        backfillJob5156LocationHierarchy
+        backfillManual51jobStructuredContent
+        backfillIngestData
+        backfillAge
+        backfillSearchText
+        backfillEvidenceText
+        backfillPrimaryRuleScore
+        backfillVerifiedRoleYears
+        reindexSearchText
+    )
+    for migration in "${migrations[@]}"; do
+        log "  Running: $migration"
+        result=$(npm --workspace @trends/convex exec convex run migrations:$migration '{}' 2>&1) || {
+            log "  ERROR: $migration failed: $result"
+            echo "$result" >> "$LOG"
+            return 1
+        }
+        log "  Done: $migration"
+    done
+    log "All migrations complete"
+}
+
+# === PHASE 1: v0.2.1 restore + baseline ===
+phase1() {
+    log "=== PHASE 1: v0.2.1 Restore + Baseline ==="
+
+    kill_dev_ports
+
+    # Verify backup exists
+    if [ ! -f "$BACKUP_FILE" ]; then
+        log "ERROR: Backup file not found: $BACKUP_FILE"
+        exit 1
+    fi
+    log "Backup: $BACKUP_FILE ($(du -h "$BACKUP_FILE" | cut -f1))"
+
+    # Save current branch for cleanup
+    ORIGINAL_BRANCH=$(git branch --show-current)
+
+    # Guard: dirty tree blocks checkout
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        log "ERROR: Working tree is dirty. Stash or commit changes before running migration test."
+        exit 1
+    fi
+
+    # Checkout v0.2.1
+    log "Checking out v0.2.1..."
+    git checkout v0.2.1 2>&1 | tee -a "$LOG"
+
+    install_and_build
+
+    # Start dev in background
+    log "Starting dev (v0.2.1)..."
+    SKIP_MATCH_SEED=true make dev-critical > "$RESULTS_DIR/dev-v021.log" 2>&1 &
+    DEV_PID=$!
+    log "Dev PID: $DEV_PID"
+
+    # Wait for Convex first, then API
+    wait_for_convex
+    wait_for_api
+
+    # Clear resumes before restore
+    log "Clearing existing resumes..."
+    make clear-resumes 2>&1 | tee -a "$LOG" || {
+        log "WARNING: clear-resumes failed, attempting retry..."
+        sleep 5
+        make clear-resumes 2>&1 | tee -a "$LOG"
+    }
+
+    # Restore backup
+    log "Restoring backup..."
+    make restore-resumes FILE="$BACKUP_FILE" MODE=replace YES=1 2>&1 | tee -a "$LOG"
+
+    # Wait for restore to settle
+    sleep 5
+
+    # Baseline verification
+    log "Recording baseline metrics..."
+    scripts/migration-test-verify.sh "$BASE_URL" "$RESULTS_DIR/baseline-v021-$TIMESTAMP.log"
+
+    # Save baseline count via Convex CLI (API response format varies between versions)
+    BASELINE_COUNT=$(npm --workspace @trends/convex exec convex run resumes:count '{}' 2>/dev/null || echo "error")
+    echo "$BASELINE_COUNT" > "$RESULTS_DIR/baseline-count.txt"
+    log "Baseline count: $BASELINE_COUNT"
+
+    # Stop dev
+    kill_dev_ports
+
+    log "=== PHASE 1 COMPLETE ==="
+    log "Baseline saved to $RESULTS_DIR/baseline-v021-$TIMESTAMP.log"
+}
+
+# === PHASE 2: upgrade to HEAD + migrate + verify ===
+phase2() {
+    log "=== PHASE 2: Upgrade to HEAD + Migrate + Verify ==="
+
+    kill_dev_ports
+
+    # Read baseline count
+    BASELINE_COUNT=$(cat "$RESULTS_DIR/baseline-count.txt" 2>/dev/null || echo "unknown")
+    log "Baseline count: $BASELINE_COUNT"
+
+    # Checkout HEAD
+    log "Checking out HEAD (v0.3.0)..."
+    git checkout main 2>&1 | tee -a "$LOG"
+
+    install_and_build
+
+    # Start dev in background
+    log "Starting dev (v0.3.0)..."
+    SKIP_MATCH_SEED=true make dev-critical > "$RESULTS_DIR/dev-v030.log" 2>&1 &
+    DEV_PID=$!
+    log "Dev PID: $DEV_PID"
+
+    # Wait for Convex first, then API
+    wait_for_convex
+    wait_for_api
+
+    # Run migrations
+    run_migrations
+
+    # Wait for migrations to settle
+    sleep 5
+
+    # Post-upgrade verification
+    log "Running post-upgrade verification..."
+    scripts/migration-test-verify.sh "$BASE_URL" "$RESULTS_DIR/post-upgrade-$TIMESTAMP.log"
+
+    # Compare counts via Convex CLI
+    POST_COUNT=$(npm --workspace @trends/convex exec convex run resumes:count '{}' 2>/dev/null || echo "error")
+    log "Post-upgrade count: $POST_COUNT"
+    log "Baseline count: $BASELINE_COUNT"
+
+    if [ "$POST_COUNT" = "error" ] || [ "$BASELINE_COUNT" = "error" ]; then
+        log "WARN: Count comparison unreliable — one or both counts failed"
+    elif [ "$POST_COUNT" = "$BASELINE_COUNT" ]; then
+        log "PASS: Resume count matches baseline"
+    else
+        log "FAIL: Resume count mismatch! baseline=$BASELINE_COUNT post=$POST_COUNT"
+    fi
+
+    # Stop dev
+    kill_dev_ports
+
+    log "=== PHASE 2 COMPLETE ==="
+    log "Results saved to $RESULTS_DIR/post-upgrade-$TIMESTAMP.log"
+}
+
+# === MAIN ===
+log "Migration test starting (phase=$PHASE)"
+log "Results directory: $RESULTS_DIR"
+
+case "$PHASE" in
+    1) phase1 ;;
+    2) phase2 ;;
+    all)
+        phase1
+        log ""
+        log "Pausing 10s before Phase 2..."
+        sleep 10
+        phase2
+        ;;
+    *)
+        log "Unknown phase: $PHASE"
+        log "Usage: $0 [1|2|all]"
+        exit 1
+        ;;
+esac
+
+log ""
+log "=== MIGRATION TEST COMPLETE ==="
+log "Logs: $RESULTS_DIR/"
+log "Review: cat $LOG"

--- a/scripts/migration-test-verify.sh
+++ b/scripts/migration-test-verify.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Migration test verification script
+# Usage: scripts/migration-test-verify.sh [BASE_URL] [OUTPUT_FILE]
+# Defaults: BASE_URL=http://localhost:3000, OUTPUT_FILE=stdout
+#
+# Verified against actual API response shape:
+#   - API returns {data: [...], summary: {total, returned, source}, metadata: {...}, success}
+#   - Data items in .data[] (not .items[])
+#   - Use `source=convex` to query Convex data (default returns sample data)
+#   - Count via Convex CLI (npm --workspace @trends/convex exec convex run resumes:count)
+#   - Search with q= + source=convex causes 500 — use q= alone for search check
+#   - primaryRuleScore not exposed at API level; use ingestData.ruleScores presence
+
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:3000}"
+OUTPUT_FILE="${2:-/dev/stdout}"
+
+log() { echo "[$(date +%H:%M:%S)] $*" | tee -a "$OUTPUT_FILE"; }
+
+log "=== Migration Verification ==="
+log "Target: $BASE_URL"
+log ""
+
+# Check 1: API health
+log "--- Check 1: API Health ---"
+if curl -fsS "$BASE_URL/api/health" >/dev/null 2>&1; then
+    log "  API: OK (health endpoint)"
+elif curl -fsS "$BASE_URL" >/dev/null 2>&1; then
+    log "  API: responding"
+else
+    log "  API: UNREACHABLE"
+    log "=== FAIL ==="
+    exit 1
+fi
+
+# Check 2: Resume count via Convex CLI
+log "--- Check 2: Record Count (Convex CLI) ---"
+CONVEX_COUNT=$(npm --workspace @trends/convex exec convex run resumes:count '{}' 2>/dev/null || echo "error")
+log "  Convex resume count: $CONVEX_COUNT"
+
+# Fetch convex data once for checks 3-7 (reduce HTTP round-trips)
+CONVEX_SAMPLE=$(curl -s "$BASE_URL/api/resumes?source=convex&limit=50" 2>/dev/null || echo "{}")
+
+# Check 3: Source distribution
+log "--- Check 3: Source Distribution ---"
+echo "$CONVEX_SAMPLE" | jq -r '
+  [.data[]? | .source // "unknown"] | group_by(.) | map({source: .[0], count: length}) | .[] | "  \(.source): \(.count)"
+' 2>/dev/null | tee -a "$OUTPUT_FILE" || log "  (could not determine source distribution)"
+
+# Check 4: Search returns results (use default endpoint since q= + source=convex 500s)
+log "--- Check 4: Search Integrity ---"
+SEARCH_RESP=$(curl -s "$BASE_URL/api/resumes?limit=5" 2>/dev/null)
+SEARCH_COUNT=$(echo "$SEARCH_RESP" | jq -r '.summary.returned // 0' 2>/dev/null || echo "0")
+SEARCH_SOURCE=$(echo "$SEARCH_RESP" | jq -r '.summary.source // "unknown"' 2>/dev/null || echo "unknown")
+log "  Default query: $SEARCH_COUNT results (source: $SEARCH_SOURCE)"
+
+# Check 5: Filters on convex data
+log "--- Check 5: Filter Integrity ---"
+FILTER_MINROLE=$(curl -s "$BASE_URL/api/resumes?source=convex&limit=5&minRoleYears=0.5" 2>/dev/null | jq -r '.summary.total // 0' 2>/dev/null || echo "0")
+log "  minRoleYears=0.5: $FILTER_MINROLE results"
+
+FILTER_AGE=$(curl -s "$BASE_URL/api/resumes?source=convex&limit=5&minAge=25&maxAge=40" 2>/dev/null | jq -r '.summary.total // 0' 2>/dev/null || echo "0")
+log "  age 25-40: $FILTER_AGE results"
+
+FILTER_MAXEXP=$(curl -s "$BASE_URL/api/resumes?source=convex&limit=5&maxExperience=20" 2>/dev/null | jq -r '.summary.total // 0' 2>/dev/null || echo "0")
+log "  maxExperience=20: $FILTER_MAXEXP results"
+
+# Check 6: Derived fields (reuse CONVEX_SAMPLE)
+log "--- Check 6: Derived Fields ---"
+echo "$CONVEX_SAMPLE" | jq -r '
+  .data[:5][]? |
+  "  \(.name // "unnamed") | source=\(.source // "?") | hasIngestData=\(.ingestData != null) | verifiedRoleYears=\(.ingestData.verifiedRoleYears // "null" | tostring) | ruleScores=\(.ingestData.ruleScores // {} | keys | length) | industryDbV2Raw=\(.ingestData.industryDbV2Raw // "null")"
+' 2>/dev/null | tee -a "$OUTPUT_FILE" || log "  (could not read derived fields)"
+
+# Check 7: Scoring (reuse CONVEX_SAMPLE)
+log "--- Check 7: Scoring Pipeline ---"
+SCORED_COUNT=$(echo "$CONVEX_SAMPLE" | jq '[.data[:10][]? | select(.ingestData.ruleScores != null)] | length' 2>/dev/null || echo "0")
+log "  Resumes with ruleScores: $SCORED_COUNT / 10 sampled"
+
+VERIFIED_COUNT=$(echo "$CONVEX_SAMPLE" | jq '[.data[:10][]? | select(.ingestData.verifiedRoleYears != null and (.ingestData.verifiedRoleYears | length > 0))] | length' 2>/dev/null || echo "0")
+log "  Resumes with verifiedRoleYears: $VERIFIED_COUNT / 10 sampled"
+
+log ""
+log "=== Verification Complete ==="
+log "Convex count: $CONVEX_COUNT"
+log "Default query results: $SEARCH_COUNT"
+log "Filter results: minRoleYears=$FILTER_MINROLE age=$FILTER_AGE maxExp=$FILTER_MAXEXP"
+log "Scored (ruleScores): $SCORED_COUNT/10"
+log "Verified role years: $VERIFIED_COUNT/10"


### PR DESCRIPTION
## Summary
- Add `scripts/migration-test-run.sh` for two-phase v0.2.1→v0.3.0 upgrade validation
- Add `scripts/migration-test-verify.sh` with 7 verification checks (health, count, source distribution, search, filters, derived fields, scoring)
- Extend JSON validator chain from 6→7 levels for deep ingestData nesting
- Fix worker startup path to run from project root with `apps.worker.api:app` module path
- Fix `install-deps.sh` to use lockfile-respecting `uv sync --reinstall-package` instead of `uv pip install --reinstall`
- Fix `dev.sh` orphan detection to match updated uvicorn module path

## Test plan
- [x] `make check` passes (typecheck, lint, governance, auth)
- [x] `npm test` — 271 test files, 5190 tests pass
- [ ] Manual: `scripts/migration-test-run.sh 1` (v0.2.1 restore + baseline)
- [ ] Manual: `scripts/migration-test-run.sh 2` (upgrade to HEAD + migrate + verify)