### PR TITLE
fix: harden preview deploy scripts and add Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -438,6 +438,32 @@ local-restore-from-prod:
 
 restore-from-prod: local-restore-from-prod
 
+# --- Preview deployment (preview.pt-mes.com on ptcloud) ---
+
+# Full preview deploy: sync code from origin/main, install, build, restart services.
+# Requires SSH access to ptcloud.
+preview-deploy:
+	@SSH_HOST="$${SSH_HOST:-ptcloud}"; \
+	echo "→ deploying preview to $$SSH_HOST"; \
+	ssh "$$SSH_HOST" "sudo bash /home/ubuntu/trends/deploy/setup-preview.sh"; \
+	echo "→ restarting API"; \
+	ssh "$$SSH_HOST" "sudo systemctl restart trends-preview-api"; \
+	echo "→ verifying endpoints"; \
+	ssh "$$SSH_HOST" "curl -s -o /dev/null -w 'Web: %{http_code}\n' https://preview.pt-mes.com/ && \
+		curl -s -o /dev/null -w 'API: %{http_code}\n' http://127.0.0.1:3002/api/blocks"
+
+# Restore production Convex data into preview. Requires SSH access to ptcloud.
+preview-restore-data:
+	@SSH_HOST="$${SSH_HOST:-ptcloud}"; \
+	echo "→ restoring prod data into preview on $$SSH_HOST"; \
+	ssh "$$SSH_HOST" "sudo bash /home/ubuntu/trends/deploy/restore-preview-from-prod.sh"
+
+# Quick smoke check for preview endpoints
+preview-smoke:
+	@echo -n "Web: "; curl -s -o /dev/null -w '%{http_code}' https://preview.pt-mes.com/; echo
+	@echo -n "API: "; curl -s -o /dev/null -w '%{http_code}' https://preview.pt-mes.com/api/blocks; echo
+	@echo -n "Convex: "; curl -s -o /dev/null -w '%{http_code}' https://preview.pt-mes.com/convex/version; echo
+
 # Dual-target: follows $API_URL. Defaults to http://localhost:3000 (local).
 # Restore resume records, then restart local Convex to release retained restore RSS
 restore-resumes-restart:

--- a/deploy/restore-preview-from-prod.sh
+++ b/deploy/restore-preview-from-prod.sh
@@ -7,6 +7,8 @@
 set -e
 
 EXPORT_PATH=/tmp/prod-convex-export.zip
+# Clean up stale exports from previous runs
+rm -f "$EXPORT_PATH" /tmp/prod-convex-export-fixed.zip
 PREVIEW_DIR=/home/ubuntu/trends-preview
 
 echo "=== Step 1: Export production Convex data ==="
@@ -51,6 +53,14 @@ chown ubuntu:ubuntu "$PREVIEW_DIR/prod-convex-export.zip"
 
 echo ""
 echo "=== Step 3: Import into preview Convex ==="
+# Restart the Convex container so it sees the freshly copied export file
+# (bind mounts can go stale on long-running containers)
+echo "Restarting preview Convex to ensure bind mount is fresh..."
+cd /home/ubuntu/trends-preview && docker compose -f docker-compose.preview.yml restart convex
+# Wait for health
+echo "Waiting for Convex to become healthy..."
+timeout 180 bash -c 'while [ "$(docker inspect --format="{{.State.Health.Status}}" trends-preview-convex 2>/dev/null)" != "healthy" ]; do sleep 10; done'
+
 # The preview Convex container needs the .env.local pointing at its own deployment.
 # The deployment name comes from /app/packages/convex/.convex/local/default/config.json
 DEPLOY_NAME=$(docker exec trends-preview-convex sh -c \

--- a/deploy/setup-preview.sh
+++ b/deploy/setup-preview.sh
@@ -51,12 +51,14 @@ sudo -u ubuntu chmod +x "$DST/start-convex.sh"
 
 # 5. Restore .env.preview (or create from template)
 if [ -f "/tmp/preview-env-$TS.env" ]; then
+    echo "[5/7] Restoring backed-up .env.preview"
     cp "/tmp/preview-env-$TS.env" "$DST/.env.preview"
 elif [ -f "$REPO_HEAD/deploy/env.preview" ]; then
     echo "[5/7] No existing .env.preview — copying from template (EDIT IT)"
-    sudo -u ubuntu cp "$REPO_HEAD/deploy/env.preview" "$DST/.env.preview"
+    cp "$REPO_HEAD/deploy/env.preview" "$DST/.env.preview"
 fi
-sudo -u ubuntu chown ubuntu:ubuntu "$DST/.env.preview"
+# Must run as root (not sudo -u ubuntu) because the file may be root-owned from cp above
+chown ubuntu:ubuntu "$DST/.env.preview"
 
 # 6. Install dependencies + rebuild native modules for the host Node
 echo "[6/7] Installing npm dependencies..."


### PR DESCRIPTION
## Summary
- `setup-preview.sh`: fix `chown` bug — bare `chown` instead of `sudo -u ubuntu chown` (the ubuntu user can't chown root-owned files)
- `restore-preview-from-prod.sh`: clean stale export files before re-run; restart Convex container before import to flush stale bind mounts
- `Makefile`: add `preview-deploy`, `preview-restore-data`, `preview-smoke` targets for one-command preview management via SSH

## Test plan
- [x] Ran `make check` — all passed
- [x] Verified `setup-preview.sh` chown fix on ptcloud (previously failed)
- [x] Verified `restore-preview-from-prod.sh` with stale export cleanup
- [x] Verified `make preview-smoke` against live preview.pt-mes.com