### PR TITLE
fix: gate related exp by CNC sales evidence

### DIFF
--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1246,6 +1246,13 @@ export function useResumeListState(loadSearchHistory = false) {
                 hasCompanyHits,
               ),
               ingestData?.market,
+              {
+                target: {
+                  keywords: sessionKeywords,
+                  jobDescription: jobDescriptionId,
+                },
+                resume,
+              },
             )
           : undefined
 

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -791,6 +791,13 @@ export function useResumeSearchState() {
             hasCompanyHits,
           ),
           resume.ingestData?.market,
+          {
+            target: {
+              keywords: analysisKeywords,
+              jobDescription: parsedState.jobDescriptionId,
+            },
+            resume,
+          },
         )
         : undefined
       const score = resolveScore(

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -339,6 +339,45 @@ describe('resume-scoring', () => {
     }))
   })
 
+  it('caps generic industrial sales for CNC sales display recompute', () => {
+    const result = overrideIndustryDbBreakdown(
+      {
+        score: 95,
+        recommendation: 'match',
+        breakdown: { related_exp: 95 },
+        summary: 'Keyence sales',
+        highlights: [],
+        concerns: [],
+      },
+      50,
+      'CN',
+      {
+        target: { keywords: ['CNC', '销售'] },
+        resume: {
+          ingestData: {
+            evidenceText: '2019-2026 基恩士中国有限公司 大客户销售 负责传感器和检测设备销售',
+            roleSignals: [{
+              type: 'sales',
+              verifyIn: 'workHistory',
+              matchedSignals: ['销售', '大客户'],
+              matchedWorkEntries: [{
+                companyName: '基恩士中国有限公司',
+                jobTitle: '大客户销售',
+                years: 6.75,
+                industryVerified: true,
+                directRoleMatch: true,
+                matchedSignals: ['销售', '大客户'],
+              }],
+            }],
+          },
+        },
+      },
+    )
+
+    expect(result.breakdown!.related_exp).toBe(15)
+    expect(result.score).toBe(65)
+  })
+
   it.each([
     { label: 'rounds to nearest integer', input: 35 as number | undefined, expected: 18 },
     { label: 'keeps at 0 when AI returns 0', input: 0 as number | undefined, expected: 0 },

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -3,7 +3,10 @@ import {
   getCurrentResumeAiPromptVersion,
   isRecord,
   normalizeOptionalString,
+  resolveRelatedExpEvidenceGate,
   resolveResumeId,
+  type RelatedExpResumeEvidence,
+  type RelatedExpTargetContext,
 } from '@trends/shared'
 import type { ResumeItem } from '@/hooks/useResumes'
 import type { ConvexResumeAnalysis } from '@/hooks/useConvexResumes'
@@ -99,6 +102,7 @@ export type ResumeMatchedWorkEntry = {
   years: number
   industryVerified: boolean
   matchedSignals: string[]
+  directRoleMatch?: boolean
 }
 
 export type ResumeRoleSignalLike = {
@@ -540,11 +544,20 @@ export function overrideIndustryDbBreakdown(
   analysis: ConvexResumeAnalysis,
   industryDb: number,
   market?: string,
+  options?: {
+    target?: RelatedExpTargetContext
+    resume?: RelatedExpResumeEvidence
+  },
 ): ConvexResumeAnalysis {
   const effectiveIndustryDb = market === 'MY' ? Math.max(MY_INDUSTRY_DB_FLOOR, industryDb) : industryDb
   const recommendationCeiling = RELATED_EXP_CEILING_BY_RECOMMENDATION[analysis.recommendation ?? ''] ?? 30
   const rawRelatedExp = typeof analysis.breakdown?.related_exp === 'number' ? analysis.breakdown.related_exp : 0
-  const cappedRelatedExp = Math.min(rawRelatedExp, recommendationCeiling)
+  const evidenceGate = resolveRelatedExpEvidenceGate({
+    target: options?.target,
+    resume: options?.resume,
+  })
+  const evidenceCeiling = evidenceGate.applies ? evidenceGate.ceiling : undefined
+  const cappedRelatedExp = Math.min(rawRelatedExp, recommendationCeiling, evidenceCeiling ?? 100)
   const normalizedRelatedExp = Math.round(clamp(cappedRelatedExp, 0, 100) * RELATED_EXP_AI_WEIGHT)
   const nextBreakdown: MatchBreakdown = {
     ...(analysis.breakdown ?? {}),

--- a/packages/convex/__tests__/analysis_normalization.test.ts
+++ b/packages/convex/__tests__/analysis_normalization.test.ts
@@ -455,6 +455,116 @@ describe("normalizeAnalysisResult", () => {
         expect(result.keyFactors[0].factor).toBe("exp");
     });
 
+    describe("CNC sales related_exp evidence gate", () => {
+        it("caps generic industrial sales for CNC sales target", () => {
+            const result = normalizeAnalysisResult(
+                { recommendation: "match", summary: "ok", breakdown: { related_exp: 95 } },
+                {
+                    ingestData: {
+                        companyHits: ["基恩士中国有限公司"],
+                        brandHits: [],
+                        evidenceText: "2019-2026 基恩士中国有限公司 大客户销售 负责传感器和检测设备销售",
+                        roleSignals: [{
+                            type: "sales",
+                            verifyIn: "workHistory",
+                            matchedSignals: ["销售", "大客户"],
+                            matchedWorkEntries: [{
+                                companyName: "基恩士中国有限公司",
+                                jobTitle: "大客户销售",
+                                years: 6.75,
+                                industryVerified: true,
+                                directRoleMatch: true,
+                                matchedSignals: ["销售", "大客户"],
+                            }],
+                        }],
+                    },
+                },
+                { target: { keywords: ["CNC", "销售"] } },
+            );
+
+            expect(result.breakdown.related_exp).toBe(30);
+            expect(result.breakdown.related_exp_llm).toBe(95);
+            expect(result.breakdown.related_exp_evidence_ceiling).toBe(30);
+            expect(result.score).toBe(65);
+        });
+
+        it("caps adjacent spindle sales below the 80 bucket", () => {
+            const result = normalizeAnalysisResult(
+                { recommendation: "match", summary: "ok", breakdown: { related_exp: 90 } },
+                {
+                    ingestData: {
+                        brandHits: [{ context: "sales" }],
+                        companyHits: [],
+                        evidenceText: "2020-2024 某主轴公司 销售工程师 负责CNC电主轴销售",
+                        roleSignals: [{
+                            type: "sales",
+                            verifyIn: "workHistory",
+                            matchedSignals: ["销售工程师"],
+                            matchedWorkEntries: [{
+                                companyName: "某主轴公司",
+                                jobTitle: "销售工程师",
+                                years: 4,
+                                industryVerified: true,
+                                directRoleMatch: true,
+                                matchedSignals: ["销售工程师"],
+                            }],
+                        }],
+                    },
+                },
+                { target: { keywords: ["CNC", "销售"] } },
+            );
+
+            expect(result.breakdown.related_exp).toBe(55);
+            expect(result.score).toBe(78);
+        });
+
+        it("keeps direct machine-tool sales eligible for high score", () => {
+            const result = normalizeAnalysisResult(
+                { recommendation: "strong_match", summary: "ok", breakdown: { related_exp: 90 } },
+                {
+                    ingestData: {
+                        companyHits: [],
+                        brandHits: [{ context: "sales" }],
+                        evidenceText: "2022-2024 东莞翔亚机械设备有限公司 销售工程师 销售沙迪克慢走丝、火花机、现代威亚CNC数控车床",
+                        roleSignals: [{
+                            type: "sales",
+                            verifyIn: "workHistory",
+                            matchedSignals: ["销售工程师"],
+                            matchedWorkEntries: [{
+                                companyName: "东莞翔亚机械设备有限公司",
+                                jobTitle: "销售工程师",
+                                years: 2,
+                                industryVerified: false,
+                                directRoleMatch: true,
+                                matchedSignals: ["销售工程师"],
+                            }],
+                        }],
+                    },
+                },
+                { target: { keywords: ["CNC", "销售"] } },
+            );
+
+            expect(result.breakdown.related_exp).toBe(90);
+            expect(result.score).toBe(95);
+        });
+
+        it("does not apply evidence cap outside CNC sales target", () => {
+            const result = normalizeAnalysisResult(
+                { recommendation: "match", summary: "ok", breakdown: { related_exp: 95 } },
+                {
+                    ingestData: {
+                        companyHits: ["基恩士中国有限公司"],
+                        evidenceText: "2019-2026 基恩士中国有限公司 大客户销售",
+                        roleSignals: [],
+                    },
+                },
+                { target: { keywords: ["CNC"] } },
+            );
+
+            expect(result.breakdown.related_exp).toBe(95);
+        });
+    });
+
     describe("recommendation ceiling — fail-closed defaults", () => {
         it("unknown recommendation string clamps related_exp to no_match ceiling (30)", () => {
             const result = normalizeAnalysisResult(

--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -129,7 +129,13 @@ async function analyzeOneResume(
         try {
             const rawResult = await callLLM(messages, apiKey);
             const parsedResult = parseLlmResult(rawResult);
-            const normalizedResult = normalizeAnalysisResult(parsedResult, resume);
+            const normalizedResult = normalizeAnalysisResult(parsedResult, resume, {
+                target: {
+                    keywords: normalizedKeywords,
+                    jobTitle,
+                    jobDescription: requirements,
+                },
+            });
             return {
                 ...normalizedResult,
                 locale,

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -277,6 +277,13 @@ export const analyzeResume = action({
         const result = normalizeAnalysisResult(
             isRecord(rawResult) ? rawResult : {},
             resume,
+            {
+                target: {
+                    keywords: args.keywords,
+                    jobTitle: jd.title,
+                    jobDescription: jd.requirements,
+                },
+            },
         );
 
         // 4. Update Resume with result
@@ -517,6 +524,11 @@ export const confirmSearchResults = action({
                 const analysis = normalizeAnalysisResult(
                     isRecord(rawResult) ? rawResult : {},
                     resume,
+                    {
+                        target: {
+                            keywords: [args.query],
+                        },
+                    },
                 );
 
                 // Store confirm result in analyses map without overwriting primary analysis

--- a/packages/convex/convex/lib/analysis_normalization.ts
+++ b/packages/convex/convex/lib/analysis_normalization.ts
@@ -6,6 +6,8 @@
  */
 import {
     isRecord,
+    resolveRelatedExpEvidenceGate,
+    type RelatedExpTargetContext,
 } from "@trends/shared";
 
 // ---------------------------------------------------------------------------
@@ -322,6 +324,9 @@ export function normalizeAnalysisResult(
         keyFactors?: unknown;
     },
     resume: unknown,
+    options?: {
+        target?: RelatedExpTargetContext;
+    },
 ): {
     score: number;
     recommendation: AnalysisRecommendation;
@@ -344,8 +349,20 @@ export function normalizeAnalysisResult(
     if (llmRecommendation === undefined && result.recommendation !== undefined) {
         console.warn("unknown LLM recommendation; defaulting to no_match ceiling", { recommendation: result.recommendation });
     }
-    const relatedExpCeiling = RELATED_EXP_CEILING_BY_RECOMMENDATION[llmRecommendation ?? "no_match"];
+    const recommendationCeiling = RELATED_EXP_CEILING_BY_RECOMMENDATION[llmRecommendation ?? "no_match"];
+    const evidenceGate = resolveRelatedExpEvidenceGate({
+        target: options?.target,
+        resume,
+    });
+    const evidenceCeiling = evidenceGate.applies ? evidenceGate.ceiling : undefined;
+    const relatedExpCeiling = Math.min(recommendationCeiling, evidenceCeiling ?? 100);
     const cappedRelatedExp = clamp(relatedExpRaw, 0, relatedExpCeiling);
+    const evidenceCapControls = evidenceCeiling !== undefined
+        && evidenceCeiling < recommendationCeiling
+        && evidenceCeiling < relatedExpRaw;
+    const storedRelatedExp = evidenceCapControls
+        ? clamp(relatedExpRaw, 0, evidenceCeiling)
+        : relatedExpRaw;
     const score = clamp(Math.round(cappedRelatedExp * RELATED_EXP_WEIGHT) + industryDb, 0, 100);
 
     const recommendation = recommendationFromScore(score);
@@ -368,7 +385,13 @@ export function normalizeAnalysisResult(
             : [],
         breakdown: {
             ...(breakdown ?? {}),
-            related_exp: relatedExpRaw,
+            related_exp: storedRelatedExp,
+            ...(evidenceCapControls
+                ? {
+                    related_exp_llm: relatedExpRaw,
+                    related_exp_evidence_ceiling: evidenceCeiling,
+                }
+                : {}),
             industry_db: industryDb,
         },
         keyFactors: parseKeyFactors(result.keyFactors),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,3 +16,4 @@ export * from "./market.js";
 export * from "./resume-filter-helpers.js";
 export * from "./generated/search-profile-templates.js";
 export * from "./export-fields-config.js";
+export * from "./related-exp-evidence.js";

--- a/packages/shared/src/related-exp-evidence.test.ts
+++ b/packages/shared/src/related-exp-evidence.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  RELATED_EXP_EVIDENCE_CEILINGS,
+  resolveRelatedExpEvidenceGate,
+} from './related-exp-evidence'
+
+describe('resolveRelatedExpEvidenceGate', () => {
+  it('does not apply outside CNC sales target context', () => {
+    const result = resolveRelatedExpEvidenceGate({
+      target: { keywords: ['CNC'] },
+      resume: { ingestData: {} },
+    })
+
+    expect(result.applies).toBe(false)
+    expect(result.classification).toBe('not_applicable')
+    expect(result.ceiling).toBeUndefined()
+  })
+
+  it('keeps direct machine-tool sales uncapped', () => {
+    const result = resolveRelatedExpEvidenceGate({
+      target: { keywords: ['CNC', '销售'] },
+      resume: {
+        ingestData: {
+          evidenceText: '2022-2024 东莞翔亚机械设备有限公司 销售工程师 销售沙迪克慢走丝、火花机、现代威亚CNC数控车床',
+          roleSignals: [{
+            type: 'sales',
+            verifyIn: 'workHistory',
+            matchedWorkEntries: [{
+              companyName: '东莞翔亚机械设备有限公司',
+              jobTitle: '销售工程师',
+              years: 2,
+              industryVerified: false,
+              directRoleMatch: true,
+              matchedSignals: ['销售工程师'],
+            }],
+          }],
+        },
+      },
+    })
+
+    expect(result.applies).toBe(true)
+    expect(result.classification).toBe('direct_machine_tool_sales')
+    expect(result.ceiling).toBeUndefined()
+  })
+
+  it('caps CNC-adjacent spindle sales below the 80 total-score bucket', () => {
+    const result = resolveRelatedExpEvidenceGate({
+      target: { keywords: ['CNC', '销售'] },
+      resume: {
+        ingestData: {
+          evidenceText: '2020-2024 某主轴公司 销售工程师 负责CNC电主轴销售',
+          roleSignals: [{
+            type: 'sales',
+            verifyIn: 'workHistory',
+            matchedWorkEntries: [{
+              companyName: '某主轴公司',
+              jobTitle: '销售工程师',
+              years: 4,
+              industryVerified: true,
+              directRoleMatch: true,
+              matchedSignals: ['销售工程师'],
+            }],
+          }],
+        },
+      },
+    })
+
+    expect(result.classification).toBe('adjacent_product_sales')
+    expect(result.ceiling).toBe(RELATED_EXP_EVIDENCE_CEILINGS.adjacentProductSales)
+  })
+
+  it('caps generic industrial sales with no machine-tool domain evidence', () => {
+    const result = resolveRelatedExpEvidenceGate({
+      target: { keywords: ['CNC', '销售'] },
+      resume: {
+        ingestData: {
+          evidenceText: '2019-2026 基恩士中国有限公司 大客户销售 负责传感器和检测设备销售',
+          roleSignals: [{
+            type: 'sales',
+            verifyIn: 'workHistory',
+            matchedSignals: ['销售', '大客户'],
+            matchedWorkEntries: [{
+              companyName: '基恩士中国有限公司',
+              jobTitle: '大客户销售',
+              years: 6.75,
+              industryVerified: true,
+              directRoleMatch: true,
+              matchedSignals: ['销售', '大客户'],
+            }],
+          }],
+        },
+      },
+    })
+
+    expect(result.classification).toBe('direct_sales_without_target_domain')
+    expect(result.ceiling).toBe(RELATED_EXP_EVIDENCE_CEILINGS.noTargetDomainSales)
+  })
+
+  it('does not treat machine-tool customers as complete machine-tool sales', () => {
+    const result = resolveRelatedExpEvidenceGate({
+      target: { keywords: ['CNC', '销售'] },
+      resume: {
+        ingestData: {
+          brandHits: [{ brand: '台群', context: 'equipment' }],
+          evidenceText: '2024-2026 德力西电气销售有限公司 销售工程师 负责低压电气与变频器销售，推动江苏亚威机床、台群机床供应链品牌入围',
+          roleSignals: [{
+            type: 'sales',
+            verifyIn: 'workHistory',
+            matchedWorkEntries: [{
+              companyName: '德力西电气销售有限公司',
+              jobTitle: '销售工程师',
+              years: 1,
+              industryVerified: true,
+              directRoleMatch: true,
+              matchedSignals: ['销售工程师'],
+            }],
+          }],
+        },
+      },
+    })
+
+    expect(result.classification).toBe('direct_sales_without_target_domain')
+    expect(result.ceiling).toBe(RELATED_EXP_EVIDENCE_CEILINGS.noTargetDomainSales)
+  })
+
+  it('does not count sales-assistant titles as direct CNC sales', () => {
+    const result = resolveRelatedExpEvidenceGate({
+      target: { keywords: ['CNC', '销售'] },
+      resume: {
+        ingestData: {
+          evidenceText: '2015-2021 苏州宇鑫精密模具 销售助理 多年CNC操机经验，操作牧野、YASDA机台，部门：CNC操机',
+          roleSignals: [{
+            type: 'sales',
+            verifyIn: 'workHistory',
+            matchedWorkEntries: [{
+              companyName: '苏州宇鑫精密模具',
+              jobTitle: '销售助理',
+              years: 6,
+              industryVerified: false,
+              directRoleMatch: true,
+              matchedSignals: ['销售'],
+            }],
+          }],
+        },
+      },
+    })
+
+    expect(result.classification).toBe('target_domain_without_direct_sales')
+    expect(result.ceiling).toBe(RELATED_EXP_EVIDENCE_CEILINGS.noDirectSales)
+  })
+
+  it('does not count support-only sales engineer entries as direct machine-tool sales', () => {
+    const result = resolveRelatedExpEvidenceGate({
+      target: { keywords: ['CNC', '销售'] },
+      resume: {
+        ingestData: {
+          evidenceText: '2010-2026 上海积品精密机械有限公司 销售工程师 公司代理数控机械和数控磨床，工作主要负责机器售后服务、交机、软件培训、客户报修、故障判断和维修管理',
+          roleSignals: [{
+            type: 'sales',
+            verifyIn: 'workHistory',
+            matchedWorkEntries: [{
+              companyName: '上海积品精密机械有限公司',
+              jobTitle: '销售工程师',
+              years: 16,
+              industryVerified: false,
+              directRoleMatch: true,
+              matchedSignals: ['销售工程师'],
+            }],
+          }],
+        },
+      },
+    })
+
+    expect(result.classification).toBe('target_domain_without_direct_sales')
+    expect(result.ceiling).toBe(RELATED_EXP_EVIDENCE_CEILINGS.noDirectSales)
+  })
+
+  it('treats CNC equipment accessories as adjacent, not complete machine-tool sales', () => {
+    const result = resolveRelatedExpEvidenceGate({
+      target: { keywords: ['CNC', '销售'] },
+      resume: {
+        ingestData: {
+          evidenceText: '2023-2026 INNA智能装配有限公司 销售工程师 负责CNC设备配套装备销售、CNC电主轴销售与商务谈判',
+          roleSignals: [{
+            type: 'sales',
+            verifyIn: 'workHistory',
+            matchedWorkEntries: [{
+              companyName: 'INNA智能装配有限公司',
+              jobTitle: '销售工程师',
+              years: 3,
+              industryVerified: false,
+              directRoleMatch: true,
+              matchedSignals: ['销售工程师'],
+            }],
+          }],
+        },
+      },
+    })
+
+    expect(result.classification).toBe('adjacent_product_sales')
+    expect(result.ceiling).toBe(RELATED_EXP_EVIDENCE_CEILINGS.adjacentProductSales)
+  })
+
+  it('keeps verified machine-tool company equipment sales uncapped', () => {
+    const result = resolveRelatedExpEvidenceGate({
+      target: { keywords: ['CNC', '销售'] },
+      resume: {
+        ingestData: {
+          companyHits: ['深圳市创世纪机械有限公司'],
+          evidenceText: '2018-2026 深圳市创世纪机械有限公司 销售工程师 负责公司设备在四川的销售工作，客户洽谈，商务条款沟通，回款和售后维护',
+          roleSignals: [{
+            type: 'sales',
+            verifyIn: 'workHistory',
+            matchedWorkEntries: [{
+              companyName: '深圳市创世纪机械有限公司',
+              jobTitle: '销售工程师',
+              years: 8,
+              industryVerified: true,
+              directRoleMatch: true,
+              matchedSignals: ['销售工程师'],
+            }],
+          }],
+        },
+      },
+    })
+
+    expect(result.classification).toBe('direct_machine_tool_sales')
+    expect(result.ceiling).toBeUndefined()
+  })
+
+  it('keeps verified machine-tool sales-manager entries uncapped even when they include customer debugging', () => {
+    const result = resolveRelatedExpEvidenceGate({
+      target: { keywords: ['CNC', '销售'] },
+      resume: {
+        ingestData: {
+          companyHits: ['津上精密机床浙江有限公司'],
+          evidenceText: '2016-2018 津上精密机床（浙江）有限公司 销售经理 解决客户加工问题，帮助客户调试产品，主要负责刀塔机车床',
+          roleSignals: [{
+            type: 'sales',
+            verifyIn: 'workHistory',
+            matchedWorkEntries: [{
+              companyName: '津上精密机床（浙江）有限公司',
+              jobTitle: '销售经理',
+              years: 2.5,
+              industryVerified: true,
+              directRoleMatch: true,
+              matchedSignals: ['销售经理'],
+            }],
+          }],
+        },
+      },
+    })
+
+    expect(result.classification).toBe('direct_machine_tool_sales')
+    expect(result.ceiling).toBeUndefined()
+  })
+
+  it('caps target-domain technical exposure when direct sales is missing', () => {
+    const result = resolveRelatedExpEvidenceGate({
+      target: { keywords: ['CNC', '销售'] },
+      resume: {
+        ingestData: {
+          evidenceText: '2020-2024 某数控公司 应用工程师 负责CNC调试加工和客户培训',
+          roleSignals: [{
+            type: 'sales',
+            verifyIn: 'workHistory',
+            matchedWorkEntries: [{
+              companyName: '某数控公司',
+              jobTitle: '应用工程师',
+              years: 4,
+              industryVerified: true,
+              directRoleMatch: false,
+              matchedSignals: ['配合销售'],
+            }],
+          }],
+        },
+      },
+    })
+
+    expect(result.classification).toBe('target_domain_without_direct_sales')
+    expect(result.ceiling).toBe(RELATED_EXP_EVIDENCE_CEILINGS.noDirectSales)
+  })
+})

--- a/packages/shared/src/related-exp-evidence.ts
+++ b/packages/shared/src/related-exp-evidence.ts
@@ -1,0 +1,504 @@
+export const RELATED_EXP_EVIDENCE_CEILINGS = {
+  adjacentProductSales: 55,
+  noTargetDomainSales: 30,
+  noDirectSales: 30,
+} as const
+
+export type RelatedExpEvidenceClassification =
+  | 'not_applicable'
+  | 'direct_machine_tool_sales'
+  | 'adjacent_product_sales'
+  | 'direct_sales_without_target_domain'
+  | 'target_domain_without_direct_sales'
+  | 'no_direct_sales'
+
+export type RelatedExpEvidenceGateResult = {
+  applies: boolean
+  classification: RelatedExpEvidenceClassification
+  ceiling?: number
+}
+
+export type RelatedExpTargetContext = {
+  keywords?: string[]
+  jobTitle?: string
+  jobDescription?: string
+}
+
+export type RelatedExpMatchedWorkEntry = {
+  companyName?: string
+  jobTitle?: string
+  years?: number
+  industryVerified?: boolean
+  matchedSignals?: string[]
+  directRoleMatch?: boolean
+}
+
+export type RelatedExpRoleSignal = {
+  type?: string
+  verifyIn?: string
+  matchedSignals?: string[]
+  matchedWorkEntries?: RelatedExpMatchedWorkEntry[]
+}
+
+export type RelatedExpResumeEvidence = {
+  ingestData?: RelatedExpIngestData
+  content?: {
+    ingestData?: RelatedExpIngestData
+  }
+}
+
+type RelatedExpIngestData = {
+  evidenceText?: string
+  companyHits?: string[]
+  roleSignals?: RelatedExpRoleSignal[]
+}
+
+type DirectSalesEntryEvidence = {
+  entry: RelatedExpMatchedWorkEntry
+  text: string
+}
+
+type ResolveRelatedExpEvidenceGateInput = {
+  target?: RelatedExpTargetContext
+  resume?: unknown
+}
+
+const SALES_TARGET_TERMS = [
+  '销售',
+  'sales',
+  'account',
+  'business development',
+  '客户开发',
+  '渠道',
+  '大客户',
+]
+
+const CNC_TARGET_TERMS = [
+  'cnc',
+  '数控',
+  '机床',
+  '加工中心',
+  '车床',
+  'machine tool',
+  'machining center',
+  'lathe',
+]
+
+const DIRECT_SALES_TERMS = [
+  '销售工程师',
+  '销售经理',
+  '销售主管',
+  '销售专员',
+  '销售代表',
+  '大客户销售',
+  '客户代表',
+  '客户经理',
+  '业务开发',
+  '业务拓展',
+  '区域销售',
+  '渠道销售',
+  'sales engineer',
+  'sales manager',
+  'account manager',
+  'key account',
+  'business development',
+  'channel sales',
+]
+
+const AUXILIARY_SALES_TERMS = [
+  '配合销售',
+  '协助销售',
+  '支持销售',
+  '辅助销售',
+  '售前支持',
+  '销售助理',
+  'support sales',
+  'sales support',
+  'sales assistant',
+  'pre-sales',
+  'presales',
+]
+
+const DIRECT_SALES_DUTY_TERMS = [
+  '客户开发',
+  '开发客户',
+  '客户洽谈',
+  '客户跟踪',
+  '客户维护',
+  '商务',
+  '合同',
+  '回款',
+  '订单',
+  '成交',
+  '销售业绩',
+  '销售目标',
+  '市场营销',
+  '市场推广',
+  '渠道',
+  '代理商',
+  '经销商',
+  '区域销售',
+  '业务开发',
+  '拓客',
+]
+
+const SUPPORT_ONLY_DUTY_TERMS = [
+  '售后服务',
+  '交机',
+  '软件培训',
+  '客户报修',
+  '故障判断',
+  '维修',
+  '维护维修',
+  '技术支持',
+  '安装调试',
+  '调试',
+  '编程',
+  '操作',
+  '培训',
+]
+
+const COMPLETE_MACHINE_TOOL_PRODUCT_TERMS = [
+  'cnc机床',
+  '数控机床',
+  '数控车床',
+  '机床设备',
+  '机床整机',
+  '加工中心',
+  '车床',
+  '磨床',
+  '铣床',
+  '镗铣床',
+  '慢走丝',
+  '中走丝',
+  '火花机',
+  '线切割设备',
+  '冲床',
+  'machine tool',
+  'machining center',
+  'cnc machine',
+  'lathe',
+  'grinder',
+  'milling machine',
+]
+
+const ADJACENT_PRODUCT_TERMS = [
+  '电主轴',
+  '主轴',
+  '刀具',
+  '量具',
+  '夹具',
+  '治具',
+  '工具',
+  '刀塔',
+  'spindle',
+  'tooling',
+  'cutting tool',
+  'gauge',
+  'fixture',
+  'sandvik',
+  '山特维克',
+]
+
+const MACHINE_TOOL_COMPANY_TERMS = [
+  '机床',
+  '数控',
+  '机械',
+  'machine',
+]
+
+const STRONG_MACHINE_TOOL_COMPANY_TERMS = [
+  '机床',
+  '数控',
+  'machine tool',
+]
+
+const COMPANY_EQUIPMENT_SALES_TERMS = [
+  '公司设备',
+  '设备销售',
+  '销售设备',
+  '设备在',
+  '市场营销',
+  '销售工作',
+  '销售合同',
+  '客户销售',
+  '客户开发',
+  '合同签订',
+  '市场推广',
+]
+
+const COMPLETE_MACHINE_TOOL_SALE_PATTERNS = [
+  /(?:销售(?!工程师|经理|主管|专员|代表|助理)|负责|代理|推广|经销|售卖|卖出|订单|项目)[^。；;|]{0,40}(?:cnc机床|数控机床|机床设备|机床整机|加工中心|数控车床|车床|磨床|铣床|镗铣床|慢走丝|中走丝|火花机|线切割设备|冲床|machine tool|machining center|cnc machine|lathe|grinder|milling machine)/iu,
+  /(?:cnc机床|数控机床|机床设备|机床整机|加工中心|数控车床|车床|磨床|铣床|镗铣床|慢走丝|中走丝|火花机|线切割设备|冲床|machine tool|machining center|cnc machine|lathe|grinder|milling machine)[^。；;|]{0,40}(?:销售|售卖|卖出|客户|订单|项目|业务)/iu,
+  /(?:销售(?!工程师|经理|主管|专员|代表|助理)|负责|代理|推广|经销|售卖|卖出)[^。；;|]{0,30}(?:马扎克|mazak|斗山|doosan|兄弟|brother|津上|tsugami|沙迪克|sodick|现代威亚|hyundai wia|哈斯|haas)/iu,
+  /(?:马扎克|mazak|斗山|doosan|兄弟|brother|津上|tsugami|沙迪克|sodick|现代威亚|hyundai wia|哈斯|haas)[^。；;|]{0,30}(?:销售|代理|经销|订单|项目)/iu,
+]
+
+const NON_PRODUCT_MACHINE_TOOL_CONTEXT_PATTERNS = [
+  /[^。；;|]{0,30}(?:机床厂|机床供应链|机床系统|数控系统|控制系统|cnc系统)[^。；;|]{0,30}/giu,
+]
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : ''
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function includesAny(text: string, terms: string[]): boolean {
+  return terms.some((term) => text.includes(term.toLowerCase()))
+}
+
+function hasAnyPattern(text: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(text))
+}
+
+function toStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+
+  const strings = value.filter((item): item is string => typeof item === 'string')
+  return strings.length > 0 ? strings : undefined
+}
+
+function toMatchedWorkEntries(value: unknown): RelatedExpMatchedWorkEntry[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+
+  const entries = value
+    .filter((item): item is Record<string, unknown> => isRecord(item))
+    .map((item) => ({
+      companyName: typeof item.companyName === 'string' ? item.companyName : undefined,
+      jobTitle: typeof item.jobTitle === 'string' ? item.jobTitle : undefined,
+      years: typeof item.years === 'number' && Number.isFinite(item.years) ? item.years : undefined,
+      industryVerified: typeof item.industryVerified === 'boolean' ? item.industryVerified : undefined,
+      matchedSignals: toStringArray(item.matchedSignals),
+      directRoleMatch: typeof item.directRoleMatch === 'boolean' ? item.directRoleMatch : undefined,
+    }))
+
+  return entries.length > 0 ? entries : undefined
+}
+
+function toRoleSignals(value: unknown): RelatedExpRoleSignal[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((item): item is Record<string, unknown> => isRecord(item))
+    .map((item) => ({
+      type: typeof item.type === 'string' ? item.type : undefined,
+      verifyIn: typeof item.verifyIn === 'string' ? item.verifyIn : undefined,
+      matchedSignals: toStringArray(item.matchedSignals),
+      matchedWorkEntries: toMatchedWorkEntries(item.matchedWorkEntries),
+    }))
+}
+
+function resolveIngestData(resume: unknown): RelatedExpIngestData {
+  if (!isRecord(resume)) {
+    return {}
+  }
+
+  const rootIngestData = isRecord(resume.ingestData) ? resume.ingestData : undefined
+  const content = isRecord(resume.content) ? resume.content : undefined
+  const contentIngestData = isRecord(content?.ingestData) ? content.ingestData : undefined
+  const ingestData = rootIngestData ?? contentIngestData
+  if (!ingestData) {
+    return {}
+  }
+
+  return {
+    evidenceText: typeof ingestData.evidenceText === 'string' ? ingestData.evidenceText : undefined,
+    companyHits: toStringArray(ingestData.companyHits),
+    roleSignals: toRoleSignals(ingestData.roleSignals),
+  }
+}
+
+function buildTargetText(target: RelatedExpTargetContext | undefined): string {
+  if (!target) {
+    return ''
+  }
+
+  return [
+    ...(target.keywords ?? []),
+    target.jobTitle,
+    target.jobDescription,
+  ]
+    .map(normalizeText)
+    .filter(Boolean)
+    .join(' ')
+}
+
+function isCncSalesTarget(target: RelatedExpTargetContext | undefined): boolean {
+  const text = buildTargetText(target)
+  return includesAny(text, SALES_TARGET_TERMS) && includesAny(text, CNC_TARGET_TERMS)
+}
+
+function splitEvidenceSegments(evidenceText: string | undefined): string[] {
+  return normalizeText(evidenceText)
+    .split(/\s*\|\|\s*|\n+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+}
+
+function entryIdentityParts(entry: RelatedExpMatchedWorkEntry): string[] {
+  return [entry.companyName, entry.jobTitle]
+    .map(normalizeText)
+    .filter(Boolean)
+}
+
+function buildEntryText(entry: RelatedExpMatchedWorkEntry, segments: string[]): string {
+  const identityParts = entryIdentityParts(entry)
+  const matchedSegments = identityParts.length > 0
+    ? segments.filter((segment) => identityParts.some((part) => segment.includes(part)))
+    : []
+  return [
+    ...matchedSegments,
+    entry.companyName,
+    entry.jobTitle,
+    ...(entry.matchedSignals ?? []),
+  ]
+    .map(normalizeText)
+    .filter(Boolean)
+    .join(' ')
+}
+
+function isDirectSalesEntry(entry: RelatedExpMatchedWorkEntry, entryText: string): boolean {
+  if (entry.directRoleMatch === false) {
+    return false
+  }
+
+  const titleAndSignals = [
+    entry.jobTitle,
+    ...(entry.matchedSignals ?? []),
+  ]
+    .map(normalizeText)
+    .filter(Boolean)
+    .join(' ')
+
+  if (includesAny(titleAndSignals, AUXILIARY_SALES_TERMS)) {
+    return false
+  }
+
+  const companyName = normalizeText(entry.companyName)
+  const isMachineToolSalesManager = includesAny(companyName, STRONG_MACHINE_TOOL_COMPANY_TERMS)
+    && includesAny(titleAndSignals, ['销售经理', 'sales manager'])
+  if (
+    includesAny(entryText, SUPPORT_ONLY_DUTY_TERMS)
+    && !includesAny(entryText, DIRECT_SALES_DUTY_TERMS)
+    && !isMachineToolSalesManager
+  ) {
+    return false
+  }
+
+  if (entry.directRoleMatch === true) {
+    return true
+  }
+
+  return includesAny(titleAndSignals || entryText, DIRECT_SALES_TERMS)
+}
+
+function resolveDirectSalesEntries(ingestData: RelatedExpIngestData): DirectSalesEntryEvidence[] {
+  const segments = splitEvidenceSegments(ingestData.evidenceText)
+  const roleSignals = ingestData.roleSignals ?? []
+
+  return roleSignals
+    .filter((signal) => normalizeText(signal.type) === 'sales')
+    .flatMap((signal) => signal.matchedWorkEntries ?? [])
+    .map((entry) => ({ entry, text: buildEntryText(entry, segments) }))
+    .filter(({ entry, text }) => isDirectSalesEntry(entry, text))
+    .filter(({ text }) => Boolean(text))
+}
+
+function isSameCompany(left: string, right: string): boolean {
+  return left.length > 0 && right.length > 0 && (left.includes(right) || right.includes(left))
+}
+
+function hasMachineToolCompanyHit(entry: RelatedExpMatchedWorkEntry, companyHits: string[] | undefined): boolean {
+  const companyName = normalizeText(entry.companyName)
+  if (!companyName) {
+    return false
+  }
+
+  if (includesAny(companyName, STRONG_MACHINE_TOOL_COMPANY_TERMS)) {
+    return true
+  }
+
+  if (!includesAny(companyName, MACHINE_TOOL_COMPANY_TERMS)) {
+    return false
+  }
+
+  return (companyHits ?? [])
+    .map(normalizeText)
+    .some((companyHit) => isSameCompany(companyName, companyHit))
+}
+
+function withoutNonProductMachineToolContext(text: string): string {
+  return NON_PRODUCT_MACHINE_TOOL_CONTEXT_PATTERNS.reduce(
+    (nextText, pattern) => nextText.replace(pattern, ' '),
+    text,
+  )
+}
+
+function hasCompleteMachineToolSalesEvidence(
+  directSalesEntry: DirectSalesEntryEvidence,
+  ingestData: RelatedExpIngestData,
+): boolean {
+  const { entry, text } = directSalesEntry
+  const productEvidenceText = withoutNonProductMachineToolContext(text)
+  if (hasAnyPattern(productEvidenceText, COMPLETE_MACHINE_TOOL_SALE_PATTERNS)) {
+    return true
+  }
+
+  return hasMachineToolCompanyHit(entry, ingestData.companyHits)
+    && includesAny(text, COMPANY_EQUIPMENT_SALES_TERMS)
+}
+
+export function resolveRelatedExpEvidenceGate(
+  input: ResolveRelatedExpEvidenceGateInput,
+): RelatedExpEvidenceGateResult {
+  if (!isCncSalesTarget(input.target)) {
+    return { applies: false, classification: 'not_applicable' }
+  }
+
+  const ingestData = resolveIngestData(input.resume)
+  const evidenceText = normalizeText(ingestData.evidenceText)
+  const directSalesEntries = resolveDirectSalesEntries(ingestData)
+
+  if (directSalesEntries.some((entry) => hasCompleteMachineToolSalesEvidence(entry, ingestData))) {
+    return { applies: true, classification: 'direct_machine_tool_sales' }
+  }
+
+  if (directSalesEntries.some(({ text }) => includesAny(text, ADJACENT_PRODUCT_TERMS))) {
+    return {
+      applies: true,
+      classification: 'adjacent_product_sales',
+      ceiling: RELATED_EXP_EVIDENCE_CEILINGS.adjacentProductSales,
+    }
+  }
+
+  if (directSalesEntries.length > 0) {
+    return {
+      applies: true,
+      classification: 'direct_sales_without_target_domain',
+      ceiling: RELATED_EXP_EVIDENCE_CEILINGS.noTargetDomainSales,
+    }
+  }
+
+  if (includesAny(evidenceText, [...COMPLETE_MACHINE_TOOL_PRODUCT_TERMS, ...CNC_TARGET_TERMS])) {
+    return {
+      applies: true,
+      classification: 'target_domain_without_direct_sales',
+      ceiling: RELATED_EXP_EVIDENCE_CEILINGS.noDirectSales,
+    }
+  }
+
+  return {
+    applies: true,
+    classification: 'no_direct_sales',
+    ceiling: RELATED_EXP_EVIDENCE_CEILINGS.noDirectSales,
+  }
+}


### PR DESCRIPTION
## Summary
- Add a shared target-aware related_exp evidence gate for CNC sales scoring.
- Apply the gate in Convex AI normalization and frontend display/export recomputation.
- Add shared, Convex, and web tests for generic industrial sales, adjacent product sales, direct CNC machine-tool sales, and non-CNC target behavior.

## HR cohort audit
- Export: /Users/karlchow/Documents/resumes-export-v0.3.0-related-exp-gate-hr-feedback-42-2026-06-01T04-04-58-148Z.csv
- Audit JSON: /Users/karlchow/Documents/resumes-export-v0.3.0-related-exp-gate-hr-feedback-42-2026-06-01T04-04-58-148Z.audit.json
- HR not_suitable 80+ rows: 19 -> 0 after gate.
- Adjacent tooling/gauge confirmation row remains reviewable at 78 by design.

## Verification
- npm test -- packages/shared/src/related-exp-evidence.test.ts packages/convex/__tests__/analysis_normalization.test.ts packages/convex/__tests__/analysis-strict-evidence.test.ts packages/convex/__tests__/analyze.test.ts
- npm --workspace @trends/web test -- src/lib/resume-scoring.test.ts
- npm --workspace @trends/shared run build
- npm --workspace @trends/convex run typecheck
- npm --workspace @trends/web run typecheck
- make check

## Notes
- The pre-existing local scripts/convex-prewarm.sh change is not included.