### PR TITLE
fix: related_exp scoring — additive industry_db weights, no_match gate, cursor null fix

### DIFF
--- a/apps/api/src/routes/resumes_admin.test.ts
+++ b/apps/api/src/routes/resumes_admin.test.ts
@@ -52,6 +52,29 @@ describe("resumes_admin", () => {
   });
 
   describe("POST /api/resumes/hard-reset-reingest", () => {
+    it("first Convex call omits cursor key entirely (never sends cursor: null)", async () => {
+      const capturedBodies: unknown[] = [];
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (_, init) => {
+        const body = JSON.parse(init?.body as string ?? "{}");
+        capturedBodies.push(body);
+        return convexSuccess({ cleared: 0, hasMore: false });
+      });
+
+      const app = createTestApp();
+      await app.request("/api/resumes/hard-reset-reingest", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ dryRun: false }),
+      });
+
+      // The first Convex mutation call must NOT contain a cursor key at all
+      expect(capturedBodies.length).toBeGreaterThan(0);
+      const firstCallBody = capturedBodies[0] as Record<string, unknown>;
+      // The body is the Convex action payload; the args should not have cursor: null
+      const firstCallArgs = (firstCallBody.args ?? firstCallBody) as Record<string, unknown>;
+      expect("cursor" in firstCallArgs).toBe(false);
+    });
+
     it("dry-run returns wouldClear count", async () => {
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
         convexSuccess({ cleared: 42, hasMore: false, cursor: null }),

--- a/apps/api/src/routes/resumes_admin.ts
+++ b/apps/api/src/routes/resumes_admin.ts
@@ -185,19 +185,17 @@ app.openapi(hardResetReingestRoute, async (c) => {
   try {
     if (dryRun) {
       const firstPage = await callConvexMutation("resumes_mutations:hardResetIngestData", {
-        cursor: null,
         batchSize: 50,
       }) as { cleared: number; hasMore: boolean; cursor?: string };
 
       let wouldClear = firstPage.cleared;
-      let cursor: string | undefined | null = firstPage.cursor;
+      let cursor: string | undefined = firstPage.cursor;
       let hasMore = firstPage.hasMore;
 
       for (let i = 0; i < 10000 && hasMore; i++) {
-        const page = await callConvexMutation("resumes_mutations:hardResetIngestData", {
-          cursor,
-          batchSize: 50,
-        }) as { cleared: number; hasMore: boolean; cursor?: string };
+        const pageArgs: { batchSize: number; cursor?: string } = { batchSize: 50 };
+        if (cursor) pageArgs.cursor = cursor;
+        const page = await callConvexMutation("resumes_mutations:hardResetIngestData", pageArgs) as { cleared: number; hasMore: boolean; cursor?: string };
         wouldClear += page.cleared;
         hasMore = page.hasMore;
         cursor = page.cursor;
@@ -212,17 +210,16 @@ app.openapi(hardResetReingestRoute, async (c) => {
     }
 
     let totalCleared = 0;
-    let cursor: string | null | undefined = null;
+    let cursor: string | undefined;
     let hasMore = true;
 
     for (let i = 0; i < 10000 && hasMore; i++) {
-      const page = await callConvexMutation("resumes_mutations:hardResetIngestData", {
-        cursor,
-        batchSize: 50,
-      }) as { cleared: number; hasMore: boolean; cursor?: string };
+      const pageArgs: { batchSize: number; cursor?: string } = { batchSize: 50 };
+      if (cursor) pageArgs.cursor = cursor;
+      const page = await callConvexMutation("resumes_mutations:hardResetIngestData", pageArgs) as { cleared: number; hasMore: boolean; cursor?: string };
       totalCleared += page.cleared;
       hasMore = page.hasMore;
-      cursor = page.cursor ?? null;
+      cursor = page.cursor;
     }
 
     try {

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1653,10 +1653,10 @@ describe('useResumeListState role filter regression', () => {
       await result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
     })
 
-    // has brand hits -> full slot (50)
-    expect(result.current.displayedResumes[0]?.match?.breakdown?.industry_db).toBe(50)
+    // has brand hits (non-employer) -> additive weight: brand-only = 30 (not flat 50)
+    expect(result.current.displayedResumes[0]?.match?.breakdown?.industry_db).toBe(30)
     expect(result.current.displayedResumes[0]?.match?.breakdown?.related_exp).toBe(15)
-    expect(result.current.displayedResumes[0]?.match?.score).toBe(65)
+    expect(result.current.displayedResumes[0]?.match?.score).toBe(45)
   })
 
   it('ignores employer-context brand hits when computing direct industry_db score', async () => {

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -348,6 +348,18 @@ describe('useResumeSearchState', () => {
     resumesMock.push(
       createResume(1, {
         primaryRuleScore: 72,
+        // Give both brand + company hits so industry_db = 50 (additive model)
+        // → overrideIndustryDbBreakdown: round(90 * 0.5) + 50 = 95, beats rule scores 91 and 84
+        ingestData: {
+          industryTags: ['Machine Tools', 'Automation'],
+          synonymHits: [],
+          brandHits: [{ brand: 'dmg', role: 'distributor', source: 'job5156', context: 'DMG distributor' }],
+          companyHits: ['FANUC'],
+          ruleScores: {},
+          experienceLevel: 'senior',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+        },
         analysis: {
           score: 95,
           summary: 'Best AI match',
@@ -1214,6 +1226,18 @@ describe('useResumeSearchState', () => {
     resumesMock.push(
       createResume(1, {
         primaryRuleScore: 88,
+        // Both brand + company hits → industry_db = 50 (additive model full cap)
+        // Score: round(90 * 0.5) + 50 = 95
+        ingestData: {
+          industryTags: ['Machine Tools', 'Automation'],
+          synonymHits: [],
+          brandHits: [{ brand: 'dmg', role: 'distributor', source: 'job5156', context: 'DMG distributor' }],
+          companyHits: ['FANUC'],
+          ruleScores: {},
+          experienceLevel: 'senior',
+          computedAt: Date.now(),
+          skillsVersion: 1,
+        },
         analysis: {
           score: 95,
           summary: 'Strong fit',

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -291,9 +291,11 @@ describe('resume-scoring', () => {
   })
 
   it.each([
-    { label: 'returns full slot for brand hits', raw: 10, hasBrandHits: true, hasCompanyHits: false, expected: 50 },
-    { label: 'returns full slot for company hits', raw: 10, hasBrandHits: false, hasCompanyHits: true, expected: 50 },
-    { label: 'returns full slot for brand and company hits', raw: 10, hasBrandHits: true, hasCompanyHits: true, expected: 50 },
+    { label: 'returns 30 for brand-only hit (additive weight)', raw: 0, hasBrandHits: true, hasCompanyHits: false, expected: 30 },
+    { label: 'returns 20 for company-only hit (additive weight)', raw: 0, hasBrandHits: false, hasCompanyHits: true, expected: 20 },
+    { label: 'returns 50 for brand and company hits (full cap)', raw: 0, hasBrandHits: true, hasCompanyHits: true, expected: 50 },
+    { label: 'raw wins when raw > additive (brand-only: raw 45 > 30)', raw: 45, hasBrandHits: true, hasCompanyHits: false, expected: 45 },
+    { label: 'additive wins when raw < additive total', raw: 10, hasBrandHits: true, hasCompanyHits: true, expected: 50 },
     { label: 'keeps raw score with no hits', raw: 20, hasBrandHits: false, hasCompanyHits: false, expected: 20 },
     { label: 'clamps raw score above cap with no hits', raw: 60, hasBrandHits: false, hasCompanyHits: false, expected: 50 },
     { label: 'defaults missing raw to 0 with no hits', raw: undefined, hasBrandHits: false, hasCompanyHits: false, expected: 0 },

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -414,9 +414,12 @@ export function computeDirectIndustryDb(
   hasBrandHits: boolean,
   hasCompanyHits: boolean,
 ): number {
-  if (hasBrandHits || hasCompanyHits) return INDUSTRY_DB_V2_SCORE_CAP
+  // Additive weights matching Convex analysis_normalization.ts:
+  //   brand hit → 30, company hit → 20, both → 50.
+  // Math.max(raw, additive) so a high raw value is never suppressed.
+  const additiveScore = (hasBrandHits ? 30 : 0) + (hasCompanyHits ? 20 : 0)
   const safeRaw = typeof raw === 'number' && Number.isFinite(raw) ? raw : 0
-  return clamp(safeRaw, 0, INDUSTRY_DB_V2_SCORE_CAP)
+  return clamp(Math.max(safeRaw, additiveScore), 0, INDUSTRY_DB_V2_SCORE_CAP)
 }
 
 function nonZeroP80FromHistogram(histogram50: number[]): { p80: number; count: number } {

--- a/packages/convex/__tests__/analysis_normalization.test.ts
+++ b/packages/convex/__tests__/analysis_normalization.test.ts
@@ -315,16 +315,16 @@ describe("getResumeIngestData", () => {
 // computeDirectIndustryDbScoreFromResume
 // ---------------------------------------------------------------------------
 describe("computeDirectIndustryDbScoreFromResume", () => {
-    it("returns cap when brand hits exist", () => {
+    it("returns 30 when brand hits exist (additive weight, not flat cap)", () => {
         expect(computeDirectIndustryDbScoreFromResume({
             ingestData: { brandHits: [{ context: "client" }] },
-        })).toBe(INDUSTRY_DB_SCORE_CAP);
+        })).toBe(30);
     });
 
-    it("returns cap when company hits exist", () => {
+    it("returns 20 when company hits exist (additive weight, not flat cap)", () => {
         expect(computeDirectIndustryDbScoreFromResume({
             ingestData: { companyHits: ["Acme"] },
-        })).toBe(INDUSTRY_DB_SCORE_CAP);
+        })).toBe(20);
     });
 
     it("returns clamped industryDbV2Raw", () => {
@@ -341,6 +341,39 @@ describe("computeDirectIndustryDbScoreFromResume", () => {
 
     it("returns 0 when no data", () => {
         expect(computeDirectIndustryDbScoreFromResume({})).toBe(0);
+    });
+
+    // Phase 1: additive weight model — brand-only = 30, company-only = 20, both = 50
+    it("brand hit only → exactly 30 (additive weight)", () => {
+        expect(computeDirectIndustryDbScoreFromResume({
+            ingestData: { brandHits: [{ context: "client" }], companyHits: [], industryDbV2Raw: 0 },
+        })).toBe(30);
+    });
+
+    it("company hit only → exactly 20 (additive weight)", () => {
+        expect(computeDirectIndustryDbScoreFromResume({
+            ingestData: { companyHits: ["Acme"], brandHits: [], industryDbV2Raw: 0 },
+        })).toBe(20);
+    });
+
+    it("both brand and company hits → exactly 50 (full cap)", () => {
+        expect(computeDirectIndustryDbScoreFromResume({
+            ingestData: { brandHits: [{ context: "client" }], companyHits: ["Acme"], industryDbV2Raw: 0 },
+        })).toBe(50);
+    });
+
+    it("high raw industryDbV2Raw wins over additive when raw > additive total", () => {
+        // brand-only additive = 30, but raw = 45 > 30; raw wins, clamped to cap
+        expect(computeDirectIndustryDbScoreFromResume({
+            ingestData: { brandHits: [{ context: "client" }], companyHits: [], industryDbV2Raw: 45 },
+        })).toBe(45);
+    });
+
+    it("low raw is superseded by additive total (Math.max semantics)", () => {
+        // raw = 10, additive (brand+company) = 50; additive wins
+        expect(computeDirectIndustryDbScoreFromResume({
+            ingestData: { brandHits: [{ context: "client" }], companyHits: ["Acme"], industryDbV2Raw: 10 },
+        })).toBe(50);
     });
 });
 
@@ -511,6 +544,45 @@ describe("normalizeAnalysisResult", () => {
                 );
                 expect(result.score).toBe(Math.round(ceiling * RELATED_EXP_WEIGHT));
             }
+        });
+    });
+
+    // Phase 2: no_match gate — LLM no_match must not be overridden by industryDb
+    describe("no_match gate — LLM rejection is preserved", () => {
+        it("LLM no_match + high industryDb still produces score ≤ 39 and no_match recommendation", () => {
+            // Simulate: brand+company hit → industryDb=50, LLM no_match related_exp=20
+            const result = normalizeAnalysisResult(
+                { recommendation: "no_match", breakdown: { related_exp: 20 } },
+                { ingestData: { brandHits: [{ context: "client" }], companyHits: ["Acme"], industryDbV2Raw: 0 } },
+            );
+            expect(result.score).toBeLessThanOrEqual(39);
+            expect(result.recommendation).toBe("no_match");
+        });
+
+        it("LLM no_match with related_exp=0 and max industryDb produces score ≤ 39", () => {
+            const result = normalizeAnalysisResult(
+                { recommendation: "no_match", breakdown: { related_exp: 0 } },
+                { ingestData: { brandHits: [{ context: "client" }], companyHits: ["Acme"], industryDbV2Raw: 0 } },
+            );
+            expect(result.score).toBeLessThanOrEqual(39);
+            expect(result.recommendation).toBe("no_match");
+        });
+
+        it("LLM match recommendation is not affected by the no_match gate", () => {
+            const result = normalizeAnalysisResult(
+                { recommendation: "match", breakdown: { related_exp: 60 } },
+                { ingestData: { industryDbV2Raw: 20 } },
+            );
+            expect(result.score).toBeGreaterThanOrEqual(40);
+            expect(result.recommendation).not.toBe("no_match");
+        });
+
+        it("LLM strong_match is not affected by the no_match gate", () => {
+            const result = normalizeAnalysisResult(
+                { recommendation: "strong_match", breakdown: { related_exp: 90 } },
+                { ingestData: { industryDbV2Raw: 20 } },
+            );
+            expect(result.score).toBeGreaterThanOrEqual(60);
         });
     });
 });

--- a/packages/convex/convex/lib/analysis_normalization.ts
+++ b/packages/convex/convex/lib/analysis_normalization.ts
@@ -49,6 +49,13 @@ export type NormalizedRoleSignal = {
 export const INDUSTRY_DB_SCORE_CAP = 50;
 export const RELATED_EXP_WEIGHT = INDUSTRY_DB_SCORE_CAP / 100;
 
+// Additive weights for brand/company hits — must stay in sync with
+// INDUSTRY_DB_V2_BRAND_SECTION_SCORE / INDUSTRY_DB_V2_COMPANY_SECTION_SCORE
+// in apps/api/src/services/industry-db-batch-stats.ts and
+// computeDirectIndustryDb() in apps/web/src/lib/resume-scoring.ts.
+const INDUSTRY_DB_BRAND_HIT_SCORE = 30;
+const INDUSTRY_DB_COMPANY_HIT_SCORE = 20;
+
 export const RELATED_EXP_CEILING_BY_RECOMMENDATION: Record<AnalysisRecommendation, number> = {
     strong_match: 100,
     match: 100,
@@ -244,12 +251,12 @@ export function computeDirectIndustryDbScoreFromResume(resume: unknown): number 
     const ingestData = getResumeIngestData(resume);
     const brandHits = hasNonEmployerBrandHits(ingestData.brandHits);
     const companyHits = hasCompanyHits(ingestData.companyHits);
-    if (brandHits || companyHits) {
-        return INDUSTRY_DB_SCORE_CAP;
-    }
+    // Additive weights: brand hit → 30, company hit → 20, both → 50.
+    // This aligns Convex with the API-layer model in industry-db-batch-stats.ts.
+    const additiveScore = (brandHits ? INDUSTRY_DB_BRAND_HIT_SCORE : 0) + (companyHits ? INDUSTRY_DB_COMPANY_HIT_SCORE : 0);
 
     const raw = toNumber(ingestData.industryDbV2Raw) ?? 0;
-    return clamp(raw, 0, INDUSTRY_DB_SCORE_CAP);
+    return clamp(Math.max(raw, additiveScore), 0, INDUSTRY_DB_SCORE_CAP);
 }
 
 // ---------------------------------------------------------------------------
@@ -346,7 +353,14 @@ export function normalizeAnalysisResult(
     }
     const relatedExpCeiling = RELATED_EXP_CEILING_BY_RECOMMENDATION[llmRecommendation ?? "no_match"];
     const cappedRelatedExp = clamp(relatedExpRaw, 0, relatedExpCeiling);
-    const score = clamp(Math.round(cappedRelatedExp * RELATED_EXP_WEIGHT) + industryDb, 0, 100);
+    let score = clamp(Math.round(cappedRelatedExp * RELATED_EXP_WEIGHT) + industryDb, 0, 100);
+
+    // Gate: preserve LLM no_match — prevent industryDb from overriding a semantic rejection.
+    // A candidate explicitly rejected by the LLM must not be elevated to potential/match
+    // even when they have recognized employer brand hits.
+    if (llmRecommendation === "no_match") {
+        score = Math.min(score, 39);
+    }
 
     const recommendation = recommendationFromScore(score);
     const rawSummary = typeof result.summary === "string" && result.summary.trim().length > 0


### PR DESCRIPTION
## Summary

P0 scoring fixes for v0.3.0 — addresses the root causes identified in the 42-row HR CNC sales cohort audit (2026-06-01).

## Root Causes Fixed

**RC-1 (industry_db OR floor — Critical Blocker)**
- Old: `if (brandHits || companyHits) return 50` — single company hit gave maximum 50 pts
- New: `max(raw, brandHits*30 + companyHits*20)` — company-only → 20, brand-only → 30, both → 50
- Applied in Convex (`analysis_normalization.ts`), web (`resume-scoring.ts`), and tests

**RC-2 (LLM no_match override — Critical Blocker)**
- Old: industryDb=50 would force final score to 60 even when LLM said no_match
- New: `if (llmRecommendation === no_match) score = min(score, 39)`
- A semantic rejection by the LLM can no longer be elevated to potential/match

**RC-5 (cursor: null — Operational)**
- Old: `hardResetIngestData({ cursor: null, batchSize: 50 })` — Convex validator rejects null
- New: first call omits cursor key entirely; subsequent pages pass cursor only when truthy

## Tests

- 76 Convex normalization tests (all green)
- 18 admin route tests (all green)
- 56 web scoring tests (all green)
- `make check` passes

## Scoring Release Gate Sign-off

| Cohort | N | Metric | Target | Status |
|:---|---:|:---|:---|:---|
| CNC Sales (CN) | 42 | FHR-NS (not_suitable as match/strong_match) | 0.0% | ⏳ Phase 3 acceptance audit pending |
| CNC Sales (CN) | 42 | not_suitable high-score (≥80) count | < 5/23 | ⏳ pending |
| CNC Sales (CN) | 42 | strong_match high-score | 3/3 | ⏳ pending |
| Global | all | make check | pass | ✅ |

Phase 3 acceptance audit must pass before merging. See plan:
`~/wiki/projects/trends/work/2026-06-01-related-exp-context-refactor-audit/plan.md`

## Anti-patterns

- [x] RF-01: No CNC-specific if branches
- [x] RF-02: No co-occurrence gates
- [x] RF-03: No flat binary score allocation (additive model)
- [x] RF-04: LLM no_match gate enforced
- [x] RF-07: Convex, web, and API all use same additive weights