### PR TITLE
refactor(scoring): score = related_exp, drop industry_db from composite (P0.5)

### DIFF
--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1600,8 +1600,8 @@ describe('useResumeListState role filter regression', () => {
     })
 
     expect(result.current.displayedResumes[0]?.match?.breakdown?.industry_db).toBe(20)
-    expect(result.current.displayedResumes[0]?.match?.breakdown?.related_exp).toBe(15)
-    expect(result.current.displayedResumes[0]?.match?.score).toBe(35)
+    expect(result.current.displayedResumes[0]?.match?.breakdown?.related_exp).toBe(30)
+    expect(result.current.displayedResumes[0]?.match?.score).toBe(30)
   })
 
   it('bumps industry_db to brand section max when resume has brand hits', async () => {
@@ -1655,8 +1655,8 @@ describe('useResumeListState role filter regression', () => {
 
     // has brand hits (non-employer) -> additive weight: brand-only = 30 (not flat 50)
     expect(result.current.displayedResumes[0]?.match?.breakdown?.industry_db).toBe(30)
-    expect(result.current.displayedResumes[0]?.match?.breakdown?.related_exp).toBe(15)
-    expect(result.current.displayedResumes[0]?.match?.score).toBe(45)
+    expect(result.current.displayedResumes[0]?.match?.breakdown?.related_exp).toBe(30)
+    expect(result.current.displayedResumes[0]?.match?.score).toBe(30)
   })
 
   it('ignores employer-context brand hits when computing direct industry_db score', async () => {
@@ -1709,11 +1709,11 @@ describe('useResumeListState role filter regression', () => {
     })
 
     expect(result.current.displayedResumes[0]?.match?.breakdown?.industry_db).toBe(5)
-    expect(result.current.displayedResumes[0]?.match?.breakdown?.related_exp).toBe(15)
-    expect(result.current.displayedResumes[0]?.match?.score).toBe(20)
+    expect(result.current.displayedResumes[0]?.match?.breakdown?.related_exp).toBe(30)
+    expect(result.current.displayedResumes[0]?.match?.score).toBe(30)
   })
 
-  it('recomputes recommendation from the normalized AI score when weighting lowers the score band', async () => {
+  it('recomputes recommendation from the related_exp score below the potential band', async () => {
     mockState.convexResumes = [
       buildResume({
         id: 'resume-rec-low-1',
@@ -1761,11 +1761,11 @@ describe('useResumeListState role filter regression', () => {
       await result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
     })
 
-    expect(result.current.displayedResumes[0]?.match?.score).toBe(23)
+    expect(result.current.displayedResumes[0]?.match?.score).toBe(45)
     expect(result.current.displayedResumes[0]?.match?.recommendation).toBe('no_match')
   })
 
-  it('recomputes recommendation from the normalized AI score when industry_db bumps the score band', async () => {
+  it('does not bump the score band from industry_db hits (score = related_exp)', async () => {
     mockState.convexResumes = [
       buildResume({
         id: 'resume-rec-high-1',
@@ -1815,8 +1815,8 @@ describe('useResumeListState role filter regression', () => {
       await result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
     })
 
-    expect(result.current.displayedResumes[0]?.match?.score).toBe(70)
-    expect(result.current.displayedResumes[0]?.match?.recommendation).toBe('match')
+    expect(result.current.displayedResumes[0]?.match?.score).toBe(40)
+    expect(result.current.displayedResumes[0]?.match?.recommendation).toBe('no_match')
   })
 
   it('allows manual profile apply to bypass the URL hydration guard', () => {

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -348,8 +348,8 @@ describe('useResumeSearchState', () => {
     resumesMock.push(
       createResume(1, {
         primaryRuleScore: 72,
-        // Give both brand + company hits so industry_db = 50 (additive model)
-        // → overrideIndustryDbBreakdown: round(90 * 0.5) + 50 = 95, beats rule scores 91 and 84
+        // Brand + company hits → industry_db = 50 (display only, not added to score).
+        // score = related_exp (95), which beats rule scores 91 and 84.
         ingestData: {
           industryTags: ['Machine Tools', 'Automation'],
           synonymHits: [],
@@ -367,7 +367,7 @@ describe('useResumeSearchState', () => {
           recommendation: 'strong_match',
           promptVersion: CURRENT_PROMPT_VERSION,
           breakdown: {
-            related_exp: 90,
+            related_exp: 95,
             industry_db: 10,
           },
         },
@@ -1227,7 +1227,7 @@ describe('useResumeSearchState', () => {
       createResume(1, {
         primaryRuleScore: 88,
         // Both brand + company hits → industry_db = 50 (additive model full cap)
-        // Score: round(90 * 0.5) + 50 = 95
+        // score = related_exp (90); industry_db = 50 is display only
         ingestData: {
           industryTags: ['Machine Tools', 'Automation'],
           synonymHits: [],
@@ -1274,12 +1274,12 @@ describe('useResumeSearchState', () => {
             resumeId: 'resume-1',
             status: 'contacted',
             match: {
-              score: 95,
+              score: 90,
               recommendation: 'strong_match',
               scoreSource: 'ai',
               summary: 'Strong fit',
               breakdown: {
-                related_exp: 45,
+                related_exp: 90,
                 industry_db: 50,
               },
             },

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -303,7 +303,7 @@ describe('resume-scoring', () => {
     expect(computeDirectIndustryDb(raw, hasBrandHits, hasCompanyHits)).toBe(expected)
   })
 
-  it('overrides AI breakdown and recomputes total score', () => {
+  it('overrides AI breakdown so score = related_exp (industry_db kept for display)', () => {
     expect(overrideIndustryDbBreakdown({
       score: 45,
       summary: 'Good match',
@@ -314,15 +314,15 @@ describe('resume-scoring', () => {
         industry_db: 15,
       },
     }, 40)).toEqual(expect.objectContaining({
-      score: 55,
+      score: 30,
       breakdown: {
-        related_exp: 15,
+        related_exp: 30,
         industry_db: 40,
       },
     }))
   })
 
-  it('weights related_exp into its 50 point contribution slot', () => {
+  it('passes related_exp through as the score, keeping industry_db for display', () => {
     expect(overrideIndustryDbBreakdown({
       score: 88,
       summary: '',
@@ -333,19 +333,19 @@ describe('resume-scoring', () => {
         industry_db: 15,
       },
     }, 50)).toEqual(expect.objectContaining({
-      score: 95,
+      score: 90,
       breakdown: {
-        related_exp: 45,
+        related_exp: 90,
         industry_db: 50,
       },
     }))
   })
 
   it.each([
-    { label: 'rounds to nearest integer', input: 35 as number | undefined, expected: 18 },
+    { label: 'passes related_exp through as the score', input: 35 as number | undefined, expected: 35 },
     { label: 'keeps at 0 when AI returns 0', input: 0 as number | undefined, expected: 0 },
     { label: 'defaults to 0 when missing', input: undefined, expected: 0 },
-  ])('$label for related_exp weight', ({ input, expected }) => {
+  ])('$label for related_exp score', ({ input, expected }) => {
     expect(overrideIndustryDbBreakdown({
       score: 40,
       summary: '',
@@ -373,13 +373,13 @@ describe('resume-scoring', () => {
     it('applies industry_db floor of 40 for MY market', () => {
       const result = overrideIndustryDbBreakdown(cnAnalysis, 0, 'MY')
       expect(result.breakdown!.industry_db).toBe(40) // MY_INDUSTRY_DB_FLOOR
-      expect(result.score).toBe(53) // related_exp(26)*0.5=13 + floor(40) = 53
+      expect(result.score).toBe(26) // score = related_exp(26); industry_db is display-only
     })
 
     it('keeps industry_db above floor for MY market with brand hits', () => {
       const result = overrideIndustryDbBreakdown(cnAnalysis, 50, 'MY')
       expect(result.breakdown!.industry_db).toBe(50) // Math.max(40, 50) = 50
-      expect(result.score).toBe(63) // 13 + 50
+      expect(result.score).toBe(26) // score = related_exp(26), unaffected by industry_db
     })
 
     it('keeps industry_db for CN market', () => {
@@ -603,12 +603,13 @@ describe('overrideIndustryDbBreakdown — score/recommendation coherence', () =>
     const analysis = {
       score: 91,
       recommendation: 'strong_match' as const,
-      breakdown: { related_exp: 82 },
+      breakdown: { related_exp: 90 },
       summary: '负责重庆地区山崎马扎克的销售',
       highlights: [],
       concerns: [],
     }
     const result = overrideIndustryDbBreakdown(analysis, 50)
+    // score = related_exp (90); a genuinely strong candidate stays >= 85.
     expect(result.score).toBeGreaterThanOrEqual(85)
   })
 
@@ -622,7 +623,7 @@ describe('overrideIndustryDbBreakdown — score/recommendation coherence', () =>
       concerns: [],
     }
     const result = overrideIndustryDbBreakdown(analysis, 0)
-    // related_exp clamped to 30 (no_match ceiling) → score = round(30 * 0.5) + 0 = 15
-    expect(result.score).toBeLessThanOrEqual(15)
+    // related_exp clamped to 30 (no_match ceiling); score = related_exp = 30
+    expect(result.score).toBe(30)
   })
 })

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -399,7 +399,6 @@ function countHistogramSamples(histogram50: number[]): number {
 
 const INDUSTRY_DB_V2_SCORE_CAP = 50
 const MY_INDUSTRY_DB_FLOOR = 40
-const RELATED_EXP_AI_WEIGHT = INDUSTRY_DB_V2_SCORE_CAP / 100
 
 const RELATED_EXP_CEILING_BY_RECOMMENDATION: Record<string, number> = {
   strong_match: 100,
@@ -547,17 +546,18 @@ export function overrideIndustryDbBreakdown(
   const effectiveIndustryDb = market === 'MY' ? Math.max(MY_INDUSTRY_DB_FLOOR, industryDb) : industryDb
   const recommendationCeiling = RELATED_EXP_CEILING_BY_RECOMMENDATION[analysis.recommendation ?? ''] ?? 30
   const rawRelatedExp = typeof analysis.breakdown?.related_exp === 'number' ? analysis.breakdown.related_exp : 0
-  const cappedRelatedExp = Math.min(rawRelatedExp, recommendationCeiling)
-  const normalizedRelatedExp = Math.round(clamp(cappedRelatedExp, 0, 100) * RELATED_EXP_AI_WEIGHT)
+  // score = the related_exp factor (after the recommendation ceiling). industry_db is NOT
+  // added to the score — it stays in the breakdown as a display/sort signal only.
+  const cappedRelatedExp = clamp(Math.min(rawRelatedExp, recommendationCeiling), 0, 100)
   const nextBreakdown: MatchBreakdown = {
     ...(analysis.breakdown ?? {}),
-    related_exp: normalizedRelatedExp,
+    related_exp: cappedRelatedExp,
     industry_db: effectiveIndustryDb,
   }
 
   return {
     ...analysis,
-    score: Math.min(100, normalizedRelatedExp + effectiveIndustryDb),
+    score: cappedRelatedExp,
     breakdown: nextBreakdown,
   }
 }

--- a/packages/convex/__tests__/analysis-strict-evidence.test.ts
+++ b/packages/convex/__tests__/analysis-strict-evidence.test.ts
@@ -179,7 +179,7 @@ describe("normalizeResume strict evidence", () => {
     );
   });
 
-  it("normalizes AI analysis into weighted related_exp and direct industry_db score", () => {
+  it("normalizes AI analysis into the related_exp factor and direct industry_db display score", () => {
     const normalized = normalizeAnalysisResult(
       {
         score: 85,
@@ -202,8 +202,8 @@ describe("normalizeResume strict evidence", () => {
 
     expect(normalized.breakdown?.related_exp).toBe(70);
     expect(normalized.breakdown?.industry_db).toBe(0);
-    expect(normalized.score).toBe(35);
-    expect(normalized.recommendation).toBe("no_match");
+    expect(normalized.score).toBe(70);
+    expect(normalized.recommendation).toBe("match");
   });
 
   it("promotes industry_db to 50 when verified company/brand evidence exists", () => {
@@ -222,14 +222,16 @@ describe("normalizeResume strict evidence", () => {
         ingestData: {
           industryDbV2Raw: 5,
           companyHits: ["大连机床集团"],
-          brandHits: [],
+          brandHits: [{ context: "product" }],
         },
       } as unknown
     );
 
     expect(normalized.breakdown?.related_exp).toBe(90);
+    // brand (30) + company (20) → additive industry_db cap (50); display signal only.
     expect(normalized.breakdown?.industry_db).toBe(50);
-    expect(normalized.score).toBe(95);
+    // score = related_exp (90); industry_db does not change it.
+    expect(normalized.score).toBe(90);
     expect(normalized.recommendation).toBe("strong_match");
   });
 
@@ -272,8 +274,8 @@ describe("normalizeResume strict evidence", () => {
     );
 
     expect(normalized.breakdown?.related_exp).toBe(40);
-    expect(normalized.score).toBe(20);
-    expect(normalized.recommendation).toBe("no_match");
+    expect(normalized.score).toBe(40);
+    expect(normalized.recommendation).toBe("potential");
   });
 
   it("passes through LLM related_exp without cap for description-only sales support (no direct sales title)", () => {
@@ -317,7 +319,7 @@ describe("normalizeResume strict evidence", () => {
 
     // LLM-primary: AI score passes through, no cap applied for description-only
     expect(normalized.breakdown?.related_exp).toBe(35);
-    expect(normalized.score).toBe(18);
+    expect(normalized.score).toBe(35);
     expect(normalized.recommendation).toBe("no_match");
   });
 
@@ -362,7 +364,7 @@ describe("normalizeResume strict evidence", () => {
     );
 
     expect(normalized.breakdown?.related_exp).toBe(35);
-    expect(normalized.score).toBe(18);
+    expect(normalized.score).toBe(35);
     expect(normalized.recommendation).toBe("no_match");
   });
 
@@ -400,11 +402,11 @@ describe("normalizeResume strict evidence", () => {
       } as unknown,
     );
 
-    expect(normalized.score).toBe(90);
-    expect(normalized.recommendation).toBe("strong_match");
-    expect(normalized.summary).toContain("score 90");
+    expect(normalized.score).toBe(80);
+    expect(normalized.recommendation).toBe("match");
+    expect(normalized.summary).toContain("score 80");
     expect(normalized.summary).not.toContain("score 58");
-    expect(normalized.summary).toContain("recommendation strong_match");
+    expect(normalized.summary).toContain("recommendation match");
   });
 
   it("includes explicit related_exp scoring bands in prompt guidance", () => {
@@ -457,8 +459,8 @@ describe("normalizeResume strict evidence", () => {
 
     // LLM-primary: insurance sales score passes through without domain-irrelevant ceiling
     expect(normalized.breakdown?.related_exp).toBe(40);
-    expect(normalized.score).toBe(20);
-    expect(normalized.recommendation).toBe("no_match");
+    expect(normalized.score).toBe(40);
+    expect(normalized.recommendation).toBe("potential");
   });
 
   it("passes through LLM related_exp for industry-verified sales (no ceiling needed)", () => {
@@ -607,7 +609,7 @@ describe("normalizeResume strict evidence", () => {
 
     // LLM-primary: AI score passes through without technical-only cap
     expect(normalized.breakdown?.related_exp).toBe(85);
-    expect(normalized.score).toBe(93);
+    expect(normalized.score).toBe(85);
     expect(normalized.recommendation).toBe("strong_match");
   });
   it("passes through LLM related_exp when industry tags from non-sales roles + domain-irrelevant company", () => {
@@ -654,8 +656,8 @@ describe("normalizeResume strict evidence", () => {
 
     // LLM-primary: AI score passes through without ceiling
     expect(normalized.breakdown?.related_exp).toBe(85);
-    expect(normalized.score).toBe(43);
-    expect(normalized.recommendation).toBe("potential");
+    expect(normalized.score).toBe(85);
+    expect(normalized.recommendation).toBe("strong_match");
   });
 
   it("passes through LLM related_exp when industry tags overlap + sales company is domain-relevant", () => {
@@ -702,10 +704,10 @@ describe("normalizeResume strict evidence", () => {
 
     // Industry tags + direct sales role at a domain-relevant company (machinery trading)
     // → tags likely reflect the sales role's domain. Ceiling does NOT apply.
-    // The AI score (85) passes through above the floor of 60.
+    // The AI score (85) passes through as score = related_exp.
     expect(normalized.breakdown?.related_exp).toBe(85); // AI score passes through
-    expect(normalized.score).toBe(43); // 85 * 0.5 + 0 = 42.5 → rounded 43
-    expect(normalized.recommendation).toBe("potential");
+    expect(normalized.score).toBe(85); // score = related_exp (strong_match ceiling 100)
+    expect(normalized.recommendation).toBe("strong_match");
   });
 
   it("passes through LLM related_exp without unverified floor for domain-relevant sales", () => {
@@ -752,8 +754,8 @@ describe("normalizeResume strict evidence", () => {
 
     // AI gave 22, pass through with no floor
     expect(normalized.breakdown?.related_exp).toBe(22);
-    expect(normalized.score).toBe(11); // 22 * 0.5 + 0 = 11
-    expect(normalized.recommendation).toBe("no_match"); // 11 < 40
+    expect(normalized.score).toBe(22); // score = related_exp
+    expect(normalized.recommendation).toBe("no_match"); // 22 < 40
   });
 
   it("passes through LLM related_exp without unverified floor for domain-irrelevant company", () => {
@@ -764,7 +766,7 @@ describe("normalizeResume strict evidence", () => {
         summary: "summary",
         highlights: [],
         breakdown: {
-          related_exp: 40, // AI scores moderately, but ceiling should cap to 15
+          related_exp: 40, // AI scores moderately; score = related_exp (no ceiling here)
           industry_db: 0,
         },
       },
@@ -800,8 +802,8 @@ describe("normalizeResume strict evidence", () => {
 
     // Insurance company → domain-irrelevant → no floor, no ceiling
     expect(normalized.breakdown?.related_exp).toBe(40);
-    expect(normalized.score).toBe(20);
-    expect(normalized.recommendation).toBe("no_match");
+    expect(normalized.score).toBe(40);
+    expect(normalized.recommendation).toBe("potential");
   });
 
   it("passes through LLM related_exp without unverified floor for description-only", () => {
@@ -895,7 +897,7 @@ describe("normalizeResume strict evidence", () => {
 
     // LLM-primary: AI score passes through without floor boost
     expect(normalized.breakdown?.related_exp).toBe(40);
-    expect(normalized.score).toBe(20);
+    expect(normalized.score).toBe(40);
   });
 
   it("passes through LLM related_exp when industry tags overlap AND sales is industry-verified", () => {
@@ -1035,9 +1037,9 @@ describe("normalizeResume strict evidence", () => {
         { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
       );
       // recommendation "potential" matches, but score 75 in prose != computed score
-      // The actual computed score = round(40*0.5) + 0 = 20
-      expect(normalized.score).toBe(20);
-      expect(normalized.summary).toContain("score 20");
+      // The actual computed score = related_exp = 40 (potential ceiling 60)
+      expect(normalized.score).toBe(40);
+      expect(normalized.summary).toContain("score 40");
       expect(normalized.summary).not.toContain("score 75");
     });
 
@@ -1048,7 +1050,7 @@ describe("normalizeResume strict evidence", () => {
           recommendation: "match",
           summary: "优秀候选人，score 90，recommendation match。",
           highlights: [],
-          breakdown: { related_exp: 80, industry_db: 10 },
+          breakdown: { related_exp: 90, industry_db: 10 },
         },
         { ingestData: { industryDbV2Raw: 10, companyHits: ["TestCo"], brandHits: [{ context: "employer" }], roleSignals: [{ type: "sales", years: 5, roleRelevantYears: 5, industryVerifiedYears: 5, matchedSignals: ["销售"] }] } } as unknown,
       );
@@ -1066,7 +1068,7 @@ describe("normalizeResume strict evidence", () => {
           recommendation: "strong_match",
           summary: originalSummary,
           highlights: [],
-          breakdown: { related_exp: 80, industry_db: 10 },
+          breakdown: { related_exp: 90, industry_db: 10 },
         },
         { ingestData: { industryDbV2Raw: 10, companyHits: ["TestCo"], brandHits: [{ context: "employer" }], roleSignals: [{ type: "sales", years: 5, roleRelevantYears: 5, industryVerifiedYears: 5, matchedSignals: ["销售"] }] } } as unknown,
       );
@@ -1085,7 +1087,7 @@ describe("normalizeResume strict evidence", () => {
         { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
       );
       // Both score and recommendation mismatch → English canonical line appended
-      expect(normalized.summary).toContain("Normalized result: score 10, recommendation no_match");
+      expect(normalized.summary).toContain("Normalized result: score 20, recommendation no_match");
     });
 
     it("appends Chinese canonical statement for Han-text mismatched summaries", () => {
@@ -1099,58 +1101,53 @@ describe("normalizeResume strict evidence", () => {
         },
         { ingestData: { industryDbV2Raw: 10, companyHits: ["深圳市创世纪机械有限公司"], brandHits: [{ context: "employer" }], roleSignals: [{ type: "sales", years: 3.8, roleRelevantYears: 3.8, industryVerifiedYears: 3.8, matchedSignals: ["销售工程师"] }] } } as unknown,
       );
-      expect(normalized.summary).toContain("系统归一化结果：score 90，recommendation strong_match");
+      expect(normalized.summary).toContain("系统归一化结果：score 80，recommendation match");
     });
   });
 
   describe("recommendationFromScore threshold boundaries", () => {
-    // score = round(related_exp * 0.5) + industry_db
-    // industry_db = 50 when companyHits exist, else industryDbV2Raw clamped 0-50
+    // score = related_exp (after the recommendation ceiling); industry_db is excluded.
+    // Each case sets related_exp to the target score with a match-tier ceiling (100) so it passes through.
 
     it("returns strong_match at exactly 85", () => {
-      // round(70*0.5)=35, industry_db=50 → score=85
       const normalized = normalizeAnalysisResult(
-        { score: 0, recommendation: "strong_match", summary: "ok", highlights: [], breakdown: { related_exp: 70, industry_db: 0 } },
-        { ingestData: { industryDbV2Raw: 0, companyHits: ["some-company"], brandHits: [], roleSignals: [] } } as unknown,
+        { score: 0, recommendation: "strong_match", summary: "ok", highlights: [], breakdown: { related_exp: 85, industry_db: 0 } },
+        { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
       );
       expect(normalized.score).toBe(85);
       expect(normalized.recommendation).toBe("strong_match");
     });
 
     it("returns match at 84 (just below strong_match)", () => {
-      // round(68*0.5)=34, industry_db=50 → score=84
       const normalized = normalizeAnalysisResult(
-        { score: 0, recommendation: "match", summary: "ok", highlights: [], breakdown: { related_exp: 68, industry_db: 0 } },
-        { ingestData: { industryDbV2Raw: 0, companyHits: ["some-company"], brandHits: [], roleSignals: [] } } as unknown,
+        { score: 0, recommendation: "match", summary: "ok", highlights: [], breakdown: { related_exp: 84, industry_db: 0 } },
+        { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
       );
       expect(normalized.score).toBe(84);
       expect(normalized.recommendation).toBe("match");
     });
 
     it("returns match at exactly 70", () => {
-      // round(80*0.5)=40, industry_db=30 → score=70
       const normalized = normalizeAnalysisResult(
-        { score: 0, recommendation: "match", summary: "ok", highlights: [], breakdown: { related_exp: 80, industry_db: 0 } },
-        { ingestData: { industryDbV2Raw: 30, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
+        { score: 0, recommendation: "match", summary: "ok", highlights: [], breakdown: { related_exp: 70, industry_db: 0 } },
+        { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
       );
       expect(normalized.score).toBe(70);
       expect(normalized.recommendation).toBe("match");
     });
 
     it("returns potential at 69 (just below match)", () => {
-      // round(78*0.5)=39, industry_db=30 → score=69
       const normalized = normalizeAnalysisResult(
-        { score: 0, recommendation: "match", summary: "ok", highlights: [], breakdown: { related_exp: 78, industry_db: 0 } },
-        { ingestData: { industryDbV2Raw: 30, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
+        { score: 0, recommendation: "match", summary: "ok", highlights: [], breakdown: { related_exp: 69, industry_db: 0 } },
+        { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
       );
       expect(normalized.score).toBe(69);
       expect(normalized.recommendation).toBe("potential");
     });
 
     it("returns potential at exactly 40", () => {
-      // round(80*0.5)=40, industry_db=0 → score=40
       const normalized = normalizeAnalysisResult(
-        { score: 0, recommendation: "match", summary: "ok", highlights: [], breakdown: { related_exp: 80, industry_db: 0 } },
+        { score: 0, recommendation: "match", summary: "ok", highlights: [], breakdown: { related_exp: 40, industry_db: 0 } },
         { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
       );
       expect(normalized.score).toBe(40);
@@ -1158,9 +1155,8 @@ describe("normalizeResume strict evidence", () => {
     });
 
     it("returns no_match at 39 (just below potential)", () => {
-      // round(78*0.5)=39, industry_db=0 → score=39
       const normalized = normalizeAnalysisResult(
-        { score: 0, recommendation: "match", summary: "ok", highlights: [], breakdown: { related_exp: 78, industry_db: 0 } },
+        { score: 0, recommendation: "match", summary: "ok", highlights: [], breakdown: { related_exp: 39, industry_db: 0 } },
         { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
       );
       expect(normalized.score).toBe(39);
@@ -1194,7 +1190,7 @@ describe("normalizeResume strict evidence", () => {
         { ingestData: { industryDbV2Raw: 0, companyHits: [], brandHits: [], roleSignals: [] } } as unknown,
       );
       expect(normalized.breakdown?.related_exp).toBe(100);
-      expect(normalized.score).toBe(50);
+      expect(normalized.score).toBe(100);
     });
 
     it("falls back to 0 when related_exp is null", () => {
@@ -1233,7 +1229,7 @@ describe("normalizeResume strict evidence", () => {
         } as unknown,
       );
       expect(normalized.breakdown?.related_exp).toBe(5); // No floor boost, no cap
-      expect(normalized.score).toBe(3); // 5 * 0.5 = 2.5 → 3
+      expect(normalized.score).toBe(5); // score = related_exp (no_match ceiling 30)
       expect(normalized.recommendation).toBe("no_match");
     });
   });

--- a/packages/convex/__tests__/analysis_normalization.test.ts
+++ b/packages/convex/__tests__/analysis_normalization.test.ts
@@ -423,13 +423,15 @@ describe("normalizeSummaryConsistency", () => {
 // normalizeAnalysisResult
 // ---------------------------------------------------------------------------
 describe("normalizeAnalysisResult", () => {
-    it("computes score from related_exp * weight + industry_db", () => {
+    it("computes score from the related_exp factor alone (industry_db excluded from score)", () => {
         const result = normalizeAnalysisResult(
             { score: 80, summary: "Test", recommendation: "match", breakdown: { related_exp: 60 } },
             { ingestData: { industryDbV2Raw: 30 } },
         );
-        expect(result.score).toBe(Math.round(60 * RELATED_EXP_WEIGHT) + 30);
+        // score = cappedRelatedExp (match ceiling 100); industry_db is NOT added.
+        expect(result.score).toBe(60);
         expect(result.breakdown.related_exp).toBe(60);
+        // industry_db remains in the breakdown for display only.
         expect(result.breakdown.industry_db).toBe(30);
     });
 
@@ -442,13 +444,13 @@ describe("normalizeAnalysisResult", () => {
         expect(result.breakdown.related_exp).toBe(0);
     });
 
-    it("clamps related_exp to 0-100 before weighting", () => {
+    it("clamps related_exp to 0-100", () => {
         const result = normalizeAnalysisResult(
             { recommendation: "match", breakdown: { related_exp: 200 } },
             {},
         );
-        // related_exp clamped to 100, then score = round(100 * 0.5) + 0 = 50
-        expect(result.score).toBe(50);
+        // related_exp clamped to 100, match ceiling 100 → score = 100
+        expect(result.score).toBe(100);
         expect(result.breakdown.related_exp).toBe(100);
     });
 
@@ -457,8 +459,8 @@ describe("normalizeAnalysisResult", () => {
             { recommendation: "match", breakdown: { related_exp: 100 } },
             { ingestData: { industryDbV2Raw: 35 } },
         );
-        // score = round(100 * 0.5) + 35 = 85 → strong_match
-        expect(result.score).toBe(85);
+        // score = cappedRelatedExp = 100 → strong_match (industry_db excluded from score)
+        expect(result.score).toBe(100);
         expect(result.recommendation).toBe("strong_match");
     });
 
@@ -494,8 +496,8 @@ describe("normalizeAnalysisResult", () => {
                 { recommendation: "weak_potential", breakdown: { related_exp: 100 } },
                 {},
             );
-            // related_exp clamped to 30 → score = round(30 * 0.5) + 0 = 15
-            expect(result.score).toBeLessThanOrEqual(15);
+            // related_exp clamped to 30 (no_match ceiling); score = 30 (industry_db excluded)
+            expect(result.score).toBe(30);
         });
 
         it("null recommendation clamps to no_match ceiling", () => {
@@ -503,7 +505,7 @@ describe("normalizeAnalysisResult", () => {
                 { recommendation: null as unknown as string, breakdown: { related_exp: 100 } },
                 {},
             );
-            expect(result.score).toBeLessThanOrEqual(15);
+            expect(result.score).toBe(30);
         });
 
         it("undefined recommendation clamps to no_match ceiling", () => {
@@ -511,7 +513,7 @@ describe("normalizeAnalysisResult", () => {
                 { breakdown: { related_exp: 100 } },
                 {},
             );
-            expect(result.score).toBeLessThanOrEqual(15);
+            expect(result.score).toBe(30);
         });
 
         it("empty-string recommendation clamps to no_match ceiling", () => {
@@ -519,7 +521,7 @@ describe("normalizeAnalysisResult", () => {
                 { recommendation: "", breakdown: { related_exp: 100 } },
                 {},
             );
-            expect(result.score).toBeLessThanOrEqual(15);
+            expect(result.score).toBe(30);
         });
 
         it("numeric recommendation clamps to no_match ceiling", () => {
@@ -527,7 +529,7 @@ describe("normalizeAnalysisResult", () => {
                 { recommendation: 42 as unknown as string, breakdown: { related_exp: 100 } },
                 {},
             );
-            expect(result.score).toBeLessThanOrEqual(15);
+            expect(result.score).toBe(30);
         });
 
         it("valid recommendation values use their ceiling, not the fallback", () => {
@@ -542,7 +544,8 @@ describe("normalizeAnalysisResult", () => {
                     { recommendation: rec, breakdown: { related_exp: 100 } },
                     {},
                 );
-                expect(result.score).toBe(Math.round(ceiling * RELATED_EXP_WEIGHT));
+                // score = cappedRelatedExp = min(100, ceiling) = ceiling (industry_db excluded)
+                expect(result.score).toBe(ceiling);
             }
         });
     });

--- a/packages/convex/__tests__/analyze.test.ts
+++ b/packages/convex/__tests__/analyze.test.ts
@@ -243,16 +243,16 @@ describe("getResumeIngestData", () => {
 describe("computeDirectIndustryDbScoreFromResume", () => {
   const CAP = 50;
 
-  it("returns CAP when brandHits has non-employer context", () => {
+  it("returns the additive brand weight (30) for non-employer brand context", () => {
     expect(computeDirectIndustryDbScoreFromResume({
       ingestData: { brandHits: [{ context: "industry" }] },
-    })).toBe(CAP);
+    })).toBe(30);
   });
 
-  it("returns CAP when companyHits has entries", () => {
+  it("returns the additive company weight (20) when companyHits has entries", () => {
     expect(computeDirectIndustryDbScoreFromResume({
       ingestData: { companyHits: ["Acme Corp"] },
-    })).toBe(CAP);
+    })).toBe(20);
   });
 
   it("clamps industryDbV2Raw to 0..CAP", () => {
@@ -479,14 +479,14 @@ describe("parseRoleSignals", () => {
 
 describe("normalizeAnalysisResult", () => {
   it("normalizes a complete analysis result", () => {
-    // Score = clamp(related_exp * 0.5, 0, 100) + industry_db
-    // With related_exp=80: 80 * 0.5 = 40, + 0 industry_db = 40 → "potential"
+    // score = the related_exp factor (match ceiling 100); industry_db is excluded from the score.
+    // With related_exp=80 → score=80 → "match".
     const result = normalizeAnalysisResult(
       { score: 80, recommendation: "match", summary: "Good candidate", breakdown: { related_exp: 80 } },
       {},
     );
-    expect(result.score).toBe(40);
-    expect(result.recommendation).toBe("potential");
+    expect(result.score).toBe(80);
+    expect(result.recommendation).toBe("match");
     expect(result.summary).toBe("Good candidate");
     expect(result.highlights).toEqual([]);
     expect(result.concerns).toEqual([]);
@@ -537,16 +537,18 @@ describe("normalizeAnalysisResult", () => {
     expect(result.breakdown.related_exp).toBe(0);
   });
 
-  it("boosts score with brand/company hits", () => {
+  it("keeps brand/company hits in the breakdown without inflating the score", () => {
     const withoutHits = normalizeAnalysisResult(
-      { breakdown: { related_exp: 60 } },
+      { recommendation: "match", breakdown: { related_exp: 60 } },
       {},
     );
     const withHits = normalizeAnalysisResult(
-      { breakdown: { related_exp: 60 } },
+      { recommendation: "match", breakdown: { related_exp: 60 } },
       { ingestData: { companyHits: ["Acme"] } },
     );
-    expect(withHits.score).toBeGreaterThan(withoutHits.score);
+    // industry_db is a display/sort signal only — it must NOT change the score (score = related_exp).
+    expect(withHits.score).toBe(withoutHits.score);
+    expect(withHits.breakdown.industry_db).toBeGreaterThan(withoutHits.breakdown.industry_db);
   });
 
   it("extracts keyFactors from LLM response", () => {

--- a/packages/convex/convex/lib/analysis_normalization.ts
+++ b/packages/convex/convex/lib/analysis_normalization.ts
@@ -47,6 +47,11 @@ export type NormalizedRoleSignal = {
 // ---------------------------------------------------------------------------
 
 export const INDUSTRY_DB_SCORE_CAP = 50;
+/**
+ * @deprecated No longer part of the score formula. `score = related_exp` (the factor)
+ * as of the P0.5 refactor; industry_db is a display/sort signal only. Kept for legacy
+ * display compatibility and downstream consumers.
+ */
 export const RELATED_EXP_WEIGHT = INDUSTRY_DB_SCORE_CAP / 100;
 
 // Additive weights for brand/company hits — must stay in sync with
@@ -353,7 +358,9 @@ export function normalizeAnalysisResult(
     }
     const relatedExpCeiling = RELATED_EXP_CEILING_BY_RECOMMENDATION[llmRecommendation ?? "no_match"];
     const cappedRelatedExp = clamp(relatedExpRaw, 0, relatedExpCeiling);
-    let score = clamp(Math.round(cappedRelatedExp * RELATED_EXP_WEIGHT) + industryDb, 0, 100);
+    // score = the related_exp factor (after the recommendation ceiling). industry_db is
+    // NOT added to the composite — it is a display/sort signal only (see breakdown below).
+    let score = clamp(cappedRelatedExp, 0, 100);
 
     // Gate: preserve LLM no_match — prevent industryDb from overriding a semantic rejection.
     // A candidate explicitly rejected by the LLM must not be elevated to potential/match


### PR DESCRIPTION
## P0.5 / REQ-04 — score = related_exp

> Note: PR #1175 (P0: additive industry_db, no_match gate, cursor fix) is **already merged** into `main`, so this P0.5 work lands as a **new PR** on the same branch rather than extending #1175.

The composite `round(related_exp * 0.5) + industry_db` inflated every recommendation tier. `score` is now the LLM `related_exp` factor (after the recommendation ceiling). `industry_db` stays in `breakdown` for display/sort only — it no longer enters the score.

### Production change (2 sites)
- **Convex** `normalizeAnalysisResult`: `score = clamp(cappedRelatedExp, 0, 100)`
- **web** `overrideIndustryDbBreakdown`: `score = cappedRelatedExp`; `breakdown.related_exp = cappedRelatedExp` (was the weighted `*0.5` value)
- export-service inherits via `match.score` (reads client-overridden value — no edit needed)
- `RELATED_EXP_WEIGHT` marked `@deprecated` (Convex); unused `RELATED_EXP_AI_WEIGHT` removed (web)

### Tests (TDD red → green)
Updated all score-formula assertions. Also realigned **stale assertions in `analyze.test.ts` and `analysis-strict-evidence.test.ts`** that the P0 additive-industry_db commit (#1175) left failing on `main` (expected flat-cap `industry_db=50`, additive model gives `30`/`20`) — these are now green alongside the formula change. Full suite green: convex 1737, web 1418, root 5200. `make check` passes.

### Acceptance audit (deterministic projection, 42-row HR cohort, same LLM run)
Formula isolated (composite vs `score=related_exp` on identical LLM outputs):

| HR category | composite ≥80 | P0.5 `score=related_exp` | spec gate |
|---|---:|---:|---|
| **not_suitable** ≥80 | 22 | **14** | must fall ✓ (P1 target ≤3) |
| strong_match ≥70 | — | **3/3** | ≥2/2 ✓ |
| requires_field_office ≥70 | — | **12/14** | ≥8/14 ✓ |

`not_suitable` over-scoring falls (22→14) without harming genuinely-strong candidates. The residual 14 is the documented **LLM over-rating** root cause that **P1** (context-derived evidence ceiling) addresses.

Spec: `projects/trends/work/2026-06-01-related-exp-context-refactor-audit/spec.md`

## Sources Used
- Local files: `packages/convex/convex/lib/analysis_normalization.ts`, `apps/web/src/lib/resume-scoring.ts`, `apps/api/src/services/export-service.ts`, `.agents/skills/resume-ai-scoring-audit/scripts/audit_hr_feedback_export.py`
- Session audit: deterministic projection on the 2026-06-01 42-row HR cohort export