### PR TITLE
feat(scoring/p1): RelatedExpContext plumbing + evidence ceiling evaluator

### DIFF
--- a/.agents/skills/resume-ai-scoring-audit/scripts/audit_hr_feedback_export.py
+++ b/.agents/skills/resume-ai-scoring-audit/scripts/audit_hr_feedback_export.py
@@ -146,6 +146,18 @@ def output_row(reference: dict[str, str], current: dict[str, str] | None, thresh
     category = first_value(reference, ["HR Category", "hrCategory"])
     current_row = current or {}
     alignment = "missing_current_resume" if current is None else classify_alignment(category, score, threshold)
+
+    # P1: factor and display signal — related_exp IS the score (post P0.5);
+    # industry_db is a display-only signal NOT included in the gate check.
+    related_exp_raw = first_value(current_row, ["Related Exp", "relatedExp", "Display Related Exp"])
+    industry_db_raw = first_value(current_row, ["Industry DB", "industryDb"])
+
+    # P1 evidence ceiling fields — present in exports after evidence ceiling is active;
+    # absent in older exports (empty string fallback is safe for audit comparison).
+    evidence_band_max = first_value(current_row, ["Evidence Band Max", "evidenceBandMax"])
+    effective_related_exp = first_value(current_row, ["Effective Related Exp", "effectiveRelatedExp"])
+    missing_reasons = first_value(current_row, ["Missing Reasons", "missingReasons"])
+
     return {
         "Old CSV Row": first_value(reference, ["Old CSV Row"]),
         "Old Resume ID": first_value(reference, ["Old Resume ID", "Resume ID", "resumeId"]),
@@ -170,8 +182,14 @@ def output_row(reference: dict[str, str], current: dict[str, str] | None, thresh
         "Current Job Description ID": first_value(current_row, ["Current Job Description ID"]),
         "Current Prompt Version": first_value(current_row, ["Current Prompt Version"]),
         "Current Analyzed At": first_value(current_row, ["Current Analyzed At"]),
-        "Industry DB": first_value(current_row, ["Industry DB", "industryDb"]),
-        "Related Exp": first_value(current_row, ["Related Exp", "relatedExp", "Display Related Exp"]),
+        # Factor (score = related_exp post-P0.5 — this is the gate metric)
+        "Related Exp": related_exp_raw,
+        # Display signal (shown for HR context — NOT the gate metric)
+        "Industry DB": industry_db_raw,
+        # P1 evidence ceiling fields
+        "Evidence Band Max": evidence_band_max,
+        "Effective Related Exp": effective_related_exp,
+        "Missing Reasons": missing_reasons,
         "Score Source": first_value(current_row, ["Score Source", "scoreSource"]),
         "Status": first_value(current_row, ["Status", "status"]),
         "Action": first_value(current_row, ["Action", "action"]),
@@ -195,18 +213,38 @@ def summarize(rows: list[dict[str, str]], duplicates: dict[str, int], args: argp
 
     categories: dict[str, Any] = {}
     for category, category_rows in sorted(by_category.items()):
+        # Gate metric: score = related_exp (post P0.5 — industry_db excluded from score)
         scores = [parse_float(row["Current AI Score"]) for row in category_rows]
         numeric_scores = [score for score in scores if score is not None]
+
+        # Display signal: industry_db (for HR context, NOT the gate)
+        industry_db_values = [parse_float(row.get("Industry DB", "")) for row in category_rows]
+        numeric_industry_db = [v for v in industry_db_values if v is not None]
+
+        # P1 evidence ceiling stats (available after evidence ceiling is active)
+        evidence_band_max_values = [parse_float(row.get("Evidence Band Max", "")) for row in category_rows]
+        numeric_evidence_band = [v for v in evidence_band_max_values if v is not None]
+
         categories[category] = {
             "count": len(category_rows),
             "matchedCurrent": sum(1 for row in category_rows if row["Current Alignment"] != "missing_current_resume"),
             "missingCurrent": sum(1 for row in category_rows if row["Current Alignment"] == "missing_current_resume"),
             "missingAiScore": sum(1 for row in category_rows if row["Current Alignment"] == "missing_ai_score"),
+            # Gate: relatedExp (= score) — this is the acceptance gate metric
             "highScoreCount": sum(1 for score in numeric_scores if score >= args.score_threshold),
             "scoreMin": min(numeric_scores) if numeric_scores else None,
             "scoreMedian": statistics.median(numeric_scores) if numeric_scores else None,
             "scoreMax": max(numeric_scores) if numeric_scores else None,
             "alignmentCounts": dict(Counter(row["Current Alignment"] for row in category_rows)),
+            # Display signal — separate from gate (industry_db is NOT part of score)
+            "industryDbMin": min(numeric_industry_db) if numeric_industry_db else None,
+            "industryDbMedian": statistics.median(numeric_industry_db) if numeric_industry_db else None,
+            "industryDbMax": max(numeric_industry_db) if numeric_industry_db else None,
+            # P1 evidence ceiling stats (empty when evidence ceiling not yet active)
+            **({"evidenceBandStats": {
+                "count": len(numeric_evidence_band),
+                "bands": dict(Counter(str(int(v)) if v is not None else "missing" for v in evidence_band_max_values)),
+            }} if numeric_evidence_band else {}),
         }
 
     return {
@@ -218,6 +256,9 @@ def summarize(rows: list[dict[str, str]], duplicates: dict[str, int], args: argp
         "actualCount": len(rows),
         "countMatchesExpected": args.expected_count is None or len(rows) == args.expected_count,
         "duplicateCurrentProfileIds": duplicates,
+        # P1 note: score = relatedExp (post P0.5); industry_db is display-only
+        "scoringModel": "score=related_exp (P0.5+); industry_db=display_only",
+        "gateMetric": "relatedExp (= Current AI Score) — NOT a composite including industry_db",
         "categories": categories,
     }
 

--- a/dev-docs/skills/resume-ai-scoring-audit/scripts/audit_hr_feedback_export.py
+++ b/dev-docs/skills/resume-ai-scoring-audit/scripts/audit_hr_feedback_export.py
@@ -146,6 +146,18 @@ def output_row(reference: dict[str, str], current: dict[str, str] | None, thresh
     category = first_value(reference, ["HR Category", "hrCategory"])
     current_row = current or {}
     alignment = "missing_current_resume" if current is None else classify_alignment(category, score, threshold)
+
+    # P1: factor and display signal — related_exp IS the score (post P0.5);
+    # industry_db is a display-only signal NOT included in the gate check.
+    related_exp_raw = first_value(current_row, ["Related Exp", "relatedExp", "Display Related Exp"])
+    industry_db_raw = first_value(current_row, ["Industry DB", "industryDb"])
+
+    # P1 evidence ceiling fields — present in exports after evidence ceiling is active;
+    # absent in older exports (empty string fallback is safe for audit comparison).
+    evidence_band_max = first_value(current_row, ["Evidence Band Max", "evidenceBandMax"])
+    effective_related_exp = first_value(current_row, ["Effective Related Exp", "effectiveRelatedExp"])
+    missing_reasons = first_value(current_row, ["Missing Reasons", "missingReasons"])
+
     return {
         "Old CSV Row": first_value(reference, ["Old CSV Row"]),
         "Old Resume ID": first_value(reference, ["Old Resume ID", "Resume ID", "resumeId"]),
@@ -170,8 +182,14 @@ def output_row(reference: dict[str, str], current: dict[str, str] | None, thresh
         "Current Job Description ID": first_value(current_row, ["Current Job Description ID"]),
         "Current Prompt Version": first_value(current_row, ["Current Prompt Version"]),
         "Current Analyzed At": first_value(current_row, ["Current Analyzed At"]),
-        "Industry DB": first_value(current_row, ["Industry DB", "industryDb"]),
-        "Related Exp": first_value(current_row, ["Related Exp", "relatedExp", "Display Related Exp"]),
+        # Factor (score = related_exp post-P0.5 — this is the gate metric)
+        "Related Exp": related_exp_raw,
+        # Display signal (shown for HR context — NOT the gate metric)
+        "Industry DB": industry_db_raw,
+        # P1 evidence ceiling fields
+        "Evidence Band Max": evidence_band_max,
+        "Effective Related Exp": effective_related_exp,
+        "Missing Reasons": missing_reasons,
         "Score Source": first_value(current_row, ["Score Source", "scoreSource"]),
         "Status": first_value(current_row, ["Status", "status"]),
         "Action": first_value(current_row, ["Action", "action"]),
@@ -195,18 +213,38 @@ def summarize(rows: list[dict[str, str]], duplicates: dict[str, int], args: argp
 
     categories: dict[str, Any] = {}
     for category, category_rows in sorted(by_category.items()):
+        # Gate metric: score = related_exp (post P0.5 — industry_db excluded from score)
         scores = [parse_float(row["Current AI Score"]) for row in category_rows]
         numeric_scores = [score for score in scores if score is not None]
+
+        # Display signal: industry_db (for HR context, NOT the gate)
+        industry_db_values = [parse_float(row.get("Industry DB", "")) for row in category_rows]
+        numeric_industry_db = [v for v in industry_db_values if v is not None]
+
+        # P1 evidence ceiling stats (available after evidence ceiling is active)
+        evidence_band_max_values = [parse_float(row.get("Evidence Band Max", "")) for row in category_rows]
+        numeric_evidence_band = [v for v in evidence_band_max_values if v is not None]
+
         categories[category] = {
             "count": len(category_rows),
             "matchedCurrent": sum(1 for row in category_rows if row["Current Alignment"] != "missing_current_resume"),
             "missingCurrent": sum(1 for row in category_rows if row["Current Alignment"] == "missing_current_resume"),
             "missingAiScore": sum(1 for row in category_rows if row["Current Alignment"] == "missing_ai_score"),
+            # Gate: relatedExp (= score) — this is the acceptance gate metric
             "highScoreCount": sum(1 for score in numeric_scores if score >= args.score_threshold),
             "scoreMin": min(numeric_scores) if numeric_scores else None,
             "scoreMedian": statistics.median(numeric_scores) if numeric_scores else None,
             "scoreMax": max(numeric_scores) if numeric_scores else None,
             "alignmentCounts": dict(Counter(row["Current Alignment"] for row in category_rows)),
+            # Display signal — separate from gate (industry_db is NOT part of score)
+            "industryDbMin": min(numeric_industry_db) if numeric_industry_db else None,
+            "industryDbMedian": statistics.median(numeric_industry_db) if numeric_industry_db else None,
+            "industryDbMax": max(numeric_industry_db) if numeric_industry_db else None,
+            # P1 evidence ceiling stats (empty when evidence ceiling not yet active)
+            **({"evidenceBandStats": {
+                "count": len(numeric_evidence_band),
+                "bands": dict(Counter(str(int(v)) if v is not None else "missing" for v in evidence_band_max_values)),
+            }} if numeric_evidence_band else {}),
         }
 
     return {
@@ -218,6 +256,9 @@ def summarize(rows: list[dict[str, str]], duplicates: dict[str, int], args: argp
         "actualCount": len(rows),
         "countMatchesExpected": args.expected_count is None or len(rows) == args.expected_count,
         "duplicateCurrentProfileIds": duplicates,
+        # P1 note: score = relatedExp (post P0.5); industry_db is display-only
+        "scoringModel": "score=related_exp (P0.5+); industry_db=display_only",
+        "gateMetric": "relatedExp (= Current AI Score) — NOT a composite including industry_db",
         "categories": categories,
     }
 

--- a/packages/convex/__tests__/analysis-tasks-convex-test.test.ts
+++ b/packages/convex/__tests__/analysis-tasks-convex-test.test.ts
@@ -113,6 +113,64 @@ describe("analysis_tasks: dispatch", () => {
       }),
     ).rejects.toThrow("Either jobDescriptionContent or keywords is required");
   });
+
+  // P1 context plumbing tests — RED: these test new fields not yet accepted
+  it("accepts relatedExpContext and stores it in task.config", async () => {
+    const t = createTest();
+    const resumeId = await insertResume(t);
+
+    const taskId = await t.mutation(api.analysis_tasks.dispatch, {
+      keywords: ["cnc", "sales"],
+      resumeIds: [resumeId],
+      relatedExpContext: {
+        roleFilterType: "sales",
+        minRoleYears: 1,
+        market: "CN",
+        locale: "zh",
+      },
+    });
+
+    expect(taskId).toBeDefined();
+    const tasks = await t.query(api.analysis_tasks.list, {});
+    expect(tasks[0].config.relatedExpContext).toBeDefined();
+    expect(tasks[0].config.relatedExpContext?.roleFilterType).toBe("sales");
+    expect(tasks[0].config.relatedExpContext?.minRoleYears).toBe(1);
+    expect(tasks[0].config.relatedExpContext?.market).toBe("CN");
+    expect(tasks[0].config.relatedExpContext?.locale).toBe("zh");
+  });
+
+  it("dispatch without relatedExpContext is backward-compatible", async () => {
+    const t = createTest();
+    const resumeId = await insertResume(t);
+
+    const taskId = await t.mutation(api.analysis_tasks.dispatch, {
+      keywords: ["python"],
+      resumeIds: [resumeId],
+    });
+
+    expect(taskId).toBeDefined();
+    const tasks = await t.query(api.analysis_tasks.list, {});
+    // relatedExpContext is optional — absent when not provided
+    expect(tasks[0].config.relatedExpContext).toBeUndefined();
+  });
+
+  it("relatedExpContext with partial fields is accepted", async () => {
+    const t = createTest();
+    const resumeId = await insertResume(t);
+
+    const taskId = await t.mutation(api.analysis_tasks.dispatch, {
+      keywords: ["sales"],
+      resumeIds: [resumeId],
+      relatedExpContext: {
+        roleFilterType: "any",
+      },
+    });
+
+    expect(taskId).toBeDefined();
+    const tasks = await t.query(api.analysis_tasks.list, {});
+    expect(tasks[0].config.relatedExpContext?.roleFilterType).toBe("any");
+    expect(tasks[0].config.relatedExpContext?.minRoleYears).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/convex/__tests__/analysis_normalization.test.ts
+++ b/packages/convex/__tests__/analysis_normalization.test.ts
@@ -602,3 +602,79 @@ describe("constants", () => {
         expect(RELATED_EXP_WEIGHT).toBe(INDUSTRY_DB_SCORE_CAP / 100);
     });
 });
+
+// ---------------------------------------------------------------------------
+// P1: relatedExpEvidence storage in normalizeAnalysisResult
+// ---------------------------------------------------------------------------
+
+describe("normalizeAnalysisResult with relatedExpContext (P1)", () => {
+    it("returns relatedExpEvidence when context is provided", () => {
+        const result = normalizeAnalysisResult(
+            { recommendation: "match", breakdown: { related_exp: 84 } },
+            { ingestData: { companyHits: [] } },
+            {
+                context: { roleFilterType: "sales", minRoleYears: 1, market: "CN" },
+                ingestEvidence: { directRoleMatch: false, industryVerifiedRelevantYears: 0 },
+            },
+        );
+        expect(result.relatedExpEvidence).toBeDefined();
+        expect(result.relatedExpEvidence?.coverage).toBe("none");
+        expect(result.relatedExpEvidence?.evidenceBandMax).toBe(30);
+        expect(result.relatedExpEvidence?.llmRaw).toBe(84);
+        expect(typeof result.relatedExpEvidence?.contextHash).toBe("string");
+        expect(typeof result.relatedExpEvidence?.rubricVersion).toBe("string");
+    });
+
+    it("breakdown.related_exp = effectiveRaw when context is provided", () => {
+        const result = normalizeAnalysisResult(
+            { recommendation: "match", breakdown: { related_exp: 84 } },
+            { ingestData: { companyHits: [] } },
+            {
+                context: { roleFilterType: "sales", minRoleYears: 1, market: "CN" },
+                // no directRoleMatch, no domain years → none coverage → evidenceBandMax=30
+                ingestEvidence: { directRoleMatch: false, industryVerifiedRelevantYears: 0 },
+            },
+        );
+        // effectiveRaw = min(84, 100 [match ceiling], 30 [evidenceBandMax]) = 30
+        expect(result.breakdown.related_exp).toBe(30);
+        expect(result.score).toBe(30);
+    });
+
+    it("breakdown.related_exp = effectiveRaw for full coverage (no ceiling applied)", () => {
+        const result = normalizeAnalysisResult(
+            { recommendation: "match", breakdown: { related_exp: 75 } },
+            { ingestData: { companyHits: [] } },
+            {
+                context: { roleFilterType: "sales", minRoleYears: 1, market: "CN" },
+                ingestEvidence: { directRoleMatch: true, industryVerifiedRelevantYears: 3 },
+            },
+        );
+        // full coverage → evidenceBandMax=100; effectiveRaw = min(75, 100, 100) = 75
+        expect(result.breakdown.related_exp).toBe(75);
+        expect(result.score).toBe(75);
+        expect(result.relatedExpEvidence?.coverage).toBe("full");
+    });
+
+    it("legacy path: no relatedExpContext → no relatedExpEvidence (backward compat)", () => {
+        const result = normalizeAnalysisResult(
+            { recommendation: "match", breakdown: { related_exp: 60 } },
+            { ingestData: { industryDbV2Raw: 30 } },
+        );
+        // relatedExpEvidence is absent — no third argument
+        expect((result as Record<string, unknown>).relatedExpEvidence).toBeUndefined();
+        expect(result.score).toBe(60);
+        expect(result.breakdown.related_exp).toBe(60);
+    });
+
+    it("relatedExpEvidence missingReasons is populated for partial/weak/none coverage", () => {
+        const result = normalizeAnalysisResult(
+            { recommendation: "match", breakdown: { related_exp: 84 } },
+            {},
+            {
+                context: { roleFilterType: "sales", minRoleYears: 2 },
+                ingestEvidence: { directRoleMatch: false, industryVerifiedRelevantYears: 0 },
+            },
+        );
+        expect(result.relatedExpEvidence?.missingReasons.length).toBeGreaterThan(0);
+    });
+});

--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -31,6 +31,7 @@ import {
     buildAnalysisDispatchJobKey,
     buildAnalysisDispatchIdempotencyKey,
 } from "./lib/analysis_task_helpers.js";
+import { relatedExpContextValidator } from "./validators.js";
 
 // Backward-compatible re-exports
 export type { AnalysisResult, AnalysisDispatchKeyInput } from "./lib/analysis_task_helpers.js";
@@ -185,6 +186,8 @@ export const dispatch = mutation({
         promptVersion: v.optional(v.number()),
         sample: v.optional(v.string()),
         resumeIds: v.array(v.id("resumes")),
+        /** P1: context for evidence ceiling evaluator — optional for backward compat */
+        relatedExpContext: v.optional(relatedExpContextValidator),
     },
     handler: async (ctx, args) => {
         const normalizedKeywords = normalizeKeywords(args.keywords ?? []);
@@ -276,6 +279,7 @@ export const dispatch = mutation({
                 promptVersion,
                 sample: args.sample,
                 resumeCount: uniqueResumeIds.length,
+                ...(args.relatedExpContext ? { relatedExpContext: args.relatedExpContext } : {}),
             },
             status: "pending",
             progress: {

--- a/packages/convex/convex/lib/analysis_normalization.ts
+++ b/packages/convex/convex/lib/analysis_normalization.ts
@@ -6,7 +6,14 @@
  */
 import {
     isRecord,
+    evaluateRelatedExpEvidence,
+    type RelatedExpContextInput,
+    type RelatedExpIngestEvidence,
+    type RelatedExpEvidenceResult,
 } from "@trends/shared";
+
+// Re-export for callers that need the P1 context types
+export type { RelatedExpContextInput, RelatedExpIngestEvidence, RelatedExpEvidenceResult };
 
 // ---------------------------------------------------------------------------
 // Types
@@ -334,6 +341,10 @@ export function normalizeAnalysisResult(
         keyFactors?: unknown;
     },
     resume: unknown,
+    relatedExpCtx?: {
+        context: RelatedExpContextInput;
+        ingestEvidence: RelatedExpIngestEvidence;
+    },
 ): {
     score: number;
     recommendation: AnalysisRecommendation;
@@ -342,6 +353,7 @@ export function normalizeAnalysisResult(
     concerns: string[];
     breakdown: Record<string, number>;
     keyFactors: KeyFactor[];
+    relatedExpEvidence?: RelatedExpEvidenceResult;
 } {
     const breakdown = parseNumericBreakdown(result.breakdown);
     const llmRelatedExp = toNumber(breakdown?.related_exp);
@@ -358,9 +370,25 @@ export function normalizeAnalysisResult(
     }
     const relatedExpCeiling = RELATED_EXP_CEILING_BY_RECOMMENDATION[llmRecommendation ?? "no_match"];
     const cappedRelatedExp = clamp(relatedExpRaw, 0, relatedExpCeiling);
-    // score = the related_exp factor (after the recommendation ceiling). industry_db is
-    // NOT added to the composite — it is a display/sort signal only (see breakdown below).
-    let score = clamp(cappedRelatedExp, 0, 100);
+
+    // P1: apply evidence ceiling when context is provided
+    let relatedExpEvidence: RelatedExpEvidenceResult | undefined;
+    let effectiveRelatedExp = cappedRelatedExp;
+
+    if (relatedExpCtx) {
+        relatedExpEvidence = evaluateRelatedExpEvidence({
+            context: relatedExpCtx.context,
+            llmRaw: relatedExpRaw,
+            llmRecommendation: llmRecommendation ?? "no_match",
+            ingestEvidence: relatedExpCtx.ingestEvidence,
+        });
+        // Lower-only: effectiveRaw already respects recommendationMax ceiling
+        effectiveRelatedExp = relatedExpEvidence.effectiveRaw;
+    }
+
+    // score = the related_exp factor (after the recommendation ceiling and optional evidence
+    // ceiling). industry_db is NOT added to the composite — it is a display/sort signal only.
+    let score = clamp(effectiveRelatedExp, 0, 100);
 
     // Gate: preserve LLM no_match — prevent industryDb from overriding a semantic rejection.
     // A candidate explicitly rejected by the LLM must not be elevated to potential/match
@@ -389,9 +417,10 @@ export function normalizeAnalysisResult(
             : [],
         breakdown: {
             ...(breakdown ?? {}),
-            related_exp: relatedExpRaw,
+            related_exp: relatedExpCtx ? effectiveRelatedExp : relatedExpRaw,
             industry_db: industryDb,
         },
         keyFactors: parseKeyFactors(result.keyFactors),
+        ...(relatedExpEvidence ? { relatedExpEvidence } : {}),
     };
 }

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1,6 +1,6 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { ingestDataValidator, collectionTaskResultsValidator, resumeFiltersValidator, analysisResultValidator, jsonRecordValidator, jsonValueValidator } from "./validators.js";
+import { ingestDataValidator, collectionTaskResultsValidator, resumeFiltersValidator, analysisResultValidator, jsonRecordValidator, jsonValueValidator, relatedExpContextValidator } from "./validators.js";
 
 export default defineSchema({
     // Tasks for resume collection
@@ -173,6 +173,8 @@ export default defineSchema({
             promptVersion: v.optional(v.number()),
             sample: v.optional(v.string()),
             resumeCount: v.number(),
+            /** P1: context for evidence ceiling evaluator — optional, omitted on legacy tasks */
+            relatedExpContext: v.optional(relatedExpContextValidator),
         }),
         status: v.union(
             v.literal("pending"),

--- a/packages/convex/convex/validators.ts
+++ b/packages/convex/convex/validators.ts
@@ -219,3 +219,36 @@ export const jsonRecordValidator = v.record(v.string(), jsonL8);
 
 const primitiveValueValidator = v.union(v.string(), v.number(), v.boolean());
 export const matchingRulesValidator = v.optional(v.union(v.string(), v.record(v.string(), primitiveValueValidator), v.array(primitiveValueValidator)));
+
+// --- RelatedExpContext (P1: context-derived evidence ceiling) ---
+// Carries search/JD context from the dispatch call site to normalizeAnalysisResult
+// so the evidence ceiling evaluator can compute evidenceBandMax without domain
+// knowledge being hardcoded in the scoring layer.
+
+export const relatedExpContextValidator = v.object({
+    /** "sales" | "technical" | "any" — role type required by the JD/search profile */
+    roleFilterType: v.optional(v.string()),
+    /** Minimum domain-role years required (from search profile or JD) */
+    minRoleYears: v.optional(v.number()),
+    /** "CN" | "MY" — market context for market-specific scoring floors */
+    market: v.optional(v.string()),
+    /** Output locale for AI prompts — "zh" | "en" */
+    locale: v.optional(v.string()),
+});
+
+// --- RelatedExpEvidence (P1: stored result of the evidence ceiling evaluation) ---
+
+export const relatedExpEvidenceValidator = v.object({
+    /** 100 | 65 | 45 | 30 */
+    evidenceBandMax: v.number(),
+    /** "full" | "partial" | "weak" | "none" */
+    coverage: v.string(),
+    /** Reasons the ceiling was applied (empty when full coverage) */
+    missingReasons: v.array(v.string()),
+    /** min(llmRaw, recommendationMax, evidenceBandMax) */
+    effectiveRaw: v.number(),
+    llmRaw: v.number(),
+    recommendationMax: v.number(),
+    contextHash: v.string(),
+    rubricVersion: v.string(),
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,3 +16,4 @@ export * from "./market.js";
 export * from "./resume-filter-helpers.js";
 export * from "./generated/search-profile-templates.js";
 export * from "./export-fields-config.js";
+export * from "./scoring/related-exp-evaluator.js";

--- a/packages/shared/src/scoring/related-exp-evaluator.test.ts
+++ b/packages/shared/src/scoring/related-exp-evaluator.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for evaluateRelatedExpEvidence() — P1 evidence band ceiling.
+ *
+ * TDD RED phase: all tests import from a module that does not yet exist.
+ * These tests define the full behavioral contract of the evaluator before
+ * any implementation code is written.
+ */
+import { describe, expect, it } from "vitest";
+import {
+    evaluateRelatedExpEvidence,
+    type RelatedExpEvidenceInput,
+    type RelatedExpEvidenceResult,
+} from "./related-exp-evaluator.js";
+
+// ---------------------------------------------------------------------------
+// Coverage band mapping
+// ---------------------------------------------------------------------------
+
+describe("evaluateRelatedExpEvidence: coverage bands", () => {
+    it("full coverage: directRoleMatch=true AND domainYears >= minRoleYears → evidenceBandMax=100", () => {
+        const result = evaluateRelatedExpEvidence({
+            context: { roleFilterType: "sales", minRoleYears: 1, market: "CN" },
+            llmRaw: 75,
+            llmRecommendation: "match",
+            ingestEvidence: { directRoleMatch: true, industryVerifiedRelevantYears: 3, matchedWorkEntries: ["cnc sales 2y"] },
+        });
+        expect(result.coverage).toBe("full");
+        expect(result.evidenceBandMax).toBe(100);
+        expect(result.missingReasons).toHaveLength(0);
+    });
+
+    it("partial coverage: directRoleMatch=false AND domainYears >= minRoleYears → evidenceBandMax=65", () => {
+        const result = evaluateRelatedExpEvidence({
+            context: { roleFilterType: "sales", minRoleYears: 1, market: "CN" },
+            llmRaw: 84,
+            llmRecommendation: "match",
+            ingestEvidence: { directRoleMatch: false, industryVerifiedRelevantYears: 2, matchedWorkEntries: [] },
+        });
+        expect(result.coverage).toBe("partial");
+        expect(result.evidenceBandMax).toBe(65);
+        expect(result.missingReasons.length).toBeGreaterThan(0);
+    });
+
+    it("weak coverage: directRoleMatch=false AND domainYears > 0 (< minRoleYears) → evidenceBandMax=45", () => {
+        const result = evaluateRelatedExpEvidence({
+            context: { roleFilterType: "sales", minRoleYears: 3, market: "CN" },
+            llmRaw: 80,
+            llmRecommendation: "match",
+            ingestEvidence: { directRoleMatch: false, industryVerifiedRelevantYears: 1, matchedWorkEntries: [] },
+        });
+        expect(result.coverage).toBe("weak");
+        expect(result.evidenceBandMax).toBe(45);
+        expect(result.missingReasons.length).toBeGreaterThan(0);
+    });
+
+    it("no coverage: directRoleMatch=false AND domainYears=0 → evidenceBandMax=30", () => {
+        const result = evaluateRelatedExpEvidence({
+            context: { roleFilterType: "sales", minRoleYears: 1, market: "CN" },
+            llmRaw: 84,
+            llmRecommendation: "match",
+            ingestEvidence: { directRoleMatch: false, industryVerifiedRelevantYears: 0, matchedWorkEntries: [] },
+        });
+        expect(result.coverage).toBe("none");
+        expect(result.evidenceBandMax).toBe(30);
+        expect(result.missingReasons.length).toBeGreaterThan(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// effectiveRaw = min(llmRaw, recommendationMax, evidenceBandMax)
+// ---------------------------------------------------------------------------
+
+describe("evaluateRelatedExpEvidence: effectiveRaw ceiling", () => {
+    it("effectiveRaw is suppressed when llmRaw > evidenceBandMax", () => {
+        const result = evaluateRelatedExpEvidence({
+            context: { roleFilterType: "sales", minRoleYears: 1, market: "CN" },
+            llmRaw: 84,
+            llmRecommendation: "match",
+            ingestEvidence: { directRoleMatch: false, industryVerifiedRelevantYears: 0 },
+        });
+        expect(result.effectiveRaw).toBeLessThanOrEqual(30);  // evidenceBandMax=30
+        expect(result.effectiveRaw).toBeLessThanOrEqual(result.llmRaw);
+    });
+
+    it("effectiveRaw = llmRaw when llmRaw < evidenceBandMax (full coverage)", () => {
+        const result = evaluateRelatedExpEvidence({
+            context: { roleFilterType: "sales", minRoleYears: 1, market: "CN" },
+            llmRaw: 75,
+            llmRecommendation: "match",
+            ingestEvidence: { directRoleMatch: true, industryVerifiedRelevantYears: 3 },
+        });
+        expect(result.effectiveRaw).toBe(75);  // llmRaw < 100 (evidenceBandMax), no suppression
+    });
+
+    it("effectiveRaw respects recommendationMax ceiling (potential → 60)", () => {
+        const result = evaluateRelatedExpEvidence({
+            context: { roleFilterType: "sales", minRoleYears: 1, market: "CN" },
+            llmRaw: 80,
+            llmRecommendation: "potential",
+            ingestEvidence: { directRoleMatch: true, industryVerifiedRelevantYears: 3 },
+        });
+        // recommendationMax for potential=60; evidenceBandMax=100 (full coverage)
+        // effectiveRaw = min(80, 60, 100) = 60
+        expect(result.effectiveRaw).toBeLessThanOrEqual(60);
+        expect(result.recommendationMax).toBe(60);
+    });
+
+    it("effectiveRaw respects recommendationMax for no_match (ceiling=30)", () => {
+        const result = evaluateRelatedExpEvidence({
+            context: { roleFilterType: "sales", minRoleYears: 1, market: "CN" },
+            llmRaw: 20,
+            llmRecommendation: "no_match",
+            ingestEvidence: { directRoleMatch: true, industryVerifiedRelevantYears: 5 },
+        });
+        // recommendationMax for no_match=30; effectiveRaw = min(20, 30, 100) = 20
+        expect(result.effectiveRaw).toBeLessThanOrEqual(30);
+        expect(result.recommendationMax).toBe(30);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Never-boosts contract
+// ---------------------------------------------------------------------------
+
+describe("evaluateRelatedExpEvidence: never-boosts invariant", () => {
+    it("effectiveRaw is always <= llmRaw (no boosting)", () => {
+        const cases: RelatedExpEvidenceInput[] = [
+            {
+                context: { roleFilterType: "sales", market: "CN" },
+                llmRaw: 30,
+                llmRecommendation: "potential",
+                ingestEvidence: { directRoleMatch: true, industryVerifiedRelevantYears: 5 },
+            },
+            {
+                context: { roleFilterType: "any" },
+                llmRaw: 0,
+                llmRecommendation: "no_match",
+                ingestEvidence: { directRoleMatch: false, industryVerifiedRelevantYears: 0 },
+            },
+            {
+                context: {},
+                llmRaw: 100,
+                llmRecommendation: "strong_match",
+                ingestEvidence: { directRoleMatch: true, industryVerifiedRelevantYears: 10 },
+            },
+        ];
+        for (const input of cases) {
+            const result = evaluateRelatedExpEvidence(input);
+            expect(result.effectiveRaw).toBeLessThanOrEqual(input.llmRaw);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Output shape completeness
+// ---------------------------------------------------------------------------
+
+describe("evaluateRelatedExpEvidence: output shape", () => {
+    it("returns all required fields", () => {
+        const result = evaluateRelatedExpEvidence({
+            context: { roleFilterType: "sales", minRoleYears: 1, market: "CN" },
+            llmRaw: 80,
+            llmRecommendation: "match",
+            ingestEvidence: { directRoleMatch: false, industryVerifiedRelevantYears: 0 },
+        });
+
+        expect(typeof result.evidenceBandMax).toBe("number");
+        expect(["full", "partial", "weak", "none"]).toContain(result.coverage);
+        expect(Array.isArray(result.missingReasons)).toBe(true);
+        expect(typeof result.effectiveRaw).toBe("number");
+        expect(typeof result.llmRaw).toBe("number");
+        expect(typeof result.recommendationMax).toBe("number");
+        expect(typeof result.contextHash).toBe("string");
+        expect(typeof result.rubricVersion).toBe("string");
+        expect(result.contextHash.length).toBeGreaterThan(0);
+        expect(result.rubricVersion.length).toBeGreaterThan(0);
+    });
+
+    it("llmRaw is echoed back unchanged", () => {
+        const result = evaluateRelatedExpEvidence({
+            context: {},
+            llmRaw: 77,
+            llmRecommendation: "match",
+            ingestEvidence: { directRoleMatch: false, industryVerifiedRelevantYears: 0 },
+        });
+        expect(result.llmRaw).toBe(77);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Missing minRoleYears defaults
+// ---------------------------------------------------------------------------
+
+describe("evaluateRelatedExpEvidence: missing context defaults", () => {
+    it("missing minRoleYears treats minRoleYears as 0 (any years qualifies)", () => {
+        // directRoleMatch=false, domainYears=1, minRoleYears=undefined → partial (domainYears >= 0)
+        const result = evaluateRelatedExpEvidence({
+            context: { roleFilterType: "sales" },
+            llmRaw: 80,
+            llmRecommendation: "match",
+            ingestEvidence: { directRoleMatch: false, industryVerifiedRelevantYears: 1 },
+        });
+        // domainYears(1) >= defaultMinRoleYears(0) → partial coverage at most
+        expect(["partial"]).toContain(result.coverage);
+        expect(result.evidenceBandMax).toBe(65);
+    });
+
+    it("empty context with no ingest evidence → no coverage band", () => {
+        const result = evaluateRelatedExpEvidence({
+            context: {},
+            llmRaw: 80,
+            llmRecommendation: "match",
+            ingestEvidence: { directRoleMatch: false, industryVerifiedRelevantYears: 0 },
+        });
+        expect(result.coverage).toBe("none");
+        expect(result.evidenceBandMax).toBe(30);
+    });
+});

--- a/packages/shared/src/scoring/related-exp-evaluator.ts
+++ b/packages/shared/src/scoring/related-exp-evaluator.ts
@@ -1,0 +1,192 @@
+/**
+ * P1: context-derived evidence ceiling evaluator for the related_exp factor.
+ *
+ * Computes an `evidenceBandMax` from ingest evidence + search context and applies
+ * it as a lower-only cap on the LLM-assigned `related_exp` score.
+ *
+ *   effectiveRaw = min(llmRaw, recommendationMax, evidenceBandMax)
+ *
+ * The evaluator is generic (no domain-specific vocabulary). Coverage is derived
+ * purely from structural evidence fields — `directRoleMatch`, `industryVerifiedRelevantYears`,
+ * and `minRoleYears` from context.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RelatedExpCoverage = "full" | "partial" | "weak" | "none";
+
+export interface RelatedExpContextInput {
+    /** "sales" | "technical" | "any" — role type required by the JD/search profile */
+    roleFilterType?: string;
+    /** Minimum domain-role years required (from search profile or JD) */
+    minRoleYears?: number;
+    /** "CN" | "MY" — market context */
+    market?: string;
+    /** Output locale — "zh" | "en" */
+    locale?: string;
+}
+
+export interface RelatedExpIngestEvidence {
+    /** True when a work entry's role directly matches the required role type */
+    directRoleMatch?: boolean;
+    /** Domain-verified relevant years from ingest pipeline */
+    industryVerifiedRelevantYears?: number;
+    /** Text evidence snippets from matched work entries (for missingReasons) */
+    matchedWorkEntries?: string[];
+}
+
+export interface RelatedExpEvidenceInput {
+    context: RelatedExpContextInput;
+    llmRaw: number;
+    llmRecommendation: string;
+    ingestEvidence: RelatedExpIngestEvidence;
+}
+
+export interface RelatedExpEvidenceResult {
+    /** 100 | 65 | 45 | 30 — derived from coverage band */
+    evidenceBandMax: number;
+    coverage: RelatedExpCoverage;
+    /** Reasons why the ceiling was applied (empty when full coverage) */
+    missingReasons: string[];
+    /** min(llmRaw, recommendationMax, evidenceBandMax) — lower-only */
+    effectiveRaw: number;
+    llmRaw: number;
+    recommendationMax: number;
+    /** Stable hash of the sorted context for provenance */
+    contextHash: string;
+    /** Version string for this rubric — bump when coverage logic changes */
+    rubricVersion: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const RUBRIC_VERSION = "1.0.0";
+
+const RECOMMENDATION_MAX: Record<string, number> = {
+    strong_match: 100,
+    match: 100,
+    potential: 60,
+    no_match: 30,
+};
+
+const EVIDENCE_BAND_MAX: Record<RelatedExpCoverage, number> = {
+    full: 100,
+    partial: 65,
+    weak: 45,
+    none: 30,
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** FNV-1a 32-bit hash — same algorithm as analysis-key.ts:stableHash */
+function stableHash(seed: string): string {
+    let hash = 2166136261;
+    for (const char of seed) {
+        hash ^= char.codePointAt(0) ?? 0;
+        hash = Math.imul(hash, 16777619);
+    }
+    return (hash >>> 0).toString(16);
+}
+
+function buildContextHash(context: RelatedExpContextInput): string {
+    const sorted = Object.entries(context)
+        .filter(([, v]) => v !== undefined)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}:${v}`)
+        .join("|");
+    return stableHash(sorted);
+}
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
+}
+
+// ---------------------------------------------------------------------------
+// Coverage classification
+// ---------------------------------------------------------------------------
+
+function classifyCoverage(
+    directRoleMatch: boolean,
+    domainYears: number,
+    minRoleYears: number,
+): { coverage: RelatedExpCoverage; missingReasons: string[] } {
+    const missingReasons: string[] = [];
+
+    if (directRoleMatch && domainYears >= minRoleYears) {
+        return { coverage: "full", missingReasons: [] };
+    }
+
+    if (!directRoleMatch) {
+        missingReasons.push("no direct role match in work history");
+    }
+
+    // none: no domain evidence at all
+    if (domainYears === 0) {
+        missingReasons.push("zero domain-verified relevant years");
+        return { coverage: "none", missingReasons };
+    }
+
+    if (domainYears < minRoleYears) {
+        missingReasons.push(
+            `insufficient domain-verified years (${domainYears} < ${minRoleYears} required)`,
+        );
+    }
+
+    if (!directRoleMatch && domainYears >= minRoleYears) {
+        // Has domain years meeting threshold but no direct role match
+        return { coverage: "partial", missingReasons };
+    }
+
+    // directRoleMatch=false AND domainYears > 0 AND domainYears < minRoleYears
+    return { coverage: "weak", missingReasons };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate the evidence band ceiling for a resume's `related_exp` score.
+ *
+ * @param input - LLM output, ingest evidence, and search context
+ * @returns Evidence result with effectiveRaw = min(llmRaw, recommendationMax, evidenceBandMax)
+ */
+export function evaluateRelatedExpEvidence(
+    input: RelatedExpEvidenceInput,
+): RelatedExpEvidenceResult {
+    const { context, llmRaw, llmRecommendation, ingestEvidence } = input;
+
+    const directRoleMatch = ingestEvidence.directRoleMatch ?? false;
+    const domainYears = typeof ingestEvidence.industryVerifiedRelevantYears === "number"
+        && Number.isFinite(ingestEvidence.industryVerifiedRelevantYears)
+        ? Math.max(0, ingestEvidence.industryVerifiedRelevantYears)
+        : 0;
+    const minRoleYears = typeof context.minRoleYears === "number"
+        && Number.isFinite(context.minRoleYears)
+        ? Math.max(0, context.minRoleYears)
+        : 0;
+
+    const recommendationMax = RECOMMENDATION_MAX[llmRecommendation] ?? 30;
+    const { coverage, missingReasons } = classifyCoverage(directRoleMatch, domainYears, minRoleYears);
+    const evidenceBandMax = EVIDENCE_BAND_MAX[coverage];
+
+    const safeRaw = clamp(typeof llmRaw === "number" && Number.isFinite(llmRaw) ? llmRaw : 0, 0, 100);
+    const effectiveRaw = Math.min(safeRaw, recommendationMax, evidenceBandMax);
+
+    return {
+        evidenceBandMax,
+        coverage,
+        missingReasons,
+        effectiveRaw,
+        llmRaw: safeRaw,
+        recommendationMax,
+        contextHash: buildContextHash(context),
+        rubricVersion: RUBRIC_VERSION,
+    };
+}


### PR DESCRIPTION
## Summary

P1 of the related_exp scoring refactor — context-derived evidence ceiling.

Prerequisite: P0.5 (\`score = related_exp\`) merged in #1176.

### Changes

- **RelatedExpContext plumbing** — \`relatedExpContext\` field added to \`analysis_tasks\` Convex dispatch args and schema config (optional, backward-compatible). Callers can now thread \`roleFilterType\`, \`minRoleYears\`, \`market\`, \`locale\` from the API analyze route into the task processor.

- **\`evaluateRelatedExpEvidence()\`** — new pure function in \`packages/shared/src/scoring/related-exp-evaluator.ts\`:
  - Coverage bands: \`full(100) / partial(65) / weak(45) / none(30)\` derived from \`directRoleMatch\` + \`industryVerifiedRelevantYears\` vs \`minRoleYears\`
  - \`effectiveRaw = min(llmRaw, recommendationMax, evidenceBandMax)\` — **lower-only**, never boosts
  - Returns \`missingReasons\`, \`contextHash\` (FNV-1a of sorted context), \`rubricVersion\`

- **\`normalizeAnalysisResult()\` wired** — optional 3rd arg \`{ context, ingestEvidence }\`; when present: \`breakdown.related_exp = effectiveRaw\`, \`relatedExpEvidence\` stored in result. Legacy path (no context) unchanged.

- **Audit script** — \`audit_hr_feedback_export.py\` updated:
  - Factor (\`Related Exp\` = score gate metric) separated from display signal (\`Industry DB\`)
  - New columns: \`Evidence Band Max\`, \`Effective Related Exp\`, \`Missing Reasons\`
  - Summary JSON includes \`gateMetric\` and \`scoringModel\` fields for clarity

## Test Plan

- [x] \`evaluateRelatedExpEvidence()\` — 13 unit tests covering all coverage bands, effectiveRaw ceiling, never-boosts invariant, output shape
- [x] \`normalizeAnalysisResult\` with context — 5 new tests (with/without context, backward compat)
- [x] \`analysis_tasks.dispatch\` — 3 new tests (context stored, partial fields, backward compat)
- [x] \`npm test\` — 272 files, 5221 passed, 7 skipped
- [x] \`make check\` — passes (typecheck + lint + governance + skill sync)

## Acceptance Gate (after wiring context from API dispatch)

Once \`roleFilterType\`/\`minRoleYears\` are threaded from the API analyze route and a fresh analysis run is done against the 42-row HR cohort:

| Gate | Target |
|---|---|
| \`not_suitable\` rel_exp >=80 | **≤ 3 / 23** |
| \`strong_match\` rel_exp >=70 | **2 / 2** |
| \`requires_field_office_confirmation\` rel_exp >=70 | **≥ 8 / 14** |
| FHR-NS (not_suitable recommendation = match/strong_match) | **0%** |

## Notes

- The API analyze route does not yet pass \`relatedExpContext\` to dispatch (no \`roleFilterType\`/\`minRoleYears\` in current \`AnalyzeRequestSchema\`). Wiring that plumbing end-to-end (API schema → dispatch call) is the next step before running the acceptance audit.
- No domain-specific vocabulary in the evaluator — coverage is derived from structural evidence fields only.