### PR TITLE
fix(scoring): activate related exp evidence context

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -1510,6 +1510,72 @@ describe("resume routes", () => {
     }));
   });
 
+  it("sends related experience context to convex analysis dispatch", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes_search:searchWithTagExpansionPaginated") {
+        return convexSuccess({
+          page: [
+            {
+              resume: buildConvexResumeRecord("resume-live-1", {
+                name: "Alice",
+                location: "China",
+              }),
+              provenance: [{ term: "销售", source: "searchText" }],
+            },
+          ],
+          continuationCursor: null,
+        });
+      }
+
+      if (call.pathName === "analysis_tasks:dispatch") {
+        expect(call.args).toEqual(expect.objectContaining({
+          keywords: ["cnc", "销售"],
+          resumeIds: ["resume-live-1"],
+          relatedExpContext: {
+            roleFilterType: "sales",
+            minRoleYears: 1,
+            market: "CN",
+          },
+        }));
+        return convexSuccess("task-related-exp");
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes/analyze", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: "CNC 销售",
+        limit: 500,
+        roleFilterType: "sales",
+        minRoleYears: 1,
+        market: "CN",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toEqual(expect.objectContaining({
+      success: true,
+      taskId: "task-related-exp",
+      resumeCount: 1,
+    }));
+    expect(calls.map((call) => call.pathName)).toEqual([
+      "resumes_search:searchWithTagExpansionPaginated",
+      "analysis_tasks:dispatch",
+    ]);
+  });
+
   it("omits a null cursor on the first dry-run clear-analyses mutation call", async () => {
     const calls: ConvexCall[] = [];
 

--- a/packages/cli/cmd/mcp.go
+++ b/packages/cli/cmd/mcp.go
@@ -315,6 +315,9 @@ func mcpTools() []map[string]any {
 					"maxSalary":         map[string]any{"type": "integer", "minimum": 0},
 					"limit":             map[string]any{"type": "integer", "minimum": 1, "maximum": 500},
 					"dryRun":            map[string]any{"type": "boolean"},
+					"roleFilterType":    map[string]any{"type": "string"},
+					"minRoleYears":      map[string]any{"type": "integer", "minimum": 0},
+					"market":            map[string]any{"type": "string"},
 				},
 			},
 		},
@@ -452,6 +455,9 @@ func runMCPTool(ctx context.Context, name string, args map[string]interface{}) (
 			MaxSalary:        intArg(args, "maxSalary", 0),
 			Limit:            intArg(args, "limit", 50),
 			DryRun:           boolArg(args, "dryRun", false),
+			RoleFilterType:   stringArg(args, "roleFilterType", ""),
+			MinRoleYears:     intArg(args, "minRoleYears", 0),
+			Market:           stringArg(args, "market", ""),
 		})
 		if err != nil {
 			return "", err

--- a/packages/cli/cmd/mcp_test.go
+++ b/packages/cli/cmd/mcp_test.go
@@ -487,6 +487,15 @@ func TestRunMCPToolResumeAnalyze(t *testing.T) {
 		if body["dryRun"] != true {
 			t.Fatalf("expected dryRun=true, got %v", body["dryRun"])
 		}
+		if body["roleFilterType"] != "sales" {
+			t.Fatalf("expected roleFilterType=sales, got %v", body["roleFilterType"])
+		}
+		if body["minRoleYears"] != float64(1) {
+			t.Fatalf("expected minRoleYears=1, got %v", body["minRoleYears"])
+		}
+		if body["market"] != "CN" {
+			t.Fatalf("expected market=CN, got %v", body["market"])
+		}
 		_ = json.NewEncoder(w).Encode(client.AnalyzeResponse{
 			Success:      true,
 			DryRun:        true,
@@ -502,8 +511,11 @@ func TestRunMCPToolResumeAnalyze(t *testing.T) {
 	setResumeCLIConfig(t, server.URL, "dev")
 
 	text, err := runMCPTool(context.Background(), "resume_analyze", map[string]interface{}{
-		"query":  "CNC 销售",
-		"dryRun": true,
+		"query":          "CNC 销售",
+		"roleFilterType": "sales",
+		"minRoleYears":   1,
+		"market":         "CN",
+		"dryRun":         true,
 	})
 	if err != nil {
 		t.Fatalf("runMCPTool returned error: %v", err)

--- a/packages/cli/cmd/resume.go
+++ b/packages/cli/cmd/resume.go
@@ -258,6 +258,9 @@ func newResumeAnalyzeCmd() *cobra.Command {
 		maxSalary        int
 		limit            int
 		dryRun           bool
+		roleType         string
+		minRoleYears     int
+		market           string
 	)
 
 	cmd := &cobra.Command{
@@ -300,6 +303,9 @@ func newResumeAnalyzeCmd() *cobra.Command {
 				MaxSalary:        maxSalary,
 				Limit:            limit,
 				DryRun:           dryRun,
+				RoleFilterType:   strings.TrimSpace(roleType),
+				MinRoleYears:     minRoleYears,
+				Market:           strings.TrimSpace(market),
 			}
 
 			response, err := newAPIClient().AnalyzeResumes(context.Background(), request)
@@ -328,6 +334,9 @@ func newResumeAnalyzeCmd() *cobra.Command {
 	cmd.Flags().IntVar(&maxSalary, "max-salary", 0, "Max salary")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Max candidates to analyze (1-500)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview candidate count without dispatching")
+	cmd.Flags().StringVar(&roleType, "role-type", "", "Role filter type for related experience evidence (e.g. sales)")
+	cmd.Flags().IntVar(&minRoleYears, "min-role-years", 0, "Minimum role years for related experience evidence")
+	cmd.Flags().StringVar(&market, "market", "", "Market context for related experience evidence (e.g. CN, MY)")
 
 	return cmd
 }

--- a/packages/cli/cmd/resume_test.go
+++ b/packages/cli/cmd/resume_test.go
@@ -250,6 +250,19 @@ func TestResumeAnalyzeCommandDryRunWritesJSON(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Fatalf("unexpected method: %s", r.Method)
 		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if body["roleFilterType"] != "sales" {
+			t.Fatalf("expected roleFilterType=sales, got %v", body["roleFilterType"])
+		}
+		if body["minRoleYears"] != float64(1) {
+			t.Fatalf("expected minRoleYears=1, got %v", body["minRoleYears"])
+		}
+		if body["market"] != "CN" {
+			t.Fatalf("expected market=CN, got %v", body["market"])
+		}
 		_ = json.NewEncoder(w).Encode(client.AnalyzeResponse{
 			Success:      true,
 			DryRun:        true,
@@ -270,7 +283,14 @@ func TestResumeAnalyzeCommandDryRunWritesJSON(t *testing.T) {
 	var output bytes.Buffer
 	cmd.SetOut(&output)
 	cmd.SetErr(&output)
-	cmd.SetArgs([]string{"--query", "CNC 销售", "--location", "Dongguan", "--dry-run"})
+	cmd.SetArgs([]string{
+		"--query", "CNC 销售",
+		"--location", "Dongguan",
+		"--role-type", "sales",
+		"--min-role-years", "1",
+		"--market", "CN",
+		"--dry-run",
+	})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("resume analyze command failed: %v", err)

--- a/packages/cli/internal/client/api.go
+++ b/packages/cli/internal/client/api.go
@@ -629,6 +629,9 @@ type AnalyzeRequest struct {
 	MaxSalary        int      `json:"maxSalary,omitempty"`
 	Limit            int      `json:"limit,omitempty"`
 	DryRun           bool     `json:"dryRun,omitempty"`
+	RoleFilterType   string   `json:"roleFilterType,omitempty"`
+	MinRoleYears     int      `json:"minRoleYears,omitempty"`
+	Market           string   `json:"market,omitempty"`
 }
 
 type AnalyzeConfig struct {

--- a/packages/convex/__tests__/analysis-idempotency.test.ts
+++ b/packages/convex/__tests__/analysis-idempotency.test.ts
@@ -70,4 +70,55 @@ describe("buildAnalysisDispatchIdempotencyKey", () => {
         expect(base).not.toBe(differentLocation);
         expect(base).not.toBe(differentVersion);
     });
+
+    it("changes when related experience context is added or changed", () => {
+        const base = buildAnalysisDispatchIdempotencyKey({
+            keywords: ["cnc", "sales"],
+            resumeIds: ["resume:1"],
+        });
+        const salesContext = buildAnalysisDispatchIdempotencyKey({
+            keywords: ["cnc", "sales"],
+            relatedExpContext: {
+                roleFilterType: "sales",
+                minRoleYears: 1,
+                market: "CN",
+            },
+            resumeIds: ["resume:1"],
+        });
+        const technicalContext = buildAnalysisDispatchIdempotencyKey({
+            keywords: ["cnc", "sales"],
+            relatedExpContext: {
+                roleFilterType: "technical",
+                minRoleYears: 1,
+                market: "CN",
+            },
+            resumeIds: ["resume:1"],
+        });
+
+        expect(base).not.toBe(salesContext);
+        expect(salesContext).not.toBe(technicalContext);
+    });
+
+    it("normalizes related experience context formatting in keys", () => {
+        const keyA = buildAnalysisDispatchIdempotencyKey({
+            keywords: ["cnc", "sales"],
+            relatedExpContext: {
+                roleFilterType: " Sales ",
+                minRoleYears: 1,
+                market: "cn",
+            },
+            resumeIds: ["resume:1"],
+        });
+        const keyB = buildAnalysisDispatchIdempotencyKey({
+            keywords: ["cnc", "sales"],
+            relatedExpContext: {
+                roleFilterType: "sales",
+                minRoleYears: 1,
+                market: "CN",
+            },
+            resumeIds: ["resume:1"],
+        });
+
+        expect(keyA).toBe(keyB);
+    });
 });

--- a/packages/convex/__tests__/analysis-tasks-parsing.test.ts
+++ b/packages/convex/__tests__/analysis-tasks-parsing.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 // For now, test the exported normalizeKeywords and extractKeywords
 // by verifying their behavior through the idempotency key construction.
 
-import { buildAnalysisDispatchIdempotencyKey } from "../convex/analysis_tasks";
+import { buildAnalysisDispatchIdempotencyKey, buildRelatedExpCtxArg } from "../convex/analysis_tasks";
 
 // We'll also directly test normalizeKeywords and extractKeywords
 // by duplicating their logic in tests (since they're simple pure functions)
@@ -59,6 +59,110 @@ describe("normalizeKeywords behavior (via idempotency key)", () => {
       resumeIds: ["resume:1"],
     });
     expect(keyA).toBe(keyB);
+  });
+});
+
+describe("buildRelatedExpCtxArg", () => {
+  it("returns undefined when a task has no related_exp context", () => {
+    const result = buildRelatedExpCtxArg(
+      { ingestData: { roleSignals: [] } },
+      {},
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("extracts direct role match and industry-verified years from matching role signals", () => {
+    const result = buildRelatedExpCtxArg(
+      {
+        ingestData: {
+          roleSignals: [
+            {
+              type: "technical",
+              matchedSignals: ["engineer"],
+              signalCount: 1,
+              occurrences: 1,
+              years: 4,
+              industryVerifiedRelevantYears: 4,
+              matchedWorkEntries: [
+                {
+                  companyName: "CNC Automation Ltd",
+                  jobTitle: "Service Engineer",
+                  years: 4,
+                  industryVerified: true,
+                  matchedSignals: ["engineer"],
+                  directRoleMatch: true,
+                },
+              ],
+              verifyIn: "workHistory",
+            },
+            {
+              type: "sales",
+              matchedSignals: ["sales"],
+              signalCount: 1,
+              occurrences: 1,
+              years: 2,
+              industryVerifiedRelevantYears: 1.5,
+              matchedWorkEntries: [
+                {
+                  companyName: "CNC Machines Co",
+                  jobTitle: "Sales Manager",
+                  years: 1.5,
+                  industryVerified: true,
+                  matchedSignals: ["sales"],
+                  directRoleMatch: true,
+                },
+              ],
+              verifyIn: "workHistory",
+            },
+          ],
+        },
+      },
+      {
+        roleFilterType: "sales",
+        minRoleYears: 1,
+        market: "CN",
+        locale: "zh",
+      },
+    );
+
+    expect(result).toEqual({
+      context: {
+        roleFilterType: "sales",
+        minRoleYears: 1,
+        market: "CN",
+        locale: "zh",
+      },
+      ingestEvidence: {
+        directRoleMatch: true,
+        industryVerifiedRelevantYears: 1.5,
+        matchedWorkEntries: ["Sales Manager @ CNC Machines Co (1.5y)"],
+      },
+    });
+  });
+
+  it("still returns empty evidence when context is present but ingest role signals are missing", () => {
+    const result = buildRelatedExpCtxArg(
+      { ingestData: {} },
+      {
+        roleFilterType: "sales",
+        minRoleYears: 1,
+        market: "CN",
+      },
+    );
+
+    expect(result).toEqual({
+      context: {
+        roleFilterType: "sales",
+        minRoleYears: 1,
+        market: "CN",
+      },
+      ingestEvidence: {
+        directRoleMatch: false,
+        industryVerifiedRelevantYears: 0,
+        matchedWorkEntries: [],
+      },
+    });
   });
 });
 

--- a/packages/convex/__tests__/schema-validator-sync.test.ts
+++ b/packages/convex/__tests__/schema-validator-sync.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { normalizeEducationLevel, parseExperienceYears } from "@trends/shared";
-import { ingestDataValidator, collectionTaskResultsValidator } from "../convex/validators";
+import { ingestDataValidator, collectionTaskResultsValidator, resumeAnalysisValidator } from "../convex/validators";
 import { storeConfirmResult } from "../convex/analyze";
+import schema from "../convex/schema";
 import * as resumesModule from "../convex/resumes";
 
 /**
@@ -101,7 +102,21 @@ describe("analysis validator sync (with intentional overrides)", () => {
      * containing all schema-defined fields without error.
      */
 
-    const ALL_SCHEMA_ANALYSIS_FIELDS = [
+    const PRIMARY_RESUME_ANALYSIS_FIELDS = [
+        "score",
+        "summary",
+        "highlights",
+        "recommendation",
+        "breakdown",
+        "jobDescriptionId",
+        "promptVersion",
+        "locale",
+        "queryLocation",
+        "analyzedAt",
+        "relatedExpEvidence",
+    ].sort();
+
+    const CONFIRM_RESULT_ANALYSIS_FIELDS = [
         "score",
         "summary",
         "highlights",
@@ -114,7 +129,15 @@ describe("analysis validator sync (with intentional overrides)", () => {
         "analyzedAt",
     ] as const;
 
-    it("storeConfirmResult accepts all schema analysis fields", async () => {
+    it("resumes.analysis schema stays in sync with the shared primary analysis validator", () => {
+        const resumeFields = schema.tables.resumes.validator.fields;
+        const analysisValidator = resumeFields.analysis as { fields: Record<string, unknown> };
+
+        expect(getFieldNames(analysisValidator)).toEqual(PRIMARY_RESUME_ANALYSIS_FIELDS);
+        expect(getFieldNames(resumeAnalysisValidator)).toEqual(PRIMARY_RESUME_ANALYSIS_FIELDS);
+    });
+
+    it("storeConfirmResult accepts all confirm analysis fields", async () => {
         const patch = vi.fn(async () => undefined);
 
         const ctx = {
@@ -131,7 +154,7 @@ describe("analysis validator sync (with intentional overrides)", () => {
             _handler: (ctx: unknown, args: unknown) => Promise<unknown>;
         })._handler;
 
-        // Provide ALL schema fields — this should succeed without
+        // Provide all confirm-result fields — this should succeed without
         // ArgumentValidationError if the validator includes them
         const fullAnalysisPayload = {
             resumeId: "resume-1",
@@ -156,13 +179,10 @@ describe("analysis validator sync (with intentional overrides)", () => {
         expect(patch).toHaveBeenCalledTimes(1);
     });
 
-    it("all schema analysis fields are tested", () => {
-        // Meta-test: ensure ALL_SCHEMA_ANALYSIS_FIELDS stays in sync with
-        // the schema definition in schema.ts
+    it("all confirm analysis fields are tested", () => {
         const expectedCount = 10; // score, summary, highlights, recommendation,
-                                  // breakdown, jobDescriptionId, promptVersion,
-                                  // locale, queryLocation, analyzedAt
-        expect(ALL_SCHEMA_ANALYSIS_FIELDS).toHaveLength(expectedCount);
+        // breakdown, jobDescriptionId, promptVersion, locale, queryLocation, analyzedAt
+        expect(CONFIRM_RESULT_ANALYSIS_FIELDS).toHaveLength(expectedCount);
     });
 });
 

--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -3,7 +3,11 @@ import type { Doc } from "./_generated/dataModel";
 import { internalAction, internalMutation, internalQuery, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { api } from "./_generated/api";
-import { getCurrentResumeAiPromptVersion } from "@trends/shared";
+import {
+    getCurrentResumeAiPromptVersion,
+    type RelatedExpContextInput,
+    type RelatedExpIngestEvidence,
+} from "@trends/shared";
 import {
     buildKeywordMatchingRules,
     buildKeywordRequirements,
@@ -24,6 +28,7 @@ import { resolveAnalysisParallelism } from "./lib/parallelism";
 import { computeProtectedAttributeHashes } from "./audit.js";
 import {
     type AnalysisResult,
+    isObject,
     parseLlmResult,
     extractKeywords,
     normalizeKeywords,
@@ -50,6 +55,106 @@ export {
 } from "./lib/analysis_task_helpers.js";
 
 type AnalysisTaskStatus = "pending" | "processing" | "completed" | "failed" | "cancelled";
+
+export type RelatedExpNormalizeContextArg = {
+    context: RelatedExpContextInput;
+    ingestEvidence: RelatedExpIngestEvidence;
+};
+
+function hasRelatedExpContext(context: RelatedExpContextInput | undefined): context is RelatedExpContextInput {
+    if (!context) {
+        return false;
+    }
+    return (
+        (typeof context.roleFilterType === "string" && context.roleFilterType.trim().length > 0)
+        || (typeof context.minRoleYears === "number" && Number.isFinite(context.minRoleYears))
+        || (typeof context.market === "string" && context.market.trim().length > 0)
+        || (typeof context.locale === "string" && context.locale.trim().length > 0)
+    );
+}
+
+function roleTypeMatches(signalType: unknown, roleFilterType: string | undefined): boolean {
+    if (!roleFilterType || roleFilterType.trim().length === 0 || roleFilterType.trim().toLowerCase() === "any") {
+        return true;
+    }
+    return typeof signalType === "string" && signalType.trim().toLowerCase() === roleFilterType.trim().toLowerCase();
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function formatMatchedWorkEntry(entry: Record<string, unknown>): string | undefined {
+    const jobTitle = typeof entry.jobTitle === "string" && entry.jobTitle.trim().length > 0
+        ? entry.jobTitle.trim()
+        : undefined;
+    const companyName = typeof entry.companyName === "string" && entry.companyName.trim().length > 0
+        ? entry.companyName.trim()
+        : undefined;
+    const years = readFiniteNumber(entry.years);
+
+    if (!jobTitle && !companyName && years === undefined) {
+        return undefined;
+    }
+
+    const titlePart = jobTitle ?? "role";
+    const companyPart = companyName ? ` @ ${companyName}` : "";
+    const yearsPart = years === undefined ? "" : ` (${years}y)`;
+    return `${titlePart}${companyPart}${yearsPart}`;
+}
+
+export function buildRelatedExpCtxArg(
+    resume: unknown,
+    relatedExpContext: RelatedExpContextInput | undefined,
+): RelatedExpNormalizeContextArg | undefined {
+    if (!hasRelatedExpContext(relatedExpContext)) {
+        return undefined;
+    }
+
+    const roleSignals = isObject(resume)
+        && isObject(resume.ingestData)
+        && Array.isArray(resume.ingestData.roleSignals)
+        ? resume.ingestData.roleSignals
+        : [];
+    const matchingSignals = roleSignals
+        .filter(isObject)
+        .filter((signal) => roleTypeMatches(signal.type, relatedExpContext.roleFilterType));
+
+    let directRoleMatch = false;
+    let industryVerifiedRelevantYears = 0;
+    const matchedWorkEntries: string[] = [];
+
+    for (const signal of matchingSignals) {
+        const signalYears = readFiniteNumber(signal.industryVerifiedRelevantYears);
+        if (signalYears !== undefined) {
+            industryVerifiedRelevantYears = Math.max(industryVerifiedRelevantYears, Math.max(0, signalYears));
+        }
+
+        if (!Array.isArray(signal.matchedWorkEntries)) {
+            continue;
+        }
+
+        for (const rawEntry of signal.matchedWorkEntries) {
+            if (!isObject(rawEntry)) {
+                continue;
+            }
+            directRoleMatch = directRoleMatch || rawEntry.directRoleMatch === true;
+            const formatted = formatMatchedWorkEntry(rawEntry);
+            if (formatted) {
+                matchedWorkEntries.push(formatted);
+            }
+        }
+    }
+
+    return {
+        context: relatedExpContext,
+        ingestEvidence: {
+            directRoleMatch,
+            industryVerifiedRelevantYears,
+            matchedWorkEntries,
+        },
+    };
+}
 
 function classifyResumes(
     resumes: Doc<"resumes">[],
@@ -91,6 +196,7 @@ async function analyzeOneResume(
         jobDescriptionContent?: string;
         keywords?: string[];
         location?: string;
+        relatedExpContext?: RelatedExpContextInput;
     },
     apiKey: string
 ): Promise<AnalysisResult> {
@@ -111,6 +217,12 @@ async function analyzeOneResume(
         ? buildKeywordMatchingRules(normalizedKeywords, locale)
         : (isEnglishLocale ? "Use the default scoring rules." : "使用默认评分标准");
     const normalizedResume = normalizeResume(resume, { locale });
+    const relatedExpContext = hasRelatedExpContext(config.relatedExpContext)
+        ? {
+            ...config.relatedExpContext,
+            locale: config.relatedExpContext.locale ?? locale,
+        }
+        : undefined;
 
     const prompt = hydrateUserPrompt(
         getUserPromptTemplate(locale),
@@ -130,7 +242,11 @@ async function analyzeOneResume(
         try {
             const rawResult = await callLLM(messages, apiKey);
             const parsedResult = parseLlmResult(rawResult);
-            const normalizedResult = normalizeAnalysisResult(parsedResult, resume);
+            const normalizedResult = normalizeAnalysisResult(
+                parsedResult,
+                resume,
+                buildRelatedExpCtxArg(resume, relatedExpContext),
+            );
             return {
                 ...normalizedResult,
                 locale,
@@ -215,6 +331,7 @@ export const dispatch = mutation({
             keywords: normalizedKeywords,
             location: normalizedLocation,
             promptVersion,
+            relatedExpContext: args.relatedExpContext,
             resumeIds: uniqueResumeIds.map((resumeId) => String(resumeId)),
         });
         const idempotencyKey = buildAnalysisDispatchIdempotencyKey({
@@ -224,6 +341,7 @@ export const dispatch = mutation({
             keywords: normalizedKeywords,
             location: normalizedLocation,
             promptVersion,
+            relatedExpContext: args.relatedExpContext,
             resumeIds: uniqueResumeIds.map((resumeId) => String(resumeId)),
         });
 
@@ -583,6 +701,7 @@ export const processAnalysisTask = internalAction({
                                     jobDescriptionContent: task.config.jobDescriptionContent,
                                     keywords: task.config.keywords,
                                     location: normalizedLocation,
+                                    relatedExpContext: task.config.relatedExpContext,
                                 },
                                 apiKey
                             );
@@ -600,6 +719,7 @@ export const processAnalysisTask = internalAction({
                                     locale: result.locale,
                                     ...(normalizedLocation ? { queryLocation: normalizedLocation } : {}),
                                     analyzedAt: Date.now(),
+                                    ...(result.relatedExpEvidence ? { relatedExpEvidence: result.relatedExpEvidence } : {}),
                                 },
                             });
 

--- a/packages/convex/convex/lib/analysis_task_helpers.ts
+++ b/packages/convex/convex/lib/analysis_task_helpers.ts
@@ -7,6 +7,7 @@
 import {
     buildKeywordAnalysisId as buildSharedKeywordAnalysisId,
     getCurrentResumeAiPromptVersion,
+    type RelatedExpContextInput,
 } from "@trends/shared";
 
 // ---------------------------------------------------------------------------
@@ -39,6 +40,7 @@ export type AnalysisDispatchKeyInput = {
     keywords?: string[];
     location?: string;
     promptVersion?: number;
+    relatedExpContext?: RelatedExpContextInput;
     resumeIds: readonly string[];
 };
 
@@ -195,10 +197,40 @@ export function buildKeywordAnalysisId(
     return buildSharedKeywordAnalysisId(keywords, options);
 }
 
+function normalizeContextString(value: string | undefined, options?: { uppercase?: boolean }): string | undefined {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    return options?.uppercase ? trimmed.toUpperCase() : trimmed.toLowerCase();
+}
+
+function buildRelatedExpContextKey(context: RelatedExpContextInput | undefined): string {
+    if (!context) {
+        return "";
+    }
+
+    const roleFilterType = normalizeContextString(context.roleFilterType);
+    const minRoleYears = typeof context.minRoleYears === "number" && Number.isFinite(context.minRoleYears)
+        ? String(context.minRoleYears)
+        : undefined;
+    const market = normalizeContextString(context.market, { uppercase: true });
+    const locale = normalizeContextString(context.locale);
+    const parts = [
+        roleFilterType ? `roleFilterType:${roleFilterType}` : undefined,
+        minRoleYears ? `minRoleYears:${minRoleYears}` : undefined,
+        market ? `market:${market}` : undefined,
+        locale ? `locale:${locale}` : undefined,
+    ].filter((part): part is string => part !== undefined);
+
+    return parts.length > 0 ? `:related-exp:${stableHash(parts.join("|"))}` : "";
+}
+
 export function buildAnalysisDispatchJobKey(input: AnalysisDispatchKeyInput): string {
     const promptVersion = input.promptVersion ?? getCurrentResumeAiPromptVersion();
+    const relatedExpContextKey = buildRelatedExpContextKey(input.relatedExpContext);
     if (input.derivedJobDescriptionId && input.derivedJobDescriptionId.trim()) {
-        return `job:${input.derivedJobDescriptionId.trim().toLowerCase()}:prompt:${promptVersion}`;
+        return `job:${input.derivedJobDescriptionId.trim().toLowerCase()}:prompt:${promptVersion}${relatedExpContextKey}`;
     }
 
     const normalizedKeywords = normalizeKeywords(input.keywords ?? []);
@@ -206,15 +238,15 @@ export function buildAnalysisDispatchJobKey(input: AnalysisDispatchKeyInput): st
         return `keywords:${buildKeywordAnalysisId(normalizedKeywords, {
             location: input.location,
             promptVersion,
-        })}`;
+        })}${relatedExpContextKey}`;
     }
 
     const title = input.jobDescriptionTitle?.trim().toLowerCase() ?? "";
     const content = input.jobDescriptionContent?.trim().toLowerCase() ?? "";
     if (!title && !content) {
-        return `job:default:prompt:${promptVersion}`;
+        return `job:default:prompt:${promptVersion}${relatedExpContextKey}`;
     }
-    return `job-content:prompt:${promptVersion}:${stableHash(`${title}|${content}`)}`;
+    return `job-content:prompt:${promptVersion}:${stableHash(`${title}|${content}`)}${relatedExpContextKey}`;
 }
 
 export function buildAnalysisDispatchIdempotencyKey(input: AnalysisDispatchKeyInput): string {

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1,6 +1,15 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { ingestDataValidator, collectionTaskResultsValidator, resumeFiltersValidator, analysisResultValidator, jsonRecordValidator, jsonValueValidator, relatedExpContextValidator } from "./validators.js";
+import {
+    ingestDataValidator,
+    collectionTaskResultsValidator,
+    resumeFiltersValidator,
+    analysisResultValidator,
+    resumeAnalysisValidator,
+    jsonRecordValidator,
+    jsonValueValidator,
+    relatedExpContextValidator,
+} from "./validators.js";
 
 export default defineSchema({
     // Tasks for resume collection
@@ -65,18 +74,7 @@ export default defineSchema({
         source: v.string(), // e.g. "hr.job5156.com"
 
         // AI Analysis
-        analysis: v.optional(v.object({
-            score: v.number(),
-            summary: v.string(),
-            highlights: v.array(v.string()),
-            recommendation: v.string(),
-            breakdown: v.optional(v.record(v.string(), v.number())),
-            jobDescriptionId: v.optional(v.string()), // Tracks which JD was used for analysis
-            promptVersion: v.optional(v.number()),
-            locale: v.optional(v.string()),
-            queryLocation: v.optional(v.string()),
-            analyzedAt: v.optional(v.number()),
-        })),
+        analysis: v.optional(resumeAnalysisValidator),
 
         // AI Analysis Cache (Multi-JD + source-aware support)
         // Key: `source:<sourceKey>|analysis:<jobDescriptionId>` when the resume source is known,


### PR DESCRIPTION
## Summary
- Threads `relatedExpContext` through CLI/MCP analyze requests and Convex analysis task execution.
- Builds ingest evidence from `roleSignals` and stores `relatedExpEvidence` with `resumes.analysis`.
- Reuses the shared `resumeAnalysisValidator` in `schema.ts` to prevent schema drift, and separates context-aware task idempotency keys from legacy no-context tasks.
- Updates vault concept notes after concept-drift review: `concepts/self-tuning-scoring.md`, `concepts/convex-operations.md`.

## Verification
- `npm test -- packages/convex/__tests__/analysis-idempotency.test.ts packages/convex/__tests__/analysis-tasks-parsing.test.ts packages/convex/__tests__/schema-validator-sync.test.ts`
- `npm test -- apps/api/src/routes/resumes.test.ts -t "related experience context|analyze location filters"`
- `go test ./cmd -run "TestResumeAnalyzeCommandDryRunWritesJSON|TestRunMCPToolResumeAnalyze"`
- `make check`

## Audit Evidence
- 42/42 resumes stored `analysis.relatedExpEvidence`.
- HR cohort gate passed: `not_suitable related_exp >= 80` is `3/23`, target `<= 3/23`.
- Final audit CSV: `/Users/karlchow/Documents/resumes-export-current-convex-hr-feedback-42-2026-06-02T02-24-01-3NZ.csv`.
- Final audit JSON: `/Users/karlchow/Documents/resumes-export-current-convex-hr-feedback-42-2026-06-02T02-24-01-3NZ.audit.json`.

## Sources Used
- Local implementation: `apps/api/src/routes/resumes.ts`, `packages/convex/convex/analysis_tasks.ts`, `packages/convex/convex/lib/analysis_task_helpers.ts`, `packages/convex/convex/schema.ts`, `packages/convex/convex/validators.ts`, `packages/cli/cmd/resume.go`, `packages/cli/cmd/mcp.go`.
- Local tests: `apps/api/src/routes/resumes.test.ts`, `packages/convex/__tests__/analysis-idempotency.test.ts`, `packages/convex/__tests__/analysis-tasks-parsing.test.ts`, `packages/convex/__tests__/schema-validator-sync.test.ts`, `packages/cli/cmd/resume_test.go`, `packages/cli/cmd/mcp_test.go`.
- Vault: `projects/trends/work/2026-06-01-related-exp-context-refactor-audit/spec.md`, `concepts/self-tuning-scoring.md`, `concepts/convex-operations.md`.
