### PR TITLE
fix(scoring): make industry db single-hit baseline default 40

### DIFF
--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -469,7 +469,7 @@ describe("resume export route", () => {
       const parsed = Papa.parse<Record<string, string>>(await response.text(), { header: true });
       expect(parsed.meta.fields).toContain("industryDbV2Raw");
       expect(parsed.meta.fields).toContain("industryDbV2Normalized");
-      expect(parsed.data[0]?.industryDbV2Raw).toBe("20");
+      expect(parsed.data[0]?.industryDbV2Raw).toBe("40");
     } finally {
       if (originalDebug === undefined) {
         delete process.env.DEBUG;

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -217,7 +217,7 @@ describe("ExportService", () => {
     const csv = file.content.toString("utf8");
     const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
 
-    expect(parsed.data[0]?.industryDb).toBe("50");
+    expect(parsed.data[0]?.industryDb).toBe("40");
     expect(parsed.data[1]?.industryDb).toBe("15");
   });
 

--- a/apps/api/src/services/industry-db-batch-stats.test.ts
+++ b/apps/api/src/services/industry-db-batch-stats.test.ts
@@ -91,18 +91,18 @@ describe("industry-db-batch-stats", () => {
     expect(thirty.normalized - six.normalized).toBeGreaterThan(20);
   });
 
-  it("bumps raw score to section max when brand or company hits are present", () => {
-    expect(bumpIndustryDbV2Raw(5, true, false)).toBe(30);
-    expect(bumpIndustryDbV2Raw(5, false, true)).toBe(20);
+  it("bumps raw score with the default 40/50 direct-hit rule", () => {
+    expect(bumpIndustryDbV2Raw(5, true, false)).toBe(40);
+    expect(bumpIndustryDbV2Raw(5, false, true)).toBe(40);
     expect(bumpIndustryDbV2Raw(5, true, true)).toBe(50);
-    expect(bumpIndustryDbV2Raw(40, true, false)).toBe(40);
+    expect(bumpIndustryDbV2Raw(45, true, false)).toBe(45);
     expect(bumpIndustryDbV2Raw(undefined, true, true)).toBe(50);
     expect(bumpIndustryDbV2Raw(0, false, false)).toBe(0);
   });
 
-  it("derives effective raw from ingest data shape", () => {
-    expect(computeEffectiveIndustryDbV2Raw({ brandHits: [{}], companyHits: [], industryDbV2Raw: 5 })).toBe(30);
-    expect(computeEffectiveIndustryDbV2Raw({ brandHits: [], companyHits: ['star'], industryDbV2Raw: 5 })).toBe(20);
+  it("derives effective raw from ingest data using the default direct-hit rule", () => {
+    expect(computeEffectiveIndustryDbV2Raw({ brandHits: [{}], companyHits: [], industryDbV2Raw: 5 })).toBe(40);
+    expect(computeEffectiveIndustryDbV2Raw({ brandHits: [], companyHits: ['star'], industryDbV2Raw: 5 })).toBe(40);
     expect(computeEffectiveIndustryDbV2Raw({ brandHits: [{}], companyHits: ['star'], industryDbV2Raw: 5 })).toBe(50);
     expect(computeEffectiveIndustryDbV2Raw({ brandHits: [], companyHits: [], industryDbV2Raw: 25 })).toBe(25);
     expect(computeEffectiveIndustryDbV2Raw(undefined)).toBe(0);
@@ -115,7 +115,7 @@ describe("industry-db-batch-stats", () => {
       brandHits: [{ brand: "fanuc", role: "employer", source: "workHistory", context: "employer" }],
       companyHits: ["fanuc"],
       industryDbV2Raw: 5,
-    })).toBe(20);
+    })).toBe(40);
     // employer brandHit + no companyHits → no bump
     expect(computeEffectiveIndustryDbV2Raw({
       brandHits: [{ brand: "fanuc", role: "employer", source: "workHistory", context: "employer" }],
@@ -133,9 +133,9 @@ describe("industry-db-batch-stats", () => {
     })).toBe(50);
   });
 
-  it("computes direct industry_db score without cohort normalization", () => {
-    expect(computeDirectIndustryDbScore({ brandHits: [{}], companyHits: [], industryDbV2Raw: 5 })).toBe(50);
-    expect(computeDirectIndustryDbScore({ brandHits: [], companyHits: ["star"], industryDbV2Raw: 5 })).toBe(50);
+  it("keeps direct export fallback aligned with effective raw scoring", () => {
+    expect(computeDirectIndustryDbScore({ brandHits: [{}], companyHits: [], industryDbV2Raw: 5 })).toBe(40);
+    expect(computeDirectIndustryDbScore({ brandHits: [], companyHits: ["star"], industryDbV2Raw: 5 })).toBe(40);
     expect(computeDirectIndustryDbScore({ brandHits: [{}], companyHits: ["star"], industryDbV2Raw: 5 })).toBe(50);
     expect(computeDirectIndustryDbScore({ brandHits: [], companyHits: [], industryDbV2Raw: 25 })).toBe(25);
     expect(computeDirectIndustryDbScore({ brandHits: [], companyHits: [], industryDbV2Raw: 60 })).toBe(50);
@@ -152,7 +152,7 @@ describe("industry-db-batch-stats", () => {
       brandHits: [{ brand: "fanuc", role: "employer", source: "workHistory", context: "employer" }],
       companyHits: ["fanuc"],
       industryDbV2Raw: 5,
-    })).toBe(50);
+    })).toBe(40);
   });
 
   it("coerces invalid raw inputs to the supported score range", () => {

--- a/apps/api/src/services/industry-db-batch-stats.ts
+++ b/apps/api/src/services/industry-db-batch-stats.ts
@@ -20,8 +20,8 @@ const INDUSTRY_DB_V2_SCORE_CAP = 50;
 const INDUSTRY_DB_V2_HISTOGRAM_SIZE = 51;
 const INDUSTRY_DB_V2_MIN_NORMALIZATION_SAMPLE_SIZE = 30;
 const INDUSTRY_DB_V2_MIN_NONZERO_SAMPLE_SIZE = 5;
-const INDUSTRY_DB_V2_BRAND_SECTION_SCORE = 30;
-const INDUSTRY_DB_V2_COMPANY_SECTION_SCORE = 20;
+const INDUSTRY_DB_V2_SINGLE_HIT_SCORE = 40;
+const INDUSTRY_DB_V2_BOTH_HIT_BOOST = 10;
 
 function roundTo2(value: number): number {
   return Number(value.toFixed(2));
@@ -68,15 +68,23 @@ function countHistogramSamples(histogram50: number[]): number {
   return histogram50.reduce((total, count) => total + count, 0);
 }
 
+function computeIndustryDbDirectHitScore(
+  hasBrandHits: boolean,
+  hasCompanyHits: boolean
+): number {
+  const hasAnyHit = hasBrandHits || hasCompanyHits;
+  const hasBoth = hasBrandHits && hasCompanyHits;
+  return (hasAnyHit ? INDUSTRY_DB_V2_SINGLE_HIT_SCORE : 0)
+    + (hasBoth ? INDUSTRY_DB_V2_BOTH_HIT_BOOST : 0);
+}
+
 export function bumpIndustryDbV2Raw(
   raw: number | undefined,
   hasBrandHits: boolean,
   hasCompanyHits: boolean
 ): number {
-  const sectionBump =
-    (hasBrandHits ? INDUSTRY_DB_V2_BRAND_SECTION_SCORE : 0) +
-    (hasCompanyHits ? INDUSTRY_DB_V2_COMPANY_SECTION_SCORE : 0);
-  return Math.max(clampIndustryDbV2RawScore(raw), sectionBump);
+  const directHitScore = computeIndustryDbDirectHitScore(hasBrandHits, hasCompanyHits);
+  return Math.max(clampIndustryDbV2RawScore(raw), directHitScore);
 }
 
 function hasNonEmployerBrandHit(brandHits: unknown[] | undefined): boolean {
@@ -102,10 +110,7 @@ export function computeDirectIndustryDbScore(ingestData: {
   companyHits?: unknown[];
   industryDbV2Raw?: number;
 } | null | undefined): number {
-  if (hasNonEmployerBrandHit(ingestData?.brandHits) || (ingestData?.companyHits?.length ?? 0) > 0) {
-    return INDUSTRY_DB_V2_SCORE_CAP;
-  }
-  return clampIndustryDbV2RawScore(ingestData?.industryDbV2Raw);
+  return computeEffectiveIndustryDbV2Raw(ingestData);
 }
 
 function nonZeroP80FromHistogram(histogram50: number[]): { p80: number; count: number } {

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1653,11 +1653,11 @@ describe('useResumeListState role filter regression', () => {
       await result.current.handleApplySearchHistory(mockState.searchHistory[0] as never)
     })
 
-    // has brand hits (non-employer) -> additive weight: brand-only = 30
-    // score = round(30*0.5)+30 = 45 (composite formula)
-    expect(result.current.displayedResumes[0]?.match?.breakdown?.industry_db).toBe(30)
+    // has brand hits (non-employer) -> single-hit baseline: brand-only = 40
+    // score = round(30*0.5)+40 = 55 (composite formula)
+    expect(result.current.displayedResumes[0]?.match?.breakdown?.industry_db).toBe(40)
     expect(result.current.displayedResumes[0]?.match?.breakdown?.related_exp).toBe(30)
-    expect(result.current.displayedResumes[0]?.match?.score).toBe(45)
+    expect(result.current.displayedResumes[0]?.match?.score).toBe(55)
   })
 
   it('ignores employer-context brand hits when computing direct industry_db score', async () => {

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -291,14 +291,13 @@ describe('resume-scoring', () => {
   })
 
   it.each([
-    { label: 'returns 30 for brand-only hit (additive weight)', raw: 0, hasBrandHits: true, hasCompanyHits: false, expected: 30 },
-    { label: 'returns 20 for company-only hit (additive weight)', raw: 0, hasBrandHits: false, hasCompanyHits: true, expected: 20 },
-    { label: 'returns 50 for brand and company hits (full cap)', raw: 0, hasBrandHits: true, hasCompanyHits: true, expected: 50 },
-    { label: 'raw wins when raw > additive (brand-only: raw 45 > 30)', raw: 45, hasBrandHits: true, hasCompanyHits: false, expected: 45 },
-    { label: 'additive wins when raw < additive total', raw: 10, hasBrandHits: true, hasCompanyHits: true, expected: 50 },
-    { label: 'keeps raw score with no hits', raw: 20, hasBrandHits: false, hasCompanyHits: false, expected: 20 },
-    { label: 'clamps raw score above cap with no hits', raw: 60, hasBrandHits: false, hasCompanyHits: false, expected: 50 },
-    { label: 'defaults missing raw to 0 with no hits', raw: undefined, hasBrandHits: false, hasCompanyHits: false, expected: 0 },
+    { label: 'brand-only hit uses 40-point single-hit baseline', raw: 0, hasBrandHits: true, hasCompanyHits: false, expected: 40 },
+    { label: 'company-only hit uses 40-point single-hit baseline', raw: 0, hasBrandHits: false, hasCompanyHits: true, expected: 40 },
+    { label: 'both brand and company hits use 50-point cap', raw: 0, hasBrandHits: true, hasCompanyHits: true, expected: 50 },
+    { label: 'no hits keeps raw score', raw: 20, hasBrandHits: false, hasCompanyHits: false, expected: 20 },
+    { label: 'no hits defaults missing raw to zero', raw: undefined, hasBrandHits: false, hasCompanyHits: false, expected: 0 },
+    { label: 'raw wins over single-hit baseline when raw is higher', raw: 45, hasBrandHits: true, hasCompanyHits: false, expected: 45 },
+    { label: 'raw is clamped to cap with no hits', raw: 60, hasBrandHits: false, hasCompanyHits: false, expected: 50 },
   ])('$label', ({ raw, hasBrandHits, hasCompanyHits, expected }) => {
     expect(computeDirectIndustryDb(raw, hasBrandHits, hasCompanyHits)).toBe(expected)
   })

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -408,17 +408,27 @@ const RELATED_EXP_CEILING_BY_RECOMMENDATION: Record<string, number> = {
 }
 const INDUSTRY_DB_V2_MIN_NONZERO_SAMPLE_SIZE = 5
 
+const INDUSTRY_DB_V2_SINGLE_HIT_SCORE = 40
+const INDUSTRY_DB_V2_BOTH_HIT_BOOST = 10
+
+function computeIndustryDbDirectHitScore(
+  hasBrandHits: boolean,
+  hasCompanyHits: boolean,
+): number {
+  const hasAnyHit = hasBrandHits || hasCompanyHits
+  const hasBoth = hasBrandHits && hasCompanyHits
+  return (hasAnyHit ? INDUSTRY_DB_V2_SINGLE_HIT_SCORE : 0)
+    + (hasBoth ? INDUSTRY_DB_V2_BOTH_HIT_BOOST : 0)
+}
+
 export function computeDirectIndustryDb(
   raw: number | undefined,
   hasBrandHits: boolean,
   hasCompanyHits: boolean,
 ): number {
-  // Additive weights matching Convex analysis_normalization.ts:
-  //   brand hit → 30, company hit → 20, both → 50.
-  // Math.max(raw, additive) so a high raw value is never suppressed.
-  const additiveScore = (hasBrandHits ? 30 : 0) + (hasCompanyHits ? 20 : 0)
+  const directHitScore = computeIndustryDbDirectHitScore(hasBrandHits, hasCompanyHits)
   const safeRaw = typeof raw === 'number' && Number.isFinite(raw) ? raw : 0
-  return clamp(Math.max(safeRaw, additiveScore), 0, INDUSTRY_DB_V2_SCORE_CAP)
+  return clamp(Math.max(safeRaw, directHitScore), 0, INDUSTRY_DB_V2_SCORE_CAP)
 }
 
 function nonZeroP80FromHistogram(histogram50: number[]): { p80: number; count: number } {

--- a/packages/convex/__tests__/analysis-strict-evidence.test.ts
+++ b/packages/convex/__tests__/analysis-strict-evidence.test.ts
@@ -1590,21 +1590,23 @@ describe("normalizeResume strict evidence", () => {
       const ingestData = getResumeIngestData(resume);
       const brandHits = hasNonEmployerBrandHitsFn(ingestData.brandHits);
       const companyHits = hasCompanyHitsFn(ingestData.companyHits);
-      if (brandHits || companyHits) return INDUSTRY_DB_SCORE_CAP;
+      const hasAnyHit = brandHits || companyHits;
+      const hasBoth = brandHits && companyHits;
+      const directHitScore = (hasAnyHit ? 40 : 0) + (hasBoth ? 10 : 0);
       const raw = toNumber(ingestData.industryDbV2Raw) ?? 0;
-      return clamp(raw, 0, INDUSTRY_DB_SCORE_CAP);
+      return clamp(Math.max(raw, directHitScore), 0, INDUSTRY_DB_SCORE_CAP);
     }
 
-    it("returns cap (50) when non-employer brand hits exist", () => {
+    it("returns 40 when non-employer brand hits exist", () => {
       expect(computeDirectIndustryDbScoreFromResume({
         ingestData: { brandHits: [{ context: "sales" }], companyHits: [] },
-      })).toBe(50);
+      })).toBe(40);
     });
 
-    it("returns cap (50) when company hits exist", () => {
+    it("returns 40 when company hits exist", () => {
       expect(computeDirectIndustryDbScoreFromResume({
         ingestData: { brandHits: [], companyHits: ["北京精雕科技"] },
-      })).toBe(50);
+      })).toBe(40);
     });
 
     it("returns cap when both brand and company hits exist", () => {
@@ -1640,14 +1642,14 @@ describe("normalizeResume strict evidence", () => {
     it("reads ingestData from content.ingestData fallback path", () => {
       expect(computeDirectIndustryDbScoreFromResume({
         content: { ingestData: { brandHits: [], companyHits: ["某公司"] } },
-      })).toBe(50);
+      })).toBe(40);
     });
 
     it("reads ingestData from root.ingestData preferentially", () => {
       expect(computeDirectIndustryDbScoreFromResume({
         ingestData: { brandHits: [], companyHits: ["根路径公司"] },
         content: { ingestData: { brandHits: [], companyHits: [], industryDbV2Raw: 20 } },
-      })).toBe(50);
+      })).toBe(40);
     });
 
     it("returns 0 when no ingestData at all", () => {

--- a/packages/convex/__tests__/analysis_normalization.test.ts
+++ b/packages/convex/__tests__/analysis_normalization.test.ts
@@ -315,16 +315,16 @@ describe("getResumeIngestData", () => {
 // computeDirectIndustryDbScoreFromResume
 // ---------------------------------------------------------------------------
 describe("computeDirectIndustryDbScoreFromResume", () => {
-    it("returns 30 when brand hits exist (additive weight, not flat cap)", () => {
+    it("returns 40 when brand hits exist", () => {
         expect(computeDirectIndustryDbScoreFromResume({
             ingestData: { brandHits: [{ context: "client" }] },
-        })).toBe(30);
+        })).toBe(40);
     });
 
-    it("returns 20 when company hits exist (additive weight, not flat cap)", () => {
+    it("returns 40 when company hits exist", () => {
         expect(computeDirectIndustryDbScoreFromResume({
             ingestData: { companyHits: ["Acme"] },
-        })).toBe(20);
+        })).toBe(40);
     });
 
     it("returns clamped industryDbV2Raw", () => {
@@ -343,17 +343,17 @@ describe("computeDirectIndustryDbScoreFromResume", () => {
         expect(computeDirectIndustryDbScoreFromResume({})).toBe(0);
     });
 
-    // Phase 1: additive weight model — brand-only = 30, company-only = 20, both = 50
-    it("brand hit only → exactly 30 (additive weight)", () => {
+    // Phase 1: default direct-hit rule — brand-only = 40, company-only = 40, both = 50
+    it("brand hit only → exactly 40 (single-hit baseline)", () => {
         expect(computeDirectIndustryDbScoreFromResume({
             ingestData: { brandHits: [{ context: "client" }], companyHits: [], industryDbV2Raw: 0 },
-        })).toBe(30);
+        })).toBe(40);
     });
 
-    it("company hit only → exactly 20 (additive weight)", () => {
+    it("company hit only → exactly 40 (single-hit baseline)", () => {
         expect(computeDirectIndustryDbScoreFromResume({
             ingestData: { companyHits: ["Acme"], brandHits: [], industryDbV2Raw: 0 },
-        })).toBe(20);
+        })).toBe(40);
     });
 
     it("both brand and company hits → exactly 50 (full cap)", () => {
@@ -362,15 +362,15 @@ describe("computeDirectIndustryDbScoreFromResume", () => {
         })).toBe(50);
     });
 
-    it("high raw industryDbV2Raw wins over additive when raw > additive total", () => {
-        // brand-only additive = 30, but raw = 45 > 30; raw wins, clamped to cap
+    it("high raw industryDbV2Raw wins over direct-hit baseline when raw > baseline", () => {
+        // brand-only baseline = 40, but raw = 45 > 40; raw wins, clamped to cap
         expect(computeDirectIndustryDbScoreFromResume({
             ingestData: { brandHits: [{ context: "client" }], companyHits: [], industryDbV2Raw: 45 },
         })).toBe(45);
     });
 
-    it("low raw is superseded by additive total (Math.max semantics)", () => {
-        // raw = 10, additive (brand+company) = 50; additive wins
+    it("low raw is superseded by both-hit baseline (Math.max semantics)", () => {
+        // raw = 10, both-hit = 50; baseline wins
         expect(computeDirectIndustryDbScoreFromResume({
             ingestData: { brandHits: [{ context: "client" }], companyHits: ["Acme"], industryDbV2Raw: 10 },
         })).toBe(50);

--- a/packages/convex/__tests__/analyze.test.ts
+++ b/packages/convex/__tests__/analyze.test.ts
@@ -243,16 +243,16 @@ describe("getResumeIngestData", () => {
 describe("computeDirectIndustryDbScoreFromResume", () => {
   const CAP = 50;
 
-  it("returns the additive brand weight (30) for non-employer brand context", () => {
+  it("returns the single-hit baseline (40) for non-employer brand context", () => {
     expect(computeDirectIndustryDbScoreFromResume({
       ingestData: { brandHits: [{ context: "industry" }] },
-    })).toBe(30);
+    })).toBe(40);
   });
 
-  it("returns the additive company weight (20) when companyHits has entries", () => {
+  it("returns the single-hit baseline (40) when companyHits has entries", () => {
     expect(computeDirectIndustryDbScoreFromResume({
       ingestData: { companyHits: ["Acme Corp"] },
-    })).toBe(20);
+    })).toBe(40);
   });
 
   it("clamps industryDbV2Raw to 0..CAP", () => {

--- a/packages/convex/convex/lib/analysis_normalization.ts
+++ b/packages/convex/convex/lib/analysis_normalization.ts
@@ -61,12 +61,12 @@ export const INDUSTRY_DB_SCORE_CAP = 50;
  */
 export const RELATED_EXP_WEIGHT = INDUSTRY_DB_SCORE_CAP / 100;
 
-// Additive weights for brand/company hits — must stay in sync with
-// INDUSTRY_DB_V2_BRAND_SECTION_SCORE / INDUSTRY_DB_V2_COMPANY_SECTION_SCORE
+// Direct-hit baseline for brand/company hits — must stay in sync with
+// INDUSTRY_DB_V2_SINGLE_HIT_SCORE / INDUSTRY_DB_V2_BOTH_HIT_BOOST
 // in apps/api/src/services/industry-db-batch-stats.ts and
 // computeDirectIndustryDb() in apps/web/src/lib/resume-scoring.ts.
-const INDUSTRY_DB_BRAND_HIT_SCORE = 30;
-const INDUSTRY_DB_COMPANY_HIT_SCORE = 20;
+const INDUSTRY_DB_SINGLE_HIT_SCORE = 40;
+const INDUSTRY_DB_BOTH_HIT_BOOST = 10;
 
 export const RELATED_EXP_CEILING_BY_RECOMMENDATION: Record<AnalysisRecommendation, number> = {
     strong_match: 100,
@@ -259,16 +259,21 @@ export function getResumeIngestData(resume: unknown): Record<string, unknown> {
     return {};
 }
 
+function computeIndustryDbDirectHitScore(brandHits: boolean, companyHits: boolean): number {
+    const hasAnyHit = brandHits || companyHits;
+    const hasBoth = brandHits && companyHits;
+    return (hasAnyHit ? INDUSTRY_DB_SINGLE_HIT_SCORE : 0)
+        + (hasBoth ? INDUSTRY_DB_BOTH_HIT_BOOST : 0);
+}
+
 export function computeDirectIndustryDbScoreFromResume(resume: unknown): number {
     const ingestData = getResumeIngestData(resume);
     const brandHits = hasNonEmployerBrandHits(ingestData.brandHits);
     const companyHits = hasCompanyHits(ingestData.companyHits);
-    // Additive weights: brand hit → 30, company hit → 20, both → 50.
-    // This aligns Convex with the API-layer model in industry-db-batch-stats.ts.
-    const additiveScore = (brandHits ? INDUSTRY_DB_BRAND_HIT_SCORE : 0) + (companyHits ? INDUSTRY_DB_COMPANY_HIT_SCORE : 0);
+    const directHitScore = computeIndustryDbDirectHitScore(brandHits, companyHits);
 
     const raw = toNumber(ingestData.industryDbV2Raw) ?? 0;
-    return clamp(Math.max(raw, additiveScore), 0, INDUSTRY_DB_SCORE_CAP);
+    return clamp(Math.max(raw, directHitScore), 0, INDUSTRY_DB_SCORE_CAP);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace additive 30/20 brand/company direct-hit model with unified 40-point single-hit baseline across web, API, and Convex scoring layers
- Any verified non-employer brand OR company hit now gives at least 40; both hit categories give 50; no-hit resumes keep raw/zero behavior
- MY market floor remains unchanged in `overrideIndustryDbBreakdown`

## Test plan
- [x] Web `resume-scoring.test.ts` — 55 tests pass
- [x] API `industry-db-batch-stats.test.ts` — 10 tests pass
- [x] Convex `analysis_normalization.test.ts`, `analyze.test.ts`, `analysis-strict-evidence.test.ts` — 341 tests pass
- [x] `make check` exits 0
- [x] `useResumeListState.test.tsx` — updated stale expectations