### PR TITLE
Display weighted match breakdown in UI

### DIFF
--- a/apps/web/src/components/ResumeCard.tsx
+++ b/apps/web/src/components/ResumeCard.tsx
@@ -26,6 +26,7 @@ import {
   summarizeBrandHits,
   getExperienceBadge,
   normalizeExperienceLevel,
+  toDisplayMatchBreakdown,
 } from '@/lib/resume-scoring'
 import {
   Tooltip,
@@ -228,6 +229,7 @@ export const ResumeCard = memo(function ResumeCard({
   const score = matchResult?.score
   const recommendation = matchResult?.recommendation
   const scoreSource = matchResult?.scoreSource
+  const displayBreakdown = toDisplayMatchBreakdown(matchResult?.breakdown)
   const scoreLabel = recommendation ? t(`resumes.matching.recommendations.${recommendation}`) : ''
   const statusOption = STATUS_OPTIONS.find((item) => item.value === candidateStatus) ?? STATUS_OPTIONS[0]
   const statusLabel = t(statusOption.labelKey)
@@ -271,9 +273,9 @@ export const ResumeCard = memo(function ResumeCard({
                 defaultValue: 'Analysis Breakdown',
               })}
             </p>
-            {matchResult?.breakdown ? (
+            {displayBreakdown ? (
               <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-                {Object.entries(matchResult.breakdown).map(([key, value]) => (
+                {Object.entries(displayBreakdown).map(([key, value]) => (
                   <div key={key} className="flex justify-between">
                     <span className="capitalize opacity-80">{key.replace('_', ' ')}:</span>
                     <span className="font-mono font-bold">{value}</span>

--- a/apps/web/src/components/ResumeDetail.tsx
+++ b/apps/web/src/components/ResumeDetail.tsx
@@ -15,7 +15,7 @@ import { AiFeedbackButtons } from '@/components/AiFeedbackButtons'
 import { StarRating } from '@/components/StarRating'
 import type { ResumeItem } from '@/hooks/useResumes'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
-import { formatRoleYears, getExperienceBadge, getResumeContentLocale, getResumeSourceLabel, getRoleLabel, hasIngestData, isSafeProfileUrl, summarizeBrandHits } from '@/lib/resume-scoring'
+import { formatRoleYears, getExperienceBadge, getResumeContentLocale, getResumeSourceLabel, getRoleLabel, hasIngestData, isSafeProfileUrl, summarizeBrandHits, toDisplayMatchBreakdown } from '@/lib/resume-scoring'
 import { getScoreClassName } from '@/lib/score-classes'
 import { cn } from '@/lib/utils'
 import { useBrandDisplayMap } from '@/hooks/useBrandDisplayMap'
@@ -178,6 +178,7 @@ export function ResumeDetail({
         defaultValue: matchResult.recommendation.replace(/_/g, ' '),
       })
     : ''
+  const displayBreakdown = toDisplayMatchBreakdown(matchResult?.breakdown)
 
   if (!resume || !presentationResume) {
     return null
@@ -418,14 +419,14 @@ export function ResumeDetail({
                 )}
               </div>
 
-              {matchResult.breakdown && (
+              {displayBreakdown && (
                 <div className="bg-background rounded p-2 border">
                   <h4 className="text-xs font-semibold mb-2">{t('resumes.detail.detailedBreakdown', { defaultValue: 'Detailed Breakdown' })}</h4>
                   <div
                     data-testid="resume-detail-breakdown-grid"
                     className="grid grid-cols-2 gap-2 text-center md:grid-cols-3 xl:grid-cols-5"
                   >
-                    {Object.entries(matchResult.breakdown).map(([k, v]) => (
+                    {Object.entries(displayBreakdown).map(([k, v]) => (
                       <div key={k} className="flex flex-col">
                         <span className="text-[10px] text-muted-foreground uppercase truncate" title={k}>{k.replace('_', ' ')}</span>
                         <span className="text-sm font-mono font-bold">{v}</span>

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -22,7 +22,7 @@ import {
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import { SnippetCardExpanded } from '@/components/search/SnippetCardExpanded'
 import { StarRating } from '@/components/StarRating'
-import { getResumeContentLocale, getResumeSourceLabel, getExperienceBadge, isSafeProfileUrl, summarizeBrandHits } from '@/lib/resume-scoring'
+import { getResumeContentLocale, getResumeSourceLabel, getExperienceBadge, isSafeProfileUrl, summarizeBrandHits, toDisplayMatchBreakdown } from '@/lib/resume-scoring'
 import { highlightTerms } from '@/lib/highlight'
 import { useBrandDisplayMap } from '@/hooks/useBrandDisplayMap'
 import { getScoreClassName } from '@/lib/score-classes'
@@ -116,6 +116,7 @@ export const SnippetCard = memo(function SnippetCard({
   const contentLocale = getResumeContentLocale(item.resume)
   const resumeSourceLabel = getResumeSourceLabel(item.resume)
   const analysis = item.analysis ?? item.resume.analysis
+  const displayBreakdown = toDisplayMatchBreakdown(analysis?.breakdown)
   const searchTerms = useMemo(
     () => (searchQuery ? searchQuery.split(/\s+/).filter(Boolean) : []),
     [searchQuery],
@@ -228,9 +229,9 @@ export const SnippetCard = memo(function SnippetCard({
                     <p className="font-semibold mb-2 text-sm border-b pb-1 border-white/20">
                       {t('resumes.searchPage.card.analysisBreakdown', { defaultValue: '分析细节' })}
                     </p>
-                    {analysis?.breakdown ? (
+                    {displayBreakdown ? (
                       <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-                        {Object.entries(analysis.breakdown).map(([key, value]) => (
+                        {Object.entries(displayBreakdown).map(([key, value]) => (
                           <div key={key} className="flex justify-between">
                             <span className="capitalize opacity-80">{key.replace('_', ' ')}:</span>
                             <span className="font-mono font-bold">{value}</span>

--- a/apps/web/src/components/search/SnippetCardExpanded.test.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.test.tsx
@@ -123,7 +123,7 @@ describe('SnippetCardExpanded', () => {
     expect(screen.getAllByText('industry db')).toHaveLength(2)
     expect(screen.getByText('48')).toBeInTheDocument()
     expect(screen.getAllByText('related exp')).toHaveLength(2)
-    expect(screen.getByText('24')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
     expect(screen.getByText('最近工作')).toBeInTheDocument()
     expect(screen.getByText('FANUC · Sales Engineer')).toBeInTheDocument()
     expect(screen.getByText('DMG MORI · Account Manager')).toBeInTheDocument()
@@ -320,6 +320,32 @@ describe('SnippetCardExpanded', () => {
       // Values appear in both main and debug sections, so use getAllByText
       expect(screen.getAllByText('36').length).toBeGreaterThanOrEqual(1)
       expect(screen.getAllByText('82').length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('shows weighted related_exp in normal breakdown while keeping raw related_exp in debug', async () => {
+      const user = userEvent.setup()
+      render(
+        <SnippetCardExpanded
+          item={createResult(1, {
+            analysis: {
+              score: 79,
+              summary: 'Weighted scoring display candidate',
+              highlights: [],
+              concerns: [],
+              recommendation: 'match',
+              breakdown: { related_exp: 78, industry_db: 40 },
+            },
+          })}
+        />
+      )
+
+      expect(screen.getByText('39')).toBeInTheDocument()
+      expect(screen.getByText('40')).toBeInTheDocument()
+      expect(screen.queryByText('78')).not.toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: /debug/i }))
+
+      expect(screen.getByText('78')).toBeInTheDocument()
     })
 
     it('shows score comparison grid with AI, confirmed, and user rating', async () => {

--- a/apps/web/src/components/search/SnippetCardExpanded.tsx
+++ b/apps/web/src/components/search/SnippetCardExpanded.tsx
@@ -7,7 +7,7 @@ import { Button, buttonVariants } from '@/components/ui/button'
 import { toast } from 'sonner'
 import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
 import { cn } from '@/lib/utils'
-import { getResumeContentLocale, getExperienceBadge, isSafeProfileUrl, summarizeBrandHits } from '@/lib/resume-scoring'
+import { getResumeContentLocale, getExperienceBadge, isSafeProfileUrl, summarizeBrandHits, toDisplayMatchBreakdown } from '@/lib/resume-scoring'
 import { useBrandDisplayMap } from '@/hooks/useBrandDisplayMap'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 
@@ -105,6 +105,7 @@ export function SnippetCardExpanded({
   const contentLocale = getResumeContentLocale(item.resume)
   const [showDebug, setShowDebug] = useState(false)
   const analysis = item.analysis ?? item.resume.analysis
+  const displayBreakdown = toDisplayMatchBreakdown(analysis?.breakdown)
   const hasAiAnalysis = item.scoreSource === 'ai' && Boolean(analysis)
   const pendingAiAnalysis = showAiScore && !hasAiAnalysis
   const scoreSourceLabel = hasAiAnalysis
@@ -297,16 +298,16 @@ export function SnippetCardExpanded({
                   </div>
                 ) : null}
 
-                {analysis.breakdown && Object.keys(analysis.breakdown).length > 0 ? (
+                {displayBreakdown ? (
                   <div className="space-y-2">
                     <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
                       {analysisBreakdownLabel}
                     </div>
                     <BreakdownBar
-                      breakdown={analysis.breakdown}
+                      breakdown={displayBreakdown}
                     />
                     <div className="grid gap-2 sm:grid-cols-2">
-                      {Object.entries(analysis.breakdown).map(([label, value]) => (
+                      {Object.entries(displayBreakdown).map(([label, value]) => (
                         <div
                           key={label}
                           className="flex min-w-0 items-center justify-between gap-3 rounded-2xl border bg-slate-50 px-3 py-2"

--- a/apps/web/src/lib/resume-scoring.test.ts
+++ b/apps/web/src/lib/resume-scoring.test.ts
@@ -15,6 +15,7 @@ import {
   isAutoFilteredAnalysis,
   overrideIndustryDbBreakdown,
   recommendationFromScore,
+  toDisplayMatchBreakdown,
   toIndustryDbV2Stats,
   toMatchBreakdown,
   toRecommendation,
@@ -129,6 +130,20 @@ describe('resume-scoring', () => {
   it('returns undefined for empty breakdown', () => {
     expect(toMatchBreakdown({})).toBeUndefined()
     expect(toMatchBreakdown(undefined)).toBeUndefined()
+  })
+
+  it('converts raw related_exp into the weighted display contribution', () => {
+    expect(toDisplayMatchBreakdown({ related_exp: 78, industry_db: 40 })).toEqual({
+      related_exp: 39,
+      industry_db: 40,
+    })
+  })
+
+  it('does not mutate the raw breakdown object when creating display values', () => {
+    const rawBreakdown = { related_exp: 78, industry_db: 40 }
+
+    expect(toDisplayMatchBreakdown(rawBreakdown)).not.toBe(rawBreakdown)
+    expect(rawBreakdown).toEqual({ related_exp: 78, industry_db: 40 })
   })
 
   it('matches the API resume id fallback order for resume keys', () => {

--- a/apps/web/src/lib/resume-scoring.ts
+++ b/apps/web/src/lib/resume-scoring.ts
@@ -203,6 +203,17 @@ export function toMatchBreakdown(value: Record<string, number> | undefined): Mat
   return value
 }
 
+export function toDisplayMatchBreakdown(value: MatchBreakdown | undefined): MatchBreakdown | undefined {
+  if (!value || Object.keys(value).length === 0) return undefined
+  const relatedExp = typeof value.related_exp === 'number' && Number.isFinite(value.related_exp)
+    ? Math.round(clamp(value.related_exp, 0, 100) * (INDUSTRY_DB_V2_SCORE_CAP / 100))
+    : undefined
+  return {
+    ...value,
+    ...(relatedExp === undefined ? {} : { related_exp: relatedExp }),
+  }
+}
+
 export function getAnalysisForJob(
   resume: {
     analyses?: Record<string, ConvexResumeAnalysis>


### PR DESCRIPTION
Add toDisplayMatchBreakdown to resume-scoring to convert raw breakdown values (notably related_exp) into a weighted display contribution (scaled by INDUSTRY_DB_V2_SCORE_CAP) while preserving the raw object. Replace direct uses of raw breakdown with the displayBreakdown in ResumeCard, ResumeDetail, SnippetCard and SnippetCardExpanded so the UI shows the weighted values by default. Update tests to expect the weighted display values and add coverage to ensure the raw breakdown is unchanged and that debug mode can still reveal raw values.