### PR TITLE
fix(samples): fix seek snapshot collection paths, add refresh-sample-snapshots skill

### DIFF
--- a/.agents/skills/refresh-sample-snapshots/SKILL.md
+++ b/.agents/skills/refresh-sample-snapshots/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: refresh-sample-snapshots
+description: >
+  Refresh, push, pull, and restore resume sample snapshots across 3 CDP sources
+  (51job, job5156, seek). Seek supports both recommended and talentsearch collection modes.
+  Use when the user mentions sample
+  snapshots, sample repo, refresh/push/pull/restore samples, dev-samples, or wants to update
+  the ptdevhk/trends-resume-samples repository.
+validation:
+  descriptionTerms: [sample, snapshot, resume, refresh, push, pull, restore, dev-samples]
+---
+
+# Refresh Sample Snapshots
+
+Manage the resume sample snapshot lifecycle: collect fresh data from browser sources via CDP, push to the shared GitHub sample repo, and pull/restore into a local dev environment.
+
+## Prerequisites
+
+- Chrome running with remote debugging on port 9222 (`make chrome-debug` or `./apps/browser-extension/scripts/cmux-setup-profile.sh`)
+- Browser extension loaded and active in Chrome
+- Logged into each target source in Chrome (see per-source reference files for details)
+- For pull/restore: local dev stack running (`make dev` or at minimum API + Convex)
+
+## Source Coverage
+
+| Source alias | Market | Collection mechanism | Reference |
+|---|---|---|---|
+| `51job` | CN | Keyword search on `ehire.51job.com` | [references/51job.md](references/51job.md) |
+| `job5156` | MY/CN | Keyword + location on `hr.job5156.com` | [references/job5156.md](references/job5156.md) |
+| `seek` (recommended) | HK | jobId-based on `hk.employer.seek.com` | [references/seek.md](references/seek.md) |
+| `seek` (talent search) | MY | Keyword-based on `hk.employer.seek.com/talentsearch` with `market=MY` | [references/seek.md](references/seek.md) |
+
+## Workflow Quick Reference
+
+| Workflow | Trigger phrases | What it does |
+|---|---|---|
+| **Collect** | "collect 51job samples", "snapshot seek", "refresh job5156 samples" | CDP scrape from one or more sources into `output/resume-backups/` |
+| **Push** | "push sample snapshots", "push samples to GitHub" | Upload latest snapshot dir to `ptdevhk/trends-resume-samples` |
+| **Pull+Restore** | "pull sample snapshots", "restore samples" | Clone sample repo → restore into local Convex |
+| **Full refresh** | "full sample refresh", "refresh all samples" | Collect all sources → push to GitHub (multi-step) |
+
+---
+
+## Collect Workflow
+
+Collect fresh resume samples from browser sources via CDP.
+
+**Primary script:** `scripts/resume/snapshot-source-backups.ts` (calls `scripts/resume/collect_browser_source.py` under the hood).
+
+### Single source
+
+```bash
+bun run scripts/resume/snapshot-source-backups.ts --source 51job --count 20
+```
+
+### Multiple sources in one run
+
+```bash
+bun run scripts/resume/snapshot-source-backups.ts \
+  --source 51job --source job5156 --source seek --count 20
+```
+
+### Custom URL override
+
+Override the default search URL for a source:
+
+```bash
+# Seek talent search (MY market) — uses keyword-based collection
+bun run scripts/resume/snapshot-source-backups.ts \
+  --source seek --count 20 \
+  --seek-url "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE"
+
+# Custom 51job keyword/location
+bun run scripts/resume/snapshot-source-backups.ts \
+  --source 51job --count 20 \
+  --51job-url "https://ehire.51job.com/Revision/talent/search?keyword=工程师&tr_min_age=25&tr_max_age=40"
+```
+
+### Key options
+
+| Option | Default | Description |
+|---|---|---|
+| `--source <alias>` | (required) | Source alias: `51job`, `job5156`, `seek` (repeatable) |
+| `--count <n>` | `20` | Resumes to collect per source |
+| `--max-pages <n>` | `10` | Max pages to paginate through |
+| `--cdp-endpoint <url>` | `http://127.0.0.1:9222` | Chrome DevTools endpoint |
+| `--<source>-url <url>` | Per-source default | Override the search URL for a source |
+| `--out-dir <path>` | `output/resume-backups` | Output directory for timestamped snapshots |
+
+### Output
+
+Creates a timestamped directory:
+```
+output/resume-backups/20260602-190034/
+├── resume-backup-51job-top20-20260602-190034.json
+├── resume-backup-job5156-top20-20260602-190034.json
+└── resume-backup-seek-top20-20260602-190034.json
+```
+
+### Known issues
+
+- **51job login redirect:** If not fully logged in, the collector raises "51job redirected to a login page". Log in inside Chrome, reopen the talent search page, then rerun.
+- **Seek account selection:** If redirected to `/account/select`, complete account selection in Chrome first.
+- **Extension `collect()` missing:** If the extension accessor doesn't expose `collect()`, reload the browser extension.
+- For detailed per-source prerequisites and troubleshooting, read the reference file for that source.
+
+---
+
+## Push Workflow
+
+Push the latest snapshot directory to the GitHub sample repo.
+
+**Command:** `make push-sample-snapshots`
+
+### What it does
+
+1. Finds the latest `output/resume-backups/YYYYMMDD-HHMMSS/` directory containing `.json` files
+2. Clones `ptdevhk/trends-resume-samples`, replaces snapshot files, regenerates README
+3. Commits and pushes to `main`
+
+### Auth gotcha
+
+The push script tries `git clone` first, then falls back to `gh repo clone`. If `gh` is authenticated as the wrong GitHub user, it fails with `HTTP 401`. Fix:
+
+```bash
+gh auth switch --user <correct-user>
+make push-sample-snapshots
+```
+
+### Note
+
+The script pushes **all** `.json` files in the latest snapshot directory. To push only a specific source, create a directory containing only that source's file, or use `SNAPSHOT_DIR` to point at a specific directory:
+
+```bash
+SNAPSHOT_DIR=output/resume-backups/20260602-190034 make push-sample-snapshots
+```
+
+---
+
+## Pull+Restore Workflow
+
+Pull sample snapshots from GitHub and restore them into the local Convex backend.
+
+### One command
+
+```bash
+make restore-sample-snapshots
+```
+
+### Step by step
+
+```bash
+# Step 1: Pull from GitHub to output/resume-samples/
+make pull-sample-snapshots
+
+# Step 2: Restore to local Convex with derived field recomputation
+make restore-resumes FILE=output/resume-samples RECOMPUTE_DERIVED_FIELDS=1
+```
+
+### Prerequisites
+
+- Local dev stack running (at minimum API + Convex backend)
+- Same `gh` auth considerations as push workflow
+
+### After restore
+
+- Resumes are available in the local Convex dashboard and search UI
+- Run `make seed` if you also need job descriptions seeded alongside the samples
+
+---
+
+## Full Refresh Workflow
+
+End-to-end pipeline: collect all sources (both seek modes) → push to GitHub.
+
+Each `snapshot-source-backups.ts` invocation creates a new timestamped directory. `push-sample-snapshots` pushes only the **latest** directory. To push all source variants together, merge the files into one directory first.
+
+### Step 1: Collect primary sources
+
+```bash
+bun run scripts/resume/snapshot-source-backups.ts \
+  --source 51job --source job5156 --source seek --count 20
+```
+
+This creates `output/resume-backups/<timestamp-1>/` with 51job, job5156, and seek-recommended snapshots.
+
+### Step 2: Collect seek talent search variant
+
+```bash
+bun run scripts/resume/snapshot-source-backups.ts \
+  --source seek --count 20 \
+  --seek-url "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE"
+```
+
+This creates `output/resume-backups/<timestamp-2>/` with the seek-talentsearch snapshot. Note that this file is also named `resume-backup-seek-top20-<timestamp>.json` (same alias), so it must be renamed before merging to avoid overwriting the seek-recommended file.
+
+### Step 3: Merge and push
+
+```bash
+# Merge talentsearch file into the first directory with a distinct name
+cp output/resume-backups/<timestamp-2>/resume-backup-seek-top20-*.json \
+   output/resume-backups/<timestamp-1>/resume-backup-seek-talentsearch-top20.json
+
+# Push the merged directory
+SNAPSHOT_DIR=output/resume-backups/<timestamp-1> make push-sample-snapshots
+```
+
+### Verification
+
+Check that all 4 files are present before pushing:
+
+```bash
+ls output/resume-backups/<timestamp-1>/
+# Expected:
+#   resume-backup-51job-top20-<ts>.json
+#   resume-backup-job5156-top20-<ts>.json
+#   resume-backup-seek-top20-<ts>.json          (recommended)
+#   resume-backup-seek-talentsearch-top20.json  (talent search)
+```

--- a/.agents/skills/refresh-sample-snapshots/agents/openai.yaml
+++ b/.agents/skills/refresh-sample-snapshots/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Refresh Sample Snapshots
+short_description: Refresh, push, pull, and restore resume sample snapshots across 51job, job5156, and seek CDP sources.
+default_prompt: Use the refresh-sample-snapshots workflow. Help the user collect, push, pull, or restore resume sample snapshots using the documented scripts and Make targets. Check per-source reference files for source-specific prerequisites and troubleshooting.

--- a/.agents/skills/refresh-sample-snapshots/references/51job.md
+++ b/.agents/skills/refresh-sample-snapshots/references/51job.md
@@ -1,0 +1,39 @@
+# 51job (CN Market)
+
+Source for Chinese mainland resumes. Uses `ehire.51job.com` employer portal.
+
+## Prerequisites
+
+- Logged into `ehire.51job.com` in Chrome with an employer account
+- The talent search page must be fully loaded with visible candidate rows before collection starts
+- The browser extension must be loaded and active
+
+## Default URL
+
+```
+https://ehire.51job.com/Revision/talent/search?keyword=CNC+%E9%94%80%E5%94%AE&tr_min_age=25&tr_max_age=40
+```
+
+## Collection mechanism
+
+CDP-based via `scripts/resume/collect_browser_source.py` with `--source 51job`. The collector:
+
+1. Navigates to the talent search URL
+2. Waits for `window.__TR_RESUME_DATA__` to report ready state (`sourceKey === "51job"`)
+3. Calls `api.collect()` which paginates through results and extracts resume data
+4. Returns JSON payload with metadata + resume array
+
+## Known issues
+
+### Login redirect
+If the collector raises "51job redirected to a login page", the session has expired or wasn't logged in. Log into `ehire.51job.com` in Chrome, navigate back to the talent search page, then rerun.
+
+### Slow page load
+51job search pages can be slow to render results. The collector waits up to 90 seconds for the page to report ready. If it times out with "Timed out waiting for the source page to finish loading results", ensure the page is fully loaded with visible candidate rows. The `domReady` flag must report `true` before the collector proceeds.
+
+### HMAC signing
+51job detail pages use per-request HMAC `sign` parameters computed by obfuscated frontend JS. The extension cannot replicate these signatures, so 51job detail enrichment goes through real browser tabs (slower than job5156 direct fetch). This doesn't affect the snapshot collection itself but means restored 51job samples may have less enriched detail than job5156 samples until the extension processes them.
+
+## Age filter
+
+The default URL includes `tr_min_age=25&tr_max_age=40`. Adjust these params to target different age ranges, or remove them for unfiltered results.

--- a/.agents/skills/refresh-sample-snapshots/references/job5156.md
+++ b/.agents/skills/refresh-sample-snapshots/references/job5156.md
@@ -1,0 +1,50 @@
+# job5156 (MY/CN Market)
+
+Source for Malaysia and China resumes via the Job5156 employer portal.
+
+## Prerequisites
+
+- Logged into `hr.job5156.com` in Chrome with an employer account
+- Must be on the `/search` page (the collector validates `pathname === "/search"`)
+- The browser extension must be loaded and active
+
+## Default URL
+
+```
+https://hr.job5156.com/search?keyword=CNC+%E9%94%80%E5%94%AE&tr_min_age=25&tr_max_age=40
+```
+
+## Collection mechanism
+
+CDP-based via `scripts/resume/collect_browser_source.py` with `--source job5156`. The collector:
+
+1. Navigates to the search URL
+2. Waits for `window.__TR_RESUME_DATA__` to report ready state (`sourceKey === "job5156"`, card count > 0 or autoSearch complete)
+3. Calls `api.collect()` which paginates and extracts resume data
+4. Returns JSON payload with metadata + resume array
+
+## URL parameters
+
+The search page supports these query params:
+
+| Param | Example | Description |
+|---|---|---|
+| `keyword` | `CNC+%E9%94%80%E5%94%AE` | Search keyword (URL-encoded) |
+| `location` | `广东` | Location filter |
+| `tr_min_age` | `25` | Minimum age (inclusive) |
+| `tr_max_age` | `40` | Maximum age (inclusive) |
+
+## Known issues
+
+### Stale extension state
+If `window.__TR_RESUME_DATA__` doesn't expose `collect()`, reload the browser extension. The collector checks for this and raises a clear error.
+
+### Source key mismatch
+If the page reports a `sourceKey` other than `job5156`, the collector fails. This usually means the wrong page is loaded — ensure you're on `hr.job5156.com/search`.
+
+## Compared to 51job
+
+job5156 collection is generally faster and more reliable than 51job:
+- No HMAC signing issues for detail enrichment
+- Direct API fetch for detail pages (no browser tab fallback needed)
+- Pages load faster and time out less often

--- a/.agents/skills/refresh-sample-snapshots/references/seek.md
+++ b/.agents/skills/refresh-sample-snapshots/references/seek.md
@@ -1,0 +1,78 @@
+# Seek (HK/MY Market)
+
+Source for Hong Kong and Malaysia resumes via the Seek employer portal. Unlike 51job and job5156, Seek has two distinct collection endpoints.
+
+## Prerequisites
+
+- Logged into the appropriate Seek employer portal in Chrome
+- Employer account selection must be complete (not stuck on `/account/select`)
+- The browser extension must be loaded and active
+
+---
+
+## Path A: Recommended Candidates (HK)
+
+jobId-based collection from an existing job posting's recommended candidates list.
+
+### Default URL
+
+```
+https://hk.employer.seek.com/candidates/recommended?jobId=92216704
+```
+
+### Collection mechanism
+
+Navigates to a specific job's recommended candidates page. The collector validates the page is on `/candidates/recommended` (not `/jobs` or `/account/select`). Results are tied to the job posting — changing the `jobId` changes which candidates appear.
+
+### Best for
+- Quick snapshots tied to a known job posting
+- Reproducible samples (same jobId = same candidate pool)
+
+### Known issues
+- If redirected to `/jobs` (jobs list), the collector reports "SEEK redirected to the jobs list instead of the recommended candidates page"
+- If redirected to `/account/select`, complete account selection first
+
+---
+
+## Path B: Talent Search (MY)
+
+Keyword-based collection that mirrors how recruiters actually search.
+
+### Default URL (not set in snapshot-source-backups.ts defaults — use `--seek-url` override)
+
+```
+https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE
+```
+
+### URL parameters
+
+| Param | Example | Description |
+|---|---|---|
+| `keywords` | `CNC+sales` | Search keywords |
+| `market` | `MY` | Market code |
+| `roleTitles` | `Sales+Manager` | Narrow by role title |
+
+### Collection command
+
+```bash
+bun run scripts/resume/snapshot-source-backups.ts \
+  --source seek --count 20 \
+  --seek-url "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE"
+```
+
+### Best for
+- Keyword-targeted samples that reflect actual recruiter search behavior
+- MY market specifically
+
+---
+
+## Path Selection
+
+| Criterion | Recommended | Talent Search |
+|---|---|---|
+| Market | HK | MY |
+| Input | jobId | keywords + market |
+| Reproducibility | High (fixed jobId) | Medium (search results change) |
+| Recruiter realism | Low (pre-filtered by job) | High (matches real search flow) |
+
+For a full refresh that covers both markets, run both paths with different `--seek-url` values. Note that both use alias `seek`, so the second run overwrites the first's snapshot file unless you rename or use separate directories.

--- a/.claude/skills/refresh-sample-snapshots
+++ b/.claude/skills/refresh-sample-snapshots
@@ -1,0 +1,1 @@
+../../.agents/skills/refresh-sample-snapshots

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -1031,7 +1031,8 @@
       if (getCurrentSeekMode2() === "talentsearch") {
         return Array.isArray(apiSnapshot2.seekTalentSearch) ? apiSnapshot2.seekTalentSearch.length : 0;
       }
-      return Array.isArray(apiSnapshot2.seekRecommendedCandidates) ? apiSnapshot2.seekRecommendedCandidates.length : 0;
+      const recommendedCount = Array.isArray(apiSnapshot2.seekRecommendedCandidates) ? apiSnapshot2.seekRecommendedCandidates.length : 0;
+      return recommendedCount || getSeekRecommendedDomCardCount();
     }
     __name(getSeekCurrentCandidateCount2, "getSeekCurrentCandidateCount");
     function setSeekAutoSyncWindowAttributes2(pageWindow) {
@@ -1238,6 +1239,9 @@
     __name(getSeekPayloadData2, "getSeekPayloadData");
     function extractSeekResumes2() {
       const candidates = Array.isArray(apiSnapshot2.seekRecommendedCandidates) ? apiSnapshot2.seekRecommendedCandidates : [];
+      if (candidates.length === 0 && getCurrentSeekMode2() === "recommended") {
+        return extractSeekRecommendedDomResumes();
+      }
       const request = getSeekRecommendedRequest2();
       const variables = request?.variables;
       const requestInput = variables?.input;
@@ -1345,11 +1349,107 @@
     }
     __name(extractSeekTalentSearchResumes2, "extractSeekTalentSearchResumes");
     function getSeekCardCount2() {
+      if (getCurrentSeekMode2() === "recommended") {
+        return getSeekRecommendedDomCardCount();
+      }
       return doc.querySelectorAll(
         'a[href*="/talentsearch/profile/"][href*="profilePosition="]'
       ).length;
     }
     __name(getSeekCardCount2, "getSeekCardCount");
+    function findSeekRecommendedDomCard(heading) {
+      let current = heading.parentElement;
+      while (current) {
+        if (current.querySelector('[data-testid="work-history"]')) {
+          return current;
+        }
+        current = current.parentElement;
+      }
+      return null;
+    }
+    __name(findSeekRecommendedDomCard, "findSeekRecommendedDomCard");
+    function getSeekRecommendedDomCardCount() {
+      if (getCurrentSeekMode2() !== "recommended") return 0;
+      const seenCards = /* @__PURE__ */ new Set();
+      for (const heading of doc.querySelectorAll('[data-role="heading"]')) {
+        const name = (heading.textContent || "").trim();
+        const card = name ? findSeekRecommendedDomCard(heading) : null;
+        if (card && !seenCards.has(card)) {
+          seenCards.add(card);
+        }
+      }
+      return seenCards.size;
+    }
+    __name(getSeekRecommendedDomCardCount, "getSeekRecommendedDomCardCount");
+    function getSeekRecommendedDomCards() {
+      if (getCurrentSeekMode2() !== "recommended") return [];
+      const seenCards = /* @__PURE__ */ new Set();
+      return Array.from(doc.querySelectorAll('[data-role="heading"]')).map((heading) => {
+        const name = (heading.textContent || "").trim();
+        const card = name ? findSeekRecommendedDomCard(heading) : null;
+        if (!card || seenCards.has(card)) return null;
+        const workHistory = Array.from(
+          card.querySelectorAll('[data-testid="work-history"]')
+        ).map((item) => (item.textContent || "").trim()).filter(Boolean);
+        if (workHistory.length === 0) return null;
+        seenCards.add(card);
+        return { name, workHistory };
+      }).filter(
+        (card) => Boolean(card)
+      );
+    }
+    __name(getSeekRecommendedDomCards, "getSeekRecommendedDomCards");
+    function getJobTitleFromWorkHistory(raw) {
+      return raw.split(/\s+at\s+/iu)[0]?.trim() || "";
+    }
+    __name(getJobTitleFromWorkHistory, "getJobTitleFromWorkHistory");
+    function extractSeekRecommendedDomResumes() {
+      const url = new URL(win.location.href);
+      const jobId = normalizeOptionalPositiveInt2(url.searchParams.get("jobId")) || "recommended";
+      const currentPage = normalizeOptionalPositiveInt2(url.searchParams.get("pageNumber")) || 1;
+      const sourceHost = win.location.hostname.toLowerCase();
+      const resumes = [];
+      let pageIndex = 0;
+      const seenCards = /* @__PURE__ */ new Set();
+      for (const heading of doc.querySelectorAll('[data-role="heading"]')) {
+        const name = (heading.textContent || "").trim();
+        const card = name ? findSeekRecommendedDomCard(heading) : null;
+        if (!card || seenCards.has(card)) continue;
+        const workHistory = [];
+        for (const item of card.querySelectorAll('[data-testid="work-history"]')) {
+          const text = (item.textContent || "").trim();
+          if (text) workHistory.push(text);
+        }
+        if (workHistory.length === 0) continue;
+        seenCards.add(card);
+        pageIndex++;
+        const profileId = `dom-${jobId}-${currentPage}-${pageIndex}`;
+        resumes.push({
+          profileId,
+          profileType: SEEK_PROFILE_TYPE2,
+          externalId: `${sourceHost}:recommended:${profileId}`,
+          name,
+          profileUrl: win.location.href,
+          activityStatus: "",
+          age: "",
+          experience: "",
+          education: "",
+          location: "",
+          jobIntention: getJobTitleFromWorkHistory(workHistory[0] || ""),
+          expectedSalary: "",
+          selfIntro: "",
+          workHistory: workHistory.map((raw) => ({ raw })),
+          extractedAt: (/* @__PURE__ */ new Date()).toISOString(),
+          pageIndex,
+          source: sourceHost,
+          searchProfileId: "",
+          language: "",
+          pageNumber: currentPage
+        });
+      }
+      return resumes;
+    }
+    __name(extractSeekRecommendedDomResumes, "extractSeekRecommendedDomResumes");
     function getSeekPaginationInfo2() {
       const isTalentSearch = getCurrentSeekMode2() === "talentsearch";
       const currentPage = normalizeOptionalPositiveInt2(
@@ -3117,6 +3217,7 @@
       apiSnapshot: apiSnapshot2,
       SELECTORS: SELECTORS2,
       getApiSnapshotCount: getApiSnapshotCount2,
+      getSeekCurrentCandidateCount: getSeekCurrentCandidateCount2,
       isExtractionReady: isExtractionReady2,
       isJob51RateLimitedPage: isJob51RateLimitedPage2,
       JOB51_RATE_LIMIT_ERROR_MESSAGE: JOB51_RATE_LIMIT_ERROR_MESSAGE2,
@@ -3243,10 +3344,11 @@
             return;
           }
           const count = getApiSnapshotCount2();
-          if (count >= minCount || getCurrentSourceKey2() === SOURCE_KEYS2.JOB51 && isExtractionReady2()) {
+          const seekCandidateCount = getCurrentSourceKey2() === SOURCE_KEYS2.SEEK ? getSeekCurrentCandidateCount2() : 0;
+          if (count >= minCount || seekCandidateCount >= minCount || getCurrentSourceKey2() === SOURCE_KEYS2.JOB51 && isExtractionReady2()) {
             done = true;
             cleanup();
-            resolve(count);
+            resolve(Math.max(count, seekCandidateCount));
           } else if (Date.now() > deadline) {
             done = true;
             cleanup();
@@ -3354,6 +3456,8 @@
         if (hasSeekListSnapshot2()) {
           return extractSeekResumes2();
         }
+        const fallbackResumes = extractSeekResumes2();
+        return fallbackResumes.length > 0 ? fallbackResumes : [];
       }
       if (isJob5156DetailPage2()) {
         return filterCurrentResumesByAgeRange2(extractJob5156DetailResume2());
@@ -7410,6 +7514,7 @@
     apiSnapshot,
     SELECTORS,
     getApiSnapshotCount: /* @__PURE__ */ __name(() => getApiSnapshotCount(), "getApiSnapshotCount"),
+    getSeekCurrentCandidateCount,
     isExtractionReady,
     isJob51RateLimitedPage,
     JOB51_RATE_LIMIT_ERROR_MESSAGE,

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -590,6 +590,7 @@ const _extractionPipeline = createExtractionPipeline({
   apiSnapshot,
   SELECTORS,
   getApiSnapshotCount: () => getApiSnapshotCount(),
+  getSeekCurrentCandidateCount,
   isExtractionReady,
   isJob51RateLimitedPage,
   JOB51_RATE_LIMIT_ERROR_MESSAGE,

--- a/apps/browser-extension/src/lib/__tests__/extraction-pipeline.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/extraction-pipeline.test.ts
@@ -48,6 +48,7 @@ function createMockDeps(overrides: Record<string, any> = {}): ExtractionPipeline
     getSeekProfileRequest: vi.fn(() => null),
     getSeekTalentSearchRequest: vi.fn(() => null),
     getSeekRecommendedRequest: vi.fn(() => null),
+    getSeekCurrentCandidateCount: vi.fn(() => 0),
     SEEK_PROFILE_TYPE: "seek",
     getJob5156DetailRoot: vi.fn(() => null),
     getSeekNextPageLinkForMode: vi.fn(() => null),
@@ -167,6 +168,39 @@ describe("extraction-pipeline", () => {
       const pipeline = createExtractionPipeline(createMockDeps());
       const el = document.createElement("button");
       expect(pipeline.isDisabledPaginationControl(el)).toBe(false);
+    });
+  });
+
+  describe("extractResumes", () => {
+    it("uses Seek recommended fallback resumes when API list snapshots are absent", () => {
+      const fallbackResumes = [{ name: "Candidate One", source: "seek" }];
+      const deps = createMockDeps({
+        getCurrentSourceKey: vi.fn(() => SOURCE_KEYS.SEEK),
+        isSeekProfileMode: vi.fn(() => false),
+        hasSeekProfileSnapshot: vi.fn(() => false),
+        hasSeekTalentSearchSnapshot: vi.fn(() => false),
+        hasSeekListSnapshot: vi.fn(() => false),
+        extractSeekResumes: vi.fn(() => fallbackResumes),
+      });
+      const pipeline = createExtractionPipeline(deps);
+
+      expect(pipeline.extractResumes()).toEqual(fallbackResumes);
+      expect(deps.extractSeekResumes).toHaveBeenCalled();
+    });
+  });
+
+  describe("waitForExtractionData", () => {
+    it("uses Seek DOM candidate count when API rows are absent", async () => {
+      const deps = createMockDeps({
+        getCurrentSourceKey: vi.fn(() => SOURCE_KEYS.SEEK),
+        getApiSnapshotCount: vi.fn(() => 0),
+        getSeekCurrentCandidateCount: vi.fn(() => 2),
+      });
+      const pipeline = createExtractionPipeline(deps);
+
+      await expect(
+        pipeline.waitForExtractionData({ timeoutMs: 1, minCount: 1 }),
+      ).resolves.toBe(2);
     });
   });
 });

--- a/apps/browser-extension/src/lib/__tests__/seek-extractor.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/seek-extractor.test.ts
@@ -159,6 +159,44 @@ describe("seek-extractor", () => {
     });
   });
 
+  describe("getSeekCardCount", () => {
+    it("counts recommended candidate cards rendered as heading rows", () => {
+      window.history.pushState(
+        {},
+        "",
+        "/candidates/recommended?jobId=92216704",
+      );
+      document.body.innerHTML = `
+        <div>
+          <span data-role="heading">Candidate One</span>
+          <span data-testid="work-history">Sales Engineer at Company A</span>
+        </div>
+        <div>
+          <span data-role="heading">Candidate Two</span>
+          <span data-testid="work-history">Service Engineer at Company B</span>
+        </div>
+      `;
+
+      try {
+        const extractor = createSeekExtractor(
+          createMockDeps({
+            doc: {
+              querySelector: (selector: string) =>
+                document.querySelector(selector),
+              querySelectorAll: (selector: string) =>
+                document.querySelectorAll(selector),
+            },
+          }),
+        );
+
+        expect(extractor.getSeekCardCount()).toBe(2);
+      } finally {
+        document.body.innerHTML = "";
+        window.history.pushState({}, "", "/");
+      }
+    });
+  });
+
   describe("resolveSeekAutoSyncPageWindow", () => {
     it("returns start page 1 by default", () => {
       const extractor = createSeekExtractor(createMockDeps());
@@ -412,6 +450,74 @@ describe("seek-extractor", () => {
       expect(result).toHaveLength(2);
       expect(result[0].name).toBe("Alice Smith");
       expect(result[1].name).toBe("Bob Jones");
+    });
+
+    it("falls back to rendered recommended cards when API candidates are absent", () => {
+      window.history.pushState(
+        {},
+        "",
+        "/candidates/recommended?jobId=92216704",
+      );
+      document.body.innerHTML = `
+        <div>
+          <span data-role="heading">Candidate One</span>
+          <span data-testid="work-history">Sales Engineer at Company A</span>
+          <span data-testid="work-history">Service Manager at Company B</span>
+        </div>
+        <div>
+          <span data-role="heading">Candidate Two</span>
+          <span data-testid="work-history">Application Engineer at Company C</span>
+        </div>
+      `;
+
+      try {
+        const extractor = createSeekExtractor(
+          createMockDeps({
+            apiSnapshot: {
+              seekRecommendedCandidates: [],
+              seekRecommendedRequest: null,
+            },
+            doc: {
+              querySelector: (selector: string) =>
+                document.querySelector(selector),
+              querySelectorAll: (selector: string) =>
+                document.querySelectorAll(selector),
+            },
+            win: {
+              location: {
+                pathname: "/candidates/recommended",
+                href: "https://hk.employer.seek.com/candidates/recommended?jobId=92216704",
+                hostname: "hk.employer.seek.com",
+                search: "?jobId=92216704",
+              },
+            },
+          }),
+        );
+
+        expect(extractor.getSeekCurrentCandidateCount()).toBe(2);
+        const result = extractor.extractSeekResumes();
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toMatchObject({
+          profileId: "dom-92216704-1-1",
+          name: "Candidate One",
+          jobIntention: "Sales Engineer",
+          source: "hk.employer.seek.com",
+          pageNumber: 1,
+        });
+        expect(result[0].workHistory).toEqual([
+          { raw: "Sales Engineer at Company A" },
+          { raw: "Service Manager at Company B" },
+        ]);
+        expect(result[1]).toMatchObject({
+          profileId: "dom-92216704-1-2",
+          name: "Candidate Two",
+          jobIntention: "Application Engineer",
+        });
+      } finally {
+        document.body.innerHTML = "";
+        window.history.pushState({}, "", "/");
+      }
     });
   });
 

--- a/apps/browser-extension/src/lib/extraction-pipeline.ts
+++ b/apps/browser-extension/src/lib/extraction-pipeline.ts
@@ -9,6 +9,7 @@ export interface ExtractionPipelineDeps extends Record<string, unknown> {
   apiSnapshot: Record<string, unknown>;
   SELECTORS: Record<string, string>;
   getApiSnapshotCount: () => number;
+  getSeekCurrentCandidateCount: () => number;
   isExtractionReady: () => boolean;
   isJob51RateLimitedPage: () => boolean;
   JOB51_RATE_LIMIT_ERROR_MESSAGE: string;
@@ -58,6 +59,7 @@ export function createExtractionPipeline(deps: ExtractionPipelineDeps) {
     apiSnapshot,
     SELECTORS,
     getApiSnapshotCount,
+    getSeekCurrentCandidateCount,
     isExtractionReady,
     isJob51RateLimitedPage,
     JOB51_RATE_LIMIT_ERROR_MESSAGE,
@@ -215,13 +217,18 @@ export function createExtractionPipeline(deps: ExtractionPipelineDeps) {
           return;
         }
         const count = getApiSnapshotCount();
+        const seekCandidateCount =
+          getCurrentSourceKey() === SOURCE_KEYS.SEEK
+            ? getSeekCurrentCandidateCount()
+            : 0;
         if (
           count >= minCount ||
+          seekCandidateCount >= minCount ||
           (getCurrentSourceKey() === SOURCE_KEYS.JOB51 && isExtractionReady())
         ) {
           done = true;
           cleanup();
-          resolve(count);
+          resolve(Math.max(count, seekCandidateCount));
         } else if (Date.now() > deadline) {
           done = true;
           cleanup();
@@ -350,6 +357,8 @@ export function createExtractionPipeline(deps: ExtractionPipelineDeps) {
       if (hasSeekListSnapshot()) {
         return extractSeekResumes();
       }
+      const fallbackResumes = extractSeekResumes();
+      return fallbackResumes.length > 0 ? fallbackResumes : [];
     }
 
     if (isJob5156DetailPage()) {

--- a/apps/browser-extension/src/lib/seek-extractor.ts
+++ b/apps/browser-extension/src/lib/seek-extractor.ts
@@ -257,7 +257,10 @@ export function createSeekExtractor(deps: SeekExtractorDeps) {
     if (getCurrentSeekMode() === "talentsearch") {
       return Array.isArray(apiSnapshot.seekTalentSearch) ? (apiSnapshot.seekTalentSearch as unknown[]).length : 0;
     }
-    return Array.isArray(apiSnapshot.seekRecommendedCandidates) ? (apiSnapshot.seekRecommendedCandidates as unknown[]).length : 0;
+    const recommendedCount = Array.isArray(apiSnapshot.seekRecommendedCandidates)
+      ? (apiSnapshot.seekRecommendedCandidates as unknown[]).length
+      : 0;
+    return recommendedCount || getSeekRecommendedDomCardCount();
   }
 
   function setSeekAutoSyncWindowAttributes(pageWindow: Record<string, unknown> | null) {
@@ -581,6 +584,9 @@ export function createSeekExtractor(deps: SeekExtractorDeps) {
     const candidates = Array.isArray(apiSnapshot.seekRecommendedCandidates)
       ? (apiSnapshot.seekRecommendedCandidates as Record<string, unknown>[])
       : [];
+    if (candidates.length === 0 && getCurrentSeekMode() === "recommended") {
+      return extractSeekRecommendedDomResumes();
+    }
     const request = getSeekRecommendedRequest();
     const variables = request?.variables as Record<string, unknown> | undefined;
     const requestInput = variables?.input as Record<string, unknown> | undefined;
@@ -764,9 +770,122 @@ export function createSeekExtractor(deps: SeekExtractorDeps) {
   // ============================================================================
 
   function getSeekCardCount() {
+    if (getCurrentSeekMode() === "recommended") {
+      return getSeekRecommendedDomCardCount();
+    }
+
     return doc.querySelectorAll(
       'a[href*="/talentsearch/profile/"][href*="profilePosition="]',
     ).length;
+  }
+
+  function findSeekRecommendedDomCard(heading: Element) {
+    let current = heading.parentElement;
+    while (current) {
+      if (current.querySelector('[data-testid="work-history"]')) {
+        return current;
+      }
+      current = current.parentElement;
+    }
+    return null;
+  }
+
+  function getSeekRecommendedDomCardCount() {
+    if (getCurrentSeekMode() !== "recommended") return 0;
+
+    const seenCards = new Set<Element>();
+    for (const heading of doc.querySelectorAll('[data-role="heading"]')) {
+      const name = (heading.textContent || "").trim();
+      const card = name ? findSeekRecommendedDomCard(heading) : null;
+      if (card && !seenCards.has(card)) {
+        seenCards.add(card);
+      }
+    }
+    return seenCards.size;
+  }
+
+  function getSeekRecommendedDomCards() {
+    if (getCurrentSeekMode() !== "recommended") return [];
+
+    const seenCards = new Set<Element>();
+    return Array.from(doc.querySelectorAll('[data-role="heading"]'))
+      .map((heading) => {
+        const name = (heading.textContent || "").trim();
+        const card = name ? findSeekRecommendedDomCard(heading) : null;
+        if (!card || seenCards.has(card)) return null;
+
+        const workHistory = Array.from(
+          card.querySelectorAll('[data-testid="work-history"]'),
+        )
+          .map((item) => (item.textContent || "").trim())
+          .filter(Boolean);
+        if (workHistory.length === 0) return null;
+
+        seenCards.add(card);
+        return { name, workHistory };
+      })
+      .filter((card): card is { name: string; workHistory: string[] } =>
+        Boolean(card),
+      );
+  }
+
+  function getJobTitleFromWorkHistory(raw: string) {
+    return raw.split(/\s+at\s+/iu)[0]?.trim() || "";
+  }
+
+  function extractSeekRecommendedDomResumes() {
+    const url = new URL(win.location.href);
+    const jobId =
+      normalizeOptionalPositiveInt(url.searchParams.get("jobId")) ||
+      "recommended";
+    const currentPage =
+      normalizeOptionalPositiveInt(url.searchParams.get("pageNumber")) || 1;
+    const sourceHost = win.location.hostname.toLowerCase();
+
+    const resumes: Record<string, unknown>[] = [];
+    let pageIndex = 0;
+    const seenCards = new Set<Element>();
+
+    for (const heading of doc.querySelectorAll('[data-role="heading"]')) {
+      const name = (heading.textContent || "").trim();
+      const card = name ? findSeekRecommendedDomCard(heading) : null;
+      if (!card || seenCards.has(card)) continue;
+
+      const workHistory: string[] = [];
+      for (const item of card.querySelectorAll('[data-testid="work-history"]')) {
+        const text = (item.textContent || "").trim();
+        if (text) workHistory.push(text);
+      }
+      if (workHistory.length === 0) continue;
+
+      seenCards.add(card);
+      pageIndex++;
+      const profileId = `dom-${jobId}-${currentPage}-${pageIndex}`;
+      resumes.push({
+        profileId,
+        profileType: SEEK_PROFILE_TYPE,
+        externalId: `${sourceHost}:recommended:${profileId}`,
+        name,
+        profileUrl: win.location.href,
+        activityStatus: "",
+        age: "",
+        experience: "",
+        education: "",
+        location: "",
+        jobIntention: getJobTitleFromWorkHistory(workHistory[0] || ""),
+        expectedSalary: "",
+        selfIntro: "",
+        workHistory: workHistory.map((raw) => ({ raw })),
+        extractedAt: new Date().toISOString(),
+        pageIndex,
+        source: sourceHost,
+        searchProfileId: "",
+        language: "",
+        pageNumber: currentPage,
+      });
+    }
+
+    return resumes;
   }
 
   function getSeekPaginationInfo() {

--- a/config/skills/install.yaml
+++ b/config/skills/install.yaml
@@ -10,6 +10,7 @@ project:
     - resume-ai-scoring-audit
     - trends-agent-governance
     - trends-cli
+    - refresh-sample-snapshots
 
 global:
   - source: https://github.com/karlorz/agent-skills/tree/main/skills/simplify

--- a/dev-docs/skills/refresh-sample-snapshots/SKILL.md
+++ b/dev-docs/skills/refresh-sample-snapshots/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: refresh-sample-snapshots
+description: >
+  Refresh, push, pull, and restore resume sample snapshots across 3 CDP sources
+  (51job, job5156, seek). Seek supports both recommended and talentsearch collection modes.
+  Use when the user mentions sample
+  snapshots, sample repo, refresh/push/pull/restore samples, dev-samples, or wants to update
+  the ptdevhk/trends-resume-samples repository.
+validation:
+  descriptionTerms: [sample, snapshot, resume, refresh, push, pull, restore, dev-samples]
+---
+
+# Refresh Sample Snapshots
+
+Manage the resume sample snapshot lifecycle: collect fresh data from browser sources via CDP, push to the shared GitHub sample repo, and pull/restore into a local dev environment.
+
+## Prerequisites
+
+- Chrome running with remote debugging on port 9222 (`make chrome-debug` or `./apps/browser-extension/scripts/cmux-setup-profile.sh`)
+- Browser extension loaded and active in Chrome
+- Logged into each target source in Chrome (see per-source reference files for details)
+- For pull/restore: local dev stack running (`make dev` or at minimum API + Convex)
+
+## Source Coverage
+
+| Source alias | Market | Collection mechanism | Reference |
+|---|---|---|---|
+| `51job` | CN | Keyword search on `ehire.51job.com` | [references/51job.md](references/51job.md) |
+| `job5156` | MY/CN | Keyword + location on `hr.job5156.com` | [references/job5156.md](references/job5156.md) |
+| `seek` (recommended) | HK | jobId-based on `hk.employer.seek.com` | [references/seek.md](references/seek.md) |
+| `seek` (talent search) | MY | Keyword-based on `hk.employer.seek.com/talentsearch` with `market=MY` | [references/seek.md](references/seek.md) |
+
+## Workflow Quick Reference
+
+| Workflow | Trigger phrases | What it does |
+|---|---|---|
+| **Collect** | "collect 51job samples", "snapshot seek", "refresh job5156 samples" | CDP scrape from one or more sources into `output/resume-backups/` |
+| **Push** | "push sample snapshots", "push samples to GitHub" | Upload latest snapshot dir to `ptdevhk/trends-resume-samples` |
+| **Pull+Restore** | "pull sample snapshots", "restore samples" | Clone sample repo → restore into local Convex |
+| **Full refresh** | "full sample refresh", "refresh all samples" | Collect all sources → push to GitHub (multi-step) |
+
+---
+
+## Collect Workflow
+
+Collect fresh resume samples from browser sources via CDP.
+
+**Primary script:** `scripts/resume/snapshot-source-backups.ts` (calls `scripts/resume/collect_browser_source.py` under the hood).
+
+### Single source
+
+```bash
+bun run scripts/resume/snapshot-source-backups.ts --source 51job --count 20
+```
+
+### Multiple sources in one run
+
+```bash
+bun run scripts/resume/snapshot-source-backups.ts \
+  --source 51job --source job5156 --source seek --count 20
+```
+
+### Custom URL override
+
+Override the default search URL for a source:
+
+```bash
+# Seek talent search (MY market) — uses keyword-based collection
+bun run scripts/resume/snapshot-source-backups.ts \
+  --source seek --count 20 \
+  --seek-url "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE"
+
+# Custom 51job keyword/location
+bun run scripts/resume/snapshot-source-backups.ts \
+  --source 51job --count 20 \
+  --51job-url "https://ehire.51job.com/Revision/talent/search?keyword=工程师&tr_min_age=25&tr_max_age=40"
+```
+
+### Key options
+
+| Option | Default | Description |
+|---|---|---|
+| `--source <alias>` | (required) | Source alias: `51job`, `job5156`, `seek` (repeatable) |
+| `--count <n>` | `20` | Resumes to collect per source |
+| `--max-pages <n>` | `10` | Max pages to paginate through |
+| `--cdp-endpoint <url>` | `http://127.0.0.1:9222` | Chrome DevTools endpoint |
+| `--<source>-url <url>` | Per-source default | Override the search URL for a source |
+| `--out-dir <path>` | `output/resume-backups` | Output directory for timestamped snapshots |
+
+### Output
+
+Creates a timestamped directory:
+```
+output/resume-backups/20260602-190034/
+├── resume-backup-51job-top20-20260602-190034.json
+├── resume-backup-job5156-top20-20260602-190034.json
+└── resume-backup-seek-top20-20260602-190034.json
+```
+
+### Known issues
+
+- **51job login redirect:** If not fully logged in, the collector raises "51job redirected to a login page". Log in inside Chrome, reopen the talent search page, then rerun.
+- **Seek account selection:** If redirected to `/account/select`, complete account selection in Chrome first.
+- **Extension `collect()` missing:** If the extension accessor doesn't expose `collect()`, reload the browser extension.
+- For detailed per-source prerequisites and troubleshooting, read the reference file for that source.
+
+---
+
+## Push Workflow
+
+Push the latest snapshot directory to the GitHub sample repo.
+
+**Command:** `make push-sample-snapshots`
+
+### What it does
+
+1. Finds the latest `output/resume-backups/YYYYMMDD-HHMMSS/` directory containing `.json` files
+2. Clones `ptdevhk/trends-resume-samples`, replaces snapshot files, regenerates README
+3. Commits and pushes to `main`
+
+### Auth gotcha
+
+The push script tries `git clone` first, then falls back to `gh repo clone`. If `gh` is authenticated as the wrong GitHub user, it fails with `HTTP 401`. Fix:
+
+```bash
+gh auth switch --user <correct-user>
+make push-sample-snapshots
+```
+
+### Note
+
+The script pushes **all** `.json` files in the latest snapshot directory. To push only a specific source, create a directory containing only that source's file, or use `SNAPSHOT_DIR` to point at a specific directory:
+
+```bash
+SNAPSHOT_DIR=output/resume-backups/20260602-190034 make push-sample-snapshots
+```
+
+---
+
+## Pull+Restore Workflow
+
+Pull sample snapshots from GitHub and restore them into the local Convex backend.
+
+### One command
+
+```bash
+make restore-sample-snapshots
+```
+
+### Step by step
+
+```bash
+# Step 1: Pull from GitHub to output/resume-samples/
+make pull-sample-snapshots
+
+# Step 2: Restore to local Convex with derived field recomputation
+make restore-resumes FILE=output/resume-samples RECOMPUTE_DERIVED_FIELDS=1
+```
+
+### Prerequisites
+
+- Local dev stack running (at minimum API + Convex backend)
+- Same `gh` auth considerations as push workflow
+
+### After restore
+
+- Resumes are available in the local Convex dashboard and search UI
+- Run `make seed` if you also need job descriptions seeded alongside the samples
+
+---
+
+## Full Refresh Workflow
+
+End-to-end pipeline: collect all sources (both seek modes) → push to GitHub.
+
+Each `snapshot-source-backups.ts` invocation creates a new timestamped directory. `push-sample-snapshots` pushes only the **latest** directory. To push all source variants together, merge the files into one directory first.
+
+### Step 1: Collect primary sources
+
+```bash
+bun run scripts/resume/snapshot-source-backups.ts \
+  --source 51job --source job5156 --source seek --count 20
+```
+
+This creates `output/resume-backups/<timestamp-1>/` with 51job, job5156, and seek-recommended snapshots.
+
+### Step 2: Collect seek talent search variant
+
+```bash
+bun run scripts/resume/snapshot-source-backups.ts \
+  --source seek --count 20 \
+  --seek-url "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE"
+```
+
+This creates `output/resume-backups/<timestamp-2>/` with the seek-talentsearch snapshot. Note that this file is also named `resume-backup-seek-top20-<timestamp>.json` (same alias), so it must be renamed before merging to avoid overwriting the seek-recommended file.
+
+### Step 3: Merge and push
+
+```bash
+# Merge talentsearch file into the first directory with a distinct name
+cp output/resume-backups/<timestamp-2>/resume-backup-seek-top20-*.json \
+   output/resume-backups/<timestamp-1>/resume-backup-seek-talentsearch-top20.json
+
+# Push the merged directory
+SNAPSHOT_DIR=output/resume-backups/<timestamp-1> make push-sample-snapshots
+```
+
+### Verification
+
+Check that all 4 files are present before pushing:
+
+```bash
+ls output/resume-backups/<timestamp-1>/
+# Expected:
+#   resume-backup-51job-top20-<ts>.json
+#   resume-backup-job5156-top20-<ts>.json
+#   resume-backup-seek-top20-<ts>.json          (recommended)
+#   resume-backup-seek-talentsearch-top20.json  (talent search)
+```

--- a/dev-docs/skills/refresh-sample-snapshots/agents/openai.yaml
+++ b/dev-docs/skills/refresh-sample-snapshots/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Refresh Sample Snapshots
+short_description: Refresh, push, pull, and restore resume sample snapshots across 51job, job5156, and seek CDP sources.
+default_prompt: Use the refresh-sample-snapshots workflow. Help the user collect, push, pull, or restore resume sample snapshots using the documented scripts and Make targets. Check per-source reference files for source-specific prerequisites and troubleshooting.

--- a/dev-docs/skills/refresh-sample-snapshots/references/51job.md
+++ b/dev-docs/skills/refresh-sample-snapshots/references/51job.md
@@ -1,0 +1,39 @@
+# 51job (CN Market)
+
+Source for Chinese mainland resumes. Uses `ehire.51job.com` employer portal.
+
+## Prerequisites
+
+- Logged into `ehire.51job.com` in Chrome with an employer account
+- The talent search page must be fully loaded with visible candidate rows before collection starts
+- The browser extension must be loaded and active
+
+## Default URL
+
+```
+https://ehire.51job.com/Revision/talent/search?keyword=CNC+%E9%94%80%E5%94%AE&tr_min_age=25&tr_max_age=40
+```
+
+## Collection mechanism
+
+CDP-based via `scripts/resume/collect_browser_source.py` with `--source 51job`. The collector:
+
+1. Navigates to the talent search URL
+2. Waits for `window.__TR_RESUME_DATA__` to report ready state (`sourceKey === "51job"`)
+3. Calls `api.collect()` which paginates through results and extracts resume data
+4. Returns JSON payload with metadata + resume array
+
+## Known issues
+
+### Login redirect
+If the collector raises "51job redirected to a login page", the session has expired or wasn't logged in. Log into `ehire.51job.com` in Chrome, navigate back to the talent search page, then rerun.
+
+### Slow page load
+51job search pages can be slow to render results. The collector waits up to 90 seconds for the page to report ready. If it times out with "Timed out waiting for the source page to finish loading results", ensure the page is fully loaded with visible candidate rows. The `domReady` flag must report `true` before the collector proceeds.
+
+### HMAC signing
+51job detail pages use per-request HMAC `sign` parameters computed by obfuscated frontend JS. The extension cannot replicate these signatures, so 51job detail enrichment goes through real browser tabs (slower than job5156 direct fetch). This doesn't affect the snapshot collection itself but means restored 51job samples may have less enriched detail than job5156 samples until the extension processes them.
+
+## Age filter
+
+The default URL includes `tr_min_age=25&tr_max_age=40`. Adjust these params to target different age ranges, or remove them for unfiltered results.

--- a/dev-docs/skills/refresh-sample-snapshots/references/job5156.md
+++ b/dev-docs/skills/refresh-sample-snapshots/references/job5156.md
@@ -1,0 +1,50 @@
+# job5156 (MY/CN Market)
+
+Source for Malaysia and China resumes via the Job5156 employer portal.
+
+## Prerequisites
+
+- Logged into `hr.job5156.com` in Chrome with an employer account
+- Must be on the `/search` page (the collector validates `pathname === "/search"`)
+- The browser extension must be loaded and active
+
+## Default URL
+
+```
+https://hr.job5156.com/search?keyword=CNC+%E9%94%80%E5%94%AE&tr_min_age=25&tr_max_age=40
+```
+
+## Collection mechanism
+
+CDP-based via `scripts/resume/collect_browser_source.py` with `--source job5156`. The collector:
+
+1. Navigates to the search URL
+2. Waits for `window.__TR_RESUME_DATA__` to report ready state (`sourceKey === "job5156"`, card count > 0 or autoSearch complete)
+3. Calls `api.collect()` which paginates and extracts resume data
+4. Returns JSON payload with metadata + resume array
+
+## URL parameters
+
+The search page supports these query params:
+
+| Param | Example | Description |
+|---|---|---|
+| `keyword` | `CNC+%E9%94%80%E5%94%AE` | Search keyword (URL-encoded) |
+| `location` | `广东` | Location filter |
+| `tr_min_age` | `25` | Minimum age (inclusive) |
+| `tr_max_age` | `40` | Maximum age (inclusive) |
+
+## Known issues
+
+### Stale extension state
+If `window.__TR_RESUME_DATA__` doesn't expose `collect()`, reload the browser extension. The collector checks for this and raises a clear error.
+
+### Source key mismatch
+If the page reports a `sourceKey` other than `job5156`, the collector fails. This usually means the wrong page is loaded — ensure you're on `hr.job5156.com/search`.
+
+## Compared to 51job
+
+job5156 collection is generally faster and more reliable than 51job:
+- No HMAC signing issues for detail enrichment
+- Direct API fetch for detail pages (no browser tab fallback needed)
+- Pages load faster and time out less often

--- a/dev-docs/skills/refresh-sample-snapshots/references/seek.md
+++ b/dev-docs/skills/refresh-sample-snapshots/references/seek.md
@@ -1,0 +1,78 @@
+# Seek (HK/MY Market)
+
+Source for Hong Kong and Malaysia resumes via the Seek employer portal. Unlike 51job and job5156, Seek has two distinct collection endpoints.
+
+## Prerequisites
+
+- Logged into the appropriate Seek employer portal in Chrome
+- Employer account selection must be complete (not stuck on `/account/select`)
+- The browser extension must be loaded and active
+
+---
+
+## Path A: Recommended Candidates (HK)
+
+jobId-based collection from an existing job posting's recommended candidates list.
+
+### Default URL
+
+```
+https://hk.employer.seek.com/candidates/recommended?jobId=92216704
+```
+
+### Collection mechanism
+
+Navigates to a specific job's recommended candidates page. The collector validates the page is on `/candidates/recommended` (not `/jobs` or `/account/select`). Results are tied to the job posting — changing the `jobId` changes which candidates appear.
+
+### Best for
+- Quick snapshots tied to a known job posting
+- Reproducible samples (same jobId = same candidate pool)
+
+### Known issues
+- If redirected to `/jobs` (jobs list), the collector reports "SEEK redirected to the jobs list instead of the recommended candidates page"
+- If redirected to `/account/select`, complete account selection first
+
+---
+
+## Path B: Talent Search (MY)
+
+Keyword-based collection that mirrors how recruiters actually search.
+
+### Default URL (not set in snapshot-source-backups.ts defaults — use `--seek-url` override)
+
+```
+https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE
+```
+
+### URL parameters
+
+| Param | Example | Description |
+|---|---|---|
+| `keywords` | `CNC+sales` | Search keywords |
+| `market` | `MY` | Market code |
+| `roleTitles` | `Sales+Manager` | Narrow by role title |
+
+### Collection command
+
+```bash
+bun run scripts/resume/snapshot-source-backups.ts \
+  --source seek --count 20 \
+  --seek-url "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE"
+```
+
+### Best for
+- Keyword-targeted samples that reflect actual recruiter search behavior
+- MY market specifically
+
+---
+
+## Path Selection
+
+| Criterion | Recommended | Talent Search |
+|---|---|---|
+| Market | HK | MY |
+| Input | jobId | keywords + market |
+| Reproducibility | High (fixed jobId) | Medium (search results change) |
+| Recruiter realism | Low (pre-filtered by job) | High (matches real search flow) |
+
+For a full refresh that covers both markets, run both paths with different `--seek-url` values. Note that both use alias `seek`, so the second run overwrites the first's snapshot file unless you rename or use separate directories.

--- a/scripts/browser_cdp.py
+++ b/scripts/browser_cdp.py
@@ -76,6 +76,32 @@ def create_target(endpoint: int | str | None, url: str):
     return None
 
 
+def normalize_target_match_url(value: str) -> str:
+    parsed = urllib.parse.urlparse(value)
+    return urllib.parse.urlunparse(parsed._replace(fragment=""))
+
+
+def select_cdp_target(pages: list[dict[str, Any]], search_url: str | None = None):
+    if search_url:
+        target_url = normalize_target_match_url(search_url)
+        for page in pages:
+            page_url = normalize_target_match_url(str(page.get("url") or ""))
+            if page_url == target_url:
+                return page
+
+        target_domain = urllib.parse.urlparse(search_url).netloc
+        for page in pages:
+            if target_domain in (page.get("url") or ""):
+                return page
+
+    for page in pages:
+        page_url = str(page.get("url") or "")
+        if "hr.job5156.com" in page_url or ".employer.seek.com" in page_url or "ehire.51job.com" in page_url:
+            return page
+
+    return pages[0] if pages else None
+
+
 def _describe_missing_accessor(search_url: str | None, current_url: str, current_title: str) -> str:
     context = []
     if search_url:
@@ -268,26 +294,10 @@ async def open_cdp_session(endpoint: int | str | None = None, search_url: str | 
         if target.get("type") == "page" and target.get("webSocketDebuggerUrl")
     ]
 
-    target = None
-    if search_url:
-        target_domain = urllib.parse.urlparse(search_url).netloc
-        for page in pages:
-            if target_domain in (page.get("url") or ""):
-                target = page
-                break
-
-    if not target:
-        for page in pages:
-            page_url = str(page.get("url") or "")
-            if "hr.job5156.com" in page_url or ".employer.seek.com" in page_url or "ehire.51job.com" in page_url:
-                target = page
-                break
+    target = select_cdp_target(pages, search_url)
 
     if not target and search_url:
         target = create_target(endpoint, search_url)
-
-    if not target and pages:
-        target = pages[0]
 
     if not target:
         raise CDPError("No debuggable Chrome pages found.")

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -365,23 +365,22 @@ if [ -d "packages/convex" ]; then
         EFFECTIVE_CONVEX_MIRROR_MODE="$(resolve_convex_mirror_mode)"
     fi
     echo "Prefetching Convex local backend and dashboard assets (mirror mode: ${EFFECTIVE_CONVEX_MIRROR_MODE})..."
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    "$SCRIPT_DIR/prefetch-convex-backend.sh" || echo "Warning: Convex prefetch failed (non-fatal)"
+    SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    "$SCRIPTS_DIR/prefetch-convex-backend.sh" || echo "Warning: Convex prefetch failed (non-fatal)"
 fi
 
-# Sync agent governance artifacts and local skill bootstrap
+# Skill bootstrap (non-CI only)
+#   1. Agent governance policy sync
+#   2. Project skills — rsync repo skills into .agents/skills + .claude/skills (repo-local only, never global)
+#   3. External global skills — install from config/skills/install.yaml global: section via npx skills add -g
 if ! is_ci_env; then
-    echo "Syncing agent governance artifacts and skill bootstrap..."
-    _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    run_tsx "$_SCRIPT_DIR/agent-governance/sync-policy.ts" || echo "Warning: Agent policy sync failed (non-fatal)"
-    if [ -x "$_SCRIPT_DIR/skills/sync-project-skills.sh" ]; then
-        "$_SCRIPT_DIR/skills/sync-project-skills.sh" || echo "Warning: Project skill sync failed (non-fatal)"
-    else
-        echo "Warning: Project skill sync script not found (non-fatal)"
-    fi
-    run_tsx "$_SCRIPT_DIR/skills/install-global-skills.ts" || echo "Warning: Global skill install failed (non-fatal)"
+	echo "Bootstrapping skills..."
+	SKILL_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	run_tsx "$SKILL_SCRIPT_DIR/agent-governance/sync-policy.ts" || echo "Warning: Agent policy sync failed (non-fatal)"
+	"$SKILL_SCRIPT_DIR/skills/sync-project-skills.sh" || echo "Warning: Project skill sync failed (non-fatal)"
+	run_tsx "$SKILL_SCRIPT_DIR/skills/install-global-skills.ts" || echo "Warning: Global skill install failed (non-fatal)"
 else
-    echo "Skipping agent governance sync and skill bootstrap in CI"
+	echo "Skipping skill bootstrap in CI"
 fi
 
 echo "Done!"

--- a/scripts/resume/collect_browser_source.py
+++ b/scripts/resume/collect_browser_source.py
@@ -30,7 +30,7 @@ DEFAULT_MAX_PAGES = 10
 SOURCE_URLS = {
     "job5156": "https://hr.job5156.com/search?keyword=CNC+%E9%94%80%E5%94%AE&tr_min_age=25&tr_max_age=40",
     "51job": "https://ehire.51job.com/Revision/talent/search?keyword=CNC+%E9%94%80%E5%94%AE&tr_min_age=25&tr_max_age=40",
-    "seek": "https://hk.employer.seek.com/candidates/recommended?jobId=90842915",
+    "seek": "https://hk.employer.seek.com/candidates/recommended?jobId=92216704",
 }
 
 SOURCE_HOSTS = {
@@ -38,6 +38,14 @@ SOURCE_HOSTS = {
     "51job": "ehire.51job.com",
     "seek": "hk.employer.seek.com",
 }
+
+
+def resolve_source_host(source: str, url: str) -> str:
+	if source == "seek":
+		hostname = (urlparse(url).hostname or "").lower()
+		if hostname:
+			return hostname
+	return SOURCE_HOSTS.get(source, "unknown")
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -85,7 +93,7 @@ def is_supported_source_page(source: str, page_url: str) -> bool:
         return hostname == "ehire.51job.com" and "/talent/search" in pathname
 
     if source == "seek":
-        return hostname.endswith(".employer.seek.com") and pathname == "/candidates/recommended"
+        return hostname.endswith(".employer.seek.com") and (pathname == "/candidates/recommended" or pathname == "/talentsearch")
 
     return False
 
@@ -112,8 +120,8 @@ def describe_unsupported_source_page(source: str, page_url: str, page_title: str
     if source == "seek" and hostname.endswith(".employer.seek.com") and pathname == "/jobs":
         detail = f" (title: {page_title})" if page_title else ""
         return (
-            "SEEK redirected to the jobs list instead of the recommended candidates page. "
-            "Open the Talent Search recommended candidates page in the same logged-in employer account, then rerun. "
+            "SEEK redirected to the jobs list instead of the candidates page. "
+            "Open the Talent Search or recommended candidates page in the same logged-in employer account, then rerun. "
             f"Requested page: {search_url}. Current page: {page_url}{detail}"
         )
 
@@ -245,7 +253,7 @@ async def run() -> int:
                 "mode": "check",
                 "endpoint": normalized_endpoint,
                 "source": args.source,
-                "sourceHost": SOURCE_HOSTS[args.source],
+                "sourceHost": resolve_source_host(args.source, search_url),
                 "url": search_url,
                 "status": status,
             }, ensure_ascii=False))
@@ -258,7 +266,7 @@ async def run() -> int:
             "mode": "collect",
             "endpoint": normalized_endpoint,
             "source": args.source,
-            "sourceHost": SOURCE_HOSTS[args.source],
+            "sourceHost": resolve_source_host(args.source, search_url),
             "url": search_url,
             "status": status,
             "payload": payload,

--- a/scripts/resume/snapshot-source-backups.test.ts
+++ b/scripts/resume/snapshot-source-backups.test.ts
@@ -207,6 +207,72 @@ describe("snapshot-source-backups", () => {
     expect(written.resumes[0]?.sourceHost).toBe(SOURCE_HOSTS.seek);
   });
 
+  it("uses the SEEK collector sourceHost override in the run summary and snapshot file", async () => {
+    const repoRoot = await createTestRepoRoot();
+    repoRoots.push(repoRoot);
+    const talentSearchUrl =
+      "https://my.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY";
+    const collectorSourceHost = "my.employer.seek.com";
+    const exec = vi.fn(async (_command: string, args: string[]) => {
+      if (args.includes("--check-only")) {
+        return {
+          stdout: JSON.stringify({
+            mode: "check",
+            source: "seek",
+            sourceHost: collectorSourceHost,
+            url: talentSearchUrl,
+            status: { sourceKey: "seek" },
+          }),
+          stderr: "",
+        };
+      }
+
+      return {
+        stdout: JSON.stringify({
+          mode: "collect",
+          source: "seek",
+          sourceHost: collectorSourceHost,
+          url: talentSearchUrl,
+          status: { sourceKey: "seek" },
+          payload: {
+            ...createCollectedPayload("seek", 20),
+            metadata: {
+              sourceUrl: talentSearchUrl,
+              generatedBy: "test-collector",
+            },
+          },
+        }),
+        stderr: "",
+      };
+    });
+
+    const result = await runSnapshotSourceBackups(
+      { ...baseOptions(repoRoot, "seek"), seekUrl: talentSearchUrl },
+      {
+        now: fixedNow,
+        exec,
+        log: () => undefined,
+        resolveUserHomeDirectory: async () => "/Users/tester",
+      },
+    );
+
+    const written = JSON.parse(
+      await readPortableBackupFile(buildExpectedFilePath(repoRoot, "seek")),
+    ) as {
+      metadata: Record<string, unknown>;
+      resumes: Array<Record<string, unknown>>;
+    };
+
+    expect(result.sources[0]).toMatchObject({
+      alias: "seek",
+      sourceHost: collectorSourceHost,
+      launchUrl: talentSearchUrl,
+    });
+    expect(written.metadata.sourceHost).toBe(collectorSourceHost);
+    expect(written.metadata.sourceUrl).toBe(talentSearchUrl);
+    expect(written.resumes[0]?.sourceHost).toBe(collectorSourceHost);
+  });
+
   it("adds the unsafe limit override to 200+ live 51job launches", async () => {
     const repoRoot = await createTestRepoRoot();
     repoRoots.push(repoRoot);

--- a/scripts/resume/snapshot-source-backups.ts
+++ b/scripts/resume/snapshot-source-backups.ts
@@ -28,7 +28,7 @@ const DEFAULT_JOB5156_URL =
 const DEFAULT_51JOB_URL =
   "https://ehire.51job.com/Revision/talent/search?keyword=CNC+%E9%94%80%E5%94%AE&tr_min_age=25&tr_max_age=40";
 const DEFAULT_SEEK_URL =
-  "https://hk.employer.seek.com/candidates/recommended?jobId=90842915";
+  "https://hk.employer.seek.com/candidates/recommended?jobId=92216704";
 
 // Default sources — these run when no --source flags are given.
 // 51job-manual is excluded; it must be requested explicitly.
@@ -454,12 +454,13 @@ function normalizeCollectedImportPayload(
   alias: BrowserSourceAlias,
   payload: ResumeBackupEnvelope | undefined,
   runtime: SnapshotRuntime,
+  sourceHostOverride?: string,
 ): ResumeImportPayload {
   if (!payload) {
     throw new Error(`[${alias}] collector did not return a payload`);
   }
 
-  const sourceHost = SOURCE_HOSTS[alias];
+  const sourceHost = sourceHostOverride || SOURCE_HOSTS[alias];
   const resumes = readResumeRecords(payload).map((resume) => ({
     ...resume,
     sourceHost,
@@ -665,7 +666,7 @@ export async function runSnapshotSourceBackups(
   const skipped: SnapshotSkippedSource[] = [];
 
   for (const alias of options.sources) {
-    const sourceHost = SOURCE_HOSTS[alias];
+    let sourceHost = SOURCE_HOSTS[alias];
     let launchUrl: string | undefined;
     let manualImportSummary: ManualImportSummary | undefined;
     let snapshotPayload: ResumeBackupEnvelope;
@@ -696,7 +697,12 @@ export async function runSnapshotSourceBackups(
         alias,
         collected.payload,
         runtime,
+        collected.sourceHost,
       );
+      const normalizedSourceHost = normalizedPayload.metadata.sourceHost;
+      if (typeof normalizedSourceHost === "string" && normalizedSourceHost.trim()) {
+        sourceHost = normalizedSourceHost;
+      }
       runtime.log(
         `[${alias}] collected ${normalizedPayload.resumes.length} resumes`,
       );

--- a/tests/test_browser_cdp.py
+++ b/tests/test_browser_cdp.py
@@ -1,0 +1,30 @@
+from scripts.browser_cdp import select_cdp_target
+
+
+def test_select_cdp_target_prefers_exact_search_url_over_same_domain():
+    search_url = (
+        "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales"
+        "&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY"
+        "&minSalary=0&salaryUnspecified=true&keywords=CNC"
+        "&matchAll=false&sortBy=RELEVANCE"
+    )
+    stripped_url = (
+        "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales"
+        "&market=MY&pageNumber=1&salaryType=MONTHLY"
+        "&minSalary=0&salaryUnspecified=true&sortBy=RELEVANCE"
+    )
+    pages = [
+        {"type": "page", "url": stripped_url, "id": "stripped"},
+        {"type": "page", "url": search_url, "id": "exact"},
+    ]
+
+    assert select_cdp_target(pages, search_url)["id"] == "exact"
+
+
+def test_select_cdp_target_falls_back_to_same_domain():
+    search_url = "https://hk.employer.seek.com/candidates/recommended?jobId=92216704"
+    pages = [
+        {"type": "page", "url": "https://hk.employer.seek.com/jobs", "id": "jobs"},
+    ]
+
+    assert select_cdp_target(pages, search_url)["id"] == "jobs"


### PR DESCRIPTION
## Summary

- Fix Seek recommended/talentsearch sample snapshot collection gaps
- Propagate collector-reported `sourceHost` to avoid hardcoded defaults (e.g. `my.employer.seek.com` vs `hk.employer.seek.com`)
- Add exact CDP target URL selection — exact match wins over same-domain stale tabs
- Add Seek recommended DOM card fallback extraction when GraphQL snapshots are absent
- Accept `/talentsearch` path as valid Seek collection source page
- Add lightweight DOM card counting for the hot polling path (avoids allocating full card objects every 300ms)
- Add `refresh-sample-snapshots` project skill with Seek recommended + talentsearch modes
- Update default Seek recommended jobId from `90842915` to `92216704`
- Includes regression tests for sourceHost propagation, CDP target selection, Seek recommended DOM extraction, and DOM card counting

## Test plan

- [x] `bun test scripts/resume/snapshot-source-backups.test.ts` — 9 tests pass
- [x] `bunx vitest run apps/browser-extension/src/lib/__tests__/extraction-pipeline.test.ts apps/browser-extension/src/lib/__tests__/seek-extractor.test.ts` — 61 tests pass
- [x] `uv run pytest tests/test_browser_cdp.py -q` — 2 tests pass
- [x] `python3 -m py_compile scripts/resume/collect_browser_source.py scripts/browser_cdp.py` — clean
- [x] `make check` — all checks pass