### PR TITLE
fix(samples): centralize collection guards, add shared config, fix push/pull auth

### DIFF
--- a/.agents/skills/refresh-sample-snapshots/SKILL.md
+++ b/.agents/skills/refresh-sample-snapshots/SKILL.md
@@ -118,13 +118,12 @@ Push the latest snapshot directory to the GitHub sample repo.
 2. Clones `ptdevhk/trends-resume-samples`, replaces snapshot files, regenerates README
 3. Commits and pushes to `main`
 
-### Auth gotcha
+### Auth
 
-The push script tries `git clone` first, then falls back to `gh repo clone`. If `gh` is authenticated as the wrong GitHub user, it fails with `HTTP 401`. Fix:
+The push script auto-detects `gh auth token` and uses authenticated HTTPS clone. Works for both public and private repos. Ensure `gh` is logged in:
 
 ```bash
-gh auth switch --user <correct-user>
-make push-sample-snapshots
+gh auth status
 ```
 
 ### Note

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -1742,12 +1742,6 @@
       JOB5156_PROFILE_URL_PREFIX: JOB5156_PROFILE_URL_PREFIX2,
       JOB5156_DETAIL_FETCH_TIMEOUT_MS: JOB5156_DETAIL_FETCH_TIMEOUT_MS2,
       JOB5156_DETAIL_FETCH_CONCURRENCY: JOB5156_DETAIL_FETCH_CONCURRENCY2,
-      DEFAULT_COLLECTION_GUARDS: DEFAULT_COLLECTION_GUARDS2,
-      GUARD_FIELD_NAMES: GUARD_FIELD_NAMES2,
-      GUARD_ARRAY_FIELD_NAMES: GUARD_ARRAY_FIELD_NAMES2,
-      loadCollectionGuards: loadCollectionGuards2,
-      parseGuardFieldNames: parseGuardFieldNames2,
-      applyCollectionGuards: applyCollectionGuards2,
       isMeaningfulJob5156WorkHistoryEntry: isMeaningfulJob5156WorkHistoryEntry2,
       collectJob5156SectionItemsByHeading: collectJob5156SectionItemsByHeading2
     } = deps;
@@ -2417,8 +2411,6 @@
     async function enrichJob5156SearchResumesWithDetail2(resumes) {
       if (!Array.isArray(resumes) || resumes.length === 0) return [];
       const extractedAt = (/* @__PURE__ */ new Date()).toISOString();
-      const collectionGuards = await loadCollectionGuards2();
-      const guardFields = parseGuardFieldNames2(collectionGuards?.job5156);
       const enriched = [];
       for (let start = 0; start < resumes.length; start += JOB5156_DETAIL_FETCH_CONCURRENCY2) {
         const batch = resumes.slice(
@@ -2431,7 +2423,7 @@
           )
         );
         enriched.push(
-          ...batchResults.filter(Boolean).map((resume) => applyCollectionGuards2(resume, guardFields))
+          ...batchResults.filter(Boolean)
         );
       }
       return enriched;
@@ -3259,13 +3251,29 @@
       getPaginationInfo: getPaginationInfo2,
       asHTMLElement: asHTMLElement2
     } = deps;
-    const GUARD_ARRAY_FIELD_NAMES2 = /* @__PURE__ */ new Set([
+    const GUARD_ARRAY_FIELD_NAMES3 = /* @__PURE__ */ new Set([
       "workHistory",
       "profileEducation",
       "projectExperience",
       "skills",
       "licences"
     ]);
+    function getDefaultGuardFields(sourceKey) {
+      const guards = DEFAULT_COLLECTION_GUARDS2?.[sourceKey];
+      return parseGuardFieldNames2(
+        typeof guards === "string" ? guards : ""
+      );
+    }
+    __name(getDefaultGuardFields, "getDefaultGuardFields");
+    function applyDefaultGuards(resumes, sourceKey) {
+      if (sourceKey !== SOURCE_KEYS2.JOB51 && sourceKey !== SOURCE_KEYS2.JOB5156 && sourceKey !== SOURCE_KEYS2.SEEK) {
+        return resumes;
+      }
+      const guardFields = getDefaultGuardFields(sourceKey);
+      if (guardFields.length === 0) return resumes;
+      return resumes.map((r) => applyCollectionGuards2(r, guardFields));
+    }
+    __name(applyDefaultGuards, "applyDefaultGuards");
     async function loadCollectionGuards2() {
       return new Promise((resolve) => {
         chrome2.storage.local.get(
@@ -3279,7 +3287,7 @@
       if (!csv || typeof csv !== "string") return [];
       return Array.from(
         new Set(
-          csv.split(",").map((field) => field.trim()).filter((field) => GUARD_ARRAY_FIELD_NAMES2.has(field))
+          csv.split(",").map((field) => field.trim()).filter((field) => GUARD_ARRAY_FIELD_NAMES3.has(field))
         )
       );
     }
@@ -3290,7 +3298,7 @@
       }
       const guarded = { ...resume };
       for (const field of guardFieldNames) {
-        guarded[field] = GUARD_ARRAY_FIELD_NAMES2.has(field) ? [] : "";
+        guarded[field] = GUARD_ARRAY_FIELD_NAMES3.has(field) ? [] : "";
       }
       return guarded;
     }
@@ -3437,48 +3445,43 @@
     }
     __name(isElementVisible2, "isElementVisible");
     function extractResumes2() {
+      const sourceKey = getCurrentSourceKey2();
+      let resumes = [];
       if (isJob51DetailPage2()) {
-        return filterCurrentResumesByAgeRange2(extractJob51DetailResume2());
-      }
-      if (getCurrentSourceKey2() === SOURCE_KEYS2.JOB51) {
-        return filterCurrentResumesByAgeRange2(extract51JobResumes2());
-      }
-      if (getCurrentSourceKey2() === SOURCE_KEYS2.SEEK) {
+        resumes = filterCurrentResumesByAgeRange2(extractJob51DetailResume2());
+      } else if (sourceKey === SOURCE_KEYS2.JOB51) {
+        resumes = filterCurrentResumesByAgeRange2(extract51JobResumes2());
+      } else if (sourceKey === SOURCE_KEYS2.SEEK) {
         if (isSeekProfileMode2()) {
           if (hasSeekProfileSnapshot2()) {
-            return extractSeekProfileResume2();
+            resumes = extractSeekProfileResume2();
           }
-          return [];
+        } else if (hasSeekTalentSearchSnapshot2()) {
+          resumes = extractSeekTalentSearchResumes2();
+        } else {
+          resumes = extractSeekResumes2();
         }
-        if (hasSeekTalentSearchSnapshot2()) {
-          return extractSeekTalentSearchResumes2();
-        }
-        if (hasSeekListSnapshot2()) {
-          return extractSeekResumes2();
-        }
-        const fallbackResumes = extractSeekResumes2();
-        return fallbackResumes.length > 0 ? fallbackResumes : [];
-      }
-      if (isJob5156DetailPage2()) {
-        return filterCurrentResumesByAgeRange2(extractJob5156DetailResume2());
-      }
-      const cards = doc.querySelectorAll(SELECTORS2.resumeCard);
-      const resumes = [];
-      cards.forEach((card, index) => {
-        try {
-          const apiRow = getApiRowForIndex2(index);
-          const resume = extractSingleResume2(card, apiRow);
-          resume.pageIndex = index + 1;
-          if (apiRow) {
-            resume.resumeId = apiRow.resumeId ?? "";
-            resume.perUserId = apiRow.perUserId ?? "";
+      } else if (isJob5156DetailPage2()) {
+        resumes = filterCurrentResumesByAgeRange2(extractJob5156DetailResume2());
+      } else {
+        const cards = doc.querySelectorAll(SELECTORS2.resumeCard);
+        cards.forEach((card, index) => {
+          try {
+            const apiRow = getApiRowForIndex2(index);
+            const resume = extractSingleResume2(card, apiRow);
+            resume.pageIndex = index + 1;
+            if (apiRow) {
+              resume.resumeId = apiRow.resumeId ?? "";
+              resume.perUserId = apiRow.perUserId ?? "";
+            }
+            resumes.push(resume);
+          } catch (error) {
+            console.error(`Error extracting resume ${index}:`, error);
           }
-          resumes.push(resume);
-        } catch (error) {
-          console.error(`Error extracting resume ${index}:`, error);
-        }
-      });
-      return filterCurrentResumesByAgeRange2(resumes);
+        });
+        resumes = filterCurrentResumesByAgeRange2(resumes);
+      }
+      return applyDefaultGuards(resumes, sourceKey);
     }
     __name(extractResumes2, "extractResumes");
     function extractResumesRaw2(options = {}) {
@@ -3630,10 +3633,6 @@
       if (!Array.isArray(resumes) || resumes.length === 0) return [];
       const extractedAt = (/* @__PURE__ */ new Date()).toISOString();
       const interBatchDelayMs = typeof options.interBatchDelayMs === "number" && Number.isFinite(options.interBatchDelayMs) ? options.interBatchDelayMs : resolveCurrentJob51DetailFetchDelayMs2();
-      const collectionGuards = await loadCollectionGuards2();
-      const guardFields = parseGuardFieldNames2(
-        collectionGuards?.[SOURCE_KEYS2.JOB51]
-      );
       const shouldContinue = typeof options.shouldContinue === "function" ? options.shouldContinue : () => true;
       const enriched = [];
       let enrichedCount = 0;
@@ -3653,7 +3652,7 @@
         );
         for (const result of batchResults) {
           if (result?.resume) {
-            enriched.push(applyCollectionGuards2(result.resume, guardFields));
+            enriched.push(result.resume);
           }
           if (result?.enriched) {
             enrichedCount += 1;
@@ -7384,12 +7383,6 @@
     JOB5156_PROFILE_URL_PREFIX,
     JOB5156_DETAIL_FETCH_TIMEOUT_MS,
     JOB5156_DETAIL_FETCH_CONCURRENCY,
-    DEFAULT_COLLECTION_GUARDS,
-    GUARD_FIELD_NAMES,
-    GUARD_ARRAY_FIELD_NAMES,
-    loadCollectionGuards,
-    parseGuardFieldNames,
-    applyCollectionGuards,
     isMeaningfulJob5156WorkHistoryEntry,
     collectJob5156SectionItemsByHeading
   });

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -457,12 +457,6 @@ const _job5156Extractor = createJob5156Extractor({
   JOB5156_PROFILE_URL_PREFIX,
   JOB5156_DETAIL_FETCH_TIMEOUT_MS,
   JOB5156_DETAIL_FETCH_CONCURRENCY,
-  DEFAULT_COLLECTION_GUARDS,
-  GUARD_FIELD_NAMES: GUARD_FIELD_NAMES as unknown as string[],
-  GUARD_ARRAY_FIELD_NAMES: GUARD_ARRAY_FIELD_NAMES as unknown as string[],
-  loadCollectionGuards,
-  parseGuardFieldNames: parseGuardFieldNames as (guards: unknown) => string[],
-  applyCollectionGuards,
   isMeaningfulJob5156WorkHistoryEntry,
   collectJob5156SectionItemsByHeading,
 });

--- a/apps/browser-extension/src/lib/extraction-pipeline.ts
+++ b/apps/browser-extension/src/lib/extraction-pipeline.ts
@@ -112,6 +112,25 @@ export function createExtractionPipeline(deps: ExtractionPipelineDeps) {
     "licences",
   ]);
 
+  function getDefaultGuardFields(sourceKey: string): string[] {
+    const guards =
+      (DEFAULT_COLLECTION_GUARDS as Record<string, unknown>)?.[sourceKey];
+    return parseGuardFieldNames(
+      typeof guards === "string" ? guards : "",
+    );
+  }
+
+  function applyDefaultGuards(resumes: unknown[], sourceKey: string): unknown[] {
+    if (sourceKey !== SOURCE_KEYS.JOB51 &&
+        sourceKey !== SOURCE_KEYS.JOB5156 &&
+        sourceKey !== SOURCE_KEYS.SEEK) {
+      return resumes;
+    }
+    const guardFields = getDefaultGuardFields(sourceKey);
+    if (guardFields.length === 0) return resumes;
+    return resumes.map((r) => applyCollectionGuards(r, guardFields));
+  }
+
   async function loadCollectionGuards() {
     return new Promise((resolve) => {
       chrome.storage.local.get(
@@ -338,52 +357,45 @@ export function createExtractionPipeline(deps: ExtractionPipelineDeps) {
   // --- Resume extraction orchestration ---
 
   function extractResumes() {
+    const sourceKey = getCurrentSourceKey();
+    let resumes: unknown[] = [];
+
     if (isJob51DetailPage()) {
-      return filterCurrentResumesByAgeRange(extractJob51DetailResume());
-    }
-    if (getCurrentSourceKey() === SOURCE_KEYS.JOB51) {
-      return filterCurrentResumesByAgeRange(extract51JobResumes());
-    }
-    if (getCurrentSourceKey() === SOURCE_KEYS.SEEK) {
+      resumes = filterCurrentResumesByAgeRange(extractJob51DetailResume());
+    } else if (sourceKey === SOURCE_KEYS.JOB51) {
+      resumes = filterCurrentResumesByAgeRange(extract51JobResumes());
+    } else if (sourceKey === SOURCE_KEYS.SEEK) {
       if (isSeekProfileMode()) {
         if (hasSeekProfileSnapshot()) {
-          return extractSeekProfileResume();
+          resumes = extractSeekProfileResume();
         }
-        return [];
+      } else if (hasSeekTalentSearchSnapshot()) {
+        resumes = extractSeekTalentSearchResumes();
+      } else {
+        resumes = extractSeekResumes();
       }
-      if (hasSeekTalentSearchSnapshot()) {
-        return extractSeekTalentSearchResumes();
-      }
-      if (hasSeekListSnapshot()) {
-        return extractSeekResumes();
-      }
-      const fallbackResumes = extractSeekResumes();
-      return fallbackResumes.length > 0 ? fallbackResumes : [];
+    } else if (isJob5156DetailPage()) {
+      resumes = filterCurrentResumesByAgeRange(extractJob5156DetailResume());
+    } else {
+      const cards = doc.querySelectorAll(SELECTORS.resumeCard);
+      cards.forEach((card, index) => {
+        try {
+          const apiRow = getApiRowForIndex(index) as Record<string, unknown> | null;
+          const resume = extractSingleResume(card, apiRow);
+          resume.pageIndex = index + 1;
+          if (apiRow) {
+            resume.resumeId = apiRow.resumeId ?? "";
+            resume.perUserId = apiRow.perUserId ?? "";
+          }
+          resumes.push(resume);
+        } catch (error) {
+          console.error(`Error extracting resume ${index}:`, error);
+        }
+      });
+      resumes = filterCurrentResumesByAgeRange(resumes);
     }
 
-    if (isJob5156DetailPage()) {
-      return filterCurrentResumesByAgeRange(extractJob5156DetailResume());
-    }
-
-    const cards = doc.querySelectorAll(SELECTORS.resumeCard);
-    const resumes = [];
-
-    cards.forEach((card, index) => {
-      try {
-        const apiRow = getApiRowForIndex(index) as Record<string, unknown> | null;
-        const resume = extractSingleResume(card, apiRow);
-        resume.pageIndex = index + 1;
-        if (apiRow) {
-          resume.resumeId = apiRow.resumeId ?? "";
-          resume.perUserId = apiRow.perUserId ?? "";
-        }
-        resumes.push(resume);
-      } catch (error) {
-        console.error(`Error extracting resume ${index}:`, error);
-      }
-    });
-
-    return filterCurrentResumesByAgeRange(resumes);
+    return applyDefaultGuards(resumes, sourceKey) as unknown[];
   }
 
   /**
@@ -600,10 +612,6 @@ export function createExtractionPipeline(deps: ExtractionPipelineDeps) {
       Number.isFinite(options.interBatchDelayMs)
         ? options.interBatchDelayMs
         : resolveCurrentJob51DetailFetchDelayMs();
-    const collectionGuards = await loadCollectionGuards();
-    const guardFields = parseGuardFieldNames(
-      collectionGuards?.[SOURCE_KEYS.JOB51],
-    );
     const shouldContinue =
       typeof options.shouldContinue === "function"
         ? options.shouldContinue
@@ -634,7 +642,7 @@ export function createExtractionPipeline(deps: ExtractionPipelineDeps) {
 
       for (const result of batchResults) {
         if (result?.resume) {
-          enriched.push(applyCollectionGuards(result.resume, guardFields));
+          enriched.push(result.resume);
         }
         if (result?.enriched) {
           enrichedCount += 1;

--- a/apps/browser-extension/src/lib/job5156-extractor.ts
+++ b/apps/browser-extension/src/lib/job5156-extractor.ts
@@ -15,12 +15,6 @@ export interface Job5156ExtractorDeps extends Record<string, unknown> {
   JOB5156_PROFILE_URL_PREFIX: string;
   JOB5156_DETAIL_FETCH_TIMEOUT_MS: number;
   JOB5156_DETAIL_FETCH_CONCURRENCY: number;
-  DEFAULT_COLLECTION_GUARDS: unknown;
-  GUARD_FIELD_NAMES: string[];
-  GUARD_ARRAY_FIELD_NAMES: string[];
-  loadCollectionGuards: () => Promise<unknown>;
-  parseGuardFieldNames: (guards: unknown) => string[];
-  applyCollectionGuards: (resume: unknown, fields: string[]) => unknown;
   isMeaningfulJob5156WorkHistoryEntry: (entry: unknown) => boolean;
   collectJob5156SectionItemsByHeading: (
     root: unknown,
@@ -43,12 +37,6 @@ export function createJob5156Extractor(deps: Job5156ExtractorDeps) {
     JOB5156_PROFILE_URL_PREFIX,
     JOB5156_DETAIL_FETCH_TIMEOUT_MS,
     JOB5156_DETAIL_FETCH_CONCURRENCY,
-    DEFAULT_COLLECTION_GUARDS,
-    GUARD_FIELD_NAMES,
-    GUARD_ARRAY_FIELD_NAMES,
-    loadCollectionGuards,
-    parseGuardFieldNames,
-    applyCollectionGuards,
     isMeaningfulJob5156WorkHistoryEntry,
     collectJob5156SectionItemsByHeading,
   } = deps;
@@ -869,8 +857,6 @@ export function createJob5156Extractor(deps: Job5156ExtractorDeps) {
     if (!Array.isArray(resumes) || resumes.length === 0) return [];
 
     const extractedAt = new Date().toISOString();
-    const collectionGuards = await loadCollectionGuards();
-    const guardFields = parseGuardFieldNames((collectionGuards as Record<string, unknown>)?.job5156);
     const enriched = [];
 
     for (
@@ -889,9 +875,7 @@ export function createJob5156Extractor(deps: Job5156ExtractorDeps) {
       );
 
       enriched.push(
-        ...batchResults
-          .filter(Boolean)
-          .map((resume) => applyCollectionGuards(resume, guardFields)),
+        ...batchResults.filter(Boolean),
       );
     }
 

--- a/apps/browser-extension/src/lib/seek-extractor.ts
+++ b/apps/browser-extension/src/lib/seek-extractor.ts
@@ -3,6 +3,7 @@
  * URL building, and auto-sync helpers. All dependencies injected from content.ts.
  */
 
+
 export interface SeekExtractorDeps extends Record<string, unknown> {
   getCurrentSourceKey: () => string;
   SOURCE_KEYS: Record<string, string>;

--- a/dev-docs/skills/refresh-sample-snapshots/SKILL.md
+++ b/dev-docs/skills/refresh-sample-snapshots/SKILL.md
@@ -118,13 +118,12 @@ Push the latest snapshot directory to the GitHub sample repo.
 2. Clones `ptdevhk/trends-resume-samples`, replaces snapshot files, regenerates README
 3. Commits and pushes to `main`
 
-### Auth gotcha
+### Auth
 
-The push script tries `git clone` first, then falls back to `gh repo clone`. If `gh` is authenticated as the wrong GitHub user, it fails with `HTTP 401`. Fix:
+The push script auto-detects `gh auth token` and uses authenticated HTTPS clone. Works for both public and private repos. Ensure `gh` is logged in:
 
 ```bash
-gh auth switch --user <correct-user>
-make push-sample-snapshots
+gh auth status
 ```
 
 ### Note

--- a/packages/shared/src/collection-guards.ts
+++ b/packages/shared/src/collection-guards.ts
@@ -1,0 +1,27 @@
+/**
+ * Canonical collection guard configuration — shared across the browser
+ * extension, snapshot backup pipeline, and any future collection entry points.
+ *
+ * Each source key maps to a list of field names that should be blanked
+ * (set to "") during collection. This is a data-minimization measure:
+ * fields like jobIntention and selfIntro may contain PII or sensitive
+ * free-text that shouldn't be persisted in sample snapshots.
+ */
+
+export const COLLECTION_GUARDS: Record<string, string[]> = {
+  job5156: ["experience", "jobIntention", "selfIntro"],
+  "51job": ["experience", "jobIntention", "selfIntro"],
+  seek: ["experience", "jobIntention", "selfIntro"],
+};
+
+export function applyCollectionGuards(
+  resume: Record<string, unknown>,
+  guardFields: string[],
+): Record<string, unknown> {
+  if (!guardFields.length) return resume;
+  const guarded = { ...resume };
+  for (const field of guardFields) {
+    guarded[field] = "";
+  }
+  return guarded;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,6 +15,7 @@ export * from "./salary.js";
 export * from "./market.js";
 export * from "./resume-filter-helpers.js";
 export * from "./generated/search-profile-templates.js";
+export * from "./collection-guards.js";
 export * from "./export-fields-config.js";
 export * from "./scoring/related-exp-evaluator.js";
 export * from "./scoring/resume-score-semantics.js";

--- a/scripts/resume/pull-sample-snapshots.ts
+++ b/scripts/resume/pull-sample-snapshots.ts
@@ -25,6 +25,31 @@ function resolveOutDir(): string {
   return path.isAbsolute(resolved) ? resolved : path.resolve(resolveRepoRoot(), resolved);
 }
 
+async function getGhToken(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("gh", ["auth", "token"]);
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function cloneSampleRepo(sampleRepo: string, tempDir: string): Promise<void> {
+  const token = await getGhToken();
+  const cloneUrl = token
+    ? `https://oauth2:${token}@github.com/${sampleRepo}.git`
+    : `https://github.com/${sampleRepo}.git`;
+
+  try {
+    await execFileAsync("git", ["clone", "--depth=1", cloneUrl, tempDir]);
+  } catch (e) {
+    if (token) {
+      throw Object.assign(new Error(`git clone failed for ${sampleRepo} — check gh auth status`), { cause: e });
+    }
+    throw e;
+  }
+}
+
 async function main(): Promise<void> {
   const repoRoot = resolveRepoRoot();
   const sampleRepo = resolveSampleRepo();
@@ -36,14 +61,7 @@ async function main(): Promise<void> {
   const tempDir = await mkdtemp("trends-pull-samples-");
   try {
     console.log(`Cloning ${sampleRepo}...`);
-    try {
-      await execFileAsync("git", ["clone", "--depth=1", `https://github.com/${sampleRepo}.git`, tempDir]);
-    } catch {
-      // Private repos require auth; fall back to `gh repo clone` which uses
-      // the GitHub CLI credential store (SSH key, token, etc.)
-      console.log("git clone failed — trying gh repo clone for authenticated access...");
-      await execFileAsync("gh", ["repo", "clone", sampleRepo, tempDir, "--", "--depth=1"]);
-    }
+    await cloneSampleRepo(sampleRepo, tempDir);
 
     const snapshotsDir = path.join(tempDir, "snapshots");
     const files = await readdir(snapshotsDir).catch(() => [] as string[]);

--- a/scripts/resume/push-sample-snapshots.ts
+++ b/scripts/resume/push-sample-snapshots.ts
@@ -56,6 +56,31 @@ async function execGit(args: string[], cwd: string): Promise<string> {
   return stdout.trim();
 }
 
+async function getGhToken(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("gh", ["auth", "token"]);
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function cloneSampleRepo(sampleRepo: string, tempDir: string): Promise<void> {
+  const token = await getGhToken();
+  const cloneUrl = token
+    ? `https://oauth2:${token}@github.com/${sampleRepo}.git`
+    : `https://github.com/${sampleRepo}.git`;
+
+  try {
+    await execFileAsync("git", ["clone", "--depth=1", cloneUrl, tempDir]);
+  } catch (e) {
+    if (token) {
+      throw Object.assign(new Error(`git clone failed for ${sampleRepo} — check gh auth status`), { cause: e });
+    }
+    throw e;
+  }
+}
+
 interface SnapshotFile {
   name: string;
   resumeCount: number;
@@ -138,12 +163,7 @@ async function main(): Promise<void> {
   const tempDir = await mkdtemp("trends-push-samples-");
   try {
     console.log(`Cloning ${sampleRepo}...`);
-    try {
-      await execFileAsync("git", ["clone", "--depth=1", `https://github.com/${sampleRepo}.git`, tempDir]);
-    } catch {
-      console.log("git clone failed — trying gh repo clone for authenticated access...");
-      await execFileAsync("gh", ["repo", "clone", sampleRepo, tempDir, "--", "--depth=1"]);
-    }
+    await cloneSampleRepo(sampleRepo, tempDir);
 
     const snapshotsDir = path.join(tempDir, "snapshots");
     await mkdir(snapshotsDir, { recursive: true });

--- a/scripts/resume/snapshot-source-backups.test.ts
+++ b/scripts/resume/snapshot-source-backups.test.ts
@@ -273,6 +273,71 @@ describe("snapshot-source-backups", () => {
     expect(written.resumes[0]?.sourceHost).toBe(collectorSourceHost);
   });
 
+  it("strips collection guard fields from snapshot backup output", async () => {
+    const repoRoot = await createTestRepoRoot();
+    repoRoots.push(repoRoot);
+    const exec = vi.fn(async (_command: string, args: string[]) => {
+      if (args.includes("--check-only")) {
+        return {
+          stdout: JSON.stringify({
+            mode: "check",
+            source: "seek",
+            sourceHost: "hk.employer.seek.com",
+            url: "https://hk.employer.seek.com/candidates/recommended?jobId=92216704",
+            status: { sourceKey: "seek" },
+          }),
+          stderr: "",
+        };
+      }
+      return {
+        stdout: JSON.stringify({
+          mode: "collect",
+          source: "seek",
+          sourceHost: "hk.employer.seek.com",
+          url: "https://hk.employer.seek.com/candidates/recommended?jobId=92216704",
+          status: { sourceKey: "seek" },
+          payload: {
+            metadata: {
+              sourceUrl: "https://hk.employer.seek.com/candidates/recommended?jobId=92216704",
+              generatedBy: "test-collector",
+            },
+            resumes: [
+              {
+                name: "Test Candidate",
+                profileId: "test-1",
+                jobIntention: "Sales Manager",
+                experience: "5 years CNC sales",
+                selfIntro: "Experienced professional",
+                workHistory: [{ raw: "Sales at Acme" }],
+              },
+            ],
+          },
+        }),
+        stderr: "",
+      };
+    });
+
+    const result = await runSnapshotSourceBackups(
+      { ...baseOptions(repoRoot, "seek"), count: 1 },
+      {
+        now: fixedNow,
+        exec,
+        log: () => undefined,
+        resolveUserHomeDirectory: async () => "/Users/tester",
+      },
+    );
+
+    const written = JSON.parse(
+      await readPortableBackupFile(buildExpectedFilePath(repoRoot, "seek", 1)),
+    ) as { resumes: Array<Record<string, unknown>> };
+
+    expect(result.sources[0].count).toBe(1);
+    expect(written.resumes[0].jobIntention).toBe("");
+    expect(written.resumes[0].experience).toBe("");
+    expect(written.resumes[0].selfIntro).toBe("");
+    expect(written.resumes[0].name).toBe("Test Candidate");
+  });
+
   it("adds the unsafe limit override to 200+ live 51job launches", async () => {
     const repoRoot = await createTestRepoRoot();
     repoRoots.push(repoRoot);

--- a/scripts/resume/snapshot-source-backups.ts
+++ b/scripts/resume/snapshot-source-backups.ts
@@ -3,6 +3,8 @@ import { constants } from "node:fs";
 import { access, mkdir, readFile, unlink } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+
+import { COLLECTION_GUARDS, applyCollectionGuards } from "@trends/shared";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
@@ -49,6 +51,7 @@ const SOURCE_HOSTS: Record<OptionalSourceAlias, string> = {
   "51job": "ehire.51job.com",
   [MANUAL_SOURCE]: MANUAL_SOURCE,
 };
+
 
 type SnapshotCliArgs = {
   apiUrl: string;
@@ -461,13 +464,19 @@ function normalizeCollectedImportPayload(
   }
 
   const sourceHost = sourceHostOverride || SOURCE_HOSTS[alias];
-  const resumes = readResumeRecords(payload).map((resume) => ({
-    ...resume,
-    sourceHost,
-    ...(Array.isArray(resume.workHistory) && resume.workHistory.length > 0
-      ? { workHistory: selectLatestWorkHistory(resume.workHistory) }
-      : {}),
-  }));
+  const guardFields = COLLECTION_GUARDS[alias] || [];
+  const resumes = readResumeRecords(payload).map((resume) =>
+    applyCollectionGuards(
+      {
+        ...resume,
+        sourceHost,
+        ...(Array.isArray(resume.workHistory) && resume.workHistory.length > 0
+          ? { workHistory: selectLatestWorkHistory(resume.workHistory) }
+          : {}),
+      },
+      guardFields,
+    ),
+  );
   if (resumes.length === 0) {
     throw new Error(`[${alias}] collector returned zero resumes`);
   }


### PR DESCRIPTION
## Summary

- Centralize guard application in `extraction-pipeline.ts` `extractResumes()` -- all paths (CDP collect, direct extract, auto-sync) now get guards applied
- Remove duplicate guard logic from `job5156-extractor.ts`, `extraction-pipeline.ts` (51job), and `seek-extractor.ts` enrichment functions
- Add canonical `COLLECTION_GUARDS` to `packages/shared/src/collection-guards.ts`
- Add defense-in-depth guard stripping in `snapshot-source-backups.ts`
- Fix push/pull sample scripts to use `gh auth token` for authenticated HTTPS clone (works for both public and private repos)
- Update `refresh-sample-snapshots` SKILL.md auth section

## Test plan

- [x] `bunx vitest` -- 141 extension tests (5 files)
- [x] `bun test scripts/resume/snapshot-source-backups.test.ts` -- 10 tests
- [x] `uv run pytest tests/test_browser_cdp.py -q` -- 2 tests
- [x] `make check` -- all pass