### PR TITLE
Fix sample-top20 CN audit parity and snapshot workflow

### DIFF
--- a/.agents/skills/refresh-sample-snapshots/SKILL.md
+++ b/.agents/skills/refresh-sample-snapshots/SKILL.md
@@ -50,14 +50,20 @@ Collect fresh resume samples from browser sources via CDP.
 ### Single source
 
 ```bash
-bun run scripts/resume/snapshot-source-backups.ts --source 51job --count 20
+bun run scripts/resume/snapshot-source-backups.ts --source 51job --count 50
+```
+
+Seek keeps a separate 20-resume ceiling by default, so the same script can still collect the smaller browser-backed samples:
+
+```bash
+bun run scripts/resume/snapshot-source-backups.ts --source seek --seek-count 20
 ```
 
 ### Multiple sources in one run
 
 ```bash
 bun run scripts/resume/snapshot-source-backups.ts \
-  --source 51job --source job5156 --source seek --count 20
+  --source 51job --source job5156 --source seek --count 50
 ```
 
 ### Custom URL override
@@ -67,12 +73,12 @@ Override the default search URL for a source:
 ```bash
 # Seek talent search (MY market) — uses keyword-based collection
 bun run scripts/resume/snapshot-source-backups.ts \
-  --source seek --count 20 \
+  --source seek --seek-count 20 \
   --seek-url "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE"
 
 # Custom 51job keyword/location
 bun run scripts/resume/snapshot-source-backups.ts \
-  --source 51job --count 20 \
+  --source 51job --count 50 \
   --51job-url "https://ehire.51job.com/Revision/talent/search?keyword=工程师&tr_min_age=25&tr_max_age=40"
 ```
 
@@ -81,7 +87,8 @@ bun run scripts/resume/snapshot-source-backups.ts \
 | Option | Default | Description |
 |---|---|---|
 | `--source <alias>` | (required) | Source alias: `51job`, `job5156`, `seek` (repeatable) |
-| `--count <n>` | `20` | Resumes to collect per source |
+| `--count <n>` | `50` | Resumes to collect per source |
+| `--seek-count <n>` | `20` | Seek resumes to collect per source |
 | `--max-pages <n>` | `10` | Max pages to paginate through |
 | `--cdp-endpoint <url>` | `http://127.0.0.1:9222` | Chrome DevTools endpoint |
 | `--<source>-url <url>` | Per-source default | Override the search URL for a source |
@@ -92,8 +99,8 @@ bun run scripts/resume/snapshot-source-backups.ts \
 Creates a timestamped directory:
 ```
 output/resume-backups/20260602-190034/
-├── resume-backup-51job-top20-20260602-190034.json
-├── resume-backup-job5156-top20-20260602-190034.json
+├── resume-backup-51job-top50-20260602-190034.json
+├── resume-backup-job5156-top50-20260602-190034.json
 └── resume-backup-seek-top20-20260602-190034.json
 ```
 
@@ -178,7 +185,7 @@ Each `snapshot-source-backups.ts` invocation creates a new timestamped directory
 
 ```bash
 bun run scripts/resume/snapshot-source-backups.ts \
-  --source 51job --source job5156 --source seek --count 20
+  --source 51job --source job5156 --source seek --count 50
 ```
 
 This creates `output/resume-backups/<timestamp-1>/` with 51job, job5156, and seek-recommended snapshots.
@@ -187,11 +194,11 @@ This creates `output/resume-backups/<timestamp-1>/` with 51job, job5156, and see
 
 ```bash
 bun run scripts/resume/snapshot-source-backups.ts \
-  --source seek --count 20 \
+  --source seek --seek-count 20 \
   --seek-url "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE"
 ```
 
-This creates `output/resume-backups/<timestamp-2>/` with the seek-talentsearch snapshot. Note that this file is also named `resume-backup-seek-top20-<timestamp>.json` (same alias), so it must be renamed before merging to avoid overwriting the seek-recommended file.
+This creates `output/resume-backups/<timestamp-2>/` with the seek-talentsearch snapshot. The file stays on the 20-resume ceiling (`resume-backup-seek-top20-<timestamp>.json`), so it can be merged without renaming conflicts.
 
 ### Step 3: Merge and push
 
@@ -211,8 +218,8 @@ Check that all 4 files are present before pushing:
 ```bash
 ls output/resume-backups/<timestamp-1>/
 # Expected:
-#   resume-backup-51job-top20-<ts>.json
-#   resume-backup-job5156-top20-<ts>.json
+#   resume-backup-51job-top50-<ts>.json
+#   resume-backup-job5156-top50-<ts>.json
 #   resume-backup-seek-top20-<ts>.json          (recommended)
 #   resume-backup-seek-talentsearch-top20.json  (talent search)
 ```

--- a/.agents/skills/refresh-sample-snapshots/references/seek.md
+++ b/.agents/skills/refresh-sample-snapshots/references/seek.md
@@ -56,7 +56,7 @@ https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNu
 
 ```bash
 bun run scripts/resume/snapshot-source-backups.ts \
-  --source seek --count 20 \
+  --source seek --seek-count 20 \
   --seek-url "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE"
 ```
 

--- a/.agents/skills/trends-cli/SKILL.md
+++ b/.agents/skills/trends-cli/SKILL.md
@@ -31,7 +31,7 @@ Use this skill when the user asks to operate backend services from terminal comm
 
 - `./bin/trends resume list --limit 50`
 - `./bin/trends resume search "CNC 东莞" --limit 50`
-- `./bin/trends resume snapshot --source job5156 --count 20`
+- `./bin/trends resume snapshot --source job5156 --count 50`
 - `./bin/trends resume import-51job ~/Downloads/51job.rar --keyword "CNC 销售"`
 - `./bin/trends resume restore output/resume-backups/<run-stamp> --mode replace --yes`
 - `./bin/trends resume match --query "CNC 销售" --source convex --mode rules_only`

--- a/Makefile
+++ b/Makefile
@@ -476,9 +476,9 @@ push-sample-snapshots:
 	@SAMPLE_REPO="$${SAMPLE_REPO:-ptdevhk/trends-resume-samples}" \
 	SNAPSHOT_DIR="$${SNAPSHOT_DIR:-}"; \
 	if command -v bun >/dev/null 2>&1; then \
-		bun run scripts/resume/push-sample-snapshots.ts; \
+		GH_TOKEN="$${GH_TOKEN:-$$(gh auth token)}" bun run scripts/resume/push-sample-snapshots.ts; \
 	else \
-		npx tsx scripts/resume/push-sample-snapshots.ts; \
+		GH_TOKEN="$${GH_TOKEN:-$$(gh auth token)}" npx tsx scripts/resume/push-sample-snapshots.ts; \
 	fi
 
 # Pull resume snapshots from the sample repo into output/resume-samples

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -885,6 +885,24 @@ describe('useResumeSearchState', () => {
       },
     }))
 
+    recentSearchHistoryRecordsMock.push({
+      _id: 'history-1',
+      sessionKey: 'session-1',
+      title: 'Saved search',
+      location: 'China',
+      keywords: ['CNC', '销售'],
+      collectionSource: {
+        type: 'job5156',
+      },
+      filters: {
+        minRoleYears: 5,
+      },
+      selectedTags: [],
+      selectedCompanies: [],
+      selectedExperienceLevel: 'senior',
+      createdAt: Date.now(),
+    })
+
     resumesMock.push(
       createResume(1, {
         ingestData: {
@@ -960,6 +978,11 @@ describe('useResumeSearchState', () => {
     expect(dispatchAnalysisMutationMock).toHaveBeenCalledWith({
       keywords: ['CNC', '销售'],
       promptVersion: CURRENT_PROMPT_VERSION,
+      relatedExpContext: {
+        market: 'CN',
+        minRoleYears: 5,
+        roleFilterType: 'sales',
+      },
       resumeIds: ['resume-1', 'resume-2'],
     })
     expect(toastSuccessMock).toHaveBeenCalledWith('Analyzing 2 resumes...')
@@ -1344,6 +1367,9 @@ describe('useResumeSearchState', () => {
       keywords: ['machine', 'tools'],
       location: 'China',
       promptVersion: CURRENT_PROMPT_VERSION,
+      relatedExpContext: {
+        market: 'CN',
+      },
       resumeIds: Array.from({ length: 10 }, (_, index) => `resume-${index + 1}`),
     })
     expect(toastSuccessMock).toHaveBeenCalledWith(
@@ -1388,6 +1414,9 @@ describe('useResumeSearchState', () => {
       keywords: ['machine', 'tools'],
       location: 'China',
       promptVersion: CURRENT_PROMPT_VERSION,
+      relatedExpContext: {
+        market: 'CN',
+      },
       resumeIds: Array.from({ length: 10 }, (_, index) => `resume-${index + 1}`),
     })
     expect(toastSuccessMock).toHaveBeenCalledWith(
@@ -1592,6 +1621,9 @@ describe('useResumeSearchState', () => {
       keywords: ['machine', 'tools'],
       location: 'China',
       promptVersion: CURRENT_PROMPT_VERSION,
+      relatedExpContext: {
+        market: 'CN',
+      },
       resumeIds: Array.from({ length: 10 }, (_, index) => `resume-${index + 1}`),
     })
     expect(result.current.disableAnalyzeResults).toBe(false)

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -1,4 +1,4 @@
-import { formatKeywordQuery, isSalesRequiredContext, parseKeywordQuery } from '@trends/shared'
+import { formatKeywordQuery, isSalesRequiredContext, parseKeywordQuery, resolveLocationHierarchy } from '@trends/shared'
 import { matchesSalaryFilter } from '@/hooks/resume-filter-helpers'
 import { useMutation } from 'convex/react'
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from 'react'
@@ -48,7 +48,7 @@ import {
   resolveResumeAnalysisSourceKey,
 } from '@/lib/analysis-utils'
 import { parseExperienceYears } from '@/lib/resume-filtering'
-import { resolveCollectionSource, getSourceLabelFromHostname } from '@/lib/search-profile-sources'
+import { getCollectionSourceMarket, resolveCollectionSource, getSourceLabelFromHostname } from '@/lib/search-profile-sources'
 import type { SearchHistoryItem } from '@/hooks/useSession'
 import type {
   CandidateActionType,
@@ -150,6 +150,62 @@ function resolveEffectiveRoleFilterType(state: UrlSearchState): string | undefin
   }
 
   return queryImpliesSalesRole(state.query, state.keywords) ? 'sales' : undefined
+}
+
+function resolveRelatedExpMarket(
+  state: UrlSearchState,
+  recentSearches: ResumeSearchRecentItem[],
+): 'CN' | 'MY' | undefined {
+  const explicitCollectionSource = recentSearches.find(
+    (item) => item.collectionSource,
+  )?.collectionSource
+
+  if (!explicitCollectionSource) {
+    const normalizedLocation = normalizeOptionalString(state.location)
+    if (!normalizedLocation) {
+      return undefined
+    }
+
+    const hierarchy = resolveLocationHierarchy(normalizedLocation)
+    if (!hierarchy) {
+      return undefined
+    }
+
+    if (hierarchy.country === 'Malaysia') {
+      return 'MY'
+    }
+
+    if (hierarchy.country === '中国') {
+      return 'CN'
+    }
+
+    return undefined
+  }
+
+  return getCollectionSourceMarket(explicitCollectionSource.type)
+}
+
+function buildRelatedExpContext(
+  state: UrlSearchState,
+  recentSearches: ResumeSearchRecentItem[],
+): {
+  roleFilterType?: string
+  minRoleYears?: number
+  market?: 'CN' | 'MY'
+} | undefined {
+  const roleFilterType = resolveEffectiveRoleFilterType(state)
+  const minRoleYears = state.filters.minRoleYears
+  const market = resolveRelatedExpMarket(state, recentSearches)
+
+  if (!roleFilterType && typeof minRoleYears !== 'number' && !market) {
+    return undefined
+  }
+
+  return {
+    ...(roleFilterType ? { roleFilterType } : {}),
+    ...(typeof minRoleYears === 'number' ? { minRoleYears } : {}),
+    ...(market ? { market } : {}),
+  }
 }
 
 function resolveScore(
@@ -1505,6 +1561,7 @@ export function useResumeSearchState() {
       const normalizedLocation = normalizeOptionalString(parsedState.location)
       const keywords =
         analysisKeywords.length > 0 ? analysisKeywords : undefined
+      const relatedExpContext = buildRelatedExpContext(parsedState, recentSearches)
       let jobDescriptionTitle: string | undefined
       let jobDescriptionContent: string | undefined
 
@@ -1530,6 +1587,7 @@ export function useResumeSearchState() {
         ...(jobDescriptionContent ? { jobDescriptionContent } : {}),
         ...(keywords ? { keywords } : {}),
         ...(normalizedLocation ? { location: normalizedLocation } : {}),
+        ...(relatedExpContext ? { relatedExpContext } : {}),
         promptVersion: currentPromptVersion,
         resumeIds: analysisDispatchBatchIds,
       })
@@ -1553,8 +1611,8 @@ export function useResumeSearchState() {
     currentPromptVersion,
     dispatchAnalysis,
     hasActiveAnalysisTask,
-    parsedState.jobDescriptionId,
-    parsedState.location,
+    parsedState,
+    recentSearches,
   ])
 
   useEffect(() => {

--- a/dev-docs/skills/refresh-sample-snapshots/SKILL.md
+++ b/dev-docs/skills/refresh-sample-snapshots/SKILL.md
@@ -50,14 +50,20 @@ Collect fresh resume samples from browser sources via CDP.
 ### Single source
 
 ```bash
-bun run scripts/resume/snapshot-source-backups.ts --source 51job --count 20
+bun run scripts/resume/snapshot-source-backups.ts --source 51job --count 50
+```
+
+Seek keeps a separate 20-resume ceiling by default, so the same script can still collect the smaller browser-backed samples:
+
+```bash
+bun run scripts/resume/snapshot-source-backups.ts --source seek --seek-count 20
 ```
 
 ### Multiple sources in one run
 
 ```bash
 bun run scripts/resume/snapshot-source-backups.ts \
-  --source 51job --source job5156 --source seek --count 20
+  --source 51job --source job5156 --source seek --count 50
 ```
 
 ### Custom URL override
@@ -67,12 +73,12 @@ Override the default search URL for a source:
 ```bash
 # Seek talent search (MY market) — uses keyword-based collection
 bun run scripts/resume/snapshot-source-backups.ts \
-  --source seek --count 20 \
+  --source seek --seek-count 20 \
   --seek-url "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE"
 
 # Custom 51job keyword/location
 bun run scripts/resume/snapshot-source-backups.ts \
-  --source 51job --count 20 \
+  --source 51job --count 50 \
   --51job-url "https://ehire.51job.com/Revision/talent/search?keyword=工程师&tr_min_age=25&tr_max_age=40"
 ```
 
@@ -81,7 +87,8 @@ bun run scripts/resume/snapshot-source-backups.ts \
 | Option | Default | Description |
 |---|---|---|
 | `--source <alias>` | (required) | Source alias: `51job`, `job5156`, `seek` (repeatable) |
-| `--count <n>` | `20` | Resumes to collect per source |
+| `--count <n>` | `50` | Resumes to collect per source |
+| `--seek-count <n>` | `20` | Seek resumes to collect per source |
 | `--max-pages <n>` | `10` | Max pages to paginate through |
 | `--cdp-endpoint <url>` | `http://127.0.0.1:9222` | Chrome DevTools endpoint |
 | `--<source>-url <url>` | Per-source default | Override the search URL for a source |
@@ -92,8 +99,8 @@ bun run scripts/resume/snapshot-source-backups.ts \
 Creates a timestamped directory:
 ```
 output/resume-backups/20260602-190034/
-├── resume-backup-51job-top20-20260602-190034.json
-├── resume-backup-job5156-top20-20260602-190034.json
+├── resume-backup-51job-top50-20260602-190034.json
+├── resume-backup-job5156-top50-20260602-190034.json
 └── resume-backup-seek-top20-20260602-190034.json
 ```
 
@@ -178,7 +185,7 @@ Each `snapshot-source-backups.ts` invocation creates a new timestamped directory
 
 ```bash
 bun run scripts/resume/snapshot-source-backups.ts \
-  --source 51job --source job5156 --source seek --count 20
+  --source 51job --source job5156 --source seek --count 50
 ```
 
 This creates `output/resume-backups/<timestamp-1>/` with 51job, job5156, and seek-recommended snapshots.
@@ -187,11 +194,11 @@ This creates `output/resume-backups/<timestamp-1>/` with 51job, job5156, and see
 
 ```bash
 bun run scripts/resume/snapshot-source-backups.ts \
-  --source seek --count 20 \
+  --source seek --seek-count 20 \
   --seek-url "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE"
 ```
 
-This creates `output/resume-backups/<timestamp-2>/` with the seek-talentsearch snapshot. Note that this file is also named `resume-backup-seek-top20-<timestamp>.json` (same alias), so it must be renamed before merging to avoid overwriting the seek-recommended file.
+This creates `output/resume-backups/<timestamp-2>/` with the seek-talentsearch snapshot. The file stays on the 20-resume ceiling (`resume-backup-seek-top20-<timestamp>.json`), so it can be merged without renaming conflicts.
 
 ### Step 3: Merge and push
 
@@ -211,8 +218,8 @@ Check that all 4 files are present before pushing:
 ```bash
 ls output/resume-backups/<timestamp-1>/
 # Expected:
-#   resume-backup-51job-top20-<ts>.json
-#   resume-backup-job5156-top20-<ts>.json
+#   resume-backup-51job-top50-<ts>.json
+#   resume-backup-job5156-top50-<ts>.json
 #   resume-backup-seek-top20-<ts>.json          (recommended)
 #   resume-backup-seek-talentsearch-top20.json  (talent search)
 ```

--- a/dev-docs/skills/refresh-sample-snapshots/references/seek.md
+++ b/dev-docs/skills/refresh-sample-snapshots/references/seek.md
@@ -56,7 +56,7 @@ https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNu
 
 ```bash
 bun run scripts/resume/snapshot-source-backups.ts \
-  --source seek --count 20 \
+  --source seek --seek-count 20 \
   --seek-url "https://hk.employer.seek.com/talentsearch?searchQuery=CNC+Sales&market=MY&pageNumber=1&roleTitles=Sales&salaryType=MONTHLY&minSalary=0&salaryUnspecified=true&keywords=CNC&matchAll=false&sortBy=RELEVANCE"
 ```
 

--- a/dev-docs/skills/trends-cli/SKILL.md
+++ b/dev-docs/skills/trends-cli/SKILL.md
@@ -31,7 +31,7 @@ Use this skill when the user asks to operate backend services from terminal comm
 
 - `./bin/trends resume list --limit 50`
 - `./bin/trends resume search "CNC 东莞" --limit 50`
-- `./bin/trends resume snapshot --source job5156 --count 20`
+- `./bin/trends resume snapshot --source job5156 --count 50`
 - `./bin/trends resume import-51job ~/Downloads/51job.rar --keyword "CNC 销售"`
 - `./bin/trends resume restore output/resume-backups/<run-stamp> --mode replace --yes`
 - `./bin/trends resume match --query "CNC 销售" --source convex --mode rules_only`

--- a/packages/cli/cmd/resume_debug.go
+++ b/packages/cli/cmd/resume_debug.go
@@ -596,7 +596,7 @@ func newResumeDebugAIScoreCmd() *cobra.Command {
 	cmd.Flags().StringVar(&jobDescriptionID, "job-description", "", "Optional job description ID")
 	cmd.Flags().StringVar(&source, "source", "convex", "Resume source: convex")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum candidates to consider before local AI scoring")
-	cmd.Flags().IntVar(&topN, "top-n", 10, "Number of top rule-ranked candidates to AI-score locally")
+	cmd.Flags().IntVar(&topN, "top-n", 50, "Number of top rule-ranked candidates to AI-score locally")
 	cmd.Flags().StringSliceVar(&resumeIDs, "resume-id", nil, "Optional specific Convex resume IDs to AI-score")
 	return cmd
 }

--- a/packages/cli/cmd/resume_debug_test.go
+++ b/packages/cli/cmd/resume_debug_test.go
@@ -90,7 +90,9 @@ func TestResumeDebugAIScoreCommandWritesTable(t *testing.T) {
 	viper.Set("output", "table")
 	viper.Set("api_url", "http://localhost:3000")
 	viper.Set("workspace", "dev")
+	var seenRequest localResumeAIScoreRequest
 	runLocalResumeAIScorer = func(ctx context.Context, request localResumeAIScoreRequest) (*localResumeAIScoreResponse, error) {
+		seenRequest = request
 		if request.Source != "convex" {
 			t.Fatalf("expected convex source, got %q", request.Source)
 		}
@@ -114,14 +116,59 @@ func TestResumeDebugAIScoreCommandWritesTable(t *testing.T) {
 	var output bytes.Buffer
 	cmd.SetOut(&output)
 	cmd.SetErr(&output)
-	cmd.SetArgs([]string{"--query", "CNC 销售", "--top-n", "1"})
+	cmd.SetArgs([]string{"--query", "CNC 销售", "--top-n", "100"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("resume debug ai-score command failed: %v", err)
 	}
+	if seenRequest.TopN != 100 {
+		t.Fatalf("expected topN=100, got %d", seenRequest.TopN)
+	}
 	text := output.String()
 	if !strings.Contains(text, "Alice") || !strings.Contains(text, "92") {
 		t.Fatalf("unexpected command output: %s", text)
+	}
+}
+
+func TestResumeDebugAIScoreCommandUsesDefaultTopN50(t *testing.T) {
+	originalOutput := viper.GetString("output")
+	originalAPIURL := viper.GetString("api_url")
+	originalWorkspace := viper.GetString("workspace")
+	originalRunner := runLocalResumeAIScorer
+	t.Cleanup(func() {
+		viper.Set("output", originalOutput)
+		viper.Set("api_url", originalAPIURL)
+		viper.Set("workspace", originalWorkspace)
+		runLocalResumeAIScorer = originalRunner
+	})
+
+	viper.Set("output", "table")
+	viper.Set("api_url", "http://localhost:3000")
+	viper.Set("workspace", "dev")
+	var seenRequest localResumeAIScoreRequest
+	runLocalResumeAIScorer = func(ctx context.Context, request localResumeAIScoreRequest) (*localResumeAIScoreResponse, error) {
+		seenRequest = request
+		return &localResumeAIScoreResponse{
+			Success: true,
+			Source:  "convex",
+			Results: []localResumeAIScoreResult{},
+		}, nil
+	}
+
+	cmd := newResumeDebugAIScoreCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--query", "CNC 销售"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume debug ai-score command failed: %v", err)
+	}
+	if seenRequest.TopN != 50 {
+		t.Fatalf("expected default topN=50, got %d", seenRequest.TopN)
+	}
+	if seenRequest.Limit != 50 {
+		t.Fatalf("expected default limit=50, got %d", seenRequest.Limit)
 	}
 }
 

--- a/packages/convex/__tests__/analysis-tasks-parsing.test.ts
+++ b/packages/convex/__tests__/analysis-tasks-parsing.test.ts
@@ -5,7 +5,11 @@ import { describe, expect, it } from "vitest";
 // For now, test the exported normalizeKeywords and extractKeywords
 // by verifying their behavior through the idempotency key construction.
 
-import { buildAnalysisDispatchIdempotencyKey, buildRelatedExpCtxArg } from "../convex/analysis_tasks";
+import {
+  buildAnalysisDispatchIdempotencyKey,
+  buildRelatedExpCtxArg,
+  classifyResumes,
+} from "../convex/analysis_tasks";
 
 // We'll also directly test normalizeKeywords and extractKeywords
 // by duplicating their logic in tests (since they're simple pure functions)
@@ -229,41 +233,8 @@ describe("normalizeKeywords logic", () => {
   });
 });
 
-// Test classifyResumes logic (duplicated as pure function for unit testing)
+// Test classifyResumes logic against the exported helper.
 describe("classifyResumes skip-threshold logic", () => {
-  // Mirrors analysis_tasks.ts:234-264
-  function classifyResumes(
-    resumes: Array<Record<string, unknown>>,
-    keywords: string[]
-  ): { toAnalyze: Array<Record<string, unknown>>; toSkip: Array<Record<string, unknown>> } {
-    if (keywords.length === 0) {
-      return { toAnalyze: resumes, toSkip: [] };
-    }
-
-    const toAnalyze: Array<Record<string, unknown>> = [];
-    const toSkip: Array<Record<string, unknown>> = [];
-    const threshold = 10;
-
-    for (const resume of resumes) {
-      const serialized = JSON.stringify(resume).toLowerCase();
-      let matches = 0;
-      for (const keyword of keywords) {
-        if (serialized.includes(keyword)) {
-          matches += 1;
-        }
-      }
-
-      const score = Math.min(100, Math.round((matches / Math.max(keywords.length, 1)) * 100));
-      if (score < threshold) {
-        toSkip.push(resume);
-        continue;
-      }
-      toAnalyze.push(resume);
-    }
-
-    return { toAnalyze, toSkip };
-  }
-
   it("analyzes all resumes when keywords are empty", () => {
     const resumes = [{ name: "A" }, { name: "B" }];
     const result = classifyResumes(resumes, []);
@@ -271,17 +242,15 @@ describe("classifyResumes skip-threshold logic", () => {
     expect(result.toSkip).toHaveLength(0);
   });
 
-  it("skips resumes with zero keyword matches", () => {
+  it("handles a mixed set of keyword matches and skips the zero-match resume", () => {
     const resumes = [
       { name: "张某", selfIntro: "保险销售" },
-      { name: "李某", selfIntro: "CNC操作员" },
+      { name: "李某", selfIntro: "质量检验员" },
     ];
-    // With 10 keywords, matching 0 gives score 0 < 10 → skip
+    // One resume matches the threshold; the other remains a zero-match skip case.
     const result = classifyResumes(resumes, ["cnc", "机床", "加工中心", "机械", "设备", "数控", "车床", "销售", "业务", "cmm"]);
-    // 张某 matches 1 keyword (销售/业务 ~2/10 = 20 >= 10 → analyze)
-    // Wait — let's check: "保险销售" contains "销售" → 1 match, "业务" not present
-    // Actually "保险销售" matches "销售" = 1 match. With 10 keywords: 1/10*100=10 >= 10 → analyze
-    // Let me adjust for a clear skip case
+    expect(result.toAnalyze).toHaveLength(1);
+    expect(result.toSkip).toHaveLength(1);
   });
 
   it("skips resumes with zero keyword matches (clear case)", () => {
@@ -315,6 +284,47 @@ describe("classifyResumes skip-threshold logic", () => {
     // "机械操作" matches "机械" → 1/11 ≈ 9% → below 10 → skip
     expect(result.toAnalyze).toHaveLength(0);
     expect(result.toSkip).toHaveLength(1);
+  });
+
+  it("keeps a low-keyword-match resume when related experience context has supporting evidence", () => {
+    const resumes = [
+      {
+        name: "赵先生",
+        ingestData: {
+          roleSignals: [
+            {
+              type: "sales",
+              matchedSignals: ["客户开发"],
+              signalCount: 1,
+              occurrences: 1,
+              years: 3,
+              industryVerifiedRelevantYears: 2,
+              matchedWorkEntries: [
+                {
+                  companyName: "富士电机（中国）有限公司深圳分公司",
+                  jobTitle: "销售主管",
+                  years: 2,
+                  industryVerified: true,
+                  matchedSignals: ["客户开发"],
+                  directRoleMatch: true,
+                },
+              ],
+              verifyIn: "workHistory",
+            },
+          ],
+        },
+      },
+    ];
+
+    const result = classifyResumes(resumes, ["cnc", "lathe"], {
+      roleFilterType: "sales",
+      minRoleYears: 1,
+      market: "CN",
+    });
+
+    expect(result.toAnalyze).toHaveLength(1);
+    expect(result.toSkip).toHaveLength(0);
+    expect(result.toAnalyze[0].name).toBe("赵先生");
   });
 });
 

--- a/packages/convex/convex/analysis_tasks.ts
+++ b/packages/convex/convex/analysis_tasks.ts
@@ -156,16 +156,36 @@ export function buildRelatedExpCtxArg(
     };
 }
 
-function classifyResumes(
-    resumes: Doc<"resumes">[],
-    keywords: string[]
-): { toAnalyze: Doc<"resumes">[]; toSkip: Doc<"resumes">[] } {
+function hasRelatedExpContextEvidence(
+    resume: Record<string, unknown>,
+    relatedExpContext: RelatedExpContextInput,
+): boolean {
+    const relatedExpArg = buildRelatedExpCtxArg(resume, relatedExpContext);
+    if (!relatedExpArg) {
+        return false;
+    }
+
+    const evidence = relatedExpArg.ingestEvidence;
+    const directRoleMatch = evidence.directRoleMatch === true;
+    const industryVerifiedRelevantYears = evidence.industryVerifiedRelevantYears ?? 0;
+    const matchedWorkEntries = evidence.matchedWorkEntries ?? [];
+
+    return directRoleMatch
+        || industryVerifiedRelevantYears > 0
+        || matchedWorkEntries.length > 0;
+}
+
+export function classifyResumes<T extends Record<string, unknown>>(
+    resumes: T[],
+    keywords: string[],
+    relatedExpContext?: RelatedExpContextInput,
+): { toAnalyze: T[]; toSkip: T[] } {
     if (keywords.length === 0) {
         return { toAnalyze: resumes, toSkip: [] };
     }
 
-    const toAnalyze: Doc<"resumes">[] = [];
-    const toSkip: Doc<"resumes">[] = [];
+    const toAnalyze: T[] = [];
+    const toSkip: T[] = [];
     const threshold = 10;
 
     for (const resume of resumes) {
@@ -178,7 +198,7 @@ function classifyResumes(
         }
 
         const score = Math.min(100, Math.round((matches / Math.max(keywords.length, 1)) * 100));
-        if (score < threshold) {
+        if (score < threshold && !(relatedExpContext && hasRelatedExpContextEvidence(resume, relatedExpContext))) {
             toSkip.push(resume);
             continue;
         }
@@ -592,7 +612,7 @@ export const processAnalysisTask = internalAction({
                 : extractKeywords(keywordSource);
             const normalizedLocation = task.config.location?.trim() || undefined;
             const promptVersion = task.config.promptVersion ?? getCurrentResumeAiPromptVersion();
-            const { toAnalyze, toSkip } = classifyResumes(resumes, keywords);
+            const { toAnalyze, toSkip } = classifyResumes(resumes, keywords, task.config.relatedExpContext);
             const analysisJobDescriptionId = task.config.jobDescriptionId
                 || (keywords.length > 0
                     ? buildKeywordAnalysisId(keywords, {

--- a/scripts/resume/push-sample-snapshots.ts
+++ b/scripts/resume/push-sample-snapshots.ts
@@ -57,6 +57,11 @@ async function execGit(args: string[], cwd: string): Promise<string> {
 }
 
 async function getGhToken(): Promise<string | null> {
+  const envToken = process.env.GH_TOKEN?.trim();
+  if (envToken) {
+    return envToken;
+  }
+
   try {
     const { stdout } = await execFileAsync("gh", ["auth", "token"]);
     return stdout.trim() || null;
@@ -65,10 +70,10 @@ async function getGhToken(): Promise<string | null> {
   }
 }
 
-async function cloneSampleRepo(sampleRepo: string, tempDir: string): Promise<void> {
+async function cloneSampleRepo(sampleRepo: string, tempDir: string): Promise<string> {
   const token = await getGhToken();
   const cloneUrl = token
-    ? `https://oauth2:${token}@github.com/${sampleRepo}.git`
+    ? `https://x-access-token:${token}@github.com/${sampleRepo}.git`
     : `https://github.com/${sampleRepo}.git`;
 
   try {
@@ -79,6 +84,8 @@ async function cloneSampleRepo(sampleRepo: string, tempDir: string): Promise<voi
     }
     throw e;
   }
+
+  return cloneUrl;
 }
 
 interface SnapshotFile {
@@ -103,7 +110,7 @@ function parseResumeCount(raw: string): number {
 }
 
 function extractSource(fileName: string): string {
-  const match = /^resume-backup-(.+)-top\d+-/.exec(fileName);
+  const match = /^resume-backup-(.+)-top\d+(?:-|\.json$)/.exec(fileName);
   return match ? match[1] : "unknown";
 }
 
@@ -163,7 +170,7 @@ async function main(): Promise<void> {
   const tempDir = await mkdtemp("trends-push-samples-");
   try {
     console.log(`Cloning ${sampleRepo}...`);
-    await cloneSampleRepo(sampleRepo, tempDir);
+    const pushUrl = await cloneSampleRepo(sampleRepo, tempDir);
 
     const snapshotsDir = path.join(tempDir, "snapshots");
     await mkdir(snapshotsDir, { recursive: true });
@@ -205,7 +212,7 @@ async function main(): Promise<void> {
     }
 
     await execGit(["commit", "-m", `Update sample snapshots from ${timestamp}`], tempDir);
-    await execGit(["push", "origin", "main"], tempDir);
+    await execGit(["push", pushUrl, "main"], tempDir);
 
     console.log(`Pushed ${jsonFiles.length} snapshot file(s) to ${sampleRepo}`);
     for (const f of fileSummaries) {

--- a/scripts/resume/snapshot-source-backups.test.ts
+++ b/scripts/resume/snapshot-source-backups.test.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_51JOB_URL,
   DEFAULT_JOB5156_URL,
   DEFAULT_SEEK_URL,
+  parseCliArgs,
   SOURCE_HOSTS,
   resolveRequestedSources,
   resolveUserFacingPath,
@@ -47,6 +48,7 @@ function baseOptions(
     apiUrl: "http://localhost:3000",
     workspace: "dev",
     count: 20,
+    seekCount: 20,
     maxPages: 10,
     outDir: path.join(repoRoot, "output", "resume-backups"),
     sources: [source],
@@ -104,6 +106,67 @@ describe("snapshot-source-backups", () => {
       "seek",
       "51job",
     ]);
+  });
+
+  it("defaults snapshot collection to 50 resumes per source and keeps Seek at 20", () => {
+    const args = parseCliArgs([]);
+    expect(args.count).toBe(50);
+    expect(args.seekCount).toBe(20);
+  });
+
+  it("caps Seek snapshot collection at 20 resumes even when the global count is 50", async () => {
+    const repoRoot = await createTestRepoRoot();
+    repoRoots.push(repoRoot);
+    const exec = vi.fn(async (_command: string, args: string[]) => {
+      if (args.includes("--check-only")) {
+        return {
+          stdout: JSON.stringify({
+            mode: "check",
+            source: "seek",
+            sourceHost: SOURCE_HOSTS.seek,
+            url: DEFAULT_SEEK_URL,
+            status: { sourceKey: "seek" },
+          }),
+          stderr: "",
+        };
+      }
+
+      return {
+        stdout: JSON.stringify({
+          mode: "collect",
+          source: "seek",
+          sourceHost: SOURCE_HOSTS.seek,
+          url: DEFAULT_SEEK_URL,
+          status: { sourceKey: "seek" },
+          payload: createCollectedPayload("seek", 20),
+        }),
+        stderr: "",
+      };
+    });
+
+    const result = await runSnapshotSourceBackups(
+      { ...baseOptions(repoRoot, "seek"), count: 50 },
+      {
+        now: fixedNow,
+        exec,
+        log: () => undefined,
+        resolveUserHomeDirectory: async () => "/Users/tester",
+      },
+    );
+
+    expect(exec).toHaveBeenCalledTimes(2);
+    const collectArgs = exec.mock.calls[1]?.[1] ?? [];
+    expect(collectArgs).toContain("--limit");
+    const limitIndex = collectArgs.indexOf("--limit");
+    expect(limitIndex).toBeGreaterThanOrEqual(0);
+    expect(collectArgs[limitIndex + 1]).toBe("20");
+    expect(result.sources[0]).toMatchObject({
+      alias: "seek",
+      sourceHost: SOURCE_HOSTS.seek,
+      count: 20,
+      observedCount: 20,
+    });
+    await access(buildExpectedFilePath(repoRoot, "seek"));
   });
 
   it("resolves ~/ paths against the invoking sudo user home directory", async () => {

--- a/scripts/resume/snapshot-source-backups.ts
+++ b/scripts/resume/snapshot-source-backups.ts
@@ -19,7 +19,8 @@ import {
 
 const execFileAsync = promisify(execFileCallback);
 
-const DEFAULT_COUNT = 20;
+const DEFAULT_COUNT = 50;
+const DEFAULT_SEEK_COUNT = 20;
 const DEFAULT_MAX_PAGES = 10;
 const DEFAULT_CDP_ENDPOINT = "http://127.0.0.1:9222";
 const DEFAULT_WAIT_TIMEOUT_SEC = 600;
@@ -57,6 +58,7 @@ type SnapshotCliArgs = {
   apiUrl: string;
   workspace: string;
   count: number;
+  seekCount: number;
   maxPages: number;
   outDir: string;
   sources: OptionalSourceAlias[];
@@ -142,6 +144,7 @@ export type SnapshotRunSummary = {
   runStamp: string;
   outputDir: string;
   countPerSource: number;
+  seekCount: number;
   sources: SnapshotSourceResult[];
   skipped: SnapshotSkippedSource[];
 };
@@ -176,6 +179,7 @@ function usage(): string {
     "Options:",
     "  --source <alias>           Repeatable source alias: job5156 | seek | 51job (51job-manual opt-in only)",
     `  --count <number>           Resumes per source (default: ${DEFAULT_COUNT})`,
+    `  --seek-count <number>      Seek resumes per source (default: ${DEFAULT_SEEK_COUNT})`,
     `  --max-pages <number>       Browser pages per source collection (default: ${DEFAULT_MAX_PAGES})`,
     `  --api-url <url>            Retained for CLI compatibility (default: ${resolveApiUrl()})`,
     `  --workspace <slug>         Retained for CLI compatibility (default: ${resolveWorkspace()})`,
@@ -282,6 +286,10 @@ export function parseCliArgs(argv: string[]): SnapshotCliArgs {
     apiUrl: readCliValue(argv, "api-url")?.trim() || resolveApiUrl(),
     workspace: readCliValue(argv, "workspace")?.trim() || resolveWorkspace(),
     count: parsePositiveInteger(readCliValue(argv, "count"), DEFAULT_COUNT),
+    seekCount: parsePositiveInteger(
+      readCliValue(argv, "seek-count"),
+      DEFAULT_SEEK_COUNT,
+    ),
     maxPages: parsePositiveInteger(
       readCliValue(argv, "max-pages"),
       DEFAULT_MAX_PAGES,
@@ -514,9 +522,13 @@ async function writeSnapshotPayloadToFile(params: {
   payload: ResumeBackupEnvelope;
   expectedCount: number;
   outFile: string;
+  allowShortfall?: boolean;
 }): Promise<number> {
   const count = readResumeRecords(params.payload).length;
-  if (count !== params.expectedCount) {
+  if (
+    (params.allowShortfall === true && (count === 0 || count > params.expectedCount))
+    || (params.allowShortfall !== true && count !== params.expectedCount)
+  ) {
     throw new Error(
       `expected ${params.expectedCount} resumes in ${params.alias} snapshot, received ${count}`,
     );
@@ -655,6 +667,13 @@ function buildSourceLaunchUrl(
   return undefined;
 }
 
+function resolveSourceCount(alias: SourceAlias, options: SnapshotOptions): number {
+  if (alias === "seek") {
+    return Math.max(1, Math.min(options.count, options.seekCount));
+  }
+  return options.count;
+}
+
 export async function runSnapshotSourceBackups(
   options: SnapshotOptions,
   runtime: SnapshotRuntime = createRuntime(),
@@ -679,6 +698,7 @@ export async function runSnapshotSourceBackups(
     let launchUrl: string | undefined;
     let manualImportSummary: ManualImportSummary | undefined;
     let snapshotPayload: ResumeBackupEnvelope;
+    const sourceCount = resolveSourceCount(alias, options);
 
     try {
     if (alias !== MANUAL_SOURCE) {
@@ -689,7 +709,7 @@ export async function runSnapshotSourceBackups(
       const browserCollectorParams = buildBrowserCollectorParams(
         alias,
         launchUrl,
-        options,
+        { ...options, count: sourceCount },
         runtime,
       );
 
@@ -723,20 +743,21 @@ export async function runSnapshotSourceBackups(
       runtime.log(`[51job-manual] parsing ${manualArchivePath}`);
       const manualSnapshot = await buildManualSnapshotPayload({
         archivePath: manualArchivePath,
-        limit: options.count,
+        limit: sourceCount,
         runtime,
       });
       manualImportSummary = manualSnapshot.summary;
       snapshotPayload = manualSnapshot.payload;
     }
 
-    const outFile = buildOutputFilePath(runDir, alias, options.count, runStamp);
+    const outFile = buildOutputFilePath(runDir, alias, sourceCount, runStamp);
     runtime.log(`[${alias}] writing snapshot file ${outFile}`);
     const snapshotCount = await writeSnapshotPayloadToFile({
       alias,
       payload: snapshotPayload,
-      expectedCount: options.count,
+      expectedCount: sourceCount,
       outFile,
+      ...(alias === "seek" ? { allowShortfall: true } : {}),
     });
 
     results.push({
@@ -774,6 +795,7 @@ export async function runSnapshotSourceBackups(
     runStamp,
     outputDir: runDir,
     countPerSource: options.count,
+    seekCount: options.seekCount,
     sources: results,
     skipped,
   };


### PR DESCRIPTION
Summary:\n- Forward relatedExpContext from the web analysis path so UI and CLI dispatch the same context.\n- Raise resume debug ai-score default topN to 50.\n- Collect 50 resumes per CN source for snapshot refresh while capping Seek at 20.\n- Fix authenticated push flow for ptdevhk/trends-resume-samples.\n\nVerification:\n- make check\n- bun test scripts/resume/snapshot-source-backups.test.ts\n- bunx vitest run src/hooks/useResumeSearchState.test.tsx (apps/web)\n- bunx vitest run packages/convex/__tests__/analysis-tasks-parsing.test.ts packages/convex/__tests__/analysis-tasks-convex-test.test.ts\n- go test ./cmd -run 'TestResumeDebugAIScoreCommand|TestResumeDebugMatchesCommand'\n- bunx tsx scripts/e2e-smoke.ts