### PR TITLE
fix: collection guard post-enrichment regression — guarded fields re-leaked after detail enrichment

### DIFF
--- a/apps/api/src/services/__tests__/resume-import-service.test.ts
+++ b/apps/api/src/services/__tests__/resume-import-service.test.ts
@@ -434,6 +434,48 @@ describe("resume-import-service", () => {
       });
       expect(result.options.recomputeDerivedFields).toBe(true);
     });
+
+    it("strips collection-guarded fields from browser-extension job5156 imports", () => {
+      const result = normalizeResumeImportPayload({
+        metadata: makeMetadata({
+          sourceKey: "job5156",
+          sourceHost: "hr.job5156.com",
+          generatedBy: "browser-extension@1.0.0",
+        }),
+        resumes: [
+          makeResume({
+            experience: "8 years",
+            jobIntention: "Sales Engineer",
+            selfIntro: "Sensitive free text",
+          }),
+        ],
+      });
+      const content = result.convexResumes[0].content as Record<string, unknown>;
+      expect(content.experience).toBe("");
+      expect(content.jobIntention).toBe("");
+      expect(content.selfIntro).toBe("");
+    });
+
+    it("preserves guarded-looking fields for manual source imports", () => {
+      const result = normalizeResumeImportPayload({
+        metadata: makeMetadata({
+          sourceKey: "51job-manual",
+          sourceHost: "51job-manual",
+          generatedBy: "manual-import@1.0.0",
+        }),
+        resumes: [
+          makeResume({
+            experience: "8 years",
+            jobIntention: "Sales Engineer",
+            selfIntro: "Manual resume text",
+          }),
+        ],
+      });
+      const content = result.convexResumes[0].content as Record<string, unknown>;
+      expect(content.experience).toBe("8 years");
+      expect(content.jobIntention).toBe("Sales Engineer");
+      expect(content.selfIntro).toBe("Manual resume text");
+    });
   });
 
   // ── submitNormalizedResumeImport ──────────────────────────────────

--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -10,6 +10,8 @@ import {
   normalizeResumeLocationHierarchy,
   normalizeSeekProfileUrlForDisplay,
   inferSeekMarket,
+  COLLECTION_GUARDS,
+  applyCollectionGuards,
 } from "@trends/shared";
 import {
   ResumeImportItemSchema,
@@ -380,6 +382,31 @@ async function submitResumesToConvex(args: { resumes: ConvexResumeSubmitItem[] }
   return totals;
 }
 
+function isBrowserExtensionGenerated(metadata: ResumeImportMetadata): boolean {
+  return typeof metadata.generatedBy === "string" &&
+    metadata.generatedBy.trim().toLowerCase().startsWith("browser-extension");
+}
+
+function resolveCollectionGuardSourceKey(source: string): string | null {
+  if (COLLECTION_GUARDS[source]) return source;
+  if (source === JOB5156_HOST) return "job5156";
+  if (source === EHIRE_51JOB_HOST) return "51job";
+  if (source === "seek" || source?.endsWith(".employer.seek.com")) return "seek";
+  return null;
+}
+
+function applyImportCollectionGuards(
+  content: Record<string, unknown>,
+  metadata: ResumeImportMetadata,
+  source: string,
+): Record<string, unknown> {
+  if (!isBrowserExtensionGenerated(metadata)) return content;
+  const guardSourceKey = resolveCollectionGuardSourceKey(source);
+  if (!guardSourceKey) return content;
+  const guardFields = COLLECTION_GUARDS[guardSourceKey] ?? [];
+  return applyCollectionGuards(content, guardFields);
+}
+
 export function normalizeResumeImportPayload(input: ResumeImportRequest): NormalizedResumeImportPayload {
   const parsedInput = ResumeImportRequestSchema.parse(input);
   const metadata = normalizeImportMetadata(parsedInput.metadata);
@@ -397,10 +424,13 @@ export function normalizeResumeImportPayload(input: ResumeImportRequest): Normal
   const convexResumes = resumes.map((resume) => {
     const itemSource = normalizeSourceHost(resume.sourceHost) ?? source;
     const itemTags = normalizeTagList(resume.tags) ?? defaultTags;
-    const content: unknown = buildNormalizedResumeContent(
+    const normalizedContent = buildNormalizedResumeContent(
       resume,
       isSeekSource ? { sourceHost: itemSource, jobId: seekJobId } : undefined,
     );
+    const content = isRecord(normalizedContent)
+      ? applyImportCollectionGuards(normalizedContent, metadata, itemSource)
+      : normalizedContent;
     const hash = crypto.createHash("sha256").update(stableStringify(content), "utf8").digest("hex");
     const externalId = buildResumeExternalId(resume, itemSource, hash);
 

--- a/apps/browser-extension/content.js
+++ b/apps/browser-extension/content.js
@@ -3251,6 +3251,17 @@
       getPaginationInfo: getPaginationInfo2,
       asHTMLElement: asHTMLElement2
     } = deps;
+    const GUARD_FIELD_NAMES2 = /* @__PURE__ */ new Set([
+      "experience",
+      "jobIntention",
+      "selfIntro",
+      "expectedSalary",
+      "workHistory",
+      "profileEducation",
+      "projectExperience",
+      "skills",
+      "licences"
+    ]);
     const GUARD_ARRAY_FIELD_NAMES3 = /* @__PURE__ */ new Set([
       "workHistory",
       "profileEducation",
@@ -3287,7 +3298,7 @@
       if (!csv || typeof csv !== "string") return [];
       return Array.from(
         new Set(
-          csv.split(",").map((field) => field.trim()).filter((field) => GUARD_ARRAY_FIELD_NAMES3.has(field))
+          csv.split(",").map((field) => field.trim()).filter((field) => GUARD_FIELD_NAMES2.has(field))
         )
       );
     }
@@ -3788,7 +3799,10 @@
       waitForPageTransition: waitForPageTransition2,
       buildSubmitMetadata: buildSubmitMetadata2,
       delay: delay2,
-      document: doc
+      document: doc,
+      loadCollectionGuards: loadCollectionGuards2,
+      parseGuardFieldNames: parseGuardFieldNames2,
+      applyCollectionGuards: applyCollectionGuards2
     } = deps;
     function getApiSnapshotCount2() {
       if (Array.isArray(apiSnapshot2.searchRows)) {
@@ -3961,6 +3975,18 @@
       }
     }
     __name(updateApiSnapshot2, "updateApiSnapshot");
+    async function applySourceCollectionGuards(resumes, sourceKey) {
+      if (!Array.isArray(resumes) || resumes.length === 0) return resumes;
+      if (sourceKey !== SOURCE_KEYS2.JOB51 && sourceKey !== SOURCE_KEYS2.JOB5156 && sourceKey !== SOURCE_KEYS2.SEEK) {
+        return resumes;
+      }
+      const collectionGuards = await loadCollectionGuards2();
+      const guards = collectionGuards && typeof collectionGuards === "object" ? collectionGuards[sourceKey] : void 0;
+      const guardFields = parseGuardFieldNames2(typeof guards === "string" ? guards : "");
+      if (guardFields.length === 0) return resumes;
+      return resumes.map((resume) => applyCollectionGuards2(resume, guardFields));
+    }
+    __name(applySourceCollectionGuards, "applySourceCollectionGuards");
     async function collectSnapshotPayload2(options = {}) {
       const { limit, maxPages, allowEmpty } = normalizeSnapshotCollectOptions2(options);
       const sourceKey = getCurrentSourceKey2();
@@ -4024,6 +4050,7 @@
         if (sourceKey === SOURCE_KEYS2.SEEK && !isSeekProfileMode2() && pageResumes.length > 0) {
           pageResumes = await enrichSeekResumesWithDetail2(pageResumes);
         }
+        pageResumes = await applySourceCollectionGuards(pageResumes, sourceKey);
         lastPageResumeCount = pageResumes.length;
         if (pageResumes.length > 0) {
           collectedResumes.push(...pageResumes);
@@ -4142,7 +4169,10 @@
       buildExportMetadata: buildExportMetadata2,
       buildExportFilename: buildExportFilename2,
       document: doc,
-      window: win
+      window: win,
+      loadCollectionGuards: loadCollectionGuards2,
+      parseGuardFieldNames: parseGuardFieldNames2,
+      applyCollectionGuards: applyCollectionGuards2
     } = deps;
     function setAutoAgeAttributes2(status, minAge, maxAge) {
       try {
@@ -5103,6 +5133,19 @@
       }
     }
     __name(runAutoExportIfEnabled2, "runAutoExportIfEnabled");
+    async function applyCurrentSourceCollectionGuards(resumes) {
+      if (!Array.isArray(resumes) || resumes.length === 0) return resumes;
+      const sourceKey = getCurrentSourceKey2();
+      if (sourceKey !== SOURCE_KEYS2.JOB51 && sourceKey !== SOURCE_KEYS2.JOB5156 && sourceKey !== SOURCE_KEYS2.SEEK) {
+        return resumes;
+      }
+      const collectionGuards = await loadCollectionGuards2();
+      const guards = collectionGuards && typeof collectionGuards === "object" ? collectionGuards[sourceKey] : void 0;
+      const guardFields = parseGuardFieldNames2(typeof guards === "string" ? guards : "");
+      if (guardFields.length === 0) return resumes;
+      return resumes.map((resume) => applyCollectionGuards2(resume, guardFields));
+    }
+    __name(applyCurrentSourceCollectionGuards, "applyCurrentSourceCollectionGuards");
     async function syncCurrentPageToServer2(resumesOverride) {
       let resumes = Array.isArray(resumesOverride) ? resumesOverride : extractResumes2();
       const shouldEnrichFromCurrentPage = !Array.isArray(resumesOverride);
@@ -5115,6 +5158,7 @@
       if (shouldEnrichFromCurrentPage && getCurrentSourceKey2() === SOURCE_KEYS2.SEEK && !isSeekProfileMode2() && resumes.length > 0) {
         resumes = await enrichSeekResumesWithDetail2(resumes);
       }
+      resumes = await applyCurrentSourceCollectionGuards(resumes);
       const metadata = buildSubmitMetadata2({
         seekCaptureMode: Array.isArray(resumesOverride) && win.location.pathname.includes("/candidates/recommended") ? "graphql-list" : void 0
       });
@@ -7595,7 +7639,10 @@
     waitForPageTransition,
     buildSubmitMetadata,
     delay,
-    document
+    document,
+    loadCollectionGuards,
+    parseGuardFieldNames,
+    applyCollectionGuards
   });
   var {
     updateApiSnapshot,
@@ -7645,7 +7692,10 @@
     buildExportMetadata,
     buildExportFilename,
     document,
-    window
+    window,
+    loadCollectionGuards,
+    parseGuardFieldNames,
+    applyCollectionGuards
   });
   var {
     findAgeFilterBlock,

--- a/apps/browser-extension/src/content.ts
+++ b/apps/browser-extension/src/content.ts
@@ -674,6 +674,9 @@ const _snapshotCollector = createSnapshotCollector({
   buildSubmitMetadata,
   delay: delay as (ms: number) => Promise<void>,
   document,
+  loadCollectionGuards: loadCollectionGuards as () => Promise<Record<string, unknown>>,
+  parseGuardFieldNames: parseGuardFieldNames as unknown as (csv: string) => string[],
+  applyCollectionGuards: applyCollectionGuards as (resume: unknown, fields: string[]) => unknown,
 });
 const {
   updateApiSnapshot,
@@ -725,6 +728,9 @@ const _autoActions = createAutoActions({
   buildExportFilename,
   document,
   window,
+  loadCollectionGuards: loadCollectionGuards as () => Promise<Record<string, unknown>>,
+  parseGuardFieldNames: parseGuardFieldNames as unknown as (csv: string) => string[],
+  applyCollectionGuards: applyCollectionGuards as (resume: unknown, fields: string[]) => unknown,
 });
 const {
   findAgeFilterBlock,

--- a/apps/browser-extension/src/lib/__tests__/auto-actions.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/auto-actions.test.ts
@@ -50,6 +50,21 @@ function createMockDeps(overrides: Record<string, unknown> = {}): AutoActionsDep
     document,
     window: window as unknown as Window,
     chrome: { runtime: { sendMessage: vi.fn(), getManifest: vi.fn(() => ({ version: "1.0.0" })) } } as unknown as AutoActionsDeps["chrome"],
+    loadCollectionGuards: vi.fn(async () => ({
+      job5156: "experience,jobIntention,selfIntro",
+      "51job": "experience,jobIntention,selfIntro",
+      seek: "experience,jobIntention,selfIntro",
+    })),
+    parseGuardFieldNames: vi.fn((csv: string) =>
+      csv ? csv.split(",").map((f) => f.trim()).filter(Boolean) : [],
+    ),
+    applyCollectionGuards: vi.fn((resume: unknown, fields: string[]) => {
+      if (!resume || typeof resume !== "object") return resume;
+      const guarded = { ...(resume as Record<string, unknown>) };
+      const arrayFields = new Set(["workHistory", "profileEducation", "projectExperience", "skills", "licences"]);
+      for (const field of fields) guarded[field] = arrayFields.has(field) ? [] : "";
+      return guarded;
+    }),
     ...overrides,
   } as AutoActionsDeps;
 }
@@ -228,6 +243,68 @@ describe("auto-actions", () => {
       vi.stubGlobal("chrome", {});
       const actions = createAutoActions(createMockDeps());
       expect(actions.getExtensionVersion()).toBe("unknown");
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe("syncCurrentPageToServer", () => {
+    it("guards resume overrides before sending them to the server", async () => {
+      const sendMessage = vi.fn(async () => ({ success: true }));
+      vi.stubGlobal("chrome", { runtime: { sendMessage, getManifest: vi.fn(() => ({ version: "1.0.0" })) } });
+      const actions = createAutoActions(createMockDeps({
+        getCurrentSourceKey: vi.fn(() => SOURCE_KEYS.JOB5156),
+      }));
+
+      await actions.syncCurrentPageToServer([
+        {
+          name: "Alice",
+          experience: "8 years",
+          jobIntention: "Sales Engineer",
+          selfIntro: "Sensitive free text",
+        },
+      ]);
+
+      expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({
+        action: "syncToServer",
+        resumes: [
+          expect.objectContaining({
+            name: "Alice",
+            experience: "",
+            jobIntention: "",
+            selfIntro: "",
+          }),
+        ],
+      }));
+      vi.unstubAllGlobals();
+    });
+
+    it("guards resumes after current-page detail enrichment", async () => {
+      const sendMessage = vi.fn(async () => ({ success: true }));
+      vi.stubGlobal("chrome", { runtime: { sendMessage, getManifest: vi.fn(() => ({ version: "1.0.0" })) } });
+      const actions = createAutoActions(createMockDeps({
+        getCurrentSourceKey: vi.fn(() => SOURCE_KEYS.JOB5156),
+        extractResumes: vi.fn(() => [{ name: "Alice", experience: "", jobIntention: "", selfIntro: "" }]),
+        enrichJob5156SearchResumesWithDetail: vi.fn(async () => [
+          {
+            name: "Alice",
+            experience: "8 years",
+            jobIntention: "Sales Engineer",
+            selfIntro: "Sensitive free text",
+          },
+        ]),
+      }));
+
+      await actions.syncCurrentPageToServer(undefined);
+
+      expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({
+        resumes: [
+          expect.objectContaining({
+            experience: "",
+            jobIntention: "",
+            selfIntro: "",
+          }),
+        ],
+      }));
       vi.unstubAllGlobals();
     });
   });

--- a/apps/browser-extension/src/lib/__tests__/extraction-pipeline.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/extraction-pipeline.test.ts
@@ -76,6 +76,21 @@ describe("extraction-pipeline", () => {
       expect(result).toContain("licences");
     });
 
+    it("parses valid scalar and array guard field names", () => {
+      const pipeline = createExtractionPipeline(createMockDeps());
+      const result = pipeline.parseGuardFieldNames(
+        "workHistory,skills,experience,jobIntention,selfIntro,licences",
+      );
+      expect(result).toEqual([
+        "workHistory",
+        "skills",
+        "experience",
+        "jobIntention",
+        "selfIntro",
+        "licences",
+      ]);
+    });
+
     it("ignores invalid field names", () => {
       const pipeline = createExtractionPipeline(createMockDeps());
       const result = pipeline.parseGuardFieldNames("workHistory,invalidField,skills");
@@ -184,8 +199,48 @@ describe("extraction-pipeline", () => {
       });
       const pipeline = createExtractionPipeline(deps);
 
-      expect(pipeline.extractResumes()).toEqual(fallbackResumes);
+      // Default guards apply experience="" because mock DEFAULT_COLLECTION_GUARDS
+      // includes "experience" for seek — verify guards are applied
+      expect(pipeline.extractResumes()).toEqual([
+        { name: "Candidate One", experience: "", source: "seek" },
+      ]);
       expect(deps.extractSeekResumes).toHaveBeenCalled();
+    });
+
+    it("applies default scalar guards to extracted resumes", () => {
+      const fallbackResumes = [
+        {
+          name: "Candidate One",
+          experience: "5 years",
+          jobIntention: "Sales Engineer",
+          selfIntro: "Detailed intro",
+          source: "seek",
+        },
+      ];
+      const deps = createMockDeps({
+        getCurrentSourceKey: vi.fn(() => SOURCE_KEYS.SEEK),
+        DEFAULT_COLLECTION_GUARDS: {
+          job5156: "experience,jobIntention,selfIntro",
+          "51job": "experience,jobIntention,selfIntro",
+          seek: "experience,jobIntention,selfIntro",
+        },
+        isSeekProfileMode: vi.fn(() => false),
+        hasSeekProfileSnapshot: vi.fn(() => false),
+        hasSeekTalentSearchSnapshot: vi.fn(() => false),
+        hasSeekListSnapshot: vi.fn(() => false),
+        extractSeekResumes: vi.fn(() => fallbackResumes),
+      });
+      const pipeline = createExtractionPipeline(deps);
+
+      expect(pipeline.extractResumes()).toEqual([
+        {
+          name: "Candidate One",
+          experience: "",
+          jobIntention: "",
+          selfIntro: "",
+          source: "seek",
+        },
+      ]);
     });
   });
 

--- a/apps/browser-extension/src/lib/__tests__/snapshot-collector.test.ts
+++ b/apps/browser-extension/src/lib/__tests__/snapshot-collector.test.ts
@@ -55,6 +55,21 @@ function createMockDeps(overrides: Record<string, unknown> = {}): SnapshotCollec
     waitForPageTransition: vi.fn(() => Promise.resolve()),
     buildSubmitMetadata: vi.fn(() => ({})),
     delay: vi.fn(() => Promise.resolve()),
+    loadCollectionGuards: vi.fn(async () => ({
+      job5156: "experience,jobIntention,selfIntro",
+      "51job": "experience,jobIntention,selfIntro",
+      seek: "experience,jobIntention,selfIntro",
+    })),
+    parseGuardFieldNames: vi.fn((csv: string) =>
+      csv ? csv.split(",").map((f) => f.trim()).filter(Boolean) : [],
+    ),
+    applyCollectionGuards: vi.fn((resume: unknown, fields: string[]) => {
+      if (!resume || typeof resume !== "object") return resume;
+      const guarded = { ...(resume as Record<string, unknown>) };
+      const arrayFields = new Set(["workHistory", "profileEducation", "projectExperience", "skills", "licences"]);
+      for (const field of fields) guarded[field] = arrayFields.has(field) ? [] : "";
+      return guarded;
+    }),
     document: {
       documentElement: {
         hasAttribute: vi.fn(() => false),
@@ -396,6 +411,45 @@ describe("snapshot-collector", () => {
       expect(result.resumes).toEqual(mockResumes);
       expect(result.summary.count).toBe(2);
       expect(result.metadata.totalResumes).toBe(2);
+    });
+
+    it("guards job5156 snapshot rows after detail enrichment", async () => {
+      const collector = createSnapshotCollector(createMockDeps({
+        getCurrentSourceKey: vi.fn(() => "job5156"),
+        extractResumes: vi.fn(() => [
+          { name: "Alice", experience: "", jobIntention: "", selfIntro: "" },
+        ]),
+        enrichJob5156SearchResumesWithDetail: vi.fn(async () => [
+          {
+            name: "Alice",
+            experience: "8 years",
+            jobIntention: "Sales Engineer",
+            selfIntro: "Sensitive free text",
+          },
+        ]),
+        getPaginationInfo: vi.fn(() => ({
+          currentPage: 1,
+          totalPages: 1,
+          totalItems: 1,
+          hasNextPage: false,
+        })),
+        buildSubmitMetadata: vi.fn(() => ({
+          sourceKey: "job5156",
+          sourceHost: "hr.job5156.com",
+          generatedBy: "browser-extension@1.0.0",
+        })),
+      }));
+
+      const payload = await collector.collectSnapshotPayload({ limit: 1 });
+
+      expect(payload.resumes).toEqual([
+        expect.objectContaining({
+          name: "Alice",
+          experience: "",
+          jobIntention: "",
+          selfIntro: "",
+        }),
+      ]);
     });
   });
 });

--- a/apps/browser-extension/src/lib/auto-actions.ts
+++ b/apps/browser-extension/src/lib/auto-actions.ts
@@ -41,6 +41,9 @@ export interface AutoActionsDeps extends Record<string, unknown> {
   enrichJob5156SearchResumesWithDetail: (resumes: unknown[]) => Promise<unknown[]>;
   enrichSeekResumesWithDetail: (resumes: unknown[]) => Promise<unknown[]>;
   buildSubmitMetadata: (options?: Record<string, unknown>) => Record<string, unknown>;
+  loadCollectionGuards: () => Promise<Record<string, unknown>>;
+  parseGuardFieldNames: (csv: string) => string[];
+  applyCollectionGuards: (resume: unknown, fields: string[]) => unknown;
   AUTO_EXPORT_PARAM: string;
   AUTO_SYNC_PARAM: string;
   buildExportMetadata: (resumes: unknown[]) => Record<string, unknown>;
@@ -92,6 +95,9 @@ export function createAutoActions(deps: AutoActionsDeps) {
     buildExportFilename,
     document: doc,
     window: win,
+    loadCollectionGuards,
+    parseGuardFieldNames,
+    applyCollectionGuards,
   } = deps;
 
   // ── setAutoAgeAttributes ──
@@ -1280,6 +1286,26 @@ export function createAutoActions(deps: AutoActionsDeps) {
 
   // ── syncCurrentPageToServer ──
 
+  async function applyCurrentSourceCollectionGuards(resumes: unknown[]): Promise<unknown[]> {
+    if (!Array.isArray(resumes) || resumes.length === 0) return resumes;
+    const sourceKey = getCurrentSourceKey();
+    if (
+      sourceKey !== SOURCE_KEYS.JOB51 &&
+      sourceKey !== SOURCE_KEYS.JOB5156 &&
+      sourceKey !== SOURCE_KEYS.SEEK
+    ) {
+      return resumes;
+    }
+    const collectionGuards = await loadCollectionGuards();
+    const guards =
+      collectionGuards && typeof collectionGuards === "object"
+        ? (collectionGuards as Record<string, unknown>)[sourceKey]
+        : undefined;
+    const guardFields = parseGuardFieldNames(typeof guards === "string" ? guards : "");
+    if (guardFields.length === 0) return resumes;
+    return resumes.map((resume) => applyCollectionGuards(resume, guardFields));
+  }
+
   async function syncCurrentPageToServer(resumesOverride) {
     let resumes = Array.isArray(resumesOverride)
       ? resumesOverride
@@ -1309,6 +1335,7 @@ export function createAutoActions(deps: AutoActionsDeps) {
     ) {
       resumes = await enrichSeekResumesWithDetail(resumes);
     }
+    resumes = await applyCurrentSourceCollectionGuards(resumes);
     const metadata = buildSubmitMetadata({
       seekCaptureMode:
         Array.isArray(resumesOverride) &&

--- a/apps/browser-extension/src/lib/extraction-pipeline.ts
+++ b/apps/browser-extension/src/lib/extraction-pipeline.ts
@@ -104,6 +104,18 @@ export function createExtractionPipeline(deps: ExtractionPipelineDeps) {
 
   // --- Collection guards ---
 
+  const GUARD_FIELD_NAMES = new Set([
+    "experience",
+    "jobIntention",
+    "selfIntro",
+    "expectedSalary",
+    "workHistory",
+    "profileEducation",
+    "projectExperience",
+    "skills",
+    "licences",
+  ]);
+
   const GUARD_ARRAY_FIELD_NAMES = new Set([
     "workHistory",
     "profileEducation",
@@ -147,7 +159,7 @@ export function createExtractionPipeline(deps: ExtractionPipelineDeps) {
         csv
           .split(",")
           .map((field) => field.trim())
-          .filter((field) => GUARD_ARRAY_FIELD_NAMES.has(field)),
+          .filter((field) => GUARD_FIELD_NAMES.has(field)),
       ),
     );
   }

--- a/apps/browser-extension/src/lib/snapshot-collector.ts
+++ b/apps/browser-extension/src/lib/snapshot-collector.ts
@@ -29,6 +29,9 @@ export interface SnapshotCollectorDeps extends Record<string, unknown> {
   isJob5156DetailPage: () => boolean;
   enrichSeekResumesWithDetail: (resumes: unknown[]) => Promise<unknown[]>;
   getPaginationInfo: () => { currentPage: number; totalPages: number; totalItems: number; hasNextPage: boolean };
+  loadCollectionGuards: () => Promise<Record<string, unknown>>;
+  parseGuardFieldNames: (csv: string) => string[];
+  applyCollectionGuards: (resume: unknown, fields: string[]) => unknown;
   isSeekAutoSyncPageWindowReached: (pageWindow: unknown, currentPage: number) => boolean;
   waitForPagination: (options?: unknown) => Promise<unknown>;
   clearCapturedResultsForNextPage: () => void;
@@ -74,6 +77,9 @@ export function createSnapshotCollector(deps: SnapshotCollectorDeps) {
     buildSubmitMetadata,
     delay,
     document: doc,
+    loadCollectionGuards,
+    parseGuardFieldNames,
+    applyCollectionGuards,
   } = deps;
 
   // ── getApiSnapshotCount ──
@@ -283,6 +289,25 @@ export function createSnapshotCollector(deps: SnapshotCollectorDeps) {
 
   // ── collectSnapshotPayload ──
 
+  async function applySourceCollectionGuards(resumes: unknown[], sourceKey: string): Promise<unknown[]> {
+    if (!Array.isArray(resumes) || resumes.length === 0) return resumes;
+    if (
+      sourceKey !== SOURCE_KEYS.JOB51 &&
+      sourceKey !== SOURCE_KEYS.JOB5156 &&
+      sourceKey !== SOURCE_KEYS.SEEK
+    ) {
+      return resumes;
+    }
+    const collectionGuards = await loadCollectionGuards();
+    const guards =
+      collectionGuards && typeof collectionGuards === "object"
+        ? (collectionGuards as Record<string, unknown>)[sourceKey]
+        : undefined;
+    const guardFields = parseGuardFieldNames(typeof guards === "string" ? guards : "");
+    if (guardFields.length === 0) return resumes;
+    return resumes.map((resume) => applyCollectionGuards(resume, guardFields));
+  }
+
   /**
    * @param {{
    *   limit?: number;
@@ -398,6 +423,8 @@ export function createSnapshotCollector(deps: SnapshotCollectorDeps) {
       ) {
         pageResumes = await enrichSeekResumesWithDetail(pageResumes);
       }
+
+      pageResumes = await applySourceCollectionGuards(pageResumes, sourceKey);
 
       lastPageResumeCount = pageResumes.length;
       if (pageResumes.length > 0) {

--- a/packages/shared/src/collection-guards.ts
+++ b/packages/shared/src/collection-guards.ts
@@ -14,6 +14,14 @@ export const COLLECTION_GUARDS: Record<string, string[]> = {
   seek: ["experience", "jobIntention", "selfIntro"],
 };
 
+export const COLLECTION_GUARD_ARRAY_FIELD_NAMES = new Set([
+  "workHistory",
+  "profileEducation",
+  "projectExperience",
+  "skills",
+  "licences",
+]);
+
 export function applyCollectionGuards(
   resume: Record<string, unknown>,
   guardFields: string[],
@@ -21,7 +29,7 @@ export function applyCollectionGuards(
   if (!guardFields.length) return resume;
   const guarded = { ...resume };
   for (const field of guardFields) {
-    guarded[field] = "";
+    guarded[field] = COLLECTION_GUARD_ARRAY_FIELD_NAMES.has(field) ? [] : "";
   }
   return guarded;
 }


### PR DESCRIPTION
## Summary
- Fixes `parseGuardFieldNames` bug where scalar guard fields (experience, jobIntention, selfIntro) were filtered out by the `GUARD_ARRAY_FIELD_NAMES` allowlist, so guards never applied
- Adds final guard boundaries after every post-extract enrichment path in auto-actions and snapshot-collector
- Adds BFF defense-in-depth that strips guarded fields for `browser-extension` generated import/submit payloads only (manual restore/import payloads preserve their fields)
- Updates shared `applyCollectionGuards` to handle array fields correctly (clears to `[]` instead of `""`)

## Files changed
| File | Change |
|------|--------|
| `extraction-pipeline.ts` | Fix: `GUARD_FIELD_NAMES` allowlist + scalar guard parsing |
| `auto-actions.ts` | Add `applyCurrentSourceCollectionGuards` helper after enrichment |
| `snapshot-collector.ts` | Add `applySourceCollectionGuards` helper after enrichment |
| `collection-guards.ts` (shared) | Add `COLLECTION_GUARD_ARRAY_FIELD_NAMES`, array-safe clearing |
| `resume-import-service.ts` | BFF defense-in-depth for browser-extension payloads |
| `content.ts` | Wire new guard dependencies to both factory calls |
| `content.js` | Rebuilt MV3 bundle |
| Test files (4) | +4 new tests, mock guard fidelity improvements |

## Test plan
- [x] 156 tests pass (6 test files): collection-guards, extraction-pipeline, auto-actions, auto-sync-runner, snapshot-collector, resume-import-service
- [x] `make check` passes
- [x] content.js bundle rebuilt and committed
- [ ] Manual verification: fresh job5156 collection with guarded fields