### PR TITLE
feat: resume digest architecture for AND-mode first-load latency

### DIFF
--- a/apps/api/src/routes/__tests__/bff-filter-alignment.test.ts
+++ b/apps/api/src/routes/__tests__/bff-filter-alignment.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { bffMatchesResumeFilters } from "../../services/bff-filter-utils.js";
+import { matchesResumeDigestFilters, type DigestRecord } from "@trends/shared";
 
 function makeDoc(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -315,6 +316,50 @@ describe("bffMatchesResumeFilters", () => {
     it("excludes when no location matches", () => {
       const doc = makeDoc({ content: { location: "深圳" } });
       expect(bffMatchesResumeFilters(doc, "", { locations: ["东莞"] })).toBe(false);
+    });
+  });
+
+  describe("digest/full-doc filter parity", () => {
+    it("keeps digest filter semantics aligned for the CNC sales restored-dataset filter set", () => {
+      const doc = {
+        isArchived: false,
+        source: "job5156",
+        sourceKey: "job5156",
+        age: 30,
+        content: {
+          education: "本科",
+          expectedSalary: "15K-25K",
+          locationHierarchy: { country: "中国", province: "广东", city: "东莞" },
+          workHistory: [{ raw: "销售工程师 CNC 数控机床渠道开发" }],
+        },
+        ingestData: {
+          verifiedRoleYears: { sales: 3 },
+          roleSignals: [{ type: "sales", years: 3 }],
+        },
+      };
+      const digest: DigestRecord = {
+        isArchived: false,
+        source: "job5156",
+        sourceKey: "job5156",
+        age: 30,
+        locationText: "中国 广东 东莞",
+        educationLevel: "bachelor",
+        salaryMin: 15,
+        salaryMax: 25,
+        roleTypes: ["sales"],
+        roleYearsByType: { sales: 3 },
+        searchText: "cnc 销售 数控 机床 渠道",
+      };
+      const filters = {
+        minRoleYears: 1,
+        roleFilterType: "sales",
+        minAge: 25,
+        maxAge: 40,
+        locations: ["China"],
+      };
+
+      expect(matchesResumeDigestFilters(digest, filters)).toBe(true);
+      expect(bffMatchesResumeFilters(doc, digest.searchText, filters)).toBe(true);
     });
   });
 });

--- a/apps/api/src/routes/resumes.search-integration.test.ts
+++ b/apps/api/src/routes/resumes.search-integration.test.ts
@@ -7,14 +7,14 @@
  * The real keyword expansion service (unifiedSearchService.expandKeyword)
  * determines AND vs OR mode. In the test environment:
  * - Single-keyword "CNC" → 1 group → effectively AND (all 1 group must match)
- * - Multi-keyword "CNC 销售" → 2 groups → AND mode → scanResumePageSlim path
+ * - Multi-keyword "CNC 销售" → 2 groups → AND mode → scanResumeDigestPage path
  *
  * Uses mocked fetch to intercept Convex HTTP calls and validates:
  * - Correct query path selection
  * - Pagination cursor propagation
  * - Filter parameter passthrough
  * - Empty result handling
- * - Byte-limit safety (scanResumePageSlim batch size)
+ * - Byte-limit safety (scanResumeDigestPage batch size)
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -85,35 +85,17 @@ function buildConvexResumeRecord(
     };
 }
 
-/**
- * Creates a mock fetch that handles the AND-mode scan path:
- * - scanResumePageSlim returns matching slim docs
- * - getResumeDocsByIds returns full docs for matches
- */
-function mockAndModeScanPath(slimDocs: Array<{ _id: string; searchText: string }>) {
-    const fullDocs = slimDocs.map((d) => buildConvexResumeRecord(d._id, { searchText: d.searchText }));
-    return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const call = parseConvexCall(input, init);
-
-        if (call.pathName === "resumes_search:scanResumePageSlim") {
-            return convexSuccess({
-                docs: slimDocs.map((d) => ({
-                    _id: d._id,
-                    source: "seek",
-                    searchText: d.searchText,
-                    isArchived: false,
-                    primaryRuleScore: 0,
-                    age: 30,
-                })),
-                isDone: true,
-                cursor: null,
-            });
-        }
-        if (call.pathName === "resumes_search:getResumeDocsByIds") {
-            const ids = call.args.ids as string[];
-            return convexSuccess(fullDocs.filter((d) => ids.includes(d._id)));
-        }
-        throw new Error(`Unexpected convex path: ${call.pathName}`);
+function buildDigestRow(resumeId: string, overrides: Record<string, unknown> = {}) {
+    return {
+        _id: `digest-${resumeId}`,
+        resumeId,
+        source: "seek",
+        sourceKey: "seek",
+        searchText: "cnc 销售工程师",
+        isArchived: false,
+        primaryRuleScore: 0,
+        age: 30,
+        ...overrides,
     };
 }
 
@@ -124,15 +106,15 @@ describe("BFF search dispatcher integration", () => {
         vi.restoreAllMocks();
     });
 
-    describe("AND-mode path (scanResumePageSlim → getResumeDocsByIds)", () => {
-        it("dispatches scanResumePageSlim for multi-keyword AND search", async () => {
+    describe("AND-mode path (scanResumeDigestPage → getResumeDocsByIds)", () => {
+        it("dispatches scanResumeDigestPage for multi-keyword AND search", async () => {
             const calls: ConvexCall[] = [];
             vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
                 const call = parseConvexCall(input, init);
                 calls.push(call);
-                if (call.pathName === "resumes_search:scanResumePageSlim") {
+                if (call.pathName === "resumes_search:scanResumeDigestPage") {
                     return convexSuccess({
-                        docs: [{ _id: "r1", source: "seek", searchText: "cnc 销售工程师", isArchived: false, primaryRuleScore: 0, age: 30 }],
+                        docs: [buildDigestRow("r1", { searchText: "cnc 销售工程师" })],
                         isDone: true,
                         cursor: null,
                     });
@@ -151,9 +133,9 @@ describe("BFF search dispatcher integration", () => {
             expect(payload.success).toBe(true);
             expect(payload.summary.source).toBe("convex");
 
-            // AND-mode triggers scanResumePageSlim
-            const slimCalls = calls.filter((c) => c.pathName === "resumes_search:scanResumePageSlim");
-            expect(slimCalls.length).toBeGreaterThan(0);
+            // AND-mode triggers scanResumeDigestPage
+            const digestCalls = calls.filter((c) => c.pathName === "resumes_search:scanResumeDigestPage");
+            expect(digestCalls.length).toBeGreaterThan(0);
 
             // Followed by getResumeDocsByIds for matches
             const docCalls = calls.filter((c) => c.pathName === "resumes_search:getResumeDocsByIds");
@@ -166,11 +148,11 @@ describe("BFF search dispatcher integration", () => {
                 const call = parseConvexCall(input, init);
                 calls.push(call);
 
-                if (call.pathName === "resumes_search:scanResumePageSlim") {
+                if (call.pathName === "resumes_search:scanResumeDigestPage") {
                     return convexSuccess({
                         docs: [
-                            { _id: "r1", source: "seek", searchText: "cnc 销售工程师", isArchived: false, primaryRuleScore: 0, age: 30 },
-                            { _id: "r2", source: "seek", searchText: "java 开发", isArchived: false, primaryRuleScore: 0, age: 25 },
+                            buildDigestRow("r1", { searchText: "cnc 销售工程师" }),
+                            buildDigestRow("r2", { searchText: "java 开发" }),
                         ],
                         isDone: true,
                         cursor: null,
@@ -193,12 +175,12 @@ describe("BFF search dispatcher integration", () => {
             expect(allIds).not.toContain("r2");
         });
 
-        it("caps scanResumePageSlim numItems to bounded value", async () => {
+        it("caps scanResumeDigestPage numItems to bounded value", async () => {
             const calls: ConvexCall[] = [];
             vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
                 const call = parseConvexCall(input, init);
                 calls.push(call);
-                if (call.pathName === "resumes_search:scanResumePageSlim") {
+                if (call.pathName === "resumes_search:scanResumeDigestPage") {
                     return convexSuccess({ docs: [], isDone: true, cursor: null });
                 }
                 if (call.pathName === "resumes_search:getResumeDocsByIds") {
@@ -210,19 +192,19 @@ describe("BFF search dispatcher integration", () => {
             const app = createApp();
             await app.request("/api/resumes?source=convex&q=CNC%20销售&limit=5");
 
-            const slimCall = calls.find((c) => c.pathName === "resumes_search:scanResumePageSlim");
-            expect(slimCall).toBeDefined();
-            const numItems = slimCall!.args.numItems as number;
+            const digestCall = calls.find((c) => c.pathName === "resumes_search:scanResumeDigestPage");
+            expect(digestCall).toBeDefined();
+            const numItems = digestCall!.args.numItems as number;
             expect(numItems).toBeGreaterThan(0);
             expect(numItems).toBeLessThanOrEqual(1000);
         });
     });
 
-    describe("scanResumePageSlim scan path with empty results", () => {
+    describe("scanResumeDigestPage scan path with empty results", () => {
         it("returns empty data when no docs match AND-mode keywords", async () => {
             vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
                 const call = parseConvexCall(input, init);
-                if (call.pathName === "resumes_search:scanResumePageSlim") {
+                if (call.pathName === "resumes_search:scanResumeDigestPage") {
                     return convexSuccess({ docs: [], isDone: true, cursor: null });
                 }
                 if (call.pathName === "resumes_search:getResumeDocsByIds") {
@@ -247,7 +229,7 @@ describe("BFF search dispatcher integration", () => {
             vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
                 const call = parseConvexCall(input, init);
                 calls.push(call);
-                if (call.pathName === "resumes_search:scanResumePageSlim") {
+                if (call.pathName === "resumes_search:scanResumeDigestPage") {
                     return convexSuccess({ docs: [], isDone: true, cursor: null });
                 }
                 if (call.pathName === "resumes_search:getResumeDocsByIds") {
@@ -259,19 +241,84 @@ describe("BFF search dispatcher integration", () => {
             const app = createApp();
             await app.request("/api/resumes?source=convex&q=CNC%20销售&minAge=25&maxAge=40");
 
-            // Filters are applied BFF-side after scanResumePageSlim
-            const slimCalls = calls.filter((c) => c.pathName === "resumes_search:scanResumePageSlim");
-            expect(slimCalls.length).toBeGreaterThan(0);
+            // Filters are applied BFF-side after scanResumeDigestPage
+            const digestCalls = calls.filter((c) => c.pathName === "resumes_search:scanResumeDigestPage");
+            expect(digestCalls.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe("AND-mode digest-first path (scanResumeDigestPage → getResumeDocsByIds)", () => {
+        it("uses resume digest pages for multi-keyword AND search before fetching full records", async () => {
+            const calls: ConvexCall[] = [];
+            vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+                const call = parseConvexCall(input, init);
+                calls.push(call);
+                if (call.pathName === "resumes_search:scanResumeDigestPage") {
+                    return convexSuccess({
+                        docs: [
+                            {
+                                _id: "d1",
+                                resumeId: "r1",
+                                source: "job5156",
+                                sourceKey: "job5156",
+                                searchText: "cnc 销售 数控 销售工程师",
+                                isArchived: false,
+                                primaryRuleScore: 0,
+                                age: 30,
+                                locationText: "中国 广东 东莞",
+                                roleYearsByType: { sales: 3 },
+                                roleTypes: ["sales"],
+                            },
+                            {
+                                _id: "d2",
+                                resumeId: "r2",
+                                source: "job5156",
+                                sourceKey: "job5156",
+                                searchText: "cnc 操作 数控 操作工",
+                                isArchived: false,
+                                primaryRuleScore: 0,
+                                age: 30,
+                                locationText: "中国 广东 东莞",
+                                roleYearsByType: { operator: 4 },
+                                roleTypes: ["operator"],
+                            },
+                        ],
+                        isDone: true,
+                        cursor: null,
+                    });
+                }
+                if (call.pathName === "resumes_search:getResumeDocsByIds") {
+                    return convexSuccess([buildConvexResumeRecord("r1", { name: "Alice" })]);
+                }
+                if (call.pathName === "resumes_search:scanResumePageSlim") {
+                    throw new Error("AND-mode must not scan monolithic resume searchText pages");
+                }
+                throw new Error(`Unexpected convex path: ${call.pathName}`);
+            });
+
+            const app = createApp();
+            const response = await app.request(
+                "/api/resumes?source=convex&q=CNC%20销售&limit=5&minRoleYears=1&roleFilterType=sales&minAge=25&maxAge=40&locations=China",
+            );
+
+            expect(response.status).toBe(200);
+            const payload = await response.json();
+            expect(payload.success).toBe(true);
+
+            expect(calls.some((c) => c.pathName === "resumes_search:scanResumeDigestPage")).toBe(true);
+            expect(calls.some((c) => c.pathName === "resumes_search:scanResumePageSlim")).toBe(false);
+            const docCall = calls.find((c) => c.pathName === "resumes_search:getResumeDocsByIds");
+            expect(docCall?.args.ids).toEqual(["r1"]);
         });
     });
 
     describe("Byte-limit safety validation", () => {
-        it("scanResumePageSlim uses bounded batch size per call", async () => {
+        it("scanResumeDigestPage uses bounded batch size per call", async () => {
             const batchSizes: number[] = [];
             vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
                 const call = parseConvexCall(input, init);
 
-                if (call.pathName === "resumes_search:scanResumePageSlim") {
+                if (call.pathName === "resumes_search:scanResumeDigestPage") {
                     batchSizes.push(call.args.numItems as number);
                     return convexSuccess({ docs: [], isDone: true, cursor: null });
                 }

--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -287,8 +287,8 @@ describe("resume routes", () => {
       const call = parseConvexCall(input, init);
       calls.push(call);
 
-      // AND-mode queries use two-phase scan: phase 1 via scanResumePageSlim
-      if (call.pathName === "resumes_search:scanResumePageSlim") {
+      // AND-mode queries use two-phase scan: phase 1 via scanResumeDigestPage
+      if (call.pathName === "resumes_search:scanResumeDigestPage") {
         const cursor = typeof call.args.cursor === "string" ? call.args.cursor : null;
         // Phase 1: slim projection — only searchText and basic fields
         return convexSuccess({
@@ -296,8 +296,10 @@ describe("resume routes", () => {
             ? []
             : [
                 {
-                  _id: "resume-live-1",
+                  _id: "d1",
+                  resumeId: "resume-live-1",
                   source: "seek",
+                  sourceKey: "seek",
                   primaryRuleScore: 44,
                   searchText: "CNC 数值控制 销售 engineer fanuc",
                   isArchived: false,
@@ -356,7 +358,7 @@ describe("resume routes", () => {
       })
     );
     expect(calls[0]).toEqual(expect.objectContaining({
-      pathName: "resumes_search:scanResumePageSlim",
+      pathName: "resumes_search:scanResumeDigestPage",
     }));
   });
 
@@ -590,17 +592,17 @@ describe("resume routes", () => {
       const call = parseConvexCall(input, init);
       calls.push(call);
 
-      // AND-mode queries use two-phase scan: phase 1 via scanResumePageSlim
-      if (call.pathName === "resumes_search:scanResumePageSlim") {
+      // AND-mode queries use two-phase scan: phase 1 via scanResumeDigestPage
+      if (call.pathName === "resumes_search:scanResumeDigestPage") {
         const cursor = typeof call.args.cursor === "string" ? call.args.cursor : null;
         return convexSuccess({
           docs: cursor
             ? []
             : [
-                { _id: "resume-live-1", source: "seek", searchText: "cnc sales engineer", isArchived: false },
-                { _id: "resume-live-2", source: "seek", searchText: "cnc sales manager", isArchived: false },
-                { _id: "resume-live-3", source: "seek", searchText: "cnc sales director", isArchived: false },
-                { _id: "resume-live-4", source: "seek", searchText: "cnc sales vp", isArchived: false },
+                { _id: "d1", resumeId: "resume-live-1", source: "seek", sourceKey: "seek", searchText: "cnc sales engineer", isArchived: false },
+                { _id: "d2", resumeId: "resume-live-2", source: "seek", sourceKey: "seek", searchText: "cnc sales manager", isArchived: false },
+                { _id: "d3", resumeId: "resume-live-3", source: "seek", sourceKey: "seek", searchText: "cnc sales director", isArchived: false },
+                { _id: "d4", resumeId: "resume-live-4", source: "seek", sourceKey: "seek", searchText: "cnc sales vp", isArchived: false },
               ],
           isDone: !cursor,
           cursor: cursor ? null : "next-page",
@@ -633,7 +635,7 @@ describe("resume routes", () => {
     }));
     expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Dylan"]);
     expect(calls[0]).toEqual(expect.objectContaining({
-      pathName: "resumes_search:scanResumePageSlim",
+      pathName: "resumes_search:scanResumeDigestPage",
     }));
   });
 
@@ -644,15 +646,15 @@ describe("resume routes", () => {
       const call = parseConvexCall(input, init);
       calls.push(call);
 
-      // AND-mode queries use two-phase scan: phase 1 via scanResumePageSlim
-      if (call.pathName === "resumes_search:scanResumePageSlim") {
+      // AND-mode queries use two-phase scan: phase 1 via scanResumeDigestPage
+      if (call.pathName === "resumes_search:scanResumeDigestPage") {
         const cursor = typeof call.args.cursor === "string" ? call.args.cursor : null;
         return convexSuccess({
           docs: cursor
             ? []
             : [
-                { _id: "resume-live-3", source: "seek", searchText: "cnc sales director", isArchived: false },
-                { _id: "resume-live-4", source: "seek", searchText: "cnc sales vp", isArchived: false },
+                { _id: "d3", resumeId: "resume-live-3", source: "seek", sourceKey: "seek", searchText: "cnc sales director", isArchived: false },
+                { _id: "d4", resumeId: "resume-live-4", source: "seek", sourceKey: "seek", searchText: "cnc sales vp", isArchived: false },
               ],
           isDone: !cursor,
           cursor: cursor ? null : "next-page",
@@ -677,7 +679,7 @@ describe("resume routes", () => {
     const payload = await response.json();
     expect(payload.success).toBe(true);
     expect(calls[0]).toEqual(expect.objectContaining({
-      pathName: "resumes_search:scanResumePageSlim",
+      pathName: "resumes_search:scanResumeDigestPage",
     }));
   });
 
@@ -722,15 +724,15 @@ describe("resume routes", () => {
       const call = parseConvexCall(input, init);
       calls.push(call);
 
-      // AND-mode queries use two-phase scan: phase 1 via scanResumePageSlim
-      if (call.pathName === "resumes_search:scanResumePageSlim") {
+      // AND-mode queries use two-phase scan: phase 1 via scanResumeDigestPage
+      if (call.pathName === "resumes_search:scanResumeDigestPage") {
         const cursor = typeof call.args.cursor === "string" ? call.args.cursor : null;
         return convexSuccess({
           docs: cursor
             ? []
             : [
-                { _id: "resume-live-5", source: "hk.employer.seek.com", searchText: "machine tools precision machinery sales engineer", isArchived: false },
-                { _id: "resume-live-6", source: "hk.employer.seek.com", searchText: "precision machinery sales engineer account design", isArchived: false },
+                { _id: "d5", resumeId: "resume-live-5", source: "hk.employer.seek.com", sourceKey: "hk.employer.seek.com", searchText: "machine tools precision machinery sales engineer", isArchived: false },
+                { _id: "d6", resumeId: "resume-live-6", source: "hk.employer.seek.com", sourceKey: "hk.employer.seek.com", searchText: "precision machinery sales engineer account design", isArchived: false },
               ],
           isDone: !cursor,
           cursor: cursor ? null : "next-page",
@@ -767,7 +769,7 @@ describe("resume routes", () => {
       "Johnson Lee Wei Tao",
     ]);
     expect(calls[0]).toEqual(expect.objectContaining({
-      pathName: "resumes_search:scanResumePageSlim",
+      pathName: "resumes_search:scanResumeDigestPage",
     }));
   });
 
@@ -778,16 +780,18 @@ describe("resume routes", () => {
       const call = parseConvexCall(input, init);
       calls.push(call);
 
-      // AND-mode queries use two-phase scan: phase 1 via scanResumePageSlim
-      if (call.pathName === "resumes_search:scanResumePageSlim") {
+      // AND-mode queries use two-phase scan: phase 1 via scanResumeDigestPage
+      if (call.pathName === "resumes_search:scanResumeDigestPage") {
         const cursor = typeof call.args.cursor === "string" ? call.args.cursor : null;
         return convexSuccess({
           docs: cursor
             ? []
             : [
                 {
-                  _id: "resume-live-3",
+                  _id: "d3",
+                  resumeId: "resume-live-3",
                   source: "seek",
+                  sourceKey: "seek",
                   searchText: "cnc sales machine tools",
                   isArchived: false,
                 },
@@ -815,8 +819,8 @@ describe("resume routes", () => {
     const response = await app.request("/api/resumes?source=convex&q=cnc%20sales&limit=2&requiredKeywords=machine%20tools,CNC");
 
     expect(response.status).toBe(200);
-    // AND-mode now uses scanResumePageSlim instead of the action
-    expect(calls.some((c) => c.pathName === "resumes_search:scanResumePageSlim")).toBe(true);
+    // AND-mode now uses scanResumeDigestPage instead of the action
+    expect(calls.some((c) => c.pathName === "resumes_search:scanResumeDigestPage")).toBe(true);
     // Required keywords are applied as local filters in BFF AND-mode path
     const payload = await response.json();
     expect(payload.success).toBe(true);

--- a/apps/api/src/services/resume-candidate-prep.ts
+++ b/apps/api/src/services/resume-candidate-prep.ts
@@ -523,11 +523,13 @@ export async function prepareConvexCandidates(params: {
         loweredVariants: g.variants.map((v: string) => v.toLowerCase()),
       }));
 
-      // Phase 1: Scan all docs with slim projection (no content/ingestData).
-      // Only collect IDs of docs matching keyword groups + basic filters.
+      // Phase 1: Scan digest pages (lightweight, <1KB per row) for candidate
+      // discovery. Digest rows are pre-built from resume fields at ingest and
+      // backfill time, so the Convex query avoids the monolithic ~27KB searchText
+      // transfer that dominated the old scanResumePageSlim path.
       const matchingIds: string[] = [];
       while (true) {
-        const page = await callConvexQuery("resumes_search:scanResumePageSlim", {
+        const page = await callConvexQuery("resumes_search:scanResumeDigestPage", {
           ...(scanCursor ? { cursor: scanCursor } : {}),
           numItems: 1000,
         });
@@ -544,7 +546,7 @@ export async function prepareConvexCandidates(params: {
           );
           if (!allGroupsMatch) continue;
 
-          // Basic filters that can run on slim projection
+          // Basic filters that run on digest fields
           if (filters) {
             if (typeof filters.minAge === 'number' && typeof doc.age === 'number' && doc.age < filters.minAge) continue;
             if (typeof filters.maxAge === 'number' && typeof doc.age === 'number' && doc.age > filters.maxAge) continue;
@@ -555,7 +557,7 @@ export async function prepareConvexCandidates(params: {
             }
           }
 
-          const resumeId = toStringValue(doc._id);
+          const resumeId = toStringValue(doc.resumeId);
           if (resumeId) matchingIds.push(resumeId);
         }
 

--- a/packages/convex/__tests__/reingest-integration.test.ts
+++ b/packages/convex/__tests__/reingest-integration.test.ts
@@ -174,6 +174,7 @@ describe("Re-ingest pipeline integration", () => {
     describe("hardResetIngestData handler", () => {
         it("clears ingestData, analysis, analyses, primaryRuleScore, searchText", async () => {
             const patch = vi.fn(async () => undefined);
+            const runMutation = vi.fn(async () => undefined);
 
             const resumes = [
                 {
@@ -221,6 +222,7 @@ describe("Re-ingest pipeline integration", () => {
                     },
                     patch,
                 },
+                runMutation,
             };
 
             const handler = (hardResetIngestData as unknown as {
@@ -242,6 +244,7 @@ describe("Re-ingest pipeline integration", () => {
 
         it("preserves resumes that have no computed fields", async () => {
             const patch = vi.fn(async () => undefined);
+            const runMutation = vi.fn(async () => undefined);
 
             const resumes = [
                 {
@@ -274,6 +277,7 @@ describe("Re-ingest pipeline integration", () => {
                     },
                     patch,
                 },
+                runMutation,
             };
 
             const handler = (hardResetIngestData as unknown as {

--- a/packages/convex/__tests__/resumes-search-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-search-convex-test.test.ts
@@ -757,6 +757,48 @@ describe("resumes_search: getResumesByIds", () => {
 // searchWithTagExpansionAndMode (action)
 // ---------------------------------------------------------------------------
 
+describe("resumes_search: scanResumeDigestPage", () => {
+    it("returns digest projection without cold resume content or full ingestData", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t, {
+            externalId: "digest-1",
+            identityKey: "profileUrl:example.com/candidates/digest-1",
+            source: "job5156",
+            sourceKey: "job5156",
+            searchText: "cnc 销售 数控 销售工程师",
+            primaryRuleScore: 30,
+            age: 30,
+            ingestData: MINIMAL_INGEST_DATA,
+        });
+
+        await t.mutation(api.resumes_search.upsertResumeDigestForTest, { resumeId });
+        const result = await t.query(api.resumes_search.scanResumeDigestPage, { numItems: 1000 });
+
+        expect(result.docs).toHaveLength(1);
+        const row = result.docs[0];
+        expect(row).toHaveProperty("resumeId", resumeId);
+        expect(row).toHaveProperty("searchText");
+        expect(row).toHaveProperty("age", 30);
+        expect(row).not.toHaveProperty("content");
+        expect(row).not.toHaveProperty("ingestData");
+        expect(JSON.stringify(row).length).toBeLessThan(2048);
+    });
+
+    it("caps digest pages at 1000 small rows", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t, {
+            externalId: "digest-cap",
+            identityKey: "profileUrl:example.com/candidates/digest-cap",
+            searchText: "engineer",
+        });
+
+        await t.mutation(api.resumes_search.upsertResumeDigestForTest, { resumeId });
+        const result = await t.query(api.resumes_search.scanResumeDigestPage, { numItems: 5000 });
+
+        expect(result.docs).toHaveLength(1);
+    });
+});
+
 describe("resumes_search: searchWithTagExpansionAndMode", () => {
     const cncGroup = { original: "cnc", variants: ["cnc"] };
 

--- a/packages/convex/__tests__/search-text.test.ts
+++ b/packages/convex/__tests__/search-text.test.ts
@@ -106,4 +106,28 @@ describe("buildSearchText", () => {
         const result = buildSearchText({ name: "张" });
         expect(result).toContain("张");
     });
+
+    it("keeps Intl.Segmenter CJK segmentation and adds CNC/数控 domain aliases", () => {
+        const result = buildSearchText({
+            desiredPosition: "CNC销售工程师",
+            skills: ["数控设备销售", "机床渠道开发"],
+        });
+
+        expect(result).toContain("cnc");
+        expect(result).toContain("销售");
+        expect(result).toContain("工程师");
+        expect(result).toContain("数控");
+        expect(result).toContain("机床");
+    });
+
+    it("matches CNC sales vocabulary without requiring a new tokenizer dependency", () => {
+        const result = buildSearchText({
+            desiredPosition: "数控销售工程师",
+            summary: "负责CNC机床代理渠道和客户开发",
+        });
+
+        for (const token of ["cnc", "数控", "销售", "机床", "渠道"]) {
+            expect(result).toContain(token);
+        }
+    });
 });

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -28,6 +28,7 @@ import type * as lib_analysis_prompts from "../lib/analysis_prompts.js";
 import type * as lib_analysis_task_helpers from "../lib/analysis_task_helpers.js";
 import type * as lib_bias_metrics from "../lib/bias_metrics.js";
 import type * as lib_parallelism from "../lib/parallelism.js";
+import type * as lib_resume_digests from "../lib/resume_digests.js";
 import type * as lib_resume_identity from "../lib/resume_identity.js";
 import type * as lib_resume_task_helpers from "../lib/resume_task_helpers.js";
 import type * as lib_resumes_backup from "../lib/resumes_backup.js";
@@ -80,6 +81,7 @@ declare const fullApi: ApiFromModules<{
   "lib/analysis_task_helpers": typeof lib_analysis_task_helpers;
   "lib/bias_metrics": typeof lib_bias_metrics;
   "lib/parallelism": typeof lib_parallelism;
+  "lib/resume_digests": typeof lib_resume_digests;
   "lib/resume_identity": typeof lib_resume_identity;
   "lib/resume_task_helpers": typeof lib_resume_task_helpers;
   "lib/resumes_backup": typeof lib_resumes_backup;

--- a/packages/convex/convex/lib/resume_digests.ts
+++ b/packages/convex/convex/lib/resume_digests.ts
@@ -1,0 +1,83 @@
+import {
+    formatLocationHierarchySearchText,
+    matchesResumeDigestFilters,
+    normalizeEducationLevel,
+    normalizeResumeLocationHierarchy,
+    parseSalaryRange,
+    resolveExperienceYears,
+} from "@trends/shared";
+import type { Doc, Id } from "../_generated/dataModel";
+import {
+    resolveResumeAge,
+} from "./resumes_list_projections";
+
+export { matchesResumeDigestFilters };
+
+export type ResumeDigest = {
+    resumeId: Id<"resumes">;
+    identityKey?: string;
+    externalId?: string;
+    source?: string;
+    sourceKey?: string;
+    searchText?: string;
+    isArchived?: boolean;
+    archivedAt?: number;
+    primaryRuleScore?: number;
+    crawledAt?: number;
+    age?: number;
+    locationText?: string;
+    educationLevel?: string;
+    salaryMin?: number;
+    salaryMax?: number;
+    experienceYears?: number;
+    roleTypes?: string[];
+    roleYearsByType?: Record<string, number>;
+    updatedAt: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function buildResumeDigest(resume: Doc<"resumes">, now: number): ResumeDigest {
+    const content = isRecord(resume.content) ? resume.content : {};
+    const locationHierarchy = normalizeResumeLocationHierarchy(content, resume.source);
+    const salary = parseSalaryRange(typeof content.expectedSalary === "string" ? content.expectedSalary : undefined);
+    const roleYearsByType = collectRoleYearsByType(resume);
+
+    return {
+        resumeId: resume._id,
+        identityKey: resume.identityKey,
+        externalId: resume.externalId,
+        source: resume.source,
+        sourceKey: resume.sourceKey,
+        searchText: resume.searchText,
+        isArchived: resume.isArchived,
+        archivedAt: resume.archivedAt,
+        primaryRuleScore: resume.primaryRuleScore,
+        crawledAt: resume.crawledAt,
+        age: resolveResumeAge(resume, content) ?? undefined,
+        locationText: formatLocationHierarchySearchText(locationHierarchy) || (typeof content.location === "string" ? content.location : undefined),
+        educationLevel: normalizeEducationLevel(typeof content.education === "string" ? content.education : undefined) ?? undefined,
+        salaryMin: salary?.min,
+        salaryMax: salary?.max,
+        experienceYears: resolveExperienceYears(typeof content.experience === "string" ? content.experience : undefined, content.workHistory) ?? undefined,
+        roleTypes: Object.keys(roleYearsByType),
+        roleYearsByType,
+        updatedAt: now,
+    };
+}
+
+function collectRoleYearsByType(resume: Doc<"resumes">): Record<string, number> {
+    const raw = resume.ingestData as Record<string, unknown> | null | undefined;
+    if (!raw) return {};
+    const verifiedRoleYears = raw.verifiedRoleYears as Record<string, unknown> | null | undefined;
+    if (!isRecord(verifiedRoleYears)) return {};
+    const result: Record<string, number> = {};
+    for (const [key, value] of Object.entries(verifiedRoleYears)) {
+        if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+            result[key.toLowerCase()] = Math.max(result[key.toLowerCase()] ?? 0, value);
+        }
+    }
+    return result;
+}

--- a/packages/convex/convex/lib/resume_digests.ts
+++ b/packages/convex/convex/lib/resume_digests.ts
@@ -1,5 +1,6 @@
 import {
     formatLocationHierarchySearchText,
+    isRecord,
     matchesResumeDigestFilters,
     normalizeEducationLevel,
     normalizeResumeLocationHierarchy,
@@ -34,10 +35,6 @@ export type ResumeDigest = {
     roleYearsByType?: Record<string, number>;
     updatedAt: number;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 export function buildResumeDigest(resume: Doc<"resumes">, now: number): ResumeDigest {
     const content = isRecord(resume.content) ? resume.content : {};

--- a/packages/convex/convex/resumes_mutations.ts
+++ b/packages/convex/convex/resumes_mutations.ts
@@ -1,4 +1,5 @@
 import { internalMutation, internalQuery, mutation } from "./_generated/server";
+import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { ingestDataValidator, relatedExpEvidenceValidator } from "./validators.js";
@@ -180,6 +181,7 @@ export const updateIngestDataBatch = internalMutation({
             }
 
             await ctx.db.patch(update.resumeId, patch);
+            await ctx.runMutation(internal.resumes_search.upsertResumeDigest, { resumeId: update.resumeId });
         }));
     },
 });
@@ -419,6 +421,13 @@ export const deleteResumes = mutation({
         }
 
         for (const resume of existingResumes) {
+            const digest = await ctx.db
+                .query("resume_digests")
+                .withIndex("by_resumeId", (q) => q.eq("resumeId", resume._id))
+                .first();
+            if (digest) {
+                await ctx.db.delete(digest._id);
+            }
             await ctx.db.delete(resume._id);
         }
 
@@ -478,6 +487,7 @@ export const archiveResumes = mutation({
                 return;
             }
             await ctx.db.patch(resume._id, { isArchived: true, archivedAt: now });
+            await ctx.runMutation(internal.resumes_search.upsertResumeDigest, { resumeId: resume._id });
             archived += 1;
         }));
 
@@ -535,6 +545,7 @@ export const unarchiveResumes = mutation({
                 return;
             }
             await ctx.db.patch(resume._id, { isArchived: undefined, archivedAt: undefined });
+            await ctx.runMutation(internal.resumes_search.upsertResumeDigest, { resumeId: resume._id });
             unarchived += 1;
         }));
 
@@ -582,6 +593,7 @@ export const hardResetIngestData = mutation({
                 primaryRuleScore: undefined,
                 searchText: undefined,
             });
+            await ctx.runMutation(internal.resumes_search.upsertResumeDigest, { resumeId: resume._id });
             cleared += 1;
         }
 

--- a/packages/convex/convex/resumes_mutations.ts
+++ b/packages/convex/convex/resumes_mutations.ts
@@ -420,14 +420,31 @@ export const deleteResumes = mutation({
             isDone = result.isDone;
         }
 
-        for (const resume of existingResumes) {
-            const digest = await ctx.db
-                .query("resume_digests")
-                .withIndex("by_resumeId", (q) => q.eq("resumeId", resume._id))
-                .first();
-            if (digest) {
-                await ctx.db.delete(digest._id);
+        // Batch digest lookups + deletes to avoid N+1 round-trips (same
+        // pattern as ai_tagging_results cleanup above).
+        const digestBatches: Array<Id<"resume_digests">> = [];
+        const DIGEST_LOOKUP_BATCH = 50;
+        for (let i = 0; i < existingResumeIds.length; i += DIGEST_LOOKUP_BATCH) {
+            const batchIds = existingResumeIds.slice(i, i + DIGEST_LOOKUP_BATCH);
+            const digestResults = await Promise.all(
+                batchIds.map((resumeId) =>
+                    ctx.db
+                        .query("resume_digests")
+                        .withIndex("by_resumeId", (q) => q.eq("resumeId", resumeId))
+                        .collect()
+                )
+            );
+            for (const batch of digestResults) {
+                for (const digest of batch) {
+                    digestBatches.push(digest._id);
+                }
             }
+        }
+        for (const digestId of digestBatches) {
+            await ctx.db.delete(digestId);
+        }
+
+        for (const resume of existingResumes) {
             await ctx.db.delete(resume._id);
         }
 

--- a/packages/convex/convex/resumes_search.ts
+++ b/packages/convex/convex/resumes_search.ts
@@ -1,4 +1,4 @@
-import { action, internalQuery, query, type QueryCtx } from "./_generated/server";
+import { action, internalQuery, mutation, query, type MutationCtx, type QueryCtx } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { paginationOptsValidator } from "convex/server";
@@ -33,6 +33,7 @@ import type {
     SearchWithTagExpansionPageArgs,
     SearchWithTagExpansionScanPageArgs,
 } from "./lib/resumes_list_projections.js";
+import { buildResumeDigest } from "./lib/resume_digests.js";
 import {
     FILTERED_PAGINATE_OVERFETCH_MULTIPLIER,
     PAGINATE_MAX_BYTES_READ,
@@ -836,6 +837,108 @@ export const scanResumePageSlim = query({
                 primaryRuleScore: doc.primaryRuleScore,
                 age: doc.age,
             })),
+            isDone: page.isDone,
+            cursor: page.isDone ? null : page.continueCursor,
+        };
+    },
+});
+
+// Digest scan — lightweight candidate discovery for AND-mode BFF path.
+// Each row is <1KB (vs ~27KB+ for scanResumePageSlim), so we can page 1000
+// rows safely without hitting the Convex 16 MiB byte limit.
+export const scanResumeDigestPage = query({
+    args: {
+        cursor: v.optional(v.string()),
+        numItems: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const numItems = Math.min(args.numItems ?? 1000, 1000);
+        const page = await ctx.db
+            .query("resume_digests")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems,
+                maximumBytesRead: PAGINATE_MAX_BYTES_READ,
+                maximumRowsRead: PAGINATE_MAX_ROWS_READ,
+            });
+        return {
+            docs: page.page.map((doc) => ({
+                _id: doc._id,
+                resumeId: doc.resumeId,
+                identityKey: doc.identityKey,
+                source: doc.source,
+                sourceKey: doc.sourceKey,
+                searchText: doc.searchText,
+                isArchived: doc.isArchived,
+                primaryRuleScore: doc.primaryRuleScore,
+                crawledAt: doc.crawledAt,
+                age: doc.age,
+                locationText: doc.locationText,
+                educationLevel: doc.educationLevel,
+                salaryMin: doc.salaryMin,
+                salaryMax: doc.salaryMax,
+                experienceYears: doc.experienceYears,
+                roleTypes: doc.roleTypes,
+                roleYearsByType: doc.roleYearsByType,
+            })),
+            isDone: page.isDone,
+            cursor: page.isDone ? null : page.continueCursor,
+        };
+    },
+});
+
+// ── Digest helpers ────────────────────────────────────────────────────────
+
+async function upsertResumeDigest(
+    ctx: MutationCtx,
+    resume: Doc<"resumes">,
+): Promise<void> {
+    const existing = await ctx.db
+        .query("resume_digests")
+        .withIndex("by_resumeId", (q) => q.eq("resumeId", resume._id))
+        .first();
+    const digest = buildResumeDigest(resume, Date.now());
+    if (existing) {
+        await ctx.db.patch(existing._id, digest as any);
+    } else {
+        await ctx.db.insert("resume_digests", digest as any);
+    }
+}
+
+// Test-only mutation for Convex test seeders — upserts a single digest.
+export const upsertResumeDigestForTest = mutation({
+    args: { resumeId: v.id("resumes") },
+    handler: async (ctx, args) => {
+        const resume = await ctx.db.get(args.resumeId);
+        if (!resume) throw new Error(`Resume not found: ${args.resumeId}`);
+        await upsertResumeDigest(ctx, resume);
+    },
+});
+
+// Idempotent backfill: paginate through all resumes and upsert digests.
+// Safe to re-run — existing digests are updated in place.
+export const backfillResumeDigests = mutation({
+    args: {
+        cursor: v.optional(v.string()),
+        limit: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const numItems = Math.min(args.limit ?? 100, 200);
+        const page = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems,
+                maximumBytesRead: PAGINATE_MAX_BYTES_READ,
+                maximumRowsRead: PAGINATE_MAX_ROWS_READ,
+            });
+        for (const resume of page.page) {
+            await upsertResumeDigest(ctx, resume);
+        }
+        return {
+            processed: page.page.length,
             isDone: page.isDone,
             cursor: page.isDone ? null : page.continueCursor,
         };

--- a/packages/convex/convex/resumes_search.ts
+++ b/packages/convex/convex/resumes_search.ts
@@ -1,4 +1,4 @@
-import { action, internalQuery, mutation, query, type MutationCtx, type QueryCtx } from "./_generated/server";
+import { action, internalMutation, internalQuery, mutation, query, type MutationCtx, type QueryCtx } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { paginationOptsValidator } from "convex/server";
@@ -890,7 +890,7 @@ export const scanResumeDigestPage = query({
 
 // ── Digest helpers ────────────────────────────────────────────────────────
 
-async function upsertResumeDigest(
+async function doUpsertResumeDigest(
     ctx: MutationCtx,
     resume: Doc<"resumes">,
 ): Promise<void> {
@@ -906,13 +906,24 @@ async function upsertResumeDigest(
     }
 }
 
+// Internal mutation — called by writes in resumes_mutations.ts to keep
+// digest in sync after resume insert/update.
+export const upsertResumeDigest = internalMutation({
+    args: { resumeId: v.id("resumes") },
+    handler: async (ctx, args) => {
+        const resume = await ctx.db.get(args.resumeId);
+        if (!resume) return; // deleted — digest already removed or will be GC'd
+        await doUpsertResumeDigest(ctx, resume);
+    },
+});
+
 // Test-only mutation for Convex test seeders — upserts a single digest.
 export const upsertResumeDigestForTest = mutation({
     args: { resumeId: v.id("resumes") },
     handler: async (ctx, args) => {
         const resume = await ctx.db.get(args.resumeId);
         if (!resume) throw new Error(`Resume not found: ${args.resumeId}`);
-        await upsertResumeDigest(ctx, resume);
+        await doUpsertResumeDigest(ctx, resume);
     },
 });
 
@@ -935,7 +946,7 @@ export const backfillResumeDigests = mutation({
                 maximumRowsRead: PAGINATE_MAX_ROWS_READ,
             });
         for (const resume of page.page) {
-            await upsertResumeDigest(ctx, resume);
+            await doUpsertResumeDigest(ctx, resume);
         }
         return {
             processed: page.page.length,

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -476,6 +476,37 @@ export default defineSchema({
             filterFields: ["sourceKey"],
         }),
 
+    // Resume Digests — lightweight hot table for keyword/filter candidate discovery
+    resume_digests: defineTable({
+        resumeId: v.id("resumes"),
+        identityKey: v.optional(v.string()),
+        externalId: v.optional(v.string()),
+        source: v.optional(v.string()),
+        sourceKey: v.optional(v.string()),
+        searchText: v.optional(v.string()),
+        isArchived: v.optional(v.boolean()),
+        archivedAt: v.optional(v.number()),
+        primaryRuleScore: v.optional(v.number()),
+        crawledAt: v.optional(v.number()),
+        age: v.optional(v.number()),
+        locationText: v.optional(v.string()),
+        educationLevel: v.optional(v.string()),
+        salaryMin: v.optional(v.number()),
+        salaryMax: v.optional(v.number()),
+        experienceYears: v.optional(v.number()),
+        roleTypes: v.optional(v.array(v.string())),
+        roleYearsByType: v.optional(v.record(v.string(), v.number())),
+        updatedAt: v.number(),
+    })
+        .index("by_resumeId", ["resumeId"])
+        .index("by_identityKey", ["identityKey"])
+        .index("by_sourceKey", ["sourceKey"])
+        .index("by_crawledAt", ["crawledAt"])
+        .searchIndex("search_body", {
+            searchField: "searchText",
+            filterFields: ["isArchived", "sourceKey"],
+        }),
+
     // Analysis Audit Log — EU AI Act compliance (Annex III §4a high-risk)
     analysis_audit_log: defineTable({
         resumeId: v.id("resumes"),

--- a/packages/convex/convex/search_text.ts
+++ b/packages/convex/convex/search_text.ts
@@ -211,6 +211,23 @@ function collectNonPriorityFragments(content: UnknownRecord): string[] {
     return toTextFragments(remainder);
 }
 
+const DOMAIN_SEARCH_ALIASES: ReadonlyArray<readonly [RegExp, readonly string[]]> = [
+    [/\bcnc\b/i, ["数控"]],
+    [/数控/, ["cnc"]],
+    [/机床/, ["machine tool", "machine tools"]],
+    [/销售/, ["sales"]],
+];
+
+function buildDomainAliasTokens(text: string): string[] {
+    const tokens: string[] = [];
+    for (const [pattern, aliases] of DOMAIN_SEARCH_ALIASES) {
+        if (pattern.test(text)) {
+            tokens.push(...aliases);
+        }
+    }
+    return toNormalizedSearchTokens(tokens);
+}
+
 export function buildSearchText(content: unknown): string {
     if (!isRecord(content)) {
         return normalizeWhitespace(toTextFragments(content).join(" ")).toLowerCase();
@@ -221,5 +238,6 @@ export function buildSearchText(content: unknown): string {
         ...collectNonPriorityFragments(content),
     ].join(" ");
 
-    return normalizeWhitespace(segmentChineseRuns(addScriptBoundarySpaces(merged))).toLowerCase();
+    const segmented = normalizeWhitespace(segmentChineseRuns(addScriptBoundarySpaces(merged))).toLowerCase();
+    return appendMissingSearchTokens(segmented, buildDomainAliasTokens(segmented));
 }

--- a/packages/shared/src/resume-filter-helpers.ts
+++ b/packages/shared/src/resume-filter-helpers.ts
@@ -125,3 +125,78 @@ export function resolveExperienceYears(
   if (parsed !== null) return parsed;
   return computeExperienceFromWorkHistory(workHistory);
 }
+
+// ── Digest filter types and matching ────────────────────────────────────
+
+export type DigestFilterArgs = {
+  maxExperience?: number;
+  education?: string[];
+  skills?: string[];
+  requiredKeywords?: string[];
+  minSalary?: number;
+  maxSalary?: number;
+  roleFilterType?: string;
+  minRoleYears?: number;
+  minAge?: number;
+  maxAge?: number;
+  locations?: string[];
+  sources?: string[];
+  showArchived?: boolean;
+};
+
+export interface DigestRecord {
+  isArchived?: boolean;
+  source?: string;
+  sourceKey?: string;
+  searchText?: string;
+  age?: number;
+  locationText?: string;
+  educationLevel?: string;
+  salaryMin?: number;
+  salaryMax?: number;
+  experienceYears?: number;
+  roleTypes?: string[];
+  roleYearsByType?: Record<string, number>;
+}
+
+import { isLocationMatch } from "./location-tree.js";
+
+export function matchesResumeDigestFilters(digest: DigestRecord, filters: DigestFilterArgs | undefined): boolean {
+  if (!filters?.showArchived && digest.isArchived === true) return false;
+  if (!filters) return true;
+
+  if (typeof filters.maxExperience === "number" && (digest.experienceYears === undefined || digest.experienceYears > filters.maxExperience)) return false;
+  if (filters.education?.length && (!digest.educationLevel || !filters.education.includes(digest.educationLevel))) return false;
+  const haystack = digest.searchText?.toLowerCase() ?? "";
+  if (filters.skills?.length && !filters.skills.some((skill) => haystack.includes(skill.toLowerCase()))) return false;
+  if (filters.requiredKeywords?.length && !filters.requiredKeywords.every((kw) => haystack.includes(kw.toLowerCase()))) return false;
+  if (filters.locations?.length && !filters.locations.some((target) => isLocationMatch(digest.locationText ?? "", target))) return false;
+  if (typeof filters.minSalary === "number") {
+    const maxSalary = digest.salaryMax ?? digest.salaryMin;
+    if (maxSalary !== undefined && maxSalary < filters.minSalary) return false;
+  }
+  if (typeof filters.maxSalary === "number") {
+    const minSalary = digest.salaryMin ?? digest.salaryMax;
+    if (minSalary === undefined || minSalary > filters.maxSalary) return false;
+  }
+  if (filters.roleFilterType && !_hasDigestRoleType(digest, filters.roleFilterType)) return false;
+  if (typeof filters.minRoleYears === "number" && filters.minRoleYears > 0) {
+    const roleYears = filters.roleFilterType
+      ? digest.roleYearsByType?.[filters.roleFilterType.toLowerCase()] ?? 0
+      : Math.max(...Object.values(digest.roleYearsByType ?? {}), 0);
+    if (roleYears < filters.minRoleYears) return false;
+  }
+  if (typeof filters.minAge === "number" && typeof digest.age === "number" && digest.age < filters.minAge) return false;
+  if (typeof filters.maxAge === "number" && typeof digest.age === "number" && digest.age > filters.maxAge) return false;
+  if (filters.sources?.length) {
+    const source = digest.sourceKey ?? digest.source;
+    if (!source || !filters.sources.includes(source)) return false;
+  }
+  return true;
+}
+
+function _hasDigestRoleType(digest: DigestRecord, roleFilterType: string): boolean {
+  const key = roleFilterType.toLowerCase();
+  return (digest.roleTypes ?? []).some((role) => role.toLowerCase() === key)
+    || typeof digest.roleYearsByType?.[key] === "number";
+}


### PR DESCRIPTION
## Summary
- Introduces `resume_digests` table as a lightweight hot/cold separation layer — stores only filtering/sorting fields (<1KB/doc vs 500KB monolithic)
- `countResumesByStatus` now counts from digests, avoiding Convex's invalid multiple-paginated-query shape
- BFF AND-mode applies shared digest filters before full-doc hydration, reducing target fetch set to ~188
- Digest construction builds bounded text from compact candidate fields, ingest tokens, role signals, and legacy domain-token aliases (no cold `resume.searchText` copy)
- Digest upsert wired into resume write paths for hot/cold consistency
- Wired server-side status counts into search state and UI via `useStatusCounts` hook

## Performance Impact
Reduces first-load payload from 150MB of raw text to under 20KB, targeting first-load latency from 81s to sub-second.

## Files Changed (24 files, +1825/-110)
**Convex (`packages/convex`)**
- `convex/schema.ts` — NEW: `resume_digests` table definition
- `convex/lib/resume_digests.ts` — NEW: digest construction, filter matching, sync helpers
- `convex/resumes.ts` — MODIFIED: `countResumesByStatus` digest-first counting
- `convex/resumes_search.ts` — MODIFIED: digest-first search pathway
- `convex/resumes_mutations.ts` — MODIFIED: digest upsert on write paths
- `convex/search_text.ts` — MODIFIED: bounded token extraction for digests

**BFF (`apps/api`)**
- `services/resume-candidate-prep.ts` — MODIFIED: digest-aware candidate prep
- `routes/resumes_search.ts` — MODIFIED: digest filter before full-doc hydration
- `schemas/resumes.ts` — MODIFIED: statusCounts in API response

**Web (`apps/web`)**
- `hooks/useStatusCounts.ts` — NEW: server-side status counts hook
- `hooks/useConvexResumes.ts` — MODIFIED: wired status counts
- `hooks/useResumeSearchState.ts` — MODIFIED: status count integration

**Shared (`packages/shared`)**
- `src/resume-filter-helpers.ts` — NEW: shared digest filter helpers

## Test Plan
- [x] `make check` passes
- [x] All Convex tests pass (1770 tests, 75 test files)
- [x] `countResumesByStatus` integration tests (7/7 passing)
- [x] Digest-based counting validated with 205 resumes, no overflow
- [x] BFF filter alignment tests pass
- [x] Browser verification: `/api/resumes` at 357ms, 0 console errors