### PR TITLE
Fix resume restore search digest backfill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ local-restore-from-prod:
 	@while $(MAKE) --no-print-directory clear-resumes 2>&1 | tee /tmp/clear-resumes.out | grep -q '"partial": true'; do :; done
 	@$(MAKE) --no-print-directory restore-resumes FILE="$(FILE)" MODE=replace YES=1 \
 		API_URL="$${API_URL:-http://localhost:3000}" WORKSPACE="$${WORKSPACE:-dev}"
-	@echo "→ backfilling derived fields"
+	@echo "→ backfilling derived fields and resume digests"
 	@$(MAKE) --no-print-directory backfill-derived-fields
 	@echo "→ checking derived field coverage"
 	@$(MAKE) --no-print-directory check-derived-fields

--- a/apps/api/src/routes/resumes.search-integration.test.ts
+++ b/apps/api/src/routes/resumes.search-integration.test.ts
@@ -99,6 +99,55 @@ function buildDigestRow(resumeId: string, overrides: Record<string, unknown> = {
     };
 }
 
+function buildFilterableConvexResumeRecord(
+    resumeId: string,
+    params: {
+        location: string;
+        verifiedRoleYears: Record<string, number>;
+    },
+) {
+    const record = buildConvexResumeRecord(resumeId, {
+        name: resumeId,
+        searchText: "cnc 销售 数控 销售工程师",
+    });
+    return {
+        ...record,
+        content: {
+            ...record.content,
+            location: params.location,
+        },
+        ingestData: {
+            ruleScores: {},
+            industryTags: ["机械", "销售"],
+            synonymHits: ["cnc", "销售"],
+            brandHits: [],
+            companyHits: [],
+            experienceLevel: "mid",
+            computedAt: Date.now(),
+            skillsVersion: 1,
+            verifiedRoleYears: params.verifiedRoleYears,
+            roleSignals: Object.entries(params.verifiedRoleYears).map(([type, years]) => ({
+                type,
+                matchedSignals: [type],
+                signalCount: 1,
+                occurrences: 1,
+                years,
+                industryVerifiedYears: years,
+                roleRelevantYears: years,
+                industryVerifiedRelevantYears: years,
+                matchedWorkEntries: [{
+                    jobTitle: `${type} role`,
+                    years,
+                    industryVerified: true,
+                    matchedSignals: [type],
+                    directRoleMatch: true,
+                }],
+                verifyIn: "workHistory",
+            })),
+        },
+    };
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────
 
 describe("BFF search dispatcher integration", () => {
@@ -309,6 +358,50 @@ describe("BFF search dispatcher integration", () => {
             expect(calls.some((c) => c.pathName === "resumes_search:scanResumePageSlim")).toBe(false);
             const docCall = calls.find((c) => c.pathName === "resumes_search:getResumeDocsByIds");
             expect(docCall?.args.ids).toEqual(["r1"]);
+        });
+
+        it("normalizes browser URL aliases for location and role type filters", async () => {
+            vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+                const call = parseConvexCall(input, init);
+                if (call.pathName === "resumes_search:scanResumeDigestPage") {
+                    return convexSuccess({
+                        docs: [
+                            buildDigestRow("r1", { searchText: "cnc 销售 数控 销售工程师" }),
+                            buildDigestRow("r2", { searchText: "cnc 销售 数控 销售工程师" }),
+                            buildDigestRow("r3", { searchText: "cnc 销售 数控 销售工程师" }),
+                        ],
+                        isDone: true,
+                        cursor: null,
+                    });
+                }
+                if (call.pathName === "resumes_search:getResumeDocsByIds") {
+                    return convexSuccess([
+                        buildFilterableConvexResumeRecord("r1", {
+                            location: "东莞",
+                            verifiedRoleYears: { sales: 3 },
+                        }),
+                        buildFilterableConvexResumeRecord("r2", {
+                            location: "Kuala Lumpur MY",
+                            verifiedRoleYears: { sales: 3 },
+                        }),
+                        buildFilterableConvexResumeRecord("r3", {
+                            location: "东莞",
+                            verifiedRoleYears: { engineer: 3 },
+                        }),
+                    ]);
+                }
+                throw new Error(`Unexpected convex path: ${call.pathName}`);
+            });
+
+            const app = createApp();
+            const response = await app.request(
+                "/api/resumes?source=convex&q=CNC%20销售&limit=5&minRoleYears=1&roleType=sales&location=China",
+            );
+
+            expect(response.status).toBe(200);
+            const payload = await response.json();
+            expect(payload.success).toBe(true);
+            expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["r1"]);
         });
     });
 

--- a/apps/api/src/routes/resumes_search.ts
+++ b/apps/api/src/routes/resumes_search.ts
@@ -628,10 +628,12 @@ app.openapi(getResumesRoute, (c) => {
     skills,
     requiredKeywords,
     locations,
+    location,
     minSalary,
     maxSalary,
     minRoleYears,
     roleFilterType,
+    roleType,
     minAge,
     maxAge,
     sources,
@@ -648,6 +650,13 @@ app.openapi(getResumesRoute, (c) => {
   const sampleName = sample?.trim() || undefined;
   const keyword = q?.trim() || undefined;
   const keywordExpansion = resumeService.expandSearchQuery(keyword);
+  const normalizedLocationAlias = location?.trim() || undefined;
+  const effectiveLocations = locations && locations.length > 0
+    ? locations
+    : normalizedLocationAlias
+      ? [normalizedLocationAlias]
+      : undefined;
+  const effectiveRoleFilterType = roleFilterType?.trim() || roleType?.trim() || undefined;
 
   try {
     if (source === "convex") {
@@ -662,11 +671,11 @@ app.openapi(getResumesRoute, (c) => {
           education,
           skills,
           requiredKeywords: normalizedRequiredKeywords,
-          locations,
+          locations: effectiveLocations,
           minSalary,
           maxSalary,
           minRoleYears,
-          roleFilterType,
+          roleFilterType: effectiveRoleFilterType,
           minAge,
           maxAge,
           sources,
@@ -677,11 +686,11 @@ app.openapi(getResumesRoute, (c) => {
           education,
           skills,
           requiredKeywords: normalizedRequiredKeywords,
-          locations,
+          locations: effectiveLocations,
           minSalary,
           maxSalary,
           minRoleYears,
-          roleFilterType,
+          roleFilterType: effectiveRoleFilterType,
           minAge,
           maxAge,
           sources,
@@ -729,13 +738,13 @@ app.openapi(getResumesRoute, (c) => {
               })),
               maxExperience,
               minRoleYears,
-              roleFilterType,
+              roleFilterType: effectiveRoleFilterType,
               minAge,
               maxAge,
               education,
               skills,
               requiredKeywords: normalizedRequiredKeywords,
-              locations,
+              locations: effectiveLocations,
               minSalary,
               maxSalary,
               sources,
@@ -1025,7 +1034,7 @@ app.openapi(getResumesRoute, (c) => {
       education,
       skills,
       requiredKeywords: normalizeKeywords(requiredKeywords),
-      locations,
+      locations: effectiveLocations,
       minSalary,
       maxSalary,
     });

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -603,6 +603,14 @@ export const ResumesQuerySchema = z.object({
     param: { name: "locations", in: "query" },
     example: "东莞,深圳",
   }),
+  location: z
+    .string()
+    .optional()
+    .openapi({
+      param: { name: "location", in: "query" },
+      example: "China",
+      description: "Legacy/browser URL alias for locations",
+    }),
   minSalary: OptionalIntParam({ name: "minSalary", example: "5000" }),
   maxSalary: OptionalIntParam({ name: "maxSalary", example: "15000" }),
   minRoleYears: OptionalIntParam({ name: "minRoleYears", example: "1" }),
@@ -612,6 +620,14 @@ export const ResumesQuerySchema = z.object({
     .openapi({
       param: { name: "roleFilterType", in: "query" },
       example: "sales",
+    }),
+  roleType: z
+    .string()
+    .optional()
+    .openapi({
+      param: { name: "roleType", in: "query" },
+      example: "sales",
+      description: "Legacy/browser URL alias for roleFilterType",
     }),
   minAge: OptionalIntParam({ name: "minAge", example: "25" }),
   maxAge: OptionalIntParam({ name: "maxAge", example: "40" }),

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -1760,10 +1760,14 @@ export interface paths {
                     skills?: string | string[];
                     requiredKeywords?: string | string[];
                     locations?: string | string[];
+                    /** @description Legacy/browser URL alias for locations */
+                    location?: string;
                     minSalary?: string;
                     maxSalary?: string;
                     minRoleYears?: string;
                     roleFilterType?: string;
+                    /** @description Legacy/browser URL alias for roleFilterType */
+                    roleType?: string;
                     minAge?: string;
                     maxAge?: string;
                     sources?: string | string[];

--- a/packages/cli/cmd/migrate.go
+++ b/packages/cli/cmd/migrate.go
@@ -139,7 +139,7 @@ func newMigrateValidateConsistencyCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "validate-consistency",
-		Short: "Run full data consistency validation and repair (reindexSearchText + backfillVerifiedRoleYears)",
+		Short: "Run full data consistency validation and repair (searchText + verifiedRoleYears + resume digests)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var extraArgs []string
 			if forceFlag {

--- a/packages/convex/__tests__/migrations-convex-test.test.ts
+++ b/packages/convex/__tests__/migrations-convex-test.test.ts
@@ -1618,6 +1618,66 @@ describe("migration: validateDataConsistency", () => {
     expect(result.backfillVerifiedRoleYears.scanned).toBeGreaterThanOrEqual(1);
   });
 
+  it("backfills resume digests needed by restored AND-mode search", async () => {
+    const t = createTest();
+
+    const resumeId = await insertResume(t, {
+      content: { name: "CNC Sales", location: "广东东莞" },
+      searchText: "cnc 销售 china",
+      ingestData: {
+        ruleScores: {},
+        industryTags: ["机械", "销售"],
+        synonymHits: ["cnc", "销售"],
+        brandHits: [],
+        companyHits: [],
+        experienceLevel: "mid",
+        computedAt: Date.now(),
+        skillsVersion: 1,
+        verifiedRoleYears: { sales: 2 },
+        roleSignals: [
+          {
+            type: "sales",
+            matchedSignals: ["销售"],
+            signalCount: 1,
+            occurrences: 1,
+            years: 2,
+            industryVerifiedYears: 2,
+            roleRelevantYears: 2,
+            industryVerifiedRelevantYears: 2,
+            matchedWorkEntries: [
+              {
+                jobTitle: "销售经理",
+                years: 2,
+                industryVerified: true,
+                matchedSignals: ["销售"],
+                directRoleMatch: true,
+              },
+            ],
+            verifyIn: "workHistory",
+          },
+        ],
+      },
+    });
+
+    const before = await t.run(async (ctx) => {
+      return ctx.db.query("resume_digests").collect();
+    });
+    expect(before).toHaveLength(0);
+
+    const result = await t.action(api.migrations.validateDataConsistency, {});
+
+    expect(result.backfillResumeDigests).toBeDefined();
+    expect(result.backfillResumeDigests.processed).toBeGreaterThanOrEqual(1);
+
+    const after = await t.run(async (ctx) => {
+      return ctx.db.query("resume_digests").collect();
+    });
+    expect(after).toHaveLength(1);
+    expect(after[0].resumeId).toBe(resumeId);
+    expect(after[0].searchText).toContain("cnc");
+    expect(after[0].roleYearsByType?.sales).toBe(2);
+  });
+
   it("reports zero updates when all data is consistent", async () => {
     const t = createTest();
 

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -527,6 +527,12 @@ type ReIngestAllResumesResult = {
     batches: number;
 };
 
+type BackfillResumeDigestsResult = {
+    processed: number;
+    isDone: boolean;
+    cursor: string | null;
+};
+
 export const backfillSearchText = mutation({
     args: {
         cursor: v.optional(v.string()),
@@ -1512,9 +1518,25 @@ export const validateDataConsistency = action({
             vryCursor = result.cursor;
         }
 
+        // Step 3: Rebuild resume_digests after all resume-derived fields settle.
+        // The BFF AND-mode search path scans this hot table; restores from older
+        // backups can have complete resumes but no digest rows.
+        let digestCursor: string | null = null;
+        let digestProcessed = 0;
+        for (let i = 0; i < 10000; i++) {
+            const result: BackfillResumeDigestsResult = await ctx.runMutation(api.resumes_search.backfillResumeDigests, {
+                cursor: digestCursor ?? undefined,
+                limit: batchSize,
+            });
+            digestProcessed += result.processed;
+            if (result.isDone) break;
+            digestCursor = result.cursor;
+        }
+
         return {
             reindexSearchText: { scanned: reindexScanned, updated: reindexUpdated },
             backfillVerifiedRoleYears: { scanned: vryScanned, updated: vryUpdated },
+            backfillResumeDigests: { processed: digestProcessed },
         };
     },
 });

--- a/scripts/install-deploy-safety.test.ts
+++ b/scripts/install-deploy-safety.test.ts
@@ -55,8 +55,7 @@ describe("seed_and_migrate_convex migration order", () => {
     "backfillSearchText",
     "backfillEvidenceText",
     "backfillPrimaryRuleScore",
-    "backfillVerifiedRoleYears",
-    "reindexSearchText",
+    "validateDataConsistency",
   ];
 
   let body = "";
@@ -106,8 +105,8 @@ describe("seed_and_migrate_convex migration order", () => {
     expect(migrations[0]).toBe("backfillSourceKey");
   });
 
-  it("ends with reindexSearchText (rebuilds index over finalized content)", () => {
-    expect(migrations.at(-1)).toBe("reindexSearchText");
+  it("ends with validateDataConsistency (repairs finalized derived fields and digests)", () => {
+    expect(migrations.at(-1)).toBe("validateDataConsistency");
   });
 
   it("passes batchSize to backfillManual51jobStructuredContent", () => {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1359,8 +1359,7 @@ seed_and_migrate_convex() {
     run_convex_migration "$convex_dir" "backfillSearchText"
     run_convex_migration "$convex_dir" "backfillEvidenceText"
     run_convex_migration "$convex_dir" "backfillPrimaryRuleScore"
-    run_convex_migration "$convex_dir" "backfillVerifiedRoleYears"
-    run_convex_migration "$convex_dir" "reindexSearchText"
+    run_convex_migration "$convex_dir" "validateDataConsistency"
 }
 
 resolve_env_file() {

--- a/scripts/migration-test-run.sh
+++ b/scripts/migration-test-run.sh
@@ -108,8 +108,7 @@ run_migrations() {
         backfillSearchText
         backfillEvidenceText
         backfillPrimaryRuleScore
-        backfillVerifiedRoleYears
-        reindexSearchText
+        validateDataConsistency
     )
     for migration in "${migrations[@]}"; do
         log "  Running: $migration"


### PR DESCRIPTION
## Summary
- Rebuild `resume_digests` from `migrations:validateDataConsistency` so old prod resume backups restore into current AND-mode search safely.
- Route restore/deploy/migration-test flows through the canonical consistency gate instead of ending with only searchText/verifiedRoleYears repairs.
- Accept browser URL aliases `location` and `roleType` at `/api/resumes` so copied dev-resume URLs verify the same way as the UI.
- Add regressions for digest backfill, browser alias filtering, and production migration ordering.

## Verification
- `make check`
- `curl -fsS 'http://localhost:3000/api/resumes?source=convex&paged=true&limit=20&q=CNC%20%E9%94%80%E5%94%AE&location=China&minRoleYears=1&roleType=sales' | jq '{total:.summary.total, returned:.summary.returned, mode:.summary.mode}'` returned `{ "total": 193, "returned": 20, "mode": "AND" }`

## Wiki
- Added migration workflow guide: `/Users/karlchow/wiki/projects/trends/compound/2026-06-04-version-migration-breakage-workflow.md`
