### PR TITLE
Clear resume digests during local reset

### DIFF
--- a/packages/convex/__tests__/resumes-hard-reset-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-hard-reset-convex-test.test.ts
@@ -145,6 +145,31 @@ describe("resumes: hardResetIngestData", () => {
 });
 
 // ---------------------------------------------------------------------------
+// resetDatabase
+// ---------------------------------------------------------------------------
+
+describe("resume_tasks: resetDatabase", () => {
+  it("clears resume digests with resume runtime state", async () => {
+    const t = createTest();
+    const resumeId = await insertResume(t, {
+      content: { name: "Digest Candidate" },
+      searchText: "digest candidate sales",
+    });
+    await t.mutation(api.resumes_search.upsertResumeDigestForTest, { resumeId });
+
+    const before = await t.run(async (ctx) => ctx.db.query("resume_digests").collect());
+    expect(before).toHaveLength(1);
+
+    const result = await t.mutation(api.resume_tasks.resetDatabase, {});
+
+    expect(result.success).toBe(true);
+    expect(result.deleted.resume_digests).toBe(1);
+    const after = await t.run(async (ctx) => ctx.db.query("resume_digests").collect());
+    expect(after).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // clearAnalyses
 // ---------------------------------------------------------------------------
 

--- a/packages/convex/__tests__/seed-workspace-demo-data-convex-test.test.ts
+++ b/packages/convex/__tests__/seed-workspace-demo-data-convex-test.test.ts
@@ -115,3 +115,32 @@ describe("seed: clearWorkspaceDemoResumes", () => {
     expect(resumes[0].externalId).toBe("real-seek-profile");
   });
 });
+
+describe("seed: clearAll", () => {
+  it("clears resume digests during full local reset", async () => {
+    const t = createTest();
+    const resumeId = await t.run(async (ctx) => {
+      return ctx.db.insert("resumes", {
+        externalId: "digest-reset",
+        identityKey: "profileUrl:example.com/digest-reset",
+        content: { name: "Digest Reset" },
+        hash: "hash-digest-reset",
+        source: "test",
+        sourceKey: "test",
+        tags: ["test"],
+        crawledAt: 1,
+        searchText: "digest reset",
+      });
+    });
+    await t.mutation(api.resumes_search.upsertResumeDigestForTest, { resumeId });
+
+    const before = await t.run(async (ctx) => ctx.db.query("resume_digests").collect());
+    expect(before).toHaveLength(1);
+
+    const result = await t.mutation(api.seed.clearAll, {});
+
+    expect(result.success).toBe(true);
+    const after = await t.run(async (ctx) => ctx.db.query("resume_digests").collect());
+    expect(after).toHaveLength(0);
+  });
+});

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -612,6 +612,7 @@ export const getSummaryWindow = query({
 
 const RESET_TABLES = [
     "collection_tasks",
+    "resume_digests",
     "resumes",
     "collection_workers",
     "candidate_blocks",

--- a/packages/convex/convex/seed.ts
+++ b/packages/convex/convex/seed.ts
@@ -982,6 +982,9 @@ export const clearAll = mutation({
     const jds = await ctx.db.query("job_descriptions").collect();
     for (const jd of jds) await ctx.db.delete(jd._id);
 
+    const resumeDigests = await ctx.db.query("resume_digests").collect();
+    for (const digest of resumeDigests) await ctx.db.delete(digest._id);
+
     const resumes = await ctx.db.query("resumes").collect();
     for (const resume of resumes) await ctx.db.delete(resume._id);
 


### PR DESCRIPTION
## Summary
- Treat `resume_digests` as resume runtime state in `resume_tasks:resetDatabase`.
- Clear `resume_digests` during `seed:clearAll` so full local resets do not leave stale hot-table rows.
- Add Convex regressions for resume reset and full seed clear.
- Updated Skillwiki migration workflow with explicit resume-only restore vs fresh local app reset recipes.

## Verification
- `npm test -- packages/convex/__tests__/resumes-hard-reset-convex-test.test.ts packages/convex/__tests__/seed-workspace-demo-data-convex-test.test.ts`
- `make check`

## Wiki
- Refined `/Users/karlchow/wiki/projects/trends/compound/2026-06-04-version-migration-breakage-workflow.md`
