### PR TITLE
refactor(cli): default to agent output format

### DIFF
--- a/packages/cli/cmd/output.go
+++ b/packages/cli/cmd/output.go
@@ -47,6 +47,25 @@ func writeMessage(cmd *cobra.Command, message string) error {
 	if options.Output == "json" {
 		return writeOutput(cmd, nil, nil, map[string]string{"message": message})
 	}
+	if options.Output == "agent" {
+		return writeAgentFields(cmd, []output.Field{
+			{Key: "kind", Value: "message"},
+			{Key: "message", Value: message},
+		})
+	}
 	_, err := fmt.Fprintln(cmd.OutOrStdout(), message)
 	return err
+}
+
+func writeAgentFields(cmd *cobra.Command, fields []output.Field) error {
+	line := output.FormatFields(fields)
+	if line == "" {
+		return nil
+	}
+	_, err := fmt.Fprintln(cmd.OutOrStdout(), line)
+	return err
+}
+
+func writeAgentSummary(cmd *cobra.Command, fields []output.Field) error {
+	return writeAgentFields(cmd, append([]output.Field{{Key: "kind", Value: "summary"}}, fields...))
 }

--- a/packages/cli/cmd/resume.go
+++ b/packages/cli/cmd/resume.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ptdevhk/trends/packages/cli/internal/client"
+	"github.com/ptdevhk/trends/packages/cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -138,7 +139,8 @@ func newResumeSearchCmd() *cobra.Command {
 			}
 
 			options := currentOptions()
-			if options.Output != "json" {
+			switch options.Output {
+			case "table":
 				fmt.Fprintf(
 					cmd.OutOrStdout(),
 					"Query: %s | Source: %s | Total: %d | Returned: %d\n\n",
@@ -147,6 +149,15 @@ func newResumeSearchCmd() *cobra.Command {
 					response.Summary.Total,
 					response.Summary.Returned,
 				)
+			case "agent":
+				if err := writeAgentSummary(cmd, []output.Field{
+					{Key: "query", Value: response.Summary.Query},
+					{Key: "source", Value: coalesceString(response.Summary.Source, normalizeResumeSourceFlag(source))},
+					{Key: "total", Value: strconv.Itoa(response.Summary.Total)},
+					{Key: "returned", Value: strconv.Itoa(response.Summary.Returned)},
+				}); err != nil {
+					return err
+				}
 			}
 
 			headers := []string{"id", "name", "intention", "location", "experience", "education"}
@@ -354,6 +365,23 @@ func splitCSV(input string) []string {
 }
 
 func writeAnalyzeTable(cmd *cobra.Command, response *client.AnalyzeResponse) error {
+	if currentOptions().Output == "agent" {
+		fields := []output.Field{
+			{Key: "kind", Value: "analysis"},
+			{Key: "candidates", Value: strconv.Itoa(response.ResumeCount)},
+			{Key: "dry_run", Value: strconv.FormatBool(response.DryRun)},
+			{Key: "task_id", Value: response.TaskID},
+		}
+		if response.Config != nil {
+			fields = append(fields,
+				output.Field{Key: "job_description_id", Value: response.Config.JobDescriptionID},
+				output.Field{Key: "keywords", Value: strings.Join(response.Config.Keywords, ",")},
+				output.Field{Key: "location", Value: response.Config.Location},
+			)
+		}
+		return writeAgentFields(cmd, fields)
+	}
+
 	fmt.Fprintf(cmd.OutOrStdout(), "Candidates: %d\n", response.ResumeCount)
 	if response.DryRun {
 		fmt.Fprintf(cmd.OutOrStdout(), "Mode: dry-run (no analysis dispatched)\n")
@@ -480,7 +508,8 @@ func newResumeManualImportCmd() *cobra.Command {
 				return err
 			}
 
-			if currentOptions().Output != "json" {
+			switch currentOptions().Output {
+			case "table":
 				fmt.Fprintf(
 					cmd.OutOrStdout(),
 					"Source: %s | Uploaded: %d | Discovered: %d | Parsed: %d | Imported: %d | Failed: %d\n\n",
@@ -491,6 +520,17 @@ func newResumeManualImportCmd() *cobra.Command {
 					response.Summary.Imported,
 					response.Summary.Failed,
 				)
+			case "agent":
+				if err := writeAgentSummary(cmd, []output.Field{
+					{Key: "source", Value: coalesceString(response.Source.Label, response.Source.Key, "51job-manual")},
+					{Key: "uploaded", Value: strconv.Itoa(response.Summary.UploadedFiles)},
+					{Key: "discovered", Value: strconv.Itoa(response.Summary.DiscoveredFiles)},
+					{Key: "parsed", Value: strconv.Itoa(response.Summary.ParsedResumes)},
+					{Key: "imported", Value: strconv.Itoa(response.Summary.Imported)},
+					{Key: "failed", Value: strconv.Itoa(response.Summary.Failed)},
+				}); err != nil {
+					return err
+				}
 			}
 
 			output := buildResumeManualImportOutput(response)
@@ -540,6 +580,26 @@ func buildResumeManualImportOutput(response *client.ResumeManualImportResponse) 
 
 func writeResumeDetailOutput(cmd *cobra.Command, response *client.ResumeDetailResponse) error {
 	item := response.Data
+
+	if currentOptions().Output == "agent" {
+		return writeAgentFields(cmd, []output.Field{
+			{Key: "kind", Value: "resume_detail"},
+			{Key: "id", Value: coalesceString(item.ResumeID, item.PerUserID, item.ProfileID, item.ExternalID)},
+			{Key: "name", Value: item.Name},
+			{Key: "source", Value: response.Source},
+			{Key: "intention", Value: item.JobIntention},
+			{Key: "location", Value: item.Location},
+			{Key: "experience", Value: item.Experience},
+			{Key: "education", Value: item.Education},
+			{Key: "activity", Value: item.ActivityStatus},
+			{Key: "salary", Value: item.ExpectedSalary},
+			{Key: "profile", Value: item.ProfileURL},
+			{Key: "self_intro", Value: strconv.FormatBool(strings.TrimSpace(item.SelfIntro) != "")},
+			{Key: "work_history", Value: strconv.Itoa(len(item.WorkHistory))},
+			{Key: "detail", Value: "use --output json for full resume"},
+		})
+	}
+
 	out := cmd.OutOrStdout()
 
 	if _, err := fmt.Fprintf(

--- a/packages/cli/cmd/resume_debug.go
+++ b/packages/cli/cmd/resume_debug.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ptdevhk/trends/packages/cli/internal/client"
+	"github.com/ptdevhk/trends/packages/cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -662,7 +663,8 @@ func newResumeDebugWorkflowDatasetCmd() *cobra.Command {
 				})
 			}
 
-			if options.Output == "table" {
+			switch options.Output {
+			case "table":
 				fmt.Fprintf(
 					cmd.OutOrStdout(),
 					"Query: %s | Workspace: %s | Query matches: %d | Visible after filters: %d\n",
@@ -681,6 +683,29 @@ func newResumeDebugWorkflowDatasetCmd() *cobra.Command {
 					"Visible by source key: %s\n\n",
 					formatWorkflowDatasetCounts(report.VisibleBySourceKey),
 				)
+			case "agent":
+				if err := writeAgentSummary(cmd, []output.Field{
+					{Key: "query", Value: report.Query},
+					{Key: "workspace", Value: report.Workspace},
+					{Key: "query_matches", Value: strconv.Itoa(report.QueryMatchCount)},
+					{Key: "visible", Value: strconv.Itoa(report.VisibleCount)},
+				}); err != nil {
+					return err
+				}
+				if err := writeAgentFields(cmd, []output.Field{
+					{Key: "kind", Value: "dataset_counts"},
+					{Key: "scope", Value: "dataset"},
+					{Key: "counts", Value: formatWorkflowDatasetCounts(report.DatasetBySourceKey)},
+				}); err != nil {
+					return err
+				}
+				if err := writeAgentFields(cmd, []output.Field{
+					{Key: "kind", Value: "dataset_counts"},
+					{Key: "scope", Value: "visible"},
+					{Key: "counts", Value: formatWorkflowDatasetCounts(report.VisibleBySourceKey)},
+				}); err != nil {
+					return err
+				}
 			}
 
 			if fieldCoverage && len(report.FieldCoverageBySource) > 0 {
@@ -713,9 +738,16 @@ func newResumeDebugWorkflowDatasetCmd() *cobra.Command {
 						formatWorkflowDatasetCoveragePercent(row.SkillsPct),
 					})
 				}
-				if options.Output == "table" {
+
+				if options.Output == "agent" {
+					coverageHeaders = append([]string{"kind"}, coverageHeaders...)
+					for i := range coverageRows {
+						coverageRows[i] = append([]string{"field_coverage"}, coverageRows[i]...)
+					}
+				} else if options.Output == "table" {
 					fmt.Fprintln(cmd.OutOrStdout(), "Field coverage by source:")
 				}
+
 				if err := writeOutput(cmd, coverageHeaders, coverageRows, report.FieldCoverageBySource); err != nil {
 					return err
 				}
@@ -724,7 +756,7 @@ func newResumeDebugWorkflowDatasetCmd() *cobra.Command {
 				}
 			}
 
-			if len(rows) == 0 && options.Output == "table" {
+			if len(rows) == 0 && (options.Output == "table" || options.Output == "agent") {
 				return writeMessage(cmd, "No visible resumes after workflow filters")
 			}
 			return writeOutput(cmd, headers, rows, report)
@@ -1163,48 +1195,59 @@ func newResumeDebugAnalysisTasksCmd() *cobra.Command {
 
 func writeAnalysisTasksTable(cmd *cobra.Command, response *client.AnalysisTasksResponse) error {
 	if len(response.Tasks) == 0 {
-		fmt.Fprintf(cmd.OutOrStdout(), "No analysis tasks found.\n")
-		return nil
+		return writeMessage(cmd, "No analysis tasks found.")
 	}
 
+	headers := []string{"task_id", "status", "progress_current", "progress_total", "skipped", "label", "location", "analyzed", "avg_score", "error"}
+	rows := make([][]string, 0, len(response.Tasks))
 	for _, task := range response.Tasks {
-		var label string
-		if task.Config != nil {
-			label = task.Config.JobDescriptionTitle
-			if label == "" && len(task.Config.Keywords) > 0 {
-				label = strings.Join(task.Config.Keywords, ", ")
-			}
-			if label == "" {
-				label = task.Config.JobDescriptionID
-			}
-		} else {
-			label = task.ID
+		label := analysisTaskLabel(task)
+		progressCurrent := ""
+		progressTotal := ""
+		skipped := "0"
+		if task.Progress != nil {
+			progressCurrent = strconv.Itoa(task.Progress.Current)
+			progressTotal = strconv.Itoa(task.Progress.Total)
+			skipped = strconv.Itoa(task.Progress.Skipped)
 		}
-
-		status := task.Status
-		if task.Progress != nil && task.Progress.Total > 0 {
-			status = fmt.Sprintf("%s (%d/%d", task.Status, task.Progress.Current, task.Progress.Total)
-			if task.Progress.Skipped > 0 {
-				status += fmt.Sprintf(", skipped: %d", task.Progress.Skipped)
-			}
-			status += ")"
-		}
-
-		line := fmt.Sprintf("%s  %s", task.ID, status)
-		if label != "" {
-			line += fmt.Sprintf("  %s", label)
-		}
-		if task.Config != nil && task.Config.Location != "" {
-			line += fmt.Sprintf("  [%s]", task.Config.Location)
-		}
+		analyzed := ""
+		avgScore := ""
 		if task.Results != nil && task.Status == "completed" {
-			line += fmt.Sprintf("  analyzed=%d avg=%.0f", task.Results.Analyzed, task.Results.AvgScore)
+			analyzed = strconv.Itoa(task.Results.Analyzed)
+			avgScore = strconv.FormatFloat(task.Results.AvgScore, 'f', 0, 64)
 		}
-		if task.Error != "" {
-			line += fmt.Sprintf("  error=%s", task.Error)
+		location := ""
+		if task.Config != nil {
+			location = task.Config.Location
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", line)
+		rows = append(rows, []string{
+			task.ID,
+			task.Status,
+			progressCurrent,
+			progressTotal,
+			skipped,
+			label,
+			location,
+			analyzed,
+			avgScore,
+			task.Error,
+		})
 	}
+	return writeOutput(cmd, headers, rows, response)
+}
 
-	return nil
+func analysisTaskLabel(task client.AnalysisTask) string {
+	if task.Config == nil {
+		return task.ID
+	}
+	if task.Config.JobDescriptionTitle != "" {
+		return task.Config.JobDescriptionTitle
+	}
+	if len(task.Config.Keywords) > 0 {
+		return strings.Join(task.Config.Keywords, ", ")
+	}
+	if task.Config.JobDescriptionID != "" {
+		return task.Config.JobDescriptionID
+	}
+	return task.ID
 }

--- a/packages/cli/cmd/resume_debug_test.go
+++ b/packages/cli/cmd/resume_debug_test.go
@@ -885,6 +885,7 @@ func TestResumeDebugAnalysisTasksCommandWritesTable(t *testing.T) {
 	defer server.Close()
 
 	setResumeCLIConfig(t, server.URL, "dev")
+	setCLIOutput(t, "table")
 
 	cmd := newResumeDebugAnalysisTasksCmd()
 	var output bytes.Buffer
@@ -899,7 +900,7 @@ func TestResumeDebugAnalysisTasksCommandWritesTable(t *testing.T) {
 	if !strings.Contains(text, "task-1") || !strings.Contains(text, "CNC Sales") {
 		t.Fatalf("unexpected analysis-tasks table output: %s", text)
 	}
-	if !strings.Contains(text, "task-2") || !strings.Contains(text, "running") || !strings.Contains(text, "5/10") {
+	if !strings.Contains(text, "task-2") || !strings.Contains(text, "running") || !strings.Contains(text, "Sales") {
 		t.Fatalf("unexpected analysis-tasks table output (task-2): %s", text)
 	}
 }

--- a/packages/cli/cmd/resume_test.go
+++ b/packages/cli/cmd/resume_test.go
@@ -345,6 +345,221 @@ func TestResumeAnalyzeCommandWithJDWritesTable(t *testing.T) {
 	}
 }
 
+func TestResumeSearchCommandDefaultsToAgentOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(client.ResumesResponse{
+			Success: true,
+			Data: []client.ResumeItem{
+				{ResumeID: "resume-1", Name: "Alice Chow", Location: "Dongguan", JobIntention: "Sales"},
+			},
+			Summary: client.ResumesSummary{Total: 1, Returned: 1, Query: "CNC sales", Source: "convex"},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "hr")
+	setCLIOutput(t, "agent")
+
+	cmd := newResumeSearchCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"CNC sales", "--limit", "5", "--source", "convex"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume search command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, `kind=summary query="CNC sales" source=convex total=1 returned=1`) {
+		t.Fatalf("missing compact summary: %s", text)
+	}
+	if !strings.Contains(text, `id=resume-1 name="Alice Chow" intention=Sales location=Dongguan`) {
+		t.Fatalf("missing compact row: %s", text)
+	}
+	if strings.Contains(text, "Query:") || strings.Contains(text, "+---") {
+		t.Fatalf("agent output contains human formatting: %s", text)
+	}
+}
+
+func TestResumeAnalyzeCommandDefaultsToAgentOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(client.AnalyzeResponse{
+			Success:     true,
+			TaskID:      "task-1",
+			ResumeCount: 42,
+			DryRun:      false,
+			Config: &client.AnalyzeConfig{
+				Keywords: []string{"CNC", "sales"},
+				Location: "Dongguan",
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "hr")
+	setCLIOutput(t, "agent")
+
+	cmd := newResumeAnalyzeCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--query", "CNC sales", "--location", "Dongguan"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume analyze command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, `kind=analysis candidates=42 dry_run=false task_id=task-1`) {
+		t.Fatalf("unexpected agent output: %s", text)
+	}
+	if strings.Contains(text, "Candidates:") || strings.Contains(text, "Task ID:") {
+		t.Fatalf("agent output contains human prose: %s", text)
+	}
+}
+
+func TestResumeManualImportCommandAgentOutput(t *testing.T) {
+	uploadPath := filepath.Join(t.TempDir(), "51job.rar")
+	if err := os.WriteFile(uploadPath, []byte("rar-bytes"), 0o644); err != nil {
+		t.Fatalf("failed to write upload file: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(8 << 20); err != nil {
+			t.Fatalf("failed to parse multipart form: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(client.ResumeManualImportResponse{
+			Success: true,
+			Source: client.ResumeManualImportSource{
+				Key:   "51job-manual",
+				Label: "51job-manual",
+			},
+			Summary: client.ResumeManualImportSummary{
+				UploadedFiles:   1,
+				DiscoveredFiles: 1,
+				ParsedResumes:   1,
+				Imported:        1,
+			},
+			Files: []client.ResumeManualImportFileResult{
+				{
+					UploadName: "51job.rar",
+					EntryPath:  "51job_张三(123456).docx",
+					Extension:  ".docx",
+					Status:     "imported",
+					ResumeName: "张三",
+					ProfileID:  "123456",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "hr")
+	setCLIOutput(t, "agent")
+
+	cmd := newResumeManualImportCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{uploadPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume manual import command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, `kind=summary source=51job-manual uploaded=1 discovered=1 parsed=1 imported=1 failed=0`) {
+		t.Fatalf("missing agent summary: %s", text)
+	}
+	if !strings.Contains(text, `extension=.docx status=imported resume_name=张三 profile_id=123456`) {
+		t.Fatalf("missing agent row: %s", text)
+	}
+}
+
+func TestResumeShowCommandAgentOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(client.ResumeDetailResponse{
+			Success: true,
+			Source:  "convex",
+			Data: client.ResumeItem{
+				ResumeID:       "resume-1",
+				Name:           "Alice",
+				JobIntention:   "Sales",
+				Location:       "Dongguan",
+				Experience:     "8 years",
+				Education:      "Bachelor",
+				ActivityStatus: "Active today",
+				ExpectedSalary: "20K",
+				ProfileURL:     "https://example.com/alice",
+				SelfIntro:      "Strong CNC sales background.",
+				WorkHistory: []client.ResumeWorkHistoryItem{
+					{Raw: "2021-03 ~ Example Co. Sales Manager"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "hr")
+	setCLIOutput(t, "agent")
+
+	cmd := newResumeShowCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"resume-1", "--source", "convex"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume show command failed: %v", err)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, `kind=resume_detail id=resume-1 name=Alice source=convex intention=Sales location=Dongguan experience="8 years" education=Bachelor`) {
+		t.Fatalf("missing agent resume detail: %s", text)
+	}
+	if !strings.Contains(text, `detail="use --output json for full resume"`) {
+		t.Fatalf("missing json hint: %s", text)
+	}
+	if strings.Contains(text, "Self Intro:") || strings.Contains(text, "Work History:") {
+		t.Fatalf("agent output contains human prose: %s", text)
+	}
+}
+
+func TestResumeSearchCommandCSVHasNoProse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(client.ResumesResponse{
+			Success: true,
+			Data: []client.ResumeItem{
+				{ResumeID: "resume-1", Name: "Alice", Location: "Dongguan", JobIntention: "Sales"},
+			},
+			Summary: client.ResumesSummary{Total: 1, Returned: 1, Query: "CNC sales", Source: "convex"},
+		})
+	}))
+	defer server.Close()
+
+	setResumeCLIConfig(t, server.URL, "hr")
+	setCLIOutput(t, "csv")
+
+	cmd := newResumeSearchCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"CNC sales", "--limit", "5", "--source", "convex"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("resume search command failed: %v", err)
+	}
+
+	text := output.String()
+	if strings.Contains(text, "Query:") || strings.Contains(text, "Source:") {
+		t.Fatalf("csv output contains prose prelude: %s", text)
+	}
+	if !strings.HasPrefix(text, "id,name,intention,location,experience,education") {
+		t.Fatalf("csv output missing header: %s", text)
+	}
+}
+
 func TestResumeManualImportCommandRejectsZeroLimitWhenExplicitlySet(t *testing.T) {
 	cmd := newResumeManualImportCmd()
 	cmd.SetArgs([]string{"sample.rar", "--limit", "0"})

--- a/packages/cli/cmd/root.go
+++ b/packages/cli/cmd/root.go
@@ -14,7 +14,7 @@ import (
 const (
 	defaultAPIURL    = "http://localhost:3000"
 	defaultWorkerURL = "http://localhost:8000"
-	defaultOutput    = "table"
+	defaultOutput    = "agent"
 )
 
 type RootOptions struct {
@@ -34,11 +34,11 @@ var rootCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		output := strings.ToLower(strings.TrimSpace(viper.GetString("output")))
 		switch output {
-		case "table", "json", "csv":
+		case "agent", "table", "json", "csv":
 			viper.Set("output", output)
 			return nil
 		default:
-			return fmt.Errorf("invalid output format %q (expected table|json|csv)", output)
+			return fmt.Errorf("invalid output format %q (expected agent|table|json|csv)", output)
 		}
 	},
 }
@@ -55,7 +55,7 @@ func init() {
 	rootCmd.PersistentFlags().String("api-url", defaultAPIURL, "BFF API base URL")
 	rootCmd.PersistentFlags().String("worker-url", defaultWorkerURL, "Worker API base URL")
 	rootCmd.PersistentFlags().String("workspace", "dev", "Workspace slug")
-	rootCmd.PersistentFlags().StringP("output", "o", defaultOutput, "Output format: table|json|csv")
+	rootCmd.PersistentFlags().StringP("output", "o", defaultOutput, "Output format: agent|table|json|csv")
 
 	_ = viper.BindPFlag("api_url", rootCmd.PersistentFlags().Lookup("api-url"))
 	_ = viper.BindPFlag("worker_url", rootCmd.PersistentFlags().Lookup("worker-url"))

--- a/packages/cli/cmd/root_test.go
+++ b/packages/cli/cmd/root_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -41,6 +42,34 @@ func TestPersistentPreRunEValidatesOutput(t *testing.T) {
 	viper.Set("output", "xml")
 	if err := rootCmd.PersistentPreRunE(rootCmd, nil); err == nil {
 		t.Fatal("expected invalid output format error")
+	}
+}
+
+func TestDefaultOutputIsAgent(t *testing.T) {
+	if got := defaultOutput; got != "agent" {
+		t.Fatalf("expected default output agent, got %q", got)
+	}
+}
+
+func TestPersistentPreRunEValidatesAgentOutput(t *testing.T) {
+	originalOutput := viper.GetString("output")
+	defer viper.Set("output", originalOutput)
+
+	valid := []string{"agent", "table", "json", "csv", " AGENT "}
+	for _, format := range valid {
+		viper.Set("output", format)
+		if err := rootCmd.PersistentPreRunE(rootCmd, nil); err != nil {
+			t.Fatalf("expected valid output format %q, got error: %v", format, err)
+		}
+	}
+
+	viper.Set("output", "xml")
+	err := rootCmd.PersistentPreRunE(rootCmd, nil)
+	if err == nil {
+		t.Fatal("expected invalid output format error")
+	}
+	if !strings.Contains(err.Error(), "agent|table|json|csv") {
+		t.Fatalf("expected error to list valid formats, got %q", err.Error())
 	}
 }
 

--- a/packages/cli/internal/output/agent.go
+++ b/packages/cli/internal/output/agent.go
@@ -1,0 +1,101 @@
+package output
+
+import (
+	"strconv"
+	"strings"
+)
+
+type Field struct {
+	Key   string
+	Value string
+}
+
+type AgentFormatter struct{}
+
+func (f *AgentFormatter) Format(data TabularData) ([]byte, error) {
+	if len(data.Rows) == 0 {
+		return nil, nil
+	}
+
+	columnCount := len(data.Headers)
+	for _, row := range data.Rows {
+		if len(row) > columnCount {
+			columnCount = len(row)
+		}
+	}
+
+	var builder strings.Builder
+	for _, row := range data.Rows {
+		fields := make([]Field, 0, columnCount)
+		for index := 0; index < columnCount; index++ {
+			key := "col_" + strconv.Itoa(index+1)
+			if index < len(data.Headers) {
+				key = data.Headers[index]
+			}
+
+			value := ""
+			if index < len(row) {
+				value = row[index]
+			}
+			fields = append(fields, Field{Key: key, Value: value})
+		}
+		builder.WriteString(FormatFields(fields))
+		builder.WriteByte('\n')
+	}
+
+	return []byte(builder.String()), nil
+}
+
+func FormatFields(fields []Field) string {
+	parts := make([]string, 0, len(fields))
+	for _, field := range fields {
+		key := normalizeFieldKey(field.Key)
+		if key == "" {
+			continue
+		}
+		parts = append(parts, key+"="+formatFieldValue(field.Value))
+	}
+	return strings.Join(parts, " ")
+}
+
+func normalizeFieldKey(key string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(key))
+	var builder strings.Builder
+	lastSeparator := false
+
+	for _, value := range trimmed {
+		switch {
+		case value >= 'a' && value <= 'z':
+			builder.WriteRune(value)
+			lastSeparator = false
+		case value >= '0' && value <= '9':
+			builder.WriteRune(value)
+			lastSeparator = false
+		case value == '_' || value == '-' || value == '.':
+			builder.WriteRune(value)
+			lastSeparator = false
+		default:
+			if !lastSeparator {
+				builder.WriteByte('_')
+				lastSeparator = true
+			}
+		}
+	}
+
+	return strings.Trim(builder.String(), "_")
+}
+
+func formatFieldValue(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "-"
+	}
+	if needsQuotedFieldValue(trimmed) {
+		return strconv.Quote(trimmed)
+	}
+	return trimmed
+}
+
+func needsQuotedFieldValue(value string) bool {
+	return strings.ContainsAny(value, " \t\n\r\"'=|")
+}

--- a/packages/cli/internal/output/formatter.go
+++ b/packages/cli/internal/output/formatter.go
@@ -19,6 +19,8 @@ func NewFormatter(name string) (Formatter, error) {
 		return &JSONFormatter{}, nil
 	case "csv":
 		return &CSVFormatter{}, nil
+	case "agent":
+		return &AgentFormatter{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported output formatter %q", name)
 	}

--- a/packages/cli/internal/output/formatter_test.go
+++ b/packages/cli/internal/output/formatter_test.go
@@ -62,3 +62,50 @@ func TestCSVFormatter(t *testing.T) {
 		t.Fatalf("unexpected CSV output: %s", text)
 	}
 }
+
+func TestNewFormatterSupportsAgent(t *testing.T) {
+	formatter, err := NewFormatter("agent")
+	if err != nil {
+		t.Fatalf("NewFormatter(agent) returned error: %v", err)
+	}
+	if formatter == nil {
+		t.Fatal("NewFormatter(agent) returned nil formatter")
+	}
+}
+
+func TestAgentFormatterFormatsKeyValueRows(t *testing.T) {
+	formatter := &AgentFormatter{}
+	output, err := formatter.Format(TabularData{
+		Headers: []string{"Resume ID", "name", "score", "empty"},
+		Rows: [][]string{
+			{"resume-1", "Alice Chow", "91", ""},
+			{"resume-2", "Bob=Ops", "", "x|y"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Agent formatter returned error: %v", err)
+	}
+
+	want := strings.Join([]string{
+		`resume_id=resume-1 name="Alice Chow" score=91 empty=-`,
+		`resume_id=resume-2 name="Bob=Ops" score=- empty="x|y"`,
+		"",
+	}, "\n")
+	if string(output) != want {
+		t.Fatalf("unexpected agent output:\nwant=%q\ngot=%q", want, string(output))
+	}
+}
+
+func TestAgentFormatterHandlesMissingCells(t *testing.T) {
+	formatter := &AgentFormatter{}
+	output, err := formatter.Format(TabularData{
+		Headers: []string{"id", "status"},
+		Rows:    [][]string{{"task-1"}},
+	})
+	if err != nil {
+		t.Fatalf("Agent formatter returned error: %v", err)
+	}
+	if got := string(output); got != "id=task-1 status=-\n" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Changed default CLI output format from `table` to `agent` (compact `key=value`)
- Added `AgentFormatter` in `packages/cli/internal/output/agent.go`
- All resume commands (search, show, analyze, match, manual-import) support agent output
- Debug commands (analysis-tasks, workflow-dataset) support agent output
- `table`, `json`, and `csv` remain as explicit backward-compatible options
- Added `writeAgentFields` and `writeAgentSummary` helpers in `output.go`

## Test plan
- [x] `go test ./packages/cli/...` passes (all new + existing)
- [x] `make check` passes
- [x] Simplify review passed with no issues