### PR TITLE
Allow HR workspace export field settings

### DIFF
--- a/apps/api/src/routes/config.test.ts
+++ b/apps/api/src/routes/config.test.ts
@@ -218,6 +218,65 @@ describe('config route workspace access', () => {
     })
   })
 
+  it('allows hr users to load export field settings', async () => {
+    const getExportFieldsSpy = vi.spyOn(workspaceConfigService, 'getExportFieldsConfig').mockResolvedValue({
+      fields: ['resumeId', 'name'],
+      includeDebugWhenEnabled: false,
+    })
+
+    const app = createTestApp()
+    const response = await app.request('/api/config/export-fields', {
+      headers: {
+        'X-Workspace-Slug': 'hr',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(getExportFieldsSpy).toHaveBeenCalledWith('hr')
+    expect(await response.json()).toEqual({
+      success: true,
+      config: {
+        fields: ['resumeId', 'name'],
+        includeDebugWhenEnabled: false,
+      },
+    })
+  })
+
+  it('allows hr users to update export field settings', async () => {
+    const setExportFieldsSpy = vi.spyOn(workspaceConfigService, 'setExportFieldsConfig').mockResolvedValue()
+    const getExportFieldsSpy = vi.spyOn(workspaceConfigService, 'getExportFieldsConfig').mockResolvedValue({
+      fields: ['resumeId', 'name', 'userRating'],
+      includeDebugWhenEnabled: true,
+    })
+
+    const app = createTestApp()
+    const response = await app.request('/api/config/export-fields', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Workspace-Slug': 'hr',
+      },
+      body: JSON.stringify({
+        fields: ['resumeId', 'name', 'userRating'],
+        includeDebugWhenEnabled: true,
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(setExportFieldsSpy).toHaveBeenCalledWith('hr', {
+      fields: ['resumeId', 'name', 'userRating'],
+      includeDebugWhenEnabled: true,
+    })
+    expect(getExportFieldsSpy).toHaveBeenCalledWith('hr')
+    expect(await response.json()).toEqual({
+      success: true,
+      config: {
+        fields: ['resumeId', 'name', 'userRating'],
+        includeDebugWhenEnabled: true,
+      },
+    })
+  })
+
   it('lists allowlisted config sources', async () => {
     const listSourcesSpy = vi.spyOn(configSourceInspector, 'listSources').mockReturnValue([
       {

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -1229,15 +1229,11 @@ const getExportFieldsRoute = createRoute({
   summary: "Get export fields configuration",
   responses: {
     200: { description: "Export fields config", content: { "application/json": { schema: ExportFieldsConfigResponseSchema } } },
-    403: { description: "Admin access required", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
   },
 });
 
 app.openapi(getExportFieldsRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
-  }
   try {
     const config = await workspaceConfigService.getExportFieldsConfig(c.var.workspaceSlug);
     return c.json({ success: true as const, config }, 200);
@@ -1258,15 +1254,11 @@ const putExportFieldsRoute = createRoute({
   responses: {
     200: { description: "Updated config", content: { "application/json": { schema: ExportFieldsConfigResponseSchema } } },
     400: { description: "Invalid payload", content: { "application/json": { schema: ErrorResponseSchema } } },
-    403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
   },
 });
 
 app.openapi(putExportFieldsRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
-  }
   try {
     const data = c.req.valid("json");
     await workspaceConfigService.setExportFieldsConfig(c.var.workspaceSlug, data);

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -126,6 +126,18 @@ describe('App redirects', () => {
     expect(screen.getByText('Resumes Page')).toBeInTheDocument()
   })
 
+  it('allows non-admin workspace users to open export field settings', async () => {
+    window.history.replaceState({}, '', '/hr/settings/export-fields')
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/hr/settings/export-fields')
+    })
+
+    expect(screen.getByText('Settings Layout')).toBeInTheDocument()
+  })
+
   it('redirects review-packets to resumes when feature flag is off', async () => {
     featureFlagsMock.reviewPacketsEnabled = false
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -183,11 +183,9 @@ function App() {
               <Route
                 path="export-fields"
                 element={(
-                  <AdminGate>
-                    <RouteSuspense>
-                      <LazySystemSettingsExportFieldsPage />
-                    </RouteSuspense>
-                  </AdminGate>
+                  <RouteSuspense>
+                    <LazySystemSettingsExportFieldsPage />
+                  </RouteSuspense>
                 )}
               />
             </Route>

--- a/apps/web/src/components/SettingsSidebar.test.tsx
+++ b/apps/web/src/components/SettingsSidebar.test.tsx
@@ -25,7 +25,7 @@ vi.mock('@trends/shared', () => ({
   SETTINGS_NAV_ITEMS: [
     { id: 'home', titleKey: 'nav.home', defaultTitle: 'Home', hrefSuffix: '/resumes', matchesSuffixes: ['/resumes'] },
     { id: 'blocks', titleKey: 'nav.blocks', defaultTitle: 'Blocks', hrefSuffix: '/blocks', matchesSuffixes: ['/blocks'] },
-    { id: 'export-fields', titleKey: 'nav.exportFields', defaultTitle: 'Export Fields', hrefSuffix: '/settings/export-fields', matchesSuffixes: ['/settings/export-fields'], requiresAdmin: true },
+    { id: 'export-fields', titleKey: 'nav.exportFields', defaultTitle: 'Export Fields', hrefSuffix: '/settings/export-fields', matchesSuffixes: ['/settings/export-fields'] },
   ],
 }))
 
@@ -53,13 +53,13 @@ describe('SettingsSidebar', () => {
     expect(screen.getByText('Export Fields')).toBeInTheDocument()
   })
 
-  it('hides admin-only navigation items for non-admin workspaces', () => {
+  it('shows export fields navigation for non-admin workspaces', () => {
     workspaceState.isAdmin = false
 
     renderWithRouter(<SettingsSidebar />)
 
     expect(screen.getByText('Home')).toBeInTheDocument()
-    expect(screen.queryByText('Export Fields')).not.toBeInTheDocument()
+    expect(screen.getByText('Export Fields')).toBeInTheDocument()
   })
 
   it('highlights active navigation item', () => {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -9370,19 +9370,6 @@ export interface paths {
                         };
                     };
                 };
-                /** @description Admin access required */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
-                    };
-                };
                 /** @description Server error */
                 500: {
                     headers: {
@@ -9433,19 +9420,6 @@ export interface paths {
                 };
                 /** @description Invalid payload */
                 400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: false;
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Forbidden */
-                403: {
                     headers: {
                         [name: string]: unknown;
                     };

--- a/packages/shared/src/system-debug-metadata.test.ts
+++ b/packages/shared/src/system-debug-metadata.test.ts
@@ -96,10 +96,10 @@ describe('SETTINGS_NAV_ITEMS', () => {
     expect(ids).toContain('export-fields')
   })
 
-  it('marks export fields as admin-only workspace settings', () => {
+  it('marks export fields as regular workspace settings', () => {
     const exportFields = SETTINGS_NAV_ITEMS.find((item) => item.id === 'export-fields')
     expect(exportFields?.hrefSuffix).toBe('/settings/export-fields')
-    expect(exportFields?.requiresAdmin).toBe(true)
+    expect(exportFields?.requiresAdmin).toBeUndefined()
   })
 })
 

--- a/packages/shared/src/system-debug-metadata.ts
+++ b/packages/shared/src/system-debug-metadata.ts
@@ -320,7 +320,6 @@ export const SETTINGS_NAV_ITEMS: SurfaceNavDefinition[] = [
     defaultTitle: "Export Fields",
     hrefSuffix: "/settings/export-fields",
     matchesSuffixes: ["/settings/export-fields"],
-    requiresAdmin: true,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Treat Export Fields as a regular workspace/user setting instead of admin-only.
- Show Export Fields in the regular Settings sidebar for HR/non-admin workspaces.
- Allow `/hr/settings/export-fields` to load without redirecting to `/hr/resumes`.
- Allow HR workspace users to GET/PUT `/api/config/export-fields` and regenerate API types.
- Revised Skillwiki reset guidance that previously described Export Fields as admin-only.

## Verification
- Red tests first confirmed old gates: shared metadata still had `requiresAdmin`, and API returned `403` for HR.
- `npm --workspace @trends/web test -- src/components/SettingsSidebar.test.tsx src/App.test.tsx src/pages/system-settings/SystemSettingsExportFieldsPage.test.tsx`
- `npm test -- packages/shared/src/system-debug-metadata.test.ts apps/api/src/routes/config.test.ts`
- `make check`
- `curl -s -H 'X-Workspace-Slug: hr' http://localhost:3000/api/config/export-fields` returns `{ "success": true, "config": null }`
- `playwright-cli open http://localhost:5173/hr/settings/export-fields` confirmed the HR settings sidebar shows `导出字段` and the page renders default export field selections.

## Wiki
- Updated `/Users/karlchow/wiki/projects/trends/compound/2026-06-04-version-migration-breakage-workflow.md`
