### PR TITLE
fix: remove requireAdmin from /api/resumes/export routes

### DIFF
--- a/apps/api/src/routes/resumes_packets.ts
+++ b/apps/api/src/routes/resumes_packets.ts
@@ -66,8 +66,6 @@ import {
 } from "./resumes-packets-helpers.js";
 
 const app = new OpenAPIHono();
-app.use("/api/resumes/export", requireAdmin);
-app.use("/api/resumes/export/*", requireAdmin);
 app.use("/api/resumes/review-packets", requireAdmin);
 app.use("/api/resumes/review-packets/*", requireAdmin);
 app.use("/api/resumes/learning-feedback", requireAdmin);


### PR DESCRIPTION
## Summary
- Removed `requireAdmin` middleware from `/api/resumes/export` and `/api/resumes/export/*` routes
- HR workspace users can now export CSV/XLSX without admin access
- Workspace isolation remains enforced by global `workspaceMiddleware`
- `review-packets` and `learning-feedback` routes remain admin-gated

## Test plan
- [x] `make check` passes (typecheck, lint, governance, auth audit)
- [x] 5/5 export tests pass
- [x] `check-route-auth` confirms all routes have auth middleware