### PR TITLE
fix: BFF status counts silently skip items without identityKey or with non-standard statuses

### DIFF
--- a/apps/api/src/routes/resumes_search.ts
+++ b/apps/api/src/routes/resumes_search.ts
@@ -975,12 +975,11 @@ app.openapi(getResumesRoute, (c) => {
           for (const item of sourceItems) {
             const resume = item.resume as Record<string, unknown> | undefined;
             const identityKey = typeof resume?.identityKey === "string" ? resume.identityKey : undefined;
-            if (identityKey) {
-              const status = statusMap.get(identityKey) ?? "new";
-              if (status in counts) {
-                counts[status] = (counts[status] ?? 0) + 1;
-              }
-            }
+            // Match Convex countResumesByStatus: missing identityKey → "new";
+            // non-standard statuses (contacted, interviewing, etc.) → "new"
+            const status = identityKey ? (statusMap.get(identityKey) ?? "new") : "new";
+            const bucket = status in counts ? status : "new";
+            counts[bucket] = (counts[bucket] ?? 0) + 1;
           }
           statusCounts = {
             new: counts.new ?? 0,


### PR DESCRIPTION
## Summary
- BFF `/api/resumes` status counting loop had two silent-skip bugs causing status count sums to be less than total results (e.g., 187 instead of 188)
- **Bug 1**: `if (identityKey)` guard skipped resumes without an `identityKey` field entirely
- **Bug 2**: `if (status in counts)` guard dropped statuses outside `{new, shortlisted, rejected}` (e.g., `contacted`, `interviewing`)
- Fix aligns BFF logic with Convex `countResumesByStatus`: missing identityKey → "new", non-standard status → "new"

## Test plan
- [x] `make check` passes (typecheck + lint + governance)
- [x] BFF search route tests pass
- [ ] Manual verification: visit the search URL and confirm counter shows correct totals