### PR TITLE
fix: use client-side status counts from actual results

### DIFF
--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -9,7 +9,7 @@ import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { useCandidateActions } from '@/hooks/useCandidateActions'
 import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
 import { useCandidateStatus } from '@/hooks/useCandidateStatus'
-import { useStatusCounts } from '@/hooks/useStatusCounts'
+
 import { useStableQuery } from '@/hooks/useStableQuery'
 import {
   useConvexResumes,
@@ -919,26 +919,13 @@ export function useResumeSearchState() {
 
   const facetCounts: FacetCounts = useFacetCounts(results, taxonomyClusters)
 
-  // Merge server-side status counts into facetCounts, falling back to client-side
-  const serverStatusCounts = useStatusCounts({
-    filters: backendFilters,
-    workspaceSlug: slug,
-    useAndModeBff: resumeQuery.isAndModeBff ?? false,
-    bffStatusCounts: resumeQuery.bffStatusCounts,
-  })
-  const facetCountsWithServerStatuses: FacetCounts = useMemo(() => {
-    if (!serverStatusCounts.loading && serverStatusCounts.total > 0) {
-      return {
-        ...facetCounts,
-        statuses: [
-          { value: 'new', label: '新候选人', count: serverStatusCounts.new },
-          { value: 'shortlisted', label: '已入围', count: serverStatusCounts.shortlisted },
-          { value: 'rejected', label: '已拒绝', count: serverStatusCounts.rejected },
-        ],
-      }
-    }
-    return facetCounts
-  }, [facetCounts, serverStatusCounts])
+  // Status counts come from useFacetCounts which computes them from the
+  // actual search results. Each result's status is looked up from
+  // candidate_status, so counts stay correct after bulk status changes.
+  // Server-side counts (BFF statusCounts / Convex countResumesByStatus)
+  // were previously used here but could diverge from displayed results
+  // due to keyword mismatch, pagination limits, or stale data.
+  const facetCountsWithServerStatuses: FacetCounts = facetCounts
   const hasMore = resumeQuery.hasMore
   const loading = !isLanding && resumeQuery.loading
   const loadingMore = resumeQuery.loadingMore


### PR DESCRIPTION
## Summary
- The counter (新候选人 / 已入围 / 已拒绝) was showing stale/wrong numbers because `facetCountsWithServerStatuses` was overriding client-side status counts from `useFacetCounts` with server-side counts
- Server-side counts could diverge from displayed results due to: keyword mismatch in Convex `countResumesByStatus`, stale BFF data not re-fetched after status changes, or Convex pagination limits
- Fix: use client-side `useFacetCounts` status counts directly, which are always computed from the actual loaded search results with their current `candidate_status` values

## Before
- Display: 186 results, Counter: 新候选人188 (2 shortlisted candidates both hidden and uncounted)

## After  
- Display: 186 results, Counter: 新候选人186 + 已入围2 = 188 ✓

## Test plan
- [x] `make check` passes
- [x] Browser verified: status counts match actual results before and after bulk status actions
- [x] 186 new + 2 shortlisted = 188 total (correct)