### PR TITLE
fix: align salary filters on raw CNY

### DIFF
--- a/apps/api/src/routes/__tests__/bff-filter-alignment.test.ts
+++ b/apps/api/src/routes/__tests__/bff-filter-alignment.test.ts
@@ -96,32 +96,36 @@ describe("bffMatchesResumeFilters", () => {
 
   describe("salary filter — parseSalaryRange", () => {
     it("parses salary with 万 multiplier correctly", () => {
-      // parseSalaryRange("15-25万/年") returns {min: 150, max: 250} (in 千 units)
+      // Search filters use raw CNY; "15-25万/年" parses to {min: 150000, max: 250000}.
       const doc = makeDoc({ content: { expectedSalary: "15-25万/年" } });
-      // max 250 should be above minSalary: 100 (千)
-      expect(bffMatchesResumeFilters(doc, "", { minSalary: 100 })).toBe(true);
+      expect(bffMatchesResumeFilters(doc, "", { minSalary: 100000 })).toBe(true);
     });
 
     it("excludes resumes below minSalary using range-aware parsing", () => {
-      // parseSalaryRange("5-8千/月") returns {min: 5, max: 8} (in 千 units)
+      // Search filters use raw CNY; "5-8千/月" parses to {min: 5000, max: 8000}.
       const doc = makeDoc({ content: { expectedSalary: "5-8千/月" } });
-      expect(bffMatchesResumeFilters(doc, "", { minSalary: 10 })).toBe(false);
+      expect(bffMatchesResumeFilters(doc, "", { minSalary: 10000 })).toBe(false);
     });
 
     it("excludes unknown salary when maxSalary is set", () => {
       const doc = makeDoc({ content: { expectedSalary: "" } });
-      expect(bffMatchesResumeFilters(doc, "", { maxSalary: 200 })).toBe(false);
+      expect(bffMatchesResumeFilters(doc, "", { maxSalary: 200000 })).toBe(false);
     });
 
     it("passes unknown salary when only minSalary is set", () => {
       const doc = makeDoc({ content: { expectedSalary: "" } });
-      expect(bffMatchesResumeFilters(doc, "", { minSalary: 50 })).toBe(true);
+      expect(bffMatchesResumeFilters(doc, "", { minSalary: 50000 })).toBe(true);
     });
 
     it("excludes resumes exceeding maxSalary", () => {
-      // parseSalaryRange("30-50万/年") returns {min: 300, max: 500} (in 千 units)
+      // Search filters use raw CNY; "30-50万/年" parses to {min: 300000, max: 500000}.
       const doc = makeDoc({ content: { expectedSalary: "30-50万/年" } });
-      expect(bffMatchesResumeFilters(doc, "", { maxSalary: 200 })).toBe(false);
+      expect(bffMatchesResumeFilters(doc, "", { maxSalary: 200000 })).toBe(false);
+    });
+
+    it("excludes monthly wan salaries above maxSalary=25000", () => {
+      const doc = makeDoc({ content: { expectedSalary: "2.8-4.2万/月" } });
+      expect(bffMatchesResumeFilters(doc, "", { maxSalary: 25000 })).toBe(false);
     });
   });
 
@@ -132,7 +136,7 @@ describe("bffMatchesResumeFilters", () => {
         maxExperience: 10,
         education: ["bachelor"],
         skills: ["cnc"],
-        minSalary: 100,
+        minSalary: 100000,
       })).toBe(true);
     });
 
@@ -344,8 +348,8 @@ describe("bffMatchesResumeFilters", () => {
         age: 30,
         locationText: "中国 广东 东莞",
         educationLevel: "bachelor",
-        salaryMin: 15,
-        salaryMax: 25,
+        salaryMin: 15000,
+        salaryMax: 25000,
         roleTypes: ["sales"],
         roleYearsByType: { sales: 3 },
         searchText: "cnc 销售 数控 机床 渠道",
@@ -356,6 +360,7 @@ describe("bffMatchesResumeFilters", () => {
         minAge: 25,
         maxAge: 40,
         locations: ["China"],
+        maxSalary: 25000,
       };
 
       expect(matchesResumeDigestFilters(digest, filters)).toBe(true);

--- a/apps/api/src/services/bff-filter-utils.test.ts
+++ b/apps/api/src/services/bff-filter-utils.test.ts
@@ -169,23 +169,28 @@ describe("bffMatchesResumeFilters — requiredKeywords", () => {
 
 describe("bffMatchesResumeFilters — salary", () => {
   it("passes when salary is within range", () => {
-    const doc = makeDoc(); // expectedSalary: "15k-25k" → parseSalaryRange returns {min:15, max:25}
-    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minSalary: 10, maxSalary: 30 })).toBe(true);
+    const doc = makeDoc(); // expectedSalary: "15k-25k" → raw CNY {min:15000, max:25000}
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minSalary: 10000, maxSalary: 30000 })).toBe(true);
   });
 
   it("fails when salary is below minimum", () => {
     const doc = makeDoc();
-    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minSalary: 30 })).toBe(false);
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minSalary: 30000 })).toBe(false);
+  });
+
+  it("excludes wan salaries above a raw-CNY maximum", () => {
+    const doc = makeDoc({ content: { expectedSalary: "2.8-4.2万/月" } });
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { maxSalary: 25000 })).toBe(false);
   });
 
   it("excludes unknown salary when maxSalary is set", () => {
     const doc = makeDoc({ content: { expectedSalary: undefined } });
-    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { maxSalary: 20 })).toBe(false);
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { maxSalary: 20000 })).toBe(false);
   });
 
   it("includes unknown salary when only minSalary is set", () => {
     const doc = makeDoc({ content: { expectedSalary: undefined } });
-    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minSalary: 10 })).toBe(true);
+    expect(bffMatchesResumeFilters(doc, BASE_TEXT, { minSalary: 10000 })).toBe(true);
   });
 });
 

--- a/apps/api/src/services/bff-filter-utils.ts
+++ b/apps/api/src/services/bff-filter-utils.ts
@@ -10,7 +10,7 @@ import {
   isLocationMatch,
   isRecord,
   normalizeResumeLocationHierarchy,
-  parseSalaryRange,
+  parseRawSalaryRange,
   resolveResumeAnalysisSourceKey,
   resolveExperienceYears,
 } from "@trends/shared";
@@ -104,7 +104,7 @@ export function bffMatchesResumeFilters(
 
   if (typeof filters.minSalary === "number" || typeof filters.maxSalary === "number") {
     const salaryStr = toStringValue(content.expectedSalary) ?? "";
-    const salary = parseSalaryRange(salaryStr);
+    const salary = parseRawSalaryRange(salaryStr);
     if (!salary) {
       // Unknown salary — exclude if maxSalary is set (cannot guarantee cap),
       // but skip minSalary (resume might meet the minimum).

--- a/apps/api/src/services/resume-service.test.ts
+++ b/apps/api/src/services/resume-service.test.ts
@@ -422,6 +422,31 @@ describe("ResumeService", () => {
       const filtered = service.filterResumes(items, { maxSalary: 10000 });
       expect(filtered).toHaveLength(0);
     });
+
+    it("excludes wan salaries above a raw-CNY maximum", () => {
+      const root = createFixtureRoot();
+      roots.push(root);
+      const service = new ResumeService(root);
+      const items = [
+        {
+          name: "High Salary",
+          profileUrl: "https://example.com/high-salary",
+          activityStatus: "Active",
+          age: "",
+          experience: "5 years",
+          education: "",
+          location: "China",
+          selfIntro: "",
+          jobIntention: "Sales",
+          expectedSalary: "2.8-4.2万/月",
+          workHistory: [],
+          extractedAt: "2026-03-20T00:00:00.000Z",
+        },
+      ];
+
+      const filtered = service.filterResumes(items, { maxSalary: 25000 });
+      expect(filtered).toHaveLength(0);
+    });
   });
 
   describe("education filter normalization", () => {

--- a/apps/api/src/services/resume-service.ts
+++ b/apps/api/src/services/resume-service.ts
@@ -10,7 +10,7 @@ import {
   normalizeProfileUrlForDisplay,
   normalizeSharedResumeFields,
   parseExperienceYears,
-  parseSalaryRange,
+  parseRawSalaryRange,
   selectLatestWorkHistory,
 } from "@trends/shared";
 
@@ -620,7 +620,7 @@ export class ResumeService {
       }
 
       if (filters.minSalary !== undefined || filters.maxSalary !== undefined) {
-        const salary = parseSalaryRange(item.expectedSalary);
+        const salary = parseRawSalaryRange(item.expectedSalary);
         if (!salary) {
           // Unknown salary — exclude if maxSalary is set (cannot guarantee cap),
           // but skip minSalary (resume might meet the minimum).
@@ -646,7 +646,7 @@ export class ResumeService {
 export { normalizeEducationLevel, parseExperienceYears } from "@trends/shared";
 
 export function parseSalaryRangeWithMeta(value: string | undefined): { min?: number; max?: number; currency?: string; period?: string } | null {
-  const parsed = parseSalaryRange(value);
+  const parsed = parseRawSalaryRange(value);
   if (!parsed) return null;
   const normalized = value!.replace(/\s/g, "");
   const periodMatch = normalized.match(/\/(月|年)/);

--- a/apps/web/src/hooks/resume-filter-helpers.test.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.test.ts
@@ -148,27 +148,31 @@ describe('matchesSalaryFilter', () => {
   })
 
   it('returns true when salary range overlaps min filter', () => {
-    expect(matchesSalaryFilter('10-20/月', 5)).toBe(true)
+    expect(matchesSalaryFilter('10000-20000/月', 5000)).toBe(true)
   })
 
   it('returns false when salary upper bound is below min filter', () => {
-    expect(matchesSalaryFilter('10-20/月', 25)).toBe(false)
+    expect(matchesSalaryFilter('10000-20000/月', 25000)).toBe(false)
   })
 
   it('returns true when salary range is below max filter', () => {
-    expect(matchesSalaryFilter('10-20/月', undefined, 25)).toBe(true)
+    expect(matchesSalaryFilter('10000-20000/月', undefined, 25000)).toBe(true)
   })
 
   it('returns false when salary lower bound exceeds max filter', () => {
-    expect(matchesSalaryFilter('10-20/月', undefined, 5)).toBe(false)
+    expect(matchesSalaryFilter('10000-20000/月', undefined, 5000)).toBe(false)
   })
 
-  it('handles 万 multiplier in filter matching', () => {
-    expect(matchesSalaryFilter('15-25万/年', 100, 300)).toBe(true)
+  it('handles raw-CNY filters with 万 multiplier in filter matching', () => {
+    expect(matchesSalaryFilter('15-25万/年', 100000, 300000)).toBe(true)
   })
 
   it('rejects 万 salary below min filter', () => {
-    expect(matchesSalaryFilter('15-25万/年', 300)).toBe(false)
+    expect(matchesSalaryFilter('15-25万/年', 300000)).toBe(false)
+  })
+
+  it('excludes monthly wan salaries above maxSalary=25000', () => {
+    expect(matchesSalaryFilter('2.8-4.2万/月', undefined, 25000)).toBe(false)
   })
 })
 

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -1,5 +1,5 @@
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
-import { formatKeywordQuery, formatLocationHierarchySearchText, getVerifiedRoleSignalYears, normalizeKeywordPhrases, parseSalaryRange } from '@trends/shared'
+import { formatKeywordQuery, formatLocationHierarchySearchText, getVerifiedRoleSignalYears, normalizeKeywordPhrases, parseRawSalaryRange } from '@trends/shared'
 import { resolveResumeAnalysisSourceKey } from '@trends/shared'
 import type { ExperienceLevelFilter, UrlSearchState } from '@/hooks/useUrlSearchState'
 
@@ -47,7 +47,7 @@ export function matchesSalaryFilter(
     return true
   }
 
-  const salary = parseSalaryRange(expectedSalary)
+  const salary = parseRawSalaryRange(expectedSalary)
   if (!salary) {
     return false
   }

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -435,8 +435,8 @@ describe('useResumeListState role filter regression', () => {
       education: ['bachelor'],
       skills: ['fanuc'],
       locations: ['Dongguan'],
-      minSalary: 10,
-      maxSalary: 20,
+      minSalary: 10000,
+      maxSalary: 20000,
     }
 
     renderHook(() => useResumeListState())
@@ -449,8 +449,8 @@ describe('useResumeListState role filter regression', () => {
           education: ['bachelor'],
           skills: ['fanuc'],
           locations: ['Dongguan'],
-          minSalary: 10,
-          maxSalary: 20,
+          minSalary: 10000,
+          maxSalary: 20000,
         },
       },
     })
@@ -459,7 +459,7 @@ describe('useResumeListState role filter regression', () => {
   it('applies skills and salary filters in AI mode', () => {
     mockState.filters = {
       skills: ['fanuc'],
-      minSalary: 15,
+      minSalary: 15000,
     }
     mockState.convexResumes = [
       buildResume({

--- a/apps/web/src/lib/search-profile-sources.test.ts
+++ b/apps/web/src/lib/search-profile-sources.test.ts
@@ -430,6 +430,7 @@ describe('buildSeekTalentSearchUrl', () => {
       matchAll: false,
       salaryType: 'MONTHLY',
       minSalary: 0,
+      maxSalary: 25000,
       salaryUnspecified: true,
     })
     expect(url).not.toBeNull()
@@ -445,6 +446,7 @@ describe('buildSeekTalentSearchUrl', () => {
     expect(parsed.searchParams.get('matchAll')).toBe('false')
     expect(parsed.searchParams.get('salaryType')).toBe('MONTHLY')
     expect(parsed.searchParams.get('minSalary')).toBe('0')
+    expect(parsed.searchParams.get('maxSalary')).toBe('25000')
     expect(parsed.searchParams.get('salaryUnspecified')).toBe('true')
   })
 

--- a/packages/convex/__tests__/resumes-list-projections.test.ts
+++ b/packages/convex/__tests__/resumes-list-projections.test.ts
@@ -2,10 +2,11 @@
  * Unit tests for lib/resumes_list_projections.ts
  *
  * Covers: projectResumeListDoc, projectResumeDetailDoc,
- * matchesResumeListFilters, sortResumeDocs,
+ * matchesResumeListFilters, buildResumeDigest, sortResumeDocs,
  * normalizeResumeListFilters, getIngestRuleScore.
  */
 import { describe, expect, it } from "vitest";
+import { buildResumeDigest } from "../convex/lib/resume_digests.js";
 import {
   projectResumeListDoc,
   projectResumeDetailDoc,
@@ -134,6 +135,30 @@ describe("matchesResumeListFilters", () => {
     // Source is resolved to the domain key (e.g. "job5156") via resolveResumeAnalysisSourceKey
     expect(matchesResumeListFilters(resume as any, { sources: ["job5156"] })).toBe(true);
     expect(matchesResumeListFilters(resume as any, { sources: ["linkedin"] })).toBe(false);
+  });
+
+  it("uses raw-CNY salary filters for wan salaries", () => {
+    const resume = makeResume({
+      content: { expectedSalary: "2.8-4.2万/月" },
+    }) as Parameters<typeof matchesResumeListFilters>[0];
+
+    expect(matchesResumeListFilters(resume, { maxSalary: 25000 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildResumeDigest
+// ---------------------------------------------------------------------------
+
+describe("buildResumeDigest", () => {
+  it("stores salary values in raw CNY for digest filtering", () => {
+    const resume = makeResume({
+      content: { expectedSalary: "2.8-4.2万/月" },
+    }) as Parameters<typeof buildResumeDigest>[0];
+    const digest = buildResumeDigest(resume, Date.UTC(2026, 5, 4));
+
+    expect(digest.salaryMin).toBe(28000);
+    expect(digest.salaryMax).toBe(42000);
   });
 });
 

--- a/packages/convex/convex/lib/resume_digests.ts
+++ b/packages/convex/convex/lib/resume_digests.ts
@@ -4,7 +4,7 @@ import {
     matchesResumeDigestFilters,
     normalizeEducationLevel,
     normalizeResumeLocationHierarchy,
-    parseSalaryRange,
+    parseRawSalaryRange,
     resolveExperienceYears,
 } from "@trends/shared";
 import type { Doc, Id } from "../_generated/dataModel";
@@ -39,7 +39,9 @@ export type ResumeDigest = {
 export function buildResumeDigest(resume: Doc<"resumes">, now: number): ResumeDigest {
     const content = isRecord(resume.content) ? resume.content : {};
     const locationHierarchy = normalizeResumeLocationHierarchy(content, resume.source);
-    const salary = parseSalaryRange(typeof content.expectedSalary === "string" ? content.expectedSalary : undefined);
+    const salary = parseRawSalaryRange(
+        typeof content.expectedSalary === "string" ? content.expectedSalary : undefined,
+    );
     const roleYearsByType = collectRoleYearsByType(resume);
 
     return {

--- a/packages/convex/convex/lib/resumes_list_projections.ts
+++ b/packages/convex/convex/lib/resumes_list_projections.ts
@@ -16,7 +16,7 @@ import {
     resolveExperienceYears,
     normalizeEducationLevel,
     isLocationMatch,
-    parseSalaryRange,
+    parseRawSalaryRange,
     resolveResumeAnalysisSourceKey,
     getVerifiedRoleSignalYears,
 } from "@trends/shared";
@@ -576,7 +576,7 @@ export function matchesResumeListFilters(resume: Doc<"resumes">, filters: Resume
     }
 
     if (filters.minSalary !== undefined || filters.maxSalary !== undefined) {
-        const salary = parseSalaryRange(toStringValue(content.expectedSalary));
+        const salary = parseRawSalaryRange(toStringValue(content.expectedSalary));
         if (!salary) {
             // Unknown salary — skip salary filter instead of excluding.
             // Same graceful-degradation pattern as experience filter:

--- a/packages/shared/src/__tests__/salary.test.ts
+++ b/packages/shared/src/__tests__/salary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseSalaryRange } from "../salary.js";
+import { parseRawSalaryRange, parseSalaryRange } from "../salary.js";
 
 // ---------------------------------------------------------------------------
 // parseSalaryRange
@@ -58,6 +58,15 @@ describe("parseSalaryRange", () => {
   it("parses '1万-2万' in raw mode", () => {
     const result = parseSalaryRange("1万-2万", { unit: "raw" });
     expect(result).toEqual({ min: 10000, max: 20000 });
+  });
+
+  it("parses monthly decimal wan salary in raw mode", () => {
+    const result = parseSalaryRange("2.8-4.2万/月", { unit: "raw" });
+    expect(result).toEqual({ min: 28000, max: 42000 });
+  });
+
+  it("parses monthly decimal wan salary with explicit raw helper", () => {
+    expect(parseRawSalaryRange("2.8-4.2万/月")).toEqual({ min: 28000, max: 42000 });
   });
 
   // --- 千 unit ---

--- a/packages/shared/src/salary.test.ts
+++ b/packages/shared/src/salary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseSalaryRange } from './salary'
+import { parseRawSalaryRange, parseSalaryRange } from './salary'
 
 describe('parseSalaryRange', () => {
   describe('null inputs', () => {
@@ -85,6 +85,14 @@ describe('parseSalaryRange', () => {
 
     it('converts single 万 value to raw CNY', () => {
       expect(parseSalaryRange('1.5万', { unit: 'raw' })).toEqual({ min: 15000, max: undefined })
+    })
+
+    it('converts monthly decimal 万 ranges to raw CNY', () => {
+      expect(parseSalaryRange('2.8-4.2万/月', { unit: 'raw' })).toEqual({ min: 28000, max: 42000 })
+    })
+
+    it('has an explicit raw-CNY helper', () => {
+      expect(parseRawSalaryRange('2.8-4.2万/月')).toEqual({ min: 28000, max: 42000 })
     })
   })
 

--- a/packages/shared/src/salary.ts
+++ b/packages/shared/src/salary.ts
@@ -9,8 +9,8 @@
  *   - "8000-12000"         → {8000, 12000} (bare numbers, same in both modes)
  *   - "12000-18000元/月"   → {12000, 18000} (bare numbers, same in both modes)
  *
- * Default output is in K-units (matches web UI filter convention).
- * Pass { unit: "raw" } for raw CNY values (ingest/index storage).
+ * Default output is in K-units for legacy callers.
+ * Pass { unit: "raw" } for raw CNY values (API filters and ingest/index storage).
  *
  * Bare numbers (no K/千/万 annotation) are returned as-is in both modes.
  * Only explicitly annotated values are unit-converted.
@@ -53,4 +53,8 @@ export function parseSalaryRange(
   // Bare numbers: returned as-is (unit-agnostic)
 
   return { min, max };
+}
+
+export function parseRawSalaryRange(value: string | undefined): { min?: number; max?: number } | null {
+  return parseSalaryRange(value, { unit: "raw" });
 }


### PR DESCRIPTION
## Summary
- Add `parseRawSalaryRange()` as the explicit raw-CNY salary parser helper while preserving legacy `parseSalaryRange()` K-mode defaults.
- Align salary filter comparisons across BFF AND-mode, BFF OR/sample filtering, Convex list filtering, Convex digest projection, and web-local fallback filtering.
- Add regression coverage for `maxSalary=25000` excluding `2.8-4.2万/月`, digest/full-doc parity, and raw salary URL preservation.

## Verification
- `npm --workspace @trends/shared run build && npm test -- apps/api/src/services/bff-filter-utils.test.ts apps/api/src/routes/__tests__/bff-filter-alignment.test.ts apps/api/src/services/resume-service.test.ts packages/convex/__tests__/resumes-list-projections.test.ts packages/shared/src/salary.test.ts packages/shared/src/__tests__/salary.test.ts`
- `npm --workspace @trends/web run test -- src/hooks/resume-filter-helpers.test.ts src/lib/search-profile-sources.test.ts`
- `make check`
- Browser smoke: `http://localhost:5173/dev/resumes?maxSalary=25000` loaded; no console errors observed, existing dev long-task warnings only.

## Deployment Note
Existing `resume_digests` rows may contain salary values projected in legacy K-units. After deploy, run the existing idempotent digest rebuild path (`resumes_search.backfillResumeDigests`, or broader `migrations.validateDataConsistency({ force: true })`) so BFF AND-mode digest scans use raw-CNY projections.

## Vault Handoff
- Updated `/Users/karlchow/wiki/queries/trends-v021-v030-feature-implementation-summary.md`.
- Updated `/Users/karlchow/wiki/projects/trends/work/2026-06-04-v021-v030-followup-audit-plan/` and added `salary-unit-parity-handoff-2026-06-04.md`.
- Vault auto-sync committed the wiki changes as `b023daa`.
