### PR TITLE
fix: backfill userRating in CSV export from stored candidate_actions

### DIFF
--- a/apps/api/src/routes/resumes_packets.test.ts
+++ b/apps/api/src/routes/resumes_packets.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeExportResumePayload,
   toExportEntryFields,
   toExportEntry,
+  applyStoredUserRatings,
   buildExportEntriesFromResolvedResumes,
   buildReviewPacketIdentityKey,
   toReviewPacketItemSnapshot,
@@ -250,6 +251,37 @@ describe("toExportEntry", () => {
   it("trims the key", () => {
     const result = toExportEntry("  r-1  ", makeExportResumePayload(), toExportEntryFields(makeEntryContext()));
     expect(result.key).toBe("r-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyStoredUserRatings
+// ---------------------------------------------------------------------------
+
+describe("applyStoredUserRatings", () => {
+  it("fills missing userRating from stored session ratings", () => {
+    const entry = toExportEntry("r-1", makeExportResumePayload(), toExportEntryFields(makeEntryContext()));
+
+    const result = applyStoredUserRatings([entry], new Map([["r-1", 5]]));
+
+    expect(result[0]?.userRating).toBe(5);
+  });
+
+  it("keeps an explicitly provided userRating over the stored fallback", () => {
+    const fields = toExportEntryFields(makeEntryContext({ userRating: 3 }));
+    const entry = toExportEntry("r-1", makeExportResumePayload(), fields);
+
+    const result = applyStoredUserRatings([entry], new Map([["r-1", 5]]));
+
+    expect(result[0]?.userRating).toBe(3);
+  });
+
+  it("returns original entries when no stored rating exists", () => {
+    const entry = toExportEntry("r-1", makeExportResumePayload(), toExportEntryFields(makeEntryContext()));
+
+    const result = applyStoredUserRatings([entry], new Map());
+
+    expect(result[0]).toBe(entry);
   });
 });
 

--- a/apps/api/src/routes/resumes_packets.ts
+++ b/apps/api/src/routes/resumes_packets.ts
@@ -236,6 +236,45 @@ export function buildExportEntriesFromResolvedResumes(
   return resolvedEntries;
 }
 
+export function applyStoredUserRatings(
+  entries: ResumeExportEntry[],
+  ratingsByResume: ReadonlyMap<string, number>
+): ResumeExportEntry[] {
+  if (ratingsByResume.size === 0) {
+    return entries;
+  }
+
+  return entries.map((entry) => {
+    if (entry.userRating !== undefined) {
+      return entry;
+    }
+
+    const rating = ratingsByResume.get(entry.key);
+    return rating === undefined
+      ? entry
+      : {
+          ...entry,
+          userRating: rating,
+        };
+  });
+}
+
+function resolveStoredRatingsForExportRequest(
+  request: Pick<ResumeExportCanonicalRequest, "sessionId" | "jobDescriptionId">,
+  entries: ResumeExportEntry[]
+): Map<string, number> {
+  const sessionId = request.sessionId?.trim();
+  if (!sessionId) {
+    return new Map();
+  }
+
+  return actionStorage.getLatestRatingsForSession({
+    sessionId,
+    jobDescriptionId: request.jobDescriptionId?.trim() || undefined,
+    resumeIds: entries.map((entry) => entry.key),
+  });
+}
+
 async function resolveExportRequest(
   request: ResumeExportCanonicalRequest
 ): Promise<{
@@ -248,7 +287,11 @@ async function resolveExportRequest(
   const resolvedResumes = request.source === "sample"
     ? resolveSampleExportResumeMap(request.sample ?? "", request.entries)
     : await resolveConvexExportResumeMap(request.entries);
-  const entries = buildExportEntriesFromResolvedResumes(request.entries, resolvedResumes);
+  const resolvedEntries = buildExportEntriesFromResolvedResumes(request.entries, resolvedResumes);
+  const entries = applyStoredUserRatings(
+    resolvedEntries,
+    resolveStoredRatingsForExportRequest(request, resolvedEntries)
+  );
 
   const industryDbV2Stats = request.industryDbV2Stats
     ?? computeBatchStats(entries.map((entry) => {
@@ -435,8 +478,12 @@ async function resolveReviewPacketExportRequest(
     ? resolveSampleReviewPacketRecordMap(request.sample ?? "", request.entries)
     : await resolveConvexReviewPacketRecordMap(request.entries);
   const resolved = buildReviewPacketEntriesFromResolvedRecords(request.entries, resolvedRecords);
+  const entries = applyStoredUserRatings(
+    resolved.entries,
+    resolveStoredRatingsForExportRequest(request, resolved.entries)
+  );
   const industryDbV2Stats = request.industryDbV2Stats
-    ?? computeBatchStats(resolved.entries.map((entry) => computeEffectiveIndustryDbV2Raw(entry.resume.ingestData)));
+    ?? computeBatchStats(entries.map((entry) => computeEffectiveIndustryDbV2Raw(entry.resume.ingestData)));
 
   return {
     format: request.format,
@@ -444,7 +491,7 @@ async function resolveReviewPacketExportRequest(
     sampleName: request.sample?.trim() || undefined,
     sessionId: request.sessionId?.trim() || undefined,
     jobDescriptionId: request.jobDescriptionId?.trim() || undefined,
-    entries: resolved.entries,
+    entries,
     items: resolved.items,
     batchMeta: {
       userComment: request.userComment,

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -951,6 +951,8 @@ export const ResumeExportCanonicalRequestSchema = z
     format: z.enum(["csv", "xlsx"]).default("csv").openapi({ example: "csv" }),
     source: ResumeExportSourceSchema,
     sample: z.string().optional().openapi({ example: "sample-initial" }),
+    sessionId: z.string().optional().openapi({ example: "lathe-sales" }),
+    jobDescriptionId: z.string().optional().openapi({ example: "jd-123" }),
     userComment: z.string().optional().openapi({ example: "Batch note" }),
     referenceNote: z.string().optional().openapi({ example: "Internal export" }),
     industryDbV2Stats: IndustryDbV2StatsSchema.optional(),

--- a/apps/api/src/services/action-storage.test.ts
+++ b/apps/api/src/services/action-storage.test.ts
@@ -158,6 +158,46 @@ describe("ActionStorage", () => {
     });
   });
 
+  describe("getLatestRatingsForSession", () => {
+    it("returns the latest non-zero ratings for requested resumes", () => {
+      setup();
+      storage.saveAction({ sessionId: "s1", resumeId: "r1", actionType: "rating", actionData: { rating: 2 } });
+      storage.saveAction({ sessionId: "s1", resumeId: "r1", actionType: "rating", actionData: { rating: 4 } });
+      storage.saveAction({ sessionId: "s1", resumeId: "r2", actionType: "rating", actionData: { rating: 0 } });
+      storage.saveAction({ sessionId: "s1", resumeId: "r3", actionType: "rating", actionData: { rating: 5 } });
+
+      const ratings = storage.getLatestRatingsForSession({
+        sessionId: "s1",
+        resumeIds: ["r1", "r2"],
+      });
+
+      expect(Object.fromEntries(ratings)).toEqual({ r1: 4 });
+    });
+
+    it("uses the same synthetic scope as the UI action loader", () => {
+      setup();
+      storage.saveAction({
+        sessionId: "keywords:cnc",
+        resumeId: "r1",
+        actionType: "rating",
+        actionData: { rating: 5 },
+      });
+      storage.saveAction({
+        sessionId: "keywords:lathe",
+        resumeId: "r1",
+        actionType: "rating",
+        actionData: { rating: 2 },
+      });
+
+      const ratings = storage.getLatestRatingsForSession({
+        sessionId: "keywords:cnc",
+        resumeIds: ["r1"],
+      });
+
+      expect(ratings.get("r1")).toBe(5);
+    });
+  });
+
   it("summarizes actions in a workspace window using persisted sessions and review packets", () => {
     root = createFixtureRoot();
     storage = new ActionStorage(root);

--- a/apps/api/src/services/action-storage.ts
+++ b/apps/api/src/services/action-storage.ts
@@ -122,6 +122,13 @@ function normalizeAction(row: Record<string, unknown>): CandidateAction {
   };
 }
 
+function parseRatingValue(actionData: Record<string, unknown> | undefined): number | undefined {
+  const rating = actionData?.rating;
+  return typeof rating === "number" && Number.isInteger(rating) && rating >= 0 && rating <= 5
+    ? rating
+    : undefined;
+}
+
 export class ActionStorage {
   private readonly db;
 
@@ -258,6 +265,37 @@ export class ActionStorage {
         );
 
     return rows.map((row) => normalizeAction(row));
+  }
+
+  getLatestRatingsForSession(params: {
+    sessionId: string;
+    resumeIds: string[];
+    jobDescriptionId?: string;
+  }): Map<string, number> {
+    const requestedResumeIds = new Set(
+      params.resumeIds
+        .map((resumeId) => resumeId.trim())
+        .filter((resumeId) => resumeId.length > 0)
+    );
+    if (requestedResumeIds.size === 0) {
+      return new Map();
+    }
+
+    const ratingsByResume = new Map<string, number>();
+    const latestActions = this.getLatestActionsForSession(params.sessionId, params.jobDescriptionId);
+    for (const action of latestActions) {
+      const resumeId = action.resumeId.trim();
+      if (action.actionType !== "rating" || !requestedResumeIds.has(resumeId)) {
+        continue;
+      }
+
+      const rating = parseRatingValue(action.actionData);
+      if (rating !== undefined && rating > 0) {
+        ratingsByResume.set(resumeId, rating);
+      }
+    }
+
+    return ratingsByResume;
   }
 
   summarizeActionsInWindow(params: {

--- a/apps/web/src/hooks/useResumeListState.test.tsx
+++ b/apps/web/src/hooks/useResumeListState.test.tsx
@@ -1140,11 +1140,13 @@ describe('useResumeListState role filter regression', () => {
 
     const parsedBody = capturedExportPayload as {
       source: string
+      sessionId?: string
       entries: Array<{ resumeId: string; userComment?: string; status?: string }>
       format: string
     }
     expect(parsedBody.format).toBe('csv')
     expect(parsedBody.source).toBe('convex')
+    expect(parsedBody.sessionId).toBe('global')
     expect(parsedBody.entries).toContainEqual(expect.objectContaining({
       resumeId: 'resume-ideal-cnc-sales',
       status: 'contacted',

--- a/apps/web/src/hooks/useResumeListState.ts
+++ b/apps/web/src/hooks/useResumeListState.ts
@@ -1483,9 +1483,12 @@ export function useResumeListState(loadSearchHistory = false) {
           userRating,
         }))
         const exportFormat = format ?? bulkExportFormat
+        const normalizedJobDescriptionId = normalizeOptionalString(jobDescriptionId)
         const exportRequest: ResumeExportRequestBody = {
           format: exportFormat,
           source: mode === 'ai' ? 'convex' : 'sample',
+          sessionId: sessionActionScope,
+          ...(normalizedJobDescriptionId ? { jobDescriptionId: normalizedJobDescriptionId } : {}),
           entries: exportEntries,
           ...(appliedSearchHistory?.industryDbV2Stats
             ? { industryDbV2Stats: appliedSearchHistory.industryDbV2Stats }
@@ -1537,7 +1540,7 @@ export function useResumeListState(loadSearchHistory = false) {
         toast.error(t('bulk.actionFailed', { defaultValue: 'Bulk action failed. Please try again.' }))
       }
     },
-    [apiBaseUrl, appliedSearchHistory?.industryDbV2Stats, blockCandidates, bulkExportFormat, displayedResumes, mode, saveAction, selectedIds, selectedSample, sendLearningFeedback, t, updateCandidateStatus]
+    [apiBaseUrl, appliedSearchHistory?.industryDbV2Stats, blockCandidates, bulkExportFormat, displayedResumes, jobDescriptionId, mode, saveAction, selectedIds, selectedSample, sendLearningFeedback, sessionActionScope, t, updateCandidateStatus]
   )
 
   const handleOpenReviewPacket = useCallback(async () => {

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -72,6 +72,7 @@ const {
   saveSearchHistoryMutationMock,
   recentSearchHistoryRecordsMock,
   analysisTasksMock,
+  ratingsByResumeMock,
   statusByIdentityMock,
   updateStatusMock,
   saveActionMock,
@@ -100,6 +101,7 @@ const {
   saveSearchHistoryMutationMock: vi.fn(async () => 'history-1'),
   recentSearchHistoryRecordsMock: [] as Array<Record<string, unknown>>,
   analysisTasksMock: [] as Array<Record<string, unknown>>,
+  ratingsByResumeMock: {} as Record<string, number>,
   statusByIdentityMock: {} as Record<string, CandidateStatusRecord>,
   updateStatusMock: vi.fn(async () => true),
   saveActionMock: vi.fn(async () => ({ success: true })),
@@ -146,7 +148,7 @@ vi.mock('@/hooks/useCandidateActions', () => ({
     actions: {},
     actionsByResume: {},
     aiFeedbackByResume: {},
-    ratingsByResume: {},
+    ratingsByResume: ratingsByResumeMock,
     loading: false,
     error: null,
     reload: vi.fn(),
@@ -278,6 +280,7 @@ describe('useResumeSearchState', () => {
     taxonomyClusterRecordsMock.splice?.(0, taxonomyClusterRecordsMock.length)
     Object.keys(statusByIdentityMock).forEach((key) => delete statusByIdentityMock[key])
     Object.keys(blocksByIdentityMock).forEach((key) => delete blocksByIdentityMock[key])
+    Object.keys(ratingsByResumeMock).forEach((key) => delete ratingsByResumeMock[key])
     convexQueryStateMock.hasMore = false
     convexQueryStateMock.loading = false
     convexQueryStateMock.loadingMore = false
@@ -1243,6 +1246,7 @@ describe('useResumeSearchState', () => {
   })
 
   it('exports the current filtered results with score-first metadata', async () => {
+    localStorage.setItem('trends.resume.search.sessionKey.dev', 'search-session-1')
     Object.assign(parsedStateMock, createParsedState({
       query: 'machine tools',
       keywords: ['machine tools'],
@@ -1283,6 +1287,7 @@ describe('useResumeSearchState', () => {
     statusByIdentityMock['identity-1'] = createStatusRecord('identity-1', 'contacted', {
       notes: 'Call first',
     })
+    ratingsByResumeMock['resume-1'] = 4
 
     const { result } = renderHook(() => useResumeSearchState())
 
@@ -1295,6 +1300,7 @@ describe('useResumeSearchState', () => {
       {
         format: 'csv',
         source: 'convex',
+        sessionId: 'search-session-1',
         entries: [
           {
             resumeId: 'resume-1',
@@ -1311,6 +1317,7 @@ describe('useResumeSearchState', () => {
             },
             ruleScore: 88,
             userComment: 'Call first',
+            userRating: 4,
           },
           {
             resumeId: 'resume-2',

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -446,6 +446,7 @@ function buildSearchExportMatch(
 
 function buildSearchExportEntry(
   item: ResumeSearchResultItem,
+  userRating?: number,
 ): ResumeExportRequestBody['entries'][number] {
   const match = buildSearchExportMatch(item)
   const userComment = normalizeOptionalString(item.statusMeta?.notes)
@@ -458,6 +459,7 @@ function buildSearchExportEntry(
       ? { ruleScore: item.resume.primaryRuleScore }
       : {}),
     ...(userComment ? { userComment } : {}),
+    ...(typeof userRating === 'number' ? { userRating } : {}),
   }
 }
 
@@ -1536,10 +1538,15 @@ export function useResumeSearchState() {
 
     setExportingResults(true)
     try {
+      const normalizedJobDescriptionId = normalizeOptionalString(parsedState.jobDescriptionId)
       const exportRequest: ResumeExportRequestBody = {
         format: exportFormat,
         source: 'convex',
-        entries: exportCandidates.map(buildSearchExportEntry),
+        sessionId: sessionKey,
+        ...(normalizedJobDescriptionId ? { jobDescriptionId: normalizedJobDescriptionId } : {}),
+        entries: exportCandidates.map((item) =>
+          buildSearchExportEntry(item, ratingsByResume[item.resume.resumeId])
+        ),
       }
 
       await submitResumeExportDownload(apiBaseUrl, exportRequest)
@@ -1554,7 +1561,7 @@ export function useResumeSearchState() {
     } finally {
       setExportingResults(false)
     }
-  }, [apiBaseUrl, exportFormat, filteredResults]) // selectedIds excluded on purpose — export uses snapshot at call time
+  }, [apiBaseUrl, exportFormat, filteredResults, parsedState.jobDescriptionId, ratingsByResume, sessionKey]) // selectedIds excluded on purpose — export uses snapshot at call time
 
   const analyzeResults = useCallback(async () => {
     if (analysisDispatchBatchIds.length === 0) {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -12205,6 +12205,10 @@ export interface components {
             source: components["schemas"]["ResumeExportSource"];
             /** @example sample-initial */
             sample?: string;
+            /** @example lathe-sales */
+            sessionId?: string;
+            /** @example jd-123 */
+            jobDescriptionId?: string;
             /** @example Batch note */
             userComment?: string;
             /** @example Internal export */


### PR DESCRIPTION
## Summary
- Search-page export now sends `userRating` from visible `ratingsByResume` and action scope (`sessionId`/`jobDescriptionId`)
- API export renderer falls back to latest non-zero `candidate_actions` rating when client doesn't provide one
- Added `getLatestRatingsForSession` to action-storage with scoped, latest-non-zero-rating semantics
- Added optional `sessionId`/`jobDescriptionId` to the normal export schema
- Resume-list bulk export now sends action scope for server fallback

## Test plan
- [x] `npm test -- apps/api/src/services/action-storage.test.ts apps/api/src/routes/resumes_packets.test.ts apps/api/src/services/export-service.test.ts` — 89 passed
- [x] `npm --workspace @trends/web run test -- src/hooks/useResumeSearchState.test.tsx src/hooks/useResumeListState.test.tsx` — 93 passed
- [x] `make check` — all checks passed
- [x] Simplify review — PASS, no blocking issues