### PR TITLE
fix: hide blocked candidates in resume search

### DIFF
--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -1908,6 +1908,27 @@ describe('useResumeSearchState', () => {
     expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1'])
   })
 
+  it('hides blocked new resumes from results and status facets by default', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'CNC 销售',
+      keywords: ['CNC', '销售'],
+      filters: { status: ['new'] },
+    }))
+
+    resumesMock.push(
+      createResume(1, { primaryRuleScore: 95 }),
+      createResume(2, { primaryRuleScore: 90 }),
+    )
+    statusByIdentityMock['identity-1'] = createStatusRecord('identity-1', 'new')
+    statusByIdentityMock['identity-2'] = createStatusRecord('identity-2', 'new')
+    blocksByIdentityMock['identity-1'] = true
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-2'])
+    expect(useFacetCountsMock.mock.calls[0]?.[0].map((item: { key: string }) => item.key)).toEqual(['resume-2'])
+  })
+
   it('includes rejected resumes when explicitly filtered for', () => {
     Object.assign(parsedStateMock, createParsedState({
       query: 'CNC 销售',

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -471,6 +471,13 @@ const ACTION_TO_STATUS: Partial<Record<CandidateActionType, CandidateStatus>> = 
   star: 'new',
 }
 
+function matchesBlockVisibility(
+  item: ResumeSearchResultItem,
+  filters: Partial<ResumeFilters>,
+): boolean {
+  return filters.showBlocked === true || !item.blocked
+}
+
 function matchesLocalFilters(
   item: ResumeSearchResultItem,
   state: UrlSearchState,
@@ -511,6 +518,10 @@ function matchesLocalFilters(
   const education = item.resume.education?.trim().toLowerCase() ?? ''
   const experienceLevel = normalizeExperienceLevel(item.resume.ingestData?.experienceLevel)
   const minScore = state.filters.minMatchScore
+
+  if (!matchesBlockVisibility(item, state.filters)) {
+    return false
+  }
 
   if (
     normalizedSelectedTags.length > 0 &&
@@ -886,10 +897,15 @@ export function useResumeSearchState() {
     statusByIdentity,
   ])
 
+  const blockVisibleResults = useMemo(
+    () => results.filter((item) => matchesBlockVisibility(item, parsedState.filters)),
+    [parsedState.filters, results],
+  )
+
   const filteredResults = useMemo(
     () =>
       sortResults(
-        results.filter((item) =>
+        blockVisibleResults.filter((item) =>
           matchesLocalFilters(
             item,
             {
@@ -908,9 +924,9 @@ export function useResumeSearchState() {
       ),
     [
       activeSort,
+      blockVisibleResults,
       effectiveRoleFilterType,
       parsedState,
-      results,
       selectedClusterTags,
       selectedRawTags,
       taxonomyResolver,
@@ -919,7 +935,7 @@ export function useResumeSearchState() {
 
   const deferredFilteredResults = useDeferredValue(filteredResults)
 
-  const facetCounts: FacetCounts = useFacetCounts(results, taxonomyClusters)
+  const facetCounts: FacetCounts = useFacetCounts(blockVisibleResults, taxonomyClusters)
 
   // Status counts come from useFacetCounts which computes them from the
   // actual search results. Each result's status is looked up from


### PR DESCRIPTION
## Summary
- hide blocked candidates from normal resume search/status results unless showBlocked is explicitly enabled
- compute status facets from the same block-visible result base so New counts do not include hidden blocked candidates
- add regression coverage for status=new with a blocked identity

## Verification
- npm --workspace @trends/web run test -- src/hooks/useResumeSearchState.test.tsx
- make check
- git diff --check
- playwright-cli smoke: http://localhost:5173/hr/resumes?status=new (0 console errors)