### PR TITLE
Fix resume status count totals

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -362,6 +362,88 @@ describe("resume routes", () => {
     }));
   });
 
+  it("excludes workspace blocked candidates from convex statusCounts by default", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes_search:scanResumeDigestPage") {
+        return convexSuccess({
+          docs: [
+            { _id: "d1", resumeId: "resume-visible-new", source: "seek", sourceKey: "seek", searchText: "cnc sales", isArchived: false },
+            { _id: "d2", resumeId: "resume-blocked-new", source: "seek", sourceKey: "seek", searchText: "cnc sales", isArchived: false },
+            { _id: "d3", resumeId: "resume-visible-rejected", source: "seek", sourceKey: "seek", searchText: "cnc sales", isArchived: false },
+          ],
+          isDone: true,
+          cursor: null,
+        });
+      }
+
+      if (call.pathName === "resumes_search:getResumeDocsByIds") {
+        return convexSuccess([
+          {
+            ...buildConvexResumeRecord("resume-visible-new", {
+              identityKey: "ik-visible-new",
+              name: "Visible New",
+            }),
+            searchText: "cnc sales",
+            isArchived: false,
+          },
+          {
+            ...buildConvexResumeRecord("resume-blocked-new", {
+              identityKey: "ik-blocked-new",
+              name: "Blocked New",
+            }),
+            searchText: "cnc sales",
+            isArchived: false,
+          },
+          {
+            ...buildConvexResumeRecord("resume-visible-rejected", {
+              identityKey: "ik-visible-rejected",
+              name: "Visible Rejected",
+            }),
+            searchText: "cnc sales",
+            isArchived: false,
+          },
+        ]);
+      }
+
+      if (call.pathName === "candidate_status:list") {
+        expect(call.args).toEqual(expect.objectContaining({ workspaceSlug: "hr" }));
+        return convexSuccess([
+          { identityKey: "ik-visible-rejected", status: "rejected" },
+        ]);
+      }
+
+      if (call.pathName === "candidate_blocks:list") {
+        expect(call.args).toEqual(expect.objectContaining({ workspaceSlug: "hr" }));
+        return convexSuccess([
+          { identityKey: "ik-blocked-new" },
+        ]);
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/resumes?source=convex&q=cnc%20sales&limit=5", {
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.summary.statusCounts).toEqual({
+      new: 1,
+      shortlisted: 0,
+      rejected: 1,
+    });
+    expect(calls.some((call) => call.pathName === "candidate_blocks:list")).toBe(true);
+  });
+
   it("keeps the static skills-version route from being shadowed by resume detail lookup", async () => {
     const app = createApp();
     const response = await app.request("/api/resumes/skills-version");
@@ -915,6 +997,10 @@ describe("resume routes", () => {
         return convexSuccess([]);
       }
 
+      if (call.pathName === "candidate_blocks:list") {
+        return convexSuccess([]);
+      }
+
       if (call.pathName === "resumes:getByIdsForExport") {
         return convexSuccess([
           buildConvexExportResumeRecord("resume-live-3", { name: "Carla" }),
@@ -959,6 +1045,12 @@ describe("resume routes", () => {
       }),
       expect.objectContaining({
         pathName: "candidate_status:list",
+        args: expect.objectContaining({
+          workspaceSlug: "dev",
+        }),
+      }),
+      expect.objectContaining({
+        pathName: "candidate_blocks:list",
         args: expect.objectContaining({
           workspaceSlug: "dev",
         }),

--- a/apps/api/src/routes/resumes_search.ts
+++ b/apps/api/src/routes/resumes_search.ts
@@ -639,6 +639,7 @@ app.openapi(getResumesRoute, (c) => {
     sources,
     minMatchScore,
     recommendation,
+    showBlocked,
     sortBy,
     sortOrder,
     sessionId,
@@ -661,6 +662,7 @@ app.openapi(getResumesRoute, (c) => {
   try {
     if (source === "convex") {
       return (async () => {
+        const workspaceSlug = c.var.workspaceSlug ?? "dev";
         const resolvedJobId = jobDescriptionId?.trim() || undefined;
         const normalizedKeywords = keyword ? normalizeKeywords(parseKeywordQuery(keyword).keywords) : [];
         const normalizedRequiredKeywords = normalizeKeywords(requiredKeywords);
@@ -961,13 +963,26 @@ app.openapi(getResumesRoute, (c) => {
         // Compute status counts from working set identityKeys
         let statusCounts: { new: number; shortlisted: number; rejected: number } | undefined;
         try {
-          const statusList: Array<{ identityKey?: string; status?: string }> = await callConvexQuery("candidate_status:list", {
-            workspaceSlug: "dev",
-          }) as Array<{ identityKey?: string; status?: string }>;
+          const [statusList, blockList] = await Promise.all([
+            callConvexQuery("candidate_status:list", {
+              workspaceSlug,
+            }) as Promise<Array<{ identityKey?: string; status?: string }>>,
+            showBlocked
+              ? Promise.resolve([] as Array<{ identityKey?: string }>)
+              : callConvexQuery("candidate_blocks:list", {
+                workspaceSlug,
+              }) as Promise<Array<{ identityKey?: string }>>,
+          ]);
           const statusMap = new Map<string, string>();
           for (const s of statusList) {
             if (s.identityKey && s.status) {
               statusMap.set(String(s.identityKey), String(s.status));
+            }
+          }
+          const blockedIdentities = new Set<string>();
+          for (const block of blockList) {
+            if (block.identityKey) {
+              blockedIdentities.add(String(block.identityKey));
             }
           }
           const counts: Record<string, number> = { new: 0, shortlisted: 0, rejected: 0 };
@@ -975,6 +990,9 @@ app.openapi(getResumesRoute, (c) => {
           for (const item of sourceItems) {
             const resume = item.resume as Record<string, unknown> | undefined;
             const identityKey = typeof resume?.identityKey === "string" ? resume.identityKey : undefined;
+            if (identityKey && blockedIdentities.has(identityKey)) {
+              continue;
+            }
             // Match Convex countResumesByStatus: missing identityKey → "new";
             // non-standard statuses (contacted, interviewing, etc.) → "new"
             const status = identityKey ? (statusMap.get(identityKey) ?? "new") : "new";

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -639,6 +639,14 @@ export const ResumesQuerySchema = z.object({
     param: { name: "recommendation", in: "query" },
     example: "strong_match,match",
   }),
+  showBlocked: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((value) => value === "true")
+    .openapi({
+      param: { name: "showBlocked", in: "query" },
+      example: "false",
+    }),
   // Semantic search parameters
   enableSemantic: z
     .enum(["true", "false"])
@@ -682,6 +690,11 @@ export const ResumesResponseSchema = z
         keywordGroups: z.array(KeywordGroupSchema).optional(),
         sourceMapping: z.record(z.string(), z.string()).optional(),
         searchMode: z.enum(["bm25", "bm25_fallback", "bm25_only_no_vectors", "hybrid"]).optional(),
+        statusCounts: z.object({
+          new: z.number().int(),
+          shortlisted: z.number().int(),
+          rejected: z.number().int(),
+        }).optional(),
       })
       .optional(),
     data: z.array(ResumeItemSchema),

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -807,6 +807,7 @@ function useBffAndModeSearch(
   keywordExpansion: KeywordExpansionSummary | null,
   expansionLoading: boolean,
   filters: ConvexResumeFilters | undefined,
+  showBlocked: boolean,
   jobDescriptionId: string | undefined,
   refetchTrigger?: number,
 ): BffAndModeResult {
@@ -853,6 +854,7 @@ function useBffAndModeSearch(
       ...(filters?.minSalary != null ? { minSalary: filters.minSalary } : {}),
       ...(filters?.maxSalary != null ? { maxSalary: filters.maxSalary } : {}),
       ...(filters?.sources?.length ? { sources: filters.sources.join(',') } : {}),
+      ...(showBlocked ? { showBlocked: 'true' } : {}),
       ...(jobDescriptionId ? { jobDescriptionId } : {}),
     }
 
@@ -928,7 +930,7 @@ function useBffAndModeSearch(
 
     return () => { active = false }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- filtersKey captures all filter fields via JSON.stringify
-  }, [enabled, expansionLoading, filtersKey, jobDescriptionId, keywordExpansion, normalizedQuery, refetchTrigger])
+  }, [enabled, expansionLoading, filtersKey, jobDescriptionId, keywordExpansion, normalizedQuery, refetchTrigger, showBlocked])
 
   return {
     ...(result.loading && result.resumes.length === 0
@@ -947,6 +949,7 @@ export function useConvexResumes(
     sortBy?: ConvexResumeSortBy
     sortOrder?: 'asc' | 'desc'
     filters?: ConvexResumeFilters
+    showBlocked?: boolean
   }
 ) {
   const enabled = options?.enabled ?? true
@@ -968,8 +971,8 @@ export function useConvexResumes(
   const [bffDisplayCount, setBffDisplayCount] = useState(CONVEX_RESUME_PAGE_SIZE)
   // Reset BFF display count when query or filters change
   const bffResetKey = useMemo(
-    () => `${normalizedQuery ?? ''}|${JSON.stringify(options?.filters ?? {})}`,
-    [normalizedQuery, options?.filters],
+    () => `${normalizedQuery ?? ''}|${JSON.stringify(options?.filters ?? {})}|${options?.showBlocked === true}`,
+    [normalizedQuery, options?.filters, options?.showBlocked],
   )
   useEffect(() => {
     setBffDisplayCount(CONVEX_RESUME_PAGE_SIZE)
@@ -1077,6 +1080,7 @@ export function useConvexResumes(
     keywordExpansion,
     expansionLoading,
     options?.filters,
+    options?.showBlocked === true,
     normalizedJobDescriptionId,
     bffRefetchTrigger,
   )

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -1929,6 +1929,82 @@ describe('useResumeSearchState', () => {
     expect(useFacetCountsMock.mock.calls[0]?.[0].map((item: { key: string }) => item.key)).toEqual(['resume-2'])
   })
 
+  it('uses server status totals for status facets instead of the loaded client slice', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'CNC 销售',
+      keywords: ['CNC', '销售'],
+    }))
+    useFacetCountsMock.mockReturnValue({
+      clusters: [],
+      tags: [],
+      companies: [],
+      experienceLevels: [],
+      education: [],
+      statuses: [{ value: 'new', count: 2, label: 'New candidate' }],
+      minScoreOptions: [],
+      sources: [],
+    })
+    useQueryMock.mockImplementation((query) => {
+      if (query === 'resumes:countResumesByStatus') {
+        return {
+          new: 797,
+          shortlisted: 0,
+          rejected: 1,
+          total: 798,
+          overflow: false,
+        }
+      }
+      return undefined
+    })
+    resumesMock.push(
+      createResume(1, { primaryRuleScore: 95 }),
+      createResume(2, { primaryRuleScore: 90 }),
+    )
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(result.current.facetCounts.statuses).toEqual([
+      { value: 'new', count: 797, label: 'New candidate' },
+      { value: 'rejected', count: 1 },
+    ])
+  })
+
+  it('uses BFF status totals for AND-mode status facets', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'CNC 销售',
+      keywords: ['CNC', '销售'],
+    }))
+    useFacetCountsMock.mockReturnValue({
+      clusters: [],
+      tags: [],
+      companies: [],
+      experienceLevels: [],
+      education: [],
+      statuses: [{ value: 'new', count: 2, label: 'New candidate' }],
+      minScoreOptions: [],
+      sources: [],
+    })
+    resumesMock.push(
+      createResume(1, { primaryRuleScore: 95 }),
+      createResume(2, { primaryRuleScore: 90 }),
+    )
+    useConvexResumesMock.mockImplementation(() => ({
+      resumes: resumesMock,
+      hasMore: false,
+      loading: false,
+      loadingMore: false,
+      isAndModeBff: true,
+      bffStatusCounts: { new: 797, shortlisted: 0, rejected: 1 },
+    }))
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(result.current.facetCounts.statuses).toEqual([
+      { value: 'new', count: 797, label: 'New candidate' },
+      { value: 'rejected', count: 1 },
+    ])
+  })
+
   it('includes rejected resumes when explicitly filtered for', () => {
     Object.assign(parsedStateMock, createParsedState({
       query: 'CNC 销售',

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -17,6 +17,7 @@ import {
   type ConvexResumeItem,
 } from '@/hooks/useConvexResumes'
 import { useFacetCounts } from '@/hooks/useFacetCounts'
+import { useStatusCounts, type StatusCounts } from '@/hooks/useStatusCounts'
 import {
   useUrlSearchState,
   type ExperienceLevelFilter,
@@ -67,6 +68,7 @@ import type {
 const INITIAL_RESUME_LIMIT = 200
 const RESUME_PAGE_INCREMENT = 200
 const SESSION_KEY_PREFIX = 'trends.resume.search.sessionKey'
+const SERVER_STATUS_FACET_VALUES = ['new', 'shortlisted', 'rejected'] as const
 
 type JobDescriptionApiResponse = {
   success: boolean
@@ -478,6 +480,40 @@ function matchesBlockVisibility(
   return filters.showBlocked === true || !item.blocked
 }
 
+function mergeServerStatusFacetCounts(
+  facetCounts: FacetCounts,
+  statusCounts: StatusCounts,
+): FacetCounts {
+  if (statusCounts.loading) {
+    return facetCounts
+  }
+
+  const labelsByValue = new Map(
+    facetCounts.statuses.map((item) => [item.value, item.label]),
+  )
+  const statuses = SERVER_STATUS_FACET_VALUES
+    .map((value) => {
+      const label = labelsByValue.get(value)
+      return {
+        value,
+        count: statusCounts[value],
+        ...(label ? { label } : {}),
+      }
+    })
+    .filter((item) => item.count > 0)
+    .sort((left, right) => {
+      if (right.count !== left.count) {
+        return right.count - left.count
+      }
+      return left.value.localeCompare(right.value)
+    })
+
+  return {
+    ...facetCounts,
+    statuses,
+  }
+}
+
 function matchesLocalFilters(
   item: ResumeSearchResultItem,
   state: UrlSearchState,
@@ -729,6 +765,7 @@ export function useResumeSearchState() {
     parsedState.filters.status,
     parsedState.filters.minSalary,
     parsedState.filters.maxSalary,
+    parsedState.filters.showBlocked,
     parsedState.jobDescriptionId,
     parsedState.location,
     parsedState.query,
@@ -801,6 +838,7 @@ export function useResumeSearchState() {
       ...(activeSort === 'experience'
         ? { sortBy: 'experience' as const, sortOrder: 'desc' as const }
         : {}),
+      showBlocked: parsedState.filters.showBlocked === true,
     },
   )
 
@@ -936,14 +974,17 @@ export function useResumeSearchState() {
   const deferredFilteredResults = useDeferredValue(filteredResults)
 
   const facetCounts: FacetCounts = useFacetCounts(blockVisibleResults, taxonomyClusters)
-
-  // Status counts come from useFacetCounts which computes them from the
-  // actual search results. Each result's status is looked up from
-  // candidate_status, so counts stay correct after bulk status changes.
-  // Server-side counts (BFF statusCounts / Convex countResumesByStatus)
-  // were previously used here but could diverge from displayed results
-  // due to keyword mismatch, pagination limits, or stale data.
-  const facetCountsWithServerStatuses: FacetCounts = facetCounts
+  const statusCounts = useStatusCounts({
+    enabled: !isLanding,
+    filters: {
+      ...backendFilters,
+      showBlocked: parsedState.filters.showBlocked === true,
+    },
+    workspaceSlug: slug,
+    useAndModeBff: resumeQuery.isAndModeBff === true,
+    bffStatusCounts: resumeQuery.bffStatusCounts,
+  })
+  const facetCountsWithServerStatuses: FacetCounts = mergeServerStatusFacetCounts(facetCounts, statusCounts)
   const hasMore = resumeQuery.hasMore
   const loading = !isLanding && resumeQuery.loading
   const loadingMore = resumeQuery.loadingMore

--- a/apps/web/src/hooks/useStatusCounts.test.ts
+++ b/apps/web/src/hooks/useStatusCounts.test.ts
@@ -60,6 +60,31 @@ describe("useStatusCounts", () => {
     expect(result.current.overflow).toBe(false);
   });
 
+  it("passes showBlocked to the Convex count query", async () => {
+    useQueryMock.mockReturnValue({
+      new: 3,
+      shortlisted: 0,
+      rejected: 0,
+      total: 3,
+      overflow: false,
+    });
+
+    const { useStatusCounts } = await import("@/hooks/useStatusCounts");
+    const filters = { locations: ["China"], showBlocked: true };
+    renderHook(() =>
+      useStatusCounts({ filters, workspaceSlug: "test", useAndModeBff: false })
+    );
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      "resumes:countResumesByStatus",
+      expect.objectContaining({
+        workspaceSlug: "test",
+        locations: ["China"],
+        showBlocked: true,
+      }),
+    );
+  });
+
   it("uses bffStatusCounts directly when useAndModeBff is true", async () => {
     useQueryMock.mockReturnValue(undefined);
 

--- a/apps/web/src/hooks/useStatusCounts.ts
+++ b/apps/web/src/hooks/useStatusCounts.ts
@@ -12,8 +12,13 @@ export interface StatusCounts {
   loading: boolean;
 }
 
+export type StatusCountFilters = ConvexResumeFilters & {
+  showBlocked?: boolean;
+};
+
 interface UseStatusCountsParams {
-  filters: ConvexResumeFilters;
+  enabled?: boolean;
+  filters: StatusCountFilters;
   workspaceSlug: string;
   useAndModeBff: boolean;
   bffStatusCounts?: { new: number; shortlisted: number; rejected: number };
@@ -28,11 +33,11 @@ interface CountResumesByStatusResult {
 }
 
 export function useStatusCounts(params: UseStatusCountsParams): StatusCounts {
-  const { filters, workspaceSlug, useAndModeBff, bffStatusCounts } = params;
+  const { enabled = true, filters, workspaceSlug, useAndModeBff, bffStatusCounts } = params;
 
   // Always call useMemo unconditionally (skip building args for BFF path)
   const queryArgs = useMemo(() => {
-    if (useAndModeBff) return "skip" as const;
+    if (!enabled || useAndModeBff) return "skip" as const;
     return {
       workspaceSlug,
       ...(filters.maxExperience != null ? { maxExperience: filters.maxExperience } : {}),
@@ -48,11 +53,16 @@ export function useStatusCounts(params: UseStatusCountsParams): StatusCounts {
       ...(filters.minSalary != null ? { minSalary: filters.minSalary } : {}),
       ...(filters.maxSalary != null ? { maxSalary: filters.maxSalary } : {}),
       ...(filters.sources?.length ? { sources: filters.sources } : {}),
+      ...(filters.showBlocked === true ? { showBlocked: true } : {}),
     };
-  }, [filters, workspaceSlug, useAndModeBff]);
+  }, [enabled, filters, workspaceSlug, useAndModeBff]);
 
   // Always call useQuery unconditionally
   const result = useQuery(api.resumes.countResumesByStatus, queryArgs as never) as CountResumesByStatusResult | undefined;
+
+  if (!enabled) {
+    return { new: 0, shortlisted: 0, rejected: 0, total: 0, overflow: false, loading: false };
+  }
 
   // BFF path: counts come from the BFF response
   if (useAndModeBff) {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -1772,6 +1772,7 @@ export interface paths {
                     maxAge?: string;
                     sources?: string | string[];
                     recommendation?: string | string[];
+                    showBlocked?: "true" | "false";
                     enableSemantic?: "true" | "false";
                     semanticWeight?: number | null;
                     semanticLimit?: string;
@@ -12523,6 +12524,11 @@ export interface components {
                 };
                 /** @enum {string} */
                 searchMode?: "bm25" | "bm25_fallback" | "bm25_only_no_vectors" | "hybrid";
+                statusCounts?: {
+                    new: number;
+                    shortlisted: number;
+                    rejected: number;
+                };
             };
             data: components["schemas"]["ResumeItem"][];
         };

--- a/packages/convex/__tests__/count-resumes-by-status-convex-test.test.ts
+++ b/packages/convex/__tests__/count-resumes-by-status-convex-test.test.ts
@@ -207,4 +207,87 @@ describe("countResumesByStatus", () => {
     expect(result.total).toBe(1);
     expect(result.new).toBe(1);
   });
+
+  it("excludes blocked resumes by default", async () => {
+    const source = "test-count-blocked-default";
+    const ws = "test-count-blocked-default-ws";
+    await test.run(async (ctx) => {
+      await ctx.db.insert("resumes", {
+        externalId: "ext-block-visible",
+        identityKey: "ik-block-visible",
+        content: { name: "Visible" },
+        hash: "hash-block-visible",
+        tags: [],
+        crawledAt: Date.now(),
+        source,
+        sourceKey: source,
+      });
+      await ctx.db.insert("resumes", {
+        externalId: "ext-block-hidden",
+        identityKey: "ik-block-hidden",
+        content: { name: "Hidden" },
+        hash: "hash-block-hidden",
+        tags: [],
+        crawledAt: Date.now(),
+        source,
+        sourceKey: source,
+      });
+      await ctx.db.insert("candidate_blocks", {
+        workspaceSlug: ws,
+        identityKey: "ik-block-hidden",
+        reason: "duplicate",
+        blockedAt: Date.now(),
+      });
+    });
+
+    const result = await test.query(api.resumes.countResumesByStatus, {
+      workspaceSlug: ws,
+      sources: [source],
+    });
+
+    expect(result.new).toBe(1);
+    expect(result.total).toBe(1);
+  });
+
+  it("includes blocked resumes when showBlocked is true", async () => {
+    const source = "test-count-blocked-visible";
+    const ws = "test-count-blocked-visible-ws";
+    await test.run(async (ctx) => {
+      await ctx.db.insert("resumes", {
+        externalId: "ext-show-block-visible",
+        identityKey: "ik-show-block-visible",
+        content: { name: "Visible" },
+        hash: "hash-show-block-visible",
+        tags: [],
+        crawledAt: Date.now(),
+        source,
+        sourceKey: source,
+      });
+      await ctx.db.insert("resumes", {
+        externalId: "ext-show-block-hidden",
+        identityKey: "ik-show-block-hidden",
+        content: { name: "Hidden" },
+        hash: "hash-show-block-hidden",
+        tags: [],
+        crawledAt: Date.now(),
+        source,
+        sourceKey: source,
+      });
+      await ctx.db.insert("candidate_blocks", {
+        workspaceSlug: ws,
+        identityKey: "ik-show-block-hidden",
+        reason: "duplicate",
+        blockedAt: Date.now(),
+      });
+    });
+
+    const result = await test.query(api.resumes.countResumesByStatus, {
+      workspaceSlug: ws,
+      sources: [source],
+      showBlocked: true,
+    });
+
+    expect(result.new).toBe(2);
+    expect(result.total).toBe(2);
+  });
 });

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -636,9 +636,10 @@ export const countResumesByStatus = query({
     minSalary: v.optional(v.number()),
     maxSalary: v.optional(v.number()),
     sources: v.optional(v.array(v.string())),
+    showBlocked: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
-    const { workspaceSlug, ...rawFilters } = args;
+    const { workspaceSlug, showBlocked, ...rawFilters } = args;
 
     // 1. Load candidate_status for workspace
     const statuses = await ctx.db
@@ -651,6 +652,19 @@ export const countResumesByStatus = query({
     const statusByIdentity = new Map<string, string>();
     for (const s of statuses) {
       statusByIdentity.set(s.identityKey, s.status);
+    }
+
+    const blockedIdentities = new Set<string>();
+    if (showBlocked !== true) {
+      const blocks = await ctx.db
+        .query("candidate_blocks")
+        .withIndex("by_workspace", (q) =>
+          q.eq("workspaceSlug", workspaceSlug)
+        )
+        .collect();
+      for (const block of blocks) {
+        blockedIdentities.add(block.identityKey);
+      }
     }
 
     // 2. Build normalized filters (always exclude archived)
@@ -682,8 +696,12 @@ export const countResumesByStatus = query({
       }
       if (matchesResumeListFilters(resume, filters)) {
         const identityKey = resume.identityKey ?? "";
+        if (identityKey && blockedIdentities.has(identityKey)) {
+          continue;
+        }
         const status = statusByIdentity.get(identityKey) ?? "new";
-        counts[status] = (counts[status] ?? 0) + 1;
+        const bucket = status === "shortlisted" || status === "rejected" ? status : "new";
+        counts[bucket] = (counts[bucket] ?? 0) + 1;
         totalMatched += 1;
       }
     }
@@ -702,5 +720,4 @@ export const countResumesByStatus = query({
     };
   },
 });
-
 


### PR DESCRIPTION
## Summary
- restore server-backed status totals in resume search facets/chips instead of loaded-slice counts
- exclude workspace-blocked candidates from default Convex and BFF status counts, with showBlocked support
- add regression coverage for hook wiring, BFF summaries, and Convex count behavior

## Verification
- bun run --filter @trends/web test -- src/hooks/useResumeSearchState.test.tsx src/hooks/useStatusCounts.test.ts
- npm test -- packages/convex/__tests__/count-resumes-by-status-convex-test.test.ts apps/api/src/routes/resumes.test.ts
- make check
- Browser smoke: http://localhost:5173/hr/resumes?location=China&q=CNC%20%E9%94%80%E5%94%AE showed 200 loaded rows with status totals New candidate1597 / Rejected1 and 0 console errors
- API smoke: default HR statusCounts.new=1597; showBlocked=true statusCounts.new=1599; /api/blocks has 2 HR blocked identities