### PR TITLE
chore(web): improve search UI quality

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,180 +1,82 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
 
-vi.mock('sonner', () => ({
-  Toaster: () => null,
+const routeTestState = vi.hoisted(() => ({
+  reviewPacketsShouldThrow: false,
 }))
 
-vi.mock('@/components/Header', () => ({
-  Header: () => <div>Header</div>,
-}))
-
-vi.mock('@/pages/ResumesPage', () => ({
-  ResumesPage: () => <div>Resumes Page</div>,
-}))
-
-vi.mock('@/pages/ReviewPacketsPage', () => ({
-  ReviewPacketsPage: () => <div>Review Packets Page</div>,
-}))
-
-const featureFlagsMock = vi.hoisted(() => ({
-  reviewPacketsEnabled: true,
+vi.mock('@/hooks/useLongTaskObserver', () => ({
+  LongTaskObserver: () => null,
 }))
 
 vi.mock('@/lib/feature-flags', () => ({
-  isReviewPacketsEnabled: () => featureFlagsMock.reviewPacketsEnabled,
+  isReviewPacketsEnabled: () => true,
 }))
 
-vi.mock('@/pages/DebugPage', () => ({
-  DebugPage: ({ basePath }: { basePath: string }) => <div>Debug Page {basePath}</div>,
+vi.mock('@/components/Header', () => ({
+  Header: () => <header>App header</header>,
 }))
 
-vi.mock('@/pages/DebugJDs', () => ({
-  default: () => <div>Debug JDs</div>,
+vi.mock('@/contexts/BrandDisplayMapContext', () => ({
+  BrandDisplayMapProvider: ({ children }: { children: React.ReactNode }) => children,
 }))
 
-vi.mock('@/pages/DebugAI', () => ({
-  default: () => <div>Debug AI</div>,
+vi.mock('@/contexts/ResumeFieldUsagePolicyContext', () => ({
+  ResumeFieldUsagePolicyProvider: ({ children }: { children: React.ReactNode }) => children,
 }))
 
-vi.mock('@/pages/DebugConfig', () => ({
-  default: () => <div>Debug Config</div>,
+vi.mock('@/pages/ResumesPage', () => ({
+  ResumesPage: () => <div>Resume route rendered</div>,
 }))
 
-vi.mock('@/pages/DebugIngest', () => ({
-  default: () => <div>Debug Ingest</div>,
+vi.mock('@/pages/ReviewPacketsPage', () => ({
+  ReviewPacketsPage: () => {
+    if (routeTestState.reviewPacketsShouldThrow) {
+      throw new Error('Review packets exploded')
+    }
+    return <div>Review packets route rendered</div>
+  },
 }))
 
-vi.mock('@/pages/DebugAiTaggingResults', () => ({
-  default: () => <div>Debug AI Tagging</div>,
-}))
-
-vi.mock('@/pages/BlacklistPage', () => ({
-  BlacklistPage: () => <div>Blacklist Page</div>,
-}))
-
-vi.mock('@/pages/SearchProfilesPage', () => ({
-  SearchProfilesPage: () => <div>Search Profiles Page</div>,
-}))
-
-vi.mock('@/pages/SearchAnalyticsPage', () => ({
-  default: () => <div>Search Analytics Page</div>,
-}))
-
-vi.mock('@/pages/system-settings/SystemSettingsConfigSourcesPage', () => ({
-  SystemSettingsConfigSourcesPage: () => <div>Config Sources</div>,
-}))
-
-vi.mock('@/pages/system-settings/SystemSettingsKeywordsPage', () => ({
-  SystemSettingsKeywordsPage: () => <div>Keywords Page</div>,
-}))
-
-vi.mock('@/pages/system-settings/SystemSettingsLocationsPage', () => ({
-  SystemSettingsLocationsPage: () => <div>Locations Page</div>,
-}))
-
-vi.mock('@/pages/system-settings/SystemSettingsOperationsPage', () => ({
-  SystemSettingsOperationsPage: () => <div>Operations Page</div>,
-}))
-
-vi.mock('@/pages/system-settings/SystemSettingsRuntimePage', () => ({
-  SystemSettingsRuntimePage: () => <div>Runtime Page</div>,
-}))
-
-vi.mock('@/layouts/SettingsLayout', () => ({
-  default: () => <div>Settings Layout</div>,
-}))
-
-vi.mock('@/layouts/SystemLayout', () => ({
-  default: () => <div>System Layout</div>,
-}))
-
-vi.mock('@/layouts/SystemSettingsLayout', () => ({
-  default: () => <div>System Settings Layout</div>,
-}))
-
-describe('App redirects', () => {
-  beforeEach(() => {
+describe('App routes', () => {
+  afterEach(() => {
+    cleanup()
+    routeTestState.reviewPacketsShouldThrow = false
     window.history.replaceState({}, '', '/')
-    featureFlagsMock.reviewPacketsEnabled = true
   })
 
-  it('preserves search params when redirecting a workspace index route to resumes', async () => {
-    window.history.replaceState({}, '', '/hr?q=CNC')
+  it('shows a not found page for unknown global routes', async () => {
+    window.history.pushState({}, '', '/missing-route?from=test')
 
     render(<App />)
 
-    await waitFor(() => {
-      expect(window.location.pathname).toBe('/hr/resumes')
-      expect(window.location.search).toBe('?q=CNC')
-    })
-
-    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Page not found' })).toBeInTheDocument()
+    expect(screen.queryByText('Resume route rendered')).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Back to resumes' })).toHaveAttribute('href', '/dev/resumes')
   })
 
-  it('preserves search params when AdminGate redirects a non-admin workspace away from system routes', async () => {
-    window.history.replaceState({}, '', '/hr/system?q=CNC&location=Kuala+Lumpur+MY')
+  it('shows a workspace-aware not found page for unknown workspace routes', async () => {
+    window.history.pushState({}, '', '/dev/missing-route')
 
     render(<App />)
 
-    await waitFor(() => {
-      expect(window.location.pathname).toBe('/hr/resumes')
-      expect(window.location.search).toBe('?q=CNC&location=Kuala+Lumpur+MY')
-    })
-
-    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Page not found' })).toBeInTheDocument()
+    expect(screen.queryByText('Resume route rendered')).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Back to resumes' })).toHaveAttribute('href', '/dev/resumes')
   })
 
-  it('allows non-admin workspace users to open export field settings', async () => {
-    window.history.replaceState({}, '', '/hr/settings/export-fields')
+  it('keeps the app shell visible when a non-search route render fails', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    routeTestState.reviewPacketsShouldThrow = true
+    window.history.pushState({}, '', '/dev/review-packets')
 
     render(<App />)
 
-    await waitFor(() => {
-      expect(window.location.pathname).toBe('/hr/settings/export-fields')
-    })
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument()
+    expect(screen.getByText('Review packets exploded')).toBeInTheDocument()
+    expect(screen.getByText('App header')).toBeInTheDocument()
 
-    expect(screen.getByText('Settings Layout')).toBeInTheDocument()
-  })
-
-  it('redirects review-packets to resumes when feature flag is off', async () => {
-    featureFlagsMock.reviewPacketsEnabled = false
-
-    window.history.replaceState({}, '', '/dev/review-packets')
-
-    render(<App />)
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe('/dev/resumes')
-    })
-
-    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
-  })
-
-  it('preserves search params when an invalid workspace slug falls back to /dev/resumes', async () => {
-    window.history.replaceState({}, '', '/unknown/resumes?q=STAR&location=Dongguan')
-
-    render(<App />)
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe('/dev/resumes')
-      expect(window.location.search).toBe('?q=STAR&location=Dongguan')
-    })
-
-    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
-  })
-
-  it('preserves search params when the wildcard route falls back to /dev/resumes', async () => {
-    window.history.replaceState({}, '', '/totally-unknown-route?q=STAR')
-
-    render(<App />)
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe('/dev/resumes')
-      expect(window.location.search).toBe('?q=STAR')
-    })
-
-    expect(screen.getByText('Resumes Page')).toBeInTheDocument()
+    spy.mockRestore()
   })
 })

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { LongTaskObserver } from '@/hooks/useLongTaskObserver'
 import { ResumesPage } from '@/pages/ResumesPage'
 import { ReviewPacketsPage } from '@/pages/ReviewPacketsPage'
+import { NotFoundPage } from '@/pages/NotFoundPage'
 import SettingsLayout from '@/layouts/SettingsLayout'
 import SystemLayout from '@/layouts/SystemLayout'
 import SystemSettingsLayout from '@/layouts/SystemSettingsLayout'
@@ -94,7 +95,9 @@ function MainShell() {
       <Toaster position="top-center" richColors />
       <Header />
       <main className="container py-6">
-        <Outlet />
+        <ErrorBoundary>
+          <Outlet />
+        </ErrorBoundary>
       </main>
       <footer className="border-t py-6 mt-8" />
     </div>
@@ -116,7 +119,7 @@ function PreserveSearchNavigate({ pathname }: { pathname: string }) {
 
 function WorkspaceShell() {
   return (
-    <WorkspaceProvider>
+    <WorkspaceProvider invalidFallback={<StandaloneNotFoundPage />}>
       <ResumeFieldUsagePolicyProvider>
         <BrandDisplayMapProvider>
           <Outlet />
@@ -124,6 +127,21 @@ function WorkspaceShell() {
       </ResumeFieldUsagePolicyProvider>
     </WorkspaceProvider>
   )
+}
+
+function StandaloneNotFoundPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="container py-6">
+        <NotFoundPage />
+      </main>
+    </div>
+  )
+}
+
+function WorkspaceNotFoundPage() {
+  const { slug } = useWorkspace()
+  return <NotFoundPage homePath={`/${slug}/resumes`} />
 }
 
 function AdminGate({ children }: { children: ReactNode }) {
@@ -160,6 +178,7 @@ function App() {
               ) : (
                 <Route path="review-packets" element={<PreserveSearchNavigate pathname="resumes" />} />
               )}
+              <Route path="*" element={<WorkspaceNotFoundPage />} />
             </Route>
 
             <Route path="settings" element={<SettingsLayout />}>
@@ -337,13 +356,16 @@ function App() {
           <Route
             path="/explanation/:resumeId"
             element={
-              <RouteSuspense>
-                <LazyCandidateExplanationPage />
-              </RouteSuspense>
+              <ErrorBoundary>
+                <RouteSuspense>
+                  <LazyCandidateExplanationPage />
+                </RouteSuspense>
+              </ErrorBoundary>
             }
           />
 
-          <Route path="*" element={<PreserveSearchNavigate pathname="/dev/resumes" />} />
+          <Route path="/" element={<PreserveSearchNavigate pathname="/dev/resumes" />} />
+          <Route path="*" element={<StandaloneNotFoundPage />} />
         </Routes>
       </ErrorBoundary>
     </BrowserRouter>

--- a/apps/web/src/components/CollectResumesButton.tsx
+++ b/apps/web/src/components/CollectResumesButton.tsx
@@ -19,6 +19,7 @@ import {
   SEARCH_PROFILE_SOURCE_TYPES,
   type CollectionSource,
 } from '@/lib/search-profile-sources'
+import { reportUiError } from '@/lib/ui-error-reporting'
 const EXTENSION_META_URL = '/extension/extension-meta.json'
 const EXTENSION_ZIP_URL = '/extension/trends-resume-collector-latest.zip'
 
@@ -197,7 +198,7 @@ export function CollectResumesButton({
           setExtensionVersion(payload.version)
         }
       } catch (error) {
-        console.error('Failed to load extension metadata', error)
+        reportUiError('Failed to load extension metadata', error)
       }
     }
 

--- a/apps/web/src/components/FilterPanel.test.tsx
+++ b/apps/web/src/components/FilterPanel.test.tsx
@@ -6,7 +6,16 @@ import { FilterPanel } from './FilterPanel'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string, options?: Record<string, unknown>) => {
+      const labels: Record<string, string> = {
+        'resumes.filters.badges.maxExperience': '≤{{value}} years',
+        'resumes.filters.badges.ageRange': '{{min}}-{{max}} years old',
+        'resumes.filters.badges.minAge': '≥{{value}} years old',
+        'resumes.filters.badges.maxAge': '≤{{value}} years old',
+      }
+      const template = labels[key] ?? key
+      return template.replace(/\{\{(\w+)\}\}/g, (_match, token: string) => String(options?.[token] ?? ''))
+    },
   }),
 }))
 
@@ -33,7 +42,7 @@ describe('FilterPanel', () => {
 
     expect(toggle).toHaveAttribute('aria-expanded', 'false')
     expect(toggle.className).toContain('min-h-10')
-    expect(screen.getByText('25-35岁')).toBeInTheDocument()
+    expect(screen.getByText('25-35 years old')).toBeInTheDocument()
     expect(screen.getByText('广东, 江苏')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '分享' })).toBeInTheDocument()
     expect(clearButton).toBeInTheDocument()
@@ -47,7 +56,7 @@ describe('FilterPanel', () => {
     expect(screen.getByRole('button', { name: '分享' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'resumes.filters.clear' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'resumes.filters.apply' })).toBeInTheDocument()
-    expect(screen.getByText('25-35岁')).toBeInTheDocument()
+    expect(screen.getByText('25-35 years old')).toBeInTheDocument()
     expect(screen.getByText('广东, 江苏')).toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/FilterPanel.tsx
+++ b/apps/web/src/components/FilterPanel.tsx
@@ -78,13 +78,30 @@ export function FilterPanel({
     const items: string[] = []
 
     if (filters.maxExperience) {
-      items.push(`≤${filters.maxExperience}年`)
+      items.push(t('resumes.filters.badges.maxExperience', {
+        value: filters.maxExperience,
+        defaultValue: '≤{{value}} years',
+      }))
     }
 
     if (filters.minAge || filters.maxAge) {
-      if (filters.minAge && filters.maxAge) items.push(`${filters.minAge}-${filters.maxAge}岁`)
-      else if (filters.minAge) items.push(`≥${filters.minAge}岁`)
-      else items.push(`≤${filters.maxAge}岁`)
+      if (filters.minAge && filters.maxAge) {
+        items.push(t('resumes.filters.badges.ageRange', {
+          min: filters.minAge,
+          max: filters.maxAge,
+          defaultValue: '{{min}}-{{max}} years old',
+        }))
+      } else if (filters.minAge) {
+        items.push(t('resumes.filters.badges.minAge', {
+          value: filters.minAge,
+          defaultValue: '≥{{value}} years old',
+        }))
+      } else {
+        items.push(t('resumes.filters.badges.maxAge', {
+          value: filters.maxAge,
+          defaultValue: '≤{{value}} years old',
+        }))
+      }
     }
 
     if (filters.minMatchScore) items.push(t('resumes.matching.scoreLabel', { score: `≥${filters.minMatchScore}` }))

--- a/apps/web/src/components/Header.test.tsx
+++ b/apps/web/src/components/Header.test.tsx
@@ -39,6 +39,7 @@ vi.mock('react-i18next', () => ({
         'nav.resumes': 'Resumes',
         'nav.reviewPackets': 'Review packets',
         'nav.settings': 'Settings',
+        'nav.system': 'System from i18n',
       }
       return values[key] ?? key
     },
@@ -130,7 +131,7 @@ describe('Header', () => {
       expect(link).toHaveAttribute('data-reset', 'false')
     })
 
-    const systemLinks = screen.getAllByRole('link', { name: 'System' })
+    const systemLinks = screen.getAllByRole('link', { name: 'System from i18n' })
     expect(systemLinks).toHaveLength(2)
     systemLinks.forEach((link) => {
       expect(link).toHaveAttribute('href', '/dev/system')

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -80,7 +80,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
                   )
                 }
               >
-                System
+                {t('nav.system', { defaultValue: 'System' })}
               </NavLink>
             ) : null}
           </nav>
@@ -137,7 +137,7 @@ export function Header({ leftAction }: HeaderProps = {}) {
                   )
                 }
               >
-                System
+                {t('nav.system', { defaultValue: 'System' })}
               </NavLink>
             ) : null}
           </nav>

--- a/apps/web/src/components/JobDescriptionEditor.tsx
+++ b/apps/web/src/components/JobDescriptionEditor.tsx
@@ -25,6 +25,7 @@ import {
     sanitizeIndustryTags,
     type StructuredSeedFields,
 } from "@/lib/jd-editor-utils"
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 const INDUSTRY_TAG_OPTIONS = CANONICAL_INDUSTRY_TAGS
 
@@ -208,7 +209,7 @@ export function JobDescriptionEditor({ open, onOpenChange, initialData, onSaveSu
             })
             onOpenChange(false)
         } catch (error) {
-            console.error("Failed to save JD", error)
+            reportUiError("Failed to save JD", error)
         } finally {
             setLoading(false)
         }

--- a/apps/web/src/components/ManualResumeImportDialog.tsx
+++ b/apps/web/src/components/ManualResumeImportDialog.tsx
@@ -16,6 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 const MANUAL_IMPORT_URL = new URL(`${apiBaseUrl}/api/resumes/manual-import`, window.location.origin).toString()
 
@@ -221,7 +222,7 @@ export function ManualResumeImportDialog({
 
       toast.error(getBatchFailureMessage(payload, t('manualResumeImport.importFailed', 'Failed to import resumes')))
     } catch (error) {
-      console.error('Failed to import manual resumes', error)
+      reportUiError('Failed to import manual resumes', error)
       const message = error instanceof Error
         ? error.message
         : t('manualResumeImport.importFailed', 'Failed to import resumes')

--- a/apps/web/src/components/ProfileCard.test.tsx
+++ b/apps/web/src/components/ProfileCard.test.tsx
@@ -7,6 +7,20 @@ vi.mock('date-fns/formatDistanceToNow', () => ({
   formatDistanceToNow: () => '2 hours ago',
 }))
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') return options
+      const translations: Record<string, string> = {
+        'searchProfiles.card.resultCount': '{{count}} CVs',
+        'searchProfiles.card.never': 'never',
+      }
+      const template = translations[key] ?? (typeof options?.defaultValue === 'string' ? options.defaultValue : key)
+      return template.replace(/\{\{(\w+)\}\}/g, (_match, token: string) => String(options?.[token] ?? ''))
+    },
+  }),
+}))
+
 const baseProfile: SearchProfileSummary = {
   id: 'p-1',
   name: 'Frontend Devs',
@@ -125,6 +139,6 @@ describe('ProfileCard', () => {
 
   it('uses submitted when resultCount is absent', () => {
     renderProfile({ runStatus: { profileId: 'p-1', taskId: 't-1', taskStatus: 'completed', startedAt: '2026-05-13T00:00:00Z', updatedAt: '2026-05-13T01:00:00Z', submitted: 15 } })
-    expect(screen.getByText(/15 resumes/)).toBeInTheDocument()
+    expect(screen.getByText(/15 CVs/)).toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/ProfileCard.tsx
+++ b/apps/web/src/components/ProfileCard.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react'
 import { formatDistanceToNow } from 'date-fns/formatDistanceToNow'
+import { useTranslation } from 'react-i18next'
 import { Play, Pencil, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
@@ -71,9 +72,14 @@ export const ProfileCard = memo(function ProfileCard({
   onEdit,
   onDelete,
 }: ProfileCardProps) {
+  const { t } = useTranslation()
+  const resultCount = runStatus?.resultCount ?? runStatus?.submitted ?? 0
   const lastRunText = runStatus
-    ? `${formatDistanceToNow(new Date(runStatus.updatedAt), { addSuffix: true })} | ${runStatus.resultCount ?? runStatus.submitted ?? 0} resumes`
-    : 'never'
+    ? `${formatDistanceToNow(new Date(runStatus.updatedAt), { addSuffix: true })} | ${t('searchProfiles.card.resultCount', {
+      count: resultCount,
+      defaultValue: '{{count}} resumes',
+    })}`
+    : t('searchProfiles.card.never', { defaultValue: 'never' })
 
   return (
     <Card>
@@ -82,7 +88,7 @@ export const ProfileCard = memo(function ProfileCard({
           <CardTitle className="text-base leading-tight">{profile.name}</CardTitle>
           <div className="flex flex-wrap items-center justify-end gap-2">
             {profile.quickStart?.enabled ? (
-              <Badge variant="secondary">quick start</Badge>
+              <Badge variant="secondary">{t('searchProfiles.card.quickStartBadge', { defaultValue: 'quick start' })}</Badge>
             ) : null}
             <Badge variant={statusBadgeVariant(profile.status)}>{profile.status}</Badge>
           </div>
@@ -94,19 +100,19 @@ export const ProfileCard = memo(function ProfileCard({
       <CardContent className="space-y-2 text-sm">
         {profile.quickStart?.enabled ? (
           <div>
-            <span className="font-medium">Landing quick start:</span>{' '}
+            <span className="font-medium">{t('searchProfiles.card.landingQuickStart', { defaultValue: 'Landing quick start:' })}</span>{' '}
             {profile.quickStart.label || profile.name}
           </div>
         ) : null}
         <div>
-          <span className="font-medium">Schedule:</span> {scheduleLabel === 'disabled' ? 'disabled' : `${scheduleLabel} (enabled)`}
+          <span className="font-medium">{t('searchProfiles.card.schedule', { defaultValue: 'Schedule:' })}</span> {scheduleLabel === 'disabled' ? t('searchProfiles.card.disabled', { defaultValue: 'disabled' }) : t('searchProfiles.card.enabledSchedule', { schedule: scheduleLabel, defaultValue: '{{schedule}} (enabled)' })}
         </div>
         <div>
-          <span className="font-medium">Last run:</span> {lastRunText}
+          <span className="font-medium">{t('searchProfiles.card.lastRun', { defaultValue: 'Last run:' })}</span> {lastRunText}
         </div>
         {runStatus ? (
           <div>
-            <span className="font-medium">Run status:</span> {runStatusLabel(runStatus.taskStatus)}
+            <span className="font-medium">{t('searchProfiles.card.runStatus', { defaultValue: 'Run status:' })}</span> {runStatusLabel(runStatus.taskStatus)}
             {runStatus.error ? ` (${runStatus.error})` : ''}
           </div>
         ) : null}
@@ -114,7 +120,7 @@ export const ProfileCard = memo(function ProfileCard({
       <CardFooter className="gap-2 justify-end">
         <Button size="sm" onClick={() => onRunNow(profile.id)} disabled={running}>
           <Play className="h-3.5 w-3.5 mr-1" />
-          Run Now
+          {t('searchProfiles.card.runNow', { defaultValue: 'Run Now' })}
         </Button>
         <Button
           size="sm"
@@ -122,7 +128,7 @@ export const ProfileCard = memo(function ProfileCard({
           onClick={() => onEdit(profile.id)}
         >
           <Pencil className="h-3.5 w-3.5 mr-1" />
-          Edit
+          {t('common.edit', { defaultValue: 'Edit' })}
         </Button>
         <Button
           size="sm"
@@ -130,7 +136,7 @@ export const ProfileCard = memo(function ProfileCard({
           onClick={() => onDelete(profile.id)}
         >
           <Trash2 className="h-3.5 w-3.5 mr-1" />
-          Delete
+          {t('common.delete', { defaultValue: 'Delete' })}
         </Button>
       </CardFooter>
     </Card>

--- a/apps/web/src/components/QuickStartPanel.tsx
+++ b/apps/web/src/components/QuickStartPanel.tsx
@@ -7,6 +7,7 @@ import { useQuery } from 'convex/react'
 import { JobDescriptionSelect } from './JobDescriptionSelect'
 import { JobDescriptionEditor } from './JobDescriptionEditor'
 import { KeywordChips } from './KeywordChips'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 const SearchAssistantDrawer = lazy(() => import('./SearchAssistantDrawer').then((m) => ({ default: m.SearchAssistantDrawer })))
 import { type SearchProfileDetails, type SearchProfileFilters } from './SearchProfileEditorDialog'
@@ -538,7 +539,7 @@ export function QuickStartPanel({
           }
         }
       } catch (error) {
-        console.error('Failed to fetch role type from job description', error)
+        reportUiError('Failed to fetch role type from job description', error)
         if (!cancelled) {
           setActiveRoleType(undefined)
           setJdMinRoleYears(undefined)
@@ -582,7 +583,7 @@ export function QuickStartPanel({
 
         setWorkflowSeeds(parsed.workflowSeeds.filter((item) => item.visible !== false))
       } catch (error) {
-        console.error('Failed to load workflow seeds', error)
+        reportUiError('Failed to load workflow seeds', error)
         if (!cancelled) {
           setWorkflowSeeds([])
         }
@@ -755,7 +756,7 @@ export function QuickStartPanel({
           setAutoMatchResult(nextAutoMatchResult)
         }
       } catch (error) {
-        console.error('Failed to auto-match search profile', error)
+        reportUiError('Failed to auto-match search profile', error)
         if (!cancelled) {
           setAutoMatchResult(null)
         }

--- a/apps/web/src/components/SchedulerStatus.test.tsx
+++ b/apps/web/src/components/SchedulerStatus.test.tsx
@@ -5,6 +5,7 @@ import { SchedulerStatus } from '@/components/SchedulerStatus'
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, options?: string | { defaultValue?: string; [key: string]: unknown }) => {
+      if (key === 'common.loading') return 'Loading from i18n'
       if (typeof options === 'string') return options
       if (options?.defaultValue) {
         return options.defaultValue.replace(/\{\{(\w+)\}\}/g, (_match: string, k: string) => String(options[k] ?? `{{${k}}}`))
@@ -44,7 +45,7 @@ describe('SchedulerStatus', () => {
   it('shows loading state initially', () => {
     mockFetch.mockReturnValue(new Promise(() => {}))
     render(<SchedulerStatus apiBaseUrl="http://localhost:3001" />)
-    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(screen.getByText('Loading from i18n')).toBeInTheDocument()
   })
 
   it('shows error state when fetch fails', async () => {

--- a/apps/web/src/components/SchedulerStatus.tsx
+++ b/apps/web/src/components/SchedulerStatus.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { formatDistanceToNow } from 'date-fns/formatDistanceToNow'
 import { useTranslation } from 'react-i18next'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 interface WorkerStatus {
     jobs_executed: number
@@ -75,7 +76,7 @@ export function SchedulerStatus({ apiBaseUrl }: SchedulerStatusProps) {
                 setStatus(data)
                 setError(null)
             } catch (err) {
-                console.error('Failed to fetch scheduler status', err)
+                reportUiError('Failed to fetch scheduler status', err)
                 setError('Failed to load scheduler status')
             } finally {
                 setLoading(false)
@@ -92,7 +93,7 @@ export function SchedulerStatus({ apiBaseUrl }: SchedulerStatusProps) {
             <Card className="bg-muted/30 border-dashed">
                 <CardHeader className="py-4">
                     <CardTitle className="text-lg">Scheduler Status</CardTitle>
-                    <CardDescription>Loading...</CardDescription>
+                    <CardDescription>{t('common.loading', { defaultValue: 'Loading...' })}</CardDescription>
                 </CardHeader>
             </Card>
         )

--- a/apps/web/src/components/SearchProfileEditorDialog.tsx
+++ b/apps/web/src/components/SearchProfileEditorDialog.tsx
@@ -23,6 +23,7 @@ import {
     type SearchProfileSource,
 } from '@/lib/search-profile-sources'
 import { api } from '../../../../packages/convex/convex/_generated/api'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 export type SearchProfileFilters = {
     maxExperience?: number | null
@@ -434,7 +435,7 @@ export function SearchProfileEditorDialog({
             setSourceForm(sourceState.known)
             setAdditionalSources(sourceState.additional)
         } catch (error) {
-            console.error('Failed to load profile', error)
+            reportUiError('Failed to load profile', error)
             toast.error(t('searchProfiles.loadDetailError', { defaultValue: 'Failed to load profile details' }))
             onOpenChange(false)
         }
@@ -550,7 +551,7 @@ export function SearchProfileEditorDialog({
                     maxAge: toNumericText(suggestedFilters?.maxAge),
                 }))
             } catch (error) {
-                console.error('Failed to load job description defaults', error)
+                reportUiError('Failed to load job description defaults', error)
             } finally {
                 if (!cancelled) {
                     completeHydration()
@@ -663,7 +664,7 @@ export function SearchProfileEditorDialog({
             onOpenChange(false)
             toast.success(t('searchProfiles.saveSuccess', { defaultValue: 'Profile saved' }))
         } catch (error) {
-            console.error('Failed to save profile', error)
+            reportUiError('Failed to save profile', error)
             toast.error(t('searchProfiles.saveError', { defaultValue: 'Failed to save profile' }))
         } finally {
             setSubmitting(false)

--- a/apps/web/src/components/ShareLinkButton.test.tsx
+++ b/apps/web/src/components/ShareLinkButton.test.tsx
@@ -15,6 +15,29 @@ vi.mock('sonner', () => ({
   },
 }))
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') return options
+      const translations: Record<string, string> = {
+        'shareLink.button': 'Share',
+        'shareLink.copiedSearch': 'Share link copied',
+        'shareLink.copiedSession': 'Session link copied',
+        'shareLink.copyPreparedFailed': 'Automatic copy failed. Copy the link below manually.',
+        'shareLink.copyUrlFailed': 'Failed to copy link. Copy the URL from the address bar manually.',
+        'shareLink.retryCopyFailed': 'Copy still failed. Copy the link below manually.',
+        'shareLink.dialog.title': 'Copy share link manually',
+        'shareLink.dialog.description': 'Automatic copy did not complete. The link is ready to copy manually.',
+        'shareLink.dialog.titleLabel': 'Share title',
+        'shareLink.dialog.urlLabel': 'Share link',
+        'shareLink.dialog.retryCopy': 'Try copying again',
+        'common.close': 'Close',
+      }
+      return translations[key] ?? (typeof options?.defaultValue === 'string' ? options.defaultValue : key)
+    },
+  }),
+}))
+
 vi.mock('@/components/ui/dialog', () => ({
   Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) => (open ? <div>{children}</div> : null),
   DialogContent: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
@@ -62,7 +85,7 @@ describe('ShareLinkButton', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: '分享' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }))
 
     await waitFor(() => {
       expect(clipboardWriteTextMock).toHaveBeenCalledWith(
@@ -71,7 +94,7 @@ describe('ShareLinkButton', () => {
     })
 
     expect(ensureApiSession).not.toHaveBeenCalled()
-    expect(toastSuccessMock).toHaveBeenCalledWith('已复制分享链接')
+    expect(toastSuccessMock).toHaveBeenCalledWith('Share link copied')
   })
 
   it('creates and copies a short sid link for bulky or session-backed state', async () => {
@@ -103,7 +126,7 @@ describe('ShareLinkButton', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: '分享' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }))
 
     await waitFor(() => {
       expect(ensureApiSession).toHaveBeenCalledWith({
@@ -127,7 +150,7 @@ describe('ShareLinkButton', () => {
       sessionId: 'session-share-1',
       usedSessionLink: true,
     })
-    expect(toastSuccessMock).toHaveBeenCalledWith('已复制会话链接')
+    expect(toastSuccessMock).toHaveBeenCalledWith('Session link copied')
   })
 
   it('creates a durable sid link when share state includes a reference note', async () => {
@@ -150,7 +173,7 @@ describe('ShareLinkButton', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: '分享' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }))
 
     await waitFor(() => {
       expect(ensureApiSession).toHaveBeenCalledWith({
@@ -166,7 +189,7 @@ describe('ShareLinkButton', () => {
     expect(clipboardWriteTextMock).toHaveBeenCalledWith(
       `${window.location.origin}/dev/resumes?sid=session-share-note`
     )
-    expect(toastSuccessMock).toHaveBeenCalledWith('已复制会话链接')
+    expect(toastSuccessMock).toHaveBeenCalledWith('Session link copied')
   })
 
   it('reports the existing sid when copying a shared-link URL directly', async () => {
@@ -190,7 +213,7 @@ describe('ShareLinkButton', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: '分享' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }))
 
     await waitFor(() => {
       expect(clipboardWriteTextMock).toHaveBeenCalledWith(
@@ -230,10 +253,10 @@ describe('ShareLinkButton', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: '分享' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }))
 
     expect(await screen.findByTestId('share-link-fallback-dialog')).toBeInTheDocument()
     expect(screen.getByDisplayValue(`${window.location.origin}/dev/resumes?sid=session-share-1`)).toBeInTheDocument()
-    expect(toastErrorMock).toHaveBeenCalledWith('自动复制失败，请手动复制下方链接')
+    expect(toastErrorMock).toHaveBeenCalledWith('Automatic copy failed. Copy the link below manually.')
   })
 })

--- a/apps/web/src/components/ShareLinkButton.tsx
+++ b/apps/web/src/components/ShareLinkButton.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -12,6 +13,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import type { EnsureApiSessionOptions, ResumeSearchShareState } from '@/hooks/useSession'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 type ShareLinkButtonProps = {
   shareTitle: string
@@ -79,17 +81,13 @@ function buildSessionShareUrl(sessionId: string): string {
   return shareUrl.toString()
 }
 
-function buildCopySuccessMessage(usedSessionLink: boolean): string {
-  return usedSessionLink ? '已复制会话链接' : '已复制分享链接'
-}
-
 async function copyText(text: string): Promise<void> {
   if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
     try {
       await navigator.clipboard.writeText(text)
       return
     } catch (error) {
-      console.error('Clipboard API copy failed, falling back to execCommand', error)
+      reportUiError('Clipboard API copy failed, falling back to execCommand', error)
     }
   }
 
@@ -112,6 +110,7 @@ async function copyText(text: string): Promise<void> {
 }
 
 export function ShareLinkButton({ shareTitle, state, ensureApiSession, onCopyState }: ShareLinkButtonProps) {
+  const { t } = useTranslation()
   const [fallbackPayload, setFallbackPayload] = useState<ShareLinkPayload | null>(null)
   const fallbackTextareaRef = useRef<HTMLTextAreaElement | null>(null)
   const selectFallbackText = useCallback(() => {
@@ -161,18 +160,24 @@ export function ShareLinkButton({ shareTitle, state, ensureApiSession, onCopySta
       await copyText(shareUrl)
       onCopyState?.(payload)
       setFallbackPayload(null)
-      toast.success(buildCopySuccessMessage(usedSessionLink))
+      toast.success(usedSessionLink
+        ? t('shareLink.copiedSession', { defaultValue: 'Session link copied' })
+        : t('shareLink.copiedSearch', { defaultValue: 'Share link copied' }))
     } catch (error) {
-      console.error('Failed to copy share URL', error)
+      reportUiError('Failed to copy share URL', error)
       if (payload) {
         setFallbackPayload(payload)
-        toast.error('自动复制失败，请手动复制下方链接')
+        toast.error(t('shareLink.copyPreparedFailed', {
+          defaultValue: 'Automatic copy failed. Copy the link below manually.',
+        }))
         return
       }
 
-      toast.error('复制链接失败，请手动复制地址栏 URL')
+      toast.error(t('shareLink.copyUrlFailed', {
+        defaultValue: 'Failed to copy link. Copy the URL from the address bar manually.',
+      }))
     }
-  }, [ensureApiSession, onCopyState, shareTitle, state])
+  }, [ensureApiSession, onCopyState, shareTitle, state, t])
 
   const handleFallbackCopy = useCallback(async () => {
     if (!fallbackPayload) {
@@ -183,13 +188,17 @@ export function ShareLinkButton({ shareTitle, state, ensureApiSession, onCopySta
       await copyText(fallbackPayload.shareUrl)
       onCopyState?.(fallbackPayload)
       setFallbackPayload(null)
-      toast.success(buildCopySuccessMessage(fallbackPayload.usedSessionLink))
+      toast.success(fallbackPayload.usedSessionLink
+        ? t('shareLink.copiedSession', { defaultValue: 'Session link copied' })
+        : t('shareLink.copiedSearch', { defaultValue: 'Share link copied' }))
     } catch (error) {
-      console.error('Retry share copy failed', error)
+      reportUiError('Retry share copy failed', error)
       selectFallbackText()
-      toast.error('自动复制仍然失败，请手动复制下方链接')
+      toast.error(t('shareLink.retryCopyFailed', {
+        defaultValue: 'Copy still failed. Copy the link below manually.',
+      }))
     }
-  }, [fallbackPayload, onCopyState, selectFallbackText])
+  }, [fallbackPayload, onCopyState, selectFallbackText, t])
 
   return (
     <>
@@ -202,7 +211,7 @@ export function ShareLinkButton({ shareTitle, state, ensureApiSession, onCopySta
         }}
       >
         <Link2 className="h-3.5 w-3.5" />
-        分享
+        {t('shareLink.button', { defaultValue: 'Share' })}
       </Button>
 
       <Dialog open={fallbackPayload !== null} onOpenChange={(open: boolean) => {
@@ -213,16 +222,18 @@ export function ShareLinkButton({ shareTitle, state, ensureApiSession, onCopySta
       >
         <DialogContent data-testid="share-link-fallback-dialog" className="sm:max-w-xl">
           <DialogHeader>
-            <DialogTitle>手动复制分享链接</DialogTitle>
+            <DialogTitle>{t('shareLink.dialog.title', { defaultValue: 'Copy share link manually' })}</DialogTitle>
             <DialogDescription>
-              当前浏览器未完成自动复制。链接已准备好，手动复制后仍可直接打开当前搜索上下文。
+              {t('shareLink.dialog.description', {
+                defaultValue: 'Automatic copy did not complete. The link is ready to copy manually.',
+              })}
             </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-3">
             <div className="rounded-lg border border-border/70 bg-muted/20 px-3 py-2">
               <div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                分享标题
+                {t('shareLink.dialog.titleLabel', { defaultValue: 'Share title' })}
               </div>
               <div className="mt-1 text-sm font-medium text-foreground">
                 {shareTitle}
@@ -230,7 +241,7 @@ export function ShareLinkButton({ shareTitle, state, ensureApiSession, onCopySta
             </div>
             <Textarea
               ref={fallbackTextareaRef}
-              aria-label="分享链接"
+              aria-label={t('shareLink.dialog.urlLabel', { defaultValue: 'Share link' })}
               readOnly
               value={fallbackPayload?.shareUrl ?? ''}
               rows={3}
@@ -248,7 +259,7 @@ export function ShareLinkButton({ shareTitle, state, ensureApiSession, onCopySta
                 setFallbackPayload(null)
               }}
             >
-              关闭
+              {t('common.close', { defaultValue: 'Close' })}
             </Button>
             <Button
               type="button"
@@ -256,7 +267,7 @@ export function ShareLinkButton({ shareTitle, state, ensureApiSession, onCopySta
                 void handleFallbackCopy()
               }}
             >
-              再试一次复制
+              {t('shareLink.dialog.retryCopy', { defaultValue: 'Try copying again' })}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/components/search/FacetGroup.test.tsx
+++ b/apps/web/src/components/search/FacetGroup.test.tsx
@@ -39,7 +39,7 @@ describe('FacetGroup', () => {
     )
 
     expect(screen.getByText('resumes.searchPage.facets.emptyLabel')).toBeInTheDocument()
-    expect(screen.queryByText(/收起/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Show less/i)).not.toBeInTheDocument()
   })
 
   it('uses case-insensitive selection and expands hidden facet values', async () => {
@@ -63,12 +63,12 @@ describe('FacetGroup', () => {
     expect(screen.getByText('1')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Machine Tools/i })).toHaveClass('bg-slate-900')
     expect(screen.queryByRole('button', { name: /Robotics/i })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /展开剩余 1 项/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Show 1 more/i })).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: /展开剩余 1 项/i }))
+    await user.click(screen.getByRole('button', { name: /Show 1 more/i }))
 
     expect(screen.getByRole('button', { name: /Robotics/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /收起/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Show less/i })).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /Automation/i }))
 
@@ -92,13 +92,13 @@ describe('FacetGroup', () => {
       />
     )
 
-    await user.click(screen.getByRole('button', { name: /展开剩余 1 项/i }))
+    await user.click(screen.getByRole('button', { name: /Show 1 more/i }))
     expect(screen.getByRole('button', { name: /Robotics/i })).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: /收起/i }))
+    await user.click(screen.getByRole('button', { name: /Show less/i }))
 
     expect(screen.queryByRole('button', { name: /Robotics/i })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /展开剩余 1 项/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Show 1 more/i })).toBeInTheDocument()
   })
 
   it('omits the show-more control when the visible limit already covers every value', () => {

--- a/apps/web/src/components/search/FacetGroup.tsx
+++ b/apps/web/src/components/search/FacetGroup.tsx
@@ -78,8 +78,8 @@ export function FacetGroup({
       {items.length > maxVisible ? (
         <Button type="button" variant="ghost" className="h-auto px-0 text-sm" onClick={() => setExpanded((value) => !value)}>
           {expanded
-            ? t('resumes.searchPage.facets.showLess', { defaultValue: '收起' })
-            : t('resumes.searchPage.facets.showMore', { count: items.length - maxVisible, defaultValue: '展开剩余 {{count}} 项' })}
+            ? t('resumes.searchPage.facets.showLess', { defaultValue: 'Show less' })
+            : t('resumes.searchPage.facets.showMore', { count: items.length - maxVisible, defaultValue: 'Show {{count}} more' })}
         </Button>
       ) : null}
     </div>

--- a/apps/web/src/components/search/FacetSidebar.test.tsx
+++ b/apps/web/src/components/search/FacetSidebar.test.tsx
@@ -101,9 +101,9 @@ describe('FacetSidebar', () => {
 
     expect(container.firstElementChild).toHaveClass('space-y-6')
     expect(container.firstElementChild).not.toHaveClass('rounded-[1.75rem]')
-    expect(screen.getByText('在当前搜索结果中进一步精确筛选。')).toBeInTheDocument()
+    expect(screen.getByText('Refine the currently loaded search results.')).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: '重置' }))
+    await user.click(screen.getByRole('button', { name: 'Reset' }))
 
     expect(onClearAll).toHaveBeenCalledTimes(1)
   })
@@ -145,9 +145,9 @@ describe('FacetSidebar', () => {
     )
 
     expect(screen.getByRole('button', { name: /Machine Tools/i })).toHaveClass('bg-slate-900')
-    expect(screen.getByRole('button', { name: /展开剩余 1 项/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Show 1 more/i })).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: '重置' }))
+    await user.click(screen.getByRole('button', { name: 'Reset' }))
     await user.click(screen.getByRole('button', { name: /Manufacturing Systems/i }))
     await user.click(screen.getByRole('button', { name: /Machine Tools/i }))
     await user.click(screen.getByRole('button', { name: /FANUC/i }))
@@ -160,6 +160,52 @@ describe('FacetSidebar', () => {
     expect(onToggleCompany).toHaveBeenCalledWith('FANUC')
     expect(onToggleEducation).toHaveBeenCalledWith('Bachelor')
     expect(onToggleStatus).toHaveBeenCalledWith('new')
+  })
+
+  it('renders the primary screening filters before secondary facets', () => {
+    const { container } = render(
+      <FacetSidebar
+        facetCounts={buildFacetCounts()}
+        selectedBrands={[]}
+        selectedClusters={[]}
+        selectedCompanies={[]}
+        selectedEducation={[]}
+        selectedStatuses={[]}
+        selectedTags={[]}
+        onClearAll={vi.fn()}
+        onSetExperienceLevel={vi.fn()}
+        onSetMinRoleYears={vi.fn()}
+        onSetAgeRange={vi.fn()}
+        onSetMinScore={vi.fn()}
+        onSetSalaryRange={vi.fn()}
+        onToggleBrand={vi.fn()}
+        onToggleCluster={vi.fn()}
+        onToggleCompany={vi.fn()}
+        onToggleEducation={vi.fn()}
+        onToggleStatus={vi.fn()}
+        onToggleTag={vi.fn()}
+        selectedSources={[]}
+        onToggleSource={vi.fn()}
+        onSetIdOrNameSearch={vi.fn()}
+      />
+    )
+
+    expect(screen.getByPlaceholderText('ID / Name / External ID')).toBeInTheDocument()
+
+    const renderedText = container.textContent ?? ''
+    const primaryLabels = [
+      'Candidate Status',
+      'Match Score',
+      'Relevant Experience',
+      'Age Range',
+      'Expected Salary',
+    ]
+    const labelPositions = primaryLabels.map((label) => renderedText.indexOf(label))
+    const firstSecondaryFacetPosition = renderedText.indexOf('Skill Clusters')
+
+    expect(labelPositions).not.toContain(-1)
+    expect(labelPositions).toEqual([...labelPositions].sort((left, right) => left - right))
+    expect(firstSecondaryFacetPosition).toBeGreaterThan(labelPositions[labelPositions.length - 1] ?? -1)
   })
 
   it('toggles experience level and minimum score filters', async () => {
@@ -196,8 +242,8 @@ describe('FacetSidebar', () => {
       />
     )
 
-    await user.click(screen.getByRole('button', { name: '资深' }))
-    await user.click(screen.getByRole('button', { name: '中级' }))
+    await user.click(screen.getByRole('button', { name: 'Senior' }))
+    await user.click(screen.getByRole('button', { name: 'Mid-level' }))
     await user.click(screen.getByRole('button', { name: /80\+/i }))
     await user.click(screen.getByRole('button', { name: /70\+/i }))
 
@@ -279,8 +325,8 @@ describe('FacetSidebar', () => {
       />
     )
 
-    // Click the "自定义" button within the minRoleYears section (first one)
-    const customButtons = screen.getAllByRole('button', { name: /自定义/i })
+    // Click the "Custom" button within the minRoleYears section (first one)
+    const customButtons = screen.getAllByRole('button', { name: /Custom/i })
     await user.click(customButtons[0])
     const inputs = screen.getAllByRole('spinbutton')
     const input = inputs[0]
@@ -413,7 +459,7 @@ describe('idOrNameSearch filter input', () => {
 
   it('renders the id/name search input placeholder', () => {
     render(<FacetSidebar {...buildProps()} embedded />)
-    expect(screen.getByPlaceholderText('ID · 候选人姓名')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('ID / Name / External ID')).toBeInTheDocument()
   })
 
   it('shows current idOrNameSearch value', () => {
@@ -425,7 +471,7 @@ describe('idOrNameSearch filter input', () => {
     const user = userEvent.setup()
     const onSetIdOrNameSearch = vi.fn()
     render(<FacetSidebar {...buildProps()} embedded onSetIdOrNameSearch={onSetIdOrNameSearch} />)
-    const input = screen.getByPlaceholderText('ID · 候选人姓名')
+    const input = screen.getByPlaceholderText('ID / Name / External ID')
     await user.type(input, 'x')
     expect(onSetIdOrNameSearch).toHaveBeenCalledWith('x')
   })

--- a/apps/web/src/components/search/FacetSidebar.tsx
+++ b/apps/web/src/components/search/FacetSidebar.tsx
@@ -122,7 +122,7 @@ function MinRoleYearsGroup({
   return (
     <div className="space-y-3">
       <div className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
-        {t('resumes.searchPage.facets.minRoleYears', { defaultValue: '岗位年限' })}
+        {t('resumes.searchPage.facets.minRoleYears', { defaultValue: 'Relevant Experience' })}
       </div>
       <div className="flex flex-wrap items-center gap-2">
         {PRESET_ROLE_YEARS.map((value) => {
@@ -170,7 +170,7 @@ function MinRoleYearsGroup({
               variant="ghost"
               size="icon"
               className="h-6 w-6 p-0 text-slate-500 hover:text-slate-700"
-              aria-label={t('common.apply', { defaultValue: '应用' })}
+              aria-label={t('common.apply', { defaultValue: 'Apply' })}
             >
               <Check className="h-4 w-4" />
             </Button>
@@ -182,7 +182,7 @@ function MinRoleYearsGroup({
                 setCustomText('')
               }}
             >
-              {t('resumes.searchPage.facets.custom', { defaultValue: '自定义' })}
+              {t('resumes.searchPage.facets.custom', { defaultValue: 'Custom' })}
             </button>
           </form>
         ) : (
@@ -193,7 +193,7 @@ function MinRoleYearsGroup({
               setCustomOpen(true)
             }}
           >
-            {t('resumes.searchPage.facets.custom', { defaultValue: '自定义' })}
+            {t('resumes.searchPage.facets.custom', { defaultValue: 'Custom' })}
           </button>
         )}
       </div>
@@ -344,7 +344,7 @@ function RangeFilterGroup({
               variant="ghost"
               size="icon"
               className="h-6 w-6 p-0 text-slate-500 hover:text-slate-700"
-              aria-label={t('common.apply', { defaultValue: '应用' })}
+              aria-label={t('common.apply', { defaultValue: 'Apply' })}
             >
               <Check className="h-4 w-4" />
             </Button>
@@ -357,7 +357,7 @@ function RangeFilterGroup({
                 setCustomMax('')
               }}
             >
-              {t('resumes.searchPage.facets.custom', { defaultValue: '自定义' })}
+              {t('resumes.searchPage.facets.custom', { defaultValue: 'Custom' })}
             </button>
           </form>
         ) : (
@@ -368,7 +368,7 @@ function RangeFilterGroup({
               setCustomOpen(true)
             }}
           >
-            {t('resumes.searchPage.facets.custom', { defaultValue: '自定义' })}
+            {t('resumes.searchPage.facets.custom', { defaultValue: 'Custom' })}
           </button>
         )}
       </div>
@@ -416,16 +416,19 @@ export function FacetSidebar({
     <div className="space-y-6">
       {loadedCount !== undefined && loadedCount > 0 && (
         <div className="text-xs text-muted-foreground">
-          {t('resumes.searchPage.facets.loadedCount', { count: loadedCount, defaultValue: `显示前 ${loadedCount} 条结果中的筛选统计` })}
+          {t('resumes.searchPage.facets.loadedCount', {
+            count: loadedCount,
+            defaultValue: 'Facet counts are based on the first {{count}} loaded results.',
+          })}
         </div>
       )}
       <div className="flex items-center justify-between">
         <div>
-          <div className="text-sm font-semibold text-slate-900">{t('resumes.searchPage.facets.filtersTitle', { defaultValue: '筛选条件' })}</div>
-          <div className="text-xs text-muted-foreground">{t('resumes.searchPage.facets.filtersDescription', { defaultValue: '在当前搜索结果中进一步精确筛选。' })}</div>
+          <div className="text-sm font-semibold text-slate-900">{t('resumes.searchPage.facets.filtersTitle', { defaultValue: 'Filters' })}</div>
+          <div className="text-xs text-muted-foreground">{t('resumes.searchPage.facets.filtersDescription', { defaultValue: 'Refine the currently loaded search results.' })}</div>
         </div>
         <button type="button" className="text-sm text-muted-foreground hover:text-foreground" onClick={onClearAll}>
-          {t('common.reset', { defaultValue: '重置' })}
+          {t('common.reset', { defaultValue: 'Reset' })}
         </button>
       </div>
 
@@ -433,7 +436,7 @@ export function FacetSidebar({
       <div className="relative">
         <Input
           type="text"
-          placeholder="ID · 候选人姓名"
+          placeholder={t('resumes.searchPage.facets.idOrNamePlaceholder', { defaultValue: 'ID / Name / External ID' })}
           value={idOrNameSearch ?? ''}
           onChange={(e) => onSetIdOrNameSearch(e.target.value || undefined)}
           className="pr-7 text-sm"
@@ -450,8 +453,9 @@ export function FacetSidebar({
         )}
       </div>
 
+      <FacetGroup title={t('resumes.searchPage.facets.status', { defaultValue: 'Candidate Status' })} items={facetCounts.statuses} selectedValues={selectedStatuses} onToggle={(value) => onToggleStatus(value as CandidateStatus)} />
       <FacetGroup
-        title={t('resumes.searchPage.facets.matchScore', { defaultValue: '匹配分' })}
+        title={t('resumes.searchPage.facets.matchScore', { defaultValue: 'Match Score' })}
         items={facetCounts.minScoreOptions.map((item) => ({ ...item, value: `${item.value}+` }))}
         selectedValues={typeof minScore === 'number' ? [`${minScore}+`] : []}
         onToggle={(value) => {
@@ -459,45 +463,44 @@ export function FacetSidebar({
           onSetMinScore(minScore === numericValue ? undefined : numericValue)
         }}
       />
-      <FacetGroup
-        title={t('resumes.searchPage.facets.skillClusters', { defaultValue: '技能图谱' })}
-        items={facetCounts.clusters}
-        selectedValues={selectedClusters}
-        onToggle={onToggleCluster}
-      />
-      <FacetGroup title={t('resumes.searchPage.facets.tags', { defaultValue: '标签聚类' })} items={facetCounts.tags} selectedValues={selectedTags} onToggle={onToggleTag} />
-      <FacetGroup title={t('resumes.searchPage.facets.brands', { defaultValue: '品牌标签' })} items={facetCounts.brands} selectedValues={selectedBrands} onToggle={onToggleBrand} />
-      <FacetGroup title={t('resumes.searchPage.facets.companies', { defaultValue: '公司经历' })} items={facetCounts.companies} selectedValues={selectedCompanies} onToggle={onToggleCompany} />
-      <FacetGroup title={t('resumes.searchPage.facets.sources', { defaultValue: '来源渠道' })} items={facetCounts.sources} selectedValues={selectedSources} onToggle={onToggleSource} />
-      <PillGroup
-        label={t('resumes.searchPage.facets.experienceLevel', { defaultValue: '工作经验' })}
-        items={[
-          { value: 'senior' as const, label: t('resumes.searchPage.facets.experience.senior', { defaultValue: '资深' }) },
-          { value: 'mid' as const, label: t('resumes.searchPage.facets.experience.mid', { defaultValue: '中级' }) },
-          { value: 'junior' as const, label: t('resumes.searchPage.facets.experience.junior', { defaultValue: '初级' }) },
-        ]}
-        selectedValue={selectedExperienceLevel}
-        onSelect={onSetExperienceLevel}
-      />
       <MinRoleYearsGroup minRoleYears={minRoleYears} onSetMinRoleYears={onSetMinRoleYears} isFilterTransitionPending={isFilterTransitionPending} />
       <RangeFilterGroup
         presets={PRESET_AGE_RANGES}
-        label={t('resumes.searchPage.facets.ageRange', { defaultValue: '年龄范围' })}
-        unitSuffix={t('resumes.searchPage.facets.ageUnit', { defaultValue: '岁' })}
+        label={t('resumes.searchPage.facets.ageRange', { defaultValue: 'Age Range' })}
+        unitSuffix={t('resumes.searchPage.facets.ageUnit', { defaultValue: 'years old' })}
         valueMin={minAge}
         valueMax={maxAge}
         onSetRange={onSetAgeRange}
       />
       <RangeFilterGroup
         presets={PRESET_SALARY_RANGES}
-        label={t('resumes.searchPage.facets.salary', { defaultValue: '期望薪资' })}
+        label={t('resumes.searchPage.facets.salary', { defaultValue: 'Expected Salary' })}
         unitSuffix={t('resumes.searchPage.facets.salaryUnit', { defaultValue: 'k' })}
         valueMin={minSalary}
         valueMax={maxSalary}
         onSetRange={onSetSalaryRange}
       />
-      <FacetGroup title={t('resumes.searchPage.facets.education', { defaultValue: '学历' })} items={facetCounts.education} selectedValues={selectedEducation} onToggle={onToggleEducation} />
-      <FacetGroup title={t('resumes.searchPage.facets.status', { defaultValue: '候选人状态' })} items={facetCounts.statuses} selectedValues={selectedStatuses} onToggle={(value) => onToggleStatus(value as CandidateStatus)} />
+      <FacetGroup
+        title={t('resumes.searchPage.facets.skillClusters', { defaultValue: 'Skill Clusters' })}
+        items={facetCounts.clusters}
+        selectedValues={selectedClusters}
+        onToggle={onToggleCluster}
+      />
+      <FacetGroup title={t('resumes.searchPage.facets.tags', { defaultValue: 'Tag clusters' })} items={facetCounts.tags} selectedValues={selectedTags} onToggle={onToggleTag} />
+      <FacetGroup title={t('resumes.searchPage.facets.brands', { defaultValue: 'Brand tags' })} items={facetCounts.brands} selectedValues={selectedBrands} onToggle={onToggleBrand} />
+      <FacetGroup title={t('resumes.searchPage.facets.companies', { defaultValue: 'Company experience' })} items={facetCounts.companies} selectedValues={selectedCompanies} onToggle={onToggleCompany} />
+      <FacetGroup title={t('resumes.searchPage.facets.sources', { defaultValue: 'Sources' })} items={facetCounts.sources} selectedValues={selectedSources} onToggle={onToggleSource} />
+      <PillGroup
+        label={t('resumes.searchPage.facets.experienceLevel', { defaultValue: 'Experience level' })}
+        items={[
+          { value: 'senior' as const, label: t('resumes.searchPage.facets.experience.senior', { defaultValue: 'Senior' }) },
+          { value: 'mid' as const, label: t('resumes.searchPage.facets.experience.mid', { defaultValue: 'Mid-level' }) },
+          { value: 'junior' as const, label: t('resumes.searchPage.facets.experience.junior', { defaultValue: 'Junior' }) },
+        ]}
+        selectedValue={selectedExperienceLevel}
+        onSelect={onSetExperienceLevel}
+      />
+      <FacetGroup title={t('resumes.searchPage.facets.education', { defaultValue: 'Education' })} items={facetCounts.education} selectedValues={selectedEducation} onToggle={onToggleEducation} />
     </div>
   )
 

--- a/apps/web/src/contexts/WorkspaceContext.tsx
+++ b/apps/web/src/contexts/WorkspaceContext.tsx
@@ -12,7 +12,13 @@ type WorkspaceContextValue = {
 
 const WorkspaceContext = createContext<WorkspaceContextValue | null>(null)
 
-export function WorkspaceProvider({ children }: { children: ReactNode }) {
+export function WorkspaceProvider({
+  children,
+  invalidFallback,
+}: {
+  children: ReactNode
+  invalidFallback?: ReactNode
+}) {
   const location = useLocation()
   const params = useParams()
   const teamSlug = params.teamSlug
@@ -30,6 +36,9 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   }, [validSlug])
 
   if (!validSlug) {
+    if (invalidFallback) {
+      return <>{invalidFallback}</>
+    }
     return <Navigate to={{ pathname: '/dev/resumes', search: location.search }} replace />
   }
 

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -466,6 +466,24 @@ describe('useResumeSearchState', () => {
     expect(result.current.filteredResults[1]?.resume.experience).toBe('3 years')
   })
 
+  it('matches idOrNameSearch against external IDs', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'machine tools',
+      keywords: ['machine tools'],
+      filters: {
+        idOrNameSearch: 'external-2',
+      },
+    }))
+    resumesMock.push(
+      createResume(1, { externalId: 'external-1' }),
+      createResume(2, { externalId: 'external-2' }),
+    )
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(result.current.filteredResults.map((item) => item.resume.externalId)).toEqual(['external-2'])
+  })
+
   it('applies age filters while keeping resumes with unknown ages', () => {
     Object.assign(parsedStateMock, createParsedState({
       query: 'machine tools',

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -639,8 +639,15 @@ function matchesLocalFilters(
   const idOrNameNeedle = state.filters.idOrNameSearch?.trim().toLowerCase()
   if (idOrNameNeedle) {
     const resumeIdStr = String(item.resume.resumeId).toLowerCase()
+    const externalIdStr = (item.resume.externalId ?? '').toLowerCase()
+    const identityKeyStr = (item.identityKey ?? item.resume.identityKey ?? '').toLowerCase()
     const nameStr = (item.resume.name ?? '').toLowerCase()
-    if (!resumeIdStr.includes(idOrNameNeedle) && !nameStr.includes(idOrNameNeedle)) {
+    if (
+      !resumeIdStr.includes(idOrNameNeedle) &&
+      !externalIdStr.includes(idOrNameNeedle) &&
+      !identityKeyStr.includes(idOrNameNeedle) &&
+      !nameStr.includes(idOrNameNeedle)
+    ) {
       return false
     }
   }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -12,12 +12,19 @@
     "debugAi": "Debug AI",
     "search": "Search",
     "settings": "Settings",
+    "system": "System",
     "reviewPackets": "Review packets",
     "jds": "JDs",
     "archived": "Archived",
     "aiTaggingCompare": "AI Tagging (Compare)",
     "dataInspector": "Data Inspector",
     "auditCompliance": "Audit & Compliance"
+  },
+  "notFound": {
+    "eyebrow": "404",
+    "title": "Page not found",
+    "description": "The page you're looking for doesn't exist or has moved.",
+    "backToResumes": "Back to resumes"
   },
   "common": {
     "loading": "Loading",
@@ -32,7 +39,10 @@
     "reset": "Reset",
     "apply": "Apply",
     "archive": "Archive",
-    "delete": "Delete"
+    "delete": "Delete",
+    "edit": "Edit",
+    "saving": "Saving...",
+    "deleting": "Deleting..."
   },
   "jdManagement": {
     "title": "Job Description Management",
@@ -277,6 +287,12 @@
         "bachelor": "Bachelor",
         "master": "Master",
         "phd": "PhD"
+      },
+      "badges": {
+        "maxExperience": "≤{{value}} years",
+        "ageRange": "{{min}}-{{max}} years old",
+        "minAge": "≥{{value}} years old",
+        "maxAge": "≤{{value}} years old"
       }
     },
     "columns": {
@@ -374,13 +390,13 @@
     "searchPage": {
       "facets": {
         "filtersTitle": "Filters",
-        "filtersDescription": "Refine your search results.",
+        "filtersDescription": "Refine the currently loaded search results.",
         "filtersDescriptionMobile": "Refine your search results.",
-        "loadedCount": "Showing counts for the first {{count}} results",
+        "loadedCount": "Facet counts are based on the first {{count}} loaded results.",
         "emptyLabel": "No options available",
         "showLess": "Show less",
         "showMore": "Show {{count}} more",
-        "experienceLevel": "Experience",
+        "experienceLevel": "Experience level",
         "experience": {
           "senior": "Senior",
           "mid": "Mid",
@@ -388,18 +404,19 @@
         },
         "skillClusters": "Skill Clusters",
         "tags": "Tags",
-        "companies": "Companies",
+        "companies": "Company experience",
         "brands": "Brand Tags",
         "education": "Education",
         "status": "Candidate Status",
         "matchScore": "Match Score",
-        "sources": "Source Channel",
+        "sources": "Sources",
         "salary": "Expected Salary",
         "salaryUnit": "k",
         "minRoleYears": "Relevant Experience",
         "ageRange": "Age Range",
-        "ageUnit": "yrs",
-        "custom": "Custom"
+        "ageUnit": "years old",
+        "custom": "Custom",
+        "idOrNamePlaceholder": "ID / Name / External ID"
       },
       "hero": {
         "quickStart": "Quick Start",
@@ -744,7 +761,19 @@
     },
     "runNetworkError": "Cannot reach API server. Start make dev or make dev-api.",
     "seekJobUrlError": "Enabled Seek source requires a Seek recommended candidates URL",
-    "seekJobUrlMissing": "Seek Run Now requires an exact Seek recommended candidates URL."
+    "seekJobUrlMissing": "Seek Run Now requires an exact Seek recommended candidates URL.",
+    "card": {
+      "resultCount": "{{count}} resumes",
+      "never": "never",
+      "quickStartBadge": "quick start",
+      "landingQuickStart": "Landing quick start:",
+      "schedule": "Schedule:",
+      "disabled": "disabled",
+      "enabledSchedule": "{{schedule}} (enabled)",
+      "lastRun": "Last run:",
+      "runStatus": "Run status:",
+      "runNow": "Run Now"
+    }
   },
   "searchAnalytics": {
     "nav": "Search Analytics",
@@ -1040,7 +1069,50 @@
     "workflowSeedStatus": "Status",
     "workflowSeedVisible": "Visible",
     "taxonomyPageDescription": "Manage grouped resume skill clusters used by the search facet sidebar.",
-    "workflowSeedsDescription": "Search-first landing quick starts now live in the same Search Profiles workspace registry as every other profile."
+    "workflowSeedsDescription": "Search-first landing quick starts now live in the same Search Profiles workspace registry as every other profile.",
+    "collectionKeywordRequired": "Please enter a keyword",
+    "collectionTaskDispatched": "Collection task dispatched",
+    "collectionTaskFailed": "Failed to start collection",
+    "databaseResetSuccess": "Database has been reset",
+    "databaseResetFailed": "Failed to reset database",
+    "taxonomy": {
+      "status": {
+        "active": "Active",
+        "draft": "Draft",
+        "archived": "Archived"
+      },
+      "source": {
+        "human": "Human",
+        "ai": "AI",
+        "merged": "Merged"
+      },
+      "none": "None",
+      "generatedDrafts": "Generated {{count}} draft taxonomy suggestions",
+      "generatingDrafts": "Generating drafts...",
+      "generateDrafts": "Generate Drafts",
+      "newCluster": "New Cluster",
+      "activeDescription": "Visible in the search facet sidebar.",
+      "draftDescription": "Generated or staged before approval.",
+      "archivedDescription": "Kept for history but hidden from search.",
+      "clusterRegistry": "Cluster registry",
+      "clusterRegistryDescription": "Drafts can be reviewed and promoted to active clusters. Active clusters are used by the search-first resume sidebar.",
+      "empty": "No taxonomy clusters yet.",
+      "name": "Name",
+      "statusLabel": "Status",
+      "sourceLabel": "Source",
+      "parent": "Parent",
+      "tags": "Tags",
+      "actions": "Actions",
+      "editCluster": "Edit taxonomy cluster",
+      "createCluster": "Create taxonomy cluster",
+      "dialogDescription": "Define a stable cluster name, slug, and the raw tags that should roll up into it.",
+      "slug": "Slug",
+      "parentCluster": "Parent Cluster",
+      "confidence": "Confidence",
+      "tagsHelp": "Separate tags with commas. Search facets will group any matching resume tag into this cluster.",
+      "saveChanges": "Save Changes",
+      "createClusterButton": "Create Cluster"
+    }
   },
   "platforms": {
     "zhihu": "Zhihu",
@@ -1166,7 +1238,19 @@
     "profileRestartVisibilityHint": "Runtime updates can take a few seconds after save. After restart, confirm the rebuilt job in worker status.",
     "profilesDescription": "Save reusable scheduled summary profiles here, then validate the output with the manual run tools below before enabling them for worker restarts.",
     "profilesEmpty": "No summary profiles saved yet. Create one here, validate it with the manual preview/send tools below, and restart the worker when you are ready to activate it.",
-    "runDescription": "Preview the outbound summary content as a dry-run, then send it through the selected channel using the existing summary ledger."
+    "runDescription": "Preview the outbound summary content as a dry-run, then send it through the selected channel using the existing summary ledger.",
+    "profileSaved": "Summary profile saved",
+    "profileCreated": "Summary profile created",
+    "profileDeleted": "Summary profile deleted",
+    "errors": {
+      "loadRunDetailFailed": "Failed to load summary run detail",
+      "loadRunsFailed": "Failed to load summary runs",
+      "loadProfilesFailed": "Failed to load summary profiles",
+      "invalidProfile": "Invalid summary profile",
+      "saveProfileFailed": "Failed to save summary profile",
+      "createProfileFailed": "Failed to create summary profile",
+      "deleteProfileFailed": "Failed to delete summary profile"
+    }
   },
   "footer": {},
   "aiTagging": {
@@ -1491,6 +1575,21 @@
     },
     "common": {
       "retry": "Retry"
+    }
+  },
+  "shareLink": {
+    "button": "Share",
+    "copiedSearch": "Share link copied",
+    "copiedSession": "Session link copied",
+    "copyPreparedFailed": "Automatic copy failed. Copy the link below manually.",
+    "copyUrlFailed": "Failed to copy link. Copy the URL from the address bar manually.",
+    "retryCopyFailed": "Copy still failed. Copy the link below manually.",
+    "dialog": {
+      "title": "Copy share link manually",
+      "description": "Automatic copy did not complete. The link is ready to copy manually.",
+      "titleLabel": "Share title",
+      "urlLabel": "Share link",
+      "retryCopy": "Try copying again"
     }
   }
 }

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -12,12 +12,19 @@
     "debugAi": "AI 调试",
     "search": "搜索",
     "settings": "设置",
+    "system": "系统",
     "reviewPackets": "评审包",
     "jds": "职位",
     "archived": "已归档",
     "aiTaggingCompare": "AI 标注（对比）",
     "dataInspector": "数据检查",
     "auditCompliance": "审计与合规"
+  },
+  "notFound": {
+    "eyebrow": "404",
+    "title": "页面未找到",
+    "description": "你访问的页面不存在或已移动。",
+    "backToResumes": "返回简历"
   },
   "common": {
     "loading": "加载中...",
@@ -32,7 +39,10 @@
     "reset": "重置",
     "apply": "应用",
     "archive": "归档",
-    "delete": "删除"
+    "delete": "删除",
+    "edit": "编辑",
+    "saving": "保存中...",
+    "deleting": "删除中..."
   },
   "jdManagement": {
     "title": "职位描述管理",
@@ -276,6 +286,12 @@
         "bachelor": "本科",
         "master": "硕士",
         "phd": "博士"
+      },
+      "badges": {
+        "maxExperience": "≤{{value}} 年",
+        "ageRange": "{{min}}-{{max}} 岁",
+        "minAge": "≥{{value}} 岁",
+        "maxAge": "≤{{value}} 岁"
       }
     },
     "columns": {
@@ -373,9 +389,9 @@
     "searchPage": {
       "facets": {
         "filtersTitle": "筛选条件",
-        "filtersDescription": "在当前搜索结果中进一步精确筛选。",
+        "filtersDescription": "在当前加载的搜索结果中进一步筛选。",
         "filtersDescriptionMobile": "在当前搜索结果中进一步精确筛选。",
-        "loadedCount": "显示前 {{count}} 条结果中的筛选统计",
+        "loadedCount": "筛选统计基于前 {{count}} 条已加载结果。",
         "emptyLabel": "暂无可用选项",
         "showLess": "收起",
         "showMore": "展开剩余 {{count}} 项",
@@ -395,10 +411,11 @@
         "sources": "来源渠道",
         "salary": "期望薪资",
         "salaryUnit": "k",
-        "minRoleYears": "相关工作年限",
+        "minRoleYears": "相关经验",
         "ageRange": "年龄范围",
         "ageUnit": "岁",
-        "custom": "自定义"
+        "custom": "自定义",
+        "idOrNamePlaceholder": "ID / 姓名 / 外部ID"
       },
       "hero": {
         "quickStart": "快速开始",
@@ -716,7 +733,50 @@
     "workflowSeedStatus": "状态",
     "workflowSeedVisible": "可见",
     "taxonomyPageDescription": "管理搜索侧面栏使用的分组简历技能集群。",
-    "workflowSeedsDescription": "搜索优先的落地快速启动现在与其他配置一样位于同一搜索配置工作区注册表中。"
+    "workflowSeedsDescription": "搜索优先的落地快速启动现在与其他配置一样位于同一搜索配置工作区注册表中。",
+    "collectionKeywordRequired": "请输入关键词",
+    "collectionTaskDispatched": "采集任务已派发",
+    "collectionTaskFailed": "启动采集失败",
+    "databaseResetSuccess": "数据库已重置",
+    "databaseResetFailed": "重置数据库失败",
+    "taxonomy": {
+      "status": {
+        "active": "启用",
+        "draft": "草稿",
+        "archived": "已归档"
+      },
+      "source": {
+        "human": "人工",
+        "ai": "AI",
+        "merged": "合并"
+      },
+      "none": "无",
+      "generatedDrafts": "已生成 {{count}} 条草稿分类建议",
+      "generatingDrafts": "正在生成草稿...",
+      "generateDrafts": "生成草稿",
+      "newCluster": "新建聚类",
+      "activeDescription": "显示在搜索筛选侧边栏中。",
+      "draftDescription": "生成或暂存，等待审核。",
+      "archivedDescription": "保留历史记录，但不在搜索中显示。",
+      "clusterRegistry": "聚类注册表",
+      "clusterRegistryDescription": "可以审核草稿并提升为启用聚类。启用聚类会用于搜索优先的简历侧边栏。",
+      "empty": "暂无分类聚类。",
+      "name": "名称",
+      "statusLabel": "状态",
+      "sourceLabel": "来源",
+      "parent": "父级",
+      "tags": "标签",
+      "actions": "操作",
+      "editCluster": "编辑分类聚类",
+      "createCluster": "创建分类聚类",
+      "dialogDescription": "定义稳定的聚类名称、slug，以及应归入该聚类的原始标签。",
+      "slug": "Slug",
+      "parentCluster": "父级聚类",
+      "confidence": "置信度",
+      "tagsHelp": "用逗号分隔标签。搜索筛选会把匹配的简历标签归入此聚类。",
+      "saveChanges": "保存更改",
+      "createClusterButton": "创建聚类"
+    }
   },
   "searchProfiles": {
     "deleteError": "删除配置失败",
@@ -788,7 +848,19 @@
     },
     "runNetworkError": "无法连接 API 服务器。请启动 make dev 或 make dev-api。",
     "seekJobUrlError": "启用 Seek 来源需要 Seek 推荐候选人 URL",
-    "seekJobUrlMissing": "Seek 立即运行需要精确的 Seek 推荐候选人 URL。"
+    "seekJobUrlMissing": "Seek 立即运行需要精确的 Seek 推荐候选人 URL。",
+    "card": {
+      "resultCount": "{{count}} 份简历",
+      "never": "从未运行",
+      "quickStartBadge": "快捷入口",
+      "landingQuickStart": "落地页快捷入口：",
+      "schedule": "计划：",
+      "disabled": "已停用",
+      "enabledSchedule": "{{schedule}}（已启用）",
+      "lastRun": "上次运行：",
+      "runStatus": "运行状态：",
+      "runNow": "立即运行"
+    }
   },
   "debug": {
     "processTitle": "处理数据",
@@ -1194,7 +1266,19 @@
     "profileRestartVisibilityHint": "保存后运行时更新可能需要几秒。重启后，请在 worker 状态中确认重建的作业。",
     "profilesDescription": "在此保存可复用的定时摘要配置，然后使用下方的手动运行工具验证输出，再启用 worker 重启。",
     "profilesEmpty": "尚未保存摘要配置。在此创建一个，使用下方的手动预览/发送工具验证，准备好后重启 worker 以激活。",
-    "runDescription": "以空运行方式预览出站摘要内容，然后使用现有摘要账本通过所选渠道发送。"
+    "runDescription": "以空运行方式预览出站摘要内容，然后使用现有摘要账本通过所选渠道发送。",
+    "profileSaved": "摘要配置已保存",
+    "profileCreated": "摘要配置已创建",
+    "profileDeleted": "摘要配置已删除",
+    "errors": {
+      "loadRunDetailFailed": "加载摘要运行详情失败",
+      "loadRunsFailed": "加载摘要运行失败",
+      "loadProfilesFailed": "加载摘要配置失败",
+      "invalidProfile": "摘要配置无效",
+      "saveProfileFailed": "保存摘要配置失败",
+      "createProfileFailed": "创建摘要配置失败",
+      "deleteProfileFailed": "删除摘要配置失败"
+    }
   },
   "aiTagging": {
     "candidateLimit": "候选人上限",
@@ -1518,6 +1602,21 @@
     },
     "common": {
       "retry": "重试"
+    }
+  },
+  "shareLink": {
+    "button": "分享",
+    "copiedSearch": "已复制分享链接",
+    "copiedSession": "已复制会话链接",
+    "copyPreparedFailed": "自动复制失败，请手动复制下方链接。",
+    "copyUrlFailed": "复制链接失败，请手动复制地址栏 URL。",
+    "retryCopyFailed": "自动复制仍然失败，请手动复制下方链接。",
+    "dialog": {
+      "title": "手动复制分享链接",
+      "description": "当前浏览器未完成自动复制。链接已准备好，手动复制后仍可直接打开当前搜索上下文。",
+      "titleLabel": "分享标题",
+      "urlLabel": "分享链接",
+      "retryCopy": "再试一次复制"
     }
   }
 }

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -12,12 +12,19 @@
     "debugAi": "AI 偵錯",
     "search": "搜尋",
     "settings": "設定",
+    "system": "系統",
     "reviewPackets": "評審包",
     "jds": "職位",
     "archived": "已歸檔",
     "aiTaggingCompare": "AI 標註（對比）",
     "dataInspector": "資料檢查",
     "auditCompliance": "稽核與合規"
+  },
+  "notFound": {
+    "eyebrow": "404",
+    "title": "頁面未找到",
+    "description": "你訪問的頁面不存在或已移動。",
+    "backToResumes": "返回簡歷"
   },
   "common": {
     "loading": "載入中...",
@@ -32,7 +39,10 @@
     "reset": "重置",
     "apply": "應用",
     "archive": "歸檔",
-    "delete": "刪除"
+    "delete": "刪除",
+    "edit": "編輯",
+    "saving": "儲存中...",
+    "deleting": "刪除中..."
   },
   "jdManagement": {
     "title": "職位描述管理",
@@ -276,6 +286,12 @@
         "bachelor": "本科",
         "master": "碩士",
         "phd": "博士"
+      },
+      "badges": {
+        "maxExperience": "≤{{value}} 年",
+        "ageRange": "{{min}}-{{max}} 歲",
+        "minAge": "≥{{value}} 歲",
+        "maxAge": "≤{{value}} 歲"
       }
     },
     "columns": {
@@ -373,9 +389,9 @@
     "searchPage": {
       "facets": {
         "filtersTitle": "篩選條件",
-        "filtersDescription": "在當前搜索結果中進一步精確篩選。",
+        "filtersDescription": "在目前已載入的搜尋結果中進一步篩選。",
         "filtersDescriptionMobile": "在當前搜索結果中進一步精確篩選。",
-        "loadedCount": "顯示前 {{count}} 條結果中的篩選統計",
+        "loadedCount": "篩選統計基於前 {{count}} 筆已載入結果。",
         "emptyLabel": "暫無可用選項",
         "showLess": "收起",
         "showMore": "展開剩餘 {{count}} 項",
@@ -395,10 +411,11 @@
         "sources": "來源渠道",
         "salary": "期望薪資",
         "salaryUnit": "k",
-        "minRoleYears": "相關工作經驗",
+        "minRoleYears": "相關經驗",
         "ageRange": "年齡範圍",
         "ageUnit": "歲",
-        "custom": "自訂"
+        "custom": "自訂",
+        "idOrNamePlaceholder": "ID / 姓名 / 外部ID"
       },
       "hero": {
         "quickStart": "快速開始",
@@ -744,7 +761,19 @@
     },
     "runNetworkError": "無法連接 API 伺服器。請啟動 make dev 或 make dev-api。",
     "seekJobUrlError": "啟用 Seek 來源需要 Seek 推薦候選人 URL",
-    "seekJobUrlMissing": "Seek 立即執行需要精確的 Seek 推薦候選人 URL。"
+    "seekJobUrlMissing": "Seek 立即執行需要精確的 Seek 推薦候選人 URL。",
+    "card": {
+      "resultCount": "{{count}} 份履歷",
+      "never": "從未執行",
+      "quickStartBadge": "快捷入口",
+      "landingQuickStart": "落地頁快捷入口：",
+      "schedule": "排程：",
+      "disabled": "已停用",
+      "enabledSchedule": "{{schedule}}（已啟用）",
+      "lastRun": "上次執行：",
+      "runStatus": "執行狀態：",
+      "runNow": "立即執行"
+    }
   },
   "searchAnalytics": {
     "nav": "搜尋分析",
@@ -1040,7 +1069,50 @@
     "workflowSeedStatus": "狀態",
     "workflowSeedVisible": "可見",
     "taxonomyPageDescription": "管理搜尋側面欄使用的分組簡歷技能集群。",
-    "workflowSeedsDescription": "搜尋優先的落地快速啟動現在與其他配置一樣位於同一搜尋配置工作區註冊表中。"
+    "workflowSeedsDescription": "搜尋優先的落地快速啟動現在與其他配置一樣位於同一搜尋配置工作區註冊表中。",
+    "collectionKeywordRequired": "請輸入關鍵字",
+    "collectionTaskDispatched": "採集任務已派發",
+    "collectionTaskFailed": "啟動採集失敗",
+    "databaseResetSuccess": "資料庫已重置",
+    "databaseResetFailed": "重置資料庫失敗",
+    "taxonomy": {
+      "status": {
+        "active": "啟用",
+        "draft": "草稿",
+        "archived": "已歸檔"
+      },
+      "source": {
+        "human": "人工",
+        "ai": "AI",
+        "merged": "合併"
+      },
+      "none": "無",
+      "generatedDrafts": "已產生 {{count}} 條草稿分類建議",
+      "generatingDrafts": "正在產生草稿...",
+      "generateDrafts": "產生草稿",
+      "newCluster": "新增聚類",
+      "activeDescription": "顯示在搜尋篩選側邊欄中。",
+      "draftDescription": "產生或暫存，等待審核。",
+      "archivedDescription": "保留歷史記錄，但不在搜尋中顯示。",
+      "clusterRegistry": "聚類註冊表",
+      "clusterRegistryDescription": "可以審核草稿並提升為啟用聚類。啟用聚類會用於搜尋優先的履歷側邊欄。",
+      "empty": "暫無分類聚類。",
+      "name": "名稱",
+      "statusLabel": "狀態",
+      "sourceLabel": "來源",
+      "parent": "父級",
+      "tags": "標籤",
+      "actions": "操作",
+      "editCluster": "編輯分類聚類",
+      "createCluster": "建立分類聚類",
+      "dialogDescription": "定義穩定的聚類名稱、slug，以及應歸入該聚類的原始標籤。",
+      "slug": "Slug",
+      "parentCluster": "父級聚類",
+      "confidence": "信心度",
+      "tagsHelp": "用逗號分隔標籤。搜尋篩選會把匹配的履歷標籤歸入此聚類。",
+      "saveChanges": "儲存變更",
+      "createClusterButton": "建立聚類"
+    }
   },
   "platforms": {
     "zhihu": "知乎",
@@ -1166,7 +1238,19 @@
     "profileRestartVisibilityHint": "儲存後執行時更新可能需要幾秒。重啟後，請在 worker 狀態中確認重建的作業。",
     "profilesDescription": "在此儲存可複用的定時摘要配置，然後使用下方的手動執行工具驗證輸出，再啟用 worker 重啟。",
     "profilesEmpty": "尚未儲存摘要配置。在此建立一個，使用下方的手動預覽/發送工具驗證，準備好後重啟 worker 以啟動。",
-    "runDescription": "以空執行方式預覽出站摘要內容，然後使用現有摘要帳本透過所選渠道發送。"
+    "runDescription": "以空執行方式預覽出站摘要內容，然後使用現有摘要帳本透過所選渠道發送。",
+    "profileSaved": "摘要設定已儲存",
+    "profileCreated": "摘要設定已建立",
+    "profileDeleted": "摘要設定已刪除",
+    "errors": {
+      "loadRunDetailFailed": "載入摘要執行詳情失敗",
+      "loadRunsFailed": "載入摘要執行失敗",
+      "loadProfilesFailed": "載入摘要設定失敗",
+      "invalidProfile": "摘要設定無效",
+      "saveProfileFailed": "儲存摘要設定失敗",
+      "createProfileFailed": "建立摘要設定失敗",
+      "deleteProfileFailed": "刪除摘要設定失敗"
+    }
   },
   "footer": {},
   "aiTagging": {
@@ -1491,6 +1575,21 @@
     },
     "common": {
       "retry": "重試"
+    }
+  },
+  "shareLink": {
+    "button": "分享",
+    "copiedSearch": "已複製分享連結",
+    "copiedSession": "已複製會話連結",
+    "copyPreparedFailed": "自動複製失敗，請手動複製下方連結。",
+    "copyUrlFailed": "複製連結失敗，請手動複製地址列 URL。",
+    "retryCopyFailed": "自動複製仍然失敗，請手動複製下方連結。",
+    "dialog": {
+      "title": "手動複製分享連結",
+      "description": "目前瀏覽器未完成自動複製。連結已準備好，手動複製後仍可直接開啟目前搜尋上下文。",
+      "titleLabel": "分享標題",
+      "urlLabel": "分享連結",
+      "retryCopy": "再試一次複製"
     }
   }
 }

--- a/apps/web/src/layouts/SettingsLayout.tsx
+++ b/apps/web/src/layouts/SettingsLayout.tsx
@@ -5,6 +5,7 @@ import { Menu } from 'lucide-react'
 import { Header } from '@/components/Header'
 import { SettingsSidebar } from '@/components/SettingsSidebar'
 import { Button } from '@/components/ui/button'
+import { ErrorBoundary } from '@/components/ErrorBoundary'
 
 export default function SettingsLayout() {
   const [open, setOpen] = useState(false)
@@ -40,7 +41,9 @@ export default function SettingsLayout() {
           )}
 
           <main className="flex-1 p-6 space-y-6">
-            <Outlet />
+            <ErrorBoundary>
+              <Outlet />
+            </ErrorBoundary>
           </main>
         </div>
       </div>

--- a/apps/web/src/layouts/SystemLayout.tsx
+++ b/apps/web/src/layouts/SystemLayout.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { useState } from 'react'
 import { SystemSidebar } from '@/components/SystemSidebar'
 import { Header } from '@/components/Header'
+import { ErrorBoundary } from '@/components/ErrorBoundary'
 
 export default function SystemLayout() {
   const [open, setOpen] = useState(false)
@@ -44,7 +45,9 @@ export default function SystemLayout() {
 
           {/* Main padding and overflow handling */}
           <main className="flex-1 p-6 space-y-6">
-            <Outlet />
+            <ErrorBoundary>
+              <Outlet />
+            </ErrorBoundary>
           </main>
         </div>
       </div>

--- a/apps/web/src/lib/ui-error-reporting.ts
+++ b/apps/web/src/lib/ui-error-reporting.ts
@@ -1,0 +1,12 @@
+export function reportUiError(message: string, error?: unknown, ...details: unknown[]) {
+  if (!import.meta.env.DEV) {
+    return
+  }
+
+  if (error === undefined && details.length === 0) {
+    console.error(message)
+    return
+  }
+
+  console.error(message, error, ...details)
+}

--- a/apps/web/src/pages/ArchivedResumes.tsx
+++ b/apps/web/src/pages/ArchivedResumes.tsx
@@ -14,6 +14,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { PageHeader } from '@/components/PageHeader'
 import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
 import { SourceFacetSelect } from '@/components/SourceFacetSelect'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 type ArchivedResume = {
   resumeId: string
@@ -122,7 +123,7 @@ export default function ArchivedResumes() {
         toast.info(t('archivedResumes.restoreNothing', { defaultValue: 'No resumes to restore' }))
       }
     } catch (error) {
-      console.error('Failed to restore resumes', error)
+      reportUiError('Failed to restore resumes', error)
       toast.error(t('archivedResumes.restoreFailed', { defaultValue: 'Failed to restore resumes' }))
     } finally {
       setUnarchiving(false)

--- a/apps/web/src/pages/DebugAI.tsx
+++ b/apps/web/src/pages/DebugAI.tsx
@@ -106,7 +106,7 @@ export default function DebugAI() {
     navigator.clipboard.writeText(analysisJson).then(() => {
       toast.success(t('debugAi.jsonCopied', 'JSON copied'))
     }).catch(() => {
-      toast.error(t('debugAi.copyFailed', '复制失败'))
+      toast.error(t('debugAi.copyFailed', 'Copy failed'))
     })
   }, [analysisJson, t])
 

--- a/apps/web/src/pages/DebugAiTaggingResults.tsx
+++ b/apps/web/src/pages/DebugAiTaggingResults.tsx
@@ -17,6 +17,7 @@ import { JobDescriptionSelect } from '@/components/JobDescriptionSelect'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
 import { useConvexResumes } from '@/hooks/useConvexResumes'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 type AiTaggingRow = Doc<'ai_tagging_results'>
 
@@ -151,7 +152,7 @@ export default function DebugAiTaggingResults() {
         })
       )
     } catch (error) {
-      console.error('Failed to enqueue AI tagging', error)
+      reportUiError('Failed to enqueue AI tagging', error)
       toast.error(t('aiTagging.enqueueFailed', { defaultValue: 'Failed to enqueue AI tagging' }))
     } finally {
       setEnqueueing(false)

--- a/apps/web/src/pages/DebugConfig.tsx
+++ b/apps/web/src/pages/DebugConfig.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/dialog'
 import { useSystemMetadata } from '@/hooks/useSystemMetadata'
 import { resolveSystemSettingsSubpages, type SystemSettingsSubpageDefinition } from '@/pages/system-settings/lib'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 function getSectionIcon(id: SystemSettingsSubpageDefinition['id']) {
   switch (id) {
@@ -58,10 +59,10 @@ export default function DebugConfig() {
     try {
       await resetDatabase()
       setResetDatabaseDialogOpen(false)
-      toast.success('Database has been reset')
+      toast.success(t('debugConfig.databaseResetSuccess', { defaultValue: 'Database has been reset' }))
     } catch (error) {
-      console.error('Failed to reset database', error)
-      toast.error('Failed to reset database')
+      reportUiError('Failed to reset database', error)
+      toast.error(t('debugConfig.databaseResetFailed', { defaultValue: 'Failed to reset database' }))
     } finally {
       setResettingDatabase(false)
     }
@@ -174,7 +175,7 @@ export default function DebugConfig() {
               variant="destructive"
               onClick={() => {
                 handleResetDatabase().catch((error) => {
-                  console.error('Unexpected handleResetDatabase failure', error)
+                  reportUiError('Unexpected handleResetDatabase failure', error)
                 })
               }}
               disabled={resettingDatabase}

--- a/apps/web/src/pages/DebugIngest.tsx
+++ b/apps/web/src/pages/DebugIngest.tsx
@@ -22,6 +22,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { PageHeader } from '@/components/PageHeader'
 import { useResumeFieldUsagePolicy } from '@/contexts/ResumeFieldUsagePolicyContext'
 import { SourceFacetSelect } from '@/components/SourceFacetSelect'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 type IngestDiagnosticsResume = {
   resumeId: string
@@ -204,7 +205,7 @@ export default function DebugIngest() {
       }
       setSkillsVersion(version)
     } catch (error) {
-      console.error('Failed to fetch skills version', error)
+      reportUiError('Failed to fetch skills version', error)
       toast.error(t('debugIngest.skillsVersionFailed', { defaultValue: 'Failed to load skills version' }))
     } finally {
       setVersionLoading(false)
@@ -380,7 +381,7 @@ export default function DebugIngest() {
       )
       await loadSkillsVersion()
     } catch (error) {
-      console.error('Failed to trigger re-ingest', error)
+      reportUiError('Failed to trigger re-ingest', error)
       toast.error(t('debugIngest.reingestFailed', { defaultValue: 'Failed to trigger re-ingest' }))
     } finally {
       setReingesting(false)
@@ -404,7 +405,7 @@ export default function DebugIngest() {
         }),
       )
     } catch (error) {
-      console.error('Failed to clear analyses', error)
+      reportUiError('Failed to clear analyses', error)
       toast.error(t('debugIngest.clearAnalysesFailed', { defaultValue: 'Failed to clear analyses' }))
     } finally {
       setClearingAnalyses(false)
@@ -432,7 +433,7 @@ export default function DebugIngest() {
       )
       await loadSkillsVersion()
     } catch (error) {
-      console.error('Failed to hard reset ingest data', error)
+      reportUiError('Failed to hard reset ingest data', error)
       toast.error(
         t('debugIngest.hardResetFailed', {
           defaultValue: 'Failed to hard reset resumes and schedule re-ingest',
@@ -461,7 +462,7 @@ export default function DebugIngest() {
       )
       await loadSkillsVersion()
     } catch (error) {
-      console.error('Failed to reset resume database', error)
+      reportUiError('Failed to reset resume database', error)
       toast.error(
         t('debugIngest.resetDatabaseFailed', {
           defaultValue: 'Failed to clear resume database',
@@ -500,7 +501,7 @@ export default function DebugIngest() {
         toast.error(summaryMessage)
       }
     } catch (error) {
-      console.error('Failed to delete resumes', error)
+      reportUiError('Failed to delete resumes', error)
       toast.error(t('debugIngest.deleteFailed', { defaultValue: 'Failed to delete resumes' }))
     } finally {
       setDeletingResumes(false)
@@ -532,7 +533,7 @@ export default function DebugIngest() {
         toast.info(t('debugIngest.archiveAlreadyDone', { defaultValue: 'Resumes already archived' }))
       }
     } catch (error) {
-      console.error('Failed to archive resumes', error)
+      reportUiError('Failed to archive resumes', error)
       toast.error(t('debugIngest.archiveFailed', { defaultValue: 'Failed to archive resumes' }))
     } finally {
       setArchivingResumes(false)

--- a/apps/web/src/pages/DebugJDs.tsx
+++ b/apps/web/src/pages/DebugJDs.tsx
@@ -16,6 +16,7 @@ import { PageHeader } from '@/components/PageHeader'
 import { useTranslation } from 'react-i18next'
 import { formatInAppTimezone } from '@/lib/timezone'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 type SortColumn = 'title' | 'type' | 'lastModified' | 'usageCount'
 type SortDirection = 'asc' | 'desc'
@@ -70,7 +71,7 @@ export default function DebugJDs() {
             const result = await loadJdsWithUsage({ workspaceSlug: slug })
             setJds(result)
         } catch (error) {
-            console.error('Failed to load job descriptions with usage', error)
+            reportUiError('Failed to load job descriptions with usage', error)
             setDeleteError((previous) => previous ?? t('jdManagement.errors.deleteFailed'))
         }
     }, [loadJdsWithUsage, slug, t])
@@ -120,7 +121,7 @@ export default function DebugJDs() {
                 setDeleteId(null)
                 setDeleteError(null)
             } catch (error) {
-                console.error("Failed to delete JD:", error)
+                reportUiError("Failed to delete JD:", error)
                 const message = error instanceof Error ? error.message : t('jdManagement.errors.deleteFailed')
                 setDeleteError(message || t('jdManagement.errors.deleteFailed'))
                 setDeleteId(null) // Close dialog so they can see the error
@@ -176,7 +177,7 @@ export default function DebugJDs() {
             setShowBulkDeleteConfirm(false)
             setDeleteError(null)
         } catch (error) {
-            console.error("Failed to batch delete JDs:", error)
+            reportUiError("Failed to batch delete JDs:", error)
             const message = error instanceof Error ? error.message : t('jdManagement.errors.deleteFailed')
             setDeleteError(message || t('jdManagement.errors.deleteFailed'))
             setShowBulkDeleteConfirm(false)
@@ -232,7 +233,7 @@ export default function DebugJDs() {
             link.remove()
             window.URL.revokeObjectURL(url)
         } catch (error) {
-            console.error('Failed to export JD markdown:', error)
+            reportUiError('Failed to export JD markdown:', error)
         }
     }
 
@@ -251,7 +252,7 @@ export default function DebugJDs() {
             link.remove()
             window.URL.revokeObjectURL(url)
         } catch (error) {
-            console.error('Failed to export bulk JDs:', error)
+            reportUiError('Failed to export bulk JDs:', error)
         }
     }
 

--- a/apps/web/src/pages/NotFoundPage.tsx
+++ b/apps/web/src/pages/NotFoundPage.tsx
@@ -1,0 +1,40 @@
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { AlertTriangle } from 'lucide-react'
+import { buttonVariants } from '@/components/ui/button'
+
+type NotFoundPageProps = {
+  homePath?: string
+}
+
+export function NotFoundPage({ homePath = '/dev/resumes' }: NotFoundPageProps) {
+  const { t } = useTranslation()
+
+  return (
+    <section className="mx-auto flex min-h-[55vh] max-w-xl flex-col justify-center gap-6 py-12">
+      <div className="flex h-12 w-12 items-center justify-center rounded-md bg-muted">
+        <AlertTriangle className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+      </div>
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-muted-foreground">
+          {t('notFound.eyebrow', { defaultValue: '404' })}
+        </p>
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+          {t('notFound.title', { defaultValue: 'Page not found' })}
+        </h1>
+        <p className="text-sm leading-6 text-muted-foreground">
+          {t('notFound.description', {
+            defaultValue: "The page you're looking for doesn't exist or has moved.",
+          })}
+        </p>
+      </div>
+      <div>
+        <Link to={homePath} className={buttonVariants()}>
+          {t('notFound.backToResumes', { defaultValue: 'Back to resumes' })}
+        </Link>
+      </div>
+    </section>
+  )
+}
+
+export default NotFoundPage

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -272,20 +272,20 @@ export function ResumeSearchPage() {
     ],
   )
   const analysisTitle = t('resumes.searchPage.analysis.title', {
-    defaultValue: '简历 AI 测算',
+    defaultValue: 'Resume AI analysis',
   })
   const analysisDescription = t('resumes.searchPage.analysis.description', {
-    defaultValue: '为加载的搜索结果生成 AI 摘要和详细分数拆解。',
+    defaultValue: 'Generate AI summary and detailed score breakdown for the loaded search results.',
   })
   const analyzingLabel = t('resumes.searchPage.analysis.analyzing', {
-    defaultValue: '分析中...',
+    defaultValue: 'Analyzing...',
   })
   const analyzeLoadedLabel = t('resumes.searchPage.analysis.analyzeLoaded', {
     count: analysisCandidateCount,
-    defaultValue: '测算 {{count}} 份简历',
+    defaultValue: 'Analyze loaded {{count}}',
   })
   const analyzeLoadedResultsLabel = t('resumes.searchPage.analysis.analyzeLoadedResults', {
-    defaultValue: '测算当前结果',
+    defaultValue: 'Analyze loaded results',
   })
   const errorSearchBarLabel = t('resumes.searchPage.error.searchBar', {
     defaultValue: 'Search bar failed to load.',

--- a/apps/web/src/pages/ReviewPacketsPage.tsx
+++ b/apps/web/src/pages/ReviewPacketsPage.tsx
@@ -17,6 +17,7 @@ import { apiBaseUrl } from '@/lib/api-client'
 import type { components } from '@/lib/api-types'
 import { rawApiClient } from '@/lib/api-helpers'
 import { withWorkspaceHeaders } from '@/lib/workspace-ref'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 type ReviewPacketRun = components['schemas']['ReviewPacketRun']
 type ReviewPacketRunStatus = components['schemas']['ReviewPacketRunStatus']
@@ -287,7 +288,7 @@ export function ReviewPacketsPage() {
         setSummaryPreview(null)
       }
     } catch (error) {
-      console.error('Failed to load review packet runs', error)
+      reportUiError('Failed to load review packet runs', error)
       const message = error instanceof Error && error.message.trim().length > 0
         ? error.message
         : t('reviewPackets.loadRunsError', { defaultValue: 'Failed to load review packet runs' })
@@ -313,7 +314,7 @@ export function ReviewPacketsPage() {
       setSelectedRun(data.run)
       setRuns((current) => mergeRun(current, data.run))
     } catch (error) {
-      console.error(`Failed to load review packet run ${runId}`, error)
+      reportUiError(`Failed to load review packet run ${runId}`, error)
       const message = error instanceof Error && error.message.trim().length > 0
         ? error.message
         : t('reviewPackets.loadRunError', { defaultValue: 'Failed to load review packet run' })
@@ -415,7 +416,7 @@ export function ReviewPacketsPage() {
       toast.success(t('reviewPackets.exportSuccess', { defaultValue: 'Review packet exported' }))
       await loadRuns(data.run.id)
     } catch (error) {
-      console.error('Failed to export review packet', error)
+      reportUiError('Failed to export review packet', error)
       const message = error instanceof Error && error.message.trim().length > 0
         ? error.message
         : t('reviewPackets.exportError', { defaultValue: 'Failed to create review packet export' })
@@ -447,7 +448,7 @@ export function ReviewPacketsPage() {
         ?? `review-packet-${run.id}.${run.format}`
       triggerBlobDownload(blob, filename)
     } catch (error) {
-      console.error(`Failed to download review packet ${run.id}`, error)
+      reportUiError(`Failed to download review packet ${run.id}`, error)
       const message = error instanceof Error && error.message.trim().length > 0
         ? error.message
         : t('reviewPackets.downloadError', { defaultValue: 'Failed to download review packet' })
@@ -513,7 +514,7 @@ export function ReviewPacketsPage() {
         }),
       )
     } catch (error) {
-      console.error(`Failed to import feedback for review packet ${selectedRun.id}`, error)
+      reportUiError(`Failed to import feedback for review packet ${selectedRun.id}`, error)
       const message = error instanceof Error && error.message.trim().length > 0
         ? error.message
         : t('reviewPackets.feedbackImportError', { defaultValue: 'Failed to import review packet feedback' })
@@ -553,7 +554,7 @@ export function ReviewPacketsPage() {
       setSummaryPreview(data)
       toast.success(t('reviewPackets.summaryPreviewSuccess', { defaultValue: 'Summary preview generated' }))
     } catch (error) {
-      console.error(`Failed to preview summary for review packet ${selectedRun.id}`, error)
+      reportUiError(`Failed to preview summary for review packet ${selectedRun.id}`, error)
       const message = error instanceof Error && error.message.trim().length > 0
         ? error.message
         : t('reviewPackets.summaryPreviewError', { defaultValue: 'Failed to preview summary' })
@@ -596,7 +597,7 @@ export function ReviewPacketsPage() {
       updateRunState(data.run)
       toast.success(t('reviewPackets.summarySendSuccess', { defaultValue: 'Summary sent' }))
     } catch (error) {
-      console.error(`Failed to send summary for review packet ${selectedRun.id}`, error)
+      reportUiError(`Failed to send summary for review packet ${selectedRun.id}`, error)
       const message = error instanceof Error && error.message.trim().length > 0
         ? error.message
         : t('reviewPackets.summarySendError', { defaultValue: 'Failed to send summary' })

--- a/apps/web/src/pages/SearchAnalyticsPage.tsx
+++ b/apps/web/src/pages/SearchAnalyticsPage.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { PageHeader } from '@/components/PageHeader'
+import { reportUiError } from '@/lib/ui-error-reporting'
 type SearchSummaryPayload = {
   totalSearches: number
   zeroResultSearches: number
@@ -85,7 +86,7 @@ export default function SearchAnalyticsPage() {
       setZeroResults(zeroResponse.data?.success ? (zeroResponse.data.items || []) : [])
       setSuggestions(suggestionResponse.data?.success ? (suggestionResponse.data.suggestions || []) : [])
     } catch (error) {
-      console.error('Failed to load search analytics', error)
+      reportUiError('Failed to load search analytics', error)
       toast.error(t('searchAnalytics.loadError', { defaultValue: 'Failed to load search analytics' }))
     } finally {
       setLoading(false)
@@ -130,7 +131,7 @@ export default function SearchAnalyticsPage() {
       toast.success(t('searchAnalytics.suggestionSaved', { defaultValue: 'Synonym suggestion saved' }))
       await loadAnalytics()
     } catch (error) {
-      console.error('Failed to submit synonym suggestion', error)
+      reportUiError('Failed to submit synonym suggestion', error)
       toast.error(t('searchAnalytics.suggestionError', { defaultValue: 'Failed to save suggestion' }))
     } finally {
       setSubmittingQuery(null)

--- a/apps/web/src/pages/SearchProfilesPage.tsx
+++ b/apps/web/src/pages/SearchProfilesPage.tsx
@@ -18,6 +18,7 @@ import {
   resolveSeekModeFromUrl,
   type CollectionSourceType,
 } from '@/lib/search-profile-sources'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 type ListProfilesResponse = {
   success: boolean
@@ -182,7 +183,7 @@ export function SearchProfilesPage() {
 
       return status
     } catch (error) {
-      console.error(`Failed to load run status for profile ${profileId}`, error)
+      reportUiError(`Failed to load run status for profile ${profileId}`, error)
       return null
     }
   }, [clearPolling])
@@ -211,7 +212,7 @@ export function SearchProfilesPage() {
       }))
       return profile
     } catch (error) {
-      console.error(`Failed to load profile detail ${profileId}`, error)
+      reportUiError(`Failed to load profile detail ${profileId}`, error)
       return null
     }
   }, [])
@@ -247,7 +248,7 @@ export function SearchProfilesPage() {
         await fetchRunStatus(profile.id)
       }))
     } catch (error) {
-      console.error('Failed to load search profiles', error)
+      reportUiError('Failed to load search profiles', error)
       toast.error(t('searchProfiles.loadError', { defaultValue: 'Failed to load profiles' }))
     } finally {
       setLoading(false)
@@ -460,7 +461,7 @@ export function SearchProfilesPage() {
       startPolling(profileId)
       runNowLocksRef.current.delete(profileId)
     } catch (error) {
-      console.error(`Failed to run profile ${profileId}`, error)
+      reportUiError(`Failed to run profile ${profileId}`, error)
       const rawMessage = extractApiErrorMessage(error)
       const message = isLikelyNetworkError(rawMessage)
         ? t('searchProfiles.runNetworkError', { defaultValue: 'Cannot reach API server. Start make dev or make dev-api.' })

--- a/apps/web/src/pages/SummaryRunsPage.tsx
+++ b/apps/web/src/pages/SummaryRunsPage.tsx
@@ -14,6 +14,7 @@ import { PageHeader } from '@/components/PageHeader'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { rawApiClient } from '@/lib/api-helpers'
 import type { paths } from '@/lib/api-types'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 type SummaryRunListResponse = paths['/api/summaries/runs']['get']['responses'][200]['content']['application/json']
 type SummaryRunDetailResponse = paths['/api/summaries/runs/{runId}']['get']['responses'][200]['content']['application/json']
@@ -330,13 +331,13 @@ export function SummaryRunsPage() {
       }
       setSelectedRun(data.item)
     } catch (error) {
-      console.error(`Failed to load summary run detail ${runId}`, error)
-      toast.error(error instanceof Error ? error.message : 'Failed to load summary run detail')
+      reportUiError(`Failed to load summary run detail ${runId}`, error)
+      toast.error(error instanceof Error ? error.message : t('summaries.errors.loadRunDetailFailed', { defaultValue: 'Failed to load summary run detail' }))
       setSelectedRun(null)
     } finally {
       setDetailLoading(false)
     }
-  }, [])
+  }, [t])
 
   const loadRuns = useCallback(async (preferredRunId?: string) => {
     setLoading(true)
@@ -368,15 +369,15 @@ export function SummaryRunsPage() {
         setSelectedRun(null)
       }
     } catch (error) {
-      console.error('Failed to load summary runs', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to load summary runs')
+      reportUiError('Failed to load summary runs', error)
+      toast.error(error instanceof Error ? error.message : t('summaries.errors.loadRunsFailed', { defaultValue: 'Failed to load summary runs' }))
       setRuns([])
       setSelectedRunId(null)
       setSelectedRun(null)
     } finally {
       setLoading(false)
     }
-  }, [loadRunDetail])
+  }, [loadRunDetail, t])
 
   useEffect(() => {
     void loadRuns()
@@ -408,15 +409,15 @@ export function SummaryRunsPage() {
         setProfileForm(createEmptyProfileForm())
       }
     } catch (error) {
-      console.error('Failed to load summary profiles', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to load summary profiles')
+      reportUiError('Failed to load summary profiles', error)
+      toast.error(error instanceof Error ? error.message : t('summaries.errors.loadProfilesFailed', { defaultValue: 'Failed to load summary profiles' }))
       setProfiles([])
       setEditingProfileId(null)
       setProfileForm(createEmptyProfileForm())
     } finally {
       setProfilesLoading(false)
     }
-  }, [])
+  }, [t])
 
   useEffect(() => {
     void loadProfiles()
@@ -602,7 +603,7 @@ export function SummaryRunsPage() {
           : t('summaries.sendSuccess', { defaultValue: 'Summary sent' }),
       )
     } catch (error) {
-      console.error(`Failed to ${mode} summary`, error)
+      reportUiError(`Failed to ${mode} summary`, error)
       toast.error(
         error instanceof Error
           ? error.message
@@ -618,7 +619,7 @@ export function SummaryRunsPage() {
   async function handleSaveProfile() {
     const { request, validationError } = buildProfileRequest()
     if (validationError || !request) {
-      toast.error(validationError ?? 'Invalid summary profile')
+      toast.error(validationError ?? t('summaries.errors.invalidProfile', { defaultValue: 'Invalid summary profile' }))
       return
     }
 
@@ -653,15 +654,17 @@ export function SummaryRunsPage() {
         resetProfileForm(data.profile)
       }
 
-      toast.success(editingExistingProfile ? 'Summary profile saved' : 'Summary profile created')
+      toast.success(editingExistingProfile
+        ? t('summaries.profileSaved', { defaultValue: 'Summary profile saved' })
+        : t('summaries.profileCreated', { defaultValue: 'Summary profile created' }))
     } catch (error) {
-      console.error(`Failed to ${nextMode} summary profile`, error)
+      reportUiError(`Failed to ${nextMode} summary profile`, error)
       toast.error(
         error instanceof Error
           ? error.message
           : editingExistingProfile
-            ? 'Failed to save summary profile'
-            : 'Failed to create summary profile',
+            ? t('summaries.errors.saveProfileFailed', { defaultValue: 'Failed to save summary profile' })
+            : t('summaries.errors.createProfileFailed', { defaultValue: 'Failed to create summary profile' }),
       )
     } finally {
       setProfileSubmittingMode(null)
@@ -687,10 +690,10 @@ export function SummaryRunsPage() {
       const nextProfiles = profiles.filter((profile) => profile.id !== editingProfileId)
       setProfiles(nextProfiles)
       resetProfileForm(nextProfiles[0] ?? null)
-      toast.success('Summary profile deleted')
+      toast.success(t('summaries.profileDeleted', { defaultValue: 'Summary profile deleted' }))
     } catch (error) {
-      console.error(`Failed to delete summary profile ${editingProfileId}`, error)
-      toast.error(error instanceof Error ? error.message : 'Failed to delete summary profile')
+      reportUiError(`Failed to delete summary profile ${editingProfileId}`, error)
+      toast.error(error instanceof Error ? error.message : t('summaries.errors.deleteProfileFailed', { defaultValue: 'Failed to delete summary profile' }))
     } finally {
       setProfileSubmittingMode(null)
     }

--- a/apps/web/src/pages/system-settings/SystemSettingsConfigSourcesPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsConfigSourcesPage.tsx
@@ -12,6 +12,7 @@ import {
   type ConfigSourceGroupSummary,
   useSettingsRequestJson,
 } from '@/pages/system-settings/lib'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 export function SystemSettingsConfigSourcesPage() {
   const { t } = useTranslation()
@@ -58,7 +59,7 @@ export function SystemSettingsConfigSourcesPage() {
 
     try {
       const resumeDisplayLimitsPromise = requestJson('/api/config/resume-display-limits').catch((error) => {
-        console.error('Failed to load resume display limits', error)
+        reportUiError('Failed to load resume display limits', error)
         return null
       })
       const payload = await requestJson('/api/config/source-groups')
@@ -83,7 +84,7 @@ export function SystemSettingsConfigSourcesPage() {
         })
       }
     } catch (error) {
-      console.error('Failed to load config source groups', error)
+      reportUiError('Failed to load config source groups', error)
       setLoadError(t('resumes.error'))
     } finally {
       setLoading(false)
@@ -92,7 +93,7 @@ export function SystemSettingsConfigSourcesPage() {
 
   useEffect(() => {
     loadData().catch((error) => {
-      console.error('Unexpected loadData failure', error)
+      reportUiError('Unexpected loadData failure', error)
     })
   }, [loadData])
 
@@ -123,7 +124,7 @@ export function SystemSettingsConfigSourcesPage() {
         if (cancelled) {
           return
         }
-        console.error('Failed to load config source detail', error)
+        reportUiError('Failed to load config source detail', error)
         setSelectedConfigSourceDetail(null)
         toast.error(t('debugConfig.configSourcesLoadError'))
       })
@@ -148,7 +149,7 @@ export function SystemSettingsConfigSourcesPage() {
           variant="outline"
           onClick={() => {
             loadData().catch((error) => {
-              console.error('Unexpected loadData failure', error)
+              reportUiError('Unexpected loadData failure', error)
             })
           }}
           disabled={loading}

--- a/apps/web/src/pages/system-settings/SystemSettingsExportFieldsPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsExportFieldsPage.tsx
@@ -9,6 +9,7 @@ import { useSettingsRequestJson } from '@/pages/system-settings/lib'
 import { EXPORT_CORE_FIELDS, isRecord } from '@trends/shared'
 import type { ExportFieldKey } from '@trends/shared'
 import { FIELD_GROUPS, FIELD_LABELS } from './SystemSettingsExportFieldsPage.metadata'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 interface ExportFieldsConfigState {
   fields: ExportFieldKey[]
@@ -68,7 +69,7 @@ export function SystemSettingsExportFieldsPage() {
         setHasConfig(false)
       }
     } catch (error) {
-      console.error('Failed to load export fields config', error)
+      reportUiError('Failed to load export fields config', error)
       setLoadError(t('resumes.error'))
     } finally {
       setLoading(false)
@@ -77,7 +78,7 @@ export function SystemSettingsExportFieldsPage() {
 
   useEffect(() => {
     loadData().catch((error) => {
-      console.error('Unexpected loadData failure', error)
+      reportUiError('Unexpected loadData failure', error)
     })
   }, [loadData])
 
@@ -125,7 +126,7 @@ export function SystemSettingsExportFieldsPage() {
       }
       toast.success(t('debugConfig.saved'))
     } catch (error) {
-      console.error('Failed to save export fields config', error)
+      reportUiError('Failed to save export fields config', error)
       toast.error(t('debugConfig.saveError'))
     } finally {
       setSaving(false)
@@ -144,7 +145,7 @@ export function SystemSettingsExportFieldsPage() {
       setHasConfig(false)
       toast.success(t('debugConfig.saved'))
     } catch (error) {
-      console.error('Failed to reset export fields config', error)
+      reportUiError('Failed to reset export fields config', error)
       toast.error(t('debugConfig.saveError'))
     } finally {
       setSaving(false)
@@ -169,7 +170,7 @@ export function SystemSettingsExportFieldsPage() {
             variant="outline"
             onClick={() => {
               loadData().catch((error) => {
-                console.error('Unexpected loadData failure', error)
+                reportUiError('Unexpected loadData failure', error)
               })
             }}
             disabled={loading}

--- a/apps/web/src/pages/system-settings/SystemSettingsKeywordsPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsKeywordsPage.tsx
@@ -29,6 +29,7 @@ import {
   useSettingsRequestJson,
 } from '@/pages/system-settings/lib'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 const MARKET_OPTIONS: Array<{ value: KeywordMarket; label: string }> = [
   { value: 'CN', label: 'CN' },
@@ -79,7 +80,7 @@ export function SystemSettingsKeywordsPage() {
     try {
       await Promise.all([loadCustomKeywords(), loadBrandKeywords()])
     } catch (error) {
-      console.error('Failed to load keyword settings', error)
+      reportUiError('Failed to load keyword settings', error)
       setLoadError(t('resumes.error'))
     } finally {
       setLoading(false)
@@ -88,7 +89,7 @@ export function SystemSettingsKeywordsPage() {
 
   useEffect(() => {
     loadData().catch((error) => {
-      console.error('Unexpected loadData failure', error)
+      reportUiError('Unexpected loadData failure', error)
     })
   }, [loadData])
 
@@ -147,7 +148,7 @@ export function SystemSettingsKeywordsPage() {
       setCustomKeywordDialogOpen(false)
       toast.success(t('debugConfig.saved'))
     } catch (error) {
-      console.error('Failed to save custom keyword', error)
+      reportUiError('Failed to save custom keyword', error)
       toast.error(t('debugConfig.saveError'))
     } finally {
       setSavingCustomKeyword(false)
@@ -168,7 +169,7 @@ export function SystemSettingsKeywordsPage() {
       setDeleteCustomKeywordTargetId(null)
       toast.success(t('debugConfig.saved'))
     } catch (error) {
-      console.error('Failed to delete custom keyword', error)
+      reportUiError('Failed to delete custom keyword', error)
       toast.error(t('debugConfig.saveError'))
     } finally {
       setDeletingCustomKeyword(false)
@@ -192,7 +193,7 @@ export function SystemSettingsKeywordsPage() {
           variant="outline"
           onClick={() => {
             loadData().catch((error) => {
-              console.error('Unexpected loadData failure', error)
+              reportUiError('Unexpected loadData failure', error)
             })
           }}
           disabled={loading}
@@ -479,7 +480,7 @@ export function SystemSettingsKeywordsPage() {
             <Button
               onClick={() => {
                 handleSaveCustomKeyword().catch((error) => {
-                  console.error('Unexpected handleSaveCustomKeyword failure', error)
+                  reportUiError('Unexpected handleSaveCustomKeyword failure', error)
                 })
               }}
               disabled={savingCustomKeyword}
@@ -526,7 +527,7 @@ export function SystemSettingsKeywordsPage() {
               variant="destructive"
               onClick={() => {
                 handleDeleteCustomKeyword().catch((error) => {
-                  console.error('Unexpected handleDeleteCustomKeyword failure', error)
+                  reportUiError('Unexpected handleDeleteCustomKeyword failure', error)
                 })
               }}
               disabled={deletingCustomKeyword}

--- a/apps/web/src/pages/system-settings/SystemSettingsLocationsPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsLocationsPage.tsx
@@ -11,6 +11,7 @@ import {
   type SystemLocationItem,
   useSettingsRequestJson,
 } from '@/pages/system-settings/lib'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 export function SystemSettingsLocationsPage() {
   const { t } = useTranslation()
@@ -64,7 +65,7 @@ export function SystemSettingsLocationsPage() {
 
       setSystemLocationItems(parsed.systemLocations)
     } catch (error) {
-      console.error('Failed to load system locations', error)
+      reportUiError('Failed to load system locations', error)
       setLoadError(t('resumes.error'))
     } finally {
       setLoading(false)
@@ -73,7 +74,7 @@ export function SystemSettingsLocationsPage() {
 
   useEffect(() => {
     loadData().catch((error) => {
-      console.error('Unexpected loadData failure', error)
+      reportUiError('Unexpected loadData failure', error)
     })
   }, [loadData])
 
@@ -93,7 +94,7 @@ export function SystemSettingsLocationsPage() {
       )
       toast.success(t('debugConfig.saved'))
     } catch (error) {
-      console.error('Failed to toggle system location visibility', error)
+      reportUiError('Failed to toggle system location visibility', error)
       toast.error(t('debugConfig.saveError'))
     } finally {
       setSavingSystemLocationId(null)
@@ -117,7 +118,7 @@ export function SystemSettingsLocationsPage() {
           variant="outline"
           onClick={() => {
             loadData().catch((error) => {
-              console.error('Unexpected loadData failure', error)
+              reportUiError('Unexpected loadData failure', error)
             })
           }}
           disabled={loading}
@@ -210,7 +211,7 @@ export function SystemSettingsLocationsPage() {
                               disabled={isSaving}
                               onClick={() => {
                                 handleToggleSystemLocationVisibility(item).catch((error) => {
-                                  console.error('Unexpected handleToggleSystemLocationVisibility failure', error)
+                                  reportUiError('Unexpected handleToggleSystemLocationVisibility failure', error)
                                 })
                               }}
                             >

--- a/apps/web/src/pages/system-settings/SystemSettingsOperationsPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsOperationsPage.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input'
 import { useSettingsRequestJson } from '@/pages/system-settings/lib'
 import { SystemSummary } from '@/pages/system-settings/SystemSummary'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 const EXTENSION_META_URL = '/extension/extension-meta.json'
 const EXTENSION_ZIP_URL = '/extension/trends-resume-collector-latest.zip'
@@ -36,7 +37,7 @@ function useExtensionVersion() {
           setVersion(payload.version)
         }
       } catch (error) {
-        console.error('Failed to load extension metadata', error)
+        reportUiError('Failed to load extension metadata', error)
       }
     }
     void load()
@@ -59,7 +60,7 @@ export function SystemSettingsOperationsPage() {
 
   async function handleStartCollection() {
     if (!collectionKeyword.trim()) {
-      toast.error('Please enter a keyword')
+      toast.error(t('debugConfig.collectionKeywordRequired', { defaultValue: 'Please enter a keyword' }))
       return
     }
 
@@ -73,11 +74,11 @@ export function SystemSettingsOperationsPage() {
         limit,
         maxPages,
       })
-      toast.success('Collection task dispatched')
+      toast.success(t('debugConfig.collectionTaskDispatched', { defaultValue: 'Collection task dispatched' }))
       setCollectionKeyword('')
     } catch (error) {
-      console.error('Failed to dispatch collection', error)
-      toast.error('Failed to start collection')
+      reportUiError('Failed to dispatch collection', error)
+      toast.error(t('debugConfig.collectionTaskFailed', { defaultValue: 'Failed to start collection' }))
     }
   }
 
@@ -167,7 +168,7 @@ export function SystemSettingsOperationsPage() {
             data-testid="ops-start-collection"
             onClick={() => {
               handleStartCollection().catch((error) => {
-                console.error('Unexpected handleStartCollection failure', error)
+                reportUiError('Unexpected handleStartCollection failure', error)
               })
             }}
             className="w-full sm:w-auto"

--- a/apps/web/src/pages/system-settings/SystemSettingsRuntimePage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsRuntimePage.tsx
@@ -14,6 +14,7 @@ import {
   type AgentsConfig,
   useSettingsRequestJson,
 } from '@/pages/system-settings/lib'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
 export function SystemSettingsRuntimePage() {
   const { t } = useTranslation()
@@ -48,7 +49,7 @@ export function SystemSettingsRuntimePage() {
       setAiStatus(parsedAiStatus)
       setAgentsConfig(parsedAgentsConfig)
     } catch (error) {
-      console.error('Failed to load runtime settings', error)
+      reportUiError('Failed to load runtime settings', error)
       setLoadError(t('resumes.error'))
     } finally {
       setLoading(false)
@@ -57,7 +58,7 @@ export function SystemSettingsRuntimePage() {
 
   useEffect(() => {
     loadData().catch((error) => {
-      console.error('Unexpected loadData failure', error)
+      reportUiError('Unexpected loadData failure', error)
     })
   }, [loadData])
 
@@ -158,7 +159,7 @@ export function SystemSettingsRuntimePage() {
       setAgentsConfig(parsed)
       toast.success(t('debugConfig.saved'))
     } catch (error) {
-      console.error('Failed to save agent config', error)
+      reportUiError('Failed to save agent config', error)
       toast.error(t('debugConfig.saveError'))
     } finally {
       setSavingAgentId(null)
@@ -184,7 +185,7 @@ export function SystemSettingsRuntimePage() {
         </div>
         <Button variant="outline" onClick={() => {
           loadData().catch((error) => {
-            console.error('Unexpected loadData failure', error)
+            reportUiError('Unexpected loadData failure', error)
           })
         }} disabled={loading}>
           {loading ? t('trends.loading') : t('common.refresh', { defaultValue: 'Refresh' })}
@@ -291,7 +292,7 @@ export function SystemSettingsRuntimePage() {
                         size="sm"
                         onClick={() => {
                           handleSaveAgents(agent.id).catch((error) => {
-                            console.error('Unexpected handleSaveAgents failure', error)
+                            reportUiError('Unexpected handleSaveAgents failure', error)
                           })
                         }}
                         disabled={isSaving}

--- a/apps/web/src/pages/system-settings/SystemSettingsTaxonomyPage.test.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsTaxonomyPage.test.tsx
@@ -19,7 +19,11 @@ const tMock = (key: string, options?: string | { defaultValue?: string; [key: st
     return options
   }
 
-  return options?.defaultValue ?? key
+  const defaultValue = options?.defaultValue ?? key
+  return defaultValue.replace(/\{\{(\w+)\}\}/g, (_: string, token: string) => {
+    const value = options?.[token]
+    return value === undefined || value === null ? '' : String(value)
+  })
 }
 
 vi.mock('react-i18next', () => ({

--- a/apps/web/src/pages/system-settings/SystemSettingsTaxonomyPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsTaxonomyPage.tsx
@@ -27,17 +27,18 @@ import {
   type TaxonomyClusterSource,
   type TaxonomyClusterStatus,
 } from '@/lib/taxonomy'
+import { reportUiError } from '@/lib/ui-error-reporting'
 
-const STATUS_OPTIONS: Array<{ value: TaxonomyClusterStatus; label: string }> = [
-  { value: 'active', label: 'Active' },
-  { value: 'draft', label: 'Draft' },
-  { value: 'archived', label: 'Archived' },
+const STATUS_OPTIONS: Array<{ value: TaxonomyClusterStatus; labelKey: string; defaultLabel: string }> = [
+  { value: 'active', labelKey: 'debugConfig.taxonomy.status.active', defaultLabel: 'Active' },
+  { value: 'draft', labelKey: 'debugConfig.taxonomy.status.draft', defaultLabel: 'Draft' },
+  { value: 'archived', labelKey: 'debugConfig.taxonomy.status.archived', defaultLabel: 'Archived' },
 ]
 
-const SOURCE_OPTIONS: Array<{ value: TaxonomyClusterSource; label: string }> = [
-  { value: 'human', label: 'Human' },
-  { value: 'ai', label: 'AI' },
-  { value: 'merged', label: 'Merged' },
+const SOURCE_OPTIONS: Array<{ value: TaxonomyClusterSource; labelKey: string; defaultLabel: string }> = [
+  { value: 'human', labelKey: 'debugConfig.taxonomy.source.human', defaultLabel: 'Human' },
+  { value: 'ai', labelKey: 'debugConfig.taxonomy.source.ai', defaultLabel: 'AI' },
+  { value: 'merged', labelKey: 'debugConfig.taxonomy.source.merged', defaultLabel: 'Merged' },
 ]
 
 function buildTaxonomyPayload(form: TaxonomyClusterFormState) {
@@ -66,14 +67,6 @@ function buildTaxonomyPayload(form: TaxonomyClusterFormState) {
   }
 }
 
-function formatSourceLabel(value: TaxonomyClusterSource): string {
-  return SOURCE_OPTIONS.find((option) => option.value === value)?.label ?? value
-}
-
-function formatStatusLabel(value: TaxonomyClusterStatus): string {
-  return STATUS_OPTIONS.find((option) => option.value === value)?.label ?? value
-}
-
 export function SystemSettingsTaxonomyPage() {
   const { t } = useTranslation()
   const { requestJson } = useSettingsRequestJson()
@@ -98,7 +91,7 @@ export function SystemSettingsTaxonomyPage() {
       }
       setItems(parsed)
     } catch (error) {
-      console.error('Failed to load taxonomy clusters', error)
+      reportUiError('Failed to load taxonomy clusters', error)
       setLoadError(t('resumes.error'))
     } finally {
       setLoading(false)
@@ -107,7 +100,7 @@ export function SystemSettingsTaxonomyPage() {
 
   useEffect(() => {
     loadData().catch((error) => {
-      console.error('Unexpected taxonomy load failure', error)
+      reportUiError('Unexpected taxonomy load failure', error)
     })
   }, [loadData])
 
@@ -117,14 +110,32 @@ export function SystemSettingsTaxonomyPage() {
     archived: items.filter((item) => item.status === 'archived').length,
   }), [items])
 
+  const statusOptions = useMemo(() => STATUS_OPTIONS.map((option) => ({
+    value: option.value,
+    label: t(option.labelKey, { defaultValue: option.defaultLabel }),
+  })), [t])
+
+  const sourceOptions = useMemo(() => SOURCE_OPTIONS.map((option) => ({
+    value: option.value,
+    label: t(option.labelKey, { defaultValue: option.defaultLabel }),
+  })), [t])
+
+  const formatStatusLabel = useCallback((value: TaxonomyClusterStatus) => {
+    return statusOptions.find((option) => option.value === value)?.label ?? value
+  }, [statusOptions])
+
+  const formatSourceLabel = useCallback((value: TaxonomyClusterSource) => {
+    return sourceOptions.find((option) => option.value === value)?.label ?? value
+  }, [sourceOptions])
+
   const parentSlugOptions = useMemo(() => {
     return [
-      { value: '', label: 'None' },
+      { value: '', label: t('debugConfig.taxonomy.none', { defaultValue: 'None' }) },
       ...items
         .filter((item) => !editingItem || item.id !== editingItem.id)
         .map((item) => ({ value: item.slug, label: item.name })),
     ]
-  }, [editingItem, items])
+  }, [editingItem, items, t])
 
   const openCreateDialog = useCallback(() => {
     setEditingItem(null)
@@ -157,7 +168,7 @@ export function SystemSettingsTaxonomyPage() {
       setDialogOpen(false)
       toast.success(t('debugConfig.saved'))
     } catch (error) {
-      console.error('Failed to save taxonomy cluster', error)
+      reportUiError('Failed to save taxonomy cluster', error)
       toast.error(t('debugConfig.saveError'))
     } finally {
       setSaving(false)
@@ -177,7 +188,7 @@ export function SystemSettingsTaxonomyPage() {
       setItems(parsed)
       toast.success(t('debugConfig.saved'))
     } catch (error) {
-      console.error('Failed to delete taxonomy cluster', error)
+      reportUiError('Failed to delete taxonomy cluster', error)
       toast.error(t('debugConfig.saveError'))
     } finally {
       setDeletingId(null)
@@ -196,9 +207,12 @@ export function SystemSettingsTaxonomyPage() {
         throw new Error('Invalid taxonomy suggest payload')
       }
       await loadData()
-      toast.success(`Generated ${parsed.length} draft taxonomy suggestions`)
+      toast.success(t('debugConfig.taxonomy.generatedDrafts', {
+        count: parsed.length,
+        defaultValue: 'Generated {{count}} draft taxonomy suggestions',
+      }))
     } catch (error) {
-      console.error('Failed to suggest taxonomy clusters', error)
+      reportUiError('Failed to suggest taxonomy clusters', error)
       toast.error(t('debugConfig.saveError'))
     } finally {
       setSuggesting(false)
@@ -221,7 +235,7 @@ export function SystemSettingsTaxonomyPage() {
         <div className="flex flex-wrap gap-2">
           <Button variant="outline" onClick={() => {
             loadData().catch((error) => {
-              console.error('Unexpected taxonomy load failure', error)
+              reportUiError('Unexpected taxonomy load failure', error)
             })
           }} disabled={loading}>
             {loading ? t('trends.loading') : t('common.refresh', { defaultValue: 'Refresh' })}
@@ -229,9 +243,11 @@ export function SystemSettingsTaxonomyPage() {
           <Button variant="outline" onClick={() => {
             void suggestClusters()
           }} disabled={suggesting}>
-            {suggesting ? 'Generating drafts...' : 'Generate Drafts'}
+            {suggesting
+              ? t('debugConfig.taxonomy.generatingDrafts', { defaultValue: 'Generating drafts...' })
+              : t('debugConfig.taxonomy.generateDrafts', { defaultValue: 'Generate Drafts' })}
           </Button>
-          <Button onClick={openCreateDialog}>New Cluster</Button>
+          <Button onClick={openCreateDialog}>{t('debugConfig.taxonomy.newCluster', { defaultValue: 'New Cluster' })}</Button>
         </div>
       </div>
 
@@ -244,22 +260,22 @@ export function SystemSettingsTaxonomyPage() {
       <div className="grid gap-4 md:grid-cols-3">
         <Card>
           <CardHeader className="pb-3">
-            <CardTitle className="text-base">Active</CardTitle>
-            <CardDescription>Visible in the search facet sidebar.</CardDescription>
+            <CardTitle className="text-base">{t('debugConfig.taxonomy.status.active', { defaultValue: 'Active' })}</CardTitle>
+            <CardDescription>{t('debugConfig.taxonomy.activeDescription', { defaultValue: 'Visible in the search facet sidebar.' })}</CardDescription>
           </CardHeader>
           <CardContent className="text-3xl font-semibold">{statusCounts.active}</CardContent>
         </Card>
         <Card>
           <CardHeader className="pb-3">
-            <CardTitle className="text-base">Draft</CardTitle>
-            <CardDescription>Generated or staged before approval.</CardDescription>
+            <CardTitle className="text-base">{t('debugConfig.taxonomy.status.draft', { defaultValue: 'Draft' })}</CardTitle>
+            <CardDescription>{t('debugConfig.taxonomy.draftDescription', { defaultValue: 'Generated or staged before approval.' })}</CardDescription>
           </CardHeader>
           <CardContent className="text-3xl font-semibold">{statusCounts.draft}</CardContent>
         </Card>
         <Card>
           <CardHeader className="pb-3">
-            <CardTitle className="text-base">Archived</CardTitle>
-            <CardDescription>Kept for history but hidden from search.</CardDescription>
+            <CardTitle className="text-base">{t('debugConfig.taxonomy.status.archived', { defaultValue: 'Archived' })}</CardTitle>
+            <CardDescription>{t('debugConfig.taxonomy.archivedDescription', { defaultValue: 'Kept for history but hidden from search.' })}</CardDescription>
           </CardHeader>
           <CardContent className="text-3xl font-semibold">{statusCounts.archived}</CardContent>
         </Card>
@@ -267,9 +283,11 @@ export function SystemSettingsTaxonomyPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Cluster registry</CardTitle>
+          <CardTitle>{t('debugConfig.taxonomy.clusterRegistry', { defaultValue: 'Cluster registry' })}</CardTitle>
           <CardDescription>
-            Drafts can be reviewed and promoted to active clusters. Active clusters are used by the search-first resume sidebar.
+            {t('debugConfig.taxonomy.clusterRegistryDescription', {
+              defaultValue: 'Drafts can be reviewed and promoted to active clusters. Active clusters are used by the search-first resume sidebar.',
+            })}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -277,18 +295,18 @@ export function SystemSettingsTaxonomyPage() {
             <div className="text-sm text-muted-foreground">{t('trends.loading')}</div>
           ) : items.length === 0 ? (
             <div className="rounded-md border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
-              No taxonomy clusters yet.
+              {t('debugConfig.taxonomy.empty', { defaultValue: 'No taxonomy clusters yet.' })}
             </div>
           ) : (
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Source</TableHead>
-                  <TableHead>Parent</TableHead>
-                  <TableHead>Tags</TableHead>
-                  <TableHead className="w-[180px] text-right">Actions</TableHead>
+                  <TableHead>{t('debugConfig.taxonomy.name', { defaultValue: 'Name' })}</TableHead>
+                  <TableHead>{t('debugConfig.taxonomy.statusLabel', { defaultValue: 'Status' })}</TableHead>
+                  <TableHead>{t('debugConfig.taxonomy.sourceLabel', { defaultValue: 'Source' })}</TableHead>
+                  <TableHead>{t('debugConfig.taxonomy.parent', { defaultValue: 'Parent' })}</TableHead>
+                  <TableHead>{t('debugConfig.taxonomy.tags', { defaultValue: 'Tags' })}</TableHead>
+                  <TableHead className="w-[180px] text-right">{t('debugConfig.taxonomy.actions', { defaultValue: 'Actions' })}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -320,7 +338,7 @@ export function SystemSettingsTaxonomyPage() {
                     <TableCell className="align-top text-right">
                       <div className="flex justify-end gap-2">
                         <Button variant="outline" size="sm" onClick={() => openEditDialog(item)}>
-                          Edit
+                          {t('common.edit', { defaultValue: 'Edit' })}
                         </Button>
                         <Button
                           variant="outline"
@@ -330,7 +348,9 @@ export function SystemSettingsTaxonomyPage() {
                           }}
                           disabled={deletingId === item.id}
                         >
-                          {deletingId === item.id ? 'Deleting...' : 'Delete'}
+                          {deletingId === item.id
+                            ? t('common.deleting', { defaultValue: 'Deleting...' })
+                            : t('common.delete', { defaultValue: 'Delete' })}
                         </Button>
                       </div>
                     </TableCell>
@@ -345,15 +365,21 @@ export function SystemSettingsTaxonomyPage() {
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="max-w-2xl">
           <DialogHeader>
-            <DialogTitle>{editingItem ? 'Edit taxonomy cluster' : 'Create taxonomy cluster'}</DialogTitle>
+            <DialogTitle>
+              {editingItem
+                ? t('debugConfig.taxonomy.editCluster', { defaultValue: 'Edit taxonomy cluster' })
+                : t('debugConfig.taxonomy.createCluster', { defaultValue: 'Create taxonomy cluster' })}
+            </DialogTitle>
             <DialogDescription>
-              Define a stable cluster name, slug, and the raw tags that should roll up into it.
+              {t('debugConfig.taxonomy.dialogDescription', {
+                defaultValue: 'Define a stable cluster name, slug, and the raw tags that should roll up into it.',
+              })}
             </DialogDescription>
           </DialogHeader>
 
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <label className="text-sm font-medium">Name</label>
+              <label className="text-sm font-medium">{t('debugConfig.taxonomy.name', { defaultValue: 'Name' })}</label>
               <Input
                 value={form.name}
                 onChange={(event) => {
@@ -372,7 +398,7 @@ export function SystemSettingsTaxonomyPage() {
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium">Slug</label>
+              <label className="text-sm font-medium">{t('debugConfig.taxonomy.slug', { defaultValue: 'Slug' })}</label>
               <Input
                 value={form.slug}
                 onChange={(event) => {
@@ -384,9 +410,9 @@ export function SystemSettingsTaxonomyPage() {
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium">Status</label>
+              <label className="text-sm font-medium">{t('debugConfig.taxonomy.statusLabel', { defaultValue: 'Status' })}</label>
               <Select
-                options={STATUS_OPTIONS}
+                options={statusOptions}
                 value={form.status}
                 onChange={(event) => {
                   setForm((current) => ({ ...current, status: event.target.value as TaxonomyClusterStatus }))
@@ -395,9 +421,9 @@ export function SystemSettingsTaxonomyPage() {
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium">Source</label>
+              <label className="text-sm font-medium">{t('debugConfig.taxonomy.sourceLabel', { defaultValue: 'Source' })}</label>
               <Select
-                options={SOURCE_OPTIONS}
+                options={sourceOptions}
                 value={form.source}
                 onChange={(event) => {
                   setForm((current) => ({ ...current, source: event.target.value as TaxonomyClusterSource }))
@@ -406,7 +432,7 @@ export function SystemSettingsTaxonomyPage() {
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium">Parent Cluster</label>
+              <label className="text-sm font-medium">{t('debugConfig.taxonomy.parentCluster', { defaultValue: 'Parent Cluster' })}</label>
               <Select
                 options={parentSlugOptions}
                 value={form.parentSlug}
@@ -417,7 +443,7 @@ export function SystemSettingsTaxonomyPage() {
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium">Confidence</label>
+              <label className="text-sm font-medium">{t('debugConfig.taxonomy.confidence', { defaultValue: 'Confidence' })}</label>
               <Input
                 value={form.confidence}
                 onChange={(event) => {
@@ -428,7 +454,7 @@ export function SystemSettingsTaxonomyPage() {
             </div>
 
             <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium">Tags</label>
+              <label className="text-sm font-medium">{t('debugConfig.taxonomy.tags', { defaultValue: 'Tags' })}</label>
               <Input
                 value={form.tags}
                 onChange={(event) => {
@@ -437,19 +463,25 @@ export function SystemSettingsTaxonomyPage() {
                 placeholder="Go, Java, Rust"
               />
               <p className="text-xs text-muted-foreground">
-                Separate tags with commas. Search facets will group any matching resume tag into this cluster.
+                {t('debugConfig.taxonomy.tagsHelp', {
+                  defaultValue: 'Separate tags with commas. Search facets will group any matching resume tag into this cluster.',
+                })}
               </p>
             </div>
           </div>
 
           <DialogFooter>
             <Button variant="outline" onClick={() => setDialogOpen(false)}>
-              Cancel
+              {t('common.cancel', { defaultValue: 'Cancel' })}
             </Button>
             <Button onClick={() => {
               void saveCluster()
             }} disabled={saving}>
-              {saving ? 'Saving...' : editingItem ? 'Save Changes' : 'Create Cluster'}
+              {saving
+                ? t('common.saving', { defaultValue: 'Saving...' })
+                : editingItem
+                  ? t('debugConfig.taxonomy.saveChanges', { defaultValue: 'Save Changes' })
+                  : t('debugConfig.taxonomy.createClusterButton', { defaultValue: 'Create Cluster' })}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Summary
- replace scoped hardcoded UI copy with i18n-backed strings across resume/search/admin/debug web surfaces
- add translated 404 handling and route-level error-boundary coverage
- clean scoped production UI console usage
- reorder resume left filters around the primary screening workflow and make the text filter match external IDs

## Verification
- npm --workspace @trends/web test -- FacetSidebar.test.tsx useResumeSearchState.test.tsx
- make i18n-check
- npm --workspace @trends/web run typecheck
- make check
- browser spot-check at /dev/resumes?location=China&q=CNC+%E9%94%80%E5%94%AE&minRoleYears=1&roleType=sales&minAge=25&maxAge=40

## Notes
- No production deployment in this PR.
- make check still emits the existing fast-refresh warnings in components/ui/badge.tsx and components/ui/button.tsx, with zero errors.
- Follow-up captured in skillwiki: Skill Clusters appears empty/low-value and should be investigated separately.