### PR TITLE
Fix resume result count display

### DIFF
--- a/apps/web/src/components/search/SearchHeader.test.tsx
+++ b/apps/web/src/components/search/SearchHeader.test.tsx
@@ -136,6 +136,27 @@ describe('SearchHeader', () => {
     expect(screen.getAllByText('找到 3 条结果')[0]).toBeInTheDocument()
   })
 
+  it('marks the result count as a lower bound when more pages may exist', () => {
+    render(
+      <SearchHeader
+        activeQuery="machine tools"
+        activeResultCount={1250}
+        activeResultCountIsLowerBound
+        queryInput="machine tools"
+        recentSearches={[]}
+        sortValue="score"
+        onApplyRecentSearch={vi.fn()}
+        onApplyExtractedKeywords={vi.fn()}
+        onChangeQuery={vi.fn()}
+        onClearQuery={vi.fn()}
+        onSubmitQuery={vi.fn()}
+        onSortChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByText('为"machine tools"找到 1,250+ 条结果')[0]).toBeInTheDocument()
+  })
+
   it('forwards header search-bar callbacks to the parent handlers', async () => {
     const user = userEvent.setup()
     const onApplyExtractedKeywords = vi.fn()

--- a/apps/web/src/components/search/SearchHeader.tsx
+++ b/apps/web/src/components/search/SearchHeader.tsx
@@ -10,6 +10,7 @@ import type { ResumeSearchRecentItem, SearchSortValue } from '@/components/searc
 type SearchHeaderProps = {
   activeQuery?: string
   activeResultCount: number
+  activeResultCountIsLowerBound?: boolean
   jobDescriptionId?: string
   loading?: boolean
   location?: string
@@ -27,6 +28,7 @@ type SearchHeaderProps = {
 export function SearchHeader({
   activeQuery,
   activeResultCount,
+  activeResultCountIsLowerBound = false,
   jobDescriptionId,
   loading = false,
   location,
@@ -41,14 +43,15 @@ export function SearchHeader({
   onSortChange,
 }: SearchHeaderProps) {
   const { t } = useTranslation()
+  const resultCountLabel = `${activeResultCount.toLocaleString()}${activeResultCountIsLowerBound ? '+' : ''}`
   const resultsLabel = activeQuery
     ? t('resumes.searchPage.header.resultsWithQuery', {
-      count: activeResultCount.toLocaleString(),
+      count: resultCountLabel,
       query: activeQuery,
       defaultValue: '为"{{query}}"找到 {{count}} 条结果',
     })
     : t('resumes.searchPage.header.results', {
-      count: activeResultCount.toLocaleString(),
+      count: resultCountLabel,
       defaultValue: '找到 {{count}} 条结果',
     })
   const sortLabel = t('resumes.searchPage.header.sort', {

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -1926,6 +1926,32 @@ describe('useResumeSearchState', () => {
     expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1'])
   })
 
+  it('treats pipeline-only statuses as part of the new triage bucket', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'CNC 销售',
+      keywords: ['CNC', '销售'],
+    }))
+
+    resumesMock.push(
+      createResume(1, { primaryRuleScore: 95 }),
+      createResume(2, { primaryRuleScore: 90 }),
+      createResume(3, { primaryRuleScore: 85 }),
+      createResume(4, { primaryRuleScore: 80 }),
+    )
+    statusByIdentityMock['identity-1'] = createStatusRecord('identity-1', 'new')
+    statusByIdentityMock['identity-2'] = createStatusRecord('identity-2', 'contacted')
+    statusByIdentityMock['identity-3'] = createStatusRecord('identity-3', 'interviewing')
+    statusByIdentityMock['identity-4'] = createStatusRecord('identity-4', 'rejected')
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual([
+      'resume-1',
+      'resume-2',
+      'resume-3',
+    ])
+  })
+
   it('hides blocked new resumes from results and status facets by default', () => {
     Object.assign(parsedStateMock, createParsedState({
       query: 'CNC 销售',

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -466,11 +466,16 @@ function buildSearchExportEntry(
 }
 
 const DEFAULT_STATUS_WHEN_EMPTY: CandidateStatus = 'new'
+const PRIMARY_STATUS_BUCKETS = new Set<CandidateStatus>(SERVER_STATUS_FACET_VALUES)
 
 const ACTION_TO_STATUS: Partial<Record<CandidateActionType, CandidateStatus>> = {
   shortlist: 'shortlisted',
   reject: 'rejected',
   star: 'new',
+}
+
+function getPrimaryStatusBucket(status: CandidateStatus): typeof SERVER_STATUS_FACET_VALUES[number] {
+  return status === 'shortlisted' || status === 'rejected' ? status : 'new'
 }
 
 function matchesBlockVisibility(
@@ -554,6 +559,7 @@ function matchesLocalFilters(
   const education = item.resume.education?.trim().toLowerCase() ?? ''
   const experienceLevel = normalizeExperienceLevel(item.resume.ingestData?.experienceLevel)
   const minScore = state.filters.minMatchScore
+  const statusBucket = getPrimaryStatusBucket(item.status)
 
   if (!matchesBlockVisibility(item, state.filters)) {
     return false
@@ -617,10 +623,15 @@ function matchesLocalFilters(
 
   // Default: show only new (untriaged) resumes unless user explicitly filters for a status
   if (normalizedStatuses.length > 0) {
-    if (!normalizedStatuses.includes(item.status)) {
+    const matchesSelectedStatus = normalizedStatuses.some((status) =>
+      PRIMARY_STATUS_BUCKETS.has(status)
+        ? getPrimaryStatusBucket(status) === statusBucket
+        : item.status === status,
+    )
+    if (!matchesSelectedStatus) {
       return false
     }
-  } else if (item.status !== DEFAULT_STATUS_WHEN_EMPTY) {
+  } else if (statusBucket !== DEFAULT_STATUS_WHEN_EMPTY) {
     return false
   }
 

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -168,6 +168,7 @@ vi.mock('@/components/search/SearchHeader', () => ({
   SearchHeader: ({
     activeQuery,
     activeResultCount,
+    activeResultCountIsLowerBound,
     exportFormat,
     exportingResults,
     onApplyExtractedKeywords,
@@ -176,6 +177,7 @@ vi.mock('@/components/search/SearchHeader', () => ({
   }: {
     activeQuery?: string
     activeResultCount: number
+    activeResultCountIsLowerBound?: boolean
     exportFormat?: string
     exportingResults?: boolean
     onApplyExtractedKeywords: (keywords: string[]) => void
@@ -184,7 +186,7 @@ vi.mock('@/components/search/SearchHeader', () => ({
   }) => (
     <div>
       <div>
-        Header {activeQuery} {activeResultCount} export:{exportFormat} exporting:
+        Header {activeQuery} {activeResultCount}{activeResultCountIsLowerBound ? '+' : ''} export:{exportFormat} exporting:
         {String(exportingResults)}
       </div>
       <button
@@ -822,6 +824,21 @@ describe('ResumeSearchPage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Load more results' }))
     expect(state.loadMore).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks the active result count as a lower bound when more search pages exist', () => {
+    useResumeSearchStateMock.mockReturnValue(createResumeSearchState({
+      activeQuery: 'machine tools',
+      filteredResults: [createResult(1), createResult(2)],
+      hasMore: true,
+      isLanding: false,
+      parsedState: createParsedState(),
+      queryInput: 'machine tools',
+    }))
+
+    render(<ResumeSearchPage />)
+
+    expect(screen.getByText(/Header machine tools 2\+/)).toBeInTheDocument()
   })
 
   it('hides the AI summary panel when the dedicated summary feature flag is off', () => {

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -333,6 +333,7 @@ export function ResumeSearchPage() {
             <SearchHeader
               activeQuery={activeQuery}
               activeResultCount={filteredResults.length}
+              activeResultCountIsLowerBound={hasMore}
               jobDescriptionId={parsedState.jobDescriptionId}
               loading={loading}
               location={parsedState.location}


### PR DESCRIPTION
## Summary
- Align the search-page default/new status filter with backend triage buckets so pipeline-only statuses counted as new are also visible in the loaded result set.
- Show a + suffix on the header result count when additional search pages may exist, e.g. 200+.
- Add focused coverage for the status-bucket and lower-bound count behavior.

## Verification
- npm --workspace @trends/web test -- SearchHeader.test.tsx ResumeSearchPage.test.tsx useResumeSearchState.test.tsx
- make check
- playwright-cli current-tab verification on /dev/resumes for the CNC 销售 query