### PR TITLE
Fix bulk action bar count display

### DIFF
--- a/apps/web/src/components/BulkActionBar.test.tsx
+++ b/apps/web/src/components/BulkActionBar.test.tsx
@@ -31,6 +31,16 @@ describe('BulkActionBar', () => {
         expect(screen.getByText(/\(10\)/)).toBeInTheDocument()
     })
 
+    it('marks the total count as a lower bound when more result pages exist', () => {
+        render(
+            <MemoryRouter>
+                <BulkActionBar {...defaultProps} totalCountIsLowerBound />
+            </MemoryRouter>,
+        )
+
+        expect(screen.getByText('5 / 100+')).toBeInTheDocument()
+    })
+
     it('triggers selection callbacks', async () => {
         const user = userEvent.setup()
         render(<MemoryRouter><BulkActionBar {...defaultProps} /></MemoryRouter>)

--- a/apps/web/src/components/BulkActionBar.tsx
+++ b/apps/web/src/components/BulkActionBar.tsx
@@ -16,6 +16,7 @@ import type { ResumeExportFormat } from '@/types/resume'
 
 interface BulkActionBarProps {
     totalCount: number
+    totalCountIsLowerBound?: boolean
     selectedCount: number
     highScoreCount: number
     exportFormat?: ResumeExportFormat
@@ -38,6 +39,7 @@ interface BulkActionBarProps {
 
 export function BulkActionBar({
     totalCount,
+    totalCountIsLowerBound = false,
     selectedCount,
     highScoreCount,
     exportFormat = 'csv',
@@ -55,6 +57,7 @@ export function BulkActionBar({
 }: BulkActionBarProps) {
     const { t } = useTranslation()
     const [loading, setLoading] = useState<string | null>(null)
+    const totalCountLabel = `${totalCount}${totalCountIsLowerBound ? '+' : ''}`
 
     const handleAction = useCallback(async (action: 'shortlist' | 'reject' | 'block' | 'export') => {
         setLoading(action)
@@ -78,7 +81,7 @@ export function BulkActionBar({
                     {t('bulkActions.selected', '已选择')}:
                 </span>
                 <span className="font-medium">
-                    {selectedCount} / {totalCount}
+                    {selectedCount} / {totalCountLabel}
                 </span>
             </div>
 

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -357,6 +357,7 @@ vi.mock('@/components/BulkActionBar', () => ({
     highScoreCount,
     selectedCount,
     totalCount,
+    totalCountIsLowerBound,
   }: {
     onExportFormatChange?: (format: string) => void
     onBulkAction?: (action: string, format?: string) => void
@@ -364,9 +365,10 @@ vi.mock('@/components/BulkActionBar', () => ({
     highScoreCount?: number
     selectedCount?: number
     totalCount?: number
+    totalCountIsLowerBound?: boolean
   }) => (
     <div>
-      <div>BulkActionBar {selectedCount}/{totalCount} high:{highScoreCount} fmt:{exportFormat}</div>
+      <div>BulkActionBar {selectedCount}/{totalCount}{totalCountIsLowerBound ? '+' : ''} high:{highScoreCount} fmt:{exportFormat}</div>
       {onExportFormatChange && (
         <button type="button" onClick={() => onExportFormatChange('xlsx')}>
           Change Export Format
@@ -839,6 +841,13 @@ describe('ResumeSearchPage', () => {
     render(<ResumeSearchPage />)
 
     expect(screen.getByText(/Header machine tools 2\+/)).toBeInTheDocument()
+    expect(screen.getByText(/BulkActionBar 0\/2\+/)).toBeInTheDocument()
+  })
+
+  it('keeps the sticky bulk bar below the app header', () => {
+    const { container } = render(<ResumeSearchPage />)
+
+    expect(container.querySelector('.sticky.top-14')).toBeInTheDocument()
   })
 
   it('hides the AI summary panel when the dedicated summary feature flag is off', () => {

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -421,9 +421,10 @@ export function ResumeSearchPage() {
                 </ErrorBoundary>
               )}
 
-              <div className="sticky top-0 z-20 -mx-1 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 px-1 py-1">
+              <div className="sticky top-14 z-20 -mx-1 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 px-1 py-1">
                 <BulkActionBar
                   totalCount={filteredResults.length}
+                  totalCountIsLowerBound={hasMore}
                   selectedCount={selectedIds.size}
                   highScoreCount={highScoreCount}
                   exportFormat={exportFormat}


### PR DESCRIPTION
## Summary
- show the bulk action bar total as a lower bound, e.g. `0 / 200+`, when more resume search pages exist
- keep the sticky bulk action bar below the app header so the full bar remains visible while scrolling
- add focused coverage for the lower-bound counter and sticky offset

## Verification
- `npm --workspace @trends/web test -- BulkActionBar.test.tsx ResumeSearchPage.test.tsx`
- `make check`
- Playwright current-tab check after scrolling: sticky bar visible from `已选择: 0 / 200+` through export controls
