### PR TITLE
ci: add app release workflow

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -1,0 +1,23 @@
+name: App Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- add App Release workflow for plain app tags matching v*
- publish GitHub Releases with generated release notes using softprops/action-gh-release
- keep CLI releases scoped to existing cli/v* workflow

## Verification
- actionlint .github/workflows/app-release.yml
- actionlint .github/workflows/*.yml
- make check