### PR TITLE
Fix digest resume search latency on preview

### DIFF
--- a/apps/api/src/routes/resumes.search-integration.test.ts
+++ b/apps/api/src/routes/resumes.search-integration.test.ts
@@ -297,6 +297,71 @@ describe("BFF search dispatcher integration", () => {
     });
 
     describe("AND-mode digest-first path (scanResumeDigestPage → getResumeDocsByIds)", () => {
+        it("applies digest-supported filters before fetching full records", async () => {
+            const calls: ConvexCall[] = [];
+            vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+                const call = parseConvexCall(input, init);
+                calls.push(call);
+                if (call.pathName === "resumes_search:scanResumeDigestPage") {
+                    return convexSuccess({
+                        docs: [
+                            buildDigestRow("r1", {
+                                searchText: "cnc 销售 数控 销售工程师",
+                                age: 30,
+                                locationText: "中国 广东 东莞",
+                                roleTypes: ["sales"],
+                                roleYearsByType: { sales: 3 },
+                            }),
+                            buildDigestRow("r2", {
+                                searchText: "cnc 销售 数控 工程师",
+                                age: 30,
+                                locationText: "中国 广东 东莞",
+                                roleTypes: ["engineer"],
+                                roleYearsByType: { engineer: 3 },
+                            }),
+                            buildDigestRow("r3", {
+                                searchText: "cnc 销售 数控 销售工程师",
+                                age: 30,
+                                locationText: "马来西亚 吉隆坡",
+                                roleTypes: ["sales"],
+                                roleYearsByType: { sales: 3 },
+                            }),
+                            buildDigestRow("r4", {
+                                searchText: "cnc 销售 数控 销售工程师",
+                                age: 45,
+                                locationText: "中国 广东 东莞",
+                                roleTypes: ["sales"],
+                                roleYearsByType: { sales: 3 },
+                            }),
+                        ],
+                        isDone: true,
+                        cursor: null,
+                    });
+                }
+                if (call.pathName === "resumes_search:getResumeDocsByIds") {
+                    const ids = Array.isArray(call.args.ids) ? call.args.ids : [];
+                    return convexSuccess(ids.map((id) => buildFilterableConvexResumeRecord(String(id), {
+                        location: id === "r3" ? "Kuala Lumpur MY" : "东莞",
+                        verifiedRoleYears: id === "r2" ? { engineer: 3 } : { sales: 3 },
+                    })));
+                }
+                if (call.pathName === "resumes_search:scanResumePageSlim") {
+                    throw new Error("AND-mode must not scan monolithic resume searchText pages");
+                }
+                throw new Error(`Unexpected convex path: ${call.pathName}`);
+            });
+
+            const app = createApp();
+            const response = await app.request(
+                "/api/resumes?source=convex&q=CNC%20销售&limit=5&minRoleYears=1&roleFilterType=sales&minAge=25&maxAge=40&locations=China",
+            );
+
+            expect(response.status).toBe(200);
+            const docCall = calls.find((c) => c.pathName === "resumes_search:getResumeDocsByIds");
+            expect(docCall?.args.ids).toEqual(["r1"]);
+            expect(calls.some((c) => c.pathName === "resumes_search:scanResumePageSlim")).toBe(false);
+        });
+
         it("uses resume digest pages for multi-keyword AND search before fetching full records", async () => {
             const calls: ConvexCall[] = [];
             vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
@@ -366,29 +431,35 @@ describe("BFF search dispatcher integration", () => {
                 if (call.pathName === "resumes_search:scanResumeDigestPage") {
                     return convexSuccess({
                         docs: [
-                            buildDigestRow("r1", { searchText: "cnc 销售 数控 销售工程师" }),
-                            buildDigestRow("r2", { searchText: "cnc 销售 数控 销售工程师" }),
-                            buildDigestRow("r3", { searchText: "cnc 销售 数控 销售工程师" }),
+                            buildDigestRow("r1", {
+                                searchText: "cnc 销售 数控 销售工程师",
+                                locationText: "中国 广东 东莞",
+                                roleTypes: ["sales"],
+                                roleYearsByType: { sales: 3 },
+                            }),
+                            buildDigestRow("r2", {
+                                searchText: "cnc 销售 数控 销售工程师",
+                                locationText: "马来西亚 吉隆坡",
+                                roleTypes: ["sales"],
+                                roleYearsByType: { sales: 3 },
+                            }),
+                            buildDigestRow("r3", {
+                                searchText: "cnc 销售 数控 销售工程师",
+                                locationText: "中国 广东 东莞",
+                                roleTypes: ["engineer"],
+                                roleYearsByType: { engineer: 3 },
+                            }),
                         ],
                         isDone: true,
                         cursor: null,
                     });
                 }
                 if (call.pathName === "resumes_search:getResumeDocsByIds") {
-                    return convexSuccess([
-                        buildFilterableConvexResumeRecord("r1", {
-                            location: "东莞",
-                            verifiedRoleYears: { sales: 3 },
-                        }),
-                        buildFilterableConvexResumeRecord("r2", {
-                            location: "Kuala Lumpur MY",
-                            verifiedRoleYears: { sales: 3 },
-                        }),
-                        buildFilterableConvexResumeRecord("r3", {
-                            location: "东莞",
-                            verifiedRoleYears: { engineer: 3 },
-                        }),
-                    ]);
+                    const ids = Array.isArray(call.args.ids) ? call.args.ids : [];
+                    return convexSuccess(ids.map((id) => buildFilterableConvexResumeRecord(String(id), {
+                        location: id === "r2" ? "Kuala Lumpur MY" : "东莞",
+                        verifiedRoleYears: id === "r3" ? { engineer: 3 } : { sales: 3 },
+                    })));
                 }
                 throw new Error(`Unexpected convex path: ${call.pathName}`);
             });

--- a/apps/api/src/services/resume-candidate-prep.ts
+++ b/apps/api/src/services/resume-candidate-prep.ts
@@ -162,6 +162,49 @@ function toDigestFilterRecord(doc: Record<string, unknown>) {
   };
 }
 
+type DigestFilterRecord = ReturnType<typeof toDigestFilterRecord>;
+
+function hasDigestRoleMetadata(digest: DigestFilterRecord): boolean {
+  return (digest.roleTypes?.length ?? 0) > 0
+    || Object.keys(digest.roleYearsByType ?? {}).length > 0;
+}
+
+function digestFiltersForAvailableFields(digest: DigestFilterRecord, filters: ResumeFilters | undefined): ResumeFilters | undefined {
+  if (!filters) return undefined;
+
+  const availableFilters: ResumeFilters = { ...filters };
+
+  if (filters.maxExperience !== undefined && digest.experienceYears === undefined) {
+    delete availableFilters.maxExperience;
+  }
+  if (filters.education?.length && !digest.educationLevel) {
+    delete availableFilters.education;
+  }
+  if ((filters.skills?.length || filters.requiredKeywords?.length)
+    && !(typeof digest.searchText === "string" && digest.searchText.length > 0)) {
+    delete availableFilters.skills;
+    delete availableFilters.requiredKeywords;
+  }
+  if (filters.locations?.length && !digest.locationText) {
+    delete availableFilters.locations;
+  }
+  if ((filters.minSalary !== undefined || filters.maxSalary !== undefined)
+    && digest.salaryMin === undefined
+    && digest.salaryMax === undefined) {
+    delete availableFilters.minSalary;
+    delete availableFilters.maxSalary;
+  }
+  if ((filters.roleFilterType || filters.minRoleYears !== undefined) && !hasDigestRoleMetadata(digest)) {
+    delete availableFilters.roleFilterType;
+    delete availableFilters.minRoleYears;
+  }
+  if (filters.sources?.length && !digest.sourceKey && !digest.source) {
+    delete availableFilters.sources;
+  }
+
+  return availableFilters;
+}
+
 export function collectBffAndModeProvenance(
   searchText: string,
   groups: Array<{ original: string; variants: string[] }>,
@@ -579,7 +622,8 @@ export async function prepareConvexCandidates(params: {
           );
           if (!allGroupsMatch) continue;
 
-          if (!matchesResumeDigestFilters(toDigestFilterRecord(doc), filters)) continue;
+          const digest = toDigestFilterRecord(doc);
+          if (!matchesResumeDigestFilters(digest, digestFiltersForAvailableFields(digest, filters))) continue;
 
           const resumeId = toStringValue(doc.resumeId);
           if (resumeId) matchingIds.push(resumeId);

--- a/apps/api/src/services/resume-candidate-prep.ts
+++ b/apps/api/src/services/resume-candidate-prep.ts
@@ -17,6 +17,7 @@ import {
   buildWorkHistoryEntryText,
   buildLatestWorkHistoryEvidence,
   selectLatestWorkHistory,
+  matchesResumeDigestFilters,
 } from "@trends/shared";
 import type { ResumeItem } from "../types/resume.js";
 import type { ResumeIndex } from "./resume-index.js";
@@ -127,6 +128,38 @@ export function parseConvexProvenance(value: unknown): ResumeSearchProvenance[] 
   });
 
   return provenance.length > 0 ? provenance : undefined;
+}
+
+function toNumberRecord(value: unknown): Record<string, number> | undefined {
+  if (!isRecord(value)) return undefined;
+  const result: Record<string, number> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === "number" && Number.isFinite(item)) {
+      result[key] = item;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function toDigestFilterRecord(doc: Record<string, unknown>) {
+  const source = typeof doc.source === "string" ? doc.source : undefined;
+  const sourceKey = typeof doc.sourceKey === "string"
+    ? doc.sourceKey
+    : resolveResumeAnalysisSourceKey({ source });
+  return {
+    isArchived: typeof doc.isArchived === "boolean" ? doc.isArchived : undefined,
+    source,
+    sourceKey,
+    searchText: typeof doc.searchText === "string" ? doc.searchText : undefined,
+    age: toOptionalNumber(doc.age),
+    locationText: typeof doc.locationText === "string" ? doc.locationText : undefined,
+    educationLevel: typeof doc.educationLevel === "string" ? doc.educationLevel : undefined,
+    salaryMin: toOptionalNumber(doc.salaryMin),
+    salaryMax: toOptionalNumber(doc.salaryMax),
+    experienceYears: toOptionalNumber(doc.experienceYears),
+    roleTypes: toStringArray(doc.roleTypes),
+    roleYearsByType: toNumberRecord(doc.roleYearsByType),
+  };
 }
 
 export function collectBffAndModeProvenance(
@@ -546,16 +579,7 @@ export async function prepareConvexCandidates(params: {
           );
           if (!allGroupsMatch) continue;
 
-          // Basic filters that run on digest fields
-          if (filters) {
-            if (typeof filters.minAge === 'number' && typeof doc.age === 'number' && doc.age < filters.minAge) continue;
-            if (typeof filters.maxAge === 'number' && typeof doc.age === 'number' && doc.age > filters.maxAge) continue;
-            if (Array.isArray(filters.sources) && filters.sources.length > 0) {
-              const resumeSourceKey = (typeof doc.sourceKey === 'string' ? doc.sourceKey : undefined)
-                ?? resolveResumeAnalysisSourceKey({ source: typeof doc.source === 'string' ? doc.source : undefined });
-              if (!resumeSourceKey || !filters.sources.includes(resumeSourceKey)) continue;
-            }
-          }
+          if (!matchesResumeDigestFilters(toDigestFilterRecord(doc), filters)) continue;
 
           const resumeId = toStringValue(doc.resumeId);
           if (resumeId) matchingIds.push(resumeId);

--- a/packages/convex/__tests__/resumes-search-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-search-convex-test.test.ts
@@ -758,6 +758,126 @@ describe("resumes_search: getResumesByIds", () => {
 // ---------------------------------------------------------------------------
 
 describe("resumes_search: scanResumeDigestPage", () => {
+    it("builds compact digest search text without copying cold resume searchText", async () => {
+        const t = convexTest(schema, modules);
+        const coldSearchText = [
+            "cnc 销售",
+            "coldblob ".repeat(6000),
+        ].join(" ");
+        const resumeId = await seedResume(t, {
+            externalId: "digest-compact",
+            identityKey: "profileUrl:example.com/candidates/digest-compact",
+            source: "job5156",
+            sourceKey: "job5156",
+            searchText: coldSearchText,
+            content: {
+                name: "Compact Candidate",
+                desiredPosition: "CNC销售工程师",
+                education: "本科",
+                expectedSalary: "15-25K",
+                locationHierarchy: { country: "中国", province: "广东", city: "东莞" },
+                skills: ["CNC", "销售"],
+                workHistory: [{
+                    companyName: "制造有限公司",
+                    jobTitle: "CNC销售工程师",
+                    description: "负责数控机床销售",
+                    startDate: "2021-01",
+                    endDate: "至今",
+                }],
+            },
+            age: 30,
+            ingestData: {
+                ...MINIMAL_INGEST_DATA,
+                synonymHits: ["数控", "销售"],
+                verifiedRoleYears: { sales: 3 },
+            },
+        });
+
+        await t.mutation(api.resumes_search.upsertResumeDigestForTest, { resumeId });
+        const result = await t.query(api.resumes_search.scanResumeDigestPage, { numItems: 1000 });
+
+        expect(result.docs).toHaveLength(1);
+        const row = result.docs[0];
+        expect(row.searchText).toContain("cnc");
+        expect(row.searchText).toContain("销售");
+        expect(row.searchText).not.toContain("coldblob");
+        expect(JSON.stringify(row).length).toBeLessThan(2048);
+    });
+
+    it("preserves domain keyword tokens from cold searchText without copying it", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t, {
+            externalId: "digest-domain-token",
+            identityKey: "profileUrl:example.com/candidates/digest-domain-token",
+            source: "job5156",
+            sourceKey: "job5156",
+            searchText: [
+                "profile education included 数控 原理 and 销售 context",
+                "coldblob ".repeat(6000),
+            ].join(" "),
+            content: {
+                name: "Domain Token Candidate",
+                education: "本科",
+                expectedSalary: "15-25K",
+                locationHierarchy: { country: "中国" },
+            },
+            age: 30,
+        });
+
+        await t.mutation(api.resumes_search.upsertResumeDigestForTest, { resumeId });
+        const result = await t.query(api.resumes_search.scanResumeDigestPage, { numItems: 1000 });
+
+        const row = result.docs[0];
+        expect(row.searchText).toContain("cnc");
+        expect(row.searchText).toContain("数控");
+        expect(row.searchText).toContain("销售");
+        expect(row.searchText).not.toContain("coldblob");
+        expect(JSON.stringify(row).length).toBeLessThan(2048);
+    });
+
+    it("derives digest role years from roleSignals when verifiedRoleYears is absent", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t, {
+            externalId: "digest-role-signals",
+            identityKey: "profileUrl:example.com/candidates/digest-role-signals",
+            searchText: "cnc 销售",
+            content: {
+                name: "Role Signal Candidate",
+                workHistory: [{ raw: "2021-2024 销售工程师" }],
+            },
+            ingestData: {
+                ...MINIMAL_INGEST_DATA,
+                verifiedRoleYears: {},
+                roleSignals: [{
+                    type: "sales",
+                    matchedSignals: ["销售"],
+                    signalCount: 1,
+                    occurrences: 1,
+                    years: 3,
+                    industryVerifiedYears: 3,
+                    industryVerifiedRelevantYears: 3,
+                    roleRelevantYears: 3,
+                    matchedWorkEntries: [{
+                        companyName: "测试公司",
+                        jobTitle: "销售工程师",
+                        years: 3,
+                        directRoleMatch: true,
+                        industryVerified: true,
+                        matchedSignals: ["销售"],
+                    }],
+                    verifyIn: "workHistory",
+                }],
+            },
+        });
+
+        await t.mutation(api.resumes_search.upsertResumeDigestForTest, { resumeId });
+        const result = await t.query(api.resumes_search.scanResumeDigestPage, { numItems: 1000 });
+
+        const row = result.docs[0];
+        expect(row.roleTypes).toEqual(["sales"]);
+        expect(row.roleYearsByType).toEqual({ sales: 3 });
+    });
+
     it("returns digest projection without cold resume content or full ingestData", async () => {
         const t = convexTest(schema, modules);
         const resumeId = await seedResume(t, {

--- a/packages/convex/convex/lib/resume_digests.ts
+++ b/packages/convex/convex/lib/resume_digests.ts
@@ -1,5 +1,8 @@
 import {
+    type AnalysisRoleSignalLike,
+    buildLatestWorkHistoryEvidence,
     formatLocationHierarchySearchText,
+    getVerifiedRoleSignalYears,
     isRecord,
     matchesResumeDigestFilters,
     normalizeEducationLevel,
@@ -11,8 +14,18 @@ import type { Doc, Id } from "../_generated/dataModel";
 import {
     resolveResumeAge,
 } from "./resumes_list_projections";
+import {
+    appendMissingSearchTokens,
+    buildIngestSearchTokens,
+    buildSearchText,
+    normalizeWhitespace,
+    toTextFragments,
+} from "../search_text.js";
 
 export { matchesResumeDigestFilters };
+
+const MAX_DIGEST_FRAGMENT_LENGTH = 160;
+const MAX_DIGEST_SEARCH_TEXT_LENGTH = 1500;
 
 export type ResumeDigest = {
     resumeId: Id<"resumes">;
@@ -39,6 +52,8 @@ export type ResumeDigest = {
 export function buildResumeDigest(resume: Doc<"resumes">, now: number): ResumeDigest {
     const content = isRecord(resume.content) ? resume.content : {};
     const locationHierarchy = normalizeResumeLocationHierarchy(content, resume.source);
+    const locationText = formatLocationHierarchySearchText(locationHierarchy) || (typeof content.location === "string" ? content.location : undefined);
+    const educationLevel = normalizeEducationLevel(typeof content.education === "string" ? content.education : undefined) ?? undefined;
     const salary = parseRawSalaryRange(
         typeof content.expectedSalary === "string" ? content.expectedSalary : undefined,
     );
@@ -50,14 +65,20 @@ export function buildResumeDigest(resume: Doc<"resumes">, now: number): ResumeDi
         externalId: resume.externalId,
         source: resume.source,
         sourceKey: resume.sourceKey,
-        searchText: resume.searchText,
+        searchText: buildCompactDigestSearchText(content, resume.ingestData, {
+            coldSearchText: resume.searchText,
+            locationHierarchy,
+            locationText,
+            educationLevel,
+            roleYearsByType,
+        }),
         isArchived: resume.isArchived,
         archivedAt: resume.archivedAt,
         primaryRuleScore: resume.primaryRuleScore,
         crawledAt: resume.crawledAt,
         age: resolveResumeAge(resume, content) ?? undefined,
-        locationText: formatLocationHierarchySearchText(locationHierarchy) || (typeof content.location === "string" ? content.location : undefined),
-        educationLevel: normalizeEducationLevel(typeof content.education === "string" ? content.education : undefined) ?? undefined,
+        locationText,
+        educationLevel,
         salaryMin: salary?.min,
         salaryMax: salary?.max,
         experienceYears: resolveExperienceYears(typeof content.experience === "string" ? content.experience : undefined, content.workHistory) ?? undefined,
@@ -67,16 +88,200 @@ export function buildResumeDigest(resume: Doc<"resumes">, now: number): ResumeDi
     };
 }
 
+type CompactDigestSearchOptions = {
+    coldSearchText?: string;
+    locationHierarchy: ReturnType<typeof normalizeResumeLocationHierarchy>;
+    locationText?: string;
+    educationLevel?: string;
+    roleYearsByType: Record<string, number>;
+};
+
+function buildCompactDigestSearchText(
+    content: Record<string, unknown>,
+    ingestData: unknown,
+    options: CompactDigestSearchOptions,
+): string | undefined {
+    const compactContent = dropUndefined({
+        name: compactFragment(content.name),
+        desiredPosition: compactFragment(
+            content.desiredPosition
+            ?? content.jobIntention
+            ?? content.title
+            ?? content.position,
+        ),
+        education: compactFragment(content.education ?? options.educationLevel),
+        expectedSalary: compactFragment(content.expectedSalary),
+        skills: compactArray(content.skills, 20),
+        companies: compactArray(content.companies, 20),
+        locationHierarchy: options.locationHierarchy,
+        workHistory: compactWorkHistory(content.workHistory),
+    });
+
+    const base = buildSearchText(compactContent);
+    const ingestTokens = collectIngestTokens(ingestData);
+    const domainTokens = collectDomainPresenceTokens(options.coldSearchText);
+    const roleTokens = Object.keys(options.roleYearsByType);
+    const withDigestFields = appendMissingSearchTokens(base, [
+        options.locationText,
+        options.educationLevel,
+        ...domainTokens,
+        ...roleTokens,
+        ...ingestTokens,
+    ].filter((value): value is string => typeof value === "string" && value.length > 0));
+    return limitSearchText(withDigestFields);
+}
+
+function dropUndefined(record: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries(
+        Object.entries(record).filter(([, value]) => value !== undefined),
+    );
+}
+
+function compactFragment(value: unknown): string | undefined {
+    const normalized = normalizeWhitespace(toTextFragments(value).join(" "));
+    if (!normalized) return undefined;
+    return normalized.length > MAX_DIGEST_FRAGMENT_LENGTH
+        ? normalized.slice(0, MAX_DIGEST_FRAGMENT_LENGTH)
+        : normalized;
+}
+
+function compactArray(value: unknown, limit: number): string[] | undefined {
+    const values = Array.isArray(value)
+        ? value.flatMap((item) => toTextFragments(item))
+        : toTextFragments(value);
+    const compacted = values
+        .map((item) => compactFragment(item))
+        .filter((item): item is string => typeof item === "string" && item.length > 0)
+        .slice(0, limit);
+    return compacted.length > 0 ? compacted : undefined;
+}
+
+function compactWorkHistory(value: unknown): string[] | undefined {
+    const lines = buildLatestWorkHistoryEvidence(value, { limit: 3 }).lines
+        .map((line) => compactFragment(line))
+        .filter((line): line is string => typeof line === "string" && line.length > 0);
+    return lines.length > 0 ? lines : undefined;
+}
+
+function collectIngestTokens(value: unknown): string[] {
+    if (!isRecord(value)) return [];
+    return buildIngestSearchTokens({
+        industryTags: toStringArray(value.industryTags),
+        synonymHits: toStringArray(value.synonymHits),
+        brandHits: toBrandHits(value.brandHits),
+        companyHits: toStringArray(value.companyHits),
+        companyPatternAliasTokens: typeof value.companyPatternAliasTokens === "string"
+            ? value.companyPatternAliasTokens
+            : undefined,
+    });
+}
+
+function toStringArray(value: unknown): string[] | undefined {
+    if (!Array.isArray(value)) return undefined;
+    const result = value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+    return result.length > 0 ? result : undefined;
+}
+
+function toBrandHits(value: unknown): Array<{ brand: string }> | undefined {
+    if (!Array.isArray(value)) return undefined;
+    const result = value.flatMap((item) => {
+        if (isRecord(item) && typeof item.brand === "string" && item.brand.trim()) {
+            return [{ brand: item.brand }];
+        }
+        if (typeof item === "string" && item.trim()) {
+            return [{ brand: item }];
+        }
+        return [];
+    });
+    return result.length > 0 ? result : undefined;
+}
+
+function limitSearchText(value: string): string | undefined {
+    const tokens = normalizeWhitespace(value).toLowerCase().split(/\s+/g).filter((token) => token.length > 0);
+    const seen = new Set<string>();
+    const result: string[] = [];
+    let length = 0;
+    for (const token of tokens) {
+        if (seen.has(token)) continue;
+        const nextLength = length + token.length + (result.length > 0 ? 1 : 0);
+        if (nextLength > MAX_DIGEST_SEARCH_TEXT_LENGTH) break;
+        seen.add(token);
+        result.push(token);
+        length = nextLength;
+    }
+    return result.length > 0 ? result.join(" ") : undefined;
+}
+
+function collectDomainPresenceTokens(value: string | undefined): string[] {
+    if (!value) return [];
+    const normalized = value.toLowerCase();
+    const tokens: string[] = [];
+    if (/\bcnc\b/.test(normalized) || normalized.includes("数控")) {
+        tokens.push("cnc", "数控");
+    }
+    if (normalized.includes("销售") || /\bsales?\b/.test(normalized)) {
+        tokens.push("销售", "sales");
+    }
+    if (normalized.includes("机床") || normalized.includes("machine tool")) {
+        tokens.push("机床", "machine tool", "machine tools");
+    }
+    return tokens;
+}
+
 function collectRoleYearsByType(resume: Doc<"resumes">): Record<string, number> {
     const raw = resume.ingestData as Record<string, unknown> | null | undefined;
     if (!raw) return {};
     const verifiedRoleYears = raw.verifiedRoleYears as Record<string, unknown> | null | undefined;
-    if (!isRecord(verifiedRoleYears)) return {};
     const result: Record<string, number> = {};
-    for (const [key, value] of Object.entries(verifiedRoleYears)) {
-        if (typeof value === "number" && Number.isFinite(value) && value > 0) {
-            result[key.toLowerCase()] = Math.max(result[key.toLowerCase()] ?? 0, value);
+    if (isRecord(verifiedRoleYears)) {
+        for (const [key, value] of Object.entries(verifiedRoleYears)) {
+            if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+                result[key.toLowerCase()] = Math.max(result[key.toLowerCase()] ?? 0, value);
+            }
+        }
+    }
+    const roleSignals = parseAnalysisRoleSignals(raw.roleSignals);
+    for (const signal of roleSignals) {
+        const key = signal.type.toLowerCase();
+        const years = getVerifiedRoleSignalYears(roleSignals, key, signal.verifyIn);
+        if (years > 0) {
+            result[key] = Math.max(result[key] ?? 0, years);
         }
     }
     return result;
+}
+
+function parseAnalysisRoleSignals(value: unknown): AnalysisRoleSignalLike[] {
+    if (!Array.isArray(value)) return [];
+    return value.flatMap((item) => {
+        if (!isRecord(item) || typeof item.type !== "string") return [];
+        return [{
+            type: item.type,
+            verifyIn: typeof item.verifyIn === "string" ? item.verifyIn : undefined,
+            years: toNumber(item.years),
+            roleRelevantYears: toNumber(item.roleRelevantYears),
+            industryVerifiedYears: toNumber(item.industryVerifiedYears),
+            industryVerifiedRelevantYears: toNumber(item.industryVerifiedRelevantYears),
+            matchedWorkEntries: parseMatchedWorkEntries(item.matchedWorkEntries),
+        }];
+    });
+}
+
+function parseMatchedWorkEntries(value: unknown): AnalysisRoleSignalLike["matchedWorkEntries"] {
+    if (!Array.isArray(value)) return undefined;
+    const entries = value.flatMap((item) => {
+        if (!isRecord(item)) return [];
+        const years = toNumber(item.years);
+        if (years === undefined) return [];
+        return [{
+            years,
+            directRoleMatch: typeof item.directRoleMatch === "boolean" ? item.directRoleMatch : undefined,
+            industryVerified: typeof item.industryVerified === "boolean" ? item.industryVerified : undefined,
+        }];
+    });
+    return entries.length > 0 ? entries : undefined;
+}
+
+function toNumber(value: unknown): number | undefined {
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }


### PR DESCRIPTION
## Summary

Fixes the digest-first AND-mode resume path so preview no longer scans/fetches oversized resume data for the CNC sales target query.

- Builds `resume_digests.searchText` from compact hot fields plus bounded domain-presence tokens instead of copying cold `resume.searchText`.
- Derives digest role years from verified `roleSignals` when `verifiedRoleYears` is absent, matching the BFF full-doc guard.
- Applies shared digest-supported filters before `getResumeDocsByIds`, while preserving the final full-doc `bffMatchesResumeFilters` guard.
- Adds regression coverage for compact digest rows, domain token preservation, role-signal role years, and pre-fetch digest filtering.

## ptcloud Evidence

- Production was inspected read-only and remains on old `/opt/trends` commit `11ad8928`; no production changes were made.
- Preview was hotfixed and backfilled across `5,557` resumes for validation.
- Final preview phase probe: `digestFiltered=189`, `legacyFinal=189`, `missingKeyword=0`, `missingFilter=0`.
- Final preview target API warm timings: local `0.550s`, public `0.547s`, preserving `total=189` and `returned=50`.

## Verification

- `npm test -- packages/convex/__tests__/resumes-search-convex-test.test.ts`
- `npm test -- apps/api/src/routes/resumes.search-integration.test.ts`
- `npm test -- apps/api/src/routes/__tests__/bff-filter-alignment.test.ts`
- `npm test -- packages/convex/__tests__/search-text.test.ts`
- `make check`

`make check` passed with only the existing web fast-refresh warnings in `badge.tsx` and `button.tsx`.
