### PR TITLE
Add extensible auth core with Casdoor OIDC

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,7 @@
     "mammoth": "^1.12.0",
     "node-unrar-js": "^2.0.2",
     "nodemailer": "^8.0.8",
+    "openid-client": "^6.8.4",
     "papaparse": "^5.5.3",
     "pdf-parse": "^2.4.5",
     "yaml": "^2.9.0",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -41,6 +41,7 @@ import {
 import { createAuthRoutes } from "./routes/auth.js";
 import { config } from "./services/config.js";
 import type { AuthStorage } from "./services/auth-storage.js";
+import type { AuthContext } from "./services/auth-types.js";
 import { workspaceMiddleware } from "./middleware/workspace.js";
 import { createAuthMiddleware } from "./middleware/auth.js";
 import { serverTimingMiddleware } from "./middleware/server-timing.js";
@@ -69,6 +70,7 @@ function resolveCorsOrigin(origin: string): string | null {
 
 type CreateAppOptions = {
   authStorage?: AuthStorage;
+  authContext?: AuthContext;
   authTtlSeconds?: number;
 };
 
@@ -137,6 +139,12 @@ export function createApp(options: CreateAppOptions = {}) {
   app.use("*", logger());
   app.use("*", prettyJSON());
   app.use("*", workspaceMiddleware);
+  if (options.authContext) {
+    app.use("*", async (c, next) => {
+      c.set("auth", options.authContext);
+      await next();
+    });
+  }
   app.use("*", authMiddleware.optionalAuth);
 
   // Rate limiting on API routes (100 req/min per IP in production).

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,7 @@ import { bodyLimit } from "hono/body-limit";
 
 import {
   healthRoutes,
+  authRoutes,
   aiSummaryRoutes,
   taxonomyRoutes,
   trendsRoutes,
@@ -40,8 +41,30 @@ import {
 } from "./routes/index.js";
 import { config } from "./services/config.js";
 import { workspaceMiddleware } from "./middleware/workspace.js";
+import { optionalAuth, requireCsrf } from "./middleware/auth.js";
 import { serverTimingMiddleware } from "./middleware/server-timing.js";
 import { rateLimit } from "./middleware/rate-limit.js";
+
+const LOCAL_DEV_ORIGINS = new Set([
+  "http://localhost:3000",
+  "http://localhost:3001",
+  "http://localhost:5173",
+  "http://localhost:5174",
+  "http://127.0.0.1:3000",
+  "http://127.0.0.1:3001",
+  "http://127.0.0.1:5173",
+  "http://127.0.0.1:5174",
+]);
+
+function resolveCorsOrigin(origin: string): string | null {
+  if (config.auth.allowedOrigins.includes(origin)) {
+    return origin;
+  }
+  if (process.env.NODE_ENV !== "production" && config.auth.allowedOrigins.length === 0 && LOCAL_DEV_ORIGINS.has(origin)) {
+    return origin;
+  }
+  return null;
+}
 
 export const openApiConfig = {
   openapi: "3.1.0",
@@ -96,13 +119,15 @@ export function createApp() {
   app.use(
     "*",
     cors({
-      origin: "*",
+      origin: resolveCorsOrigin,
+      credentials: true,
       exposeHeaders: ["Content-Disposition", "Content-Length"],
     })
   );
   app.use("*", logger());
   app.use("*", prettyJSON());
   app.use("*", workspaceMiddleware);
+  app.use("*", optionalAuth);
 
   // Rate limiting on API routes (100 req/min per IP in production).
   // In development, localhost requests share key "unknown" and exhaust the budget quickly.
@@ -126,9 +151,11 @@ export function createApp() {
       })(c, next);
     },
   );
+  app.use("/api/*", requireCsrf);
 
   // Mount routes
   app.route("/", healthRoutes);
+  app.route("/", authRoutes);
   app.route("/", aiSummaryRoutes);
   app.route("/", taxonomyRoutes);
   app.route("/", trendsRoutes);

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,7 +7,6 @@ import { bodyLimit } from "hono/body-limit";
 
 import {
   healthRoutes,
-  authRoutes,
   aiSummaryRoutes,
   taxonomyRoutes,
   trendsRoutes,
@@ -39,9 +38,11 @@ import {
   resumesSearchRoutes,
   resumesMatchRoutes,
 } from "./routes/index.js";
+import { createAuthRoutes } from "./routes/auth.js";
 import { config } from "./services/config.js";
+import type { AuthStorage } from "./services/auth-storage.js";
 import { workspaceMiddleware } from "./middleware/workspace.js";
-import { optionalAuth, requireCsrf } from "./middleware/auth.js";
+import { createAuthMiddleware } from "./middleware/auth.js";
 import { serverTimingMiddleware } from "./middleware/server-timing.js";
 import { rateLimit } from "./middleware/rate-limit.js";
 
@@ -65,6 +66,11 @@ function resolveCorsOrigin(origin: string): string | null {
   }
   return null;
 }
+
+type CreateAppOptions = {
+  authStorage?: AuthStorage;
+  authTtlSeconds?: number;
+};
 
 export const openApiConfig = {
   openapi: "3.1.0",
@@ -95,8 +101,12 @@ export const openApiConfig = {
   ],
 };
 
-export function createApp() {
+export function createApp(options: CreateAppOptions = {}) {
   const app = new OpenAPIHono();
+  const authMiddleware = createAuthMiddleware({
+    storage: options.authStorage,
+    ttlSeconds: options.authTtlSeconds,
+  });
 
   // Middleware
   app.use("*", serverTimingMiddleware);
@@ -127,7 +137,7 @@ export function createApp() {
   app.use("*", logger());
   app.use("*", prettyJSON());
   app.use("*", workspaceMiddleware);
-  app.use("*", optionalAuth);
+  app.use("*", authMiddleware.optionalAuth);
 
   // Rate limiting on API routes (100 req/min per IP in production).
   // In development, localhost requests share key "unknown" and exhaust the budget quickly.
@@ -151,11 +161,14 @@ export function createApp() {
       })(c, next);
     },
   );
-  app.use("/api/*", requireCsrf);
+  app.use("/api/*", authMiddleware.requireCsrf);
 
   // Mount routes
   app.route("/", healthRoutes);
-  app.route("/", authRoutes);
+  app.route("/", createAuthRoutes({
+    storage: options.authStorage,
+    ttlSeconds: options.authTtlSeconds,
+  }));
   app.route("/", aiSummaryRoutes);
   app.route("/", taxonomyRoutes);
   app.route("/", trendsRoutes);

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -1,0 +1,157 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+
+import { AuthSessionService } from "../services/auth-session-service.js";
+import { AuthStorage } from "../services/auth-storage.js";
+import type { AuthContext, WorkspaceRole } from "../services/auth-types.js";
+import { hasWorkspaceRole } from "../services/auth-types.js";
+import { config } from "../services/config.js";
+import { resetResumeScreeningDb } from "../services/database.js";
+import { createAuthMiddleware, getAuthenticatedActorId } from "./auth.js";
+import { workspaceMiddleware } from "./workspace.js";
+
+function createAuthContext(role: WorkspaceRole, workspaceSlug = "hr"): AuthContext {
+  return {
+    user: {
+      id: "user-1",
+      email: "hr@example.com",
+      displayName: "HR User",
+      status: "active",
+    },
+    memberships: [{ userId: "user-1", workspaceSlug, role }],
+    sessionId: "session-1",
+    csrfToken: "csrf-hash",
+  };
+}
+
+function createGateApp(
+  auth: AuthContext | undefined,
+  gate: ReturnType<typeof createAuthMiddleware>["requireWorkspaceUser"],
+) {
+  const app = new Hono();
+  app.use("*", workspaceMiddleware);
+  app.use("*", async (c, next) => {
+    if (auth) {
+      c.set("auth", auth);
+    }
+    await next();
+  });
+  app.use("*", gate);
+  app.get("/protected", (c) => c.json({ actorId: getAuthenticatedActorId(c) }));
+  return app;
+}
+
+describe("auth middleware role helpers", () => {
+  it("requires membership in the selected workspace", () => {
+    expect(hasWorkspaceRole([{ userId: "u1", workspaceSlug: "hr", role: "user" }], "hr", ["user", "admin"])).toBe(true);
+    expect(hasWorkspaceRole([{ userId: "u1", workspaceSlug: "hr", role: "user" }], "dev", ["user", "admin"])).toBe(false);
+    expect(hasWorkspaceRole([{ userId: "u1", workspaceSlug: "hr", role: "user" }], "hr", ["admin"])).toBe(false);
+  });
+});
+
+describe("auth middleware gates", () => {
+  it("rejects a protected route when auth is missing", async () => {
+    const middleware = createAuthMiddleware();
+    const app = createGateApp(undefined, middleware.requireWorkspaceUser);
+
+    const res = await app.request("/protected", {
+      headers: { "X-Workspace-Slug": "hr" },
+    });
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toMatchObject({
+      success: false,
+      error: "Authentication required",
+    });
+  });
+
+  it("rejects a protected route when membership belongs to another workspace", async () => {
+    const middleware = createAuthMiddleware();
+    const app = createGateApp(createAuthContext("user", "hr"), middleware.requireWorkspaceUser);
+
+    const res = await app.request("/protected", {
+      headers: { "X-Workspace-Slug": "dev" },
+    });
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      success: false,
+      error: "Workspace access required",
+    });
+  });
+
+  it("allows a workspace user member on the selected workspace", async () => {
+    const middleware = createAuthMiddleware();
+    const app = createGateApp(createAuthContext("user", "hr"), middleware.requireWorkspaceUser);
+
+    const res = await app.request("/protected", {
+      headers: { "X-Workspace-Slug": "hr" },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ actorId: "user-1" });
+  });
+
+  it("requires admin membership for admin routes", async () => {
+    const middleware = createAuthMiddleware();
+    const userApp = createGateApp(createAuthContext("user", "hr"), middleware.requireAdmin);
+    const adminApp = createGateApp(createAuthContext("admin", "hr"), middleware.requireAdmin);
+
+    const userRes = await userApp.request("/protected", {
+      headers: { "X-Workspace-Slug": "hr" },
+    });
+    const adminRes = await adminApp.request("/protected", {
+      headers: { "X-Workspace-Slug": "hr" },
+    });
+
+    expect(userRes.status).toBe(403);
+    await expect(userRes.json()).resolves.toMatchObject({
+      success: false,
+      error: "Admin access required",
+    });
+    expect(adminRes.status).toBe(200);
+  });
+
+  it("requires a valid CSRF header for mutating requests", async () => {
+    resetResumeScreeningDb();
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-middleware-"));
+    const storage = new AuthStorage(root);
+    const user = storage.createUser({ email: "hr@example.com", displayName: "HR" });
+    storage.upsertMembership({ userId: user.id, workspaceSlug: "hr", role: "user" });
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(user.id);
+    const middleware = createAuthMiddleware({ storage, ttlSeconds: 3600 });
+
+    const app = new Hono();
+    app.use("*", workspaceMiddleware);
+    app.use("*", middleware.optionalAuth);
+    app.use("*", middleware.requireWorkspaceUser);
+    app.use("*", middleware.requireCsrf);
+    app.post("/mutate", (c) => c.json({ actorId: getAuthenticatedActorId(c) }));
+
+    const headers = {
+      "X-Workspace-Slug": "hr",
+      Cookie: `${config.auth.sessionCookieName}=${session.token}`,
+    };
+    const missingRes = await app.request("/mutate", { method: "POST", headers });
+    const validRes = await app.request("/mutate", {
+      method: "POST",
+      headers: {
+        ...headers,
+        "X-CSRF-Token": session.csrfToken,
+      },
+    });
+
+    expect(missingRes.status).toBe(403);
+    await expect(missingRes.json()).resolves.toMatchObject({
+      success: false,
+      error: "CSRF token required",
+    });
+    expect(validRes.status).toBe(200);
+    await expect(validRes.json()).resolves.toMatchObject({ actorId: user.id });
+  });
+});

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -20,16 +20,22 @@ type AuthMiddlewareOptions = {
 };
 
 export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
-  const storage = options.storage ?? new AuthStorage(config.projectRoot);
-  const sessions = new AuthSessionService(storage, {
-    ttlSeconds: options.ttlSeconds ?? config.auth.sessionTtlSeconds,
-  });
+  let storage = options.storage;
+  let sessions: AuthSessionService | undefined;
   const sessionCookieName = options.sessionCookieName ?? config.auth.sessionCookieName;
   const csrfHeaderName = options.csrfHeaderName ?? "X-CSRF-Token";
 
+  function getSessions(): AuthSessionService {
+    storage ??= new AuthStorage(config.projectRoot);
+    sessions ??= new AuthSessionService(storage, {
+      ttlSeconds: options.ttlSeconds ?? config.auth.sessionTtlSeconds,
+    });
+    return sessions;
+  }
+
   const optionalAuth: MiddlewareHandler = async (c, next) => {
     const token = getCookie(c, sessionCookieName);
-    const auth = token ? sessions.resolveSession(token) : null;
+    const auth = token ? getSessions().resolveSession(token) : null;
     if (auth) {
       c.set("auth", auth);
     }
@@ -71,7 +77,7 @@ export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
     }
 
     const csrf = c.req.header(csrfHeaderName);
-    if (!csrf || !sessions.verifyCsrf(token, csrf)) {
+    if (!csrf || !getSessions().verifyCsrf(token, csrf)) {
       return c.json({ success: false as const, error: "CSRF token required" }, 403);
     }
     await next();

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,0 +1,96 @@
+import type { MiddlewareHandler } from "hono";
+import { getCookie } from "hono/cookie";
+
+import { AuthSessionService } from "../services/auth-session-service.js";
+import { AuthStorage } from "../services/auth-storage.js";
+import { config } from "../services/config.js";
+import { hasWorkspaceRole, type AuthContext } from "../services/auth-types.js";
+
+declare module "hono" {
+  interface ContextVariableMap {
+    auth?: AuthContext;
+  }
+}
+
+type AuthMiddlewareOptions = {
+  storage?: AuthStorage;
+  ttlSeconds?: number;
+  sessionCookieName?: string;
+  csrfHeaderName?: string;
+};
+
+export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
+  const storage = options.storage ?? new AuthStorage(config.projectRoot);
+  const sessions = new AuthSessionService(storage, {
+    ttlSeconds: options.ttlSeconds ?? config.auth.sessionTtlSeconds,
+  });
+  const sessionCookieName = options.sessionCookieName ?? config.auth.sessionCookieName;
+  const csrfHeaderName = options.csrfHeaderName ?? "X-CSRF-Token";
+
+  const optionalAuth: MiddlewareHandler = async (c, next) => {
+    const token = getCookie(c, sessionCookieName);
+    const auth = token ? sessions.resolveSession(token) : null;
+    if (auth) {
+      c.set("auth", auth);
+    }
+    await next();
+  };
+
+  const requireWorkspaceUser: MiddlewareHandler = async (c, next) => {
+    const auth = c.var.auth;
+    if (!auth) {
+      return c.json({ success: false as const, error: "Authentication required" }, 401);
+    }
+    if (!hasWorkspaceRole(auth.memberships, c.var.workspaceSlug, ["user", "admin"])) {
+      return c.json({ success: false as const, error: "Workspace access required" }, 403);
+    }
+    await next();
+  };
+
+  const requireAdmin: MiddlewareHandler = async (c, next) => {
+    const auth = c.var.auth;
+    if (!auth) {
+      return c.json({ success: false as const, error: "Authentication required" }, 401);
+    }
+    if (!hasWorkspaceRole(auth.memberships, c.var.workspaceSlug, ["admin"])) {
+      return c.json({ success: false as const, error: "Admin access required" }, 403);
+    }
+    await next();
+  };
+
+  const requireCsrf: MiddlewareHandler = async (c, next) => {
+    if (c.req.method === "GET" || c.req.method === "HEAD" || c.req.method === "OPTIONS") {
+      await next();
+      return;
+    }
+
+    const token = getCookie(c, sessionCookieName);
+    const csrf = c.req.header(csrfHeaderName);
+    if (!token || !csrf || !sessions.verifyCsrf(token, csrf)) {
+      return c.json({ success: false as const, error: "CSRF token required" }, 403);
+    }
+    await next();
+  };
+
+  return {
+    optionalAuth,
+    requireWorkspaceUser,
+    requireAdmin,
+    requireCsrf,
+  };
+}
+
+const defaultAuthMiddleware = createAuthMiddleware();
+
+export const optionalAuth = defaultAuthMiddleware.optionalAuth;
+export const requireWorkspaceUser = defaultAuthMiddleware.requireWorkspaceUser;
+export const requireAdmin = defaultAuthMiddleware.requireAdmin;
+export const requireCsrf = defaultAuthMiddleware.requireCsrf;
+
+export function getAuthenticatedActorId(c: { var: { auth?: AuthContext } }): string {
+  const userId = c.var.auth?.user.id;
+  if (!userId) {
+    throw new Error("Authenticated actor required");
+  }
+  return userId;
+}

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -19,6 +19,28 @@ type AuthMiddlewareOptions = {
   csrfHeaderName?: string;
 };
 
+type AdminAccessError = {
+  body: { success: false; error: string };
+  status: 401 | 403;
+};
+
+export function getAdminAccessError(c: { var: { auth?: AuthContext; workspaceSlug: string } }): AdminAccessError | null {
+  const auth = c.var.auth;
+  if (!auth) {
+    return {
+      body: { success: false, error: "Authentication required" },
+      status: 401,
+    };
+  }
+  if (!hasWorkspaceRole(auth.memberships, c.var.workspaceSlug, ["admin"])) {
+    return {
+      body: { success: false, error: "Admin access required" },
+      status: 403,
+    };
+  }
+  return null;
+}
+
 export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
   let storage = options.storage;
   let sessions: AuthSessionService | undefined;
@@ -54,12 +76,9 @@ export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
   };
 
   const requireAdmin: MiddlewareHandler = async (c, next) => {
-    const auth = c.var.auth;
-    if (!auth) {
-      return c.json({ success: false as const, error: "Authentication required" }, 401);
-    }
-    if (!hasWorkspaceRole(auth.memberships, c.var.workspaceSlug, ["admin"])) {
-      return c.json({ success: false as const, error: "Admin access required" }, 403);
+    const adminError = getAdminAccessError(c);
+    if (adminError) {
+      return c.json(adminError.body, adminError.status);
     }
     await next();
   };

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -65,8 +65,13 @@ export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
     }
 
     const token = getCookie(c, sessionCookieName);
+    if (!token) {
+      await next();
+      return;
+    }
+
     const csrf = c.req.header(csrfHeaderName);
-    if (!token || !csrf || !sessions.verifyCsrf(token, csrf)) {
+    if (!csrf || !sessions.verifyCsrf(token, csrf)) {
       return c.json({ success: false as const, error: "CSRF token required" }, 403);
     }
     await next();

--- a/apps/api/src/routes/__tests__/notifications-route.test.ts
+++ b/apps/api/src/routes/__tests__/notifications-route.test.ts
@@ -2,6 +2,10 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import notificationsRoutes from "../notifications";
+import { createAuthMiddleware } from "../../middleware/auth";
+import { workspaceMiddleware } from "../../middleware/workspace";
+import { resetResumeScreeningDb } from "../../services/database";
+import { createAuthHeaders } from "../test-auth-helpers";
 
 vi.mock("../../services/notification-service", () => ({
   notificationService: {
@@ -27,9 +31,14 @@ vi.mock("../../services/ai-matching", () => ({
 }));
 
 function createTestApp() {
+  const auth = createAuthHeaders({ workspaceSlug: "hr", role: "user" });
+  const middleware = createAuthMiddleware({ storage: auth.storage, ttlSeconds: 3600 });
   const app = new OpenAPIHono();
+  app.use("*", workspaceMiddleware);
+  app.use("*", middleware.optionalAuth);
+  app.use("/api/*", middleware.requireCsrf);
   app.route("/api/notifications", notificationsRoutes);
-  return app;
+  return { app, headers: auth.headers };
 }
 
 const jsonHeaders = (extra: Record<string, string> = {}): Record<string, string> => ({
@@ -40,11 +49,12 @@ const jsonHeaders = (extra: Record<string, string> = {}): Record<string, string>
 describe("notifications routes", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    resetResumeScreeningDb();
   });
 
   describe("GET /api/notifications/templates", () => {
     it("returns template list", async () => {
-      const app = createTestApp();
+      const { app } = createTestApp();
       const response = await app.request("/api/notifications/templates");
 
       expect(response.status).toBe(200);
@@ -56,7 +66,7 @@ describe("notifications routes", () => {
 
   describe("POST /api/notifications/draft", () => {
     it("generates outreach draft", async () => {
-      const app = createTestApp();
+      const { app } = createTestApp();
       const response = await app.request("/api/notifications/draft", {
         method: "POST",
         headers: jsonHeaders(),
@@ -73,7 +83,7 @@ describe("notifications routes", () => {
     });
 
     it("returns 400 for invalid body", async () => {
-      const app = createTestApp();
+      const { app } = createTestApp();
       const response = await app.request("/api/notifications/draft", {
         method: "POST",
         headers: jsonHeaders(),
@@ -86,7 +96,7 @@ describe("notifications routes", () => {
 
   describe("POST /api/notifications/preview", () => {
     it("renders email preview", async () => {
-      const app = createTestApp();
+      const { app } = createTestApp();
       const response = await app.request("/api/notifications/preview", {
         method: "POST",
         headers: jsonHeaders(),
@@ -103,7 +113,7 @@ describe("notifications routes", () => {
     });
 
     it("renders feishu preview", async () => {
-      const app = createTestApp();
+      const { app } = createTestApp();
       const response = await app.request("/api/notifications/preview", {
         method: "POST",
         headers: jsonHeaders(),
@@ -123,10 +133,10 @@ describe("notifications routes", () => {
 
   describe("POST /api/notifications/send", () => {
     it("rejects non-admin with 403", async () => {
-      const app = createTestApp();
+      const { app, headers } = createTestApp();
       const response = await app.request("/api/notifications/send", {
         method: "POST",
-        headers: jsonHeaders({ "X-Workspace-Slug": "hr" }),
+        headers: jsonHeaders(headers),
         body: JSON.stringify({ to: "test@example.com", subject: "Hi", body: "Hello" }),
       });
 
@@ -136,10 +146,10 @@ describe("notifications routes", () => {
 
   describe("POST /api/notifications/send-template", () => {
     it("rejects non-admin with 403", async () => {
-      const app = createTestApp();
+      const { app, headers } = createTestApp();
       const response = await app.request("/api/notifications/send-template", {
         method: "POST",
-        headers: jsonHeaders({ "X-Workspace-Slug": "hr" }),
+        headers: jsonHeaders(headers),
         body: JSON.stringify({
           channel: "feishu",
           templateId: "test-template",

--- a/apps/api/src/routes/__tests__/resumes-packets-route.test.ts
+++ b/apps/api/src/routes/__tests__/resumes-packets-route.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import Papa from "papaparse";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { createAuthContext } from "../test-auth-helpers";
 import type { ResumeItem } from "../types/resume.js";
 
 function createFixtureRoot(): string {
@@ -95,6 +96,10 @@ async function loadModules(root: string) {
   };
 }
 
+function createAdminApp(createApp: Awaited<ReturnType<typeof loadModules>>["createApp"]) {
+  return createApp({ authContext: createAuthContext({ workspaceSlug: "dev", role: "admin" }) });
+}
+
 describe("resumes packets route", () => {
   let root = "";
 
@@ -116,7 +121,7 @@ describe("resumes packets route", () => {
   it("returns empty list when no runs exist", async () => {
     root = createFixtureRoot();
     const { createApp } = await loadModules(root);
-    const app = createApp();
+    const app = createAdminApp(createApp);
 
     const response = await app.request("/api/resumes/review-packets", {
       headers: { "X-Workspace-Slug": "dev" },
@@ -150,7 +155,7 @@ describe("resumes packets route", () => {
       items: [],
     });
 
-    const app = createApp();
+    const app = createAdminApp(createApp);
     const response = await app.request("/api/resumes/review-packets", {
       headers: { "X-Workspace-Slug": "dev" },
     });
@@ -173,7 +178,7 @@ describe("resumes packets route", () => {
     storage.createRun({ id: "run-lim-2", workspaceSlug: "dev", source: "convex", format: "csv", totalCount: 1, items: [] });
     storage.createRun({ id: "run-lim-3", workspaceSlug: "dev", source: "convex", format: "csv", totalCount: 1, items: [] });
 
-    const app = createApp();
+    const app = createAdminApp(createApp);
     const response = await app.request("/api/resumes/review-packets?limit=2", {
       headers: { "X-Workspace-Slug": "dev" },
     });
@@ -203,7 +208,7 @@ describe("resumes packets route", () => {
       items: [{ resumeId: "r1", identityKey: "k1" }],
     });
 
-    const app = createApp();
+    const app = createAdminApp(createApp);
     const response = await app.request("/api/resumes/review-packets/my-run", {
       headers: { "X-Workspace-Slug": "dev" },
     });
@@ -219,7 +224,7 @@ describe("resumes packets route", () => {
   it("returns 404 when run not found", async () => {
     root = createFixtureRoot();
     const { createApp } = await loadModules(root);
-    const app = createApp();
+    const app = createAdminApp(createApp);
 
     const response = await app.request("/api/resumes/review-packets/nonexistent", {
       headers: { "X-Workspace-Slug": "dev" },
@@ -254,7 +259,7 @@ describe("resumes packets route", () => {
     fs.mkdirSync(packetDir, { recursive: true });
     fs.writeFileSync(path.join(packetDir, "review-packet-csv-run.csv"), "Resume ID,Name\nr1,Alice\n", "utf8");
 
-    const app = createApp();
+    const app = createAdminApp(createApp);
     const response = await app.request("/api/resumes/review-packets/csv-run/download?workspaceSlug=dev");
 
     expect(response.status).toBe(200);
@@ -287,7 +292,7 @@ describe("resumes packets route", () => {
     fs.mkdirSync(packetDir, { recursive: true });
     fs.writeFileSync(path.join(packetDir, "review-packet-xlsx-run.xlsx"), "fake-xlsx-content");
 
-    const app = createApp();
+    const app = createAdminApp(createApp);
     const response = await app.request("/api/resumes/review-packets/xlsx-run/download?workspaceSlug=dev");
 
     expect(response.status).toBe(200);
@@ -302,7 +307,7 @@ describe("resumes packets route", () => {
   it("returns 404 when download run not found", async () => {
     root = createFixtureRoot();
     const { createApp } = await loadModules(root);
-    const app = createApp();
+    const app = createAdminApp(createApp);
 
     const response = await app.request("/api/resumes/review-packets/nonexistent/download?workspaceSlug=dev");
 
@@ -326,7 +331,7 @@ describe("resumes packets route", () => {
       items: [{ resumeId: "r1", identityKey: "k1" }],
     });
 
-    const app = createApp();
+    const app = createAdminApp(createApp);
     const response = await app.request("/api/resumes/review-packets/missing-file/download?workspaceSlug=dev");
 
     expect(response.status).toBe(404);
@@ -355,7 +360,7 @@ describe("resumes packets route", () => {
 
     const formData = new FormData();
 
-    const app = createApp();
+    const app = createAdminApp(createApp);
     const response = await app.request("/api/resumes/review-packets/fb-no-file/feedback-import", {
       method: "POST",
       headers: { "X-Workspace-Slug": "dev" },
@@ -372,7 +377,7 @@ describe("resumes packets route", () => {
     const formData = new FormData();
     formData.append("file", new File(["Resume ID\nr1"], "test.csv", { type: "text/csv" }));
 
-    const app = createApp();
+    const app = createAdminApp(createApp);
     const response = await app.request("/api/resumes/review-packets/nonexistent-fb/feedback-import", {
       method: "POST",
       headers: { "X-Workspace-Slug": "dev" },
@@ -393,7 +398,7 @@ describe("resumes packets route", () => {
     root = createFixtureRoot();
     const { createApp } = await loadModules(root);
 
-    const app = createApp();
+    const app = createAdminApp(createApp);
     const response = await app.request("/api/resumes/learning-feedback", {
       method: "POST",
       headers: {
@@ -417,7 +422,7 @@ describe("resumes packets route", () => {
       observation: "Test observation",
     });
 
-    const app = createApp();
+    const app = createAdminApp(createApp);
     const response = await app.request("/api/resumes/learning-feedback", {
       method: "POST",
       headers: {
@@ -451,7 +456,7 @@ describe("resumes packets route", () => {
       );
     });
 
-    const app = createApp();
+    const app = createAdminApp(createApp);
     const response = await app.request("/api/resumes/learning-feedback", {
       method: "POST",
       headers: {
@@ -513,7 +518,7 @@ describe("resumes packets route", () => {
       })
     );
 
-    const app = createApp();
+    const app = createAdminApp(createApp);
     const response = await app.request("/api/resumes/export/download", {
       method: "POST",
       headers: { "X-Workspace-Slug": "dev" },

--- a/apps/api/src/routes/actions.test.ts
+++ b/apps/api/src/routes/actions.test.ts
@@ -2,12 +2,21 @@ import { OpenAPIHono } from '@hono/zod-openapi'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import actionsRoutes from './actions'
+import { createAuthMiddleware } from '../middleware/auth'
 import { workspaceMiddleware } from '../middleware/workspace'
 import { ActionStorage } from '../services/action-storage'
+import type { AuthStorage } from '../services/auth-storage'
+import { resetResumeScreeningDb } from '../services/database'
+import { createAuthHeaders } from './test-auth-helpers'
 
-function createTestApp() {
+function createTestApp(storage?: AuthStorage) {
   const app = new OpenAPIHono()
   app.use('*', workspaceMiddleware)
+  if (storage) {
+    const middleware = createAuthMiddleware({ storage, ttlSeconds: 3600 })
+    app.use('*', middleware.optionalAuth)
+    app.use('/api/*', middleware.requireCsrf)
+  }
   app.route('/', actionsRoutes)
   return app
 }
@@ -27,11 +36,12 @@ const MOCK_ACTIONS = [
 describe('actions routes', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    resetResumeScreeningDb()
   })
 
   describe('POST /api/actions', () => {
-    it('creates a star action', async () => {
-      vi.spyOn(ActionStorage.prototype, 'saveAction').mockReturnValue(MOCK_ACTION as never)
+    it('rejects writes without a session', async () => {
+      const saveSpy = vi.spyOn(ActionStorage.prototype, 'saveAction').mockReturnValue(MOCK_ACTION as never)
       const app = createTestApp()
       const response = await app.request('/api/actions', {
         method: 'POST',
@@ -44,20 +54,51 @@ describe('actions routes', () => {
           actionType: 'star',
         }),
       })
+      expect(response.status).toBe(401)
+      expect(saveSpy).not.toHaveBeenCalled()
+    })
+
+    it('creates a star action with the authenticated actor', async () => {
+      const auth = createAuthHeaders({ workspaceSlug: 'hr', role: 'user' })
+      const saveSpy = vi.spyOn(ActionStorage.prototype, 'saveAction').mockReturnValue({
+        ...MOCK_ACTION,
+        userId: auth.userId,
+      } as never)
+      const app = createTestApp(auth.storage)
+      const response = await app.request('/api/actions', {
+        method: 'POST',
+        headers: {
+          ...auth.headers,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          userId: 'body-user',
+          resumeId: 'resume-123',
+          actionType: 'star',
+        }),
+      })
       expect(response.status).toBe(200)
       const body = await response.json()
       expect(body.success).toBe(true)
       expect(body.action.actionType).toBe('star')
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: auth.userId,
+          resumeId: 'resume-123',
+          actionType: 'star',
+        }),
+      )
     })
 
     it('creates an action with optional data', async () => {
+      const auth = createAuthHeaders({ workspaceSlug: 'hr', role: 'user' })
       const saveSpy = vi.spyOn(ActionStorage.prototype, 'saveAction').mockReturnValue(MOCK_ACTION as never)
-      const app = createTestApp()
+      const app = createTestApp(auth.storage)
       await app.request('/api/actions', {
         method: 'POST',
         headers: {
+          ...auth.headers,
           'Content-Type': 'application/json',
-          'X-Workspace-Slug': 'dev',
         },
         body: JSON.stringify({
           resumeId: 'resume-123',
@@ -71,6 +112,25 @@ describe('actions routes', () => {
           actionData: { text: 'Great candidate' },
         }),
       )
+    })
+
+    it('rejects authenticated users outside the selected workspace', async () => {
+      const auth = createAuthHeaders({ workspaceSlug: 'hr', requestWorkspaceSlug: 'dev', role: 'user' })
+      const saveSpy = vi.spyOn(ActionStorage.prototype, 'saveAction').mockReturnValue(MOCK_ACTION as never)
+      const app = createTestApp(auth.storage)
+      const response = await app.request('/api/actions', {
+        method: 'POST',
+        headers: {
+          ...auth.headers,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          resumeId: 'resume-123',
+          actionType: 'star',
+        }),
+      })
+      expect(response.status).toBe(403)
+      expect(saveSpy).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/api/src/routes/actions.ts
+++ b/apps/api/src/routes/actions.ts
@@ -2,9 +2,17 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
 import { config } from "../services/config.js";
 import { ActionStorage } from "../services/action-storage.js";
+import { getAuthenticatedActorId, requireWorkspaceUser } from "../middleware/auth.js";
 
 const app = new OpenAPIHono();
 const actionStorage = new ActionStorage(config.projectRoot);
+
+app.use("/api/actions", async (c, next) => {
+  if (c.req.method === "POST") {
+    return requireWorkspaceUser(c, next);
+  }
+  await next();
+});
 
 const ActionTypeSchema = z.enum([
   "star",
@@ -84,7 +92,7 @@ const createActionRoute = createRoute({
 app.openapi(createActionRoute, (c) => {
   const body = c.req.valid("json");
   const action = actionStorage.saveAction({
-    userId: body.userId,
+    userId: getAuthenticatedActorId(c),
     sessionId: body.sessionId,
     resumeId: body.resumeId,
     actionType: body.actionType,

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1,0 +1,136 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createAuthMiddleware } from "../middleware/auth.js";
+import { workspaceMiddleware } from "../middleware/workspace.js";
+import { AuthSessionService } from "../services/auth-session-service.js";
+import { AuthStorage } from "../services/auth-storage.js";
+import { config } from "../services/config.js";
+import { resetResumeScreeningDb } from "../services/database.js";
+import { hashPassword } from "../services/local-password-provider.js";
+import { createAuthRoutes } from "./auth.js";
+
+async function seedLocalUser(storage: AuthStorage) {
+  const user = storage.createUser({ email: "hr@example.com", displayName: "HR Admin" });
+  storage.linkIdentity({
+    userId: user.id,
+    provider: "local",
+    providerSubject: "hr-admin",
+    providerTenant: "local",
+    email: user.email,
+    displayName: user.displayName,
+  });
+  storage.upsertMembership({ userId: user.id, workspaceSlug: "hr", role: "admin" });
+  storage.savePasswordCredential({
+    userId: user.id,
+    ...(await hashPassword("secret-pass")),
+    mustChangePassword: false,
+  });
+  return user;
+}
+
+function createTestApp(storage: AuthStorage) {
+  const middleware = createAuthMiddleware({ storage, ttlSeconds: 3600 });
+  const app = new OpenAPIHono();
+  app.use("*", workspaceMiddleware);
+  app.use("*", middleware.optionalAuth);
+  app.use("/api/*", middleware.requireCsrf);
+  app.route("/", createAuthRoutes({ storage, ttlSeconds: 3600 }));
+  return app;
+}
+
+function readCookie(response: Response, name: string): string {
+  const setCookie = response.headers.get("Set-Cookie") ?? "";
+  const match = setCookie.match(new RegExp(`${name}=([^;]*)`));
+  expect(match).not.toBeNull();
+  return `${name}=${match?.[1] ?? ""}`;
+}
+
+describe("auth routes", () => {
+  afterEach(() => {
+    resetResumeScreeningDb();
+  });
+
+  it("logs in local users and sets auth and csrf cookies", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-routes-"));
+    const storage = new AuthStorage(root);
+    await seedLocalUser(storage);
+    const app = createTestApp(storage);
+
+    const response = await app.request("/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Workspace-Slug": "hr" },
+      body: JSON.stringify({ username: "hr-admin", password: "secret-pass" }),
+    });
+
+    expect(response.status).toBe(200);
+    const setCookie = response.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain(`${config.auth.sessionCookieName}=`);
+    expect(setCookie).toContain(`${config.auth.csrfCookieName}=`);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      csrfToken: expect.any(String),
+      user: { email: "hr@example.com" },
+    });
+  });
+
+  it("returns current user and active workspace role", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-routes-"));
+    const storage = new AuthStorage(root);
+    const user = await seedLocalUser(storage);
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(user.id);
+    const app = createTestApp(storage);
+
+    const response = await app.request("/api/auth/me", {
+      headers: {
+        "X-Workspace-Slug": "hr",
+        Cookie: `${config.auth.sessionCookieName}=${session.token}`,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      workspaceRole: "admin",
+      user: { id: user.id, email: "hr@example.com" },
+      memberships: [{ workspaceSlug: "hr", role: "admin" }],
+    });
+  });
+
+  it("keeps casdoor login disabled when OIDC is not enabled", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-routes-"));
+    const storage = new AuthStorage(root);
+    const app = createTestApp(storage);
+
+    const response = await app.request("/api/auth/casdoor/login");
+
+    expect(response.status).toBe(404);
+  });
+
+  it("revokes the current session on logout", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-routes-"));
+    const storage = new AuthStorage(root);
+    const user = await seedLocalUser(storage);
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(user.id);
+    const app = createTestApp(storage);
+
+    const response = await app.request("/api/auth/logout", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "hr",
+        "X-CSRF-Token": session.csrfToken,
+        Cookie: `${config.auth.sessionCookieName}=${session.token}`,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(sessions.resolveSession(session.token)).toBeNull();
+    expect(readCookie(response, config.auth.sessionCookieName)).toBe(`${config.auth.sessionCookieName}=`);
+  });
+});

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,0 +1,413 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+
+import { AuthSessionService } from "../services/auth-session-service.js";
+import { AuthStorage } from "../services/auth-storage.js";
+import type { AuthContext, AuthUser, WorkspaceRole } from "../services/auth-types.js";
+import { config } from "../services/config.js";
+import { hashPassword, verifyPassword } from "../services/local-password-provider.js";
+import { CasdoorOidcProvider } from "../services/oidc-provider.js";
+
+type AuthRoutesOptions = {
+  storage?: AuthStorage;
+  ttlSeconds?: number;
+  oidcEnabled?: boolean;
+  oidcProvider?: CasdoorOidcProvider;
+};
+
+const cookieOptions = {
+  httpOnly: true,
+  sameSite: "Lax" as const,
+  secure: config.auth.secureCookies,
+  path: "/",
+};
+
+const csrfCookieOptions = {
+  sameSite: "Lax" as const,
+  secure: config.auth.secureCookies,
+  path: "/",
+};
+
+const ErrorResponseSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+});
+
+const AuthUserSchema = z.object({
+  id: z.string(),
+  email: z.string().optional(),
+  displayName: z.string().optional(),
+  status: z.enum(["active", "disabled"]),
+});
+
+const MembershipSchema = z.object({
+  userId: z.string(),
+  workspaceSlug: z.string(),
+  role: z.enum(["user", "admin"]),
+});
+
+const LoginRequestSchema = z.object({
+  username: z.string().min(1),
+  password: z.string().min(1),
+});
+
+const LoginResponseSchema = z.object({
+  success: z.literal(true),
+  user: AuthUserSchema,
+  memberships: z.array(MembershipSchema),
+  csrfToken: z.string(),
+  expiresAt: z.string(),
+});
+
+const MeResponseSchema = z.object({
+  success: z.literal(true),
+  user: AuthUserSchema,
+  memberships: z.array(MembershipSchema),
+  workspaceRole: z.enum(["user", "admin"]).nullable(),
+});
+
+const ChangePasswordRequestSchema = z.object({
+  currentPassword: z.string().min(1),
+  newPassword: z.string().min(8),
+});
+
+const SuccessResponseSchema = z.object({
+  success: z.literal(true),
+});
+
+const RedirectQuerySchema = z.object({
+  redirectTo: z.string().optional(),
+});
+
+function sanitizeRedirect(value: string | undefined): string {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) {
+    return "/";
+  }
+  return value;
+}
+
+function getWorkspaceRole(auth: AuthContext, workspaceSlug: string): WorkspaceRole | null {
+  return auth.memberships.find((membership) => membership.workspaceSlug === workspaceSlug)?.role ?? null;
+}
+
+function setSessionCookies(
+  c: Parameters<typeof setCookie>[0],
+  session: { token: string; csrfToken: string; expiresAt: string },
+): void {
+  const expires = new Date(session.expiresAt);
+  setCookie(c, config.auth.sessionCookieName, session.token, { ...cookieOptions, expires });
+  setCookie(c, config.auth.csrfCookieName, session.csrfToken, { ...csrfCookieOptions, expires });
+}
+
+function clearSessionCookies(c: Parameters<typeof deleteCookie>[0]): void {
+  deleteCookie(c, config.auth.sessionCookieName, { path: "/" });
+  deleteCookie(c, config.auth.csrfCookieName, { path: "/" });
+}
+
+async function createSessionResponse(
+  user: AuthUser,
+  storage: AuthStorage,
+  sessions: AuthSessionService,
+  c: Parameters<typeof setCookie>[0],
+) {
+  const session = sessions.createSession(user.id);
+  setSessionCookies(c, session);
+
+  return {
+    success: true as const,
+    user,
+    memberships: storage.listMemberships(user.id),
+    csrfToken: session.csrfToken,
+    expiresAt: session.expiresAt,
+  };
+}
+
+export function createAuthRoutes(options: AuthRoutesOptions = {}) {
+  const app = new OpenAPIHono();
+  const storage = options.storage ?? new AuthStorage(config.projectRoot);
+  const sessions = new AuthSessionService(storage, {
+    ttlSeconds: options.ttlSeconds ?? config.auth.sessionTtlSeconds,
+  });
+  const oidcEnabled = options.oidcEnabled ?? config.auth.oidc.enabled;
+  const oidcProvider = options.oidcProvider ?? new CasdoorOidcProvider(config.auth.oidc);
+
+  const loginRoute = createRoute({
+    method: "post",
+    path: "/api/auth/login",
+    tags: ["auth"],
+    request: {
+      body: {
+        content: {
+          "application/json": {
+            schema: LoginRequestSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Authenticated local user",
+        content: {
+          "application/json": {
+            schema: LoginResponseSchema,
+          },
+        },
+      },
+      401: {
+        description: "Invalid credentials",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  app.openapi(loginRoute, async (c) => {
+    const { username, password } = c.req.valid("json");
+    const identity = storage.findIdentity("local", username, "local");
+    const credential = identity ? storage.findPasswordCredential(identity.userId) : null;
+    const user = identity ? storage.findUser(identity.userId) : null;
+
+    if (!credential || !user || !(await verifyPassword(password, credential))) {
+      return c.json({ success: false as const, error: "Invalid username or password" }, 401);
+    }
+
+    return c.json(await createSessionResponse(user, storage, sessions, c), 200);
+  });
+
+  const meRoute = createRoute({
+    method: "get",
+    path: "/api/auth/me",
+    tags: ["auth"],
+    responses: {
+      200: {
+        description: "Current authenticated user",
+        content: {
+          "application/json": {
+            schema: MeResponseSchema,
+          },
+        },
+      },
+      401: {
+        description: "Authentication required",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  app.openapi(meRoute, (c) => {
+    const auth = c.var.auth;
+    if (!auth) {
+      return c.json({ success: false as const, error: "Authentication required" }, 401);
+    }
+
+    return c.json({
+      success: true as const,
+      user: auth.user,
+      memberships: auth.memberships,
+      workspaceRole: getWorkspaceRole(auth, c.var.workspaceSlug),
+    }, 200);
+  });
+
+  const logoutRoute = createRoute({
+    method: "post",
+    path: "/api/auth/logout",
+    tags: ["auth"],
+    responses: {
+      200: {
+        description: "Session revoked",
+        content: {
+          "application/json": {
+            schema: SuccessResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  app.openapi(logoutRoute, (c) => {
+    const token = getCookie(c, config.auth.sessionCookieName);
+    if (token) {
+      sessions.revokeSession(token);
+    }
+    clearSessionCookies(c);
+    return c.json({ success: true as const }, 200);
+  });
+
+  const changePasswordRoute = createRoute({
+    method: "post",
+    path: "/api/auth/change-password",
+    tags: ["auth"],
+    request: {
+      body: {
+        content: {
+          "application/json": {
+            schema: ChangePasswordRequestSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Password changed",
+        content: {
+          "application/json": {
+            schema: SuccessResponseSchema,
+          },
+        },
+      },
+      401: {
+        description: "Authentication required",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      403: {
+        description: "Current password invalid",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  app.openapi(changePasswordRoute, async (c) => {
+    const auth = c.var.auth;
+    if (!auth) {
+      return c.json({ success: false as const, error: "Authentication required" }, 401);
+    }
+
+    const { currentPassword, newPassword } = c.req.valid("json");
+    const credential = storage.findPasswordCredential(auth.user.id);
+    if (!credential || !(await verifyPassword(currentPassword, credential))) {
+      return c.json({ success: false as const, error: "Current password is incorrect" }, 403);
+    }
+
+    storage.savePasswordCredential({
+      userId: auth.user.id,
+      ...(await hashPassword(newPassword)),
+      mustChangePassword: false,
+    });
+    return c.json({ success: true as const }, 200);
+  });
+
+  const casdoorLoginRoute = createRoute({
+    method: "get",
+    path: "/api/auth/casdoor/login",
+    tags: ["auth"],
+    request: {
+      query: RedirectQuerySchema,
+    },
+    responses: {
+      302: {
+        description: "Redirect to Casdoor authorization URL",
+      },
+      404: {
+        description: "OIDC disabled",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  app.openapi(casdoorLoginRoute, async (c) => {
+    if (!oidcEnabled) {
+      return c.json({ success: false as const, error: "Casdoor login is disabled" }, 404);
+    }
+
+    const { redirectTo } = c.req.valid("query");
+    const result = await oidcProvider.buildLoginUrl(
+      sanitizeRedirect(redirectTo),
+      (state) => storage.saveOidcState(state),
+    );
+    return c.redirect(result.url.href, 302);
+  });
+
+  const casdoorCallbackRoute = createRoute({
+    method: "get",
+    path: "/api/auth/casdoor/callback",
+    tags: ["auth"],
+    responses: {
+      302: {
+        description: "Redirect after successful OIDC callback",
+      },
+      400: {
+        description: "Invalid OIDC callback",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      404: {
+        description: "OIDC disabled",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  app.openapi(casdoorCallbackRoute, async (c) => {
+    if (!oidcEnabled) {
+      return c.json({ success: false as const, error: "Casdoor login is disabled" }, 404);
+    }
+
+    const stateValue = c.req.query("state");
+    if (!stateValue) {
+      return c.json({ success: false as const, error: "OIDC state is required" }, 400);
+    }
+
+    const storedState = storage.consumeOidcState(stateValue);
+    if (!storedState) {
+      return c.json({ success: false as const, error: "OIDC state is invalid or expired" }, 400);
+    }
+
+    const identity = await oidcProvider.handleCallback(new URL(c.req.url), storedState);
+    const existing = storage.findIdentity(
+      identity.provider,
+      identity.providerSubject,
+      identity.providerTenant,
+    );
+    const user = existing
+      ? storage.findUser(existing.userId)
+      : storage.createUser({ email: identity.email, displayName: identity.displayName });
+
+    if (!user) {
+      return c.json({ success: false as const, error: "OIDC user is disabled" }, 403);
+    }
+
+    storage.linkIdentity({
+      userId: user.id,
+      provider: identity.provider,
+      providerSubject: identity.providerSubject,
+      providerTenant: identity.providerTenant,
+      email: identity.email,
+      displayName: identity.displayName,
+      rawProfile: identity.rawProfile,
+    });
+
+    const session = sessions.createSession(user.id);
+    setSessionCookies(c, session);
+    return c.redirect(sanitizeRedirect(storedState.redirectTo), 302);
+  });
+
+  return app;
+}
+
+export default createAuthRoutes();

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -124,12 +124,22 @@ async function createSessionResponse(
 
 export function createAuthRoutes(options: AuthRoutesOptions = {}) {
   const app = new OpenAPIHono();
-  const storage = options.storage ?? new AuthStorage(config.projectRoot);
-  const sessions = new AuthSessionService(storage, {
-    ttlSeconds: options.ttlSeconds ?? config.auth.sessionTtlSeconds,
-  });
+  let storage = options.storage;
+  let sessions: AuthSessionService | undefined;
   const oidcEnabled = options.oidcEnabled ?? config.auth.oidc.enabled;
   const oidcProvider = options.oidcProvider ?? new CasdoorOidcProvider(config.auth.oidc);
+
+  function getStorage(): AuthStorage {
+    storage ??= new AuthStorage(config.projectRoot);
+    return storage;
+  }
+
+  function getSessions(): AuthSessionService {
+    sessions ??= new AuthSessionService(getStorage(), {
+      ttlSeconds: options.ttlSeconds ?? config.auth.sessionTtlSeconds,
+    });
+    return sessions;
+  }
 
   const loginRoute = createRoute({
     method: "post",
@@ -166,15 +176,16 @@ export function createAuthRoutes(options: AuthRoutesOptions = {}) {
 
   app.openapi(loginRoute, async (c) => {
     const { username, password } = c.req.valid("json");
-    const identity = storage.findIdentity("local", username, "local");
-    const credential = identity ? storage.findPasswordCredential(identity.userId) : null;
-    const user = identity ? storage.findUser(identity.userId) : null;
+    const authStorage = getStorage();
+    const identity = authStorage.findIdentity("local", username, "local");
+    const credential = identity ? authStorage.findPasswordCredential(identity.userId) : null;
+    const user = identity ? authStorage.findUser(identity.userId) : null;
 
     if (!credential || !user || !(await verifyPassword(password, credential))) {
       return c.json({ success: false as const, error: "Invalid username or password" }, 401);
     }
 
-    return c.json(await createSessionResponse(user, storage, sessions, c), 200);
+    return c.json(await createSessionResponse(user, authStorage, getSessions(), c), 200);
   });
 
   const meRoute = createRoute({
@@ -234,7 +245,7 @@ export function createAuthRoutes(options: AuthRoutesOptions = {}) {
   app.openapi(logoutRoute, (c) => {
     const token = getCookie(c, config.auth.sessionCookieName);
     if (token) {
-      sessions.revokeSession(token);
+      getSessions().revokeSession(token);
     }
     clearSessionCookies(c);
     return c.json({ success: true as const }, 200);
@@ -288,12 +299,13 @@ export function createAuthRoutes(options: AuthRoutesOptions = {}) {
     }
 
     const { currentPassword, newPassword } = c.req.valid("json");
-    const credential = storage.findPasswordCredential(auth.user.id);
+    const authStorage = getStorage();
+    const credential = authStorage.findPasswordCredential(auth.user.id);
     if (!credential || !(await verifyPassword(currentPassword, credential))) {
       return c.json({ success: false as const, error: "Current password is incorrect" }, 403);
     }
 
-    storage.savePasswordCredential({
+    authStorage.savePasswordCredential({
       userId: auth.user.id,
       ...(await hashPassword(newPassword)),
       mustChangePassword: false,
@@ -331,7 +343,7 @@ export function createAuthRoutes(options: AuthRoutesOptions = {}) {
     const { redirectTo } = c.req.valid("query");
     const result = await oidcProvider.buildLoginUrl(
       sanitizeRedirect(redirectTo),
-      (state) => storage.saveOidcState(state),
+      (state) => getStorage().saveOidcState(state),
     );
     return c.redirect(result.url.href, 302);
   });
@@ -373,26 +385,27 @@ export function createAuthRoutes(options: AuthRoutesOptions = {}) {
       return c.json({ success: false as const, error: "OIDC state is required" }, 400);
     }
 
-    const storedState = storage.consumeOidcState(stateValue);
+    const authStorage = getStorage();
+    const storedState = authStorage.consumeOidcState(stateValue);
     if (!storedState) {
       return c.json({ success: false as const, error: "OIDC state is invalid or expired" }, 400);
     }
 
     const identity = await oidcProvider.handleCallback(new URL(c.req.url), storedState);
-    const existing = storage.findIdentity(
+    const existing = authStorage.findIdentity(
       identity.provider,
       identity.providerSubject,
       identity.providerTenant,
     );
     const user = existing
-      ? storage.findUser(existing.userId)
-      : storage.createUser({ email: identity.email, displayName: identity.displayName });
+      ? authStorage.findUser(existing.userId)
+      : authStorage.createUser({ email: identity.email, displayName: identity.displayName });
 
     if (!user) {
       return c.json({ success: false as const, error: "OIDC user is disabled" }, 403);
     }
 
-    storage.linkIdentity({
+    authStorage.linkIdentity({
       userId: user.id,
       provider: identity.provider,
       providerSubject: identity.providerSubject,
@@ -402,7 +415,7 @@ export function createAuthRoutes(options: AuthRoutesOptions = {}) {
       rawProfile: identity.rawProfile,
     });
 
-    const session = sessions.createSession(user.id);
+    const session = getSessions().createSession(user.id);
     setSessionCookies(c, session);
     return c.redirect(sanitizeRedirect(storedState.redirectTo), 302);
   });

--- a/apps/api/src/routes/blocks.test.ts
+++ b/apps/api/src/routes/blocks.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createApp } from '../app'
+import { resetResumeScreeningDb } from '../services/database'
+import { createAuthHeaders } from './test-auth-helpers'
 
 type ConvexCall = {
   type: 'query' | 'mutation'
@@ -56,6 +58,7 @@ function convexSuccess(value: unknown): Response {
 describe('blocks route', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    resetResumeScreeningDb()
   })
 
   it('respects workspace isolation via X-Workspace-Slug on list', async () => {
@@ -85,7 +88,43 @@ describe('blocks route', () => {
     expect(calls[1]?.args.workspaceSlug).toBe('dev')
   })
 
-  it('passes hr workspace slug through bulk block requests', async () => {
+  it('rejects block mutations without a session', async () => {
+    const calls: ConvexCall[] = []
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      calls.push(parseConvexCall(input, init))
+      return convexSuccess(null)
+    })
+
+    const app = createApp()
+    const postResponse = await app.request('/api/blocks', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Workspace-Slug': 'hr',
+      },
+      body: JSON.stringify({ identityKey: 'resume-1' }),
+    })
+    const patchResponse = await app.request('/api/blocks', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Workspace-Slug': 'hr',
+      },
+      body: JSON.stringify({ identityKey: 'resume-1', reason: 'duplicate' }),
+    })
+    const deleteResponse = await app.request('/api/blocks?identityKey=resume-1', {
+      method: 'DELETE',
+      headers: { 'X-Workspace-Slug': 'hr' },
+    })
+
+    expect(postResponse.status).toBe(401)
+    expect(patchResponse.status).toBe(401)
+    expect(deleteResponse.status).toBe(401)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('passes hr workspace slug and authenticated actor through bulk block requests', async () => {
+    const auth = createAuthHeaders({ workspaceSlug: 'hr', role: 'user' })
     const calls: ConvexCall[] = []
 
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
@@ -99,17 +138,17 @@ describe('blocks route', () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`)
     })
 
-    const app = createApp()
+    const app = createApp({ authStorage: auth.storage })
     const response = await app.request('/api/blocks', {
       method: 'POST',
       headers: {
+        ...auth.headers,
         'Content-Type': 'application/json',
-        'X-Workspace-Slug': 'hr',
       },
       body: JSON.stringify({
         identityKeys: ['resume-1', 'resume-2', 'resume-1'],
         reason: 'duplicate applicants',
-        blockedBy: 'hr-user',
+        blockedBy: 'body-user',
       }),
     })
 
@@ -130,12 +169,35 @@ describe('blocks route', () => {
         workspaceSlug: 'hr',
         identityKeys: ['resume-1', 'resume-2'],
         reason: 'duplicate applicants',
-        blockedBy: 'hr-user',
+        blockedBy: auth.userId,
       },
     })
   })
 
-  it('uses the default dev workspace when unblocking without a header', async () => {
+  it('rejects authenticated users outside the selected workspace', async () => {
+    const auth = createAuthHeaders({ workspaceSlug: 'hr', requestWorkspaceSlug: 'dev', role: 'user' })
+    const calls: ConvexCall[] = []
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      calls.push(parseConvexCall(input, init))
+      return convexSuccess(null)
+    })
+
+    const app = createApp({ authStorage: auth.storage })
+    const response = await app.request('/api/blocks', {
+      method: 'POST',
+      headers: {
+        ...auth.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ identityKey: 'resume-1' }),
+    })
+
+    expect(response.status).toBe(403)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('uses the default dev workspace when unblocking with dev auth', async () => {
+    const auth = createAuthHeaders({ workspaceSlug: 'dev', role: 'user' })
     const calls: ConvexCall[] = []
 
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
@@ -149,9 +211,10 @@ describe('blocks route', () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`)
     })
 
-    const app = createApp()
+    const app = createApp({ authStorage: auth.storage })
     const response = await app.request('/api/blocks?identityKey=resume-7', {
       method: 'DELETE',
+      headers: auth.headers,
     })
 
     expect(response.status).toBe(200)

--- a/apps/api/src/routes/blocks.ts
+++ b/apps/api/src/routes/blocks.ts
@@ -5,8 +5,16 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
 
 import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
+import { getAuthenticatedActorId, requireWorkspaceUser } from "../middleware/auth.js";
 
 const app = new OpenAPIHono();
+
+app.use("/api/blocks", async (c, next) => {
+  if (c.req.method === "POST" || c.req.method === "PATCH" || c.req.method === "DELETE") {
+    return requireWorkspaceUser(c, next);
+  }
+  await next();
+});
 
 
 const CandidateBlockSchema = z.object({
@@ -27,7 +35,6 @@ const UpsertBlockRequestSchema = z.object({
   identityKey: z.string().optional(),
   identityKeys: z.array(z.string()).optional(),
   reason: z.string().optional(),
-  blockedBy: z.string().optional(),
 });
 
 const PatchBlockRequestSchema = z.object({
@@ -105,6 +112,7 @@ const upsertRoute = createRoute({
 
 app.openapi(upsertRoute, async (c) => {
   const body = c.req.valid("json");
+  const actorId = getAuthenticatedActorId(c);
   const identityKeys = Array.from(
     new Set((body.identityKeys ?? []).map((key) => key.trim()).filter((key) => key.length > 0))
   );
@@ -121,7 +129,7 @@ app.openapi(upsertRoute, async (c) => {
       workspaceSlug: c.var.workspaceSlug,
       identityKey: identityKeys[0],
       reason: body.reason,
-      blockedBy: body.blockedBy,
+      blockedBy: actorId,
     });
 
     return c.json({
@@ -137,7 +145,7 @@ app.openapi(upsertRoute, async (c) => {
     workspaceSlug: c.var.workspaceSlug,
     identityKeys,
     reason: body.reason,
-    blockedBy: body.blockedBy,
+    blockedBy: actorId,
   });
 
   const normalized = isRecord(result) ? result : {};

--- a/apps/api/src/routes/blocks.ts
+++ b/apps/api/src/routes/blocks.ts
@@ -5,6 +5,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
 
 import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
+import { config } from "../services/config.js";
 import { getAuthenticatedActorId, requireWorkspaceUser } from "../middleware/auth.js";
 
 const app = new OpenAPIHono();
@@ -130,6 +131,7 @@ app.openapi(upsertRoute, async (c) => {
       identityKey: identityKeys[0],
       reason: body.reason,
       blockedBy: actorId,
+      writeSecret: config.auth.convexWriteSecret,
     });
 
     return c.json({
@@ -146,6 +148,7 @@ app.openapi(upsertRoute, async (c) => {
     identityKeys,
     reason: body.reason,
     blockedBy: actorId,
+    writeSecret: config.auth.convexWriteSecret,
   });
 
   const normalized = isRecord(result) ? result : {};
@@ -192,6 +195,7 @@ app.openapi(patchRoute, async (c) => {
     workspaceSlug: c.var.workspaceSlug,
     identityKey,
     reason: body.reason,
+    writeSecret: config.auth.convexWriteSecret,
   });
 
   return c.json({ success: true as const, updated: updated === true }, 200);
@@ -218,6 +222,7 @@ app.openapi(deleteRoute, async (c) => {
   const removed = await callConvexMutation( "candidate_blocks:remove", {
     workspaceSlug: c.var.workspaceSlug,
     identityKey: query.identityKey,
+    writeSecret: config.auth.convexWriteSecret,
   });
 
   return c.json({ success: true as const, removed: removed === true }, 200);

--- a/apps/api/src/routes/candidate-status.test.ts
+++ b/apps/api/src/routes/candidate-status.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../app";
+import { config } from "../services/config";
+import { resetResumeScreeningDb } from "../services/database";
 import { workspaceConfigService } from "../services/workspace-config-service";
+import { createAuthHeaders } from "./test-auth-helpers";
 
 type ConvexCall = {
   type: "query" | "mutation";
@@ -57,9 +60,35 @@ function convexSuccess(value: unknown): Response {
 describe("candidate-status route", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    resetResumeScreeningDb();
+  });
+
+  it("rejects status writes without a session", async () => {
+    const calls: ConvexCall[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      calls.push(parseConvexCall(input, init));
+      return convexSuccess(null);
+    });
+
+    const app = createApp();
+    const response = await app.request("/api/candidate-status", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        identityKey: "resume-1",
+        status: "interviewing",
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(calls).toHaveLength(0);
   });
 
   it("updates candidate status successfully", async () => {
+    const auth = createAuthHeaders({ workspaceSlug: "hr", role: "user" });
     const calls: ConvexCall[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const call = parseConvexCall(input, init);
@@ -72,8 +101,9 @@ describe("candidate-status route", () => {
         return convexSuccess({
           _id: "status-id-1",
           identityKey: "resume-1",
-          workspaceSlug: "dev",
+          workspaceSlug: "hr",
           status: "interviewing",
+          updatedBy: auth.userId,
           updatedAt: 1_700_000_000_000,
         });
       }
@@ -81,16 +111,17 @@ describe("candidate-status route", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createApp({ authStorage: auth.storage });
     const response = await app.request("/api/candidate-status", {
       method: "POST",
       headers: {
+        ...auth.headers,
         "Content-Type": "application/json",
-        "X-Workspace-Slug": "dev",
       },
       body: JSON.stringify({
         identityKey: "resume-1",
         status: "interviewing",
+        updatedBy: "body-user",
       }),
     });
 
@@ -100,7 +131,7 @@ describe("candidate-status route", () => {
       success: true,
       item: {
         identityKey: "resume-1",
-        workspaceSlug: "dev",
+        workspaceSlug: "hr",
         status: "interviewing",
       },
     });
@@ -111,22 +142,25 @@ describe("candidate-status route", () => {
       type: "mutation",
       pathName: "candidate_status:upsert",
       args: {
-        workspaceSlug: "dev",
+        workspaceSlug: "hr",
         identityKey: "resume-1",
         status: "interviewing",
+        updatedBy: auth.userId,
+        writeSecret: config.auth.convexWriteSecret,
       },
     });
     expect(calls[1]).toMatchObject({
       type: "query",
       pathName: "candidate_status:getByIdentity",
       args: {
-        workspaceSlug: "dev",
+        workspaceSlug: "hr",
         identityKey: "resume-1",
       },
     });
   });
 
   it("appends learning log entry for interviewed_reject updates", async () => {
+    const auth = createAuthHeaders({ workspaceSlug: "dev", role: "user" });
     const appendSpy = vi
       .spyOn(workspaceConfigService, "appendLearningLogEntry")
       .mockResolvedValue({
@@ -152,12 +186,12 @@ describe("candidate-status route", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createApp({ authStorage: auth.storage });
     const response = await app.request("/api/candidate-status", {
       method: "POST",
       headers: {
+        ...auth.headers,
         "Content-Type": "application/json",
-        "X-Workspace-Slug": "dev",
       },
       body: JSON.stringify({
         identityKey: "resume-2",
@@ -179,7 +213,33 @@ describe("candidate-status route", () => {
     );
   });
 
-  it("rejects non-admin workspace access with 403", async () => {
+  it("rejects status writes when auth lacks selected workspace membership", async () => {
+    const auth = createAuthHeaders({ workspaceSlug: "hr", requestWorkspaceSlug: "dev", role: "user" });
+    const calls: ConvexCall[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+      return convexSuccess(null);
+    });
+
+    const app = createApp({ authStorage: auth.storage });
+    const response = await app.request("/api/candidate-status", {
+      method: "POST",
+      headers: {
+        ...auth.headers,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        identityKey: "resume-1",
+        status: "interviewing",
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("lists statuses for the selected workspace", async () => {
     const calls: ConvexCall[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const call = parseConvexCall(input, init);
@@ -198,10 +258,11 @@ describe("candidate-status route", () => {
     });
     const devResponse = await app.request("/api/candidate-status");
 
-    expect(hrResponse.status).toBe(403);
+    expect(hrResponse.status).toBe(200);
     expect(devResponse.status).toBe(200);
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.args.workspaceSlug).toBe("dev");
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.args.workspaceSlug).toBe("hr");
+    expect(calls[1]?.args.workspaceSlug).toBe("dev");
   });
 
   describe("POST /api/candidate-appeal", () => {

--- a/apps/api/src/routes/candidate-status.ts
+++ b/apps/api/src/routes/candidate-status.ts
@@ -5,12 +5,19 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
 
 import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
+import { config } from "../services/config.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { logger } from "../services/logger.js";
-import { requireAdmin } from "../middleware/workspace.js";
+import { getAuthenticatedActorId, requireWorkspaceUser } from "../middleware/auth.js";
 
 const app = new OpenAPIHono();
-app.use("/api/candidate-status", requireAdmin);
+
+app.use("/api/candidate-status", async (c, next) => {
+  if (c.req.method === "POST") {
+    return requireWorkspaceUser(c, next);
+  }
+  await next();
+});
 
 
 const CandidateStatusEnum = z.enum([
@@ -144,7 +151,8 @@ app.openapi(updateRoute, async (c) => {
     identityKey: body.identityKey,
     status: body.status,
     notes: body.notes,
-    updatedBy: body.updatedBy,
+    updatedBy: getAuthenticatedActorId(c),
+    writeSecret: config.auth.convexWriteSecret,
   });
 
   const item = await callConvexQuery( "candidate_status:getByIdentity", {

--- a/apps/api/src/routes/config.test.ts
+++ b/apps/api/src/routes/config.test.ts
@@ -2,14 +2,23 @@ import { OpenAPIHono } from '@hono/zod-openapi'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import configRoutes from './config'
+import { createAuthMiddleware } from '../middleware/auth'
 import { workspaceMiddleware } from '../middleware/workspace'
+import type { AuthStorage } from '../services/auth-storage'
 import { configSourceInspector, UnknownConfigSourceError } from '../services/config-source-inspector'
 import { customKeywordService } from '../services/custom-keyword-service'
+import { resetResumeScreeningDb } from '../services/database'
 import { workspaceConfigService } from '../services/workspace-config-service'
+import { createAuthHeaders } from './test-auth-helpers'
 
-function createTestApp() {
+function createTestApp(storage?: AuthStorage) {
   const app = new OpenAPIHono()
   app.use('*', workspaceMiddleware)
+  if (storage) {
+    const middleware = createAuthMiddleware({ storage, ttlSeconds: 3600 })
+    app.use('*', middleware.optionalAuth)
+    app.use('/api/*', middleware.requireCsrf)
+  }
   app.route('/api/config', configRoutes)
   return app
 }
@@ -17,6 +26,7 @@ function createTestApp() {
 describe('config route workspace access', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    resetResumeScreeningDb()
   })
 
   it('loads rule weights for the requested workspace', async () => {
@@ -89,7 +99,7 @@ describe('config route workspace access', () => {
     })
   })
 
-  it('blocks hr users from updating workspace config', async () => {
+  it('requires authentication for workspace config updates', async () => {
     const setRuleWeightsSpy = vi.spyOn(workspaceConfigService, 'setWorkspaceRuleWeights').mockResolvedValue()
 
     const app = createTestApp()
@@ -98,6 +108,32 @@ describe('config route workspace access', () => {
       headers: {
         'Content-Type': 'application/json',
         'X-Workspace-Slug': 'hr',
+      },
+      body: JSON.stringify({
+        roleMatch: {
+          screener: { passThreshold: 60 },
+        },
+      }),
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({
+      success: false,
+      error: 'Authentication required',
+    })
+    expect(setRuleWeightsSpy).not.toHaveBeenCalled()
+  })
+
+  it('blocks workspace users from updating workspace config', async () => {
+    const auth = createAuthHeaders({ workspaceSlug: 'hr', role: 'user' })
+    const setRuleWeightsSpy = vi.spyOn(workspaceConfigService, 'setWorkspaceRuleWeights').mockResolvedValue()
+
+    const app = createTestApp(auth.storage)
+    const response = await app.request('/api/config/rule-weights', {
+      method: 'PUT',
+      headers: {
+        ...auth.headers,
+        'Content-Type': 'application/json',
       },
       body: JSON.stringify({
         roleMatch: {
@@ -115,6 +151,7 @@ describe('config route workspace access', () => {
   })
 
   it('allows dev admin updates and persists them to the dev workspace', async () => {
+    const auth = createAuthHeaders({ workspaceSlug: 'dev', role: 'admin' })
     const setRuleWeightsSpy = vi.spyOn(workspaceConfigService, 'setWorkspaceRuleWeights').mockResolvedValue()
     const getRuleWeightsSpy = vi.spyOn(workspaceConfigService, 'getRuleWeights').mockResolvedValue({
       roleMatch: {
@@ -122,12 +159,12 @@ describe('config route workspace access', () => {
       },
     } as never)
 
-    const app = createTestApp()
+    const app = createTestApp(auth.storage)
     const response = await app.request('/api/config/rule-weights', {
       method: 'PUT',
       headers: {
+        ...auth.headers,
         'Content-Type': 'application/json',
-        'X-Workspace-Slug': 'dev',
       },
       body: JSON.stringify({
         roleMatch: {
@@ -153,6 +190,38 @@ describe('config route workspace access', () => {
     })
   })
 
+  it('allows hr workspace admins to update hr workspace config', async () => {
+    const auth = createAuthHeaders({ workspaceSlug: 'hr', role: 'admin' })
+    const setRuleWeightsSpy = vi.spyOn(workspaceConfigService, 'setWorkspaceRuleWeights').mockResolvedValue()
+    const getRuleWeightsSpy = vi.spyOn(workspaceConfigService, 'getRuleWeights').mockResolvedValue({
+      roleMatch: {
+        screener: { passThreshold: 68 },
+      },
+    } as never)
+
+    const app = createTestApp(auth.storage)
+    const response = await app.request('/api/config/rule-weights', {
+      method: 'PUT',
+      headers: {
+        ...auth.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        roleMatch: {
+          screener: { passThreshold: 68 },
+        },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(setRuleWeightsSpy).toHaveBeenCalledWith('hr', {
+      roleMatch: {
+        screener: { passThreshold: 68 },
+      },
+    })
+    expect(getRuleWeightsSpy).toHaveBeenCalledWith('hr')
+  })
+
   it('allows dev admin updates for the resume field usage policy', async () => {
     const setPolicySpy = vi.spyOn(workspaceConfigService, 'setWorkspaceResumeFieldUsagePolicy').mockResolvedValue()
     const getPolicySpy = vi.spyOn(workspaceConfigService, 'getResumeFieldUsagePolicy').mockResolvedValue({
@@ -170,12 +239,13 @@ describe('config route workspace access', () => {
       },
     })
 
-    const app = createTestApp()
+    const auth = createAuthHeaders({ workspaceSlug: 'dev', role: 'admin' })
+    const app = createTestApp(auth.storage)
     const response = await app.request('/api/config/resume-field-usage-policy', {
       method: 'PUT',
       headers: {
+        ...auth.headers,
         'Content-Type': 'application/json',
-        'X-Workspace-Slug': 'dev',
       },
       body: JSON.stringify({
         fields: {
@@ -620,12 +690,13 @@ describe('config route workspace access', () => {
     } as never)
     const setWorkspaceCustomKeywordsSpy = vi.spyOn(workspaceConfigService, 'setWorkspaceCustomKeywords').mockResolvedValue()
 
-    const app = createTestApp()
+    const auth = createAuthHeaders({ workspaceSlug: 'dev', role: 'admin' })
+    const app = createTestApp(auth.storage)
     const response = await app.request('/api/config/custom-keywords/seed-role-sales', {
       method: 'PUT',
       headers: {
+        ...auth.headers,
         'Content-Type': 'application/json',
-        'X-Workspace-Slug': 'dev',
       },
       body: JSON.stringify({
         id: 'seed-role-sales',
@@ -711,12 +782,11 @@ describe('config route workspace access', () => {
     } as never)
     const setWorkspaceCustomKeywordsSpy = vi.spyOn(workspaceConfigService, 'setWorkspaceCustomKeywords').mockResolvedValue()
 
-    const app = createTestApp()
+    const auth = createAuthHeaders({ workspaceSlug: 'dev', role: 'admin' })
+    const app = createTestApp(auth.storage)
     const response = await app.request('/api/config/custom-keywords/workflow-seeds/seek-my-cnc-sales', {
       method: 'DELETE',
-      headers: {
-        'X-Workspace-Slug': 'dev',
-      },
+      headers: auth.headers,
     })
 
     expect(response.status).toBe(200)

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -19,7 +19,7 @@ import {
   SYSTEM_NAV_ITEMS,
   isRecord,
 } from "@trends/shared";
-import { denyIfNotAdmin } from "../middleware/workspace.js";
+import { getAdminAccessError } from "../middleware/auth.js";
 import { getMaskedApiKey, loadAIConfig, validateAIConfig } from "../services/ai-config.js";
 import { configSourceInspector, UnknownConfigSourceError } from "../services/config-source-inspector.js";
 import { customKeywordService } from "../services/custom-keyword-service.js";
@@ -447,14 +447,16 @@ const putAgentsRoute = createRoute({
   responses: {
     200: { description: "Updated agents config", content: { "application/json": { schema: AgentsGetResponseSchema } } },
     400: { description: "Invalid payload", content: { "application/json": { schema: ErrorResponseSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorResponseSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
   },
 });
 
 app.openapi(putAgentsRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
   try {
     const data = c.req.valid("json");
@@ -547,6 +549,7 @@ const putSystemLocationRoute = createRoute({
   responses: {
     200: { description: "Updated location", content: { "application/json": { schema: SystemLocationUpdateResponseSchema } } },
     400: { description: "Invalid payload", content: { "application/json": { schema: ErrorResponseSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorResponseSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
     404: { description: "Not found", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
@@ -554,8 +557,9 @@ const putSystemLocationRoute = createRoute({
 });
 
 app.openapi(putSystemLocationRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
   try {
     const { id } = c.req.valid("param");
@@ -599,6 +603,7 @@ const postCustomKeywordRoute = createRoute({
   responses: {
     201: { description: "Created tag", content: { "application/json": { schema: CustomKeywordTagResponseSchema } } },
     400: { description: "Invalid payload", content: { "application/json": { schema: ErrorResponseSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorResponseSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
     409: { description: "Already exists", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
@@ -606,8 +611,9 @@ const postCustomKeywordRoute = createRoute({
 });
 
 app.openapi(postCustomKeywordRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
   try {
     const data = c.req.valid("json");
@@ -654,6 +660,7 @@ const putCustomKeywordRoute = createRoute({
   responses: {
     200: { description: "Updated tag", content: { "application/json": { schema: CustomKeywordTagResponseSchema } } },
     400: { description: "Invalid payload", content: { "application/json": { schema: ErrorResponseSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorResponseSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
     404: { description: "Not found", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
@@ -661,8 +668,9 @@ const putCustomKeywordRoute = createRoute({
 });
 
 app.openapi(putCustomKeywordRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
   try {
     const { id } = c.req.valid("param");
@@ -710,6 +718,7 @@ const deleteCustomKeywordRoute = createRoute({
   },
   responses: {
     200: { description: "Deleted", content: { "application/json": { schema: SuccessResponseSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorResponseSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
     404: { description: "Not found", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
@@ -717,8 +726,9 @@ const deleteCustomKeywordRoute = createRoute({
 });
 
 app.openapi(deleteCustomKeywordRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
   try {
     const { id } = c.req.valid("param");
@@ -761,6 +771,7 @@ const postWorkflowSeedRoute = createRoute({
   responses: {
     201: { description: "Created seed", content: { "application/json": { schema: CustomKeywordWorkflowSeedResponseSchema } } },
     400: { description: "Invalid payload", content: { "application/json": { schema: ErrorResponseSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorResponseSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
     409: { description: "Already exists", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
@@ -768,8 +779,9 @@ const postWorkflowSeedRoute = createRoute({
 });
 
 app.openapi(postWorkflowSeedRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
   try {
     const data = c.req.valid("json");
@@ -807,6 +819,7 @@ const putWorkflowSeedRoute = createRoute({
   responses: {
     200: { description: "Updated seed", content: { "application/json": { schema: CustomKeywordWorkflowSeedResponseSchema } } },
     400: { description: "Invalid payload", content: { "application/json": { schema: ErrorResponseSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorResponseSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
     404: { description: "Not found", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
@@ -814,8 +827,9 @@ const putWorkflowSeedRoute = createRoute({
 });
 
 app.openapi(putWorkflowSeedRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
   try {
     const { id } = c.req.valid("param");
@@ -857,6 +871,7 @@ const deleteWorkflowSeedRoute = createRoute({
   },
   responses: {
     200: { description: "Deleted", content: { "application/json": { schema: SuccessResponseSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorResponseSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
     404: { description: "Not found", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
@@ -864,8 +879,9 @@ const deleteWorkflowSeedRoute = createRoute({
 });
 
 app.openapi(deleteWorkflowSeedRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
   try {
     const { id } = c.req.valid("param");
@@ -928,14 +944,16 @@ const putRuleWeightsRoute = createRoute({
   responses: {
     200: { description: "Updated rule weights", content: { "application/json": { schema: RuleWeightsResponseSchema } } },
     400: { description: "Invalid payload", content: { "application/json": { schema: ErrorResponseSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorResponseSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
   },
 });
 
 app.openapi(putRuleWeightsRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
   try {
     const data = c.req.valid("json");
@@ -985,14 +1003,16 @@ const putResumeFieldUsagePolicyRoute = createRoute({
   responses: {
     200: { description: "Updated policy", content: { "application/json": { schema: ResumeFieldUsagePolicyResponseSchema } } },
     400: { description: "Invalid payload", content: { "application/json": { schema: ErrorResponseSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorResponseSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
   },
 });
 
 app.openapi(putResumeFieldUsagePolicyRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
   try {
     const data = c.req.valid("json");
@@ -1042,14 +1062,16 @@ const postLearningLogRoute = createRoute({
   responses: {
     201: { description: "Appended entry", content: { "application/json": { schema: LearningLogAppendResponseSchema } } },
     400: { description: "Invalid payload", content: { "application/json": { schema: ErrorResponseSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorResponseSchema } } },
     403: { description: "Forbidden", content: { "application/json": { schema: ErrorResponseSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorResponseSchema } } },
   },
 });
 
 app.openapi(postLearningLogRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
   try {
     const data = c.req.valid("json");

--- a/apps/api/src/routes/filter-presets.test.ts
+++ b/apps/api/src/routes/filter-presets.test.ts
@@ -4,11 +4,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import filterPresetsRoutes from './filter-presets'
 import { workspaceMiddleware } from '../middleware/workspace'
 import { workspaceConfigService } from '../services/workspace-config-service'
+import { createAuthContext } from './test-auth-helpers'
 
 // dev workspace = admin, hr workspace = user
 function createTestApp() {
   const app = new OpenAPIHono()
   app.use('*', workspaceMiddleware)
+  app.use('*', async (c, next) => {
+    c.set('auth', createAuthContext({ workspaceSlug: 'dev', role: 'admin' }))
+    await next()
+  })
   app.route('/api/filter-presets', filterPresetsRoutes)
   return app
 }

--- a/apps/api/src/routes/filter-presets.ts
+++ b/apps/api/src/routes/filter-presets.ts
@@ -4,7 +4,7 @@
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
-import { denyIfNotAdmin } from "../middleware/workspace.js";
+import { getAdminAccessError } from "../middleware/auth.js";
 
 const app = new OpenAPIHono();
 
@@ -217,9 +217,10 @@ const createPresetRoute = createRoute({
 });
 
 app.openapi(createPresetRoute, async (c) => {
-    if (denyIfNotAdmin(c.var.accessLevel)) {
-        return c.json({ success: false as const, error: "Admin access required" }, 403);
-    }
+    const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
+  }
     const payload = c.req.valid("json");
     const workspaceConfig = await workspaceConfigService.getWorkspaceFilterPresets(c.var.workspaceSlug);
     const exists = workspaceConfig.presets.some((preset) => preset.id === payload.id);
@@ -278,9 +279,10 @@ const updatePresetRoute = createRoute({
 });
 
 app.openapi(updatePresetRoute, async (c) => {
-    if (denyIfNotAdmin(c.var.accessLevel)) {
-        return c.json({ success: false as const, error: "Admin access required" }, 403);
-    }
+    const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
+  }
     const { id } = c.req.valid("param");
     const updates = c.req.valid("json");
     const workspaceConfig = await workspaceConfigService.getWorkspaceFilterPresets(c.var.workspaceSlug);
@@ -336,9 +338,10 @@ const deletePresetRoute = createRoute({
 });
 
 app.openapi(deletePresetRoute, async (c) => {
-    if (denyIfNotAdmin(c.var.accessLevel)) {
-        return c.json({ success: false as const, error: "Admin access required" }, 403);
-    }
+    const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
+  }
     const { id } = c.req.valid("param");
     const workspaceConfig = await workspaceConfigService.getWorkspaceFilterPresets(c.var.workspaceSlug);
     const nextPresets = workspaceConfig.presets.filter((preset) => preset.id !== id);

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,4 +1,5 @@
 export { default as healthRoutes } from "./health.js";
+export { default as authRoutes } from "./auth.js";
 export { default as aiSummaryRoutes } from "./ai-summary.js";
 export { default as taxonomyRoutes } from "./taxonomy.js";
 export { default as trendsRoutes } from "./trends.js";

--- a/apps/api/src/routes/job-descriptions.test.ts
+++ b/apps/api/src/routes/job-descriptions.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import jobDescriptionsRoutes from "./job-descriptions";
 import { workspaceMiddleware } from "../middleware/workspace";
+import { createAuthContext } from "./test-auth-helpers";
 
 const DEFAULT_TEST_MODEL = "openai/gpt-4o-mini";
 
@@ -21,6 +22,10 @@ vi.mock("../services/jd-keyword-extraction-service.js", () => ({
 function createTestApp() {
   const app = new OpenAPIHono()
   app.use("*", workspaceMiddleware)
+  app.use("*", async (c, next) => {
+    c.set("auth", createAuthContext({ workspaceSlug: "dev", role: "admin" }))
+    await next()
+  })
   app.route("/", jobDescriptionsRoutes)
   return app
 }

--- a/apps/api/src/routes/job-descriptions.ts
+++ b/apps/api/src/routes/job-descriptions.ts
@@ -6,7 +6,7 @@ import { isRecord } from "@trends/shared";
 import { logger } from "../services/logger.js";
 import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
 import { readString } from "../services/workspace-config-service.js";
-import { denyIfNotAdmin } from "../middleware/workspace.js";
+import { getAdminAccessError } from "../middleware/auth.js";
 
 const app = new OpenAPIHono();
 
@@ -218,8 +218,9 @@ const createRouteDef = createRoute({
 });
 
 app.openapi(createRouteDef, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
   const { name, content, overwrite } = c.req.valid("json");
   try {

--- a/apps/api/src/routes/manual-resume-import.test.ts
+++ b/apps/api/src/routes/manual-resume-import.test.ts
@@ -3,19 +3,24 @@ import JSZip from "jszip";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { workspaceMiddleware } from "../middleware/workspace";
+import { createAuthContext } from "./test-auth-helpers";
 
 type ConvexCall = {
   pathName: string;
   args: Record<string, unknown>;
 };
 
-async function createTestApp() {
+async function createTestApp(role: "user" | "admin" = "admin") {
   const [{ default: resumesRoutes }, { default: resumesImportRoutes }] = await Promise.all([
     import("./resumes"),
     import("./resumes_import"),
   ]);
   const app = new OpenAPIHono();
   app.use("*", workspaceMiddleware);
+  app.use("*", async (c, next) => {
+    c.set("auth", createAuthContext({ workspaceSlug: "hr", role }));
+    await next();
+  });
   app.route("/", resumesImportRoutes);
   app.route("/", resumesRoutes);
   return app;
@@ -1571,7 +1576,7 @@ describe("manual resume import route", () => {
 
   it("keeps the legacy JSON import route admin-only", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
-    const app = await createTestApp();
+    const app = await createTestApp("user");
 
     const response = await app.request("/api/resumes/import", {
       method: "POST",

--- a/apps/api/src/routes/notifications.test.ts
+++ b/apps/api/src/routes/notifications.test.ts
@@ -5,13 +5,33 @@ import notificationsRoutes from './notifications'
 import { aiMatchingService } from '../services/ai-matching'
 import { notificationService } from '../services/notification-service'
 import { notificationTemplateService } from '../services/notification-template-service'
+import { createAuthMiddleware } from '../middleware/auth'
 import { workspaceMiddleware } from '../middleware/workspace'
+import type { AuthStorage } from '../services/auth-storage'
+import { resetResumeScreeningDb } from '../services/database'
+import { createAuthHeaders } from './test-auth-helpers'
 
-function createTestApp() {
+let defaultAuthHeaders: Record<string, string> = {}
+
+function createTestApp(storage?: AuthStorage) {
   const app = new Hono()
   app.use('/api/*', workspaceMiddleware)
+  const auth = storage ? undefined : createAuthHeaders({ workspaceSlug: 'dev', role: 'admin' })
+  const authStorage = storage ?? auth!.storage
+  defaultAuthHeaders = auth?.headers ?? defaultAuthHeaders
+  const middleware = createAuthMiddleware({ storage: authStorage, ttlSeconds: 3600 })
+  app.use('/api/*', middleware.optionalAuth)
+  app.use('/api/*', middleware.requireCsrf)
   app.route('/api/notifications', notificationsRoutes)
   return app
+}
+
+function jsonHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    ...defaultAuthHeaders,
+    'Content-Type': 'application/json',
+    ...extra,
+  }
 }
 
 const MOCK_TEMPLATES = [
@@ -32,6 +52,7 @@ const MOCK_RENDERED = {
 describe('notifications routes', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    resetResumeScreeningDb()
   })
 
   describe('GET /api/notifications/templates', () => {
@@ -149,7 +170,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
+        headers: jsonHeaders(),
         body: JSON.stringify({ to: 'test@example.com', subject: 'Hello', body: '<p>Hi</p>' }),
       })
       expect(response.status).toBe(200)
@@ -163,7 +184,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
+        headers: jsonHeaders(),
         body: JSON.stringify({ to: 'test@example.com', subject: 'Hello', body: '<p>Hi</p>' }),
       })
       expect(response.status).toBe(500)
@@ -173,7 +194,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
+        headers: jsonHeaders(),
         body: JSON.stringify({ to: 'not-an-email', subject: 'Hello', body: 'test' }),
       })
       expect(response.status).toBe(400)
@@ -187,7 +208,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send-template', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
+        headers: jsonHeaders(),
         body: JSON.stringify({ channel: 'email', templateId: 'outreach-email', to: 'test@example.com', data: {} }),
       })
       expect(response.status).toBe(200)
@@ -203,7 +224,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send-template', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
+        headers: jsonHeaders(),
         body: JSON.stringify({ channel: 'wechat_work', templateId: 'match-alert', data: {} }),
       })
       expect(response.status).toBe(200)
@@ -218,7 +239,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send-template', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
+        headers: jsonHeaders(),
         body: JSON.stringify({ channel: 'feishu', templateId: 'match-alert', data: {} }),
       })
       expect(response.status).toBe(200)
@@ -234,7 +255,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/send-template', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'dev' },
+        headers: jsonHeaders(),
         body: JSON.stringify({ channel: 'email', templateId: 'missing', to: 'test@example.com', data: {} }),
       })
       expect(response.status).toBe(500)
@@ -243,20 +264,24 @@ describe('notifications routes', () => {
 
   describe('admin guard', () => {
     it('rejects /send without admin workspace', async () => {
-      const app = createTestApp()
+      const auth = createAuthHeaders({ workspaceSlug: 'hr', role: 'user' })
+      defaultAuthHeaders = auth.headers
+      const app = createTestApp(auth.storage)
       const response = await app.request('/api/notifications/send', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'hr' },
+        headers: jsonHeaders(),
         body: JSON.stringify({ to: 'test@example.com', subject: 'Hello', body: '<p>Hi</p>' }),
       })
       expect(response.status).toBe(403)
     })
 
     it('rejects /send-template without admin workspace', async () => {
-      const app = createTestApp()
+      const auth = createAuthHeaders({ workspaceSlug: 'hr', role: 'user' })
+      defaultAuthHeaders = auth.headers
+      const app = createTestApp(auth.storage)
       const response = await app.request('/api/notifications/send-template', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Workspace-Slug': 'hr' },
+        headers: jsonHeaders(),
         body: JSON.stringify({ channel: 'email', templateId: 'outreach-email', to: 'test@example.com', data: {} }),
       })
       expect(response.status).toBe(403)

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -5,7 +5,7 @@ import { notificationService } from "../services/notification-service.js";
 import { notificationTemplateService } from "../services/notification-template-service.js";
 import { config } from "../services/config.js";
 import { formatIsoOffsetInTimezone } from "../services/timezone.js";
-import { requireAdmin } from "../middleware/workspace.js";
+import { requireAdmin } from "../middleware/auth.js";
 
 const app = new OpenAPIHono();
 

--- a/apps/api/src/routes/resume-import.test.ts
+++ b/apps/api/src/routes/resume-import.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import resumesRoutes from "./resumes";
 import resumesImportRoutes from "./resumes_import";
 import { workspaceMiddleware } from "../middleware/workspace";
+import { createAuthContext } from "./test-auth-helpers";
 
 type ConvexCall = {
   pathName: string;
@@ -13,6 +14,10 @@ type ConvexCall = {
 function createTestApp() {
   const app = new OpenAPIHono();
   app.use("*", workspaceMiddleware);
+  app.use("*", async (c, next) => {
+    c.set("auth", createAuthContext({ workspaceSlug: "dev", role: "admin" }));
+    await next();
+  });
   app.route("/", resumesImportRoutes);
   app.route("/", resumesRoutes);
   return app;

--- a/apps/api/src/routes/resumes-backup.test.ts
+++ b/apps/api/src/routes/resumes-backup.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../app";
+import { createAuthContext } from "./test-auth-helpers";
 
 type ConvexCall = {
   pathName: string;
@@ -134,7 +135,7 @@ describe("resume backup and reset routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createApp({ authContext: createAuthContext({ workspaceSlug: "dev", role: "admin" }) });
     const response = await app.request("/api/resumes/backup", {
       method: "POST",
       headers: {
@@ -276,7 +277,7 @@ describe("resume backup and reset routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createApp({ authContext: createAuthContext({ workspaceSlug: "dev", role: "admin" }) });
     const response = await app.request("/api/resumes/backup", {
       method: "POST",
       headers: {
@@ -295,7 +296,7 @@ describe("resume backup and reset routes", () => {
 
   it("blocks resume backup for non-admin workspaces", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
-    const app = createApp();
+    const app = createApp({ authContext: createAuthContext({ workspaceSlug: "hr", role: "user" }) });
 
     const response = await app.request("/api/resumes/backup", {
       method: "POST",
@@ -336,7 +337,7 @@ describe("resume backup and reset routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createApp({ authContext: createAuthContext({ workspaceSlug: "dev", role: "admin" }) });
     const response = await app.request("/api/resumes/reset", {
       method: "POST",
       headers: {

--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -4,6 +4,7 @@ import { createApp } from "../app";
 import { MatchStorage, type StoredMatch } from "../services/match-storage";
 import { ResumeService } from "../services/resume-service";
 import { SessionManager } from "../services/session-manager";
+import { createAuthContext } from "./test-auth-helpers";
 
 type ConvexCall = {
   pathName: string;
@@ -62,6 +63,12 @@ function convexSuccess(value: unknown): Response {
       },
     }
   );
+}
+
+function createTestApp() {
+  return createApp({
+    authContext: createAuthContext({ workspaceSlug: "dev", role: "admin" }),
+  });
 }
 
 function buildConvexResumeRecord(
@@ -188,7 +195,7 @@ describe("resume routes", () => {
       indexes: new Map(),
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes/sample-resume-1?source=sample");
 
     expect(response.status).toBe(200);
@@ -253,7 +260,7 @@ describe("resume routes", () => {
       });
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes/resume-live-1?source=convex");
 
     expect(response.status).toBe(200);
@@ -340,7 +347,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&q=CNC%20%E9%94%80%E5%94%AE&limit=5");
 
     expect(response.status).toBe(200);
@@ -427,7 +434,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&q=cnc%20sales&limit=5", {
       headers: {
         "X-Workspace-Slug": "hr",
@@ -445,7 +452,7 @@ describe("resume routes", () => {
   });
 
   it("keeps the static skills-version route from being shadowed by resume detail lookup", async () => {
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes/skills-version");
 
     expect(response.status).toBe(200);
@@ -491,7 +498,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request(
       "/api/resumes/diagnostics?archived=true&sourceKey=51job-manual&sourceKey=seek&limit=25"
     );
@@ -565,7 +572,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes/match", {
       method: "POST",
       headers: {
@@ -644,7 +651,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&limit=2&offset=2");
 
     expect(response.status).toBe(200);
@@ -704,7 +711,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&q=cnc%20sales&limit=2&offset=2");
 
     expect(response.status).toBe(200);
@@ -754,7 +761,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&q=cnc%20sales&limit=2&offset=2&sortBy=name&sortOrder=desc");
 
     expect(response.status).toBe(200);
@@ -832,7 +839,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request(
       "/api/resumes?source=convex&q=%22machine%20tools%22&locations=Kuala%20Lumpur%20MY&jobDescriptionId=seek-malaysia-sales&limit=5"
     );
@@ -897,7 +904,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&q=cnc%20sales&limit=2&requiredKeywords=machine%20tools,CNC");
 
     expect(response.status).toBe(200);
@@ -928,7 +935,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&locations=%E4%B8%9C%E8%8E%9E&requiredKeywords=CNC");
 
     expect(response.status).toBe(200);
@@ -961,7 +968,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&sortBy=experience");
 
     expect(response.status).toBe(200);
@@ -1015,7 +1022,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request(
       "/api/resumes?source=convex&limit=1&offset=1&sortBy=score&jobDescriptionId=jd-1&locations=%E4%B8%9C%E8%8E%9E"
     );
@@ -1088,7 +1095,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request(
       "/api/resumes?source=convex&limit=1&offset=1&sortBy=score&jobDescriptionId=jd-1&q=cnc%20sales&locations=%E4%B8%9C%E8%8E%9E"
     );
@@ -1143,7 +1150,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&limit=1&offset=1&sortBy=score&jobDescriptionId=jd-1&q=cnc%20sales");
 
     expect(response.status).toBe(200);
@@ -1200,7 +1207,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&limit=2&sortBy=score&jobDescriptionId=jd-1&q=cnc%20sales");
 
     expect(response.status).toBe(200);
@@ -1316,7 +1323,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&limit=2&sortBy=score&jobDescriptionId=jd-1&q=cnc%20sales");
 
     expect(response.status).toBe(200);
@@ -1373,7 +1380,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request(
       "/api/resumes?source=convex&limit=2&jobDescriptionId=jd-1&q=cnc%20sales&minMatchScore=70&sortBy=name&sortOrder=desc"
     );
@@ -1428,7 +1435,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&sortBy=score&jobDescriptionId=jd-1");
 
     expect(response.status).toBe(200);
@@ -1483,7 +1490,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes?source=convex&limit=2&jobDescriptionId=jd-1&minMatchScore=70");
 
     expect(response.status).toBe(200);
@@ -1544,7 +1551,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request(
       "/api/resumes?source=convex&limit=2&jobDescriptionId=jd-1&recommendation=strong_match,match"
     );
@@ -1599,7 +1606,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes/analyze", {
       method: "POST",
       headers: {
@@ -1666,7 +1673,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes/analyze", {
       method: "POST",
       headers: {
@@ -1720,7 +1727,7 @@ describe("resume routes", () => {
       return convexSuccess({ cleared: 1, hasMore: false, cursor: null });
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes/clear-analyses", {
       method: "POST",
       headers: {
@@ -1769,7 +1776,7 @@ describe("resume routes", () => {
       return convexSuccess({ cleared: 1, hasMore: false, cursor: null });
     });
 
-    const app = createApp();
+    const app = createTestApp();
     const response = await app.request("/api/resumes/clear-analyses", {
       method: "POST",
       headers: {
@@ -1790,7 +1797,7 @@ describe("resume routes", () => {
   });
 
   it("rejects convex or read-only match-stream requests", async () => {
-    const app = createApp();
+    const app = createTestApp();
 
     const convexResponse = await app.request("/api/resumes/match-stream", {
       method: "POST",
@@ -1838,7 +1845,7 @@ describe("resume routes", () => {
         });
       });
 
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/explanation", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1860,7 +1867,7 @@ describe("resume routes", () => {
         return convexSuccess(null);
       });
 
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/explanation", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1874,7 +1881,7 @@ describe("resume routes", () => {
     });
 
     it("returns 400 when resumeId is missing", async () => {
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/explanation", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1887,7 +1894,7 @@ describe("resume routes", () => {
     });
 
     it("returns 400 when workspaceSlug is missing", async () => {
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/explanation", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1907,7 +1914,7 @@ describe("resume routes", () => {
         });
       });
 
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/explanation", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1932,7 +1939,7 @@ describe("resume routes", () => {
         ]);
       });
 
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/audit-logs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1954,7 +1961,7 @@ describe("resume routes", () => {
         ]);
       });
 
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/audit-logs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1967,7 +1974,7 @@ describe("resume routes", () => {
     });
 
     it("returns 400 when workspaceSlug is missing", async () => {
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/audit-logs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1978,7 +1985,7 @@ describe("resume routes", () => {
     });
 
     it("returns 400 for invalid decisionType", async () => {
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/audit-logs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1997,7 +2004,7 @@ describe("resume routes", () => {
         ]);
       });
 
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/audit-logs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -2010,7 +2017,7 @@ describe("resume routes", () => {
     });
 
     it("returns 400 for invalid outcome", async () => {
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/audit-logs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -2030,7 +2037,7 @@ describe("resume routes", () => {
         return convexSuccess(null);
       });
 
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/audit-outcome", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -2049,7 +2056,7 @@ describe("resume routes", () => {
         return convexSuccess(null);
       });
 
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/audit-outcome", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -2066,7 +2073,7 @@ describe("resume routes", () => {
         return convexSuccess(null);
       });
 
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/audit-outcome", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -2077,7 +2084,7 @@ describe("resume routes", () => {
     });
 
     it("returns 400 when auditLogId is missing", async () => {
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/audit-outcome", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -2088,7 +2095,7 @@ describe("resume routes", () => {
     });
 
     it("returns 400 for invalid outcome", async () => {
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/audit-outcome", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -2106,7 +2113,7 @@ describe("resume routes", () => {
         });
       });
 
-      const app = createApp();
+      const app = createTestApp();
       const response = await app.request("/api/resumes/audit-outcome", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -60,7 +60,7 @@ import { formatIsoOffsetInTimezone } from "../services/timezone.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { BrandDisplayResolver } from "../services/brand-display-resolver.js";
 import { logger } from "../services/logger.js";
-import { requireAdmin } from "../middleware/workspace.js";
+import { requireAdmin } from "../middleware/auth.js";
 
 import { isRecord } from "@trends/shared";
 import type { ResumeItem } from "../types/resume.js";

--- a/apps/api/src/routes/resumes_admin.test.ts
+++ b/apps/api/src/routes/resumes_admin.test.ts
@@ -2,7 +2,11 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import resumesAdminRoutes from "./resumes_admin";
+import { createAuthMiddleware } from "../middleware/auth";
 import { workspaceMiddleware } from "../middleware/workspace";
+import type { AuthStorage } from "../services/auth-storage";
+import { resetResumeScreeningDb } from "../services/database";
+import { createAuthHeaders } from "./test-auth-helpers";
 
 vi.mock("../services/notification-service", () => ({
   notificationService: {
@@ -12,9 +16,17 @@ vi.mock("../services/notification-service", () => ({
   },
 }));
 
-function createTestApp() {
+let defaultAuthHeaders: Record<string, string> = {};
+
+function createTestApp(storage?: AuthStorage) {
+  const auth = storage ? undefined : createAuthHeaders({ workspaceSlug: "dev", role: "admin" });
+  const authStorage = storage ?? auth!.storage;
+  defaultAuthHeaders = auth?.headers ?? defaultAuthHeaders;
+  const middleware = createAuthMiddleware({ storage: authStorage, ttlSeconds: 3600 });
   const app = new OpenAPIHono();
   app.use("*", workspaceMiddleware);
+  app.use("*", middleware.optionalAuth);
+  app.use("/api/*", middleware.requireCsrf);
   app.route("/", resumesAdminRoutes);
   return app;
 }
@@ -28,12 +40,14 @@ function convexSuccess(value: unknown): Response {
 
 describe("resumes_admin", () => {
   const jsonHeaders = (extra: Record<string, string> = {}): Record<string, string> => ({
+    ...defaultAuthHeaders,
     "Content-Type": "application/json",
     ...extra,
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    resetResumeScreeningDb();
   });
 
   describe("admin access gating", () => {

--- a/apps/api/src/routes/resumes_admin.ts
+++ b/apps/api/src/routes/resumes_admin.ts
@@ -3,7 +3,7 @@ import { callConvexAction, callConvexMutation, callConvexQuery } from "../servic
 import { IngestComputeService } from "../services/ingest-compute-service.js";
 import { config } from "../services/config.js";
 import { logger } from "../services/logger.js";
-import { requireAdmin } from "../middleware/workspace.js";
+import { requireAdmin } from "../middleware/auth.js";
 import { notificationService } from "../services/notification-service.js";
 
 const app = new OpenAPIHono();

--- a/apps/api/src/routes/resumes_diagnostics.test.ts
+++ b/apps/api/src/routes/resumes_diagnostics.test.ts
@@ -3,10 +3,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import resumesDiagnosticsRoutes from "./resumes_diagnostics";
 import { workspaceMiddleware } from "../middleware/workspace";
+import { createAuthContext } from "./test-auth-helpers";
 
 function createTestApp() {
   const app = new OpenAPIHono();
   app.use("*", workspaceMiddleware);
+  app.use("*", async (c, next) => {
+    c.set("auth", createAuthContext({ workspaceSlug: "dev", role: "admin" }));
+    await next();
+  });
   app.route("/", resumesDiagnosticsRoutes);
   return app;
 }

--- a/apps/api/src/routes/resumes_diagnostics.ts
+++ b/apps/api/src/routes/resumes_diagnostics.ts
@@ -9,7 +9,7 @@ import {
   ResumeDiagnosticsQuerySchema,
   ResumeDiagnosticsResponseSchema,
 } from "../schemas/index.js";
-import { requireAdmin } from "../middleware/workspace.js";
+import { requireAdmin } from "../middleware/auth.js";
 
 const app = new OpenAPIHono();
 app.use("/api/resumes/analysis-tasks", requireAdmin);

--- a/apps/api/src/routes/resumes_import.test.ts
+++ b/apps/api/src/routes/resumes_import.test.ts
@@ -3,10 +3,18 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import resumesImportRoutes from "./resumes_import";
 import { workspaceMiddleware } from "../middleware/workspace";
+import { createAuthContext } from "./test-auth-helpers";
 
-function createTestApp() {
+function createTestApp(input: { workspaceSlug?: string; role?: "user" | "admin" } = {}) {
   const app = new OpenAPIHono();
   app.use("*", workspaceMiddleware);
+  app.use("*", async (c, next) => {
+    c.set("auth", createAuthContext({
+      workspaceSlug: input.workspaceSlug ?? "dev",
+      role: input.role ?? "admin",
+    }));
+    await next();
+  });
   app.route("/", resumesImportRoutes);
   return app;
 }
@@ -47,7 +55,7 @@ describe("resumes_import", () => {
     });
 
     it("rejects non-admin access with 403", async () => {
-      const app = createTestApp();
+      const app = createTestApp({ workspaceSlug: "hr", role: "user" });
       const response = await app.request("/api/resumes/import", {
         method: "POST",
         headers: { "Content-Type": "application/json", "X-Workspace-Slug": "hr" },
@@ -107,7 +115,7 @@ describe("resumes_import", () => {
     });
 
     it("rejects non-admin access with 403", async () => {
-      const app = createTestApp();
+      const app = createTestApp({ workspaceSlug: "hr", role: "user" });
       const response = await app.request("/api/resumes/backup", {
         method: "POST",
         headers: { "Content-Type": "application/json", "X-Workspace-Slug": "hr" },
@@ -120,7 +128,7 @@ describe("resumes_import", () => {
 
   describe("POST /api/resumes/reset", () => {
     it("rejects non-admin access with 403", async () => {
-      const app = createTestApp();
+      const app = createTestApp({ workspaceSlug: "hr", role: "user" });
       const response = await app.request("/api/resumes/reset", {
         method: "POST",
         headers: { "Content-Type": "application/json", "X-Workspace-Slug": "hr" },

--- a/apps/api/src/routes/resumes_import.ts
+++ b/apps/api/src/routes/resumes_import.ts
@@ -7,7 +7,7 @@ import { submitResumeImport } from "../services/resume-import-service.js";
 import { getManualResumeImportMaxUploadBytes, importManualResumes } from "../services/manual-resume-import-service.js";
 import { config } from "../services/config.js";
 import { logger } from "../services/logger.js";
-import { requireAdmin } from "../middleware/workspace.js";
+import { requireAdmin } from "../middleware/auth.js";
 import {
   ResumeBackupRequestSchema,
   ResumeImportRequestSchema,

--- a/apps/api/src/routes/resumes_packets.ts
+++ b/apps/api/src/routes/resumes_packets.ts
@@ -1165,6 +1165,7 @@ app.openapi(importReviewPacketFeedbackRoute, async (c) => {
             status: params.status,
             notes: params.notes,
             updatedBy: params.updatedBy,
+            writeSecret: config.auth.convexWriteSecret,
           });
         },
         saveAction: async (params) => {

--- a/apps/api/src/routes/resumes_packets.ts
+++ b/apps/api/src/routes/resumes_packets.ts
@@ -21,7 +21,7 @@ import {
   SimpleErrorSchema,
 } from "../schemas/index.js";
 import { logger } from "../services/logger.js";
-import { requireAdmin } from "../middleware/workspace.js";
+import { requireAdmin } from "../middleware/auth.js";
 import { config } from "../services/config.js";
 import { ResumeService } from "../services/resume-service.js";
 import { DataNotFoundError } from "../services/errors.js";

--- a/apps/api/src/routes/review-packets.test.ts
+++ b/apps/api/src/routes/review-packets.test.ts
@@ -74,8 +74,11 @@ async function loadReviewPacketModules(root: string) {
   const { ActionStorage } = await import("../services/action-storage");
   const { resetResumeScreeningDb } = await import("../services/database");
   const { notificationService } = await import("../services/notification-service");
+  const { createAuthContext } = await import("./test-auth-helpers");
   return {
-    createApp,
+    createApp: () => createApp({
+      authContext: createAuthContext({ workspaceSlug: "dev", role: "admin" }),
+    }),
     ResumeService,
     ReviewPacketStorage,
     ActionStorage,

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -23,7 +23,7 @@ import {
     type SearchProfile,
 } from "../services/search-profile-service.js";
 import { logger } from "../services/logger.js";
-import { requireAdmin } from "../middleware/workspace.js";
+import { requireAdmin } from "../middleware/auth.js";
 import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
 import { resolveConvexUrl } from "../services/resume-import-service.js";
 import { readString, readNumber } from "../services/workspace-config-service.js";

--- a/apps/api/src/routes/summaries.test.ts
+++ b/apps/api/src/routes/summaries.test.ts
@@ -131,8 +131,11 @@ async function loadSummaryModules(root: string) {
   const { summaryTelegramBridge } = await import("../services/summaries/summary-telegram-bridge");
   const { workspaceConfigService } = await import("../services/workspace-config-service");
   const { resetResumeScreeningDb } = await import("../services/database");
+  const { createAuthContext } = await import("./test-auth-helpers");
   return {
-    createApp,
+    createApp: () => createApp({
+      authContext: createAuthContext({ workspaceSlug: "dev", role: "admin" }),
+    }),
     SessionManager,
     ActionStorage,
     ReviewPacketStorage,

--- a/apps/api/src/routes/summaries.ts
+++ b/apps/api/src/routes/summaries.ts
@@ -15,7 +15,7 @@ import { summaryDispatcher } from "../services/summaries/summary-dispatcher.js";
 import { SummaryRenderer } from "../services/summaries/summary-renderer.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { logger } from "../services/logger.js";
-import { denyIfNotAdmin } from "../middleware/workspace.js";
+import { getAdminAccessError } from "../middleware/auth.js";
 import {
   WorkspaceSummaryRunStorage,
   type StoredWorkspaceSummaryRun,
@@ -416,6 +416,14 @@ const listProfilesRoute = createRoute({
         },
       },
     },
+    401: {
+      description: "Authentication required",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
     403: {
       description: "Forbidden",
       content: {
@@ -428,8 +436,9 @@ const listProfilesRoute = createRoute({
 });
 
 app.openapi(listProfilesRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
 
   const config = await workspaceConfigService.getWorkspaceSummaryProfiles(c.var.workspaceSlug);
@@ -470,6 +479,14 @@ const createProfileRoute = createRoute({
         },
       },
     },
+    401: {
+      description: "Authentication required",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
     403: {
       description: "Forbidden",
       content: {
@@ -490,8 +507,9 @@ const createProfileRoute = createRoute({
 });
 
 app.openapi(createProfileRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
 
   const payload = c.req.valid("json");
@@ -575,6 +593,14 @@ const getProfileRoute = createRoute({
         },
       },
     },
+    401: {
+      description: "Authentication required",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
     403: {
       description: "Forbidden",
       content: {
@@ -595,8 +621,9 @@ const getProfileRoute = createRoute({
 });
 
 app.openapi(getProfileRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
 
   const { profileId } = c.req.valid("param");
@@ -649,6 +676,14 @@ const updateProfileRoute = createRoute({
         },
       },
     },
+    401: {
+      description: "Authentication required",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
     403: {
       description: "Forbidden",
       content: {
@@ -669,8 +704,9 @@ const updateProfileRoute = createRoute({
 });
 
 app.openapi(updateProfileRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
 
   const { profileId } = c.req.valid("param");
@@ -729,6 +765,14 @@ const deleteProfileRoute = createRoute({
         },
       },
     },
+    401: {
+      description: "Authentication required",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
     403: {
       description: "Forbidden",
       content: {
@@ -749,8 +793,9 @@ const deleteProfileRoute = createRoute({
 });
 
 app.openapi(deleteProfileRoute, async (c) => {
-  if (denyIfNotAdmin(c.var.accessLevel)) {
-    return c.json({ success: false as const, error: "Admin access required" }, 403);
+  const adminError = getAdminAccessError(c);
+  if (adminError) {
+    return c.json(adminError.body, adminError.status);
   }
 
   const { profileId } = c.req.valid("param");

--- a/apps/api/src/routes/taxonomy.test.ts
+++ b/apps/api/src/routes/taxonomy.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import taxonomyRoutes from "./taxonomy";
 import { workspaceMiddleware } from "../middleware/workspace";
 import { logger } from "../services/logger";
+import { createAuthContext } from "./test-auth-helpers";
 
 const {
   resolveConvexUrlMock,
@@ -18,6 +19,10 @@ vi.mock("../services/resume-import-service.js", () => ({
 function createTestApp() {
   const app = new OpenAPIHono()
   app.use("*", workspaceMiddleware)
+  app.use("*", async (c, next) => {
+    c.set("auth", createAuthContext({ workspaceSlug: "dev", role: "admin" }))
+    await next()
+  })
   app.route("/", taxonomyRoutes)
   return app
 }

--- a/apps/api/src/routes/taxonomy.ts
+++ b/apps/api/src/routes/taxonomy.ts
@@ -1,5 +1,5 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import { requireAdmin } from "../middleware/workspace.js";
+import { requireAdmin } from "../middleware/auth.js";
 import { callConvexQuery, callConvexMutation } from "../services/convex-utils.js";
 import { isRecord } from "@trends/shared";
 import { logger } from "../services/logger.js";

--- a/apps/api/src/routes/test-auth-helpers.ts
+++ b/apps/api/src/routes/test-auth-helpers.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { AuthSessionService } from "../services/auth-session-service.js";
+import { AuthStorage } from "../services/auth-storage.js";
+import type { WorkspaceRole } from "../services/auth-types.js";
+import { config } from "../services/config.js";
+import { resetResumeScreeningDb } from "../services/database.js";
+
+export function createAuthHeaders(input: {
+  workspaceSlug: string;
+  role: WorkspaceRole;
+  requestWorkspaceSlug?: string;
+}) {
+  resetResumeScreeningDb();
+  const root = mkdtempSync(path.join(tmpdir(), "trends-route-auth-"));
+  const storage = new AuthStorage(root);
+  const user = storage.createUser({
+    email: `${input.role}@example.com`,
+    displayName: input.role,
+  });
+  storage.upsertMembership({
+    userId: user.id,
+    workspaceSlug: input.workspaceSlug,
+    role: input.role,
+  });
+  const session = new AuthSessionService(storage, { ttlSeconds: 3600 }).createSession(user.id);
+
+  return {
+    root,
+    storage,
+    userId: user.id,
+    headers: {
+      "X-Workspace-Slug": input.requestWorkspaceSlug ?? input.workspaceSlug,
+      "X-CSRF-Token": session.csrfToken,
+      Cookie: `${config.auth.sessionCookieName}=${session.token}`,
+    },
+  };
+}

--- a/apps/api/src/routes/test-auth-helpers.ts
+++ b/apps/api/src/routes/test-auth-helpers.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { AuthSessionService } from "../services/auth-session-service.js";
 import { AuthStorage } from "../services/auth-storage.js";
-import type { WorkspaceRole } from "../services/auth-types.js";
+import type { AuthContext, WorkspaceRole } from "../services/auth-types.js";
 import { config } from "../services/config.js";
 import { resetResumeScreeningDb } from "../services/database.js";
 
@@ -36,5 +36,24 @@ export function createAuthHeaders(input: {
       "X-CSRF-Token": session.csrfToken,
       Cookie: `${config.auth.sessionCookieName}=${session.token}`,
     },
+  };
+}
+
+export function createAuthContext(input: {
+  workspaceSlug: string;
+  role: WorkspaceRole;
+  userId?: string;
+}): AuthContext {
+  const userId = input.userId ?? `${input.role}-user`;
+  return {
+    user: {
+      id: userId,
+      email: `${input.role}@example.com`,
+      displayName: input.role,
+      status: "active",
+    },
+    memberships: [{ userId, workspaceSlug: input.workspaceSlug, role: input.role }],
+    sessionId: "test-session",
+    csrfToken: "test-csrf-token-hash",
   };
 }

--- a/apps/api/src/services/auth-session-service.test.ts
+++ b/apps/api/src/services/auth-session-service.test.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AuthSessionService } from "./auth-session-service.js";
+import { AuthStorage } from "./auth-storage.js";
+import { resetResumeScreeningDb } from "./database.js";
+
+describe("auth sessions", () => {
+  afterEach(() => {
+    resetResumeScreeningDb();
+  });
+
+  it("creates, resolves, verifies csrf, and revokes opaque sessions", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-session-"));
+    const storage = new AuthStorage(root);
+    const user = storage.createUser({ email: "hr@example.com", displayName: "HR" });
+    storage.upsertMembership({ userId: user.id, workspaceSlug: "hr", role: "user" });
+
+    const service = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const created = service.createSession(user.id);
+
+    expect(created.token).not.toBe(created.csrfToken);
+    expect(storage.findSessionByTokenHash(created.token)).toBeNull();
+    expect(service.resolveSession(created.token)?.user.id).toBe(user.id);
+    expect(service.resolveSession(created.token)?.memberships).toEqual([
+      { userId: user.id, workspaceSlug: "hr", role: "user" },
+    ]);
+    expect(service.verifyCsrf(created.token, created.csrfToken)).toBe(true);
+    expect(service.verifyCsrf(created.token, "wrong-csrf")).toBe(false);
+
+    service.revokeSession(created.token);
+    expect(service.resolveSession(created.token)).toBeNull();
+  });
+});

--- a/apps/api/src/services/auth-session-service.ts
+++ b/apps/api/src/services/auth-session-service.ts
@@ -1,0 +1,58 @@
+import { createHash, randomBytes } from "node:crypto";
+
+import type { AuthContext } from "./auth-types.js";
+import type { AuthStorage } from "./auth-storage.js";
+
+export function hashSecret(value: string): string {
+  return createHash("sha256").update(value).digest("base64url");
+}
+
+export class AuthSessionService {
+  constructor(
+    private readonly storage: AuthStorage,
+    private readonly options: { ttlSeconds: number },
+  ) {}
+
+  createSession(userId: string): { token: string; csrfToken: string; expiresAt: string } {
+    const token = randomBytes(32).toString("base64url");
+    const csrfToken = randomBytes(32).toString("base64url");
+    const expiresAt = new Date(Date.now() + this.options.ttlSeconds * 1000).toISOString();
+
+    this.storage.createSession({
+      userId,
+      tokenHash: hashSecret(token),
+      csrfTokenHash: hashSecret(csrfToken),
+      expiresAt,
+    });
+
+    return { token, csrfToken, expiresAt };
+  }
+
+  resolveSession(token: string): AuthContext | null {
+    const session = this.storage.findSessionByTokenHash(hashSecret(token));
+    if (!session) {
+      return null;
+    }
+
+    const user = this.storage.findUser(session.userId);
+    if (!user) {
+      return null;
+    }
+
+    return {
+      user,
+      memberships: this.storage.listMemberships(user.id),
+      sessionId: session.id,
+      csrfToken: session.csrfTokenHash,
+    };
+  }
+
+  verifyCsrf(token: string, csrfToken: string): boolean {
+    const session = this.storage.findSessionByTokenHash(hashSecret(token));
+    return Boolean(session && session.csrfTokenHash === hashSecret(csrfToken));
+  }
+
+  revokeSession(token: string): void {
+    this.storage.revokeSessionByTokenHash(hashSecret(token));
+  }
+}

--- a/apps/api/src/services/auth-storage.test.ts
+++ b/apps/api/src/services/auth-storage.test.ts
@@ -53,4 +53,29 @@ describe("auth sqlite schema", () => {
       { userId: user.id, workspaceSlug: "hr", role: "admin" },
     ]);
   });
+
+  it("consumes OIDC state only once", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-oidc-state-"));
+    const storage = new AuthStorage(root);
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+
+    storage.saveOidcState({
+      state: "state-123",
+      provider: "casdoor",
+      codeVerifier: "verifier-123",
+      nonce: "nonce-123",
+      redirectTo: "/resumes",
+      expiresAt,
+    });
+
+    expect(storage.consumeOidcState("state-123")).toEqual({
+      state: "state-123",
+      provider: "casdoor",
+      codeVerifier: "verifier-123",
+      nonce: "nonce-123",
+      redirectTo: "/resumes",
+      expiresAt,
+    });
+    expect(storage.consumeOidcState("state-123")).toBeNull();
+  });
 });

--- a/apps/api/src/services/auth-storage.test.ts
+++ b/apps/api/src/services/auth-storage.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { AuthStorage } from "./auth-storage.js";
 import { getResumeScreeningDb, resetResumeScreeningDb } from "./database.js";
 
 describe("auth sqlite schema", () => {
@@ -29,5 +30,27 @@ describe("auth sqlite schema", () => {
         "workspace_memberships",
       ]),
     );
+  });
+
+  it("creates a user, local identity, and workspace membership", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-storage-"));
+    const storage = new AuthStorage(root);
+
+    const user = storage.createUser({
+      email: "hr@example.com",
+      displayName: "HR User",
+    });
+    storage.linkIdentity({
+      userId: user.id,
+      provider: "local",
+      providerSubject: "hr-admin",
+      providerTenant: "local",
+    });
+    storage.upsertMembership({ userId: user.id, workspaceSlug: "hr", role: "admin" });
+
+    expect(storage.findIdentity("local", "hr-admin", "local")?.userId).toBe(user.id);
+    expect(storage.listMemberships(user.id)).toEqual([
+      { userId: user.id, workspaceSlug: "hr", role: "admin" },
+    ]);
   });
 });

--- a/apps/api/src/services/auth-storage.test.ts
+++ b/apps/api/src/services/auth-storage.test.ts
@@ -1,0 +1,33 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getResumeScreeningDb, resetResumeScreeningDb } from "./database.js";
+
+describe("auth sqlite schema", () => {
+  afterEach(() => {
+    resetResumeScreeningDb();
+  });
+
+  it("creates auth tables and indexes in resume_screening.db", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-db-"));
+    const db = getResumeScreeningDb(root);
+
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+      .all() as Array<{ name: string }>;
+
+    expect(tables.map((row) => row.name)).toEqual(
+      expect.arrayContaining([
+        "users",
+        "auth_identities",
+        "auth_password_credentials",
+        "auth_sessions",
+        "auth_oidc_states",
+        "workspace_memberships",
+      ]),
+    );
+  });
+});

--- a/apps/api/src/services/auth-storage.ts
+++ b/apps/api/src/services/auth-storage.ts
@@ -3,7 +3,13 @@ import { randomUUID } from "node:crypto";
 import { config } from "./config.js";
 import { getResumeScreeningDb } from "./database.js";
 import { formatIsoOffsetInTimezone } from "./timezone.js";
-import type { AuthProvider, AuthUser, WorkspaceMembership, WorkspaceRole } from "./auth-types.js";
+import type {
+  AuthProvider,
+  AuthUser,
+  StoredOidcState,
+  WorkspaceMembership,
+  WorkspaceRole,
+} from "./auth-types.js";
 
 type IdentityRow = {
   user_id?: unknown;
@@ -36,6 +42,15 @@ type SessionRow = {
   csrf_token_hash?: unknown;
   expires_at?: unknown;
   revoked_at?: unknown;
+};
+
+type OidcStateRow = {
+  state?: unknown;
+  provider?: unknown;
+  code_verifier?: unknown;
+  nonce?: unknown;
+  redirect_to?: unknown;
+  expires_at?: unknown;
 };
 
 function toIsoNow(): string {
@@ -246,5 +261,66 @@ export class AuthStorage {
       SET revoked_at = ?
       WHERE token_hash = ? AND revoked_at IS NULL
     `).run(toIsoNow(), tokenHash);
+  }
+
+  saveOidcState(state: StoredOidcState): void {
+    const now = toIsoNow();
+    this.db.prepare(`
+      INSERT INTO auth_oidc_states (
+        state,
+        provider,
+        code_verifier,
+        nonce,
+        redirect_to,
+        created_at,
+        expires_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(state)
+      DO UPDATE SET
+        provider = excluded.provider,
+        code_verifier = excluded.code_verifier,
+        nonce = excluded.nonce,
+        redirect_to = excluded.redirect_to,
+        created_at = excluded.created_at,
+        expires_at = excluded.expires_at
+    `).run(
+      state.state,
+      state.provider,
+      state.codeVerifier,
+      state.nonce ?? null,
+      state.redirectTo ?? null,
+      now,
+      state.expiresAt,
+    );
+  }
+
+  consumeOidcState(state: string): StoredOidcState | null {
+    const row = this.db.prepare(`
+      SELECT state, provider, code_verifier, nonce, redirect_to, expires_at
+      FROM auth_oidc_states
+      WHERE state = ?
+    `).get(state) as OidcStateRow | undefined;
+
+    this.db.prepare("DELETE FROM auth_oidc_states WHERE state = ?").run(state);
+
+    if (
+      !row
+      || row.provider !== "casdoor"
+      || typeof row.state !== "string"
+      || typeof row.code_verifier !== "string"
+      || typeof row.expires_at !== "string"
+      || Date.parse(row.expires_at) <= Date.now()
+    ) {
+      return null;
+    }
+
+    return {
+      state: row.state,
+      provider: row.provider,
+      codeVerifier: row.code_verifier,
+      nonce: typeof row.nonce === "string" ? row.nonce : undefined,
+      redirectTo: typeof row.redirect_to === "string" ? row.redirect_to : undefined,
+      expiresAt: row.expires_at,
+    };
   }
 }

--- a/apps/api/src/services/auth-storage.ts
+++ b/apps/api/src/services/auth-storage.ts
@@ -23,6 +23,21 @@ type UserRow = {
   status?: unknown;
 };
 
+export type StoredAuthSession = {
+  id: string;
+  userId: string;
+  csrfTokenHash: string;
+  expiresAt: string;
+};
+
+type SessionRow = {
+  id?: unknown;
+  user_id?: unknown;
+  csrf_token_hash?: unknown;
+  expires_at?: unknown;
+  revoked_at?: unknown;
+};
+
 function toIsoNow(): string {
   return formatIsoOffsetInTimezone(new Date(), config.timezone);
 }
@@ -165,5 +180,71 @@ export class AuthStorage {
       workspaceSlug: row.workspace_slug,
       role: row.role,
     }));
+  }
+
+  createSession(input: {
+    userId: string;
+    tokenHash: string;
+    csrfTokenHash: string;
+    expiresAt: string;
+  }): StoredAuthSession {
+    const id = randomUUID();
+    const now = toIsoNow();
+    this.db.prepare(`
+      INSERT INTO auth_sessions (
+        id,
+        user_id,
+        token_hash,
+        csrf_token_hash,
+        created_at,
+        expires_at,
+        revoked_at
+      ) VALUES (?, ?, ?, ?, ?, ?, NULL)
+    `).run(id, input.userId, input.tokenHash, input.csrfTokenHash, now, input.expiresAt);
+
+    return {
+      id,
+      userId: input.userId,
+      csrfTokenHash: input.csrfTokenHash,
+      expiresAt: input.expiresAt,
+    };
+  }
+
+  findSessionByTokenHash(tokenHash: string): StoredAuthSession | null {
+    const row = this.db.prepare(`
+      SELECT id, user_id, csrf_token_hash, expires_at, revoked_at
+      FROM auth_sessions
+      WHERE token_hash = ?
+    `).get(tokenHash) as SessionRow | undefined;
+
+    if (
+      !row
+      || typeof row.id !== "string"
+      || typeof row.user_id !== "string"
+      || typeof row.csrf_token_hash !== "string"
+      || typeof row.expires_at !== "string"
+      || row.revoked_at
+    ) {
+      return null;
+    }
+
+    if (Date.parse(row.expires_at) <= Date.now()) {
+      return null;
+    }
+
+    return {
+      id: row.id,
+      userId: row.user_id,
+      csrfTokenHash: row.csrf_token_hash,
+      expiresAt: row.expires_at,
+    };
+  }
+
+  revokeSessionByTokenHash(tokenHash: string): void {
+    this.db.prepare(`
+      UPDATE auth_sessions
+      SET revoked_at = ?
+      WHERE token_hash = ? AND revoked_at IS NULL
+    `).run(toIsoNow(), tokenHash);
   }
 }

--- a/apps/api/src/services/auth-storage.ts
+++ b/apps/api/src/services/auth-storage.ts
@@ -1,0 +1,169 @@
+import { randomUUID } from "node:crypto";
+
+import { config } from "./config.js";
+import { getResumeScreeningDb } from "./database.js";
+import { formatIsoOffsetInTimezone } from "./timezone.js";
+import type { AuthProvider, AuthUser, WorkspaceMembership, WorkspaceRole } from "./auth-types.js";
+
+type IdentityRow = {
+  user_id?: unknown;
+};
+
+type MembershipRow = {
+  user_id: string;
+  workspace_slug: string;
+  role: WorkspaceRole;
+};
+
+type UserRow = {
+  id?: unknown;
+  email?: unknown;
+  name?: unknown;
+  display_name?: unknown;
+  status?: unknown;
+};
+
+function toIsoNow(): string {
+  return formatIsoOffsetInTimezone(new Date(), config.timezone);
+}
+
+export class AuthStorage {
+  private readonly db;
+
+  constructor(projectRoot?: string) {
+    this.db = getResumeScreeningDb(projectRoot);
+  }
+
+  createUser(input: { email?: string; displayName?: string }): AuthUser {
+    const id = randomUUID();
+    const now = toIsoNow();
+    this.db.prepare(`
+      INSERT INTO users (id, email, name, display_name, status, created_at, last_active_at)
+      VALUES (?, ?, ?, ?, 'active', ?, ?)
+    `).run(
+      id,
+      input.email ?? null,
+      input.displayName ?? null,
+      input.displayName ?? null,
+      now,
+      now,
+    );
+
+    return {
+      id,
+      email: input.email,
+      displayName: input.displayName,
+      status: "active",
+    };
+  }
+
+  findUser(userId: string): AuthUser | null {
+    const row = this.db
+      .prepare("SELECT id, email, name, display_name, status FROM users WHERE id = ?")
+      .get(userId) as UserRow | undefined;
+
+    if (!row || typeof row.id !== "string") {
+      return null;
+    }
+
+    const status = typeof row.status === "string" ? row.status : "active";
+    if (status !== "active") {
+      return null;
+    }
+
+    const displayName = typeof row.display_name === "string"
+      ? row.display_name
+      : typeof row.name === "string"
+        ? row.name
+        : undefined;
+
+    return {
+      id: row.id,
+      email: typeof row.email === "string" ? row.email : undefined,
+      displayName,
+      status: "active",
+    };
+  }
+
+  linkIdentity(input: {
+    userId: string;
+    provider: AuthProvider;
+    providerSubject: string;
+    providerTenant?: string;
+    email?: string;
+    displayName?: string;
+    rawProfile?: unknown;
+  }): void {
+    const now = toIsoNow();
+    this.db.prepare(`
+      INSERT INTO auth_identities (
+        id,
+        user_id,
+        provider,
+        provider_subject,
+        provider_tenant,
+        email,
+        display_name,
+        raw_profile_json,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(provider, provider_subject, provider_tenant)
+      DO UPDATE SET
+        user_id = excluded.user_id,
+        email = excluded.email,
+        display_name = excluded.display_name,
+        raw_profile_json = excluded.raw_profile_json,
+        updated_at = excluded.updated_at
+    `).run(
+      randomUUID(),
+      input.userId,
+      input.provider,
+      input.providerSubject,
+      input.providerTenant ?? null,
+      input.email ?? null,
+      input.displayName ?? null,
+      input.rawProfile === undefined ? null : JSON.stringify(input.rawProfile),
+      now,
+      now,
+    );
+  }
+
+  findIdentity(
+    provider: AuthProvider,
+    providerSubject: string,
+    providerTenant?: string,
+  ): { userId: string } | null {
+    const row = this.db.prepare(`
+      SELECT user_id FROM auth_identities
+      WHERE provider = ? AND provider_subject = ? AND provider_tenant IS ?
+    `).get(provider, providerSubject, providerTenant ?? null) as IdentityRow | undefined;
+
+    return typeof row?.user_id === "string" ? { userId: row.user_id } : null;
+  }
+
+  upsertMembership(input: WorkspaceMembership): void {
+    const now = toIsoNow();
+    this.db.prepare(`
+      INSERT INTO workspace_memberships (user_id, workspace_slug, role, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(user_id, workspace_slug)
+      DO UPDATE SET role = excluded.role, updated_at = excluded.updated_at
+    `).run(input.userId, input.workspaceSlug, input.role, now, now);
+  }
+
+  listMemberships(userId: string): WorkspaceMembership[] {
+    const rows = this.db.prepare(`
+      SELECT user_id, workspace_slug, role
+      FROM workspace_memberships
+      WHERE user_id = ?
+      ORDER BY workspace_slug ASC
+    `).all(userId) as MembershipRow[];
+
+    return rows.map((row) => ({
+      userId: row.user_id,
+      workspaceSlug: row.workspace_slug,
+      role: row.role,
+    }));
+  }
+}

--- a/apps/api/src/services/auth-storage.ts
+++ b/apps/api/src/services/auth-storage.ts
@@ -10,6 +10,7 @@ import type {
   WorkspaceMembership,
   WorkspaceRole,
 } from "./auth-types.js";
+import type { PasswordCredential } from "./local-password-provider.js";
 
 type IdentityRow = {
   user_id?: unknown;
@@ -19,6 +20,18 @@ type MembershipRow = {
   user_id: string;
   workspace_slug: string;
   role: WorkspaceRole;
+};
+
+type PasswordCredentialRow = {
+  user_id?: unknown;
+  password_hash?: unknown;
+  salt?: unknown;
+  scrypt_n?: unknown;
+  scrypt_r?: unknown;
+  scrypt_p?: unknown;
+  key_length?: unknown;
+  must_change_password?: unknown;
+  password_changed_at?: unknown;
 };
 
 type UserRow = {
@@ -34,6 +47,12 @@ export type StoredAuthSession = {
   userId: string;
   csrfTokenHash: string;
   expiresAt: string;
+};
+
+export type StoredPasswordCredential = PasswordCredential & {
+  userId: string;
+  mustChangePassword: boolean;
+  passwordChangedAt?: string;
 };
 
 type SessionRow = {
@@ -195,6 +214,93 @@ export class AuthStorage {
       workspaceSlug: row.workspace_slug,
       role: row.role,
     }));
+  }
+
+  savePasswordCredential(input: PasswordCredential & {
+    userId: string;
+    mustChangePassword?: boolean;
+  }): void {
+    const now = toIsoNow();
+    const mustChangePassword = input.mustChangePassword ?? true;
+    this.db.prepare(`
+      INSERT INTO auth_password_credentials (
+        user_id,
+        password_hash,
+        salt,
+        scrypt_n,
+        scrypt_r,
+        scrypt_p,
+        key_length,
+        must_change_password,
+        password_changed_at,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(user_id)
+      DO UPDATE SET
+        password_hash = excluded.password_hash,
+        salt = excluded.salt,
+        scrypt_n = excluded.scrypt_n,
+        scrypt_r = excluded.scrypt_r,
+        scrypt_p = excluded.scrypt_p,
+        key_length = excluded.key_length,
+        must_change_password = excluded.must_change_password,
+        password_changed_at = excluded.password_changed_at,
+        updated_at = excluded.updated_at
+    `).run(
+      input.userId,
+      input.passwordHash,
+      input.salt,
+      input.scryptN,
+      input.scryptR,
+      input.scryptP,
+      input.keyLength,
+      mustChangePassword ? 1 : 0,
+      mustChangePassword ? null : now,
+      now,
+      now,
+    );
+  }
+
+  findPasswordCredential(userId: string): StoredPasswordCredential | null {
+    const row = this.db.prepare(`
+      SELECT
+        user_id,
+        password_hash,
+        salt,
+        scrypt_n,
+        scrypt_r,
+        scrypt_p,
+        key_length,
+        must_change_password,
+        password_changed_at
+      FROM auth_password_credentials
+      WHERE user_id = ?
+    `).get(userId) as PasswordCredentialRow | undefined;
+
+    if (
+      typeof row?.user_id !== "string"
+      || typeof row.password_hash !== "string"
+      || typeof row.salt !== "string"
+      || typeof row.scrypt_n !== "number"
+      || typeof row.scrypt_r !== "number"
+      || typeof row.scrypt_p !== "number"
+      || typeof row.key_length !== "number"
+    ) {
+      return null;
+    }
+
+    return {
+      userId: row.user_id,
+      passwordHash: row.password_hash,
+      salt: row.salt,
+      scryptN: row.scrypt_n,
+      scryptR: row.scrypt_r,
+      scryptP: row.scrypt_p,
+      keyLength: row.key_length,
+      mustChangePassword: row.must_change_password === 1,
+      passwordChangedAt: typeof row.password_changed_at === "string" ? row.password_changed_at : undefined,
+    };
   }
 
   createSession(input: {

--- a/apps/api/src/services/auth-types.ts
+++ b/apps/api/src/services/auth-types.ts
@@ -21,6 +21,15 @@ export type AuthContext = {
   csrfToken: string;
 };
 
+export type StoredOidcState = {
+  state: string;
+  provider: "casdoor";
+  codeVerifier: string;
+  nonce?: string;
+  redirectTo?: string;
+  expiresAt: string;
+};
+
 export function hasWorkspaceRole(
   memberships: WorkspaceMembership[],
   workspaceSlug: string,

--- a/apps/api/src/services/auth-types.ts
+++ b/apps/api/src/services/auth-types.ts
@@ -1,0 +1,32 @@
+export type AuthProvider = "local" | "casdoor";
+export type WorkspaceRole = "user" | "admin";
+
+export type AuthUser = {
+  id: string;
+  email?: string;
+  displayName?: string;
+  status: "active" | "disabled";
+};
+
+export type WorkspaceMembership = {
+  userId: string;
+  workspaceSlug: string;
+  role: WorkspaceRole;
+};
+
+export type AuthContext = {
+  user: AuthUser;
+  memberships: WorkspaceMembership[];
+  sessionId: string;
+  csrfToken: string;
+};
+
+export function hasWorkspaceRole(
+  memberships: WorkspaceMembership[],
+  workspaceSlug: string,
+  roles: readonly WorkspaceRole[],
+): boolean {
+  return memberships.some((membership) => (
+    membership.workspaceSlug === workspaceSlug && roles.includes(membership.role)
+  ));
+}

--- a/apps/api/src/services/config.ts
+++ b/apps/api/src/services/config.ts
@@ -23,10 +23,34 @@ const timezone = resolveTimezone({
 });
 ensureProcessTimezone(timezone);
 
+const isProduction = process.env.NODE_ENV === "production";
+
 export const config = {
   port: parseInt(process.env.PORT || "3000", 10),
   workerUrl: process.env.WORKER_URL || "http://localhost:8000",
   projectRoot,
   timezone,
   version: "0.4.6",
+  auth: {
+    sessionCookieName: process.env.AUTH_SESSION_COOKIE_NAME || "trends_session",
+    csrfCookieName: process.env.AUTH_CSRF_COOKIE_NAME || "trends_csrf",
+    sessionTtlSeconds: parseInt(process.env.AUTH_SESSION_TTL_SECONDS || "604800", 10),
+    secureCookies: isProduction,
+    devBypassEnabled: process.env.AUTH_DEV_BYPASS === "true" && !isProduction,
+    devUserId: process.env.AUTH_DEV_USER_ID || "dev-admin",
+    allowedOrigins: (process.env.AUTH_ALLOWED_ORIGINS || "")
+      .split(",")
+      .map((origin) => origin.trim())
+      .filter((origin) => origin.length > 0),
+    convexWriteSecret: process.env.CONVEX_WRITE_SECRET || "",
+    oidc: {
+      enabled: process.env.AUTH_OIDC_ENABLED === "true",
+      provider: "casdoor" as const,
+      issuer: process.env.AUTH_OIDC_ISSUER || "",
+      clientId: process.env.AUTH_OIDC_CLIENT_ID || "",
+      clientSecret: process.env.AUTH_OIDC_CLIENT_SECRET || "",
+      redirectUri: process.env.AUTH_OIDC_REDIRECT_URI || "",
+      scope: process.env.AUTH_OIDC_SCOPE || "openid profile email",
+    },
+  },
 };

--- a/apps/api/src/services/database.ts
+++ b/apps/api/src/services/database.ts
@@ -82,6 +82,8 @@ function initSchema(db: Database.Database): void {
       id TEXT PRIMARY KEY,
       email TEXT,
       name TEXT,
+      display_name TEXT,
+      status TEXT DEFAULT 'active',
       role TEXT DEFAULT 'recruiter',
       team_id TEXT,
       created_at TEXT NOT NULL,
@@ -172,6 +174,72 @@ function initSchema(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_actions_user ON candidate_actions(user_id);
     CREATE INDEX IF NOT EXISTS idx_actions_type ON candidate_actions(action_type);
 
+    CREATE TABLE IF NOT EXISTS auth_identities (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      provider_subject TEXT NOT NULL,
+      provider_tenant TEXT,
+      email TEXT,
+      display_name TEXT,
+      raw_profile_json TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      UNIQUE(provider, provider_subject, provider_tenant),
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS auth_password_credentials (
+      user_id TEXT PRIMARY KEY,
+      password_hash TEXT NOT NULL,
+      salt TEXT NOT NULL,
+      scrypt_n INTEGER NOT NULL,
+      scrypt_r INTEGER NOT NULL,
+      scrypt_p INTEGER NOT NULL,
+      key_length INTEGER NOT NULL,
+      must_change_password INTEGER NOT NULL DEFAULT 1,
+      password_changed_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS auth_sessions (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      token_hash TEXT NOT NULL UNIQUE,
+      csrf_token_hash TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      revoked_at TEXT,
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS auth_oidc_states (
+      state TEXT PRIMARY KEY,
+      provider TEXT NOT NULL,
+      code_verifier TEXT NOT NULL,
+      nonce TEXT,
+      redirect_to TEXT,
+      created_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS workspace_memberships (
+      user_id TEXT NOT NULL,
+      workspace_slug TEXT NOT NULL,
+      role TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (user_id, workspace_slug),
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_auth_identities_user ON auth_identities(user_id);
+    CREATE INDEX IF NOT EXISTS idx_auth_sessions_user ON auth_sessions(user_id);
+    CREATE INDEX IF NOT EXISTS idx_auth_sessions_token ON auth_sessions(token_hash);
+    CREATE INDEX IF NOT EXISTS idx_workspace_memberships_workspace ON workspace_memberships(workspace_slug);
+
     CREATE TABLE IF NOT EXISTS workspace_summary_runs (
       id TEXT PRIMARY KEY,
       workspace_slug TEXT NOT NULL DEFAULT 'dev',
@@ -219,6 +287,11 @@ function initSchema(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_review_packet_runs_workspace ON review_packet_runs(workspace_slug);
     CREATE INDEX IF NOT EXISTS idx_review_packet_runs_exported ON review_packet_runs(exported_at DESC);
   `);
+
+  if (existingTables.has("users")) {
+    ensureColumn(db, "users", "display_name", "TEXT");
+    ensureColumn(db, "users", "status", "TEXT DEFAULT 'active'");
+  }
 
   if (existingTables.has("resume_matches")) {
     ensureColumn(db, "resume_matches", "breakdown", "TEXT");

--- a/apps/api/src/services/local-password-provider.test.ts
+++ b/apps/api/src/services/local-password-provider.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { hashPassword, verifyPassword } from "./local-password-provider.js";
+
+describe("local password provider", () => {
+  it("verifies the original password and rejects a different password", async () => {
+    const credential = await hashPassword("Correct Horse Battery Staple 1");
+
+    await expect(verifyPassword("Correct Horse Battery Staple 1", credential)).resolves.toBe(true);
+    await expect(verifyPassword("wrong-password", credential)).resolves.toBe(false);
+  });
+});

--- a/apps/api/src/services/local-password-provider.ts
+++ b/apps/api/src/services/local-password-provider.ts
@@ -1,0 +1,64 @@
+import { randomBytes, scrypt, timingSafeEqual } from "node:crypto";
+
+export type PasswordCredential = {
+  passwordHash: string;
+  salt: string;
+  scryptN: number;
+  scryptR: number;
+  scryptP: number;
+  keyLength: number;
+};
+
+const DEFAULT_PARAMS = {
+  scryptN: 16_384,
+  scryptR: 8,
+  scryptP: 1,
+  keyLength: 64,
+};
+
+function deriveKey(
+  password: string,
+  salt: string,
+  credential: Pick<PasswordCredential, "scryptN" | "scryptR" | "scryptP" | "keyLength">,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    scrypt(
+      password,
+      salt,
+      credential.keyLength,
+      {
+        N: credential.scryptN,
+        r: credential.scryptR,
+        p: credential.scryptP,
+      },
+      (error, key) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(key);
+      },
+    );
+  });
+}
+
+export async function hashPassword(password: string): Promise<PasswordCredential> {
+  const salt = randomBytes(16).toString("base64url");
+  const key = await deriveKey(password, salt, DEFAULT_PARAMS);
+
+  return {
+    passwordHash: key.toString("base64url"),
+    salt,
+    ...DEFAULT_PARAMS,
+  };
+}
+
+export async function verifyPassword(
+  password: string,
+  credential: PasswordCredential,
+): Promise<boolean> {
+  const expected = Buffer.from(credential.passwordHash, "base64url");
+  const actual = await deriveKey(password, credential.salt, credential);
+
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}

--- a/apps/api/src/services/oidc-provider.test.ts
+++ b/apps/api/src/services/oidc-provider.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as client from "openid-client";
+
+import { CasdoorOidcProvider } from "./oidc-provider.js";
+import type { StoredOidcState } from "./auth-types.js";
+
+vi.mock("openid-client", () => ({
+  ClientSecretPost: vi.fn(() => "client-secret-post"),
+  authorizationCodeGrant: vi.fn(),
+  buildAuthorizationUrl: vi.fn((_config: unknown, parameters: Record<string, string>) => {
+    const url = new URL("https://auth.example.test/login/oauth/authorize");
+    for (const [key, value] of Object.entries(parameters)) {
+      url.searchParams.set(key, value);
+    }
+    return url;
+  }),
+  calculatePKCECodeChallenge: vi.fn(async () => "challenge-123"),
+  discovery: vi.fn(),
+  fetchUserInfo: vi.fn(),
+  randomNonce: vi.fn(() => "nonce-123"),
+  randomPKCECodeVerifier: vi.fn(() => "verifier-123"),
+  randomState: vi.fn(() => "state-123"),
+}));
+
+const settings = {
+  issuer: "https://auth.example.test",
+  clientId: "trends",
+  clientSecret: "secret",
+  redirectUri: "https://app.example.test/api/auth/casdoor/callback",
+  scope: "openid profile email",
+};
+
+describe("CasdoorOidcProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(client.discovery).mockResolvedValue({} as Awaited<ReturnType<typeof client.discovery>>);
+  });
+
+  it("builds an authorization URL with PKCE and stores state", async () => {
+    const provider = new CasdoorOidcProvider(settings);
+    const stateStore = vi.fn();
+
+    const result = await provider.buildLoginUrl("/resumes", stateStore);
+
+    expect(result.url.href).toContain("/login/oauth/authorize");
+    expect(result.url.searchParams.get("client_id")).toBe("trends");
+    expect(result.url.searchParams.get("redirect_uri")).toBe(settings.redirectUri);
+    expect(result.url.searchParams.get("scope")).toBe("openid profile email");
+    expect(result.url.searchParams.get("code_challenge")).toBe("challenge-123");
+    expect(result.url.searchParams.get("state")).toBe("state-123");
+    expect(result.url.searchParams.get("nonce")).toBe("nonce-123");
+    expect(stateStore).toHaveBeenCalledWith(expect.objectContaining({
+      state: "state-123",
+      provider: "casdoor",
+      codeVerifier: "verifier-123",
+      nonce: "nonce-123",
+      redirectTo: "/resumes",
+    }));
+  });
+
+  it("maps validated callback claims to a Casdoor identity", async () => {
+    vi.mocked(client.authorizationCodeGrant).mockResolvedValue({
+      access_token: "access-token",
+      claims: () => ({ sub: "casdoor-user-1", email: "hr@example.com" }),
+      expiresIn: () => 3600,
+    } as Awaited<ReturnType<typeof client.authorizationCodeGrant>>);
+    vi.mocked(client.fetchUserInfo).mockResolvedValue({
+      sub: "casdoor-user-1",
+      name: "HR Manager",
+      email: "hr@example.com",
+    });
+
+    const provider = new CasdoorOidcProvider(settings);
+    const state: StoredOidcState = {
+      state: "state-123",
+      provider: "casdoor",
+      codeVerifier: "verifier-123",
+      nonce: "nonce-123",
+      redirectTo: "/resumes",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    };
+
+    const identity = await provider.handleCallback(
+      new URL(`${settings.redirectUri}?code=code-123&state=state-123`),
+      state,
+    );
+
+    expect(client.authorizationCodeGrant).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(URL),
+      {
+        expectedNonce: "nonce-123",
+        expectedState: "state-123",
+        idTokenExpected: true,
+        pkceCodeVerifier: "verifier-123",
+      },
+    );
+    expect(identity).toEqual({
+      provider: "casdoor",
+      providerSubject: "casdoor-user-1",
+      providerTenant: "https://auth.example.test",
+      email: "hr@example.com",
+      displayName: "HR Manager",
+      rawProfile: {
+        sub: "casdoor-user-1",
+        name: "HR Manager",
+        email: "hr@example.com",
+      },
+    });
+  });
+});

--- a/apps/api/src/services/oidc-provider.ts
+++ b/apps/api/src/services/oidc-provider.ts
@@ -1,0 +1,115 @@
+import * as client from "openid-client";
+
+import type { StoredOidcState } from "./auth-types.js";
+
+export type OidcSettings = {
+  issuer: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  scope: string;
+};
+
+export type OidcIdentityClaims = {
+  provider: "casdoor";
+  providerSubject: string;
+  providerTenant: string;
+  email?: string;
+  displayName?: string;
+  rawProfile: unknown;
+};
+
+type SaveOidcState = (state: StoredOidcState) => void | Promise<void>;
+
+function readStringField(value: unknown, key: string): string | undefined {
+  if (typeof value !== "object" || value === null || !(key in value)) {
+    return undefined;
+  }
+
+  const field = value[key as keyof typeof value];
+  return typeof field === "string" ? field : undefined;
+}
+
+export class CasdoorOidcProvider {
+  private configPromise?: Promise<client.Configuration>;
+
+  constructor(private readonly settings: OidcSettings) {}
+
+  async buildLoginUrl(
+    redirectTo: string | undefined,
+    saveState: SaveOidcState,
+  ): Promise<{ url: URL; state: StoredOidcState }> {
+    const config = await this.discover();
+    const codeVerifier = client.randomPKCECodeVerifier();
+    const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
+    const state = client.randomState();
+    const nonce = client.randomNonce();
+    const storedState: StoredOidcState = {
+      state,
+      provider: "casdoor",
+      codeVerifier,
+      nonce,
+      redirectTo,
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+    };
+
+    await saveState(storedState);
+
+    const url = client.buildAuthorizationUrl(config, {
+      client_id: this.settings.clientId,
+      redirect_uri: this.settings.redirectUri,
+      scope: this.settings.scope,
+      code_challenge: codeChallenge,
+      code_challenge_method: "S256",
+      state,
+      nonce,
+    });
+
+    return { url, state: storedState };
+  }
+
+  async handleCallback(callbackUrl: URL, state: StoredOidcState): Promise<OidcIdentityClaims> {
+    if (state.provider !== "casdoor") {
+      throw new Error("Unsupported OIDC provider");
+    }
+
+    const config = await this.discover();
+    const tokens = await client.authorizationCodeGrant(config, callbackUrl, {
+      expectedNonce: state.nonce,
+      expectedState: state.state,
+      idTokenExpected: true,
+      pkceCodeVerifier: state.codeVerifier,
+    });
+    const claims = tokens.claims();
+    const providerSubject = claims?.sub;
+    if (!providerSubject) {
+      throw new Error("OIDC subject claim is required");
+    }
+    if (!tokens.access_token) {
+      throw new Error("OIDC access token is required");
+    }
+
+    const userInfo = await client.fetchUserInfo(config, tokens.access_token, providerSubject);
+    const email = readStringField(userInfo, "email") ?? readStringField(claims, "email");
+    const displayName = readStringField(userInfo, "name") ?? readStringField(claims, "name");
+
+    return {
+      provider: "casdoor",
+      providerSubject,
+      providerTenant: this.settings.issuer,
+      email,
+      displayName,
+      rawProfile: userInfo,
+    };
+  }
+
+  private discover(): Promise<client.Configuration> {
+    this.configPromise ??= client.discovery(
+      new URL(this.settings.issuer),
+      this.settings.clientId,
+      undefined,
+      client.ClientSecretPost(this.settings.clientSecret),
+    );
+    return this.configPromise;
+  }
+}

--- a/apps/api/src/services/resume-import-service.ts
+++ b/apps/api/src/services/resume-import-service.ts
@@ -513,6 +513,7 @@ export async function replayCandidateState(params: {
               status: entry.status,
               notes: entry.notes,
               updatedBy: entry.updatedBy,
+              writeSecret: config.auth.convexWriteSecret,
             },
           }),
         });

--- a/apps/web/src/hooks/useCandidateBlocks.test.ts
+++ b/apps/web/src/hooks/useCandidateBlocks.test.ts
@@ -56,7 +56,7 @@ describe('useCandidateBlocks', () => {
     expect(Object.keys(result.current.blocksByIdentity)).toEqual(['a', 'b'])
   })
 
-  it('blockCandidates POSTs and reloads', async () => {
+  it('blockCandidates POSTs without client-supplied actor and reloads', async () => {
     mockApiClient.GET.mockResolvedValue({ data: { success: true, items: [] } })
     mockApiClient.POST.mockResolvedValueOnce({ data: { success: true } })
 
@@ -70,7 +70,7 @@ describe('useCandidateBlocks', () => {
 
     expect(success).toBe(true)
     expect(mockApiClient.POST).toHaveBeenCalledWith('/api/blocks', {
-      body: { identityKeys: ['key-1', 'key-2'], reason: 'spam', blockedBy: undefined },
+      body: { identityKeys: ['key-1', 'key-2'], reason: 'spam' },
     })
   })
 

--- a/apps/web/src/hooks/useCandidateBlocks.ts
+++ b/apps/web/src/hooks/useCandidateBlocks.ts
@@ -41,7 +41,7 @@ export function useCandidateBlocks(enabled: boolean = true) {
   }, [enabled])
 
   const blockCandidates = useCallback(
-    async (identityKeys: string[], reason?: string, blockedBy?: string) => {
+    async (identityKeys: string[], reason?: string) => {
       const normalized = Array.from(new Set(identityKeys.map((item) => item.trim()).filter((item) => item.length > 0)))
       if (normalized.length === 0) {
         return false
@@ -51,7 +51,6 @@ export function useCandidateBlocks(enabled: boolean = true) {
         body: {
           identityKeys: normalized,
           reason,
-          blockedBy,
         },
       })
 

--- a/apps/web/src/hooks/useCandidateStatus.test.ts
+++ b/apps/web/src/hooks/useCandidateStatus.test.ts
@@ -7,6 +7,9 @@ const upsertMock = vi.fn(async () => 'doc-id')
 let useQueryArg: unknown = undefined
 
 const mockQueryItems = vi.hoisted(() => ({ value: [] as CandidateStatusRecord[] | undefined }))
+const mockApiClient = vi.hoisted(() => ({
+  POST: vi.fn(async () => ({ data: { success: true } })),
+}))
 
 vi.mock('convex/react', () => ({
   useQuery: (_api: unknown, args: unknown) => {
@@ -19,6 +22,10 @@ vi.mock('convex/react', () => ({
 
 vi.mock('@/contexts/WorkspaceContext', () => ({
   useWorkspace: () => ({ slug: 'dev' }),
+}))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: mockApiClient,
 }))
 
 vi.mock('../../../../packages/convex/convex/_generated/api', () => ({
@@ -91,7 +98,7 @@ describe('useCandidateStatus', () => {
     expect(result.current.statusByIdentity['key-2']).toEqual(item2)
   })
 
-  it('updateStatus calls Convex upsert with correct args', async () => {
+  it('updateStatus posts to BFF with correct args', async () => {
     mockQueryItems.value = [mockItem]
     const { result } = renderHook(() => useCandidateStatus(true))
 
@@ -101,11 +108,45 @@ describe('useCandidateStatus', () => {
     })
 
     expect(success).toBe(true)
-    expect(upsertMock).toHaveBeenCalledWith({
-      identityKey: 'key-1',
-      status: 'interviewing',
-      workspaceSlug: 'dev',
-      notes: 'good fit',
+    expect(mockApiClient.POST).toHaveBeenCalledWith('/api/candidate-status', {
+      body: {
+        identityKey: 'key-1',
+        status: 'interviewing',
+        notes: 'good fit',
+      },
+    })
+    expect(upsertMock).not.toHaveBeenCalled()
+  })
+
+  it('updateStatus trims identityKey before posting to BFF', async () => {
+    const { result } = renderHook(() => useCandidateStatus(true))
+
+    await act(async () => {
+      await result.current.updateStatus('  key-1  ', 'shortlisted')
+    })
+
+    expect(mockApiClient.POST).toHaveBeenCalledWith('/api/candidate-status', {
+      body: {
+        identityKey: 'key-1',
+        status: 'shortlisted',
+        notes: undefined,
+      },
+    })
+  })
+
+  it('updateStatus does not send workspaceSlug or updatedBy from the browser', async () => {
+    const { result } = renderHook(() => useCandidateStatus(true))
+
+    await act(async () => {
+      await result.current.updateStatus('key-1', 'interviewing')
+    })
+
+    expect(mockApiClient.POST).toHaveBeenCalledWith('/api/candidate-status', {
+      body: {
+        identityKey: 'key-1',
+        status: 'interviewing',
+        notes: undefined,
+      },
     })
   })
 
@@ -118,11 +159,12 @@ describe('useCandidateStatus', () => {
     })
 
     expect(success).toBe(false)
+    expect(mockApiClient.POST).not.toHaveBeenCalled()
     expect(upsertMock).not.toHaveBeenCalled()
   })
 
-  it('updateStatus returns false when Convex mutation throws', async () => {
-    upsertMock.mockRejectedValueOnce(new Error('Convex error'))
+  it('updateStatus returns false when BFF write fails', async () => {
+    mockApiClient.POST.mockResolvedValueOnce({ data: { success: false } })
     const { result } = renderHook(() => useCandidateStatus(true))
 
     let success = true

--- a/apps/web/src/hooks/useCandidateStatus.ts
+++ b/apps/web/src/hooks/useCandidateStatus.ts
@@ -1,7 +1,8 @@
 import { useCallback, useMemo } from 'react'
-import { useMutation, useQuery } from 'convex/react'
+import { useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
+import { rawApiClient } from '@/lib/api-helpers'
 import type { CandidateStatus } from '@/types/resume'
 
 export type CandidateStatusRecord = {
@@ -17,6 +18,10 @@ export type CandidateStatusRecord = {
     updatedAt: number
     notes?: string
   }>
+}
+
+type CandidateStatusWriteResponse = {
+  success: boolean
 }
 
 export function useCandidateStatus(enabled: boolean = true) {
@@ -41,8 +46,6 @@ export function useCandidateStatus(enabled: boolean = true) {
     }))
   }, [rawItems])
 
-  const upsert = useMutation(api.candidate_status.upsert)
-
   const updateStatus = useCallback(
     async (identityKey: string, status: CandidateStatus, notes?: string) => {
       const normalized = identityKey.trim()
@@ -51,13 +54,19 @@ export function useCandidateStatus(enabled: boolean = true) {
       }
 
       try {
-        await upsert({ identityKey: normalized, status, workspaceSlug, notes })
-        return true
+        const { data, error: apiError } = await rawApiClient.POST<CandidateStatusWriteResponse>('/api/candidate-status', {
+          body: {
+            identityKey: normalized,
+            status,
+            notes,
+          },
+        })
+        return !apiError && data?.success === true
       } catch {
         return false
       }
     },
-    [upsert, workspaceSlug],
+    [],
   )
 
   const statusByIdentity = useMemo(() => {

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockCreateClient = vi.hoisted(() => {
   const use = vi.fn()
@@ -10,9 +10,13 @@ vi.mock('openapi-fetch', () => ({ default: mockCreateClient.client }))
 import './api-client'
 
 describe('api-client', () => {
+  beforeEach(() => {
+    document.cookie = 'trends_csrf=; Max-Age=0; path=/'
+  })
+
   it('creates client with api base URL', () => {
     expect(mockCreateClient.client).toHaveBeenCalledWith(
-      expect.objectContaining({ baseUrl: expect.any(String) })
+      expect.objectContaining({ baseUrl: expect.any(String), credentials: 'include' })
     )
   })
 
@@ -27,5 +31,25 @@ describe('api-client', () => {
     const request = new Request('http://localhost/test', { headers })
     middleware.onRequest({ request })
     expect(request.headers.get('X-Workspace-Slug')).toBe('dev')
+  })
+
+  it('middleware adds csrf header to mutating requests from csrf cookie', () => {
+    document.cookie = 'trends_csrf=csrf-token-1; path=/'
+    const middleware = mockCreateClient.use.mock.calls[0][0]
+    const request = new Request('http://localhost/test', { method: 'POST' })
+
+    middleware.onRequest({ request })
+
+    expect(request.headers.get('X-CSRF-Token')).toBe('csrf-token-1')
+  })
+
+  it('middleware does not add csrf header to read requests', () => {
+    document.cookie = 'trends_csrf=csrf-token-1; path=/'
+    const middleware = mockCreateClient.use.mock.calls[0][0]
+    const request = new Request('http://localhost/test', { method: 'GET' })
+
+    middleware.onRequest({ request })
+
+    expect(request.headers.get('X-CSRF-Token')).toBeNull()
   })
 })

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -4,12 +4,33 @@ import { workspaceRef } from './workspace-ref'
 
 const rawBaseUrl = import.meta.env.VITE_API_URL || '/api'
 export const apiBaseUrl = rawBaseUrl.replace(/\/api\/?$/, '')
+const csrfCookieName = 'trends_csrf'
+const csrfHeaderName = 'X-CSRF-Token'
+const mutatingMethods = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
-export const apiClient = createClient<paths>({ baseUrl: apiBaseUrl })
+function readCookie(name: string): string | null {
+  if (typeof document === 'undefined') {
+    return null
+  }
+  const prefix = `${name}=`
+  const match = document.cookie
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix))
+  return match ? decodeURIComponent(match.slice(prefix.length)) : null
+}
+
+export const apiClient = createClient<paths>({ baseUrl: apiBaseUrl, credentials: 'include' })
 
 apiClient.use({
   onRequest({ request }) {
     request.headers.set('X-Workspace-Slug', workspaceRef.get())
+    if (mutatingMethods.has(request.method.toUpperCase()) && !request.headers.has(csrfHeaderName)) {
+      const csrfToken = readCookie(csrfCookieName)
+      if (csrfToken) {
+        request.headers.set(csrfHeaderName, csrfToken)
+      }
+    }
     return request
   },
 })

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -43,6 +43,361 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        username: string;
+                        password: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Authenticated local user */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            user: {
+                                id: string;
+                                email?: string;
+                                displayName?: string;
+                                /** @enum {string} */
+                                status: "active" | "disabled";
+                            };
+                            memberships: {
+                                userId: string;
+                                workspaceSlug: string;
+                                /** @enum {string} */
+                                role: "user" | "admin";
+                            }[];
+                            csrfToken: string;
+                            expiresAt: string;
+                        };
+                    };
+                };
+                /** @description Invalid credentials */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Current authenticated user */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            user: {
+                                id: string;
+                                email?: string;
+                                displayName?: string;
+                                /** @enum {string} */
+                                status: "active" | "disabled";
+                            };
+                            memberships: {
+                                userId: string;
+                                workspaceSlug: string;
+                                /** @enum {string} */
+                                role: "user" | "admin";
+                            }[];
+                            /** @enum {string|null} */
+                            workspaceRole: "user" | "admin" | null;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Session revoked */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/change-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        currentPassword: string;
+                        newPassword: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Password changed */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Current password invalid */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/casdoor/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    redirectTo?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Redirect to Casdoor authorization URL */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description OIDC disabled */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/casdoor/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Redirect after successful OIDC callback */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Invalid OIDC callback */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description OIDC disabled */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/resumes/search-summary": {
         parameters: {
             query?: never;
@@ -4895,7 +5250,6 @@ export interface paths {
                         identityKey?: string;
                         identityKeys?: string[];
                         reason?: string;
-                        blockedBy?: string;
                     };
                 };
             };
@@ -7572,6 +7926,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Forbidden */
                 403: {
                     headers: {
@@ -7813,6 +8180,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Forbidden */
                 403: {
                     headers: {
@@ -7909,6 +8289,19 @@ export interface paths {
                 };
                 /** @description Invalid payload */
                 400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -8036,6 +8429,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Forbidden */
                 403: {
                     headers: {
@@ -8099,6 +8505,19 @@ export interface paths {
                         "application/json": {
                             /** @enum {boolean} */
                             success: true;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
                         };
                     };
                 };
@@ -8216,6 +8635,19 @@ export interface paths {
                 };
                 /** @description Invalid payload */
                 400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -8354,6 +8786,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Forbidden */
                 403: {
                     headers: {
@@ -8417,6 +8862,19 @@ export interface paths {
                         "application/json": {
                             /** @enum {boolean} */
                             success: true;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
                         };
                     };
                 };
@@ -8546,6 +9004,19 @@ export interface paths {
                 };
                 /** @description Invalid payload */
                 400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -8728,6 +9199,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Forbidden */
                 403: {
                     headers: {
@@ -8846,6 +9330,19 @@ export interface paths {
                 };
                 /** @description Invalid payload */
                 400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -9859,6 +10356,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Forbidden */
                 403: {
                     headers: {
@@ -9940,6 +10450,19 @@ export interface paths {
                 };
                 /** @description Invalid summary profile */
                 400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -10088,6 +10611,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Forbidden */
                 403: {
                     headers: {
@@ -10194,6 +10730,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
                 /** @description Forbidden */
                 403: {
                     headers: {
@@ -10244,6 +10793,19 @@ export interface paths {
                         "application/json": {
                             /** @enum {boolean} */
                             success: true;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
                         };
                     };
                 };

--- a/apps/web/src/lib/auth.test.ts
+++ b/apps/web/src/lib/auth.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockApiClient = vi.hoisted(() => ({
+  GET: vi.fn(),
+  POST: vi.fn(),
+}))
+
+vi.mock('./api-helpers', () => ({
+  rawApiClient: mockApiClient,
+}))
+
+vi.mock('./api-client', () => ({
+  apiBaseUrl: '',
+}))
+
+import {
+  fetchCurrentAuth,
+  getCasdoorLoginUrl,
+  loginWithLocalPassword,
+  logout,
+} from './auth'
+
+const user = {
+  id: 'user-1',
+  email: 'admin@example.com',
+  displayName: 'Admin',
+  status: 'active' as const,
+}
+
+const authMe = {
+  success: true as const,
+  user,
+  memberships: [{ userId: 'user-1', workspaceSlug: 'dev', role: 'admin' as const }],
+  workspaceRole: 'admin' as const,
+}
+
+describe('auth helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches the current auth context', async () => {
+    mockApiClient.GET.mockResolvedValueOnce({ data: authMe })
+
+    await expect(fetchCurrentAuth()).resolves.toEqual(authMe)
+
+    expect(mockApiClient.GET).toHaveBeenCalledWith('/api/auth/me')
+  })
+
+  it('returns null when current auth request is unauthenticated', async () => {
+    mockApiClient.GET.mockResolvedValueOnce({ error: { status: 401 } })
+
+    await expect(fetchCurrentAuth()).resolves.toBeNull()
+  })
+
+  it('logs in with local credentials', async () => {
+    const loginResponse = {
+      success: true as const,
+      user,
+      memberships: authMe.memberships,
+      csrfToken: 'csrf-token',
+      expiresAt: '2026-06-06T00:00:00.000Z',
+    }
+    mockApiClient.POST.mockResolvedValueOnce({ data: loginResponse })
+
+    await expect(loginWithLocalPassword('admin', 'secret')).resolves.toEqual(loginResponse)
+
+    expect(mockApiClient.POST).toHaveBeenCalledWith('/api/auth/login', {
+      body: { username: 'admin', password: 'secret' },
+    })
+  })
+
+  it('logs out through the auth endpoint', async () => {
+    mockApiClient.POST.mockResolvedValueOnce({ data: { success: true } })
+
+    await expect(logout()).resolves.toBe(true)
+
+    expect(mockApiClient.POST).toHaveBeenCalledWith('/api/auth/logout')
+  })
+
+  it('builds a Casdoor login URL with a safe redirect path', () => {
+    expect(getCasdoorLoginUrl('/settings?tab=auth')).toBe(
+      '/api/auth/casdoor/login?redirectTo=%2Fsettings%3Ftab%3Dauth',
+    )
+  })
+})

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,0 +1,82 @@
+import { rawApiClient } from './api-helpers'
+import { apiBaseUrl } from './api-client'
+
+export type AuthUser = {
+  id: string
+  email?: string
+  displayName?: string
+  status: 'active' | 'disabled'
+}
+
+export type WorkspaceRole = 'user' | 'admin'
+
+export type WorkspaceMembership = {
+  userId: string
+  workspaceSlug: string
+  role: WorkspaceRole
+}
+
+export type CurrentAuth = {
+  success: true
+  user: AuthUser
+  memberships: WorkspaceMembership[]
+  workspaceRole: WorkspaceRole | null
+}
+
+export type LocalLoginResponse = {
+  success: true
+  user: AuthUser
+  memberships: WorkspaceMembership[]
+  csrfToken: string
+  expiresAt: string
+}
+
+function joinApiPath(path: string): string {
+  return `${apiBaseUrl.replace(/\/$/, '')}${path}`
+}
+
+function getCurrentRedirectPath(): string {
+  if (typeof window === 'undefined') {
+    return '/'
+  }
+  return `${window.location.pathname}${window.location.search}${window.location.hash}` || '/'
+}
+
+function sanitizeRedirectPath(path: string): string {
+  if (!path.startsWith('/') || path.startsWith('//')) {
+    return '/'
+  }
+  return path
+}
+
+export async function fetchCurrentAuth(): Promise<CurrentAuth | null> {
+  const { data, error } = await rawApiClient.GET<CurrentAuth>('/api/auth/me')
+  if (error || data?.success !== true) {
+    return null
+  }
+  return data
+}
+
+export async function loginWithLocalPassword(username: string, password: string): Promise<LocalLoginResponse | null> {
+  const { data, error } = await rawApiClient.POST<LocalLoginResponse>('/api/auth/login', {
+    body: { username, password },
+  })
+  if (error || data?.success !== true) {
+    return null
+  }
+  return data
+}
+
+export async function logout(): Promise<boolean> {
+  const { data, error } = await rawApiClient.POST<{ success: boolean }>('/api/auth/logout')
+  return !error && data?.success === true
+}
+
+export function getCasdoorLoginUrl(redirectTo: string = getCurrentRedirectPath()): string {
+  const params = new URLSearchParams({ redirectTo: sanitizeRedirectPath(redirectTo) })
+  return `${joinApiPath('/api/auth/casdoor/login')}?${params.toString()}`
+}
+
+export function redirectToCasdoorLogin(redirectTo?: string): void {
+  window.location.assign(getCasdoorLoginUrl(redirectTo))
+}

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "mammoth": "^1.12.0",
         "node-unrar-js": "^2.0.2",
         "nodemailer": "^8.0.8",
+        "openid-client": "^6.8.4",
         "papaparse": "^5.5.3",
         "pdf-parse": "^2.4.5",
         "yaml": "^2.9.0",
@@ -899,6 +900,8 @@
 
     "jiti": ["jiti@1.21.7", "", { "bin": "bin/jiti.js" }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
     "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
@@ -1015,6 +1018,8 @@
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
+    "oauth4webapi": ["oauth4webapi@3.8.6", "", {}, "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
@@ -1030,6 +1035,8 @@
     "openapi-typescript-helpers": ["openapi-typescript-helpers@0.1.0", "", {}, "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw=="],
 
     "openapi3-ts": ["openapi3-ts@4.5.0", "", { "dependencies": { "yaml": "^2.8.0" } }, "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ=="],
+
+    "openid-client": ["openid-client@6.8.4", "", { "dependencies": { "jose": "^6.2.2", "oauth4webapi": "^3.8.5" } }, "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw=="],
 
     "option": ["option@0.2.4", "", {}, "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A=="],
 
@@ -1343,11 +1350,7 @@
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
-
     "@typescript-eslint/typescript-estree/semver": ["semver@7.8.1", "", { "bin": "bin/semver.js" }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
-
-    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -1389,8 +1392,6 @@
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "tinyglobby/fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -1401,8 +1402,6 @@
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "vite/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
-
     "zip-stream/archiver-utils": ["archiver-utils@3.0.4", "", { "dependencies": { "glob": "^7.2.3", "graceful-fs": "^4.2.0", "lazystream": "^1.0.0", "lodash.defaults": "^4.2.0", "lodash.difference": "^4.5.0", "lodash.flatten": "^4.4.0", "lodash.isplainobject": "^4.0.6", "lodash.union": "^4.6.0", "normalize-path": "^3.0.0", "readable-stream": "^3.6.0" } }, "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw=="],
 
     "@radix-ui/react-label/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
@@ -1410,8 +1409,6 @@
     "@radix-ui/react-progress/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
     "@redocly/openapi-core/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "archiver-utils/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
@@ -1542,8 +1539,6 @@
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@redocly/openapi-core/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/packages/convex/__tests__/candidate-blocks-auth-convex-test.test.ts
+++ b/packages/convex/__tests__/candidate-blocks-auth-convex-test.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { api } from "../convex/_generated/api.js";
+import { createTest } from "./test-helpers.js";
+
+const WRITE_SECRET = "test-secret";
+
+describe("candidate_blocks write authorization", () => {
+  const originalWriteSecret = process.env.CONVEX_WRITE_SECRET;
+
+  beforeEach(() => {
+    process.env.CONVEX_WRITE_SECRET = WRITE_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalWriteSecret === undefined) {
+      delete process.env.CONVEX_WRITE_SECRET;
+      return;
+    }
+    process.env.CONVEX_WRITE_SECRET = originalWriteSecret;
+  });
+
+  it("rejects block mutations without the server write secret", async () => {
+    const t = createTest();
+
+    await expect(
+      t.mutation(api.candidate_blocks.upsert, {
+        workspaceSlug: "hr",
+        identityKey: "candidate-1",
+        reason: "duplicate",
+      }),
+    ).rejects.toThrow("Unauthorized Convex write");
+
+    await expect(
+      t.mutation(api.candidate_blocks.bulkUpsert, {
+        workspaceSlug: "hr",
+        identityKeys: ["candidate-1"],
+        reason: "duplicate",
+        writeSecret: "wrong-secret",
+      }),
+    ).rejects.toThrow("Unauthorized Convex write");
+
+    await expect(
+      t.mutation(api.candidate_blocks.updateReason, {
+        workspaceSlug: "hr",
+        identityKey: "candidate-1",
+        reason: "new reason",
+      }),
+    ).rejects.toThrow("Unauthorized Convex write");
+
+    await expect(
+      t.mutation(api.candidate_blocks.remove, {
+        workspaceSlug: "hr",
+        identityKey: "candidate-1",
+      }),
+    ).rejects.toThrow("Unauthorized Convex write");
+  });
+
+  it("allows block mutations with the server write secret", async () => {
+    const t = createTest();
+
+    const id = await t.mutation(api.candidate_blocks.upsert, {
+      workspaceSlug: "hr",
+      identityKey: "candidate-1",
+      blockedBy: "api-user",
+      writeSecret: WRITE_SECRET,
+    });
+    expect(id).toBeDefined();
+
+    const bulk = await t.mutation(api.candidate_blocks.bulkUpsert, {
+      workspaceSlug: "hr",
+      identityKeys: ["candidate-1", "candidate-2"],
+      reason: "bulk reason",
+      blockedBy: "api-user",
+      writeSecret: WRITE_SECRET,
+    });
+    expect(bulk).toMatchObject({ total: 2, inserted: 1, updated: 1 });
+
+    await expect(
+      t.mutation(api.candidate_blocks.updateReason, {
+        workspaceSlug: "hr",
+        identityKey: "candidate-2",
+        reason: "updated reason",
+        writeSecret: WRITE_SECRET,
+      }),
+    ).resolves.toBe(true);
+
+    await expect(
+      t.mutation(api.candidate_blocks.remove, {
+        workspaceSlug: "hr",
+        identityKey: "candidate-1",
+        writeSecret: WRITE_SECRET,
+      }),
+    ).resolves.toBe(true);
+  });
+});

--- a/packages/convex/__tests__/candidate-blocks-convex-test.test.ts
+++ b/packages/convex/__tests__/candidate-blocks-convex-test.test.ts
@@ -4,9 +4,23 @@
  * Uses edge-runtime environment (configured via environmentMatchGlobs in root vitest.config.ts).
  */
 import { createTest } from "./test-helpers.js";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
 
+const WRITE_SECRET = "test-secret";
+const originalWriteSecret = process.env.CONVEX_WRITE_SECRET;
+
+beforeEach(() => {
+  process.env.CONVEX_WRITE_SECRET = WRITE_SECRET;
+});
+
+afterEach(() => {
+  if (originalWriteSecret === undefined) {
+    delete process.env.CONVEX_WRITE_SECRET;
+    return;
+  }
+  process.env.CONVEX_WRITE_SECRET = originalWriteSecret;
+});
 
 describe("candidate_blocks (convex-test)", () => {
   describe("list", () => {
@@ -94,6 +108,7 @@ describe("candidate_blocks (convex-test)", () => {
         workspaceSlug: "ws1",
         identityKey: "user-new",
         reason: "fraud",
+        writeSecret: WRITE_SECRET,
       });
 
       expect(id).toBeDefined();
@@ -113,6 +128,7 @@ describe("candidate_blocks (convex-test)", () => {
         workspaceSlug: "ws1",
         identityKey: "user-dup",
         reason: "first",
+        writeSecret: WRITE_SECRET,
       });
 
       const id2 = await t.mutation(api.candidate_blocks.upsert, {
@@ -120,6 +136,7 @@ describe("candidate_blocks (convex-test)", () => {
         identityKey: "user-dup",
         reason: "second",
         blockedBy: "admin",
+        writeSecret: WRITE_SECRET,
       });
 
       expect(id2).toBe(id1);
@@ -137,6 +154,7 @@ describe("candidate_blocks (convex-test)", () => {
       await expect(
         t.mutation(api.candidate_blocks.upsert, {
           identityKey: "  ",
+          writeSecret: WRITE_SECRET,
         }),
       ).rejects.toThrow("identityKey is required");
     });
@@ -150,12 +168,14 @@ describe("candidate_blocks (convex-test)", () => {
         workspaceSlug: "ws1",
         identityKey: "user-upd",
         reason: "old",
+        writeSecret: WRITE_SECRET,
       });
 
       const updated = await t.mutation(api.candidate_blocks.updateReason, {
         workspaceSlug: "ws1",
         identityKey: "user-upd",
         reason: "new reason",
+        writeSecret: WRITE_SECRET,
       });
       expect(updated).toBe(true);
 
@@ -172,6 +192,7 @@ describe("candidate_blocks (convex-test)", () => {
         workspaceSlug: "ws1",
         identityKey: "nonexistent",
         reason: "test",
+        writeSecret: WRITE_SECRET,
       });
       expect(updated).toBe(false);
     });
@@ -185,6 +206,7 @@ describe("candidate_blocks (convex-test)", () => {
         workspaceSlug: "ws1",
         identityKeys: ["user-a", "user-b", "user-c"],
         reason: "bulk",
+        writeSecret: WRITE_SECRET,
       });
 
       expect(result.total).toBe(3);
@@ -199,6 +221,7 @@ describe("candidate_blocks (convex-test)", () => {
         workspaceSlug: "ws1",
         identityKeys: ["user-x", "user-x", "user-y"],
         reason: "dedup",
+        writeSecret: WRITE_SECRET,
       });
 
       expect(result.total).toBe(2);
@@ -212,12 +235,14 @@ describe("candidate_blocks (convex-test)", () => {
         workspaceSlug: "ws1",
         identityKey: "user-exist",
         reason: "original",
+        writeSecret: WRITE_SECRET,
       });
 
       const result = await t.mutation(api.candidate_blocks.bulkUpsert, {
         workspaceSlug: "ws1",
         identityKeys: ["user-exist", "user-new"],
         reason: "bulk",
+        writeSecret: WRITE_SECRET,
       });
 
       expect(result.total).toBe(2);
@@ -232,6 +257,7 @@ describe("candidate_blocks (convex-test)", () => {
         workspaceSlug: "ws1",
         identityKeys: ["user-ok", "  ", ""],
         reason: "filter",
+        writeSecret: WRITE_SECRET,
       });
 
       expect(result.total).toBe(1);
@@ -245,11 +271,13 @@ describe("candidate_blocks (convex-test)", () => {
       await t.mutation(api.candidate_blocks.upsert, {
         workspaceSlug: "ws1",
         identityKey: "user-del",
+        writeSecret: WRITE_SECRET,
       });
 
       const removed = await t.mutation(api.candidate_blocks.remove, {
         workspaceSlug: "ws1",
         identityKey: "user-del",
+        writeSecret: WRITE_SECRET,
       });
       expect(removed).toBe(true);
 
@@ -265,6 +293,7 @@ describe("candidate_blocks (convex-test)", () => {
       const removed = await t.mutation(api.candidate_blocks.remove, {
         workspaceSlug: "ws1",
         identityKey: "nonexistent",
+        writeSecret: WRITE_SECRET,
       });
       expect(removed).toBe(false);
     });
@@ -274,6 +303,7 @@ describe("candidate_blocks (convex-test)", () => {
       const removed = await t.mutation(api.candidate_blocks.remove, {
         workspaceSlug: "ws1",
         identityKey: "  ",
+        writeSecret: WRITE_SECRET,
       });
       expect(removed).toBe(false);
     });

--- a/packages/convex/__tests__/candidate-status-auth-convex-test.test.ts
+++ b/packages/convex/__tests__/candidate-status-auth-convex-test.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { api } from "../convex/_generated/api.js";
+import { createTest } from "./test-helpers.js";
+
+const WRITE_SECRET = "test-secret";
+
+describe("candidate_status write authorization", () => {
+  const originalWriteSecret = process.env.CONVEX_WRITE_SECRET;
+
+  beforeEach(() => {
+    process.env.CONVEX_WRITE_SECRET = WRITE_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalWriteSecret === undefined) {
+      delete process.env.CONVEX_WRITE_SECRET;
+      return;
+    }
+    process.env.CONVEX_WRITE_SECRET = originalWriteSecret;
+  });
+
+  it("rejects candidate status upsert without the server write secret", async () => {
+    const t = createTest();
+
+    await expect(
+      t.mutation(api.candidate_status.upsert, {
+        workspaceSlug: "hr",
+        identityKey: "candidate-1",
+        status: "new",
+      }),
+    ).rejects.toThrow("Unauthorized Convex write");
+
+    await expect(
+      t.mutation(api.candidate_status.upsert, {
+        workspaceSlug: "hr",
+        identityKey: "candidate-1",
+        status: "new",
+        writeSecret: "wrong-secret",
+      }),
+    ).rejects.toThrow("Unauthorized Convex write");
+  });
+
+  it("allows candidate status upsert with the server write secret", async () => {
+    const t = createTest();
+
+    const id = await t.mutation(api.candidate_status.upsert, {
+      workspaceSlug: "hr",
+      identityKey: "candidate-1",
+      status: "contacted",
+      updatedBy: "api-user",
+      writeSecret: WRITE_SECRET,
+    });
+
+    expect(id).toBeDefined();
+    const status = await t.query(api.candidate_status.getByIdentity, {
+      workspaceSlug: "hr",
+      identityKey: "candidate-1",
+    });
+    expect(status?.updatedBy).toBe("api-user");
+  });
+});

--- a/packages/convex/__tests__/candidate-status-convex-test.test.ts
+++ b/packages/convex/__tests__/candidate-status-convex-test.test.ts
@@ -4,9 +4,23 @@
  * Covers: list, listForBackup, getByIdentity, upsert (insert + update + history).
  */
 import { createTest } from "./test-helpers.js";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
 
+const WRITE_SECRET = "test-secret";
+const originalWriteSecret = process.env.CONVEX_WRITE_SECRET;
+
+beforeEach(() => {
+  process.env.CONVEX_WRITE_SECRET = WRITE_SECRET;
+});
+
+afterEach(() => {
+  if (originalWriteSecret === undefined) {
+    delete process.env.CONVEX_WRITE_SECRET;
+    return;
+  }
+  process.env.CONVEX_WRITE_SECRET = originalWriteSecret;
+});
 
 // ---------------------------------------------------------------------------
 // upsert + getByIdentity
@@ -21,6 +35,7 @@ describe("candidate_status: upsert + getByIdentity", () => {
       status: "new",
       notes: "Initial entry",
       updatedBy: "recruiter@example.com",
+      writeSecret: WRITE_SECRET,
     });
 
     expect(id).toBeDefined();
@@ -43,14 +58,15 @@ describe("candidate_status: upsert + getByIdentity", () => {
     await t.mutation(api.candidate_status.upsert, {
       identityKey: "candidate-2",
       status: "new",
+      writeSecret: WRITE_SECRET,
     });
 
-    const now = Date.now();
     await t.mutation(api.candidate_status.upsert, {
       identityKey: "candidate-2",
       status: "contacted",
       notes: "Reached out via email",
       updatedBy: "recruiter@example.com",
+      writeSecret: WRITE_SECRET,
     });
 
     const result = await t.query(api.candidate_status.getByIdentity, {
@@ -70,12 +86,14 @@ describe("candidate_status: upsert + getByIdentity", () => {
     await t.mutation(api.candidate_status.upsert, {
       identityKey: "candidate-3",
       status: "new",
+      writeSecret: WRITE_SECRET,
     });
 
     await t.mutation(api.candidate_status.upsert, {
       identityKey: "candidate-3",
       status: "new",
       notes: "Updated notes only",
+      writeSecret: WRITE_SECRET,
     });
 
     const result = await t.query(api.candidate_status.getByIdentity, {
@@ -105,6 +123,7 @@ describe("candidate_status: upsert + getByIdentity", () => {
       t.mutation(api.candidate_status.upsert, {
         identityKey: "  ",
         status: "new",
+        writeSecret: WRITE_SECRET,
       }),
     ).rejects.toThrow("identityKey is required");
   });
@@ -116,6 +135,7 @@ describe("candidate_status: upsert + getByIdentity", () => {
       workspaceSlug: "",
       identityKey: "candidate-empty-ws",
       status: "new",
+      writeSecret: WRITE_SECRET,
     });
 
     const result = await t.query(api.candidate_status.getByIdentity, {
@@ -160,16 +180,19 @@ describe("candidate_status: list + listForBackup", () => {
       workspaceSlug: "ws-list",
       identityKey: "c-1",
       status: "new",
+      writeSecret: WRITE_SECRET,
     });
     await t.mutation(api.candidate_status.upsert, {
       workspaceSlug: "ws-list",
       identityKey: "c-2",
       status: "contacted",
+      writeSecret: WRITE_SECRET,
     });
     await t.mutation(api.candidate_status.upsert, {
       workspaceSlug: "ws-other",
       identityKey: "c-3",
       status: "interviewing",
+      writeSecret: WRITE_SECRET,
     });
 
     const list = await t.query(api.candidate_status.list, {
@@ -190,6 +213,7 @@ describe("candidate_status: list + listForBackup", () => {
       status: "interviewed_pass",
       notes: "Strong candidate",
       updatedBy: "reviewer",
+      writeSecret: WRITE_SECRET,
     });
 
     const rows = await t.query(api.candidate_status.listForBackup, {

--- a/packages/convex/convex/candidate_blocks.ts
+++ b/packages/convex/convex/candidate_blocks.ts
@@ -12,6 +12,13 @@ function normalizeIdentityKey(value: string): string {
     return value.trim();
 }
 
+function requireWriteSecret(writeSecret: string | undefined): void {
+    const expected = process.env.CONVEX_WRITE_SECRET;
+    if (!expected || writeSecret !== expected) {
+        throw new Error("Unauthorized Convex write");
+    }
+}
+
 export const list = query({
     args: {
         workspaceSlug: v.optional(v.string()),
@@ -52,8 +59,10 @@ export const upsert = mutation({
         identityKey: v.string(),
         reason: v.optional(v.string()),
         blockedBy: v.optional(v.string()),
+        writeSecret: v.optional(v.string()),
     },
     handler: async (ctx, args) => {
+        requireWriteSecret(args.writeSecret);
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
         const identityKey = normalizeIdentityKey(args.identityKey);
         if (!identityKey) {
@@ -92,8 +101,10 @@ export const updateReason = mutation({
         workspaceSlug: v.optional(v.string()),
         identityKey: v.string(),
         reason: v.optional(v.string()),
+        writeSecret: v.optional(v.string()),
     },
     handler: async (ctx, args) => {
+        requireWriteSecret(args.writeSecret);
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
         const identityKey = normalizeIdentityKey(args.identityKey);
         if (!identityKey) {
@@ -125,8 +136,10 @@ export const bulkUpsert = mutation({
         identityKeys: v.array(v.string()),
         reason: v.optional(v.string()),
         blockedBy: v.optional(v.string()),
+        writeSecret: v.optional(v.string()),
     },
     handler: async (ctx, args) => {
+        requireWriteSecret(args.writeSecret);
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
         const identityKeys = Array.from(
             new Set(args.identityKeys.map((item) => normalizeIdentityKey(item)).filter((item) => item.length > 0))
@@ -178,8 +191,10 @@ export const remove = mutation({
     args: {
         workspaceSlug: v.optional(v.string()),
         identityKey: v.string(),
+        writeSecret: v.optional(v.string()),
     },
     handler: async (ctx, args) => {
+        requireWriteSecret(args.writeSecret);
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
         const identityKey = normalizeIdentityKey(args.identityKey);
         if (!identityKey) {

--- a/packages/convex/convex/candidate_status.ts
+++ b/packages/convex/convex/candidate_status.ts
@@ -13,6 +13,13 @@ function normalizeIdentityKey(value: string): string {
     return value.trim();
 }
 
+function requireWriteSecret(writeSecret: string | undefined): void {
+    const expected = process.env.CONVEX_WRITE_SECRET;
+    if (!expected || writeSecret !== expected) {
+        throw new Error("Unauthorized Convex write");
+    }
+}
+
 export const listForBackup = query({
     args: {
         workspaceSlug: v.optional(v.string()),
@@ -90,8 +97,10 @@ export const upsert = mutation({
         ),
         notes: v.optional(v.string()),
         updatedBy: v.optional(v.string()),
+        writeSecret: v.optional(v.string()),
     },
     handler: async (ctx, args) => {
+        requireWriteSecret(args.writeSecret);
         const workspaceSlug = normalizeWorkspaceSlug(args.workspaceSlug);
         const identityKey = normalizeIdentityKey(args.identityKey);
         if (!identityKey) {
@@ -139,4 +148,3 @@ export const upsert = mutation({
         });
     },
 });
-

--- a/scripts/check-route-auth.sh
+++ b/scripts/check-route-auth.sh
@@ -2,15 +2,15 @@
 # check-route-auth.sh — Verify that API route files have auth middleware.
 #
 # Checks each route file in apps/api/src/routes/ for:
-# 1. Import of requireAdmin or denyIfNotAdmin from workspace middleware
-# 2. At least one app.use() with requireAdmin or inline denyIfNotAdmin check
+# 1. Admin middleware or inline admin auth checks
+# 2. Workspace-user middleware for authenticated non-admin write routes
 #
 # Exit 0 if all route files with createRoute have auth.
-# Exit 1 if any route file has createRoute but no auth mechanism detected.
+# Exit 1 if any non-public route file has createRoute but no auth mechanism detected.
 
 set -euo pipefail
 
-ROUTES_DIR="apps/api/src/routes"
+ROUTES_DIR="${ROUTES_DIR:-apps/api/src/routes}"
 FAIL=0
 SKIP_FILES=(
   # Health/version — public endpoints
@@ -24,8 +24,9 @@ SKIP_FILES=(
   "industry.ts"
   # User-facing session/action/state endpoints (workspace-scoped, no admin required)
   "sessions.ts"
-  "actions.ts"
   "web-vitals.ts"
+  # Auth endpoints are public by design; protected routes consume their sessions.
+  "auth.ts"
   # Resume search/match (workspace-scoped read paths)
   "resumes_search.ts"
   "resumes_match.ts"
@@ -37,7 +38,6 @@ SKIP_FILES=(
   "scoring-evaluation.ts"
   # Internal worker endpoints (own auth via WORKER_SECRET)
   "worker.ts"
-  "blocks.ts"
 )
 
 is_skipped() {
@@ -71,18 +71,23 @@ for file in "$ROUTES_DIR"/*.ts; do
   fi
 
   # Check for auth mechanism
-  has_require_admin=false
-  has_deny_inline=false
+  has_auth_gate=false
 
   if grep -q 'requireAdmin' "$file" 2>/dev/null; then
-    has_require_admin=true
+    has_auth_gate=true
   fi
   if grep -q 'denyIfNotAdmin' "$file" 2>/dev/null; then
-    has_deny_inline=true
+    has_auth_gate=true
+  fi
+  if grep -q 'getAdminAccessError' "$file" 2>/dev/null; then
+    has_auth_gate=true
+  fi
+  if grep -q 'requireWorkspaceUser' "$file" 2>/dev/null; then
+    has_auth_gate=true
   fi
 
-  if [[ "$has_require_admin" == false ]] && [[ "$has_deny_inline" == false ]]; then
-    echo "FAIL: $base — has createRoute but no requireAdmin or denyIfNotAdmin"
+  if [[ "$has_auth_gate" == false ]]; then
+    echo "FAIL: $base — has createRoute but no auth gate"
     FAIL=1
   fi
 done
@@ -92,6 +97,6 @@ if [[ "$FAIL" -eq 0 ]]; then
   exit 0
 else
   echo ""
-  echo "Some route files are missing auth gating. Add requireAdmin or denyIfNotAdmin."
+  echo "Some route files are missing auth gating. Add requireAdmin, getAdminAccessError, or requireWorkspaceUser."
   exit 1
 fi

--- a/scripts/check-route-auth.test.sh
+++ b/scripts/check-route-auth.test.sh
@@ -16,6 +16,8 @@ fi
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+PASS_OUT="$TMP_DIR/pass.out"
+FAIL_OUT="$TMP_DIR/fail.out"
 
 cat >"$TMP_DIR/workspace-write.ts" <<'ROUTE'
 import { createRoute } from "@hono/zod-openapi";
@@ -35,7 +37,7 @@ app.openapi(route, (c) => {
 });
 ROUTE
 
-ROUTES_DIR="$TMP_DIR" bash "$SCRIPT" >/tmp/check-route-auth-pass.out
+ROUTES_DIR="$TMP_DIR" bash "$SCRIPT" >"$PASS_OUT"
 
 cat >"$TMP_DIR/missing-auth.ts" <<'ROUTE'
 import { createRoute } from "@hono/zod-openapi";
@@ -43,14 +45,14 @@ const route = createRoute({ method: "post", path: "/api/example", responses: {} 
 app.openapi(route, () => {});
 ROUTE
 
-if ROUTES_DIR="$TMP_DIR" bash "$SCRIPT" >/tmp/check-route-auth-fail.out 2>&1; then
+if ROUTES_DIR="$TMP_DIR" bash "$SCRIPT" >"$FAIL_OUT" 2>&1; then
   echo "FAIL: checker passed a createRoute file without auth"
   exit 1
 fi
 
-if ! grep -q "missing-auth.ts" /tmp/check-route-auth-fail.out; then
+if ! grep -q "missing-auth.ts" "$FAIL_OUT"; then
   echo "FAIL: checker did not report the unauthenticated route file"
-  cat /tmp/check-route-auth-fail.out
+  cat "$FAIL_OUT"
   exit 1
 fi
 

--- a/scripts/check-route-auth.test.sh
+++ b/scripts/check-route-auth.test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/check-route-auth.sh"
+
+if grep -q '"actions.ts"' "$SCRIPT"; then
+  echo "FAIL: actions.ts must not be skipped by route auth checker"
+  exit 1
+fi
+
+if grep -q '"blocks.ts"' "$SCRIPT"; then
+  echo "FAIL: blocks.ts must not be skipped by route auth checker"
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat >"$TMP_DIR/workspace-write.ts" <<'ROUTE'
+import { createRoute } from "@hono/zod-openapi";
+import { requireWorkspaceUser } from "../middleware/auth.js";
+const route = createRoute({ method: "post", path: "/api/example", responses: {} });
+app.use("/api/example", requireWorkspaceUser);
+app.openapi(route, () => {});
+ROUTE
+
+cat >"$TMP_DIR/inline-admin.ts" <<'ROUTE'
+import { createRoute } from "@hono/zod-openapi";
+import { getAdminAccessError } from "../middleware/auth.js";
+const route = createRoute({ method: "put", path: "/api/example", responses: {} });
+app.openapi(route, (c) => {
+  const adminError = getAdminAccessError(c);
+  if (adminError) return c.json(adminError.body, adminError.status);
+});
+ROUTE
+
+ROUTES_DIR="$TMP_DIR" bash "$SCRIPT" >/tmp/check-route-auth-pass.out
+
+cat >"$TMP_DIR/missing-auth.ts" <<'ROUTE'
+import { createRoute } from "@hono/zod-openapi";
+const route = createRoute({ method: "post", path: "/api/example", responses: {} });
+app.openapi(route, () => {});
+ROUTE
+
+if ROUTES_DIR="$TMP_DIR" bash "$SCRIPT" >/tmp/check-route-auth-fail.out 2>&1; then
+  echo "FAIL: checker passed a createRoute file without auth"
+  exit 1
+fi
+
+if ! grep -q "missing-auth.ts" /tmp/check-route-auth-fail.out; then
+  echo "FAIL: checker did not report the unauthenticated route file"
+  cat /tmp/check-route-auth-fail.out
+  exit 1
+fi
+
+echo "OK: check-route-auth recognizes auth middleware and reports gaps"


### PR DESCRIPTION
## Summary
- Add SQLite-backed auth users, identities, local password credentials, sessions, OIDC state, and workspace memberships.
- Add local password auth routes plus config-gated Casdoor/OIDC login/callback, CSRF/session middleware, and membership-derived admin/workspace gates.
- Route candidate actions/status/block writes through the BFF, derive actor IDs from auth, and harden Convex write mutations with a server-only secret.
- Update web API credentials/CSRF handling, auth helpers, route-auth checker coverage, and generated API types.

## Verification
- bunx vitest run apps/api/src/middleware/auth.test.ts apps/api/src/middleware/workspace.test.ts
- bunx vitest run apps/api/src/routes/auth.test.ts apps/api/src/middleware/auth.test.ts
- bunx vitest run apps/api/src/routes/actions.test.ts apps/api/src/routes/candidate-status.test.ts apps/api/src/routes/blocks.test.ts
- bunx vitest run packages/convex/__tests__/candidate-status-auth-convex-test.test.ts packages/convex/__tests__/candidate-blocks-auth-convex-test.test.ts packages/convex/__tests__/candidate-status-convex-test.test.ts packages/convex/__tests__/candidate-blocks-convex-test.test.ts
- bunx vitest run apps/api/src/routes/resumes_admin.test.ts apps/api/src/routes/search-profiles.test.ts apps/api/src/routes/config.test.ts apps/api/src/routes/notifications.test.ts apps/api/src/routes/__tests__/notifications-route.test.ts
- bunx vitest run apps/api/src/routes/taxonomy.test.ts apps/api/src/routes/resume-import.test.ts apps/api/src/routes/resumes_diagnostics.test.ts apps/api/src/routes/resumes.test.ts apps/api/src/routes/review-packets.test.ts apps/api/src/routes/summaries.test.ts apps/api/src/routes/filter-presets.test.ts apps/api/src/routes/job-descriptions.test.ts
- bunx vitest run src/lib/api-client.test.ts src/lib/auth.test.ts src/hooks/useCandidateStatus.test.ts src/hooks/useCandidateBlocks.test.ts (from apps/web)
- bash scripts/check-route-auth.test.sh
- npm --workspace @trends/web run gen:api
- bunx tsc -p apps/api/tsconfig.json --noEmit
- bunx tsc -p apps/web/tsconfig.json --noEmit
- make check
- Browser smoke with playwright-cli against http://localhost:5173: app rendered, API client sent X-CSRF-Token and X-Workspace-Slug on POST, unauthenticated candidate-status write returned 401.

## Notes
- Local dev MCP sidecar logged an existing FastMCP import error during browser smoke; web and BFF services were healthy.
- make check/pre-push reported concept-drift reminders for candidate_status/candidate_blocks and concepts/star-rating-identity-model.md; checks still passed.