### PR TITLE
Update Trends agent governance docs and add CONTEXT

### DIFF
--- a/.agents/skills/trends-agent-governance/SKILL.md
+++ b/.agents/skills/trends-agent-governance/SKILL.md
@@ -13,29 +13,20 @@ validation:
 
 # Trends Agent Governance
 
-Apply this workflow for non-trivial technical planning and recommendation tasks.
+Lightweight adapter for Trends-specific governance. Do not duplicate the
+dev-loop pipeline here.
 
 ## Workflow
 
-1. Classify the task.
-   - If the task is a technical design/recommendation task, require source evidence.
-   - If the task is a trivial edit or command-only action, skip evidence unless explicitly requested.
-2. Load local sources first.
-   - Read implementation files and relevant docs in this repository.
-   - Read `dev-docs/*.txt` material relevant to the task.
-3. Query Context7 for libraries/frameworks/APIs involved in the recommendation.
-4. Query official web sources only when freshness-sensitive facts are required.
-5. Format output for portability.
-   - Use repo-relative paths for implementation/report content (for example `apps/api/src/routes/resumes.ts`).
-   - Write commands so they are copy/paste-ready from repository root in a fresh environment.
-   - Avoid machine-specific absolute paths in implementation guidance.
-6. Produce output with `Sources Used` section using the template in `references/evidence-template.md`.
-   - Use repo-relative paths in `Sources Used`.
-7. If AGENTS governance files changed, run:
-   - `make sync-agent-policy`
-   - `make check-agent-policy`
+1. For implementation, debugging, review, prep, investigate, merge, and browser verification work, follow `@dev-loop` and `.claude/dev-loop.config.md`.
+2. For non-trivial architecture, design, library, framework, API, or governance recommendations, apply the canonical policy in `AGENTS.md`.
+3. Use the source order from `AGENTS.md`: local repo, Context7, DevTools for browser-facing verification, then official web only for freshness-sensitive facts.
+4. Include `Sources Used` only for non-trivial technical recommendations, and list only source categories actually consulted.
+5. Keep reusable guidance portable: repo-relative paths, repo-root commands, and no machine-specific paths.
+6. If governance policy or this skill package changes, run the relevant sync/check commands from `AGENTS.md`.
 
 ## References
 
-- Source matrix rules: `references/source-matrix.md`
-- Evidence format template: `references/evidence-template.md`
+- Canonical policy: `AGENTS.md`
+- Pipeline config: `.claude/dev-loop.config.md`
+- Evidence reminder: `references/evidence-template.md`

--- a/.agents/skills/trends-agent-governance/agents/openai.yaml
+++ b/.agents/skills/trends-agent-governance/agents/openai.yaml
@@ -1,3 +1,3 @@
 display_name: Trends Agent Governance
-short_description: Enforce source usage order, portable report pathing, evidence format, and AGENTS policy synchronization for technical guidance.
-default_prompt: Apply the trends-agent-governance workflow before technical recommendations. Use local sources first, then Context7, then official web docs only for freshness-sensitive facts. Keep implementation guidance repo-relative and paste-ready for fresh environments, and include a Sources Used section with repo-relative file paths.
+short_description: Route Trends work to dev-loop config or canonical AGENTS governance policy.
+default_prompt: Use @dev-loop and .claude/dev-loop.config.md for implementation pipeline work. For non-trivial technical recommendations, apply AGENTS.md source/evidence policy and keep reusable guidance repo-relative.

--- a/.agents/skills/trends-agent-governance/references/evidence-template.md
+++ b/.agents/skills/trends-agent-governance/references/evidence-template.md
@@ -1,21 +1,13 @@
 # Sources Used Template
 
-Use this template in non-trivial technical design/recommendation responses.
-
-Pathing requirements:
-- Use repo-relative paths in implementation content outside this section.
-- Use repo-relative paths for local files.
+Use `Sources Used` only for non-trivial technical recommendations.
 
 ```markdown
 ## Sources Used
-- Local files:
-  - apps/example/path.ts
-  - config/example/config.json5
-- Context7:
-  - /org/project
-  - /org/project/version
-- Web:
-  - https://example.com/reference
+- Local files: AGENTS.md, .claude/dev-loop.config.md
+- Context7: /org/project
+- DevTools MCP: take_snapshot, list_console_messages
+- Web: https://example.com/reference
 ```
 
-If a category is not used, set it to `none`.
+Include only categories actually consulted. Omit unused categories.

--- a/.agents/skills/trends-agent-governance/references/source-matrix.md
+++ b/.agents/skills/trends-agent-governance/references/source-matrix.md
@@ -1,17 +1,7 @@
 # Source Matrix
 
-Use this order for non-trivial technical design/recommendation tasks.
+Canonical source policy lives in `AGENTS.md`.
 
-1. Local repository files
-   - Prefer implementation files and config in this repository.
-   - Include relevant cached docs under `dev-docs/*.txt`.
-2. Context7
-   - Query library/framework/API documentation for behavioral correctness and usage details.
-3. Official web sources
-   - Use only for freshness-sensitive facts (new releases, policy changes, current status).
+Summary: local repository sources first, Context7 for library/framework/API behavior, DevTools for browser-facing verification, and official web only for freshness-sensitive facts.
 
-Output pathing rules:
-- Use repo-relative paths in implementation/report content so the output is portable to fresh environments.
-- Use repo-relative paths in `Sources Used` to document what was consulted.
-
-If a source tier is not used, state `none` for that tier in `Sources Used`.
+For dev-loop execution work, use `.claude/dev-loop.config.md` because it defines the active fact-check tier and browser verification gate.

--- a/.claude/commands/trends-agent-governance.md
+++ b/.claude/commands/trends-agent-governance.md
@@ -1,59 +1,19 @@
 # Trends Agent Governance
 
-Apply this governance workflow for non-trivial technical planning and recommendation tasks in this repository.
+Thin command wrapper for the canonical Trends governance policy.
 
 ## Workflow
 
-1. Classify the task.
-   - If the task is technical design/recommendation, source evidence is required.
-   - If the task is a trivial edit or command-only action, evidence is optional unless explicitly requested.
-2. Load local sources first.
-   - Read relevant implementation and configuration files in this repository.
-   - Read relevant cached docs under `./dev-docs/*.txt`.
-3. Query Context7 for library/framework/API behavior and usage details.
-4. Query official web sources only when freshness-sensitive facts are required.
-5. Format output for portability.
-   - Use repo-relative paths for implementation/report content (for example `apps/api/src/routes/resumes.ts`).
-   - Write commands so they are copy/paste-ready from repository root in a fresh environment.
-   - Avoid machine-specific absolute paths in implementation guidance.
-6. Include a `Sources Used` section in the final response using the template below.
-   - Use repo-relative paths in `Sources Used`.
-7. If AGENTS governance files changed, run:
-   - `make sync-agent-policy`
-   - `make check-agent-policy`
+1. If the task is implementation, debugging, review, prep, investigate, merge, or browser verification, follow `@dev-loop` and `.claude/dev-loop.config.md`.
+2. If the task is architecture, design, library/framework/API recommendation, technical planning, or governance policy, follow `AGENTS.md`.
+3. Keep reusable guidance portable: repo-relative paths, repo-root commands, and no machine-specific paths.
+4. If governance policy changes, run the sync/check commands listed in `AGENTS.md`.
+5. If the governance skill package changes, run `make sync-project-skills` and `make check-project-skills`.
 
 ## Source Matrix
 
-Use this strict order for non-trivial technical design/recommendation tasks:
-
-1. Local repository files
-   - Prefer implementation files and config in this repository.
-   - Include relevant cached docs under `./dev-docs/*.txt`.
-2. Context7
-   - Query library/framework/API documentation for correctness and usage details.
-3. Official web sources
-   - Use only for freshness-sensitive facts (new releases, policy changes, current status).
-
-Output pathing rules:
-- Use repo-relative paths in implementation/report content so the output is portable to fresh environments.
-- Use repo-relative paths in `Sources Used` to document what was consulted.
-
-If a source tier is not used, set it to `none` in `Sources Used`.
+Use the canonical source order in `AGENTS.md`: local repository sources, Context7, DevTools MCP for browser-facing verification, then official web only for freshness-sensitive facts.
 
 ## Evidence Template
 
-Use this template in non-trivial technical design/recommendation responses:
-
-```markdown
-## Sources Used
-- Local files:
-  - apps/example/path.ts
-  - config/example/config.json5
-- Context7:
-  - /org/project
-  - /org/project/version
-- Web:
-  - https://example.com/reference
-```
-
-If a category is not used, set it to `none`.
+For non-trivial technical recommendations, include `Sources Used` with only categories actually consulted. Omit unused categories.

--- a/.claude/dev-loop.config.md
+++ b/.claude/dev-loop.config.md
@@ -195,6 +195,24 @@ idle_deep_research:
     p_score_default: P3
 ```
 
+## Preflight prep
+
+> Human-attended readiness mode for `/dev-loop prep`. It batches questions
+> and writes readiness metadata only after approval, then unattended `/goal`
+> cycles skip work that is not explicitly ready.
+
+```yaml
+preflight:
+  enabled: true
+  default_limit: 5
+  default_lanes: [work, captures, hygiene]
+  require_approved_spec_and_plan: true
+  unattended_not_ready_behavior: skip
+  defaults:
+    compatibility_policy: "Trends changes are additive/backward-compatible unless explicitly scoped otherwise."
+    verification_policy: "Run make check; browser-facing changes require make dev plus playwright-cli/e2e per CLAUDE.md."
+```
+
 ## Browser verification
 
 > Per CLAUDE.md feedback memory: every browser-facing change MUST be
@@ -289,7 +307,7 @@ knowledge_backends:
 interview:
   setup:
     skill: setup-dev-loop
-    glossary: native           # grill-with-docs not installed; setup uses bundled prompts
+    glossary: grill-with-docs  # installed at ~/.claude/skills/grill-with-docs/SKILL.md
   work_item:
     default: native
     upgrade: grill-me          # installed at ~/.claude/skills/grill-me/SKILL.md

--- a/.claude/rules/agent-governance.md
+++ b/.claude/rules/agent-governance.md
@@ -1,55 +1,25 @@
 # Agent Governance Workflow
 
-Apply the evidence and source workflow to non-trivial tasks. Trivial tasks (simple edits, running commands, formatting) skip evidence unless explicitly requested.
+Use this file as a short router. `AGENTS.md` is the canonical governance policy; `.claude/dev-loop.config.md` is the operational dev-loop configuration.
 
 ## Task Classification
 
-1. **Non-trivial tasks** (architecture, design, library/framework/API recommendations, technical planning): Full evidence required.
-2. **Trivial tasks** (simple edits, running commands, formatting): Evidence optional unless explicitly requested.
+1. **Dev-loop work**: implementation, debugging, review, prep, investigate, merge, and browser verification follow `@dev-loop` plus `.claude/dev-loop.config.md`.
+2. **Governance work**: architecture, design, library/framework/API recommendations, technical planning, and AGENTS policy changes follow `AGENTS.md`.
+3. **Trivial work**: simple edits, formatting, and command-only tasks skip evidence unless requested.
 
-## Source Priority (strict order)
+## Source Priority
 
-For non-trivial tasks, consult sources in this order:
-
-1. **Local repository files** — implementation files, config, and cached docs under `dev-docs/*.txt`.
-2. **Context7** — query library/framework/API documentation for correctness and usage details.
-3. **DevTools MCP** — browser snapshots, console messages, network requests, and script evaluation for live verification. **Only when the task involves browser-facing changes.**
-4. **Official web sources** — use only for freshness-sensitive facts (new releases, policy changes, current status).
-
-## Output Portability
-
-1. Use repo-relative paths (for example `apps/api/src/routes/resumes.ts`) so output is reusable in a fresh environment.
-2. Write commands that are copy/paste-ready from repository root.
-3. Avoid machine-specific absolute paths.
+Use the strict source order from `AGENTS.md`: local repository sources, Context7, DevTools for browser-facing verification, then official web only for freshness-sensitive facts.
 
 ## Evidence Reporting
 
-For non-trivial technical design/recommendation responses, include a `Sources Used` section with only the categories actually consulted:
+For non-trivial technical recommendations, include `Sources Used` with only categories actually consulted. Omit unused categories.
 
-    ## Sources Used
-    - Local files: apps/example/path.ts
-    - Context7: /org/project
-    - DevTools MCP: take_snapshot — verified X (omit if no browser changes)
-    - Web: https://example.com/reference (omit if no web sources used)
+## Output Portability
 
-Omit entire categories that were not consulted — no need to list `none`.
-
-## Reviser Workflow
-
-After implementing changes to UI or browser-facing code with a running dev server and chrome-debug:
-
-1. **Snapshot** — `take_snapshot` to confirm expected elements exist.
-2. **Console** — `list_console_messages` (filter: error, warn) to verify no regressions.
-3. **Evaluate** — `evaluate_script` to assert runtime state (optional, for state-dependent fixes).
-4. **Compare** — Diff snapshot before/after (optional, for visual regressions).
-
-Skip the entire reviser workflow when:
-- The change is backend-only with no browser-visible effect
-- The dev server / chrome-debug is not running
-- The change is trivial (text, formatting, non-interactive)
+Use repo-relative paths and repo-root commands in reusable guidance. Avoid machine-specific paths unless describing this local workspace.
 
 ## Governance File Changes
 
-If any AGENTS governance files are modified during a session, run:
-- `make sync-agent-policy`
-- `make check-agent-policy`
+If `AGENTS.md` or its generated mirror changes, run `make sync-agent-policy` and `make check-agent-policy`. If this skill package changes, run `make sync-project-skills` and `make check-project-skills`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,45 @@
+# Trends
+
+Trends is a multi-source data aggregation platform. Its primary context is resume screening; news aggregation is a supported extension.
+
+## Language
+
+**Resume Screening**:
+The workflow for ingesting resumes, evaluating fit, filtering candidates, and notifying humans only when needed.
+_Avoid_: HR automation, recruitment bot
+
+**Resume**:
+A candidate profile collected from a supported source and normalized enough for search, scoring, and review.
+_Avoid_: CV record, profile blob
+
+**Candidate**:
+The person represented by one or more resumes or source profiles.
+_Avoid_: Applicant, user
+
+**Search Profile**:
+A reusable screening configuration that captures the role, filters, and matching intent for candidate discovery.
+_Avoid_: Saved search, query preset
+
+**Job Description**:
+The role description used to derive or compare screening intent.
+_Avoid_: JD text blob, prompt
+
+**JD Auto-Match**:
+The workflow that turns a job description into candidate matching criteria and scoreable screening signals.
+_Avoid_: Semantic search, embedding match
+
+**Candidate Action**:
+A human or workflow action on a candidate, such as star, archive, shortlist, reject, note, or contact.
+_Avoid_: Candidate status
+
+**Candidate Status**:
+The candidate's pipeline stage.
+_Avoid_: Candidate action
+
+**Resume Source**:
+An external site or feed that provides resume data.
+_Avoid_: Crawler, provider
+
+**News Aggregation**:
+The older supported extension path for collecting and processing news items.
+_Avoid_: Main product path

--- a/dev-docs/skills/trends-agent-governance/SKILL.md
+++ b/dev-docs/skills/trends-agent-governance/SKILL.md
@@ -13,29 +13,20 @@ validation:
 
 # Trends Agent Governance
 
-Apply this workflow for non-trivial technical planning and recommendation tasks.
+Lightweight adapter for Trends-specific governance. Do not duplicate the
+dev-loop pipeline here.
 
 ## Workflow
 
-1. Classify the task.
-   - If the task is a technical design/recommendation task, require source evidence.
-   - If the task is a trivial edit or command-only action, skip evidence unless explicitly requested.
-2. Load local sources first.
-   - Read implementation files and relevant docs in this repository.
-   - Read `dev-docs/*.txt` material relevant to the task.
-3. Query Context7 for libraries/frameworks/APIs involved in the recommendation.
-4. Query official web sources only when freshness-sensitive facts are required.
-5. Format output for portability.
-   - Use repo-relative paths for implementation/report content (for example `apps/api/src/routes/resumes.ts`).
-   - Write commands so they are copy/paste-ready from repository root in a fresh environment.
-   - Avoid machine-specific absolute paths in implementation guidance.
-6. Produce output with `Sources Used` section using the template in `references/evidence-template.md`.
-   - Use repo-relative paths in `Sources Used`.
-7. If AGENTS governance files changed, run:
-   - `make sync-agent-policy`
-   - `make check-agent-policy`
+1. For implementation, debugging, review, prep, investigate, merge, and browser verification work, follow `@dev-loop` and `.claude/dev-loop.config.md`.
+2. For non-trivial architecture, design, library, framework, API, or governance recommendations, apply the canonical policy in `AGENTS.md`.
+3. Use the source order from `AGENTS.md`: local repo, Context7, DevTools for browser-facing verification, then official web only for freshness-sensitive facts.
+4. Include `Sources Used` only for non-trivial technical recommendations, and list only source categories actually consulted.
+5. Keep reusable guidance portable: repo-relative paths, repo-root commands, and no machine-specific paths.
+6. If governance policy or this skill package changes, run the relevant sync/check commands from `AGENTS.md`.
 
 ## References
 
-- Source matrix rules: `references/source-matrix.md`
-- Evidence format template: `references/evidence-template.md`
+- Canonical policy: `AGENTS.md`
+- Pipeline config: `.claude/dev-loop.config.md`
+- Evidence reminder: `references/evidence-template.md`

--- a/dev-docs/skills/trends-agent-governance/agents/openai.yaml
+++ b/dev-docs/skills/trends-agent-governance/agents/openai.yaml
@@ -1,3 +1,3 @@
 display_name: Trends Agent Governance
-short_description: Enforce source usage order, portable report pathing, evidence format, and AGENTS policy synchronization for technical guidance.
-default_prompt: Apply the trends-agent-governance workflow before technical recommendations. Use local sources first, then Context7, then official web docs only for freshness-sensitive facts. Keep implementation guidance repo-relative and paste-ready for fresh environments, and include a Sources Used section with repo-relative file paths.
+short_description: Route Trends work to dev-loop config or canonical AGENTS governance policy.
+default_prompt: Use @dev-loop and .claude/dev-loop.config.md for implementation pipeline work. For non-trivial technical recommendations, apply AGENTS.md source/evidence policy and keep reusable guidance repo-relative.

--- a/dev-docs/skills/trends-agent-governance/references/evidence-template.md
+++ b/dev-docs/skills/trends-agent-governance/references/evidence-template.md
@@ -1,21 +1,13 @@
 # Sources Used Template
 
-Use this template in non-trivial technical design/recommendation responses.
-
-Pathing requirements:
-- Use repo-relative paths in implementation content outside this section.
-- Use repo-relative paths for local files.
+Use `Sources Used` only for non-trivial technical recommendations.
 
 ```markdown
 ## Sources Used
-- Local files:
-  - apps/example/path.ts
-  - config/example/config.json5
-- Context7:
-  - /org/project
-  - /org/project/version
-- Web:
-  - https://example.com/reference
+- Local files: AGENTS.md, .claude/dev-loop.config.md
+- Context7: /org/project
+- DevTools MCP: take_snapshot, list_console_messages
+- Web: https://example.com/reference
 ```
 
-If a category is not used, set it to `none`.
+Include only categories actually consulted. Omit unused categories.

--- a/dev-docs/skills/trends-agent-governance/references/source-matrix.md
+++ b/dev-docs/skills/trends-agent-governance/references/source-matrix.md
@@ -1,17 +1,7 @@
 # Source Matrix
 
-Use this order for non-trivial technical design/recommendation tasks.
+Canonical source policy lives in `AGENTS.md`.
 
-1. Local repository files
-   - Prefer implementation files and config in this repository.
-   - Include relevant cached docs under `dev-docs/*.txt`.
-2. Context7
-   - Query library/framework/API documentation for behavioral correctness and usage details.
-3. Official web sources
-   - Use only for freshness-sensitive facts (new releases, policy changes, current status).
+Summary: local repository sources first, Context7 for library/framework/API behavior, DevTools for browser-facing verification, and official web only for freshness-sensitive facts.
 
-Output pathing rules:
-- Use repo-relative paths in implementation/report content so the output is portable to fresh environments.
-- Use repo-relative paths in `Sources Used` to document what was consulted.
-
-If a source tier is not used, state `none` for that tier in `Sources Used`.
+For dev-loop execution work, use `.claude/dev-loop.config.md` because it defines the active fact-check tier and browser verification gate.


### PR DESCRIPTION
Consolidate Trends governance to use the canonical AGENTS.md and route implementation/dev-loop work to .claude/dev-loop.config.md. Simplify and standardize the source matrix and evidence template to list only consulted categories and to prefer local repo, Context7, DevTools, then official web for freshness. Update agent metadata/prompts (openai.yaml) and command/rule wrappers to reference the canonical policy and dev-loop pipeline; add guidance to run sync/check commands when AGENTS or skill packages change. Add a new CONTEXT.md with Trends terminology and add a preflight prep section to .claude/dev-loop.config.md (plus a small glossary change).