### PR TITLE
fix: harden production deploy readiness smokes

### DIFF
--- a/deploy/preview-doctor.sh
+++ b/deploy/preview-doctor.sh
@@ -5,7 +5,7 @@
 #   - Caddy reachability (preview.pt-mes.com)
 #   - Convex container health + memory headroom
 #   - Convex /version + sync HTTP upgrade
-#   - Preview API systemd status + /api/blocks /api/search-profiles
+#   - Preview API systemd status + /api/blocks and a public resume query
 #   - MCP container status
 #   - Recent dmesg OOM kills affecting any preview container
 #
@@ -21,6 +21,7 @@ COMPOSE_FILE="$PREVIEW_DIR/docker-compose.preview.yml"
 CONVEX_PORT=4210
 API_PORT=3002
 PUBLIC_HOST=preview.pt-mes.com
+RESUME_SMOKE_PATH="/api/resumes?source=convex&paged=true&limit=1"
 
 RECOVER=0
 FULL=0
@@ -89,9 +90,9 @@ if systemctl is-active --quiet trends-preview-api 2>/dev/null; then
 else
     fail "trends-preview-api is NOT active"
 fi
-SP=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:$API_PORT/api/search-profiles" || echo 000)
+RS=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:$API_PORT$RESUME_SMOKE_PATH" || echo 000)
 BL=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:$API_PORT/api/blocks" || echo 000)
-[ "$SP" = "200" ] && ok "/api/search-profiles → $SP" || fail "/api/search-profiles → $SP"
+[ "$RS" = "200" ] && ok "$RESUME_SMOKE_PATH → $RS" || fail "$RESUME_SMOKE_PATH → $RS"
 [ "$BL" = "200" ] && ok "/api/blocks → $BL"          || fail "/api/blocks → $BL"
 
 echo
@@ -145,9 +146,9 @@ if [ $FAIL -gt 0 ] && [ $RECOVER -eq 1 ]; then
     echo "→ Restarting trends-preview-api…"
     $SUDO systemctl restart trends-preview-api
     sleep 4
-    SP2=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:$API_PORT/api/search-profiles" || echo 000)
+    RS2=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:$API_PORT$RESUME_SMOKE_PATH" || echo 000)
     BL2=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:$API_PORT/api/blocks" || echo 000)
-    info "post-recovery /api/search-profiles → $SP2"
+    info "post-recovery $RESUME_SMOKE_PATH → $RS2"
     info "post-recovery /api/blocks → $BL2"
 fi
 

--- a/deploy/restore-preview-from-prod.sh
+++ b/deploy/restore-preview-from-prod.sh
@@ -12,13 +12,16 @@ rm -f "$EXPORT_PATH" /tmp/prod-convex-export-fixed.zip
 PROD_DIR="${PROD_DIR:-/opt/trends}"
 PROD_CONVEX_DIR="$PROD_DIR/packages/convex"
 PREVIEW_DIR="${PREVIEW_DIR:-/home/ubuntu/trends-preview}"
+PREVIEW_API_URL="${PREVIEW_API_URL:-http://127.0.0.1:3002}"
+PREVIEW_RESUME_SMOKE_PATH="/api/resumes?source=convex&paged=true&limit=1"
+PREVIEW_CONVEX_URL="${PREVIEW_CONVEX_URL:-http://127.0.0.1:4210}"
 
 wait_for_preview_api() {
     local max_wait=120
     local waited=0
 
     echo "Waiting for preview API to become ready..."
-    while ! curl -fsS http://127.0.0.1:3002/ >/dev/null 2>&1; do
+    while ! curl -fsS "$PREVIEW_API_URL/" >/dev/null 2>&1; do
         sleep 2
         waited=$((waited + 2))
         if [ "$waited" -ge "$max_wait" ]; then
@@ -28,6 +31,53 @@ wait_for_preview_api() {
         fi
     done
     echo "Preview API ready after ${waited}s"
+}
+
+check_preview_endpoint() {
+    local path="$1"
+    local status=""
+
+    status="$(curl -s -o /dev/null -w '%{http_code}' "$PREVIEW_API_URL$path" || echo 000)"
+    printf '%s: %s\n' "$path" "$status"
+    if [ "$status" != "200" ]; then
+        echo "Preview endpoint failed: $path returned $status" >&2
+        exit 1
+    fi
+}
+
+run_preview_ai_smoke() {
+    local keyword="${PREVIEW_AI_SMOKE_KEYWORD:-CNC}"
+    local timeout="${PREVIEW_AI_SMOKE_TIMEOUT_SEC:-300}"
+
+    case "${SKIP_PREVIEW_AI_SMOKE:-}" in
+        1|true|yes)
+            echo "Skipping preview AI smoke because SKIP_PREVIEW_AI_SMOKE is set."
+            return 0
+            ;;
+    esac
+
+    echo ""
+    echo "=== Preview AI Analysis Smoke ==="
+    if [ -x "$PREVIEW_DIR/node_modules/.bin/tsx" ]; then
+        cd "$PREVIEW_DIR" && \
+            CONVEX_URL="$PREVIEW_CONVEX_URL" \
+            ANALYSIS_TIMEOUT_SEC="$timeout" \
+            "$PREVIEW_DIR/node_modules/.bin/tsx" scripts/verify-critical-path.ts \
+                --mode=seeded \
+                --keyword="$keyword" \
+                --analysis-timeout-sec="$timeout" \
+                --json
+        return
+    fi
+
+    cd "$PREVIEW_DIR" && \
+        CONVEX_URL="$PREVIEW_CONVEX_URL" \
+        ANALYSIS_TIMEOUT_SEC="$timeout" \
+        npx tsx scripts/verify-critical-path.ts \
+            --mode=seeded \
+            --keyword="$keyword" \
+            --analysis-timeout-sec="$timeout" \
+            --json
 }
 
 echo "=== Step 1: Export production Convex data ==="
@@ -197,8 +247,9 @@ wait_for_preview_api
 
 echo ""
 echo "=== Verification ==="
-echo -n "/api/blocks: " && curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3002/api/blocks
-echo -n "/api/search-profiles: " && curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3002/api/search-profiles
+check_preview_endpoint "/api/blocks"
+check_preview_endpoint "$PREVIEW_RESUME_SMOKE_PATH"
+run_preview_ai_smoke
 
 echo ""
 echo "=== Done ==="

--- a/deploy/restore-preview-full-state-from-prod.sh
+++ b/deploy/restore-preview-full-state-from-prod.sh
@@ -9,6 +9,8 @@ PROD_DB="${PROD_DB:-$PROD_DIR/output/resume_screening.db}"
 PREVIEW_DB="${PREVIEW_DB:-$PREVIEW_DIR/output/resume_screening.db}"
 PREVIEW_API_SERVICE="${PREVIEW_API_SERVICE:-trends-preview-api}"
 PREVIEW_API_URL="${PREVIEW_API_URL:-http://127.0.0.1:3002}"
+PREVIEW_RESUME_SMOKE_PATH="/api/resumes?source=convex&paged=true&limit=1"
+PREVIEW_CONVEX_URL="${PREVIEW_CONVEX_URL:-http://127.0.0.1:4210}"
 CONVEX_RESTORE_SCRIPT="${CONVEX_RESTORE_SCRIPT:-$PROD_DIR/deploy/restore-preview-from-prod.sh}"
 MODE="all"
 API_STOPPED=0
@@ -31,7 +33,9 @@ Environment overrides:
   PREVIEW_DB            default: \$PREVIEW_DIR/output/resume_screening.db
   PREVIEW_API_SERVICE   default: trends-preview-api
   PREVIEW_API_URL       default: http://127.0.0.1:3002
+  PREVIEW_CONVEX_URL    default: http://127.0.0.1:4210
   CONVEX_RESTORE_SCRIPT default: \$PROD_DIR/deploy/restore-preview-from-prod.sh
+  SKIP_PREVIEW_AI_SMOKE set to 1/true/yes to skip the bounded AI analysis smoke
 EOF
 }
 
@@ -111,6 +115,41 @@ check_endpoint() {
     fi
 }
 
+run_preview_ai_smoke() {
+    local keyword="${PREVIEW_AI_SMOKE_KEYWORD:-CNC}"
+    local timeout="${PREVIEW_AI_SMOKE_TIMEOUT_SEC:-300}"
+
+    case "${SKIP_PREVIEW_AI_SMOKE:-}" in
+        1|true|yes)
+            log "Skipping preview AI smoke because SKIP_PREVIEW_AI_SMOKE is set."
+            return 0
+            ;;
+    esac
+
+    log ""
+    log "=== Step 4: Preview AI analysis smoke ==="
+    if [ -x "$PREVIEW_DIR/node_modules/.bin/tsx" ]; then
+        cd "$PREVIEW_DIR" && \
+            CONVEX_URL="$PREVIEW_CONVEX_URL" \
+            ANALYSIS_TIMEOUT_SEC="$timeout" \
+            "$PREVIEW_DIR/node_modules/.bin/tsx" scripts/verify-critical-path.ts \
+                --mode=seeded \
+                --keyword="$keyword" \
+                --analysis-timeout-sec="$timeout" \
+                --json
+        return
+    fi
+
+    cd "$PREVIEW_DIR" && \
+        CONVEX_URL="$PREVIEW_CONVEX_URL" \
+        ANALYSIS_TIMEOUT_SEC="$timeout" \
+        npx tsx scripts/verify-critical-path.ts \
+            --mode=seeded \
+            --keyword="$keyword" \
+            --analysis-timeout-sec="$timeout" \
+            --json
+}
+
 restore_convex_state() {
     if [ ! -f "$CONVEX_RESTORE_SCRIPT" ]; then
         echo "Missing Convex restore script: $CONVEX_RESTORE_SCRIPT" >&2
@@ -118,7 +157,10 @@ restore_convex_state() {
     fi
 
     log "=== Step 1: Restore production Convex state into preview ==="
-    bash "$CONVEX_RESTORE_SCRIPT"
+    case "${SKIP_PREVIEW_AI_SMOKE:-}" in
+        1|true|yes) bash "$CONVEX_RESTORE_SCRIPT" ;;
+        *) SKIP_PREVIEW_AI_SMOKE=1 bash "$CONVEX_RESTORE_SCRIPT" ;;
+    esac
 }
 
 restore_sqlite_state() {
@@ -197,7 +239,7 @@ verify_preview() {
     log ""
     log "=== Step 3: Verify preview API ==="
     check_endpoint "/api/blocks"
-    check_endpoint "/api/search-profiles"
+    check_endpoint "$PREVIEW_RESUME_SMOKE_PATH"
 }
 
 require_root
@@ -210,13 +252,17 @@ case "$MODE" in
         restore_convex_state
         restore_sqlite_state
         verify_preview
+        run_preview_ai_smoke
         ;;
     sqlite-only)
         restore_sqlite_state
         verify_preview
+        run_preview_ai_smoke
         ;;
     convex-only)
         restore_convex_state
+        verify_preview
+        run_preview_ai_smoke
         ;;
 esac
 

--- a/scripts/install-deploy-safety.test.ts
+++ b/scripts/install-deploy-safety.test.ts
@@ -11,6 +11,7 @@ const setupPreviewScript = readFileSync(new URL("../deploy/setup-preview.sh", im
 const restorePreviewScript = readFileSync(new URL("../deploy/restore-preview-from-prod.sh", import.meta.url), "utf8");
 const restorePreviewFullStateScript = readFileSync(new URL("../deploy/restore-preview-full-state-from-prod.sh", import.meta.url), "utf8");
 const syncPreviewConvexEnvScript = readFileSync(new URL("../deploy/sync-preview-convex-env.sh", import.meta.url), "utf8");
+const previewDoctorScript = readFileSync(new URL("../deploy/preview-doctor.sh", import.meta.url), "utf8");
 const previewMcpDockerfile = readFileSync(new URL("../deploy/docker/Dockerfile.mcp", import.meta.url), "utf8");
 const previewCompose = readFileSync(new URL("../deploy/docker/docker-compose.preview.yml", import.meta.url), "utf8");
 const previewConvexStartScript = readFileSync(new URL("../deploy/docker/start-convex.sh", import.meta.url), "utf8");
@@ -24,6 +25,32 @@ function getTargetRecipe(target: string): string {
     throw new Error(`Missing Makefile recipe for target: ${target}`);
   }
   return match[1];
+}
+
+function extractShellFunction(script: string, functionName: string): string {
+  const startMarker = `${functionName}() {`;
+  const startIdx = script.indexOf(startMarker);
+  if (startIdx === -1) {
+    throw new Error(`Could not find ${functionName}`);
+  }
+  const bodyStart = script.indexOf("{", startIdx) + 1;
+  let depth = 1;
+  let index = bodyStart;
+  while (index < script.length && depth > 0) {
+    if (script[index] === "{") depth++;
+    else if (script[index] === "}") depth--;
+    if (depth > 0) index++;
+  }
+  if (depth !== 0) {
+    throw new Error(`Could not extract ${functionName} body`);
+  }
+  return script.slice(bodyStart, index);
+}
+
+function expectBefore(source: string, first: string, second: string): void {
+  expect(source).toContain(first);
+  expect(source).toContain(second);
+  expect(source.indexOf(first)).toBeLessThan(source.indexOf(second));
 }
 
 describe("install/deploy demo resume safety", () => {
@@ -71,26 +98,6 @@ describe("seed_and_migrate_convex migration order", () => {
   let body = "";
   let migrations: string[] = [];
 
-  function extractSeedAndMigrateBody(script: string): string {
-    const startMarker = "seed_and_migrate_convex() {";
-    const startIdx = script.indexOf(startMarker);
-    if (startIdx === -1) {
-      throw new Error("Could not find seed_and_migrate_convex in install.sh");
-    }
-    const bodyStart = script.indexOf("{", startIdx) + 1;
-    let depth = 1;
-    let i = bodyStart;
-    while (i < script.length && depth > 0) {
-      if (script[i] === "{") depth++;
-      else if (script[i] === "}") depth--;
-      if (depth > 0) i++;
-    }
-    if (depth !== 0) {
-      throw new Error("Could not extract seed_and_migrate_convex body from install.sh");
-    }
-    return script.slice(bodyStart, i);
-  }
-
   function extractMigrationCalls(fnBody: string): string[] {
     const calls: string[] = [];
     for (const line of fnBody.split("\n")) {
@@ -103,7 +110,7 @@ describe("seed_and_migrate_convex migration order", () => {
   }
 
   beforeAll(() => {
-    body = extractSeedAndMigrateBody(installScript);
+    body = extractShellFunction(installScript, "seed_and_migrate_convex");
     migrations = extractMigrationCalls(body);
   });
 
@@ -127,6 +134,46 @@ describe("seed_and_migrate_convex migration order", () => {
   it("passes limit to backfillIngestData", () => {
     expect(body).toContain("backfillIngestData");
     expect(body).toContain('{"limit":100}');
+  });
+});
+
+describe("production deploy readiness checks", () => {
+  it("validates auth env before production install, upgrade, env-only, and upgrade-check paths", () => {
+    expect(installScript).toContain("validate_auth_env()");
+    expect(installScript).toContain("scripts/check-auth-env.ts");
+    expect(installScript).toContain("--mode production");
+
+    expectBefore(extractShellFunction(installScript, "install_flow"), "validate_auth_env", "deploy_env_file");
+    expectBefore(extractShellFunction(installScript, "full_upgrade_steps"), "validate_auth_env", "deploy_env_file");
+    expectBefore(extractShellFunction(installScript, "env_only_upgrade_steps"), "validate_auth_env", "deploy_env_file");
+    expectBefore(extractShellFunction(installScript, "upgrade_check_flow"), "validate_auth_env", "plan_upgrade_action");
+  });
+
+  it("uses the real API health route for production readiness and operator guidance", () => {
+    expect(installScript).toContain("wait_for_api_health()");
+    expect(installScript).toContain("/health");
+    expect(installScript).not.toContain("127.0.0.1:3000/api/health");
+  });
+
+  it("does not use anonymous admin-gated search profile routes as preview smoke checks", () => {
+    expect(restorePreviewScript).not.toContain("/api/search-profiles");
+    expect(restorePreviewFullStateScript).not.toContain("/api/search-profiles");
+    expect(previewDoctorScript).not.toContain("/api/search-profiles");
+
+    expect(restorePreviewScript).toContain("/api/resumes?source=convex&paged=true&limit=1");
+    expect(restorePreviewFullStateScript).toContain("/api/resumes?source=convex&paged=true&limit=1");
+    expect(previewDoctorScript).toContain("/api/resumes?source=convex&paged=true&limit=1");
+  });
+
+  it("runs a bounded preview AI analysis smoke after production-state restores", () => {
+    expect(restorePreviewScript).toContain("run_preview_ai_smoke");
+    expect(restorePreviewScript).toContain("SKIP_PREVIEW_AI_SMOKE");
+    expect(restorePreviewScript).toContain("scripts/verify-critical-path.ts");
+    expect(restorePreviewScript).toContain("--mode=seeded");
+    expect(restorePreviewScript).toContain("ANALYSIS_TIMEOUT_SEC");
+
+    expect(restorePreviewFullStateScript).toContain("run_preview_ai_smoke");
+    expect(restorePreviewFullStateScript).toContain("SKIP_PREVIEW_AI_SMOKE");
   });
 });
 
@@ -160,7 +207,8 @@ describe("preview restore export compatibility", () => {
 
   it("waits for the preview API after restart before final smoke checks", () => {
     expect(restorePreviewScript).toContain("wait_for_preview_api()");
-    expect(restorePreviewScript).toContain("http://127.0.0.1:3002/");
+    expect(restorePreviewScript).toContain('PREVIEW_API_URL="${PREVIEW_API_URL:-http://127.0.0.1:3002}"');
+    expect(restorePreviewScript).toContain('"$PREVIEW_API_URL/"');
     expect(restorePreviewScript.indexOf("wait_for_preview_api")).toBeLessThan(
       restorePreviewScript.indexOf("=== Verification ==="),
     );
@@ -216,7 +264,7 @@ describe("preview full-state restore", () => {
     expect(restorePreviewFullStateScript).toContain("systemctl start \"$PREVIEW_API_SERVICE\"");
     expect(restorePreviewFullStateScript).toContain("wait_for_preview_api");
     expect(restorePreviewFullStateScript).toContain("/api/blocks");
-    expect(restorePreviewFullStateScript).toContain("/api/search-profiles");
+    expect(restorePreviewFullStateScript).toContain("/api/resumes?source=convex&paged=true&limit=1");
     expect(restorePreviewFullStateScript).not.toContain("ssh ");
   });
 });

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -868,9 +868,11 @@ env_only_upgrade_steps() {
     ensure_uv
     create_service_user
     sync_service_user_gh_credentials
+    validate_auth_env
     deploy_env_file
     setup_convex
     restart_units
+    wait_for_api_health
 }
 
 env_only_upgrade_flow() {
@@ -1409,6 +1411,27 @@ deploy_env_file() {
     log_info "  - $system_env_path"
 }
 
+validate_auth_env() {
+    local resolved_env_path=""
+
+    if [[ -z "${ENV_FILE:-}" ]]; then
+        log_warn "ENV_FILE is empty; skipping production auth environment validation."
+        return 0
+    fi
+
+    resolved_env_path="$(resolve_env_file)"
+    if [[ ! -f "$INSTALL_DIR/scripts/check-auth-env.ts" ]]; then
+        log_error "Auth environment checker not found at $INSTALL_DIR/scripts/check-auth-env.ts"
+        exit 1
+    fi
+
+    log_info "Validating production auth environment from $resolved_env_path..."
+    if ! (cd "$INSTALL_DIR" && npx tsx scripts/check-auth-env.ts --mode production --env-file "$resolved_env_path"); then
+        log_error "Production auth environment validation failed."
+        exit 1
+    fi
+}
+
 copy_file_if_exists() {
     local source_path="$1"
     local target_path="$2"
@@ -1771,6 +1794,33 @@ start_services() {
     done
 }
 
+wait_for_api_health() {
+    local port=""
+    local url=""
+    local timeout=120
+    local elapsed=0
+
+    port="$(resolve_runtime_env_var "PORT")"
+    if [[ -z "$port" ]]; then
+        port="3000"
+    fi
+    url="http://127.0.0.1:$port/health"
+
+    log_info "Waiting for API health at $url..."
+    while [[ "$elapsed" -lt "$timeout" ]]; do
+        if curl -fsS "$url" >/dev/null 2>&1; then
+            log_info "API health check passed after ${elapsed}s."
+            return 0
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+
+    log_error "API health check did not pass after ${timeout}s: $url"
+    systemctl status trends-api.service --no-pager -l >&2 || true
+    exit 1
+}
+
 stop_port_processes() {
     local port="$1"
     local pids pid
@@ -1839,6 +1889,7 @@ install_flow() {
     sync_service_user_gh_credentials
     clone_or_update_repo
     sync_dependencies
+    validate_auth_env
     deploy_env_file
     sync_web_build_env
     build_shared_artifact
@@ -1850,13 +1901,14 @@ install_flow() {
     install_systemd_units
     enable_units
     start_services
+    wait_for_api_health
 
     echo ""
     log_info "Installation completed."
     echo ""
     echo "Verification commands:"
     echo "  systemctl status trends-convex trends-api trends-worker trends-worker-api trends-mcp"
-    echo "  curl -s http://127.0.0.1:3000/api/health"
+    echo "  curl -s http://127.0.0.1:3000/health"
     echo "  curl -s https://trends.pt-mes.com/"
     echo ""
     echo "Caddy setup recommendation:"
@@ -1869,6 +1921,7 @@ full_upgrade_steps() {
     clone_or_update_repo
     sync_dependencies
     if [[ -n "$ENV_FILE" ]]; then
+        validate_auth_env
         deploy_env_file
         sync_web_build_env
     else
@@ -1882,6 +1935,7 @@ full_upgrade_steps() {
     remove_legacy_units
     install_systemd_units
     restart_units
+    wait_for_api_health
 }
 
 upgrade_flow() {
@@ -1934,6 +1988,7 @@ upgrade_check_flow() {
     fi
 
     create_service_user
+    validate_auth_env
     plan_upgrade_action
     print_upgrade_plan
 


### PR DESCRIPTION
## Summary
- validate production auth env before install/full/env-only deploy paths and deploy dry-run checks
- wait for the real API /health endpoint after production starts/restarts
- replace preview anonymous admin-route smoke checks with public resume checks and add bounded AI analysis smoke

## Verification
- bunx vitest run scripts/install-deploy-safety.test.ts
- bash -n scripts/install.sh deploy/restore-preview-from-prod.sh deploy/restore-preview-full-state-from-prod.sh deploy/preview-doctor.sh
- git diff --check
- make check